### PR TITLE
fix(tests): replace spyOn(process, "exit") with dependency injection in install.spec.ts (fixes #923)

### DIFF
--- a/packages/command/src/commands/install.spec.ts
+++ b/packages/command/src/commands/install.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, spyOn, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import type { McpConfigFile } from "@mcp-cli/core";
 import { testOptions } from "../../../../test/test-options";
@@ -200,15 +200,17 @@ describe("cmdInstall", () => {
 
   test("exits with 1 on empty args", async () => {
     using _opts = testOptions();
-    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
-      throw new Error("process.exit");
-    });
-    try {
-      await expect(cmdInstall([])).rejects.toThrow("process.exit");
-      expect(exitSpy).toHaveBeenCalledWith(1);
-    } finally {
-      exitSpy.mockRestore();
-    }
+    let exitCode: number | undefined;
+    const deps: InstallDeps = {
+      ...makeDeps({ servers: [], metadata: { count: 0 } }),
+      exit: (code: number) => {
+        exitCode = code;
+        throw new Error(`exit:${code}`);
+      },
+    };
+
+    await expect(cmdInstall([], deps)).rejects.toThrow("exit:1");
+    expect(exitCode).toBe(1);
   });
 
   test("outputs JSON when --json flag is used", async () => {

--- a/packages/command/src/commands/install.ts
+++ b/packages/command/src/commands/install.ts
@@ -14,6 +14,7 @@ import { CONFIG_SCOPES, type ConfigScope, addServerToConfig, resolveConfigPath }
 export interface InstallDeps {
   searchRegistry: (query: string, opts?: RegistryOpts) => Promise<RegistryResponse>;
   log?: (msg: string) => void;
+  exit?: (code: number) => never;
 }
 
 const defaultDeps: InstallDeps = { searchRegistry: realSearchRegistry };
@@ -68,7 +69,7 @@ export async function cmdInstall(args: string[], deps?: InstallDeps): Promise<vo
   const d = deps ?? defaultDeps;
   if (args.length === 0) {
     printError("Usage: mcx install <slug> [--as name] [--scope user|project] [--env KEY=VALUE]");
-    process.exit(1);
+    (d.exit ?? process.exit)(1);
   }
 
   const parsed = parseInstallArgs(args);
@@ -98,7 +99,7 @@ export async function cmdInstall(args: string[], deps?: InstallDeps): Promise<vo
     if (meta.documentation) {
       console.error(`\nDocumentation: ${meta.documentation}`);
     }
-    process.exit(1);
+    (d.exit ?? process.exit)(1);
   }
 
   // Warn about required env vars that aren't provided


### PR DESCRIPTION
## Summary
- Added `exit?: (code: number) => never` to `InstallDeps` interface
- Replaced both `process.exit(1)` calls in `cmdInstall` with `(d.exit ?? process.exit)(1)`
- Updated test to inject an `exit` mock via deps instead of using `spyOn(process, "exit")`

## Test plan
- [x] Existing `install.spec.ts` tests all pass (22/22)
- [x] Full test suite passes (3752 pass, 0 fail)
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)