### PR TITLE
feat(control): show process holding WS port when mismatch detected (fixes #745)

### DIFF
--- a/packages/control/src/components/header.spec.tsx
+++ b/packages/control/src/components/header.spec.tsx
@@ -39,6 +39,26 @@ describe("Header", () => {
     const { lastFrame } = render(<Header status={status()} error={null} />);
     expect(lastFrame() ?? "").not.toContain("WS on port");
   });
+
+  it("shows port holder when wsPortHolder is provided", () => {
+    const { lastFrame } = render(
+      <Header
+        status={status({ wsPort: 54321, wsPortExpected: 19275, wsPortHolder: "mcpd (PID 38291)" })}
+        error={null}
+      />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("Port 19275 held by: mcpd (PID 38291)");
+  });
+
+  it("does not show port holder line when wsPortHolder is null", () => {
+    const { lastFrame } = render(
+      <Header status={status({ wsPort: 54321, wsPortExpected: 19275, wsPortHolder: null })} error={null} />,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("WS on port 54321");
+    expect(frame).not.toContain("held by");
+  });
 });
 
 describe("formatUptime", () => {

--- a/packages/control/src/components/header.tsx
+++ b/packages/control/src/components/header.tsx
@@ -52,13 +52,23 @@ export function Header({ status, error, daemonProcessCount }: HeaderProps) {
       ) : null}
 
       {status?.wsPort != null && status.wsPortExpected != null && status.wsPort !== status.wsPortExpected && (
-        <Text color="yellow">
-          {"⚠ WS on port "}
-          {status.wsPort}
-          {" (expected "}
-          {status.wsPortExpected}
-          {") — CLI sessions may not reconnect after restart"}
-        </Text>
+        <Box flexDirection="column">
+          <Text color="yellow">
+            {"⚠ WS on port "}
+            {status.wsPort}
+            {" (expected "}
+            {status.wsPortExpected}
+            {") — CLI sessions may not reconnect after restart"}
+          </Text>
+          {status.wsPortHolder && (
+            <Text color="yellow">
+              {"  Port "}
+              {status.wsPortExpected}
+              {" held by: "}
+              {status.wsPortHolder}
+            </Text>
+          )}
+        </Box>
       )}
 
       <Text>

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -208,6 +208,8 @@ export interface DaemonStatus {
   wsPort?: number | null;
   /** The well-known port the daemon was configured to use. */
   wsPortExpected?: number;
+  /** Process holding the expected WS port when there's a mismatch (e.g. "mcpd (PID 38291)"). */
+  wsPortHolder?: string | null;
 }
 
 export interface GetConfigResult {

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -57,6 +57,7 @@ import { McpOAuthProvider } from "./auth/oauth-provider";
 import { getDaemonLogLines } from "./daemon-log";
 import type { StateDb } from "./db/state";
 import { metrics } from "./metrics";
+import { getPortHolder } from "./port-holder";
 import type { ServerPool } from "./server-pool";
 
 /** Per-request context passed to every handler (fixes race condition on shared state). */
@@ -287,6 +288,8 @@ export class IpcServer {
       }
 
       const wsPortInfo = this.getWsPortInfo?.();
+      const hasMismatch = wsPortInfo != null && wsPortInfo.actual != null && wsPortInfo.actual !== wsPortInfo.expected;
+      const wsPortHolder = hasMismatch ? await getPortHolder(wsPortInfo.expected) : null;
       return {
         pid: process.pid,
         uptime: process.uptime(),
@@ -297,6 +300,7 @@ export class IpcServer {
         usageStats,
         wsPort: wsPortInfo?.actual ?? null,
         wsPortExpected: wsPortInfo?.expected,
+        wsPortHolder,
       };
     });
 

--- a/packages/daemon/src/port-holder.spec.ts
+++ b/packages/daemon/src/port-holder.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import { getPortHolder } from "./port-holder";
+
+describe("getPortHolder", () => {
+  it("returns null for a port with no listener", async () => {
+    // Use a port unlikely to have a listener
+    const result = await getPortHolder(19);
+    expect(result).toBeNull();
+  });
+
+  it("returns process info for a port with a listener", async () => {
+    // Start a server on a random port, then query it
+    const server = Bun.serve({ port: 0, fetch: () => new Response("ok") });
+    try {
+      const port = server.port;
+      if (port === undefined) throw new Error("server.port is undefined");
+      const result = await getPortHolder(port);
+      // lsof should find the bun process holding this port
+      expect(result).not.toBeNull();
+      expect(result).toContain("PID");
+    } finally {
+      server.stop(true);
+    }
+  });
+});

--- a/packages/daemon/src/port-holder.ts
+++ b/packages/daemon/src/port-holder.ts
@@ -1,0 +1,22 @@
+/**
+ * Identify the process listening on a given TCP port via lsof.
+ * Returns e.g. "mcpd (PID 38291)" or null if nothing found / lsof unavailable.
+ */
+
+import { execFile } from "node:child_process";
+
+export function getPortHolder(port: number): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile("lsof", ["-i", `TCP:${port}`, "-sTCP:LISTEN", "-n", "-P"], { timeout: 2000 }, (err, stdout) => {
+      if (err || !stdout) return resolve(null);
+      // Skip header line, parse first result
+      const lines = stdout.trim().split("\n");
+      if (lines.length < 2) return resolve(null);
+      const parts = lines[1].split(/\s+/);
+      const command = parts[0];
+      const pid = parts[1];
+      if (command && pid) return resolve(`${command} (PID ${pid})`);
+      resolve(null);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- When the daemon detects a WS port mismatch (actual != expected), the status handler now runs `lsof` to identify which process holds the expected port
- Added `wsPortHolder` field to `DaemonStatus` IPC type (e.g. `"mcpd (PID 38291)"`)
- mcpctl header displays the holder info below the existing port mismatch warning: `Port 19275 held by: mcpd (PID 38291)`

## Test plan
- [x] Unit test for `getPortHolder` — verifies null for unused port, finds process for active listener
- [x] Header component tests — verifies holder line renders when `wsPortHolder` is set, hidden when null
- [x] All 2759 tests pass, coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)