### PR TITLE
fix(control): add @types/react to root devDependencies for typecheck (fixes #267)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@types/bun": "latest",
+        "@types/react": "^18.3.0",
         "typescript": "^5.9.3",
       },
     },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@types/bun": "latest",
+    "@types/react": "^18.3.0",
     "typescript": "^5.9.3"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Adds `@types/react` to root `package.json` devDependencies so it gets properly symlinked to `node_modules/@types/react`
- Previously, `@types/react` was only in `packages/control/devDependencies` — Bun placed it in `.bun/` cache but did not create a direct symlink accessible to `tsc`
- The root `tsconfig.json` includes all `packages/*/src/**/*.tsx` files, so TypeScript needs `@types/react` accessible from the root `node_modules/@types/` directory

## Test plan
- [x] `bun typecheck` passes (exit 0)
- [x] `bun lint` passes with no issues
- [x] `bun test` passes (1371 tests)
- [x] Coverage thresholds met
- [x] Pre-commit hook passes
- [x] Verified `node_modules/@types/react` symlink is now created after `bun install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)