### PR TITLE
docs: align token count figure across README and SKILL.md (fixes #365)

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,6 +1,6 @@
 # MCP CLI — Context-Free MCP Tool Access
 
-Use the `mcx` CLI via Bash instead of native MCP tools. This eliminates ~12,000 tokens of tool definitions per server from every conversation context.
+Use the `mcx` CLI via Bash instead of native MCP tools. This eliminates 15,000+ tokens of tool definitions per server from every conversation context.
 
 ## When to Use This
 


### PR DESCRIPTION
## Summary
- Aligned token count in `skill/SKILL.md` from "~12,000" to "15,000+" to match the figure used in `README.md` (lines 5 and 235)

## Test plan
- [x] Verified both files now reference the same "15,000+" figure
- [x] typecheck, lint, and tests all pass (1614 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)