### PR TITLE
fix(control): set disconnected=true when all plan servers fail (fixes #749)

### DIFF
--- a/packages/control/src/hooks/use-plans.spec.ts
+++ b/packages/control/src/hooks/use-plans.spec.ts
@@ -201,6 +201,41 @@ describe("usePlans", () => {
     expect(stateRef.current.error).toBeNull();
   });
 
+  it("sets disconnected when all plan servers fail", async () => {
+    const ipcCallFn = async (method: string) => {
+      if (method === "status") {
+        return daemonStatus([
+          { name: "server-a", hasList: true },
+          { name: "server-b", hasList: true },
+        ]);
+      }
+      throw new Error("server unreachable");
+    };
+
+    const { stateRef } = mount({ ipcCallFn: ipcCallFn as UsePlansOptions["ipcCallFn"] });
+    await flush();
+
+    expect(stateRef.current.plans).toHaveLength(0);
+    expect(stateRef.current.disconnected).toBe(true);
+    expect(stateRef.current.loading).toBe(false);
+    expect(stateRef.current.error).toBeNull();
+  });
+
+  it("sets disconnected when all servers return unparseable responses", async () => {
+    const ipcCallFn = async (method: string) => {
+      if (method === "status") {
+        return daemonStatus([{ name: "server-a", hasList: true }]);
+      }
+      return { content: [{ type: "text", text: "not valid json{" }] };
+    };
+
+    const { stateRef } = mount({ ipcCallFn: ipcCallFn as UsePlansOptions["ipcCallFn"] });
+    await flush();
+
+    expect(stateRef.current.plans).toHaveLength(0);
+    expect(stateRef.current.disconnected).toBe(true);
+  });
+
   it("cleanup stops polling on unmount", async () => {
     let callCount = 0;
     const ipcCallFn = async () => {

--- a/packages/control/src/hooks/use-plans.ts
+++ b/packages/control/src/hooks/use-plans.ts
@@ -47,6 +47,7 @@ export function usePlans(opts: UsePlansOptions = {}): UsePlansResult {
         );
 
         const allPlans: Plan[] = [];
+        let successCount = 0;
 
         await Promise.allSettled(
           planServers.map(async (srv: ServerStatus) => {
@@ -60,6 +61,7 @@ export function usePlans(opts: UsePlansOptions = {}): UsePlansResult {
               if (!text) return;
               const parsed = ListPlansResultSchema.safeParse(JSON.parse(text));
               if (parsed.success) {
+                successCount++;
                 allPlans.push(...parsed.data.plans);
               }
             } catch {
@@ -69,9 +71,10 @@ export function usePlans(opts: UsePlansOptions = {}): UsePlansResult {
         );
 
         if (cancelled) return;
+        const allFailed = planServers.length > 0 && successCount === 0;
         setPlans(allPlans);
         setError(null);
-        setDisconnected(false);
+        setDisconnected(allFailed);
         setLoading(false);
       } catch (err) {
         if (cancelled) return;


### PR DESCRIPTION
## Summary
- Track per-server success count inside the `Promise.allSettled` loop in `usePlans`
- When `planServers.length > 0` but no server returned a parseable response, set `disconnected: true` so the UI shows the disconnected banner instead of misleading "No plans available"
- Previously, all per-server errors were silently swallowed and `setDisconnected(false)` was always called

## Test plan
- [x] New test: "sets disconnected when all plan servers fail" — verifies `disconnected: true` when all servers throw
- [x] New test: "sets disconnected when all servers return unparseable responses" — verifies `disconnected: true` on parse failures
- [x] Existing test "continues when one server's callTool fails" still passes — partial failure keeps `disconnected: false`
- [x] All 2754 tests pass, typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)