### PR TITLE
feat(daemon): Claude session state machine (fixes #173)

### DIFF
--- a/packages/daemon/src/claude-session/session-state.spec.ts
+++ b/packages/daemon/src/claude-session/session-state.spec.ts
@@ -103,7 +103,6 @@ function activeSession(): SessionState {
 // ── Tests ──
 
 describe("SessionState", () => {
-
   // -- Construction --
 
   test("starts in connecting state", () => {

--- a/packages/daemon/src/claude-session/session-state.ts
+++ b/packages/daemon/src/claude-session/session-state.ts
@@ -179,7 +179,15 @@ export class SessionState {
       this.numTurns += r.num_turns;
       this.tokens += resultTokens;
       this.state = "idle";
-      return [{ type: "session:result", cost: r.total_cost_usd, tokens: resultTokens, numTurns: r.num_turns, result: r.result }];
+      return [
+        {
+          type: "session:result",
+          cost: r.total_cost_usd,
+          tokens: resultTokens,
+          numTurns: r.num_turns,
+          result: r.result,
+        },
+      ];
     }
 
     const errorResult = ResultError.safeParse(msg);


### PR DESCRIPTION
## Summary
- Adds `SessionState` class in `packages/daemon/src/claude-session/session-state.ts` — a state machine that processes inbound NDJSON messages from Claude Code CLI sessions
- States: `connecting → init → active → waiting_permission → result → idle → ended`
- Tracks session metadata: model, cwd, cumulative cost/tokens/turns, pending permission requests
- Emits typed `SessionEvent` discriminated union for observers (init, response, permission_request, result, error, ended)
- Provides action methods: `queuePrompt()`, `respondToPermission()`, `interrupt()`, `end()`

## Test plan
- 29 tests covering:
  - Full lifecycle (init → prompt → response → permission → approve → result → idle → end)
  - Permission flow (approve, deny, multiple concurrent, unknown request id)
  - Cost/token accumulation across turns
  - Invalid state transitions throw (prompt during waiting_permission, prompt on ended)
  - Ignored message types (keep_alive, stream_event, tool_progress, system/status, etc.)
  - Interrupt and end behavior (idempotent end, clears pending permissions)
- 100% function and line coverage on session-state.ts
- Full suite: 1129 tests pass, typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)