### PR TITLE
feat(codex): add --json flag to mcx codex spawn for machine-parseable output (fixes #580)

### DIFF
--- a/packages/command/src/commands/codex.spec.ts
+++ b/packages/command/src/commands/codex.spec.ts
@@ -141,6 +141,16 @@ describe("parseCodexSpawnArgs", () => {
     const result = parseCodexSpawnArgs(["--task", "x"]);
     expect(result.wait).toBe(false);
   });
+
+  test("parses --json flag", () => {
+    const result = parseCodexSpawnArgs(["--task", "fix bug", "--json"]);
+    expect(result.json).toBe(true);
+  });
+
+  test("json defaults to false", () => {
+    const result = parseCodexSpawnArgs(["--task", "x"]);
+    expect(result.json).toBe(false);
+  });
 });
 
 // ── cmdCodex — subcommand dispatch ──
@@ -270,6 +280,62 @@ describe("codex spawn", () => {
     const deps = makeDeps();
     await expect(cmdCodex(["spawn", "--timeout", "abc"], deps)).rejects.toThrow(ExitError);
     expect(deps.printError).toHaveBeenCalledWith("--timeout must be a number");
+  });
+
+  test("--json outputs raw JSON to stdout", async () => {
+    const spawnResult = { sessionId: "s1-full-uuid", state: "active" };
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(spawnResult)),
+    });
+    const logCalls: string[] = [];
+    const origLog = console.log;
+    console.log = mock((...args: unknown[]) => logCalls.push(String(args[0])));
+    try {
+      await cmdCodex(["spawn", "--task", "do stuff", "--json"], deps);
+      const output = logCalls.join("");
+      const parsed = JSON.parse(output);
+      expect(parsed.sessionId).toBe("s1-full-uuid");
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("--json suppresses human-friendly stderr", async () => {
+    const spawnResult = { sessionId: "s1-full-uuid", state: "active" };
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(spawnResult)),
+    });
+    const errCalls: string[] = [];
+    const origLog = console.log;
+    const origErr = console.error;
+    console.log = mock(() => {});
+    console.error = mock((...args: unknown[]) => errCalls.push(String(args[0])));
+    try {
+      await cmdCodex(["spawn", "--task", "do stuff", "--json"], deps);
+      expect(errCalls.filter((l) => l.includes("Codex session started"))).toHaveLength(0);
+    } finally {
+      console.log = origLog;
+      console.error = origErr;
+    }
+  });
+
+  test("without --json prints human-friendly session info to stderr", async () => {
+    const spawnResult = { sessionId: "abc12345-full-uuid", state: "active" };
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(spawnResult)),
+    });
+    const errCalls: string[] = [];
+    const origLog = console.log;
+    const origErr = console.error;
+    console.log = mock(() => {});
+    console.error = mock((...args: unknown[]) => errCalls.push(String(args[0])));
+    try {
+      await cmdCodex(["spawn", "--task", "do stuff"], deps);
+      expect(errCalls.some((l) => l.includes("abc12345"))).toBe(true);
+    } finally {
+      console.log = origLog;
+      console.error = origErr;
+    }
   });
 });
 

--- a/packages/command/src/commands/codex.ts
+++ b/packages/command/src/commands/codex.ts
@@ -102,6 +102,7 @@ interface CodexSpawnArgs {
   timeout: number | undefined;
   model: string | undefined;
   wait: boolean;
+  json: boolean;
   error: string | undefined;
 }
 
@@ -111,12 +112,15 @@ export function parseCodexSpawnArgs(args: string[]): CodexSpawnArgs {
   let timeout: number | undefined;
   let model: string | undefined;
   let wait = false;
+  let json = false;
   const allow: string[] = [];
   let error: string | undefined;
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
-    if (arg === "--task" || arg === "-t") {
+    if (arg === "--json") {
+      json = true;
+    } else if (arg === "--task" || arg === "-t") {
       task = args[++i];
       if (!task) error = "--task requires a value";
     } else if (arg === "--allow") {
@@ -149,7 +153,7 @@ export function parseCodexSpawnArgs(args: string[]): CodexSpawnArgs {
     }
   }
 
-  return { task, allow, cwd, timeout, model, wait, error };
+  return { task, allow, cwd, timeout, model, wait, json, error };
 }
 
 async function codexSpawn(args: string[], d: CodexDeps): Promise<void> {
@@ -173,7 +177,23 @@ async function codexSpawn(args: string[], d: CodexDeps): Promise<void> {
   if (parsed.wait) toolArgs.wait = true;
 
   const result = await d.callTool(`${P}_prompt`, toolArgs);
-  console.log(formatToolResult(result));
+  const text = formatToolResult(result);
+
+  if (parsed.json) {
+    console.log(text);
+    return;
+  }
+
+  // Human-friendly: extract sessionId from JSON result when possible
+  try {
+    const data = JSON.parse(text) as { sessionId?: string };
+    if (data.sessionId) {
+      console.error(`Codex session started: ${data.sessionId.slice(0, 8)}`);
+    }
+  } catch {
+    // Not JSON — fall through
+  }
+  console.log(text);
 }
 
 // ── List ──
@@ -420,6 +440,7 @@ function printCodexUsage(): void {
 
 Usage:
   mcx codex spawn --task "description"    Start a new Codex session (non-blocking)
+  mcx codex spawn --task "..." --json     Machine-parseable JSON output
   mcx codex spawn "description"           Shorthand (positional task)
   mcx codex ls                            List active Codex sessions
   mcx codex send <session> <message>      Send follow-up prompt (non-blocking)
@@ -433,6 +454,7 @@ Usage:
 
 Spawn options:
   --task, -t "description"    Task prompt for Codex
+  --json                      Output raw JSON (for scripting/orchestration)
   --wait                      Block until Codex produces a result
   --model, -m <name>          Model to use (default: provider default)
   --allow <tools...>          Pre-approved tool patterns


### PR DESCRIPTION
## Summary
- Adds `--json` flag to `mcx codex spawn` that outputs raw JSON (including `sessionId`) for orchestrator consumption
- Without `--json`, adds a human-friendly stderr message showing the truncated session ID
- Updates help text to document the new flag

## Test plan
- [x] `parseCodexSpawnArgs` correctly parses `--json` flag (defaults to `false`)
- [x] `--json` outputs raw JSON to stdout with `sessionId` intact
- [x] `--json` suppresses human-friendly stderr message
- [x] Without `--json`, human-friendly session info printed to stderr
- [x] All 2327 existing tests pass
- [x] Typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)