### PR TITLE
feat(cli): add mcx opencode CLI commands (fixes #505)

### DIFF
--- a/packages/command/src/commands/opencode.spec.ts
+++ b/packages/command/src/commands/opencode.spec.ts
@@ -1,0 +1,811 @@
+import { describe, expect, mock, test } from "bun:test";
+import { ExitError } from "../test-helpers";
+import type { OpencodeDeps } from "./opencode";
+import { cmdOpencode, parseOpencodeSpawnArgs } from "./opencode";
+
+// ── Helpers ──
+
+function makeDeps(overrides?: Partial<OpencodeDeps>): OpencodeDeps {
+  return {
+    callTool: mock(async () => ({ content: [{ type: "text", text: "[]" }] })),
+    printError: mock(() => {}),
+    exit: mock((code: number) => {
+      throw new ExitError(code);
+    }) as OpencodeDeps["exit"],
+    getStaleDaemonWarning: mock(() => null),
+    exec: mock(() => ({ stdout: "", stderr: "", exitCode: 0 })),
+    ...overrides,
+  };
+}
+
+function toolResult(data: unknown): { content: Array<{ type: "text"; text: string }> } {
+  return { content: [{ type: "text", text: JSON.stringify(data) }] };
+}
+
+const SESSION_LIST = [
+  {
+    sessionId: "abc12345-1111-2222-3333-444444444444",
+    provider: "opencode",
+    state: "active",
+    model: "grok-3",
+    cwd: "/tmp",
+    cost: 0.0523,
+    tokens: 1000,
+    reasoningTokens: 200,
+    numTurns: 3,
+    pendingPermissions: 0,
+    pendingPermissionDetails: [],
+    worktree: null,
+    processAlive: true,
+  },
+  {
+    sessionId: "def67890-aaaa-bbbb-cccc-dddddddddddd",
+    provider: "opencode",
+    state: "idle",
+    model: "gemini-2.5-pro",
+    cwd: "/home",
+    cost: 0.0012,
+    tokens: 500,
+    reasoningTokens: 100,
+    numTurns: 1,
+    pendingPermissions: 0,
+    pendingPermissionDetails: [],
+    worktree: null,
+    processAlive: true,
+  },
+];
+
+// ── parseOpencodeSpawnArgs ──
+
+describe("parseOpencodeSpawnArgs", () => {
+  test("parses --task flag", () => {
+    const result = parseOpencodeSpawnArgs(["--task", "fix bug"]);
+    expect(result.task).toBe("fix bug");
+    expect(result.error).toBeUndefined();
+  });
+
+  test("parses -t shorthand", () => {
+    const result = parseOpencodeSpawnArgs(["-t", "fix bug"]);
+    expect(result.task).toBe("fix bug");
+  });
+
+  test("parses positional task", () => {
+    const result = parseOpencodeSpawnArgs(["fix the tests"]);
+    expect(result.task).toBe("fix the tests");
+  });
+
+  test("parses --allow with multiple tools", () => {
+    const result = parseOpencodeSpawnArgs(["--allow", "Read", "Glob", "Grep", "--task", "x"]);
+    expect(result.allow).toEqual(["Read", "Glob", "Grep"]);
+  });
+
+  test("parses --wait flag", () => {
+    const result = parseOpencodeSpawnArgs(["--task", "fix bug", "--wait"]);
+    expect(result.wait).toBe(true);
+  });
+
+  test("parses --model flag", () => {
+    const result = parseOpencodeSpawnArgs(["--model", "grok-3", "--task", "x"]);
+    expect(result.model).toBe("grok-3");
+  });
+
+  test("parses --provider flag", () => {
+    const result = parseOpencodeSpawnArgs(["--provider", "xai", "--task", "x"]);
+    expect(result.provider).toBe("xai");
+  });
+
+  test("parses -p shorthand for provider", () => {
+    const result = parseOpencodeSpawnArgs(["-p", "google", "--task", "x"]);
+    expect(result.provider).toBe("google");
+  });
+
+  test("errors on missing --provider value", () => {
+    const result = parseOpencodeSpawnArgs(["--provider", "--task", "x"]);
+    expect(result.error).toContain("--provider requires a value");
+  });
+
+  test("errors on missing --task value", () => {
+    const result = parseOpencodeSpawnArgs(["--task"]);
+    expect(result.error).toBe("--task requires a value");
+  });
+
+  test("errors on non-numeric --timeout", () => {
+    const result = parseOpencodeSpawnArgs(["--timeout", "abc"]);
+    expect(result.error).toBe("--timeout must be a number");
+  });
+
+  test("parses --json flag", () => {
+    const result = parseOpencodeSpawnArgs(["--task", "fix bug", "--json"]);
+    expect(result.json).toBe(true);
+  });
+
+  test("json defaults to false", () => {
+    const result = parseOpencodeSpawnArgs(["--task", "x"]);
+    expect(result.json).toBe(false);
+  });
+
+  test("parses --worktree with name", () => {
+    const result = parseOpencodeSpawnArgs(["--worktree", "my-branch", "--task", "x"]);
+    expect(result.worktree).toBe("my-branch");
+  });
+
+  test("parses -w shorthand with name", () => {
+    const result = parseOpencodeSpawnArgs(["-w", "my-branch", "--task", "x"]);
+    expect(result.worktree).toBe("my-branch");
+  });
+
+  test("auto-generates worktree name when no value given", () => {
+    const result = parseOpencodeSpawnArgs(["--worktree", "--task", "x"]);
+    expect(result.worktree).toMatch(/^opencode-/);
+  });
+
+  test("auto-generates worktree name at end of args", () => {
+    const result = parseOpencodeSpawnArgs(["--task", "x", "-w"]);
+    expect(result.worktree).toMatch(/^opencode-/);
+  });
+
+  test("worktree defaults to undefined", () => {
+    const result = parseOpencodeSpawnArgs(["--task", "x"]);
+    expect(result.worktree).toBeUndefined();
+  });
+
+  test("provider defaults to undefined", () => {
+    const result = parseOpencodeSpawnArgs(["--task", "x"]);
+    expect(result.provider).toBeUndefined();
+  });
+});
+
+// ── cmdOpencode — subcommand dispatch ──
+
+describe("cmdOpencode", () => {
+  test("prints usage on --help", async () => {
+    const log = mock(() => {});
+    const origLog = console.log;
+    console.log = log;
+    try {
+      const deps = makeDeps();
+      await cmdOpencode(["--help"], deps);
+      expect(log).toHaveBeenCalled();
+      const output = (log.mock.calls[0] as string[])[0];
+      expect(output).toContain("mcx opencode");
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("prints usage on no subcommand", async () => {
+    const log = mock(() => {});
+    const origLog = console.log;
+    console.log = log;
+    try {
+      const deps = makeDeps();
+      await cmdOpencode([], deps);
+      expect(log).toHaveBeenCalled();
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("rejects unknown subcommand", async () => {
+    const deps = makeDeps();
+    await expect(cmdOpencode(["bogus"], deps)).rejects.toThrow(ExitError);
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("Unknown opencode subcommand"));
+  });
+
+  test("fails fast when daemon build is stale", async () => {
+    const deps = makeDeps({
+      getStaleDaemonWarning: mock(() => "Daemon is running a different build. Run `mcx shutdown`."),
+    });
+    await expect(cmdOpencode(["spawn", "--task", "x"], deps)).rejects.toThrow(ExitError);
+    expect(deps.callTool).not.toHaveBeenCalled();
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("mcx shutdown"));
+  });
+});
+
+// ── spawn ──
+
+describe("opencode spawn", () => {
+  test("calls opencode_prompt with task", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult({ sessionId: "s1", state: "active" })),
+    });
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdOpencode(["spawn", "--task", "do stuff"], deps);
+      expect(deps.callTool).toHaveBeenCalledWith("opencode_prompt", expect.objectContaining({ prompt: "do stuff" }));
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("passes --wait flag", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult({ sessionId: "s1" })),
+    });
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdOpencode(["spawn", "--task", "do stuff", "--wait"], deps);
+      expect(deps.callTool).toHaveBeenCalledWith("opencode_prompt", expect.objectContaining({ wait: true }));
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("errors without task", async () => {
+    const deps = makeDeps();
+    await expect(cmdOpencode(["spawn"], deps)).rejects.toThrow(ExitError);
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("Usage"));
+  });
+
+  test("passes --model flag", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult({ sessionId: "s1" })),
+    });
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdOpencode(["spawn", "--task", "x", "--model", "grok-3"], deps);
+      expect(deps.callTool).toHaveBeenCalledWith("opencode_prompt", expect.objectContaining({ model: "grok-3" }));
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("passes --provider flag", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult({ sessionId: "s1" })),
+    });
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdOpencode(["spawn", "--task", "x", "--provider", "xai"], deps);
+      expect(deps.callTool).toHaveBeenCalledWith("opencode_prompt", expect.objectContaining({ provider: "xai" }));
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("passes --allow tools", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult({ sessionId: "s1" })),
+    });
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdOpencode(["spawn", "--task", "x", "--allow", "Read", "Write"], deps);
+      expect(deps.callTool).toHaveBeenCalledWith(
+        "opencode_prompt",
+        expect.objectContaining({ allowedTools: ["Read", "Write"] }),
+      );
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("passes --cwd and --timeout", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult({ sessionId: "s1" })),
+    });
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdOpencode(["spawn", "--task", "x", "--cwd", "/tmp", "--timeout", "10000"], deps);
+      expect(deps.callTool).toHaveBeenCalledWith(
+        "opencode_prompt",
+        expect.objectContaining({ cwd: "/tmp", timeout: 10000 }),
+      );
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("reports parse errors", async () => {
+    const deps = makeDeps();
+    await expect(cmdOpencode(["spawn", "--timeout", "abc"], deps)).rejects.toThrow(ExitError);
+    expect(deps.printError).toHaveBeenCalledWith("--timeout must be a number");
+  });
+
+  test("--json outputs raw JSON to stdout", async () => {
+    const spawnResult = { sessionId: "s1-full-uuid", state: "active" };
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(spawnResult)),
+    });
+    const logCalls: string[] = [];
+    const origLog = console.log;
+    console.log = mock((...args: unknown[]) => logCalls.push(String(args[0])));
+    try {
+      await cmdOpencode(["spawn", "--task", "do stuff", "--json"], deps);
+      const output = logCalls.join("");
+      const parsed = JSON.parse(output);
+      expect(parsed.sessionId).toBe("s1-full-uuid");
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("--json suppresses human-friendly stderr", async () => {
+    const spawnResult = { sessionId: "s1-full-uuid", state: "active" };
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(spawnResult)),
+    });
+    const errCalls: string[] = [];
+    const origLog = console.log;
+    const origErr = console.error;
+    console.log = mock(() => {});
+    console.error = mock((...args: unknown[]) => errCalls.push(String(args[0])));
+    try {
+      await cmdOpencode(["spawn", "--task", "do stuff", "--json"], deps);
+      expect(errCalls.filter((l) => l.includes("OpenCode session started"))).toHaveLength(0);
+    } finally {
+      console.log = origLog;
+      console.error = origErr;
+    }
+  });
+
+  test("without --json prints human-friendly session info to stderr", async () => {
+    const spawnResult = { sessionId: "abc12345-full-uuid", state: "active" };
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(spawnResult)),
+    });
+    const errCalls: string[] = [];
+    const origLog = console.log;
+    const origErr = console.error;
+    console.log = mock(() => {});
+    console.error = mock((...args: unknown[]) => errCalls.push(String(args[0])));
+    try {
+      await cmdOpencode(["spawn", "--task", "do stuff"], deps);
+      expect(errCalls.some((l) => l.includes("abc12345"))).toBe(true);
+    } finally {
+      console.log = origLog;
+      console.error = origErr;
+    }
+  });
+
+  test("passes worktree name to daemon when no hooks or branchPrefix config", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult({ sessionId: "s1" })),
+    });
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdOpencode(["spawn", "--task", "x", "--worktree", "my-wt"], deps);
+      expect(deps.callTool).toHaveBeenCalledWith("opencode_prompt", expect.objectContaining({ worktree: "my-wt" }));
+    } finally {
+      console.log = origLog;
+    }
+  });
+});
+
+// ── ls ──
+
+describe("opencode ls", () => {
+  test("calls opencode_session_list", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(SESSION_LIST)),
+    });
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdOpencode(["ls"], deps);
+      expect(deps.callTool).toHaveBeenCalledWith("opencode_session_list", {});
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("shows cost in USD in table output", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(SESSION_LIST)),
+    });
+    const logCalls: string[] = [];
+    const origLog = console.log;
+    console.log = mock((...args: unknown[]) => logCalls.push(String(args[0])));
+    try {
+      await cmdOpencode(["ls"], deps);
+      const sessionRows = logCalls.filter((l) => l.includes("abc12345".slice(0, 8)));
+      expect(sessionRows.length).toBeGreaterThan(0);
+      expect(sessionRows[0]).toContain("$0.0523");
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("outputs JSON with --json flag", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(SESSION_LIST)),
+    });
+    const logCalls: string[] = [];
+    const origLog = console.log;
+    console.log = mock((...args: unknown[]) => logCalls.push(String(args[0])));
+    try {
+      await cmdOpencode(["ls", "--json"], deps);
+      const output = logCalls.join("");
+      expect(() => JSON.parse(output)).not.toThrow();
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("outputs short format with --short", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(SESSION_LIST)),
+    });
+    const logCalls: string[] = [];
+    const origLog = console.log;
+    console.log = mock((...args: unknown[]) => logCalls.push(String(args[0])));
+    try {
+      await cmdOpencode(["ls", "--short"], deps);
+      expect(logCalls.length).toBe(2);
+      expect(logCalls[0]).toContain("abc12345");
+      expect(logCalls[1]).toContain("def67890");
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("prints empty message when no sessions", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult([])),
+    });
+    const errCalls: string[] = [];
+    const origErr = console.error;
+    console.error = mock((...args: unknown[]) => errCalls.push(String(args[0])));
+    try {
+      await cmdOpencode(["ls"], deps);
+      expect(errCalls.some((l) => l.includes("No active OpenCode sessions"))).toBe(true);
+    } finally {
+      console.error = origErr;
+    }
+  });
+});
+
+// ── send ──
+
+describe("opencode send", () => {
+  test("calls opencode_prompt with sessionId and prompt", async () => {
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "opencode_session_list") return toolResult(SESSION_LIST);
+        return toolResult({ ok: true });
+      }),
+    });
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdOpencode(["send", "abc12345", "hello world"], deps);
+      expect(deps.callTool).toHaveBeenCalledWith(
+        "opencode_prompt",
+        expect.objectContaining({ sessionId: SESSION_LIST[0].sessionId, prompt: "hello world" }),
+      );
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("passes --wait flag", async () => {
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "opencode_session_list") return toolResult(SESSION_LIST);
+        return toolResult({ ok: true });
+      }),
+    });
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdOpencode(["send", "--wait", "abc12345", "hello"], deps);
+      expect(deps.callTool).toHaveBeenCalledWith(
+        "opencode_prompt",
+        expect.objectContaining({ wait: true, prompt: "hello" }),
+      );
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("errors without session and message", async () => {
+    const deps = makeDeps();
+    await expect(cmdOpencode(["send"], deps)).rejects.toThrow(ExitError);
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("Usage"));
+  });
+});
+
+// ── bye ──
+
+describe("opencode bye", () => {
+  test("calls opencode_bye with resolved sessionId", async () => {
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "opencode_session_list") return toolResult(SESSION_LIST);
+        return toolResult({ ended: true, worktree: null, cwd: null, repoRoot: null });
+      }),
+    });
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdOpencode(["bye", "abc12345"], deps);
+      expect(deps.callTool).toHaveBeenCalledWith("opencode_bye", { sessionId: SESSION_LIST[0].sessionId });
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("errors without session id", async () => {
+    const deps = makeDeps();
+    await expect(cmdOpencode(["bye"], deps)).rejects.toThrow(ExitError);
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("Usage"));
+  });
+
+  test("triggers worktree cleanup when bye returns worktree metadata", async () => {
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "opencode_session_list") return toolResult(SESSION_LIST);
+        return toolResult({ ended: true, worktree: "my-wt", cwd: "/tmp/wt/my-wt", repoRoot: "/tmp/repo" });
+      }),
+      exec: mock(() => ({ stdout: "", stderr: "", exitCode: 0 })),
+    });
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdOpencode(["bye", "abc12345"], deps);
+      expect(deps.exec).toHaveBeenCalled();
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("skips worktree cleanup when bye returns null worktree", async () => {
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "opencode_session_list") return toolResult(SESSION_LIST);
+        return toolResult({ ended: true, worktree: null, cwd: null, repoRoot: null });
+      }),
+    });
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdOpencode(["bye", "abc12345"], deps);
+      expect(deps.exec).not.toHaveBeenCalled();
+    } finally {
+      console.log = origLog;
+    }
+  });
+});
+
+// ── interrupt ──
+
+describe("opencode interrupt", () => {
+  test("calls opencode_interrupt", async () => {
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "opencode_session_list") return toolResult(SESSION_LIST);
+        return toolResult({ ok: true });
+      }),
+    });
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdOpencode(["interrupt", "abc12345"], deps);
+      expect(deps.callTool).toHaveBeenCalledWith("opencode_interrupt", { sessionId: SESSION_LIST[0].sessionId });
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("errors without session id", async () => {
+    const deps = makeDeps();
+    await expect(cmdOpencode(["interrupt"], deps)).rejects.toThrow(ExitError);
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("Usage"));
+  });
+});
+
+// ── log ──
+
+describe("opencode log", () => {
+  test("calls opencode_transcript", async () => {
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "opencode_session_list") return toolResult(SESSION_LIST);
+        return toolResult([]);
+      }),
+    });
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdOpencode(["log", "abc12345"], deps);
+      expect(deps.callTool).toHaveBeenCalledWith("opencode_transcript", {
+        sessionId: SESSION_LIST[0].sessionId,
+        limit: 20,
+      });
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("passes --last flag", async () => {
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "opencode_session_list") return toolResult(SESSION_LIST);
+        return toolResult([]);
+      }),
+    });
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdOpencode(["log", "abc12345", "--last", "5"], deps);
+      expect(deps.callTool).toHaveBeenCalledWith("opencode_transcript", {
+        sessionId: SESSION_LIST[0].sessionId,
+        limit: 5,
+      });
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("errors without session prefix", async () => {
+    const deps = makeDeps();
+    await expect(cmdOpencode(["log"], deps)).rejects.toThrow(ExitError);
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("Usage"));
+  });
+
+  test("outputs JSON with --json flag", async () => {
+    const entries = [{ timestamp: 1000, direction: "outbound", message: { type: "user" } }];
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "opencode_session_list") return toolResult(SESSION_LIST);
+        return toolResult(entries);
+      }),
+    });
+    const logCalls: string[] = [];
+    const origLog = console.log;
+    console.log = mock((...args: unknown[]) => logCalls.push(String(args[0])));
+    try {
+      await cmdOpencode(["log", "abc12345", "--json"], deps);
+      expect(() => JSON.parse(logCalls.join(""))).not.toThrow();
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("formats transcript entries", async () => {
+    const entries = [
+      {
+        timestamp: Date.now(),
+        direction: "outbound",
+        message: { type: "user", message: { content: "hello" } },
+      },
+      {
+        timestamp: Date.now(),
+        direction: "inbound",
+        message: { type: "assistant", message: { content: "hi there" } },
+      },
+      {
+        timestamp: Date.now(),
+        direction: "inbound",
+        message: { type: "result", result: "done" },
+      },
+    ];
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "opencode_session_list") return toolResult(SESSION_LIST);
+        return toolResult(entries);
+      }),
+    });
+    const logCalls: string[] = [];
+    const origLog = console.log;
+    console.log = mock((...args: unknown[]) => logCalls.push(String(args[0])));
+    try {
+      await cmdOpencode(["log", "abc12345"], deps);
+      expect(logCalls.some((l) => l.includes("user"))).toBe(true);
+      expect(logCalls.some((l) => l.includes("assistant"))).toBe(true);
+      expect(logCalls.some((l) => l.includes("result"))).toBe(true);
+    } finally {
+      console.log = origLog;
+    }
+  });
+});
+
+// ── wait ──
+
+describe("opencode wait", () => {
+  test("calls opencode_wait with sessionId", async () => {
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "opencode_session_list") return toolResult(SESSION_LIST);
+        return toolResult({ event: "session:result", sessionId: SESSION_LIST[0].sessionId });
+      }),
+    });
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdOpencode(["wait", "abc12345"], deps);
+      expect(deps.callTool).toHaveBeenCalledWith("opencode_wait", { sessionId: SESSION_LIST[0].sessionId });
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("calls opencode_wait without sessionId for global wait", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult({ event: "session:result" })),
+    });
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdOpencode(["wait"], deps);
+      expect(deps.callTool).toHaveBeenCalledWith("opencode_wait", {});
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("passes --timeout flag", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult({ event: "timeout" })),
+    });
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdOpencode(["wait", "--timeout", "5000"], deps);
+      expect(deps.callTool).toHaveBeenCalledWith("opencode_wait", { timeout: 5000 });
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("passes --after flag", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult({ event: "session:result" })),
+    });
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdOpencode(["wait", "--after", "42"], deps);
+      expect(deps.callTool).toHaveBeenCalledWith("opencode_wait", { afterSeq: 42 });
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("--short formats event result with cost", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () =>
+        toolResult({
+          sessionId: "abc12345-1111-2222-3333-444444444444",
+          event: "session:result",
+          cost: 0.0523,
+          numTurns: 5,
+          result: "completed the task",
+        }),
+      ),
+    });
+    const logCalls: string[] = [];
+    const origLog = console.log;
+    console.log = mock((...args: unknown[]) => logCalls.push(String(args[0])));
+    try {
+      await cmdOpencode(["wait", "--short"], deps);
+      expect(logCalls.length).toBe(1);
+      expect(logCalls[0]).toContain("abc12345");
+      expect(logCalls[0]).toContain("session:result");
+      expect(logCalls[0]).toContain("$0.0523");
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("--short formats session list fallback", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(SESSION_LIST)),
+    });
+    const logCalls: string[] = [];
+    const origLog = console.log;
+    console.log = mock((...args: unknown[]) => logCalls.push(String(args[0])));
+    try {
+      await cmdOpencode(["wait", "--short"], deps);
+      expect(logCalls.length).toBe(2);
+    } finally {
+      console.log = origLog;
+    }
+  });
+});

--- a/packages/command/src/commands/opencode.ts
+++ b/packages/command/src/commands/opencode.ts
@@ -1,0 +1,524 @@
+/**
+ * `mcx opencode` commands — manage OpenCode sessions via the _opencode virtual server.
+ *
+ * Mirrors `mcx codex` but adds a `--provider` flag for selecting the LLM provider
+ * backend (anthropic, openai, google, xai, bedrock, etc.) and displays cost in USD.
+ */
+
+import { existsSync } from "node:fs";
+import {
+  OPENCODE_SERVER_NAME,
+  PROMPT_IPC_TIMEOUT_MS,
+  buildHookEnv,
+  hasWorktreeHooks,
+  readWorktreeConfig,
+  resolveWorktreePath,
+} from "@mcp-cli/core";
+import type { AgentSessionInfo } from "@mcp-cli/core";
+import { getStaleDaemonWarning, ipcCall } from "../daemon-lifecycle";
+import { applyJqFilter } from "../jq/index";
+import { c, printError as defaultPrintError, formatToolResult } from "../output";
+import { extractFullFlag, extractJqFlag, extractJsonFlag } from "../parse";
+
+import {
+  type SharedSessionDeps,
+  cleanupWorktree,
+  parseByeResult,
+  parseLogArgs,
+  parseWaitArgs,
+  resolveSessionId,
+} from "./claude";
+import { colorState, extractContentSummary, formatSessionShort } from "./session-display";
+import type { SharedSpawnArgs } from "./spawn-args";
+import { parseSharedSpawnArgs } from "./spawn-args";
+
+// ── Constants ──
+
+/** Tool name prefix for the OpenCode provider. */
+const P = "opencode";
+
+// ── Dependency injection ──
+
+/** OpenCode deps use only the shared session fields — no provider-specific helpers. */
+export interface OpencodeDeps extends SharedSessionDeps {
+  getStaleDaemonWarning: () => string | null;
+}
+
+const defaultDeps: OpencodeDeps = {
+  callTool: (tool, args) => {
+    const needsLongTimeout = (tool === "opencode_prompt" && args.wait) || tool === "opencode_wait";
+    const timeoutMs = needsLongTimeout ? PROMPT_IPC_TIMEOUT_MS : undefined;
+    return ipcCall("callTool", { server: OPENCODE_SERVER_NAME, tool, arguments: args }, { timeoutMs });
+  },
+  printError: defaultPrintError,
+  exit: (code) => process.exit(code),
+  getStaleDaemonWarning,
+  exec: (cmd, opts) => {
+    const result = Bun.spawnSync(cmd, {
+      stdout: "pipe",
+      stderr: "pipe",
+      env: opts?.env ? { ...process.env, ...opts.env } : undefined,
+    });
+    return {
+      stdout: result.stdout.toString().trim(),
+      stderr: result.stderr.toString().trim(),
+      exitCode: result.exitCode,
+    };
+  },
+};
+
+// ── Entry point ──
+
+export async function cmdOpencode(args: string[], deps?: Partial<OpencodeDeps>): Promise<void> {
+  const d: OpencodeDeps = { ...defaultDeps, ...deps };
+  const sub = args[0];
+
+  if (!sub || sub === "--help" || sub === "-h") {
+    printOpencodeUsage();
+    return;
+  }
+
+  const staleWarning = d.getStaleDaemonWarning();
+  if (staleWarning) {
+    d.printError(staleWarning);
+    d.exit(1);
+  }
+
+  switch (sub) {
+    case "spawn":
+      await opencodeSpawn(args.slice(1), d);
+      break;
+    case "ls":
+    case "list":
+      await opencodeList(args.slice(1), d);
+      break;
+    case "send":
+      await opencodeSend(args.slice(1), d);
+      break;
+    case "bye":
+    case "quit":
+      await opencodeBye(args.slice(1), d);
+      break;
+    case "interrupt":
+      await opencodeInterrupt(args.slice(1), d);
+      break;
+    case "log":
+      await opencodeLog(args.slice(1), d);
+      break;
+    case "wait":
+      await opencodeWait(args.slice(1), d);
+      break;
+    default:
+      d.printError(
+        `Unknown opencode subcommand: ${sub}. Use "spawn", "ls", "send", "bye", "interrupt", "log", or "wait".`,
+      );
+      d.exit(1);
+  }
+}
+
+// ── Spawn ──
+
+/** OpenCode spawn args extend the shared set with --json, --worktree, and --provider flags. */
+export interface OpencodeSpawnArgs extends SharedSpawnArgs {
+  json: boolean;
+  worktree: string | undefined;
+  provider: string | undefined;
+}
+
+export function parseOpencodeSpawnArgs(args: string[]): OpencodeSpawnArgs {
+  let json = false;
+  let worktree: string | undefined;
+  let provider: string | undefined;
+  let extraError: string | undefined;
+
+  const shared = parseSharedSpawnArgs(args, (arg, allArgs, i) => {
+    if (arg === "--json") {
+      json = true;
+      return 0;
+    }
+    if (arg === "--worktree" || arg === "-w") {
+      const next = allArgs[i + 1];
+      if (next && !next.startsWith("-")) {
+        worktree = allArgs[i + 1];
+        return 1;
+      }
+      worktree = `opencode-${Date.now().toString(36)}`;
+      return 0;
+    }
+    if (arg === "--provider" || arg === "-p") {
+      const val = allArgs[i + 1];
+      if (!val || val.startsWith("-")) {
+        extraError = "--provider requires a value (e.g. anthropic, openai, google, xai, bedrock)";
+        return 0;
+      }
+      provider = val;
+      return 1;
+    }
+    return undefined;
+  });
+  return { ...shared, error: shared.error ?? extraError, json, worktree, provider };
+}
+
+async function opencodeSpawn(args: string[], d: OpencodeDeps): Promise<void> {
+  const parsed = parseOpencodeSpawnArgs(args);
+
+  if (parsed.error) {
+    d.printError(parsed.error);
+    d.exit(1);
+  }
+
+  if (!parsed.task) {
+    d.printError(
+      'Usage: mcx opencode spawn --task "description" [--provider name] [--worktree [name]] [--allow tools...]',
+    );
+    d.exit(1);
+  }
+
+  const toolArgs: Record<string, unknown> = { prompt: parsed.task };
+  if (parsed.allow.length > 0) toolArgs.allowedTools = parsed.allow;
+  if (parsed.cwd) toolArgs.cwd = parsed.cwd;
+  if (parsed.timeout) toolArgs.timeout = parsed.timeout;
+  if (parsed.model) toolArgs.model = parsed.model;
+  if (parsed.provider) toolArgs.provider = parsed.provider;
+  if (parsed.wait) toolArgs.wait = true;
+
+  if (parsed.worktree) {
+    const repoRoot = process.cwd();
+    const wtConfig = readWorktreeConfig(repoRoot);
+
+    if (hasWorktreeHooks(wtConfig)) {
+      const worktreePath = resolveWorktreePath(repoRoot, parsed.worktree, wtConfig);
+      const hookEnv = buildHookEnv({ branch: parsed.worktree, path: worktreePath, cwd: repoRoot });
+      const { exitCode, stderr } = d.exec(["sh", "-c", wtConfig.setup], { env: hookEnv });
+      if (exitCode !== 0) {
+        d.printError(`Worktree setup hook failed: ${stderr}`);
+        d.exit(1);
+      }
+      if (!existsSync(worktreePath)) {
+        d.printError(`Worktree setup hook succeeded but directory does not exist: ${worktreePath}`);
+        d.exit(1);
+      }
+      toolArgs.cwd = worktreePath;
+      toolArgs.worktree = parsed.worktree;
+      toolArgs.repoRoot = repoRoot;
+      d.printError(`Created worktree via hook: ${worktreePath}`);
+    } else if (wtConfig?.branchPrefix === false) {
+      const worktreePath = resolveWorktreePath(repoRoot, parsed.worktree, wtConfig);
+      const { exitCode, stdout } = d.exec(["git", "worktree", "add", worktreePath, "-b", parsed.worktree, "HEAD"]);
+      if (exitCode !== 0) {
+        d.printError(`Failed to create worktree: ${stdout}`);
+        d.exit(1);
+      }
+      toolArgs.cwd = worktreePath;
+      toolArgs.worktree = parsed.worktree;
+      toolArgs.repoRoot = repoRoot;
+      d.printError(`Created worktree: ${worktreePath}`);
+    } else {
+      toolArgs.worktree = parsed.worktree;
+    }
+  }
+
+  const result = await d.callTool(`${P}_prompt`, toolArgs);
+  const text = formatToolResult(result);
+
+  if (parsed.json) {
+    console.log(text);
+    return;
+  }
+
+  // Human-friendly: extract sessionId from JSON result when possible
+  try {
+    const data = JSON.parse(text) as { sessionId?: string };
+    if (data.sessionId) {
+      console.error(`OpenCode session started: ${data.sessionId.slice(0, 8)}`);
+    }
+  } catch {
+    // Not JSON — fall through
+  }
+  console.log(text);
+}
+
+// ── List ──
+
+async function opencodeList(args: string[], d: OpencodeDeps): Promise<void> {
+  const { json } = extractJsonFlag(args);
+  const short = args.includes("--short");
+  const result = await d.callTool(`${P}_session_list`, {});
+  const text = formatToolResult(result);
+
+  if (json) {
+    console.log(text);
+    return;
+  }
+
+  let sessions: AgentSessionInfo[];
+  try {
+    sessions = JSON.parse(text);
+  } catch {
+    console.log(text);
+    return;
+  }
+
+  if (sessions.length === 0) {
+    console.error("No active OpenCode sessions.");
+    return;
+  }
+
+  if (short) {
+    for (const s of sessions) {
+      console.log(formatSessionShort(s));
+    }
+    return;
+  }
+
+  // Table output
+  const header = `${"SESSION".padEnd(10)} ${"STATE".padEnd(12)} ${"MODEL".padEnd(16)} ${"COST".padEnd(8)} ${"TOKENS".padEnd(10)} CWD`;
+  console.log(`${c.dim}${header}${c.reset}`);
+
+  for (const s of sessions) {
+    const id = s.sessionId.slice(0, 8);
+    const state = colorState(s.state);
+    const model = (s.model ?? "—").padEnd(16);
+    const cost = s.cost != null && s.cost > 0 ? `$${s.cost.toFixed(4)}`.padEnd(8) : "—".padEnd(8);
+    const tokens = s.tokens > 0 ? String(s.tokens).padEnd(10) : "—".padEnd(10);
+    const cwd = s.cwd ?? "—";
+    console.log(`${c.cyan}${id}${c.reset}   ${state} ${model} ${cost} ${tokens} ${c.dim}${cwd}${c.reset}`);
+  }
+}
+
+// ── Send ──
+
+async function opencodeSend(args: string[], d: OpencodeDeps): Promise<void> {
+  let wait = false;
+  const rest: string[] = [];
+  for (const arg of args) {
+    if (arg === "--wait") {
+      wait = true;
+    } else {
+      rest.push(arg);
+    }
+  }
+
+  const sessionPrefix = rest[0];
+  const message = rest.slice(1).join(" ").trim();
+
+  if (!sessionPrefix || !message) {
+    d.printError("Usage: mcx opencode send [--wait] <session-id> <message>");
+    d.exit(1);
+  }
+
+  const sessionId = await resolveSessionId(sessionPrefix, d, `${P}_session_list`);
+  const toolArgs: Record<string, unknown> = { sessionId, prompt: message };
+  if (wait) toolArgs.wait = true;
+
+  const result = await d.callTool(`${P}_prompt`, toolArgs);
+  console.log(formatToolResult(result));
+}
+
+// ── Bye ──
+
+async function opencodeBye(args: string[], d: OpencodeDeps): Promise<void> {
+  const sessionPrefix = args[0];
+
+  if (!sessionPrefix) {
+    d.printError("Usage: mcx opencode bye <session-id>");
+    d.exit(1);
+  }
+
+  const sessionId = await resolveSessionId(sessionPrefix, d, `${P}_session_list`);
+  const result = await d.callTool(`${P}_bye`, { sessionId });
+
+  const byeResult = parseByeResult(result);
+  console.log(formatToolResult(result));
+
+  if (byeResult.worktree && byeResult.cwd) {
+    cleanupWorktree(byeResult.worktree, byeResult.cwd, d, byeResult.repoRoot);
+  }
+}
+
+// ── Interrupt ──
+
+async function opencodeInterrupt(args: string[], d: OpencodeDeps): Promise<void> {
+  const sessionPrefix = args[0];
+
+  if (!sessionPrefix) {
+    d.printError("Usage: mcx opencode interrupt <session-id>");
+    d.exit(1);
+  }
+
+  const sessionId = await resolveSessionId(sessionPrefix, d, `${P}_session_list`);
+  const result = await d.callTool(`${P}_interrupt`, { sessionId });
+  console.log(formatToolResult(result));
+}
+
+// ── Log ──
+
+async function opencodeLog(args: string[], d: OpencodeDeps): Promise<void> {
+  const parsed = parseLogArgs(args);
+
+  if (parsed.error) {
+    d.printError(parsed.error);
+    d.exit(1);
+  }
+
+  if (!parsed.sessionPrefix) {
+    d.printError("Usage: mcx opencode log <session-id> [--last N]");
+    d.exit(1);
+  }
+
+  const sessionId = await resolveSessionId(parsed.sessionPrefix, d, `${P}_session_list`);
+  const result = await d.callTool(`${P}_transcript`, { sessionId, limit: parsed.last });
+  const text = formatToolResult(result);
+
+  if (parsed.json) {
+    if (parsed.jq) {
+      try {
+        const data = JSON.parse(text);
+        const filtered = await applyJqFilter(data, parsed.jq);
+        console.log(JSON.stringify(filtered, null, 2));
+      } catch (err) {
+        d.printError(err instanceof Error ? err.message : String(err));
+        d.exit(1);
+      }
+      return;
+    }
+    console.log(text);
+    return;
+  }
+
+  let entries: Array<{ timestamp: number; direction: string; message: { type: string; [k: string]: unknown } }>;
+  try {
+    entries = JSON.parse(text);
+  } catch {
+    console.log(text);
+    return;
+  }
+
+  const truncate = (s: string) => (parsed.full || s.length <= 200 ? s : `${s.slice(0, 200)}…`);
+
+  for (const entry of entries) {
+    const time = new Date(entry.timestamp).toLocaleTimeString();
+    const dir = entry.direction === "outbound" ? `${c.green}→${c.reset}` : `${c.cyan}←${c.reset}`;
+    const type = entry.message.type ?? "unknown";
+    console.log(`${c.dim}${time}${c.reset} ${dir} ${c.bold}${type}${c.reset}`);
+
+    if ((type === "user" || type === "assistant") && entry.message.message) {
+      const msg = entry.message.message as { content?: unknown };
+      const summary = extractContentSummary(msg.content);
+      if (summary) {
+        console.log(`  ${type === "assistant" ? truncate(summary) : summary}`);
+      }
+    } else if (type === "result") {
+      const res = entry.message as { result?: string };
+      if (res.result) {
+        console.log(`  ${c.dim}${truncate(res.result)}${c.reset}`);
+      }
+    }
+  }
+}
+
+// ── Wait ──
+
+async function opencodeWait(args: string[], d: OpencodeDeps): Promise<void> {
+  const parsed = parseWaitArgs(args);
+
+  if (parsed.error) {
+    d.printError(parsed.error);
+    d.exit(1);
+  }
+
+  const toolArgs: Record<string, unknown> = {};
+
+  if (parsed.sessionPrefix) {
+    const sessionId = await resolveSessionId(parsed.sessionPrefix, d, `${P}_session_list`);
+    toolArgs.sessionId = sessionId;
+  }
+  if (parsed.timeout) {
+    toolArgs.timeout = parsed.timeout;
+  }
+  if (parsed.afterSeq !== undefined) {
+    toolArgs.afterSeq = parsed.afterSeq;
+  }
+
+  const result = await d.callTool(`${P}_wait`, toolArgs);
+  const text = formatToolResult(result);
+
+  if (!parsed.short) {
+    console.log(text);
+    return;
+  }
+
+  let data: unknown;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    console.log(text);
+    return;
+  }
+
+  // Timeout fallback returns a session list array
+  if (Array.isArray(data)) {
+    for (const s of data as Array<{
+      sessionId: string;
+      state: string;
+      model?: string | null;
+      cost?: number | null;
+      tokens?: number;
+      numTurns?: number;
+    }>) {
+      console.log(formatSessionShort(s));
+    }
+    return;
+  }
+
+  // Normal event result
+  const evt = data as { sessionId?: string; event?: string; cost?: number; numTurns?: number; result?: string };
+  const id = evt.sessionId ? evt.sessionId.slice(0, 8) : "—";
+  const event = evt.event ?? "—";
+  const cost = evt.cost != null && evt.cost > 0 ? `$${evt.cost.toFixed(4)}` : "—";
+  const turns = evt.numTurns !== undefined ? String(evt.numTurns) : "—";
+  const preview = evt.result ? evt.result.slice(0, 100) : "";
+  console.log(`${id} ${event} ${cost} ${turns}${preview ? ` ${preview}` : ""}`);
+}
+
+// ── Usage ──
+
+function printOpencodeUsage(): void {
+  console.log(`mcx opencode — manage OpenCode sessions
+
+Usage:
+  mcx opencode spawn --task "description"    Start a new OpenCode session (non-blocking)
+  mcx opencode spawn --task "..." --json     Machine-parseable JSON output
+  mcx opencode spawn "description"           Shorthand (positional task)
+  mcx opencode spawn -w --task "desc"        Spawn in a new git worktree
+  mcx opencode ls                            List active OpenCode sessions
+  mcx opencode send <session> <message>      Send follow-up prompt (non-blocking)
+  mcx opencode wait [session]                Block until a session event occurs
+  mcx opencode bye <session>                 End session and stop process
+  mcx opencode interrupt <session>           Interrupt the current turn
+  mcx opencode log <session> [--last N]      View session transcript
+  mcx opencode log <session> --json          Raw JSON transcript output
+  mcx opencode log <session> --json --jq '.' Apply jq filter to JSON output
+  mcx opencode log <session> --full          Full output (no truncation)
+
+Spawn options:
+  --task, -t "description"    Task prompt for OpenCode
+  --provider, -p <name>       LLM provider backend (anthropic, openai, google, xai, bedrock)
+  --worktree, -w [name]       Run in a new git worktree (auto-generates name if omitted)
+  --json                      Output raw JSON (for scripting/orchestration)
+  --wait                      Block until OpenCode produces a result
+  --model, -m <name>          Model to use (e.g. grok-3, gemini-2.5-pro, claude-sonnet-4-6)
+  --allow <tools...>          Pre-approved tool patterns
+  --cwd <path>                Working directory for OpenCode
+  --timeout <ms>              Max wait time (default: 300000, only with --wait)
+
+Send options:
+  --wait                      Block until OpenCode produces a result
+
+Wait options:
+  --after <seq>               Sequence cursor for race-free polling
+  --timeout, -t <ms>          Max wait time (default: 300000)
+
+Session IDs support prefix matching (like git SHAs).
+OpenCode tracks cost in USD and reports reasoning tokens.`);
+}

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -33,6 +33,7 @@ import { cmdAddFromClaudeDesktop, cmdImport } from "./commands/import";
 import { cmdInstall } from "./commands/install";
 import { cmdLogs } from "./commands/logs";
 import { cmdMail } from "./commands/mail";
+import { cmdOpencode } from "./commands/opencode";
 import { cmdRegistryDispatch } from "./commands/registry-cmd";
 import { cmdRemove } from "./commands/remove";
 import { cmdRun } from "./commands/run";
@@ -278,6 +279,10 @@ async function main(): Promise<void> {
 
       case "codex":
         await cmdCodex(cleanArgs.slice(1));
+        break;
+
+      case "opencode":
+        await cmdOpencode(cleanArgs.slice(1));
         break;
 
       case "acp":

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -232,6 +232,7 @@ export const DEFAULT_CLAUDE_WS_PORT = 19275;
 /** Virtual MCP server names — used in IPC callTool requests and daemon registration */
 export const CLAUDE_SERVER_NAME = "_claude";
 export const CODEX_SERVER_NAME = "_codex";
+export const OPENCODE_SERVER_NAME = "_opencode";
 export const ACP_SERVER_NAME = "_acp";
 export const ALIAS_SERVER_NAME = "_aliases";
 export const METRICS_SERVER_NAME = "_metrics";


### PR DESCRIPTION
## Summary
- Add `mcx opencode` command with full subcommand suite: spawn, ls, send, bye, interrupt, log, wait
- Includes `--provider` flag for selecting LLM provider backend (anthropic, openai, google, xai, bedrock)
- Cost displayed in USD (OpenCode tracks cost), reasoning tokens shown
- Add `OPENCODE_SERVER_NAME` constant to core

## Test plan
- [x] `parseOpencodeSpawnArgs` unit tests: --task, --provider/-p, --model, --worktree/-w, --json, --wait, --allow, --cwd, --timeout, error cases
- [x] `cmdOpencode` dispatch tests: help, no subcommand, unknown subcommand, stale daemon check
- [x] spawn: calls opencode_prompt with correct args, --json output, --provider passthrough, worktree passthrough
- [x] ls: calls opencode_session_list, cost in USD display, --json, --short, empty list message
- [x] send: session resolution + prompt, --wait flag
- [x] bye: session resolution, worktree cleanup on/off
- [x] interrupt: session resolution
- [x] log: transcript call, --last, --json, entry formatting
- [x] wait: sessionId resolution, global wait, --timeout, --after, --short formatting
- [x] `bun typecheck && bun lint && bun test` all green (3390 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)