### PR TITLE
fix(control): gate useLogs polling behind active tab check (fixes #238)

### DIFF
--- a/packages/control/src/app.tsx
+++ b/packages/control/src/app.tsx
@@ -36,7 +36,11 @@ export function App() {
     loading: claudeLoading,
     error: claudeError,
   } = useClaudeSessions({ intervalMs: view === "claude" ? 2500 : 10_000 });
-  const { lines: logLines, source: logSource, setSource: setLogSource } = useLogs(servers);
+  const {
+    lines: logLines,
+    source: logSource,
+    setSource: setLogSource,
+  } = useLogs(servers, { enabled: view === "logs" });
 
   const filteredLogLines = useMemo(() => filterLogLines(logLines, filterText), [logLines, filterText]);
   const prevFilterRef = useRef(filterText);

--- a/packages/control/src/hooks/use-logs.spec.ts
+++ b/packages/control/src/hooks/use-logs.spec.ts
@@ -82,6 +82,22 @@ describe("useLogs", () => {
     expect(maxConcurrency).toBe(1);
   });
 
+  it("does not poll when enabled is false", async () => {
+    let callCount = 0;
+    const ipcCallFn = async () => {
+      callCount++;
+      return { lines: [] };
+    };
+
+    mount({
+      enabled: false,
+      ipcCallFn: ipcCallFn as UseLogsOptions["ipcCallFn"],
+    });
+
+    await flush(50);
+    expect(callCount).toBe(0);
+  });
+
   it("cleanup stops polling on unmount", async () => {
     let callCount = 0;
     const ipcCallFn = async () => {

--- a/packages/control/src/hooks/use-logs.ts
+++ b/packages/control/src/hooks/use-logs.ts
@@ -27,12 +27,14 @@ interface UseLogsResult {
 }
 
 export interface UseLogsOptions {
+  /** Gate polling — when false, the effect is a no-op. Defaults to true. */
+  enabled?: boolean;
   /** Override ipcCall for testing (dependency injection). */
   ipcCallFn?: typeof ipcCall;
 }
 
 export function useLogs(servers: ServerStatus[], opts: UseLogsOptions = {}): UseLogsResult {
-  const { ipcCallFn = ipcCall } = opts;
+  const { enabled = true, ipcCallFn = ipcCall } = opts;
   const [source, setSourceRaw] = useState<LogSource>({ type: "daemon" });
   const [lines, setLines] = useState<LogEntry[]>([]);
   const sinceRef = useRef<number | undefined>(undefined);
@@ -51,6 +53,8 @@ export function useLogs(servers: ServerStatus[], opts: UseLogsOptions = {}): Use
   );
 
   useEffect(() => {
+    if (!enabled) return;
+
     let cancelled = false;
     let isFirst = true;
 
@@ -111,7 +115,7 @@ export function useLogs(servers: ServerStatus[], opts: UseLogsOptions = {}): Use
       cancelled = true;
       if (timerId !== undefined) clearTimeout(timerId);
     };
-  }, [source, ipcCallFn]);
+  }, [source, enabled, ipcCallFn]);
 
   return { lines, source, setSource };
 }


### PR DESCRIPTION
## Summary
- Add `enabled` option to `useLogs` hook's `UseLogsOptions`, gating the polling `useEffect` when disabled
- Pass `view === "logs"` from `app.tsx` to skip ~1 IPC call/second on non-logs tabs
- Matches the existing pattern used by `useClaudeSessions`
- Add test verifying no polls occur when `enabled: false`

**Replaces #386** which bundled unrelated regressions (reverted #376, #387, deleted tests, removed help text).

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — all 1625 tests pass (including new `enabled` test)
- [x] `enabled` parameter defaults to `true` (backwards compatible)
- [x] `useEffect` dependency array includes `enabled`
- [x] Preserves `setTimeout` chain from #376 (no overlap regression)
- [x] Preserves DI `ipcCallFn` option for testability

🤖 Generated with [Claude Code](https://claude.com/claude-code)