### PR TITLE
fix(daemon): guard handshake timeout counter against clearTimeout race (fixes #956)

### DIFF
--- a/packages/daemon/src/acp-server.ts
+++ b/packages/daemon/src/acp-server.ts
@@ -190,10 +190,15 @@ export class AcpServer {
       this.client = this.clientFactory();
 
       let handshakeTimer: ReturnType<typeof setTimeout> | undefined;
+      let connectResolved = false;
       await Promise.race([
-        this.client.connect(this.transport),
+        this.client.connect(this.transport).then((r) => {
+          connectResolved = true;
+          return r;
+        }),
         new Promise<never>((_, reject) => {
           handshakeTimer = setTimeout(() => {
+            if (connectResolved) return;
             this.metrics.counter("mcpd_connect_timeouts_total").inc();
             reject(new Error("MCP handshake timeout (10s)"));
           }, this.handshakeTimeoutMs);

--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -230,10 +230,18 @@ export class ClaudeServer {
       // Connect triggers MCP handshake (calls transport.start() which sets worker.onmessage).
       // Race with a timeout to prevent indefinite hangs on broken handshakes (#454).
       let handshakeTimer: ReturnType<typeof setTimeout> | undefined;
+      let connectResolved = false;
       await Promise.race([
-        this.client.connect(this.transport),
+        this.client.connect(this.transport).then((r) => {
+          connectResolved = true;
+          return r;
+        }),
         new Promise<never>((_, reject) => {
           handshakeTimer = setTimeout(() => {
+            // Guard: if connect already won the race but clearTimeout didn't
+            // prevent this callback (Bun event-loop edge case, #956), skip the
+            // side-effect so the counter stays accurate.
+            if (connectResolved) return;
             this.metrics.counter("mcpd_connect_timeouts_total").inc();
             reject(new Error("MCP handshake timeout (10s)"));
           }, this.handshakeTimeoutMs);

--- a/packages/daemon/src/codex-server.ts
+++ b/packages/daemon/src/codex-server.ts
@@ -194,10 +194,15 @@ export class CodexServer {
       this.client = this.clientFactory();
 
       let handshakeTimer: ReturnType<typeof setTimeout> | undefined;
+      let connectResolved = false;
       await Promise.race([
-        this.client.connect(this.transport),
+        this.client.connect(this.transport).then((r) => {
+          connectResolved = true;
+          return r;
+        }),
         new Promise<never>((_, reject) => {
           handshakeTimer = setTimeout(() => {
+            if (connectResolved) return;
             this.metrics.counter("mcpd_connect_timeouts_total").inc();
             reject(new Error("MCP handshake timeout (10s)"));
           }, this.handshakeTimeoutMs);

--- a/packages/daemon/src/opencode-server.ts
+++ b/packages/daemon/src/opencode-server.ts
@@ -195,10 +195,15 @@ export class OpenCodeServer {
       this.client = this.clientFactory();
 
       let handshakeTimer: ReturnType<typeof setTimeout> | undefined;
+      let connectResolved = false;
       await Promise.race([
-        this.client.connect(this.transport),
+        this.client.connect(this.transport).then((r) => {
+          connectResolved = true;
+          return r;
+        }),
         new Promise<never>((_, reject) => {
           handshakeTimer = setTimeout(() => {
+            if (connectResolved) return;
             this.metrics.counter("mcpd_connect_timeouts_total").inc();
             reject(new Error("MCP handshake timeout (10s)"));
           }, this.handshakeTimeoutMs);


### PR DESCRIPTION
## Summary
- Add a `connectResolved` guard flag to the handshake timeout callback in all four server implementations (claude, codex, opencode, acp)
- Under heavy test suite load, the `setTimeout` callback can fire after `connect()` wins the `Promise.race` — Bun's `clearTimeout` may not prevent an already-enqueued callback from executing
- The guard ensures the `mcpd_connect_timeouts_total` counter is only incremented when the timeout genuinely caused the failure, preventing spurious increments that make the "does not increment counter on successful connect" test flaky

## Test plan
- [x] `bun test packages/daemon/src/claude-server.spec.ts` — 67 pass, 0 fail
- [x] `bun test packages/daemon/src/opencode-server.spec.ts packages/daemon/src/codex-server.spec.ts` — 68 pass, 0 fail
- [x] Full suite `bun test` — 3612 pass, 0 fail
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] Coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)