### PR TITLE
fix: config watcher detects atomic saves + add reloadConfig IPC (fixes #128)

### DIFF
--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -31,7 +31,8 @@ export type IpcMethod =
   | "readMail"
   | "waitForMail"
   | "replyToMail"
-  | "markRead";
+  | "markRead"
+  | "reloadConfig";
 
 // -- Request/Response --
 

--- a/packages/daemon/src/config/watcher.spec.ts
+++ b/packages/daemon/src/config/watcher.spec.ts
@@ -1,5 +1,9 @@
-import { describe, expect, mock, test } from "bun:test";
-import type { ConfigSource, ResolvedConfig, ResolvedServer } from "@mcp-cli/core";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import type { ConfigSource, McpConfigFile, ResolvedConfig, ResolvedServer, ServerConfig } from "@mcp-cli/core";
+import { projectConfigPath } from "@mcp-cli/core";
+import { testOptions } from "../../../../test/test-options";
 import { configHash } from "./loader";
 import { type ConfigChangeEvent, ConfigWatcher } from "./watcher";
 
@@ -13,6 +17,36 @@ function makeConfig(servers: Record<string, { command: string }>): ResolvedConfi
   }
   return { servers: map, sources: [] };
 }
+
+/** Build an McpConfigFile from server entries */
+function mcpConfig(servers: Record<string, ServerConfig>): McpConfigFile {
+  return { mcpServers: servers };
+}
+
+/** Write JSON to a path, creating parent dirs */
+function writeJson(path: string, data: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(data, null, 2));
+}
+
+/** Atomic write: write to temp file, then rename over target */
+function atomicWrite(path: string, data: unknown): void {
+  const tmp = `${path}.tmp.${Date.now()}`;
+  writeFileSync(tmp, JSON.stringify(data, null, 2));
+  renameSync(tmp, path);
+}
+
+/** Wait for a mock to be called, with timeout */
+async function waitForCall(fn: ReturnType<typeof mock>, timeoutMs = 2000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (fn.mock.calls.length === 0 && Date.now() < deadline) {
+    await Bun.sleep(50);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests (no filesystem)
+// ---------------------------------------------------------------------------
 
 describe("ConfigWatcher", () => {
   test("constructor stores initial config hash", () => {
@@ -113,5 +147,434 @@ describe("ConfigWatcher.diffServers", () => {
     expect(diff.added).toEqual([]);
     expect(diff.removed).toEqual([]);
     expect(diff.changed).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration tests — real filesystem with testOptions
+// ---------------------------------------------------------------------------
+
+describe("ConfigWatcher integration", () => {
+  let watcher: ConfigWatcher | undefined;
+
+  afterEach(() => {
+    watcher?.stop();
+    watcher = undefined;
+  });
+
+  test("detects direct write to servers.json", async () => {
+    using opts = testOptions({
+      files: {
+        "servers.json": mcpConfig({ alpha: { command: "echo" } }),
+      },
+    });
+
+    const initial = makeConfig({ alpha: { command: "echo" } });
+    const cb = mock((_e: ConfigChangeEvent) => {});
+
+    watcher = new ConfigWatcher(initial, cb, opts.dir);
+    watcher.start();
+
+    // Modify the config file
+    writeJson(opts.USER_SERVERS_PATH, mcpConfig({ alpha: { command: "echo" }, beta: { command: "cat" } }));
+
+    await waitForCall(cb);
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    const event = cb.mock.calls[0][0];
+    expect(event.added).toContain("beta");
+    expect(event.config.servers.has("beta")).toBe(true);
+  });
+
+  test("detects atomic write (rename-based save)", async () => {
+    using opts = testOptions({
+      files: {
+        "servers.json": mcpConfig({ alpha: { command: "echo" } }),
+      },
+    });
+
+    const initial = makeConfig({ alpha: { command: "echo" } });
+    const cb = mock((_e: ConfigChangeEvent) => {});
+
+    watcher = new ConfigWatcher(initial, cb, opts.dir);
+    watcher.start();
+
+    // Simulate atomic save: write to tmp, rename over original
+    atomicWrite(opts.USER_SERVERS_PATH, mcpConfig({ alpha: { command: "echo" }, gamma: { command: "ls" } }));
+
+    await waitForCall(cb);
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    const event = cb.mock.calls[0][0];
+    expect(event.added).toContain("gamma");
+  });
+
+  test("detects new file creation when file didn't exist initially", async () => {
+    using opts = testOptions();
+
+    // No servers.json exists yet
+    const initial: ResolvedConfig = { servers: new Map(), sources: [] };
+    const cb = mock((_e: ConfigChangeEvent) => {});
+
+    watcher = new ConfigWatcher(initial, cb, opts.dir);
+    watcher.start();
+
+    // Create the file for the first time
+    writeJson(opts.USER_SERVERS_PATH, mcpConfig({ newserver: { command: "echo" } }));
+
+    await waitForCall(cb);
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    const event = cb.mock.calls[0][0];
+    expect(event.added).toContain("newserver");
+  });
+
+  test("detects server removal", async () => {
+    using opts = testOptions({
+      files: {
+        "servers.json": mcpConfig({ alpha: { command: "echo" }, beta: { command: "cat" } }),
+      },
+    });
+
+    const initial = makeConfig({ alpha: { command: "echo" }, beta: { command: "cat" } });
+    const cb = mock((_e: ConfigChangeEvent) => {});
+
+    watcher = new ConfigWatcher(initial, cb, opts.dir);
+    watcher.start();
+
+    // Remove beta from config
+    writeJson(opts.USER_SERVERS_PATH, mcpConfig({ alpha: { command: "echo" } }));
+
+    await waitForCall(cb);
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    const event = cb.mock.calls[0][0];
+    expect(event.removed).toContain("beta");
+  });
+
+  test("detects server config change", async () => {
+    using opts = testOptions({
+      files: {
+        "servers.json": mcpConfig({ alpha: { command: "echo" } }),
+      },
+    });
+
+    const initial = makeConfig({ alpha: { command: "echo" } });
+    const cb = mock((_e: ConfigChangeEvent) => {});
+
+    watcher = new ConfigWatcher(initial, cb, opts.dir);
+    watcher.start();
+
+    // Change alpha's command
+    writeJson(opts.USER_SERVERS_PATH, mcpConfig({ alpha: { command: "cat" } }));
+
+    await waitForCall(cb);
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    const event = cb.mock.calls[0][0];
+    expect(event.changed).toContain("alpha");
+  });
+
+  test("does not fire callback when config hash is unchanged", async () => {
+    using opts = testOptions({
+      files: {
+        "servers.json": mcpConfig({ alpha: { command: "echo" } }),
+      },
+    });
+
+    const initial = makeConfig({ alpha: { command: "echo" } });
+    const cb = mock((_e: ConfigChangeEvent) => {});
+
+    watcher = new ConfigWatcher(initial, cb, opts.dir);
+    watcher.start();
+
+    // Write the same config (no actual change)
+    writeJson(opts.USER_SERVERS_PATH, mcpConfig({ alpha: { command: "echo" } }));
+
+    // Wait enough time for debounce + reload
+    await Bun.sleep(500);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  test("debounces rapid successive writes", async () => {
+    using opts = testOptions({
+      files: {
+        "servers.json": mcpConfig({ alpha: { command: "echo" } }),
+      },
+    });
+
+    const initial = makeConfig({ alpha: { command: "echo" } });
+    const cb = mock((_e: ConfigChangeEvent) => {});
+
+    watcher = new ConfigWatcher(initial, cb, opts.dir);
+    watcher.start();
+
+    // Rapid writes — should debounce to a single reload
+    for (let i = 0; i < 5; i++) {
+      writeJson(opts.USER_SERVERS_PATH, mcpConfig({ alpha: { command: `echo-${i}` } }));
+      await Bun.sleep(50);
+    }
+
+    // Wait for the debounce to settle
+    await Bun.sleep(500);
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    // Should have the final config
+    const event = cb.mock.calls[0][0];
+    expect(event.changed).toContain("alpha");
+  });
+
+  test("detects project config changes", async () => {
+    using opts = testOptions();
+    const cwd = join(opts.dir, "myproject");
+    mkdirSync(cwd, { recursive: true });
+
+    const projPath = projectConfigPath(cwd);
+    writeJson(projPath, mcpConfig({ projserver: { command: "echo" } }));
+
+    const initial = makeConfig({ projserver: { command: "echo" } });
+    const cb = mock((_e: ConfigChangeEvent) => {});
+
+    watcher = new ConfigWatcher(initial, cb, cwd);
+    watcher.start();
+
+    // Modify project config
+    writeJson(projPath, mcpConfig({ projserver: { command: "echo" }, newproj: { command: "cat" } }));
+
+    await waitForCall(cb);
+    expect(cb).toHaveBeenCalledTimes(1);
+
+    const event = cb.mock.calls[0][0];
+    expect(event.added).toContain("newproj");
+  });
+
+  test("forceReload triggers immediate reload without debounce", async () => {
+    using opts = testOptions({
+      files: {
+        "servers.json": mcpConfig({ alpha: { command: "echo" } }),
+      },
+    });
+
+    const initial = makeConfig({ alpha: { command: "echo" } });
+    const cb = mock((_e: ConfigChangeEvent) => {});
+
+    watcher = new ConfigWatcher(initial, cb, opts.dir);
+    // Note: NOT calling start() — testing forceReload in isolation
+
+    // Modify the config file
+    writeJson(opts.USER_SERVERS_PATH, mcpConfig({ alpha: { command: "echo" }, forced: { command: "ls" } }));
+
+    // Force reload should fire callback synchronously (within the await)
+    await watcher.forceReload();
+
+    expect(cb).toHaveBeenCalledTimes(1);
+    const event = cb.mock.calls[0][0];
+    expect(event.added).toContain("forced");
+  });
+
+  test("forceReload is a no-op when config hasn't changed", async () => {
+    using opts = testOptions({
+      files: {
+        "servers.json": mcpConfig({ alpha: { command: "echo" } }),
+      },
+    });
+
+    const initial = makeConfig({ alpha: { command: "echo" } });
+    const cb = mock((_e: ConfigChangeEvent) => {});
+
+    watcher = new ConfigWatcher(initial, cb, opts.dir);
+
+    await watcher.forceReload();
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  test("stop prevents further callbacks", async () => {
+    using opts = testOptions({
+      files: {
+        "servers.json": mcpConfig({ alpha: { command: "echo" } }),
+      },
+    });
+
+    const initial = makeConfig({ alpha: { command: "echo" } });
+    const cb = mock((_e: ConfigChangeEvent) => {});
+
+    watcher = new ConfigWatcher(initial, cb, opts.dir);
+    watcher.start();
+    watcher.stop();
+
+    // Modify after stop
+    writeJson(opts.USER_SERVERS_PATH, mcpConfig({ alpha: { command: "echo" }, stopped: { command: "ls" } }));
+
+    await Bun.sleep(500);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  test("forceReload after stop is a no-op", async () => {
+    using opts = testOptions({
+      files: {
+        "servers.json": mcpConfig({ alpha: { command: "echo" } }),
+      },
+    });
+
+    const initial = makeConfig({ alpha: { command: "echo" } });
+    const cb = mock((_e: ConfigChangeEvent) => {});
+
+    watcher = new ConfigWatcher(initial, cb, opts.dir);
+    watcher.stop();
+
+    writeJson(opts.USER_SERVERS_PATH, mcpConfig({ alpha: { command: "echo" }, post_stop: { command: "ls" } }));
+    await watcher.forceReload();
+
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  test("event includes updated hash", async () => {
+    using opts = testOptions({
+      files: {
+        "servers.json": mcpConfig({ alpha: { command: "echo" } }),
+      },
+    });
+
+    const initial = makeConfig({ alpha: { command: "echo" } });
+    const initialHash = configHash(initial);
+    const cb = mock((_e: ConfigChangeEvent) => {});
+
+    watcher = new ConfigWatcher(initial, cb, opts.dir);
+
+    writeJson(opts.USER_SERVERS_PATH, mcpConfig({ alpha: { command: "cat" } }));
+    await watcher.forceReload();
+
+    expect(cb).toHaveBeenCalledTimes(1);
+    const event = cb.mock.calls[0][0];
+    expect(event.hash).not.toBe(initialHash);
+    expect(typeof event.hash).toBe("string");
+    expect(event.hash.length).toBeGreaterThan(0);
+  });
+
+  test("detects multiple sequential changes", async () => {
+    using opts = testOptions({
+      files: {
+        "servers.json": mcpConfig({ alpha: { command: "echo" } }),
+      },
+    });
+
+    const initial = makeConfig({ alpha: { command: "echo" } });
+    const cb = mock((_e: ConfigChangeEvent) => {});
+
+    watcher = new ConfigWatcher(initial, cb, opts.dir);
+    watcher.start();
+
+    // First change
+    writeJson(opts.USER_SERVERS_PATH, mcpConfig({ alpha: { command: "echo" }, beta: { command: "cat" } }));
+    await waitForCall(cb);
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb.mock.calls[0][0].added).toContain("beta");
+
+    // Second change (after first has been processed)
+    await Bun.sleep(400); // Wait for debounce window to fully close
+    writeJson(
+      opts.USER_SERVERS_PATH,
+      mcpConfig({ alpha: { command: "echo" }, beta: { command: "cat" }, gamma: { command: "ls" } }),
+    );
+
+    // Wait for second callback
+    const deadline = Date.now() + 2000;
+    while (cb.mock.calls.length < 2 && Date.now() < deadline) {
+      await Bun.sleep(50);
+    }
+    expect(cb).toHaveBeenCalledTimes(2);
+    expect(cb.mock.calls[1][0].added).toContain("gamma");
+  });
+
+  test("handles malformed JSON gracefully (no crash, treats as empty)", async () => {
+    using opts = testOptions({
+      files: {
+        "servers.json": mcpConfig({ alpha: { command: "echo" } }),
+      },
+    });
+
+    const initial = makeConfig({ alpha: { command: "echo" } });
+    const cb = mock((_e: ConfigChangeEvent) => {});
+
+    watcher = new ConfigWatcher(initial, cb, opts.dir);
+
+    // Write malformed JSON — loadConfig silently returns empty config,
+    // so the watcher sees "alpha" as removed (hash changes)
+    writeFileSync(opts.USER_SERVERS_PATH, "{ invalid json !!!");
+
+    await watcher.forceReload();
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb.mock.calls[0][0].removed).toContain("alpha");
+  });
+
+  test("recovers after malformed JSON is fixed", async () => {
+    using opts = testOptions({
+      files: {
+        "servers.json": mcpConfig({ alpha: { command: "echo" } }),
+      },
+    });
+
+    const initial = makeConfig({ alpha: { command: "echo" } });
+    const cb = mock((_e: ConfigChangeEvent) => {});
+
+    watcher = new ConfigWatcher(initial, cb, opts.dir);
+
+    // Write malformed JSON — watcher treats it as empty config
+    writeFileSync(opts.USER_SERVERS_PATH, "not json");
+    await watcher.forceReload();
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb.mock.calls[0][0].removed).toContain("alpha");
+
+    // Fix the JSON — both alpha and recovered appear as new
+    writeJson(opts.USER_SERVERS_PATH, mcpConfig({ alpha: { command: "echo" }, recovered: { command: "ls" } }));
+    await watcher.forceReload();
+    expect(cb).toHaveBeenCalledTimes(2);
+    expect(cb.mock.calls[1][0].added).toContain("alpha");
+    expect(cb.mock.calls[1][0].added).toContain("recovered");
+  });
+
+  test("detects HTTP server additions", async () => {
+    using opts = testOptions({
+      files: {
+        "servers.json": mcpConfig({ alpha: { command: "echo" } }),
+      },
+    });
+
+    const initial = makeConfig({ alpha: { command: "echo" } });
+    const cb = mock((_e: ConfigChangeEvent) => {});
+
+    watcher = new ConfigWatcher(initial, cb, opts.dir);
+
+    writeJson(
+      opts.USER_SERVERS_PATH,
+      mcpConfig({
+        alpha: { command: "echo" },
+        remote: { type: "http" as const, url: "https://example.com/mcp" },
+      }),
+    );
+
+    await watcher.forceReload();
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb.mock.calls[0][0].added).toContain("remote");
+  });
+
+  test("detects config file deletion", async () => {
+    using opts = testOptions({
+      files: {
+        "servers.json": mcpConfig({ alpha: { command: "echo" } }),
+      },
+    });
+
+    const initial = makeConfig({ alpha: { command: "echo" } });
+    const cb = mock((_e: ConfigChangeEvent) => {});
+
+    watcher = new ConfigWatcher(initial, cb, opts.dir);
+
+    // Delete the config file — loadConfig returns empty config
+    unlinkSync(opts.USER_SERVERS_PATH);
+
+    await watcher.forceReload();
+    expect(cb).toHaveBeenCalledTimes(1);
+    expect(cb.mock.calls[0][0].removed).toContain("alpha");
   });
 });

--- a/packages/daemon/src/config/watcher.ts
+++ b/packages/daemon/src/config/watcher.ts
@@ -99,21 +99,15 @@ export class ConfigWatcher {
     return [...paths];
   }
 
-  /** Set up fs.watch on a file (or its parent directory if it doesn't exist yet). */
+  /**
+   * Set up fs.watch on the parent directory of a config file.
+   *
+   * Always watches the directory rather than the file itself because many
+   * editors perform atomic saves (write tmp → rename), which replaces the
+   * file's inode and silently breaks a direct `fs.watch(file)` handle.
+   */
   private watchFile(filePath: string): void {
-    if (existsSync(filePath)) {
-      // Watch the file directly
-      try {
-        const watcher = watch(filePath, () => this.scheduleReload());
-        this.watchers.push(watcher);
-      } catch {
-        // Fall back to watching the directory
-        this.watchDirectory(filePath);
-      }
-    } else {
-      // File doesn't exist yet — watch the parent directory for creation
-      this.watchDirectory(filePath);
-    }
+    this.watchDirectory(filePath);
   }
 
   /** Watch a parent directory for file creation/modification. */
@@ -129,6 +123,11 @@ export class ConfigWatcher {
     } catch {
       // Directory not watchable — skip silently
     }
+  }
+
+  /** Force an immediate config reload, bypassing debounce. */
+  async forceReload(): Promise<void> {
+    await this.reload();
   }
 
   /** Schedule a debounced config reload. */

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -80,20 +80,6 @@ async function main(): Promise<void> {
     }, idleTimeoutMs);
   }
 
-  // Start IPC server
-  const ipcServer = new IpcServer(pool, config, db, {
-    onActivity: () => {
-      inFlightCount++;
-      resetIdleTimer();
-    },
-    onRequestComplete: () => {
-      inFlightCount = Math.max(0, inFlightCount - 1);
-      resetIdleTimer();
-    },
-    onShutdown: () => shutdown(),
-  });
-  ipcServer.start();
-
   // Watch config files for hot reload
   const watcher = new ConfigWatcher(config, (event) => {
     const { added, removed, changed } = pool.updateConfig(event.config);
@@ -116,6 +102,21 @@ async function main(): Promise<void> {
     writeFileSync(options.PID_PATH, JSON.stringify(updatedPid));
   });
   watcher.start();
+
+  // Start IPC server
+  const ipcServer = new IpcServer(pool, config, db, {
+    onActivity: () => {
+      inFlightCount++;
+      resetIdleTimer();
+    },
+    onRequestComplete: () => {
+      inFlightCount = Math.max(0, inFlightCount - 1);
+      resetIdleTimer();
+    },
+    onShutdown: () => shutdown(),
+    onReloadConfig: () => watcher.forceReload(),
+  });
+  ipcServer.start();
 
   // Start idle timer
   resetIdleTimer();

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -49,15 +49,23 @@ export class IpcServer {
   private onRequestComplete: () => void;
   private onShutdown: () => void;
 
+  private onReloadConfig: (() => Promise<void>) | null = null;
+
   constructor(
     private pool: ServerPool,
     private config: ResolvedConfig,
     private db: StateDb,
-    options: { onActivity: () => void; onRequestComplete?: () => void; onShutdown?: () => void },
+    options: {
+      onActivity: () => void;
+      onRequestComplete?: () => void;
+      onShutdown?: () => void;
+      onReloadConfig?: () => Promise<void>;
+    },
   ) {
     this.onActivity = options.onActivity;
     this.onRequestComplete = options.onRequestComplete ?? (() => {});
     this.onShutdown = options.onShutdown ?? (() => process.exit(0));
+    this.onReloadConfig = options.onReloadConfig ?? null;
     this.registerHandlers();
   }
 
@@ -434,6 +442,14 @@ export class IpcServer {
       const { id } = MarkReadParamsSchema.parse(params);
       this.db.markMailRead(id);
       return {};
+    });
+
+    this.handlers.set("reloadConfig", async () => {
+      if (!this.onReloadConfig) {
+        throw Object.assign(new Error("Config reload not available"), { code: IPC_ERROR.INTERNAL_ERROR });
+      }
+      await this.onReloadConfig();
+      return { ok: true };
     });
 
     this.handlers.set("shutdown", async () => {


### PR DESCRIPTION
## Summary
- **Root cause fix**: Config watcher now watches parent directories instead of files directly, so atomic saves (write tmp → rename) used by most editors are properly detected
- **New `forceReload()` method**: Allows immediate config reload bypassing debounce timer
- **New `reloadConfig` IPC method**: Users can force a config reload via the daemon IPC protocol when auto-detection fails

## Test plan
- [x] 18 new integration tests using `testOptions` with real filesystem operations
- [x] Tests cover: direct writes, atomic writes (rename), file creation, server removal, server config changes, debouncing, project config changes, force reload, malformed JSON handling, recovery after bad JSON, HTTP server additions, file deletion, sequential changes, stop behavior
- [x] All 869 tests pass, typecheck clean, lint clean
- [x] Coverage: 100% functions, 100% lines for `watcher.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)