### PR TITLE
fix(daemon): resolve hook-based worktree paths in orphan reaper (fixes #541)

### DIFF
--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -44,6 +44,7 @@ interface DbUpsert {
     model?: string;
     cwd?: string;
     worktree?: string;
+    repoRoot?: string;
   };
 }
 

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -148,6 +148,7 @@ async function handlePrompt(
         state: "connecting",
         cwd: args.cwd as string | undefined,
         worktree: args.worktree as string | undefined,
+        repoRoot: args.repoRoot as string | undefined,
       },
     });
 

--- a/packages/daemon/src/codex-server.ts
+++ b/packages/daemon/src/codex-server.ts
@@ -32,6 +32,7 @@ interface DbUpsert {
     model?: string;
     cwd?: string;
     worktree?: string;
+    repoRoot?: string;
   };
 }
 

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -31,6 +31,7 @@ export interface AgentSessionRow {
   model: string | null;
   cwd: string | null;
   worktree: string | null;
+  repoRoot: string | null;
   totalCost: number;
   totalTokens: number;
   spawnedAt: string;
@@ -211,6 +212,11 @@ export class StateDb {
       this.db.exec("ALTER TABLE agent_sessions ADD COLUMN provider TEXT NOT NULL DEFAULT 'claude'");
     } catch {
       /* column already exists (from rename or fresh creation) */
+    }
+    try {
+      this.db.exec("ALTER TABLE agent_sessions ADD COLUMN repo_root TEXT");
+    } catch {
+      /* column already exists */
     }
 
     // -- Spans table (export buffer) --
@@ -783,17 +789,19 @@ export class StateDb {
     model?: string;
     cwd?: string;
     worktree?: string;
+    repoRoot?: string;
   }): void {
     this.db.run(
-      `INSERT INTO agent_sessions (session_id, provider, pid, state, model, cwd, worktree)
-       VALUES (?, ?, ?, ?, ?, ?, ?)
+      `INSERT INTO agent_sessions (session_id, provider, pid, state, model, cwd, worktree, repo_root)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(session_id) DO UPDATE SET
          provider = COALESCE(excluded.provider, agent_sessions.provider),
          pid = COALESCE(excluded.pid, agent_sessions.pid),
          state = COALESCE(excluded.state, agent_sessions.state),
          model = COALESCE(excluded.model, agent_sessions.model),
          cwd = COALESCE(excluded.cwd, agent_sessions.cwd),
-         worktree = COALESCE(excluded.worktree, agent_sessions.worktree)`,
+         worktree = COALESCE(excluded.worktree, agent_sessions.worktree),
+         repo_root = COALESCE(excluded.repo_root, agent_sessions.repo_root)`,
       [
         session.sessionId,
         session.provider ?? "claude",
@@ -802,6 +810,7 @@ export class StateDb {
         session.model ?? null,
         session.cwd ?? null,
         session.worktree ?? null,
+        session.repoRoot ?? null,
       ],
     );
   }
@@ -827,7 +836,7 @@ export class StateDb {
   getSession(sessionId: string): AgentSessionRow | null {
     const row = this.db
       .query<RawSessionRow, [string]>(
-        "SELECT session_id, provider, pid, state, model, cwd, worktree, total_cost, total_tokens, spawned_at, ended_at FROM agent_sessions WHERE session_id = ?",
+        "SELECT session_id, provider, pid, state, model, cwd, worktree, repo_root, total_cost, total_tokens, spawned_at, ended_at FROM agent_sessions WHERE session_id = ?",
       )
       .get(sessionId);
     return row ? toSessionRow(row) : null;
@@ -837,7 +846,7 @@ export class StateDb {
     const where = active === true ? " WHERE ended_at IS NULL" : active === false ? " WHERE ended_at IS NOT NULL" : "";
     return this.db
       .query<RawSessionRow, []>(
-        `SELECT session_id, provider, pid, state, model, cwd, worktree, total_cost, total_tokens, spawned_at, ended_at FROM agent_sessions${where} ORDER BY spawned_at DESC`,
+        `SELECT session_id, provider, pid, state, model, cwd, worktree, repo_root, total_cost, total_tokens, spawned_at, ended_at FROM agent_sessions${where} ORDER BY spawned_at DESC`,
       )
       .all()
       .map(toSessionRow);
@@ -1001,6 +1010,7 @@ interface RawSessionRow {
   model: string | null;
   cwd: string | null;
   worktree: string | null;
+  repo_root: string | null;
   total_cost: number;
   total_tokens: number;
   spawned_at: string;
@@ -1016,6 +1026,7 @@ function toSessionRow(row: RawSessionRow): AgentSessionRow {
     model: row.model,
     cwd: row.cwd,
     worktree: row.worktree,
+    repoRoot: row.repo_root,
     totalCost: row.total_cost,
     totalTokens: row.total_tokens,
     spawnedAt: row.spawned_at,

--- a/packages/daemon/src/index.spec.ts
+++ b/packages/daemon/src/index.spec.ts
@@ -494,6 +494,105 @@ describe("pruneOrphanedWorktrees", () => {
     }
   });
 
+  test("resolves hook-based worktree paths using repoRoot and .mcx-worktree.json", () => {
+    opts = testOptions();
+    const db = new StateDb(opts.DB_PATH);
+    try {
+      // Strip inherited git env vars
+      const cleanEnv = { ...process.env };
+      for (const k of [
+        "GIT_INDEX_FILE",
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_PREFIX",
+        "GIT_AUTHOR_DATE",
+        "GIT_COMMITTER_DATE",
+      ]) {
+        delete cleanEnv[k];
+      }
+      const gitOpts = { stdout: "pipe" as const, stderr: "pipe" as const, env: cleanEnv };
+
+      // Create a repo with a custom worktree base via .mcx-worktree.json
+      const repoDir = join(opts.dir, "repo-hooks");
+      mkdirSync(repoDir, { recursive: true });
+      Bun.spawnSync(["git", "init", repoDir], gitOpts);
+      Bun.spawnSync(["git", "-C", repoDir, "commit", "--allow-empty", "-m", "init"], gitOpts);
+
+      // Configure custom worktree base
+      const customBase = join(opts.dir, "custom-worktrees");
+      mkdirSync(customBase, { recursive: true });
+      writeFileSync(join(repoDir, ".mcx-worktree.json"), JSON.stringify({ worktree: { base: customBase } }));
+
+      // Create a worktree in the custom base
+      const worktreeDir = join(customBase, "hook-wt");
+      Bun.spawnSync(["git", "-C", repoDir, "worktree", "add", worktreeDir, "-b", "hook-branch"], gitOpts);
+
+      // Simulate a hook-based session: cwd = worktreeDir, repoRoot = repoDir
+      db.upsertSession({
+        sessionId: "ended-hook",
+        pid: 99999,
+        model: "sonnet",
+        cwd: worktreeDir,
+        worktree: "hook-wt",
+        repoRoot: repoDir,
+      });
+      db.endSession("ended-hook");
+
+      // Should resolve the path correctly via repoRoot + .mcx-worktree.json
+      pruneOrphanedWorktrees(db);
+
+      // Worktree should be removed
+      expect(existsSync(worktreeDir)).toBe(false);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("falls back to cwd when repoRoot is not set (legacy sessions)", () => {
+    opts = testOptions();
+    const db = new StateDb(opts.DB_PATH);
+    try {
+      const cleanEnv = { ...process.env };
+      for (const k of [
+        "GIT_INDEX_FILE",
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_PREFIX",
+        "GIT_AUTHOR_DATE",
+        "GIT_COMMITTER_DATE",
+      ]) {
+        delete cleanEnv[k];
+      }
+      const gitOpts = { stdout: "pipe" as const, stderr: "pipe" as const, env: cleanEnv };
+
+      const repoDir = join(opts.dir, "repo-legacy");
+      mkdirSync(repoDir, { recursive: true });
+      Bun.spawnSync(["git", "init", repoDir], gitOpts);
+      Bun.spawnSync(["git", "-C", repoDir, "commit", "--allow-empty", "-m", "init"], gitOpts);
+
+      const worktreeDir = join(repoDir, ".claude", "worktrees", "legacy-wt");
+      mkdirSync(join(repoDir, ".claude", "worktrees"), { recursive: true });
+      Bun.spawnSync(["git", "-C", repoDir, "worktree", "add", worktreeDir, "-b", "legacy-branch"], gitOpts);
+
+      // Legacy session: no repoRoot field
+      db.upsertSession({
+        sessionId: "ended-legacy",
+        pid: 99999,
+        model: "sonnet",
+        cwd: repoDir,
+        worktree: "legacy-wt",
+      });
+      db.endSession("ended-legacy");
+
+      pruneOrphanedWorktrees(db);
+
+      // Should still work via cwd fallback
+      expect(existsSync(worktreeDir)).toBe(false);
+    } finally {
+      db.close();
+    }
+  });
+
   test("handles errors gracefully without crashing", () => {
     // Pass a closed DB to trigger an error inside the function
     opts = testOptions();

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -26,6 +26,8 @@ import {
   fixCoreBare,
   generateSpanId,
   options,
+  readWorktreeConfig,
+  resolveWorktreePath,
 } from "@mcp-cli/core";
 import { AliasServer, buildAliasToolCache } from "./alias-server";
 import { ClaudeServer, buildClaudeToolCache } from "./claude-server";
@@ -60,7 +62,11 @@ export function pruneOrphanedWorktrees(db: StateDb, logger: Logger = consoleLogg
       if (!session.worktree || !session.cwd) continue;
       if (activeWorktrees.has(session.worktree)) continue;
 
-      const worktreePath = join(session.cwd, ".claude", "worktrees", session.worktree);
+      // Determine repo root: use persisted repoRoot if available, otherwise fall back to cwd
+      // (pre-hook sessions have cwd == repoRoot; hook-based sessions store repoRoot separately)
+      const repoRoot = session.repoRoot ?? session.cwd;
+      const hookConfig = readWorktreeConfig(repoRoot);
+      const worktreePath = resolveWorktreePath(repoRoot, session.worktree, hookConfig);
       if (!existsSync(worktreePath)) continue;
 
       // Check if clean
@@ -72,20 +78,20 @@ export function pruneOrphanedWorktrees(db: StateDb, logger: Logger = consoleLogg
       const branch = branchResult.exitCode === 0 ? branchResult.stdout.toString().trim() : null;
 
       // Remove worktree
-      const removeResult = Bun.spawnSync(["git", "-C", session.cwd, "worktree", "remove", worktreePath], gitOpts);
+      const removeResult = Bun.spawnSync(["git", "-C", repoRoot, "worktree", "remove", worktreePath], gitOpts);
       if (removeResult.exitCode === 0) {
         const gitExec = (cmd: string[]) => {
           const r = Bun.spawnSync(cmd, gitOpts);
           return { stdout: r.stdout.toString().trim(), exitCode: r.exitCode };
         };
-        if (fixCoreBare(session.cwd, gitExec)) {
+        if (fixCoreBare(repoRoot, gitExec)) {
           logger.warn("[mcpd] Fixed core.bare=true after worktree removal");
         }
         pruned++;
         logger.info(`[mcpd] Pruned orphaned worktree: ${worktreePath}`);
         // Delete merged branch
         if (branch) {
-          const branchDelete = Bun.spawnSync(["git", "-C", session.cwd, "branch", "-d", branch], gitOpts);
+          const branchDelete = Bun.spawnSync(["git", "-C", repoRoot, "branch", "-d", branch], gitOpts);
           if (branchDelete.exitCode === 0) {
             logger.info(`[mcpd] Deleted branch: ${branch} (merged)`);
           }


### PR DESCRIPTION
## Summary
- Add `repo_root` column to `agent_sessions` table and persist `repoRoot` from spawn
- Update orphan reaper to use `repoRoot` (falling back to `cwd`) with `readWorktreeConfig` + `resolveWorktreePath` for correct path resolution
- Keep `DbUpsert` interfaces in claude-server and codex-server in sync with new field

## Test plan
- [x] New test: hook-based worktree with custom `.mcx-worktree.json` base is correctly resolved and pruned
- [x] New test: legacy sessions without `repoRoot` still work via `cwd` fallback
- [x] All existing orphan reaper tests pass (no regression)
- [x] Full suite: 2146 tests pass, 0 failures
- [x] Typecheck + lint + coverage all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)