### PR TITLE
fix(control): log console.error on Zod parse failures in plan hooks (fixes #762)

### DIFF
--- a/packages/control/src/hooks/use-plans.spec.ts
+++ b/packages/control/src/hooks/use-plans.spec.ts
@@ -316,6 +316,33 @@ describe("usePlans", () => {
     expect(stateRef.current.disconnected).toBe(true);
   });
 
+  it("logs console.error when safeParse fails for a server (#762)", async () => {
+    const errors: unknown[][] = [];
+    const origError = console.error;
+    console.error = (...args: unknown[]) => errors.push(args);
+
+    try {
+      const ipcCallFn = async (method: string) => {
+        if (method === "status") {
+          return daemonStatus([{ name: "bad-schema-server", hasList: true }]);
+        }
+        // Valid JSON but wrong shape — safeParse will fail
+        return { content: [{ type: "text", text: JSON.stringify({ wrong: "shape" }) }] };
+      };
+
+      const { stateRef } = mount({ ipcCallFn: ipcCallFn as UsePlansOptions["ipcCallFn"] });
+      await waitFor(() => stateRef.current.loading === false);
+
+      const parseErrors = errors.filter(
+        (args) => typeof args[0] === "string" && args[0].includes("[usePlans] parse error"),
+      );
+      expect(parseErrors.length).toBeGreaterThanOrEqual(1);
+      expect(parseErrors[0][0]).toContain("bad-schema-server");
+    } finally {
+      console.error = origError;
+    }
+  });
+
   it("cleanup stops polling on unmount", async () => {
     let callCount = 0;
     const ipcCallFn = async () => {

--- a/packages/control/src/hooks/use-plans.ts
+++ b/packages/control/src/hooks/use-plans.ts
@@ -162,6 +162,8 @@ export function usePlans(opts: UsePlansOptions = {}): UsePlansResult {
                 if (parsed.success) {
                   successCount++;
                   allPlans.push(...parsed.data.plans);
+                } else {
+                  console.error(`[usePlans] parse error for server ${srv.name}:`, parsed.error.issues);
                 }
               } catch {
                 // One server failing doesn't break the whole list
@@ -275,6 +277,8 @@ export function usePlan(planId: string, server: string, opts: UsePlanOptions = {
           const parsed = GetPlanResultSchema.safeParse(JSON.parse(text));
           if (parsed.success) {
             setPlan(parsed.data.plan);
+          } else {
+            console.error(`[usePlan] parse error for plan ${planId} on ${server}:`, parsed.error.issues);
           }
         }
         setError(null);
@@ -360,6 +364,8 @@ export function usePlanMetrics(
           const parsed = GetPlanMetricsResultSchema.safeParse(JSON.parse(text));
           if (parsed.success) {
             setMetrics(parsed.data.metrics);
+          } else {
+            console.error(`[usePlanMetrics] parse error for plan ${planId} on ${server}:`, parsed.error.issues);
           }
         }
         setError(null);


### PR DESCRIPTION
## Summary
- Add `console.error` logging when `safeParse` fails in all three plan hooks (`usePlans`, `usePlan`, `usePlanMetrics`)
- Log messages include the server name and Zod validation issues for debugging
- Add test verifying parse failure logging in `usePlans`

## Test plan
- [x] New test: `logs console.error when safeParse fails for a server (#762)` — verifies error is logged with server name
- [x] All 2916 existing tests pass
- [x] Typecheck, lint, coverage all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)