### PR TITLE
feat(codex): add process-level watchdog timeout for silent processes (fixes #538)

### DIFF
--- a/packages/codex/src/codex-session.spec.ts
+++ b/packages/codex/src/codex-session.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { join } from "node:path";
 import type { AgentSessionEvent } from "@mcp-cli/core";
-import { CodexSession } from "./codex-session";
+import { CodexSession, WATCHDOG_TIMEOUT_MS } from "./codex-session";
 
 const FAKE_SERVER = join(import.meta.dirname, "fake-codex-server.ts");
 const TEST_CWD = process.cwd();
@@ -356,5 +356,85 @@ describe("CodexSession (with fake codex server)", () => {
 
     // currentTurn is null after turn/completed
     await expect(session.interrupt()).resolves.toBeUndefined();
+  });
+});
+
+// ── Watchdog tests ─────────────────────────────────────────────────────────
+
+describe("CodexSession watchdog", () => {
+  test("WATCHDOG_TIMEOUT_MS is 5 minutes", () => {
+    expect(WATCHDOG_TIMEOUT_MS).toBe(5 * 60 * 1000);
+  });
+
+  test("watchdog fires when process goes silent", async () => {
+    const { session, events } = makeSession({
+      command: fakeCommand("silent"),
+      watchdogTimeoutMs: 200, // 200ms for testing
+    });
+
+    const resultPromise = session.waitForResult(5000);
+    await session.start();
+    const result = await resultPromise;
+
+    // Should have fired watchdog → session:error + session:ended
+    expect(result.type).toBe("session:error");
+    if (result.type === "session:error") {
+      expect(result.errors[0]).toMatch(/watchdog timeout/i);
+    }
+    expect(session.currentState).toBe("ended");
+    expect(events.some((e) => e.type === "session:ended")).toBe(true);
+  });
+
+  test("watchdog does not fire when events arrive in time", async () => {
+    const { session, events } = makeSession({
+      command: fakeCommand("simple"),
+      watchdogTimeoutMs: 5000, // generous — turn completes in ~30ms
+    });
+
+    const resultPromise = session.waitForResult(10000);
+    await session.start();
+    const result = await resultPromise;
+
+    expect(result.type).toBe("session:result");
+    // No watchdog error
+    expect(events.some((e) => e.type === "session:error")).toBe(false);
+  });
+
+  test("watchdog disabled when watchdogTimeoutMs is 0", async () => {
+    const { session, events } = makeSession({
+      command: fakeCommand("silent"),
+      watchdogTimeoutMs: 0,
+    });
+
+    await session.start();
+
+    // Wait a bit — watchdog should NOT fire
+    await Bun.sleep(100);
+
+    expect(session.currentState).not.toBe("ended");
+    expect(events.some((e) => e.type === "session:error")).toBe(false);
+
+    // Cleanup
+    session.terminate();
+  });
+
+  test("terminate() clears watchdog without firing", async () => {
+    const { session, events } = makeSession({
+      command: fakeCommand("silent"),
+      watchdogTimeoutMs: 200,
+    });
+
+    await session.start();
+    // Terminate before watchdog fires
+    session.terminate();
+
+    // Wait past the watchdog timeout
+    await Bun.sleep(300);
+
+    // Should only have the terminate-caused events, no watchdog error
+    const errorEvents = events.filter(
+      (e): e is Extract<AgentSessionEvent, { type: "session:error" }> => e.type === "session:error",
+    );
+    expect(errorEvents.some((e) => e.errors[0]?.includes("watchdog"))).toBe(false);
   });
 });

--- a/packages/codex/src/codex-session.ts
+++ b/packages/codex/src/codex-session.ts
@@ -21,6 +21,9 @@ import { CodexRpcClient } from "./codex-rpc";
 import { type TranscriptEntry, itemToTranscript } from "./codex-transcript";
 import type { InitializeResult, Thread, ThreadItem, Turn } from "./schemas";
 
+/** Default watchdog timeout: 5 minutes with no events kills the process. */
+export const WATCHDOG_TIMEOUT_MS = 5 * 60 * 1000;
+
 export interface CodexSessionConfig {
   /** Working directory for the codex process. */
   cwd: string;
@@ -48,6 +51,8 @@ export interface CodexSessionConfig {
   command?: string[];
   /** Extra environment variables. */
   env?: Record<string, string>;
+  /** Watchdog timeout in ms. Defaults to WATCHDOG_TIMEOUT_MS (5 min). Set 0 to disable. */
+  watchdogTimeoutMs?: number;
 }
 
 export type SessionEventHandler = (event: AgentSessionEvent) => void;
@@ -66,6 +71,8 @@ export class CodexSession {
   private readonly transcript: TranscriptEntry[] = [];
   private model: string | null = null;
   private readonly eventHandler: SessionEventHandler;
+  private readonly watchdogTimeoutMs: number;
+  private watchdogTimer: ReturnType<typeof setTimeout> | null = null;
 
   /** Resolvers for waitForResult/waitForEvent. */
   private resultWaiters: Array<(event: AgentSessionEvent) => void> = [];
@@ -77,6 +84,7 @@ export class CodexSession {
     this.eventHandler = onEvent;
     this.eventState = createEventMapState();
     this.rules = buildRules(config.allowedTools, config.disallowedTools);
+    this.watchdogTimeoutMs = config.watchdogTimeoutMs ?? WATCHDOG_TIMEOUT_MS;
   }
 
   /** Start the session: spawn process, handshake, start thread and first turn. */
@@ -191,6 +199,7 @@ export class CodexSession {
 
   /** Terminate the session. */
   terminate(): void {
+    this.clearWatchdog();
     this.proc?.kill();
     this.rpc?.rejectAll("Session terminated");
     this.setState("ended");
@@ -283,6 +292,7 @@ export class CodexSession {
     })) as Turn;
 
     this.currentTurn = turnResult;
+    this.resetWatchdog();
   }
 
   private handleMessage(msg: Record<string, unknown>): void {
@@ -293,6 +303,7 @@ export class CodexSession {
   private handleNotification(method: string, params: Record<string, unknown>): void {
     // Skip legacy duplicate events
     if (isLegacyEvent(method)) return;
+    this.resetWatchdog();
 
     // Track item metadata for transcript
     if (method === "item/completed") {
@@ -308,9 +319,11 @@ export class CodexSession {
     for (const event of events) {
       // Update state based on event type
       if (event.type === "session:result") {
+        this.clearWatchdog();
         this.setState("idle");
         this.currentTurn = null;
       } else if (event.type === "session:error") {
+        this.clearWatchdog();
         this.setState("idle");
         this.currentTurn = null;
       }
@@ -319,6 +332,7 @@ export class CodexSession {
   }
 
   private handleServerRequest(id: number | string, method: string, params: Record<string, unknown>): void {
+    this.resetWatchdog();
     // Map approval requests to permission requests
     const permission = mapApprovalToPermission(method, params, this.eventState);
     if (!permission) {
@@ -357,6 +371,7 @@ export class CodexSession {
   }
 
   private handleExit(code: number | null, _signal: string | null): void {
+    this.clearWatchdog();
     this.rpc?.rejectAll("Process exited");
 
     if (this.state !== "ended") {
@@ -382,6 +397,33 @@ export class CodexSession {
     const endedEvent: AgentSessionEvent = { type: "session:ended" };
     for (const w of rw) w(endedEvent);
     for (const w of ew) w(endedEvent);
+  }
+
+  private resetWatchdog(): void {
+    if (this.watchdogTimeoutMs <= 0) return;
+    this.clearWatchdog();
+    this.watchdogTimer = setTimeout(() => {
+      this.watchdogTimer = null;
+      this.proc?.kill();
+      this.rpc?.rejectAll("Watchdog timeout");
+      if (this.state !== "ended") {
+        this.setState("ended");
+        this.emit({
+          type: "session:error",
+          errors: [`Codex process watchdog timeout — no events for ${Math.round(this.watchdogTimeoutMs / 1000)}s`],
+          cost: null,
+        });
+        this.emit({ type: "session:ended" });
+      }
+      this.rejectAllWaiters("Watchdog timeout");
+    }, this.watchdogTimeoutMs);
+  }
+
+  private clearWatchdog(): void {
+    if (this.watchdogTimer !== null) {
+      clearTimeout(this.watchdogTimer);
+      this.watchdogTimer = null;
+    }
   }
 
   private setState(newState: AgentSessionState): void {

--- a/packages/codex/src/fake-codex-server.ts
+++ b/packages/codex/src/fake-codex-server.ts
@@ -6,6 +6,7 @@
  *   simple        (default) — handshake + turn/completed, clean exit
  *   approval      — handshake + turn + commandExecution approval request + turn/completed
  *   crash-after-turn — handshake + turn/completed + exit code 2
+ *   silent        — handshake + turn/start response, then no events (for watchdog testing)
  */
 import { createInterface } from "node:readline";
 
@@ -70,6 +71,8 @@ function scheduleEvents(): void {
       sendTurnCompleted();
       setTimeout(() => process.exit(2), 50);
     }, 30);
+  } else if (mode === "silent") {
+    // No events after turn/start — process stays alive but silent (for watchdog testing)
   } else {
     // simple
     setTimeout(() => sendTurnCompleted(), 30);


### PR DESCRIPTION
## Summary
- Adds a watchdog timer to `CodexSession` that resets on every notification and server request received from the Codex process
- If no event arrives within 5 minutes (default, configurable via `watchdogTimeoutMs`), kills the process and emits `session:error` + `session:ended`
- Watchdog is active only during turns (started on `startTurn`, cleared on turn completion/terminate/exit)

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes  
- [x] All 2212 tests pass (0 failures)
- [x] Coverage thresholds met
- [x] New tests: watchdog fires on silent process, does not fire on normal turn, disabled when timeout=0, terminate clears watchdog

🤖 Generated with [Claude Code](https://claude.com/claude-code)