### PR TITLE
feat(daemon): human-readable session names (fixes #1207)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,1 @@
-# Dependencies
-node_modules/
-
-# Build output
-dist/
-build/
-tsconfig.tsbuildinfo
-
-# Environment
-.env
-
-# OS
-.DS_Store
-
-# Project-specific
 .clone/
-.claude/worktrees/
-test-timings.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,18 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+build/
+tsconfig.tsbuildinfo
+
+# Environment
+.env
+
+# OS
+.DS_Store
+
+# Project-specific
 .clone/
+.claude/worktrees/
+test-timings.json

--- a/packages/acp/src/acp-session.ts
+++ b/packages/acp/src/acp-session.ts
@@ -308,6 +308,7 @@ export class AcpSession {
   getInfo(): AgentSessionInfo {
     return {
       sessionId: this.sessionId,
+      name: null,
       provider: "acp",
       state: this.state,
       model: this.model,

--- a/packages/codex/src/codex-session.ts
+++ b/packages/codex/src/codex-session.ts
@@ -256,6 +256,7 @@ export class CodexSession {
   getInfo(): AgentSessionInfo {
     return {
       sessionId: this.sessionId,
+      name: null,
       provider: "codex",
       state: this.state,
       model: this.model,

--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -223,6 +223,26 @@ describe("parseSpawnArgs", () => {
     const result = parseSpawnArgs(["--task", "fix bug"]);
     expect(result.headed).toBe(false);
   });
+
+  test("parses --name flag", () => {
+    const result = parseSpawnArgs(["--name", "Alice", "--task", "fix bug"]);
+    expect(result.name).toBe("Alice");
+  });
+
+  test("parses -n shorthand", () => {
+    const result = parseSpawnArgs(["-n", "Bob", "-t", "fix bug"]);
+    expect(result.name).toBe("Bob");
+  });
+
+  test("name defaults to undefined", () => {
+    const result = parseSpawnArgs(["--task", "fix bug"]);
+    expect(result.name).toBeUndefined();
+  });
+
+  test("errors on missing --name value", () => {
+    const result = parseSpawnArgs(["--name"]);
+    expect(result.error).toBe("--name requires a value");
+  });
 });
 
 // ── resolveModelName ──
@@ -425,6 +445,30 @@ describe("resolveSessionId", () => {
     });
     await expect(resolveSessionId("abc", deps)).rejects.toThrow(ExitError);
     expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("Ambiguous"));
+  });
+
+  test("resolves by name (case-insensitive)", async () => {
+    const sessions = [
+      { sessionId: "abc12345-1111-2222-3333-444444444444", name: "Alice" },
+      { sessionId: "def67890-aaaa-bbbb-cccc-dddddddddddd", name: "Bob" },
+    ];
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(sessions)),
+    });
+    const id = await resolveSessionId("alice", deps);
+    expect(id).toBe("abc12345-1111-2222-3333-444444444444");
+  });
+
+  test("name match takes priority over UUID prefix", async () => {
+    const sessions = [
+      { sessionId: "abc12345-1111-2222-3333-444444444444", name: "Alice" },
+      { sessionId: "def67890-aaaa-bbbb-cccc-dddddddddddd", name: "Bob" },
+    ];
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(sessions)),
+    });
+    const id = await resolveSessionId("Bob", deps);
+    expect(id).toBe("def67890-aaaa-bbbb-cccc-dddddddddddd");
   });
 });
 

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -835,14 +835,17 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
   // Table output
   const diffHeader = hasAnyDiff ? ` ${"DIFF".padEnd(16)}` : "";
   const prHeader = hasAnyPr ? ` ${"PR".padEnd(12)}` : "";
-  const header = `${"SESSION".padEnd(16)} ${"STATE".padEnd(12)} ${"MODEL".padEnd(16)} ${"COST".padEnd(8)} ${"TOKENS".padEnd(10)}${diffHeader}${prHeader} CWD`;
+  const sessionColWidth = 20;
+  const header = `${"SESSION".padEnd(sessionColWidth)} ${"STATE".padEnd(12)} ${"MODEL".padEnd(16)} ${"COST".padEnd(8)} ${"TOKENS".padEnd(10)}${diffHeader}${prHeader} CWD`;
   console.log(`${c.dim}${header}${c.reset}`);
 
   for (let i = 0; i < sessions.length; i++) {
     const s = sessions[i];
     const id = s.sessionId.slice(0, 8);
-    const nameLabel = s.name ? ` ${s.name}` : "";
-    const sessionCol = `${id}${nameLabel}`.padEnd(16);
+    const maxNameLen = sessionColWidth - id.length - 1; // 1 for leading space
+    const truncatedName = s.name && s.name.length > maxNameLen ? `${s.name.slice(0, maxNameLen - 1)}…` : s.name;
+    const nameLabel = truncatedName ? ` ${truncatedName}` : "";
+    const sessionCol = `${id}${nameLabel}`.padEnd(sessionColWidth);
     const stateStr = s.rateLimited ? `${colorState(s.state)} ${c.red}[RATE LIMITED]${c.reset}` : colorState(s.state);
     const model = (s.model ?? "—").padEnd(16);
     const cost = s.cost > 0 ? `$${s.cost.toFixed(4)}`.padEnd(8) : "—".padEnd(8);
@@ -853,7 +856,7 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
     const age = formatAge(s.createdAt);
     const ageSuffix = age ? ` ${c.yellow}${age}${c.reset}` : "";
     console.log(
-      `${c.cyan}${id}${c.reset}${c.bold}${nameLabel}${c.reset}${" ".repeat(Math.max(1, 16 - id.length - nameLabel.length))}${stateStr} ${model} ${cost} ${tokens}${diff}${pr} ${c.dim}${cwd}${c.reset}${ageSuffix}`,
+      `${c.cyan}${id}${c.reset}${c.bold}${nameLabel}${c.reset}${" ".repeat(Math.max(1, sessionColWidth - id.length - nameLabel.length))}${stateStr} ${model} ${cost} ${tokens}${diff}${pr} ${c.dim}${cwd}${c.reset}${ageSuffix}`,
     );
 
     // Work item lifecycle line (indented under the session)
@@ -1614,10 +1617,20 @@ export async function resolveSessionId(
   // Try exact name match first (case-insensitive)
   const prefixLower = prefix.toLowerCase();
   const nameMatches = sessions.filter((s) => s.name?.toLowerCase() === prefixLower);
-  if (nameMatches.length === 1) return nameMatches[0].sessionId;
 
-  // Fall back to UUID prefix match
+  // Also check UUID prefix matches
   const matches = sessions.filter((s) => s.sessionId.startsWith(prefix));
+
+  if (nameMatches.length === 1) {
+    // Warn if a UUID prefix match is being shadowed by the name match
+    const shadowedById = matches.filter((s) => s.sessionId !== nameMatches[0].sessionId);
+    if (shadowedById.length > 0) {
+      d.printError(
+        `Warning: name "${prefix}" shadows UUID prefix match (${shadowedById.map((s) => s.sessionId.slice(0, 8)).join(", ")}). Using named session.`,
+      );
+    }
+    return nameMatches[0].sessionId;
+  }
 
   if (matches.length === 0 && nameMatches.length === 0) {
     d.printError(`No session matching "${prefix}"`);

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -270,12 +270,15 @@ export interface SpawnArgs extends SharedSpawnArgs {
   worktree: string | undefined;
   resume: string | undefined;
   headed: boolean;
+  /** Human-readable session name. Auto-generated if omitted. */
+  name: string | undefined;
 }
 
 export function parseSpawnArgs(args: string[]): SpawnArgs {
   let worktree: string | undefined;
   let resume: string | undefined;
   let headed = false;
+  let name: string | undefined;
   let extraError: string | undefined;
 
   const shared = parseSharedSpawnArgs(args, (arg, allArgs, i) => {
@@ -298,11 +301,16 @@ export function parseSpawnArgs(args: string[]): SpawnArgs {
       if (!resume) extraError = "--resume requires a session ID";
       return 1;
     }
+    if (arg === "--name" || arg === "-n") {
+      name = allArgs[i + 1];
+      if (!name) extraError = "--name requires a value";
+      return 1;
+    }
     return undefined;
   });
 
   // shared.error wins: it reflects a bad shared flag; extraError covers provider-specific failures
-  return { ...shared, error: shared.error ?? extraError, worktree, resume, headed };
+  return { ...shared, error: shared.error ?? extraError, worktree, resume, headed, name };
 }
 
 /**
@@ -363,6 +371,7 @@ async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
   if (parsed.cwd) toolArgs.cwd = parsed.cwd;
   if (parsed.timeout) toolArgs.timeout = parsed.timeout;
   if (parsed.model) toolArgs.model = parsed.model;
+  if (parsed.name) toolArgs.name = parsed.name;
   if (parsed.wait) toolArgs.wait = true;
 
   // Handle worktree: always pre-create via shim so cwd points to the worktree.
@@ -826,12 +835,14 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
   // Table output
   const diffHeader = hasAnyDiff ? ` ${"DIFF".padEnd(16)}` : "";
   const prHeader = hasAnyPr ? ` ${"PR".padEnd(12)}` : "";
-  const header = `${"SESSION".padEnd(10)} ${"STATE".padEnd(12)} ${"MODEL".padEnd(16)} ${"COST".padEnd(8)} ${"TOKENS".padEnd(10)}${diffHeader}${prHeader} CWD`;
+  const header = `${"SESSION".padEnd(16)} ${"STATE".padEnd(12)} ${"MODEL".padEnd(16)} ${"COST".padEnd(8)} ${"TOKENS".padEnd(10)}${diffHeader}${prHeader} CWD`;
   console.log(`${c.dim}${header}${c.reset}`);
 
   for (let i = 0; i < sessions.length; i++) {
     const s = sessions[i];
     const id = s.sessionId.slice(0, 8);
+    const nameLabel = s.name ? ` ${s.name}` : "";
+    const sessionCol = `${id}${nameLabel}`.padEnd(16);
     const stateStr = s.rateLimited ? `${colorState(s.state)} ${c.red}[RATE LIMITED]${c.reset}` : colorState(s.state);
     const model = (s.model ?? "—").padEnd(16);
     const cost = s.cost > 0 ? `$${s.cost.toFixed(4)}`.padEnd(8) : "—".padEnd(8);
@@ -842,7 +853,7 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
     const age = formatAge(s.createdAt);
     const ageSuffix = age ? ` ${c.yellow}${age}${c.reset}` : "";
     console.log(
-      `${c.cyan}${id}${c.reset}   ${stateStr} ${model} ${cost} ${tokens}${diff}${pr} ${c.dim}${cwd}${c.reset}${ageSuffix}`,
+      `${c.cyan}${id}${c.reset}${c.bold}${nameLabel}${c.reset}${" ".repeat(Math.max(1, 16 - id.length - nameLabel.length))}${stateStr} ${model} ${cost} ${tokens}${diff}${pr} ${c.dim}${cwd}${c.reset}${ageSuffix}`,
     );
 
     // Work item lifecycle line (indented under the session)
@@ -1593,22 +1604,34 @@ export async function resolveSessionId(
 ): Promise<string> {
   const result = await d.callTool(listTool, {});
   const text = formatToolResult(result);
-  let sessions: Array<{ sessionId: string }>;
+  let sessions: Array<{ sessionId: string; name?: string | null }>;
   try {
     sessions = JSON.parse(text);
   } catch {
     throw new Error("Failed to parse session list");
   }
 
+  // Try exact name match first (case-insensitive)
+  const prefixLower = prefix.toLowerCase();
+  const nameMatches = sessions.filter((s) => s.name?.toLowerCase() === prefixLower);
+  if (nameMatches.length === 1) return nameMatches[0].sessionId;
+
+  // Fall back to UUID prefix match
   const matches = sessions.filter((s) => s.sessionId.startsWith(prefix));
 
-  if (matches.length === 0) {
+  if (matches.length === 0 && nameMatches.length === 0) {
     d.printError(`No session matching "${prefix}"`);
     d.exit(1);
   }
 
   if (matches.length > 1) {
     d.printError(`Ambiguous session prefix "${prefix}" — matches ${matches.length} sessions`);
+    d.exit(1);
+  }
+
+  if (matches.length === 0) {
+    // Multiple name matches
+    d.printError(`Ambiguous session name "${prefix}" — matches ${nameMatches.length} sessions`);
     d.exit(1);
   }
 
@@ -1649,6 +1672,7 @@ Options:
                              e.g. Bash Read Write Edit Glob Grep Skill
                              Supports globs: mcp__grafana__*
   --headed                   Open in a visible terminal tab (via tty)
+  --name, -n <name>          Human-readable session name (auto-generated if omitted)
   --resume <id>              Resume a previous session by ID
   --model, -m <name>         Model: opus, sonnet, haiku, or full ID (default: opus)
   --cwd <path>               Working directory for the session

--- a/packages/command/src/commands/session-display.ts
+++ b/packages/command/src/commands/session-display.ts
@@ -30,6 +30,7 @@ export function formatAge(createdAt: number | null | undefined, now?: number): s
 /** Compact one-line format: SESSION STATE MODEL COST TOKENS TURNS [(date)] */
 export function formatSessionShort(s: {
   sessionId: string;
+  name?: string | null;
   state: string;
   model?: string | null;
   cost?: number | null;
@@ -39,6 +40,7 @@ export function formatSessionShort(s: {
   createdAt?: number | null;
 }): string {
   const id = s.sessionId.slice(0, 8);
+  const nameLabel = s.name ? `/${s.name}` : "";
   const state = s.rateLimited ? `${s.state} [RATE LIMITED]` : s.state;
   const model = s.model ?? "—";
   const cost = s.cost && s.cost > 0 ? `$${s.cost.toFixed(4)}` : "—";
@@ -46,8 +48,8 @@ export function formatSessionShort(s: {
   const turns = s.numTurns !== undefined ? String(s.numTurns) : "—";
   const age = formatAge(s.createdAt);
   return age
-    ? `${id} ${state} ${model} ${cost} ${tokens} ${turns} ${age}`
-    : `${id} ${state} ${model} ${cost} ${tokens} ${turns}`;
+    ? `${id}${nameLabel} ${state} ${model} ${cost} ${tokens} ${turns} ${age}`
+    : `${id}${nameLabel} ${state} ${model} ${cost} ${tokens} ${turns}`;
 }
 
 /** Extract a readable summary from a Claude API content field (string or content block array). */

--- a/packages/control/src/hooks/use-agent-sessions.spec.ts
+++ b/packages/control/src/hooks/use-agent-sessions.spec.ts
@@ -11,6 +11,7 @@ import { type UseAgentSessionsOptions, useAgentSessions } from "./use-agent-sess
 function session(id: string, provider: "claude" | "codex" = "claude"): AgentSessionInfo {
   return {
     sessionId: id,
+    name: null,
     provider,
     state: "active",
     model: "opus",

--- a/packages/core/src/agent-session.ts
+++ b/packages/core/src/agent-session.ts
@@ -31,6 +31,8 @@ export interface AgentPermissionRequest {
 
 export interface AgentSessionInfo {
   sessionId: string;
+  /** Human-readable session name (e.g. "Alice", "Bob"). Null if not assigned. */
+  name: string | null;
   provider: AgentProviderName;
   state: AgentSessionState;
   model: string | null;

--- a/packages/core/src/agent-tools.ts
+++ b/packages/core/src/agent-tools.ts
@@ -161,6 +161,7 @@ export function buildAgentTools(opts: BuildAgentToolsOptions): readonly AgentToo
             description: "Tool patterns to auto-approve (e.g. 'Bash(git *)', 'Read')",
           },
           worktree: { type: "string", description: "Git worktree name for isolation" },
+          name: { type: "string", description: "Human-readable session name (auto-generated if omitted)" },
           timeout: timeoutProp,
           wait: { type: "boolean", description: "Block until result (default: false)" },
           ...ov("prompt")?.extraProperties,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export * from "./schema-display";
 export * from "./model";
 export * from "./agent-provider";
 export * from "./agent-session";
+export * from "./session-names";
 export * from "./session-types";
 export * from "./trace";
 export * from "./git";

--- a/packages/core/src/session-names.spec.ts
+++ b/packages/core/src/session-names.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "bun:test";
+import { SESSION_NAMES, generateSessionName } from "./session-names";
+
+describe("SESSION_NAMES", () => {
+  it("contains at least 20 names", () => {
+    expect(SESSION_NAMES.length).toBeGreaterThanOrEqual(20);
+  });
+
+  it("has no duplicates", () => {
+    const unique = new Set(SESSION_NAMES);
+    expect(unique.size).toBe(SESSION_NAMES.length);
+  });
+});
+
+describe("generateSessionName", () => {
+  it("returns first name when none are in use", () => {
+    const name = generateSessionName(new Set());
+    expect(name).toBe("Alice");
+  });
+
+  it("skips names already in use", () => {
+    const used = new Set(["Alice", "Bob"]);
+    const name = generateSessionName(used);
+    expect(name).toBe("Carol");
+  });
+
+  it("returns suffixed name when all base names are taken", () => {
+    const used = new Set(SESSION_NAMES);
+    const name = generateSessionName(used);
+    expect(name).toBe("Alice-2");
+  });
+
+  it("returns suffixed name skipping used suffixed names", () => {
+    const used = new Set([...SESSION_NAMES, "Alice-2"]);
+    const name = generateSessionName(used);
+    expect(name).toBe("Bob-2");
+  });
+});

--- a/packages/core/src/session-names.ts
+++ b/packages/core/src/session-names.ts
@@ -1,0 +1,59 @@
+/**
+ * Human-readable session name generator.
+ *
+ * Assigns short first names to sessions for identity anchoring.
+ * Names are picked round-robin from a curated list to minimize
+ * collisions while keeping the pool small enough to be memorable.
+ */
+
+const SESSION_NAMES: readonly string[] = [
+  "Alice",
+  "Bob",
+  "Carol",
+  "Dave",
+  "Eve",
+  "Frank",
+  "Grace",
+  "Hank",
+  "Iris",
+  "June",
+  "Kurt",
+  "Luna",
+  "Max",
+  "Nora",
+  "Oscar",
+  "Pam",
+  "Quinn",
+  "Ray",
+  "Sage",
+  "Tess",
+  "Uri",
+  "Vera",
+  "Walt",
+  "Xena",
+  "Yuri",
+  "Zara",
+];
+
+export { SESSION_NAMES };
+
+/**
+ * Pick a session name that isn't already in use.
+ * Falls back to Name-N suffix if all base names are taken.
+ *
+ * @param usedNames - Set of names currently assigned to active sessions
+ */
+export function generateSessionName(usedNames: ReadonlySet<string>): string {
+  // Try each base name in order
+  for (const name of SESSION_NAMES) {
+    if (!usedNames.has(name)) return name;
+  }
+
+  // All base names taken — append numeric suffix
+  for (let i = 2; ; i++) {
+    for (const name of SESSION_NAMES) {
+      const suffixed = `${name}-${i}`;
+      if (!usedNames.has(suffixed)) return suffixed;
+    }
+  }
+}

--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -40,6 +40,7 @@ interface DbUpsert {
   type: "db:upsert";
   session: {
     sessionId: string;
+    name?: string;
     pid?: number;
     /** Captured by the worker at spawn time (off main thread) to avoid blocking ps(1) call on main. */
     pidStartTime?: number | null;
@@ -356,6 +357,7 @@ export class ClaudeServer {
       type: "restore_sessions",
       sessions: restorable.map((row) => ({
         sessionId: row.sessionId,
+        name: row.name,
         pid: row.pid,
         pidStartTime: row.pidStartTime,
         state: "disconnected",

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -166,8 +166,9 @@ async function handlePrompt(
       ? effectiveTools.map((tool) => ({ tool, action: "allow" as const }))
       : undefined;
 
-    server.prepareSession(sessionId, {
+    const sessionName = server.prepareSession(sessionId, {
       prompt,
+      name: args.name as string | undefined,
       cwd: args.cwd as string | undefined,
       permissionStrategy: permissionMode,
       permissionRules: rules,
@@ -183,6 +184,7 @@ async function handlePrompt(
       type: "db:upsert",
       session: {
         sessionId,
+        name: sessionName,
         state: "connecting",
         cwd: args.cwd as string | undefined,
         worktree: args.worktree as string | undefined,

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -166,18 +166,26 @@ async function handlePrompt(
       ? effectiveTools.map((tool) => ({ tool, action: "allow" as const }))
       : undefined;
 
-    const sessionName = server.prepareSession(sessionId, {
-      prompt,
-      name: args.name as string | undefined,
-      cwd: args.cwd as string | undefined,
-      permissionStrategy: permissionMode,
-      permissionRules: rules,
-      allowedTools,
-      worktree: args.worktree as string | undefined,
-      model: args.model ? resolveModelName(args.model as string) : undefined,
-      resumeSessionId: args.resumeSessionId as string | undefined,
-      repoRoot: args.repoRoot as string | undefined,
-    });
+    let sessionName: string;
+    try {
+      sessionName = server.prepareSession(sessionId, {
+        prompt,
+        name: args.name as string | undefined,
+        cwd: args.cwd as string | undefined,
+        permissionStrategy: permissionMode,
+        permissionRules: rules,
+        allowedTools,
+        worktree: args.worktree as string | undefined,
+        model: args.model ? resolveModelName(args.model as string) : undefined,
+        resumeSessionId: args.resumeSessionId as string | undefined,
+        repoRoot: args.repoRoot as string | undefined,
+      });
+    } catch (err) {
+      return {
+        content: [{ type: "text", text: `Error: ${(err as Error).message}` }],
+        isError: true,
+      };
+    }
 
     // Post DB upsert
     self.postMessage({

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -13,7 +13,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { AgentPermissionRequest, Logger, SessionInfo, SessionStateEnum, WorkItemEvent } from "@mcp-cli/core";
-import { consoleLogger } from "@mcp-cli/core";
+import { consoleLogger, generateSessionName } from "@mcp-cli/core";
 import type { ServerWebSocket } from "bun";
 import { killPid } from "../process-util";
 import type { NdjsonMessage } from "./ndjson";
@@ -55,6 +55,8 @@ export class WaitTimeoutError extends Error {
 
 export interface SessionConfig {
   prompt: string;
+  /** Human-readable session name. Auto-generated if not provided. */
+  name?: string;
   permissionStrategy?: PermissionStrategy;
   permissionRules?: PermissionRule[];
   allowedTools?: string[];
@@ -254,6 +256,8 @@ interface WsSession {
   ws: ServerWebSocket<WsData> | null;
   transcript: TranscriptEntry[];
   config: SessionConfig;
+  /** Human-readable session name. */
+  name: string | null;
   pid: number | null;
   /** Process start time (epoch ms) — used to detect PID reuse before sending signals. */
   pidStartTime: number | null;
@@ -484,6 +488,7 @@ export class ClaudeWsServer {
   restoreSessions(
     sessions: Array<{
       sessionId: string;
+      name?: string | null;
       pid: number | null;
       pidStartTime?: number | null;
       state: string;
@@ -515,6 +520,7 @@ export class ClaudeWsServer {
         ws: null,
         transcript: [],
         config: { prompt: "", worktree: s.worktree ?? undefined },
+        name: s.name ?? null,
         pid: s.pid,
         pidStartTime: s.pidStartTime ?? null,
         proc: null,
@@ -538,9 +544,13 @@ export class ClaudeWsServer {
    * Prepare a session for an incoming Claude CLI connection.
    * Call this before spawning the Claude process.
    */
-  prepareSession(sessionId: string, config: SessionConfig): void {
+  /** Prepare a session and return the assigned name. */
+  prepareSession(sessionId: string, config: SessionConfig): string {
     const state = new SessionState(sessionId);
     const router = new PermissionRouter(config.permissionStrategy ?? "auto", config.permissionRules);
+
+    // Auto-generate a name if not explicitly provided
+    const name = config.name ?? this.generateName();
 
     this.sessions.set(sessionId, {
       state,
@@ -548,6 +558,7 @@ export class ClaudeWsServer {
       ws: null,
       transcript: [],
       config,
+      name,
       pid: null,
       pidStartTime: null,
       proc: null,
@@ -561,6 +572,7 @@ export class ClaudeWsServer {
       createdAt: Date.now(),
       pendingImmediate: false,
     });
+    return name;
   }
 
   /**
@@ -1633,6 +1645,7 @@ export class ClaudeWsServer {
     }
     return {
       sessionId,
+      name: s.name,
       provider: "claude",
       state: s.state.state,
       model: s.state.model,
@@ -1652,6 +1665,15 @@ export class ClaudeWsServer {
       spawnAlive: s.spawnAlive,
       snapshotTs: Date.now(),
     };
+  }
+
+  /** Generate a unique session name by checking names already in use. */
+  private generateName(): string {
+    const usedNames = new Set<string>();
+    for (const s of this.sessions.values()) {
+      if (s.name) usedNames.add(s.name);
+    }
+    return generateSessionName(usedNames);
   }
 
   private sendToWs(session: WsSession, message: string): void {

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -550,6 +550,15 @@ export class ClaudeWsServer {
     const router = new PermissionRouter(config.permissionStrategy ?? "auto", config.permissionRules);
 
     // Auto-generate a name if not explicitly provided
+    // If an explicit name was given, reject duplicates among active sessions
+    if (config.name) {
+      const nameLower = config.name.toLowerCase();
+      for (const s of this.sessions.values()) {
+        if (s.name?.toLowerCase() === nameLower) {
+          throw new Error(`Session name "${config.name}" is already in use`);
+        }
+      }
+    }
     const name = config.name ?? this.generateName();
 
     this.sessions.set(sessionId, {

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -1043,14 +1043,6 @@ export class StateDb {
       .map(toSessionRow);
   }
 
-  /** Get the set of session names currently in use by active sessions. */
-  getActiveSessionNames(): Set<string> {
-    const rows = this.db
-      .query<{ name: string }, []>("SELECT name FROM agent_sessions WHERE ended_at IS NULL AND name IS NOT NULL")
-      .all();
-    return new Set(rows.map((r) => r.name));
-  }
-
   pruneOldSessions(maxAgeDays = 30): number {
     const cutoff = formatSqliteDatetime(Date.now() - maxAgeDays * 24 * 60 * 60 * 1000);
     const result = this.db.run("DELETE FROM agent_sessions WHERE ended_at IS NOT NULL AND ended_at < ?", [cutoff]);

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -26,6 +26,7 @@ export type { UsageStat } from "@mcp-cli/core";
 
 export interface AgentSessionRow {
   sessionId: string;
+  name: string | null;
   provider: string;
   pid: number | null;
   pidStartTime: number | null;
@@ -266,6 +267,11 @@ export class StateDb {
     }
     try {
       this.db.exec("ALTER TABLE agent_sessions ADD COLUMN pid_start_time INTEGER");
+    } catch {
+      /* column already exists */
+    }
+    try {
+      this.db.exec("ALTER TABLE agent_sessions ADD COLUMN name TEXT");
     } catch {
       /* column already exists */
     }
@@ -962,6 +968,7 @@ export class StateDb {
 
   upsertSession(session: {
     sessionId: string;
+    name?: string;
     provider?: string;
     pid?: number;
     pidStartTime?: number;
@@ -972,9 +979,10 @@ export class StateDb {
     repoRoot?: string;
   }): void {
     this.db.run(
-      `INSERT INTO agent_sessions (session_id, provider, pid, pid_start_time, state, model, cwd, worktree, repo_root)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `INSERT INTO agent_sessions (session_id, name, provider, pid, pid_start_time, state, model, cwd, worktree, repo_root)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(session_id) DO UPDATE SET
+         name = COALESCE(excluded.name, agent_sessions.name),
          provider = COALESCE(excluded.provider, agent_sessions.provider),
          pid = COALESCE(excluded.pid, agent_sessions.pid),
          pid_start_time = COALESCE(excluded.pid_start_time, agent_sessions.pid_start_time),
@@ -985,6 +993,7 @@ export class StateDb {
          repo_root = COALESCE(excluded.repo_root, agent_sessions.repo_root)`,
       [
         session.sessionId,
+        session.name ?? null,
         session.provider ?? "claude",
         session.pid ?? null,
         session.pidStartTime ?? null,
@@ -1018,7 +1027,7 @@ export class StateDb {
   getSession(sessionId: string): AgentSessionRow | null {
     const row = this.db
       .query<RawSessionRow, [string]>(
-        "SELECT session_id, provider, pid, pid_start_time, state, model, cwd, worktree, repo_root, total_cost, total_tokens, spawned_at, ended_at FROM agent_sessions WHERE session_id = ?",
+        "SELECT session_id, name, provider, pid, pid_start_time, state, model, cwd, worktree, repo_root, total_cost, total_tokens, spawned_at, ended_at FROM agent_sessions WHERE session_id = ?",
       )
       .get(sessionId);
     return row ? toSessionRow(row) : null;
@@ -1028,10 +1037,18 @@ export class StateDb {
     const where = active === true ? " WHERE ended_at IS NULL" : active === false ? " WHERE ended_at IS NOT NULL" : "";
     return this.db
       .query<RawSessionRow, []>(
-        `SELECT session_id, provider, pid, pid_start_time, state, model, cwd, worktree, repo_root, total_cost, total_tokens, spawned_at, ended_at FROM agent_sessions${where} ORDER BY spawned_at DESC`,
+        `SELECT session_id, name, provider, pid, pid_start_time, state, model, cwd, worktree, repo_root, total_cost, total_tokens, spawned_at, ended_at FROM agent_sessions${where} ORDER BY spawned_at DESC`,
       )
       .all()
       .map(toSessionRow);
+  }
+
+  /** Get the set of session names currently in use by active sessions. */
+  getActiveSessionNames(): Set<string> {
+    const rows = this.db
+      .query<{ name: string }, []>("SELECT name FROM agent_sessions WHERE ended_at IS NULL AND name IS NOT NULL")
+      .all();
+    return new Set(rows.map((r) => r.name));
   }
 
   pruneOldSessions(maxAgeDays = 30): number {
@@ -1224,6 +1241,7 @@ function safeJsonParse<T>(json: string, fallback: T): T {
 
 interface RawSessionRow {
   session_id: string;
+  name: string | null;
   provider: string;
   pid: number | null;
   pid_start_time: number | null;
@@ -1241,6 +1259,7 @@ interface RawSessionRow {
 function toSessionRow(row: RawSessionRow): AgentSessionRow {
   return {
     sessionId: row.session_id,
+    name: row.name,
     provider: row.provider,
     pid: row.pid,
     pidStartTime: row.pid_start_time,

--- a/packages/opencode/src/opencode-session.ts
+++ b/packages/opencode/src/opencode-session.ts
@@ -291,6 +291,7 @@ export class OpenCodeSession {
   getInfo(): AgentSessionInfo {
     return {
       sessionId: this.sessionId,
+      name: null,
       provider: "opencode",
       state: this.state,
       model: this.model,


### PR DESCRIPTION
## Summary
- Sessions are auto-assigned short human-readable names (Alice, Bob, Carol...) at spawn time from a 26-name pool, with round-robin fallback to suffixed names (Alice-2, Bob-2) when all base names are taken
- Names are displayed in `mcx claude ls` (both table and short format) and accepted by all session commands (`send`, `bye`, `wait`, `log`, etc.) via case-insensitive name matching alongside UUID prefix matching
- Explicit naming supported via `mcx claude spawn --name <name>` / `-n <name>`
- Names persisted in SQLite (`agent_sessions.name` column) and restored across daemon restarts

## Test plan
- [x] `generateSessionName` unit tests: first pick, skip-used, overflow to suffixed names
- [x] `parseSpawnArgs` tests for `--name` and `-n` flags
- [x] `resolveSessionId` tests for name-based resolution (case-insensitive)
- [x] All 4351 existing tests pass
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)