### PR TITLE
feat(command): mcx claude resume — reattach to orphaned worktree sessions (fixes #262)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -4,16 +4,20 @@ import { ExitError } from "../test-helpers";
 import type { ClaudeDeps } from "./claude";
 import {
   MODEL_SHORTNAMES,
+  buildResumePrompt,
   cmdClaude,
   defaultGetPrStatus,
   extractContentSummary,
+  extractIssueNumber,
   parseDiffShortstat,
   parseLogArgs,
+  parseResumeArgs,
   parseSpawnArgs,
   parseWaitArgs,
   parseWorktreeList,
   resolveModelName,
   resolveSessionId,
+  resolveWorktree,
 } from "./claude";
 
 // ── Helpers ──
@@ -1959,5 +1963,361 @@ describe("mcx claude worktrees", () => {
     await cmdClaude(["wt"], deps);
     const errOutput = printError.mock.calls.map((c: unknown[]) => c[0]).join("\n");
     expect(errOutput).toContain("No mcx worktrees found.");
+  });
+});
+
+// ── Resume ──
+
+describe("parseResumeArgs", () => {
+  test("parses target positional arg", () => {
+    const result = parseResumeArgs(["my-worktree"]);
+    expect(result.target).toBe("my-worktree");
+    expect(result.all).toBe(false);
+    expect(result.error).toBeUndefined();
+  });
+
+  test("parses --all flag", () => {
+    const result = parseResumeArgs(["--all"]);
+    expect(result.all).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  test("parses --model flag", () => {
+    const result = parseResumeArgs(["my-wt", "--model", "sonnet"]);
+    expect(result.target).toBe("my-wt");
+    expect(result.model).toContain("sonnet");
+  });
+
+  test("parses --allow flag", () => {
+    const result = parseResumeArgs(["my-wt", "--allow", "Read", "Write"]);
+    expect(result.allow).toEqual(["Read", "Write"]);
+  });
+
+  test("parses --wait flag", () => {
+    const result = parseResumeArgs(["my-wt", "--wait"]);
+    expect(result.wait).toBe(true);
+  });
+
+  test("parses --timeout flag", () => {
+    const result = parseResumeArgs(["my-wt", "--timeout", "60000"]);
+    expect(result.timeout).toBe(60000);
+  });
+
+  test("errors when no target and no --all", () => {
+    const result = parseResumeArgs([]);
+    expect(result.error).toBeDefined();
+  });
+
+  test("errors on --model without value", () => {
+    const result = parseResumeArgs(["my-wt", "--model"]);
+    expect(result.error).toBe("--model requires a value");
+  });
+
+  test("errors on --timeout without value", () => {
+    const result = parseResumeArgs(["my-wt", "--timeout"]);
+    expect(result.error).toBe("--timeout requires a value in ms");
+  });
+
+  test("errors on --allow without patterns", () => {
+    const result = parseResumeArgs(["my-wt", "--allow"]);
+    expect(result.error).toBe("--allow requires at least one tool pattern");
+  });
+});
+
+describe("extractIssueNumber", () => {
+  test("extracts from feat/issue-N-slug", () => {
+    expect(extractIssueNumber("feat/issue-262-claude-resume")).toBe(262);
+  });
+
+  test("extracts from fix/issue-N-slug", () => {
+    expect(extractIssueNumber("fix/issue-42-some-fix")).toBe(42);
+  });
+
+  test("returns null for non-matching branches", () => {
+    expect(extractIssueNumber("main")).toBeNull();
+    expect(extractIssueNumber("feature/add-auth")).toBeNull();
+  });
+
+  test("extracts issue number from middle of branch name", () => {
+    expect(extractIssueNumber("refactor/issue-100-cleanup")).toBe(100);
+  });
+});
+
+describe("resolveWorktree", () => {
+  const worktrees = [
+    { path: "/repo/.claude/worktrees/claude-abc123", branch: "feat/issue-1-foo" },
+    { path: "/repo/.claude/worktrees/claude-def456", branch: "fix/issue-2-bar" },
+  ];
+
+  test("resolves by full path", () => {
+    const result = resolveWorktree("/repo/.claude/worktrees/claude-abc123", worktrees);
+    expect(result).toEqual(worktrees[0]);
+  });
+
+  test("resolves by directory name", () => {
+    const result = resolveWorktree("claude-def456", worktrees);
+    expect(result).toEqual(worktrees[1]);
+  });
+
+  test("resolves by branch name", () => {
+    const result = resolveWorktree("feat/issue-1-foo", worktrees);
+    expect(result).toEqual(worktrees[0]);
+  });
+
+  test("returns null for no match", () => {
+    const result = resolveWorktree("nonexistent", worktrees);
+    expect(result).toBeNull();
+  });
+});
+
+describe("buildResumePrompt", () => {
+  test("includes branch name", () => {
+    const prompt = buildResumePrompt({
+      branch: "feat/issue-42-auth",
+      issueNumber: 42,
+      gitLog: "abc1234 add auth module",
+      gitDiff: "",
+      prInfo: null,
+    });
+    expect(prompt).toContain("`feat/issue-42-auth`");
+    expect(prompt).toContain("#42");
+    expect(prompt).toContain("abc1234 add auth module");
+  });
+
+  test("includes PR info when present", () => {
+    const prompt = buildResumePrompt({
+      branch: "feat/issue-1-foo",
+      issueNumber: 1,
+      gitLog: "",
+      gitDiff: "",
+      prInfo: "#99 (open)",
+    });
+    expect(prompt).toContain("#99 (open)");
+  });
+
+  test("includes uncommitted changes", () => {
+    const prompt = buildResumePrompt({
+      branch: "feat/issue-1-foo",
+      issueNumber: null,
+      gitLog: "",
+      gitDiff: " src/index.ts | 5 ++---",
+      prInfo: null,
+    });
+    expect(prompt).toContain("Uncommitted changes");
+    expect(prompt).toContain("src/index.ts");
+  });
+
+  test("omits empty sections", () => {
+    const prompt = buildResumePrompt({
+      branch: "feat/foo",
+      issueNumber: null,
+      gitLog: "",
+      gitDiff: "",
+      prInfo: null,
+    });
+    expect(prompt).not.toContain("Commits on this branch");
+    expect(prompt).not.toContain("Uncommitted changes");
+    expect(prompt).not.toContain("Issue:");
+    expect(prompt).not.toContain("PR:");
+  });
+});
+
+describe("cmdClaude resume", () => {
+  const cwd = process.cwd();
+  const worktreeParent = `${cwd}/.claude/worktrees`;
+
+  test("errors with no arguments", async () => {
+    const deps = makeDeps();
+    await expect(cmdClaude(["resume"], deps)).rejects.toThrow(ExitError);
+    expect(deps.printError).toHaveBeenCalled();
+  });
+
+  test("errors when worktree not found", async () => {
+    const exec = mock((cmd: string[]) => {
+      if (cmd.includes("worktree") && cmd.includes("list")) {
+        return { stdout: `worktree ${cwd}\nHEAD abc\nbranch refs/heads/main\n`, exitCode: 0 };
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    const deps = makeDeps({ exec });
+    await expect(cmdClaude(["resume", "nonexistent"], deps)).rejects.toThrow(ExitError);
+    const errOutput = (deps.printError as ReturnType<typeof mock>).mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    expect(errOutput).toContain('No worktree matching "nonexistent"');
+  });
+
+  test("errors when worktree has active session", async () => {
+    const wtPath = `${worktreeParent}/claude-test123`;
+    const exec = mock((cmd: string[]) => {
+      if (cmd.includes("worktree") && cmd.includes("list")) {
+        return {
+          stdout: `worktree ${cwd}\nHEAD abc\nbranch refs/heads/main\n\nworktree ${wtPath}\nHEAD def\nbranch refs/heads/feat/issue-1-test\n`,
+          exitCode: 0,
+        };
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    const callTool = mock(async (tool: string) => {
+      if (tool === "claude_session_list") {
+        return toolResult([{ sessionId: "s1", state: "active", worktree: "claude-test123" }]);
+      }
+      return toolResult({});
+    });
+    const deps = makeDeps({ exec, callTool });
+    await expect(cmdClaude(["resume", "claude-test123"], deps)).rejects.toThrow(ExitError);
+    const errOutput = (deps.printError as ReturnType<typeof mock>).mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    expect(errOutput).toContain("already has an active session");
+  });
+
+  test("skips already-merged branches", async () => {
+    const wtPath = `${worktreeParent}/claude-merged`;
+    const exec = mock((cmd: string[]) => {
+      if (cmd.includes("worktree") && cmd.includes("list")) {
+        return {
+          stdout: `worktree ${cwd}\nHEAD abc\nbranch refs/heads/main\n\nworktree ${wtPath}\nHEAD def\nbranch refs/heads/feat/issue-5-done\n`,
+          exitCode: 0,
+        };
+      }
+      if (cmd.includes("--merged")) {
+        return { stdout: "  main\n  feat/issue-5-done\n", exitCode: 0 };
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    const callTool = mock(async (tool: string) => {
+      if (tool === "claude_session_list") return toolResult([]);
+      return toolResult({});
+    });
+    const printError = mock(() => {});
+    const deps = makeDeps({ exec, callTool, printError });
+    await cmdClaude(["resume", "claude-merged"], deps);
+    const errOutput = printError.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    expect(errOutput).toContain("already merged into main");
+  });
+
+  test("spawns session with cwd set to worktree path", async () => {
+    const wtPath = `${worktreeParent}/claude-orphan`;
+    const exec = mock((cmd: string[]) => {
+      if (cmd.includes("worktree") && cmd.includes("list")) {
+        return {
+          stdout: `worktree ${cwd}\nHEAD abc\nbranch refs/heads/main\n\nworktree ${wtPath}\nHEAD def\nbranch refs/heads/feat/issue-42-auth\n`,
+          exitCode: 0,
+        };
+      }
+      if (cmd.includes("--merged")) {
+        return { stdout: "  main\n", exitCode: 0 };
+      }
+      if (cmd.includes("log")) {
+        return { stdout: "abc1234 add auth module\ndef5678 add tests", exitCode: 0 };
+      }
+      if (cmd.includes("diff")) {
+        return { stdout: " src/auth.ts | 3 ++-\n", exitCode: 0 };
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    const callTool: ClaudeDeps["callTool"] = mock(async (tool: string, _args: Record<string, unknown>) => {
+      if (tool === "claude_session_list") return toolResult([]);
+      if (tool === "claude_prompt") return toolResult({ sessionId: "new-session-id", seq: 1 });
+      return toolResult({});
+    });
+    const deps = makeDeps({ exec, callTool });
+    await cmdClaude(["resume", "claude-orphan"], deps);
+
+    // Verify claude_prompt was called with correct cwd
+    const promptCall = (callTool as ReturnType<typeof mock>).mock.calls.find(
+      (c: unknown[]) => c[0] === "claude_prompt",
+    );
+    expect(promptCall).toBeDefined();
+    const promptArgs = promptCall?.[1] as Record<string, unknown>;
+    expect(promptArgs.cwd).toBe(wtPath);
+    expect(promptArgs.prompt).toContain("feat/issue-42-auth");
+    expect(promptArgs.prompt).toContain("#42");
+    expect(promptArgs.prompt).toContain("abc1234 add auth module");
+    expect(promptArgs.prompt).toContain("src/auth.ts");
+  });
+
+  test("--all resumes all orphaned worktrees", async () => {
+    const wt1 = `${worktreeParent}/claude-wt1`;
+    const wt2 = `${worktreeParent}/claude-wt2`;
+    const exec = mock((cmd: string[]) => {
+      if (cmd.includes("worktree") && cmd.includes("list")) {
+        return {
+          stdout: [
+            `worktree ${cwd}`,
+            "HEAD abc",
+            "branch refs/heads/main",
+            "",
+            `worktree ${wt1}`,
+            "HEAD def",
+            "branch refs/heads/feat/issue-1-foo",
+            "",
+            `worktree ${wt2}`,
+            "HEAD ghi",
+            "branch refs/heads/feat/issue-2-bar",
+            "",
+          ].join("\n"),
+          exitCode: 0,
+        };
+      }
+      if (cmd.includes("--merged")) {
+        return { stdout: "  main\n", exitCode: 0 };
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    const callTool = mock(async (tool: string) => {
+      if (tool === "claude_session_list") return toolResult([]);
+      if (tool === "claude_prompt") return toolResult({ sessionId: "new-id", seq: 1 });
+      return toolResult({});
+    });
+    const deps = makeDeps({ exec, callTool });
+    await cmdClaude(["resume", "--all"], deps);
+
+    // Should have spawned 2 sessions
+    const promptCalls = callTool.mock.calls.filter((c: unknown[]) => c[0] === "claude_prompt");
+    expect(promptCalls.length).toBe(2);
+  });
+
+  test("--all reports when no orphaned worktrees found", async () => {
+    const exec = mock((cmd: string[]) => {
+      if (cmd.includes("worktree") && cmd.includes("list")) {
+        return { stdout: `worktree ${cwd}\nHEAD abc\nbranch refs/heads/main\n`, exitCode: 0 };
+      }
+      return { stdout: "", exitCode: 0 };
+    });
+    const callTool = mock(async (tool: string) => {
+      if (tool === "claude_session_list") return toolResult([]);
+      return toolResult({});
+    });
+    const printError = mock(() => {});
+    const deps = makeDeps({ exec, callTool, printError });
+    await cmdClaude(["resume", "--all"], deps);
+    const errOutput = printError.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    expect(errOutput).toContain("No orphaned worktrees to resume");
+  });
+
+  test("passes --model and --allow to spawn", async () => {
+    const wtPath = `${worktreeParent}/claude-opts`;
+    const exec = mock((cmd: string[]) => {
+      if (cmd.includes("worktree") && cmd.includes("list")) {
+        return {
+          stdout: `worktree ${cwd}\nHEAD abc\nbranch refs/heads/main\n\nworktree ${wtPath}\nHEAD def\nbranch refs/heads/feat/issue-1-test\n`,
+          exitCode: 0,
+        };
+      }
+      if (cmd.includes("--merged")) return { stdout: "  main\n", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    });
+    const callTool: ClaudeDeps["callTool"] = mock(async (tool: string, _args: Record<string, unknown>) => {
+      if (tool === "claude_session_list") return toolResult([]);
+      if (tool === "claude_prompt") return toolResult({ sessionId: "s1", seq: 1 });
+      return toolResult({});
+    });
+    const deps = makeDeps({ exec, callTool });
+    await cmdClaude(["resume", "claude-opts", "--model", "sonnet", "--allow", "Read", "Grep"], deps);
+
+    const promptCall = (callTool as ReturnType<typeof mock>).mock.calls.find(
+      (c: unknown[]) => c[0] === "claude_prompt",
+    );
+    const promptArgs = promptCall?.[1] as Record<string, unknown>;
+    expect(promptArgs.model).toContain("sonnet");
+    expect(promptArgs.allowedTools).toEqual(["Read", "Grep"]);
   });
 });

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -147,13 +147,16 @@ export async function cmdClaude(args: string[], deps?: Partial<ClaudeDeps>): Pro
     case "wait":
       await claudeWait(args.slice(1), d);
       break;
+    case "resume":
+      await claudeResume(args.slice(1), d);
+      break;
     case "worktrees":
     case "wt":
       await claudeWorktrees(args.slice(1), d);
       break;
     default:
       d.printError(
-        `Unknown claude subcommand: ${sub}. Use "spawn", "ls", "send", "bye", "interrupt", "log", "wait", or "worktrees".`,
+        `Unknown claude subcommand: ${sub}. Use "spawn", "resume", "ls", "send", "bye", "interrupt", "log", "wait", or "worktrees".`,
       );
       d.exit(1);
   }
@@ -263,6 +266,260 @@ async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
   if (parsed.model) toolArgs.model = parsed.model;
   if (parsed.wait) toolArgs.wait = true;
 
+  const result = await d.callTool("claude_prompt", toolArgs);
+  console.log(formatToolResult(result));
+}
+
+// ── Resume ──
+
+export interface ResumeArgs {
+  target: string | undefined;
+  all: boolean;
+  allow: string[];
+  model: string | undefined;
+  wait: boolean;
+  timeout: number | undefined;
+  error: string | undefined;
+}
+
+export function parseResumeArgs(args: string[]): ResumeArgs {
+  let target: string | undefined;
+  let all = false;
+  let model: string | undefined;
+  let wait = false;
+  let timeout: number | undefined;
+  let error: string | undefined;
+  const allow: string[] = [];
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--all") {
+      all = true;
+    } else if (arg === "--model" || arg === "-m") {
+      const val = args[++i];
+      if (!val) {
+        error = "--model requires a value";
+      } else {
+        model = resolveModelName(val);
+      }
+    } else if (arg === "--allow") {
+      while (i + 1 < args.length && !args[i + 1].startsWith("-")) {
+        allow.push(args[++i]);
+      }
+      if (allow.length === 0) error = "--allow requires at least one tool pattern";
+    } else if (arg === "--wait") {
+      wait = true;
+    } else if (arg === "--timeout") {
+      const val = args[++i];
+      if (!val) {
+        error = "--timeout requires a value in ms";
+      } else {
+        timeout = Number(val);
+        if (Number.isNaN(timeout)) error = "--timeout must be a number";
+      }
+    } else if (!arg.startsWith("-")) {
+      if (!target) target = arg;
+    }
+  }
+
+  if (!all && !target) {
+    error =
+      "Usage: mcx claude resume <worktree-path-or-branch> [--model M] [--allow tools...]\n       mcx claude resume --all";
+  }
+
+  return { target, all, allow, model, wait, timeout, error };
+}
+
+/** Extract issue number from branch name convention: feat/issue-N-slug, fix/issue-N-slug, etc. */
+export function extractIssueNumber(branch: string): number | null {
+  const match = branch.match(/issue-(\d+)/);
+  return match ? Number(match[1]) : null;
+}
+
+/** Resolve a worktree target (path or branch name) to an actual worktree path. */
+export function resolveWorktree(
+  target: string,
+  worktrees: Array<{ path: string; branch: string | null }>,
+): { path: string; branch: string | null } | null {
+  // Direct path match
+  for (const wt of worktrees) {
+    if (wt.path === target) return wt;
+  }
+
+  // Match by worktree directory name (last path segment)
+  for (const wt of worktrees) {
+    const name = wt.path.split("/").pop();
+    if (name === target) return wt;
+  }
+
+  // Match by branch name
+  for (const wt of worktrees) {
+    if (wt.branch === target) return wt;
+  }
+
+  return null;
+}
+
+/** Build a context-rich resume prompt from git state. */
+export function buildResumePrompt(opts: {
+  branch: string;
+  issueNumber: number | null;
+  gitLog: string;
+  gitDiff: string;
+  prInfo: string | null;
+}): string {
+  const lines: string[] = [];
+  lines.push("You are resuming work in an existing worktree. Here is the context of what has already been done:");
+  lines.push("");
+  lines.push(`**Branch:** \`${opts.branch}\``);
+
+  if (opts.issueNumber) {
+    lines.push(`**Issue:** #${opts.issueNumber}`);
+  }
+
+  if (opts.prInfo) {
+    lines.push(`**PR:** ${opts.prInfo}`);
+  }
+
+  if (opts.gitLog.trim()) {
+    lines.push("");
+    lines.push("**Commits on this branch:**");
+    lines.push("```");
+    lines.push(opts.gitLog.trim());
+    lines.push("```");
+  }
+
+  if (opts.gitDiff.trim()) {
+    lines.push("");
+    lines.push("**Uncommitted changes:**");
+    lines.push("```");
+    lines.push(opts.gitDiff.trim());
+    lines.push("```");
+  }
+
+  lines.push("");
+  lines.push(
+    "Review the state above and continue where the previous session left off. If there are uncommitted changes, decide whether to commit or discard them. If there's a PR, check if it needs updates. If the work appears complete, verify it (typecheck, lint, test) and wrap up.",
+  );
+
+  return lines.join("\n");
+}
+
+async function claudeResume(args: string[], d: ClaudeDeps): Promise<void> {
+  const parsed = parseResumeArgs(args);
+
+  if (parsed.error) {
+    d.printError(parsed.error);
+    d.exit(1);
+  }
+
+  const cwd = process.cwd();
+
+  // List all worktrees
+  const { stdout: wtOutput, exitCode: wtExit } = d.exec(["git", "-C", cwd, "worktree", "list", "--porcelain"]);
+  if (wtExit !== 0) {
+    d.printError("Failed to list git worktrees (not a git repo?)");
+    d.exit(1);
+  }
+
+  const allWorktrees = parseWorktreeList(wtOutput);
+  const worktreeParent = join(cwd, ".claude", "worktrees");
+  const mcxWorktrees = allWorktrees.filter((wt) => wt.path.startsWith(`${worktreeParent}/`));
+
+  // Get active sessions to find orphaned worktrees
+  let sessionWorktrees = new Set<string>();
+  try {
+    const result = await d.callTool("claude_session_list", {});
+    const text = formatToolResult(result);
+    const sessions = JSON.parse(text) as SessionInfo[];
+    sessionWorktrees = new Set(sessions.filter((s) => s.worktree).map((s) => s.worktree as string));
+  } catch {
+    // Daemon may not be running — all worktrees are orphaned
+  }
+
+  if (parsed.all) {
+    // Resume all orphaned worktrees
+    const orphaned = mcxWorktrees.filter((wt) => {
+      const wtName = wt.path.slice(`${worktreeParent}/`.length);
+      return !sessionWorktrees.has(wtName);
+    });
+
+    if (orphaned.length === 0) {
+      d.printError("No orphaned worktrees to resume.");
+      return;
+    }
+
+    d.printError(`Resuming ${orphaned.length} orphaned worktree${orphaned.length === 1 ? "" : "s"}...`);
+
+    for (const wt of orphaned) {
+      await resumeWorktree(wt, parsed, d);
+    }
+    return;
+  }
+
+  // Single worktree resume
+  const target = parsed.target ?? "";
+  const resolved = resolveWorktree(target, mcxWorktrees);
+
+  if (!resolved) {
+    // Also try resolving against all worktrees (not just mcx ones)
+    const resolvedAll = resolveWorktree(target, allWorktrees);
+    if (resolvedAll) {
+      d.printError(`Worktree "${target}" exists but is not an mcx worktree (not under .claude/worktrees/).`);
+    } else {
+      d.printError(`No worktree matching "${target}". Use "mcx claude worktrees" to list available worktrees.`);
+    }
+    d.exit(1);
+  }
+
+  // Check if it already has an active session
+  const wtName = resolved.path.slice(`${worktreeParent}/`.length);
+  if (sessionWorktrees.has(wtName)) {
+    d.printError(`Worktree "${wtName}" already has an active session. Use "mcx claude send" to interact with it.`);
+    d.exit(1);
+  }
+
+  await resumeWorktree(resolved, parsed, d);
+}
+
+async function resumeWorktree(
+  wt: { path: string; branch: string | null },
+  parsed: ResumeArgs,
+  d: ClaudeDeps,
+): Promise<void> {
+  const branch = wt.branch ?? "unknown";
+
+  // Check if branch is already merged into main
+  const { stdout: mergedOutput } = d.exec(["git", "-C", wt.path, "branch", "--merged", "main"]);
+  const mergedBranches = mergedOutput.split("\n").map((l) => l.trim().replace(/^\* /, ""));
+  if (mergedBranches.includes(branch)) {
+    d.printError(`Skipping "${branch}" — already merged into main. Use "mcx claude worktrees --prune" to clean up.`);
+    return;
+  }
+
+  // Gather context
+  const { stdout: gitLog } = d.exec(["git", "-C", wt.path, "log", "--oneline", `main..${branch}`, "--"]);
+  const { stdout: gitDiff } = d.exec(["git", "-C", wt.path, "diff", "--stat"]);
+
+  const issueNumber = extractIssueNumber(branch);
+
+  // Check for existing PR
+  let prInfo: string | null = null;
+  const prStatus = await d.getPrStatus(wt.path);
+  if (prStatus) {
+    prInfo = `#${prStatus.number} (${prStatus.state})`;
+  }
+
+  const prompt = buildResumePrompt({ branch, issueNumber, gitLog, gitDiff, prInfo });
+
+  // Spawn a new session with cwd set to the worktree path (not --worktree, which would create a new one)
+  const toolArgs: Record<string, unknown> = { prompt, cwd: wt.path };
+  if (parsed.allow.length > 0) toolArgs.allowedTools = parsed.allow;
+  if (parsed.model) toolArgs.model = parsed.model;
+  if (parsed.timeout) toolArgs.timeout = parsed.timeout;
+  if (parsed.wait) toolArgs.wait = true;
+
+  d.printError(`Resuming session in ${wt.path} (branch: ${branch})`);
   const result = await d.callTool("claude_prompt", toolArgs);
   console.log(formatToolResult(result));
 }
@@ -807,6 +1064,8 @@ function printClaudeUsage(): void {
 Usage:
   mcx claude spawn --task "description"    Start a new Claude session (non-blocking)
   mcx claude spawn "description"           Shorthand (positional task)
+  mcx claude resume <worktree-or-branch>   Resume work in an orphaned worktree
+  mcx claude resume --all                  Resume all orphaned worktrees
   mcx claude ls [--pr]                     List active sessions (--pr shows PR number/status)
   mcx claude send <session> <message>      Send follow-up prompt (non-blocking)
   mcx claude wait [session]                Block until a session event occurs
@@ -827,6 +1086,13 @@ Spawn options:
   --resume <id>               Resume a previous session
   --allow <tools...>          Pre-approved tool patterns (default: Read Glob Grep Write Edit)
   --cwd <path>                Working directory for Claude
+  --timeout <ms>              Max wait time (default: 300000, only with --wait)
+
+Resume options:
+  --all                       Resume all orphaned worktrees (batch mode)
+  --model, -m <name>          Model to use: opus, sonnet, haiku, or full ID
+  --allow <tools...>          Pre-approved tool patterns
+  --wait                      Block until Claude produces a result
   --timeout <ms>              Max wait time (default: 300000, only with --wait)
 
 Send options:


### PR DESCRIPTION
## Summary
- Adds `mcx claude resume <worktree-path-or-branch>` command to spawn a new Claude session in an existing orphaned worktree, with full git context (branch, commits, diff, PR status, issue number)
- Supports `--all` flag to batch-resume all orphaned worktrees at once
- Detects already-merged branches and skips them with a helpful message; detects active sessions and warns instead of double-spawning

## Test plan
- [x] `parseResumeArgs` — all flags (--all, --model, --allow, --wait, --timeout) and error cases
- [x] `extractIssueNumber` — various branch name conventions, non-matching branches
- [x] `resolveWorktree` — resolution by full path, directory name, and branch name
- [x] `buildResumePrompt` — includes/omits sections based on available context
- [x] `cmdClaude resume` integration tests — error on missing target, worktree not found, active session conflict, merged branch skip, correct spawn args, --all batch mode, option passthrough
- [x] All 1607 tests pass, coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)