### PR TITLE
fix(completions): add missing serve, mail, import, export commands (fixes #162)

### DIFF
--- a/packages/command/src/commands/completions.spec.ts
+++ b/packages/command/src/commands/completions.spec.ts
@@ -33,6 +33,10 @@ describe("SUBCOMMANDS", () => {
     "install",
     "registry",
     "completions",
+    "serve",
+    "mail",
+    "import",
+    "export",
     "help",
   ];
 

--- a/packages/command/src/commands/completions.ts
+++ b/packages/command/src/commands/completions.ts
@@ -41,6 +41,10 @@ export const SUBCOMMANDS = [
   "install",
   "registry",
   "completions",
+  "serve",
+  "mail",
+  "import",
+  "export",
   "help",
 ] as const;
 


### PR DESCRIPTION
## Summary
- Added `serve`, `mail`, `import`, `export` to the `SUBCOMMANDS` array in `completions.ts` so they appear in shell tab completion
- Updated test expectations in `completions.spec.ts` to match

## Test plan
- [x] All 36 completions tests pass
- [x] Lint passes
- [x] Typecheck failures are pre-existing (unrelated `control` package missing `react` types)

🤖 Generated with [Claude Code](https://claude.com/claude-code)