### PR TITLE
feat: ergonomic inline alias creation with -c/--code flag (closes #88)

### DIFF
--- a/packages/command/src/commands/alias.spec.ts
+++ b/packages/command/src/commands/alias.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from "bun:test";
+import { DEFINE_ALIAS_SKELETON, extractDefinitionName, wrapDefineAlias } from "./alias.js";
+
+describe("wrapDefineAlias", () => {
+  test("wraps object literal into full defineAlias script", () => {
+    const code = '{ name: "greet", fn: (name) => `Hello, ${name}!` }';
+    const result = wrapDefineAlias(code);
+    expect(result).toBe(`import { defineAlias, z } from "mcp-cli";\ndefineAlias(({ mcp, z }) => (${code}));\n`);
+  });
+
+  test("includes import and defineAlias sentinel", () => {
+    const result = wrapDefineAlias("{}");
+    expect(result).toContain('import { defineAlias, z } from "mcp-cli"');
+    expect(result).toContain("defineAlias(");
+  });
+});
+
+describe("extractDefinitionName", () => {
+  test("extracts name from double-quoted field", () => {
+    expect(extractDefinitionName('{ name: "greet", fn: () => {} }')).toBe("greet");
+  });
+
+  test("extracts name from single-quoted field", () => {
+    expect(extractDefinitionName("{ name: 'my-tool', fn: () => {} }")).toBe("my-tool");
+  });
+
+  test("handles extra whitespace around colon", () => {
+    expect(extractDefinitionName('{ name :  "spaced" }')).toBe("spaced");
+  });
+
+  test("returns undefined when no name field", () => {
+    expect(extractDefinitionName("{ fn: () => {} }")).toBeUndefined();
+  });
+
+  test("returns undefined for empty string", () => {
+    expect(extractDefinitionName("")).toBeUndefined();
+  });
+
+  test("extracts first name if multiple appear", () => {
+    const code = '{ name: "first", nested: { name: "second" } }';
+    expect(extractDefinitionName(code)).toBe("first");
+  });
+});
+
+describe("DEFINE_ALIAS_SKELETON", () => {
+  test("contains defineAlias import", () => {
+    expect(DEFINE_ALIAS_SKELETON).toContain('import { defineAlias, z } from "mcp-cli"');
+  });
+
+  test("contains defineAlias call", () => {
+    expect(DEFINE_ALIAS_SKELETON).toContain("defineAlias(");
+  });
+
+  test("contains placeholder name", () => {
+    expect(DEFINE_ALIAS_SKELETON).toContain('name: "my-alias"');
+  });
+});

--- a/packages/command/src/commands/alias.ts
+++ b/packages/command/src/commands/alias.ts
@@ -3,10 +3,36 @@
  */
 
 import { spawnSync } from "node:child_process";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 import type { AliasDetail, AliasInfo } from "@mcp-cli/core";
-import { ipcCall } from "@mcp-cli/core";
+import { ipcCall, safeAliasPath } from "@mcp-cli/core";
 import { readFileWithLimit } from "../file-read.js";
 import { printAliasList, printError } from "../output.js";
+
+/** Wrap a defineAlias object literal body into a full script */
+export function wrapDefineAlias(code: string): string {
+  return `import { defineAlias, z } from "mcp-cli";\ndefineAlias(({ mcp, z }) => (${code}));\n`;
+}
+
+/** Extract the `name` field from a defineAlias object literal (no execution) */
+export function extractDefinitionName(code: string): string | undefined {
+  const match = code.match(/name\s*:\s*["']([^"']+)["']/);
+  return match?.[1];
+}
+
+/** Default defineAlias skeleton for new aliases */
+export const DEFINE_ALIAS_SKELETON = `import { defineAlias, z } from "mcp-cli";
+
+defineAlias(({ mcp, z }) => ({
+  name: "my-alias",
+  description: "Describe what this alias does",
+  input: z.object({}),
+  fn: async (input, ctx) => {
+    // Your implementation here
+  },
+}));
+`;
 
 export async function cmdAlias(args: string[]): Promise<void> {
   const sub = args[0];
@@ -21,9 +47,49 @@ export async function cmdAlias(args: string[]): Promise<void> {
     }
 
     case "save": {
+      // Parse -c / --code flag
+      const codeIdx = args.indexOf("-c") !== -1 ? args.indexOf("-c") : args.indexOf("--code");
+      const hasCode = codeIdx !== -1;
+
+      if (hasCode) {
+        // mcp alias save [-c CODE] [name]
+        // or: mcp alias save [name] -c CODE
+        const codeBody = args[codeIdx + 1];
+        if (!codeBody) {
+          printError("Missing code body after -c/--code flag");
+          process.exit(1);
+        }
+
+        // Collect remaining args (not -c or its value) after "save"
+        const rest = args.slice(1).filter((_, i) => {
+          const absIdx = i + 1; // offset because we sliced at 1
+          return absIdx !== codeIdx && absIdx !== codeIdx + 1;
+        });
+        const positionalName = rest[0];
+
+        const definitionName = extractDefinitionName(codeBody);
+        const name = positionalName ?? definitionName;
+        if (!name) {
+          printError("No alias name — provide a name field in the definition or as a positional arg");
+          process.exit(1);
+        }
+
+        const script = wrapDefineAlias(codeBody);
+        const description = extractDescription(script);
+        const result = (await ipcCall("saveAlias", { name, script, description })) as {
+          ok: boolean;
+          filePath: string;
+        };
+        console.error(`Saved alias "${name}" → ${result.filePath}`);
+        break;
+      }
+
+      // Standard save: mcp alias save <name> <@file | - | script>
       const name = args[1];
       if (!name) {
-        printError("Usage: mcp alias save <name> <@file | - | script>");
+        printError(
+          "Usage: mcp alias save <name> <@file | - | script>\n       mcp alias save -c '{...defineAlias body...}'",
+        );
         process.exit(1);
       }
 
@@ -80,23 +146,31 @@ export async function cmdAlias(args: string[]): Promise<void> {
       }
 
       const alias = (await ipcCall("getAlias", { name })) as AliasDetail | null;
-      if (!alias) {
-        printError(`Alias "${name}" not found`);
-        process.exit(1);
+      let filePath: string;
+
+      if (alias) {
+        filePath = alias.filePath;
+      } else {
+        // New alias — create file with defineAlias skeleton
+        filePath = safeAliasPath(name);
+        const skeleton = DEFINE_ALIAS_SKELETON.replace('name: "my-alias"', `name: "${name}"`);
+        mkdirSync(dirname(filePath), { recursive: true });
+        writeFileSync(filePath, skeleton, "utf-8");
+        console.error(`Creating new alias "${name}"…`);
       }
 
       const editor = process.env.EDITOR ?? process.env.VISUAL ?? "vi";
-      const result = spawnSync(editor, [alias.filePath], { stdio: "inherit" });
+      const result = spawnSync(editor, [filePath], { stdio: "inherit" });
       if (result.status !== 0) {
         printError(`Editor exited with code ${result.status}`);
         process.exit(1);
       }
 
-      // Re-save to update timestamp
-      const updatedScript = readFileWithLimit(alias.filePath);
+      // Re-save to update timestamp and extract metadata
+      const updatedScript = readFileWithLimit(filePath);
       const description = extractDescription(updatedScript);
       await ipcCall("saveAlias", { name, script: updatedScript, description });
-      console.error(`Updated alias "${name}"`);
+      console.error(`${alias ? "Updated" : "Saved"} alias "${name}"`);
       break;
     }
 


### PR DESCRIPTION
## Summary
- Add `-c`/`--code` flag to `mcp alias save` that takes a defineAlias object literal body, wraps it in a full `defineAlias` script, and extracts the alias name from the `name` field
- Positional name argument overrides the definition's `name` field
- `mcp alias edit <name>` now creates new aliases with a defineAlias skeleton template when the alias doesn't exist yet

## Test plan
- [x] `wrapDefineAlias()` wraps code body into full defineAlias script with import
- [x] `extractDefinitionName()` extracts name from single/double-quoted fields, handles whitespace, returns undefined for missing names
- [x] `DEFINE_ALIAS_SKELETON` contains proper defineAlias template
- [x] All 651 tests pass, typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)