### PR TITLE
fix(daemon): filter keep_alive from session transcript ring buffer (fixes #665)

### DIFF
--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -437,6 +437,35 @@ describe("ClaudeWsServer", () => {
     }
   });
 
+  test("transcript excludes keep_alive messages", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    const port = await server.start();
+
+    server.prepareSession("test-session", { prompt: "Hello" });
+    server.spawnClaude("test-session");
+
+    const ws = await connectMockClaude(port, "test-session");
+    try {
+      await waitForMessage(ws);
+      ws.send(systemInitMessage("test-session"));
+      // Send keep_alive messages — these should be filtered out
+      ws.send(`${JSON.stringify({ type: "keep_alive" })}\n`);
+      ws.send(`${JSON.stringify({ type: "keep_alive" })}\n`);
+      ws.send(assistantMessage("test-session"));
+
+      // Wait for the assistant message to appear (outbound user + system/init + assistant = 3)
+      await pollUntil(() => (server?.getTranscript("test-session")?.length ?? 0) >= 3);
+
+      const transcript = server.getTranscript("test-session");
+      // Should have user, system/init, assistant — but NO keep_alive entries
+      expect(transcript.every((e) => e.message.type !== "keep_alive")).toBe(true);
+      expect(transcript.length).toBe(3);
+    } finally {
+      ws.close();
+    }
+  });
+
   test("waitForResult rejects on timeout", async () => {
     const ms = mockSpawn();
     server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -1235,6 +1235,7 @@ export class ClaudeWsServer {
   }
 
   private addTranscript(session: WsSession, direction: "inbound" | "outbound", message: NdjsonMessage): void {
+    if (message.type === "keep_alive") return;
     session.transcript.push({ timestamp: Date.now(), direction, message });
     if (session.transcript.length > MAX_TRANSCRIPT) {
       session.transcript.shift();


### PR DESCRIPTION
## Summary
- Skip `keep_alive` messages in `addTranscript()` so they don't fill the 100-entry ring buffer during idle sessions
- Idle sessions previously lost all meaningful transcript content within ~50 minutes, making `mcx claude log` useless

## Test plan
- [x] Added test verifying keep_alive messages are excluded from transcript
- [x] Existing transcript tests still pass (109 tests)
- [x] Full test suite passes (2589 tests)
- [x] typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)