### PR TITLE
fix(daemon): replace fragile isControlMessage heuristic in alias-server-worker (fixes #489)

### DIFF
--- a/packages/daemon/src/alias-server-worker.ts
+++ b/packages/daemon/src/alias-server-worker.ts
@@ -42,8 +42,16 @@ interface RefreshMessage {
 
 type ControlMessage = InitMessage | RefreshMessage;
 
+const CONTROL_MESSAGE_TYPES: ReadonlySet<string> = new Set<ControlMessage["type"]>(["init", "refresh"]);
+
 function isControlMessage(data: unknown): data is ControlMessage {
-  return typeof data === "object" && data !== null && "type" in data;
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "type" in data &&
+    typeof (data as Record<string, unknown>).type === "string" &&
+    CONTROL_MESSAGE_TYPES.has((data as Record<string, unknown>).type as string)
+  );
 }
 
 // -- Alias execution infrastructure --


### PR DESCRIPTION
## Summary
- Replaced the fragile `isControlMessage()` heuristic in `alias-server-worker.ts` with a `CONTROL_MESSAGE_TYPES` allowlist set
- Same pattern as PR #485 applied to `claude-session-worker.ts` — checks that `type` is a string and is in the known set (`"init"`, `"refresh"`) instead of relying on the absence of `"jsonrpc"`

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes  
- [x] `bun test` — all 1846 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)