### PR TITLE
test(daemon): extract isControlMessage into shared module for unit testing (fixes #516)

### DIFF
--- a/packages/daemon/src/alias-server-worker.ts
+++ b/packages/daemon/src/alias-server-worker.ts
@@ -16,6 +16,7 @@ import { type AliasDefinition, generateSpanId } from "@mcp-cli/core";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod/v4";
+import { createIsControlMessage } from "./worker-control-message";
 import { registerMcpPlugin, stubProxy } from "./worker-plugin";
 import { WorkerServerTransport } from "./worker-transport";
 
@@ -43,16 +44,7 @@ interface RefreshMessage {
 type ControlMessage = InitMessage | RefreshMessage;
 
 const CONTROL_MESSAGE_TYPES: ReadonlySet<string> = new Set<ControlMessage["type"]>(["init", "refresh"]);
-
-function isControlMessage(data: unknown): data is ControlMessage {
-  return (
-    typeof data === "object" &&
-    data !== null &&
-    "type" in data &&
-    typeof (data as Record<string, unknown>).type === "string" &&
-    CONTROL_MESSAGE_TYPES.has((data as Record<string, unknown>).type as string)
-  );
-}
+const isControlMessage = createIsControlMessage<ControlMessage>(CONTROL_MESSAGE_TYPES);
 
 // -- Alias execution infrastructure --
 

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -21,6 +21,7 @@ import { DEFAULT_SAFE_TOOLS, type PermissionRule, type PermissionStrategy } from
 import type { SessionEvent } from "./claude-session/session-state";
 import { CLAUDE_TOOLS } from "./claude-session/tools";
 import { ClaudeWsServer, type WaitResult, WaitTimeoutError } from "./claude-session/ws-server";
+import { createIsControlMessage } from "./worker-control-message";
 import { WorkerServerTransport } from "./worker-transport";
 
 // ── Control messages ──
@@ -37,16 +38,7 @@ interface ToolsChangedMessage {
 type ControlMessage = InitMessage | ToolsChangedMessage;
 
 const CONTROL_MESSAGE_TYPES: ReadonlySet<string> = new Set<ControlMessage["type"]>(["init", "tools_changed"]);
-
-function isControlMessage(data: unknown): data is ControlMessage {
-  return (
-    typeof data === "object" &&
-    data !== null &&
-    "type" in data &&
-    typeof (data as Record<string, unknown>).type === "string" &&
-    CONTROL_MESSAGE_TYPES.has((data as Record<string, unknown>).type as string)
-  );
-}
+const isControlMessage = createIsControlMessage<ControlMessage>(CONTROL_MESSAGE_TYPES);
 
 // ── Worker globals ──
 

--- a/packages/daemon/src/worker-control-message.spec.ts
+++ b/packages/daemon/src/worker-control-message.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import { createIsControlMessage } from "./worker-control-message";
+
+describe("createIsControlMessage", () => {
+  const validTypes = new Set(["init", "refresh"]);
+  const isControlMessage = createIsControlMessage(validTypes);
+
+  it("returns true for { type: 'init' }", () => {
+    expect(isControlMessage({ type: "init", aliases: [] })).toBe(true);
+  });
+
+  it("returns true for { type: 'refresh' }", () => {
+    expect(isControlMessage({ type: "refresh", aliases: [] })).toBe(true);
+  });
+
+  it("returns false for JSON-RPC messages", () => {
+    expect(isControlMessage({ jsonrpc: "2.0", method: "tools/list", id: 1 })).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isControlMessage(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isControlMessage(undefined)).toBe(false);
+  });
+
+  it("returns false for plain objects without type", () => {
+    expect(isControlMessage({ foo: "bar" })).toBe(false);
+  });
+
+  it("returns false for objects with non-string type", () => {
+    expect(isControlMessage({ type: 42 })).toBe(false);
+  });
+
+  it("returns false for objects with unknown type string", () => {
+    expect(isControlMessage({ type: "unknown" })).toBe(false);
+  });
+
+  it("returns false for primitives", () => {
+    expect(isControlMessage("init")).toBe(false);
+    expect(isControlMessage(123)).toBe(false);
+    expect(isControlMessage(true)).toBe(false);
+  });
+
+  it("returns false for arrays", () => {
+    expect(isControlMessage([{ type: "init" }])).toBe(false);
+  });
+
+  it("uses different type sets independently", () => {
+    const otherGuard = createIsControlMessage(new Set(["tools_changed"]));
+    expect(otherGuard({ type: "tools_changed" })).toBe(true);
+    expect(otherGuard({ type: "init" })).toBe(false);
+    // Original guard is unaffected
+    expect(isControlMessage({ type: "init" })).toBe(true);
+    expect(isControlMessage({ type: "tools_changed" })).toBe(false);
+  });
+});

--- a/packages/daemon/src/worker-control-message.ts
+++ b/packages/daemon/src/worker-control-message.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared control-message guard for worker files.
+ *
+ * Worker postMessage channels carry both JSON-RPC messages (with `jsonrpc`)
+ * and control messages (with `type`). This module provides a reusable type
+ * guard to distinguish them without duplicating logic across workers.
+ */
+
+/** A control message has a string `type` field from a known allowlist. */
+export interface ControlMessageBase {
+  type: string;
+}
+
+/**
+ * Creates a type guard that checks whether `data` is a control message
+ * whose `type` is in the provided allowlist.
+ */
+export function createIsControlMessage<T extends ControlMessageBase>(
+  validTypes: ReadonlySet<string>,
+): (data: unknown) => data is T {
+  return (data: unknown): data is T =>
+    typeof data === "object" &&
+    data !== null &&
+    "type" in data &&
+    typeof (data as Record<string, unknown>).type === "string" &&
+    validTypes.has((data as Record<string, unknown>).type as string);
+}


### PR DESCRIPTION
## Summary
- Extracted `isControlMessage()` + `CONTROL_MESSAGE_TYPES` pattern into a shared `worker-control-message.ts` module with a `createIsControlMessage<T>()` factory
- Updated `alias-server-worker.ts` and `claude-session-worker.ts` to use the shared factory, eliminating duplicated logic
- Added comprehensive spec covering: valid control messages, JSON-RPC messages, null/undefined, non-string types, unknown type strings, primitives, arrays, and independent type set isolation

## Test plan
- [x] 11 new tests in `worker-control-message.spec.ts` — all pass with 100% coverage
- [x] Full test suite: 1963 tests pass, 0 failures
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)