### PR TITLE
fix(control): gate footer plan action hints on individual capabilities (fixes #782)

### DIFF
--- a/packages/control/src/app.tsx
+++ b/packages/control/src/app.tsx
@@ -15,7 +15,7 @@ import { TabBar, buildBadges } from "./components/tab-bar.js";
 import { useClaudeSessions } from "./hooks/use-claude-sessions.js";
 import { useDaemonProcessCount } from "./hooks/use-daemon-process-count.js";
 import { useDaemon } from "./hooks/use-daemon.js";
-import { type ExpandedPlanKey, type StatusType, isPlanReadOnly } from "./hooks/use-keyboard-plans.js";
+import { type ExpandedPlanKey, type StatusType, hasCapability } from "./hooks/use-keyboard-plans.js";
 import type { View } from "./hooks/use-keyboard.js";
 import { useKeyboard } from "./hooks/use-keyboard.js";
 import { filterLogLines, useLogs } from "./hooks/use-logs.js";
@@ -402,11 +402,17 @@ export function App() {
         mailExpanded={expandedMessage !== null}
         planExpanded={expandedPlan !== null}
         planConfirmAbort={planConfirmAbort}
-        planReadOnly={(() => {
+        canAdvance={(() => {
           const targetPlan = expandedPlan
             ? plans.find((p) => p.id === expandedPlan.id && p.server === expandedPlan.server)
             : plans[plansSelectedIndex];
-          return targetPlan ? isPlanReadOnly(servers, targetPlan) : false;
+          return targetPlan ? hasCapability(servers, targetPlan.server, "advance") : false;
+        })()}
+        canAbort={(() => {
+          const targetPlan = expandedPlan
+            ? plans.find((p) => p.id === expandedPlan.id && p.server === expandedPlan.server)
+            : plans[plansSelectedIndex];
+          return targetPlan ? hasCapability(servers, targetPlan.server, "abort") : false;
         })()}
       />
     </Box>

--- a/packages/control/src/components/footer.tsx
+++ b/packages/control/src/components/footer.tsx
@@ -14,7 +14,8 @@ interface FooterProps {
   mailExpanded?: boolean;
   planExpanded?: boolean;
   planConfirmAbort?: boolean;
-  planReadOnly?: boolean;
+  canAdvance?: boolean;
+  canAbort?: boolean;
 }
 
 export function Footer({
@@ -29,7 +30,8 @@ export function Footer({
   mailExpanded,
   planExpanded,
   planConfirmAbort,
-  planReadOnly,
+  canAdvance,
+  canAbort,
 }: FooterProps) {
   if (denyReasonMode) {
     return (
@@ -176,9 +178,13 @@ export function Footer({
               <Text dimColor>←/→</Text> steps{"  "}
             </>
           ) : null}
-          {!planReadOnly ? (
+          {canAdvance ? (
             <>
               <Text dimColor>a</Text> advance{"  "}
+            </>
+          ) : null}
+          {canAbort ? (
+            <>
               <Text dimColor>x</Text> abort{"  "}
             </>
           ) : null}


### PR DESCRIPTION
## Summary
- Replace single planReadOnly boolean prop in Footer with per-capability canAdvance and canAbort flags
- Each footer hint (a advance, x abort) now gates independently on its own capability
- Keyboard handlers already checked capabilities individually — no changes needed there

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] All 2918 tests pass
- [x] Existing isPlanReadOnly / hasCapability unit tests still pass
- [x] No remaining references to removed planReadOnly prop

Generated with Claude Code