### PR TITLE
fix(test): replace fixed delays with deadline-based polling in daemon-integration.spec.ts (fixes #333)

### DIFF
--- a/test/daemon-integration.spec.ts
+++ b/test/daemon-integration.spec.ts
@@ -127,10 +127,11 @@ describe.skipIf(process.platform === "linux")("P2: Config hot reload", () => {
     // Write echo server config
     writeFileSync(join(daemon.dir, "servers.json"), JSON.stringify({ mcpServers: { echo: echoServerConfig() } }));
 
-    // Wait for debounce (300ms) + processing — poll with retries for CI
+    // Wait for debounce (300ms) + processing — poll with deadline for CI reliability
+    const deadline = Date.now() + 10_000;
     let found = false;
-    for (let i = 0; i < 10 && !found; i++) {
-      await Bun.sleep(500);
+    while (!found && Date.now() < deadline) {
+      await Bun.sleep(100);
       const after = await rpc(daemon.socketPath, "listServers");
       const servers = after.result as Array<{ name: string }>;
       found = servers.some((s) => s.name === "echo");
@@ -148,10 +149,11 @@ describe.skipIf(process.platform === "linux")("P2: Config hot reload", () => {
     // Remove all servers
     writeFileSync(join(daemon.dir, "servers.json"), JSON.stringify({ mcpServers: {} }));
 
-    // Wait for debounce + processing — poll with retries for CI
+    // Wait for debounce + processing — poll with deadline for CI reliability
+    const deadline = Date.now() + 10_000;
     let removed = false;
-    for (let i = 0; i < 10 && !removed; i++) {
-      await Bun.sleep(500);
+    while (!removed && Date.now() < deadline) {
+      await Bun.sleep(100);
       const after = await rpc(daemon.socketPath, "listServers");
       const afterServers = after.result as Array<{ name: string }>;
       removed = afterServers.every((s) => s.name.startsWith("_"));


### PR DESCRIPTION
## Summary
- Replace two `for` loops with fixed `Bun.sleep(500)` delays with `while` loops using a 10-second deadline and 100ms backoff
- Polling now exits as soon as the condition is met, rather than waiting up to 5 seconds (10×500ms)
- Follows the deadline-based polling pattern established in `test/CLAUDE.md`

## Test plan
- [x] `bun test test/daemon-integration.spec.ts` — all 16 tests pass
- [x] `bun typecheck` — no errors
- [x] `bun lint` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)