### PR TITLE
fix(daemon): reuse WS port and rehydrate sessions on worker crash (fixes #402)

### DIFF
--- a/packages/daemon/src/claude-server.spec.ts
+++ b/packages/daemon/src/claude-server.spec.ts
@@ -265,7 +265,7 @@ describe("ClaudeServer", () => {
 
   // ── Crash recovery ──
 
-  test("handleWorkerCrash ends all active sessions in SQLite", async () => {
+  test("handleWorkerCrash preserves sessions in DB and rehydrates activeSessions", async () => {
     using opts = testOptions();
     db = new StateDb(opts.DB_PATH);
     server = new ClaudeServer(db);
@@ -283,17 +283,17 @@ describe("ClaudeServer", () => {
     ).handleWorkerCrash.bind(server);
     await crash("test crash");
 
-    // Both sessions should be marked as ended
+    // Sessions should NOT be marked as ended — Claude processes are still running
     const row1 = db.getSession("crash-1");
-    expect(row1?.state).toBe("ended");
-    expect(row1?.endedAt).not.toBeNull();
+    expect(row1?.state).toBe("active");
+    expect(row1?.endedAt).toBeNull();
 
     const row2 = db.getSession("crash-2");
-    expect(row2?.state).toBe("ended");
-    expect(row2?.endedAt).not.toBeNull();
+    expect(row2?.state).toBe("active");
+    expect(row2?.endedAt).toBeNull();
 
-    // Active sessions cleared
-    expect(server.hasActiveSessions()).toBe(false);
+    // activeSessions should be rehydrated from DB
+    expect(server.hasActiveSessions()).toBe(true);
   });
 
   test("handleWorkerCrash auto-restarts and fires onRestarted", async () => {
@@ -302,7 +302,6 @@ describe("ClaudeServer", () => {
     server = new ClaudeServer(db);
 
     await server.start();
-    const originalPort = server.port;
 
     let restartedCalled = false;
     server.onRestarted = () => {
@@ -314,9 +313,8 @@ describe("ClaudeServer", () => {
     ).handleWorkerCrash.bind(server);
     await crash("test crash");
 
-    // Worker should be restarted with a new port
+    // Worker should be restarted (port reuse attempted, falls back to random if old worker still holds it)
     expect(server.port).toBeGreaterThan(0);
-    expect(server.port).not.toBe(originalPort);
     expect(restartedCalled).toBe(true);
   });
 

--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -108,8 +108,8 @@ export class ClaudeServer {
     this.db = db;
   }
 
-  /** Start the worker and connect the MCP client. */
-  async start(): Promise<{ client: Client; transport: WorkerClientTransport }> {
+  /** Start the worker and connect the MCP client. Pass a port to reuse a specific WS port (e.g. after crash recovery). */
+  async start(preferredPort?: number): Promise<{ client: Client; transport: WorkerClientTransport }> {
     this.stopped = false;
     const worker = new Worker(workerPath("claude-session-worker.ts"));
     this.worker = worker;
@@ -128,8 +128,8 @@ export class ClaudeServer {
         const msg = event instanceof ErrorEvent ? event.message : String(event);
         reject(new Error(`Claude session worker error: ${msg}`));
       };
-      // Send init to start the worker
-      worker.postMessage({ type: "init", daemonId: this.daemonId });
+      // Send init to start the worker, optionally reusing a specific port
+      worker.postMessage({ type: "init", daemonId: this.daemonId, port: preferredPort });
     });
 
     // Now set up MCP transport
@@ -199,21 +199,29 @@ export class ClaudeServer {
     );
   }
 
-  /** Handle a worker crash: end orphaned sessions and attempt auto-restart. */
+  /** Handle a worker crash: preserve session state and attempt auto-restart on the same port. */
   private async handleWorkerCrash(reason: string): Promise<void> {
     if (this.restartInProgress || this.stopped) return;
     this.restartInProgress = true;
 
     console.error(`[claude-server] Worker crash detected: ${reason}`);
 
-    // Mark all tracked sessions as ended in SQLite
-    for (const sessionId of this.activeSessions) {
-      console.error(`[claude-server] Ending orphaned session: ${sessionId}`);
-      this.db.endSession(sessionId);
-    }
-    this.activeSessions.clear();
+    // Preserve the WS port so we can restart on the same one — orphaned Claude
+    // processes are still connected to this port and will reconnect.
+    const previousPort = this.wsPort;
 
-    // Clear stale references (don't terminate — worker is already dead)
+    // Do NOT end sessions in the DB or clear activeSessions — the Claude processes
+    // are still running. We'll rehydrate activeSessions from the DB after restart.
+
+    // Terminate old worker defensively to release the port — in a real crash
+    // the worker is already dead and terminate() is a no-op.
+    try {
+      this.worker?.terminate();
+    } catch {
+      // ignore — worker may already be dead
+    }
+    // Brief yield to let the terminated worker release its port binding
+    await new Promise((r) => setTimeout(r, 50));
     this.worker = null;
     this.transport = null;
     this.client = null;
@@ -235,10 +243,12 @@ export class ClaudeServer {
       return;
     }
 
-    // Auto-restart
+    // Auto-restart on the same port
     try {
       console.error("[claude-server] Restarting worker...");
-      const { client, transport } = await this.start();
+      const { client, transport } = await this.start(previousPort ?? undefined);
+      // Rehydrate activeSessions from the DB — any session not yet ended is still active
+      this.rehydrateActiveSessions();
       console.error(`[claude-server] Worker restarted successfully (port ${this.wsPort})`);
       // Notify connected MCP clients that the tool list may have changed
       // (this.worker is set by start() but TS can't track cross-method mutation)
@@ -249,6 +259,19 @@ export class ClaudeServer {
       this.stopped = true;
     } finally {
       this.restartInProgress = false;
+    }
+  }
+
+  /** Rehydrate activeSessions from the DB by querying for sessions that aren't ended. */
+  private rehydrateActiveSessions(): void {
+    const sessions = this.db.listSessions(true); // active only (ended_at IS NULL)
+    this.activeSessions.clear();
+    for (const session of sessions) {
+      this.activeSessions.add(session.sessionId);
+    }
+    if (sessions.length > 0) {
+      console.error(`[claude-server] Rehydrated ${sessions.length} active session(s) from DB`);
+      metrics.gauge("mcpd_active_sessions").set(this.activeSessions.size);
     }
   }
 

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -28,6 +28,7 @@ import { WorkerServerTransport } from "./worker-transport";
 interface InitMessage {
   type: "init";
   daemonId?: string;
+  port?: number;
 }
 
 interface ToolsChangedMessage {
@@ -304,10 +305,10 @@ function forwardSessionEvent(sessionId: string, event: SessionEvent): void {
 
 // ── Server startup ──
 
-async function startServer(): Promise<void> {
+async function startServer(preferredPort?: number): Promise<void> {
   // Start WebSocket server
   wsServer = new ClaudeWsServer();
-  const port = wsServer.start();
+  const port = wsServer.start(preferredPort);
   wsServer.onSessionEvent = forwardSessionEvent;
 
   // Report port to main thread
@@ -354,6 +355,6 @@ self.onmessage = async (event: MessageEvent) => {
   if (isControlMessage(data) && data.type === "init") {
     daemonId = data.daemonId;
     workerId = generateSpanId();
-    await startServer();
+    await startServer(data.port);
   }
 };

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -168,11 +168,11 @@ export class ClaudeWsServer {
     return this.eventSeq;
   }
 
-  /** Start the WebSocket server. Returns the assigned port. */
-  start(): number {
-    this.server = Bun.serve<WsData>({
-      port: 0,
-      fetch: (req, server) => {
+  /** Start the WebSocket server. Returns the assigned port. Pass a port to reuse a specific port (e.g. after crash recovery, falls back to random port if unavailable). */
+  start(preferredPort?: number): number {
+    const targetPort = preferredPort ?? 0;
+    const serveOpts = {
+      fetch: (req: Request, server: { upgrade: (req: Request, opts: { data: WsData }) => boolean }) => {
         const url = new URL(req.url);
         const match = url.pathname.match(/^\/session\/([^/]+)$/);
         if (!match) {
@@ -189,11 +189,22 @@ export class ClaudeWsServer {
         return undefined;
       },
       websocket: {
-        open: (ws) => this.handleOpen(ws),
-        message: (ws, message) => this.handleMessage(ws, String(message)),
-        close: (ws) => this.handleClose(ws),
+        open: (ws: ServerWebSocket<WsData>) => this.handleOpen(ws),
+        message: (ws: ServerWebSocket<WsData>, message: string | Buffer) => this.handleMessage(ws, String(message)),
+        close: (ws: ServerWebSocket<WsData>) => this.handleClose(ws),
       },
-    });
+    };
+
+    try {
+      this.server = Bun.serve<WsData>({ port: targetPort, ...serveOpts });
+    } catch (err) {
+      // If preferred port is in use, fall back to a random port
+      if (targetPort !== 0) {
+        this.server = Bun.serve<WsData>({ port: 0, ...serveOpts });
+      } else {
+        throw err;
+      }
+    }
 
     return this.server.port as number;
   }


### PR DESCRIPTION
## Summary
- **Port reuse**: On worker crash, attempt to restart on the same WS port so orphaned Claude processes can reconnect. Falls back to random port if the old port is still held.
- **Session rehydration**: On worker restart, rehydrate `activeSessions` from the DB (query for sessions without `ended_at`) instead of starting with an empty Set. This prevents the idle timeout from firing while sessions exist.
- **No premature session ending**: Worker crash handler no longer marks sessions as ended in SQLite — the Claude processes are still running and can reconnect.

## Test plan
- [x] `handleWorkerCrash preserves sessions in DB and rehydrates activeSessions` — verifies sessions are NOT ended in DB after crash and activeSessions is rehydrated
- [x] `handleWorkerCrash auto-restarts and fires onRestarted` — verifies restart succeeds with valid port
- [x] All existing crash recovery tests pass (debounce, rate limiting, stop prevention)
- [x] All 1737 tests pass, typecheck clean, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)