### PR TITLE
feat(command): show quota warning banner in mcx claude ls (fixes #1064)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -12,6 +12,7 @@ import {
   cmdClaude,
   defaultGetPrStatus,
   extractIssueNumber,
+  formatQuotaBanner,
   parseDiffShortstat,
   parseLogArgs,
   parseResumeArgs,
@@ -3611,5 +3612,60 @@ describe("cmdClaude resume", () => {
     const promptArgs = promptCall?.[1] as Record<string, unknown>;
     expect(promptArgs.wait).toBe(true);
     expect(promptArgs.timeout).toBe(30000);
+  });
+});
+// ── formatQuotaBanner ──
+
+describe("formatQuotaBanner", () => {
+  const makeQuota = (utilization: number, resetsAt = "2026-04-08T20:00:00Z") => ({
+    fiveHour: { utilization, resetsAt },
+    sevenDay: null,
+    sevenDaySonnet: null,
+    sevenDayOpus: null,
+    extraUsage: null,
+    fetchedAt: Date.now(),
+    lastError: null,
+  });
+
+  test("returns null when quota is null", () => {
+    expect(formatQuotaBanner(null)).toBeNull();
+  });
+
+  test("returns null when fetchedAt is 0", () => {
+    expect(formatQuotaBanner({ ...makeQuota(90), fetchedAt: 0 })).toBeNull();
+  });
+
+  test("returns null when fiveHour is null", () => {
+    expect(formatQuotaBanner({ ...makeQuota(90), fiveHour: null })).toBeNull();
+  });
+
+  test("returns null at 80% (threshold is >80)", () => {
+    expect(formatQuotaBanner(makeQuota(80))).toBeNull();
+  });
+
+  test("returns warning at 81%", () => {
+    const banner = formatQuotaBanner(makeQuota(81));
+    expect(banner).toContain("81%");
+    expect(banner).toContain("stop spawning new sessions");
+  });
+
+  test("returns critical at 95%", () => {
+    const banner = formatQuotaBanner(makeQuota(95));
+    expect(banner).toContain("95%");
+    expect(banner).toContain("pause all spawning");
+    expect(banner).toContain("CRITICAL");
+  });
+
+  test("returns critical at 100%", () => {
+    const banner = formatQuotaBanner(makeQuota(100));
+    expect(banner).toContain("CRITICAL");
+  });
+
+  test("warning tier does not say CRITICAL", () => {
+    const banner = formatQuotaBanner(makeQuota(87));
+    expect(banner).not.toBeNull();
+    expect(banner).not.toContain("CRITICAL");
+    expect(banner).toContain("87%");
+    expect(banner).toContain("resets");
   });
 });

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -29,7 +29,7 @@ import type { SharedSpawnArgs } from "./spawn-args";
 import { parseSharedSpawnArgs } from "./spawn-args";
 import { ttyOpen } from "./tty";
 
-import type { SessionInfo } from "@mcp-cli/core";
+import type { QuotaStatusResult, SessionInfo } from "@mcp-cli/core";
 
 // ── Dependency injection ──
 
@@ -687,6 +687,26 @@ async function resumeWorktree(
   console.log(formatToolResult(result));
 }
 
+/**
+ * Format a quota warning banner when 5-hour utilization exceeds 80%.
+ * Returns null if no warning needed.
+ */
+export function formatQuotaBanner(quota: QuotaStatusResult | null): string | null {
+  if (!quota || !quota.fiveHour || quota.fetchedAt === 0) return null;
+  const util = quota.fiveHour.utilization;
+  if (util <= 80) return null;
+
+  const reset = new Date(quota.fiveHour.resetsAt).toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+
+  if (util >= 95) {
+    return `🔴 Quota CRITICAL: 5h window at ${util}% (resets ${reset}) — pause all spawning`;
+  }
+  return `⚠  Quota: 5h window at ${util}% (resets ${reset}) — stop spawning new sessions`;
+}
+
 async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
   const { json } = extractJsonFlag(args);
   const short = args.includes("--short");
@@ -721,12 +741,23 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
     return;
   }
 
+  // Fetch quota status (non-blocking — don't fail ls if quota unavailable)
+  let quotaBanner: string | null = null;
+  try {
+    const quota = await ipcCall("quotaStatus", undefined, { timeoutMs: 2000 });
+    quotaBanner = formatQuotaBanner(quota);
+  } catch {
+    // Quota monitoring unavailable — continue without banner
+  }
+
   if (sessions.length === 0) {
+    if (quotaBanner) console.error(quotaBanner);
     console.error("No active sessions.");
     return;
   }
 
   if (short) {
+    if (quotaBanner) console.error(quotaBanner);
     for (const s of sessions) {
       console.log(formatSessionShort(s));
     }
@@ -743,6 +774,9 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
 
   const hasAnyDiff = diffStats.some((stat) => stat !== null);
   const hasAnyPr = showPr && prStatuses.some((pr) => pr !== null);
+
+  // Quota warning banner (stderr, before table)
+  if (quotaBanner) console.error(quotaBanner);
 
   // Table output
   const diffHeader = hasAnyDiff ? ` ${"DIFF".padEnd(16)}` : "";


### PR DESCRIPTION
## Summary
- Adds a quota warning banner to `mcx claude ls` output when 5-hour utilization exceeds 80%
- Warning tier (⚠ at >80%) and critical tier (🔴 at ≥95%) with appropriate messaging
- Banner prints to stderr so it doesn't interfere with `--json` output; shows in all output modes (table, `--short`, empty session list)

## Test plan
- [x] `formatQuotaBanner` returns null for null/missing/below-threshold quota
- [x] Returns warning text at 81% (>80 threshold, not ≥80)
- [x] Returns critical text at 95% and 100%
- [x] Warning tier does not include "CRITICAL" text
- [x] Banner includes reset time and utilization percentage
- [x] All 234 claude.spec.ts tests pass (8 new)
- [x] Full suite passes (3851 tests)
- [x] Typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)