### PR TITLE
fix(scripts): increase run-2 deadline from 120s to 300s (fixes #1078)

### DIFF
--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -225,8 +225,11 @@ const proc2 = Bun.spawn(["bun", "test", "--timeout", "60000", "packages/daemon/s
 });
 
 // Process-level deadline: if run-2 hangs (e.g. daemon teardown bug), kill it
-// after 120s rather than blocking pre-commit indefinitely.
-const RUN2_DEADLINE_MS = 120_000;
+// rather than blocking pre-commit indefinitely. 300s is generous enough for
+// the full daemon + integration test suite while still catching real hangs.
+// See #1078 — the previous 120s deadline was too aggressive and consistently
+// killed daemon tests that were still making progress.
+const RUN2_DEADLINE_MS = 300_000;
 const run2Deadline = setTimeout(() => {
   console.error(`\nERROR: run-2 (daemon tests) exceeded ${RUN2_DEADLINE_MS / 1000}s deadline — killing process`);
   proc2.kill();


### PR DESCRIPTION
## Summary
- Increases `RUN2_DEADLINE_MS` from 120s to 300s in `scripts/check-coverage.ts`
- The daemon + integration test suite routinely exceeds 120s (~166s on this machine), causing the pre-commit hook to kill the process and block all source-change commits
- 300s is generous enough for normal completion while still catching real hangs

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (3861 tests, 0 failures, ~166s)
- [x] Verified the deadline constant is now 300_000 on line 232

🤖 Generated with [Claude Code](https://claude.com/claude-code)