### PR TITLE
fix(daemon): check draining flag in waitForMail poll loop (fixes #465)

### DIFF
--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -875,6 +875,47 @@ describe("IpcServer HTTP transport", () => {
     expect((json.result as { message: null }).message).toBeNull();
   });
 
+  test("waitForMail returns null early when shutdown is requested", async () => {
+    socketPath = tmpSocket();
+    let shutdownCalled = false;
+    const db = mockDb({
+      getNextUnread: () => undefined,
+    });
+    server = new IpcServer(
+      mockPool() as never,
+      mockConfig(),
+      db,
+      null,
+      opts({
+        onShutdown: () => {
+          shutdownCalled = true;
+        },
+      }),
+    );
+    server.start(socketPath);
+
+    // Start a waitForMail with a long timeout (30s)
+    const waitReq = rpc("/rpc", { id: "wm-drain", method: "waitForMail", params: { recipient: "mgr", timeout: 30 } });
+
+    // Give it a moment to enter the poll loop
+    await Bun.sleep(100);
+
+    // Trigger shutdown — this should cause waitForMail to return early
+    const shutdownRes = await rpc("/rpc", { id: "sd-wm", method: "shutdown" });
+    const shutdownJson = (await shutdownRes.json()) as IpcResponse;
+    expect(shutdownJson.result).toEqual({ ok: true });
+
+    // waitForMail should complete quickly (not wait 30s)
+    const waitRes = await waitReq;
+    const waitJson = (await waitRes.json()) as IpcResponse;
+    expect(waitJson.error).toBeUndefined();
+    expect((waitJson.result as { message: null }).message).toBeNull();
+
+    // Shutdown should have completed
+    await pollUntil(() => shutdownCalled);
+    expect(shutdownCalled).toBe(true);
+  });
+
   test("replyToMail creates reply with swapped sender/recipient", async () => {
     socketPath = tmpSocket();
     const original = {

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -565,6 +565,7 @@ export class IpcServer {
       const deadline = Date.now() + maxWait;
 
       while (Date.now() < deadline) {
+        if (this.draining) return { message: null };
         const msg = this.db.getNextUnread(recipient);
         if (msg) {
           this.db.markMailRead(msg.id);


### PR DESCRIPTION
## Summary
- Added `this.draining` check at the top of the `waitForMail` poll loop so it returns `{ message: null }` immediately when shutdown is requested
- Prevents the poll loop from holding an in-flight request for up to 30s, which blocked the drain mechanism from completing shutdown

## Test plan
- [x] New test: "waitForMail returns null early when shutdown is requested" — starts a 30s waitForMail, triggers shutdown, verifies waitForMail returns promptly and shutdown completes
- [x] All existing tests pass (1819 tests, 0 failures)
- [x] Typecheck and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)