### PR TITLE
cleanup(control): comma join, double-nullable, dead export, required props, shared sources (fixes #165)

### DIFF
--- a/packages/control/src/components/auth-banner.tsx
+++ b/packages/control/src/components/auth-banner.tsx
@@ -10,7 +10,7 @@ export interface AuthStatus {
 
 interface AuthBannerProps {
   servers: ServerStatus[];
-  authStatus?: AuthStatus | null;
+  authStatus: AuthStatus | null;
 }
 
 export function isAuthError(error?: string): boolean {

--- a/packages/control/src/components/footer.tsx
+++ b/packages/control/src/components/footer.tsx
@@ -3,12 +3,12 @@ import React from "react";
 import type { View } from "../hooks/use-keyboard.js";
 
 interface FooterProps {
-  view?: View;
-  filterMode?: boolean;
-  filterText?: string;
+  view: View;
+  filterMode: boolean;
+  filterText: string;
 }
 
-export function Footer({ view = "servers", filterMode, filterText }: FooterProps) {
+export function Footer({ view, filterMode, filterText }: FooterProps) {
   if (filterMode) {
     return (
       <Box marginTop={1}>

--- a/packages/control/src/components/header.tsx
+++ b/packages/control/src/components/header.tsx
@@ -52,26 +52,39 @@ export function Header({ status, error }: HeaderProps) {
 
       <Text>
         <Text dimColor>Servers: </Text>
-        {connected > 0 && <Text color="green">{connected} connected</Text>}
-        {connecting > 0 && (
-          <Text>
-            {connected > 0 && <Text dimColor>, </Text>}
-            <Text color="yellow">{connecting} connecting</Text>
-          </Text>
+        {servers.length === 0 ? (
+          <Text dimColor>none</Text>
+        ) : (
+          [
+            connected > 0 && (
+              <Text key="connected" color="green">
+                {connected} connected
+              </Text>
+            ),
+            connecting > 0 && (
+              <Text key="connecting" color="yellow">
+                {connecting} connecting
+              </Text>
+            ),
+            errored > 0 && (
+              <Text key="errored" color="red">
+                {errored} error
+              </Text>
+            ),
+            disconnected > 0 && (
+              <Text key="disconnected" dimColor>
+                {disconnected} disconnected
+              </Text>
+            ),
+          ]
+            .filter(Boolean)
+            .map((el, i, arr) => (
+              <React.Fragment key={(el as React.ReactElement).key}>
+                {i > 0 && <Text dimColor>, </Text>}
+                {el}
+              </React.Fragment>
+            ))
         )}
-        {errored > 0 && (
-          <Text>
-            {(connected > 0 || connecting > 0) && <Text dimColor>, </Text>}
-            <Text color="red">{errored} error</Text>
-          </Text>
-        )}
-        {disconnected > 0 && (
-          <Text>
-            {(connected > 0 || connecting > 0 || errored > 0) && <Text dimColor>, </Text>}
-            <Text dimColor>{disconnected} disconnected</Text>
-          </Text>
-        )}
-        {servers.length === 0 && <Text dimColor>none</Text>}
       </Text>
 
       {totalCalls > 0 && (

--- a/packages/control/src/components/log-viewer.tsx
+++ b/packages/control/src/components/log-viewer.tsx
@@ -1,7 +1,7 @@
 import type { LogEntry, ServerStatus } from "@mcp-cli/core";
 import { Box, Text } from "ink";
 import React from "react";
-import type { LogSource } from "../hooks/use-logs.js";
+import { type LogSource, buildLogSources } from "../hooks/use-logs.js";
 
 interface LogViewerProps {
   lines: LogEntry[];
@@ -27,8 +27,7 @@ function formatTime(ts: number): string {
 }
 
 export function LogViewer({ lines, source, servers, scrollOffset, height, filterText, totalCount }: LogViewerProps) {
-  // Build source tabs
-  const sources: LogSource[] = [{ type: "daemon" }, ...servers.map((s) => ({ type: "server" as const, name: s.name }))];
+  const sources = buildLogSources(servers);
 
   const currentLabel = sourceLabel(source);
 

--- a/packages/control/src/components/utils.spec.ts
+++ b/packages/control/src/components/utils.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { filterLogLines } from "../hooks/use-logs";
+import { buildLogSources, filterLogLines } from "../hooks/use-logs";
 import { isAuthError } from "./auth-banner";
 import { formatUptime } from "./header";
 import { formatRelativeTime } from "./server-detail";
@@ -100,6 +100,21 @@ describe("filterLogLines", () => {
     const result = filterLogLines(lines, "Cache");
     expect(result).toHaveLength(1);
     expect(result[0].line).toBe("DEBUG: cache miss");
+  });
+});
+
+describe("buildLogSources", () => {
+  it("returns daemon-only when no servers", () => {
+    expect(buildLogSources([])).toEqual([{ type: "daemon" }]);
+  });
+
+  it("returns daemon + one entry per server", () => {
+    const servers = [
+      { name: "a", state: "connected" },
+      { name: "b", state: "error" },
+    ] as import("@mcp-cli/core").ServerStatus[];
+    const result = buildLogSources(servers);
+    expect(result).toEqual([{ type: "daemon" }, { type: "server", name: "a" }, { type: "server", name: "b" }]);
   });
 });
 

--- a/packages/control/src/hooks/use-keyboard.ts
+++ b/packages/control/src/hooks/use-keyboard.ts
@@ -2,7 +2,7 @@ import type { ServerStatus } from "@mcp-cli/core";
 import { ipcCall } from "@mcp-cli/core";
 import { useApp, useInput } from "ink";
 import type { AuthStatus } from "../components/auth-banner";
-import type { LogSource } from "./use-logs";
+import { type LogSource, buildLogSources } from "./use-logs";
 
 export type View = "servers" | "logs";
 
@@ -116,10 +116,7 @@ export function useKeyboard({
 
       // Cycle log source
       if (key.tab) {
-        const sources: LogSource[] = [
-          { type: "daemon" },
-          ...servers.map((s) => ({ type: "server" as const, name: s.name })),
-        ];
+        const sources = buildLogSources(servers);
         const currentIdx = sources.findIndex((s) => {
           if (s.type === "daemon" && logSource.type === "daemon") return true;
           if (s.type === "server" && logSource.type === "server" && s.name === logSource.name) return true;

--- a/packages/control/src/hooks/use-logs.ts
+++ b/packages/control/src/hooks/use-logs.ts
@@ -4,6 +4,11 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 export type LogSource = { type: "daemon" } | { type: "server"; name: string };
 
+/** Build the ordered list of log sources: daemon + one per server. */
+export function buildLogSources(servers: ServerStatus[]): LogSource[] {
+  return [{ type: "daemon" }, ...servers.map((s) => ({ type: "server" as const, name: s.name }))];
+}
+
 /** Case-insensitive substring filter for log entries. */
 export function filterLogLines(lines: LogEntry[], filterText: string): LogEntry[] {
   if (!filterText) return lines;
@@ -19,7 +24,6 @@ interface UseLogsResult {
   lines: LogEntry[];
   source: LogSource;
   setSource: (source: LogSource) => void;
-  clear: () => void;
 }
 
 export function useLogs(servers: ServerStatus[]): UseLogsResult {
@@ -95,5 +99,5 @@ export function useLogs(servers: ServerStatus[]): UseLogsResult {
     };
   }, [source]);
 
-  return { lines, source, setSource, clear };
+  return { lines, source, setSource };
 }


### PR DESCRIPTION
## Summary
- **header.tsx**: Replace brittle manual comma-separator conditions with `array.filter(Boolean).map()` pattern — adding new server states no longer requires updating every subsequent separator
- **auth-banner.tsx**: Fix double-nullable `authStatus?: AuthStatus | null` → `authStatus: AuthStatus | null` (required, nullable)
- **use-logs.ts**: Remove unused `clear` from `UseLogsResult` public interface; extract shared `buildLogSources()` helper
- **footer.tsx**: Make `view`/`filterMode`/`filterText` required props (all callers already pass them explicitly)
- **log-viewer.tsx + use-keyboard.ts**: Replace duplicated `sources` array construction with shared `buildLogSources()`

## Test plan
- [x] Added `buildLogSources` unit tests (empty servers, multiple servers)
- [x] All 1264 tests pass
- [x] TypeScript strict mode passes
- [x] Biome lint clean
- [x] Coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)