### PR TITLE
fix(agent): support --keep flag in bye subcommand (fixes #1233)

### DIFF
--- a/packages/command/src/commands/agent.spec.ts
+++ b/packages/command/src/commands/agent.spec.ts
@@ -1153,6 +1153,65 @@ describe("agent bye with worktree", () => {
     await expect(cmdAgent(["codex", "bye"], deps)).rejects.toThrow(ExitError);
     expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("Usage"));
   });
+
+  test("--keep flag before session id is not treated as session prefix", async () => {
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "claude_session_list") return toolResult(SESSION_LIST);
+        return toolResult({
+          ended: true,
+          worktree: "wt-name",
+          cwd: "/repo/.claude/worktrees/wt-name",
+          repoRoot: "/repo",
+        });
+      }),
+      exec: mock(() => ({ stdout: "", stderr: "", exitCode: 0 })),
+    });
+    await cmdAgent(["claude", "bye", "--keep", "abc12345"], deps);
+    expect(deps.callTool).toHaveBeenCalledWith("claude_bye", { sessionId: SESSION_LIST[0].sessionId });
+    // With --keep, cleanupWorktree should not run (no exec of git worktree remove)
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("Worktree preserved"));
+  });
+
+  test("--keep after session id preserves worktree", async () => {
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "claude_session_list") return toolResult(SESSION_LIST);
+        return toolResult({
+          ended: true,
+          worktree: "wt-name",
+          cwd: "/repo/.claude/worktrees/wt-name",
+          repoRoot: "/repo",
+        });
+      }),
+      exec: mock(() => ({ stdout: "", stderr: "", exitCode: 0 })),
+    });
+    await cmdAgent(["claude", "bye", "abc12345", "--keep"], deps);
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("Worktree preserved"));
+    // Ensure cleanupWorktree did not remove the worktree (no git worktree remove exec)
+    const execCalls = (deps.exec as ReturnType<typeof mock>).mock.calls;
+    const removedWorktree = execCalls.some(
+      (call) => Array.isArray(call[1]) && call[1].includes("worktree") && call[1].includes("remove"),
+    );
+    expect(removedWorktree).toBe(false);
+  });
+
+  test("--keep-worktree is a valid alias for --keep", async () => {
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "claude_session_list") return toolResult(SESSION_LIST);
+        return toolResult({
+          ended: true,
+          worktree: "wt-name",
+          cwd: "/repo/.claude/worktrees/wt-name",
+          repoRoot: "/repo",
+        });
+      }),
+      exec: mock(() => ({ stdout: "", stderr: "", exitCode: 0 })),
+    });
+    await cmdAgent(["claude", "bye", "--keep-worktree", "abc12345"], deps);
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("Worktree preserved"));
+  });
 });
 
 // ── Interrupt missing session ──

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -723,10 +723,12 @@ async function agentSend(args: string[], provider: AgentProvider, d: AgentDeps):
 
 async function agentBye(args: string[], provider: AgentProvider, d: AgentDeps): Promise<void> {
   const P = provider.toolPrefix;
-  const sessionPrefix = args[0];
+  const keepWorktree = args.includes("--keep") || args.includes("--keep-worktree");
+  const positional = args.filter((a) => !a.startsWith("-"));
+  const sessionPrefix = positional[0];
 
   if (!sessionPrefix) {
-    d.printError(`Usage: mcx agent ${provider.name} bye <session-id>`);
+    d.printError(`Usage: mcx agent ${provider.name} bye <session-id> [--keep|--keep-worktree]`);
     d.exit(1);
   }
 
@@ -737,7 +739,11 @@ async function agentBye(args: string[], provider: AgentProvider, d: AgentDeps): 
   d.log(formatToolResult(result));
 
   if (byeResult.worktree) {
-    if (byeResult.cwd) {
+    if (keepWorktree) {
+      const wtPath =
+        byeResult.cwd ?? resolveWorktreePath(d.getCwd(), byeResult.worktree, readWorktreeConfig(d.getCwd()));
+      d.printError(`Worktree preserved: ${wtPath}`);
+    } else if (byeResult.cwd) {
       cleanupWorktree(byeResult.worktree, byeResult.cwd, d, byeResult.repoRoot);
     } else if (hasFeature(provider, "resume")) {
       // Claude: daemon-created worktrees have cwd=null — resolve from local repo root
@@ -1455,7 +1461,7 @@ Usage:
   mcx agent ${name} ls [--short] [--json]        List active sessions
   mcx agent ${name} send <session> <message>     Send follow-up prompt
   mcx agent ${name} wait [session]               Block until session event
-  mcx agent ${name} bye <session>                End session
+  mcx agent ${name} bye <session> [--keep]       End session (--keep preserves worktree)
   mcx agent ${name} interrupt <session>          Interrupt current turn
   mcx agent ${name} log <session> [--last N]     View transcript
   mcx agent ${name} resume <worktree>            ${resumeNote}


### PR DESCRIPTION
## Summary
- Filter flags from positional args in `agentBye()` so `--keep` is no longer treated as a session ID prefix
- Port `--keep` / `--keep-worktree` handling from `claude.ts:claudeBye()` to `agent.ts:agentBye()` (the production path)
- Update help text to document the flag

Previously `mcx claude bye --keep <id>` failed with `Error: No session matching "--keep"`, and `mcx claude bye <id> --keep` torn down the worktree anyway because the production path in `agent.ts` lacked `--keep` support entirely.

## Test plan
- [x] Added spec: `--keep` before session id is not parsed as a session prefix
- [x] Added spec: `--keep` after session id preserves the worktree (no `git worktree remove` exec)
- [x] Added spec: `--keep-worktree` works as an alias for `--keep`
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (4563 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)