### PR TITLE
feat(control): multi-permission queue navigation in Claude tab (fixes #252)

### DIFF
--- a/packages/control/src/app.tsx
+++ b/packages/control/src/app.tsx
@@ -28,6 +28,7 @@ export function App() {
   const [filterMode, setFilterMode] = useState(false);
   const [claudeSelectedIndex, setClaudeSelectedIndex] = useState(0);
   const [expandedSession, setExpandedSession] = useState<string | null>(null);
+  const [permissionIndex, setPermissionIndex] = useState(0);
 
   const servers = status?.servers ?? [];
   // Poll faster on claude tab, slower off-tab (badge still updates)
@@ -58,6 +59,19 @@ export function App() {
   useEffect(() => {
     setClaudeSelectedIndex((i) => Math.min(i, Math.max(0, sessions.length - 1)));
   }, [sessions.length]);
+
+  // Clamp permission index when selected session or permission count changes
+  const selectedSessionId = sessions[claudeSelectedIndex]?.sessionId;
+  const permCount = sessions[claudeSelectedIndex]?.pendingPermissionDetails?.length ?? 0;
+  const prevSessionRef = useRef(selectedSessionId);
+  useEffect(() => {
+    if (prevSessionRef.current !== selectedSessionId) {
+      prevSessionRef.current = selectedSessionId;
+      setPermissionIndex(0);
+    } else {
+      setPermissionIndex((i) => Math.min(i, Math.max(0, permCount - 1)));
+    }
+  }, [selectedSessionId, permCount]);
 
   // Auto-clear success/error auth status after 5 seconds
   useEffect(() => {
@@ -95,6 +109,8 @@ export function App() {
     setClaudeSelectedIndex,
     expandedSession,
     setExpandedSession,
+    permissionIndex,
+    setPermissionIndex,
   });
 
   if (loading && !status) return <Loading />;
@@ -135,6 +151,7 @@ export function App() {
           expandedSession={expandedSession}
           loading={claudeLoading}
           error={claudeError}
+          permissionIndex={permissionIndex}
         />
       ) : (
         <Box marginTop={1}>

--- a/packages/control/src/components/claude-session-list.tsx
+++ b/packages/control/src/components/claude-session-list.tsx
@@ -9,6 +9,7 @@ interface ClaudeSessionListProps {
   expandedSession: string | null;
   loading: boolean;
   error: string | null;
+  permissionIndex: number;
 }
 
 const stateColor: Record<SessionStateEnum, string> = {
@@ -60,6 +61,7 @@ export function ClaudeSessionList({
   expandedSession,
   loading,
   error,
+  permissionIndex,
 }: ClaudeSessionListProps) {
   if (loading && sessions.length === 0) {
     return (
@@ -125,18 +127,26 @@ export function ClaudeSessionList({
             </Text>
             {selected && session.pendingPermissionDetails?.length > 0 && (
               <Box flexDirection="column" marginLeft={4}>
-                {session.pendingPermissionDetails.map((perm) => (
-                  <Text key={perm.requestId} color="yellow">
-                    {"└─ "}
-                    <Text bold>{perm.toolName}</Text>
-                    {perm.inputSummary ? <Text dimColor>({perm.inputSummary})</Text> : null}
-                    {" — "}
-                    <Text color="green">[a]</Text>
-                    <Text>pprove </Text>
-                    <Text color="red">[d]</Text>
-                    <Text>eny</Text>
-                  </Text>
-                ))}
+                {session.pendingPermissionDetails.map((perm, permIdx) => {
+                  const targeted = permIdx === permissionIndex;
+                  return (
+                    <Text key={perm.requestId} color={targeted ? "yellow" : "gray"}>
+                      {targeted ? "▸ " : "  "}
+                      <Text bold={targeted}>{perm.toolName}</Text>
+                      {perm.inputSummary ? <Text dimColor>({perm.inputSummary})</Text> : null}
+                      {targeted && (
+                        <>
+                          {" — "}
+                          <Text color="green">[a]</Text>
+                          <Text>pprove </Text>
+                          <Text color="red">[d]</Text>
+                          <Text>eny</Text>
+                        </>
+                      )}
+                    </Text>
+                  );
+                })}
+                {session.pendingPermissionDetails.length > 1 && <Text dimColor>{"  ←/→ navigate permissions"}</Text>}
               </Box>
             )}
             {expanded && <ClaudeSessionDetail sessionId={session.sessionId} />}

--- a/packages/control/src/hooks/use-keyboard.ts
+++ b/packages/control/src/hooks/use-keyboard.ts
@@ -47,6 +47,8 @@ interface UseKeyboardOptions {
   setClaudeSelectedIndex: (fn: (i: number) => number) => void;
   expandedSession: string | null;
   setExpandedSession: (id: string | null) => void;
+  permissionIndex: number;
+  setPermissionIndex: (fn: (i: number) => number) => void;
 }
 
 export function useKeyboard({
@@ -74,6 +76,8 @@ export function useKeyboard({
   setClaudeSelectedIndex,
   expandedSession,
   setExpandedSession,
+  permissionIndex,
+  setPermissionIndex,
 }: UseKeyboardOptions): void {
   const { exit } = useApp();
 
@@ -196,6 +200,17 @@ export function useKeyboard({
         return;
       }
 
+      // Navigate pending permissions within selected session
+      if (key.leftArrow) {
+        setPermissionIndex((i) => Math.max(0, i - 1));
+        return;
+      }
+      if (key.rightArrow) {
+        const permCount = selectedSession?.pendingPermissionDetails?.length ?? 0;
+        setPermissionIndex((i) => Math.min(Math.max(0, permCount - 1), i + 1));
+        return;
+      }
+
       // Toggle transcript detail
       if (key.return) {
         if (selectedSession) {
@@ -204,9 +219,9 @@ export function useKeyboard({
         return;
       }
 
-      // Approve / deny pending permission
+      // Approve / deny targeted pending permission
       if (input === "a" || input === "d") {
-        const perm = selectedSession?.pendingPermissionDetails?.[0];
+        const perm = selectedSession?.pendingPermissionDetails?.[permissionIndex];
         if (perm) {
           ipcCall("callTool", {
             server: "_claude",


### PR DESCRIPTION
## Summary
- Add left/right arrow key navigation to cycle through pending permissions within a selected Claude session
- Highlight the currently targeted permission with `▸` indicator; non-targeted permissions shown in gray
- `a`/`d` keys now act on the targeted permission instead of always the first one
- Show `←/→ navigate permissions` hint when multiple permissions are pending

## Test plan
- [ ] Open mcpctl, switch to Claude tab with a session that has multiple pending permissions
- [ ] Verify left/right arrows cycle the `▸` indicator between permissions
- [ ] Verify `a` approves and `d` denies the targeted (highlighted) permission
- [ ] Verify permission index resets when switching sessions
- [ ] Verify permission index clamps when permissions are resolved
- [ ] All 1624 tests pass, typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)