### PR TITLE
docs: add mcx add-from-claude-desktop to README (closes #849)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ mcx import                          # auto-find .mcp.json in parent dirs
 mcx import /path/to/config.json     # import from specific file
 mcx import --claude                 # import from Claude Code config
 mcx import --claude --all           # import all Claude Code projects
+mcx add-from-claude-desktop         # import all servers from Claude Desktop config
 mcx export                          # export to stdout
 mcx export .mcp.json                # export to file
 mcx export --server <name>          # export specific server(s)


### PR DESCRIPTION
## Summary
- Adds `mcx add-from-claude-desktop` to the Import/Export section of the README
- The command was implemented in PR #844 but was missing from the docs

## Test plan
- [ ] Verified the command exists at `packages/command/src/commands/import.ts:229`
- [ ] README now reflects the full set of import commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)