### PR TITLE
perf(test): split slow tsc tests from alias-bundle, ratchet aggregate budget (fixes #902)

### DIFF
--- a/packages/core/src/alias-bundle-tsc.spec.ts
+++ b/packages/core/src/alias-bundle-tsc.spec.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { validateFreeformTsc } from "./alias-bundle";
+
+function makeTmpDir(): string {
+  const dir = join(tmpdir(), `alias-bundle-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe("validateFreeformTsc", () => {
+  test("returns no warnings for valid freeform script", async () => {
+    const dir = makeTmpDir();
+    const scriptPath = join(dir, "valid-freeform.ts");
+    writeFileSync(scriptPath, "const x: number = 42;\nconsole.log(x);\n");
+
+    const result = await validateFreeformTsc(scriptPath);
+
+    expect(result.timedOut).toBe(false);
+    expect(result.warnings).toHaveLength(0);
+  }, 15_000);
+
+  test("returns warnings for type errors", async () => {
+    const dir = makeTmpDir();
+    const scriptPath = join(dir, "bad-types.ts");
+    writeFileSync(scriptPath, 'const x: number = "not a number";\n');
+
+    const result = await validateFreeformTsc(scriptPath);
+
+    expect(result.timedOut).toBe(false);
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings.some((w) => w.includes("TS"))).toBe(true);
+  }, 15_000);
+
+  test("handles scripts that import from mcp-cli", async () => {
+    const dir = makeTmpDir();
+    const scriptPath = join(dir, "with-import.ts");
+    writeFileSync(
+      scriptPath,
+      'import { mcp, args } from "mcp-cli";\nconst name: string = args["name"] ?? "world";\nconsole.log(name);\n',
+    );
+
+    const result = await validateFreeformTsc(scriptPath);
+
+    expect(result.timedOut).toBe(false);
+    // Should not have import resolution errors thanks to the stub
+    const importErrors = result.warnings.filter((w) => w.includes("Cannot find module"));
+    expect(importErrors).toHaveLength(0);
+  }, 15_000);
+
+  test("respects timeout", async () => {
+    const dir = makeTmpDir();
+    const scriptPath = join(dir, "timeout-test.ts");
+    writeFileSync(scriptPath, "const x = 1;\n");
+
+    // Use an extremely short timeout to trigger it
+    const result = await validateFreeformTsc(scriptPath, 1);
+
+    // May or may not time out depending on how fast bunx starts,
+    // but the function should not throw
+    expect(typeof result.timedOut).toBe("boolean");
+  }, 15_000);
+});

--- a/packages/core/src/alias-bundle.spec.ts
+++ b/packages/core/src/alias-bundle.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -10,7 +10,6 @@ import {
   stripMcpCliImport,
   stubProxy,
   validateAliasBundled,
-  validateFreeformTsc,
 } from "./alias-bundle";
 
 function makeTmpDir(): string {
@@ -416,58 +415,4 @@ describe("validateAliasBundled", () => {
     expect(result.valid).toBe(true);
     expect(result.name).toBe("minimal");
   });
-});
-
-describe("validateFreeformTsc", () => {
-  test("returns no warnings for valid freeform script", async () => {
-    const dir = makeTmpDir();
-    const scriptPath = join(dir, "valid-freeform.ts");
-    writeFileSync(scriptPath, "const x: number = 42;\nconsole.log(x);\n");
-
-    const result = await validateFreeformTsc(scriptPath);
-
-    expect(result.timedOut).toBe(false);
-    expect(result.warnings).toHaveLength(0);
-  }, 15_000);
-
-  test("returns warnings for type errors", async () => {
-    const dir = makeTmpDir();
-    const scriptPath = join(dir, "bad-types.ts");
-    writeFileSync(scriptPath, 'const x: number = "not a number";\n');
-
-    const result = await validateFreeformTsc(scriptPath);
-
-    expect(result.timedOut).toBe(false);
-    expect(result.warnings.length).toBeGreaterThan(0);
-    expect(result.warnings.some((w) => w.includes("TS"))).toBe(true);
-  }, 15_000);
-
-  test("handles scripts that import from mcp-cli", async () => {
-    const dir = makeTmpDir();
-    const scriptPath = join(dir, "with-import.ts");
-    writeFileSync(
-      scriptPath,
-      'import { mcp, args } from "mcp-cli";\nconst name: string = args["name"] ?? "world";\nconsole.log(name);\n',
-    );
-
-    const result = await validateFreeformTsc(scriptPath);
-
-    expect(result.timedOut).toBe(false);
-    // Should not have import resolution errors thanks to the stub
-    const importErrors = result.warnings.filter((w) => w.includes("Cannot find module"));
-    expect(importErrors).toHaveLength(0);
-  }, 15_000);
-
-  test("respects timeout", async () => {
-    const dir = makeTmpDir();
-    const scriptPath = join(dir, "timeout-test.ts");
-    writeFileSync(scriptPath, "const x = 1;\n");
-
-    // Use an extremely short timeout to trigger it
-    const result = await validateFreeformTsc(scriptPath, 1);
-
-    // May or may not time out depending on how fast bunx starts,
-    // but the function should not throw
-    expect(typeof result.timedOut).toBe("boolean");
-  }, 15_000);
 });

--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -36,7 +36,7 @@ const PER_FILE_TIME_BUDGET_MS = 5_000;
  * Uses sequential sum (not parallel wall time) for reproducibility across machines.
  * Ratchet this down as optimizations land. Warns but never blocks commits.
  */
-const AGGREGATE_TIME_BUDGET_MS = 60_000;
+const AGGREGATE_TIME_BUDGET_MS = 50_000;
 
 /** Number of test files to profile concurrently — scales with available CPUs */
 const PROFILE_CONCURRENCY = Math.max(4, Math.min(navigator.hardwareConcurrency ?? 4, 32));
@@ -51,6 +51,7 @@ const TIMING_EXCLUSIONS: Record<string, string> = {
   "test/transport-errors.spec.ts": "Live daemon transport error integration tests",
   "packages/daemon/src/index.spec.ts": "13 in-process daemon instances for startup/shutdown/idle/reload",
   "packages/daemon/src/config/watcher.spec.ts": "FS polling integration tests with 8s timeouts",
+  "packages/core/src/alias-bundle-tsc.spec.ts": "bunx tsc subprocess spawning per test (~3-4s each)",
 };
 
 /**


### PR DESCRIPTION
## Summary
- Split `validateFreeformTsc` tests (4 tests spawning `bunx tsc`, ~14s total) from `alias-bundle.spec.ts` into `alias-bundle-tsc.spec.ts` with `TIMING_EXCLUSION`
- Ratcheted `AGGREGATE_TIME_BUDGET_MS` from 60s → 50s — actual aggregate dropped from 58.2s to 40.7s
- `alias-bundle.spec.ts` went from 17.7s (3.5x over budget) to ~0.2s

## Test plan
- [x] `bun test packages/core/src/alias-bundle.spec.ts` — 27 tests pass in ~200ms
- [x] `bun test packages/core/src/alias-bundle-tsc.spec.ts` — 4 tests pass in ~2.7s
- [x] `bun typecheck` — passes
- [x] `bun lint` — passes
- [x] `bun test` — 3527 tests pass, 0 failures
- [x] `bun scripts/check-coverage.ts` — no OVER BUDGET warnings, aggregate 40.7s < 50s budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)