### PR TITLE
fix(ci): retry test steps on Bun segfault exit code 132 (fixes #1084)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,31 @@ jobs:
       # Split daemon tests into a separate invocation to avoid a non-deterministic
       # Bun v1.3.11 segfault that triggers when daemon worker-thread tests run in
       # the same process as all other tests. See #1004 for upstream tracking.
-      - run: bun test packages/acp packages/codex packages/command packages/control packages/core packages/opencode packages/permissions test/integration.spec.ts
-      - run: bun test packages/daemon test/cli-orchestration.spec.ts test/daemon-integration.spec.ts test/stress.spec.ts test/transport-errors.spec.ts
+      #
+      # Each test step retries once on exit code 132 (SIGILL) — the Bun segfault
+      # crashes after all tests pass, so a retry is safe. See #1084.
+      - name: Test (non-daemon)
+        run: |
+          set +e
+          bun test packages/acp packages/codex packages/command packages/control packages/core packages/opencode packages/permissions test/integration.spec.ts
+          code=$?
+          if [ $code -eq 132 ]; then
+            echo "::warning::Bun segfault (exit 132) after tests passed — retrying once (see #1004)"
+            bun test packages/acp packages/codex packages/command packages/control packages/core packages/opencode packages/permissions test/integration.spec.ts
+          else
+            exit $code
+          fi
+      - name: Test (daemon)
+        run: |
+          set +e
+          bun test packages/daemon test/cli-orchestration.spec.ts test/daemon-integration.spec.ts test/stress.spec.ts test/transport-errors.spec.ts
+          code=$?
+          if [ $code -eq 132 ]; then
+            echo "::warning::Bun segfault (exit 132) after tests passed — retrying once (see #1004)"
+            bun test packages/daemon test/cli-orchestration.spec.ts test/daemon-integration.spec.ts test/stress.spec.ts test/transport-errors.spec.ts
+          else
+            exit $code
+          fi
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Wraps both CI test steps with shell logic that detects Bun's SIGILL crash (exit code 132) and retries once
- Emits a `::warning::` annotation when a retry occurs so the segfault is visible in the Actions UI
- No application code changes — CI workflow only

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes  
- [x] `bun test` passes (3861 tests)
- [ ] Verify CI runs on this PR itself — if it segfaults, the retry logic should kick in

🤖 Generated with [Claude Code](https://claude.com/claude-code)