### PR TITLE
feat(daemon): add virtual _tracing MCP server for trace introspection (closes #295)

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -243,3 +243,4 @@ export const METRICS_SERVER_NAME = "_metrics";
 export const MAIL_SERVER_NAME = "_mail";
 export const WORK_ITEMS_SERVER_NAME = "_work_items";
 export const MOCK_SERVER_NAME = "_mock";
+export const TRACING_SERVER_NAME = "_tracing";

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -291,6 +291,7 @@ export class StateDb {
       );
       CREATE INDEX IF NOT EXISTS idx_spans_trace ON spans(trace_id);
       CREATE INDEX IF NOT EXISTS idx_spans_exported ON spans(exported_at, created_at);
+      CREATE INDEX IF NOT EXISTS idx_spans_daemon ON spans(daemon_id);
     `);
   }
 
@@ -1134,6 +1135,158 @@ export class StateDb {
     }));
   }
 
+  /** Query spans with flexible filters. Returns matching spans (no exported_at). */
+  querySpans(opts?: {
+    daemonId?: string;
+    traceId?: string;
+    server?: string;
+    tool?: string;
+    status?: string;
+    sinceMs?: number;
+    untilMs?: number;
+    limit?: number;
+    afterId?: number;
+  }): Omit<SpanRow, "exportedAt">[] {
+    const conditions: string[] = [];
+    const params: (string | number)[] = [];
+
+    if (opts?.daemonId) {
+      conditions.push("daemon_id = ?");
+      params.push(opts.daemonId);
+    }
+    if (opts?.traceId) {
+      conditions.push("trace_id = ?");
+      params.push(opts.traceId);
+    }
+    if (opts?.server) {
+      conditions.push("name LIKE ? ESCAPE '\\'");
+      params.push(`%${escapeLike(opts.server)}%`);
+    }
+    if (opts?.tool) {
+      // Tool names appear after the last colon in structured span names (e.g. "tool_call:server:tool")
+      conditions.push("name LIKE ? ESCAPE '\\'");
+      params.push(`%:${escapeLike(opts.tool)}`);
+    }
+    if (opts?.status) {
+      conditions.push("status = ?");
+      params.push(opts.status);
+    }
+    if (opts?.sinceMs !== undefined) {
+      conditions.push("start_time_ms >= ?");
+      params.push(opts.sinceMs);
+    }
+    if (opts?.untilMs !== undefined) {
+      conditions.push("start_time_ms <= ?");
+      params.push(opts.untilMs);
+    }
+    if (opts?.afterId !== undefined) {
+      conditions.push("id < ?");
+      params.push(opts.afterId);
+    }
+
+    const limit = Math.min(Math.max(1, opts?.limit ?? 100), 1000);
+    params.push(limit);
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+    const rows = this.db
+      .prepare(
+        `SELECT id, trace_id, span_id, parent_span_id, trace_flags, name,
+          start_time_ms, end_time_ms, duration_ms, status, attributes_json,
+          events_json, daemon_id
+         FROM spans ${where} ORDER BY start_time_ms DESC, id DESC LIMIT ?`,
+      )
+      .all(...params) as Array<{
+      id: number;
+      trace_id: string;
+      span_id: string;
+      parent_span_id: string | null;
+      trace_flags: string;
+      name: string;
+      start_time_ms: number;
+      end_time_ms: number;
+      duration_ms: number;
+      status: string;
+      attributes_json: string | null;
+      events_json: string | null;
+      daemon_id: string | null;
+    }>;
+
+    return rows.map((row) => ({
+      id: row.id,
+      traceId: row.trace_id,
+      spanId: row.span_id,
+      parentSpanId: row.parent_span_id,
+      traceFlags: row.trace_flags,
+      name: row.name,
+      startTimeMs: row.start_time_ms,
+      endTimeMs: row.end_time_ms,
+      durationMs: row.duration_ms,
+      status: row.status,
+      attributes: row.attributes_json ? safeJsonParse(row.attributes_json, {}) : {},
+      events: row.events_json ? safeJsonParse(row.events_json, []) : [],
+      daemonId: row.daemon_id,
+    }));
+  }
+
+  /** Get all spans for a specific trace, ordered by start time ASC. */
+  getTraceSpans(traceId: string): Omit<SpanRow, "exportedAt">[] {
+    const rows = this.db
+      .prepare(
+        `SELECT id, trace_id, span_id, parent_span_id, trace_flags, name,
+          start_time_ms, end_time_ms, duration_ms, status, attributes_json,
+          events_json, daemon_id
+         FROM spans WHERE trace_id = ? ORDER BY start_time_ms ASC`,
+      )
+      .all(traceId) as Array<{
+      id: number;
+      trace_id: string;
+      span_id: string;
+      parent_span_id: string | null;
+      trace_flags: string;
+      name: string;
+      start_time_ms: number;
+      end_time_ms: number;
+      duration_ms: number;
+      status: string;
+      attributes_json: string | null;
+      events_json: string | null;
+      daemon_id: string | null;
+    }>;
+
+    return rows.map((row) => ({
+      id: row.id,
+      traceId: row.trace_id,
+      spanId: row.span_id,
+      parentSpanId: row.parent_span_id,
+      traceFlags: row.trace_flags,
+      name: row.name,
+      startTimeMs: row.start_time_ms,
+      endTimeMs: row.end_time_ms,
+      durationMs: row.duration_ms,
+      status: row.status,
+      attributes: row.attributes_json ? safeJsonParse(row.attributes_json, {}) : {},
+      events: row.events_json ? safeJsonParse(row.events_json, []) : [],
+      daemonId: row.daemon_id,
+    }));
+  }
+
+  /** List distinct daemon instances with span counts and time ranges. */
+  listDaemons(): Array<{ daemonId: string; spanCount: number; earliestMs: number; latestMs: number }> {
+    const rows = this.db
+      .prepare(
+        `SELECT daemon_id, COUNT(*) as span_count, MIN(start_time_ms) as earliest_ms, MAX(start_time_ms) as latest_ms
+         FROM spans WHERE daemon_id IS NOT NULL GROUP BY daemon_id ORDER BY latest_ms DESC`,
+      )
+      .all() as Array<{ daemon_id: string; span_count: number; earliest_ms: number; latest_ms: number }>;
+
+    return rows.map((r) => ({
+      daemonId: r.daemon_id,
+      spanCount: r.span_count,
+      earliestMs: r.earliest_ms,
+      latestMs: r.latest_ms,
+    }));
+  }
+
   markSpansExported(ids: number[]): number {
     if (ids.length === 0) return 0;
     const placeholders = ids.map(() => "?").join(",");
@@ -1211,6 +1364,11 @@ export class StateDb {
 /** Format a JS timestamp as a SQLite-compatible datetime string (`YYYY-MM-DD HH:MM:SS`). */
 function formatSqliteDatetime(ms: number): string {
   return new Date(ms).toISOString().replace("T", " ").slice(0, 19);
+}
+
+/** Escape SQL LIKE wildcards (% and _) with backslash. Use with ESCAPE '\\'. */
+function escapeLike(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/%/g, "\\%").replace(/_/g, "\\_");
 }
 
 /** Parse JSON safely, returning fallback on corrupt/invalid data. */

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -40,6 +40,7 @@ import {
   MOCK_SERVER_NAME,
   OPENCODE_SERVER_NAME,
   PROTOCOL_VERSION,
+  TRACING_SERVER_NAME,
   WORK_ITEMS_SERVER_NAME,
   auditRuntimePermissions,
   consoleLogger,
@@ -73,6 +74,7 @@ import { OpenCodeServer, buildOpenCodeToolCache } from "./opencode-server";
 import { reapOrphanedSessions } from "./orphan-reaper";
 import { QuotaPoller } from "./quota";
 import { ServerPool } from "./server-pool";
+import { TracingServer } from "./tracing-server";
 import { WorkItemsServer } from "./work-items-server";
 
 /**
@@ -372,6 +374,7 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
   quotaPoller.start();
 
   const metricsServer = new MetricsServer(metrics, quotaPoller);
+  const tracingServer = new TracingServer(db);
 
   // Work items server: constructed lazily inside registerPendingVirtualServer
   // to keep migration errors from crashing the daemon (matches _metrics/_mail pattern).
@@ -693,6 +696,23 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
     );
 
     pool.registerPendingVirtualServer(
+      TRACING_SERVER_NAME,
+      (async () => {
+        try {
+          const {
+            client: tracingClient,
+            transport: tracingTransport,
+            tools: tracingTools,
+          } = await tracingServer.start();
+          pool.registerVirtualServer(TRACING_SERVER_NAME, tracingClient, tracingTransport, tracingTools);
+          logger.info("[mcpd] Tracing server started");
+        } catch (err) {
+          logger.error(`[mcpd] Failed to start tracing server: ${err}`);
+        }
+      })(),
+    );
+
+    pool.registerPendingVirtualServer(
       MAIL_SERVER_NAME,
       (async () => {
         try {
@@ -785,6 +805,7 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
           [MOCK_SERVER_NAME, mockServer],
           [ALIAS_SERVER_NAME, aliasServer],
           [METRICS_SERVER_NAME, metricsServer],
+          [TRACING_SERVER_NAME, tracingServer],
           [MAIL_SERVER_NAME, mailServer],
           [WORK_ITEMS_SERVER_NAME, workItemsServer],
         ];

--- a/packages/daemon/src/tracing-server.spec.ts
+++ b/packages/daemon/src/tracing-server.spec.ts
@@ -4,12 +4,6 @@ import { testOptions } from "../../../test/test-options";
 import { StateDb } from "./db/state";
 import { TracingServer, buildTracingToolCache } from "./tracing-server";
 
-describe("TRACING_SERVER_NAME", () => {
-  test("is _tracing", () => {
-    expect(TRACING_SERVER_NAME).toBe("_tracing");
-  });
-});
-
 describe("buildTracingToolCache", () => {
   test("returns all 3 tools", () => {
     const cache = buildTracingToolCache();
@@ -22,7 +16,7 @@ describe("buildTracingToolCache", () => {
   test("each tool has correct server name", () => {
     const cache = buildTracingToolCache();
     for (const tool of cache.values()) {
-      expect(tool.server).toBe("_tracing");
+      expect(tool.server).toBe(TRACING_SERVER_NAME);
     }
   });
 });
@@ -68,6 +62,13 @@ describe("TracingServer", () => {
       events: overrides?.events ?? [],
     };
     stateDb.recordSpan(span, overrides?.daemonId);
+  }
+
+  function parseResult(
+    result: Awaited<ReturnType<typeof import("@modelcontextprotocol/sdk/client/index.js").Client.prototype.callTool>>,
+  ): Record<string, unknown> {
+    const content = result.content as Array<{ type: string; text: string }>;
+    return JSON.parse(content[0].text);
   }
 
   test("start() connects and listTools returns 3 tools", async () => {
@@ -116,11 +117,33 @@ describe("TracingServer", () => {
       server = new TracingServer(db);
       const { client } = await server.start();
 
-      const result = await client.callTool({ name: "query_traces", arguments: {} });
-      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
-
-      expect(data.count).toBe(0);
+      const data = parseResult(await client.callTool({ name: "query_traces", arguments: {} }));
       expect(data.spans).toEqual([]);
+    });
+
+    test("does not include count field", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      insertSpan(db, { spanId: "span1".padEnd(16, "0") });
+
+      server = new TracingServer(db);
+      const { client } = await server.start();
+
+      const data = parseResult(await client.callTool({ name: "query_traces", arguments: {} }));
+      expect(data).not.toHaveProperty("count");
+    });
+
+    test("does not include exportedAt in spans", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      insertSpan(db, { spanId: "span1".padEnd(16, "0") });
+
+      server = new TracingServer(db);
+      const { client } = await server.start();
+
+      const data = parseResult(await client.callTool({ name: "query_traces", arguments: {} }));
+      const spans = data.spans as Array<Record<string, unknown>>;
+      expect(spans[0]).not.toHaveProperty("exportedAt");
     });
 
     test("returns all spans with no filters", async () => {
@@ -132,10 +155,8 @@ describe("TracingServer", () => {
       server = new TracingServer(db);
       const { client } = await server.start();
 
-      const result = await client.callTool({ name: "query_traces", arguments: {} });
-      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
-
-      expect(data.count).toBe(2);
+      const data = parseResult(await client.callTool({ name: "query_traces", arguments: {} }));
+      expect((data.spans as unknown[]).length).toBe(2);
     });
 
     test("filters by daemon_id", async () => {
@@ -147,11 +168,10 @@ describe("TracingServer", () => {
       server = new TracingServer(db);
       const { client } = await server.start();
 
-      const result = await client.callTool({ name: "query_traces", arguments: { daemon_id: "daemon-1" } });
-      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
-
-      expect(data.count).toBe(1);
-      expect(data.spans[0].daemonId).toBe("daemon-1");
+      const data = parseResult(await client.callTool({ name: "query_traces", arguments: { daemon_id: "daemon-1" } }));
+      const spans = data.spans as Array<Record<string, unknown>>;
+      expect(spans.length).toBe(1);
+      expect(spans[0].daemonId).toBe("daemon-1");
     });
 
     test("filters by trace_id", async () => {
@@ -165,11 +185,10 @@ describe("TracingServer", () => {
       server = new TracingServer(db);
       const { client } = await server.start();
 
-      const result = await client.callTool({ name: "query_traces", arguments: { trace_id: traceA } });
-      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
-
-      expect(data.count).toBe(1);
-      expect(data.spans[0].traceId).toBe(traceA);
+      const data = parseResult(await client.callTool({ name: "query_traces", arguments: { trace_id: traceA } }));
+      const spans = data.spans as Array<Record<string, unknown>>;
+      expect(spans.length).toBe(1);
+      expect(spans[0].traceId).toBe(traceA);
     });
 
     test("filters by status", async () => {
@@ -181,11 +200,10 @@ describe("TracingServer", () => {
       server = new TracingServer(db);
       const { client } = await server.start();
 
-      const result = await client.callTool({ name: "query_traces", arguments: { status: "ERROR" } });
-      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
-
-      expect(data.count).toBe(1);
-      expect(data.spans[0].status).toBe("ERROR");
+      const data = parseResult(await client.callTool({ name: "query_traces", arguments: { status: "ERROR" } }));
+      const spans = data.spans as Array<Record<string, unknown>>;
+      expect(spans.length).toBe(1);
+      expect(spans[0].status).toBe("ERROR");
     });
 
     test("filters by time range", async () => {
@@ -198,14 +216,12 @@ describe("TracingServer", () => {
       server = new TracingServer(db);
       const { client } = await server.start();
 
-      const result = await client.callTool({
-        name: "query_traces",
-        arguments: { since_ms: 1500, until_ms: 2500 },
-      });
-      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
-
-      expect(data.count).toBe(1);
-      expect(data.spans[0].startTimeMs).toBe(2000);
+      const data = parseResult(
+        await client.callTool({ name: "query_traces", arguments: { since_ms: 1500, until_ms: 2500 } }),
+      );
+      const spans = data.spans as Array<Record<string, unknown>>;
+      expect(spans.length).toBe(1);
+      expect(spans[0].startTimeMs).toBe(2000);
     });
 
     test("respects limit", async () => {
@@ -218,22 +234,22 @@ describe("TracingServer", () => {
       server = new TracingServer(db);
       const { client } = await server.start();
 
-      const result = await client.callTool({ name: "query_traces", arguments: { limit: 2 } });
-      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
-
-      expect(data.count).toBe(2);
+      const data = parseResult(await client.callTool({ name: "query_traces", arguments: { limit: 2 } }));
+      expect((data.spans as unknown[]).length).toBe(2);
     });
 
-    test("clamps limit to 1000", async () => {
+    test("clamps limit to valid range", async () => {
       using opts = testOptions();
       db = new StateDb(opts.DB_PATH);
       server = new TracingServer(db);
       const { client } = await server.start();
 
-      // Should not error with oversized limit
-      const result = await client.callTool({ name: "query_traces", arguments: { limit: 9999 } });
-      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
-      expect(data.count).toBe(0);
+      // Should not error with oversized or zero limit
+      const over = parseResult(await client.callTool({ name: "query_traces", arguments: { limit: 9999 } }));
+      expect(over.spans).toEqual([]);
+
+      const zero = parseResult(await client.callTool({ name: "query_traces", arguments: { limit: 0 } }));
+      expect(zero.spans).toEqual([]);
     });
 
     test("filters by server name substring", async () => {
@@ -245,11 +261,88 @@ describe("TracingServer", () => {
       server = new TracingServer(db);
       const { client } = await server.start();
 
-      const result = await client.callTool({ name: "query_traces", arguments: { server: "atlassian" } });
-      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+      const data = parseResult(await client.callTool({ name: "query_traces", arguments: { server: "atlassian" } }));
+      const spans = data.spans as Array<Record<string, unknown>>;
+      expect(spans.length).toBe(1);
+      expect(spans[0].name).toContain("atlassian");
+    });
 
-      expect(data.count).toBe(1);
-      expect(data.spans[0].name).toContain("atlassian");
+    test("tool filter matches end of span name (after last colon)", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      insertSpan(db, { spanId: "s1".padEnd(16, "0"), name: "tool_call:atlassian:search" });
+      insertSpan(db, { spanId: "s2".padEnd(16, "0"), name: "tool_call:github:search" });
+      insertSpan(db, { spanId: "s3".padEnd(16, "0"), name: "tool_call:github:list_prs" });
+
+      server = new TracingServer(db);
+      const { client } = await server.start();
+
+      const data = parseResult(await client.callTool({ name: "query_traces", arguments: { tool: "search" } }));
+      const spans = data.spans as Array<Record<string, unknown>>;
+      expect(spans.length).toBe(2);
+    });
+
+    test("combined server and tool filter", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      insertSpan(db, { spanId: "s1".padEnd(16, "0"), name: "tool_call:atlassian:search" });
+      insertSpan(db, { spanId: "s2".padEnd(16, "0"), name: "tool_call:github:search" });
+
+      server = new TracingServer(db);
+      const { client } = await server.start();
+
+      const data = parseResult(
+        await client.callTool({ name: "query_traces", arguments: { server: "atlassian", tool: "search" } }),
+      );
+      const spans = data.spans as Array<Record<string, unknown>>;
+      expect(spans.length).toBe(1);
+      expect(spans[0].name).toBe("tool_call:atlassian:search");
+    });
+
+    test("LIKE wildcards in filter values are escaped", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      insertSpan(db, { spanId: "s1".padEnd(16, "0"), name: "tool_call:a%b:search" });
+      insertSpan(db, { spanId: "s2".padEnd(16, "0"), name: "tool_call:axb:search" });
+
+      server = new TracingServer(db);
+      const { client } = await server.start();
+
+      // "a%b" should match only the literal percent, not wildcard
+      const data = parseResult(await client.callTool({ name: "query_traces", arguments: { server: "a%b" } }));
+      const spans = data.spans as Array<Record<string, unknown>>;
+      expect(spans.length).toBe(1);
+      expect(spans[0].name).toBe("tool_call:a%b:search");
+    });
+
+    test("after_id enables cursor pagination", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      for (let i = 0; i < 5; i++) {
+        insertSpan(db, { spanId: `s${i}`.padEnd(16, "0"), startTimeMs: 1000 + i });
+      }
+
+      server = new TracingServer(db);
+      const { client } = await server.start();
+
+      // Get first page
+      const page1 = parseResult(await client.callTool({ name: "query_traces", arguments: { limit: 2 } }));
+      const page1Spans = page1.spans as Array<Record<string, unknown>>;
+      expect(page1Spans.length).toBe(2);
+
+      // Get second page using last id from first page
+      const lastId = page1Spans[page1Spans.length - 1].id as number;
+      const page2 = parseResult(
+        await client.callTool({ name: "query_traces", arguments: { limit: 2, after_id: lastId } }),
+      );
+      const page2Spans = page2.spans as Array<Record<string, unknown>>;
+      expect(page2Spans.length).toBe(2);
+
+      // Pages should not overlap
+      const page1Ids = new Set(page1Spans.map((s) => s.id));
+      for (const s of page2Spans) {
+        expect(page1Ids.has(s.id as number)).toBe(false);
+      }
     });
   });
 
@@ -260,11 +353,9 @@ describe("TracingServer", () => {
       server = new TracingServer(db);
       const { client } = await server.start();
 
-      const result = await client.callTool({ name: "list_daemons", arguments: {} });
-      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
-
-      expect(data.count).toBe(0);
+      const data = parseResult(await client.callTool({ name: "list_daemons", arguments: {} }));
       expect(data.daemons).toEqual([]);
+      expect(data).not.toHaveProperty("count");
     });
 
     test("groups spans by daemon_id", async () => {
@@ -277,14 +368,14 @@ describe("TracingServer", () => {
       server = new TracingServer(db);
       const { client } = await server.start();
 
-      const result = await client.callTool({ name: "list_daemons", arguments: {} });
-      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
-
-      expect(data.count).toBe(2);
-      const d1 = data.daemons.find((d: Record<string, unknown>) => d.daemon_id === "daemon-1");
-      expect(d1.span_count).toBe(2);
-      expect(d1.earliest_ms).toBe(1000);
-      expect(d1.latest_ms).toBe(2000);
+      const data = parseResult(await client.callTool({ name: "list_daemons", arguments: {} }));
+      const daemons = data.daemons as Array<Record<string, unknown>>;
+      expect(daemons.length).toBe(2);
+      const d1 = daemons.find((d) => d.daemonId === "daemon-1");
+      expect(d1).toBeDefined();
+      expect(d1?.spanCount).toBe(2);
+      expect(d1?.earliestMs).toBe(1000);
+      expect(d1?.latestMs).toBe(2000);
     });
 
     test("excludes spans with null daemon_id", async () => {
@@ -296,10 +387,8 @@ describe("TracingServer", () => {
       server = new TracingServer(db);
       const { client } = await server.start();
 
-      const result = await client.callTool({ name: "list_daemons", arguments: {} });
-      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
-
-      expect(data.count).toBe(1);
+      const data = parseResult(await client.callTool({ name: "list_daemons", arguments: {} }));
+      expect((data.daemons as unknown[]).length).toBe(1);
     });
   });
 
@@ -320,11 +409,10 @@ describe("TracingServer", () => {
       server = new TracingServer(db);
       const { client } = await server.start();
 
-      const result = await client.callTool({ name: "get_trace", arguments: { trace_id: "x".repeat(32) } });
-      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
-
-      expect(data.count).toBe(0);
+      const data = parseResult(await client.callTool({ name: "get_trace", arguments: { trace_id: "x".repeat(32) } }));
+      expect((data.spans as unknown[]).length).toBe(0);
       expect(data.trace_id).toBe("x".repeat(32));
+      expect(data).not.toHaveProperty("count");
     });
 
     test("returns all spans for a trace ordered by start time ASC", async () => {
@@ -340,18 +428,17 @@ describe("TracingServer", () => {
       server = new TracingServer(db);
       const { client } = await server.start();
 
-      const result = await client.callTool({ name: "get_trace", arguments: { trace_id: traceId } });
-      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
-
-      expect(data.count).toBe(3);
+      const data = parseResult(await client.callTool({ name: "get_trace", arguments: { trace_id: traceId } }));
+      const spans = data.spans as Array<Record<string, unknown>>;
+      expect(spans.length).toBe(3);
       expect(data.trace_id).toBe(traceId);
       // Ordered by start time ASC
-      expect(data.spans[0].name).toBe("root");
-      expect(data.spans[1].name).toBe("child_a");
-      expect(data.spans[2].name).toBe("child_b");
+      expect(spans[0].name).toBe("root");
+      expect(spans[1].name).toBe("child_a");
+      expect(spans[2].name).toBe("child_b");
     });
 
-    test("includes attributes and events", async () => {
+    test("includes attributes and events but not exportedAt", async () => {
       using opts = testOptions();
       db = new StateDb(opts.DB_PATH);
       const traceId = "c".repeat(32);
@@ -365,11 +452,11 @@ describe("TracingServer", () => {
       server = new TracingServer(db);
       const { client } = await server.start();
 
-      const result = await client.callTool({ name: "get_trace", arguments: { trace_id: traceId } });
-      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
-
-      expect(data.spans[0].attributes["tool.name"]).toBe("search");
-      expect(data.spans[0].events[0].name).toBe("error");
+      const data = parseResult(await client.callTool({ name: "get_trace", arguments: { trace_id: traceId } }));
+      const spans = data.spans as Array<Record<string, unknown>>;
+      expect((spans[0].attributes as Record<string, string>)["tool.name"]).toBe("search");
+      expect((spans[0].events as Array<Record<string, string>>)[0].name).toBe("error");
+      expect(spans[0]).not.toHaveProperty("exportedAt");
     });
   });
 });

--- a/packages/daemon/src/tracing-server.spec.ts
+++ b/packages/daemon/src/tracing-server.spec.ts
@@ -1,0 +1,375 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { TRACING_SERVER_NAME } from "@mcp-cli/core";
+import { testOptions } from "../../../test/test-options";
+import { StateDb } from "./db/state";
+import { TracingServer, buildTracingToolCache } from "./tracing-server";
+
+describe("TRACING_SERVER_NAME", () => {
+  test("is _tracing", () => {
+    expect(TRACING_SERVER_NAME).toBe("_tracing");
+  });
+});
+
+describe("buildTracingToolCache", () => {
+  test("returns all 3 tools", () => {
+    const cache = buildTracingToolCache();
+    expect(cache.size).toBe(3);
+    expect(cache.has("query_traces")).toBe(true);
+    expect(cache.has("list_daemons")).toBe(true);
+    expect(cache.has("get_trace")).toBe(true);
+  });
+
+  test("each tool has correct server name", () => {
+    const cache = buildTracingToolCache();
+    for (const tool of cache.values()) {
+      expect(tool.server).toBe("_tracing");
+    }
+  });
+});
+
+describe("TracingServer", () => {
+  let server: TracingServer | undefined;
+  let db: StateDb | undefined;
+
+  afterEach(async () => {
+    await server?.stop();
+    db?.close();
+    server = undefined;
+    db = undefined;
+  });
+
+  function insertSpan(
+    stateDb: StateDb,
+    overrides?: Partial<{
+      traceId: string;
+      spanId: string;
+      parentSpanId: string;
+      name: string;
+      startTimeMs: number;
+      endTimeMs: number;
+      durationMs: number;
+      status: string;
+      daemonId: string;
+      attributes: Record<string, string | number | boolean>;
+      events: Array<{ name: string; timeMs: number; attributes?: Record<string, string | number | boolean> }>;
+    }>,
+  ): void {
+    const span = {
+      traceId: overrides?.traceId ?? "a".repeat(32),
+      spanId: overrides?.spanId ?? "b".repeat(16),
+      parentSpanId: overrides?.parentSpanId,
+      traceFlags: "01",
+      name: overrides?.name ?? "test_span",
+      startTimeMs: overrides?.startTimeMs ?? 1000,
+      endTimeMs: overrides?.endTimeMs ?? 2000,
+      durationMs: overrides?.durationMs ?? 1000,
+      status: (overrides?.status ?? "OK") as "OK" | "ERROR" | "UNSET",
+      attributes: overrides?.attributes ?? {},
+      events: overrides?.events ?? [],
+    };
+    stateDb.recordSpan(span, overrides?.daemonId);
+  }
+
+  test("start() connects and listTools returns 3 tools", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new TracingServer(db);
+
+    const { client } = await server.start();
+    const { tools } = await client.listTools();
+
+    expect(tools).toHaveLength(3);
+    expect(tools.map((t) => t.name).sort()).toEqual(["get_trace", "list_daemons", "query_traces"]);
+  });
+
+  test("double start throws", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new TracingServer(db);
+    await server.start();
+    await expect(server.start()).rejects.toThrow("TracingServer already started");
+  });
+
+  test("can restart after stop", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new TracingServer(db);
+    await server.start();
+    await server.stop();
+    const { client } = await server.start();
+    expect(client).toBeDefined();
+  });
+
+  test("unknown tool returns error", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new TracingServer(db);
+    const { client } = await server.start();
+    const result = await client.callTool({ name: "nonexistent", arguments: {} });
+    expect(result.isError).toBe(true);
+  });
+
+  describe("query_traces", () => {
+    test("returns empty when no spans", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      server = new TracingServer(db);
+      const { client } = await server.start();
+
+      const result = await client.callTool({ name: "query_traces", arguments: {} });
+      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+
+      expect(data.count).toBe(0);
+      expect(data.spans).toEqual([]);
+    });
+
+    test("returns all spans with no filters", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      insertSpan(db, { spanId: "span1".padEnd(16, "0") });
+      insertSpan(db, { spanId: "span2".padEnd(16, "0") });
+
+      server = new TracingServer(db);
+      const { client } = await server.start();
+
+      const result = await client.callTool({ name: "query_traces", arguments: {} });
+      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+
+      expect(data.count).toBe(2);
+    });
+
+    test("filters by daemon_id", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      insertSpan(db, { spanId: "s1".padEnd(16, "0"), daemonId: "daemon-1" });
+      insertSpan(db, { spanId: "s2".padEnd(16, "0"), daemonId: "daemon-2" });
+
+      server = new TracingServer(db);
+      const { client } = await server.start();
+
+      const result = await client.callTool({ name: "query_traces", arguments: { daemon_id: "daemon-1" } });
+      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+
+      expect(data.count).toBe(1);
+      expect(data.spans[0].daemonId).toBe("daemon-1");
+    });
+
+    test("filters by trace_id", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      const traceA = "a".repeat(32);
+      const traceB = "b".repeat(32);
+      insertSpan(db, { traceId: traceA, spanId: "s1".padEnd(16, "0") });
+      insertSpan(db, { traceId: traceB, spanId: "s2".padEnd(16, "0") });
+
+      server = new TracingServer(db);
+      const { client } = await server.start();
+
+      const result = await client.callTool({ name: "query_traces", arguments: { trace_id: traceA } });
+      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+
+      expect(data.count).toBe(1);
+      expect(data.spans[0].traceId).toBe(traceA);
+    });
+
+    test("filters by status", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      insertSpan(db, { spanId: "s1".padEnd(16, "0"), status: "OK" });
+      insertSpan(db, { spanId: "s2".padEnd(16, "0"), status: "ERROR" });
+
+      server = new TracingServer(db);
+      const { client } = await server.start();
+
+      const result = await client.callTool({ name: "query_traces", arguments: { status: "ERROR" } });
+      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+
+      expect(data.count).toBe(1);
+      expect(data.spans[0].status).toBe("ERROR");
+    });
+
+    test("filters by time range", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      insertSpan(db, { spanId: "s1".padEnd(16, "0"), startTimeMs: 1000 });
+      insertSpan(db, { spanId: "s2".padEnd(16, "0"), startTimeMs: 2000 });
+      insertSpan(db, { spanId: "s3".padEnd(16, "0"), startTimeMs: 3000 });
+
+      server = new TracingServer(db);
+      const { client } = await server.start();
+
+      const result = await client.callTool({
+        name: "query_traces",
+        arguments: { since_ms: 1500, until_ms: 2500 },
+      });
+      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+
+      expect(data.count).toBe(1);
+      expect(data.spans[0].startTimeMs).toBe(2000);
+    });
+
+    test("respects limit", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      for (let i = 0; i < 5; i++) {
+        insertSpan(db, { spanId: `s${i}`.padEnd(16, "0"), startTimeMs: 1000 + i });
+      }
+
+      server = new TracingServer(db);
+      const { client } = await server.start();
+
+      const result = await client.callTool({ name: "query_traces", arguments: { limit: 2 } });
+      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+
+      expect(data.count).toBe(2);
+    });
+
+    test("clamps limit to 1000", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      server = new TracingServer(db);
+      const { client } = await server.start();
+
+      // Should not error with oversized limit
+      const result = await client.callTool({ name: "query_traces", arguments: { limit: 9999 } });
+      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+      expect(data.count).toBe(0);
+    });
+
+    test("filters by server name substring", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      insertSpan(db, { spanId: "s1".padEnd(16, "0"), name: "tool_call:atlassian:search" });
+      insertSpan(db, { spanId: "s2".padEnd(16, "0"), name: "tool_call:github:list_prs" });
+
+      server = new TracingServer(db);
+      const { client } = await server.start();
+
+      const result = await client.callTool({ name: "query_traces", arguments: { server: "atlassian" } });
+      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+
+      expect(data.count).toBe(1);
+      expect(data.spans[0].name).toContain("atlassian");
+    });
+  });
+
+  describe("list_daemons", () => {
+    test("returns empty when no spans", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      server = new TracingServer(db);
+      const { client } = await server.start();
+
+      const result = await client.callTool({ name: "list_daemons", arguments: {} });
+      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+
+      expect(data.count).toBe(0);
+      expect(data.daemons).toEqual([]);
+    });
+
+    test("groups spans by daemon_id", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      insertSpan(db, { spanId: "s1".padEnd(16, "0"), daemonId: "daemon-1", startTimeMs: 1000 });
+      insertSpan(db, { spanId: "s2".padEnd(16, "0"), daemonId: "daemon-1", startTimeMs: 2000 });
+      insertSpan(db, { spanId: "s3".padEnd(16, "0"), daemonId: "daemon-2", startTimeMs: 3000 });
+
+      server = new TracingServer(db);
+      const { client } = await server.start();
+
+      const result = await client.callTool({ name: "list_daemons", arguments: {} });
+      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+
+      expect(data.count).toBe(2);
+      const d1 = data.daemons.find((d: Record<string, unknown>) => d.daemon_id === "daemon-1");
+      expect(d1.span_count).toBe(2);
+      expect(d1.earliest_ms).toBe(1000);
+      expect(d1.latest_ms).toBe(2000);
+    });
+
+    test("excludes spans with null daemon_id", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      insertSpan(db, { spanId: "s1".padEnd(16, "0") }); // no daemonId
+      insertSpan(db, { spanId: "s2".padEnd(16, "0"), daemonId: "daemon-1" });
+
+      server = new TracingServer(db);
+      const { client } = await server.start();
+
+      const result = await client.callTool({ name: "list_daemons", arguments: {} });
+      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+
+      expect(data.count).toBe(1);
+    });
+  });
+
+  describe("get_trace", () => {
+    test("returns error for missing trace_id", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      server = new TracingServer(db);
+      const { client } = await server.start();
+
+      const result = await client.callTool({ name: "get_trace", arguments: {} });
+      expect(result.isError).toBe(true);
+    });
+
+    test("returns empty for nonexistent trace", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      server = new TracingServer(db);
+      const { client } = await server.start();
+
+      const result = await client.callTool({ name: "get_trace", arguments: { trace_id: "x".repeat(32) } });
+      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+
+      expect(data.count).toBe(0);
+      expect(data.trace_id).toBe("x".repeat(32));
+    });
+
+    test("returns all spans for a trace ordered by start time ASC", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      const traceId = "a".repeat(32);
+      insertSpan(db, { traceId, spanId: "s1".padEnd(16, "0"), startTimeMs: 3000, name: "child_b" });
+      insertSpan(db, { traceId, spanId: "s2".padEnd(16, "0"), startTimeMs: 1000, name: "root" });
+      insertSpan(db, { traceId, spanId: "s3".padEnd(16, "0"), startTimeMs: 2000, name: "child_a" });
+      // Different trace — should not appear
+      insertSpan(db, { traceId: "b".repeat(32), spanId: "s4".padEnd(16, "0"), startTimeMs: 1500 });
+
+      server = new TracingServer(db);
+      const { client } = await server.start();
+
+      const result = await client.callTool({ name: "get_trace", arguments: { trace_id: traceId } });
+      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+
+      expect(data.count).toBe(3);
+      expect(data.trace_id).toBe(traceId);
+      // Ordered by start time ASC
+      expect(data.spans[0].name).toBe("root");
+      expect(data.spans[1].name).toBe("child_a");
+      expect(data.spans[2].name).toBe("child_b");
+    });
+
+    test("includes attributes and events", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      const traceId = "c".repeat(32);
+      insertSpan(db, {
+        traceId,
+        spanId: "s1".padEnd(16, "0"),
+        attributes: { "tool.name": "search", "tool.server": "atlassian" },
+        events: [{ name: "error", timeMs: 1500, attributes: { message: "timeout" } }],
+      });
+
+      server = new TracingServer(db);
+      const { client } = await server.start();
+
+      const result = await client.callTool({ name: "get_trace", arguments: { trace_id: traceId } });
+      const data = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+
+      expect(data.spans[0].attributes["tool.name"]).toBe("search");
+      expect(data.spans[0].events[0].name).toBe("error");
+    });
+  });
+});

--- a/packages/daemon/src/tracing-server.ts
+++ b/packages/daemon/src/tracing-server.ts
@@ -2,7 +2,7 @@
  * Virtual MCP server that exposes trace data as MCP tools.
  *
  * Uses an in-process MCP Server with InMemoryTransport (no Workers).
- * Read-only — queries spans and usage_stats tables.
+ * Read-only — queries spans table via StateDb API.
  */
 
 import type { ToolInfo } from "@mcp-cli/core";
@@ -14,19 +14,25 @@ import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import type { StateDb } from "./db/state";
 
+/** Maximum serialized response size in bytes (5 MB). */
+const MAX_RESPONSE_BYTES = 5 * 1024 * 1024;
+
 const TOOLS = [
   {
     name: "query_traces",
     description:
       "Query trace spans with optional filters. Returns matching spans ordered by start time (newest first). " +
-      "Use to search by daemon, trace, server, tool, status, or time range.",
+      "Use to search by daemon, trace, server, tool, status, or time range. Supports cursor-based pagination via after_id.",
     inputSchema: {
       type: "object" as const,
       properties: {
         daemon_id: { type: "string", description: "Filter by daemon instance ID" },
         trace_id: { type: "string", description: "Filter by trace ID" },
-        server: { type: "string", description: "Filter by server name (substring match on span name)" },
-        tool: { type: "string", description: "Filter by tool name (substring match on span name)" },
+        server: { type: "string", description: "Filter spans whose name contains this server name" },
+        tool: {
+          type: "string",
+          description: "Filter spans whose name ends with :toolName (structured span name convention)",
+        },
         status: {
           type: "string",
           enum: ["OK", "ERROR", "UNSET"],
@@ -43,6 +49,11 @@ const TOOLS = [
         limit: {
           type: "number",
           description: "Maximum number of spans to return (default: 100, max: 1000)",
+        },
+        after_id: {
+          type: "number",
+          description:
+            "Cursor for pagination: only return spans with id < this value (use last span's id from previous page)",
         },
       },
     },
@@ -143,76 +154,26 @@ export class TracingServer {
     content: Array<{ type: "text"; text: string }>;
     isError?: boolean;
   } {
-    const conditions: string[] = [];
-    const params: (string | number)[] = [];
+    const spans = this.db.querySpans({
+      daemonId: typeof args?.daemon_id === "string" && args.daemon_id ? args.daemon_id : undefined,
+      traceId: typeof args?.trace_id === "string" && args.trace_id ? args.trace_id : undefined,
+      server: typeof args?.server === "string" && args.server ? args.server : undefined,
+      tool: typeof args?.tool === "string" && args.tool ? args.tool : undefined,
+      status: typeof args?.status === "string" && args.status ? args.status : undefined,
+      sinceMs: typeof args?.since_ms === "number" ? args.since_ms : undefined,
+      untilMs: typeof args?.until_ms === "number" ? args.until_ms : undefined,
+      limit: typeof args?.limit === "number" ? args.limit : undefined,
+      afterId: typeof args?.after_id === "number" ? args.after_id : undefined,
+    });
 
-    if (typeof args?.daemon_id === "string" && args.daemon_id) {
-      conditions.push("daemon_id = ?");
-      params.push(args.daemon_id);
-    }
-    if (typeof args?.trace_id === "string" && args.trace_id) {
-      conditions.push("trace_id = ?");
-      params.push(args.trace_id);
-    }
-    if (typeof args?.server === "string" && args.server) {
-      conditions.push("name LIKE ?");
-      params.push(`%${args.server}%`);
-    }
-    if (typeof args?.tool === "string" && args.tool) {
-      conditions.push("name LIKE ?");
-      params.push(`%${args.tool}%`);
-    }
-    if (typeof args?.status === "string" && args.status) {
-      conditions.push("status = ?");
-      params.push(args.status);
-    }
-    if (typeof args?.since_ms === "number") {
-      conditions.push("start_time_ms >= ?");
-      params.push(args.since_ms);
-    }
-    if (typeof args?.until_ms === "number") {
-      conditions.push("start_time_ms <= ?");
-      params.push(args.until_ms);
-    }
-
-    const rawLimit = typeof args?.limit === "number" ? args.limit : 100;
-    const limit = Math.min(Math.max(1, rawLimit), 1000);
-    params.push(limit);
-
-    const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
-    const sql = `SELECT id, trace_id, span_id, parent_span_id, trace_flags, name,
-      start_time_ms, end_time_ms, duration_ms, status, attributes_json,
-      events_json, daemon_id, exported_at
-     FROM spans ${where} ORDER BY start_time_ms DESC LIMIT ?`;
-
-    const rows = this.db.database.prepare(sql).all(...params) as SpanRawRow[];
-    const spans = rows.map(mapSpanRow);
-
-    return {
-      content: [{ type: "text", text: JSON.stringify({ count: spans.length, spans }, null, 2) }],
-    };
+    return sizeGuardedResponse({ spans });
   }
 
   private handleListDaemons(): {
     content: Array<{ type: "text"; text: string }>;
   } {
-    const rows = this.db.database
-      .prepare(
-        `SELECT
-          daemon_id,
-          COUNT(*) as span_count,
-          MIN(start_time_ms) as earliest_ms,
-          MAX(start_time_ms) as latest_ms
-        FROM spans
-        WHERE daemon_id IS NOT NULL
-        GROUP BY daemon_id
-        ORDER BY latest_ms DESC`,
-      )
-      .all() as Array<{ daemon_id: string; span_count: number; earliest_ms: number; latest_ms: number }>;
-
-    return {
-      content: [{ type: "text", text: JSON.stringify({ count: rows.length, daemons: rows }, null, 2) }],
-    };
+    const daemons = this.db.listDaemons();
+    return { content: [{ type: "text", text: JSON.stringify({ daemons }, null, 2) }] };
   }
 
   private handleGetTrace(args: Record<string, unknown> | undefined): {
@@ -227,21 +188,35 @@ export class TracingServer {
       };
     }
 
-    const rows = this.db.database
-      .prepare(
-        `SELECT id, trace_id, span_id, parent_span_id, trace_flags, name,
-          start_time_ms, end_time_ms, duration_ms, status, attributes_json,
-          events_json, daemon_id, exported_at
-        FROM spans WHERE trace_id = ? ORDER BY start_time_ms ASC`,
-      )
-      .all(traceId) as SpanRawRow[];
-
-    const spans = rows.map(mapSpanRow);
-
-    return {
-      content: [{ type: "text", text: JSON.stringify({ trace_id: traceId, count: spans.length, spans }, null, 2) }],
-    };
+    const spans = this.db.getTraceSpans(traceId);
+    return sizeGuardedResponse({ trace_id: traceId, spans });
   }
+}
+
+/** Serialize response JSON with a size guard. If over MAX_RESPONSE_BYTES, truncate spans. */
+function sizeGuardedResponse(data: { spans: unknown[]; [key: string]: unknown }): {
+  content: Array<{ type: "text"; text: string }>;
+} {
+  const json = JSON.stringify(data, null, 2);
+  if (json.length <= MAX_RESPONSE_BYTES) {
+    return { content: [{ type: "text", text: json }] };
+  }
+
+  // Binary search for safe span count
+  let lo = 0;
+  let hi = data.spans.length;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >>> 1;
+    const trial = JSON.stringify({ ...data, spans: data.spans.slice(0, mid), truncated: true }, null, 2);
+    if (trial.length <= MAX_RESPONSE_BYTES) {
+      lo = mid;
+    } else {
+      hi = mid - 1;
+    }
+  }
+
+  const truncated = { ...data, spans: data.spans.slice(0, lo), truncated: true };
+  return { content: [{ type: "text", text: JSON.stringify(truncated, null, 2) }] };
 }
 
 /** Pre-build tool cache for pool registration. */
@@ -256,50 +231,4 @@ export function buildTracingToolCache(): Map<string, ToolInfo> {
     });
   }
   return cache;
-}
-
-// -- Internal helpers --
-
-interface SpanRawRow {
-  id: number;
-  trace_id: string;
-  span_id: string;
-  parent_span_id: string | null;
-  trace_flags: string;
-  name: string;
-  start_time_ms: number;
-  end_time_ms: number;
-  duration_ms: number;
-  status: string;
-  attributes_json: string | null;
-  events_json: string | null;
-  daemon_id: string | null;
-  exported_at: number | null;
-}
-
-function mapSpanRow(row: SpanRawRow) {
-  return {
-    id: row.id,
-    traceId: row.trace_id,
-    spanId: row.span_id,
-    parentSpanId: row.parent_span_id,
-    traceFlags: row.trace_flags,
-    name: row.name,
-    startTimeMs: row.start_time_ms,
-    endTimeMs: row.end_time_ms,
-    durationMs: row.duration_ms,
-    status: row.status,
-    attributes: row.attributes_json ? safeJsonParse(row.attributes_json, {}) : {},
-    events: row.events_json ? safeJsonParse(row.events_json, []) : [],
-    daemonId: row.daemon_id,
-    exportedAt: row.exported_at,
-  };
-}
-
-function safeJsonParse<T>(json: string, fallback: T): T {
-  try {
-    return JSON.parse(json) as T;
-  } catch {
-    return fallback;
-  }
 }

--- a/packages/daemon/src/tracing-server.ts
+++ b/packages/daemon/src/tracing-server.ts
@@ -1,0 +1,305 @@
+/**
+ * Virtual MCP server that exposes trace data as MCP tools.
+ *
+ * Uses an in-process MCP Server with InMemoryTransport (no Workers).
+ * Read-only — queries spans and usage_stats tables.
+ */
+
+import type { ToolInfo } from "@mcp-cli/core";
+import { TRACING_SERVER_NAME } from "@mcp-cli/core";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import type { StateDb } from "./db/state";
+
+const TOOLS = [
+  {
+    name: "query_traces",
+    description:
+      "Query trace spans with optional filters. Returns matching spans ordered by start time (newest first). " +
+      "Use to search by daemon, trace, server, tool, status, or time range.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        daemon_id: { type: "string", description: "Filter by daemon instance ID" },
+        trace_id: { type: "string", description: "Filter by trace ID" },
+        server: { type: "string", description: "Filter by server name (substring match on span name)" },
+        tool: { type: "string", description: "Filter by tool name (substring match on span name)" },
+        status: {
+          type: "string",
+          enum: ["OK", "ERROR", "UNSET"],
+          description: "Filter by span status",
+        },
+        since_ms: {
+          type: "number",
+          description: "Only return spans with start_time_ms >= this value (epoch milliseconds)",
+        },
+        until_ms: {
+          type: "number",
+          description: "Only return spans with start_time_ms <= this value (epoch milliseconds)",
+        },
+        limit: {
+          type: "number",
+          description: "Maximum number of spans to return (default: 100, max: 1000)",
+        },
+      },
+    },
+  },
+  {
+    name: "list_daemons",
+    description:
+      "List distinct daemon instances that have recorded spans. Returns daemon_id, earliest and latest span times, and span count.",
+    inputSchema: { type: "object" as const, properties: {} },
+  },
+  {
+    name: "get_trace",
+    description:
+      "Get all spans for a specific trace ID, ordered by start time. Shows the full call tree for a single trace.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        trace_id: { type: "string", description: "The trace ID to look up" },
+      },
+      required: ["trace_id"],
+    },
+  },
+] as const;
+
+export class TracingServer {
+  private server: Server | null = null;
+  private client: Client | null = null;
+  private serverTransport: Transport | null = null;
+  private clientTransport: Transport | null = null;
+
+  constructor(private db: StateDb) {}
+
+  async start(): Promise<{ client: Client; transport: Transport; tools: Map<string, ToolInfo> }> {
+    if (this.server) {
+      throw new Error("TracingServer already started");
+    }
+
+    const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+    this.serverTransport = serverTransport;
+    this.clientTransport = clientTransport;
+
+    this.server = new Server({ name: TRACING_SERVER_NAME, version: "0.1.0" }, { capabilities: { tools: {} } });
+
+    this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: TOOLS.map((t) => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: t.inputSchema,
+      })),
+    }));
+
+    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+      const { name, arguments: args } = request.params;
+
+      switch (name) {
+        case "query_traces":
+          return this.handleQueryTraces(args);
+
+        case "list_daemons":
+          return this.handleListDaemons();
+
+        case "get_trace":
+          return this.handleGetTrace(args);
+
+        default:
+          return {
+            content: [{ type: "text" as const, text: `Unknown tool: ${name}` }],
+            isError: true,
+          };
+      }
+    });
+
+    await this.server.connect(serverTransport);
+    this.client = new Client({ name: `mcp-cli/${TRACING_SERVER_NAME}`, version: "0.1.0" });
+    await this.client.connect(clientTransport);
+
+    return { client: this.client, transport: this.clientTransport, tools: buildTracingToolCache() };
+  }
+
+  async stop(): Promise<void> {
+    try {
+      await this.client?.close();
+    } catch {
+      // ignore close errors
+    }
+    try {
+      await this.server?.close();
+    } catch {
+      // ignore close errors
+    }
+    this.server = null;
+    this.client = null;
+    this.serverTransport = null;
+    this.clientTransport = null;
+  }
+
+  private handleQueryTraces(args: Record<string, unknown> | undefined): {
+    content: Array<{ type: "text"; text: string }>;
+    isError?: boolean;
+  } {
+    const conditions: string[] = [];
+    const params: (string | number)[] = [];
+
+    if (typeof args?.daemon_id === "string" && args.daemon_id) {
+      conditions.push("daemon_id = ?");
+      params.push(args.daemon_id);
+    }
+    if (typeof args?.trace_id === "string" && args.trace_id) {
+      conditions.push("trace_id = ?");
+      params.push(args.trace_id);
+    }
+    if (typeof args?.server === "string" && args.server) {
+      conditions.push("name LIKE ?");
+      params.push(`%${args.server}%`);
+    }
+    if (typeof args?.tool === "string" && args.tool) {
+      conditions.push("name LIKE ?");
+      params.push(`%${args.tool}%`);
+    }
+    if (typeof args?.status === "string" && args.status) {
+      conditions.push("status = ?");
+      params.push(args.status);
+    }
+    if (typeof args?.since_ms === "number") {
+      conditions.push("start_time_ms >= ?");
+      params.push(args.since_ms);
+    }
+    if (typeof args?.until_ms === "number") {
+      conditions.push("start_time_ms <= ?");
+      params.push(args.until_ms);
+    }
+
+    const rawLimit = typeof args?.limit === "number" ? args.limit : 100;
+    const limit = Math.min(Math.max(1, rawLimit), 1000);
+    params.push(limit);
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+    const sql = `SELECT id, trace_id, span_id, parent_span_id, trace_flags, name,
+      start_time_ms, end_time_ms, duration_ms, status, attributes_json,
+      events_json, daemon_id, exported_at
+     FROM spans ${where} ORDER BY start_time_ms DESC LIMIT ?`;
+
+    const rows = this.db.database.prepare(sql).all(...params) as SpanRawRow[];
+    const spans = rows.map(mapSpanRow);
+
+    return {
+      content: [{ type: "text", text: JSON.stringify({ count: spans.length, spans }, null, 2) }],
+    };
+  }
+
+  private handleListDaemons(): {
+    content: Array<{ type: "text"; text: string }>;
+  } {
+    const rows = this.db.database
+      .prepare(
+        `SELECT
+          daemon_id,
+          COUNT(*) as span_count,
+          MIN(start_time_ms) as earliest_ms,
+          MAX(start_time_ms) as latest_ms
+        FROM spans
+        WHERE daemon_id IS NOT NULL
+        GROUP BY daemon_id
+        ORDER BY latest_ms DESC`,
+      )
+      .all() as Array<{ daemon_id: string; span_count: number; earliest_ms: number; latest_ms: number }>;
+
+    return {
+      content: [{ type: "text", text: JSON.stringify({ count: rows.length, daemons: rows }, null, 2) }],
+    };
+  }
+
+  private handleGetTrace(args: Record<string, unknown> | undefined): {
+    content: Array<{ type: "text"; text: string }>;
+    isError?: boolean;
+  } {
+    const traceId = args?.trace_id;
+    if (typeof traceId !== "string" || !traceId) {
+      return {
+        content: [{ type: "text", text: 'Missing required parameter "trace_id"' }],
+        isError: true,
+      };
+    }
+
+    const rows = this.db.database
+      .prepare(
+        `SELECT id, trace_id, span_id, parent_span_id, trace_flags, name,
+          start_time_ms, end_time_ms, duration_ms, status, attributes_json,
+          events_json, daemon_id, exported_at
+        FROM spans WHERE trace_id = ? ORDER BY start_time_ms ASC`,
+      )
+      .all(traceId) as SpanRawRow[];
+
+    const spans = rows.map(mapSpanRow);
+
+    return {
+      content: [{ type: "text", text: JSON.stringify({ trace_id: traceId, count: spans.length, spans }, null, 2) }],
+    };
+  }
+}
+
+/** Pre-build tool cache for pool registration. */
+export function buildTracingToolCache(): Map<string, ToolInfo> {
+  const cache = new Map<string, ToolInfo>();
+  for (const t of TOOLS) {
+    cache.set(t.name, {
+      server: TRACING_SERVER_NAME,
+      name: t.name,
+      description: t.description,
+      inputSchema: t.inputSchema as Record<string, unknown>,
+    });
+  }
+  return cache;
+}
+
+// -- Internal helpers --
+
+interface SpanRawRow {
+  id: number;
+  trace_id: string;
+  span_id: string;
+  parent_span_id: string | null;
+  trace_flags: string;
+  name: string;
+  start_time_ms: number;
+  end_time_ms: number;
+  duration_ms: number;
+  status: string;
+  attributes_json: string | null;
+  events_json: string | null;
+  daemon_id: string | null;
+  exported_at: number | null;
+}
+
+function mapSpanRow(row: SpanRawRow) {
+  return {
+    id: row.id,
+    traceId: row.trace_id,
+    spanId: row.span_id,
+    parentSpanId: row.parent_span_id,
+    traceFlags: row.trace_flags,
+    name: row.name,
+    startTimeMs: row.start_time_ms,
+    endTimeMs: row.end_time_ms,
+    durationMs: row.duration_ms,
+    status: row.status,
+    attributes: row.attributes_json ? safeJsonParse(row.attributes_json, {}) : {},
+    events: row.events_json ? safeJsonParse(row.events_json, []) : [],
+    daemonId: row.daemon_id,
+    exportedAt: row.exported_at,
+  };
+}
+
+function safeJsonParse<T>(json: string, fallback: T): T {
+  try {
+    return JSON.parse(json) as T;
+  } catch {
+    return fallback;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a virtual `_tracing` MCP server registered alongside `_metrics`, `_mail`, etc.
- Exposes three read-only tools: `query_traces` (filtered span search by daemon, trace, server, tool, status, time range), `list_daemons` (distinct daemon instances with span counts), and `get_trace` (full span tree for a trace ID)
- Follows the same in-process `InMemoryTransport` pattern as `MetricsServer` — no workers needed since it just queries SQLite

## Test plan
- [x] 23 new tests in `tracing-server.spec.ts` covering all three tools, filtering, pagination, edge cases
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] Full test suite (4396 tests) passes with 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)