### PR TITLE
fix: unwrap SDK-wrapped errors in wrapTransportError (fixes #855)

### DIFF
--- a/packages/daemon/src/server-pool.spec.ts
+++ b/packages/daemon/src/server-pool.spec.ts
@@ -9,6 +9,7 @@ import {
   ServerPool,
   buildChildEnv,
   detectPlanCapabilities,
+  findCauseCode,
   isRetryableError,
   isTransientCallError,
   safeStderrWrite,
@@ -24,6 +25,11 @@ function errWithCode(message: string, code: string): Error {
   const e = new Error(message);
   (e as unknown as Record<string, unknown>).code = code;
   return e;
+}
+
+/** Create an error with a cause chain (simulating SDK wrapping). */
+function sdkWrapped(message: string, cause: Error): Error {
+  return new Error(message, { cause });
 }
 
 describe("isRetryableError", () => {
@@ -267,6 +273,108 @@ describe("wrapTransportError", () => {
       );
       expect(result.message).toContain("TLS/certificate error");
     });
+  });
+
+  // -- SDK-wrapped errors (cause chain) --
+
+  describe("SDK-wrapped errors", () => {
+    test("HTTP 'Unable to connect' with ECONNREFUSED cause → connection refused", () => {
+      const cause = errWithCode("connect ECONNREFUSED 127.0.0.1:8080", "ECONNREFUSED");
+      const result = wrapTransportError(
+        "api",
+        http,
+        sdkWrapped("Unable to connect. Is the computer able to access the url?", cause),
+      );
+      expect(result.message).toContain("could not connect to https://example.com/mcp");
+      expect(result.message).toContain("Is the server running?");
+    });
+
+    test("HTTP 'Unable to connect' with ENOTFOUND cause → DNS failure", () => {
+      const cause = errWithCode("getaddrinfo ENOTFOUND example.invalid", "ENOTFOUND");
+      const result = wrapTransportError(
+        "api",
+        http,
+        sdkWrapped("Unable to connect. Is the computer able to access the url?", cause),
+      );
+      expect(result.message).toContain("DNS lookup failed");
+      expect(result.message).toContain("https://example.com/mcp");
+    });
+
+    test("HTTP 'Unable to connect' without cause → falls back to connection refused", () => {
+      const result = wrapTransportError(
+        "api",
+        http,
+        new Error("Unable to connect. Is the computer able to access the url?"),
+      );
+      expect(result.message).toContain("could not connect to https://example.com/mcp");
+    });
+
+    test("SSE 'SSE error: Unable to connect' → connection refused", () => {
+      const result = wrapTransportError(
+        "events",
+        sse,
+        new Error("SSE error: Unable to connect. Is the computer able to access the url?"),
+      );
+      expect(result.message).toContain("could not connect to https://sse.example.com/events");
+    });
+
+    test("SSE 'Unable to connect' with ENOTFOUND cause → DNS failure", () => {
+      const cause = errWithCode("getaddrinfo ENOTFOUND", "ENOTFOUND");
+      const result = wrapTransportError(
+        "events",
+        sse,
+        sdkWrapped("SSE error: Unable to connect. Is the computer able to access the url?", cause),
+      );
+      expect(result.message).toContain("DNS lookup failed");
+    });
+
+    test("stdio 'MCP error -32000: Connection closed' → process exit message", () => {
+      const result = wrapTransportError("foo", stdio, new Error("MCP error -32000: Connection closed"));
+      expect(result.message).toContain("process exited unexpectedly");
+      expect(result.message).toContain("npx -y my-server");
+    });
+
+    test("stdio 'Connection closed' → process exit message", () => {
+      const result = wrapTransportError("foo", stdio, new Error("Connection closed"));
+      expect(result.message).toContain("process exited unexpectedly");
+    });
+
+    test("deeply nested cause chain → finds code", () => {
+      const inner = errWithCode("connect ECONNREFUSED", "ECONNREFUSED");
+      const mid = new Error("transport failed", { cause: inner });
+      const outer = new Error("Unable to connect. Is the computer able to access the url?", { cause: mid });
+      const result = wrapTransportError("api", http, outer);
+      expect(result.message).toContain("could not connect to https://example.com/mcp");
+    });
+  });
+});
+
+describe("findCauseCode", () => {
+  test("returns code from direct error", () => {
+    expect(findCauseCode(errWithCode("fail", "ECONNREFUSED"))).toBe("ECONNREFUSED");
+  });
+
+  test("returns code from cause chain", () => {
+    const inner = errWithCode("inner", "ENOTFOUND");
+    const outer = new Error("outer", { cause: inner });
+    expect(findCauseCode(outer)).toBe("ENOTFOUND");
+  });
+
+  test("returns undefined for errors without codes", () => {
+    expect(findCauseCode(new Error("no code"))).toBeUndefined();
+  });
+
+  test("returns undefined for non-Error input", () => {
+    expect(findCauseCode("string")).toBeUndefined();
+  });
+
+  test("handles circular-ish chains by depth limit", () => {
+    let err: Error = errWithCode("base", "FOUND");
+    for (let i = 0; i < 15; i++) {
+      err = new Error(`level-${i}`, { cause: err });
+    }
+    // Code is at depth 15, but we only search 10 levels
+    expect(findCauseCode(err)).toBeUndefined();
   });
 });
 

--- a/packages/daemon/src/server-pool.ts
+++ b/packages/daemon/src/server-pool.ts
@@ -870,6 +870,23 @@ function createTransport(config: ServerConfig, authProvider?: OAuthClientProvide
 // -- Error wrapping --
 
 /**
+ * Walk the `.cause` chain of an error looking for a system error code
+ * (e.g., ECONNREFUSED, ENOTFOUND). The MCP SDK often wraps the original
+ * system error as a `cause`, stripping the code from the outer error.
+ * @internal Exported for testing only.
+ */
+export function findCauseCode(err: unknown): string | undefined {
+  let current: unknown = err;
+  for (let depth = 0; depth < 10; depth++) {
+    if (!(current instanceof Error)) break;
+    const code = (current as unknown as Record<string, unknown>).code;
+    if (typeof code === "string" && code.length > 0) return code;
+    current = current.cause;
+  }
+  return undefined;
+}
+
+/**
  * Inspect a transport-level error and return a new Error with an actionable,
  * user-friendly message that includes the server name and hints for resolution.
  * @internal Exported for testing only.
@@ -878,8 +895,9 @@ export function wrapTransportError(serverName: string, config: ServerConfig, raw
   const err = raw instanceof Error ? raw : new Error(String(raw));
   const msg = err.message.toLowerCase();
 
-  // Extract system error code (Node/Bun set `err.code` on system errors)
-  const code: string | undefined = (err as unknown as Record<string, unknown>).code as string | undefined;
+  // Extract system error code — check the error itself and its cause chain
+  const code: string | undefined =
+    ((err as unknown as Record<string, unknown>).code as string | undefined) ?? findCauseCode(err);
 
   const prefix = `Server "${serverName}"`;
 
@@ -892,7 +910,14 @@ export function wrapTransportError(serverName: string, config: ServerConfig, raw
     if (code === "EACCES" || msg.includes("permission denied") || msg.includes("eacces")) {
       return new Error(`${prefix} failed: permission denied for "${config.command}". Check file permissions.`);
     }
-    if (msg.includes("exited") || msg.includes("exit code") || msg.includes("killed") || msg.includes("spawn")) {
+    if (
+      msg.includes("exited") ||
+      msg.includes("exit code") ||
+      msg.includes("killed") ||
+      msg.includes("spawn") ||
+      msg.includes("connection closed") ||
+      msg.includes("mcp error -32000")
+    ) {
       return new Error(
         `${prefix} process exited unexpectedly. Check server logs or run the command manually: ${config.command} ${(config.args ?? []).join(" ")}`,
       );
@@ -904,11 +929,18 @@ export function wrapTransportError(serverName: string, config: ServerConfig, raw
   // HTTP and SSE share most network-level errors
   const url = (config as { url: string }).url;
 
-  if (code === "ECONNREFUSED" || msg.includes("econnrefused") || msg.includes("connection refused")) {
-    return new Error(`${prefix} failed: could not connect to ${url}. Is the server running?`);
-  }
+  // SDK wraps ECONNREFUSED/ENOTFOUND as "Unable to connect" — check cause chain
+  // to distinguish DNS failures from connection refused
   if (code === "ENOTFOUND" || msg.includes("enotfound") || msg.includes("getaddrinfo")) {
     return new Error(`${prefix} failed: DNS lookup failed for ${url}. Check the URL and your network connection.`);
+  }
+  if (
+    code === "ECONNREFUSED" ||
+    msg.includes("econnrefused") ||
+    msg.includes("connection refused") ||
+    msg.includes("unable to connect")
+  ) {
+    return new Error(`${prefix} failed: could not connect to ${url}. Is the server running?`);
   }
   if (
     msg.includes("certificate") ||

--- a/test/transport-errors.spec.ts
+++ b/test/transport-errors.spec.ts
@@ -5,14 +5,12 @@
  * conn.lastError → listServers(). Verifies that friendly, actionable
  * error messages surface correctly for each transport type.
  *
- * NOTE: The MCP SDK wraps low-level system errors (ECONNREFUSED, ENOTFOUND,
- * etc.) in its own higher-level messages before they reach wrapTransportError.
- * This means some of the pattern matches in wrapTransportError (which look for
- * raw error codes/patterns) fall through to generic fallbacks. The tests below
- * verify the ACTUAL end-to-end behavior. See filed follow-up issue for improving
- * SDK error unwrapping.
+ * The MCP SDK wraps low-level system errors (ECONNREFUSED, ENOTFOUND, etc.)
+ * in higher-level messages. wrapTransportError handles this by:
+ * 1. Walking err.cause chains to find the original system error code
+ * 2. Pattern-matching SDK message formats (e.g., "Unable to connect")
  *
- * @see https://github.com/theshadow27/mcp-cli/issues/38
+ * @see https://github.com/theshadow27/mcp-cli/issues/855
  */
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { chmodSync, writeFileSync } from "node:fs";
@@ -82,22 +80,22 @@ describe("Stdio transport errors", () => {
     expect(status?.lastError).toContain("permission denied");
   });
 
-  test("process exits immediately → error surfaces through lastError", async () => {
+  test("process exits immediately → actionable exit message with command", async () => {
     daemon = await startTestDaemon({
       crasher: { command: "bun", args: [resolve("test/exit-immediately.ts")] },
     });
 
     const rpcError = await triggerConnect(daemon.socketPath, "crasher");
-    // The MCP SDK wraps the exit in "MCP error -32000: Connection closed"
-    // which wrapTransportError sees as a generic stdio error. The server
-    // name and transport type still appear in the wrapped message.
+    // The MCP SDK wraps the exit as "MCP error -32000: Connection closed".
+    // wrapTransportError now matches this pattern and produces an actionable message.
     expect(rpcError).toBeDefined();
     expect(rpcError).toContain('Server "crasher"');
-    expect(rpcError).toContain("stdio");
+    expect(rpcError).toContain("process exited unexpectedly");
+    expect(rpcError).toContain("bun");
 
     const status = await getServerStatus(daemon.socketPath, "crasher");
     expect(status?.state).toBe("error");
-    expect(status?.lastError).toBeDefined();
+    expect(status?.lastError).toContain("process exited unexpectedly");
   });
 });
 
@@ -114,34 +112,38 @@ describe("HTTP transport errors", () => {
     }
   });
 
-  test("connection refused → error with server name and transport type", async () => {
+  test("connection refused → friendly message with URL", async () => {
     daemon = await startTestDaemon({
       deadhttp: { type: "http", url: "http://127.0.0.1:19999/mcp" },
     });
 
     const rpcError = await triggerConnect(daemon.socketPath, "deadhttp");
     expect(rpcError).toBeDefined();
-    // The MCP SDK wraps ECONNREFUSED as "Unable to connect. Is the computer
-    // able to access the url?" which doesn't match wrapTransportError's
-    // ECONNREFUSED pattern — falls through to generic HTTP fallback
+    // The MCP SDK wraps ECONNREFUSED as "Unable to connect..." — wrapTransportError
+    // now matches this pattern and produces a URL-specific message.
     expect(rpcError).toContain('Server "deadhttp"');
-    expect(rpcError).toContain("http");
+    expect(rpcError).toContain("could not connect to http://127.0.0.1:19999/mcp");
+    expect(rpcError).toContain("Is the server running?");
 
     const status = await getServerStatus(daemon.socketPath, "deadhttp");
     expect(status?.state).toBe("error");
-    expect(status?.lastError).toBeDefined();
-    expect(status?.lastError).toContain('"deadhttp"');
+    expect(status?.lastError).toContain("could not connect to");
   });
 
-  test("DNS failure → error with server name", async () => {
+  test("DNS failure → DNS-specific message with URL", async () => {
     daemon = await startTestDaemon({
       baddns: { type: "http", url: "http://this-host-does-not-resolve.invalid/mcp" },
     });
 
     const rpcError = await triggerConnect(daemon.socketPath, "baddns");
     expect(rpcError).toBeDefined();
-    // The MCP SDK wraps ENOTFOUND in its own message too
+    // The MCP SDK wraps ENOTFOUND — wrapTransportError now checks err.cause
+    // to recover the original code and distinguish DNS from connection refused.
     expect(rpcError).toContain('Server "baddns"');
+    // Should get either DNS-specific or connection-refused message (depends on
+    // whether the SDK preserves the cause chain). Either is better than generic.
+    const isDnsOrConnectMsg = rpcError?.includes("DNS lookup failed") || rpcError?.includes("could not connect to");
+    expect(isDnsOrConnectMsg).toBe(true);
 
     const status = await getServerStatus(daemon.socketPath, "baddns");
     expect(status?.state).toBe("error");
@@ -162,7 +164,7 @@ describe("SSE transport errors", () => {
     }
   });
 
-  test("connection refused → error with server name and SSE context", async () => {
+  test("connection refused → friendly message with URL", async () => {
     daemon = await startTestDaemon({
       deadsse: { type: "sse", url: "http://127.0.0.1:19998/events" },
     });
@@ -170,13 +172,13 @@ describe("SSE transport errors", () => {
     const rpcError = await triggerConnect(daemon.socketPath, "deadsse");
     expect(rpcError).toBeDefined();
     expect(rpcError).toContain('Server "deadsse"');
-    // SSE errors may be caught as "SSE error:" by the SDK
-    expect(rpcError).toContain("sse");
+    // The MCP SDK wraps as "SSE error: Unable to connect..." — wrapTransportError
+    // now matches "unable to connect" pattern for SSE too.
+    expect(rpcError).toContain("could not connect to http://127.0.0.1:19998/events");
 
     const status = await getServerStatus(daemon.socketPath, "deadsse");
     expect(status?.state).toBe("error");
-    expect(status?.lastError).toBeDefined();
-    expect(status?.lastError).toContain('"deadsse"');
+    expect(status?.lastError).toContain("could not connect to");
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `findCauseCode()` helper that walks `err.cause` chains to recover original system error codes (ECONNREFUSED, ENOTFOUND) stripped by the MCP SDK
- Add SDK message pattern matching: `"Unable to connect"` → connection refused, `"Connection closed"` / `"MCP error -32000"` → stdio process exit
- Reorder ENOTFOUND check before ECONNREFUSED so cause-chain DNS codes take priority over the generic "unable to connect" message match

## Test plan
- [x] 8 new unit tests for SDK-wrapped errors (cause chains, nested causes, SDK message patterns for HTTP/SSE/stdio)
- [x] 5 new unit tests for `findCauseCode()` (direct code, cause chain, no code, non-Error, depth limit)
- [x] Updated 4 integration test assertions to verify specific messages instead of generic fallbacks
- [x] All 3162 tests pass, coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)