### PR TITLE
fix(daemon): skip virtual servers during restart-all to prevent permanent failure (fixes #595)

### DIFF
--- a/packages/daemon/src/server-pool.spec.ts
+++ b/packages/daemon/src/server-pool.spec.ts
@@ -1128,6 +1128,63 @@ describe("ServerPool.restart", () => {
     expect(connectCalls).toHaveLength(2);
   });
 
+  test("restart without name skips virtual servers", async () => {
+    const connectCalls: string[] = [];
+    const connectFn: ConnectFn = mock((name: string) => {
+      connectCalls.push(name);
+      return Promise.resolve({
+        client: makeMockClient() as unknown as Client,
+        transport: makeMockTransport() as unknown as Transport,
+      });
+    });
+    const pool = new ServerPool(makeConfig({ a: { command: "echo" } }), undefined, connectFn, silentLogger);
+
+    // Connect server "a" via config
+    await pool.listTools("a");
+
+    // Register a virtual server
+    pool.registerVirtualServer(
+      "_virtual",
+      makeMockClient() as unknown as Client,
+      makeMockTransport() as unknown as Transport,
+    );
+
+    connectCalls.length = 0;
+
+    await pool.restart();
+
+    // Only "a" should be restarted, not the virtual server
+    expect(connectCalls).toContain("a");
+    expect(connectCalls).not.toContain("_virtual");
+    expect(connectCalls).toHaveLength(1);
+
+    // Virtual server should still be listed as connected
+    const servers = pool.listServers();
+    const virtualServer = servers.find((s) => s.name === "_virtual");
+    expect(virtualServer?.state).toBe("connected");
+  });
+
+  test("ensureConnected on disconnected virtual server throws clear error", async () => {
+    const connectFn: ConnectFn = mock(() => {
+      return Promise.resolve({
+        client: makeMockClient() as unknown as Client,
+        transport: makeMockTransport() as unknown as Transport,
+      });
+    });
+    const pool = new ServerPool(makeConfig({}), undefined, connectFn, silentLogger);
+
+    // Register and then disconnect a virtual server
+    pool.registerVirtualServer(
+      "_test",
+      makeMockClient() as unknown as Client,
+      makeMockTransport() as unknown as Transport,
+    );
+    await pool.disconnect("_test");
+
+    // Attempting to use the disconnected virtual server should throw
+    await expect(pool.callTool("_test", "some-tool", {})).rejects.toThrow(/Virtual server "_test" failed to start/);
+  });
+
   test("restart logs errors for failed servers but does not throw", async () => {
     let firstConnect = true;
     const connectFn: ConnectFn = mock((name: string) => {

--- a/packages/daemon/src/server-pool.ts
+++ b/packages/daemon/src/server-pool.ts
@@ -238,9 +238,11 @@ export class ServerPool {
     const conn = this.connections.get(name);
     if (!conn) throw new Error(`Server "${name}" not found`);
 
-    // Failed virtual servers have no recoverable config — surface the startup error
-    if (conn.virtual && conn.state === "error" && !conn.client) {
-      throw new Error(`Virtual server "${name}" failed to start: ${conn.lastError ?? "unknown error"}`);
+    // Virtual servers cannot be reconnected via config — they must be
+    // re-registered by the daemon code that manages them (e.g., ClaudeServer, AliasServer).
+    if (conn.virtual && !conn.client) {
+      const detail = conn.lastError ?? "server was disconnected and cannot be auto-reconnected";
+      throw new Error(`Virtual server "${name}" failed to start: ${detail}`);
     }
 
     if (conn.state === "connected" && conn.client) {
@@ -568,8 +570,10 @@ export class ServerPool {
       await this.disconnect(name);
       await this.ensureConnected(name);
     } else {
-      // Restart all connected servers in parallel
-      const connected = [...this.connections.entries()].filter(([, c]) => c.state === "connected");
+      // Restart all connected non-virtual servers in parallel.
+      // Virtual servers cannot be reconnected via config — they must be
+      // re-registered by the daemon code that manages them.
+      const connected = [...this.connections.entries()].filter(([, c]) => c.state === "connected" && !c.virtual);
       const results = await Promise.allSettled(
         connected.map(async ([serverName]) => {
           await this.disconnect(serverName);


### PR DESCRIPTION
## Summary
- `pool.restart()` without a server name now filters out virtual servers (`_aliases`, `_claude`, `_codex`) since they cannot be reconnected via config — they must be re-registered by their managing daemon code
- `ensureConnected()` now guards against all disconnected virtual servers (not just `error` state), preventing attempts to spawn `__virtual__` as a stdio command
- Root cause: `mcx restart` (no args) → `pool.restart()` → disconnect + reconnect virtual servers → ENOENT on `command: "__virtual__"` → permanent failure requiring full daemon restart

## Test plan
- [x] New test: restart-all skips virtual servers, only restarts config-based servers
- [x] New test: disconnected virtual server throws clear error on `callTool`
- [x] Existing restart tests still pass (114 tests in server-pool.spec.ts)
- [x] Full suite: 2229 tests pass, coverage thresholds met
- [x] `bun typecheck` clean
- [x] `bun lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)