### PR TITLE
fix(alias): auto-parse Python repr in extractContent for MCP responses (fixes #941)

### DIFF
--- a/packages/core/src/alias.spec.ts
+++ b/packages/core/src/alias.spec.ts
@@ -83,4 +83,24 @@ describe("extractContent", () => {
     const result = { content: [] };
     expect(extractContent(result)).toEqual([]);
   });
+
+  test("auto-parses Python repr text when JSON.parse fails", () => {
+    const result = {
+      content: [{ type: "text", text: "{'key': 'value', 'active': True}" }],
+    };
+    expect(extractContent(result)).toEqual({ key: "value", active: true });
+  });
+
+  test("auto-parses Python repr with nested JSON strings (Coralogix)", () => {
+    const pythonRepr = `{'records': [{'user_data': '{"r":{"tid":"abc123"}}'}]}`;
+    const result = { content: [{ type: "text", text: pythonRepr }] };
+    expect(extractContent(result)).toEqual({
+      records: [{ user_data: '{"r":{"tid":"abc123"}}' }],
+    });
+  });
+
+  test("returns raw text when neither JSON nor Python repr", () => {
+    const result = { content: [{ type: "text", text: "just plain text" }] };
+    expect(extractContent(result)).toBe("just plain text");
+  });
 });

--- a/packages/core/src/alias.ts
+++ b/packages/core/src/alias.ts
@@ -3,6 +3,7 @@
  */
 
 import type { z } from "zod/v4";
+import { parsePythonRepr } from "./python-repr";
 
 /** Options for the cache() helper in alias context */
 export interface CacheOptions {
@@ -69,10 +70,14 @@ export function extractContent(result: unknown): unknown {
   if (result && typeof result === "object" && "content" in result) {
     const { content } = result as { content: Array<{ type: string; text?: string }> };
     if (Array.isArray(content) && content.length === 1 && content[0].type === "text" && content[0].text) {
+      const text = content[0].text;
       try {
-        return JSON.parse(content[0].text);
+        return JSON.parse(text);
       } catch {
-        return content[0].text;
+        // JSON.parse failed — try Python repr conversion (e.g. Coralogix MCP responses)
+        const parsed = parsePythonRepr(text);
+        if (parsed !== text) return parsed;
+        return text;
       }
     }
     // Multiple content items — return array of text

--- a/packages/core/src/python-repr.spec.ts
+++ b/packages/core/src/python-repr.spec.ts
@@ -146,6 +146,20 @@ describe("pythonReprToJson", () => {
     expect(JSON.parse(result)).toBe("C:\\Users\\test");
   });
 
+  it("handles nested JSON strings inside single-quoted Python values", () => {
+    const input = `{'records': [{'metadata': {}, 'labels': {}, 'user_data': '{"r":{"tid":"2724a35f0406edd1bb84ad31f5c21894"}}'}]}`;
+    const result = JSON.parse(pythonReprToJson(input));
+    expect(result).toEqual({
+      records: [
+        {
+          metadata: {},
+          labels: {},
+          user_data: '{"r":{"tid":"2724a35f0406edd1bb84ad31f5c21894"}}',
+        },
+      ],
+    });
+  });
+
   it("does not infinite loop on bare + or -", () => {
     const input = "{'a': +, 'b': -}";
     // Should complete without hanging — output may not be valid JSON
@@ -216,5 +230,19 @@ describe("parsePythonRepr", () => {
   it("handles mixed quote styles in values", () => {
     const input = `{'msg': "it's broken"}`;
     expect(parsePythonRepr(input)).toEqual({ msg: "it's broken" });
+  });
+
+  it("parses Coralogix response with nested JSON in user_data", () => {
+    const input = `{'records': [{'metadata': {}, 'labels': {}, 'user_data': '{"r":{"tid":"2724a35f0406edd1bb84ad31f5c21894"}}'}]}`;
+    const result = parsePythonRepr(input);
+    expect(result).toEqual({
+      records: [
+        {
+          metadata: {},
+          labels: {},
+          user_data: '{"r":{"tid":"2724a35f0406edd1bb84ad31f5c21894"}}',
+        },
+      ],
+    });
   });
 });


### PR DESCRIPTION
## Summary
- `extractContent` now falls back to `parsePythonRepr` when `JSON.parse` fails on MCP text content, so Python-repr responses (e.g. Coralogix MCP) are automatically parsed for all aliases
- Added tests for the Coralogix nested-JSON-in-dict-value case to both `python-repr.spec.ts` and `alias.spec.ts`
- The existing character-level tokenizer already handled the nested JSON case correctly — the fix is just wiring it into the MCP result pipeline

## Test plan
- [x] `python-repr.spec.ts`: new test for nested JSON strings inside single-quoted Python values
- [x] `python-repr.spec.ts`: new test for Coralogix response with nested JSON in `user_data` via `parsePythonRepr`
- [x] `alias.spec.ts`: new test for auto-parsing Python repr text when JSON.parse fails
- [x] `alias.spec.ts`: new test for auto-parsing Python repr with nested JSON strings (Coralogix case)
- [x] `alias.spec.ts`: new test confirming plain text still returned as-is
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (3757 pass, 1 flaky unrelated — filed #952)

🤖 Generated with [Claude Code](https://claude.com/claude-code)