### PR TITLE
feat(command): spawn/send non-blocking by default, add --wait flag (fixes #192)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -129,6 +129,17 @@ describe("parseSpawnArgs", () => {
     // --allow stops collecting when it hits --task (a flag), so allow is empty
     expect(result.error).toBe("--allow requires at least one tool pattern");
   });
+
+  test("parses --wait flag", () => {
+    const result = parseSpawnArgs(["--task", "fix bug", "--wait"]);
+    expect(result.wait).toBe(true);
+    expect(result.task).toBe("fix bug");
+  });
+
+  test("wait defaults to false", () => {
+    const result = parseSpawnArgs(["--task", "fix bug"]);
+    expect(result.wait).toBe(false);
+  });
 });
 
 // ── parseLogArgs ──
@@ -328,6 +339,35 @@ describe("mcx claude spawn", () => {
     }
   });
 
+  test("passes wait flag when --wait is set", async () => {
+    const callTool = mock(async () => toolResult({ sessionId: "abc", success: true }));
+    const deps = makeDeps({ callTool });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["spawn", "--task", "fix", "--wait"], deps);
+      expect(callTool).toHaveBeenCalledWith("claude_prompt", { prompt: "fix", wait: true });
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("does not pass wait flag by default", async () => {
+    const callTool = mock(async () => toolResult({ sessionId: "abc" }));
+    const deps = makeDeps({ callTool });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["spawn", "--task", "fix"], deps);
+      const callArgs = (callTool.mock.calls[0] as unknown as [string, Record<string, unknown>])[1];
+      expect(callArgs.wait).toBeUndefined();
+    } finally {
+      console.log = origLog;
+    }
+  });
+
   test("errors when no task and no resume", async () => {
     const deps = makeDeps();
     await expect(cmdClaude(["spawn"], deps)).rejects.toThrow(ExitError);
@@ -442,6 +482,48 @@ describe("mcx claude send", () => {
   test("errors when no message", async () => {
     const deps = makeDeps();
     await expect(cmdClaude(["send", "abc"], deps)).rejects.toThrow(ExitError);
+  });
+
+  test("passes wait flag when --wait is set", async () => {
+    const callTool: ClaudeDeps["callTool"] = mock(async (tool: string) => {
+      if (tool === "claude_session_list") return toolResult(SESSION_LIST);
+      return toolResult({ success: true });
+    });
+    const deps = makeDeps({ callTool });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["send", "--wait", "abc", "do something"], deps);
+      expect(callTool).toHaveBeenCalledWith("claude_prompt", {
+        sessionId: "abc12345-1111-2222-3333-444444444444",
+        prompt: "do something",
+        wait: true,
+      });
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("does not pass wait flag by default", async () => {
+    const callTool = mock(async (tool: string) => {
+      if (tool === "claude_session_list") return toolResult(SESSION_LIST);
+      return toolResult({ sessionId: "abc12345-1111-2222-3333-444444444444" });
+    });
+    const deps = makeDeps({ callTool });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["send", "abc", "do something"], deps);
+      const promptCall = (callTool.mock.calls as unknown as Array<[string, Record<string, unknown>]>).find(
+        (c) => c[0] === "claude_prompt",
+      );
+      expect(promptCall).toBeDefined();
+      expect(promptCall?.[1].wait).toBeUndefined();
+    } finally {
+      console.log = origLog;
+    }
   });
 });
 

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -30,12 +30,12 @@ export interface ClaudeDeps {
   exit: (code: number) => never;
 }
 
-/** Default IPC timeout for claude_prompt (5 min + buffer). Other tools use default 60s. */
+/** IPC timeout for blocking claude_prompt calls (5 min + buffer). Other tools use default 60s. */
 const PROMPT_IPC_TIMEOUT_MS = 330_000;
 
 const defaultDeps: ClaudeDeps = {
   callTool: (tool, args) => {
-    const timeoutMs = tool === "claude_prompt" ? PROMPT_IPC_TIMEOUT_MS : undefined;
+    const timeoutMs = tool === "claude_prompt" && args.wait ? PROMPT_IPC_TIMEOUT_MS : undefined;
     return ipcCall("callTool", { server: "_claude", tool, arguments: args }, { timeoutMs });
   },
   printError: defaultPrintError,
@@ -89,6 +89,7 @@ export interface SpawnArgs {
   allow: string[];
   cwd: string | undefined;
   timeout: number | undefined;
+  wait: boolean;
   error: string | undefined;
 }
 
@@ -98,6 +99,7 @@ export function parseSpawnArgs(args: string[]): SpawnArgs {
   let resume: string | undefined;
   let cwd: string | undefined;
   let timeout: number | undefined;
+  let wait = false;
   const allow: string[] = [];
   let error: string | undefined;
 
@@ -135,13 +137,15 @@ export function parseSpawnArgs(args: string[]): SpawnArgs {
         timeout = Number(val);
         if (Number.isNaN(timeout)) error = "--timeout must be a number";
       }
+    } else if (arg === "--wait") {
+      wait = true;
     } else if (!arg.startsWith("-")) {
       // Positional arg treated as task if no --task provided
       if (!task) task = arg;
     }
   }
 
-  return { task, worktree, resume, allow, cwd, timeout, error };
+  return { task, worktree, resume, allow, cwd, timeout, wait, error };
 }
 
 async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
@@ -165,6 +169,7 @@ async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
   if (parsed.allow.length > 0) toolArgs.allowedTools = parsed.allow;
   if (parsed.cwd) toolArgs.cwd = parsed.cwd;
   if (parsed.timeout) toolArgs.timeout = parsed.timeout;
+  if (parsed.wait) toolArgs.wait = true;
 
   const result = await d.callTool("claude_prompt", toolArgs);
   console.log(formatToolResult(result));
@@ -209,16 +214,29 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
 }
 
 async function claudeSend(args: string[], d: ClaudeDeps): Promise<void> {
-  const sessionPrefix = args[0];
-  const message = args.slice(1).join(" ").trim();
+  let wait = false;
+  const rest: string[] = [];
+  for (const arg of args) {
+    if (arg === "--wait") {
+      wait = true;
+    } else {
+      rest.push(arg);
+    }
+  }
+
+  const sessionPrefix = rest[0];
+  const message = rest.slice(1).join(" ").trim();
 
   if (!sessionPrefix || !message) {
-    d.printError("Usage: mcx claude send <session-id> <message>");
+    d.printError("Usage: mcx claude send [--wait] <session-id> <message>");
     d.exit(1);
   }
 
   const sessionId = await resolveSessionId(sessionPrefix, d);
-  const result = await d.callTool("claude_prompt", { sessionId, prompt: message });
+  const toolArgs: Record<string, unknown> = { sessionId, prompt: message };
+  if (wait) toolArgs.wait = true;
+
+  const result = await d.callTool("claude_prompt", toolArgs);
   console.log(formatToolResult(result));
 }
 
@@ -380,21 +398,25 @@ function printClaudeUsage(): void {
   console.log(`mcx claude — manage Claude Code sessions
 
 Usage:
-  mcx claude spawn --task "description"    Start a new Claude session
+  mcx claude spawn --task "description"    Start a new Claude session (non-blocking)
   mcx claude spawn "description"           Shorthand (positional task)
   mcx claude ls                            List active sessions
-  mcx claude send <session> <message>      Send follow-up prompt
+  mcx claude send <session> <message>      Send follow-up prompt (non-blocking)
   mcx claude bye <session>                 End session and stop process
   mcx claude interrupt <session>           Interrupt the current turn
   mcx claude log <session> [--last N]      View session transcript
 
 Spawn options:
   --task, -t "description"    Task prompt for Claude
+  --wait                      Block until Claude produces a result
   --worktree, -w [name]       Git worktree isolation (auto-generates name if omitted)
   --resume <id>               Resume a previous session
   --allow <tools...>          Pre-approved tool patterns (e.g. Read Glob "Bash(git *)")
   --cwd <path>                Working directory for Claude
-  --timeout <ms>              Max wait time (default: 300000)
+  --timeout <ms>              Max wait time (default: 300000, only with --wait)
+
+Send options:
+  --wait                      Block until Claude produces a result
 
 Session IDs support prefix matching (like git SHAs).`);
 }

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -130,7 +130,15 @@ async function handlePrompt(
     });
   }
 
-  // Wait for result
+  const shouldWait = (args.wait as boolean) ?? false;
+
+  if (!shouldWait) {
+    return {
+      content: [{ type: "text", text: JSON.stringify({ sessionId }) }],
+    };
+  }
+
+  // Block until result
   const result = await server.waitForResult(sessionId, timeoutMs);
   return {
     content: [{ type: "text", text: JSON.stringify(result, null, 2) }],

--- a/packages/daemon/src/claude-session/tools.ts
+++ b/packages/daemon/src/claude-session/tools.ts
@@ -10,7 +10,7 @@ export const CLAUDE_TOOLS = [
     name: "claude_prompt",
     description:
       "Start a new Claude Code session with a prompt, or send a follow-up prompt to an existing session. " +
-      "Blocks until Claude produces a result or times out.",
+      "Returns the session ID immediately by default. Set wait=true to block until Claude produces a result.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -29,6 +29,7 @@ export const CLAUDE_TOOLS = [
         },
         worktree: { type: "string", description: "Git worktree name for isolation" },
         timeout: { type: "number", description: "Max wait time in ms (default: 300000)" },
+        wait: { type: "boolean", description: "Block until result (default: false)" },
       },
       required: ["prompt"],
     },


### PR DESCRIPTION
## Summary
- `mcx claude spawn` and `mcx claude send` now return the session ID immediately (non-blocking by default)
- Added `--wait` flag to both commands to opt into blocking behavior
- `claude_prompt` tool gains a `wait` parameter (default: `false`) that skips `waitForResult` when not set

## Test plan
- [x] `parseSpawnArgs` tests for `--wait` flag parsing and default `false`
- [x] `spawn` tests verify `wait: true` is passed with `--wait`, and omitted without
- [x] `send` tests verify `wait: true` is passed with `--wait`, and omitted without
- [x] All 1246 existing tests pass
- [x] Typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)