### PR TITLE
fix(daemon): embed workers in compiled binary (fixes #259)

### DIFF
--- a/packages/daemon/src/alias-server.ts
+++ b/packages/daemon/src/alias-server.ts
@@ -10,6 +10,7 @@ import { formatToolSignature } from "@mcp-cli/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { AliasToolDef } from "./alias-server-worker";
 import type { StateDb } from "./db/state";
+import { workerPath } from "./worker-path";
 import { WorkerClientTransport } from "./worker-transport";
 
 export const ALIAS_SERVER_NAME = "_aliases";
@@ -31,7 +32,7 @@ export class AliasServer {
   async start(): Promise<{ client: Client; transport: WorkerClientTransport }> {
     const aliases = this.buildAliasDefs();
 
-    this.worker = new Worker(new URL("./alias-server-worker.ts", import.meta.url));
+    this.worker = new Worker(workerPath("alias-server-worker.ts"));
     this.transport = new WorkerClientTransport(this.worker);
     this.client = new Client({ name: `mcp-cli/${ALIAS_SERVER_NAME}`, version: "0.1.0" });
 

--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -15,6 +15,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { CLAUDE_TOOLS } from "./claude-session/tools";
 import type { StateDb } from "./db/state";
 import { metrics } from "./metrics";
+import { workerPath } from "./worker-path";
 import { WorkerClientTransport } from "./worker-transport";
 
 export const CLAUDE_SERVER_NAME = "_claude";
@@ -104,7 +105,7 @@ export class ClaudeServer {
   /** Start the worker and connect the MCP client. */
   async start(): Promise<{ client: Client; transport: WorkerClientTransport }> {
     this.stopped = false;
-    const worker = new Worker(new URL("./claude-session-worker.ts", import.meta.url));
+    const worker = new Worker(workerPath("claude-session-worker.ts"));
     this.worker = worker;
 
     // Wait for the worker to report ready with its WS port

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -43,6 +43,7 @@ import { getDaemonLogLines } from "./daemon-log";
 import type { StateDb } from "./db/state";
 import { metrics } from "./metrics";
 import type { ServerPool } from "./server-pool";
+import { workerPath } from "./worker-path";
 
 /** Per-request context passed to every handler (fixes race condition on shared state). */
 export interface RequestContext {
@@ -581,7 +582,7 @@ interface AliasMetadata {
 /** Extract metadata from a defineAlias script using a Bun Worker */
 function extractAliasMetadata(aliasPath: string): Promise<AliasMetadata> {
   return new Promise((resolve, reject) => {
-    const worker = new Worker(new URL("./alias-worker.ts", import.meta.url));
+    const worker = new Worker(workerPath("alias-worker.ts"));
     const timeout = setTimeout(() => {
       worker.terminate();
       reject(new Error("Alias metadata extraction timed out"));

--- a/packages/daemon/src/worker-path.ts
+++ b/packages/daemon/src/worker-path.ts
@@ -1,0 +1,22 @@
+/**
+ * Resolve worker file paths for both dev mode and compiled binaries.
+ *
+ * In compiled binaries (`bun build --compile`), workers are embedded as
+ * additional entrypoints and resolved via relative string paths.
+ * In dev mode, workers are resolved via absolute paths using import.meta.dir.
+ *
+ * Build injects `__COMPILED__ = true` via --define; defaults to false at runtime.
+ */
+
+import { join } from "node:path";
+
+declare const __COMPILED__: boolean;
+const isCompiled = typeof __COMPILED__ !== "undefined" && __COMPILED__;
+
+/** Directory containing worker source files (dev mode only). */
+const WORKER_DIR = import.meta.dir;
+
+/** Resolve a worker filename to a path usable with `new Worker()`. */
+export function workerPath(filename: string): string {
+  return isCompiled ? `./${filename}` : join(WORKER_DIR, filename);
+}

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -19,6 +19,7 @@ const hasher = new Bun.CryptoHasher("sha256");
 hasher.update(ipcSource);
 const protocolHash = hasher.digest("hex").slice(0, 12);
 const defineFlag = `--define=__PROTOCOL_HASH__="${protocolHash}"`;
+const compiledFlag = "--define=__COMPILED__=true";
 console.log(`Protocol hash: ${protocolHash}`);
 
 // ── jq-web build plugin ──
@@ -102,6 +103,13 @@ const devtoolsStubPlugin: BunPlugin = {
 
 await $`mkdir -p dist`;
 
+// mcpd worker entrypoints — must be listed explicitly for bun build --compile
+const daemonWorkers = [
+  "packages/daemon/src/alias-server-worker.ts",
+  "packages/daemon/src/alias-worker.ts",
+  "packages/daemon/src/claude-session-worker.ts",
+];
+
 interface BinaryBuildConfig {
   entrypoint: string;
   bundleName: string;
@@ -164,7 +172,7 @@ if (releaseMode) {
     const suffix = target.replace("bun-", "");
     console.log(`Building for ${suffix}...`);
     await Promise.all([
-      $`bun build --compile --minify ${defineFlag} --target=${target} packages/daemon/src/index.ts --outfile dist/mcpd-${suffix}`,
+      $`bun build --compile --minify ${defineFlag} ${compiledFlag} --target=${target} packages/daemon/src/index.ts ${daemonWorkers} --outfile dist/mcpd-${suffix}`,
       buildBinary(mcxConfig, `dist/mcx-${suffix}`, target),
       buildBinary(mcpctlConfig, `dist/mcpctl-${suffix}`, target),
     ]);
@@ -174,7 +182,7 @@ if (releaseMode) {
 } else {
   // Dev build: current platform, simple names
   await Promise.all([
-    $`bun build --compile --minify ${defineFlag} packages/daemon/src/index.ts --outfile dist/mcpd`,
+    $`bun build --compile --minify ${defineFlag} ${compiledFlag} packages/daemon/src/index.ts ${daemonWorkers} --outfile dist/mcpd`,
     buildBinary(mcxConfig, "dist/mcx"),
     buildBinary(mcpctlConfig, "dist/mcpctl"),
   ]);


### PR DESCRIPTION
## Summary
- Add worker `.ts` files as additional entrypoints to `bun build --compile` so they're embedded in the binary
- Add `workerPath()` helper that uses `"./"` prefix in compiled mode (`__COMPILED__` define) and `join(import.meta.dir, ...)` in dev mode
- Replaces the broken `new URL()` approach from PR #287 which resolved to `/$bunfs/root/` at runtime

## What went wrong with #287
`new URL("./worker.ts", import.meta.url)` resolves to `file:///$bunfs/root/worker.ts` inside a compiled binary. Bun's Worker constructor can't find files at that path. The fix requires **two things**: listing workers as additional entrypoints AND using string paths (not URL objects).

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] All 1472 tests pass, coverage thresholds met
- [x] `bun scripts/build.ts` compiles successfully
- [x] **Compiled `dist/mcpd`** starts alias + claude workers, `mcx status` shows `_claude connected (9 tools)`
- [x] **Dev mode** `bun dev:daemon` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)