### PR TITLE
feat(daemon): plan server auto-detection in server-pool (fixes #702)

### DIFF
--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -7,6 +7,7 @@
 
 import { z } from "zod/v4";
 import type { AliasType } from "./alias";
+import type { PlanProtocolCapability } from "./plan";
 import type { SpanEvent } from "./trace";
 
 // -- Methods --
@@ -182,6 +183,8 @@ export interface ServerStatus {
   callCount?: number;
   errorCount?: number;
   avgDurationMs?: number;
+  /** Plan protocol capabilities detected from tool names, if any. */
+  planCapabilities?: PlanProtocolCapability;
 }
 
 export interface ToolInfo {

--- a/packages/daemon/src/server-pool.spec.ts
+++ b/packages/daemon/src/server-pool.spec.ts
@@ -8,6 +8,7 @@ import {
   type ConnectFn,
   ServerPool,
   buildChildEnv,
+  detectPlanCapabilities,
   isRetryableError,
   isTransientCallError,
   safeStderrWrite,
@@ -1249,5 +1250,130 @@ describe("ServerPool.restart", () => {
 
     // Should not throw despite server "b" failing on restart
     await pool.restart();
+  });
+});
+
+// -- helpers --
+
+function toolMap(
+  ...names: string[]
+): Map<string, { name: string; server: string; description: string; inputSchema: Record<string, unknown> }> {
+  const m = new Map();
+  for (const name of names) m.set(name, { name, server: "test", description: "", inputSchema: {} });
+  return m;
+}
+
+describe("detectPlanCapabilities", () => {
+  test("returns undefined for empty tool map", () => {
+    expect(detectPlanCapabilities(new Map())).toBeUndefined();
+  });
+
+  test("returns undefined for non-plan tools", () => {
+    expect(detectPlanCapabilities(toolMap("search", "write_file", "list_files"))).toBeUndefined();
+  });
+
+  test("list_plans → list capability", () => {
+    const result = detectPlanCapabilities(toolMap("list_plans"));
+    expect(result).toBeDefined();
+    expect(result?.capabilities).toContain("list");
+    expect(result?.capabilities).not.toContain("advance");
+  });
+
+  test("get_plan → get capability", () => {
+    const result = detectPlanCapabilities(toolMap("get_plan"));
+    expect(result).toBeDefined();
+    expect(result?.capabilities).toContain("get");
+  });
+
+  test("get_plan_step → get capability", () => {
+    const result = detectPlanCapabilities(toolMap("get_plan_step"));
+    expect(result).toBeDefined();
+    expect(result?.capabilities).toContain("get");
+  });
+
+  test("advance_plan → advance capability", () => {
+    const result = detectPlanCapabilities(toolMap("advance_plan"));
+    expect(result).toBeDefined();
+    expect(result?.capabilities).toContain("advance");
+  });
+
+  test("abort_plan → abort capability", () => {
+    const result = detectPlanCapabilities(toolMap("abort_plan"));
+    expect(result).toBeDefined();
+    expect(result?.capabilities).toContain("abort");
+  });
+
+  test("get_plan_metrics → metrics capability", () => {
+    const result = detectPlanCapabilities(toolMap("get_plan_metrics"));
+    expect(result).toBeDefined();
+    expect(result?.capabilities).toContain("metrics");
+  });
+
+  test("read-only server: list_plans + get_plan → list and get, no advance/abort", () => {
+    const result = detectPlanCapabilities(toolMap("list_plans", "get_plan"));
+    expect(result).toBeDefined();
+    expect(result?.capabilities).toContain("list");
+    expect(result?.capabilities).toContain("get");
+    expect(result?.capabilities).not.toContain("advance");
+    expect(result?.capabilities).not.toContain("abort");
+  });
+
+  test("full plan server: all tools → all capabilities", () => {
+    const result = detectPlanCapabilities(
+      toolMap("list_plans", "get_plan", "get_plan_step", "advance_plan", "abort_plan", "get_plan_metrics"),
+    );
+    expect(result).toBeDefined();
+    const caps = result?.capabilities;
+    expect(caps).toContain("list");
+    expect(caps).toContain("get");
+    expect(caps).toContain("advance");
+    expect(caps).toContain("abort");
+    expect(caps).toContain("metrics");
+    expect(caps).toHaveLength(5);
+  });
+
+  test("get_plan and get_plan_step deduplicate to a single get capability", () => {
+    const result = detectPlanCapabilities(toolMap("get_plan", "get_plan_step"));
+    expect(result?.capabilities.filter((c) => c === "get")).toHaveLength(1);
+  });
+
+  test("listServers includes planCapabilities for plan-aware server after connect", async () => {
+    const connectFn: ConnectFn = mock(() =>
+      Promise.resolve({
+        client: makeMockClient({
+          listTools: () =>
+            Promise.resolve({
+              tools: [
+                { name: "list_plans", inputSchema: {} },
+                { name: "get_plan", inputSchema: {} },
+                { name: "advance_plan", inputSchema: {} },
+              ],
+            }),
+        }) as unknown as Client,
+        transport: makeMockTransport() as unknown as Transport,
+      }),
+    );
+    const pool = new ServerPool(makeConfig({ planner: { command: "echo" } }), undefined, connectFn, silentLogger);
+    await pool.listTools("planner");
+
+    const [status] = pool.listServers();
+    expect(status.planCapabilities).toBeDefined();
+    expect(status.planCapabilities?.capabilities).toContain("list");
+    expect(status.planCapabilities?.capabilities).toContain("get");
+    expect(status.planCapabilities?.capabilities).toContain("advance");
+  });
+
+  test("listServers has no planCapabilities for non-plan server", async () => {
+    const connectFn: ConnectFn = mock(() =>
+      Promise.resolve({
+        client: makeMockClient() as unknown as Client,
+        transport: makeMockTransport() as unknown as Transport,
+      }),
+    );
+    const pool = new ServerPool(makeConfig({ plain: { command: "echo" } }), undefined, connectFn, silentLogger);
+    await pool.listTools("plain");
+
+    const [status] = pool.listServers();
+    expect(status.planCapabilities).toBeUndefined();
   });
 });

--- a/packages/daemon/src/server-pool.ts
+++ b/packages/daemon/src/server-pool.ts
@@ -15,6 +15,8 @@ import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type {
   JsonSchema,
   Logger,
+  PlanCapability,
+  PlanProtocolCapability,
   ResolvedConfig,
   ResolvedServer,
   ServerConfig,
@@ -52,6 +54,8 @@ interface ServerConnection {
   stderrCleanup?: () => void;
   /** Virtual servers are not managed by config and survive updateConfig(). */
   virtual?: boolean;
+  /** Plan protocol capabilities detected from tool names, if any. */
+  planCapabilities?: PlanProtocolCapability;
 }
 
 /**
@@ -110,15 +114,17 @@ export class ServerPool {
       existing.client?.close().catch(() => {});
     }
 
+    const toolMap = tools ?? new Map();
     this.connections.set(name, {
       name,
       resolved: { name, config: { command: "__virtual__" }, source: { file: "built-in", scope: "mcp-cli" } },
       client,
       transport,
-      tools: tools ?? new Map(),
+      tools: toolMap,
       state: "connected",
       lastUsed: Date.now(),
       virtual: true,
+      planCapabilities: detectPlanCapabilities(toolMap),
     });
   }
 
@@ -356,6 +362,8 @@ export class ServerPool {
       if (this.db) {
         this.db.cacheTools(conn.name, [...conn.tools.values()]);
       }
+      // Detect plan protocol capabilities from tool names
+      conn.planCapabilities = detectPlanCapabilities(conn.tools);
     } catch (err) {
       this.logger.error(`[pool] Failed to list tools for "${conn.name}": ${err}`);
     }
@@ -435,6 +443,7 @@ export class ServerPool {
         lastError: conn.lastError,
         source: conn.resolved.source.file,
         recentStderr,
+        planCapabilities: conn.planCapabilities,
       };
     });
 
@@ -910,6 +919,34 @@ function searchRegex(pattern: string): RegExp {
     .replace(/\*/g, ".*")
     .replace(/\?/g, ".");
   return new RegExp(escaped, "i");
+}
+
+/**
+ * Scan a server's tool map for plan protocol tool names and return the
+ * detected capabilities. Returns `undefined` if no plan tools are found
+ * (server does not speak the plan protocol at all).
+ *
+ * Tool-to-capability mapping:
+ *   list_plans      → "list"
+ *   get_plan        → "get"
+ *   get_plan_step   → "get"
+ *   advance_plan    → "advance"
+ *   abort_plan      → "abort"
+ *   get_plan_metrics→ "metrics"
+ *
+ * @internal Exported for testing only.
+ */
+export function detectPlanCapabilities(tools: Map<string, ToolInfo>): PlanProtocolCapability | undefined {
+  const capSet = new Set<PlanCapability>();
+
+  if (tools.has("list_plans")) capSet.add("list");
+  if (tools.has("get_plan") || tools.has("get_plan_step")) capSet.add("get");
+  if (tools.has("advance_plan")) capSet.add("advance");
+  if (tools.has("abort_plan")) capSet.add("abort");
+  if (tools.has("get_plan_metrics")) capSet.add("metrics");
+
+  if (capSet.size === 0) return undefined;
+  return { capabilities: [...capSet] };
 }
 
 /** Check if a tool passes allowedTools/disabledTools glob filters.


### PR DESCRIPTION
## Summary
- Adds `detectPlanCapabilities()` helper in `server-pool.ts` that scans a server's tool map for plan protocol tool names (`list_plans`, `get_plan`, `get_plan_step`, `advance_plan`, `abort_plan`, `get_plan_metrics`) and returns a `PlanProtocolCapability` object
- Detects plan capabilities on connect (after `refreshTools()`) and when registering virtual servers with pre-populated tools
- Adds `planCapabilities?: PlanProtocolCapability` to `ServerStatus` in `ipc.ts` so the IPC `listServers` response includes plan support information for each server

## Test plan
- [x] `detectPlanCapabilities` unit tests: empty map, non-plan tools, each individual capability, read-only server (list+get only), full server (all 5 capabilities), deduplication of get from both `get_plan` and `get_plan_step`
- [x] Integration test: `listServers()` includes `planCapabilities` after connecting to a plan-aware server
- [x] Integration test: `listServers()` has no `planCapabilities` for a non-plan server
- [x] Full test suite: 2693 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)