### PR TITLE
fix(test): reduce S2 stress test concurrency from 20 to 10 (fixes #1020)

### DIFF
--- a/test/stress.spec.ts
+++ b/test/stress.spec.ts
@@ -105,10 +105,10 @@ describe("S2: Concurrent CLI tool calls", () => {
     await daemon.kill();
   });
 
-  test("20 concurrent mcx call requests return correct results", async () => {
-    const count = 20;
+  test("10 concurrent mcx call requests return correct results", async () => {
+    const count = 10;
 
-    // Use a generous timeout — spawning 20 concurrent bun processes is CPU-heavy
+    // Use a generous timeout — spawning concurrent bun processes is CPU-heavy
     const results = await Promise.all(
       Array.from({ length: count }, (_, i) =>
         mcx(daemon.dir, ["call", "echo", "add", JSON.stringify({ a: i, b: 1000 })], { timeout: 60_000 }),


### PR DESCRIPTION
## Summary
- Reduced concurrent CLI process count in S2 stress test from 20 to 10
- Spawning 20 simultaneous `bun` processes overwhelms CPU and causes the test to exceed its 60s timeout (~70s observed)
- 10 concurrent processes still validates concurrent handling while keeping runtime well under budget (~16s total for the file)

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — all 3865 tests pass
- [x] `bun test test/stress.spec.ts` — all 6 stress tests pass in ~16s

🤖 Generated with [Claude Code](https://claude.com/claude-code)