### PR TITLE
fix(daemon): add import.meta.main guard to main.ts entry points (fixes #416)

### DIFF
--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -720,4 +720,6 @@ Examples:
   mcx run get-time`);
 }
 
-main().then(() => process.exit(process.exitCode ?? 0));
+if (import.meta.main) {
+  main().then(() => process.exit(process.exitCode ?? 0));
+}

--- a/packages/control/src/main.tsx
+++ b/packages/control/src/main.tsx
@@ -9,13 +9,15 @@ import { render } from "ink";
 import React from "react";
 import { App } from "./app.js";
 
-if (!process.stdout.isTTY) {
-  console.error("mcpctl requires a terminal. Use 'mcx status' for non-interactive output.");
-  process.exit(1);
+if (import.meta.main) {
+  if (!process.stdout.isTTY) {
+    console.error("mcpctl requires a terminal. Use 'mcx status' for non-interactive output.");
+    process.exit(1);
+  }
+
+  const { waitUntilExit } = render(<App />, {
+    exitOnCtrlC: true,
+  });
+
+  await waitUntilExit();
 }
-
-const { waitUntilExit } = render(<App />, {
-  exitOnCtrlC: true,
-});
-
-await waitUntilExit();

--- a/packages/daemon/src/main.ts
+++ b/packages/daemon/src/main.ts
@@ -38,7 +38,9 @@ async function main(): Promise<void> {
   });
 }
 
-main().catch((err) => {
-  console.error("[mcpd] Fatal:", err);
-  process.exit(1);
-});
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error("[mcpd] Fatal:", err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- Wrap `main()` calls in all three package entry points (`packages/daemon/src/main.ts`, `packages/command/src/main.ts`, `packages/control/src/main.tsx`) with `import.meta.main` guards
- Prevents accidental daemon/CLI startup if tests or other code paths import `main.ts` instead of `index.ts`
- One line of defense-in-depth insurance per file

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes — no changes needed
- [x] `bun test` — all 1818 tests pass
- [x] Coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)