### PR TITLE
fix(acp): resolve copilot binary — try standalone then fall back to `gh copilot` (fixes #857)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,6 +16,13 @@
         "typescript": "^5.9.3",
       },
     },
+    "packages/acp": {
+      "name": "@mcp-cli/acp",
+      "version": "0.1.0",
+      "dependencies": {
+        "@mcp-cli/core": "workspace:*",
+      },
+    },
     "packages/codex": {
       "name": "@mcp-cli/codex",
       "version": "0.1.0",
@@ -92,6 +99,8 @@
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
+
+    "@mcp-cli/acp": ["@mcp-cli/acp@workspace:packages/acp"],
 
     "@mcp-cli/codex": ["@mcp-cli/codex@workspace:packages/codex"],
 

--- a/packages/acp/package.json
+++ b/packages/acp/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@mcp-cli/acp",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@mcp-cli/core": "workspace:*"
+  }
+}

--- a/packages/acp/src/acp-resolve.spec.ts
+++ b/packages/acp/src/acp-resolve.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test";
+import { type WhichFn, resolveAcpCommand } from "./acp-resolve";
+import type { AcpAgent } from "./agents";
+
+const copilot: AcpAgent = {
+  name: "copilot",
+  command: "copilot",
+  args: ["--acp"],
+  installHint: "Install with: gh extension install github/gh-copilot",
+};
+
+describe("resolveAcpCommand", () => {
+  it("returns standalone binary when it exists", () => {
+    const which: WhichFn = (bin) => (bin === "copilot" ? "/usr/local/bin/copilot" : null);
+    expect(resolveAcpCommand(copilot, which)).toEqual(["copilot", "--acp"]);
+  });
+
+  it("falls back to gh extension when standalone is missing", () => {
+    const which: WhichFn = (bin) => (bin === "gh" ? "/usr/bin/gh" : null);
+    expect(resolveAcpCommand(copilot, which)).toEqual(["gh", "copilot", "--acp"]);
+  });
+
+  it("prefers standalone over gh when both exist", () => {
+    const which: WhichFn = () => "/some/path";
+    expect(resolveAcpCommand(copilot, which)).toEqual(["copilot", "--acp"]);
+  });
+
+  it("throws with install hint when neither is found", () => {
+    const which: WhichFn = () => null;
+    expect(() => resolveAcpCommand(copilot, which)).toThrow(/ACP agent `copilot` not found.*gh extension install/);
+  });
+
+  it("works with custom agent definitions", () => {
+    const gemini: AcpAgent = {
+      name: "gemini",
+      command: "gemini",
+      args: ["--acp"],
+      installHint: "Install gemini-cli",
+    };
+    const which: WhichFn = (bin) => (bin === "gemini" ? "/usr/local/bin/gemini" : null);
+    expect(resolveAcpCommand(gemini, which)).toEqual(["gemini", "--acp"]);
+  });
+
+  it("passes agent args through unchanged", () => {
+    const custom: AcpAgent = {
+      name: "test",
+      command: "test-agent",
+      args: ["--acp", "--verbose", "--json"],
+      installHint: "n/a",
+    };
+    const which: WhichFn = (bin) => (bin === "gh" ? "/usr/bin/gh" : null);
+    expect(resolveAcpCommand(custom, which)).toEqual(["gh", "test-agent", "--acp", "--verbose", "--json"]);
+  });
+});

--- a/packages/acp/src/acp-resolve.ts
+++ b/packages/acp/src/acp-resolve.ts
@@ -1,0 +1,37 @@
+/**
+ * Resolve an ACP agent's spawn command.
+ *
+ * Strategy:
+ *   1. Try the standalone binary (e.g. `copilot`)
+ *   2. Fall back to `gh <command>` (e.g. `gh copilot`)
+ *   3. Throw with install instructions if neither is found
+ *
+ * Resolution happens once at spawn time — callers cache the result.
+ */
+
+import type { AcpAgent } from "./agents";
+
+/** Signature matching Bun.which — injectable for testing. */
+export type WhichFn = (bin: string) => string | null;
+
+/**
+ * Resolve the full spawn command array for an ACP agent.
+ *
+ * @param agent  Agent definition from the registry
+ * @param which  Binary lookup function (defaults to Bun.which)
+ * @returns      Command array suitable for Bun.spawn (e.g. ["gh", "copilot", "--acp"])
+ */
+export function resolveAcpCommand(agent: AcpAgent, which: WhichFn = Bun.which): string[] {
+  // 1. Try standalone binary
+  if (which(agent.command)) {
+    return [agent.command, ...agent.args];
+  }
+
+  // 2. Fall back to gh extension
+  if (which("gh")) {
+    return ["gh", agent.command, ...agent.args];
+  }
+
+  // 3. Neither found
+  throw new Error(`ACP agent \`${agent.command}\` not found in PATH. ${agent.installHint}`);
+}

--- a/packages/acp/src/agents.ts
+++ b/packages/acp/src/agents.ts
@@ -1,0 +1,33 @@
+/**
+ * ACP agent registry — known ACP-compatible agents and their spawn commands.
+ */
+
+export interface AcpAgent {
+  /** Display name (e.g. "copilot", "gemini"). */
+  name: string;
+  /** Standalone binary name to try first. */
+  command: string;
+  /** Args appended after the command (e.g. ["--acp"]). */
+  args: string[];
+  /** Human-readable install instructions shown when the agent is not found. */
+  installHint: string;
+}
+
+/**
+ * Known ACP agents. The command field is the standalone binary name;
+ * resolution logic in acp-resolve.ts handles falling back to `gh <command>`.
+ */
+export const ACP_AGENTS: Record<string, AcpAgent> = {
+  copilot: {
+    name: "copilot",
+    command: "copilot",
+    args: ["--acp"],
+    installHint: "Install with: gh extension install github/gh-copilot",
+  },
+  gemini: {
+    name: "gemini",
+    command: "gemini",
+    args: ["--acp"],
+    installHint: "Install with: npm install -g @anthropic-ai/gemini-cli",
+  },
+};

--- a/packages/acp/src/index.ts
+++ b/packages/acp/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./agents";
+export * from "./acp-resolve";

--- a/packages/acp/tsconfig.json
+++ b/packages/acp/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,8 @@
       "@mcp-cli/permissions/*": ["./packages/permissions/src/*"],
       "@mcp-cli/codex": ["./packages/codex/src/index.ts"],
       "@mcp-cli/codex/*": ["./packages/codex/src/*"],
+      "@mcp-cli/acp": ["./packages/acp/src/index.ts"],
+      "@mcp-cli/acp/*": ["./packages/acp/src/*"],
       "@mcp-cli/command": ["./packages/command/src/main.ts"],
       "@mcp-cli/command/*": ["./packages/command/src/*"],
       "@mcp-cli/control": ["./packages/control/src/main.tsx"],


### PR DESCRIPTION
## Summary
- Adds `packages/acp/` with `AcpAgent` type, known agent registry (`agents.ts`), and `resolveAcpCommand()` function (`acp-resolve.ts`)
- Resolution uses `Bun.which()` to try standalone binary first (e.g. `copilot`), then falls back to `gh <command>` (e.g. `gh copilot --acp`)
- Throws a helpful error with install instructions if neither binary is found
- Uses dependency injection for `Bun.which` — no `mock.module()` needed in tests

## Test plan
- [x] 6 unit tests covering all resolution paths (standalone, gh fallback, both present, neither present, custom agents, arg passthrough)
- [x] 100% function and line coverage on `acp-resolve.ts`
- [x] Full test suite passes (3155 tests, 0 failures)
- [x] Typecheck, lint, and coverage ratchet all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)