### PR TITLE
feat(core): add branchPrefix config field for worktree hooks (fixes #542)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -1,4 +1,7 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import { existsSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { WORKTREE_CONFIG_FILENAME } from "@mcp-cli/core/worktree-config";
 import { _resetJqStateForTesting } from "../jq/index";
 import { ExitError } from "../test-helpers";
 import type { ClaudeDeps } from "./claude";
@@ -678,6 +681,96 @@ describe("mcx claude spawn --headed", () => {
       const ttyArgs = ttyOpen.mock.calls[0] as unknown as [string[]];
       expect(ttyArgs[0][0]).toContain("cd ");
       expect(ttyArgs[0][0]).toContain("my-feat");
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("headed --worktree uses headed/ prefix by default", async () => {
+    const ttyOpen = mock(async () => {});
+    const exec = mock(() => ({ stdout: "", stderr: "", exitCode: 0 }));
+    const deps = makeDeps({ ttyOpen, exec });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["spawn", "--headed", "--task", "x", "--worktree", "my-feat"], deps);
+      const execCalls = exec.mock.calls as unknown as Array<[string[]]>;
+      const wtCall = execCalls.find((c) => c[0][0] === "git" && c[0][1] === "worktree");
+      expect(wtCall?.[0]).toContain("headed/my-feat");
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("headed --worktree skips prefix when branchPrefix: false", async () => {
+    const configPath = join(process.cwd(), WORKTREE_CONFIG_FILENAME);
+    writeFileSync(configPath, JSON.stringify({ worktree: { branchPrefix: false } }));
+    try {
+      const ttyOpen = mock(async () => {});
+      const exec = mock(() => ({ stdout: "", stderr: "", exitCode: 0 }));
+      const deps = makeDeps({ ttyOpen, exec });
+
+      const origLog = console.log;
+      console.log = mock(() => {});
+      try {
+        await cmdClaude(["spawn", "--headed", "--task", "x", "--worktree", "my-feat"], deps);
+        const execCalls = exec.mock.calls as unknown as Array<[string[]]>;
+        const wtCall = execCalls.find((c) => c[0][0] === "git" && c[0][1] === "worktree");
+        // Branch name should be "my-feat" without prefix
+        expect(wtCall?.[0]).toContain("my-feat");
+        expect(wtCall?.[0]).not.toContain("headed/my-feat");
+      } finally {
+        console.log = origLog;
+      }
+    } finally {
+      if (existsSync(configPath)) unlinkSync(configPath);
+    }
+  });
+});
+
+describe("mcx claude spawn --worktree branchPrefix", () => {
+  test("headless --worktree pre-creates worktree without prefix when branchPrefix: false", async () => {
+    const configPath = join(process.cwd(), WORKTREE_CONFIG_FILENAME);
+    writeFileSync(configPath, JSON.stringify({ worktree: { branchPrefix: false } }));
+    try {
+      const exec = mock(() => ({ stdout: "", stderr: "", exitCode: 0 }));
+      const callTool = mock(async () => toolResult({ sessionId: "s1" }));
+      const deps = makeDeps({ exec, callTool });
+
+      const origLog = console.log;
+      console.log = mock(() => {});
+      try {
+        await cmdClaude(["spawn", "--task", "x", "--worktree", "my-feat"], deps);
+        // Verify git worktree add was called with raw branch name
+        const execCalls = exec.mock.calls as unknown as Array<[string[]]>;
+        const wtCall = execCalls.find((c) => c[0][0] === "git" && c[0][1] === "worktree");
+        expect(wtCall).toBeDefined();
+        expect(wtCall?.[0]).toContain("my-feat");
+        // Verify cwd was set (pre-created worktree path passed as cwd)
+        const toolCalls = callTool.mock.calls as unknown as Array<[string, Record<string, unknown>]>;
+        expect(toolCalls[0][1].cwd).toBeDefined();
+        expect(toolCalls[0][1].worktree).toBe("my-feat");
+      } finally {
+        console.log = origLog;
+      }
+    } finally {
+      if (existsSync(configPath)) unlinkSync(configPath);
+    }
+  });
+
+  test("headless --worktree delegates to daemon when branchPrefix is not false", async () => {
+    const callTool = mock(async () => toolResult({ sessionId: "s1" }));
+    const deps = makeDeps({ callTool });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["spawn", "--task", "x", "--worktree", "my-feat"], deps);
+      // Should pass worktree to daemon (no cwd pre-creation)
+      const toolCalls = callTool.mock.calls as unknown as Array<[string, Record<string, unknown>]>;
+      expect(toolCalls[0][1].worktree).toBe("my-feat");
+      expect(toolCalls[0][1].cwd).toBeUndefined();
     } finally {
       console.log = origLog;
     }

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -377,6 +377,18 @@ async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
       toolArgs.worktree = parsed.worktree;
       toolArgs.repoRoot = repoRoot;
       d.printError(`Created worktree via hook: ${worktreePath}`);
+    } else if (wtConfig?.branchPrefix === false) {
+      // branchPrefix: false — pre-create worktree with raw branch name (no claude/ prefix)
+      const worktreePath = resolveWorktreePath(repoRoot, parsed.worktree, wtConfig);
+      const { exitCode, stdout } = d.exec(["git", "worktree", "add", worktreePath, "-b", parsed.worktree, "HEAD"]);
+      if (exitCode !== 0) {
+        d.printError(`Failed to create worktree: ${stdout}`);
+        d.exit(1);
+      }
+      toolArgs.cwd = worktreePath;
+      toolArgs.worktree = parsed.worktree;
+      toolArgs.repoRoot = repoRoot;
+      d.printError(`Created worktree: ${worktreePath}`);
     } else {
       toolArgs.worktree = parsed.worktree;
     }
@@ -416,15 +428,8 @@ async function claudeSpawnHeaded(parsed: SpawnArgs, d: ClaudeDeps): Promise<void
         d.exit(1);
       }
     } else {
-      const { exitCode, stdout } = d.exec([
-        "git",
-        "worktree",
-        "add",
-        worktreePath,
-        "-b",
-        `headed/${parsed.worktree}`,
-        "HEAD",
-      ]);
+      const branchName = wtConfig?.branchPrefix === false ? parsed.worktree : `headed/${parsed.worktree}`;
+      const { exitCode, stdout } = d.exec(["git", "worktree", "add", worktreePath, "-b", branchName, "HEAD"]);
       if (exitCode !== 0) {
         d.printError(`Failed to create worktree: ${stdout}`);
         d.exit(1);

--- a/packages/core/src/worktree-config.spec.ts
+++ b/packages/core/src/worktree-config.spec.ts
@@ -54,6 +54,25 @@ describe("readWorktreeConfig", () => {
     writeFileSync(join(dir, WORKTREE_CONFIG_FILENAME), JSON.stringify(config));
     expect(readWorktreeConfig(dir)).toEqual({ setup: "echo $MCX_BRANCH" });
   });
+
+  test("parses branchPrefix: false", () => {
+    const dir = makeTempDir();
+    const config = { worktree: { branchPrefix: false } };
+    writeFileSync(join(dir, WORKTREE_CONFIG_FILENAME), JSON.stringify(config));
+    expect(readWorktreeConfig(dir)).toEqual({ branchPrefix: false });
+  });
+
+  test("parses branchPrefix: true with other fields", () => {
+    const dir = makeTempDir();
+    const config = {
+      worktree: {
+        setup: "./scripts/setup.sh",
+        branchPrefix: true,
+      },
+    };
+    writeFileSync(join(dir, WORKTREE_CONFIG_FILENAME), JSON.stringify(config));
+    expect(readWorktreeConfig(dir)).toEqual(config.worktree);
+  });
 });
 
 describe("resolveWorktreeBase", () => {

--- a/packages/core/src/worktree-config.ts
+++ b/packages/core/src/worktree-config.ts
@@ -16,6 +16,12 @@ export interface WorktreeHooksConfig {
   teardown?: string;
   /** Base directory for worktrees (absolute or relative to repo root). Defaults to `.claude/worktrees`. */
   base?: string;
+  /**
+   * Whether to prepend a prefix to worktree branch names (`claude/` for headless, `headed/` for headed).
+   * Set to `false` to use branch names exactly as provided.
+   * Defaults to `true` (prefixes applied).
+   */
+  branchPrefix?: boolean;
 }
 
 /** Config file shape */


### PR DESCRIPTION
## Summary
- Adds `branchPrefix?: boolean` to `WorktreeHooksConfig` in `.mcx-worktree.json`
- When `branchPrefix: false`, worktree branches are created with the exact name provided — no `claude/` prefix (headless) or `headed/` prefix (headed)
- Default behavior (field absent or `true`) is unchanged

## Test plan
- [x] `readWorktreeConfig` parses `branchPrefix: false` and `branchPrefix: true`
- [x] Headed spawn uses raw branch name when `branchPrefix: false`
- [x] Headed spawn uses `headed/` prefix by default
- [x] Headless spawn pre-creates worktree without prefix when `branchPrefix: false`
- [x] Headless spawn delegates to daemon (with `claude/` prefix) by default
- [x] All 2246 tests pass, coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)