### PR TITLE
fix(test): add bounded timeout to TestDaemon.kill() (fixes #809)

### DIFF
--- a/test/harness.ts
+++ b/test/harness.ts
@@ -106,7 +106,16 @@ export async function startTestDaemon(
       } catch {
         // already exited
       }
-      await proc.exited;
+      // Bounded wait: if SIGTERM doesn't work within 5s, escalate to SIGKILL
+      const exited = await Promise.race([proc.exited.then(() => true), Bun.sleep(5_000).then(() => false)]);
+      if (!exited) {
+        try {
+          proc.kill("SIGKILL");
+        } catch {
+          // already exited
+        }
+        await Promise.race([proc.exited, Bun.sleep(2_000)]);
+      }
       rmSync(dir, { recursive: true, force: true });
     },
   };


### PR DESCRIPTION
## Summary
- `TestDaemon.kill()` now has a bounded timeout: SIGTERM gets 5s, then escalates to SIGKILL with a 2s final deadline
- Prevents beforeEach/afterEach hooks from hanging indefinitely when a daemon ignores SIGTERM under parallel test load

## Test plan
- [x] All 2965 existing tests pass
- [x] Typecheck passes
- [x] Lint passes
- [x] Coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)