### PR TITLE
feat: alias descriptions and rich ls output (fixes #87)

### DIFF
--- a/packages/command/src/commands/alias.ts
+++ b/packages/command/src/commands/alias.ts
@@ -14,8 +14,9 @@ export async function cmdAlias(args: string[]): Promise<void> {
   switch (sub) {
     case "ls":
     case "list": {
+      const verbose = args.includes("--verbose") || args.includes("-v");
       const aliases = (await ipcCall("listAliases")) as AliasInfo[];
-      printAliasList(aliases);
+      printAliasList(aliases, { verbose });
       break;
     }
 

--- a/packages/command/src/output.ts
+++ b/packages/command/src/output.ts
@@ -4,7 +4,7 @@
  * JSON to stdout (pipeable), errors/status to stderr.
  */
 
-import { type JsonSchema, jsonSchemaToTs } from "@mcp-cli/core";
+import { type JsonSchema, formatAliasSignature, jsonSchemaToTs } from "@mcp-cli/core";
 import type { RegistryEntry } from "./registry/client.js";
 
 const isTTY = process.stdout.isTTY && !process.env.NO_COLOR;
@@ -162,7 +162,10 @@ export function printAliasList(
     filePath: string;
     updatedAt: number;
     aliasType?: "freeform" | "defineAlias";
+    inputSchemaJson?: Record<string, unknown>;
+    outputSchemaJson?: Record<string, unknown>;
   }>,
+  opts?: { verbose?: boolean },
 ): void {
   if (aliases.length === 0) {
     console.error("No aliases saved. Use `mcp alias save <name> <@file | ->` to create one.");
@@ -170,11 +173,23 @@ export function printAliasList(
   }
 
   const maxName = Math.max(...aliases.map((a) => a.name.length));
+  const typeLabel = (a: { aliasType?: string }) =>
+    a.aliasType === "defineAlias" ? `${c.cyan}defineAlias${c.reset}` : `${c.dim}freeform${c.reset}  `;
 
   for (const a of aliases) {
-    const tag = a.aliasType === "defineAlias" ? `${c.cyan}[defined]${c.reset} ` : "";
-    const desc = a.description ? `  ${c.dim}${a.description}${c.reset}` : "";
-    console.log(`  ${c.green}${a.name.padEnd(maxName)}${c.reset}  ${tag}${a.filePath}${desc}`);
+    const desc = a.description ? `  ${a.description}` : "";
+    let line = `  ${c.green}${a.name.padEnd(maxName)}${c.reset}  ${typeLabel(a)}${desc}`;
+
+    if (opts?.verbose && a.aliasType === "defineAlias") {
+      const sig = formatAliasSignature(
+        a.name,
+        a.inputSchemaJson as JsonSchema | undefined,
+        a.outputSchemaJson as JsonSchema | undefined,
+      );
+      line += `  ${c.dim}${sig}${c.reset}`;
+    }
+
+    console.log(line);
   }
   console.log(`\n${aliases.length} alias(es)`);
 }

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -105,6 +105,8 @@ export interface AliasInfo {
   filePath: string;
   updatedAt: number;
   aliasType: "freeform" | "defineAlias";
+  inputSchemaJson?: Record<string, unknown>;
+  outputSchemaJson?: Record<string, unknown>;
 }
 
 export interface AliasDetail extends AliasInfo {

--- a/packages/core/src/schema-display.spec.ts
+++ b/packages/core/src/schema-display.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { type JsonSchema, formatToolSignature, jsonSchemaToTs } from "./schema-display.js";
+import { type JsonSchema, formatAliasSignature, formatToolSignature, jsonSchemaToTs } from "./schema-display.js";
 
 describe("jsonSchemaToTs", () => {
   test("primitive types", () => {
@@ -218,5 +218,65 @@ describe("formatToolSignature", () => {
     expect(formatToolSignature("getConfluencePage", schema)).toBe(
       "getConfluencePage({cloudId: string, pageId: string, contentFormat?: 'markdown' | 'adf'})",
     );
+  });
+});
+
+describe("formatAliasSignature", () => {
+  test("no schemas", () => {
+    expect(formatAliasSignature("my-alias")).toBe("my-alias()");
+    expect(formatAliasSignature("my-alias", undefined, undefined)).toBe("my-alias()");
+  });
+
+  test("input schema only", () => {
+    const input: JsonSchema = {
+      type: "object",
+      properties: { query: { type: "string" } },
+      required: ["query"],
+    };
+    expect(formatAliasSignature("search", input)).toBe("search({query: string})");
+  });
+
+  test("input and output schemas", () => {
+    const input: JsonSchema = {
+      type: "object",
+      properties: { query: { type: "string" } },
+      required: ["query"],
+    };
+    const output: JsonSchema = {
+      type: "object",
+      properties: {
+        dashboards: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: { name: { type: "string" }, url: { type: "string" } },
+            required: ["name", "url"],
+          },
+        },
+      },
+      required: ["dashboards"],
+    };
+    expect(formatAliasSignature("gf-search", input, output)).toBe(
+      "gf-search({query: string}): {dashboards: {name: string, url: string}[]}",
+    );
+  });
+
+  test("output schema only", () => {
+    const output: JsonSchema = {
+      type: "object",
+      properties: { panels: { type: "array", items: { type: "string" } } },
+      required: ["panels"],
+    };
+    expect(formatAliasSignature("go-dashboards", undefined, output)).toBe("go-dashboards(): {panels: string[]}");
+  });
+
+  test("empty input schema properties", () => {
+    const input: JsonSchema = { type: "object", properties: {} };
+    expect(formatAliasSignature("ping", input)).toBe("ping()");
+  });
+
+  test("output with no useful type returns no colon", () => {
+    const output: JsonSchema = {};
+    expect(formatAliasSignature("test", undefined, output)).toBe("test()");
   });
 });

--- a/packages/core/src/schema-display.ts
+++ b/packages/core/src/schema-display.ts
@@ -76,6 +76,42 @@ export function formatToolSignature(name: string, inputSchema: JsonSchema): stri
   return `${name}({${parts.join(", ")}})`;
 }
 
+/**
+ * Format an alias name + optional input/output schemas as a compact signature.
+ *
+ * Example: `gf-search({query: string}): {dashboards: {name, url}[]}`
+ */
+export function formatAliasSignature(name: string, inputSchema?: JsonSchema, outputSchema?: JsonSchema): string {
+  // Input part
+  let input = "";
+  if (inputSchema?.properties && Object.keys(inputSchema.properties).length > 0) {
+    const required = inputSchema.required ?? [];
+    const entries = Object.entries(inputSchema.properties);
+    const parts: string[] = [];
+    const maxSigProps = 6;
+    for (let i = 0; i < entries.length && i < maxSigProps; i++) {
+      const [key, value] = entries[i];
+      const opt = required.includes(key) ? "" : "?";
+      const type = walk(value, { maxDepth: 1, maxProps: 4 }, 0);
+      parts.push(`${key}${opt}: ${type}`);
+    }
+    if (entries.length > maxSigProps) {
+      parts.push(`...${entries.length - maxSigProps} more`);
+    }
+    input = `{${parts.join(", ")}}`;
+  }
+
+  // Output part
+  let output = "";
+  if (outputSchema) {
+    const ts = walk(outputSchema, { maxDepth: 3, maxProps: 4 }, 0);
+    if (ts !== "unknown") output = ts;
+  }
+
+  const sig = `${name}(${input})`;
+  return output ? `${sig}: ${output}` : sig;
+}
+
 // -- Internal recursive walker --
 
 function walk(schema: JsonSchema, opts: Required<SchemaDisplayOpts>, depth: number): string {

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -381,12 +381,24 @@ export class StateDb {
     filePath: string;
     updatedAt: number;
     aliasType: "freeform" | "defineAlias";
+    inputSchemaJson?: Record<string, unknown>;
+    outputSchemaJson?: Record<string, unknown>;
   }> {
     return this.db
       .query<
-        { name: string; description: string | null; file_path: string; updated_at: number; alias_type: string },
+        {
+          name: string;
+          description: string | null;
+          file_path: string;
+          updated_at: number;
+          alias_type: string;
+          input_schema_json: string | null;
+          output_schema_json: string | null;
+        },
         []
-      >("SELECT name, description, file_path, updated_at, alias_type FROM aliases ORDER BY name")
+      >(
+        "SELECT name, description, file_path, updated_at, alias_type, input_schema_json, output_schema_json FROM aliases ORDER BY name",
+      )
       .all()
       .map((row) => ({
         name: row.name,
@@ -394,6 +406,8 @@ export class StateDb {
         filePath: row.file_path,
         updatedAt: row.updated_at,
         aliasType: row.alias_type as "freeform" | "defineAlias",
+        ...(row.input_schema_json ? { inputSchemaJson: JSON.parse(row.input_schema_json) } : {}),
+        ...(row.output_schema_json ? { outputSchemaJson: JSON.parse(row.output_schema_json) } : {}),
       }));
   }
 


### PR DESCRIPTION
## Summary
- `mcp alias ls` now shows type indicator (`defineAlias`/`freeform`) and description for each alias
- `mcp alias ls --verbose` adds compact Zod-derived type signatures for defineAlias aliases (e.g. `search({query: string}): {results: string[]}`)
- Schema data (input/output JSON Schema) flows from daemon SQLite through IPC to CLI formatting

## Test plan
- [x] `formatAliasSignature` unit tests: no schemas, input only, output only, input+output, empty properties, unknown output
- [x] All 640 existing tests pass
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)