### PR TITLE
fix(manifest): distinguish ENOENT from permission errors (fixes #1316)

### DIFF
--- a/packages/core/src/manifest.spec.ts
+++ b/packages/core/src/manifest.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -49,6 +49,27 @@ describe("findManifest", () => {
 
   test("exposes filename preference order", () => {
     expect(MANIFEST_FILENAMES).toEqual([".mcx.yaml", ".mcx.yml", ".mcx.json"]);
+  });
+
+  test("returns null when parent component is a file (ENOTDIR)", () => {
+    // dir/file/.mcx.yaml — lstatSync throws ENOTDIR, treated as "not present"
+    const filePath = join(dir, "file");
+    writeFileSync(filePath, "x");
+    expect(findManifest(filePath)).toBeNull();
+  });
+
+  test("throws on permission errors (EACCES)", () => {
+    // Skip when running as root (chmod is a no-op for root)
+    if (typeof process.getuid === "function" && process.getuid() === 0) return;
+    const locked = join(dir, "locked");
+    mkdirSync(locked);
+    writeFileSync(join(locked, ".mcx.yaml"), "x: 1");
+    chmodSync(locked, 0o000);
+    try {
+      expect(() => findManifest(locked)).toThrow();
+    } finally {
+      chmodSync(locked, 0o755);
+    }
   });
 });
 

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -124,8 +124,9 @@ export function findManifest(dir: string): string | null {
     try {
       const st = lstatSync(p);
       if (st.isFile()) return p;
-    } catch {
-      // not present; try next
+    } catch (e) {
+      const code = (e as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT" && code !== "ENOTDIR") throw e;
     }
   }
   return null;


### PR DESCRIPTION
## Summary
- `findManifest` now rethrows on non-ENOENT/ENOTDIR errno codes instead of swallowing them with a bare `catch {}`.
- Previously EACCES/EPERM/ESTALE silently produced "no manifest found", yielding zero-diagnostic "pipeline does nothing" on restrictive-umask CI and NFS mounts.

## Test plan
- [x] Added `findManifest` test verifying ENOTDIR (parent is a file) still returns null.
- [x] Added EACCES test using `chmod 0o000` (skipped under root) confirming the error propagates.
- [x] `bun typecheck`, `bun lint`, full `bun test` (5000 pass, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)