### PR TITLE
fix(wait): drop cross-repo event wakeups with cwd fallback (fixes #1308)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -2523,6 +2523,35 @@ describe("mcx claude wait", () => {
     }
   });
 
+  test("passes through event when session has null repoRoot and null cwd under no filter (#1308)", async () => {
+    // Ghost sessions (crashed workers, recorded before cwd was set) have both
+    // repoRoot and cwd null. They must still surface when no --repo/--scope filter
+    // is active, so the caller can observe and clean them up.
+    const ghostEvent = {
+      source: "session",
+      event: {
+        sessionId: "dead0000-cafe-babe-dead-000000000000",
+        event: "session:result",
+        session: { sessionId: "dead0000-cafe-babe-dead-000000000000", repoRoot: null, cwd: null },
+      },
+      sessions: [],
+    };
+    const callTool = mock(async () => toolResult(ghostEvent));
+    // No getGitRoot override — defaults to null, meaning no repo filter is applied
+    const deps = makeDeps({ callTool });
+
+    const logSpy = mock(() => {});
+    const origLog = console.log;
+    console.log = logSpy;
+    try {
+      await cmdClaude(["wait", "--short", "--timeout", "1000"], deps);
+      expect(logSpy.mock.calls.length).toBe(1);
+      expect((logSpy.mock.calls[0] as string[])[0]).toContain("dead0000");
+    } finally {
+      console.log = origLog;
+    }
+  });
+
   // ── old daemon compat (pre-unification response shapes) ──
 
   test("--short handles bare event object from old daemon", async () => {

--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -2433,6 +2433,96 @@ describe("mcx claude wait", () => {
     }
   });
 
+  // ── cross-repo event leak (#1308) ──
+
+  test("drops single event whose session has foreign repoRoot (#1308)", async () => {
+    // Daemon wakeup returns an event with a cross-repo session snapshot. The
+    // client must drop the event rather than surfacing it on --short output.
+    const leakedEvent = {
+      source: "session",
+      event: {
+        sessionId: "ff008800-aaaa-bbbb-cccc-dddddddddddd",
+        event: "session:result",
+        session: { sessionId: "ff008800-aaaa-bbbb-cccc-dddddddddddd", repoRoot: "/repo/b", cwd: "/repo/b" },
+      },
+      sessions: [],
+    };
+    const callTool = mock(async () => toolResult(leakedEvent));
+    const deps = makeDeps({ callTool, getGitRoot: mock(() => "/repo/a") });
+
+    const logSpy = mock(() => {});
+    const origLog = console.log;
+    console.log = logSpy;
+    try {
+      await cmdClaude(["wait", "--short", "--timeout", "1000"], deps);
+      for (const call of logSpy.mock.calls as string[][]) {
+        expect(call[0]).not.toContain("ff008800");
+      }
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("drops event when session has null repoRoot but cwd is in another repo (#1308)", async () => {
+    // Session missing repoRoot (core.bare ambient repo — #1243) must still be
+    // filtered by cwd prefix so wait does not leak cross-repo wakeups.
+    const leakedEvent = {
+      source: "session",
+      event: {
+        sessionId: "ff008800-aaaa-bbbb-cccc-dddddddddddd",
+        event: "session:result",
+        session: { sessionId: "ff008800-aaaa-bbbb-cccc-dddddddddddd", repoRoot: null, cwd: "/repo/b/sub" },
+      },
+      sessions: [],
+    };
+    const callTool = mock(async () => toolResult(leakedEvent));
+    const deps = makeDeps({ callTool, getGitRoot: mock(() => "/repo/a") });
+
+    const logSpy = mock(() => {});
+    const origLog = console.log;
+    console.log = logSpy;
+    try {
+      await cmdClaude(["wait", "--short", "--timeout", "1000"], deps);
+      for (const call of logSpy.mock.calls as string[][]) {
+        expect(call[0]).not.toContain("ff008800");
+      }
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("keeps event when session matches repo via cwd fallback (#1308)", async () => {
+    // Mirror of the drop case: null repoRoot + matching cwd must still surface.
+    const inScopeEvent = {
+      source: "session",
+      event: {
+        sessionId: "abc12345-1111-2222-3333-444444444444",
+        event: "session:result",
+        cost: 0.01,
+        numTurns: 1,
+        session: {
+          sessionId: "abc12345-1111-2222-3333-444444444444",
+          repoRoot: null,
+          cwd: "/repo/a/worktree",
+        },
+      },
+      sessions: [],
+    };
+    const callTool = mock(async () => toolResult(inScopeEvent));
+    const deps = makeDeps({ callTool, getGitRoot: mock(() => "/repo/a") });
+
+    const logSpy = mock(() => {});
+    const origLog = console.log;
+    console.log = logSpy;
+    try {
+      await cmdClaude(["wait", "--short", "--timeout", "1000"], deps);
+      expect(logSpy.mock.calls.length).toBe(1);
+      expect((logSpy.mock.calls[0] as string[])[0]).toContain("abc12345");
+    } finally {
+      console.log = origLog;
+    }
+  });
+
   // ── old daemon compat (pre-unification response shapes) ──
 
   test("--short handles bare event object from old daemon", async () => {

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -1514,19 +1514,33 @@ async function claudeWait(args: string[], d: ClaudeDeps): Promise<void> {
       workItemEvent?: Record<string, unknown>;
       sessions: Array<Record<string, unknown>>;
     };
+    const matchesRepo = (s: Record<string, unknown>): boolean => {
+      if (!repoFilter) return true;
+      if (typeof s.repoRoot === "string") return s.repoRoot === repoFilter;
+      // Legacy sessions without repoRoot: fall back to cwd prefix match (fixes #1242)
+      const cwd = typeof s.cwd === "string" ? s.cwd : null;
+      return cwd !== null && (cwd === repoFilter || cwd.startsWith(`${repoFilter}/`));
+    };
+    const matchesScope = (s: Record<string, unknown>): boolean => {
+      if (!scopeFilter) return true;
+      const cwd = typeof s.cwd === "string" ? s.cwd : null;
+      return cwd !== null && (cwd === scopeFilter || cwd.startsWith(`${scopeFilter}/`));
+    };
     if (repoFilter) {
-      unified.sessions = unified.sessions.filter((s) => {
-        if (s.repoRoot) return s.repoRoot === repoFilter;
-        // Legacy sessions without repoRoot: fall back to cwd prefix match (fixes #1242)
-        const cwd = typeof s.cwd === "string" ? s.cwd : null;
-        return cwd !== null && (cwd === repoFilter || cwd.startsWith(`${repoFilter}/`));
-      });
-      // Filter event if its session snapshot is from another repo
-      if (unified.event?.session) {
-        const eventRepo = (unified.event.session as Record<string, unknown>).repoRoot;
-        if (eventRepo && eventRepo !== repoFilter) {
-          unified.event = undefined;
-        }
+      unified.sessions = unified.sessions.filter(matchesRepo);
+    } else if (scopeFilter) {
+      unified.sessions = unified.sessions.filter(matchesScope);
+    }
+    // Filter event if its session snapshot is from another repo/scope (fixes #1308).
+    // Drop events without session info when any filter is active — we can't verify scope.
+    if (unified.event && (repoFilter || scopeFilter)) {
+      const session = unified.event.session as Record<string, unknown> | undefined;
+      if (!session) {
+        unified.event = undefined;
+      } else if (repoFilter && !matchesRepo(session)) {
+        unified.event = undefined;
+      } else if (scopeFilter && !matchesScope(session)) {
+        unified.event = undefined;
       }
     }
     if (!parsed.short) {

--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -10,7 +10,14 @@ import {
   parseLockfile,
   readTransitionHistory,
 } from "@mcp-cli/core";
-import { bundleAlias, extractMetadata, hashFileSync, loadManifest, parseManifestText, validateManifest } from "@mcp-cli/core";
+import {
+  bundleAlias,
+  extractMetadata,
+  hashFileSync,
+  loadManifest,
+  parseManifestText,
+  validateManifest,
+} from "@mcp-cli/core";
 import {
   buildPhaseList,
   buildPhaseShow,

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -717,6 +717,7 @@ async function runPhase(argv: string[], d: PhaseInstallDeps): Promise<void> {
     cache: async (_k, producer) => producer() as Promise<never>,
     state: stubState,
     globalState: stubState,
+    workItem: null,
   };
   const ctx = wrapDryRunContext(baseCtx, (line) => d.log(line));
 

--- a/packages/core/src/alias-dry-run.spec.ts
+++ b/packages/core/src/alias-dry-run.spec.ts
@@ -64,6 +64,7 @@ describe("wrapDryRunContext", () => {
       cache: async (_k, p) => p() as Promise<never>,
       state: { get: async () => undefined, all: async () => ({}), set: async () => {}, delete: async () => {} },
       globalState: { get: async () => undefined, all: async () => ({}), set: async () => {}, delete: async () => {} },
+      workItem: null,
     };
     const ctx = wrapDryRunContext(base, (l) => lines.push(l));
 
@@ -90,6 +91,7 @@ describe("wrapDryRunContext", () => {
       cache: async (_k, p) => p() as Promise<never>,
       state: { get: async () => undefined, all: async () => ({}), set: async () => {}, delete: async () => {} },
       globalState: { get: async () => undefined, all: async () => ({}), set: async () => {}, delete: async () => {} },
+      workItem: null,
     };
     const ctx = wrapDryRunContext(base, (l) => lines.push(l));
 

--- a/packages/daemon/src/claude-session-worker.spec.ts
+++ b/packages/daemon/src/claude-session-worker.spec.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+import { matchesRepoRoot, matchesScopeRoot } from "./claude-session-worker";
+
+// ── matchesScopeRoot ──
+
+describe("matchesScopeRoot", () => {
+  test("returns true when scopeRoot is undefined (no filter)", () => {
+    expect(matchesScopeRoot({ cwd: "/repo/a" }, undefined)).toBe(true);
+    expect(matchesScopeRoot(undefined, undefined)).toBe(true);
+  });
+
+  test("returns false when session is undefined and scopeRoot is set", () => {
+    expect(matchesScopeRoot(undefined, "/repo/a")).toBe(false);
+  });
+
+  test("exact cwd match passes", () => {
+    expect(matchesScopeRoot({ cwd: "/repo/a" }, "/repo/a")).toBe(true);
+  });
+
+  test("cwd under scopeRoot passes via prefix", () => {
+    expect(matchesScopeRoot({ cwd: "/repo/a/worktree" }, "/repo/a")).toBe(true);
+    expect(matchesScopeRoot({ cwd: "/repo/a/deep/nested" }, "/repo/a")).toBe(true);
+  });
+
+  test("partial prefix without slash separator does not pass", () => {
+    // /repo/abc should not match /repo/a
+    expect(matchesScopeRoot({ cwd: "/repo/abc" }, "/repo/a")).toBe(false);
+  });
+
+  test("different repo does not pass", () => {
+    expect(matchesScopeRoot({ cwd: "/repo/b" }, "/repo/a")).toBe(false);
+    expect(matchesScopeRoot({ cwd: "/repo/b/sub" }, "/repo/a")).toBe(false);
+  });
+
+  test("null cwd does not pass", () => {
+    expect(matchesScopeRoot({ cwd: null }, "/repo/a")).toBe(false);
+  });
+});
+
+// ── matchesRepoRoot ──
+
+describe("matchesRepoRoot", () => {
+  test("returns true when repoRoot is undefined (no filter)", () => {
+    expect(matchesRepoRoot({ repoRoot: "/repo/a", cwd: "/repo/a" }, undefined)).toBe(true);
+    expect(matchesRepoRoot(undefined, undefined)).toBe(true);
+  });
+
+  test("returns false when session is undefined and repoRoot is set", () => {
+    expect(matchesRepoRoot(undefined, "/repo/a")).toBe(false);
+  });
+
+  test("matching repoRoot passes", () => {
+    expect(matchesRepoRoot({ repoRoot: "/repo/a", cwd: "/repo/a" }, "/repo/a")).toBe(true);
+  });
+
+  test("different repoRoot does not pass", () => {
+    expect(matchesRepoRoot({ repoRoot: "/repo/b", cwd: "/repo/b" }, "/repo/a")).toBe(false);
+  });
+
+  // null-repoRoot fallback: cwd prefix match (#1242, #1308)
+
+  test("null repoRoot falls back to cwd exact match", () => {
+    expect(matchesRepoRoot({ repoRoot: null, cwd: "/repo/a" }, "/repo/a")).toBe(true);
+  });
+
+  test("null repoRoot falls back to cwd prefix match", () => {
+    expect(matchesRepoRoot({ repoRoot: null, cwd: "/repo/a/worktree" }, "/repo/a")).toBe(true);
+  });
+
+  test("null repoRoot with cwd in different repo does not pass", () => {
+    expect(matchesRepoRoot({ repoRoot: null, cwd: "/repo/b/sub" }, "/repo/a")).toBe(false);
+  });
+
+  test("null repoRoot with partial prefix without slash does not pass", () => {
+    expect(matchesRepoRoot({ repoRoot: null, cwd: "/repo/abc" }, "/repo/a")).toBe(false);
+  });
+
+  test("null repoRoot with null cwd does not pass when filter is set", () => {
+    // Ghost sessions (crashed workers) with both fields null are invisible to filtered waits.
+    // They remain visible when no filter is active (repoRoot=undefined path above).
+    expect(matchesRepoRoot({ repoRoot: null, cwd: null }, "/repo/a")).toBe(false);
+  });
+});

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -243,7 +243,10 @@ async function handlePrompt(
  * Check if a session's cwd is within the scope root.
  * Returns true when scopeRoot is undefined (no filter).
  */
-function matchesScopeRoot(session: Pick<SessionInfo, "cwd"> | undefined, scopeRoot: string | undefined): boolean {
+export function matchesScopeRoot(
+  session: Pick<SessionInfo, "cwd"> | undefined,
+  scopeRoot: string | undefined,
+): boolean {
   if (!scopeRoot) return true;
   if (!session) return false;
   const cwd = session.cwd;
@@ -255,7 +258,7 @@ function matchesScopeRoot(session: Pick<SessionInfo, "cwd"> | undefined, scopeRo
  * Falls back to cwd prefix for sessions missing repoRoot (fixes #1242, #1308).
  * Returns true when repoRoot is undefined (no filter).
  */
-function matchesRepoRoot(
+export function matchesRepoRoot(
   session: Pick<SessionInfo, "cwd" | "repoRoot"> | undefined,
   repoRoot: string | undefined,
 ): boolean {

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -17,6 +17,7 @@
 import {
   CLAUDE_SERVER_NAME,
   type LiveSpan,
+  type SessionInfo,
   type WorkItemEvent,
   resolveModelName,
   silentLogger,
@@ -238,6 +239,33 @@ async function handlePrompt(
   };
 }
 
+/**
+ * Check if a session's cwd is within the scope root.
+ * Returns true when scopeRoot is undefined (no filter).
+ */
+function matchesScopeRoot(session: Pick<SessionInfo, "cwd"> | undefined, scopeRoot: string | undefined): boolean {
+  if (!scopeRoot) return true;
+  if (!session) return false;
+  const cwd = session.cwd;
+  return cwd !== null && cwd !== undefined && (cwd === scopeRoot || cwd.startsWith(`${scopeRoot}/`));
+}
+
+/**
+ * Check if a session belongs to the given repo root.
+ * Falls back to cwd prefix for sessions missing repoRoot (fixes #1242, #1308).
+ * Returns true when repoRoot is undefined (no filter).
+ */
+function matchesRepoRoot(
+  session: Pick<SessionInfo, "cwd" | "repoRoot"> | undefined,
+  repoRoot: string | undefined,
+): boolean {
+  if (!repoRoot) return true;
+  if (!session) return false;
+  if (session.repoRoot) return session.repoRoot === repoRoot;
+  const cwd = session.cwd;
+  return cwd !== null && cwd !== undefined && (cwd === repoRoot || cwd.startsWith(`${repoRoot}/`));
+}
+
 function handleSessionList(
   server: ClaudeWsServer,
   args: Record<string, unknown>,
@@ -246,15 +274,9 @@ function handleSessionList(
   const repoRoot = args.repoRoot as string | undefined;
   const scopeRoot = args.scopeRoot as string | undefined;
   if (scopeRoot) {
-    // Scope filter: include sessions whose cwd is under the scope root
-    sessions = sessions.filter((s) => s.cwd !== null && (s.cwd === scopeRoot || s.cwd.startsWith(`${scopeRoot}/`)));
+    sessions = sessions.filter((s) => matchesScopeRoot(s, scopeRoot));
   } else if (repoRoot) {
-    sessions = sessions.filter((s) => {
-      if (s.repoRoot) return s.repoRoot === repoRoot;
-      // Legacy sessions without repoRoot: fall back to cwd prefix match
-      // so they stay scoped to their originating repo (fixes #1242).
-      return s.cwd !== null && (s.cwd === repoRoot || s.cwd.startsWith(`${repoRoot}/`));
-    });
+    sessions = sessions.filter((s) => matchesRepoRoot(s, repoRoot));
   }
   return { content: [{ type: "text", text: JSON.stringify(sessions, null, 2) }] };
 }
@@ -358,9 +380,14 @@ async function handleWait(
   const prNumber = typeof args.pr === "number" ? args.pr : null;
   const checks = args.checks === true;
 
-  /** Check if a session's cwd is within the scope root. */
-  const matchesScope = (cwd: string | null | undefined): boolean =>
-    cwd !== null && cwd !== undefined && (cwd === scopeRoot || cwd.startsWith(`${scopeRoot}/`));
+  const eventInScope = (e: { session?: SessionInfo }): boolean => {
+    if (!scopeRoot && !repoRoot) return true;
+    // Events without session info can't be filtered — drop them when a filter is active
+    // rather than leaking cross-repo wakeups (fixes #1308).
+    if (!e.session) return false;
+    if (scopeRoot) return matchesScopeRoot(e.session, scopeRoot);
+    return matchesRepoRoot(e.session, repoRoot);
+  };
 
   // Work-item-only paths: --pr or --checks without --any
   if ((prNumber !== null || checks) && !any) {
@@ -372,44 +399,54 @@ async function handleWait(
     return handleAnyWait(server, sessionId, prNumber, checks, timeoutMs, afterSeq, repoRoot, scopeRoot);
   }
 
-  // Cursor-based path: use waitForEventsSince (errors propagate — no session-list fallback)
+  const deadline = Date.now() + timeoutMs;
+  const timeoutResponse = () => handleSessionList(server, { scopeRoot, repoRoot });
+
+  // Cursor-based path: use waitForEventsSince. Re-subscribe with the advanced cursor
+  // when all events in a batch are filtered out, so the wait respects the requested
+  // timeout instead of returning a false wakeup (fixes #1308).
   if (afterSeq !== undefined) {
-    const result: WaitResult = await server.waitForEventsSince(sessionId, afterSeq, timeoutMs);
-    if (scopeRoot) {
-      result.events = result.events.filter((e) => matchesScope(e.session?.cwd));
-    } else if (repoRoot) {
-      result.events = result.events.filter((e) => !e.session?.repoRoot || e.session.repoRoot === repoRoot);
+    let seq = afterSeq;
+    while (true) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        return { content: [{ type: "text", text: JSON.stringify({ seq, events: [] }, null, 2) }] };
+      }
+      const result: WaitResult = await server.waitForEventsSince(sessionId, seq, remaining);
+      seq = result.seq;
+      if (result.events.length === 0) {
+        // Real timeout from the subscriber — don't loop
+        return { content: [{ type: "text", text: JSON.stringify({ seq, events: [] }, null, 2) }] };
+      }
+      const filtered = result.events.filter(eventInScope);
+      if (filtered.length > 0) {
+        return { content: [{ type: "text", text: JSON.stringify({ seq, events: filtered }, null, 2) }] };
+      }
+      // All events filtered out — loop with advanced cursor
     }
-    return {
-      content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
-    };
   }
 
-  // Legacy path: unified { event?, sessions } shape
-  try {
-    const event = await server.waitForEvent(sessionId, timeoutMs);
-    // Filter single event by scope or repoRoot — if mismatched, return empty array (same as timeout)
-    if (scopeRoot && !matchesScope(event.session?.cwd)) {
-      return handleSessionList(server, { scopeRoot });
-    }
-    if (repoRoot && event.session?.repoRoot && event.session.repoRoot !== repoRoot) {
-      return handleSessionList(server, { repoRoot });
-    }
-    return {
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify({ source: "session", event, sessions: server.listSessions() }, null, 2),
-        },
-      ],
-    };
-  } catch (err) {
-    if (err instanceof WaitTimeoutError) {
+  // Legacy path: unified { event?, sessions } shape. Re-subscribe for the remaining
+  // timeout when a wakeup is from an out-of-scope session (fixes #1308).
+  while (true) {
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) return timeoutResponse();
+    try {
+      const event = await server.waitForEvent(sessionId, remaining);
+      if (!eventInScope(event)) continue;
+      const filteredSessions = JSON.parse(timeoutResponse().content[0].text) as SessionInfo[];
       return {
-        content: [{ type: "text", text: JSON.stringify({ sessions: server.listSessions() }, null, 2) }],
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ source: "session", event, sessions: filteredSessions }, null, 2),
+          },
+        ],
       };
+    } catch (err) {
+      if (err instanceof WaitTimeoutError) return timeoutResponse();
+      throw err;
     }
-    throw err;
   }
 }
 
@@ -455,8 +492,12 @@ async function handleAnyWait(
   repoRoot: string | undefined,
   scopeRoot: string | undefined,
 ): Promise<{ content: Array<{ type: "text"; text: string }> }> {
-  const matchesScope = (cwd: string | null | undefined): boolean =>
-    cwd !== null && cwd !== undefined && (cwd === scopeRoot || cwd.startsWith(`${scopeRoot}/`));
+  const eventInScope = (e: { session?: SessionInfo }): boolean => {
+    if (!scopeRoot && !repoRoot) return true;
+    if (!e.session) return false;
+    if (scopeRoot) return matchesScopeRoot(e.session, scopeRoot);
+    return matchesRepoRoot(e.session, repoRoot);
+  };
 
   // AbortController for cancelling the losing racer after Promise.race settles.
   // Without this, the loser's internal timeout timer fires and rejects an unobserved
@@ -479,11 +520,7 @@ async function handleAnyWait(
         const r = await server.waitForEventsSince(sessionId, currentSeq, timeoutMs, abort.signal);
         // Advance cursor even if events are filtered — prevents re-reading the same batch
         currentSeq = r.seq;
-        if (scopeRoot) {
-          r.events = r.events.filter((e) => matchesScope(e.session?.cwd));
-        } else if (repoRoot) {
-          r.events = r.events.filter((e) => !e.session?.repoRoot || e.session.repoRoot === repoRoot);
-        }
+        r.events = r.events.filter(eventInScope);
         if (r.events.length > 0) {
           return { kind: "session" as const, result: r };
         }
@@ -502,9 +539,7 @@ async function handleAnyWait(
     sessionPromise = server
       .waitForEvent(sessionId, timeoutMs, abort.signal)
       .then<SessionResult>((event) => {
-        if (scopeRoot && !matchesScope(event.session?.cwd)) return new Promise<never>(() => {});
-        if (repoRoot && event.session?.repoRoot && event.session.repoRoot !== repoRoot)
-          return new Promise<never>(() => {});
+        if (!eventInScope(event)) return new Promise<never>(() => {});
         return { kind: "session" as const, result: event };
       })
       .catch((err) => {


### PR DESCRIPTION
## Summary
- `mcx claude wait` was leaking `session:result` events from sessions in other repos whenever the source session had a null/missing `repoRoot` (e.g. `core.bare` ambient repo #1243, or legacy sessions). The existing repo/scope filter short-circuited on `!session.repoRoot`, so those events waved straight through.
- Daemon now matches events the same way `claude_session_list` does: when a session has no `repoRoot`, it falls back to a `cwd` prefix check against the caller's repo root. This plugs both the session-list and event-stream paths, matching the #1242 fix.
- When a wakeup is out of scope, the daemon re-subscribes for the remaining timeout instead of returning a session-list (which looked like a timeout to the client). This removes the false-positive wakeups that were breaking the orchestrator's event-driven loop.
- Client `mcx claude wait` now applies the same `cwd` fallback on the event it receives, and also filters events when `--scope` is active (previously only `--repo` filtered events).

## Test plan
- [x] `bun typecheck`
- [x] `bun lint`
- [x] `bun test` (4848 pass / 0 fail)
- [x] New `claude.spec.ts` cases cover: event drop when snapshot is cross-repo, event drop via `cwd` fallback when `repoRoot` is null, and event pass-through when `cwd` prefix matches the current repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)