### PR TITLE
feat(command): add mcx scope init/list/rm commands (fixes #1009)

### DIFF
--- a/packages/command/src/commands/scope.spec.ts
+++ b/packages/command/src/commands/scope.spec.ts
@@ -1,0 +1,168 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { testOptions } from "../../../../test/test-options";
+import { type ScopeFile, cmdScope } from "./scope";
+
+function makeDeps(cwd: string) {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return {
+    deps: {
+      cwd: () => cwd,
+      log: (msg: string) => logs.push(msg),
+      error: (msg: string) => errors.push(msg),
+    },
+    logs,
+    errors,
+  };
+}
+
+describe("mcx scope init", () => {
+  test("creates scope file with cwd as root", async () => {
+    using opts = testOptions();
+    const { deps, logs } = makeDeps("/tmp/my-project");
+
+    await cmdScope(["init", "myproj"], deps);
+
+    const scopeFile = JSON.parse(readFileSync(join(opts.SCOPES_DIR, "myproj.json"), "utf-8")) as ScopeFile;
+    expect(scopeFile.root).toBe("/tmp/my-project");
+    expect(scopeFile.created).toBeTruthy();
+    expect(logs[0]).toContain("myproj");
+  });
+
+  test("defaults name to directory basename", async () => {
+    using opts = testOptions();
+    const { deps } = makeDeps("/tmp/cool-project");
+
+    await cmdScope(["init"], deps);
+
+    expect(existsSync(join(opts.SCOPES_DIR, "cool-project.json"))).toBe(true);
+  });
+
+  test("errors on duplicate name without --force", async () => {
+    using _opts = testOptions({
+      files: { "scopes/existing.json": { root: "/old", created: "2026-01-01T00:00:00Z" } },
+    });
+    const { deps } = makeDeps("/tmp/new");
+
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    try {
+      expect(() => cmdScope(["init", "existing"], deps)).toThrow("process.exit");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  test("overwrites with --force", async () => {
+    using opts = testOptions({
+      files: { "scopes/existing.json": { root: "/old", created: "2026-01-01T00:00:00Z" } },
+    });
+    const { deps } = makeDeps("/tmp/new");
+
+    await cmdScope(["init", "existing", "--force"], deps);
+
+    const scopeFile = JSON.parse(readFileSync(join(opts.SCOPES_DIR, "existing.json"), "utf-8")) as ScopeFile;
+    expect(scopeFile.root).toBe("/tmp/new");
+  });
+
+  test("warns when cwd is under existing scope", async () => {
+    using _opts = testOptions({
+      files: { "scopes/parent.json": { root: "/projects/mono", created: "2026-01-01T00:00:00Z" } },
+    });
+    const { deps, errors } = makeDeps("/projects/mono/packages/lib");
+
+    await cmdScope(["init", "lib"], deps);
+
+    expect(errors.some((e) => e.includes('Already under scope "parent"'))).toBe(true);
+  });
+
+  test("rejects invalid scope name", async () => {
+    using _opts = testOptions();
+    const { deps } = makeDeps("/tmp/test");
+
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    try {
+      expect(() => cmdScope(["init", "bad name!"], deps)).toThrow("process.exit");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+});
+
+describe("mcx scope list", () => {
+  test("lists all registered scopes", async () => {
+    using _opts = testOptions({
+      files: {
+        "scopes/alpha.json": { root: "/projects/alpha", created: "2026-01-01T00:00:00Z" },
+        "scopes/beta.json": { root: "/projects/beta", created: "2026-01-02T00:00:00Z" },
+      },
+    });
+    const { deps, logs } = makeDeps("/tmp");
+
+    await cmdScope(["list"], deps);
+
+    expect(logs.length).toBe(2);
+    expect(logs.some((l) => l.includes("alpha") && l.includes("/projects/alpha"))).toBe(true);
+    expect(logs.some((l) => l.includes("beta") && l.includes("/projects/beta"))).toBe(true);
+  });
+
+  test("shows message when no scopes exist", async () => {
+    using _opts = testOptions();
+    const { deps, errors } = makeDeps("/tmp");
+
+    await cmdScope(["list"], deps);
+
+    expect(errors[0]).toContain("No scopes registered");
+  });
+});
+
+describe("mcx scope rm", () => {
+  test("removes an existing scope", async () => {
+    using opts = testOptions({
+      files: { "scopes/removeme.json": { root: "/old", created: "2026-01-01T00:00:00Z" } },
+    });
+    const { deps, logs } = makeDeps("/tmp");
+
+    await cmdScope(["rm", "removeme"], deps);
+
+    expect(existsSync(join(opts.SCOPES_DIR, "removeme.json"))).toBe(false);
+    expect(logs[0]).toContain("removed");
+  });
+
+  test("errors when scope not found", async () => {
+    using _opts = testOptions();
+    const { deps } = makeDeps("/tmp");
+
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    try {
+      expect(() => cmdScope(["rm", "nonexistent"], deps)).toThrow("process.exit");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  test("errors when no name provided", async () => {
+    using _opts = testOptions();
+    const { deps } = makeDeps("/tmp");
+
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    try {
+      expect(() => cmdScope(["rm"], deps)).toThrow("process.exit");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+});

--- a/packages/command/src/commands/scope.ts
+++ b/packages/command/src/commands/scope.ts
@@ -1,0 +1,141 @@
+/**
+ * `mcx scope` — manage project scopes.
+ *
+ * Scopes register directory roots by name, stored as JSON files in ~/.mcp-cli/scopes/.
+ */
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { basename, join, resolve } from "node:path";
+import { options } from "@mcp-cli/core";
+import { printError } from "../output";
+
+export interface ScopeFile {
+  root: string;
+  created: string;
+}
+
+/** Dependency injection for testability */
+export interface ScopeDeps {
+  cwd: () => string;
+  log?: (msg: string) => void;
+  error?: (msg: string) => void;
+}
+
+const defaultDeps: ScopeDeps = {
+  cwd: () => process.cwd(),
+};
+
+export function cmdScope(args: string[], deps: ScopeDeps = defaultDeps): void {
+  const sub = args[0];
+
+  switch (sub) {
+    case "init":
+      scopeInit(args.slice(1), deps);
+      break;
+    case "list":
+    case "ls":
+      scopeList(deps);
+      break;
+    case "rm":
+    case "remove":
+      scopeRm(args.slice(1), deps);
+      break;
+    default:
+      printError("Usage: mcx scope {init|list|rm} [args]");
+      process.exit(1);
+  }
+}
+
+function scopePath(name: string): string {
+  return join(options.SCOPES_DIR, `${name}.json`);
+}
+
+function readScope(name: string): ScopeFile | null {
+  const path = scopePath(name);
+  if (!existsSync(path)) return null;
+  return JSON.parse(readFileSync(path, "utf-8")) as ScopeFile;
+}
+
+function listAllScopes(): Array<{ name: string; scope: ScopeFile }> {
+  if (!existsSync(options.SCOPES_DIR)) return [];
+  const entries = readdirSync(options.SCOPES_DIR).filter((f) => f.endsWith(".json"));
+  const result: Array<{ name: string; scope: ScopeFile }> = [];
+  for (const entry of entries) {
+    const name = entry.replace(/\.json$/, "");
+    const scope = readScope(name);
+    if (scope) result.push({ name, scope });
+  }
+  return result;
+}
+
+function scopeInit(args: string[], deps: ScopeDeps): void {
+  const force = args.includes("--force");
+  const positional = args.filter((a) => !a.startsWith("-"));
+  const cwd = resolve(deps.cwd());
+  const name = positional[0] ?? basename(cwd);
+  const log = deps.log ?? console.log;
+  const error = deps.error ?? console.error;
+
+  // Validate name
+  if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+    printError(`Invalid scope name "${name}": must be alphanumeric, hyphens, or underscores`);
+    process.exit(1);
+  }
+
+  // Check if cwd is already under an existing scope
+  const existing = listAllScopes();
+  for (const { name: existingName, scope } of existing) {
+    const root = resolve(scope.root);
+    if (cwd.startsWith(`${root}/`) || cwd === root) {
+      error(`Warning: Already under scope "${existingName}" (root: ${root})`);
+      break;
+    }
+  }
+
+  // Check if name already exists
+  if (!force && existsSync(scopePath(name))) {
+    printError(`Scope "${name}" already exists. Use --force to overwrite.`);
+    process.exit(1);
+  }
+
+  mkdirSync(options.SCOPES_DIR, { recursive: true });
+
+  const scopeFile: ScopeFile = {
+    root: cwd,
+    created: new Date().toISOString(),
+  };
+  writeFileSync(scopePath(name), `${JSON.stringify(scopeFile, null, 2)}\n`);
+  log(`Scope "${name}" registered at ${cwd}`);
+}
+
+function scopeList(deps: ScopeDeps): void {
+  const log = deps.log ?? console.log;
+  const error = deps.error ?? console.error;
+  const scopes = listAllScopes();
+
+  if (scopes.length === 0) {
+    error("No scopes registered. Use `mcx scope init` to create one.");
+    return;
+  }
+
+  for (const { name, scope } of scopes) {
+    log(`  ${name}\t${scope.root}`);
+  }
+}
+
+function scopeRm(args: string[], deps: ScopeDeps): void {
+  const name = args.find((a) => !a.startsWith("-"));
+  if (!name) {
+    printError("Usage: mcx scope rm <name>");
+    process.exit(1);
+  }
+
+  const path = scopePath(name);
+  if (!existsSync(path)) {
+    printError(`Scope "${name}" not found`);
+    process.exit(1);
+  }
+
+  unlinkSync(path);
+  (deps.log ?? console.log)(`Scope "${name}" removed`);
+}

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -34,6 +34,7 @@ import { cmdNote } from "./commands/note";
 import { cmdRegistryDispatch } from "./commands/registry-cmd";
 import { cmdRemove } from "./commands/remove";
 import { cmdRun } from "./commands/run";
+import { cmdScope } from "./commands/scope";
 import { cmdServe } from "./commands/serve";
 import { cmdSpans } from "./commands/spans";
 import { cmdTty } from "./commands/tty";
@@ -294,6 +295,10 @@ async function main(): Promise<void> {
       case "opencode":
         console.error(`Warning: "mcx ${command}" is deprecated. Use "mcx agent ${command}" instead.`);
         await cmdAgent([command, ...cleanArgs.slice(1)]);
+        break;
+
+      case "scope":
+        await cmdScope(cleanArgs.slice(1));
         break;
 
       case "serve":
@@ -796,6 +801,9 @@ Usage:
   mcx agent codex spawn --task "..."   Start a Codex session
   mcx agent acp spawn --task "..."     Start an ACP agent session
   mcx claude <subcommand>              Alias for mcx agent claude <subcommand>
+  mcx scope init [name] [--force]     Register current directory as a scope
+  mcx scope list                      List all registered scopes
+  mcx scope rm <name>                 Remove a scope
   mcx serve                           Run as stdio MCP server (for .mcp.json)
   mcx completions {bash|zsh|fish}     Generate shell completion script
   mcx restart [server]                Restart server connection(s)

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -100,6 +100,8 @@ const _originalOptions = {
   DAEMON_LOG_BACKUP_PATH: join(MCP_CLI_DIR, "mcpd.log.1"),
   /** Directory for headless process logs (`mcx tty open --headless`) */
   LOGS_DIR: join(MCP_CLI_DIR, "logs"),
+  /** Directory for project scope definitions */
+  SCOPES_DIR: join(MCP_CLI_DIR, "scopes"),
   /** Mail TTL (ms) — read messages older than this are pruned (default 7 days) */
   MAIL_TTL_MS: 7 * 24 * 60 * 60 * 1000,
   /** How many log inserts between prune passes (amortized O(1)) */

--- a/test/test-options.ts
+++ b/test/test-options.ts
@@ -39,6 +39,7 @@ export function testOptions(input?: TestOptionsInput) {
   options.LOCK_PATH = join(dir, "mcpd.lock");
   options.DAEMON_LOG_PATH = join(dir, "mcpd.log");
   options.DAEMON_LOG_BACKUP_PATH = join(dir, "mcpd.log.1");
+  options.SCOPES_DIR = join(dir, "scopes");
 
   if (Object.keys(overrides).length > 0) Object.assign(options, overrides);
 


### PR DESCRIPTION
## Summary
- Adds `mcx scope init [name] [--force]` to register the current directory as a named scope (stored as `~/.mcp-cli/scopes/<name>.json`)
- Adds `mcx scope list` to display all registered scopes with root directories
- Adds `mcx scope rm <name>` to remove a scope registration
- Init warns when CWD is already under an existing scope, errors on name conflict unless `--force`

## Test plan
- [x] `scope init` creates scope JSON with correct root and timestamp
- [x] `scope init` defaults name to directory basename
- [x] `scope init` errors on duplicate without `--force`, succeeds with `--force`
- [x] `scope init` warns when CWD is under existing scope
- [x] `scope init` rejects invalid names
- [x] `scope list` shows all registered scopes
- [x] `scope list` shows message when none exist
- [x] `scope rm` deletes scope file
- [x] `scope rm` errors when scope not found or no name given
- [x] All 11 tests pass, typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)