### PR TITLE
fix(daemon): replace fragile isControlMessage heuristic with allowlist in worker (fixes #450)

### DIFF
--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -36,8 +36,16 @@ interface ToolsChangedMessage {
 
 type ControlMessage = InitMessage | ToolsChangedMessage;
 
+const CONTROL_MESSAGE_TYPES: ReadonlySet<string> = new Set<ControlMessage["type"]>(["init", "tools_changed"]);
+
 function isControlMessage(data: unknown): data is ControlMessage {
-  return typeof data === "object" && data !== null && "type" in data && !("jsonrpc" in data);
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "type" in data &&
+    typeof (data as Record<string, unknown>).type === "string" &&
+    CONTROL_MESSAGE_TYPES.has((data as Record<string, unknown>).type as string)
+  );
 }
 
 // ── Worker globals ──


### PR DESCRIPTION
## Summary
- Replace the fragile `isControlMessage` heuristic in `claude-session-worker.ts` with an explicit `CONTROL_MESSAGE_TYPES` allowlist (`'init'`, `'tools_changed'`)
- Mirrors the parent-side fix from PR #449, closing the same class of routing ambiguity on the worker side
- Messages with unexpected `type` values are no longer incorrectly consumed as control messages

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (1808 tests, 0 failures)
- [x] Coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)