### PR TITLE
refactor: move PROMPT_IPC_TIMEOUT_MS to core constants (fixes #582)

### DIFF
--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -8,6 +8,7 @@
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import {
+  PROMPT_IPC_TIMEOUT_MS,
   buildHookEnv,
   fixCoreBare,
   hasWorktreeHooks,
@@ -49,9 +50,6 @@ export interface ClaudeDeps {
   /** Resolve the git repo root for the current working directory. Returns null if not in a git repo. */
   getGitRoot: () => string | null;
 }
-
-/** IPC timeout for blocking claude_prompt calls (5 min + buffer). Other tools use default 60s. */
-const PROMPT_IPC_TIMEOUT_MS = 330_000;
 
 /**
  * Parse `git diff --shortstat` output into a compact diff summary.

--- a/packages/command/src/commands/codex.ts
+++ b/packages/command/src/commands/codex.ts
@@ -5,7 +5,7 @@
  * No resume, headed, or worktrees subcommands (Codex threads are ephemeral).
  */
 
-import { ipcCall, resolveModelName } from "@mcp-cli/core";
+import { PROMPT_IPC_TIMEOUT_MS, ipcCall, resolveModelName } from "@mcp-cli/core";
 import type { AgentSessionInfo } from "@mcp-cli/core";
 import { applyJqFilter } from "../jq/index";
 import { c, printError as defaultPrintError, formatToolResult } from "../output";
@@ -25,9 +25,6 @@ import {
 
 /** Tool name prefix for the Codex provider. */
 const P = "codex";
-
-/** IPC timeout for blocking codex_prompt calls (5 min + buffer). */
-const PROMPT_IPC_TIMEOUT_MS = 330_000;
 
 // ── Dependency injection ──
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -197,3 +197,6 @@ export const DAEMON_BINARY_NAME = "mcpd";
 
 /** Daemon dev-mode script path (relative to workspace root) */
 export const DAEMON_DEV_SCRIPT = "packages/daemon/src/main.ts";
+
+/** IPC timeout for prompt-like commands (claude send/wait, codex) that may take minutes (ms) */
+export const PROMPT_IPC_TIMEOUT_MS = 330_000;


### PR DESCRIPTION
## Summary
- Move `PROMPT_IPC_TIMEOUT_MS` from duplicate definitions in `claude.ts` and `codex.ts` to `packages/core/src/constants.ts`
- Both command files now import from `@mcp-cli/core`

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — all 2297 tests pass
- [x] Coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)