### PR TITLE
feat(command): server-name-aware fallthrough for mcx <server> shorthand (fixes #1072)

### DIFF
--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -331,9 +331,22 @@ async function main(): Promise<void> {
           break;
         }
 
-        // Check if it looks like "mcx server tool" (missing "call")
+        // Check if subcommand matches a configured server name (case-insensitive).
+        // This handles "mcx grafana get_dashboard ..." → "mcx call grafana get_dashboard ..."
+        // Only check when daemon is already running to avoid 5s startup delay on typos.
+        if (!command.startsWith("-") && (await isDaemonRunning())) {
+          const servers: ServerStatus[] = await ipcCall("listServers");
+          const match = servers.find((s) => s.name.toLowerCase() === command.toLowerCase());
+          if (match) {
+            // Use the exact server name from config (handles case mismatch)
+            await cmdCall([match.name, ...cleanArgs.slice(1)]);
+            break;
+          }
+        }
+
+        // Fallback: if it looks like "mcx <word> <word> ..." (two non-flag args),
+        // try as call shorthand even if the daemon isn't running yet (auto-starts it).
         if (!command.startsWith("-") && cleanArgs.length >= 2 && !cleanArgs[1].startsWith("-")) {
-          // Treat as shorthand: mcx <server> <tool> [args]
           await cmdCall(cleanArgs);
           break;
         }


### PR DESCRIPTION
## Summary
- When daemon is running, check if the subcommand matches a configured server name (case-insensitive) before treating it as a call shorthand
- Uses exact server name from config for the IPC call (handles case mismatches like `mcx Coralogix` → server `coralogix`)
- Keeps the existing broad 2-arg shorthand as fallback when daemon isn't running

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (all tests, segfault is known Bun bug #1004)
- [ ] Manual: `mcx <server-name> <tool> <args>` routes correctly when daemon is running
- [ ] Manual: `mcx <Server-Name> <tool>` with case mismatch uses correct server name
- [ ] Manual: `mcx <unknown> <tool>` falls through to existing shorthand behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)