### PR TITLE
fix(command): add claude/ branch prefix for headless --worktree spawns (fixes #1115)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -801,7 +801,7 @@ describe("mcx claude spawn --worktree branchPrefix", () => {
     }
   });
 
-  test("headless --worktree pre-creates worktree and passes cwd", async () => {
+  test("headless --worktree pre-creates worktree with claude/ prefix and passes cwd", async () => {
     const exec = mock(() => ({ stdout: "", stderr: "", exitCode: 0 }));
     const callTool = mock(async () => toolResult({ sessionId: "s1" }));
     const deps = makeDeps({ exec, callTool });
@@ -814,7 +814,8 @@ describe("mcx claude spawn --worktree branchPrefix", () => {
       const execCalls = exec.mock.calls as unknown as Array<[string[]]>;
       const wtCall = execCalls.find((c) => c[0][0] === "git" && c[0][1] === "worktree");
       expect(wtCall).toBeDefined();
-      expect(wtCall?.[0]).toContain("my-feat");
+      // Branch name must use claude/ prefix to avoid collisions with main-repo branches (#1115)
+      expect(wtCall?.[0]).toContain("claude/my-feat");
       // cwd must be set so daemon spawns Claude in the worktree, not the main repo
       const toolCalls = callTool.mock.calls as unknown as Array<[string, Record<string, unknown>]>;
       expect(toolCalls[0][1].worktree).toBe("my-feat");

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -364,7 +364,7 @@ async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
   // operations leak into the main working tree (#1109).
   if (parsed.worktree) {
     try {
-      const result = createWorktree({ name: parsed.worktree, repoRoot: process.cwd() }, d);
+      const result = createWorktree({ name: parsed.worktree, repoRoot: process.cwd(), branchPrefix: "claude/" }, d);
       Object.assign(toolArgs, result.toolArgs);
     } catch (e) {
       d.printError(e instanceof WorktreeError ? e.message : String(e));


### PR DESCRIPTION
## Summary
- Headless `mcx claude spawn --worktree <name>` now creates git branches with `claude/` prefix (e.g. `claude/my-feat`) instead of raw `<name>`, avoiding collisions with existing repo branches
- Consistent with headed spawns which already use `headed/` prefix
- Updated test to verify the `claude/` prefix is applied

## Test plan
- [x] Existing test updated to assert `claude/my-feat` branch name
- [x] `branchPrefix: false` config override test still passes (raw name when opted out)
- [x] Full test suite: 2790 pass, 0 fail
- [x] Typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)