### PR TITLE
feat(ci): add quiet test output ratchet for production log noise (fixes #540)

### DIFF
--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -19,6 +19,13 @@ const GLOBAL_THRESHOLDS = {
   lines: 69,
 };
 
+/**
+ * Maximum allowed production log noise lines during test runs.
+ * Matches daemon log prefixes ([mcpd], [_claude], [_aliases]) and
+ * production signals (MCPD_READY). Ratchet this down toward zero.
+ */
+const NOISE_THRESHOLD = 15;
+
 /** Per-file minimum coverage — every file must meet this unless excluded */
 const PER_FILE_MIN_LINES = 80;
 
@@ -72,6 +79,7 @@ const EXCLUSIONS: Record<string, string> = {
 // --- Main ---
 
 import { logTestRun } from "./test-failure-log";
+import { detectTestNoise } from "./test-noise";
 
 // Ensure deps are installed (fast no-op when already present)
 const installProc = Bun.spawn(["bun", "install"], { stdout: "ignore", stderr: "ignore" });
@@ -133,6 +141,10 @@ for (const match of output.matchAll(fileRowRegex)) {
   failures.push({ file, lines });
 }
 
+// --- Check test output noise ---
+
+const noiseLines = detectTestNoise(output);
+
 // --- Report ---
 
 console.log("\n--- Coverage Report ---");
@@ -158,6 +170,19 @@ if (failures.length > 0) {
     console.error(`  ${lines.toFixed(1)}%  ${file}`);
   }
   console.error("\nEither add tests or add an exclusion with a reason in scripts/check-coverage.ts");
+  failed = true;
+}
+
+console.log(`\nTest noise: ${noiseLines.length} production log line(s) detected (threshold: ${NOISE_THRESHOLD})`);
+if (noiseLines.length > NOISE_THRESHOLD) {
+  console.error(`\nFAIL: Test output noise ${noiseLines.length} exceeds threshold ${NOISE_THRESHOLD}`);
+  console.error("Production log output leaked into test run. Inject silentLogger to suppress:");
+  for (const line of noiseLines.slice(0, 20)) {
+    console.error(`  ${line}`);
+  }
+  if (noiseLines.length > 20) {
+    console.error(`  ... and ${noiseLines.length - 20} more`);
+  }
   failed = true;
 }
 

--- a/scripts/test-noise.spec.ts
+++ b/scripts/test-noise.spec.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import { detectTestNoise } from "./test-noise";
+
+describe("detectTestNoise", () => {
+  it("detects [mcpd] prefixed lines", () => {
+    const output = "some test output\n[mcpd] starting server\n✓ test passed\n";
+    expect(detectTestNoise(output)).toEqual(["[mcpd] starting server"]);
+  });
+
+  it("detects [_claude] prefixed lines", () => {
+    const output = "[_claude] session started\n";
+    expect(detectTestNoise(output)).toEqual(["[_claude] session started"]);
+  });
+
+  it("detects [_aliases] prefixed lines", () => {
+    const output = "[_aliases] loading aliases\n";
+    expect(detectTestNoise(output)).toEqual(["[_aliases] loading aliases"]);
+  });
+
+  it("detects [alias-*] prefixed lines", () => {
+    const output = "[alias-foo] running\n[alias-bar_baz] done\n";
+    expect(detectTestNoise(output)).toEqual(["[alias-foo] running", "[alias-bar_baz] done"]);
+  });
+
+  it("detects MCPD_READY", () => {
+    const output = "starting\nMCPD_READY\ndone\n";
+    expect(detectTestNoise(output)).toEqual(["MCPD_READY"]);
+  });
+
+  it("returns empty for clean test output", () => {
+    const output = "✓ test 1\n✓ test 2\n2 pass\n";
+    expect(detectTestNoise(output)).toEqual([]);
+  });
+
+  it("handles multiple noise patterns in one output", () => {
+    const output = ["MCPD_READY", "[mcpd] connected", "✓ some test", "[_claude] ws open", "[_aliases] loaded 3"].join(
+      "\n",
+    );
+    expect(detectTestNoise(output)).toHaveLength(4);
+  });
+
+  it("trims whitespace before matching", () => {
+    const output = "  MCPD_READY  \n  [mcpd] foo  \n";
+    expect(detectTestNoise(output)).toEqual(["MCPD_READY", "[mcpd] foo"]);
+  });
+
+  it("does not match MCPD_READY as substring", () => {
+    const output = "got MCPD_READY signal\nMCPD_READY\n";
+    expect(detectTestNoise(output)).toEqual(["MCPD_READY"]);
+  });
+});

--- a/scripts/test-noise.ts
+++ b/scripts/test-noise.ts
@@ -1,0 +1,24 @@
+/**
+ * Detect production log noise in test output.
+ *
+ * Matches daemon log prefixes ([mcpd], [_claude], [_aliases], [alias-*])
+ * and production signals (MCPD_READY) that should not appear during test runs.
+ */
+
+/** Patterns that indicate production log output leaking into tests. */
+const NOISE_PATTERNS = [/^\[mcpd\]/, /^\[_claude\]/, /^\[_aliases\]/, /^\[alias[-\w]*\]/, /^MCPD_READY$/];
+
+/**
+ * Scan test output for production log noise lines.
+ * Returns the matched lines (trimmed).
+ */
+export function detectTestNoise(text: string): string[] {
+  const results: string[] = [];
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed && NOISE_PATTERNS.some((p) => p.test(trimmed))) {
+      results.push(trimmed);
+    }
+  }
+  return results;
+}


### PR DESCRIPTION
## Summary
- Adds production log noise detection to `scripts/check-coverage.ts` — counts lines matching daemon prefixes (`[mcpd]`, `[_claude]`, `[_aliases]`, `[alias-*]`) and `MCPD_READY` signals
- Extracts detection logic into `scripts/test-noise.ts` for testability, with 9 unit tests covering all patterns, edge cases, and clean output
- Configurable `NOISE_THRESHOLD` (set at 15) follows the existing coverage ratchet pattern — can be lowered toward zero as noise sources are fixed

## Test plan
- [x] `bun test scripts/test-noise.spec.ts` — 9/9 pass (pattern matching, whitespace trimming, substring rejection, multi-pattern)
- [x] `bun test` — all 2306 tests pass
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)