### PR TITLE
fix(build): use generic target for Bun.build() bundle step (fixes #969)

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -143,12 +143,14 @@ const mcpctlConfig: BinaryBuildConfig = {
 const bundleCleanup: string[] = [];
 
 async function buildBinary(config: BinaryBuildConfig, outfile: string, target?: string): Promise<void> {
+  // Always bundle for generic "bun" target — the JS bundle is platform-agnostic.
+  // Platform-specific cross-compilation happens in the subsequent --compile step.
   const result = await Bun.build({
     entrypoints: [resolve(config.entrypoint)],
     outdir: resolve("dist"),
     naming: `${config.bundleName}.[ext]`,
     minify: true,
-    target: (target as "bun") ?? "bun",
+    target: "bun",
     plugins: config.plugins,
     define: {
       __PROTOCOL_HASH__: JSON.stringify(protocolHash),


### PR DESCRIPTION
## Summary
- `Bun.build()` was passed platform-specific targets (e.g., `"bun-linux-x64"`) which it doesn't reliably support — only `"bun"`, `"node"`, `"browser"` are valid
- This caused the bundle step to silently produce no output, failing with "bundle not found at dist/index.js" on all 3 release platforms
- Fixed by always using `target: "bun"` for the JS bundle step; the platform target is only needed for the subsequent `bun build --compile` step

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — all 3518 tests pass
- [x] Dev build (`bun scripts/build.ts`) produces dist/mcpd, dist/mcx, dist/mcpctl
- [x] Release build (`bun scripts/build.ts --release --target=bun-darwin-arm64`) completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)