### PR TITLE
feat(phases): mcx phase install + .mcx.lock writer (fixes #1291)

### DIFF
--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseLockfile } from "@mcp-cli/core";
+import { checkStateSubset, cmdPhase, resolvePhaseSource } from "./phase";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "mcx-phase-"));
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("resolvePhaseSource", () => {
+  test("resolves relative paths against repo root", () => {
+    expect(resolvePhaseSource("./foo.ts", "/repo")).toBe("/repo/foo.ts");
+  });
+
+  test("resolves bare relative paths against repo root", () => {
+    expect(resolvePhaseSource("scripts/foo.ts", "/repo")).toBe("/repo/scripts/foo.ts");
+  });
+
+  test("passes absolute paths through", () => {
+    expect(resolvePhaseSource("/abs/path.ts", "/repo")).toBe("/abs/path.ts");
+  });
+
+  test("handles file:// URIs", () => {
+    expect(resolvePhaseSource("file:///abs/path.ts", "/repo")).toBe("/abs/path.ts");
+  });
+
+  test("rejects remote `scheme://` URIs", () => {
+    expect(() => resolvePhaseSource("https://example.com/x.ts", "/repo")).toThrow(/remote sources/);
+    expect(() => resolvePhaseSource("github://owner/repo/path.ts", "/repo")).toThrow(/remote sources/);
+  });
+});
+
+describe("checkStateSubset", () => {
+  test("empty phase state is always a subset", () => {
+    expect(checkStateSubset("p", undefined, { foo: "string" })).toEqual([]);
+    expect(checkStateSubset("p", {}, { foo: "string" })).toEqual([]);
+  });
+
+  test("phase key not in manifest state is an error", () => {
+    const errs = checkStateSubset("p", { extra: {} }, { foo: "string" });
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toContain('phase "p"');
+    expect(errs[0]).toContain('"extra"');
+  });
+
+  test("phase is subset of manifest state", () => {
+    expect(checkStateSubset("p", { foo: {} }, { foo: "string", bar: "number" })).toEqual([]);
+  });
+});
+
+const simpleAlias = `
+import { defineAlias, z } from "mcp-cli";
+
+defineAlias(({ z }) => ({
+  name: "implement",
+  description: "Implement phase",
+  input: z.object({ issue: z.number() }),
+  output: z.object({ pr: z.number() }),
+  fn: async (input) => ({ pr: input.issue + 1 }),
+}));
+`.trim();
+
+const simpleManifest = `
+initial: implement
+phases:
+  implement:
+    source: ./impl.ts
+    next: []
+`.trim();
+
+describe("cmdPhase install — integration", () => {
+  test("writes .mcx.lock after resolving sources", async () => {
+    writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);
+    writeFileSync(join(dir, "impl.ts"), simpleAlias);
+
+    const logs: string[] = [];
+    const errs: string[] = [];
+    await cmdPhase(["install"], {
+      cwd: () => dir,
+      log: (m) => logs.push(m),
+      logError: (m) => errs.push(m),
+      exit: ((code: number) => {
+        throw new Error(`exit(${code})`);
+      }) as (code: number) => never,
+    });
+
+    const lockPath = join(dir, ".mcx.lock");
+    expect(existsSync(lockPath)).toBe(true);
+
+    const lock = parseLockfile(readFileSync(lockPath, "utf-8"));
+    expect(lock.version).toBe(1);
+    expect(lock.phases).toHaveLength(1);
+    expect(lock.phases[0].name).toBe("implement");
+    expect(lock.phases[0].resolvedPath).toBe("impl.ts");
+    expect(lock.phases[0].contentHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(lock.phases[0].schemaHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(logs.some((l) => l.includes("Installed 1 phase"))).toBe(true);
+  }, 15_000);
+
+  test("errors when no manifest present", async () => {
+    const errs: string[] = [];
+    let exitCode: number | undefined;
+    await cmdPhase(["install"], {
+      cwd: () => dir,
+      log: () => {},
+      logError: (m) => errs.push(m),
+      exit: ((code: number) => {
+        exitCode = code;
+        throw new Error("exit");
+      }) as (code: number) => never,
+    }).catch(() => {});
+
+    expect(exitCode).toBe(1);
+    expect(errs.some((e) => e.includes("no .mcx.yaml or .mcx.json"))).toBe(true);
+  });
+
+  test("errors when source not found", async () => {
+    writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);
+    // impl.ts missing
+
+    const errs: string[] = [];
+    let exitCode: number | undefined;
+    await cmdPhase(["install"], {
+      cwd: () => dir,
+      log: () => {},
+      logError: (m) => errs.push(m),
+      exit: ((code: number) => {
+        exitCode = code;
+        throw new Error("exit");
+      }) as (code: number) => never,
+    }).catch(() => {});
+
+    expect(exitCode).toBe(1);
+    const joined = errs.join("\n");
+    expect(joined).toContain('phase "implement"');
+    expect(joined).toContain("not found");
+  });
+});

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -1,0 +1,232 @@
+/**
+ * `mcx phase` — declarative phase orchestration (#1286).
+ *
+ * Currently implements `install`: resolves sources in the manifest,
+ * hashes them, extracts phase metadata, writes `.mcx.lock`.
+ *
+ * Scope registration (#1289) and state-schema subset validation (#1290)
+ * are deferred until their dependency PRs merge.
+ */
+
+import { writeFileSync } from "node:fs";
+import { isAbsolute, relative, resolve as resolvePath } from "node:path";
+import {
+  LOCKFILE_NAME,
+  LOCKFILE_VERSION,
+  type LockedPhase,
+  type Lockfile,
+  type Manifest,
+  ManifestError,
+  type ManifestState,
+  bundleAlias,
+  canonicalJson,
+  extractMetadata,
+  hashFileSync,
+  loadManifest,
+  serializeLockfile,
+  sha256Hex,
+} from "@mcp-cli/core";
+import type { AliasMetadata } from "@mcp-cli/core";
+
+export interface PhaseInstallDeps {
+  loadManifest: typeof loadManifest;
+  bundleAlias: typeof bundleAlias;
+  extractMetadata: typeof extractMetadata;
+  hashFileSync: typeof hashFileSync;
+  writeFileSync: typeof writeFileSync;
+  cwd: () => string;
+  log: (msg: string) => void;
+  logError: (msg: string) => void;
+  exit: (code: number) => never;
+}
+
+const defaultDeps: PhaseInstallDeps = {
+  loadManifest,
+  bundleAlias,
+  extractMetadata,
+  hashFileSync,
+  writeFileSync: (path, data) => writeFileSync(path, data, "utf-8"),
+  cwd: () => process.cwd(),
+  log: (msg) => console.log(msg),
+  logError: (msg) => console.error(msg),
+  exit: (code) => process.exit(code),
+};
+
+/**
+ * Resolve a phase `source:` URI into an absolute path.
+ * v1 supports `./relative`, bare relative, absolute, and `file://` forms.
+ * Remote schemes (#1297) are rejected with an actionable message.
+ */
+export function resolvePhaseSource(source: string, repoRoot: string): string {
+  if (source.startsWith("file://")) {
+    const rest = source.slice("file://".length);
+    const path = rest.startsWith("/") ? rest : `/${rest}`;
+    return resolvePath(path);
+  }
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(source)) {
+    throw new Error(`remote sources not yet supported: ${source}`);
+  }
+  return isAbsolute(source) ? resolvePath(source) : resolvePath(repoRoot, source);
+}
+
+/**
+ * Compare a phase's declared state schema (as extracted from defineAlias)
+ * against the manifest's state declaration. The phase may narrow, never
+ * widen: every key it declares must exist in the manifest's `state:`.
+ *
+ * v1 uses the manifest state DSL (`string`/`number`/`boolean`[?]) as the
+ * authoritative key-set. When defineAlias gains a `state` field (#1290),
+ * the extractor will surface it here.
+ */
+export function checkStateSubset(
+  phaseName: string,
+  phaseState: Record<string, unknown> | undefined,
+  manifestState: ManifestState | undefined,
+): string[] {
+  if (!phaseState) return [];
+  const allowed = new Set(Object.keys(manifestState ?? {}));
+  const errors: string[] = [];
+  for (const key of Object.keys(phaseState)) {
+    if (!allowed.has(key)) {
+      errors.push(`phase "${phaseName}" declares state field "${key}" not present in manifest state schema`);
+    }
+  }
+  return errors;
+}
+
+interface InstallResult {
+  manifest: Manifest;
+  manifestPath: string;
+  lockfile: Lockfile;
+  warnings: string[];
+}
+
+export async function installPhases(cwd: string, deps: PhaseInstallDeps): Promise<InstallResult> {
+  const loaded = deps.loadManifest(cwd);
+  if (!loaded) {
+    throw new Error("no .mcx.yaml or .mcx.json in this repo");
+  }
+
+  const { path: manifestPath, manifest } = loaded;
+  const manifestHash = deps.hashFileSync(manifestPath);
+
+  const warnings: string[] = [];
+  const errors: string[] = [];
+  const phases: LockedPhase[] = [];
+
+  const phaseNames = Object.keys(manifest.phases).sort();
+  for (const name of phaseNames) {
+    const phase = manifest.phases[name];
+    let resolvedAbs: string;
+    try {
+      resolvedAbs = resolvePhaseSource(phase.source, cwd);
+    } catch (err) {
+      errors.push(`phase "${name}": ${err instanceof Error ? err.message : String(err)}`);
+      continue;
+    }
+
+    let contentHash: string;
+    try {
+      contentHash = deps.hashFileSync(resolvedAbs);
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      if (e?.code === "ENOENT") {
+        errors.push(`phase "${name}": source ${phase.source} not found`);
+      } else {
+        errors.push(`phase "${name}": cannot read ${phase.source}: ${e?.message ?? String(err)}`);
+      }
+      continue;
+    }
+
+    let meta: AliasMetadata;
+    try {
+      const bundle = await deps.bundleAlias(resolvedAbs);
+      meta = await deps.extractMetadata(bundle.js);
+    } catch (err) {
+      errors.push(`phase "${name}": bundle failed: ${err instanceof Error ? err.message : String(err)}`);
+      continue;
+    }
+
+    const subsetErrs = checkStateSubset(
+      name,
+      (meta as AliasMetadata & { state?: Record<string, unknown> }).state,
+      manifest.state,
+    );
+    errors.push(...subsetErrs);
+
+    const schemaHash = meta.outputSchema ? sha256Hex(canonicalJson(meta.outputSchema)) : "";
+    const rel = relative(cwd, resolvedAbs).split("\\").join("/");
+    phases.push({
+      name,
+      resolvedPath: rel === "" ? "." : rel,
+      contentHash,
+      schemaHash,
+    });
+  }
+
+  if (errors.length > 0) {
+    errors.sort();
+    throw new ManifestError(errors.join("\n"), manifestPath);
+  }
+
+  const lockfile: Lockfile = {
+    version: LOCKFILE_VERSION,
+    manifestHash,
+    phases,
+  };
+
+  return { manifest, manifestPath, lockfile, warnings };
+}
+
+export async function cmdPhase(args: string[], deps?: Partial<PhaseInstallDeps>): Promise<void> {
+  const d: PhaseInstallDeps = { ...defaultDeps, ...deps };
+  const sub = args[0];
+
+  switch (sub) {
+    case "install": {
+      const cwd = d.cwd();
+      let result: InstallResult;
+      try {
+        result = await installPhases(cwd, d);
+      } catch (err) {
+        if (err instanceof ManifestError) {
+          d.logError(err.message);
+        } else {
+          d.logError(err instanceof Error ? err.message : String(err));
+        }
+        d.exit(1);
+      }
+
+      const lockPath = resolvePath(cwd, LOCKFILE_NAME);
+      d.writeFileSync(lockPath, serializeLockfile(result.lockfile));
+
+      const count = result.lockfile.phases.length;
+      d.log(`Installed ${count} phase${count === 1 ? "" : "s"} → ${LOCKFILE_NAME}`);
+      for (const p of result.lockfile.phases) {
+        d.log(`  ${p.name}  ${p.resolvedPath}  ${p.contentHash.slice(0, 12)}`);
+      }
+      for (const w of result.warnings) {
+        d.logError(`  ⚠ ${w}`);
+      }
+      d.logError(
+        "note: scope registration (#1289) and state-schema subset (#1290) are deferred — lockfile written, aliases not yet scoped.",
+      );
+      break;
+    }
+
+    default: {
+      printPhaseHelp(d);
+      const isHelp = !sub || sub === "help" || sub === "--help" || sub === "-h";
+      if (!isHelp) d.exit(1);
+      break;
+    }
+  }
+}
+
+function printPhaseHelp(d: PhaseInstallDeps): void {
+  d.logError(`Usage: mcx phase <command>
+
+Commands:
+  install    Resolve sources from .mcx.{yaml,json}, hash, write .mcx.lock
+`);
+}

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -8,7 +8,7 @@
  * are deferred until their dependency PRs merge.
  */
 
-import { writeFileSync } from "node:fs";
+import { renameSync, writeFileSync } from "node:fs";
 import { isAbsolute, relative, resolve as resolvePath } from "node:path";
 import {
   LOCKFILE_NAME,
@@ -147,12 +147,12 @@ export async function installPhases(cwd: string, deps: PhaseInstallDeps): Promis
       continue;
     }
 
-    const subsetErrs = checkStateSubset(
-      name,
-      (meta as AliasMetadata & { state?: Record<string, unknown> }).state,
-      manifest.state,
-    );
-    errors.push(...subsetErrs);
+    // state field wires in with #1290 — no-op until AliasMetadata carries it
+    const subsetErrs = checkStateSubset(name, undefined, manifest.state);
+    if (subsetErrs.length > 0) {
+      errors.push(...subsetErrs);
+      continue;
+    }
 
     const schemaHash = meta.outputSchema ? sha256Hex(canonicalJson(meta.outputSchema)) : "";
     const rel = relative(cwd, resolvedAbs).split("\\").join("/");
@@ -198,7 +198,9 @@ export async function cmdPhase(args: string[], deps?: Partial<PhaseInstallDeps>)
       }
 
       const lockPath = resolvePath(cwd, LOCKFILE_NAME);
-      d.writeFileSync(lockPath, serializeLockfile(result.lockfile));
+      const tmpPath = `${lockPath}.tmp`;
+      d.writeFileSync(tmpPath, serializeLockfile(result.lockfile));
+      renameSync(tmpPath, lockPath);
 
       const count = result.lockfile.phases.length;
       d.log(`Installed ${count} phase${count === 1 ? "" : "s"} → ${LOCKFILE_NAME}`);

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -41,6 +41,7 @@ import { cmdInstall } from "./commands/install";
 import { cmdLogs } from "./commands/logs";
 import { cmdMail } from "./commands/mail";
 import { cmdNote } from "./commands/note";
+import { cmdPhase } from "./commands/phase";
 import { cmdRegistryDispatch } from "./commands/registry-cmd";
 import { cmdRemove } from "./commands/remove";
 import { cmdRun } from "./commands/run";
@@ -290,6 +291,10 @@ async function main(): Promise<void> {
 
       case "gc":
         await cmdGc(cleanArgs.slice(1), { dryRun: _dryRun });
+        break;
+
+      case "phase":
+        await cmdPhase(cleanArgs.slice(1));
         break;
 
       case "auth":

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,7 @@ export * from "./trace";
 export * from "./git";
 export * from "./logger";
 export * from "./manifest";
+export * from "./manifest-lock";
 export * from "./worktree-config";
 export * from "./worktree-shim";
 export * from "./plan";

--- a/packages/core/src/manifest-lock.spec.ts
+++ b/packages/core/src/manifest-lock.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import {
+  LOCKFILE_VERSION,
+  type Lockfile,
+  canonicalJson,
+  parseLockfile,
+  serializeLockfile,
+  sha256Hex,
+} from "./manifest-lock";
+
+const H = "a".repeat(64);
+const H2 = "b".repeat(64);
+
+describe("sha256Hex", () => {
+  test("hashes a known string", () => {
+    expect(sha256Hex("hello")).toBe("2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824");
+  });
+});
+
+describe("canonicalJson", () => {
+  test("sorts object keys", () => {
+    expect(canonicalJson({ b: 1, a: 2 })).toBe('{"a":2,"b":1}');
+  });
+
+  test("recurses into nested objects", () => {
+    expect(canonicalJson({ x: { z: 1, y: 2 } })).toBe('{"x":{"y":2,"z":1}}');
+  });
+
+  test("preserves array order", () => {
+    expect(canonicalJson([3, 1, 2])).toBe("[3,1,2]");
+  });
+});
+
+describe("serializeLockfile / parseLockfile", () => {
+  const lock: Lockfile = {
+    version: LOCKFILE_VERSION,
+    manifestHash: H,
+    phases: [
+      { name: "review", resolvedPath: "scripts/review.ts", contentHash: H2, schemaHash: "" },
+      { name: "implement", resolvedPath: "scripts/implement.ts", contentHash: H, schemaHash: H2 },
+    ],
+  };
+
+  test("serializes phases sorted by name", () => {
+    const s = serializeLockfile(lock);
+    const implementIdx = s.indexOf("implement");
+    const reviewIdx = s.indexOf("review");
+    expect(implementIdx).toBeGreaterThan(0);
+    expect(implementIdx).toBeLessThan(reviewIdx);
+  });
+
+  test("ends with a newline", () => {
+    expect(serializeLockfile(lock).endsWith("\n")).toBe(true);
+  });
+
+  test("round-trips through parseLockfile", () => {
+    const parsed = parseLockfile(serializeLockfile(lock));
+    expect(parsed.manifestHash).toBe(H);
+    expect(parsed.phases).toHaveLength(2);
+    expect(parsed.phases[0].name).toBe("implement");
+  });
+
+  test("rejects bad hash format", () => {
+    const bad = { ...lock, manifestHash: "not-hex" };
+    expect(() => parseLockfile(JSON.stringify(bad))).toThrow();
+  });
+
+  test("rejects unknown version", () => {
+    const bad = { ...lock, version: 2 };
+    expect(() => parseLockfile(JSON.stringify(bad))).toThrow();
+  });
+});

--- a/packages/core/src/manifest-lock.ts
+++ b/packages/core/src/manifest-lock.ts
@@ -1,0 +1,80 @@
+/**
+ * `.mcx.lock` — install-time lockfile for the phase manifest.
+ *
+ * Written by `mcx phase install` (#1291). Consumed by drift detection
+ * (#1292) and runtime phase dispatch. Committed to the repo — it is
+ * authoritative over the manifest at run time.
+ *
+ * Format v1: JSON, keys sorted (deterministic), LF line endings.
+ */
+
+import { readFileSync } from "node:fs";
+import { z } from "zod";
+
+export const LOCKFILE_NAME = ".mcx.lock";
+export const LOCKFILE_VERSION = 1;
+
+export const LockedPhaseSchema = z
+  .object({
+    /** Phase name from manifest. */
+    name: z.string(),
+    /** Path relative to the repo root, forward slashes. */
+    resolvedPath: z.string(),
+    /** sha256 of the source file contents (hex). */
+    contentHash: z.string().regex(/^[a-f0-9]{64}$/),
+    /** sha256 of the extracted output-schema JSON, or empty string if none. */
+    schemaHash: z.string().regex(/^([a-f0-9]{64}|)$/),
+  })
+  .strict();
+export type LockedPhase = z.infer<typeof LockedPhaseSchema>;
+
+export const LockfileSchema = z
+  .object({
+    version: z.literal(LOCKFILE_VERSION),
+    /** sha256 of the raw manifest file contents (hex). */
+    manifestHash: z.string().regex(/^[a-f0-9]{64}$/),
+    /** Phases, sorted alphabetically by name. */
+    phases: z.array(LockedPhaseSchema),
+  })
+  .strict();
+export type Lockfile = z.infer<typeof LockfileSchema>;
+
+/** Compute the sha256 hex hash of a utf-8 string. */
+export function sha256Hex(input: string | Uint8Array | ArrayBuffer): string {
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(input as Parameters<Bun.CryptoHasher["update"]>[0]);
+  return hasher.digest("hex");
+}
+
+/** Compute the sha256 of a file's contents. */
+export function hashFileSync(path: string): string {
+  return sha256Hex(readFileSync(path));
+}
+
+/** Deterministic JSON.stringify with sorted object keys (recursive). */
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(value, (_k, v) => {
+    if (v && typeof v === "object" && !Array.isArray(v)) {
+      const o = v as Record<string, unknown>;
+      const sorted: Record<string, unknown> = {};
+      for (const k of Object.keys(o).sort()) sorted[k] = o[k];
+      return sorted;
+    }
+    return v;
+  });
+}
+
+/** Serialize a lockfile to its on-disk string form (trailing newline). */
+export function serializeLockfile(lock: Lockfile): string {
+  const sorted: Lockfile = {
+    ...lock,
+    phases: [...lock.phases].sort((a, b) => a.name.localeCompare(b.name)),
+  };
+  return `${JSON.stringify(sorted, null, 2)}\n`;
+}
+
+/** Parse a lockfile string; throws on structural issues. */
+export function parseLockfile(text: string): Lockfile {
+  const raw = JSON.parse(text) as unknown;
+  return LockfileSchema.parse(raw);
+}


### PR DESCRIPTION
## Summary
- New `mcx phase install` command: reads `.mcx.{yaml,json}`, resolves each phase's `source:` (relative + `file://`), bundles it via `bundleAlias`, computes content + schema hashes, and writes `.mcx.lock`.
- New `packages/core/src/manifest-lock.ts`: lockfile schema (Zod), deterministic serializer, `sha256Hex` + `canonicalJson` helpers.
- Scope registration (#1289) and state-schema subset enforcement (#1290) are **deferred** — their dependency PRs (#1310, #1307) haven't merged. The subset-check plumbing (`checkStateSubset`) is in place and no-ops when phases don't declare state; wiring it to `defineAlias({ state })` lands with #1290. The install command emits a stderr note that aliases are not yet scope-registered.

## Test plan
- [x] `packages/core/src/manifest-lock.spec.ts` — hash/canonical/round-trip, rejects bad hex + wrong version
- [x] `packages/command/src/commands/phase.spec.ts` — URI resolution (relative, bare, absolute, `file://`, rejects `scheme://`), state-subset check, end-to-end install writes valid lockfile, error paths (missing manifest, missing source)
- [x] `bun typecheck` + `bun lint` + full `bun test` (4752 pass, 0 fail)

## Deferred / follow-ups
- Alias registration with `scope=<repo-abs-path>` — waits on #1289
- `defineAlias({ state: zodSchema })` extraction + enforcement — waits on #1290
- Drift detection at run time — tracked separately (#1292)
- Remote source schemes (`github:`, `https:`) — rejected for now; resolver lands in #1297

🤖 Generated with [Claude Code](https://claude.com/claude-code)