### PR TITLE
fix(cli): auto-start daemon for mcx claude subcommands (fixes #835)

### DIFF
--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -13,14 +13,13 @@ import {
   buildHookEnv,
   fixCoreBare,
   hasWorktreeHooks,
-  ipcCall,
   readWorktreeConfig,
   resolveModelName,
   resolveWorktreeBase,
   resolveWorktreePath,
 } from "@mcp-cli/core";
 import type { WorktreeHooksConfig } from "@mcp-cli/core";
-import { getStaleDaemonWarning } from "../daemon-lifecycle";
+import { getStaleDaemonWarning, ipcCall } from "../daemon-lifecycle";
 import { applyJqFilter } from "../jq/index";
 import { c, printError as defaultPrintError, formatToolResult } from "../output";
 import { extractFullFlag, extractJqFlag, extractJsonFlag } from "../parse";


### PR DESCRIPTION
## Summary
- `mcx claude` subcommands (ls, spawn, send, bye, wait, etc.) imported the raw `ipcCall` from `@mcp-cli/core` which does not auto-start the daemon
- Switched to the CLI's wrapped `ipcCall` from `daemon-lifecycle.ts` which calls `ensureDaemon()` before each IPC request
- Now all `mcx claude` commands transparently start the daemon if it's not running, matching `mcx status` behavior

## Test plan
- [x] Typecheck passes
- [x] Lint passes
- [x] All 3149 tests pass
- [x] Coverage thresholds met
- [x] Existing claude.spec.ts tests still pass (they use dependency injection so are unaffected by the import change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)