### PR TITLE
fix(control): floor seconds in uptime display to avoid excessive precision (fixes #715)

### DIFF
--- a/packages/control/src/components/header.spec.ts
+++ b/packages/control/src/components/header.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { formatUptime } from "./header";
+
+describe("formatUptime", () => {
+  it("formats seconds only", () => {
+    expect(formatUptime(45)).toBe("45s");
+  });
+
+  it("formats minutes and seconds", () => {
+    expect(formatUptime(125)).toBe("2m 5s");
+  });
+
+  it("formats hours, minutes, and seconds", () => {
+    expect(formatUptime(3661)).toBe("1h 1m 1s");
+  });
+
+  it("floors fractional seconds from process.uptime()", () => {
+    expect(formatUptime(251.0678)).toBe("4m 11s");
+  });
+
+  it("floors fractional seconds under a minute", () => {
+    expect(formatUptime(11.9999)).toBe("11s");
+  });
+
+  it("handles zero", () => {
+    expect(formatUptime(0)).toBe("0s");
+  });
+});

--- a/packages/control/src/components/header.tsx
+++ b/packages/control/src/components/header.tsx
@@ -10,7 +10,7 @@ interface HeaderProps {
 export function formatUptime(seconds: number): string {
   const h = Math.floor(seconds / 3600);
   const m = Math.floor((seconds % 3600) / 60);
-  const s = seconds % 60;
+  const s = Math.floor(seconds % 60);
 
   const parts: string[] = [];
   if (h > 0) parts.push(`${h}h`);


### PR DESCRIPTION
## Summary
- Add `Math.floor()` to the seconds calculation in `formatUptime()` in `header.tsx`, matching the correct pattern already used in `stats-view.tsx`
- Before: `Uptime: 4m 11.067863000000017s` — After: `Uptime: 4m 11s`

## Test plan
- [x] Added `header.spec.ts` with 6 tests covering seconds-only, minutes+seconds, hours+minutes+seconds, fractional seconds, and zero
- [x] All 2743 tests pass
- [x] Typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)