### PR TITLE
feat(alias): enable cross-alias composition with cycle detection (fixes #104)

### DIFF
--- a/packages/command/src/alias-runner.ts
+++ b/packages/command/src/alias-runner.ts
@@ -16,6 +16,7 @@ import {
   bundleAlias,
   createAliasCache,
   executeAliasBundled,
+  extractContent,
   ipcCall,
   isDefineAlias,
   options,
@@ -131,20 +132,5 @@ function createMcpProxy(): McpProxy {
   });
 }
 
-export function extractContent(result: unknown): unknown {
-  // MCP results: { content: [{type: "text", text: "..."}] }
-  // Unwrap to actual content for ergonomic alias authoring
-  if (result && typeof result === "object" && "content" in result) {
-    const { content } = result as { content: Array<{ type: string; text?: string }> };
-    if (Array.isArray(content) && content.length === 1 && content[0].type === "text" && content[0].text) {
-      try {
-        return JSON.parse(content[0].text);
-      } catch {
-        return content[0].text;
-      }
-    }
-    // Multiple content items — return array of text
-    return content.filter((c) => c.type === "text").map((c) => c.text);
-  }
-  return result;
-}
+// extractContent is now imported from @mcp-cli/core and re-exported for test compatibility
+export { extractContent } from "@mcp-cli/core";

--- a/packages/core/src/alias.spec.ts
+++ b/packages/core/src/alias.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { DEFINE_ALIAS_SENTINEL, isDefineAlias } from "./alias";
+import { DEFINE_ALIAS_SENTINEL, extractContent, isDefineAlias } from "./alias";
 
 describe("DEFINE_ALIAS_SENTINEL", () => {
   test("is the expected string", () => {
@@ -33,5 +33,54 @@ describe("isDefineAlias", () => {
 
   test("returns false for partial match without open paren", () => {
     expect(isDefineAlias("const defineAlias = 42")).toBe(false);
+  });
+});
+
+describe("extractContent", () => {
+  test("unwraps single text content with JSON parsing", () => {
+    const result = { content: [{ type: "text", text: '{"id":1,"name":"test"}' }] };
+    expect(extractContent(result)).toEqual({ id: 1, name: "test" });
+  });
+
+  test("unwraps single text content as plain string when not JSON", () => {
+    const result = { content: [{ type: "text", text: "hello world" }] };
+    expect(extractContent(result)).toBe("hello world");
+  });
+
+  test("returns array of text for multiple content items", () => {
+    const result = {
+      content: [
+        { type: "text", text: "line 1" },
+        { type: "text", text: "line 2" },
+      ],
+    };
+    expect(extractContent(result)).toEqual(["line 1", "line 2"]);
+  });
+
+  test("filters out non-text content items", () => {
+    const result = {
+      content: [
+        { type: "image", text: "ignored" },
+        { type: "text", text: "only text" },
+      ],
+    };
+    expect(extractContent(result)).toEqual(["only text"]);
+  });
+
+  test("passes through non-MCP values unchanged", () => {
+    expect(extractContent("raw string")).toBe("raw string");
+    expect(extractContent(42)).toBe(42);
+    expect(extractContent(null)).toBe(null);
+    expect(extractContent(undefined)).toBe(undefined);
+  });
+
+  test("handles content without text field", () => {
+    const result = { content: [{ type: "text" }] };
+    expect(extractContent(result)).toEqual([]);
+  });
+
+  test("handles empty content array", () => {
+    const result = { content: [] };
+    expect(extractContent(result)).toEqual([]);
   });
 });

--- a/packages/core/src/alias.ts
+++ b/packages/core/src/alias.ts
@@ -58,3 +58,25 @@ export interface AliasDefinition<I = unknown, O = unknown> {
 
 /** Alias type discriminant for DB and IPC */
 export type AliasType = "freeform" | "defineAlias";
+
+/**
+ * Unwrap MCP tool call result content for ergonomic alias authoring.
+ *
+ * MCP results look like: { content: [{type: "text", text: "..."}] }
+ * This extracts the actual value, attempting JSON parse on text content.
+ */
+export function extractContent(result: unknown): unknown {
+  if (result && typeof result === "object" && "content" in result) {
+    const { content } = result as { content: Array<{ type: string; text?: string }> };
+    if (Array.isArray(content) && content.length === 1 && content[0].type === "text" && content[0].text) {
+      try {
+        return JSON.parse(content[0].text);
+      } catch {
+        return content[0].text;
+      }
+    }
+    // Multiple content items — return array of text
+    return content.filter((c) => c.type === "text").map((c) => c.text);
+  }
+  return result;
+}

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -78,6 +78,8 @@ export const CallToolParamsSchema = z.object({
   tool: z.string(),
   arguments: z.record(z.string(), z.unknown()).optional().default({}),
   timeoutMs: z.number().optional(),
+  /** Alias call chain for cycle detection in cross-alias composition. */
+  callChain: z.array(z.string()).optional(),
 });
 
 export const ListToolsParamsSchema = z.object({

--- a/packages/daemon/src/alias-executor.spec.ts
+++ b/packages/daemon/src/alias-executor.spec.ts
@@ -155,6 +155,95 @@ describe("alias-executor subprocess protocol", () => {
     }
   });
 
+  test("cycle detection: errors when alias is already in callChain", async () => {
+    const dir = makeTmpDir();
+    const scriptPath = join(dir, "cyclic.ts");
+    writeFileSync(
+      scriptPath,
+      [
+        'import { defineAlias, z } from "mcp-cli";',
+        "defineAlias({",
+        '  name: "cyclic",',
+        "  input: z.object({ x: z.string() }),",
+        "  fn: (input) => input.x,",
+        "});",
+      ].join("\n"),
+    );
+
+    const { js } = await bundleAlias(scriptPath);
+    const { stdout, exitCode } = await runExecutor({
+      bundledJs: js,
+      input: { x: "test" },
+      isDefineAlias: true,
+      aliasName: "cyclic",
+      callChain: ["parent", "cyclic"],
+    });
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error).toContain("Alias cycle detected");
+    expect(parsed.error).toContain("parent → cyclic → cyclic");
+  });
+
+  test("depth limit: errors when callChain exceeds max depth", async () => {
+    const dir = makeTmpDir();
+    const scriptPath = join(dir, "deep.ts");
+    writeFileSync(
+      scriptPath,
+      [
+        'import { defineAlias, z } from "mcp-cli";',
+        "defineAlias({",
+        '  name: "deep",',
+        "  input: z.object({ x: z.string() }),",
+        "  fn: (input) => input.x,",
+        "});",
+      ].join("\n"),
+    );
+
+    const { js } = await bundleAlias(scriptPath);
+    const chain = Array.from({ length: 16 }, (_, i) => `alias-${i}`);
+    const { stdout, exitCode } = await runExecutor({
+      bundledJs: js,
+      input: { x: "test" },
+      isDefineAlias: true,
+      aliasName: "deep",
+      callChain: chain,
+    });
+
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error).toContain("too deep");
+  });
+
+  test("no cycle: succeeds when alias is not in callChain", async () => {
+    const dir = makeTmpDir();
+    const scriptPath = join(dir, "nocycle.ts");
+    writeFileSync(
+      scriptPath,
+      [
+        'import { defineAlias, z } from "mcp-cli";',
+        "defineAlias({",
+        '  name: "nocycle",',
+        "  input: z.object({ x: z.string() }),",
+        "  fn: (input) => input.x,",
+        "});",
+      ].join("\n"),
+    );
+
+    const { js } = await bundleAlias(scriptPath);
+    const { stdout, exitCode } = await runExecutor({
+      bundledJs: js,
+      input: { x: "hello" },
+      isDefineAlias: true,
+      aliasName: "nocycle",
+      callChain: ["parent", "other"],
+    });
+
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.result).toBe("hello");
+  });
+
   test("console.log in alias script does not corrupt stdout JSON", async () => {
     const dir = makeTmpDir();
     const scriptPath = join(dir, "noisy.ts");

--- a/packages/daemon/src/alias-executor.ts
+++ b/packages/daemon/src/alias-executor.ts
@@ -8,16 +8,25 @@
  *
  * This provides fault isolation: sync infinite loops, prototype
  * pollution, or crashes kill this subprocess, not the daemon.
+ *
+ * Supports alias composition: when an alias calls another alias via
+ * mcp._aliases.tool(), the proxy makes a real IPC call back to the
+ * daemon. A callChain tracks the alias call stack for cycle detection.
  */
 
 import { readFile } from "node:fs/promises";
 import {
   type AliasContext,
+  type McpProxy,
   createAliasCache,
   executeAliasBundled,
-  stubProxy,
+  extractContent,
+  ipcCall,
   validateAliasBundled,
 } from "@mcp-cli/core";
+
+/** Maximum depth for alias composition to prevent runaway chains. */
+const MAX_CALL_DEPTH = 16;
 
 interface ExecutorInput {
   bundledJs: string;
@@ -25,6 +34,32 @@ interface ExecutorInput {
   isDefineAlias: boolean;
   mode?: "execute" | "validate";
   aliasName?: string;
+  /** Chain of alias names that led to this execution, for cycle detection. */
+  callChain?: string[];
+}
+
+/**
+ * Create a real MCP proxy that calls tools via IPC back to the daemon.
+ * For _aliases calls, includes the callChain for cycle detection.
+ */
+function createExecutorProxy(callChain: string[]): McpProxy {
+  return new Proxy({} as McpProxy, {
+    get(_target, serverName: string) {
+      return new Proxy({} as Record<string, (args?: Record<string, unknown>) => Promise<unknown>>, {
+        get(_inner, toolName: string) {
+          return async (toolArgs?: Record<string, unknown>) => {
+            const result = await ipcCall("callTool", {
+              server: serverName,
+              tool: toolName,
+              arguments: toolArgs ?? {},
+              callChain,
+            });
+            return extractContent(result);
+          };
+        },
+      });
+    },
+  });
 }
 
 async function main(): Promise<void> {
@@ -38,7 +73,7 @@ async function main(): Promise<void> {
 
   // Read input from stdin
   const stdinText = await Bun.stdin.text();
-  const { bundledJs, input, isDefineAlias, mode, aliasName } = JSON.parse(stdinText) as ExecutorInput;
+  const { bundledJs, input, isDefineAlias, mode, aliasName, callChain } = JSON.parse(stdinText) as ExecutorInput;
 
   if (mode === "validate") {
     const validation = await validateAliasBundled(bundledJs);
@@ -46,15 +81,31 @@ async function main(): Promise<void> {
     return;
   }
 
+  const currentAlias = aliasName ?? "unknown";
+  const chain = callChain ?? [];
+
+  // Cycle detection: check if this alias is already in the call chain
+  if (chain.includes(currentAlias)) {
+    throw new Error(`Alias cycle detected: ${[...chain, currentAlias].join(" → ")}`);
+  }
+
+  // Depth limit
+  if (chain.length >= MAX_CALL_DEPTH) {
+    throw new Error(`Alias call chain too deep (max ${MAX_CALL_DEPTH}): ${[...chain, currentAlias].join(" → ")}`);
+  }
+
+  // Build the updated chain including the current alias
+  const updatedChain = [...chain, currentAlias];
+
   const ctx: AliasContext = {
-    mcp: stubProxy,
+    mcp: createExecutorProxy(updatedChain),
     args:
       typeof input === "object" && input !== null
         ? Object.fromEntries(Object.entries(input as Record<string, unknown>).map(([k, v]) => [k, String(v)]))
         : {},
     file: (path: string) => readFile(path, "utf-8"),
     json: async (path: string) => JSON.parse(await readFile(path, "utf-8")),
-    cache: createAliasCache(aliasName ?? "unknown"),
+    cache: createAliasCache(currentAlias),
   };
 
   const result = await executeAliasBundled(bundledJs, input, ctx, isDefineAlias);

--- a/packages/daemon/src/alias-server.spec.ts
+++ b/packages/daemon/src/alias-server.spec.ts
@@ -258,6 +258,28 @@ describe("AliasServer", () => {
     expect(tools).toHaveLength(0);
   });
 
+  test("callToolWithChain returns error for unknown alias", async () => {
+    using opts = testOptions();
+    const { db: testDb } = setupAlias(opts);
+    server = new AliasServer(testDb);
+    await server.start();
+
+    const result = await server.callToolWithChain("nonexistent", {}, []);
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("not found");
+  });
+
+  test("callToolWithChain executes alias with call chain", async () => {
+    using opts = testOptions();
+    const { db: testDb } = setupAlias(opts);
+    server = new AliasServer(testDb);
+    await server.start();
+
+    const result = await server.callToolWithChain("greet", { name: "Chain" }, ["parent-alias"]);
+    expect(result.isError).toBeUndefined();
+    expect(JSON.parse(result.content[0].text)).toEqual({ message: "Hello, Chain!" });
+  });
+
   test("refresh() updates tool list after alias save", async () => {
     using opts = testOptions();
     db = new StateDb(opts.DB_PATH);

--- a/packages/daemon/src/alias-server.ts
+++ b/packages/daemon/src/alias-server.ts
@@ -149,8 +149,43 @@ export class AliasServer {
     this.clientTransport = null;
   }
 
+  /**
+   * Call an alias tool with call-chain tracking for cross-alias composition.
+   * Used by the IPC server when a callTool request includes a callChain.
+   * Returns MCP-formatted result (same shape as pool.callTool).
+   */
+  async callToolWithChain(
+    name: string,
+    args: Record<string, unknown>,
+    callChain: string[],
+  ): Promise<{ content: Array<{ type: "text"; text: string }>; isError?: boolean }> {
+    const aliasDef = this.currentAliases.find((a) => a.name === name);
+    if (!aliasDef) {
+      return {
+        content: [{ type: "text" as const, text: `Alias "${name}" not found` }],
+        isError: true,
+      };
+    }
+
+    try {
+      const result = await this.executeInSubprocess(aliasDef, args, callChain);
+      const text = typeof result === "string" ? result : JSON.stringify(result, null, 2);
+      return { content: [{ type: "text" as const, text }] };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: "text" as const, text: `Error: ${message}` }],
+        isError: true,
+      };
+    }
+  }
+
   /** Execute an alias in a subprocess for fault isolation. */
-  private async executeInSubprocess(aliasDef: AliasToolDef, args: Record<string, unknown>): Promise<unknown> {
+  private async executeInSubprocess(
+    aliasDef: AliasToolDef,
+    args: Record<string, unknown>,
+    callChain?: string[],
+  ): Promise<unknown> {
     // Load bundled JS lazily from DB (not held in memory on tool list)
     const dbAlias = this.db.getAlias(aliasDef.name);
     let bundledJs = dbAlias?.bundledJs;
@@ -196,6 +231,7 @@ export class AliasServer {
       input: args,
       isDefineAlias: aliasDef.isDefineAlias,
       aliasName: aliasDef.name,
+      ...(callChain && callChain.length > 0 ? { callChain } : {}),
     });
 
     return this.spawnExecutor(payload, 30_000) as Promise<unknown>;

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -18,6 +18,7 @@ import type {
   ToolInfo,
 } from "@mcp-cli/core";
 import {
+  ALIAS_SERVER_NAME,
   AuthStatusParamsSchema,
   BUILD_VERSION,
   CallToolParamsSchema,
@@ -360,13 +361,19 @@ export class IpcServer {
     });
 
     this.handlers.set("callTool", async (params, ctx) => {
-      const { server, tool, arguments: args, timeoutMs } = CallToolParamsSchema.parse(params);
+      const { server, tool, arguments: args, timeoutMs, callChain } = CallToolParamsSchema.parse(params);
       const toolSpan = ctx.span.child(`tool.${server}.${tool}`);
       toolSpan.setAttribute("tool.server", server);
       toolSpan.setAttribute("tool.name", tool);
+      if (callChain) toolSpan.setAttribute("alias.callChainDepth", callChain.length);
       const toolLabels = { server, tool };
       try {
-        const result = await this.pool.callTool(server, tool, args, timeoutMs);
+        // For cross-alias composition: route _aliases calls with a callChain
+        // directly through the alias server to thread cycle detection.
+        const result =
+          callChain && server === ALIAS_SERVER_NAME && this.aliasServer
+            ? await this.aliasServer.callToolWithChain(tool, args, callChain)
+            : await this.pool.callTool(server, tool, args, timeoutMs);
         toolSpan.setStatus("OK");
         const finished = toolSpan.end();
         // Dual-write: usage_stats (Phase 1 compat) + spans table


### PR DESCRIPTION
## Summary
- Aliases executed via the `_aliases` virtual server can now call other aliases through `mcp._aliases.tool_name()` — the executor subprocess connects back to the daemon via IPC instead of using a stub proxy that returned `undefined`
- Added call chain tracking with cycle detection and a max depth of 16 to prevent infinite recursion in alias-calls-alias chains
- Moved `extractContent` (MCP content unwrapping) from command package to core for shared use by both CLI runner and daemon executor

## Test plan
- [x] Cycle detection: executor errors with descriptive message when alias appears in its own call chain
- [x] Depth limit: executor errors when call chain exceeds 16
- [x] No false positives: aliases succeed when called with a non-cyclic call chain
- [x] `callToolWithChain` returns MCP-formatted error for unknown aliases
- [x] `callToolWithChain` executes aliases with call chain propagation
- [x] `extractContent` tests moved to core with full coverage (JSON unwrap, plain text, multi-content, passthrough)
- [x] All 3342 existing tests pass, coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)