### PR TITLE
fix(control): reset add-server form state when switching tabs (fixes #992)

### DIFF
--- a/packages/control/src/hooks/use-keyboard-servers.spec.ts
+++ b/packages/control/src/hooks/use-keyboard-servers.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, mock, test } from "bun:test";
 import type { Key } from "ink";
 import { initialAddServerState } from "../components/server-add-form";
 import type { ServersNav } from "./use-keyboard";
-import { handleServersInput } from "./use-keyboard-servers";
+import { clearServersState, handleServersInput } from "./use-keyboard-servers";
 
 const baseKey: Key = {
   upArrow: false,
@@ -178,5 +178,30 @@ describe("handleServersInput", () => {
     const nav = makeNav({ selectedIndex: 1 });
     handleServersInput("a", baseKey, nav);
     expect(nav.setAuthStatus).toHaveBeenCalledWith({ server: "s2", state: "pending" });
+  });
+});
+
+describe("clearServersState", () => {
+  test("resets addServerMode, addServerState, and confirmRemove", () => {
+    const nav = makeNav({
+      addServerMode: true,
+      addServerState: {
+        step: "name",
+        transport: "stdio",
+        name: "partial",
+        url: "",
+        env: [],
+        envInput: "",
+        envError: "",
+        scope: "project",
+      },
+      confirmRemove: true,
+    });
+
+    clearServersState(nav);
+
+    expect(nav.setAddServerMode).toHaveBeenCalledWith(false);
+    expect(nav.setAddServerState).toHaveBeenCalled();
+    expect(nav.setConfirmRemove).toHaveBeenCalledWith(false);
   });
 });

--- a/packages/control/src/hooks/use-keyboard-servers.ts
+++ b/packages/control/src/hooks/use-keyboard-servers.ts
@@ -81,6 +81,13 @@ export function buildConfig(state: AddServerState): ServerConfig {
   };
 }
 
+/** Reset add-server / confirm-remove modal state (e.g. when leaving the servers tab). */
+export function clearServersState(nav: ServersNav): void {
+  nav.setAddServerMode(false);
+  nav.setAddServerState(initialAddServerState());
+  nav.setConfirmRemove(false);
+}
+
 /**
  * Handle keyboard input for the servers view.
  * Returns true if the input was consumed.

--- a/packages/control/src/hooks/use-keyboard.ts
+++ b/packages/control/src/hooks/use-keyboard.ts
@@ -14,7 +14,7 @@ import type { PlansNav } from "./use-keyboard-plans";
 import { clearPlansState, handlePlansInput } from "./use-keyboard-plans";
 import type { RegistryNav } from "./use-keyboard-registry";
 import { handleRegistryInput } from "./use-keyboard-registry";
-import { handleServersInput } from "./use-keyboard-servers";
+import { clearServersState, handleServersInput } from "./use-keyboard-servers";
 import { handleStatsInput } from "./use-keyboard-stats";
 import type { LogSource } from "./use-logs";
 
@@ -242,13 +242,17 @@ export function useKeyboard({
       return;
     }
 
-    // Helper: clear plans modal state when navigating away
+    // Helpers: clear modal state when navigating away from a view
     const leavePlansView = () => {
       if (view === "plans") clearPlansState(plansNav);
+    };
+    const leaveServersView = () => {
+      if (view === "servers") clearServersState(serversNav);
     };
 
     // Global: Tab / Shift+Tab cycle tabs
     if (key.tab) {
+      leaveServersView();
       leavePlansView();
       setView(key.shift ? prevTab(view) : nextTab(view));
       return;
@@ -259,6 +263,7 @@ export function useKeyboard({
     if (tabNum >= 1 && tabNum <= ALL_TABS.length) {
       const target = tabByNumber(tabNum);
       if (target) {
+        leaveServersView();
         leavePlansView();
         setView(target);
       }
@@ -271,6 +276,7 @@ export function useKeyboard({
         logsNav.setFilterText("");
         setView("servers");
       } else {
+        leaveServersView();
         leavePlansView();
         setView("logs");
       }
@@ -297,6 +303,7 @@ export function useKeyboard({
         return;
       }
       if (view === "logs") logsNav.setFilterText("");
+      leaveServersView();
       leavePlansView();
       setView("servers");
       return;
@@ -313,6 +320,7 @@ export function useKeyboard({
 
     // `b` opens registry browser from any view
     if (input === "b" && view !== "registry") {
+      leaveServersView();
       leavePlansView();
       setView("registry");
       return;


### PR DESCRIPTION
## Summary
- Adds `clearServersState()` function that resets `addServerMode`, `addServerState`, and `confirmRemove` when leaving the servers tab
- Calls `leaveServersView()` at every tab-switch point (Tab/Shift+Tab, number keys, `l`, `b`, Esc) alongside existing `leavePlansView()` pattern
- Prevents the add-server form and confirm-remove dialog from persisting across tab switches

## Test plan
- [x] Added unit test for `clearServersState` verifying all three state values are reset
- [x] All 3746 existing tests pass
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)