### PR TITLE
feat(command): emit stderr note when repo-scoped ls/wait filters out sessions (fixes #592)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -1038,6 +1038,52 @@ describe("mcx claude ls", () => {
       console.log = origLog;
     }
   });
+
+  test("emits stderr note when repo filtering hides all sessions", async () => {
+    const sessions = [
+      { ...SESSION_LIST[0], repoRoot: "/repo/b" },
+      { ...SESSION_LIST[1], repoRoot: "/repo/b" },
+    ];
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(sessions)),
+      getGitRoot: mock(() => "/repo/a"),
+    });
+
+    const errSpy = mock(() => {});
+    const origErr = console.error;
+    const origLog = console.log;
+    console.error = errSpy;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["ls"], deps);
+      expect(errSpy.mock.calls.length).toBe(1);
+      expect((errSpy.mock.calls[0] as string[])[0]).toBe("(2 sessions in other repos — use --all to see them)");
+    } finally {
+      console.error = origErr;
+      console.log = origLog;
+    }
+  });
+
+  test("emits generic message when no sessions exist and none filtered", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult([])),
+      getGitRoot: mock(() => "/repo/a"),
+    });
+
+    const errSpy = mock(() => {});
+    const origErr = console.error;
+    const origLog = console.log;
+    console.error = errSpy;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["ls"], deps);
+      expect(errSpy.mock.calls.length).toBe(1);
+      expect((errSpy.mock.calls[0] as string[])[0]).toBe("No active sessions.");
+    } finally {
+      console.error = origErr;
+      console.log = origLog;
+    }
+  });
 });
 
 // ── formatSessionShort ──
@@ -1875,6 +1921,73 @@ describe("mcx claude wait", () => {
       expect(line).toContain("abc12345");
     } finally {
       console.log = origLog;
+    }
+  });
+
+  test("--short emits stderr note when timeout fallback filters all sessions", async () => {
+    const sessions = [
+      { ...SESSION_LIST[0], repoRoot: "/repo/b" },
+      { ...SESSION_LIST[1], repoRoot: "/repo/b" },
+    ];
+    const callTool = mock(async () => toolResult(sessions));
+    const deps = makeDeps({
+      callTool,
+      getGitRoot: mock(() => "/repo/a"),
+    });
+
+    const logSpy = mock(() => {});
+    const errSpy = mock(() => {});
+    const origLog = console.log;
+    const origErr = console.error;
+    console.log = logSpy;
+    console.error = errSpy;
+    try {
+      await cmdClaude(["wait", "--short", "--timeout", "1000"], deps);
+      // No sessions printed to stdout
+      expect(logSpy.mock.calls.length).toBe(0);
+      // Stderr note about hidden sessions
+      expect(errSpy.mock.calls.length).toBe(1);
+      expect((errSpy.mock.calls[0] as string[])[0]).toBe("(2 sessions in other repos — use --all to see them)");
+    } finally {
+      console.log = origLog;
+      console.error = origErr;
+    }
+  });
+
+  test("--short emits stderr note when cursor-based events filter to empty", async () => {
+    const waitResult = {
+      seq: 5,
+      events: [
+        {
+          event: "session:result",
+          session: { sessionId: "abc12345", repoRoot: "/repo/b", cost: 0.05, numTurns: 2 },
+        },
+        {
+          event: "session:result",
+          session: { sessionId: "def67890", repoRoot: "/repo/b", cost: 0.02, numTurns: 1 },
+        },
+      ],
+    };
+    const callTool = mock(async () => toolResult(waitResult));
+    const deps = makeDeps({
+      callTool,
+      getGitRoot: mock(() => "/repo/a"),
+    });
+
+    const logSpy = mock(() => {});
+    const errSpy = mock(() => {});
+    const origLog = console.log;
+    const origErr = console.error;
+    console.log = logSpy;
+    console.error = errSpy;
+    try {
+      await cmdClaude(["wait", "--short", "--after", "0"], deps);
+      expect(logSpy.mock.calls.length).toBe(0);
+      expect(errSpy.mock.calls.length).toBe(1);
+      expect((errSpy.mock.calls[0] as string[])[0]).toBe("(2 events in other repos — use --all to see them)");
+    } finally {
+      console.log = origLog;
+      console.error = origErr;
     }
   });
 });

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -765,6 +765,7 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
   }
 
   // Scope to current repo unless --all
+  const totalBeforeFilter = sessions.length;
   if (!showAll) {
     const gitRoot = d.getGitRoot();
     if (gitRoot) {
@@ -773,7 +774,12 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
   }
 
   if (sessions.length === 0) {
-    console.error("No active sessions.");
+    const hidden = totalBeforeFilter - sessions.length;
+    if (hidden > 0) {
+      console.error(`(${hidden} session${hidden === 1 ? "" : "s"} in other repos — use --all to see them)`);
+    } else {
+      console.error("No active sessions.");
+    }
     return;
   }
 
@@ -1200,15 +1206,25 @@ async function claudeWait(args: string[], d: ClaudeDeps): Promise<void> {
           // Timeout fallback: session list
           const filtered = data.filter((s: Record<string, unknown>) => !s.repoRoot || s.repoRoot === repoFilter);
           console.log(JSON.stringify(filtered, null, 2));
+          if (filtered.length === 0 && data.length > 0) {
+            const n = data.length;
+            console.error(`(${n} session${n === 1 ? "" : "s"} in other repos — use --all to see them)`);
+          }
           return;
         }
         if (data && typeof data === "object" && "events" in data && Array.isArray(data.events)) {
           // Cursor-based: filter events by session's repoRoot
+          const totalEvents = data.events.length;
           data.events = data.events.filter((e: Record<string, unknown>) => {
             const repo = e.session && (e.session as Record<string, unknown>).repoRoot;
             return !repo || repo === repoFilter;
           });
           console.log(JSON.stringify(data, null, 2));
+          if (data.events.length === 0 && totalEvents > 0) {
+            console.error(
+              `(${totalEvents} event${totalEvents === 1 ? "" : "s"} in other repos — use --all to see them)`,
+            );
+          }
           return;
         }
         // Single event (legacy): check session snapshot
@@ -1217,6 +1233,7 @@ async function claudeWait(args: string[], d: ClaudeDeps): Promise<void> {
           if (sessionRepo && sessionRepo !== repoFilter) {
             // Event is for a different repo — treat as empty
             console.log("[]");
+            console.error("(1 event in other repos — use --all to see them)");
             return;
           }
         }
@@ -1248,11 +1265,16 @@ async function claudeWait(args: string[], d: ClaudeDeps): Promise<void> {
       numTurns?: number;
       repoRoot?: string | null;
     }>;
+    const totalBeforeFilter = sessions.length;
     if (repoFilter) {
       sessions = sessions.filter((s) => !s.repoRoot || s.repoRoot === repoFilter);
     }
     for (const s of sessions) {
       console.log(formatSessionShort(s));
+    }
+    if (sessions.length === 0 && totalBeforeFilter > 0 && repoFilter) {
+      const n = totalBeforeFilter;
+      console.error(`(${n} session${n === 1 ? "" : "s"} in other repos — use --all to see them)`);
     }
     return;
   }
@@ -1261,6 +1283,7 @@ async function claudeWait(args: string[], d: ClaudeDeps): Promise<void> {
   if (data && typeof data === "object" && "events" in data) {
     const waitResult = data as { seq: number; events: Array<Record<string, unknown>> };
     let events = waitResult.events;
+    const totalEventsBeforeFilter = events.length;
     if (repoFilter) {
       events = events.filter((e) => {
         const repo = e.session && (e.session as Record<string, unknown>).repoRoot;
@@ -1275,6 +1298,10 @@ async function claudeWait(args: string[], d: ClaudeDeps): Promise<void> {
       const turns = session?.numTurns !== undefined ? String(session.numTurns) : "—";
       const preview = (e.result as string) ? (e.result as string).slice(0, 100) : "";
       console.log(`${id} ${event} ${cost} ${turns}${preview ? ` ${preview}` : ""}`);
+    }
+    if (events.length === 0 && totalEventsBeforeFilter > 0 && repoFilter) {
+      const n = totalEventsBeforeFilter;
+      console.error(`(${n} event${n === 1 ? "" : "s"} in other repos — use --all to see them)`);
     }
     return;
   }


### PR DESCRIPTION
## Summary
- When `mcx claude ls` repo filtering hides all sessions, emit `(N sessions in other repos — use --all to see them)` to stderr instead of the generic "No active sessions."
- When `mcx claude wait --short` timeout fallback or cursor-based events filter to empty, emit a similar stderr note about hidden sessions/events
- When `mcx claude wait` (non-short JSON mode) filters to empty arrays, also emit the stderr note
- Covers all three wait result shapes: array (timeout fallback), cursor-based events, and single legacy event

## Test plan
- [x] `ls` emits stderr note when all sessions belong to other repos (2 sessions hidden)
- [x] `ls` emits "No active sessions." when genuinely no sessions exist
- [x] `wait --short` timeout fallback emits stderr note when all sessions filtered
- [x] `wait --short` cursor-based events emit stderr note when all events filtered
- [x] All 209 existing tests pass, typecheck clean, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)