### PR TITLE
cleanup: remove duplicate ConfigSource, use .get(), remove dead code (fixes #163)

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -104,12 +104,7 @@ export function validateAliasName(name: string): void {
  */
 export function safeAliasPath(name: string): string {
   validateAliasName(name);
-  const resolved = join(options.ALIASES_DIR, `${name}.ts`);
-  // Defense-in-depth: verify resolved path is inside ALIASES_DIR
-  if (!resolved.startsWith(`${options.ALIASES_DIR}/`)) {
-    throw new Error(`Alias path "${resolved}" escapes aliases directory`);
-  }
-  return resolved;
+  return join(options.ALIASES_DIR, `${name}.ts`);
 }
 
 /** Project-level MCP config filename */

--- a/packages/core/src/fs.ts
+++ b/packages/core/src/fs.ts
@@ -44,13 +44,12 @@ export function auditRuntimePermissions(): void {
  */
 export function findFileUpward(filename: string, startDir: string): string | null {
   let dir = resolve(startDir);
-  const root = dirname(dir) === dir ? dir : "/";
 
   while (true) {
     const candidate = join(dir, filename);
     if (existsSync(candidate)) return candidate;
     const parent = dirname(dir);
-    if (parent === dir || dir === root) return null;
+    if (parent === dir) return null;
     dir = parent;
   }
 }

--- a/packages/daemon/src/auth/oauth-provider.ts
+++ b/packages/daemon/src/auth/oauth-provider.ts
@@ -181,7 +181,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
         // Verifier is ephemeral, no need to explicitly clear
         break;
       case "discovery":
-        // Clear discovery state to force re-discovery
+        // No cached state to clear — discovery is fetched on demand
         break;
     }
   }

--- a/packages/daemon/src/config/loader.ts
+++ b/packages/daemon/src/config/loader.ts
@@ -11,14 +11,15 @@
 
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
-import type { McpConfigFile, ResolvedConfig, ResolvedServer, ServerConfig, ServerConfigMap } from "@mcp-cli/core";
-import { options, projectConfigPath } from "@mcp-cli/core";
-import { expandEnvVarsDeep } from "@mcp-cli/core";
-
-interface ConfigSource {
-  file: string;
-  scope: "user" | "project" | "local" | "mcp-cli";
-}
+import type {
+  ConfigSource,
+  McpConfigFile,
+  ResolvedConfig,
+  ResolvedServer,
+  ServerConfig,
+  ServerConfigMap,
+} from "@mcp-cli/core";
+import { expandEnvVarsDeep, options, projectConfigPath } from "@mcp-cli/core";
 
 /**
  * Load and merge all config sources for the given working directory.

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -642,7 +642,7 @@ export class StateDb {
       >(
         `SELECT id, sender, recipient, subject, body, reply_to, read, created_at FROM mail WHERE ${where} ORDER BY created_at ASC LIMIT 1`,
       )
-      .all(...params)[0];
+      .get(...params);
     return row ? toMailMessage(row) : undefined;
   }
 


### PR DESCRIPTION
## Summary
- Import `ConfigSource` from `@mcp-cli/core` instead of redefining locally in `loader.ts`; consolidate three `@mcp-cli/core` imports into two
- Use `.get()` instead of `.all()[0]` for `LIMIT 1` query in `getNextUnread` (consistent with rest of file)
- Remove unreachable `startsWith` guard in `safeAliasPath` (regex validation makes path traversal impossible)
- Remove redundant `root` variable in `findFileUpward` (`parent === dir` already catches filesystem root)
- Fix misleading comment on empty `discovery` case in `oauth-provider.ts`

Note: Item #5 (basename in watcher.ts) was already fixed — `basename` is imported and used.

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — 1262 tests pass, coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)