### PR TITLE
docs: add missing db.ts to estimate skill tools list (fixes #370)

### DIFF
--- a/.claude/skills/estimate/SKILL.md
+++ b/.claude/skills/estimate/SKILL.md
@@ -51,6 +51,7 @@ Everything else is low scrutiny.
 - `embed.ts` — text embeddings for PR similarity (research; not used in triage)
 - `validate.ts` — method comparison (proves triage > prediction)
 - `validate-triage.ts` — validates triage rules against historical data
+- `db.ts` — shared SQLite database helpers (used by backfill, validate, triage)
 
 ## Data
 


### PR DESCRIPTION
## Summary
- Added `db.ts` (shared SQLite database helpers) to the estimate SKILL.md Tools section — it was the only tool file not listed
- The typo ("orchistrator") mentioned in the issue was already fixed in a prior commit

## Test plan
- [x] Verified `db.ts` exists in `.claude/skills/estimate/`
- [x] Confirmed the typo is already corrected (grepped for "orchistrat" — no matches)
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (1609 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)