### PR TITLE
chore(test): suppress worker log noise from restoreSessions (fixes #680)

### DIFF
--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -10,7 +10,7 @@
  */
 
 import type { JsonSchema, Logger, ToolInfo } from "@mcp-cli/core";
-import { consoleLogger, formatToolSignature } from "@mcp-cli/core";
+import { consoleLogger, formatToolSignature, silentLogger } from "@mcp-cli/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { CLAUDE_TOOLS } from "./claude-session/tools";
 import type { StateDb } from "./db/state";
@@ -209,7 +209,12 @@ export class ClaudeServer {
         if (cleanup()) reject(new Error(`Claude session worker error: ${msg}`));
       };
       // Send init to start the worker
-      worker.postMessage({ type: "init", daemonId: this.daemonId, wsPort: this.configuredWsPort });
+      worker.postMessage({
+        type: "init",
+        daemonId: this.daemonId,
+        wsPort: this.configuredWsPort,
+        quiet: this.logger === silentLogger,
+      });
     });
 
     // Set up MCP transport and connect — if anything throws, terminate the worker

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -14,7 +14,7 @@
  *   { type: "db:end", sessionId }
  */
 
-import { generateSpanId, resolveModelName } from "@mcp-cli/core";
+import { generateSpanId, resolveModelName, silentLogger } from "@mcp-cli/core";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { DEFAULT_SAFE_TOOLS, type PermissionRule, type PermissionStrategy } from "./claude-session/permission-router";
@@ -30,6 +30,8 @@ interface InitMessage {
   type: "init";
   daemonId?: string;
   wsPort?: number;
+  /** Suppress worker-side console logging (used in tests). */
+  quiet?: boolean;
 }
 
 interface ToolsChangedMessage {
@@ -354,9 +356,9 @@ function forwardSessionEvent(sessionId: string, event: SessionEvent): void {
 
 // ── Server startup ──
 
-async function startServer(wsPort?: number): Promise<number> {
+async function startServer(wsPort?: number, quiet?: boolean): Promise<number> {
   // Start WebSocket server
-  wsServer = new ClaudeWsServer();
+  wsServer = new ClaudeWsServer({ logger: quiet ? silentLogger : undefined });
   const port = await wsServer.start(wsPort);
   wsServer.onSessionEvent = forwardSessionEvent;
 
@@ -406,7 +408,7 @@ self.onmessage = async (event: MessageEvent) => {
     daemonId = data.daemonId;
     workerId = generateSpanId();
     try {
-      const port = await startServer(data.wsPort);
+      const port = await startServer(data.wsPort, data.quiet);
       self.postMessage({ type: "ready", port });
     } catch (err) {
       // Clean up partially-initialized resources

--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -43,7 +43,7 @@ const TIMING_EXCLUSIONS: Record<string, string> = {
  * Matches daemon log prefixes ([mcpd], [_claude], [_aliases]) and
  * production signals (MCPD_READY). Ratchet this down toward zero.
  */
-const NOISE_THRESHOLD = 22;
+const NOISE_THRESHOLD = 14;
 
 /** Per-file minimum coverage — every file must meet this unless excluded */
 const PER_FILE_MIN_LINES = 80;


### PR DESCRIPTION
## Summary
- Adds `quiet?: boolean` to the worker `init` message in `claude-session-worker.ts`; when set, `ClaudeWsServer` is created with `silentLogger`, suppressing the `[_claude] Restored session ...` `console.info` calls that were leaking into test output
- `ClaudeServer` passes `quiet: true` automatically when its own logger is `silentLogger` (the pattern used in all integration tests)
- Ratchets `NOISE_THRESHOLD` in `scripts/check-coverage.ts` from 22 down to 14 (remaining 13 noise lines are `MCPD_READY` signals from integration tests that start real daemon processes)

## Test plan
- [x] `bun typecheck` — passes
- [x] `bun lint` — passes
- [x] `bun test` — 2694 pass, 0 fail
- [x] Verified `[_claude] Restored session` lines no longer appear in test output after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)