### PR TITLE
feat(serve): add SIGTERM/SIGINT handler for graceful shutdown (fixes #765)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,7 @@
   "private": true,
   "version": "0.7.0",
   "type": "module",
-  "workspaces": [
-    "packages/*"
-  ],
+  "workspaces": ["packages/*"],
   "scripts": {
     "build": "bun scripts/build.ts",
     "typecheck": "bun install && bun --bun tsc -b",

--- a/packages/command/src/commands/serve.ts
+++ b/packages/command/src/commands/serve.ts
@@ -295,7 +295,18 @@ export async function cmdServe(): Promise<void> {
   const stopPoller = startToolListPoller(server, ipcCall);
   console.error("[mcx serve] MCP server running on stdio");
 
+  // Graceful shutdown on SIGTERM/SIGINT — close server and transport so
+  // inflight MCP requests get proper responses before the process exits.
+  const shutdown = async () => {
+    await server.close();
+    await transport.close();
+  };
+  process.once("SIGTERM", shutdown);
+  process.once("SIGINT", shutdown);
+
   // Block until stdin closes — prevents main() from calling process.exit()
   await transport.closed;
   stopPoller();
+  process.off("SIGTERM", shutdown);
+  process.off("SIGINT", shutdown);
 }


### PR DESCRIPTION
## Summary
- Register `SIGTERM` and `SIGINT` signal handlers in `cmdServe()` that call `server.close()` and `transport.close()` for graceful shutdown
- Ensures inflight MCP requests complete before exit instead of being dropped
- Cleans up signal handlers after `transport.closed` resolves

## Test plan
- [x] Typecheck passes
- [x] Lint passes (no new warnings)
- [x] All 2965 tests pass
- [x] Coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)