### PR TITLE
refactor(test): eliminate mock.module to prevent global test pollution

### DIFF
--- a/packages/command/src/commands/completions.spec.ts
+++ b/packages/command/src/commands/completions.spec.ts
@@ -4,6 +4,7 @@ import {
   CONFIG_SUBCOMMANDS,
   SUBCOMMANDS,
   bashScript,
+  cmdCompletions,
   fishScript,
   zshScript,
 } from "./completions.js";
@@ -154,17 +155,10 @@ describe("daemon guard", () => {
   test("completion helpers do not call ipcCall when daemon is not running", async () => {
     const ipcCallMock = mock(() => Promise.resolve([]));
     const isDaemonRunningMock = mock(() => Promise.resolve(false));
-
-    mock.module("@mcp-cli/core", () => ({
-      ipcCall: ipcCallMock,
-      isDaemonRunning: isDaemonRunningMock,
-    }));
-
-    // Re-import to pick up mocked module
-    const { cmdCompletions } = await import("./completions.js");
+    const deps = { ipcCall: ipcCallMock, isDaemonRunning: isDaemonRunningMock };
 
     // --servers
-    await cmdCompletions(["--servers"]);
+    await cmdCompletions(["--servers"], deps);
     expect(isDaemonRunningMock).toHaveBeenCalled();
     expect(ipcCallMock).not.toHaveBeenCalled();
 
@@ -173,7 +167,7 @@ describe("daemon guard", () => {
     ipcCallMock.mockClear();
 
     // --tools
-    await cmdCompletions(["--tools", "some-server"]);
+    await cmdCompletions(["--tools", "some-server"], deps);
     expect(isDaemonRunningMock).toHaveBeenCalled();
     expect(ipcCallMock).not.toHaveBeenCalled();
 
@@ -182,7 +176,7 @@ describe("daemon guard", () => {
     ipcCallMock.mockClear();
 
     // --aliases
-    await cmdCompletions(["--aliases"]);
+    await cmdCompletions(["--aliases"], deps);
     expect(isDaemonRunningMock).toHaveBeenCalled();
     expect(ipcCallMock).not.toHaveBeenCalled();
   });

--- a/packages/command/src/commands/completions.ts
+++ b/packages/command/src/commands/completions.ts
@@ -7,8 +7,15 @@
  */
 
 import type { AliasInfo, ServerStatus, ToolInfo } from "@mcp-cli/core";
-import { ipcCall, isDaemonRunning } from "@mcp-cli/core";
+import { ipcCall as realIpcCall, isDaemonRunning as realIsDaemonRunning } from "@mcp-cli/core";
 import { printError } from "../output.js";
+
+export interface CompletionDeps {
+  ipcCall: typeof realIpcCall;
+  isDaemonRunning: typeof realIsDaemonRunning;
+}
+
+const defaultDeps: CompletionDeps = { ipcCall: realIpcCall, isDaemonRunning: realIsDaemonRunning };
 
 /** Top-level subcommands for the mcp CLI */
 export const SUBCOMMANDS = [
@@ -52,18 +59,19 @@ const TOOL_COMMANDS = ["call", "info"];
 /** Alias subcommands that accept an alias name */
 const ALIAS_NAME_COMMANDS = ["show", "edit", "rm"];
 
-export async function cmdCompletions(args: string[]): Promise<void> {
+export async function cmdCompletions(args: string[], deps?: CompletionDeps): Promise<void> {
+  const d = deps ?? defaultDeps;
   // Dynamic data helpers (called by the generated scripts)
   if (args[0] === "--servers") {
-    await printServers();
+    await printServers(d);
     return;
   }
   if (args[0] === "--tools" && args[1]) {
-    await printTools(args[1]);
+    await printTools(args[1], d);
     return;
   }
   if (args[0] === "--aliases") {
-    await printAliases();
+    await printAliases(d);
     return;
   }
 
@@ -91,10 +99,10 @@ export async function cmdCompletions(args: string[]): Promise<void> {
 }
 
 /** Print server names, one per line. Skips if daemon not running. */
-async function printServers(): Promise<void> {
+async function printServers(deps: CompletionDeps): Promise<void> {
   try {
-    if (!(await isDaemonRunning())) return;
-    const servers = (await ipcCall("listServers")) as ServerStatus[];
+    if (!(await deps.isDaemonRunning())) return;
+    const servers = (await deps.ipcCall("listServers")) as ServerStatus[];
     for (const s of servers) {
       console.log(s.name);
     }
@@ -104,10 +112,10 @@ async function printServers(): Promise<void> {
 }
 
 /** Print tool names for a server, one per line. Skips if daemon not running. */
-async function printTools(server: string): Promise<void> {
+async function printTools(server: string, deps: CompletionDeps): Promise<void> {
   try {
-    if (!(await isDaemonRunning())) return;
-    const tools = (await ipcCall("listTools", { server })) as ToolInfo[];
+    if (!(await deps.isDaemonRunning())) return;
+    const tools = (await deps.ipcCall("listTools", { server })) as ToolInfo[];
     for (const t of tools) {
       console.log(t.name);
     }
@@ -117,10 +125,10 @@ async function printTools(server: string): Promise<void> {
 }
 
 /** Print alias names, one per line. Skips if daemon not running. */
-async function printAliases(): Promise<void> {
+async function printAliases(deps: CompletionDeps): Promise<void> {
   try {
-    if (!(await isDaemonRunning())) return;
-    const aliases = (await ipcCall("listAliases")) as AliasInfo[];
+    if (!(await deps.isDaemonRunning())) return;
+    const aliases = (await deps.ipcCall("listAliases")) as AliasInfo[];
     for (const a of aliases) {
       console.log(a.name);
     }

--- a/packages/daemon/src/auth/keychain.spec.ts
+++ b/packages/daemon/src/auth/keychain.spec.ts
@@ -1,11 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-
-// Dynamic import to avoid mock.module pollution from oauth-provider.spec.ts.
-// We re-import each test to get the real (un-mocked) module.
-async function importKeychain() {
-  const mod = await import(`./keychain.js?t=${Date.now()}`);
-  return mod.readKeychainTokens as typeof import("./keychain.js")["readKeychainTokens"];
-}
+import { readKeychainTokens } from "./keychain.js";
 
 // Save original so we can restore after platform override tests
 const originalPlatform = process.platform;
@@ -41,22 +35,17 @@ afterEach(() => {
 describe("readKeychainTokens", () => {
   test("returns null on non-darwin platforms", async () => {
     setPlatform("linux");
-    const readKeychainTokens = await importKeychain();
     expect(await readKeychainTokens("https://api.example.com")).toBeNull();
   });
 
   test("returns null when security command fails", async () => {
     if (originalPlatform !== "darwin") return;
-    const readKeychainTokens = await importKeychain();
-
     const result = await withSpawnMock(["false"], () => readKeychainTokens("https://api.example.com"));
     expect(result).toBeNull();
   });
 
   test("returns null when no mcpOAuth entries exist", async () => {
     if (originalPlatform !== "darwin") return;
-    const readKeychainTokens = await importKeychain();
-
     const result = await withSpawnMock(["echo", JSON.stringify({ otherKey: true })], () =>
       readKeychainTokens("https://api.example.com"),
     );
@@ -65,8 +54,6 @@ describe("readKeychainTokens", () => {
 
   test("returns null when no entry matches the target URL", async () => {
     if (originalPlatform !== "darwin") return;
-    const readKeychainTokens = await importKeychain();
-
     const keychainData = {
       mcpOAuth: {
         "server1|abc": {
@@ -86,8 +73,6 @@ describe("readKeychainTokens", () => {
 
   test("returns tokens when URL matches", async () => {
     if (originalPlatform !== "darwin") return;
-    const readKeychainTokens = await importKeychain();
-
     const keychainData = {
       mcpOAuth: {
         "myserver|xyz": {
@@ -120,8 +105,6 @@ describe("readKeychainTokens", () => {
 
   test("returns null for expired token without refresh token", async () => {
     if (originalPlatform !== "darwin") return;
-    const readKeychainTokens = await importKeychain();
-
     const keychainData = {
       mcpOAuth: {
         "srv|a": {
@@ -142,8 +125,6 @@ describe("readKeychainTokens", () => {
 
   test("returns tokens for expired token with refresh token", async () => {
     if (originalPlatform !== "darwin") return;
-    const readKeychainTokens = await importKeychain();
-
     const keychainData = {
       mcpOAuth: {
         "srv|a": {
@@ -167,8 +148,6 @@ describe("readKeychainTokens", () => {
 
   test("returns null on malformed JSON", async () => {
     if (originalPlatform !== "darwin") return;
-    const readKeychainTokens = await importKeychain();
-
     const result = await withSpawnMock(["echo", "not-valid-json{{{"], () =>
       readKeychainTokens("https://api.example.com"),
     );

--- a/packages/daemon/src/auth/oauth-provider.spec.ts
+++ b/packages/daemon/src/auth/oauth-provider.spec.ts
@@ -3,18 +3,9 @@ import { unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
+import { StateDb } from "../db/state.js";
 import type { KeychainTokens } from "./keychain.js";
-
-// Set up module mock BEFORE importing McpOAuthProvider
-const mockReadKeychain = mock<(url: string) => Promise<KeychainTokens | null>>(() => Promise.resolve(null));
-
-mock.module("./keychain.js", () => ({
-  readKeychainTokens: (...args: Parameters<typeof mockReadKeychain>) => mockReadKeychain(...args),
-}));
-
-// Now import the provider — it will use our mocked keychain
-const { McpOAuthProvider, getBrowserCommand } = await import("./oauth-provider.js");
-const { StateDb } = await import("../db/state.js");
+import { McpOAuthProvider, getBrowserCommand } from "./oauth-provider.js";
 
 const originalPlatform = process.platform;
 const originalWslDistro = process.env.WSL_DISTRO_NAME;
@@ -42,11 +33,22 @@ function cleanup(path: string): void {
 
 describe("McpOAuthProvider", () => {
   const paths: string[] = [];
+  const mockReadKeychain = mock<(url: string) => Promise<KeychainTokens | null>>(() => Promise.resolve(null));
 
   function createDb(): InstanceType<typeof StateDb> {
     const p = tmpDb();
     paths.push(p);
     return new StateDb(p);
+  }
+
+  function createProvider(
+    db: InstanceType<typeof StateDb>,
+    opts?: { clientId?: string; clientSecret?: string; callbackPort?: number },
+  ): InstanceType<typeof McpOAuthProvider> {
+    return new McpOAuthProvider("srv", "https://api.example.com", db, {
+      ...opts,
+      readKeychain: mockReadKeychain,
+    });
   }
 
   afterEach(() => {
@@ -72,7 +74,7 @@ describe("McpOAuthProvider", () => {
         Promise.resolve({ accessToken: "keychain-tok", clientId: "kc-client" }),
       );
 
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
       const tokens = await provider.tokens();
 
       expect(tokens).toBeDefined();
@@ -95,7 +97,7 @@ describe("McpOAuthProvider", () => {
         }),
       );
 
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
       const tokens = await provider.tokens();
 
       expect(tokens).toBeDefined();
@@ -111,7 +113,7 @@ describe("McpOAuthProvider", () => {
       const db = createDb();
       // mockReadKeychain already returns null by default
 
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
       const tokens = await provider.tokens();
 
       expect(tokens).toBeUndefined();
@@ -122,7 +124,7 @@ describe("McpOAuthProvider", () => {
       const db = createDb();
       mockReadKeychain.mockImplementation(() => Promise.resolve({ accessToken: "kc-tok", clientId: "kc-client" }));
 
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
       const tokens = await provider.tokens();
 
       expect(tokens).toBeDefined();
@@ -140,7 +142,7 @@ describe("McpOAuthProvider", () => {
       db.saveClientInfo("srv", { client_id: "sqlite-client" });
       mockReadKeychain.mockImplementation(() => Promise.resolve({ accessToken: "x", clientId: "kc-client" }));
 
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
       const info = await provider.clientInformation();
 
       expect(info).toBeDefined();
@@ -152,7 +154,7 @@ describe("McpOAuthProvider", () => {
       const db = createDb();
       mockReadKeychain.mockImplementation(() => Promise.resolve({ accessToken: "x", clientId: "kc-client-id" }));
 
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
       const info = await provider.clientInformation();
 
       expect(info).toBeDefined();
@@ -163,7 +165,7 @@ describe("McpOAuthProvider", () => {
     test("returns undefined when no client info anywhere", async () => {
       const db = createDb();
 
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
       const info = await provider.clientInformation();
 
       expect(info).toBeUndefined();
@@ -176,7 +178,7 @@ describe("McpOAuthProvider", () => {
       db.saveClientInfo("srv", { client_id: "sqlite-client" });
       mockReadKeychain.mockImplementation(() => Promise.resolve({ accessToken: "x", clientId: "kc-client" }));
 
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db, {
+      const provider = createProvider(db, {
         clientId: "config-client",
         clientSecret: "config-secret",
       });
@@ -193,7 +195,7 @@ describe("McpOAuthProvider", () => {
     test("returns config-level clientId without secret when only clientId provided", async () => {
       const db = createDb();
 
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db, {
+      const provider = createProvider(db, {
         clientId: "config-only-id",
       });
       const info = await provider.clientInformation();
@@ -206,14 +208,14 @@ describe("McpOAuthProvider", () => {
 
     test("exposes callbackPort from opts", () => {
       const db = createDb();
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db, { callbackPort: 9876 });
+      const provider = createProvider(db, { callbackPort: 9876 });
       expect(provider.callbackPort).toBe(9876);
       db.close();
     });
 
     test("callbackPort is undefined when not configured", () => {
       const db = createDb();
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
       expect(provider.callbackPort).toBeUndefined();
       db.close();
     });
@@ -234,7 +236,7 @@ describe("McpOAuthProvider", () => {
         }),
       );
 
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
       const result = await provider.discoveryState();
 
       expect(result).toEqual({ authorizationServerUrl: "https://auth.sqlite.com" });
@@ -251,7 +253,7 @@ describe("McpOAuthProvider", () => {
         }),
       );
 
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
       const result = await provider.discoveryState();
 
       expect(result).toEqual({ authorizationServerUrl: "https://auth.keychain.com" });
@@ -261,7 +263,7 @@ describe("McpOAuthProvider", () => {
     test("returns undefined when no discovery state anywhere", async () => {
       const db = createDb();
 
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
       const result = await provider.discoveryState();
 
       expect(result).toBeUndefined();
@@ -276,7 +278,7 @@ describe("McpOAuthProvider", () => {
       const db = createDb();
       mockReadKeychain.mockImplementation(() => Promise.resolve({ accessToken: "tok", clientId: "cid" }));
 
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
 
       // Call multiple methods that trigger Keychain lookup
       await provider.tokens();
@@ -296,7 +298,7 @@ describe("McpOAuthProvider", () => {
         return Promise.resolve({ accessToken: `tok-${callCount}`, clientId: "cid" });
       });
 
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
 
       // First call caches
       const first = await provider.tokens();
@@ -314,7 +316,7 @@ describe("McpOAuthProvider", () => {
 
     test("invalidateCredentials('all') also deletes SQLite tokens", async () => {
       const db = createDb();
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
 
       db.saveTokens("srv", { access_token: "to-delete", token_type: "Bearer" });
       expect(db.getTokens("srv")).toBeDefined();
@@ -327,7 +329,7 @@ describe("McpOAuthProvider", () => {
 
     test("invalidateCredentials('client') does not affect tokens or verifier", () => {
       const db = createDb();
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
 
       db.saveTokens("srv", { access_token: "tok", token_type: "Bearer" });
       db.saveVerifier("srv", "pkce-123");
@@ -341,7 +343,7 @@ describe("McpOAuthProvider", () => {
 
     test("invalidateCredentials('verifier') does not affect tokens", () => {
       const db = createDb();
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
 
       db.saveTokens("srv", { access_token: "tok", token_type: "Bearer" });
 
@@ -353,7 +355,7 @@ describe("McpOAuthProvider", () => {
 
     test("invalidateCredentials('discovery') does not affect tokens", () => {
       const db = createDb();
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
 
       db.saveTokens("srv", { access_token: "tok", token_type: "Bearer" });
       db.saveDiscoveryState("srv", { authorizationServerUrl: "https://auth.example.com" });
@@ -372,7 +374,7 @@ describe("McpOAuthProvider", () => {
         return Promise.resolve({ accessToken: `tok-${callCount}`, clientId: "cid" });
       });
 
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
 
       await provider.tokens();
       provider.invalidateCredentials("tokens");
@@ -388,7 +390,7 @@ describe("McpOAuthProvider", () => {
   describe("writes go to SQLite", () => {
     test("saveTokens persists to SQLite", () => {
       const db = createDb();
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
 
       provider.saveTokens({
         access_token: "saved-tok",
@@ -403,7 +405,7 @@ describe("McpOAuthProvider", () => {
 
     test("saveClientInformation persists to SQLite", () => {
       const db = createDb();
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
 
       provider.saveClientInformation({ client_id: "saved-client" });
 
@@ -415,7 +417,7 @@ describe("McpOAuthProvider", () => {
 
     test("saveDiscoveryState persists to SQLite", async () => {
       const db = createDb();
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
 
       await provider.saveDiscoveryState({
         authorizationServerUrl: "https://auth.example.com",
@@ -432,7 +434,7 @@ describe("McpOAuthProvider", () => {
   describe("other behavior", () => {
     test("clientMetadata returns correct defaults without redirect URL", () => {
       const db = createDb();
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
 
       const meta = provider.clientMetadata;
       expect(meta.client_name).toBe("mcp-cli");
@@ -446,7 +448,7 @@ describe("McpOAuthProvider", () => {
 
     test("clientMetadata uses setRedirectUrl when set", () => {
       const db = createDb();
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
       provider.setRedirectUrl("http://127.0.0.1:12345/callback");
 
       const meta = provider.clientMetadata;
@@ -456,7 +458,7 @@ describe("McpOAuthProvider", () => {
 
     test("redirectToAuthorization calls Bun.spawn with platform command", () => {
       const db = createDb();
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
 
       const origSpawn = Bun.spawn;
       let spawnedArgs: string[] | undefined;
@@ -479,7 +481,7 @@ describe("McpOAuthProvider", () => {
 
     test("codeVerifier throws when no verifier saved", () => {
       const db = createDb();
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
 
       expect(() => provider.codeVerifier()).toThrow("No PKCE code verifier");
       db.close();
@@ -487,7 +489,7 @@ describe("McpOAuthProvider", () => {
 
     test("saveCodeVerifier and codeVerifier round-trip", () => {
       const db = createDb();
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
 
       provider.saveCodeVerifier("my-verifier-123");
       expect(provider.codeVerifier()).toBe("my-verifier-123");
@@ -496,7 +498,7 @@ describe("McpOAuthProvider", () => {
 
     test("setRedirectUrl updates redirectUrl", () => {
       const db = createDb();
-      const provider = new McpOAuthProvider("srv", "https://api.example.com", db);
+      const provider = createProvider(db);
 
       expect(provider.redirectUrl).toBeUndefined();
       provider.setRedirectUrl("http://localhost:9999/callback");

--- a/packages/daemon/src/auth/oauth-provider.ts
+++ b/packages/daemon/src/auth/oauth-provider.ts
@@ -37,6 +37,7 @@ export interface OAuthProviderOpts {
   clientId?: string;
   clientSecret?: string;
   callbackPort?: number;
+  readKeychain?: (url: string) => Promise<KeychainTokens | null>;
 }
 
 export class McpOAuthProvider implements OAuthClientProvider {
@@ -189,7 +190,8 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
   private async loadKeychain(): Promise<KeychainTokens | null> {
     if (this.keychainCache !== undefined) return this.keychainCache;
-    this.keychainCache = await readKeychainTokens(this.serverUrl);
+    const reader = this.opts.readKeychain ?? readKeychainTokens;
+    this.keychainCache = await reader(this.serverUrl);
     return this.keychainCache;
   }
 }


### PR DESCRIPTION
## Summary

- **Inject keychain reader into `McpOAuthProvider`**: Added optional `readKeychain` to `OAuthProviderOpts`, used in `loadKeychain()` instead of the hard-coded module import. Tests pass a mock function directly via constructor opts.
- **Inject IPC deps into `cmdCompletions`**: Added optional `CompletionDeps` parameter for `ipcCall`/`isDaemonRunning`. Tests pass mock deps directly instead of replacing the global module.
- **Remove cache-busting hack**: `keychain.spec.ts` no longer needs `import(\`./keychain.js?t=${Date.now()}\`)` since `mock.module` pollution is gone.

Fixes #95

## Test plan

- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — all 585 tests pass
- [x] Zero `mock.module` calls remain in the codebase
- [x] Production callers unchanged (no `readKeychain`/`deps` arg needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)