### PR TITLE
fix(daemon): resolve waitForEvent immediately for already-idle sessions (fixes #382)

### DIFF
--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -856,6 +856,91 @@ describe("ClaudeWsServer", () => {
     expect((err as Error).message).toContain("Timeout");
   });
 
+  test("waitForEvent resolves immediately when session is already idle", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn });
+    const port = server.start();
+
+    server.prepareSession("test-session", { prompt: "Hello" });
+    server.spawnClaude("test-session");
+
+    const ws = await connectMockClaude(port, "test-session");
+    try {
+      await waitForMessage(ws); // consume initial user message
+
+      // Drive session to idle state
+      ws.send(systemInitMessage("test-session"));
+      ws.send(resultMessage("test-session"));
+      await pollUntil(() => server?.listSessions().some((s) => s.sessionId === "test-session" && s.state === "idle"));
+
+      // waitForEvent should resolve immediately — session is already idle
+      const event = await server.waitForEvent("test-session", 1000);
+      expect(event.sessionId).toBe("test-session");
+      expect(event.event).toBe("session:result");
+      expect(event.cost).toBe(0.01);
+      expect(event.numTurns).toBe(1);
+    } finally {
+      ws.close();
+    }
+  });
+
+  test("waitForEvent resolves immediately when any session is idle (null filter)", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn });
+    const port = server.start();
+
+    server.prepareSession("s1", { prompt: "Hello" });
+    server.spawnClaude("s1");
+
+    const ws = await connectMockClaude(port, "s1");
+    try {
+      await waitForMessage(ws);
+
+      ws.send(systemInitMessage("s1"));
+      ws.send(resultMessage("s1"));
+      await pollUntil(() => server?.listSessions().some((s) => s.sessionId === "s1" && s.state === "idle"));
+
+      // null sessionId — should find idle s1 immediately
+      const event = await server.waitForEvent(null, 1000);
+      expect(event.sessionId).toBe("s1");
+      expect(event.event).toBe("session:result");
+    } finally {
+      ws.close();
+    }
+  });
+
+  test("waitForEvent resolves immediately when session has pending permission", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn });
+    const port = server.start();
+
+    server.prepareSession("test-session", {
+      prompt: "Hello",
+      permissionStrategy: "delegate",
+    });
+    server.spawnClaude("test-session");
+
+    const ws = await connectMockClaude(port, "test-session");
+    try {
+      await waitForMessage(ws);
+
+      ws.send(systemInitMessage("test-session"));
+      ws.send(canUseToolMessage("req-perm-1"));
+      await pollUntil(() =>
+        server?.listSessions().some((s) => s.sessionId === "test-session" && s.state === "waiting_permission"),
+      );
+
+      // waitForEvent should resolve immediately with the pending permission
+      const event = await server.waitForEvent("test-session", 1000);
+      expect(event.sessionId).toBe("test-session");
+      expect(event.event).toBe("session:permission_request");
+      expect(event.requestId).toBe("req-perm-1");
+      expect(event.toolName).toBe("Bash");
+    } finally {
+      ws.close();
+    }
+  });
+
   test("waitForEvent rejects for unknown session", async () => {
     const ms = mockSpawn();
     server = new ClaudeWsServer({ spawn: ms.spawn });

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -471,10 +471,17 @@ export class ClaudeWsServer {
   /**
    * Wait for the next interesting session event (result, error, or permission_request).
    * If sessionId is provided, waits for that session only. Otherwise waits for any session.
+   *
+   * If a matching session is already idle or has pending permissions, resolves immediately
+   * with a synthetic event instead of blocking until timeout.
    */
   waitForEvent(sessionId: string | null, timeoutMs: number): Promise<SessionWaitEvent> {
     const err = this.validateWaitTarget(sessionId);
     if (err) return Promise.reject(err);
+
+    // Check if any matching session already has an actionable state
+    const immediate = this.findImmediateEvent(sessionId);
+    if (immediate) return Promise.resolve(immediate);
 
     return new Promise<SessionWaitEvent>((resolve, reject) => {
       const waiter: EventWaiter = {
@@ -709,6 +716,40 @@ export class ClaudeWsServer {
   }
 
   // ── Helpers ──
+
+  /**
+   * Check if any matching session is already in a state that should resolve immediately.
+   * Returns a synthetic event for idle sessions (result already available) or sessions
+   * with pending permissions. Returns null if no immediate event is available.
+   */
+  private findImmediateEvent(sessionId: string | null): SessionWaitEvent | null {
+    for (const [sid, session] of this.sessions) {
+      if (sessionId !== null && sid !== sessionId) continue;
+
+      if (session.state.state === "idle") {
+        return {
+          sessionId: sid,
+          event: "session:result",
+          cost: session.state.cost,
+          tokens: session.state.tokens,
+          numTurns: session.state.numTurns,
+        };
+      }
+
+      if (session.state.state === "waiting_permission" && session.state.pendingPermissions.size > 0) {
+        const entry = session.state.pendingPermissions.entries().next().value;
+        if (!entry) continue;
+        const [requestId, req] = entry;
+        return {
+          sessionId: sid,
+          event: "session:permission_request",
+          requestId,
+          toolName: req.tool_name,
+        };
+      }
+    }
+    return null;
+  }
 
   /** Validate that a wait target (sessionId or any-session) is valid. Returns null if OK, Error otherwise. */
   private validateWaitTarget(sessionId: string | null): Error | null {


### PR DESCRIPTION
## Summary
- `waitForEvent()` now checks if matching sessions are already `idle` or `waiting_permission` before creating a blocking waiter promise
- Idle sessions return a synthetic `session:result` event immediately; permission-waiting sessions return `session:permission_request`
- Fixes the orchestrator pattern where `bye → wait` times out when sessions complete between poll cycles

## Test plan
- [x] New test: `waitForEvent resolves immediately when session is already idle` — drives session to idle, then calls waitForEvent and asserts immediate resolution
- [x] New test: `waitForEvent resolves immediately when any session is idle (null filter)` — same with null sessionId filter
- [x] New test: `waitForEvent resolves immediately when session has pending permission` — tests the waiting_permission immediate path
- [x] All existing waitForEvent tests continue to pass (timeout, unknown session, no sessions, etc.)
- [x] Full suite: 1617 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)