### PR TITLE
feat(daemon): add SSE endpoint for streaming daemon logs (fixes #41)

### DIFF
--- a/packages/command/src/commands/logs.spec.ts
+++ b/packages/command/src/commands/logs.spec.ts
@@ -1,13 +1,28 @@
 import { describe, expect, mock, test } from "bun:test";
+import type { openLogStream } from "@mcp-cli/core";
 import { ExitError } from "../test-helpers";
 import type { LogsDeps } from "./logs";
-import { cmdLogs, pad2, pad3, parseLogsArgs, printLogLine } from "./logs";
+import { cmdLogs, pad2, pad3, parseLogsArgs, printLogLine, streamLogsSSE } from "./logs";
 
 /* ── helpers ─────────────────────────────────────────────────────── */
+
+/** Create a mock openLogStream that yields the given entries then completes. */
+function mockLogStream(entries: Array<{ timestamp: number; line: string }>): typeof openLogStream {
+  return ((_params: unknown) => {
+    const abortFn = mock(() => {});
+    async function* iterate() {
+      for (const entry of entries) {
+        yield entry;
+      }
+    }
+    return { entries: iterate(), abort: abortFn };
+  }) as unknown as typeof openLogStream;
+}
 
 function makeDeps(overrides?: Partial<LogsDeps>): Partial<LogsDeps> {
   return {
     ipcCall: mock(() => Promise.resolve({ lines: [] })) as LogsDeps["ipcCall"],
+    openLogStream: mockLogStream([]),
     printError: mock(() => {}),
     readFileSync: mock(() => ""),
     daemonLogPath: "/tmp/test-mcpd.log",
@@ -231,124 +246,113 @@ describe("cmdLogs server (no follow)", () => {
   });
 });
 
-/* ── cmdLogs: server logs (follow mode) ─────────────────────────── */
+/* ── cmdLogs: server logs (follow mode via SSE) ────────────────── */
 
 describe("cmdLogs server (follow)", () => {
-  test("starts polling after initial fetch", async () => {
-    const deps = makeDeps({
-      ipcCall: mock(() => Promise.resolve({ lines: [] })) as LogsDeps["ipcCall"],
-    });
+  test("uses openLogStream for follow mode", async () => {
+    const openLogStreamMock = mock(mockLogStream([]));
+    const deps = makeDeps({ openLogStream: openLogStreamMock as unknown as typeof openLogStream });
 
     await cmdLogs(["myserver", "-f"], deps);
 
-    expect(deps.schedule).toHaveBeenCalled();
-    expect(deps.onSigint).toHaveBeenCalled();
+    expect(openLogStreamMock).toHaveBeenCalledWith({ server: "myserver", lines: 50 });
   });
 
-  test("prints initial lines before entering follow mode", async () => {
+  test("prints streamed log lines", async () => {
     const output: string[] = [];
-    const deps = makeDeps({
-      ipcCall: mock(() =>
-        Promise.resolve({
-          lines: [{ timestamp: Date.now(), line: "initial" }],
-        }),
-      ) as LogsDeps["ipcCall"],
-      writeStderr: (msg: string) => output.push(msg),
-    });
-
-    await cmdLogs(["myserver", "-f"], deps);
-
-    expect(output).toHaveLength(1);
-    expect(output[0]).toContain("initial");
-  });
-
-  test("poll callback prints new lines and resets backoff", async () => {
-    const output: string[] = [];
-    const scheduledFns: Array<() => void> = [];
     const ts = Date.now();
-
     const deps = makeDeps({
-      ipcCall: mock()
-        .mockResolvedValueOnce({ lines: [{ timestamp: ts, line: "initial" }] }) // initial fetch
-        .mockResolvedValueOnce({ lines: [{ timestamp: ts + 1000, line: "polled" }] }) as LogsDeps["ipcCall"], // poll
+      openLogStream: mockLogStream([
+        { timestamp: ts, line: "first" },
+        { timestamp: ts + 1000, line: "second" },
+      ]),
       writeStderr: (msg: string) => output.push(msg),
-      schedule: mock((fn: () => void) => {
-        scheduledFns.push(fn);
-        return null as unknown as ReturnType<typeof setTimeout>;
-      }),
     });
 
     await cmdLogs(["myserver", "-f"], deps);
-
-    // Execute the poll callback
-    expect(scheduledFns.length).toBeGreaterThanOrEqual(1);
-    await scheduledFns[0]();
 
     expect(output).toHaveLength(2);
-    expect(output[1]).toContain("polled");
+    expect(output[0]).toContain("[myserver] first");
+    expect(output[1]).toContain("[myserver] second");
   });
 
-  test("poll callback backs off when no new data", async () => {
-    const scheduledFns: Array<() => void> = [];
-    const scheduledDelays: number[] = [];
-
-    const deps = makeDeps({
-      ipcCall: mock(() => Promise.resolve({ lines: [] })) as LogsDeps["ipcCall"],
-      schedule: mock((fn: () => void, ms: number) => {
-        scheduledFns.push(fn);
-        scheduledDelays.push(ms);
-        return null as unknown as ReturnType<typeof setTimeout>;
-      }),
-    });
-
-    await cmdLogs(["myserver", "-f"], deps);
-
-    // Execute poll twice — should see increasing delays
-    await scheduledFns[0]();
-    await scheduledFns[1]();
-
-    expect(scheduledDelays[1]).toBeGreaterThan(scheduledDelays[0]);
-  });
-
-  test("poll callback handles errors with backoff", async () => {
-    const scheduledFns: Array<() => void> = [];
-    const scheduledDelays: number[] = [];
-
-    const deps = makeDeps({
-      ipcCall: mock()
-        .mockResolvedValueOnce({ lines: [] }) // initial fetch
-        .mockRejectedValueOnce(new Error("connection lost")) as LogsDeps["ipcCall"], // poll error
-      schedule: mock((fn: () => void, ms: number) => {
-        scheduledFns.push(fn);
-        scheduledDelays.push(ms);
-        return null as unknown as ReturnType<typeof setTimeout>;
-      }),
-    });
-
-    await cmdLogs(["myserver", "-f"], deps);
-    await scheduledFns[0](); // This should catch the error
-
-    // Should still schedule next poll (with backoff)
-    expect(scheduledFns).toHaveLength(2);
-    expect(scheduledDelays[1]).toBeGreaterThan(scheduledDelays[0]);
-  });
-
-  test("SIGINT handler cancels polling and exits", async () => {
+  test("registers SIGINT handler that aborts stream", async () => {
     let sigintHandler: (() => void) | undefined;
-
     const deps = makeDeps({
-      ipcCall: mock(() => Promise.resolve({ lines: [] })) as LogsDeps["ipcCall"],
+      openLogStream: mockLogStream([]),
       onSigint: mock((fn: () => void) => {
         sigintHandler = fn;
       }),
-      schedule: mock(() => "timer-id" as unknown as ReturnType<typeof setTimeout>),
     });
 
     await cmdLogs(["myserver", "-f"], deps);
 
     expect(sigintHandler).toBeDefined();
     expect(() => (sigintHandler as () => void)()).toThrow(ExitError);
-    expect(deps.cancelSchedule).toHaveBeenCalled();
+  });
+
+  test("respects --lines with follow mode", async () => {
+    const openLogStreamMock = mock(mockLogStream([]));
+    const deps = makeDeps({ openLogStream: openLogStreamMock as unknown as typeof openLogStream });
+
+    await cmdLogs(["myserver", "-f", "--lines", "10"], deps);
+
+    expect(openLogStreamMock).toHaveBeenCalledWith({ server: "myserver", lines: 10 });
+  });
+});
+
+/* ── streamLogsSSE ─────────────────────────────────────────────── */
+
+describe("streamLogsSSE", () => {
+  test("prints entries from the async iterable", async () => {
+    const output: string[] = [];
+    const ts = Date.now();
+    const deps = makeDeps({
+      openLogStream: mockLogStream([
+        { timestamp: ts, line: "line-a" },
+        { timestamp: ts + 500, line: "line-b" },
+      ]),
+      writeStderr: (msg: string) => output.push(msg),
+    });
+
+    await streamLogsSSE({ server: "srv" }, "srv", 50, { ...makeDeps(), ...deps } as LogsDeps);
+
+    expect(output).toHaveLength(2);
+    expect(output[0]).toContain("[srv] line-a");
+    expect(output[1]).toContain("[srv] line-b");
+  });
+
+  test("handles AbortError gracefully", async () => {
+    const deps = makeDeps({
+      openLogStream: ((_params: unknown) => {
+        const iter: AsyncIterable<{ timestamp: number; line: string }> = {
+          [Symbol.asyncIterator]: () => ({
+            next: () => Promise.reject(new DOMException("The operation was aborted", "AbortError")),
+          }),
+        };
+        return { entries: iter, abort: () => {} };
+      }) as unknown as typeof openLogStream,
+    });
+
+    // Should not throw
+    await streamLogsSSE({ server: "srv" }, "srv", 50, { ...makeDeps(), ...deps } as LogsDeps);
+  });
+
+  test("re-throws non-abort errors", async () => {
+    const deps = makeDeps({
+      openLogStream: ((_params: unknown) => {
+        const iter: AsyncIterable<{ timestamp: number; line: string }> = {
+          [Symbol.asyncIterator]: () => ({
+            next: () => Promise.reject(new Error("connection failed")),
+          }),
+        };
+        return { entries: iter, abort: () => {} };
+      }) as unknown as typeof openLogStream,
+    });
+
+    await expect(streamLogsSSE({ server: "srv" }, "srv", 50, { ...makeDeps(), ...deps } as LogsDeps)).rejects.toThrow(
+      "connection failed",
+    );
   });
 });
 
@@ -398,120 +402,54 @@ describe("cmdLogs --daemon (no follow)", () => {
   });
 });
 
-/* ── cmdLogs: daemon logs (follow mode) ─────────────────────────── */
+/* ── cmdLogs: daemon logs (follow mode via SSE) ────────────────── */
 
 describe("cmdLogs --daemon (follow)", () => {
-  test("uses IPC getDaemonLogs and starts polling", async () => {
+  test("uses openLogStream with daemon flag", async () => {
+    const openLogStreamMock = mock(mockLogStream([]));
+    const deps = makeDeps({ openLogStream: openLogStreamMock as unknown as typeof openLogStream });
+
+    await cmdLogs(["--daemon", "-f"], deps);
+
+    expect(openLogStreamMock).toHaveBeenCalledWith({ daemon: true, lines: 50 });
+  });
+
+  test("prints streamed daemon lines", async () => {
     const output: string[] = [];
+    const ts = Date.now();
     const deps = makeDeps({
-      ipcCall: mock(() =>
-        Promise.resolve({
-          lines: [{ timestamp: Date.now(), line: "daemon line" }],
-        }),
-      ) as LogsDeps["ipcCall"],
+      openLogStream: mockLogStream([{ timestamp: ts, line: "daemon line" }]),
       writeStderr: (msg: string) => output.push(msg),
     });
 
     await cmdLogs(["--daemon", "-f"], deps);
 
-    expect(deps.ipcCall).toHaveBeenCalledWith("getDaemonLogs", { limit: 50 });
     expect(output).toHaveLength(1);
-    expect(output[0]).toContain("daemon line");
-    expect(deps.schedule).toHaveBeenCalled();
-    expect(deps.onSigint).toHaveBeenCalled();
+    expect(output[0]).toContain("[mcpd] daemon line");
   });
 
   test("respects --lines with --daemon -f", async () => {
-    const deps = makeDeps({
-      ipcCall: mock(() => Promise.resolve({ lines: [] })) as LogsDeps["ipcCall"],
-    });
+    const openLogStreamMock = mock(mockLogStream([]));
+    const deps = makeDeps({ openLogStream: openLogStreamMock as unknown as typeof openLogStream });
 
     await cmdLogs(["--daemon", "-f", "--lines", "20"], deps);
-    expect(deps.ipcCall).toHaveBeenCalledWith("getDaemonLogs", { limit: 20 });
+
+    expect(openLogStreamMock).toHaveBeenCalledWith({ daemon: true, lines: 20 });
   });
 
-  test("daemon poll callback prints new lines", async () => {
-    const output: string[] = [];
-    const scheduledFns: Array<() => void> = [];
-    const ts = Date.now();
-
-    const deps = makeDeps({
-      ipcCall: mock()
-        .mockResolvedValueOnce({ lines: [{ timestamp: ts, line: "init" }] })
-        .mockResolvedValueOnce({
-          lines: [{ timestamp: ts + 1000, line: "polled-daemon" }],
-        }) as unknown as LogsDeps["ipcCall"],
-      writeStderr: (msg: string) => output.push(msg),
-      schedule: mock((fn: () => void) => {
-        scheduledFns.push(fn);
-        return null as unknown as ReturnType<typeof setTimeout>;
-      }),
-    });
-
-    await cmdLogs(["--daemon", "-f"], deps);
-    await scheduledFns[0]();
-
-    expect(output).toHaveLength(2);
-    expect(output[1]).toContain("polled-daemon");
-  });
-
-  test("daemon poll backs off on empty data", async () => {
-    const scheduledFns: Array<() => void> = [];
-    const scheduledDelays: number[] = [];
-
-    const deps = makeDeps({
-      ipcCall: mock(() => Promise.resolve({ lines: [] })) as LogsDeps["ipcCall"],
-      schedule: mock((fn: () => void, ms: number) => {
-        scheduledFns.push(fn);
-        scheduledDelays.push(ms);
-        return null as unknown as ReturnType<typeof setTimeout>;
-      }),
-    });
-
-    await cmdLogs(["--daemon", "-f"], deps);
-    await scheduledFns[0]();
-    await scheduledFns[1]();
-
-    expect(scheduledDelays[1]).toBeGreaterThan(scheduledDelays[0]);
-  });
-
-  test("daemon poll handles errors with backoff", async () => {
-    const scheduledFns: Array<() => void> = [];
-    const scheduledDelays: number[] = [];
-
-    const deps = makeDeps({
-      ipcCall: mock()
-        .mockResolvedValueOnce({ lines: [] })
-        .mockRejectedValueOnce(new Error("ipc error")) as unknown as LogsDeps["ipcCall"],
-      schedule: mock((fn: () => void, ms: number) => {
-        scheduledFns.push(fn);
-        scheduledDelays.push(ms);
-        return null as unknown as ReturnType<typeof setTimeout>;
-      }),
-    });
-
-    await cmdLogs(["--daemon", "-f"], deps);
-    await scheduledFns[0]();
-
-    expect(scheduledFns).toHaveLength(2);
-    expect(scheduledDelays[1]).toBeGreaterThan(scheduledDelays[0]);
-  });
-
-  test("daemon SIGINT handler cancels polling and exits", async () => {
+  test("daemon SIGINT handler aborts stream and exits", async () => {
     let sigintHandler: (() => void) | undefined;
 
     const deps = makeDeps({
-      ipcCall: mock(() => Promise.resolve({ lines: [] })) as LogsDeps["ipcCall"],
+      openLogStream: mockLogStream([]),
       onSigint: mock((fn: () => void) => {
         sigintHandler = fn;
       }),
-      schedule: mock(() => "timer-id" as unknown as ReturnType<typeof setTimeout>),
     });
 
     await cmdLogs(["--daemon", "-f"], deps);
 
     expect(sigintHandler).toBeDefined();
     expect(() => (sigintHandler as () => void)()).toThrow(ExitError);
-    expect(deps.cancelSchedule).toHaveBeenCalled();
   });
 });

--- a/packages/command/src/commands/logs.ts
+++ b/packages/command/src/commands/logs.ts
@@ -10,7 +10,7 @@
 
 import { readFileSync } from "node:fs";
 import type { IpcMethod, IpcMethodResult } from "@mcp-cli/core";
-import { ipcCall, options } from "@mcp-cli/core";
+import { ipcCall, openLogStream, options } from "@mcp-cli/core";
 import { printError } from "../output";
 
 export interface LogsArgs {
@@ -23,6 +23,7 @@ export interface LogsArgs {
 
 export interface LogsDeps {
   ipcCall: <M extends IpcMethod>(method: M, params?: unknown) => Promise<IpcMethodResult[M]>;
+  openLogStream: typeof openLogStream;
   printError: (msg: string) => void;
   readFileSync: (path: string, encoding: BufferEncoding) => string;
   daemonLogPath: string;
@@ -36,6 +37,7 @@ export interface LogsDeps {
 
 const defaultDeps: LogsDeps = {
   ipcCall,
+  openLogStream,
   printError,
   readFileSync: (path, enc) => readFileSync(path, enc),
   daemonLogPath: options.DAEMON_LOG_PATH,
@@ -75,10 +77,6 @@ export function parseLogsArgs(args: string[]): LogsArgs {
   return { server, daemon, follow, lines, error };
 }
 
-/** Backoff constants for follow-mode polling */
-const POLL_MIN_MS = 200;
-const POLL_MAX_MS = 5_000;
-
 export async function cmdLogs(args: string[], deps?: Partial<LogsDeps>): Promise<void> {
   const d: LogsDeps = { ...defaultDeps, ...deps };
   const parsed = parseLogsArgs(args);
@@ -103,17 +101,18 @@ export async function cmdLogs(args: string[], deps?: Partial<LogsDeps>): Promise
   const serverName = parsed.server;
   const { follow, lines } = parsed;
 
-  // Fetch initial batch
+  if (follow) {
+    // Use SSE for real-time streaming (no polling)
+    await streamLogsSSE({ server: serverName }, serverName, lines, d);
+    return;
+  }
+
+  // One-shot fetch
   const result = await d.ipcCall("getLogs", { server: serverName, limit: lines });
 
   for (const entry of result.lines) {
     printLogLine(serverName, entry.timestamp, entry.line, d);
   }
-
-  if (!follow) return;
-
-  const since = result.lines.at(-1)?.timestamp;
-  await followLogs("getLogs", { server: serverName }, serverName, since, d);
 }
 
 async function cmdDaemonLogs(parsed: LogsArgs, d: LogsDeps): Promise<void> {
@@ -137,55 +136,33 @@ async function cmdDaemonLogs(parsed: LogsArgs, d: LogsDeps): Promise<void> {
     return;
   }
 
-  // Follow mode: use IPC getDaemonLogs with adaptive backoff
-  const result = await d.ipcCall("getDaemonLogs", { limit: lines });
-
-  for (const entry of result.lines) {
-    printLogLine("mcpd", entry.timestamp, entry.line, d);
-  }
-
-  const since = result.lines.at(-1)?.timestamp;
-  await followLogs("getDaemonLogs", {}, "mcpd", since, d);
+  // Follow mode: use SSE for real-time streaming
+  await streamLogsSSE({ daemon: true }, "mcpd", lines, d);
 }
 
-/** Shared follow-mode polling with adaptive backoff. */
-export async function followLogs(
-  method: IpcMethod,
-  baseParams: Record<string, unknown>,
+/** Stream logs via SSE — replaces polling with push-based real-time streaming. */
+export async function streamLogsSSE(
+  params: { server?: string; daemon?: boolean },
   label: string,
-  since: number | undefined,
+  lines: number,
   d: LogsDeps,
 ): Promise<void> {
-  let lastTimestamp = since ?? Date.now();
-  let delay = POLL_MIN_MS;
+  const { entries, abort } = d.openLogStream({ ...params, lines });
 
-  const poll = async () => {
-    try {
-      const update = (await d.ipcCall(method, { ...baseParams, since: lastTimestamp })) as {
-        lines: Array<{ timestamp: number; line: string }>;
-      };
-      if (update.lines.length > 0) {
-        for (const entry of update.lines) {
-          printLogLine(label, entry.timestamp, entry.line, d);
-          lastTimestamp = entry.timestamp;
-        }
-        delay = POLL_MIN_MS;
-      } else {
-        delay = Math.min(delay * 2, POLL_MAX_MS);
-      }
-    } catch {
-      delay = Math.min(delay * 2, POLL_MAX_MS);
-    }
-    timeout = d.schedule(poll, delay);
-  };
-
-  let timeout = d.schedule(poll, delay);
   d.onSigint(() => {
-    d.cancelSchedule(timeout);
+    abort();
     d.exit(0);
   });
 
-  await d.keepAlive();
+  try {
+    for await (const entry of entries) {
+      printLogLine(label, entry.timestamp, entry.line, d);
+    }
+  } catch (err) {
+    // AbortError is expected on SIGINT
+    if (err instanceof DOMException && err.name === "AbortError") return;
+    throw err;
+  }
 }
 
 export function printLogLine(server: string, timestamp: number, line: string, deps?: Partial<LogsDeps>): void {

--- a/packages/core/src/ipc-client.ts
+++ b/packages/core/src/ipc-client.ts
@@ -115,3 +115,59 @@ export function pingDaemon(): Promise<boolean> {
     .then((res) => res.ok)
     .catch(() => false);
 }
+
+/**
+ * Open an SSE stream to the daemon's GET /logs endpoint.
+ * Returns an async iterable of parsed log entries plus an abort function.
+ */
+export function openLogStream(params: {
+  server?: string;
+  daemon?: boolean;
+  lines?: number;
+  since?: number;
+}): { entries: AsyncIterable<{ timestamp: number; line: string }>; abort: () => void } {
+  const qs = new URLSearchParams();
+  if (params.server) qs.set("server", params.server);
+  if (params.daemon) qs.set("daemon", "true");
+  if (params.lines !== undefined) qs.set("lines", String(params.lines));
+  if (params.since !== undefined) qs.set("since", String(params.since));
+
+  const controller = new AbortController();
+  const url = `http://localhost/logs?${qs.toString()}`;
+
+  async function* iterate(): AsyncGenerator<{ timestamp: number; line: string }> {
+    const res = await fetch(url, {
+      method: "GET",
+      unix: options.SOCKET_PATH,
+      signal: controller.signal,
+    } as RequestInit);
+
+    if (!res.ok) {
+      throw new Error(`SSE stream error: ${res.status} ${await res.text()}`);
+    }
+
+    const body = res.body;
+    if (!body) throw new Error("No response body");
+
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    for await (const chunk of body) {
+      buffer += decoder.decode(chunk as Uint8Array, { stream: true });
+      const parts = buffer.split("\n\n");
+      buffer = parts.pop() ?? "";
+
+      for (const part of parts) {
+        const line = part.replace(/^data: /, "");
+        if (!line) continue;
+        try {
+          yield JSON.parse(line) as { timestamp: number; line: string };
+        } catch {
+          // Skip malformed SSE events
+        }
+      }
+    }
+  }
+
+  return { entries: iterate(), abort: () => controller.abort() };
+}

--- a/packages/daemon/src/daemon-log.ts
+++ b/packages/daemon/src/daemon-log.ts
@@ -8,7 +8,7 @@
 
 import { appendFileSync, closeSync, openSync, renameSync, statSync } from "node:fs";
 import { DAEMON_LOG_MAX_BYTES, options } from "@mcp-cli/core";
-import { type StderrLine, StderrRingBuffer } from "./stderr-buffer";
+import { type StderrLine, StderrRingBuffer, type StderrSubscriber } from "./stderr-buffer";
 
 const DAEMON_KEY = "__daemon__";
 const DAEMON_CAPACITY = 200;
@@ -86,6 +86,14 @@ export function closeDaemonLogFile(): void {
 /** Retrieve captured daemon log lines. */
 export function getDaemonLogLines(limit?: number): StderrLine[] {
   return buffer.getLines(DAEMON_KEY, limit);
+}
+
+/** Subscribe to new daemon log lines. Returns an unsubscribe function. */
+export function subscribeDaemonLogs(fn: (entry: StderrLine) => void): () => void {
+  const wrapper: StderrSubscriber = (server, entry) => {
+    if (server === DAEMON_KEY) fn(entry);
+  };
+  return buffer.subscribe(wrapper);
 }
 
 function writeToLogFile(line: string): void {

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -32,6 +32,7 @@ function mockPool() {
     getDb: () => null,
     restart: async () => {},
     getStderrLines: () => [],
+    subscribeStderr: () => () => {},
   };
 }
 
@@ -1902,5 +1903,111 @@ describe("IpcServer HTTP transport", () => {
     });
     const json = (await res.json()) as IpcResponse;
     expect(json.error?.code).toBe(IPC_ERROR.INVALID_PARAMS);
+  });
+
+  // -- SSE /logs endpoint tests --
+
+  test("GET /logs without params returns 400", async () => {
+    startServer();
+
+    const res = await fetch("http://localhost/logs", {
+      method: "GET",
+      unix: socketPath,
+    } as RequestInit);
+
+    expect(res.status).toBe(400);
+    const text = await res.text();
+    expect(text).toContain("Missing");
+  });
+
+  test("GET /logs?daemon=true returns SSE content-type", async () => {
+    startServer();
+
+    const controller = new AbortController();
+    const res = await fetch("http://localhost/logs?daemon=true&lines=0", {
+      method: "GET",
+      unix: socketPath,
+      signal: controller.signal,
+    } as RequestInit);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
+
+    // Abort to close the stream
+    controller.abort();
+  });
+
+  test("GET /logs?daemon=true streams backfill lines", async () => {
+    startServer();
+
+    // Emit a recognizable log line
+    const marker = `sse-test-${Date.now()}`;
+    console.error(marker);
+
+    const controller = new AbortController();
+    const res = await fetch("http://localhost/logs?daemon=true&lines=10", {
+      method: "GET",
+      unix: socketPath,
+      signal: controller.signal,
+    } as RequestInit);
+
+    expect(res.status).toBe(200);
+    if (!res.body) throw new Error("Expected response body");
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+
+    // Read until we get our marker or timeout
+    let buffer = "";
+    const deadline = Date.now() + 2_000;
+    while (Date.now() < deadline) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      if (buffer.includes(marker)) break;
+    }
+
+    controller.abort();
+    reader.releaseLock();
+
+    expect(buffer).toContain(marker);
+    expect(buffer).toContain("data: ");
+  });
+
+  test("GET /logs?server=<name> streams backfill from pool", async () => {
+    socketPath = tmpSocket();
+    const pool = {
+      ...mockPool(),
+      getStderrLines: () => [{ timestamp: 1000, line: "pool-line" }],
+    };
+    server = new IpcServer(pool as never, mockConfig(), mockDb(), null, opts());
+    server.start(socketPath);
+
+    const controller = new AbortController();
+    const res = await fetch("http://localhost/logs?server=myserver&lines=5", {
+      method: "GET",
+      unix: socketPath,
+      signal: controller.signal,
+    } as RequestInit);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
+
+    if (!res.body) throw new Error("Expected response body");
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+
+    let buffer = "";
+    const deadline = Date.now() + 2_000;
+    while (Date.now() < deadline) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      if (buffer.includes("pool-line")) break;
+    }
+
+    controller.abort();
+    reader.releaseLock();
+
+    expect(buffer).toContain("pool-line");
   });
 });

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -61,7 +61,7 @@ import { z } from "zod/v4";
 import type { AliasServer } from "./alias-server";
 import { startCallbackServer } from "./auth/callback-server";
 import { McpOAuthProvider } from "./auth/oauth-provider";
-import { getDaemonLogLines } from "./daemon-log";
+import { getDaemonLogLines, subscribeDaemonLogs } from "./daemon-log";
 import type { StateDb } from "./db/state";
 import { metrics } from "./metrics";
 import { getPortHolder } from "./port-holder";
@@ -155,6 +155,11 @@ export class IpcServer {
           return new Response(metrics.toPrometheusText(), {
             headers: { "content-type": "text/plain; version=0.0.4; charset=utf-8" },
           });
+        }
+
+        // GET /logs — SSE stream for real-time log tailing
+        if (url.pathname === "/logs" && req.method === "GET") {
+          return self.handleLogsSSE(url);
         }
 
         if (req.method !== "POST") {
@@ -887,6 +892,84 @@ export class IpcServer {
       this.draining = true;
       this.startDrainTimeout();
       return { ok: true };
+    });
+  }
+
+  /**
+   * Handle GET /logs — Server-Sent Events stream for real-time log tailing.
+   *
+   * Query params:
+   *   server=<name>  — stream stderr from a specific MCP server
+   *   daemon=true    — stream daemon logs
+   *   lines=<n>      — number of initial backfill lines (default 50)
+   *   since=<ts>     — only backfill lines after this timestamp (ms)
+   */
+  private handleLogsSSE(url: URL): Response {
+    const serverName = url.searchParams.get("server");
+    const isDaemon = url.searchParams.get("daemon") === "true";
+    const lines = Number(url.searchParams.get("lines") ?? "50");
+    const since = url.searchParams.has("since") ? Number(url.searchParams.get("since")) : undefined;
+
+    if (!serverName && !isDaemon) {
+      return new Response("Missing ?server=<name> or ?daemon=true", { status: 400 });
+    }
+
+    let unsubscribe: (() => void) | undefined;
+
+    const stream = new ReadableStream({
+      start: (controller) => {
+        const encoder = new TextEncoder();
+        const send = (entry: { timestamp: number; line: string }) => {
+          try {
+            const data = JSON.stringify({ timestamp: entry.timestamp, line: entry.line });
+            controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+          } catch {
+            // Stream closed — clean up
+            unsubscribe?.();
+          }
+        };
+
+        // Backfill initial lines
+        if (isDaemon) {
+          let backfill = getDaemonLogLines(lines);
+          if (since !== undefined) {
+            backfill = backfill.filter((l) => l.timestamp > since);
+          }
+          for (const entry of backfill) {
+            send(entry);
+          }
+        } else if (serverName) {
+          let backfill = this.pool.getStderrLines(serverName, since === undefined ? lines : undefined);
+          if (since !== undefined) {
+            backfill = backfill.filter((l) => l.timestamp > since);
+            if (backfill.length > lines) backfill = backfill.slice(-lines);
+          }
+          for (const entry of backfill) {
+            send(entry);
+          }
+        }
+
+        // Subscribe to new lines
+        if (isDaemon) {
+          unsubscribe = subscribeDaemonLogs((entry) => send(entry));
+        } else if (serverName) {
+          unsubscribe = this.pool.subscribeStderr((server, entry) => {
+            if (server !== serverName) return;
+            send(entry);
+          });
+        }
+      },
+      cancel: () => {
+        unsubscribe?.();
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+        connection: "keep-alive",
+      },
     });
   }
 

--- a/packages/daemon/src/server-pool.ts
+++ b/packages/daemon/src/server-pool.ts
@@ -438,6 +438,11 @@ export class ServerPool {
     return this.stderrBuffer.getLines(server, limit);
   }
 
+  /** Subscribe to new stderr lines across all servers. Returns an unsubscribe function. */
+  subscribeStderr(fn: (server: string, entry: { timestamp: number; line: string }) => void): () => void {
+    return this.stderrBuffer.subscribe(fn);
+  }
+
   /** List all configured servers with status */
   listServers(): ServerStatus[] {
     const servers: ServerStatus[] = [...this.connections.values()].map((conn) => {

--- a/packages/daemon/src/stderr-buffer.spec.ts
+++ b/packages/daemon/src/stderr-buffer.spec.ts
@@ -80,4 +80,50 @@ describe("StderrRingBuffer", () => {
     expect(buf.getLines("s1")).toEqual([]);
     expect(buf.getLines("s2")).toEqual([]);
   });
+
+  test("subscribe receives new entries with server name", () => {
+    const buf = new StderrRingBuffer();
+    const received: Array<{ server: string; line: string }> = [];
+
+    buf.subscribe((server, entry) => {
+      received.push({ server, line: entry.line });
+    });
+
+    buf.push("s1", "hello");
+    buf.push("s2", "world");
+
+    expect(received).toHaveLength(2);
+    expect(received[0]).toEqual({ server: "s1", line: "hello" });
+    expect(received[1]).toEqual({ server: "s2", line: "world" });
+  });
+
+  test("unsubscribe stops notifications", () => {
+    const buf = new StderrRingBuffer();
+    const received: string[] = [];
+
+    const unsub = buf.subscribe((_server, entry) => {
+      received.push(entry.line);
+    });
+
+    buf.push("s1", "before");
+    unsub();
+    buf.push("s1", "after");
+
+    expect(received).toEqual(["before"]);
+  });
+
+  test("subscriber errors do not break push", () => {
+    const buf = new StderrRingBuffer();
+    const received: string[] = [];
+
+    buf.subscribe(() => {
+      throw new Error("boom");
+    });
+    buf.subscribe((_server, entry) => {
+      received.push(entry.line);
+    });
+
+    buf.push("s1", "still works");
+    expect(received).toEqual(["still works"]);
+  });
 });

--- a/packages/daemon/src/stderr-buffer.ts
+++ b/packages/daemon/src/stderr-buffer.ts
@@ -15,9 +15,12 @@ export interface StderrLine {
 
 const DEFAULT_CAPACITY = 100;
 
+export type StderrSubscriber = (server: string, entry: StderrLine) => void;
+
 export class StderrRingBuffer {
   private buffers = new Map<string, CircularBuffer>();
   private capacity: number;
+  private subscribers = new Set<StderrSubscriber>();
 
   constructor(capacity = DEFAULT_CAPACITY) {
     this.capacity = capacity;
@@ -32,7 +35,22 @@ export class StderrRingBuffer {
     }
     const entry: StderrLine = { timestamp: Date.now(), line };
     buf.push(entry);
+    for (const fn of this.subscribers) {
+      try {
+        fn(server, entry);
+      } catch {
+        // subscriber errors must not break the push path
+      }
+    }
     return entry;
+  }
+
+  /** Subscribe to new lines across all servers. Returns an unsubscribe function. */
+  subscribe(fn: StderrSubscriber): () => void {
+    this.subscribers.add(fn);
+    return () => {
+      this.subscribers.delete(fn);
+    };
   }
 
   /** Get lines for a server in chronological order. */


### PR DESCRIPTION
## Summary
- Add `GET /logs` SSE endpoint to the daemon IPC server with `?server=<name>` or `?daemon=true` query params for real-time log streaming
- Replace polling-based `mcx logs -f` follow mode with push-based SSE consumption via new `openLogStream()` helper in `@mcp-cli/core`
- Add subscribe/unsubscribe mechanism to `StderrRingBuffer` and daemon log module for push notifications when new lines arrive

## Test plan
- [x] `StderrRingBuffer.subscribe()` receives entries, unsubscribe stops notifications, subscriber errors don't break push
- [x] `GET /logs` without params returns 400
- [x] `GET /logs?daemon=true` returns SSE content-type and streams backfill lines
- [x] `GET /logs?server=<name>` returns SSE stream with pool backfill
- [x] `cmdLogs` follow mode calls `openLogStream` with correct params for both server and daemon modes
- [x] `streamLogsSSE` prints entries, handles AbortError gracefully, re-throws other errors
- [x] All 3336 existing tests pass, typecheck clean, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)