### PR TITLE
chore: top 10 tech debt / correctness fixes (fixes #150)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 
 # Build artifacts
 *.js.map
+build/

--- a/biome.json
+++ b/biome.json
@@ -26,6 +26,6 @@
     }
   },
   "files": {
-    "ignore": ["node_modules", "dist", "*.d.ts", ".claude"]
+    "ignore": ["node_modules", "dist", "build", "*.d.ts", ".claude"]
   }
 }

--- a/packages/command/src/commands/add.spec.ts
+++ b/packages/command/src/commands/add.spec.ts
@@ -166,6 +166,17 @@ describe("parseAddArgs", () => {
     );
   });
 
+  test("throws on --callback-port above 65535", () => {
+    expect(() =>
+      parseAddArgs(["--transport", "http", "--callback-port", "70000", "name", "https://example.com"]),
+    ).toThrow('Invalid --callback-port "70000"');
+  });
+
+  test("accepts --callback-port at boundary 65535", () => {
+    const result = parseAddArgs(["--transport", "http", "--callback-port", "65535", "name", "https://example.com"]);
+    expect(result.callbackPort).toBe(65535);
+  });
+
   test("rejects --client-id on stdio transport", () => {
     expect(() => parseAddArgs(["--transport", "stdio", "--client-id", "id", "name", "--", "cmd"])).toThrow(
       "not valid for stdio transport",

--- a/packages/command/src/commands/add.ts
+++ b/packages/command/src/commands/add.ts
@@ -90,8 +90,8 @@ export function parseAddArgs(args: string[]): ParsedAddArgs {
       const val = flagArgs[++i];
       if (!val) throw new Error("--callback-port requires a value");
       callbackPort = Number.parseInt(val, 10);
-      if (!Number.isFinite(callbackPort) || callbackPort <= 0) {
-        throw new Error(`Invalid --callback-port "${val}": must be a positive integer`);
+      if (!Number.isFinite(callbackPort) || callbackPort <= 0 || callbackPort > 65535) {
+        throw new Error(`Invalid --callback-port "${val}": must be an integer between 1 and 65535`);
       }
     } else if (!arg.startsWith("-")) {
       positional.push(arg);

--- a/packages/command/src/commands/registry-cmd.spec.ts
+++ b/packages/command/src/commands/registry-cmd.spec.ts
@@ -150,6 +150,21 @@ describe("cmdRegistryDispatch", () => {
     expect(capturedUrl).toContain("search=test");
   });
 
+  test("throws on non-numeric --limit", async () => {
+    const { extractRegistryFlags } = await import("./registry-cmd.js");
+    expect(() => extractRegistryFlags(["list", "--limit", "abc"])).toThrow('Invalid --limit "abc"');
+  });
+
+  test("throws on negative --limit", async () => {
+    const { extractRegistryFlags } = await import("./registry-cmd.js");
+    expect(() => extractRegistryFlags(["list", "--limit", "-5"])).toThrow('Invalid --limit "-5"');
+  });
+
+  test("throws on zero --limit", async () => {
+    const { extractRegistryFlags } = await import("./registry-cmd.js");
+    expect(() => extractRegistryFlags(["list", "--limit", "0"])).toThrow('Invalid --limit "0"');
+  });
+
   test("defaults to list when no subcommand given", async () => {
     const { cmdRegistryDispatch } = await import("./registry-cmd.js");
     let capturedUrl = "";

--- a/packages/command/src/commands/registry-cmd.ts
+++ b/packages/command/src/commands/registry-cmd.ts
@@ -57,7 +57,8 @@ async function cmdRegistryList(args: string[]): Promise<void> {
   }
 }
 
-function extractRegistryFlags(args: string[]): {
+/** @internal Exported for testing. */
+export function extractRegistryFlags(args: string[]): {
   limit: number | undefined;
   noCache: boolean;
   remaining: string[];
@@ -69,6 +70,9 @@ function extractRegistryFlags(args: string[]): {
   for (let i = 0; i < args.length; i++) {
     if ((args[i] === "--limit" || args[i] === "-n") && i + 1 < args.length) {
       limit = Number.parseInt(args[i + 1], 10);
+      if (Number.isNaN(limit) || limit <= 0) {
+        throw new Error(`Invalid --limit "${args[i + 1]}": must be a positive integer`);
+      }
       i++;
     } else if (args[i] === "--no-cache") {
       noCache = true;

--- a/packages/core/src/ipc-client.ts
+++ b/packages/core/src/ipc-client.ts
@@ -22,6 +22,9 @@ import { ensureStateDir } from "./fs";
 import type { IpcMethod, IpcRequest, IpcResponse } from "./ipc";
 import { nextId } from "./ipc";
 
+/** Base URL for IPC requests over the Unix domain socket. */
+const IPC_RPC_URL = "http://localhost/rpc";
+
 /**
  * Send a single request to the daemon and return the response.
  * Auto-starts the daemon if it's not running.
@@ -40,7 +43,7 @@ export async function ipcCall(method: IpcMethod, params?: unknown): Promise<unkn
 
 /** Send a request via HTTP-over-Unix-socket and return the response */
 async function sendRequest(request: IpcRequest): Promise<IpcResponse> {
-  const res = await fetch("http://localhost/rpc", {
+  const res = await fetch(IPC_RPC_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(request),
@@ -169,7 +172,7 @@ let mismatchWarned = false;
 async function stopDaemon(): Promise<void> {
   verifiedMcpdPid = null;
   try {
-    await fetch("http://localhost/rpc", {
+    await fetch(IPC_RPC_URL, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ id: nextId(), method: "shutdown" }),
@@ -186,7 +189,7 @@ async function stopDaemon(): Promise<void> {
 
 /** Send a quick HTTP ping to verify the daemon is responsive */
 function pingDaemon(): Promise<boolean> {
-  return fetch("http://localhost/rpc", {
+  return fetch(IPC_RPC_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ id: nextId(), method: "ping" }),
@@ -330,7 +333,9 @@ async function startDaemon(): Promise<void> {
   }
 
   proc.kill();
-  await stderrDrain.catch(() => {}); // collect any remaining stderr
+  await stderrDrain.catch((e) => {
+    stderrOutput += `\n[drain error: ${e instanceof Error ? e.message : String(e)}]`;
+  });
   const details = [stdout && `stdout: ${stdout.trim()}`, stderrOutput && `stderr: ${stderrOutput.trim()}`]
     .filter(Boolean)
     .join("; ");

--- a/packages/daemon/src/config/watcher.ts
+++ b/packages/daemon/src/config/watcher.ts
@@ -133,8 +133,15 @@ export class ConfigWatcher {
   /** Schedule a debounced config reload. */
   private scheduleReload(): void {
     if (this.stopped) return;
-    if (this.debounceTimer) clearTimeout(this.debounceTimer);
-    this.debounceTimer = setTimeout(() => this.reload(), DEBOUNCE_MS);
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null;
+      if (this.stopped) return;
+      this.reload();
+    }, DEBOUNCE_MS);
   }
 
   /** Reload config and fire callback if hash changed. */

--- a/packages/daemon/src/db/state.spec.ts
+++ b/packages/daemon/src/db/state.spec.ts
@@ -106,6 +106,19 @@ describe("StateDb", () => {
       expect(db.getCachedTools("s2")).toHaveLength(0);
       db.close();
     });
+
+    test("getCachedTools returns empty schema for corrupt JSON", () => {
+      const db = createDb();
+      // biome-ignore lint/complexity/useLiteralKeys: access private field for test
+      db["db"].run(
+        "INSERT INTO tool_cache (server_name, tool_name, description, input_schema_json) VALUES (?, ?, ?, ?)",
+        ["s1", "broken", "desc", "{invalid json"],
+      );
+      const cached = db.getCachedTools("s1");
+      expect(cached).toHaveLength(1);
+      expect(cached[0].inputSchema).toEqual({});
+      db.close();
+    });
   });
 
   describe("usage stats", () => {
@@ -331,6 +344,21 @@ describe("StateDb", () => {
       db.close();
     });
 
+    test("listAliases returns empty schema for corrupt schema JSON", () => {
+      const db = createDb();
+      // biome-ignore lint/complexity/useLiteralKeys: access private field for test
+      db["db"].run(
+        `INSERT INTO aliases (name, file_path, description, alias_type, input_schema_json, output_schema_json, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, unixepoch(), unixepoch())`,
+        ["broken", "/tmp/broken.ts", "desc", "defineAlias", "not{json", "also{bad"],
+      );
+      const aliases = db.listAliases();
+      expect(aliases).toHaveLength(1);
+      expect(aliases[0].inputSchemaJson).toEqual({});
+      expect(aliases[0].outputSchemaJson).toEqual({});
+      db.close();
+    });
+
     test("saveAlias stores aliasType as defineAlias", () => {
       const db = createDb();
       db.saveAlias("structured", "/tmp/structured.ts", "A defined alias", "defineAlias");
@@ -491,6 +519,19 @@ describe("StateDb", () => {
       expect(db.getClientInfo("nope")).toBeUndefined();
       db.close();
     });
+
+    test("getClientInfo falls back to basic fields on corrupt JSON", () => {
+      const db = createDb();
+      // biome-ignore lint/complexity/useLiteralKeys: access private field for test
+      db["db"].run(
+        "INSERT INTO oauth_clients (server_name, client_id, client_secret, client_info_json, created_at) VALUES (?, ?, ?, ?, unixepoch())",
+        ["srv", "cid-123", "secret", "not valid json"],
+      );
+      const info = db.getClientInfo("srv");
+      expect(info).toBeDefined();
+      expect(info?.client_id).toBe("cid-123");
+      db.close();
+    });
   });
 
   describe("oauth_verifiers", () => {
@@ -553,6 +594,17 @@ describe("StateDb", () => {
     test("getDiscoveryState returns undefined for missing server", () => {
       const db = createDb();
       expect(db.getDiscoveryState("nope")).toBeUndefined();
+      db.close();
+    });
+
+    test("getDiscoveryState returns undefined for corrupt JSON", () => {
+      const db = createDb();
+      // biome-ignore lint/complexity/useLiteralKeys: access private field for test
+      db["db"].run("INSERT INTO oauth_discovery (server_name, state_json, updated_at) VALUES (?, ?, unixepoch())", [
+        "srv",
+        "corrupt{",
+      ]);
+      expect(db.getDiscoveryState("srv")).toBeUndefined();
       db.close();
     });
   });

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -162,7 +162,7 @@ export class StateDb {
       name: row.tool_name,
       server: row.server_name,
       description: row.description ?? "",
-      inputSchema: row.input_schema_json ? JSON.parse(row.input_schema_json) : {},
+      inputSchema: row.input_schema_json ? safeJsonParse(row.input_schema_json, {}) : {},
       signature: row.signature ?? undefined,
     }));
   }
@@ -325,7 +325,10 @@ export class StateDb {
       .get(serverName);
 
     if (!row) return undefined;
-    if (row.client_info_json) return JSON.parse(row.client_info_json);
+    if (row.client_info_json) {
+      const parsed = safeJsonParse<OAuthClientInformationMixed | null>(row.client_info_json, null);
+      if (parsed) return parsed;
+    }
     const info: OAuthClientInformationMixed = { client_id: row.client_id };
     if (row.client_secret) (info as Record<string, unknown>).client_secret = row.client_secret;
     return info;
@@ -373,7 +376,7 @@ export class StateDb {
       .query<{ state_json: string }, [string]>("SELECT state_json FROM oauth_discovery WHERE server_name = ?")
       .get(serverName);
     if (!row) return undefined;
-    return JSON.parse(row.state_json);
+    return safeJsonParse<OAuthDiscoveryState | undefined>(row.state_json, undefined);
   }
 
   saveDiscoveryState(serverName: string, state: OAuthDiscoveryState): void {
@@ -418,8 +421,8 @@ export class StateDb {
         filePath: row.file_path,
         updatedAt: row.updated_at,
         aliasType: row.alias_type as "freeform" | "defineAlias",
-        ...(row.input_schema_json ? { inputSchemaJson: JSON.parse(row.input_schema_json) } : {}),
-        ...(row.output_schema_json ? { outputSchemaJson: JSON.parse(row.output_schema_json) } : {}),
+        ...(row.input_schema_json ? { inputSchemaJson: safeJsonParse(row.input_schema_json, {}) } : {}),
+        ...(row.output_schema_json ? { outputSchemaJson: safeJsonParse(row.output_schema_json, {}) } : {}),
       }));
   }
 
@@ -499,11 +502,12 @@ export class StateDb {
     }
 
     const where = conditions.join(" AND ");
-    const limitClause = limit ? `LIMIT ${Number(limit)}` : "";
+    const limitClause = limit ? " LIMIT ?" : "";
+    if (limit) params.push(limit);
 
     return this.db
       .query<{ line: string; timestamp_ms: number }, (string | number)[]>(
-        `SELECT line, timestamp_ms FROM server_logs WHERE ${where} ORDER BY timestamp_ms ASC ${limitClause}`,
+        `SELECT line, timestamp_ms FROM server_logs WHERE ${where} ORDER BY timestamp_ms ASC${limitClause}`,
       )
       .all(...params)
       .map((row) => ({ line: row.line, timestampMs: row.timestamp_ms }));
@@ -546,7 +550,8 @@ export class StateDb {
     }
 
     const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
-    const limitClause = limit ? `LIMIT ${Number(limit)}` : "";
+    const limitClause = limit ? " LIMIT ?" : "";
+    if (limit) params.push(limit);
 
     return this.db
       .query<
@@ -562,7 +567,7 @@ export class StateDb {
         },
         (string | number)[]
       >(
-        `SELECT id, sender, recipient, subject, body, reply_to, read, created_at FROM mail ${where} ORDER BY created_at DESC ${limitClause}`,
+        `SELECT id, sender, recipient, subject, body, reply_to, read, created_at FROM mail ${where} ORDER BY created_at DESC${limitClause}`,
       )
       .all(...params)
       .map(toMailMessage);
@@ -642,6 +647,15 @@ export class StateDb {
 }
 
 // -- Helpers --
+
+/** Parse JSON safely, returning fallback on corrupt/invalid data. */
+function safeJsonParse<T>(json: string, fallback: T): T {
+  try {
+    return JSON.parse(json) as T;
+  } catch {
+    return fallback;
+  }
+}
 
 function toMailMessage(row: {
   id: number;

--- a/packages/daemon/src/server-pool.ts
+++ b/packages/daemon/src/server-pool.ts
@@ -47,6 +47,7 @@ interface ServerConnection {
 
 export class ServerPool {
   private connections = new Map<string, ServerConnection>();
+  private reconnecting = new Map<string, Promise<void>>();
   private config: ResolvedConfig;
   private db: StateDb | null;
   private stderrBuffer = new StderrRingBuffer();
@@ -121,16 +122,21 @@ export class ServerPool {
       } else if (!Bun.deepEquals(existing.resolved.config, resolved.config)) {
         changed.push(name);
         existing.resolved = resolved;
-        // Reconnect if currently connected
-        if (existing.state === "connected") {
-          this.disconnect(name)
+        // Reconnect if currently connected (skip if already reconnecting)
+        if (existing.state === "connected" && !this.reconnecting.has(name)) {
+          const reconnectPromise = this.disconnect(name)
             .then(() => {
               console.error(`[pool] Reconnecting "${name}" after config change`);
               return this.ensureConnected(name);
             })
+            .then(() => {})
             .catch((err) => {
               console.error(`[pool] Failed to reconnect "${name}" after config change: ${err}`);
+            })
+            .finally(() => {
+              this.reconnecting.delete(name);
             });
+          this.reconnecting.set(name, reconnectPromise);
         }
       }
     }
@@ -208,7 +214,7 @@ export class ServerPool {
 
           return conn;
         } catch (err) {
-          lastErr = err instanceof Error ? err : new Error(String(err));
+          lastErr = err instanceof Error ? err : new Error(String(err), { cause: err });
 
           if (attempt < maxRetries && isRetryableError(err)) {
             const delay = Math.min(CONNECT_INITIAL_DELAY_MS * 2 ** attempt, CONNECT_MAX_DELAY_MS);


### PR DESCRIPTION
## Summary
- **Item 1**: Wrap 5 `JSON.parse` callsites in `state.ts` with `safeJsonParse` helper — prevents daemon crash on corrupted DB rows
- **Item 2**: Serialize reconnections per-server via `reconnecting` Map — prevents interleaved reconnects on rapid config changes
- **Item 3**: Replace `LIMIT ${Number(limit)}` with parameterized `LIMIT ?` in 2 queries
- **Item 5**: Guard config watcher debounce timer with `stopped` check inside callback + null timer after clearing
- **Item 6**: Validate `--callback-port` range 1–65535 (was only checking > 0)
- **Item 7**: Validate `--limit` for NaN/negative/zero in registry command
- **Item 8**: Extract `IPC_RPC_URL` constant (was hardcoded 3 times)
- **Item 9**: Preserve original error as `cause` when wrapping non-Error values
- **Item 10**: Capture stderr drain errors instead of silently swallowing them
- **Bonus**: Ignore `build/` directory in `.gitignore` and biome config (scratch POC files)

Item 4 (console.error → daemon-log) skipped — `daemon-log.ts` already monkey-patches `console.error` globally, so all callsites are captured. Converting to an explicit logger is a separate concern.

## Test plan
- [x] 4 new tests for corrupt JSON handling in `state.spec.ts` (tool cache, aliases, OAuth client info, discovery state)
- [x] 2 new tests for port range validation in `add.spec.ts` (> 65535 rejected, 65535 boundary accepted)
- [x] 3 new tests for `--limit` validation in `registry-cmd.spec.ts` (NaN, negative, zero)
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (932 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)