### PR TITLE
refactor(test): make pollUntil support async predicates (fixes #361)

### DIFF
--- a/test/daemon-integration.spec.ts
+++ b/test/daemon-integration.spec.ts
@@ -11,7 +11,7 @@ setDefaultTimeout(30_000);
 import { existsSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { TestDaemon } from "./harness";
-import { echoServerConfig, rpc, startTestDaemon } from "./harness";
+import { echoServerConfig, pollUntil, rpc, startTestDaemon } from "./harness";
 
 // ---------------------------------------------------------------------------
 // P1: Daemon lifecycle
@@ -127,16 +127,13 @@ describe("P2: Config hot reload", () => {
     // Write echo server config
     writeFileSync(join(daemon.dir, "servers.json"), JSON.stringify({ mcpServers: { echo: echoServerConfig() } }));
 
-    // Poll with deadline — short backoff, exits as soon as condition is met
-    const deadline = Date.now() + 10_000;
-    let found = false;
-    while (!found && Date.now() < deadline) {
-      await Bun.sleep(100);
-      const after = await rpc(daemon.socketPath, "listServers");
+    // Poll with async predicate — exits as soon as condition is met
+    const sock = daemon.socketPath;
+    await pollUntil(async () => {
+      const after = await rpc(sock, "listServers");
       const servers = after.result as Array<{ name: string }>;
-      found = servers.some((s) => s.name === "echo");
-    }
-    expect(found).toBe(true);
+      return servers.some((s) => s.name === "echo");
+    }, 10_000);
   });
 
   test("removing a server from config is detected", async () => {
@@ -149,16 +146,13 @@ describe("P2: Config hot reload", () => {
     // Remove all servers
     writeFileSync(join(daemon.dir, "servers.json"), JSON.stringify({ mcpServers: {} }));
 
-    // Poll with deadline — short backoff, exits as soon as condition is met
-    const deadline = Date.now() + 10_000;
-    let removed = false;
-    while (!removed && Date.now() < deadline) {
-      await Bun.sleep(100);
-      const after = await rpc(daemon.socketPath, "listServers");
+    // Poll with async predicate — exits as soon as condition is met
+    const sock = daemon.socketPath;
+    await pollUntil(async () => {
+      const after = await rpc(sock, "listServers");
       const afterServers = after.result as Array<{ name: string }>;
-      removed = afterServers.every((s) => s.name.startsWith("_"));
-    }
-    expect(removed).toBe(true);
+      return afterServers.every((s) => s.name.startsWith("_"));
+    }, 10_000);
   });
 });
 

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -116,12 +116,15 @@ export async function startTestDaemon(
  * Never use a fixed sleep to wait for async side effects — poll instead.
  * Throws with a descriptive message on timeout so test failures are visible.
  */
-export async function pollUntil(condition: () => boolean | undefined | null | number, timeoutMs = 5000): Promise<void> {
+export async function pollUntil(
+  condition: () => Promise<boolean | undefined | null | number> | boolean | undefined | null | number,
+  timeoutMs = 5000,
+): Promise<void> {
   const deadline = Date.now() + timeoutMs;
-  while (!condition() && Date.now() < deadline) {
+  while (!(await condition()) && Date.now() < deadline) {
     await Bun.sleep(10);
   }
-  if (!condition()) throw new Error(`pollUntil: condition not met within ${timeoutMs}ms`);
+  if (!(await condition())) throw new Error(`pollUntil: condition not met within ${timeoutMs}ms`);
 }
 
 /** Send an IPC RPC request directly to a daemon's Unix socket */


### PR DESCRIPTION
## Summary
- Updated `pollUntil` in `test/harness.ts` to accept `() => Promise<boolean> | boolean` and `await` the condition
- Replaced two inline deadline-based polling loops in `test/daemon-integration.spec.ts` (adding/removing server hot-reload tests) with calls to the now-async-capable `pollUntil`

## Test plan
- [x] All 2461 existing tests pass — no regressions from the signature change
- [x] Typecheck passes
- [x] Lint passes
- [x] Existing sync callers of `pollUntil` continue to work (backward compatible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)