### PR TITLE
feat(daemon): expose mail as virtual MCP server _mail (fixes #138)

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -40,6 +40,7 @@ import { ConfigWatcher } from "./config/watcher";
 import { closeDaemonLogFile, installDaemonLogCapture, installDaemonLogFile } from "./daemon-log";
 import { StateDb } from "./db/state";
 import { IpcServer } from "./ipc-server";
+import { MailServer, buildMailToolCache } from "./mail-server";
 import { metrics } from "./metrics";
 import { MetricsServer } from "./metrics-server";
 import { reapOrphanedSessions } from "./orphan-reaper";
@@ -218,6 +219,7 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
   const pool = new ServerPool(config, db, undefined, logger);
 
   // Create virtual servers (started lazily after IPC socket is ready)
+  const mailServer = new MailServer(db);
   const aliasServer = new AliasServer(db, daemonId);
   const cliConfig = readCliConfig();
   const wsPort = cliConfig.wsPort ?? DEFAULT_CLAUDE_WS_PORT;
@@ -409,6 +411,19 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
         }
       })(),
     );
+
+    pool.registerPendingVirtualServer(
+      "_mail",
+      (async () => {
+        try {
+          const { client: mailClient, transport: mailTransport, tools: mailTools } = await mailServer.start();
+          pool.registerVirtualServer("_mail", mailClient, mailTransport, mailTools);
+          logger.info("[mcpd] Mail server started");
+        } catch (err) {
+          logger.error(`[mcpd] Failed to start mail server: ${err}`);
+        }
+      })(),
+    );
   }
 
   // Graceful shutdown — re-entrant safe
@@ -435,6 +450,7 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
         ["_codex", codexServer],
         ["_aliases", aliasServer],
         ["_metrics", metricsServer],
+        ["_mail", mailServer],
       ];
     for (const [name, server] of virtualServers) {
       try {

--- a/packages/daemon/src/mail-server.spec.ts
+++ b/packages/daemon/src/mail-server.spec.ts
@@ -1,0 +1,223 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { testOptions } from "../../../test/test-options";
+import { StateDb } from "./db/state";
+import { MAIL_SERVER_NAME, MailServer, buildMailToolCache } from "./mail-server";
+
+describe("MAIL_SERVER_NAME", () => {
+  test("is _mail", () => {
+    expect(MAIL_SERVER_NAME).toBe("_mail");
+  });
+});
+
+describe("buildMailToolCache", () => {
+  test("returns all 4 tools", () => {
+    const cache = buildMailToolCache();
+    expect(cache.size).toBe(4);
+    expect(cache.has("_mail_send")).toBe(true);
+    expect(cache.has("_mail_read")).toBe(true);
+    expect(cache.has("_mail_wait")).toBe(true);
+    expect(cache.has("_mail_reply")).toBe(true);
+  });
+
+  test("each tool has correct server name", () => {
+    const cache = buildMailToolCache();
+    for (const tool of cache.values()) {
+      expect(tool.server).toBe("_mail");
+    }
+  });
+});
+
+describe("MailServer", () => {
+  let server: MailServer | undefined;
+  let db: StateDb | undefined;
+
+  afterEach(async () => {
+    await server?.stop();
+    db?.close();
+    server = undefined;
+    db = undefined;
+  });
+
+  test("start() connects and listTools returns 4 mail tools", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new MailServer(db);
+
+    const { client } = await server.start();
+    const { tools } = await client.listTools();
+
+    expect(tools).toHaveLength(4);
+    const names = tools.map((t) => t.name);
+    expect(names).toContain("_mail_send");
+    expect(names).toContain("_mail_read");
+    expect(names).toContain("_mail_wait");
+    expect(names).toContain("_mail_reply");
+  });
+
+  test("_mail_send inserts a message and returns its id", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new MailServer(db);
+
+    const { client } = await server.start();
+    const result = await client.callTool({
+      name: "_mail_send",
+      arguments: { sender: "alice", recipient: "bob", subject: "hello", body: "hi there" },
+    });
+
+    const content = result.content as Array<{ type: string; text: string }>;
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(content[0].text) as { id: number };
+    expect(typeof parsed.id).toBe("number");
+    expect(parsed.id).toBeGreaterThan(0);
+  });
+
+  test("_mail_read returns sent messages", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new MailServer(db);
+
+    const { client } = await server.start();
+
+    await client.callTool({
+      name: "_mail_send",
+      arguments: { sender: "alice", recipient: "bob", body: "msg1" },
+    });
+    await client.callTool({
+      name: "_mail_send",
+      arguments: { sender: "alice", recipient: "bob", body: "msg2" },
+    });
+
+    const result = await client.callTool({
+      name: "_mail_read",
+      arguments: { recipient: "bob" },
+    });
+
+    const content = result.content as Array<{ type: string; text: string }>;
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(content[0].text) as { messages: unknown[] };
+    expect(parsed.messages).toHaveLength(2);
+  });
+
+  test("_mail_wait returns immediately if message is available", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new MailServer(db);
+
+    const { client } = await server.start();
+
+    await client.callTool({
+      name: "_mail_send",
+      arguments: { sender: "alice", recipient: "bob", body: "waiting message" },
+    });
+
+    const result = await client.callTool({
+      name: "_mail_wait",
+      arguments: { recipient: "bob", timeout: 5 },
+    });
+
+    const content = result.content as Array<{ type: string; text: string }>;
+    expect(result.isError).toBeFalsy();
+    const parsed = JSON.parse(content[0].text) as { message: { body: string } | null };
+    expect(parsed.message).not.toBeNull();
+    expect(parsed.message?.body).toBe("waiting message");
+  });
+
+  test("_mail_wait returns null on timeout when no message", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new MailServer(db);
+
+    const { client } = await server.start();
+
+    const result = await client.callTool({
+      name: "_mail_wait",
+      arguments: { recipient: "nobody", timeout: 0.5 },
+    });
+
+    const content = result.content as Array<{ type: string; text: string }>;
+    const parsed = JSON.parse(content[0].text) as { message: null };
+    expect(parsed.message).toBeNull();
+  });
+
+  test("_mail_reply sends a reply to original sender", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new MailServer(db);
+
+    const { client } = await server.start();
+
+    const sendResult = await client.callTool({
+      name: "_mail_send",
+      arguments: { sender: "alice", recipient: "bob", subject: "hello", body: "original" },
+    });
+    const sendContent = sendResult.content as Array<{ type: string; text: string }>;
+    const { id } = JSON.parse(sendContent[0].text) as { id: number };
+
+    const replyResult = await client.callTool({
+      name: "_mail_reply",
+      arguments: { id, sender: "bob", body: "reply body" },
+    });
+
+    const replyContent = replyResult.content as Array<{ type: string; text: string }>;
+    expect(replyResult.isError).toBeFalsy();
+    const { id: replyId } = JSON.parse(replyContent[0].text) as { id: number };
+    expect(replyId).toBeGreaterThan(id);
+
+    // Verify reply is in alice's mailbox
+    const readResult = await client.callTool({
+      name: "_mail_read",
+      arguments: { recipient: "alice" },
+    });
+    const readContent = readResult.content as Array<{ type: string; text: string }>;
+    const { messages } = JSON.parse(readContent[0].text) as { messages: Array<{ subject: string; replyTo: number }> };
+    expect(messages).toHaveLength(1);
+    expect(messages[0].subject).toBe("Re: hello");
+    expect(messages[0].replyTo).toBe(id);
+  });
+
+  test("_mail_reply returns error for nonexistent message", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new MailServer(db);
+
+    const { client } = await server.start();
+
+    const result = await client.callTool({
+      name: "_mail_reply",
+      arguments: { id: 9999, sender: "bob", body: "reply" },
+    });
+
+    expect(result.isError).toBe(true);
+    const content = result.content as Array<{ type: string; text: string }>;
+    expect(content[0].text).toContain("not found");
+  });
+
+  test("_mail_send returns error when sender is missing", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new MailServer(db);
+
+    const { client } = await server.start();
+
+    const result = await client.callTool({
+      name: "_mail_send",
+      arguments: { sender: "", recipient: "bob" },
+    });
+
+    expect(result.isError).toBe(true);
+  });
+
+  test("unknown tool returns error", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new MailServer(db);
+
+    const { client } = await server.start();
+
+    const result = await client.callTool({ name: "_mail_unknown", arguments: {} });
+    expect(result.isError).toBe(true);
+    const content = result.content as Array<{ type: string; text: string }>;
+    expect(content[0].text).toContain("Unknown tool");
+  });
+});

--- a/packages/daemon/src/mail-server.ts
+++ b/packages/daemon/src/mail-server.ts
@@ -1,0 +1,217 @@
+/**
+ * Virtual MCP server that exposes daemon mail as MCP tools.
+ *
+ * Uses an in-process MCP Server with InMemoryTransport (no Workers).
+ * Tools map 1:1 to the IPC mail handlers: sendMail, readMail, waitForMail, replyToMail.
+ */
+
+import type { ToolInfo } from "@mcp-cli/core";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import type { StateDb } from "./db/state";
+
+export const MAIL_SERVER_NAME = "_mail";
+
+const TOOLS = [
+  {
+    name: "_mail_send",
+    description: "Send a mail message to a recipient.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        sender: { type: "string", description: "Sender identifier (e.g. session name or role)" },
+        recipient: { type: "string", description: "Recipient identifier" },
+        subject: { type: "string", description: "Optional subject line" },
+        body: { type: "string", description: "Message body" },
+        replyTo: { type: "number", description: "ID of message being replied to, if any" },
+      },
+      required: ["sender", "recipient"],
+    },
+  },
+  {
+    name: "_mail_read",
+    description: "Read messages from a mailbox.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        recipient: { type: "string", description: "Filter by recipient (omit for all)" },
+        unreadOnly: { type: "boolean", description: "Return only unread messages (default false)" },
+        limit: { type: "number", description: "Max messages to return" },
+      },
+    },
+  },
+  {
+    name: "_mail_wait",
+    description: "Block until a message arrives for the given recipient, or timeout expires.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        recipient: { type: "string", description: "Recipient to wait for" },
+        timeout: { type: "number", description: "Timeout in seconds (default 30, max 30)" },
+      },
+    },
+  },
+  {
+    name: "_mail_reply",
+    description: "Reply to an existing message.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        id: { type: "number", description: "ID of the message to reply to" },
+        sender: { type: "string", description: "Sender identifier for the reply" },
+        body: { type: "string", description: "Reply body" },
+        subject: { type: "string", description: "Optional subject override (defaults to Re: <original>)" },
+      },
+      required: ["id", "sender", "body"],
+    },
+  },
+] as const;
+
+export class MailServer {
+  private server: Server | null = null;
+  private client: Client | null = null;
+  private serverTransport: Transport | null = null;
+  private clientTransport: Transport | null = null;
+  private stopped = false;
+
+  constructor(private db: StateDb) {}
+
+  async start(): Promise<{ client: Client; transport: Transport; tools: Map<string, ToolInfo> }> {
+    if (this.server) {
+      throw new Error("MailServer already started");
+    }
+
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    this.serverTransport = serverTransport;
+    this.clientTransport = clientTransport;
+
+    this.server = new Server({ name: MAIL_SERVER_NAME, version: "0.1.0" }, { capabilities: { tools: {} } });
+
+    this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: TOOLS.map((t) => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: t.inputSchema,
+      })),
+    }));
+
+    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      const { name, arguments: args } = request.params;
+      const a = args ?? {};
+
+      try {
+        switch (name) {
+          case "_mail_send": {
+            const sender = String(a.sender ?? "");
+            const recipient = String(a.recipient ?? "");
+            if (!sender || !recipient) {
+              return { content: [{ type: "text" as const, text: "sender and recipient are required" }], isError: true };
+            }
+            const subject = a.subject !== undefined ? String(a.subject) : undefined;
+            const body = a.body !== undefined ? String(a.body) : undefined;
+            const replyTo = a.replyTo !== undefined ? Number(a.replyTo) : undefined;
+            const id = this.db.insertMail(sender, recipient, subject, body, replyTo);
+            return { content: [{ type: "text" as const, text: JSON.stringify({ id }) }] };
+          }
+
+          case "_mail_read": {
+            const recipient = a.recipient !== undefined ? String(a.recipient) : undefined;
+            const unreadOnly = a.unreadOnly !== undefined ? Boolean(a.unreadOnly) : undefined;
+            const limit = a.limit !== undefined ? Number(a.limit) : undefined;
+            const messages = this.db.readMail(recipient, unreadOnly, limit);
+            return { content: [{ type: "text" as const, text: JSON.stringify({ messages }) }] };
+          }
+
+          case "_mail_wait": {
+            const recipient = a.recipient !== undefined ? String(a.recipient) : undefined;
+            const timeoutSec = a.timeout !== undefined ? Number(a.timeout) : 30;
+            const maxWait = Math.min(timeoutSec * 1000, 30_000);
+            const deadline = Date.now() + maxWait;
+
+            while (Date.now() < deadline) {
+              if (this.stopped)
+                return { content: [{ type: "text" as const, text: JSON.stringify({ message: null }) }] };
+              const msg = this.db.getNextUnread(recipient);
+              if (msg) {
+                this.db.markMailRead(msg.id);
+                return { content: [{ type: "text" as const, text: JSON.stringify({ message: msg }) }] };
+              }
+              await Bun.sleep(500);
+            }
+            return { content: [{ type: "text" as const, text: JSON.stringify({ message: null }) }] };
+          }
+
+          case "_mail_reply": {
+            const id = Number(a.id);
+            const sender = String(a.sender ?? "");
+            const body = String(a.body ?? "");
+            if (!sender || !body) {
+              return { content: [{ type: "text" as const, text: "sender and body are required" }], isError: true };
+            }
+            const original = this.db.getMailById(id);
+            if (!original) {
+              return {
+                content: [{ type: "text" as const, text: `Mail message ${id} not found` }],
+                isError: true,
+              };
+            }
+            const subject =
+              a.subject !== undefined ? String(a.subject) : original.subject ? `Re: ${original.subject}` : undefined;
+            const newId = this.db.insertMail(sender, original.sender, subject, body, id);
+            return { content: [{ type: "text" as const, text: JSON.stringify({ id: newId }) }] };
+          }
+
+          default:
+            return {
+              content: [{ type: "text" as const, text: `Unknown tool: ${name}` }],
+              isError: true,
+            };
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { content: [{ type: "text" as const, text: `Error: ${message}` }], isError: true };
+      }
+    });
+
+    await this.server.connect(serverTransport);
+    this.client = new Client({ name: `mcp-cli/${MAIL_SERVER_NAME}`, version: "0.1.0" });
+    await this.client.connect(clientTransport);
+
+    return { client: this.client, transport: this.clientTransport, tools: buildMailToolCache() };
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+    try {
+      await this.client?.close();
+    } catch {
+      // ignore close errors
+    }
+    try {
+      await this.server?.close();
+    } catch {
+      // ignore close errors
+    }
+    this.server = null;
+    this.client = null;
+    this.serverTransport = null;
+    this.clientTransport = null;
+  }
+}
+
+/** Pre-build tool cache for pool registration. */
+export function buildMailToolCache(): Map<string, ToolInfo> {
+  const cache = new Map<string, ToolInfo>();
+  for (const t of TOOLS) {
+    cache.set(t.name, {
+      server: MAIL_SERVER_NAME,
+      name: t.name,
+      description: t.description,
+      inputSchema: t.inputSchema as Record<string, unknown>,
+    });
+  }
+  return cache;
+}


### PR DESCRIPTION
## Summary
- Add `MailServer` class (`mail-server.ts`) using `InMemoryTransport` — same pattern as `MetricsServer`
- Expose 4 MCP tools on the `_mail` virtual server: `_mail_send`, `_mail_read`, `_mail_wait`, `_mail_reply`
- Each tool maps 1:1 to the existing IPC mail handlers, calling `StateDb` directly in-process
- Register `_mail` as a pending virtual server in daemon startup (alongside `_aliases`, `_claude`, etc.)

## Test plan
- [x] 12 unit tests in `mail-server.spec.ts` covering all 4 tools
- [x] Tests cover happy paths, error cases (missing message, missing required fields, unknown tool)
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] Full `bun test` suite passes (2661 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)