### PR TITLE
feat(daemon): add Prometheus /metrics endpoint (fixes #70)

### DIFF
--- a/packages/command/src/index.ts
+++ b/packages/command/src/index.ts
@@ -14,7 +14,7 @@
  *   mcx status                                   # daemon status
  */
 
-import type { DaemonStatus, ServerStatus } from "@mcp-cli/core";
+import type { DaemonStatus, MetricsSnapshot, ServerStatus } from "@mcp-cli/core";
 import { IpcCallError, PING_TIMEOUT_MS, ProtocolMismatchError, VERSION } from "@mcp-cli/core";
 import { cmdAdd, cmdAddJson } from "./commands/add";
 import { cmdAlias } from "./commands/alias";
@@ -135,6 +135,10 @@ async function main(): Promise<void> {
 
       case "status":
         await cmdStatus(args.slice(1));
+        break;
+
+      case "metrics":
+        await cmdMetrics(args.slice(1));
         break;
 
       case "config":
@@ -413,6 +417,55 @@ async function cmdStatus(args: string[] = []): Promise<void> {
   }
 }
 
+async function cmdMetrics(args: string[] = []): Promise<void> {
+  const { json } = extractJsonFlag(args);
+  const snap = await ipcCall("getMetrics", undefined, { timeoutMs: PING_TIMEOUT_MS });
+
+  if (json) {
+    console.log(JSON.stringify(snap, null, 2));
+    return;
+  }
+
+  // Human-readable summary
+  if (snap.gauges.length > 0) {
+    console.log("Gauges:");
+    for (const g of snap.gauges) {
+      const labels = formatMetricLabels(g.labels);
+      console.log(`  ${g.name}${labels} = ${g.value}`);
+    }
+    console.log();
+  }
+
+  if (snap.counters.length > 0) {
+    console.log("Counters:");
+    for (const c of snap.counters) {
+      const labels = formatMetricLabels(c.labels);
+      console.log(`  ${c.name}${labels} = ${c.value}`);
+    }
+    console.log();
+  }
+
+  if (snap.histograms.length > 0) {
+    console.log("Histograms:");
+    for (const h of snap.histograms) {
+      const labels = formatMetricLabels(h.labels);
+      const avg = h.count > 0 ? (h.sum / h.count).toFixed(1) : "0";
+      console.log(`  ${h.name}${labels}  count=${h.count} sum=${h.sum.toFixed(1)}ms avg=${avg}ms`);
+    }
+    console.log();
+  }
+
+  if (snap.counters.length === 0 && snap.gauges.length === 0 && snap.histograms.length === 0) {
+    console.log("No metrics collected yet.");
+  }
+}
+
+function formatMetricLabels(labels: Record<string, string>): string {
+  const entries = Object.entries(labels);
+  if (entries.length === 0) return "";
+  return `{${entries.map(([k, v]) => `${k}="${v}"`).join(",")}}`;
+}
+
 async function cmdAuth(args: string[]): Promise<void> {
   if (args.length < 1) {
     printError("Usage: mcx auth <server>");
@@ -516,6 +569,8 @@ Usage:
   mcx config get <server>             Inspect a server's config (env, args, url)
   mcx config set <srv> env <K>:<V>    Set an env var on a stdio server
   mcx status                          Daemon status
+  mcx metrics                         Show daemon metrics (Prometheus-style)
+  mcx metrics -j                      Metrics as JSON
   mcx mail -s "subject" <recipient>   Send a message (body from stdin)
   mcx mail -H                        List message headers
   mcx mail -u <user>                 Read a user's mailbox

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -33,7 +33,8 @@ export type IpcMethod =
   | "waitForMail"
   | "replyToMail"
   | "markRead"
-  | "reloadConfig";
+  | "reloadConfig"
+  | "getMetrics";
 
 // -- Request/Response --
 
@@ -287,6 +288,19 @@ export interface ShutdownResult {
   ok: true;
 }
 
+export interface MetricsSnapshot {
+  collectedAt: number;
+  counters: Array<{ name: string; labels: Record<string, string>; value: number }>;
+  gauges: Array<{ name: string; labels: Record<string, string>; value: number }>;
+  histograms: Array<{
+    name: string;
+    labels: Record<string, string>;
+    count: number;
+    sum: number;
+    buckets: Array<{ le: number; count: number }>;
+  }>;
+}
+
 // -- Method → Result type map --
 
 export interface IpcMethodResult {
@@ -313,6 +327,7 @@ export interface IpcMethodResult {
   replyToMail: ReplyToMailResult;
   markRead: Record<string, never>;
   reloadConfig: ReloadConfigResult;
+  getMetrics: MetricsSnapshot;
 }
 
 // -- Error codes --

--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -15,6 +15,7 @@ import { formatToolSignature } from "@mcp-cli/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { CLAUDE_TOOLS } from "./claude-session/tools";
 import type { StateDb } from "./db/state";
+import { metrics } from "./metrics";
 import { WorkerClientTransport } from "./worker-transport";
 
 export const CLAUDE_SERVER_NAME = "_claude";
@@ -51,12 +52,26 @@ interface DbEnd {
   sessionId: string;
 }
 
+interface DbMetric {
+  type: "metrics:inc";
+  name: string;
+  labels?: Record<string, string>;
+  value?: number;
+}
+
+interface DbHistogram {
+  type: "metrics:observe";
+  name: string;
+  labels?: Record<string, string>;
+  value: number;
+}
+
 interface ReadyMessage {
   type: "ready";
   port: number;
 }
 
-type WorkerEvent = DbUpsert | DbState | DbCost | DbEnd | ReadyMessage;
+type WorkerEvent = DbUpsert | DbState | DbCost | DbEnd | DbMetric | DbHistogram | ReadyMessage;
 
 function isWorkerEvent(data: unknown): data is WorkerEvent {
   return typeof data === "object" && data !== null && "type" in data && !("jsonrpc" in data);
@@ -235,16 +250,26 @@ export class ClaudeServer {
       case "db:upsert":
         this.activeSessions.add(event.session.sessionId);
         this.db.upsertSession(event.session);
+        metrics.gauge("mcpd_active_sessions").set(this.activeSessions.size);
+        metrics.counter("mcpd_sessions_total").inc();
         break;
       case "db:state":
         this.db.updateSessionState(event.sessionId, event.state);
         break;
       case "db:cost":
         this.db.updateSessionCost(event.sessionId, event.cost, event.tokens);
+        metrics.counter("mcpd_session_cost_usd").inc(event.cost);
         break;
       case "db:end":
         this.activeSessions.delete(event.sessionId);
         this.db.endSession(event.sessionId);
+        metrics.gauge("mcpd_active_sessions").set(this.activeSessions.size);
+        break;
+      case "metrics:inc":
+        metrics.counter(event.name, event.labels).inc(event.value ?? 1);
+        break;
+      case "metrics:observe":
+        metrics.histogram(event.name, event.labels).observe(event.value);
         break;
     }
   }

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -30,6 +30,7 @@ import { ConfigWatcher } from "./config/watcher";
 import { closeDaemonLogFile, installDaemonLogCapture, installDaemonLogFile } from "./daemon-log";
 import { StateDb } from "./db/state";
 import { IpcServer } from "./ipc-server";
+import { metrics } from "./metrics";
 import { ServerPool } from "./server-pool";
 
 async function main(): Promise<void> {
@@ -92,6 +93,20 @@ async function main(): Promise<void> {
     pool.registerVirtualServer("_claude", client, transport, claudeTools);
     console.error(`[mcpd] Claude session server re-registered after crash recovery (port ${claudeServer.port})`);
   };
+
+  // Register uptime and server metrics
+  const uptimeGauge = metrics.gauge("mcpd_uptime_seconds");
+  const serversTotal = metrics.gauge("mcpd_servers_total");
+  const serversConnected = metrics.gauge("mcpd_servers_connected");
+  serversTotal.set(config.servers.size);
+
+  // Update uptime and server gauges periodically
+  const metricsInterval = setInterval(() => {
+    uptimeGauge.set(Math.round(process.uptime()));
+    const servers = pool.listServers();
+    serversTotal.set(servers.length);
+    serversConnected.set(servers.filter((s) => s.state === "connected").length);
+  }, 5_000);
 
   // Idle timeout management with in-flight request tracking
   const idleTimeoutMs = Number(process.env.MCP_DAEMON_TIMEOUT) || DAEMON_IDLE_TIMEOUT_MS;
@@ -163,6 +178,7 @@ async function main(): Promise<void> {
   // Graceful shutdown
   async function shutdown(): Promise<void> {
     console.error("[mcpd] Shutting down...");
+    clearInterval(metricsInterval);
     watcher.stop();
     ipcServer.stop();
     await claudeServer.stop();

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -6,6 +6,7 @@ import type { IpcResponse } from "@mcp-cli/core";
 import { IPC_ERROR, PROTOCOL_VERSION } from "@mcp-cli/core";
 import { installDaemonLogCapture } from "./daemon-log";
 import { IpcServer } from "./ipc-server";
+import { metrics } from "./metrics";
 
 // Install daemon log capture so getDaemonLogs handler works
 installDaemonLogCapture();
@@ -858,6 +859,114 @@ describe("IpcServer HTTP transport", () => {
 
     expect(json.error?.message).toBe("string error");
     expect(json.error?.stack).toBeUndefined();
+  });
+
+  // -- Metrics tests --
+
+  test("GET /metrics returns prometheus text format", async () => {
+    startServer();
+
+    // Make a ping call first to generate some metrics
+    await rpc("/rpc", { id: "m1", method: "ping" });
+
+    const res = await fetch("http://localhost/metrics", {
+      method: "GET",
+      unix: socketPath,
+    } as RequestInit);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/plain");
+
+    const text = await res.text();
+    // Should have IPC request metrics from the ping call
+    expect(text).toContain("mcpd_ipc_requests_total");
+    expect(text).toContain("mcpd_ipc_request_duration_ms");
+  });
+
+  test("getMetrics returns structured JSON snapshot", async () => {
+    startServer();
+
+    // Generate some metrics via a ping
+    await rpc("/rpc", { id: "gm0", method: "ping" });
+
+    const res = await rpc("/rpc", { id: "gm1", method: "getMetrics" });
+    expect(res.status).toBe(200);
+
+    const json = (await res.json()) as IpcResponse;
+    expect(json.error).toBeUndefined();
+
+    const snap = json.result as {
+      collectedAt: number;
+      counters: Array<{ name: string; labels: Record<string, string>; value: number }>;
+      gauges: Array<{ name: string; labels: Record<string, string>; value: number }>;
+      histograms: Array<{ name: string; labels: Record<string, string>; count: number; sum: number }>;
+    };
+
+    expect(snap.collectedAt).toBeGreaterThan(0);
+    expect(Array.isArray(snap.counters)).toBe(true);
+    expect(Array.isArray(snap.gauges)).toBe(true);
+    expect(Array.isArray(snap.histograms)).toBe(true);
+
+    // Should have ping-related IPC metrics
+    const pingCounter = snap.counters.find((c) => c.name === "mcpd_ipc_requests_total" && c.labels.method === "ping");
+    expect(pingCounter).toBeDefined();
+    expect(pingCounter?.value).toBeGreaterThanOrEqual(1);
+  });
+
+  test("callTool records tool metrics", async () => {
+    metrics.reset();
+    startServer();
+
+    // Call a tool
+    await rpc("/rpc", { id: "tm1", method: "callTool", params: { server: "s", tool: "t", arguments: {} } });
+
+    const res = await rpc("/rpc", { id: "tm2", method: "getMetrics" });
+    const json = (await res.json()) as IpcResponse;
+    const snap = json.result as {
+      counters: Array<{ name: string; labels: Record<string, string>; value: number }>;
+      histograms: Array<{ name: string; labels: Record<string, string>; count: number }>;
+    };
+
+    const toolCounter = snap.counters.find(
+      (c) => c.name === "mcpd_tool_calls_total" && c.labels.server === "s" && c.labels.tool === "t",
+    );
+    expect(toolCounter).toBeDefined();
+    expect(toolCounter?.value).toBe(1);
+
+    const toolHistogram = snap.histograms.find(
+      (h) => h.name === "mcpd_tool_call_duration_ms" && h.labels.server === "s" && h.labels.tool === "t",
+    );
+    expect(toolHistogram).toBeDefined();
+    expect(toolHistogram?.count).toBe(1);
+  });
+
+  test("failed callTool records error metrics", async () => {
+    metrics.reset();
+    socketPath = tmpSocket();
+    const failPool = {
+      ...mockPool(),
+      callTool: async () => {
+        throw new Error("tool failed");
+      },
+    };
+    server = new IpcServer(failPool as never, mockConfig(), mockDb(), null, {
+      onActivity: () => {},
+    });
+    server.start(socketPath);
+
+    await rpc("/rpc", { id: "em1", method: "callTool", params: { server: "s", tool: "t", arguments: {} } });
+
+    const res = await rpc("/rpc", { id: "em2", method: "getMetrics" });
+    const json = (await res.json()) as IpcResponse;
+    const snap = json.result as {
+      counters: Array<{ name: string; labels: Record<string, string>; value: number }>;
+    };
+
+    const errorCounter = snap.counters.find(
+      (c) => c.name === "mcpd_tool_errors_total" && c.labels.server === "s" && c.labels.tool === "t",
+    );
+    expect(errorCounter).toBeDefined();
+    expect(errorCounter?.value).toBe(1);
   });
 
   test("getConfig returns server info with correct transport and toolCount", async () => {

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -38,6 +38,7 @@ import { startCallbackServer } from "./auth/callback-server";
 import { McpOAuthProvider } from "./auth/oauth-provider";
 import { getDaemonLogLines } from "./daemon-log";
 import type { StateDb } from "./db/state";
+import { metrics } from "./metrics";
 import type { ServerPool } from "./server-pool";
 
 type RequestHandler = (params: unknown) => Promise<unknown>;
@@ -91,11 +92,19 @@ export class IpcServer {
     this.server = Bun.serve({
       unix: socketPath,
       async fetch(req) {
+        const url = new URL(req.url);
+
+        // GET /metrics — Prometheus text exposition format
+        if (url.pathname === "/metrics" && req.method === "GET") {
+          return new Response(metrics.toPrometheusText(), {
+            headers: { "content-type": "text/plain; version=0.0.4; charset=utf-8" },
+          });
+        }
+
         if (req.method !== "POST") {
           return new Response("Method Not Allowed", { status: 405 });
         }
 
-        const url = new URL(req.url);
         if (url.pathname !== "/rpc") {
           return new Response("Not Found", { status: 404 });
         }
@@ -155,7 +164,20 @@ export class IpcServer {
         code: IPC_ERROR.METHOD_NOT_FOUND,
       });
     }
-    return handler(request.params);
+
+    const labels = { method: request.method };
+    metrics.counter("mcpd_ipc_requests_total", labels).inc();
+    const stopTimer = metrics.histogram("mcpd_ipc_request_duration_ms", labels).startTimer();
+
+    try {
+      const result = await handler(request.params);
+      return result;
+    } catch (err) {
+      metrics.counter("mcpd_ipc_errors_total", labels).inc();
+      throw err;
+    } finally {
+      stopTimer();
+    }
   }
 
   // -- Handler registration --
@@ -207,13 +229,21 @@ export class IpcServer {
 
     this.handlers.set("callTool", async (params) => {
       const { server, tool, arguments: args } = CallToolParamsSchema.parse(params);
+      const toolLabels = { server, tool };
       const start = Date.now();
       try {
         const result = await this.pool.callTool(server, tool, args);
-        this.db.recordUsage(server, tool, Date.now() - start, true);
+        const durationMs = Date.now() - start;
+        this.db.recordUsage(server, tool, durationMs, true);
+        metrics.counter("mcpd_tool_calls_total", toolLabels).inc();
+        metrics.histogram("mcpd_tool_call_duration_ms", toolLabels).observe(durationMs);
         return result;
       } catch (err) {
-        this.db.recordUsage(server, tool, Date.now() - start, false, err instanceof Error ? err.message : String(err));
+        const durationMs = Date.now() - start;
+        this.db.recordUsage(server, tool, durationMs, false, err instanceof Error ? err.message : String(err));
+        metrics.counter("mcpd_tool_calls_total", toolLabels).inc();
+        metrics.counter("mcpd_tool_errors_total", toolLabels).inc();
+        metrics.histogram("mcpd_tool_call_duration_ms", toolLabels).observe(durationMs);
         throw err;
       }
     });
@@ -457,6 +487,10 @@ export class IpcServer {
       }
       await this.onReloadConfig();
       return { ok: true };
+    });
+
+    this.handlers.set("getMetrics", async () => {
+      return metrics.toJSON();
     });
 
     this.handlers.set("shutdown", async () => {

--- a/packages/daemon/src/metrics.spec.ts
+++ b/packages/daemon/src/metrics.spec.ts
@@ -1,0 +1,237 @@
+import { describe, expect, test } from "bun:test";
+import { MetricsCollector } from "./metrics";
+
+describe("MetricsCollector", () => {
+  // -- Counter --
+
+  test("counter starts at 0", () => {
+    const m = new MetricsCollector();
+    expect(m.counter("requests").value()).toBe(0);
+  });
+
+  test("counter inc() increments by 1", () => {
+    const m = new MetricsCollector();
+    const c = m.counter("requests");
+    c.inc();
+    c.inc();
+    expect(c.value()).toBe(2);
+  });
+
+  test("counter inc(n) increments by n", () => {
+    const m = new MetricsCollector();
+    const c = m.counter("requests");
+    c.inc(5);
+    expect(c.value()).toBe(5);
+  });
+
+  test("counter with same name and labels returns same instance", () => {
+    const m = new MetricsCollector();
+    const c1 = m.counter("requests", { server: "a" });
+    c1.inc(3);
+    const c2 = m.counter("requests", { server: "a" });
+    expect(c2.value()).toBe(3);
+    c2.inc(2);
+    expect(c1.value()).toBe(5);
+  });
+
+  test("counter with different labels are independent", () => {
+    const m = new MetricsCollector();
+    const c1 = m.counter("requests", { server: "a" });
+    const c2 = m.counter("requests", { server: "b" });
+    c1.inc(10);
+    c2.inc(3);
+    expect(c1.value()).toBe(10);
+    expect(c2.value()).toBe(3);
+  });
+
+  // -- Gauge --
+
+  test("gauge starts at 0", () => {
+    const m = new MetricsCollector();
+    expect(m.gauge("connections").value()).toBe(0);
+  });
+
+  test("gauge set() replaces value", () => {
+    const m = new MetricsCollector();
+    const g = m.gauge("connections");
+    g.set(42);
+    expect(g.value()).toBe(42);
+    g.set(0);
+    expect(g.value()).toBe(0);
+  });
+
+  test("gauge inc()/dec() modify value", () => {
+    const m = new MetricsCollector();
+    const g = m.gauge("connections");
+    g.inc();
+    g.inc();
+    g.dec();
+    expect(g.value()).toBe(1);
+    g.inc(5);
+    g.dec(3);
+    expect(g.value()).toBe(3);
+  });
+
+  // -- Histogram --
+
+  test("histogram observe tracks count and sum", () => {
+    const m = new MetricsCollector();
+    const h = m.histogram("latency", undefined, [10, 50, 100]);
+    h.observe(5);
+    h.observe(25);
+    h.observe(75);
+
+    const snap = m.toJSON();
+    const hist = snap.histograms[0];
+    expect(hist.count).toBe(3);
+    expect(hist.sum).toBe(105);
+  });
+
+  test("histogram buckets accumulate correctly", () => {
+    const m = new MetricsCollector();
+    const h = m.histogram("latency", undefined, [10, 50, 100]);
+    h.observe(5); // <= 10, <= 50, <= 100
+    h.observe(25); // <= 50, <= 100
+    h.observe(75); // <= 100
+    h.observe(200); // none (only +Inf)
+
+    const snap = m.toJSON();
+    const hist = snap.histograms[0];
+    // le=10: 1, le=50: 2, le=100: 3
+    expect(hist.buckets).toEqual([
+      { le: 10, count: 1 },
+      { le: 50, count: 2 },
+      { le: 100, count: 3 },
+    ]);
+  });
+
+  test("histogram startTimer observes elapsed ms", async () => {
+    const m = new MetricsCollector();
+    const h = m.histogram("latency", undefined, [100, 500]);
+    const stop = h.startTimer();
+    await Bun.sleep(10);
+    const elapsed = stop();
+
+    expect(elapsed).toBeGreaterThan(5);
+    const snap = m.toJSON();
+    expect(snap.histograms[0].count).toBe(1);
+    expect(snap.histograms[0].sum).toBeGreaterThan(5);
+  });
+
+  // -- Type conflicts --
+
+  test("reusing name with different type throws", () => {
+    const m = new MetricsCollector();
+    m.counter("metric_a");
+    expect(() => m.gauge("metric_a")).toThrow("already registered as counter");
+  });
+
+  // -- Label deduplication --
+
+  test("labels sorted for consistent keys regardless of insertion order", () => {
+    const m = new MetricsCollector();
+    const c1 = m.counter("x", { b: "2", a: "1" });
+    c1.inc(7);
+    const c2 = m.counter("x", { a: "1", b: "2" });
+    expect(c2.value()).toBe(7);
+  });
+
+  // -- Prometheus text format --
+
+  test("counter renders as prometheus text", () => {
+    const m = new MetricsCollector();
+    m.counter("http_requests", { method: "GET" }).inc(42);
+
+    const text = m.toPrometheusText();
+    expect(text).toContain("# TYPE http_requests counter");
+    expect(text).toContain('http_requests{method="GET"} 42');
+  });
+
+  test("gauge renders as prometheus text", () => {
+    const m = new MetricsCollector();
+    m.gauge("active_sessions").set(3);
+
+    const text = m.toPrometheusText();
+    expect(text).toContain("# TYPE active_sessions gauge");
+    expect(text).toContain("active_sessions 3");
+  });
+
+  test("histogram renders buckets, count, and sum", () => {
+    const m = new MetricsCollector();
+    const h = m.histogram("latency_ms", { server: "a" }, [10, 50]);
+    h.observe(5);
+    h.observe(30);
+
+    const text = m.toPrometheusText();
+    expect(text).toContain("# TYPE latency_ms histogram");
+    expect(text).toContain('latency_ms_bucket{server="a",le="10"} 1');
+    expect(text).toContain('latency_ms_bucket{server="a",le="50"} 2');
+    expect(text).toContain('latency_ms_bucket{server="a",le="+Inf"} 2');
+    expect(text).toContain('latency_ms_count{server="a"} 2');
+    expect(text).toContain('latency_ms_sum{server="a"} 35');
+  });
+
+  test("dots in metric names are replaced with underscores", () => {
+    const m = new MetricsCollector();
+    m.counter("mcpd.ipc.requests").inc();
+
+    const text = m.toPrometheusText();
+    expect(text).toContain("mcpd_ipc_requests");
+    expect(text).not.toContain("mcpd.ipc.requests");
+  });
+
+  test("no labels renders without braces", () => {
+    const m = new MetricsCollector();
+    m.counter("total").inc(1);
+
+    const text = m.toPrometheusText();
+    expect(text).toContain("total 1");
+    expect(text).not.toContain("total{");
+  });
+
+  test("prometheus text ends with trailing newline", () => {
+    const m = new MetricsCollector();
+    m.counter("x").inc();
+
+    const text = m.toPrometheusText();
+    expect(text.endsWith("\n")).toBe(true);
+  });
+
+  test("empty collector produces empty string", () => {
+    const m = new MetricsCollector();
+    expect(m.toPrometheusText()).toBe("");
+  });
+
+  // -- JSON snapshot --
+
+  test("toJSON returns structured snapshot", () => {
+    const m = new MetricsCollector();
+    m.counter("c", { a: "1" }).inc(5);
+    m.gauge("g").set(42);
+    m.histogram("h", undefined, [10]).observe(7);
+
+    const snap = m.toJSON();
+    expect(snap.collectedAt).toBeGreaterThan(0);
+    expect(snap.counters).toEqual([{ name: "c", labels: { a: "1" }, value: 5 }]);
+    expect(snap.gauges).toEqual([{ name: "g", labels: {}, value: 42 }]);
+    expect(snap.histograms).toHaveLength(1);
+    expect(snap.histograms[0].name).toBe("h");
+    expect(snap.histograms[0].count).toBe(1);
+    expect(snap.histograms[0].sum).toBe(7);
+  });
+
+  // -- Reset --
+
+  test("reset clears all metrics and type registry", () => {
+    const m = new MetricsCollector();
+    m.counter("a").inc();
+    m.gauge("b").set(1);
+    m.reset();
+
+    expect(m.toJSON().counters).toEqual([]);
+    expect(m.toJSON().gauges).toEqual([]);
+    // After reset, name can be reused with different type
+    m.gauge("a").set(5);
+    expect(m.gauge("a").value()).toBe(5);
+  });
+});

--- a/packages/daemon/src/metrics.ts
+++ b/packages/daemon/src/metrics.ts
@@ -1,0 +1,281 @@
+/**
+ * Lightweight Prometheus-style metrics collector.
+ *
+ * Zero external dependencies. Counters, gauges, and histograms with label support.
+ * Serializes to Prometheus text exposition format or JSON for IPC consumption.
+ */
+
+// -- Public types --
+
+export type Labels = Record<string, string>;
+
+export interface Counter {
+  inc(n?: number): void;
+  value(): number;
+}
+
+export interface Gauge {
+  set(n: number): void;
+  inc(n?: number): void;
+  dec(n?: number): void;
+  value(): number;
+}
+
+export interface Histogram {
+  observe(value: number): void;
+  /** Start a timer; call the returned function to observe elapsed ms. */
+  startTimer(): () => number;
+}
+
+export interface MetricsSnapshot {
+  collectedAt: number;
+  counters: Array<{ name: string; labels: Labels; value: number }>;
+  gauges: Array<{ name: string; labels: Labels; value: number }>;
+  histograms: Array<{
+    name: string;
+    labels: Labels;
+    count: number;
+    sum: number;
+    buckets: Array<{ le: number; count: number }>;
+  }>;
+}
+
+// -- Internal types --
+
+type MetricType = "counter" | "gauge" | "histogram";
+
+interface CounterEntry {
+  type: "counter";
+  value: number;
+}
+
+interface GaugeEntry {
+  type: "gauge";
+  value: number;
+}
+
+interface HistogramEntry {
+  type: "histogram";
+  bucketBounds: number[];
+  bucketCounts: number[];
+  count: number;
+  sum: number;
+}
+
+type MetricEntry = CounterEntry | GaugeEntry | HistogramEntry;
+
+// -- Series key --
+
+/** Canonical series key: "name|k1=v1,k2=v2" with sorted labels. */
+function seriesKey(name: string, labels?: Labels): string {
+  if (!labels || Object.keys(labels).length === 0) return name;
+  const sorted = Object.keys(labels)
+    .sort()
+    .map((k) => `${k}=${labels[k]}`)
+    .join(",");
+  return `${name}|${sorted}`;
+}
+
+function parseSeriesKey(key: string): { name: string; labels: Labels } {
+  const pipe = key.indexOf("|");
+  if (pipe === -1) return { name: key, labels: {} };
+  const name = key.slice(0, pipe);
+  const labels: Labels = {};
+  for (const pair of key.slice(pipe + 1).split(",")) {
+    const eq = pair.indexOf("=");
+    if (eq > 0) labels[pair.slice(0, eq)] = pair.slice(eq + 1);
+  }
+  return { name, labels };
+}
+
+// -- Default histogram buckets (milliseconds) --
+
+const DEFAULT_BUCKETS = [5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000];
+
+// -- MetricsCollector --
+
+export class MetricsCollector {
+  private entries = new Map<string, MetricEntry>();
+  private typeRegistry = new Map<string, MetricType>();
+
+  private assertType(name: string, expected: MetricType): void {
+    const existing = this.typeRegistry.get(name);
+    if (existing && existing !== expected) {
+      throw new Error(`Metric "${name}" already registered as ${existing}, cannot use as ${expected}`);
+    }
+    this.typeRegistry.set(name, expected);
+  }
+
+  counter(name: string, labels?: Labels): Counter {
+    this.assertType(name, "counter");
+    const key = seriesKey(name, labels);
+    let entry = this.entries.get(key) as CounterEntry | undefined;
+    if (!entry) {
+      entry = { type: "counter", value: 0 };
+      this.entries.set(key, entry);
+    }
+    return {
+      inc(n = 1) {
+        entry.value += n;
+      },
+      value() {
+        return entry.value;
+      },
+    };
+  }
+
+  gauge(name: string, labels?: Labels): Gauge {
+    this.assertType(name, "gauge");
+    const key = seriesKey(name, labels);
+    let entry = this.entries.get(key) as GaugeEntry | undefined;
+    if (!entry) {
+      entry = { type: "gauge", value: 0 };
+      this.entries.set(key, entry);
+    }
+    return {
+      set(n: number) {
+        entry.value = n;
+      },
+      inc(n = 1) {
+        entry.value += n;
+      },
+      dec(n = 1) {
+        entry.value -= n;
+      },
+      value() {
+        return entry.value;
+      },
+    };
+  }
+
+  histogram(name: string, labels?: Labels, buckets?: number[]): Histogram {
+    this.assertType(name, "histogram");
+    const key = seriesKey(name, labels);
+    let entry = this.entries.get(key) as HistogramEntry | undefined;
+    if (!entry) {
+      const bounds = buckets ?? DEFAULT_BUCKETS;
+      entry = {
+        type: "histogram",
+        bucketBounds: bounds,
+        bucketCounts: new Array(bounds.length + 1).fill(0), // +1 for +Inf
+        count: 0,
+        sum: 0,
+      };
+      this.entries.set(key, entry);
+    }
+    return {
+      observe(value: number) {
+        entry.count++;
+        entry.sum += value;
+        // Increment all buckets where value <= bound
+        for (let i = 0; i < entry.bucketBounds.length; i++) {
+          if (value <= entry.bucketBounds[i]) {
+            entry.bucketCounts[i]++;
+          }
+        }
+        // +Inf bucket always incremented
+        entry.bucketCounts[entry.bucketBounds.length]++;
+      },
+      startTimer() {
+        const start = performance.now();
+        return () => {
+          const elapsed = performance.now() - start;
+          entry.count++;
+          entry.sum += elapsed;
+          for (let i = 0; i < entry.bucketBounds.length; i++) {
+            if (elapsed <= entry.bucketBounds[i]) {
+              entry.bucketCounts[i]++;
+            }
+          }
+          entry.bucketCounts[entry.bucketBounds.length]++;
+          return elapsed;
+        };
+      },
+    };
+  }
+
+  /** Serialize all metrics to Prometheus text exposition format. */
+  toPrometheusText(): string {
+    const lines: string[] = [];
+    const emittedTypes = new Set<string>();
+
+    for (const [key, entry] of this.entries) {
+      const { name, labels } = parseSeriesKey(key);
+      const sanitized = name.replace(/\./g, "_");
+      const labelStr = formatLabels(labels);
+
+      if (!emittedTypes.has(sanitized)) {
+        emittedTypes.add(sanitized);
+        lines.push(`# TYPE ${sanitized} ${entry.type}`);
+      }
+
+      if (entry.type === "counter" || entry.type === "gauge") {
+        lines.push(`${sanitized}${labelStr} ${entry.value}`);
+      } else {
+        // Histogram: emit _bucket, _count, _sum
+        for (let i = 0; i < entry.bucketBounds.length; i++) {
+          const bucketLabels = { ...labels, le: String(entry.bucketBounds[i]) };
+          lines.push(`${sanitized}_bucket${formatLabels(bucketLabels)} ${entry.bucketCounts[i]}`);
+        }
+        lines.push(
+          `${sanitized}_bucket${formatLabels({ ...labels, le: "+Inf" })} ${entry.bucketCounts[entry.bucketBounds.length]}`,
+        );
+        lines.push(`${sanitized}_count${labelStr} ${entry.count}`);
+        lines.push(`${sanitized}_sum${labelStr} ${entry.sum}`);
+      }
+    }
+
+    if (lines.length > 0) lines.push(""); // trailing newline per spec
+    return lines.join("\n");
+  }
+
+  /** Serialize all metrics to a JSON snapshot for IPC consumption. */
+  toJSON(): MetricsSnapshot {
+    const snap: MetricsSnapshot = {
+      collectedAt: Date.now(),
+      counters: [],
+      gauges: [],
+      histograms: [],
+    };
+
+    for (const [key, entry] of this.entries) {
+      const { name, labels } = parseSeriesKey(key);
+
+      if (entry.type === "counter") {
+        snap.counters.push({ name, labels, value: entry.value });
+      } else if (entry.type === "gauge") {
+        snap.gauges.push({ name, labels, value: entry.value });
+      } else {
+        const buckets = entry.bucketBounds.map((le, i) => ({
+          le,
+          count: entry.bucketCounts[i],
+        }));
+        snap.histograms.push({
+          name,
+          labels,
+          count: entry.count,
+          sum: entry.sum,
+          buckets,
+        });
+      }
+    }
+
+    return snap;
+  }
+
+  /** Reset all metrics (primarily for testing). */
+  reset(): void {
+    this.entries.clear();
+    this.typeRegistry.clear();
+  }
+}
+
+function formatLabels(labels: Labels): string {
+  const entries = Object.entries(labels);
+  if (entries.length === 0) return "";
+  return `{${entries.map(([k, v]) => `${k}="${v}"`).join(",")}}`;
+}
+
+// -- Singleton --
+
+export const metrics = new MetricsCollector();


### PR DESCRIPTION
## Summary

- Add lightweight `MetricsCollector` (counters, gauges, histograms) with label support — zero external deps, Prometheus text + JSON serialization
- `GET /metrics` endpoint on the daemon Unix socket — Prometheus text exposition format
- `getMetrics` IPC method — JSON snapshot for CLI/mcpctl consumption
- `mcx metrics` command (human-readable) and `mcx metrics -j` (JSON)
- Instrument: IPC requests, tool calls, active sessions, session cost, server connections, daemon uptime
- Worker→main metric event channel (`metrics:inc`, `metrics:observe` via postMessage) for workers to emit metrics without shared memory

### Metrics exposed

| Metric | Type | Labels |
|--------|------|--------|
| `mcpd_uptime_seconds` | gauge | — |
| `mcpd_servers_total` | gauge | — |
| `mcpd_servers_connected` | gauge | — |
| `mcpd_active_sessions` | gauge | — |
| `mcpd_sessions_total` | counter | — |
| `mcpd_session_cost_usd` | counter | — |
| `mcpd_ipc_requests_total` | counter | method |
| `mcpd_ipc_request_duration_ms` | histogram | method |
| `mcpd_ipc_errors_total` | counter | method |
| `mcpd_tool_calls_total` | counter | server, tool |
| `mcpd_tool_call_duration_ms` | histogram | server, tool |
| `mcpd_tool_errors_total` | counter | server, tool |

### Unblocks

- #34 (mcpctl usage stats) — consumes `getMetrics` IPC
- #93 (mcpctl stats viewer) — same
- #286 (idle timeout bug) — `mcpd_active_sessions` gauge provides observability to diagnose
- #290 (`_metrics` virtual MCP server) — filed as follow-up

## Test plan

- [x] 22 unit tests for MetricsCollector (100% line coverage)
- [x] 4 IPC server tests: GET /metrics, getMetrics handler, tool call metrics, error metrics
- [x] All 1409 tests pass
- [x] Coverage ratchet passes
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)