### PR TITLE
test(command): add handler coverage for add, remove, install (closes #126)

### DIFF
--- a/packages/command/src/commands/add.spec.ts
+++ b/packages/command/src/commands/add.spec.ts
@@ -1,9 +1,10 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { McpConfigFile, ServerConfig } from "@mcp-cli/core";
-import { buildServerConfig, parseAddArgs } from "./add";
+import { testOptions } from "../../../../test/test-options";
+import { buildServerConfig, cmdAdd, cmdAddJson, parseAddArgs } from "./add";
 import {
   addServerToConfig,
   readConfigFile,
@@ -536,5 +537,130 @@ describe("parseRemoveArgs edge cases", () => {
     const result = parseRemoveArgs(["-s", "local", "my-server"]);
     expect(result.scope).toBe("local");
     expect(result.name).toBe("my-server");
+  });
+});
+
+// -- cmdAdd handler tests --
+
+describe("cmdAdd", () => {
+  test("writes http server config to servers.json", async () => {
+    using opts = testOptions();
+    await cmdAdd(["--transport", "http", "my-server", "https://example.com/mcp"]);
+
+    const config = JSON.parse(readFileSync(opts.USER_SERVERS_PATH, "utf-8")) as McpConfigFile;
+    expect(config.mcpServers?.["my-server"]).toEqual({ type: "http", url: "https://example.com/mcp" });
+  });
+
+  test("writes stdio server config with command and args", async () => {
+    using opts = testOptions();
+    await cmdAdd(["--transport", "stdio", "my-stdio", "--", "npx", "-y", "some-pkg"]);
+
+    const config = JSON.parse(readFileSync(opts.USER_SERVERS_PATH, "utf-8")) as McpConfigFile;
+    expect(config.mcpServers?.["my-stdio"]).toEqual({
+      command: "npx",
+      args: ["-y", "some-pkg"],
+    });
+  });
+
+  test("writes http server with env vars and headers", async () => {
+    using opts = testOptions();
+    await cmdAdd([
+      "--transport",
+      "http",
+      "--env",
+      "API_KEY=secret",
+      "--header",
+      "Authorization: Bearer tok",
+      "my-server",
+      "https://example.com",
+    ]);
+
+    const config = JSON.parse(readFileSync(opts.USER_SERVERS_PATH, "utf-8")) as McpConfigFile;
+    expect(config.mcpServers?.["my-server"]).toEqual({
+      type: "http",
+      url: "https://example.com",
+      headers: { Authorization: "Bearer tok" },
+    });
+  });
+
+  test("overwrites existing server and preserves others", async () => {
+    using opts = testOptions({
+      files: {
+        "servers.json": { mcpServers: { existing: { command: "old" }, "my-server": { command: "old-cmd" } } },
+      },
+    });
+
+    await cmdAdd(["--transport", "http", "my-server", "https://new.com"]);
+
+    const config = JSON.parse(readFileSync(opts.USER_SERVERS_PATH, "utf-8")) as McpConfigFile;
+    expect(config.mcpServers?.["my-server"]).toEqual({ type: "http", url: "https://new.com" });
+    expect(config.mcpServers?.existing).toEqual({ command: "old" });
+  });
+
+  test("exits with 1 on empty args", async () => {
+    using _opts = testOptions();
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    try {
+      await expect(cmdAdd([])).rejects.toThrow("process.exit");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+});
+
+// -- cmdAddJson handler tests --
+
+describe("cmdAddJson", () => {
+  test("writes server config from raw JSON", async () => {
+    using opts = testOptions();
+    await cmdAddJson(["my-server", '{"type":"http","url":"https://example.com"}']);
+
+    const config = JSON.parse(readFileSync(opts.USER_SERVERS_PATH, "utf-8")) as McpConfigFile;
+    expect(config.mcpServers?.["my-server"]).toEqual({ type: "http", url: "https://example.com" });
+  });
+
+  test("writes stdio config from raw JSON", async () => {
+    using opts = testOptions();
+    await cmdAddJson(["my-stdio", '{"command":"node","args":["server.js"]}']);
+
+    const config = JSON.parse(readFileSync(opts.USER_SERVERS_PATH, "utf-8")) as McpConfigFile;
+    expect(config.mcpServers?.["my-stdio"]).toEqual({ command: "node", args: ["server.js"] });
+  });
+
+  test("respects --scope flag", async () => {
+    using opts = testOptions();
+    // User scope writes to USER_SERVERS_PATH
+    await cmdAddJson(["my-server", '{"command":"cmd"}', "--scope", "user"]);
+
+    const config = JSON.parse(readFileSync(opts.USER_SERVERS_PATH, "utf-8")) as McpConfigFile;
+    expect(config.mcpServers?.["my-server"]).toEqual({ command: "cmd" });
+  });
+
+  test("throws on invalid JSON", async () => {
+    using _opts = testOptions();
+    await expect(cmdAddJson(["name", "not-json"])).rejects.toThrow("Invalid JSON");
+  });
+
+  test("throws on config without command or url", async () => {
+    using _opts = testOptions();
+    await expect(cmdAddJson(["name", '{"type":"unknown"}'])).rejects.toThrow(
+      "must have either 'command' (stdio) or 'url' (http/sse)",
+    );
+  });
+
+  test("exits with 1 on insufficient args", async () => {
+    using _opts = testOptions();
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    try {
+      await expect(cmdAddJson(["only-name"])).rejects.toThrow("process.exit");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    } finally {
+      exitSpy.mockRestore();
+    }
   });
 });

--- a/packages/command/src/commands/install.spec.ts
+++ b/packages/command/src/commands/install.spec.ts
@@ -1,5 +1,9 @@
-import { describe, expect, test } from "bun:test";
-import { parseInstallArgs } from "./install";
+import { describe, expect, spyOn, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import type { McpConfigFile } from "@mcp-cli/core";
+import { testOptions } from "../../../../test/test-options";
+import type { RegistryResponse } from "../registry/client";
+import { type InstallDeps, cmdInstall, parseInstallArgs } from "./install";
 
 describe("parseInstallArgs", () => {
   test("parses slug only", () => {
@@ -76,5 +80,151 @@ describe("parseInstallArgs", () => {
   test("parses --no-cache flag", () => {
     const result = parseInstallArgs(["sentry", "--no-cache"]);
     expect(result.noCache).toBe(true);
+  });
+});
+
+// -- cmdInstall handler tests --
+
+/** Build a fake registry response for a server with a streamable-http remote. */
+function fakeRegistryResponse(slug: string, url: string): RegistryResponse {
+  return {
+    servers: [
+      {
+        server: {
+          name: slug,
+          title: slug,
+          description: `The ${slug} server`,
+          version: "1.0.0",
+          remotes: [{ type: "streamable-http", url }],
+        },
+        _meta: {
+          "com.anthropic.api/mcp-registry": {
+            slug,
+            displayName: slug.charAt(0).toUpperCase() + slug.slice(1),
+            oneLiner: `${slug} integration`,
+            isAuthless: true,
+          },
+        },
+      },
+    ],
+    metadata: { count: 1 },
+  };
+}
+
+function makeDeps(response: RegistryResponse): InstallDeps {
+  return { searchRegistry: async () => response };
+}
+
+describe("cmdInstall", () => {
+  test("installs http server from registry", async () => {
+    using opts = testOptions();
+    const deps = makeDeps(fakeRegistryResponse("sentry", "https://mcp.sentry.io"));
+
+    await cmdInstall(["sentry"], deps);
+
+    const config = JSON.parse(readFileSync(opts.USER_SERVERS_PATH, "utf-8")) as McpConfigFile;
+    expect(config.mcpServers?.sentry).toEqual({ type: "http", url: "https://mcp.sentry.io" });
+  });
+
+  test("uses --as name for server key", async () => {
+    using opts = testOptions();
+    const deps = makeDeps(fakeRegistryResponse("sentry", "https://mcp.sentry.io"));
+
+    await cmdInstall(["sentry", "--as", "my-sentry"], deps);
+
+    const config = JSON.parse(readFileSync(opts.USER_SERVERS_PATH, "utf-8")) as McpConfigFile;
+    expect(config.mcpServers?.["my-sentry"]).toEqual({ type: "http", url: "https://mcp.sentry.io" });
+    expect(config.mcpServers?.sentry).toBeUndefined();
+  });
+
+  test("throws when slug not found in registry", async () => {
+    using _opts = testOptions();
+    const deps = makeDeps({ servers: [], metadata: { count: 0 } });
+
+    await expect(cmdInstall(["nonexistent"], deps)).rejects.toThrow('Server "nonexistent" not found');
+  });
+
+  test("overwrites existing server", async () => {
+    using opts = testOptions({
+      files: { "servers.json": { mcpServers: { sentry: { command: "old" } } } },
+    });
+    const deps = makeDeps(fakeRegistryResponse("sentry", "https://mcp.sentry.io"));
+
+    await cmdInstall(["sentry"], deps);
+
+    const config = JSON.parse(readFileSync(opts.USER_SERVERS_PATH, "utf-8")) as McpConfigFile;
+    expect(config.mcpServers?.sentry).toEqual({ type: "http", url: "https://mcp.sentry.io" });
+  });
+
+  test("installs stdio server from package", async () => {
+    using opts = testOptions();
+    const response: RegistryResponse = {
+      servers: [
+        {
+          server: {
+            name: "filesystem",
+            title: "Filesystem",
+            description: "File system access",
+            version: "1.0.0",
+            packages: [
+              {
+                registryType: "npm",
+                identifier: "@modelcontextprotocol/server-filesystem",
+                runtimeHint: "npx",
+                transport: { type: "stdio" },
+              },
+            ],
+          },
+          _meta: {
+            "com.anthropic.api/mcp-registry": {
+              slug: "filesystem",
+              displayName: "Filesystem",
+              oneLiner: "File system access",
+              isAuthless: true,
+            },
+          },
+        },
+      ],
+      metadata: { count: 1 },
+    };
+    const deps = makeDeps(response);
+
+    await cmdInstall(["filesystem"], deps);
+
+    const config = JSON.parse(readFileSync(opts.USER_SERVERS_PATH, "utf-8")) as McpConfigFile;
+    expect(config.mcpServers?.filesystem).toEqual({
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-filesystem"],
+    });
+  });
+
+  test("exits with 1 on empty args", async () => {
+    using _opts = testOptions();
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    try {
+      await expect(cmdInstall([])).rejects.toThrow("process.exit");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  test("outputs JSON when --json flag is used", async () => {
+    using opts = testOptions();
+    const deps = makeDeps(fakeRegistryResponse("sentry", "https://mcp.sentry.io"));
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+
+    try {
+      await cmdInstall(["sentry", "--json"], deps);
+
+      expect(logSpy).toHaveBeenCalledTimes(1);
+      const output = JSON.parse(logSpy.mock.calls[0][0] as string);
+      expect(output.name).toBe("sentry");
+      expect(output.config).toEqual({ type: "http", url: "https://mcp.sentry.io" });
+    } finally {
+      logSpy.mockRestore();
+    }
   });
 });

--- a/packages/command/src/commands/install.ts
+++ b/packages/command/src/commands/install.ts
@@ -7,9 +7,15 @@
 
 import { printError } from "../output";
 import { extractJsonFlag, parseEnvVar, parseScope } from "../parse";
-import { searchRegistry } from "../registry/client";
+import { type RegistryOpts, type RegistryResponse, searchRegistry as realSearchRegistry } from "../registry/client";
 import { buildConfigFromSelection, selectTransport } from "../registry/transport";
 import { CONFIG_SCOPES, type ConfigScope, addServerToConfig, resolveConfigPath } from "./config-file";
+
+export interface InstallDeps {
+  searchRegistry: (query: string, opts?: RegistryOpts) => Promise<RegistryResponse>;
+}
+
+const defaultDeps: InstallDeps = { searchRegistry: realSearchRegistry };
 
 export interface ParsedInstallArgs {
   slug: string;
@@ -57,7 +63,8 @@ export function parseInstallArgs(args: string[]): ParsedInstallArgs {
   return { slug, name, scope, env, json, noCache };
 }
 
-export async function cmdInstall(args: string[]): Promise<void> {
+export async function cmdInstall(args: string[], deps?: InstallDeps): Promise<void> {
+  const d = deps ?? defaultDeps;
   if (args.length === 0) {
     printError("Usage: mcx install <slug> [--as name] [--scope user|project] [--env KEY=VALUE]");
     process.exit(1);
@@ -66,7 +73,7 @@ export async function cmdInstall(args: string[]): Promise<void> {
   const parsed = parseInstallArgs(args);
 
   // Search registry for exact slug match
-  const result = await searchRegistry(parsed.slug, { noCache: parsed.noCache });
+  const result = await d.searchRegistry(parsed.slug, { noCache: parsed.noCache });
   const entry = result.servers.find((s) => s._meta["com.anthropic.api/mcp-registry"].slug === parsed.slug);
 
   if (!entry) {

--- a/packages/command/src/commands/remove.spec.ts
+++ b/packages/command/src/commands/remove.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import type { McpConfigFile } from "@mcp-cli/core";
+import { testOptions } from "../../../../test/test-options";
+import { writeConfigFile } from "./config-file";
+import { cmdRemove, parseRemoveArgs } from "./remove";
+
+// parseRemoveArgs tests live in add.spec.ts — these cover the cmdRemove handler
+
+describe("cmdRemove", () => {
+  test("removes an existing server from config", async () => {
+    using opts = testOptions({
+      files: {
+        "servers.json": {
+          mcpServers: {
+            keep: { type: "http", url: "https://keep.com" },
+            removeme: { type: "http", url: "https://remove.com" },
+          },
+        },
+      },
+    });
+
+    await cmdRemove(["removeme"]);
+
+    const config = JSON.parse(readFileSync(opts.USER_SERVERS_PATH, "utf-8")) as McpConfigFile;
+    expect(config.mcpServers?.keep).toEqual({ type: "http", url: "https://keep.com" });
+    expect(config.mcpServers?.removeme).toBeUndefined();
+  });
+
+  test("exits with 1 when server not found", async () => {
+    using _opts = testOptions({
+      files: { "servers.json": { mcpServers: {} } },
+    });
+
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    try {
+      await expect(cmdRemove(["nonexistent"])).rejects.toThrow("process.exit");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  test("exits with 1 on empty args", async () => {
+    using _opts = testOptions();
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    try {
+      await expect(cmdRemove([])).rejects.toThrow("process.exit");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  test("preserves other servers when removing one", async () => {
+    using opts = testOptions({
+      files: {
+        "servers.json": {
+          mcpServers: {
+            alpha: { command: "a" },
+            beta: { command: "b" },
+            gamma: { command: "c" },
+          },
+        },
+      },
+    });
+
+    await cmdRemove(["beta"]);
+
+    const config = JSON.parse(readFileSync(opts.USER_SERVERS_PATH, "utf-8")) as McpConfigFile;
+    expect(config.mcpServers?.alpha).toEqual({ command: "a" });
+    expect(config.mcpServers?.gamma).toEqual({ command: "c" });
+    expect(config.mcpServers?.beta).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `cmdAdd` and `cmdAddJson` handler tests to `add.spec.ts` using `testOptions()` — verifies config file writes, overwrites, env/headers, and empty-args exit
- Create `remove.spec.ts` with `cmdRemove` handler tests — covers removal, not-found exit, and preservation of other servers
- Add DI `deps` param to `cmdInstall` (following `completions.ts` pattern) and test handler in `install.spec.ts` — covers http/stdio installs, `--as` aliasing, not-found errors, overwrites, and `--json` output

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — 2483 tests pass, 0 failures
- [x] Coverage improved: `add.ts` 98.5%, `remove.ts` 100%, `install.ts` 81%

🤖 Generated with [Claude Code](https://claude.com/claude-code)