### PR TITLE
feat(daemon): support 'auth' tool convention for stdio servers (fixes #408)

### DIFF
--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -589,6 +589,63 @@ describe("IpcServer HTTP transport", () => {
     expect(json.error?.message).toContain("Database not available");
   });
 
+  test("triggerAuth calls auth tool on stdio server that exposes one", async () => {
+    socketPath = tmpSocket();
+    const pool = Object.assign(mockPool(), {
+      getServerUrl: () => undefined, // not a remote server
+      listTools: (name: string) =>
+        name === "myserver" ? [{ name: "auth", server: "myserver", description: "Authenticate", inputSchema: {} }] : [],
+      callTool: async (_server: string, tool: string) =>
+        tool === "auth"
+          ? { content: [{ type: "text", text: "SSO login completed" }], isError: false }
+          : { content: [] },
+    });
+    server = new IpcServer(pool as never, mockConfig(), mockDb(), null, opts());
+    server.start(socketPath);
+
+    const res = await rpc("/rpc", { id: "auth3", method: "triggerAuth", params: { server: "myserver" } });
+    const json = (await res.json()) as IpcResponse;
+    expect(json.id).toBe("auth3");
+    expect(json.error).toBeUndefined();
+    expect(json.result).toEqual({ ok: true, message: "SSO login completed" });
+  });
+
+  test("triggerAuth on stdio server without auth tool returns SERVER_NOT_FOUND", async () => {
+    socketPath = tmpSocket();
+    const pool = Object.assign(mockPool(), {
+      getServerUrl: () => undefined,
+      listTools: () => [{ name: "query", server: "myserver", description: "Query data", inputSchema: {} }],
+    });
+    server = new IpcServer(pool as never, mockConfig(), mockDb(), null, opts());
+    server.start(socketPath);
+
+    const res = await rpc("/rpc", { id: "auth4", method: "triggerAuth", params: { server: "myserver" } });
+    const json = (await res.json()) as IpcResponse;
+    expect(json.id).toBe("auth4");
+    expect(json.error?.code).toBe(IPC_ERROR.SERVER_NOT_FOUND);
+    expect(json.error?.message).toContain("does not support auth");
+  });
+
+  test("triggerAuth returns error when auth tool reports isError", async () => {
+    socketPath = tmpSocket();
+    const pool = Object.assign(mockPool(), {
+      getServerUrl: () => undefined,
+      listTools: () => [{ name: "auth", server: "myserver", description: "Auth", inputSchema: {} }],
+      callTool: async () => ({
+        content: [{ type: "text", text: "SSO session expired, please retry" }],
+        isError: true,
+      }),
+    });
+    server = new IpcServer(pool as never, mockConfig(), mockDb(), null, opts());
+    server.start(socketPath);
+
+    const res = await rpc("/rpc", { id: "auth5", method: "triggerAuth", params: { server: "myserver" } });
+    const json = (await res.json()) as IpcResponse;
+    expect(json.id).toBe("auth5");
+    expect(json.error?.code).toBe(IPC_ERROR.INTERNAL_ERROR);
+    expect(json.error?.message).toContain("SSO session expired");
+  });
+
   // -- Parameter validation tests --
 
   test("callTool with missing server param returns INVALID_PARAMS", async () => {

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -5,7 +5,7 @@
  */
 
 import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
-import type { IpcError, IpcMethod, IpcRequest, IpcResponse, LiveSpan, ResolvedConfig } from "@mcp-cli/core";
+import type { IpcError, IpcMethod, IpcRequest, IpcResponse, LiveSpan, ResolvedConfig, ToolInfo } from "@mcp-cli/core";
 import {
   BUILD_VERSION,
   CallToolParamsSchema,
@@ -306,10 +306,38 @@ export class IpcServer {
     this.handlers.set("triggerAuth", async (params, _ctx) => {
       const { server } = TriggerAuthParamsSchema.parse(params);
       const serverUrl = this.pool.getServerUrl(server);
+
+      // Non-remote server — check for `auth` tool convention
       if (!serverUrl) {
-        throw Object.assign(new Error(`Server "${server}" not found or is not a remote (SSE/HTTP) server`), {
-          code: IPC_ERROR.SERVER_NOT_FOUND,
-        });
+        let tools: ToolInfo[];
+        try {
+          tools = await this.pool.listTools(server);
+        } catch {
+          tools = [];
+        }
+        const hasAuthTool = tools.some((t) => t.name === "auth");
+        if (!hasAuthTool) {
+          throw Object.assign(
+            new Error(`Server "${server}" not found or does not support auth (no OAuth endpoint and no "auth" tool)`),
+            { code: IPC_ERROR.SERVER_NOT_FOUND },
+          );
+        }
+
+        const result = (await this.pool.callTool(server, "auth", {})) as {
+          content?: Array<{ type?: string; text?: string }>;
+          isError?: boolean;
+        };
+        const text =
+          result.content
+            ?.filter((c) => c.type === "text")
+            .map((c) => c.text)
+            .join("\n") ?? "";
+        if (result.isError) {
+          throw Object.assign(new Error(text || "auth tool returned an error"), {
+            code: IPC_ERROR.INTERNAL_ERROR,
+          });
+        }
+        return { ok: true, message: text || "Authenticated via auth tool" };
       }
 
       const poolDb = this.pool.getDb();


### PR DESCRIPTION
## Summary
- When `triggerAuth` is called for a non-HTTP/SSE server, the daemon now checks if the server exposes a tool named `auth` and calls it
- HTTP/SSE servers continue using the existing OAuth flow unchanged
- Servers without OAuth or an `auth` tool get a clearer error message

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] All tests pass (54/54 in ipc-server.spec.ts)
- [x] New test: stdio server with `auth` tool → calls it, returns result
- [x] New test: stdio server without `auth` tool → SERVER_NOT_FOUND error
- [x] New test: `auth` tool returning `isError: true` → INTERNAL_ERROR
- [x] Existing test: unknown server still returns SERVER_NOT_FOUND

🤖 Generated with [Claude Code](https://claude.com/claude-code)