### PR TITLE
feat: first-run prompt when .mcp.json detected (fixes #86)

### DIFF
--- a/packages/command/src/first-run.spec.ts
+++ b/packages/command/src/first-run.spec.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { _restoreOptions, options } from "@mcp-cli/core";
+import { maybeShowFirstRunPrompt } from "./first-run";
+
+let tmpDir: string;
+let configDir: string;
+
+beforeEach(() => {
+  tmpDir = join(tmpdir(), `first-run-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(tmpDir, { recursive: true });
+
+  configDir = join(tmpDir, "mcp-cli");
+  mkdirSync(configDir, { recursive: true });
+
+  // Point options to temp dirs for isolation
+  options.MCP_CLI_DIR = configDir;
+  options.MCP_CLI_CONFIG_PATH = join(configDir, "config.json");
+  options.PROJECTS_DIR = join(configDir, "projects");
+});
+
+afterEach(() => {
+  _restoreOptions();
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("maybeShowFirstRunPrompt", () => {
+  test("shows prompt when .mcp.json exists and no project config", () => {
+    const mcpJson = { mcpServers: { github: { command: "gh" }, notion: { command: "notion" } } };
+    writeFileSync(join(tmpDir, ".mcp.json"), JSON.stringify(mcpJson));
+
+    const errors: string[] = [];
+    const origError = console.error;
+    console.error = (...args: unknown[]) => errors.push(args.join(" "));
+    try {
+      maybeShowFirstRunPrompt(tmpDir);
+    } finally {
+      console.error = origError;
+    }
+
+    expect(errors.length).toBe(2);
+    expect(errors[0]).toContain("Found .mcp.json with 2 server(s)");
+    expect(errors[0]).toContain("github");
+    expect(errors[0]).toContain("notion");
+    expect(errors[1]).toContain("mcx import");
+  });
+
+  test("does not show prompt when no .mcp.json", () => {
+    const errors: string[] = [];
+    const origError = console.error;
+    console.error = (...args: unknown[]) => errors.push(args.join(" "));
+    try {
+      maybeShowFirstRunPrompt(tmpDir);
+    } finally {
+      console.error = origError;
+    }
+
+    expect(errors.length).toBe(0);
+  });
+
+  test("does not show prompt when project config already exists", () => {
+    const mcpJson = { mcpServers: { github: { command: "gh" } } };
+    writeFileSync(join(tmpDir, ".mcp.json"), JSON.stringify(mcpJson));
+
+    // Create project config
+    const projDir = join(configDir, "projects", tmpDir.replaceAll("/", "_").replace(/^_/, ""));
+    mkdirSync(projDir, { recursive: true });
+    writeFileSync(join(projDir, "servers.json"), "{}");
+
+    const errors: string[] = [];
+    const origError = console.error;
+    console.error = (...args: unknown[]) => errors.push(args.join(" "));
+    try {
+      maybeShowFirstRunPrompt(tmpDir);
+    } finally {
+      console.error = origError;
+    }
+
+    expect(errors.length).toBe(0);
+  });
+
+  test("shows prompt only once per directory", () => {
+    const mcpJson = { mcpServers: { github: { command: "gh" } } };
+    writeFileSync(join(tmpDir, ".mcp.json"), JSON.stringify(mcpJson));
+
+    const errors: string[] = [];
+    const origError = console.error;
+    console.error = (...args: unknown[]) => errors.push(args.join(" "));
+    try {
+      maybeShowFirstRunPrompt(tmpDir);
+      errors.length = 0; // reset
+      maybeShowFirstRunPrompt(tmpDir);
+    } finally {
+      console.error = origError;
+    }
+
+    // Second call should produce no output
+    expect(errors.length).toBe(0);
+  });
+
+  test("does not show prompt for empty mcpServers", () => {
+    writeFileSync(join(tmpDir, ".mcp.json"), JSON.stringify({ mcpServers: {} }));
+
+    const errors: string[] = [];
+    const origError = console.error;
+    console.error = (...args: unknown[]) => errors.push(args.join(" "));
+    try {
+      maybeShowFirstRunPrompt(tmpDir);
+    } finally {
+      console.error = origError;
+    }
+
+    expect(errors.length).toBe(0);
+  });
+
+  test("truncates long server lists", () => {
+    const servers: Record<string, { command: string }> = {};
+    for (let i = 0; i < 8; i++) servers[`server${i}`] = { command: `cmd${i}` };
+    writeFileSync(join(tmpDir, ".mcp.json"), JSON.stringify({ mcpServers: servers }));
+
+    const errors: string[] = [];
+    const origError = console.error;
+    console.error = (...args: unknown[]) => errors.push(args.join(" "));
+    try {
+      maybeShowFirstRunPrompt(tmpDir);
+    } finally {
+      console.error = origError;
+    }
+
+    expect(errors[0]).toContain("8 server(s)");
+    expect(errors[0]).toContain("...");
+  });
+
+  test("handles malformed .mcp.json gracefully", () => {
+    writeFileSync(join(tmpDir, ".mcp.json"), "not valid json{{{");
+
+    const errors: string[] = [];
+    const origError = console.error;
+    console.error = (...args: unknown[]) => errors.push(args.join(" "));
+    try {
+      maybeShowFirstRunPrompt(tmpDir);
+    } finally {
+      console.error = origError;
+    }
+
+    expect(errors.length).toBe(0);
+  });
+});

--- a/packages/command/src/first-run.ts
+++ b/packages/command/src/first-run.ts
@@ -1,0 +1,56 @@
+/**
+ * First-run prompt: when .mcp.json is detected in CWD but no project config
+ * exists in ~/.mcp-cli/projects/, show a one-time informational message.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { McpConfigFile } from "@mcp-cli/core";
+import { PROJECT_MCP_FILENAME, projectConfigPath, readCliConfig, writeCliConfig } from "@mcp-cli/core";
+
+/**
+ * Check for .mcp.json and show import prompt if this is the first run
+ * for this directory. Writes to stderr only. No-op if already prompted
+ * or if no .mcp.json exists.
+ */
+export function maybeShowFirstRunPrompt(cwd = process.cwd()): void {
+  const resolvedCwd = resolve(cwd);
+
+  // Check for .mcp.json in CWD (not walking up — only CWD for first-run)
+  const mcpJsonPath = `${resolvedCwd}/${PROJECT_MCP_FILENAME}`;
+  if (!existsSync(mcpJsonPath)) return;
+
+  // Check if project config already exists
+  const projConfig = projectConfigPath(resolvedCwd);
+  if (existsSync(projConfig)) return;
+
+  // Check if we already prompted for this directory
+  const config = readCliConfig();
+  const prompted = config.promptedDirs ?? [];
+  if (prompted.includes(resolvedCwd)) return;
+
+  // Count servers in .mcp.json
+  let serverCount = 0;
+  let serverNames: string[] = [];
+  try {
+    const content = readFileSync(mcpJsonPath, "utf-8");
+    const parsed = JSON.parse(content) as McpConfigFile;
+    if (parsed.mcpServers) {
+      serverNames = Object.keys(parsed.mcpServers);
+      serverCount = serverNames.length;
+    }
+  } catch {
+    // Malformed .mcp.json — skip prompt
+    return;
+  }
+
+  if (serverCount === 0) return;
+
+  // Show the prompt
+  const nameList = serverNames.length <= 5 ? serverNames.join(", ") : `${serverNames.slice(0, 4).join(", ")}, ...`;
+  console.error(`Found ${PROJECT_MCP_FILENAME} with ${serverCount} server(s) (${nameList}).`);
+  console.error("Run `mcx import` to add them, or `mcx import .` to anchor to this directory.");
+
+  // Mark as prompted
+  writeCliConfig({ ...config, promptedDirs: [...prompted, resolvedCwd] });
+}

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -49,6 +49,7 @@ import {
 import { checkDeprecatedName } from "./deprecation";
 import { maybeAutoSaveEphemeral } from "./ephemeral";
 import { readFileWithLimit } from "./file-read";
+import { maybeShowFirstRunPrompt } from "./first-run";
 import { SIZE_HINT, SIZE_OK, applyJqFilter, generateAnalysis } from "./jq/index";
 import {
   extractErrorMessage,
@@ -65,6 +66,7 @@ import {
   extractFullFlag,
   extractJqFlag,
   extractJsonFlag,
+  extractQuietFlag,
   extractTimeoutFlag,
   extractVerboseFlag,
   readStdinJson,
@@ -91,11 +93,21 @@ async function main(): Promise<void> {
 
   // Extract global flags before command dispatch
   const { verbose, rest: afterVerbose } = extractVerboseFlag(args);
-  const { dryRun, rest: cleanArgs } = extractDryRunFlag(afterVerbose);
+  const { dryRun, rest: afterDryRun } = extractDryRunFlag(afterVerbose);
+  const { quiet, rest: cleanArgs } = extractQuietFlag(afterDryRun);
   _dryRun = dryRun;
   if (verbose) process.env.MCX_VERBOSE = "1";
 
   const command = cleanArgs[0];
+
+  // First-run prompt: show once per directory when .mcp.json detected
+  if (!quiet) {
+    try {
+      maybeShowFirstRunPrompt();
+    } catch {
+      // Best-effort — never block CLI startup
+    }
+  }
 
   // --dry-run is only valid for call (and shorthand call forms handled in the default branch)
   if (dryRun && command && command !== "call") {
@@ -782,6 +794,7 @@ Options:
   --jq '<filter>'                   Apply jq filter to call output (client-side)
   --full, -f                        Bypass output size protection (call)
   --verbose, -V                     Show IPC requests/responses and debug info (stderr)
+  --quiet, -q                       Suppress informational prompts (e.g. first-run hint)
   --dry-run                         Show what would be executed without running it (call)
 
 Examples:

--- a/packages/command/src/parse.ts
+++ b/packages/command/src/parse.ts
@@ -169,6 +169,25 @@ export function extractDryRunFlag(args: string[]): { dryRun: boolean; rest: stri
 }
 
 /**
+ * Extract --quiet / -q flag from args.
+ * Returns whether quiet mode was requested and the remaining args.
+ */
+export function extractQuietFlag(args: string[]): { quiet: boolean; rest: string[] } {
+  const rest: string[] = [];
+  let quiet = false;
+
+  for (const arg of args) {
+    if (arg === "--quiet" || arg === "-q") {
+      quiet = true;
+    } else {
+      rest.push(arg);
+    }
+  }
+
+  return { quiet, rest };
+}
+
+/**
  * Extract --jq '<filter>' flag from args.
  * Returns the jq filter string (or undefined) and the remaining args.
  */

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -73,6 +73,8 @@ export interface CliConfig {
   wsPort?: number;
   /** Configuration for ephemeral (auto-saved) aliases */
   ephemeralAliases?: EphemeralAliasConfig;
+  /** Directories where the first-run import prompt has already been shown */
+  promptedDirs?: string[];
 }
 
 /** Claude Code project settings (.claude/settings.local.json) */


### PR DESCRIPTION
## Summary
- When `mcx` runs in a directory with `.mcp.json` but no project config in `~/.mcp-cli/projects/`, shows a one-time informational prompt to stderr with server count and `mcx import` guidance
- Tracks prompted directories in `~/.mcp-cli/config.json` (`promptedDirs` field) so the prompt only appears once per directory
- Adds `--quiet` / `-q` global flag to suppress the prompt
- Handles edge cases: malformed JSON, empty servers, long server lists (truncated with `...`)

## Test plan
- [x] Prompt shown when `.mcp.json` exists and no project config found
- [x] Prompt not shown when no `.mcp.json` in CWD
- [x] Prompt not shown when project config already exists
- [x] Prompt shown only once per directory (persisted to config)
- [x] Empty mcpServers object does not trigger prompt
- [x] Long server lists are truncated
- [x] Malformed `.mcp.json` handled gracefully (no crash)
- [x] All 3070 tests pass, typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)