### PR TITLE
fix(command): clean up orphaned worktree when IPC call fails after creation (fixes #1116)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -824,6 +824,38 @@ describe("mcx claude spawn --worktree branchPrefix", () => {
       console.log = origLog;
     }
   });
+
+  test("cleans up worktree when IPC callTool fails (#1116)", async () => {
+    const exec = mock(() => ({ stdout: "", stderr: "", exitCode: 0 }));
+    const callTool = mock(async () => {
+      throw new Error("daemon unreachable");
+    });
+    const printError = mock(() => {});
+    const deps = makeDeps({ exec, callTool, printError });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["spawn", "--task", "x", "--worktree", "my-feat"], deps);
+      throw new Error("should have exited");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ExitError);
+      expect((e as ExitError).code).toBe(1);
+
+      // Verify cleanup was attempted: git status --porcelain on the worktree path
+      const execCalls = exec.mock.calls as unknown as Array<[string[], { env?: Record<string, string> }?]>;
+      const statusCall = execCalls.find(
+        (c) => c[0][0] === "git" && c[0][1] === "-C" && c[0].includes("status") && c[0].includes("--porcelain"),
+      );
+      expect(statusCall).toBeDefined();
+
+      // Verify the error message was printed
+      const errorCalls = printError.mock.calls as unknown as Array<[string]>;
+      expect(errorCalls.some((c) => c[0].includes("daemon unreachable"))).toBe(true);
+    } finally {
+      console.log = origLog;
+    }
+  });
 });
 
 // ── ls ──

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -362,18 +362,33 @@ async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
   // Handle worktree: always pre-create via shim so cwd points to the worktree.
   // Without cwd, Claude inherits the daemon's cwd (main repo) and file
   // operations leak into the main working tree (#1109).
+  let worktreeResult: { path: string } | undefined;
   if (parsed.worktree) {
     try {
-      const result = createWorktree({ name: parsed.worktree, repoRoot: process.cwd() }, d);
-      Object.assign(toolArgs, result.toolArgs);
+      const wt = createWorktree({ name: parsed.worktree, repoRoot: process.cwd() }, d);
+      Object.assign(toolArgs, wt.toolArgs);
+      worktreeResult = wt;
     } catch (e) {
       d.printError(e instanceof WorktreeError ? e.message : String(e));
       d.exit(1);
     }
   }
 
-  const result = await d.callTool("claude_prompt", toolArgs);
-  console.log(formatToolResult(result));
+  try {
+    const result = await d.callTool("claude_prompt", toolArgs);
+    console.log(formatToolResult(result));
+  } catch (e) {
+    // IPC failed after worktree was created — clean up to avoid orphans (#1116)
+    if (parsed.worktree && worktreeResult) {
+      try {
+        cleanupWorktree(parsed.worktree, worktreeResult.path, d, process.cwd());
+      } catch {
+        // Best-effort cleanup — don't mask the original error
+      }
+    }
+    d.printError(String(e));
+    d.exit(1);
+  }
 }
 
 async function claudeSpawnHeaded(parsed: SpawnArgs, d: ClaudeDeps): Promise<void> {


### PR DESCRIPTION
## Summary
- Wraps `callTool("claude_prompt", ...)` in try/catch in the headless `spawn --worktree` path
- On IPC failure (daemon unreachable, protocol mismatch, socket timeout), calls `cleanupWorktree()` to remove the pre-created worktree before exiting
- Prevents orphaned worktree directories and git branches from accumulating on disk

## Test plan
- [x] Added test: IPC failure after worktree creation triggers cleanup (`git status --porcelain` call observed)
- [x] Existing worktree spawn tests still pass (257 tests in claude.spec.ts)
- [x] Full suite passes: 3947 tests, typecheck clean, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)