### PR TITLE
perf(test): speed up watcher.spec.ts from 8.1s to <2s (fixes #555)

### DIFF
--- a/packages/daemon/src/config/watcher.spec.ts
+++ b/packages/daemon/src/config/watcher.spec.ts
@@ -40,9 +40,17 @@ async function waitForCall(fn: ReturnType<typeof mock>, timeoutMs = 8000): Promi
   await waitForCalls(fn, 1, timeoutMs);
 }
 
-/** Default watcher options for tests: fast polling + bound loadConfig */
+/** Debounce used in test watcher options — keep in sync with sleeps below */
+const TEST_DEBOUNCE_MS = 50;
+
+/** Default watcher options for tests: fast polling + fast debounce + bound loadConfig */
 function testWatcherOpts(): ConfigWatcherOptions {
-  return { pollIntervalMs: 200, loadConfig: (cwd: string) => loadConfig(cwd, silentLogger), logger: silentLogger };
+  return {
+    pollIntervalMs: 50,
+    debounceMs: TEST_DEBOUNCE_MS,
+    loadConfig: (cwd: string) => loadConfig(cwd, silentLogger),
+    logger: silentLogger,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -292,8 +300,8 @@ describe("ConfigWatcher integration", () => {
     // Write the same config (no actual change)
     writeJson(opts.USER_SERVERS_PATH, mcpConfig({ alpha: { command: "echo" } }));
 
-    // Wait enough time for debounce + poll + reload
-    await Bun.sleep(800);
+    // Wait enough time for debounce + poll + reload (negative assertion)
+    await Bun.sleep(TEST_DEBOUNCE_MS * 3);
     expect(cb).not.toHaveBeenCalled();
   });
 
@@ -313,15 +321,15 @@ describe("ConfigWatcher integration", () => {
     // Rapid writes — should debounce to a single reload
     for (let i = 0; i < 5; i++) {
       writeJson(opts.USER_SERVERS_PATH, mcpConfig({ alpha: { command: `echo-${i}` } }));
-      await Bun.sleep(50);
+      await Bun.sleep(10);
     }
 
     // Poll until the debounced callback fires
     await waitForCall(cb);
     expect(cb).toHaveBeenCalledTimes(1);
 
-    // Wait a bit more to verify no extra calls arrive
-    await Bun.sleep(500);
+    // Wait a bit more to verify no extra calls arrive (negative assertion)
+    await Bun.sleep(TEST_DEBOUNCE_MS * 3);
     expect(cb).toHaveBeenCalledTimes(1);
 
     // Should have the final config
@@ -415,7 +423,8 @@ describe("ConfigWatcher integration", () => {
     // Modify after stop
     writeJson(opts.USER_SERVERS_PATH, mcpConfig({ alpha: { command: "echo" }, stopped: { command: "ls" } }));
 
-    await Bun.sleep(800);
+    // Negative assertion: callback should not fire after stop
+    await Bun.sleep(TEST_DEBOUNCE_MS * 3);
     expect(cb).not.toHaveBeenCalled();
   });
 
@@ -481,8 +490,7 @@ describe("ConfigWatcher integration", () => {
     expect(cb.mock.calls[0][0].added).toContain("beta");
 
     // Wait for the debounce window to fully close before writing the second change.
-    // The debounce is 300ms; poll until enough time has passed after the first callback.
-    await Bun.sleep(500);
+    await Bun.sleep(TEST_DEBOUNCE_MS * 2);
 
     // Second change (after first has been processed)
     writeJson(
@@ -620,12 +628,12 @@ describe("ConfigWatcher integration", () => {
     // Write a change to trigger scheduleReload
     writeJson(opts.USER_SERVERS_PATH, mcpConfig({ alpha: { command: "echo" }, beta: { command: "cat" } }));
 
-    // Stop immediately before debounce fires (debounce is 300ms)
-    await Bun.sleep(50);
+    // Stop immediately before debounce fires
+    await Bun.sleep(TEST_DEBOUNCE_MS / 2);
     watcher.stop();
 
-    // Wait long enough for debounce to have fired (if not cancelled)
-    await Bun.sleep(800);
+    // Wait long enough for debounce to have fired (if not cancelled) — negative assertion
+    await Bun.sleep(TEST_DEBOUNCE_MS * 3);
     expect(cb).not.toHaveBeenCalled();
   });
 });

--- a/packages/daemon/src/config/watcher.ts
+++ b/packages/daemon/src/config/watcher.ts
@@ -26,6 +26,7 @@ export type ConfigChangeCallback = (event: ConfigChangeEvent) => void;
 
 export interface ConfigWatcherOptions {
   pollIntervalMs?: number;
+  debounceMs?: number;
   loadConfig?: (cwd: string) => Promise<ResolvedConfig>;
   logger?: Logger;
 }
@@ -35,6 +36,7 @@ export class ConfigWatcher {
   private debounceTimer: Timer | null = null;
   private pollTimer: Timer | null = null;
   private pollIntervalMs: number;
+  private debounceMs: number;
   private loadConfigFn: (cwd: string) => Promise<ResolvedConfig>;
   private lastMtimes: Map<string, number> = new Map();
   private currentHash: string;
@@ -55,6 +57,7 @@ export class ConfigWatcher {
     this.callback = callback;
     this.cwd = cwd;
     this.pollIntervalMs = opts?.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.debounceMs = opts?.debounceMs ?? DEBOUNCE_MS;
     this.loadConfigFn = opts?.loadConfig ?? defaultLoadConfig;
     this.logger = opts?.logger ?? consoleLogger;
   }
@@ -210,7 +213,7 @@ export class ConfigWatcher {
       this.debounceTimer = null;
       if (this.stopped) return;
       this.reload();
-    }, DEBOUNCE_MS);
+    }, this.debounceMs);
   }
 
   /** Reload config and fire callback if hash changed. */


### PR DESCRIPTION
## Summary
- Add `debounceMs` option to `ConfigWatcherOptions` (default 300ms unchanged) so tests can use a 50ms debounce
- Reduce test poll interval from 200ms to 50ms
- Replace all fixed 500-800ms sleeps with `TEST_DEBOUNCE_MS * 3` (150ms) for negative assertions, and proportional values for inter-change waits
- Reduce rapid-write inter-sleep from 50ms to 10ms to stay under the test debounce window

## Test plan
- [x] `bun test packages/daemon/src/config/watcher.spec.ts` — 31/31 pass in 1.97s (down from 8.1s)
- [x] Full suite: 2144/2144 pass
- [x] `bun typecheck` clean
- [x] `bun lint` clean
- [x] Coverage thresholds met (watcher.ts at 100% lines/functions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)