### PR TITLE
fix(core): add limit/cursor pagination to ListPlans schemas (fixes #722)

### DIFF
--- a/packages/core/src/plan.spec.ts
+++ b/packages/core/src/plan.spec.ts
@@ -168,6 +168,8 @@ describe("IPC param/result schemas", () => {
   test("ListPlansParamsSchema — no filter", () => {
     const params = ListPlansParamsSchema.parse({});
     expect(params.server).toBeUndefined();
+    expect(params.limit).toBeUndefined();
+    expect(params.cursor).toBeUndefined();
   });
 
   test("ListPlansParamsSchema — server filter", () => {
@@ -175,11 +177,28 @@ describe("IPC param/result schemas", () => {
     expect(params.server).toBe("ci");
   });
 
+  test("ListPlansParamsSchema — pagination params", () => {
+    const params = ListPlansParamsSchema.parse({ server: "ci", limit: 10, cursor: "abc123" });
+    expect(params.server).toBe("ci");
+    expect(params.limit).toBe(10);
+    expect(params.cursor).toBe("abc123");
+  });
+
   test("ListPlansResultSchema", () => {
     const result = ListPlansResultSchema.parse({
       plans: [{ id: "p1", name: "X", status: "pending", server: "s", steps: [] }],
     });
     expect(result.plans).toHaveLength(1);
+    expect(result.cursor).toBeUndefined();
+  });
+
+  test("ListPlansResultSchema — with cursor", () => {
+    const result = ListPlansResultSchema.parse({
+      plans: [{ id: "p1", name: "X", status: "pending", server: "s", steps: [] }],
+      cursor: "next-page",
+    });
+    expect(result.plans).toHaveLength(1);
+    expect(result.cursor).toBe("next-page");
   });
 
   test("GetPlanParamsSchema", () => {

--- a/packages/core/src/plan.ts
+++ b/packages/core/src/plan.ts
@@ -73,12 +73,15 @@ export type PlanProtocolCapability = z.infer<typeof PlanProtocolCapabilitySchema
 
 export const ListPlansParamsSchema = z.object({
   server: z.string().optional(),
+  limit: z.number().optional(),
+  cursor: z.string().optional(),
 });
 
 export type ListPlansParams = z.infer<typeof ListPlansParamsSchema>;
 
 export const ListPlansResultSchema = z.object({
   plans: z.array(PlanSchema),
+  cursor: z.string().optional(),
 });
 
 export type ListPlansResult = z.infer<typeof ListPlansResultSchema>;


### PR DESCRIPTION
## Summary
- Added `limit` (number) and `cursor` (string) optional fields to `ListPlansParamsSchema` for bounded plan listing
- Added `cursor` (string) optional field to `ListPlansResultSchema` for cursor-based pagination
- Added tests covering the new pagination params and cursor in results

## Test plan
- [x] `ListPlansParamsSchema` parses with limit and cursor
- [x] `ListPlansParamsSchema` still works with no params (backward compatible)
- [x] `ListPlansResultSchema` parses with optional cursor
- [x] All 2739 tests pass, typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)