### PR TITLE
fix(test): prevent ECONNRESET leak in shutdown test (fixes #658)

### DIFF
--- a/packages/daemon/src/index.spec.ts
+++ b/packages/daemon/src/index.spec.ts
@@ -197,14 +197,9 @@ describe("daemon index.ts", () => {
 
       await handle.shutdown("SIGTERM");
 
-      // IPC should no longer respond
-      let threw = false;
-      try {
-        await rpc(socketPath, "ping");
-      } catch {
-        threw = true;
-      }
-      expect(threw).toBe(true);
+      // IPC should no longer respond — use expect().rejects to properly
+      // chain the rejection so it doesn't leak as an unhandled error (#658)
+      await expect(rpc(socketPath, "ping")).rejects.toThrow();
     });
 
     test("shutdown loop continues after one server stop() throws", async () => {


### PR DESCRIPTION
## Summary
- Replace manual try/catch with `expect().rejects.toThrow()` in the "shutdown stops IPC server" test
- This properly chains the promise rejection so it doesn't leak as an unhandled ECONNRESET error between tests

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — all 2737 tests pass, no coverage drop
- [x] Verified the specific test in `packages/daemon/src/index.spec.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)