### PR TITLE
feat(command): add mcx serve kill --stale to kill instances older than N hours (fixes #1097)

### DIFF
--- a/packages/command/src/commands/serve-kill.spec.ts
+++ b/packages/command/src/commands/serve-kill.spec.ts
@@ -75,4 +75,67 @@ describe("cmdServeKill", () => {
     await cmdServeKill(["abc"], deps);
     expect(deps.errors[0]).toContain("Invalid PID");
   });
+
+  test("kills stale with default 24h", async () => {
+    let calledWith: unknown;
+    const deps = makeDeps({
+      ipcCall: async <M extends IpcMethod>(_method: M, params?: unknown) => {
+        calledWith = params;
+        return { killed: 2 } as IpcMethodResult[M];
+      },
+    });
+    await cmdServeKill(["--stale"], deps);
+    expect(calledWith).toEqual({ staleHours: 24 });
+    expect(deps.errors[0]).toContain("Killed 2");
+  });
+
+  test("kills stale with custom hours", async () => {
+    let calledWith: unknown;
+    const deps = makeDeps({
+      ipcCall: async <M extends IpcMethod>(_method: M, params?: unknown) => {
+        calledWith = params;
+        return { killed: 1 } as IpcMethodResult[M];
+      },
+    });
+    await cmdServeKill(["--stale", "6"], deps);
+    expect(calledWith).toEqual({ staleHours: 6 });
+  });
+
+  test("kills stale with fractional hours", async () => {
+    let calledWith: unknown;
+    const deps = makeDeps({
+      ipcCall: async <M extends IpcMethod>(_method: M, params?: unknown) => {
+        calledWith = params;
+        return { killed: 1 } as IpcMethodResult[M];
+      },
+    });
+    await cmdServeKill(["--stale", "0.5"], deps);
+    expect(calledWith).toEqual({ staleHours: 0.5 });
+  });
+
+  test("rejects invalid --stale value", async () => {
+    const deps = makeDeps();
+    await cmdServeKill(["--stale", "abc"], deps);
+    expect(deps.errors[0]).toContain("Invalid --stale value");
+  });
+
+  test("--stale ignores negative-looking next arg and uses default", async () => {
+    let calledWith: unknown;
+    const deps = makeDeps({
+      ipcCall: async <M extends IpcMethod>(_method: M, params?: unknown) => {
+        calledWith = params;
+        return { killed: 0 } as IpcMethodResult[M];
+      },
+    });
+    await cmdServeKill(["--stale", "-5"], deps);
+    expect(calledWith).toEqual({ staleHours: 24 });
+  });
+
+  test("--stale with --json outputs JSON", async () => {
+    const deps = makeDeps({
+      ipcCall: async <M extends IpcMethod>() => ({ killed: 3 }) as IpcMethodResult[M],
+    });
+    await cmdServeKill(["--stale", "12", "--json"], deps);
+    expect(JSON.parse(deps.logs[0])).toEqual({ killed: 3 });
+  });
 });

--- a/packages/command/src/commands/serve-kill.ts
+++ b/packages/command/src/commands/serve-kill.ts
@@ -2,8 +2,9 @@
  * `mcx serve kill` — kill running serve instances.
  *
  * Usage:
- *   mcx serve kill <pid>       Kill a specific serve instance by PID
- *   mcx serve kill --all       Kill all serve instances
+ *   mcx serve kill <pid>           Kill a specific serve instance by PID
+ *   mcx serve kill --all           Kill all serve instances
+ *   mcx serve kill --stale [hours] Kill instances older than N hours (default: 24)
  */
 
 import type { IpcMethod, IpcMethodResult } from "@mcp-cli/core";
@@ -27,8 +28,9 @@ function printHelp(log: (msg: string) => void): void {
   log(`mcx serve kill — kill running serve instances
 
 Usage:
-  mcx serve kill <pid>       Kill a specific serve instance by PID
-  mcx serve kill --all       Kill all serve instances
+  mcx serve kill <pid>           Kill a specific serve instance by PID
+  mcx serve kill --all           Kill all serve instances
+  mcx serve kill --stale [hours] Kill instances older than N hours (default: 24)
 
 Flags:
   --json, -j     Output as JSON
@@ -45,10 +47,25 @@ export async function cmdServeKill(args: string[], deps?: Partial<ServeKillDeps>
   }
 
   const killAll = rest.includes("--all");
-  const positional = rest.filter((a) => !a.startsWith("-"));
+  const staleIdx = rest.indexOf("--stale");
+  let staleHours: number | undefined;
+  if (staleIdx !== -1) {
+    const next = rest[staleIdx + 1];
+    staleHours = next != null && !next.startsWith("-") ? Number(next) : 24;
+    if (Number.isNaN(staleHours) || staleHours < 0) {
+      d.logError(`Invalid --stale value: ${next}`);
+      return;
+    }
+  }
+
+  const positional = rest.filter((a, i) => {
+    if (a.startsWith("-")) return false;
+    if (staleIdx !== -1 && i === staleIdx + 1) return false;
+    return true;
+  });
   const pidArg = positional[0] ? Number(positional[0]) : undefined;
 
-  if (!killAll && pidArg == null) {
+  if (!killAll && pidArg == null && staleHours == null) {
     printHelp(d.logError);
     return;
   }
@@ -58,7 +75,7 @@ export async function cmdServeKill(args: string[], deps?: Partial<ServeKillDeps>
     return;
   }
 
-  const params = killAll ? { all: true } : { pid: pidArg };
+  const params = staleHours != null ? { staleHours } : killAll ? { all: true } : { pid: pidArg };
   const result = await d.ipcCall("killServe", params);
 
   if (isJson) {

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -369,6 +369,8 @@ export const KillServeParamsSchema = z.object({
   pid: z.number().optional(),
   /** Kill all serve instances. */
   all: z.boolean().optional(),
+  /** Kill instances older than this many hours. */
+  staleHours: z.number().optional(),
 });
 
 // -- Note schemas --

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -958,10 +958,10 @@ export class IpcServer {
     });
 
     this.handlers.set("killServe", async (params, _ctx) => {
-      const { instanceId, pid, all } = KillServeParamsSchema.parse(params ?? {});
+      const { instanceId, pid, all, staleHours } = KillServeParamsSchema.parse(params ?? {});
 
-      if (!instanceId && pid == null && !all) {
-        throw Object.assign(new Error("Specify instanceId, pid, or all"), {
+      if (!instanceId && pid == null && !all && staleHours == null) {
+        throw Object.assign(new Error("Specify instanceId, pid, all, or staleHours"), {
           code: IPC_ERROR.INVALID_PARAMS,
         });
       }
@@ -969,7 +969,12 @@ export class IpcServer {
       this.pruneStaleServeInstances();
 
       const targets: ServeInstanceInfo[] = [];
-      if (all) {
+      if (staleHours != null) {
+        const cutoff = Date.now() - staleHours * 60 * 60 * 1000;
+        for (const inst of this.serveInstances.values()) {
+          if (inst.startedAt < cutoff) targets.push(inst);
+        }
+      } else if (all) {
         targets.push(...this.serveInstances.values());
       } else if (instanceId) {
         const inst = this.serveInstances.get(instanceId);


### PR DESCRIPTION
## Summary
- Adds `--stale [hours]` flag to `mcx serve kill` that kills serve instances older than N hours (default: 24)
- Supports fractional hours (e.g. `--stale 0.5` for 30 minutes)
- Adds `staleHours` param to `KillServeParamsSchema` and daemon handler filters by `startedAt` age

## Test plan
- [x] `--stale` with no value defaults to 24h
- [x] `--stale 6` passes custom hours to IPC
- [x] `--stale 0.5` supports fractional hours
- [x] `--stale abc` rejects invalid values
- [x] `--stale -5` treats as flag, defaults to 24h
- [x] `--stale` with `--json` outputs JSON
- [x] All 3899 existing tests pass
- [x] Typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)