### PR TITLE
feat(phases): runsOn branch guard (fixes #1294)

### DIFF
--- a/packages/core/src/branch-guard.spec.ts
+++ b/packages/core/src/branch-guard.spec.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "bun:test";
+import { BranchGuardError, DEFAULT_RUNS_ON, checkRunsOn, currentBranch } from "./branch-guard";
+import type { ExecFn, ExecResult } from "./git";
+import type { Manifest } from "./manifest";
+
+type CmdKey = string;
+
+function mockExec(responses: Record<CmdKey, ExecResult>): ExecFn {
+  return (cmd: string[]): ExecResult => {
+    const key = cmd.join(" ");
+    const resp = responses[key];
+    if (!resp) {
+      return { stdout: "", exitCode: 128 };
+    }
+    return resp;
+  };
+}
+
+const CWD = "/repo";
+
+function manifest(runsOn?: string): Pick<Manifest, "runsOn"> {
+  return runsOn === undefined ? {} : { runsOn };
+}
+
+const OK = (stdout: string): ExecResult => ({ stdout, exitCode: 0 });
+const FAIL: ExecResult = { stdout: "", exitCode: 128 };
+
+describe("currentBranch", () => {
+  test("returns branch name on normal worktree", () => {
+    const exec = mockExec({
+      "git -C /repo rev-parse --is-inside-work-tree": OK("true\n"),
+      "git -C /repo symbolic-ref --short HEAD": OK("main\n"),
+    });
+    expect(currentBranch(CWD, exec)).toEqual({ kind: "branch", name: "main" });
+  });
+
+  test("returns detached for detached HEAD", () => {
+    const exec = mockExec({
+      "git -C /repo rev-parse --is-inside-work-tree": OK("true\n"),
+      "git -C /repo symbolic-ref --short HEAD": FAIL,
+    });
+    expect(currentBranch(CWD, exec)).toEqual({ kind: "detached" });
+  });
+
+  test("returns bare for bare repository", () => {
+    const exec = mockExec({
+      "git -C /repo rev-parse --is-inside-work-tree": { stdout: "false\n", exitCode: 128 },
+      "git -C /repo rev-parse --is-bare-repository": OK("true\n"),
+    });
+    expect(currentBranch(CWD, exec)).toEqual({ kind: "bare" });
+  });
+
+  test("returns not-a-repo when rev-parse fails entirely", () => {
+    const exec = mockExec({});
+    expect(currentBranch(CWD, exec)).toEqual({ kind: "not-a-repo" });
+  });
+
+  test("returns detached when symbolic-ref prints empty stdout", () => {
+    const exec = mockExec({
+      "git -C /repo rev-parse --is-inside-work-tree": OK("true\n"),
+      "git -C /repo symbolic-ref --short HEAD": OK(""),
+    });
+    expect(currentBranch(CWD, exec)).toEqual({ kind: "detached" });
+  });
+});
+
+describe("checkRunsOn", () => {
+  test("passes on main when runsOn is unset (default)", () => {
+    const exec = mockExec({
+      "git -C /repo rev-parse --is-inside-work-tree": OK("true\n"),
+      "git -C /repo symbolic-ref --short HEAD": OK("main\n"),
+    });
+    expect(() => checkRunsOn({ cwd: CWD, manifest: manifest(), exec })).not.toThrow();
+  });
+
+  test("refuses on feature branch with explicit message", () => {
+    const exec = mockExec({
+      "git -C /repo rev-parse --is-inside-work-tree": OK("true\n"),
+      "git -C /repo symbolic-ref --short HEAD": OK("feat/1241-foo\n"),
+    });
+    try {
+      checkRunsOn({ cwd: CWD, manifest: manifest(), exec });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(BranchGuardError);
+      const e = err as BranchGuardError;
+      expect(e.expected).toBe("main");
+      expect(e.actual).toBe("feat/1241-foo");
+      expect(e.message).toContain('phases only run from branch "main"');
+      expect(e.message).toContain('current branch is "feat/1241-foo"');
+      expect(e.message).toContain("install security boundary");
+    }
+  });
+
+  test("passes when manifest runsOn matches current branch (develop)", () => {
+    const exec = mockExec({
+      "git -C /repo rev-parse --is-inside-work-tree": OK("true\n"),
+      "git -C /repo symbolic-ref --short HEAD": OK("develop\n"),
+    });
+    expect(() => checkRunsOn({ cwd: CWD, manifest: manifest("develop"), exec })).not.toThrow();
+  });
+
+  test("refuses when on main but manifest requires develop", () => {
+    const exec = mockExec({
+      "git -C /repo rev-parse --is-inside-work-tree": OK("true\n"),
+      "git -C /repo symbolic-ref --short HEAD": OK("main\n"),
+    });
+    expect(() => checkRunsOn({ cwd: CWD, manifest: manifest("develop"), exec })).toThrow(
+      /phases only run from branch "develop", current branch is "main"/,
+    );
+  });
+
+  test("refuses on detached HEAD", () => {
+    const exec = mockExec({
+      "git -C /repo rev-parse --is-inside-work-tree": OK("true\n"),
+      "git -C /repo symbolic-ref --short HEAD": FAIL,
+    });
+    try {
+      checkRunsOn({ cwd: CWD, manifest: manifest(), exec });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(BranchGuardError);
+      expect((err as BranchGuardError).actual).toBe("detached");
+      expect((err as BranchGuardError).message).toContain("detached HEAD");
+    }
+  });
+
+  test("refuses in bare repo", () => {
+    const exec = mockExec({
+      "git -C /repo rev-parse --is-inside-work-tree": { stdout: "false\n", exitCode: 128 },
+      "git -C /repo rev-parse --is-bare-repository": OK("true\n"),
+    });
+    try {
+      checkRunsOn({ cwd: CWD, manifest: manifest(), exec });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(BranchGuardError);
+      expect((err as BranchGuardError).actual).toBe("bare");
+      expect((err as BranchGuardError).message).toContain("bare repository");
+    }
+  });
+
+  test("refuses outside any git repo", () => {
+    const exec = mockExec({});
+    try {
+      checkRunsOn({ cwd: CWD, manifest: manifest(), exec });
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(BranchGuardError);
+      expect((err as BranchGuardError).actual).toBe("not-a-repo");
+      expect((err as BranchGuardError).message).toContain("not a git repository");
+    }
+  });
+
+  test("DEFAULT_RUNS_ON is main", () => {
+    expect(DEFAULT_RUNS_ON).toBe("main");
+  });
+});

--- a/packages/core/src/branch-guard.ts
+++ b/packages/core/src/branch-guard.ts
@@ -1,0 +1,88 @@
+/**
+ * Phase `runsOn` branch guard (epic #1286, issue #1294).
+ *
+ * Phase execution runs with full shell + MCP access. A compromised feature
+ * branch could inject phase source that executes at orchestrator time before
+ * review/merge. The guard refuses to run phases from any branch other than
+ * the manifest's `runsOn` (default "main").
+ */
+
+import type { ExecFn } from "./git";
+import type { Manifest } from "./manifest";
+
+/** Default branch when manifest omits `runsOn`. */
+export const DEFAULT_RUNS_ON = "main";
+
+/** Thrown when the current branch does not match the manifest's runsOn. */
+export class BranchGuardError extends Error {
+  constructor(
+    message: string,
+    public readonly expected: string,
+    public readonly actual: string,
+  ) {
+    super(message);
+    this.name = "BranchGuardError";
+  }
+}
+
+/**
+ * Resolve the current branch of the repo at `cwd`. Returns the branch name,
+ * or a `{ kind: "detached" | "bare" | "not-a-repo" }` describing why no
+ * branch is available.
+ */
+export type CurrentBranch =
+  | { kind: "branch"; name: string }
+  | { kind: "detached" }
+  | { kind: "bare" }
+  | { kind: "not-a-repo" };
+
+export function currentBranch(cwd: string, exec: ExecFn): CurrentBranch {
+  const inside = exec(["git", "-C", cwd, "rev-parse", "--is-inside-work-tree"]);
+  if (inside.exitCode !== 0) {
+    const bare = exec(["git", "-C", cwd, "rev-parse", "--is-bare-repository"]);
+    if (bare.exitCode === 0 && bare.stdout.trim() === "true") {
+      return { kind: "bare" };
+    }
+    return { kind: "not-a-repo" };
+  }
+
+  const sym = exec(["git", "-C", cwd, "symbolic-ref", "--short", "HEAD"]);
+  if (sym.exitCode !== 0) {
+    return { kind: "detached" };
+  }
+  const name = sym.stdout.trim();
+  if (name === "") return { kind: "detached" };
+  return { kind: "branch", name };
+}
+
+function describe(cb: CurrentBranch): string {
+  switch (cb.kind) {
+    case "branch":
+      return `"${cb.name}"`;
+    case "detached":
+      return "a detached HEAD";
+    case "bare":
+      return "a bare repository (no working branch)";
+    case "not-a-repo":
+      return "a directory that is not a git repository";
+  }
+}
+
+/**
+ * Verify the repo at `cwd` is on the manifest's `runsOn` branch.
+ * Throws `BranchGuardError` with a user-facing refusal message on mismatch.
+ */
+export function checkRunsOn(opts: { cwd: string; manifest: Pick<Manifest, "runsOn">; exec: ExecFn }): void {
+  const expected = opts.manifest.runsOn ?? DEFAULT_RUNS_ON;
+  const cb = currentBranch(opts.cwd, opts.exec);
+
+  if (cb.kind === "branch" && cb.name === expected) {
+    return;
+  }
+
+  const actualDesc = describe(cb);
+  const actualValue = cb.kind === "branch" ? cb.name : cb.kind;
+  const message = `phases only run from branch "${expected}", current branch is ${actualDesc}.\nphases execute with full shell/mcp access; running arbitrary branch code would defeat the install security boundary.`;
+
+  throw new BranchGuardError(message, expected, actualValue);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export * from "./session-types";
 export * from "./trace";
 export * from "./git";
 export * from "./logger";
+export * from "./branch-guard";
 export * from "./manifest";
 export * from "./worktree-config";
 export * from "./worktree-shim";


### PR DESCRIPTION
## Summary
- Adds `checkRunsOn()` + `currentBranch()` in `packages/core/src/branch-guard.ts`. Refuses phase execution when current branch does not match manifest's `runsOn` (default `"main"`), preventing feature-branch code from running with orchestrator shell/MCP access before review/merge.
- Git-aware with injected `ExecFn` (same pattern as `worktree-shim.ts`/`gc`); handles detached HEAD, bare repos, and non-repo cwds with distinct refusal descriptions.
- Exported from `@mcp-cli/core` so phase entry points (#1291 install, #1292 drift/run) can call it; not wired to any entry point in this PR since those don't exist yet.

## Test plan
- [x] `bun test packages/core/src/branch-guard.spec.ts` — 13 pass, 24 expect() calls
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun test` (full suite) — 4745 pass / 0 fail across 201 files
- Covers: on main + default runsOn, on main with `runsOn: develop` (refuse), feature branch (refuse with exact message), detached HEAD, bare repo, non-repo cwd, empty symbolic-ref output, `runsOn: develop` matching current branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)