### PR TITLE
fix(daemon): add try/catch in handleSessionEvent to prevent silent event drops (fixes #509)

### DIFF
--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -1832,6 +1832,43 @@ describe("ClaudeWsServer", () => {
     }
   });
 
+  test("handleSessionEvent throw does not drop remaining events in the same NDJSON frame", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn });
+    const port = server.start();
+
+    // Make handleSessionEvent throw on session:init but delegate normally for all other events.
+    // This simulates an unexpected exception in the event handler for one event type.
+    // biome-ignore lint/suspicious/noExplicitAny: testing private method via monkeypatching
+    const original = (server as any).handleSessionEvent.bind(server);
+    // biome-ignore lint/suspicious/noExplicitAny: testing private method via monkeypatching
+    (server as any).handleSessionEvent = (sessionId: string, session: unknown, event: { type: string }) => {
+      if (event.type === "session:init") {
+        throw new Error("simulated handleSessionEvent failure on session:init");
+      }
+      return original(sessionId, session, event);
+    };
+
+    server.prepareSession("test-session", { prompt: "Hello" });
+    server.spawnClaude("test-session");
+
+    const ws = await connectMockClaude(port, "test-session");
+    try {
+      await waitForMessage(ws); // consume initial prompt
+
+      // Send all three messages as a SINGLE WebSocket frame (concatenated NDJSON).
+      // parseFrame splits them, so handleMessage processes all three in one call.
+      // session:init handler will throw, but session:result must still be processed.
+      const resultPromise = server.waitForResult("test-session", 5000);
+      ws.send(systemInitMessage("test-session") + assistantMessage("test-session") + resultMessage("test-session"));
+
+      const result = await resultPromise;
+      expect(result.success).toBe(true);
+    } finally {
+      ws.close();
+    }
+  });
+
   test("throwing onSessionEvent callback does not prevent handleSessionEvent from running", async () => {
     const ms = mockSpawn();
     server = new ClaudeWsServer({ spawn: ms.spawn });

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -331,7 +331,13 @@ export class ClaudeWsServer {
       const events = session.state.disconnect("spawn exited");
       for (const event of events) {
         this.onSessionEvent?.(sessionId, event);
-        this.handleSessionEvent(sessionId, session, event);
+        try {
+          this.handleSessionEvent(sessionId, session, event);
+        } catch (err) {
+          console.error(
+            `[_claude] handleSessionEvent failed for session ${sessionId}, event ${event.type}: ${err instanceof Error ? err.stack : err}`,
+          );
+        }
       }
       // Reject pending result waiters — they can't get results without a process
       for (const waiter of session.resultWaiters) {
@@ -438,7 +444,13 @@ export class ClaudeWsServer {
     const events = session.state.resetForClear();
     for (const event of events) {
       this.onSessionEvent?.(sessionId, event);
-      this.handleSessionEvent(sessionId, session, event);
+      try {
+        this.handleSessionEvent(sessionId, session, event);
+      } catch (err) {
+        console.error(
+          `[_claude] handleSessionEvent failed for session ${sessionId}, event ${event.type}: ${err instanceof Error ? err.stack : err}`,
+        );
+      }
     }
 
     // Clear keep-alive timer
@@ -493,7 +505,13 @@ export class ClaudeWsServer {
     const events = session.state.setModel(model);
     for (const event of events) {
       this.onSessionEvent?.(sessionId, event);
-      this.handleSessionEvent(sessionId, session, event);
+      try {
+        this.handleSessionEvent(sessionId, session, event);
+      } catch (err) {
+        console.error(
+          `[_claude] handleSessionEvent failed for session ${sessionId}, event ${event.type}: ${err instanceof Error ? err.stack : err}`,
+        );
+      }
     }
   }
 
@@ -756,7 +774,13 @@ export class ClaudeWsServer {
             `[_claude] onSessionEvent callback threw for session ${sessionId}, event ${event.type}: ${err instanceof Error ? err.stack : err}`,
           );
         }
-        this.handleSessionEvent(sessionId, session, event);
+        try {
+          this.handleSessionEvent(sessionId, session, event);
+        } catch (err) {
+          console.error(
+            `[_claude] handleSessionEvent failed for session ${sessionId}, event ${event.type}: ${err instanceof Error ? err.stack : err}`,
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Wraps the body of `handleSessionEvent` in a try/catch to prevent exceptions (e.g., from `resolveEventWaiters` → `buildSessionInfo`) from escaping the event processing loop
- Logs caught errors with session ID and event type for debuggability
- Prevents silent event drops, unresolved waiters, and state divergence when a single event handler throws

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — all 1846 tests pass
- [x] Coverage thresholds met (88.34% functions, 86.97% lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)