### PR TITLE
fix(core): make PlanCapabilitySchema forward-compatible with unknown values (fixes #721)

### DIFF
--- a/packages/core/src/plan.spec.ts
+++ b/packages/core/src/plan.spec.ts
@@ -144,6 +144,16 @@ describe("PlanCapabilitySchema", () => {
       expect(PlanCapabilitySchema.parse(c)).toBe(c);
     }
   });
+
+  test("accepts unknown capability strings (forward compat)", () => {
+    expect(PlanCapabilitySchema.parse("subscribe")).toBe("subscribe");
+    expect(PlanCapabilitySchema.parse("cancel")).toBe("cancel");
+  });
+
+  test("rejects non-string values", () => {
+    expect(() => PlanCapabilitySchema.parse(42)).toThrow();
+    expect(() => PlanCapabilitySchema.parse(null)).toThrow();
+  });
 });
 
 describe("PlanProtocolCapabilitySchema", () => {
@@ -157,6 +167,11 @@ describe("PlanProtocolCapabilitySchema", () => {
     const serialized = JSON.stringify(cap);
     const parsed = PlanProtocolCapabilitySchema.parse(JSON.parse(serialized));
     expect(parsed.capabilities).toEqual(["list", "get", "advance"]);
+  });
+
+  test("accepts unknown capabilities (forward compat)", () => {
+    const cap = PlanProtocolCapabilitySchema.parse({ capabilities: ["list", "subscribe"] });
+    expect(cap.capabilities).toEqual(["list", "subscribe"]);
   });
 
   test("rejects non-array", () => {

--- a/packages/core/src/plan.ts
+++ b/packages/core/src/plan.ts
@@ -58,9 +58,12 @@ export type Plan = z.infer<typeof PlanSchema>;
 // -- Capability --
 
 export const PlanCapabilityValues = ["list", "get", "advance", "abort", "metrics"] as const;
-export type PlanCapability = (typeof PlanCapabilityValues)[number];
 
-export const PlanCapabilitySchema = z.enum(PlanCapabilityValues);
+// Open union: known capabilities are typed; unknown strings from newer daemons pass through
+// instead of throwing, preventing CLI crashes when daemon adds new capabilities.
+export type PlanCapability = (typeof PlanCapabilityValues)[number] | string;
+
+export const PlanCapabilitySchema = z.enum(PlanCapabilityValues).or(z.string());
 
 // Array (not Set) so JSON.stringify works correctly over IPC.
 export const PlanProtocolCapabilitySchema = z.object({


### PR DESCRIPTION
## Summary
- Changed `PlanCapabilitySchema` from strict `z.enum()` to open union `z.enum().or(z.string())`, matching the existing `PlanStatusSchema` pattern
- Updated `PlanCapability` type to include `| string` for forward compatibility
- Added tests for unknown capability strings and non-string rejection

## Test plan
- [x] `PlanCapabilitySchema` accepts known capabilities (`list`, `get`, `advance`, `abort`, `metrics`)
- [x] `PlanCapabilitySchema` accepts unknown strings (`subscribe`, `cancel`) without throwing
- [x] `PlanCapabilitySchema` rejects non-string values (numbers, null)
- [x] `PlanProtocolCapabilitySchema` accepts arrays containing unknown capabilities
- [x] All 2740 tests pass, typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)