### PR TITLE
feat(core): scope detection — walk-up cwd matching against registered roots (fixes #1010)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,3 +23,4 @@ export * from "./claude-plan-adapter";
 export * from "./python-repr";
 export * from "./agent-tools";
 export * from "./config-file";
+export * from "./scope";

--- a/packages/core/src/scope.spec.ts
+++ b/packages/core/src/scope.spec.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detectScope } from "./scope";
+
+describe("detectScope", () => {
+  let tmp: string;
+  let scopesDir: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "scope-test-"));
+    scopesDir = join(tmp, "scopes");
+    mkdirSync(scopesDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  function writeScope(name: string, root: string): void {
+    writeFileSync(join(scopesDir, `${name}.json`), JSON.stringify({ root, created: new Date().toISOString() }));
+  }
+
+  test("detects scope from exact root directory", () => {
+    const root = join(tmp, "project");
+    mkdirSync(root, { recursive: true });
+    writeScope("myproject", root);
+
+    const result = detectScope(root, { scopesDir });
+    expect(result).toEqual({ name: "myproject", root });
+  });
+
+  test("detects scope from subdirectory", () => {
+    const root = join(tmp, "project");
+    const sub = join(root, "src", "lib");
+    mkdirSync(sub, { recursive: true });
+    writeScope("myproject", root);
+
+    const result = detectScope(sub, { scopesDir });
+    expect(result).toEqual({ name: "myproject", root });
+  });
+
+  test("detects scope from worktree under root", () => {
+    const root = join(tmp, "project");
+    const worktree = join(root, ".claude", "worktrees", "feat-123");
+    mkdirSync(worktree, { recursive: true });
+    writeScope("myproject", root);
+
+    const result = detectScope(worktree, { scopesDir });
+    expect(result).toEqual({ name: "myproject", root });
+  });
+
+  test("returns most specific scope when nested", () => {
+    const outer = join(tmp, "workspace");
+    const inner = join(outer, "packages", "core");
+    mkdirSync(inner, { recursive: true });
+    writeScope("workspace", outer);
+    writeScope("core", inner);
+
+    const result = detectScope(join(inner, "src"), { scopesDir });
+    expect(result).toEqual({ name: "core", root: inner });
+  });
+
+  test("returns null when unscoped", () => {
+    const unrelated = join(tmp, "elsewhere");
+    mkdirSync(unrelated, { recursive: true });
+    writeScope("myproject", join(tmp, "project"));
+
+    const result = detectScope(unrelated, { scopesDir });
+    expect(result).toBeNull();
+  });
+
+  test("returns null when scopes directory does not exist", () => {
+    const result = detectScope("/tmp", { scopesDir: join(tmp, "nonexistent") });
+    expect(result).toBeNull();
+  });
+
+  test("skips malformed scope files", () => {
+    const root = join(tmp, "project");
+    mkdirSync(root, { recursive: true });
+    writeScope("good", root);
+    writeFileSync(join(scopesDir, "bad.json"), "not json");
+
+    const result = detectScope(root, { scopesDir });
+    expect(result).toEqual({ name: "good", root });
+  });
+
+  test("ignores non-json files in scopes directory", () => {
+    const root = join(tmp, "project");
+    mkdirSync(root, { recursive: true });
+    writeScope("myproject", root);
+    writeFileSync(join(scopesDir, "README.md"), "# Scopes");
+
+    const result = detectScope(root, { scopesDir });
+    expect(result).toEqual({ name: "myproject", root });
+  });
+});

--- a/packages/core/src/scope.ts
+++ b/packages/core/src/scope.ts
@@ -1,0 +1,50 @@
+/**
+ * Scope detection — walk up from cwd and match against registered scope roots.
+ */
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { options } from "./constants";
+
+export interface ScopeMatch {
+  name: string;
+  root: string;
+}
+
+export interface DetectScopeDeps {
+  scopesDir?: string;
+}
+
+/**
+ * Detect the current scope by matching `cwd` against registered scope roots.
+ *
+ * Reads all `~/.mcp-cli/scopes/*.json` files and returns the most specific
+ * match (longest root prefix), or `null` if no scope matches.
+ */
+export function detectScope(cwd?: string, deps: DetectScopeDeps = {}): ScopeMatch | null {
+  const dir = resolve(cwd ?? process.cwd());
+  const scopesDir = deps.scopesDir ?? options.SCOPES_DIR;
+
+  if (!existsSync(scopesDir)) return null;
+
+  let best: ScopeMatch | null = null;
+  let bestLen = -1;
+
+  const entries = readdirSync(scopesDir).filter((f) => f.endsWith(".json"));
+  for (const entry of entries) {
+    const name = entry.replace(/\.json$/, "");
+    const filePath = `${scopesDir}/${entry}`;
+    try {
+      const data = JSON.parse(readFileSync(filePath, "utf-8")) as { root: string };
+      const root = resolve(data.root);
+      if ((dir === root || dir.startsWith(`${root}/`)) && root.length > bestLen) {
+        best = { name, root };
+        bestLen = root.length;
+      }
+    } catch {
+      // Skip malformed scope files
+    }
+  }
+
+  return best;
+}


### PR DESCRIPTION
## Summary
- Add `detectScope(cwd?, deps?)` function in `packages/core/src/scope.ts` that reads `~/.mcp-cli/scopes/*.json` files and returns the most specific scope match (longest root prefix) for the given directory
- Supports dependency injection for `scopesDir` to enable testability without touching real filesystem state
- Exported from `@mcp-cli/core` barrel

## Test plan
- [x] Detects scope from exact root directory
- [x] Detects scope from subdirectory
- [x] Detects scope from worktree under root
- [x] Returns most specific scope when nested (longest prefix wins)
- [x] Returns null when unscoped
- [x] Returns null when scopes directory doesn't exist
- [x] Skips malformed scope files gracefully
- [x] Ignores non-JSON files in scopes directory
- [x] All 8 unit tests pass, full suite (3792 tests) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)