### PR TITLE
feat(publish): set up npm publishing for bun add -g support (fixes #36)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   build:
@@ -70,3 +71,28 @@ jobs:
           files: |
             artifacts/*.tar.gz
             artifacts/checksums.txt
+
+  publish:
+    needs: release
+    runs-on: ubuntu-latest
+    if: ${{ vars.NPM_PUBLISH_ENABLED == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - name: Set version from tag
+        env:
+          RELEASE_VERSION: ${{ github.ref_name }}
+        run: |
+          bun -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json','utf-8'));
+            pkg.version = process.env.RELEASE_VERSION.replace(/^v/, '');
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/package.json
+++ b/package.json
@@ -1,9 +1,15 @@
 {
-  "name": "mcp-cli",
-  "private": true,
+  "name": "@theshadow27/mcp-cli",
   "version": "0.10.0",
+  "description": "MCP CLI — call MCP server tools from the command line with zero context overhead",
   "type": "module",
   "workspaces": ["packages/*"],
+  "bin": {
+    "mcx": "packages/command/src/main.ts",
+    "mcpd": "packages/daemon/src/main.ts",
+    "mcpctl": "packages/control/src/main.tsx"
+  },
+  "files": ["packages/*/src/**", "packages/*/package.json", "tsconfig*.json", "!**/*.spec.ts", "!**/test/**"],
   "scripts": {
     "build": "bun scripts/build.ts",
     "typecheck": "bun install && bun --bun tsc -b",


### PR DESCRIPTION
## Summary
- Scope package as `@theshadow27/mcp-cli`, remove `private: true`, add `bin` field mapping `mcx`/`mcpd`/`mcpctl` to their TS entrypoints (Bun runs TS natively via shebangs)
- Add `files` field to control what's published (source packages only, no tests)
- Add `.npmrc` for CI npm auth and a `publish` job to the release workflow, gated on `NPM_PUBLISH_ENABLED` repo variable + `NPM_TOKEN` secret

## Setup required
1. Set repo variable `NPM_PUBLISH_ENABLED` to `true` in GitHub Settings → Variables
2. Add `NPM_TOKEN` secret in GitHub Settings → Secrets
3. Ensure the npm org/scope `@theshadow27` exists on npmjs.com

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (3330 tests)
- [ ] After merge + tag push: verify publish job runs (requires NPM_TOKEN secret)
- [ ] `bun add -g @theshadow27/mcp-cli` installs and `mcx --version` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)