### PR TITLE
feat(aliases): scope column + dispatch filter (fixes #1289)

### DIFF
--- a/packages/command/src/commands/alias-scope.spec.ts
+++ b/packages/command/src/commands/alias-scope.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for `--scope` flag parsing on `mcx alias save` and the scope cwd
+ * enforcement in `mcx alias run` (issue #1289).
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+import { parseScopeFlag } from "./alias";
+import { type CmdRunDeps, cmdRun, isScopeAllowed } from "./run";
+
+describe("parseScopeFlag", () => {
+  test("defaults to global when --scope is not passed", () => {
+    const { scope, scopeDefaulted, rest } = parseScopeFlag(["save", "name", "@file.ts"]);
+    expect(scope).toBe("global");
+    expect(scopeDefaulted).toBe(true);
+    expect(rest).toEqual(["save", "name", "@file.ts"]);
+  });
+
+  test("--scope global is explicit", () => {
+    const { scope, scopeDefaulted } = parseScopeFlag(["save", "--scope", "global", "n"]);
+    expect(scope).toBe("global");
+    expect(scopeDefaulted).toBe(false);
+  });
+
+  test("--scope null sets scope to null (legacy dispatch)", () => {
+    const { scope } = parseScopeFlag(["save", "--scope", "null", "n"]);
+    expect(scope).toBeNull();
+  });
+
+  test("--scope legacy is an alias for null", () => {
+    const { scope } = parseScopeFlag(["save", "--scope", "legacy", "n"]);
+    expect(scope).toBeNull();
+  });
+
+  test("--scope <path> resolves to absolute path", () => {
+    const { scope } = parseScopeFlag(["save", "--scope", "/absolute/path", "n"]);
+    expect(scope).toBe("/absolute/path");
+  });
+
+  test("--scope . resolves to provided cwd", () => {
+    const { scope } = parseScopeFlag(["save", "--scope", ".", "n"], "/workspace/repo");
+    expect(scope).toBe("/workspace/repo");
+  });
+
+  test("--scope=global equals --scope global", () => {
+    const { scope, rest } = parseScopeFlag(["save", "--scope=global", "n"]);
+    expect(scope).toBe("global");
+    expect(rest).toEqual(["save", "n"]);
+  });
+
+  test("strips --scope from rest", () => {
+    const { rest } = parseScopeFlag(["save", "--scope", "global", "name", "src"]);
+    expect(rest).toEqual(["save", "name", "src"]);
+  });
+});
+
+describe("isScopeAllowed", () => {
+  test("null scope is allowed from any cwd (legacy)", () => {
+    expect(isScopeAllowed(null, "/anywhere")).toBe(true);
+    expect(isScopeAllowed(undefined, "/anywhere")).toBe(true);
+  });
+
+  test("global scope is allowed from any cwd", () => {
+    expect(isScopeAllowed("global", "/anywhere")).toBe(true);
+  });
+
+  test("path scope is allowed when cwd equals the path", () => {
+    expect(isScopeAllowed("/workspace/repo", "/workspace/repo")).toBe(true);
+  });
+
+  test("path scope is allowed when cwd is inside the path", () => {
+    expect(isScopeAllowed("/workspace/repo", "/workspace/repo/sub/dir")).toBe(true);
+  });
+
+  test("path scope is rejected for sibling paths with matching prefix", () => {
+    // /workspace/repo should NOT match /workspace/repository
+    expect(isScopeAllowed("/workspace/repo", "/workspace/repository")).toBe(false);
+  });
+
+  test("path scope is rejected from an outside cwd", () => {
+    expect(isScopeAllowed("/workspace/repo", "/elsewhere")).toBe(false);
+  });
+});
+
+describe("cmdRun scope enforcement", () => {
+  function makeRunDeps(
+    aliasScope: string | null | undefined,
+    cwd: string,
+    exitImpl?: (code: number) => never,
+  ): CmdRunDeps {
+    const ipcResponses: Record<string, unknown> = {
+      getAlias: {
+        name: "scoped",
+        description: "d",
+        filePath: "/tmp/scoped.ts",
+        aliasType: "defineAlias",
+        script: "// test",
+        runCount: 0,
+        lastRunAt: null,
+        scope: aliasScope ?? null,
+      },
+      touchAlias: { ok: true },
+      recordAliasRun: { ok: true, runCount: 1 },
+    };
+
+    return {
+      ipcCall: mock(((method: string) => Promise.resolve(ipcResponses[method])) as CmdRunDeps["ipcCall"]),
+      readCliConfig: () => ({}),
+      runAlias: mock(() => Promise.resolve()) as unknown as CmdRunDeps["runAlias"],
+      printError: mock(() => {}) as unknown as CmdRunDeps["printError"],
+      logError: mock(() => {}),
+      exit:
+        (exitImpl as CmdRunDeps["exit"]) ??
+        (mock(() => {
+          throw new Error("exit called");
+        }) as unknown as CmdRunDeps["exit"]),
+      cwd: mock(() => cwd),
+    };
+  }
+
+  test("runs null-scoped alias from any cwd", async () => {
+    const deps = makeRunDeps(null, "/elsewhere");
+    const { _recordPromise } = await cmdRun(["scoped"], deps);
+    await _recordPromise;
+    expect(deps.runAlias).toHaveBeenCalled();
+  });
+
+  test("runs global-scoped alias from any cwd", async () => {
+    const deps = makeRunDeps("global", "/elsewhere");
+    const { _recordPromise } = await cmdRun(["scoped"], deps);
+    await _recordPromise;
+    expect(deps.runAlias).toHaveBeenCalled();
+  });
+
+  test("runs path-scoped alias when cwd is inside the scope", async () => {
+    const deps = makeRunDeps("/workspace/repo", "/workspace/repo/src");
+    const { _recordPromise } = await cmdRun(["scoped"], deps);
+    await _recordPromise;
+    expect(deps.runAlias).toHaveBeenCalled();
+  });
+
+  test("rejects path-scoped alias when cwd is outside", async () => {
+    const exit = mock(() => {
+      throw new Error("exit");
+    });
+    const deps = makeRunDeps("/workspace/repo", "/elsewhere", exit as unknown as CmdRunDeps["exit"]);
+    await expect(cmdRun(["scoped"], deps)).rejects.toThrow("exit");
+    expect(deps.runAlias).not.toHaveBeenCalled();
+    expect(deps.printError).toHaveBeenCalled();
+  });
+});

--- a/packages/command/src/commands/alias-scope.spec.ts
+++ b/packages/command/src/commands/alias-scope.spec.ts
@@ -51,6 +51,19 @@ describe("parseScopeFlag", () => {
     const { rest } = parseScopeFlag(["save", "--scope", "global", "name", "src"]);
     expect(rest).toEqual(["save", "name", "src"]);
   });
+
+  test("--scope as the last argument throws (no silent swallow)", () => {
+    expect(() => parseScopeFlag(["save", "name", "--scope"])).toThrow(/--scope requires a value/);
+  });
+
+  test("--scope with empty string is rejected", () => {
+    expect(() => parseScopeFlag(["save", "--scope", "", "n"])).toThrow(/--scope value cannot be empty/);
+    expect(() => parseScopeFlag(["save", "--scope=", "n"])).toThrow(/--scope value cannot be empty/);
+  });
+
+  test("--scope containing a null byte is rejected", () => {
+    expect(() => parseScopeFlag(["save", "--scope", "/tmp/\0bad", "n"])).toThrow(/invalid/);
+  });
 });
 
 describe("isScopeAllowed", () => {
@@ -78,6 +91,20 @@ describe("isScopeAllowed", () => {
 
   test("path scope is rejected from an outside cwd", () => {
     expect(isScopeAllowed("/workspace/repo", "/elsewhere")).toBe(false);
+  });
+
+  test("non-absolute scope strings fail closed (never grant access)", () => {
+    // A malformed scope that isn't null/global/absolute must NOT silently grant
+    // access — see adversarial review #3 (fail-closed boundary).
+    expect(isScopeAllowed("dev", "/anywhere")).toBe(false);
+    expect(isScopeAllowed("./proj", "/anywhere")).toBe(false);
+    expect(isScopeAllowed("", "/anywhere")).toBe(false);
+  });
+
+  test("cwd with .. segments is normalized before comparison", () => {
+    // /workspace/repo/../sibling normalizes to /workspace/sibling, which is NOT
+    // inside /workspace/repo — must be rejected.
+    expect(isScopeAllowed("/workspace/repo", "/workspace/repo/../sibling")).toBe(false);
   });
 });
 

--- a/packages/command/src/commands/alias.spec.ts
+++ b/packages/command/src/commands/alias.spec.ts
@@ -180,6 +180,7 @@ describe("cmdAlias save (standard)", () => {
       name: "my-alias",
       script: "console.log('hi')",
       description: undefined,
+      scope: "global",
     });
     expect(deps.logError).toHaveBeenCalled();
   });
@@ -195,6 +196,7 @@ describe("cmdAlias save (standard)", () => {
       name: "my-alias",
       script: "const x = 1",
       description: undefined,
+      scope: "global",
     });
   });
 
@@ -211,6 +213,7 @@ describe("cmdAlias save (standard)", () => {
       name: "my-alias",
       script: "// description: from file\nfile content",
       description: "from file",
+      scope: "global",
     });
   });
 
@@ -227,6 +230,7 @@ describe("cmdAlias save (standard)", () => {
       name: "my-alias",
       script: "stdin script",
       description: undefined,
+      scope: "global",
     });
   });
 

--- a/packages/command/src/commands/alias.ts
+++ b/packages/command/src/commands/alias.ts
@@ -4,7 +4,7 @@
 
 import { spawnSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, resolve } from "node:path";
 import type { IpcMethod, IpcMethodResult } from "@mcp-cli/core";
 import { ipcCall, safeAliasPath } from "@mcp-cli/core";
 import { readFileWithLimit } from "../file-read";
@@ -42,6 +42,37 @@ const defaultDeps: AliasDeps = {
   log: (msg) => console.log(msg),
   logError: (msg) => console.error(msg),
 };
+
+/**
+ * Parse `--scope <value>` from args (mutates nothing; returns cleaned args and resolved scope).
+ * Values:
+ *  - `null` or `legacy` → NULL scope (top-level `mcx <name>` dispatch enabled)
+ *  - `global` (default) → hidden from top-level, callable via run/mcp
+ *  - `.` or any path → resolved to absolute path; callable only when cwd is inside
+ */
+export function parseScopeFlag(
+  args: string[],
+  cwd: string = process.cwd(),
+): { scope: string | null; scopeDefaulted: boolean; rest: string[] } {
+  const rest: string[] = [];
+  let raw: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--scope" && i + 1 < args.length) {
+      raw = args[++i];
+      continue;
+    }
+    if (args[i].startsWith("--scope=")) {
+      raw = args[i].slice("--scope=".length);
+      continue;
+    }
+    rest.push(args[i]);
+  }
+  if (raw === undefined) return { scope: "global", scopeDefaulted: true, rest };
+  if (raw === "null" || raw === "legacy") return { scope: null, scopeDefaulted: false, rest };
+  if (raw === "global") return { scope: "global", scopeDefaulted: false, rest };
+  // Treat anything else as a path — resolve to absolute
+  return { scope: resolve(cwd, raw), scopeDefaulted: false, rest };
+}
 
 /** Wrap a defineAlias object literal body into a full script */
 export function wrapDefineAlias(code: string): string {
@@ -81,21 +112,24 @@ export async function cmdAlias(args: string[], deps?: Partial<AliasDeps>): Promi
     }
 
     case "save": {
+      // Strip --scope first so it doesn't interfere with -c/positional parsing.
+      const { scope, rest: saveArgs } = parseScopeFlag(args);
+
       // Parse -c / --code flag
-      const codeIdx = args.indexOf("-c") !== -1 ? args.indexOf("-c") : args.indexOf("--code");
+      const codeIdx = saveArgs.indexOf("-c") !== -1 ? saveArgs.indexOf("-c") : saveArgs.indexOf("--code");
       const hasCode = codeIdx !== -1;
 
       if (hasCode) {
         // mcx alias save [-c CODE] [name]
         // or: mcx alias save [name] -c CODE
-        const codeBody = args[codeIdx + 1];
+        const codeBody = saveArgs[codeIdx + 1];
         if (!codeBody) {
           d.printError("Missing code body after -c/--code flag");
           d.exit(1);
         }
 
         // Collect remaining args (not -c or its value) after "save"
-        const rest = args.slice(1).filter((_, i) => {
+        const rest = saveArgs.slice(1).filter((_, i) => {
           const absIdx = i + 1; // offset because we sliced at 1
           return absIdx !== codeIdx && absIdx !== codeIdx + 1;
         });
@@ -110,7 +144,7 @@ export async function cmdAlias(args: string[], deps?: Partial<AliasDeps>): Promi
 
         const script = wrapDefineAlias(codeBody);
         const description = extractDescription(script);
-        const result = (await d.ipcCall("saveAlias", { name, script, description })) as {
+        const result = (await d.ipcCall("saveAlias", { name, script, description, scope })) as {
           ok: boolean;
           filePath: string;
           warnings?: string[];
@@ -122,15 +156,15 @@ export async function cmdAlias(args: string[], deps?: Partial<AliasDeps>): Promi
       }
 
       // Standard save: mcx alias save <name> <@file | - | script>
-      const name = args[1];
+      const name = saveArgs[1];
       if (!name) {
         d.printError(
-          "Usage: mcx alias save <name> <@file | - | script>\n       mcx alias save -c '{...defineAlias body...}'",
+          "Usage: mcx alias save <name> <@file | - | script> [--scope global|null|<path>]\n       mcx alias save -c '{...defineAlias body...}'",
         );
         d.exit(1);
       }
 
-      const source = args[2];
+      const source = saveArgs[2];
       let script: string;
 
       if (!source || source === "-") {
@@ -141,7 +175,7 @@ export async function cmdAlias(args: string[], deps?: Partial<AliasDeps>): Promi
         script = d.readFileWithLimit(source.slice(1));
       } else {
         // Inline script (remaining args joined)
-        script = args.slice(2).join(" ");
+        script = saveArgs.slice(2).join(" ");
       }
 
       if (!script.trim()) {
@@ -150,7 +184,7 @@ export async function cmdAlias(args: string[], deps?: Partial<AliasDeps>): Promi
       }
 
       const description = extractDescription(script);
-      const result = (await d.ipcCall("saveAlias", { name, script, description })) as {
+      const result = (await d.ipcCall("saveAlias", { name, script, description, scope })) as {
         ok: boolean;
         filePath: string;
         warnings?: string[];

--- a/packages/command/src/commands/alias.ts
+++ b/packages/command/src/commands/alias.ts
@@ -57,7 +57,10 @@ export function parseScopeFlag(
   const rest: string[] = [];
   let raw: string | undefined;
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--scope" && i + 1 < args.length) {
+    if (args[i] === "--scope") {
+      if (i + 1 >= args.length) {
+        throw new Error("--scope requires a value (null, legacy, global, or a path)");
+      }
       raw = args[++i];
       continue;
     }
@@ -70,8 +73,15 @@ export function parseScopeFlag(
   if (raw === undefined) return { scope: "global", scopeDefaulted: true, rest };
   if (raw === "null" || raw === "legacy") return { scope: null, scopeDefaulted: false, rest };
   if (raw === "global") return { scope: "global", scopeDefaulted: false, rest };
-  // Treat anything else as a path — resolve to absolute
-  return { scope: resolve(cwd, raw), scopeDefaulted: false, rest };
+  if (raw === "") {
+    throw new Error("--scope value cannot be empty");
+  }
+  // Treat anything else as a path — resolve to absolute, reject null bytes
+  const resolved = resolve(cwd, raw);
+  if (resolved.includes("\0") || resolved === "/") {
+    throw new Error(`--scope path is invalid: ${JSON.stringify(raw)}`);
+  }
+  return { scope: resolved, scopeDefaulted: false, rest };
 }
 
 /** Wrap a defineAlias object literal body into a full script */
@@ -113,7 +123,14 @@ export async function cmdAlias(args: string[], deps?: Partial<AliasDeps>): Promi
 
     case "save": {
       // Strip --scope first so it doesn't interfere with -c/positional parsing.
-      const { scope, rest: saveArgs } = parseScopeFlag(args);
+      let scope: string | null;
+      let saveArgs: string[];
+      try {
+        ({ scope, rest: saveArgs } = parseScopeFlag(args));
+      } catch (err) {
+        d.printError(err instanceof Error ? err.message : String(err));
+        d.exit(1);
+      }
 
       // Parse -c / --code flag
       const codeIdx = saveArgs.indexOf("-c") !== -1 ? saveArgs.indexOf("-c") : saveArgs.indexOf("--code");

--- a/packages/command/src/commands/run.spec.ts
+++ b/packages/command/src/commands/run.spec.ts
@@ -85,6 +85,7 @@ describe("cmdRun promotion hint", () => {
       exit: mock(() => {
         throw new Error("exit called");
       }) as unknown as CmdRunDeps["exit"],
+      cwd: mock(() => "/tmp"),
       ...overrides,
     };
   }

--- a/packages/command/src/commands/run.ts
+++ b/packages/command/src/commands/run.ts
@@ -17,6 +17,7 @@ export interface CmdRunDeps {
   printError: typeof printError;
   logError: (msg: string) => void;
   exit: (code: number) => never;
+  cwd: () => string;
 }
 
 const defaultDeps: CmdRunDeps = {
@@ -26,7 +27,21 @@ const defaultDeps: CmdRunDeps = {
   printError,
   logError: (msg) => console.error(msg),
   exit: (code) => process.exit(code),
+  cwd: () => process.cwd(),
 };
+
+/**
+ * Check whether an alias with `scope` is callable from `cwd`.
+ * - `null`/`undefined`: always allowed (legacy)
+ * - `"global"`: always allowed
+ * - absolute path: allowed only when cwd starts with that path
+ */
+export function isScopeAllowed(scope: string | null | undefined, cwd: string): boolean {
+  if (scope == null || scope === "global") return true;
+  if (!scope.startsWith("/")) return true;
+  const prefix = scope.endsWith("/") ? scope : `${scope}/`;
+  return cwd === scope || cwd.startsWith(prefix);
+}
 
 export async function cmdRun(args: string[], deps?: Partial<CmdRunDeps>): Promise<{ _recordPromise: Promise<void> }> {
   const d: CmdRunDeps = { ...defaultDeps, ...deps };
@@ -41,6 +56,11 @@ export async function cmdRun(args: string[], deps?: Partial<CmdRunDeps>): Promis
   const aliasInfo = await d.ipcCall("getAlias", { name: aliasName });
   if (!aliasInfo) {
     d.printError(`Alias "${aliasName}" not found`);
+    d.exit(1);
+  }
+
+  if (!isScopeAllowed(aliasInfo.scope, d.cwd())) {
+    d.printError(`Alias "${aliasName}" is scoped to ${aliasInfo.scope} — cannot run from ${d.cwd()}`);
     d.exit(1);
   }
 

--- a/packages/command/src/commands/run.ts
+++ b/packages/command/src/commands/run.ts
@@ -6,6 +6,7 @@
  * --key value pairs are passed as CLI args (available in ctx.args).
  */
 
+import { relative, resolve } from "node:path";
 import { type IpcMethod, type IpcMethodResult, options as coreOptions, ipcCall, readCliConfig } from "@mcp-cli/core";
 import { runAlias } from "../alias-runner";
 import { printError } from "../output";
@@ -38,9 +39,16 @@ const defaultDeps: CmdRunDeps = {
  */
 export function isScopeAllowed(scope: string | null | undefined, cwd: string): boolean {
   if (scope == null || scope === "global") return true;
-  if (!scope.startsWith("/")) return true;
-  const prefix = scope.endsWith("/") ? scope : `${scope}/`;
-  return cwd === scope || cwd.startsWith(prefix);
+  // Anything that isn't `null`, `"global"`, or an absolute path is malformed —
+  // fail closed so a misconfigured scope can't accidentally grant global access.
+  if (!scope.startsWith("/")) return false;
+  const normalizedScope = resolve(scope);
+  const normalizedCwd = resolve(cwd);
+  if (normalizedCwd === normalizedScope) return true;
+  const rel = relative(normalizedScope, normalizedCwd);
+  // `relative` returns "" for same path, a non-".." path for inside,
+  // and a path starting with ".." (or an absolute path on Windows) for outside.
+  return rel !== "" && !rel.startsWith("..") && !rel.startsWith("/");
 }
 
 export async function cmdRun(args: string[], deps?: Partial<CmdRunDeps>): Promise<{ _recordPromise: Promise<void> }> {

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -438,11 +438,13 @@ async function main(): Promise<void> {
           break;
         }
 
-        // Check if command matches an alias name → run it
-        // Only check if daemon is already running to avoid 5s startup delay on typos
+        // Check if command matches an alias name → run it.
+        // Only aliases with scope IS NULL are dispatched at the top level.
+        // `global` and path-scoped aliases are invisible here; use `mcx alias run` or `mcx call _aliases`.
+        // Only check if daemon is already running to avoid 5s startup delay on typos.
         if (!command.startsWith("-") && (await isDaemonRunning())) {
           const alias = await ipcCall("getAlias", { name: command });
-          if (alias) {
+          if (alias && (alias.scope == null || alias.scope === undefined)) {
             const { _recordPromise } = await cmdRun([command, ...cleanArgs.slice(1)]);
             await _recordPromise;
             break;

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -444,7 +444,7 @@ async function main(): Promise<void> {
         // Only check if daemon is already running to avoid 5s startup delay on typos.
         if (!command.startsWith("-") && (await isDaemonRunning())) {
           const alias = await ipcCall("getAlias", { name: command });
-          if (alias && (alias.scope == null || alias.scope === undefined)) {
+          if (alias && alias.scope == null) {
             const { _recordPromise } = await cmdRun([command, ...cleanArgs.slice(1)]);
             await _recordPromise;
             break;

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -137,6 +137,13 @@ export const SaveAliasParamsSchema = z.object({
   outputSchema: z.record(z.string(), z.unknown()).optional(),
   /** Absolute ms timestamp when this alias expires (ephemeral aliases only) */
   expiresAt: z.number().optional(),
+  /**
+   * Dispatch scope:
+   * - `null`/omitted: top-level `mcx <name>` dispatch enabled, callable anywhere
+   * - `"global"`: callable via run/MCP, hidden from top-level dispatch
+   * - absolute path: callable only when cwd is inside that path
+   */
+  scope: z.union([z.literal("global"), z.string().startsWith("/"), z.null()]).optional(),
 });
 
 export const DeleteAliasParamsSchema = z.object({
@@ -177,6 +184,12 @@ export interface AliasInfo {
   runCount?: number;
   /** Epoch seconds of last run (null = never run) */
   lastRunAt?: number | null;
+  /**
+   * Dispatch scope (see SaveAliasParamsSchema).
+   * `null` = legacy top-level dispatch. `"global"` = hidden from top-level.
+   * Absolute path = cwd-restricted.
+   */
+  scope?: string | null;
 }
 
 export interface AliasDetail extends AliasInfo {

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -143,7 +143,16 @@ export const SaveAliasParamsSchema = z.object({
    * - `"global"`: callable via run/MCP, hidden from top-level dispatch
    * - absolute path: callable only when cwd is inside that path
    */
-  scope: z.union([z.literal("global"), z.string().startsWith("/"), z.null()]).optional(),
+  scope: z
+    .union([
+      z.literal("global"),
+      // Absolute path: must start with "/", be longer than just "/", and contain no NUL bytes.
+      z
+        .string()
+        .regex(/^\/[^\0]+$/, "scope must be an absolute path"),
+      z.null(),
+    ])
+    .optional(),
 });
 
 export const DeleteAliasParamsSchema = z.object({

--- a/packages/daemon/src/db/alias-scope.spec.ts
+++ b/packages/daemon/src/db/alias-scope.spec.ts
@@ -63,4 +63,39 @@ describe("aliases.scope column", () => {
     db.saveAlias("x", "/tmp/x.ts", "d", "freeform", undefined, undefined, undefined, undefined, undefined, null);
     expect(db.getAlias("x")?.scope).toBeNull();
   });
+
+  test("scopeProvided=false preserves existing scope atomically (TOCTOU fix)", () => {
+    // Pre-seed with a path scope.
+    db.saveAlias(
+      "keep",
+      "/tmp/keep.ts",
+      "d",
+      "freeform",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "/workspace/repo",
+    );
+    expect(db.getAlias("keep")?.scope).toBe("/workspace/repo");
+
+    // Upsert without providing a scope — the SQL CASE branch must keep the
+    // existing value instead of clobbering with the caller's placeholder null.
+    db.saveAlias(
+      "keep",
+      "/tmp/keep.ts",
+      "new description",
+      "freeform",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      null, // placeholder — caller didn't actually supply a scope
+      false, // scopeProvided=false
+    );
+    expect(db.getAlias("keep")?.scope).toBe("/workspace/repo");
+    expect(db.getAlias("keep")?.description).toBe("new description");
+  });
 });

--- a/packages/daemon/src/db/alias-scope.spec.ts
+++ b/packages/daemon/src/db/alias-scope.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for the aliases.scope column introduced in #1289.
+ *
+ * Verifies:
+ *  - legacy NULL rows round-trip unchanged (regression guard)
+ *  - global scope is persisted and round-trips
+ *  - path scope is persisted and round-trips
+ *  - scope survives upsert when the same column is rewritten explicitly
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { StateDb } from "./state";
+
+describe("aliases.scope column", () => {
+  let tmpDir: string;
+  let db: StateDb;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "mcp-alias-scope-"));
+    db = new StateDb(join(tmpDir, "state.db"));
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("legacy save (no scope) round-trips as null", () => {
+    db.saveAlias("legacy", "/tmp/legacy.ts", "desc");
+    const row = db.getAlias("legacy");
+    expect(row?.scope).toBeNull();
+    const list = db.listAliases();
+    expect(list.find((a) => a.name === "legacy")?.scope).toBeNull();
+  });
+
+  test("global scope is persisted", () => {
+    db.saveAlias("g", "/tmp/g.ts", "desc", "freeform", undefined, undefined, undefined, undefined, undefined, "global");
+    expect(db.getAlias("g")?.scope).toBe("global");
+  });
+
+  test("path scope is persisted", () => {
+    db.saveAlias(
+      "p",
+      "/tmp/p.ts",
+      "desc",
+      "freeform",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "/workspace/repo",
+    );
+    expect(db.getAlias("p")?.scope).toBe("/workspace/repo");
+  });
+
+  test("explicit null scope clears existing scope on upsert", () => {
+    db.saveAlias("x", "/tmp/x.ts", "d", "freeform", undefined, undefined, undefined, undefined, undefined, "global");
+    expect(db.getAlias("x")?.scope).toBe("global");
+    db.saveAlias("x", "/tmp/x.ts", "d", "freeform", undefined, undefined, undefined, undefined, undefined, null);
+    expect(db.getAlias("x")?.scope).toBeNull();
+  });
+});

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -222,6 +222,11 @@ export class StateDb {
     } catch {
       /* column already exists */
     }
+    try {
+      this.db.exec("ALTER TABLE aliases ADD COLUMN scope TEXT");
+    } catch {
+      /* column already exists */
+    }
 
     // -- Trace context columns on usage_stats --
     try {
@@ -616,6 +621,7 @@ export class StateDb {
     expiresAt?: number | null;
     runCount: number;
     lastRunAt: number | null;
+    scope: string | null;
   }> {
     this.maybeRunAliasPrune();
     return this.db
@@ -631,10 +637,11 @@ export class StateDb {
           expires_at: number | null;
           run_count: number;
           last_run_at: number | null;
+          scope: string | null;
         },
         [number]
       >(
-        "SELECT name, description, file_path, updated_at, alias_type, input_schema_json, output_schema_json, expires_at, run_count, last_run_at FROM aliases WHERE expires_at IS NULL OR expires_at > ? ORDER BY name",
+        "SELECT name, description, file_path, updated_at, alias_type, input_schema_json, output_schema_json, expires_at, run_count, last_run_at, scope FROM aliases WHERE expires_at IS NULL OR expires_at > ? ORDER BY name",
       )
       .all(Date.now())
       .map((row) => ({
@@ -648,6 +655,7 @@ export class StateDb {
         expiresAt: row.expires_at,
         runCount: row.run_count,
         lastRunAt: row.last_run_at,
+        scope: row.scope,
       }));
   }
 
@@ -662,6 +670,7 @@ export class StateDb {
         expiresAt?: number | null;
         runCount: number;
         lastRunAt: number | null;
+        scope: string | null;
       }
     | undefined {
     const row = this.db
@@ -676,10 +685,11 @@ export class StateDb {
           expires_at: number | null;
           run_count: number;
           last_run_at: number | null;
+          scope: string | null;
         },
         [string]
       >(
-        "SELECT name, description, file_path, alias_type, bundled_js, source_hash, expires_at, run_count, last_run_at FROM aliases WHERE name = ?",
+        "SELECT name, description, file_path, alias_type, bundled_js, source_hash, expires_at, run_count, last_run_at, scope FROM aliases WHERE name = ?",
       )
       .get(name);
     if (!row) return undefined;
@@ -693,6 +703,7 @@ export class StateDb {
       expiresAt: row.expires_at,
       runCount: row.run_count,
       lastRunAt: row.last_run_at,
+      scope: row.scope,
     };
   }
 
@@ -706,6 +717,7 @@ export class StateDb {
     bundledJs?: string,
     sourceHash?: string,
     expiresAt?: number,
+    scope?: string | null,
   ): void {
     // If the caller is saving an ephemeral alias (expiresAt set), refuse to
     // overwrite an existing permanent alias (expires_at IS NULL). This prevents
@@ -721,8 +733,8 @@ export class StateDb {
     }
 
     this.db.run(
-      `INSERT INTO aliases (name, file_path, description, alias_type, input_schema_json, output_schema_json, bundled_js, source_hash, expires_at, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, unixepoch(), unixepoch())
+      `INSERT INTO aliases (name, file_path, description, alias_type, input_schema_json, output_schema_json, bundled_js, source_hash, expires_at, scope, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, unixepoch(), unixepoch())
        ON CONFLICT(name) DO UPDATE SET
          file_path = excluded.file_path,
          description = excluded.description,
@@ -732,6 +744,7 @@ export class StateDb {
          bundled_js = excluded.bundled_js,
          source_hash = excluded.source_hash,
          expires_at = excluded.expires_at,
+         scope = excluded.scope,
          updated_at = unixepoch()`,
       [
         name,
@@ -743,6 +756,7 @@ export class StateDb {
         bundledJs ?? null,
         sourceHash ?? null,
         expiresAt ?? null,
+        scope ?? null,
       ],
     );
   }

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -224,8 +224,12 @@ export class StateDb {
     }
     try {
       this.db.exec("ALTER TABLE aliases ADD COLUMN scope TEXT");
-    } catch {
-      /* column already exists */
+    } catch (err) {
+      // Only swallow the "column already exists" case; rethrow anything else
+      // (disk-full, permissions, corruption) so it surfaces instead of silently
+      // leaving the schema unmigrated.
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!/duplicate column name: scope/i.test(msg)) throw err;
     }
 
     // -- Trace context columns on usage_stats --
@@ -718,6 +722,7 @@ export class StateDb {
     sourceHash?: string,
     expiresAt?: number,
     scope?: string | null,
+    scopeProvided = true,
   ): void {
     // If the caller is saving an ephemeral alias (expiresAt set), refuse to
     // overwrite an existing permanent alias (expires_at IS NULL). This prevents
@@ -744,7 +749,7 @@ export class StateDb {
          bundled_js = excluded.bundled_js,
          source_hash = excluded.source_hash,
          expires_at = excluded.expires_at,
-         scope = excluded.scope,
+         scope = CASE WHEN ?11 = 1 THEN excluded.scope ELSE aliases.scope END,
          updated_at = unixepoch()`,
       [
         name,
@@ -757,6 +762,7 @@ export class StateDb {
         sourceHash ?? null,
         expiresAt ?? null,
         scope ?? null,
+        scopeProvided ? 1 : 0,
       ],
     );
   }

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -720,7 +720,9 @@ export class IpcServer {
         }
       }
 
-      const scope: string | null = scopeProvided ? (parsed.scope ?? null) : (this.db.getAlias(name)?.scope ?? null);
+      // When caller didn't supply scope, pass scopeProvided=false so the SQL
+      // UPDATE branch preserves the existing row's scope atomically (no TOCTOU).
+      const scope: string | null = scopeProvided ? (parsed.scope ?? null) : null;
 
       const isStructured = isDefineAlias(script);
 
@@ -764,6 +766,7 @@ export class IpcServer {
             sourceHash,
             expiresAt,
             scope ?? null,
+            scopeProvided,
           );
         } else {
           this.db.saveAlias(
@@ -777,6 +780,7 @@ export class IpcServer {
             sourceHash,
             expiresAt,
             scope ?? null,
+            scopeProvided,
           );
         }
       } catch (err) {
@@ -793,6 +797,7 @@ export class IpcServer {
           undefined,
           expiresAt,
           scope ?? null,
+          scopeProvided,
         );
       }
 

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -702,7 +702,12 @@ export class IpcServer {
     });
 
     this.handlers.set("saveAlias", async (params, _ctx) => {
-      const { name, script, description, expiresAt } = SaveAliasParamsSchema.parse(params);
+      const parsed = SaveAliasParamsSchema.parse(params);
+      const { name, script, description, expiresAt } = parsed;
+      // If the caller did not supply `scope`, preserve the existing row's scope.
+      // An explicit `null` clears scope; an explicit string sets it.
+      const scopeProvided =
+        typeof params === "object" && params !== null && Object.prototype.hasOwnProperty.call(params, "scope");
       const filePath = safeAliasPath(name);
       mkdirSync(options.ALIASES_DIR, { recursive: true });
 
@@ -714,6 +719,8 @@ export class IpcServer {
           return { ok: false, reason: "permanent_alias_exists" };
         }
       }
+
+      const scope: string | null = scopeProvided ? (parsed.scope ?? null) : (this.db.getAlias(name)?.scope ?? null);
 
       const isStructured = isDefineAlias(script);
 
@@ -756,9 +763,21 @@ export class IpcServer {
             js,
             sourceHash,
             expiresAt,
+            scope ?? null,
           );
         } else {
-          this.db.saveAlias(name, filePath, description, aliasType, undefined, undefined, js, sourceHash, expiresAt);
+          this.db.saveAlias(
+            name,
+            filePath,
+            description,
+            aliasType,
+            undefined,
+            undefined,
+            js,
+            sourceHash,
+            expiresAt,
+            scope ?? null,
+          );
         }
       } catch (err) {
         // Bundle/extraction failed — save without bundle
@@ -773,6 +792,7 @@ export class IpcServer {
           undefined,
           undefined,
           expiresAt,
+          scope ?? null,
         );
       }
 


### PR DESCRIPTION
## Summary

Introduces a nullable `scope` column on the `aliases` table that discriminates top-level dispatch. Foundation for the phase/manifest epic (#1286).

| scope | `mcx <name>` | run/mcp | cwd restriction |
|---|---|---|---|
| `NULL` (legacy rows) | ✅ | ✅ | none |
| `"global"` | ❌ | ✅ | none |
| absolute path | ❌ | ✅ | cwd must start with path |

- Additive migration `ALTER TABLE aliases ADD COLUMN scope TEXT`
- `mcx <name>` top-level resolver filters to `scope IS NULL`
- `mcx alias run` enforces path-scope cwd check (rejects with clear error from wrong cwd)
- `mcx alias save` grows `--scope <global|null|legacy|<path>>`; default `global` per spec
- `saveAlias` IPC handler preserves existing scope when the caller omits `scope` (so `edit`/`promote`/ephemeral saves don't clobber an explicitly-set scope)

## Test plan

- [x] `bun typecheck`
- [x] `bun lint`
- [x] New specs: `packages/daemon/src/db/alias-scope.spec.ts` (round-trip NULL/global/path, explicit null clears scope), `packages/command/src/commands/alias-scope.spec.ts` (flag parsing, `isScopeAllowed`, cwd enforcement in `cmdRun`)
- [x] Updated `alias.spec.ts` save assertions to include the new `scope: "global"` default
- [x] All alias/run/state/ipc-server suites pass (317 tests across 6 files)

## Non-goals

- `mcx phase install` (separate issue — this lands the column + dispatch semantics it will use)
- MCP-path scope enforcement (`mcx call _aliases <tool>`): the alias MCP server has no per-caller cwd; path-scope check is enforced at `mcx alias run` only. Flag for follow-up in the phase install issue.

## Hook bypass

Pushed with `--no-verify` — pre-commit hook blocked on pre-existing t5801-32/-33 flakes in `remote-helper.integration.spec.ts` which also fail on pristine `main` (58dffb86). Tracked in #1309 and being actively fixed in #1283. User authorized this bypass for this commit only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)