### PR TITLE
cleanup: remove 16 dead *Params interfaces, use AliasType everywhere (fixes #157)

### DIFF
--- a/packages/command/src/output.ts
+++ b/packages/command/src/output.ts
@@ -5,7 +5,7 @@
  */
 
 import { type JsonSchema, formatAliasSignature, jsonSchemaToTs } from "@mcp-cli/core";
-import type { AliasDetail } from "@mcp-cli/core";
+import type { AliasDetail, AliasType } from "@mcp-cli/core";
 import type { RegistryEntry } from "./registry/client";
 
 const isTTY = process.stdout.isTTY && !process.env.NO_COLOR;
@@ -162,7 +162,7 @@ export function printAliasList(
     description: string;
     filePath: string;
     updatedAt: number;
-    aliasType?: "freeform" | "defineAlias";
+    aliasType?: AliasType;
     inputSchemaJson?: Record<string, unknown>;
     outputSchemaJson?: Record<string, unknown>;
   }>,

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -6,6 +6,7 @@
  */
 
 import { z } from "zod/v4";
+import type { AliasType } from "./alias";
 
 // -- Methods --
 
@@ -55,13 +56,7 @@ export interface IpcError {
   stack?: string;
 }
 
-// -- Param types per method --
-
-export interface CallToolParams {
-  server: string;
-  tool: string;
-  arguments: Record<string, unknown>;
-}
+// -- Param schemas per method --
 
 export const CallToolParamsSchema = z.object({
   server: z.string(),
@@ -69,58 +64,27 @@ export const CallToolParamsSchema = z.object({
   arguments: z.record(z.string(), z.unknown()).optional().default({}),
 });
 
-export interface ListToolsParams {
-  server?: string;
-  format?: "compact" | "full";
-}
-
 export const ListToolsParamsSchema = z.object({
   server: z.string().optional(),
   format: z.enum(["compact", "full"]).optional(),
 });
-
-export interface GetToolInfoParams {
-  server: string;
-  tool: string;
-}
 
 export const GetToolInfoParamsSchema = z.object({
   server: z.string(),
   tool: z.string(),
 });
 
-export interface GrepToolsParams {
-  pattern: string;
-}
-
 export const GrepToolsParamsSchema = z.object({
   pattern: z.string(),
 });
-
-export interface TriggerAuthParams {
-  server: string;
-}
 
 export const TriggerAuthParamsSchema = z.object({
   server: z.string(),
 });
 
-export interface RestartServerParams {
-  server?: string; // if omitted, restart all
-}
-
 export const RestartServerParamsSchema = z.object({
   server: z.string().optional(),
 });
-
-export interface SaveAliasParams {
-  name: string;
-  script: string;
-  description?: string;
-  aliasType?: "freeform" | "defineAlias";
-  inputSchema?: Record<string, unknown>;
-  outputSchema?: Record<string, unknown>;
-}
 
 export const SaveAliasParamsSchema = z.object({
   name: z.string(),
@@ -131,27 +95,13 @@ export const SaveAliasParamsSchema = z.object({
   outputSchema: z.record(z.string(), z.unknown()).optional(),
 });
 
-export interface DeleteAliasParams {
-  name: string;
-}
-
 export const DeleteAliasParamsSchema = z.object({
   name: z.string(),
 });
 
-export interface GetAliasParams {
-  name: string;
-}
-
 export const GetAliasParamsSchema = z.object({
   name: z.string(),
 });
-
-export interface GetLogsParams {
-  server: string;
-  limit?: number;
-  since?: number;
-}
 
 export const GetLogsParamsSchema = z.object({
   server: z.string(),
@@ -164,7 +114,7 @@ export interface AliasInfo {
   description: string;
   filePath: string;
   updatedAt: number;
-  aliasType: "freeform" | "defineAlias";
+  aliasType: AliasType;
   inputSchemaJson?: Record<string, unknown>;
   outputSchemaJson?: Record<string, unknown>;
 }
@@ -183,11 +133,6 @@ export interface LogEntry {
 export interface GetLogsResult {
   server: string;
   lines: LogEntry[];
-}
-
-export interface GetDaemonLogsParams {
-  limit?: number;
-  since?: number;
 }
 
 export const GetDaemonLogsParamsSchema = z.object({
@@ -262,14 +207,6 @@ export interface MailMessage {
   createdAt: string;
 }
 
-export interface SendMailParams {
-  sender: string;
-  recipient: string;
-  subject?: string;
-  body?: string;
-  replyTo?: number;
-}
-
 export const SendMailParamsSchema = z.object({
   sender: z.string(),
   recipient: z.string(),
@@ -278,34 +215,16 @@ export const SendMailParamsSchema = z.object({
   replyTo: z.number().optional(),
 });
 
-export interface ReadMailParams {
-  recipient?: string;
-  unreadOnly?: boolean;
-  limit?: number;
-}
-
 export const ReadMailParamsSchema = z.object({
   recipient: z.string().optional(),
   unreadOnly: z.boolean().optional(),
   limit: z.number().optional(),
 });
 
-export interface WaitForMailParams {
-  recipient?: string;
-  timeout?: number;
-}
-
 export const WaitForMailParamsSchema = z.object({
   recipient: z.string().optional(),
   timeout: z.number().optional(),
 });
-
-export interface ReplyToMailParams {
-  id: number;
-  sender: string;
-  body: string;
-  subject?: string;
-}
 
 export const ReplyToMailParamsSchema = z.object({
   id: z.number(),
@@ -313,10 +232,6 @@ export const ReplyToMailParamsSchema = z.object({
   body: z.string(),
   subject: z.string().optional(),
 });
-
-export interface MarkReadParams {
-  id: number;
-}
 
 export const MarkReadParamsSchema = z.object({
   id: z.number(),

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -8,7 +8,7 @@
  */
 
 import { Database } from "bun:sqlite";
-import { type MailMessage, type ToolInfo, type UsageStat, hardenFile, options } from "@mcp-cli/core";
+import { type AliasType, type MailMessage, type ToolInfo, type UsageStat, hardenFile, options } from "@mcp-cli/core";
 import type { OAuthDiscoveryState } from "@modelcontextprotocol/sdk/client/auth.js";
 import type { OAuthClientInformationMixed, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js";
 
@@ -421,7 +421,7 @@ export class StateDb {
     description: string;
     filePath: string;
     updatedAt: number;
-    aliasType: "freeform" | "defineAlias";
+    aliasType: AliasType;
     inputSchemaJson?: Record<string, unknown>;
     outputSchemaJson?: Record<string, unknown>;
   }> {
@@ -446,15 +446,13 @@ export class StateDb {
         description: row.description ?? "",
         filePath: row.file_path,
         updatedAt: row.updated_at,
-        aliasType: row.alias_type as "freeform" | "defineAlias",
+        aliasType: row.alias_type as AliasType,
         ...(row.input_schema_json ? { inputSchemaJson: safeJsonParse(row.input_schema_json, {}) } : {}),
         ...(row.output_schema_json ? { outputSchemaJson: safeJsonParse(row.output_schema_json, {}) } : {}),
       }));
   }
 
-  getAlias(
-    name: string,
-  ): { name: string; description: string; filePath: string; aliasType: "freeform" | "defineAlias" } | undefined {
+  getAlias(name: string): { name: string; description: string; filePath: string; aliasType: AliasType } | undefined {
     const row = this.db
       .query<{ name: string; description: string | null; file_path: string; alias_type: string }, [string]>(
         "SELECT name, description, file_path, alias_type FROM aliases WHERE name = ?",
@@ -465,7 +463,7 @@ export class StateDb {
       name: row.name,
       description: row.description ?? "",
       filePath: row.file_path,
-      aliasType: row.alias_type as "freeform" | "defineAlias",
+      aliasType: row.alias_type as AliasType,
     };
   }
 
@@ -473,7 +471,7 @@ export class StateDb {
     name: string,
     filePath: string,
     description?: string,
-    aliasType: "freeform" | "defineAlias" = "freeform",
+    aliasType: AliasType = "freeform",
     inputSchemaJson?: string,
     outputSchemaJson?: string,
   ): void {


### PR DESCRIPTION
## Summary
- Delete 16 dead `*Params` interfaces from `core/src/ipc.ts` (~87 lines removed) that duplicated Zod schema-inferred types
- Replace inline `"freeform" | "defineAlias"` unions with the existing `AliasType` export from `core/alias.ts` across `ipc.ts`, `daemon/db/state.ts`, and `command/output.ts`

## Test plan
- [x] `bun typecheck` — no new errors (pre-existing `control` package errors unchanged)
- [x] `bun lint` — passes clean
- [x] `bun test` — 1241 pass, no new failures (1 pre-existing `react` import error in `control`)
- [x] Verified all 16 removed interfaces had zero imports outside `ipc.ts`
- [x] Verified `AliasType` is properly re-exported from `@mcp-cli/core` barrel

🤖 Generated with [Claude Code](https://claude.com/claude-code)