### PR TITLE
fix(test): add coverage for prepare-npm.ts entrypoint via DI (fixes #934)

### DIFF
--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -109,9 +109,6 @@ const EXCLUSIONS: Record<string, string> = {
 
   // CI scripts — git-dependent, tested via pure-function unit tests + CI integration
   "scripts/release.ts": "CI-only release script, git-dependent async functions untestable in isolation",
-  "scripts/prepare-npm.ts":
-    "import.meta.main entrypoint block uses real fs/dist paths — pure functions fully tested, entrypoint requires e2e",
-
   // Test harness — not production code
   "test/harness.ts": "Test infrastructure, not source",
 };

--- a/scripts/prepare-npm.spec.ts
+++ b/scripts/prepare-npm.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { BINARIES, PLATFORMS, parseVersion, stampOptionalDeps, stampPlatformPackage } from "./prepare-npm";
+import { resolve } from "node:path";
+import type { PrepareNpmDeps } from "./prepare-npm";
+import { BINARIES, PLATFORMS, parseVersion, prepareNpm, stampOptionalDeps, stampPlatformPackage } from "./prepare-npm";
 
 describe("parseVersion", () => {
   test("reads version from --version arg", () => {
@@ -104,5 +106,126 @@ describe("BINARIES constant", () => {
     expect(BINARIES).toContain("mcx");
     expect(BINARIES).toContain("mcpd");
     expect(BINARIES).toContain("mcpctl");
+  });
+});
+
+describe("prepareNpm", () => {
+  const rootPkgJson = JSON.stringify({
+    name: "@theshadow27/mcp-cli",
+    version: "0.11.0",
+    optionalDependencies: {
+      "@theshadow27/mcp-cli-darwin-arm64": "0.0.0",
+      "@theshadow27/mcp-cli-darwin-x64": "0.0.0",
+      "@theshadow27/mcp-cli-linux-x64": "0.0.0",
+      "@theshadow27/mcp-cli-linux-arm64": "0.0.0",
+    },
+  });
+
+  const platformPkgJson = JSON.stringify({
+    name: "@theshadow27/mcp-cli-darwin-arm64",
+    version: "0.0.0",
+  });
+
+  function makeDeps(): {
+    deps: PrepareNpmDeps;
+    written: Map<string, string>;
+    copied: Array<{ src: string; dst: string }>;
+    chmods: Array<{ path: string; mode: number }>;
+    logs: string[];
+  } {
+    const written = new Map<string, string>();
+    const copied: Array<{ src: string; dst: string }> = [];
+    const chmods: Array<{ path: string; mode: number }> = [];
+    const logs: string[] = [];
+
+    const deps: PrepareNpmDeps = {
+      readFile: (path: string) => {
+        if (path === "package.json" || path === resolve("package.json")) return rootPkgJson;
+        return platformPkgJson;
+      },
+      writeFile: (path: string, data: string) => {
+        written.set(path, data);
+      },
+      copyFile: (src: string, dst: string) => {
+        copied.push({ src, dst });
+      },
+      chmod: (path: string, mode: number) => {
+        chmods.push({ path, mode });
+      },
+      log: (msg: string) => {
+        logs.push(msg);
+      },
+    };
+
+    return { deps, written, copied, chmods, logs };
+  }
+
+  test("stamps all platform package.json files with version", () => {
+    const { deps, written } = makeDeps();
+    prepareNpm(["--version", "2.0.0"], deps);
+
+    for (const platform of PLATFORMS) {
+      const key = [...written.keys()].find((k) => k.includes(`npm/${platform.dir}/package.json`));
+      expect(key).toBeDefined();
+      const content = written.get(key as string) as string;
+      expect(JSON.parse(content).version).toBe("2.0.0");
+    }
+  });
+
+  test("copies all binaries for each platform", () => {
+    const { deps, copied } = makeDeps();
+    prepareNpm(["--version", "1.0.0"], deps);
+
+    expect(copied).toHaveLength(PLATFORMS.length * BINARIES.length);
+    for (const platform of PLATFORMS) {
+      for (const binary of BINARIES) {
+        expect(
+          copied.some(
+            (c) =>
+              c.src.includes(`${binary}-${platform.suffix}`) && c.dst.includes(`npm/${platform.dir}/bin/${binary}`),
+          ),
+        ).toBe(true);
+      }
+    }
+  });
+
+  test("chmods all copied binaries to 755", () => {
+    const { deps, chmods } = makeDeps();
+    prepareNpm(["--version", "1.0.0"], deps);
+
+    expect(chmods).toHaveLength(PLATFORMS.length * BINARIES.length);
+    for (const entry of chmods) {
+      expect(entry.mode).toBe(0o755);
+    }
+  });
+
+  test("stamps root package.json optionalDependencies", () => {
+    const { deps, written } = makeDeps();
+    prepareNpm(["--version", "3.0.0"], deps);
+
+    const rootKey = [...written.keys()].find((k) => k.endsWith("package.json") && !k.includes("/npm/"));
+    expect(rootKey).toBeDefined();
+    const parsed = JSON.parse(written.get(rootKey as string) as string);
+    for (const dep of Object.keys(parsed.optionalDependencies)) {
+      if (dep.startsWith("@theshadow27/mcp-cli-")) {
+        expect(parsed.optionalDependencies[dep]).toBe("3.0.0");
+      }
+    }
+  });
+
+  test("logs progress messages", () => {
+    const { deps, logs } = makeDeps();
+    prepareNpm(["--version", "1.0.0"], deps);
+
+    expect(logs.some((l) => l.includes("Preparing npm packages for version 1.0.0"))).toBe(true);
+    expect(logs.some((l) => l.includes("Done."))).toBe(true);
+    expect(logs.some((l) => l.includes("Stamped optionalDependencies"))).toBe(true);
+  });
+
+  test("reads version from package.json when no --version arg", () => {
+    const { deps, logs } = makeDeps();
+    prepareNpm([], deps);
+
+    expect(logs.some((l) => l.includes("version 0.11.0"))).toBe(true);
   });
 });

--- a/scripts/prepare-npm.ts
+++ b/scripts/prepare-npm.ts
@@ -48,30 +48,50 @@ export function stampOptionalDeps(pkgText: string, version: string): string {
   return `${JSON.stringify(pkg, null, 2)}\n`;
 }
 
-if (import.meta.main) {
-  const args = process.argv.slice(2);
-  const version = parseVersion(args, readFileSync("package.json", "utf-8"));
+export interface PrepareNpmDeps {
+  readFile: (path: string) => string;
+  writeFile: (path: string, data: string) => void;
+  copyFile: (src: string, dst: string) => void;
+  chmod: (path: string, mode: number) => void;
+  log?: (msg: string) => void;
+}
 
-  console.log(`Preparing npm packages for version ${version}`);
+const defaultDeps: PrepareNpmDeps = {
+  readFile: (p) => readFileSync(p, "utf-8"),
+  writeFile: writeFileSync,
+  copyFile: copyFileSync,
+  chmod: chmodSync,
+  log: console.log,
+};
+
+export function prepareNpm(args: string[], deps: PrepareNpmDeps = defaultDeps): void {
+  const d = { ...defaultDeps, ...deps };
+  const version = parseVersion(args, d.readFile("package.json"));
+
+  d.log?.(`Preparing npm packages for version ${version}`);
 
   for (const platform of PLATFORMS) {
     const pkgPath = resolve(`npm/${platform.dir}/package.json`);
-    const stamped = stampPlatformPackage(readFileSync(pkgPath, "utf-8"), version);
-    writeFileSync(pkgPath, stamped);
+    const stamped = stampPlatformPackage(d.readFile(pkgPath), version);
+    d.writeFile(pkgPath, stamped);
 
     for (const binary of BINARIES) {
       const src = resolve(`dist/${binary}-${platform.suffix}`);
       const dst = resolve(`npm/${platform.dir}/bin/${binary}`);
-      copyFileSync(src, dst);
-      chmodSync(dst, 0o755);
-      console.log(`  ${binary}-${platform.suffix} → npm/${platform.dir}/bin/${binary}`);
+      d.copyFile(src, dst);
+      d.chmod(dst, 0o755);
+      d.log?.(`  ${binary}-${platform.suffix} → npm/${platform.dir}/bin/${binary}`);
     }
   }
 
   const rootPkgPath = resolve("package.json");
-  const stamped = stampOptionalDeps(readFileSync(rootPkgPath, "utf-8"), version);
-  writeFileSync(rootPkgPath, stamped);
-  console.log(`Stamped optionalDependencies to ${version}`);
+  const stamped = stampOptionalDeps(d.readFile(rootPkgPath), version);
+  d.writeFile(rootPkgPath, stamped);
+  d.log?.(`Stamped optionalDependencies to ${version}`);
 
-  console.log("Done.");
+  d.log?.("Done.");
+}
+
+if (import.meta.main) {
+  prepareNpm(process.argv.slice(2));
 }


### PR DESCRIPTION
## Summary
- Refactored `import.meta.main` block in `scripts/prepare-npm.ts` into an exported `prepareNpm()` function with a `PrepareNpmDeps` interface for injected fs operations (`readFile`, `writeFile`, `copyFile`, `chmod`, `log`)
- Added 6 tests for `prepareNpm()` covering: platform package stamping, binary copying, chmod, root optionalDeps stamping, log output, and version fallback
- Removed the coverage exclusion in `scripts/check-coverage.ts` — file now has 98.25% line coverage

## Test plan
- [x] All 20 tests in `prepare-npm.spec.ts` pass (6 new + 14 existing)
- [x] Full test suite passes (3758 pass, 0 fail)
- [x] Typecheck passes
- [x] Lint passes
- [x] Coverage threshold met without exclusion (98.25% lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)