### PR TITLE
feat(daemon): add persistent crash counter metric and log on crashTimestamps reset (fixes #475)

### DIFF
--- a/packages/daemon/src/claude-server.spec.ts
+++ b/packages/daemon/src/claude-server.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { silentLogger } from "@mcp-cli/core";
+import { capturingLogger, silentLogger } from "@mcp-cli/core";
 import { ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types.js";
 import { testOptions } from "../../../test/test-options";
 import {
@@ -10,6 +10,7 @@ import {
   isWorkerEvent,
 } from "./claude-server";
 import { StateDb } from "./db/state";
+import { metrics } from "./metrics";
 
 // ── WORKER_EVENT_TYPES exhaustiveness ──
 
@@ -700,6 +701,59 @@ describe("ClaudeServer", () => {
     expect(internals.client).toBeNull();
     expect(server.port).toBeNull();
     server = undefined; // already cleaned up
+  });
+
+  // ── Crash counter metric (#475) ──
+
+  test("handleWorkerCrash increments mcpd_claude_server_crashes_total", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new ClaudeServer(db, undefined, undefined, silentLogger);
+
+    await server.start();
+
+    const before = metrics.counter("mcpd_claude_server_crashes_total").value();
+
+    const crash = (
+      server as unknown as { handleWorkerCrash: (reason: string) => Promise<void> }
+    ).handleWorkerCrash.bind(server);
+    await crash("test crash for metric");
+
+    expect(metrics.counter("mcpd_claude_server_crashes_total").value()).toBe(before + 1);
+  });
+
+  // ── Crash timestamp log on stop (#475) ──
+
+  test("stop() logs cleared crash timestamps count after a crash", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    const { logger, texts } = capturingLogger();
+    server = new ClaudeServer(db, undefined, undefined, logger);
+
+    await server.start();
+
+    const crash = (
+      server as unknown as { handleWorkerCrash: (reason: string) => Promise<void> }
+    ).handleWorkerCrash.bind(server);
+    await crash("test crash");
+
+    await server.stop();
+    server = undefined;
+
+    expect(texts.some((t) => t.includes("Cleared") && t.includes("crash timestamp"))).toBe(true);
+  });
+
+  test("stop() does not log crash timestamps when none exist", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    const { logger, texts } = capturingLogger();
+    server = new ClaudeServer(db, undefined, undefined, logger);
+
+    await server.start();
+    await server.stop();
+    server = undefined;
+
+    expect(texts.some((t) => t.includes("Cleared") && t.includes("crash timestamp"))).toBe(false);
   });
 
   // ── Re-entrancy guard (#493) ──

--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -288,6 +288,9 @@ export class ClaudeServer {
     this.activeSessions.clear();
     this.sessionPids.clear();
     this.sessionAddedAt.clear();
+    if (this.crashTimestamps.length > 0) {
+      this.logger.error(`[claude-server] Cleared ${this.crashTimestamps.length} crash timestamp(s) on stop`);
+    }
     this.crashTimestamps.length = 0;
   }
 
@@ -362,6 +365,7 @@ export class ClaudeServer {
   /** Handle a worker crash: end orphaned sessions and attempt auto-restart. */
   private async handleWorkerCrash(reason: string): Promise<void> {
     metrics.counter("mcpd_worker_crashes_total").inc();
+    metrics.counter("mcpd_claude_server_crashes_total").inc();
     if (this.stopped) return;
     if (this.restartInProgress) {
       this.pendingCrashReason = reason;


### PR DESCRIPTION
## Summary
- Adds `mcpd_claude_server_crashes_total` counter metric that increments on every crash and is never cleared, enabling monitoring to detect crash cycling even when `crashTimestamps` are reset by `stop()`
- Logs the number of cleared crash timestamps when `stop()` resets them, making the state mutation observable for debugging
- Adds 3 tests: metric increment on crash, log presence after crash+stop, no log when no crashes occurred

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — all 2300 tests pass
- [x] Coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)