### PR TITLE
fix(daemon): add connect timeout for sessions stuck in connecting state (fixes #837)

### DIFF
--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -2721,6 +2721,83 @@ describe("stderr drain", () => {
     // --worktree should NOT be in the command (hook pre-created)
     expect(ms.lastCmd).not.toContain("--worktree");
   });
+
+  test("connect timeout transitions session to disconnected when CLI does not connect", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger, connectTimeoutMs: 100 });
+    const port = await server.start();
+
+    const events: SessionEvent[] = [];
+    server.onSessionEvent = (_id, event) => events.push(event);
+
+    server.prepareSession("timeout-test", { prompt: "Hello" });
+    server.spawnClaude("timeout-test");
+
+    // Session starts in connecting state
+    expect(server.listSessions()[0].state).toBe("connecting");
+
+    // Wait for the connect timeout to fire
+    await pollUntil(() => {
+      const s = server?.listSessions()[0];
+      return s?.state === "disconnected";
+    }, 2_000);
+
+    expect(server.listSessions()[0].state).toBe("disconnected");
+    expect(events.some((e) => e.type === "session:disconnected")).toBe(true);
+    const disconnectEvent = events.find((e) => e.type === "session:disconnected") as {
+      type: "session:disconnected";
+      reason: string;
+    };
+    expect(disconnectEvent.reason).toBe("connect timeout");
+    // Process should have been killed
+    expect(ms.killed).toBe(true);
+  });
+
+  test("connect timeout is cleared when WS connection arrives", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger, connectTimeoutMs: 200 });
+    const port = await server.start();
+
+    server.prepareSession("connect-ok", { prompt: "Hello" });
+    server.spawnClaude("connect-ok");
+
+    // Connect before timeout fires
+    const ws = await connectMockClaude(port, "connect-ok");
+    const initMsg = await waitForMessage(ws);
+    expect(initMsg).toContain('"type":"user"');
+
+    // Wait past the timeout period — session should NOT transition to disconnected
+    await Bun.sleep(300);
+    expect(server.listSessions()[0].state).toBe("connecting"); // still waiting for system/init
+
+    ws.close();
+  });
+
+  test("connect timeout does not fire for sessions that already received WS open", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger, connectTimeoutMs: 100 });
+    const port = await server.start();
+
+    server.prepareSession("no-timeout", { prompt: "Hello" });
+    server.spawnClaude("no-timeout");
+
+    // Connect and send system/init to move past connecting state
+    const ws = await connectMockClaude(port, "no-timeout");
+    await waitForMessage(ws);
+    ws.send(systemInitMessage("no-timeout"));
+
+    // Wait past timeout — should still be in init state, not disconnected
+    await pollUntil(() => {
+      const s = server?.listSessions()[0];
+      return s?.state === "init";
+    }, 1_000);
+
+    await Bun.sleep(150);
+    expect(server.listSessions()[0].state).toBe("init");
+    expect(ms.killed).toBe(false);
+
+    ws.close();
+  });
 });
 
 // ── restoreSessions ──

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -29,6 +29,8 @@ import { SessionState } from "./session-state";
 const KILL_TIMEOUT_MS = 5_000;
 /** Time (ms) to wait after SIGKILL before giving up. */
 const KILL_SIGKILL_GRACE_MS = 2_000;
+/** Time (ms) to wait for a WebSocket connection after spawning a Claude CLI process. */
+const CONNECT_TIMEOUT_MS = 30_000;
 
 // ── Errors ──
 
@@ -235,6 +237,8 @@ interface WsSession {
   clearing: boolean;
   /** Claude Code's own session ID (from system/init), used for JSONL file lookup. */
   claudeSessionId: string | null;
+  /** Timer that fires if the Claude CLI process doesn't connect via WS within the deadline. */
+  connectTimer: Timer | null;
 }
 
 interface WsData {
@@ -274,6 +278,7 @@ export class ClaudeWsServer {
   private readonly portRetryCount: number;
   private readonly portRetryDelayMs: number;
   private readonly reclaimIntervalMs: number;
+  private readonly connectTimeoutMs: number;
   private eventSeq = 0;
   private readonly eventBuffer: BufferedEvent[] = [];
   private nextRequestId = 1;
@@ -289,6 +294,7 @@ export class ClaudeWsServer {
     portRetryCount?: number;
     portRetryDelayMs?: number;
     reclaimIntervalMs?: number;
+    connectTimeoutMs?: number;
   }) {
     this.spawn = deps?.spawn ?? defaultSpawn;
     this.killTimeoutMs = deps?.killTimeoutMs ?? KILL_TIMEOUT_MS;
@@ -296,6 +302,7 @@ export class ClaudeWsServer {
     this.portRetryCount = deps?.portRetryCount ?? 10;
     this.portRetryDelayMs = deps?.portRetryDelayMs ?? 500;
     this.reclaimIntervalMs = deps?.reclaimIntervalMs ?? PORT_RECLAIM_INTERVAL_MS;
+    this.connectTimeoutMs = deps?.connectTimeoutMs ?? CONNECT_TIMEOUT_MS;
   }
 
   /** Current event sequence number (monotonically increasing). */
@@ -475,6 +482,7 @@ export class ClaudeWsServer {
         keepAliveTimer: null,
         clearing: false,
         claudeSessionId: null,
+        connectTimer: null,
       });
       restored++;
       this.logger.info(`[_claude] Restored session ${s.sessionId} (state: disconnected, pid: ${s.pid})`);
@@ -505,6 +513,7 @@ export class ClaudeWsServer {
       keepAliveTimer: null,
       clearing: false,
       claudeSessionId: null,
+      connectTimer: null,
     });
   }
 
@@ -563,6 +572,40 @@ export class ClaudeWsServer {
     session.pid = proc.pid;
     session.proc = proc;
     session.spawnAlive = true;
+
+    // Start connect timeout — if no WS connection arrives within the deadline,
+    // kill the stuck process and transition to disconnected. This prevents sessions
+    // from being stuck in "connecting" forever when the Claude CLI fails to establish
+    // a WebSocket connection (e.g., race after daemon auto-start, #837).
+    if (session.connectTimer) clearTimeout(session.connectTimer);
+    session.connectTimer = setTimeout(() => {
+      session.connectTimer = null;
+      // Only act if still in connecting state with no WS
+      if (session.ws !== null || session.state.state !== "connecting") return;
+      this.logger.error(
+        `[_claude] Connect timeout for session ${sessionId} — Claude CLI did not connect within ${this.connectTimeoutMs}ms`,
+      );
+      // Kill the stuck process
+      if (session.proc) {
+        try {
+          session.proc.kill();
+        } catch {
+          /* already dead */
+        }
+      }
+      // Transition to disconnected so callers see a clear state
+      const events = session.state.disconnect("connect timeout");
+      for (const event of events) {
+        this.onSessionEvent?.(sessionId, event);
+        try {
+          this.handleSessionEvent(sessionId, session, event);
+        } catch (err) {
+          this.logger.error(
+            `[_claude] handleSessionEvent failed for session ${sessionId}, event ${event.type}: ${err instanceof Error ? err.stack : err}`,
+          );
+        }
+      }
+    }, this.connectTimeoutMs);
 
     // Drain stderr immediately to prevent pipe buffer deadlock.
     // On macOS the pipe buffer is 64KB — if the child writes more than that
@@ -772,6 +815,12 @@ export class ClaudeWsServer {
           `[_claude] handleSessionEvent failed for session ${sessionId}, event ${event.type}: ${err instanceof Error ? err.stack : err}`,
         );
       }
+    }
+
+    // Clear connect timeout timer
+    if (session.connectTimer) {
+      clearTimeout(session.connectTimer);
+      session.connectTimer = null;
     }
 
     // Clear keep-alive timer
@@ -1032,6 +1081,12 @@ export class ClaudeWsServer {
     if (!session) {
       ws.close(1008, "Unknown session");
       return;
+    }
+
+    // Clear the connect timeout — WS connection established successfully
+    if (session.connectTimer) {
+      clearTimeout(session.connectTimer);
+      session.connectTimer = null;
     }
 
     session.ws = ws;
@@ -1492,6 +1547,12 @@ export class ClaudeWsServer {
     }
     this.eventWaiters.length = 0;
     this.eventWaiters.push(...remainingEventWaiters);
+
+    // Clear connect timeout timer
+    if (session.connectTimer) {
+      clearTimeout(session.connectTimer);
+      session.connectTimer = null;
+    }
 
     // Clear keep-alive timer
     if (session.keepAliveTimer) {


### PR DESCRIPTION
## Summary
- Added a 30-second connect timeout to `ClaudeWsServer.spawnClaude()` that fires if the Claude CLI process doesn't establish a WebSocket connection after being spawned
- On timeout: kills the stuck process and transitions the session to "disconnected" state with reason "connect timeout", making the failure visible instead of silently stuck forever
- Timer is properly cleared on successful WS connection, session termination, and session clear/respawn

## Test plan
- [x] New test: connect timeout transitions session to disconnected when CLI does not connect within deadline
- [x] New test: connect timeout is cleared when WS connection arrives before deadline
- [x] New test: sessions that receive WS open + system/init are not affected by timeout
- [x] All 3152 existing tests pass
- [x] TypeScript typecheck passes
- [x] Biome lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)