### PR TITLE
fix(vfs): check isError in unwrapToolResult for confluence and jira providers (fixes #1205)

### DIFF
--- a/packages/clone/src/providers/confluence.spec.ts
+++ b/packages/clone/src/providers/confluence.spec.ts
@@ -265,6 +265,10 @@ function wrapMcpResult(data: unknown) {
   return { content: [{ type: "text", text: JSON.stringify(data) }] };
 }
 
+function wrapMcpError(message: string) {
+  return { content: [{ type: "text", text: message }], isError: true };
+}
+
 describe("list", () => {
   test("yields all pages from a single page response", async () => {
     const scope = makeScope();
@@ -476,5 +480,39 @@ describe("bulkFetchPages", () => {
     });
 
     expect(progressCalls).toContain(1);
+  });
+});
+
+describe("unwrapToolResult — isError handling", () => {
+  test("throws on MCP error response during resolveScope", async () => {
+    const provider = createConfluenceProvider({
+      callTool: async (_server, tool, _args) => {
+        if (tool === "getAccessibleAtlassianResources") {
+          return wrapMcpError("Rate limit exceeded");
+        }
+        return null;
+      },
+    });
+
+    await expect(provider.resolveScope({ key: "TEST" })).rejects.toThrow("MCP tool error: Rate limit exceeded");
+  });
+
+  test("throws on isError during list", async () => {
+    const scope = makeScope();
+    const provider = createConfluenceProvider({
+      callTool: async (_server, tool, _args) => {
+        if (tool === "getPagesInConfluenceSpace") {
+          return wrapMcpError("403 Forbidden");
+        }
+        return null;
+      },
+    });
+
+    const entries: unknown[] = [];
+    await expect(async () => {
+      for await (const entry of provider.list(scope)) {
+        entries.push(entry);
+      }
+    }).toThrow("MCP tool error: 403 Forbidden");
   });
 });

--- a/packages/clone/src/providers/confluence.ts
+++ b/packages/clone/src/providers/confluence.ts
@@ -85,9 +85,13 @@ interface McpToolResult {
   isError?: boolean;
 }
 
-/** Extract and parse JSON from an MCP tool call result. */
+/** Extract and parse JSON from an MCP tool call result. Throws on error responses. */
 function unwrapToolResult(result: unknown): unknown {
   const mcpResult = result as McpToolResult;
+  if (mcpResult?.isError) {
+    const text = mcpResult.content?.[0]?.text ?? "Unknown MCP tool error";
+    throw new Error(`MCP tool error: ${text}`);
+  }
   if (mcpResult?.content?.[0]?.type === "text") {
     const text = mcpResult.content[0].text;
     try {

--- a/packages/clone/src/providers/jira.spec.ts
+++ b/packages/clone/src/providers/jira.spec.ts
@@ -52,6 +52,10 @@ function wrapMcpResult(data: unknown) {
   return { content: [{ type: "text", text: JSON.stringify(data) }] };
 }
 
+function wrapMcpError(message: string) {
+  return { content: [{ type: "text", text: message }], isError: true };
+}
+
 describe("validateScopeKey (via resolveScope)", () => {
   function makeCallTool(): (server: string, tool: string, args: Record<string, unknown>) => Promise<unknown> {
     return async () => null;
@@ -591,5 +595,39 @@ describe("changes", () => {
     }
     expect(changes).toHaveLength(2);
     expect(callCount).toBe(2);
+  });
+});
+
+describe("unwrapToolResult — isError handling", () => {
+  test("throws on MCP error response during resolveScope", async () => {
+    const provider = createJiraProvider({
+      callTool: async (_server, tool, _args) => {
+        if (tool === "getAccessibleAtlassianResources") {
+          return wrapMcpError("Rate limit exceeded");
+        }
+        return null;
+      },
+    });
+
+    await expect(provider.resolveScope({ key: "FOO" })).rejects.toThrow("MCP tool error: Rate limit exceeded");
+  });
+
+  test("throws on isError during list", async () => {
+    const scope = makeScope();
+    const provider = createJiraProvider({
+      callTool: async (_server, tool, _args) => {
+        if (tool === "searchJiraIssuesUsingJql") {
+          return wrapMcpError("403 Forbidden");
+        }
+        return null;
+      },
+    });
+
+    const entries: unknown[] = [];
+    await expect(async () => {
+      for await (const entry of provider.list(scope)) {
+        entries.push(entry);
+      }
+    }).toThrow("MCP tool error: 403 Forbidden");
   });
 });

--- a/packages/clone/src/providers/jira.ts
+++ b/packages/clone/src/providers/jira.ts
@@ -50,9 +50,13 @@ interface McpToolResult {
   isError?: boolean;
 }
 
-/** Extract and parse JSON from an MCP tool call result. */
+/** Extract and parse JSON from an MCP tool call result. Throws on error responses. */
 function unwrapToolResult(result: unknown): unknown {
   const mcpResult = result as McpToolResult;
+  if (mcpResult?.isError) {
+    const text = mcpResult.content?.[0]?.text ?? "Unknown MCP tool error";
+    throw new Error(`MCP tool error: ${text}`);
+  }
   if (mcpResult?.content?.[0]?.type === "text") {
     const text = mcpResult.content[0].text;
     try {


### PR DESCRIPTION
## Summary
- Add `isError` check to `unwrapToolResult` in both Confluence and Jira providers, matching the existing Asana provider pattern
- When an MCP server returns an error response (rate limit, auth failure, etc.), the function now throws with a descriptive message instead of silently parsing the error as valid data
- Prevents silent data corruption where error objects would be coerced to empty arrays during clone operations

## Test plan
- [x] Added `wrapMcpError` helper and `unwrapToolResult — isError handling` test block to `confluence.spec.ts`
- [x] Added `wrapMcpError` helper and `unwrapToolResult — isError handling` test block to `jira.spec.ts`
- [x] Tests verify `isError` throws during both `resolveScope` and `list` operations
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (4343 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)