### PR TITLE
fix(test): replace bare setTimeout with waitFor in use-plans.spec.ts (fixes #792)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "private": true,
   "version": "0.7.0",
   "type": "module",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "scripts": {
     "build": "bun scripts/build.ts",
     "typecheck": "bun install && bun --bun tsc -b",

--- a/packages/control/src/hooks/use-plans.spec.ts
+++ b/packages/control/src/hooks/use-plans.spec.ts
@@ -221,8 +221,9 @@ describe("usePlans", () => {
       return planToolResult([plan]);
     };
 
-    // Wrapper that lets us toggle enabled
+    // Wrapper that lets us toggle enabled and tracks render count
     let setEnabled: ((v: boolean) => void) | undefined;
+    let renderCount = 0;
     const stateRef: { current: HookState } = {
       current: { plans: [], loading: true, error: null, disconnected: false, failedServers: [] },
     };
@@ -235,6 +236,7 @@ describe("usePlans", () => {
         ipcCallFn: ipcCallFn as UsePlansOptions["ipcCallFn"],
       });
       stateRef.current = result;
+      renderCount++;
       return React.createElement(Text, null, "ok");
     };
 
@@ -245,9 +247,10 @@ describe("usePlans", () => {
     await waitFor(() => stateRef.current.loading === false);
     expect(stateRef.current.plans).toHaveLength(1);
 
-    // Disable — effect cleanup runs
+    // Disable — effect cleanup runs; wait for React to process the update
+    const countBeforeDisable = renderCount;
     setEnabled?.(false);
-    await new Promise((r) => setTimeout(r, 10));
+    await waitFor(() => renderCount > countBeforeDisable);
 
     // Make next poll slow so we can observe loading=true before it completes
     pollDelay = 200;


### PR DESCRIPTION
## Summary
- Replace `await new Promise(r => setTimeout(r, 10))` at line 250 of `use-plans.spec.ts` with a render-count-based `waitFor` predicate
- Tracks component render count to deterministically confirm React processed the `setEnabled(false)` state update before proceeding
- Includes unrelated `package.json` format fix caught by biome lint

## Test plan
- [x] `bun test packages/control/src/hooks/use-plans.spec.ts` — all 35 tests pass
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun test` — all 2965 tests pass
- [x] Pre-commit hook passes (typecheck + lint + test + coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)