### PR TITLE
fix(release): run biome format on package.json after version bump (fixes #833)

### DIFF
--- a/.claude/skills/release/release.ts
+++ b/.claude/skills/release/release.ts
@@ -121,6 +121,13 @@ function updatePackageJson(version: string): void {
   const oldVersion = pkg.version;
   pkg.version = version;
   writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+  // Re-format so Biome-preferred style (e.g. inline short arrays) is used,
+  // avoiding a lint failure on the release commit.
+  Bun.spawnSync(["bunx", "biome", "format", "--write", pkgPath], {
+    stdout: "pipe",
+    stderr: "pipe",
+    cwd: process.cwd(),
+  });
   console.error(`package.json: ${oldVersion} → ${version}`);
 }
 


### PR DESCRIPTION
## Summary
- After `updatePackageJson()` writes `package.json` with `JSON.stringify`, run `bunx biome format --write` to normalize formatting
- Prevents lint failures caused by Biome's preferred inline style for short arrays vs JSON.stringify's multi-line expansion

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (3149 tests)
- [x] Verified the biome format call is placed between the file write and the log message

🤖 Generated with [Claude Code](https://claude.com/claude-code)