### PR TITLE
docs: fix prod dependencies claim in README (fixes #248)

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ packages/
 ```
 
 - **Runtime:** [Bun](https://bun.sh) (build, test, compile, SQLite)
-- **Single prod dep:** `@modelcontextprotocol/sdk`
+- **Prod dependencies:** `@modelcontextprotocol/sdk`, `zod` (v4)
 - **Transports:** stdio, SSE, Streamable HTTP
 - **State:** `~/.mcp-cli/` — SQLite db, aliases, PID file, Unix socket
 


### PR DESCRIPTION
## Summary
- Updated README line 251 to list both prod dependencies (`@modelcontextprotocol/sdk` and `zod` v4), matching what CLAUDE.md already documents

## Test plan
- [x] Verified the README now matches CLAUDE.md's prod dependencies list
- [x] All checks pass (typecheck, lint, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)