### PR TITLE
fix(test): apply shutdownComplete pattern to all daemon afterEach blocks (fixes #950)

### DIFF
--- a/packages/daemon/src/index.spec.ts
+++ b/packages/daemon/src/index.spec.ts
@@ -113,8 +113,9 @@ describe("daemon index.ts", () => {
     let opts: ReturnType<typeof testOptions> | undefined;
 
     afterEach(async () => {
-      if (handle && !handle.isShuttingDown) {
-        await handle.shutdown("SIGTERM");
+      if (handle) {
+        if (!handle.isShuttingDown) await handle.shutdown("SIGTERM");
+        await handle.shutdownComplete;
       }
       handle = undefined;
       if (opts) {
@@ -165,8 +166,9 @@ describe("daemon index.ts", () => {
     let opts: ReturnType<typeof testOptions> | undefined;
 
     afterEach(async () => {
-      if (handle && !handle.isShuttingDown) {
-        await handle.shutdown("SIGTERM");
+      if (handle) {
+        if (!handle.isShuttingDown) await handle.shutdown("SIGTERM");
+        await handle.shutdownComplete;
       }
       handle = undefined;
       if (opts) {
@@ -327,8 +329,9 @@ describe("daemon index.ts", () => {
     let opts: ReturnType<typeof testOptions> | undefined;
 
     afterEach(async () => {
-      if (handle && !handle.isShuttingDown) {
-        await handle.shutdown("SIGTERM");
+      if (handle) {
+        if (!handle.isShuttingDown) await handle.shutdown("SIGTERM");
+        await handle.shutdownComplete;
       }
       handle = undefined;
       if (opts) {


### PR DESCRIPTION
## Summary
- Applied the `shutdownComplete` await pattern (from PR #948) to the three remaining daemon `afterEach` blocks: startup variants (P2), shutdown sequence (P3), and config hot reload (P4)
- Audited all `afterEach` blocks in `index.spec.ts` — the two `pruneOrphanedWorktrees` blocks don't manage daemon handles and need no changes

## Test plan
- [x] All 3518 tests pass (`bun test`)
- [x] Typecheck passes (`bun typecheck`)
- [x] Lint passes (`bun lint`)
- [x] Coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)