### PR TITLE
fix(command): expand ~ in @file paths (fixes #1062)

### DIFF
--- a/packages/command/src/file-read.spec.ts
+++ b/packages/command/src/file-read.spec.ts
@@ -1,6 +1,7 @@
 import { afterAll, describe, expect, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { homedir } from "node:os";
+import { join, relative } from "node:path";
 import { readFileWithLimit } from "./file-read";
 
 const TMP = join(import.meta.dir, "__tmp_file_read_test__");
@@ -29,5 +30,12 @@ describe("readFileWithLimit", () => {
 
   test("throws on non-existent files", () => {
     expect(() => readFileWithLimit(join(TMP, "nope.txt"))).toThrow();
+  });
+
+  test("expands ~ to home directory", () => {
+    const p = join(TMP, "tilde-test.json");
+    writeFileSync(p, '{"tilde":true}');
+    const relFromHome = relative(homedir(), p);
+    expect(readFileWithLimit(`~/${relFromHome}`)).toBe('{"tilde":true}');
   });
 });

--- a/packages/command/src/file-read.ts
+++ b/packages/command/src/file-read.ts
@@ -6,6 +6,8 @@
  */
 
 import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 
@@ -14,9 +16,10 @@ const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
  * Throws if the file exceeds MAX_FILE_SIZE or doesn't exist.
  */
 export function readFileWithLimit(path: string): string {
-  const file = Bun.file(path);
+  const resolved = path.startsWith("~/") ? join(homedir(), path.slice(2)) : path;
+  const file = Bun.file(resolved);
   if (file.size > MAX_FILE_SIZE) {
-    throw new Error(`File "${path}" is ${(file.size / 1024 / 1024).toFixed(1)}MB — exceeds 10MB limit`);
+    throw new Error(`File "${resolved}" is ${(file.size / 1024 / 1024).toFixed(1)}MB — exceeds 10MB limit`);
   }
-  return readFileSync(path, "utf-8");
+  return readFileSync(resolved, "utf-8");
 }


### PR DESCRIPTION
## Summary
- `readFileWithLimit` now expands `~/` to the user's home directory before reading
- Fixes ENOENT errors when using `@~/...` paths in `mcx call` and `mcx alias save`
- Single-location fix covers both call sites

## Test plan
- [x] New test: tilde path resolves to home directory and reads file correctly
- [x] Existing tests pass (normal read, size limit, missing file)
- [x] `bun typecheck` — pass
- [x] `bun lint` — pass
- [x] `bun test` — 3844 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)