### PR TITLE
perf(test): optimize test suite wall time and add aggregate ratchet (fixes #690)

### DIFF
--- a/packages/daemon/src/server-pool.spec.ts
+++ b/packages/daemon/src/server-pool.spec.ts
@@ -984,8 +984,11 @@ describe("ServerPool.updateConfig reconnect", () => {
     const updated = makeConfig({ a: { command: "cat" } });
     pool.updateConfig(updated);
 
-    // Wait for the async disconnect → reconnect chain
-    await new Promise((r) => setTimeout(r, 50));
+    // Poll until reconnect completes (replaces fixed sleep)
+    const deadline = Date.now() + 5000;
+    while (connectCount < 2 && Date.now() < deadline) {
+      await Bun.sleep(10);
+    }
 
     expect(connectCount).toBe(2);
   });
@@ -1007,7 +1010,8 @@ describe("ServerPool.updateConfig reconnect", () => {
     const updated = makeConfig({ a: { command: "cat" } });
     pool.updateConfig(updated);
 
-    await new Promise((r) => setTimeout(r, 50));
+    // Brief yield to allow any async reconnect to fire (negative assertion)
+    await Bun.sleep(50);
 
     // Should NOT have connected because the server wasn't connected before config change
     expect(connectCount).toBe(0);

--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -30,6 +30,14 @@ const GLOBAL_THRESHOLDS = {
 /** Per-file test time budget in milliseconds — no single file should exceed this */
 const PER_FILE_TIME_BUDGET_MS = 5_000;
 
+/**
+ * Aggregate test suite time budget in milliseconds.
+ * Sum of all non-excluded test file times (sequential sum) should stay below this.
+ * Uses sequential sum (not parallel wall time) for reproducibility across machines.
+ * Ratchet this down as optimizations land. Warns but never blocks commits.
+ */
+const AGGREGATE_TIME_BUDGET_MS = 60_000;
+
 /** Number of test files to profile concurrently — scales with available CPUs */
 const PROFILE_CONCURRENCY = Math.max(4, Math.min(navigator.hardwareConcurrency ?? 4, 32));
 
@@ -40,6 +48,7 @@ const PROFILE_CONCURRENCY = Math.max(4, Math.min(navigator.hardwareConcurrency ?
 const TIMING_EXCLUSIONS: Record<string, string> = {
   "test/daemon-integration.spec.ts": "Full daemon lifecycle integration tests",
   "test/stress.spec.ts": "Stress tests spawning real CLI processes",
+  "test/transport-errors.spec.ts": "Live daemon transport error integration tests",
   "packages/daemon/src/index.spec.ts": "13 in-process daemon instances for startup/shutdown/idle/reload",
   "packages/daemon/src/config/watcher.spec.ts": "FS polling integration tests with 8s timeouts",
 };
@@ -320,6 +329,21 @@ if (allTimings.length > 0) {
       console.warn(`  ${ms}ms  ${file}`);
     }
     console.warn("\nConsider extracting pure logic into unit tests or splitting the file.");
+  }
+
+  // --- Aggregate time ratchet (sequential sum of non-excluded files) ---
+  const nonExcludedTimings = allTimings.filter(
+    (t) => !Object.keys(TIMING_EXCLUSIONS).some((pattern) => t.file.endsWith(pattern)),
+  );
+  const aggregateMs = nonExcludedTimings.reduce((sum, t) => sum + t.ms, 0);
+  console.log(
+    `\nAggregate test time (non-excluded): ${(aggregateMs / 1000).toFixed(1)}s ` +
+      `(budget: ${(AGGREGATE_TIME_BUDGET_MS / 1000).toFixed(0)}s, ${nonExcludedTimings.length} files)`,
+  );
+  if (aggregateMs > AGGREGATE_TIME_BUDGET_MS) {
+    console.warn(
+      `\nWARN: Aggregate test time ${(aggregateMs / 1000).toFixed(1)}s exceeds ${(AGGREGATE_TIME_BUDGET_MS / 1000).toFixed(0)}s budget. Optimize slow test files or raise the budget if justified.`,
+    );
   }
 }
 

--- a/test/transport-errors.spec.ts
+++ b/test/transport-errors.spec.ts
@@ -10,9 +10,12 @@
  * 1. Walking err.cause chains to find the original system error code
  * 2. Pattern-matching SDK message formats (e.g., "Unable to connect")
  *
+ * Performance: all tests share a single daemon instance (started once in
+ * beforeAll) to avoid per-test daemon startup overhead (~5s each).
+ *
  * @see https://github.com/theshadow27/mcp-cli/issues/855
  */
-import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { chmodSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import type { TestDaemon } from "./harness";
@@ -37,23 +40,45 @@ async function getServerStatus(
 }
 
 // ---------------------------------------------------------------------------
+// Shared daemon — all transport error tests use a single daemon instance
+// with all server configs registered upfront.
+// ---------------------------------------------------------------------------
+
+let daemon: TestDaemon;
+
+beforeAll(async () => {
+  const dir = createTestDir();
+  const script = join(dir, "no-exec.sh");
+  writeFileSync(script, "#!/bin/sh\necho hello");
+  chmodSync(script, 0o644); // not executable
+
+  daemon = await startTestDaemon(
+    {
+      // Stdio servers
+      bogus: { command: "nonexistent-mcp-server-binary-xyz" },
+      noperm: { command: script },
+      crasher: { command: "bun", args: [resolve("test/exit-immediately.ts")] },
+      // HTTP servers
+      deadhttp: { type: "http", url: "http://127.0.0.1:19999/mcp" },
+      baddns: { type: "http", url: "http://this-host-does-not-resolve.invalid/mcp" },
+      // SSE server
+      deadsse: { type: "sse", url: "http://127.0.0.1:19998/events" },
+      // Healthy server (for listServers tests)
+      echo: { command: "bun", args: [resolve("test/echo-server.ts")] },
+    },
+    { dir },
+  );
+});
+
+afterAll(async () => {
+  await daemon?.kill();
+});
+
+// ---------------------------------------------------------------------------
 // Stdio transport errors
 // ---------------------------------------------------------------------------
 describe("Stdio transport errors", () => {
-  let daemon: TestDaemon | undefined;
-
-  afterEach(async () => {
-    if (daemon) {
-      await daemon.kill();
-      daemon = undefined;
-    }
-  });
-
   test("command not found → friendly message with command name and PATH hint", async () => {
-    daemon = await startTestDaemon({
-      bogus: { command: "nonexistent-mcp-server-binary-xyz" },
-    });
-
     const rpcError = await triggerConnect(daemon.socketPath, "bogus");
     expect(rpcError).toContain('command "nonexistent-mcp-server-binary-xyz" not found');
     expect(rpcError).toContain("PATH");
@@ -65,13 +90,6 @@ describe("Stdio transport errors", () => {
   });
 
   test("permission denied → friendly message with file path", async () => {
-    const dir = createTestDir();
-    const script = join(dir, "no-exec.sh");
-    writeFileSync(script, "#!/bin/sh\necho hello");
-    chmodSync(script, 0o644); // not executable
-
-    daemon = await startTestDaemon({ noperm: { command: script } }, { dir });
-
     const rpcError = await triggerConnect(daemon.socketPath, "noperm");
     expect(rpcError).toContain("permission denied");
 
@@ -81,10 +99,6 @@ describe("Stdio transport errors", () => {
   });
 
   test("process exits immediately → actionable exit message with command", async () => {
-    daemon = await startTestDaemon({
-      crasher: { command: "bun", args: [resolve("test/exit-immediately.ts")] },
-    });
-
     const rpcError = await triggerConnect(daemon.socketPath, "crasher");
     // The MCP SDK wraps the exit as "MCP error -32000: Connection closed".
     // wrapTransportError now matches this pattern and produces an actionable message.
@@ -103,20 +117,7 @@ describe("Stdio transport errors", () => {
 // HTTP transport errors
 // ---------------------------------------------------------------------------
 describe("HTTP transport errors", () => {
-  let daemon: TestDaemon | undefined;
-
-  afterEach(async () => {
-    if (daemon) {
-      await daemon.kill();
-      daemon = undefined;
-    }
-  });
-
   test("connection refused → friendly message with URL", async () => {
-    daemon = await startTestDaemon({
-      deadhttp: { type: "http", url: "http://127.0.0.1:19999/mcp" },
-    });
-
     const rpcError = await triggerConnect(daemon.socketPath, "deadhttp");
     expect(rpcError).toBeDefined();
     // The MCP SDK wraps ECONNREFUSED as "Unable to connect..." — wrapTransportError
@@ -131,10 +132,6 @@ describe("HTTP transport errors", () => {
   });
 
   test("DNS failure → DNS-specific message with URL", async () => {
-    daemon = await startTestDaemon({
-      baddns: { type: "http", url: "http://this-host-does-not-resolve.invalid/mcp" },
-    });
-
     const rpcError = await triggerConnect(daemon.socketPath, "baddns");
     expect(rpcError).toBeDefined();
     // The MCP SDK wraps ENOTFOUND — wrapTransportError now checks err.cause
@@ -155,20 +152,7 @@ describe("HTTP transport errors", () => {
 // SSE transport errors
 // ---------------------------------------------------------------------------
 describe("SSE transport errors", () => {
-  let daemon: TestDaemon | undefined;
-
-  afterEach(async () => {
-    if (daemon) {
-      await daemon.kill();
-      daemon = undefined;
-    }
-  });
-
   test("connection refused → friendly message with URL", async () => {
-    daemon = await startTestDaemon({
-      deadsse: { type: "sse", url: "http://127.0.0.1:19998/events" },
-    });
-
     const rpcError = await triggerConnect(daemon.socketPath, "deadsse");
     expect(rpcError).toBeDefined();
     expect(rpcError).toContain('Server "deadsse"');
@@ -186,20 +170,7 @@ describe("SSE transport errors", () => {
 // listServers: lastError field end-to-end verification
 // ---------------------------------------------------------------------------
 describe("listServers lastError field", () => {
-  let daemon: TestDaemon | undefined;
-
-  afterEach(async () => {
-    if (daemon) {
-      await daemon.kill();
-      daemon = undefined;
-    }
-  });
-
   test("failed server: state=error, lastError includes server name", async () => {
-    daemon = await startTestDaemon({
-      bogus: { command: "nonexistent-mcp-server-binary-xyz" },
-    });
-
     await triggerConnect(daemon.socketPath, "bogus");
 
     const status = await getServerStatus(daemon.socketPath, "bogus");
@@ -212,10 +183,6 @@ describe("listServers lastError field", () => {
   });
 
   test("healthy server: lastError is undefined after successful connect", async () => {
-    daemon = await startTestDaemon({
-      echo: { command: "bun", args: [resolve("test/echo-server.ts")] },
-    });
-
     await triggerConnect(daemon.socketPath, "echo");
 
     const status = await getServerStatus(daemon.socketPath, "echo");
@@ -225,11 +192,6 @@ describe("listServers lastError field", () => {
   });
 
   test("daemon remains functional after transport errors", async () => {
-    daemon = await startTestDaemon({
-      bogus: { command: "nonexistent-mcp-server-binary-xyz" },
-      echo: { command: "bun", args: [resolve("test/echo-server.ts")] },
-    });
-
     // Trigger failure on bogus server
     await triggerConnect(daemon.socketPath, "bogus");
 


### PR DESCRIPTION
## Summary
- **Share single daemon** across all `transport-errors.spec.ts` tests via `beforeAll` — reduces from 9 separate daemon startups to 1, cutting file time from **~46s to ~5s**
- **Add `transport-errors.spec.ts` to `TIMING_EXCLUSIONS`** — it's an integration test spawning a live daemon, same category as `daemon-integration.spec.ts`
- **Replace fixed `setTimeout` sleep** in `server-pool.spec.ts` with deadline-based polling (per test guidelines)
- **Add `AGGREGATE_TIME_BUDGET_MS` (60s) ratchet** — tracks sequential sum of non-excluded test files and warns when exceeded; current aggregate is 43.2s

## Test plan
- [x] `bun test test/transport-errors.spec.ts` — 9 tests pass, 5.2s (was 46s)
- [x] `bun test packages/daemon/src/server-pool.spec.ts` — 157 tests pass, 4.1s
- [x] Full suite: 3330 tests pass, 0 failures
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] Pre-commit hook (typecheck + lint + test + coverage) passes
- [x] Aggregate ratchet reports: `43.2s (budget: 60s, 139 files)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)