### PR TITLE
fix(daemon): default permission mode to safe rules instead of auto-approve (fixes #197)

### DIFF
--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -481,7 +481,7 @@ Spawn options:
   --wait                      Block until Claude produces a result
   --worktree, -w [name]       Git worktree isolation (auto-generates name if omitted)
   --resume <id>               Resume a previous session
-  --allow <tools...>          Pre-approved tool patterns (e.g. Read Glob "Bash(git *)")
+  --allow <tools...>          Pre-approved tool patterns (default: Read Glob Grep Write Edit)
   --cwd <path>                Working directory for Claude
   --timeout <ms>              Max wait time (default: 300000, only with --wait)
 

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -16,7 +16,7 @@
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
-import type { PermissionRule, PermissionStrategy } from "./claude-session/permission-router";
+import { DEFAULT_SAFE_TOOLS, type PermissionRule, type PermissionStrategy } from "./claude-session/permission-router";
 import type { SessionEvent } from "./claude-session/session-state";
 import { CLAUDE_TOOLS } from "./claude-session/tools";
 import { ClaudeWsServer } from "./claude-session/ws-server";
@@ -96,12 +96,12 @@ async function handlePrompt(
   } else {
     // New session
     sessionId = crypto.randomUUID();
-    const permissionMode = (args.permissionMode as PermissionStrategy) ?? "auto";
+    const permissionMode = (args.permissionMode as PermissionStrategy) ?? "rules";
     const allowedTools = (args.allowedTools as string[]) ?? undefined;
-    const rules: PermissionRule[] | undefined =
-      permissionMode === "rules" && allowedTools
-        ? allowedTools.map((tool) => ({ tool, action: "allow" as const }))
-        : undefined;
+    const effectiveTools = permissionMode === "rules" ? (allowedTools ?? DEFAULT_SAFE_TOOLS) : undefined;
+    const rules: PermissionRule[] | undefined = effectiveTools
+      ? effectiveTools.map((tool) => ({ tool, action: "allow" as const }))
+      : undefined;
 
     server.prepareSession(sessionId, {
       prompt,

--- a/packages/daemon/src/claude-session/permission-router.spec.ts
+++ b/packages/daemon/src/claude-session/permission-router.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   type CanUseToolRequest,
+  DEFAULT_SAFE_TOOLS,
   type PermissionDecision,
   PermissionRouter,
   type PermissionRule,
@@ -196,6 +197,42 @@ describe("PermissionRouter — delegate", () => {
     const decision = await router.evaluate(makeRequest("Bash", { command: "git push" }));
     expect(decision.allow).toBe(true);
     expect(decision.updatedPermissions).toEqual([{ tool: "Bash(git *)", action: "allow" }]);
+  });
+});
+
+// ── DEFAULT_SAFE_TOOLS ──
+
+describe("DEFAULT_SAFE_TOOLS", () => {
+  test("contains expected safe tools", () => {
+    expect(DEFAULT_SAFE_TOOLS).toContain("Read");
+    expect(DEFAULT_SAFE_TOOLS).toContain("Glob");
+    expect(DEFAULT_SAFE_TOOLS).toContain("Grep");
+    expect(DEFAULT_SAFE_TOOLS).toContain("Write");
+    expect(DEFAULT_SAFE_TOOLS).toContain("Edit");
+  });
+
+  test("does not contain dangerous tools", () => {
+    expect(DEFAULT_SAFE_TOOLS).not.toContain("Bash");
+    expect(DEFAULT_SAFE_TOOLS).not.toContain("WebFetch");
+    expect(DEFAULT_SAFE_TOOLS).not.toContain("WebSearch");
+  });
+
+  test("is frozen", () => {
+    expect(Object.isFrozen(DEFAULT_SAFE_TOOLS)).toBe(true);
+  });
+
+  test("creates a working rules router", async () => {
+    const rules = DEFAULT_SAFE_TOOLS.map((tool) => ({ tool, action: "allow" as const }));
+    const router = new PermissionRouter("rules", rules);
+
+    // Safe tools allowed
+    expect((await router.evaluate(makeRequest("Read"))).allow).toBe(true);
+    expect((await router.evaluate(makeRequest("Edit"))).allow).toBe(true);
+    expect((await router.evaluate(makeRequest("Write"))).allow).toBe(true);
+
+    // Dangerous tools denied
+    expect((await router.evaluate(makeRequest("Bash", { command: "rm -rf /" }))).allow).toBe(false);
+    expect((await router.evaluate(makeRequest("WebFetch"))).allow).toBe(false);
   });
 });
 

--- a/packages/daemon/src/claude-session/permission-router.ts
+++ b/packages/daemon/src/claude-session/permission-router.ts
@@ -61,6 +61,14 @@ function matchesPattern(pattern: string, toolName: string, input: Record<string,
   return false;
 }
 
+// ── Defaults ──
+
+/**
+ * Safe tools allowed by default when no explicit --allow is provided.
+ * Permits file read/write but blocks shell execution and network access.
+ */
+export const DEFAULT_SAFE_TOOLS: readonly string[] = Object.freeze(["Read", "Glob", "Grep", "Write", "Edit"]);
+
 // ── Router ──
 
 export class PermissionRouter {

--- a/packages/daemon/src/claude-session/tools.ts
+++ b/packages/daemon/src/claude-session/tools.ts
@@ -5,6 +5,8 @@
  * and the main thread (tool cache for ServerPool).
  */
 
+import { DEFAULT_SAFE_TOOLS } from "./permission-router";
+
 export const CLAUDE_TOOLS = [
   {
     name: "claude_prompt",
@@ -20,7 +22,7 @@ export const CLAUDE_TOOLS = [
         permissionMode: {
           type: "string",
           enum: ["auto", "rules"],
-          description: "Permission handling strategy (default: auto)",
+          description: `Permission handling strategy (default: "rules" with safe tools: ${DEFAULT_SAFE_TOOLS.join(", ")})`,
         },
         allowedTools: {
           type: "array",


### PR DESCRIPTION
## Summary
- Default permission mode for spawned Claude sessions changed from `"auto"` (approve everything) to `"rules"` with a safe allowlist: Read, Glob, Grep, Write, Edit
- Added `DEFAULT_SAFE_TOOLS` constant in `permission-router.ts` as single source of truth for the default allowlist
- Explicit `--allow` or `permissionMode: "auto"` still work as before for full autonomy

## Test plan
- [x] New tests for `DEFAULT_SAFE_TOOLS` — contains expected safe tools, excludes dangerous tools (Bash, WebFetch, WebSearch), is frozen
- [x] Integration test: default safe tools create a working rules router that allows safe tools and denies dangerous ones
- [x] All existing permission-router and claude command tests pass (97 tests)
- [x] Full test suite passes (1281 tests, 0 failures)
- [x] Coverage thresholds met (84.47% functions, 84.61% lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)