### PR TITLE
fix(daemon): add PRAGMA user_version migration versioning to WorkItemDb (fixes #1158)

### DIFF
--- a/packages/daemon/src/db/work-items.spec.ts
+++ b/packages/daemon/src/db/work-items.spec.ts
@@ -301,5 +301,84 @@ describe("WorkItemDb", () => {
       // Second call should be fine (CREATE TABLE IF NOT EXISTS)
       expect(() => new WorkItemDb(raw)).not.toThrow();
     });
+
+    test("sets user_version to 1 on fresh database", () => {
+      const p = tmpDb();
+      paths.push(p);
+      const raw = new Database(p, { create: true });
+      raw.exec("PRAGMA journal_mode = WAL");
+      new WorkItemDb(raw);
+      const version = raw.query<{ user_version: number }, []>("PRAGMA user_version").get()?.user_version;
+      expect(version).toBe(1);
+    });
+
+    test("skips migration when user_version is already current", () => {
+      const p = tmpDb();
+      paths.push(p);
+      const raw = new Database(p, { create: true });
+      raw.exec("PRAGMA journal_mode = WAL");
+
+      // Manually create the table and set version to simulate existing DB
+      raw.exec(`
+        CREATE TABLE work_items (
+          id              TEXT PRIMARY KEY,
+          issue_number    INTEGER UNIQUE,
+          branch          TEXT UNIQUE,
+          pr_number       INTEGER UNIQUE,
+          pr_state        TEXT DEFAULT 'open',
+          pr_url          TEXT,
+          ci_status       TEXT DEFAULT 'none',
+          ci_run_id       INTEGER,
+          ci_summary      TEXT,
+          review_status   TEXT DEFAULT 'none',
+          phase           TEXT DEFAULT 'impl',
+          created_at      TEXT DEFAULT (datetime('now')),
+          updated_at      TEXT DEFAULT (datetime('now'))
+        );
+        PRAGMA user_version = 1;
+      `);
+
+      // Should not error — migration is a no-op
+      expect(() => new WorkItemDb(raw)).not.toThrow();
+    });
+
+    test("upgrades pre-versioned database (user_version = 0) with existing table", () => {
+      const p = tmpDb();
+      paths.push(p);
+      const raw = new Database(p, { create: true });
+      raw.exec("PRAGMA journal_mode = WAL");
+
+      // Simulate pre-versioned DB: table exists but user_version is 0
+      raw.exec(`
+        CREATE TABLE work_items (
+          id              TEXT PRIMARY KEY,
+          issue_number    INTEGER UNIQUE,
+          branch          TEXT UNIQUE,
+          pr_number       INTEGER UNIQUE,
+          pr_state        TEXT DEFAULT 'open',
+          pr_url          TEXT,
+          ci_status       TEXT DEFAULT 'none',
+          ci_run_id       INTEGER,
+          ci_summary      TEXT,
+          review_status   TEXT DEFAULT 'none',
+          phase           TEXT DEFAULT 'impl',
+          created_at      TEXT DEFAULT (datetime('now')),
+          updated_at      TEXT DEFAULT (datetime('now'))
+        );
+      `);
+
+      // Insert data before migration
+      raw.exec("INSERT INTO work_items (id, issue_number) VALUES ('existing-1', 99)");
+
+      // Migration should succeed (CREATE TABLE IF NOT EXISTS is idempotent)
+      const db = new WorkItemDb(raw);
+      const version = raw.query<{ user_version: number }, []>("PRAGMA user_version").get()?.user_version;
+      expect(version).toBe(1);
+
+      // Existing data should be preserved
+      const item = db.getWorkItemByIssue(99);
+      expect(item).not.toBeNull();
+      expect(item?.id).toBe("existing-1");
+    });
   });
 });

--- a/packages/daemon/src/db/work-items.ts
+++ b/packages/daemon/src/db/work-items.ts
@@ -62,30 +62,41 @@ export class WorkItemDb {
     this.migrate();
   }
 
+  /**
+   * Versioned migration using PRAGMA user_version.
+   *
+   * NOTE: user_version is database-wide. This works because WorkItemDb is
+   * currently the only consumer. If StateDb (which shares this connection)
+   * ever needs versioned migrations, switch to a per-table schema_versions table.
+   */
   private migrate(): void {
-    this.db.exec(`
-      CREATE TABLE IF NOT EXISTS work_items (
-        id              TEXT PRIMARY KEY,
-        issue_number    INTEGER UNIQUE,
-        branch          TEXT UNIQUE,
-        pr_number       INTEGER UNIQUE,
-        pr_state        TEXT DEFAULT 'open',
-        pr_url          TEXT,
-        ci_status       TEXT DEFAULT 'none',
-        ci_run_id       INTEGER,
-        ci_summary      TEXT,
-        review_status   TEXT DEFAULT 'none',
-        phase           TEXT DEFAULT 'impl',
-        created_at      TEXT DEFAULT (datetime('now')),
-        updated_at      TEXT DEFAULT (datetime('now'))
-      );
-      -- For existing tables that lack these constraints, add indexes.
-      -- CREATE UNIQUE INDEX IF NOT EXISTS is a no-op if the index already exists.
-      CREATE UNIQUE INDEX IF NOT EXISTS idx_work_items_issue_number
-        ON work_items(issue_number) WHERE issue_number IS NOT NULL;
-      CREATE UNIQUE INDEX IF NOT EXISTS idx_work_items_branch
-        ON work_items(branch) WHERE branch IS NOT NULL;
-    `);
+    const version = this.db.query<{ user_version: number }, []>("PRAGMA user_version").get()?.user_version ?? 0;
+
+    if (version < 1) {
+      this.db.exec(`
+        CREATE TABLE IF NOT EXISTS work_items (
+          id              TEXT PRIMARY KEY,
+          issue_number    INTEGER UNIQUE,
+          branch          TEXT UNIQUE,
+          pr_number       INTEGER UNIQUE,
+          pr_state        TEXT DEFAULT 'open',
+          pr_url          TEXT,
+          ci_status       TEXT DEFAULT 'none',
+          ci_run_id       INTEGER,
+          ci_summary      TEXT,
+          review_status   TEXT DEFAULT 'none',
+          phase           TEXT DEFAULT 'impl',
+          created_at      TEXT DEFAULT (datetime('now')),
+          updated_at      TEXT DEFAULT (datetime('now'))
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_work_items_issue_number
+          ON work_items(issue_number) WHERE issue_number IS NOT NULL;
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_work_items_branch
+          ON work_items(branch) WHERE branch IS NOT NULL;
+        PRAGMA user_version = 1;
+      `);
+    }
+    // Future: if (version < 2) { ALTER TABLE work_items ADD COLUMN ...; PRAGMA user_version = 2; }
   }
 
   createWorkItem(item: Partial<WorkItem>): WorkItem {


### PR DESCRIPTION
## Summary
- Rewrites `WorkItemDb.migrate()` to use `PRAGMA user_version` for versioned schema migrations
- Wraps existing `CREATE TABLE IF NOT EXISTS` in a `version < 1` guard so future `ALTER TABLE` additions (Phase 2+ of #1049) won't silently no-op
- Adds 3 new migration tests: version stamp on fresh DB, skip when current, and upgrade of pre-versioned DB with existing data

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — 2967 tests pass, 0 failures
- [x] 100% coverage on `work-items.ts`
- [x] Migration idempotency: constructor called twice on same DB does not error
- [x] Pre-versioned upgrade: existing table with data at user_version=0 gets upgraded to v1 with data preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)