### PR TITLE
feat: dynamic tool list updates via `tools/list_changed` notification (fixes #146)

### DIFF
--- a/packages/command/src/commands/serve.spec.ts
+++ b/packages/command/src/commands/serve.spec.ts
@@ -5,10 +5,13 @@ import {
   type CuratedTool,
   FIND_TOOL,
   type IpcCaller,
+  type ToolListNotifier,
   checkRecursionGuard,
+  computeToolsFingerprint,
   handleCallTool,
   handleListTools,
   parseMcpTools,
+  startToolListPoller,
 } from "./serve";
 
 // -- parseMcpTools --
@@ -278,5 +281,131 @@ describe("meta-tool definitions", () => {
   test("CALL_TOOL has expected shape", () => {
     expect(CALL_TOOL.name).toBe("call");
     expect(CALL_TOOL.inputSchema.required).toContain("tool");
+  });
+});
+
+// -- computeToolsFingerprint --
+
+describe("computeToolsFingerprint", () => {
+  test("returns consistent hash for same tool list", async () => {
+    const ipc: IpcCaller = async () => [
+      { name: "search", server: "atlassian", description: "Search" },
+      { name: "echo", server: "test", description: "Echo" },
+    ];
+    const a = await computeToolsFingerprint(ipc);
+    const b = await computeToolsFingerprint(ipc);
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[a-f0-9]{32}$/);
+  });
+
+  test("returns same hash regardless of order", async () => {
+    const ipcA: IpcCaller = async () => [
+      { name: "search", server: "atlassian", description: "Search" },
+      { name: "echo", server: "test", description: "Echo" },
+    ];
+    const ipcB: IpcCaller = async () => [
+      { name: "echo", server: "test", description: "Echo" },
+      { name: "search", server: "atlassian", description: "Search" },
+    ];
+    expect(await computeToolsFingerprint(ipcA)).toBe(await computeToolsFingerprint(ipcB));
+  });
+
+  test("returns different hash when tools change", async () => {
+    const ipcBefore: IpcCaller = async () => [{ name: "search", server: "atlassian", description: "Search" }];
+    const ipcAfter: IpcCaller = async () => [
+      { name: "search", server: "atlassian", description: "Search" },
+      { name: "echo", server: "test", description: "Echo" },
+    ];
+    const before = await computeToolsFingerprint(ipcBefore);
+    const after = await computeToolsFingerprint(ipcAfter);
+    expect(before).not.toBe(after);
+  });
+});
+
+// -- startToolListPoller --
+
+describe("startToolListPoller", () => {
+  test("sends notification when tool list changes", async () => {
+    let callCount = 0;
+    const tools = [
+      [{ name: "search", server: "atlassian", description: "Search" }],
+      [{ name: "search", server: "atlassian", description: "Search" }],
+      [
+        { name: "search", server: "atlassian", description: "Search" },
+        { name: "echo", server: "test", description: "Echo" },
+      ],
+    ];
+    const ipc: IpcCaller = async () => tools[Math.min(callCount++, tools.length - 1)];
+
+    const notifications: string[] = [];
+    const notifier: ToolListNotifier = {
+      notification: async (params) => {
+        notifications.push(params.method);
+      },
+    };
+
+    const stop = startToolListPoller(notifier, ipc, 20);
+    // Wait for 3 poll cycles
+    await new Promise((r) => setTimeout(r, 80));
+    stop();
+
+    expect(notifications).toEqual(["notifications/tools/list_changed"]);
+  });
+
+  test("does not notify when tool list is unchanged", async () => {
+    const ipc: IpcCaller = async () => [{ name: "search", server: "atlassian", description: "Search" }];
+
+    const notifications: string[] = [];
+    const notifier: ToolListNotifier = {
+      notification: async (params) => {
+        notifications.push(params.method);
+      },
+    };
+
+    const stop = startToolListPoller(notifier, ipc, 20);
+    await new Promise((r) => setTimeout(r, 80));
+    stop();
+
+    expect(notifications).toEqual([]);
+  });
+
+  test("handles IPC errors gracefully without crashing", async () => {
+    let callCount = 0;
+    const ipc: IpcCaller = async () => {
+      callCount++;
+      if (callCount === 2) throw new Error("daemon unreachable");
+      return [{ name: "search", server: "atlassian", description: "Search" }];
+    };
+
+    const notifier: ToolListNotifier = {
+      notification: async () => {},
+    };
+
+    const stop = startToolListPoller(notifier, ipc, 20);
+    await new Promise((r) => setTimeout(r, 80));
+    stop();
+
+    // Should have made multiple calls despite the error
+    expect(callCount).toBeGreaterThanOrEqual(3);
+  });
+
+  test("cleanup function stops polling", async () => {
+    let callCount = 0;
+    const ipc: IpcCaller = async () => {
+      callCount++;
+      return [];
+    };
+
+    const notifier: ToolListNotifier = {
+      notification: async () => {},
+    };
+
+    const stop = startToolListPoller(notifier, ipc, 20);
+    await new Promise((r) => setTimeout(r, 50));
+    stop();
+    const countAtStop = callCount;
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(callCount).toBe(countAtStop);
   });
 });

--- a/packages/command/src/commands/serve.ts
+++ b/packages/command/src/commands/serve.ts
@@ -122,6 +122,61 @@ export function checkRecursionGuard(): boolean {
   return process.env[MCX_SERVE_GUARD] === "1";
 }
 
+// -- Tool list change detection --
+
+const POLL_INTERVAL_MS = 5_000;
+
+/**
+ * Compute a fingerprint of the current tool list from the daemon.
+ * Uses sorted server/name pairs so the result is order-independent.
+ */
+export async function computeToolsFingerprint(ipc: IpcCaller): Promise<string> {
+  const tools = (await ipc("listTools")) as ToolInfo[];
+  const key = tools
+    .map((t) => `${t.server}/${t.name}`)
+    .sort()
+    .join("\n");
+  const hash = new Bun.CryptoHasher("md5");
+  hash.update(key);
+  return hash.digest("hex");
+}
+
+/** Notifier interface for sending MCP notifications (matches MCP SDK Server). */
+export interface ToolListNotifier {
+  notification(params: { method: string }): Promise<void>;
+}
+
+/**
+ * Poll the daemon for tool list changes and send `tools/list_changed` notification.
+ * Returns a cleanup function that stops the polling.
+ */
+export function startToolListPoller(
+  notifier: ToolListNotifier,
+  ipc: IpcCaller,
+  intervalMs = POLL_INTERVAL_MS,
+): () => void {
+  let previousFingerprint: string | undefined;
+
+  const timer = setInterval(async () => {
+    try {
+      const fingerprint = await computeToolsFingerprint(ipc);
+      if (previousFingerprint === undefined) {
+        previousFingerprint = fingerprint;
+        return;
+      }
+      if (fingerprint !== previousFingerprint) {
+        previousFingerprint = fingerprint;
+        console.error("[mcx serve] Tool list changed, notifying client");
+        await notifier.notification({ method: "notifications/tools/list_changed" });
+      }
+    } catch (err) {
+      console.error(`[mcx serve] Tool list poll failed: ${err}`);
+    }
+  }, intervalMs);
+
+  return () => clearInterval(timer);
+}
+
 // -- Handler logic (extracted for testability) --
 
 export async function handleListTools(
@@ -223,7 +278,10 @@ export async function cmdServe(): Promise<void> {
   const { ipcCall } = await import("@mcp-cli/core");
   const curated = parseMcpTools(process.env.MCP_TOOLS);
 
-  const server = new Server({ name: "mcx-serve", version: "1.0.0" }, { capabilities: { tools: {} } });
+  const server = new Server(
+    { name: "mcx-serve", version: "1.0.0" },
+    { capabilities: { tools: { listChanged: true } } },
+  );
 
   server.setRequestHandler(ListToolsRequestSchema, () => handleListTools(curated, ipcCall));
 
@@ -234,5 +292,6 @@ export async function cmdServe(): Promise<void> {
 
   const transport = new StdioServerTransport();
   await server.connect(transport);
+  startToolListPoller(server, ipcCall);
   console.error("[mcx serve] MCP server running on stdio");
 }


### PR DESCRIPTION
## Summary
- Poll the daemon's `listTools` endpoint every 5s from `mcx serve`, fingerprinting tool names to detect changes
- Send MCP `notifications/tools/list_changed` when the tool list changes, so connected clients (e.g. Claude Code) automatically re-fetch tools
- Advertise `listChanged: true` in server capabilities per MCP spec

## Test plan
- [x] `computeToolsFingerprint` returns consistent hashes, is order-independent, and detects changes
- [x] `startToolListPoller` sends notification on change, stays silent when unchanged, handles IPC errors gracefully, and cleanup stops polling
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (1040 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)