### PR TITLE
fix(daemon): use URL-based Worker paths for compiled binary support (fixes #259)

### DIFF
--- a/packages/daemon/src/alias-server.ts
+++ b/packages/daemon/src/alias-server.ts
@@ -5,7 +5,6 @@
  * WorkerClientTransport, and provides the client for injection into ServerPool.
  */
 
-import { join } from "node:path";
 import type { JsonSchema, ToolInfo } from "@mcp-cli/core";
 import { formatToolSignature } from "@mcp-cli/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -32,7 +31,7 @@ export class AliasServer {
   async start(): Promise<{ client: Client; transport: WorkerClientTransport }> {
     const aliases = this.buildAliasDefs();
 
-    this.worker = new Worker(join(import.meta.dir, "alias-server-worker.ts"));
+    this.worker = new Worker(new URL("./alias-server-worker.ts", import.meta.url));
     this.transport = new WorkerClientTransport(this.worker);
     this.client = new Client({ name: `mcp-cli/${ALIAS_SERVER_NAME}`, version: "0.1.0" });
 

--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -9,7 +9,6 @@
  * Follows the same pattern as AliasServer (alias-server.ts).
  */
 
-import { join } from "node:path";
 import type { JsonSchema, ToolInfo } from "@mcp-cli/core";
 import { formatToolSignature } from "@mcp-cli/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -105,7 +104,7 @@ export class ClaudeServer {
   /** Start the worker and connect the MCP client. */
   async start(): Promise<{ client: Client; transport: WorkerClientTransport }> {
     this.stopped = false;
-    const worker = new Worker(join(import.meta.dir, "claude-session-worker.ts"));
+    const worker = new Worker(new URL("./claude-session-worker.ts", import.meta.url));
     this.worker = worker;
 
     // Wait for the worker to report ready with its WS port

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -5,7 +5,6 @@
  */
 
 import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
 import type { IpcError, IpcMethod, IpcRequest, IpcResponse, LiveSpan, ResolvedConfig } from "@mcp-cli/core";
 import {
   CallToolParamsSchema,
@@ -582,7 +581,7 @@ interface AliasMetadata {
 /** Extract metadata from a defineAlias script using a Bun Worker */
 function extractAliasMetadata(aliasPath: string): Promise<AliasMetadata> {
   return new Promise((resolve, reject) => {
-    const worker = new Worker(join(import.meta.dir, "alias-worker.ts"));
+    const worker = new Worker(new URL("./alias-worker.ts", import.meta.url));
     const timeout = setTimeout(() => {
       worker.terminate();
       reject(new Error("Alias metadata extraction timed out"));


### PR DESCRIPTION
## Summary
- Replace `new Worker(join(import.meta.dir, "..."))` with `new Worker(new URL("./...", import.meta.url))` at all 3 Worker creation sites (`claude-server.ts`, `alias-server.ts`, `ipc-server.ts`)
- Bun's compiler statically analyzes the `new URL()` pattern and embeds worker source in compiled binaries, fixing the `/$bunfs/root/` virtual FS resolution failure
- Remove now-unused `join` imports from `node:path`

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes  
- [x] All 1378 tests pass
- [x] Coverage thresholds met
- [ ] Manual: `bun build` then verify `dist/mcpd` starts workers (claude sessions, alias server, alias metadata extraction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)