### PR TITLE
feat(vfs): Jira Issues provider (fixes #1167)

### DIFF
--- a/packages/clone/src/engine/cache.ts
+++ b/packages/clone/src/engine/cache.ts
@@ -177,7 +177,9 @@ export class CloneCache {
 
   /** Find the provider name from the first scope_meta row (when we don't know which provider was used). */
   findProviderName(): string | null {
-    const row = this.db.query("SELECT provider FROM scope_meta LIMIT 1").get() as { provider: string } | null;
+    const row = this.db.query("SELECT provider FROM scope_meta ORDER BY rowid LIMIT 1").get() as {
+      provider: string;
+    } | null;
     return row?.provider ?? null;
   }
 

--- a/packages/clone/src/engine/cache.ts
+++ b/packages/clone/src/engine/cache.ts
@@ -175,6 +175,12 @@ export class CloneCache {
       .run(new Date().toISOString(), provider, scopeKey);
   }
 
+  /** Find the provider name from the first scope_meta row (when we don't know which provider was used). */
+  findProviderName(): string | null {
+    const row = this.db.query("SELECT provider FROM scope_meta LIMIT 1").get() as { provider: string } | null;
+    return row?.provider ?? null;
+  }
+
   /** Remove an entry. */
   remove(provider: string, cloudId: string, id: string): void {
     this.db.query("DELETE FROM entries WHERE provider = ? AND cloud_id = ? AND id = ?").run(provider, cloudId, id);

--- a/packages/clone/src/engine/push.ts
+++ b/packages/clone/src/engine/push.ts
@@ -128,7 +128,7 @@ export async function push(opts: PushOptions): Promise<PushSyncResult> {
     const localFileSet = new Set(localFiles);
 
     // ── Categorize changes ───────────────────────────────────
-    const modified: Array<{ cached: CachedEntry; rawContent: string }> = [];
+    const modified: Array<{ cached: CachedEntry; rawContent: string; fields: Record<string, unknown> | null }> = [];
     const created: Array<{ relPath: string; rawContent: string; title: string }> = [];
     const deleted: CachedEntry[] = [];
 
@@ -141,11 +141,11 @@ export async function push(opts: PushOptions): Promise<PushSyncResult> {
 
       const absPath = join(repoDir, cached.localPath);
       const localContent = readFileSync(absPath, "utf-8");
-      const { content: rawContent } = stripFrontmatter(localContent);
+      const { content: rawContent, fields } = stripFrontmatter(localContent);
       const hash = contentHash(rawContent);
 
       if (hash !== cached.contentHash) {
-        modified.push({ cached, rawContent });
+        modified.push({ cached, rawContent, fields });
       }
     }
 
@@ -209,8 +209,8 @@ export async function push(opts: PushOptions): Promise<PushSyncResult> {
 
     // ── Push modifications ───────────────────────────────────
     if (provider.push) {
-      for (const { cached, rawContent } of modified) {
-        await pushModified(opts, provider, scope, cache, cached, rawContent, result);
+      for (const { cached, rawContent, fields } of modified) {
+        await pushModified(opts, provider, scope, cache, cached, rawContent, fields, result);
       }
     }
 
@@ -253,11 +253,12 @@ async function pushModified(
   cache: CloneCache,
   cached: CachedEntry,
   rawContent: string,
+  fields: Record<string, unknown> | null,
   result: PushSyncResult,
 ): Promise<void> {
   log(opts, `  pushing ${cached.localPath}...`);
   try {
-    const pushResult = await provider.push?.(scope, cached.id, rawContent, cached.version);
+    const pushResult = await provider.push?.(scope, cached.id, rawContent, cached.version, fields ?? undefined);
     if (!pushResult) throw new Error("Provider push returned no result");
 
     if (pushResult.ok) {

--- a/packages/clone/src/index.ts
+++ b/packages/clone/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./providers/provider";
 export * from "./providers/confluence";
+export * from "./providers/jira";
 export * from "./engine/cache";
 export * from "./engine/clone";
 export * from "./engine/frontmatter";

--- a/packages/clone/src/providers/confluence.ts
+++ b/packages/clone/src/providers/confluence.ts
@@ -1,7 +1,15 @@
 /**
  * Confluence provider — maps a Confluence space to a local directory of markdown files.
  */
-import type { ChangeEvent, FetchResult, RemoteEntry, RemoteProvider, ResolvedScope, Scope } from "./provider";
+import type {
+  ChangeEvent,
+  FetchResult,
+  McpToolCaller,
+  RemoteEntry,
+  RemoteProvider,
+  ResolvedScope,
+  Scope,
+} from "./provider";
 
 /** Thrown when CQL search returns truncated results, signaling the caller to fall back to full sync. */
 export class TruncatedChangesError extends Error {
@@ -68,13 +76,8 @@ interface ResourcesResponse {
   avatarUrl?: string;
 }
 
-/** Function signature for calling MCP tools via the daemon. */
-export type McpToolCaller = (
-  server: string,
-  tool: string,
-  args: Record<string, unknown>,
-  timeoutMs?: number,
-) => Promise<unknown>;
+// McpToolCaller is now defined in provider.ts and re-exported here for backwards compatibility.
+export type { McpToolCaller } from "./provider";
 
 /** MCP tool call result shape. */
 interface McpToolResult {

--- a/packages/clone/src/providers/jira.spec.ts
+++ b/packages/clone/src/providers/jira.spec.ts
@@ -6,7 +6,7 @@ function makeScope(key = "FOO"): ResolvedScope {
   return {
     key,
     cloudId: "cloud-123",
-    resolved: { projectKey: key },
+    resolved: { projectKey: key, siteUrl: "https://mycompany.atlassian.net" },
   };
 }
 
@@ -138,7 +138,31 @@ describe("frontmatter", () => {
     expect(fm.assignee).toBe("Jane Developer");
     expect(fm.labels).toEqual(["auth", "captain"]);
     expect(fm.parent).toBe("FOO-1000");
-    expect(fm.url).toContain("FOO-1234");
+    expect(fm.url).toBe("https://mycompany.atlassian.net/browse/FOO-1234");
+  });
+
+  test("uses siteUrl from resolved scope for URL, not cloudId", () => {
+    const provider = createJiraProvider({ callTool: async () => null });
+    const scope: ResolvedScope = {
+      key: "FOO",
+      cloudId: "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      resolved: { projectKey: "FOO", siteUrl: "https://acme.atlassian.net" },
+    };
+    const entry = makeEntry({ id: "FOO-42" });
+    const fm = provider.frontmatter(entry, scope);
+    expect(fm.url).toBe("https://acme.atlassian.net/browse/FOO-42");
+  });
+
+  test("falls back to cloudId-based URL when siteUrl not in scope", () => {
+    const provider = createJiraProvider({ callTool: async () => null });
+    const scope: ResolvedScope = {
+      key: "FOO",
+      cloudId: "cloud-123",
+      resolved: { projectKey: "FOO" },
+    };
+    const entry = makeEntry({ id: "FOO-42" });
+    const fm = provider.frontmatter(entry, scope);
+    expect(fm.url).toBe("https://cloud-123.atlassian.net/browse/FOO-42");
   });
 
   test("omits parent field when not present", () => {
@@ -333,6 +357,166 @@ describe("create", () => {
     await createFn(scope, "FOO-1", "Subtask", "Sub content");
     expect(capturedArgs.parent).toBe("FOO-1");
   });
+
+  test("uses configurable defaultIssueType", async () => {
+    const scope = makeScope();
+    let capturedArgs: Record<string, unknown> = {};
+    const provider = createJiraProvider({
+      callTool: async (_server, tool, args) => {
+        if (tool === "createJiraIssue") {
+          capturedArgs = args;
+          return wrapMcpResult(makeIssueResponse("FOO-101", "Story Issue"));
+        }
+        return null;
+      },
+      defaultIssueType: "Story",
+    });
+
+    const createFn = provider.create as NonNullable<typeof provider.create>;
+    await createFn(scope, undefined, "Story Issue", "Content");
+    expect(capturedArgs.issueTypeName).toBe("Story");
+  });
+});
+
+describe("push (frontmatter fields)", () => {
+  test("pushes summary from frontmatter when changed", async () => {
+    const scope = makeScope();
+    const baseVersion = new Date("2026-01-01T00:00:00Z").getTime();
+    let capturedFields: Record<string, unknown> = {};
+    const provider = createJiraProvider({
+      callTool: async (_server, tool, args) => {
+        if (tool === "getJiraIssue") {
+          return wrapMcpResult(makeIssueResponse("FOO-1", "Old Title", "2026-01-01T00:00:00Z"));
+        }
+        if (tool === "editJiraIssue") {
+          capturedFields = args.fields as Record<string, unknown>;
+          return wrapMcpResult({});
+        }
+        return null;
+      },
+    });
+
+    const pushFn = provider.push as NonNullable<typeof provider.push>;
+    const result = await pushFn(scope, "FOO-1", "Updated body", baseVersion, { summary: "New Title" });
+    expect(result.ok).toBe(true);
+    expect(capturedFields.summary).toBe("New Title");
+    expect(capturedFields.description).toBe("Updated body");
+  });
+
+  test("does not push summary when unchanged", async () => {
+    const scope = makeScope();
+    const baseVersion = new Date("2026-01-01T00:00:00Z").getTime();
+    let capturedFields: Record<string, unknown> = {};
+    const provider = createJiraProvider({
+      callTool: async (_server, tool, args) => {
+        if (tool === "getJiraIssue") {
+          return wrapMcpResult(makeIssueResponse("FOO-1", "Same Title", "2026-01-01T00:00:00Z"));
+        }
+        if (tool === "editJiraIssue") {
+          capturedFields = args.fields as Record<string, unknown>;
+          return wrapMcpResult({});
+        }
+        return null;
+      },
+    });
+
+    const pushFn = provider.push as NonNullable<typeof provider.push>;
+    await pushFn(scope, "FOO-1", "Body", baseVersion, { summary: "Same Title" });
+    expect(capturedFields.summary).toBeUndefined();
+  });
+});
+
+describe("push (NaN version guard)", () => {
+  test("returns error when remote updated field is malformed", async () => {
+    const scope = makeScope();
+    const provider = createJiraProvider({
+      callTool: async (_server, tool) => {
+        if (tool === "getJiraIssue") {
+          return wrapMcpResult({
+            id: "10001",
+            key: "FOO-1",
+            fields: {
+              summary: "Issue",
+              updated: "not-a-date",
+              created: "2026-01-01T00:00:00Z",
+            },
+          });
+        }
+        return null;
+      },
+    });
+
+    const pushFn = provider.push as NonNullable<typeof provider.push>;
+    const result = await pushFn(scope, "FOO-1", "Content", 1);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("missing or malformed");
+  });
+});
+
+describe("toRemoteEntry (NaN guard)", () => {
+  test("defaults version to 0 for null updated field", async () => {
+    const scope = makeScope();
+    const provider = createJiraProvider({
+      callTool: async (_server, tool) => {
+        if (tool === "getJiraIssue") {
+          return wrapMcpResult({
+            id: "10001",
+            key: "FOO-1",
+            fields: {
+              summary: "Issue",
+              description: "Body",
+              updated: null,
+              created: "2026-01-01T00:00:00Z",
+            },
+          });
+        }
+        return null;
+      },
+    });
+
+    const result = await provider.fetch(scope, "FOO-1");
+    expect(result.entry.version).toBe(0);
+    expect(Number.isNaN(result.entry.version)).toBe(false);
+  });
+});
+
+describe("resolveScope", () => {
+  test("stores siteUrl from resources response", async () => {
+    const provider = createJiraProvider({
+      callTool: async (_server, tool) => {
+        if (tool === "getAccessibleAtlassianResources") {
+          return [{ id: "cloud-1", url: "https://acme.atlassian.net", name: "Acme", scopes: [] }];
+        }
+        return null;
+      },
+    });
+    const resolved = await provider.resolveScope({ key: "FOO" });
+    expect(resolved.resolved.siteUrl).toBe("https://acme.atlassian.net");
+  });
+
+  test("warns on multiple resources but still resolves", async () => {
+    const stderrMessages: string[] = [];
+    const origError = console.error;
+    console.error = (...args: unknown[]) => stderrMessages.push(args.join(" "));
+    try {
+      const provider = createJiraProvider({
+        callTool: async (_server, tool) => {
+          if (tool === "getAccessibleAtlassianResources") {
+            return [
+              { id: "cloud-1", url: "https://acme.atlassian.net", name: "Acme", scopes: [] },
+              { id: "cloud-2", url: "https://corp.atlassian.net", name: "Corp", scopes: [] },
+            ];
+          }
+          return null;
+        },
+      });
+      const resolved = await provider.resolveScope({ key: "FOO" });
+      expect(resolved.cloudId).toBe("cloud-1");
+      expect(stderrMessages.some((m) => m.includes("2 Atlassian instances"))).toBe(true);
+    } finally {
+      console.error = origError;
+    }
+  });
 });
 
 describe("changes", () => {
@@ -355,6 +539,28 @@ describe("changes", () => {
       changes.push(change);
     }
     expect(changes).toHaveLength(1);
+  });
+
+  test("formats JQL date in UTC", async () => {
+    const scope = makeScope();
+    let capturedJql = "";
+    const provider = createJiraProvider({
+      callTool: async (_server, tool, args) => {
+        if (tool === "searchJiraIssuesUsingJql") {
+          capturedJql = args.jql as string;
+          return wrapMcpResult({ issues: [] });
+        }
+        return null;
+      },
+    });
+
+    const changesFn = provider.changes as NonNullable<typeof provider.changes>;
+    // Use a timestamp where UTC and local time differ for most timezones
+    for await (const _change of changesFn(scope, "2026-03-15T03:30:00Z")) {
+      // drain
+    }
+    // The JQL date should be in UTC: 2026-03-15 03:30
+    expect(capturedJql).toContain('updated >= "2026-03-15 03:30"');
   });
 
   test("paginates changes via nextPageToken", async () => {

--- a/packages/clone/src/providers/jira.spec.ts
+++ b/packages/clone/src/providers/jira.spec.ts
@@ -1,0 +1,389 @@
+import { describe, expect, test } from "bun:test";
+import { createJiraProvider } from "./jira";
+import type { RemoteEntry, ResolvedScope } from "./provider";
+
+function makeScope(key = "FOO"): ResolvedScope {
+  return {
+    key,
+    cloudId: "cloud-123",
+    resolved: { projectKey: key },
+  };
+}
+
+function makeEntry(overrides: Partial<RemoteEntry> = {}): RemoteEntry {
+  return {
+    id: "FOO-1",
+    title: "Test Issue",
+    version: new Date("2026-01-01T00:00:00Z").getTime(),
+    lastModified: "2026-01-01T00:00:00Z",
+    metadata: {
+      numericId: "10001",
+      status: "In Progress",
+      type: "Task",
+      priority: "High",
+      assignee: "Jane Developer",
+      labels: ["auth"],
+      created: "2026-01-01T00:00:00Z",
+    },
+    ...overrides,
+  };
+}
+
+function makeIssueResponse(key: string, summary: string, updated = "2026-01-01T00:00:00Z") {
+  return {
+    id: "10001",
+    key,
+    fields: {
+      summary,
+      status: { name: "In Progress" },
+      issuetype: { name: "Task" },
+      priority: { name: "High" },
+      assignee: { displayName: "Jane Developer" },
+      labels: ["auth"],
+      description: `# ${summary}\n\nDescription content.`,
+      updated,
+      created: "2026-01-01T00:00:00Z",
+      parent: undefined,
+    },
+  };
+}
+
+function wrapMcpResult(data: unknown) {
+  return { content: [{ type: "text", text: JSON.stringify(data) }] };
+}
+
+describe("validateScopeKey (via resolveScope)", () => {
+  function makeCallTool(): (server: string, tool: string, args: Record<string, unknown>) => Promise<unknown> {
+    return async () => null;
+  }
+
+  test("rejects keys with double-quotes (JQL injection)", async () => {
+    const provider = createJiraProvider({ callTool: makeCallTool() });
+    await expect(provider.resolveScope({ key: '"OR 1=1--' })).rejects.toThrow("Invalid scope key");
+  });
+
+  test("rejects keys with spaces", async () => {
+    const provider = createJiraProvider({ callTool: makeCallTool() });
+    await expect(provider.resolveScope({ key: "FOO BAR" })).rejects.toThrow("Invalid scope key");
+  });
+
+  test("accepts alphanumeric keys", async () => {
+    const provider = createJiraProvider({
+      callTool: async (_server, tool) => {
+        if (tool === "getAccessibleAtlassianResources") {
+          return [{ id: "cloud-1", url: "https://example.atlassian.net", name: "Example", scopes: [] }];
+        }
+        return null;
+      },
+    });
+    const resolved = await provider.resolveScope({ key: "FOO123" });
+    expect(resolved.key).toBe("FOO123");
+    expect(resolved.cloudId).toBe("cloud-1");
+  });
+
+  test("uses provided cloudId without auto-discovery", async () => {
+    let calledResources = false;
+    const provider = createJiraProvider({
+      callTool: async (_server, tool) => {
+        if (tool === "getAccessibleAtlassianResources") calledResources = true;
+        return null;
+      },
+    });
+    const resolved = await provider.resolveScope({ key: "FOO", cloudId: "my-cloud" });
+    expect(resolved.cloudId).toBe("my-cloud");
+    expect(calledResources).toBe(false);
+  });
+});
+
+describe("toPath", () => {
+  test("returns issue key as filename", () => {
+    const provider = createJiraProvider({ callTool: async () => null });
+    const entry = makeEntry({ id: "FOO-1234" });
+    expect(provider.toPath(entry, [entry])).toBe("FOO-1234.md");
+  });
+
+  test("ignores other entries (flat structure)", () => {
+    const provider = createJiraProvider({ callTool: async () => null });
+    const e1 = makeEntry({ id: "FOO-1" });
+    const e2 = makeEntry({ id: "FOO-2" });
+    expect(provider.toPath(e1, [e1, e2])).toBe("FOO-1.md");
+    expect(provider.toPath(e2, [e1, e2])).toBe("FOO-2.md");
+  });
+});
+
+describe("frontmatter", () => {
+  test("returns expected fields", () => {
+    const provider = createJiraProvider({ callTool: async () => null });
+    const scope = makeScope();
+    const entry = makeEntry({
+      id: "FOO-1234",
+      title: "Fix authentication timeout",
+      metadata: {
+        numericId: "10001",
+        status: "In Progress",
+        type: "Task",
+        priority: "High",
+        assignee: "Jane Developer",
+        labels: ["auth", "captain"],
+        parent: "FOO-1000",
+      },
+    });
+    const fm = provider.frontmatter(entry, scope);
+    expect(fm.key).toBe("FOO-1234");
+    expect(fm.id).toBe("10001");
+    expect(fm.summary).toBe("Fix authentication timeout");
+    expect(fm.status).toBe("In Progress");
+    expect(fm.type).toBe("Task");
+    expect(fm.priority).toBe("High");
+    expect(fm.assignee).toBe("Jane Developer");
+    expect(fm.labels).toEqual(["auth", "captain"]);
+    expect(fm.parent).toBe("FOO-1000");
+    expect(fm.url).toContain("FOO-1234");
+  });
+
+  test("omits parent field when not present", () => {
+    const provider = createJiraProvider({ callTool: async () => null });
+    const scope = makeScope();
+    const entry = makeEntry({ metadata: { numericId: "10001", labels: [] } });
+    const fm = provider.frontmatter(entry, scope);
+    expect(fm.parent).toBeUndefined();
+  });
+});
+
+describe("list", () => {
+  test("yields all issues from a single response", async () => {
+    const scope = makeScope();
+    const provider = createJiraProvider({
+      callTool: async (_server, tool) => {
+        if (tool === "searchJiraIssuesUsingJql") {
+          return wrapMcpResult({
+            issues: [makeIssueResponse("FOO-1", "Issue 1"), makeIssueResponse("FOO-2", "Issue 2")],
+          });
+        }
+        return null;
+      },
+    });
+
+    const entries: RemoteEntry[] = [];
+    for await (const entry of provider.list(scope)) {
+      entries.push(entry);
+    }
+    expect(entries).toHaveLength(2);
+    expect(entries[0].id).toBe("FOO-1");
+    expect(entries[1].id).toBe("FOO-2");
+  });
+
+  test("paginates via nextPageToken", async () => {
+    const scope = makeScope();
+    let callCount = 0;
+    const provider = createJiraProvider({
+      callTool: async (_server, tool) => {
+        if (tool === "searchJiraIssuesUsingJql") {
+          callCount++;
+          if (callCount === 1) {
+            return wrapMcpResult({
+              issues: [makeIssueResponse("FOO-1", "Issue 1")],
+              nextPageToken: "page2",
+            });
+          }
+          return wrapMcpResult({
+            issues: [makeIssueResponse("FOO-2", "Issue 2")],
+          });
+        }
+        return null;
+      },
+    });
+
+    const entries: RemoteEntry[] = [];
+    for await (const entry of provider.list(scope)) {
+      entries.push(entry);
+    }
+    expect(entries).toHaveLength(2);
+    expect(callCount).toBe(2);
+  });
+
+  test("includes inline content from description", async () => {
+    const scope = makeScope();
+    const provider = createJiraProvider({
+      callTool: async (_server, tool) => {
+        if (tool === "searchJiraIssuesUsingJql") {
+          return wrapMcpResult({
+            issues: [makeIssueResponse("FOO-1", "Issue 1")],
+          });
+        }
+        return null;
+      },
+    });
+
+    const entries: RemoteEntry[] = [];
+    for await (const entry of provider.list(scope)) {
+      entries.push(entry);
+    }
+    expect(entries[0].content).toContain("Description content.");
+  });
+});
+
+describe("fetch", () => {
+  test("fetches a single issue by key", async () => {
+    const scope = makeScope();
+    const provider = createJiraProvider({
+      callTool: async (_server, tool) => {
+        if (tool === "getJiraIssue") {
+          return wrapMcpResult(makeIssueResponse("FOO-1", "My Issue"));
+        }
+        return null;
+      },
+    });
+
+    const result = await provider.fetch(scope, "FOO-1");
+    expect(result.entry.id).toBe("FOO-1");
+    expect(result.entry.title).toBe("My Issue");
+    expect(result.content).toContain("My Issue");
+  });
+});
+
+describe("push", () => {
+  test("returns ok: true on success", async () => {
+    const scope = makeScope();
+    const baseVersion = new Date("2026-01-01T00:00:00Z").getTime();
+    const provider = createJiraProvider({
+      callTool: async (_server, tool) => {
+        if (tool === "getJiraIssue") {
+          // Return same timestamp on first check, then updated on re-fetch
+          return wrapMcpResult(makeIssueResponse("FOO-1", "Issue", "2026-01-01T00:00:00Z"));
+        }
+        if (tool === "editJiraIssue") {
+          return wrapMcpResult({});
+        }
+        return null;
+      },
+    });
+
+    const pushFn = provider.push as NonNullable<typeof provider.push>;
+    const result = await pushFn(scope, "FOO-1", "Updated content", baseVersion);
+    expect(result.ok).toBe(true);
+  });
+
+  test("detects conflict via updated timestamp", async () => {
+    const scope = makeScope();
+    const baseVersion = new Date("2026-01-01T00:00:00Z").getTime();
+    const provider = createJiraProvider({
+      callTool: async (_server, tool) => {
+        if (tool === "getJiraIssue") {
+          // Remote is newer than base
+          return wrapMcpResult(makeIssueResponse("FOO-1", "Issue", "2026-02-01T00:00:00Z"));
+        }
+        return null;
+      },
+    });
+
+    const pushFn = provider.push as NonNullable<typeof provider.push>;
+    const result = await pushFn(scope, "FOO-1", "Content", baseVersion);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("conflict");
+  });
+
+  test("returns ok: false with error message on API error", async () => {
+    const scope = makeScope();
+    const provider = createJiraProvider({
+      callTool: async () => {
+        throw new Error("Network timeout");
+      },
+    });
+
+    const pushFn = provider.push as NonNullable<typeof provider.push>;
+    const result = await pushFn(scope, "FOO-1", "Content", 1);
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("Network timeout");
+  });
+});
+
+describe("create", () => {
+  test("creates a new issue and returns the entry", async () => {
+    const scope = makeScope();
+    const provider = createJiraProvider({
+      callTool: async (_server, tool) => {
+        if (tool === "createJiraIssue") {
+          return wrapMcpResult(makeIssueResponse("FOO-99", "New Issue"));
+        }
+        return null;
+      },
+    });
+
+    const createFn = provider.create as NonNullable<typeof provider.create>;
+    const entry = await createFn(scope, undefined, "New Issue", "Content here");
+    expect(entry.id).toBe("FOO-99");
+    expect(entry.title).toBe("New Issue");
+  });
+
+  test("passes parent key for subtasks", async () => {
+    const scope = makeScope();
+    let capturedArgs: Record<string, unknown> = {};
+    const provider = createJiraProvider({
+      callTool: async (_server, tool, args) => {
+        if (tool === "createJiraIssue") {
+          capturedArgs = args;
+          return wrapMcpResult(makeIssueResponse("FOO-100", "Subtask"));
+        }
+        return null;
+      },
+    });
+
+    const createFn = provider.create as NonNullable<typeof provider.create>;
+    await createFn(scope, "FOO-1", "Subtask", "Sub content");
+    expect(capturedArgs.parent).toBe("FOO-1");
+  });
+});
+
+describe("changes", () => {
+  test("yields changed issues since timestamp", async () => {
+    const scope = makeScope();
+    const provider = createJiraProvider({
+      callTool: async (_server, tool) => {
+        if (tool === "searchJiraIssuesUsingJql") {
+          return wrapMcpResult({
+            issues: [makeIssueResponse("FOO-1", "Updated Issue", "2026-02-01T00:00:00Z")],
+          });
+        }
+        return null;
+      },
+    });
+
+    const changesFn = provider.changes as NonNullable<typeof provider.changes>;
+    const changes: unknown[] = [];
+    for await (const change of changesFn(scope, "2026-01-01T00:00:00Z")) {
+      changes.push(change);
+    }
+    expect(changes).toHaveLength(1);
+  });
+
+  test("paginates changes via nextPageToken", async () => {
+    const scope = makeScope();
+    let callCount = 0;
+    const provider = createJiraProvider({
+      callTool: async (_server, tool) => {
+        if (tool === "searchJiraIssuesUsingJql") {
+          callCount++;
+          if (callCount === 1) {
+            return wrapMcpResult({
+              issues: [makeIssueResponse("FOO-1", "Issue 1")],
+              nextPageToken: "next",
+            });
+          }
+          return wrapMcpResult({
+            issues: [makeIssueResponse("FOO-2", "Issue 2")],
+          });
+        }
+        return null;
+      },
+    });
+
+    const changesFn = provider.changes as NonNullable<typeof provider.changes>;
+    const changes: unknown[] = [];
+    for await (const change of changesFn(scope, "2026-01-01T00:00:00Z")) {
+      changes.push(change);
+    }
+    expect(changes).toHaveLength(2);
+    expect(callCount).toBe(2);
+  });
+});

--- a/packages/clone/src/providers/jira.ts
+++ b/packages/clone/src/providers/jira.ts
@@ -1,8 +1,15 @@
-import type { McpToolCaller } from "./confluence";
 /**
  * Jira provider — maps a Jira project's issues to a local directory of markdown files.
  */
-import type { ChangeEvent, FetchResult, RemoteEntry, RemoteProvider, ResolvedScope, Scope } from "./provider";
+import type {
+  ChangeEvent,
+  FetchResult,
+  McpToolCaller,
+  RemoteEntry,
+  RemoteProvider,
+  ResolvedScope,
+  Scope,
+} from "./provider";
 
 /** Shape of an issue from the Jira REST/MCP API. */
 interface JiraIssue {
@@ -68,13 +75,17 @@ function validateScopeKey(key: string): void {
 export interface JiraProviderOptions {
   /** Function to call an MCP tool: (server, tool, args, timeoutMs?) → result */
   callTool: McpToolCaller;
+  /** Default issue type name for create (default: "Task"). */
+  defaultIssueType?: string;
 }
 
 /** Convert a Jira issue to a RemoteEntry. */
 function toRemoteEntry(issue: JiraIssue): RemoteEntry {
   const f = issue.fields;
-  // Jira has no version number — use updated timestamp as epoch ms for ordering
-  const updatedMs = new Date(f.updated).getTime();
+  // Jira has no version number — use updated timestamp as epoch ms for ordering.
+  // Guard against null/malformed dates: default to 0 so conflict detection remains functional.
+  const parsedMs = new Date(f.updated).getTime();
+  const updatedMs = Number.isNaN(parsedMs) ? 0 : parsedMs;
   return {
     id: issue.key,
     title: f.summary,
@@ -110,7 +121,7 @@ const SEARCH_FIELDS = [
 ];
 
 export function createJiraProvider(opts: JiraProviderOptions): RemoteProvider {
-  const { callTool } = opts;
+  const { callTool, defaultIssueType = "Task" } = opts;
   const SERVER = "atlassian";
 
   async function callAtlassian(tool: string, args: Record<string, unknown>): Promise<unknown> {
@@ -124,6 +135,7 @@ export function createJiraProvider(opts: JiraProviderOptions): RemoteProvider {
     async resolveScope(scope: Scope): Promise<ResolvedScope> {
       validateScopeKey(scope.key);
       let cloudId = scope.cloudId;
+      let siteUrl: string | undefined;
 
       // Auto-discover cloudId if not provided
       if (!cloudId) {
@@ -131,8 +143,15 @@ export function createJiraProvider(opts: JiraProviderOptions): RemoteProvider {
         if (!resources || (Array.isArray(resources) && resources.length === 0)) {
           throw new Error("No accessible Atlassian resources found. Check your authentication.");
         }
+        if (Array.isArray(resources) && resources.length > 1) {
+          console.error(
+            `[jira] Warning: ${resources.length} Atlassian instances found (${resources.map((r) => r.name).join(", ")}). ` +
+              `Using "${resources[0].name}". Pass --cloud-id explicitly to select a different instance.`,
+          );
+        }
         const resource = Array.isArray(resources) ? resources[0] : resources;
         cloudId = resource.id;
+        siteUrl = resource.url;
       }
 
       return {
@@ -140,6 +159,7 @@ export function createJiraProvider(opts: JiraProviderOptions): RemoteProvider {
         cloudId,
         resolved: {
           projectKey: scope.key,
+          ...(siteUrl ? { siteUrl } : {}),
         },
       };
     },
@@ -183,9 +203,9 @@ export function createJiraProvider(opts: JiraProviderOptions): RemoteProvider {
     },
 
     async *changes(scope: ResolvedScope, since: string): AsyncIterable<ChangeEvent> {
-      // Convert ISO timestamp to JQL date format (yyyy-MM-dd HH:mm)
+      // Convert ISO timestamp to JQL date format (yyyy-MM-dd HH:mm) using UTC to avoid timezone drift
       const sinceDate = new Date(since);
-      const jqlDate = `${sinceDate.getFullYear()}-${String(sinceDate.getMonth() + 1).padStart(2, "0")}-${String(sinceDate.getDate()).padStart(2, "0")} ${String(sinceDate.getHours()).padStart(2, "0")}:${String(sinceDate.getMinutes()).padStart(2, "0")}`;
+      const jqlDate = `${sinceDate.getUTCFullYear()}-${String(sinceDate.getUTCMonth() + 1).padStart(2, "0")}-${String(sinceDate.getUTCDate()).padStart(2, "0")} ${String(sinceDate.getUTCHours()).padStart(2, "0")}:${String(sinceDate.getUTCMinutes()).padStart(2, "0")}`;
 
       const jql = `project = "${scope.key}" AND updated >= "${jqlDate}" ORDER BY updated DESC`;
       let nextPageToken: string | undefined;
@@ -220,6 +240,7 @@ export function createJiraProvider(opts: JiraProviderOptions): RemoteProvider {
 
     frontmatter(entry: RemoteEntry, scope: ResolvedScope): Record<string, unknown> {
       const m = entry.metadata;
+      const siteUrl = (scope.resolved.siteUrl as string) ?? `https://${scope.cloudId}.atlassian.net`;
       return {
         key: entry.id,
         id: m.numericId as string,
@@ -231,11 +252,17 @@ export function createJiraProvider(opts: JiraProviderOptions): RemoteProvider {
         labels: m.labels,
         ...(m.parent ? { parent: m.parent } : {}),
         updated: entry.lastModified,
-        url: `https://${scope.cloudId}.atlassian.net/browse/${entry.id}`,
+        url: `${siteUrl.replace(/\/$/, "")}/browse/${entry.id}`,
       };
     },
 
-    async push(scope: ResolvedScope, id: string, content: string, baseVersion: number) {
+    async push(
+      scope: ResolvedScope,
+      id: string,
+      content: string,
+      baseVersion: number,
+      frontmatter?: Record<string, unknown>,
+    ) {
       try {
         // Fetch current issue to check for conflicts via updated timestamp
         const current = (await callAtlassian("getJiraIssue", {
@@ -245,6 +272,12 @@ export function createJiraProvider(opts: JiraProviderOptions): RemoteProvider {
         })) as JiraIssue;
 
         const currentVersion = new Date(current.fields.updated).getTime();
+        if (Number.isNaN(currentVersion)) {
+          return {
+            ok: false,
+            error: `Cannot determine remote version for issue ${id}: 'updated' field is missing or malformed.`,
+          };
+        }
         if (currentVersion > baseVersion) {
           return {
             ok: false,
@@ -252,10 +285,16 @@ export function createJiraProvider(opts: JiraProviderOptions): RemoteProvider {
           };
         }
 
+        // Build fields to push — always include description, plus any editable frontmatter fields
+        const fields: Record<string, unknown> = { description: content };
+        if (frontmatter?.summary && frontmatter.summary !== current.fields.summary) {
+          fields.summary = frontmatter.summary;
+        }
+
         await callAtlassian("editJiraIssue", {
           cloudId: scope.cloudId,
           issueIdOrKey: id,
-          fields: { description: content },
+          fields,
           contentFormat: "markdown",
         });
 
@@ -280,7 +319,7 @@ export function createJiraProvider(opts: JiraProviderOptions): RemoteProvider {
       const args: Record<string, unknown> = {
         cloudId: scope.cloudId,
         projectKey: scope.key,
-        issueTypeName: "Task",
+        issueTypeName: defaultIssueType,
         summary: title,
         description: content,
         contentFormat: "markdown",

--- a/packages/clone/src/providers/jira.ts
+++ b/packages/clone/src/providers/jira.ts
@@ -1,0 +1,296 @@
+import type { McpToolCaller } from "./confluence";
+/**
+ * Jira provider — maps a Jira project's issues to a local directory of markdown files.
+ */
+import type { ChangeEvent, FetchResult, RemoteEntry, RemoteProvider, ResolvedScope, Scope } from "./provider";
+
+/** Shape of an issue from the Jira REST/MCP API. */
+interface JiraIssue {
+  id: string;
+  key: string;
+  fields: {
+    summary: string;
+    status?: { name: string };
+    issuetype?: { name: string };
+    priority?: { name: string };
+    assignee?: { displayName: string } | null;
+    labels?: string[];
+    description?: string;
+    updated: string;
+    created: string;
+    parent?: { key: string };
+  };
+}
+
+/** Shape of a Jira search response. */
+interface JiraSearchResponse {
+  issues: JiraIssue[];
+  nextPageToken?: string;
+  total?: number;
+}
+
+/** Shape of accessible Atlassian resources response. */
+interface ResourcesResponse {
+  id: string;
+  url: string;
+  name: string;
+  scopes: string[];
+}
+
+/** MCP tool call result shape. */
+interface McpToolResult {
+  content: Array<{ type: string; text: string }>;
+  isError?: boolean;
+}
+
+/** Extract and parse JSON from an MCP tool call result. */
+function unwrapToolResult(result: unknown): unknown {
+  const mcpResult = result as McpToolResult;
+  if (mcpResult?.content?.[0]?.type === "text") {
+    const text = mcpResult.content[0].text;
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+  return result;
+}
+
+/** Validate a scope key to prevent JQL injection. Only alphanumeric, hyphens, and underscores allowed. */
+function validateScopeKey(key: string): void {
+  if (!/^[a-zA-Z0-9_-]+$/.test(key)) {
+    throw new Error(`Invalid scope key "${key}": must contain only alphanumeric characters, hyphens, and underscores.`);
+  }
+}
+
+/** Options for creating the Jira provider. */
+export interface JiraProviderOptions {
+  /** Function to call an MCP tool: (server, tool, args, timeoutMs?) → result */
+  callTool: McpToolCaller;
+}
+
+/** Convert a Jira issue to a RemoteEntry. */
+function toRemoteEntry(issue: JiraIssue): RemoteEntry {
+  const f = issue.fields;
+  // Jira has no version number — use updated timestamp as epoch ms for ordering
+  const updatedMs = new Date(f.updated).getTime();
+  return {
+    id: issue.key,
+    title: f.summary,
+    parentId: f.parent?.key,
+    version: updatedMs,
+    lastModified: f.updated,
+    content: f.description ?? "",
+    metadata: {
+      numericId: issue.id,
+      status: f.status?.name,
+      type: f.issuetype?.name,
+      priority: f.priority?.name,
+      assignee: f.assignee?.displayName ?? undefined,
+      labels: f.labels ?? [],
+      created: f.created,
+      parent: f.parent?.key,
+    },
+  };
+}
+
+/** Standard JQL fields to request from search. */
+const SEARCH_FIELDS = [
+  "summary",
+  "status",
+  "issuetype",
+  "priority",
+  "assignee",
+  "labels",
+  "description",
+  "updated",
+  "created",
+  "parent",
+];
+
+export function createJiraProvider(opts: JiraProviderOptions): RemoteProvider {
+  const { callTool } = opts;
+  const SERVER = "atlassian";
+
+  async function callAtlassian(tool: string, args: Record<string, unknown>): Promise<unknown> {
+    const raw = await callTool(SERVER, tool, args, 30_000);
+    return unwrapToolResult(raw);
+  }
+
+  const provider: RemoteProvider = {
+    name: "jira",
+
+    async resolveScope(scope: Scope): Promise<ResolvedScope> {
+      validateScopeKey(scope.key);
+      let cloudId = scope.cloudId;
+
+      // Auto-discover cloudId if not provided
+      if (!cloudId) {
+        const resources = (await callAtlassian("getAccessibleAtlassianResources", {})) as ResourcesResponse[];
+        if (!resources || (Array.isArray(resources) && resources.length === 0)) {
+          throw new Error("No accessible Atlassian resources found. Check your authentication.");
+        }
+        const resource = Array.isArray(resources) ? resources[0] : resources;
+        cloudId = resource.id;
+      }
+
+      return {
+        key: scope.key,
+        cloudId,
+        resolved: {
+          projectKey: scope.key,
+        },
+      };
+    },
+
+    async *list(scope: ResolvedScope): AsyncIterable<RemoteEntry> {
+      const jql = `project = "${scope.key}" ORDER BY key ASC`;
+      let nextPageToken: string | undefined;
+
+      do {
+        const args: Record<string, unknown> = {
+          cloudId: scope.cloudId,
+          jql,
+          fields: SEARCH_FIELDS,
+          responseContentFormat: "markdown",
+          maxResults: 100,
+        };
+        if (nextPageToken) args.nextPageToken = nextPageToken;
+
+        const resp = (await callAtlassian("searchJiraIssuesUsingJql", args)) as JiraSearchResponse;
+
+        for (const issue of resp.issues ?? []) {
+          yield toRemoteEntry(issue);
+        }
+
+        nextPageToken = resp.nextPageToken;
+      } while (nextPageToken);
+    },
+
+    async fetch(scope: ResolvedScope, id: string): Promise<FetchResult> {
+      const resp = (await callAtlassian("getJiraIssue", {
+        cloudId: scope.cloudId,
+        issueIdOrKey: id,
+        responseContentFormat: "markdown",
+      })) as JiraIssue;
+
+      const entry = toRemoteEntry(resp);
+      return {
+        content: entry.content ?? "",
+        entry,
+      };
+    },
+
+    async *changes(scope: ResolvedScope, since: string): AsyncIterable<ChangeEvent> {
+      // Convert ISO timestamp to JQL date format (yyyy-MM-dd HH:mm)
+      const sinceDate = new Date(since);
+      const jqlDate = `${sinceDate.getFullYear()}-${String(sinceDate.getMonth() + 1).padStart(2, "0")}-${String(sinceDate.getDate()).padStart(2, "0")} ${String(sinceDate.getHours()).padStart(2, "0")}:${String(sinceDate.getMinutes()).padStart(2, "0")}`;
+
+      const jql = `project = "${scope.key}" AND updated >= "${jqlDate}" ORDER BY updated DESC`;
+      let nextPageToken: string | undefined;
+
+      do {
+        const args: Record<string, unknown> = {
+          cloudId: scope.cloudId,
+          jql,
+          fields: SEARCH_FIELDS,
+          responseContentFormat: "markdown",
+          maxResults: 100,
+        };
+        if (nextPageToken) args.nextPageToken = nextPageToken;
+
+        const resp = (await callAtlassian("searchJiraIssuesUsingJql", args)) as JiraSearchResponse;
+
+        for (const issue of resp.issues ?? []) {
+          yield {
+            entry: toRemoteEntry(issue),
+            type: "updated",
+          };
+        }
+
+        nextPageToken = resp.nextPageToken;
+      } while (nextPageToken);
+    },
+
+    toPath(entry: RemoteEntry, _entries: RemoteEntry[]): string {
+      // Flat structure: issue key is the filename
+      return `${entry.id}.md`;
+    },
+
+    frontmatter(entry: RemoteEntry, scope: ResolvedScope): Record<string, unknown> {
+      const m = entry.metadata;
+      return {
+        key: entry.id,
+        id: m.numericId as string,
+        summary: entry.title,
+        status: m.status,
+        type: m.type,
+        priority: m.priority,
+        assignee: m.assignee,
+        labels: m.labels,
+        ...(m.parent ? { parent: m.parent } : {}),
+        updated: entry.lastModified,
+        url: `https://${scope.cloudId}.atlassian.net/browse/${entry.id}`,
+      };
+    },
+
+    async push(scope: ResolvedScope, id: string, content: string, baseVersion: number) {
+      try {
+        // Fetch current issue to check for conflicts via updated timestamp
+        const current = (await callAtlassian("getJiraIssue", {
+          cloudId: scope.cloudId,
+          issueIdOrKey: id,
+          responseContentFormat: "markdown",
+        })) as JiraIssue;
+
+        const currentVersion = new Date(current.fields.updated).getTime();
+        if (currentVersion > baseVersion) {
+          return {
+            ok: false,
+            error: `Version conflict: issue ${id} was updated remotely (${current.fields.updated}). Pull first to get the latest version.`,
+          };
+        }
+
+        await callAtlassian("editJiraIssue", {
+          cloudId: scope.cloudId,
+          issueIdOrKey: id,
+          fields: { description: content },
+          contentFormat: "markdown",
+        });
+
+        // Fetch the updated issue to get the new timestamp
+        const updated = (await callAtlassian("getJiraIssue", {
+          cloudId: scope.cloudId,
+          issueIdOrKey: id,
+          responseContentFormat: "markdown",
+        })) as JiraIssue;
+
+        return {
+          ok: true,
+          newVersion: new Date(updated.fields.updated).getTime(),
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return { ok: false, error: message };
+      }
+    },
+
+    async create(scope: ResolvedScope, parentId: string | undefined, title: string, content: string) {
+      const args: Record<string, unknown> = {
+        cloudId: scope.cloudId,
+        projectKey: scope.key,
+        issueTypeName: "Task",
+        summary: title,
+        description: content,
+        contentFormat: "markdown",
+      };
+      if (parentId) args.parent = parentId;
+
+      const resp = (await callAtlassian("createJiraIssue", args)) as JiraIssue;
+      return toRemoteEntry(resp);
+    },
+  };
+
+  return provider;
+}

--- a/packages/clone/src/providers/provider.ts
+++ b/packages/clone/src/providers/provider.ts
@@ -108,8 +108,14 @@ export interface RemoteProvider {
 
   // ── Phase 2: Write support ─────────────────────────────────
 
-  /** Push updated content to the remote. */
-  push?(scope: ResolvedScope, id: string, content: string, baseVersion: number): Promise<PushResult>;
+  /** Push updated content to the remote. Frontmatter fields (if provided) allow updating metadata like summary/title. */
+  push?(
+    scope: ResolvedScope,
+    id: string,
+    content: string,
+    baseVersion: number,
+    frontmatter?: Record<string, unknown>,
+  ): Promise<PushResult>;
 
   /** Validate content before push. */
   validate?(content: string): ValidationResult;
@@ -133,3 +139,11 @@ export interface ResolvedScope extends Scope {
   /** Provider-specific resolved metadata (e.g., spaceId for Confluence). */
   resolved: Record<string, unknown>;
 }
+
+/** Function type for calling an MCP tool on a named server. */
+export type McpToolCaller = (
+  server: string,
+  tool: string,
+  args: Record<string, unknown>,
+  timeoutMs?: number,
+) => Promise<unknown>;

--- a/packages/command/src/commands/vfs.ts
+++ b/packages/command/src/commands/vfs.ts
@@ -8,7 +8,7 @@
  */
 import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
-import { CloneCache, clone, createConfluenceProvider, pull, push } from "@mcp-cli/clone";
+import { CloneCache, clone, createConfluenceProvider, createJiraProvider, pull, push } from "@mcp-cli/clone";
 import type { McpToolCaller } from "@mcp-cli/clone";
 import { ipcCall } from "../daemon-lifecycle";
 import { printError } from "../output";
@@ -120,8 +120,10 @@ function resolveProvider(name: string) {
   switch (name) {
     case "confluence":
       return createConfluenceProvider({ callTool });
+    case "jira":
+      return createJiraProvider({ callTool });
     default:
-      printError(`Unknown provider: "${name}". Available: confluence`);
+      printError(`Unknown provider: "${name}". Available: confluence, jira`);
       process.exit(1);
   }
 }
@@ -134,36 +136,41 @@ function resolveProviderFromCache(repoDir: string) {
   }
 
   const cache = new CloneCache(cachePath);
-  const scope = cache.findFirstScope("confluence");
+  const providerName = cache.findProviderName();
   cache.close();
 
-  if (!scope) {
+  if (!providerName) {
     printError("No provider scope found in cache.");
     process.exit(1);
   }
 
-  // For now, only Confluence. Extend when more providers land.
-  return createConfluenceProvider({ callTool });
+  return resolveProvider(providerName);
 }
 
 function printUsage(): void {
   process.stderr.write(`mcx vfs — virtual filesystem: clone, sync, and edit remote content locally
 
 Usage:
-  mcx vfs clone confluence <space> [dir]   Clone a Confluence space as a local git repo
+  mcx vfs clone <provider> <scope> [dir]   Clone remote content as a local git repo
   mcx vfs pull [dir]                       Pull remote changes (incremental)
   mcx vfs pull --full [dir]                Pull all pages (detects deletions)
   mcx vfs push [dir]                       Push local changes to the remote
   mcx --dry-run vfs push [dir]             Show what would be pushed
 
+Providers:
+  confluence   Clone a Confluence space (scope = space key)
+  jira         Clone Jira project issues (scope = project key)
+
 Options:
   --cloud-id <id>     Atlassian cloud ID (auto-discovered if omitted)
-  --limit <n>         Max pages to fetch (for testing)
+  --limit <n>         Max items to fetch (for testing)
   --full              Force full sync instead of incremental
+  --create            Create new remote items from local files (push only)
 
 Examples:
   mcx vfs clone confluence FOO ~/atlassian/foo
-  cd ~/atlassian/foo && mcx vfs pull
-  $EDITOR some-page.md && mcx vfs push
+  mcx vfs clone jira FOO ~/jira/foo
+  cd ~/jira/foo && mcx vfs pull
+  $EDITOR FOO-1234.md && mcx vfs push
 `);
 }


### PR DESCRIPTION
## Summary
- Implement `createJiraProvider` — a `RemoteProvider` for mapping Jira project issues to flat `FOO-1234.md` files with YAML frontmatter (key, summary, status, type, priority, assignee, labels, parent, updated, url)
- Full lifecycle support: clone (paginated via `nextPageToken`), incremental pull (JQL `updated >= since`), push (conflict detection via `updated` timestamp), and create
- Wire into `resolveProvider` switch in `vfs.ts` and make `resolveProviderFromCache` auto-detect provider name from cache (no longer hardcoded to confluence)

## Test plan
- [x] 19 unit tests covering: scope validation (JQL injection prevention), toPath (flat key-based), frontmatter fields, list (single page + pagination), fetch, push (success + conflict + error), create (with/without parent), changes (single page + pagination)
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] Full test suite: 4240 tests pass, 0 failures
- [x] Coverage ratchet met (91.21% functions, 93.22% lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)