### PR TITLE
test(core,command): add file I/O tests via testOptions() (fixes #125)

### DIFF
--- a/packages/command/src/commands/config-file.spec.ts
+++ b/packages/command/src/commands/config-file.spec.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { McpConfigFile, ServerConfig } from "@mcp-cli/core";
+import { testOptions } from "../../../../test/test-options";
+import {
+  addServerToConfig,
+  readConfigFile,
+  removeServerFromConfig,
+  resolveConfigPath,
+  writeConfigFile,
+} from "./config-file";
+
+const HTTP_SERVER: ServerConfig = { type: "http", url: "https://example.com/mcp" };
+const SSE_SERVER: ServerConfig = { type: "sse", url: "https://sse.example.com" };
+const STDIO_SERVER: ServerConfig = { command: "npx", args: ["-y", "some-pkg"] };
+
+describe("resolveConfigPath", () => {
+  test("user scope returns USER_SERVERS_PATH", () => {
+    using opts = testOptions();
+    expect(resolveConfigPath("user")).toBe(opts.USER_SERVERS_PATH);
+  });
+
+  test("local scope returns same as user", () => {
+    using opts = testOptions();
+    expect(resolveConfigPath("local")).toBe(opts.USER_SERVERS_PATH);
+  });
+
+  test("project scope returns path under PROJECTS_DIR", () => {
+    using opts = testOptions();
+    const path = resolveConfigPath("project");
+    expect(path).toContain(opts.PROJECTS_DIR);
+    expect(path).toEndWith("servers.json");
+  });
+});
+
+describe("readConfigFile", () => {
+  test("returns empty structure for missing file", () => {
+    using opts = testOptions();
+    expect(readConfigFile(join(opts.dir, "nonexistent.json"))).toEqual({ mcpServers: {} });
+  });
+
+  test("reads existing config", () => {
+    const data: McpConfigFile = { mcpServers: { test: HTTP_SERVER } };
+    using opts = testOptions({ files: { "servers.json": data } });
+    const result = readConfigFile(opts.USER_SERVERS_PATH);
+    expect(result.mcpServers?.test).toEqual(HTTP_SERVER);
+  });
+
+  test("adds mcpServers key if missing", () => {
+    using opts = testOptions({ files: { "servers.json": "{}" } });
+    const result = readConfigFile(opts.USER_SERVERS_PATH);
+    expect(result.mcpServers).toEqual({});
+  });
+});
+
+describe("writeConfigFile", () => {
+  test("writes JSON with trailing newline", () => {
+    using opts = testOptions();
+    const config: McpConfigFile = { mcpServers: { s: HTTP_SERVER } };
+    const path = join(opts.dir, "output.json");
+
+    writeConfigFile(path, config);
+
+    const content = readFileSync(path, "utf-8");
+    expect(content).toBe(`${JSON.stringify(config, null, 2)}\n`);
+  });
+
+  test("creates parent directories", () => {
+    using opts = testOptions();
+    const nested = join(opts.dir, "a", "b", "config.json");
+
+    writeConfigFile(nested, { mcpServers: {} });
+
+    const content = readFileSync(nested, "utf-8");
+    expect(JSON.parse(content)).toEqual({ mcpServers: {} });
+  });
+});
+
+describe("addServerToConfig", () => {
+  test("creates file and adds new server, returns false", () => {
+    using opts = testOptions();
+    const result = addServerToConfig("user", "my-server", HTTP_SERVER);
+
+    expect(result).toBe(false);
+    const config = readConfigFile(opts.USER_SERVERS_PATH);
+    expect(config.mcpServers?.["my-server"]).toEqual(HTTP_SERVER);
+  });
+
+  test("returns true when replacing existing server", () => {
+    using opts = testOptions({
+      files: { "servers.json": { mcpServers: { s: HTTP_SERVER } } },
+    });
+    const result = addServerToConfig("user", "s", SSE_SERVER);
+
+    expect(result).toBe(true);
+    const config = readConfigFile(opts.USER_SERVERS_PATH);
+    expect(config.mcpServers?.s).toEqual(SSE_SERVER);
+  });
+
+  test("preserves existing servers when adding new one", () => {
+    using opts = testOptions({
+      files: { "servers.json": { mcpServers: { existing: HTTP_SERVER } } },
+    });
+
+    addServerToConfig("user", "new-server", STDIO_SERVER);
+
+    const config = readConfigFile(opts.USER_SERVERS_PATH);
+    expect(config.mcpServers?.existing).toEqual(HTTP_SERVER);
+    expect(config.mcpServers?.["new-server"]).toEqual(STDIO_SERVER);
+  });
+});
+
+describe("removeServerFromConfig", () => {
+  test("removes server and returns true", () => {
+    using opts = testOptions({
+      files: {
+        "servers.json": { mcpServers: { keep: HTTP_SERVER, remove: SSE_SERVER } },
+      },
+    });
+
+    const result = removeServerFromConfig("user", "remove");
+
+    expect(result).toBe(true);
+    const config = readConfigFile(opts.USER_SERVERS_PATH);
+    expect(config.mcpServers?.keep).toEqual(HTTP_SERVER);
+    expect(config.mcpServers?.remove).toBeUndefined();
+  });
+
+  test("returns false for nonexistent server", () => {
+    using _opts = testOptions({
+      files: { "servers.json": { mcpServers: {} } },
+    });
+
+    expect(removeServerFromConfig("user", "nope")).toBe(false);
+  });
+
+  test("returns false when config file is missing", () => {
+    using _opts = testOptions();
+    expect(removeServerFromConfig("user", "nope")).toBe(false);
+  });
+});

--- a/packages/core/src/cli-config.spec.ts
+++ b/packages/core/src/cli-config.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { testOptions } from "../../../test/test-options";
+import { readCliConfig, writeCliConfig } from "./cli-config";
+
+describe("readCliConfig", () => {
+  test("returns {} when file is missing", () => {
+    using _opts = testOptions();
+    expect(readCliConfig()).toEqual({});
+  });
+
+  test("returns {} on malformed JSON", () => {
+    using _opts = testOptions({ files: { "config.json": "not json{{{" } });
+    expect(readCliConfig()).toEqual({});
+  });
+
+  test("parses valid JSON", () => {
+    const config = { trustClaude: true, terminal: "ghostty" };
+    using _opts = testOptions({ files: { "config.json": config } });
+    expect(readCliConfig()).toEqual(config);
+  });
+});
+
+describe("writeCliConfig", () => {
+  test("creates parent directory and writes JSON with trailing newline", () => {
+    using opts = testOptions();
+    const config = { trustClaude: false };
+
+    writeCliConfig(config);
+
+    const content = readFileSync(opts.MCP_CLI_CONFIG_PATH, "utf-8");
+    expect(content).toBe(`${JSON.stringify(config, null, 2)}\n`);
+    expect(content.endsWith("\n")).toBe(true);
+  });
+
+  test("overwrites existing config", () => {
+    using opts = testOptions({ files: { "config.json": { trustClaude: true } } });
+
+    writeCliConfig({ terminal: "iterm" });
+
+    const result = JSON.parse(readFileSync(opts.MCP_CLI_CONFIG_PATH, "utf-8"));
+    expect(result).toEqual({ terminal: "iterm" });
+    expect(result.trustClaude).toBeUndefined();
+  });
+
+  test("creates nested parent directories", () => {
+    using opts = testOptions();
+    // testOptions already sets MCP_CLI_CONFIG_PATH inside temp dir
+    // writeCliConfig should create the dir if it doesn't exist
+    writeCliConfig({ trustClaude: true });
+
+    const content = readFileSync(opts.MCP_CLI_CONFIG_PATH, "utf-8");
+    expect(JSON.parse(content)).toEqual({ trustClaude: true });
+  });
+});

--- a/packages/core/src/fs.spec.ts
+++ b/packages/core/src/fs.spec.ts
@@ -1,30 +1,14 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
-import { chmodSync, mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { describe, expect, mock, test } from "bun:test";
+import { chmodSync, mkdirSync, statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { hardenFile } from "./fs";
-
-function tmpPath(prefix: string): string {
-  return join(tmpdir(), `mcp-cli-test-${prefix}-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-}
+import { testOptions } from "../../../test/test-options";
+import { options } from "./constants";
+import { auditRuntimePermissions, ensureStateDir, hardenFile } from "./fs";
 
 describe("hardenFile", () => {
-  const paths: string[] = [];
-
-  afterEach(() => {
-    for (const p of paths) {
-      try {
-        rmSync(p, { recursive: true, force: true });
-      } catch {
-        /* ignore */
-      }
-    }
-    paths.length = 0;
-  });
-
   test("sets file permissions to 0600", () => {
-    const filePath = tmpPath("harden");
-    paths.push(filePath);
+    using opts = testOptions();
+    const filePath = join(opts.dir, "secret.txt");
     writeFileSync(filePath, "secret data");
 
     hardenFile(filePath);
@@ -34,8 +18,8 @@ describe("hardenFile", () => {
   });
 
   test("tightens overly permissive file", () => {
-    const filePath = tmpPath("harden-open");
-    paths.push(filePath);
+    using opts = testOptions();
+    const filePath = join(opts.dir, "open.txt");
     writeFileSync(filePath, "secret data");
     chmodSync(filePath, 0o666);
 
@@ -47,42 +31,103 @@ describe("hardenFile", () => {
 });
 
 describe("ensureStateDir", () => {
-  const paths: string[] = [];
+  test("creates directory with mode 0700", () => {
+    using opts = testOptions();
+    const subDir = join(opts.dir, "nested", "state");
+    options.MCP_CLI_DIR = subDir;
 
-  afterEach(() => {
-    for (const p of paths) {
-      try {
-        rmSync(p, { recursive: true, force: true });
-      } catch {
-        /* ignore */
-      }
-    }
-    paths.length = 0;
+    ensureStateDir();
+
+    const mode = statSync(subDir).mode & 0o777;
+    expect(mode).toBe(0o700);
   });
 
-  test("mkdirSync with mode 0700 creates directory with correct permissions", () => {
-    const dir = tmpPath("statedir");
-    paths.push(dir);
+  test("is idempotent on existing directory", () => {
+    using _opts = testOptions();
 
-    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    ensureStateDir();
+    ensureStateDir(); // should not throw
 
-    const mode = statSync(dir).mode & 0o777;
-    expect(mode).toBe(0o700);
+    expect(statSync(options.MCP_CLI_DIR).isDirectory()).toBe(true);
   });
 });
 
 describe("auditRuntimePermissions", () => {
-  test("runs without error", () => {
+  test("emits no warnings for properly permissioned dir", () => {
+    using opts = testOptions();
+    mkdirSync(opts.MCP_CLI_DIR, { recursive: true, mode: 0o700 });
+
     const errors: string[] = [];
     const origError = console.error;
     console.error = mock((...args: unknown[]) => {
       errors.push(args.map(String).join(" "));
     });
-
     try {
-      const { auditRuntimePermissions } = require("./fs.js");
       auditRuntimePermissions();
-      // Function should complete without throwing
+      expect(errors.filter((e) => e.includes("[security]"))).toHaveLength(0);
+    } finally {
+      console.error = origError;
+    }
+  });
+
+  test("warns when directory has group/other bits set", () => {
+    using opts = testOptions();
+    mkdirSync(opts.MCP_CLI_DIR, { recursive: true });
+    chmodSync(opts.MCP_CLI_DIR, 0o777);
+
+    const errors: string[] = [];
+    const origError = console.error;
+    console.error = mock((...args: unknown[]) => {
+      errors.push(args.map(String).join(" "));
+    });
+    try {
+      auditRuntimePermissions();
+      const warnings = errors.filter((e) => e.includes("[security]"));
+      expect(warnings.length).toBeGreaterThanOrEqual(1);
+      expect(warnings[0]).toContain("0777");
+      expect(warnings[0]).toContain("expected 0700");
+    } finally {
+      console.error = origError;
+    }
+  });
+
+  test("warns when file has group/other bits set", () => {
+    using opts = testOptions();
+    mkdirSync(opts.MCP_CLI_DIR, { recursive: true, mode: 0o700 });
+    writeFileSync(opts.DB_PATH, "db");
+    chmodSync(opts.DB_PATH, 0o644);
+
+    const errors: string[] = [];
+    const origError = console.error;
+    console.error = mock((...args: unknown[]) => {
+      errors.push(args.map(String).join(" "));
+    });
+    try {
+      auditRuntimePermissions();
+      const warnings = errors.filter((e) => e.includes("[security]"));
+      expect(warnings.length).toBeGreaterThanOrEqual(1);
+      expect(warnings.some((w) => w.includes("0644"))).toBe(true);
+      expect(warnings.some((w) => w.includes("expected 0600"))).toBe(true);
+    } finally {
+      console.error = origError;
+    }
+  });
+
+  test("does not warn for nonexistent dir or files", () => {
+    using opts = testOptions();
+    // testOptions sets MCP_CLI_DIR to temp dir, but no DB_PATH or SOCKET_PATH files exist
+    // Remove the MCP_CLI_DIR so even the directory stat fails
+    const { rmSync } = require("node:fs");
+    rmSync(opts.MCP_CLI_DIR, { recursive: true, force: true });
+
+    const errors: string[] = [];
+    const origError = console.error;
+    console.error = mock((...args: unknown[]) => {
+      errors.push(args.map(String).join(" "));
+    });
+    try {
+      auditRuntimePermissions();
+      expect(errors.filter((e) => e.includes("[security]"))).toHaveLength(0);
     } finally {
       console.error = origError;
     }


### PR DESCRIPTION
## Summary
- New `cli-config.spec.ts`: tests `readCliConfig()` (missing file, malformed JSON, valid JSON) and `writeCliConfig()` (parent dir creation, trailing newline, overwrite)
- Rewrote `fs.spec.ts` with `testOptions()`: proper `ensureStateDir` tests (creates dir with 0700, idempotent) and `auditRuntimePermissions` tests (no-warn for correct perms, warns on 0777 dir, warns on 0644 file, silent on nonexistent paths)
- New `config-file.spec.ts`: `resolveConfigPath` (user/local/project scopes), `readConfigFile`, `writeConfigFile`, `addServerToConfig` (new + replace + preserve), `removeServerFromConfig` (remove + missing)

## Test plan
- [x] All 28 new/updated tests pass
- [x] Full suite passes (1656 tests, 0 failures)
- [x] `bun typecheck` clean
- [x] `bun lint` clean
- [x] Coverage ratchet passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)