### PR TITLE
fix: log warning for orphaned RPC responses in codex client (fixes #536)

### DIFF
--- a/packages/codex/src/codex-rpc.spec.ts
+++ b/packages/codex/src/codex-rpc.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import type { CodexProcess } from "./codex-process";
 import { CodexRpcClient } from "./codex-rpc";
 
@@ -159,13 +159,16 @@ describe("CodexRpcClient", () => {
     expect(rpc.pendingCount).toBe(0);
   });
 
-  test("ignores orphaned responses", () => {
+  test("logs warning for orphaned responses", () => {
     const { proc } = createMockProcess();
     const rpc = new CodexRpcClient(proc);
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
 
-    // Should not throw — just silently drops
     rpc.handleMessage({ jsonrpc: "2.0", id: 999, result: "orphan" });
     expect(rpc.pendingCount).toBe(0);
+    expect(warnSpy).toHaveBeenCalledWith("[codex-rpc] Orphaned response for id 999 — request may have timed out");
+
+    warnSpy.mockRestore();
   });
 
   test("ignores unknown message shapes", () => {

--- a/packages/codex/src/codex-rpc.ts
+++ b/packages/codex/src/codex-rpc.ts
@@ -48,7 +48,10 @@ export class CodexRpcClient {
       case "response": {
         const id = msg.id as number | string;
         const pending = this.pending.get(id);
-        if (!pending) return; // orphaned response
+        if (!pending) {
+          console.warn(`[codex-rpc] Orphaned response for id ${id} — request may have timed out`);
+          return;
+        }
         this.pending.delete(id);
         clearTimeout(pending.timer);
         if ("error" in msg && msg.error) {


### PR DESCRIPTION
## Summary
- Added `console.warn` when `CodexRpcClient.handleMessage()` receives a response for an already-timed-out request
- Previously orphaned responses were silently dropped, making timing bugs invisible
- Updated test to verify the warning is emitted

## Test plan
- [x] Existing test updated: "logs warning for orphaned responses" verifies `console.warn` is called with the expected message
- [x] All 2107 tests pass
- [x] Typecheck, lint, coverage all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)