### PR TITLE
feat(control): show partial-failure warning when some plan servers fail to respond (fixes #779)

### DIFF
--- a/packages/control/src/app.tsx
+++ b/packages/control/src/app.tsx
@@ -98,6 +98,7 @@ export function App() {
     loading: plansLoading,
     error: plansError,
     disconnected: plansDisconnected,
+    failedServers: plansFailedServers,
     refresh: plansRefresh,
   } = usePlans({ enabled: plansEnabled });
   plansRef.current = plans;
@@ -374,6 +375,7 @@ export function App() {
           loading={plansLoading}
           error={plansError}
           disconnected={plansDisconnected}
+          failedServers={plansFailedServers}
           selectedIndex={plansSelectedIndex}
           expandedPlan={expandedPlan}
           selectedStep={selectedStep}

--- a/packages/control/src/components/plans-tab.spec.ts
+++ b/packages/control/src/components/plans-tab.spec.ts
@@ -34,6 +34,7 @@ interface TabProps {
   loading?: boolean;
   error?: string | null;
   disconnected?: boolean;
+  failedServers?: string[];
   selectedIndex?: number;
   expandedPlan?: { id: string; server: string } | null;
   selectedStep?: number;
@@ -50,6 +51,7 @@ function renderTab(props: TabProps = {}) {
       loading: props.loading ?? false,
       error: props.error ?? null,
       disconnected: props.disconnected ?? false,
+      failedServers: props.failedServers,
       selectedIndex: props.selectedIndex ?? 0,
       expandedPlan: props.expandedPlan ?? null,
       selectedStep: props.selectedStep ?? 0,
@@ -105,6 +107,23 @@ describe("PlansTab", () => {
   it("shows disconnected warning", () => {
     const inst = renderTab({ disconnected: true });
     expect(inst.lastFrame() ?? "").toContain("stale data");
+    inst.unmount();
+  });
+
+  it("shows partial failure warning with failed server names", () => {
+    const inst = renderTab({ failedServers: ["auth-server", "deploy-server"] });
+    const output = inst.lastFrame() ?? "";
+    expect(output).toContain("2 server(s) unavailable");
+    expect(output).toContain("auth-server");
+    expect(output).toContain("deploy-server");
+    inst.unmount();
+  });
+
+  it("prefers disconnected warning over partial failure warning", () => {
+    const inst = renderTab({ disconnected: true, failedServers: ["auth-server"] });
+    const output = inst.lastFrame() ?? "";
+    expect(output).toContain("stale data");
+    expect(output).not.toContain("unavailable");
     inst.unmount();
   });
 

--- a/packages/control/src/components/plans-tab.tsx
+++ b/packages/control/src/components/plans-tab.tsx
@@ -15,6 +15,7 @@ interface PlansTabProps {
   expandedPlan: ExpandedPlanKey | null;
   selectedStep: number;
   disconnected?: boolean;
+  failedServers?: string[];
   servers: ServerStatus[];
   statusMessage?: string | null;
   statusType?: StatusType | null;
@@ -36,6 +37,7 @@ export function PlansTab({
   expandedPlan,
   selectedStep,
   disconnected,
+  failedServers,
   servers,
   statusMessage,
   statusType,
@@ -66,6 +68,10 @@ export function PlansTab({
       {disconnected ? (
         <Text color="yellow" dimColor>
           ⚠ Disconnected — showing stale data
+        </Text>
+      ) : failedServers && failedServers.length > 0 ? (
+        <Text color="yellow" dimColor>
+          ⚠ {failedServers.length} server(s) unavailable: {failedServers.join(", ")}
         </Text>
       ) : null}
       <PlanList plans={plans} selectedIndex={selectedIndex} expandedPlan={expandedPlan} />

--- a/packages/control/src/hooks/use-plans.spec.ts
+++ b/packages/control/src/hooks/use-plans.spec.ts
@@ -80,6 +80,7 @@ describe("usePlans", () => {
     loading: boolean;
     error: string | null;
     disconnected: boolean;
+    failedServers: string[];
   }
 
   const instances: ReturnType<typeof render>[] = [];
@@ -97,7 +98,7 @@ describe("usePlans", () => {
 
   function mount(opts: UsePlansOptions) {
     const stateRef: { current: HookState } = {
-      current: { plans: [], loading: true, error: null, disconnected: false },
+      current: { plans: [], loading: true, error: null, disconnected: false, failedServers: [] },
     };
     const instance = render(React.createElement(Harness, { opts, stateRef }));
     instances.push(instance);
@@ -223,7 +224,7 @@ describe("usePlans", () => {
     // Wrapper that lets us toggle enabled
     let setEnabled: ((v: boolean) => void) | undefined;
     const stateRef: { current: HookState } = {
-      current: { plans: [], loading: true, error: null, disconnected: false },
+      current: { plans: [], loading: true, error: null, disconnected: false, failedServers: [] },
     };
     const Wrapper: FC = () => {
       const [enabled, _setEnabled] = React.useState(true);
@@ -280,6 +281,64 @@ describe("usePlans", () => {
     // Plans from good server still returned; no top-level error
     expect(stateRef.current.plans).toHaveLength(1);
     expect(stateRef.current.error).toBeNull();
+  });
+
+  it("reports failedServers when one server fails and another succeeds", async () => {
+    const plan = makePlan("plan-1", "good-server");
+    const ipcCallFn = async (method: string, params?: unknown) => {
+      if (method === "status") {
+        return daemonStatus([
+          { name: "good-server", hasList: true },
+          { name: "bad-server", hasList: true },
+        ]);
+      }
+      const p = params as { server: string };
+      if (p.server === "bad-server") throw new Error("server unreachable");
+      return planToolResult([plan]);
+    };
+
+    const { stateRef } = mount({ ipcCallFn: ipcCallFn as UsePlansOptions["ipcCallFn"] });
+    await waitFor(() => stateRef.current.loading === false);
+
+    expect(stateRef.current.failedServers).toEqual(["bad-server"]);
+    expect(stateRef.current.disconnected).toBe(false);
+  });
+
+  it("reports failedServers when a server returns unparseable response", async () => {
+    const plan = makePlan("plan-1", "good-server");
+    const ipcCallFn = async (method: string, params?: unknown) => {
+      if (method === "status") {
+        return daemonStatus([
+          { name: "good-server", hasList: true },
+          { name: "bad-schema-server", hasList: true },
+        ]);
+      }
+      const p = params as { server: string };
+      if (p.server === "bad-schema-server") {
+        return { content: [{ type: "text", text: JSON.stringify({ wrong: "shape" }) }] };
+      }
+      return planToolResult([plan]);
+    };
+
+    const { stateRef } = mount({ ipcCallFn: ipcCallFn as UsePlansOptions["ipcCallFn"] });
+    await waitFor(() => stateRef.current.loading === false);
+
+    expect(stateRef.current.failedServers).toEqual(["bad-schema-server"]);
+    expect(stateRef.current.plans).toHaveLength(1);
+    expect(stateRef.current.disconnected).toBe(false);
+  });
+
+  it("clears failedServers when all servers succeed", async () => {
+    const plan = makePlan("plan-1", "server-a");
+    const ipcCallFn = async (method: string) => {
+      if (method === "status") return daemonStatus([{ name: "server-a", hasList: true }]);
+      return planToolResult([plan]);
+    };
+
+    const { stateRef } = mount({ ipcCallFn: ipcCallFn as UsePlansOptions["ipcCallFn"] });
+    await waitFor(() => stateRef.current.loading === false);
+
+    expect(stateRef.current.failedServers).toEqual([]);
   });
 
   it("treats a hanging server as a failure (per-server IPC timeout)", async () => {
@@ -524,6 +583,7 @@ describe("usePlans — Claude plan integration", () => {
     loading: boolean;
     error: string | null;
     disconnected: boolean;
+    failedServers: string[];
   }
 
   const instances: ReturnType<typeof render>[] = [];
@@ -541,7 +601,7 @@ describe("usePlans — Claude plan integration", () => {
 
   function mount(opts: UsePlansOptions) {
     const stateRef: { current: HookState } = {
-      current: { plans: [], loading: true, error: null, disconnected: false },
+      current: { plans: [], loading: true, error: null, disconnected: false, failedServers: [] },
     };
     const instance = render(React.createElement(Harness, { opts, stateRef }));
     instances.push(instance);

--- a/packages/control/src/hooks/use-plans.ts
+++ b/packages/control/src/hooks/use-plans.ts
@@ -114,6 +114,8 @@ export interface UsePlansResult {
   error: string | null;
   /** True when the last poll failed (stale data is shown). */
   disconnected: boolean;
+  /** Server names that failed to respond during the last poll. */
+  failedServers: string[];
   /** Force an immediate re-poll. Accepts optional completion callback. */
   refresh: (onComplete?: () => void) => void;
 }
@@ -137,6 +139,7 @@ export function usePlans(opts: UsePlansOptions = {}): UsePlansResult {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [disconnected, setDisconnected] = useState(false);
+  const [failedServers, setFailedServers] = useState<string[]>([]);
   const [tick, setTick] = useState(0);
   const refreshCallbackRef = useRef<(() => void) | null>(null);
 
@@ -170,6 +173,7 @@ export function usePlans(opts: UsePlansOptions = {}): UsePlansResult {
 
         const allPlans: Plan[] = [];
         let successCount = 0;
+        const failed: string[] = [];
 
         // Fetch server plans and Claude session plans in parallel
         const [_serverResults, claudePlans] = await Promise.all([
@@ -186,16 +190,20 @@ export function usePlans(opts: UsePlansOptions = {}): UsePlansResult {
                   `list_plans(${srv.name})`,
                 );
                 const text = extractToolText(result);
-                if (!text) return;
+                if (!text) {
+                  failed.push(srv.name);
+                  return;
+                }
                 const parsed = ListPlansResultSchema.safeParse(JSON.parse(text));
                 if (parsed.success) {
                   successCount++;
                   allPlans.push(...parsed.data.plans);
                 } else {
                   console.error(`[usePlans] parse error for server ${srv.name}:`, parsed.error.issues);
+                  failed.push(srv.name);
                 }
               } catch {
-                // One server failing doesn't break the whole list
+                failed.push(srv.name);
               }
             }),
           ),
@@ -211,6 +219,7 @@ export function usePlans(opts: UsePlansOptions = {}): UsePlansResult {
         setPlans(allPlans);
         setError(null);
         setDisconnected(allFailed);
+        setFailedServers(failed);
         setLoading(false);
         if (refreshCallbackRef.current) {
           refreshCallbackRef.current();
@@ -220,6 +229,7 @@ export function usePlans(opts: UsePlansOptions = {}): UsePlansResult {
         if (cancelRef.current) return;
         setError(err instanceof Error ? err.message : String(err));
         setDisconnected(true);
+        setFailedServers([]);
         setLoading(false);
         if (refreshCallbackRef.current) {
           refreshCallbackRef.current();
@@ -245,7 +255,7 @@ export function usePlans(opts: UsePlansOptions = {}): UsePlansResult {
     };
   }, [intervalMs, enabled, tick]);
 
-  return { plans, loading, error, disconnected, refresh };
+  return { plans, loading, error, disconnected, failedServers, refresh };
 }
 
 // -- usePlan --


### PR DESCRIPTION
## Summary
- Track `failedServers: string[]` in `usePlans` hook — servers that throw, timeout, or return unparseable responses are recorded by name
- Surface a yellow warning in `PlansTab`: "⚠ N server(s) unavailable: server-a, server-b" when partial failures occur
- Disconnected banner (total failure) takes precedence over partial-failure warning

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] New test: `failedServers` populated when one server fails and another succeeds
- [x] New test: `failedServers` populated when a server returns unparseable response
- [x] New test: `failedServers` cleared when all servers succeed
- [x] New test: PlansTab renders partial failure warning with server names
- [x] New test: disconnected warning takes precedence over partial failure warning
- [x] All 47 existing tests in `use-plans.spec.ts` + `plans-tab.spec.ts` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)