### PR TITLE
feat: --short flag for mcx claude ls and wait (fixes #539)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -10,6 +10,7 @@ import {
   defaultGetPrStatus,
   extractContentSummary,
   extractIssueNumber,
+  formatSessionShort,
   parseDiffShortstat,
   parseLogArgs,
   parseResumeArgs,
@@ -898,6 +899,60 @@ describe("mcx claude ls", () => {
       console.log = origLog;
     }
   });
+
+  test("--short outputs compact one-line-per-session", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(SESSION_LIST)),
+    });
+
+    const logSpy = mock(() => {});
+    const origLog = console.log;
+    console.log = logSpy;
+    try {
+      await cmdClaude(["ls", "--short"], deps);
+      // No header row — just one line per session
+      expect(logSpy.mock.calls.length).toBe(2);
+      const line1 = (logSpy.mock.calls[0] as string[])[0];
+      expect(line1).toContain("abc12345");
+      expect(line1).toContain("active");
+      expect(line1).toContain("opus-4");
+      expect(line1).toContain("$0.0500");
+      expect(line1).toContain("1000");
+      expect(line1).toContain("3");
+      const line2 = (logSpy.mock.calls[1] as string[])[0];
+      expect(line2).toContain("def67890");
+      expect(line2).toContain("idle");
+    } finally {
+      console.log = origLog;
+    }
+  });
+});
+
+// ── formatSessionShort ──
+
+describe("formatSessionShort", () => {
+  test("formats session as compact one-liner", () => {
+    const line = formatSessionShort({
+      sessionId: "abc12345-1111-2222-3333-444444444444",
+      state: "active",
+      model: "opus-4",
+      cost: 0.05,
+      tokens: 1000,
+      numTurns: 3,
+    });
+    expect(line).toBe("abc12345 active opus-4 $0.0500 1000 3");
+  });
+
+  test("uses dashes for missing values", () => {
+    const line = formatSessionShort({
+      sessionId: "abc12345-1111-2222-3333-444444444444",
+      state: "idle",
+      model: null,
+      cost: 0,
+      tokens: 0,
+    });
+    expect(line).toContain("abc12345 idle — — —");
+  });
 });
 
 // ── defaultGetPrStatus ──
@@ -1479,6 +1534,19 @@ describe("parseWaitArgs", () => {
     const result = parseWaitArgs(["--after"]);
     expect(result.error).toBe("--after requires a sequence number");
   });
+
+  test("parses --short flag", () => {
+    const result = parseWaitArgs(["--short"]);
+    expect(result.short).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  test("parses --short with session and timeout", () => {
+    const result = parseWaitArgs(["abc123", "--short", "--timeout", "5000"]);
+    expect(result.sessionPrefix).toBe("abc123");
+    expect(result.short).toBe(true);
+    expect(result.timeout).toBe(5000);
+  });
 });
 
 // ── wait ──
@@ -1547,6 +1615,54 @@ describe("mcx claude wait", () => {
       const parsed = JSON.parse(output);
       expect(parsed).toHaveLength(2);
       expect(parsed[0].sessionId).toBe(SESSION_LIST[0].sessionId);
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("--short outputs compact event line", async () => {
+    const callTool = mock(async () =>
+      toolResult({
+        sessionId: "abc12345-1111-2222-3333-444444444444",
+        event: "session:result",
+        cost: 0.05,
+        numTurns: 3,
+        result: "Done fixing tests",
+      }),
+    );
+    const deps = makeDeps({ callTool });
+
+    const logSpy = mock(() => {});
+    const origLog = console.log;
+    console.log = logSpy;
+    try {
+      await cmdClaude(["wait", "--short"], deps);
+      expect(logSpy.mock.calls.length).toBe(1);
+      const line = (logSpy.mock.calls[0] as string[])[0];
+      expect(line).toContain("abc12345");
+      expect(line).toContain("session:result");
+      expect(line).toContain("$0.0500");
+      expect(line).toContain("3");
+      expect(line).toContain("Done fixing tests");
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("--short outputs compact session list on timeout fallback", async () => {
+    const callTool = mock(async () => toolResult(SESSION_LIST));
+    const deps = makeDeps({ callTool });
+
+    const logSpy = mock(() => {});
+    const origLog = console.log;
+    console.log = logSpy;
+    try {
+      await cmdClaude(["wait", "--short", "--timeout", "1000"], deps);
+      // One line per session, no header
+      expect(logSpy.mock.calls.length).toBe(2);
+      const line1 = (logSpy.mock.calls[0] as string[])[0];
+      expect(line1).toContain("abc12345");
+      expect(line1).toContain("active");
     } finally {
       console.log = origLog;
     }

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -717,6 +717,7 @@ async function resumeWorktree(
 
 async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
   const { json } = extractJsonFlag(args);
+  const short = args.includes("--short");
   const showPr = args.includes("--pr");
   const result = await d.callTool("claude_session_list", {});
   const text = formatToolResult(result);
@@ -736,6 +737,13 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
 
   if (sessions.length === 0) {
     console.error("No active sessions.");
+    return;
+  }
+
+  if (short) {
+    for (const s of sessions) {
+      console.log(formatSessionShort(s));
+    }
     return;
   }
 
@@ -768,6 +776,24 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
     const cwd = s.cwd ?? "—";
     console.log(`${c.cyan}${id}${c.reset}   ${state} ${model} ${cost} ${tokens}${diff}${pr} ${c.dim}${cwd}${c.reset}`);
   }
+}
+
+/** Compact one-line format: SESSION STATE MODEL COST TOKENS TURNS */
+export function formatSessionShort(s: {
+  sessionId: string;
+  state: string;
+  model?: string | null;
+  cost?: number | null;
+  tokens?: number;
+  numTurns?: number;
+}): string {
+  const id = s.sessionId.slice(0, 8);
+  const state = s.state;
+  const model = s.model ?? "—";
+  const cost = s.cost && s.cost > 0 ? `$${s.cost.toFixed(4)}` : "—";
+  const tokens = s.tokens && s.tokens > 0 ? String(s.tokens) : "—";
+  const turns = s.numTurns !== undefined ? String(s.numTurns) : "—";
+  return `${id} ${state} ${model} ${cost} ${tokens} ${turns}`;
 }
 
 function formatPrStatus(pr: PrStatus | null): string {
@@ -1058,6 +1084,7 @@ export interface WaitArgs {
   sessionPrefix: string | undefined;
   timeout: number | undefined;
   afterSeq: number | undefined;
+  short: boolean;
   error: string | undefined;
 }
 
@@ -1065,6 +1092,7 @@ export function parseWaitArgs(args: string[]): WaitArgs {
   let sessionPrefix: string | undefined;
   let timeout: number | undefined;
   let afterSeq: number | undefined;
+  let short = false;
   let error: string | undefined;
 
   for (let i = 0; i < args.length; i++) {
@@ -1085,12 +1113,14 @@ export function parseWaitArgs(args: string[]): WaitArgs {
         afterSeq = Number(val);
         if (Number.isNaN(afterSeq)) error = "--after must be a number";
       }
+    } else if (arg === "--short") {
+      short = true;
     } else if (!arg.startsWith("-")) {
       sessionPrefix = arg;
     }
   }
 
-  return { sessionPrefix, timeout, afterSeq, error };
+  return { sessionPrefix, timeout, afterSeq, short, error };
 }
 
 async function claudeWait(args: string[], d: ClaudeDeps): Promise<void> {
@@ -1115,7 +1145,45 @@ async function claudeWait(args: string[], d: ClaudeDeps): Promise<void> {
   }
 
   const result = await d.callTool("claude_wait", toolArgs);
-  console.log(formatToolResult(result));
+  const text = formatToolResult(result);
+
+  if (!parsed.short) {
+    console.log(text);
+    return;
+  }
+
+  // --short: try to parse the result
+  let data: unknown;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    console.log(text);
+    return;
+  }
+
+  // Timeout fallback returns a session list array
+  if (Array.isArray(data)) {
+    for (const s of data as Array<{
+      sessionId: string;
+      state: string;
+      model?: string | null;
+      cost?: number | null;
+      tokens?: number;
+      numTurns?: number;
+    }>) {
+      console.log(formatSessionShort(s));
+    }
+    return;
+  }
+
+  // Normal event result: SESSION EVENT COST TURNS RESULT_PREVIEW
+  const evt = data as { sessionId?: string; event?: string; cost?: number; numTurns?: number; result?: string };
+  const id = evt.sessionId ? evt.sessionId.slice(0, 8) : "—";
+  const event = evt.event ?? "—";
+  const cost = evt.cost && evt.cost > 0 ? `$${evt.cost.toFixed(4)}` : "—";
+  const turns = evt.numTurns !== undefined ? String(evt.numTurns) : "—";
+  const preview = evt.result ? evt.result.slice(0, 100) : "";
+  console.log(`${id} ${event} ${cost} ${turns}${preview ? ` ${preview}` : ""}`);
 }
 
 /** Parse `git worktree list --porcelain` output into structured entries. */


### PR DESCRIPTION
## Summary
- `mcx claude ls --short`: outputs compact one-line-per-session format: `SESSION STATE MODEL COST TOKENS TURNS`
- `mcx claude wait --short`: outputs compact event line: `SESSION EVENT COST TURNS RESULT_PREVIEW` (first 100 chars of result)
- On timeout with `--short`, outputs compact session list (same as `ls --short`)
- Adds `formatSessionShort()` helper shared between both commands

## Test plan
- [x] `ls --short` outputs one line per session with no header
- [x] `wait --short` outputs compact event line
- [x] `wait --short` on timeout fallback outputs compact session list
- [x] `parseWaitArgs` parses `--short` flag correctly
- [x] `formatSessionShort` unit tests for formatting and missing values
- [x] All 2013 existing tests pass, coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)