### PR TITLE
fix(install): use idempotent add_to_path for .profile fallback (fixes #1154)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -98,8 +98,8 @@ case ":$PATH:" in
     fi
     if [ "$added" = false ]; then
       # No rc file found — create .profile entry as fallback
-      printf '\n# mcp-cli\nexport PATH="%s:$PATH"\n' "$INSTALL_DIR" >> "$HOME/.profile"
-      echo "Added $INSTALL_DIR to PATH in ~/.profile"
+      touch "$HOME/.profile"
+      add_to_path "$HOME/.profile"
     fi
     echo "Restart your shell or run: export PATH=\"$INSTALL_DIR:\$PATH\""
     ;;


### PR DESCRIPTION
## Summary
- Replace direct `printf >>` to `~/.profile` with `touch` + `add_to_path()` call, matching the idempotency guard used for `.zshrc` and `.bashrc`
- Running `install.sh` multiple times on a machine with only `~/.profile` no longer appends duplicate PATH entries

## Test plan
- [x] Verified `add_to_path()` already handles the `grep -q` idempotency check
- [x] `touch` ensures the file exists so `add_to_path`'s `[ -f ]` guard passes
- [x] All 4221 tests pass, typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)