### PR TITLE
feat(import): add --from-keychain to discover OAuth servers from macOS Keychain (fixes #113)

### DIFF
--- a/packages/command/src/commands/import.spec.ts
+++ b/packages/command/src/commands/import.spec.ts
@@ -7,10 +7,15 @@ import { testOptions } from "../../../../test/test-options";
 import { readConfigFile, writeConfigFile } from "./config-file";
 import {
   type ClaudeConfig,
+  type KeychainOAuthEntry,
   cmdAddFromClaudeDesktop,
   cmdImport,
   collectClaudeServers,
   importFromClaude,
+  importFromKeychain,
+  inferTransportType,
+  keychainEntryToServerConfig,
+  readKeychainOAuthEntries,
 } from "./import";
 
 /**
@@ -771,6 +776,11 @@ describe("mcx import", () => {
       await cmdAddFromClaudeDesktop(["-h"]);
     });
 
+    test("--from-keychain flag is recognized", async () => {
+      // On non-macOS or without keychain, this should just print "no OAuth servers"
+      await cmdImport(["--from-keychain"]);
+    });
+
     test("imports all transport types", async () => {
       using opts = testOptions();
       const configPath = join(opts.dir, "desktop-all.json");
@@ -800,6 +810,186 @@ describe("mcx import", () => {
 
       const result = readConfigFile(targetPath);
       expect(result.mcpServers?.notion).toEqual(FIXTURES.notion);
+    });
+  });
+
+  describe("--from-keychain: readKeychainOAuthEntries", () => {
+    const sampleKeychainData = JSON.stringify({
+      mcpOAuth: {
+        "asana|abc123": {
+          serverName: "asana",
+          serverUrl: "https://mcp.asana.com/sse",
+          clientId: "44EBfNxyz",
+          accessToken: "tok_asana",
+        },
+        "sentry|def456": {
+          serverName: "sentry",
+          serverUrl: "https://mcp.sentry.dev/mcp",
+          clientId: "lwL7Cdabc",
+          accessToken: "tok_sentry",
+        },
+      },
+    });
+
+    test("parses entries from keychain JSON", async () => {
+      const entries = await readKeychainOAuthEntries(async () => sampleKeychainData);
+      expect(entries).toHaveLength(2);
+      expect(entries.map((e) => e.serverName).sort()).toEqual(["asana", "sentry"]);
+      expect(entries.find((e) => e.serverName === "asana")?.serverUrl).toBe("https://mcp.asana.com/sse");
+      expect(entries.find((e) => e.serverName === "asana")?.clientId).toBe("44EBfNxyz");
+    });
+
+    test("returns empty array when keychain returns null", async () => {
+      const entries = await readKeychainOAuthEntries(async () => null);
+      expect(entries).toEqual([]);
+    });
+
+    test("returns empty array when no mcpOAuth key", async () => {
+      const entries = await readKeychainOAuthEntries(async () => JSON.stringify({ otherStuff: true }));
+      expect(entries).toEqual([]);
+    });
+
+    test("returns empty array on invalid JSON", async () => {
+      const entries = await readKeychainOAuthEntries(async () => "not valid json{{{");
+      expect(entries).toEqual([]);
+    });
+
+    test("skips entries missing required fields", async () => {
+      const data = JSON.stringify({
+        mcpOAuth: {
+          "missing-url|123": {
+            serverName: "test",
+            clientId: "abc",
+            accessToken: "tok",
+            // serverUrl is missing
+          },
+          "valid|456": {
+            serverName: "valid",
+            serverUrl: "https://example.com/mcp",
+            clientId: "xyz",
+            accessToken: "tok",
+          },
+        },
+      });
+      const entries = await readKeychainOAuthEntries(async () => data);
+      expect(entries).toHaveLength(1);
+      expect(entries[0].serverName).toBe("valid");
+    });
+  });
+
+  describe("--from-keychain: inferTransportType", () => {
+    test("returns sse for URLs ending with /sse", () => {
+      expect(inferTransportType("https://mcp.asana.com/sse")).toBe("sse");
+      expect(inferTransportType("https://mcp.atlassian.com/v1/sse")).toBe("sse");
+    });
+
+    test("returns http for other URLs", () => {
+      expect(inferTransportType("https://mcp.sentry.dev/mcp")).toBe("http");
+      expect(inferTransportType("https://mcp.notion.com/mcp")).toBe("http");
+    });
+
+    test("returns http for invalid URLs", () => {
+      expect(inferTransportType("not a url")).toBe("http");
+    });
+  });
+
+  describe("--from-keychain: keychainEntryToServerConfig", () => {
+    test("creates SSE config for /sse URLs", () => {
+      const config = keychainEntryToServerConfig({
+        serverName: "asana",
+        serverUrl: "https://mcp.asana.com/sse",
+        clientId: "44EBfN",
+      });
+      expect(config).toEqual({ type: "sse", url: "https://mcp.asana.com/sse" });
+    });
+
+    test("creates HTTP config for non-sse URLs", () => {
+      const config = keychainEntryToServerConfig({
+        serverName: "sentry",
+        serverUrl: "https://mcp.sentry.dev/mcp",
+        clientId: "lwL7Cd",
+      });
+      expect(config).toEqual({ type: "http", url: "https://mcp.sentry.dev/mcp" });
+    });
+  });
+
+  describe("--from-keychain: importFromKeychain", () => {
+    const keychainJson = JSON.stringify({
+      mcpOAuth: {
+        "asana|abc123": {
+          serverName: "asana",
+          serverUrl: "https://mcp.asana.com/sse",
+          clientId: "44EBfNxyz",
+          accessToken: "tok_asana",
+        },
+        "sentry|def456": {
+          serverName: "sentry",
+          serverUrl: "https://mcp.sentry.dev/mcp",
+          clientId: "lwL7Cdabc",
+          accessToken: "tok_sentry",
+        },
+      },
+    });
+
+    test("imports new servers from keychain", async () => {
+      using opts = testOptions();
+      await importFromKeychain("user", async () => keychainJson);
+
+      const result = readConfigFile(join(opts.dir, "servers.json"));
+      expect(result.mcpServers?.asana).toEqual({ type: "sse", url: "https://mcp.asana.com/sse" });
+      expect(result.mcpServers?.sentry).toEqual({ type: "http", url: "https://mcp.sentry.dev/mcp" });
+    });
+
+    test("skips servers that are already configured by URL", async () => {
+      using opts = testOptions();
+      // Pre-configure asana with the same URL
+      writeConfigFile(join(opts.dir, "servers.json"), {
+        mcpServers: {
+          "my-asana": { type: "sse" as const, url: "https://mcp.asana.com/sse" },
+        },
+      });
+
+      await importFromKeychain("user", async () => keychainJson);
+
+      const result = readConfigFile(join(opts.dir, "servers.json"));
+      // asana should NOT be added (URL already exists under "my-asana")
+      expect(result.mcpServers?.asana).toBeUndefined();
+      // my-asana should still be there
+      expect(result.mcpServers?.["my-asana"]).toBeDefined();
+      // sentry should be added
+      expect(result.mcpServers?.sentry).toEqual({ type: "http", url: "https://mcp.sentry.dev/mcp" });
+    });
+
+    test("handles empty keychain gracefully", async () => {
+      using opts = testOptions();
+      await importFromKeychain("user", async () => null);
+      // Should not throw, just print a message
+    });
+
+    test("handles keychain with no entries", async () => {
+      using opts = testOptions();
+      await importFromKeychain("user", async () => JSON.stringify({ mcpOAuth: {} }));
+    });
+
+    test("preserves URL exactly as-is from keychain", async () => {
+      using opts = testOptions();
+      const data = JSON.stringify({
+        mcpOAuth: {
+          "test|1": {
+            serverName: "test",
+            serverUrl: "https://WEIRD.example.COM/Path/To/MCP",
+            clientId: "abc",
+            accessToken: "tok",
+          },
+        },
+      });
+      await importFromKeychain("user", async () => data);
+
+      const result = readConfigFile(join(opts.dir, "servers.json"));
+      expect(result.mcpServers?.test).toBeDefined();
+      if (result.mcpServers?.test && "url" in result.mcpServers.test) {
+        expect(result.mcpServers.test.url).toBe("https://WEIRD.example.COM/Path/To/MCP");
+      }
     });
   });
 });

--- a/packages/command/src/commands/import.ts
+++ b/packages/command/src/commands/import.ts
@@ -19,7 +19,13 @@ import type { McpConfigFile, ServerConfig, ServerConfigMap } from "@mcp-cli/core
 import { PROJECT_MCP_FILENAME, findFileUpward, options } from "@mcp-cli/core";
 import { printError } from "../output";
 import { parseScope } from "../parse";
-import { CONFIG_SCOPES_NO_LOCAL, type ConfigScope, addServerToConfig, resolveConfigPath } from "./config-file";
+import {
+  CONFIG_SCOPES_NO_LOCAL,
+  type ConfigScope,
+  addServerToConfig,
+  readConfigFile,
+  resolveConfigPath,
+} from "./config-file";
 
 /** Shape of ~/.claude.json relevant to server config */
 export interface ClaudeConfig {
@@ -73,11 +79,161 @@ export function collectClaudeServers(config: ClaudeConfig, cwd: string, all: boo
   return { servers, sources, warnings };
 }
 
+/** A single OAuth entry from the macOS Keychain */
+export interface KeychainOAuthEntry {
+  serverName: string;
+  serverUrl: string;
+  clientId: string;
+}
+
+/** Raw keychain data shape for mcpOAuth entries */
+interface KeychainOAuthData {
+  mcpOAuth?: Record<
+    string,
+    {
+      serverName: string;
+      serverUrl: string;
+      clientId: string;
+      accessToken: string;
+    }
+  >;
+}
+
+/**
+ * Read all OAuth server entries from the Claude Code macOS Keychain.
+ * Returns an empty array on non-macOS, missing keychain, or parse errors.
+ *
+ * @param readKeychain - optional override for testing (returns raw JSON string or null)
+ */
+export async function readKeychainOAuthEntries(
+  readKeychain?: () => Promise<string | null>,
+): Promise<KeychainOAuthEntry[]> {
+  let raw: string | null;
+
+  if (readKeychain) {
+    raw = await readKeychain();
+  } else {
+    if (process.platform !== "darwin") return [];
+    try {
+      const proc = Bun.spawn(["security", "find-generic-password", "-s", "Claude Code-credentials", "-w"], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      raw = await new Response(proc.stdout).text();
+      const exitCode = await proc.exited;
+      if (exitCode !== 0) return [];
+      raw = raw.trim();
+    } catch {
+      return [];
+    }
+  }
+
+  if (!raw) return [];
+
+  try {
+    const data: KeychainOAuthData = JSON.parse(raw);
+    const mcpOAuth = data.mcpOAuth;
+    if (!mcpOAuth) return [];
+
+    const entries: KeychainOAuthEntry[] = [];
+    for (const entry of Object.values(mcpOAuth)) {
+      if (entry.serverUrl && entry.clientId && entry.serverName) {
+        entries.push({
+          serverName: entry.serverName,
+          serverUrl: entry.serverUrl,
+          clientId: entry.clientId,
+        });
+      }
+    }
+    return entries;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Determine transport type from a URL.
+ * URLs ending with /sse get SSE transport; everything else gets HTTP.
+ */
+export function inferTransportType(url: string): "http" | "sse" {
+  try {
+    const parsed = new URL(url);
+    return parsed.pathname.endsWith("/sse") ? "sse" : "http";
+  } catch {
+    return "http";
+  }
+}
+
+/**
+ * Build a ServerConfig from a keychain OAuth entry.
+ */
+export function keychainEntryToServerConfig(entry: KeychainOAuthEntry): ServerConfig {
+  const transport = inferTransportType(entry.serverUrl);
+  return {
+    type: transport,
+    url: entry.serverUrl,
+  };
+}
+
+/**
+ * Import OAuth servers discovered in the macOS Keychain.
+ * Checks existing config and only adds servers that aren't already present (by URL match).
+ */
+export async function importFromKeychain(
+  scope: ConfigScope,
+  readKeychain?: () => Promise<string | null>,
+): Promise<void> {
+  const entries = await readKeychainOAuthEntries(readKeychain);
+  if (entries.length === 0) {
+    console.error("No OAuth servers found in Claude Code keychain.");
+    return;
+  }
+
+  // Load existing config to check for already-configured servers
+  const configPath = resolveConfigPath(scope);
+  const existing = readConfigFile(configPath);
+  const existingServers = existing.mcpServers ?? {};
+
+  // Check each entry's URL against all existing server URLs
+  const existingUrls = new Set<string>();
+  for (const cfg of Object.values(existingServers)) {
+    if ("url" in cfg) {
+      existingUrls.add(cfg.url);
+    }
+  }
+
+  console.error(`Found ${entries.length} OAuth server(s) in Claude Code keychain:`);
+
+  let imported = 0;
+  for (const entry of entries) {
+    const shortClientId = entry.clientId.length > 6 ? `${entry.clientId.slice(0, 6)}...` : entry.clientId;
+
+    if (existingUrls.has(entry.serverUrl)) {
+      console.error(
+        `  ${entry.serverName.padEnd(12)} ${entry.serverUrl.padEnd(40)} (client: ${shortClientId})  ✓ already configured`,
+      );
+      continue;
+    }
+
+    const serverConfig = keychainEntryToServerConfig(entry);
+    addServerToConfig(scope, entry.serverName, serverConfig);
+    imported++;
+    console.error(`  ${entry.serverName.padEnd(12)} ${entry.serverUrl.padEnd(40)} (client: ${shortClientId})  → added`);
+  }
+
+  if (imported > 0) {
+    console.error(`\nImported ${imported} server(s).`);
+  } else {
+    console.error("\nAll servers already configured.");
+  }
+}
+
 export async function cmdImport(args: string[]): Promise<void> {
   // Parse flags
   let scope: ConfigScope | undefined;
   let claude = false;
   let all = false;
+  let fromKeychain = false;
   const positional: string[] = [];
 
   for (let i = 0; i < args.length; i++) {
@@ -88,6 +244,8 @@ export async function cmdImport(args: string[]): Promise<void> {
       claude = true;
     } else if (arg === "--all") {
       all = true;
+    } else if (arg === "--from-keychain") {
+      fromKeychain = true;
     } else if (arg === "--help" || arg === "-h") {
       printImportUsage();
       return;
@@ -96,6 +254,11 @@ export async function cmdImport(args: string[]): Promise<void> {
     } else {
       positional.push(arg);
     }
+  }
+
+  if (fromKeychain) {
+    await importFromKeychain(scope ?? "user");
+    return;
   }
 
   if (claude) {
@@ -284,10 +447,12 @@ Usage:
   mcx import <dir>                    Import from .mcp.json in directory (project scope)
   mcx import --claude                 Import from ~/.claude.json (global + matching projects)
   mcx import --claude --all           Import from ~/.claude.json (all projects)
+  mcx import --from-keychain          Discover OAuth servers from Claude Code's macOS Keychain
 
 Options:
   --claude, -c                        Read servers from Claude Code's ~/.claude.json
   --all                               With --claude: import from all projects, not just CWD
+  --from-keychain                     Auto-discover OAuth servers from macOS Keychain
   --scope user|project                Override target scope (default varies by source)
   -s                                  Shorthand for --scope
 


### PR DESCRIPTION
## Summary
- Adds `mcx import --from-keychain` flag that reads Claude Code's `mcpOAuth` entries from the macOS Keychain
- Checks each discovered server against existing config (by URL match) and only imports missing ones
- Infers transport type from URL (`/sse` → SSE, otherwise HTTP) and preserves URLs exactly as-is
- Supports `--scope` flag to control target config file

## Test plan
- [x] `readKeychainOAuthEntries` parses entries, handles null/empty/invalid JSON, skips entries with missing fields
- [x] `inferTransportType` correctly identifies SSE vs HTTP URLs
- [x] `keychainEntryToServerConfig` creates correct config for both transport types
- [x] `importFromKeychain` imports new servers, skips already-configured ones (by URL), preserves URLs exactly
- [x] `--from-keychain` flag recognized by `cmdImport` parser
- [x] All 3346 tests pass, coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)