### PR TITLE
feat(clone): fast-import stream writer for git-remote-mcx (fixes #1211)

### DIFF
--- a/packages/clone/src/engine/fast-import-writer.spec.ts
+++ b/packages/clone/src/engine/fast-import-writer.spec.ts
@@ -107,6 +107,135 @@ describe("generateFastImport", () => {
     expect(stream).toContain("committer Alice <alice@example.com> 1700000000 +0000\n");
   });
 
+  test("paths with special characters are C-quoted", () => {
+    const { stream } = generateFastImport({
+      entries: [
+        { path: 'weird"name.md', content: "x" },
+        { path: "with\nnewline.md", content: "y" },
+        { path: "with\ttab.md", content: "z" },
+        { path: "back\\slash.md", content: "w" },
+      ],
+      ref: "refs/heads/main",
+      message: "m",
+    });
+    expect(stream).toContain('M 100644 :1 "weird\\"name.md"\n');
+    expect(stream).toContain('M 100644 :2 "with\\nnewline.md"\n');
+    expect(stream).toContain('M 100644 :3 "with\\ttab.md"\n');
+    expect(stream).toContain('M 100644 :4 "back\\\\slash.md"\n');
+  });
+
+  test("paths with spaces pass through unquoted (spec allows it)", () => {
+    const { stream } = generateFastImport({
+      entries: [{ path: "my file.md", content: "x" }],
+      ref: "refs/heads/main",
+      message: "m",
+    });
+    expect(stream).toContain("M 100644 :1 my file.md\n");
+  });
+
+  test("paths starting with double-quote are quoted", () => {
+    const { stream } = generateFastImport({
+      entries: [{ path: '"leading.md', content: "x" }],
+      ref: "refs/heads/main",
+      message: "m",
+    });
+    expect(stream).toContain('M 100644 :1 "\\"leading.md"\n');
+  });
+
+  test("empty entries + parent throws (would wipe branch)", () => {
+    expect(() =>
+      generateFastImport({
+        entries: [],
+        ref: "refs/heads/main",
+        message: "m",
+        parent: ":5",
+      }),
+    ).toThrow(/branch-wiping/);
+  });
+
+  test("empty entries without parent is allowed (initial empty commit is fine to skip guard)", () => {
+    // No parent means this is just an orphan commit on a ref with no blobs —
+    // not the branch-wiping case. Should not throw.
+    const { stream } = generateFastImport({
+      entries: [],
+      ref: "refs/heads/main",
+      message: "m",
+    });
+    expect(stream).toContain("commit refs/heads/main\n");
+  });
+
+  test("commitMark colliding with blob range throws", () => {
+    expect(() =>
+      generateFastImport({
+        entries: [
+          { path: "a", content: "A" },
+          { path: "b", content: "B" },
+        ],
+        ref: "refs/heads/main",
+        message: "m",
+        startMark: 1,
+        commitMark: 1,
+      }),
+    ).toThrow(/collides/);
+  });
+
+  test("commitMark outside blob range is accepted", () => {
+    const { commitMark } = generateFastImport({
+      entries: [{ path: "a", content: "A" }],
+      ref: "refs/heads/main",
+      message: "m",
+      startMark: 1,
+      commitMark: 99,
+    });
+    expect(commitMark).toBe(99);
+  });
+
+  test("round-trip: path with space survives git fast-import", () => {
+    const gitOk = spawnSync("git", ["--version"]).status === 0;
+    if (!gitOk) return;
+
+    const dir = mkdtempSync(join(tmpdir(), "mcx-fast-import-sp-"));
+    try {
+      spawnSync("git", ["init", "--bare", "--initial-branch=main", dir], { stdio: "ignore" });
+      const { stream } = generateFastImport({
+        entries: [{ path: "my file.md", content: "hi\n" }],
+        ref: "refs/heads/main",
+        message: "m",
+        timestamp: 1700000000,
+      });
+      const r = spawnSync("git", ["-C", dir, "fast-import"], { input: stream });
+      expect(r.status).toBe(0);
+      const show = spawnSync("git", ["-C", dir, "show", "refs/heads/main:my file.md"]);
+      expect(show.status).toBe(0);
+      expect(show.stdout.toString()).toBe("hi\n");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("round-trip: quoted path with double-quote survives git fast-import", () => {
+    const gitOk = spawnSync("git", ["--version"]).status === 0;
+    if (!gitOk) return;
+
+    const dir = mkdtempSync(join(tmpdir(), "mcx-fast-import-q-"));
+    try {
+      spawnSync("git", ["init", "--bare", "--initial-branch=main", dir], { stdio: "ignore" });
+      const { stream } = generateFastImport({
+        entries: [{ path: 'weird"name.md', content: "ok\n" }],
+        ref: "refs/heads/main",
+        message: "m",
+        timestamp: 1700000000,
+      });
+      const r = spawnSync("git", ["-C", dir, "fast-import"], { input: stream });
+      expect(r.status).toBe(0);
+      const show = spawnSync("git", ["-C", dir, "show", 'refs/heads/main:weird"name.md']);
+      expect(show.status).toBe(0);
+      expect(show.stdout.toString()).toBe("ok\n");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("round-trip: git fast-import reproduces the commit and content", () => {
     const gitOk = spawnSync("git", ["--version"]).status === 0;
     if (!gitOk) return;

--- a/packages/clone/src/engine/fast-import-writer.spec.ts
+++ b/packages/clone/src/engine/fast-import-writer.spec.ts
@@ -1,0 +1,218 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { formatMarksFile, generateFastImport, parseMarksFile } from "./fast-import-writer";
+
+describe("generateFastImport", () => {
+  test("single file produces a well-formed blob + commit", () => {
+    const { stream, marks, commitMark } = generateFastImport({
+      entries: [{ path: "README.md", content: "hello\n" }],
+      ref: "refs/heads/main",
+      message: "init",
+    });
+
+    expect(marks).toEqual({ "README.md": 1 });
+    expect(commitMark).toBe(2);
+    expect(stream).toContain("blob\nmark :1\ndata 6\nhello\n\n");
+    expect(stream).toContain("commit refs/heads/main\n");
+    expect(stream).toContain("mark :2\n");
+    expect(stream).toContain("committer mcx <mcx@local> 0 +0000\n");
+    expect(stream).toContain("data 4\ninit\n");
+    expect(stream).toContain("M 100644 :1 README.md\n");
+    expect(stream.endsWith("done\n")).toBe(true);
+  });
+
+  test("nested directory paths are preserved verbatim", () => {
+    const { stream, marks } = generateFastImport({
+      entries: [
+        { path: "Engineering/Runbooks/Deployment.md", content: "a" },
+        { path: "Product/Roadmap.md", content: "b" },
+      ],
+      ref: "refs/heads/main",
+      message: "seed",
+    });
+
+    expect(marks["Engineering/Runbooks/Deployment.md"]).toBe(1);
+    expect(marks["Product/Roadmap.md"]).toBe(2);
+    expect(stream).toContain("M 100644 :1 Engineering/Runbooks/Deployment.md\n");
+    expect(stream).toContain("M 100644 :2 Product/Roadmap.md\n");
+  });
+
+  test("empty content emits `data 0`", () => {
+    const { stream } = generateFastImport({
+      entries: [{ path: "empty.md", content: "" }],
+      ref: "refs/heads/main",
+      message: "e",
+    });
+    expect(stream).toContain("blob\nmark :1\ndata 0\n\n");
+  });
+
+  test("byte length is computed in UTF-8 bytes, not codepoints", () => {
+    // "é" is 2 bytes in UTF-8, 1 JS string unit.
+    const content = "é";
+    const { stream } = generateFastImport({
+      entries: [{ path: "fr.md", content }],
+      ref: "refs/heads/main",
+      message: "m",
+    });
+    expect(stream).toContain("data 2\né\n");
+  });
+
+  test("startMark shifts numbering for incremental imports", () => {
+    const { marks, commitMark } = generateFastImport({
+      entries: [
+        { path: "a", content: "A" },
+        { path: "b", content: "B" },
+      ],
+      ref: "refs/heads/main",
+      message: "m",
+      startMark: 100,
+    });
+    expect(marks).toEqual({ a: 100, b: 101 });
+    expect(commitMark).toBe(102);
+  });
+
+  test("parent triggers a `from` line and `deleteall` for full-tree semantics", () => {
+    const { stream } = generateFastImport({
+      entries: [{ path: "x", content: "x" }],
+      ref: "refs/heads/main",
+      message: "m",
+      parent: ":50",
+    });
+    expect(stream).toContain("from :50\n");
+    expect(stream).toContain("deleteall\n");
+  });
+
+  test("no parent means no `from` or `deleteall`", () => {
+    const { stream } = generateFastImport({
+      entries: [{ path: "x", content: "x" }],
+      ref: "refs/heads/main",
+      message: "m",
+    });
+    expect(stream).not.toContain("from ");
+    expect(stream).not.toContain("deleteall");
+  });
+
+  test("custom committer identity and timestamp", () => {
+    const { stream } = generateFastImport({
+      entries: [{ path: "x", content: "x" }],
+      ref: "refs/heads/main",
+      message: "m",
+      committerName: "Alice",
+      committerEmail: "alice@example.com",
+      timestamp: 1700000000,
+    });
+    expect(stream).toContain("committer Alice <alice@example.com> 1700000000 +0000\n");
+  });
+
+  test("round-trip: git fast-import reproduces the commit and content", () => {
+    const gitOk = spawnSync("git", ["--version"]).status === 0;
+    if (!gitOk) return;
+
+    const dir = mkdtempSync(join(tmpdir(), "mcx-fast-import-"));
+    try {
+      spawnSync("git", ["init", "--bare", "--initial-branch=main", dir], { stdio: "ignore" });
+
+      const { stream } = generateFastImport({
+        entries: [
+          { path: "README.md", content: "# hello\n" },
+          { path: "docs/guide.md", content: "body with é and 🙂\n" },
+        ],
+        ref: "refs/heads/main",
+        message: "import\n",
+        timestamp: 1700000000,
+      });
+
+      const streamPath = join(dir, "stream");
+      writeFileSync(streamPath, stream);
+
+      const importRes = spawnSync("git", ["-C", dir, "fast-import"], { input: stream });
+      expect(importRes.status).toBe(0);
+
+      const log = spawnSync("git", ["-C", dir, "log", "--format=%s", "refs/heads/main"]);
+      expect(log.status).toBe(0);
+      expect(log.stdout.toString().trim()).toBe("import");
+
+      const show = spawnSync("git", ["-C", dir, "show", "refs/heads/main:docs/guide.md"]);
+      expect(show.status).toBe(0);
+      expect(show.stdout.toString()).toBe("body with é and 🙂\n");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("round-trip with parent: two commits build on each other", () => {
+    const gitOk = spawnSync("git", ["--version"]).status === 0;
+    if (!gitOk) return;
+
+    const dir = mkdtempSync(join(tmpdir(), "mcx-fast-import-p-"));
+    const marksOut = join(dir, "marks");
+    try {
+      spawnSync("git", ["init", "--bare", "--initial-branch=main", dir], { stdio: "ignore" });
+
+      const first = generateFastImport({
+        entries: [{ path: "a.md", content: "one\n" }],
+        ref: "refs/heads/main",
+        message: "first",
+        timestamp: 1700000000,
+      });
+      const r1 = spawnSync("git", ["-C", dir, "fast-import", `--export-marks=${marksOut}`], {
+        input: first.stream,
+      });
+      expect(r1.status).toBe(0);
+
+      const loaded = parseMarksFile(readFileSync(marksOut, "utf8"));
+      expect(loaded.size).toBe(2);
+
+      const second = generateFastImport({
+        entries: [{ path: "a.md", content: "two\n" }],
+        ref: "refs/heads/main",
+        message: "second",
+        parent: `:${first.commitMark}`,
+        startMark: first.commitMark + 1,
+        timestamp: 1700000001,
+      });
+      const r2 = spawnSync("git", ["-C", dir, "fast-import", `--import-marks=${marksOut}`], {
+        input: second.stream,
+      });
+      expect(r2.status).toBe(0);
+
+      const log = spawnSync("git", ["-C", dir, "log", "--format=%s", "refs/heads/main"]);
+      expect(log.stdout.toString().trim().split("\n")).toEqual(["second", "first"]);
+
+      const show = spawnSync("git", ["-C", dir, "show", "refs/heads/main:a.md"]);
+      expect(show.stdout.toString()).toBe("two\n");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("marks file parsing", () => {
+  test("parseMarksFile reads `:mark sha` lines", () => {
+    const text = ":1 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n:42 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n";
+    const m = parseMarksFile(text);
+    expect(m.get(1)).toBe("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    expect(m.get(42)).toBe("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+  });
+
+  test("parseMarksFile ignores malformed lines", () => {
+    const m = parseMarksFile("garbage\n:7 short\n:9 cccccccccccccccccccccccccccccccccccccccc\n");
+    expect(m.size).toBe(1);
+    expect(m.get(9)).toBe("cccccccccccccccccccccccccccccccccccccccc");
+  });
+
+  test("formatMarksFile round-trips through parseMarksFile in mark order", () => {
+    const original = new Map<number, string>([
+      [10, "1111111111111111111111111111111111111111"],
+      [2, "2222222222222222222222222222222222222222"],
+    ]);
+    const text = formatMarksFile(original);
+    expect(text.split("\n")[0]).toBe(":2 2222222222222222222222222222222222222222");
+    const parsed = parseMarksFile(text);
+    expect(parsed.get(2)).toBe("2222222222222222222222222222222222222222");
+    expect(parsed.get(10)).toBe("1111111111111111111111111111111111111111");
+  });
+});

--- a/packages/clone/src/engine/fast-import-writer.ts
+++ b/packages/clone/src/engine/fast-import-writer.ts
@@ -1,0 +1,107 @@
+/**
+ * Generate a git fast-import stream from a flat list of entries.
+ *
+ * The stream format is documented at https://git-scm.com/docs/git-fast-import.
+ * For each entry we emit a `blob` command with a mark, then a single `commit`
+ * command that references each blob via its mark in a filemodify (`M`) line.
+ */
+
+export interface FastImportEntry {
+  path: string;
+  content: string;
+}
+
+export interface GenerateFastImportOptions {
+  entries: FastImportEntry[];
+  /** Full ref name, e.g. `refs/heads/main`. */
+  ref: string;
+  /** Commit message body. */
+  message: string;
+  /** Optional parent — either a mark (`:42`) or a 40-char sha1. */
+  parent?: string;
+  /** First mark number to use for blobs. Defaults to 1. */
+  startMark?: number;
+  /** Commit mark number. Defaults to startMark + entries.length. */
+  commitMark?: number;
+  /** Committer identity. Defaults to `mcx <mcx@local>`. */
+  committerName?: string;
+  committerEmail?: string;
+  /** Commit timestamp (unix seconds). Defaults to 0 for deterministic output. */
+  timestamp?: number;
+}
+
+export interface GenerateFastImportResult {
+  /** The fast-import stream as a string. */
+  stream: string;
+  /** Map of path → mark used for its blob. */
+  marks: Record<string, number>;
+  /** The mark used for the commit itself. */
+  commitMark: number;
+}
+
+/**
+ * Generate a fast-import stream. Pure function — same inputs produce the same output.
+ */
+export function generateFastImport(opts: GenerateFastImportOptions): GenerateFastImportResult {
+  const startMark = opts.startMark ?? 1;
+  const committerName = opts.committerName ?? "mcx";
+  const committerEmail = opts.committerEmail ?? "mcx@local";
+  const timestamp = opts.timestamp ?? 0;
+  const encoder = new TextEncoder();
+
+  const parts: string[] = [];
+  const marks: Record<string, number> = {};
+
+  opts.entries.forEach((entry, i) => {
+    const mark = startMark + i;
+    marks[entry.path] = mark;
+    const byteLen = encoder.encode(entry.content).length;
+    parts.push(`blob\nmark :${mark}\ndata ${byteLen}\n${entry.content}\n`);
+  });
+
+  const commitMark = opts.commitMark ?? startMark + opts.entries.length;
+  const messageBytes = encoder.encode(opts.message).length;
+
+  let commit = "";
+  commit += `commit ${opts.ref}\n`;
+  commit += `mark :${commitMark}\n`;
+  commit += `committer ${committerName} <${committerEmail}> ${timestamp} +0000\n`;
+  commit += `data ${messageBytes}\n${opts.message}\n`;
+  if (opts.parent) {
+    commit += `from ${opts.parent}\n`;
+    // Reset the tree so only the listed entries survive — callers that want
+    // incremental updates should pass their own M/D lines via a different API.
+    commit += "deleteall\n";
+  }
+  for (const entry of opts.entries) {
+    const mark = marks[entry.path];
+    commit += `M 100644 :${mark} ${entry.path}\n`;
+  }
+  commit += "\n";
+  parts.push(commit);
+  parts.push("done\n");
+
+  return { stream: parts.join(""), marks, commitMark };
+}
+
+/**
+ * Parse a marks file (`:<mark> <sha1>` per line) into a Map.
+ * Lines that don't match the format are ignored.
+ */
+export function parseMarksFile(text: string): Map<number, string> {
+  const out = new Map<number, string>();
+  for (const line of text.split("\n")) {
+    const m = line.match(/^:(\d+)\s+([0-9a-f]{40})$/);
+    if (m) out.set(Number.parseInt(m[1], 10), m[2]);
+  }
+  return out;
+}
+
+/** Serialize a marks map back to the on-disk format. */
+export function formatMarksFile(marks: Map<number, string>): string {
+  const lines: string[] = [];
+  for (const [mark, sha] of Array.from(marks.entries()).sort((a, b) => a[0] - b[0])) {
+    lines.push(`:${mark} ${sha}`);
+  }
+  return `${lines.join("\n")}\n`;
+}

--- a/packages/clone/src/engine/fast-import-writer.ts
+++ b/packages/clone/src/engine/fast-import-writer.ts
@@ -40,6 +40,30 @@ export interface GenerateFastImportResult {
 }
 
 /**
+ * C-quote a path per the fast-import spec. Paths containing control characters,
+ * backslashes, or double quotes — or paths starting with `"` — must be quoted.
+ * Regular paths (including those with spaces) pass through unchanged.
+ */
+function quoteFastImportPath(path: string): string {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: matching control chars is the point
+  const needsQuoting = /[\x00-\x1f"\\]/.test(path) || path.startsWith('"');
+  if (!needsQuoting) return path;
+  let out = '"';
+  for (let i = 0; i < path.length; i++) {
+    const ch = path[i];
+    const code = path.charCodeAt(i);
+    if (ch === '"') out += '\\"';
+    else if (ch === "\\") out += "\\\\";
+    else if (ch === "\n") out += "\\n";
+    else if (ch === "\r") out += "\\r";
+    else if (ch === "\t") out += "\\t";
+    else if (code < 0x20) out += `\\${code.toString(8).padStart(3, "0")}`;
+    else out += ch;
+  }
+  return `${out}"`;
+}
+
+/**
  * Generate a fast-import stream. Pure function — same inputs produce the same output.
  */
 export function generateFastImport(opts: GenerateFastImportOptions): GenerateFastImportResult {
@@ -48,6 +72,23 @@ export function generateFastImport(opts: GenerateFastImportOptions): GenerateFas
   const committerEmail = opts.committerEmail ?? "mcx@local";
   const timestamp = opts.timestamp ?? 0;
   const encoder = new TextEncoder();
+
+  // Guard: empty entries + parent would emit `deleteall` with no M lines,
+  // silently replacing the branch tip with an empty tree.
+  if (opts.entries.length === 0 && opts.parent) {
+    throw new Error("generateFastImport: refusing to emit branch-wiping commit (entries is empty but parent is set)");
+  }
+
+  const resolvedCommitMark = opts.commitMark ?? startMark + opts.entries.length;
+  // Guard: caller-supplied commitMark must not overlap the blob mark range.
+  if (opts.commitMark !== undefined && opts.entries.length > 0) {
+    const lastBlobMark = startMark + opts.entries.length - 1;
+    if (opts.commitMark >= startMark && opts.commitMark <= lastBlobMark) {
+      throw new Error(
+        `generateFastImport: commitMark ${opts.commitMark} collides with blob mark range :${startMark}..:${lastBlobMark}`,
+      );
+    }
+  }
 
   const parts: string[] = [];
   const marks: Record<string, number> = {};
@@ -59,12 +100,11 @@ export function generateFastImport(opts: GenerateFastImportOptions): GenerateFas
     parts.push(`blob\nmark :${mark}\ndata ${byteLen}\n${entry.content}\n`);
   });
 
-  const commitMark = opts.commitMark ?? startMark + opts.entries.length;
   const messageBytes = encoder.encode(opts.message).length;
 
   let commit = "";
   commit += `commit ${opts.ref}\n`;
-  commit += `mark :${commitMark}\n`;
+  commit += `mark :${resolvedCommitMark}\n`;
   commit += `committer ${committerName} <${committerEmail}> ${timestamp} +0000\n`;
   commit += `data ${messageBytes}\n${opts.message}\n`;
   if (opts.parent) {
@@ -75,13 +115,13 @@ export function generateFastImport(opts: GenerateFastImportOptions): GenerateFas
   }
   for (const entry of opts.entries) {
     const mark = marks[entry.path];
-    commit += `M 100644 :${mark} ${entry.path}\n`;
+    commit += `M 100644 :${mark} ${quoteFastImportPath(entry.path)}\n`;
   }
   commit += "\n";
   parts.push(commit);
   parts.push("done\n");
 
-  return { stream: parts.join(""), marks, commitMark };
+  return { stream: parts.join(""), marks, commitMark: resolvedCommitMark };
 }
 
 /**

--- a/packages/clone/src/engine/pull.spec.ts
+++ b/packages/clone/src/engine/pull.spec.ts
@@ -451,7 +451,7 @@ describe("pull", () => {
         join(repoDir, "Root/Child.md"),
         injectFrontmatter("> **Shallow clone stub**", { id: "c1", stub: true }),
       );
-      execSync("git add -A && git commit -m 'shallow clone'", { cwd: repoDir, stdio: "pipe" });
+      execSync("git add -A && git commit -m 'shallow clone'", { cwd: repoDir, stdio: "pipe", env: cleanEnv() });
       cache.close();
 
       const provider = hierarchyProvider(entries);
@@ -470,7 +470,7 @@ describe("pull", () => {
       cache.saveScopeMeta("test", scopeWithDepth);
       cache.upsert("test", scopeWithDepth, makeEntry({ id: "r1", title: "Root", version: 1 }), "Root.md", "h1");
       writeFileSync(join(repoDir, "Root.md"), injectFrontmatter("# Root", { id: "r1" }));
-      execSync("git add -A && git commit -m 'seed'", { cwd: repoDir, stdio: "pipe" });
+      execSync("git add -A && git commit -m 'seed'", { cwd: repoDir, stdio: "pipe", env: cleanEnv() });
       cache.updateLastSynced("test", "TEST");
       cache.close();
 


### PR DESCRIPTION
## Summary
- Adds `generateFastImport()` — pure function turning `{path, content}[]` into a git fast-import stream, ready for the upcoming `git-remote-mcx` import handler (#1209).
- Adds `parseMarksFile` / `formatMarksFile` helpers for incremental sync — writes `:<mark> <sha1>` per line, round-trips via `git fast-import --import-marks/--export-marks`.
- Good-neighbor fix for #1256 — two `git commit` calls in `pull.spec.ts` were missing `env: cleanEnv()`, leaking commits into the parent repo when the suite ran under a pre-commit hook.

## Test plan
- [x] `bun test packages/clone` — 274 pass (including 13 new tests)
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] Round-trip test: generate stream → pipe to real `git fast-import` → `git log` / `git show` verify commit message + file contents, including UTF-8 and emoji.
- [x] Parent-commit round-trip: two imports on the same bare repo, second carrying `--import-marks` from the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)