### PR TITLE
fix(command): remove redundant intersection type in claudeList session array (fixes #591)

### DIFF
--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -768,7 +768,7 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
     return;
   }
 
-  let sessions: (SessionInfo & { repoRoot?: string | null })[];
+  let sessions: SessionInfo[];
   try {
     sessions = JSON.parse(text);
   } catch {


### PR DESCRIPTION
## Summary
- Remove redundant `& { repoRoot?: string | null }` intersection from `sessions` variable type in `claudeList`
- `SessionInfo` extends `AgentSessionInfo` which already declares `repoRoot: string | null` as required — the optional intersection was misleading

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes  
- [x] `bun test` — all 2297 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)