### PR TITLE
feat(control): add j/k scroll support to stats tab (fixes #446)

### DIFF
--- a/packages/control/src/app.tsx
+++ b/packages/control/src/app.tsx
@@ -7,7 +7,7 @@ import { Header } from "./components/header.js";
 import { Loading } from "./components/loading.js";
 import { LogViewer } from "./components/log-viewer.js";
 import { ServerList } from "./components/server-list.js";
-import { StatsView } from "./components/stats-view.js";
+import { StatsView, buildStatsLines } from "./components/stats-view.js";
 import { TabBar, buildBadges } from "./components/tab-bar.js";
 import { useClaudeSessions } from "./hooks/use-claude-sessions.js";
 import { useDaemon } from "./hooks/use-daemon.js";
@@ -17,6 +17,7 @@ import { filterLogLines, useLogs } from "./hooks/use-logs.js";
 import { useMetrics } from "./hooks/use-metrics.js";
 
 const LOG_VIEW_HEIGHT = 20;
+const STATS_VIEW_HEIGHT = 20;
 
 export function App() {
   const { status, error, loading, refresh } = useDaemon({ intervalMs: 2500 });
@@ -33,6 +34,7 @@ export function App() {
   const [permissionIndex, setPermissionIndex] = useState(0);
   const [denyReasonMode, setDenyReasonMode] = useState(false);
   const [denyReasonText, setDenyReasonText] = useState("");
+  const [statsScrollOffset, setStatsScrollOffset] = useState(0);
 
   const servers = status?.servers ?? [];
   // Poll faster on claude tab, slower off-tab (badge still updates)
@@ -53,6 +55,10 @@ export function App() {
   } = useLogs(servers, { enabled: view === "logs" });
 
   const filteredLogLines = useMemo(() => filterLogLines(logLines, filterText), [logLines, filterText]);
+  const statsLineCount = useMemo(
+    () => (metricsData ? buildStatsLines(metricsData, metricsError).length : 0),
+    [metricsData, metricsError],
+  );
   const prevFilterRef = useRef(filterText);
 
   // Auto-scroll: follow new lines at the tail, or force-jump when filter changes
@@ -134,6 +140,11 @@ export function App() {
       denyReasonText,
       setDenyReasonText,
     },
+    statsNav: {
+      scrollOffset: statsScrollOffset,
+      setScrollOffset: setStatsScrollOffset,
+      lineCount: statsLineCount,
+    },
   });
 
   if (loading && !status) return <Loading />;
@@ -177,7 +188,13 @@ export function App() {
           permissionIndex={permissionIndex}
         />
       ) : view === "stats" ? (
-        <StatsView metrics={metricsData} loading={metricsLoading} error={metricsError} />
+        <StatsView
+          metrics={metricsData}
+          loading={metricsLoading}
+          error={metricsError}
+          scrollOffset={statsScrollOffset}
+          height={STATS_VIEW_HEIGHT}
+        />
       ) : (
         <Box marginTop={1}>
           <Text dimColor>Coming soon</Text>

--- a/packages/control/src/components/footer.tsx
+++ b/packages/control/src/components/footer.tsx
@@ -103,6 +103,7 @@ export function Footer({ view, filterMode, filterText, denyReasonMode, denyReaso
       <Box marginTop={1}>
         <Text>
           {tabHints}
+          <Text dimColor>j/k</Text> scroll{"  "}
           <Text dimColor>esc</Text> back{"  "}
           <Text dimColor>q</Text> quit{"  "}
           <Text dimColor>s</Text> shutdown

--- a/packages/control/src/components/stats-view.spec.ts
+++ b/packages/control/src/components/stats-view.spec.ts
@@ -2,7 +2,15 @@ import { describe, expect, it } from "bun:test";
 import type { MetricsSnapshot } from "@mcp-cli/core";
 import { render } from "ink-testing-library";
 import React from "react";
-import { StatsView, aggregateByServer, findCounter, findGauge, percentile, topTools } from "./stats-view";
+import {
+  StatsView,
+  aggregateByServer,
+  buildStatsLines,
+  findCounter,
+  findGauge,
+  percentile,
+  topTools,
+} from "./stats-view";
 
 function makeSnapshot(overrides: Partial<MetricsSnapshot> = {}): MetricsSnapshot {
   return {
@@ -131,21 +139,66 @@ describe("topTools", () => {
   });
 });
 
+describe("buildStatsLines", () => {
+  it("returns lines array with dashboard, servers, and tools sections", () => {
+    const snap = makeSnapshot({
+      counters: [{ name: "mcpd_tool_calls_total", labels: { server: "a", tool: "search" }, value: 10 }],
+      gauges: [
+        { name: "mcpd_uptime_seconds", labels: {}, value: 60 },
+        { name: "mcpd_servers_total", labels: {}, value: 1 },
+        { name: "mcpd_servers_connected", labels: {}, value: 1 },
+      ],
+    });
+
+    const lines = buildStatsLines(snap, null);
+    // Dashboard header + 3 dashboard lines + spacer + servers header + 1 server + spacer + tools header + 1 tool
+    expect(lines.length).toBeGreaterThanOrEqual(4); // at least dashboard
+    expect(lines.length).toBeLessThan(50); // sanity check
+  });
+
+  it("grows with more servers", () => {
+    const snap1 = makeSnapshot({
+      counters: [{ name: "mcpd_tool_calls_total", labels: { server: "a", tool: "t" }, value: 1 }],
+      gauges: [{ name: "mcpd_uptime_seconds", labels: {}, value: 60 }],
+    });
+    const snap2 = makeSnapshot({
+      counters: [
+        { name: "mcpd_tool_calls_total", labels: { server: "a", tool: "t" }, value: 1 },
+        { name: "mcpd_tool_calls_total", labels: { server: "b", tool: "t" }, value: 1 },
+        { name: "mcpd_tool_calls_total", labels: { server: "c", tool: "t" }, value: 1 },
+      ],
+      gauges: [{ name: "mcpd_uptime_seconds", labels: {}, value: 60 }],
+    });
+
+    expect(buildStatsLines(snap2, null).length).toBeGreaterThan(buildStatsLines(snap1, null).length);
+  });
+});
+
 describe("StatsView", () => {
   it("shows loading state", () => {
-    const { lastFrame } = render(React.createElement(StatsView, { metrics: null, loading: true, error: null }));
+    const { lastFrame } = render(
+      React.createElement(StatsView, { metrics: null, loading: true, error: null, scrollOffset: 0, height: 20 }),
+    );
     expect(lastFrame()).toContain("Loading metrics");
   });
 
   it("shows error state", () => {
     const { lastFrame } = render(
-      React.createElement(StatsView, { metrics: null, loading: false, error: "connection refused" }),
+      React.createElement(StatsView, {
+        metrics: null,
+        loading: false,
+        error: "connection refused",
+        scrollOffset: 0,
+        height: 20,
+      }),
     );
     expect(lastFrame()).toContain("connection refused");
   });
 
   it("shows no metrics state", () => {
-    const { lastFrame } = render(React.createElement(StatsView, { metrics: null, loading: false, error: null }));
+    const { lastFrame } = render(
+      React.createElement(StatsView, { metrics: null, loading: false, error: null, scrollOffset: 0, height: 20 }),
+    );
     expect(lastFrame()).toContain("No metrics available");
   });
 
@@ -179,7 +232,9 @@ describe("StatsView", () => {
       ],
     });
 
-    const { lastFrame } = render(React.createElement(StatsView, { metrics: snap, loading: false, error: null }));
+    const { lastFrame } = render(
+      React.createElement(StatsView, { metrics: snap, loading: false, error: null, scrollOffset: 0, height: 40 }),
+    );
     const output = lastFrame() ?? "";
 
     expect(output).toContain("Dashboard");
@@ -201,7 +256,9 @@ describe("StatsView", () => {
       ],
     });
 
-    const { lastFrame } = render(React.createElement(StatsView, { metrics: snap, loading: false, error: null }));
+    const { lastFrame } = render(
+      React.createElement(StatsView, { metrics: snap, loading: false, error: null, scrollOffset: 0, height: 40 }),
+    );
     const output = lastFrame() ?? "";
 
     expect(output).toContain("Dashboard");
@@ -215,13 +272,70 @@ describe("StatsView", () => {
     expect(output).not.toContain("Top Tools");
   });
 
+  it("scrolls content when offset is applied", () => {
+    const snap = makeSnapshot({
+      counters: Array.from({ length: 20 }, (_, i) => ({
+        name: "mcpd_tool_calls_total",
+        labels: { server: `server-${i}`, tool: `tool-${i}` },
+        value: 10 - i,
+      })),
+      gauges: [
+        { name: "mcpd_uptime_seconds", labels: {}, value: 60 },
+        { name: "mcpd_servers_total", labels: {}, value: 20 },
+        { name: "mcpd_servers_connected", labels: {}, value: 20 },
+      ],
+    });
+
+    // With small height and offset=0, should show Dashboard
+    const { lastFrame: frame0 } = render(
+      React.createElement(StatsView, { metrics: snap, loading: false, error: null, scrollOffset: 0, height: 5 }),
+    );
+    expect(frame0()).toContain("Dashboard");
+
+    // With large offset, should skip past Dashboard to show later content
+    const { lastFrame: frameOffset } = render(
+      React.createElement(StatsView, { metrics: snap, loading: false, error: null, scrollOffset: 6, height: 5 }),
+    );
+    const output = frameOffset() ?? "";
+    // Should show server entries instead of Dashboard header
+    expect(output).toContain("server-");
+  });
+
+  it("shows scroll position indicator when content exceeds height", () => {
+    const snap = makeSnapshot({
+      counters: Array.from({ length: 20 }, (_, i) => ({
+        name: "mcpd_tool_calls_total",
+        labels: { server: `server-${i}`, tool: `tool-${i}` },
+        value: 10,
+      })),
+      gauges: [
+        { name: "mcpd_uptime_seconds", labels: {}, value: 60 },
+        { name: "mcpd_servers_total", labels: {}, value: 20 },
+        { name: "mcpd_servers_connected", labels: {}, value: 20 },
+      ],
+    });
+
+    const { lastFrame } = render(
+      React.createElement(StatsView, { metrics: snap, loading: false, error: null, scrollOffset: 0, height: 5 }),
+    );
+    const output = lastFrame() ?? "";
+    // Should contain position indicator like [1-5/N]
+    expect(output).toMatch(/\[\d+-\d+\/\d+\]/);
+  });
+
   it("shows stale data warning when error occurs after successful fetch", () => {
     const snap = makeSnapshot({
       gauges: [{ name: "mcpd_uptime_seconds", labels: {}, value: 60 }],
     });
 
     const { lastFrame } = render(
-      React.createElement(StatsView, { metrics: snap, loading: false, error: "connection refused" }),
+      React.createElement(StatsView, {
+        metrics: snap,
+        loading: false,
+        error: "connection refused",
+        scrollOffset: 0,
+        height: 40,
+      }),
     );
     const output = lastFrame() ?? "";
 

--- a/packages/control/src/components/stats-view.tsx
+++ b/packages/control/src/components/stats-view.tsx
@@ -1,11 +1,13 @@
 import type { MetricsSnapshot } from "@mcp-cli/core";
 import { Box, Text } from "ink";
-import React from "react";
+import type React from "react";
 
 interface StatsViewProps {
   metrics: MetricsSnapshot | null;
   loading: boolean;
   error: string | null;
+  scrollOffset: number;
+  height: number;
 }
 
 /** Find a counter value by name and optional label match. */
@@ -118,30 +120,16 @@ function formatUptime(seconds: number): string {
   return `${h}h ${m}m`;
 }
 
-export function StatsView({ metrics, loading, error }: StatsViewProps) {
-  if (loading && !metrics) {
-    return (
-      <Box marginLeft={2} marginTop={1}>
-        <Text dimColor>Loading metrics...</Text>
-      </Box>
-    );
-  }
-
-  if (error && !metrics) {
-    return (
-      <Box marginLeft={2} marginTop={1}>
-        <Text color="red">Error: {error}</Text>
-      </Box>
-    );
-  }
-
+/** Build all stats lines as a flat array of React elements. */
+export function buildStatsLines(metrics: MetricsSnapshot, error: string | null): React.ReactElement[] {
+  const lines: React.ReactElement[] = [];
   const staleError = error && metrics;
 
-  if (!metrics) {
-    return (
-      <Box marginLeft={2} marginTop={1}>
-        <Text dimColor>No metrics available.</Text>
-      </Box>
+  if (staleError) {
+    lines.push(
+      <Box key="stale" marginLeft={2}>
+        <Text color="yellow">⚠ stale data — {error}</Text>
+      </Box>,
     );
   }
 
@@ -155,7 +143,6 @@ export function StatsView({ metrics, loading, error }: StatsViewProps) {
   const serversConnected = findGauge(metrics, "mcpd_servers_connected");
   const activeSessions = findGauge(metrics, "mcpd_active_sessions");
 
-  // Aggregate tool call duration histogram for p50/p99
   let totalHistCount = 0;
   const mergedBuckets = new Map<number, number>();
   for (const h of metrics.histograms) {
@@ -173,91 +160,147 @@ export function StatsView({ metrics, loading, error }: StatsViewProps) {
   const p50 = percentile(sortedBuckets, totalHistCount, 0.5);
   const p99 = percentile(sortedBuckets, totalHistCount, 0.99);
 
+  // Dashboard header
+  lines.push(
+    <Box key="dash-hdr" marginLeft={2}>
+      <Text bold color="cyan">
+        Dashboard
+      </Text>
+    </Box>,
+  );
+  lines.push(
+    <Box key="dash-1" marginLeft={4}>
+      <Text>
+        <Text dimColor>uptime:</Text> {formatUptime(uptime)}
+        {"  "}
+        <Text dimColor>servers:</Text> {serversConnected}/{serversTotal}
+        {"  "}
+        <Text dimColor>sessions:</Text> {activeSessions}
+      </Text>
+    </Box>,
+  );
+  lines.push(
+    <Box key="dash-2" marginLeft={4}>
+      <Text>
+        <Text dimColor>tool calls:</Text> {totalCalls}
+        {"  "}
+        <Text dimColor>errors:</Text> <Text color={totalErrors > 0 ? "red" : undefined}>{totalErrors}</Text>
+        {"  "}
+        <Text dimColor>success:</Text>{" "}
+        {successRate === null ? (
+          <Text dimColor>—</Text>
+        ) : (
+          <Text color={successRate >= 99 ? "green" : successRate >= 90 ? "yellow" : "red"}>{fmt(successRate)}%</Text>
+        )}
+      </Text>
+    </Box>,
+  );
+  lines.push(
+    <Box key="dash-3" marginLeft={4}>
+      <Text>
+        <Text dimColor>p50:</Text> {fmt(p50)}ms{"  "}
+        <Text dimColor>p99:</Text> {fmt(p99)}ms{"  "}
+        <Text dimColor>ipc reqs:</Text> {ipcRequests}
+        {"  "}
+        <Text dimColor>ipc errs:</Text> {ipcErrors}
+      </Text>
+    </Box>,
+  );
+
+  // Per-server breakdown
   const serverStats = aggregateByServer(metrics);
+  if (serverStats.length > 0) {
+    lines.push(<Box key="srv-spacer" />);
+    lines.push(
+      <Box key="srv-hdr" marginLeft={2}>
+        <Text bold color="cyan">
+          Servers
+        </Text>
+      </Box>,
+    );
+    for (const s of serverStats) {
+      lines.push(
+        <Box key={`srv-${s.server}`} marginLeft={4}>
+          <Text>
+            <Text bold>{s.server}</Text>
+            {"  "}
+            <Text dimColor>calls:</Text> {s.calls}
+            {"  "}
+            <Text dimColor>errors:</Text> <Text color={s.errors > 0 ? "red" : undefined}>{s.errors}</Text>
+            {"  "}
+            <Text dimColor>avg:</Text> {fmt(s.avgMs)}ms
+          </Text>
+        </Box>,
+      );
+    }
+  }
+
+  // Top tools
   const topToolsList = topTools(metrics, 8);
+  if (topToolsList.length > 0) {
+    lines.push(<Box key="tool-spacer" />);
+    lines.push(
+      <Box key="tool-hdr" marginLeft={2}>
+        <Text bold color="cyan">
+          Top Tools
+        </Text>
+      </Box>,
+    );
+    for (const t of topToolsList) {
+      lines.push(
+        <Box key={`tool-${t.server}:${t.tool}`} marginLeft={4}>
+          <Text>
+            <Text dimColor>{t.server}/</Text>
+            <Text>{t.tool}</Text>
+            {"  "}
+            <Text dimColor>{t.calls} calls</Text>
+          </Text>
+        </Box>,
+      );
+    }
+  }
+
+  return lines;
+}
+
+export function StatsView({ metrics, loading, error, scrollOffset, height }: StatsViewProps) {
+  if (loading && !metrics) {
+    return (
+      <Box marginLeft={2} marginTop={1}>
+        <Text dimColor>Loading metrics...</Text>
+      </Box>
+    );
+  }
+
+  if (error && !metrics) {
+    return (
+      <Box marginLeft={2} marginTop={1}>
+        <Text color="red">Error: {error}</Text>
+      </Box>
+    );
+  }
+
+  if (!metrics) {
+    return (
+      <Box marginLeft={2} marginTop={1}>
+        <Text dimColor>No metrics available.</Text>
+      </Box>
+    );
+  }
+
+  const allLines = buildStatsLines(metrics, error);
+  const maxOffset = Math.max(0, allLines.length - height);
+  const effectiveOffset = Math.min(scrollOffset, maxOffset);
+  const visible = allLines.slice(effectiveOffset, effectiveOffset + height);
 
   return (
     <Box flexDirection="column" marginTop={1}>
-      {staleError && (
+      {visible}
+      {allLines.length > height && (
         <Box marginLeft={2}>
-          <Text color="yellow">⚠ stale data — {error}</Text>
-        </Box>
-      )}
-      {/* Aggregate dashboard */}
-      <Box marginLeft={2} flexDirection="column">
-        <Text bold color="cyan">
-          Dashboard
-        </Text>
-        <Box marginLeft={2} flexDirection="column">
-          <Text>
-            <Text dimColor>uptime:</Text> {formatUptime(uptime)}
-            {"  "}
-            <Text dimColor>servers:</Text> {serversConnected}/{serversTotal}
-            {"  "}
-            <Text dimColor>sessions:</Text> {activeSessions}
+          <Text dimColor>
+            [{effectiveOffset + 1}-{Math.min(effectiveOffset + height, allLines.length)}/{allLines.length}]
           </Text>
-          <Text>
-            <Text dimColor>tool calls:</Text> {totalCalls}
-            {"  "}
-            <Text dimColor>errors:</Text> <Text color={totalErrors > 0 ? "red" : undefined}>{totalErrors}</Text>
-            {"  "}
-            <Text dimColor>success:</Text>{" "}
-            {successRate === null ? (
-              <Text dimColor>—</Text>
-            ) : (
-              <Text color={successRate >= 99 ? "green" : successRate >= 90 ? "yellow" : "red"}>
-                {fmt(successRate)}%
-              </Text>
-            )}
-          </Text>
-          <Text>
-            <Text dimColor>p50:</Text> {fmt(p50)}ms{"  "}
-            <Text dimColor>p99:</Text> {fmt(p99)}ms{"  "}
-            <Text dimColor>ipc reqs:</Text> {ipcRequests}
-            {"  "}
-            <Text dimColor>ipc errs:</Text> {ipcErrors}
-          </Text>
-        </Box>
-      </Box>
-
-      {/* Per-server breakdown */}
-      {serverStats.length > 0 && (
-        <Box marginLeft={2} marginTop={1} flexDirection="column">
-          <Text bold color="cyan">
-            Servers
-          </Text>
-          {serverStats.map((s) => (
-            <Box key={s.server} marginLeft={2}>
-              <Text>
-                <Text bold>{s.server}</Text>
-                {"  "}
-                <Text dimColor>calls:</Text> {s.calls}
-                {"  "}
-                <Text dimColor>errors:</Text> <Text color={s.errors > 0 ? "red" : undefined}>{s.errors}</Text>
-                {"  "}
-                <Text dimColor>avg:</Text> {fmt(s.avgMs)}ms
-              </Text>
-            </Box>
-          ))}
-        </Box>
-      )}
-
-      {/* Top tools */}
-      {topToolsList.length > 0 && (
-        <Box marginLeft={2} marginTop={1} flexDirection="column">
-          <Text bold color="cyan">
-            Top Tools
-          </Text>
-          {topToolsList.map((t) => (
-            <Box key={`${t.server}:${t.tool}`} marginLeft={2}>
-              <Text>
-                <Text dimColor>{t.server}/</Text>
-                <Text>{t.tool}</Text>
-                {"  "}
-                <Text dimColor>{t.calls} calls</Text>
-              </Text>
-            </Box>
-          ))}
         </Box>
       )}
     </Box>

--- a/packages/control/src/hooks/use-keyboard.spec.ts
+++ b/packages/control/src/hooks/use-keyboard.spec.ts
@@ -4,6 +4,7 @@ import {
   type ClaudeNav,
   type LogsNav,
   type ServersNav,
+  type StatsNav,
   escAction,
   nextTab,
   prevTab,
@@ -107,6 +108,16 @@ describe("exported nav interfaces", () => {
     expect(nav.logSource.type).toBe("daemon");
     expect(nav.filterMode).toBe(false);
     expect(nav.filterText).toBe("");
+  });
+
+  test("StatsNav shape is structurally valid", () => {
+    const nav: StatsNav = {
+      scrollOffset: 0,
+      setScrollOffset: () => {},
+      lineCount: 0,
+    };
+    expect(nav.scrollOffset).toBe(0);
+    expect(nav.lineCount).toBe(0);
   });
 
   test("ClaudeNav shape is structurally valid", () => {

--- a/packages/control/src/hooks/use-keyboard.ts
+++ b/packages/control/src/hooks/use-keyboard.ts
@@ -65,15 +65,22 @@ export interface ClaudeNav {
   setDenyReasonText: (fn: string | ((prev: string) => string)) => void;
 }
 
+export interface StatsNav {
+  scrollOffset: number;
+  setScrollOffset: (fn: (offset: number) => number) => void;
+  lineCount: number;
+}
+
 interface UseKeyboardOptions {
   view: View;
   setView: (view: View) => void;
   serversNav: ServersNav;
   logsNav: LogsNav;
   claudeNav: ClaudeNav;
+  statsNav: StatsNav;
 }
 
-export function useKeyboard({ view, setView, serversNav, logsNav, claudeNav }: UseKeyboardOptions): void {
+export function useKeyboard({ view, setView, serversNav, logsNav, claudeNav, statsNav }: UseKeyboardOptions): void {
   const {
     servers,
     selectedIndex,
@@ -322,6 +329,19 @@ export function useKeyboard({ view, setView, serversNav, logsNav, claudeNav }: U
         return;
       }
 
+      return;
+    }
+
+    // -- Stats view --
+    if (view === "stats") {
+      if (key.upArrow || input === "k") {
+        statsNav.setScrollOffset((o) => Math.max(0, o - 1));
+        return;
+      }
+      if (key.downArrow || input === "j") {
+        statsNav.setScrollOffset((o) => Math.min(Math.max(0, statsNav.lineCount - 1), o + 1));
+        return;
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- Add j/k (and arrow key) scroll navigation to the stats tab for long server/tool lists
- Content is built as a flat line array and sliced by scroll offset + viewport height (20 lines), matching the logs tab pattern
- Shows position indicator `[start-end/total]` when content exceeds viewport
- Footer now displays `j/k scroll` hint on the stats tab

## Test plan
- [x] `buildStatsLines` unit tests verify line count grows with servers
- [x] Scroll offset test verifies content changes when offset applied
- [x] Position indicator test verifies `[N-M/total]` format appears
- [x] All existing StatsView tests updated and passing with new props
- [x] `StatsNav` interface shape test added
- [x] Full suite: 2367 tests pass, coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)