### PR TITLE
fix(daemon): clean up worker message/error handlers on restart (fixes #428)

### DIFF
--- a/packages/daemon/src/claude-server.spec.ts
+++ b/packages/daemon/src/claude-server.spec.ts
@@ -503,6 +503,55 @@ describe("ClaudeServer", () => {
     server = undefined; // prevent double stop
   });
 
+  // ── Worker handler cleanup ──
+
+  test("restart cleans up old worker message/error handlers to prevent closure leaks", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new ClaudeServer(db);
+
+    await server.start();
+
+    // Grab reference to the old worker before crash
+    const oldWorker = (server as unknown as { worker: Worker | null }).worker;
+    expect(oldWorker).not.toBeNull();
+
+    // Verify old worker has handlers set
+    expect(oldWorker?.onmessage).not.toBeNull();
+
+    const crash = (
+      server as unknown as { handleWorkerCrash: (reason: string) => Promise<void> }
+    ).handleWorkerCrash.bind(server);
+    await crash("test crash for cleanup");
+
+    // After restart, old worker's onmessage should be nulled (cleaned up)
+    expect(oldWorker?.onmessage).toBeNull();
+
+    // New worker should be different and have its own handlers
+    const newWorker = (server as unknown as { worker: Worker | null }).worker;
+    expect(newWorker).not.toBeNull();
+    expect(newWorker).not.toBe(oldWorker);
+    expect(newWorker?.onmessage).not.toBeNull();
+  });
+
+  test("stop() cleans up worker message/error handlers", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new ClaudeServer(db);
+
+    await server.start();
+
+    const worker = (server as unknown as { worker: Worker | null }).worker;
+    expect(worker).not.toBeNull();
+    expect(worker?.onmessage).not.toBeNull();
+
+    await server.stop();
+
+    // After stop, worker handlers should be cleaned up
+    expect(worker?.onmessage).toBeNull();
+    server = undefined; // prevent double stop
+  });
+
   // ── pruneDeadSessions ──
 
   test("pruneDeadSessions removes sessions with dead PIDs", async () => {

--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -128,6 +128,8 @@ export class ClaudeServer {
   private restartInProgress = false;
   private stopped = false;
   private readonly crashTimestamps: number[] = [];
+  /** Stored reference to the crash error handler so it can be removed via removeEventListener. */
+  private crashErrorHandler: ((event: ErrorEvent | Event) => void) | null = null;
   private static readonly MAX_CRASHES = 3;
   private static readonly CRASH_WINDOW_MS = 60_000;
   /** Sessions without PIDs that stay disconnected longer than this are pruned as zombies. */
@@ -224,7 +226,10 @@ export class ClaudeServer {
     } catch {
       // ignore close errors
     }
-    this.worker?.terminate();
+    if (this.worker) {
+      this.cleanupWorkerHandlers(this.worker);
+      this.worker.terminate();
+    }
     this.worker = null;
     this.transport = null;
     this.client = null;
@@ -280,14 +285,26 @@ export class ClaudeServer {
 
   // ── Crash detection ──
 
+  /** Remove event listeners and null handlers on the current worker to prevent closure leaks. */
+  private cleanupWorkerHandlers(worker: Worker): void {
+    if (this.crashErrorHandler) {
+      worker.removeEventListener("error", this.crashErrorHandler);
+      this.crashErrorHandler = null;
+    }
+    worker.onmessage = null;
+    worker.onerror = null;
+  }
+
   /** Attach post-startup error listener to detect worker crashes. */
   private attachCrashDetection(worker: Worker): void {
-    worker.addEventListener("error", (event: ErrorEvent | Event) => {
+    const handler = (event: ErrorEvent | Event) => {
       // Only handle if this is still our active worker
       if (this.worker !== worker) return;
       const msg = event instanceof ErrorEvent ? event.message : "unknown error";
       this.handleWorkerCrash(`worker error: ${msg}`);
-    });
+    };
+    this.crashErrorHandler = handler;
+    worker.addEventListener("error", handler);
   }
 
   /** Handle a worker crash: end orphaned sessions and attempt auto-restart. */
@@ -309,7 +326,10 @@ export class ClaudeServer {
     // to the new WS server (new port, new worker instance).
     const orphanedSessions = new Set(this.activeSessions);
 
-    // Clear stale references (don't terminate — worker is already dead)
+    // Clean up event handlers on the dead worker to release closure references
+    if (this.worker) {
+      this.cleanupWorkerHandlers(this.worker);
+    }
     this.worker = null;
     this.transport = null;
     this.client = null;


### PR DESCRIPTION
## Summary
- Store the crash error handler reference so it can be removed via `removeEventListener` on worker replacement
- Add `cleanupWorkerHandlers()` method that removes the error listener and nulls `onmessage`/`onerror` on the old worker
- Call cleanup in both `stop()` and `handleWorkerCrash()` to release closure references to the old worker, transport handler, and `this`

## Test plan
- [x] Added test: restart cleans up old worker's `onmessage` handler (verified null after crash+restart)
- [x] Added test: `stop()` cleans up worker handlers
- [x] All 39 claude-server tests pass
- [x] Full suite: 1780 tests pass
- [x] typecheck, lint, coverage all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)