### PR TITLE
fix(daemon): add drain timeout to IPC server shutdown (fixes #808)

### DIFF
--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -72,6 +72,7 @@ function opts(overrides?: {
   onRequestComplete?: () => void;
   onShutdown?: () => void;
   onReloadConfig?: () => Promise<void>;
+  drainTimeoutMs?: number;
 }) {
   return {
     daemonId: TEST_DAEMON_ID,
@@ -388,6 +389,64 @@ describe("IpcServer HTTP transport", () => {
 
     await pollUntil(() => shutdownCalled);
     expect(shutdownCalled).toBe(true);
+  });
+
+  test("shutdown drain timeout forces shutdown when requests are stuck", async () => {
+    socketPath = tmpSocket();
+    let shutdownCalled = false;
+    let handlerEntered: () => void;
+    const handlerStarted = new Promise<void>((resolve) => {
+      handlerEntered = resolve;
+    });
+    // Pool with a handler that never resolves — simulates a stuck request
+    let resolveStuck: (() => void) | undefined;
+    const stuckForever = new Promise<void>((resolve) => {
+      resolveStuck = resolve;
+    });
+    const stuckPool = {
+      ...mockPool(),
+      callTool: async () => {
+        handlerEntered();
+        await stuckForever;
+        return { content: [] };
+      },
+    };
+    server = new IpcServer(
+      stuckPool as never,
+      mockConfig(),
+      mockDb(),
+      null,
+      opts({
+        onShutdown: () => {
+          shutdownCalled = true;
+        },
+        drainTimeoutMs: 200,
+      }),
+    );
+    server.start(socketPath);
+
+    // Start a stuck callTool request (don't await — it will never resolve on its own)
+    const stuckReq = rpc("/rpc", {
+      id: "stuck1",
+      method: "callTool",
+      params: { server: "s", tool: "t", arguments: {} },
+    });
+
+    // Wait for the handler to start executing
+    await handlerStarted;
+
+    // Trigger shutdown — drain timeout (200ms) should force shutdown even though request is stuck
+    const shutdownRes = await rpc("/rpc", { id: "sd-timeout", method: "shutdown" });
+    const shutdownJson = (await shutdownRes.json()) as IpcResponse;
+    expect(shutdownJson.result).toEqual({ ok: true });
+
+    // Shutdown should fire within the drain timeout despite stuck request
+    await pollUntil(() => shutdownCalled, 2_000);
+    expect(shutdownCalled).toBe(true);
+
+    // Unblock the stuck handler so the test can clean up
+    resolveStuck?.();
+    await stuckReq.catch(() => {});
   });
 
   test("shutdown works when pool has active servers", async () => {

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -78,6 +78,8 @@ export class IpcServer {
   private inflightCount = 0;
   private draining = false;
   private shutdownScheduled = false;
+  private drainTimer: ReturnType<typeof setTimeout> | null = null;
+  private drainTimeoutMs: number;
 
   private onReloadConfig: (() => Promise<void>) | null = null;
   private getWsPortInfo: (() => { actual: number | null; expected: number }) | null = null;
@@ -101,6 +103,8 @@ export class IpcServer {
       logger?: Logger;
       /** Returns the current and expected WS port for status reporting. */
       getWsPortInfo?: () => { actual: number | null; expected: number };
+      /** Max ms to wait for in-flight requests before forcing shutdown (default 5000) */
+      drainTimeoutMs?: number;
     },
   ) {
     this.daemonId = options.daemonId;
@@ -112,6 +116,7 @@ export class IpcServer {
     this.aliasServer = aliasServer;
     this.logger = options.logger ?? consoleLogger;
     this.getWsPortInfo = options.getWsPortInfo ?? null;
+    this.drainTimeoutMs = options.drainTimeoutMs ?? 5_000;
     this.registerHandlers();
     // Prune expired ephemeral aliases on startup
     this.db.pruneExpiredAliases();
@@ -208,6 +213,10 @@ export class IpcServer {
 
   /** Stop listening and clean up socket */
   stop(): void {
+    if (this.drainTimer) {
+      clearTimeout(this.drainTimer);
+      this.drainTimer = null;
+    }
     this.server?.stop(true);
     try {
       unlinkSync(this.socketPath);
@@ -220,9 +229,26 @@ export class IpcServer {
   private checkDrain(): void {
     if (this.draining && this.inflightCount === 0 && !this.shutdownScheduled) {
       this.shutdownScheduled = true;
+      if (this.drainTimer) {
+        clearTimeout(this.drainTimer);
+        this.drainTimer = null;
+      }
       // Defer to next event-loop turn so Bun can finish writing the HTTP response
       setTimeout(() => this.onShutdown(), 0);
     }
+  }
+
+  /** Start a drain timeout — force shutdown after drainTimeoutMs even if requests are stuck */
+  private startDrainTimeout(): void {
+    this.drainTimer = setTimeout(() => {
+      if (!this.shutdownScheduled) {
+        this.logger.warn(
+          `[ipc] Drain timeout (${this.drainTimeoutMs}ms) — forcing shutdown with ${this.inflightCount} request(s) still in-flight`,
+        );
+        this.shutdownScheduled = true;
+        this.onShutdown();
+      }
+    }, this.drainTimeoutMs);
   }
 
   // -- Dispatch --
@@ -770,6 +796,7 @@ export class IpcServer {
       }
       // Enter drain mode — onShutdown fires after all in-flight responses are sent
       this.draining = true;
+      this.startDrainTimeout();
       return { ok: true };
     });
   }


### PR DESCRIPTION
## Summary
- Add a configurable drain timeout (default 5s) to the IPC server shutdown path so it doesn't hang indefinitely when in-flight requests are stuck
- The timeout force-fires `onShutdown` and logs a warning with the number of stuck requests
- Clean up the drain timer in `stop()` and when drain completes normally

## Test plan
- [x] New test: "shutdown drain timeout forces shutdown when requests are stuck" — uses a 200ms drain timeout with a never-resolving handler, verifies `onShutdown` fires within the timeout
- [x] Existing drain test ("shutdown rejects new requests while draining") still passes — normal drain completes before the timeout
- [x] Full test suite: 2966 pass, 0 fail
- [x] Typecheck and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)