### PR TITLE
test(hooks): add automated tests for pre-commit classification logic (fixes #796)

### DIFF
--- a/.git-hooks/classify.sh
+++ b/.git-hooks/classify.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# classify_files: classify a newline-delimited list of filenames into tiers.
+#
+# Reads filenames from stdin, sets two variables in the caller's scope:
+#   has_source  (true/false)
+#   has_config  (true/false)
+#
+# If neither is true, all files were docs-only (or input was empty).
+#
+# Usage:
+#   classify_files <<< "$staged_files"
+
+classify_files() {
+  has_source=false
+  has_config=false
+
+  local file
+  while IFS= read -r file; do
+    [ -z "$file" ] && continue
+    case "$file" in
+      # Docs: markdown files, .claude/ directory contents
+      *.md | .claude/*)
+        ;;
+      # Config: JSON files, scripts/, build tooling, git hooks
+      *.json | scripts/* | .git-hooks/*)
+        has_config=true
+        ;;
+      # Everything else is source code
+      *)
+        has_source=true
+        ;;
+    esac
+  done
+}

--- a/.git-hooks/classify.spec.ts
+++ b/.git-hooks/classify.spec.ts
@@ -1,0 +1,93 @@
+import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
+
+const CLASSIFY_SH = resolve(import.meta.dir, "classify.sh");
+
+/** Run classify_files on a list of filenames, return { has_source, has_config } */
+async function classify(files: string[]): Promise<{ has_source: boolean; has_config: boolean }> {
+  const input = files.join("\n");
+  const script = `
+    source "${CLASSIFY_SH}"
+    classify_files <<'__FILES__'
+${input}
+__FILES__
+    echo "has_source=$has_source"
+    echo "has_config=$has_config"
+  `;
+  const proc = Bun.spawn(["bash", "-c", script], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const text = await new Response(proc.stdout).text();
+  const code = await proc.exited;
+  if (code !== 0) {
+    const err = await new Response(proc.stderr).text();
+    throw new Error(`classify.sh exited ${code}: ${err}`);
+  }
+  const lines = text.trim().split("\n");
+  const vars: Record<string, boolean> = {};
+  for (const line of lines) {
+    const [key, val] = line.split("=");
+    vars[key] = val === "true";
+  }
+  return {
+    has_source: vars.has_source ?? false,
+    has_config: vars.has_config ?? false,
+  };
+}
+
+describe("pre-commit classify_files", () => {
+  test("docs-only: markdown files", async () => {
+    const result = await classify(["README.md", ".claude/sprints/sprint-15.md", "CLAUDE.md"]);
+    expect(result.has_source).toBe(false);
+    expect(result.has_config).toBe(false);
+  });
+
+  test("docs-only: .claude/ non-markdown files", async () => {
+    const result = await classify([".claude/diary/20260318.md", ".claude/arcs.md"]);
+    expect(result.has_source).toBe(false);
+    expect(result.has_config).toBe(false);
+  });
+
+  test("config-only: JSON files", async () => {
+    const result = await classify(["package.json", "tsconfig.json"]);
+    expect(result.has_source).toBe(false);
+    expect(result.has_config).toBe(true);
+  });
+
+  test("config-only: scripts/ and .git-hooks/", async () => {
+    const result = await classify(["scripts/check-coverage.ts", ".git-hooks/pre-commit"]);
+    expect(result.has_source).toBe(false);
+    expect(result.has_config).toBe(true);
+  });
+
+  test("source: TypeScript files in packages/", async () => {
+    const result = await classify(["packages/core/src/foo.ts", "packages/daemon/src/bar.ts"]);
+    expect(result.has_source).toBe(true);
+    expect(result.has_config).toBe(false);
+  });
+
+  test("mixed docs+config → config tier", async () => {
+    const result = await classify(["README.md", "package.json"]);
+    expect(result.has_source).toBe(false);
+    expect(result.has_config).toBe(true);
+  });
+
+  test("mixed docs+source → source tier", async () => {
+    const result = await classify(["README.md", "packages/core/src/foo.ts"]);
+    expect(result.has_source).toBe(true);
+    expect(result.has_config).toBe(false);
+  });
+
+  test("mixed all three → source tier", async () => {
+    const result = await classify(["README.md", "package.json", "packages/core/src/foo.ts"]);
+    expect(result.has_source).toBe(true);
+    expect(result.has_config).toBe(true);
+  });
+
+  test("empty file list → neither flag set", async () => {
+    const result = await classify([]);
+    expect(result.has_source).toBe(false);
+    expect(result.has_config).toBe(false);
+  });
+});

--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -17,25 +17,10 @@ if [ -z "$staged_files" ]; then
 fi
 
 # Classify staged files into tiers
-has_source=false
-has_config=false
-
-while IFS= read -r file; do
-  case "$file" in
-    # Docs: markdown files, .claude/ directory contents, CLAUDE.md
-    *.md | .claude/* | CLAUDE.md)
-      # docs-only tier — no action needed
-      ;;
-    # Config: JSON files, scripts/, build tooling, git hooks (not shipped in binaries)
-    *.json | scripts/* | .git-hooks/*)
-      has_config=true
-      ;;
-    # Everything else is source code
-    *)
-      has_source=true
-      ;;
-  esac
-done <<< "$staged_files"
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=classify.sh
+source "$HOOK_DIR/classify.sh"
+classify_files <<< "$staged_files"
 
 if $has_source; then
   echo "Running pre-commit checks (source changes detected)..."


### PR DESCRIPTION
## Summary
- Extract file classification logic from `.git-hooks/pre-commit` into a sourceable `.git-hooks/classify.sh` function
- Add `.git-hooks/classify.spec.ts` with 9 test cases covering all tier combinations: docs-only, config-only, source, mixed docs+config, mixed docs+source, mixed all three, and empty input
- Pre-commit hook now sources `classify.sh` instead of inlining the logic

## Test plan
- [x] All 9 classification test cases pass
- [x] Full test suite passes (2965 tests, 0 failures)
- [x] Typecheck passes
- [x] Lint passes (auto-fixed formatting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)