### PR TITLE
fix(daemon): accept same-origin OAuth protected resource URLs (fixes #1120)

### DIFF
--- a/packages/daemon/src/auth/oauth-provider.spec.ts
+++ b/packages/daemon/src/auth/oauth-provider.spec.ts
@@ -553,6 +553,73 @@ describe("McpOAuthProvider", () => {
     });
   });
 
+  // -- validateResourceURL() --
+
+  describe("validateResourceURL()", () => {
+    test("returns resource URL when same origin with different path", async () => {
+      const db = createDb();
+      const provider = createProvider(db);
+
+      const result = await provider.validateResourceURL("https://api.example.com/sse", "https://api.example.com/v2");
+
+      expect(result).toEqual(new URL("https://api.example.com/v2"));
+      db.close();
+    });
+
+    test("returns resource URL when paths match", async () => {
+      const db = createDb();
+      const provider = createProvider(db);
+
+      const result = await provider.validateResourceURL("https://api.example.com/api", "https://api.example.com/api");
+
+      expect(result).toEqual(new URL("https://api.example.com/api"));
+      db.close();
+    });
+
+    test("returns undefined when no resource provided", async () => {
+      const db = createDb();
+      const provider = createProvider(db);
+
+      const result = await provider.validateResourceURL("https://api.example.com/sse");
+
+      expect(result).toBeUndefined();
+      db.close();
+    });
+
+    test("throws when origins differ", async () => {
+      const db = createDb();
+      const provider = createProvider(db);
+
+      await expect(
+        provider.validateResourceURL("https://api.example.com/sse", "https://evil.example.com/v2"),
+      ).rejects.toThrow("origin does not match");
+      db.close();
+    });
+
+    test("throws when schemes differ", async () => {
+      const db = createDb();
+      const provider = createProvider(db);
+
+      await expect(
+        provider.validateResourceURL("https://api.example.com/sse", "http://api.example.com/v2"),
+      ).rejects.toThrow("origin does not match");
+      db.close();
+    });
+
+    test("accepts URL objects as serverUrl", async () => {
+      const db = createDb();
+      const provider = createProvider(db);
+
+      const result = await provider.validateResourceURL(
+        new URL("https://api.example.com/sse"),
+        "https://api.example.com/v2",
+      );
+
+      expect(result).toEqual(new URL("https://api.example.com/v2"));
+      db.close();
+    });
+  });
+
   // -- getEffectiveScope() --
 
   describe("getEffectiveScope()", () => {

--- a/packages/daemon/src/auth/oauth-provider.ts
+++ b/packages/daemon/src/auth/oauth-provider.ts
@@ -207,6 +207,27 @@ export class McpOAuthProvider implements OAuthClientProvider {
     return kc?.discoveryState;
   }
 
+  /**
+   * Accept the server's advertised resource URL if it shares the same origin.
+   *
+   * The SDK default rejects resources whose path doesn't prefix-match the
+   * configured server URL (e.g. Asana advertises `/v2` but the SSE endpoint
+   * is `/sse`). Same-origin is sufficient — the server is authoritative about
+   * which resource it protects.
+   */
+  async validateResourceURL(serverUrl: string | URL, resource?: string): Promise<URL | undefined> {
+    if (!resource) return undefined;
+
+    const server = new URL(typeof serverUrl === "string" ? serverUrl : serverUrl.href);
+    const resourceUrl = new URL(resource);
+
+    if (server.origin !== resourceUrl.origin) {
+      throw new Error(`Protected resource ${resource} origin does not match server ${server.origin}`);
+    }
+
+    return resourceUrl;
+  }
+
   invalidateCredentials(scope: "all" | "client" | "tokens" | "verifier" | "discovery"): void {
     switch (scope) {
       case "all":


### PR DESCRIPTION
## Summary
- Implement `validateResourceURL` on `McpOAuthProvider` to override the SDK's strict path-prefix check
- Accept any server-advertised protected resource URL that shares the same origin as the configured server URL
- Fixes SSE connections to servers like Asana that advertise a different resource path (`/v2`) than the SSE endpoint (`/sse`)

## Test plan
- [x] Same-origin with different paths accepted (e.g. `/sse` server + `/v2` resource)
- [x] Matching paths accepted
- [x] Missing resource returns undefined
- [x] Cross-origin resource rejected with error
- [x] Scheme mismatch rejected
- [x] URL objects accepted as serverUrl parameter
- [x] All 63 auth tests pass, 100% line coverage on changed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)