### PR TITLE
fix(codex): evict itemFiles/itemCommands maps at turn completion (fixes #535)

### DIFF
--- a/packages/codex/src/codex-event-map.spec.ts
+++ b/packages/codex/src/codex-event-map.spec.ts
@@ -200,6 +200,26 @@ describe("mapNotification", () => {
     });
   });
 
+  test("turn/completed evicts itemFiles and itemCommands maps", () => {
+    const state = createEventMapState();
+    // Populate tracking maps as if items were started during the turn
+    state.itemFiles.set("item-1", ["src/a.ts"]);
+    state.itemFiles.set("item-2", ["src/b.ts", "src/c.ts"]);
+    state.itemCommands.set("item-3", "npm test");
+    state.itemCommands.set("item-4", "bun build");
+
+    mapNotification(
+      "turn/completed",
+      { threadId: "t1", turnId: "turn1", status: "completed" },
+      state,
+      sessionId,
+      provider,
+    );
+
+    expect(state.itemFiles.size).toBe(0);
+    expect(state.itemCommands.size).toBe(0);
+  });
+
   test("turn/completed includes diff when available", () => {
     const state = createEventMapState();
     state.currentDiff = "unified diff content";

--- a/packages/codex/src/codex-event-map.ts
+++ b/packages/codex/src/codex-event-map.ts
@@ -135,6 +135,11 @@ export function mapNotification(
         diff: state.currentDiff ?? undefined,
       };
 
+      // Evict item tracking maps — correlation is only needed during
+      // active approval flows within the turn, not after completion.
+      state.itemFiles.clear();
+      state.itemCommands.clear();
+
       return [{ type: "session:result", result }];
     }
 


### PR DESCRIPTION
## Summary
- Clear `itemFiles` and `itemCommands` maps after each `turn/completed` event
- Item-to-file and item-to-command correlation is only needed during active approval flows within a turn, so evicting at turn completion prevents unbounded memory growth in long-running sessions
- Added test verifying both maps are cleared after turn completion

## Test plan
- [x] New test: `turn/completed evicts itemFiles and itemCommands maps`
- [x] All 2108 existing tests pass
- [x] Typecheck clean
- [x] Lint clean
- [x] Coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)