### PR TITLE
fix(daemon): trigger immediate poll when work items are tracked (fixes #1188)

### DIFF
--- a/packages/daemon/src/github/work-item-poller.spec.ts
+++ b/packages/daemon/src/github/work-item-poller.spec.ts
@@ -434,6 +434,51 @@ describe("WorkItemPoller", () => {
     }
   });
 
+  test("pollNow triggers an immediate poll cycle", async () => {
+    db.createWorkItem({ id: "pr:50", prNumber: 50, prState: "open" });
+
+    const events: WorkItemEvent[] = [];
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      intervalMs: 60_000, // Long interval — pollNow should bypass it
+      fetchPRs: async () => [makePRStatus({ number: 50, state: "MERGED" })],
+      detectRepo: async () => TEST_REPO,
+      onEvent: (e) => events.push(e),
+    });
+
+    poller.start();
+    // Wait for the initial poll from start() to complete
+    await Bun.sleep(50);
+    expect(poller.pollCount).toBe(1);
+
+    // Reset state so the next poll sees a change
+    db.updateWorkItem("pr:50", { prState: "open" });
+    events.length = 0;
+
+    poller.pollNow();
+    // Wait for the triggered poll to complete
+    await Bun.sleep(50);
+
+    expect(poller.pollCount).toBe(2);
+    expect(events).toContainEqual({ type: "pr:merged", prNumber: 50 });
+    poller.stop();
+  });
+
+  test("pollNow is a no-op when stopped", () => {
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => [],
+      detectRepo: async () => TEST_REPO,
+    });
+
+    poller.stop();
+    // Should not throw
+    poller.pollNow();
+    expect(poller.pollCount).toBe(0);
+  });
+
   test("EXPECTED status maps to pending, not running", async () => {
     db.createWorkItem({ id: "pr:12", prNumber: 12, ciStatus: "none" });
 

--- a/packages/daemon/src/github/work-item-poller.ts
+++ b/packages/daemon/src/github/work-item-poller.ts
@@ -74,6 +74,19 @@ export class WorkItemPoller {
     this.scheduleNext(0);
   }
 
+  /** Trigger an immediate poll cycle and reschedule the next tick.
+   *  Useful when a new item is tracked — avoids waiting up to 5 minutes. */
+  pollNow(): void {
+    if (this.stopped) return;
+    // Cancel the current timer and reschedule with 0 delay so the
+    // next tick runs immediately, then resumes at currentIntervalMs.
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.scheduleNext(0);
+  }
+
   /** Stop polling and clean up. In-flight polls will bail before writing. */
   stop(): void {
     this.stopped = true;

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -688,7 +688,17 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
       (async () => {
         try {
           const workItemDb = new WorkItemDb(db.database);
-          workItemsServer = new WorkItemsServer(workItemDb);
+
+          // Create the poller first so we can pass pollNow to the server
+          workItemPoller = new WorkItemPoller({
+            db: workItemDb,
+            logger,
+            onEvent: (event) => claudeServer.forwardWorkItemEvent(event),
+          });
+
+          workItemsServer = new WorkItemsServer(workItemDb, {
+            onTrack: () => workItemPoller?.pollNow(),
+          });
           const {
             client: workItemsClient,
             transport: workItemsTransport,
@@ -699,11 +709,6 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
 
           // Start the GitHub work item poller — forwards events to the claude session worker
           // so `mcx wait --any` / `--pr` / `--checks` can race work item events.
-          workItemPoller = new WorkItemPoller({
-            db: workItemDb,
-            logger,
-            onEvent: (event) => claudeServer.forwardWorkItemEvent(event),
-          });
           workItemPoller.start();
           logger.info("[mcpd] Work item poller started");
         } catch (err) {

--- a/packages/daemon/src/work-items-server.spec.ts
+++ b/packages/daemon/src/work-items-server.spec.ts
@@ -492,6 +492,22 @@ describe("WorkItemsServer", () => {
     expect(content[0].text).toContain("Expected integer");
   });
 
+  test("work_items_track calls onTrack callback", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+
+    let trackCallCount = 0;
+    server = new WorkItemsServer(db, { onTrack: () => trackCallCount++ });
+
+    const { client } = await server.start();
+    await client.callTool({ name: "work_items_track", arguments: { prNumber: 99 } });
+    expect(trackCallCount).toBe(1);
+
+    // Second track call also fires
+    await client.callTool({ name: "work_items_track", arguments: { prNumber: 100 } });
+    expect(trackCallCount).toBe(2);
+  });
+
   test("start() throws if called twice", async () => {
     const { db, raw } = createWorkItemDb();
     rawDb = raw;

--- a/packages/daemon/src/work-items-server.ts
+++ b/packages/daemon/src/work-items-server.ts
@@ -126,8 +126,15 @@ export class WorkItemsServer {
   private client: Client | null = null;
   private serverTransport: Transport | null = null;
   private clientTransport: Transport | null = null;
+  private workItemDb: WorkItemDb;
 
-  constructor(private workItemDb: WorkItemDb) {}
+  /** Called after a work item is tracked/updated so the poller can run immediately. */
+  private onTrack: (() => void) | null;
+
+  constructor(workItemDb: WorkItemDb, opts?: { onTrack?: () => void }) {
+    this.workItemDb = workItemDb;
+    this.onTrack = opts?.onTrack ?? null;
+  }
 
   async start(): Promise<{ client: Client; transport: Transport; tools: Map<string, ToolInfo> }> {
     if (this.server) {
@@ -193,6 +200,7 @@ export class WorkItemsServer {
               prUrl: a.prUrl !== undefined ? String(a.prUrl) : undefined,
               phase: (a.phase as WorkItemPhase | undefined) ?? (existing ? undefined : "impl"),
             });
+            this.onTrack?.();
             return { content: [{ type: "text" as const, text: JSON.stringify(item) }] };
           }
 


### PR DESCRIPTION
## Summary
- Add `pollNow()` method to `WorkItemPoller` — cancels current timer and reschedules with zero delay for an immediate poll cycle
- `WorkItemsServer` accepts an `onTrack` callback, called after each `work_items_track` upsert
- Wired in `index.ts`: server's `onTrack` calls `workItemPoller.pollNow()`

## Test plan
- [x] `pollNow()` triggers an immediate poll cycle (new test in poller spec)
- [x] `pollNow()` is a no-op when stopped (new test)
- [x] `onTrack` callback fires on each `work_items_track` call (new test in server spec)
- [x] All 4156 existing tests pass, 0 failures
- [x] 100% line coverage on work-item-poller.ts
- [x] Typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)