### PR TITLE
feat(daemon): GitHub GraphQL poller for work item state (fixes #1140)

### DIFF
--- a/packages/core/src/work-item.ts
+++ b/packages/core/src/work-item.ts
@@ -43,7 +43,7 @@ export type WorkItemEvent =
   | { type: "pr:opened"; prNumber: number }
   | { type: "pr:merged"; prNumber: number }
   | { type: "pr:closed"; prNumber: number }
-  | { type: "checks:started"; prNumber: number; runId: number }
+  | { type: "checks:started"; prNumber: number }
   | { type: "checks:passed"; prNumber: number }
   | { type: "checks:failed"; prNumber: number; failedJob: string }
   | { type: "review:approved"; prNumber: number }

--- a/packages/daemon/src/github/graphql-client.spec.ts
+++ b/packages/daemon/src/github/graphql-client.spec.ts
@@ -204,6 +204,38 @@ describe("fetchTrackedPRs", () => {
     expect(result).toEqual([]);
   });
 
+  test("clears token cache on 403 non-rate-limit", async () => {
+    const doFetch = async () => new Response("Forbidden", { status: 403, headers: {} });
+
+    let tokenCallCount = 0;
+    const getToken = async () => {
+      tokenCallCount++;
+      return `token-${tokenCallCount}`;
+    };
+
+    await expect(fetchTrackedPRs(repo, [1], { getToken, fetch: doFetch })).rejects.toThrow(
+      "403 (possible token scope change)",
+    );
+    // Token should have been fetched once, then cache cleared for next poll
+    expect(tokenCallCount).toBe(1);
+  });
+
+  test("throws rate limit error on 403 with exhausted limit", async () => {
+    const resetTime = Math.floor(Date.now() / 1000) + 3600;
+    const doFetch = async () =>
+      new Response("Rate limited", {
+        status: 403,
+        headers: {
+          "x-ratelimit-remaining": "0",
+          "x-ratelimit-reset": String(resetTime),
+        },
+      });
+
+    await expect(fetchTrackedPRs(repo, [1], { getToken: mockGetToken, fetch: doFetch })).rejects.toThrow(
+      "rate limit exhausted",
+    );
+  });
+
   test("handles PR with no CI or reviews", async () => {
     const body = {
       data: {

--- a/packages/daemon/src/github/graphql-client.spec.ts
+++ b/packages/daemon/src/github/graphql-client.spec.ts
@@ -1,0 +1,234 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { buildQuery, clearTokenCache, fetchTrackedPRs, getGhToken, parseRemoteUrl } from "./graphql-client";
+
+afterEach(() => {
+  clearTokenCache();
+});
+
+// ---------- parseRemoteUrl ----------
+
+describe("parseRemoteUrl", () => {
+  test("parses HTTPS URL", () => {
+    expect(parseRemoteUrl("https://github.com/theshadow27/mcp-cli.git")).toEqual({
+      owner: "theshadow27",
+      repo: "mcp-cli",
+    });
+  });
+
+  test("parses HTTPS URL without .git", () => {
+    expect(parseRemoteUrl("https://github.com/theshadow27/mcp-cli")).toEqual({
+      owner: "theshadow27",
+      repo: "mcp-cli",
+    });
+  });
+
+  test("parses SSH URL", () => {
+    expect(parseRemoteUrl("git@github.com:theshadow27/mcp-cli.git")).toEqual({
+      owner: "theshadow27",
+      repo: "mcp-cli",
+    });
+  });
+
+  test("parses SSH URL without .git", () => {
+    expect(parseRemoteUrl("git@github.com:theshadow27/mcp-cli")).toEqual({
+      owner: "theshadow27",
+      repo: "mcp-cli",
+    });
+  });
+
+  test("throws on non-GitHub URL", () => {
+    expect(() => parseRemoteUrl("https://gitlab.com/foo/bar.git")).toThrow("Cannot parse GitHub");
+  });
+
+  test("throws on garbage", () => {
+    expect(() => parseRemoteUrl("not-a-url")).toThrow("Cannot parse GitHub");
+  });
+});
+
+// ---------- buildQuery ----------
+
+describe("buildQuery", () => {
+  test("builds aliased query for multiple PRs", () => {
+    const q = buildQuery([42, 99]);
+    expect(q).toContain("pr42: pullRequest(number: 42)");
+    expect(q).toContain("pr99: pullRequest(number: 99)");
+    expect(q).toContain("$owner: String!");
+    expect(q).toContain("$repo: String!");
+  });
+
+  test("builds single PR query", () => {
+    const q = buildQuery([1]);
+    expect(q).toContain("pr1: pullRequest(number: 1)");
+  });
+});
+
+// ---------- getGhToken ----------
+
+describe("getGhToken", () => {
+  test("caches token across calls", async () => {
+    let callCount = 0;
+    const exec = async () => {
+      callCount++;
+      return "ghp_test123";
+    };
+
+    const t1 = await getGhToken({ exec });
+    const t2 = await getGhToken({ exec });
+    expect(t1).toBe("ghp_test123");
+    expect(t2).toBe("ghp_test123");
+    expect(callCount).toBe(1);
+  });
+
+  test("refreshes after clearTokenCache", async () => {
+    let callCount = 0;
+    const exec = async () => {
+      callCount++;
+      return `token-${callCount}`;
+    };
+
+    await getGhToken({ exec });
+    clearTokenCache();
+    const t2 = await getGhToken({ exec });
+    expect(t2).toBe("token-2");
+    expect(callCount).toBe(2);
+  });
+});
+
+// ---------- fetchTrackedPRs ----------
+
+describe("fetchTrackedPRs", () => {
+  const repo = { owner: "test", repo: "repo" };
+
+  function mockFetch(body: unknown, status = 200) {
+    return async () => new Response(JSON.stringify(body), { status });
+  }
+
+  const mockGetToken = async () => "fake-token";
+
+  test("returns empty array for no PR numbers", async () => {
+    const result = await fetchTrackedPRs(repo, [], { getToken: mockGetToken });
+    expect(result).toEqual([]);
+  });
+
+  test("parses successful GraphQL response", async () => {
+    const body = {
+      data: {
+        repository: {
+          pr42: {
+            number: 42,
+            state: "OPEN",
+            isDraft: false,
+            mergeable: "MERGEABLE",
+            commits: {
+              nodes: [
+                {
+                  commit: {
+                    statusCheckRollup: {
+                      state: "SUCCESS",
+                      contexts: {
+                        nodes: [{ name: "ci/test", status: "COMPLETED", conclusion: "SUCCESS" }],
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+            reviews: {
+              nodes: [{ state: "APPROVED", author: { login: "reviewer1" } }],
+            },
+          },
+        },
+      },
+    };
+
+    const result = await fetchTrackedPRs(repo, [42], {
+      getToken: mockGetToken,
+      fetch: mockFetch(body),
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].number).toBe(42);
+    expect(result[0].state).toBe("OPEN");
+    expect(result[0].isDraft).toBe(false);
+    expect(result[0].mergeable).toBe("MERGEABLE");
+    expect(result[0].ciState).toBe("SUCCESS");
+    expect(result[0].ciChecks).toHaveLength(1);
+    expect(result[0].ciChecks[0].name).toBe("ci/test");
+    expect(result[0].reviews).toHaveLength(1);
+    expect(result[0].reviews[0].state).toBe("APPROVED");
+    expect(result[0].reviews[0].author).toBe("reviewer1");
+  });
+
+  test("retries on 401", async () => {
+    let callCount = 0;
+    const doFetch = async () => {
+      callCount++;
+      if (callCount === 1) {
+        return new Response("Unauthorized", { status: 401 });
+      }
+      return new Response(JSON.stringify({ data: { repository: {} } }), { status: 200 });
+    };
+
+    let tokenCallCount = 0;
+    const getToken = async () => {
+      tokenCallCount++;
+      return `token-${tokenCallCount}`;
+    };
+
+    await fetchTrackedPRs(repo, [1], { getToken, fetch: doFetch });
+    expect(callCount).toBe(2);
+    expect(tokenCallCount).toBe(2); // first call + refresh
+  });
+
+  test("throws on GraphQL errors", async () => {
+    const body = { errors: [{ message: "Not found" }] };
+    await expect(fetchTrackedPRs(repo, [1], { getToken: mockGetToken, fetch: mockFetch(body) })).rejects.toThrow(
+      "GitHub GraphQL errors: Not found",
+    );
+  });
+
+  test("throws on non-200 after retry", async () => {
+    const doFetch = async () => new Response("Server Error", { status: 500 });
+
+    await expect(fetchTrackedPRs(repo, [1], { getToken: mockGetToken, fetch: doFetch })).rejects.toThrow(
+      "GitHub GraphQL API returned 500",
+    );
+  });
+
+  test("handles missing repository data", async () => {
+    const body = { data: {} };
+    const result = await fetchTrackedPRs(repo, [1], {
+      getToken: mockGetToken,
+      fetch: mockFetch(body),
+    });
+    expect(result).toEqual([]);
+  });
+
+  test("handles PR with no CI or reviews", async () => {
+    const body = {
+      data: {
+        repository: {
+          pr10: {
+            number: 10,
+            state: "MERGED",
+            isDraft: false,
+            mergeable: "UNKNOWN",
+            commits: { nodes: [] },
+            reviews: { nodes: [] },
+          },
+        },
+      },
+    };
+
+    const result = await fetchTrackedPRs(repo, [10], {
+      getToken: mockGetToken,
+      fetch: mockFetch(body),
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].state).toBe("MERGED");
+    expect(result[0].ciState).toBeNull();
+    expect(result[0].ciChecks).toEqual([]);
+    expect(result[0].reviews).toEqual([]);
+  });
+});

--- a/packages/daemon/src/github/graphql-client.ts
+++ b/packages/daemon/src/github/graphql-client.ts
@@ -57,7 +57,7 @@ export function buildQuery(prNumbers: readonly number[]): string {
           commit {
             statusCheckRollup {
               state
-              contexts(first: 10) {
+              contexts(first: 50) {
                 nodes {
                   ... on CheckRun {
                     name
@@ -247,11 +247,25 @@ export async function fetchTrackedPRs(
   let token = await getToken();
   let resp = await doGraphQL(doFetch, token, query, variables);
 
-  // Retry once on 401
+  // Retry once on 401 (expired token)
   if (resp.status === 401) {
     clearTokenCache();
     token = await getToken();
     resp = await doGraphQL(doFetch, token, query, variables);
+  }
+
+  // Handle 403: rate limit exhaustion or token scope change
+  if (resp.status === 403) {
+    const remaining = resp.headers.get("x-ratelimit-remaining");
+    const resetHeader = resp.headers.get("x-ratelimit-reset");
+    if (remaining === "0" && resetHeader) {
+      const resetAt = new Date(Number(resetHeader) * 1000);
+      throw new Error(`GitHub API rate limit exhausted, resets at ${resetAt.toISOString()}`);
+    }
+    // Scope change or other auth issue — clear token cache so next poll gets a fresh token
+    clearTokenCache();
+    const body = await resp.text().catch(() => "");
+    throw new Error(`GitHub API returned 403 (possible token scope change): ${body}`);
   }
 
   if (!resp.ok) {

--- a/packages/daemon/src/github/graphql-client.ts
+++ b/packages/daemon/src/github/graphql-client.ts
@@ -1,0 +1,296 @@
+/**
+ * GitHub GraphQL client for fetching PR status.
+ *
+ * Uses aliased per-PR queries in a single GraphQL request to fetch only
+ * tracked PRs. Auth via `gh auth token` with automatic refresh on 401.
+ *
+ * Phase 2a of #1049.
+ */
+
+const GITHUB_GRAPHQL_URL = "https://api.github.com/graphql";
+const REQUEST_TIMEOUT_MS = 10_000;
+
+// ---------- Types ----------
+
+export interface RepoInfo {
+  owner: string;
+  repo: string;
+}
+
+export interface CiCheck {
+  name: string;
+  status: string;
+  conclusion: string | null;
+}
+
+export interface Review {
+  state: string;
+  author: string;
+}
+
+export interface PRStatus {
+  number: number;
+  state: "OPEN" | "CLOSED" | "MERGED";
+  isDraft: boolean;
+  mergeable: "MERGEABLE" | "CONFLICTING" | "UNKNOWN";
+  ciState: string | null;
+  ciChecks: CiCheck[];
+  reviews: Review[];
+}
+
+// ---------- GraphQL query builder ----------
+
+/**
+ * Build a GraphQL query with aliased pullRequest fields, one per tracked PR.
+ * This avoids fetching all PRs and filtering client-side.
+ */
+export function buildQuery(prNumbers: readonly number[]): string {
+  const fragments = prNumbers.map(
+    (n) => `
+    pr${n}: pullRequest(number: ${n}) {
+      number
+      state
+      isDraft
+      mergeable
+      commits(last: 1) {
+        nodes {
+          commit {
+            statusCheckRollup {
+              state
+              contexts(first: 10) {
+                nodes {
+                  ... on CheckRun {
+                    name
+                    conclusion
+                    status
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      reviews(last: 5) {
+        nodes {
+          state
+          author { login }
+        }
+      }
+    }`,
+  );
+
+  return `query TrackedPRs($owner: String!, $repo: String!) {
+  repository(owner: $owner, name: $repo) {
+    ${fragments.join("\n    ")}
+  }
+}`;
+}
+
+// ---------- Response parsing ----------
+
+interface RawCheckRun {
+  name?: string;
+  conclusion?: string | null;
+  status?: string;
+}
+
+interface RawReview {
+  state?: string;
+  author?: { login?: string } | null;
+}
+
+interface RawPR {
+  number?: number;
+  state?: string;
+  isDraft?: boolean;
+  mergeable?: string;
+  commits?: {
+    nodes?: Array<{
+      commit?: {
+        statusCheckRollup?: {
+          state?: string;
+          contexts?: { nodes?: RawCheckRun[] };
+        } | null;
+      };
+    }>;
+  };
+  reviews?: { nodes?: RawReview[] };
+}
+
+function parsePR(raw: RawPR): PRStatus {
+  const commit = raw.commits?.nodes?.[0]?.commit;
+  const rollup = commit?.statusCheckRollup;
+
+  const ciChecks: CiCheck[] = (rollup?.contexts?.nodes ?? [])
+    .filter((n): n is RawCheckRun & { name: string } => !!n.name)
+    .map((n) => ({
+      name: n.name,
+      status: n.status ?? "QUEUED",
+      conclusion: n.conclusion ?? null,
+    }));
+
+  const reviews: Review[] = (raw.reviews?.nodes ?? [])
+    .filter((r): r is RawReview & { state: string } => !!r.state)
+    .map((r) => ({
+      state: r.state,
+      author: r.author?.login ?? "unknown",
+    }));
+
+  return {
+    number: raw.number ?? 0,
+    state: (raw.state as PRStatus["state"]) ?? "OPEN",
+    isDraft: raw.isDraft ?? false,
+    mergeable: (raw.mergeable as PRStatus["mergeable"]) ?? "UNKNOWN",
+    ciState: rollup?.state ?? null,
+    ciChecks,
+    reviews,
+  };
+}
+
+// ---------- Auth ----------
+
+let cachedToken: string | null = null;
+
+/** Get a GitHub token via `gh auth token`. Caches the result. */
+export async function getGhToken(opts?: { exec?: typeof execGhAuthToken }): Promise<string> {
+  if (cachedToken) return cachedToken;
+  const exec = opts?.exec ?? execGhAuthToken;
+  const token = await exec();
+  cachedToken = token;
+  return token;
+}
+
+/** Clear the cached token (used on 401 to force refresh). */
+export function clearTokenCache(): void {
+  cachedToken = null;
+}
+
+async function execGhAuthToken(): Promise<string> {
+  const proc = Bun.spawn(["gh", "auth", "token"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    const stderr = await new Response(proc.stderr as ReadableStream).text();
+    throw new Error(`gh auth token failed (exit ${exitCode}): ${stderr.trim()}`);
+  }
+  const stdout = await new Response(proc.stdout as ReadableStream).text();
+  return stdout.trim();
+}
+
+// ---------- Repo detection ----------
+
+/** Detect owner/repo from the git remote origin URL. */
+export async function detectRepo(
+  cwd?: string,
+  opts?: { exec?: (args: string[], cwd?: string) => Promise<string> },
+): Promise<RepoInfo> {
+  const exec = opts?.exec ?? execGitRemote;
+  const url = await exec(["git", "remote", "get-url", "origin"], cwd);
+  return parseRemoteUrl(url.trim());
+}
+
+async function execGitRemote(args: string[], cwd?: string): Promise<string> {
+  const proc = Bun.spawn(args, {
+    stdout: "pipe",
+    stderr: "pipe",
+    cwd,
+  });
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    throw new Error("Failed to get git remote origin URL");
+  }
+  return new Response(proc.stdout).text();
+}
+
+/** Parse a git remote URL into owner/repo. Supports HTTPS and SSH formats. */
+export function parseRemoteUrl(url: string): RepoInfo {
+  // SSH: git@github.com:owner/repo.git
+  const sshMatch = url.match(/github\.com[:/]([^/]+)\/([^/\s]+?)(?:\.git)?$/);
+  if (sshMatch) return { owner: sshMatch[1], repo: sshMatch[2] };
+
+  // HTTPS: https://github.com/owner/repo.git
+  const httpsMatch = url.match(/github\.com\/([^/]+)\/([^/\s]+?)(?:\.git)?$/);
+  if (httpsMatch) return { owner: httpsMatch[1], repo: httpsMatch[2] };
+
+  throw new Error(`Cannot parse GitHub owner/repo from remote URL: ${url}`);
+}
+
+// ---------- Fetch ----------
+
+/** A minimal fetch signature (avoids Bun's extended `typeof fetch` with `preconnect`). */
+type FetchFn = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+export interface FetchPRsOptions {
+  getToken?: () => Promise<string>;
+  fetch?: FetchFn;
+}
+
+/**
+ * Fetch status for tracked PRs in a single GraphQL request.
+ * Retries once on 401 after refreshing the token.
+ */
+export async function fetchTrackedPRs(
+  repo: RepoInfo,
+  prNumbers: readonly number[],
+  opts?: FetchPRsOptions,
+): Promise<PRStatus[]> {
+  if (prNumbers.length === 0) return [];
+
+  const getToken = opts?.getToken ?? getGhToken;
+  const doFetch: FetchFn = opts?.fetch ?? globalThis.fetch;
+
+  const query = buildQuery(prNumbers);
+  const variables = { owner: repo.owner, repo: repo.repo };
+
+  let token = await getToken();
+  let resp = await doGraphQL(doFetch, token, query, variables);
+
+  // Retry once on 401
+  if (resp.status === 401) {
+    clearTokenCache();
+    token = await getToken();
+    resp = await doGraphQL(doFetch, token, query, variables);
+  }
+
+  if (!resp.ok) {
+    const body = await resp.text().catch(() => "");
+    throw new Error(`GitHub GraphQL API returned ${resp.status}: ${body}`);
+  }
+
+  const json: { data?: { repository?: Record<string, RawPR> }; errors?: Array<{ message: string }> } =
+    await resp.json();
+
+  if (json.errors?.length) {
+    throw new Error(`GitHub GraphQL errors: ${json.errors.map((e) => e.message).join(", ")}`);
+  }
+
+  const repoData = json.data?.repository;
+  if (!repoData) return [];
+
+  const results: PRStatus[] = [];
+  for (const num of prNumbers) {
+    const raw = repoData[`pr${num}`];
+    if (raw) results.push(parsePR(raw));
+  }
+  return results;
+}
+
+async function doGraphQL(
+  doFetch: FetchFn,
+  token: string,
+  query: string,
+  variables: Record<string, string>,
+): Promise<Response> {
+  return doFetch(GITHUB_GRAPHQL_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `bearer ${token}`,
+      "Content-Type": "application/json",
+      "User-Agent": "mcp-cli/1.0",
+    },
+    body: JSON.stringify({ query, variables }),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+}

--- a/packages/daemon/src/github/work-item-poller.spec.ts
+++ b/packages/daemon/src/github/work-item-poller.spec.ts
@@ -311,4 +311,142 @@ describe("WorkItemPoller", () => {
     expect(events).toContainEqual({ type: "pr:merged", prNumber: 1 });
     expect(events).toContainEqual({ type: "pr:closed", prNumber: 2 });
   });
+
+  test("concurrency guard prevents overlapping polls", async () => {
+    db.createWorkItem({ id: "pr:1", prNumber: 1 });
+
+    let concurrentCalls = 0;
+    let maxConcurrent = 0;
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => {
+        concurrentCalls++;
+        maxConcurrent = Math.max(maxConcurrent, concurrentCalls);
+        await Bun.sleep(50);
+        concurrentCalls--;
+        return [makePRStatus({ number: 1 })];
+      },
+      detectRepo: async () => TEST_REPO,
+    });
+
+    // Fire two polls simultaneously — second should be skipped
+    const [, secondResult] = await Promise.all([poller.poll(), poller.poll()]);
+    expect(maxConcurrent).toBe(1);
+    // Only one poll should have completed
+    expect(poller.pollCount).toBe(1);
+  });
+
+  test("stopped flag prevents DB writes during shutdown", async () => {
+    db.createWorkItem({ id: "pr:1", prNumber: 1, prState: "open" });
+
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => {
+        // Simulate stop being called during fetch
+        poller.stop();
+        return [makePRStatus({ number: 1, state: "MERGED" })];
+      },
+      detectRepo: async () => TEST_REPO,
+    });
+
+    await poller.poll();
+    // PR state should NOT have been updated because stop() was called
+    const item = db.getWorkItem("pr:1");
+    expect(item?.prState).toBe("open");
+  });
+
+  test("detectRepo failure caches after 3 attempts", async () => {
+    db.createWorkItem({ id: "pr:1", prNumber: 1 });
+
+    let detectCalls = 0;
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => [],
+      detectRepo: async () => {
+        detectCalls++;
+        throw new Error("not a github repo");
+      },
+    });
+
+    // First 3 attempts should try detectRepo
+    await poller.poll();
+    await poller.poll();
+    await poller.poll();
+    expect(detectCalls).toBe(3);
+    expect(poller.lastError).toBe("not a github repo");
+
+    // 4th attempt should skip detectRepo entirely
+    await poller.poll();
+    expect(detectCalls).toBe(3);
+  });
+
+  test("review status ignores COMMENTED after APPROVED", async () => {
+    db.createWorkItem({ id: "pr:9", prNumber: 9, reviewStatus: "none" });
+
+    const events: WorkItemEvent[] = [];
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => [
+        makePRStatus({
+          number: 9,
+          reviews: [
+            { state: "APPROVED", author: "alice" },
+            { state: "COMMENTED", author: "bob" },
+          ],
+        }),
+      ],
+      detectRepo: async () => TEST_REPO,
+      onEvent: (e) => events.push(e),
+    });
+
+    await poller.poll();
+
+    // Should be approved, not pending — COMMENTED doesn't override APPROVED
+    const item = db.getWorkItem("pr:9");
+    expect(item?.reviewStatus).toBe("approved");
+    expect(events).toContainEqual({ type: "review:approved", prNumber: 9 });
+  });
+
+  test("checks:started event has no runId", async () => {
+    db.createWorkItem({ id: "pr:11", prNumber: 11, ciStatus: "none" });
+
+    const events: WorkItemEvent[] = [];
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => [makePRStatus({ number: 11, ciState: "PENDING" })],
+      detectRepo: async () => TEST_REPO,
+      onEvent: (e) => events.push(e),
+    });
+
+    await poller.poll();
+
+    expect(events).toContainEqual({ type: "checks:started", prNumber: 11 });
+    // Verify no runId field
+    const startedEvent = events.find((e) => e.type === "checks:started");
+    expect(startedEvent).toBeDefined();
+    if (startedEvent) {
+      expect("runId" in startedEvent).toBe(false);
+    }
+  });
+
+  test("EXPECTED status maps to pending, not running", async () => {
+    db.createWorkItem({ id: "pr:12", prNumber: 12, ciStatus: "none" });
+
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => [makePRStatus({ number: 12, ciState: "EXPECTED" })],
+      detectRepo: async () => TEST_REPO,
+    });
+
+    await poller.poll();
+
+    const item = db.getWorkItem("pr:12");
+    expect(item?.ciStatus).toBe("pending");
+  });
 });

--- a/packages/daemon/src/github/work-item-poller.spec.ts
+++ b/packages/daemon/src/github/work-item-poller.spec.ts
@@ -1,0 +1,314 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { WorkItemEvent } from "@mcp-cli/core";
+import { WorkItemDb } from "../db/work-items";
+import type { PRStatus, RepoInfo } from "./graphql-client";
+import { WorkItemPoller } from "./work-item-poller";
+
+const SILENT_LOGGER = { info() {}, warn() {}, error() {}, debug() {} };
+const TEST_REPO: RepoInfo = { owner: "test", repo: "repo" };
+
+function makePRStatus(overrides: Partial<PRStatus> & { number: number }): PRStatus {
+  return {
+    state: "OPEN",
+    isDraft: false,
+    mergeable: "UNKNOWN",
+    ciState: null,
+    ciChecks: [],
+    reviews: [],
+    ...overrides,
+  };
+}
+
+describe("WorkItemPoller", () => {
+  let sqlDb: Database;
+  let db: WorkItemDb;
+
+  beforeEach(() => {
+    sqlDb = new Database(":memory:");
+    db = new WorkItemDb(sqlDb);
+  });
+
+  afterEach(() => {
+    sqlDb.close();
+  });
+
+  test("no-op poll when no tracked items", async () => {
+    let fetchCalled = false;
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => {
+        fetchCalled = true;
+        return [];
+      },
+      detectRepo: async () => TEST_REPO,
+    });
+
+    await poller.poll();
+    expect(fetchCalled).toBe(false);
+    expect(poller.pollCount).toBe(1);
+    expect(poller.lastError).toBeNull();
+  });
+
+  test("no-op when items exist but none have prNumber", async () => {
+    db.createWorkItem({ id: "#100", issueNumber: 100 });
+
+    let fetchCalled = false;
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => {
+        fetchCalled = true;
+        return [];
+      },
+      detectRepo: async () => TEST_REPO,
+    });
+
+    await poller.poll();
+    expect(fetchCalled).toBe(false);
+  });
+
+  test("fetches and updates PR state", async () => {
+    db.createWorkItem({ id: "pr:42", prNumber: 42, prState: "open" });
+
+    const events: WorkItemEvent[] = [];
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => [makePRStatus({ number: 42, state: "MERGED" })],
+      detectRepo: async () => TEST_REPO,
+      onEvent: (e) => events.push(e),
+    });
+
+    await poller.poll();
+
+    const item = db.getWorkItem("pr:42");
+    expect(item?.prState).toBe("merged");
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ type: "pr:merged", prNumber: 42 });
+  });
+
+  test("updates CI status and emits checks:passed", async () => {
+    db.createWorkItem({ id: "pr:10", prNumber: 10, ciStatus: "running" });
+
+    const events: WorkItemEvent[] = [];
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => [makePRStatus({ number: 10, ciState: "SUCCESS" })],
+      detectRepo: async () => TEST_REPO,
+      onEvent: (e) => events.push(e),
+    });
+
+    await poller.poll();
+
+    const item = db.getWorkItem("pr:10");
+    expect(item?.ciStatus).toBe("passed");
+    expect(events).toContainEqual({ type: "checks:passed", prNumber: 10 });
+  });
+
+  test("updates review status and emits review:approved", async () => {
+    db.createWorkItem({ id: "pr:5", prNumber: 5, reviewStatus: "pending" });
+
+    const events: WorkItemEvent[] = [];
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => [
+        makePRStatus({
+          number: 5,
+          reviews: [{ state: "APPROVED", author: "alice" }],
+        }),
+      ],
+      detectRepo: async () => TEST_REPO,
+      onEvent: (e) => events.push(e),
+    });
+
+    await poller.poll();
+
+    const item = db.getWorkItem("pr:5");
+    expect(item?.reviewStatus).toBe("approved");
+    expect(events).toContainEqual({ type: "review:approved", prNumber: 5 });
+  });
+
+  test("emits checks:failed with failedJob", async () => {
+    db.createWorkItem({ id: "pr:7", prNumber: 7, ciStatus: "running" });
+
+    const events: WorkItemEvent[] = [];
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => [
+        makePRStatus({
+          number: 7,
+          ciState: "FAILURE",
+          ciChecks: [
+            { name: "lint", status: "COMPLETED", conclusion: "SUCCESS" },
+            { name: "test", status: "COMPLETED", conclusion: "FAILURE" },
+          ],
+        }),
+      ],
+      detectRepo: async () => TEST_REPO,
+      onEvent: (e) => events.push(e),
+    });
+
+    await poller.poll();
+
+    expect(events).toContainEqual({ type: "checks:failed", prNumber: 7, failedJob: "test" });
+  });
+
+  test("emits review:changes_requested with reviewer", async () => {
+    db.createWorkItem({ id: "pr:8", prNumber: 8, reviewStatus: "none" });
+
+    const events: WorkItemEvent[] = [];
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => [
+        makePRStatus({
+          number: 8,
+          reviews: [{ state: "CHANGES_REQUESTED", author: "bob" }],
+        }),
+      ],
+      detectRepo: async () => TEST_REPO,
+      onEvent: (e) => events.push(e),
+    });
+
+    await poller.poll();
+
+    expect(events).toContainEqual({
+      type: "review:changes_requested",
+      prNumber: 8,
+      reviewer: "bob",
+    });
+  });
+
+  test("no events when state hasn't changed", async () => {
+    db.createWorkItem({
+      id: "pr:20",
+      prNumber: 20,
+      prState: "open",
+      ciStatus: "passed",
+      reviewStatus: "approved",
+    });
+
+    const events: WorkItemEvent[] = [];
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => [
+        makePRStatus({
+          number: 20,
+          state: "OPEN",
+          isDraft: false,
+          ciState: "SUCCESS",
+          reviews: [{ state: "APPROVED", author: "x" }],
+        }),
+      ],
+      detectRepo: async () => TEST_REPO,
+      onEvent: (e) => events.push(e),
+    });
+
+    await poller.poll();
+    expect(events).toHaveLength(0);
+  });
+
+  test("handles fetch error gracefully", async () => {
+    db.createWorkItem({ id: "pr:1", prNumber: 1 });
+
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => {
+        throw new Error("network failure");
+      },
+      detectRepo: async () => TEST_REPO,
+    });
+
+    await poller.poll();
+    expect(poller.lastError).toBe("network failure");
+    expect(poller.pollCount).toBe(1);
+  });
+
+  test("caches repo detection across polls", async () => {
+    db.createWorkItem({ id: "pr:1", prNumber: 1 });
+
+    let detectCount = 0;
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => [],
+      detectRepo: async () => {
+        detectCount++;
+        return TEST_REPO;
+      },
+    });
+
+    await poller.poll();
+    await poller.poll();
+    expect(detectCount).toBe(1);
+    expect(poller.repo).toEqual(TEST_REPO);
+  });
+
+  test("start and stop lifecycle", () => {
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      intervalMs: 60_000,
+      fetchPRs: async () => [],
+      detectRepo: async () => TEST_REPO,
+    });
+
+    poller.start();
+    // start is idempotent
+    poller.start();
+    poller.stop();
+    // stop is idempotent
+    poller.stop();
+  });
+
+  test("maps draft PRs correctly", async () => {
+    db.createWorkItem({ id: "pr:15", prNumber: 15, prState: "open" });
+
+    const events: WorkItemEvent[] = [];
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => [makePRStatus({ number: 15, state: "OPEN", isDraft: true })],
+      detectRepo: async () => TEST_REPO,
+      onEvent: (e) => events.push(e),
+    });
+
+    await poller.poll();
+
+    const item = db.getWorkItem("pr:15");
+    expect(item?.prState).toBe("draft");
+    // No pr:opened event for draft transition
+    expect(events.some((e) => e.type === "pr:opened")).toBe(false);
+  });
+
+  test("handles multiple PRs in single poll", async () => {
+    db.createWorkItem({ id: "pr:1", prNumber: 1, prState: "open" });
+    db.createWorkItem({ id: "pr:2", prNumber: 2, prState: "open" });
+
+    const events: WorkItemEvent[] = [];
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => [
+        makePRStatus({ number: 1, state: "MERGED" }),
+        makePRStatus({ number: 2, state: "CLOSED" }),
+      ],
+      detectRepo: async () => TEST_REPO,
+      onEvent: (e) => events.push(e),
+    });
+
+    await poller.poll();
+
+    expect(db.getWorkItem("pr:1")?.prState).toBe("merged");
+    expect(db.getWorkItem("pr:2")?.prState).toBe("closed");
+    expect(events).toContainEqual({ type: "pr:merged", prNumber: 1 });
+    expect(events).toContainEqual({ type: "pr:closed", prNumber: 2 });
+  });
+});

--- a/packages/daemon/src/github/work-item-poller.ts
+++ b/packages/daemon/src/github/work-item-poller.ts
@@ -39,6 +39,9 @@ export class WorkItemPoller {
   private _repo: RepoInfo | null = null;
   private _lastError: string | null = null;
   private _pollCount = 0;
+  private polling = false;
+  private stopped = false;
+  private repoDetectFailures = 0;
   private fetchPRs: NonNullable<WorkItemPollerOptions["fetchPRs"]>;
   private detectRepoFn: NonNullable<WorkItemPollerOptions["detectRepo"]>;
   private onEvent: (event: WorkItemEvent) => void;
@@ -65,27 +68,54 @@ export class WorkItemPoller {
     return this._repo;
   }
 
-  /** Start polling. Does an immediate first poll. */
+  /** Start polling. Does an immediate first poll, then chains via setTimeout. */
   start(): void {
-    if (this.timer) return;
-    this.poll();
-    this.timer = setInterval(() => this.poll(), this.currentIntervalMs);
+    if (this.timer || this.stopped) return;
+    this.scheduleNext(0);
   }
 
-  /** Stop polling and clean up. */
+  /** Stop polling and clean up. In-flight polls will bail before writing. */
   stop(): void {
+    this.stopped = true;
     if (this.timer) {
-      clearInterval(this.timer);
+      clearTimeout(this.timer);
       this.timer = null;
     }
   }
 
+  private scheduleNext(delayMs: number): void {
+    if (this.stopped) return;
+    this.timer = setTimeout(async () => {
+      await this.poll();
+      this.scheduleNext(this.currentIntervalMs);
+    }, delayMs);
+  }
+
   /** Run a single poll cycle. Exported for testing. */
   async poll(): Promise<void> {
+    if (this.polling || this.stopped) return;
+    this.polling = true;
     try {
-      // Detect repo on first poll
+      // Detect repo (with failure caching — stop retrying after 3 failures)
       if (!this._repo) {
-        this._repo = await this.detectRepoFn();
+        if (this.repoDetectFailures >= 3) {
+          this._pollCount++;
+          return;
+        }
+        try {
+          this._repo = await this.detectRepoFn();
+        } catch (err) {
+          this.repoDetectFailures++;
+          const msg = err instanceof Error ? err.message : String(err);
+          if (this.repoDetectFailures >= 3) {
+            this.logger.warn(`[mcpd] Repo detection failed ${this.repoDetectFailures} times, giving up: ${msg}`);
+          } else {
+            this.logger.warn(`[mcpd] Repo detection failed (attempt ${this.repoDetectFailures}/3): ${msg}`);
+          }
+          this._lastError = msg;
+          this._pollCount++;
+          return;
+        }
       }
 
       const allItems = this.db.listWorkItems();
@@ -107,6 +137,8 @@ export class WorkItemPoller {
       const prNumbers = tracked.map((item) => item.prNumber as number);
       const statuses = await this.fetchPRs(this._repo, prNumbers);
 
+      if (this.stopped) return; // bail before writing if stopped during fetch
+
       // Build lookup by PR number
       const statusMap = new Map<number, PRStatus>();
       for (const s of statuses) {
@@ -115,6 +147,7 @@ export class WorkItemPoller {
 
       // Compare and update
       for (const item of tracked) {
+        if (this.stopped) return; // bail before writing if stopped mid-reconcile
         const status = statusMap.get(item.prNumber as number);
         if (!status) continue;
         this.reconcile(item, status);
@@ -128,6 +161,8 @@ export class WorkItemPoller {
       this._lastError = msg;
       this._pollCount++;
       this.logger.warn(`[mcpd] Work item poll failed: ${msg}`);
+    } finally {
+      this.polling = false;
     }
   }
 
@@ -152,7 +187,7 @@ export class WorkItemPoller {
     if (newCiStatus !== item.ciStatus) {
       patch.ciStatus = newCiStatus;
       changed = true;
-      this.emitCiEvent(prNumber, newCiStatus, item.ciRunId ?? 0, status);
+      this.emitCiEvent(prNumber, newCiStatus, status);
     }
 
     // Review status changes
@@ -182,7 +217,7 @@ export class WorkItemPoller {
     }
   }
 
-  private emitCiEvent(prNumber: number, newStatus: CiStatus, ciRunId: number, status: PRStatus): void {
+  private emitCiEvent(prNumber: number, newStatus: CiStatus, status: PRStatus): void {
     switch (newStatus) {
       case "passed":
         this.onEvent({ type: "checks:passed", prNumber });
@@ -194,7 +229,7 @@ export class WorkItemPoller {
       }
       case "running":
       case "pending":
-        this.onEvent({ type: "checks:started", prNumber, runId: ciRunId });
+        this.onEvent({ type: "checks:started", prNumber });
         break;
     }
   }
@@ -218,11 +253,6 @@ export class WorkItemPoller {
     const target = hasActive ? ACTIVE_INTERVAL_MS : STABLE_INTERVAL_MS;
     if (target !== this.currentIntervalMs) {
       this.currentIntervalMs = target;
-      // Restart the timer with the new interval
-      if (this.timer) {
-        clearInterval(this.timer);
-        this.timer = setInterval(() => this.poll(), this.currentIntervalMs);
-      }
       this.logger.info(`[mcpd] Work item poll interval adjusted to ${target / 1000}s`);
     }
   }
@@ -254,7 +284,7 @@ function mapCiStatus(status: PRStatus): CiStatus {
     case "PENDING":
       return "pending";
     case "EXPECTED":
-      return "running";
+      return "pending";
     default:
       return "none";
   }
@@ -262,17 +292,17 @@ function mapCiStatus(status: PRStatus): CiStatus {
 
 function mapReviewStatus(status: PRStatus): ReviewStatus {
   if (status.reviews.length === 0) return "none";
-  // Use the most recent review state
-  const latest = status.reviews[status.reviews.length - 1];
+  // Filter to decisive review states — ignore COMMENTED/PENDING/DISMISSED
+  // which don't change the approval status. Take the latest decisive review.
+  const decisive = status.reviews.filter((r) => r.state === "APPROVED" || r.state === "CHANGES_REQUESTED");
+  if (decisive.length === 0) return "pending";
+  const latest = decisive[decisive.length - 1];
   switch (latest.state) {
     case "APPROVED":
       return "approved";
     case "CHANGES_REQUESTED":
       return "changes_requested";
-    case "COMMENTED":
-    case "PENDING":
-      return "pending";
     default:
-      return "none";
+      return "pending";
   }
 }

--- a/packages/daemon/src/github/work-item-poller.ts
+++ b/packages/daemon/src/github/work-item-poller.ts
@@ -1,0 +1,278 @@
+/**
+ * GitHub work item poller.
+ *
+ * Periodically fetches PR state from GitHub's GraphQL API and updates
+ * the work_items table when state changes. Emits WorkItemEvent via callback.
+ *
+ * Adaptive polling: 30s when active items exist, 5min when all stable.
+ *
+ * Phase 2a of #1049.
+ */
+
+import type { Logger, WorkItemEvent } from "@mcp-cli/core";
+import { consoleLogger } from "@mcp-cli/core";
+import type { CiStatus, PrState, ReviewStatus, WorkItem, WorkItemDb } from "../db/work-items";
+import { type FetchPRsOptions, type PRStatus, type RepoInfo, detectRepo, fetchTrackedPRs } from "./graphql-client";
+
+const ACTIVE_INTERVAL_MS = 30_000;
+const STABLE_INTERVAL_MS = 5 * 60_000;
+
+export interface WorkItemPollerOptions {
+  db: WorkItemDb;
+  logger?: Logger;
+  /** Override poll interval (ms). If set, disables adaptive interval. */
+  intervalMs?: number;
+  /** Injected for testing. */
+  fetchPRs?: (repo: RepoInfo, prNumbers: readonly number[], opts?: FetchPRsOptions) => Promise<PRStatus[]>;
+  /** Injected for testing. */
+  detectRepo?: (cwd?: string) => Promise<RepoInfo>;
+  /** Called on each work item event. */
+  onEvent?: (event: WorkItemEvent) => void;
+}
+
+export class WorkItemPoller {
+  private db: WorkItemDb;
+  private logger: Logger;
+  private fixedInterval: number | null;
+  private currentIntervalMs: number;
+  private timer: Timer | null = null;
+  private _repo: RepoInfo | null = null;
+  private _lastError: string | null = null;
+  private _pollCount = 0;
+  private fetchPRs: NonNullable<WorkItemPollerOptions["fetchPRs"]>;
+  private detectRepoFn: NonNullable<WorkItemPollerOptions["detectRepo"]>;
+  private onEvent: (event: WorkItemEvent) => void;
+
+  constructor(opts: WorkItemPollerOptions) {
+    this.db = opts.db;
+    this.logger = opts.logger ?? consoleLogger;
+    this.fixedInterval = opts.intervalMs ?? null;
+    this.currentIntervalMs = this.fixedInterval ?? ACTIVE_INTERVAL_MS;
+    this.fetchPRs = opts.fetchPRs ?? fetchTrackedPRs;
+    this.detectRepoFn = opts.detectRepo ?? detectRepo;
+    this.onEvent = opts.onEvent ?? (() => {});
+  }
+
+  get lastError(): string | null {
+    return this._lastError;
+  }
+
+  get pollCount(): number {
+    return this._pollCount;
+  }
+
+  get repo(): RepoInfo | null {
+    return this._repo;
+  }
+
+  /** Start polling. Does an immediate first poll. */
+  start(): void {
+    if (this.timer) return;
+    this.poll();
+    this.timer = setInterval(() => this.poll(), this.currentIntervalMs);
+  }
+
+  /** Stop polling and clean up. */
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** Run a single poll cycle. Exported for testing. */
+  async poll(): Promise<void> {
+    try {
+      // Detect repo on first poll
+      if (!this._repo) {
+        this._repo = await this.detectRepoFn();
+      }
+
+      const allItems = this.db.listWorkItems();
+      const tracked = allItems.filter((item) => item.prNumber !== null);
+
+      if (tracked.length === 0) {
+        this._lastError = null;
+        this._pollCount++;
+        this.adjustInterval(false);
+        return;
+      }
+
+      // Determine if any items are "active" (not done/merged/closed)
+      const hasActive = tracked.some(
+        (item) => item.phase !== "done" && item.prState !== "merged" && item.prState !== "closed",
+      );
+
+      // Safe: we filtered for prNumber !== null above
+      const prNumbers = tracked.map((item) => item.prNumber as number);
+      const statuses = await this.fetchPRs(this._repo, prNumbers);
+
+      // Build lookup by PR number
+      const statusMap = new Map<number, PRStatus>();
+      for (const s of statuses) {
+        statusMap.set(s.number, s);
+      }
+
+      // Compare and update
+      for (const item of tracked) {
+        const status = statusMap.get(item.prNumber as number);
+        if (!status) continue;
+        this.reconcile(item, status);
+      }
+
+      this._lastError = null;
+      this._pollCount++;
+      this.adjustInterval(hasActive);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this._lastError = msg;
+      this._pollCount++;
+      this.logger.warn(`[mcpd] Work item poll failed: ${msg}`);
+    }
+  }
+
+  /** Compare fetched PR status against stored work item and emit events for changes. */
+  private reconcile(item: WorkItem, status: PRStatus): void {
+    const prNumber = item.prNumber as number; // Safe: caller filters for non-null prNumber
+    const newPrState = mapPrState(status);
+    const newCiStatus = mapCiStatus(status);
+    const newReviewStatus = mapReviewStatus(status);
+
+    const patch: Partial<WorkItem> = {};
+    let changed = false;
+
+    // PR state changes
+    if (newPrState !== item.prState) {
+      patch.prState = newPrState;
+      changed = true;
+      this.emitPrEvent(prNumber, newPrState);
+    }
+
+    // CI status changes
+    if (newCiStatus !== item.ciStatus) {
+      patch.ciStatus = newCiStatus;
+      changed = true;
+      this.emitCiEvent(prNumber, newCiStatus, item.ciRunId ?? 0, status);
+    }
+
+    // Review status changes
+    if (newReviewStatus !== item.reviewStatus) {
+      patch.reviewStatus = newReviewStatus;
+      changed = true;
+      this.emitReviewEvent(prNumber, newReviewStatus, status);
+    }
+
+    if (changed) {
+      this.db.updateWorkItem(item.id, patch);
+      this.logger.info(`[mcpd] Work item ${item.id} (PR #${prNumber}) updated: ${JSON.stringify(patch)}`);
+    }
+  }
+
+  private emitPrEvent(prNumber: number, newState: PrState): void {
+    switch (newState) {
+      case "merged":
+        this.onEvent({ type: "pr:merged", prNumber });
+        break;
+      case "closed":
+        this.onEvent({ type: "pr:closed", prNumber });
+        break;
+      case "open":
+        this.onEvent({ type: "pr:opened", prNumber });
+        break;
+    }
+  }
+
+  private emitCiEvent(prNumber: number, newStatus: CiStatus, ciRunId: number, status: PRStatus): void {
+    switch (newStatus) {
+      case "passed":
+        this.onEvent({ type: "checks:passed", prNumber });
+        break;
+      case "failed": {
+        const failedCheck = status.ciChecks.find((c) => c.conclusion === "FAILURE");
+        this.onEvent({ type: "checks:failed", prNumber, failedJob: failedCheck?.name ?? "unknown" });
+        break;
+      }
+      case "running":
+      case "pending":
+        this.onEvent({ type: "checks:started", prNumber, runId: ciRunId });
+        break;
+    }
+  }
+
+  private emitReviewEvent(prNumber: number, newStatus: ReviewStatus, status: PRStatus): void {
+    switch (newStatus) {
+      case "approved":
+        this.onEvent({ type: "review:approved", prNumber });
+        break;
+      case "changes_requested": {
+        const reviewer = status.reviews.find((r) => r.state === "CHANGES_REQUESTED")?.author ?? "unknown";
+        this.onEvent({ type: "review:changes_requested", prNumber, reviewer });
+        break;
+      }
+    }
+  }
+
+  /** Adjust the polling interval based on whether active items exist. */
+  private adjustInterval(hasActive: boolean): void {
+    if (this.fixedInterval !== null) return;
+    const target = hasActive ? ACTIVE_INTERVAL_MS : STABLE_INTERVAL_MS;
+    if (target !== this.currentIntervalMs) {
+      this.currentIntervalMs = target;
+      // Restart the timer with the new interval
+      if (this.timer) {
+        clearInterval(this.timer);
+        this.timer = setInterval(() => this.poll(), this.currentIntervalMs);
+      }
+      this.logger.info(`[mcpd] Work item poll interval adjusted to ${target / 1000}s`);
+    }
+  }
+}
+
+// ---------- State mapping ----------
+
+function mapPrState(status: PRStatus): PrState {
+  switch (status.state) {
+    case "MERGED":
+      return "merged";
+    case "CLOSED":
+      return "closed";
+    case "OPEN":
+      return status.isDraft ? "draft" : "open";
+    default:
+      return "open";
+  }
+}
+
+function mapCiStatus(status: PRStatus): CiStatus {
+  if (!status.ciState) return "none";
+  switch (status.ciState) {
+    case "SUCCESS":
+      return "passed";
+    case "FAILURE":
+    case "ERROR":
+      return "failed";
+    case "PENDING":
+      return "pending";
+    case "EXPECTED":
+      return "running";
+    default:
+      return "none";
+  }
+}
+
+function mapReviewStatus(status: PRStatus): ReviewStatus {
+  if (status.reviews.length === 0) return "none";
+  // Use the most recent review state
+  const latest = status.reviews[status.reviews.length - 1];
+  switch (latest.state) {
+    case "APPROVED":
+      return "approved";
+    case "CHANGES_REQUESTED":
+      return "changes_requested";
+    case "COMMENTED":
+    case "PENDING":
+      return "pending";
+    default:
+      return "none";
+  }
+}

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -62,6 +62,7 @@ import { ConfigWatcher } from "./config/watcher";
 import { closeDaemonLogFile, installDaemonLogCapture, installDaemonLogFile } from "./daemon-log";
 import { StateDb } from "./db/state";
 import { WorkItemDb } from "./db/work-items";
+import { WorkItemPoller } from "./github/work-item-poller";
 import { IpcServer } from "./ipc-server";
 import { MailServer, buildMailToolCache } from "./mail-server";
 import { metrics } from "./metrics";
@@ -362,6 +363,10 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
   // Work items server: constructed lazily inside registerPendingVirtualServer
   // to keep migration errors from crashing the daemon (matches _metrics/_mail pattern).
   let workItemsServer: WorkItemsServer | null = null;
+
+  // GitHub poller: starts after work items DB is available.
+  // Polls tracked PRs and updates state in the work_items table.
+  let workItemPoller: WorkItemPoller | null = null;
 
   // Register uptime and server metrics
   const uptimeGauge = metrics.gauge("mcpd_uptime_seconds");
@@ -694,6 +699,17 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
           } = await workItemsServer.start();
           pool.registerVirtualServer(WORK_ITEMS_SERVER_NAME, workItemsClient, workItemsTransport, workItemsTools);
           logger.info("[mcpd] Work items server started");
+
+          // Start GitHub poller now that work items DB is ready
+          workItemPoller = new WorkItemPoller({
+            db: workItemDb,
+            logger,
+            onEvent: (event) => {
+              logger.info(`[mcpd] Work item event: ${JSON.stringify(event)}`);
+            },
+          });
+          workItemPoller.start();
+          logger.info("[mcpd] Work item poller started");
         } catch (err) {
           logger.error(`[mcpd] Failed to start work items server: ${err}`);
         }
@@ -717,6 +733,7 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
       clearInterval(pruneInterval);
       clearInterval(metricsInterval);
       quotaPoller.stop();
+      if (workItemPoller) workItemPoller.stop();
       try {
         watcher.stop();
       } catch (err) {


### PR DESCRIPTION
## Summary
- Adds `graphql-client.ts`: aliased per-PR GraphQL queries, `gh auth token` authentication with 401 retry, git remote URL parsing for repo detection
- Adds `work-item-poller.ts`: adaptive polling (30s for active items, 5min for stable), state diff engine that compares fetched PR/CI/review status against stored work items and emits `WorkItemEvent` via callback
- Integrated into daemon startup/shutdown lifecycle (starts after work items server, stops on shutdown)

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes  
- [x] 30 new tests across 2 spec files (graphql-client + work-item-poller)
- [x] Full test suite passes (4066 tests, 0 failures)
- [x] Coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)