### PR TITLE
fix(control): guard setState after unmount in useClaudeSessions (fixes #237)

### DIFF
--- a/packages/control/src/hooks/use-claude-sessions.ts
+++ b/packages/control/src/hooks/use-claude-sessions.ts
@@ -1,5 +1,5 @@
 import { ipcCall } from "@mcp-cli/core";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { extractToolText } from "./ipc-tool-helpers.js";
 
 // Mirror the daemon's SessionInfo shape (from claude-session/ws-server.ts)


### PR DESCRIPTION
## Summary
- Add `if (cancelled) return` guards after `await ipcCall(...)` in `useClaudeSessions` to prevent setState on unmounted components
- Inline `poll()` into the effect to give it direct access to the `cancelled` flag, matching the `useDaemon` pattern
- Remove the now-unnecessary `useCallback` wrapper

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — all 1356 tests pass
- [x] Coverage thresholds maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)