### PR TITLE
fix(ci): add workflow_dispatch trigger to CI workflow (fixes #899)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   check:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to `.github/workflows/ci.yml` so CI can be manually triggered when the `pull_request: opened` event doesn't fire
- Fixes the race condition where pushing a branch before `gh pr create` leaves PRs without CI status checks

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (3527 tests)
- [ ] Verify `workflow_dispatch` button appears in GitHub Actions UI after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)