### PR TITLE
fix(ws-server): drain waiters on process exit to prevent flaky hangs (fixes #480)

### DIFF
--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -627,6 +627,43 @@ describe("ClaudeWsServer", () => {
     await expect(server.waitForResult("test-session", 5000)).rejects.toThrow("Session is disconnected");
   });
 
+  test("process exit rejects pending result waiters", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn });
+    server.start();
+
+    server.prepareSession("test-session", { prompt: "Hello" });
+    server.spawnClaude("test-session");
+
+    // Register a result waiter BEFORE process exits
+    const resultPromise = server.waitForResult("test-session", 5000).catch((e: unknown) => e);
+
+    // Process exits — waiter should be rejected
+    ms.exitResolve(0);
+
+    const err = await resultPromise;
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain("Process exited");
+  });
+
+  test("process exit resolves pending event waiters with disconnect event", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn });
+    server.start();
+
+    server.prepareSession("test-session", { prompt: "Hello" });
+    server.spawnClaude("test-session");
+
+    // Register an event waiter BEFORE process exits
+    const eventPromise = server.waitForEvent("test-session", 5000);
+
+    // Process exits — event waiter should resolve with a session event
+    ms.exitResolve(0);
+
+    const event = await eventPromise;
+    expect(event.sessionId).toBe("test-session");
+  });
+
   test("waitForEvent on already-disconnected session rejects immediately", async () => {
     const ms = mockSpawn();
     server = new ClaudeWsServer({ spawn: ms.spawn });

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -309,7 +309,13 @@ export class ClaudeWsServer {
       const events = session.state.disconnect("spawn exited");
       for (const event of events) {
         this.onSessionEvent?.(sessionId, event);
+        this.handleSessionEvent(sessionId, session, event);
       }
+      // Reject pending result waiters — they can't get results without a process
+      for (const waiter of session.resultWaiters) {
+        waiter.reject(new Error("Process exited"));
+      }
+      session.resultWaiters.length = 0;
     });
 
     return proc.pid;
@@ -802,6 +808,12 @@ export class ClaudeWsServer {
         this.resolveEventWaiters(sessionId, {
           sessionId,
           event: "session:model_changed",
+        });
+        break;
+      case "session:disconnected":
+        this.resolveEventWaiters(sessionId, {
+          sessionId,
+          event: "session:disconnected",
         });
         break;
     }


### PR DESCRIPTION
## Summary
- The `proc.exited` handler in `spawnClaude()` transitioned state to disconnected but never drained pending result waiters or resolved event waiters, causing them to hang until timeout
- Added result waiter rejection with "Process exited" error in the exit handler
- Added `session:disconnected` case to `handleSessionEvent` so event waiters are resolved on process exit
- Added two new tests covering both the result waiter and event waiter race conditions

## Test plan
- [x] New test: `process exit rejects pending result waiters` — registers waiter before exit, verifies rejection
- [x] New test: `process exit resolves pending event waiters with disconnect event` — registers event waiter before exit, verifies resolution
- [x] All 1806 tests pass, typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)