### PR TITLE
fix(test): remove brittle exact-set assertion in completions.spec.ts (fixes #479)

### DIFF
--- a/packages/command/src/commands/completions.spec.ts
+++ b/packages/command/src/commands/completions.spec.ts
@@ -46,10 +46,6 @@ describe("SUBCOMMANDS", () => {
       expect((SUBCOMMANDS as readonly string[]).includes(cmd)).toBe(true);
     }
   });
-
-  test("has no unexpected commands", () => {
-    expect(SUBCOMMANDS).toHaveLength(expected.length);
-  });
 });
 
 describe("ALIAS_SUBCOMMANDS", () => {


### PR DESCRIPTION
## Summary
- Removed the "has no unexpected commands" test that asserts exact length of `SUBCOMMANDS`, which breaks every time a new command is added
- The "contains all expected commands" test remains and validates the important invariant — known commands are present
- New commands no longer cause test failures

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — all 1803 tests pass
- [x] Verified `completions.spec.ts` still validates all expected commands exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)