### PR TITLE
fix(daemon): isolate each shutdown cleanup step in its own try/catch (fixes #676)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "private": true,
   "version": "0.4.1",
   "type": "module",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "scripts": {
     "build": "bun scripts/build.ts",
     "typecheck": "bun install && bun --bun tsc -b",

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -417,40 +417,52 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
     if (_isShuttingDown) return;
     _isShuttingDown = true;
     logger.info(`[mcpd] Shutting down${reason ? ` (${reason})` : ""}...`);
+    if (idleTimer) clearTimeout(idleTimer);
+    clearInterval(pruneInterval);
+    clearInterval(metricsInterval);
+    watcher.stop();
+    ipcServer.stop();
+    // Wait for any in-progress virtual server startups before stopping them
     try {
-      if (idleTimer) clearTimeout(idleTimer);
-      clearInterval(pruneInterval);
-      clearInterval(metricsInterval);
-      watcher.stop();
-      ipcServer.stop();
-      // Wait for any in-progress virtual server startups before stopping them
       await pool.awaitPendingServers();
-      // Stop each virtual server individually so one failure doesn't leak the rest
-      const virtualServers: ReadonlyArray<readonly [string, { stop(): Promise<void> } | null]> =
-        opts?._virtualServers ?? [
-          ["_claude", claudeServer],
-          ["_codex", codexServer],
-          ["_aliases", aliasServer],
-          ["_metrics", metricsServer],
-        ];
-      for (const [name, server] of virtualServers) {
-        try {
-          if (server) {
-            await server.stop();
-            pool.unregisterVirtualServer(name);
-          }
-        } catch (err) {
-          logger.error(`[mcpd] Error stopping ${name}: ${err}`);
+    } catch (err) {
+      logger.error(`[mcpd] Error awaiting pending servers: ${err}`);
+    }
+    // Stop each virtual server individually so one failure doesn't leak the rest
+    const virtualServers: ReadonlyArray<readonly [string, { stop(): Promise<void> } | null]> =
+      opts?._virtualServers ?? [
+        ["_claude", claudeServer],
+        ["_codex", codexServer],
+        ["_aliases", aliasServer],
+        ["_metrics", metricsServer],
+      ];
+    for (const [name, server] of virtualServers) {
+      try {
+        if (server) {
+          await server.stop();
           pool.unregisterVirtualServer(name);
         }
+      } catch (err) {
+        logger.error(`[mcpd] Error stopping ${name}: ${err}`);
+        pool.unregisterVirtualServer(name);
       }
+    }
+    try {
       await pool.closeAll();
+    } catch (err) {
+      logger.error(`[mcpd] Error closing server pool: ${err}`);
+    }
+    try {
       db.close();
-      if (!opts?.skipLogSetup) {
+    } catch (err) {
+      logger.error(`[mcpd] Error closing database: ${err}`);
+    }
+    if (!opts?.skipLogSetup) {
+      try {
         closeDaemonLogFile();
+      } catch (err) {
+        logger.error(`[mcpd] Error closing log file: ${err}`);
       }
-    } catch (cleanupErr) {
-      logger.error("[mcpd] Error during shutdown cleanup:", cleanupErr);
     }
     try {
       unlinkSync(options.PID_PATH);


### PR DESCRIPTION
## Summary
- Removed the single outer `try/catch` wrapping the entire shutdown sequence in `packages/daemon/src/index.ts`
- Each cleanup step (`pool.awaitPendingServers()`, `pool.closeAll()`, `db.close()`, `closeDaemonLogFile()`) now has its own `try/catch` so a failure in one doesn't skip the rest
- Prevents leaked MCP server processes (from skipped `pool.closeAll()`) and uncheckpointed SQLite WAL (from skipped `db.close()`)

## Test plan
- [x] Existing test "shutdown loop continues after one server stop() throws" validates virtual server isolation
- [x] All 2641 tests pass, coverage thresholds met
- [x] typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)