### PR TITLE
fix(control): add viewport scrolling for transcript list in Claude tab (fixes #641)

### DIFF
--- a/packages/control/src/app.tsx
+++ b/packages/control/src/app.tsx
@@ -20,6 +20,7 @@ import { useUnreadMail } from "./hooks/use-unread-mail.js";
 
 const LOG_VIEW_HEIGHT = 20;
 const STATS_VIEW_HEIGHT = 20;
+const TRANSCRIPT_VIEW_HEIGHT = 15;
 
 export function App() {
   const { status, error, loading, refresh } = useDaemon({ intervalMs: 2500 });
@@ -38,6 +39,7 @@ export function App() {
   const [denyReasonText, setDenyReasonText] = useState("");
   const [transcriptCursor, setTranscriptCursor] = useState<string | null>(null);
   const [expandedEntries, setExpandedEntries] = useState<ReadonlySet<string>>(new Set());
+  const [transcriptScrollOffset, setTranscriptScrollOffset] = useState(0);
   const [statsScrollOffset, setStatsScrollOffset] = useState(0);
 
   const servers = status?.servers ?? [];
@@ -87,6 +89,7 @@ export function App() {
     prevExpandedRef.current = expandedSession;
     setTranscriptCursor(null);
     setExpandedEntries(new Set());
+    setTranscriptScrollOffset(0);
   }
 
   // Clamp claudeSelectedIndex when sessions list shrinks
@@ -159,6 +162,9 @@ export function App() {
       transcriptEntries,
       expandedEntries,
       setExpandedEntries,
+      transcriptScrollOffset,
+      setTranscriptScrollOffset,
+      transcriptViewHeight: TRANSCRIPT_VIEW_HEIGHT,
     },
     statsNav: {
       scrollOffset: statsScrollOffset,
@@ -215,6 +221,8 @@ export function App() {
           transcriptError={transcriptError}
           transcriptSelectedEntry={transcriptCursor}
           transcriptExpandedEntries={expandedEntries}
+          transcriptScrollOffset={transcriptScrollOffset}
+          transcriptViewHeight={TRANSCRIPT_VIEW_HEIGHT}
         />
       ) : view === "stats" ? (
         <StatsView

--- a/packages/control/src/components/claude-session-detail.tsx
+++ b/packages/control/src/components/claude-session-detail.tsx
@@ -17,6 +17,8 @@ interface ClaudeSessionDetailProps {
   error: string | null;
   selectedEntry: string | null;
   expandedEntries: ReadonlySet<string>;
+  scrollOffset: number;
+  height: number;
 }
 
 /** Extract a short summary of the tool input for display. */
@@ -143,7 +145,14 @@ function ExpandedContent({ entry }: { entry: TranscriptEntry }) {
   );
 }
 
-export function ClaudeSessionDetail({ entries, error, selectedEntry, expandedEntries }: ClaudeSessionDetailProps) {
+export function ClaudeSessionDetail({
+  entries,
+  error,
+  selectedEntry,
+  expandedEntries,
+  scrollOffset,
+  height,
+}: ClaudeSessionDetailProps) {
   if (error) {
     return (
       <Box marginLeft={4}>
@@ -160,9 +169,14 @@ export function ClaudeSessionDetail({ entries, error, selectedEntry, expandedEnt
     );
   }
 
+  // Compute visible window
+  const maxOffset = Math.max(0, entries.length - height);
+  const effectiveOffset = Math.min(scrollOffset, maxOffset);
+  const visible = entries.slice(effectiveOffset, effectiveOffset + height);
+
   return (
     <Box flexDirection="column" marginLeft={4}>
-      {entries.map((entry) => {
+      {visible.map((entry) => {
         const arrow = entry.direction === "outbound" ? "→" : "←";
         const color = entry.direction === "outbound" ? "cyan" : "white";
         const key = entryKey(entry);
@@ -179,6 +193,11 @@ export function ClaudeSessionDetail({ entries, error, selectedEntry, expandedEnt
           </Box>
         );
       })}
+      {entries.length > height && (
+        <Text dimColor>
+          {effectiveOffset + 1}-{Math.min(effectiveOffset + height, entries.length)} of {entries.length}
+        </Text>
+      )}
     </Box>
   );
 }

--- a/packages/control/src/components/claude-session-list.tsx
+++ b/packages/control/src/components/claude-session-list.tsx
@@ -14,6 +14,8 @@ interface ClaudeSessionListProps {
   transcriptError: string | null;
   transcriptSelectedEntry: string | null;
   transcriptExpandedEntries: ReadonlySet<string>;
+  transcriptScrollOffset: number;
+  transcriptViewHeight: number;
 }
 
 const stateColor: Record<SessionStateEnum, string> = {
@@ -70,6 +72,8 @@ export function ClaudeSessionList({
   transcriptError,
   transcriptSelectedEntry,
   transcriptExpandedEntries,
+  transcriptScrollOffset,
+  transcriptViewHeight,
 }: ClaudeSessionListProps) {
   if (loading && sessions.length === 0) {
     return (
@@ -163,6 +167,8 @@ export function ClaudeSessionList({
                 error={transcriptError}
                 selectedEntry={transcriptSelectedEntry}
                 expandedEntries={transcriptExpandedEntries}
+                scrollOffset={transcriptScrollOffset}
+                height={transcriptViewHeight}
               />
             )}
           </Box>

--- a/packages/control/src/hooks/use-keyboard-claude.spec.ts
+++ b/packages/control/src/hooks/use-keyboard-claude.spec.ts
@@ -44,6 +44,9 @@ function makeNav(overrides: Partial<ClaudeNav> = {}): ClaudeNav {
     transcriptEntries: [],
     expandedEntries: new Set(),
     setExpandedEntries: mock(() => {}),
+    transcriptScrollOffset: 0,
+    setTranscriptScrollOffset: mock(() => {}),
+    transcriptViewHeight: 15,
     ...overrides,
   };
 }
@@ -241,5 +244,72 @@ describe("handleClaudeInput transcript navigation (expanded session)", () => {
     const consumed = handleClaudeInput("", { ...baseKey, return: true }, nav);
     expect(consumed).toBe(true);
     expect(nav.setExpandedEntries).not.toHaveBeenCalled();
+  });
+
+  test("j adjusts scroll offset when cursor moves past viewport", () => {
+    // 20 entries, viewport height 3, cursor at entry 2 (index 2), scroll at 0
+    const manyEntries = Array.from({ length: 20 }, (_, i) => ({
+      direction: "inbound" as const,
+      timestamp: i,
+      message: { type: "result", result: `entry-${i}` },
+    }));
+    let scrollResult = -1;
+    const nav = makeNav({
+      expandedSession: "sess-1",
+      transcriptEntries: manyEntries,
+      transcriptCursor: "2-inbound", // at index 2
+      transcriptScrollOffset: 0,
+      transcriptViewHeight: 3,
+      setTranscriptScrollOffset: mock((fn: (o: number) => number) => {
+        scrollResult = fn(0);
+      }),
+    });
+    handleClaudeInput("j", baseKey, nav);
+    // cursor moves to index 3, which is >= offset(0) + height(3), so scroll should advance
+    expect(scrollResult).toBe(1);
+  });
+
+  test("k adjusts scroll offset when cursor moves above viewport", () => {
+    const manyEntries = Array.from({ length: 20 }, (_, i) => ({
+      direction: "inbound" as const,
+      timestamp: i,
+      message: { type: "result", result: `entry-${i}` },
+    }));
+    let scrollResult = -1;
+    const nav = makeNav({
+      expandedSession: "sess-1",
+      transcriptEntries: manyEntries,
+      transcriptCursor: "5-inbound", // at index 5
+      transcriptScrollOffset: 5,
+      transcriptViewHeight: 3,
+      setTranscriptScrollOffset: mock((fn: (o: number) => number) => {
+        scrollResult = fn(5);
+      }),
+    });
+    handleClaudeInput("k", baseKey, nav);
+    // cursor moves to index 4, which is < offset(5), so scroll should move to 4
+    expect(scrollResult).toBe(4);
+  });
+
+  test("scroll offset unchanged when cursor stays in viewport", () => {
+    const manyEntries = Array.from({ length: 20 }, (_, i) => ({
+      direction: "inbound" as const,
+      timestamp: i,
+      message: { type: "result", result: `entry-${i}` },
+    }));
+    let scrollResult = -1;
+    const nav = makeNav({
+      expandedSession: "sess-1",
+      transcriptEntries: manyEntries,
+      transcriptCursor: "1-inbound", // at index 1
+      transcriptScrollOffset: 0,
+      transcriptViewHeight: 5,
+      setTranscriptScrollOffset: mock((fn: (o: number) => number) => {
+        scrollResult = fn(0);
+      }),
+    });
+    handleClaudeInput("j", baseKey, nav);
+    // cursor moves to index 2, still within viewport [0..5), so no scroll change
+    expect(scrollResult).toBe(0);
   });
 });

--- a/packages/control/src/hooks/use-keyboard-claude.ts
+++ b/packages/control/src/hooks/use-keyboard-claude.ts
@@ -25,6 +25,9 @@ export function handleClaudeInput(input: string, key: Key, nav: ClaudeNav): bool
     transcriptEntries,
     expandedEntries: _expandedEntries,
     setExpandedEntries,
+    transcriptScrollOffset: _transcriptScrollOffset,
+    setTranscriptScrollOffset,
+    transcriptViewHeight,
   } = nav;
 
   // -- Deny reason mode: capture text for denial message --
@@ -73,6 +76,13 @@ export function handleClaudeInput(input: string, key: Key, nav: ClaudeNav): bool
         const next = Math.max(0, (idx === -1 ? 0 : idx) - 1);
         return transcriptEntries[next] ? entryKey(transcriptEntries[next]) : cur;
       });
+      // Keep cursor visible in viewport
+      setTranscriptScrollOffset((offset) => {
+        const idx = transcriptCursor ? transcriptEntries.findIndex((e) => entryKey(e) === transcriptCursor) : 0;
+        const next = Math.max(0, (idx === -1 ? 0 : idx) - 1);
+        if (next < offset) return next;
+        return offset;
+      });
       return true;
     }
     if (key.downArrow || input === "j") {
@@ -80,6 +90,13 @@ export function handleClaudeInput(input: string, key: Key, nav: ClaudeNav): bool
         const idx = cur ? transcriptEntries.findIndex((e) => entryKey(e) === cur) : -1;
         const next = Math.min(transcriptEntries.length - 1, (idx === -1 ? -1 : idx) + 1);
         return transcriptEntries[next] ? entryKey(transcriptEntries[next]) : cur;
+      });
+      // Keep cursor visible in viewport
+      setTranscriptScrollOffset((offset) => {
+        const idx = transcriptCursor ? transcriptEntries.findIndex((e) => entryKey(e) === transcriptCursor) : -1;
+        const next = Math.min(transcriptEntries.length - 1, (idx === -1 ? -1 : idx) + 1);
+        if (next >= offset + transcriptViewHeight) return next - transcriptViewHeight + 1;
+        return offset;
       });
       return true;
     }

--- a/packages/control/src/hooks/use-keyboard.spec.ts
+++ b/packages/control/src/hooks/use-keyboard.spec.ts
@@ -138,6 +138,9 @@ describe("exported nav interfaces", () => {
       transcriptEntries: [],
       expandedEntries: new Set<string>(),
       setExpandedEntries: () => {},
+      transcriptScrollOffset: 0,
+      setTranscriptScrollOffset: () => 0,
+      transcriptViewHeight: 15,
     };
     expect(nav.sessions).toBeArray();
     expect(nav.expandedSession).toBeNull();

--- a/packages/control/src/hooks/use-keyboard.ts
+++ b/packages/control/src/hooks/use-keyboard.ts
@@ -76,6 +76,9 @@ export interface ClaudeNav {
   transcriptEntries: TranscriptEntry[];
   expandedEntries: ReadonlySet<string>;
   setExpandedEntries: (fn: (prev: ReadonlySet<string>) => ReadonlySet<string>) => void;
+  transcriptScrollOffset: number;
+  setTranscriptScrollOffset: (fn: (offset: number) => number) => void;
+  transcriptViewHeight: number;
 }
 
 export interface StatsNav {


### PR DESCRIPTION
## Summary
- Added `transcriptScrollOffset` state that tracks the viewport window for transcript entries in the Claude tab
- Keyboard navigation (j/k) auto-adjusts scroll offset to keep the cursor visible, following the same pattern as the logs and stats views
- Renders only the visible slice of entries plus a scroll indicator when the list exceeds viewport height

## Test plan
- [x] Added test: j scrolls down when cursor moves past viewport bottom
- [x] Added test: k scrolls up when cursor moves above viewport top
- [x] Added test: scroll offset stays unchanged when cursor stays within viewport
- [x] All 2464 tests pass, typecheck + lint clean, coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)