### PR TITLE
feat(cli): add --keep/--keep-worktree flag to mcx claude bye (fixes #1048)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -1356,6 +1356,59 @@ describe("mcx claude bye", () => {
     await expect(cmdClaude(["bye"], deps)).rejects.toThrow(ExitError);
   });
 
+  test("--keep skips worktree cleanup and prints preserved path", async () => {
+    const callTool: ClaudeDeps["callTool"] = mock(async (tool: string) => {
+      if (tool === "claude_session_list") return toolResult(SESSION_LIST);
+      return toolResult({ ended: true, worktree: "claude-abc123", cwd: "/repo" });
+    });
+    const exec: ClaudeDeps["exec"] = mock(() => ({
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+    }));
+    const printError = mock(() => {});
+    const deps = makeDeps({ callTool, exec, printError });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["bye", "def", "--keep"], deps);
+      // Should NOT call any git commands (no cleanup)
+      expect(exec).not.toHaveBeenCalled();
+      // Should print preserved message
+      const errOutput = printError.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+      expect(errOutput).toContain("Worktree preserved:");
+      expect(errOutput).toContain("/repo");
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("--keep-worktree is an alias for --keep", async () => {
+    const callTool: ClaudeDeps["callTool"] = mock(async (tool: string) => {
+      if (tool === "claude_session_list") return toolResult(SESSION_LIST);
+      return toolResult({ ended: true, worktree: "claude-abc123", cwd: "/repo" });
+    });
+    const exec: ClaudeDeps["exec"] = mock(() => ({
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+    }));
+    const printError = mock(() => {});
+    const deps = makeDeps({ callTool, exec, printError });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["bye", "def", "--keep-worktree"], deps);
+      expect(exec).not.toHaveBeenCalled();
+      const errOutput = printError.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+      expect(errOutput).toContain("Worktree preserved:");
+    } finally {
+      console.log = origLog;
+    }
+  });
+
   test("removes clean worktree after bye", async () => {
     const callTool: ClaudeDeps["callTool"] = mock(async (tool: string) => {
       if (tool === "claude_session_list") return toolResult(SESSION_LIST);

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -803,10 +803,12 @@ async function claudeSend(args: string[], d: ClaudeDeps): Promise<void> {
 }
 
 async function claudeBye(args: string[], d: ClaudeDeps): Promise<void> {
-  const sessionPrefix = args[0];
+  const keepWorktree = args.includes("--keep") || args.includes("--keep-worktree");
+  const positional = args.filter((a) => a !== "--keep" && a !== "--keep-worktree");
+  const sessionPrefix = positional[0];
 
   if (!sessionPrefix) {
-    d.printError("Usage: mcx claude bye <session-id>");
+    d.printError("Usage: mcx claude bye <session-id> [--keep|--keep-worktree]");
     d.exit(1);
   }
 
@@ -818,7 +820,10 @@ async function claudeBye(args: string[], d: ClaudeDeps): Promise<void> {
   console.log(formatToolResult(result));
 
   if (byeResult.worktree) {
-    if (byeResult.cwd) {
+    if (keepWorktree) {
+      const wtPath = byeResult.cwd ?? resolveKeptWorktreePath(byeResult);
+      d.printError(`Worktree preserved: ${wtPath}`);
+    } else if (byeResult.cwd) {
       cleanupWorktree(byeResult.worktree, byeResult.cwd, d, byeResult.repoRoot);
     } else {
       // Daemon-created worktrees: cwd is null — resolve from local repo root
@@ -828,6 +833,13 @@ async function claudeBye(args: string[], d: ClaudeDeps): Promise<void> {
       cleanupWorktree(byeResult.worktree, cwd, d, repoRoot);
     }
   }
+}
+
+/** Resolve the worktree path for --keep output when cwd is not provided */
+function resolveKeptWorktreePath(byeResult: ByeResult): string {
+  const repoRoot = process.cwd();
+  const wtConfig = readWorktreeConfig(repoRoot);
+  return resolveWorktreePath(repoRoot, byeResult.worktree as string, wtConfig);
 }
 
 export interface ByeResult {


### PR DESCRIPTION
## Summary
- Adds `--keep` / `--keep-worktree` flag to `mcx claude bye` that ends the session normally but skips worktree cleanup
- Session is terminated (process killed, DB updated, removed from `ls`), but the worktree directory and branch remain on disk
- Prints the preserved worktree path to stderr for easy `cd`

## Test plan
- [x] `mcx claude bye <id> --keep` ends session, does not call `git worktree remove`, prints preserved path
- [x] `--keep-worktree` works as long-form alias
- [x] Without flag, existing cleanup behavior is unchanged (clean removal, dirty warning, null-cwd resolution)
- [x] Typecheck, lint, and all 1075 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)