### PR TITLE
fix(clone): quote numeric strings in frontmatter YAML to preserve type on round-trip (fixes #1182)

### DIFF
--- a/packages/clone/src/engine/frontmatter.spec.ts
+++ b/packages/clone/src/engine/frontmatter.spec.ts
@@ -4,7 +4,7 @@ import { hasFrontmatter, injectFrontmatter, stripFrontmatter } from "./frontmatt
 describe("injectFrontmatter", () => {
   test("injects frontmatter into plain content", () => {
     const result = injectFrontmatter("Hello world", { id: "123", title: "My Page" });
-    expect(result).toBe("---\nid: 123\ntitle: My Page\n---\n\nHello world");
+    expect(result).toBe('---\nid: "123"\ntitle: My Page\n---\n\nHello world');
   });
 
   test("replaces existing frontmatter", () => {
@@ -22,7 +22,7 @@ describe("injectFrontmatter", () => {
     const result = injectFrontmatter("body", { id: "1", url: undefined, extra: null });
     expect(result).not.toContain("url");
     expect(result).not.toContain("extra");
-    expect(result).toContain("id: 1");
+    expect(result).toContain('id: "1"');
   });
 
   test("handles numbers and booleans", () => {
@@ -33,7 +33,7 @@ describe("injectFrontmatter", () => {
 
   test("handles empty content", () => {
     const result = injectFrontmatter("", { id: "1" });
-    expect(result).toBe("---\nid: 1\n---\n\n");
+    expect(result).toBe('---\nid: "1"\n---\n\n');
   });
 });
 
@@ -79,6 +79,26 @@ describe("stripFrontmatter", () => {
     expect(content).toBe(original);
     expect(fields?.id).toBe("abc-123");
     expect(fields?.version).toBe(7);
+  });
+
+  test("round-trips numeric string IDs without type loss", () => {
+    const original = "Page content";
+    const fm = { id: "1234567890", version: 3, title: "Confluence Page" };
+    const injected = injectFrontmatter(original, fm);
+    const { content, fields } = stripFrontmatter(injected);
+    expect(content).toBe(original);
+    expect(fields?.id).toBe("1234567890");
+    expect(typeof fields?.id).toBe("string");
+    expect(fields?.version).toBe(3);
+  });
+
+  test("round-trips boolean-like strings without type loss", () => {
+    const injected = injectFrontmatter("body", { flag: "true", label: "false" });
+    const { fields } = stripFrontmatter(injected);
+    expect(fields?.flag).toBe("true");
+    expect(typeof fields?.flag).toBe("string");
+    expect(fields?.label).toBe("false");
+    expect(typeof fields?.label).toBe("string");
   });
 });
 

--- a/packages/clone/src/engine/frontmatter.ts
+++ b/packages/clone/src/engine/frontmatter.ts
@@ -46,8 +46,15 @@ function toYaml(obj: Record<string, unknown>): string {
 
 function formatYamlValue(value: unknown): string {
   if (typeof value === "string") {
-    // Quote strings that contain special YAML characters
-    if (/[:#\[\]{},&*!|>'"%@`]/.test(value) || value.includes("\n") || value.trim() !== value) {
+    // Quote strings that contain special YAML characters or look like numbers/booleans
+    if (
+      /[:#\[\]{},&*!|>'"%@`]/.test(value) ||
+      value.includes("\n") ||
+      value.trim() !== value ||
+      /^-?\d+(\.\d+)?([eE][+-]?\d+)?$/.test(value) ||
+      value === "true" ||
+      value === "false"
+    ) {
       return JSON.stringify(value);
     }
     return value;


### PR DESCRIPTION
## Summary
- `formatYamlValue` now quotes strings that look like numbers or booleans (`"123"`, `"true"`, `"false"`) so they round-trip through YAML without type coercion
- Fixes Confluence page IDs (numeric strings) being parsed back as numbers after inject → strip

## Test plan
- [x] Updated existing tests to expect quoted numeric string values
- [x] Added round-trip test for numeric string IDs — verifies `typeof` stays `"string"`
- [x] Added round-trip test for boolean-like strings (`"true"`, `"false"`)
- [x] All 4223 tests pass, typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)