### PR TITLE
fix(daemon): idle timeout accounts for active WebSocket sessions (fixes #194)

### DIFF
--- a/packages/daemon/src/claude-server.spec.ts
+++ b/packages/daemon/src/claude-server.spec.ts
@@ -181,6 +181,69 @@ describe("ClaudeServer", () => {
     expect(row?.endedAt).not.toBeNull();
   });
 
+  test("hasActiveSessions() returns false initially", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new ClaudeServer(db);
+
+    await server.start();
+
+    expect(server.hasActiveSessions()).toBe(false);
+  });
+
+  test("hasActiveSessions() returns true after db:upsert, false after db:end", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new ClaudeServer(db);
+
+    await server.start();
+
+    const handle = (server as unknown as { handleWorkerEvent: (e: unknown) => void }).handleWorkerEvent.bind(server);
+    handle({ type: "db:upsert", session: { sessionId: "s-active", state: "connecting" } });
+
+    expect(server.hasActiveSessions()).toBe(true);
+
+    handle({ type: "db:end", sessionId: "s-active" });
+
+    expect(server.hasActiveSessions()).toBe(false);
+  });
+
+  test("hasActiveSessions() tracks multiple sessions independently", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new ClaudeServer(db);
+
+    await server.start();
+
+    const handle = (server as unknown as { handleWorkerEvent: (e: unknown) => void }).handleWorkerEvent.bind(server);
+    handle({ type: "db:upsert", session: { sessionId: "s1", state: "connecting" } });
+    handle({ type: "db:upsert", session: { sessionId: "s2", state: "connecting" } });
+
+    expect(server.hasActiveSessions()).toBe(true);
+
+    handle({ type: "db:end", sessionId: "s1" });
+    expect(server.hasActiveSessions()).toBe(true);
+
+    handle({ type: "db:end", sessionId: "s2" });
+    expect(server.hasActiveSessions()).toBe(false);
+  });
+
+  test("stop() clears active sessions", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new ClaudeServer(db);
+
+    await server.start();
+
+    const handle = (server as unknown as { handleWorkerEvent: (e: unknown) => void }).handleWorkerEvent.bind(server);
+    handle({ type: "db:upsert", session: { sessionId: "s-stop", state: "connecting" } });
+    expect(server.hasActiveSessions()).toBe(true);
+
+    await server.stop();
+    expect(server.hasActiveSessions()).toBe(false);
+    server = undefined; // prevent double stop
+  });
+
   test("stop() terminates worker cleanly", async () => {
     using opts = testOptions();
     db = new StateDb(opts.DB_PATH);

--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -70,6 +70,7 @@ export class ClaudeServer {
   private client: Client | null = null;
   private db: StateDb;
   private wsPort: number | null = null;
+  private readonly activeSessions = new Set<string>();
 
   constructor(db: StateDb) {
     this.db = db;
@@ -132,11 +133,17 @@ export class ClaudeServer {
     this.transport = null;
     this.client = null;
     this.wsPort = null;
+    this.activeSessions.clear();
   }
 
   /** Get the WebSocket server port (available after start). */
   get port(): number | null {
     return this.wsPort;
+  }
+
+  /** True if any WebSocket sessions are active (not yet ended). */
+  hasActiveSessions(): boolean {
+    return this.activeSessions.size > 0;
   }
 
   // ── DB event handling ──
@@ -147,6 +154,7 @@ export class ClaudeServer {
         // Already handled during start(), ignore subsequent
         break;
       case "db:upsert":
+        this.activeSessions.add(event.session.sessionId);
         this.db.upsertSession(event.session);
         break;
       case "db:state":
@@ -156,6 +164,7 @@ export class ClaudeServer {
         this.db.updateSessionCost(event.sessionId, event.cost, event.tokens);
         break;
       case "db:end":
+        this.activeSessions.delete(event.sessionId);
         this.db.endSession(event.sessionId);
         break;
     }

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -520,6 +520,26 @@ describe("ClaudeWsServer", () => {
     }
   });
 
+  test("sessionCount tracks active sessions", () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn });
+    server.start();
+
+    expect(server.sessionCount).toBe(0);
+
+    server.prepareSession("s1", { prompt: "Hello" });
+    expect(server.sessionCount).toBe(1);
+
+    server.prepareSession("s2", { prompt: "World" });
+    expect(server.sessionCount).toBe(2);
+
+    server.bye("s1");
+    expect(server.sessionCount).toBe(1);
+
+    server.bye("s2");
+    expect(server.sessionCount).toBe(0);
+  });
+
   test("stop() cleans up all sessions", () => {
     const ms = mockSpawn();
     server = new ClaudeWsServer({ spawn: ms.spawn });

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -156,6 +156,11 @@ export class ClaudeWsServer {
     return this.server?.port ?? 0;
   }
 
+  /** Number of active (not yet ended) sessions. */
+  get sessionCount(): number {
+    return this.sessions.size;
+  }
+
   /**
    * Prepare a session for an incoming Claude CLI connection.
    * Call this before spawning the Claude process.

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -99,6 +99,11 @@ async function main(): Promise<void> {
         resetIdleTimer();
         return;
       }
+      if (claudeServer.hasActiveSessions()) {
+        console.error("[mcpd] Idle timeout deferred: active WebSocket session(s)");
+        resetIdleTimer();
+        return;
+      }
       console.error("[mcpd] Idle timeout reached, shutting down");
       shutdown();
     }, idleTimeoutMs);


### PR DESCRIPTION
## Summary
- `ClaudeServer` now tracks active session IDs via existing `db:upsert`/`db:end` worker events and exposes `hasActiveSessions()`
- `ClaudeWsServer` exposes a `sessionCount` getter for direct session tracking
- Daemon idle timer defers shutdown when `claudeServer.hasActiveSessions()` is true, preventing mid-session shutdowns

## Test plan
- [x] `ClaudeServer.hasActiveSessions()` returns false initially
- [x] Returns true after `db:upsert`, false after `db:end`
- [x] Tracks multiple sessions independently
- [x] `stop()` clears active sessions
- [x] `ClaudeWsServer.sessionCount` tracks prepare/bye lifecycle
- [x] All 1240 tests pass, typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)