### PR TITLE
fix(control): clamp claudeSelectedIndex when sessions list shrinks (fixes #236)

### DIFF
--- a/packages/control/src/app.tsx
+++ b/packages/control/src/app.tsx
@@ -51,10 +51,8 @@ export function App() {
 
   // Clamp claudeSelectedIndex when sessions list shrinks
   useEffect(() => {
-    if (claudeSelectedIndex >= sessions.length && sessions.length > 0) {
-      setClaudeSelectedIndex(sessions.length - 1);
-    }
-  }, [sessions.length, claudeSelectedIndex]);
+    setClaudeSelectedIndex((i) => Math.min(i, Math.max(0, sessions.length - 1)));
+  }, [sessions.length]);
 
   // Auto-clear success/error auth status after 5 seconds
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Add `useEffect` in `app.tsx` to clamp `claudeSelectedIndex` to `sessions.length - 1` whenever the sessions list shrinks below the current index
- Prevents invisible selection and broken j/k navigation when Claude sessions end or get killed

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] All 1347 tests pass
- [x] Coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)