### PR TITLE
feat(phases): dry-run via logging Proxy on ctx.mcp (fixes #1296)

### DIFF
--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -221,7 +221,9 @@ defineAlias(({ z }) => ({
     expect(errs.some((e) => e.includes('unknown phase "nope"'))).toBe(true);
   });
 
-  test("run without --dry-run is rejected", async () => {
+  test("run without --dry-run dispatches to transition enforcement", async () => {
+    // Since #1293 merged, `run <target>` without --dry-run validates and records
+    // the transition (transition-enforcement path), not the dry-run execution path.
     writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);
     writeFileSync(join(dir, "impl.ts"), simpleAlias);
     const errs: string[] = [];
@@ -235,8 +237,9 @@ defineAlias(({ z }) => ({
         throw new Error("exit");
       }) as (c: number) => never,
     }).catch(() => {});
-    expect(code).toBe(1);
-    expect(errs.some((e) => e.includes("--dry-run"))).toBe(true);
+    // simpleManifest has initial: implement — transition is valid from initial state
+    expect(code).toBeUndefined();
+    expect(errs.some((e) => e.includes("approved") && e.includes("implement"))).toBe(true);
   });
 
   test("errors when source not found", async () => {

--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -165,6 +165,80 @@ describe("cmdPhase install — integration", () => {
     expect(errs.some((e) => e.includes("no .mcx.yaml or .mcx.json"))).toBe(true);
   });
 
+  test("run --dry-run logs mcp + state writes without dispatching", async () => {
+    writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);
+    writeFileSync(
+      join(dir, "impl.ts"),
+      `
+import { defineAlias, z } from "mcp-cli";
+
+defineAlias(({ z }) => ({
+  name: "implement",
+  description: "impl",
+  input: z.object({}).optional(),
+  fn: async (_input, ctx) => {
+    await ctx.mcp._work_items.work_items_update({ id: "#1241", phase: "qa" });
+    await ctx.mcp._work_items.untrack({ issue: 1241 });
+    await ctx.state.set("prNumber", 123);
+  },
+}));
+`.trim(),
+    );
+
+    const logs: string[] = [];
+    const errs: string[] = [];
+    await cmdPhase(["run", "implement", "--dry-run"], {
+      cwd: () => dir,
+      log: (m) => logs.push(m),
+      logError: (m) => errs.push(m),
+      exit: ((code: number) => {
+        throw new Error(`exit(${code})`);
+      }) as (code: number) => never,
+    });
+
+    expect(logs).toEqual([
+      `[dry-run] mcp._work_items.work_items_update({"id":"#1241","phase":"qa"})`,
+      `[dry-run] mcp._work_items.untrack({"issue":1241})`,
+      `[dry-run] ctx.state.set("prNumber", 123)`,
+    ]);
+  }, 15_000);
+
+  test("run errors on unknown phase", async () => {
+    writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);
+    writeFileSync(join(dir, "impl.ts"), simpleAlias);
+    const errs: string[] = [];
+    let code: number | undefined;
+    await cmdPhase(["run", "nope", "--dry-run"], {
+      cwd: () => dir,
+      log: () => {},
+      logError: (m) => errs.push(m),
+      exit: ((c: number) => {
+        code = c;
+        throw new Error("exit");
+      }) as (c: number) => never,
+    }).catch(() => {});
+    expect(code).toBe(1);
+    expect(errs.some((e) => e.includes('unknown phase "nope"'))).toBe(true);
+  });
+
+  test("run without --dry-run is rejected", async () => {
+    writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);
+    writeFileSync(join(dir, "impl.ts"), simpleAlias);
+    const errs: string[] = [];
+    let code: number | undefined;
+    await cmdPhase(["run", "implement"], {
+      cwd: () => dir,
+      log: () => {},
+      logError: (m) => errs.push(m),
+      exit: ((c: number) => {
+        code = c;
+        throw new Error("exit");
+      }) as (c: number) => never,
+    }).catch(() => {});
+    expect(code).toBe(1);
+    expect(errs.some((e) => e.includes("--dry-run"))).toBe(true);
+  });
+
   test("errors when source not found", async () => {
     writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);
 

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -18,6 +18,7 @@
 import { existsSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
 import { isAbsolute, join, relative, resolve as resolvePath } from "node:path";
 import {
+  type AliasContext,
   DisallowedTransitionError,
   LOCKFILE_NAME,
   LOCKFILE_VERSION,
@@ -31,9 +32,12 @@ import {
   appendTransitionLog,
   bundleAlias,
   canonicalJson,
+  createAliasCache,
+  executeAliasBundled,
   extractMetadata,
   hashFileSync,
   historyTargets,
+  isDefineAlias,
   loadManifest,
   parseLockfile,
   readTransitionHistory,
@@ -41,6 +45,7 @@ import {
   sha256Hex,
   suggestPhases,
   validateTransition,
+  wrapDryRunContext,
 } from "@mcp-cli/core";
 import type { AliasMetadata } from "@mcp-cli/core";
 import { printError } from "../output";
@@ -53,6 +58,8 @@ export interface PhaseInstallDeps {
   writeFileSync: (path: string, data: string) => void;
   readFileSync: (path: string) => string;
   existsSync: (path: string) => boolean;
+  readFile: (path: string) => Promise<string>;
+  executeAliasBundled: typeof executeAliasBundled;
   cwd: () => string;
   log: (msg: string) => void;
   logError: (msg: string) => void;
@@ -67,6 +74,8 @@ const defaultDeps: PhaseInstallDeps = {
   writeFileSync: (path, data) => writeFileSync(path, data, "utf-8"),
   readFileSync: (path) => readFileSync(path, "utf-8"),
   existsSync: (path) => existsSync(path),
+  readFile: (path) => Bun.file(path).text(),
+  executeAliasBundled,
   cwd: () => process.cwd(),
   log: (msg) => console.log(msg),
   logError: (msg) => console.error(msg),
@@ -603,12 +612,17 @@ export async function cmdPhase(args: string[], deps?: Partial<PhaseInstallDeps>)
     }
 
     if (sub === "run") {
-      const opts = parsePhaseRunArgs(args.slice(1));
-      const result = phaseRun(opts, { cwd: d.cwd() });
-      const source = result.manifest.phases[opts.target]?.source ?? "(unknown)";
-      const tag = result.forced ? " [FORCED]" : "";
-      const trail = result.from ?? "(initial)";
-      d.logError(`approved${tag}: ${trail} → ${opts.target} (${source})`);
+      const argv = args.slice(1);
+      if (argv.includes("--dry-run")) {
+        await runPhase(argv, d);
+      } else {
+        const opts = parsePhaseRunArgs(argv);
+        const result = phaseRun(opts, { cwd: d.cwd() });
+        const source = result.manifest.phases[opts.target]?.source ?? "(unknown)";
+        const tag = result.forced ? " [FORCED]" : "";
+        const trail = result.from ?? "(initial)";
+        d.logError(`approved${tag}: ${trail} → ${opts.target} (${source})`);
+      }
       return;
     }
 
@@ -636,6 +650,77 @@ export async function cmdPhase(args: string[], deps?: Partial<PhaseInstallDeps>)
   }
 }
 
+async function runPhase(argv: string[], d: PhaseInstallDeps): Promise<void> {
+  const positional: string[] = [];
+  const flags = new Set<string>();
+  for (const a of argv) {
+    if (a.startsWith("--")) flags.add(a);
+    else positional.push(a);
+  }
+  const name = positional[0];
+  if (!name) {
+    d.logError("Usage: mcx phase run <name> --dry-run");
+    d.exit(1);
+  }
+  if (!flags.has("--dry-run")) {
+    d.logError("mcx phase run currently supports --dry-run only");
+    d.exit(1);
+  }
+
+  const cwd = d.cwd();
+  const loaded = d.loadManifest(cwd);
+  if (!loaded) {
+    d.logError("no .mcx.yaml or .mcx.json in this repo");
+    d.exit(1);
+  }
+
+  const phase = loaded.manifest.phases[name];
+  if (!phase) {
+    d.logError(`unknown phase "${name}"`);
+    d.exit(1);
+  }
+
+  let resolved: string;
+  try {
+    resolved = resolvePhaseSource(phase.source, cwd);
+  } catch (err) {
+    d.logError(`phase "${name}": ${err instanceof Error ? err.message : String(err)}`);
+    d.exit(1);
+  }
+
+  let source: string;
+  try {
+    source = await d.readFile(resolved);
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e?.code === "ENOENT") d.logError(`phase "${name}": source ${phase.source} not found`);
+    else d.logError(`phase "${name}": cannot read ${phase.source}: ${e?.message ?? String(err)}`);
+    d.exit(1);
+  }
+  const structured = isDefineAlias(source);
+
+  const { js } = await d.bundleAlias(resolved);
+
+  const stubState = {
+    get: async () => undefined,
+    all: async () => ({}),
+    set: async () => {},
+    delete: async () => {},
+  };
+  const baseCtx: AliasContext = {
+    mcp: {},
+    args: {},
+    file: (p) => Bun.file(p).text(),
+    json: async (p) => JSON.parse(await Bun.file(p).text()),
+    cache: createAliasCache(name),
+    state: stubState,
+    globalState: stubState,
+  };
+  const ctx = wrapDryRunContext(baseCtx, (line) => d.log(line));
+
+  await d.executeAliasBundled(js, structured ? {} : undefined, ctx, structured);
+}
+
 function printPhaseHelp(d: PhaseInstallDeps): void {
   d.log(`mcx phase — orchestration phase graph
 
@@ -650,6 +735,9 @@ Subcommands:
       Validate and record a phase transition against .mcx.{yaml,json}.
       --force <message> bypasses disallowed-transition and regression checks;
       unknown-phase errors are never bypassable.
+
+  mcx phase run <name> --dry-run
+      Execute a phase handler with side effects logged but not dispatched.
 
   mcx phase list [--json]
       List all phases declared in the manifest with install status.

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -32,7 +32,6 @@ import {
   appendTransitionLog,
   bundleAlias,
   canonicalJson,
-  createAliasCache,
   executeAliasBundled,
   extractMetadata,
   hashFileSync,
@@ -712,7 +711,10 @@ async function runPhase(argv: string[], d: PhaseInstallDeps): Promise<void> {
     args: {},
     file: (p) => Bun.file(p).text(),
     json: async (p) => JSON.parse(await Bun.file(p).text()),
-    cache: createAliasCache(name),
+    // Dry-run: use an in-memory no-op cache so producers still run but
+    // nothing is written to ~/.mcp-cli/cache — avoids caching `undefined`
+    // (the dry-run proxy return value) and corrupting real cache entries.
+    cache: async (_k, producer) => producer() as Promise<never>,
     state: stubState,
     globalState: stubState,
   };

--- a/packages/core/src/alias-dry-run.spec.ts
+++ b/packages/core/src/alias-dry-run.spec.ts
@@ -3,6 +3,28 @@ import type { AliasContext } from "./alias";
 import { createDryRunMcp, createDryRunState, wrapDryRunContext } from "./alias-dry-run";
 
 describe("createDryRunMcp", () => {
+  test("server proxy is not thenable — Promise.resolve does not hang", async () => {
+    const lines: string[] = [];
+    const mcp = createDryRunMcp((l) => lines.push(l));
+    // If the server-level proxy were a thenable, Promise.resolve would call
+    // .then(resolve, reject), resolve would never fire, and this would hang.
+    const server = await Promise.resolve(mcp.server);
+    // It resolved (didn't hang) and emitted no bogus [dry-run] lines
+    expect(typeof server).toBe("object");
+    expect(lines).toEqual([]);
+  });
+
+  test("symbol probes on server and tool proxies return undefined without logging", () => {
+    const lines: string[] = [];
+    const mcp = createDryRunMcp((l) => lines.push(l));
+    // Bun inspect / V8 probe these — must not emit log lines or crash
+    expect((mcp as unknown as Record<symbol, unknown>)[Symbol.iterator]).toBeUndefined();
+    expect((mcp as unknown as Record<symbol, unknown>)[Symbol.toPrimitive]).toBeUndefined();
+    expect((mcp.server as unknown as Record<symbol, unknown>)[Symbol.iterator]).toBeUndefined();
+    expect((mcp.server as unknown as { then: unknown }).then).toBeUndefined();
+    expect(lines).toEqual([]);
+  });
+
   test("logs tool calls and returns undefined", async () => {
     const lines: string[] = [];
     const mcp = createDryRunMcp((l) => lines.push(l));

--- a/packages/core/src/alias-dry-run.spec.ts
+++ b/packages/core/src/alias-dry-run.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import type { AliasContext } from "./alias";
+import { createDryRunMcp, createDryRunState, wrapDryRunContext } from "./alias-dry-run";
+
+describe("createDryRunMcp", () => {
+  test("logs tool calls and returns undefined", async () => {
+    const lines: string[] = [];
+    const mcp = createDryRunMcp((l) => lines.push(l));
+    const result = await mcp._work_items.work_items_update({ id: "#1241", phase: "qa" });
+    expect(result).toBeUndefined();
+    expect(lines).toEqual([`[dry-run] mcp._work_items.work_items_update({"id":"#1241","phase":"qa"})`]);
+  });
+
+  test("no-arg calls render with empty parens", async () => {
+    const lines: string[] = [];
+    const mcp = createDryRunMcp((l) => lines.push(l));
+    await mcp.foo.bar();
+    expect(lines).toEqual(["[dry-run] mcp.foo.bar()"]);
+  });
+});
+
+describe("createDryRunState", () => {
+  test("set/delete log, get/all return empty", async () => {
+    const lines: string[] = [];
+    const state = createDryRunState((l) => lines.push(l), "ctx.state");
+    await state.set("prNumber", 123);
+    await state.delete("prNumber");
+    expect(await state.get("prNumber")).toBeUndefined();
+    expect(await state.all()).toEqual({});
+    expect(lines).toEqual([`[dry-run] ctx.state.set("prNumber", 123)`, `[dry-run] ctx.state.delete("prNumber")`]);
+  });
+});
+
+describe("wrapDryRunContext", () => {
+  test("intercepts mcp + state.set, passes args/file through", async () => {
+    const lines: string[] = [];
+    const base: AliasContext = {
+      mcp: {},
+      args: { foo: "bar" },
+      file: async () => "file-content",
+      json: async () => ({}),
+      cache: async (_k, p) => p() as Promise<never>,
+      state: { get: async () => undefined, all: async () => ({}), set: async () => {}, delete: async () => {} },
+      globalState: { get: async () => undefined, all: async () => ({}), set: async () => {}, delete: async () => {} },
+    };
+    const ctx = wrapDryRunContext(base, (l) => lines.push(l));
+
+    await ctx.mcp.server.tool({ x: 1 });
+    await ctx.state.set("k", "v");
+    await ctx.globalState.set("g", 1);
+    expect(ctx.args.foo).toBe("bar");
+    expect(await ctx.file("anything")).toBe("file-content");
+
+    expect(lines).toEqual([
+      `[dry-run] mcp.server.tool({"x":1})`,
+      `[dry-run] ctx.state.set("k", "v")`,
+      `[dry-run] ctx.globalState.set("g", 1)`,
+    ]);
+  });
+
+  test("handler with 3 side effects yields exactly 3 log lines", async () => {
+    const lines: string[] = [];
+    const base: AliasContext = {
+      mcp: {},
+      args: {},
+      file: async () => "",
+      json: async () => ({}),
+      cache: async (_k, p) => p() as Promise<never>,
+      state: { get: async () => undefined, all: async () => ({}), set: async () => {}, delete: async () => {} },
+      globalState: { get: async () => undefined, all: async () => ({}), set: async () => {}, delete: async () => {} },
+    };
+    const ctx = wrapDryRunContext(base, (l) => lines.push(l));
+
+    const handler = async (c: AliasContext) => {
+      await c.mcp._work_items.work_items_update({ id: "#1241", phase: "qa" });
+      await c.mcp._work_items.untrack({ issue: 1241 });
+      await c.state.set("prNumber", 123);
+    };
+    await handler(ctx);
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toBe(`[dry-run] mcp._work_items.work_items_update({"id":"#1241","phase":"qa"})`);
+    expect(lines[1]).toBe(`[dry-run] mcp._work_items.untrack({"issue":1241})`);
+    expect(lines[2]).toBe(`[dry-run] ctx.state.set("prNumber", 123)`);
+  });
+});

--- a/packages/core/src/alias-dry-run.ts
+++ b/packages/core/src/alias-dry-run.ts
@@ -1,0 +1,59 @@
+/**
+ * Dry-run context for phases (#1296).
+ *
+ * Wraps an AliasContext so that side-effectful accessors (`mcp.*`, `state.set`,
+ * `state.delete`, `globalState.set`, `globalState.delete`) are logged instead
+ * of dispatched. Non-mutating reads (`state.get`, `state.all`) return
+ * `undefined` / `{}` so handlers still progress through their control flow
+ * without touching the daemon, DB, or network.
+ */
+
+import type { AliasContext, AliasStateAccessor, McpProxy } from "./alias";
+
+export type DryRunLogger = (line: string) => void;
+
+function formatArgs(args: unknown): string {
+  if (args === undefined) return "";
+  try {
+    return JSON.stringify(args);
+  } catch {
+    return String(args);
+  }
+}
+
+export function createDryRunMcp(log: DryRunLogger): McpProxy {
+  return new Proxy({} as McpProxy, {
+    get(_t, server: string) {
+      return new Proxy({} as Record<string, (args?: Record<string, unknown>) => Promise<unknown>>, {
+        get(_i, tool: string) {
+          return async (args?: Record<string, unknown>) => {
+            log(`[dry-run] mcp.${server}.${tool}(${formatArgs(args)})`);
+            return undefined;
+          };
+        },
+      });
+    },
+  });
+}
+
+export function createDryRunState(log: DryRunLogger, label: string): AliasStateAccessor {
+  return {
+    get: async () => undefined,
+    all: async () => ({}),
+    set: async (key, value) => {
+      log(`[dry-run] ${label}.set(${JSON.stringify(key)}, ${formatArgs(value)})`);
+    },
+    delete: async (key) => {
+      log(`[dry-run] ${label}.delete(${JSON.stringify(key)})`);
+    },
+  };
+}
+
+export function wrapDryRunContext(ctx: AliasContext, log: DryRunLogger): AliasContext {
+  return {
+    ...ctx,
+    mcp: createDryRunMcp(log),
+    state: createDryRunState(log, "ctx.state"),
+    globalState: createDryRunState(log, "ctx.globalState"),
+  };
+}

--- a/packages/core/src/alias-dry-run.ts
+++ b/packages/core/src/alias-dry-run.ts
@@ -23,11 +23,31 @@ function formatArgs(args: unknown): string {
 
 export function createDryRunMcp(log: DryRunLogger): McpProxy {
   return new Proxy({} as McpProxy, {
-    get(_t, server: string) {
+    get(_t, server) {
+      // Guard symbol probes and Promise machinery (.then/.catch/.finally) so
+      // this Proxy is never treated as a thenable by await / Promise.resolve().
+      if (
+        typeof server === "symbol" ||
+        server === "then" ||
+        server === "catch" ||
+        server === "finally" ||
+        server === "toJSON"
+      ) {
+        return undefined;
+      }
       return new Proxy({} as Record<string, (args?: Record<string, unknown>) => Promise<unknown>>, {
-        get(_i, tool: string) {
+        get(_i, tool) {
+          if (
+            typeof tool === "symbol" ||
+            tool === "then" ||
+            tool === "catch" ||
+            tool === "finally" ||
+            tool === "toJSON"
+          ) {
+            return undefined;
+          }
           return async (args?: Record<string, unknown>) => {
-            log(`[dry-run] mcp.${server}.${tool}(${formatArgs(args)})`);
+            log(`[dry-run] mcp.${String(server)}.${String(tool)}(${formatArgs(args)})`);
             return undefined;
           };
         },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./alias";
+export * from "./alias-dry-run";
 export * from "./alias-state";
 export * from "./alias-bundle";
 export * from "./cache";


### PR DESCRIPTION
## Summary
- Add `wrapDryRunContext` helper in `packages/core/src/alias-dry-run.ts` that wraps an `AliasContext` so `mcp.*` calls and `state.set/delete` / `globalState.set/delete` are logged instead of dispatched. Reads (`state.get`/`all`) return empty so handlers still progress.
- Wire `mcx phase run <name> --dry-run` to load the manifest, resolve + bundle the phase source, and invoke the handler with a dry-run ctx. Non-dry-run execution is deferred to a follow-up.
- Filed #1332 for a pre-existing flaky `findGitRoot` test encountered during pre-commit (unrelated to this change).

## Test plan
- [x] `bun typecheck`
- [x] `bun lint`
- [x] `bun test packages/core/src/alias-dry-run.spec.ts packages/command/src/commands/phase.spec.ts` → 19 pass
- [x] Integration test: phase handler with 3 side effects → exactly 3 `[dry-run] …` lines, no DB / network writes
- [x] `bun test` full suite: 4853 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)