### PR TITLE
perf(hooks): skip checks for non-code changes in pre-commit hook (fixes #789)

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -1,21 +1,68 @@
 #!/usr/bin/env bash
-# Pre-commit hook: typecheck, lint, and test must all pass.
+# Pre-commit hook: typecheck, lint, and test — skips checks for non-code changes.
+#
+# Tiers:
+#   docs-only  (.md, .claude/ docs)          → skip all checks
+#   config-only (package.json, *.json config) → typecheck + lint only
+#   source changes                            → full suite
 
 set -euo pipefail
 
-echo "Running pre-commit checks..."
+# Get list of staged files (excludes deleted files)
+staged_files=$(git diff --cached --name-only --diff-filter=d)
 
-echo "  typecheck..."
-bun run typecheck
-
-echo "  lint..."
-bun run lint:check
-
-echo "  test + coverage..."
-if ! bun run test:coverage; then
-  # check-coverage.ts logs failures via test-failure-log.ts
-  echo "  (test failures logged to ~/.mcp-cli/test-failures.log)"
-  exit 1
+if [ -z "$staged_files" ]; then
+  echo "No staged files, skipping checks."
+  exit 0
 fi
 
-echo "All checks passed."
+# Classify staged files into tiers
+has_source=false
+has_config=false
+
+while IFS= read -r file; do
+  case "$file" in
+    # Docs: markdown files, .claude/ directory contents, CLAUDE.md
+    *.md | .claude/* | CLAUDE.md)
+      # docs-only tier — no action needed
+      ;;
+    # Config: JSON files (package.json, tsconfig, etc.)
+    *.json)
+      has_config=true
+      ;;
+    # Everything else is source code
+    *)
+      has_source=true
+      ;;
+  esac
+done <<< "$staged_files"
+
+if $has_source; then
+  echo "Running pre-commit checks (source changes detected)..."
+
+  echo "  typecheck..."
+  bun run typecheck
+
+  echo "  lint..."
+  bun run lint:check
+
+  echo "  test + coverage..."
+  if ! bun run test:coverage; then
+    echo "  (test failures logged to ~/.mcp-cli/test-failures.log)"
+    exit 1
+  fi
+
+  echo "All checks passed."
+elif $has_config; then
+  echo "Running pre-commit checks (config-only changes, skipping tests)..."
+
+  echo "  typecheck..."
+  bun run typecheck
+
+  echo "  lint..."
+  bun run lint:check
+
+  echo "Config checks passed (tests skipped)."
+else
+  echo "Docs-only changes detected, skipping all checks."
+fi


### PR DESCRIPTION
## Summary
- Classify staged files into three tiers: docs-only (.md, .claude/*), config-only (.json), and source changes
- Docs-only commits skip all checks entirely (~6 min → <1s)
- Config-only commits run typecheck + lint but skip the full test suite
- Source changes run the full suite as before (no behavior change)
- Also closes #753 (docs-only skip was a subset of this)

## Test plan
- [x] Verified file classification logic with 10 test cases covering all tiers and mixed scenarios
- [x] All 2913 existing tests pass
- [x] Typecheck passes
- [x] Lint passes
- [x] Manual verification: the hook correctly identifies `.git-hooks/pre-commit` as source (ran full suite for this commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)