### PR TITLE
fix(spawn): refuse to spawn against stale daemon (fixes #1218)

### DIFF
--- a/packages/command/src/commands/agent.spec.ts
+++ b/packages/command/src/commands/agent.spec.ts
@@ -1447,6 +1447,38 @@ describe("agent ls stale daemon warning", () => {
   });
 });
 
+// ── spawn refuses against stale daemon (#1218) ──
+
+describe("agent spawn with stale daemon", () => {
+  test("refuses to spawn and does not call tool", async () => {
+    const callTool = mock(async () => toolResult({ sessionId: "s1" }));
+    const deps = makeDeps({
+      callTool,
+      getStaleDaemonWarning: mock(() => "Daemon is running a different build..."),
+    });
+    await expect(cmdAgent(["codex", "spawn", "--task", "x"], deps)).rejects.toThrow(ExitError);
+    expect(callTool).not.toHaveBeenCalled();
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("different build"));
+  });
+
+  test("allows spawn when daemon is fresh", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult({ sessionId: "s1" })),
+      getStaleDaemonWarning: mock(() => null),
+    });
+    await cmdAgent(["codex", "spawn", "--task", "x"], deps);
+    expect(deps.callTool).toHaveBeenCalled();
+  });
+
+  test("--headed spawn is not blocked by stale daemon (no daemon needed)", async () => {
+    const deps = makeDeps({
+      getStaleDaemonWarning: mock(() => "Daemon stale"),
+    });
+    await cmdAgent(["claude", "spawn", "--task", "x", "--headed"], deps);
+    expect(deps.ttyOpen).toHaveBeenCalled();
+  });
+});
+
 // ── Worktree spawn (passthrough path) ──
 
 describe("agent spawn with worktree passthrough", () => {

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -427,6 +427,13 @@ async function agentSpawn(
     return;
   }
 
+  // Refuse to spawn against a stale daemon — sessions would land in `disconnected` (#1218).
+  const staleWarning = d.getStaleDaemonWarning();
+  if (staleWarning) {
+    d.printError(staleWarning);
+    d.exit(1);
+  }
+
   const P = provider.toolPrefix;
   const toolArgs: Record<string, unknown> = {
     prompt: parsed.task ?? "Continue from where you left off.",

--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -41,6 +41,7 @@ function makeDeps(overrides?: Partial<ClaudeDeps>): ClaudeDeps {
     exec: mock(() => ({ stdout: "", stderr: "", exitCode: 0 })),
     ttyOpen: mock(async () => {}),
     getGitRoot: mock(() => null),
+    getStaleDaemonWarning: mock(() => null),
     ...overrides,
   };
 }
@@ -668,6 +669,17 @@ describe("mcx claude spawn", () => {
     const deps = makeDeps();
     await expect(cmdClaude(["spawn"], deps)).rejects.toThrow(ExitError);
     expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("Usage"));
+  });
+
+  test("refuses to spawn when daemon is stale (#1218)", async () => {
+    const callTool = mock(async () => toolResult({ sessionId: "abc" }));
+    const deps = makeDeps({
+      callTool,
+      getStaleDaemonWarning: mock(() => "Daemon is running a different build..."),
+    });
+    await expect(cmdClaude(["spawn", "--task", "fix"], deps)).rejects.toThrow(ExitError);
+    expect(callTool).not.toHaveBeenCalled();
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("different build"));
   });
 });
 

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -63,6 +63,8 @@ export interface ClaudeDeps extends SharedSessionDeps {
   ttyOpen: (args: string[]) => Promise<void>;
   /** Resolve the git repo root for the current working directory. Returns null if not in a git repo. */
   getGitRoot: () => string | null;
+  /** Return a warning string if the running daemon is a stale build, null otherwise. */
+  getStaleDaemonWarning: () => string | null;
 }
 
 /**
@@ -177,6 +179,7 @@ export const defaultDeps: ClaudeDeps = {
   },
   ttyOpen: (args) => ttyOpen(args),
   getGitRoot,
+  getStaleDaemonWarning,
 };
 
 // ── Entry point ──
@@ -361,6 +364,13 @@ async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
   if (parsed.headed) {
     await claudeSpawnHeaded(parsed, d);
     return;
+  }
+
+  // Refuse to spawn against a stale daemon — sessions would land in `disconnected` (#1218).
+  const staleWarning = d.getStaleDaemonWarning();
+  if (staleWarning) {
+    d.printError(staleWarning);
+    d.exit(1);
   }
 
   const toolArgs: Record<string, unknown> = {
@@ -866,7 +876,7 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
     }
   }
 
-  const staleWarning = getStaleDaemonWarning();
+  const staleWarning = d.getStaleDaemonWarning();
   if (staleWarning) {
     console.error(`\n⚠ ${staleWarning}`);
   }


### PR DESCRIPTION
## Summary
- `mcx claude spawn` / `mcx agent <provider> spawn` now fail fast with the existing stale-daemon warning instead of silently creating sessions that immediately land in `disconnected` state.
- Check is routed through the existing `getStaleDaemonWarning()` dep (already used by `ls`). No new IPC calls.
- `--headed` spawn is exempted — it runs the provider CLI directly and doesn't depend on mcpd's build.

## Test plan
- [x] `bun typecheck`
- [x] `bun lint`
- [x] `bun test` — 4564 pass
- [x] New unit tests cover: refusal when stale, pass-through when fresh, headed-exempt

Fixes #1218.