### PR TITLE
fix(command): record repoRoot on native worktree spawn (fixes #1243)

### DIFF
--- a/packages/command/src/commands/agent.spec.ts
+++ b/packages/command/src/commands/agent.spec.ts
@@ -1458,6 +1458,34 @@ describe("agent spawn with worktree passthrough", () => {
     await cmdAgent(["codex", "spawn", "--task", "x", "--worktree", "my-branch"], deps);
     expect(deps.callTool).toHaveBeenCalledWith("codex_prompt", expect.objectContaining({ worktree: "my-branch" }));
   });
+
+  test("records repoRoot on native worktree path (#1243)", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult({ sessionId: "s1" })),
+      getGitRoot: mock(() => "/real/repo"),
+      getCwd: mock(() => "/real/repo/.claude/worktrees/something"),
+      exec: mock(() => ({ stdout: "", stderr: "", exitCode: 0 })),
+    });
+    await cmdAgent(["codex", "spawn", "--task", "x", "--worktree", "my-branch"], deps);
+    expect(deps.callTool).toHaveBeenCalledWith(
+      "codex_prompt",
+      expect.objectContaining({ worktree: "my-branch", repoRoot: "/real/repo" }),
+    );
+  });
+
+  test("falls back to cwd when getGitRoot returns null", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult({ sessionId: "s1" })),
+      getGitRoot: mock(() => null),
+      getCwd: mock(() => "/fallback/cwd"),
+      exec: mock(() => ({ stdout: "", stderr: "", exitCode: 0 })),
+    });
+    await cmdAgent(["codex", "spawn", "--task", "x", "--worktree", "my-branch"], deps);
+    expect(deps.callTool).toHaveBeenCalledWith(
+      "codex_prompt",
+      expect.objectContaining({ worktree: "my-branch", repoRoot: "/fallback/cwd" }),
+    );
+  });
 });
 
 // ── agentSpawnHeaded ──

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -521,7 +521,10 @@ async function agentSpawnHeaded(parsed: AgentSpawnArgs, provider: AgentProvider,
 
 /** Set up a worktree for spawn — shared logic across all providers. */
 function setupWorktree(worktreeName: string, toolArgs: Record<string, unknown>, d: AgentDeps): void {
-  const repoRoot = d.getCwd();
+  // Prefer getGitRoot() over getCwd(): it resolves to the main repo even when
+  // invoked from a worktree, and works when core.bare=true is set on the
+  // ambient repo (see #1243, #1206).
+  const repoRoot = d.getGitRoot() ?? d.getCwd();
   const wtConfig = readWorktreeConfig(repoRoot);
 
   if (hasWorktreeHooks(wtConfig)) {
@@ -552,7 +555,11 @@ function setupWorktree(worktreeName: string, toolArgs: Record<string, unknown>, 
     toolArgs.repoRoot = repoRoot;
     d.printError(`Created worktree: ${worktreePath}`);
   } else {
+    // Native worktree path (provider creates the worktree itself). We still
+    // record repoRoot so session scoping, hook lookup at teardown, and
+    // cross-repo filters work correctly (#1243).
     toolArgs.worktree = worktreeName;
+    toolArgs.repoRoot = repoRoot;
   }
 }
 

--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -870,6 +870,23 @@ describe("mcx claude spawn --worktree branchPrefix", () => {
     }
   });
 
+  test("--worktree uses getGitRoot for repoRoot (#1243)", async () => {
+    const exec = mock(() => ({ stdout: "", stderr: "", exitCode: 0 }));
+    const callTool = mock(async () => toolResult({ sessionId: "s1" }));
+    const getGitRoot = mock(() => "/resolved/repo/root");
+    const deps = makeDeps({ exec, callTool, getGitRoot });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["spawn", "--task", "x", "--worktree", "my-feat"], deps);
+      const toolCalls = callTool.mock.calls as unknown as Array<[string, Record<string, unknown>]>;
+      expect(toolCalls[0][1].repoRoot).toBe("/resolved/repo/root");
+    } finally {
+      console.log = origLog;
+    }
+  });
+
   test("cleans up worktree when IPC callTool fails (#1116)", async () => {
     const exec = mock(() => ({ stdout: "", stderr: "", exitCode: 0 }));
     const callTool = mock(async () => {

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -380,7 +380,10 @@ async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
   let worktreeResult: { path: string } | undefined;
   if (parsed.worktree) {
     try {
-      const wt = createWorktree({ name: parsed.worktree, repoRoot: process.cwd(), branchPrefix: "claude/" }, d);
+      // Prefer getGitRoot() so repoRoot resolves to the main repo even when
+      // invoked from a worktree or when core.bare=true is set (#1243).
+      const repoRoot = d.getGitRoot() ?? process.cwd();
+      const wt = createWorktree({ name: parsed.worktree, repoRoot, branchPrefix: "claude/" }, d);
       Object.assign(toolArgs, wt.toolArgs);
       worktreeResult = wt;
     } catch (e) {
@@ -420,7 +423,8 @@ async function claudeSpawnHeaded(parsed: SpawnArgs, d: ClaudeDeps): Promise<void
   let cwd = parsed.cwd;
   if (parsed.worktree) {
     try {
-      const result = createWorktree({ name: parsed.worktree, repoRoot: process.cwd(), branchPrefix: "headed/" }, d);
+      const repoRoot = d.getGitRoot() ?? process.cwd();
+      const result = createWorktree({ name: parsed.worktree, repoRoot, branchPrefix: "headed/" }, d);
       cwd = result.path;
     } catch (e) {
       d.printError(e instanceof WorktreeError ? e.message : String(e));


### PR DESCRIPTION
## Summary
- `agent.ts:setupWorktree` native path now sets `toolArgs.repoRoot` — previously it only set `worktree`, causing the daemon to persist `repoRoot: null` for sessions spawned via `mcx agent claude spawn --worktree` (or any provider's native worktree path).
- `claude.ts` worktree spawn paths now resolve `repoRoot` via `getGitRoot()` (which uses `--git-common-dir` and survives `core.bare=true`), falling back to `process.cwd()`. This fixes the mis-resolution when invoked from inside a worktree and when #1206's recurrence flips `core.bare=true`.

## Test plan
- [x] New unit test: native worktree path records `repoRoot` from `getGitRoot()` (`agent.spec.ts`)
- [x] New unit test: native path falls back to `getCwd()` when `getGitRoot()` returns null
- [x] New unit test: `claude spawn --worktree` passes resolved `getGitRoot()` as `repoRoot` (`claude.spec.ts`)
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — 4563/4563 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)