### PR TITLE
fix(ci): disable global coverage in bunfig.toml to fix Linux exit code 1 (fixes #1181)

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,8 +1,9 @@
 [test]
 
-# Always generate coverage report when running tests
-coverage = true
-coverageReporter = ["text"]
+# Coverage is collected on-demand via `--coverage` in scripts/check-coverage.ts.
+# Do NOT enable `coverage = true` here — Bun 1.3.12 on Linux exits non-zero
+# when coverage is collected on files with 0% coverage, even without a
+# configured threshold. This broke CI (see #1181).
 
 # Prune directories that should not be scanned for tests
 pathIgnorePatterns = ["scripts/**", ".claude/**", "dist/**", ".git-hooks/**"]


### PR DESCRIPTION
## Summary
- Remove `coverage = true` and `coverageReporter` from bunfig.toml — Bun 1.3.12 on Linux exits non-zero when coverage is collected on files with 0% coverage, even without a configured threshold
- Coverage collection is already handled on-demand by `scripts/check-coverage.ts` via explicit `--coverage` flag, so the global setting was redundant
- Added a comment explaining why `coverage = true` must not be re-enabled

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (2967 tests, 0 failures)
- [x] Pre-commit hook passes (coverage ratchet still works via `scripts/check-coverage.ts`)
- [ ] CI should pass on Linux (the fix removes the root cause of the exit code 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)