### PR TITLE
perf(test): scale test profiler concurrency to available CPUs (fixes #750)

### DIFF
--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -26,8 +26,8 @@ const GLOBAL_THRESHOLDS = {
 /** Per-file test time budget in milliseconds — no single file should exceed this */
 const PER_FILE_TIME_BUDGET_MS = 5_000;
 
-/** Number of test files to profile concurrently — kept low to avoid FS/network contention inflating times */
-const PROFILE_CONCURRENCY = 4;
+/** Number of test files to profile concurrently — scales with available CPUs */
+const PROFILE_CONCURRENCY = Math.max(4, Math.min(navigator.hardwareConcurrency ?? 4, 32));
 
 /**
  * Test files excluded from the per-file time budget.
@@ -256,7 +256,8 @@ const profileDuration = Math.round(performance.now() - profileStart);
 const sequentialSum = timings.reduce((sum, t) => sum + t.ms, 0);
 
 console.log(
-  `Profiled ${timings.length} test files in ${(profileDuration / 1000).toFixed(1)}s (sequential sum: ${(sequentialSum / 1000).toFixed(1)}s)`,
+  `Profiled ${timings.length} test files in ${(profileDuration / 1000).toFixed(1)}s ` +
+    `(sequential sum: ${(sequentialSum / 1000).toFixed(1)}s, concurrency: ${PROFILE_CONCURRENCY})`,
 );
 console.log(
   `\nTop 10 slowest test files (budget: ${PER_FILE_TIME_BUDGET_MS}ms, ${Object.keys(TIMING_EXCLUSIONS).length} excluded):`,


### PR DESCRIPTION
## Summary
- `PROFILE_CONCURRENCY` now scales dynamically with `navigator.hardwareConcurrency` (capped at 32, min 4) instead of being hardcoded to 4
- Profile output now reports the concurrency level used for visibility

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (2752 tests, 0 failures)
- [x] Pre-commit hook runs full coverage check including profiler with new concurrency
- [x] Verified `navigator.hardwareConcurrency` returns correct value in Bun (14 on this machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)