### PR TITLE
feat(scripts): migrate test-failure-log from JSONL to SQLite (fixes #466)

### DIFF
--- a/scripts/test-failure-log.spec.ts
+++ b/scripts/test-failure-log.spec.ts
@@ -115,10 +115,9 @@ describe("test-failure-log", () => {
       expect(result.error).toBe("some error message");
     });
 
-    it("handles concurrent writes from same process", () => {
+    it("handles sequential writes from same process", () => {
       const dbPath = makeDbPath();
 
-      // Simulate two concurrent append operations
       appendFailures([makeEntry({ test: "writer-1" })], dbPath);
       appendFailures([makeEntry({ test: "writer-2" })], dbPath);
 

--- a/scripts/test-failure-log.ts
+++ b/scripts/test-failure-log.ts
@@ -3,6 +3,11 @@
  *
  * Uses bun:sqlite for concurrent-safe persistence at ~/.mcp-cli/test-failures.db.
  * Failures are preserved across ephemeral worktree lifetimes.
+ *
+ * Migration note: This replaces the previous JSONL-based test-failures.log.
+ * Existing .log data is not migrated — this is intentional since the JSONL
+ * format had no stable schema and the data is ephemeral diagnostic info.
+ * The old test-failures.log file can be safely deleted.
  */
 
 import { Database } from "bun:sqlite";
@@ -40,7 +45,7 @@ function openDb(dbPath: string): Database {
 
   const db = new Database(dbPath, { create: true });
   db.exec("PRAGMA journal_mode = WAL");
-  db.exec("PRAGMA busy_timeout = 3000");
+  db.exec("PRAGMA busy_timeout = 5000");
   db.exec(`
     CREATE TABLE IF NOT EXISTS test_failures (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -78,12 +83,12 @@ export function closeDb(dbPath: string): void {
 
 /** Resolve the database path from env or default */
 export function getDbPath(): string {
-  const dir = process.env.MCP_CLI_DIR || `${process.env.HOME}/.mcp-cli`;
-  return `${dir}/test-failures.db`;
+  const dir = process.env.MCP_CLI_DIR;
+  if (dir) return `${dir}/test-failures.db`;
+  const home = process.env.HOME;
+  if (!home) throw new Error("Neither MCP_CLI_DIR nor HOME is set");
+  return `${home}/.mcp-cli/test-failures.db`;
 }
-
-/** @deprecated Use getDbPath() instead */
-export const getLogPath = getDbPath;
 
 /** Extract current git context (worktree name, branch, PR number) */
 export function getGitContext(): { worktree: string; branch: string; pr: number | null } {
@@ -171,7 +176,7 @@ export function appendFailures(entries: TestFailureEntry[], dbPath?: string): vo
     VALUES ($timestamp, $file, $test, $worktree, $branch, $pr, $exitCode, $retryPassed, $duration, $error)
   `);
 
-  const insertMany = db.transaction((rows: TestFailureEntry[]) => {
+  const insertAndPrune = db.transaction((rows: TestFailureEntry[]) => {
     for (const e of rows) {
       insert.run({
         $timestamp: e.timestamp,
@@ -186,12 +191,10 @@ export function appendFailures(entries: TestFailureEntry[], dbPath?: string): vo
         $error: e.error,
       });
     }
+    pruneIfNeeded(db);
   });
 
-  insertMany(entries);
-
-  // Prune if over limit
-  pruneIfNeeded(db);
+  insertAndPrune(entries);
 }
 
 /** Delete rows beyond MAX_ENTRIES, keeping the most recent. */
@@ -250,7 +253,7 @@ export function readFailures(dbPath?: string, filters?: { since?: number; file?:
     branch: r.branch,
     pr: r.pr,
     exitCode: r.exit_code,
-    retryPassed: r.retry_passed === 1,
+    retryPassed: r.retry_passed !== 0,
     duration: r.duration,
     error: r.error,
   }));

--- a/scripts/test-failures.spec.ts
+++ b/scripts/test-failures.spec.ts
@@ -78,6 +78,26 @@ describe("test-failures CLI", () => {
       expect(result.file).toBeNull();
       expect(result.json).toBe(false);
     });
+
+    it("throws on --top without value", () => {
+      expect(() => parseArgs(["node", "script", "--top"])).toThrow("--top requires a numeric argument");
+    });
+
+    it("throws on --top with non-numeric value", () => {
+      expect(() => parseArgs(["node", "script", "--top", "abc"])).toThrow("--top value must be a positive integer");
+    });
+
+    it("throws on --since without value", () => {
+      expect(() => parseArgs(["node", "script", "--since"])).toThrow("--since requires an argument");
+    });
+
+    it("throws on --since with invalid format", () => {
+      expect(() => parseArgs(["node", "script", "--since", "xyz"])).toThrow("Invalid --since value");
+    });
+
+    it("throws on --file without value", () => {
+      expect(() => parseArgs(["node", "script", "--file"])).toThrow("--file requires an argument");
+    });
   });
 
   describe("formatOutput", () => {

--- a/scripts/test-failures.ts
+++ b/scripts/test-failures.ts
@@ -29,13 +29,11 @@ export function parseArgs(argv: string[]): {
       case "--top": {
         const val = args[++i];
         if (val === undefined) {
-          console.error("Error: --top requires a numeric argument");
-          process.exit(1);
+          throw new Error("--top requires a numeric argument");
         }
         const parsed = Number.parseInt(val, 10);
         if (Number.isNaN(parsed) || parsed <= 0) {
-          console.error(`Error: --top value must be a positive integer, got: ${val}`);
-          process.exit(1);
+          throw new Error(`--top value must be a positive integer, got: ${val}`);
         }
         top = parsed;
         break;
@@ -43,13 +41,11 @@ export function parseArgs(argv: string[]): {
       case "--since": {
         const val = args[++i];
         if (val === undefined) {
-          console.error("Error: --since requires an argument (e.g. 7d, 24h, 30m)");
-          process.exit(1);
+          throw new Error("--since requires an argument (e.g. 7d, 24h, 30m)");
         }
         const match = val.match(/^(\d+)([dhm])$/);
         if (!match) {
-          console.error(`Invalid --since value: ${val} (expected e.g. 7d, 24h, 30m)`);
-          process.exit(1);
+          throw new Error(`Invalid --since value: ${val} (expected e.g. 7d, 24h, 30m)`);
         }
         const num = Number.parseInt(match[1], 10);
         const unit = match[2];
@@ -60,8 +56,7 @@ export function parseArgs(argv: string[]): {
       case "--file": {
         const val = args[++i];
         if (val === undefined) {
-          console.error("Error: --file requires an argument");
-          process.exit(1);
+          throw new Error("--file requires an argument");
         }
         file = val;
         break;
@@ -139,7 +134,15 @@ export function formatOutput(entries: TestFailureEntry[], opts: { top: number | 
 }
 
 function main(): void {
-  const { top, since, file, json } = parseArgs(process.argv);
+  let parsed: ReturnType<typeof parseArgs>;
+  try {
+    parsed = parseArgs(process.argv);
+  } catch (err) {
+    console.error(`Error: ${(err as Error).message}`);
+    process.exit(1);
+  }
+
+  const { top, since, file, json } = parsed;
 
   // Push filters to SQL
   const entries = readFailures(undefined, {
@@ -150,4 +153,6 @@ function main(): void {
   console.log(formatOutput(entries, { top, json }));
 }
 
-main();
+if (import.meta.main) {
+  main();
+}


### PR DESCRIPTION
## Summary
- Replace JSONL file (`test-failures.log`) with SQLite database (`test-failures.db`) using `bun:sqlite` for concurrent-safe writes via WAL mode + busy_timeout
- Push `--since` and `--file` filtering to SQL queries instead of in-memory filtering
- Add input validation for `--top` (must be positive integer), `--since` (must have value), and `--file` (must have value) CLI args
- Add test coverage for `test-failures.ts` CLI query tool (new `test-failures.spec.ts`)
- Add `closeDb()` export for proper test cleanup

## Test plan
- [x] All 30 tests pass across both spec files (184ms)
- [x] Full suite: 2481 tests pass, 0 failures
- [x] Roundtrip test: write → read preserves all fields including null PR, boolean retryPassed
- [x] Pruning test: 10,050 entries → pruned to 10,000, keeping most recent
- [x] Filter tests: `since` and `file` filters pushed to SQL
- [x] CLI arg validation: `--top` rejects NaN/missing, `--since` rejects missing value
- [x] `formatOutput` tested: empty, JSON, top aggregation, default table, truncation at 50
- [x] typecheck + lint + coverage all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)