### PR TITLE
fix(alias-executor): wire up createAliasCache in daemon execution path (fixes #852)

### DIFF
--- a/packages/daemon/src/alias-executor.spec.ts
+++ b/packages/daemon/src/alias-executor.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { bundleAlias } from "@mcp-cli/core";
 
@@ -105,6 +105,54 @@ describe("alias-executor subprocess protocol", () => {
     const parsed = JSON.parse(stdout);
     expect(parsed.error).toBeDefined();
     expect(typeof parsed.error).toBe("string");
+  });
+
+  test("cache() writes to disk and returns cached value on second call", async () => {
+    const dir = makeTmpDir();
+    const scriptPath = join(dir, "cached.ts");
+    // Script uses cache() — on first call writes file, on second call reads it
+    writeFileSync(
+      scriptPath,
+      [
+        'import { defineAlias, z } from "mcp-cli";',
+        "defineAlias({",
+        '  name: "cached",',
+        "  input: z.object({ seed: z.string() }),",
+        "  fn: async (input, ctx) => {",
+        '    const val = await ctx.cache("test-key", () => input.seed);',
+        "    return val;",
+        "  },",
+        "});",
+      ].join("\n"),
+    );
+
+    const { js } = await bundleAlias(scriptPath);
+
+    // First call: producer runs, value cached
+    const first = await runExecutor({
+      bundledJs: js,
+      input: { seed: "original" },
+      isDefineAlias: true,
+      aliasName: "executor-cache-test",
+    });
+    expect(first.exitCode).toBe(0);
+    expect(JSON.parse(first.stdout).result).toBe("original");
+
+    // Second call with different seed: should return cached "original"
+    const second = await runExecutor({
+      bundledJs: js,
+      input: { seed: "different" },
+      isDefineAlias: true,
+      aliasName: "executor-cache-test",
+    });
+    expect(second.exitCode).toBe(0);
+    expect(JSON.parse(second.stdout).result).toBe("original");
+
+    // Clean up cache files
+    const cacheDir = join(homedir(), ".mcp-cli", "cache", "alias", "executor-cache-test");
+    if (existsSync(cacheDir)) {
+      rmSync(cacheDir, { recursive: true });
+    }
   });
 
   test("console.log in alias script does not corrupt stdout JSON", async () => {

--- a/packages/daemon/src/alias-executor.ts
+++ b/packages/daemon/src/alias-executor.ts
@@ -11,13 +11,20 @@
  */
 
 import { readFile } from "node:fs/promises";
-import { type AliasContext, executeAliasBundled, stubProxy, validateAliasBundled } from "@mcp-cli/core";
+import {
+  type AliasContext,
+  createAliasCache,
+  executeAliasBundled,
+  stubProxy,
+  validateAliasBundled,
+} from "@mcp-cli/core";
 
 interface ExecutorInput {
   bundledJs: string;
   input: unknown;
   isDefineAlias: boolean;
   mode?: "execute" | "validate";
+  aliasName?: string;
 }
 
 async function main(): Promise<void> {
@@ -31,7 +38,7 @@ async function main(): Promise<void> {
 
   // Read input from stdin
   const stdinText = await Bun.stdin.text();
-  const { bundledJs, input, isDefineAlias, mode } = JSON.parse(stdinText) as ExecutorInput;
+  const { bundledJs, input, isDefineAlias, mode, aliasName } = JSON.parse(stdinText) as ExecutorInput;
 
   if (mode === "validate") {
     const validation = await validateAliasBundled(bundledJs);
@@ -47,7 +54,7 @@ async function main(): Promise<void> {
         : {},
     file: (path: string) => readFile(path, "utf-8"),
     json: async (path: string) => JSON.parse(await readFile(path, "utf-8")),
-    cache: async (_key, producer) => producer(),
+    cache: createAliasCache(aliasName ?? "unknown"),
   };
 
   const result = await executeAliasBundled(bundledJs, input, ctx, isDefineAlias);

--- a/packages/daemon/src/alias-server.ts
+++ b/packages/daemon/src/alias-server.ts
@@ -195,6 +195,7 @@ export class AliasServer {
       bundledJs,
       input: args,
       isDefineAlias: aliasDef.isDefineAlias,
+      aliasName: aliasDef.name,
     });
 
     return this.spawnExecutor(payload, 30_000) as Promise<unknown>;


### PR DESCRIPTION
## Summary
- Replaced stub `cache: async (_key, producer) => producer()` in `alias-executor.ts` with `createAliasCache(aliasName)` so caching works identically via daemon (`mcx call _aliases.*`) and command path (`mcx run`)
- Added `aliasName` field to `ExecutorInput` interface and passed it from `alias-server.ts` when spawning the executor subprocess
- Added test verifying cache persistence across executor invocations (second call returns cached value, not fresh producer result)

## Test plan
- [x] New test: `cache() writes to disk and returns cached value on second call` — verifies producer is bypassed on cache hit
- [x] All existing alias-executor tests pass (5/5)
- [x] Full test suite passes (3150/3150)
- [x] `bun typecheck` clean
- [x] `bun lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)