### PR TITLE
fix(command): surface ShellError stderr in alias runner error output (fixes #628)

### DIFF
--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -42,6 +42,7 @@ import { checkDeprecatedName } from "./deprecation";
 import { readFileWithLimit } from "./file-read";
 import { SIZE_HINT, SIZE_OK, applyJqFilter, generateAnalysis } from "./jq/index";
 import {
+  extractErrorMessage,
   formatToolResult,
   printError,
   printRegistryList,
@@ -279,7 +280,7 @@ async function main(): Promise<void> {
       printError(err.message);
       process.exit(2);
     }
-    printError(err instanceof Error ? err.message : String(err));
+    printError(extractErrorMessage(err));
     if (process.env.MCX_DEBUG === "1" && err instanceof IpcCallError && err.remoteStack) {
       console.error("\nRemote stack trace:");
       console.error(err.remoteStack);

--- a/packages/command/src/output.spec.ts
+++ b/packages/command/src/output.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { AliasDetail } from "@mcp-cli/core";
-import { formatToolResult, printAliasDebug, printAliasList } from "./output";
+import { extractErrorMessage, formatToolResult, printAliasDebug, printAliasList } from "./output";
 
 describe("formatToolResult", () => {
   test("returns empty string for null", () => {
@@ -190,5 +190,43 @@ describe("printAliasDebug", () => {
     const output = captureStderr(() => printAliasDebug(alias));
     expect(output).not.toContain("description");
     expect(output).toContain("source");
+  });
+});
+
+describe("extractErrorMessage", () => {
+  test("returns message for regular Error", () => {
+    expect(extractErrorMessage(new Error("something broke"))).toBe("something broke");
+  });
+
+  test("returns String(err) for non-Error", () => {
+    expect(extractErrorMessage("raw string")).toBe("raw string");
+    expect(extractErrorMessage(42)).toBe("42");
+  });
+
+  test("returns stderr for ShellError-like object", () => {
+    const err = new Error("Failed with exit code 254");
+    Object.assign(err, {
+      stderr: Buffer.from("An error occurred (InvalidParameterValue)\n"),
+      exitCode: 254,
+    });
+    expect(extractErrorMessage(err)).toBe("An error occurred (InvalidParameterValue)");
+  });
+
+  test("falls back to message when stderr is empty", () => {
+    const err = new Error("Failed with exit code 1");
+    Object.assign(err, {
+      stderr: Buffer.from(""),
+      exitCode: 1,
+    });
+    expect(extractErrorMessage(err)).toBe("Failed with exit code 1");
+  });
+
+  test("falls back to message when stderr is whitespace-only", () => {
+    const err = new Error("Failed with exit code 1");
+    Object.assign(err, {
+      stderr: Buffer.from("  \n  "),
+      exitCode: 1,
+    });
+    expect(extractErrorMessage(err)).toBe("Failed with exit code 1");
   });
 });

--- a/packages/command/src/output.ts
+++ b/packages/command/src/output.ts
@@ -246,6 +246,21 @@ export function printRegistryList(entries: RegistryEntry[]): void {
   console.log(`\n${entries.length} server(s)`);
 }
 
+/**
+ * Extract a useful error message from an error object.
+ * Handles Bun's ShellError (which has stderr containing the real error)
+ * via duck-typing to avoid importing internal Bun types.
+ */
+export function extractErrorMessage(err: unknown): string {
+  if (!(err instanceof Error)) return String(err);
+  // Bun ShellError: has .stderr (Buffer) and .exitCode (number)
+  if ("stderr" in err && "exitCode" in err) {
+    const stderr = (err as Error & { stderr: { toString(): string } }).stderr?.toString()?.trim();
+    if (stderr) return stderr;
+  }
+  return err.message;
+}
+
 /** Print an error to stderr */
 export function printError(message: string): void {
   console.error(`${c.red}Error${c.reset}: ${message}`);


### PR DESCRIPTION
## Summary
- Added `extractErrorMessage()` helper that duck-types Bun's `ShellError` and extracts `.stderr` content instead of the opaque "Failed with exit code N" message
- Updated the top-level catch in `main.ts` to use the new helper
- When stderr is empty/whitespace, falls back to the original `.message`

## Test plan
- [x] 5 new unit tests for `extractErrorMessage` covering: regular Error, non-Error, ShellError with stderr, empty stderr fallback, whitespace-only stderr fallback
- [x] All 2367 tests pass
- [x] Typecheck, lint, coverage all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)