### PR TITLE
feat(clone): git remote helper stdin line protocol parser + capability handler (fixes #1210)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,18 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+build/
+tsconfig.tsbuildinfo
+
+# Environment
+.env
+
+# OS
+.DS_Store
+
+# Project-specific
 .clone/
+.claude/worktrees/
+test-timings.json

--- a/packages/clone/src/engine/remote-protocol.spec.ts
+++ b/packages/clone/src/engine/remote-protocol.spec.ts
@@ -1,0 +1,232 @@
+import { describe, expect, test } from "bun:test";
+import { type RemoteHelperHandlers, runProtocol } from "./remote-protocol";
+
+/** Encode a string as a ReadableStream<Uint8Array>. */
+function streamFrom(input: string): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(input));
+      controller.close();
+    },
+  });
+}
+
+/** Collect a WritableStream<Uint8Array> into a string. */
+function collectStream(): { stream: WritableStream<Uint8Array>; result: () => string } {
+  const chunks: Uint8Array[] = [];
+  const stream = new WritableStream<Uint8Array>({
+    write(chunk) {
+      chunks.push(chunk);
+    },
+  });
+  return {
+    stream,
+    result: () => new TextDecoder().decode(Buffer.concat(chunks)),
+  };
+}
+
+/** Create stub handlers that record calls. */
+function makeHandlers(overrides: Partial<RemoteHelperHandlers> = {}): RemoteHelperHandlers {
+  return {
+    list: async (_forPush: boolean) => "@ refs/heads/main HEAD\nrefs/heads/main refs/heads/main\n",
+    handleImport: async (_refs: string[]) => "done\n",
+    handleExport: async (_stdin: ReadableStream<Uint8Array>) => "ok refs/heads/main\n\n",
+    ...overrides,
+  };
+}
+
+const MARKS_DIR = "/tmp/test-marks";
+
+describe("remote-protocol", () => {
+  test("capabilities response format", async () => {
+    const stdin = streamFrom("capabilities\n\n");
+    const { stream, result } = collectStream();
+    await runProtocol(stdin, stream, makeHandlers(), { marksDir: MARKS_DIR });
+
+    const output = result();
+    expect(output).toContain("import\n");
+    expect(output).toContain("export\n");
+    expect(output).toContain("refspec refs/heads/*:refs/mcx/*/heads/*\n");
+    expect(output).toContain("option\n");
+    expect(output).toContain(`*import-marks ${MARKS_DIR}/marks\n`);
+    expect(output).toContain(`*export-marks ${MARKS_DIR}/marks\n`);
+    // Capabilities block ends with blank line
+    expect(output).toContain("\n\n");
+  });
+
+  test("list dispatch (not for-push)", async () => {
+    let calledForPush: boolean | undefined;
+    const handlers = makeHandlers({
+      list: async (forPush) => {
+        calledForPush = forPush;
+        return "@ refs/heads/main HEAD\n";
+      },
+    });
+
+    const stdin = streamFrom("list\n\n");
+    const { stream, result } = collectStream();
+    await runProtocol(stdin, stream, handlers, { marksDir: MARKS_DIR });
+
+    expect(calledForPush).toBe(false);
+    expect(result()).toContain("@ refs/heads/main HEAD");
+  });
+
+  test("list for-push dispatch", async () => {
+    let calledForPush: boolean | undefined;
+    const handlers = makeHandlers({
+      list: async (forPush) => {
+        calledForPush = forPush;
+        return "@ refs/heads/main HEAD\n";
+      },
+    });
+
+    const stdin = streamFrom("list for-push\n\n");
+    const { stream, result } = collectStream();
+    await runProtocol(stdin, stream, handlers, { marksDir: MARKS_DIR });
+
+    expect(calledForPush).toBe(true);
+    expect(result()).toContain("@ refs/heads/main HEAD");
+  });
+
+  test("import batching (multiple refs)", async () => {
+    let importedRefs: string[] = [];
+    const handlers = makeHandlers({
+      handleImport: async (refs) => {
+        importedRefs = refs;
+        return "done\n";
+      },
+    });
+
+    const stdin = streamFrom("import refs/heads/main\nimport refs/heads/dev\nimport refs/heads/feature\n\n");
+    const { stream, result } = collectStream();
+    await runProtocol(stdin, stream, handlers, { marksDir: MARKS_DIR });
+
+    expect(importedRefs).toEqual(["refs/heads/main", "refs/heads/dev", "refs/heads/feature"]);
+    expect(result()).toContain("done");
+  });
+
+  test("import single ref", async () => {
+    let importedRefs: string[] = [];
+    const handlers = makeHandlers({
+      handleImport: async (refs) => {
+        importedRefs = refs;
+        return "done\n";
+      },
+    });
+
+    const stdin = streamFrom("import refs/heads/main\n\n");
+    const { stream, result } = collectStream();
+    await runProtocol(stdin, stream, handlers, { marksDir: MARKS_DIR });
+
+    expect(importedRefs).toEqual(["refs/heads/main"]);
+    expect(result()).toContain("done");
+  });
+
+  test("export dispatch", async () => {
+    let exportCalled = false;
+    const handlers = makeHandlers({
+      handleExport: async (stdin) => {
+        exportCalled = true;
+        // Consume the stream
+        const reader = stdin.getReader();
+        while (true) {
+          const { done } = await reader.read();
+          if (done) break;
+        }
+        return "ok refs/heads/main\n\n";
+      },
+    });
+
+    const stdin = streamFrom("export\nsome-fast-import-data\n");
+    const { stream, result } = collectStream();
+    await runProtocol(stdin, stream, handlers, { marksDir: MARKS_DIR });
+
+    expect(exportCalled).toBe(true);
+    expect(result()).toContain("ok refs/heads/main");
+  });
+
+  test("option handling — supported option", async () => {
+    const stdin = streamFrom("option verbosity 2\n\n");
+    const { stream, result } = collectStream();
+    await runProtocol(stdin, stream, makeHandlers(), { marksDir: MARKS_DIR });
+
+    expect(result()).toBe("ok\n");
+  });
+
+  test("option handling — unsupported option", async () => {
+    const stdin = streamFrom("option progress true\n\n");
+    const { stream, result } = collectStream();
+    await runProtocol(stdin, stream, makeHandlers(), { marksDir: MARKS_DIR });
+
+    expect(result()).toBe("unsupported\n");
+  });
+
+  test("empty line exits cleanly", async () => {
+    const stdin = streamFrom("\n");
+    const { stream, result } = collectStream();
+    await runProtocol(stdin, stream, makeHandlers(), { marksDir: MARKS_DIR });
+
+    // Should exit without writing anything
+    expect(result()).toBe("");
+  });
+
+  test("EOF exits cleanly", async () => {
+    const stdin = streamFrom("");
+    const { stream, result } = collectStream();
+    await runProtocol(stdin, stream, makeHandlers(), { marksDir: MARKS_DIR });
+
+    expect(result()).toBe("");
+  });
+
+  test("unknown command returns unsupported", async () => {
+    const stdin = streamFrom("connect\n\n");
+    const { stream, result } = collectStream();
+    await runProtocol(stdin, stream, makeHandlers(), { marksDir: MARKS_DIR });
+
+    expect(result()).toBe("unsupported\n");
+  });
+
+  test("multiple commands in sequence", async () => {
+    let listCount = 0;
+    const handlers = makeHandlers({
+      list: async () => {
+        listCount++;
+        return `listing-${listCount}\n`;
+      },
+    });
+
+    const stdin = streamFrom("capabilities\nlist\nlist for-push\n\n");
+    const { stream, result } = collectStream();
+    await runProtocol(stdin, stream, handlers, { marksDir: MARKS_DIR });
+
+    const output = result();
+    // Capabilities output
+    expect(output).toContain("import\n");
+    // Two list calls
+    expect(listCount).toBe(2);
+    expect(output).toContain("listing-1");
+    expect(output).toContain("listing-2");
+  });
+
+  test("import followed by other command", async () => {
+    let importedRefs: string[] = [];
+    let listCalled = false;
+    const handlers = makeHandlers({
+      handleImport: async (refs) => {
+        importedRefs = refs;
+        return "done\n";
+      },
+      list: async () => {
+        listCalled = true;
+        return "refs\n";
+      },
+    });
+
+    const stdin = streamFrom("import refs/heads/main\nimport refs/heads/dev\nlist\n\n");
+    const { stream } = collectStream();
+    await runProtocol(stdin, stream, handlers, { marksDir: MARKS_DIR });
+
+    expect(importedRefs).toEqual(["refs/heads/main", "refs/heads/dev"]);
+    expect(listCalled).toBe(true);
+  });
+});

--- a/packages/clone/src/engine/remote-protocol.ts
+++ b/packages/clone/src/engine/remote-protocol.ts
@@ -1,0 +1,152 @@
+/**
+ * Git remote helper stdin/stdout line protocol parser and capability handler.
+ *
+ * Git writes commands to stdin; the helper writes responses to stdout.
+ * This module implements the line protocol parsing, command batching,
+ * and capability negotiation for git-remote-mcx.
+ */
+
+export interface RemoteHelperHandlers {
+  list(forPush: boolean): Promise<string>;
+  handleImport(refs: string[]): Promise<string>;
+  handleExport(stdin: ReadableStream<Uint8Array>): Promise<string>;
+}
+
+export interface ProtocolOptions {
+  marksDir: string;
+}
+
+/** Read a single line from a ReadableStream reader, stripping the trailing newline. */
+async function readLine(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  buffer: { remainder: string },
+): Promise<string | null> {
+  while (true) {
+    const nlIndex = buffer.remainder.indexOf("\n");
+    if (nlIndex !== -1) {
+      const line = buffer.remainder.slice(0, nlIndex);
+      buffer.remainder = buffer.remainder.slice(nlIndex + 1);
+      return line;
+    }
+
+    const { done, value } = await reader.read();
+    if (done) {
+      // Return remaining data as final line if non-empty
+      if (buffer.remainder.length > 0) {
+        const last = buffer.remainder;
+        buffer.remainder = "";
+        return last;
+      }
+      return null;
+    }
+
+    buffer.remainder += new TextDecoder().decode(value);
+  }
+}
+
+/** Write a string to stdout, encoding as UTF-8. */
+async function writeLine(writer: WritableStreamDefaultWriter<Uint8Array>, data: string): Promise<void> {
+  await writer.write(new TextEncoder().encode(data));
+}
+
+/** Known options that the helper supports. */
+const SUPPORTED_OPTIONS = new Set(["verbosity"]);
+
+/**
+ * Run the git remote helper protocol loop.
+ *
+ * Reads commands from stdin line-by-line, dispatches to the provided handlers,
+ * and writes responses to stdout.
+ */
+export async function runProtocol(
+  stdin: ReadableStream<Uint8Array>,
+  stdout: WritableStream<Uint8Array>,
+  handlers: RemoteHelperHandlers,
+  options: ProtocolOptions,
+): Promise<void> {
+  const reader = stdin.getReader();
+  const writer = stdout.getWriter();
+  const buffer = { remainder: "" };
+
+  try {
+    while (true) {
+      const line = await readLine(reader, buffer);
+
+      // EOF or empty line = exit
+      if (line === null || line === "") {
+        return;
+      }
+
+      if (line === "capabilities") {
+        const caps = [
+          "import",
+          "export",
+          "refspec refs/heads/*:refs/mcx/*/heads/*",
+          "option",
+          `*import-marks ${options.marksDir}/marks`,
+          `*export-marks ${options.marksDir}/marks`,
+        ];
+        await writeLine(writer, `${caps.join("\n")}\n\n`);
+      } else if (line === "list" || line === "list for-push") {
+        const forPush = line === "list for-push";
+        const response = await handlers.list(forPush);
+        await writeLine(writer, `${response}\n`);
+      } else if (line.startsWith("import ")) {
+        // Batch import: collect all consecutive import lines
+        const refs: string[] = [line.slice("import ".length)];
+
+        while (true) {
+          const nextLine = await readLine(reader, buffer);
+          if (nextLine === null || !nextLine.startsWith("import ")) {
+            // Put back non-import line by prepending to remainder
+            if (nextLine !== null && nextLine !== "") {
+              buffer.remainder = `${nextLine}\n${buffer.remainder}`;
+            }
+            break;
+          }
+          refs.push(nextLine.slice("import ".length));
+        }
+
+        const response = await handlers.handleImport(refs);
+        await writeLine(writer, response);
+      } else if (line === "export") {
+        // For export, we pass the remaining stdin as a stream to the handler.
+        // Create a new ReadableStream that feeds from our buffered reader.
+        const exportStream = new ReadableStream<Uint8Array>({
+          async pull(controller) {
+            // First drain any buffered remainder
+            if (buffer.remainder.length > 0) {
+              controller.enqueue(new TextEncoder().encode(buffer.remainder));
+              buffer.remainder = "";
+            }
+            const { done, value } = await reader.read();
+            if (done) {
+              controller.close();
+            } else {
+              controller.enqueue(value);
+            }
+          },
+        });
+
+        const response = await handlers.handleExport(exportStream);
+        await writeLine(writer, response);
+      } else if (line.startsWith("option ")) {
+        const rest = line.slice("option ".length);
+        const spaceIdx = rest.indexOf(" ");
+        const key = spaceIdx === -1 ? rest : rest.slice(0, spaceIdx);
+
+        if (SUPPORTED_OPTIONS.has(key)) {
+          await writeLine(writer, "ok\n");
+        } else {
+          await writeLine(writer, "unsupported\n");
+        }
+      } else {
+        // Unknown command — ignore per git remote helper convention
+        await writeLine(writer, "unsupported\n");
+      }
+    }
+  } finally {
+    reader.releaseLock();
+    writer.releaseLock();
+  }
+}

--- a/packages/clone/src/index.ts
+++ b/packages/clone/src/index.ts
@@ -7,3 +7,4 @@ export * from "./engine/clone";
 export * from "./engine/frontmatter";
 export * from "./engine/pull";
 export * from "./engine/push";
+export * from "./engine/remote-protocol";


### PR DESCRIPTION
## Summary
- Implement `runProtocol()` in `packages/clone/src/engine/remote-protocol.ts` — a git remote helper stdin/stdout line protocol parser for git-remote-mcx
- Handles all protocol commands: `capabilities`, `list`, `import` (with batching), `export`, `option`, and empty-line exit
- Pluggable `RemoteHelperHandlers` interface for provider-specific behavior

## Test plan
- [x] 13 unit tests covering all protocol commands with string-based stdin/stdout
- [x] Capabilities response format verified (all 6 capabilities + blank line terminator)
- [x] `list` and `list for-push` dispatch correctly
- [x] Import batching tested with single and multiple refs
- [x] Import-then-other-command sequence tested (non-import line put back correctly)
- [x] Export dispatch passes remaining stdin as stream
- [x] Option handling: supported (`verbosity`) returns `ok`, unsupported returns `unsupported`
- [x] Empty line and EOF exit cleanly
- [x] Unknown commands return `unsupported`
- [x] Multiple commands in sequence work correctly
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] Full test suite passes (4352 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)