### PR TITLE
fix(daemon): show error state for failed virtual servers in listServers (fixes #326)

### DIFF
--- a/packages/daemon/src/server-pool.spec.ts
+++ b/packages/daemon/src/server-pool.spec.ts
@@ -933,10 +933,9 @@ describe("ServerPool.registerPendingVirtualServer", () => {
     await pool.awaitPendingServers();
   });
 
-  test("callTool throws 'not found' after pending server fails to start", async () => {
+  test("callTool throws startup error after pending server fails to start", async () => {
     const pool = new ServerPool(makeConfig({}));
 
-    // Register a pending server whose startup fails (the IIFE catches and resolves)
     pool.registerPendingVirtualServer(
       "_broken",
       (async () => {
@@ -947,8 +946,30 @@ describe("ServerPool.registerPendingVirtualServer", () => {
     // Wait for the pending promise to settle
     await pool.awaitPendingServers();
 
-    // Now callTool should throw "not found" since the server never registered
-    await expect(pool.callTool("_broken", "tool", {})).rejects.toThrow('Server "_broken" not found');
+    // callTool should throw the startup error, not "not found"
+    await expect(pool.callTool("_broken", "tool", {})).rejects.toThrow(
+      'Virtual server "_broken" failed to start: worker crash',
+    );
+  });
+
+  test("listServers shows error state after pending server fails to start", async () => {
+    const pool = new ServerPool(makeConfig({}));
+
+    pool.registerPendingVirtualServer(
+      "_broken",
+      (async () => {
+        throw new Error("worker crash");
+      })(),
+    );
+
+    await pool.awaitPendingServers();
+
+    const servers = pool.listServers();
+    const broken = servers.find((s) => s.name === "_broken");
+    expect(broken).toBeDefined();
+    expect(broken?.state).toBe("error");
+    expect(broken?.lastError).toBe("worker crash");
+    expect(broken?.transport).toBe("virtual");
   });
 
   test("failed pending server does not block other operations", async () => {

--- a/packages/daemon/src/server-pool.ts
+++ b/packages/daemon/src/server-pool.ts
@@ -121,6 +121,21 @@ export class ServerPool {
     const tracked = startPromise
       .catch((err) => {
         console.error(`[pool] Pending virtual server "${name}" failed: ${err}`);
+        // Create error placeholder so the server remains visible in listServers()
+        if (!this.connections.has(name)) {
+          const errorMsg = err instanceof Error ? err.message : String(err);
+          this.connections.set(name, {
+            name,
+            resolved: { name, config: { command: "__virtual__" }, source: { file: "built-in", scope: "mcp-cli" } },
+            client: null,
+            transport: null,
+            tools: new Map(),
+            state: "error",
+            lastUsed: 0,
+            lastError: errorMsg,
+            virtual: true,
+          });
+        }
       })
       .finally(() => this.pendingServers.delete(name));
     this.pendingServers.set(name, tracked);
@@ -202,6 +217,11 @@ export class ServerPool {
 
     const conn = this.connections.get(name);
     if (!conn) throw new Error(`Server "${name}" not found`);
+
+    // Virtual servers in error state cannot be reconnected automatically
+    if (conn.virtual && conn.state === "error") {
+      throw new Error(`Virtual server "${name}" failed to start: ${conn.lastError ?? "unknown error"}`);
+    }
 
     if (conn.state === "connected" && conn.client) {
       conn.lastUsed = Date.now();


### PR DESCRIPTION
## Summary
- When a pending virtual server's startup promise rejects, a placeholder entry is now created in `connections` with `state: "error"` and `lastError` set to the error message
- `mcx status` now shows failed virtual servers (e.g., `_aliases`, `_claude`) with their error rather than silently dropping them
- Added guard in `ensureConnected` to fast-fail for virtual servers in error state, avoiding confusing reconnect attempts via the `__virtual__` command config

## Test plan
- Updated existing test "callTool throws after pending server fails" to expect the new error message (`Virtual server "_broken" failed to start: worker crash`)
- Added new test `listServers shows error state after pending server fails to start` verifying `state: "error"` and `lastError` are set
- All 1576 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)