### PR TITLE
feat: add feature parity shims for non-claude providers (fixes #911)

### DIFF
--- a/packages/command/src/commands/acp.spec.ts
+++ b/packages/command/src/commands/acp.spec.ts
@@ -13,6 +13,8 @@ function makeDeps(overrides?: Partial<AcpDeps>): AcpDeps {
       throw new ExitError(code);
     }) as AcpDeps["exit"],
     getStaleDaemonWarning: mock(() => null),
+    getGitRoot: mock(() => null),
+    getPrStatus: mock(async () => null),
     exec: mock(() => ({ stdout: "", stderr: "", exitCode: 0 })),
     ...overrides,
   };

--- a/packages/command/src/commands/acp.ts
+++ b/packages/command/src/commands/acp.ts
@@ -26,14 +26,25 @@ import { c, printError as defaultPrintError, formatToolResult } from "../output"
 import { extractFullFlag, extractJqFlag, extractJsonFlag } from "../parse";
 
 import {
+  type PrStatus,
   type SharedSessionDeps,
   cleanupWorktree,
+  defaultGetPrStatus,
   parseByeResult,
   parseLogArgs,
   parseWaitArgs,
   resolveSessionId,
 } from "./claude";
-import { colorState, extractContentSummary, formatSessionShort } from "./session-display";
+import {
+  type TranscriptEntry,
+  colorState,
+  compactTranscript,
+  extractContentSummary,
+  filterByRepo,
+  formatCost,
+  formatSessionShort,
+  getGitRepoRoot,
+} from "./session-display";
 import type { SharedSpawnArgs } from "./spawn-args";
 import { parseSharedSpawnArgs } from "./spawn-args";
 
@@ -46,6 +57,8 @@ const P = "acp";
 
 export interface AcpDeps extends SharedSessionDeps {
   getStaleDaemonWarning: () => string | null;
+  getGitRoot: () => string | null;
+  getPrStatus: (worktreePath: string) => Promise<PrStatus | null>;
 }
 
 const defaultDeps: AcpDeps = {
@@ -57,6 +70,8 @@ const defaultDeps: AcpDeps = {
   printError: defaultPrintError,
   exit: (code) => process.exit(code),
   getStaleDaemonWarning,
+  getGitRoot: getGitRepoRoot,
+  getPrStatus: defaultGetPrStatus,
   exec: (cmd, opts) => {
     const result = Bun.spawnSync(cmd, {
       stdout: "pipe",
@@ -265,6 +280,8 @@ async function acpSpawn(args: string[], agentOverride: string | undefined, d: Ac
 async function acpList(args: string[], agentOverride: string | undefined, d: AcpDeps): Promise<void> {
   const { json } = extractJsonFlag(args);
   const short = args.includes("--short");
+  const showPr = args.includes("--pr");
+  const showAll = args.includes("--all") || args.includes("-a");
 
   // Pass agent filter to daemon — when using `mcx copilot ls`, only show copilot sessions
   const toolArgs: Record<string, unknown> = {};
@@ -287,6 +304,14 @@ async function acpList(args: string[], agentOverride: string | undefined, d: Acp
     return;
   }
 
+  // Client-side repo-scoping: filter by cwd prefix unless --all
+  if (!showAll) {
+    const gitRoot = d.getGitRoot();
+    if (gitRoot) {
+      sessions = filterByRepo(sessions, gitRoot);
+    }
+  }
+
   if (sessions.length === 0) {
     const label = agentFilter ? `${agentFilter} ` : "ACP ";
     console.error(`No active ${label}sessions.`);
@@ -300,24 +325,41 @@ async function acpList(args: string[], agentOverride: string | undefined, d: Acp
     return;
   }
 
+  // Gather PR status for worktree sessions in parallel
+  const prStatuses = showPr
+    ? await Promise.all(sessions.map((s) => (s.worktree ? d.getPrStatus(s.worktree) : Promise.resolve(null))))
+    : sessions.map(() => null);
+
+  const hasAnyPr = showPr && prStatuses.some((pr) => pr !== null);
+
   // Table output
   const showAgent = !agentOverride;
   const agentHeader = showAgent ? ` ${"AGENT".padEnd(10)}` : "";
-  const header = `${"SESSION".padEnd(10)} ${"STATE".padEnd(12)}${agentHeader} ${"MODEL".padEnd(16)} ${"COST".padEnd(8)} ${"TOKENS".padEnd(10)} CWD`;
+  const prHeader = hasAnyPr ? ` ${"PR".padEnd(12)}` : "";
+  const header = `${"SESSION".padEnd(10)} ${"STATE".padEnd(12)}${agentHeader} ${"MODEL".padEnd(16)} ${"COST".padEnd(8)} ${"TOKENS".padEnd(10)}${prHeader} CWD`;
   console.log(`${c.dim}${header}${c.reset}`);
 
-  for (const s of sessions) {
+  for (let i = 0; i < sessions.length; i++) {
+    const s = sessions[i];
     const id = s.sessionId.slice(0, 8);
     const state = colorState(s.state);
     const agentCol = showAgent
       ? ` ${(((s as unknown as Record<string, unknown>).agent as string) ?? "—").padEnd(10)}`
       : "";
     const model = (s.model ?? "—").padEnd(16);
-    const cost = s.cost != null && s.cost > 0 ? `$${s.cost.toFixed(4)}`.padEnd(8) : "N/A".padEnd(8);
+    const cost = formatCost(s.cost, s.tokens).padEnd(8);
     const tokens = s.tokens > 0 ? String(s.tokens).padEnd(10) : "—".padEnd(10);
+    const pr = hasAnyPr ? ` ${formatPrStatus(prStatuses[i]).padEnd(12)}` : "";
     const cwd = s.cwd ?? "—";
-    console.log(`${c.cyan}${id}${c.reset}   ${state}${agentCol} ${model} ${cost} ${tokens} ${c.dim}${cwd}${c.reset}`);
+    console.log(
+      `${c.cyan}${id}${c.reset}   ${state}${agentCol} ${model} ${cost} ${tokens}${pr} ${c.dim}${cwd}${c.reset}`,
+    );
   }
+}
+
+function formatPrStatus(pr: PrStatus | null): string {
+  if (!pr) return "—";
+  return `#${pr.number} ${pr.state}`;
 }
 
 /** Extract --agent value from args without consuming them. */
@@ -399,6 +441,7 @@ async function acpInterrupt(args: string[], _agentOverride: string | undefined, 
 
 async function acpLog(args: string[], _agentOverride: string | undefined, d: AcpDeps): Promise<void> {
   const parsed = parseLogArgs(args);
+  const compact = args.includes("--compact");
 
   if (parsed.error) {
     d.printError(parsed.error);
@@ -406,7 +449,7 @@ async function acpLog(args: string[], _agentOverride: string | undefined, d: Acp
   }
 
   if (!parsed.sessionPrefix) {
-    d.printError("Usage: mcx acp log <session-id> [--last N]");
+    d.printError("Usage: mcx acp log <session-id> [--last N] [--compact]");
     d.exit(1);
   }
 
@@ -430,12 +473,16 @@ async function acpLog(args: string[], _agentOverride: string | undefined, d: Acp
     return;
   }
 
-  let entries: Array<{ timestamp: number; direction: string; message: { type: string; [k: string]: unknown } }>;
+  let entries: TranscriptEntry[];
   try {
     entries = JSON.parse(text);
   } catch {
     console.log(text);
     return;
+  }
+
+  if (compact) {
+    entries = compactTranscript(entries);
   }
 
   const truncate = (s: string) => (parsed.full || s.length <= 200 ? s : `${s.slice(0, 200)}…`);
@@ -562,7 +609,9 @@ function printAcpUsage(agentOverride?: string): void {
 
 Usage:
   mcx ${name} spawn${agentFlag} --task "description"    Start a new session
-  mcx ${name} ls${agentOverride ? "" : " [--agent <name>]"}                        List active sessions
+  mcx ${name} ls${agentOverride ? "" : " [--agent <name>]"}                        List active sessions (current repo)
+  mcx ${name} ls --all                      List all sessions (all repos)
+  mcx ${name} ls --pr                       Show PR status for worktree sessions
   mcx ${name} send <session> <message>      Send follow-up prompt
   mcx ${name} wait [session]                Block until a session event occurs
   mcx ${name} bye <session>                 End session and stop process
@@ -571,6 +620,7 @@ Usage:
   mcx ${name} log <session> --json          Raw JSON transcript output
   mcx ${name} log <session> --json --jq '.' Apply jq filter to JSON output
   mcx ${name} log <session> --full          Full output (no truncation)
+  mcx ${name} log <session> --compact       Truncated tool results for overview
 
 Spawn options:
 ${

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -1001,6 +1001,7 @@ export function parseLogArgs(args: string[]): LogArgs {
 
 async function claudeLog(args: string[], d: ClaudeDeps): Promise<void> {
   const parsed = parseLogArgs(args);
+  const compact = args.includes("--compact");
 
   if (parsed.error) {
     d.printError(parsed.error);
@@ -1008,12 +1009,15 @@ async function claudeLog(args: string[], d: ClaudeDeps): Promise<void> {
   }
 
   if (!parsed.sessionPrefix) {
-    d.printError("Usage: mcx claude log <session-id> [--last N]");
+    d.printError("Usage: mcx claude log <session-id> [--last N] [--compact]");
     d.exit(1);
   }
 
   const sessionId = await resolveSessionId(parsed.sessionPrefix, d);
-  const result = await d.callTool("claude_transcript", { sessionId, limit: parsed.last });
+  // Claude supports compact natively in the daemon
+  const toolArgs: Record<string, unknown> = { sessionId, limit: parsed.last };
+  if (compact) toolArgs.compact = true;
+  const result = await d.callTool("claude_transcript", toolArgs);
   const text = formatToolResult(result);
 
   if (parsed.json) {

--- a/packages/command/src/commands/codex.spec.ts
+++ b/packages/command/src/commands/codex.spec.ts
@@ -13,6 +13,8 @@ function makeDeps(overrides?: Partial<CodexDeps>): CodexDeps {
       throw new ExitError(code);
     }) as CodexDeps["exit"],
     getStaleDaemonWarning: mock(() => null),
+    getGitRoot: mock(() => null),
+    getPrStatus: mock(async () => null),
     exec: mock(() => ({ stdout: "", stderr: "", exitCode: 0 })),
     ...overrides,
   };
@@ -401,7 +403,7 @@ describe("codex ls", () => {
     }
   });
 
-  test("shows N/A for cost in table output", async () => {
+  test("shows estimated cost when real cost is null", async () => {
     const deps = makeDeps({
       callTool: mock(async () => toolResult(SESSION_LIST)),
     });
@@ -410,10 +412,10 @@ describe("codex ls", () => {
     console.log = mock((...args: unknown[]) => logCalls.push(String(args[0])));
     try {
       await cmdCodex(["ls"], deps);
-      // Session rows should contain N/A for cost
+      // Session rows should show estimated cost (with ~ prefix) instead of N/A
       const sessionRows = logCalls.filter((l) => l.includes("abc12345".slice(0, 8)));
       expect(sessionRows.length).toBeGreaterThan(0);
-      expect(sessionRows[0]).toContain("N/A");
+      expect(sessionRows[0]).toContain("~$");
     } finally {
       console.log = origLog;
     }
@@ -465,6 +467,92 @@ describe("codex ls", () => {
       expect(errCalls.some((l) => l.includes("No active Codex sessions"))).toBe(true);
     } finally {
       console.error = origErr;
+    }
+  });
+
+  test("filters sessions by repo root when getGitRoot returns a path", async () => {
+    const sessionsWithCwd = [
+      { ...SESSION_LIST[0], cwd: "/my/repo/src" },
+      { ...SESSION_LIST[1], cwd: "/other/project" },
+    ];
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(sessionsWithCwd)),
+      getGitRoot: mock(() => "/my/repo"),
+    });
+    const logCalls: string[] = [];
+    const origLog = console.log;
+    console.log = mock((...args: unknown[]) => logCalls.push(String(args[0])));
+    try {
+      await cmdCodex(["ls"], deps);
+      // Only first session should appear (cwd under /my/repo)
+      const sessionRows = logCalls.filter((l) => l.includes("abc12345".slice(0, 8)));
+      expect(sessionRows.length).toBe(1);
+      const otherRows = logCalls.filter((l) => l.includes("def67890".slice(0, 8)));
+      expect(otherRows.length).toBe(0);
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("--all bypasses repo filtering", async () => {
+    const sessionsWithCwd = [
+      { ...SESSION_LIST[0], cwd: "/my/repo/src" },
+      { ...SESSION_LIST[1], cwd: "/other/project" },
+    ];
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(sessionsWithCwd)),
+      getGitRoot: mock(() => "/my/repo"),
+    });
+    const logCalls: string[] = [];
+    const origLog = console.log;
+    console.log = mock((...args: unknown[]) => logCalls.push(String(args[0])));
+    try {
+      await cmdCodex(["ls", "--all"], deps);
+      // Both sessions should appear
+      const allRows = logCalls.filter((l) => l.includes("abc12345".slice(0, 8)) || l.includes("def67890".slice(0, 8)));
+      expect(allRows.length).toBe(2);
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("shows estimated cost when real cost is null", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(SESSION_LIST)),
+    });
+    const logCalls: string[] = [];
+    const origLog = console.log;
+    console.log = mock((...args: unknown[]) => logCalls.push(String(args[0])));
+    try {
+      await cmdCodex(["ls"], deps);
+      // Cost should show estimated value with ~ prefix instead of N/A
+      const sessionRows = logCalls.filter((l) => l.includes("abc12345".slice(0, 8)));
+      expect(sessionRows.length).toBeGreaterThan(0);
+      expect(sessionRows[0]).toContain("~$");
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("--pr shows PR status for worktree sessions", async () => {
+    const sessionsWithWt = [
+      { ...SESSION_LIST[0], worktree: "feat-branch", cwd: "/repo/.claude/worktrees/feat-branch" },
+    ];
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(sessionsWithWt)),
+      getPrStatus: mock(async () => ({ number: 42, state: "open" })),
+    });
+    const logCalls: string[] = [];
+    const origLog = console.log;
+    console.log = mock((...args: unknown[]) => logCalls.push(String(args[0])));
+    try {
+      await cmdCodex(["ls", "--pr"], deps);
+      const headerRow = logCalls.find((l) => l.includes("PR"));
+      expect(headerRow).toBeDefined();
+      const sessionRow = logCalls.find((l) => l.includes("#42"));
+      expect(sessionRow).toBeDefined();
+    } finally {
+      console.log = origLog;
     }
   });
 });

--- a/packages/command/src/commands/codex.ts
+++ b/packages/command/src/commands/codex.ts
@@ -22,14 +22,25 @@ import { c, printError as defaultPrintError, formatToolResult } from "../output"
 import { extractFullFlag, extractJqFlag, extractJsonFlag } from "../parse";
 
 import {
+  type PrStatus,
   type SharedSessionDeps,
   cleanupWorktree,
+  defaultGetPrStatus,
   parseByeResult,
   parseLogArgs,
   parseWaitArgs,
   resolveSessionId,
 } from "./claude";
-import { colorState, extractContentSummary, formatSessionShort } from "./session-display";
+import {
+  type TranscriptEntry,
+  colorState,
+  compactTranscript,
+  extractContentSummary,
+  filterByRepo,
+  formatCost,
+  formatSessionShort,
+  getGitRepoRoot,
+} from "./session-display";
 import type { SharedSpawnArgs } from "./spawn-args";
 import { parseSharedSpawnArgs } from "./spawn-args";
 
@@ -40,9 +51,11 @@ const P = "codex";
 
 // ── Dependency injection ──
 
-/** Codex deps use only the shared session fields — no claude-specific helpers. */
+/** Codex deps extend shared deps with PR/diff/repo helpers for feature parity. */
 export interface CodexDeps extends SharedSessionDeps {
   getStaleDaemonWarning: () => string | null;
+  getGitRoot: () => string | null;
+  getPrStatus: (worktreePath: string) => Promise<PrStatus | null>;
 }
 
 const defaultDeps: CodexDeps = {
@@ -54,6 +67,8 @@ const defaultDeps: CodexDeps = {
   printError: defaultPrintError,
   exit: (code) => process.exit(code),
   getStaleDaemonWarning,
+  getGitRoot: getGitRepoRoot,
+  getPrStatus: defaultGetPrStatus,
   exec: (cmd, opts) => {
     const result = Bun.spawnSync(cmd, {
       stdout: "pipe",
@@ -228,6 +243,9 @@ async function codexSpawn(args: string[], d: CodexDeps): Promise<void> {
 async function codexList(args: string[], d: CodexDeps): Promise<void> {
   const { json } = extractJsonFlag(args);
   const short = args.includes("--short");
+  const showPr = args.includes("--pr");
+  const showAll = args.includes("--all") || args.includes("-a");
+
   const result = await d.callTool(`${P}_session_list`, {});
   const text = formatToolResult(result);
 
@@ -244,6 +262,14 @@ async function codexList(args: string[], d: CodexDeps): Promise<void> {
     return;
   }
 
+  // Client-side repo-scoping: filter by cwd prefix unless --all
+  if (!showAll) {
+    const gitRoot = d.getGitRoot();
+    if (gitRoot) {
+      sessions = filterByRepo(sessions, gitRoot);
+    }
+  }
+
   if (sessions.length === 0) {
     console.error("No active Codex sessions.");
     return;
@@ -256,19 +282,34 @@ async function codexList(args: string[], d: CodexDeps): Promise<void> {
     return;
   }
 
+  // Gather PR status for worktree sessions in parallel
+  const prStatuses = showPr
+    ? await Promise.all(sessions.map((s) => (s.worktree ? d.getPrStatus(s.worktree) : Promise.resolve(null))))
+    : sessions.map(() => null);
+
+  const hasAnyPr = showPr && prStatuses.some((pr) => pr !== null);
+
   // Table output
-  const header = `${"SESSION".padEnd(10)} ${"STATE".padEnd(12)} ${"MODEL".padEnd(16)} ${"COST".padEnd(8)} ${"TOKENS".padEnd(10)} CWD`;
+  const prHeader = hasAnyPr ? ` ${"PR".padEnd(12)}` : "";
+  const header = `${"SESSION".padEnd(10)} ${"STATE".padEnd(12)} ${"MODEL".padEnd(16)} ${"COST".padEnd(8)} ${"TOKENS".padEnd(10)}${prHeader} CWD`;
   console.log(`${c.dim}${header}${c.reset}`);
 
-  for (const s of sessions) {
+  for (let i = 0; i < sessions.length; i++) {
+    const s = sessions[i];
     const id = s.sessionId.slice(0, 8);
     const state = colorState(s.state);
     const model = (s.model ?? "—").padEnd(16);
-    const cost = s.cost != null && s.cost > 0 ? `$${s.cost.toFixed(4)}`.padEnd(8) : "N/A".padEnd(8);
+    const cost = formatCost(s.cost, s.tokens).padEnd(8);
     const tokens = s.tokens > 0 ? String(s.tokens).padEnd(10) : "—".padEnd(10);
+    const pr = hasAnyPr ? ` ${formatPrStatus(prStatuses[i]).padEnd(12)}` : "";
     const cwd = s.cwd ?? "—";
-    console.log(`${c.cyan}${id}${c.reset}   ${state} ${model} ${cost} ${tokens} ${c.dim}${cwd}${c.reset}`);
+    console.log(`${c.cyan}${id}${c.reset}   ${state} ${model} ${cost} ${tokens}${pr} ${c.dim}${cwd}${c.reset}`);
   }
+}
+
+function formatPrStatus(pr: PrStatus | null): string {
+  if (!pr) return "—";
+  return `#${pr.number} ${pr.state}`;
 }
 
 // ── Send ──
@@ -340,6 +381,7 @@ async function codexInterrupt(args: string[], d: CodexDeps): Promise<void> {
 
 async function codexLog(args: string[], d: CodexDeps): Promise<void> {
   const parsed = parseLogArgs(args);
+  const compact = args.includes("--compact");
 
   if (parsed.error) {
     d.printError(parsed.error);
@@ -347,7 +389,7 @@ async function codexLog(args: string[], d: CodexDeps): Promise<void> {
   }
 
   if (!parsed.sessionPrefix) {
-    d.printError("Usage: mcx codex log <session-id> [--last N]");
+    d.printError("Usage: mcx codex log <session-id> [--last N] [--compact]");
     d.exit(1);
   }
 
@@ -371,12 +413,17 @@ async function codexLog(args: string[], d: CodexDeps): Promise<void> {
     return;
   }
 
-  let entries: Array<{ timestamp: number; direction: string; message: { type: string; [k: string]: unknown } }>;
+  let entries: TranscriptEntry[];
   try {
     entries = JSON.parse(text);
   } catch {
     console.log(text);
     return;
+  }
+
+  // Client-side compact: truncate tool results
+  if (compact) {
+    entries = compactTranscript(entries);
   }
 
   const truncate = (s: string) => (parsed.full || s.length <= 200 ? s : `${s.slice(0, 200)}…`);
@@ -476,7 +523,9 @@ Usage:
   mcx codex spawn --task "..." --json     Machine-parseable JSON output
   mcx codex spawn "description"           Shorthand (positional task)
   mcx codex spawn -w --task "desc"        Spawn in a new git worktree
-  mcx codex ls                            List active Codex sessions
+  mcx codex ls                            List active Codex sessions (current repo)
+  mcx codex ls --all                      List all Codex sessions (all repos)
+  mcx codex ls --pr                       Show PR status for worktree sessions
   mcx codex send <session> <message>      Send follow-up prompt (non-blocking)
   mcx codex wait [session]                Block until a session event occurs
   mcx codex bye <session>                 End session and stop process
@@ -485,6 +534,7 @@ Usage:
   mcx codex log <session> --json          Raw JSON transcript output
   mcx codex log <session> --json --jq '.' Apply jq filter to JSON output
   mcx codex log <session> --full          Full output (no truncation)
+  mcx codex log <session> --compact       Truncated tool results for overview
 
 Spawn options:
   --task, -t "description"    Task prompt for Codex
@@ -504,5 +554,5 @@ Wait options:
   --timeout, -t <ms>          Max wait time (default: 300000)
 
 Session IDs support prefix matching (like git SHAs).
-Cost is not tracked for Codex sessions (shown as N/A).`);
+Cost is estimated from token counts when not reported by the provider (shown as ~$X.XXXX).`);
 }

--- a/packages/command/src/commands/opencode.spec.ts
+++ b/packages/command/src/commands/opencode.spec.ts
@@ -13,6 +13,8 @@ function makeDeps(overrides?: Partial<OpencodeDeps>): OpencodeDeps {
       throw new ExitError(code);
     }) as OpencodeDeps["exit"],
     getStaleDaemonWarning: mock(() => null),
+    getGitRoot: mock(() => null),
+    getPrStatus: mock(async () => null),
     exec: mock(() => ({ stdout: "", stderr: "", exitCode: 0 })),
     ...overrides,
   };

--- a/packages/command/src/commands/opencode.ts
+++ b/packages/command/src/commands/opencode.ts
@@ -21,14 +21,25 @@ import { c, printError as defaultPrintError, formatToolResult } from "../output"
 import { extractFullFlag, extractJqFlag, extractJsonFlag } from "../parse";
 
 import {
+  type PrStatus,
   type SharedSessionDeps,
   cleanupWorktree,
+  defaultGetPrStatus,
   parseByeResult,
   parseLogArgs,
   parseWaitArgs,
   resolveSessionId,
 } from "./claude";
-import { colorState, extractContentSummary, formatSessionShort } from "./session-display";
+import {
+  type TranscriptEntry,
+  colorState,
+  compactTranscript,
+  extractContentSummary,
+  filterByRepo,
+  formatCost,
+  formatSessionShort,
+  getGitRepoRoot,
+} from "./session-display";
 import type { SharedSpawnArgs } from "./spawn-args";
 import { parseSharedSpawnArgs } from "./spawn-args";
 
@@ -39,9 +50,11 @@ const P = "opencode";
 
 // ── Dependency injection ──
 
-/** OpenCode deps use only the shared session fields — no provider-specific helpers. */
+/** OpenCode deps extend shared deps with PR/repo helpers for feature parity. */
 export interface OpencodeDeps extends SharedSessionDeps {
   getStaleDaemonWarning: () => string | null;
+  getGitRoot: () => string | null;
+  getPrStatus: (worktreePath: string) => Promise<PrStatus | null>;
 }
 
 const defaultDeps: OpencodeDeps = {
@@ -53,6 +66,8 @@ const defaultDeps: OpencodeDeps = {
   printError: defaultPrintError,
   exit: (code) => process.exit(code),
   getStaleDaemonWarning,
+  getGitRoot: getGitRepoRoot,
+  getPrStatus: defaultGetPrStatus,
   exec: (cmd, opts) => {
     const result = Bun.spawnSync(cmd, {
       stdout: "pipe",
@@ -243,6 +258,9 @@ async function opencodeSpawn(args: string[], d: OpencodeDeps): Promise<void> {
 async function opencodeList(args: string[], d: OpencodeDeps): Promise<void> {
   const { json } = extractJsonFlag(args);
   const short = args.includes("--short");
+  const showPr = args.includes("--pr");
+  const showAll = args.includes("--all") || args.includes("-a");
+
   const result = await d.callTool(`${P}_session_list`, {});
   const text = formatToolResult(result);
 
@@ -259,6 +277,14 @@ async function opencodeList(args: string[], d: OpencodeDeps): Promise<void> {
     return;
   }
 
+  // Client-side repo-scoping: filter by cwd prefix unless --all
+  if (!showAll) {
+    const gitRoot = d.getGitRoot();
+    if (gitRoot) {
+      sessions = filterByRepo(sessions, gitRoot);
+    }
+  }
+
   if (sessions.length === 0) {
     console.error("No active OpenCode sessions.");
     return;
@@ -271,19 +297,34 @@ async function opencodeList(args: string[], d: OpencodeDeps): Promise<void> {
     return;
   }
 
+  // Gather PR status for worktree sessions in parallel
+  const prStatuses = showPr
+    ? await Promise.all(sessions.map((s) => (s.worktree ? d.getPrStatus(s.worktree) : Promise.resolve(null))))
+    : sessions.map(() => null);
+
+  const hasAnyPr = showPr && prStatuses.some((pr) => pr !== null);
+
   // Table output
-  const header = `${"SESSION".padEnd(10)} ${"STATE".padEnd(12)} ${"MODEL".padEnd(16)} ${"COST".padEnd(8)} ${"TOKENS".padEnd(10)} CWD`;
+  const prHeader = hasAnyPr ? ` ${"PR".padEnd(12)}` : "";
+  const header = `${"SESSION".padEnd(10)} ${"STATE".padEnd(12)} ${"MODEL".padEnd(16)} ${"COST".padEnd(8)} ${"TOKENS".padEnd(10)}${prHeader} CWD`;
   console.log(`${c.dim}${header}${c.reset}`);
 
-  for (const s of sessions) {
+  for (let i = 0; i < sessions.length; i++) {
+    const s = sessions[i];
     const id = s.sessionId.slice(0, 8);
     const state = colorState(s.state);
     const model = (s.model ?? "—").padEnd(16);
-    const cost = s.cost != null && s.cost > 0 ? `$${s.cost.toFixed(4)}`.padEnd(8) : "—".padEnd(8);
+    const cost = formatCost(s.cost, s.tokens).padEnd(8);
     const tokens = s.tokens > 0 ? String(s.tokens).padEnd(10) : "—".padEnd(10);
+    const pr = hasAnyPr ? ` ${formatPrStatus(prStatuses[i]).padEnd(12)}` : "";
     const cwd = s.cwd ?? "—";
-    console.log(`${c.cyan}${id}${c.reset}   ${state} ${model} ${cost} ${tokens} ${c.dim}${cwd}${c.reset}`);
+    console.log(`${c.cyan}${id}${c.reset}   ${state} ${model} ${cost} ${tokens}${pr} ${c.dim}${cwd}${c.reset}`);
   }
+}
+
+function formatPrStatus(pr: PrStatus | null): string {
+  if (!pr) return "—";
+  return `#${pr.number} ${pr.state}`;
 }
 
 // ── Send ──
@@ -355,6 +396,7 @@ async function opencodeInterrupt(args: string[], d: OpencodeDeps): Promise<void>
 
 async function opencodeLog(args: string[], d: OpencodeDeps): Promise<void> {
   const parsed = parseLogArgs(args);
+  const compact = args.includes("--compact");
 
   if (parsed.error) {
     d.printError(parsed.error);
@@ -362,7 +404,7 @@ async function opencodeLog(args: string[], d: OpencodeDeps): Promise<void> {
   }
 
   if (!parsed.sessionPrefix) {
-    d.printError("Usage: mcx opencode log <session-id> [--last N]");
+    d.printError("Usage: mcx opencode log <session-id> [--last N] [--compact]");
     d.exit(1);
   }
 
@@ -386,12 +428,16 @@ async function opencodeLog(args: string[], d: OpencodeDeps): Promise<void> {
     return;
   }
 
-  let entries: Array<{ timestamp: number; direction: string; message: { type: string; [k: string]: unknown } }>;
+  let entries: TranscriptEntry[];
   try {
     entries = JSON.parse(text);
   } catch {
     console.log(text);
     return;
+  }
+
+  if (compact) {
+    entries = compactTranscript(entries);
   }
 
   const truncate = (s: string) => (parsed.full || s.length <= 200 ? s : `${s.slice(0, 200)}…`);
@@ -491,7 +537,9 @@ Usage:
   mcx opencode spawn --task "..." --json     Machine-parseable JSON output
   mcx opencode spawn "description"           Shorthand (positional task)
   mcx opencode spawn -w --task "desc"        Spawn in a new git worktree
-  mcx opencode ls                            List active OpenCode sessions
+  mcx opencode ls                            List active OpenCode sessions (current repo)
+  mcx opencode ls --all                      List all OpenCode sessions (all repos)
+  mcx opencode ls --pr                       Show PR status for worktree sessions
   mcx opencode send <session> <message>      Send follow-up prompt (non-blocking)
   mcx opencode wait [session]                Block until a session event occurs
   mcx opencode bye <session>                 End session and stop process
@@ -500,6 +548,7 @@ Usage:
   mcx opencode log <session> --json          Raw JSON transcript output
   mcx opencode log <session> --json --jq '.' Apply jq filter to JSON output
   mcx opencode log <session> --full          Full output (no truncation)
+  mcx opencode log <session> --compact       Truncated tool results for overview
 
 Spawn options:
   --task, -t "description"    Task prompt for OpenCode
@@ -520,5 +569,6 @@ Wait options:
   --timeout, -t <ms>          Max wait time (default: 300000)
 
 Session IDs support prefix matching (like git SHAs).
-OpenCode tracks cost in USD and reports reasoning tokens.`);
+OpenCode tracks cost in USD and reports reasoning tokens.
+Cost is estimated from token counts when not reported by the provider (shown as ~$X.XXXX).`);
 }

--- a/packages/command/src/commands/session-display.spec.ts
+++ b/packages/command/src/commands/session-display.spec.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+import { type TranscriptEntry, compactTranscript, estimateCost, filterByRepo, formatCost } from "./session-display";
+
+describe("estimateCost", () => {
+  test("returns null for zero tokens", () => {
+    expect(estimateCost(0)).toBeNull();
+  });
+
+  test("returns null for undefined/null", () => {
+    expect(estimateCost(undefined)).toBeNull();
+    expect(estimateCost(null)).toBeNull();
+  });
+
+  test("estimates cost at $5/M tokens", () => {
+    const cost = estimateCost(1_000_000);
+    expect(cost).toBeCloseTo(5.0, 4);
+  });
+
+  test("estimates small token counts", () => {
+    const cost = estimateCost(1000);
+    expect(cost).toBeCloseTo(0.005, 6);
+  });
+});
+
+describe("formatCost", () => {
+  test("uses real cost when available", () => {
+    expect(formatCost(1.2345, 1000)).toBe("$1.2345");
+  });
+
+  test("uses estimated cost when real cost is null", () => {
+    expect(formatCost(null, 1000)).toBe("~$0.0050");
+  });
+
+  test("uses estimated cost when real cost is zero", () => {
+    expect(formatCost(0, 1000)).toBe("~$0.0050");
+  });
+
+  test("returns dash when no cost or tokens", () => {
+    expect(formatCost(null, null)).toBe("—");
+    expect(formatCost(null, 0)).toBe("—");
+  });
+});
+
+describe("filterByRepo", () => {
+  const sessions = [
+    { sessionId: "a", cwd: "/repo/project/src" },
+    { sessionId: "b", cwd: "/other/place" },
+    { sessionId: "c", cwd: "/repo/project/tests" },
+    { sessionId: "d", cwd: null },
+  ];
+
+  test("filters sessions by repo root prefix", () => {
+    const filtered = filterByRepo(sessions, "/repo/project");
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map((s) => s.sessionId)).toEqual(["a", "c"]);
+  });
+
+  test("excludes sessions with null cwd", () => {
+    const filtered = filterByRepo(sessions, "/repo/project");
+    expect(filtered.every((s) => s.cwd !== null)).toBe(true);
+  });
+
+  test("returns empty when no matches", () => {
+    const filtered = filterByRepo(sessions, "/nonexistent");
+    expect(filtered).toHaveLength(0);
+  });
+});
+
+describe("compactTranscript", () => {
+  test("truncates long tool results", () => {
+    const longResult = "x".repeat(200);
+    const entries: TranscriptEntry[] = [
+      {
+        timestamp: Date.now(),
+        direction: "inbound",
+        message: { type: "result", result: longResult },
+      },
+    ];
+    const compacted = compactTranscript(entries, 100);
+    const result = (compacted[0].message as Record<string, unknown>).result as string;
+    expect(result.length).toBe(101); // 100 chars + "…"
+    expect(result.endsWith("…")).toBe(true);
+  });
+
+  test("leaves short results unchanged", () => {
+    const entries: TranscriptEntry[] = [
+      {
+        timestamp: Date.now(),
+        direction: "inbound",
+        message: { type: "result", result: "short" },
+      },
+    ];
+    const compacted = compactTranscript(entries, 100);
+    expect((compacted[0].message as Record<string, unknown>).result).toBe("short");
+  });
+
+  test("truncates tool_result content in assistant messages", () => {
+    const longContent = "y".repeat(200);
+    const entries: TranscriptEntry[] = [
+      {
+        timestamp: Date.now(),
+        direction: "outbound",
+        message: {
+          type: "assistant",
+          message: {
+            content: [{ type: "tool_result", content: longContent }],
+          },
+        },
+      },
+    ];
+    const compacted = compactTranscript(entries, 100);
+    const msg = compacted[0].message.message as { content: Array<{ content: string }> };
+    expect(msg.content[0].content.length).toBe(101);
+    expect(msg.content[0].content.endsWith("…")).toBe(true);
+  });
+
+  test("preserves non-tool entries unchanged", () => {
+    const entries: TranscriptEntry[] = [
+      {
+        timestamp: Date.now(),
+        direction: "outbound",
+        message: { type: "user", message: { content: "hello" } },
+      },
+    ];
+    const compacted = compactTranscript(entries, 100);
+    expect(compacted).toEqual(entries);
+  });
+});

--- a/packages/command/src/commands/session-display.ts
+++ b/packages/command/src/commands/session-display.ts
@@ -1,8 +1,16 @@
 /**
- * Shared session-display helpers used by both `claude.ts` and `codex.ts`.
+ * Shared session-display helpers used by `claude.ts`, `codex.ts`, `opencode.ts`, and `acp.ts`.
  */
 
+import { dirname, resolve } from "node:path";
 import { c } from "../output";
+
+/** Transcript entry shape shared across providers. */
+export interface TranscriptEntry {
+  timestamp: number;
+  direction: string;
+  message: { type: string; [k: string]: unknown };
+}
 
 /** Compact one-line format: SESSION STATE MODEL COST TOKENS TURNS */
 export function formatSessionShort(s: {
@@ -48,6 +56,99 @@ export function extractContentSummary(content: unknown): string | null {
     }
   }
   return parts.length > 0 ? parts.join(" ") : null;
+}
+
+/**
+ * Estimate cost from token count when the provider doesn't report cost.
+ * Uses a rough blended rate of $5/M tokens (input-weighted average across common models).
+ * Returns null if tokens are unavailable.
+ */
+export function estimateCost(tokens: number | undefined | null): number | null {
+  if (!tokens || tokens <= 0) return null;
+  return tokens * 5e-6; // $5 per million tokens
+}
+
+/**
+ * Format cost for display, using estimate if real cost is unavailable.
+ * Returns a formatted string like "$0.1234" or "~$0.0050" (estimated) or "—".
+ */
+export function formatCost(cost: number | null | undefined, tokens: number | undefined | null): string {
+  if (cost != null && cost > 0) return `$${cost.toFixed(4)}`;
+  const est = estimateCost(tokens);
+  if (est !== null) return `~$${est.toFixed(4)}`;
+  return "—";
+}
+
+/**
+ * Compact a transcript by truncating tool results and collapsing verbose entries.
+ * This is a client-side shim for providers that don't support compact natively.
+ */
+export function compactTranscript(entries: TranscriptEntry[], maxResultLen = 100): TranscriptEntry[] {
+  return entries.map((entry) => {
+    const msg = entry.message;
+    if (msg.type === "result" && typeof (msg as Record<string, unknown>).result === "string") {
+      const result = (msg as Record<string, unknown>).result as string;
+      if (result.length > maxResultLen) {
+        return {
+          ...entry,
+          message: { ...msg, result: `${result.slice(0, maxResultLen)}…` },
+        };
+      }
+    }
+    // Truncate tool_use input in assistant messages
+    if ((msg.type === "assistant" || msg.type === "user") && msg.message) {
+      const inner = msg.message as { content?: unknown };
+      if (Array.isArray(inner.content)) {
+        const compacted = inner.content.map((block: unknown) => {
+          if (block && typeof block === "object") {
+            const b = block as Record<string, unknown>;
+            if (
+              b.type === "tool_result" &&
+              typeof b.content === "string" &&
+              (b.content as string).length > maxResultLen
+            ) {
+              return { ...b, content: `${(b.content as string).slice(0, maxResultLen)}…` };
+            }
+          }
+          return block;
+        });
+        return {
+          ...entry,
+          message: { ...msg, message: { ...inner, content: compacted } },
+        };
+      }
+    }
+    return entry;
+  });
+}
+
+/**
+ * Get the git repo root for the current working directory.
+ * Uses --git-common-dir to resolve to the main repo root, not a worktree.
+ */
+export function getGitRepoRoot(): string | null {
+  try {
+    const result = Bun.spawnSync(["git", "rev-parse", "--git-common-dir"], {
+      stdout: "pipe",
+      stderr: "ignore",
+      timeout: 5000,
+    });
+    if (result.exitCode !== 0) return null;
+    const commonDir = result.stdout.toString().trim();
+    if (!commonDir) return null;
+    const resolved = resolve(commonDir);
+    return resolved.endsWith(".git") ? dirname(resolved) : resolved;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Filter sessions to only those whose cwd is under the current repo root.
+ * This is the client-side shim for repo-scoped filtering.
+ */
+export function filterByRepo<T extends { cwd?: string | null }>(sessions: T[], repoRoot: string): T[] {
+  return sessions.filter((s) => s.cwd?.startsWith(repoRoot));
 }
 
 export function colorState(state: string): string {

--- a/packages/daemon/src/acp-session-worker.ts
+++ b/packages/daemon/src/acp-session-worker.ts
@@ -47,9 +47,48 @@ let transport: WorkerServerTransport | null = null;
 /** Active sessions indexed by session ID. */
 const sessions = new Map<string, AcpSession>();
 
+// ── afterSeq event buffer ──
+
+interface BufferedEvent {
+  seq: number;
+  sessionId: string;
+  event: AgentSessionEvent;
+}
+
+const MAX_EVENT_BUFFER = 200;
+let nextSeq = 1;
+const eventBuffer: BufferedEvent[] = [];
+
+/** Resolvers waiting for events after a specific sequence number. */
+const afterSeqWaiters: Array<{
+  sessionId: string | null;
+  afterSeq: number;
+  resolve: (entry: BufferedEvent) => void;
+  timer: ReturnType<typeof setTimeout>;
+}> = [];
+
+function bufferEvent(sessionId: string, event: AgentSessionEvent): void {
+  const entry: BufferedEvent = { seq: nextSeq++, sessionId, event };
+  eventBuffer.push(entry);
+  if (eventBuffer.length > MAX_EVENT_BUFFER) {
+    eventBuffer.shift();
+  }
+
+  // Resolve any afterSeq waiters that match
+  for (let i = afterSeqWaiters.length - 1; i >= 0; i--) {
+    const w = afterSeqWaiters[i];
+    if (entry.seq > w.afterSeq && (w.sessionId === null || w.sessionId === sessionId)) {
+      clearTimeout(w.timer);
+      afterSeqWaiters.splice(i, 1);
+      w.resolve(entry);
+    }
+  }
+}
+
 // ── Session event → DB message forwarding ──
 
 function forwardSessionEvent(sessionId: string, event: AgentSessionEvent): void {
+  bufferEvent(sessionId, event);
   switch (event.type) {
     case "session:init":
       self.postMessage({
@@ -326,6 +365,51 @@ async function handleWait(args: Record<string, unknown>): Promise<{
 }> {
   const sessionId = args.sessionId as string | undefined;
   const timeoutMs = (args.timeout as number) ?? 300_000;
+  const afterSeq = args.afterSeq as number | undefined;
+
+  // afterSeq cursor: check buffer first, then block until a new event arrives
+  if (afterSeq !== undefined) {
+    const buffered = eventBuffer.filter((e) => e.seq > afterSeq && (sessionId == null || e.sessionId === sessionId));
+    if (buffered.length > 0) {
+      const entry = buffered[0];
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ ...entry.event, seq: entry.seq, sessionId: entry.sessionId }, null, 2),
+          },
+        ],
+      };
+    }
+
+    const entry = await new Promise<BufferedEvent>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const idx = afterSeqWaiters.findIndex((w) => w.resolve === resolve);
+        if (idx !== -1) afterSeqWaiters.splice(idx, 1);
+        const list = [...sessions.values()].map((s) => s.getInfo());
+        reject({ timeout: true, sessions: list });
+      }, timeoutMs);
+      afterSeqWaiters.push({ sessionId: sessionId ?? null, afterSeq, resolve, timer });
+    }).catch((err) => {
+      if (err && typeof err === "object" && "timeout" in err) {
+        return err as { timeout: true; sessions: unknown[] };
+      }
+      throw err;
+    });
+
+    if ("timeout" in entry) {
+      return { content: [{ type: "text", text: JSON.stringify(entry.sessions, null, 2) }] };
+    }
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ ...entry.event, seq: entry.seq, sessionId: entry.sessionId }, null, 2),
+        },
+      ],
+    };
+  }
 
   if (sessionId) {
     const session = sessions.get(sessionId);

--- a/packages/daemon/src/codex-session-worker.ts
+++ b/packages/daemon/src/codex-session-worker.ts
@@ -52,9 +52,48 @@ let transport: WorkerServerTransport | null = null;
 /** Active sessions indexed by session ID. */
 const sessions = new Map<string, CodexSession>();
 
+// ── afterSeq event buffer ──
+
+interface BufferedEvent {
+  seq: number;
+  sessionId: string;
+  event: AgentSessionEvent;
+}
+
+const MAX_EVENT_BUFFER = 200;
+let nextSeq = 1;
+const eventBuffer: BufferedEvent[] = [];
+
+/** Resolvers waiting for events after a specific sequence number. */
+const afterSeqWaiters: Array<{
+  sessionId: string | null;
+  afterSeq: number;
+  resolve: (entry: BufferedEvent) => void;
+  timer: ReturnType<typeof setTimeout>;
+}> = [];
+
+function bufferEvent(sessionId: string, event: AgentSessionEvent): void {
+  const entry: BufferedEvent = { seq: nextSeq++, sessionId, event };
+  eventBuffer.push(entry);
+  if (eventBuffer.length > MAX_EVENT_BUFFER) {
+    eventBuffer.shift();
+  }
+
+  // Resolve any afterSeq waiters that match
+  for (let i = afterSeqWaiters.length - 1; i >= 0; i--) {
+    const w = afterSeqWaiters[i];
+    if (entry.seq > w.afterSeq && (w.sessionId === null || w.sessionId === sessionId)) {
+      clearTimeout(w.timer);
+      afterSeqWaiters.splice(i, 1);
+      w.resolve(entry);
+    }
+  }
+}
+
 // ── Session event → DB message forwarding ──
 
 function forwardSessionEvent(sessionId: string, event: AgentSessionEvent): void {
+  bufferEvent(sessionId, event);
   switch (event.type) {
     case "session:init":
       self.postMessage({
@@ -335,6 +374,54 @@ async function handleWait(args: Record<string, unknown>): Promise<{
 }> {
   const sessionId = args.sessionId as string | undefined;
   const timeoutMs = (args.timeout as number) ?? 300_000;
+  const afterSeq = args.afterSeq as number | undefined;
+
+  // afterSeq cursor: check buffer first, then block until a new event arrives
+  if (afterSeq !== undefined) {
+    // Check buffer for events past the cursor
+    const buffered = eventBuffer.filter((e) => e.seq > afterSeq && (sessionId == null || e.sessionId === sessionId));
+    if (buffered.length > 0) {
+      const entry = buffered[0];
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ ...entry.event, seq: entry.seq, sessionId: entry.sessionId }, null, 2),
+          },
+        ],
+      };
+    }
+
+    // No buffered events — block until one arrives
+    const entry = await new Promise<BufferedEvent>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const idx = afterSeqWaiters.findIndex((w) => w.resolve === resolve);
+        if (idx !== -1) afterSeqWaiters.splice(idx, 1);
+        // On timeout, return current session list as fallback
+        const list = [...sessions.values()].map((s) => s.getInfo());
+        reject({ timeout: true, sessions: list });
+      }, timeoutMs);
+      afterSeqWaiters.push({ sessionId: sessionId ?? null, afterSeq, resolve, timer });
+    }).catch((err) => {
+      if (err && typeof err === "object" && "timeout" in err) {
+        return err as { timeout: true; sessions: unknown[] };
+      }
+      throw err;
+    });
+
+    if ("timeout" in entry) {
+      return { content: [{ type: "text", text: JSON.stringify(entry.sessions, null, 2) }] };
+    }
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ ...entry.event, seq: entry.seq, sessionId: entry.sessionId }, null, 2),
+        },
+      ],
+    };
+  }
 
   if (sessionId) {
     const session = sessions.get(sessionId);

--- a/packages/daemon/src/opencode-session-worker.ts
+++ b/packages/daemon/src/opencode-session-worker.ts
@@ -47,9 +47,48 @@ let transport: WorkerServerTransport | null = null;
 /** Active sessions indexed by session ID. */
 const sessions = new Map<string, OpenCodeSession>();
 
+// ── afterSeq event buffer ──
+
+interface BufferedEvent {
+  seq: number;
+  sessionId: string;
+  event: AgentSessionEvent;
+}
+
+const MAX_EVENT_BUFFER = 200;
+let nextSeq = 1;
+const eventBuffer: BufferedEvent[] = [];
+
+/** Resolvers waiting for events after a specific sequence number. */
+const afterSeqWaiters: Array<{
+  sessionId: string | null;
+  afterSeq: number;
+  resolve: (entry: BufferedEvent) => void;
+  timer: ReturnType<typeof setTimeout>;
+}> = [];
+
+function bufferEvent(sessionId: string, event: AgentSessionEvent): void {
+  const entry: BufferedEvent = { seq: nextSeq++, sessionId, event };
+  eventBuffer.push(entry);
+  if (eventBuffer.length > MAX_EVENT_BUFFER) {
+    eventBuffer.shift();
+  }
+
+  // Resolve any afterSeq waiters that match
+  for (let i = afterSeqWaiters.length - 1; i >= 0; i--) {
+    const w = afterSeqWaiters[i];
+    if (entry.seq > w.afterSeq && (w.sessionId === null || w.sessionId === sessionId)) {
+      clearTimeout(w.timer);
+      afterSeqWaiters.splice(i, 1);
+      w.resolve(entry);
+    }
+  }
+}
+
 // ── Session event → DB message forwarding ──
 
 function forwardSessionEvent(sessionId: string, event: AgentSessionEvent): void {
+  bufferEvent(sessionId, event);
   switch (event.type) {
     case "session:init":
       self.postMessage({
@@ -324,6 +363,51 @@ async function handleWait(args: Record<string, unknown>): Promise<{
 }> {
   const sessionId = args.sessionId as string | undefined;
   const timeoutMs = (args.timeout as number) ?? 300_000;
+  const afterSeq = args.afterSeq as number | undefined;
+
+  // afterSeq cursor: check buffer first, then block until a new event arrives
+  if (afterSeq !== undefined) {
+    const buffered = eventBuffer.filter((e) => e.seq > afterSeq && (sessionId == null || e.sessionId === sessionId));
+    if (buffered.length > 0) {
+      const entry = buffered[0];
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ ...entry.event, seq: entry.seq, sessionId: entry.sessionId }, null, 2),
+          },
+        ],
+      };
+    }
+
+    const entry = await new Promise<BufferedEvent>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        const idx = afterSeqWaiters.findIndex((w) => w.resolve === resolve);
+        if (idx !== -1) afterSeqWaiters.splice(idx, 1);
+        const list = [...sessions.values()].map((s) => s.getInfo());
+        reject({ timeout: true, sessions: list });
+      }, timeoutMs);
+      afterSeqWaiters.push({ sessionId: sessionId ?? null, afterSeq, resolve, timer });
+    }).catch((err) => {
+      if (err && typeof err === "object" && "timeout" in err) {
+        return err as { timeout: true; sessions: unknown[] };
+      }
+      throw err;
+    });
+
+    if ("timeout" in entry) {
+      return { content: [{ type: "text", text: JSON.stringify(entry.sessions, null, 2) }] };
+    }
+
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify({ ...entry.event, seq: entry.seq, sessionId: entry.sessionId }, null, 2),
+        },
+      ],
+    };
+  }
 
   if (sessionId) {
     const session = sessions.get(sessionId);

--- a/packages/daemon/src/opencode-session/tools.ts
+++ b/packages/daemon/src/opencode-session/tools.ts
@@ -96,12 +96,17 @@ export const OPENCODE_TOOLS = [
     name: "opencode_wait",
     description:
       "Block until an OpenCode agent session event occurs (result, error, permission request, or ended). " +
-      "If sessionId is provided, waits for that session only. Otherwise waits for any session.",
+      "If sessionId is provided, waits for that session only. Otherwise waits for any session. " +
+      "Use afterSeq for race-free cursor-based polling: returns immediately if events exist past the cursor.",
     inputSchema: {
       type: "object" as const,
       properties: {
         sessionId: { type: "string", description: "Session ID to wait on (omit for any session)" },
         timeout: { type: "number", description: "Max wait time in ms (default: 300000)" },
+        afterSeq: {
+          type: "number",
+          description: "Return events after this sequence number. Enables race-free polling.",
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary
- **Repo-scoped session filtering**: Client-side cwd prefix matching for codex/opencode/acp `ls` with `--all` bypass flag
- **Compact transcript**: `--compact` flag for client-side tool result truncation on codex/opencode/acp; Claude uses native daemon `compact` support
- **afterSeq cursor**: Event buffer with sequence numbers in codex/opencode/acp daemon workers for race-free cursor-based polling (matches Claude's native `waitForEventsSince`)
- **Cost estimation**: `~$X.XXXX` estimated from token counts ($5/M blended rate) when provider doesn't report cost
- **PR status in ls**: `--pr` flag using `gh pr list` branch detection for codex/opencode/acp (reuses existing `defaultGetPrStatus`)

All shims are no-ops for Claude which has native support for these features.

## Test plan
- [x] New `session-display.spec.ts` with tests for `estimateCost`, `formatCost`, `filterByRepo`, `compactTranscript`
- [x] Updated `codex.spec.ts` with tests for repo filtering, `--all` bypass, estimated cost display, `--pr` flag
- [x] Updated `opencode.spec.ts` and `acp.spec.ts` with new deps in `makeDeps`
- [x] All 3546 tests pass, 0 failures
- [x] TypeScript typecheck passes
- [x] Lint passes (biome check)
- [x] Coverage thresholds met (89.77% functions, 91.25% lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)