### PR TITLE
fix(daemon): handle EPIPE on stderr to prevent daemon crash (fixes #411)

### DIFF
--- a/packages/daemon/src/daemon-log.spec.ts
+++ b/packages/daemon/src/daemon-log.spec.ts
@@ -52,6 +52,27 @@ describe("daemon-log", () => {
     expect(match).toBeDefined();
   });
 
+  test("console.error survives EPIPE from stderr", () => {
+    const original = process.stderr.write;
+    process.stderr.write = (() => {
+      const err = new Error("EPIPE: broken pipe, write");
+      (err as NodeJS.ErrnoException).code = "EPIPE";
+      throw err;
+    }) as typeof process.stderr.write;
+
+    try {
+      // Should not throw — EPIPE is caught internally
+      expect(() => console.error("epipe-test-line")).not.toThrow();
+
+      // Line should still be captured in ring buffer
+      const lines = getDaemonLogLines();
+      const match = lines.find((l) => l.line === "epipe-test-line");
+      expect(match).toBeDefined();
+    } finally {
+      process.stderr.write = original;
+    }
+  });
+
   test("second installDaemonLogCapture call is a no-op", () => {
     const countBefore = getDaemonLogLines().length;
     installDaemonLogCapture(); // should not double-wrap

--- a/packages/daemon/src/daemon-log.ts
+++ b/packages/daemon/src/daemon-log.ts
@@ -32,7 +32,11 @@ export function installDaemonLogCapture(): void {
   console.error = (...args: unknown[]) => {
     const line = args.map(String).join(" ");
     buffer.push(DAEMON_KEY, line);
-    original(...args);
+    try {
+      original(...args);
+    } catch {
+      // EPIPE: parent terminal disconnected — silently swallow
+    }
     writeToLogFile(line);
   };
 }

--- a/packages/daemon/src/main.ts
+++ b/packages/daemon/src/main.ts
@@ -8,6 +8,11 @@
 import { startDaemon } from "./index";
 
 async function main(): Promise<void> {
+  // Prevent EPIPE on stderr from crashing the daemon when the parent
+  // terminal disconnects. This is a safety net — individual write sites
+  // also catch EPIPE, but this covers any we might miss.
+  process.stderr.on("error", () => {});
+
   const handle = await startDaemon();
 
   process.on("SIGTERM", () => {

--- a/packages/daemon/src/server-pool.spec.ts
+++ b/packages/daemon/src/server-pool.spec.ts
@@ -10,6 +10,7 @@ import {
   buildChildEnv,
   isRetryableError,
   isTransientCallError,
+  safeStderrWrite,
   wrapTransportError,
 } from "./server-pool";
 import { makeConfig, makeMockClient, makeMockTransport } from "./test-helpers";
@@ -1070,6 +1071,29 @@ describe("ServerPool.registerPendingVirtualServer", () => {
     // Server is now usable
     const result = await pool.callTool("_test", "my-tool", {});
     expect(result).toEqual({ content: [{ text: "ok" }] });
+  });
+});
+
+describe("safeStderrWrite", () => {
+  test("writes to stderr normally", () => {
+    // Should not throw
+    safeStderrWrite("test output\n");
+  });
+
+  test("swallows EPIPE errors from process.stderr.write", () => {
+    const original = process.stderr.write;
+    process.stderr.write = (() => {
+      const err = new Error("EPIPE: broken pipe, write");
+      (err as NodeJS.ErrnoException).code = "EPIPE";
+      throw err;
+    }) as typeof process.stderr.write;
+
+    try {
+      // Should not throw despite EPIPE
+      expect(() => safeStderrWrite("test\n")).not.toThrow();
+    } finally {
+      process.stderr.write = original;
+    }
   });
 });
 

--- a/packages/daemon/src/server-pool.ts
+++ b/packages/daemon/src/server-pool.ts
@@ -355,7 +355,7 @@ export class ServerPool {
       for (const line of lines) {
         if (line === "") continue;
         const entry = this.stderrBuffer.push(name, line);
-        process.stderr.write(`[${name}] ${line}\n`);
+        safeStderrWrite(`[${name}] ${line}\n`);
         this.db?.insertServerLog(name, line, entry.timestamp);
       }
     };
@@ -367,7 +367,7 @@ export class ServerPool {
       // Flush any remaining partial line
       if (partial) {
         const entry = this.stderrBuffer.push(name, partial);
-        process.stderr.write(`[${name}] ${partial}\n`);
+        safeStderrWrite(`[${name}] ${partial}\n`);
         this.db?.insertServerLog(name, partial, entry.timestamp);
         partial = "";
       }
@@ -606,6 +606,20 @@ export class ServerPool {
     return [...this.connections.entries()]
       .filter(([, c]) => c.state === "connected" && c.lastUsed > 0 && now - c.lastUsed > thresholdMs)
       .map(([name]) => name);
+  }
+}
+
+// -- Stderr safety --
+
+/**
+ * Write to stderr, silently swallowing EPIPE when the parent terminal has disconnected.
+ * @internal Exported for testing only.
+ */
+export function safeStderrWrite(data: string): void {
+  try {
+    process.stderr.write(data);
+  } catch {
+    // EPIPE: parent terminal disconnected — don't crash the daemon
   }
 }
 


### PR DESCRIPTION
## Summary
- Wrap `process.stderr.write()` calls in `server-pool.ts` with try/catch to silently swallow EPIPE when the parent terminal disconnects
- Wrap the forwarded `console.error()` call in `daemon-log.ts` with try/catch for the same reason
- Add a global `process.stderr.on('error')` handler in `main.ts` as a safety net for any unprotected stderr writes

## Test plan
- [x] Added test: `safeStderrWrite` swallows EPIPE errors without throwing
- [x] Added test: `console.error` survives EPIPE and still captures to ring buffer
- [x] All 1731 existing tests pass
- [x] typecheck, lint, and coverage checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)