### PR TITLE
feat(command): enriched mcx claude ls with work item lifecycle line (fixes #1142)

### DIFF
--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -24,12 +24,18 @@ import { getStaleDaemonWarning, ipcCall } from "../daemon-lifecycle";
 import { applyJqFilter } from "../jq/index";
 import { c, printError as defaultPrintError, formatToolResult } from "../output";
 import { extractFullFlag, extractJqFlag, extractJsonFlag } from "../parse";
-import { colorState, extractContentSummary, formatAge, formatSessionShort } from "./session-display";
+import {
+  colorState,
+  extractContentSummary,
+  formatAge,
+  formatLifecycleLine,
+  formatSessionShort,
+} from "./session-display";
 import type { SharedSpawnArgs } from "./spawn-args";
 import { parseSharedSpawnArgs } from "./spawn-args";
 import { ttyOpen } from "./tty";
 
-import type { QuotaStatusResult, SessionInfo } from "@mcp-cli/core";
+import type { QuotaStatusResult, SessionInfo, WorkItem } from "@mcp-cli/core";
 
 // ── Dependency injection ──
 
@@ -748,19 +754,35 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
     }
   }
 
-  const result = await d.callTool("claude_session_list", toolArgs);
+  // Fetch sessions and work items in parallel
+  const [result, workItems] = await Promise.all([
+    d.callTool("claude_session_list", toolArgs),
+    ipcCall("listWorkItems", {}, { timeoutMs: 2000 }).catch((): WorkItem[] => []),
+  ]);
   const text = formatToolResult(result);
-
-  if (json) {
-    console.log(text);
-    return;
-  }
 
   let sessions: SessionInfo[];
   try {
     sessions = JSON.parse(text);
   } catch {
-    console.log(text);
+    if (json) {
+      console.log(text);
+    } else {
+      console.log(text);
+    }
+    return;
+  }
+
+  // Join sessions → work items via worktree branch matching
+  const sessionWorkItems = joinSessionsToWorkItems(sessions, workItems);
+
+  if (json) {
+    // Enrich session objects with work_item field
+    const enriched = sessions.map((s) => ({
+      ...s,
+      workItem: sessionWorkItems.get(s.sessionId) ?? null,
+    }));
+    console.log(JSON.stringify(enriched, null, 2));
     return;
   }
 
@@ -822,6 +844,12 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
     console.log(
       `${c.cyan}${id}${c.reset}   ${stateStr} ${model} ${cost} ${tokens}${diff}${pr} ${c.dim}${cwd}${c.reset}${ageSuffix}`,
     );
+
+    // Work item lifecycle line (indented under the session)
+    const wi = sessionWorkItems.get(s.sessionId);
+    if (wi) {
+      console.log(`  ${formatLifecycleLine(wi)}`);
+    }
   }
 
   const staleWarning = getStaleDaemonWarning();
@@ -831,11 +859,76 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
 }
 
 // formatSessionShort, extractContentSummary, colorState → ./session-display.ts
-export { colorState, extractContentSummary, formatAge, formatSessionShort } from "./session-display";
+export {
+  colorState,
+  extractContentSummary,
+  formatAge,
+  formatLifecycleLine,
+  formatSessionShort,
+} from "./session-display";
 
 function formatPrStatus(pr: PrStatus | null): string {
   if (!pr) return "—";
   return `#${pr.number} ${pr.state}`;
+}
+
+/** Get the current git branch for a worktree path. Returns null on failure. */
+function getWorktreeBranch(worktreePath: string): string | null {
+  try {
+    const result = Bun.spawnSync(["git", "-C", worktreePath, "rev-parse", "--abbrev-ref", "HEAD"], {
+      stdout: "pipe",
+      stderr: "ignore",
+      timeout: 3000,
+    });
+    if (result.exitCode !== 0) return null;
+    const branch = result.stdout.toString().trim();
+    return branch && branch !== "HEAD" ? branch : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Build a map from session → work item by matching worktree branches to work item branches.
+ * Also matches by issue number extracted from branch name (e.g. feat/issue-1142-slug → #1142).
+ */
+function joinSessionsToWorkItems(sessions: SessionInfo[], workItems: WorkItem[]): Map<string, WorkItem> {
+  const byBranch = new Map<string, WorkItem>();
+  const byIssue = new Map<number, WorkItem>();
+  const byPr = new Map<number, WorkItem>();
+
+  for (const wi of workItems) {
+    if (wi.branch) byBranch.set(wi.branch, wi);
+    if (wi.issueNumber != null) byIssue.set(wi.issueNumber, wi);
+    if (wi.prNumber != null) byPr.set(wi.prNumber, wi);
+  }
+
+  const result = new Map<string, WorkItem>();
+
+  for (const s of sessions) {
+    if (!s.worktree) continue;
+    const branch = getWorktreeBranch(s.worktree);
+    if (!branch) continue;
+
+    // Try exact branch match first
+    const byBranchMatch = byBranch.get(branch);
+    if (byBranchMatch) {
+      result.set(s.sessionId, byBranchMatch);
+      continue;
+    }
+
+    // Try extracting issue number from branch name (e.g. feat/issue-1142-slug)
+    const issueMatch = branch.match(/issue-(\d+)/);
+    if (issueMatch) {
+      const num = Number(issueMatch[1]);
+      const byIssueMatch = byIssue.get(num);
+      if (byIssueMatch) {
+        result.set(s.sessionId, byIssueMatch);
+      }
+    }
+  }
+
+  return result;
 }
 
 async function claudeSend(args: string[], d: ClaudeDeps): Promise<void> {

--- a/packages/command/src/commands/session-display.spec.ts
+++ b/packages/command/src/commands/session-display.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type { WorkItem } from "@mcp-cli/core";
 import {
   type TranscriptEntry,
   compactTranscript,
@@ -6,6 +7,7 @@ import {
   filterByRepo,
   formatAge,
   formatCost,
+  formatLifecycleLine,
   formatSessionShort,
 } from "./session-display";
 
@@ -213,5 +215,134 @@ describe("formatSessionShort with createdAt", () => {
       rateLimited: false,
     });
     expect(line).not.toContain("[RATE LIMITED]");
+  });
+});
+
+// Strip ANSI escape codes for test assertions
+const ESC = String.fromCharCode(0x1b);
+const ANSI_RE = new RegExp(`${ESC}\\[[0-9;]*m`, "g");
+function stripAnsi(str: string): string {
+  return str.replace(ANSI_RE, "");
+}
+
+function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
+  return {
+    id: "#1135",
+    issueNumber: 1135,
+    branch: "feat/issue-1135-test",
+    prNumber: null,
+    prState: null,
+    prUrl: null,
+    ciStatus: "none",
+    ciRunId: null,
+    ciSummary: null,
+    reviewStatus: "none",
+    phase: "impl",
+    createdAt: "2026-04-10T00:00:00Z",
+    updatedAt: "2026-04-10T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("formatLifecycleLine", () => {
+  test("impl phase with no PR", () => {
+    const line = stripAnsi(formatLifecycleLine(makeWorkItem()));
+    expect(line).toBe("impl → (no PR yet)");
+  });
+
+  test("open PR with CI passed and review approved", () => {
+    const line = stripAnsi(
+      formatLifecycleLine(
+        makeWorkItem({
+          prNumber: 1135,
+          prState: "open",
+          ciStatus: "passed",
+          reviewStatus: "approved",
+        }),
+      ),
+    );
+    expect(line).toBe("impl → PR #1135 open → CI ✓ → review ✓");
+  });
+
+  test("open PR with CI failed", () => {
+    const line = stripAnsi(
+      formatLifecycleLine(
+        makeWorkItem({
+          prNumber: 1135,
+          prState: "open",
+          ciStatus: "failed",
+        }),
+      ),
+    );
+    expect(line).toBe("impl → PR #1135 open → CI ✗");
+  });
+
+  test("open PR with CI running and review pending", () => {
+    const line = stripAnsi(
+      formatLifecycleLine(
+        makeWorkItem({
+          prNumber: 1135,
+          prState: "open",
+          ciStatus: "running",
+          reviewStatus: "pending",
+        }),
+      ),
+    );
+    expect(line).toBe("impl → PR #1135 open → CI running → review pending");
+  });
+
+  test("merged PR shows merged checkmark", () => {
+    const line = stripAnsi(
+      formatLifecycleLine(
+        makeWorkItem({
+          prNumber: 1134,
+          prState: "merged",
+          phase: "done",
+          ciStatus: "passed",
+          reviewStatus: "approved",
+        }),
+      ),
+    );
+    expect(line).toBe("done → PR #1134 merged ✓");
+  });
+
+  test("closed PR shows closed", () => {
+    const line = stripAnsi(
+      formatLifecycleLine(
+        makeWorkItem({
+          prNumber: 1136,
+          prState: "closed",
+        }),
+      ),
+    );
+    expect(line).toBe("impl → PR #1136 closed");
+  });
+
+  test("draft PR state", () => {
+    const line = stripAnsi(
+      formatLifecycleLine(
+        makeWorkItem({
+          prNumber: 1137,
+          prState: "draft",
+          ciStatus: "none",
+        }),
+      ),
+    );
+    expect(line).toBe("impl → PR #1137 draft");
+  });
+
+  test("review phase with changes requested", () => {
+    const line = stripAnsi(
+      formatLifecycleLine(
+        makeWorkItem({
+          phase: "review",
+          prNumber: 1138,
+          prState: "open",
+          ciStatus: "passed",
+          reviewStatus: "changes_requested",
+        }),
+      ),
+    );
+    expect(line).toBe("review → PR #1138 open → CI ✓ → review changes requested");
   });
 });

--- a/packages/command/src/commands/session-display.ts
+++ b/packages/command/src/commands/session-display.ts
@@ -3,6 +3,7 @@
  */
 
 import { dirname, resolve } from "node:path";
+import type { WorkItem } from "@mcp-cli/core";
 import { c } from "../output";
 
 /** Transcript entry shape shared across providers. */
@@ -186,4 +187,61 @@ export function colorState(state: string): string {
     default:
       return padded;
   }
+}
+
+/**
+ * Format a work item lifecycle pipeline for display as a second line under a session.
+ *
+ * Examples:
+ *   impl → PR #1135 open → CI ✓ → QA pending
+ *   impl → PR #1134 merged ✓
+ *   impl (no PR yet)
+ */
+export function formatLifecycleLine(wi: WorkItem): string {
+  const parts: string[] = [wi.phase];
+
+  if (wi.prNumber != null) {
+    const prLabel = `PR #${wi.prNumber}`;
+    if (wi.prState === "merged") {
+      parts.push(`${prLabel} merged ${c.green}✓${c.reset}`);
+    } else if (wi.prState === "closed") {
+      parts.push(`${prLabel} ${c.red}closed${c.reset}`);
+    } else {
+      // open or draft
+      parts.push(`${prLabel} ${wi.prState ?? "open"}`);
+
+      // CI status (only relevant for open PRs)
+      switch (wi.ciStatus) {
+        case "passed":
+          parts.push(`CI ${c.green}✓${c.reset}`);
+          break;
+        case "failed":
+          parts.push(`CI ${c.red}✗${c.reset}`);
+          break;
+        case "running":
+        case "pending":
+          parts.push(`CI ${c.yellow}${wi.ciStatus}${c.reset}`);
+          break;
+        // "none" → omit
+      }
+
+      // Review status (only relevant for open PRs)
+      switch (wi.reviewStatus) {
+        case "approved":
+          parts.push(`review ${c.green}✓${c.reset}`);
+          break;
+        case "changes_requested":
+          parts.push(`review ${c.red}changes requested${c.reset}`);
+          break;
+        case "pending":
+          parts.push(`review ${c.yellow}pending${c.reset}`);
+          break;
+        // "none" → omit
+      }
+    }
+  } else {
+    parts.push("(no PR yet)");
+  }
+
+  return parts.join(" → ");
 }


### PR DESCRIPTION
## Summary
- Add a second line to `mcx claude ls` showing the work item lifecycle pipeline for each session: `phase → PR #N state → CI status → review → merge`
- Join sessions to work items by matching worktree git branch to work item branch (or extracting issue number from branch name pattern `issue-N`)
- `--json` flag now includes `workItem` object (or null) in each session entry
- `--short` flag unchanged (backwards compatible, no lifecycle line)
- Sessions without tracked work items gracefully degrade to single-line display

## Test plan
- [x] Added 8 tests for `formatLifecycleLine()` covering: no PR, open PR with CI/review states, merged PR, closed PR, draft PR, changes_requested
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (4209 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)