### PR TITLE
fix(test): harden daemon integration tests against resource contention (fixes #1019)

### DIFF
--- a/test/daemon-integration.spec.ts
+++ b/test/daemon-integration.spec.ts
@@ -47,7 +47,7 @@ describe("P1: Daemon lifecycle", () => {
     const res = await rpc(daemon.socketPath, "shutdown");
     expect(res.result).toEqual({ ok: true });
 
-    const exitCode = await daemon.proc.exited;
+    const exitCode = await Promise.race([daemon.proc.exited, Bun.sleep(10_000).then(() => "timeout" as const)]);
     expect(exitCode).toBe(0);
 
     // PID file should be cleaned up
@@ -59,7 +59,8 @@ describe("P1: Daemon lifecycle", () => {
   test("shutdown via IPC logs reason and timing in stderr", async () => {
     daemon = await startTestDaemon({});
     await rpc(daemon.socketPath, "shutdown");
-    await daemon.proc.exited;
+    const exitCode = await Promise.race([daemon.proc.exited, Bun.sleep(10_000).then(() => "timeout" as const)]);
+    expect(exitCode).not.toBe("timeout");
 
     const stderr = await new Response(daemon.proc.stderr as ReadableStream).text();
     expect(stderr).toContain("Shutting down (IPC shutdown request)");
@@ -70,7 +71,8 @@ describe("P1: Daemon lifecycle", () => {
   test("shutdown via SIGTERM logs reason in stderr", async () => {
     daemon = await startTestDaemon({});
     daemon.proc.kill("SIGTERM");
-    await daemon.proc.exited;
+    const exitCode = await Promise.race([daemon.proc.exited, Bun.sleep(10_000).then(() => "timeout" as const)]);
+    expect(exitCode).not.toBe("timeout");
 
     const stderr = await new Response(daemon.proc.stderr as ReadableStream).text();
     expect(stderr).toContain("Shutting down (SIGTERM)");
@@ -484,20 +486,11 @@ describe("P5b: Error scenario edge cases", () => {
   });
 
   test("HTTP 401 error suggests 'mcx auth' in the error message", async () => {
-    // Start a local HTTP server that always returns 401
-    const authServer = Bun.spawn(["bun", resolve("test/http-401-server.ts")], {
-      stdout: "pipe",
-      stderr: "ignore",
-    });
+    // Start a local HTTP server that always returns 401, using harness for proper cleanup
+    const authServer = await startMockServer("test/http-401-server.ts");
     try {
-      // Read the port from stdout
-      const reader = authServer.stdout.getReader();
-      const { value } = await reader.read();
-      reader.releaseLock();
-      const port = Number(new TextDecoder().decode(value).trim());
-
       daemon = await startTestDaemon({
-        authfail: { type: "http", url: `http://127.0.0.1:${port}/mcp` },
+        authfail: { type: "http", url: `http://127.0.0.1:${authServer.port}/mcp` },
       });
 
       // Trigger a connection attempt — the 401 should produce an auth hint
@@ -511,8 +504,7 @@ describe("P5b: Error scenario edge cases", () => {
       const server = (list.result as Array<{ name: string; lastError?: string }>).find((s) => s.name === "authfail");
       expect(server?.lastError).toContain("mcx auth");
     } finally {
-      authServer.kill();
-      await authServer.exited;
+      await authServer.kill();
     }
   });
 

--- a/test/stress.spec.ts
+++ b/test/stress.spec.ts
@@ -192,10 +192,10 @@ describe("S4: Resilience after errors", () => {
   });
 
   test("daemon stays healthy after a burst of error calls", async () => {
-    // Fire 5 calls to non-existent servers concurrently — generous timeout for process spawning
+    // Fire 5 calls to non-existent servers concurrently
     const errorResults = await Promise.all(
       Array.from({ length: 5 }, (_, i) =>
-        mcx(daemon.dir, ["call", `ghost-${i}`, "anything", "{}"], { timeout: 60_000 }),
+        mcx(daemon.dir, ["call", `ghost-${i}`, "anything", "{}"], { timeout: 15_000 }),
       ),
     );
 
@@ -211,14 +211,13 @@ describe("S4: Resilience after errors", () => {
   });
 
   test("interleaved success and failure calls all resolve correctly", async () => {
-    // Use generous timeout — 10 concurrent bun processes under load
     const results = await Promise.all(
       Array.from({ length: 10 }, (_, i) => {
         if (i % 3 === 0) {
           // Every 3rd call targets a non-existent server
-          return mcx(daemon.dir, ["call", "ghost", "nope", "{}"], { timeout: 60_000 });
+          return mcx(daemon.dir, ["call", "ghost", "nope", "{}"], { timeout: 15_000 });
         }
-        return mcx(daemon.dir, ["call", "echo", "add", JSON.stringify({ a: i, b: i })], { timeout: 60_000 });
+        return mcx(daemon.dir, ["call", "echo", "add", JSON.stringify({ a: i, b: i })], { timeout: 15_000 });
       }),
     );
 


### PR DESCRIPTION
## Summary
- **P1 shutdown tests**: Added 10s `Promise.race` deadline around `await daemon.proc.exited` in 3 shutdown tests — prevents infinite hangs when daemon doesn't exit under resource contention
- **P5b auth error test**: Refactored inline `Bun.spawn` + manual stdout reading to use `startMockServer` from test harness — proper timeout on port reading and `await`ed cleanup via `authServer.kill()`
- **S4 stress tests**: Reduced per-process timeout from 60s to 15s — prevents worst-case 600s (10 procs × 60s) cascading timeout under contention

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — all 3865 tests pass, 0 failures
- [x] `bun test test/daemon-integration.spec.ts` — 32 pass (97s)
- [x] `bun test test/stress.spec.ts` — 6 pass (16s)
- [x] Pre-commit hook passes (typecheck + lint + test + coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)