### PR TITLE
fix(command): strip --json flag in cmdCall to prevent @file arg corruption (fixes #1052)

### DIFF
--- a/packages/command/src/index.spec.ts
+++ b/packages/command/src/index.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { checkDeprecatedName } from "./deprecation";
-import { extractJsonFlag } from "./parse";
+import { extractFullFlag, extractJqFlag, extractJsonFlag, extractTimeoutFlag } from "./parse";
 
 describe("checkDeprecatedName", () => {
   let stderrOutput: string[] = [];
@@ -102,5 +102,41 @@ describe("extractJsonFlag", () => {
 
   test("extracts --json flag", () => {
     expect(extractJsonFlag(["atlassian", "--json"])).toEqual({ json: true, rest: ["atlassian"] });
+  });
+});
+
+describe("cmdCall flag extraction chain", () => {
+  // Simulates the flag extraction chain used by cmdCall in main.ts.
+  // Verifies that all known flags are stripped before positional arg parsing,
+  // preventing flags like --json from contaminating @file paths (#1052).
+  function extractCallFlags(args: string[]) {
+    const { full, rest: afterFull } = extractFullFlag(args);
+    const { jq: jqFilter, rest: afterJq } = extractJqFlag(afterFull);
+    const { timeoutMs, rest: afterTimeout } = extractTimeoutFlag(afterJq);
+    const { rest: afterJson } = extractJsonFlag(afterTimeout);
+    return { full, jqFilter, timeoutMs, rest: afterJson };
+  }
+
+  test("--json after @file does not contaminate positional args", () => {
+    const result = extractCallFlags(["server", "tool", "@/tmp/test.json", "--json"]);
+    expect(result.rest).toEqual(["server", "tool", "@/tmp/test.json"]);
+  });
+
+  test("--json before positional args is stripped cleanly", () => {
+    const result = extractCallFlags(["--json", "server", "tool", "@/tmp/test.json"]);
+    expect(result.rest).toEqual(["server", "tool", "@/tmp/test.json"]);
+  });
+
+  test("multiple flags with @file are all stripped", () => {
+    const result = extractCallFlags(["server", "tool", "@/tmp/data.json", "--json", "--full", "--timeout", "30"]);
+    expect(result.rest).toEqual(["server", "tool", "@/tmp/data.json"]);
+    expect(result.full).toBe(true);
+    expect(result.timeoutMs).toBe(30_000);
+  });
+
+  test("--jq and --json together do not leak into rest", () => {
+    const result = extractCallFlags(["server", "tool", "@/tmp/data.json", "--jq", ".foo", "--json"]);
+    expect(result.rest).toEqual(["server", "tool", "@/tmp/data.json"]);
+    expect(result.jqFilter).toBe(".foo");
   });
 });

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -421,14 +421,15 @@ async function cmdLs(args: string[]): Promise<void> {
 }
 
 async function cmdCall(args: string[]): Promise<void> {
-  // Extract --full/-f, --jq, and --timeout flags before parsing positional args
+  // Extract known flags before parsing positional args (prevents flags from contaminating @file paths)
   const { full, rest: afterFull } = extractFullFlag(args);
   const { jq: jqFilter, rest: afterJq } = extractJqFlag(afterFull);
   const { timeoutMs, rest: afterTimeout } = extractTimeoutFlag(afterJq);
+  const { rest: afterJson } = extractJsonFlag(afterTimeout);
 
   // Support slash notation: "server/tool" → ["server", "tool"]
-  const split = afterTimeout.length >= 1 ? splitServerTool(afterTimeout[0]) : null;
-  const resolved = split ? [...split, ...afterTimeout.slice(1)] : afterTimeout;
+  const split = afterJson.length >= 1 ? splitServerTool(afterJson[0]) : null;
+  const resolved = split ? [...split, ...afterJson.slice(1)] : afterJson;
 
   if (resolved.length < 2) {
     printError("Usage: mcx call <server> <tool> [json|@file] [--jq '<filter>'] [--full] [--timeout <seconds>]");


### PR DESCRIPTION
## Summary
- Add `extractJsonFlag()` to `cmdCall`'s flag extraction chain so `--json`/`-j` is stripped before positional arg parsing
- Prevents `--json` from being joined into `@file` paths (e.g. `@/tmp/test.json --json` → ENOENT)
- Bug 2 (Python repr output) was already fixed by #1080, verified in current code

## Test plan
- [x] Added 4 tests verifying the flag extraction chain strips `--json` alongside `@file` args
- [x] Tests cover: `--json` after `@file`, `--json` before positional args, multiple flags combined, `--jq` + `--json` together
- [x] All 3865 existing tests pass
- [x] Typecheck and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)