### PR TITLE
feat(mcpctl): display duplicate daemon process count as alert (fixes #716)

### DIFF
--- a/packages/control/src/app.tsx
+++ b/packages/control/src/app.tsx
@@ -11,6 +11,7 @@ import { ServerList } from "./components/server-list.js";
 import { StatsView, buildStatsLines } from "./components/stats-view.js";
 import { TabBar, buildBadges } from "./components/tab-bar.js";
 import { useClaudeSessions } from "./hooks/use-claude-sessions.js";
+import { useDaemonProcessCount } from "./hooks/use-daemon-process-count.js";
 import { useDaemon } from "./hooks/use-daemon.js";
 import type { View } from "./hooks/use-keyboard.js";
 import { useKeyboard } from "./hooks/use-keyboard.js";
@@ -26,6 +27,7 @@ const TRANSCRIPT_VIEW_HEIGHT = 15;
 
 export function App() {
   const { status, error, loading, refresh } = useDaemon({ intervalMs: 2500 });
+  const daemonProcessCount = useDaemonProcessCount();
   const [selectedIndex, setSelectedIndex] = useState(0);
   const [expandedServer, setExpandedServer] = useState<string | null>(null);
   const [authStatus, setAuthStatus] = useState<AuthStatus | null>(null);
@@ -222,7 +224,7 @@ export function App() {
 
   return (
     <Box flexDirection="column" padding={1}>
-      <Header status={status} error={error} />
+      <Header status={status} error={error} daemonProcessCount={daemonProcessCount} />
       <TabBar activeTab={view} badges={badges} />
       {view === "servers" ? (
         <>

--- a/packages/control/src/components/header.spec.ts
+++ b/packages/control/src/components/header.spec.ts
@@ -1,5 +1,18 @@
 import { describe, expect, it } from "bun:test";
-import { formatUptime } from "./header";
+import type { DaemonStatus } from "@mcp-cli/core";
+import { render } from "ink-testing-library";
+import React from "react";
+import { Header, formatUptime } from "./header";
+
+function daemonStatus(overrides: Partial<DaemonStatus> = {}): DaemonStatus {
+  return {
+    pid: 1234,
+    uptime: 100,
+    servers: [],
+    usageStats: [],
+    ...overrides,
+  } as DaemonStatus;
+}
 
 describe("formatUptime", () => {
   it("formats seconds only", () => {
@@ -24,5 +37,28 @@ describe("formatUptime", () => {
 
   it("handles zero", () => {
     expect(formatUptime(0)).toBe("0s");
+  });
+});
+
+describe("Header", () => {
+  it("does not show duplicate daemon warning when count is 0 or 1", () => {
+    const { lastFrame } = render(
+      React.createElement(Header, { status: daemonStatus(), error: null, daemonProcessCount: 1 }),
+    );
+    expect(lastFrame()).not.toContain("mcpd processes running");
+  });
+
+  it("does not show duplicate daemon warning when count is omitted", () => {
+    const { lastFrame } = render(React.createElement(Header, { status: daemonStatus(), error: null }));
+    expect(lastFrame()).not.toContain("mcpd processes running");
+  });
+
+  it("shows duplicate daemon warning when count > 1", () => {
+    const { lastFrame } = render(
+      React.createElement(Header, { status: daemonStatus(), error: null, daemonProcessCount: 4 }),
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("4 mcpd processes running");
+    expect(frame).toContain("killall mcpd");
   });
 });

--- a/packages/control/src/components/header.tsx
+++ b/packages/control/src/components/header.tsx
@@ -5,6 +5,7 @@ import React from "react";
 interface HeaderProps {
   status: DaemonStatus | null;
   error: string | null;
+  daemonProcessCount?: number;
 }
 
 export function formatUptime(seconds: number): string {
@@ -19,7 +20,7 @@ export function formatUptime(seconds: number): string {
   return parts.join(" ");
 }
 
-export function Header({ status, error }: HeaderProps) {
+export function Header({ status, error, daemonProcessCount }: HeaderProps) {
   const servers = status?.servers ?? [];
   const connected = servers.filter((s) => s.state === "connected").length;
   const errored = servers.filter((s) => s.state === "error").length;
@@ -113,6 +114,13 @@ export function Header({ status, error }: HeaderProps) {
               <Text color={totalErrors === 0 ? "green" : "yellow"}>{successRate}% success</Text>
             </Text>
           )}
+        </Text>
+      )}
+
+      {(daemonProcessCount ?? 0) > 1 && (
+        <Text color="yellow">
+          {"⚠"} {daemonProcessCount} mcpd processes running — daemon may behave erratically. Run `killall mcpd && mcx
+          status` to clean up.
         </Text>
       )}
 

--- a/packages/control/src/hooks/use-daemon-process-count.spec.ts
+++ b/packages/control/src/hooks/use-daemon-process-count.spec.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { Text } from "ink";
+import { render } from "ink-testing-library";
+import React, { type FC } from "react";
+import {
+  type UseDaemonProcessCountOptions,
+  countDaemonProcesses,
+  useDaemonProcessCount,
+} from "./use-daemon-process-count";
+
+const Harness: FC<{ opts: UseDaemonProcessCountOptions; stateRef: { current: number } }> = ({ opts, stateRef }) => {
+  const count = useDaemonProcessCount(opts);
+  stateRef.current = count;
+  return React.createElement(Text, null, `count:${count}`);
+};
+
+async function flush(ms = 20) {
+  await Bun.sleep(ms);
+}
+
+describe("countDaemonProcesses", () => {
+  it("returns a non-negative number", async () => {
+    const count = await countDaemonProcesses();
+    expect(count).toBeGreaterThanOrEqual(0);
+    expect(Number.isInteger(count)).toBe(true);
+  });
+});
+
+describe("useDaemonProcessCount", () => {
+  const instances: ReturnType<typeof render>[] = [];
+
+  afterEach(() => {
+    for (const inst of instances) inst.unmount();
+    instances.length = 0;
+  });
+
+  function mount(opts: UseDaemonProcessCountOptions) {
+    const stateRef = { current: 0 };
+    const instance = render(React.createElement(Harness, { opts, stateRef }));
+    instances.push(instance);
+    return { instance, stateRef };
+  }
+
+  it("returns count from countFn", async () => {
+    const countFn = async () => 3;
+    const { stateRef } = mount({ countFn });
+
+    await flush();
+    expect(stateRef.current).toBe(3);
+  });
+
+  it("defaults to 0 before first poll", () => {
+    const countFn = async () => {
+      await Bun.sleep(100);
+      return 2;
+    };
+    const { stateRef } = mount({ countFn });
+    expect(stateRef.current).toBe(0);
+  });
+
+  it("updates on subsequent polls", async () => {
+    let callCount = 0;
+    const countFn = async () => {
+      callCount++;
+      return callCount;
+    };
+
+    const { stateRef } = mount({ countFn, intervalMs: 30 });
+
+    await flush();
+    expect(stateRef.current).toBe(1);
+
+    await flush(50);
+    expect(stateRef.current).toBeGreaterThan(1);
+  });
+
+  it("stops polling on unmount", async () => {
+    let callCount = 0;
+    const countFn = async () => {
+      callCount++;
+      return 1;
+    };
+
+    const { instance } = mount({ countFn, intervalMs: 30 });
+    await flush(50);
+
+    instance.unmount();
+    instances.pop();
+    // Allow any in-flight poll to complete
+    await flush(20);
+    const countAfterUnmount = callCount;
+
+    // No new polls should fire after unmount settles
+    await flush(100);
+    expect(callCount).toBe(countAfterUnmount);
+  });
+});

--- a/packages/control/src/hooks/use-daemon-process-count.ts
+++ b/packages/control/src/hooks/use-daemon-process-count.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+
+export interface UseDaemonProcessCountOptions {
+  /** Polling interval in ms (default: 5000). */
+  intervalMs?: number;
+  /** Override for testing — returns the process count. */
+  countFn?: () => Promise<number>;
+}
+
+/** Count running mcpd processes via pgrep. */
+export async function countDaemonProcesses(): Promise<number> {
+  try {
+    const proc = Bun.spawn(["pgrep", "-x", "mcpd"], {
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    const text = await new Response(proc.stdout).text();
+    await proc.exited;
+    // Each line is a PID; empty output = 0 processes
+    const lines = text.trim().split("\n").filter(Boolean);
+    return lines.length;
+  } catch {
+    return 0;
+  }
+}
+
+export function useDaemonProcessCount(opts: UseDaemonProcessCountOptions = {}): number {
+  const { intervalMs = 5000, countFn = countDaemonProcesses } = opts;
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function poll() {
+      const n = await countFn();
+      if (!cancelled) setCount(n);
+    }
+
+    let timerId: ReturnType<typeof setTimeout> | undefined;
+
+    async function scheduleNext() {
+      await poll();
+      if (!cancelled) {
+        timerId = setTimeout(scheduleNext, intervalMs);
+      }
+    }
+
+    scheduleNext();
+
+    return () => {
+      cancelled = true;
+      if (timerId !== undefined) clearTimeout(timerId);
+    };
+  }, [intervalMs, countFn]);
+
+  return count;
+}


### PR DESCRIPTION
## Summary
- Add `useDaemonProcessCount` hook that polls `pgrep -x mcpd` every 5s to count running daemon processes
- Show a yellow warning banner in the mcpctl header when >1 mcpd process is detected, with cleanup instructions
- Prevents the invisible duplicate daemon situation that caused P0 #712

## Test plan
- [x] `countDaemonProcesses` unit test verifies pgrep integration returns non-negative integer
- [x] Hook tests verify polling, unmount cleanup, and state updates via dependency-injected countFn
- [x] Header rendering tests verify warning hidden when count ≤1 or omitted, shown with correct count when >1
- [x] All 2748 tests pass, coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)