### PR TITLE
feat(core): support Python string prefixes in parsePythonRepr (fixes #667)

### DIFF
--- a/packages/core/src/python-repr.spec.ts
+++ b/packages/core/src/python-repr.spec.ts
@@ -82,6 +82,54 @@ describe("pythonReprToJson", () => {
     expect(result).toEqual({ bell: "\u0007", vt: "\u000b", null: "\u0000" });
   });
 
+  it("strips b'' prefix and parses byte string as regular string", () => {
+    expect(pythonReprToJson("{'data': b'hello'}")).toBe('{"data": "hello"}');
+  });
+
+  it("strips B'' prefix (uppercase)", () => {
+    expect(pythonReprToJson("B'hello'")).toBe('"hello"');
+  });
+
+  it("strips u'' prefix", () => {
+    expect(pythonReprToJson("{'name': u'Alice'}")).toBe('{"name": "Alice"}');
+  });
+
+  it("strips f'' prefix", () => {
+    expect(pythonReprToJson("f'formatted'")).toBe('"formatted"');
+  });
+
+  it("handles r'' raw string — backslashes are literal", () => {
+    const result = pythonReprToJson("r'\\path\\to\\file'");
+    expect(JSON.parse(result)).toBe("\\path\\to\\file");
+  });
+
+  it("handles r'' raw string with Windows path", () => {
+    const result = pythonReprToJson("{'path': r'C:\\Users\\test\\file.txt'}");
+    expect(JSON.parse(result)).toEqual({ path: "C:\\Users\\test\\file.txt" });
+  });
+
+  it("handles br'' two-character prefix", () => {
+    expect(pythonReprToJson("br'hello'")).toBe('"hello"');
+  });
+
+  it("handles rb'' two-character prefix", () => {
+    expect(pythonReprToJson("rb'hello'")).toBe('"hello"');
+  });
+
+  it("handles rb'' raw mode — backslashes literal", () => {
+    const result = pythonReprToJson("rb'\\n\\t'");
+    expect(JSON.parse(result)).toBe("\\n\\t");
+  });
+
+  it("handles prefix on double-quoted strings", () => {
+    expect(pythonReprToJson('b"hello"')).toBe('"hello"');
+  });
+
+  it("handles r prefix on double-quoted strings", () => {
+    const result = pythonReprToJson('r"C:\\Users\\test"');
+    expect(JSON.parse(result)).toBe("C:\\Users\\test");
+  });
+
   it("does not infinite loop on bare + or -", () => {
     const input = "{'a': +, 'b': -}";
     // Should complete without hanging — output may not be valid JSON
@@ -123,6 +171,14 @@ describe("parsePythonRepr", () => {
       total: 1,
       has_more: true,
     });
+  });
+
+  it("parses dict with byte string values", () => {
+    expect(parsePythonRepr("{'data': b'hello'}")).toEqual({ data: "hello" });
+  });
+
+  it("parses dict with raw string path", () => {
+    expect(parsePythonRepr("{'path': r'C:\\Users\\test'}")).toEqual({ path: "C:\\Users\\test" });
   });
 
   it("returns original string on unparseable input", () => {

--- a/packages/core/src/python-repr.ts
+++ b/packages/core/src/python-repr.ts
@@ -2,12 +2,11 @@
  * Converts Python repr strings to valid JSON.
  *
  * Handles: single-quoted strings, True/False/None, tuple syntax (,) → arrays,
- * nested structures. Uses a character-level tokenizer to avoid regex pitfalls
- * with embedded quotes (e.g., `{'msg': "it's broken"}`).
+ * nested structures, and Python string prefixes (b'', r'', u'', f'', br'', etc.).
+ * Uses a character-level tokenizer to avoid regex pitfalls with embedded quotes
+ * (e.g., `{'msg': "it's broken"}`).
  *
  * Limitations:
- * - Python string prefixes (b'', r'', u'', f'') are not supported and will
- *   produce invalid JSON, causing silent fallback to the raw string.
  * - Octal escapes (\177) are not converted and will produce invalid JSON.
  */
 
@@ -60,12 +59,35 @@ export function pythonReprToJson(input: string): string {
       continue;
     }
 
+    // String prefix detection — b'', r'', f'', u'', br'', rb'', fr'', rf'', etc.
+    // Must be checked before the word handler to avoid emitting the prefix as a bare word.
+    const prefix = tryStringPrefix(input, i, len);
+    if (prefix) {
+      i = prefix.quotePos;
+      // Fall through — i now points at the quote, handled below
+    }
+
+    const isRaw = prefix?.isRaw ?? false;
+
     // Single-quoted string → double-quoted JSON string
-    if (ch === "'") {
+    if (input[i] === "'") {
       i++;
       const str: string[] = [];
       while (i < len && input[i] !== "'") {
         if (input[i] === "\\") {
+          if (isRaw) {
+            // Raw strings: backslashes are literal, except \' which ends the string
+            if (i + 1 < len && input[i + 1] === "'") {
+              // \' in raw string — literal apostrophe
+              str.push("'");
+              i += 2;
+            } else {
+              // Literal backslash — must be escaped for JSON
+              str.push("\\\\");
+              i++;
+            }
+            continue;
+          }
           i++;
           if (i >= len) break;
           const esc = input[i];
@@ -148,16 +170,23 @@ export function pythonReprToJson(input: string): string {
     }
 
     // Double-quoted string — pass through (already JSON-compatible)
-    if (ch === '"') {
+    // Note: uses input[i] not ch, because prefix detection may have advanced i
+    if (input[i] === '"') {
       out.push('"');
       i++;
       while (i < len && input[i] !== '"') {
         if (input[i] === "\\") {
-          out.push(input[i]);
-          i++;
-          if (i < len) {
+          if (isRaw) {
+            // Raw strings: backslashes are literal
+            out.push("\\\\");
+            i++;
+          } else {
             out.push(input[i]);
             i++;
+            if (i < len) {
+              out.push(input[i]);
+              i++;
+            }
           }
         } else {
           out.push(input[i]);
@@ -226,6 +255,39 @@ export function pythonReprToJson(input: string): string {
   }
 
   return out.join("");
+}
+
+const STRING_PREFIX_CHARS = new Set(["b", "B", "r", "R", "u", "U", "f", "F"]);
+
+/**
+ * Check if position `i` starts a Python string prefix (b, r, u, f, br, rb, fr, rf, etc.)
+ * immediately followed by a quote character (' or ").
+ * Returns the quote position and whether it's a raw string, or null if not a prefix.
+ */
+function tryStringPrefix(input: string, i: number, len: number): { quotePos: number; isRaw: boolean } | null {
+  if (i >= len || !STRING_PREFIX_CHARS.has(input[i])) return null;
+
+  const c1 = input[i];
+  // Two-character prefix (br, rb, fr, rf)
+  if (i + 2 < len && STRING_PREFIX_CHARS.has(input[i + 1])) {
+    const c2 = input[i + 1];
+    const quote = input[i + 2];
+    if (quote === "'" || quote === '"') {
+      const pair = (c1 + c2).toLowerCase();
+      // Valid two-char prefixes: br, rb, fr, rf
+      if (pair === "br" || pair === "rb" || pair === "fr" || pair === "rf") {
+        return { quotePos: i + 2, isRaw: pair.includes("r") };
+      }
+    }
+  }
+  // Single-character prefix
+  if (i + 1 < len) {
+    const quote = input[i + 1];
+    if (quote === "'" || quote === '"') {
+      return { quotePos: i + 1, isRaw: c1 === "r" || c1 === "R" };
+    }
+  }
+  return null;
 }
 
 function isWordChar(ch: string): boolean {


### PR DESCRIPTION
## Summary
- Detect and strip Python string prefixes (`b`, `r`, `u`, `f`, `br`, `rb`, `fr`, `rf` and case variants) before parsing quoted strings in `pythonReprToJson`
- Raw string prefixes (`r`, `rb`, `br`, etc.) treat backslashes as literal characters instead of escape sequences
- Works with both single-quoted and double-quoted prefixed strings

## Test plan
- [x] `b'hello'` → `"hello"` (byte string stripped)
- [x] `r'\path\to\file'` → `"\\path\\to\\file"` (raw string, literal backslashes)
- [x] Two-char prefixes (`br`, `rb`, `fr`, `rf`) work correctly
- [x] Uppercase variants (`B`, `R`, `U`, `F`) work
- [x] Prefixes on double-quoted strings work
- [x] `parsePythonRepr("{'data': b'hello'}")` → `{data: "hello"}` (integration test)
- [x] All 2601 existing tests pass, coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)