### PR TITLE
feat(serve): detect TTY stdin and print helpful error (fixes #766)

### DIFF
--- a/packages/command/src/commands/serve.spec.ts
+++ b/packages/command/src/commands/serve.spec.ts
@@ -8,6 +8,7 @@ import {
   type IpcCaller,
   type ToolListNotifier,
   checkRecursionGuard,
+  checkTtyStdin,
   computeToolsFingerprint,
   handleCallTool,
   handleListTools,
@@ -90,6 +91,17 @@ describe("parseMcpTools", () => {
   test("skips entries with empty server or tool (bare slash)", () => {
     const result = parseMcpTools("/search,atlassian/,valid/tool");
     expect(result).toEqual([{ name: "tool", server: "valid", tool: "tool" }]);
+  });
+});
+
+// -- TTY stdin check --
+
+describe("checkTtyStdin", () => {
+  test("returns a boolean reflecting Bun.stdin.isTTY", () => {
+    const result = checkTtyStdin();
+    expect(typeof result).toBe("boolean");
+    // In test runner, stdin is typically not a TTY
+    expect(result).toBe(!!process.stdin.isTTY);
   });
 });
 

--- a/packages/command/src/commands/serve.ts
+++ b/packages/command/src/commands/serve.ts
@@ -267,7 +267,17 @@ export async function handleCallTool(
 
 // -- Server --
 
+export function checkTtyStdin(): boolean {
+  return !!process.stdin.isTTY;
+}
+
 export async function cmdServe(): Promise<void> {
+  if (checkTtyStdin()) {
+    console.error("[mcx serve] Error: mcx serve is an MCP stdio server — connect it via stdio, not a terminal.");
+    console.error("[mcx serve] Example: claude mcp add my-server -- mcx serve");
+    process.exit(1);
+  }
+
   if (checkRecursionGuard()) {
     console.error("[mcx serve] Recursion detected (MCX_SERVE=1 already set). Aborting to prevent infinite loop.");
     process.exit(1);


### PR DESCRIPTION
## Summary
- Add `checkTtyStdin()` guard at the top of `cmdServe` that detects when stdin is a TTY
- When detected, prints a clear error message explaining `mcx serve` is an MCP stdio server and shows correct usage (`claude mcp add my-server -- mcx serve`)
- Exits with code 1 instead of silently hanging

## Test plan
- [x] `checkTtyStdin` unit test added to `serve.spec.ts`
- [x] All 2966 tests pass
- [x] Typecheck, lint, and coverage all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)