### PR TITLE
feat(clone): --depth flag for shallow clone of large Confluence spaces (fixes #1178)

### DIFF
--- a/packages/clone/src/engine/cache.ts
+++ b/packages/clone/src/engine/cache.ts
@@ -22,6 +22,7 @@ export interface CachedEntry {
   lastModified: string;
   fetchedAt: string;
   contentHash: string | null;
+  isStub: number;
 }
 
 const SCHEMA = `
@@ -37,6 +38,7 @@ CREATE TABLE IF NOT EXISTS entries (
   last_modified TEXT NOT NULL,
   fetched_at  TEXT NOT NULL,
   content_hash TEXT,
+  is_stub     INTEGER NOT NULL DEFAULT 0,
   PRIMARY KEY (provider, cloud_id, id)
 );
 
@@ -61,6 +63,12 @@ export class CloneCache {
     this.db = new Database(dbPath);
     this.db.exec("PRAGMA journal_mode=WAL;");
     this.db.exec(SCHEMA);
+    // Migrate: add is_stub column for databases created before --depth support
+    try {
+      this.db.exec("ALTER TABLE entries ADD COLUMN is_stub INTEGER NOT NULL DEFAULT 0");
+    } catch {
+      // Column already exists — expected for new databases
+    }
   }
 
   /** Upsert an entry after fetch. */
@@ -70,12 +78,13 @@ export class CloneCache {
     entry: RemoteEntry,
     localPath: string,
     contentHash: string | null,
+    isStub = false,
   ): void {
     this.db
       .query(
         `INSERT OR REPLACE INTO entries
-				(id, provider, scope_key, cloud_id, title, parent_id, local_path, version, last_modified, fetched_at, content_hash)
-				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				(id, provider, scope_key, cloud_id, title, parent_id, local_path, version, last_modified, fetched_at, content_hash, is_stub)
+				VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         entry.id,
@@ -89,6 +98,7 @@ export class CloneCache {
         entry.lastModified,
         new Date().toISOString(),
         contentHash,
+        isStub ? 1 : 0,
       );
   }
 
@@ -98,7 +108,8 @@ export class CloneCache {
       .query(
         `SELECT id, provider, scope_key as scopeKey, cloud_id as cloudId, title,
 				parent_id as parentId, local_path as localPath, version,
-				last_modified as lastModified, fetched_at as fetchedAt, content_hash as contentHash
+				last_modified as lastModified, fetched_at as fetchedAt, content_hash as contentHash,
+				is_stub as isStub
 				FROM entries WHERE local_path = ?`,
       )
       .get(localPath) as CachedEntry | null;
@@ -111,7 +122,8 @@ export class CloneCache {
       .query(
         `SELECT id, provider, scope_key as scopeKey, cloud_id as cloudId, title,
 				parent_id as parentId, local_path as localPath, version,
-				last_modified as lastModified, fetched_at as fetchedAt, content_hash as contentHash
+				last_modified as lastModified, fetched_at as fetchedAt, content_hash as contentHash,
+				is_stub as isStub
 				FROM entries WHERE provider = ? AND cloud_id = ? AND id = ?`,
       )
       .get(provider, cloudId, id) as CachedEntry | null;
@@ -124,7 +136,8 @@ export class CloneCache {
       .query(
         `SELECT id, provider, scope_key as scopeKey, cloud_id as cloudId, title,
 				parent_id as parentId, local_path as localPath, version,
-				last_modified as lastModified, fetched_at as fetchedAt, content_hash as contentHash
+				last_modified as lastModified, fetched_at as fetchedAt, content_hash as contentHash,
+				is_stub as isStub
 				FROM entries WHERE provider = ? AND scope_key = ?`,
       )
       .all(provider, scopeKey) as CachedEntry[];
@@ -181,6 +194,20 @@ export class CloneCache {
       provider: string;
     } | null;
     return row?.provider ?? null;
+  }
+
+  /** Get the clone depth stored in scope_meta (0 = unlimited). */
+  getCloneDepth(provider: string, scopeKey: string): number {
+    const scope = this.loadScopeMeta(provider, scopeKey);
+    return (scope?.resolved?.cloneDepth as number) ?? 0;
+  }
+
+  /** Count stub entries for a scope. */
+  countStubs(provider: string, scopeKey: string): number {
+    const row = this.db
+      .query("SELECT COUNT(*) as count FROM entries WHERE provider = ? AND scope_key = ? AND is_stub = 1")
+      .get(provider, scopeKey) as { count: number } | null;
+    return row?.count ?? 0;
   }
 
   /** Remove an entry. */

--- a/packages/clone/src/engine/cache.ts
+++ b/packages/clone/src/engine/cache.ts
@@ -22,7 +22,7 @@ export interface CachedEntry {
   lastModified: string;
   fetchedAt: string;
   contentHash: string | null;
-  isStub: number;
+  isStub: boolean;
 }
 
 const SCHEMA = `
@@ -55,6 +55,16 @@ CREATE TABLE IF NOT EXISTS scope_meta (
 );
 `;
 
+/** Normalize SQLite INTEGER to boolean for isStub. */
+function normalizeEntry(row: Record<string, unknown> | null): CachedEntry | null {
+  if (!row) return null;
+  return { ...row, isStub: !!(row.isStub as number) } as CachedEntry;
+}
+
+function normalizeEntries(rows: Record<string, unknown>[]): CachedEntry[] {
+  return rows.map((r) => ({ ...r, isStub: !!(r.isStub as number) }) as CachedEntry);
+}
+
 export class CloneCache {
   private db: Database;
 
@@ -63,11 +73,13 @@ export class CloneCache {
     this.db = new Database(dbPath);
     this.db.exec("PRAGMA journal_mode=WAL;");
     this.db.exec(SCHEMA);
-    // Migrate: add is_stub column for databases created before --depth support
+    // Migrate: add is_stub column for databases created before --depth support.
+    // New databases already have it from CREATE TABLE; this only fires for pre-existing DBs.
     try {
       this.db.exec("ALTER TABLE entries ADD COLUMN is_stub INTEGER NOT NULL DEFAULT 0");
-    } catch {
-      // Column already exists — expected for new databases
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "";
+      if (!msg.includes("duplicate column")) throw err;
     }
   }
 
@@ -112,8 +124,8 @@ export class CloneCache {
 				is_stub as isStub
 				FROM entries WHERE local_path = ?`,
       )
-      .get(localPath) as CachedEntry | null;
-    return row;
+      .get(localPath) as Record<string, unknown> | null;
+    return normalizeEntry(row);
   }
 
   /** Get a cached entry by remote ID. */
@@ -126,13 +138,13 @@ export class CloneCache {
 				is_stub as isStub
 				FROM entries WHERE provider = ? AND cloud_id = ? AND id = ?`,
       )
-      .get(provider, cloudId, id) as CachedEntry | null;
-    return row;
+      .get(provider, cloudId, id) as Record<string, unknown> | null;
+    return normalizeEntry(row);
   }
 
   /** Get all entries for a scope. */
   listScope(provider: string, scopeKey: string): CachedEntry[] {
-    return this.db
+    const rows = this.db
       .query(
         `SELECT id, provider, scope_key as scopeKey, cloud_id as cloudId, title,
 				parent_id as parentId, local_path as localPath, version,
@@ -140,7 +152,8 @@ export class CloneCache {
 				is_stub as isStub
 				FROM entries WHERE provider = ? AND scope_key = ?`,
       )
-      .all(provider, scopeKey) as CachedEntry[];
+      .all(provider, scopeKey) as Record<string, unknown>[];
+    return normalizeEntries(rows);
   }
 
   /** Save resolved scope metadata. */
@@ -199,7 +212,9 @@ export class CloneCache {
   /** Get the clone depth stored in scope_meta (0 = unlimited). */
   getCloneDepth(provider: string, scopeKey: string): number {
     const scope = this.loadScopeMeta(provider, scopeKey);
-    return (scope?.resolved?.cloneDepth as number) ?? 0;
+    const raw = scope?.resolved?.cloneDepth;
+    const depth = typeof raw === "string" ? Number(raw) : typeof raw === "number" ? raw : 0;
+    return Number.isFinite(depth) ? depth : 0;
   }
 
   /** Count stub entries for a scope. */

--- a/packages/clone/src/engine/clone.spec.ts
+++ b/packages/clone/src/engine/clone.spec.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { RemoteEntry, RemoteProvider, ResolvedScope, Scope } from "../providers/provider";
 import { CloneCache } from "./cache";
-import { clone } from "./clone";
+import { clone, computeDepth } from "./clone";
 import { stripFrontmatter } from "./frontmatter";
 
 const TMP = join(tmpdir(), `clone-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -58,6 +58,48 @@ beforeEach(() => {
 
 afterEach(() => {
   rmSync(TMP, { recursive: true, force: true });
+});
+
+describe("computeDepth", () => {
+  function entry(id: string, parentId?: string): RemoteEntry {
+    return { id, title: `Page ${id}`, parentId, version: 1, lastModified: "2026-01-01T00:00:00Z", metadata: {} };
+  }
+
+  test("root page (no parent) has depth 1", () => {
+    const entries = [entry("r1")];
+    const byId = new Map(entries.map((e) => [e.id, e]));
+    expect(computeDepth(entries[0], byId)).toBe(1);
+  });
+
+  test("child of root has depth 2", () => {
+    const entries = [entry("r1"), entry("c1", "r1")];
+    const byId = new Map(entries.map((e) => [e.id, e]));
+    expect(computeDepth(entries[1], byId)).toBe(2);
+  });
+
+  test("grandchild has depth 3", () => {
+    const entries = [entry("r1"), entry("c1", "r1"), entry("gc1", "c1")];
+    const byId = new Map(entries.map((e) => [e.id, e]));
+    expect(computeDepth(entries[2], byId)).toBe(3);
+  });
+
+  test("parent not in entries set counts as root", () => {
+    const entries = [entry("orphan", "missing-parent")];
+    const byId = new Map(entries.map((e) => [e.id, e]));
+    expect(computeDepth(entries[0], byId)).toBe(1);
+  });
+
+  test("cycle does not cause infinite loop", () => {
+    const e1 = entry("a", "b");
+    const e2 = entry("b", "a");
+    const byId = new Map([
+      [e1.id, e1],
+      [e2.id, e2],
+    ]);
+    const depth = computeDepth(e1, byId);
+    expect(depth).toBeGreaterThanOrEqual(1);
+    expect(depth).toBeLessThanOrEqual(3);
+  });
 });
 
 describe("clone", () => {
@@ -233,5 +275,144 @@ describe("clone", () => {
     expect(result.pageCount).toBe(0);
     // Git repo still gets initialized
     expect(existsSync(join(targetDir, ".git"))).toBe(true);
+  });
+});
+
+describe("clone with --depth", () => {
+  const DEPTH_TMP = join(tmpdir(), `clone-depth-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+
+  function entry(id: string, title: string, parentId?: string, content?: string): RemoteEntry {
+    return {
+      id,
+      title,
+      parentId,
+      version: 1,
+      lastModified: "2026-01-01T00:00:00Z",
+      metadata: {},
+      ...(content != null ? { content } : {}),
+    };
+  }
+
+  function makeDepthProvider(entries: RemoteEntry[]): RemoteProvider {
+    return {
+      name: "test",
+      resolveScope: async (s: Scope) => ({
+        key: s.key,
+        cloudId: s.cloudId ?? "cloud-1",
+        resolved: { spaceId: "sp-1", spaceName: "Test Space" },
+      }),
+      list: async function* () {
+        for (const e of entries) yield e;
+      },
+      fetch: async (_s, id) => {
+        const e = entries.find((x) => x.id === id);
+        return { content: e?.content ?? "", entry: e ?? entry(id, id) };
+      },
+      toPath: (e, all) => {
+        // Simple path: parentTitle/childTitle.md
+        const parent = e.parentId ? all.find((x) => x.id === e.parentId) : undefined;
+        const hasChildren = all.some((x) => x.parentId === e.id);
+        const name = e.title.replace(/[^a-zA-Z0-9-_ ]/g, "");
+        if (hasChildren) {
+          return parent ? `${parent.title}/${name}/_index.md` : `${name}/_index.md`;
+        }
+        return parent ? `${parent.title}/${name}.md` : `${name}.md`;
+      },
+      frontmatter: (e, s) => ({ id: e.id, version: e.version, space: s.key }),
+    };
+  }
+
+  beforeEach(() => {
+    mkdirSync(DEPTH_TMP, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(DEPTH_TMP, { recursive: true, force: true });
+  });
+
+  test("depth 1 clones only root pages, stubs the rest", async () => {
+    const entries = [
+      entry("r1", "Root", undefined, "# Root content"),
+      entry("c1", "Child", "r1", "# Child content"),
+      entry("gc1", "Grandchild", "c1", "# Grandchild content"),
+    ];
+
+    const depthTargetDir = join(DEPTH_TMP, "depth1");
+    const result = await clone({
+      targetDir: depthTargetDir,
+      provider: makeDepthProvider(entries),
+      scope: { key: "TEST" },
+      depth: 1,
+      onProgress: () => {},
+    });
+
+    expect(result.pageCount).toBe(1);
+    expect(result.stubCount).toBe(2);
+
+    // Root should have full content
+    const rootFile = readFileSync(join(depthTargetDir, "Root/_index.md"), "utf-8");
+    const { content: rootContent } = stripFrontmatter(rootFile);
+    expect(rootContent).toBe("# Root content");
+
+    // Child should be a stub (has children, so it's _index.md)
+    const childFile = readFileSync(join(depthTargetDir, "Root/Child/_index.md"), "utf-8");
+    const { content: childContent, fields: childFields } = stripFrontmatter(childFile);
+    expect(childContent).toContain("Shallow clone stub");
+    expect(childFields?.stub).toBe(true);
+  });
+
+  test("depth 2 includes root + children, stubs grandchildren", async () => {
+    const entries = [
+      entry("r1", "Root", undefined, "# Root"),
+      entry("c1", "Child", "r1", "# Child"),
+      entry("gc1", "Grandchild", "c1", "# Grandchild"),
+    ];
+
+    const depthTargetDir = join(DEPTH_TMP, "depth2");
+    const result = await clone({
+      targetDir: depthTargetDir,
+      provider: makeDepthProvider(entries),
+      scope: { key: "TEST" },
+      depth: 2,
+      onProgress: () => {},
+    });
+
+    expect(result.pageCount).toBe(2);
+    expect(result.stubCount).toBe(1);
+  });
+
+  test("depth 0 (unlimited) clones everything", async () => {
+    const entries = [
+      entry("r1", "Root", undefined, "# Root"),
+      entry("c1", "Child", "r1", "# Child"),
+      entry("gc1", "Grandchild", "c1", "# Grandchild"),
+    ];
+
+    const depthTargetDir = join(DEPTH_TMP, "depth0");
+    const result = await clone({
+      targetDir: depthTargetDir,
+      provider: makeDepthProvider(entries),
+      scope: { key: "TEST" },
+      depth: 0,
+      onProgress: () => {},
+    });
+
+    expect(result.pageCount).toBe(3);
+    expect(result.stubCount).toBe(0);
+  });
+
+  test("stores depth in scope meta", async () => {
+    const entries = [entry("r1", "Root", undefined, "# Root")];
+    const depthTargetDir = join(DEPTH_TMP, "meta");
+
+    const result = await clone({
+      targetDir: depthTargetDir,
+      provider: makeDepthProvider(entries),
+      scope: { key: "TEST" },
+      depth: 2,
+      onProgress: () => {},
+    });
+
+    expect(result.scope.resolved.cloneDepth).toBe(2);
   });
 });

--- a/packages/clone/src/engine/clone.ts
+++ b/packages/clone/src/engine/clone.ts
@@ -27,13 +27,17 @@ export interface CloneOptions {
   onProgress?: (message: string) => void;
   /** Maximum pages to fetch (for testing/debugging). 0 = unlimited. */
   limit?: number;
+  /** Maximum hierarchy depth to clone. 0 = unlimited. Depth 1 = root pages only. */
+  depth?: number;
 }
 
 export interface CloneResult {
   /** Absolute path to the cloned directory. */
   path: string;
-  /** Number of pages cloned. */
+  /** Number of pages cloned (full content). */
   pageCount: number;
+  /** Number of pages written as stubs (depth-limited). */
+  stubCount: number;
   /** Resolved scope info. */
   scope: ResolvedScope;
 }
@@ -47,8 +51,29 @@ function contentHash(content: string): string {
   return Bun.hash(content).toString(16);
 }
 
+/** Compute hierarchy depth of an entry (1 = root, 2 = child of root, etc.). */
+export function computeDepth(entry: RemoteEntry, entryById: Map<string, RemoteEntry>): number {
+  let depth = 1;
+  let current = entry;
+  const visited = new Set<string>();
+  while (current.parentId && entryById.has(current.parentId)) {
+    if (visited.has(current.id)) break;
+    visited.add(current.id);
+    const parent = entryById.get(current.parentId);
+    if (!parent) break;
+    current = parent;
+    depth++;
+  }
+  return depth;
+}
+
+const STUB_BODY = `> **Shallow clone stub** — this page was not fetched (depth limit).
+>
+> Run \`mcx vfs pull\` to fetch all pages, or \`mcx vfs pull --depth N\` with a larger depth.
+`;
+
 export async function clone(opts: CloneOptions): Promise<CloneResult> {
-  const { targetDir, provider, scope, limit = 0 } = opts;
+  const { targetDir, provider, scope, limit = 0, depth = 0 } = opts;
   const absTarget = resolve(targetDir);
 
   // ── Preflight checks ───────────────────────────────────────
@@ -93,8 +118,25 @@ export async function clone(opts: CloneOptions): Promise<CloneResult> {
 
   log(opts, `  → ${entries.length} pages fetched`);
 
-  // Fetch content individually only for entries that didn't include it inline
-  const missingContent = entries.filter((e) => !contentMap.has(e.id));
+  // ── Step 2b: Depth filtering ───────────────────────────────
+  let includedEntries: RemoteEntry[];
+  let stubEntries: RemoteEntry[] = [];
+
+  if (depth > 0) {
+    const entryById = new Map(entries.map((e) => [e.id, e]));
+    const depthMap = new Map<string, number>();
+    for (const entry of entries) {
+      depthMap.set(entry.id, computeDepth(entry, entryById));
+    }
+    includedEntries = entries.filter((e) => (depthMap.get(e.id) ?? 1) <= depth);
+    stubEntries = entries.filter((e) => (depthMap.get(e.id) ?? 1) > depth);
+    log(opts, `  → depth ${depth}: ${includedEntries.length} included, ${stubEntries.length} stubs`);
+  } else {
+    includedEntries = entries;
+  }
+
+  // Fetch content individually only for included entries that didn't include it inline
+  const missingContent = includedEntries.filter((e) => !contentMap.has(e.id));
   if (missingContent.length > 0) {
     log(opts, `Fetching content for ${missingContent.length} pages without inline content...`);
     const BATCH_SIZE = 10;
@@ -109,8 +151,8 @@ export async function clone(opts: CloneOptions): Promise<CloneResult> {
       );
       for (const r of results) {
         contentMap.set(r.id, r.content);
-        const idx = entries.findIndex((e) => e.id === r.id);
-        if (idx >= 0) entries[idx] = r.entry;
+        const idx = includedEntries.findIndex((e) => e.id === r.id);
+        if (idx >= 0) includedEntries[idx] = r.entry;
         contentFetched++;
       }
       if (contentFetched % 50 === 0 || contentFetched === missingContent.length) {
@@ -120,6 +162,7 @@ export async function clone(opts: CloneOptions): Promise<CloneResult> {
   }
 
   // ── Step 3: Build path map ─────────────────────────────────
+  // Use all entries for path computation (stubs need parent context for correct paths)
   log(opts, "Building directory tree...");
   const pathMap = new Map<string, string>();
   for (const entry of entries) {
@@ -132,7 +175,7 @@ export async function clone(opts: CloneOptions): Promise<CloneResult> {
   mkdirSync(absTarget, { recursive: true });
 
   let written = 0;
-  for (const entry of entries) {
+  for (const entry of includedEntries) {
     const relPath = pathMap.get(entry.id) ?? `${entry.id}.md`;
     const absPath = join(absTarget, relPath);
     const content = contentMap.get(entry.id) ?? "";
@@ -143,21 +186,45 @@ export async function clone(opts: CloneOptions): Promise<CloneResult> {
     writeFileSync(absPath, withFrontmatter, "utf-8");
     written++;
   }
-  log(opts, `  → ${written} files written`);
+
+  // Write stubs for depth-excluded pages
+  for (const entry of stubEntries) {
+    const relPath = pathMap.get(entry.id) ?? `${entry.id}.md`;
+    const absPath = join(absTarget, relPath);
+    const fm = { ...provider.frontmatter(entry, resolved), stub: true };
+    const withFrontmatter = injectFrontmatter(STUB_BODY, fm);
+
+    mkdirSync(dirname(absPath), { recursive: true });
+    writeFileSync(absPath, withFrontmatter, "utf-8");
+  }
+
+  if (stubEntries.length > 0) {
+    log(opts, `  → ${written} files + ${stubEntries.length} stubs written`);
+  } else {
+    log(opts, `  → ${written} files written`);
+  }
 
   // ── Step 5: Populate cache (before git init so interrupted clones can be repaired) ──
   log(opts, "Building cache...");
   const cacheDir = join(absTarget, ".clone");
   const cache = new CloneCache(join(cacheDir, "cache.sqlite"));
 
-  cache.saveScopeMeta(provider.name, resolved);
-  for (const entry of entries) {
+  // Store depth in resolved metadata so pull can read it
+  const resolvedWithDepth =
+    depth > 0 ? { ...resolved, resolved: { ...resolved.resolved, cloneDepth: depth } } : resolved;
+  cache.saveScopeMeta(provider.name, resolvedWithDepth);
+
+  for (const entry of includedEntries) {
     const relPath = pathMap.get(entry.id) ?? `${entry.id}.md`;
     const content = contentMap.get(entry.id) ?? "";
-    cache.upsert(provider.name, resolved, entry, relPath, contentHash(content));
+    cache.upsert(provider.name, resolvedWithDepth, entry, relPath, contentHash(content));
+  }
+  for (const entry of stubEntries) {
+    const relPath = pathMap.get(entry.id) ?? `${entry.id}.md`;
+    cache.upsert(provider.name, resolvedWithDepth, entry, relPath, null, true);
   }
   cache.close();
-  log(opts, `  → cache populated (${entries.length} entries)`);
+  log(opts, `  → cache populated (${includedEntries.length} entries, ${stubEntries.length} stubs)`);
 
   // ── Step 6: Initialize git repo ────────────────────────────
   log(opts, "Initializing git repository...");
@@ -179,15 +246,18 @@ export async function clone(opts: CloneOptions): Promise<CloneResult> {
   writeFileSync(join(absTarget, ".gitignore"), ".clone/\n", "utf-8");
   execSync("git add .gitignore", gitOpts);
 
-  const commitMsg = `Clone ${provider.name}/${scope.key}: ${spaceName} (${entries.length} pages)`;
+  const depthNote = depth > 0 ? `, depth ${depth}` : "";
+  const stubNote = stubEntries.length > 0 ? `, ${stubEntries.length} stubs` : "";
+  const commitMsg = `Clone ${provider.name}/${scope.key}: ${spaceName} (${includedEntries.length} pages${stubNote}${depthNote})`;
   spawnSync("git", ["commit", "-m", commitMsg, "--allow-empty"], gitOpts);
   log(opts, "  → initial commit created");
 
-  log(opts, `\nDone! Cloned ${entries.length} pages to ${absTarget}`);
+  log(opts, `\nDone! Cloned ${includedEntries.length} pages${stubNote} to ${absTarget}`);
 
   return {
     path: absTarget,
-    pageCount: entries.length,
-    scope: resolved,
+    pageCount: includedEntries.length,
+    stubCount: stubEntries.length,
+    scope: resolvedWithDepth,
   };
 }

--- a/packages/clone/src/engine/clone.ts
+++ b/packages/clone/src/engine/clone.ts
@@ -14,6 +14,7 @@ import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import type { RemoteEntry, RemoteProvider, ResolvedScope, Scope } from "../providers/provider";
 import { CloneCache } from "./cache";
+import { STUB_BODY } from "./constants";
 import { injectFrontmatter } from "./frontmatter";
 
 export interface CloneOptions {
@@ -66,11 +67,6 @@ export function computeDepth(entry: RemoteEntry, entryById: Map<string, RemoteEn
   }
   return depth;
 }
-
-const STUB_BODY = `> **Shallow clone stub** — this page was not fetched (depth limit).
->
-> Run \`mcx vfs pull\` to fetch all pages, or \`mcx vfs pull --depth N\` with a larger depth.
-`;
 
 export async function clone(opts: CloneOptions): Promise<CloneResult> {
   const { targetDir, provider, scope, limit = 0, depth = 0 } = opts;

--- a/packages/clone/src/engine/constants.ts
+++ b/packages/clone/src/engine/constants.ts
@@ -1,0 +1,5 @@
+/** Placeholder body written for pages excluded by --depth. */
+export const STUB_BODY = `> **Shallow clone stub** — this page was not fetched (depth limit).
+>
+> Run \`mcx vfs pull\` to fetch all pages, or \`mcx vfs pull --depth N\` with a larger depth.
+`;

--- a/packages/clone/src/engine/pull.spec.ts
+++ b/packages/clone/src/engine/pull.spec.ts
@@ -417,6 +417,109 @@ describe("pull", () => {
     });
   });
 
+  describe("depth-aware pull", () => {
+    function hierarchyProvider(entries: RemoteEntry[]): RemoteProvider {
+      return makeProvider({
+        list: async function* () {
+          for (const e of entries) yield e;
+        },
+        fetch: async (_s, id) => {
+          const e = entries.find((x) => x.id === id);
+          return { content: e?.content ?? `Content of ${id}`, entry: e ?? makeEntry({ id }) };
+        },
+        toPath: (e, all) => {
+          const parent = e.parentId ? all.find((x) => x.id === e.parentId) : undefined;
+          return parent ? `${parent.title}/${e.title}.md` : `${e.title}.md`;
+        },
+      });
+    }
+
+    test("pull deepens stubs into full content", async () => {
+      const entries = [
+        makeEntry({ id: "r1", title: "Root", version: 1, content: "# Root" }),
+        makeEntry({ id: "c1", title: "Child", parentId: "r1", version: 1, content: "# Child" }),
+      ];
+
+      const scopeWithDepth = { ...scope, resolved: { ...scope.resolved, cloneDepth: 1 } };
+      cache.saveScopeMeta("test", scopeWithDepth);
+      cache.upsert("test", scopeWithDepth, entries[0], "Root.md", "h1");
+      cache.upsert("test", scopeWithDepth, entries[1], "Root/Child.md", null, true);
+
+      writeFileSync(join(repoDir, "Root.md"), injectFrontmatter("# Root", { id: "r1" }));
+      mkdirSync(join(repoDir, "Root"), { recursive: true });
+      writeFileSync(
+        join(repoDir, "Root/Child.md"),
+        injectFrontmatter("> **Shallow clone stub**", { id: "c1", stub: true }),
+      );
+      execSync("git add -A && git commit -m 'shallow clone'", { cwd: repoDir, stdio: "pipe" });
+      cache.close();
+
+      const provider = hierarchyProvider(entries);
+      const result = await pull({ repoDir, provider, onProgress: () => {} });
+
+      expect(result.deepened).toBe(1);
+      expect(result.committed).toBe(true);
+
+      const childFile = readFileSync(join(repoDir, "Root/Child.md"), "utf-8");
+      const { content } = stripFrontmatter(childFile);
+      expect(content).toBe("# Child");
+    });
+
+    test("incremental pull writes stubs for new pages beyond depth limit", async () => {
+      const scopeWithDepth = { ...scope, resolved: { ...scope.resolved, cloneDepth: 1 } };
+      cache.saveScopeMeta("test", scopeWithDepth);
+      cache.upsert("test", scopeWithDepth, makeEntry({ id: "r1", title: "Root", version: 1 }), "Root.md", "h1");
+      writeFileSync(join(repoDir, "Root.md"), injectFrontmatter("# Root", { id: "r1" }));
+      execSync("git add -A && git commit -m 'seed'", { cwd: repoDir, stdio: "pipe" });
+      cache.updateLastSynced("test", "TEST");
+      cache.close();
+
+      const changeEvents: ChangeEvent[] = [
+        {
+          entry: makeEntry({ id: "c1", title: "Child", parentId: "r1", version: 1, content: "# Child" }),
+          type: "created",
+        },
+      ];
+      const provider = makeProvider({
+        changes: async function* () {
+          for (const c of changeEvents) yield c;
+        },
+        toPath: (e, all) => {
+          const parent = e.parentId ? all.find((x) => x.id === e.parentId) : undefined;
+          return parent ? `${parent.title}/${e.title}.md` : `${e.title}.md`;
+        },
+      });
+
+      const result = await pull({ repoDir, provider, depth: 1, onProgress: () => {} });
+
+      expect(result.incremental).toBe(true);
+      const childFile = readFileSync(join(repoDir, "Root/Child.md"), "utf-8");
+      const { content, fields } = stripFrontmatter(childFile);
+      expect(content).toContain("Shallow clone stub");
+      expect(fields?.stub).toBe(true);
+    });
+
+    test("full pull with depth creates stubs for excluded entries", async () => {
+      cache.close();
+
+      const entries = [
+        makeEntry({ id: "r1", title: "Root", version: 1, content: "# Root" }),
+        makeEntry({ id: "c1", title: "Child", parentId: "r1", version: 1, content: "# Child" }),
+      ];
+      const provider = hierarchyProvider(entries);
+
+      const result = await pull({ repoDir, provider, depth: 1, onProgress: () => {} });
+
+      expect(result.created).toBe(1);
+      expect(result.committed).toBe(true);
+      expect(existsSync(join(repoDir, "Root.md"))).toBe(true);
+
+      const childFile = readFileSync(join(repoDir, "Root/Child.md"), "utf-8");
+      const { content } = stripFrontmatter(childFile);
+      expect(content).toContain("Shallow clone stub");
+    });
+  });
+
   describe("commit behavior", () => {
     test("commit message includes change counts and mode", async () => {
       cache.close();

--- a/packages/clone/src/engine/pull.ts
+++ b/packages/clone/src/engine/pull.ts
@@ -18,7 +18,13 @@ import { dirname, join } from "node:path";
 import { TruncatedChangesError } from "../providers/confluence";
 import type { ChangeEvent, RemoteEntry, RemoteProvider, ResolvedScope } from "../providers/provider";
 import { CloneCache } from "./cache";
+import { computeDepth } from "./clone";
 import { injectFrontmatter } from "./frontmatter";
+
+const STUB_BODY = `> **Shallow clone stub** — this page was not fetched (depth limit).
+>
+> Run \`mcx vfs pull\` to fetch all pages, or \`mcx vfs pull --depth N\` with a larger depth.
+`;
 
 export interface PullOptions {
   /** Root directory of the cloned repo. */
@@ -29,6 +35,8 @@ export interface PullOptions {
   onProgress?: (message: string) => void;
   /** Force full sync instead of incremental. */
   full?: boolean;
+  /** Maximum hierarchy depth. 0 = unlimited (deepens shallow clones). */
+  depth?: number;
 }
 
 export interface PullResult {
@@ -38,6 +46,8 @@ export interface PullResult {
   created: number;
   /** Number of pages deleted. */
   deleted: number;
+  /** Number of stubs replaced with full content (deepened). */
+  deepened: number;
   /** Whether a new commit was created. */
   committed: boolean;
   /** Whether incremental sync was used. */
@@ -62,7 +72,7 @@ export async function pull(opts: PullOptions): Promise<PullResult> {
   }
 
   const cache = new CloneCache(cachePath);
-  const result: PullResult = { updated: 0, created: 0, deleted: 0, committed: false, incremental: false };
+  const result: PullResult = { updated: 0, created: 0, deleted: 0, deepened: 0, committed: false, incremental: false };
 
   try {
     // ── Load scope from cache ────────────────────────────────
@@ -73,9 +83,25 @@ export async function pull(opts: PullOptions): Promise<PullResult> {
 
     log(opts, `Pulling ${provider.name}/${scope.key}...`);
 
+    // ── Decide depth ─────────────────────────────────────────
+    // If user specifies --depth, use it. Otherwise, use the stored clone depth.
+    // Pull without --depth on a shallow clone deepens (fetches everything).
+    const { depth: userDepth = 0 } = opts;
+    const storedDepth = cache.getCloneDepth(provider.name, scope.key);
+    const hasStubs = cache.countStubs(provider.name, scope.key) > 0;
+    // If user didn't specify depth and there are stubs, deepen (depth=0 means unlimited)
+    const effectiveDepth = userDepth > 0 ? userDepth : hasStubs ? 0 : storedDepth;
+    const isDeepening = hasStubs && effectiveDepth === 0;
+
+    if (isDeepening) {
+      log(opts, "Deepening shallow clone — fetching all pages...");
+    }
+
     // ── Decide: incremental or full ──────────────────────────
     const lastSynced = cache.getLastSynced(provider.name, scope.key);
-    const canIncremental = !full && lastSynced && provider.changes;
+    // Force full sync when deepening (stubs need to be replaced)
+    const forceFullForDeepen = isDeepening || (effectiveDepth !== storedDepth && storedDepth > 0);
+    const canIncremental = !full && !forceFullForDeepen && lastSynced && provider.changes;
 
     if (canIncremental) {
       try {
@@ -84,20 +110,26 @@ export async function pull(opts: PullOptions): Promise<PullResult> {
         if (err instanceof TruncatedChangesError) {
           log(opts, `  ${err.message}`);
           result.incremental = false;
-          await fullPull(opts, cache, scope, result);
+          await fullPull(opts, cache, scope, result, effectiveDepth);
         } else {
           throw err;
         }
       }
     } else {
-      if (!full && lastSynced) {
+      if (!full && !forceFullForDeepen && lastSynced) {
         log(opts, "Provider doesn't support incremental sync, falling back to full sync.");
       }
-      await fullPull(opts, cache, scope, result);
+      await fullPull(opts, cache, scope, result, effectiveDepth);
+    }
+
+    // ── Update stored depth if it changed ─────────────────────
+    if (effectiveDepth !== storedDepth) {
+      const updatedResolved = { ...scope, resolved: { ...scope.resolved, cloneDepth: effectiveDepth || undefined } };
+      cache.saveScopeMeta(provider.name, updatedResolved);
     }
 
     // ── Git commit ───────────────────────────────────────────
-    const totalChanges = result.created + result.updated + result.deleted;
+    const totalChanges = result.created + result.updated + result.deleted + result.deepened;
     if (totalChanges > 0) {
       // Strip GIT_* env vars so inherited env (e.g. from git hooks) doesn't
       // redirect git commands to the parent repo.
@@ -116,6 +148,7 @@ export async function pull(opts: PullOptions): Promise<PullResult> {
         if (result.created > 0) parts.push(`${result.created} new`);
         if (result.updated > 0) parts.push(`${result.updated} updated`);
         if (result.deleted > 0) parts.push(`${result.deleted} deleted`);
+        if (result.deepened > 0) parts.push(`${result.deepened} deepened`);
         const mode = result.incremental ? "incremental" : "full";
         const commitMsg = `Pull ${provider.name}/${scope.key} (${mode}): ${parts.join(", ")}`;
         spawnSync("git", ["commit", "-m", commitMsg], gitOpts);
@@ -127,10 +160,18 @@ export async function pull(opts: PullOptions): Promise<PullResult> {
     // ── Update last_synced (after commit so interrupted syncs don't advance watermark) ──
     cache.updateLastSynced(provider.name, scope.key);
 
-    if (result.created + result.updated + result.deleted === 0) {
+    if (totalChanges === 0) {
       log(opts, "Already up to date.");
     } else {
-      log(opts, `\nPull complete. ${result.created} new, ${result.updated} updated, ${result.deleted} deleted.`);
+      const summary = [
+        result.created > 0 ? `${result.created} new` : null,
+        result.updated > 0 ? `${result.updated} updated` : null,
+        result.deleted > 0 ? `${result.deleted} deleted` : null,
+        result.deepened > 0 ? `${result.deepened} deepened` : null,
+      ]
+        .filter(Boolean)
+        .join(", ");
+      log(opts, `\nPull complete. ${summary}.`);
     }
   } finally {
     cache.close();
@@ -237,7 +278,13 @@ async function incrementalPull(
 }
 
 /** Full pull — fetch all pages and diff against cache. */
-async function fullPull(opts: PullOptions, cache: CloneCache, scope: ResolvedScope, result: PullResult): Promise<void> {
+async function fullPull(
+  opts: PullOptions,
+  cache: CloneCache,
+  scope: ResolvedScope,
+  result: PullResult,
+  effectiveDepth = 0,
+): Promise<void> {
   const { repoDir, provider } = opts;
 
   log(opts, "Full sync...");
@@ -261,18 +308,43 @@ async function fullPull(opts: PullOptions, cache: CloneCache, scope: ResolvedSco
 
   log(opts, `  → ${remoteEntries.length} remote pages`);
 
+  // Compute depth map if depth filtering is active
+  const entryById = new Map(remoteEntries.map((e) => [e.id, e]));
+  const depthMap = new Map<string, number>();
+  if (effectiveDepth > 0) {
+    for (const entry of remoteEntries) {
+      depthMap.set(entry.id, computeDepth(entry, entryById));
+    }
+  }
+
+  const isIncluded = (id: string) => effectiveDepth <= 0 || (depthMap.get(id) ?? 1) <= effectiveDepth;
+  const isStubEntry = (id: string) => effectiveDepth > 0 && !isIncluded(id);
+
   const remoteById = new Map(remoteEntries.map((e) => [e.id, e]));
 
-  // Diff
+  // Diff — categorize into full entries, stubs, and deletions
   const toUpdate: RemoteEntry[] = [];
   const toCreate: RemoteEntry[] = [];
+  const toDeepen: RemoteEntry[] = []; // stubs being replaced with full content
+  const toStub: RemoteEntry[] = []; // entries that should become stubs (new depth-limited entries)
   const toDelete: string[] = [];
 
   for (const remote of remoteEntries) {
     const cached = cachedById.get(remote.id);
+    const included = isIncluded(remote.id);
+
     if (!cached) {
-      toCreate.push(remote);
-    } else if (remote.version > cached.version || remote.lastModified > cached.lastModified) {
+      if (included) {
+        toCreate.push(remote);
+      } else {
+        toStub.push(remote);
+      }
+    } else if (cached.isStub && included) {
+      // Was a stub, now included (deepening)
+      toDeepen.push(remote);
+    } else if (!cached.isStub && isStubEntry(remote.id)) {
+      // Was included, now excluded (re-shallowing) — keep as-is, don't downgrade
+    } else if (included && (remote.version > cached.version || remote.lastModified > cached.lastModified)) {
       toUpdate.push(remote);
     }
   }
@@ -283,13 +355,22 @@ async function fullPull(opts: PullOptions, cache: CloneCache, scope: ResolvedSco
     }
   }
 
-  const totalChanges = toCreate.length + toUpdate.length + toDelete.length;
+  const totalChanges = toCreate.length + toUpdate.length + toDelete.length + toDeepen.length + toStub.length;
   if (totalChanges === 0) return;
 
-  log(opts, `Changes: ${toCreate.length} new, ${toUpdate.length} updated, ${toDelete.length} deleted`);
+  const changeParts = [
+    toCreate.length > 0 ? `${toCreate.length} new` : null,
+    toUpdate.length > 0 ? `${toUpdate.length} updated` : null,
+    toDelete.length > 0 ? `${toDelete.length} deleted` : null,
+    toDeepen.length > 0 ? `${toDeepen.length} to deepen` : null,
+    toStub.length > 0 ? `${toStub.length} stubs` : null,
+  ]
+    .filter(Boolean)
+    .join(", ");
+  log(opts, `Changes: ${changeParts}`);
 
-  // Fetch content for entries without inline content
-  const needsFetch = [...toCreate, ...toUpdate].filter((e) => !remoteContentMap.has(e.id));
+  // Fetch content for included entries without inline content
+  const needsFetch = [...toCreate, ...toUpdate, ...toDeepen].filter((e) => !remoteContentMap.has(e.id));
   if (needsFetch.length > 0) {
     log(opts, `Fetching content for ${needsFetch.length} pages...`);
     const BATCH_SIZE = 10;
@@ -307,8 +388,8 @@ async function fullPull(opts: PullOptions, cache: CloneCache, scope: ResolvedSco
     }
   }
 
-  // Apply changes
-  for (const entry of [...toCreate, ...toUpdate]) {
+  // Apply full-content changes
+  for (const entry of [...toCreate, ...toUpdate, ...toDeepen]) {
     const relPath = provider.toPath(entry, remoteEntries);
     const absPath = join(repoDir, relPath);
     const content = remoteContentMap.get(entry.id) ?? "";
@@ -319,7 +400,14 @@ async function fullPull(opts: PullOptions, cache: CloneCache, scope: ResolvedSco
     writeFileSync(absPath, withFrontmatter, "utf-8");
     cache.upsert(provider.name, scope, entry, relPath, contentHash(content));
 
-    if (cachedById.has(entry.id)) {
+    if (toDeepen.includes(entry)) {
+      const oldCached = cachedById.get(entry.id);
+      if (oldCached && oldCached.localPath !== relPath) {
+        const oldAbsPath = join(repoDir, oldCached.localPath);
+        if (existsSync(oldAbsPath)) unlinkSync(oldAbsPath);
+      }
+      result.deepened++;
+    } else if (cachedById.has(entry.id)) {
       const oldCached = cachedById.get(entry.id);
       if (oldCached && oldCached.localPath !== relPath) {
         const oldAbsPath = join(repoDir, oldCached.localPath);
@@ -329,6 +417,18 @@ async function fullPull(opts: PullOptions, cache: CloneCache, scope: ResolvedSco
     } else {
       result.created++;
     }
+  }
+
+  // Write stubs for new depth-limited entries
+  for (const entry of toStub) {
+    const relPath = provider.toPath(entry, remoteEntries);
+    const absPath = join(repoDir, relPath);
+    const fm = { ...provider.frontmatter(entry, scope), stub: true };
+    const withFrontmatter = injectFrontmatter(STUB_BODY, fm);
+
+    mkdirSync(dirname(absPath), { recursive: true });
+    writeFileSync(absPath, withFrontmatter, "utf-8");
+    cache.upsert(provider.name, scope, entry, relPath, null, true);
   }
 
   for (const id of toDelete) {

--- a/packages/clone/src/engine/pull.ts
+++ b/packages/clone/src/engine/pull.ts
@@ -19,12 +19,8 @@ import { TruncatedChangesError } from "../providers/confluence";
 import type { ChangeEvent, RemoteEntry, RemoteProvider, ResolvedScope } from "../providers/provider";
 import { CloneCache } from "./cache";
 import { computeDepth } from "./clone";
+import { STUB_BODY } from "./constants";
 import { injectFrontmatter } from "./frontmatter";
-
-const STUB_BODY = `> **Shallow clone stub** — this page was not fetched (depth limit).
->
-> Run \`mcx vfs pull\` to fetch all pages, or \`mcx vfs pull --depth N\` with a larger depth.
-`;
 
 export interface PullOptions {
   /** Root directory of the cloned repo. */
@@ -93,8 +89,18 @@ export async function pull(opts: PullOptions): Promise<PullResult> {
     const effectiveDepth = userDepth > 0 ? userDepth : hasStubs ? 0 : storedDepth;
     const isDeepening = hasStubs && effectiveDepth === 0;
 
+    // Re-shallowing (e.g. pull --depth 1 on a depth-2 clone) updates stored depth
+    // but does NOT remove content already on disk for deeper pages. Those pages become
+    // invisible to the depth system but remain as full files.
+    if (userDepth > 0 && storedDepth > 0 && userDepth < storedDepth) {
+      log(
+        opts,
+        `Warning: re-shallowing from depth ${storedDepth} to ${userDepth}. Pages already fetched beyond depth ${userDepth} will remain on disk.`,
+      );
+    }
+
     if (isDeepening) {
-      log(opts, "Deepening shallow clone — fetching all pages...");
+      log(opts, "Deepening shallow clone — fetching all pages (this may take a while)...");
     }
 
     // ── Decide: incremental or full ──────────────────────────
@@ -105,7 +111,7 @@ export async function pull(opts: PullOptions): Promise<PullResult> {
 
     if (canIncremental) {
       try {
-        await incrementalPull(opts, cache, scope, lastSynced, result);
+        await incrementalPull(opts, cache, scope, lastSynced, result, effectiveDepth);
       } catch (err) {
         if (err instanceof TruncatedChangesError) {
           log(opts, `  ${err.message}`);
@@ -124,6 +130,7 @@ export async function pull(opts: PullOptions): Promise<PullResult> {
 
     // ── Update stored depth if it changed ─────────────────────
     if (effectiveDepth !== storedDepth) {
+      // 0 = unlimited depth — strip the key rather than storing 0
       const updatedResolved = { ...scope, resolved: { ...scope.resolved, cloneDepth: effectiveDepth || undefined } };
       cache.saveScopeMeta(provider.name, updatedResolved);
     }
@@ -187,6 +194,7 @@ async function incrementalPull(
   scope: ResolvedScope,
   since: string,
   result: PullResult,
+  effectiveDepth = 0,
 ): Promise<void> {
   const { repoDir, provider } = opts;
   result.incremental = true;
@@ -223,6 +231,15 @@ async function incrementalPull(
     metadata: {},
   }));
 
+  // Build depth map for depth-filtered incremental sync. Include changed entries
+  // so new pages get correct parent context for depth computation.
+  const allEntriesForDepth = new Map<string, RemoteEntry>(allCachedAsEntries.map((e) => [e.id, e]));
+  for (const change of changes) {
+    if (change.type !== "deleted") {
+      allEntriesForDepth.set(change.entry.id, change.entry);
+    }
+  }
+
   for (const change of changes) {
     const { entry } = change;
 
@@ -238,17 +255,35 @@ async function incrementalPull(
       continue;
     }
 
-    // Created or updated — fetch content if not inline
-    let content = entry.content;
-    if (content == null) {
-      const fetched = await provider.fetch(scope, entry.id);
-      content = fetched.content;
-    }
+    // Enforce depth limit: new pages beyond depth get written as stubs so the
+    // depth invariant doesn't erode silently when incremental sync is the hot path.
+    const entryDepth = effectiveDepth > 0 ? computeDepth(entry, allEntriesForDepth) : 1;
+    const excluded = effectiveDepth > 0 && entryDepth > effectiveDepth;
 
     // Compute path — use cached entries + this entry for context
     const entriesForPath = [...allCachedAsEntries.filter((e) => e.id !== entry.id), entry];
     const relPath = provider.toPath(entry, entriesForPath);
     const absPath = join(repoDir, relPath);
+
+    if (excluded) {
+      const fm = { ...provider.frontmatter(entry, scope), stub: true };
+      const withFrontmatter = injectFrontmatter(STUB_BODY, fm);
+      mkdirSync(dirname(absPath), { recursive: true });
+      writeFileSync(absPath, withFrontmatter, "utf-8");
+      cache.upsert(provider.name, scope, entry, relPath, null, true);
+
+      if (!cachedById.has(entry.id)) {
+        log(opts, `  + ${relPath} (stub — depth limit)`);
+      }
+      continue;
+    }
+
+    // Included — fetch content if not inline
+    let content = entry.content;
+    if (content == null) {
+      const fetched = await provider.fetch(scope, entry.id);
+      content = fetched.content;
+    }
 
     const fm = provider.frontmatter(entry, scope);
     const withFrontmatter = injectFrontmatter(content, fm);
@@ -307,6 +342,12 @@ async function fullPull(
   }
 
   log(opts, `  → ${remoteEntries.length} remote pages`);
+
+  // Warn when deepening will fetch many pages
+  const stubCount = cachedEntries.filter((e) => e.isStub).length;
+  if (stubCount > 0 && effectiveDepth === 0) {
+    log(opts, `  Deepening: will fetch content for ${remoteEntries.length} pages (replacing ${stubCount} stubs)...`);
+  }
 
   // Compute depth map if depth filtering is active
   const entryById = new Map(remoteEntries.map((e) => [e.id, e]));

--- a/packages/command/src/commands/vfs.spec.ts
+++ b/packages/command/src/commands/vfs.spec.ts
@@ -16,6 +16,7 @@ function makeDeps(overrides: Partial<VfsDeps> = {}): VfsDeps {
     clone: async (opts) => ({
       path: opts.targetDir,
       pageCount: 5,
+      stubCount: 0,
       scope: { key: opts.scope.key, cloudId: opts.scope.cloudId ?? "auto-123", resolved: {} },
     }),
     pull: async () => ({
@@ -24,6 +25,7 @@ function makeDeps(overrides: Partial<VfsDeps> = {}): VfsDeps {
       deleted: 0,
       committed: true,
       incremental: true,
+      deepened: 0,
     }),
     push: async () => ({
       files: [],
@@ -50,7 +52,7 @@ describe("cmdVfs", () => {
       const deps = makeDeps({
         clone: async () => {
           called = true;
-          return { path: "/tmp/test", pageCount: 1, scope: { key: "FOO", cloudId: "c1", resolved: {} } };
+          return { path: "/tmp/test", pageCount: 1, stubCount: 0, scope: { key: "FOO", cloudId: "c1", resolved: {} } };
         },
       });
 
@@ -63,7 +65,7 @@ describe("cmdVfs", () => {
       const deps = makeDeps({
         pull: async () => {
           called = true;
-          return { updated: 0, created: 0, deleted: 0, committed: false, incremental: true };
+          return { updated: 0, created: 0, deleted: 0, deepened: 0, committed: false, incremental: true };
         },
       });
 
@@ -101,7 +103,12 @@ describe("cmdVfs", () => {
       const deps = makeDeps({
         clone: async (opts) => {
           capturedLimit = opts.limit;
-          return { path: opts.targetDir, pageCount: 3, scope: { key: "SP", cloudId: "c1", resolved: {} } };
+          return {
+            path: opts.targetDir,
+            pageCount: 3,
+            stubCount: 0,
+            scope: { key: "SP", cloudId: "c1", resolved: {} },
+          };
         },
       });
 
@@ -117,6 +124,7 @@ describe("cmdVfs", () => {
           return {
             path: opts.targetDir,
             pageCount: 1,
+            stubCount: 0,
             scope: { key: "SP", cloudId: opts.scope.cloudId ?? "", resolved: {} },
           };
         },
@@ -131,7 +139,12 @@ describe("cmdVfs", () => {
       const deps = makeDeps({
         clone: async (opts) => {
           capturedDir = opts.targetDir;
-          return { path: opts.targetDir, pageCount: 1, scope: { key: "SP", cloudId: "c1", resolved: {} } };
+          return {
+            path: opts.targetDir,
+            pageCount: 1,
+            stubCount: 0,
+            scope: { key: "SP", cloudId: "c1", resolved: {} },
+          };
         },
       });
 
@@ -147,6 +160,24 @@ describe("cmdVfs", () => {
     test("clone with only provider (no scope) exits non-zero", async () => {
       const deps = makeDeps();
       await expect(cmdVfs(["clone", "confluence"], undefined, deps)).rejects.toThrow("exit(1)");
+    });
+
+    test("--depth is parsed and forwarded", async () => {
+      let capturedDepth: number | undefined;
+      const deps = makeDeps({
+        clone: async (opts) => {
+          capturedDepth = opts.depth;
+          return {
+            path: opts.targetDir,
+            pageCount: 3,
+            stubCount: 2,
+            scope: { key: "SP", cloudId: "c1", resolved: {} },
+          };
+        },
+      });
+
+      await cmdVfs(["clone", "confluence", "SP", "--depth", "2"], undefined, deps);
+      expect(capturedDepth).toBe(2);
     });
 
     test("resolveProvider is called with provider name", async () => {
@@ -170,12 +201,25 @@ describe("cmdVfs", () => {
       const deps = makeDeps({
         pull: async (opts) => {
           capturedFull = opts.full;
-          return { updated: 0, created: 0, deleted: 0, committed: false, incremental: false };
+          return { updated: 0, created: 0, deleted: 0, deepened: 0, committed: false, incremental: false };
         },
       });
 
       await cmdVfs(["pull", "--full", "/tmp/repo"], undefined, deps);
       expect(capturedFull).toBe(true);
+    });
+
+    test("--depth is parsed and forwarded", async () => {
+      let capturedDepth: number | undefined;
+      const deps = makeDeps({
+        pull: async (opts) => {
+          capturedDepth = opts.depth;
+          return { updated: 0, created: 0, deleted: 0, deepened: 0, committed: false, incremental: false };
+        },
+      });
+
+      await cmdVfs(["pull", "--depth", "3", "/tmp/repo"], undefined, deps);
+      expect(capturedDepth).toBe(3);
     });
 
     test("resolveProviderFromCache is called with repo dir", async () => {

--- a/packages/command/src/commands/vfs.ts
+++ b/packages/command/src/commands/vfs.ts
@@ -126,7 +126,7 @@ export async function cmdVfs(args: string[], opts?: { dryRun?: boolean }, deps?:
 
 async function vfsClone(args: string[], deps: VfsDeps): Promise<void> {
   if (args.length < 2) {
-    printError("Usage: mcx vfs clone <provider> <scope> [target-dir] [--limit N] [--cloud-id ID]");
+    printError("Usage: mcx vfs clone <provider> <scope> [target-dir] [--limit N] [--depth N] [--cloud-id ID]");
     deps.exit(1);
   }
 
@@ -135,6 +135,7 @@ async function vfsClone(args: string[], deps: VfsDeps): Promise<void> {
   let targetDir: string | undefined;
   let cloudId: string | undefined;
   let limit = 0;
+  let depth = 0;
 
   for (let i = 2; i < args.length; i++) {
     const arg = args[i];
@@ -142,6 +143,8 @@ async function vfsClone(args: string[], deps: VfsDeps): Promise<void> {
       cloudId = args[++i];
     } else if (arg === "--limit" && args[i + 1]) {
       limit = Number.parseInt(args[++i], 10);
+    } else if (arg === "--depth" && args[i + 1]) {
+      depth = Number.parseInt(args[++i], 10);
     } else if (!arg.startsWith("-") && !targetDir) {
       targetDir = arg;
     }
@@ -159,6 +162,7 @@ async function vfsClone(args: string[], deps: VfsDeps): Promise<void> {
       provider,
       scope: { key: scopeKey, cloudId },
       limit,
+      depth,
       onProgress: log,
     });
   } catch (err) {
@@ -176,7 +180,9 @@ async function vfsClone(args: string[], deps: VfsDeps): Promise<void> {
         space: result.scope.key,
         path: result.path,
         pages: result.pageCount,
+        stubs: result.stubCount,
         cloudId: result.scope.cloudId,
+        ...(depth > 0 ? { depth } : {}),
       },
       null,
       2,
@@ -186,14 +192,23 @@ async function vfsClone(args: string[], deps: VfsDeps): Promise<void> {
 
 async function vfsPull(args: string[], deps: VfsDeps): Promise<void> {
   const full = args.includes("--full");
-  const filteredArgs = args.filter((a) => a !== "--full");
+  let depth = 0;
+  const filteredArgs: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--full") continue;
+    if (args[i] === "--depth" && args[i + 1]) {
+      depth = Number.parseInt(args[++i], 10);
+      continue;
+    }
+    filteredArgs.push(args[i]);
+  }
   const repoDir = resolve(filteredArgs[0] ?? ".");
   const { provider, providerName } = deps.resolveProviderFromCache(repoDir);
 
   await deps.preflightCheck(providerName);
 
   try {
-    const result = await deps.pull({ repoDir, provider, full, onProgress: log });
+    const result = await deps.pull({ repoDir, provider, full, depth, onProgress: log });
     console.log(JSON.stringify(result, null, 2));
   } catch (err) {
     if (err instanceof VfsError) {
@@ -291,12 +306,14 @@ Providers:
 
 Options:
   --cloud-id <id>     Cloud/workspace ID (auto-discovered if omitted)
+  --depth <n>         Max hierarchy depth to clone (1 = root only, 2 = root + children)
   --limit <n>         Max items to fetch (for testing)
   --full              Force full sync instead of incremental
   --create            Create new remote items from local files (push only)
 
 Examples:
   mcx vfs clone confluence FOO ~/atlassian/foo
+  mcx vfs clone confluence FOO ~/atlassian/foo --depth 2
   mcx vfs clone asana 1234567890 ~/asana/my-project
   mcx vfs clone jira FOO ~/jira/foo
   mcx vfs clone github-issues octocat/hello-world ~/github-issues/hello-world


### PR DESCRIPTION
## Summary
- Add `--depth N` flag to `mcx vfs clone` and `mcx vfs pull` that limits cloning to N levels of page hierarchy (depth 1 = root only, depth 2 = root + children)
- Pages beyond the depth limit are written as stubs with frontmatter metadata preserved and `stub: true` marker
- Pull without `--depth` on a shallow clone automatically deepens it (fetches all pages); pull with `--depth N` respects the limit
- Cache schema extended with `is_stub` column and depth stored in scope metadata for pull compatibility

## Test plan
- [x] `computeDepth` unit tests: root pages, children, grandchildren, orphans, cycle protection
- [x] Clone integration tests: depth 1 (root only + stubs), depth 2 (root + children), depth 0 (unlimited), depth stored in scope meta
- [x] VFS command flag parsing tests: `--depth` forwarded correctly for both clone and pull
- [x] All existing tests pass (4384 tests, 0 failures)
- [x] Typecheck passes
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)