### PR TITLE
fix(command): resolve --cwd to absolute path before sending to daemon (fixes #723)

### DIFF
--- a/packages/command/src/commands/spawn-args.ts
+++ b/packages/command/src/commands/spawn-args.ts
@@ -5,6 +5,7 @@
  * Provider-specific flags are handled by callers via the `extra` hook.
  */
 
+import { resolve } from "node:path";
 import { resolveModelName } from "@mcp-cli/core";
 
 export interface SharedSpawnArgs {
@@ -58,8 +59,12 @@ export function parseSharedSpawnArgs(
       }
       if (allow.length === 0) error = "--allow requires at least one tool pattern";
     } else if (arg === "--cwd") {
-      cwd = args[++i];
-      if (!cwd) error = "--cwd requires a path";
+      const rawCwd = args[++i];
+      if (!rawCwd) {
+        error = "--cwd requires a path";
+      } else {
+        cwd = resolve(rawCwd);
+      }
     } else if (arg === "--timeout") {
       const val = args[++i];
       if (!val) {


### PR DESCRIPTION
## Summary
- `parseSharedSpawnArgs` now resolves `--cwd` to an absolute path at parse time using `path.resolve()`
- Previously, relative `--cwd` values were passed raw to the daemon, which resolved them against the daemon's own CWD — not the caller's CWD
- This caused spawned sessions to escape their intended worktree and edit files in the root repo

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes  
- [x] All 2737 tests pass
- [x] Pre-commit hook clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)