### PR TITLE
fix(tests): silence alias-state corruption warn leak (fixes #1357)

### DIFF
--- a/packages/daemon/src/db/state.spec.ts
+++ b/packages/daemon/src/db/state.spec.ts
@@ -1797,8 +1797,19 @@ describe("StateDb", () => {
         "INSERT INTO alias_state (repo_root, namespace, key, value_json, updated_at) VALUES ('/repo', 'ns', 'bad', ?, unixepoch())",
         ["{not-json"],
       );
-      expect(db.getAliasState("/repo", "ns", "bad")).toBeUndefined();
-      expect(db.listAliasState("/repo", "ns")).toEqual({ good: 1 });
+      const originalWarn = console.warn;
+      const warned: string[] = [];
+      console.warn = (...args: unknown[]) => {
+        warned.push(args.map(String).join(" "));
+      };
+      try {
+        expect(db.getAliasState("/repo", "ns", "bad")).toBeUndefined();
+        expect(db.listAliasState("/repo", "ns")).toEqual({ good: 1 });
+      } finally {
+        console.warn = originalWarn;
+      }
+      expect(warned.every((l) => l.startsWith("[alias-state] corrupt value_json"))).toBe(true);
+      expect(warned.length).toBeGreaterThan(0);
       db.close();
     });
   });


### PR DESCRIPTION
## Summary
- `state.spec.ts` test for corrupt `value_json` triggered `console.warn` from `safeParseStateValue` twice per run, leaking `[alias-state]` lines into test output and pushing the quiet-test-ratchet over threshold (3 > 1) — red CI on main after sprint 33.
- Stub `console.warn` for the duration of the corrupt-row assertions and assert that the expected warn message was emitted, so we verify the warn path *and* keep stderr clean.
- Threshold stays at 1 (the intentional `[mcpd] test message` capture in `daemon-log.spec.ts`).

## Test plan
- [x] `bun typecheck`
- [x] `bun lint`
- [x] `bun test packages/daemon/src/db/state.spec.ts` — 138 pass
- [x] `bun scripts/check-coverage.ts --ci` — `Test noise: 1 ... PASS: All coverage thresholds met`

🤖 Generated with [Claude Code](https://claude.com/claude-code)