### PR TITLE
feat(permissions): shell quoting-aware compound command detection (fixes #523)

### DIFF
--- a/packages/permissions/src/bash-matcher.spec.ts
+++ b/packages/permissions/src/bash-matcher.spec.ts
@@ -49,6 +49,65 @@ describe("isCompoundCommand", () => {
   test("detects embedded newlines", () => {
     expect(isCompoundCommand("git status\nrm -rf /")).toBe(true);
   });
+
+  // ── Shell quoting: false-positive fixes ──
+
+  test("ignores operators inside double quotes", () => {
+    expect(isCompoundCommand('git commit -m "fix: a && b"')).toBe(false);
+    expect(isCompoundCommand('git commit -m "a || b"')).toBe(false);
+    expect(isCompoundCommand('echo "hello; world"')).toBe(false);
+    expect(isCompoundCommand('grep "pattern|other"')).toBe(false);
+  });
+
+  test("ignores operators inside single quotes", () => {
+    expect(isCompoundCommand("git commit -m 'fix: a && b'")).toBe(false);
+    expect(isCompoundCommand("grep 'a|b|c'")).toBe(false);
+    expect(isCompoundCommand("echo 'hello; world'")).toBe(false);
+  });
+
+  test("ignores substitution patterns inside single quotes", () => {
+    expect(isCompoundCommand("echo '$(whoami)'")).toBe(false);
+    expect(isCompoundCommand("echo '`whoami`'")).toBe(false);
+    expect(isCompoundCommand("echo '<(cmd)'")).toBe(false);
+  });
+
+  test("detects substitution patterns inside double quotes", () => {
+    // $() and backticks expand inside double quotes in real bash
+    expect(isCompoundCommand('echo "$(whoami)"')).toBe(true);
+    expect(isCompoundCommand('echo "`whoami`"')).toBe(true);
+  });
+
+  test("ignores process substitution inside double quotes", () => {
+    // <( and >( are operators, not expansions — literal inside double quotes
+    expect(isCompoundCommand('echo "<(cmd)"')).toBe(false);
+  });
+
+  test("backslash escapes outside quotes", () => {
+    // \; is an escaped semicolon, not an operator
+    expect(isCompoundCommand("echo hello\\; world")).toBe(false);
+    expect(isCompoundCommand("echo a\\&\\& b")).toBe(false);
+    expect(isCompoundCommand("echo \\$(cmd)")).toBe(false);
+    expect(isCompoundCommand("echo \\`cmd\\`")).toBe(false);
+  });
+
+  test("backslash escapes inside double quotes", () => {
+    expect(isCompoundCommand('echo "\\$(cmd)"')).toBe(false);
+    expect(isCompoundCommand('echo "\\`cmd\\`"')).toBe(false);
+  });
+
+  test("mixed quoted and unquoted segments", () => {
+    // Operator is outside the quotes
+    expect(isCompoundCommand('git commit -m "ok" && echo done')).toBe(true);
+    // Operator is inside the quotes
+    expect(isCompoundCommand('git commit -m "a && b" --amend')).toBe(false);
+  });
+
+  test("unclosed quotes treat rest as quoted", () => {
+    // Unclosed double quote — && is inside the quote
+    expect(isCompoundCommand('echo "a && b')).toBe(false);
+    // Unclosed single quote
+    expect(isCompoundCommand("echo 'a && b")).toBe(false);
+  });
 });
 
 describe("matchBashCommand", () => {
@@ -122,5 +181,17 @@ describe("matchBashCommand", () => {
 
   test("rejects newline injection on prefix match", () => {
     expect(matchBashCommand("git status\nrm -rf /", "git ")).toBe(false);
+  });
+
+  // ── Quoting-aware prefix matching ──
+
+  test("allows quoted operators in prefix match", () => {
+    expect(matchBashCommand('git commit -m "fix: a && b"', "git ")).toBe(true);
+    expect(matchBashCommand("git commit -m 'a || b'", "git ")).toBe(true);
+    expect(matchBashCommand('grep "pattern|other" file.txt', "grep ")).toBe(true);
+  });
+
+  test("rejects real operators after quoted segment", () => {
+    expect(matchBashCommand('git commit -m "ok" && rm -rf /', "git ")).toBe(false);
   });
 });

--- a/packages/permissions/src/bash-matcher.ts
+++ b/packages/permissions/src/bash-matcher.ts
@@ -5,35 +5,95 @@
  * - Exact match: command === prefix (e.g., "npm run build")
  * - Prefix match: command.startsWith(prefix) (e.g., "git " matches "git push")
  * - Compound rejection: refuse prefix/wildcard on commands with &&, ||, ;, |
+ *
+ * The compound detector implements a basic shell lexer that respects
+ * single and double quoting to avoid false positives on quoted operators.
  */
 
-/** Operators that indicate compound commands. */
-const COMPOUND_OPERATORS = ["&&", "||", ";", "|"];
-
 /**
- * Patterns that indicate command substitution or injection vectors.
- * These allow arbitrary code execution inside an otherwise-safe prefix match.
+ * Quoting context during shell lexing.
+ * - none: outside any quotes
+ * - single: inside '...' (everything literal)
+ * - double: inside "..." (operators literal, but $() and backticks still expand)
  */
-const SUBSTITUTION_PATTERNS = ["$(", "`", "<(", ">("];
+type QuoteState = "none" | "single" | "double";
 
 /**
- * Check if a command string is compound (contains shell operators)
- * or contains command substitution patterns.
+ * Check if a command string is compound (contains shell operators or
+ * command substitution patterns) while respecting shell quoting rules.
  *
- * Compound commands are rejected for prefix/wildcard rules because
- * `git status && rm -rf /` should not match `Bash(git *)`.
+ * Single quotes: suppress everything — no operators or substitutions detected.
+ * Double quotes: suppress operators (&&, ||, ;, |) but NOT $() or backticks
+ *   (which still expand in real bash).
+ * Process substitution (<(, >() and embedded newlines are checked outside any quotes.
  *
- * Command substitutions like `$(...)` and backticks are also rejected
- * because they allow arbitrary execution inside a permitted prefix.
- *
- * Note: This is a cooperative guardrail, not a security boundary.
- * It uses naive string matching and does not parse shell quoting,
- * so `git commit -m "a && b"` will be falsely rejected.
+ * This is a cooperative guardrail, not a security boundary.
  */
 export function isCompoundCommand(command: string): boolean {
-  if (COMPOUND_OPERATORS.some((op) => command.includes(op))) return true;
-  if (SUBSTITUTION_PATTERNS.some((p) => command.includes(p))) return true;
-  if (command.includes("\n")) return true;
+  let state: QuoteState = "none";
+  const len = command.length;
+
+  for (let i = 0; i < len; i++) {
+    const ch = command[i];
+
+    // ── State transitions ──
+
+    if (state === "none") {
+      // Backslash escapes the next character outside quotes
+      if (ch === "\\") {
+        i++; // skip next char
+        continue;
+      }
+      if (ch === "'") {
+        state = "single";
+        continue;
+      }
+      if (ch === '"') {
+        state = "double";
+        continue;
+      }
+    } else if (state === "single") {
+      // Single quotes: no escape processing, just wait for closing quote
+      if (ch === "'") {
+        state = "none";
+      }
+      continue; // everything inside single quotes is literal
+    } else if (state === "double") {
+      // Backslash escapes inside double quotes (for \", \\, \$, \`, \newline)
+      if (ch === "\\") {
+        i++; // skip next char
+        continue;
+      }
+      if (ch === '"') {
+        state = "none";
+        continue;
+      }
+      // $() and backticks still expand inside double quotes
+      if (ch === "$" && i + 1 < len && command[i + 1] === "(") return true;
+      if (ch === "`") return true;
+      continue; // operators are literal inside double quotes
+    }
+
+    // ── Outside quotes: detect dangerous patterns ──
+
+    // Embedded newlines
+    if (ch === "\n") return true;
+
+    // Compound operators: &&, ||, ;, |
+    if (ch === "&" && i + 1 < len && command[i + 1] === "&") return true;
+    if (ch === "|" && i + 1 < len && command[i + 1] === "|") return true;
+    if (ch === ";") return true;
+    if (ch === "|") return true;
+
+    // Command substitution
+    if (ch === "$" && i + 1 < len && command[i + 1] === "(") return true;
+    if (ch === "`") return true;
+
+    // Process substitution
+    if (ch === "<" && i + 1 < len && command[i + 1] === "(") return true;
+    if (ch === ">" && i + 1 < len && command[i + 1] === "(") return true;
+  }
+
   return false;
 }
 


### PR DESCRIPTION
## Summary
- Replace naive `string.includes()` compound command detection with a character-by-character shell lexer that tracks single/double quoting state
- Single quotes suppress all operator and substitution detection (everything is literal)
- Double quotes suppress operator detection (`&&`, `||`, `;`, `|`) but still flag `$()` and backticks (which expand in real bash)
- Backslash escapes respected outside quotes and inside double quotes
- Fixes false positives like `git commit -m "fix: a && b"` while maintaining security detection for unquoted operators and substitutions

## Test plan
- [x] All existing tests pass (no regressions)
- [x] New tests for operators inside double quotes (not compound)
- [x] New tests for operators inside single quotes (not compound)
- [x] New tests for substitutions inside single quotes (not compound — literal in bash)
- [x] New tests for substitutions inside double quotes (compound — expand in bash)
- [x] New tests for backslash escapes outside and inside double quotes
- [x] New tests for mixed quoted/unquoted segments
- [x] New tests for unclosed quotes (conservative: treat rest as quoted)
- [x] 100% line coverage on bash-matcher.ts
- [x] Full suite: 1963 tests pass, typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)