### PR TITLE
fix(daemon): prevent session state regression to init after CLI reconnect (fixes #983)

### DIFF
--- a/packages/daemon/src/claude-server.spec.ts
+++ b/packages/daemon/src/claude-server.spec.ts
@@ -1096,6 +1096,56 @@ describe("ClaudeServer", () => {
     const row = db.getSession("no-pid-ttl");
     expect(row?.state).toBe("ended");
   });
+
+  test("db:state event refreshes sessionAddedAt so active sessions survive TTL prune", () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new ClaudeServer(db, undefined, undefined, silentLogger);
+
+    const handle = (server as unknown as { handleWorkerEvent: (e: unknown) => void }).handleWorkerEvent.bind(server);
+    const internals = server as unknown as { sessionAddedAt: Map<string, number> };
+
+    handle({ type: "db:upsert", session: { sessionId: "active-1", state: "active" } });
+
+    // Backdate the creation to 9 minutes ago (simulating passage of time)
+    const nineMinAgo = Date.now() - 9 * 60 * 1000;
+    internals.sessionAddedAt.set("active-1", nineMinAgo);
+
+    // Verify it survives at now (9min < 10min TTL)
+    server.pruneDeadSessions(Date.now());
+    expect(server.hasActiveSessions()).toBe(true);
+
+    // Send a db:state event to refresh the timestamp
+    handle({ type: "db:state", sessionId: "active-1", state: "idle" });
+
+    // Prune at 11 minutes from original creation — session should SURVIVE
+    // because db:state refreshed the timestamp to ~now
+    server.pruneDeadSessions(nineMinAgo + 11 * 60 * 1000);
+    expect(server.hasActiveSessions()).toBe(true);
+
+    // Prune 11 minutes after the refresh — NOW it should be pruned
+    const refreshedAt = internals.sessionAddedAt.get("active-1") ?? 0;
+    server.pruneDeadSessions(refreshedAt + 11 * 60 * 1000);
+    expect(server.hasActiveSessions()).toBe(false);
+  });
+
+  test("db:cost event also refreshes sessionAddedAt", () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new ClaudeServer(db, undefined, undefined, silentLogger);
+
+    const handle = (server as unknown as { handleWorkerEvent: (e: unknown) => void }).handleWorkerEvent.bind(server);
+    handle({ type: "db:upsert", session: { sessionId: "cost-1", state: "active" } });
+
+    const internals = server as unknown as { sessionAddedAt: Map<string, number> };
+    const originalAt = internals.sessionAddedAt.get("cost-1") ?? 0;
+
+    // Simulate a cost event arriving later
+    handle({ type: "db:cost", sessionId: "cost-1", cost: 0.01, tokens: 100 });
+    const afterCost = internals.sessionAddedAt.get("cost-1") ?? 0;
+
+    expect(afterCost).toBeGreaterThanOrEqual(originalAt);
+  });
 });
 
 // ── connect timeout metric ──

--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -665,10 +665,12 @@ export class ClaudeServer {
         break;
       }
       case "db:state":
+        this.sessionAddedAt.set(event.sessionId, Date.now());
         this.db.updateSessionState(event.sessionId, event.state);
         this.onActivity?.();
         break;
       case "db:cost":
+        this.sessionAddedAt.set(event.sessionId, Date.now());
         this.db.updateSessionCost(event.sessionId, event.cost, event.tokens);
         this.metrics.counter("mcpd_session_cost_usd").inc(event.cost);
         this.onActivity?.();

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -349,11 +349,15 @@ async function handleWait(
 function forwardSessionEvent(sessionId: string, event: SessionEvent): void {
   switch (event.type) {
     case "session:init":
+      // Forward the actual state from the state machine — not a hardcoded "init".
+      // If the CLI reconnects after a WS drop and re-sends system/init, the
+      // state machine preserves its current state (e.g., "idle") rather than
+      // regressing to "init". Forwarding event.state keeps the DB in sync.
       self.postMessage({
         type: "db:upsert",
         session: {
           sessionId,
-          state: "init",
+          state: event.state,
           model: event.model,
           cwd: event.cwd,
         },

--- a/packages/daemon/src/claude-session/session-state.spec.ts
+++ b/packages/daemon/src/claude-session/session-state.spec.ts
@@ -131,8 +131,54 @@ describe("SessionState", () => {
           sessionId: "sess-1",
           model: "claude-sonnet-4-6",
           cwd: "/home/user/project",
+          state: "init",
         },
       ]);
+    });
+
+    test("does not regress state when CLI re-sends system/init after reconnect", () => {
+      // Simulate: session completes work (idle), WS drops, CLI reconnects
+      // and re-sends system/init — state should NOT regress to "init"
+      const session = new SessionState("sess-1");
+      session.handleMessage(SYSTEM_INIT);
+      session.handleMessage(ASSISTANT_MSG);
+      session.handleMessage(RESULT_SUCCESS);
+      expect(session.state).toBe("idle");
+      expect(session.cost).toBe(0.05);
+
+      // CLI reconnects and re-sends system/init
+      const events = session.handleMessage(SYSTEM_INIT);
+
+      // State stays "idle" — no regression
+      expect(session.state).toBe("idle");
+      // Model/cwd still updated
+      expect(session.model).toBe("claude-sonnet-4-6");
+      expect(session.cwd).toBe("/home/user/project");
+      // Event carries the actual state, not "init"
+      expect(events[0].type).toBe("session:init");
+      expect((events[0] as { state: string }).state).toBe("idle");
+      // Cost preserved
+      expect(session.cost).toBe(0.05);
+    });
+
+    test("transitions to init after reconnect (disconnected → connecting → init)", () => {
+      // Simulate: session disconnects, reconnects, gets system/init
+      const session = new SessionState("sess-1");
+      session.handleMessage(SYSTEM_INIT);
+      session.handleMessage(ASSISTANT_MSG);
+      session.handleMessage(RESULT_SUCCESS);
+      expect(session.state).toBe("idle");
+
+      // WS drops → disconnected → reconnect → connecting
+      session.disconnect("WS closed");
+      expect(session.state).toBe("disconnected");
+      session.reconnect();
+      expect(session.state).toBe("connecting");
+
+      // system/init should transition to "init" from "connecting"
+      const events = session.handleMessage(SYSTEM_INIT);
+      expect(session.state).toBe("init");
+      expect((events[0] as { state: string }).state).toBe("init");
     });
   });
 
@@ -517,6 +563,11 @@ describe("SessionState", () => {
       // 10. End
       allEvents.push(...session.end());
       expect(session.state).toBe("ended");
+
+      // Verify session:init event carries state
+      const initEvent = allEvents.find((e) => e.type === "session:init");
+      expect(initEvent).toBeDefined();
+      expect((initEvent as { state: string }).state).toBe("init");
 
       // Verify event stream
       const types = allEvents.map((e) => e.type);

--- a/packages/daemon/src/claude-session/session-state.ts
+++ b/packages/daemon/src/claude-session/session-state.ts
@@ -23,7 +23,7 @@ import {
 // ── Events emitted by handleMessage ──
 
 export type SessionEvent =
-  | { type: "session:init"; sessionId: string; model: string; cwd: string }
+  | { type: "session:init"; sessionId: string; model: string; cwd: string; state: SessionStateEnum }
   | { type: "session:response"; message: AssistantMsg }
   | { type: "session:permission_request"; requestId: string; request: CanUseToolMsg["request"] }
   | { type: "session:result"; cost: number; tokens: number; numTurns: number; result: string }
@@ -181,7 +181,12 @@ export class SessionState {
     const parsed = SystemInit.parse(msg);
     this.model = parsed.model;
     this.cwd = parsed.cwd;
-    this.state = "init";
+
+    // Only transition to "init" from "connecting" — don't regress state
+    // when the CLI reconnects after a WS drop and re-sends system/init.
+    if (this.state === "connecting") {
+      this.state = "init";
+    }
 
     return [
       {
@@ -189,6 +194,7 @@ export class SessionState {
         sessionId: parsed.session_id,
         model: parsed.model,
         cwd: parsed.cwd,
+        state: this.state,
       },
     ];
   }


### PR DESCRIPTION
## Summary
- **State regression fix**: `SessionState.handleInit()` now only transitions to `init` from `connecting` state, preventing state regression when a CLI reconnects and re-sends `system/init` after WS drop (daemon worker crash/restart, macOS sleep/wake). The `session:init` event now carries the actual state for accurate DB persistence.
- **Missing sessionAddedAt refresh**: Added `sessionAddedAt.set()` to ClaudeServer's `db:state` and `db:cost` handlers (already present in codex/opencode servers), preventing the TTL-based dead session pruner from incorrectly pruning pid-less sessions that are still active.

## Test plan
- [x] New test: `system/init` does not regress state when CLI re-sends after reconnect (idle stays idle)
- [x] New test: `system/init` correctly transitions to `init` after `disconnected → connecting` flow
- [x] New test: `db:state` event refreshes sessionAddedAt so active sessions survive TTL prune
- [x] New test: `db:cost` event also refreshes sessionAddedAt
- [x] All existing tests pass (3553 pass, 0 fail)
- [x] Typecheck, lint, coverage all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)