### PR TITLE
feat(serve): add compact mode to claude_transcript tool (fixes #788)

### DIFF
--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -20,7 +20,7 @@ import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprot
 import { DEFAULT_SAFE_TOOLS, type PermissionRule, type PermissionStrategy } from "./claude-session/permission-router";
 import type { SessionEvent } from "./claude-session/session-state";
 import { CLAUDE_TOOLS } from "./claude-session/tools";
-import { ClaudeWsServer, type WaitResult, WaitTimeoutError } from "./claude-session/ws-server";
+import { ClaudeWsServer, type WaitResult, WaitTimeoutError, compactifyEntry } from "./claude-session/ws-server";
 import { getProcessStartTime } from "./process-identity";
 import { createIsControlMessage } from "./worker-control-message";
 import { WorkerServerTransport } from "./worker-transport";
@@ -253,7 +253,14 @@ function handleTranscript(
   content: Array<{ type: "text"; text: string }>;
 } {
   const limit = (args.limit as number) ?? 50;
+  const compact = (args.compact as boolean) ?? false;
   const transcript = server.getTranscript(args.sessionId as string, limit);
+
+  if (compact) {
+    const compacted = transcript.map(compactifyEntry);
+    return { content: [{ type: "text", text: JSON.stringify(compacted, null, 2) }] };
+  }
+
   return { content: [{ type: "text", text: JSON.stringify(transcript, null, 2) }] };
 }
 

--- a/packages/daemon/src/claude-session/compactify.spec.ts
+++ b/packages/daemon/src/claude-session/compactify.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+import { type TranscriptEntry, compactifyEntry } from "./ws-server";
+
+function entry(type: string, direction: "inbound" | "outbound", extra: Record<string, unknown> = {}): TranscriptEntry {
+  return { timestamp: 1710600000000, direction, message: { type, ...extra } };
+}
+
+describe("compactifyEntry", () => {
+  test("user message extracts text content", () => {
+    const e = entry("user", "outbound", {
+      message: { content: "Hello world" },
+    });
+    const c = compactifyEntry(e);
+    expect(c).toEqual({ timestamp: 1710600000000, role: "user", content: "Hello world" });
+  });
+
+  test("assistant message with content blocks", () => {
+    const e = entry("assistant", "inbound", {
+      message: {
+        content: [
+          { type: "text", text: "Thinking about it..." },
+          { type: "tool_use", name: "Read", id: "tu_123", input: { file_path: "/foo" } },
+        ],
+      },
+    });
+    const c = compactifyEntry(e);
+    expect(c.role).toBe("assistant");
+    expect(c.content).toBe("Thinking about it... [tool_use: Read]");
+    expect(c.tool).toBe("Read");
+  });
+
+  test("result message extracts result field", () => {
+    const e = entry("result", "inbound", { result: "Operation succeeded" });
+    const c = compactifyEntry(e);
+    expect(c).toEqual({ timestamp: 1710600000000, role: "result", content: "Operation succeeded" });
+  });
+
+  test("truncates content over 200 chars", () => {
+    const longText = "x".repeat(300);
+    const e = entry("user", "outbound", { message: { content: longText } });
+    const c = compactifyEntry(e);
+    expect(c.content?.length).toBe(201); // 200 + "…"
+    expect(c.content?.endsWith("…")).toBe(true);
+  });
+
+  test("system message has null content", () => {
+    const e = entry("system", "inbound");
+    const c = compactifyEntry(e);
+    expect(c.role).toBe("system");
+    expect(c.content).toBeNull();
+  });
+
+  test("unknown type uses type as role", () => {
+    const e = entry("keep_alive", "inbound");
+    const c = compactifyEntry(e);
+    expect(c.role).toBe("keep_alive");
+  });
+
+  test("tool field omitted when no tool_use block", () => {
+    const e = entry("assistant", "inbound", {
+      message: { content: [{ type: "text", text: "Just text" }] },
+    });
+    const c = compactifyEntry(e);
+    expect(c.tool).toBeUndefined();
+    expect("tool" in c).toBe(false);
+  });
+
+  test("content array with tool_result blocks", () => {
+    const e = entry("user", "outbound", {
+      message: {
+        content: [{ type: "tool_result", content: "file contents here" }, { type: "tool_result" }],
+      },
+    });
+    const c = compactifyEntry(e);
+    expect(c.content).toBe("file contents here [tool_result]");
+  });
+});

--- a/packages/daemon/src/claude-session/tools.ts
+++ b/packages/daemon/src/claude-session/tools.ts
@@ -103,6 +103,12 @@ export const CLAUDE_TOOLS = [
       properties: {
         sessionId: { type: "string", description: "Session ID to query" },
         limit: { type: "number", description: "Max entries to return (default: 50)" },
+        compact: {
+          type: "boolean",
+          description:
+            "When true, return only timestamp, role, content summary (≤200 chars), " +
+            "and tool name — much smaller for monitoring. Default: false.",
+        },
       },
       required: ["sessionId"],
     },

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -66,6 +66,92 @@ export interface TranscriptEntry {
   message: NdjsonMessage;
 }
 
+/** Lightweight transcript entry for monitoring — omits verbose metadata. */
+export interface CompactTranscriptEntry {
+  timestamp: number;
+  role: string;
+  content: string | null;
+  tool?: string;
+}
+
+/** Convert a full TranscriptEntry to compact form. */
+export function compactifyEntry(entry: TranscriptEntry): CompactTranscriptEntry {
+  const type = entry.message.type ?? "unknown";
+
+  // Derive role from message type
+  const role =
+    type === "user"
+      ? "user"
+      : type === "assistant"
+        ? "assistant"
+        : type === "result"
+          ? "result"
+          : type === "system"
+            ? "system"
+            : type;
+
+  let content: string | null = null;
+  let tool: string | undefined;
+
+  if ((type === "user" || type === "assistant") && entry.message.message) {
+    const msg = entry.message.message as { content?: unknown };
+    content = extractContentSummaryPlain(msg.content);
+  } else if (type === "result") {
+    const res = entry.message as { result?: string };
+    content = res.result ?? null;
+  }
+
+  // Truncate to 200 chars
+  if (content && content.length > 200) {
+    content = `${content.slice(0, 200)}…`;
+  }
+
+  // Extract tool name from assistant tool_use blocks
+  if (type === "assistant" && entry.message.message) {
+    const msg = entry.message.message as { content?: unknown };
+    if (Array.isArray(msg.content)) {
+      for (const block of msg.content) {
+        if (block && typeof block === "object" && (block as Record<string, unknown>).type === "tool_use") {
+          tool = (block as Record<string, unknown>).name as string;
+          break;
+        }
+      }
+    }
+  }
+
+  const result: CompactTranscriptEntry = { timestamp: entry.timestamp, role, content };
+  if (tool) result.tool = tool;
+  return result;
+}
+
+/** Extract content summary without ANSI color codes (for JSON output). */
+function extractContentSummaryPlain(content: unknown): string | null {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return null;
+
+  const parts: string[] = [];
+  for (const block of content) {
+    if (typeof block === "string") {
+      parts.push(block);
+    } else if (block && typeof block === "object") {
+      const b = block as Record<string, unknown>;
+      if (b.type === "text" && typeof b.text === "string") {
+        parts.push(b.text);
+      } else if (b.type === "tool_use" && typeof b.name === "string") {
+        parts.push(`[tool_use: ${b.name}]`);
+      } else if (b.type === "tool_result") {
+        const rc = b.content;
+        if (typeof rc === "string") {
+          parts.push(rc);
+        } else {
+          parts.push("[tool_result]");
+        }
+      }
+    }
+  }
+  return parts.length > 0 ? parts.join(" ") : null;
+}
+
 export interface SessionDetail extends SessionInfo {
   pendingPermissionIds: string[];
   pid: number | null;


### PR DESCRIPTION
## Summary
- Adds `compact` boolean parameter to `claude_transcript` MCP tool (default: false)
- When true, returns lightweight entries with only: timestamp, role, content summary (≤200 chars), and tool name
- Mirrors the compact format of `mcx claude log --last N`, reducing token overhead ~10x for orchestrator monitoring

## Test plan
- [x] Unit tests for `compactifyEntry()` covering: user/assistant/result/system messages, content truncation, tool_use extraction, tool_result blocks, unknown types
- [x] All 2926 existing tests pass
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)