### PR TITLE
feat(gc): add mcx gc command (fixes #1219)

### DIFF
--- a/.claude/skills/sprint/references/run.md
+++ b/.claude/skills/sprint/references/run.md
@@ -537,22 +537,27 @@ When the sprint is winding down (2 or fewer active sessions remaining):
    Use `mcx tracked --json` for the final status dashboard — items in `done` phase
    were merged, items in other phases need follow-up.
 4. Clean up tracking: `mcx untrack` any remaining items (they'll carry into next sprint otherwise)
-5. **Check for concurrent cross-repo sprints before rebuilding** (see #1250).
+5. **Run gc to prune accumulated branches and stale worktrees:**
+   ```bash
+   mcx gc --dry-run    # preview what would be cleaned
+   mcx gc              # prune merged branches + stale worktrees + remote refs
+   ```
+6. **Check for concurrent cross-repo sprints before rebuilding** (see #1250).
    The rebuild produces new `dist/mcx` and `dist/mcpd` binaries; a daemon
    restart kills *all* sessions including those from other repos sharing this
    daemon. Check:
    ```bash
    ps aux | grep mcpd | grep -v grep    # confirm single daemon
    # Ask the user if any other sprint is active in another repo.
-   # If yes: defer steps 6-7 until they complete.
+   # If yes: defer steps 7-8 until they complete.
    ```
-6. Pull main and rebuild: `git checkout main && git pull && bun run build`
-7. Restart the daemon so it picks up the new build: verify no sessions active
+7. Pull main and rebuild: `git checkout main && git pull && bun run build`
+8. Restart the daemon so it picks up the new build: verify no sessions active
    with `mcx claude ls`, then `mcx shutdown && mcx status`. This ensures the
    next sprint runs on the latest code (including any daemon fixes merged
    during this sprint). **Skip if another sprint is still active.**
-8. Run `/sprint review` to cut a release
-9. Run `/sprint retro` to capture learnings
+9. Run `/sprint review` to cut a release
+10. Run `/sprint retro` to capture learnings
 
 ## Sweeping main commits during a sprint
 

--- a/packages/clone/src/engine/fast-import-writer.spec.ts
+++ b/packages/clone/src/engine/fast-import-writer.spec.ts
@@ -5,6 +5,20 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { formatMarksFile, generateFastImport, parseMarksFile } from "./fast-import-writer";
 
+/**
+ * Filter out git-inherited env vars (GIT_DIR, GIT_INDEX_FILE, GIT_WORK_TREE)
+ * that would redirect child `git fast-import` processes to the parent repo
+ * instead of the throwaway test directory — see #1282.
+ */
+function cleanGitEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (k === "GIT_DIR" || k === "GIT_INDEX_FILE" || k === "GIT_WORK_TREE") continue;
+    if (v !== undefined) env[k] = v;
+  }
+  return env;
+}
+
 describe("generateFastImport", () => {
   test("single file produces a well-formed blob + commit", () => {
     const { stream, marks, commitMark } = generateFastImport({
@@ -196,16 +210,16 @@ describe("generateFastImport", () => {
 
     const dir = mkdtempSync(join(tmpdir(), "mcx-fast-import-sp-"));
     try {
-      spawnSync("git", ["init", "--bare", "--initial-branch=main", dir], { stdio: "ignore" });
+      spawnSync("git", ["init", "--bare", "--initial-branch=main", dir], { stdio: "ignore", env: cleanGitEnv() });
       const { stream } = generateFastImport({
         entries: [{ path: "my file.md", content: "hi\n" }],
         ref: "refs/heads/main",
         message: "m",
         timestamp: 1700000000,
       });
-      const r = spawnSync("git", ["-C", dir, "fast-import"], { input: stream });
+      const r = spawnSync("git", ["-C", dir, "fast-import"], { input: stream, env: cleanGitEnv() });
       expect(r.status).toBe(0);
-      const show = spawnSync("git", ["-C", dir, "show", "refs/heads/main:my file.md"]);
+      const show = spawnSync("git", ["-C", dir, "show", "refs/heads/main:my file.md"], { env: cleanGitEnv() });
       expect(show.status).toBe(0);
       expect(show.stdout.toString()).toBe("hi\n");
     } finally {
@@ -219,16 +233,16 @@ describe("generateFastImport", () => {
 
     const dir = mkdtempSync(join(tmpdir(), "mcx-fast-import-q-"));
     try {
-      spawnSync("git", ["init", "--bare", "--initial-branch=main", dir], { stdio: "ignore" });
+      spawnSync("git", ["init", "--bare", "--initial-branch=main", dir], { stdio: "ignore", env: cleanGitEnv() });
       const { stream } = generateFastImport({
         entries: [{ path: 'weird"name.md', content: "ok\n" }],
         ref: "refs/heads/main",
         message: "m",
         timestamp: 1700000000,
       });
-      const r = spawnSync("git", ["-C", dir, "fast-import"], { input: stream });
+      const r = spawnSync("git", ["-C", dir, "fast-import"], { input: stream, env: cleanGitEnv() });
       expect(r.status).toBe(0);
-      const show = spawnSync("git", ["-C", dir, "show", 'refs/heads/main:weird"name.md']);
+      const show = spawnSync("git", ["-C", dir, "show", 'refs/heads/main:weird"name.md'], { env: cleanGitEnv() });
       expect(show.status).toBe(0);
       expect(show.stdout.toString()).toBe("ok\n");
     } finally {
@@ -242,7 +256,7 @@ describe("generateFastImport", () => {
 
     const dir = mkdtempSync(join(tmpdir(), "mcx-fast-import-"));
     try {
-      spawnSync("git", ["init", "--bare", "--initial-branch=main", dir], { stdio: "ignore" });
+      spawnSync("git", ["init", "--bare", "--initial-branch=main", dir], { stdio: "ignore", env: cleanGitEnv() });
 
       const { stream } = generateFastImport({
         entries: [
@@ -257,14 +271,14 @@ describe("generateFastImport", () => {
       const streamPath = join(dir, "stream");
       writeFileSync(streamPath, stream);
 
-      const importRes = spawnSync("git", ["-C", dir, "fast-import"], { input: stream });
+      const importRes = spawnSync("git", ["-C", dir, "fast-import"], { input: stream, env: cleanGitEnv() });
       expect(importRes.status).toBe(0);
 
-      const log = spawnSync("git", ["-C", dir, "log", "--format=%s", "refs/heads/main"]);
+      const log = spawnSync("git", ["-C", dir, "log", "--format=%s", "refs/heads/main"], { env: cleanGitEnv() });
       expect(log.status).toBe(0);
       expect(log.stdout.toString().trim()).toBe("import");
 
-      const show = spawnSync("git", ["-C", dir, "show", "refs/heads/main:docs/guide.md"]);
+      const show = spawnSync("git", ["-C", dir, "show", "refs/heads/main:docs/guide.md"], { env: cleanGitEnv() });
       expect(show.status).toBe(0);
       expect(show.stdout.toString()).toBe("body with é and 🙂\n");
     } finally {
@@ -279,7 +293,7 @@ describe("generateFastImport", () => {
     const dir = mkdtempSync(join(tmpdir(), "mcx-fast-import-p-"));
     const marksOut = join(dir, "marks");
     try {
-      spawnSync("git", ["init", "--bare", "--initial-branch=main", dir], { stdio: "ignore" });
+      spawnSync("git", ["init", "--bare", "--initial-branch=main", dir], { stdio: "ignore", env: cleanGitEnv() });
 
       const first = generateFastImport({
         entries: [{ path: "a.md", content: "one\n" }],
@@ -289,6 +303,7 @@ describe("generateFastImport", () => {
       });
       const r1 = spawnSync("git", ["-C", dir, "fast-import", `--export-marks=${marksOut}`], {
         input: first.stream,
+        env: cleanGitEnv(),
       });
       expect(r1.status).toBe(0);
 
@@ -305,13 +320,14 @@ describe("generateFastImport", () => {
       });
       const r2 = spawnSync("git", ["-C", dir, "fast-import", `--import-marks=${marksOut}`], {
         input: second.stream,
+        env: cleanGitEnv(),
       });
       expect(r2.status).toBe(0);
 
-      const log = spawnSync("git", ["-C", dir, "log", "--format=%s", "refs/heads/main"]);
+      const log = spawnSync("git", ["-C", dir, "log", "--format=%s", "refs/heads/main"], { env: cleanGitEnv() });
       expect(log.stdout.toString().trim().split("\n")).toEqual(["second", "first"]);
 
-      const show = spawnSync("git", ["-C", dir, "show", "refs/heads/main:a.md"]);
+      const show = spawnSync("git", ["-C", dir, "show", "refs/heads/main:a.md"], { env: cleanGitEnv() });
       expect(show.stdout.toString()).toBe("two\n");
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -1351,7 +1351,7 @@ async function agentWorktrees(args: string[], provider: AgentProvider, d: AgentD
   }
 
   if (prune) {
-    const { pruned, skippedUnmerged } = pruneWorktrees({
+    const { pruned, skippedUnmerged } = await pruneWorktrees({
       repoRoot: cwd,
       activeWorktrees: sessionWorktrees,
       deps: d,

--- a/packages/command/src/commands/gc.spec.ts
+++ b/packages/command/src/commands/gc.spec.ts
@@ -1,0 +1,435 @@
+import { describe, expect, test } from "bun:test";
+import type { GcDeps } from "./gc";
+import { cmdGc, defaultGcDeps, parseDuration, parseGcArgs, runGc } from "./gc";
+
+describe("parseDuration", () => {
+  test("parses common units", () => {
+    expect(parseDuration("30s")).toBe(30_000);
+    expect(parseDuration("5m")).toBe(300_000);
+    expect(parseDuration("2h")).toBe(7_200_000);
+    expect(parseDuration("1d")).toBe(86_400_000);
+    expect(parseDuration("2w")).toBe(2 * 604_800_000);
+  });
+
+  test("rejects invalid formats", () => {
+    expect(() => parseDuration("1x")).toThrow();
+    expect(() => parseDuration("abc")).toThrow();
+    expect(() => parseDuration("1")).toThrow();
+  });
+});
+
+describe("parseGcArgs", () => {
+  test("defaults", () => {
+    const opts = parseGcArgs([]);
+    expect(opts.dryRun).toBe(false);
+    expect(opts.olderThanMs).toBe(86_400_000);
+    expect(opts.branchesOnly).toBe(false);
+    expect(opts.worktreesOnly).toBe(false);
+  });
+
+  test("--dry-run, -n", () => {
+    expect(parseGcArgs(["--dry-run"]).dryRun).toBe(true);
+    expect(parseGcArgs(["-n"]).dryRun).toBe(true);
+  });
+
+  test("--older-than <dur> and --older-than=<dur>", () => {
+    expect(parseGcArgs(["--older-than", "3d"]).olderThanMs).toBe(3 * 86_400_000);
+    expect(parseGcArgs(["--older-than=2h"]).olderThanMs).toBe(7_200_000);
+  });
+
+  test("--branches-only / --worktrees-only", () => {
+    expect(parseGcArgs(["--branches-only"]).branchesOnly).toBe(true);
+    expect(parseGcArgs(["--worktrees-only"]).worktreesOnly).toBe(true);
+  });
+
+  test("mutually exclusive only-flags", () => {
+    expect(() => parseGcArgs(["--branches-only", "--worktrees-only"])).toThrow();
+  });
+
+  test("unknown arg throws", () => {
+    expect(() => parseGcArgs(["--frobnicate"])).toThrow();
+  });
+
+  test("missing --older-than value throws", () => {
+    expect(() => parseGcArgs(["--older-than"])).toThrow();
+  });
+});
+
+// ── runGc integration tests with mocked deps ──
+
+function makeDeps(
+  overrides: {
+    execResponses?: Map<string, { stdout: string; stderr?: string; exitCode?: number }>;
+    execFallback?: (cmd: string[]) => { stdout: string; stderr: string; exitCode: number };
+    callTool?: GcDeps["callTool"];
+    mtimes?: Map<string, number>;
+  } = {},
+): GcDeps & { logs: string[]; errors: string[]; execCalls: string[][] } {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const execCalls: string[][] = [];
+  const exec = (cmd: string[]): { stdout: string; stderr: string; exitCode: number } => {
+    execCalls.push(cmd);
+    const key = cmd.join(" ");
+    const r = overrides.execResponses?.get(key);
+    if (r) {
+      return { stdout: r.stdout, stderr: r.stderr ?? "", exitCode: r.exitCode ?? 0 };
+    }
+    if (overrides.execFallback) return overrides.execFallback(cmd);
+    return { stdout: "", stderr: "", exitCode: 0 };
+  };
+  return {
+    cwd: "/repo",
+    callTool: overrides.callTool ?? (async () => "[]"),
+    exec,
+    getMtime: (p) => overrides.mtimes?.get(p) ?? null,
+    printError: (m) => errors.push(m),
+    log: (m) => logs.push(m),
+    logError: (m) => errors.push(m),
+    logs,
+    errors,
+    execCalls,
+  };
+}
+
+describe("runGc branches", () => {
+  test("dry-run lists merged branches without deleting", async () => {
+    const responses = new Map<string, { stdout: string }>();
+    responses.set("git -C /repo worktree list --porcelain", {
+      stdout: "worktree /repo\nbranch refs/heads/main\n\n",
+    });
+    responses.set("git -C /repo symbolic-ref refs/remotes/origin/HEAD", { stdout: "refs/remotes/origin/main" });
+    responses.set("git -C /repo branch --merged main", { stdout: "* main\n  feat-a\n  feat-b\n" });
+    responses.set("git -C /repo branch --show-current", { stdout: "main" });
+
+    const d = makeDeps({ execResponses: responses });
+    await runGc({ dryRun: true, olderThanMs: 86_400_000, branchesOnly: true, worktreesOnly: false }, d);
+
+    expect(d.logs.some((l) => l.includes("would delete 2 merged"))).toBe(true);
+    expect(d.logs.some((l) => l.includes("feat-a"))).toBe(true);
+    expect(d.logs.some((l) => l.includes("feat-b"))).toBe(true);
+    // Must not actually call `git branch -d`
+    expect(d.execCalls.some((c) => c[3] === "branch" && c[4] === "-d")).toBe(false);
+  });
+
+  test("live mode deletes merged branches via git branch -d", async () => {
+    const responses = new Map<string, { stdout: string; stderr?: string; exitCode?: number }>();
+    responses.set("git -C /repo worktree list --porcelain", { stdout: "" });
+    responses.set("git -C /repo symbolic-ref refs/remotes/origin/HEAD", { stdout: "refs/remotes/origin/main" });
+    responses.set("git -C /repo branch --merged main", { stdout: "* main\n  old-feat\n" });
+    responses.set("git -C /repo branch --show-current", { stdout: "main" });
+    responses.set("git -C /repo fetch --prune", { stdout: "" });
+    responses.set("git -C /repo branch -d old-feat", { stdout: "Deleted branch old-feat", exitCode: 0 });
+
+    const d = makeDeps({ execResponses: responses });
+    await runGc({ dryRun: false, olderThanMs: 86_400_000, branchesOnly: true, worktreesOnly: false }, d);
+
+    expect(d.execCalls.some((c) => c.join(" ") === "git -C /repo branch -d old-feat")).toBe(true);
+    expect(d.errors.some((l) => l.includes("branches: deleted 1"))).toBe(true);
+  });
+
+  test("excludes default branch and current branch", async () => {
+    const responses = new Map<string, { stdout: string; exitCode?: number }>();
+    responses.set("git -C /repo worktree list --porcelain", { stdout: "" });
+    responses.set("git -C /repo symbolic-ref refs/remotes/origin/HEAD", { stdout: "refs/remotes/origin/main" });
+    responses.set("git -C /repo branch --merged main", { stdout: "  main\n  feat\n* working\n" });
+    responses.set("git -C /repo branch --show-current", { stdout: "working" });
+
+    const d = makeDeps({ execResponses: responses });
+    await runGc({ dryRun: true, olderThanMs: 86_400_000, branchesOnly: true, worktreesOnly: false }, d);
+
+    // Only "feat" should be removable — neither "main" (default) nor "working" (current)
+    expect(d.logs.some((l) => l.includes("would delete 1 merged"))).toBe(true);
+    expect(d.logs.some((l) => l.includes("feat"))).toBe(true);
+    expect(d.logs.some((l) => l.includes("main") && l.includes("-"))).toBe(false);
+    expect(d.logs.some((l) => l.includes("working"))).toBe(false);
+  });
+
+  test("excludes branches checked out by a worktree", async () => {
+    const responses = new Map<string, { stdout: string }>();
+    responses.set("git -C /repo worktree list --porcelain", {
+      stdout: "worktree /repo\nbranch refs/heads/main\n\nworktree /other\nbranch refs/heads/feat\n\n",
+    });
+    responses.set("git -C /repo symbolic-ref refs/remotes/origin/HEAD", { stdout: "refs/remotes/origin/main" });
+    responses.set("git -C /repo branch --merged main", { stdout: "* main\n  feat\n  stale\n" });
+    responses.set("git -C /repo branch --show-current", { stdout: "main" });
+
+    const d = makeDeps({ execResponses: responses });
+    await runGc({ dryRun: true, olderThanMs: 86_400_000, branchesOnly: true, worktreesOnly: false }, d);
+
+    // Only "stale" — feat is checked out by /other
+    expect(d.logs.some((l) => l.includes("would delete 1 merged"))).toBe(true);
+    expect(d.logs.some((l) => l.includes("stale"))).toBe(true);
+  });
+});
+
+describe("runGc worktrees", () => {
+  const baseWorktreeList = [
+    "worktree /repo",
+    "branch refs/heads/main",
+    "",
+    "worktree /repo/.claude/worktrees/wt-a",
+    "branch refs/heads/feat-a",
+    "",
+    "worktree /repo/.claude/worktrees/wt-b",
+    "branch refs/heads/feat-b",
+    "",
+  ].join("\n");
+
+  function makeWorktreeResponses() {
+    const r = new Map<string, { stdout: string; stderr?: string; exitCode?: number }>();
+    r.set("git -C /repo worktree list --porcelain", { stdout: baseWorktreeList });
+    r.set("git -C /repo symbolic-ref refs/remotes/origin/HEAD", { stdout: "refs/remotes/origin/main" });
+    r.set("git -C /repo branch --merged main", { stdout: "* main\n  feat-a\n  feat-b\n" });
+    // Both worktrees clean
+    r.set("git -C /repo/.claude/worktrees/wt-a status --porcelain", { stdout: "" });
+    r.set("git -C /repo/.claude/worktrees/wt-b status --porcelain", { stdout: "" });
+    return r;
+  }
+
+  test("dry-run lists worktree candidates", async () => {
+    const responses = makeWorktreeResponses();
+    const d = makeDeps({ execResponses: responses });
+
+    await runGc({ dryRun: true, olderThanMs: 86_400_000, branchesOnly: false, worktreesOnly: true }, d);
+
+    expect(d.logs.some((l) => l.includes("would remove 2"))).toBe(true);
+    expect(d.logs.some((l) => l.includes("wt-a"))).toBe(true);
+    expect(d.logs.some((l) => l.includes("wt-b"))).toBe(true);
+  });
+
+  test("age filter skips recently-modified worktrees", async () => {
+    const responses = makeWorktreeResponses();
+    const now = Date.now();
+    const mtimes = new Map<string, number>([
+      // wt-a is fresh (modified now) → skipped
+      ["/repo/.claude/worktrees/wt-a", now],
+      // wt-b is old → eligible
+      ["/repo/.claude/worktrees/wt-b", now - 10 * 86_400_000],
+    ]);
+    const d = makeDeps({ execResponses: responses, mtimes });
+
+    await runGc({ dryRun: true, olderThanMs: 86_400_000, branchesOnly: false, worktreesOnly: true }, d);
+
+    expect(d.logs.some((l) => l.includes("would remove 1"))).toBe(true);
+    expect(d.logs.some((l) => l.includes("1 skipped (too recent)"))).toBe(true);
+    expect(d.logs.some((l) => l.includes("wt-b"))).toBe(true);
+  });
+
+  test("dry-run reports unmerged worktrees", async () => {
+    const responses = makeWorktreeResponses();
+    // Neither branch merged
+    responses.set("git -C /repo branch --merged main", { stdout: "* main\n" });
+    const d = makeDeps({ execResponses: responses });
+
+    await runGc({ dryRun: true, olderThanMs: 86_400_000, branchesOnly: false, worktreesOnly: true }, d);
+
+    expect(d.logs.some((l) => l.includes("would remove 0"))).toBe(true);
+    expect(d.logs.some((l) => l.includes("2 skipped (unmerged)"))).toBe(true);
+  });
+
+  test("active-session worktree is skipped even without age filter", async () => {
+    const responses = makeWorktreeResponses();
+    const d = makeDeps({
+      execResponses: responses,
+      callTool: async (tool) => {
+        // Pretend wt-a is an active claude session
+        if (tool === "claude_session_list") return [{ worktree: "wt-a" }];
+        return [];
+      },
+    });
+
+    await runGc({ dryRun: true, olderThanMs: 86_400_000, branchesOnly: false, worktreesOnly: true }, d);
+
+    expect(d.logs.some((l) => l.includes("would remove 1"))).toBe(true);
+    expect(d.logs.some((l) => l.includes("wt-b"))).toBe(true);
+    expect(d.logs.some((l) => l.includes("wt-a") && l.includes("- "))).toBe(false);
+  });
+
+  test("fails closed when session list throws", async () => {
+    const responses = makeWorktreeResponses();
+    const d = makeDeps({
+      execResponses: responses,
+      callTool: async () => {
+        throw new Error("daemon unreachable");
+      },
+    });
+
+    await runGc({ dryRun: true, olderThanMs: 86_400_000, branchesOnly: false, worktreesOnly: true }, d);
+
+    expect(d.errors.some((e) => e.includes("gc:") && e.includes("daemon"))).toBe(true);
+    // Should not have proceeded to list worktrees
+    expect(d.logs.some((l) => l.includes("would remove"))).toBe(false);
+  });
+
+  test("live mode runs fetch --prune and reports result", async () => {
+    const responses = makeWorktreeResponses();
+    responses.set("git -C /repo fetch --prune", { stdout: "" });
+    responses.set("git -C /repo branch --show-current", { stdout: "main" });
+    // worktree remove for both
+    responses.set("git -C /repo worktree remove /repo/.claude/worktrees/wt-a", { stdout: "" });
+    responses.set("git -C /repo worktree remove /repo/.claude/worktrees/wt-b", { stdout: "" });
+    responses.set("git -C /repo branch -d feat-a", { stdout: "" });
+    responses.set("git -C /repo branch -d feat-b", { stdout: "" });
+    // core.bare check used by fixCoreBare
+    responses.set("git -C /repo config --get core.bare", { stdout: "false" });
+
+    const d = makeDeps({
+      execResponses: responses,
+      execFallback: () => ({ stdout: "", stderr: "", exitCode: 0 }),
+    });
+
+    await runGc({ dryRun: false, olderThanMs: 86_400_000, branchesOnly: false, worktreesOnly: false }, d);
+
+    expect(d.execCalls.some((c) => c.join(" ") === "git -C /repo fetch --prune")).toBe(true);
+    expect(d.errors.some((e) => e.includes("worktrees: removed"))).toBe(true);
+  });
+});
+
+describe("runGc error paths", () => {
+  test("reports WorktreeError from listMcxWorktrees", async () => {
+    const responses = new Map<string, { stdout: string; exitCode?: number }>();
+    // Make worktree list fail → triggers WorktreeError
+    responses.set("git -C /repo worktree list --porcelain", { stdout: "", exitCode: 128 });
+    const d = makeDeps({ execResponses: responses });
+
+    await runGc({ dryRun: true, olderThanMs: 86_400_000, branchesOnly: false, worktreesOnly: true }, d);
+
+    expect(d.errors.some((e) => e.includes("gc:") && e.includes("Failed to list"))).toBe(true);
+  });
+
+  test("reports fetch --prune failure but continues", async () => {
+    const responses = new Map<string, { stdout: string; stderr?: string; exitCode?: number }>();
+    responses.set("git -C /repo worktree list --porcelain", { stdout: "" });
+    responses.set("git -C /repo fetch --prune", { stdout: "", stderr: "network down", exitCode: 1 });
+    responses.set("git -C /repo symbolic-ref refs/remotes/origin/HEAD", { stdout: "refs/remotes/origin/main" });
+    responses.set("git -C /repo branch --merged main", { stdout: "" });
+    responses.set("git -C /repo branch --show-current", { stdout: "main" });
+
+    const d = makeDeps({ execResponses: responses });
+    await runGc({ dryRun: false, olderThanMs: 86_400_000, branchesOnly: true, worktreesOnly: false }, d);
+
+    expect(d.errors.some((e) => e.includes("fetch --prune failed") && e.includes("network down"))).toBe(true);
+  });
+
+  test("reports branch delete failures", async () => {
+    const responses = new Map<string, { stdout: string; stderr?: string; exitCode?: number }>();
+    responses.set("git -C /repo worktree list --porcelain", { stdout: "" });
+    responses.set("git -C /repo fetch --prune", { stdout: "" });
+    responses.set("git -C /repo symbolic-ref refs/remotes/origin/HEAD", { stdout: "refs/remotes/origin/main" });
+    responses.set("git -C /repo branch --merged main", { stdout: "* main\n  bad-branch\n" });
+    responses.set("git -C /repo branch --show-current", { stdout: "main" });
+    responses.set("git -C /repo branch -d bad-branch", {
+      stdout: "",
+      stderr: "not fully merged",
+      exitCode: 1,
+    });
+
+    const d = makeDeps({ execResponses: responses });
+    await runGc({ dryRun: false, olderThanMs: 86_400_000, branchesOnly: true, worktreesOnly: false }, d);
+
+    expect(d.errors.some((e) => e.includes("deleted 0") && e.includes("1 failed"))).toBe(true);
+    expect(d.errors.some((e) => e.includes("bad-branch") && e.includes("not fully merged"))).toBe(true);
+  });
+});
+
+describe("defaultGcDeps", () => {
+  test("exec returns stdout/stderr/exitCode from a real command", () => {
+    const deps = defaultGcDeps();
+    const r = deps.exec(["echo", "hello"]);
+    expect(r.stdout).toContain("hello");
+    expect(r.exitCode).toBe(0);
+  });
+
+  test("getMtime returns null for nonexistent paths", () => {
+    const deps = defaultGcDeps();
+    expect(deps.getMtime("/definitely/not/a/real/path/xyz")).toBeNull();
+  });
+
+  test("getMtime returns a number for existing paths", () => {
+    const deps = defaultGcDeps();
+    const mtime = deps.getMtime("/");
+    expect(typeof mtime).toBe("number");
+  });
+});
+
+describe("cmdGc dispatch", () => {
+  async function catchExit(fn: () => Promise<unknown>): Promise<number | undefined> {
+    const origExit = process.exit;
+    const origLog = console.log;
+    let exitCode: number | undefined;
+    process.exit = ((c?: number) => {
+      exitCode = c;
+      throw new Error("__exit__");
+    }) as typeof process.exit;
+    console.log = () => {};
+    try {
+      await fn().catch((e) => {
+        if ((e as Error).message !== "__exit__") throw e;
+      });
+    } finally {
+      process.exit = origExit;
+      console.log = origLog;
+    }
+    return exitCode;
+  }
+
+  test("invalid args cause exit(1)", async () => {
+    expect(await catchExit(() => cmdGc(["--frobnicate"]))).toBe(1);
+  });
+
+  test("--help shows usage and exits 0", async () => {
+    const origExit = process.exit;
+    const origLog = console.log;
+    let exitCode: number | undefined;
+    process.exit = ((c?: number) => {
+      exitCode = c;
+      throw new Error("__exit__");
+    }) as typeof process.exit;
+    console.log = () => {};
+    try {
+      expect(() => parseGcArgs(["--help"])).toThrow("__exit__");
+    } finally {
+      process.exit = origExit;
+      console.log = origLog;
+    }
+    expect(exitCode).toBe(0);
+  });
+
+  test("overrides.dryRun forces dry-run mode", async () => {
+    // Use a fake cwd and empty exec results — we just care that it doesn't throw
+    // and produces dry-run output paths. Redirect console to capture.
+    const origLog = console.log;
+    const origErr = console.error;
+    const lines: string[] = [];
+    console.log = (msg: unknown) => lines.push(String(msg));
+    console.error = (msg: unknown) => lines.push(String(msg));
+    try {
+      // Pass --worktrees-only so we don't need to mock branch commands
+      // but we will still invoke real git in cwd — that's fine for the test.
+      // Force dry-run via overrides even though args don't include --dry-run.
+      await cmdGc(["--worktrees-only"], { dryRun: true });
+    } finally {
+      console.log = origLog;
+      console.error = origErr;
+    }
+    // Just assert something ran — dry-run output should be present
+    expect(lines.some((l) => l.includes("[dry-run]") || l.includes("would remove") || l.includes("gc:"))).toBe(true);
+  });
+});
+
+describe("runGc worktrees-only skips branch work", () => {
+  test("worktrees-only does not call git branch --merged or fetch", async () => {
+    const responses = new Map<string, { stdout: string }>();
+    // listMcxWorktrees requires worktree list
+    responses.set("git -C /repo worktree list --porcelain", { stdout: "" });
+
+    const d = makeDeps({ execResponses: responses });
+    await runGc({ dryRun: true, olderThanMs: 86_400_000, branchesOnly: false, worktreesOnly: true }, d);
+
+    // No branch deletions should happen (no `git branch -d` calls)
+    expect(d.execCalls.some((c) => c[3] === "branch" && c[4] === "-d")).toBe(false);
+    // No fetch --prune should happen when only cleaning worktrees
+    expect(d.execCalls.some((c) => c.includes("fetch"))).toBe(false);
+  });
+});

--- a/packages/command/src/commands/gc.spec.ts
+++ b/packages/command/src/commands/gc.spec.ts
@@ -246,7 +246,23 @@ describe("runGc worktrees", () => {
     expect(d.logs.some((l) => l.includes("wt-a") && l.includes("- "))).toBe(false);
   });
 
-  test("fails closed when session list throws", async () => {
+  test("live mode fails closed when session list throws", async () => {
+    const responses = makeWorktreeResponses();
+    const d = makeDeps({
+      execResponses: responses,
+      callTool: async () => {
+        throw new Error("daemon unreachable");
+      },
+    });
+
+    await runGc({ dryRun: false, olderThanMs: 86_400_000, branchesOnly: false, worktreesOnly: true }, d);
+
+    expect(d.errors.some((e) => e.includes("gc:") && e.includes("daemon"))).toBe(true);
+    // Should not have pruned anything — aborted before reaching the list phase
+    expect(d.errors.some((e) => e.includes("worktrees: removed"))).toBe(false);
+  });
+
+  test("dry-run fails open when session list throws (daemon unreachable)", async () => {
     const responses = makeWorktreeResponses();
     const d = makeDeps({
       execResponses: responses,
@@ -257,9 +273,42 @@ describe("runGc worktrees", () => {
 
     await runGc({ dryRun: true, olderThanMs: 86_400_000, branchesOnly: false, worktreesOnly: true }, d);
 
-    expect(d.errors.some((e) => e.includes("gc:") && e.includes("daemon"))).toBe(true);
-    // Should not have proceeded to list worktrees
-    expect(d.logs.some((l) => l.includes("would remove"))).toBe(false);
+    // Warning emitted about skipped filter
+    expect(d.errors.some((e) => e.includes("active-session filter skipped"))).toBe(true);
+    // But inspection still proceeds
+    expect(d.logs.some((l) => l.includes("would remove"))).toBe(true);
+  });
+
+  test("default mode: worktree-phase branch deletions don't cause false branch-phase failures", async () => {
+    // Regression: when the worktree phase's deleteIfMerged removes a branch,
+    // the branch phase must skip it rather than trying `git branch -d` again
+    // and reporting a false failure.
+    const responses = makeWorktreeResponses();
+    responses.set("git -C /repo fetch --prune", { stdout: "" });
+    responses.set("git -C /repo branch --show-current", { stdout: "main" });
+    responses.set("git -C /repo worktree remove /repo/.claude/worktrees/wt-a", { stdout: "" });
+    responses.set("git -C /repo worktree remove /repo/.claude/worktrees/wt-b", { stdout: "" });
+    responses.set("git -C /repo branch -d feat-a", { stdout: "" });
+    responses.set("git -C /repo branch -d feat-b", { stdout: "" });
+    responses.set("git -C /repo config --get core.bare", { stdout: "false" });
+
+    const d = makeDeps({
+      execResponses: responses,
+      execFallback: () => ({ stdout: "", stderr: "", exitCode: 0 }),
+    });
+
+    // Default mode: both worktrees and branches.
+    await runGc({ dryRun: false, olderThanMs: 86_400_000, branchesOnly: false, worktreesOnly: false }, d);
+
+    // The branch phase must not report any failures — it must skip branches
+    // the worktree phase already deleted.
+    expect(d.errors.some((e) => e.includes("branches: deleted") && e.includes("failed"))).toBe(false);
+    // Exactly one `git branch -d feat-a` and one `git branch -d feat-b` — the
+    // branch phase must not issue a second attempt.
+    const featADeletes = d.execCalls.filter((c) => c.join(" ") === "git -C /repo branch -d feat-a").length;
+    const featBDeletes = d.execCalls.filter((c) => c.join(" ") === "git -C /repo branch -d feat-b").length;
+    expect(featADeletes).toBe(1);
+    expect(featBDeletes).toBe(1);
   });
 
   test("live mode runs fetch --prune and reports result", async () => {

--- a/packages/command/src/commands/gc.spec.ts
+++ b/packages/command/src/commands/gc.spec.ts
@@ -262,6 +262,47 @@ describe("runGc worktrees", () => {
     expect(d.errors.some((e) => e.includes("worktrees: removed"))).toBe(false);
   });
 
+  test("live mode: refreshActive preserves stale active set on mid-loop daemon loss", async () => {
+    // Regression for PR #1278 round-2 🔴: if refreshActive uses failClosed=false,
+    // a daemon death mid-loop returns Set{} (not a throw), which would be
+    // assigned over the initial active set and cause every remaining
+    // candidate to be pruned — including the active session's worktree.
+    //
+    // Fix: refreshActive uses failClosed=true, so daemon loss throws; the
+    // callback catches and returns the last-known active set, protecting
+    // in-flight sessions.
+    const responses = makeWorktreeResponses();
+    responses.set("git -C /repo worktree remove /repo/.claude/worktrees/wt-a", { stdout: "" });
+    responses.set("git -C /repo worktree remove /repo/.claude/worktrees/wt-b", { stdout: "" });
+    responses.set("git -C /repo branch -d feat-a", { stdout: "" });
+    responses.set("git -C /repo branch -d feat-b", { stdout: "" });
+    responses.set("git -C /repo config --get core.bare", { stdout: "false" });
+
+    let callCount = 0;
+    const d = makeDeps({
+      execResponses: responses,
+      execFallback: () => ({ stdout: "", stderr: "", exitCode: 0 }),
+      callTool: async (tool) => {
+        if (tool !== "claude_session_list") return [];
+        callCount++;
+        // First call (initial fetch): wt-a is active.
+        if (callCount === 1) return [{ worktree: "wt-a" }];
+        // Subsequent calls (refreshActive between removals): daemon died.
+        throw new Error("daemon unreachable mid-loop");
+      },
+    });
+
+    await runGc({ dryRun: false, olderThanMs: 86_400_000, branchesOnly: false, worktreesOnly: true }, d);
+
+    // wt-a must NOT be removed — stale active set preserves the skip.
+    const removedA = d.execCalls.some(
+      (c) => c.join(" ") === "git -C /repo worktree remove /repo/.claude/worktrees/wt-a",
+    );
+    expect(removedA).toBe(false);
+    // A diagnostic must be emitted so post-mortem is possible.
+    expect(d.errors.some((e) => e.includes("daemon unreachable during prune"))).toBe(true);
+  });
+
   test("dry-run fails open when session list throws (daemon unreachable)", async () => {
     const responses = makeWorktreeResponses();
     const d = makeDeps({

--- a/packages/command/src/commands/gc.ts
+++ b/packages/command/src/commands/gc.ts
@@ -124,6 +124,10 @@ export function defaultGcDeps(): GcDeps {
       };
     },
     getMtime: (path) => {
+      // node:fs statSync is Bun's native implementation — not a compat shim.
+      // Bun.file().lastModified returns a max-int sentinel for missing paths
+      // and Bun.file().exists() returns false for directories, so neither
+      // works here (worktree paths are directories).
       try {
         return statSync(path).mtimeMs;
       } catch {
@@ -143,20 +147,36 @@ export async function runGc(opts: GcOptions, deps: GcDeps): Promise<void> {
   const { cwd } = deps;
   const prefix = opts.dryRun ? `${c.dim}[dry-run]${c.reset} ` : "";
 
+  // Branches deleted during the worktree phase — skipped by the branch phase
+  // to avoid "not found" false failures on the second `git branch -d`.
+  let worktreeDeletedBranches = new Set<string>();
+
+  // Branches currently checked out by any worktree — must not be deleted.
+  // Captured from listMcxWorktrees during the worktree phase (if run) to
+  // avoid a second independent `git worktree list` syscall and a TOCTOU
+  // window between the two snapshots.
+  let checkedOutFromList: Set<string> | null = null;
+
   // --- Worktrees ---
   if (!opts.branchesOnly) {
+    // Fail-closed for live mode (don't destroy worktrees if daemon is
+    // unreachable). For --dry-run, fail-open and warn — inspection must
+    // degrade gracefully; nothing destructive happens.
     let activeWorktrees: Set<string>;
+    const shimDeps = {
+      ...deps,
+      exit: ((code: number) => process.exit(code)) as (code: number) => never,
+    };
     try {
-      activeWorktrees = await getAllActiveSessionWorktrees(
-        {
-          ...deps,
-          exit: ((code: number) => process.exit(code)) as (code: number) => never,
-        },
-        true, // fail closed — don't destroy worktrees if daemon is unreachable
-      );
+      activeWorktrees = await getAllActiveSessionWorktrees(shimDeps, true);
     } catch (e) {
-      deps.logError(`gc: ${e instanceof Error ? e.message : String(e)}`);
-      return;
+      if (!opts.dryRun) {
+        deps.logError(`gc: ${e instanceof Error ? e.message : String(e)}`);
+        return;
+      }
+      // dry-run: degrade gracefully — warn and continue with empty set.
+      deps.logError("gc: active-session filter skipped — daemon unreachable (dry-run)");
+      activeWorktrees = new Set();
     }
 
     // Add too-recent worktrees to the "active" set so pruneWorktrees skips them.
@@ -179,20 +199,44 @@ export async function runGc(opts: GcOptions, deps: GcDeps): Promise<void> {
       }
     }
 
+    // Thread checked-out branches to the branch phase — avoid a second
+    // independent `git worktree list --porcelain` call (and its TOCTOU).
+    checkedOutFromList = new Set<string>();
+    for (const wt of listed.allWorktrees) {
+      if (wt.branch) checkedOutFromList.add(wt.branch);
+    }
+
+    // refreshActive re-queries sessions between removals (TOCTOU mitigation).
+    // Only meaningful in live mode; in dry-run we don't execute.
+    const refreshActive = opts.dryRun
+      ? undefined
+      : async (): Promise<Set<string>> => {
+          try {
+            return await getAllActiveSessionWorktrees(shimDeps, false);
+          } catch {
+            return activeWorktrees;
+          }
+        };
+    const result = await pruneWorktrees({
+      repoRoot: cwd,
+      activeWorktrees,
+      deps,
+      dryRun: opts.dryRun,
+      refreshActive,
+    });
+
+    worktreeDeletedBranches = result.deletedBranches;
+
     if (opts.dryRun) {
-      // Collect candidates without removing (reuse pruneWorktrees safety logic
-      // is tricky without executing — list clean merged worktrees directly).
-      const candidates = dryRunWorktreeCandidates(listed, activeWorktrees, deps, cwd);
-      deps.log(`${prefix}worktrees: would remove ${candidates.removable.length}`);
-      for (const name of candidates.removable) deps.log(`  ${c.red}-${c.reset} ${name}`);
-      if (candidates.skippedUnmerged.length > 0) {
-        deps.log(`${prefix}worktrees: ${candidates.skippedUnmerged.length} skipped (unmerged)`);
+      deps.log(`${prefix}worktrees: would remove ${result.removable.length}`);
+      for (const name of result.removable) deps.log(`  ${c.red}-${c.reset} ${name}`);
+      if (result.skippedUnmerged.length > 0) {
+        deps.log(`${prefix}worktrees: ${result.skippedUnmerged.length} skipped (unmerged)`);
       }
       if (recentSkipped.length > 0) {
         deps.log(`${prefix}worktrees: ${recentSkipped.length} skipped (too recent)`);
       }
     } else {
-      const result = pruneWorktrees({ repoRoot: cwd, activeWorktrees, deps });
       const unmerged = result.skippedUnmerged.length > 0 ? `, skipped ${result.skippedUnmerged.length} unmerged` : "";
       const tooRecent = recentSkipped.length > 0 ? `, skipped ${recentSkipped.length} too recent` : "";
       deps.logError(`worktrees: removed ${result.pruned}${unmerged}${tooRecent}`);
@@ -212,11 +256,15 @@ export async function runGc(opts: GcOptions, deps: GcDeps): Promise<void> {
     }
 
     const defaultBranch = getDefaultBranch(deps, cwd);
-    const checkedOut = getCheckedOutBranches(deps, cwd);
+    // Reuse checked-out set from the worktree phase if available; else fall
+    // back to an independent query (branches-only mode).
+    const checkedOut = checkedOutFromList ?? getCheckedOutBranches(deps, cwd);
     const mergedBranches = getMergedBranches(deps, cwd, defaultBranch);
     const current = getCurrentBranch(deps, cwd);
 
-    const candidates = mergedBranches.filter((b) => b !== defaultBranch && b !== current && !checkedOut.has(b));
+    const candidates = mergedBranches.filter(
+      (b) => b !== defaultBranch && b !== current && !checkedOut.has(b) && !worktreeDeletedBranches.has(b),
+    );
 
     if (opts.dryRun) {
       deps.log(`${prefix}branches: would delete ${candidates.length} merged`);
@@ -236,47 +284,6 @@ export async function runGc(opts: GcOptions, deps: GcDeps): Promise<void> {
       for (const f of failed) deps.logError(`  ${f}`);
     }
   }
-}
-
-function dryRunWorktreeCandidates(
-  listed: ReturnType<typeof listMcxWorktrees>,
-  activeWorktrees: Set<string>,
-  deps: GcDeps,
-  cwd: string,
-): { removable: string[]; skippedUnmerged: string[] } {
-  const defaultBranch = getDefaultBranch(deps, cwd);
-  const { stdout: mergedOutput, exitCode: mergedExit } = deps.exec([
-    "git",
-    "-C",
-    cwd,
-    "branch",
-    "--merged",
-    defaultBranch,
-  ]);
-  const mergedBranches =
-    mergedExit === 0
-      ? new Set(
-          mergedOutput
-            .split("\n")
-            .map((l) => l.replace(/^\*?\s+/, "").trim())
-            .filter(Boolean),
-        )
-      : null;
-
-  const removable: string[] = [];
-  const skippedUnmerged: string[] = [];
-  for (const wt of listed.worktrees) {
-    const name = wt.path.slice(`${listed.worktreeBase}/`.length);
-    if (activeWorktrees.has(name)) continue;
-    if (mergedBranches && wt.branch && !mergedBranches.has(wt.branch)) {
-      skippedUnmerged.push(wt.branch);
-      continue;
-    }
-    const { stdout: status, exitCode: statusExit } = deps.exec(["git", "-C", wt.path, "status", "--porcelain"]);
-    if (statusExit !== 0 || status.trim() !== "") continue;
-    removable.push(name);
-  }
-  return { removable, skippedUnmerged };
 }
 
 function getMergedBranches(deps: WorktreeShimDeps, cwd: string, defaultBranch: string): string[] {

--- a/packages/command/src/commands/gc.ts
+++ b/packages/command/src/commands/gc.ts
@@ -11,8 +11,10 @@ import {
   WorktreeError,
   type WorktreeShimDeps,
   getDefaultBranch,
+  hasWorktreeHooks,
   listMcxWorktrees,
   pruneWorktrees,
+  readWorktreeConfig,
 } from "@mcp-cli/core";
 import { ipcCall } from "../daemon-lifecycle";
 import { c, printError } from "../output";
@@ -208,12 +210,22 @@ export async function runGc(opts: GcOptions, deps: GcDeps): Promise<void> {
 
     // refreshActive re-queries sessions between removals (TOCTOU mitigation).
     // Only meaningful in live mode; in dry-run we don't execute.
+    //
+    // IMPORTANT: fail-closed here. `failClosed=false` silently returns an
+    // empty Set when the daemon is unreachable — which would then be
+    // treated as "no sessions are active" and prune every remaining
+    // candidate mid-loop. `failClosed=true` throws on daemon loss, and we
+    // preserve the last-known-good active set so in-flight sessions are
+    // still protected. See PR #1278 round-2 review.
     const refreshActive = opts.dryRun
       ? undefined
       : async (): Promise<Set<string>> => {
           try {
-            return await getAllActiveSessionWorktrees(shimDeps, false);
-          } catch {
+            return await getAllActiveSessionWorktrees(shimDeps, true);
+          } catch (e) {
+            deps.logError(
+              `gc: daemon unreachable during prune — preserving last-known active set (${activeWorktrees.size} entries): ${e instanceof Error ? e.message : String(e)}`,
+            );
             return activeWorktrees;
           }
         };
@@ -235,6 +247,13 @@ export async function runGc(opts: GcOptions, deps: GcDeps): Promise<void> {
       }
       if (recentSkipped.length > 0) {
         deps.log(`${prefix}worktrees: ${recentSkipped.length} skipped (too recent)`);
+      }
+      // Teardown hooks run in live mode only; a failing hook keeps the
+      // worktree but still shows in this list. Warn so users aren't
+      // surprised by a delta between dry-run and live counts. See #1278.
+      const wtConfig = readWorktreeConfig(cwd);
+      if (result.removable.length > 0 && hasWorktreeHooks(wtConfig) && wtConfig?.teardown) {
+        deps.log(`${prefix}note: teardown hook success is not simulated — live count may be lower`);
       }
     } else {
       const unmerged = result.skippedUnmerged.length > 0 ? `, skipped ${result.skippedUnmerged.length} unmerged` : "";

--- a/packages/command/src/commands/gc.ts
+++ b/packages/command/src/commands/gc.ts
@@ -1,0 +1,317 @@
+/**
+ * `mcx gc` — garbage-collect merged branches, stale worktrees, and remote refs.
+ *
+ * Safe: only deletes branches that `git branch -d` accepts (fully merged).
+ * Worktrees are pruned using the existing safety checks (active session skip,
+ * clean-only, merged-only). An age filter shields recently-used worktrees.
+ */
+
+import { statSync } from "node:fs";
+import {
+  WorktreeError,
+  type WorktreeShimDeps,
+  getDefaultBranch,
+  listMcxWorktrees,
+  pruneWorktrees,
+} from "@mcp-cli/core";
+import { ipcCall } from "../daemon-lifecycle";
+import { c, printError } from "../output";
+import { getAllActiveSessionWorktrees } from "./worktree-commands";
+
+export interface GcOptions {
+  dryRun: boolean;
+  olderThanMs: number;
+  branchesOnly: boolean;
+  worktreesOnly: boolean;
+}
+
+const DEFAULT_OLDER_THAN_MS = 24 * 60 * 60 * 1000; // 1 day
+
+/** Parse durations like "1d", "3h", "30m", "45s", "2w". */
+export function parseDuration(s: string): number {
+  const m = s.match(/^(\d+)([smhdw])$/);
+  if (!m) throw new Error(`Invalid duration: "${s}" (expected e.g. 30m, 3h, 1d, 2w)`);
+  const n = Number(m[1]);
+  const mul = { s: 1_000, m: 60_000, h: 3_600_000, d: 86_400_000, w: 604_800_000 }[m[2]] ?? 0;
+  return n * mul;
+}
+
+export function parseGcArgs(args: string[]): GcOptions {
+  const opts: GcOptions = {
+    dryRun: false,
+    olderThanMs: DEFAULT_OLDER_THAN_MS,
+    branchesOnly: false,
+    worktreesOnly: false,
+  };
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--dry-run" || a === "-n") opts.dryRun = true;
+    else if (a === "--branches-only") opts.branchesOnly = true;
+    else if (a === "--worktrees-only") opts.worktreesOnly = true;
+    else if (a === "--older-than") {
+      const v = args[++i];
+      if (!v) throw new Error("--older-than requires a value (e.g. 1d, 3h)");
+      opts.olderThanMs = parseDuration(v);
+    } else if (a.startsWith("--older-than=")) {
+      opts.olderThanMs = parseDuration(a.slice("--older-than=".length));
+    } else if (a === "--help" || a === "-h") {
+      printUsage();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${a}`);
+    }
+  }
+  if (opts.branchesOnly && opts.worktreesOnly) {
+    throw new Error("--branches-only and --worktrees-only are mutually exclusive");
+  }
+  return opts;
+}
+
+function printUsage(): void {
+  console.log(`mcx gc — garbage-collect merged branches and stale worktrees
+
+Usage: mcx gc [options]
+
+Options:
+  --dry-run, -n         Show what would be cleaned without making changes
+  --older-than <dur>    Only clean worktrees older than duration (default: 1d)
+                        Supported suffixes: s, m, h, d, w (e.g. 3h, 2d)
+  --branches-only       Only prune merged branches
+  --worktrees-only      Only clean stale worktrees
+  -h, --help            Show this help
+
+Examples:
+  mcx gc
+  mcx gc --dry-run
+  mcx gc --older-than 3d
+  mcx gc --branches-only`);
+}
+
+export interface GcDeps extends WorktreeShimDeps {
+  cwd: string;
+  callTool: (tool: string, args: Record<string, unknown>) => Promise<unknown>;
+  /** Returns mtime (ms since epoch) for the given path, or null if it can't be stat'd. */
+  getMtime: (path: string) => number | null;
+  log: (msg: string) => void;
+  logError: (msg: string) => void;
+}
+
+/** Route a session_list tool to the matching provider server. */
+const SESSION_TOOL_SERVER: Record<string, string> = {
+  claude_session_list: "_claude",
+  codex_session_list: "_codex",
+  acp_session_list: "_acp",
+  opencode_session_list: "_opencode",
+};
+
+export function defaultGcDeps(): GcDeps {
+  return {
+    cwd: process.cwd(),
+    callTool: (tool, args) => {
+      const server = SESSION_TOOL_SERVER[tool] ?? "_claude";
+      return ipcCall("callTool", { server, tool, arguments: args });
+    },
+    exec: (cmd, opts) => {
+      const result = Bun.spawnSync(cmd, {
+        stdout: "pipe",
+        stderr: "pipe",
+        env: opts?.env ? { ...process.env, ...opts.env } : undefined,
+      });
+      return {
+        stdout: result.stdout.toString(),
+        stderr: result.stderr.toString(),
+        exitCode: result.exitCode,
+      };
+    },
+    getMtime: (path) => {
+      try {
+        return statSync(path).mtimeMs;
+      } catch {
+        return null;
+      }
+    },
+    printError,
+    log: console.log,
+    logError: console.error,
+  };
+}
+
+/**
+ * Core gc logic — pure enough to test with injected deps.
+ */
+export async function runGc(opts: GcOptions, deps: GcDeps): Promise<void> {
+  const { cwd } = deps;
+  const prefix = opts.dryRun ? `${c.dim}[dry-run]${c.reset} ` : "";
+
+  // --- Worktrees ---
+  if (!opts.branchesOnly) {
+    let activeWorktrees: Set<string>;
+    try {
+      activeWorktrees = await getAllActiveSessionWorktrees(
+        {
+          ...deps,
+          exit: ((code: number) => process.exit(code)) as (code: number) => never,
+        },
+        true, // fail closed — don't destroy worktrees if daemon is unreachable
+      );
+    } catch (e) {
+      deps.logError(`gc: ${e instanceof Error ? e.message : String(e)}`);
+      return;
+    }
+
+    // Add too-recent worktrees to the "active" set so pruneWorktrees skips them.
+    const ageCutoff = Date.now() - opts.olderThanMs;
+    let listed: ReturnType<typeof listMcxWorktrees>;
+    try {
+      listed = listMcxWorktrees(cwd, deps);
+    } catch (e) {
+      deps.logError(`gc: ${e instanceof WorktreeError ? e.message : String(e)}`);
+      return;
+    }
+
+    const recentSkipped: string[] = [];
+    for (const wt of listed.worktrees) {
+      const name = wt.path.slice(`${listed.worktreeBase}/`.length);
+      const mtime = deps.getMtime(wt.path);
+      if (mtime !== null && mtime > ageCutoff) {
+        activeWorktrees.add(name);
+        recentSkipped.push(name);
+      }
+    }
+
+    if (opts.dryRun) {
+      // Collect candidates without removing (reuse pruneWorktrees safety logic
+      // is tricky without executing — list clean merged worktrees directly).
+      const candidates = dryRunWorktreeCandidates(listed, activeWorktrees, deps, cwd);
+      deps.log(`${prefix}worktrees: would remove ${candidates.removable.length}`);
+      for (const name of candidates.removable) deps.log(`  ${c.red}-${c.reset} ${name}`);
+      if (candidates.skippedUnmerged.length > 0) {
+        deps.log(`${prefix}worktrees: ${candidates.skippedUnmerged.length} skipped (unmerged)`);
+      }
+      if (recentSkipped.length > 0) {
+        deps.log(`${prefix}worktrees: ${recentSkipped.length} skipped (too recent)`);
+      }
+    } else {
+      const result = pruneWorktrees({ repoRoot: cwd, activeWorktrees, deps });
+      const unmerged = result.skippedUnmerged.length > 0 ? `, skipped ${result.skippedUnmerged.length} unmerged` : "";
+      const tooRecent = recentSkipped.length > 0 ? `, skipped ${recentSkipped.length} too recent` : "";
+      deps.logError(`worktrees: removed ${result.pruned}${unmerged}${tooRecent}`);
+    }
+  }
+
+  // --- Branches ---
+  if (!opts.worktreesOnly) {
+    // git fetch --prune — drop stale remote-tracking refs before checking merged branches
+    if (!opts.dryRun) {
+      const fetched = deps.exec(["git", "-C", cwd, "fetch", "--prune"]);
+      if (fetched.exitCode !== 0) {
+        deps.logError(`gc: git fetch --prune failed: ${fetched.stderr.trim()}`);
+      }
+    } else {
+      deps.log(`${prefix}would run: git fetch --prune`);
+    }
+
+    const defaultBranch = getDefaultBranch(deps, cwd);
+    const checkedOut = getCheckedOutBranches(deps, cwd);
+    const mergedBranches = getMergedBranches(deps, cwd, defaultBranch);
+    const current = getCurrentBranch(deps, cwd);
+
+    const candidates = mergedBranches.filter((b) => b !== defaultBranch && b !== current && !checkedOut.has(b));
+
+    if (opts.dryRun) {
+      deps.log(`${prefix}branches: would delete ${candidates.length} merged`);
+      for (const b of candidates) deps.log(`  ${c.red}-${c.reset} ${b}`);
+    } else {
+      let deleted = 0;
+      const failed: string[] = [];
+      for (const b of candidates) {
+        const { exitCode, stderr } = deps.exec(["git", "-C", cwd, "branch", "-d", b]);
+        if (exitCode === 0) {
+          deleted++;
+        } else {
+          failed.push(`${b}: ${stderr.trim()}`);
+        }
+      }
+      deps.logError(`branches: deleted ${deleted}${failed.length > 0 ? `, ${failed.length} failed` : ""}`);
+      for (const f of failed) deps.logError(`  ${f}`);
+    }
+  }
+}
+
+function dryRunWorktreeCandidates(
+  listed: ReturnType<typeof listMcxWorktrees>,
+  activeWorktrees: Set<string>,
+  deps: GcDeps,
+  cwd: string,
+): { removable: string[]; skippedUnmerged: string[] } {
+  const defaultBranch = getDefaultBranch(deps, cwd);
+  const { stdout: mergedOutput, exitCode: mergedExit } = deps.exec([
+    "git",
+    "-C",
+    cwd,
+    "branch",
+    "--merged",
+    defaultBranch,
+  ]);
+  const mergedBranches =
+    mergedExit === 0
+      ? new Set(
+          mergedOutput
+            .split("\n")
+            .map((l) => l.replace(/^\*?\s+/, "").trim())
+            .filter(Boolean),
+        )
+      : null;
+
+  const removable: string[] = [];
+  const skippedUnmerged: string[] = [];
+  for (const wt of listed.worktrees) {
+    const name = wt.path.slice(`${listed.worktreeBase}/`.length);
+    if (activeWorktrees.has(name)) continue;
+    if (mergedBranches && wt.branch && !mergedBranches.has(wt.branch)) {
+      skippedUnmerged.push(wt.branch);
+      continue;
+    }
+    const { stdout: status, exitCode: statusExit } = deps.exec(["git", "-C", wt.path, "status", "--porcelain"]);
+    if (statusExit !== 0 || status.trim() !== "") continue;
+    removable.push(name);
+  }
+  return { removable, skippedUnmerged };
+}
+
+function getMergedBranches(deps: WorktreeShimDeps, cwd: string, defaultBranch: string): string[] {
+  const { stdout, exitCode } = deps.exec(["git", "-C", cwd, "branch", "--merged", defaultBranch]);
+  if (exitCode !== 0) return [];
+  return stdout
+    .split("\n")
+    .map((l) => l.replace(/^\*?\s+/, "").trim())
+    .filter(Boolean);
+}
+
+function getCurrentBranch(deps: WorktreeShimDeps, cwd: string): string {
+  const { stdout, exitCode } = deps.exec(["git", "-C", cwd, "branch", "--show-current"]);
+  return exitCode === 0 ? stdout.trim() : "";
+}
+
+/** Branches currently checked out by any worktree — must not be deleted. */
+function getCheckedOutBranches(deps: WorktreeShimDeps, cwd: string): Set<string> {
+  const { stdout, exitCode } = deps.exec(["git", "-C", cwd, "worktree", "list", "--porcelain"]);
+  const set = new Set<string>();
+  if (exitCode !== 0) return set;
+  for (const line of stdout.split("\n")) {
+    if (line.startsWith("branch refs/heads/")) set.add(line.slice("branch refs/heads/".length));
+  }
+  return set;
+}
+
+export async function cmdGc(args: string[], overrides: { dryRun?: boolean } = {}): Promise<void> {
+  let opts: GcOptions;
+  try {
+    opts = parseGcArgs(args);
+  } catch (e) {
+    printError(e instanceof Error ? e.message : String(e));
+    process.exit(1);
+  }
+  if (overrides.dryRun) opts.dryRun = true;
+  await runGc(opts, defaultGcDeps());
+}

--- a/packages/command/src/commands/worktree-commands.ts
+++ b/packages/command/src/commands/worktree-commands.ts
@@ -86,7 +86,7 @@ export async function worktreesCommand(args: string[], deps: WorktreeCommandDeps
   }
 
   if (prune) {
-    const result = pruneWorktrees({ repoRoot: cwd, activeWorktrees, deps });
+    const result = await pruneWorktrees({ repoRoot: cwd, activeWorktrees, deps });
     if (result.pruned === 0) {
       deps.printError("Nothing to prune.");
     } else {

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -139,8 +139,8 @@ async function main(): Promise<void> {
   }
 
   // --dry-run is only valid for call (and shorthand call forms handled in the default branch)
-  // and for commands that opt in (gc, vfs).
-  if (dryRun && command && command !== "call" && command !== "gc" && command !== "vfs") {
+  // and for commands that opt in (gc).
+  if (dryRun && command && command !== "call" && command !== "gc") {
     const isShorthand =
       !command.startsWith("-") &&
       (splitServerTool(command) !== null || (cleanArgs.length >= 2 && !cleanArgs[1].startsWith("-")));

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -33,6 +33,7 @@ import { cmdCompletions } from "./commands/completions";
 import { cmdConfig } from "./commands/config";
 import { cmdDump } from "./commands/dump";
 import { cmdExport } from "./commands/export";
+import { cmdGc } from "./commands/gc";
 import { cmdGet } from "./commands/get";
 import { cmdAddFromClaudeDesktop, cmdImport } from "./commands/import";
 import { cmdInstall } from "./commands/install";
@@ -138,7 +139,8 @@ async function main(): Promise<void> {
   }
 
   // --dry-run is only valid for call (and shorthand call forms handled in the default branch)
-  if (dryRun && command && command !== "call") {
+  // and for commands that opt in (gc, vfs).
+  if (dryRun && command && command !== "call" && command !== "gc" && command !== "vfs") {
     const isShorthand =
       !command.startsWith("-") &&
       (splitServerTool(command) !== null || (cleanArgs.length >= 2 && !cleanArgs[1].startsWith("-")));
@@ -269,6 +271,10 @@ async function main(): Promise<void> {
 
       case "get":
         await cmdGet(cleanArgs.slice(1));
+        break;
+
+      case "gc":
+        await cmdGc(cleanArgs.slice(1), { dryRun: _dryRun });
         break;
 
       case "auth":
@@ -883,6 +889,7 @@ Aliases:
 
 Utility:
   mcx search/install/update           Registry search and install
+  mcx gc [--dry-run]                  Prune merged branches + stale worktrees
   mcx logs <server> [-f]              View server stderr
   mcx mail <subcommand>               Inter-session messaging
   mcx note <subcommand>               Tool annotations

--- a/packages/core/src/worktree-shim.spec.ts
+++ b/packages/core/src/worktree-shim.spec.ts
@@ -403,7 +403,7 @@ describe("listMcxWorktrees", () => {
 // ── pruneWorktrees ──
 
 describe("pruneWorktrees", () => {
-  test("prunes clean merged worktrees", () => {
+  test("prunes clean merged worktrees", async () => {
     const porcelainOutput = [
       "worktree /repo",
       "HEAD abc123",
@@ -429,7 +429,7 @@ describe("pruneWorktrees", () => {
     });
     const printError = mock(() => {});
 
-    const result = pruneWorktrees({
+    const result = await pruneWorktrees({
       repoRoot: "/repo",
       activeWorktrees: new Set(),
       deps: { exec, printError },
@@ -439,7 +439,7 @@ describe("pruneWorktrees", () => {
     expect(result.skippedUnmerged).toEqual([]);
   });
 
-  test("skips worktrees with active sessions", () => {
+  test("skips worktrees with active sessions", async () => {
     const porcelainOutput = [
       "worktree /repo",
       "HEAD abc123",
@@ -460,7 +460,7 @@ describe("pruneWorktrees", () => {
     });
     const printError = mock(() => {});
 
-    const result = pruneWorktrees({
+    const result = await pruneWorktrees({
       repoRoot: "/repo",
       activeWorktrees: new Set(["feat-active"]),
       deps: { exec, printError },
@@ -469,7 +469,7 @@ describe("pruneWorktrees", () => {
     expect(result.pruned).toBe(0);
   });
 
-  test("skips unmerged branches", () => {
+  test("skips unmerged branches", async () => {
     const porcelainOutput = [
       "worktree /repo",
       "HEAD abc123",
@@ -490,7 +490,7 @@ describe("pruneWorktrees", () => {
     });
     const printError = mock(() => {});
 
-    const result = pruneWorktrees({
+    const result = await pruneWorktrees({
       repoRoot: "/repo",
       activeWorktrees: new Set(),
       deps: { exec, printError },
@@ -500,7 +500,7 @@ describe("pruneWorktrees", () => {
     expect(result.skippedUnmerged).toEqual(["claude/feat-wip"]);
   });
 
-  test("batch guard: calls fixCoreBare after pruning when core.bare=true on last removal", () => {
+  test("batch guard: calls fixCoreBare after pruning when core.bare=true on last removal", async () => {
     // Simulate the recurrence bug: individual per-removal fix runs but a subsequent
     // removal flips core.bare back to true. The final batch guard should catch it.
     // fixCoreBare guards against non-existent repos via existsSync(.git), so we need
@@ -547,7 +547,7 @@ describe("pruneWorktrees", () => {
       const printErrors: string[] = [];
       const printError = mock((msg: string) => printErrors.push(msg));
 
-      const result = pruneWorktrees({
+      const result = await pruneWorktrees({
         repoRoot,
         activeWorktrees: new Set(),
         deps: { exec, printError },

--- a/packages/core/src/worktree-shim.ts
+++ b/packages/core/src/worktree-shim.ts
@@ -65,12 +65,25 @@ export interface WorktreePruneOptions {
   /** Set of worktree names that have active sessions (skip these). */
   activeWorktrees: Set<string>;
   deps: WorktreeShimDeps;
+  /** If true, compute candidates but don't execute removals or branch deletes. */
+  dryRun?: boolean;
+  /**
+   * Optional async refresh of active-session set, called before each removal.
+   * Mitigates TOCTOU: orchestrator spawning a session into a candidate between
+   * list and remove. Callers without a way to refresh may omit.
+   */
+  refreshActive?: () => Promise<Set<string>>;
 }
 
 /** Result of a prune operation. */
 export interface WorktreePruneResult {
+  /** Count of worktrees actually removed (0 in dry-run). */
   pruned: number;
+  /** Names of worktrees that would be or were removed. */
+  removable: string[];
   skippedUnmerged: string[];
+  /** Branches that were deleted (empty in dry-run). */
+  deletedBranches: Set<string>;
 }
 
 // ── Create ──
@@ -223,12 +236,14 @@ export function cleanupWorktree(worktree: string, cwd: string, deps: WorktreeShi
 }
 
 /** Delete a branch if it's been merged (git branch -d is safe — refuses unmerged). */
-function deleteIfMerged(branch: string, repoRoot: string, deps: WorktreeShimDeps): void {
-  if (!branch) return;
+function deleteIfMerged(branch: string, repoRoot: string, deps: WorktreeShimDeps): boolean {
+  if (!branch) return false;
   const { exitCode } = deps.exec(["git", "-C", repoRoot, "branch", "-d", branch]);
   if (exitCode === 0) {
     deps.printError(`Deleted branch: ${branch} (merged)`);
+    return true;
   }
+  return false;
 }
 
 // ── List ──
@@ -291,8 +306,9 @@ export function getDefaultBranch(deps: WorktreeShimDeps, cwd: string): string {
  * Prune clean, merged, orphaned worktrees.
  * Skips worktrees with active sessions and unmerged branches.
  */
-export function pruneWorktrees(opts: WorktreePruneOptions): WorktreePruneResult {
-  const { repoRoot, activeWorktrees, deps } = opts;
+export async function pruneWorktrees(opts: WorktreePruneOptions): Promise<WorktreePruneResult> {
+  const { repoRoot, deps, dryRun = false, refreshActive } = opts;
+  let activeWorktrees = opts.activeWorktrees;
   const wtConfig = readWorktreeConfig(repoRoot);
   const { worktrees, worktreeBase } = listMcxWorktrees(repoRoot, deps);
 
@@ -324,10 +340,28 @@ export function pruneWorktrees(opts: WorktreePruneOptions): WorktreePruneResult 
   }
 
   let pruned = 0;
+  const removable: string[] = [];
   const skippedUnmerged: string[] = [];
+  const deletedBranches = new Set<string>();
+  const cwd = (() => {
+    try {
+      return process.cwd();
+    } catch {
+      return "";
+    }
+  })();
 
   for (const wt of worktrees) {
     const wtName = wt.path.slice(`${worktreeBase}/`.length);
+    // Refresh active set between iterations to narrow the TOCTOU window
+    // (orchestrator spawning a session into a candidate worktree).
+    if (refreshActive && !dryRun) {
+      try {
+        activeWorktrees = await refreshActive();
+      } catch {
+        // Keep prior set on refresh failure.
+      }
+    }
     if (activeWorktrees.has(wtName)) continue;
     if (!skipMergeCheck && wt.branch && !mergedBranches.has(wt.branch)) {
       skippedUnmerged.push(wt.branch);
@@ -338,6 +372,15 @@ export function pruneWorktrees(opts: WorktreePruneOptions): WorktreePruneResult 
     const { stdout: status, exitCode: statusExit } = deps.exec(["git", "-C", wt.path, "status", "--porcelain"]);
     if (statusExit !== 0 || status.trim() !== "") continue;
 
+    // Guard: refuse to remove a worktree that contains the current CWD.
+    if (cwd && (cwd === wt.path || cwd.startsWith(`${wt.path}/`))) {
+      deps.printError(`Skipping worktree containing current directory: ${wt.path}`);
+      continue;
+    }
+
+    removable.push(wtName);
+    if (dryRun) continue;
+
     // Remove worktree
     if (hasWorktreeHooks(wtConfig) && wtConfig.teardown) {
       const hookEnv = buildHookEnv({ branch: wtName, path: wt.path, cwd: repoRoot });
@@ -345,7 +388,9 @@ export function pruneWorktrees(opts: WorktreePruneOptions): WorktreePruneResult 
       if (hookExit === 0) {
         deps.printError(`Removed worktree via hook: ${wt.path}`);
         pruned++;
-        deleteIfMerged(wt.branch ?? "", repoRoot, deps);
+        if (wt.branch && deleteIfMerged(wt.branch, repoRoot, deps)) {
+          deletedBranches.add(wt.branch);
+        }
       } else {
         deps.printError(`Worktree teardown hook failed for: ${wt.path}: ${hookStderr}`);
       }
@@ -357,7 +402,9 @@ export function pruneWorktrees(opts: WorktreePruneOptions): WorktreePruneResult 
         }
         deps.printError(`Removed worktree: ${wt.path}`);
         pruned++;
-        deleteIfMerged(wt.branch ?? "", repoRoot, deps);
+        if (wt.branch && deleteIfMerged(wt.branch, repoRoot, deps)) {
+          deletedBranches.add(wt.branch);
+        }
       }
     }
   }
@@ -371,7 +418,7 @@ export function pruneWorktrees(opts: WorktreePruneOptions): WorktreePruneResult 
     }
   }
 
-  return { pruned, skippedUnmerged };
+  return { pruned, removable, skippedUnmerged, deletedBranches };
 }
 
 // ── Errors ──

--- a/packages/core/src/worktree-shim.ts
+++ b/packages/core/src/worktree-shim.ts
@@ -8,7 +8,7 @@
  * @see https://github.com/theshadow27/mcp-cli/issues/909
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import type { ExecFn } from "./git";
 import { fixCoreBare } from "./git";
@@ -343,9 +343,17 @@ export async function pruneWorktrees(opts: WorktreePruneOptions): Promise<Worktr
   const removable: string[] = [];
   const skippedUnmerged: string[] = [];
   const deletedBranches = new Set<string>();
+  // Resolve symlinks on cwd — macOS does not resolve them in process.cwd(),
+  // so a shell that cd'd through a symlink into a candidate worktree would
+  // bypass the "don't remove my cwd" guard below.
   const cwd = (() => {
     try {
-      return process.cwd();
+      const raw = process.cwd();
+      try {
+        return realpathSync(raw);
+      } catch {
+        return raw;
+      }
     } catch {
       return "";
     }


### PR DESCRIPTION
## Summary
- New `mcx gc` command prunes merged local branches and clean/merged worktrees, then `git fetch --prune`s stale remote refs.
- Safe-by-construction: branches only deleted via `git branch -d` (fails on unmerged); skips default branch, current branch, and any branch checked out by a worktree.
- Age filter (`--older-than`, default `1d`) prevents pruning recently-used worktrees; flags `--dry-run`, `--branches-only`, `--worktrees-only` round it out.
- Intended for the sprint wind-down phase — addresses 1,368-local-branch accumulation from sprint 31.

## Test plan
- [x] `bun typecheck`
- [x] `bun lint`
- [x] `bun test` (4581 pass, incl. 29 new gc specs)
- [x] Coverage check passes (gc.ts 100% line coverage)
- [ ] Manual smoke in a real repo: `mcx gc --dry-run` shows candidates without changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)