### PR TITLE
fix(control): add inflight guard to confirmAbort y-handler (fixes #784)

### DIFF
--- a/packages/control/src/hooks/use-keyboard-plans.spec.ts
+++ b/packages/control/src/hooks/use-keyboard-plans.spec.ts
@@ -410,6 +410,21 @@ describe("handlePlansInput", () => {
     expect(nav.state.selectedIndex).toBe(0);
   });
 
+  it("y is blocked while inflight (guard against double-fire)", () => {
+    let called = false;
+    const mockIpc = (() => {
+      called = true;
+      return Promise.resolve({ content: [{ type: "text", text: "{}" }] });
+    }) as PlansNav["ipcCallFn"];
+
+    const nav = makeNav({ confirmAbort: true, ipcCallFn: mockIpc, inflight: true });
+    const consumed = handlePlansInput("y", baseKey, nav);
+    expect(consumed).toBe(true);
+    expect(called).toBe(false);
+    // Should remain in confirmAbort mode since no action was taken
+    expect(nav.state.confirmAbort).toBe(true);
+  });
+
   it("abort sets and clears inflight", async () => {
     const mockIpc = (() =>
       Promise.resolve({ content: [{ type: "text", text: '{"plan":{}}' }] })) as PlansNav["ipcCallFn"];

--- a/packages/control/src/hooks/use-keyboard-plans.ts
+++ b/packages/control/src/hooks/use-keyboard-plans.ts
@@ -111,6 +111,7 @@ export function handlePlansInput(input: string, key: Key, nav: PlansNav): boolea
   // Abort confirmation mode — capture y/n, ignore everything else
   if (nav.confirmAbort) {
     if (input === "y" || input === "Y") {
+      if (nav.inflight) return true; // guard against double-fire
       const plan = getTargetPlan(nav);
       if (!plan || !hasCapability(servers, plan.server, "abort")) {
         // Plan disappeared or lost capability while confirming


### PR DESCRIPTION
## Summary
- Added `if (nav.inflight) return true;` guard at the top of the `y` branch inside the `confirmAbort` block in `use-keyboard-plans.ts`
- This prevents a redundant abort IPC call if `confirmAbort` and `inflight` are both true via a state race
- Matches the existing guard pattern used by the `a` (advance) and `x` (abort-enter) handlers

## Test plan
- [x] Added test: "y is blocked while inflight (guard against double-fire)" — verifies IPC is not called and confirmAbort remains true
- [x] All 2914 tests pass (0 failures)
- [x] Typecheck passes
- [x] Lint passes
- [x] Coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)