### PR TITLE
fix(test): eliminate virtual server startup jitter from idle timeout test (fixes #492)

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -208,6 +208,8 @@ export interface StartDaemonOptions {
  * Does not install process signal handlers or call process.exit — the caller is responsible.
  */
 export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHandle> {
+  // Allow env-based override for subprocess integration tests
+  const skipVirtualServers = opts?.skipVirtualServers ?? process.env.MCP_DAEMON_SKIP_VIRTUAL_SERVERS === "1";
   const logger = opts?.logger ?? consoleLogger;
 
   if (!opts?.skipLogSetup) {
@@ -386,7 +388,7 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
   console.log(DAEMON_READY_SIGNAL);
 
   // Boot virtual servers in the background — commands that need them will await
-  if (!opts?.skipVirtualServers) {
+  if (!skipVirtualServers) {
     pool.registerPendingVirtualServer(
       ALIAS_SERVER_NAME,
       (async () => {

--- a/test/daemon-integration.spec.ts
+++ b/test/daemon-integration.spec.ts
@@ -69,10 +69,13 @@ describe("P1: Daemon lifecycle", () => {
   });
 
   test("idle timeout fires and process exits", async () => {
-    daemon = await startTestDaemon({}, { idleTimeout: 2_000 });
+    // Skip virtual servers — their variable startup time defers the idle timer
+    // via hasPendingServers(), which was the root cause of the 15s margin (#492).
+    daemon = await startTestDaemon({}, { idleTimeout: 2_000, skipVirtualServers: true });
 
-    // Daemon should exit within a reasonable window (2s idle + generous margin for loaded CI)
-    const exitCode = await Promise.race([daemon.proc.exited, Bun.sleep(15_000).then(() => "timeout" as const)]);
+    // With no virtual servers, idle timer starts immediately on daemon ready.
+    // 2s idle + 3s margin = 5s total should be plenty, even on slow CI.
+    const exitCode = await Promise.race([daemon.proc.exited, Bun.sleep(5_000).then(() => "timeout" as const)]);
     expect(exitCode).toBe(0);
     daemon = undefined;
   });

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -37,7 +37,7 @@ export function echoServerConfig(): ServerConfig {
  */
 export async function startTestDaemon(
   servers: ServerConfigMap,
-  options?: { timeout?: number; idleTimeout?: number; dir?: string },
+  options?: { timeout?: number; idleTimeout?: number; dir?: string; skipVirtualServers?: boolean },
 ): Promise<TestDaemon> {
   const dir = options?.dir ?? createTestDir();
   const socketPath = join(dir, "mcpd.sock");
@@ -59,6 +59,7 @@ export async function startTestDaemon(
       ...process.env,
       MCP_CLI_DIR: dir,
       MCP_DAEMON_TIMEOUT: String(options?.idleTimeout ?? 30_000),
+      ...(options?.skipVirtualServers ? { MCP_DAEMON_SKIP_VIRTUAL_SERVERS: "1" } : {}),
     },
   });
 


### PR DESCRIPTION
## Summary
- Root cause: virtual servers (`_aliases`, `_claude`) boot asynchronously after daemon readiness, and `hasPendingServers()` defers the idle timer until they settle — adding variable seconds of delay
- Added `MCP_DAEMON_SKIP_VIRTUAL_SERVERS` env var support in daemon `startDaemon()`, wired through test harness `skipVirtualServers` option
- Idle timeout test now skips virtual servers, reducing race margin from 15s to 3s (5s total deadline vs 17s before)

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes  
- [x] `bun test` — all 2755 tests pass
- [x] Idle timeout integration test passes with tighter 5s deadline
- [x] Coverage thresholds maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)