### PR TITLE
feat(daemon): config loader parent matching for worktrees (fixes #1012)

### DIFF
--- a/packages/daemon/src/config/loader.spec.ts
+++ b/packages/daemon/src/config/loader.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import type { McpConfigFile, ResolvedConfig, ServerConfig } from "@mcp-cli/core";
-import { projectConfigPath, silentLogger } from "@mcp-cli/core";
+import { options, projectConfigPath, silentLogger } from "@mcp-cli/core";
 import { testOptions } from "../../../../test/test-options";
 import { loadConfig } from "./loader";
 
@@ -230,5 +230,59 @@ describe("loadConfig", () => {
     const projectSource = config.sources.find((s) => s.scope === "project");
     expect(projectSource).toBeDefined();
     expect(projectSource?.file).toBe(configPath);
+  });
+
+  test("worktree under a scope root loads the root's project config", async () => {
+    using opts = testOptions();
+
+    // Register a scope root
+    const root = join(opts.dir, "myproject");
+    mkdirSync(root, { recursive: true });
+    const scopesDir = options.SCOPES_DIR;
+    mkdirSync(scopesDir, { recursive: true });
+    writeJson(join(scopesDir, "myproject.json"), { root, created: new Date().toISOString() });
+
+    // Write config for the scope root
+    writeJson(projectConfigPath(root), fixtureConfig("filesystem"));
+
+    // Load config from a worktree path under the root
+    const worktree = join(root, ".claude", "worktrees", "claude-abc123");
+    mkdirSync(worktree, { recursive: true });
+
+    const config = await loadConfig(worktree, silentLogger);
+    expect(config.servers.has("filesystem")).toBe(true);
+    const source = config.servers.get("filesystem")?.source;
+    expect(source?.file).toBe(projectConfigPath(root));
+  });
+
+  test("subdirectory under a scope root loads the root's project config", async () => {
+    using opts = testOptions();
+
+    const root = join(opts.dir, "myproject");
+    mkdirSync(root, { recursive: true });
+    const scopesDir = options.SCOPES_DIR;
+    mkdirSync(scopesDir, { recursive: true });
+    writeJson(join(scopesDir, "myproject.json"), { root, created: new Date().toISOString() });
+
+    writeJson(projectConfigPath(root), fixtureConfig("notion"));
+
+    const subdir = join(root, "src", "lib");
+    mkdirSync(subdir, { recursive: true });
+
+    const config = await loadConfig(subdir, silentLogger);
+    expect(config.servers.has("notion")).toBe(true);
+  });
+
+  test("unscoped directory uses exact cwd for config lookup", async () => {
+    using opts = testOptions();
+
+    // No scope registered — should use exact cwd
+    const cwd = join(opts.dir, "unscoped-project");
+    mkdirSync(cwd, { recursive: true });
+
+    writeJson(projectConfigPath(cwd), fixtureConfig("sentry"));
+
+    const config = await loadConfig(cwd, silentLogger);
+    expect(config.servers.has("sentry")).toBe(true);
   });
 });

--- a/packages/daemon/src/config/loader.ts
+++ b/packages/daemon/src/config/loader.ts
@@ -20,7 +20,8 @@ import type {
   ServerConfigMap,
 } from "@mcp-cli/core";
 import type { Logger } from "@mcp-cli/core";
-import { consoleLogger, expandEnvVarsDeep, options, projectConfigPath } from "@mcp-cli/core";
+import { consoleLogger, detectScope, expandEnvVarsDeep, options, projectConfigPath } from "@mcp-cli/core";
+import type { DetectScopeDeps } from "@mcp-cli/core";
 
 /**
  * Load and merge all config sources for the given working directory.
@@ -29,12 +30,21 @@ import { consoleLogger, expandEnvVarsDeep, options, projectConfigPath } from "@m
  *   1. ~/.mcp-cli/projects/{mangled-cwd}/servers.json (project-scoped, lower priority)
  *   2. ~/.mcp-cli/servers.json (global, highest priority)
  */
-export async function loadConfig(cwd = process.cwd(), logger: Logger = consoleLogger): Promise<ResolvedConfig> {
+export async function loadConfig(
+  cwd = process.cwd(),
+  logger: Logger = consoleLogger,
+  scopeDeps?: DetectScopeDeps,
+): Promise<ResolvedConfig> {
   const servers = new Map<string, ResolvedServer>();
   const sources: ConfigSource[] = [];
 
+  // Resolve scope: worktrees and subdirectories inherit the nearest scope root's config.
+  // Falls back to exact cwd when no scope matches.
+  const scope = detectScope(cwd, scopeDeps);
+  const configCwd = scope?.root ?? cwd;
+
   // Priority 2 (lower): project-scoped config
-  const projectPath = projectConfigPath(cwd);
+  const projectPath = projectConfigPath(configCwd);
   if (existsSync(projectPath)) {
     const projectConfig = await readJsonFile<McpConfigFile>(projectPath, logger);
     if (projectConfig?.mcpServers) {


### PR DESCRIPTION
## Summary
- `loadConfig()` now calls `detectScope(cwd)` to find the nearest registered scope root before resolving project config paths
- Worktrees and subdirectories under a scope root inherit the root's project config instead of getting no config (mangled path mismatch)
- Unscoped directories fall back to exact cwd matching (backward compatible)
- Includes `detectScope()` in `@mcp-cli/core` (dependency from #1010)

## Test plan
- [x] Worktree under scope root loads the root's project config
- [x] Subdirectory under scope root loads the root's project config
- [x] Unscoped directory uses exact cwd (backward compatible)
- [x] Scope detection: exact match, subdirectory, worktree, nested scopes, malformed files, missing dir
- [x] All existing loader tests still pass
- [x] Typecheck, lint, full test suite (3794 tests), coverage all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)