### PR TITLE
feat: replace manual ANSI slicing with Bun.sliceAnsi and Bun.stringWidth (fixes #938)

### DIFF
--- a/packages/command/src/commands/auth.ts
+++ b/packages/command/src/commands/auth.ts
@@ -119,7 +119,7 @@ export async function cmdAuth(args: string[], deps?: Partial<AuthDeps>): Promise
     d.log(`${c.bold}${"SERVER".padEnd(nameWidth)}  ${"TRANSPORT".padEnd(9)}  ${"AUTH".padEnd(10)}  STATUS${c.reset}`);
     for (const s of result.servers) {
       const authLabel = authSupportLabel(s);
-      const authPad = 10 + (authLabel.length - stripAnsi(authLabel).length);
+      const authPad = 10 + (authLabel.length - Bun.stringWidth(authLabel));
       d.log(`${s.server.padEnd(nameWidth)}  ${s.transport.padEnd(9)}  ${authLabel.padEnd(authPad)}  ${statusLabel(s)}`);
     }
     return;

--- a/packages/command/src/output.spec.ts
+++ b/packages/command/src/output.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { AliasDetail } from "@mcp-cli/core";
-import { extractErrorMessage, formatToolResult, printAliasDebug, printAliasList } from "./output";
+import { extractErrorMessage, formatToolResult, printAliasDebug, printAliasList, printToolList } from "./output";
 
 describe("formatToolResult", () => {
   test("returns empty string for null", () => {
@@ -212,6 +212,46 @@ describe("printAliasDebug", () => {
     const output = captureStderr(() => printAliasDebug(alias));
     expect(output).not.toContain("description");
     expect(output).toContain("source");
+  });
+});
+
+describe("printToolList ANSI-aware truncation", () => {
+  function captureStdout(fn: () => void): string {
+    const original = console.log;
+    const lines: string[] = [];
+    console.log = mock((...args: unknown[]) => lines.push(args.join(" ")));
+    try {
+      fn();
+      return lines.join("\n");
+    } finally {
+      console.log = original;
+    }
+  }
+
+  test("truncates long descriptions using Bun.sliceAnsi", () => {
+    const longDesc = "A".repeat(100);
+    const tools = [{ name: "tool1", server: "srv", description: longDesc }];
+    const output = captureStdout(() => printToolList(tools));
+    // Should be truncated to 77 chars + "..."
+    expect(output).toContain(`${"A".repeat(77)}...`);
+    expect(output).not.toContain("A".repeat(78));
+  });
+
+  test("preserves ANSI codes in truncated descriptions", () => {
+    // Description with ANSI color that would break with naive .slice()
+    const colored = `\x1b[32m${"A".repeat(100)}\x1b[0m`;
+    const tools = [{ name: "tool1", server: "srv", description: colored }];
+    const output = captureStdout(() => printToolList(tools));
+    // Bun.sliceAnsi should preserve the opening SGR and add a reset
+    expect(output).toContain("\x1b[32m");
+    expect(output).toContain("...");
+  });
+
+  test("does not truncate short descriptions", () => {
+    const tools = [{ name: "tool1", server: "srv", description: "short desc" }];
+    const output = captureStdout(() => printToolList(tools));
+    expect(output).toContain("short desc");
+    expect(output).not.toContain("...");
   });
 });
 

--- a/packages/command/src/output.ts
+++ b/packages/command/src/output.ts
@@ -111,7 +111,7 @@ export function printToolList(
   const maxServer = Math.max(...tools.map((t) => t.server.length));
 
   for (const t of tools) {
-    const desc = t.description.length > 80 ? `${t.description.slice(0, 77)}...` : t.description;
+    const desc = Bun.stringWidth(t.description) > 80 ? `${Bun.sliceAnsi(t.description, 0, 77)}...` : t.description;
     console.log(
       `  ${c.green}${t.name.padEnd(maxName)}${c.reset}  ${c.dim}${t.server.padEnd(maxServer)}${c.reset}  ${desc}`,
     );
@@ -232,7 +232,7 @@ export function printAliasDebug(alias: AliasDetail): void {
   const type = alias.aliasType === "defineAlias" ? "defineAlias" : "freeform";
   const width = 46;
   const header = `── ${alias.name} (${type}) `;
-  const pad = Math.max(0, width - header.length);
+  const pad = Math.max(0, width - Bun.stringWidth(header));
 
   console.error(`${c.dim}${header}${"─".repeat(pad)}${c.reset}`);
 
@@ -268,7 +268,7 @@ export function printRegistryList(entries: RegistryEntry[]): void {
 
   for (const e of entries) {
     const meta = e._meta["com.anthropic.api/mcp-registry"];
-    const oneLiner = meta.oneLiner.length > 60 ? `${meta.oneLiner.slice(0, 57)}...` : meta.oneLiner;
+    const oneLiner = Bun.stringWidth(meta.oneLiner) > 60 ? `${Bun.sliceAnsi(meta.oneLiner, 0, 57)}...` : meta.oneLiner;
     const toolCount = meta.toolNames?.length ?? 0;
     const tools = toolCount > 0 ? `${c.dim}${toolCount} tools${c.reset}` : "";
     console.log(


### PR DESCRIPTION
## Summary
- Replace `.slice()` / `.length` with `Bun.sliceAnsi()` / `Bun.stringWidth()` in `output.ts` for ANSI-safe truncation of tool descriptions, registry one-liners, and alias debug headers
- Replace `stripAnsi(x).length` with `Bun.stringWidth(x)` in `auth.ts` for correct column-width padding of ANSI-colored auth labels
- Add tests verifying ANSI-aware truncation preserves escape codes and handles long/short descriptions

## Test plan
- [x] New tests: truncation of plain text, truncation of ANSI-colored text preserving SGR codes, short text passthrough
- [x] Existing auth tests still pass (table formatting with colored labels)
- [x] Full test suite: 3764 tests pass, coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)