### PR TITLE
perf(test): add per-file test timing profiler and enforce 5s budget (fixes #551)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ packages/
 - JSON output to stdout, errors/status to stderr
 - **Coverage ratchet**: never lower thresholds or add exclusions in `scripts/check-coverage.ts`. If new code drops coverage, add tests to bring it back up.
 - **Flaky test prevention**: see `test/CLAUDE.md` for required patterns. Never use `setTimeout` for waiting, never hardcode ports, always poll with deadlines instead of fixed delays.
+- **Test time budget**: no single test file should take >5s in isolation. If it does, extract pure logic into unit tests or split the file. `scripts/check-coverage.ts` profiles every test file and enforces this budget.
 - **No implementation code in index files**: `index.ts` is for barrel exports only. Entry points go in `main.ts` (or `main.tsx`). This keeps testable code separate from untestable process boilerplate.
 
 ## Project Structure

--- a/packages/codex/src/codex-session.spec.ts
+++ b/packages/codex/src/codex-session.spec.ts
@@ -421,7 +421,7 @@ describe("CodexSession watchdog", () => {
   test("terminate() clears watchdog without firing", async () => {
     const { session, events } = makeSession({
       command: fakeCommand("silent"),
-      watchdogTimeoutMs: 200,
+      watchdogTimeoutMs: 100,
     });
 
     await session.start();
@@ -429,7 +429,7 @@ describe("CodexSession watchdog", () => {
     session.terminate();
 
     // Wait past the watchdog timeout
-    await Bun.sleep(300);
+    await Bun.sleep(150);
 
     // Should only have the terminate-caused events, no watchdog error
     const errorEvents = events.filter(

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -904,7 +904,7 @@ describe("IpcServer HTTP transport", () => {
     const waitReq = rpc("/rpc", { id: "wm-drain", method: "waitForMail", params: { recipient: "mgr", timeout: 30 } });
 
     // Give it a moment to enter the poll loop
-    await Bun.sleep(100);
+    await Bun.sleep(50);
 
     // Trigger shutdown — this should cause waitForMail to return early
     const shutdownRes = await rpc("/rpc", { id: "sd-wm", method: "shutdown" });

--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -1,10 +1,14 @@
 #!/usr/bin/env bun
 /**
- * Coverage threshold enforcement.
+ * Coverage threshold enforcement + per-file test timing.
  *
  * Parses `bun test --coverage` text output and exits non-zero if:
  *   1. Overall coverage drops below global thresholds (ratchet)
  *   2. Any individual file drops below per-file minimum (unless excluded)
+ *   3. Any single test file exceeds the per-file time budget
+ *
+ * After the coverage run, profiles each test file individually (in parallel)
+ * to collect per-file timing and reports the top 10 slowest.
  *
  * Usage:  bun scripts/check-coverage.ts
  *
@@ -17,6 +21,21 @@
 const GLOBAL_THRESHOLDS = {
   functions: 72,
   lines: 69,
+};
+
+/** Per-file test time budget in milliseconds — no single file should exceed this */
+const PER_FILE_TIME_BUDGET_MS = 5_000;
+
+/** Number of test files to profile concurrently — kept low to avoid FS/network contention inflating times */
+const PROFILE_CONCURRENCY = 4;
+
+/**
+ * Test files excluded from the per-file time budget.
+ * These are intentionally slow integration/stress tests that spawn real daemons.
+ */
+const TIMING_EXCLUSIONS: Record<string, string> = {
+  "test/daemon-integration.spec.ts": "Full daemon lifecycle integration tests",
+  "test/stress.spec.ts": "Stress tests spawning real CLI processes",
 };
 
 /**
@@ -78,8 +97,48 @@ const EXCLUSIONS: Record<string, string> = {
 
 // --- Main ---
 
+import { Glob } from "bun";
 import { logTestRun } from "./test-failure-log";
 import { detectTestNoise } from "./test-noise";
+
+/** Discover all test files in the project */
+async function findTestFiles(): Promise<string[]> {
+  const files: string[] = [];
+  for await (const path of new Glob("**/*.spec.{ts,tsx}").scan({ cwd: ".", onlyFiles: true })) {
+    files.push(path);
+  }
+  return files.sort();
+}
+
+/** Run a single test file and return its wall-clock duration in ms */
+async function timeTestFile(file: string): Promise<{ file: string; ms: number }> {
+  const start = performance.now();
+  const p = Bun.spawn(["bun", "test", file, "--timeout", "30000"], {
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  await p.exited;
+  return { file, ms: Math.round(performance.now() - start) };
+}
+
+/** Profile all test files with bounded concurrency, return sorted results */
+async function profileTestFiles(files: string[], concurrency: number): Promise<{ file: string; ms: number }[]> {
+  const results: { file: string; ms: number }[] = [];
+  const queue = [...files];
+
+  async function worker(): Promise<void> {
+    let file = queue.shift();
+    while (file) {
+      results.push(await timeTestFile(file));
+      file = queue.shift();
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(concurrency, files.length) }, () => worker());
+  await Promise.all(workers);
+
+  return results.sort((a, b) => b.ms - a.ms);
+}
 
 // Ensure deps are installed (fast no-op when already present)
 const installProc = Bun.spawn(["bun", "install"], { stdout: "ignore", stderr: "ignore" });
@@ -183,6 +242,41 @@ if (noiseLines.length > NOISE_THRESHOLD) {
   if (noiseLines.length > 20) {
     console.error(`  ... and ${noiseLines.length - 20} more`);
   }
+  failed = true;
+}
+
+// --- Per-file test timing ---
+
+console.log("\n--- Test Timing Profile ---");
+const testFiles = await findTestFiles();
+const profileStart = performance.now();
+const timings = await profileTestFiles(testFiles, PROFILE_CONCURRENCY);
+const profileDuration = Math.round(performance.now() - profileStart);
+const sequentialSum = timings.reduce((sum, t) => sum + t.ms, 0);
+
+console.log(
+  `Profiled ${timings.length} test files in ${(profileDuration / 1000).toFixed(1)}s (sequential sum: ${(sequentialSum / 1000).toFixed(1)}s)`,
+);
+console.log(
+  `\nTop 10 slowest test files (budget: ${PER_FILE_TIME_BUDGET_MS}ms, ${Object.keys(TIMING_EXCLUSIONS).length} excluded):`,
+);
+for (const { file, ms } of timings.slice(0, 10)) {
+  const excluded = Object.keys(TIMING_EXCLUSIONS).some((pattern) => file.endsWith(pattern));
+  const marker = ms > PER_FILE_TIME_BUDGET_MS ? (excluded ? " (excluded)" : " ← OVER BUDGET") : "";
+  console.log(`  ${String(ms).padStart(6)}ms  ${file}${marker}`);
+}
+
+const overBudget = timings.filter((t) => {
+  if (t.ms <= PER_FILE_TIME_BUDGET_MS) return false;
+  const excluded = Object.keys(TIMING_EXCLUSIONS).some((pattern) => t.file.endsWith(pattern));
+  return !excluded;
+});
+if (overBudget.length > 0) {
+  console.error(`\nFAIL: ${overBudget.length} test file(s) exceed ${PER_FILE_TIME_BUDGET_MS}ms per-file budget:`);
+  for (const { file, ms } of overBudget) {
+    console.error(`  ${ms}ms  ${file}`);
+  }
+  console.error("\nExtract pure logic into unit tests or split the file. See CLAUDE.md test budget rule.");
   failed = true;
 }
 

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -91,6 +91,16 @@ This pattern also works for asserting state changes, event emissions, or any con
 
 **Exception:** A standalone sleep is acceptable when asserting that something does NOT happen within a time window (negative assertions). For example, testing that a debounced callback does not fire prematurely.
 
+## Test Time Budget
+
+No single test file should take more than **5 seconds** in isolation. The pre-commit hook (`scripts/check-coverage.ts`) profiles every test file and fails if any exceeds this budget.
+
+If a test file is too slow:
+1. **Extract pure logic** — state machines, hash functions, diffing algorithms can be unit-tested without spinning up real servers or workers
+2. **Reduce sleep budgets** — if testing a 300ms debounce, use `TEST_DEBOUNCE_MS = 50` in tests
+3. **Split the file** — separate fast unit tests from slow integration tests (e.g., `foo.spec.ts` for units, `foo.integration.spec.ts` for integration)
+4. **Use `pollUntil`** instead of fixed sleeps — exits as soon as the condition is met
+
 ## Summary
 
 Every `Bun.sleep` or `setTimeout` in a test is a potential flake. If you must sleep, it should be inside a retry/poll loop with a deadline — never as "wait and hope". The two acceptable standalone sleeps are: short backoff between retry attempts, and negative assertions (verifying something does NOT happen).


### PR DESCRIPTION
## Summary
- Adds per-file test timing profiler to `scripts/check-coverage.ts` that runs after coverage checks — profiles each test file individually (concurrency=4) and reports the top 10 slowest
- Enforces a 5s per-file time budget with CI failure for violations (integration/stress tests excluded)
- Reduces sleep budgets in `codex-session.spec.ts` (watchdog 200→100ms, post-sleep 300→150ms) and `ipc-server.spec.ts` (poll entry 100→50ms)
- Adds test time budget rule to `CLAUDE.md` and `test/CLAUDE.md` with guidance on fixing slow tests

## Acceptance criteria status
- [x] CI reports per-file test timing (top 10 slowest)
- [ ] Total test suite time < 25s *(currently ~40s parallel; sequential sum ~43s — further optimization needs separate issues)*
- [x] No single test file > 5s *(all package tests under 2.2s; integration/stress excluded)*
- [x] Slowest files refactored to separate unit tests from integration tests *(already done in prior PRs)*

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — 2603 tests pass, 0 failures
- [x] Pre-commit hook passes with per-file profiling (concurrency=4 avoids FS contention)
- [x] Profiler correctly excludes `test/daemon-integration.spec.ts` and `test/stress.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)