### PR TITLE
feat: add `mcx add-from-claude-desktop` command (fixes #77)

### DIFF
--- a/packages/command/src/commands/completions.ts
+++ b/packages/command/src/commands/completions.ts
@@ -26,6 +26,7 @@ export const SUBCOMMANDS = [
   "config",
   "add",
   "add-json",
+  "add-from-claude-desktop",
   "remove",
   "get",
   "auth",

--- a/packages/command/src/commands/import.spec.ts
+++ b/packages/command/src/commands/import.spec.ts
@@ -5,7 +5,13 @@ import type { McpConfigFile, ServerConfig } from "@mcp-cli/core";
 import { findFileUpward } from "@mcp-cli/core";
 import { testOptions } from "../../../../test/test-options";
 import { readConfigFile, writeConfigFile } from "./config-file";
-import { type ClaudeConfig, cmdImport, collectClaudeServers, importFromClaude } from "./import";
+import {
+  type ClaudeConfig,
+  cmdAddFromClaudeDesktop,
+  cmdImport,
+  collectClaudeServers,
+  importFromClaude,
+} from "./import";
 
 /**
  * Tests for mcx import's source resolution and file I/O.
@@ -686,6 +692,114 @@ describe("mcx import", () => {
       const result = readConfigFile(join(opts.dir, "servers.json"));
       expect(result.mcpServers?.github).toEqual(FIXTURES.github);
       expect(result.mcpServers?.sentry).toEqual(FIXTURES.sentry);
+    });
+  });
+
+  describe("cmdAddFromClaudeDesktop", () => {
+    test("imports servers from Claude Desktop config", async () => {
+      using opts = testOptions();
+      const configPath = join(opts.dir, "claude_desktop_config.json");
+      const desktopConfig = fixtureConfig("notion", "filesystem");
+      writeFileSync(configPath, JSON.stringify(desktopConfig));
+
+      await cmdAddFromClaudeDesktop([], configPath);
+
+      const result = readConfigFile(join(opts.dir, "servers.json"));
+      expect(result.mcpServers?.notion).toEqual(FIXTURES.notion);
+      expect(result.mcpServers?.filesystem).toEqual(FIXTURES.filesystem);
+    });
+
+    test("throws when config file is missing", async () => {
+      using opts = testOptions();
+      const missingPath = join(opts.dir, "nonexistent.json");
+      await expect(cmdAddFromClaudeDesktop([], missingPath)).rejects.toThrow("config not found");
+    });
+
+    test("throws on invalid JSON", async () => {
+      using opts = testOptions();
+      const badPath = join(opts.dir, "bad.json");
+      writeFileSync(badPath, "not valid json{{{");
+      await expect(cmdAddFromClaudeDesktop([], badPath)).rejects.toThrow("Cannot parse");
+    });
+
+    test("handles empty mcpServers gracefully", async () => {
+      using opts = testOptions();
+      const emptyPath = join(opts.dir, "empty-desktop.json");
+      writeFileSync(emptyPath, JSON.stringify({ mcpServers: {} }));
+      await cmdAddFromClaudeDesktop([], emptyPath);
+    });
+
+    test("handles config with no mcpServers key", async () => {
+      using opts = testOptions();
+      const noServersPath = join(opts.dir, "no-servers.json");
+      writeFileSync(noServersPath, JSON.stringify({}));
+      await cmdAddFromClaudeDesktop([], noServersPath);
+    });
+
+    test("accepts --scope flag", async () => {
+      using opts = testOptions();
+      const configPath = join(opts.dir, "desktop.json");
+      writeFileSync(configPath, JSON.stringify(fixtureConfig("sentry")));
+
+      await cmdAddFromClaudeDesktop(["--scope", "user"], configPath);
+
+      const result = readConfigFile(join(opts.dir, "servers.json"));
+      expect(result.mcpServers?.sentry).toEqual(FIXTURES.sentry);
+    });
+
+    test("accepts -s shorthand for scope", async () => {
+      using opts = testOptions();
+      const configPath = join(opts.dir, "desktop.json");
+      writeFileSync(configPath, JSON.stringify(fixtureConfig("github")));
+
+      await cmdAddFromClaudeDesktop(["-s", "user"], configPath);
+
+      const result = readConfigFile(join(opts.dir, "servers.json"));
+      expect(result.mcpServers?.github).toEqual(FIXTURES.github);
+    });
+
+    test("throws on unknown flag", async () => {
+      using opts = testOptions();
+      await expect(cmdAddFromClaudeDesktop(["--bogus"], join(opts.dir, "x.json"))).rejects.toThrow("Unknown flag");
+    });
+
+    test("--help does not throw", async () => {
+      await cmdAddFromClaudeDesktop(["--help"]);
+    });
+
+    test("-h does not throw", async () => {
+      await cmdAddFromClaudeDesktop(["-h"]);
+    });
+
+    test("imports all transport types", async () => {
+      using opts = testOptions();
+      const configPath = join(opts.dir, "desktop-all.json");
+      const allServers = fixtureConfig("filesystem", "notion", "atlassian", "sentry");
+      writeFileSync(configPath, JSON.stringify(allServers));
+
+      await cmdAddFromClaudeDesktop([], configPath);
+
+      const result = readConfigFile(join(opts.dir, "servers.json"));
+      expect(Object.keys(result.mcpServers ?? {})).toHaveLength(4);
+      expect("command" in (result.mcpServers?.filesystem ?? {})).toBe(true);
+      expect(result.mcpServers?.notion?.type).toBe("http");
+      expect(result.mcpServers?.atlassian?.type).toBe("sse");
+    });
+
+    test("overwrites existing servers", async () => {
+      using opts = testOptions();
+      const targetPath = join(opts.dir, "servers.json");
+      writeConfigFile(targetPath, {
+        mcpServers: { notion: { type: "http" as const, url: "https://old.example.com" } },
+      });
+
+      const configPath = join(opts.dir, "desktop-overwrite.json");
+      writeFileSync(configPath, JSON.stringify(fixtureConfig("notion")));
+
+      await cmdAddFromClaudeDesktop([], configPath);
+
+      const result = readConfigFile(targetPath);
+      expect(result.mcpServers?.notion).toEqual(FIXTURES.notion);
     });
   });
 });

--- a/packages/command/src/commands/import.ts
+++ b/packages/command/src/commands/import.ts
@@ -220,6 +220,60 @@ function resolveSource(source: string | undefined): ResolvedSource {
   return { filePath: resolved, defaultScope: "user" };
 }
 
+/**
+ * `mcx add-from-claude-desktop` — import servers from Claude Desktop's config.
+ *
+ * Reads ~/Library/Application Support/Claude/claude_desktop_config.json,
+ * lists discovered servers, and imports them into mcp-cli.
+ */
+export async function cmdAddFromClaudeDesktop(
+  args: string[],
+  configPath = options.CLAUDE_DESKTOP_CONFIG_PATH,
+): Promise<void> {
+  let scope: ConfigScope = "user";
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--scope" || arg === "-s") {
+      scope = parseScope(args[++i], CONFIG_SCOPES_NO_LOCAL);
+    } else if (arg === "--help" || arg === "-h") {
+      console.log(`mcx add-from-claude-desktop — import servers from Claude Desktop
+
+Usage:
+  mcx add-from-claude-desktop              Import all servers from Claude Desktop config
+  mcx add-from-claude-desktop --scope user Override target scope (default: user)
+
+Options:
+  --scope user|project    Target config scope (default: user)
+  -s                      Shorthand for --scope
+
+Reads: ~/Library/Application Support/Claude/claude_desktop_config.json`);
+      return;
+    } else if (arg.startsWith("-")) {
+      throw new Error(`Unknown flag: ${arg}`);
+    }
+  }
+
+  if (!existsSync(configPath)) {
+    throw new Error(`Claude Desktop config not found: ${configPath}`);
+  }
+
+  let config: McpConfigFile;
+  try {
+    config = JSON.parse(readFileSync(configPath, "utf-8")) as McpConfigFile;
+  } catch {
+    throw new Error(`Cannot parse ${configPath}`);
+  }
+
+  const servers = config.mcpServers;
+  if (!servers || Object.keys(servers).length === 0) {
+    console.error(`No servers found in ${configPath}`);
+    return;
+  }
+
+  importServers(servers, scope, "Claude Desktop");
+}
+
 function printImportUsage(): void {
   console.log(`mcx import — import servers from external config files
 

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -26,7 +26,7 @@ import { cmdConfig } from "./commands/config";
 import { cmdDump } from "./commands/dump";
 import { cmdExport } from "./commands/export";
 import { cmdGet } from "./commands/get";
-import { cmdImport } from "./commands/import";
+import { cmdAddFromClaudeDesktop, cmdImport } from "./commands/import";
 import { cmdInstall } from "./commands/install";
 import { cmdLogs } from "./commands/logs";
 import { cmdMail } from "./commands/mail";
@@ -204,6 +204,10 @@ async function main(): Promise<void> {
 
       case "add-json":
         await cmdAddJson(cleanArgs.slice(1));
+        break;
+
+      case "add-from-claude-desktop":
+        await cmdAddFromClaudeDesktop(cleanArgs.slice(1));
         break;
 
       case "remove":
@@ -715,6 +719,7 @@ Usage:
   mcx export [file] [--scope ...]      Export servers to .mcp.json format
   mcx add --transport {stdio|http|sse} <name> ...   Add a server
   mcx add-json <name> '<json>'        Add a server from raw JSON
+  mcx add-from-claude-desktop         Import servers from Claude Desktop config
   mcx remove <name>                   Remove a server
   mcx get <name>                      Inspect a server's config and status
   mcx auth                             List servers with auth status

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -91,6 +91,7 @@ const _originalOptions = {
   ALIASES_DIR,
   CACHE_DIR,
   CLAUDE_CONFIG_PATH: join(homedir(), ".claude.json"),
+  CLAUDE_DESKTOP_CONFIG_PATH: join(homedir(), "Library", "Application Support", "Claude", "claude_desktop_config.json"),
   USER_SERVERS_PATH: join(MCP_CLI_DIR, "servers.json"),
   PROJECTS_DIR: join(MCP_CLI_DIR, "projects"),
   TYPES_PATH: join(MCP_CLI_DIR, "mcp-cli.d.ts"),


### PR DESCRIPTION
## Summary
- Adds `mcx add-from-claude-desktop` command that reads Claude Desktop's config file (`~/Library/Application Support/Claude/claude_desktop_config.json`) and imports all discovered MCP servers into mcp-cli's `servers.json`
- Supports `--scope user|project` flag to control target config
- Reuses existing `importServers` helper for consistent import behavior (merge, overwrite, logging)

## Test plan
- [x] 11 new tests covering: import success, missing file, invalid JSON, empty config, scope flags, help output, all transport types, overwrite behavior
- [x] All 3075 tests pass
- [x] TypeScript type check passes
- [x] Lint passes with no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)