### PR TITLE
feat(command): `mcx claude` spawn/ls/send/kill/log commands (fixes #176)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -1,0 +1,532 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { ClaudeDeps } from "./claude";
+import { cmdClaude, parseLogArgs, parseSpawnArgs, resolveSessionId } from "./claude";
+
+// ── Helpers ──
+
+class ExitError extends Error {
+  constructor(public code: number) {
+    super(`process.exit(${code})`);
+  }
+}
+
+function makeDeps(overrides?: Partial<ClaudeDeps>): ClaudeDeps {
+  return {
+    callTool: mock(async () => ({ content: [{ type: "text", text: "[]" }] })),
+    printError: mock(() => {}),
+    exit: mock((code: number) => {
+      throw new ExitError(code);
+    }) as ClaudeDeps["exit"],
+    ...overrides,
+  };
+}
+
+function toolResult(data: unknown): { content: Array<{ type: "text"; text: string }> } {
+  return { content: [{ type: "text", text: JSON.stringify(data) }] };
+}
+
+const SESSION_LIST = [
+  {
+    sessionId: "abc12345-1111-2222-3333-444444444444",
+    state: "active",
+    model: "opus-4",
+    cwd: "/tmp",
+    cost: 0.05,
+    tokens: 1000,
+    numTurns: 3,
+    pendingPermissions: 0,
+  },
+  {
+    sessionId: "def67890-aaaa-bbbb-cccc-dddddddddddd",
+    state: "idle",
+    model: "sonnet-4",
+    cwd: "/home",
+    cost: 0.02,
+    tokens: 500,
+    numTurns: 1,
+    pendingPermissions: 0,
+  },
+];
+
+// ── parseSpawnArgs ──
+
+describe("parseSpawnArgs", () => {
+  test("parses --task flag", () => {
+    const result = parseSpawnArgs(["--task", "fix bug"]);
+    expect(result.task).toBe("fix bug");
+    expect(result.error).toBeUndefined();
+  });
+
+  test("parses -t shorthand", () => {
+    const result = parseSpawnArgs(["-t", "fix bug"]);
+    expect(result.task).toBe("fix bug");
+  });
+
+  test("parses positional task", () => {
+    const result = parseSpawnArgs(["fix the tests"]);
+    expect(result.task).toBe("fix the tests");
+  });
+
+  test("--task takes precedence over positional", () => {
+    const result = parseSpawnArgs(["--task", "from flag", "positional"]);
+    expect(result.task).toBe("from flag");
+  });
+
+  test("parses --worktree with name", () => {
+    const result = parseSpawnArgs(["--worktree", "my-feature", "--task", "x"]);
+    expect(result.worktree).toBe("my-feature");
+  });
+
+  test("parses --worktree without name (auto-generates)", () => {
+    const result = parseSpawnArgs(["--worktree", "--task", "x"]);
+    expect(result.worktree).toBeDefined();
+    expect(result.worktree).toStartWith("claude-");
+  });
+
+  test("parses -w shorthand", () => {
+    const result = parseSpawnArgs(["-w", "feat", "-t", "x"]);
+    expect(result.worktree).toBe("feat");
+  });
+
+  test("parses --resume", () => {
+    const result = parseSpawnArgs(["--resume", "abc123", "--task", "continue"]);
+    expect(result.resume).toBe("abc123");
+  });
+
+  test("parses --allow with multiple tools", () => {
+    const result = parseSpawnArgs(["--allow", "Read", "Glob", "Grep", "--task", "x"]);
+    expect(result.allow).toEqual(["Read", "Glob", "Grep"]);
+  });
+
+  test("parses --cwd", () => {
+    const result = parseSpawnArgs(["--cwd", "/tmp/work", "--task", "x"]);
+    expect(result.cwd).toBe("/tmp/work");
+  });
+
+  test("parses --timeout", () => {
+    const result = parseSpawnArgs(["--timeout", "60000", "--task", "x"]);
+    expect(result.timeout).toBe(60000);
+  });
+
+  test("errors on missing --task value", () => {
+    const result = parseSpawnArgs(["--task"]);
+    expect(result.error).toBe("--task requires a value");
+  });
+
+  test("errors on missing --resume value", () => {
+    const result = parseSpawnArgs(["--resume"]);
+    expect(result.error).toBe("--resume requires a session ID");
+  });
+
+  test("errors on non-numeric --timeout", () => {
+    const result = parseSpawnArgs(["--timeout", "abc"]);
+    expect(result.error).toBe("--timeout must be a number");
+  });
+
+  test("errors on empty --allow", () => {
+    const result = parseSpawnArgs(["--allow", "--task", "x"]);
+    expect(result.allow).toEqual([]);
+    // --allow stops collecting when it hits --task (a flag), so allow is empty
+    expect(result.error).toBe("--allow requires at least one tool pattern");
+  });
+});
+
+// ── parseLogArgs ──
+
+describe("parseLogArgs", () => {
+  test("parses session prefix and default last", () => {
+    const result = parseLogArgs(["abc123"]);
+    expect(result.sessionPrefix).toBe("abc123");
+    expect(result.last).toBe(20);
+  });
+
+  test("parses --last flag", () => {
+    const result = parseLogArgs(["abc123", "--last", "50"]);
+    expect(result.last).toBe(50);
+  });
+
+  test("parses -n shorthand", () => {
+    const result = parseLogArgs(["abc123", "-n", "10"]);
+    expect(result.last).toBe(10);
+  });
+
+  test("errors on non-numeric --last", () => {
+    const result = parseLogArgs(["abc123", "--last", "abc"]);
+    expect(result.error).toBe("--last must be a number");
+  });
+});
+
+// ── resolveSessionId ──
+
+describe("resolveSessionId", () => {
+  test("resolves exact match", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(SESSION_LIST)),
+    });
+    const id = await resolveSessionId("abc12345-1111-2222-3333-444444444444", deps);
+    expect(id).toBe("abc12345-1111-2222-3333-444444444444");
+  });
+
+  test("resolves prefix match", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(SESSION_LIST)),
+    });
+    const id = await resolveSessionId("abc", deps);
+    expect(id).toBe("abc12345-1111-2222-3333-444444444444");
+  });
+
+  test("resolves short prefix", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(SESSION_LIST)),
+    });
+    const id = await resolveSessionId("def", deps);
+    expect(id).toBe("def67890-aaaa-bbbb-cccc-dddddddddddd");
+  });
+
+  test("errors on no match", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(SESSION_LIST)),
+    });
+    await expect(resolveSessionId("zzz", deps)).rejects.toThrow(ExitError);
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining('No session matching "zzz"'));
+  });
+
+  test("errors on ambiguous match", async () => {
+    const sessions = [
+      {
+        sessionId: "abc11111",
+        state: "active",
+        model: null,
+        cwd: null,
+        cost: 0,
+        tokens: 0,
+        numTurns: 0,
+        pendingPermissions: 0,
+      },
+      {
+        sessionId: "abc22222",
+        state: "active",
+        model: null,
+        cwd: null,
+        cost: 0,
+        tokens: 0,
+        numTurns: 0,
+        pendingPermissions: 0,
+      },
+    ];
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(sessions)),
+    });
+    await expect(resolveSessionId("abc", deps)).rejects.toThrow(ExitError);
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("Ambiguous"));
+  });
+});
+
+// ── cmdClaude dispatch ──
+
+describe("cmdClaude", () => {
+  test("shows usage with no args", async () => {
+    const logSpy = mock(() => {});
+    const origLog = console.log;
+    console.log = logSpy;
+    try {
+      await cmdClaude([]);
+      expect(logSpy).toHaveBeenCalled();
+      const output = (logSpy.mock.calls[0] as string[])[0];
+      expect(output).toContain("mcx claude");
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("shows usage with --help", async () => {
+    const logSpy = mock(() => {});
+    const origLog = console.log;
+    console.log = logSpy;
+    try {
+      await cmdClaude(["--help"]);
+      expect(logSpy).toHaveBeenCalled();
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("errors on unknown subcommand", async () => {
+    const deps = makeDeps();
+    await expect(cmdClaude(["unknown"], deps)).rejects.toThrow(ExitError);
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("Unknown claude subcommand"));
+  });
+});
+
+// ── spawn ──
+
+describe("mcx claude spawn", () => {
+  test("calls claude_prompt with task", async () => {
+    const callTool = mock(async () => toolResult({ sessionId: "abc", success: true, cost: 0.01 }));
+    const deps = makeDeps({ callTool });
+
+    const logSpy = mock(() => {});
+    const origLog = console.log;
+    console.log = logSpy;
+    try {
+      await cmdClaude(["spawn", "--task", "fix the bug"], deps);
+      expect(callTool).toHaveBeenCalledWith("claude_prompt", { prompt: "fix the bug" });
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("passes worktree and allowedTools", async () => {
+    const callTool = mock(async () => toolResult({ success: true }));
+    const deps = makeDeps({ callTool });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["spawn", "--task", "x", "--worktree", "feat", "--allow", "Read", "Glob"], deps);
+      expect(callTool).toHaveBeenCalledWith("claude_prompt", {
+        prompt: "x",
+        worktree: "feat",
+        allowedTools: ["Read", "Glob"],
+      });
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("passes resume as sessionId", async () => {
+    const callTool = mock(async () => toolResult({ success: true }));
+    const deps = makeDeps({ callTool });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["spawn", "--resume", "abc123", "--task", "continue"], deps);
+      expect(callTool).toHaveBeenCalledWith("claude_prompt", {
+        prompt: "continue",
+        sessionId: "abc123",
+      });
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("uses default prompt when --resume without --task", async () => {
+    const callTool = mock(async () => toolResult({ success: true }));
+    const deps = makeDeps({ callTool });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["spawn", "--resume", "abc123"], deps);
+      expect(callTool).toHaveBeenCalledWith("claude_prompt", {
+        prompt: "Continue from where you left off.",
+        sessionId: "abc123",
+      });
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("errors when no task and no resume", async () => {
+    const deps = makeDeps();
+    await expect(cmdClaude(["spawn"], deps)).rejects.toThrow(ExitError);
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("Usage"));
+  });
+});
+
+// ── ls ──
+
+describe("mcx claude ls", () => {
+  test("outputs table for sessions", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(SESSION_LIST)),
+    });
+
+    const logSpy = mock(() => {});
+    const origLog = console.log;
+    console.log = logSpy;
+    try {
+      await cmdClaude(["ls"], deps);
+      expect(deps.callTool).toHaveBeenCalledWith("claude_session_list", {});
+      // Should have header + 2 session rows
+      expect(logSpy.mock.calls.length).toBe(3);
+      const header = (logSpy.mock.calls[0] as string[])[0];
+      expect(header).toContain("SESSION");
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("outputs JSON with -j flag", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(SESSION_LIST)),
+    });
+
+    const logSpy = mock(() => {});
+    const origLog = console.log;
+    console.log = logSpy;
+    try {
+      await cmdClaude(["ls", "-j"], deps);
+      const output = (logSpy.mock.calls[0] as string[])[0];
+      const parsed = JSON.parse(output);
+      expect(parsed).toHaveLength(2);
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("shows message when no sessions", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult([])),
+    });
+
+    const errSpy = mock(() => {});
+    const origErr = console.error;
+    console.error = errSpy;
+    try {
+      await cmdClaude(["ls"], deps);
+      expect(errSpy).toHaveBeenCalledWith("No active sessions.");
+    } finally {
+      console.error = origErr;
+    }
+  });
+
+  test("accepts 'list' alias", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult([])),
+    });
+    const origErr = console.error;
+    console.error = mock(() => {});
+    try {
+      await cmdClaude(["list"], deps);
+      expect(deps.callTool).toHaveBeenCalledWith("claude_session_list", {});
+    } finally {
+      console.error = origErr;
+    }
+  });
+});
+
+// ── send ──
+
+describe("mcx claude send", () => {
+  test("sends prompt to resolved session", async () => {
+    const callTool: ClaudeDeps["callTool"] = mock(async (tool: string) => {
+      if (tool === "claude_session_list") return toolResult(SESSION_LIST);
+      return toolResult({ success: true });
+    });
+    const deps = makeDeps({ callTool });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["send", "abc", "fix the tests please"], deps);
+      // First call: list sessions for resolution
+      expect(callTool).toHaveBeenCalledWith("claude_session_list", {});
+      // Second call: send prompt
+      expect(callTool).toHaveBeenCalledWith("claude_prompt", {
+        sessionId: "abc12345-1111-2222-3333-444444444444",
+        prompt: "fix the tests please",
+      });
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("errors when no session or message", async () => {
+    const deps = makeDeps();
+    await expect(cmdClaude(["send"], deps)).rejects.toThrow(ExitError);
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("Usage"));
+  });
+
+  test("errors when no message", async () => {
+    const deps = makeDeps();
+    await expect(cmdClaude(["send", "abc"], deps)).rejects.toThrow(ExitError);
+  });
+});
+
+// ── kill ──
+
+describe("mcx claude kill", () => {
+  test("interrupts resolved session", async () => {
+    const callTool: ClaudeDeps["callTool"] = mock(async (tool: string) => {
+      if (tool === "claude_session_list") return toolResult(SESSION_LIST);
+      return toolResult({ interrupted: true });
+    });
+    const deps = makeDeps({ callTool });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["kill", "def"], deps);
+      expect(callTool).toHaveBeenCalledWith("claude_interrupt", {
+        sessionId: "def67890-aaaa-bbbb-cccc-dddddddddddd",
+      });
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("errors when no session specified", async () => {
+    const deps = makeDeps();
+    await expect(cmdClaude(["kill"], deps)).rejects.toThrow(ExitError);
+  });
+});
+
+// ── log ──
+
+describe("mcx claude log", () => {
+  test("fetches transcript with default limit", async () => {
+    const transcript = [
+      {
+        timestamp: 1700000000000,
+        direction: "outbound",
+        message: { type: "user", message: { role: "user", content: "hello" } },
+      },
+      {
+        timestamp: 1700000001000,
+        direction: "inbound",
+        message: { type: "assistant", message: { role: "assistant", content: "hi there" } },
+      },
+    ];
+    const callTool: ClaudeDeps["callTool"] = mock(async (tool: string) => {
+      if (tool === "claude_session_list") return toolResult(SESSION_LIST);
+      return toolResult(transcript);
+    });
+    const deps = makeDeps({ callTool });
+
+    const logSpy = mock(() => {});
+    const origLog = console.log;
+    console.log = logSpy;
+    try {
+      await cmdClaude(["log", "abc"], deps);
+      expect(callTool).toHaveBeenCalledWith("claude_transcript", {
+        sessionId: "abc12345-1111-2222-3333-444444444444",
+        limit: 20,
+      });
+      // Should output formatted entries
+      expect(logSpy.mock.calls.length).toBeGreaterThanOrEqual(2);
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("passes custom --last value", async () => {
+    const callTool: ClaudeDeps["callTool"] = mock(async (tool: string) => {
+      if (tool === "claude_session_list") return toolResult(SESSION_LIST);
+      return toolResult([]);
+    });
+    const deps = makeDeps({ callTool });
+
+    await cmdClaude(["log", "abc", "--last", "5"], deps);
+    expect(callTool).toHaveBeenCalledWith("claude_transcript", {
+      sessionId: "abc12345-1111-2222-3333-444444444444",
+      limit: 5,
+    });
+  });
+
+  test("errors when no session specified", async () => {
+    const deps = makeDeps();
+    await expect(cmdClaude(["log"], deps)).rejects.toThrow(ExitError);
+  });
+});

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -1,0 +1,376 @@
+/**
+ * `mcx claude` commands — manage Claude Code sessions via the _claude virtual server.
+ *
+ * All commands route through `callTool` on the `_claude` virtual server.
+ * No dedicated IPC methods — the same tools work from any MCP client.
+ */
+
+import { ipcCall } from "@mcp-cli/core";
+import { c, printError as defaultPrintError, formatToolResult } from "../output";
+import { extractJsonFlag } from "../parse";
+
+// ── Types ──
+
+interface SessionInfo {
+  sessionId: string;
+  state: string;
+  model: string | null;
+  cwd: string | null;
+  cost: number;
+  tokens: number;
+  numTurns: number;
+  pendingPermissions: number;
+}
+
+// ── Dependency injection ──
+
+export interface ClaudeDeps {
+  callTool: (tool: string, args: Record<string, unknown>) => Promise<unknown>;
+  printError: (msg: string) => void;
+  exit: (code: number) => never;
+}
+
+const defaultDeps: ClaudeDeps = {
+  callTool: (tool, args) => ipcCall("callTool", { server: "_claude", tool, arguments: args }),
+  printError: defaultPrintError,
+  exit: (code) => process.exit(code),
+};
+
+// ── Entry point ──
+
+export async function cmdClaude(args: string[], deps?: Partial<ClaudeDeps>): Promise<void> {
+  const d: ClaudeDeps = { ...defaultDeps, ...deps };
+  const sub = args[0];
+
+  if (!sub || sub === "--help" || sub === "-h") {
+    printClaudeUsage();
+    return;
+  }
+
+  switch (sub) {
+    case "spawn":
+      await claudeSpawn(args.slice(1), d);
+      break;
+    case "ls":
+    case "list":
+      await claudeList(args.slice(1), d);
+      break;
+    case "send":
+      await claudeSend(args.slice(1), d);
+      break;
+    case "kill":
+      await claudeKill(args.slice(1), d);
+      break;
+    case "log":
+      await claudeLog(args.slice(1), d);
+      break;
+    default:
+      d.printError(`Unknown claude subcommand: ${sub}. Use "spawn", "ls", "send", "kill", or "log".`);
+      d.exit(1);
+  }
+}
+
+// ── Subcommands ──
+
+export interface SpawnArgs {
+  task: string | undefined;
+  worktree: string | undefined;
+  resume: string | undefined;
+  allow: string[];
+  cwd: string | undefined;
+  timeout: number | undefined;
+  error: string | undefined;
+}
+
+export function parseSpawnArgs(args: string[]): SpawnArgs {
+  let task: string | undefined;
+  let worktree: string | undefined;
+  let resume: string | undefined;
+  let cwd: string | undefined;
+  let timeout: number | undefined;
+  const allow: string[] = [];
+  let error: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--task" || arg === "-t") {
+      task = args[++i];
+      if (!task) error = "--task requires a value";
+    } else if (arg === "--worktree" || arg === "-w") {
+      const next = args[i + 1];
+      if (next && !next.startsWith("-")) {
+        worktree = next;
+        i++;
+      } else {
+        // Auto-generate worktree name
+        worktree = `claude-${Date.now().toString(36)}`;
+      }
+    } else if (arg === "--resume") {
+      resume = args[++i];
+      if (!resume) error = "--resume requires a session ID";
+    } else if (arg === "--allow") {
+      // Collect all following non-flag args as tool patterns
+      while (i + 1 < args.length && !args[i + 1].startsWith("-")) {
+        allow.push(args[++i]);
+      }
+      if (allow.length === 0) error = "--allow requires at least one tool pattern";
+    } else if (arg === "--cwd") {
+      cwd = args[++i];
+      if (!cwd) error = "--cwd requires a path";
+    } else if (arg === "--timeout") {
+      const val = args[++i];
+      if (!val) {
+        error = "--timeout requires a value in ms";
+      } else {
+        timeout = Number(val);
+        if (Number.isNaN(timeout)) error = "--timeout must be a number";
+      }
+    } else if (!arg.startsWith("-")) {
+      // Positional arg treated as task if no --task provided
+      if (!task) task = arg;
+    }
+  }
+
+  return { task, worktree, resume, allow, cwd, timeout, error };
+}
+
+async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
+  const parsed = parseSpawnArgs(args);
+
+  if (parsed.error) {
+    d.printError(parsed.error);
+    d.exit(1);
+  }
+
+  if (!parsed.task && !parsed.resume) {
+    d.printError('Usage: mcx claude spawn --task "description" [--worktree [name]] [--allow tools...]');
+    d.exit(1);
+  }
+
+  const toolArgs: Record<string, unknown> = {
+    prompt: parsed.task ?? "Continue from where you left off.",
+  };
+  if (parsed.resume) toolArgs.sessionId = parsed.resume;
+  if (parsed.worktree) toolArgs.worktree = parsed.worktree;
+  if (parsed.allow.length > 0) toolArgs.allowedTools = parsed.allow;
+  if (parsed.cwd) toolArgs.cwd = parsed.cwd;
+  if (parsed.timeout) toolArgs.timeout = parsed.timeout;
+
+  const result = await d.callTool("claude_prompt", toolArgs);
+  console.log(formatToolResult(result));
+}
+
+async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
+  const { json } = extractJsonFlag(args);
+  const result = await d.callTool("claude_session_list", {});
+  const text = formatToolResult(result);
+
+  if (json) {
+    console.log(text);
+    return;
+  }
+
+  let sessions: SessionInfo[];
+  try {
+    sessions = JSON.parse(text);
+  } catch {
+    console.log(text);
+    return;
+  }
+
+  if (sessions.length === 0) {
+    console.error("No active sessions.");
+    return;
+  }
+
+  // Table output
+  const header = `${"SESSION".padEnd(10)} ${"STATE".padEnd(12)} ${"MODEL".padEnd(16)} ${"COST".padEnd(8)} ${"TOKENS".padEnd(10)} CWD`;
+  console.log(`${c.dim}${header}${c.reset}`);
+
+  for (const s of sessions) {
+    const id = s.sessionId.slice(0, 8);
+    const state = colorState(s.state);
+    const model = (s.model ?? "—").padEnd(16);
+    const cost = s.cost > 0 ? `$${s.cost.toFixed(4)}`.padEnd(8) : "—".padEnd(8);
+    const tokens = s.tokens > 0 ? String(s.tokens).padEnd(10) : "—".padEnd(10);
+    const cwd = s.cwd ?? "—";
+    console.log(`${c.cyan}${id}${c.reset}   ${state} ${model} ${cost} ${tokens} ${c.dim}${cwd}${c.reset}`);
+  }
+}
+
+async function claudeSend(args: string[], d: ClaudeDeps): Promise<void> {
+  const sessionPrefix = args[0];
+  const message = args.slice(1).join(" ").trim();
+
+  if (!sessionPrefix || !message) {
+    d.printError("Usage: mcx claude send <session-id> <message>");
+    d.exit(1);
+  }
+
+  const sessionId = await resolveSessionId(sessionPrefix, d);
+  const result = await d.callTool("claude_prompt", { sessionId, prompt: message });
+  console.log(formatToolResult(result));
+}
+
+async function claudeKill(args: string[], d: ClaudeDeps): Promise<void> {
+  const sessionPrefix = args[0];
+
+  if (!sessionPrefix) {
+    d.printError("Usage: mcx claude kill <session-id>");
+    d.exit(1);
+  }
+
+  const sessionId = await resolveSessionId(sessionPrefix, d);
+  const result = await d.callTool("claude_interrupt", { sessionId });
+  console.log(formatToolResult(result));
+}
+
+export interface LogArgs {
+  sessionPrefix: string | undefined;
+  last: number;
+  error: string | undefined;
+}
+
+export function parseLogArgs(args: string[]): LogArgs {
+  let sessionPrefix: string | undefined;
+  let last = 20;
+  let error: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--last" || arg === "-n") {
+      const val = args[++i];
+      if (!val) {
+        error = "--last requires a number";
+      } else {
+        last = Number(val);
+        if (Number.isNaN(last)) error = "--last must be a number";
+      }
+    } else if (!arg.startsWith("-")) {
+      sessionPrefix = arg;
+    }
+  }
+
+  return { sessionPrefix, last, error };
+}
+
+async function claudeLog(args: string[], d: ClaudeDeps): Promise<void> {
+  const parsed = parseLogArgs(args);
+
+  if (parsed.error) {
+    d.printError(parsed.error);
+    d.exit(1);
+  }
+
+  if (!parsed.sessionPrefix) {
+    d.printError("Usage: mcx claude log <session-id> [--last N]");
+    d.exit(1);
+  }
+
+  const sessionId = await resolveSessionId(parsed.sessionPrefix, d);
+  const result = await d.callTool("claude_transcript", { sessionId, limit: parsed.last });
+  const text = formatToolResult(result);
+
+  let entries: Array<{ timestamp: number; direction: string; message: { type: string; [k: string]: unknown } }>;
+  try {
+    entries = JSON.parse(text);
+  } catch {
+    console.log(text);
+    return;
+  }
+
+  for (const entry of entries) {
+    const time = new Date(entry.timestamp).toLocaleTimeString();
+    const dir = entry.direction === "outbound" ? `${c.green}→${c.reset}` : `${c.cyan}←${c.reset}`;
+    const type = entry.message.type ?? "unknown";
+    console.log(`${c.dim}${time}${c.reset} ${dir} ${c.bold}${type}${c.reset}`);
+
+    // Show content for user/assistant messages
+    if (type === "user" && entry.message.message) {
+      const msg = entry.message.message as { content?: string };
+      if (msg.content) {
+        console.log(`  ${msg.content}`);
+      }
+    } else if (type === "assistant" && entry.message.message) {
+      const msg = entry.message.message as { content?: string };
+      if (msg.content) {
+        const preview = msg.content.length > 200 ? `${msg.content.slice(0, 200)}…` : msg.content;
+        console.log(`  ${preview}`);
+      }
+    } else if (type === "result") {
+      const res = entry.message as { result?: string };
+      if (res.result) {
+        const preview = res.result.length > 200 ? `${res.result.slice(0, 200)}…` : res.result;
+        console.log(`  ${c.dim}${preview}${c.reset}`);
+      }
+    }
+  }
+}
+
+// ── Helpers ──
+
+export async function resolveSessionId(prefix: string, d: ClaudeDeps): Promise<string> {
+  const result = await d.callTool("claude_session_list", {});
+  const text = formatToolResult(result);
+  let sessions: SessionInfo[];
+  try {
+    sessions = JSON.parse(text);
+  } catch {
+    throw new Error("Failed to parse session list");
+  }
+
+  const matches = sessions.filter((s) => s.sessionId.startsWith(prefix));
+
+  if (matches.length === 0) {
+    d.printError(`No session matching "${prefix}"`);
+    d.exit(1);
+  }
+
+  if (matches.length > 1) {
+    d.printError(`Ambiguous session prefix "${prefix}" — matches ${matches.length} sessions`);
+    d.exit(1);
+  }
+
+  return matches[0].sessionId;
+}
+
+function colorState(state: string): string {
+  const padded = state.padEnd(12);
+  switch (state) {
+    case "active":
+      return `${c.green}${padded}${c.reset}`;
+    case "connecting":
+    case "init":
+      return `${c.yellow}${padded}${c.reset}`;
+    case "waiting_permission":
+      return `${c.red}${padded}${c.reset}`;
+    case "ended":
+      return `${c.dim}${padded}${c.reset}`;
+    default:
+      return padded;
+  }
+}
+
+// ── Usage ──
+
+function printClaudeUsage(): void {
+  console.log(`mcx claude — manage Claude Code sessions
+
+Usage:
+  mcx claude spawn --task "description"    Start a new Claude session
+  mcx claude spawn "description"           Shorthand (positional task)
+  mcx claude ls                            List active sessions
+  mcx claude send <session> <message>      Send follow-up prompt
+  mcx claude kill <session>                Interrupt a session
+  mcx claude log <session> [--last N]      View session transcript
+
+Spawn options:
+  --task, -t "description"    Task prompt for Claude
+  --worktree, -w [name]       Git worktree isolation (auto-generates name if omitted)
+  --resume <id>               Resume a previous session
+  --allow <tools...>          Pre-approved tool patterns (e.g. Read Glob "Bash(git *)")
+  --cwd <path>                Working directory for Claude
+  --timeout <ms>              Max wait time (default: 300000)
+
+Session IDs support prefix matching (like git SHAs).`);
+}

--- a/packages/command/src/index.ts
+++ b/packages/command/src/index.ts
@@ -19,6 +19,7 @@ import { IpcCallError, VERSION, isDaemonRunning } from "@mcp-cli/core";
 import { ipcCall } from "@mcp-cli/core";
 import { cmdAdd, cmdAddJson } from "./commands/add";
 import { cmdAlias } from "./commands/alias";
+import { cmdClaude } from "./commands/claude";
 import { cmdCompletions } from "./commands/completions";
 import { cmdConfig } from "./commands/config";
 import { cmdExport } from "./commands/export";
@@ -186,6 +187,10 @@ async function main(): Promise<void> {
 
       case "tty":
         await cmdTty(args.slice(1));
+        break;
+
+      case "claude":
+        await cmdClaude(args.slice(1));
         break;
 
       case "serve":
@@ -506,6 +511,11 @@ Usage:
   mcx tty open <command>               Open command in new terminal tab
   mcx tty open --window <command>      Open command in new terminal window
   mcx tty open --headless <command>    Run command as background process
+  mcx claude spawn --task "..."        Start a Claude Code session
+  mcx claude ls                        List active Claude sessions
+  mcx claude send <session> <msg>      Send follow-up prompt to session
+  mcx claude kill <session>            Interrupt a session
+  mcx claude log <session>             View session transcript
   mcx serve                           Run as stdio MCP server (for .mcp.json)
   mcx completions {bash|zsh|fish}     Generate shell completion script
   mcx restart [server]                Restart server connection(s)


### PR DESCRIPTION
## Summary

- Add `mcx claude` CLI commands: `spawn`, `ls`, `send`, `kill`, `log`
- All commands route through `callTool` on the `_claude` virtual server — zero new IPC methods
- Session ID prefix matching (like git SHAs) for `send`, `kill`, `log`
- Dependency injection for full testability without daemon

## Test plan

- [x] `bun typecheck` passes
- [x] `bun lint` passes (no fixes needed)
- [x] `bun test` — all 1225 tests pass (44 new tests in `claude.spec.ts`)
- [x] Arg parsing: `parseSpawnArgs` covers all flag combos, edge cases
- [x] Arg parsing: `parseLogArgs` covers `--last`/`-n` flags
- [x] Session ID resolution: exact match, prefix match, no match, ambiguous
- [x] Each subcommand calls correct `_claude.*` tool with correct args
- [x] `ls` table output and `-j` JSON output
- [x] Unknown subcommand error handling
- [x] Help/usage output

🤖 Generated with [Claude Code](https://claude.com/claude-code)