### PR TITLE
fix(coverage): remove stale clone.ts/pull.ts exclusions (fixes #1221)

### DIFF
--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -102,10 +102,6 @@ const EXCLUSIONS: Record<string, string> = {
   "command/src/alias-runner.ts": "Virtual module + import(), integration-only (#52)",
   "command/src/output.ts": "Formatting output, low-risk — tracked in #47",
 
-  // Clone engine — requires MCP server connections to test, tracked in #1221
-  "clone/src/engine/clone.ts": "4% coverage, requires live MCP servers (#1221)",
-  "clone/src/engine/pull.ts": "2% in pre-commit (run-2 skipped), 98% in full suite (#1221)",
-
   // Commands below PER_FILE_MIN — tracked in open issues
   "command/src/commands/alias.ts": "5% coverage, tracked in #47",
   "command/src/commands/logs.ts": "19% coverage, tracked in #47",


### PR DESCRIPTION
## Summary
- Tests added in #1183 brought `clone.ts` to 100% line coverage and `pull.ts` to 96.65% — both well above the 80% per-file threshold.
- The exclusions from #1221 are no longer needed.

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun scripts/check-coverage.ts` passes with 28 exclusions (down from 30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)