### PR TITLE
fix(test): replace Bun.sleep with pollUntil in interrupt test (fixes #1041)

### DIFF
--- a/test/cli-orchestration.spec.ts
+++ b/test/cli-orchestration.spec.ts
@@ -295,8 +295,17 @@ describe("CLI→daemon orchestration (mock provider)", () => {
       const spawnResult = JSON.parse((spawnRes.result as { content: Array<{ text: string }> }).content[0].text);
       const sessionId: string = spawnResult.sessionId;
 
-      // Wait a bit for the script to start, then interrupt
-      await Bun.sleep(100);
+      // Wait for the session to enter running state before interrupting
+      await pollUntil(async () => {
+        const statusRes = await rpc(daemon.socketPath, "callTool", {
+          server: "_mock",
+          tool: "mock_session_status",
+          arguments: { sessionId },
+        });
+        const status = JSON.parse((statusRes.result as { content: Array<{ text: string }> }).content[0].text);
+        return status.state === "running";
+      });
+
       const intRes = await rpc(daemon.socketPath, "callTool", {
         server: "_mock",
         tool: "mock_interrupt",


### PR DESCRIPTION
## Summary
- Replace bare `Bun.sleep(100)` in the interrupt test with `pollUntil` that checks session state is `"running"` before sending the interrupt
- Eliminates the "wait and hope" anti-pattern that could flake on slow CI runners
- Follows the same `pollUntil` + `mock_session_status` pattern already used elsewhere in the test file

## Test plan
- [x] All 3865 tests pass (0 failures)
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] Pre-commit hook passes (coverage thresholds met)

🤖 Generated with [Claude Code](https://claude.com/claude-code)