### PR TITLE
feat(command): mcx track/untrack/tracked CLI commands (fixes #1139)

### DIFF
--- a/packages/command/src/commands/completions.ts
+++ b/packages/command/src/commands/completions.ts
@@ -54,6 +54,9 @@ export const SUBCOMMANDS = [
   "help",
   "agent",
   "claude",
+  "track",
+  "untrack",
+  "tracked",
 ] as const;
 
 /** Subcommands for `mcx alias` */

--- a/packages/command/src/commands/track.spec.ts
+++ b/packages/command/src/commands/track.spec.ts
@@ -31,7 +31,7 @@ function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
     id: "#1135",
     issueNumber: 1135,
     branch: "feat/issue-1135-cleanup",
-    prNumber: 1135,
+    prNumber: null,
     prState: "open",
     prUrl: null,
     ciStatus: "passed",
@@ -94,6 +94,15 @@ describe("cmdTrack", () => {
     const deps = makeDeps();
     await expect(cmdTrack(["--branch"], deps)).rejects.toThrow("exit(1)");
   });
+
+  test("handles IPC error gracefully", async () => {
+    const deps = makeDeps({
+      trackWorkItem: () => {
+        throw new Error("daemon unavailable");
+      },
+    });
+    await expect(cmdTrack(["1135"], deps)).rejects.toThrow("exit(1)");
+  });
 });
 
 describe("cmdUntrack", () => {
@@ -110,6 +119,19 @@ describe("cmdUntrack", () => {
     expect(captured).toEqual({ number: 1135 });
   });
 
+  test("untracks a branch", async () => {
+    let captured: unknown;
+    const deps = makeDeps({
+      untrackWorkItem: (params: unknown) => {
+        captured = params;
+        return { ok: true, deleted: true };
+      },
+    });
+
+    await cmdUntrack(["--branch", "feat/test"], deps);
+    expect(captured).toEqual({ branch: "feat/test" });
+  });
+
   test("handles not tracked", async () => {
     const deps = makeDeps({
       untrackWorkItem: () => ({ ok: true, deleted: false }),
@@ -119,14 +141,36 @@ describe("cmdUntrack", () => {
     await cmdUntrack(["999"], deps);
   });
 
+  test("handles branch not tracked", async () => {
+    const deps = makeDeps({
+      untrackWorkItem: () => ({ ok: true, deleted: false }),
+    });
+
+    await cmdUntrack(["--branch", "feat/nonexistent"], deps);
+  });
+
   test("rejects invalid number", async () => {
     const deps = makeDeps();
     await expect(cmdUntrack(["abc"], deps)).rejects.toThrow("exit(1)");
   });
 
+  test("rejects missing branch name", async () => {
+    const deps = makeDeps();
+    await expect(cmdUntrack(["--branch"], deps)).rejects.toThrow("exit(1)");
+  });
+
   test("prints help with no args", async () => {
     const deps = makeDeps();
     await cmdUntrack([], deps);
+  });
+
+  test("handles IPC error gracefully", async () => {
+    const deps = makeDeps({
+      untrackWorkItem: () => {
+        throw new Error("daemon unavailable");
+      },
+    });
+    await expect(cmdUntrack(["1135"], deps)).rejects.toThrow("exit(1)");
   });
 });
 
@@ -194,11 +238,36 @@ describe("cmdTracked", () => {
     await cmdTracked(["--phase", "qa"], deps);
     expect(captured).toEqual({ phase: "qa" });
   });
+
+  test("rejects --phase with no value", async () => {
+    const deps = makeDeps();
+    await expect(cmdTracked(["--phase"], deps)).rejects.toThrow("exit(1)");
+  });
+
+  test("rejects --phase followed by another flag", async () => {
+    const deps = makeDeps();
+    await expect(cmdTracked(["--phase", "--json"], deps)).rejects.toThrow("exit(1)");
+  });
+
+  test("rejects unknown phase value", async () => {
+    const deps = makeDeps();
+    await expect(cmdTracked(["--phase", "bogus"], deps)).rejects.toThrow("exit(1)");
+  });
+
+  test("handles IPC error gracefully", async () => {
+    const deps = makeDeps({
+      listWorkItems: () => {
+        throw new Error("daemon unavailable");
+      },
+    });
+    await expect(cmdTracked(["--json"], deps)).rejects.toThrow("exit(1)");
+  });
 });
 
 describe("formatWorkItemRow", () => {
   test("formats a work item with all fields", () => {
     const item = makeWorkItem({
+      prNumber: 1135,
       ciStatus: "passed",
       reviewStatus: "approved",
       phase: "qa",

--- a/packages/command/src/commands/track.spec.ts
+++ b/packages/command/src/commands/track.spec.ts
@@ -1,0 +1,241 @@
+import { describe, expect, test } from "bun:test";
+import type { IpcMethod, IpcMethodResult, WorkItem } from "@mcp-cli/core";
+import type { TrackDeps } from "./track";
+import { cmdTrack, cmdTracked, cmdUntrack, formatWorkItemRow } from "./track";
+
+class ExitError extends Error {
+  code: number;
+  constructor(code: number) {
+    super(`exit(${code})`);
+    this.code = code;
+  }
+}
+
+function makeDeps(overrides: Partial<Record<IpcMethod, unknown>> = {}): TrackDeps {
+  return {
+    ipcCall: async <M extends IpcMethod>(method: M, params?: unknown): Promise<IpcMethodResult[M]> => {
+      if (method in overrides) {
+        const fn = overrides[method];
+        return (typeof fn === "function" ? fn(params) : fn) as IpcMethodResult[M];
+      }
+      throw new Error(`Unexpected IPC call: ${method}`);
+    },
+    exit: (code: number): never => {
+      throw new ExitError(code);
+    },
+  };
+}
+
+function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
+  return {
+    id: "#1135",
+    issueNumber: 1135,
+    branch: "feat/issue-1135-cleanup",
+    prNumber: 1135,
+    prState: "open",
+    prUrl: null,
+    ciStatus: "passed",
+    ciRunId: null,
+    ciSummary: null,
+    reviewStatus: "none",
+    phase: "impl",
+    createdAt: "2026-04-01T00:00:00Z",
+    updatedAt: "2026-04-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("cmdTrack", () => {
+  test("tracks a number", async () => {
+    let captured: unknown;
+    const item = makeWorkItem();
+    const deps = makeDeps({
+      trackWorkItem: (params: unknown) => {
+        captured = params;
+        return item;
+      },
+    });
+
+    await cmdTrack(["1135"], deps);
+    expect(captured).toEqual({ number: 1135 });
+  });
+
+  test("tracks a branch", async () => {
+    let captured: unknown;
+    const item = makeWorkItem({ id: "branch:feat/test", branch: "feat/test" });
+    const deps = makeDeps({
+      trackWorkItem: (params: unknown) => {
+        captured = params;
+        return item;
+      },
+    });
+
+    await cmdTrack(["--branch", "feat/test"], deps);
+    expect(captured).toEqual({ branch: "feat/test" });
+  });
+
+  test("rejects missing args", async () => {
+    const deps = makeDeps();
+    // No args — prints help, doesn't exit
+    await cmdTrack([], deps);
+  });
+
+  test("rejects invalid number", async () => {
+    const deps = makeDeps();
+    await expect(cmdTrack(["abc"], deps)).rejects.toThrow("exit(1)");
+  });
+
+  test("rejects zero", async () => {
+    const deps = makeDeps();
+    await expect(cmdTrack(["0"], deps)).rejects.toThrow("exit(1)");
+  });
+
+  test("rejects missing branch name", async () => {
+    const deps = makeDeps();
+    await expect(cmdTrack(["--branch"], deps)).rejects.toThrow("exit(1)");
+  });
+});
+
+describe("cmdUntrack", () => {
+  test("untracks a number", async () => {
+    let captured: unknown;
+    const deps = makeDeps({
+      untrackWorkItem: (params: unknown) => {
+        captured = params;
+        return { ok: true, deleted: true };
+      },
+    });
+
+    await cmdUntrack(["1135"], deps);
+    expect(captured).toEqual({ number: 1135 });
+  });
+
+  test("handles not tracked", async () => {
+    const deps = makeDeps({
+      untrackWorkItem: () => ({ ok: true, deleted: false }),
+    });
+
+    // Should not throw
+    await cmdUntrack(["999"], deps);
+  });
+
+  test("rejects invalid number", async () => {
+    const deps = makeDeps();
+    await expect(cmdUntrack(["abc"], deps)).rejects.toThrow("exit(1)");
+  });
+
+  test("prints help with no args", async () => {
+    const deps = makeDeps();
+    await cmdUntrack([], deps);
+  });
+});
+
+describe("cmdTracked", () => {
+  test("outputs JSON with --json", async () => {
+    const items = [makeWorkItem()];
+    const deps = makeDeps({ listWorkItems: items });
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+    try {
+      await cmdTracked(["--json"], deps);
+    } finally {
+      console.log = origLog;
+    }
+
+    const parsed = JSON.parse(logs.join(""));
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].id).toBe("#1135");
+  });
+
+  test("outputs table for human-readable", async () => {
+    const items = [makeWorkItem(), makeWorkItem({ id: "#1120", prNumber: 1131, phase: "qa", ciStatus: "running" })];
+    const deps = makeDeps({ listWorkItems: items });
+
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (msg: string) => logs.push(msg);
+    try {
+      await cmdTracked([], deps);
+    } finally {
+      console.log = origLog;
+    }
+
+    expect(logs).toHaveLength(2);
+    expect(logs[0]).toContain("#1135");
+    expect(logs[1]).toContain("#1120");
+  });
+
+  test("shows empty message when no items", async () => {
+    const deps = makeDeps({ listWorkItems: [] });
+
+    const errors: string[] = [];
+    const origErr = console.error;
+    console.error = (msg: string) => errors.push(msg);
+    try {
+      await cmdTracked([], deps);
+    } finally {
+      console.error = origErr;
+    }
+
+    expect(errors[0]).toContain("No tracked work items");
+  });
+
+  test("passes phase filter", async () => {
+    let captured: unknown;
+    const deps = makeDeps({
+      listWorkItems: (params: unknown) => {
+        captured = params;
+        return [];
+      },
+    });
+
+    await cmdTracked(["--phase", "qa"], deps);
+    expect(captured).toEqual({ phase: "qa" });
+  });
+});
+
+describe("formatWorkItemRow", () => {
+  test("formats a work item with all fields", () => {
+    const item = makeWorkItem({
+      ciStatus: "passed",
+      reviewStatus: "approved",
+      phase: "qa",
+    });
+    const row = formatWorkItemRow(item);
+    expect(row).toContain("#1135");
+    expect(row).toContain("PR #1135");
+    expect(row).toContain("CI");
+    expect(row).toContain("phase: qa");
+  });
+
+  test("formats item without PR", () => {
+    const item = makeWorkItem({ prNumber: null });
+    const row = formatWorkItemRow(item);
+    expect(row).toContain("#1135");
+    expect(row).not.toContain("PR #");
+  });
+
+  test("formats various CI statuses", () => {
+    for (const status of ["none", "pending", "running", "passed", "failed"] as const) {
+      const item = makeWorkItem({ ciStatus: status });
+      const row = formatWorkItemRow(item);
+      expect(row).toContain("CI");
+    }
+  });
+
+  test("formats various review statuses", () => {
+    for (const status of ["none", "pending", "approved", "changes_requested"] as const) {
+      const item = makeWorkItem({ reviewStatus: status });
+      const row = formatWorkItemRow(item);
+      expect(row).toContain("review:");
+    }
+  });
+
+  test("includes branch when present", () => {
+    const item = makeWorkItem({ branch: "feat/issue-1135-cleanup" });
+    const row = formatWorkItemRow(item);
+    expect(row).toContain("feat/issue-1135-cleanup");
+  });
+});

--- a/packages/command/src/commands/track.ts
+++ b/packages/command/src/commands/track.ts
@@ -1,0 +1,155 @@
+/**
+ * mcx track/untrack/tracked — work item tracking commands.
+ *
+ * Track:   mcx track <number>           Track a PR or issue
+ *          mcx track --branch <name>    Track a branch
+ * Untrack: mcx untrack <number>         Stop tracking
+ * List:    mcx tracked                  Human-readable table
+ *          mcx tracked --json           Machine-readable output
+ */
+
+import type { IpcMethod, IpcMethodResult, WorkItem } from "@mcp-cli/core";
+import { ipcCall } from "@mcp-cli/core";
+import { c, printError } from "../output";
+
+export interface TrackDeps {
+  ipcCall: <M extends IpcMethod>(method: M, params?: unknown) => Promise<IpcMethodResult[M]>;
+  exit: (code: number) => never;
+}
+
+const defaultDeps: TrackDeps = {
+  ipcCall,
+  exit: (code) => process.exit(code),
+};
+
+// -- mcx track --
+
+export async function cmdTrack(args: string[], deps: TrackDeps = defaultDeps): Promise<void> {
+  if (!args.length || args[0] === "--help" || args[0] === "-h") {
+    printTrackHelp();
+    return;
+  }
+
+  if (args[0] === "--branch") {
+    const branch = args[1];
+    if (!branch) {
+      printError("Usage: mcx track --branch <name>");
+      deps.exit(1);
+    }
+    const item = await deps.ipcCall("trackWorkItem", { branch });
+    console.error(`Tracking branch ${branch} (${item.id})`);
+    return;
+  }
+
+  const num = Number(args[0]);
+  if (!Number.isInteger(num) || num <= 0) {
+    printError(`Invalid number: ${args[0]}`);
+    deps.exit(1);
+  }
+
+  const item = await deps.ipcCall("trackWorkItem", { number: num });
+  console.error(`Tracking #${num} (${item.id})`);
+}
+
+// -- mcx untrack --
+
+export async function cmdUntrack(args: string[], deps: TrackDeps = defaultDeps): Promise<void> {
+  if (!args.length || args[0] === "--help" || args[0] === "-h") {
+    console.log("Usage: mcx untrack <number>");
+    return;
+  }
+
+  const num = Number(args[0]);
+  if (!Number.isInteger(num) || num <= 0) {
+    printError(`Invalid number: ${args[0]}`);
+    deps.exit(1);
+  }
+
+  const result = await deps.ipcCall("untrackWorkItem", { number: num });
+  if (result.deleted) {
+    console.error(`Untracked #${num}`);
+  } else {
+    console.error(`#${num} was not tracked`);
+  }
+}
+
+// -- mcx tracked --
+
+export async function cmdTracked(args: string[], deps: TrackDeps = defaultDeps): Promise<void> {
+  if (args[0] === "--help" || args[0] === "-h") {
+    console.log("Usage: mcx tracked [--json] [--phase <phase>]");
+    return;
+  }
+
+  const jsonFlag = args.includes("--json");
+  const phaseIdx = args.indexOf("--phase");
+  const phase = phaseIdx >= 0 ? args[phaseIdx + 1] : undefined;
+
+  const items = await deps.ipcCall("listWorkItems", phase ? { phase } : {});
+
+  if (jsonFlag) {
+    console.log(JSON.stringify(items, null, 2));
+    return;
+  }
+
+  if (items.length === 0) {
+    console.error("No tracked work items. Use `mcx track <number>` to start tracking.");
+    return;
+  }
+
+  for (const item of items) {
+    console.log(formatWorkItemRow(item));
+  }
+}
+
+// -- Formatting --
+
+const CI_ICONS: Record<string, string> = {
+  none: "-",
+  pending: "\u23F3",
+  running: "\u23F3",
+  passed: "\u2713",
+  failed: "\u2717",
+};
+
+const REVIEW_ICONS: Record<string, string> = {
+  none: "none",
+  pending: "pending",
+  approved: "\u2713",
+  changes_requested: "\u2717",
+};
+
+/** Format a single work item as a scannable row. */
+export function formatWorkItemRow(item: WorkItem): string {
+  const id = item.id.padEnd(10);
+  const pr = item.prNumber ? `PR #${item.prNumber}` : "      ";
+  const prPad = pr.padEnd(10);
+  const ci = `CI ${CI_ICONS[item.ciStatus] ?? item.ciStatus}`;
+  const ciPad = ci.padEnd(8);
+  const review = `review: ${REVIEW_ICONS[item.reviewStatus] ?? item.reviewStatus}`;
+  const reviewPad = review.padEnd(20);
+  const phase = `phase: ${item.phase}`;
+  const phasePad = phase.padEnd(14);
+  const branch = item.branch ? `  ${c.dim}${item.branch}${c.reset}` : "";
+
+  return `${c.cyan}${id}${c.reset}  ${prPad}  ${ciPad}  ${reviewPad}  ${phasePad}${branch}`;
+}
+
+function printTrackHelp(): void {
+  console.log(`mcx track — work item tracking
+
+Usage:
+  mcx track <number>           Track a PR or issue number
+  mcx track --branch <name>    Track a branch (PR may not exist yet)
+  mcx untrack <number>         Stop tracking a work item
+  mcx tracked                  List all tracked work items
+  mcx tracked --json           Machine-readable output
+  mcx tracked --phase <phase>  Filter by phase (impl, review, repair, qa, done)
+
+Examples:
+  mcx track 1135
+  mcx track --branch feat/new-feature
+  mcx untrack 1135
+  mcx tracked
+  mcx tracked --json`);
+}

--- a/packages/command/src/commands/track.ts
+++ b/packages/command/src/commands/track.ts
@@ -1,15 +1,16 @@
 /**
  * mcx track/untrack/tracked — work item tracking commands.
  *
- * Track:   mcx track <number>           Track a PR or issue
+ * Track:   mcx track <number>           Track an issue/PR by number
  *          mcx track --branch <name>    Track a branch
- * Untrack: mcx untrack <number>         Stop tracking
+ * Untrack: mcx untrack <number>         Stop tracking by number
+ *          mcx untrack --branch <name>  Stop tracking by branch
  * List:    mcx tracked                  Human-readable table
  *          mcx tracked --json           Machine-readable output
  */
 
-import type { IpcMethod, IpcMethodResult, WorkItem } from "@mcp-cli/core";
-import { ipcCall } from "@mcp-cli/core";
+import type { IpcMethod, IpcMethodResult, WorkItem, WorkItemPhase } from "@mcp-cli/core";
+import { WORK_ITEM_PHASES, ipcCall } from "@mcp-cli/core";
 import { c, printError } from "../output";
 
 export interface TrackDeps {
@@ -34,42 +35,77 @@ export async function cmdTrack(args: string[], deps: TrackDeps = defaultDeps): P
     const branch = args[1];
     if (!branch) {
       printError("Usage: mcx track --branch <name>");
-      deps.exit(1);
+      return deps.exit(1);
     }
-    const item = await deps.ipcCall("trackWorkItem", { branch });
-    console.error(`Tracking branch ${branch} (${item.id})`);
+    try {
+      const item = await deps.ipcCall("trackWorkItem", { branch });
+      console.error(`Tracking branch ${branch} (${item.id})`);
+    } catch (err) {
+      printError(`Failed to track branch: ${err instanceof Error ? err.message : String(err)}`);
+      return deps.exit(1);
+    }
     return;
   }
 
   const num = Number(args[0]);
   if (!Number.isInteger(num) || num <= 0) {
     printError(`Invalid number: ${args[0]}`);
-    deps.exit(1);
+    return deps.exit(1);
   }
 
-  const item = await deps.ipcCall("trackWorkItem", { number: num });
-  console.error(`Tracking #${num} (${item.id})`);
+  try {
+    const item = await deps.ipcCall("trackWorkItem", { number: num });
+    console.error(`Tracking #${num} (${item.id})`);
+  } catch (err) {
+    printError(`Failed to track #${num}: ${err instanceof Error ? err.message : String(err)}`);
+    return deps.exit(1);
+  }
 }
 
 // -- mcx untrack --
 
 export async function cmdUntrack(args: string[], deps: TrackDeps = defaultDeps): Promise<void> {
   if (!args.length || args[0] === "--help" || args[0] === "-h") {
-    console.log("Usage: mcx untrack <number>");
+    console.log("Usage: mcx untrack <number>\n       mcx untrack --branch <name>");
+    return;
+  }
+
+  if (args[0] === "--branch") {
+    const branch = args[1];
+    if (!branch) {
+      printError("Usage: mcx untrack --branch <name>");
+      return deps.exit(1);
+    }
+    try {
+      const result = await deps.ipcCall("untrackWorkItem", { branch });
+      if (result.deleted) {
+        console.error(`Untracked branch ${branch}`);
+      } else {
+        console.error(`Branch ${branch} was not tracked`);
+      }
+    } catch (err) {
+      printError(`Failed to untrack branch: ${err instanceof Error ? err.message : String(err)}`);
+      return deps.exit(1);
+    }
     return;
   }
 
   const num = Number(args[0]);
   if (!Number.isInteger(num) || num <= 0) {
     printError(`Invalid number: ${args[0]}`);
-    deps.exit(1);
+    return deps.exit(1);
   }
 
-  const result = await deps.ipcCall("untrackWorkItem", { number: num });
-  if (result.deleted) {
-    console.error(`Untracked #${num}`);
-  } else {
-    console.error(`#${num} was not tracked`);
+  try {
+    const result = await deps.ipcCall("untrackWorkItem", { number: num });
+    if (result.deleted) {
+      console.error(`Untracked #${num}`);
+    } else {
+      console.error(`#${num} was not tracked`);
+    }
+  } catch (err) {
+    printError(`Failed to untrack #${num}: ${err instanceof Error ? err.message : String(err)}`);
+    return deps.exit(1);
   }
 }
 
@@ -83,22 +119,40 @@ export async function cmdTracked(args: string[], deps: TrackDeps = defaultDeps):
 
   const jsonFlag = args.includes("--json");
   const phaseIdx = args.indexOf("--phase");
-  const phase = phaseIdx >= 0 ? args[phaseIdx + 1] : undefined;
+  let phase: WorkItemPhase | undefined;
 
-  const items = await deps.ipcCall("listWorkItems", phase ? { phase } : {});
-
-  if (jsonFlag) {
-    console.log(JSON.stringify(items, null, 2));
-    return;
+  if (phaseIdx >= 0) {
+    const raw = args[phaseIdx + 1];
+    if (!raw || raw.startsWith("--")) {
+      printError(`--phase requires a value: ${WORK_ITEM_PHASES.join(", ")}`);
+      return deps.exit(1);
+    }
+    if (!WORK_ITEM_PHASES.includes(raw as WorkItemPhase)) {
+      printError(`Unknown phase "${raw}". Valid phases: ${WORK_ITEM_PHASES.join(", ")}`);
+      return deps.exit(1);
+    }
+    phase = raw as WorkItemPhase;
   }
 
-  if (items.length === 0) {
-    console.error("No tracked work items. Use `mcx track <number>` to start tracking.");
-    return;
-  }
+  try {
+    const items = await deps.ipcCall("listWorkItems", phase ? { phase } : {});
 
-  for (const item of items) {
-    console.log(formatWorkItemRow(item));
+    if (jsonFlag) {
+      console.log(JSON.stringify(items, null, 2));
+      return;
+    }
+
+    if (items.length === 0) {
+      console.error("No tracked work items. Use `mcx track <number>` to start tracking.");
+      return;
+    }
+
+    for (const item of items) {
+      console.log(formatWorkItemRow(item));
+    }
+  } catch (err) {
+    printError(`Failed to list work items: ${err instanceof Error ? err.message : String(err)}`);
+    return deps.exit(1);
   }
 }
 
@@ -139,9 +193,10 @@ function printTrackHelp(): void {
   console.log(`mcx track — work item tracking
 
 Usage:
-  mcx track <number>           Track a PR or issue number
+  mcx track <number>           Track an issue/PR by number
   mcx track --branch <name>    Track a branch (PR may not exist yet)
-  mcx untrack <number>         Stop tracking a work item
+  mcx untrack <number>         Stop tracking by number
+  mcx untrack --branch <name>  Stop tracking by branch
   mcx tracked                  List all tracked work items
   mcx tracked --json           Machine-readable output
   mcx tracked --phase <phase>  Filter by phase (impl, review, repair, qa, done)
@@ -150,6 +205,7 @@ Examples:
   mcx track 1135
   mcx track --branch feat/new-feature
   mcx untrack 1135
+  mcx untrack --branch feat/new-feature
   mcx tracked
   mcx tracked --json`);
 }

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -38,6 +38,7 @@ import { cmdScope } from "./commands/scope";
 import { cmdServe } from "./commands/serve";
 import { cmdServeKill } from "./commands/serve-kill";
 import { cmdSpans } from "./commands/spans";
+import { cmdTrack, cmdTracked, cmdUntrack } from "./commands/track";
 import { cmdTty } from "./commands/tty";
 import { cmdTypegen } from "./commands/typegen";
 import { cmdUpdate } from "./commands/update";
@@ -281,6 +282,18 @@ async function main(): Promise<void> {
 
       case "note":
         await cmdNote(cleanArgs.slice(1));
+        break;
+
+      case "track":
+        await cmdTrack(cleanArgs.slice(1));
+        break;
+
+      case "untrack":
+        await cmdUntrack(cleanArgs.slice(1));
+        break;
+
+      case "tracked":
+        await cmdTracked(cleanArgs.slice(1));
         break;
 
       case "typegen":

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -397,17 +397,27 @@ export const DeleteNoteParamsSchema = z.object({
 
 // -- Work item schemas --
 
-export const TrackWorkItemParamsSchema = z.object({
-  /** Issue or PR number to track. */
-  number: z.number().optional(),
-  /** Branch name to track (PR may not exist yet). */
-  branch: z.string().optional(),
-});
+export const TrackWorkItemParamsSchema = z
+  .object({
+    /** Issue or PR number to track. */
+    number: z.number().optional(),
+    /** Branch name to track (PR may not exist yet). */
+    branch: z.string().optional(),
+  })
+  .refine((p) => p.number != null || p.branch != null, {
+    message: "Either number or branch is required",
+  });
 
-export const UntrackWorkItemParamsSchema = z.object({
-  /** Issue or PR number to untrack. */
-  number: z.number(),
-});
+export const UntrackWorkItemParamsSchema = z
+  .object({
+    /** Issue or PR number to untrack. */
+    number: z.number().optional(),
+    /** Branch name to untrack. */
+    branch: z.string().optional(),
+  })
+  .refine((p) => p.number != null || p.branch != null, {
+    message: "Either number or branch is required",
+  });
 
 export const ListWorkItemsParamsSchema = z.object({
   /** Filter by phase. */

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -9,6 +9,7 @@ import { z } from "zod/v4";
 import type { AliasType } from "./alias";
 import type { PlanProtocolCapability } from "./plan";
 import type { SpanEvent } from "./trace";
+import type { WorkItem } from "./work-item";
 
 // -- Methods --
 
@@ -52,7 +53,10 @@ export type IpcMethod =
   | "setNote"
   | "getNote"
   | "listNotes"
-  | "deleteNote";
+  | "deleteNote"
+  | "trackWorkItem"
+  | "untrackWorkItem"
+  | "listWorkItems";
 
 // -- Request/Response --
 
@@ -391,6 +395,25 @@ export const DeleteNoteParamsSchema = z.object({
   tool: z.string(),
 });
 
+// -- Work item schemas --
+
+export const TrackWorkItemParamsSchema = z.object({
+  /** Issue or PR number to track. */
+  number: z.number().optional(),
+  /** Branch name to track (PR may not exist yet). */
+  branch: z.string().optional(),
+});
+
+export const UntrackWorkItemParamsSchema = z.object({
+  /** Issue or PR number to untrack. */
+  number: z.number(),
+});
+
+export const ListWorkItemsParamsSchema = z.object({
+  /** Filter by phase. */
+  phase: z.string().optional(),
+});
+
 // -- Result types for methods without a named interface --
 
 export interface PingResult {
@@ -578,6 +601,9 @@ export interface IpcMethodResult {
   getNote: { note: string | null };
   listNotes: NoteEntry[];
   deleteNote: { ok: true; deleted: boolean };
+  trackWorkItem: WorkItem;
+  untrackWorkItem: { ok: true; deleted: boolean };
+  listWorkItems: WorkItem[];
 }
 
 // -- Error codes --

--- a/packages/core/src/work-item.ts
+++ b/packages/core/src/work-item.ts
@@ -22,7 +22,7 @@ export type ReviewStatus = "none" | "pending" | "approved" | "changes_requested"
 
 /** A tracked work item matching the SQLite schema from #1049. */
 export interface WorkItem {
-  /** Primary key — e.g. "pr:1135" or "issue:1116". */
+  /** Primary key — e.g. "#1135" (number-tracked) or "branch:feat/foo" (branch-tracked). */
   id: string;
   issueNumber: number | null;
   branch: string | null;

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -57,6 +57,11 @@ export class StateDb {
     this.migrate();
   }
 
+  /** Expose the raw bun:sqlite Database for sibling modules (e.g. WorkItemDb). */
+  getDatabase(): Database {
+    return this.db;
+  }
+
   // -- Migrations --
 
   private migrate(): void {

--- a/packages/daemon/src/db/work-items.ts
+++ b/packages/daemon/src/db/work-items.ts
@@ -198,4 +198,9 @@ export class WorkItemDb {
       .get(issueNumber);
     return row ? rowToWorkItem(row) : null;
   }
+
+  getWorkItemByBranch(branch: string): WorkItem | null {
+    const row = this.db.query<WorkItemRow, [string]>("SELECT * FROM work_items WHERE branch = ?").get(branch);
+    return row ? rowToWorkItem(row) : null;
+  }
 }

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -1,3 +1,4 @@
+import { Database } from "bun:sqlite";
 import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, readFileSync, statSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -53,6 +54,7 @@ function mockDb(overrides?: Partial<Record<string, unknown>>) {
     getServerLogs: () => [],
     getCachedTools: () => [],
     listSessions: () => [],
+    getDatabase: () => new Database(":memory:"),
     ...overrides,
   } as never;
 }

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -1037,39 +1037,47 @@ export class IpcServer {
 
     this.handlers.set("trackWorkItem", async (params, _ctx) => {
       const { number, branch } = TrackWorkItemParamsSchema.parse(params);
-      if (!number && !branch) {
-        throw Object.assign(new Error("Either number or branch is required"), {
-          code: IPC_ERROR.INVALID_PARAMS,
-        });
-      }
 
       // Check if already tracked
       if (number) {
-        const existing = this.workItemDb.getWorkItemByPr(number) ?? this.workItemDb.getWorkItemByIssue(number);
+        const existing = this.workItemDb.getWorkItemByIssue(number) ?? this.workItemDb.getWorkItem(`#${number}`);
+        if (existing) return existing;
+      } else if (branch) {
+        const existing = this.workItemDb.getWorkItemByBranch(branch);
         if (existing) return existing;
       }
 
-      // Create new work item
+      // Create new work item — only set issueNumber for number-based tracking.
+      // prNumber is set later when a PR is actually associated.
       const id = number ? `#${number}` : `branch:${branch}`;
       return this.workItemDb.createWorkItem({
         id,
         issueNumber: number ?? null,
-        prNumber: number ?? null,
+        prNumber: null,
         branch: branch ?? null,
       });
     });
 
     this.handlers.set("untrackWorkItem", async (params, _ctx) => {
-      const { number } = UntrackWorkItemParamsSchema.parse(params);
-      const existing = this.workItemDb.getWorkItemByPr(number) ?? this.workItemDb.getWorkItemByIssue(number);
+      const { number, branch } = UntrackWorkItemParamsSchema.parse(params);
+
+      if (branch) {
+        const existing = this.workItemDb.getWorkItemByBranch(branch) ?? this.workItemDb.getWorkItem(`branch:${branch}`);
+        if (existing) {
+          this.workItemDb.deleteWorkItem(existing.id);
+          return { ok: true as const, deleted: true };
+        }
+        return { ok: true as const, deleted: false };
+      }
+
+      // Number-based lookup (number is guaranteed non-null when branch is absent per schema refine)
+      const num = number as number;
+      const existing =
+        this.workItemDb.getWorkItemByPr(num) ??
+        this.workItemDb.getWorkItemByIssue(num) ??
+        this.workItemDb.getWorkItem(`#${num}`);
       if (existing) {
         this.workItemDb.deleteWorkItem(existing.id);
-        return { ok: true as const, deleted: true };
-      }
-      // Also try the id pattern
-      const byId = this.workItemDb.getWorkItem(`#${number}`);
-      if (byId) {
-        this.workItemDb.deleteWorkItem(byId.id);
         return { ok: true as const, deleted: true };
       }
       return { ok: true as const, deleted: false };

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -36,6 +36,7 @@ import {
   IPC_ERROR,
   KillServeParamsSchema,
   ListToolsParamsSchema,
+  ListWorkItemsParamsSchema,
   MarkReadParamsSchema,
   MarkSpansExportedParamsSchema,
   PROTOCOL_VERSION,
@@ -50,8 +51,10 @@ import {
   SetNoteParamsSchema,
   ShutdownParamsSchema,
   TouchAliasParamsSchema,
+  TrackWorkItemParamsSchema,
   TriggerAuthParamsSchema,
   UnregisterServeParamsSchema,
+  UntrackWorkItemParamsSchema,
   WaitForMailParamsSchema,
   bundleAlias,
   consoleLogger,
@@ -69,6 +72,7 @@ import { startCallbackServer } from "./auth/callback-server";
 import { DEFAULT_OAUTH_SCOPE, McpOAuthProvider } from "./auth/oauth-provider";
 import { getDaemonLogLines, subscribeDaemonLogs } from "./daemon-log";
 import type { StateDb } from "./db/state";
+import { WorkItemDb } from "./db/work-items";
 import { metrics } from "./metrics";
 import { getPortHolder } from "./port-holder";
 import { killPid } from "./process-util";
@@ -94,6 +98,7 @@ export class IpcServer {
   private drainTimer: ReturnType<typeof setTimeout> | null = null;
   private drainTimeoutMs: number;
 
+  private workItemDb: WorkItemDb;
   private serveInstances = new Map<string, ServeInstanceInfo>();
   private onReloadConfig: (() => Promise<void>) | null = null;
   private getWsPortInfo: (() => { actual: number | null; expected: number }) | null = null;
@@ -135,6 +140,7 @@ export class IpcServer {
     this.getWsPortInfo = options.getWsPortInfo ?? null;
     this.getQuotaStatus = options.getQuotaStatus ?? null;
     this.drainTimeoutMs = options.drainTimeoutMs ?? 5_000;
+    this.workItemDb = new WorkItemDb(this.db.getDatabase());
     this.registerHandlers();
     // Prune expired ephemeral aliases on startup
     this.db.pruneExpiredAliases();
@@ -1025,6 +1031,53 @@ export class IpcServer {
       const { server, tool } = DeleteNoteParamsSchema.parse(params);
       const deleted = this.db.deleteNote(server, tool);
       return { ok: true as const, deleted };
+    });
+
+    // -- Work item tracking --
+
+    this.handlers.set("trackWorkItem", async (params, _ctx) => {
+      const { number, branch } = TrackWorkItemParamsSchema.parse(params);
+      if (!number && !branch) {
+        throw Object.assign(new Error("Either number or branch is required"), {
+          code: IPC_ERROR.INVALID_PARAMS,
+        });
+      }
+
+      // Check if already tracked
+      if (number) {
+        const existing = this.workItemDb.getWorkItemByPr(number) ?? this.workItemDb.getWorkItemByIssue(number);
+        if (existing) return existing;
+      }
+
+      // Create new work item
+      const id = number ? `#${number}` : `branch:${branch}`;
+      return this.workItemDb.createWorkItem({
+        id,
+        issueNumber: number ?? null,
+        prNumber: number ?? null,
+        branch: branch ?? null,
+      });
+    });
+
+    this.handlers.set("untrackWorkItem", async (params, _ctx) => {
+      const { number } = UntrackWorkItemParamsSchema.parse(params);
+      const existing = this.workItemDb.getWorkItemByPr(number) ?? this.workItemDb.getWorkItemByIssue(number);
+      if (existing) {
+        this.workItemDb.deleteWorkItem(existing.id);
+        return { ok: true as const, deleted: true };
+      }
+      // Also try the id pattern
+      const byId = this.workItemDb.getWorkItem(`#${number}`);
+      if (byId) {
+        this.workItemDb.deleteWorkItem(byId.id);
+        return { ok: true as const, deleted: true };
+      }
+      return { ok: true as const, deleted: false };
+    });
+
+    this.handlers.set("listWorkItems", async (params, _ctx) => {
+      const { phase } = ListWorkItemsParamsSchema.parse(params ?? {});
+      return this.workItemDb.listWorkItems(phase ? { phase } : undefined);
     });
 
     this.handlers.set("shutdown", async (params, _ctx) => {


### PR DESCRIPTION
## Summary
- Add `mcx track <number>` and `mcx track --branch <name>` to start tracking work items via daemon IPC
- Add `mcx untrack <number>` to stop tracking, `mcx tracked` for human-readable table, `mcx tracked --json` for machine output
- Wire up IPC methods (`trackWorkItem`, `untrackWorkItem`, `listWorkItems`) through `WorkItemDb`, sharing the daemon's SQLite connection via new `StateDb.getDatabase()` accessor

## Test plan
- [x] 19 unit tests for `cmdTrack`, `cmdUntrack`, `cmdTracked`, and `formatWorkItemRow`
- [x] Tests cover: valid inputs, invalid inputs (non-integer, zero, missing args), help flags, JSON output, phase filtering, empty state, all CI/review status formatting
- [x] IPC server tests pass (added `getDatabase` to mock)
- [x] Full test suite: 2884 pass, 0 fail (run-1); 4061 pass, 0 fail (full)
- [x] Typecheck, lint, coverage all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)