### PR TITLE
fix(command): remove redundant intersection type in claudeList session array (fixes #591)

### DIFF
--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -770,7 +770,7 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
     return;
   }
 
-  let sessions: (SessionInfo & { repoRoot?: string | null })[];
+  let sessions: SessionInfo[];
   try {
     sessions = JSON.parse(text);
   } catch {


### PR DESCRIPTION
## Summary
- Remove redundant `& { repoRoot?: string | null }` intersection from `sessions` variable type in `claudeList`
- `SessionInfo` already includes `repoRoot: string | null` via `AgentSessionInfo`, making the intersection misleading

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes  
- [x] `bun test` passes (2297/2297)

🤖 Generated with [Claude Code](https://claude.com/claude-code)