### PR TITLE
fix(command): wire approve/deny into agent.ts runtime path (fixes #1121)

### DIFF
--- a/packages/command/src/commands/agent.spec.ts
+++ b/packages/command/src/commands/agent.spec.ts
@@ -1557,3 +1557,101 @@ describe("agent log non-JSON response", () => {
     expect(allOutput).toContain("error: no transcript");
   });
 });
+
+// ── approve / deny ──
+
+const SESSION_WITH_PENDING = [
+  {
+    ...SESSION_LIST[0],
+    pendingPermissions: 1,
+    pendingPermissionDetails: [{ requestId: "req-pending-001" }],
+  },
+  SESSION_LIST[1],
+];
+
+describe("agent approve", () => {
+  test("calls provider_approve with explicit requestId", async () => {
+    const con = mockConsole();
+    try {
+      const callTool = mock(async (tool: string) => {
+        if (tool === "codex_session_list") return toolResult(SESSION_WITH_PENDING);
+        return toolResult({ approved: true });
+      });
+      const deps = makeDeps({ callTool });
+      await cmdAgent(["codex", "approve", "abc12345", "req-explicit"], deps);
+      expect(callTool).toHaveBeenCalledWith("codex_approve", {
+        sessionId: SESSION_WITH_PENDING[0].sessionId,
+        requestId: "req-explicit",
+      });
+    } finally {
+      con.restore();
+    }
+  });
+
+  test("auto-resolves latest pending requestId when omitted", async () => {
+    const con = mockConsole();
+    try {
+      const callTool = mock(async (tool: string) => {
+        if (tool === "codex_session_list") return toolResult(SESSION_WITH_PENDING);
+        return toolResult({ approved: true });
+      });
+      const deps = makeDeps({ callTool });
+      await cmdAgent(["codex", "approve", "abc12345"], deps);
+      expect(callTool).toHaveBeenCalledWith("codex_approve", {
+        sessionId: SESSION_WITH_PENDING[0].sessionId,
+        requestId: "req-pending-001",
+      });
+    } finally {
+      con.restore();
+    }
+  });
+
+  test("errors when no session prefix provided", async () => {
+    const deps = makeDeps();
+    await expect(cmdAgent(["codex", "approve"], deps)).rejects.toThrow(ExitError);
+  });
+});
+
+describe("agent deny", () => {
+  test("calls provider_deny with explicit requestId", async () => {
+    const con = mockConsole();
+    try {
+      const callTool = mock(async (tool: string) => {
+        if (tool === "codex_session_list") return toolResult(SESSION_WITH_PENDING);
+        return toolResult({ denied: true });
+      });
+      const deps = makeDeps({ callTool });
+      await cmdAgent(["codex", "deny", "abc12345", "req-explicit"], deps);
+      expect(callTool).toHaveBeenCalledWith("codex_deny", {
+        sessionId: SESSION_WITH_PENDING[0].sessionId,
+        requestId: "req-explicit",
+      });
+    } finally {
+      con.restore();
+    }
+  });
+
+  test("passes --message to deny tool", async () => {
+    const con = mockConsole();
+    try {
+      const callTool = mock(async (tool: string) => {
+        if (tool === "codex_session_list") return toolResult(SESSION_WITH_PENDING);
+        return toolResult({ denied: true });
+      });
+      const deps = makeDeps({ callTool });
+      await cmdAgent(["codex", "deny", "abc12345", "--message", "Not allowed"], deps);
+      expect(callTool).toHaveBeenCalledWith("codex_deny", {
+        sessionId: SESSION_WITH_PENDING[0].sessionId,
+        requestId: "req-pending-001",
+        message: "Not allowed",
+      });
+    } finally {
+      con.restore();
+    }
+  });
+
+  test("errors when no session prefix provided", async () => {
+    const deps = makeDeps();
+    await expect(cmdAgent(["codex", "deny"], deps)).rejects.toThrow(ExitError);
+  });
+});

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -4,7 +4,7 @@
  * Dispatches subcommands parameterized by the provider registry, eliminating
  * the duplication that existed across the former per-provider command files.
  *
- * Subcommands: spawn, ls, send, bye, wait, interrupt, log, resume, worktrees
+ * Subcommands: spawn, ls, send, bye, wait, interrupt, log, resume, approve, deny, worktrees
  * Provider-specific flags (--headed, --agent, --provider) are gated by feature flags.
  */
 
@@ -33,7 +33,10 @@ import {
   buildResumePrompt,
   cleanupWorktree,
   extractIssueNumber,
+  parseApproveArgs,
   parseByeResult,
+  parseDenyArgs,
+  resolvePermissionTarget,
   resolveSessionId,
   resolveWorktree,
 } from "./claude";
@@ -265,9 +268,15 @@ export async function cmdAgent(args: string[], deps?: Partial<AgentDeps>): Promi
     case "wt":
       await agentWorktrees(args.slice(2), provider, d);
       break;
+    case "approve":
+      await agentApprove(args.slice(2), provider, d);
+      break;
+    case "deny":
+      await agentDeny(args.slice(2), provider, d);
+      break;
     default:
       d.printError(
-        `Unknown ${providerName} subcommand: ${sub}. Use "spawn", "ls", "send", "bye", "interrupt", "log", "wait", "resume", or "worktrees".`,
+        `Unknown ${providerName} subcommand: ${sub}. Use "spawn", "ls", "send", "bye", "interrupt", "log", "wait", "resume", "approve", "deny", or "worktrees".`,
       );
       d.exit(1);
   }
@@ -1359,6 +1368,38 @@ async function agentWorktrees(args: string[], provider: AgentProvider, d: AgentD
 
 // ── Usage ──
 
+// ── Approve / Deny ──
+
+async function agentApprove(args: string[], provider: AgentProvider, d: AgentDeps): Promise<void> {
+  const P = provider.toolPrefix;
+  const { sessionPrefix, requestId } = parseApproveArgs(args, d);
+
+  const { sessionId, resolvedRequestId } = await resolvePermissionTarget(
+    sessionPrefix,
+    requestId,
+    d,
+    `${P}_session_list`,
+  );
+  const result = await d.callTool(`${P}_approve`, { sessionId, requestId: resolvedRequestId });
+  console.log(formatToolResult(result));
+}
+
+async function agentDeny(args: string[], provider: AgentProvider, d: AgentDeps): Promise<void> {
+  const P = provider.toolPrefix;
+  const { sessionPrefix, requestId, message } = parseDenyArgs(args, d);
+
+  const { sessionId, resolvedRequestId } = await resolvePermissionTarget(
+    sessionPrefix,
+    requestId,
+    d,
+    `${P}_session_list`,
+  );
+  const toolArgs: Record<string, unknown> = { sessionId, requestId: resolvedRequestId };
+  if (message) toolArgs.message = message;
+  const result = await d.callTool(`${P}_deny`, toolArgs);
+  console.log(formatToolResult(result));
+}
+
 function printAgentUsage(log: ((...args: unknown[]) => void) | undefined = console.log): void {
   const out = log ?? console.log;
   const providers = getAllProviders()
@@ -1404,6 +1445,8 @@ Usage:
   mcx agent ${name} interrupt <session>          Interrupt current turn
   mcx agent ${name} log <session> [--last N]     View transcript
   mcx agent ${name} resume <worktree>            ${resumeNote}
+  mcx agent ${name} approve <session> [req-id]  Approve pending permission request
+  mcx agent ${name} deny <session> [req-id]     Deny pending permission request
   mcx agent ${name} worktrees [--prune]          List mcx-created worktrees
 
 Run "mcx agent ${name} spawn --help" for spawn options.`);

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -1077,13 +1077,14 @@ export function parseDenyArgs(
 /**
  * Resolve sessionId (via prefix match) and requestId (explicit or auto-detect latest pending).
  */
-async function resolvePermissionTarget(
+export async function resolvePermissionTarget(
   sessionPrefix: string,
   requestId: string | undefined,
   d: SharedSessionDeps,
+  listToolName = "claude_session_list",
 ): Promise<{ sessionId: string; resolvedRequestId: string }> {
   // Fetch session list (same call resolveSessionId uses)
-  const result = await d.callTool("claude_session_list", {});
+  const result = await d.callTool(listToolName, {});
   const text = formatToolResult(result);
   let sessions: Array<{ sessionId: string; pendingPermissionDetails?: Array<{ requestId: string }> }>;
   try {


### PR DESCRIPTION
## Summary
- Add `approve` and `deny` cases to agent.ts switch statement, wiring them to new `agentApprove`/`agentDeny` functions that use the provider's tool prefix
- Export and generalize `resolvePermissionTarget` from claude.ts to accept a dynamic `listToolName` parameter (defaulting to `claude_session_list` for backward compatibility)
- Update usage text and error messages to include approve/deny

## Test plan
- [x] Added 6 tests in agent.spec.ts covering approve with explicit/auto-resolved requestId, deny with message, and error cases
- [x] All 3938 existing tests pass (0 failures)
- [x] `bun typecheck` passes
- [x] `bun lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)