### PR TITLE
fix(serve): add session ID prefix matching to daemon tool handlers (fixes #787)

### DIFF
--- a/packages/daemon/src/claude-session/tools.ts
+++ b/packages/daemon/src/claude-session/tools.ts
@@ -17,7 +17,10 @@ export const CLAUDE_TOOLS = [
       type: "object" as const,
       properties: {
         prompt: { type: "string", description: "The message to send to Claude Code" },
-        sessionId: { type: "string", description: "Existing session ID to continue (omit for new session)" },
+        sessionId: {
+          type: "string",
+          description: "Existing session ID to continue, supports prefix matching (omit for new session)",
+        },
         cwd: { type: "string", description: "Working directory for the Claude process" },
         permissionMode: {
           type: "string",
@@ -68,7 +71,7 @@ export const CLAUDE_TOOLS = [
     inputSchema: {
       type: "object" as const,
       properties: {
-        sessionId: { type: "string", description: "Session ID to query" },
+        sessionId: { type: "string", description: "Session ID or unique prefix to query" },
       },
       required: ["sessionId"],
     },
@@ -79,7 +82,7 @@ export const CLAUDE_TOOLS = [
     inputSchema: {
       type: "object" as const,
       properties: {
-        sessionId: { type: "string", description: "Session ID to interrupt" },
+        sessionId: { type: "string", description: "Session ID or unique prefix to interrupt" },
       },
       required: ["sessionId"],
     },
@@ -90,7 +93,7 @@ export const CLAUDE_TOOLS = [
     inputSchema: {
       type: "object" as const,
       properties: {
-        sessionId: { type: "string", description: "Session ID to end" },
+        sessionId: { type: "string", description: "Session ID or unique prefix to end" },
       },
       required: ["sessionId"],
     },
@@ -101,7 +104,7 @@ export const CLAUDE_TOOLS = [
     inputSchema: {
       type: "object" as const,
       properties: {
-        sessionId: { type: "string", description: "Session ID to query" },
+        sessionId: { type: "string", description: "Session ID or unique prefix to query" },
         limit: { type: "number", description: "Max entries to return (default: 50)" },
       },
       required: ["sessionId"],
@@ -116,7 +119,7 @@ export const CLAUDE_TOOLS = [
     inputSchema: {
       type: "object" as const,
       properties: {
-        sessionId: { type: "string", description: "Session ID to wait on (omit for any session)" },
+        sessionId: { type: "string", description: "Session ID or unique prefix to wait on (omit for any session)" },
         timeout: { type: "number", description: "Max wait time in ms (default: 300000)" },
         afterSeq: {
           type: "number",
@@ -136,7 +139,7 @@ export const CLAUDE_TOOLS = [
     inputSchema: {
       type: "object" as const,
       properties: {
-        sessionId: { type: "string", description: "Session ID containing the permission request" },
+        sessionId: { type: "string", description: "Session ID or unique prefix containing the permission request" },
         requestId: { type: "string", description: "Permission request ID to approve" },
       },
       required: ["sessionId", "requestId"],
@@ -148,7 +151,7 @@ export const CLAUDE_TOOLS = [
     inputSchema: {
       type: "object" as const,
       properties: {
-        sessionId: { type: "string", description: "Session ID containing the permission request" },
+        sessionId: { type: "string", description: "Session ID or unique prefix containing the permission request" },
         requestId: { type: "string", description: "Permission request ID to deny" },
         message: { type: "string", description: "Denial reason (default: 'Denied by user via mcpctl')" },
       },

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -2853,4 +2853,48 @@ describe("restoreSessions", () => {
     expect(s2?.state).toBe("disconnected");
     expect(s2?.worktree).toBe("/b-wt");
   });
+
+  // ── Session ID prefix matching ──
+
+  describe("resolveSessionId", () => {
+    test("exact match returns the session ID", async () => {
+      server = new ClaudeWsServer({ spawn: mockSpawn().spawn, logger: silentLogger });
+      await server.start();
+      server.prepareSession("abc-123-full-id", { prompt: "test" });
+      expect(server.resolveSessionId("abc-123-full-id")).toBe("abc-123-full-id");
+    });
+
+    test("unique prefix resolves to full session ID", async () => {
+      server = new ClaudeWsServer({ spawn: mockSpawn().spawn, logger: silentLogger });
+      await server.start();
+      server.prepareSession("abc-123-full-id", { prompt: "test" });
+      expect(server.resolveSessionId("abc-1")).toBe("abc-123-full-id");
+      expect(server.resolveSessionId("abc")).toBe("abc-123-full-id");
+    });
+
+    test("ambiguous prefix throws with matching IDs", async () => {
+      server = new ClaudeWsServer({ spawn: mockSpawn().spawn, logger: silentLogger });
+      await server.start();
+      server.prepareSession("abc-111", { prompt: "test" });
+      server.prepareSession("abc-222", { prompt: "test" });
+      expect(() => server?.resolveSessionId("abc")).toThrow(/Ambiguous session prefix "abc"/);
+    });
+
+    test("no match throws unknown session", async () => {
+      server = new ClaudeWsServer({ spawn: mockSpawn().spawn, logger: silentLogger });
+      await server.start();
+      server.prepareSession("abc-123", { prompt: "test" });
+      expect(() => server?.resolveSessionId("xyz")).toThrow(/Unknown session: xyz/);
+    });
+
+    test("prefix matching works for getStatus", async () => {
+      server = new ClaudeWsServer({ spawn: mockSpawn().spawn, logger: silentLogger });
+      await server.start();
+      server.prepareSession("prefix-test-session-long-id", { prompt: "Hello" });
+
+      // getStatus works with prefix even in "spawning" state
+      const status = server.getStatus("prefix-test");
+      expect(status.sessionId).toBe("prefix-test-session-long-id");
+    });
+  });
 });

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -700,14 +700,15 @@ export class ClaudeWsServer {
    * process is stuck. Callers that need a fast return should fire-and-forget this.
    */
   async bye(sessionId: string): Promise<{ worktree: string | null; cwd: string | null; repoRoot: string | null }> {
-    const session = this.sessions.get(sessionId);
-    if (!session) throw new Error(`No session with id ${sessionId}`);
+    const resolvedId = this.resolveSessionId(sessionId);
+    const session = this.sessions.get(resolvedId);
+    if (!session) throw new Error(`No session with id ${resolvedId}`);
     const info = {
       worktree: session.worktree,
       cwd: session.config.cwd ?? null,
       repoRoot: session.config.repoRoot ?? null,
     };
-    await this.terminateSession(sessionId, session, "Session ended by user");
+    await this.terminateSession(resolvedId, session, "Session ended by user");
     return info;
   }
 
@@ -738,9 +739,10 @@ export class ClaudeWsServer {
 
   /** Get detailed status for a session. */
   getStatus(sessionId: string): SessionDetail {
-    const session = this.getSession(sessionId);
+    const resolvedId = this.resolveSessionId(sessionId);
+    const session = this.getSession(resolvedId);
     return {
-      ...this.buildSessionInfo(sessionId, session),
+      ...this.buildSessionInfo(resolvedId, session),
       pendingPermissionIds: [...session.state.pendingPermissions.keys()],
       pid: session.pid,
     };
@@ -786,16 +788,16 @@ export class ClaudeWsServer {
    * with a synthetic event instead of blocking until timeout.
    */
   waitForEvent(sessionId: string | null, timeoutMs: number): Promise<SessionWaitEvent> {
-    const err = this.validateWaitTarget(sessionId);
-    if (err) return Promise.reject(err);
+    const { error, resolvedId } = this.validateWaitTarget(sessionId);
+    if (error) return Promise.reject(error);
 
     // Check if any matching session already has an actionable state
-    const immediate = this.findImmediateEvent(sessionId);
+    const immediate = this.findImmediateEvent(resolvedId);
     if (immediate) return Promise.resolve(immediate);
 
     return new Promise<SessionWaitEvent>((resolve, reject) => {
       const waiter: EventWaiter = {
-        sessionId,
+        sessionId: resolvedId,
         resolve: (e) => {
           clearTimeout(waiter.timer);
           resolve(e);
@@ -820,11 +822,11 @@ export class ClaudeWsServer {
    * On timeout, returns `{ seq: currentSeq, events: [] }` instead of throwing.
    */
   waitForEventsSince(sessionId: string | null, afterSeq: number, timeoutMs: number): Promise<WaitResult> {
-    const err = this.validateWaitTarget(sessionId);
-    if (err) return Promise.reject(err);
+    const { error, resolvedId } = this.validateWaitTarget(sessionId);
+    if (error) return Promise.reject(error);
 
     // Check buffer for events after afterSeq
-    const buffered = this.getBufferedEventsAfter(sessionId, afterSeq);
+    const buffered = this.getBufferedEventsAfter(resolvedId, afterSeq);
     if (buffered.length > 0) {
       return Promise.resolve({ seq: this.eventSeq, events: buffered });
     }
@@ -832,7 +834,7 @@ export class ClaudeWsServer {
     // Block until next matching event
     return new Promise<WaitResult>((resolve, reject) => {
       const waiter: EventWaiter = {
-        sessionId,
+        sessionId: resolvedId,
         resolve: (e) => {
           clearTimeout(waiter.timer);
           resolve({ seq: this.eventSeq, events: [e] });
@@ -1157,17 +1159,24 @@ export class ClaudeWsServer {
   }
 
   /** Validate that a wait target (sessionId or any-session) is valid. Returns null if OK, Error otherwise. */
-  private validateWaitTarget(sessionId: string | null): Error | null {
+  private validateWaitTarget(sessionId: string | null): { error?: Error; resolvedId: string | null } {
     if (sessionId) {
-      const session = this.sessions.get(sessionId);
-      if (!session) return new Error(`Unknown session: ${sessionId}`);
-      if (session.state.state === "ended") return new Error("Session already ended");
-      if (session.state.state === "disconnected") return new Error("Session is disconnected");
+      let resolvedId: string;
+      try {
+        resolvedId = this.resolveSessionId(sessionId);
+      } catch (e) {
+        return { error: e as Error, resolvedId: null };
+      }
+      const session = this.sessions.get(resolvedId);
+      if (session?.state.state === "ended") return { error: new Error("Session already ended"), resolvedId: null };
+      if (session?.state.state === "disconnected")
+        return { error: new Error("Session is disconnected"), resolvedId: null };
+      return { resolvedId };
     }
-    if (!sessionId && this.sessions.size === 0) {
-      return new Error("No active sessions");
+    if (this.sessions.size === 0) {
+      return { error: new Error("No active sessions"), resolvedId: null };
     }
-    return null;
+    return { resolvedId: null };
   }
 
   /** Buffer an event with a monotonic sequence number. Returns the assigned seq. */
@@ -1198,9 +1207,28 @@ export class ClaudeWsServer {
     return events;
   }
 
+  /**
+   * Resolve a session ID or unique prefix to the full session ID.
+   * Throws if zero or multiple sessions match.
+   */
+  resolveSessionId(sessionId: string): string {
+    if (this.sessions.has(sessionId)) return sessionId;
+
+    const matches: string[] = [];
+    for (const id of this.sessions.keys()) {
+      if (id.startsWith(sessionId)) matches.push(id);
+    }
+    if (matches.length === 1) return matches[0];
+    if (matches.length > 1) {
+      throw new Error(`Ambiguous session prefix "${sessionId}" — matches: ${matches.join(", ")}`);
+    }
+    throw new Error(`Unknown session: ${sessionId}`);
+  }
+
   private getSession(sessionId: string): WsSession {
-    const session = this.sessions.get(sessionId);
-    if (!session) throw new Error(`Unknown session: ${sessionId}`);
+    const resolved = this.resolveSessionId(sessionId);
+    const session = this.sessions.get(resolved);
+    if (!session) throw new Error(`Unknown session: ${resolved}`);
     return session;
   }
 


### PR DESCRIPTION
## Summary
- Added `resolveSessionId()` public method to `ClaudeWsServer` that resolves session ID prefixes to full IDs (exact match first, then prefix match with ambiguity detection)
- Updated `getSession()`, `getStatus()`, `bye()`, `validateWaitTarget()`, `waitForEvent()`, and `waitForEventsSince()` to use prefix resolution
- Updated tool descriptions in `tools.ts` to document prefix support for all `sessionId` parameters

## Test plan
- [x] Added unit tests for `resolveSessionId`: exact match, unique prefix, ambiguous prefix, no match
- [x] Added integration test verifying `getStatus()` works with prefix
- [x] All 114 ws-server tests pass
- [x] Typecheck passes
- [x] Lint passes
- [x] Full test suite: 2920/2923 pass (3 pre-existing flaky failures unrelated to changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)