### PR TITLE
fix(daemon): capture pidStartTime in worker thread to avoid blocking ps(1) on main event loop (fixes #694)

### DIFF
--- a/packages/daemon/src/claude-server.spec.ts
+++ b/packages/daemon/src/claude-server.spec.ts
@@ -259,6 +259,73 @@ describe("ClaudeServer", () => {
     expect(row?.pidStartTime ?? null).toBeNull();
   });
 
+  test("db:upsert uses worker-provided pidStartTime without calling getProcessStartTimeFn", () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    let fnCallCount = 0;
+    // getProcessStartTimeFn should NOT be called when pidStartTime is provided by worker
+    server = new ClaudeServer(db, undefined, undefined, silentLogger, 10_000, undefined, () => {
+      fnCallCount++;
+      return 99999;
+    });
+
+    const handle = (server as unknown as { handleWorkerEvent: (e: unknown) => void }).handleWorkerEvent.bind(server);
+    const workerPidStartTime = 1_700_111_111_000;
+    handle({
+      type: "db:upsert",
+      session: { sessionId: "worker-pst-1", pid: 12345, pidStartTime: workerPidStartTime, state: "active" },
+    });
+
+    // Worker-provided pidStartTime is used directly — no ps(1) call on main thread
+    expect(fnCallCount).toBe(0);
+    const row = db.getSession("worker-pst-1");
+    expect(row?.pidStartTime).toBe(workerPidStartTime);
+    const pidStartTimes = (server as unknown as { sessionPidStartTimes: Map<string, number> }).sessionPidStartTimes;
+    expect(pidStartTimes.get("worker-pst-1")).toBe(workerPidStartTime);
+  });
+
+  test("db:upsert falls back to getProcessStartTimeFn when worker omits pidStartTime", () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    const fallbackStartTime = 1_700_222_222_000;
+    server = new ClaudeServer(db, undefined, undefined, silentLogger, 10_000, undefined, () => fallbackStartTime);
+
+    const handle = (server as unknown as { handleWorkerEvent: (e: unknown) => void }).handleWorkerEvent.bind(server);
+    // pidStartTime omitted (undefined) → falls back to getProcessStartTimeFn
+    handle({
+      type: "db:upsert",
+      session: { sessionId: "worker-pst-omit", pid: 12345, state: "active" },
+    });
+
+    const row = db.getSession("worker-pst-omit");
+    expect(row?.pidStartTime).toBe(fallbackStartTime);
+  });
+
+  test("db:upsert with worker pidStartTime: null disables PID protection (no fallback)", () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    const { logger, messages } = capturingLogger();
+    let fnCallCount = 0;
+    server = new ClaudeServer(db, undefined, undefined, logger, 10_000, undefined, () => {
+      fnCallCount++;
+      return 99999;
+    });
+
+    const handle = (server as unknown as { handleWorkerEvent: (e: unknown) => void }).handleWorkerEvent.bind(server);
+    handle({
+      type: "db:upsert",
+      session: { sessionId: "worker-pst-null", pid: 12345, pidStartTime: null, state: "active" },
+    });
+
+    // Worker explicitly signaled null — do not call getProcessStartTimeFn (would still hit main thread)
+    expect(fnCallCount).toBe(0);
+    expect(
+      messages.some((m) => m.level === "warn" && String(m.args[0]).includes("PID reuse protection disabled")),
+    ).toBe(true);
+    const row = db.getSession("worker-pst-null");
+    expect(row?.pidStartTime ?? null).toBeNull();
+  });
+
   test("worker db:state event updates session state", () => {
     using opts = testOptions();
     db = new StateDb(opts.DB_PATH);

--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -42,6 +42,8 @@ interface DbUpsert {
   session: {
     sessionId: string;
     pid?: number;
+    /** Captured by the worker at spawn time (off main thread) to avoid blocking ps(1) call on main. */
+    pidStartTime?: number | null;
     state?: string;
     model?: string;
     cwd?: string;
@@ -631,11 +633,17 @@ export class ClaudeServer {
         break;
       case "db:upsert": {
         this.activeSessions.add(event.session.sessionId);
-        const upsertData: Parameters<StateDb["upsertSession"]>[0] = { ...event.session };
+        // Exclude pidStartTime from spread — we set it explicitly below after null-check.
+        const { pidStartTime: _workerPidStartTime, ...sessionFields } = event.session;
+        const upsertData: Parameters<StateDb["upsertSession"]>[0] = { ...sessionFields };
         if (event.session.pid != null) {
           this.sessionPids.set(event.session.sessionId, event.session.pid);
-          // Capture process start time for PID reuse detection
-          const startTime = this.getProcessStartTimeFn(event.session.pid);
+          // Use pidStartTime provided by the worker (captured off-main-thread at spawn time).
+          // Fall back to getProcessStartTimeFn only if the worker didn't supply it.
+          const startTime =
+            event.session.pidStartTime !== undefined
+              ? event.session.pidStartTime
+              : this.getProcessStartTimeFn(event.session.pid);
           if (startTime != null) {
             this.sessionPidStartTimes.set(event.session.sessionId, startTime);
             upsertData.pidStartTime = startTime;

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -8,7 +8,7 @@
  *   4. Worker sends MCP JSON-RPC responses + DB event messages back
  *
  * DB event messages (worker → parent) for SQLite persistence:
- *   { type: "db:upsert", session: { sessionId, pid?, state?, model?, cwd?, worktree? } }
+ *   { type: "db:upsert", session: { sessionId, pid?, pidStartTime?, state?, model?, cwd?, worktree? } }
  *   { type: "db:state", sessionId, state }
  *   { type: "db:cost", sessionId, cost, tokens }
  *   { type: "db:end", sessionId }
@@ -21,6 +21,7 @@ import { DEFAULT_SAFE_TOOLS, type PermissionRule, type PermissionStrategy } from
 import type { SessionEvent } from "./claude-session/session-state";
 import { CLAUDE_TOOLS } from "./claude-session/tools";
 import { ClaudeWsServer, type WaitResult, WaitTimeoutError } from "./claude-session/ws-server";
+import { getProcessStartTime } from "./process-identity";
 import { createIsControlMessage } from "./worker-control-message";
 import { WorkerServerTransport } from "./worker-transport";
 
@@ -174,10 +175,14 @@ async function handlePrompt(
 
     const pid = server.spawnClaude(sessionId);
 
-    // Update DB with PID
+    // Capture pidStartTime here in the worker thread (off the main event loop)
+    // so the parent doesn't need to do a blocking ps(1) call per session.
+    const pidStartTime = getProcessStartTime(pid);
+
+    // Update DB with PID and start time
     self.postMessage({
       type: "db:upsert",
-      session: { sessionId, pid },
+      session: { sessionId, pid, pidStartTime },
     });
   }
 


### PR DESCRIPTION
## Summary
- `pruneDeadSessions` already batches its `ps(1)` calls via `findDeadPids`, but when a new session registers via `db:upsert` with a PID, `claude-server.ts` was calling `getProcessStartTime(pid)` → `Bun.spawnSync(["ps", ...])` on the main event loop — one blocking call per new session spawn
- Moved the `ps(1)` call into the worker thread (`claude-session-worker.ts`), which runs off the main loop; the worker captures `pidStartTime` immediately after `spawnClaude()` and includes it in the `db:upsert` message
- `claude-server.ts` uses the worker-provided `pidStartTime` directly; falls back to `getProcessStartTimeFn` only when `pidStartTime` is absent (backward compatibility)

## Test plan
- Added test: worker-provided `pidStartTime` is used directly without calling `getProcessStartTimeFn` (verifies call count = 0)
- Added test: when `pidStartTime` is omitted from worker event, falls back to `getProcessStartTimeFn`
- Added test: when worker provides `pidStartTime: null` (capture failed), emits warning without calling `getProcessStartTimeFn` again
- All 2684 tests pass, coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)