### PR TITLE
feat(command): add dump rotation and size cap (fixes #510)

### DIFF
--- a/packages/command/src/commands/dump.spec.ts
+++ b/packages/command/src/commands/dump.spec.ts
@@ -1,9 +1,17 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { DaemonStatus, MetricsSnapshot } from "@mcp-cli/core";
-import { type DumpDeps, type GatherError, cmdDump, isGatherError } from "./dump";
+import {
+  type DumpDeps,
+  type GatherError,
+  MAX_DUMP_FILES,
+  cmdDump,
+  isGatherError,
+  rotateDumps,
+  truncateDump,
+} from "./dump";
 
 const fakeDaemonStatus: DaemonStatus = {
   pid: 12345,
@@ -304,6 +312,54 @@ describe("cmdDump", () => {
     expect(parsed.sessions[2].transcript).toEqual(["line1", "line2"]);
   });
 
+  test("rotates old dump files keeping at most MAX_DUMP_FILES", async () => {
+    mkdirSync(tempDir, { recursive: true });
+    // Create MAX_DUMP_FILES + 5 existing dumps
+    const fileNames: string[] = [];
+    for (let i = 0; i < MAX_DUMP_FILES + 5; i++) {
+      const name = `dump-2026-01-${String(i + 1).padStart(2, "0")}_00-00-00.json`;
+      writeFileSync(join(tempDir, name), "{}");
+      fileNames.push(name);
+    }
+
+    rotateDumps(tempDir);
+
+    const remaining = readdirSync(tempDir)
+      .filter((f) => f.startsWith("dump-") && f.endsWith(".json"))
+      .sort();
+    expect(remaining).toHaveLength(MAX_DUMP_FILES);
+    // Oldest 5 should be gone
+    for (let i = 0; i < 5; i++) {
+      expect(remaining).not.toContain(fileNames[i]);
+    }
+    // Newest should remain
+    expect(remaining).toContain(fileNames[MAX_DUMP_FILES + 4]);
+  });
+
+  test("rotateDumps is no-op when under limit", async () => {
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(join(tempDir, "dump-2026-01-01_00-00-00.json"), "{}");
+
+    rotateDumps(tempDir);
+
+    const remaining = readdirSync(tempDir);
+    expect(remaining).toHaveLength(1);
+  });
+
+  test("rotateDumps ignores non-dump files", async () => {
+    mkdirSync(tempDir, { recursive: true });
+    writeFileSync(join(tempDir, "notes.txt"), "keep me");
+    for (let i = 0; i < MAX_DUMP_FILES + 2; i++) {
+      writeFileSync(join(tempDir, `dump-2026-01-${String(i + 1).padStart(2, "0")}_00-00-00.json`), "{}");
+    }
+
+    rotateDumps(tempDir);
+
+    expect(existsSync(join(tempDir, "notes.txt"))).toBe(true);
+    const dumps = readdirSync(tempDir).filter((f) => f.startsWith("dump-"));
+    expect(dumps).toHaveLength(MAX_DUMP_FILES);
+  });
+
   test("gathers worktree list", async () => {
     const deps = makeDeps({
       dumpsDir: tempDir,
@@ -342,5 +398,49 @@ describe("cmdDump", () => {
     expect(parsed.worktrees).toHaveLength(2);
     expect(parsed.worktrees[0]).toEqual({ path: "/Users/test/repo", branch: "main" });
     expect(parsed.worktrees[1]).toEqual({ path: "/Users/test/repo/.claude/worktrees/test-wt", branch: "feat/test" });
+  });
+});
+
+describe("truncateDump", () => {
+  test("no-op when dump is under size limit", () => {
+    const dump: Record<string, unknown> = { timestamp: "2026-01-01", data: "small" };
+    truncateDump(dump);
+    expect(dump.truncated).toBeUndefined();
+  });
+
+  test("strips transcripts first, then metrics, then logs", () => {
+    // Build a dump that exceeds MAX_DUMP_BYTES via transcripts
+    const bigTranscript = Array.from({ length: 100_000 }, (_, i) => `line ${i} ${"x".repeat(500)}`);
+    const dump: Record<string, unknown> = {
+      timestamp: "2026-01-01",
+      sessions: [
+        { sessionId: "s1", transcript: bigTranscript },
+        { sessionId: "s2", transcript: bigTranscript },
+      ],
+      metrics: { counters: Array.from({ length: 1000 }, () => ({ name: "c", value: 1 })) },
+      daemonLog: Array.from({ length: 1000 }, () => ({ line: "x".repeat(100), timestamp: 0 })),
+    };
+
+    truncateDump(dump);
+
+    expect(dump.truncated).toBe(true);
+    // Transcripts should be replaced
+    const sessions = dump.sessions as Array<{ transcript: string[] }>;
+    expect(sessions[0].transcript).toEqual(["(truncated — dump exceeded size limit)"]);
+    expect(sessions[1].transcript).toEqual(["(truncated — dump exceeded size limit)"]);
+  });
+
+  test("sets truncated flag in output JSON", () => {
+    const bigData = "x".repeat(60 * 1024 * 1024);
+    const dump: Record<string, unknown> = {
+      timestamp: "2026-01-01",
+      sessions: [{ sessionId: "s1", transcript: [bigData] }],
+      metrics: {},
+      daemonLog: [],
+    };
+
+    truncateDump(dump);
+
+    expect(dump.truncated).toBe(true);
   });
 });

--- a/packages/command/src/commands/dump.ts
+++ b/packages/command/src/commands/dump.ts
@@ -10,7 +10,7 @@
  *   mcx dump --include-transcripts   Include last 50 lines of each session log
  */
 
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type {
   DaemonStatus,
@@ -26,6 +26,12 @@ import { printError as defaultPrintError } from "../output";
 
 /** Timeout for individual session transcript fetches (independent of ping timeout). */
 const TRANSCRIPT_TIMEOUT_MS = 5_000;
+
+/** Maximum number of dump files to keep in the dumps directory. */
+export const MAX_DUMP_FILES = 20;
+
+/** Maximum size in bytes for a single dump file before truncation kicks in. */
+export const MAX_DUMP_BYTES = 50 * 1024 * 1024; // 50 MB
 
 /** Structured error returned when a gather function fails, instead of opaque null. */
 export interface GatherError {
@@ -117,6 +123,9 @@ export async function cmdDump(args: string[], deps?: Partial<DumpDeps>): Promise
       : null,
   };
 
+  // Apply size cap with progressive truncation
+  truncateDump(dump);
+
   const json = JSON.stringify(dump, null, 2);
 
   if (toStdout) {
@@ -133,6 +142,9 @@ export async function cmdDump(args: string[], deps?: Partial<DumpDeps>): Promise
   const filePath = join(d.dumpsDir, `dump-${slug}.json`);
   writeFileSync(filePath, `${json}\n`);
   console.error(`Dump written to ${filePath}`);
+
+  // Rotate old dumps
+  rotateDumps(d.dumpsDir);
 }
 
 // ── Data gatherers ──
@@ -219,6 +231,61 @@ async function gatherSessions(d: DumpDeps, includeTranscripts: boolean): Promise
     });
   } catch (err) {
     return gatherError(err);
+  }
+}
+
+// ── Dump rotation and size capping ──
+
+/**
+ * Progressively truncate dump content to stay under MAX_DUMP_BYTES.
+ * Truncation order: transcripts → metrics → daemonLog.
+ * Mutates the dump object in-place and sets `truncated: true` when content is removed.
+ */
+export function truncateDump(dump: Record<string, unknown>): void {
+  const size = () => JSON.stringify(dump).length;
+
+  if (size() <= MAX_DUMP_BYTES) return;
+
+  dump.truncated = true;
+
+  // 1. Strip transcripts from sessions
+  if (Array.isArray(dump.sessions)) {
+    for (const session of dump.sessions as Array<Record<string, unknown>>) {
+      if ("transcript" in session) {
+        session.transcript = ["(truncated — dump exceeded size limit)"];
+      }
+    }
+  }
+  if (size() <= MAX_DUMP_BYTES) return;
+
+  // 2. Strip metrics
+  dump.metrics = { truncated: true };
+  if (size() <= MAX_DUMP_BYTES) return;
+
+  // 3. Strip daemon logs
+  dump.daemonLog = [{ line: "(truncated — dump exceeded size limit)", timestamp: Date.now() }];
+}
+
+/**
+ * Delete oldest dump files when the directory contains more than MAX_DUMP_FILES.
+ * Files are sorted lexicographically (timestamp-based names sort chronologically).
+ */
+export function rotateDumps(dumpsDir: string): void {
+  if (!existsSync(dumpsDir)) return;
+
+  const files = readdirSync(dumpsDir)
+    .filter((f) => f.startsWith("dump-") && f.endsWith(".json"))
+    .sort(); // lexicographic = chronological for ISO-based names
+
+  const excess = files.length - MAX_DUMP_FILES;
+  if (excess <= 0) return;
+
+  for (let i = 0; i < excess; i++) {
+    try {
+      unlinkSync(join(dumpsDir, files[i]));
+    } catch {
+      // Best-effort cleanup — don't fail the dump command
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Rotate dump files in `~/.mcp-cli/dumps/`, keeping at most 20 and deleting oldest on write
- Cap individual dump size at 50MB with progressive truncation: transcripts → metrics → daemon logs
- Set `"truncated": true` flag in dump output when content is removed due to size cap

## Test plan
- [x] Rotation: verified oldest dumps deleted when exceeding 20 files
- [x] Rotation: no-op when under limit
- [x] Rotation: non-dump files ignored
- [x] Truncation: no-op when dump is under 50MB
- [x] Truncation: strips transcripts first, sets truncated flag
- [x] Truncation: handles large single-field dumps
- [x] All 2236 existing tests pass
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)