### PR TITLE
fix(test): add retry budget invariant test (fixes #478)

### DIFF
--- a/packages/core/src/constants.spec.ts
+++ b/packages/core/src/constants.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CONNECT_INITIAL_DELAY_MS,
+  CONNECT_MAX_DELAY_MS,
+  CONNECT_MAX_RETRIES,
+  CONNECT_TIMEOUT_MS,
+  IPC_REQUEST_TIMEOUT_MS,
+} from "./constants";
+
+describe("connection retry budget", () => {
+  test("worst-case retry budget fits inside IPC_REQUEST_TIMEOUT_MS", () => {
+    // Compute worst-case total time:
+    //   (MAX_RETRIES + 1) connect attempts, each taking up to CONNECT_TIMEOUT_MS,
+    //   plus backoff delays between retries: delay_i = min(INITIAL * 2^i, MAX_DELAY)
+    const totalConnectTime = (CONNECT_MAX_RETRIES + 1) * CONNECT_TIMEOUT_MS;
+
+    let totalBackoffDelay = 0;
+    for (let i = 0; i < CONNECT_MAX_RETRIES; i++) {
+      totalBackoffDelay += Math.min(CONNECT_INITIAL_DELAY_MS * 2 ** i, CONNECT_MAX_DELAY_MS);
+    }
+
+    const worstCase = totalConnectTime + totalBackoffDelay;
+
+    // Must fit within IPC request timeout with margin for processing overhead
+    expect(worstCase).toBeLessThan(IPC_REQUEST_TIMEOUT_MS);
+  });
+
+  test("backoff delays are bounded by CONNECT_MAX_DELAY_MS", () => {
+    for (let i = 0; i <= CONNECT_MAX_RETRIES; i++) {
+      const delay = CONNECT_INITIAL_DELAY_MS * 2 ** i;
+      expect(Math.min(delay, CONNECT_MAX_DELAY_MS)).toBeLessThanOrEqual(CONNECT_MAX_DELAY_MS);
+    }
+  });
+
+  test("constants have sensible values", () => {
+    expect(CONNECT_MAX_RETRIES).toBeGreaterThanOrEqual(1);
+    expect(CONNECT_TIMEOUT_MS).toBeGreaterThan(0);
+    expect(CONNECT_INITIAL_DELAY_MS).toBeGreaterThan(0);
+    expect(CONNECT_MAX_DELAY_MS).toBeGreaterThanOrEqual(CONNECT_INITIAL_DELAY_MS);
+    expect(IPC_REQUEST_TIMEOUT_MS).toBeGreaterThan(CONNECT_TIMEOUT_MS);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `packages/core/src/constants.spec.ts` with deterministic arithmetic tests on the connection retry constants
- Verifies worst-case retry budget `(MAX_RETRIES + 1) × CONNECT_TIMEOUT + sum(backoff delays)` fits within `IPC_REQUEST_TIMEOUT_MS`
- Replaces need for fragile runtime timing assertions that fail under load with pure constant-based checks

## Test plan
- [x] New test computes worst-case budget from constants and asserts `< IPC_REQUEST_TIMEOUT_MS`
- [x] Backoff delay bounds verified against `CONNECT_MAX_DELAY_MS`
- [x] Sanity checks on constant values (positive, sensible ordering)
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — all 1807 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)