### PR TITLE
ci: upgrade actions/checkout from v4 to v6 for Node.js 24 (fixes #921)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: check
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
             suffix: linux-arm64
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -88,7 +88,7 @@ jobs:
           - suffix: linux-arm64
             platform: linux-arm64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/download-artifact@v4
         with:
           name: binaries-${{ matrix.suffix }}
@@ -125,7 +125,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ vars.NPM_PUBLISH_ENABLED == 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -157,7 +157,7 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/download-artifact@v4
         with:
           path: artifacts


### PR DESCRIPTION
## Summary
- Upgrade `actions/checkout` from v4 (Node.js 20) to v6 (Node.js 24) across all workflows
- Updated 2 occurrences in `ci.yml` and 4 in `release.yml`
- Addresses GitHub's Node.js 20 deprecation deadline of June 2, 2026

## Test plan
- [ ] CI workflow runs successfully with `actions/checkout@v6`
- [ ] Verify checkout behavior unchanged (branch detection, submodules, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)