### PR TITLE
fix(coverage): remove permission-router exclusion — tests already cover 100% (fixes #1026)

### DIFF
--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -121,9 +121,6 @@ const EXCLUSIONS: Record<string, string> = {
   // ACP server — worker crash/restart lifecycle requires integration with real Worker threads
   "daemon/src/acp-server.ts": "45% coverage, crash recovery lifecycle requires integration test",
 
-  // Incremental coverage bug — 100% on full run, 19% on incremental (#1036)
-  "daemon/src/claude-session/permission-router.ts": "Incremental coverage artifact, 100% on full run (#1036)",
-
   // CI scripts — git-dependent, tested via pure-function unit tests + CI integration
   "scripts/release.ts": "CI-only release script, git-dependent async functions untestable in isolation",
   // Test harness — not production code


### PR DESCRIPTION
## Summary
- Removed the `permission-router.ts` exclusion from `scripts/check-coverage.ts`
- The file already has 100% test coverage in the daemon test run (run 2); the 19% figure was an incremental coverage artifact from run 1 (transitive-only measurement)
- The `bestCoverage` logic already takes the max across both runs, so no exclusion is needed

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes  
- [x] `bun test` — all 3764 tests pass
- [x] `bun scripts/check-coverage.ts` — PASS with 28 exclusions (down from 29)
- [x] Verified permission-router.ts shows 100% in run 2 coverage output

🤖 Generated with [Claude Code](https://claude.com/claude-code)