### PR TITLE
test(triage): extract pure functions to triage-logic.ts for unit testing (fixes #550)

### DIFF
--- a/.claude/skills/estimate/triage-logic.spec.ts
+++ b/.claude/skills/estimate/triage-logic.spec.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from "bun:test";
+import { type FileEntry, RISK_PATTERNS, parseNumstat, triage } from "./triage-logic.ts";
+
+describe("parseNumstat", () => {
+	test("returns empty array for empty input", () => {
+		expect(parseNumstat("")).toEqual([]);
+	});
+
+	test("returns empty array for whitespace-only input", () => {
+		expect(parseNumstat("  \n  \n")).toEqual([]);
+	});
+
+	test("parses a single .ts file", () => {
+		const result = parseNumstat("10\t5\tpackages/core/src/foo.ts");
+		expect(result).toEqual([
+			{ path: "packages/core/src/foo.ts", additions: 10, deletions: 5 },
+		]);
+	});
+
+	test("parses multiple files", () => {
+		const input = [
+			"10\t5\tpackages/core/src/foo.ts",
+			"3\t1\tpackages/daemon/src/bar.ts",
+		].join("\n");
+		expect(parseNumstat(input)).toHaveLength(2);
+	});
+
+	test("handles binary files (dashes for add/del)", () => {
+		const result = parseNumstat("-\t-\tpackages/core/src/binary.ts");
+		expect(result).toEqual([
+			{ path: "packages/core/src/binary.ts", additions: 0, deletions: 0 },
+		]);
+	});
+
+	test("filters out non-.ts files", () => {
+		const input = [
+			"10\t5\tpackages/core/src/foo.ts",
+			"20\t10\tREADME.md",
+			"5\t2\tpackage.json",
+		].join("\n");
+		expect(parseNumstat(input)).toHaveLength(1);
+		expect(parseNumstat(input)[0].path).toBe("packages/core/src/foo.ts");
+	});
+
+	test("filters out node_modules paths", () => {
+		const input = "10\t5\tnode_modules/@types/bun/index.ts";
+		expect(parseNumstat(input)).toEqual([]);
+	});
+});
+
+describe("triage", () => {
+	function file(path: string, additions: number, deletions: number): FileEntry {
+		return { path, additions, deletions };
+	}
+
+	test("returns low scrutiny when all metrics are below thresholds", () => {
+		const result = triage([
+			file("packages/core/src/foo.ts", 10, 5),
+		]);
+		expect(result.scrutiny).toBe("low");
+		expect(result.pipeline).toBe("QA");
+		expect(result.reasons).toHaveLength(0);
+	});
+
+	test("triggers high scrutiny on churn >= 120", () => {
+		const result = triage([
+			file("packages/core/src/foo.ts", 60, 60),
+		]);
+		expect(result.scrutiny).toBe("high");
+		expect(result.reasons).toEqual(
+			expect.arrayContaining([expect.stringContaining("churn 120")]),
+		);
+	});
+
+	test("triggers high scrutiny on additions >= 100", () => {
+		const result = triage([
+			file("packages/core/src/foo.ts", 100, 0),
+		]);
+		expect(result.scrutiny).toBe("high");
+		expect(result.reasons).toEqual(
+			expect.arrayContaining([expect.stringContaining("additions 100")]),
+		);
+	});
+
+	test("triggers high scrutiny on 2+ risk areas", () => {
+		const result = triage([
+			file("packages/daemon/src/ipc-server.ts", 5, 2),
+			file("packages/daemon/src/auth/token.ts", 5, 2),
+		]);
+		expect(result.scrutiny).toBe("high");
+		expect(result.metrics.riskAreas).toEqual(
+			expect.arrayContaining(["auth", "ipc"]),
+		);
+		expect(result.reasons).toEqual(
+			expect.arrayContaining([expect.stringContaining("risk areas")]),
+		);
+	});
+
+	test("triggers high scrutiny on 4+ files across 2+ packages", () => {
+		const result = triage([
+			file("packages/core/src/a.ts", 5, 0),
+			file("packages/core/src/b.ts", 5, 0),
+			file("packages/daemon/src/c.ts", 5, 0),
+			file("packages/daemon/src/d.ts", 5, 0),
+		]);
+		expect(result.scrutiny).toBe("high");
+		expect(result.reasons).toEqual(
+			expect.arrayContaining([expect.stringContaining("4 files across 2 packages")]),
+		);
+	});
+
+	test("does not trigger cross-package rule with 4+ files in 1 package", () => {
+		const result = triage([
+			file("packages/core/src/a.ts", 5, 0),
+			file("packages/core/src/b.ts", 5, 0),
+			file("packages/core/src/c.ts", 5, 0),
+			file("packages/core/src/d.ts", 5, 0),
+		]);
+		expect(result.reasons.some(r => r.includes("packages"))).toBe(false);
+	});
+
+	test("separates test files from src files in metrics", () => {
+		const result = triage([
+			file("packages/core/src/foo.ts", 10, 5),
+			file("packages/core/src/foo.spec.ts", 50, 20),
+		]);
+		expect(result.metrics.srcFiles).toBe(1);
+		expect(result.metrics.testFiles).toBe(1);
+		expect(result.metrics.srcAdditions).toBe(10);
+	});
+
+	test("reports correct packages", () => {
+		const result = triage([
+			file("packages/core/src/a.ts", 1, 0),
+			file("packages/daemon/src/b.ts", 1, 0),
+			file("packages/command/src/c.ts", 1, 0),
+		]);
+		expect(result.metrics.packages).toEqual(["command", "core", "daemon"]);
+	});
+});
+
+describe("RISK_PATTERNS", () => {
+	test("matches ipc-server and ipc-client paths", () => {
+		const ipcPattern = RISK_PATTERNS.find(([, label]) => label === "ipc")![0];
+		expect(ipcPattern.test("packages/core/src/ipc-server.ts")).toBe(true);
+		expect(ipcPattern.test("packages/core/src/ipc-client.ts")).toBe(true);
+		expect(ipcPattern.test("packages/core/src/ipc.server.ts")).toBe(true);
+	});
+
+	test("matches auth paths", () => {
+		const authPattern = RISK_PATTERNS.find(([, label]) => label === "auth")![0];
+		expect(authPattern.test("packages/daemon/src/auth/token.ts")).toBe(true);
+		expect(authPattern.test("packages/daemon/src/keychain.ts")).toBe(true);
+	});
+
+	test("matches worker paths", () => {
+		const workerPattern = RISK_PATTERNS.find(([, label]) => label === "worker")![0];
+		expect(workerPattern.test("packages/daemon/src/alias-worker.ts")).toBe(true);
+		expect(workerPattern.test("packages/daemon/src/session.worker.ts")).toBe(true);
+	});
+});

--- a/.claude/skills/estimate/triage-logic.ts
+++ b/.claude/skills/estimate/triage-logic.ts
@@ -1,0 +1,116 @@
+/**
+ * Pure triage logic — extracted for testability.
+ *
+ * All side-effect-free scoring and parsing lives here.
+ * The entry-point script (triage.ts) handles I/O and arg parsing.
+ */
+
+// ─── Risk patterns ───────────────────────────────────────────────────────────
+
+export const RISK_PATTERNS: [RegExp, string][] = [
+	[/ipc[-.](?:server|client)/i, "ipc"],
+	[/auth[/\\]|keychain/i, "auth"],
+	[/[-.]worker\.ts$/, "worker"],
+	[/server-pool/i, "pool"],
+	[/config[/\\]|cli-config/i, "config"],
+	[/db[/\\]/, "db"],
+	[/[-.]transport\.ts$/, "transport"],
+	[/(?:daemon|command|control)[/\\]src[/\\]index\.ts$/, "entrypoint"],
+];
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface FileEntry {
+	path: string;
+	additions: number;
+	deletions: number;
+}
+
+export interface TriageResult {
+	scrutiny: "low" | "high";
+	pipeline: string;
+	metrics: {
+		srcAdditions: number;
+		srcDeletions: number;
+		srcChurn: number;
+		srcFiles: number;
+		testFiles: number;
+		packages: string[];
+		riskAreas: string[];
+		changedFiles: string[];
+	};
+	reasons: string[];
+}
+
+// ─── Pure functions ──────────────────────────────────────────────────────────
+
+export function parseNumstat(diffStat: string): FileEntry[] {
+	const files: FileEntry[] = [];
+	for (const line of diffStat.split("\n").filter(Boolean)) {
+		const [add, del, path] = line.split("\t");
+		if (!path || !path.endsWith(".ts") || path.includes("node_modules")) continue;
+		files.push({
+			path,
+			additions: add === "-" ? 0 : parseInt(add, 10),
+			deletions: del === "-" ? 0 : parseInt(del, 10),
+		});
+	}
+	return files;
+}
+
+export function triage(files: FileEntry[]): TriageResult {
+	const isTest = (p: string) => /\.spec\.ts$|\.test\.ts$|__tests__/.test(p);
+	const srcFiles = files.filter(f => !isTest(f.path));
+	const testFiles = files.filter(f => isTest(f.path));
+
+	const srcAdditions = srcFiles.reduce((s, f) => s + f.additions, 0);
+	const srcDeletions = srcFiles.reduce((s, f) => s + f.deletions, 0);
+	const srcChurn = srcAdditions + srcDeletions;
+
+	// Detect packages
+	const packages = new Set<string>();
+	for (const f of srcFiles) {
+		const m = f.path.match(/packages[/\\]([^/\\]+)/);
+		if (m) packages.add(m[1]);
+	}
+
+	// Detect risk areas
+	const riskAreas = new Set<string>();
+	for (const f of srcFiles) {
+		for (const [pat, label] of RISK_PATTERNS) {
+			if (pat.test(f.path)) riskAreas.add(label);
+		}
+	}
+
+	// Apply triage rules
+	const reasons: string[] = [];
+
+	if (srcChurn >= 120) reasons.push(`src churn ${srcChurn} ≥ 120`);
+	if (srcAdditions >= 100) reasons.push(`src additions ${srcAdditions} ≥ 100`);
+	if (riskAreas.size >= 2) reasons.push(`${riskAreas.size} risk areas: ${[...riskAreas].join(", ")}`);
+	if (srcFiles.length >= 4 && packages.size >= 2) {
+		reasons.push(`${srcFiles.length} files across ${packages.size} packages`);
+	}
+
+	const scrutiny = reasons.length > 0 ? "high" : "low";
+
+	const pipeline = scrutiny === "high"
+		? "adversarial-review → QA (with repair loop if needed)"
+		: "QA";
+
+	return {
+		scrutiny,
+		pipeline,
+		metrics: {
+			srcAdditions,
+			srcDeletions,
+			srcChurn,
+			srcFiles: srcFiles.length,
+			testFiles: testFiles.length,
+			packages: [...packages].sort(),
+			riskAreas: [...riskAreas].sort(),
+			changedFiles: srcFiles.map(f => f.path),
+		},
+		reasons,
+	};
+}

--- a/.claude/skills/estimate/triage.ts
+++ b/.claude/skills/estimate/triage.ts
@@ -19,69 +19,10 @@
  */
 
 import { execSync } from "child_process";
-
-// ─── Risk patterns ───────────────────────────────────────────────────────────
-
-const RISK_PATTERNS: [RegExp, string][] = [
-	[/ipc[-.](?:server|client)/i, "ipc"],
-	[/auth[/\\]|keychain/i, "auth"],
-	[/[-.]worker\.ts$/, "worker"],
-	[/server-pool/i, "pool"],
-	[/config[/\\]|cli-config/i, "config"],
-	[/db[/\\]/, "db"],
-	[/[-.]transport\.ts$/, "transport"],
-	[/(?:daemon|command|control)[/\\]src[/\\]index\.ts$/, "entrypoint"],
-];
-
-// ─── Triage thresholds (validated against 91 historical PRs) ─────────────────
-//
-// High scrutiny if ANY of:
-//   - src churn (additions + deletions) ≥ 120 lines
-//   - src additions ≥ 100 lines
-//   - 2+ risk areas touched
-//   - 4+ source files changed across 2+ packages
-//
-// These thresholds were derived from the P60 of historical churn distribution
-// and validated with 92.5% F1 / 0% false negatives on 91 merged PRs.
-
-interface TriageResult {
-	scrutiny: "low" | "high";
-	pipeline: string;
-	metrics: {
-		srcAdditions: number;
-		srcDeletions: number;
-		srcChurn: number;
-		srcFiles: number;
-		testFiles: number;
-		packages: string[];
-		riskAreas: string[];
-		changedFiles: string[];
-	};
-	reasons: string[];
-}
+import { type FileEntry, parseNumstat, triage } from "./triage-logic.ts";
 
 function exec(cmd: string): string {
 	return execSync(cmd, { encoding: "utf-8", maxBuffer: 10 * 1024 * 1024 }).trim();
-}
-
-interface FileEntry {
-	path: string;
-	additions: number;
-	deletions: number;
-}
-
-function parseNumstat(diffStat: string): FileEntry[] {
-	const files: FileEntry[] = [];
-	for (const line of diffStat.split("\n").filter(Boolean)) {
-		const [add, del, path] = line.split("\t");
-		if (!path || !path.endsWith(".ts") || path.includes("node_modules")) continue;
-		files.push({
-			path,
-			additions: add === "-" ? 0 : parseInt(add, 10),
-			deletions: del === "-" ? 0 : parseInt(del, 10),
-		});
-	}
-	return files;
 }
 
 function getFilesFromGitDiff(baseBranch: string): FileEntry[] {
@@ -107,63 +48,6 @@ function getFilesFromPr(prNumber: number): FileEntry[] {
 			additions: f.additions,
 			deletions: f.deletions,
 		}));
-}
-
-function triage(files: FileEntry[]): TriageResult {
-	const isTest = (p: string) => /\.spec\.ts$|\.test\.ts$|__tests__/.test(p);
-	const srcFiles = files.filter(f => !isTest(f.path));
-	const testFiles = files.filter(f => isTest(f.path));
-
-	const srcAdditions = srcFiles.reduce((s, f) => s + f.additions, 0);
-	const srcDeletions = srcFiles.reduce((s, f) => s + f.deletions, 0);
-	const srcChurn = srcAdditions + srcDeletions;
-
-	// Detect packages
-	const packages = new Set<string>();
-	for (const f of srcFiles) {
-		const m = f.path.match(/packages[/\\]([^/\\]+)/);
-		if (m) packages.add(m[1]);
-	}
-
-	// Detect risk areas
-	const riskAreas = new Set<string>();
-	for (const f of srcFiles) {
-		for (const [pat, label] of RISK_PATTERNS) {
-			if (pat.test(f.path)) riskAreas.add(label);
-		}
-	}
-
-	// Apply triage rules
-	const reasons: string[] = [];
-
-	if (srcChurn >= 120) reasons.push(`src churn ${srcChurn} ≥ 120`);
-	if (srcAdditions >= 100) reasons.push(`src additions ${srcAdditions} ≥ 100`);
-	if (riskAreas.size >= 2) reasons.push(`${riskAreas.size} risk areas: ${[...riskAreas].join(", ")}`);
-	if (srcFiles.length >= 4 && packages.size >= 2) {
-		reasons.push(`${srcFiles.length} files across ${packages.size} packages`);
-	}
-
-	const scrutiny = reasons.length > 0 ? "high" : "low";
-
-	const pipeline = scrutiny === "high"
-		? "adversarial-review → QA (with repair loop if needed)"
-		: "QA";
-
-	return {
-		scrutiny,
-		pipeline,
-		metrics: {
-			srcAdditions,
-			srcDeletions,
-			srcChurn,
-			srcFiles: srcFiles.length,
-			testFiles: testFiles.length,
-			packages: [...packages].sort(),
-			riskAreas: [...riskAreas].sort(),
-			changedFiles: srcFiles.map(f => f.path),
-		},
-		reasons,
-	};
 }
 
 // ─── Main ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Extracted `parseNumstat`, `triage`, `FileEntry`, `TriageResult`, and `RISK_PATTERNS` from `triage.ts` into a new `triage-logic.ts` module with exports
- Updated `triage.ts` to import from `triage-logic.ts`, keeping only I/O and arg parsing
- Added `triage-logic.spec.ts` with 18 tests covering both functions and risk pattern matching

## Test plan
- [x] `parseNumstat`: empty input, whitespace, single file, multi-file, binary files (dashes), non-.ts filtering, node_modules filtering
- [x] `triage`: low scrutiny baseline, each high-scrutiny trigger independently (churn >= 120, additions >= 100, 2+ risk areas, 4+ files across 2+ packages), negative case for cross-package rule, test/src separation, package detection
- [x] `RISK_PATTERNS`: ipc, auth, and worker pattern matching
- [x] All 2237 tests pass, coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)