### PR TITLE
perf(daemon): cap ended session iteration in orphan reaper to 7-day window (fixes #574)

### DIFF
--- a/packages/daemon/src/index.spec.ts
+++ b/packages/daemon/src/index.spec.ts
@@ -660,6 +660,42 @@ describe("pruneOrphanedWorktrees", () => {
     }
   });
 
+  test("skips sessions ended more than 7 days ago", () => {
+    opts = testOptions();
+    const db = new StateDb(opts.DB_PATH);
+    try {
+      db.upsertSession({
+        sessionId: "old-ended",
+        pid: 12345,
+        model: "sonnet",
+        cwd: "/tmp/test",
+        worktree: "old-wt",
+      });
+      db.endSession("old-ended");
+      // Backdate ended_at to 10 days ago via raw SQL
+      const { Database } = require("bun:sqlite");
+      const rawDb = new Database(opts.DB_PATH);
+      rawDb.run("UPDATE agent_sessions SET ended_at = datetime('now', '-10 days') WHERE session_id = ?", ["old-ended"]);
+      rawDb.close();
+
+      const pathsChecked: string[] = [];
+      pruneOrphanedWorktrees(
+        db,
+        silentLogger,
+        mockGitOps({
+          pathExists: (p: string) => {
+            pathsChecked.push(p);
+            return true;
+          },
+        }),
+      );
+      // Old session should be skipped entirely — no path checks
+      expect(pathsChecked).toHaveLength(0);
+    } finally {
+      db.close();
+    }
+  });
+
   test("handles errors gracefully without crashing", () => {
     opts = testOptions();
     const db = new StateDb(opts.DB_PATH);

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -84,7 +84,10 @@ export function pruneOrphanedWorktrees(
       activeSessions.filter((s) => s.worktree).map((s) => `${s.repoRoot ?? s.cwd}:${s.worktree}`),
     );
 
-    const endedSessions = db.listSessions(false);
+    const RETENTION_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+    const endedSessions = db
+      .listSessions(false)
+      .filter((s) => s.endedAt && Date.now() - new Date(s.endedAt).getTime() < RETENTION_MS);
     let pruned = 0;
 
     for (const session of endedSessions) {


### PR DESCRIPTION
## Summary
- Filter `pruneOrphanedWorktrees` to only process sessions ended within the last 7 days, preventing unbounded iteration over the full session history
- Avoids `existsSync` + git subprocess spawns for thousands of stale sessions on daemon startup

## Test plan
- [x] Added test verifying sessions ended >7 days ago are skipped (no path checks performed)
- [x] All 2228 existing tests pass
- [x] Coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)