### PR TITLE
feat(vfs): set mcx:// remote on clone; deprecate vfs push/pull (fixes #1215)

### DIFF
--- a/packages/clone/src/engine/clone.spec.ts
+++ b/packages/clone/src/engine/clone.spec.ts
@@ -157,6 +157,34 @@ describe("clone", () => {
     expect(log).toContain("2 pages");
   });
 
+  test("sets mcx:// remote and upstream tracking on main", async () => {
+    const provider = makeProvider({
+      list: async function* () {
+        yield makeEntry({ id: "p1", title: "Page One", version: 1, content: "body" });
+      },
+    });
+
+    await clone({ targetDir, provider, scope: makeScope("FOO"), onProgress: () => {} });
+
+    const remotes = execSync("git remote -v", { cwd: targetDir, encoding: "utf-8", env: cleanEnv() });
+    expect(remotes).toContain("origin\tmcx://test/FOO (fetch)");
+    expect(remotes).toContain("origin\tmcx://test/FOO (push)");
+
+    const branchRemote = execSync("git config branch.main.remote", {
+      cwd: targetDir,
+      encoding: "utf-8",
+      env: cleanEnv(),
+    }).trim();
+    expect(branchRemote).toBe("origin");
+
+    const branchMerge = execSync("git config branch.main.merge", {
+      cwd: targetDir,
+      encoding: "utf-8",
+      env: cleanEnv(),
+    }).trim();
+    expect(branchMerge).toBe("refs/heads/main");
+  });
+
   test("populates cache with all entries", async () => {
     const entries = [
       makeEntry({ id: "p1", title: "Alpha", version: 1, content: "alpha body" }),

--- a/packages/clone/src/engine/clone.ts
+++ b/packages/clone/src/engine/clone.ts
@@ -248,6 +248,17 @@ export async function clone(opts: CloneOptions): Promise<CloneResult> {
   spawnSync("git", ["commit", "-m", commitMsg, "--allow-empty"], gitOpts);
   log(opts, "  → initial commit created");
 
+  // Wire up the mcx:// remote so standard `git push`/`git pull` work via the
+  // git-remote-mcx helper (see #1209).
+  const remoteUrl = `mcx://${provider.name}/${scope.key}`;
+  spawnSync("git", ["remote", "add", "origin", remoteUrl], gitOpts);
+  // Configure upstream tracking via git config directly — `git branch
+  // --set-upstream-to=origin/main` would fail because we haven't fetched yet
+  // and origin/main doesn't exist locally.
+  spawnSync("git", ["config", "branch.main.remote", "origin"], gitOpts);
+  spawnSync("git", ["config", "branch.main.merge", "refs/heads/main"], gitOpts);
+  log(opts, `  → remote "origin" set to ${remoteUrl}`);
+
   log(opts, `\nDone! Cloned ${includedEntries.length} pages${stubNote} to ${absTarget}`);
 
   return {

--- a/packages/clone/src/engine/pull.spec.ts
+++ b/packages/clone/src/engine/pull.spec.ts
@@ -451,7 +451,7 @@ describe("pull", () => {
         join(repoDir, "Root/Child.md"),
         injectFrontmatter("> **Shallow clone stub**", { id: "c1", stub: true }),
       );
-      execSync("git add -A && git commit -m 'shallow clone'", { cwd: repoDir, stdio: "pipe" });
+      execSync("git add -A && git commit -m 'shallow clone'", { cwd: repoDir, stdio: "pipe", env: cleanEnv() });
       cache.close();
 
       const provider = hierarchyProvider(entries);
@@ -470,7 +470,7 @@ describe("pull", () => {
       cache.saveScopeMeta("test", scopeWithDepth);
       cache.upsert("test", scopeWithDepth, makeEntry({ id: "r1", title: "Root", version: 1 }), "Root.md", "h1");
       writeFileSync(join(repoDir, "Root.md"), injectFrontmatter("# Root", { id: "r1" }));
-      execSync("git add -A && git commit -m 'seed'", { cwd: repoDir, stdio: "pipe" });
+      execSync("git add -A && git commit -m 'seed'", { cwd: repoDir, stdio: "pipe", env: cleanEnv() });
       cache.updateLastSynced("test", "TEST");
       cache.close();
 

--- a/packages/command/src/commands/vfs.spec.ts
+++ b/packages/command/src/commands/vfs.spec.ts
@@ -241,6 +241,36 @@ describe("cmdVfs", () => {
     });
   });
 
+  describe("deprecation warnings", () => {
+    function captureStderr<T>(fn: () => Promise<T>): Promise<{ result: T; stderr: string }> {
+      const orig = process.stderr.write.bind(process.stderr);
+      let captured = "";
+      process.stderr.write = ((chunk: string | Uint8Array) => {
+        captured += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8");
+        return true;
+      }) as typeof process.stderr.write;
+      return fn()
+        .then((result) => ({ result, stderr: captured }))
+        .finally(() => {
+          process.stderr.write = orig;
+        });
+    }
+
+    test("vfs pull warns that it is deprecated", async () => {
+      const deps = makeDeps();
+      const { stderr } = await captureStderr(() => cmdVfs(["pull", "/tmp/repo"], undefined, deps));
+      expect(stderr).toContain('"mcx vfs pull" is deprecated');
+      expect(stderr).toContain('Use "git pull" instead');
+    });
+
+    test("vfs push warns that it is deprecated", async () => {
+      const deps = makeDeps();
+      const { stderr } = await captureStderr(() => cmdVfs(["push", "/tmp/repo"], undefined, deps));
+      expect(stderr).toContain('"mcx vfs push" is deprecated');
+      expect(stderr).toContain('Use "git push" instead');
+    });
+  });
+
   describe("push flags", () => {
     test("--dry-run from opts is forwarded", async () => {
       let capturedDryRun: boolean | undefined;

--- a/packages/command/src/commands/vfs.ts
+++ b/packages/command/src/commands/vfs.ts
@@ -200,6 +200,9 @@ async function vfsClone(args: string[], deps: VfsDeps): Promise<void> {
 }
 
 async function vfsPull(args: string[], deps: VfsDeps): Promise<void> {
+  log(
+    'Warning: "mcx vfs pull" is deprecated. Use "git pull" instead.\n         The command will be removed in a future release.',
+  );
   const full = args.includes("--full");
   let depth = 0;
   const filteredArgs: string[] = [];
@@ -229,6 +232,9 @@ async function vfsPull(args: string[], deps: VfsDeps): Promise<void> {
 }
 
 async function vfsPush(args: string[], dryRun: boolean | undefined, deps: VfsDeps): Promise<void> {
+  log(
+    'Warning: "mcx vfs push" is deprecated. Use "git push" instead.\n         The command will be removed in a future release.',
+  );
   const isCreate = args.includes("--create");
   const filteredArgs = args.filter((a) => a !== "--dry-run" && a !== "--create");
   const isDryRun = dryRun ?? args.includes("--dry-run");


### PR DESCRIPTION
## Summary
- `mcx vfs clone` now wires up `origin mcx://<provider>/<scope>` and configures `main` to track it, so standard `git push`/`git pull` will work once the git-remote-mcx helper (#1209) lands.
- `mcx vfs push` and `mcx vfs pull` still function but emit a deprecation warning on stderr.
- Upstream tracking is set via `git config branch.main.{remote,merge}` directly, since `git branch --set-upstream-to=origin/main` fails pre-fetch (no `origin/main` locally).
- Drive-by: fixes two `execSync` calls in `pull.spec.ts` that leaked test commits to the parent repo under pre-commit (details in #1267).

## Test plan
- [x] `bun typecheck`, `bun lint`, `bun test` (4563 pass)
- [x] New `clone` engine test asserts `git remote -v` shows `origin mcx://test/FOO` and `branch.main.remote/merge` are set.
- [x] New `cmdVfs` tests assert deprecation warning on pull and push stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)