### PR TITLE
fix(daemon): bound client.close() with 5s timeout in virtual server stop() (fixes #692)

### DIFF
--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -13,6 +13,7 @@ import type { JsonSchema, Logger, ToolInfo } from "@mcp-cli/core";
 import { consoleLogger, formatToolSignature } from "@mcp-cli/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { CLAUDE_TOOLS } from "./claude-session/tools";
+import { closeClientWithTimeout } from "./close-timeout";
 import type { StateDb } from "./db/state";
 import { metrics } from "./metrics";
 import { getProcessStartTime as defaultGetProcessStartTime, findDeadPids, isOurProcess } from "./process-identity";
@@ -355,11 +356,7 @@ export class ClaudeServer {
   async stop(): Promise<void> {
     this.stopped = true;
     this.onRestarted = undefined;
-    try {
-      await this.client?.close();
-    } catch {
-      // ignore close errors
-    }
+    await closeClientWithTimeout(this.client);
     if (this.worker) {
       this.cleanupWorkerHandlers(this.worker);
       this.worker.terminate();
@@ -517,11 +514,7 @@ export class ClaudeServer {
     metrics.gauge("mcpd_active_sessions").set(0);
 
     // Close MCP client to reject pending promises (matches stop() pattern)
-    try {
-      await this.client?.close();
-    } catch {
-      // ignore close errors — worker may already be dead
-    }
+    await closeClientWithTimeout(this.client);
 
     // Clean up event handlers and terminate the dead worker to release resources
     if (this.worker) {

--- a/packages/daemon/src/close-timeout.spec.ts
+++ b/packages/daemon/src/close-timeout.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { CLOSE_TIMEOUT_MS, closeClientWithTimeout } from "./close-timeout";
+
+describe("closeClientWithTimeout", () => {
+  test("resolves immediately when client is null", async () => {
+    await closeClientWithTimeout(null);
+  });
+
+  test("resolves immediately when client is undefined", async () => {
+    await closeClientWithTimeout(undefined);
+  });
+
+  test("resolves when close() resolves quickly", async () => {
+    let closed = false;
+    const client = {
+      close: async () => {
+        closed = true;
+      },
+    };
+    await closeClientWithTimeout(client, 1000);
+    expect(closed).toBe(true);
+  });
+
+  test("resolves within timeout when close() hangs indefinitely", async () => {
+    const client = {
+      close: () => new Promise<void>(() => {}), // never resolves
+    };
+    const start = Date.now();
+    await closeClientWithTimeout(client, 50);
+    expect(Date.now() - start).toBeLessThan(2000);
+  });
+
+  test("does not throw when close() rejects", async () => {
+    const client = {
+      close: async () => {
+        throw new Error("connection refused");
+      },
+    };
+    await closeClientWithTimeout(client, 1000);
+    // should not throw
+  });
+
+  test("does not throw on timeout", async () => {
+    const client = {
+      close: () => new Promise<void>(() => {}), // never resolves
+    };
+    await closeClientWithTimeout(client, 10);
+    // should not throw
+  });
+
+  test("uses CLOSE_TIMEOUT_MS as default timeout", () => {
+    expect(CLOSE_TIMEOUT_MS).toBe(5_000);
+  });
+
+  test("timer is cleared after close() resolves (no unhandled rejection)", async () => {
+    // If the timer leaked, it would fire a rejection after the promise settles.
+    // This test verifies the timer is cleared by checking multiple rapid calls work.
+    for (let i = 0; i < 5; i++) {
+      const client = { close: async () => {} };
+      await closeClientWithTimeout(client, 100);
+    }
+  });
+});

--- a/packages/daemon/src/close-timeout.ts
+++ b/packages/daemon/src/close-timeout.ts
@@ -1,0 +1,35 @@
+/**
+ * Utility for closing MCP clients with a bounded timeout.
+ *
+ * Used by virtual server stop() and crash handler paths to prevent
+ * client.close() from blocking shutdown indefinitely when a worker is wedged.
+ */
+
+export const CLOSE_TIMEOUT_MS = 5_000;
+
+/**
+ * Close an MCP client with a timeout.
+ *
+ * Resolves (never throws) regardless of whether close() resolved, rejected,
+ * or timed out. Callers should terminate the worker unconditionally after
+ * calling this.
+ */
+export async function closeClientWithTimeout(
+  client: { close(): Promise<void> } | null | undefined,
+  timeoutMs: number = CLOSE_TIMEOUT_MS,
+): Promise<void> {
+  if (!client) return;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      client.close(),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error("client.close() timeout")), timeoutMs);
+      }),
+    ]);
+  } catch {
+    // timeout or close error — caller terminates worker unconditionally
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/daemon/src/codex-server.ts
+++ b/packages/daemon/src/codex-server.ts
@@ -13,6 +13,7 @@
 import type { JsonSchema, Logger, ToolInfo } from "@mcp-cli/core";
 import { consoleLogger, formatToolSignature } from "@mcp-cli/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { closeClientWithTimeout } from "./close-timeout";
 import { CODEX_TOOLS } from "./codex-session/tools";
 import type { StateDb } from "./db/state";
 import { metrics } from "./metrics";
@@ -240,11 +241,7 @@ export class CodexServer {
   async stop(): Promise<void> {
     this.stopped = true;
     this.onRestarted = undefined;
-    try {
-      await this.client?.close();
-    } catch {
-      // ignore close errors
-    }
+    await closeClientWithTimeout(this.client);
     if (this.worker) {
       this.cleanupWorkerHandlers(this.worker);
       this.worker.terminate();
@@ -326,11 +323,7 @@ export class CodexServer {
 
     const orphanedSessions = new Set(this.activeSessions);
 
-    try {
-      await this.client?.close();
-    } catch {
-      // ignore
-    }
+    await closeClientWithTimeout(this.client);
 
     if (this.worker) {
       this.cleanupWorkerHandlers(this.worker);


### PR DESCRIPTION
## Summary
- Add `closeClientWithTimeout()` helper that races `client.close()` against a 5s deadline and swallows all errors (timeout or close failure)
- Replace bare `await this.client?.close()` in `ClaudeServer.stop()`, `ClaudeServer.handleWorkerCrash()`, `CodexServer.stop()`, and `CodexServer.handleWorkerCrash()` — all four paths previously had no timeout
- Worker `terminate()` is still called unconditionally after the timeout, so shutdown always completes within a bounded time even when a worker is wedged

## Test plan
- [x] 8 unit tests for `closeClientWithTimeout`: null client, fast close, hanging close (verifies resolves within 2s on 50ms timeout), `close()` rejection, no throw on timeout, timer cleanup
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (2689 tests, 100% coverage on new file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)