### PR TITLE
refactor(command): extract SharedSessionDeps base type from ClaudeDeps (fixes #578)

### DIFF
--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -35,17 +35,21 @@ export interface PrStatus {
   state: string;
 }
 
-export interface ClaudeDeps {
+/** Shared dependency interface for session-based commands (claude, codex). */
+export interface SharedSessionDeps {
   callTool: (tool: string, args: Record<string, unknown>) => Promise<unknown>;
   printError: (msg: string) => void;
   exit: (code: number) => never;
-  getDiffStats: (worktreePath: string) => Promise<string | null>;
-  getPrStatus: (worktreePath: string) => Promise<PrStatus | null>;
   /** Run a command and return stdout + stderr + exit code. Used for git operations in `bye`. */
   exec: (
     cmd: string[],
     opts?: { env?: Record<string, string> },
   ) => { stdout: string; stderr: string; exitCode: number };
+}
+
+export interface ClaudeDeps extends SharedSessionDeps {
+  getDiffStats: (worktreePath: string) => Promise<string | null>;
+  getPrStatus: (worktreePath: string) => Promise<PrStatus | null>;
   /** Open a command in a terminal tab/window. Used for --headed spawn. */
   ttyOpen: (args: string[]) => Promise<void>;
   /** Resolve the git repo root for the current working directory. Returns null if not in a git repo. */
@@ -1436,7 +1440,7 @@ async function claudeWorktrees(args: string[], d: ClaudeDeps): Promise<void> {
 
 export async function resolveSessionId(
   prefix: string,
-  d: ClaudeDeps,
+  d: SharedSessionDeps,
   listTool = "claude_session_list",
 ): Promise<string> {
   const result = await d.callTool(listTool, {});

--- a/packages/command/src/commands/codex.spec.ts
+++ b/packages/command/src/commands/codex.spec.ts
@@ -12,11 +12,7 @@ function makeDeps(overrides?: Partial<CodexDeps>): CodexDeps {
     exit: mock((code: number) => {
       throw new ExitError(code);
     }) as CodexDeps["exit"],
-    getDiffStats: mock(async () => null),
-    getPrStatus: mock(async () => null),
     exec: mock(() => ({ stdout: "", stderr: "", exitCode: 0 })),
-    ttyOpen: mock(async () => {}),
-    getGitRoot: mock(() => null),
     ...overrides,
   };
 }

--- a/packages/command/src/commands/codex.ts
+++ b/packages/command/src/commands/codex.ts
@@ -11,7 +11,7 @@ import { applyJqFilter } from "../jq/index";
 import { c, printError as defaultPrintError, formatToolResult } from "../output";
 import { extractFullFlag, extractJqFlag, extractJsonFlag } from "../parse";
 
-import { type ClaudeDeps, parseLogArgs, parseWaitArgs, resolveSessionId } from "./claude";
+import { type SharedSessionDeps, parseLogArgs, parseWaitArgs, resolveSessionId } from "./claude";
 import { colorState, extractContentSummary, formatSessionShort } from "./session-display";
 
 // ── Constants ──
@@ -21,8 +21,8 @@ const P = "codex";
 
 // ── Dependency injection ──
 
-/** Codex deps are identical to ClaudeDeps — just route to _codex server. */
-export type CodexDeps = ClaudeDeps;
+/** Codex deps use only the shared session fields — no claude-specific helpers. */
+export type CodexDeps = SharedSessionDeps;
 
 const defaultDeps: CodexDeps = {
   callTool: (tool, args) => {
@@ -32,8 +32,6 @@ const defaultDeps: CodexDeps = {
   },
   printError: defaultPrintError,
   exit: (code) => process.exit(code),
-  getDiffStats: async () => null,
-  getPrStatus: async () => null,
   exec: (cmd, opts) => {
     const result = Bun.spawnSync(cmd, {
       stdout: "pipe",
@@ -46,8 +44,6 @@ const defaultDeps: CodexDeps = {
       exitCode: result.exitCode,
     };
   },
-  ttyOpen: async () => {},
-  getGitRoot: () => null,
 };
 
 // ── Entry point ──


### PR DESCRIPTION
## Summary
- Extract `SharedSessionDeps` interface with the four shared fields (`callTool`, `printError`, `exit`, `exec`) from `ClaudeDeps`
- `ClaudeDeps` now extends `SharedSessionDeps`, adding claude-specific fields (`getDiffStats`, `getPrStatus`, `ttyOpen`, `getGitRoot`)
- `CodexDeps = SharedSessionDeps` — no more no-op claude-specific fields in codex defaultDeps
- Widen `resolveSessionId` parameter from `ClaudeDeps` to `SharedSessionDeps` since it only uses shared fields

## Test plan
- [x] Typecheck passes — no type errors
- [x] Lint passes — no issues
- [x] All 2322 tests pass, 0 failures
- [x] Coverage thresholds maintained (89.83% functions, 88.99% lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)