### PR TITLE
feat: `mcx serve` — expose tools as a stdio MCP server (fixes #136)

### DIFF
--- a/packages/command/src/commands/serve.spec.ts
+++ b/packages/command/src/commands/serve.spec.ts
@@ -1,0 +1,282 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { IpcMethod } from "@mcp-cli/core";
+import {
+  CALL_TOOL,
+  type CuratedTool,
+  FIND_TOOL,
+  type IpcCaller,
+  checkRecursionGuard,
+  handleCallTool,
+  handleListTools,
+  parseMcpTools,
+} from "./serve";
+
+// -- parseMcpTools --
+
+describe("parseMcpTools", () => {
+  test("returns empty array for undefined", () => {
+    expect(parseMcpTools(undefined)).toEqual([]);
+  });
+
+  test("returns empty array for empty string", () => {
+    expect(parseMcpTools("")).toEqual([]);
+  });
+
+  test("returns empty array for whitespace-only", () => {
+    expect(parseMcpTools("  ")).toEqual([]);
+  });
+
+  test("parses server/tool entries", () => {
+    const result = parseMcpTools("atlassian/search,github/create_issue");
+    expect(result).toEqual([
+      { name: "search", server: "atlassian", tool: "search" },
+      { name: "create_issue", server: "github", tool: "create_issue" },
+    ]);
+  });
+
+  test("parses alias entries (no slash) as _aliases", () => {
+    const result = parseMcpTools("deploy-pr,run-tests");
+    expect(result).toEqual([
+      { name: "deploy-pr", server: "_aliases", tool: "deploy-pr" },
+      { name: "run-tests", server: "_aliases", tool: "run-tests" },
+    ]);
+  });
+
+  test("handles mixed server/tool and alias entries", () => {
+    const result = parseMcpTools("atlassian/search,deploy-pr");
+    expect(result).toEqual([
+      { name: "search", server: "atlassian", tool: "search" },
+      { name: "deploy-pr", server: "_aliases", tool: "deploy-pr" },
+    ]);
+  });
+
+  test("trims whitespace around entries", () => {
+    const result = parseMcpTools(" atlassian/search , github/list ");
+    expect(result).toEqual([
+      { name: "search", server: "atlassian", tool: "search" },
+      { name: "list", server: "github", tool: "list" },
+    ]);
+  });
+
+  test("skips empty entries from extra commas", () => {
+    const result = parseMcpTools(",atlassian/search,,github/list,");
+    expect(result).toEqual([
+      { name: "search", server: "atlassian", tool: "search" },
+      { name: "list", server: "github", tool: "list" },
+    ]);
+  });
+
+  test("deduplicates on tool name, keeps first", () => {
+    const result = parseMcpTools("atlassian/search,github/search");
+    expect(result).toEqual([{ name: "search", server: "atlassian", tool: "search" }]);
+    expect(result).toHaveLength(1);
+  });
+
+  test("deduplicates alias vs server/tool with same name", () => {
+    const result = parseMcpTools("atlassian/deploy,deploy");
+    expect(result).toEqual([{ name: "deploy", server: "atlassian", tool: "deploy" }]);
+    expect(result).toHaveLength(1);
+  });
+
+  test("handles single entry", () => {
+    const result = parseMcpTools("atlassian/search");
+    expect(result).toEqual([{ name: "search", server: "atlassian", tool: "search" }]);
+  });
+
+  test("skips entries with empty server or tool (bare slash)", () => {
+    const result = parseMcpTools("/search,atlassian/,valid/tool");
+    expect(result).toEqual([{ name: "tool", server: "valid", tool: "tool" }]);
+  });
+});
+
+// -- Recursion guard --
+
+describe("checkRecursionGuard", () => {
+  let savedEnv: string | undefined;
+
+  beforeEach(() => {
+    savedEnv = process.env.MCX_SERVE;
+  });
+
+  afterEach(() => {
+    if (savedEnv === undefined) {
+      process.env.MCX_SERVE = undefined;
+    } else {
+      process.env.MCX_SERVE = savedEnv;
+    }
+  });
+
+  test("returns false when MCX_SERVE is not set", () => {
+    process.env.MCX_SERVE = undefined;
+    expect(checkRecursionGuard()).toBe(false);
+  });
+
+  test("returns false when MCX_SERVE is empty", () => {
+    process.env.MCX_SERVE = "";
+    expect(checkRecursionGuard()).toBe(false);
+  });
+
+  test("returns true when MCX_SERVE is '1'", () => {
+    process.env.MCX_SERVE = "1";
+    expect(checkRecursionGuard()).toBe(true);
+  });
+
+  test("returns false when MCX_SERVE is some other value", () => {
+    process.env.MCX_SERVE = "yes";
+    expect(checkRecursionGuard()).toBe(false);
+  });
+});
+
+// -- handleListTools --
+
+describe("handleListTools", () => {
+  const mockIpc: IpcCaller = async (method: IpcMethod, params?: unknown) => {
+    if (method === "getToolInfo") {
+      const p = params as { server: string; tool: string };
+      return {
+        name: p.tool,
+        server: p.server,
+        description: `Description of ${p.tool}`,
+        inputSchema: { type: "object", properties: { q: { type: "string" } } },
+      };
+    }
+    return null;
+  };
+
+  test("returns find and call meta-tools when no curated tools", async () => {
+    const result = await handleListTools([], mockIpc);
+    expect(result.tools).toHaveLength(2);
+    expect(result.tools[0].name).toBe("find");
+    expect(result.tools[1].name).toBe("call");
+  });
+
+  test("returns curated tools with real schemas + meta-tools", async () => {
+    const curated: CuratedTool[] = [{ name: "search", server: "atlassian", tool: "search" }];
+    const result = await handleListTools(curated, mockIpc);
+    expect(result.tools).toHaveLength(3);
+    expect(result.tools[0].name).toBe("search");
+    expect(result.tools[0].description).toBe("Description of search");
+    expect(result.tools[0].inputSchema).toEqual({ type: "object", properties: { q: { type: "string" } } });
+    expect(result.tools[1].name).toBe("find");
+    expect(result.tools[2].name).toBe("call");
+  });
+
+  test("handles schema fetch failure gracefully", async () => {
+    const failIpc: IpcCaller = async (_method: IpcMethod) => {
+      throw new Error("Connection refused");
+    };
+    const curated: CuratedTool[] = [{ name: "broken", server: "bad", tool: "broken" }];
+    const result = await handleListTools(curated, failIpc);
+    expect(result.tools).toHaveLength(3);
+    expect(result.tools[0].name).toBe("broken");
+    expect(result.tools[0].description).toContain("schema unavailable");
+  });
+});
+
+// -- handleCallTool --
+
+describe("handleCallTool", () => {
+  const mockIpc: IpcCaller = async (method: IpcMethod, params?: unknown) => {
+    if (method === "listTools") {
+      return [
+        { name: "search", server: "atlassian", description: "Search stuff" },
+        { name: "echo", server: "test", description: "Echo input" },
+      ];
+    }
+    if (method === "grepTools") {
+      const p = params as { pattern: string };
+      return [{ name: "search", server: "atlassian", description: `Matched: ${p.pattern}` }];
+    }
+    if (method === "callTool") {
+      const p = params as { server: string; tool: string; arguments: Record<string, unknown> };
+      return {
+        content: [{ type: "text", text: `Called ${p.server}/${p.tool}` }],
+      };
+    }
+    return null;
+  };
+
+  const curated: CuratedTool[] = [{ name: "search", server: "atlassian", tool: "search" }];
+
+  test("find lists all tools when no query", async () => {
+    const result = await handleCallTool("find", {}, curated, mockIpc);
+    expect(result.content[0].text).toContain("atlassian/search");
+    expect(result.content[0].text).toContain("test/echo");
+  });
+
+  test("find filters tools with query", async () => {
+    const result = await handleCallTool("find", { q: "search" }, curated, mockIpc);
+    expect(result.content[0].text).toContain("atlassian/search");
+    expect(result.content[0].text).not.toContain("test/echo");
+  });
+
+  test("find returns message when no tools found", async () => {
+    const emptyIpc: IpcCaller = async (_method: IpcMethod) => [];
+    const result = await handleCallTool("find", { q: "nonexistent" }, [], emptyIpc);
+    expect(result.content[0].text).toBe("No tools found.");
+  });
+
+  test("call proxies to ipcCall with correct params", async () => {
+    const result = await handleCallTool("call", { tool: "test/echo", input: { msg: "hi" } }, curated, mockIpc);
+    expect(result.content[0].text).toBe("Called test/echo");
+  });
+
+  test("call errors on missing tool argument", async () => {
+    const result = await handleCallTool("call", {}, curated, mockIpc);
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Missing required");
+  });
+
+  test("call errors on invalid tool path (no slash)", async () => {
+    const result = await handleCallTool("call", { tool: "noslash" }, curated, mockIpc);
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("server/tool");
+  });
+
+  test("call defaults input to empty object when omitted", async () => {
+    let captured: Record<string, unknown> | undefined;
+    const capturingIpc: IpcCaller = async (_method: IpcMethod, params?: unknown) => {
+      captured = params as Record<string, unknown>;
+      return { content: [{ type: "text", text: "ok" }] };
+    };
+    await handleCallTool("call", { tool: "s/t" }, [], capturingIpc);
+    expect((captured as Record<string, unknown>).arguments).toEqual({});
+  });
+
+  test("curated tool proxies to correct server/tool", async () => {
+    const result = await handleCallTool("search", { query: "test" }, curated, mockIpc);
+    expect(result.content[0].text).toBe("Called atlassian/search");
+  });
+
+  test("unknown tool returns error", async () => {
+    const result = await handleCallTool("nonexistent", {}, curated, mockIpc);
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Unknown tool: nonexistent");
+  });
+
+  test("curated tool passes arguments through", async () => {
+    let captured: Record<string, unknown> | undefined;
+    const capturingIpc: IpcCaller = async (_method: IpcMethod, params?: unknown) => {
+      captured = params as Record<string, unknown>;
+      return { content: [{ type: "text", text: "ok" }] };
+    };
+    await handleCallTool("search", { query: "test" }, curated, capturingIpc);
+    expect((captured as Record<string, unknown>).arguments).toEqual({ query: "test" });
+    expect((captured as Record<string, unknown>).server).toBe("atlassian");
+    expect((captured as Record<string, unknown>).tool).toBe("search");
+  });
+});
+
+// -- Meta-tool schemas --
+
+describe("meta-tool definitions", () => {
+  test("FIND_TOOL has expected shape", () => {
+    expect(FIND_TOOL.name).toBe("find");
+    expect(FIND_TOOL.inputSchema.type).toBe("object");
+  });
+
+  test("CALL_TOOL has expected shape", () => {
+    expect(CALL_TOOL.name).toBe("call");
+    expect(CALL_TOOL.inputSchema.required).toContain("tool");
+  });
+});

--- a/packages/command/src/commands/serve.ts
+++ b/packages/command/src/commands/serve.ts
@@ -1,0 +1,238 @@
+/**
+ * mcx serve — stdio MCP server that proxies tools from the daemon.
+ *
+ * Two modes that compose:
+ *
+ * **Curated mode** (MCP_TOOLS is set):
+ *   Each entry becomes a top-level MCP tool with its real JSON Schema.
+ *   Format: "server/tool" for server tools, "name" for aliases (_aliases/name).
+ *
+ * **Discovery mode** (always available):
+ *   `find` — search/list available tools across all servers
+ *   `call` — invoke any tool by server/tool path
+ */
+
+import type { IpcMethod, ToolInfo } from "@mcp-cli/core";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+// -- Types --
+
+export interface CuratedTool {
+  /** Display name (tool name, last segment) */
+  name: string;
+  server: string;
+  tool: string;
+}
+
+interface ToolCallResult {
+  [key: string]: unknown;
+  isError?: boolean;
+  content: Array<{ type: string; text: string }>;
+}
+
+/** Dependency-injectable IPC caller for testing */
+export type IpcCaller = (method: IpcMethod, params?: unknown) => Promise<unknown>;
+
+// -- MCP_TOOLS parsing --
+
+/**
+ * Parse the MCP_TOOLS env var into a list of curated tools.
+ * Format: comma-separated, "server/tool" or "aliasName".
+ * Alias names (no slash) resolve to _aliases/<name>.
+ * Returns deduplicated list; warns on stderr for name conflicts.
+ */
+export function parseMcpTools(env: string | undefined): CuratedTool[] {
+  if (!env?.trim()) return [];
+
+  const seen = new Map<string, CuratedTool>();
+  const results: CuratedTool[] = [];
+
+  for (const raw of env.split(",")) {
+    const entry = raw.trim();
+    if (!entry) continue;
+
+    const slashIdx = entry.indexOf("/");
+    let server: string;
+    let tool: string;
+    let name: string;
+
+    if (slashIdx >= 0) {
+      server = entry.slice(0, slashIdx);
+      tool = entry.slice(slashIdx + 1);
+      name = tool;
+    } else {
+      // Alias — resolve as _aliases/<name>
+      server = "_aliases";
+      tool = entry;
+      name = entry;
+    }
+
+    if (!server || !tool) continue;
+
+    const existing = seen.get(name);
+    if (existing) {
+      console.error(
+        `[mcx serve] Name conflict: "${name}" from ${server}/${tool} conflicts with ${existing.server}/${existing.tool}. Keeping first.`,
+      );
+      continue;
+    }
+
+    const ct: CuratedTool = { name, server, tool };
+    seen.set(name, ct);
+    results.push(ct);
+  }
+
+  return results;
+}
+
+// -- Meta-tool definitions --
+
+export const FIND_TOOL = {
+  name: "find",
+  description:
+    "Search available MCP tools across all connected servers. Returns tool names, servers, and descriptions.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      q: { type: "string", description: "Filter tools by name or description. Omit to list all." },
+    },
+  },
+};
+
+export const CALL_TOOL = {
+  name: "call",
+  description: "Call any MCP tool by server/tool path. Use 'find' to discover available tools first.",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      tool: { type: "string", description: "Tool path as 'server/tool'" },
+      input: { type: "object", description: "Arguments to pass to the tool" },
+    },
+    required: ["tool"],
+  },
+};
+
+// -- Recursion guard --
+
+const MCX_SERVE_GUARD = "MCX_SERVE";
+
+export function checkRecursionGuard(): boolean {
+  return process.env[MCX_SERVE_GUARD] === "1";
+}
+
+// -- Handler logic (extracted for testability) --
+
+export async function handleListTools(
+  curated: CuratedTool[],
+  ipc: IpcCaller,
+): Promise<{ tools: Array<{ name: string; description: string; inputSchema: Record<string, unknown> }> }> {
+  const curatedTools = await Promise.all(
+    curated.map(async (ct) => {
+      try {
+        const info = (await ipc("getToolInfo", {
+          server: ct.server,
+          tool: ct.tool,
+        })) as ToolInfo & { inputSchema: Record<string, unknown> };
+        return {
+          name: ct.name,
+          description: info.description ?? "",
+          inputSchema: info.inputSchema ?? { type: "object" as const, properties: {} },
+        };
+      } catch (err) {
+        console.error(`[mcx serve] Failed to fetch schema for ${ct.server}/${ct.tool}: ${err}`);
+        return {
+          name: ct.name,
+          description: `(schema unavailable) ${ct.server}/${ct.tool}`,
+          inputSchema: { type: "object" as const, properties: {} },
+        };
+      }
+    }),
+  );
+
+  return {
+    tools: [...curatedTools, FIND_TOOL, CALL_TOOL],
+  };
+}
+
+export async function handleCallTool(
+  name: string,
+  args: Record<string, unknown> | undefined,
+  curated: CuratedTool[],
+  ipc: IpcCaller,
+): Promise<ToolCallResult> {
+  // Meta-tool: find
+  if (name === "find") {
+    const q = args?.q as string | undefined;
+    const tools = q
+      ? ((await ipc("grepTools", { pattern: q })) as ToolInfo[])
+      : ((await ipc("listTools")) as ToolInfo[]);
+    const lines = tools.map((t) => `${t.server}/${t.name} — ${t.description}`);
+    return { content: [{ type: "text", text: lines.join("\n") || "No tools found." }] };
+  }
+
+  // Meta-tool: call
+  if (name === "call") {
+    const toolPath = args?.tool as string | undefined;
+    if (!toolPath) {
+      return {
+        isError: true,
+        content: [{ type: "text", text: "Missing required 'tool' argument (format: server/tool)" }],
+      };
+    }
+    const slashIdx = toolPath.indexOf("/");
+    if (slashIdx < 0) {
+      return {
+        isError: true,
+        content: [{ type: "text", text: `Invalid tool path "${toolPath}". Use "server/tool" format.` }],
+      };
+    }
+    const server = toolPath.slice(0, slashIdx);
+    const tool = toolPath.slice(slashIdx + 1);
+    const input = (args?.input as Record<string, unknown>) ?? {};
+    return (await ipc("callTool", { server, tool, arguments: input })) as ToolCallResult;
+  }
+
+  // Curated tool
+  const ct = curated.find((c) => c.name === name);
+  if (ct) {
+    return (await ipc("callTool", {
+      server: ct.server,
+      tool: ct.tool,
+      arguments: args ?? {},
+    })) as ToolCallResult;
+  }
+
+  return {
+    isError: true,
+    content: [{ type: "text", text: `Unknown tool: ${name}` }],
+  };
+}
+
+// -- Server --
+
+export async function cmdServe(): Promise<void> {
+  if (checkRecursionGuard()) {
+    console.error("[mcx serve] Recursion detected (MCX_SERVE=1 already set). Aborting to prevent infinite loop.");
+    process.exit(1);
+  }
+  // Set the guard so any child `mcx serve` spawned by the daemon will detect the loop
+  process.env[MCX_SERVE_GUARD] = "1";
+
+  const { ipcCall } = await import("@mcp-cli/core");
+  const curated = parseMcpTools(process.env.MCP_TOOLS);
+
+  const server = new Server({ name: "mcx-serve", version: "1.0.0" }, { capabilities: { tools: {} } });
+
+  server.setRequestHandler(ListToolsRequestSchema, () => handleListTools(curated, ipcCall));
+
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const { name, arguments: args } = req.params;
+    return handleCallTool(name, args as Record<string, unknown> | undefined, curated, ipcCall);
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("[mcx serve] MCP server running on stdio");
+}

--- a/packages/command/src/index.ts
+++ b/packages/command/src/index.ts
@@ -30,6 +30,7 @@ import { cmdMail } from "./commands/mail";
 import { cmdRegistryDispatch } from "./commands/registry-cmd";
 import { cmdRemove } from "./commands/remove";
 import { cmdRun, parseRunArgs } from "./commands/run";
+import { cmdServe } from "./commands/serve";
 import { cmdTypegen } from "./commands/typegen";
 import { readFileWithLimit } from "./file-read";
 import { SIZE_HINT, SIZE_OK, applyJqFilter, generateAnalysis } from "./jq/index";
@@ -180,6 +181,10 @@ async function main(): Promise<void> {
 
       case "completions":
         await cmdCompletions(args.slice(1));
+        break;
+
+      case "serve":
+        await cmdServe();
         break;
 
       case "restart":
@@ -487,6 +492,7 @@ Usage:
   mcx mail --wait --for=<name>       Wait for mail to specific recipient
   mcx logs <server> [-f] [--lines N]  View server stderr output
   mcx typegen                         Generate TypeScript types for alias scripts
+  mcx serve                           Run as stdio MCP server (for .mcp.json)
   mcx completions {bash|zsh|fish}     Generate shell completion script
   mcx restart [server]                Restart server connection(s)
   mcx shutdown                        Stop the daemon


### PR DESCRIPTION
## Summary
- Adds `mcx serve` command that acts as a stdio MCP server, designed for `.mcp.json` integration
- **Curated mode** (`MCP_TOOLS` env): cherry-picked `server/tool` pairs and aliases become top-level MCP tools with real JSON schemas from the daemon
- **Discovery mode** (always on): `find` and `call` meta-tools for ad-hoc tool discovery and invocation across all connected servers
- Recursion guard (`MCX_SERVE` env var) prevents infinite loops when mcx serve is itself listed as an MCP server

### Example `.mcp.json`
```jsonc
{
  "mcpServers": {
    "x": {
      "command": "mcx",
      "args": ["serve"],
      "env": {
        "MCP_TOOLS": "atlassian/search,github/create_issue,deploy-pr"
      }
    }
  }
}
```

Claude sees `mcp__x__search`, `mcp__x__create_issue`, `mcp__x__deploy_pr`, `mcp__x__find`, `mcp__x__call`.

## Test plan
- [x] `parseMcpTools()` — server/tool entries, alias entries, mixed, dedup, conflicts, edge cases (11 tests)
- [x] `checkRecursionGuard()` — env var states (4 tests)
- [x] `handleListTools()` — empty curated, with curated, schema fetch failure (3 tests)
- [x] `handleCallTool()` — find (all/filtered/empty), call (valid/missing/invalid), curated proxy, unknown tool (9 tests)
- [x] Meta-tool schema shapes (2 tests)
- [x] All 922 tests pass, typecheck clean, lint clean, coverage ratchet passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)