### PR TITLE
chore(daemon): import work-item types from core instead of re-exporting (fixes #1153)

### DIFF
--- a/packages/daemon/src/db/work-items.ts
+++ b/packages/daemon/src/db/work-items.ts
@@ -8,13 +8,6 @@
 import type { Database } from "bun:sqlite";
 import { randomUUIDv7 } from "bun";
 
-export type {
-  WorkItemPhase,
-  PrState,
-  CiStatus,
-  ReviewStatus,
-  WorkItem,
-} from "@mcp-cli/core";
 import type { CiStatus, PrState, ReviewStatus, WorkItem, WorkItemPhase } from "@mcp-cli/core";
 
 /** Snake-case row shape from SQLite. */

--- a/packages/daemon/src/github/work-item-poller.ts
+++ b/packages/daemon/src/github/work-item-poller.ts
@@ -11,7 +11,8 @@
 
 import type { Logger, WorkItemEvent } from "@mcp-cli/core";
 import { consoleLogger } from "@mcp-cli/core";
-import type { CiStatus, PrState, ReviewStatus, WorkItem, WorkItemDb } from "../db/work-items";
+import type { CiStatus, PrState, ReviewStatus, WorkItem } from "@mcp-cli/core";
+import type { WorkItemDb } from "../db/work-items";
 import { type FetchPRsOptions, type PRStatus, type RepoInfo, detectRepo, fetchTrackedPRs } from "./graphql-client";
 
 const ACTIVE_INTERVAL_MS = 30_000;


### PR DESCRIPTION
## Summary
- Removed unnecessary `export type { ... } from "@mcp-cli/core"` re-export block from `packages/daemon/src/db/work-items.ts`
- Updated `packages/daemon/src/github/work-item-poller.ts` to import `CiStatus`, `PrState`, `ReviewStatus`, `WorkItem` directly from `@mcp-cli/core` instead of through the db module

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (4221 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)