### PR TITLE
feat(control): add mail tab badge with unread count and yellow attention color (fixes #341)

### DIFF
--- a/packages/control/src/app.tsx
+++ b/packages/control/src/app.tsx
@@ -15,6 +15,7 @@ import type { View } from "./hooks/use-keyboard.js";
 import { useKeyboard } from "./hooks/use-keyboard.js";
 import { filterLogLines, useLogs } from "./hooks/use-logs.js";
 import { useMetrics } from "./hooks/use-metrics.js";
+import { useUnreadMail } from "./hooks/use-unread-mail.js";
 
 const LOG_VIEW_HEIGHT = 20;
 
@@ -52,6 +53,7 @@ export function App() {
     setSource: setLogSource,
   } = useLogs(servers, { enabled: view === "logs" });
 
+  const { unreadCount: unreadMailCount } = useUnreadMail();
   const filteredLogLines = useMemo(() => filterLogLines(logLines, filterText), [logLines, filterText]);
   const prevFilterRef = useRef(filterText);
 
@@ -141,7 +143,12 @@ export function App() {
   const needsAuth = servers.filter((s) => s.state === "error" && isAuthError(s.lastError));
   const pendingPermissionCount = sessions.reduce((n, s) => n + s.pendingPermissions, 0);
   const errorServerCount = servers.filter((s) => s.state === "error").length;
-  const badges = buildBadges({ sessionCount: sessions.length, pendingPermissionCount, errorServerCount });
+  const badges = buildBadges({
+    sessionCount: sessions.length,
+    pendingPermissionCount,
+    errorServerCount,
+    unreadMailCount,
+  });
 
   return (
     <Box flexDirection="column" padding={1}>

--- a/packages/control/src/components/tab-bar.spec.ts
+++ b/packages/control/src/components/tab-bar.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import { buildBadges } from "./tab-bar";
+
+describe("buildBadges", () => {
+  it("returns empty when all counts are zero", () => {
+    const badges = buildBadges({ sessionCount: 0, pendingPermissionCount: 0, errorServerCount: 0 });
+    expect(badges).toEqual({});
+  });
+
+  it("sets claude badge without color when no pending permissions", () => {
+    const badges = buildBadges({ sessionCount: 3, pendingPermissionCount: 0, errorServerCount: 0 });
+    expect(badges.claude).toEqual({ count: 3 });
+  });
+
+  it("sets claude badge with red color when pending permissions exist", () => {
+    const badges = buildBadges({ sessionCount: 2, pendingPermissionCount: 1, errorServerCount: 0 });
+    expect(badges.claude).toEqual({ count: 2, color: "red" });
+  });
+
+  it("sets servers badge with red color for error servers", () => {
+    const badges = buildBadges({ sessionCount: 0, pendingPermissionCount: 0, errorServerCount: 2 });
+    expect(badges.servers).toEqual({ count: 2, color: "red" });
+  });
+
+  it("sets mail badge with yellow color when unread mail exists", () => {
+    const badges = buildBadges({ sessionCount: 0, pendingPermissionCount: 0, errorServerCount: 0, unreadMailCount: 5 });
+    expect(badges.mail).toEqual({ count: 5, color: "yellow" });
+  });
+
+  it("does not set mail badge when unreadMailCount is zero", () => {
+    const badges = buildBadges({ sessionCount: 0, pendingPermissionCount: 0, errorServerCount: 0, unreadMailCount: 0 });
+    expect(badges.mail).toBeUndefined();
+  });
+
+  it("does not set mail badge when unreadMailCount is omitted", () => {
+    const badges = buildBadges({ sessionCount: 0, pendingPermissionCount: 0, errorServerCount: 0 });
+    expect(badges.mail).toBeUndefined();
+  });
+
+  it("sets all badges simultaneously", () => {
+    const badges = buildBadges({ sessionCount: 1, pendingPermissionCount: 1, errorServerCount: 1, unreadMailCount: 3 });
+    expect(badges.claude).toBeDefined();
+    expect(badges.servers).toBeDefined();
+    expect(badges.mail).toEqual({ count: 3, color: "yellow" });
+  });
+});

--- a/packages/control/src/components/tab-bar.tsx
+++ b/packages/control/src/components/tab-bar.tsx
@@ -21,6 +21,7 @@ export function buildBadges(opts: {
   sessionCount: number;
   pendingPermissionCount: number;
   errorServerCount: number;
+  unreadMailCount?: number;
 }): Partial<Record<View, TabBadge>> {
   const badges: Partial<Record<View, TabBadge>> = {};
   if (opts.sessionCount > 0) {
@@ -29,6 +30,9 @@ export function buildBadges(opts: {
   }
   if (opts.errorServerCount > 0) {
     badges.servers = { count: opts.errorServerCount, color: "red" };
+  }
+  if (opts.unreadMailCount && opts.unreadMailCount > 0) {
+    badges.mail = { count: opts.unreadMailCount, color: "yellow" };
   }
   return badges;
 }

--- a/packages/control/src/hooks/use-unread-mail.spec.ts
+++ b/packages/control/src/hooks/use-unread-mail.spec.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { Text } from "ink";
+import { render } from "ink-testing-library";
+import React, { type FC } from "react";
+import { type UseUnreadMailOptions, useUnreadMail } from "./use-unread-mail";
+
+interface HookState {
+  unreadCount: number;
+}
+
+const Harness: FC<{ opts: UseUnreadMailOptions; stateRef: { current: HookState } }> = ({ opts, stateRef }) => {
+  const result = useUnreadMail(opts);
+  stateRef.current = result;
+  return React.createElement(Text, null, "ok");
+};
+
+async function flush(ms = 10) {
+  await Bun.sleep(ms);
+}
+
+describe("useUnreadMail", () => {
+  const instances: ReturnType<typeof render>[] = [];
+
+  afterEach(() => {
+    for (const inst of instances) inst.unmount();
+    instances.length = 0;
+  });
+
+  function mount(opts: UseUnreadMailOptions) {
+    const stateRef: { current: HookState } = {
+      current: { unreadCount: 0 },
+    };
+    const instance = render(React.createElement(Harness, { opts, stateRef }));
+    instances.push(instance);
+    return { instance, stateRef };
+  }
+
+  it("polls readMail and sets unread count", async () => {
+    const ipcCallFn = async () => ({
+      messages: [
+        { id: 1, sender: "a", recipient: "b", subject: null, body: null, replyTo: null, read: false, createdAt: "" },
+        { id: 2, sender: "c", recipient: "b", subject: null, body: null, replyTo: null, read: false, createdAt: "" },
+      ],
+    });
+
+    const { stateRef } = mount({
+      ipcCallFn: ipcCallFn as UseUnreadMailOptions["ipcCallFn"],
+    });
+
+    await flush();
+    expect(stateRef.current.unreadCount).toBe(2);
+  });
+
+  it("starts at zero and stays zero on error", async () => {
+    const ipcCallFn = async () => {
+      throw new Error("daemon offline");
+    };
+
+    const { stateRef } = mount({
+      ipcCallFn: ipcCallFn as UseUnreadMailOptions["ipcCallFn"],
+    });
+
+    await flush();
+    expect(stateRef.current.unreadCount).toBe(0);
+  });
+
+  it("stops polling on unmount", async () => {
+    let callCount = 0;
+    const ipcCallFn = async () => {
+      callCount++;
+      return { messages: [] };
+    };
+
+    const { instance } = mount({
+      intervalMs: 30,
+      ipcCallFn: ipcCallFn as UseUnreadMailOptions["ipcCallFn"],
+    });
+
+    await flush(50);
+    instance.unmount();
+    instances.pop();
+    const countAtUnmount = callCount;
+
+    await flush(100);
+    expect(callCount).toBe(countAtUnmount);
+  });
+});

--- a/packages/control/src/hooks/use-unread-mail.ts
+++ b/packages/control/src/hooks/use-unread-mail.ts
@@ -1,0 +1,51 @@
+import { ipcCall } from "@mcp-cli/core";
+import { useEffect, useState } from "react";
+
+interface UseUnreadMailResult {
+  unreadCount: number;
+}
+
+export interface UseUnreadMailOptions {
+  intervalMs?: number;
+  /** Override ipcCall for testing (dependency injection). */
+  ipcCallFn?: typeof ipcCall;
+}
+
+export function useUnreadMail(opts: UseUnreadMailOptions = {}): UseUnreadMailResult {
+  const { intervalMs = 10_000, ipcCallFn = ipcCall } = opts;
+  const [unreadCount, setUnreadCount] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function poll() {
+      if (cancelled) return;
+      try {
+        const result = await ipcCallFn("readMail", { unreadOnly: true });
+        if (!cancelled) {
+          setUnreadCount(result.messages.length);
+        }
+      } catch {
+        // Silently ignore — badge just won't update
+      }
+    }
+
+    let timerId: ReturnType<typeof setTimeout> | undefined;
+
+    async function scheduleNext() {
+      await poll();
+      if (!cancelled) {
+        timerId = setTimeout(scheduleNext, intervalMs);
+      }
+    }
+
+    scheduleNext();
+
+    return () => {
+      cancelled = true;
+      if (timerId !== undefined) clearTimeout(timerId);
+    };
+  }, [intervalMs, ipcCallFn]);
+
+  return { unreadCount };
+}


### PR DESCRIPTION
## Summary
- Add `useUnreadMail` hook that polls daemon `readMail` IPC with `unreadOnly: true` every 10s
- Extend `buildBadges()` to accept `unreadMailCount` and emit a yellow badge on the Mail tab when unread messages exist
- Wire the hook into `App` component to pass unread count to the tab bar

## Test plan
- [x] `buildBadges` unit tests: mail badge appears with yellow color when count > 0, absent when 0 or omitted
- [x] `useUnreadMail` hook tests: polls and sets count, stays at 0 on error, stops on unmount
- [x] All 2378 tests pass, typecheck and lint clean, coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)