### PR TITLE
fix(command): use short timeout for mcx status (fixes #281)

### DIFF
--- a/packages/command/src/index.ts
+++ b/packages/command/src/index.ts
@@ -15,7 +15,7 @@
  */
 
 import type { DaemonStatus, ServerStatus } from "@mcp-cli/core";
-import { IpcCallError, ProtocolMismatchError, VERSION } from "@mcp-cli/core";
+import { IpcCallError, PING_TIMEOUT_MS, ProtocolMismatchError, VERSION } from "@mcp-cli/core";
 import { cmdAdd, cmdAddJson } from "./commands/add";
 import { cmdAlias } from "./commands/alias";
 import { cmdClaude } from "./commands/claude";
@@ -399,7 +399,9 @@ async function cmdGrep(args: string[]): Promise<void> {
 
 async function cmdStatus(args: string[] = []): Promise<void> {
   const { json } = extractJsonFlag(args);
-  const status = await ipcCall("status");
+  // Use a short timeout — status reads in-memory state and must return immediately.
+  // The default 60s IPC timeout would cause mcx status to hang if the daemon is slow.
+  const status = await ipcCall("status", undefined, { timeoutMs: PING_TIMEOUT_MS });
 
   if (json) {
     console.log(JSON.stringify(status, null, 2));


### PR DESCRIPTION
## Summary
- `mcx status` was using the default 60-second IPC timeout, causing it to block for the full timeout if the daemon's event loop was under load (e.g., during server connection retries)
- Switched to `PING_TIMEOUT_MS` (5s) since the status handler reads only in-memory daemon state and should always respond in milliseconds
- Disconnected servers now show as disconnected immediately rather than after the full 60s timeout

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (1371 tests, all coverage thresholds met)
- [x] The change is minimal and targeted — only `cmdStatus()` timeout is affected; all other IPC calls retain the 60s timeout needed for slow stdio servers

🤖 Generated with [Claude Code](https://claude.com/claude-code)