### PR TITLE
feat(daemon): work_items SQLite table and CRUD operations (fixes #1137)

### DIFF
--- a/packages/daemon/src/db/work-items.spec.ts
+++ b/packages/daemon/src/db/work-items.spec.ts
@@ -1,0 +1,243 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, test } from "bun:test";
+import { unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { WorkItemDb } from "./work-items";
+
+function tmpDb(): string {
+  return join(tmpdir(), `mcp-cli-wi-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+}
+
+function cleanup(path: string): void {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      unlinkSync(`${path}${suffix}`);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+describe("WorkItemDb", () => {
+  const paths: string[] = [];
+
+  afterEach(() => {
+    for (const p of paths) cleanup(p);
+    paths.length = 0;
+  });
+
+  function createDb(): WorkItemDb {
+    const p = tmpDb();
+    paths.push(p);
+    const db = new Database(p, { create: true });
+    db.exec("PRAGMA journal_mode = WAL");
+    return new WorkItemDb(db);
+  }
+
+  describe("createWorkItem", () => {
+    test("creates with defaults", () => {
+      const db = createDb();
+      const item = db.createWorkItem({ issueNumber: 42 });
+
+      expect(item.id).toBeTruthy();
+      expect(item.issueNumber).toBe(42);
+      expect(item.phase).toBe("impl");
+      expect(item.prState).toBe("open");
+      expect(item.ciStatus).toBe("none");
+      expect(item.reviewStatus).toBe("none");
+      expect(item.createdAt).toBeTruthy();
+      expect(item.updatedAt).toBeTruthy();
+    });
+
+    test("creates with custom id", () => {
+      const db = createDb();
+      const item = db.createWorkItem({ id: "custom-id", issueNumber: 1 });
+      expect(item.id).toBe("custom-id");
+    });
+
+    test("creates with all fields", () => {
+      const db = createDb();
+      const item = db.createWorkItem({
+        issueNumber: 10,
+        branch: "feat/test",
+        prNumber: 100,
+        prState: "draft",
+        prUrl: "https://github.com/org/repo/pull/100",
+        ciStatus: "running",
+        ciRunId: 999,
+        ciSummary: "2/5 passed",
+        reviewStatus: "pending",
+        phase: "review",
+      });
+
+      expect(item.issueNumber).toBe(10);
+      expect(item.branch).toBe("feat/test");
+      expect(item.prNumber).toBe(100);
+      expect(item.prState).toBe("draft");
+      expect(item.prUrl).toBe("https://github.com/org/repo/pull/100");
+      expect(item.ciStatus).toBe("running");
+      expect(item.ciRunId).toBe(999);
+      expect(item.ciSummary).toBe("2/5 passed");
+      expect(item.reviewStatus).toBe("pending");
+      expect(item.phase).toBe("review");
+    });
+
+    test("rejects duplicate pr_number", () => {
+      const db = createDb();
+      db.createWorkItem({ prNumber: 50 });
+      expect(() => db.createWorkItem({ prNumber: 50 })).toThrow();
+    });
+  });
+
+  describe("getWorkItem", () => {
+    test("returns null for missing id", () => {
+      const db = createDb();
+      expect(db.getWorkItem("nonexistent")).toBeNull();
+    });
+
+    test("returns created item", () => {
+      const db = createDb();
+      const created = db.createWorkItem({ issueNumber: 7 });
+      const fetched = db.getWorkItem(created.id);
+      expect(fetched).toEqual(created);
+    });
+  });
+
+  describe("updateWorkItem", () => {
+    test("updates a single field", () => {
+      const db = createDb();
+      const item = db.createWorkItem({ issueNumber: 1 });
+      const updated = db.updateWorkItem(item.id, { phase: "review" });
+      expect(updated.phase).toBe("review");
+      expect(updated.issueNumber).toBe(1);
+    });
+
+    test("bumps updated_at", () => {
+      const db = createDb();
+      const item = db.createWorkItem({ issueNumber: 1 });
+      const updated = db.updateWorkItem(item.id, { ciStatus: "passed" });
+      // updated_at should be set (may or may not differ from createdAt within the same second)
+      expect(updated.updatedAt).toBeTruthy();
+    });
+
+    test("updates multiple fields", () => {
+      const db = createDb();
+      const item = db.createWorkItem({ issueNumber: 1 });
+      const updated = db.updateWorkItem(item.id, {
+        prNumber: 200,
+        prState: "merged",
+        phase: "done",
+        ciStatus: "passed",
+        reviewStatus: "approved",
+      });
+      expect(updated.prNumber).toBe(200);
+      expect(updated.prState).toBe("merged");
+      expect(updated.phase).toBe("done");
+      expect(updated.ciStatus).toBe("passed");
+      expect(updated.reviewStatus).toBe("approved");
+    });
+
+    test("throws for nonexistent item", () => {
+      const db = createDb();
+      expect(() => db.updateWorkItem("nope", { phase: "done" })).toThrow("work item not found");
+    });
+
+    test("no-op patch returns existing item unchanged", () => {
+      const db = createDb();
+      const item = db.createWorkItem({ issueNumber: 1 });
+      const same = db.updateWorkItem(item.id, {});
+      expect(same).toEqual(item);
+    });
+  });
+
+  describe("deleteWorkItem", () => {
+    test("removes item", () => {
+      const db = createDb();
+      const item = db.createWorkItem({ issueNumber: 1 });
+      db.deleteWorkItem(item.id);
+      expect(db.getWorkItem(item.id)).toBeNull();
+    });
+
+    test("no-op for missing id", () => {
+      const db = createDb();
+      expect(() => db.deleteWorkItem("missing")).not.toThrow();
+    });
+  });
+
+  describe("listWorkItems", () => {
+    test("returns all items ordered by created_at", () => {
+      const db = createDb();
+      db.createWorkItem({ issueNumber: 1 });
+      db.createWorkItem({ issueNumber: 2 });
+      db.createWorkItem({ issueNumber: 3 });
+      const items = db.listWorkItems();
+      expect(items).toHaveLength(3);
+      expect(items.map((i) => i.issueNumber)).toEqual([1, 2, 3]);
+    });
+
+    test("filters by phase", () => {
+      const db = createDb();
+      db.createWorkItem({ issueNumber: 1, phase: "impl" });
+      db.createWorkItem({ issueNumber: 2, phase: "review" });
+      db.createWorkItem({ issueNumber: 3, phase: "impl" });
+
+      const implItems = db.listWorkItems({ phase: "impl" });
+      expect(implItems).toHaveLength(2);
+      expect(implItems.map((i) => i.issueNumber)).toEqual([1, 3]);
+
+      const reviewItems = db.listWorkItems({ phase: "review" });
+      expect(reviewItems).toHaveLength(1);
+      expect(reviewItems[0].issueNumber).toBe(2);
+    });
+
+    test("returns empty array when no items", () => {
+      const db = createDb();
+      expect(db.listWorkItems()).toEqual([]);
+    });
+  });
+
+  describe("getWorkItemByPr", () => {
+    test("finds by PR number", () => {
+      const db = createDb();
+      db.createWorkItem({ issueNumber: 1, prNumber: 101 });
+      db.createWorkItem({ issueNumber: 2, prNumber: 102 });
+
+      const item = db.getWorkItemByPr(101);
+      expect(item).not.toBeNull();
+      expect(item?.issueNumber).toBe(1);
+    });
+
+    test("returns null for unknown PR", () => {
+      const db = createDb();
+      expect(db.getWorkItemByPr(999)).toBeNull();
+    });
+  });
+
+  describe("getWorkItemByIssue", () => {
+    test("finds by issue number", () => {
+      const db = createDb();
+      db.createWorkItem({ issueNumber: 42, branch: "feat/42" });
+      const item = db.getWorkItemByIssue(42);
+      expect(item).not.toBeNull();
+      expect(item?.branch).toBe("feat/42");
+    });
+
+    test("returns null for unknown issue", () => {
+      const db = createDb();
+      expect(db.getWorkItemByIssue(999)).toBeNull();
+    });
+  });
+
+  describe("migration idempotency", () => {
+    test("calling constructor twice on same db does not error", () => {
+      const p = tmpDb();
+      paths.push(p);
+      const raw = new Database(p, { create: true });
+      raw.exec("PRAGMA journal_mode = WAL");
+      new WorkItemDb(raw);
+      // Second call should be fine (CREATE TABLE IF NOT EXISTS)
+      expect(() => new WorkItemDb(raw)).not.toThrow();
+    });
+  });
+});

--- a/packages/daemon/src/db/work-items.ts
+++ b/packages/daemon/src/db/work-items.ts
@@ -1,0 +1,201 @@
+/**
+ * SQLite persistence for work items (sprint tracking).
+ *
+ * Standalone module — takes a bun:sqlite Database instance so it can share
+ * the daemon's existing connection or be used independently in tests.
+ */
+
+import type { Database } from "bun:sqlite";
+import { randomUUIDv7 } from "bun";
+
+// ---------- Types (local until #1136 lands in core) ----------
+
+export type WorkItemPhase = "impl" | "review" | "repair" | "qa" | "done";
+export type PrState = "open" | "closed" | "merged" | "draft";
+export type CiStatus = "none" | "pending" | "running" | "passed" | "failed";
+export type ReviewStatus = "none" | "pending" | "approved" | "changes_requested";
+
+export interface WorkItem {
+  id: string;
+  issueNumber: number | null;
+  branch: string | null;
+  prNumber: number | null;
+  prState: PrState;
+  prUrl: string | null;
+  ciStatus: CiStatus;
+  ciRunId: number | null;
+  ciSummary: string | null;
+  reviewStatus: ReviewStatus;
+  phase: WorkItemPhase;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** Snake-case row shape from SQLite. */
+interface WorkItemRow {
+  id: string;
+  issue_number: number | null;
+  branch: string | null;
+  pr_number: number | null;
+  pr_state: string;
+  pr_url: string | null;
+  ci_status: string;
+  ci_run_id: number | null;
+  ci_summary: string | null;
+  review_status: string;
+  phase: string;
+  created_at: string;
+  updated_at: string;
+}
+
+function rowToWorkItem(row: WorkItemRow): WorkItem {
+  return {
+    id: row.id,
+    issueNumber: row.issue_number,
+    branch: row.branch,
+    prNumber: row.pr_number,
+    prState: row.pr_state as PrState,
+    prUrl: row.pr_url,
+    ciStatus: row.ci_status as CiStatus,
+    ciRunId: row.ci_run_id,
+    ciSummary: row.ci_summary,
+    reviewStatus: row.review_status as ReviewStatus,
+    phase: row.phase as WorkItemPhase,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+// ---------- DB class ----------
+
+export class WorkItemDb {
+  private db: Database;
+
+  constructor(db: Database) {
+    this.db = db;
+    this.migrate();
+  }
+
+  private migrate(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS work_items (
+        id              TEXT PRIMARY KEY,
+        issue_number    INTEGER,
+        branch          TEXT,
+        pr_number       INTEGER UNIQUE,
+        pr_state        TEXT DEFAULT 'open',
+        pr_url          TEXT,
+        ci_status       TEXT DEFAULT 'none',
+        ci_run_id       INTEGER,
+        ci_summary      TEXT,
+        review_status   TEXT DEFAULT 'none',
+        phase           TEXT DEFAULT 'impl',
+        created_at      TEXT DEFAULT (datetime('now')),
+        updated_at      TEXT DEFAULT (datetime('now'))
+      )
+    `);
+  }
+
+  createWorkItem(item: Partial<WorkItem>): WorkItem {
+    const id = item.id ?? randomUUIDv7();
+    this.db
+      .query(
+        `INSERT INTO work_items (id, issue_number, branch, pr_number, pr_state, pr_url, ci_status, ci_run_id, ci_summary, review_status, phase)
+         VALUES ($id, $issue_number, $branch, $pr_number, $pr_state, $pr_url, $ci_status, $ci_run_id, $ci_summary, $review_status, $phase)`,
+      )
+      .run({
+        $id: id,
+        $issue_number: item.issueNumber ?? null,
+        $branch: item.branch ?? null,
+        $pr_number: item.prNumber ?? null,
+        $pr_state: item.prState ?? "open",
+        $pr_url: item.prUrl ?? null,
+        $ci_status: item.ciStatus ?? "none",
+        $ci_run_id: item.ciRunId ?? null,
+        $ci_summary: item.ciSummary ?? null,
+        $review_status: item.reviewStatus ?? "none",
+        $phase: item.phase ?? "impl",
+      });
+
+    // We just inserted with this id, so the row must exist
+    const created = this.getWorkItem(id);
+    if (!created) throw new Error(`failed to read back work item: ${id}`);
+    return created;
+  }
+
+  getWorkItem(id: string): WorkItem | null {
+    const row = this.db.query<WorkItemRow, [string]>("SELECT * FROM work_items WHERE id = ?").get(id);
+    return row ? rowToWorkItem(row) : null;
+  }
+
+  updateWorkItem(id: string, patch: Partial<WorkItem>): WorkItem {
+    const existing = this.getWorkItem(id);
+    if (!existing) {
+      throw new Error(`work item not found: ${id}`);
+    }
+
+    const fields: string[] = [];
+    const values: Record<string, unknown> = { $id: id };
+
+    const mappings: Array<[keyof WorkItem, string]> = [
+      ["issueNumber", "issue_number"],
+      ["branch", "branch"],
+      ["prNumber", "pr_number"],
+      ["prState", "pr_state"],
+      ["prUrl", "pr_url"],
+      ["ciStatus", "ci_status"],
+      ["ciRunId", "ci_run_id"],
+      ["ciSummary", "ci_summary"],
+      ["reviewStatus", "review_status"],
+      ["phase", "phase"],
+    ];
+
+    for (const [key, col] of mappings) {
+      if (key in patch) {
+        fields.push(`${col} = $${col}`);
+        values[`$${col}`] = patch[key] ?? null;
+      }
+    }
+
+    if (fields.length === 0) {
+      return existing;
+    }
+
+    // Always bump updated_at
+    fields.push("updated_at = datetime('now')");
+
+    this.db
+      .prepare(`UPDATE work_items SET ${fields.join(", ")} WHERE id = $id`)
+      .run(values as Record<string, string | number | null>);
+
+    const updated = this.getWorkItem(id);
+    if (!updated) throw new Error(`failed to read back work item: ${id}`);
+    return updated;
+  }
+
+  deleteWorkItem(id: string): void {
+    this.db.query("DELETE FROM work_items WHERE id = ?").run(id);
+  }
+
+  listWorkItems(filter?: { phase?: string }): WorkItem[] {
+    if (filter?.phase) {
+      return this.db
+        .query<WorkItemRow, [string]>("SELECT * FROM work_items WHERE phase = ? ORDER BY created_at")
+        .all(filter.phase)
+        .map(rowToWorkItem);
+    }
+    return this.db.query<WorkItemRow, []>("SELECT * FROM work_items ORDER BY created_at").all().map(rowToWorkItem);
+  }
+
+  getWorkItemByPr(prNumber: number): WorkItem | null {
+    const row = this.db.query<WorkItemRow, [number]>("SELECT * FROM work_items WHERE pr_number = ?").get(prNumber);
+    return row ? rowToWorkItem(row) : null;
+  }
+
+  getWorkItemByIssue(issueNumber: number): WorkItem | null {
+    const row = this.db
+      .query<WorkItemRow, [number]>("SELECT * FROM work_items WHERE issue_number = ?")
+      .get(issueNumber);
+    return row ? rowToWorkItem(row) : null;
+  }
+}


### PR DESCRIPTION
## Summary
- Add `WorkItemDb` class in `packages/daemon/src/db/work-items.ts` with full CRUD: `createWorkItem`, `getWorkItem`, `updateWorkItem`, `deleteWorkItem`, `listWorkItems` (with phase filter), `getWorkItemByPr`, `getWorkItemByIssue`
- Migration creates `work_items` table via `CREATE TABLE IF NOT EXISTS` (idempotent, runs in constructor)
- `updated_at` auto-bumps on every update; types defined locally until #1136 lands in core

## Test plan
- [x] 21 unit tests covering all CRUD operations, edge cases (duplicate PR, missing ID, empty patch, migration idempotency)
- [x] 100% function and line coverage
- [x] `bun typecheck` passes
- [x] `bun lint` passes (no errors in new files)
- [x] Full test suite passes (2791 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)