### PR TITLE
fix(permissions): canonicalize file paths before glob matching (fixes #524)

### DIFF
--- a/packages/permissions/src/file-matcher.spec.ts
+++ b/packages/permissions/src/file-matcher.spec.ts
@@ -35,4 +35,27 @@ describe("matchFilePath", () => {
     expect(matchFilePath("file.tsx", "*.{ts,tsx}")).toBe(true);
     expect(matchFilePath("file.js", "*.{ts,tsx}")).toBe(false);
   });
+
+  test("rejects directory traversal with ..", () => {
+    // "src/../../etc/passwd" normalizes to "../etc/passwd", not under "src/"
+    expect(matchFilePath("src/../../etc/passwd", "src/**")).toBe(false);
+    expect(matchFilePath("src/../../../etc/shadow", "src/**")).toBe(false);
+  });
+
+  test("normalizes redundant segments", () => {
+    // "src/./index.ts" normalizes to "src/index.ts"
+    expect(matchFilePath("src/./index.ts", "src/**")).toBe(true);
+    expect(matchFilePath("src/./index.ts", "src/*.ts")).toBe(true);
+  });
+
+  test("normalizes parent traversal that stays within pattern scope", () => {
+    // "src/deep/../index.ts" normalizes to "src/index.ts" — still under src/
+    expect(matchFilePath("src/deep/../index.ts", "src/**")).toBe(true);
+    expect(matchFilePath("src/deep/../index.ts", "src/*.ts")).toBe(true);
+  });
+
+  test("rejects traversal escaping absolute path patterns", () => {
+    // "/home/user/../../../etc/passwd" normalizes to "/etc/passwd"
+    expect(matchFilePath("/home/user/../../../etc/passwd", "/home/user/**")).toBe(false);
+  });
 });

--- a/packages/permissions/src/file-matcher.ts
+++ b/packages/permissions/src/file-matcher.ts
@@ -4,11 +4,17 @@
  * Uses Bun's built-in Glob for matching file paths against patterns.
  */
 
+import { normalize } from "node:path";
+
 /**
  * Match a file path against a glob pattern (e.g., "src/**\/*.ts").
  * Uses Bun's native Glob implementation — no external dependencies.
+ *
+ * The file path is normalized before matching to prevent directory
+ * traversal attacks (e.g., "src/../../etc/passwd" matching "src/**").
  */
 export function matchFilePath(filePath: string, pattern: string): boolean {
-  const glob = new Bun.Glob(pattern);
-  return glob.match(filePath);
+  const normalized = normalize(filePath);
+  const glob = new Bun.Glob(normalize(pattern));
+  return glob.match(normalized);
 }


### PR DESCRIPTION
## Summary
- Normalize file paths with `path.normalize()` before glob matching in `matchFilePath` to prevent directory traversal attacks
- Both the input path and pattern are normalized, ensuring `//`-prefixed paths and patterns stay consistent
- Added tests for `..` traversal sequences, redundant `.` segments, traversal within scope, and absolute path escapes

## Test plan
- [x] `src/../../etc/passwd` correctly rejected by `src/**` pattern
- [x] `src/./index.ts` still matches `src/**` after normalization
- [x] `src/deep/../index.ts` correctly matches `src/**` (stays within scope)
- [x] `/home/user/../../../etc/passwd` rejected by `/home/user/**`
- [x] All 87 permissions tests pass, 100% coverage
- [x] Full suite: 1956 tests pass, typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)