### PR TITLE
refactor(test): use ALIAS_SERVER_NAME constant in alias-server.spec.ts (fixes #732)

### DIFF
--- a/packages/daemon/src/alias-server.spec.ts
+++ b/packages/daemon/src/alias-server.spec.ts
@@ -134,7 +134,7 @@ describe("buildAliasToolCache", () => {
     expect(tool).toBeDefined();
 
     expect(tool?.name).toBe("greet");
-    expect(tool?.server).toBe("_aliases");
+    expect(tool?.server).toBe(ALIAS_SERVER_NAME);
     expect(tool?.description).toBe("Greet someone");
     expect(tool?.inputSchema).toEqual(inputSchema);
     expect(tool?.signature).toBeDefined();


### PR DESCRIPTION
## Summary
- Replace hardcoded `"_aliases"` string literal with `ALIAS_SERVER_NAME` constant in `alias-server.spec.ts:137`
- The constant was already imported but not used in this one assertion, missed during PR #710

## Test plan
- [x] Existing test still passes with the constant reference
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — 2737 tests pass, coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)