### PR TITLE
chore: update /implement and /qa skills for branch + PR workflow

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -8,6 +8,23 @@ The user will provide a GitHub issue number (e.g., `/implement 12` or `/implemen
 
 ## Workflow
 
+### Step 0: Prepare Branch
+
+Start from a clean, up-to-date main:
+
+```bash
+git checkout main
+git pull origin main
+```
+
+Create a feature branch named after the issue:
+
+```bash
+git checkout -b feat/issue-<number>-<short-slug>
+```
+
+Use a prefix that matches the expected commit type (`feat/`, `fix/`, `refactor/`, etc.).
+
 ### Step 1: Fetch the Issue
 
 ```bash
@@ -71,18 +88,31 @@ Stage the relevant files and create a commit. Follow the repo's commit style (lo
 - Reference the issue number (e.g., `fixes #12` or `closes #12`)
 - Be concise but descriptive
 
-### Step 7: Push
+### Step 7: Push and Create PR
 
 ```bash
-git push
+git push -u origin <branch>
 ```
 
-If the branch is new or doesn't track a remote yet, use `git push -u origin <branch>`.
+Then create a pull request targeting main:
+
+```bash
+gh pr create --title "<conventional commit style title> (fixes #<number>)" --body "$(cat <<'EOF'
+## Summary
+<1-3 bullet points describing the changes>
+
+## Test plan
+<bulleted checklist of how the changes were verified>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
 
 After pushing, report back with:
 - What was implemented
 - What tests were added
-- The commit hash
+- The PR URL
 
 ## Rules
 

--- a/.claude/commands/qa.md
+++ b/.claude/commands/qa.md
@@ -4,17 +4,34 @@ You are the QA controller for the mcp-cli project. Your job is to verify that a 
 
 ## Input
 
-The user will provide a GitHub issue number (e.g., `/qa 5` or `/qa #5`). Parse the number from: $ARGUMENTS
+The user will provide a GitHub issue number or PR number (e.g., `/qa 5`, `/qa #5`, or a PR URL). Parse the number from: $ARGUMENTS
 
 ## Workflow
 
 Execute these steps in order. Be thorough but concise in your reporting.
+
+### Step 0: Determine Context and Checkout
+
+First, determine whether the input refers to a PR or an issue:
+
+```bash
+gh pr view <number> --json number,headRefName,state 2>/dev/null
+```
+
+- **If a PR exists**: check out the PR branch so QA runs against the actual changes:
+  ```bash
+  git checkout main && git pull origin main
+  gh pr checkout <number>
+  ```
+- **If no PR exists**: stay on the current branch and proceed with issue-based QA.
 
 ### Step 1: Pull the Issue
 
 ```bash
 gh issue view <number>
 ```
+
+If working from a PR, also pull the linked issue number from the PR body or title (look for `fixes #N` or `closes #N`).
 
 Read the issue title, body, labels, and any existing comments. Understand:
 - What functionality was promised
@@ -62,15 +79,15 @@ bun test
 
 Run the full test suite. All tests — including any you just wrote — must pass. If any fail, fix them before proceeding.
 
-### Step 6: Comment and Close
+### Step 6: Comment, Close, and Merge
 
-Post a structured QA comment to the issue, then close it. Use this format:
+Post a structured QA comment to the issue, then close it:
 
 ```bash
-gh issue comment <number> --body "$(cat <<'EOF'
+gh issue comment <issue-number> --body "$(cat <<'EOF'
 ## QA Verification ✅
 
-**Issue:** #<number> — <title>
+**Issue:** #<issue-number> — <title>
 
 ### Implementation Evidence
 <bullet list of files and what they implement, with line references>
@@ -89,7 +106,19 @@ All described functionality is implemented and verified. Tests pass. Closing.
 EOF
 )"
 
-gh issue close <number>
+gh issue close <issue-number>
+```
+
+**If a PR was checked out in Step 0**, merge it after closing the issue:
+
+```bash
+gh pr merge <pr-number> --squash --delete-branch
+```
+
+Then return to main:
+
+```bash
+git checkout main && git pull origin main
 ```
 
 ### Step 7: File Follow-Up Issues


### PR DESCRIPTION
## Summary

- **`/implement`**: Now pulls main and creates a feature branch before starting work, and creates a PR at the end instead of just pushing
- **`/qa`**: Now detects PR context (checks out the branch), and merges the PR via `gh pr merge --squash` after leaving the QA comment and closing the issue

## Test plan

- [x] Read through both updated skill files to verify workflow correctness
- [x] `bun typecheck` / `bun lint` / `bun test` all pass (no code changes, just markdown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)