### PR TITLE
test(core): add edge-case tests for type guards and nextId (fixes #50)

### DIFF
--- a/packages/core/src/config.spec.ts
+++ b/packages/core/src/config.spec.ts
@@ -12,6 +12,11 @@ describe("isStdioConfig", () => {
     const config: ServerConfig = { type: "http", url: "https://example.com" };
     expect(isStdioConfig(config)).toBe(false);
   });
+
+  test("returns true when both command and url are present (stdio wins)", () => {
+    const config = { command: "node", url: "https://example.com" } as ServerConfig;
+    expect(isStdioConfig(config)).toBe(true);
+  });
 });
 
 describe("isHttpConfig", () => {
@@ -22,6 +27,16 @@ describe("isHttpConfig", () => {
 
   test("returns false for type: sse with url", () => {
     const config: ServerConfig = { type: "sse", url: "https://example.com" };
+    expect(isHttpConfig(config)).toBe(false);
+  });
+
+  test("returns false for config with command", () => {
+    const config: ServerConfig = { command: "node", args: ["server.js"] };
+    expect(isHttpConfig(config)).toBe(false);
+  });
+
+  test("returns false for url with no type and no command", () => {
+    const config = { url: "https://example.com" } as ServerConfig;
     expect(isHttpConfig(config)).toBe(false);
   });
 });
@@ -41,6 +56,14 @@ describe("isSseConfig", () => {
     // Previously this would have defaulted to SSE — now it must be explicit
     const config = { url: "https://example.com" } as ServerConfig;
     expect(isSseConfig(config)).toBe(false);
+  });
+
+  test("returns false when command is present even with url", () => {
+    const config = { command: "node", url: "https://example.com", type: "sse" } as ServerConfig;
+    // isSseConfig only checks url + type, but getTransportType checks stdio first
+    expect(isSseConfig(config)).toBe(true);
+    // However, getTransportType would route this to stdio
+    expect(getTransportType(config)).toBe("stdio");
   });
 });
 

--- a/packages/core/src/ipc.spec.ts
+++ b/packages/core/src/ipc.spec.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test";
+import { nextId } from "./ipc";
+
+describe("nextId", () => {
+  test("returns sequential IDs with r prefix", () => {
+    const id1 = nextId();
+    const id2 = nextId();
+    const id3 = nextId();
+
+    // IDs should match r<number> pattern
+    expect(id1).toMatch(/^r\d+$/);
+    expect(id2).toMatch(/^r\d+$/);
+    expect(id3).toMatch(/^r\d+$/);
+
+    // Each call should increment
+    const num1 = Number.parseInt(id1.slice(1), 10);
+    const num2 = Number.parseInt(id2.slice(1), 10);
+    const num3 = Number.parseInt(id3.slice(1), 10);
+    expect(num2).toBe(num1 + 1);
+    expect(num3).toBe(num2 + 1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add missing edge-case tests for `isStdioConfig`, `isHttpConfig`, `isSseConfig` in `config.spec.ts` (command+url precedence, negative cases, stdio override behavior)
- Create `ipc.spec.ts` with sequential ID generation tests for `nextId()`
- Both `config.ts` and `ipc.ts` now at 100% line/function coverage

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — all 1614 tests pass (16 in the modified/new files)
- [x] 100% line coverage on `config.ts` and `ipc.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)