### PR TITLE
feat(control): plan data fetching hooks — usePlans, usePlan, usePlanMetrics (fixes #703)

### DIFF
--- a/packages/control/src/hooks/use-plans.spec.ts
+++ b/packages/control/src/hooks/use-plans.spec.ts
@@ -1,0 +1,476 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import type { Plan, PlanMetrics } from "@mcp-cli/core";
+import { Text } from "ink";
+import { render } from "ink-testing-library";
+import React, { type FC } from "react";
+import {
+  type UsePlanMetricsOptions,
+  type UsePlanOptions,
+  type UsePlansOptions,
+  usePlan,
+  usePlanMetrics,
+  usePlans,
+} from "./use-plans";
+
+/* ---------- fixtures ---------- */
+
+function makePlan(id: string, server: string): Plan {
+  return {
+    id,
+    name: `Plan ${id}`,
+    status: "active",
+    server,
+    steps: [{ id: "step-1", name: "Step 1", status: "active" }],
+    activeStepId: "step-1",
+  };
+}
+
+function planToolResult(plans: Plan[]): object {
+  return { content: [{ type: "text", text: JSON.stringify({ plans }) }] };
+}
+
+function planDetailResult(plan: Plan): object {
+  return { content: [{ type: "text", text: JSON.stringify({ plan }) }] };
+}
+
+function metricsResult(metrics: PlanMetrics): object {
+  return { content: [{ type: "text", text: JSON.stringify({ metrics }) }] };
+}
+
+function daemonStatus(servers: Array<{ name: string; hasList?: boolean; hasAdvance?: boolean; hasMetrics?: boolean }>) {
+  return {
+    pid: 1,
+    uptime: 0,
+    protocolVersion: "1",
+    dbPath: "/tmp/db",
+    servers: servers.map((s) => {
+      const capabilities: string[] = [];
+      if (s.hasList !== false) capabilities.push("list");
+      if (s.hasAdvance) capabilities.push("advance");
+      if (s.hasMetrics) capabilities.push("metrics");
+      return {
+        name: s.name,
+        transport: "stdio" as const,
+        state: "connected" as const,
+        toolCount: 1,
+        source: "test",
+        planCapabilities: { capabilities },
+      };
+    }),
+    usageStats: [],
+  };
+}
+
+async function flush(ms = 10) {
+  await Bun.sleep(ms);
+}
+
+/* ---------- usePlans tests ---------- */
+
+describe("usePlans", () => {
+  interface HookState {
+    plans: Plan[];
+    loading: boolean;
+    error: string | null;
+    disconnected: boolean;
+  }
+
+  const instances: ReturnType<typeof render>[] = [];
+
+  afterEach(() => {
+    for (const inst of instances) inst.unmount();
+    instances.length = 0;
+  });
+
+  const Harness: FC<{ opts: UsePlansOptions; stateRef: { current: HookState } }> = ({ opts, stateRef }) => {
+    const result = usePlans(opts);
+    stateRef.current = result;
+    return React.createElement(Text, null, "ok");
+  };
+
+  function mount(opts: UsePlansOptions) {
+    const stateRef: { current: HookState } = {
+      current: { plans: [], loading: true, error: null, disconnected: false },
+    };
+    const instance = render(React.createElement(Harness, { opts, stateRef }));
+    instances.push(instance);
+    return { instance, stateRef };
+  }
+
+  it("fetches plans from plan-capable servers on mount", async () => {
+    const plan = makePlan("plan-1", "test-server");
+    const ipcCallFn = async (method: string, params?: unknown) => {
+      if (method === "status") return daemonStatus([{ name: "test-server", hasList: true }]);
+      return planToolResult([plan]);
+    };
+
+    const { stateRef } = mount({ ipcCallFn: ipcCallFn as UsePlansOptions["ipcCallFn"] });
+    await flush();
+
+    expect(stateRef.current.plans).toHaveLength(1);
+    expect(stateRef.current.plans[0].id).toBe("plan-1");
+    expect(stateRef.current.loading).toBe(false);
+    expect(stateRef.current.error).toBeNull();
+    expect(stateRef.current.disconnected).toBe(false);
+  });
+
+  it("aggregates plans from multiple plan-capable servers", async () => {
+    const plan1 = makePlan("plan-1", "server-a");
+    const plan2 = makePlan("plan-2", "server-b");
+    const ipcCallFn = async (method: string, params?: unknown) => {
+      if (method === "status") {
+        return daemonStatus([
+          { name: "server-a", hasList: true },
+          { name: "server-b", hasList: true },
+        ]);
+      }
+      const p = params as { server: string };
+      if (p.server === "server-a") return planToolResult([plan1]);
+      if (p.server === "server-b") return planToolResult([plan2]);
+      return planToolResult([]);
+    };
+
+    const { stateRef } = mount({ ipcCallFn: ipcCallFn as UsePlansOptions["ipcCallFn"] });
+    await flush();
+
+    expect(stateRef.current.plans).toHaveLength(2);
+    expect(stateRef.current.loading).toBe(false);
+  });
+
+  it("skips servers without list capability", async () => {
+    let callToolCallCount = 0;
+    const ipcCallFn = async (method: string) => {
+      if (method === "status") {
+        return daemonStatus([{ name: "no-plan-server", hasList: false }]);
+      }
+      callToolCallCount++;
+      return planToolResult([]);
+    };
+
+    mount({ ipcCallFn: ipcCallFn as UsePlansOptions["ipcCallFn"] });
+    await flush();
+
+    expect(callToolCallCount).toBe(0);
+  });
+
+  it("sets disconnected and error when status call fails", async () => {
+    const ipcCallFn = async () => {
+      throw new Error("daemon offline");
+    };
+
+    const { stateRef } = mount({ ipcCallFn: ipcCallFn as UsePlansOptions["ipcCallFn"] });
+    await flush();
+
+    expect(stateRef.current.error).toBe("daemon offline");
+    expect(stateRef.current.disconnected).toBe(true);
+    expect(stateRef.current.loading).toBe(false);
+  });
+
+  it("does not poll when enabled=false", async () => {
+    let callCount = 0;
+    const ipcCallFn = async () => {
+      callCount++;
+      return daemonStatus([]);
+    };
+
+    mount({ enabled: false, ipcCallFn: ipcCallFn as UsePlansOptions["ipcCallFn"] });
+    await flush(30);
+
+    expect(callCount).toBe(0);
+  });
+
+  it("continues when one server's callTool fails", async () => {
+    const plan = makePlan("plan-1", "good-server");
+    const ipcCallFn = async (method: string, params?: unknown) => {
+      if (method === "status") {
+        return daemonStatus([
+          { name: "good-server", hasList: true },
+          { name: "bad-server", hasList: true },
+        ]);
+      }
+      const p = params as { server: string };
+      if (p.server === "bad-server") throw new Error("server unreachable");
+      return planToolResult([plan]);
+    };
+
+    const { stateRef } = mount({ ipcCallFn: ipcCallFn as UsePlansOptions["ipcCallFn"] });
+    await flush();
+
+    // Plans from good server still returned; no top-level error
+    expect(stateRef.current.plans).toHaveLength(1);
+    expect(stateRef.current.error).toBeNull();
+  });
+
+  it("cleanup stops polling on unmount", async () => {
+    let callCount = 0;
+    const ipcCallFn = async () => {
+      callCount++;
+      return daemonStatus([]);
+    };
+
+    const { instance } = mount({
+      intervalMs: 30,
+      ipcCallFn: ipcCallFn as UsePlansOptions["ipcCallFn"],
+    });
+
+    await flush(50);
+    instance.unmount();
+    instances.pop();
+    const countAtUnmount = callCount;
+
+    await flush(100);
+    expect(callCount).toBe(countAtUnmount);
+  });
+});
+
+/* ---------- usePlan tests ---------- */
+
+describe("usePlan", () => {
+  interface HookState {
+    plan: Plan | null;
+    loading: boolean;
+    error: string | null;
+    canAdvance: boolean;
+    disconnected: boolean;
+  }
+
+  const instances: ReturnType<typeof render>[] = [];
+
+  afterEach(() => {
+    for (const inst of instances) inst.unmount();
+    instances.length = 0;
+  });
+
+  const Harness: FC<{
+    planId: string;
+    server: string;
+    opts: UsePlanOptions;
+    stateRef: { current: HookState };
+  }> = ({ planId, server, opts, stateRef }) => {
+    const result = usePlan(planId, server, opts);
+    stateRef.current = result;
+    return React.createElement(Text, null, "ok");
+  };
+
+  function mount(planId: string, server: string, opts: UsePlanOptions) {
+    const stateRef: { current: HookState } = {
+      current: { plan: null, loading: true, error: null, canAdvance: false, disconnected: false },
+    };
+    const instance = render(React.createElement(Harness, { planId, server, opts, stateRef }));
+    instances.push(instance);
+    return { instance, stateRef };
+  }
+
+  it("fetches plan on mount", async () => {
+    const plan = makePlan("plan-1", "srv");
+    const ipcCallFn = async () => planDetailResult(plan);
+
+    const { stateRef } = mount("plan-1", "srv", {
+      ipcCallFn: ipcCallFn as UsePlanOptions["ipcCallFn"],
+    });
+    await flush();
+
+    expect(stateRef.current.plan?.id).toBe("plan-1");
+    expect(stateRef.current.loading).toBe(false);
+    expect(stateRef.current.error).toBeNull();
+    expect(stateRef.current.disconnected).toBe(false);
+  });
+
+  it("exposes canAdvance=false by default", async () => {
+    const plan = makePlan("plan-1", "srv");
+    const ipcCallFn = async () => planDetailResult(plan);
+
+    const { stateRef } = mount("plan-1", "srv", {
+      ipcCallFn: ipcCallFn as UsePlanOptions["ipcCallFn"],
+    });
+    await flush();
+
+    expect(stateRef.current.canAdvance).toBe(false);
+  });
+
+  it("exposes canAdvance=true when provided", async () => {
+    const plan = makePlan("plan-1", "srv");
+    const ipcCallFn = async () => planDetailResult(plan);
+
+    const { stateRef } = mount("plan-1", "srv", {
+      canAdvance: true,
+      ipcCallFn: ipcCallFn as UsePlanOptions["ipcCallFn"],
+    });
+    await flush();
+
+    expect(stateRef.current.canAdvance).toBe(true);
+  });
+
+  it("sets disconnected and error when callTool fails", async () => {
+    const ipcCallFn = async () => {
+      throw new Error("server offline");
+    };
+
+    const { stateRef } = mount("plan-1", "srv", {
+      ipcCallFn: ipcCallFn as UsePlanOptions["ipcCallFn"],
+    });
+    await flush();
+
+    expect(stateRef.current.error).toBe("server offline");
+    expect(stateRef.current.disconnected).toBe(true);
+    expect(stateRef.current.loading).toBe(false);
+  });
+
+  it("does not fetch when enabled=false", async () => {
+    let callCount = 0;
+    const ipcCallFn = async () => {
+      callCount++;
+      return planDetailResult(makePlan("plan-1", "srv"));
+    };
+
+    mount("plan-1", "srv", {
+      enabled: false,
+      ipcCallFn: ipcCallFn as UsePlanOptions["ipcCallFn"],
+    });
+    await flush(30);
+
+    expect(callCount).toBe(0);
+  });
+});
+
+/* ---------- usePlanMetrics tests ---------- */
+
+describe("usePlanMetrics", () => {
+  interface HookState {
+    metrics: PlanMetrics | null;
+    loading: boolean;
+    error: string | null;
+  }
+
+  const instances: ReturnType<typeof render>[] = [];
+
+  afterEach(() => {
+    for (const inst of instances) inst.unmount();
+    instances.length = 0;
+  });
+
+  const Harness: FC<{
+    planId: string;
+    stepId: string | undefined;
+    server: string;
+    opts: UsePlanMetricsOptions;
+    stateRef: { current: HookState };
+  }> = ({ planId, stepId, server, opts, stateRef }) => {
+    const result = usePlanMetrics(planId, stepId, server, opts);
+    stateRef.current = result;
+    return React.createElement(Text, null, "ok");
+  };
+
+  function mount(planId: string, stepId: string | undefined, server: string, opts: UsePlanMetricsOptions) {
+    const stateRef: { current: HookState } = {
+      current: { metrics: null, loading: false, error: null },
+    };
+    const instance = render(React.createElement(Harness, { planId, stepId, server, opts, stateRef }));
+    instances.push(instance);
+    return { instance, stateRef };
+  }
+
+  it("returns null immediately when supportsMetrics=false", async () => {
+    let callCount = 0;
+    const ipcCallFn = async () => {
+      callCount++;
+      return metricsResult({ steps_complete: 1 });
+    };
+
+    const { stateRef } = mount("plan-1", "step-1", "srv", {
+      supportsMetrics: false,
+      ipcCallFn: ipcCallFn as UsePlanMetricsOptions["ipcCallFn"],
+    });
+    await flush(30);
+
+    expect(callCount).toBe(0);
+    expect(stateRef.current.metrics).toBeNull();
+    expect(stateRef.current.loading).toBe(false);
+  });
+
+  it("polls metrics when supportsMetrics=true", async () => {
+    const metrics: PlanMetrics = { steps_complete: 2, duration_ms: 1234 };
+    const ipcCallFn = async () => metricsResult(metrics);
+
+    const { stateRef } = mount("plan-1", "step-1", "srv", {
+      supportsMetrics: true,
+      ipcCallFn: ipcCallFn as UsePlanMetricsOptions["ipcCallFn"],
+    });
+    await flush();
+
+    expect(stateRef.current.metrics).toEqual(metrics);
+    expect(stateRef.current.loading).toBe(false);
+    expect(stateRef.current.error).toBeNull();
+  });
+
+  it("sets error when callTool fails", async () => {
+    const ipcCallFn = async () => {
+      throw new Error("metrics unavailable");
+    };
+
+    const { stateRef } = mount("plan-1", "step-1", "srv", {
+      supportsMetrics: true,
+      ipcCallFn: ipcCallFn as UsePlanMetricsOptions["ipcCallFn"],
+    });
+    await flush();
+
+    expect(stateRef.current.error).toBe("metrics unavailable");
+    expect(stateRef.current.loading).toBe(false);
+  });
+
+  it("polls repeatedly at intervalMs", async () => {
+    let callCount = 0;
+    const ipcCallFn = async () => {
+      callCount++;
+      return metricsResult({});
+    };
+
+    mount("plan-1", "step-1", "srv", {
+      supportsMetrics: true,
+      intervalMs: 30,
+      ipcCallFn: ipcCallFn as UsePlanMetricsOptions["ipcCallFn"],
+    });
+
+    await flush(100);
+    expect(callCount).toBeGreaterThanOrEqual(3);
+  });
+
+  it("cleanup stops polling on unmount", async () => {
+    let callCount = 0;
+    const ipcCallFn = async () => {
+      callCount++;
+      return metricsResult({});
+    };
+
+    const { instance } = mount("plan-1", "step-1", "srv", {
+      supportsMetrics: true,
+      intervalMs: 30,
+      ipcCallFn: ipcCallFn as UsePlanMetricsOptions["ipcCallFn"],
+    });
+
+    await flush(50);
+    instance.unmount();
+    instances.pop();
+    const countAtUnmount = callCount;
+
+    await flush(100);
+    expect(callCount).toBe(countAtUnmount);
+  });
+
+  it("does not poll when enabled=false", async () => {
+    let callCount = 0;
+    const ipcCallFn = async () => {
+      callCount++;
+      return metricsResult({});
+    };
+
+    mount("plan-1", "step-1", "srv", {
+      supportsMetrics: true,
+      enabled: false,
+      ipcCallFn: ipcCallFn as UsePlanMetricsOptions["ipcCallFn"],
+    });
+
+    await flush(30);
+    expect(callCount).toBe(0);
+  });
+});

--- a/packages/control/src/hooks/use-plans.ts
+++ b/packages/control/src/hooks/use-plans.ts
@@ -1,0 +1,269 @@
+import type { Plan, PlanMetrics, ServerStatus } from "@mcp-cli/core";
+import { GetPlanMetricsResultSchema, GetPlanResultSchema, ListPlansResultSchema } from "@mcp-cli/core";
+import { ipcCall } from "@mcp-cli/core";
+import { useEffect, useRef, useState } from "react";
+import { extractToolText } from "./ipc-tool-helpers.js";
+
+// -- usePlans --
+
+export interface UsePlansResult {
+  plans: Plan[];
+  loading: boolean;
+  error: string | null;
+  /** True when the last poll failed (stale data is shown). */
+  disconnected: boolean;
+}
+
+export interface UsePlansOptions {
+  intervalMs?: number;
+  enabled?: boolean;
+  /** Override ipcCall for testing (dependency injection). */
+  ipcCallFn?: typeof ipcCall;
+}
+
+/**
+ * Polls `list_plans` on all plan-capable servers every 30s.
+ * Aggregates results across all servers into a single flat list.
+ */
+export function usePlans(opts: UsePlansOptions = {}): UsePlansResult {
+  const { intervalMs = 30_000, enabled = true, ipcCallFn = ipcCall } = opts;
+  const [plans, setPlans] = useState<Plan[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [disconnected, setDisconnected] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let cancelled = false;
+
+    async function poll() {
+      try {
+        const status = await ipcCallFn("status");
+        if (cancelled) return;
+
+        const planServers = status.servers.filter(
+          (s: ServerStatus) => s.state === "connected" && s.planCapabilities?.capabilities.includes("list"),
+        );
+
+        const allPlans: Plan[] = [];
+
+        await Promise.allSettled(
+          planServers.map(async (srv: ServerStatus) => {
+            try {
+              const result = await ipcCallFn("callTool", {
+                server: srv.name,
+                tool: "list_plans",
+                arguments: {},
+              });
+              const text = extractToolText(result);
+              if (!text) return;
+              const parsed = ListPlansResultSchema.safeParse(JSON.parse(text));
+              if (parsed.success) {
+                allPlans.push(...parsed.data.plans);
+              }
+            } catch {
+              // One server failing doesn't break the whole list
+            }
+          }),
+        );
+
+        if (cancelled) return;
+        setPlans(allPlans);
+        setError(null);
+        setDisconnected(false);
+        setLoading(false);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+        setDisconnected(true);
+        setLoading(false);
+      }
+    }
+
+    let timerId: ReturnType<typeof setTimeout> | undefined;
+
+    async function scheduleNext() {
+      await poll();
+      if (!cancelled) {
+        timerId = setTimeout(scheduleNext, intervalMs);
+      }
+    }
+
+    scheduleNext();
+
+    return () => {
+      cancelled = true;
+      if (timerId !== undefined) clearTimeout(timerId);
+    };
+  }, [intervalMs, enabled, ipcCallFn]);
+
+  return { plans, loading, error, disconnected };
+}
+
+// -- usePlan --
+
+export interface UsePlanResult {
+  plan: Plan | null;
+  loading: boolean;
+  error: string | null;
+  /** True when the server has `advance_plan` capability. */
+  canAdvance: boolean;
+  /** True when the last fetch failed (stale data is shown). */
+  disconnected: boolean;
+}
+
+export interface UsePlanOptions {
+  enabled?: boolean;
+  /**
+   * Whether the plan server supports `advance_plan`.
+   * Pass from server's `planCapabilities` (e.g. from `usePlans` or `useDaemon`).
+   * Defaults to false if not provided.
+   */
+  canAdvance?: boolean;
+  /** Override ipcCall for testing (dependency injection). */
+  ipcCallFn?: typeof ipcCall;
+}
+
+/**
+ * Fetches a single plan via `get_plan`. Re-fetches when planId or server changes.
+ */
+export function usePlan(planId: string, server: string, opts: UsePlanOptions = {}): UsePlanResult {
+  const { enabled = true, canAdvance = false, ipcCallFn = ipcCall } = opts;
+  const [plan, setPlan] = useState<Plan | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [disconnected, setDisconnected] = useState(false);
+
+  useEffect(() => {
+    if (!enabled || !planId || !server) return;
+
+    let cancelled = false;
+
+    async function fetch() {
+      try {
+        const result = await ipcCallFn("callTool", {
+          server,
+          tool: "get_plan",
+          arguments: { planId },
+        });
+        if (cancelled) return;
+        const text = extractToolText(result);
+        if (text) {
+          const parsed = GetPlanResultSchema.safeParse(JSON.parse(text));
+          if (parsed.success) {
+            setPlan(parsed.data.plan);
+          }
+        }
+        setError(null);
+        setDisconnected(false);
+        setLoading(false);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+        setDisconnected(true);
+        setLoading(false);
+      }
+    }
+
+    fetch();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [planId, server, enabled, ipcCallFn]);
+
+  return { plan, loading, error, canAdvance, disconnected };
+}
+
+// -- usePlanMetrics --
+
+export interface UsePlanMetricsResult {
+  metrics: PlanMetrics | null;
+  loading: boolean;
+  error: string | null;
+}
+
+export interface UsePlanMetricsOptions {
+  intervalMs?: number;
+  enabled?: boolean;
+  /**
+   * Whether the plan server supports `get_plan_metrics`.
+   * When false, the hook returns null immediately without polling.
+   * Pass from server's `planCapabilities.capabilities.includes("metrics")`.
+   */
+  supportsMetrics?: boolean;
+  /** Override ipcCall for testing (dependency injection). */
+  ipcCallFn?: typeof ipcCall;
+}
+
+/**
+ * Polls `get_plan_metrics` every 5s for the given plan/step.
+ * Returns `{ metrics: null }` when the server doesn't support metrics.
+ */
+export function usePlanMetrics(
+  planId: string,
+  stepId: string | undefined,
+  server: string,
+  opts: UsePlanMetricsOptions = {},
+): UsePlanMetricsResult {
+  const { intervalMs = 5_000, enabled = true, supportsMetrics = false, ipcCallFn = ipcCall } = opts;
+  const [metrics, setMetrics] = useState<PlanMetrics | null>(null);
+  const [loading, setLoading] = useState(supportsMetrics);
+  const [error, setError] = useState<string | null>(null);
+
+  // Track supportsMetrics in a ref so the effect can read the latest value
+  const supportsRef = useRef(supportsMetrics);
+  supportsRef.current = supportsMetrics;
+
+  useEffect(() => {
+    if (!enabled || !supportsMetrics || !planId || !server) {
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function poll() {
+      try {
+        const result = await ipcCallFn("callTool", {
+          server,
+          tool: "get_plan_metrics",
+          arguments: stepId ? { planId, stepId } : { planId },
+        });
+        if (cancelled) return;
+        const text = extractToolText(result);
+        if (text) {
+          const parsed = GetPlanMetricsResultSchema.safeParse(JSON.parse(text));
+          if (parsed.success) {
+            setMetrics(parsed.data.metrics);
+          }
+        }
+        setError(null);
+        setLoading(false);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+        setLoading(false);
+      }
+    }
+
+    let timerId: ReturnType<typeof setTimeout> | undefined;
+
+    async function scheduleNext() {
+      await poll();
+      if (!cancelled) {
+        timerId = setTimeout(scheduleNext, intervalMs);
+      }
+    }
+
+    scheduleNext();
+
+    return () => {
+      cancelled = true;
+      if (timerId !== undefined) clearTimeout(timerId);
+    };
+  }, [planId, stepId, server, intervalMs, enabled, supportsMetrics, ipcCallFn]);
+
+  return { metrics, loading, error };
+}


### PR DESCRIPTION
## Summary

- `usePlans()` — discovers plan-capable servers via `status` IPC (using `ServerStatus.planCapabilities`), calls `list_plans` on each, aggregates into a flat list, polls every 30s. Per-server failures are silenced so one bad server doesn't break the whole list.
- `usePlan(planId, server, opts)` — fetches a single plan via `get_plan` callTool, re-fetches on planId/server change. Exposes `canAdvance` (caller-provided from server capabilities) and `disconnected` flag on error.
- `usePlanMetrics(planId, stepId, server, opts)` — polls `get_plan_metrics` every 5s; returns `null` immediately without any IPC calls when `supportsMetrics=false` for graceful degradation.

All three hooks follow existing patterns (dependency injection `ipcCallFn`, `cancelled` guard, `scheduleNext` polling loop).

## Test plan

- [x] 18 tests across `usePlans`, `usePlan`, and `usePlanMetrics`
- [x] Happy path: plans fetched and returned correctly
- [x] Multi-server aggregation in `usePlans`
- [x] Server without `list` capability skipped (no callTool made)
- [x] Per-server callTool failures don't propagate to error state
- [x] `disconnected: true` set when status/callTool throws
- [x] `enabled=false` skips all polling
- [x] `supportsMetrics=false` returns null without polling
- [x] `canAdvance` reflected correctly from option
- [x] Cleanup on unmount stops polling
- [x] 100% line and function coverage on `use-plans.ts`
- [x] Full test suite: 2712 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)