### PR TITLE
fix(control): disambiguate transcript detail React keys (fixes #239)

### DIFF
--- a/packages/control/src/components/claude-session-detail.tsx
+++ b/packages/control/src/components/claude-session-detail.tsx
@@ -106,10 +106,10 @@ export function ClaudeSessionDetail({ sessionId }: ClaudeSessionDetailProps) {
 
   return (
     <Box flexDirection="column" marginLeft={4}>
-      {entries.map((entry) => {
+      {entries.map((entry, i) => {
         const arrow = entry.direction === "outbound" ? "→" : "←";
         const color = entry.direction === "outbound" ? "cyan" : "white";
-        const key = `${entry.timestamp}-${entry.direction}`;
+        const key = `${entry.timestamp}-${entry.direction}-${i}`;
         return (
           <Text key={key} wrap="truncate">
             <Text dimColor>{arrow}</Text> <Text color={color}>{summarizeEntry(entry)}</Text>


### PR DESCRIPTION
## Summary
- Include array index in transcript entry React keys to prevent collisions when rapid tool sequences produce entries with identical timestamps and directions
- Changes `${timestamp}-${direction}` to `${timestamp}-${direction}-${index}` in `claude-session-detail.tsx`

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] All tests pass (pre-existing flaky failures in unrelated daemon tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)