### PR TITLE
feat(control): denial reason prompt for Claude permission deny (fixes #253)

### DIFF
--- a/packages/control/src/app.tsx
+++ b/packages/control/src/app.tsx
@@ -28,6 +28,8 @@ export function App() {
   const [filterMode, setFilterMode] = useState(false);
   const [claudeSelectedIndex, setClaudeSelectedIndex] = useState(0);
   const [expandedSession, setExpandedSession] = useState<string | null>(null);
+  const [denyReasonMode, setDenyReasonMode] = useState(false);
+  const [denyReasonText, setDenyReasonText] = useState("");
 
   const servers = status?.servers ?? [];
   // Poll faster on claude tab, slower off-tab (badge still updates)
@@ -95,6 +97,10 @@ export function App() {
     setClaudeSelectedIndex,
     expandedSession,
     setExpandedSession,
+    denyReasonMode,
+    setDenyReasonMode,
+    denyReasonText,
+    setDenyReasonText,
   });
 
   if (loading && !status) return <Loading />;
@@ -141,7 +147,13 @@ export function App() {
           <Text dimColor>Coming soon — see #181</Text>
         </Box>
       )}
-      <Footer view={view} filterMode={filterMode} filterText={filterText} />
+      <Footer
+        view={view}
+        filterMode={filterMode}
+        filterText={filterText}
+        denyReasonMode={denyReasonMode}
+        denyReasonText={denyReasonText}
+      />
     </Box>
   );
 }

--- a/packages/control/src/components/footer.tsx
+++ b/packages/control/src/components/footer.tsx
@@ -6,9 +6,25 @@ interface FooterProps {
   view: View;
   filterMode: boolean;
   filterText: string;
+  denyReasonMode: boolean;
+  denyReasonText: string;
 }
 
-export function Footer({ view, filterMode, filterText }: FooterProps) {
+export function Footer({ view, filterMode, filterText, denyReasonMode, denyReasonText }: FooterProps) {
+  if (denyReasonMode) {
+    return (
+      <Box marginTop={1}>
+        <Text>
+          <Text color="red">deny reason:</Text> {denyReasonText}
+          <Text dimColor>█</Text>
+          {"  "}
+          <Text dimColor>enter</Text> deny{"  "}
+          <Text dimColor>esc</Text> cancel
+        </Text>
+      </Box>
+    );
+  }
+
   if (filterMode) {
     return (
       <Box marginTop={1}>

--- a/packages/control/src/hooks/use-keyboard.ts
+++ b/packages/control/src/hooks/use-keyboard.ts
@@ -47,6 +47,10 @@ interface UseKeyboardOptions {
   setClaudeSelectedIndex: (fn: (i: number) => number) => void;
   expandedSession: string | null;
   setExpandedSession: (id: string | null) => void;
+  denyReasonMode: boolean;
+  setDenyReasonMode: (mode: boolean) => void;
+  denyReasonText: string;
+  setDenyReasonText: (fn: string | ((prev: string) => string)) => void;
 }
 
 export function useKeyboard({
@@ -74,10 +78,50 @@ export function useKeyboard({
   setClaudeSelectedIndex,
   expandedSession,
   setExpandedSession,
+  denyReasonMode,
+  setDenyReasonMode,
+  denyReasonText,
+  setDenyReasonText,
 }: UseKeyboardOptions): void {
   const { exit } = useApp();
 
   useInput((input, key) => {
+    // -- Deny reason mode: capture text for denial message --
+    if (denyReasonMode) {
+      if (key.return) {
+        const selectedSession = claudeSessions[claudeSelectedIndex];
+        const perm = selectedSession?.pendingPermissionDetails?.[0];
+        if (perm) {
+          const args: Record<string, string> = {
+            sessionId: selectedSession.sessionId,
+            requestId: perm.requestId,
+          };
+          if (denyReasonText) args.message = denyReasonText;
+          ipcCall("callTool", {
+            server: "_claude",
+            tool: "claude_deny",
+            arguments: args,
+          }).catch(() => {});
+        }
+        setDenyReasonText("");
+        setDenyReasonMode(false);
+        return;
+      }
+      if (key.escape) {
+        setDenyReasonText("");
+        setDenyReasonMode(false);
+        return;
+      }
+      if (key.backspace || key.delete) {
+        setDenyReasonText((prev) => prev.slice(0, -1));
+        return;
+      }
+      if (input && !key.ctrl && !key.meta) {
+        setDenyReasonText((prev) => prev + input);
+      }
+      return;
+    }
+
     // -- Filter mode: capture all input for filter text --
     if (filterMode) {
       if (key.return) {
@@ -204,15 +248,24 @@ export function useKeyboard({
         return;
       }
 
-      // Approve / deny pending permission
-      if (input === "a" || input === "d") {
+      // Approve pending permission
+      if (input === "a") {
         const perm = selectedSession?.pendingPermissionDetails?.[0];
         if (perm) {
           ipcCall("callTool", {
             server: "_claude",
-            tool: input === "a" ? "claude_approve" : "claude_deny",
+            tool: "claude_approve",
             arguments: { sessionId: selectedSession.sessionId, requestId: perm.requestId },
           }).catch(() => {});
+        }
+        return;
+      }
+
+      // Deny pending permission — enter reason prompt
+      if (input === "d") {
+        const perm = selectedSession?.pendingPermissionDetails?.[0];
+        if (perm) {
+          setDenyReasonMode(true);
         }
         return;
       }


### PR DESCRIPTION
## Summary
- When pressing `d` to deny a permission in the Claude tab, mcpctl now enters a text input mode (like the existing log filter) where the user can type a denial reason
- Pressing Enter sends the deny with the custom message; pressing Enter with no text uses the server default
- Pressing Escape cancels without denying
- Footer shows a `deny reason:` prompt with cursor during input mode

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes  
- [x] `bun test` — all 1624 tests pass
- [x] Coverage thresholds met
- [x] Pre-commit hook passes (typecheck + lint + test + coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)