### PR TITLE
feat(control): warn user when adding a server that already exists (fixes #991)

### DIFF
--- a/packages/control/src/app.tsx
+++ b/packages/control/src/app.tsx
@@ -451,7 +451,11 @@ export function App() {
         <>
           {(needsAuth.length > 0 || authStatus) && <AuthBanner servers={needsAuth} authStatus={authStatus} />}
           {addServerMode ? (
-            <ServerAddForm state={addServerState} configPath={resolveConfigPath(addServerState.scope)} />
+            <ServerAddForm
+              state={addServerState}
+              configPath={resolveConfigPath(addServerState.scope)}
+              nameExists={addServerState.name !== "" && addServerState.name in configInfo}
+            />
           ) : (
             <ServerList
               servers={servers}

--- a/packages/control/src/components/server-add-form.spec.tsx
+++ b/packages/control/src/components/server-add-form.spec.tsx
@@ -3,9 +3,9 @@ import { render } from "ink-testing-library";
 import React from "react";
 import { type AddServerState, ServerAddForm, initialAddServerState } from "./server-add-form";
 
-function renderForm(overrides: Partial<AddServerState> = {}) {
+function renderForm(overrides: Partial<AddServerState> = {}, props: { nameExists?: boolean } = {}) {
   const state: AddServerState = { ...initialAddServerState(), ...overrides };
-  const { lastFrame } = render(<ServerAddForm state={state} />);
+  const { lastFrame } = render(<ServerAddForm state={state} {...props} />);
   return lastFrame() ?? "";
 }
 
@@ -102,5 +102,23 @@ describe("ServerAddForm", () => {
     });
     expect(frame).not.toContain("Env:");
     expect(frame).toContain("project");
+  });
+
+  test("confirm step shows overwrite warning when nameExists is true", () => {
+    const frame = renderForm(
+      { step: "confirm", name: "my-server", transport: "http", url: "https://example.com", scope: "user" },
+      { nameExists: true },
+    );
+    expect(frame).toContain("already exists");
+    expect(frame).toContain("my-server");
+    expect(frame).toContain("overwrite");
+  });
+
+  test("confirm step hides overwrite warning when nameExists is false", () => {
+    const frame = renderForm(
+      { step: "confirm", name: "my-server", transport: "http", url: "https://example.com", scope: "user" },
+      { nameExists: false },
+    );
+    expect(frame).not.toContain("already exists");
   });
 });

--- a/packages/control/src/components/server-add-form.tsx
+++ b/packages/control/src/components/server-add-form.tsx
@@ -38,12 +38,14 @@ interface ServerAddFormProps {
   state: AddServerState;
   /** Resolved config file path for the current scope — shown on the confirm step. */
   configPath?: string;
+  /** When true, the server name already exists in the config and will be overwritten. */
+  nameExists?: boolean;
 }
 
 const TRANSPORT_OPTIONS: AddServerTransport[] = ["http", "sse", "stdio"];
 const SCOPE_OPTIONS: AddServerScope[] = ["user", "project"];
 
-export function ServerAddForm({ state, configPath }: ServerAddFormProps) {
+export function ServerAddForm({ state, configPath, nameExists }: ServerAddFormProps) {
   return (
     <Box flexDirection="column" marginLeft={2} marginTop={1}>
       <Text bold color="cyan">
@@ -159,6 +161,11 @@ export function ServerAddForm({ state, configPath }: ServerAddFormProps) {
           {configPath && (
             <Text>
               Config: <Text dimColor>{configPath}</Text>
+            </Text>
+          )}
+          {nameExists && (
+            <Text color="yellow">
+              ⚠ A server named &apos;{state.name}&apos; already exists — continuing will overwrite it
             </Text>
           )}
           <Text dimColor>enter save esc cancel</Text>


### PR DESCRIPTION
## Summary
- On the confirm step of the server add form, show a yellow warning when the entered name matches an existing server in `configInfo`
- Uses the `existed` information already tracked by `configInfo` — no new config reads needed
- User can press esc to go back and change the name, or enter to proceed with overwrite

## Test plan
- [x] Added test: confirm step shows overwrite warning when `nameExists` is true
- [x] Added test: confirm step hides warning when `nameExists` is false
- [x] All 1059 tests pass, typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)