### PR TITLE
feat(mcpctl): warn when WS port falls back to random (fixes #717)

### DIFF
--- a/packages/control/src/components/header.spec.tsx
+++ b/packages/control/src/components/header.spec.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "bun:test";
+import type { DaemonStatus } from "@mcp-cli/core";
+import { render } from "ink-testing-library";
+import React from "react";
+import { Header, formatUptime } from "./header";
+
+function status(overrides: Partial<DaemonStatus> = {}): DaemonStatus {
+  return {
+    pid: 1234,
+    uptime: 100,
+    protocolVersion: "1",
+    servers: [],
+    dbPath: "/tmp/test.db",
+    usageStats: [],
+    ...overrides,
+  } as DaemonStatus;
+}
+
+describe("Header", () => {
+  it("shows WS port warning when port differs from expected", () => {
+    const { lastFrame } = render(<Header status={status({ wsPort: 54321, wsPortExpected: 19275 })} error={null} />);
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("WS on port 54321");
+    expect(frame).toContain("expected 19275");
+    expect(frame).toContain("may not reconnect");
+  });
+
+  it("does not show WS port warning when port matches expected", () => {
+    const { lastFrame } = render(<Header status={status({ wsPort: 19275, wsPortExpected: 19275 })} error={null} />);
+    expect(lastFrame() ?? "").not.toContain("WS on port");
+  });
+
+  it("does not show WS port warning when wsPort is null", () => {
+    const { lastFrame } = render(<Header status={status({ wsPort: null, wsPortExpected: 19275 })} error={null} />);
+    expect(lastFrame() ?? "").not.toContain("WS on port");
+  });
+
+  it("does not show WS port warning when fields are absent", () => {
+    const { lastFrame } = render(<Header status={status()} error={null} />);
+    expect(lastFrame() ?? "").not.toContain("WS on port");
+  });
+});
+
+describe("formatUptime", () => {
+  it("formats seconds only", () => {
+    expect(formatUptime(45)).toBe("45s");
+  });
+
+  it("formats minutes and seconds", () => {
+    expect(formatUptime(125)).toBe("2m 5s");
+  });
+
+  it("formats hours and minutes", () => {
+    expect(formatUptime(3665)).toBe("1h 1m 5s");
+  });
+});

--- a/packages/control/src/components/header.tsx
+++ b/packages/control/src/components/header.tsx
@@ -50,6 +50,16 @@ export function Header({ status, error }: HeaderProps) {
         <Text color="red">Daemon: {error}</Text>
       ) : null}
 
+      {status?.wsPort != null && status.wsPortExpected != null && status.wsPort !== status.wsPortExpected && (
+        <Text color="yellow">
+          {"⚠ WS on port "}
+          {status.wsPort}
+          {" (expected "}
+          {status.wsPortExpected}
+          {") — CLI sessions may not reconnect after restart"}
+        </Text>
+      )}
+
       <Text>
         <Text dimColor>Servers: </Text>
         {servers.length === 0 ? (

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -204,6 +204,10 @@ export interface DaemonStatus {
   servers: ServerStatus[];
   dbPath: string;
   usageStats: UsageStat[];
+  /** Actual WebSocket port the daemon is listening on (null if not started). */
+  wsPort?: number | null;
+  /** The well-known port the daemon was configured to use. */
+  wsPortExpected?: number;
 }
 
 export interface GetConfigResult {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -369,6 +369,7 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
     onShutdown: () => shutdown("IPC shutdown request"),
     onReloadConfig: () => watcher.forceReload(),
     logger,
+    getWsPortInfo: () => ({ actual: claudeServer.port, expected: wsPort }),
   });
   ipcServer.start();
 

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -438,6 +438,35 @@ describe("IpcServer HTTP transport", () => {
     expect(result.usageStats).toEqual([]);
   });
 
+  test("status response includes wsPort info when getWsPortInfo is provided", async () => {
+    socketPath = tmpSocket();
+    server = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, {
+      ...opts(),
+      getWsPortInfo: () => ({ actual: 54321, expected: 19275 }),
+    });
+    server.start(socketPath);
+
+    const res = await rpc("/rpc", { id: "ws1", method: "status" });
+    expect(res.status).toBe(200);
+
+    const json = (await res.json()) as IpcResponse;
+    const result = json.result as { wsPort: number | null; wsPortExpected: number };
+    expect(result.wsPort).toBe(54321);
+    expect(result.wsPortExpected).toBe(19275);
+  });
+
+  test("status response has null wsPort when getWsPortInfo is not provided", async () => {
+    startServer();
+
+    const res = await rpc("/rpc", { id: "ws2", method: "status" });
+    expect(res.status).toBe(200);
+
+    const json = (await res.json()) as IpcResponse;
+    const result = json.result as { wsPort: number | null; wsPortExpected?: number };
+    expect(result.wsPort).toBeNull();
+    expect(result.wsPortExpected).toBeUndefined();
+  });
+
   test("status with usage data aggregates per-server stats onto ServerStatus", async () => {
     socketPath = tmpSocket();
     const pool = Object.assign(mockPool(), {

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -77,6 +77,7 @@ export class IpcServer {
   private shutdownScheduled = false;
 
   private onReloadConfig: (() => Promise<void>) | null = null;
+  private getWsPortInfo: (() => { actual: number | null; expected: number }) | null = null;
   private aliasServer: AliasServer | null = null;
   private daemonId: string;
   private startedAt: number;
@@ -95,6 +96,8 @@ export class IpcServer {
       onShutdown?: () => void;
       onReloadConfig?: () => Promise<void>;
       logger?: Logger;
+      /** Returns the current and expected WS port for status reporting. */
+      getWsPortInfo?: () => { actual: number | null; expected: number };
     },
   ) {
     this.daemonId = options.daemonId;
@@ -105,6 +108,7 @@ export class IpcServer {
     this.onReloadConfig = options.onReloadConfig ?? null;
     this.aliasServer = aliasServer;
     this.logger = options.logger ?? consoleLogger;
+    this.getWsPortInfo = options.getWsPortInfo ?? null;
     this.registerHandlers();
   }
 
@@ -281,6 +285,7 @@ export class IpcServer {
         }
       }
 
+      const wsPortInfo = this.getWsPortInfo?.();
       return {
         pid: process.pid,
         uptime: process.uptime(),
@@ -289,6 +294,8 @@ export class IpcServer {
         servers,
         dbPath: options.DB_PATH,
         usageStats,
+        wsPort: wsPortInfo?.actual ?? null,
+        wsPortExpected: wsPortInfo?.expected,
       };
     });
 


### PR DESCRIPTION
## Summary
- Add `wsPort` and `wsPortExpected` fields to `DaemonStatus` IPC response
- Wire daemon's `IpcServer` to report the ClaudeServer's actual vs configured WS port
- Display a yellow warning in mcpctl's header when the WS port doesn't match the expected well-known port (19275), with actionable message about CLI session reconnection

## Test plan
- [x] IPC server test: status includes wsPort info when `getWsPortInfo` callback is provided
- [x] IPC server test: status returns null wsPort when callback is absent
- [x] Header component test: warning shown when port differs from expected
- [x] Header component test: no warning when port matches expected
- [x] Header component test: no warning when wsPort is null
- [x] Header component test: no warning when fields are absent
- [x] All 2746 tests pass, typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)