### PR TITLE
fix(build): use epoch seconds in BUILD_VERSION for same-day rebuild detection (fixes #604)

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -30,11 +30,20 @@ export const PROTOCOL_VERSION: string =
 
 /**
  * Build version identifier.
- * Compiled binaries: just VERSION (the git tag IS the identifier).
+ * Compiled binaries: VERSION+epoch (epoch seconds set at compile time).
  * Dev mode: VERSION-dev suffix.
+ *
+ * The epoch suffix ensures two builds of the same version are distinguishable,
+ * which is critical for stale daemon detection (see #604).
  */
 declare const __COMPILED__: boolean;
-export const BUILD_VERSION: string = typeof __COMPILED__ !== "undefined" ? VERSION : `${VERSION}-dev`;
+declare const __BUILD_EPOCH__: string;
+export const BUILD_VERSION: string =
+  typeof __COMPILED__ !== "undefined"
+    ? typeof __BUILD_EPOCH__ !== "undefined"
+      ? `${VERSION}+${__BUILD_EPOCH__}`
+      : VERSION
+    : `${VERSION}-dev`;
 
 function computeDevProtocolHash(): string {
   try {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -26,7 +26,10 @@ hasher.update(ipcSource);
 const protocolHash = hasher.digest("hex").slice(0, 12);
 const defineFlag = `--define=__PROTOCOL_HASH__="${protocolHash}"`;
 const compiledFlag = "--define=__COMPILED__=true";
+const buildEpoch = Math.floor(Date.now() / 1000).toString();
+const epochFlag = `--define=__BUILD_EPOCH__="${buildEpoch}"`;
 console.log(`Protocol hash: ${protocolHash}`);
+console.log(`Build epoch: ${buildEpoch}`);
 
 // ── jq-web build plugin ──
 // Patches jq-web's Emscripten loader at build time:
@@ -149,6 +152,7 @@ async function buildBinary(config: BinaryBuildConfig, outfile: string, target?: 
       __PROTOCOL_HASH__: JSON.stringify(protocolHash),
       __VERSION__: JSON.stringify(version),
       __COMPILED__: "true",
+      __BUILD_EPOCH__: JSON.stringify(buildEpoch),
     },
   });
   if (!result.success) {
@@ -182,7 +186,7 @@ if (releaseMode) {
     const suffix = target.replace("bun-", "");
     console.log(`Building for ${suffix}...`);
     await Promise.all([
-      $`bun build --compile --minify ${defineFlag} ${compiledFlag} ${versionFlag} --target=${target} packages/daemon/src/main.ts ${daemonWorkers} --outfile dist/mcpd-${suffix}`,
+      $`bun build --compile --minify ${defineFlag} ${compiledFlag} ${versionFlag} ${epochFlag} --target=${target} packages/daemon/src/main.ts ${daemonWorkers} --outfile dist/mcpd-${suffix}`,
       buildBinary(mcxConfig, `dist/mcx-${suffix}`, target),
       buildBinary(mcpctlConfig, `dist/mcpctl-${suffix}`, target),
     ]);
@@ -192,7 +196,7 @@ if (releaseMode) {
 } else {
   // Dev build: current platform, simple names
   await Promise.all([
-    $`bun build --compile --minify ${defineFlag} ${compiledFlag} ${versionFlag} packages/daemon/src/main.ts ${daemonWorkers} --outfile dist/mcpd`,
+    $`bun build --compile --minify ${defineFlag} ${compiledFlag} ${versionFlag} ${epochFlag} packages/daemon/src/main.ts ${daemonWorkers} --outfile dist/mcpd`,
     buildBinary(mcxConfig, "dist/mcx"),
     buildBinary(mcpctlConfig, "dist/mcpctl"),
   ]);


### PR DESCRIPTION
## Summary
- Injects `__BUILD_EPOCH__` (unix epoch seconds) at compile time via `--define`
- `BUILD_VERSION` format changes from `0.2.0` to `0.2.0+1741700000` for compiled binaries
- Dev mode unchanged (`VERSION-dev`), graceful fallback if epoch not injected

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes  
- [x] `bun test` — all 2362 tests pass
- [x] Existing `_buildStaleDaemonWarning` tests still pass (they compare against `BUILD_VERSION` dynamically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)