### PR TITLE
fix(daemon): treat total_cost_usd and num_turns as cumulative values (fixes #1028)

### DIFF
--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -137,6 +137,8 @@ export class ClaudeServer {
   private readonly sessionPidStartTimes = new Map<string, number>();
   /** Timestamp (ms) when each session was added to activeSessions — used to TTL pid-less zombies. */
   private readonly sessionAddedAt = new Map<string, number>();
+  /** Last known cumulative cost per session — used to compute delta for metrics counter. */
+  private readonly sessionLastCost = new Map<string, number>();
   private restartInProgress = false;
   private pendingCrashReason: string | null = null;
   private stopped = false;
@@ -395,6 +397,7 @@ export class ClaudeServer {
     this.sessionPids.clear();
     this.sessionPidStartTimes.clear();
     this.sessionAddedAt.clear();
+    this.sessionLastCost.clear();
     if (this.crashTimestamps.length > 0) {
       this.logger.error(`[claude-server] Cleared ${this.crashTimestamps.length} crash timestamp(s) on stop`);
     }
@@ -440,6 +443,7 @@ export class ClaudeServer {
       this.sessionPids.delete(sessionId);
       this.sessionPidStartTimes.delete(sessionId);
       this.sessionAddedAt.delete(sessionId);
+      this.sessionLastCost.delete(sessionId);
       this.db.endSession(sessionId);
       this.metrics.gauge("mcpd_active_sessions").set(this.activeSessions.size);
       this.logger.warn(`[claude-server] Pruned dead session ${sessionId} (pid ${pid} no longer alive)`);
@@ -451,6 +455,7 @@ export class ClaudeServer {
         this.activeSessions.delete(sessionId);
         this.sessionPids.delete(sessionId);
         this.sessionAddedAt.delete(sessionId);
+        this.sessionLastCost.delete(sessionId);
         this.db.endSession(sessionId);
         this.metrics.gauge("mcpd_active_sessions").set(this.activeSessions.size);
         this.logger.warn(`[claude-server] Pruned dead session ${sessionId} (pid ${pid} no longer alive)`);
@@ -530,6 +535,7 @@ export class ClaudeServer {
     this.activeSessions.clear();
     this.sessionPids.clear();
     this.sessionAddedAt.clear();
+    this.sessionLastCost.clear();
     this.metrics.gauge("mcpd_active_sessions").set(0);
 
     // Close MCP client to reject pending promises (matches stop() pattern)
@@ -561,6 +567,7 @@ export class ClaudeServer {
       this.sessionPids.clear();
       this.sessionPidStartTimes.clear();
       this.sessionAddedAt.clear();
+      this.sessionLastCost.clear();
       this.metrics.gauge("mcpd_active_sessions").set(0);
       this.metrics.gauge("mcpd_worker_crash_loop_stopped").set(1);
       return;
@@ -600,6 +607,7 @@ export class ClaudeServer {
               this.sessionPids.delete(sessionId);
               this.sessionPidStartTimes.delete(sessionId);
               this.sessionAddedAt.delete(sessionId);
+              this.sessionLastCost.delete(sessionId);
               this.db.endSession(sessionId);
             }
           }
@@ -623,6 +631,7 @@ export class ClaudeServer {
       this.sessionPids.clear();
       this.sessionPidStartTimes.clear();
       this.sessionAddedAt.clear();
+      this.sessionLastCost.clear();
       this.metrics.gauge("mcpd_active_sessions").set(0);
     } finally {
       this.restartInProgress = false;
@@ -677,12 +686,17 @@ export class ClaudeServer {
         this.db.updateSessionState(event.sessionId, event.state);
         this.onActivity?.();
         break;
-      case "db:cost":
+      case "db:cost": {
         this.sessionAddedAt.set(event.sessionId, Date.now());
         this.db.updateSessionCost(event.sessionId, event.cost, event.tokens);
-        this.metrics.counter("mcpd_session_cost_usd").inc(event.cost);
+        // event.cost is cumulative — compute delta for the metrics counter
+        const prevCost = this.sessionLastCost.get(event.sessionId) ?? 0;
+        const costDelta = event.cost - prevCost;
+        if (costDelta > 0) this.metrics.counter("mcpd_session_cost_usd").inc(costDelta);
+        this.sessionLastCost.set(event.sessionId, event.cost);
         this.onActivity?.();
         break;
+      }
       case "db:disconnected":
         // Session lost transport but was NOT bye'd — keep in activeSessions
         this.logger.warn(`[claude-server] Session ${event.sessionId} disconnected: ${event.reason}`);
@@ -693,6 +707,7 @@ export class ClaudeServer {
         this.sessionPids.delete(event.sessionId);
         this.sessionPidStartTimes.delete(event.sessionId);
         this.sessionAddedAt.delete(event.sessionId);
+        this.sessionLastCost.delete(event.sessionId);
         this.db.endSession(event.sessionId);
         this.metrics.gauge("mcpd_active_sessions").set(this.activeSessions.size);
         break;

--- a/packages/daemon/src/claude-session/session-state.spec.ts
+++ b/packages/daemon/src/claude-session/session-state.spec.ts
@@ -207,18 +207,21 @@ describe("SessionState", () => {
   // -- result --
 
   describe("result messages", () => {
-    test("success transitions to idle and accumulates cost", () => {
+    test("success transitions to idle and sets cumulative cost", () => {
       const session = activeSession();
       const events = session.handleMessage(RESULT_SUCCESS);
 
       expect(session.state).toBe("idle");
       expect(session.cost).toBe(0.05);
       expect(session.numTurns).toBe(3);
+      // tokens = 150 from the assistant message; result usage is NOT added
+      // (assistant messages already accumulate per-message tokens)
+      expect(session.tokens).toBe(150);
       expect(events).toEqual([
         {
           type: "session:result",
           cost: 0.05,
-          tokens: 300,
+          tokens: 150,
           numTurns: 3,
           result: "Done!",
         },
@@ -240,17 +243,22 @@ describe("SessionState", () => {
       ]);
     });
 
-    test("accumulates cost across multiple turns", () => {
+    test("sets cumulative cost from SDK (not additive)", () => {
       const session = activeSession();
-      session.handleMessage(RESULT_SUCCESS);
+      session.handleMessage(RESULT_SUCCESS); // total_cost_usd=0.05, num_turns=3
 
-      // Start a new turn
+      // Start a new turn — SDK sends higher cumulative values
       session.queuePrompt("Next task");
       session.handleMessage(ASSISTANT_MSG);
-      session.handleMessage(RESULT_SUCCESS);
+      session.handleMessage({
+        ...RESULT_SUCCESS,
+        total_cost_usd: 0.1,
+        num_turns: 7,
+      });
 
+      // Cost/turns are SET to the cumulative value, not added
       expect(session.cost).toBe(0.1);
-      expect(session.numTurns).toBe(6);
+      expect(session.numTurns).toBe(7);
     });
   });
 
@@ -555,9 +563,15 @@ describe("SessionState", () => {
       session.queuePrompt("Now fix the bug");
       expect(session.state).toBe("active");
 
-      // 9. Quick response + result
+      // 9. Quick response + result (SDK sends higher cumulative values)
       allEvents.push(...session.handleMessage(ASSISTANT_MSG));
-      allEvents.push(...session.handleMessage(RESULT_SUCCESS));
+      allEvents.push(
+        ...session.handleMessage({
+          ...RESULT_SUCCESS,
+          total_cost_usd: 0.1,
+          num_turns: 7,
+        }),
+      );
       expect(session.state).toBe("idle");
 
       // 10. End
@@ -582,9 +596,9 @@ describe("SessionState", () => {
         "session:ended",
       ]);
 
-      // Verify accumulated stats
+      // Verify cumulative stats (set from SDK, not additive)
       expect(session.cost).toBe(0.1);
-      expect(session.numTurns).toBe(6);
+      expect(session.numTurns).toBe(7);
     });
   });
 
@@ -612,7 +626,8 @@ describe("SessionState", () => {
       if (events[0].type === "session:result") {
         expect(events[0].cost).toBe(0.03);
         expect(events[0].numTurns).toBe(2);
-        expect(events[0].tokens).toBe(225);
+        // tokens = 150 from the assistant message only (result usage not added)
+        expect(events[0].tokens).toBe(150);
       }
     });
 
@@ -635,10 +650,11 @@ describe("SessionState", () => {
       expect(events).toHaveLength(1);
       expect(events[0].type).toBe("session:result");
       if (events[0].type === "session:result") {
-        // Fallback defaults for missing fields
+        // Fallback defaults for missing fields — cost/turns stay at 0 (no SDK data)
+        // tokens = 150 from the assistant message (cumulative)
         expect(events[0].cost).toBe(0);
         expect(events[0].numTurns).toBe(0);
-        expect(events[0].tokens).toBe(0);
+        expect(events[0].tokens).toBe(150);
         expect(events[0].result).toBe("All done");
       }
     });
@@ -678,7 +694,8 @@ describe("SessionState", () => {
       if (events[0].type === "session:result") {
         expect(events[0].cost).toBe(0.05);
         expect(events[0].numTurns).toBe(3);
-        expect(events[0].tokens).toBe(300);
+        // tokens = 150 from assistant message only (result usage not added)
+        expect(events[0].tokens).toBe(150);
       }
     });
 

--- a/packages/daemon/src/claude-session/session-state.ts
+++ b/packages/daemon/src/claude-session/session-state.ts
@@ -282,18 +282,18 @@ export class SessionState {
     const successResult = ResultSuccess.safeParse(msg);
     if (successResult.success) {
       const r = successResult.data;
-      const resultTokens = r.usage.input_tokens + r.usage.output_tokens;
-      this.cost += r.total_cost_usd;
-      this.numTurns += r.num_turns;
-      this.tokens += resultTokens;
+      this.cost = r.total_cost_usd;
+      this.numTurns = r.num_turns;
+      // Don't add result usage to tokens — assistant messages already accumulate
+      // per-message usage throughout the turn. Result usage would double-count.
       this.state = "idle";
       this.rateLimited = false;
       return [
         {
           type: "session:result",
-          cost: r.total_cost_usd,
-          tokens: resultTokens,
-          numTurns: r.num_turns,
+          cost: this.cost,
+          tokens: this.tokens,
+          numTurns: this.numTurns,
           result: r.result,
         },
       ];
@@ -302,10 +302,10 @@ export class SessionState {
     const errorResult = ResultError.safeParse(msg);
     if (errorResult.success) {
       const r = errorResult.data;
-      this.cost += r.total_cost_usd;
-      this.numTurns += r.num_turns;
+      this.cost = r.total_cost_usd;
+      this.numTurns = r.num_turns;
       this.state = "idle";
-      return [{ type: "session:error", errors: r.errors, cost: r.total_cost_usd }];
+      return [{ type: "session:error", errors: r.errors, cost: this.cost }];
     }
 
     // Fallback: transition to idle for any result message, even if neither
@@ -315,24 +315,23 @@ export class SessionState {
     if (fallback.success) {
       this.parseMismatch = true;
       const r = fallback.data;
-      const cost = r.total_cost_usd ?? 0;
-      const turns = r.num_turns ?? 0;
-      const resultTokens = r.usage ? r.usage.input_tokens + r.usage.output_tokens : 0;
-      this.cost += cost;
-      this.numTurns += turns;
-      this.tokens += resultTokens;
+      // total_cost_usd and num_turns are cumulative — assign, don't add.
+      // Only fall back to += when the field is missing (0), since we can't
+      // tell if 0 means "zero cost" or "field absent".
+      if (r.total_cost_usd != null) this.cost = r.total_cost_usd;
+      if (r.num_turns != null) this.numTurns = r.num_turns;
       this.state = "idle";
 
       const errors = r.errors;
       if (r.subtype !== "success" && Array.isArray(errors) && errors.length > 0) {
-        return [{ type: "session:error", errors, cost }];
+        return [{ type: "session:error", errors, cost: this.cost }];
       }
       return [
         {
           type: "session:result",
-          cost,
-          tokens: resultTokens,
-          numTurns: turns,
+          cost: this.cost,
+          tokens: this.tokens,
+          numTurns: this.numTurns,
           result: r.result ?? "",
         },
       ];


### PR DESCRIPTION
## Summary
- **Root cause**: Claude SDK sends cumulative `total_cost_usd` and `num_turns` in result messages, but `SessionState` was adding them with `+=`, causing triangular number growth (e.g. $6994 for a normal session)
- Changed `session-state.ts` to use `=` instead of `+=` for cost and numTurns; stopped double-counting result usage tokens (assistant messages already accumulate per-message tokens)
- Emit cumulative values in `session:result`/`session:error` events; compute cost delta in `claude-server.ts` for the metrics counter

## Test plan
- [x] `session-state.spec.ts` — 55 tests pass, 100% line coverage on session-state.ts
- [x] `ws-server.spec.ts` — 131 tests pass
- [x] `claude-server.spec.ts` — 67 tests pass
- [x] Full daemon test suite — 1080 tests pass
- [x] Typecheck and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)