### PR TITLE
feat(command): add transitional mcp → mcx deprecation warning (fixes #135)

### DIFF
--- a/packages/command/src/deprecation.ts
+++ b/packages/command/src/deprecation.ts
@@ -1,0 +1,18 @@
+/**
+ * Transitional deprecation warning for the `mcp` → `mcx` rename.
+ */
+
+/**
+ * Check if the CLI was invoked via the deprecated `mcp` name and warn on stderr.
+ * Returns true if the deprecated name was detected.
+ */
+export function checkDeprecatedName(argv1: string): boolean {
+  const base = argv1.split("/").pop() ?? "";
+  if (base === "mcp" || base === "mcp.exe") {
+    console.error(
+      'Warning: "mcp" has been renamed to "mcx". Please update your scripts. "mcp" will be removed in a future release.',
+    );
+    return true;
+  }
+  return false;
+}

--- a/packages/command/src/index.spec.ts
+++ b/packages/command/src/index.spec.ts
@@ -1,5 +1,66 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { checkDeprecatedName } from "./deprecation";
 import { extractJsonFlag } from "./parse";
+
+describe("checkDeprecatedName", () => {
+  let stderrOutput: string[] = [];
+  const origError = console.error;
+
+  afterEach(() => {
+    console.error = origError;
+    stderrOutput = [];
+  });
+
+  function captureStderr(): void {
+    console.error = (...args: unknown[]) => {
+      stderrOutput.push(args.map(String).join(" "));
+    };
+  }
+
+  test("returns true and warns when invoked as 'mcp'", () => {
+    captureStderr();
+    expect(checkDeprecatedName("/usr/local/bin/mcp")).toBe(true);
+    expect(stderrOutput.length).toBe(1);
+    expect(stderrOutput[0]).toContain("renamed to");
+    expect(stderrOutput[0]).toContain("mcx");
+  });
+
+  test("returns true for bare 'mcp' without path", () => {
+    captureStderr();
+    expect(checkDeprecatedName("mcp")).toBe(true);
+    expect(stderrOutput.length).toBe(1);
+  });
+
+  test("returns true for mcp.exe on Windows", () => {
+    captureStderr();
+    expect(checkDeprecatedName("C:/bin/mcp.exe")).toBe(true);
+    expect(stderrOutput.length).toBe(1);
+  });
+
+  test("returns false for 'mcx'", () => {
+    captureStderr();
+    expect(checkDeprecatedName("/usr/local/bin/mcx")).toBe(false);
+    expect(stderrOutput.length).toBe(0);
+  });
+
+  test("returns false for 'mcpd'", () => {
+    captureStderr();
+    expect(checkDeprecatedName("/usr/local/bin/mcpd")).toBe(false);
+    expect(stderrOutput.length).toBe(0);
+  });
+
+  test("returns false for 'mcpctl'", () => {
+    captureStderr();
+    expect(checkDeprecatedName("/usr/local/bin/mcpctl")).toBe(false);
+    expect(stderrOutput.length).toBe(0);
+  });
+
+  test("returns false for empty string", () => {
+    captureStderr();
+    expect(checkDeprecatedName("")).toBe(false);
+    expect(stderrOutput.length).toBe(0);
+  });
+});
 
 describe("extractJsonFlag", () => {
   test("extracts -j flag", () => {

--- a/packages/command/src/index.ts
+++ b/packages/command/src/index.ts
@@ -36,6 +36,7 @@ import { cmdTty } from "./commands/tty";
 import { cmdTypegen } from "./commands/typegen";
 import { cmdVersion } from "./commands/version";
 import { ipcCall, isDaemonInitializing, isDaemonRunning, stopDaemon } from "./daemon-lifecycle";
+import { checkDeprecatedName } from "./deprecation";
 import { readFileWithLimit } from "./file-read";
 import { SIZE_HINT, SIZE_OK, applyJqFilter, generateAnalysis } from "./jq/index";
 import {
@@ -58,6 +59,7 @@ import {
 import { searchRegistry } from "./registry/client";
 
 async function main(): Promise<void> {
+  checkDeprecatedName(process.argv[1] ?? "");
   const args = process.argv.slice(2);
 
   if (args.includes("--version") || args.includes("-v")) {

--- a/scripts/homebrew-formula.rb
+++ b/scripts/homebrew-formula.rb
@@ -30,6 +30,8 @@ class McpCli < Formula
     bin.install "mcx"
     bin.install "mcpd"
     bin.install "mcpctl"
+    # Transitional symlink: mcp → mcx (deprecated name)
+    bin.install_symlink "mcx" => "mcp"
   end
 
   test do

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -51,7 +51,10 @@ mv "$TMP/mcpd-${TARGET}" "$INSTALL_DIR/mcpd"
 mv "$TMP/mcpctl-${TARGET}" "$INSTALL_DIR/mcpctl"
 chmod +x "$INSTALL_DIR/mcx" "$INSTALL_DIR/mcpd" "$INSTALL_DIR/mcpctl"
 
-echo "Installed mcx, mcpd, and mcpctl to $INSTALL_DIR"
+# Transitional symlink: mcp → mcx (deprecated name)
+ln -sf "$INSTALL_DIR/mcx" "$INSTALL_DIR/mcp"
+
+echo "Installed mcx, mcpd, mcpctl, and mcp (deprecated symlink) to $INSTALL_DIR"
 
 # Check if install dir is in PATH
 case ":$PATH:" in


### PR DESCRIPTION
## Summary
- When the CLI is invoked as `mcp` (via symlink), prints a deprecation warning to stderr: `Warning: "mcp" has been renamed to "mcx". Please update your scripts. "mcp" will be removed in a future release.`
- `scripts/install.sh` now creates an `mcp` → `mcx` symlink after installing binaries
- `scripts/homebrew-formula.rb` now creates an `mcp` → `mcx` symlink via `bin.install_symlink`
- Detection logic extracted to `packages/command/src/deprecation.ts` for testability

## Test plan
- [x] 7 new tests in `index.spec.ts` covering: bare `mcp`, full path `/usr/local/bin/mcp`, Windows `mcp.exe`, and negative cases (`mcx`, `mcpd`, `mcpctl`, empty string)
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] All 805 command package tests pass (0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)