### PR TITLE
fix(work-items): allow impl→qa phase transition (fixes #1227)

### DIFF
--- a/packages/core/src/work-item.spec.ts
+++ b/packages/core/src/work-item.spec.ts
@@ -4,6 +4,7 @@ import { WORK_ITEM_PHASES, type WorkItemPhase, canTransition, createWorkItem, re
 describe("canTransition", () => {
   const allowed: [WorkItemPhase, WorkItemPhase][] = [
     ["impl", "review"],
+    ["impl", "qa"],
     ["impl", "done"],
     ["review", "repair"],
     ["review", "qa"],
@@ -22,7 +23,6 @@ describe("canTransition", () => {
 
   const forbidden: [WorkItemPhase, WorkItemPhase][] = [
     ["impl", "repair"],
-    ["impl", "qa"],
     ["impl", "impl"],
     ["review", "impl"],
     ["review", "review"],
@@ -46,8 +46,8 @@ describe("canTransition", () => {
 });
 
 describe("reachablePhases", () => {
-  it("returns review and done from impl", () => {
-    expect([...reachablePhases("impl")].sort()).toEqual(["done", "review"]);
+  it("returns review, qa, and done from impl", () => {
+    expect([...reachablePhases("impl")].sort()).toEqual(["done", "qa", "review"]);
   });
 
   it("returns nothing from done", () => {

--- a/packages/core/src/work-item.ts
+++ b/packages/core/src/work-item.ts
@@ -57,7 +57,7 @@ export type WorkItemEvent =
  * and any active phase can jump to done (e.g. issue dropped or PR merged).
  */
 const VALID_TRANSITIONS: Record<WorkItemPhase, ReadonlySet<WorkItemPhase>> = {
-  impl: new Set(["review", "done"]),
+  impl: new Set(["review", "qa", "done"]),
   review: new Set(["repair", "qa", "done"]),
   repair: new Set(["review", "done"]),
   qa: new Set(["repair", "done"]),


### PR DESCRIPTION
## Summary
- Add `qa` to the set of phases reachable from `impl` in the work-items phase machine, so low-scrutiny items can skip review as documented.
- Update `work-item.spec.ts` to move `impl → qa` from forbidden to allowed and adjust `reachablePhases("impl")`.

## Test plan
- [x] `bun typecheck`
- [x] `bun lint`
- [x] `bun test` (4567 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)