### PR TITLE
fix(serve): add buffer size limit in BunStdioServerTransport to prevent OOM (fixes #764)

### DIFF
--- a/packages/command/src/bun-stdio-transport.spec.ts
+++ b/packages/command/src/bun-stdio-transport.spec.ts
@@ -164,6 +164,30 @@ describe("BunStdioServerTransport", () => {
     expect(stdout.writes).toHaveLength(0);
   });
 
+  test("calls onerror and closes when buffer exceeds 10 MB", async () => {
+    // Stream a single huge chunk with no newlines so the buffer grows unbounded
+    const huge = new Uint8Array(11 * 1024 * 1024); // 11 MB of zeros
+    const stdin = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(huge);
+        controller.close();
+      },
+    });
+    const stdout = mockStdout();
+    const transport = new BunStdioServerTransport(stdin, stdout.writer);
+
+    const errors: Error[] = [];
+    transport.onerror = (e) => errors.push(e);
+
+    await transport.start();
+    await transport.closed;
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain("buffer exceeded");
+
+    await transport.close();
+  });
+
   test("handles \\r\\n line endings", async () => {
     const msg = { jsonrpc: "2.0", id: 1, method: "initialize", params: {} };
     const stdin = streamFromLines([`${JSON.stringify(msg)}\r\n`]);

--- a/packages/command/src/bun-stdio-transport.ts
+++ b/packages/command/src/bun-stdio-transport.ts
@@ -11,6 +11,8 @@ import { deserializeMessage, serializeMessage } from "@modelcontextprotocol/sdk/
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 
+const MAX_BUFFER_SIZE = 10 * 1024 * 1024; // 10 MB
+
 export class BunStdioServerTransport implements Transport {
   private _started = false;
   private _closed = false;
@@ -56,6 +58,14 @@ export class BunStdioServerTransport implements Transport {
 
         this._buffer += decoder.decode(value, { stream: true });
         this._processBuffer();
+
+        if (this._buffer.length > MAX_BUFFER_SIZE) {
+          this.onerror?.(
+            new Error(`BunStdioServerTransport: buffer exceeded ${MAX_BUFFER_SIZE} bytes — message too large`),
+          );
+          await this.close();
+          return;
+        }
       }
       // Flush remaining UTF-8 state from the decoder
       if (!this._aborted) {


### PR DESCRIPTION
## Summary
- Add `MAX_BUFFER_SIZE` (10 MB) constant to `BunStdioServerTransport`
- Check buffer length after each read+process cycle in `_readLoop`; if exceeded, fire `onerror` and close the transport gracefully
- Prevents OOM from malicious/buggy clients sending huge messages without newlines

## Test plan
- [x] New test: verifies onerror fires and transport closes when an 11 MB chunk with no newlines is streamed
- [x] All existing transport tests still pass (10/10)
- [x] Full suite passes: 2914 tests, typecheck, lint, coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)