### PR TITLE
docs: document missing CLI commands in README (fixes #364)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,12 @@ mcx config set <key> <value>        # set CLI option or server env var
 mcx status                          # daemon PID, uptime, server states
 mcx restart [server]                # reconnect server(s)
 mcx daemon restart                  # restart daemon (kills sessions)
-mcx daemon shutdown                 # stop the daemon
+mcx daemon shutdown                 # stop the daemon (alias: daemon stop)
+mcx shutdown                        # stop the daemon (legacy shorthand)
+mcx version                         # show CLI, daemon, and protocol versions
+mcx metrics                         # show daemon metrics (Prometheus-style)
+mcx spans                           # list trace spans
+mcx spans prune                     # delete exported spans
 mcx logs <server> [-f]              # view server stderr output
 mcx logs --daemon [-f]              # view daemon log file
 ```
@@ -139,12 +144,16 @@ Spawn and manage headless Claude Code sessions:
 ```bash
 mcx claude spawn --task "describe the work"   # start a session (non-blocking)
 mcx claude spawn -w --task "work in isolation" # start in a git worktree
-mcx claude ls                                  # list active sessions
+mcx claude ls                                  # list active sessions (alias: list)
 mcx claude send <session> <message>            # send follow-up prompt
 mcx claude wait [session]                      # block until session event
 mcx claude log <session> [--last N]            # view session transcript
 mcx claude interrupt <session>                 # interrupt current turn
-mcx claude bye <session>                       # end session (cleans up worktree)
+mcx claude bye <session>                       # end session (alias: quit)
+mcx claude resume <worktree-or-branch>         # reattach to orphaned worktree session
+mcx claude resume --all                        # resume all orphaned worktree sessions
+mcx claude worktrees                           # list mcx-created worktrees (alias: wt)
+mcx claude worktrees --prune                   # remove orphaned worktrees + merged branches
 ```
 
 Session IDs support prefix matching (like git SHAs). Use `--wait` on `spawn` or `send` to block until Claude produces a result. Use `--json` on `ls` or `log` for machine-readable output.


### PR DESCRIPTION
## Summary
- Add undocumented commands to Auth & Management section: `mcx version`, `mcx metrics`, `mcx spans`, `mcx shutdown`, and `daemon stop` alias
- Add missing Claude Session subcommands: `mcx claude resume`, `mcx claude worktrees` (with `--prune`)
- Note command aliases inline: `daemon stop`, `claude list`, `claude quit`, `claude wt`

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (1609 tests)
- [x] Verified each documented command exists in source (`index.ts`, `claude.ts`, `spans.ts`, `version.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)