### PR TITLE
feat(alias): add tsc --noEmit fallback validation for freeform aliases (fixes #861)

### DIFF
--- a/packages/core/src/alias-bundle.spec.ts
+++ b/packages/core/src/alias-bundle.spec.ts
@@ -10,6 +10,7 @@ import {
   stripMcpCliImport,
   stubProxy,
   validateAliasBundled,
+  validateFreeformTsc,
 } from "./alias-bundle";
 
 function makeTmpDir(): string {
@@ -415,4 +416,58 @@ describe("validateAliasBundled", () => {
     expect(result.valid).toBe(true);
     expect(result.name).toBe("minimal");
   });
+});
+
+describe("validateFreeformTsc", () => {
+  test("returns no warnings for valid freeform script", async () => {
+    const dir = makeTmpDir();
+    const scriptPath = join(dir, "valid-freeform.ts");
+    writeFileSync(scriptPath, "const x: number = 42;\nconsole.log(x);\n");
+
+    const result = await validateFreeformTsc(scriptPath);
+
+    expect(result.timedOut).toBe(false);
+    expect(result.warnings).toHaveLength(0);
+  }, 15_000);
+
+  test("returns warnings for type errors", async () => {
+    const dir = makeTmpDir();
+    const scriptPath = join(dir, "bad-types.ts");
+    writeFileSync(scriptPath, 'const x: number = "not a number";\n');
+
+    const result = await validateFreeformTsc(scriptPath);
+
+    expect(result.timedOut).toBe(false);
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings.some((w) => w.includes("TS"))).toBe(true);
+  }, 15_000);
+
+  test("handles scripts that import from mcp-cli", async () => {
+    const dir = makeTmpDir();
+    const scriptPath = join(dir, "with-import.ts");
+    writeFileSync(
+      scriptPath,
+      'import { mcp, args } from "mcp-cli";\nconst name: string = args["name"] ?? "world";\nconsole.log(name);\n',
+    );
+
+    const result = await validateFreeformTsc(scriptPath);
+
+    expect(result.timedOut).toBe(false);
+    // Should not have import resolution errors thanks to the stub
+    const importErrors = result.warnings.filter((w) => w.includes("Cannot find module"));
+    expect(importErrors).toHaveLength(0);
+  }, 15_000);
+
+  test("respects timeout", async () => {
+    const dir = makeTmpDir();
+    const scriptPath = join(dir, "timeout-test.ts");
+    writeFileSync(scriptPath, "const x = 1;\n");
+
+    // Use an extremely short timeout to trigger it
+    const result = await validateFreeformTsc(scriptPath, 1);
+
+    // May or may not time out depending on how fast bunx starts,
+    // but the function should not throw
+    expect(typeof result.timedOut).toBe("boolean");
+  }, 15_000);
 });

--- a/packages/core/src/alias-bundle.ts
+++ b/packages/core/src/alias-bundle.ts
@@ -343,6 +343,121 @@ export async function validateAliasBundled(bundledJs: string, timeoutMs = 5_000)
   return result;
 }
 
+/**
+ * Stub declaration for the "mcp-cli" virtual module, used during tsc validation
+ * so that freeform alias imports resolve without errors.
+ */
+const MCP_CLI_STUB_DTS = `
+declare module "mcp-cli" {
+  export const mcp: Record<string, Record<string, (args?: Record<string, unknown>) => Promise<unknown>>>;
+  export const args: Record<string, string>;
+  export function file(path: string): Promise<string>;
+  export function json(path: string): Promise<unknown>;
+  export function defineAlias(def: unknown): void;
+  export const z: typeof import("zod/v4").z;
+}
+`.trimStart();
+
+/** Minimal tsconfig for tsc validation of freeform alias scripts. */
+const TSC_TSCONFIG = JSON.stringify(
+  {
+    compilerOptions: {
+      target: "ESNext",
+      module: "ESNext",
+      moduleResolution: "bundler",
+      noEmit: true,
+      strict: false,
+      skipLibCheck: true,
+      paths: { "mcp-cli": ["./mcp-cli.d.ts"] },
+    },
+    include: ["*.ts"],
+  },
+  null,
+  2,
+);
+
+/**
+ * Parse tsc diagnostic lines into human-readable messages.
+ * Only includes lines matching the tsc diagnostic format: file(line,col): error TSxxxx: message
+ * Filters out bunx/npm noise (e.g. "Resolving dependencies").
+ */
+function parseTscDiagnostics(output: string, scriptBasename: string): string[] {
+  // Match: file.ts(line,col): error TS1234: message  OR  error TS1234: message
+  const diagPattern = /^(?:.*\(\d+,\d+\):\s*)?error\s+TS\d+:/;
+  const diagnostics: string[] = [];
+  for (const line of output.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || !diagPattern.test(trimmed)) continue;
+    // Simplify by stripping the temp file path prefix
+    const simplified = trimmed.replace(new RegExp(`^${escapeRegExp(scriptBasename)}\\(`), "(");
+    diagnostics.push(simplified);
+  }
+  return diagnostics;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Validate a freeform alias script using `bunx tsc --noEmit`.
+ *
+ * Creates a temp directory with the script, a stub mcp-cli.d.ts, and a
+ * tsconfig.json, then runs tsc. Diagnostics are returned as warnings.
+ * Returns valid: true unless tsc crashes (signal kill, not diagnostic errors).
+ */
+export async function validateFreeformTsc(
+  sourcePath: string,
+  timeoutMs = 10_000,
+): Promise<{ warnings: string[]; timedOut: boolean }> {
+  const { mkdtempSync, writeFileSync, cpSync, rmSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join, basename } = await import("node:path");
+
+  const tmpDir = mkdtempSync(join(tmpdir(), "mcp-alias-tsc-"));
+  const scriptName = basename(sourcePath);
+
+  try {
+    // Copy alias source and write support files
+    cpSync(sourcePath, join(tmpDir, scriptName));
+    writeFileSync(join(tmpDir, "mcp-cli.d.ts"), MCP_CLI_STUB_DTS);
+    writeFileSync(join(tmpDir, "tsconfig.json"), TSC_TSCONFIG);
+
+    const proc = Bun.spawn(["bunx", "tsc", "--noEmit"], {
+      cwd: tmpDir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      proc.kill();
+    }, timeoutMs);
+
+    const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+    clearTimeout(timer);
+
+    await proc.exited;
+
+    if (timedOut) {
+      return { warnings: ["tsc validation timed out"], timedOut: true };
+    }
+
+    // Parse diagnostics from stdout (tsc writes diagnostics to stdout)
+    const output = stdout || stderr;
+    const warnings = parseTscDiagnostics(output, scriptName);
+
+    return { warnings, timedOut: false };
+  } finally {
+    try {
+      rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort cleanup */
+    }
+  }
+}
+
 // AsyncFunction constructor (not directly accessible as a global)
 const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor as new (
   ...args: string[]

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -54,6 +54,7 @@ import {
   options,
   safeAliasPath,
   startSpan,
+  validateFreeformTsc,
 } from "@mcp-cli/core";
 import { auth } from "@modelcontextprotocol/sdk/client/auth.js";
 import { z } from "zod/v4";
@@ -708,7 +709,6 @@ export class IpcServer {
         // Freeform aliases — try bundling to check for syntax errors
         try {
           await bundleAlias(alias.filePath);
-          return { valid: true, aliasType: "freeform", errors: [], warnings: [] };
         } catch (err) {
           return {
             valid: false,
@@ -717,6 +717,10 @@ export class IpcServer {
             warnings: [],
           };
         }
+
+        // Run tsc --noEmit for type-level diagnostics (warnings only)
+        const tsc = await validateFreeformTsc(alias.filePath);
+        return { valid: true, aliasType: "freeform", errors: [], warnings: tsc.warnings };
       }
 
       // defineAlias — full validation


### PR DESCRIPTION
## Summary
- Adds `validateFreeformTsc()` in `packages/core/src/alias-bundle.ts` that creates a temp dir with the alias script, a stub `mcp-cli.d.ts`, and a tsconfig, then runs `bunx tsc --noEmit` with a 10s timeout
- Updates the daemon's `checkAlias` IPC handler to call `validateFreeformTsc()` for freeform aliases after successful bundling, reporting tsc diagnostics as warnings
- Only actual tsc diagnostic lines (matching `error TSxxxx:`) are included — bunx noise (e.g. "Resolving dependencies") is filtered out

## Test plan
- [x] Valid freeform script produces no warnings
- [x] Script with type errors produces warnings containing TS error codes
- [x] Scripts importing from "mcp-cli" resolve correctly via stub declaration
- [x] Timeout handling works without throwing
- [x] All 3162 existing tests pass (1 pre-existing flaky watcher test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)