### PR TITLE
fix(control): apply setTimeout chain pattern to useClaudeSessions hook (fixes #388)

### DIFF
--- a/packages/control/src/hooks/use-claude-sessions.ts
+++ b/packages/control/src/hooks/use-claude-sessions.ts
@@ -55,12 +55,20 @@ export function useClaudeSessions(opts: UseClaudeSessionsOptions = {}): UseClaud
       }
     }
 
-    poll();
-    const id = setInterval(poll, intervalMs);
+    let timerId: ReturnType<typeof setTimeout> | undefined;
+
+    async function scheduleNext() {
+      await poll();
+      if (!cancelled) {
+        timerId = setTimeout(scheduleNext, intervalMs);
+      }
+    }
+
+    scheduleNext();
 
     return () => {
       cancelled = true;
-      clearInterval(id);
+      if (timerId !== undefined) clearTimeout(timerId);
     };
   }, [intervalMs, enabled, ipcCallFn]);
 


### PR DESCRIPTION
## Summary
- Replace `setInterval` with `setTimeout` chain in `useClaudeSessions` hook to prevent overlapping polls when `ipcCall` takes longer than the polling interval
- Matches the pattern already applied to `useDaemon` and `useLogs` hooks in PR #376

## Test plan
- [x] All 7 existing `use-claude-sessions.spec.ts` tests pass (including polling and cleanup tests)
- [x] 100% coverage on `use-claude-sessions.ts`
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)