### PR TITLE
docs: update README TUI section with tab bar and views (fixes #247)

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,13 @@ mcpctl                              # interactive dashboard
 # or: bun run packages/control/src/index.tsx
 ```
 
-Navigate servers, view tool counts, trigger restarts, see connection states.
+Tab bar with 5 views — navigate with Tab/Shift+Tab or press 1-5 to jump directly:
+
+1. **Servers** — server list, tool counts, connection states, restarts
+2. **Logs** — daemon and per-server log viewer
+3. **Claude** — Claude Code session list with transcript viewing
+4. **Mail** — message system (coming soon)
+5. **Stats** — usage statistics (coming soon)
 
 ## Claude Code Integration
 


### PR DESCRIPTION
## Summary
- Updated the TUI section in README to document the 5-tab interface (Servers, Logs, Claude, Mail, Stats)
- Added keyboard navigation instructions (Tab/Shift+Tab to cycle, 1-5 to jump)
- Replaced the old single-line description with a numbered list of views

## Test plan
- [x] Verified tab names match source code (`ALL_TABS` in `use-keyboard.ts`)
- [x] typecheck, lint, and tests all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)