### PR TITLE
fix(release): skip pre-commit hook on version-bump commit (fixes #652)

### DIFF
--- a/.claude/skills/release/release.ts
+++ b/.claude/skills/release/release.ts
@@ -129,7 +129,7 @@ function main(): void {
 
   // 2. Commit
   run(["git", "add", "package.json"]);
-  run(["git", "commit", "-m", `release: ${tag}`]);
+  run(["git", "commit", "--no-verify", "-m", `release: ${tag}`]);
 
   // 3. Tag
   run(["git", "tag", tag]);


### PR DESCRIPTION
## Summary
- Add `--no-verify` to the `git commit` command in the release script (`.claude/skills/release/release.ts`)
- The release commit only touches `package.json` — the code being released has already passed CI on merge to main
- Eliminates unnecessary test suite overhead and flaky-test risk during automated releases

## Test plan
- [x] Verified the change is a single-flag addition on line 132
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (2590 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)