### PR TITLE
test(control): add tests for useClaudeSessions hook (fixes #260)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
       },
       "devDependencies": {
         "@types/react": "^18.3.0",
+        "ink-testing-library": "^4.0.0",
       },
     },
     "packages/core": {
@@ -214,6 +215,8 @@
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ink": ["ink@5.2.1", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.1.3", "ansi-escapes": "^7.0.0", "ansi-styles": "^6.2.1", "auto-bind": "^5.0.1", "chalk": "^5.3.0", "cli-boxes": "^3.0.0", "cli-cursor": "^4.0.0", "cli-truncate": "^4.0.0", "code-excerpt": "^4.0.0", "es-toolkit": "^1.22.0", "indent-string": "^5.0.0", "is-in-ci": "^1.0.0", "patch-console": "^2.0.0", "react-reconciler": "^0.29.0", "scheduler": "^0.23.0", "signal-exit": "^3.0.7", "slice-ansi": "^7.1.0", "stack-utils": "^2.0.6", "string-width": "^7.2.0", "type-fest": "^4.27.0", "widest-line": "^5.0.0", "wrap-ansi": "^9.0.0", "ws": "^8.18.0", "yoga-layout": "~3.2.1" }, "peerDependencies": { "@types/react": ">=18.0.0", "react": ">=18.0.0", "react-devtools-core": "^4.19.1" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg=="],
+
+    "ink-testing-library": ["ink-testing-library@4.0.0", "", { "peerDependencies": { "@types/react": ">=18.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q=="],
 
     "ip-address": ["ip-address@10.0.1", "", {}, "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA=="],
 

--- a/packages/control/package.json
+++ b/packages/control/package.json
@@ -11,6 +11,7 @@
     "ink": "^5.1.0"
   },
   "devDependencies": {
-    "@types/react": "^18.3.0"
+    "@types/react": "^18.3.0",
+    "ink-testing-library": "^4.0.0"
   }
 }

--- a/packages/control/src/app.tsx
+++ b/packages/control/src/app.tsx
@@ -31,7 +31,11 @@ export function App() {
 
   const servers = status?.servers ?? [];
   // Poll faster on claude tab, slower off-tab (badge still updates)
-  const { sessions, loading: claudeLoading, error: claudeError } = useClaudeSessions(view === "claude" ? 2500 : 10_000);
+  const {
+    sessions,
+    loading: claudeLoading,
+    error: claudeError,
+  } = useClaudeSessions({ intervalMs: view === "claude" ? 2500 : 10_000 });
   const { lines: logLines, source: logSource, setSource: setLogSource } = useLogs(servers);
 
   const filteredLogLines = useMemo(() => filterLogLines(logLines, filterText), [logLines, filterText]);

--- a/packages/control/src/hooks/use-claude-sessions.spec.ts
+++ b/packages/control/src/hooks/use-claude-sessions.spec.ts
@@ -1,0 +1,185 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import type { SessionInfo } from "@mcp-cli/core";
+import { Text } from "ink";
+import { render } from "ink-testing-library";
+import React, { type FC } from "react";
+import { type UseClaudeSessionsOptions, useClaudeSessions } from "./use-claude-sessions";
+
+/* ---------- helpers ---------- */
+
+/** Minimal SessionInfo fixture */
+function session(id: string): SessionInfo {
+  return {
+    sessionId: id,
+    state: "active",
+    model: "opus",
+    cwd: "/tmp",
+    cost: 0,
+    tokens: 0,
+    numTurns: 0,
+    pendingPermissions: 0,
+    pendingPermissionDetails: [],
+    worktree: null,
+  };
+}
+
+/** Mutable ref to capture hook state without parsing rendered output */
+interface HookState {
+  sessions: SessionInfo[];
+  loading: boolean;
+  error: string | null;
+}
+
+/** Wrapper component that captures hook state into a shared ref */
+const Harness: FC<{ opts: UseClaudeSessionsOptions; stateRef: { current: HookState } }> = ({ opts, stateRef }) => {
+  const result = useClaudeSessions(opts);
+  stateRef.current = result;
+  return React.createElement(Text, null, "ok");
+};
+
+/** Flush microtask queue and give React time to re-render */
+async function flush(ms = 10) {
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+/* ---------- tests ---------- */
+
+describe("useClaudeSessions", () => {
+  const instances: ReturnType<typeof render>[] = [];
+
+  afterEach(() => {
+    for (const inst of instances) inst.unmount();
+    instances.length = 0;
+  });
+
+  function mount(opts: UseClaudeSessionsOptions) {
+    const stateRef: { current: HookState } = {
+      current: { sessions: [], loading: true, error: null },
+    };
+    const instance = render(React.createElement(Harness, { opts, stateRef }));
+    instances.push(instance);
+    return { instance, stateRef };
+  }
+
+  it("calls ipcCallFn on mount and sets sessions", async () => {
+    const sessions = [session("s1"), session("s2")];
+    const ipcCallFn = async () => ({
+      content: [{ type: "text", text: JSON.stringify(sessions) }],
+    });
+
+    const { stateRef } = mount({
+      ipcCallFn: ipcCallFn as UseClaudeSessionsOptions["ipcCallFn"],
+    });
+
+    await flush();
+    expect(stateRef.current.sessions).toHaveLength(2);
+    expect(stateRef.current.sessions[0].sessionId).toBe("s1");
+    expect(stateRef.current.loading).toBe(false);
+    expect(stateRef.current.error).toBeNull();
+  });
+
+  it("sets error state when ipcCallFn throws", async () => {
+    const ipcCallFn = async () => {
+      throw new Error("daemon offline");
+    };
+
+    const { stateRef } = mount({
+      ipcCallFn: ipcCallFn as UseClaudeSessionsOptions["ipcCallFn"],
+    });
+
+    await flush();
+    expect(stateRef.current.error).toBe("daemon offline");
+    expect(stateRef.current.loading).toBe(false);
+  });
+
+  it("skips polling when enabled=false", async () => {
+    let callCount = 0;
+    const ipcCallFn = async () => {
+      callCount++;
+      return { content: [{ type: "text", text: "[]" }] };
+    };
+
+    const { stateRef } = mount({
+      enabled: false,
+      ipcCallFn: ipcCallFn as UseClaudeSessionsOptions["ipcCallFn"],
+    });
+
+    await flush();
+    expect(callCount).toBe(0);
+    expect(stateRef.current.loading).toBe(true);
+    expect(stateRef.current.sessions).toEqual([]);
+  });
+
+  it("sets empty sessions when extractToolText returns null", async () => {
+    const ipcCallFn = async () => ({ content: [] });
+
+    const { stateRef } = mount({
+      ipcCallFn: ipcCallFn as UseClaudeSessionsOptions["ipcCallFn"],
+    });
+
+    await flush();
+    expect(stateRef.current.sessions).toEqual([]);
+    expect(stateRef.current.loading).toBe(false);
+  });
+
+  it("cancelled flag prevents setState after unmount", async () => {
+    const resolveRef: { current: (() => void) | null } = { current: null };
+    const ipcCallFn = async () => {
+      await new Promise<void>((r) => {
+        resolveRef.current = r;
+      });
+      return { content: [{ type: "text", text: "[]" }] };
+    };
+
+    const { instance } = mount({
+      ipcCallFn: ipcCallFn as UseClaudeSessionsOptions["ipcCallFn"],
+    });
+
+    // Unmount while ipcCall is still pending
+    instance.unmount();
+    // Remove from cleanup list since already unmounted
+    instances.pop();
+
+    // Resolve the pending call — cancelled flag should prevent setState
+    resolveRef.current?.();
+    await flush();
+    // Test passes without errors = cancelled flag works correctly
+  });
+
+  it("polls repeatedly at the given interval", async () => {
+    let callCount = 0;
+    const ipcCallFn = async () => {
+      callCount++;
+      return { content: [{ type: "text", text: "[]" }] };
+    };
+
+    mount({
+      intervalMs: 50,
+      ipcCallFn: ipcCallFn as UseClaudeSessionsOptions["ipcCallFn"],
+    });
+
+    await flush(150);
+    expect(callCount).toBeGreaterThanOrEqual(3);
+  });
+
+  it("cleanup clears interval on unmount", async () => {
+    let callCount = 0;
+    const ipcCallFn = async () => {
+      callCount++;
+      return { content: [{ type: "text", text: "[]" }] };
+    };
+
+    const { instance } = mount({
+      intervalMs: 30,
+      ipcCallFn: ipcCallFn as UseClaudeSessionsOptions["ipcCallFn"],
+    });
+
+    await flush(50);
+    instance.unmount();
+    instances.pop();
+    const countAtUnmount = callCount;
+
+    await flush(100);
+    expect(callCount).toBe(countAtUnmount);
+  });
+});

--- a/packages/control/src/hooks/use-claude-sessions.ts
+++ b/packages/control/src/hooks/use-claude-sessions.ts
@@ -9,7 +9,15 @@ interface UseClaudeSessionsResult {
   error: string | null;
 }
 
-export function useClaudeSessions(intervalMs = 2500, enabled = true): UseClaudeSessionsResult {
+export interface UseClaudeSessionsOptions {
+  intervalMs?: number;
+  enabled?: boolean;
+  /** Override ipcCall for testing (dependency injection). */
+  ipcCallFn?: typeof ipcCall;
+}
+
+export function useClaudeSessions(opts: UseClaudeSessionsOptions = {}): UseClaudeSessionsResult {
+  const { intervalMs = 2500, enabled = true, ipcCallFn = ipcCall } = opts;
   const [sessions, setSessions] = useState<SessionInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -22,7 +30,7 @@ export function useClaudeSessions(intervalMs = 2500, enabled = true): UseClaudeS
     async function poll() {
       if (cancelled) return;
       try {
-        const result = await ipcCall("callTool", {
+        const result = await ipcCallFn("callTool", {
           server: "_claude",
           tool: "claude_session_list",
           arguments: {},
@@ -54,7 +62,7 @@ export function useClaudeSessions(intervalMs = 2500, enabled = true): UseClaudeS
       cancelled = true;
       clearInterval(id);
     };
-  }, [intervalMs, enabled]);
+  }, [intervalMs, enabled, ipcCallFn]);
 
   return { sessions, loading, error };
 }


### PR DESCRIPTION
## Summary
- Add `ink-testing-library` as devDependency for testing Ink components/hooks
- Write 7 tests for `useClaudeSessions` hook covering mount polling, error handling, `enabled=false`, empty content, cancelled flag (the #237 fix), repeated polling, and cleanup on unmount
- Refactor `useClaudeSessions` to accept an options object with optional `ipcCallFn` for dependency injection (avoids `mock.module()` per project rules)

## Test plan
- [x] All 7 new tests pass (`bun test packages/control/src/hooks/use-claude-sessions.spec.ts`)
- [x] Full suite passes (1378 tests, 0 failures)
- [x] `use-claude-sessions.ts` at 100% function and line coverage
- [x] Typecheck clean, lint clean
- [x] Coverage ratchet passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)