### PR TITLE
fix(daemon): prevent registerVirtualServer double-close race on crash-restart during shutdown (fixes #691)

### DIFF
--- a/packages/daemon/src/server-pool.spec.ts
+++ b/packages/daemon/src/server-pool.spec.ts
@@ -1210,6 +1210,33 @@ describe("ServerPool.restart", () => {
     expect(pool.listServers().some((s) => s.name === "real")).toBe(true);
   });
 
+  test("registerVirtualServer is a no-op after closeAll (stopped pool)", async () => {
+    const closeOld = mock(() => Promise.resolve());
+    const oldClient = makeMockClient();
+    (oldClient as Record<string, unknown>).close = closeOld;
+    const { connectFn } = mockConnectFn();
+    const pool = new ServerPool(makeConfig({}), undefined, connectFn, silentLogger);
+
+    pool.registerVirtualServer("_test", oldClient as unknown as Client, makeMockTransport() as unknown as Transport);
+    await pool.closeAll(); // sets stopped = true, closes old client
+
+    const closeNew = mock(() => Promise.resolve());
+    const newClient = makeMockClient();
+    (newClient as Record<string, unknown>).close = closeNew;
+
+    // Simulate crash-restart calling registerVirtualServer after shutdown
+    pool.registerVirtualServer("_test", newClient as unknown as Client, makeMockTransport() as unknown as Transport);
+
+    // The entry remains disconnected (leftover from closeAll) — not reconnected with the new client
+    const servers = pool.listServers();
+    const entry = servers.find((s) => s.name === "_test");
+    expect(entry?.state).toBe("disconnected");
+
+    // Old client should have been closed once by closeAll; new client never touched
+    expect(closeOld).toHaveBeenCalledTimes(1);
+    expect(closeNew).not.toHaveBeenCalled();
+  });
+
   test("unregisterVirtualServer prevents closeAll from double-closing", async () => {
     const closeMock = mock(() => Promise.resolve());
     const client = makeMockClient();

--- a/packages/daemon/src/server-pool.ts
+++ b/packages/daemon/src/server-pool.ts
@@ -73,6 +73,8 @@ export class ServerPool {
   private stderrBuffer = new StderrRingBuffer();
   private connectFn: ConnectFn;
   private logger: Logger;
+  /** Set to true by closeAll() to prevent re-registration during shutdown. */
+  private stopped = false;
 
   constructor(config: ResolvedConfig, db?: StateDb, connectFn?: ConnectFn, logger?: Logger) {
     this.config = config;
@@ -104,6 +106,11 @@ export class ServerPool {
    * Virtual servers survive updateConfig() and are reported with transport "virtual".
    */
   registerVirtualServer(name: string, client: Client, transport: Transport, tools?: Map<string, ToolInfo>): void {
+    // Bail out if the pool is shutting down — closeAll() owns cleanup from here.
+    // This prevents a double-close race where a crash-restarted virtual server
+    // tries to close the old client while shutdown is also closing it (#691).
+    if (this.stopped) return;
+
     // Disconnect existing connection if present
     const existing = this.connections.get(name);
     if (existing) {
@@ -602,6 +609,7 @@ export class ServerPool {
 
   /** Disconnect all servers */
   async closeAll(): Promise<void> {
+    this.stopped = true;
     for (const name of this.connections.keys()) {
       await this.disconnect(name);
     }


### PR DESCRIPTION
## Summary
- Added a `stopped` flag to `ServerPool` that is set to `true` at the start of `closeAll()`
- `registerVirtualServer` now returns early if `stopped` is set, preventing crash-restarted virtual servers from double-closing the old client while shutdown is also closing it
- Added a test covering the race: after `closeAll()`, a subsequent `registerVirtualServer` call is a no-op and the new client is never closed

## Test plan
- `bun test packages/daemon/src/server-pool.spec.ts` — all 118 tests pass, including the new `registerVirtualServer is a no-op after closeAll (stopped pool)` test
- `bun test` — 2653 tests pass, all coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)