### PR TITLE
feat: `mcx config get/set` for server config inspection (fixes #123)

### DIFF
--- a/packages/command/src/commands/config.spec.ts
+++ b/packages/command/src/commands/config.spec.ts
@@ -1,7 +1,21 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { GetConfigResult, McpConfigFile, ServerConfig } from "@mcp-cli/core";
+import type { ConfigDeps } from "./config";
+import {
+  cmdConfig,
+  configGetDispatch,
+  configGetServer,
+  configSetDispatch,
+  configSetServerEnv,
+  isCliOptionKey,
+  maskConfig,
+  maskValue,
+  parseEnvKeyValue,
+  printServerConfigDetails,
+} from "./config";
 
 let testDir: string;
 let configPath: string;
@@ -16,40 +30,760 @@ afterEach(() => {
   rmSync(testDir, { recursive: true, force: true });
 });
 
-describe("config set/get", () => {
-  // Test the core read/write functions directly since they are the shared logic
-  it("writeCliConfig creates file with correct JSON", async () => {
-    // We test the core functions directly
-    const { writeFileSync } = await import("node:fs");
-    writeFileSync(configPath, `${JSON.stringify({ trustClaude: true }, null, 2)}\n`);
+// -- Helper: create mock deps --
 
+function makeDeps(
+  servers: Record<string, { transport: string; source: string; scope: string; toolCount: number }>,
+  fileContents: Record<string, McpConfigFile> = {},
+  writtenFiles: Record<string, McpConfigFile> = {},
+): ConfigDeps {
+  return {
+    getConfig: async () =>
+      ({
+        servers,
+        sources: Object.values(servers).map((s) => ({ file: s.source, scope: s.scope })),
+      }) as GetConfigResult,
+    readConfig: (path: string) => fileContents[path] ?? { mcpServers: {} },
+    writeConfig: (path: string, config: McpConfigFile) => {
+      writtenFiles[path] = structuredClone(config);
+    },
+  };
+}
+
+// -- maskValue --
+
+describe("maskValue", () => {
+  it("preserves env var references like ${API_KEY}", () => {
+    expect(maskValue("${API_KEY}")).toBe("${API_KEY}");
+  });
+
+  it("preserves env var references with defaults like ${API_KEY:-fallback}", () => {
+    expect(maskValue("${API_KEY:-fallback}")).toBe("${API_KEY:-fallback}");
+  });
+
+  it("masks short values entirely", () => {
+    expect(maskValue("abc")).toBe("****");
+    expect(maskValue("12345678")).toBe("****");
+  });
+
+  it("masks long values with first 4 and last 3 visible", () => {
+    expect(maskValue("cxup_longSecretKeyiFR")).toBe("cxup****iFR");
+  });
+
+  it("masks 9-character values", () => {
+    expect(maskValue("123456789")).toBe("1234****789");
+  });
+
+  it("masks empty string", () => {
+    expect(maskValue("")).toBe("****");
+  });
+
+  it("does not mask partial env refs (not full match)", () => {
+    expect(maskValue("prefix${VAR}suffix")).not.toBe("prefix${VAR}suffix");
+  });
+});
+
+// -- maskConfig --
+
+describe("maskConfig", () => {
+  it("returns config unchanged when showSecrets is true", () => {
+    const config: ServerConfig = { command: "node", env: { KEY: "secret123456" } };
+    expect(maskConfig(config, true)).toBe(config);
+  });
+
+  it("masks env values in stdio config", () => {
+    const config: ServerConfig = { command: "node", env: { API_KEY: "sk-1234567890abc" } };
+    const result = maskConfig(config, false);
+    expect(result).toHaveProperty("env");
+    expect((result as { env: Record<string, string> }).env.API_KEY).toBe("sk-1****abc");
+  });
+
+  it("returns stdio config unchanged when no env", () => {
+    const config: ServerConfig = { command: "node", args: ["server.js"] };
+    expect(maskConfig(config, false)).toEqual(config);
+  });
+
+  it("masks headers in http config", () => {
+    const config: ServerConfig = {
+      type: "http",
+      url: "https://example.com",
+      headers: { Authorization: "Bearer sk-1234567890abc" },
+    };
+    const result = maskConfig(config, false);
+    expect((result as { headers: Record<string, string> }).headers.Authorization).toBe("Bear****abc");
+  });
+
+  it("returns http config unchanged when no headers", () => {
+    const config: ServerConfig = { type: "http", url: "https://example.com" };
+    expect(maskConfig(config, false)).toEqual(config);
+  });
+
+  it("preserves env var references in masked output", () => {
+    const config: ServerConfig = { command: "node", env: { KEY: "${MY_SECRET}" } };
+    const result = maskConfig(config, false);
+    expect((result as { env: Record<string, string> }).env.KEY).toBe("${MY_SECRET}");
+  });
+});
+
+// -- parseEnvKeyValue --
+
+describe("parseEnvKeyValue", () => {
+  it("parses KEY:VALUE correctly", () => {
+    expect(parseEnvKeyValue("API_KEY:sk-xxx")).toEqual({ key: "API_KEY", value: "sk-xxx" });
+  });
+
+  it("handles values containing colons", () => {
+    expect(parseEnvKeyValue("URL:https://example.com:8080")).toEqual({
+      key: "URL",
+      value: "https://example.com:8080",
+    });
+  });
+
+  it("handles empty value after colon", () => {
+    expect(parseEnvKeyValue("KEY:")).toEqual({ key: "KEY", value: "" });
+  });
+
+  it("returns null for missing colon", () => {
+    expect(parseEnvKeyValue("NOVALUE")).toBeNull();
+  });
+
+  it("returns null for colon at start", () => {
+    expect(parseEnvKeyValue(":value")).toBeNull();
+  });
+});
+
+// -- isCliOptionKey --
+
+describe("isCliOptionKey", () => {
+  it("recognizes trust-claude", () => {
+    expect(isCliOptionKey("trust-claude")).toBe(true);
+  });
+
+  it("returns false for server names", () => {
+    expect(isCliOptionKey("my-server")).toBe(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isCliOptionKey("")).toBe(false);
+  });
+});
+
+// -- printServerConfigDetails --
+
+describe("printServerConfigDetails", () => {
+  it("prints stdio server details", () => {
+    const logs: string[] = [];
+    spyOn(console, "log").mockImplementation((msg: string) => {
+      logs.push(msg);
+    });
+
+    const config: ServerConfig = {
+      command: "npx",
+      args: ["my-server", "--flag"],
+      env: { API_KEY: "secret12345678" },
+      cwd: "/some/path",
+    };
+    printServerConfigDetails(config, false);
+
+    expect(logs.some((l) => l.includes("npx my-server --flag"))).toBe(true);
+    expect(logs.some((l) => l.includes("/some/path"))).toBe(true);
+    expect(logs.some((l) => l.includes("API_KEY"))).toBe(true);
+    expect(logs.some((l) => l.includes("secr****678"))).toBe(true);
+  });
+
+  it("prints stdio server details with --show-secrets", () => {
+    const logs: string[] = [];
+    spyOn(console, "log").mockImplementation((msg: string) => {
+      logs.push(msg);
+    });
+
+    const config: ServerConfig = {
+      command: "node",
+      env: { API_KEY: "secret12345678" },
+    };
+    printServerConfigDetails(config, true);
+
+    expect(logs.some((l) => l.includes("secret12345678"))).toBe(true);
+  });
+
+  it("prints http server details", () => {
+    const logs: string[] = [];
+    spyOn(console, "log").mockImplementation((msg: string) => {
+      logs.push(msg);
+    });
+
+    const config: ServerConfig = {
+      type: "http",
+      url: "https://example.com/mcp",
+      headers: { Authorization: "Bearer secret12345678" },
+    };
+    printServerConfigDetails(config, false);
+
+    expect(logs.some((l) => l.includes("https://example.com/mcp"))).toBe(true);
+    expect(logs.some((l) => l.includes("Authorization"))).toBe(true);
+    expect(logs.some((l) => l.includes("****"))).toBe(true);
+  });
+
+  it("prints stdio without env or cwd", () => {
+    const logs: string[] = [];
+    spyOn(console, "log").mockImplementation((msg: string) => {
+      logs.push(msg);
+    });
+
+    const config: ServerConfig = { command: "node", args: ["server.js"] };
+    printServerConfigDetails(config, false);
+
+    expect(logs.some((l) => l.includes("node server.js"))).toBe(true);
+    expect(logs.some((l) => l.includes("env"))).toBe(false);
+  });
+
+  it("prints http without headers", () => {
+    const logs: string[] = [];
+    spyOn(console, "log").mockImplementation((msg: string) => {
+      logs.push(msg);
+    });
+
+    const config: ServerConfig = { type: "sse", url: "https://example.com/sse" };
+    printServerConfigDetails(config, false);
+
+    expect(logs.some((l) => l.includes("https://example.com/sse"))).toBe(true);
+    expect(logs.some((l) => l.includes("headers"))).toBe(false);
+  });
+});
+
+// -- configGetServer (with DI) --
+
+describe("configGetServer", () => {
+  it("displays server config in text mode", async () => {
+    const logs: string[] = [];
+    spyOn(console, "log").mockImplementation((msg: string) => {
+      logs.push(msg);
+    });
+
+    const sourcePath = join(testDir, "servers.json");
+    const deps = makeDeps(
+      { "my-server": { transport: "stdio", source: sourcePath, scope: "user", toolCount: 3 } },
+      {
+        [sourcePath]: {
+          mcpServers: {
+            "my-server": { command: "node", args: ["srv.js"], env: { KEY: "val123456789" } },
+          },
+        },
+      },
+    );
+
+    await configGetServer(["my-server"], deps);
+
+    expect(logs.some((l) => l.includes("my-server"))).toBe(true);
+    expect(logs.some((l) => l.includes("node srv.js"))).toBe(true);
+    expect(logs.some((l) => l.includes("KEY"))).toBe(true);
+    expect(logs.some((l) => l.includes(sourcePath))).toBe(true);
+  });
+
+  it("displays server config in JSON mode", async () => {
+    const logs: string[] = [];
+    spyOn(console, "log").mockImplementation((msg: string) => {
+      logs.push(msg);
+    });
+
+    const sourcePath = join(testDir, "servers.json");
+    const deps = makeDeps(
+      { "my-server": { transport: "stdio", source: sourcePath, scope: "user", toolCount: 2 } },
+      {
+        [sourcePath]: {
+          mcpServers: {
+            "my-server": { command: "node", env: { SECRET: "supersecret123" } },
+          },
+        },
+      },
+    );
+
+    await configGetServer(["my-server", "--json"], deps);
+
+    const output = JSON.parse(logs.join(""));
+    expect(output.name).toBe("my-server");
+    expect(output.transport).toBe("stdio");
+    expect(output.config.env.SECRET).toBe("supe****123");
+  });
+
+  it("shows secrets in JSON mode with --show-secrets", async () => {
+    const logs: string[] = [];
+    spyOn(console, "log").mockImplementation((msg: string) => {
+      logs.push(msg);
+    });
+
+    const sourcePath = join(testDir, "servers.json");
+    const deps = makeDeps(
+      { "my-server": { transport: "stdio", source: sourcePath, scope: "user", toolCount: 0 } },
+      {
+        [sourcePath]: {
+          mcpServers: {
+            "my-server": { command: "node", env: { SECRET: "supersecret123" } },
+          },
+        },
+      },
+    );
+
+    await configGetServer(["my-server", "--json", "--show-secrets"], deps);
+
+    const output = JSON.parse(logs.join(""));
+    expect(output.config.env.SECRET).toBe("supersecret123");
+  });
+
+  it("handles server with no config in file (virtual)", async () => {
+    const logs: string[] = [];
+    spyOn(console, "log").mockImplementation((msg: string) => {
+      logs.push(msg);
+    });
+
+    const deps = makeDeps(
+      { "virtual-srv": { transport: "virtual", source: "/some/path", scope: "mcp-cli", toolCount: 1 } },
+      { "/some/path": { mcpServers: {} } },
+    );
+
+    await configGetServer(["virtual-srv"], deps);
+
+    expect(logs.some((l) => l.includes("virtual-srv"))).toBe(true);
+    expect(logs.some((l) => l.includes("source"))).toBe(true);
+  });
+});
+
+// -- configSetServerEnv (with DI) --
+
+describe("configSetServerEnv", () => {
+  it("sets env var on stdio server", async () => {
+    const sourcePath = join(testDir, "servers.json");
+    const writtenFiles: Record<string, McpConfigFile> = {};
+    const deps = makeDeps(
+      { "my-server": { transport: "stdio", source: sourcePath, scope: "user", toolCount: 3 } },
+      {
+        [sourcePath]: {
+          mcpServers: {
+            "my-server": { command: "node", env: { EXISTING: "value" } },
+          },
+        },
+      },
+      writtenFiles,
+    );
+
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+
+    await configSetServerEnv(["my-server", "env", "NEW_KEY:new-value"], deps);
+
+    expect(writtenFiles[sourcePath]).toBeDefined();
+    const updated = writtenFiles[sourcePath].mcpServers?.["my-server"] as { env: Record<string, string> };
+    expect(updated.env.EXISTING).toBe("value");
+    expect(updated.env.NEW_KEY).toBe("new-value");
+    expect(logSpy).toHaveBeenCalledWith("Set NEW_KEY on my-server");
+  });
+
+  it("creates env object when missing", async () => {
+    const sourcePath = join(testDir, "servers.json");
+    const writtenFiles: Record<string, McpConfigFile> = {};
+    const deps = makeDeps(
+      { "my-server": { transport: "stdio", source: sourcePath, scope: "user", toolCount: 0 } },
+      {
+        [sourcePath]: {
+          mcpServers: {
+            "my-server": { command: "node" },
+          },
+        },
+      },
+      writtenFiles,
+    );
+
+    spyOn(console, "log").mockImplementation(() => {});
+
+    await configSetServerEnv(["my-server", "env", "API_KEY:sk-test"], deps);
+
+    const updated = writtenFiles[sourcePath].mcpServers?.["my-server"] as { env: Record<string, string> };
+    expect(updated.env.API_KEY).toBe("sk-test");
+  });
+
+  it("handles values containing colons", async () => {
+    const sourcePath = join(testDir, "servers.json");
+    const writtenFiles: Record<string, McpConfigFile> = {};
+    const deps = makeDeps(
+      { "my-server": { transport: "stdio", source: sourcePath, scope: "user", toolCount: 0 } },
+      { [sourcePath]: { mcpServers: { "my-server": { command: "node" } } } },
+      writtenFiles,
+    );
+
+    spyOn(console, "log").mockImplementation(() => {});
+
+    await configSetServerEnv(["my-server", "env", "URL:https://host:8080/path"], deps);
+
+    const updated = writtenFiles[sourcePath].mcpServers?.["my-server"] as { env: Record<string, string> };
+    expect(updated.env.URL).toBe("https://host:8080/path");
+  });
+});
+
+// -- configGetDispatch --
+
+describe("configGetDispatch", () => {
+  it("dispatches to server config for unknown keys", async () => {
+    const logs: string[] = [];
+    spyOn(console, "log").mockImplementation((msg: string) => {
+      logs.push(msg);
+    });
+
+    const sourcePath = join(testDir, "servers.json");
+    const deps = makeDeps(
+      { "my-server": { transport: "stdio", source: sourcePath, scope: "user", toolCount: 1 } },
+      { [sourcePath]: { mcpServers: { "my-server": { command: "echo" } } } },
+    );
+
+    await configGetDispatch(["my-server"], deps);
+
+    expect(logs.some((l) => l.includes("my-server"))).toBe(true);
+  });
+});
+
+// -- configSetDispatch --
+
+describe("configSetDispatch", () => {
+  it("dispatches to server env set when second arg is 'env'", async () => {
+    const sourcePath = join(testDir, "servers.json");
+    const writtenFiles: Record<string, McpConfigFile> = {};
+    const deps = makeDeps(
+      { srv: { transport: "stdio", source: sourcePath, scope: "user", toolCount: 0 } },
+      { [sourcePath]: { mcpServers: { srv: { command: "node" } } } },
+      writtenFiles,
+    );
+
+    spyOn(console, "log").mockImplementation(() => {});
+
+    await configSetDispatch(["srv", "env", "K:V"], deps);
+
+    const updated = writtenFiles[sourcePath].mcpServers?.srv as { env: Record<string, string> };
+    expect(updated.env.K).toBe("V");
+  });
+});
+
+// -- cmdConfig dispatch --
+
+describe("cmdConfig", () => {
+  it("dispatches 'show' subcommand", async () => {
+    const logs: string[] = [];
+    spyOn(console, "log").mockImplementation((msg: string) => {
+      logs.push(msg);
+    });
+
+    const deps = makeDeps({
+      srv: { transport: "stdio", source: "/path", scope: "user", toolCount: 2 },
+    });
+
+    await cmdConfig(["show"], deps);
+
+    expect(logs.some((l) => l.includes("srv"))).toBe(true);
+    expect(logs.some((l) => l.includes("1 server(s)"))).toBe(true);
+  });
+
+  it("dispatches 'sources' subcommand", async () => {
+    const logs: string[] = [];
+    spyOn(console, "log").mockImplementation((msg: string) => {
+      logs.push(msg);
+    });
+
+    const deps = makeDeps({
+      srv: { transport: "stdio", source: "/path/servers.json", scope: "user", toolCount: 0 },
+    });
+
+    await cmdConfig(["sources"], deps);
+
+    expect(logs.some((l) => l.includes("Config sources"))).toBe(true);
+    expect(logs.some((l) => l.includes("/path/servers.json"))).toBe(true);
+  });
+
+  it("dispatches 'get' to configGetDispatch", async () => {
+    const logs: string[] = [];
+    spyOn(console, "log").mockImplementation((msg: string) => {
+      logs.push(msg);
+    });
+
+    const sourcePath = join(testDir, "servers.json");
+    const deps = makeDeps(
+      { srv: { transport: "stdio", source: sourcePath, scope: "user", toolCount: 0 } },
+      { [sourcePath]: { mcpServers: { srv: { command: "echo" } } } },
+    );
+
+    await cmdConfig(["get", "srv"], deps);
+
+    expect(logs.some((l) => l.includes("srv"))).toBe(true);
+  });
+
+  it("dispatches 'set' with env to configSetServerEnv", async () => {
+    const sourcePath = join(testDir, "servers.json");
+    const writtenFiles: Record<string, McpConfigFile> = {};
+    const deps = makeDeps(
+      { srv: { transport: "stdio", source: sourcePath, scope: "user", toolCount: 0 } },
+      { [sourcePath]: { mcpServers: { srv: { command: "node" } } } },
+      writtenFiles,
+    );
+
+    spyOn(console, "log").mockImplementation(() => {});
+
+    await cmdConfig(["set", "srv", "env", "K:V"], deps);
+
+    expect(writtenFiles[sourcePath]).toBeDefined();
+  });
+
+  it("defaults to 'show' when no subcommand", async () => {
+    const logs: string[] = [];
+    spyOn(console, "log").mockImplementation((msg: string) => {
+      logs.push(msg);
+    });
+
+    const deps = makeDeps({
+      srv: { transport: "stdio", source: "/path", scope: "user", toolCount: 1 },
+    });
+
+    await cmdConfig([], deps);
+
+    expect(logs.some((l) => l.includes("srv"))).toBe(true);
+  });
+});
+
+// -- configShow edge cases --
+
+describe("configShow", () => {
+  it("prints message when no servers configured", async () => {
+    const errors: string[] = [];
+    spyOn(console, "error").mockImplementation((msg: string) => {
+      errors.push(msg);
+    });
+
+    const deps = makeDeps({});
+
+    await cmdConfig(["show"], deps);
+
+    expect(errors.some((l) => l.includes("No servers configured"))).toBe(true);
+  });
+
+  it("shows tool count when > 0", async () => {
+    const logs: string[] = [];
+    spyOn(console, "log").mockImplementation((msg: string) => {
+      logs.push(msg);
+    });
+
+    const deps = makeDeps({
+      a: { transport: "stdio", source: "/p", scope: "user", toolCount: 5 },
+    });
+
+    await cmdConfig(["show"], deps);
+
+    expect(logs.some((l) => l.includes("5 tools"))).toBe(true);
+  });
+});
+
+// -- configSources edge cases --
+
+describe("configSources", () => {
+  it("prints message when no sources", async () => {
+    const errors: string[] = [];
+    spyOn(console, "error").mockImplementation((msg: string) => {
+      errors.push(msg);
+    });
+
+    // Use a custom deps with empty sources
+    const deps: ConfigDeps = {
+      getConfig: async () => ({ servers: {}, sources: [] }),
+      readConfig: () => ({ mcpServers: {} }),
+      writeConfig: () => {},
+    };
+
+    await cmdConfig(["sources"], deps);
+
+    expect(errors.some((l) => l.includes("No config sources found"))).toBe(true);
+  });
+});
+
+// -- configGetServer error cases --
+
+describe("configGetServer error handling", () => {
+  it("exits when server not found", async () => {
+    const errors: string[] = [];
+    spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("exit");
+    });
+
+    const deps = makeDeps({});
+
+    try {
+      await configGetServer(["nonexistent"], deps);
+    } catch {
+      // expected
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("outputs JSON with null config for virtual server", async () => {
+    const logs: string[] = [];
+    spyOn(console, "log").mockImplementation((msg: string) => {
+      logs.push(msg);
+    });
+
+    const deps = makeDeps(
+      { virt: { transport: "virtual", source: "/p", scope: "mcp-cli", toolCount: 0 } },
+      { "/p": { mcpServers: {} } },
+    );
+
+    await configGetServer(["virt", "--json"], deps);
+
+    const output = JSON.parse(logs.join(""));
+    expect(output.config).toBeNull();
+  });
+});
+
+// -- configSetServerEnv error cases --
+
+describe("configSetServerEnv error handling", () => {
+  it("exits when server not found in daemon config", async () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("exit");
+    });
+    spyOn(console, "error").mockImplementation(() => {});
+
+    const deps = makeDeps({});
+
+    try {
+      await configSetServerEnv(["nonexistent", "env", "K:V"], deps);
+    } catch {
+      // expected
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("exits when server not found in config file", async () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("exit");
+    });
+    spyOn(console, "error").mockImplementation(() => {});
+
+    const deps = makeDeps(
+      { srv: { transport: "stdio", source: "/p", scope: "user", toolCount: 0 } },
+      { "/p": { mcpServers: {} } }, // Server not in file
+    );
+
+    try {
+      await configSetServerEnv(["srv", "env", "K:V"], deps);
+    } catch {
+      // expected
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("exits when server is not stdio transport", async () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("exit");
+    });
+    spyOn(console, "error").mockImplementation(() => {});
+
+    const deps = makeDeps(
+      { srv: { transport: "http", source: "/p", scope: "user", toolCount: 0 } },
+      { "/p": { mcpServers: { srv: { type: "http", url: "https://example.com" } } } },
+    );
+
+    try {
+      await configSetServerEnv(["srv", "env", "K:V"], deps);
+    } catch {
+      // expected
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("exits for invalid KEY:VALUE format", async () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("exit");
+    });
+    spyOn(console, "error").mockImplementation(() => {});
+
+    const deps = makeDeps({});
+
+    try {
+      await configSetServerEnv(["srv", "env", "invalidformat"], deps);
+    } catch {
+      // expected
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});
+
+// -- config file round-trip --
+
+describe("config file round-trip", () => {
+  it("sets env var on a stdio server via file", () => {
+    const config = {
+      mcpServers: {
+        "my-server": {
+          command: "node",
+          args: ["server.js"],
+          env: { EXISTING_KEY: "existing-value" },
+        },
+      },
+    };
+    writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+
+    const { readConfigFile, writeConfigFile } = require("./config-file");
+    const fileConfig = readConfigFile(configPath);
+    const serverConfig = fileConfig.mcpServers["my-server"];
+    serverConfig.env = serverConfig.env ?? {};
+    serverConfig.env.NEW_KEY = "new-value";
+    writeConfigFile(configPath, fileConfig);
+
+    const updated = JSON.parse(readFileSync(configPath, "utf-8"));
+    expect(updated.mcpServers["my-server"].env.EXISTING_KEY).toBe("existing-value");
+    expect(updated.mcpServers["my-server"].env.NEW_KEY).toBe("new-value");
+  });
+
+  it("creates env object when missing", () => {
+    const config = {
+      mcpServers: {
+        "my-server": { command: "node", args: ["server.js"] },
+      },
+    };
+    writeFileSync(configPath, `${JSON.stringify(config, null, 2)}\n`);
+
+    const { readConfigFile, writeConfigFile } = require("./config-file");
+    const fileConfig = readConfigFile(configPath);
+    const serverConfig = fileConfig.mcpServers["my-server"];
+    serverConfig.env = serverConfig.env ?? {};
+    serverConfig.env.API_KEY = "sk-test";
+    writeConfigFile(configPath, fileConfig);
+
+    const updated = JSON.parse(readFileSync(configPath, "utf-8"));
+    expect(updated.mcpServers["my-server"].env.API_KEY).toBe("sk-test");
+  });
+});
+
+// -- CLI config --
+
+describe("CLI config read/write", () => {
+  it("writeCliConfig creates file with correct JSON", () => {
+    writeFileSync(configPath, `${JSON.stringify({ trustClaude: true }, null, 2)}\n`);
     const content = JSON.parse(readFileSync(configPath, "utf-8"));
     expect(content.trustClaude).toBe(true);
   });
 
-  it("readCliConfig returns {} when file missing", async () => {
-    const { readCliConfig } = await import("@mcp-cli/core");
-    // readCliConfig reads from the real MCP_CLI_CONFIG_PATH,
-    // so we test the logic with our own implementation
+  it("readCliConfig returns {} when file missing", () => {
     const result = readConfigFrom(configPath);
     expect(result).toEqual({});
   });
 
   it("round-trip: set true then get returns true", () => {
-    const { writeFileSync } = require("node:fs");
-
-    // Write
     writeFileSync(configPath, `${JSON.stringify({ trustClaude: true }, null, 2)}\n`);
-
-    // Read back
     const content = JSON.parse(readFileSync(configPath, "utf-8"));
     expect(content.trustClaude).toBe(true);
   });
 
   it("readCliConfig returns {} for malformed JSON", () => {
-    const { writeFileSync } = require("node:fs");
     writeFileSync(configPath, "not json{{{");
-
     const result = readConfigFrom(configPath);
     expect(result).toEqual({});
   });
@@ -58,7 +792,6 @@ describe("config set/get", () => {
     const nestedPath = join(testDir, "deep", "nested", "config.json");
     const dir = join(nestedPath, "..");
     mkdirSync(dir, { recursive: true });
-    const { writeFileSync } = require("node:fs");
     writeFileSync(nestedPath, `${JSON.stringify({ trustClaude: false }, null, 2)}\n`);
 
     expect(existsSync(nestedPath)).toBe(true);

--- a/packages/command/src/commands/config.ts
+++ b/packages/command/src/commands/config.ts
@@ -1,27 +1,44 @@
 /**
  * `mcx config` commands — display resolved configuration and sources,
- * plus get/set for CLI options like trust-claude.
+ * plus get/set for CLI options like trust-claude, and server config inspection/modification.
  */
 
-import type { GetConfigResult } from "@mcp-cli/core";
-import { ipcCall, readCliConfig, writeCliConfig } from "@mcp-cli/core";
+import type { GetConfigResult, McpConfigFile, ServerConfig } from "@mcp-cli/core";
+import { ipcCall, isStdioConfig, readCliConfig, writeCliConfig } from "@mcp-cli/core";
 import { c, printError } from "../output";
+import { readConfigFile, writeConfigFile } from "./config-file";
 
-export async function cmdConfig(args: string[]): Promise<void> {
+// -- Dependency injection for testability --
+
+export interface ConfigDeps {
+  getConfig: () => Promise<GetConfigResult>;
+  readConfig: (path: string) => McpConfigFile;
+  writeConfig: (path: string, config: McpConfigFile) => void;
+}
+
+const defaultDeps: ConfigDeps = {
+  getConfig: () => ipcCall("getConfig") as Promise<GetConfigResult>,
+  readConfig: readConfigFile,
+  writeConfig: writeConfigFile,
+};
+
+// -- Entry point --
+
+export async function cmdConfig(args: string[], deps: ConfigDeps = defaultDeps): Promise<void> {
   const sub = args[0] ?? "show";
 
   switch (sub) {
     case "show":
-      await configShow();
+      await configShow(deps);
       break;
     case "sources":
-      await configSources();
+      await configSources(deps);
       break;
     case "set":
-      configSet(args.slice(1));
+      await configSetDispatch(args.slice(1), deps);
       break;
     case "get":
-      configGet(args.slice(1));
+      await configGetDispatch(args.slice(1), deps);
       break;
     default:
       printError(`Unknown config subcommand: ${sub}. Use "show", "sources", "set", or "get".`);
@@ -29,8 +46,8 @@ export async function cmdConfig(args: string[]): Promise<void> {
   }
 }
 
-async function configShow(): Promise<void> {
-  const config = (await ipcCall("getConfig")) as GetConfigResult;
+async function configShow(deps: ConfigDeps): Promise<void> {
+  const config = await deps.getConfig();
   const entries = Object.entries(config.servers);
 
   if (entries.length === 0) {
@@ -48,8 +65,8 @@ async function configShow(): Promise<void> {
   console.log(`\n${entries.length} server(s) from ${config.sources.length} source(s)`);
 }
 
-async function configSources(): Promise<void> {
-  const config = (await ipcCall("getConfig")) as GetConfigResult;
+async function configSources(deps: ConfigDeps): Promise<void> {
+  const config = await deps.getConfig();
 
   if (config.sources.length === 0) {
     console.error("No config sources found.");
@@ -62,21 +79,61 @@ async function configSources(): Promise<void> {
   }
 }
 
+// -- CLI option keys --
+
 const VALID_KEYS = ["trust-claude"] as const;
 type ConfigKey = (typeof VALID_KEYS)[number];
 
-/** Map CLI key names (kebab-case) to CliConfig property names (camelCase). */
 const KEY_MAP: Record<ConfigKey, "trustClaude"> = {
   "trust-claude": "trustClaude",
 };
 
-function configSet(args: string[]): void {
+/** Check if a key is a known CLI option (vs a server name). */
+export function isCliOptionKey(key: string): boolean {
+  return VALID_KEYS.includes(key as ConfigKey);
+}
+
+// -- Dispatch: CLI option vs server config --
+
+export async function configGetDispatch(args: string[], deps: ConfigDeps = defaultDeps): Promise<void> {
+  const key = args.find((a) => !a.startsWith("-"));
+  if (!key) {
+    printError("Usage: mcx config get <key|server> [--show-secrets] [--json]");
+    process.exit(1);
+  }
+
+  if (isCliOptionKey(key)) {
+    configGetCliOption(args);
+    return;
+  }
+
+  await configGetServer(args, deps);
+}
+
+export async function configSetDispatch(args: string[], deps: ConfigDeps = defaultDeps): Promise<void> {
+  const [first, second] = args;
+  if (!first) {
+    printError("Usage: mcx config set <key> <value>\n       mcx config set <server> env <KEY>:<VALUE>");
+    process.exit(1);
+  }
+
+  if (second === "env") {
+    await configSetServerEnv(args, deps);
+    return;
+  }
+
+  configSetCliOption(args);
+}
+
+// -- CLI option get/set --
+
+function configSetCliOption(args: string[]): void {
   const [key, value] = args;
   if (!key || value === undefined) {
     printError("Usage: mcx config set <key> <value>");
     process.exit(1);
   }
-  if (!VALID_KEYS.includes(key as ConfigKey)) {
+  if (!isCliOptionKey(key)) {
     printError(`Unknown config key: ${key}. Valid keys: ${VALID_KEYS.join(", ")}`);
     process.exit(1);
   }
@@ -87,17 +144,175 @@ function configSet(args: string[]): void {
   console.log(`${key} = ${config[prop]}`);
 }
 
-function configGet(args: string[]): void {
+function configGetCliOption(args: string[]): void {
   const key = args[0];
   if (!key) {
     printError("Usage: mcx config get <key>");
     process.exit(1);
   }
-  if (!VALID_KEYS.includes(key as ConfigKey)) {
+  if (!isCliOptionKey(key)) {
     printError(`Unknown config key: ${key}. Valid keys: ${VALID_KEYS.join(", ")}`);
     process.exit(1);
   }
   const prop = KEY_MAP[key as ConfigKey];
   const config = readCliConfig();
   console.log(String(config[prop] ?? false));
+}
+
+// -- Server config get/set --
+
+export async function configGetServer(args: string[], deps: ConfigDeps = defaultDeps): Promise<void> {
+  const showSecrets = args.includes("--show-secrets");
+  const json = args.includes("--json") || args.includes("-j");
+  const name = args.find((a) => !a.startsWith("-"));
+
+  if (!name) {
+    printError("Usage: mcx config get <server> [--show-secrets] [--json]");
+    process.exit(1);
+  }
+
+  const result = await deps.getConfig();
+  const serverMeta = result.servers[name];
+  if (!serverMeta) {
+    printError(`Server "${name}" not found`);
+    process.exit(1);
+  }
+
+  const fileConfig = deps.readConfig(serverMeta.source);
+  const serverConfig = fileConfig.mcpServers?.[name];
+
+  if (json) {
+    console.log(
+      JSON.stringify(
+        {
+          name,
+          transport: serverMeta.transport,
+          source: serverMeta.source,
+          scope: serverMeta.scope,
+          config: serverConfig ? maskConfig(serverConfig, showSecrets) : null,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  console.log(`${c.cyan}${name}${c.reset} ${c.dim}(${serverMeta.transport})${c.reset}`);
+
+  if (serverConfig) {
+    printServerConfigDetails(serverConfig, showSecrets);
+  }
+
+  console.log(`  ${c.bold}source${c.reset}: ${serverMeta.source} ${c.dim}(${serverMeta.scope})${c.reset}`);
+}
+
+export function printServerConfigDetails(config: ServerConfig, showSecrets: boolean): void {
+  if (isStdioConfig(config)) {
+    const cmdLine = [config.command, ...(config.args ?? [])].join(" ");
+    console.log(`  ${c.bold}command${c.reset}: ${cmdLine}`);
+    if (config.cwd) {
+      console.log(`  ${c.bold}cwd${c.reset}: ${config.cwd}`);
+    }
+    if (config.env && Object.keys(config.env).length > 0) {
+      console.log(`  ${c.bold}env${c.reset}:`);
+      for (const [k, v] of Object.entries(config.env)) {
+        console.log(`    ${k}: ${showSecrets ? v : maskValue(v)}`);
+      }
+    }
+  } else {
+    console.log(`  ${c.bold}url${c.reset}: ${config.url}`);
+    if (config.headers && Object.keys(config.headers).length > 0) {
+      console.log(`  ${c.bold}headers${c.reset}:`);
+      for (const [k, v] of Object.entries(config.headers)) {
+        console.log(`    ${k}: ${showSecrets ? v : maskValue(v)}`);
+      }
+    }
+  }
+}
+
+/** Parse KEY:VALUE string. Returns null on invalid format. */
+export function parseEnvKeyValue(input: string): { key: string; value: string } | null {
+  const colonIdx = input.indexOf(":");
+  if (colonIdx < 1) return null;
+  return { key: input.slice(0, colonIdx), value: input.slice(colonIdx + 1) };
+}
+
+export async function configSetServerEnv(args: string[], deps: ConfigDeps = defaultDeps): Promise<void> {
+  const serverName = args[0];
+  const keyValue = args[2];
+
+  if (!serverName || !keyValue) {
+    printError("Usage: mcx config set <server> env <KEY>:<VALUE>");
+    process.exit(1);
+  }
+
+  const parsed = parseEnvKeyValue(keyValue);
+  if (!parsed) {
+    printError("Invalid format. Use <KEY>:<VALUE> (e.g. API_KEY:sk-xxx)");
+    process.exit(1);
+  }
+
+  const { key, value } = parsed;
+
+  const result = await deps.getConfig();
+  const serverMeta = result.servers[serverName];
+  if (!serverMeta) {
+    printError(`Server "${serverName}" not found`);
+    process.exit(1);
+  }
+
+  const fileConfig = deps.readConfig(serverMeta.source);
+  const serverConfig = fileConfig.mcpServers?.[serverName];
+  if (!serverConfig) {
+    printError(`Server "${serverName}" not found in ${serverMeta.source}`);
+    process.exit(1);
+  }
+
+  if (!isStdioConfig(serverConfig)) {
+    printError(
+      `Server "${serverName}" uses ${serverConfig.type} transport. Environment variables are only supported for stdio servers.`,
+    );
+    process.exit(1);
+  }
+
+  serverConfig.env = serverConfig.env ?? {};
+  serverConfig.env[key] = value;
+  deps.writeConfig(serverMeta.source, fileConfig);
+
+  console.log(`Set ${key} on ${serverName}`);
+}
+
+// -- Masking --
+
+/**
+ * Mask a sensitive value for display.
+ * Preserves ${VAR} env references as-is (they're not secrets).
+ */
+export function maskValue(value: string): string {
+  if (/^\$\{[^}]+\}$/.test(value)) return value;
+  if (value.length <= 8) return "****";
+  return `${value.slice(0, 4)}****${value.slice(-3)}`;
+}
+
+/** Return a config object with sensitive values masked (for JSON output). */
+export function maskConfig(config: ServerConfig, showSecrets: boolean): ServerConfig {
+  if (showSecrets) return config;
+
+  if (isStdioConfig(config)) {
+    if (!config.env) return config;
+    const maskedEnv: Record<string, string> = {};
+    for (const [k, v] of Object.entries(config.env)) {
+      maskedEnv[k] = maskValue(v);
+    }
+    return { ...config, env: maskedEnv };
+  }
+
+  const httpConfig = config as { headers?: Record<string, string> };
+  if (!httpConfig.headers) return config;
+  const maskedHeaders: Record<string, string> = {};
+  for (const [k, v] of Object.entries(httpConfig.headers)) {
+    maskedHeaders[k] = maskValue(v);
+  }
+  return { ...config, headers: maskedHeaders };
 }

--- a/packages/command/src/index.ts
+++ b/packages/command/src/index.ts
@@ -483,6 +483,8 @@ Usage:
   mcx config sources                  Show config file sources
   mcx config set <key> <value>        Set a CLI option (e.g. trust-claude)
   mcx config get <key>                Get a CLI option value
+  mcx config get <server>             Inspect a server's config (env, args, url)
+  mcx config set <srv> env <K>:<V>    Set an env var on a stdio server
   mcx status                          Daemon status
   mcx mail -s "subject" <recipient>   Send a message (body from stdin)
   mcx mail -H                        List message headers


### PR DESCRIPTION
## Summary
- Add `mcx config get <server> [--show-secrets] [--json]` to display a server's transport, command/args/url, env vars (masked by default), and config source file
- Add `mcx config set <server> env <KEY>:<VALUE>` to update env vars on stdio servers, with automatic daemon reload via existing ConfigWatcher
- Disambiguates between CLI option keys (e.g. `trust-claude`) and server names in the existing `config get/set` subcommands

## Test plan
- [x] 56 tests covering maskValue, maskConfig, parseEnvKeyValue, isCliOptionKey, printServerConfigDetails, configGetServer, configSetServerEnv, cmdConfig dispatch, and error paths
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — 983 tests pass, 0 failures
- [x] Coverage ratchet passes (config.ts at 82.4% line coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)