### PR TITLE
fix(core): preserve error context through IPC serialization (fixes #91)

### DIFF
--- a/packages/command/src/index.ts
+++ b/packages/command/src/index.ts
@@ -15,7 +15,7 @@
  */
 
 import type { AliasDetail, DaemonStatus, ServerStatus, ToolInfo } from "@mcp-cli/core";
-import { VERSION, isDaemonRunning } from "@mcp-cli/core";
+import { IpcCallError, VERSION, isDaemonRunning } from "@mcp-cli/core";
 import { ipcCall } from "@mcp-cli/core";
 import { cmdAdd, cmdAddJson } from "./commands/add";
 import { cmdAlias } from "./commands/alias";
@@ -229,6 +229,10 @@ async function main(): Promise<void> {
     }
   } catch (err) {
     printError(err instanceof Error ? err.message : String(err));
+    if (process.env.MCX_DEBUG === "1" && err instanceof IpcCallError && err.remoteStack) {
+      console.error("\nRemote stack trace:");
+      console.error(err.remoteStack);
+    }
     process.exit(1);
   }
 }

--- a/packages/core/src/ipc-client.spec.ts
+++ b/packages/core/src/ipc-client.spec.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { testOptions } from "../../../test/test-options";
 import { PROTOCOL_VERSION } from "./constants";
-import { isDaemonRunning } from "./ipc-client";
+import { IpcCallError, isDaemonRunning } from "./ipc-client";
 
 /**
  * Tests for ensureDaemon startup lock and stderr handling.
@@ -183,5 +183,36 @@ describe("protocol version mismatch detection", () => {
 
     const result = await isDaemonRunning();
     expect(result).toBe(false);
+  });
+});
+
+describe("IpcCallError", () => {
+  it("preserves code, message, data, and remoteStack", () => {
+    const err = new IpcCallError({
+      code: -1001,
+      message: "Server not found",
+      data: { server: "test" },
+      stack: "Error: Server not found\n    at dispatch (ipc-server.ts:42)",
+    });
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(IpcCallError);
+    expect(err.name).toBe("IpcCallError");
+    expect(err.message).toBe("Server not found");
+    expect(err.code).toBe(-1001);
+    expect(err.data).toEqual({ server: "test" });
+    expect(err.remoteStack).toBe("Error: Server not found\n    at dispatch (ipc-server.ts:42)");
+  });
+
+  it("handles missing optional fields", () => {
+    const err = new IpcCallError({
+      code: -32603,
+      message: "Internal error",
+    });
+
+    expect(err.message).toBe("Internal error");
+    expect(err.code).toBe(-32603);
+    expect(err.data).toBeUndefined();
+    expect(err.remoteStack).toBeUndefined();
   });
 });

--- a/packages/core/src/ipc-client.ts
+++ b/packages/core/src/ipc-client.ts
@@ -19,8 +19,26 @@ import {
   options,
 } from "./constants";
 import { ensureStateDir } from "./fs";
-import type { IpcMethod, IpcRequest, IpcResponse } from "./ipc";
+import type { IpcError, IpcMethod, IpcRequest, IpcResponse } from "./ipc";
 import { nextId } from "./ipc";
+
+/**
+ * Structured error thrown by ipcCall() when the daemon returns an error response.
+ * Preserves the error code, data, and remote stack trace from the daemon.
+ */
+export class IpcCallError extends Error {
+  readonly code: number;
+  readonly data: unknown;
+  readonly remoteStack: string | undefined;
+
+  constructor(err: IpcError) {
+    super(err.message);
+    this.name = "IpcCallError";
+    this.code = err.code;
+    this.data = err.data;
+    this.remoteStack = err.stack;
+  }
+}
 
 /** Base URL for IPC requests over the Unix domain socket. */
 const IPC_RPC_URL = "http://localhost/rpc";
@@ -36,7 +54,7 @@ export async function ipcCall(method: IpcMethod, params?: unknown): Promise<unkn
   const response = await sendRequest(request);
 
   if (response.error) {
-    throw new Error(`[${response.error.code}] ${response.error.message}`);
+    throw new IpcCallError(response.error);
   }
   return response.result;
 }

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -52,6 +52,7 @@ export interface IpcError {
   code: number;
   message: string;
   data?: unknown;
+  stack?: string;
 }
 
 // -- Param types per method --

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -793,4 +793,70 @@ describe("IpcServer HTTP transport", () => {
     const json = (await res.json()) as IpcResponse;
     expect(json.error?.code).toBe(IPC_ERROR.INVALID_PARAMS);
   });
+
+  // -- Error context preservation --
+
+  test("error response includes stack trace from thrown Error", async () => {
+    socketPath = tmpSocket();
+    const failPool = {
+      ...mockPool(),
+      callTool: async () => {
+        throw new Error("tool failed");
+      },
+    };
+    server = new IpcServer(failPool as never, mockConfig(), mockDb(), null, {
+      onActivity: () => {},
+    });
+    server.start(socketPath);
+
+    const res = await rpc("/rpc", { id: "st1", method: "callTool", params: { server: "s", tool: "t", arguments: {} } });
+    const json = (await res.json()) as IpcResponse;
+
+    expect(json.error?.code).toBe(IPC_ERROR.INTERNAL_ERROR);
+    expect(json.error?.message).toBe("tool failed");
+    expect(json.error?.stack).toBeString();
+    expect(json.error?.stack).toContain("tool failed");
+  });
+
+  test("error response includes data when error has data property", async () => {
+    socketPath = tmpSocket();
+    const failPool = {
+      ...mockPool(),
+      callTool: async () => {
+        const err = new Error("enriched failure");
+        (err as unknown as { data: unknown }).data = { detail: "extra context" };
+        throw err;
+      },
+    };
+    server = new IpcServer(failPool as never, mockConfig(), mockDb(), null, {
+      onActivity: () => {},
+    });
+    server.start(socketPath);
+
+    const res = await rpc("/rpc", { id: "st2", method: "callTool", params: { server: "s", tool: "t", arguments: {} } });
+    const json = (await res.json()) as IpcResponse;
+
+    expect(json.error?.message).toBe("enriched failure");
+    expect(json.error?.data).toEqual({ detail: "extra context" });
+  });
+
+  test("error response omits stack for non-Error throws", async () => {
+    socketPath = tmpSocket();
+    const failPool = {
+      ...mockPool(),
+      callTool: async () => {
+        throw "string error";
+      },
+    };
+    server = new IpcServer(failPool as never, mockConfig(), mockDb(), null, {
+      onActivity: () => {},
+    });
+    server.start(socketPath);
+
+    const res = await rpc("/rpc", { id: "st3", method: "callTool", params: { server: "s", tool: "t", arguments: {} } });
+    const json = (await res.json()) as IpcResponse;
+
+    expect(json.error?.message).toBe("string error");
+    expect(json.error?.stack).toBeUndefined();
+  });
 });

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -514,9 +514,12 @@ function toIpcError(err: unknown): IpcError {
   }
   if (err instanceof Error) {
     const code = (err as unknown as { code?: number }).code;
+    const data = (err as unknown as { data?: unknown }).data;
     return {
       code: typeof code === "number" ? code : IPC_ERROR.INTERNAL_ERROR,
       message: err.message,
+      ...(err.stack ? { stack: err.stack } : {}),
+      ...(data !== undefined ? { data } : {}),
     };
   }
   return { code: IPC_ERROR.INTERNAL_ERROR, message: String(err) };


### PR DESCRIPTION
## Summary
- Add optional `stack` field to `IpcError` protocol type and serialize stack traces + error data in the daemon's `toIpcError()`
- Introduce `IpcCallError` class in the IPC client that preserves `code`, `data`, and `remoteStack` instead of flattening to a plain `Error`
- Display remote stack traces in the CLI when `MCX_DEBUG=1` is set

## Test plan
- [x] `IpcCallError` unit tests: preserves all fields, handles missing optionals
- [x] `toIpcError` integration tests: stack trace included for `Error` throws, `data` property forwarded, stack omitted for non-Error throws
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — all 988 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)