### PR TITLE
security: set IPC socket permissions to 0600 (fixes #56)

### DIFF
--- a/packages/core/src/fs.ts
+++ b/packages/core/src/fs.ts
@@ -1,6 +1,6 @@
 import { chmodSync, existsSync, mkdirSync, statSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { DB_PATH, MCP_CLI_DIR } from "./constants.js";
+import { DB_PATH, MCP_CLI_DIR, SOCKET_PATH } from "./constants.js";
 
 /** Ensure ~/.mcp-cli/ exists with owner-only permissions (0700) */
 export function ensureStateDir(): void {
@@ -25,15 +25,17 @@ export function auditRuntimePermissions(): void {
     /* directory doesn't exist yet */
   }
 
-  try {
-    const fileMode = statSync(DB_PATH).mode & 0o777;
-    if (fileMode & 0o077) {
-      console.error(
-        `[security] Warning: ${DB_PATH} has mode 0${fileMode.toString(8)}, expected 0600 — run: chmod 600 ${DB_PATH}`,
-      );
+  for (const filePath of [DB_PATH, SOCKET_PATH]) {
+    try {
+      const fileMode = statSync(filePath).mode & 0o777;
+      if (fileMode & 0o077) {
+        console.error(
+          `[security] Warning: ${filePath} has mode 0${fileMode.toString(8)}, expected 0600 — run: chmod 600 ${filePath}`,
+        );
+      }
+    } catch {
+      /* file doesn't exist yet */
     }
-  } catch {
-    /* db doesn't exist yet */
   }
 }
 

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { unlinkSync } from "node:fs";
+import { statSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { IpcResponse } from "@mcp-cli/core";
@@ -93,6 +93,13 @@ describe("IpcServer HTTP transport", () => {
     expect(json.result).toHaveProperty("pong", true);
     expect(json.result).toHaveProperty("time");
     expect(json.error).toBeUndefined();
+  });
+
+  test("socket file has 0600 permissions after start", () => {
+    startServer();
+
+    const mode = statSync(socketPath).mode & 0o777;
+    expect(mode).toBe(0o600);
   });
 
   test("ping response includes protocolVersion", async () => {

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -30,6 +30,7 @@ import {
   IPC_ERROR,
   PROTOCOL_VERSION,
   SOCKET_PATH,
+  hardenFile,
   isDefineAlias,
   safeAliasPath,
 } from "@mcp-cli/core";
@@ -118,6 +119,9 @@ export class IpcServer {
         }
       },
     });
+
+    // Restrict socket to owner-only access (0600)
+    hardenFile(socketPath);
 
     console.error(`[ipc] Listening on ${socketPath}`);
   }


### PR DESCRIPTION
## Summary
- Call `hardenFile(socketPath)` after `Bun.serve()` to set `mcpd.sock` to `0600` (owner-only)
- Extend `auditRuntimePermissions()` to also warn if the socket has overly permissive modes
- Add test verifying socket file permissions after server start

## Test plan
- [x] New test: `socket file has 0600 permissions after start`
- [x] All 660 existing tests pass
- [x] `bun typecheck` clean
- [x] `bun lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)