### PR TITLE
fix(control): move pager temp file cleanup to outer finally block (fixes #640)

### DIFF
--- a/packages/control/src/hooks/use-keyboard.ts
+++ b/packages/control/src/hooks/use-keyboard.ts
@@ -145,16 +145,16 @@ export function useKeyboard({ view, setView, serversNav, logsNav, claudeNav, sta
         if (process.stdin.isTTY) {
           process.stdin.setRawMode(true);
         }
-        try {
-          unlinkSync(tmpFile);
-        } catch {
-          /* already gone */
-        }
       }
     } catch (err) {
       console.error("[mcpctl] Pager error:", err instanceof Error ? err.message : String(err));
     } finally {
       pagerBusyRef.current = false;
+      try {
+        unlinkSync(tmpFile);
+      } catch {
+        /* file may not have been written */
+      }
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- Moved `unlinkSync` of pager temp file from inner `finally` (after pager exit) to outer `finally` block
- Prevents temp file leaks when errors occur between `Bun.write()` and the pager spawn (e.g., `setRawMode` throwing)
- No behavioral change for the happy path — cleanup still happens after pager exits

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes  
- [x] `bun test` passes (2461 tests)
- [x] Verified the outer finally always runs regardless of where errors occur in the try block

🤖 Generated with [Claude Code](https://claude.com/claude-code)