### PR TITLE
test(daemon): mock Worker startup in CodexServer tests for defense-in-depth (fixes #1029)

### DIFF
--- a/packages/daemon/src/codex-server.spec.ts
+++ b/packages/daemon/src/codex-server.spec.ts
@@ -1,10 +1,30 @@
-import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { CODEX_SERVER_NAME, silentLogger } from "@mcp-cli/core";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { testOptions } from "../../../test/test-options";
 import { CodexServer, buildCodexToolCache, isWorkerEvent } from "./codex-server";
 import { StateDb } from "./db/state";
 import { MetricsCollector } from "./metrics";
+
+/** Minimal Worker stub that emits "ready" synchronously via postMessage. */
+function mockWorkerFactory() {
+  return (_scriptPath: string) => {
+    const w = {
+      postMessage: mock((_msg: unknown) => {
+        // Simulate the worker sending "ready" after receiving "init"
+        queueMicrotask(() => {
+          w.onmessage?.({ data: { type: "ready" } } as MessageEvent);
+        });
+      }),
+      terminate: mock(() => {}),
+      addEventListener: mock(() => {}),
+      removeEventListener: mock(() => {}),
+      onmessage: null as ((event: MessageEvent) => void) | null,
+      onerror: null as ((event: ErrorEvent | Event) => void) | null,
+    };
+    return w as unknown as Worker;
+  };
+}
 
 // ── isWorkerEvent ──
 
@@ -542,7 +562,15 @@ describe("CodexServer", () => {
       },
       close: async () => {},
     };
-    server = new CodexServer(db, undefined, () => fakeClient as never, silentLogger);
+    server = new CodexServer(
+      db,
+      undefined,
+      () => fakeClient as never,
+      silentLogger,
+      undefined,
+      undefined,
+      mockWorkerFactory(),
+    );
 
     await expect(server.start()).rejects.toThrow("simulated connect failure");
 
@@ -581,7 +609,7 @@ describe("CodexServer connect timeout metric", () => {
     } as unknown as Client;
 
     const testMetrics = new MetricsCollector();
-    server = new CodexServer(db, undefined, () => neverConnect, silentLogger, 50, testMetrics);
+    server = new CodexServer(db, undefined, () => neverConnect, silentLogger, 50, testMetrics, mockWorkerFactory());
 
     await expect(server.start()).rejects.toThrow("MCP handshake timeout (10s)");
     expect(testMetrics.counter("mcpd_connect_timeouts_total").value()).toBe(1);
@@ -597,7 +625,15 @@ describe("CodexServer connect timeout metric", () => {
       close: async () => {},
     } as unknown as Client;
     const testMetrics = new MetricsCollector();
-    server = new CodexServer(db, undefined, () => instantConnect, silentLogger, 10_000, testMetrics);
+    server = new CodexServer(
+      db,
+      undefined,
+      () => instantConnect,
+      silentLogger,
+      10_000,
+      testMetrics,
+      mockWorkerFactory(),
+    );
 
     await server.start();
 

--- a/packages/daemon/src/codex-server.ts
+++ b/packages/daemon/src/codex-server.ts
@@ -103,6 +103,7 @@ export function isWorkerEvent(data: unknown): data is WorkerEvent {
 // ── Server ──
 
 type ClientFactory = () => Client;
+type WorkerFactory = (scriptPath: string) => Worker;
 
 export class CodexServer {
   private worker: Worker | null = null;
@@ -110,6 +111,7 @@ export class CodexServer {
   private client: Client | null = null;
   private db: StateDb;
   private readonly clientFactory: ClientFactory;
+  private readonly workerFactory: WorkerFactory;
   private readonly activeSessions = new Set<string>();
   private readonly sessionAddedAt = new Map<string, number>();
   private restartInProgress = false;
@@ -137,12 +139,14 @@ export class CodexServer {
     logger?: Logger,
     private handshakeTimeoutMs = 10_000,
     metricsCollector?: MetricsCollector,
+    workerFactory?: WorkerFactory,
   ) {
     this.db = db;
     this.clientFactory =
       clientFactory ?? (() => new Client({ name: `mcp-cli/${CODEX_SERVER_NAME}`, version: "0.1.0" }));
     this.logger = logger ?? consoleLogger;
     this.metrics = metricsCollector ?? defaultMetrics;
+    this.workerFactory = workerFactory ?? ((path) => new Worker(path));
   }
 
   /** Start the worker and connect the MCP client. */
@@ -150,7 +154,7 @@ export class CodexServer {
     if (this.worker) throw new Error("start() called while worker is already running");
     this.stopped = false;
     this.metrics.gauge("mcpd_codex_worker_crash_loop_stopped").set(0);
-    const worker = new Worker(workerPath("codex-session-worker.ts"));
+    const worker = this.workerFactory(workerPath("codex-session-worker.ts"));
     this.worker = worker;
 
     // Wait for the worker to report ready


### PR DESCRIPTION
## Summary
- Add injectable `workerFactory` parameter to `CodexServer` constructor, matching the existing `OpenCodeServer` pattern
- Inject a lightweight mock Worker stub in timeout metric tests and connect-failure tests, eliminating real Worker thread spawning
- Mock Worker emits `"ready"` via `queueMicrotask` and supports `addEventListener`/`removeEventListener` for crash detection

## Test plan
- [x] All 34 codex-server tests pass (including the 3 tests now using mock workers)
- [x] Full test suite passes (3865 tests, 0 failures)
- [x] `bun typecheck` clean
- [x] `bun lint` clean
- [x] Coverage unchanged — no new production code paths, only test infra

🤖 Generated with [Claude Code](https://claude.com/claude-code)