### PR TITLE
fix(mcpctl): add escape/left-arrow to collapse expanded session in Claude tab (fixes #720)

### DIFF
--- a/packages/control/src/hooks/use-keyboard-claude.spec.ts
+++ b/packages/control/src/hooks/use-keyboard-claude.spec.ts
@@ -258,6 +258,34 @@ describe("handleClaudeInput transcript navigation (expanded session)", () => {
     { direction: "inbound", timestamp: 2, message: { role: "assistant", content: "b" } },
   ];
 
+  test("escape collapses expanded session and resets transcript state", () => {
+    const nav = makeNav({
+      expandedSession: "sess-1",
+      transcriptEntries: entries,
+      transcriptCursor: "1-outbound",
+    });
+    const consumed = handleClaudeInput("", { ...baseKey, escape: true }, nav);
+    expect(consumed).toBe(true);
+    expect(nav.setExpandedSession).toHaveBeenCalledWith(null);
+    expect(nav.setTranscriptCursor).toHaveBeenCalled();
+    expect(nav.setTranscriptScrollOffset).toHaveBeenCalled();
+    expect(nav.setExpandedEntries).toHaveBeenCalled();
+  });
+
+  test("left arrow collapses expanded session", () => {
+    const nav = makeNav({
+      expandedSession: "sess-1",
+      transcriptEntries: entries,
+      transcriptCursor: "1-outbound",
+    });
+    const consumed = handleClaudeInput("", { ...baseKey, leftArrow: true }, nav);
+    expect(consumed).toBe(true);
+    expect(nav.setExpandedSession).toHaveBeenCalledWith(null);
+    expect(nav.setTranscriptCursor).toHaveBeenCalled();
+    expect(nav.setTranscriptScrollOffset).toHaveBeenCalled();
+    expect(nav.setExpandedEntries).toHaveBeenCalled();
+  });
+
   test("j moves transcript cursor down", () => {
     let result: string | null = null;
     const nav = makeNav({

--- a/packages/control/src/hooks/use-keyboard-claude.ts
+++ b/packages/control/src/hooks/use-keyboard-claude.ts
@@ -104,6 +104,15 @@ export function handleClaudeInput(input: string, key: Key, nav: ClaudeNav): bool
 
   // When transcript is expanded, j/k navigate within transcript entries
   if (expandedSession) {
+    // Escape or left arrow: collapse transcript back to session list
+    if (key.escape || key.leftArrow) {
+      setExpandedSession(null);
+      setTranscriptCursor(() => null);
+      setTranscriptScrollOffset(() => 0);
+      setExpandedEntries(() => new Set());
+      return true;
+    }
+
     if (key.upArrow || input === "k") {
       setTranscriptCursor((cur) => {
         const idx = cur ? transcriptEntries.findIndex((e) => entryKey(e) === cur) : 0;

--- a/packages/control/src/hooks/use-keyboard.ts
+++ b/packages/control/src/hooks/use-keyboard.ts
@@ -233,6 +233,9 @@ export function useKeyboard({
     if (key.escape && view !== "servers") {
       if (escAction(view, claudeNav.expandedSession) === "collapse-transcript") {
         claudeNav.setExpandedSession(null);
+        claudeNav.setTranscriptCursor(() => null);
+        claudeNav.setTranscriptScrollOffset(() => 0);
+        claudeNav.setExpandedEntries(() => new Set());
         return;
       }
       if (view === "mail" && mailNav.expandedMessage !== null) {


### PR DESCRIPTION
## Summary
- When a session transcript is expanded in mcpctl's Claude tab, Escape and ← now collapse back to the session list
- Left arrow was previously consumed by the permission index navigator even when transcript was expanded — now it collapses instead
- Collapsing resets transcript state (cursor, scroll offset, expanded entries) to avoid stale UI on re-expand

## Test plan
- [x] Added test: Escape collapses expanded session and resets transcript state
- [x] Added test: Left arrow collapses expanded session
- [x] All 2739 existing tests pass
- [x] Typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)