### PR TITLE
feat(serve): add ability to kill serve instances from CLI and TUI (fixes #1051)

### DIFF
--- a/packages/command/src/commands/serve-kill.spec.ts
+++ b/packages/command/src/commands/serve-kill.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import type { IpcMethod, IpcMethodResult } from "@mcp-cli/core";
+import { type ServeKillDeps, cmdServeKill } from "./serve-kill";
+
+function makeDeps(overrides?: Partial<ServeKillDeps>): ServeKillDeps & { logs: string[]; errors: string[] } {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  return {
+    logs,
+    errors,
+    ipcCall: overrides?.ipcCall ?? (async <M extends IpcMethod>() => ({ killed: 0 }) as IpcMethodResult[M]),
+    log: (msg) => logs.push(msg),
+    logError: (msg) => errors.push(msg),
+    ...overrides,
+  };
+}
+
+describe("cmdServeKill", () => {
+  test("prints help with --help", async () => {
+    const deps = makeDeps();
+    await cmdServeKill(["--help"], deps);
+    expect(deps.logs.join("\n")).toContain("mcx serve kill");
+  });
+
+  test("prints help when no args provided", async () => {
+    const deps = makeDeps();
+    await cmdServeKill([], deps);
+    expect(deps.errors.join("\n")).toContain("mcx serve kill");
+  });
+
+  test("kills by PID", async () => {
+    let calledWith: unknown;
+    const deps = makeDeps({
+      ipcCall: async <M extends IpcMethod>(_method: M, params?: unknown) => {
+        calledWith = params;
+        return { killed: 1 } as IpcMethodResult[M];
+      },
+    });
+    await cmdServeKill(["1234"], deps);
+    expect(calledWith).toEqual({ pid: 1234 });
+    expect(deps.errors[0]).toContain("Killed 1");
+  });
+
+  test("kills all with --all", async () => {
+    let calledWith: unknown;
+    const deps = makeDeps({
+      ipcCall: async <M extends IpcMethod>(_method: M, params?: unknown) => {
+        calledWith = params;
+        return { killed: 3 } as IpcMethodResult[M];
+      },
+    });
+    await cmdServeKill(["--all"], deps);
+    expect(calledWith).toEqual({ all: true });
+    expect(deps.errors[0]).toContain("Killed 3");
+  });
+
+  test("reports zero kills", async () => {
+    const deps = makeDeps({
+      ipcCall: async <M extends IpcMethod>() => ({ killed: 0 }) as IpcMethodResult[M],
+    });
+    await cmdServeKill(["--all"], deps);
+    expect(deps.errors[0]).toContain("No serve instances");
+  });
+
+  test("outputs JSON with --json", async () => {
+    const deps = makeDeps({
+      ipcCall: async <M extends IpcMethod>() => ({ killed: 2 }) as IpcMethodResult[M],
+    });
+    await cmdServeKill(["--all", "--json"], deps);
+    expect(JSON.parse(deps.logs[0])).toEqual({ killed: 2 });
+  });
+
+  test("rejects invalid PID", async () => {
+    const deps = makeDeps();
+    await cmdServeKill(["abc"], deps);
+    expect(deps.errors[0]).toContain("Invalid PID");
+  });
+});

--- a/packages/command/src/commands/serve-kill.ts
+++ b/packages/command/src/commands/serve-kill.ts
@@ -1,0 +1,73 @@
+/**
+ * `mcx serve kill` — kill running serve instances.
+ *
+ * Usage:
+ *   mcx serve kill <pid>       Kill a specific serve instance by PID
+ *   mcx serve kill --all       Kill all serve instances
+ */
+
+import type { IpcMethod, IpcMethodResult } from "@mcp-cli/core";
+import { ipcCall as defaultIpcCall } from "../daemon-lifecycle";
+import { c } from "../output";
+import { extractJsonFlag } from "../parse";
+
+export interface ServeKillDeps {
+  ipcCall: <M extends IpcMethod>(method: M, params?: unknown) => Promise<IpcMethodResult[M]>;
+  log: (msg: string) => void;
+  logError: (msg: string) => void;
+}
+
+const defaultDeps: ServeKillDeps = {
+  ipcCall: defaultIpcCall,
+  log: (msg) => console.log(msg),
+  logError: (msg) => console.error(msg),
+};
+
+function printHelp(log: (msg: string) => void): void {
+  log(`mcx serve kill — kill running serve instances
+
+Usage:
+  mcx serve kill <pid>       Kill a specific serve instance by PID
+  mcx serve kill --all       Kill all serve instances
+
+Flags:
+  --json, -j     Output as JSON
+  --help, -h     Show this help`);
+}
+
+export async function cmdServeKill(args: string[], deps?: Partial<ServeKillDeps>): Promise<void> {
+  const d: ServeKillDeps = { ...defaultDeps, ...deps };
+  const { json: isJson, rest } = extractJsonFlag(args);
+
+  if (rest.includes("--help") || rest.includes("-h")) {
+    printHelp(d.log);
+    return;
+  }
+
+  const killAll = rest.includes("--all");
+  const positional = rest.filter((a) => !a.startsWith("-"));
+  const pidArg = positional[0] ? Number(positional[0]) : undefined;
+
+  if (!killAll && pidArg == null) {
+    printHelp(d.logError);
+    return;
+  }
+
+  if (pidArg != null && Number.isNaN(pidArg)) {
+    d.logError(`Invalid PID: ${positional[0]}`);
+    return;
+  }
+
+  const params = killAll ? { all: true } : { pid: pidArg };
+  const result = await d.ipcCall("killServe", params);
+
+  if (isJson) {
+    d.log(JSON.stringify(result));
+  } else {
+    if (result.killed === 0) {
+      d.logError("No serve instances to kill.");
+    } else {
+      d.logError(`${c.green}Killed ${result.killed} serve instance${result.killed > 1 ? "s" : ""}.${c.reset}`);
+    }
+  }
+}

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -36,6 +36,7 @@ import { cmdRemove } from "./commands/remove";
 import { cmdRun } from "./commands/run";
 import { cmdScope } from "./commands/scope";
 import { cmdServe } from "./commands/serve";
+import { cmdServeKill } from "./commands/serve-kill";
 import { cmdSpans } from "./commands/spans";
 import { cmdTty } from "./commands/tty";
 import { cmdTypegen } from "./commands/typegen";
@@ -311,7 +312,11 @@ async function main(): Promise<void> {
         break;
 
       case "serve":
-        await cmdServe();
+        if (cleanArgs[1] === "kill") {
+          await cmdServeKill(cleanArgs.slice(2));
+        } else {
+          await cmdServe();
+        }
         break;
 
       case "connect":
@@ -869,6 +874,8 @@ Usage:
   mcx scope list                      List all registered scopes
   mcx scope rm <name>                 Remove a scope
   mcx serve                           Run as stdio MCP server (for .mcp.json)
+  mcx serve kill <pid>                Kill a serve instance by PID
+  mcx serve kill --all                Kill all serve instances
   mcx completions {bash|zsh|fish}     Generate shell completion script
   mcx restart [server]                Restart server connection(s)
   mcx daemon restart                  Restart the daemon (kills sessions)

--- a/packages/control/src/app.tsx
+++ b/packages/control/src/app.tsx
@@ -79,6 +79,7 @@ export function App() {
   const [addServerMode, setAddServerMode] = useState(false);
   const [addServerState, setAddServerState] = useState<AddServerState>(initialAddServerState);
   const [confirmRemove, setConfirmRemove] = useState(false);
+  const [confirmKillServe, setConfirmKillServe] = useState(false);
   const [configInfo, setConfigInfo] = useState<Record<string, { source: string; scope: string }>>({});
 
   // Registry browser state
@@ -358,6 +359,9 @@ export function App() {
       confirmRemove,
       setConfirmRemove,
       configInfo,
+      serveInstances: status?.serveInstances,
+      confirmKillServe,
+      setConfirmKillServe,
     },
     logsNav: {
       logSource,
@@ -588,6 +592,8 @@ export function App() {
         addServerMode={addServerMode}
         confirmRemove={confirmRemove}
         confirmRemoveServer={servers[selectedIndex]?.name}
+        confirmKillServe={confirmKillServe}
+        confirmKillServeCount={status?.serveInstances?.length}
         registryMode={registryMode}
       />
     </Box>

--- a/packages/control/src/components/footer.tsx
+++ b/packages/control/src/components/footer.tsx
@@ -20,6 +20,8 @@ interface FooterProps {
   addServerMode?: boolean;
   confirmRemove?: boolean;
   confirmRemoveServer?: string;
+  confirmKillServe?: boolean;
+  confirmKillServeCount?: number;
   registryMode?: RegistryMode;
 }
 
@@ -40,6 +42,8 @@ export function Footer({
   addServerMode,
   confirmRemove,
   confirmRemoveServer,
+  confirmKillServe,
+  confirmKillServeCount,
   registryMode,
 }: FooterProps) {
   if (confirmRemove) {
@@ -47,6 +51,21 @@ export function Footer({
       <Box marginTop={1}>
         <Text>
           <Text color="yellow">Remove {confirmRemoveServer ?? "server"}?</Text>
+          {"  "}
+          <Text dimColor>y</Text> confirm{"  "}
+          <Text dimColor>n</Text> cancel
+        </Text>
+      </Box>
+    );
+  }
+
+  if (confirmKillServe) {
+    return (
+      <Box marginTop={1}>
+        <Text>
+          <Text color="yellow">
+            Kill {confirmKillServeCount ?? "all"} serve instance{(confirmKillServeCount ?? 0) !== 1 ? "s" : ""}?
+          </Text>
           {"  "}
           <Text dimColor>y</Text> confirm{"  "}
           <Text dimColor>n</Text> cancel

--- a/packages/control/src/components/server-list.tsx
+++ b/packages/control/src/components/server-list.tsx
@@ -96,6 +96,7 @@ export function ServerList({
             <Text bold dimColor>
               Serve Instances ({instances.length})
             </Text>
+            <Text dimColor> — K to kill all</Text>
           </Box>
           {instances.map((inst) => {
             const uptime = formatUptime(Date.now() - inst.startedAt);

--- a/packages/control/src/hooks/use-keyboard-servers-add-remove.spec.ts
+++ b/packages/control/src/hooks/use-keyboard-servers-add-remove.spec.ts
@@ -44,6 +44,9 @@ function makeNav(overrides: Partial<ServersNav> = {}): ServersNav {
       s1: { source: "/path/servers.json", scope: "user" },
       s2: { source: "/path/servers.json", scope: "project" },
     },
+    serveInstances: [],
+    confirmKillServe: false,
+    setConfirmKillServe: mock(() => {}),
     ...overrides,
   };
 }

--- a/packages/control/src/hooks/use-keyboard-servers.spec.ts
+++ b/packages/control/src/hooks/use-keyboard-servers.spec.ts
@@ -41,6 +41,9 @@ function makeNav(overrides: Partial<ServersNav> = {}): ServersNav {
     confirmRemove: false,
     setConfirmRemove: mock(() => {}),
     configInfo: {},
+    serveInstances: [],
+    confirmKillServe: false,
+    setConfirmKillServe: mock(() => {}),
     ...overrides,
   };
 }
@@ -181,6 +184,51 @@ describe("handleServersInput", () => {
   });
 });
 
+describe("handleServersInput — kill serve", () => {
+  test("K activates kill-serve confirmation when instances exist", () => {
+    const nav = makeNav({
+      serveInstances: [{ instanceId: "abc", pid: 100, tools: [], startedAt: Date.now() }],
+    });
+    const consumed = handleServersInput("K", baseKey, nav);
+    expect(consumed).toBe(true);
+    expect(nav.setConfirmKillServe).toHaveBeenCalledWith(true);
+  });
+
+  test("K is no-op when no serve instances", () => {
+    const nav = makeNav({ serveInstances: [] });
+    const consumed = handleServersInput("K", baseKey, nav);
+    expect(consumed).toBe(true);
+    expect(nav.setConfirmKillServe).not.toHaveBeenCalled();
+  });
+
+  test("y in kill-serve confirm mode calls killServe and clears", () => {
+    const nav = makeNav({ confirmKillServe: true });
+    const consumed = handleServersInput("y", baseKey, nav);
+    expect(consumed).toBe(true);
+    expect(nav.setConfirmKillServe).toHaveBeenCalledWith(false);
+  });
+
+  test("n in kill-serve confirm mode cancels", () => {
+    const nav = makeNav({ confirmKillServe: true });
+    const consumed = handleServersInput("n", baseKey, nav);
+    expect(consumed).toBe(true);
+    expect(nav.setConfirmKillServe).toHaveBeenCalledWith(false);
+  });
+
+  test("escape in kill-serve confirm mode cancels", () => {
+    const nav = makeNav({ confirmKillServe: true });
+    const consumed = handleServersInput("", { ...baseKey, escape: true }, nav);
+    expect(consumed).toBe(true);
+    expect(nav.setConfirmKillServe).toHaveBeenCalledWith(false);
+  });
+
+  test("other keys swallowed in kill-serve confirm mode", () => {
+    const nav = makeNav({ confirmKillServe: true });
+    const consumed = handleServersInput("x", baseKey, nav);
+    expect(consumed).toBe(true);
+  });
+});
+
 describe("clearServersState", () => {
   test("resets addServerMode, addServerState, and confirmRemove", () => {
     const nav = makeNav({
@@ -203,5 +251,6 @@ describe("clearServersState", () => {
     expect(nav.setAddServerMode).toHaveBeenCalledWith(false);
     expect(nav.setAddServerState).toHaveBeenCalled();
     expect(nav.setConfirmRemove).toHaveBeenCalledWith(false);
+    expect(nav.setConfirmKillServe).toHaveBeenCalledWith(false);
   });
 });

--- a/packages/control/src/hooks/use-keyboard-servers.ts
+++ b/packages/control/src/hooks/use-keyboard-servers.ts
@@ -1,4 +1,5 @@
 import { addServerToConfig, ipcCall, removeServerFromConfig } from "@mcp-cli/core";
+import type { ServeInstanceInfo } from "@mcp-cli/core";
 import type { ServerConfig } from "@mcp-cli/core";
 import type { Key } from "ink";
 import {
@@ -85,6 +86,7 @@ export function clearServersState(nav: ServersNav): void {
   nav.setAddServerMode(false);
   nav.setAddServerState(initialAddServerState());
   nav.setConfirmRemove(false);
+  nav.setConfirmKillServe(false);
 }
 
 /**
@@ -110,7 +112,26 @@ export function handleServersInput(input: string, key: Key, nav: ServersNav): bo
     configInfo,
     onAddServer,
     onRemoveServer,
+    serveInstances,
+    confirmKillServe,
+    setConfirmKillServe,
   } = nav;
+
+  // ── Confirm kill-all-serve mode ──
+  if (confirmKillServe) {
+    if (input === "y") {
+      ipcCall("killServe", { all: true })
+        .then(refresh)
+        .catch(() => {});
+      setConfirmKillServe(false);
+      return true;
+    }
+    if (input === "n" || key.escape) {
+      setConfirmKillServe(false);
+      return true;
+    }
+    return true; // swallow all other input in confirm mode
+  }
 
   // ── Confirm remove mode ──
   if (confirmRemove) {
@@ -217,6 +238,15 @@ export function handleServersInput(input: string, key: Key, nav: ServersNav): bo
     ipcCall("restartServer", {})
       .then(refresh)
       .catch(() => {});
+    return true;
+  }
+
+  // Kill all serve instances (with confirmation)
+  if (input === "K") {
+    const instances = serveInstances ?? [];
+    if (instances.length > 0) {
+      setConfirmKillServe(true);
+    }
     return true;
   }
 

--- a/packages/control/src/hooks/use-keyboard.spec.ts
+++ b/packages/control/src/hooks/use-keyboard.spec.ts
@@ -107,6 +107,9 @@ describe("exported nav interfaces", () => {
       confirmRemove: false,
       setConfirmRemove: () => {},
       configInfo: {},
+      serveInstances: [],
+      confirmKillServe: false,
+      setConfirmKillServe: () => {},
     };
     expect(nav.servers).toBeArray();
     expect(nav.selectedIndex).toBe(0);

--- a/packages/control/src/hooks/use-keyboard.ts
+++ b/packages/control/src/hooks/use-keyboard.ts
@@ -68,6 +68,11 @@ export interface ServersNav {
   onAddServer?: (scope: "user" | "project", name: string, config: import("@mcp-cli/core").ServerConfig) => void;
   /** Injected for testing — defaults to the real removeServerFromConfig. */
   onRemoveServer?: (scope: "user" | "project", name: string) => void;
+  /** Active serve instances from daemon status (for kill keybinds). */
+  serveInstances?: import("@mcp-cli/core").ServeInstanceInfo[];
+  /** Whether the kill-all-serve confirmation prompt is active. */
+  confirmKillServe: boolean;
+  setConfirmKillServe: (mode: boolean) => void;
 }
 
 export interface LogsNav {

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -48,6 +48,7 @@ export type IpcMethod =
   | "registerServe"
   | "unregisterServe"
   | "listServeInstances"
+  | "killServe"
   | "setNote"
   | "getNote"
   | "listNotes"
@@ -361,6 +362,15 @@ export const UnregisterServeParamsSchema = z.object({
   instanceId: z.string(),
 });
 
+export const KillServeParamsSchema = z.object({
+  /** Kill a specific instance by ID. */
+  instanceId: z.string().optional(),
+  /** Kill a specific instance by PID. */
+  pid: z.number().optional(),
+  /** Kill all serve instances. */
+  all: z.boolean().optional(),
+});
+
 // -- Note schemas --
 
 export const SetNoteParamsSchema = z.object({
@@ -561,6 +571,7 @@ export interface IpcMethodResult {
   registerServe: { ok: true };
   unregisterServe: { ok: true };
   listServeInstances: ServeInstanceInfo[];
+  killServe: { killed: number };
   setNote: { ok: true };
   getNote: { note: string | null };
   listNotes: NoteEntry[];

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -34,6 +34,7 @@ import {
   GetToolInfoParamsSchema,
   GrepToolsParamsSchema,
   IPC_ERROR,
+  KillServeParamsSchema,
   ListToolsParamsSchema,
   MarkReadParamsSchema,
   MarkSpansExportedParamsSchema,
@@ -70,6 +71,7 @@ import { getDaemonLogLines, subscribeDaemonLogs } from "./daemon-log";
 import type { StateDb } from "./db/state";
 import { metrics } from "./metrics";
 import { getPortHolder } from "./port-holder";
+import { killPid } from "./process-util";
 import type { ServerPool } from "./server-pool";
 
 /** Per-request context passed to every handler (fixes race condition on shared state). */
@@ -953,6 +955,47 @@ export class IpcServer {
     this.handlers.set("listServeInstances", async (_params, _ctx) => {
       this.pruneStaleServeInstances();
       return [...this.serveInstances.values()];
+    });
+
+    this.handlers.set("killServe", async (params, _ctx) => {
+      const { instanceId, pid, all } = KillServeParamsSchema.parse(params ?? {});
+
+      if (!instanceId && pid == null && !all) {
+        throw Object.assign(new Error("Specify instanceId, pid, or all"), {
+          code: IPC_ERROR.INVALID_PARAMS,
+        });
+      }
+
+      this.pruneStaleServeInstances();
+
+      const targets: ServeInstanceInfo[] = [];
+      if (all) {
+        targets.push(...this.serveInstances.values());
+      } else if (instanceId) {
+        const inst = this.serveInstances.get(instanceId);
+        if (!inst) {
+          throw Object.assign(new Error(`Serve instance "${instanceId}" not found`), {
+            code: IPC_ERROR.SERVER_NOT_FOUND,
+          });
+        }
+        targets.push(inst);
+      } else if (pid != null) {
+        for (const inst of this.serveInstances.values()) {
+          if (inst.pid === pid) targets.push(inst);
+        }
+        if (targets.length === 0) {
+          throw Object.assign(new Error(`No serve instance with PID ${pid}`), {
+            code: IPC_ERROR.SERVER_NOT_FOUND,
+          });
+        }
+      }
+
+      for (const inst of targets) {
+        await killPid(inst.pid, this.logger);
+        this.serveInstances.delete(inst.instanceId);
+      }
+
+      return { killed: targets.length };
     });
 
     // -- Note handlers --


### PR DESCRIPTION
## Summary
- New `killServe` IPC method supporting kill by instanceId, PID, or all instances at once
- New `mcx serve kill <pid>` and `mcx serve kill --all` CLI commands with JSON output support
- New `K` keybind in mcpctl Servers tab to kill all serve instances (with y/n confirmation)

## Test plan
- [x] Unit tests for `cmdServeKill` (help, PID, --all, --json, invalid PID, zero kills)
- [x] Unit tests for TUI kill keybinds (K activates confirm, y/n/escape behavior, swallow other keys)
- [x] Updated `clearServersState` test to verify kill-serve state reset
- [x] Typecheck passes
- [x] Lint passes
- [x] All 2711+ tests pass (0 failures; daemon integration exit 143 is known Bun issue #1004)

🤖 Generated with [Claude Code](https://claude.com/claude-code)