### PR TITLE
fix(daemon): failed virtual servers show error state in listServers (fixes #326)

### DIFF
--- a/packages/daemon/src/server-pool.spec.ts
+++ b/packages/daemon/src/server-pool.spec.ts
@@ -947,8 +947,10 @@ describe("ServerPool.registerPendingVirtualServer", () => {
     // Wait for the pending promise to settle
     await pool.awaitPendingServers();
 
-    // Now callTool should throw "not found" since the server never registered
-    await expect(pool.callTool("_broken", "tool", {})).rejects.toThrow('Server "_broken" not found');
+    // Now callTool should throw with the startup error since the server failed
+    await expect(pool.callTool("_broken", "tool", {})).rejects.toThrow(
+      'Virtual server "_broken" failed to start: worker crash',
+    );
   });
 
   test("failed pending server does not block other operations", async () => {
@@ -962,6 +964,33 @@ describe("ServerPool.registerPendingVirtualServer", () => {
     // listServers should still work
     const servers = poolWithConnect.listServers();
     expect(servers.some((s) => s.name === "a")).toBe(true);
+  });
+
+  test("failed pending server shows error state in listServers", async () => {
+    const pool = new ServerPool(makeConfig({}));
+
+    pool.registerPendingVirtualServer(
+      "_broken",
+      (async () => {
+        throw new Error("worker crash");
+      })(),
+    );
+
+    // While pending, should show as connecting
+    const before = pool.listServers();
+    const pending = before.find((s) => s.name === "_broken");
+    expect(pending).toBeDefined();
+    expect(pending?.state).toBe("connecting");
+
+    // After settling, should show as error with lastError
+    await pool.awaitPendingServers();
+
+    const after = pool.listServers();
+    const failed = after.find((s) => s.name === "_broken");
+    expect(failed).toBeDefined();
+    expect(failed?.state).toBe("error");
+    expect(failed?.lastError).toBe("worker crash");
+    expect(failed?.transport).toBe("virtual");
   });
 
   test("hasPendingServers returns true while server is starting, false after settled", async () => {

--- a/packages/daemon/src/server-pool.ts
+++ b/packages/daemon/src/server-pool.ts
@@ -121,6 +121,18 @@ export class ServerPool {
     const tracked = startPromise
       .catch((err) => {
         console.error(`[pool] Pending virtual server "${name}" failed: ${err}`);
+        // Create a placeholder connection so listServers() shows the error state
+        this.connections.set(name, {
+          name,
+          resolved: { name, config: { command: "" }, source: { file: "built-in", scope: "mcp-cli" } },
+          client: null,
+          transport: null,
+          tools: new Map(),
+          state: "error",
+          lastUsed: 0,
+          lastError: err instanceof Error ? err.message : String(err),
+          virtual: true,
+        });
       })
       .finally(() => this.pendingServers.delete(name));
     this.pendingServers.set(name, tracked);
@@ -202,6 +214,11 @@ export class ServerPool {
 
     const conn = this.connections.get(name);
     if (!conn) throw new Error(`Server "${name}" not found`);
+
+    // Failed virtual servers have no recoverable config — surface the startup error
+    if (conn.virtual && conn.state === "error" && !conn.client) {
+      throw new Error(`Virtual server "${name}" failed to start: ${conn.lastError ?? "unknown error"}`);
+    }
 
     if (conn.state === "connected" && conn.client) {
       conn.lastUsed = Date.now();


### PR DESCRIPTION
## Summary
- When a pending virtual server fails to start, creates a placeholder `ServerConnection` with `state: "error"` and `lastError` so it appears in `listServers()` instead of silently vanishing
- `ensureConnected()` now detects failed virtual server placeholders and throws a clear error message instead of attempting to reconnect with invalid config
- Added test for the new error state behavior; updated existing test expectation

## Test plan
- [x] New test: failed pending server shows `state: "error"`, `lastError`, and `transport: "virtual"` in `listServers()`
- [x] Updated test: `callTool` on failed virtual server throws descriptive startup error
- [x] All 1576 tests pass, typecheck clean, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)