### PR TITLE
feat(daemon): expose _metrics as virtual MCP server (fixes #290)

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -41,7 +41,7 @@ import { closeDaemonLogFile, installDaemonLogCapture, installDaemonLogFile } fro
 import { StateDb } from "./db/state";
 import { IpcServer } from "./ipc-server";
 import { metrics } from "./metrics";
-import { MetricsServer, buildMetricsToolCache } from "./metrics-server";
+import { MetricsServer } from "./metrics-server";
 import { reapOrphanedSessions } from "./orphan-reaper";
 import { ServerPool } from "./server-pool";
 
@@ -395,8 +395,11 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
       "_metrics",
       (async () => {
         try {
-          const { client: metricsClient, transport: metricsTransport } = await metricsServer.start();
-          const metricsTools = buildMetricsToolCache();
+          const {
+            client: metricsClient,
+            transport: metricsTransport,
+            tools: metricsTools,
+          } = await metricsServer.start();
           pool.registerVirtualServer("_metrics", metricsClient, metricsTransport, metricsTools);
           logger.info("[mcpd] Metrics server started");
         } catch (err) {

--- a/packages/daemon/src/metrics-server.spec.ts
+++ b/packages/daemon/src/metrics-server.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { MetricsCollector } from "./metrics";
-import { METRICS_SERVER_NAME, MetricsServer, buildMetricsToolCache } from "./metrics-server";
+import { METRICS_SERVER_NAME, MetricsServer } from "./metrics-server";
 
 describe("METRICS_SERVER_NAME", () => {
   test("is _metrics", () => {
@@ -8,34 +8,58 @@ describe("METRICS_SERVER_NAME", () => {
   });
 });
 
-describe("buildMetricsToolCache", () => {
-  test("returns 3 tools", () => {
-    const cache = buildMetricsToolCache();
-    expect(cache.size).toBe(3);
-    expect(cache.has("get_metrics")).toBe(true);
-    expect(cache.has("get_metric")).toBe(true);
-    expect(cache.has("get_health")).toBe(true);
-  });
-
-  test("tool entries have correct server name", () => {
-    const cache = buildMetricsToolCache();
-    for (const [, info] of cache) {
-      expect(info.server).toBe("_metrics");
+describe("start() returns tool cache", () => {
+  test("returns 3 tools with correct server name", async () => {
+    const collector = new MetricsCollector();
+    const server = new MetricsServer(collector);
+    try {
+      const { tools } = await server.start();
+      expect(tools.size).toBe(3);
+      expect(tools.has("get_metrics")).toBe(true);
+      expect(tools.has("get_metric")).toBe(true);
+      expect(tools.has("get_health")).toBe(true);
+      for (const [, info] of tools) {
+        expect(info.server).toBe("_metrics");
+      }
+    } finally {
+      await server.stop();
     }
   });
 });
 
 describe("MetricsServer", () => {
-  test("start returns client and transport", async () => {
+  test("start returns client, transport, and tools", async () => {
     const collector = new MetricsCollector();
     const server = new MetricsServer(collector);
     try {
-      const { client, transport } = await server.start();
+      const { client, transport, tools } = await server.start();
       expect(client).toBeDefined();
       expect(transport).toBeDefined();
+      expect(tools).toBeDefined();
     } finally {
       await server.stop();
     }
+  });
+
+  test("double start throws", async () => {
+    const collector = new MetricsCollector();
+    const server = new MetricsServer(collector);
+    try {
+      await server.start();
+      await expect(server.start()).rejects.toThrow("MetricsServer already started");
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("can restart after stop", async () => {
+    const collector = new MetricsCollector();
+    const server = new MetricsServer(collector);
+    await server.start();
+    await server.stop();
+    const { client } = await server.start();
+    expect(client).toBeDefined();
+    await server.stop();
   });
 
   test("get_metrics returns full snapshot", async () => {
@@ -101,6 +125,24 @@ describe("MetricsServer", () => {
 
       expect(data.series).toHaveLength(1);
       expect(data.series[0].value).toBe(7);
+    } finally {
+      await server.stop();
+    }
+  });
+
+  test("get_metric returns error for non-string label values", async () => {
+    const collector = new MetricsCollector();
+    collector.counter("mcpd_tool_calls_total", { server: "foo" }).inc(3);
+    const server = new MetricsServer(collector);
+    try {
+      const { client } = await server.start();
+      const result = await client.callTool({
+        name: "get_metric",
+        arguments: { name: "mcpd_tool_calls_total", labels: { server: 42 } },
+      });
+      expect(result.isError).toBe(true);
+      const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+      expect(text).toContain("must be a string");
     } finally {
       await server.stop();
     }

--- a/packages/daemon/src/metrics-server.ts
+++ b/packages/daemon/src/metrics-server.ts
@@ -54,7 +54,11 @@ export class MetricsServer {
 
   constructor(private metrics: MetricsCollector) {}
 
-  async start(): Promise<{ client: Client; transport: Transport }> {
+  async start(): Promise<{ client: Client; transport: Transport; tools: Map<string, ToolInfo> }> {
+    if (this.server) {
+      throw new Error("MetricsServer already started");
+    }
+
     const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
     this.serverTransport = serverTransport;
     this.clientTransport = clientTransport;
@@ -94,7 +98,7 @@ export class MetricsServer {
     this.client = new Client({ name: `mcp-cli/${METRICS_SERVER_NAME}`, version: "0.1.0" });
     await this.client.connect(clientTransport);
 
-    return { client: this.client, transport: this.clientTransport };
+    return { client: this.client, transport: this.clientTransport, tools: buildMetricsToolCache() };
   }
 
   async stop(): Promise<void> {
@@ -126,7 +130,22 @@ export class MetricsServer {
       };
     }
 
-    const labelFilter = (args?.labels ?? {}) as Record<string, string>;
+    const rawLabels = args?.labels ?? {};
+    if (typeof rawLabels !== "object" || rawLabels === null || Array.isArray(rawLabels)) {
+      return {
+        content: [{ type: "text", text: '"labels" must be an object with string values' }],
+        isError: true,
+      };
+    }
+    for (const [k, v] of Object.entries(rawLabels)) {
+      if (typeof v !== "string") {
+        return {
+          content: [{ type: "text", text: `Label "${k}" must be a string, got ${typeof v}` }],
+          isError: true,
+        };
+      }
+    }
+    const labelFilter = rawLabels as Record<string, string>;
     const snap = this.metrics.toJSON();
     const matches: Array<Record<string, unknown>> = [];
 


### PR DESCRIPTION
## Summary
- Add `_metrics` virtual MCP server with 3 read-only tools: `get_metrics` (full snapshot), `get_metric` (filter by name/labels), `get_health` (summary)
- Registered in daemon startup alongside `_aliases` and `_claude`, with proper shutdown cleanup
- Enables `mcx call _metrics get_metrics` and alias scripts to query daemon health via standard tool calls

## Test plan
- [x] 10 new tests in `metrics-server.spec.ts` covering all 3 tools, error cases, and label filtering
- [x] Full test suite passes (2479 tests, 0 failures)
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)