### PR TITLE
fix(daemon): scope null-repoRoot sessions by cwd prefix (fixes #1242)

### DIFF
--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -932,7 +932,12 @@ async function agentWait(
       sessions: Array<Record<string, unknown>>;
     };
     if (repoFilter) {
-      unified.sessions = unified.sessions.filter((s) => !s.repoRoot || s.repoRoot === repoFilter);
+      unified.sessions = unified.sessions.filter((s) => {
+        if (s.repoRoot) return s.repoRoot === repoFilter;
+        // Legacy sessions without repoRoot: fall back to cwd prefix match (fixes #1242)
+        const cwd = typeof s.cwd === "string" ? s.cwd : null;
+        return cwd !== null && (cwd === repoFilter || cwd.startsWith(`${repoFilter}/`));
+      });
       if (unified.event?.session) {
         const eventRepo = (unified.event.session as Record<string, unknown>).repoRoot;
         if (eventRepo && eventRepo !== repoFilter) {

--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -1256,7 +1256,8 @@ describe("mcx claude ls", () => {
     console.log = logSpy;
     try {
       await cmdClaude(["ls"], deps);
-      // Header + 2 sessions (null repoRoot passes through)
+      // Header + 2 sessions — ls relies on daemon-side filtering and
+      // renders whatever the daemon returns.
       expect(logSpy.mock.calls.length).toBe(3);
     } finally {
       console.log = origLog;

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -1501,7 +1501,12 @@ async function claudeWait(args: string[], d: ClaudeDeps): Promise<void> {
       sessions: Array<Record<string, unknown>>;
     };
     if (repoFilter) {
-      unified.sessions = unified.sessions.filter((s) => !s.repoRoot || s.repoRoot === repoFilter);
+      unified.sessions = unified.sessions.filter((s) => {
+        if (s.repoRoot) return s.repoRoot === repoFilter;
+        // Legacy sessions without repoRoot: fall back to cwd prefix match (fixes #1242)
+        const cwd = typeof s.cwd === "string" ? s.cwd : null;
+        return cwd !== null && (cwd === repoFilter || cwd.startsWith(`${repoFilter}/`));
+      });
       // Filter event if its session snapshot is from another repo
       if (unified.event?.session) {
         const eventRepo = (unified.event.session as Record<string, unknown>).repoRoot;

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -249,7 +249,12 @@ function handleSessionList(
     // Scope filter: include sessions whose cwd is under the scope root
     sessions = sessions.filter((s) => s.cwd !== null && (s.cwd === scopeRoot || s.cwd.startsWith(`${scopeRoot}/`)));
   } else if (repoRoot) {
-    sessions = sessions.filter((s) => !s.repoRoot || s.repoRoot === repoRoot);
+    sessions = sessions.filter((s) => {
+      if (s.repoRoot) return s.repoRoot === repoRoot;
+      // Legacy sessions without repoRoot: fall back to cwd prefix match
+      // so they stay scoped to their originating repo (fixes #1242).
+      return s.cwd !== null && (s.cwd === repoRoot || s.cwd.startsWith(`${repoRoot}/`));
+    });
   }
   return { content: [{ type: "text", text: JSON.stringify(sessions, null, 2) }] };
 }

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -2341,10 +2341,7 @@ describe("ClaudeWsServer", () => {
     expect(sessions.filter((s) => predicate(s, "/repo/b")).map((s) => s.sessionId)).toEqual(["healthy-b"]);
 
     // From /repo/a: null-repoRoot session under /repo/a IS included (via cwd).
-    expect(sessions.filter((s) => predicate(s, "/repo/a")).map((s) => s.sessionId)).toEqual([
-      "leaky-a",
-      "healthy-a",
-    ]);
+    expect(sessions.filter((s) => predicate(s, "/repo/a")).map((s) => s.sessionId)).toEqual(["leaky-a", "healthy-a"]);
 
     // Session with null repoRoot AND null cwd is filtered out from every repo.
     expect(sessions.filter((s) => predicate(s, "/repo/c")).map((s) => s.sessionId)).toEqual([]);

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -2305,18 +2305,49 @@ describe("ClaudeWsServer", () => {
 
     server.prepareSession("s1", { prompt: "A", repoRoot: "/repo/a" });
     server.prepareSession("s2", { prompt: "B", repoRoot: "/repo/b" });
-    server.prepareSession("s3", { prompt: "C" }); // no repoRoot
 
     const allSessions = server.listSessions();
-    expect(allSessions).toHaveLength(3);
+    expect(allSessions).toHaveLength(2);
 
     // Apply the same filter predicate used in handleSessionList
     const repoRoot = "/repo/a";
-    const filtered = allSessions.filter((s) => !s.repoRoot || s.repoRoot === repoRoot);
+    const filtered = allSessions.filter((s) => {
+      if (s.repoRoot) return s.repoRoot === repoRoot;
+      return s.cwd !== null && (s.cwd === repoRoot || s.cwd.startsWith(`${repoRoot}/`));
+    });
 
-    // Should include s1 (matching repoRoot) and s3 (no repoRoot), but NOT s2
-    expect(filtered).toHaveLength(2);
-    expect(filtered.map((s) => s.sessionId).sort()).toEqual(["s1", "s3"]);
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]?.sessionId).toBe("s1");
+  });
+
+  test("handleSessionList predicate: null repoRoot falls back to cwd prefix (#1242)", () => {
+    // Mirror the predicate used in handleSessionList. Prior buggy version
+    // (`!s.repoRoot || s.repoRoot === repoRoot`) let null-repoRoot sessions
+    // leak across every repo; the fix scopes them by cwd prefix instead.
+    type S = { sessionId: string; repoRoot: string | null; cwd: string | null };
+    const predicate = (s: S, repoRoot: string) => {
+      if (s.repoRoot) return s.repoRoot === repoRoot;
+      return s.cwd !== null && (s.cwd === repoRoot || s.cwd.startsWith(`${repoRoot}/`));
+    };
+
+    const sessions: S[] = [
+      { sessionId: "leaky-a", repoRoot: null, cwd: "/repo/a/sub" },
+      { sessionId: "healthy-b", repoRoot: "/repo/b", cwd: "/repo/b/sub" },
+      { sessionId: "healthy-a", repoRoot: "/repo/a", cwd: "/repo/a/wt" },
+      { sessionId: "no-cwd", repoRoot: null, cwd: null },
+    ];
+
+    // From /repo/b: null-repoRoot session under /repo/a must NOT leak in.
+    expect(sessions.filter((s) => predicate(s, "/repo/b")).map((s) => s.sessionId)).toEqual(["healthy-b"]);
+
+    // From /repo/a: null-repoRoot session under /repo/a IS included (via cwd).
+    expect(sessions.filter((s) => predicate(s, "/repo/a")).map((s) => s.sessionId)).toEqual([
+      "leaky-a",
+      "healthy-a",
+    ]);
+
+    // Session with null repoRoot AND null cwd is filtered out from every repo.
+    expect(sessions.filter((s) => predicate(s, "/repo/c")).map((s) => s.sessionId)).toEqual([]);
   });
 
   test("listSessions repoRoot filter: no filter returns all sessions", () => {


### PR DESCRIPTION
## Summary
- Drop the `!s.repoRoot` escape hatch in the daemon session filter: null-repoRoot sessions no longer leak across repos.
- Fall back to **cwd prefix match** when a session has no recorded repoRoot (handles legacy / core.bare=true spawns from #1243).
- Apply the same fix to the two client-side post-filters (`mcx claude wait`, `mcx agent wait`).

## Test plan
- [x] `bun typecheck`
- [x] `bun lint`
- [x] `bun test` (4561 pass, 0 fail; post-suite Bun segfault logged on #1004)
- [x] New ws-server predicate test: null-repoRoot session under `/repo/a` is NOT returned when filtering from `/repo/b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)