### PR TITLE
fix(daemon): clear crashTimestamps in stop() to prevent stale history poisoning restarts (fixes #434)

### DIFF
--- a/packages/daemon/src/claude-server.spec.ts
+++ b/packages/daemon/src/claude-server.spec.ts
@@ -291,6 +291,44 @@ describe("ClaudeServer", () => {
     server = undefined; // prevent double stop
   });
 
+  test("stop() clears crashTimestamps so stale history does not poison restarts", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new ClaudeServer(db);
+
+    await server.start();
+
+    // Simulate 2 crashes to accumulate timestamps
+    const crash = (
+      server as unknown as { handleWorkerCrash: (reason: string) => Promise<void> }
+    ).handleWorkerCrash.bind(server);
+    await crash("crash 0");
+    await crash("crash 1");
+
+    const timestamps = (server as unknown as { crashTimestamps: number[] }).crashTimestamps;
+    expect(timestamps.length).toBe(2);
+
+    // Manual stop + restart cycle
+    await server.stop();
+    expect(timestamps.length).toBe(0);
+
+    // Restart — should have a fresh crash budget
+    await server.start();
+
+    // 3 more crashes should all succeed (not poisoned by stale history)
+    let restartCount = 0;
+    server.onRestarted = () => {
+      restartCount++;
+    };
+    const crash2 = (
+      server as unknown as { handleWorkerCrash: (reason: string) => Promise<void> }
+    ).handleWorkerCrash.bind(server);
+    for (let i = 0; i < 3; i++) {
+      await crash2(`post-restart crash ${i}`);
+    }
+    expect(restartCount).toBe(3);
+  });
+
   test("stop() terminates worker cleanly", async () => {
     using opts = testOptions();
     db = new StateDb(opts.DB_PATH);

--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -237,6 +237,7 @@ export class ClaudeServer {
     this.activeSessions.clear();
     this.sessionPids.clear();
     this.sessionAddedAt.clear();
+    this.crashTimestamps.length = 0;
   }
 
   /** Get the WebSocket server port (available after start). */


### PR DESCRIPTION
## Summary
- Clear `crashTimestamps` array in `ClaudeServer.stop()` so stale crash history from a previous lifecycle doesn't poison the rate limiter after a manual stop/restart cycle
- Added test verifying that after stop+restart, the full crash budget (3 crashes) is available again

## Test plan
- [x] New test: `stop() clears crashTimestamps so stale history does not poison restarts` — simulates 2 crashes, stops, restarts, then verifies 3 more crashes all succeed
- [x] All 40 existing claude-server tests pass
- [x] typecheck, lint, full test suite pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)