### PR TITLE
feat(daemon): emit session:rate_limited event and surface in mcx claude ls (fixes #1043)

### DIFF
--- a/packages/acp/src/acp-session.ts
+++ b/packages/acp/src/acp-session.ts
@@ -321,6 +321,7 @@ export class AcpSession {
       worktree: this.config.worktree ?? null,
       repoRoot: this.config.repoRoot ?? null,
       processAlive: this.proc?.alive ?? false,
+      rateLimited: false,
       createdAt: this.createdAt,
     };
   }

--- a/packages/codex/src/codex-session.ts
+++ b/packages/codex/src/codex-session.ts
@@ -269,6 +269,7 @@ export class CodexSession {
       worktree: this.config.worktree ?? null,
       repoRoot: this.config.repoRoot ?? null,
       processAlive: this.proc?.alive ?? false,
+      rateLimited: false,
       createdAt: this.createdAt,
     };
   }

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -747,7 +747,7 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
   for (let i = 0; i < sessions.length; i++) {
     const s = sessions[i];
     const id = s.sessionId.slice(0, 8);
-    const state = colorState(s.state);
+    const stateStr = s.rateLimited ? `${colorState(s.state)} ${c.red}[RATE LIMITED]${c.reset}` : colorState(s.state);
     const model = (s.model ?? "—").padEnd(16);
     const cost = s.cost > 0 ? `$${s.cost.toFixed(4)}`.padEnd(8) : "—".padEnd(8);
     const tokens = s.tokens > 0 ? String(s.tokens).padEnd(10) : "—".padEnd(10);
@@ -757,7 +757,7 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
     const age = formatAge(s.createdAt);
     const ageSuffix = age ? ` ${c.yellow}${age}${c.reset}` : "";
     console.log(
-      `${c.cyan}${id}${c.reset}   ${state} ${model} ${cost} ${tokens}${diff}${pr} ${c.dim}${cwd}${c.reset}${ageSuffix}`,
+      `${c.cyan}${id}${c.reset}   ${stateStr} ${model} ${cost} ${tokens}${diff}${pr} ${c.dim}${cwd}${c.reset}${ageSuffix}`,
     );
   }
 

--- a/packages/command/src/commands/session-display.spec.ts
+++ b/packages/command/src/commands/session-display.spec.ts
@@ -196,4 +196,22 @@ describe("formatSessionShort with createdAt", () => {
     });
     expect(line).not.toContain("(");
   });
+
+  test("shows [RATE LIMITED] when rateLimited is true", () => {
+    const line = formatSessionShort({
+      sessionId: "84418297-1234-5678-9abc-def012345678",
+      state: "active",
+      rateLimited: true,
+    });
+    expect(line).toContain("[RATE LIMITED]");
+  });
+
+  test("does not show [RATE LIMITED] when rateLimited is false", () => {
+    const line = formatSessionShort({
+      sessionId: "84418297-1234-5678-9abc-def012345678",
+      state: "active",
+      rateLimited: false,
+    });
+    expect(line).not.toContain("[RATE LIMITED]");
+  });
 });

--- a/packages/command/src/commands/session-display.ts
+++ b/packages/command/src/commands/session-display.ts
@@ -34,10 +34,11 @@ export function formatSessionShort(s: {
   cost?: number | null;
   tokens?: number;
   numTurns?: number;
+  rateLimited?: boolean;
   createdAt?: number | null;
 }): string {
   const id = s.sessionId.slice(0, 8);
-  const state = s.state;
+  const state = s.rateLimited ? `${s.state} [RATE LIMITED]` : s.state;
   const model = s.model ?? "—";
   const cost = s.cost && s.cost > 0 ? `$${s.cost.toFixed(4)}` : "—";
   const tokens = s.tokens && s.tokens > 0 ? String(s.tokens) : "—";

--- a/packages/control/src/hooks/use-agent-sessions.spec.ts
+++ b/packages/control/src/hooks/use-agent-sessions.spec.ts
@@ -24,6 +24,7 @@ function session(id: string, provider: "claude" | "codex" = "claude"): AgentSess
     worktree: null,
     repoRoot: null,
     processAlive: true,
+    rateLimited: false,
     createdAt: Date.now(),
   };
 }

--- a/packages/core/src/agent-session.ts
+++ b/packages/core/src/agent-session.ts
@@ -48,6 +48,8 @@ export interface AgentSessionInfo {
   repoRoot: string | null;
   /** Whether the agent process is still alive. */
   processAlive: boolean;
+  /** Whether the session is currently rate-limited by the API. */
+  rateLimited: boolean;
   /** Unix timestamp (ms) when this session was created. Null if unknown. */
   createdAt: number | null;
 }

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -380,6 +380,9 @@ function forwardSessionEvent(sessionId: string, event: SessionEvent): void {
     case "session:cleared":
       self.postMessage({ type: "db:state", sessionId, state: "connecting" });
       break;
+    case "session:rate_limited":
+      self.postMessage({ type: "metrics:inc", name: "mcpd_session_rate_limited_total" });
+      break;
     case "session:model_changed":
       self.postMessage({ type: "db:upsert", session: { sessionId, model: event.model } });
       break;

--- a/packages/daemon/src/claude-session/session-state.spec.ts
+++ b/packages/daemon/src/claude-session/session-state.spec.ts
@@ -859,6 +859,68 @@ describe("SessionState", () => {
     });
   });
 
+  describe("rate limiting", () => {
+    const ASSISTANT_RATE_LIMITED = {
+      ...ASSISTANT_MSG,
+      error: "rate_limit",
+    };
+
+    test("emits session:rate_limited when assistant has error: rate_limit", () => {
+      const session = initSession();
+      const events = session.handleMessage(ASSISTANT_RATE_LIMITED);
+
+      expect(events).toHaveLength(2);
+      expect(events[0].type).toBe("session:response");
+      expect(events[1]).toEqual({ type: "session:rate_limited", sessionId: "sess-1" });
+      expect(session.rateLimited).toBe(true);
+    });
+
+    test("does not emit session:rate_limited for normal assistant messages", () => {
+      const session = initSession();
+      const events = session.handleMessage(ASSISTANT_MSG);
+
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe("session:response");
+      expect(session.rateLimited).toBe(false);
+    });
+
+    test("clears rateLimited on successful result", () => {
+      const session = initSession();
+      session.handleMessage(ASSISTANT_RATE_LIMITED);
+      expect(session.rateLimited).toBe(true);
+
+      session.handleMessage(RESULT_SUCCESS);
+      expect(session.rateLimited).toBe(false);
+    });
+
+    test("rateLimited flag persists across multiple assistant messages", () => {
+      const session = initSession();
+      session.handleMessage(ASSISTANT_RATE_LIMITED);
+      expect(session.rateLimited).toBe(true);
+
+      // A normal assistant message does not clear the flag
+      session.handleMessage(ASSISTANT_MSG);
+      expect(session.rateLimited).toBe(true);
+    });
+
+    test("rate limit detected in fallback assistant messages", () => {
+      const session = new SessionState("test-rl");
+      session.handleMessage(SYSTEM_INIT);
+      const events = session.handleMessage({
+        type: "assistant",
+        error: "rate_limit",
+        message: {
+          usage: { input_tokens: 10, output_tokens: 5 },
+        },
+      });
+
+      expect(session.rateLimited).toBe(true);
+      expect(session.parseMismatch).toBe(true);
+      expect(events).toHaveLength(2);
+      expect(events[1]).toEqual({ type: "session:rate_limited", sessionId: "test-rl" });
+    });
+  });
+
   describe("parseMismatch lifecycle", () => {
     test("parseMismatch is cleared on each handleMessage call", () => {
       const session = new SessionState("test");

--- a/packages/daemon/src/claude-session/session-state.ts
+++ b/packages/daemon/src/claude-session/session-state.ts
@@ -36,6 +36,7 @@ export type SessionEvent =
   | { type: "session:permission_request"; requestId: string; request: CanUseToolMsg["request"] }
   | { type: "session:result"; cost: number; tokens: number; numTurns: number; result: string }
   | { type: "session:error"; errors: string[]; cost: number }
+  | { type: "session:rate_limited"; sessionId: string }
   | { type: "session:disconnected"; reason: string }
   | { type: "session:ended" }
   | { type: "session:cleared" }
@@ -74,6 +75,7 @@ export class SessionState {
   cost = 0;
   tokens = 0;
   numTurns = 0;
+  rateLimited = false;
   readonly pendingPermissions = new Map<string, CanUseToolMsg["request"]>();
   private readonly genRequestId: RequestIdGenerator;
 
@@ -243,7 +245,12 @@ export class SessionState {
       this.state = "active";
       const usage = strict.data.message.usage;
       this.tokens += usage.input_tokens + usage.output_tokens;
-      return [{ type: "session:response", message: strict.data }];
+      const events: SessionEvent[] = [{ type: "session:response", message: strict.data }];
+      if (strict.data.error === "rate_limit") {
+        this.rateLimited = true;
+        events.push({ type: "session:rate_limited", sessionId: this.sessionId });
+      }
+      return events;
     }
 
     // Fallback: still transition to active and extract tokens if possible
@@ -255,7 +262,13 @@ export class SessionState {
       if (usage) {
         this.tokens += usage.input_tokens + usage.output_tokens;
       }
-      return [{ type: "session:response", message: buildFallbackAssistant(msg, loose.data) }];
+      const assistant = buildFallbackAssistant(msg, loose.data);
+      const events: SessionEvent[] = [{ type: "session:response", message: assistant }];
+      if (assistant.error === "rate_limit") {
+        this.rateLimited = true;
+        events.push({ type: "session:rate_limited", sessionId: this.sessionId });
+      }
+      return events;
     }
 
     // Even the fallback failed — still transition to active
@@ -274,6 +287,7 @@ export class SessionState {
       this.numTurns += r.num_turns;
       this.tokens += resultTokens;
       this.state = "idle";
+      this.rateLimited = false;
       return [
         {
           type: "session:result",

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -1302,6 +1302,17 @@ export class ClaudeWsServer {
           logErr("resolveEventWaiters failed", err);
         }
         break;
+      case "session:rate_limited":
+        session.pendingImmediate = true;
+        try {
+          this.resolveEventWaiters(sessionId, {
+            sessionId,
+            event: "session:rate_limited",
+          });
+        } catch (err) {
+          logErr("resolveEventWaiters failed", err);
+        }
+        break;
       case "session:disconnected":
         try {
           this.resolveEventWaiters(sessionId, {
@@ -1477,6 +1488,7 @@ export class ClaudeWsServer {
       worktree: s.config.worktree ?? null,
       repoRoot: s.config.repoRoot ?? null,
       processAlive: s.spawnAlive,
+      rateLimited: s.state.rateLimited,
       createdAt: s.createdAt,
       wsConnected: s.ws !== null,
       spawnAlive: s.spawnAlive,

--- a/packages/opencode/src/opencode-session.ts
+++ b/packages/opencode/src/opencode-session.ts
@@ -304,6 +304,7 @@ export class OpenCodeSession {
       worktree: this.config.worktree ?? null,
       repoRoot: this.config.repoRoot ?? null,
       processAlive: this.proc?.alive ?? false,
+      rateLimited: false,
       createdAt: this.createdAt,
     };
   }


### PR DESCRIPTION
## Summary
- Adds `session:rate_limited` event to the SessionEvent union, emitted when an assistant NDJSON message carries `error: "rate_limit"` — gives orchestrators a signal to pause spawning
- Adds `rateLimited` boolean to `AgentSessionInfo`/`SessionInfo`, set on rate limit hit, cleared on next `session:result`
- Shows `[RATE LIMITED]` indicator in `mcx claude ls` output (table and `--short` formats), included in `--json` output
- Increments `mcpd_session_rate_limited_total` Prometheus counter on each rate limit event

## Test plan
- [x] `session:rate_limited` event emitted when `error: "rate_limit"` seen on assistant message (strict and fallback paths)
- [x] `rateLimited` flag set on rate limit, persists across normal assistant messages, cleared on `session:result`
- [x] `formatSessionShort` shows `[RATE LIMITED]` when flag is true, omits when false
- [x] All 3771 tests pass, typecheck + lint clean
- [x] Coverage thresholds met (session-state.ts at 100% line + function coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)