### PR TITLE
refactor(control): deduplicate TRANSPORT_OPTIONS and SCOPE_OPTIONS constants (fixes #993)

### DIFF
--- a/packages/control/src/components/server-add-form.tsx
+++ b/packages/control/src/components/server-add-form.tsx
@@ -40,8 +40,8 @@ interface ServerAddFormProps {
   configPath?: string;
 }
 
-const TRANSPORT_OPTIONS: AddServerTransport[] = ["http", "sse", "stdio"];
-const SCOPE_OPTIONS: AddServerScope[] = ["user", "project"];
+export const TRANSPORT_OPTIONS: AddServerTransport[] = ["http", "sse", "stdio"];
+export const SCOPE_OPTIONS: AddServerScope[] = ["user", "project"];
 
 export function ServerAddForm({ state, configPath }: ServerAddFormProps) {
   return (

--- a/packages/control/src/hooks/use-keyboard-servers.ts
+++ b/packages/control/src/hooks/use-keyboard-servers.ts
@@ -6,12 +6,11 @@ import {
   type AddServerScope,
   type AddServerState,
   type AddServerTransport,
+  SCOPE_OPTIONS,
+  TRANSPORT_OPTIONS,
   initialAddServerState,
 } from "../components/server-add-form";
 import type { ServersNav } from "./use-keyboard";
-
-const TRANSPORT_OPTIONS: AddServerTransport[] = ["http", "sse", "stdio"];
-const SCOPE_OPTIONS: AddServerScope[] = ["user", "project"];
 
 /**
  * Split a command string into tokens, respecting single and double quotes.


### PR DESCRIPTION
## Summary
- Export `TRANSPORT_OPTIONS` and `SCOPE_OPTIONS` from `server-add-form.tsx` instead of keeping them module-private
- Import both constants in `use-keyboard-servers.ts` instead of redefining them
- Single source of truth for transport and scope option lists

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — all 3745 tests pass
- [x] Pre-commit hook passes (typecheck + lint + test + coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)