### PR TITLE
fix(daemon): address review issues in crash restart backoff

### DIFF
--- a/packages/daemon/src/claude-server.spec.ts
+++ b/packages/daemon/src/claude-server.spec.ts
@@ -567,6 +567,57 @@ describe("ClaudeServer", () => {
     expect(stopped).toBe(true);
   });
 
+  test("handleWorkerCrash aborts retry loop when stop() is called during backoff", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new ClaudeServer(db);
+
+    await server.start();
+
+    let startCalled = false;
+    // Patch start() to track if it's called after stop()
+    (server as unknown as { start: typeof server.start }).start = async () => {
+      startCalled = true;
+      throw new Error("should not reach here");
+    };
+
+    // Call stop() immediately — sets stopped = true
+    await server.stop();
+
+    // Now trigger crash handler (it would normally be blocked by stopped check,
+    // but we need to test the in-loop check, so reset the flags)
+    const srv = server as unknown as { stopped: boolean; restartInProgress: boolean };
+    srv.stopped = false;
+    srv.restartInProgress = false;
+
+    // Patch start to fail once, then set stopped during backoff sleep
+    let attempt = 0;
+    (server as unknown as { start: typeof server.start }).start = async () => {
+      attempt++;
+      if (attempt === 1) {
+        // First attempt fails — triggers backoff sleep
+        // Schedule stop() to fire during the sleep
+        queueMicrotask(() => {
+          srv.stopped = true;
+        });
+        throw new Error("first attempt fails");
+      }
+      // Should never reach attempt 2
+      startCalled = true;
+      throw new Error("should not reach second attempt");
+    };
+
+    const crash = (
+      server as unknown as { handleWorkerCrash: (reason: string) => Promise<void> }
+    ).handleWorkerCrash.bind(server);
+    await crash("test stop-during-backoff");
+
+    expect(attempt).toBe(1);
+    expect(startCalled).toBe(false);
+    expect(srv.stopped).toBe(true);
+    server = undefined; // prevent double stop — already stopped
+  });
+
   // ── Worker handler cleanup ──
 
   test("restart cleans up old worker message/error handlers to prevent closure leaks", async () => {

--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -132,8 +132,8 @@ export class ClaudeServer {
   private crashErrorHandler: ((event: ErrorEvent | Event) => void) | null = null;
   private static readonly MAX_CRASHES = 3;
   private static readonly CRASH_WINDOW_MS = 60_000;
-  /** Exponential backoff delays (ms) for retrying start() during crash restart. */
-  static readonly RESTART_BACKOFF_MS: readonly number[] = [100, 500, 2000];
+  /** Backoff delays (ms) for retrying start() during crash restart. */
+  private static readonly RESTART_BACKOFF_MS: readonly number[] = [100, 500, 2000];
   /** Sessions without PIDs that stay disconnected longer than this are pruned as zombies. */
   private static readonly NO_PID_SESSION_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
@@ -353,50 +353,60 @@ export class ClaudeServer {
       return;
     }
 
-    // Auto-restart with exponential backoff
+    // Auto-restart with backoff retries
     const backoffs = ClaudeServer.RESTART_BACKOFF_MS;
     let lastErr: unknown;
 
-    for (let attempt = 0; attempt <= backoffs.length; attempt++) {
-      if (attempt > 0) {
-        const delay = backoffs[attempt - 1] ?? backoffs.at(-1) ?? 2000;
-        console.error(`[claude-server] Retry ${attempt}/${backoffs.length} after ${delay}ms...`);
-        await Bun.sleep(delay);
-      }
-
-      try {
-        console.error("[claude-server] Restarting worker...");
-        const { client, transport } = await this.start();
-        console.error(`[claude-server] Worker restarted successfully (port ${this.wsPort})`);
-
-        // End sessions orphaned by the old worker — they can no longer reconnect
-        // to the new WS server (new port). Skip any already ended via db:end.
-        for (const sessionId of orphanedSessions) {
-          if (!this.activeSessions.has(sessionId)) continue;
-          console.error(`[claude-server] Ending orphaned session ${sessionId} (old worker, new WS port)`);
-          this.activeSessions.delete(sessionId);
-          this.sessionPids.delete(sessionId);
-          this.sessionAddedAt.delete(sessionId);
-          this.db.endSession(sessionId);
+    try {
+      for (let attempt = 0; attempt <= backoffs.length; attempt++) {
+        if (attempt > 0) {
+          const delay = backoffs[attempt - 1] ?? backoffs.at(-1) ?? 2000;
+          console.error(`[claude-server] Retry ${attempt}/${backoffs.length} after ${delay}ms...`);
+          await Bun.sleep(delay);
         }
-        metrics.gauge("mcpd_active_sessions").set(this.activeSessions.size);
 
-        // Notify connected MCP clients that the tool list may have changed
-        // (this.worker is set by start() but TS can't track cross-method mutation)
-        (this.worker as Worker | null)?.postMessage({ type: "tools_changed" });
-        this.onRestarted?.(client, transport);
-        this.restartInProgress = false;
-        return;
-      } catch (err) {
-        lastErr = err;
-        console.error(`[claude-server] Restart attempt ${attempt + 1} failed: ${err}`);
+        // Respect stop() called during backoff sleep
+        if (this.stopped) {
+          console.error("[claude-server] Server stopped during restart backoff — aborting");
+          return;
+        }
+
+        try {
+          console.error("[claude-server] Restarting worker...");
+          const { client, transport } = await this.start();
+          console.error(`[claude-server] Worker restarted successfully (port ${this.wsPort})`);
+
+          // End sessions orphaned by the old worker — they can no longer reconnect
+          // to the new WS server (new port). Skip any already ended via db:end.
+          for (const sessionId of orphanedSessions) {
+            if (!this.activeSessions.has(sessionId)) continue;
+            console.error(`[claude-server] Ending orphaned session ${sessionId} (old worker, new WS port)`);
+            this.activeSessions.delete(sessionId);
+            this.sessionPids.delete(sessionId);
+            this.sessionAddedAt.delete(sessionId);
+            this.db.endSession(sessionId);
+          }
+          metrics.gauge("mcpd_active_sessions").set(this.activeSessions.size);
+
+          // Notify connected MCP clients that the tool list may have changed
+          // (this.worker is set by start() but TS can't track cross-method mutation)
+          (this.worker as Worker | null)?.postMessage({ type: "tools_changed" });
+          this.onRestarted?.(client, transport);
+          return;
+        } catch (err) {
+          lastErr = err;
+          console.error(`[claude-server] Restart attempt ${attempt + 1} failed: ${err}`);
+        }
       }
-    }
 
-    // All retries exhausted
-    console.error(`[claude-server] All ${backoffs.length + 1} restart attempts failed (last: ${lastErr}) — giving up`);
-    this.stopped = true;
-    this.restartInProgress = false;
+      // All retries exhausted
+      console.error(
+        `[claude-server] All ${backoffs.length + 1} restart attempts failed (last: ${lastErr}) — giving up`,
+      );
+      this.stopped = true;
+    } finally {
+      this.restartInProgress = false;
+    }
   }
 
   // ── DB event handling ──


### PR DESCRIPTION
## Summary
- Add `this.stopped` check inside retry loop to respect `stop()` called during backoff sleep
- Wrap retry loop in `try/finally` to guarantee `restartInProgress` reset on any throw
- Make `RESTART_BACKOFF_MS` private for consistency with sibling statics
- Add test for stop-during-backoff race condition

Fixes issues found during adversarial review of #468.

## Test plan
- [x] New test: `stop()` during backoff aborts retry loop
- [x] All 42 claude-server tests pass
- [x] Typecheck + lint clean
- [x] Coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)