### PR TITLE
test(daemon): add HTTP/SSE transport integration tests (fixes #115)

### DIFF
--- a/test/daemon-integration.spec.ts
+++ b/test/daemon-integration.spec.ts
@@ -10,8 +10,16 @@ import { afterAll, afterEach, beforeAll, describe, expect, setDefaultTimeout, te
 setDefaultTimeout(30_000);
 import { existsSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
-import type { TestDaemon } from "./harness";
-import { echoServerConfig, pollUntil, rpc, startTestDaemon } from "./harness";
+import type { MockServer, TestDaemon } from "./harness";
+import {
+  echoHttpServerConfig,
+  echoServerConfig,
+  echoSseServerConfig,
+  pollUntil,
+  rpc,
+  startMockServer,
+  startTestDaemon,
+} from "./harness";
 
 // ---------------------------------------------------------------------------
 // P1: Daemon lifecycle
@@ -550,6 +558,180 @@ describe("P5b: Error scenario edge cases", () => {
     expect(res.error?.message).toContain("crasher");
 
     // Daemon should still be alive after the error
+    const ping = await rpc(daemon.socketPath, "ping");
+    expect(ping.result).toHaveProperty("pong", true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P3b: HTTP (Streamable HTTP) transport end-to-end (#115)
+// ---------------------------------------------------------------------------
+describe("P3b: HTTP transport end-to-end", () => {
+  let mockServer: MockServer;
+  let daemon: TestDaemon;
+
+  beforeAll(async () => {
+    mockServer = await startMockServer("test/echo-http-server.ts");
+    daemon = await startTestDaemon({ echohttp: echoHttpServerConfig(mockServer.port) });
+  });
+
+  afterAll(async () => {
+    await daemon.kill();
+    await mockServer.kill();
+  });
+
+  test("listTools returns echo server tools via HTTP transport", async () => {
+    const res = await rpc(daemon.socketPath, "listTools", { server: "echohttp" });
+    expect(res.error).toBeUndefined();
+    const tools = res.result as Array<{ name: string }>;
+    const names = tools.map((t) => t.name).sort();
+    expect(names).toEqual(["add", "echo", "fail"]);
+  });
+
+  test("callTool echo returns correct result via HTTP transport", async () => {
+    const res = await rpc(daemon.socketPath, "callTool", {
+      server: "echohttp",
+      tool: "echo",
+      arguments: { message: "hello http" },
+    });
+    expect(res.error).toBeUndefined();
+    const result = res.result as { content: Array<{ type: string; text: string }> };
+    expect(result.content[0].text).toBe("hello http");
+  });
+
+  test("callTool add returns correct sum via HTTP transport", async () => {
+    const res = await rpc(daemon.socketPath, "callTool", {
+      server: "echohttp",
+      tool: "add",
+      arguments: { a: 30, b: 12 },
+    });
+    expect(res.error).toBeUndefined();
+    const result = res.result as { content: Array<{ text: string }> };
+    expect(result.content[0].text).toBe("42");
+  });
+
+  test("callTool fail returns error content via HTTP transport", async () => {
+    const res = await rpc(daemon.socketPath, "callTool", {
+      server: "echohttp",
+      tool: "fail",
+      arguments: {},
+    });
+    expect(res.error).toBeUndefined();
+    const result = res.result as { isError: boolean; content: Array<{ text: string }> };
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe("intentional failure");
+
+    // Daemon should still be alive
+    const ping = await rpc(daemon.socketPath, "ping");
+    expect(ping.result).toHaveProperty("pong", true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P3c: SSE transport end-to-end (#115)
+// ---------------------------------------------------------------------------
+describe("P3c: SSE transport end-to-end", () => {
+  let mockServer: MockServer;
+  let daemon: TestDaemon;
+
+  beforeAll(async () => {
+    mockServer = await startMockServer("test/echo-sse-server.ts");
+    daemon = await startTestDaemon({ echosse: echoSseServerConfig(mockServer.port) });
+  });
+
+  afterAll(async () => {
+    await daemon.kill();
+    await mockServer.kill();
+  });
+
+  test("listTools returns echo server tools via SSE transport", async () => {
+    const res = await rpc(daemon.socketPath, "listTools", { server: "echosse" });
+    expect(res.error).toBeUndefined();
+    const tools = res.result as Array<{ name: string }>;
+    const names = tools.map((t) => t.name).sort();
+    expect(names).toEqual(["add", "echo", "fail"]);
+  });
+
+  test("callTool echo returns correct result via SSE transport", async () => {
+    const res = await rpc(daemon.socketPath, "callTool", {
+      server: "echosse",
+      tool: "echo",
+      arguments: { message: "hello sse" },
+    });
+    expect(res.error).toBeUndefined();
+    const result = res.result as { content: Array<{ type: string; text: string }> };
+    expect(result.content[0].text).toBe("hello sse");
+  });
+
+  test("callTool add returns correct sum via SSE transport", async () => {
+    const res = await rpc(daemon.socketPath, "callTool", {
+      server: "echosse",
+      tool: "add",
+      arguments: { a: 19, b: 23 },
+    });
+    expect(res.error).toBeUndefined();
+    const result = res.result as { content: Array<{ text: string }> };
+    expect(result.content[0].text).toBe("42");
+  });
+
+  test("callTool fail returns error content via SSE transport", async () => {
+    const res = await rpc(daemon.socketPath, "callTool", {
+      server: "echosse",
+      tool: "fail",
+      arguments: {},
+    });
+    expect(res.error).toBeUndefined();
+    const result = res.result as { isError: boolean; content: Array<{ text: string }> };
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe("intentional failure");
+
+    // Daemon should still be alive
+    const ping = await rpc(daemon.socketPath, "ping");
+    expect(ping.result).toHaveProperty("pong", true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// P5c: HTTP/SSE transport error scenarios (#115)
+// ---------------------------------------------------------------------------
+describe("P5c: Transport connection error scenarios", () => {
+  let daemon: TestDaemon | undefined;
+
+  afterEach(async () => {
+    if (daemon) {
+      await daemon.kill();
+      daemon = undefined;
+    }
+  });
+
+  test("HTTP connection refused returns clear error", async () => {
+    // Point at a port with nothing listening
+    daemon = await startTestDaemon({
+      deadhttp: { type: "http", url: "http://127.0.0.1:1/mcp" },
+    });
+
+    const res = await rpc(daemon.socketPath, "listTools", { server: "deadhttp" });
+    expect(res.error).toBeDefined();
+    // Error should mention connection or the URL
+    const msg = res.error?.message?.toLowerCase() ?? "";
+    expect(msg.includes("connect") || msg.includes("127.0.0.1")).toBe(true);
+
+    // Daemon should survive
+    const ping = await rpc(daemon.socketPath, "ping");
+    expect(ping.result).toHaveProperty("pong", true);
+  });
+
+  test("SSE connection refused returns clear error", async () => {
+    daemon = await startTestDaemon({
+      deadsse: { type: "sse", url: "http://127.0.0.1:1/sse" },
+    });
+
+    const res = await rpc(daemon.socketPath, "listTools", { server: "deadsse" });
+    expect(res.error).toBeDefined();
+    const msg = res.error?.message?.toLowerCase() ?? "";
+    expect(msg.includes("connect") || msg.includes("127.0.0.1")).toBe(true);
+
+    // Daemon should survive
     const ping = await rpc(daemon.socketPath, "ping");
     expect(ping.result).toHaveProperty("pong", true);
   });

--- a/test/echo-http-server.ts
+++ b/test/echo-http-server.ts
@@ -1,0 +1,103 @@
+/**
+ * Minimal HTTP (Streamable HTTP) MCP server for integration testing.
+ *
+ * Same tools as echo-server.ts (echo, add, fail) but served over HTTP
+ * using StreamableHTTPServerTransport.
+ *
+ * Prints the listening port to stdout so the test harness can discover it.
+ */
+import { createServer } from "node:http";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+const mcpServer = new Server({ name: "echo-http-server", version: "0.1.0" }, { capabilities: { tools: {} } });
+
+mcpServer.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: "echo",
+      description: "Returns the input message",
+      inputSchema: {
+        type: "object" as const,
+        properties: { message: { type: "string", description: "Message to echo" } },
+        required: ["message"],
+      },
+    },
+    {
+      name: "add",
+      description: "Adds two numbers",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          a: { type: "number", description: "First operand" },
+          b: { type: "number", description: "Second operand" },
+        },
+        required: ["a", "b"],
+      },
+    },
+    {
+      name: "fail",
+      description: "Always fails (for error-handling tests)",
+      inputSchema: { type: "object" as const, properties: {} },
+    },
+  ],
+}));
+
+mcpServer.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const { name, arguments: args } = req.params;
+
+  switch (name) {
+    case "echo":
+      return {
+        content: [{ type: "text", text: String((args as Record<string, unknown>)?.message ?? "") }],
+      };
+
+    case "add": {
+      const a = Number((args as Record<string, unknown>)?.a);
+      const b = Number((args as Record<string, unknown>)?.b);
+      return { content: [{ type: "text", text: String(a + b) }] };
+    }
+
+    case "fail":
+      return {
+        isError: true,
+        content: [{ type: "text", text: "intentional failure" }],
+      };
+
+    default:
+      throw new Error(`Unknown tool: ${name}`);
+  }
+});
+
+// Single stateful transport — handles one session at a time (sufficient for testing)
+const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: () => crypto.randomUUID() });
+await mcpServer.connect(transport);
+
+const httpServer = createServer(async (req, res) => {
+  const url = new URL(req.url ?? "/", "http://127.0.0.1");
+
+  if (url.pathname !== "/mcp") {
+    res.writeHead(404).end("Not found");
+    return;
+  }
+
+  // Read body for POST requests
+  let body: unknown;
+  if (req.method === "POST") {
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+      chunks.push(Buffer.from(chunk));
+    }
+    body = JSON.parse(Buffer.concat(chunks).toString());
+  }
+
+  await transport.handleRequest(req, res, body);
+});
+
+httpServer.listen(0, "127.0.0.1", () => {
+  const addr = httpServer.address();
+  if (addr && typeof addr === "object") {
+    console.log(addr.port);
+  }
+});

--- a/test/echo-sse-server.ts
+++ b/test/echo-sse-server.ts
@@ -1,0 +1,126 @@
+/**
+ * Minimal SSE MCP server for integration testing.
+ *
+ * Same tools as echo-server.ts (echo, add, fail) but served over SSE
+ * using SSEServerTransport with Node.js http compat.
+ *
+ * Prints the listening port to stdout so the test harness can discover it.
+ */
+import { createServer } from "node:http";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+
+function createMcpServer(): Server {
+  const server = new Server({ name: "echo-sse-server", version: "0.1.0" }, { capabilities: { tools: {} } });
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+      {
+        name: "echo",
+        description: "Returns the input message",
+        inputSchema: {
+          type: "object" as const,
+          properties: { message: { type: "string", description: "Message to echo" } },
+          required: ["message"],
+        },
+      },
+      {
+        name: "add",
+        description: "Adds two numbers",
+        inputSchema: {
+          type: "object" as const,
+          properties: {
+            a: { type: "number", description: "First operand" },
+            b: { type: "number", description: "Second operand" },
+          },
+          required: ["a", "b"],
+        },
+      },
+      {
+        name: "fail",
+        description: "Always fails (for error-handling tests)",
+        inputSchema: { type: "object" as const, properties: {} },
+      },
+    ],
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (req) => {
+    const { name, arguments: args } = req.params;
+
+    switch (name) {
+      case "echo":
+        return {
+          content: [{ type: "text", text: String((args as Record<string, unknown>)?.message ?? "") }],
+        };
+
+      case "add": {
+        const a = Number((args as Record<string, unknown>)?.a);
+        const b = Number((args as Record<string, unknown>)?.b);
+        return { content: [{ type: "text", text: String(a + b) }] };
+      }
+
+      case "fail":
+        return {
+          isError: true,
+          content: [{ type: "text", text: "intentional failure" }],
+        };
+
+      default:
+        throw new Error(`Unknown tool: ${name}`);
+    }
+  });
+
+  return server;
+}
+
+// One transport per SSE connection
+const transports = new Map<string, SSEServerTransport>();
+
+const httpServer = createServer(async (req, res) => {
+  const url = new URL(req.url ?? "/", "http://127.0.0.1");
+
+  if (url.pathname === "/sse" && req.method === "GET") {
+    // New SSE connection — create transport and MCP server
+    const mcpServer = createMcpServer();
+    const transport = new SSEServerTransport("/messages", res);
+    transports.set(transport.sessionId, transport);
+
+    transport.onclose = () => {
+      transports.delete(transport.sessionId);
+    };
+
+    await mcpServer.connect(transport);
+    return;
+  }
+
+  if (url.pathname === "/messages" && req.method === "POST") {
+    // Message for existing session
+    const sessionId = url.searchParams.get("sessionId");
+    const transport = sessionId ? transports.get(sessionId) : undefined;
+
+    if (!transport) {
+      res.writeHead(400).end("No session");
+      return;
+    }
+
+    // Read body
+    const chunks: Buffer[] = [];
+    for await (const chunk of req) {
+      chunks.push(Buffer.from(chunk));
+    }
+    const body = JSON.parse(Buffer.concat(chunks).toString());
+
+    await transport.handlePostMessage(req, res, body);
+    return;
+  }
+
+  res.writeHead(404).end("Not found");
+});
+
+httpServer.listen(0, "127.0.0.1", () => {
+  const addr = httpServer.address();
+  if (addr && typeof addr === "object") {
+    console.log(addr.port);
+  }
+});

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -9,6 +9,12 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import type { IpcResponse, ServerConfig, ServerConfigMap } from "@mcp-cli/core";
 
+export interface MockServer {
+  proc: ReturnType<typeof Bun.spawn>;
+  port: number;
+  kill: () => Promise<void>;
+}
+
 export interface TestDaemon {
   proc: ReturnType<typeof Bun.spawn>;
   dir: string;
@@ -135,6 +141,63 @@ export async function pollUntil(
     await Bun.sleep(10);
   }
   if (!(await condition())) throw new Error(`pollUntil: condition not met within ${timeoutMs}ms`);
+}
+
+/**
+ * Spawn a mock MCP server process (HTTP or SSE) and read its port from stdout.
+ * The server script must print the listening port as the first line of stdout.
+ */
+export async function startMockServer(scriptPath: string): Promise<MockServer> {
+  const proc = Bun.spawn(["bun", resolve(scriptPath)], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  // Read the port from the first line of stdout
+  const reader = proc.stdout.getReader();
+  const { value } = await reader.read();
+  reader.releaseLock();
+
+  if (!value) {
+    proc.kill();
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(`Mock server failed to start: ${stderr}`);
+  }
+
+  const port = Number(new TextDecoder().decode(value).trim());
+  if (!port || Number.isNaN(port)) {
+    proc.kill();
+    throw new Error(`Mock server printed invalid port: ${new TextDecoder().decode(value)}`);
+  }
+
+  return {
+    proc,
+    port,
+    kill: async () => {
+      try {
+        proc.kill("SIGTERM");
+      } catch {
+        // already exited
+      }
+      await Promise.race([proc.exited, Bun.sleep(3_000)]);
+    },
+  };
+}
+
+/** HTTP (Streamable HTTP) config pointing to a mock server */
+export function echoHttpServerConfig(port: number): ServerConfig {
+  return {
+    type: "http",
+    url: `http://127.0.0.1:${port}/mcp`,
+  };
+}
+
+/** SSE config pointing to a mock server */
+export function echoSseServerConfig(port: number): ServerConfig {
+  return {
+    type: "sse",
+    url: `http://127.0.0.1:${port}/sse`,
+  };
 }
 
 /** Send an IPC RPC request directly to a daemon's Unix socket */


### PR DESCRIPTION
## Summary
- Add mock MCP servers for HTTP (StreamableHTTP) and SSE transports (`test/echo-http-server.ts`, `test/echo-sse-server.ts`)
- Add `startMockServer`, `echoHttpServerConfig`, `echoSseServerConfig` helpers to test harness
- Add P3b (HTTP), P3c (SSE), and P5c (connection error) integration test groups covering listTools, callTool, error handling, and connection-refused scenarios

## Test plan
- [x] P3b: HTTP transport — listTools, callTool echo/add/fail through daemon
- [x] P3c: SSE transport — listTools, callTool echo/add/fail through daemon
- [x] P5c: Connection refused errors for both HTTP and SSE produce clear messages
- [x] All 3340 tests pass, 0 failures
- [x] Coverage thresholds met (91.26% functions, 92.72% lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)