### PR TITLE
fix(test): widen S3 slow-server timing headroom (fixes #1042)

### DIFF
--- a/test/stress.spec.ts
+++ b/test/stress.spec.ts
@@ -144,7 +144,7 @@ describe("S3: Slow server isolation", () => {
       slow: {
         command: "bun",
         args: [resolve("test/slow-echo-server.ts")],
-        env: { SLOW_MS: "3000" },
+        env: { SLOW_MS: "5000" },
       },
     });
   });
@@ -166,7 +166,7 @@ describe("S3: Slow server isolation", () => {
 
     const fastElapsed = (fastResult as Record<string, unknown>).elapsed as number;
 
-    // Fast should complete successfully — and well before the slow server's 3s delay
+    // Fast should complete successfully — well before the slow server's 5s delay
     expect(fastResult.stdout).toContain("fast");
     expect(fastResult.exitCode).toBe(0);
     expect(fastElapsed).toBeLessThan(3_000);


### PR DESCRIPTION
## Summary
- Increase `SLOW_MS` from 3000 to 5000 in the S3 slow-server isolation stress test
- The fast-call assertion (`< 3000ms`) now has 2s of headroom instead of zero margin, preventing flaky failures under CPU pressure

## Test plan
- [x] All 6 stress tests pass (`bun test test/stress.spec.ts`)
- [x] Full test suite passes (1163 tests, 0 failures)
- [x] Typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)