### PR TITLE
fix(worktree): unset core.bare instead of setting false, add batch guard (fixes #1206)

### DIFF
--- a/packages/core/src/git.spec.ts
+++ b/packages/core/src/git.spec.ts
@@ -17,17 +17,17 @@ function makeFakeBareRepo(): string {
 }
 
 describe("fixCoreBare", () => {
-  test("resets core.bare when it is true", () => {
+  test("unsets core.bare when it is true", () => {
     const cwd = makeFakeWorktree();
     try {
       const calls: string[][] = [];
       const exec: ExecFn = mock((cmd: string[]) => {
         calls.push(cmd);
-        if (cmd.length === 5) {
+        if (cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset")) {
           // git config core.bare (read)
           return { stdout: "true\n", exitCode: 0 };
         }
-        // git config core.bare false (write)
+        // git config --unset core.bare
         return { stdout: "", exitCode: 0 };
       });
 
@@ -36,23 +36,23 @@ describe("fixCoreBare", () => {
       expect(result).toBe(true);
       expect(calls).toHaveLength(2);
       expect(calls[0]).toEqual(["git", "-C", cwd, "config", "core.bare"]);
-      expect(calls[1]).toEqual(["git", "-C", cwd, "config", "core.bare", "false"]);
+      expect(calls[1]).toEqual(["git", "-C", cwd, "config", "--unset", "core.bare"]);
     } finally {
       rmSync(cwd, { recursive: true });
     }
   });
 
-  test("returns false when write fails", () => {
+  test("returns false when unset fails", () => {
     const cwd = makeFakeWorktree();
     try {
       const calls: string[][] = [];
       const exec: ExecFn = mock((cmd: string[]) => {
         calls.push(cmd);
-        if (cmd.length === 5) {
+        if (cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset")) {
           // read — core.bare is true
           return { stdout: "true\n", exitCode: 0 };
         }
-        // write fails
+        // unset fails
         return { stdout: "", exitCode: 1 };
       });
 

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -28,8 +28,12 @@ export function fixCoreBare(cwd: string, exec: ExecFn): boolean {
 
   const { stdout, exitCode } = exec(["git", "-C", cwd, "config", "core.bare"]);
   if (exitCode === 0 && stdout.trim() === "true") {
-    const write = exec(["git", "-C", cwd, "config", "core.bare", "false"]);
-    return write.exitCode === 0;
+    // Unset the key entirely rather than setting to "false". Without the key,
+    // git auto-detects bare status from the directory structure (.git dir = non-bare).
+    // This prevents the recurrence where concurrent worktree operations flip an
+    // existing "false" value back to "true". See #1206.
+    const unset = exec(["git", "-C", cwd, "config", "--unset", "core.bare"]);
+    return unset.exitCode === 0;
   }
   return false;
 }

--- a/packages/core/src/worktree-shim.spec.ts
+++ b/packages/core/src/worktree-shim.spec.ts
@@ -499,4 +499,68 @@ describe("pruneWorktrees", () => {
     expect(result.pruned).toBe(0);
     expect(result.skippedUnmerged).toEqual(["claude/feat-wip"]);
   });
+
+  test("batch guard: calls fixCoreBare after pruning when core.bare=true on last removal", () => {
+    // Simulate the recurrence bug: individual per-removal fix runs but a subsequent
+    // removal flips core.bare back to true. The final batch guard should catch it.
+    // fixCoreBare guards against non-existent repos via existsSync(.git), so we need
+    // a real temp dir with a .git marker.
+    const repoRoot = makeTmpDir();
+    try {
+      writeFileSync(join(repoRoot, ".git"), "gitdir: /some/repo\n");
+      const wt1 = join(repoRoot, ".claude", "worktrees", "feat-a");
+      const wt2 = join(repoRoot, ".claude", "worktrees", "feat-b");
+
+      const porcelainOutput = [
+        `worktree ${repoRoot}`,
+        "HEAD abc123",
+        "branch refs/heads/main",
+        "",
+        `worktree ${wt1}`,
+        "HEAD def456",
+        "branch refs/heads/claude/feat-a",
+        "",
+        `worktree ${wt2}`,
+        "HEAD ghi789",
+        "branch refs/heads/claude/feat-b",
+        "",
+      ].join("\n");
+
+      const execCalls: string[][] = [];
+      const exec = mock((cmd: string[]) => {
+        execCalls.push(cmd);
+        if (cmd.includes("list") && cmd.includes("--porcelain"))
+          return { stdout: porcelainOutput, stderr: "", exitCode: 0 };
+        if (cmd.includes("symbolic-ref")) return { stdout: "refs/remotes/origin/main", stderr: "", exitCode: 0 };
+        if (cmd.includes("--merged"))
+          return { stdout: "  main\n  claude/feat-a\n  claude/feat-b\n", stderr: "", exitCode: 0 };
+        if (cmd.includes("status")) return { stdout: "", stderr: "", exitCode: 0 };
+        if (cmd.includes("worktree") && cmd.includes("remove")) return { stdout: "", stderr: "", exitCode: 0 };
+        if (cmd.includes("branch") && cmd.includes("-d")) return { stdout: "", stderr: "", exitCode: 0 };
+        // Simulate core.bare=true after all removals complete
+        if (cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset")) {
+          return { stdout: "true", stderr: "", exitCode: 0 };
+        }
+        // --unset succeeds
+        return { stdout: "", stderr: "", exitCode: 0 };
+      });
+      const printErrors: string[] = [];
+      const printError = mock((msg: string) => printErrors.push(msg));
+
+      const result = pruneWorktrees({
+        repoRoot,
+        activeWorktrees: new Set(),
+        deps: { exec, printError },
+      });
+
+      expect(result.pruned).toBe(2);
+      // Verify the batch-guard --unset call was made
+      const unsetCalls = execCalls.filter((c) => c.includes("--unset") && c.includes("core.bare"));
+      expect(unsetCalls.length).toBeGreaterThanOrEqual(1);
+      // Verify the batch guard printed the fix
+      expect(printErrors.some((m) => m.includes("batch worktree prune"))).toBe(true);
+    } finally {
+      rmSync(repoRoot, { recursive: true });
+    }
+  });
 });

--- a/packages/core/src/worktree-shim.spec.ts
+++ b/packages/core/src/worktree-shim.spec.ts
@@ -185,11 +185,11 @@ describe("createWorktree", () => {
       exec: mock((cmd: string[]) => {
         execCalls.push(cmd);
         // Simulate git reporting core.bare=true (the bug we're guarding against)
-        if (cmd.includes("config") && cmd.includes("core.bare") && cmd.length === 5) {
+        if (cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset")) {
           return { stdout: "true", stderr: "", exitCode: 0 };
         }
-        // git config core.bare false — the fix
-        if (cmd.includes("config") && cmd.includes("core.bare") && cmd.includes("false")) {
+        // git config --unset core.bare — the fix
+        if (cmd.includes("--unset") && cmd.includes("core.bare")) {
           return { stdout: "", stderr: "", exitCode: 0 };
         }
         return { stdout: "", stderr: "", exitCode: 0 };
@@ -201,15 +201,13 @@ describe("createWorktree", () => {
 
     // Verify core.bare was checked after worktree add
     const coreBareReadIdx = execCalls.findIndex(
-      (c) => c.includes("config") && c.includes("core.bare") && c.length === 5,
+      (c) => c.includes("config") && c.includes("core.bare") && !c.includes("--unset"),
     );
     const worktreeAddIdx = execCalls.findIndex((c) => c.includes("worktree") && c.includes("add"));
     expect(coreBareReadIdx).toBeGreaterThan(worktreeAddIdx);
 
-    // Verify it was fixed (core.bare set to false)
-    const coreBareFixIdx = execCalls.findIndex(
-      (c) => c.includes("config") && c.includes("core.bare") && c.includes("false"),
-    );
+    // Verify it was fixed (core.bare unset)
+    const coreBareFixIdx = execCalls.findIndex((c) => c.includes("--unset") && c.includes("core.bare"));
     expect(coreBareFixIdx).toBeGreaterThan(coreBareReadIdx);
 
     // Should log the fix

--- a/packages/core/src/worktree-shim.ts
+++ b/packages/core/src/worktree-shim.ts
@@ -362,6 +362,15 @@ export function pruneWorktrees(opts: WorktreePruneOptions): WorktreePruneResult 
     }
   }
 
+  // Final guard: check core.bare one last time after all removals complete.
+  // Individual per-removal fixes can be undone by subsequent removals in the
+  // same batch. This ensures the repo is in a valid state when we return. #1206
+  if (pruned > 0) {
+    if (fixCoreBare(repoRoot, (cmd) => deps.exec(cmd))) {
+      deps.printError("Fixed core.bare=true after batch worktree prune");
+    }
+  }
+
   return { pruned, skippedUnmerged };
 }
 

--- a/packages/daemon/src/index.spec.ts
+++ b/packages/daemon/src/index.spec.ts
@@ -794,6 +794,54 @@ describe("pruneOrphanedWorktrees", () => {
     // Should not throw — catches internally
     pruneOrphanedWorktrees(db, silentLogger, mockGitOps());
   });
+
+  test("batch guard: calls fixCoreBare after all removals when core.bare=true (#1206)", () => {
+    // fixCoreBare guards against non-existent repos via existsSync(.git), so we
+    // need a real temp dir with a .git marker for the repoRoot.
+    opts = testOptions();
+    const repoDir = join(opts.dir, "repo-batch-guard");
+    mkdirSync(repoDir, { recursive: true });
+    writeFileSync(join(repoDir, ".git"), "gitdir: /some/repo\n");
+
+    const db = new StateDb(opts.DB_PATH);
+    try {
+      // Two sessions in the same repo — simulates a batch wind-down
+      for (const id of ["ended-1", "ended-2"]) {
+        db.upsertSession({ sessionId: id, pid: 99999, model: "sonnet", cwd: repoDir, worktree: `wt-${id}` });
+        db.endSession(id);
+      }
+
+      const execCalls: string[][] = [];
+      const warnMessages: string[] = [];
+      const logger = { ...silentLogger, warn: (msg: string) => warnMessages.push(msg) };
+
+      pruneOrphanedWorktrees(
+        db,
+        logger,
+        mockGitOps({
+          pathExists: () => true,
+          status: () => ({ exitCode: 0, stdout: "" }),
+          removeWorktree: () => ({ exitCode: 0 }),
+          exec: (cmd: string[]) => {
+            execCalls.push(cmd);
+            // Simulate core.bare=true on every read (per-removal and batch guard)
+            if (cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset")) {
+              return { exitCode: 0, stdout: "true\n" };
+            }
+            return { exitCode: 0, stdout: "" };
+          },
+        }),
+      );
+
+      // The batch guard should have called --unset at least once (once per affected repo)
+      const unsetCalls = execCalls.filter((c) => c.includes("--unset") && c.includes("core.bare"));
+      expect(unsetCalls.length).toBeGreaterThanOrEqual(1);
+      // And logged a warning
+      expect(warnMessages.some((m) => m.includes("core.bare"))).toBe(true);
+    } finally {
+      db.close();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -159,6 +159,7 @@ export function pruneOrphanedWorktrees(
       .listSessions(false)
       .filter((s) => s.endedAt && Date.now() - new Date(s.endedAt).getTime() < RETENTION_MS);
     let pruned = 0;
+    const affectedRepoRoots = new Set<string>();
 
     for (const session of endedSessions) {
       if (!session.worktree || !session.cwd) continue;
@@ -183,6 +184,7 @@ export function pruneOrphanedWorktrees(
         if (fixCoreBare(repoRoot, (cmd) => gitOps.exec(cmd))) {
           logger.warn("[mcpd] Fixed core.bare=true after worktree removal");
         }
+        affectedRepoRoots.add(repoRoot);
         pruned++;
         logger.info(`[mcpd] Pruned orphaned worktree: ${worktreePath}`);
         // Delete merged branch
@@ -196,6 +198,13 @@ export function pruneOrphanedWorktrees(
     }
 
     if (pruned > 0) {
+      // Final guard: check core.bare after all removals complete. Individual
+      // per-removal fixes can be undone by subsequent removals. #1206
+      for (const root of affectedRepoRoots) {
+        if (fixCoreBare(root, (cmd) => gitOps.exec(cmd))) {
+          logger.warn("[mcpd] Fixed core.bare=true after batch worktree prune");
+        }
+      }
       logger.info(`[mcpd] Pruned ${pruned} orphaned worktree${pruned === 1 ? "" : "s"}`);
     }
   } catch (err) {


### PR DESCRIPTION
## Summary
- Changed `fixCoreBare()` to use `git config --unset core.bare` instead of `git config core.bare false`. Removing the key entirely lets git auto-detect bare status from the directory structure, preventing concurrent worktree operations from flipping an existing value back to `true`.
- Added a final `fixCoreBare` guard after batch prune loops in both `pruneWorktrees()` (worktree-shim) and `pruneOrphanedWorktrees()` (daemon), ensuring the repo is in a valid state after the last removal completes.
- Updated tests to verify the `--unset` behavior.

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] All 4271 tests pass (`bun test packages/`)
- [x] `git.spec.ts` — verifies `fixCoreBare` calls `git config --unset core.bare` (not `git config core.bare false`)
- [x] `worktree-shim.spec.ts` — verifies `--unset` is used after worktree add
- [x] `index.spec.ts` (daemon) — 29 tests pass including orphan prune tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)