### PR TITLE
fix(test): clean cache before test to survive prior segfaults (fixes #1146)

### DIFF
--- a/packages/daemon/src/alias-executor.spec.ts
+++ b/packages/daemon/src/alias-executor.spec.ts
@@ -108,6 +108,10 @@ describe("alias-executor subprocess protocol", () => {
   });
 
   test("cache() writes to disk and returns cached value on second call", async () => {
+    // Clean up BEFORE test to handle stale state from prior crashes (#1146)
+    const cacheDir = join(homedir(), ".mcp-cli", "cache", "alias", "executor-cache-test");
+    if (existsSync(cacheDir)) rmSync(cacheDir, { recursive: true });
+
     const dir = makeTmpDir();
     const scriptPath = join(dir, "cached.ts");
     // Script uses cache() — on first call writes file, on second call reads it
@@ -149,10 +153,7 @@ describe("alias-executor subprocess protocol", () => {
     expect(JSON.parse(second.stdout).result).toBe("original");
 
     // Clean up cache files
-    const cacheDir = join(homedir(), ".mcp-cli", "cache", "alias", "executor-cache-test");
-    if (existsSync(cacheDir)) {
-      rmSync(cacheDir, { recursive: true });
-    }
+    if (existsSync(cacheDir)) rmSync(cacheDir, { recursive: true });
   });
 
   test("cycle detection: errors when alias is already in callChain", async () => {


### PR DESCRIPTION
## Summary
- Move cache directory cleanup from **after** to **before** the cache test in `alias-executor.spec.ts`
- Reuses the `cacheDir` variable for both pre-test and post-test cleanup, eliminating the duplicate declaration
- Prevents stale cache from prior segfault runs (#1004) from causing false test failures

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes  
- [x] `bun test` passes (2791 tests, 0 failures)
- [x] Verified the specific cache test passes: `bun test packages/daemon/src/alias-executor.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)