### PR TITLE
feat(trace): proper W3C span hierarchy with causal chain propagation (fixes #299)

### DIFF
--- a/packages/core/src/ipc-client.ts
+++ b/packages/core/src/ipc-client.ts
@@ -105,12 +105,21 @@ export async function ipcCall<M extends IpcMethod>(
     params,
     traceparent: callSpan.traceparent(),
   };
-  const response = await sendRequest(request, opts?.timeoutMs);
+  try {
+    const response = await sendRequest(request, opts?.timeoutMs);
 
-  if (response.error) {
-    throw new IpcCallError(response.error);
+    if (response.error) {
+      callSpan.setStatus("ERROR");
+      throw new IpcCallError(response.error);
+    }
+    callSpan.setStatus("OK");
+    return response.result as IpcMethodResult[M];
+  } catch (err) {
+    callSpan.setStatus("ERROR");
+    throw err;
+  } finally {
+    callSpan.end();
   }
-  return response.result as IpcMethodResult[M];
 }
 
 /** Send a request via HTTP-over-Unix-socket and return the response */

--- a/packages/core/src/ipc-client.ts
+++ b/packages/core/src/ipc-client.ts
@@ -8,7 +8,21 @@
 import { IPC_REQUEST_TIMEOUT_MS, PING_TIMEOUT_MS, options } from "./constants";
 import type { IpcError, IpcMethod, IpcMethodResult, IpcRequest, IpcResponse } from "./ipc";
 import { nextId } from "./ipc";
-import { formatTraceparent, generateSpanId, generateTraceId } from "./trace";
+import type { LiveSpan } from "./trace";
+import { startSpan } from "./trace";
+
+/**
+ * Module-level startup span for the mcx CLI process.
+ * Constant for the process lifetime — per-call spans are children of this.
+ */
+let _processSpan: LiveSpan | null = null;
+
+function getProcessSpan(): LiveSpan {
+  if (!_processSpan) {
+    _processSpan = startSpan("mcx");
+  }
+  return _processSpan;
+}
 
 /**
  * Structured error thrown by ipcCall() when the daemon returns an error response.
@@ -84,11 +98,12 @@ export async function ipcCall<M extends IpcMethod>(
   params?: unknown,
   opts?: { timeoutMs?: number },
 ): Promise<IpcMethodResult[M]> {
+  const callSpan = getProcessSpan().child(`ipc.${method}`);
   const request: IpcRequest = {
     id: nextId(),
     method,
     params,
-    traceparent: formatTraceparent(generateTraceId(), generateSpanId()),
+    traceparent: callSpan.traceparent(),
   };
   const response = await sendRequest(request, opts?.timeoutMs);
 

--- a/packages/core/src/trace.spec.ts
+++ b/packages/core/src/trace.spec.ts
@@ -248,6 +248,27 @@ describe("LiveSpan", () => {
     expect(mid.parentSpanId).toBe(root.spanId);
   });
 
+  test("full causal chain: mcx → daemon → worker → claude", () => {
+    // Simulate the full propagation chain
+    const mcxSpan = startSpan("mcx");
+    const callSpan = mcxSpan.child("ipc.callTool");
+
+    // Daemon receives callSpan's traceparent
+    const daemonSpan = startSpan("ipc.callTool", {
+      parentTraceparent: callSpan.traceparent(),
+    });
+    expect(daemonSpan.traceId).toBe(mcxSpan.traceId);
+    expect(daemonSpan.parentSpanId).toBe(callSpan.spanId);
+
+    // Worker has its own startup span
+    const workerSpan = startSpan("claude-worker");
+    // Worker passes its traceparent to spawned process
+    const workerTp = workerSpan.traceparent();
+    const parsed = parseTraceparent(workerTp);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.parentId).toBe(workerSpan.spanId);
+  });
+
   test("end() snapshots attributes (mutations don't leak)", () => {
     const live = startSpan("test.snapshot");
     live.setAttribute("before", true);

--- a/packages/core/src/trace.spec.ts
+++ b/packages/core/src/trace.spec.ts
@@ -250,23 +250,32 @@ describe("LiveSpan", () => {
 
   test("full causal chain: mcx → daemon → worker → claude", () => {
     // Simulate the full propagation chain
+
+    // 1. mcx CLI creates a process-level span
     const mcxSpan = startSpan("mcx");
     const callSpan = mcxSpan.child("ipc.callTool");
 
-    // Daemon receives callSpan's traceparent
-    const daemonSpan = startSpan("ipc.callTool", {
+    // 2. Daemon receives callSpan's traceparent on the IPC request
+    const daemonRequestSpan = startSpan("ipc.callTool", {
       parentTraceparent: callSpan.traceparent(),
     });
-    expect(daemonSpan.traceId).toBe(mcxSpan.traceId);
-    expect(daemonSpan.parentSpanId).toBe(callSpan.spanId);
+    expect(daemonRequestSpan.traceId).toBe(mcxSpan.traceId);
+    expect(daemonRequestSpan.parentSpanId).toBe(callSpan.spanId);
 
-    // Worker has its own startup span
-    const workerSpan = startSpan("claude-worker");
-    // Worker passes its traceparent to spawned process
-    const workerTp = workerSpan.traceparent();
-    const parsed = parseTraceparent(workerTp);
-    expect(parsed).not.toBeNull();
-    expect(parsed?.parentId).toBe(workerSpan.spanId);
+    // 3. Daemon has its own startup span, passes its traceparent to the worker
+    const daemonSpan = startSpan("mcpd");
+    const workerSpan = startSpan("claude-worker", {
+      parentTraceparent: daemonSpan.traceparent(),
+    });
+    expect(workerSpan.traceId).toBe(daemonSpan.traceId);
+    expect(workerSpan.parentSpanId).toBe(daemonSpan.spanId);
+
+    // 4. Worker passes its traceparent to spawned Claude CLI process
+    const claudeSpan = startSpan("claude-cli", {
+      parentTraceparent: workerSpan.traceparent(),
+    });
+    expect(claudeSpan.traceId).toBe(daemonSpan.traceId);
+    expect(claudeSpan.parentSpanId).toBe(workerSpan.spanId);
   });
 
   test("end() snapshots attributes (mutations don't leak)", () => {

--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -9,8 +9,8 @@
  * Follows the same pattern as AliasServer (alias-server.ts).
  */
 
-import type { JsonSchema, Logger, ToolInfo, WorkItemEvent } from "@mcp-cli/core";
-import { CLAUDE_SERVER_NAME, consoleLogger, formatToolSignature, silentLogger } from "@mcp-cli/core";
+import type { JsonSchema, LiveSpan, Logger, ToolInfo, WorkItemEvent } from "@mcp-cli/core";
+import { CLAUDE_SERVER_NAME, consoleLogger, formatToolSignature, silentLogger, startSpan } from "@mcp-cli/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { CLAUDE_TOOLS } from "./claude-session/tools";
 import { closeClientWithTimeout } from "./close-timeout";
@@ -148,6 +148,8 @@ export class ClaudeServer {
   private readonly logger: Logger;
   private readonly metrics: MetricsCollector;
   private readonly restartPolicy = DEFAULT_RESTART_POLICY;
+  /** Daemon-level span — children (worker, sessions) inherit its traceId. */
+  private readonly daemonSpan: LiveSpan;
   /** Sessions without PIDs that stay disconnected longer than this are pruned as zombies. */
   private static readonly NO_PID_SESSION_TTL_MS = 10 * 60 * 1000; // 10 minutes
 
@@ -172,6 +174,7 @@ export class ClaudeServer {
       clientFactory ?? (() => new Client({ name: `mcp-cli/${CLAUDE_SERVER_NAME}`, version: "0.1.0" }));
     this.logger = logger ?? consoleLogger;
     this.metrics = metricsCollector ?? defaultMetrics;
+    this.daemonSpan = startSpan("mcpd");
   }
 
   /** Start the worker and connect the MCP client. */
@@ -214,12 +217,14 @@ export class ClaudeServer {
         const msg = event instanceof ErrorEvent ? event.message : String(event);
         if (cleanup()) reject(new Error(`Claude session worker error: ${msg}`));
       };
-      // Send init to start the worker
+      // Send init to start the worker — include daemon traceparent so the worker
+      // span becomes a child of the daemon span, completing the causal chain.
       worker.postMessage({
         type: "init",
         daemonId: this.daemonId,
         wsPort: this.configuredWsPort,
         quiet: this.logger === silentLogger,
+        traceparent: this.daemonSpan.traceparent(),
       });
     });
 

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -47,6 +47,8 @@ interface InitMessage {
   wsPort?: number;
   /** Suppress worker-side console logging (used in tests). */
   quiet?: boolean;
+  /** Daemon's W3C traceparent — worker span becomes a child of this. */
+  traceparent?: string;
 }
 
 interface ToolsChangedMessage {
@@ -652,7 +654,9 @@ self.onmessage = async (event: MessageEvent) => {
   const data = event.data;
   if (isControlMessage(data) && data.type === "init") {
     daemonId = data.daemonId;
-    workerSpan = startSpan("claude-worker");
+    workerSpan = startSpan("claude-worker", {
+      parentTraceparent: data.traceparent,
+    });
     try {
       const port = await startServer(data.wsPort, data.quiet);
       self.postMessage({ type: "ready", port });
@@ -662,8 +666,14 @@ self.onmessage = async (event: MessageEvent) => {
       wsServer = null;
       mcpServer = null;
       transport = null;
+      workerSpan?.end();
       const message = err instanceof Error ? err.message : String(err);
       self.postMessage({ type: "error", message });
     }
   }
 };
+
+// End the worker span when the worker is terminated
+self.addEventListener("close", () => {
+  workerSpan?.end();
+});

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -14,7 +14,14 @@
  *   { type: "db:end", sessionId }
  */
 
-import { CLAUDE_SERVER_NAME, type WorkItemEvent, generateSpanId, resolveModelName, silentLogger } from "@mcp-cli/core";
+import {
+  CLAUDE_SERVER_NAME,
+  type LiveSpan,
+  type WorkItemEvent,
+  resolveModelName,
+  silentLogger,
+  startSpan,
+} from "@mcp-cli/core";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { DEFAULT_SAFE_TOOLS, type PermissionRule, type PermissionStrategy } from "./claude-session/permission-router";
@@ -86,7 +93,7 @@ let transport: WorkerServerTransport | null = null;
 
 // Trace context — set on init, stable for worker lifetime
 let daemonId: string | undefined;
-let workerId: string | undefined;
+let workerSpan: LiveSpan | undefined;
 
 // ── Tool handlers ──
 
@@ -190,7 +197,7 @@ async function handlePrompt(
       },
     });
 
-    const pid = server.spawnClaude(sessionId);
+    const pid = server.spawnClaude(sessionId, workerSpan?.traceparent());
 
     // Capture pidStartTime here in the worker thread (off the main event loop)
     // so the parent doesn't need to do a blocking ps(1) call per session.
@@ -645,7 +652,7 @@ self.onmessage = async (event: MessageEvent) => {
   const data = event.data;
   if (isControlMessage(data) && data.type === "init") {
     daemonId = data.daemonId;
-    workerId = generateSpanId();
+    workerSpan = startSpan("claude-worker");
     try {
       const port = await startServer(data.wsPort, data.quiet);
       self.postMessage({ type: "ready", port });

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -15,11 +15,13 @@ function mockSpawn(): {
   exitResolve: (code: number) => void;
   killed: boolean;
   lastCmd: string[];
+  lastOpts: { cwd?: string; env?: Record<string, string | undefined> };
 } {
   let exitResolve: (code: number) => void = () => {};
   const state = {
-    spawn: ((cmd: string[]) => {
+    spawn: ((cmd: string[], opts: { cwd?: string; env?: Record<string, string | undefined> }) => {
       state.lastCmd = cmd;
+      state.lastOpts = { cwd: opts?.cwd, env: opts?.env };
       return {
         pid: 12345,
         exited: new Promise<number>((r) => {
@@ -35,6 +37,7 @@ function mockSpawn(): {
     exitResolve: (code: number) => exitResolve(code),
     killed: false,
     lastCmd: [] as string[],
+    lastOpts: {} as { cwd?: string; env?: Record<string, string | undefined> },
   };
   return state;
 }
@@ -1378,6 +1381,29 @@ describe("ClaudeWsServer", () => {
 
     expect(ms.lastCmd).toContain("--worktree");
     expect(ms.lastCmd).toContain("my-tree");
+  });
+
+  test("spawnClaude passes TRACEPARENT env when traceparent is provided", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    await server.start();
+
+    server.prepareSession("trace-session", { prompt: "Hello" });
+    const tp = `00-${"a".repeat(32)}-${"b".repeat(16)}-01`;
+    server.spawnClaude("trace-session", tp);
+
+    expect(ms.lastOpts.env).toEqual({ TRACEPARENT: tp });
+  });
+
+  test("spawnClaude omits TRACEPARENT env when traceparent is not provided", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    await server.start();
+
+    server.prepareSession("no-trace-session", { prompt: "Hello" });
+    server.spawnClaude("no-trace-session");
+
+    expect(ms.lastOpts.env).toBeUndefined();
   });
 
   test("bye returns null worktree for non-worktree session", async () => {

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -275,6 +275,8 @@ interface WsSession {
   connectTimer: Timer | null;
   /** Unix timestamp (ms) when this session was created. */
   createdAt: number;
+  /** W3C traceparent used for the last spawn — reused on respawn after clear. */
+  traceparent: string | null;
   /**
    * Whether this session has an unreported actionable state (idle or waiting_permission).
    * Set to true when the session transitions to an actionable state via a real event.
@@ -533,6 +535,7 @@ export class ClaudeWsServer {
         connectTimer: null,
         createdAt: s.spawnedAt ? new Date(`${s.spawnedAt}Z`).getTime() : Date.now(),
         pendingImmediate: false, // Restored sessions have no new events
+        traceparent: null,
       });
       restored++;
       this.logger.info(`[_claude] Restored session ${s.sessionId} (state: disconnected, pid: ${s.pid})`);
@@ -566,6 +569,7 @@ export class ClaudeWsServer {
       connectTimer: null,
       createdAt: Date.now(),
       pendingImmediate: false,
+      traceparent: null,
     });
   }
 
@@ -576,6 +580,8 @@ export class ClaudeWsServer {
    */
   spawnClaude(sessionId: string, traceparent?: string): number {
     const session = this.getSession(sessionId);
+    // Store traceparent so respawn after clear can reuse it
+    if (traceparent) session.traceparent = traceparent;
     const port = this.port;
     if (!port) throw new Error("WS server not started");
 
@@ -867,8 +873,8 @@ export class ClaudeWsServer {
     // Clear transcript for fresh start
     session.transcript.length = 0;
 
-    // Respawn
-    this.spawnClaude(sessionId);
+    // Respawn — reuse stored traceparent to maintain trace continuity across clears
+    this.spawnClaude(sessionId, session.traceparent ?? undefined);
     session.clearing = false;
   }
 

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -181,7 +181,13 @@ export interface SessionResult {
 /** Dependency-injectable process spawner for testing. */
 export type SpawnFn = (
   cmd: string[],
-  opts: { cwd?: string; stdout?: "ignore" | "pipe"; stderr?: "ignore" | "pipe"; stdin?: "ignore" | "pipe" },
+  opts: {
+    cwd?: string;
+    stdout?: "ignore" | "pipe";
+    stderr?: "ignore" | "pipe";
+    stdin?: "ignore" | "pipe";
+    env?: Record<string, string | undefined>;
+  },
 ) => {
   pid: number;
   exited: Promise<number>;
@@ -566,8 +572,9 @@ export class ClaudeWsServer {
   /**
    * Spawn the Claude CLI process for a prepared session.
    * Returns the PID of the spawned process.
+   * @param traceparent Optional W3C traceparent to propagate via TRACEPARENT env var.
    */
-  spawnClaude(sessionId: string): number {
+  spawnClaude(sessionId: string, traceparent?: string): number {
     const session = this.getSession(sessionId);
     const port = this.port;
     if (!port) throw new Error("WS server not started");
@@ -613,6 +620,7 @@ export class ClaudeWsServer {
       stdout: "ignore",
       stderr: "pipe",
       stdin: "ignore",
+      env: traceparent ? { TRACEPARENT: traceparent } : undefined,
     });
 
     session.pid = proc.pid;
@@ -1909,7 +1917,13 @@ function isAddrInUse(err: unknown): boolean {
 
 function defaultSpawn(
   cmd: string[],
-  opts: { cwd?: string; stdout?: "ignore" | "pipe"; stderr?: "ignore" | "pipe"; stdin?: "ignore" | "pipe" },
+  opts: {
+    cwd?: string;
+    stdout?: "ignore" | "pipe";
+    stderr?: "ignore" | "pipe";
+    stdin?: "ignore" | "pipe";
+    env?: Record<string, string | undefined>;
+  },
 ): {
   pid: number;
   exited: Promise<number>;
@@ -1918,7 +1932,7 @@ function defaultSpawn(
 } {
   // Strip CLAUDECODE env var so the spawned claude process doesn't think
   // it's a nested session and refuse to start.
-  const env = { ...process.env };
+  const env = { ...process.env, ...opts.env };
   env.CLAUDECODE = undefined;
   // Shells set PWD on cd; Bun.spawn only does chdir(). Without this,
   // the spawned process inherits the daemon's PWD and tools that read


### PR DESCRIPTION
## Summary
- **ipc-client**: Creates a module-level startup span for the mcx CLI process; each `ipcCall()` creates a child span whose traceparent is sent to the daemon — replacing the previous random-ID-per-call approach
- **claude-session-worker**: Replaces bare `workerId = generateSpanId()` with a proper `LiveSpan` (`startSpan("claude-worker")`) and passes its traceparent to `spawnClaude()`
- **ws-server**: Adds `env` support to `SpawnFn`, propagates `TRACEPARENT` env var to spawned Claude CLI processes via `defaultSpawn()`

## Test plan
- [x] New test: `spawnClaude passes TRACEPARENT env when traceparent is provided`
- [x] New test: `spawnClaude omits TRACEPARENT env when traceparent is not provided`
- [x] New test: `full causal chain: mcx → daemon → worker → claude` (trace.spec.ts)
- [x] All 4376 existing tests pass
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)