### PR TITLE
fix(daemon): stop callback server after successful OAuth flow (fixes #159)

### DIFF
--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -249,7 +249,6 @@ export class IpcServer {
         if (result === "AUTHORIZED") {
           // Already authorized (tokens were valid) — restart server to reconnect
           await this.pool.restart(server);
-          callback.stop();
           return { ok: true, message: "Already authorized" };
         }
 
@@ -263,9 +262,8 @@ export class IpcServer {
         await this.pool.restart(server);
 
         return { ok: true, message: "Authenticated successfully" };
-      } catch (err) {
+      } finally {
         callback.stop();
-        throw err;
       }
     });
 


### PR DESCRIPTION
## Summary
- Replace `catch`-only cleanup with `try/finally` so `callback.stop()` runs on all code paths (AUTHORIZED, REDIRECT success, and error)
- Fixes a leak where successful OAuth flows left the callback HTTP server running for up to 2 minutes

## Test plan
- [x] Existing daemon tests pass (485/485)
- [x] Lint passes
- [x] Typecheck errors are pre-existing and unrelated (packages/control missing ink/react types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)