### PR TITLE
fix(daemon): intercept /clear and /model in session sendPrompt (fixes #346)

### DIFF
--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -289,6 +289,12 @@ function forwardSessionEvent(sessionId: string, event: SessionEvent): void {
     case "session:ended":
       self.postMessage({ type: "db:end", sessionId });
       break;
+    case "session:cleared":
+      self.postMessage({ type: "db:state", sessionId, state: "connecting" });
+      break;
+    case "session:model_changed":
+      self.postMessage({ type: "db:upsert", session: { sessionId, model: event.model } });
+      break;
   }
 }
 

--- a/packages/daemon/src/claude-session/ndjson.ts
+++ b/packages/daemon/src/claude-session/ndjson.ts
@@ -385,6 +385,15 @@ export function interruptRequest(requestId: string): string {
   });
 }
 
+/** Build a `control_request` for `set_model`. Pass "default" to reset. */
+export function setModelRequest(requestId: string, model: string): string {
+  return serialize({
+    type: "control_request",
+    request_id: requestId,
+    request: { subtype: "set_model", model },
+  });
+}
+
 /** Build a `keep_alive` message. */
 export function keepAlive(): string {
   return serialize({ type: "keep_alive" });

--- a/packages/daemon/src/claude-session/session-state.spec.ts
+++ b/packages/daemon/src/claude-session/session-state.spec.ts
@@ -419,6 +419,58 @@ describe("SessionState", () => {
     });
   });
 
+  // -- resetForClear --
+
+  describe("resetForClear", () => {
+    test("resets to connecting, preserves cost/tokens", () => {
+      const session = activeSession();
+      session.handleMessage(RESULT_SUCCESS);
+      expect(session.state).toBe("idle");
+      expect(session.cost).toBe(0.05);
+      expect(session.tokens).toBeGreaterThan(0);
+
+      const events = session.resetForClear();
+
+      expect(session.state).toBe("connecting");
+      expect(session.cost).toBe(0.05); // preserved
+      expect(session.tokens).toBeGreaterThan(0); // preserved
+      expect(events).toEqual([{ type: "session:cleared" }]);
+    });
+
+    test("clears pending permissions", () => {
+      const session = activeSession();
+      session.handleMessage(CAN_USE_TOOL);
+      expect(session.pendingPermissions.size).toBe(1);
+
+      session.resetForClear();
+
+      expect(session.pendingPermissions.size).toBe(0);
+    });
+
+    test("no-op on ended session", () => {
+      const session = new SessionState("sess-1");
+      session.end();
+
+      const events = session.resetForClear();
+      expect(events).toEqual([]);
+      expect(session.state).toBe("ended");
+    });
+  });
+
+  // -- setModel --
+
+  describe("setModel", () => {
+    test("updates model and emits event", () => {
+      const session = initSession();
+      expect(session.model).toBe("claude-sonnet-4-6");
+
+      const events = session.setModel("claude-opus-4-6");
+
+      expect(session.model).toBe("claude-opus-4-6");
+      expect(events).toEqual([{ type: "session:model_changed", model: "claude-opus-4-6" }]);
+    });
+  });
+
   // -- Full lifecycle --
 
   describe("full lifecycle", () => {

--- a/packages/daemon/src/claude-session/session-state.ts
+++ b/packages/daemon/src/claude-session/session-state.ts
@@ -29,7 +29,9 @@ export type SessionEvent =
   | { type: "session:result"; cost: number; tokens: number; numTurns: number; result: string }
   | { type: "session:error"; errors: string[]; cost: number }
   | { type: "session:disconnected"; reason: string }
-  | { type: "session:ended" };
+  | { type: "session:ended" }
+  | { type: "session:cleared" }
+  | { type: "session:model_changed"; model: string };
 
 // ── Outbound message (string ready to send over WS) ──
 
@@ -149,6 +151,20 @@ export class SessionState {
   reconnect(): void {
     if (this.state !== "disconnected") return;
     this.state = "connecting";
+  }
+
+  /** Reset state for a /clear (kill+respawn). Preserves cumulative cost/tokens. */
+  resetForClear(): SessionEvent[] {
+    if (this.state === "ended") return [];
+    this.state = "connecting";
+    this.pendingPermissions.clear();
+    return [{ type: "session:cleared" }];
+  }
+
+  /** Update the tracked model (from /model command). */
+  setModel(model: string): SessionEvent[] {
+    this.model = model;
+    return [{ type: "session:model_changed", model }];
   }
 
   /** Mark the session as ended (explicit bye or server shutdown). */

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -1207,6 +1207,184 @@ describe("ClaudeWsServer", () => {
 
     await expect(server.waitForEventsSince(null, 0, 100)).rejects.toThrow("No active sessions");
   });
+
+  // ── /clear and /model interception ──
+
+  test("sendPrompt with /clear kills process and respawns", async () => {
+    const spawnCalls: string[][] = [];
+    let exitResolve: (code: number) => void = () => {};
+    const spawn: SpawnFn = (cmd: string[]) => {
+      spawnCalls.push(cmd);
+      return {
+        pid: 12345 + spawnCalls.length,
+        exited: new Promise<number>((r) => {
+          exitResolve = r;
+        }),
+        kill: () => {},
+      };
+    };
+
+    server = new ClaudeWsServer({ spawn });
+    const port = server.start();
+
+    server.prepareSession("test-session", { prompt: "Hello" });
+    server.spawnClaude("test-session");
+
+    const ws = await connectMockClaude(port, "test-session");
+    await waitForMessage(ws); // initial prompt
+    ws.send(systemInitMessage("test-session"));
+    await Bun.sleep(20);
+    ws.send(resultMessage("test-session"));
+    await Bun.sleep(20);
+
+    const events: SessionEvent[] = [];
+    server.onSessionEvent = (_id, event) => events.push(event);
+
+    // Send /clear — should kill+respawn
+    server.sendPrompt("test-session", "/clear");
+    await Bun.sleep(50);
+
+    // Should have spawned a second time
+    expect(spawnCalls.length).toBe(2);
+
+    // Should have emitted session:cleared event
+    const clearedEvent = events.find((e) => e.type === "session:cleared");
+    expect(clearedEvent).toBeDefined();
+
+    // Session should still exist in connecting state
+    const sessions = server.listSessions();
+    expect(sessions.length).toBe(1);
+    expect(sessions[0].state).toBe("connecting");
+
+    // New claude should be able to connect
+    const ws2 = await connectMockClaude(port, "test-session");
+    try {
+      const msg = await waitForMessage(ws2);
+      const parsed = JSON.parse(msg.trim());
+      // Prompt should be empty after clear
+      expect(parsed.message.content).toBe("");
+    } finally {
+      ws2.close();
+    }
+    ws.close();
+  });
+
+  test("sendPrompt with /model sends set_model control request", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn });
+    const port = server.start();
+
+    server.prepareSession("test-session", { prompt: "Hello" });
+    server.spawnClaude("test-session");
+
+    const ws = await connectMockClaude(port, "test-session");
+    try {
+      await waitForMessage(ws); // initial prompt
+      ws.send(systemInitMessage("test-session"));
+      await Bun.sleep(20);
+
+      const events: SessionEvent[] = [];
+      server.onSessionEvent = (_id, event) => events.push(event);
+
+      // Send /model command
+      const msgPromise = waitForMessage(ws);
+      server.sendPrompt("test-session", "/model claude-opus-4-6");
+
+      const msg = await msgPromise;
+      const parsed = JSON.parse(msg.trim());
+      expect(parsed.type).toBe("control_request");
+      expect(parsed.request.subtype).toBe("set_model");
+      expect(parsed.request.model).toBe("claude-opus-4-6");
+
+      // Should have emitted session:model_changed event
+      const modelEvent = events.find((e) => e.type === "session:model_changed");
+      expect(modelEvent).toBeDefined();
+      if (modelEvent?.type === "session:model_changed") {
+        expect(modelEvent.model).toBe("claude-opus-4-6");
+      }
+
+      // State should track new model
+      const status = server.getStatus("test-session");
+      expect(status.model).toBe("claude-opus-4-6");
+    } finally {
+      ws.close();
+    }
+  });
+
+  test("sendPrompt with regular message is not intercepted", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn });
+    const port = server.start();
+
+    server.prepareSession("test-session", { prompt: "Hello" });
+    server.spawnClaude("test-session");
+
+    const ws = await connectMockClaude(port, "test-session");
+    try {
+      await waitForMessage(ws);
+      ws.send(systemInitMessage("test-session"));
+      await Bun.sleep(20);
+      ws.send(resultMessage("test-session"));
+      await Bun.sleep(20);
+
+      // Regular message should be sent as user message
+      const msgPromise = waitForMessage(ws);
+      server.sendPrompt("test-session", "Do something");
+
+      const msg = await msgPromise;
+      const parsed = JSON.parse(msg.trim());
+      expect(parsed.type).toBe("user");
+      expect(parsed.message.content).toBe("Do something");
+    } finally {
+      ws.close();
+    }
+  });
+
+  test("clearSession preserves cumulative cost/tokens", async () => {
+    const spawnCalls: string[][] = [];
+    let exitResolve: (code: number) => void = () => {};
+    const spawn: SpawnFn = (cmd: string[]) => {
+      spawnCalls.push(cmd);
+      return {
+        pid: 12345 + spawnCalls.length,
+        exited: new Promise<number>((r) => {
+          exitResolve = r;
+        }),
+        kill: () => {},
+      };
+    };
+
+    server = new ClaudeWsServer({ spawn });
+    const port = server.start();
+
+    server.prepareSession("test-session", { prompt: "Hello" });
+    server.spawnClaude("test-session");
+
+    const ws = await connectMockClaude(port, "test-session");
+    await waitForMessage(ws);
+    ws.send(systemInitMessage("test-session"));
+    await Bun.sleep(20);
+    ws.send(assistantMessage("test-session"));
+    await Bun.sleep(20);
+    ws.send(resultMessage("test-session"));
+    await Bun.sleep(20);
+
+    // Verify cost accumulated
+    const statusBefore = server.getStatus("test-session");
+    expect(statusBefore.cost).toBeGreaterThan(0);
+    const costBefore = statusBefore.cost;
+
+    // Clear session
+    server.clearSession("test-session");
+    await Bun.sleep(50);
+
+    // Cost should be preserved
+    const statusAfter = server.getStatus("test-session");
+    expect(statusAfter.cost).toBe(costBefore);
+    expect(statusAfter.state).toBe("connecting");
+
+    ws.close();
+  });
 });
 
 // ── summarizeInput ──

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -12,7 +12,7 @@
 import type { PendingPermissionInfo, SessionInfo, SessionStateEnum } from "@mcp-cli/core";
 import type { ServerWebSocket } from "bun";
 import type { NdjsonMessage } from "./ndjson";
-import { keepAlive, parseFrame, permissionAllow, permissionDeny, userMessage } from "./ndjson";
+import { keepAlive, parseFrame, permissionAllow, permissionDeny, setModelRequest, userMessage } from "./ndjson";
 import type { CanUseToolRequest, PermissionRule, PermissionStrategy } from "./permission-router";
 import { PermissionRouter } from "./permission-router";
 import type { SessionEvent } from "./session-state";
@@ -117,6 +117,7 @@ interface WsSession {
   worktree: string | null;
   resultWaiters: ResultWaiter[];
   keepAliveTimer: Timer | null;
+  clearing: boolean;
 }
 
 interface WsData {
@@ -148,6 +149,7 @@ export class ClaudeWsServer {
   private readonly spawn: SpawnFn;
   private eventSeq = 0;
   private readonly eventBuffer: BufferedEvent[] = [];
+  private nextRequestId = 1;
 
   /** Called when session events occur (for DB updates). */
   onSessionEvent: ((sessionId: string, event: SessionEvent) => void) | null = null;
@@ -234,6 +236,7 @@ export class ClaudeWsServer {
       worktree: config.worktree ?? null,
       resultWaiters: [],
       keepAliveTimer: null,
+      clearing: false,
     });
   }
 
@@ -284,6 +287,8 @@ export class ClaudeWsServer {
 
     // Watch for process exit — mark spawn as dead but don't terminate the session
     proc.exited.then(() => {
+      // If a new process has been spawned (e.g. via clearSession), ignore the old one
+      if (session.proc !== proc) return;
       session.spawnAlive = false;
       if (session.state.state === "ended") return;
       console.error(`[_claude] Spawn exited for session ${sessionId} (pid ${proc.pid})`);
@@ -297,8 +302,23 @@ export class ClaudeWsServer {
     return proc.pid;
   }
 
-  /** Send a follow-up prompt to an active session. */
+  /** Send a follow-up prompt to an active session. Intercepts /clear and /model. */
   sendPrompt(sessionId: string, message: string): void {
+    const trimmed = message.trim();
+
+    // Intercept /clear — kill process and respawn for fresh context
+    if (trimmed === "/clear") {
+      this.clearSession(sessionId);
+      return;
+    }
+
+    // Intercept /model — send set_model control request instead of user message
+    const modelMatch = trimmed.match(/^\/model\s+(.+)$/);
+    if (modelMatch) {
+      this.setModel(sessionId, modelMatch[1].trim());
+      return;
+    }
+
     const session = this.getSession(sessionId);
     const outbound = session.state.queuePrompt(message);
     this.sendToWs(session, outbound);
@@ -317,6 +337,70 @@ export class ClaudeWsServer {
     const session = this.getSession(sessionId);
     const outbound = session.state.interrupt();
     this.sendToWs(session, outbound);
+  }
+
+  /**
+   * Clear a session by killing the claude process and respawning.
+   * Gives a truly fresh context without losing the session entry.
+   */
+  clearSession(sessionId: string): void {
+    const session = this.getSession(sessionId);
+    session.clearing = true;
+
+    // Reset state machine (preserves cumulative cost/tokens)
+    const events = session.state.resetForClear();
+    for (const event of events) {
+      this.onSessionEvent?.(sessionId, event);
+      this.handleSessionEvent(sessionId, session, event);
+    }
+
+    // Clear keep-alive timer
+    if (session.keepAliveTimer) {
+      clearInterval(session.keepAliveTimer);
+      session.keepAliveTimer = null;
+    }
+
+    // Close WebSocket
+    if (session.ws?.readyState === WS_OPEN) {
+      session.ws.close(1000, "Session cleared");
+    }
+    session.ws = null;
+
+    // Kill process
+    if (session.proc) {
+      try {
+        session.proc.kill();
+      } catch {
+        // already dead
+      }
+      session.proc = null;
+      session.spawnAlive = false;
+    }
+
+    // Update config prompt to empty — next sendPrompt() will carry real work
+    session.config.prompt = "";
+
+    // Clear transcript for fresh start
+    session.transcript.length = 0;
+
+    // Respawn
+    this.spawnClaude(sessionId);
+    session.clearing = false;
+  }
+
+  /** Send a set_model control request to change the session's model. */
+  setModel(sessionId: string, model: string): void {
+    const session = this.getSession(sessionId);
+    const requestId = `mcpd-model-${this.nextRequestId++}`;
+    const outbound = setModelRequest(requestId, model);
+    this.sendToWs(session, outbound);
+
+    // Update tracked model in state
+    const events = session.state.setModel(model);
+    for (const event of events) {
+      this.onSessionEvent?.(sessionId, event);
+      this.handleSessionEvent(sessionId, session, event);
+    }
   }
 
   /** Gracefully end a session: close WS, stop process, clean up. Returns worktree info. */
@@ -522,8 +606,8 @@ export class ClaudeWsServer {
       session.keepAliveTimer = null;
     }
 
-    // If already ended (bye was called), nothing more to do
-    if (session.state.state === "ended") return;
+    // If already ended (bye was called) or being cleared (kill+respawn), nothing more to do
+    if (session.state.state === "ended" || session.clearing) return;
 
     console.error(
       `[_claude] WebSocket disconnected for session ${sessionId} (spawn ${session.spawnAlive ? "alive" : "dead"})`,
@@ -589,6 +673,18 @@ export class ClaudeWsServer {
           cost: event.cost,
           tokens: 0,
           numTurns: 0,
+        });
+        break;
+      case "session:cleared":
+        this.resolveEventWaiters(sessionId, {
+          sessionId,
+          event: "session:cleared",
+        });
+        break;
+      case "session:model_changed":
+        this.resolveEventWaiters(sessionId, {
+          sessionId,
+          event: "session:model_changed",
         });
         break;
     }


### PR DESCRIPTION
## Summary
- **`/clear` → kill+respawn**: `sendPrompt()` now intercepts `/clear` messages and performs a full process kill + respawn, giving sessions truly fresh context instead of sending an ineffective user message. Cumulative cost/tokens are preserved across clears.
- **`/model` → `set_model` control request**: `sendPrompt()` intercepts `/model <name>` and sends a `set_model` control_request over the WebSocket protocol, updating the tracked model in session state.
- **Race-safe process lifecycle**: Old process exit handlers are ignored after `clearSession()` respawns a new process, preventing stale exits from transitioning the session to "disconnected".

## Test plan
- [x] `sendPrompt("/clear")` kills the old process, respawns, and the new claude connects with an empty prompt
- [x] `sendPrompt("/model claude-opus-4-6")` sends a `set_model` control_request and updates tracked model
- [x] Regular messages are not intercepted
- [x] `clearSession()` preserves cumulative cost/tokens across respawn
- [x] `resetForClear()` on SessionState resets to connecting, clears permissions, preserves stats
- [x] `setModel()` on SessionState updates model and emits event
- [x] All 1572 existing tests pass, coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)