### PR TITLE
fix(test): await shutdownComplete in P1 afterAll block (fixes #973)

### DIFF
--- a/packages/daemon/src/index.spec.ts
+++ b/packages/daemon/src/index.spec.ts
@@ -74,8 +74,9 @@ describe("daemon index.ts", () => {
     });
 
     afterAll(async () => {
-      if (handle && !handle.isShuttingDown) {
-        await handle.shutdown("SIGTERM");
+      if (handle) {
+        if (!handle.isShuttingDown) await handle.shutdown("SIGTERM");
+        await handle.shutdownComplete;
       }
       opts[Symbol.dispose]();
       _restoreOptions();


### PR DESCRIPTION
## Summary
- Apply the `shutdownComplete` await pattern to the P1 startup sequence `afterAll` block in `index.spec.ts`
- Matches the fix already applied to `afterEach` blocks in PR #971 (fixes #950)
- Prevents ENXIO race condition during test teardown

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] All 28 tests in `packages/daemon/src/index.spec.ts` pass
- [x] Pre-existing noise threshold failure on main (#1030) is unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)