### PR TITLE
fix(codex): map fileChange transcript tool name by change kind (fixes #537)

### DIFF
--- a/packages/codex/src/codex-transcript.spec.ts
+++ b/packages/codex/src/codex-transcript.spec.ts
@@ -53,7 +53,7 @@ describe("itemToTranscript", () => {
     });
   });
 
-  test("fileChange → tool_use + tool_result pair", () => {
+  test("fileChange → one tool_use + tool_result pair per change", () => {
     const item: ThreadItem = {
       id: "4",
       type: "fileChange",
@@ -64,21 +64,77 @@ describe("itemToTranscript", () => {
       ],
     };
     const entries = itemToTranscript(item, ts);
-    expect(entries).toHaveLength(2);
+    expect(entries).toHaveLength(4);
     expect(entries[0]).toEqual({
       role: "tool_use",
       tool: "Write",
-      content: "src/foo.ts, src/bar.ts",
-      input: { files: ["src/foo.ts", "src/bar.ts"] },
+      content: "src/foo.ts",
+      input: { file: "src/foo.ts", kind: "modify" },
       timestamp: ts,
     });
     expect(entries[1]).toEqual({
       role: "tool_result",
       tool: "Write",
-      content: "Updated 2 file(s)",
-      diff: "--- a/src/foo.ts\n+++ b/src/foo.ts\n+new file",
+      content: "Updated src/foo.ts",
+      diff: "--- a/src/foo.ts\n+++ b/src/foo.ts",
       timestamp: ts,
     });
+    expect(entries[2]).toEqual({
+      role: "tool_use",
+      tool: "Write",
+      content: "src/bar.ts",
+      input: { file: "src/bar.ts", kind: "add" },
+      timestamp: ts,
+    });
+    expect(entries[3]).toEqual({
+      role: "tool_result",
+      tool: "Write",
+      content: "Updated src/bar.ts",
+      diff: "+new file",
+      timestamp: ts,
+    });
+  });
+
+  test("fileChange with delete → uses Delete tool", () => {
+    const item: ThreadItem = {
+      id: "4b",
+      type: "fileChange",
+      status: "completed",
+      changes: [{ path: "src/old.ts", kind: "delete", diff: "-removed" }],
+    };
+    const entries = itemToTranscript(item, ts);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toEqual({
+      role: "tool_use",
+      tool: "Delete",
+      content: "src/old.ts",
+      input: { file: "src/old.ts", kind: "delete" },
+      timestamp: ts,
+    });
+    expect(entries[1]).toEqual({
+      role: "tool_result",
+      tool: "Delete",
+      content: "Deleted src/old.ts",
+      diff: "-removed",
+      timestamp: ts,
+    });
+  });
+
+  test("fileChange with mixed kinds → correct tool per change", () => {
+    const item: ThreadItem = {
+      id: "4c",
+      type: "fileChange",
+      status: "completed",
+      changes: [
+        { path: "src/new.ts", kind: "add", diff: "+added" },
+        { path: "src/gone.ts", kind: "delete", diff: "-removed" },
+      ],
+    };
+    const entries = itemToTranscript(item, ts);
+    expect(entries).toHaveLength(4);
+    expect(entries[0]?.tool).toBe("Write");
+    expect(entries[2]?.tool).toBe("Delete");
+    expect(entries[3]?.content).toBe("Deleted src/gone.ts");
   });
 
   test("reasoning → empty (not transcribed)", () => {

--- a/packages/codex/src/codex-transcript.ts
+++ b/packages/codex/src/codex-transcript.ts
@@ -72,24 +72,34 @@ export function itemToTranscript(item: ThreadItem, timestamp?: number): Transcri
       ];
 
     case "fileChange": {
-      const files = item.changes?.map((c) => c.path) ?? [];
-      const diffContent = item.changes?.map((c) => c.diff).join("\n") ?? "";
-      return [
-        {
-          role: "tool_use",
-          tool: "Write",
-          content: files.join(", "),
-          input: { files },
-          timestamp: ts,
-        },
-        {
-          role: "tool_result",
-          tool: "Write",
-          content: `Updated ${files.length} file(s)`,
-          diff: diffContent,
-          timestamp: ts,
-        },
-      ];
+      const changes = item.changes ?? [];
+      if (changes.length === 0) {
+        return [
+          { role: "tool_use", tool: "Write", content: "", input: { files: [] }, timestamp: ts },
+          { role: "tool_result", tool: "Write", content: "Updated 0 file(s)", timestamp: ts },
+        ];
+      }
+      const entries: TranscriptEntry[] = [];
+      for (const change of changes) {
+        const tool = change.kind === "delete" ? "Delete" : "Write";
+        entries.push(
+          {
+            role: "tool_use",
+            tool,
+            content: change.path,
+            input: { file: change.path, kind: change.kind },
+            timestamp: ts,
+          },
+          {
+            role: "tool_result",
+            tool,
+            content: change.kind === "delete" ? `Deleted ${change.path}` : `Updated ${change.path}`,
+            diff: change.diff,
+            timestamp: ts,
+          },
+        );
+      }
+      return entries;
     }
 
     // Reasoning, reviewMode entries: not transcribed


### PR DESCRIPTION
## Summary
- Emit one tool_use + tool_result pair **per change** instead of grouping all changes under a single "Write" entry
- Map tool name by change kind: `add`/`modify` → "Write", `delete` → "Delete"
- Each entry now includes per-file `kind` in input and individual diff/content

## Test plan
- [x] Existing fileChange test updated for new per-change structure
- [x] New test: delete changes use "Delete" tool name
- [x] New test: mixed add + delete changes map to correct tools
- [x] Empty changes case still produces fallback entry
- [x] All 2209 tests pass, typecheck + lint clean, coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)