### PR TITLE
fix(test): suppress MCPD_READY noise and ratchet threshold from 21 to 1 (fixes #1014)

### DIFF
--- a/packages/daemon/src/index.spec.ts
+++ b/packages/daemon/src/index.spec.ts
@@ -37,11 +37,12 @@ async function withDaemonTimeout<T>(timeoutMs: string, fn: () => Promise<T>): Pr
   }
 }
 
-/** Start a daemon with test-appropriate defaults (skip log setup + virtual servers). */
+/** Start a daemon with test-appropriate defaults (skip log setup + virtual servers + ready signal). */
 async function startTestDaemonInProcess(overrides?: Partial<Parameters<typeof startDaemon>[0]>): Promise<DaemonHandle> {
   return startDaemon({
     skipLogSetup: true,
     skipVirtualServers: true,
+    skipReadySignal: true,
     logger: silentLogger,
     ...overrides,
   });

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -206,6 +206,8 @@ export interface StartDaemonOptions {
   skipLogSetup?: boolean;
   /** Skip booting virtual servers (_aliases, _claude). */
   skipVirtualServers?: boolean;
+  /** Skip printing MCPD_READY to stdout (useful for tests). */
+  skipReadySignal?: boolean;
   /** Logger for daemon output. Defaults to consoleLogger. */
   logger?: Logger;
   /** Override virtual servers used in the shutdown loop (test injection only). */
@@ -449,8 +451,13 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
     `[mcpd] Idle timer started ${Math.round(performance.now())}ms after process start (timeout=${idleTimeoutMs}ms)`,
   );
 
-  // Signal readiness to parent (IPC socket is open, commands can connect now)
-  console.log(DAEMON_READY_SIGNAL);
+  // Signal readiness to parent (IPC socket is open, commands can connect now).
+  // Uses console.log (stdout) because installDaemonLogCapture redirects
+  // console.info/error/warn to stderr — the parent process reads stdout.
+  // Tests pass skipReadySignal to suppress this output.
+  if (!opts?.skipReadySignal) {
+    console.log(DAEMON_READY_SIGNAL);
+  }
 
   // Boot virtual servers in the background — commands that need them will await
   if (!skipVirtualServers) {

--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -69,11 +69,10 @@ const TIMING_EXCLUSIONS: Record<string, string> = {
  * Matches daemon log prefixes ([mcpd], [_claude], [_aliases]) and
  * production signals (MCPD_READY). Ratchet this down toward zero.
  *
- * Current sources (14 total):
- *   13 × MCPD_READY — index.spec.ts spawns real daemon processes
+ * Current sources (1 total):
  *    1 × [mcpd] test message — daemon-log.spec.ts intentionally tests capture
  */
-const NOISE_THRESHOLD = 21;
+const NOISE_THRESHOLD = 1;
 
 /** Per-file minimum coverage — every file must meet this unless excluded */
 const PER_FILE_MIN_LINES = 80;


### PR DESCRIPTION
## Summary
- Add `skipReadySignal` option to `startDaemon()` so tests suppress the 13 `MCPD_READY` stdout lines that leaked into test output
- Pass `skipReadySignal: true` in `startTestDaemonInProcess()` helper
- Ratchet `NOISE_THRESHOLD` from 21 down to 1 (the single remaining line is the intentional `[mcpd] test message` from daemon-log.spec.ts capture test)

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — all 3764 tests pass
- [x] `bun scripts/check-coverage.ts` — noise count is 1 (≤ threshold 1), all coverage thresholds met
- [x] Verified `MCPD_READY` no longer appears in `bun test packages/daemon/src/index.spec.ts` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)