### PR TITLE
fix(daemon): drain orphaned async ops in startup variants afterEach (fixes #960)

### DIFF
--- a/packages/daemon/src/index.spec.ts
+++ b/packages/daemon/src/index.spec.ts
@@ -117,6 +117,25 @@ describe("daemon index.ts", () => {
         if (!handle.isShuttingDown) await handle.shutdown("SIGTERM");
         await handle.shutdownComplete;
       }
+      // After shutdown, worker threads and Bun's fetch connection pool may still
+      // have pending async operations. Yield the event loop to let them fire before
+      // the temp directory is removed, preventing ENXIO/ECONNRESET from leaking
+      // into the next test as unhandled exceptions (#960).
+      if (opts) {
+        const socketPath = join(opts.dir, "mcpd.sock");
+        await pollUntil(() => !existsSync(socketPath), 2_000).catch(() => {});
+        // Suppress expected post-shutdown socket errors during drain
+        const suppress = (err: Error) => {
+          const code = (err as NodeJS.ErrnoException).code;
+          if (code === "ENXIO" || code === "ECONNRESET") return;
+          throw err;
+        };
+        process.on("uncaughtException", suppress);
+        process.on("unhandledRejection", suppress);
+        await Bun.sleep(50);
+        process.removeListener("uncaughtException", suppress);
+        process.removeListener("unhandledRejection", suppress);
+      }
       handle = undefined;
       if (opts) {
         opts[Symbol.dispose]();


### PR DESCRIPTION
## Summary
- After `shutdownComplete` in the "startup variants" test group, worker threads and Bun's fetch connection pool may still have pending async operations
- Added post-shutdown drain step: polls for socket removal, then temporarily suppresses expected ENXIO/ECONNRESET errors while yielding the event loop
- Prevents orphaned async errors from leaking into the next test as unhandled exceptions

## Test plan
- [x] All 3620 tests pass
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] Coverage thresholds met
- [x] Pre-commit hook passes (typecheck + lint + test + coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)