### PR TITLE
feat(daemon): stdio-specific retry semantics for process crash vs startup failure (fixes #39)

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -197,6 +197,8 @@ export const PID_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
  *             = 3 × 15s + 1s + 2s = 48s < 60s
  */
 export const CONNECT_MAX_RETRIES = 2;
+/** Stdio transports get fewer retries — process bugs won't self-heal. */
+export const STDIO_CONNECT_MAX_RETRIES = 1;
 export const CONNECT_INITIAL_DELAY_MS = 1_000;
 export const CONNECT_MAX_DELAY_MS = 15_000;
 

--- a/packages/daemon/src/server-pool.spec.ts
+++ b/packages/daemon/src/server-pool.spec.ts
@@ -91,6 +91,48 @@ describe("isRetryableError", () => {
       expect(isRetryableError(new Error("something went wrong"))).toBe(false);
     });
   });
+
+  describe("stdio-specific retry semantics", () => {
+    test("process exit is retryable for stdio transport", () => {
+      expect(isRetryableError(new Error("process exited with code 1"), "stdio")).toBe(true);
+    });
+
+    test("process killed is retryable for stdio transport", () => {
+      expect(isRetryableError(new Error("process killed by SIGTERM"), "stdio")).toBe(true);
+    });
+
+    test("spawn error (non-ENOENT) is retryable for stdio transport", () => {
+      expect(isRetryableError(new Error("spawn failed: resource busy"), "stdio")).toBe(true);
+    });
+
+    test("signal termination is retryable for stdio transport", () => {
+      expect(isRetryableError(new Error("process received signal SIGKILL"), "stdio")).toBe(true);
+    });
+
+    test("process crash is retryable for stdio transport", () => {
+      expect(isRetryableError(new Error("child process crashed"), "stdio")).toBe(true);
+    });
+
+    test("process exit is NOT retryable for http transport", () => {
+      expect(isRetryableError(new Error("process exited with code 1"), "http")).toBe(false);
+    });
+
+    test("process exit is NOT retryable without transport context", () => {
+      expect(isRetryableError(new Error("process exited with code 1"))).toBe(false);
+    });
+
+    test("ENOENT is NOT retryable even for stdio transport", () => {
+      expect(isRetryableError(errWithCode("spawn ENOENT", "ENOENT"), "stdio")).toBe(false);
+    });
+
+    test("EACCES is NOT retryable even for stdio transport", () => {
+      expect(isRetryableError(errWithCode("permission denied", "EACCES"), "stdio")).toBe(false);
+    });
+
+    test("network errors are still retryable regardless of transport", () => {
+      expect(isRetryableError(errWithCode("connect failed", "ECONNREFUSED"), "stdio")).toBe(true);
+    });
+  });
 });
 
 describe("wrapTransportError", () => {
@@ -575,6 +617,59 @@ describe("isTransientCallError", () => {
     test("generic unknown error is not transient", () => {
       expect(isTransientCallError(new Error("something went wrong"))).toBe(false);
     });
+  });
+});
+
+// -- ensureConnected stdio retry semantics --
+
+describe("ServerPool stdio retry semantics", () => {
+  test("stdio server retries process crash up to STDIO_CONNECT_MAX_RETRIES times", async () => {
+    let connectCount = 0;
+    const connectFn: ConnectFn = mock(() => {
+      connectCount++;
+      return Promise.reject(new Error("process exited with code 1"));
+    });
+    const pool = new ServerPool(
+      makeConfig({ srv: { command: "npx", args: ["-y", "flaky-server"] } }),
+      undefined,
+      connectFn,
+      silentLogger,
+    );
+
+    await expect(pool.listTools("srv")).rejects.toThrow("process exited unexpectedly");
+    // STDIO_CONNECT_MAX_RETRIES = 1, so: initial attempt + 1 retry = 2 total
+    expect(connectCount).toBe(2);
+  });
+
+  test("stdio server does not retry ENOENT", async () => {
+    let connectCount = 0;
+    const connectFn: ConnectFn = mock(() => {
+      connectCount++;
+      return Promise.reject(errWithCode("spawn ENOENT", "ENOENT"));
+    });
+    const pool = new ServerPool(makeConfig({ srv: { command: "nonexistent" } }), undefined, connectFn, silentLogger);
+
+    await expect(pool.listTools("srv")).rejects.toThrow('command "nonexistent" not found');
+    // No retries for ENOENT
+    expect(connectCount).toBe(1);
+  });
+
+  test("http server retries up to CONNECT_MAX_RETRIES times", async () => {
+    let connectCount = 0;
+    const connectFn: ConnectFn = mock(() => {
+      connectCount++;
+      return Promise.reject(errWithCode("connect failed", "ECONNREFUSED"));
+    });
+    const pool = new ServerPool(
+      makeConfig({ srv: { type: "http" as const, url: "https://example.com/mcp" } }),
+      undefined,
+      connectFn,
+      silentLogger,
+    );
+
+    await expect(pool.listTools("srv")).rejects.toThrow();
+    // CONNECT_MAX_RETRIES = 2, so: initial attempt + 2 retries = 3 total
+    expect(connectCount).toBe(3);
   });
 });
 

--- a/packages/daemon/src/server-pool.ts
+++ b/packages/daemon/src/server-pool.ts
@@ -30,6 +30,7 @@ import {
   CONNECT_MAX_RETRIES,
   CONNECT_TIMEOUT_MS,
   MCP_TOOL_TIMEOUT_MS,
+  STDIO_CONNECT_MAX_RETRIES,
   getTransportType,
   isHttpConfig,
   isSseConfig,
@@ -290,7 +291,8 @@ export class ServerPool {
       }
 
       let lastErr: Error = new Error("Connection failed");
-      const maxRetries = CONNECT_MAX_RETRIES;
+      const transportType = getTransportType(config);
+      const maxRetries = transportType === "stdio" ? STDIO_CONNECT_MAX_RETRIES : CONNECT_MAX_RETRIES;
 
       for (let attempt = 0; attempt <= maxRetries; attempt++) {
         try {
@@ -324,7 +326,7 @@ export class ServerPool {
         } catch (err) {
           lastErr = err instanceof Error ? err : new Error(String(err), { cause: err });
 
-          if (attempt < maxRetries && isRetryableError(err)) {
+          if (attempt < maxRetries && isRetryableError(err, transportType)) {
             const delay = Math.min(CONNECT_INITIAL_DELAY_MS * 2 ** attempt, CONNECT_MAX_DELAY_MS);
             this.logger.warn(
               `[mcpd] Connection to "${name}" failed (attempt ${attempt + 1}/${maxRetries + 1}), retrying in ${delay}ms: ${lastErr.message}`,
@@ -685,8 +687,15 @@ const RETRYABLE_CODES = new Set([
   "EAI_AGAIN",
 ]);
 
-/** Classify whether a connection error is transient and worth retrying. */
-export function isRetryableError(err: unknown): boolean {
+/**
+ * Classify whether a connection error is transient and worth retrying.
+ *
+ * When `transport` is "stdio", process crashes during startup (exit code,
+ * killed, spawn errors) are considered retryable — transient issues like
+ * `npx -y` download failures may succeed on retry. Permanent failures
+ * (ENOENT, EACCES) are still excluded.
+ */
+export function isRetryableError(err: unknown, transport?: "stdio" | "http" | "sse"): boolean {
   if (!(err instanceof Error)) return false;
   const msg = err.message.toLowerCase();
   const code = (err as NodeJS.ErrnoException).code;
@@ -697,9 +706,24 @@ export function isRetryableError(err: unknown): boolean {
   // Fetch-style network errors (no system code)
   if (msg.includes("fetch failed") || msg.includes("socket hang up")) return true;
 
-  // NOT retryable: auth failures, bad config
+  // NOT retryable: auth failures, bad config, command not found, permission denied
+  if (code === "ENOENT" || code === "EACCES") return false;
   if (msg.includes("401") || msg.includes("403") || msg.includes("not found") || msg.includes("permission denied")) {
     return false;
+  }
+
+  // Stdio-specific: process crash during startup is worth one retry
+  if (transport === "stdio") {
+    if (
+      msg.includes("exited") ||
+      msg.includes("exit code") ||
+      msg.includes("killed") ||
+      msg.includes("spawn") ||
+      msg.includes("crashed") ||
+      msg.includes("signal")
+    ) {
+      return true;
+    }
   }
 
   return false;


### PR DESCRIPTION
## Summary
- **Transport-aware retry classification**: `isRetryableError()` now accepts an optional transport type parameter. For stdio transports, process crashes during startup (exit, killed, signal) are classified as retryable — transient issues like `npx -y` download failures may succeed on retry. Permanent failures (ENOENT, EACCES) remain non-retryable regardless of transport.
- **Shorter stdio retry budget**: Added `STDIO_CONNECT_MAX_RETRIES = 1` (vs `CONNECT_MAX_RETRIES = 2` for remote transports), since process bugs rarely self-heal and retrying wastes time.
- **`ensureConnected()` uses transport context**: The retry loop now determines max retries and retry eligibility based on the server's transport type.

## Test plan
- [x] Unit tests for `isRetryableError()` with stdio transport: process exit, killed, spawn, signal, crashed patterns all retryable
- [x] Unit tests confirming ENOENT/EACCES are NOT retryable even for stdio
- [x] Unit tests confirming process exit is NOT retryable for http or without transport context
- [x] Integration test: stdio server with process crash retries exactly STDIO_CONNECT_MAX_RETRIES times (2 total attempts)
- [x] Integration test: stdio server with ENOENT does not retry (1 attempt)
- [x] Integration test: http server retries up to CONNECT_MAX_RETRIES times (3 total attempts)
- [x] Full test suite passes (3071 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)