### PR TITLE
feat(core): add sprint state serialization for pause/resume (fixes #968)

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -126,6 +126,8 @@ const _originalOptions = {
   ALIAS_PRUNE_INTERVAL: 20,
   /** Run count threshold to trigger ephemeral alias promotion hint */
   EPHEMERAL_ALIAS_PROMOTION_THRESHOLD: 3,
+  /** Sprint state file path (pause/resume state) */
+  SPRINT_STATE_PATH: join(MCP_CLI_DIR, "sprint-state.json"),
 };
 export const options = { ..._originalOptions };
 export function _restoreOptions(): void {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,3 +25,4 @@ export * from "./agent-tools";
 export * from "./config-file";
 export * from "./flock";
 export * from "./scope";
+export * from "./sprint-state";

--- a/packages/core/src/sprint-state.spec.ts
+++ b/packages/core/src/sprint-state.spec.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { testOptions } from "../../../test/test-options";
+import {
+  clearSprintState,
+  createIssueState,
+  createSprintState,
+  readSprintState,
+  updateIssuePhase,
+  writeSprintState,
+} from "./sprint-state";
+import type { SprintState } from "./sprint-state";
+
+function findIssue(state: SprintState, num: number) {
+  const found = state.issues.find((i) => i.issue === num);
+  if (!found) throw new Error(`Test bug: issue #${num} not found`);
+  return found;
+}
+
+function makeSampleState(): SprintState {
+  return createSprintState(26, "Stability cleanup", [
+    createIssueState(1109, "Worktree pollution", 1, { scrutiny: "medium", provider: "claude" }),
+    createIssueState(1108, "approve/deny wiring", 1, { scrutiny: "low" }),
+    createIssueState(968, "Sprint pause/resume", 2),
+  ]);
+}
+
+describe("createIssueState", () => {
+  test("creates issue with defaults", () => {
+    const issue = createIssueState(42, "Fix bug", 1);
+    expect(issue).toEqual({
+      issue: 42,
+      title: "Fix bug",
+      phase: "queued",
+      scrutiny: null,
+      batch: 1,
+      provider: null,
+      sessionId: null,
+      worktree: null,
+      prNumber: null,
+      cost: 0,
+      startedAt: null,
+      completedAt: null,
+    });
+  });
+
+  test("accepts optional scrutiny and provider", () => {
+    const issue = createIssueState(42, "Fix bug", 2, { scrutiny: "high", provider: "codex" });
+    expect(issue.scrutiny).toBe("high");
+    expect(issue.provider).toBe("codex");
+  });
+});
+
+describe("createSprintState", () => {
+  test("creates sprint with running status", () => {
+    const state = makeSampleState();
+    expect(state.version).toBe(1);
+    expect(state.sprint).toBe(26);
+    expect(state.status).toBe("running");
+    expect(state.issues).toHaveLength(3);
+    expect(state.pausedAt).toBeNull();
+    expect(state.completedAt).toBeNull();
+    expect(state.quota).toBeNull();
+  });
+});
+
+describe("updateIssuePhase", () => {
+  test("transitions phase and sets startedAt on first move from queued", () => {
+    const state = makeSampleState();
+    const updated = updateIssuePhase(state, 1109, "implementing", {
+      sessionId: "sess-abc",
+      worktree: "claude-1109",
+    });
+
+    const issue = findIssue(updated, 1109);
+    expect(issue.phase).toBe("implementing");
+    expect(issue.sessionId).toBe("sess-abc");
+    expect(issue.worktree).toBe("claude-1109");
+    expect(issue.startedAt).not.toBeNull();
+    expect(issue.completedAt).toBeNull();
+  });
+
+  test("sets completedAt on terminal phase (merged)", () => {
+    let state = makeSampleState();
+    state = updateIssuePhase(state, 1108, "implementing");
+    state = updateIssuePhase(state, 1108, "merged", { prNumber: 1200, cost: 3.5 });
+
+    const issue = findIssue(state, 1108);
+    expect(issue.phase).toBe("merged");
+    expect(issue.completedAt).not.toBeNull();
+    expect(issue.prNumber).toBe(1200);
+    expect(issue.cost).toBe(3.5);
+  });
+
+  test("sets completedAt on terminal phase (dropped)", () => {
+    const state = makeSampleState();
+    const updated = updateIssuePhase(state, 968, "dropped");
+
+    const issue = findIssue(updated, 968);
+    expect(issue.phase).toBe("dropped");
+    expect(issue.completedAt).not.toBeNull();
+  });
+
+  test("does not mutate original state", () => {
+    const state = makeSampleState();
+    const original1109Phase = state.issues[0].phase;
+    updateIssuePhase(state, 1109, "implementing");
+    expect(state.issues[0].phase).toBe(original1109Phase);
+  });
+
+  test("throws for unknown issue", () => {
+    const state = makeSampleState();
+    expect(() => updateIssuePhase(state, 9999, "implementing")).toThrow("Issue #9999 not found");
+  });
+
+  test("preserves startedAt on subsequent transitions", () => {
+    let state = makeSampleState();
+    state = updateIssuePhase(state, 1109, "implementing");
+    const startedAt = findIssue(state, 1109).startedAt;
+
+    state = updateIssuePhase(state, 1109, "triaging");
+    expect(findIssue(state, 1109).startedAt).toBe(startedAt);
+  });
+});
+
+describe("readSprintState / writeSprintState", () => {
+  test("returns null when file is missing", () => {
+    using _opts = testOptions();
+    expect(readSprintState()).toBeNull();
+  });
+
+  test("returns null on malformed JSON", () => {
+    using _opts = testOptions({ files: { "sprint-state.json": "not json{{{" } });
+    expect(readSprintState()).toBeNull();
+  });
+
+  test("returns null when version is not 1", () => {
+    using _opts = testOptions({ files: { "sprint-state.json": { version: 2 } } });
+    expect(readSprintState()).toBeNull();
+  });
+
+  test("roundtrips sprint state through write/read", () => {
+    using _opts = testOptions();
+    const state = makeSampleState();
+
+    writeSprintState(state);
+    const loaded = readSprintState();
+
+    expect(loaded).not.toBeNull();
+    expect(loaded?.sprint).toBe(26);
+    expect(loaded?.goal).toBe("Stability cleanup");
+    expect(loaded?.issues).toHaveLength(3);
+    expect(loaded?.issues[0].issue).toBe(1109);
+    expect(loaded?.issues[0].scrutiny).toBe("medium");
+    expect(loaded?.issues[0].provider).toBe("claude");
+  });
+
+  test("writes JSON with trailing newline", () => {
+    using opts = testOptions();
+    writeSprintState(makeSampleState());
+    const raw = readFileSync(opts.SPRINT_STATE_PATH, "utf-8");
+    expect(raw.endsWith("\n")).toBe(true);
+  });
+
+  test("supports custom path", () => {
+    using opts = testOptions();
+    const customPath = `${opts.dir}/custom-sprint.json`;
+    const state = makeSampleState();
+
+    writeSprintState(state, customPath);
+    const loaded = readSprintState(customPath);
+
+    expect(loaded).not.toBeNull();
+    expect(loaded?.sprint).toBe(26);
+  });
+});
+
+describe("clearSprintState", () => {
+  test("removes existing state file", () => {
+    using _opts = testOptions();
+    writeSprintState(makeSampleState());
+    expect(readSprintState()).not.toBeNull();
+
+    clearSprintState();
+    expect(readSprintState()).toBeNull();
+  });
+
+  test("no-op when file does not exist", () => {
+    using _opts = testOptions();
+    expect(() => clearSprintState()).not.toThrow();
+  });
+});

--- a/packages/core/src/sprint-state.ts
+++ b/packages/core/src/sprint-state.ts
@@ -1,0 +1,199 @@
+/**
+ * Sprint state serialization — enables pause/resume of in-flight sprints.
+ *
+ * The sprint state file captures which phase each issue is in, session IDs,
+ * worktree paths, PR numbers, and costs. This lets a paused sprint be
+ * resumed from exactly where it left off.
+ *
+ * File location: ~/.mcp-cli/sprint-state.json (configurable via options.SPRINT_STATE_PATH)
+ */
+
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import type { AgentProviderName } from "./agent-session";
+import { options } from "./constants";
+
+/** Pipeline phase for a single issue within a sprint. */
+export type SprintIssuePhase =
+  | "queued"
+  | "implementing"
+  | "triaging"
+  | "reviewing"
+  | "repairing"
+  | "qa"
+  | "merged"
+  | "dropped";
+
+/** Per-issue state within a sprint. */
+export interface SprintIssueState {
+  /** GitHub issue number. */
+  issue: number;
+  /** Short title (for display). */
+  title: string;
+  /** Current pipeline phase. */
+  phase: SprintIssuePhase;
+  /** Scrutiny classification from triage. */
+  scrutiny: "low" | "medium" | "high" | null;
+  /** Batch number (1-indexed). */
+  batch: number;
+  /** Agent provider used for implementation. */
+  provider: AgentProviderName | null;
+  /** Active session ID (null when between phases). */
+  sessionId: string | null;
+  /** Worktree name (persists across phases for the same issue). */
+  worktree: string | null;
+  /** PR number once created. */
+  prNumber: number | null;
+  /** Accumulated cost across all sessions for this issue. */
+  cost: number;
+  /** ISO timestamp when this issue entered the pipeline. */
+  startedAt: string | null;
+  /** ISO timestamp when this issue reached a terminal phase (merged/dropped). */
+  completedAt: string | null;
+}
+
+/** Sprint-level status. */
+export type SprintStatus = "running" | "paused" | "completed";
+
+/** Quota snapshot at time of state save. */
+export interface QuotaSnapshot {
+  /** Utilization percentage (0-100). */
+  utilization: number;
+  /** ISO timestamp when the quota window resets. */
+  resetsAt: string | null;
+  /** ISO timestamp when this snapshot was taken. */
+  capturedAt: string;
+}
+
+/** Top-level sprint state. */
+export interface SprintState {
+  /** Schema version for forward compatibility. */
+  version: 1;
+  /** Sprint number. */
+  sprint: number;
+  /** One-line sprint goal. */
+  goal: string;
+  /** Current sprint status. */
+  status: SprintStatus;
+  /** ISO timestamp when the sprint started. */
+  startedAt: string;
+  /** ISO timestamp when the sprint was paused (null if never paused). */
+  pausedAt: string | null;
+  /** ISO timestamp when the sprint completed (null if still active). */
+  completedAt: string | null;
+  /** Per-issue pipeline state. */
+  issues: SprintIssueState[];
+  /** Most recent quota snapshot (null if never captured). */
+  quota: QuotaSnapshot | null;
+}
+
+/** Create a fresh issue state with sensible defaults. */
+export function createIssueState(
+  issue: number,
+  title: string,
+  batch: number,
+  opts?: Partial<Pick<SprintIssueState, "scrutiny" | "provider">>,
+): SprintIssueState {
+  return {
+    issue,
+    title,
+    phase: "queued",
+    scrutiny: opts?.scrutiny ?? null,
+    batch,
+    provider: opts?.provider ?? null,
+    sessionId: null,
+    worktree: null,
+    prNumber: null,
+    cost: 0,
+    startedAt: null,
+    completedAt: null,
+  };
+}
+
+/** Create a fresh sprint state. */
+export function createSprintState(sprint: number, goal: string, issues: SprintIssueState[]): SprintState {
+  return {
+    version: 1,
+    sprint,
+    goal,
+    status: "running",
+    startedAt: new Date().toISOString(),
+    pausedAt: null,
+    completedAt: null,
+    issues,
+    quota: null,
+  };
+}
+
+/**
+ * Return a new SprintState with the given issue's phase and fields updated.
+ * Does not mutate the input. Throws if the issue is not found.
+ */
+export function updateIssuePhase(
+  state: SprintState,
+  issueNumber: number,
+  phase: SprintIssuePhase,
+  updates?: Partial<Omit<SprintIssueState, "issue" | "phase">>,
+): SprintState {
+  const idx = state.issues.findIndex((i) => i.issue === issueNumber);
+  if (idx === -1) {
+    throw new Error(`Issue #${issueNumber} not found in sprint state`);
+  }
+  const issue = state.issues[idx];
+  const now = new Date().toISOString();
+  const isTerminal = phase === "merged" || phase === "dropped";
+  const isStarting = issue.phase === "queued" && phase !== "queued";
+
+  const updated: SprintIssueState = {
+    ...issue,
+    ...updates,
+    phase,
+    startedAt: isStarting ? (updates?.startedAt ?? now) : issue.startedAt,
+    completedAt: isTerminal ? (updates?.completedAt ?? now) : issue.completedAt,
+  };
+
+  const issues = [...state.issues];
+  issues[idx] = updated;
+  return { ...state, issues };
+}
+
+/**
+ * Read sprint state from the default path (or a custom path).
+ * Returns null if the file doesn't exist or is malformed.
+ */
+export function readSprintState(path?: string): SprintState | null {
+  const filePath = path ?? options.SPRINT_STATE_PATH;
+  try {
+    const text = readFileSync(filePath, "utf-8");
+    const parsed = JSON.parse(text) as SprintState;
+    if (parsed.version !== 1) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Write sprint state to the default path (or a custom path).
+ * Creates parent directories if needed.
+ */
+export function writeSprintState(state: SprintState, path?: string): void {
+  const filePath = path ?? options.SPRINT_STATE_PATH;
+  const dir = dirname(filePath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  writeFileSync(filePath, `${JSON.stringify(state, null, 2)}\n`);
+}
+
+/**
+ * Remove the sprint state file. No-op if it doesn't exist.
+ */
+export function clearSprintState(path?: string): void {
+  const filePath = path ?? options.SPRINT_STATE_PATH;
+  try {
+    unlinkSync(filePath);
+  } catch {
+    // File doesn't exist — fine.
+  }
+}

--- a/test/test-options.ts
+++ b/test/test-options.ts
@@ -40,6 +40,7 @@ export function testOptions(input?: TestOptionsInput) {
   options.DAEMON_LOG_PATH = join(dir, "mcpd.log");
   options.DAEMON_LOG_BACKUP_PATH = join(dir, "mcpd.log.1");
   options.SCOPES_DIR = join(dir, "scopes");
+  options.SPRINT_STATE_PATH = join(dir, "sprint-state.json");
 
   if (Object.keys(overrides).length > 0) Object.assign(options, overrides);
 


### PR DESCRIPTION
## Summary
- Add `SprintState` types and read/write helpers to `packages/core/src/sprint-state.ts` — captures per-issue pipeline phase, session IDs, worktree paths, PR numbers, costs, and quota snapshots
- Add `SPRINT_STATE_PATH` to `constants.ts` options (`~/.mcp-cli/sprint-state.json`)
- This is piece 1 of 5 from the sprint pause/resume epic (#968) — state schema and file I/O only. No pause/resume commands, no quota monitoring, no orchestrator integration yet.

## Test plan
- [x] 17 tests in `sprint-state.spec.ts` covering:
  - `createIssueState` defaults and optional fields
  - `createSprintState` initialization
  - `updateIssuePhase` transitions, terminal phases, immutability, unknown issue error
  - `readSprintState` / `writeSprintState` roundtrip, missing file, malformed JSON, version check, custom path
  - `clearSprintState` removal and no-op on missing
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] All 388 core package tests pass
- [x] Coverage check passes (98.75% lines on new file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)