### PR TITLE
feat(daemon): JSONL file fallback for large transcript requests (fixes #184)

### DIFF
--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -1,8 +1,11 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { serialize } from "./ndjson";
 import type { SessionEvent } from "./session-state";
 import type { SpawnFn, WaitResult } from "./ws-server";
-import { ClaudeWsServer, WaitTimeoutError, summarizeInput } from "./ws-server";
+import { ClaudeWsServer, WaitTimeoutError, readJsonlTranscript, resolveJsonlPath, summarizeInput } from "./ws-server";
 
 // ── Mock spawn ──
 
@@ -1477,5 +1480,235 @@ describe("summarizeInput", () => {
 
   test("JSON-stringifies non-string values", () => {
     expect(summarizeInput({ count: 42 })).toBe("count=42");
+  });
+});
+
+// ── JSONL fallback tests ──
+
+describe("resolveJsonlPath", () => {
+  test("encodes cwd with dashes and appends session ID", () => {
+    const path = resolveJsonlPath("/Users/alice/code", "abc-123");
+    expect(path).toBe(join(homedir(), ".claude/projects/-Users-alice-code/abc-123.jsonl"));
+  });
+});
+
+describe("readJsonlTranscript", () => {
+  const testDir = join(homedir(), ".claude", "projects", "-tmp-jsonl-test");
+  const sessionId = "test-session-id";
+  const filePath = join(testDir, `${sessionId}.jsonl`);
+
+  afterEach(() => {
+    try {
+      rmSync(testDir, { recursive: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  test("returns null when cwd is null", () => {
+    expect(readJsonlTranscript(null, sessionId, 10)).toBeNull();
+  });
+
+  test("returns null when claudeSessionId is null", () => {
+    expect(readJsonlTranscript("/tmp/jsonl-test", null, 10)).toBeNull();
+  });
+
+  test("returns null when file does not exist", () => {
+    expect(readJsonlTranscript("/tmp/nonexistent-dir-xyz", sessionId, 10)).toBeNull();
+  });
+
+  test("reads user and assistant messages from JSONL file", () => {
+    mkdirSync(testDir, { recursive: true });
+    const lines = [
+      JSON.stringify({
+        type: "user",
+        message: { role: "user", content: "Hello" },
+        timestamp: "2026-01-01T00:00:00.000Z",
+        sessionId,
+      }),
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          id: "msg-1",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [{ type: "text", text: "Hi!" }],
+          stop_reason: "end_turn",
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+        timestamp: "2026-01-01T00:00:01.000Z",
+        sessionId,
+      }),
+      JSON.stringify({
+        type: "result",
+        subtype: "success",
+        is_error: false,
+        result: "Done",
+        timestamp: "2026-01-01T00:00:02.000Z",
+        sessionId,
+      }),
+    ];
+    writeFileSync(filePath, `${lines.join("\n")}\n`);
+
+    const entries = readJsonlTranscript("/tmp/jsonl-test", sessionId, 10);
+    expect(entries).not.toBeNull();
+    expect(entries?.length).toBe(3);
+    expect(entries?.[0].direction).toBe("outbound"); // user
+    expect(entries?.[1].direction).toBe("inbound"); // assistant
+    expect(entries?.[2].direction).toBe("inbound"); // result
+    expect(entries?.[0].timestamp).toBe(new Date("2026-01-01T00:00:00.000Z").getTime());
+  });
+
+  test("filters out non-transcript types", () => {
+    mkdirSync(testDir, { recursive: true });
+    const lines = [
+      JSON.stringify({ type: "file-history-snapshot", timestamp: "2026-01-01T00:00:00.000Z" }),
+      JSON.stringify({ type: "user", message: { role: "user", content: "Hi" }, timestamp: "2026-01-01T00:00:01.000Z" }),
+      JSON.stringify({ type: "stream_event", event: {}, timestamp: "2026-01-01T00:00:02.000Z" }),
+    ];
+    writeFileSync(filePath, `${lines.join("\n")}\n`);
+
+    const entries = readJsonlTranscript("/tmp/jsonl-test", sessionId, 10);
+    expect(entries).not.toBeNull();
+    expect(entries?.length).toBe(1);
+    expect((entries?.[0].message as Record<string, unknown>).type).toBe("user");
+  });
+
+  test("returns last N entries when file has more", () => {
+    mkdirSync(testDir, { recursive: true });
+    const lines = Array.from({ length: 20 }, (_, i) =>
+      JSON.stringify({
+        type: "user",
+        message: { role: "user", content: `Message ${i}` },
+        timestamp: `2026-01-01T00:00:${String(i).padStart(2, "0")}.000Z`,
+      }),
+    );
+    writeFileSync(filePath, `${lines.join("\n")}\n`);
+
+    const entries = readJsonlTranscript("/tmp/jsonl-test", sessionId, 5);
+    expect(entries).not.toBeNull();
+    expect(entries?.length).toBe(5);
+    expect((entries?.[0].message as Record<string, unknown>).message).toEqual({
+      role: "user",
+      content: "Message 15",
+    });
+  });
+
+  test("skips malformed lines gracefully", () => {
+    mkdirSync(testDir, { recursive: true });
+    const lines = [
+      "not valid json",
+      JSON.stringify({
+        type: "user",
+        message: { role: "user", content: "Valid" },
+        timestamp: "2026-01-01T00:00:00.000Z",
+      }),
+      "{broken",
+    ];
+    writeFileSync(filePath, `${lines.join("\n")}\n`);
+
+    const entries = readJsonlTranscript("/tmp/jsonl-test", sessionId, 10);
+    expect(entries).not.toBeNull();
+    expect(entries?.length).toBe(1);
+  });
+});
+
+describe("getTranscript JSONL fallback", () => {
+  const testDir = join(homedir(), ".claude", "projects", "-test-cwd");
+  const claudeSessionId = "claude-session-for-transcript";
+  const filePath = join(testDir, `${claudeSessionId}.jsonl`);
+  let server: ClaudeWsServer;
+  let spawnState: ReturnType<typeof mockSpawn>;
+
+  afterEach(() => {
+    // Resolve mock spawn exit to prevent stop() from hanging
+    spawnState?.exitResolve(0);
+    server?.stop();
+    try {
+      rmSync(testDir, { recursive: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  test("falls back to JSONL file when buffer has fewer entries than requested", async () => {
+    // Create JSONL file with 5 entries
+    mkdirSync(testDir, { recursive: true });
+    const lines = Array.from({ length: 5 }, (_, i) =>
+      JSON.stringify({
+        type: "user",
+        message: { role: "user", content: `JSONL msg ${i}` },
+        timestamp: `2026-01-01T00:00:${String(i).padStart(2, "0")}.000Z`,
+      }),
+    );
+    writeFileSync(filePath, `${lines.join("\n")}\n`);
+
+    // Set up server with a session
+    spawnState = mockSpawn();
+    server = new ClaudeWsServer({ spawn: spawnState.spawn });
+    server.start();
+
+    const sessionId = "test-session-1";
+    server.prepareSession(sessionId, { prompt: "test", cwd: "/test-cwd" });
+    server.spawnClaude(sessionId);
+
+    // Connect mock client and send system/init so claudeSessionId is captured
+    const ws = await connectMockClaude(server.port, sessionId);
+    await waitForMessage(ws); // consume initial prompt
+
+    ws.send(
+      serialize({
+        type: "system",
+        subtype: "init",
+        cwd: "/test-cwd",
+        session_id: claudeSessionId,
+        tools: [],
+        mcp_servers: [],
+        model: "claude-sonnet-4-6",
+        permissionMode: "default",
+        apiKeySource: "test",
+        claude_code_version: "2.1.70",
+        uuid: "test-uuid",
+      }),
+    );
+
+    // Wait for init to be processed
+    await pollUntil(() => {
+      const status = server.getStatus(sessionId);
+      return status.model === "claude-sonnet-4-6";
+    });
+
+    // Buffer has 1 entry (the outbound prompt), requesting 200 exceeds it
+    const transcript = server.getTranscript(sessionId, 200);
+    // Should get 5 entries from JSONL (not just the 1 in buffer)
+    expect(transcript.length).toBe(5);
+    expect((transcript[0].message as Record<string, unknown>).message).toEqual({
+      role: "user",
+      content: "JSONL msg 0",
+    });
+
+    ws.close();
+  });
+
+  test("returns buffer entries when request fits in buffer", async () => {
+    spawnState = mockSpawn();
+    server = new ClaudeWsServer({ spawn: spawnState.spawn });
+    server.start();
+
+    const sessionId = "test-session-2";
+    server.prepareSession(sessionId, { prompt: "hello", cwd: "/test-cwd" });
+    server.spawnClaude(sessionId);
+
+    // Connect so the initial prompt is added to transcript
+    const ws = await connectMockClaude(server.port, sessionId);
+    await waitForMessage(ws); // consume initial prompt
+
+    // Buffer has 1 entry (the outbound prompt); requesting 1 should use buffer
+    const transcript = server.getTranscript(sessionId, 1);
+    expect(transcript.length).toBe(1);
+    expect(transcript[0].direction).toBe("outbound");
+
+    ws.close();
   });
 });

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -9,6 +9,9 @@
  * Waiting for `system/init` first causes deadlock.
  */
 
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import type { PendingPermissionInfo, SessionInfo, SessionStateEnum } from "@mcp-cli/core";
 import type { ServerWebSocket } from "bun";
 import type { NdjsonMessage } from "./ndjson";
@@ -118,6 +121,8 @@ interface WsSession {
   resultWaiters: ResultWaiter[];
   keepAliveTimer: Timer | null;
   clearing: boolean;
+  /** Claude Code's own session ID (from system/init), used for JSONL file lookup. */
+  claudeSessionId: string | null;
 }
 
 interface WsData {
@@ -237,6 +242,7 @@ export class ClaudeWsServer {
       resultWaiters: [],
       keepAliveTimer: null,
       clearing: false,
+      claudeSessionId: null,
     });
   }
 
@@ -417,12 +423,23 @@ export class ClaudeWsServer {
     return [...this.sessions.entries()].map(([sessionId, s]) => this.buildSessionInfo(sessionId, s));
   }
 
-  /** Get transcript for a session. */
+  /** Get transcript for a session. Falls back to JSONL file when requesting more entries than the ring buffer holds. */
   getTranscript(sessionId: string, last?: number): TranscriptEntry[] {
     const session = this.getSession(sessionId);
-    if (last !== undefined && last > 0) {
-      return session.transcript.slice(-last);
+    const bufferHasEnough = last === undefined || last <= session.transcript.length;
+
+    if (bufferHasEnough) {
+      if (last !== undefined && last > 0) {
+        return session.transcript.slice(-last);
+      }
+      return [...session.transcript];
     }
+
+    // Fall back to JSONL file on disk
+    const entries = readJsonlTranscript(session.state.cwd, session.claudeSessionId, last);
+    if (entries) return entries;
+
+    // JSONL unavailable — return whatever the buffer has
     return [...session.transcript];
   }
 
@@ -637,6 +654,10 @@ export class ClaudeWsServer {
 
   private handleSessionEvent(sessionId: string, session: WsSession, event: SessionEvent): void {
     switch (event.type) {
+      case "session:init":
+        // Capture Claude Code's own session ID for JSONL file lookup
+        session.claudeSessionId = event.sessionId;
+        break;
       case "session:permission_request":
         this.resolveEventWaiters(sessionId, {
           sessionId,
@@ -916,6 +937,63 @@ export class ClaudeWsServer {
 
     // Remove from map
     this.sessions.delete(sessionId);
+  }
+}
+
+// ── JSONL fallback ──
+
+/** Message types in Claude Code's JSONL files that map to transcript entries. */
+const JSONL_TRANSCRIPT_TYPES: ReadonlySet<string> = new Set(["user", "assistant", "result", "control_request"]);
+
+/**
+ * Resolve the path to Claude Code's JSONL conversation file.
+ * Path convention: ~/.claude/projects/<dash-encoded-cwd>/<claudeSessionId>.jsonl
+ */
+export function resolveJsonlPath(cwd: string, claudeSessionId: string): string {
+  const encoded = cwd.replace(/\//g, "-");
+  return join(homedir(), ".claude", "projects", encoded, `${claudeSessionId}.jsonl`);
+}
+
+/**
+ * Read transcript entries from a Claude Code JSONL file on disk.
+ * Returns the last `last` entries, or null if the file cannot be read.
+ */
+export function readJsonlTranscript(
+  cwd: string | null,
+  claudeSessionId: string | null,
+  last: number,
+): TranscriptEntry[] | null {
+  if (!cwd || !claudeSessionId) return null;
+
+  const filePath = resolveJsonlPath(cwd, claudeSessionId);
+  if (!existsSync(filePath)) return null;
+
+  try {
+    const content = readFileSync(filePath, "utf-8");
+    const lines = content.split("\n").filter((l: string) => l.trim());
+    const entries: TranscriptEntry[] = [];
+
+    for (const line of lines) {
+      try {
+        const obj = JSON.parse(line) as Record<string, unknown>;
+        if (!obj.type || !JSONL_TRANSCRIPT_TYPES.has(obj.type as string)) continue;
+
+        const direction: "inbound" | "outbound" = obj.type === "user" ? "outbound" : "inbound";
+        const timestamp = typeof obj.timestamp === "string" ? new Date(obj.timestamp).getTime() : Date.now();
+
+        entries.push({
+          timestamp,
+          direction,
+          message: obj as NdjsonMessage,
+        });
+      } catch {
+        // Skip malformed lines
+      }
+    }
+
+    return entries.slice(-last);
+  } catch {
+    return null;
   }
 }
 


### PR DESCRIPTION
## Summary
- When `claude_transcript` is called with a `limit` exceeding the in-memory ring buffer size (100 entries), falls back to reading Claude Code's JSONL conversation file on disk (`~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`)
- Tracks Claude Code's own session ID (from `system/init`) in `WsSession` for JSONL file path resolution
- Gracefully degrades: returns buffer contents if JSONL file is unavailable or unreadable

## Test plan
- [x] `resolveJsonlPath` correctly encodes cwd with dashes and builds expected path
- [x] `readJsonlTranscript` returns null for missing cwd, session ID, or nonexistent files
- [x] Reads and filters JSONL entries by transcript-relevant types (user, assistant, result, control_request)
- [x] Returns last N entries when file has more
- [x] Skips malformed JSONL lines gracefully
- [x] Integration test: `getTranscript` falls back to JSONL when buffer has fewer entries than requested
- [x] Integration test: `getTranscript` uses buffer when request fits
- [x] All 1634 existing tests pass, coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)