### PR TITLE
chore(daemon): add exhaustiveness check for WORKER_EVENT_TYPES allowlist (fixes #451)

### DIFF
--- a/packages/daemon/src/claude-server.spec.ts
+++ b/packages/daemon/src/claude-server.spec.ts
@@ -2,8 +2,38 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { silentLogger } from "@mcp-cli/core";
 import { ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types.js";
 import { testOptions } from "../../../test/test-options";
-import { CLAUDE_SERVER_NAME, ClaudeServer, buildClaudeToolCache, isWorkerEvent } from "./claude-server";
+import {
+  CLAUDE_SERVER_NAME,
+  ClaudeServer,
+  WORKER_EVENT_TYPES,
+  buildClaudeToolCache,
+  isWorkerEvent,
+} from "./claude-server";
 import { StateDb } from "./db/state";
+
+// ── WORKER_EVENT_TYPES exhaustiveness ──
+
+describe("WORKER_EVENT_TYPES", () => {
+  test("covers all WorkerEvent type literals", () => {
+    // This list must be updated when new WorkerEvent types are added.
+    // The Record<WorkerEvent["type"], true> in claude-server.ts provides
+    // compile-time enforcement; this test catches runtime drift.
+    const expected: string[] = [
+      "ready",
+      "db:upsert",
+      "db:state",
+      "db:cost",
+      "db:disconnected",
+      "db:end",
+      "metrics:inc",
+      "metrics:observe",
+    ];
+    expect(WORKER_EVENT_TYPES.size).toBe(expected.length);
+    for (const t of expected) {
+      expect(WORKER_EVENT_TYPES.has(t)).toBe(true);
+    }
+  });
+});
 
 // ── isWorkerEvent ──
 

--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -92,17 +92,20 @@ interface ReadyMessage {
 
 type WorkerEvent = DbUpsert | DbState | DbCost | DbDisconnected | DbEnd | DbMetric | DbHistogram | ReadyMessage;
 
+/** Compile-time exhaustiveness: TS errors if a WorkerEvent["type"] member is missing. */
+const WORKER_EVENT_TYPE_MAP: Record<WorkerEvent["type"], true> = {
+  ready: true,
+  "db:upsert": true,
+  "db:state": true,
+  "db:cost": true,
+  "db:disconnected": true,
+  "db:end": true,
+  "metrics:inc": true,
+  "metrics:observe": true,
+};
+
 /** Explicit set of known worker event types — prevents ambiguous routing with MCP messages. */
-const WORKER_EVENT_TYPES: ReadonlySet<string> = new Set<WorkerEvent["type"]>([
-  "ready",
-  "db:upsert",
-  "db:state",
-  "db:cost",
-  "db:disconnected",
-  "db:end",
-  "metrics:inc",
-  "metrics:observe",
-]);
+export const WORKER_EVENT_TYPES: ReadonlySet<string> = new Set(Object.keys(WORKER_EVENT_TYPE_MAP));
 
 export function isWorkerEvent(data: unknown): data is WorkerEvent {
   return (


### PR DESCRIPTION
## Summary
- Replace `Set<WorkerEvent["type"]>` with a `Record<WorkerEvent["type"], true>` map that TypeScript validates at compile time — missing event types cause a build error
- Derive `WORKER_EVENT_TYPES` Set from the record's keys, export it for testing
- Add exhaustiveness test verifying the Set covers all expected worker event type literals

## Test plan
- [x] New `WORKER_EVENT_TYPES` test verifies Set size and membership against expected list
- [x] All existing `isWorkerEvent` tests continue to pass
- [x] `bun typecheck` passes — compile-time enforcement confirmed
- [x] `bun lint` clean
- [x] Full test suite: 2108 tests pass (1 pre-existing flaky timeout in watcher.spec.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)