### PR TITLE
fix(test): make awaitDeath throw on timeout instead of returning silently (fixes #1071)

### DIFF
--- a/packages/daemon/src/server-pool.spec.ts
+++ b/packages/daemon/src/server-pool.spec.ts
@@ -1666,13 +1666,14 @@ describe("disconnect kills stdio child processes (#940)", () => {
     }
   }
 
-  /** Poll until process is dead or deadline reached. */
+  /** Poll until process is dead or throw on timeout. */
   async function awaitDeath(pid: number, deadlineMs = 5_000): Promise<void> {
     const deadline = Date.now() + deadlineMs;
     while (Date.now() < deadline) {
       if (!isAlive(pid)) return;
       await Bun.sleep(5);
     }
+    throw new Error(`process ${pid} still alive after ${deadlineMs}ms`);
   }
 
   /** Force-kill a PID if still alive (test cleanup safety net). */


### PR DESCRIPTION
## Summary
- `awaitDeath` test helper in `server-pool.spec.ts` now throws `Error` when the polling deadline is exceeded, instead of returning silently
- This ensures tests fail with a clear "process X still alive after Yms" message rather than a confusing Bun timeout or a stale `isAlive` assertion

## Test plan
- [x] All 162 tests in `server-pool.spec.ts` pass
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] Full test suite + coverage passes via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)