### PR TITLE
feat(completions): add tab completion for `mcx install` from registry slugs (closes #80)

### DIFF
--- a/packages/command/src/commands/completions.spec.ts
+++ b/packages/command/src/commands/completions.spec.ts
@@ -83,6 +83,10 @@ describe("bashScript", () => {
     expect(script).toContain("mcx completions --aliases 2>/dev/null");
   });
 
+  test("calls back for registry slugs on install", () => {
+    expect(script).toContain("mcx completions --registry 2>/dev/null");
+  });
+
   test("contains all subcommands", () => {
     for (const cmd of SUBCOMMANDS) {
       expect(script).toContain(cmd);
@@ -117,6 +121,10 @@ describe("zshScript", () => {
     expect(script).toContain("mcx completions --aliases 2>/dev/null");
   });
 
+  test("calls back for registry slugs on install", () => {
+    expect(script).toContain("mcx completions --registry 2>/dev/null");
+  });
+
   test("contains all subcommands", () => {
     for (const cmd of SUBCOMMANDS) {
       expect(script).toContain(cmd);
@@ -147,8 +155,56 @@ describe("fishScript", () => {
     expect(script).toContain("mcx completions --aliases 2>/dev/null");
   });
 
+  test("calls back for registry slugs on install", () => {
+    expect(script).toContain("mcx completions --registry 2>/dev/null");
+  });
+
   test("contains all subcommands in initial completion", () => {
     expect(script).toContain(SUBCOMMANDS.join(" "));
+  });
+});
+
+describe("--registry helper", () => {
+  function makeDeps(registryResult: unknown): CompletionDeps {
+    return {
+      ipcCall: mock(() => Promise.resolve([])) as CompletionDeps["ipcCall"],
+      isDaemonRunning: mock(() => Promise.resolve(false)),
+      listRegistry: mock(() => Promise.resolve(registryResult)),
+    } as CompletionDeps;
+  }
+
+  test("prints slugs from registry response", async () => {
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+    try {
+      const deps = makeDeps({
+        servers: [
+          { _meta: { "com.anthropic.api/mcp-registry": { slug: "server-a" } } },
+          { _meta: { "com.anthropic.api/mcp-registry": { slug: "server-b" } } },
+        ],
+        metadata: { count: 2 },
+      });
+      await cmdCompletions(["--registry"], deps);
+      expect(logs).toEqual(["server-a", "server-b"]);
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("outputs nothing on network error", async () => {
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+    try {
+      const deps = makeDeps(null);
+      // Override to throw
+      deps.listRegistry = mock(() => Promise.reject(new Error("network"))) as CompletionDeps["listRegistry"];
+      await cmdCompletions(["--registry"], deps);
+      expect(logs).toEqual([]);
+    } finally {
+      console.log = origLog;
+    }
   });
 });
 
@@ -156,7 +212,12 @@ describe("daemon guard", () => {
   test("completion helpers do not call ipcCall when daemon is not running", async () => {
     const ipcCallMock = mock(() => Promise.resolve([]));
     const isDaemonRunningMock = mock(() => Promise.resolve(false));
-    const deps = { ipcCall: ipcCallMock as CompletionDeps["ipcCall"], isDaemonRunning: isDaemonRunningMock };
+    const listRegistryMock = mock(() => Promise.resolve({ servers: [], metadata: { count: 0 } }));
+    const deps = {
+      ipcCall: ipcCallMock as CompletionDeps["ipcCall"],
+      isDaemonRunning: isDaemonRunningMock,
+      listRegistry: listRegistryMock as CompletionDeps["listRegistry"],
+    };
 
     // --servers
     await cmdCompletions(["--servers"], deps);
@@ -201,6 +262,10 @@ describe("cross-script consistency", () => {
 
     test(`${name} references --aliases`, () => {
       expect(fn()).toContain("--aliases");
+    });
+
+    test(`${name} references --registry`, () => {
+      expect(fn()).toContain("--registry");
     });
 
     test(`${name} suppresses stderr with 2>/dev/null`, () => {

--- a/packages/command/src/commands/completions.ts
+++ b/packages/command/src/commands/completions.ts
@@ -8,13 +8,19 @@
 
 import { ipcCall as realIpcCall, isDaemonRunning as realIsDaemonRunning } from "../daemon-lifecycle";
 import { printError } from "../output";
+import { listRegistry as realListRegistry } from "../registry/client";
 
 export interface CompletionDeps {
   ipcCall: typeof realIpcCall;
   isDaemonRunning: typeof realIsDaemonRunning;
+  listRegistry: typeof realListRegistry;
 }
 
-const defaultDeps: CompletionDeps = { ipcCall: realIpcCall, isDaemonRunning: realIsDaemonRunning };
+const defaultDeps: CompletionDeps = {
+  ipcCall: realIpcCall,
+  isDaemonRunning: realIsDaemonRunning,
+  listRegistry: realListRegistry,
+};
 
 /** Top-level subcommands for the mcx CLI */
 export const SUBCOMMANDS = [
@@ -76,6 +82,10 @@ export async function cmdCompletions(args: string[], deps?: CompletionDeps): Pro
   }
   if (args[0] === "--aliases") {
     await printAliases(d);
+    return;
+  }
+  if (args[0] === "--registry") {
+    await printRegistrySlugs(d);
     return;
   }
 
@@ -141,6 +151,18 @@ async function printAliases(deps: CompletionDeps): Promise<void> {
   }
 }
 
+/** Print registry slugs, one per line. Silent on failure (network, etc.). */
+async function printRegistrySlugs(deps: CompletionDeps): Promise<void> {
+  try {
+    const response = await deps.listRegistry();
+    for (const entry of response.servers) {
+      console.log(entry._meta["com.anthropic.api/mcp-registry"].slug);
+    }
+  } catch {
+    // Network error or registry unavailable — output nothing
+  }
+}
+
 // -- Shell script generators --
 
 export function bashScript(): string {
@@ -203,6 +225,14 @@ _mcx_completions() {
     local aliases
     aliases="$(mcx completions --aliases 2>/dev/null)"
     COMPREPLY=( $(compgen -W "$aliases" -- "$cur") )
+    return
+  fi
+
+  # mcx install <TAB> — registry slugs
+  if [[ "$cmd" == "install" && $cword -eq 2 ]]; then
+    local slugs
+    slugs="$(mcx completions --registry 2>/dev/null)"
+    COMPREPLY=( $(compgen -W "$slugs" -- "$cur") )
     return
   fi
 
@@ -308,6 +338,14 @@ _mcx() {
     return
   fi
 
+  # mcx install <TAB> — registry slugs
+  if [[ "$cmd" == "install" ]] && (( CURRENT == 3 )); then
+    local -a slugs
+    slugs=(\${(f)"$(mcx completions --registry 2>/dev/null)"})
+    _describe 'registry server' slugs
+    return
+  fi
+
   # mcx <server-command> <TAB> — server names
   if (( CURRENT == 3 )) && (( \${server_commands[(Ie)$cmd]} )); then
     local -a servers
@@ -369,6 +407,9 @@ ${ALIAS_NAME_COMMANDS.map(
 
 # mcx run <TAB> — alias names
 complete -c mcx -n '__mcx_token_count -eq 2; and __mcx_token 2 = run' -a '(mcx completions --aliases 2>/dev/null)' -d 'alias'
+
+# mcx install <TAB> — registry slugs
+complete -c mcx -n '__mcx_token_count -eq 2; and __mcx_token 2 = install' -a '(mcx completions --registry 2>/dev/null)' -d 'registry server'
 
 # Server name completion for: ${SERVER_COMMANDS.join(", ")}
 ${SERVER_COMMANDS.map(


### PR DESCRIPTION
## Summary
- Add `--registry` dynamic completion helper that fetches cached registry slugs via `listRegistry`
- Wire `mcx install <TAB>` into bash, zsh, and fish completion scripts to suggest available server slugs
- Add `listRegistry` to `CompletionDeps` for testability via dependency injection

## Test plan
- [x] New tests: `--registry` helper prints slugs from registry response
- [x] New tests: `--registry` helper outputs nothing on network error
- [x] All three shell scripts reference `--registry` (cross-script consistency tests)
- [x] Per-shell tests verify `mcx completions --registry 2>/dev/null` appears in generated scripts
- [x] Existing daemon guard tests updated with new dep
- [x] Full suite: 3078 tests pass, typecheck clean, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)