### PR TITLE
refactor(control): remove unused usePlan hook (fixes #776)

### DIFF
--- a/packages/control/src/hooks/use-plans.spec.ts
+++ b/packages/control/src/hooks/use-plans.spec.ts
@@ -3,14 +3,7 @@ import type { Plan, PlanMetrics } from "@mcp-cli/core";
 import { Text } from "ink";
 import { render } from "ink-testing-library";
 import React, { type FC } from "react";
-import {
-  type UsePlanMetricsOptions,
-  type UsePlanOptions,
-  type UsePlansOptions,
-  usePlan,
-  usePlanMetrics,
-  usePlans,
-} from "./use-plans";
+import { type UsePlanMetricsOptions, type UsePlansOptions, usePlanMetrics, usePlans } from "./use-plans";
 
 /* ---------- fixtures ---------- */
 
@@ -27,10 +20,6 @@ function makePlan(id: string, server: string): Plan {
 
 function planToolResult(plans: Plan[]): object {
   return { content: [{ type: "text", text: JSON.stringify({ plans }) }] };
-}
-
-function planDetailResult(plan: Plan): object {
-  return { content: [{ type: "text", text: JSON.stringify({ plan }) }] };
 }
 
 function metricsResult(metrics: PlanMetrics): object {
@@ -816,114 +805,6 @@ describe("usePlans — Claude plan integration", () => {
     const cp = stateRef.current.plans.filter((p) => p.server === "_claude");
     expect(cp).toHaveLength(0);
     expect(stateRef.current.error).toBeNull();
-  });
-});
-
-/* ---------- usePlan tests ---------- */
-
-describe("usePlan", () => {
-  interface HookState {
-    plan: Plan | null;
-    loading: boolean;
-    error: string | null;
-    canAdvance: boolean;
-    disconnected: boolean;
-  }
-
-  const instances: ReturnType<typeof render>[] = [];
-
-  afterEach(() => {
-    for (const inst of instances) inst.unmount();
-    instances.length = 0;
-  });
-
-  const Harness: FC<{
-    planId: string;
-    server: string;
-    opts: UsePlanOptions;
-    stateRef: { current: HookState };
-  }> = ({ planId, server, opts, stateRef }) => {
-    const result = usePlan(planId, server, opts);
-    stateRef.current = result;
-    return React.createElement(Text, null, "ok");
-  };
-
-  function mount(planId: string, server: string, opts: UsePlanOptions) {
-    const stateRef: { current: HookState } = {
-      current: { plan: null, loading: true, error: null, canAdvance: false, disconnected: false },
-    };
-    const instance = render(React.createElement(Harness, { planId, server, opts, stateRef }));
-    instances.push(instance);
-    return { instance, stateRef };
-  }
-
-  it("fetches plan on mount", async () => {
-    const plan = makePlan("plan-1", "srv");
-    const ipcCallFn = async () => planDetailResult(plan);
-
-    const { stateRef } = mount("plan-1", "srv", {
-      ipcCallFn: ipcCallFn as UsePlanOptions["ipcCallFn"],
-    });
-    await waitFor(() => stateRef.current.loading === false);
-
-    expect(stateRef.current.plan?.id).toBe("plan-1");
-    expect(stateRef.current.error).toBeNull();
-    expect(stateRef.current.disconnected).toBe(false);
-  });
-
-  it("exposes canAdvance=false by default", async () => {
-    const plan = makePlan("plan-1", "srv");
-    const ipcCallFn = async () => planDetailResult(plan);
-
-    const { stateRef } = mount("plan-1", "srv", {
-      ipcCallFn: ipcCallFn as UsePlanOptions["ipcCallFn"],
-    });
-    await waitFor(() => stateRef.current.loading === false);
-
-    expect(stateRef.current.canAdvance).toBe(false);
-  });
-
-  it("exposes canAdvance=true when provided", async () => {
-    const plan = makePlan("plan-1", "srv");
-    const ipcCallFn = async () => planDetailResult(plan);
-
-    const { stateRef } = mount("plan-1", "srv", {
-      canAdvance: true,
-      ipcCallFn: ipcCallFn as UsePlanOptions["ipcCallFn"],
-    });
-    await waitFor(() => stateRef.current.loading === false);
-
-    expect(stateRef.current.canAdvance).toBe(true);
-  });
-
-  it("sets disconnected and error when callTool fails", async () => {
-    const ipcCallFn = async () => {
-      throw new Error("server offline");
-    };
-
-    const { stateRef } = mount("plan-1", "srv", {
-      ipcCallFn: ipcCallFn as UsePlanOptions["ipcCallFn"],
-    });
-    await waitFor(() => stateRef.current.loading === false);
-
-    expect(stateRef.current.error).toBe("server offline");
-    expect(stateRef.current.disconnected).toBe(true);
-  });
-
-  it("does not fetch when enabled=false", async () => {
-    let callCount = 0;
-    const ipcCallFn = async () => {
-      callCount++;
-      return planDetailResult(makePlan("plan-1", "srv"));
-    };
-
-    mount("plan-1", "srv", {
-      enabled: false,
-      ipcCallFn: ipcCallFn as UsePlanOptions["ipcCallFn"],
-    });
-    await new Promise((r) => setTimeout(r, 30));
-
-    expect(callCount).toBe(0);
   });
 });
 

--- a/packages/control/src/hooks/use-plans.ts
+++ b/packages/control/src/hooks/use-plans.ts
@@ -1,10 +1,5 @@
 import type { Plan, PlanMetrics, ServerStatus } from "@mcp-cli/core";
-import {
-  CLAUDE_SERVER_NAME,
-  GetPlanMetricsResultSchema,
-  GetPlanResultSchema,
-  ListPlansResultSchema,
-} from "@mcp-cli/core";
+import { CLAUDE_SERVER_NAME, GetPlanMetricsResultSchema, ListPlansResultSchema } from "@mcp-cli/core";
 import { ipcCall } from "@mcp-cli/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { extractToolText } from "./ipc-tool-helpers.js";
@@ -204,89 +199,6 @@ export function usePlans(opts: UsePlansOptions = {}): UsePlansResult {
   }, [intervalMs, enabled, tick]);
 
   return { plans, loading, error, disconnected, failedServers, refresh };
-}
-
-// -- usePlan --
-
-export interface UsePlanResult {
-  plan: Plan | null;
-  loading: boolean;
-  error: string | null;
-  /** True when the server has `advance_plan` capability. */
-  canAdvance: boolean;
-  /** True when the last fetch failed (stale data is shown). */
-  disconnected: boolean;
-}
-
-export interface UsePlanOptions {
-  enabled?: boolean;
-  /**
-   * Whether the plan server supports `advance_plan`.
-   * Pass from server's `planCapabilities` (e.g. from `usePlans` or `useDaemon`).
-   * Defaults to false if not provided.
-   */
-  canAdvance?: boolean;
-  /** Override ipcCall for testing (dependency injection). */
-  ipcCallFn?: typeof ipcCall;
-}
-
-/**
- * Fetches a single plan via `get_plan`. Re-fetches when planId or server changes.
- */
-export function usePlan(planId: string, server: string, opts: UsePlanOptions = {}): UsePlanResult {
-  const { enabled = true, canAdvance = false, ipcCallFn = ipcCall } = opts;
-  const [plan, setPlan] = useState<Plan | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [disconnected, setDisconnected] = useState(false);
-
-  const ipcCallRef = useRef(ipcCallFn);
-  ipcCallRef.current = ipcCallFn;
-
-  useEffect(() => {
-    if (!enabled || !planId || !server) return;
-
-    // Reset loading when re-enabled so stale data shows a spinner (#775)
-    setLoading(true);
-
-    let cancelled = false;
-
-    async function fetch() {
-      try {
-        const result = await ipcCallRef.current("callTool", {
-          server,
-          tool: "get_plan",
-          arguments: { planId },
-        });
-        if (cancelled) return;
-        const text = extractToolText(result);
-        if (text) {
-          const parsed = GetPlanResultSchema.safeParse(JSON.parse(text));
-          if (parsed.success) {
-            setPlan(parsed.data.plan);
-          } else {
-            console.error(`[usePlan] parse error for plan ${planId} on ${server}:`, parsed.error.issues);
-          }
-        }
-        setError(null);
-        setDisconnected(false);
-        setLoading(false);
-      } catch (err) {
-        if (cancelled) return;
-        setError(err instanceof Error ? err.message : String(err));
-        setDisconnected(true);
-        setLoading(false);
-      }
-    }
-
-    fetch();
-
-    return () => {
-      cancelled = true;
-    };
-  }, [planId, server, enabled]);
-
-  return { plan, loading, error, canAdvance, disconnected };
 }
 
 // -- usePlanMetrics --


### PR DESCRIPTION
## Summary
- Removed the `usePlan` hook, its interfaces (`UsePlanResult`, `UsePlanOptions`), and the unused `GetPlanResultSchema` import from `use-plans.ts`
- Removed the corresponding `usePlan` test block (~105 lines) and `planDetailResult` fixture from `use-plans.spec.ts`
- Dead code cleanup — `usePlan` was exported but never called anywhere in the codebase

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — 3058 tests pass, 0 failures
- [x] Coverage thresholds still met (90.96% functions, 92.71% lines)
- [x] Verified `usePlan` has no callers outside its own definition and tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)