### PR TITLE
feat(cli): show creation date for sessions older than 24h in mcx claude ls (fixes #962)

### DIFF
--- a/packages/acp/src/acp-session.ts
+++ b/packages/acp/src/acp-session.ts
@@ -63,6 +63,7 @@ export type SessionEventHandler = (event: AgentSessionEvent) => void;
 
 export class AcpSession {
   readonly sessionId: string;
+  private readonly createdAt = Date.now();
   private state: AgentSessionState = "connecting";
   private proc: AcpProcess | null = null;
   private rpc: AcpRpcClient | null = null;
@@ -320,6 +321,7 @@ export class AcpSession {
       worktree: this.config.worktree ?? null,
       repoRoot: this.config.repoRoot ?? null,
       processAlive: this.proc?.alive ?? false,
+      createdAt: this.createdAt,
     };
   }
 

--- a/packages/codex/src/codex-session.ts
+++ b/packages/codex/src/codex-session.ts
@@ -61,6 +61,7 @@ export type SessionEventHandler = (event: AgentSessionEvent) => void;
 
 export class CodexSession {
   readonly sessionId: string;
+  private readonly createdAt = Date.now();
   private state: AgentSessionState = "connecting";
   private proc: CodexProcess | null = null;
   private rpc: CodexRpcClient | null = null;
@@ -268,6 +269,7 @@ export class CodexSession {
       worktree: this.config.worktree ?? null,
       repoRoot: this.config.repoRoot ?? null,
       processAlive: this.proc?.alive ?? false,
+      createdAt: this.createdAt,
     };
   }
 

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -37,7 +37,7 @@ import {
   resolveSessionId,
   resolveWorktree,
 } from "./claude";
-import { colorState, extractContentSummary, formatSessionShort } from "./session-display";
+import { colorState, extractContentSummary, formatAge, formatSessionShort } from "./session-display";
 import { looksLikeToolName, parseSharedSpawnArgs } from "./spawn-args";
 import { ttyOpen } from "./tty";
 
@@ -638,8 +638,10 @@ async function agentList(
     const diff = hasAnyDiff ? ` ${(diffStats[i] ?? "—").padEnd(16)}` : "";
     const pr = hasAnyPr ? ` ${formatPrStatus(prStatuses[i]).padEnd(12)}` : "";
     const cwd = String(s.cwd ?? "—");
+    const age = formatAge(s.createdAt as number | null | undefined);
+    const ageSuffix = age ? ` ${c.yellow}${age}${c.reset}` : "";
     d.log(
-      `${c.cyan}${id}${c.reset}   ${state}${agentCol} ${model} ${cost} ${tokens}${diff}${pr} ${c.dim}${cwd}${c.reset}`,
+      `${c.cyan}${id}${c.reset}   ${state}${agentCol} ${model} ${cost} ${tokens}${diff}${pr} ${c.dim}${cwd}${c.reset}${ageSuffix}`,
     );
   }
 

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -23,7 +23,7 @@ import { getStaleDaemonWarning, ipcCall } from "../daemon-lifecycle";
 import { applyJqFilter } from "../jq/index";
 import { c, printError as defaultPrintError, formatToolResult } from "../output";
 import { extractFullFlag, extractJqFlag, extractJsonFlag } from "../parse";
-import { colorState, extractContentSummary, formatSessionShort } from "./session-display";
+import { colorState, extractContentSummary, formatAge, formatSessionShort } from "./session-display";
 import type { SharedSpawnArgs } from "./spawn-args";
 import { parseSharedSpawnArgs } from "./spawn-args";
 import { ttyOpen } from "./tty";
@@ -754,7 +754,11 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
     const diff = hasAnyDiff ? ` ${(diffStats[i] ?? "—").padEnd(16)}` : "";
     const pr = hasAnyPr ? ` ${formatPrStatus(prStatuses[i]).padEnd(12)}` : "";
     const cwd = s.cwd ?? "—";
-    console.log(`${c.cyan}${id}${c.reset}   ${state} ${model} ${cost} ${tokens}${diff}${pr} ${c.dim}${cwd}${c.reset}`);
+    const age = formatAge(s.createdAt);
+    const ageSuffix = age ? ` ${c.yellow}${age}${c.reset}` : "";
+    console.log(
+      `${c.cyan}${id}${c.reset}   ${state} ${model} ${cost} ${tokens}${diff}${pr} ${c.dim}${cwd}${c.reset}${ageSuffix}`,
+    );
   }
 
   const staleWarning = getStaleDaemonWarning();
@@ -764,7 +768,7 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
 }
 
 // formatSessionShort, extractContentSummary, colorState → ./session-display.ts
-export { colorState, extractContentSummary, formatSessionShort } from "./session-display";
+export { colorState, extractContentSummary, formatAge, formatSessionShort } from "./session-display";
 
 function formatPrStatus(pr: PrStatus | null): string {
   if (!pr) return "—";

--- a/packages/command/src/commands/session-display.spec.ts
+++ b/packages/command/src/commands/session-display.spec.ts
@@ -1,5 +1,13 @@
 import { describe, expect, test } from "bun:test";
-import { type TranscriptEntry, compactTranscript, estimateCost, filterByRepo, formatCost } from "./session-display";
+import {
+  type TranscriptEntry,
+  compactTranscript,
+  estimateCost,
+  filterByRepo,
+  formatAge,
+  formatCost,
+  formatSessionShort,
+} from "./session-display";
 
 describe("estimateCost", () => {
   test("returns null for zero tokens", () => {
@@ -124,5 +132,68 @@ describe("compactTranscript", () => {
     ];
     const compacted = compactTranscript(entries, 100);
     expect(compacted).toEqual(entries);
+  });
+});
+
+describe("formatAge", () => {
+  const NOW = Date.UTC(2026, 2, 23, 12, 0, 0); // 2026-03-23 12:00 UTC
+
+  test("returns empty string for null/undefined", () => {
+    expect(formatAge(null, NOW)).toBe("");
+    expect(formatAge(undefined, NOW)).toBe("");
+  });
+
+  test("returns empty string for sessions < 24h old", () => {
+    const recent = NOW - 23 * 60 * 60 * 1000; // 23 hours ago
+    expect(formatAge(recent, NOW)).toBe("");
+  });
+
+  test("returns date label for sessions >= 24h old", () => {
+    const old = Date.UTC(2026, 2, 19, 10, 0, 0); // Mar 19
+    expect(formatAge(old, NOW)).toBe("(Mar 19)");
+  });
+
+  test("returns date label for sessions days old", () => {
+    const old = Date.UTC(2026, 0, 15, 8, 0, 0); // Jan 15
+    expect(formatAge(old, NOW)).toBe("(Jan 15)");
+  });
+});
+
+describe("formatSessionShort with createdAt", () => {
+  test("appends age for old sessions", () => {
+    const old = Date.UTC(2026, 2, 19, 10, 0, 0);
+    const line = formatSessionShort({
+      sessionId: "e94a6668-1234-5678-9abc-def012345678",
+      state: "active",
+      model: "claude-opus-4-6[1m]",
+      cost: 519.51,
+      tokens: 4912380,
+      numTurns: 8415,
+      createdAt: old,
+    });
+    expect(line).toContain("(Mar 19)");
+    expect(line).toStartWith("e94a6668");
+  });
+
+  test("no age suffix for recent sessions", () => {
+    const line = formatSessionShort({
+      sessionId: "84418297-1234-5678-9abc-def012345678",
+      state: "active",
+      model: "claude-opus-4-6[1m]",
+      cost: 1.01,
+      tokens: 6885,
+      numTurns: 27,
+      createdAt: Date.now(),
+    });
+    expect(line).not.toContain("(");
+  });
+
+  test("no age suffix when createdAt is null", () => {
+    const line = formatSessionShort({
+      sessionId: "84418297-1234-5678-9abc-def012345678",
+      state: "active",
+      createdAt: null,
+    });
+    expect(line).not.toContain("(");
   });
 });

--- a/packages/command/src/commands/session-display.ts
+++ b/packages/command/src/commands/session-display.ts
@@ -12,7 +12,21 @@ export interface TranscriptEntry {
   message: { type: string; [k: string]: unknown };
 }
 
-/** Compact one-line format: SESSION STATE MODEL COST TOKENS TURNS */
+/**
+ * Format a short date label like "(Mar 19)" for sessions older than 24 hours.
+ * Returns empty string for recent sessions or if createdAt is unavailable.
+ */
+export function formatAge(createdAt: number | null | undefined, now?: number): string {
+  if (createdAt == null) return "";
+  const elapsed = (now ?? Date.now()) - createdAt;
+  if (elapsed < 24 * 60 * 60 * 1000) return "";
+  const date = new Date(createdAt);
+  const month = date.toLocaleString("en-US", { month: "short", timeZone: "UTC" });
+  const day = date.getUTCDate();
+  return `(${month} ${day})`;
+}
+
+/** Compact one-line format: SESSION STATE MODEL COST TOKENS TURNS [(date)] */
 export function formatSessionShort(s: {
   sessionId: string;
   state: string;
@@ -20,6 +34,7 @@ export function formatSessionShort(s: {
   cost?: number | null;
   tokens?: number;
   numTurns?: number;
+  createdAt?: number | null;
 }): string {
   const id = s.sessionId.slice(0, 8);
   const state = s.state;
@@ -27,7 +42,10 @@ export function formatSessionShort(s: {
   const cost = s.cost && s.cost > 0 ? `$${s.cost.toFixed(4)}` : "—";
   const tokens = s.tokens && s.tokens > 0 ? String(s.tokens) : "—";
   const turns = s.numTurns !== undefined ? String(s.numTurns) : "—";
-  return `${id} ${state} ${model} ${cost} ${tokens} ${turns}`;
+  const age = formatAge(s.createdAt);
+  return age
+    ? `${id} ${state} ${model} ${cost} ${tokens} ${turns} ${age}`
+    : `${id} ${state} ${model} ${cost} ${tokens} ${turns}`;
 }
 
 /** Extract a readable summary from a Claude API content field (string or content block array). */

--- a/packages/control/src/hooks/use-agent-sessions.spec.ts
+++ b/packages/control/src/hooks/use-agent-sessions.spec.ts
@@ -24,6 +24,7 @@ function session(id: string, provider: "claude" | "codex" = "claude"): AgentSess
     worktree: null,
     repoRoot: null,
     processAlive: true,
+    createdAt: Date.now(),
   };
 }
 

--- a/packages/core/src/agent-session.ts
+++ b/packages/core/src/agent-session.ts
@@ -48,6 +48,8 @@ export interface AgentSessionInfo {
   repoRoot: string | null;
   /** Whether the agent process is still alive. */
   processAlive: boolean;
+  /** Unix timestamp (ms) when this session was created. Null if unknown. */
+  createdAt: number | null;
 }
 
 export interface AgentResult {

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -239,6 +239,8 @@ interface WsSession {
   claudeSessionId: string | null;
   /** Timer that fires if the Claude CLI process doesn't connect via WS within the deadline. */
   connectTimer: Timer | null;
+  /** Unix timestamp (ms) when this session was created. */
+  createdAt: number;
 }
 
 interface WsData {
@@ -451,6 +453,7 @@ export class ClaudeWsServer {
       worktree: string | null;
       totalCost: number;
       totalTokens: number;
+      spawnedAt?: string | null;
     }>,
   ): number {
     let restored = 0;
@@ -483,6 +486,7 @@ export class ClaudeWsServer {
         clearing: false,
         claudeSessionId: null,
         connectTimer: null,
+        createdAt: s.spawnedAt ? new Date(`${s.spawnedAt}Z`).getTime() : Date.now(),
       });
       restored++;
       this.logger.info(`[_claude] Restored session ${s.sessionId} (state: disconnected, pid: ${s.pid})`);
@@ -514,6 +518,7 @@ export class ClaudeWsServer {
       clearing: false,
       claudeSessionId: null,
       connectTimer: null,
+      createdAt: Date.now(),
     });
   }
 
@@ -1408,6 +1413,7 @@ export class ClaudeWsServer {
       worktree: s.config.worktree ?? null,
       repoRoot: s.config.repoRoot ?? null,
       processAlive: s.spawnAlive,
+      createdAt: s.createdAt,
       wsConnected: s.ws !== null,
       spawnAlive: s.spawnAlive,
       snapshotTs: Date.now(),

--- a/packages/opencode/src/opencode-session.ts
+++ b/packages/opencode/src/opencode-session.ts
@@ -64,6 +64,7 @@ export type SessionEventHandler = (event: AgentSessionEvent) => void;
 
 export class OpenCodeSession {
   readonly sessionId: string;
+  private readonly createdAt = Date.now();
   private state: AgentSessionState = "connecting";
   private proc: OpenCodeProcess | null = null;
   private client: OpenCodeClient | null = null;
@@ -303,6 +304,7 @@ export class OpenCodeSession {
       worktree: this.config.worktree ?? null,
       repoRoot: this.config.repoRoot ?? null,
       processAlive: this.proc?.alive ?? false,
+      createdAt: this.createdAt,
     };
   }
 


### PR DESCRIPTION
## Summary
- Sessions older than 24 hours now display a `(Mar 19)` style date suffix in `mcx claude ls` output (both `--short` and verbose table formats)
- Added `createdAt` field to `AgentSessionInfo` interface, populated from `spawned_at` DB column for restored sessions and `Date.now()` for new sessions
- All providers (Claude, Codex, OpenCode, ACP) include `createdAt` in session info

## Test plan
- [x] `formatAge` returns empty string for sessions < 24h old
- [x] `formatAge` returns `(Mon DD)` label for sessions >= 24h old
- [x] `formatAge` handles null/undefined gracefully
- [x] `formatSessionShort` appends age suffix only for old sessions
- [x] All 3525 existing tests pass
- [x] typecheck, lint, coverage all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)