### PR TITLE
fix(command): resolve worktree path client-side when daemon returns null cwd (fixes #671)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -1349,6 +1349,37 @@ describe("mcx claude bye", () => {
     }
   });
 
+  test("resolves cwd from worktree name when daemon returns null cwd", async () => {
+    const callTool: ClaudeDeps["callTool"] = mock(async (tool: string) => {
+      if (tool === "claude_session_list") return toolResult(SESSION_LIST);
+      // Daemon-created worktree: cwd and repoRoot are null
+      return toolResult({ ended: true, worktree: "claude-abc123", cwd: null, repoRoot: null });
+    });
+    const exec: ClaudeDeps["exec"] = mock((cmd: string[]) => {
+      if (cmd.includes("status")) return { stdout: "", stderr: "", exitCode: 0 };
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const printError = mock(() => {});
+    const deps = makeDeps({ callTool, exec, printError });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["bye", "def"], deps);
+      // Should still attempt cleanup by resolving cwd from process.cwd()
+      const removeCalls = (exec as ReturnType<typeof mock>).mock.calls.filter((c: unknown[]) =>
+        (c[0] as string[]).includes("remove"),
+      );
+      expect(removeCalls.length).toBe(1);
+      // The worktree path should contain the worktree name
+      expect(removeCalls[0][0].join(" ")).toContain("claude-abc123");
+      const errOutput = printError.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+      expect(errOutput).toContain("Removed worktree:");
+    } finally {
+      console.log = origLog;
+    }
+  });
+
   test("warns about dirty worktree after bye", async () => {
     const callTool: ClaudeDeps["callTool"] = mock(async (tool: string) => {
       if (tool === "claude_session_list") return toolResult(SESSION_LIST);

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -841,8 +841,16 @@ async function claudeBye(args: string[], d: ClaudeDeps): Promise<void> {
   const byeResult = parseByeResult(result);
   console.log(formatToolResult(result));
 
-  if (byeResult.worktree && byeResult.cwd) {
-    cleanupWorktree(byeResult.worktree, byeResult.cwd, d, byeResult.repoRoot);
+  if (byeResult.worktree) {
+    if (byeResult.cwd) {
+      cleanupWorktree(byeResult.worktree, byeResult.cwd, d, byeResult.repoRoot);
+    } else {
+      // Daemon-created worktrees: cwd is null — resolve from local repo root
+      const repoRoot = process.cwd();
+      const wtConfig = readWorktreeConfig(repoRoot);
+      const cwd = resolveWorktreePath(repoRoot, byeResult.worktree, wtConfig);
+      cleanupWorktree(byeResult.worktree, cwd, d, repoRoot);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- When `mcx claude bye` receives a worktree name but null `cwd` from the daemon (default daemon-created worktrees), the client now resolves the worktree path locally using `process.cwd()` + `resolveWorktreePath()` instead of skipping cleanup entirely
- This fixes the root cause of worktree accumulation after sprint runs (~48+ orphaned worktrees per sprint)

## Test plan
- [x] Added test: "resolves cwd from worktree name when daemon returns null cwd" — verifies cleanup runs when daemon returns `{ worktree: "...", cwd: null, repoRoot: null }`
- [x] All 217 existing bye/worktree tests pass (no regressions)
- [x] Full suite: 2589 tests pass, typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)