### PR TITLE
docs(sprint): document session scoping for multi-repo sprints (closes #1240)

### DIFF
--- a/.claude/skills/bootstrap-sprint/references/design.md
+++ b/.claude/skills/bootstrap-sprint/references/design.md
@@ -148,6 +148,21 @@ don't apply (provider routing, ACP), add any project-specific flags or worktree
 hooks. The orchestrator should never have to guess at command syntax — every spawn,
 wait, bye, and ls command should be spelled out with exact flags.
 
+**Always include the "Session Scoping" section** when generating an mcx-claude.md for a
+new project. Session scoping is a non-obvious feature that trips up orchestrators running
+concurrent sprints:
+
+- `mcx claude ls` and `mcx claude wait` filter to the **current repo's git root** by default
+- `--all` bypasses the filter and shows sessions from every repo
+- Registered scopes (`mcx scope init`) take precedence over git root detection
+- All sprint orchestrator commands must be run from within the project root — otherwise
+  sessions appear missing even though they're actively running
+- When two sprints run in parallel across different repos, each orchestrator only sees its
+  own sessions; this is intentional isolation, not a bug
+
+The generated mcx-claude.md should include the "Diagnosing 'missing' sessions" checklist
+so orchestrators can self-diagnose when `mcx claude ls` shows nothing unexpected.
+
 ### The review reference (review.md)
 
 How to wrap up: gather what shipped, record results in the sprint file, extract

--- a/.claude/skills/sprint/references/mcx-claude.md
+++ b/.claude/skills/sprint/references/mcx-claude.md
@@ -79,6 +79,71 @@ mcx acp spawn --agent my-agent --worktree -t "task" --allow Read Glob Grep Write
 Session management commands (ls, send, bye, wait, log, interrupt) use the same
 provider prefix. E.g., `mcx copilot bye <id>`, `mcx gemini wait --timeout 30000`.
 
+## Session Scoping
+
+Sessions are scoped to a repository. `mcx claude ls` (and `mcx claude wait`) filter
+to the current repo by default — you only see sessions that were spawned from within
+the same project. Use `--all` to bypass the filter and see every session across all repos.
+
+### How scoping works
+
+When a session is spawned, the daemon records its `repoRoot` (the git root of the
+spawn directory). When listing or waiting, the CLI sends the current repo's root as a
+filter — the daemon returns only sessions whose `repoRoot` matches.
+
+**Precedence: registered scope > git repo detection**
+
+If you've run `mcx scope init` in a project directory, the registered scope root takes
+precedence over git root detection. This matters when the git root is higher than your
+project root (e.g., a monorepo where you scope to a subdirectory).
+
+```bash
+# Register the current directory as a named scope
+mcx scope init                    # uses directory name as scope name
+mcx scope init my-project         # explicit name
+
+# List registered scopes
+mcx scope ls
+
+# Remove a scope
+mcx scope rm my-project
+```
+
+Scopes are stored as JSON files in `~/.mcp-cli/scopes/`. The most specific match
+(longest root prefix) wins when multiple scopes could match.
+
+### Multi-repo sprint isolation
+
+When running concurrent sprints in different repos, each sprint's orchestrator only
+sees its own sessions by default:
+
+```bash
+# In repo A — sees only repo A sessions
+cd /path/to/repo-a
+mcx claude ls
+
+# In repo B — sees only repo B sessions
+cd /path/to/repo-b
+mcx claude ls
+
+# See all sessions across all repos
+mcx claude ls --all
+```
+
+**Critical:** Sprint orchestrator commands (`mcx claude ls`, `mcx claude wait`, etc.)
+must be run from within the project root. If run from the wrong directory, the filter
+will not match your sessions — they'll appear to be missing when they're actually running.
+
+### Diagnosing "missing" sessions
+
+If `mcx claude ls` shows no sessions but you know sessions should be running:
+
+1. Check `mcx claude ls --all` — if sessions appear, you're in the wrong directory
+2. Verify your current directory is at or inside the project root
+3. Check if a registered scope is expected: `mcx scope ls`
+4. If the git root is wrong (e.g., bare repo or unusual config), register a scope
+   explicitly with `mcx scope init`
+
 ## Concurrency
 
 - **Maximum recommended**: 5 concurrent sessions

--- a/.claude/skills/sprint/references/plan.md
+++ b/.claude/skills/sprint/references/plan.md
@@ -6,6 +6,11 @@ Plan the next sprint: survey the board, set a goal, pick issues, write the plan 
 starting fresh. If running at sprint end, you already have context — skip reading
 issue bodies you just worked on.
 
+**Run planning commands from within the project root.** `mcx claude ls` and related
+session commands filter to the current repo. If you're in the wrong directory, you
+won't see your sessions. When running concurrent sprints across repos, each orchestrator
+is isolated to its own repo — use `--all` only when you explicitly need a cross-repo view.
+
 ## Step 1: Survey the board
 
 Fetch all open issues and recently closed issues:

--- a/.claude/skills/sprint/references/run.md
+++ b/.claude/skills/sprint/references/run.md
@@ -42,6 +42,13 @@ Only restart when no sessions are active. If other sessions are running
 (including from a concurrent sprint in a different repo), defer the restart
 until they idle — restarting kills them.
 
+**Run all sprint commands from within the project root.** `mcx claude ls` and
+`mcx claude wait` filter sessions by the current repo's git root (or registered
+scope). If you run from the wrong directory, your sessions will appear missing.
+When running concurrent sprints in multiple repos, each orchestrator only sees
+its own sessions — this is intentional isolation, not a bug. Use `--all` to
+see sessions from all repos.
+
 ### Quota check
 
 Check quota headroom before spawning the first batch:


### PR DESCRIPTION
## Summary

- Adds a **Session Scoping** section to `sprint/references/mcx-claude.md` covering: how `repoRoot`/`scopeRoot` filtering works, the `--all` bypass flag, registered scopes via `mcx scope init`, multi-repo sprint isolation, and a self-diagnosing checklist for "missing sessions"
- Adds a pre-flight scoping note to `sprint/references/run.md` and `sprint/references/plan.md` reminding orchestrators to run commands from within the project root
- Updates `bootstrap-sprint/references/design.md` to instruct that the Session Scoping section must always be included when generating an mcx-claude.md for a new project

## Test plan

- [ ] Read `mcx-claude.md` Session Scoping section — covers `repoRoot` vs `scopeRoot`, `--all`, precedence, multi-repo isolation, and the diagnostic checklist
- [ ] Read `run.md` pre-flight section — new note present about running from project root
- [ ] Read `plan.md` — new note present before Step 1
- [ ] Read `bootstrap-sprint/references/design.md` — new requirement to include Session Scoping in generated mcx-claude.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)