### PR TITLE
feat(manifest): export DEFAULT_RUNS_ON + resolveRunsOn (fixes #1318)

### DIFF
--- a/packages/core/src/branch-guard.ts
+++ b/packages/core/src/branch-guard.ts
@@ -8,10 +8,9 @@
  */
 
 import type { ExecFn } from "./git";
-import type { Manifest } from "./manifest";
+import { DEFAULT_RUNS_ON, type Manifest, resolveRunsOn } from "./manifest";
 
-/** Default branch when manifest omits `runsOn`. */
-export const DEFAULT_RUNS_ON = "main";
+export { DEFAULT_RUNS_ON };
 
 /** Thrown when the current branch does not match the manifest's runsOn. */
 export class BranchGuardError extends Error {
@@ -73,7 +72,7 @@ function describe(cb: CurrentBranch): string {
  * Throws `BranchGuardError` with a user-facing refusal message on mismatch.
  */
 export function checkRunsOn(opts: { cwd: string; manifest: Pick<Manifest, "runsOn">; exec: ExecFn }): void {
-  const expected = opts.manifest.runsOn ?? DEFAULT_RUNS_ON;
+  const expected = resolveRunsOn(opts.manifest);
   const cb = currentBranch(opts.cwd, opts.exec);
 
   if (cb.kind === "branch" && cb.name === expected) {

--- a/packages/core/src/manifest.spec.ts
+++ b/packages/core/src/manifest.spec.ts
@@ -3,11 +3,13 @@ import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:f
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  DEFAULT_RUNS_ON,
   MANIFEST_FILENAMES,
   ManifestError,
   findManifest,
   loadManifest,
   parseManifestText,
+  resolveRunsOn,
   validateManifest,
 } from "./manifest";
 
@@ -273,5 +275,19 @@ describe("loadManifest", () => {
   test("wraps validation errors in ManifestError", () => {
     writeFileSync(join(dir, ".mcx.yaml"), "initial: a\nphases:\n  b:\n    source: ./b.ts\n");
     expect(() => loadManifest(dir)).toThrow(/not a declared phase/);
+  });
+});
+
+describe("resolveRunsOn", () => {
+  test("DEFAULT_RUNS_ON is 'main'", () => {
+    expect(DEFAULT_RUNS_ON).toBe("main");
+  });
+
+  test("returns DEFAULT_RUNS_ON when runsOn is undefined", () => {
+    expect(resolveRunsOn({ runsOn: undefined })).toBe(DEFAULT_RUNS_ON);
+  });
+
+  test("returns explicit runsOn when set", () => {
+    expect(resolveRunsOn({ runsOn: "develop" })).toBe("develop");
   });
 });

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -90,6 +90,13 @@ export type ManifestState = z.infer<typeof ManifestStateSchema>;
  * are intentional and part of the design. Only unreachable phases are
  * rejected.
  */
+/**
+ * Default branch for `runsOn` when a manifest omits it. Canonical constant
+ * for all consumers — do not write `manifest.runsOn ?? "main"` inline.
+ * See #1318.
+ */
+export const DEFAULT_RUNS_ON = "main";
+
 export const ManifestSchema = z
   .object({
     version: z.literal(1).default(1),
@@ -102,6 +109,11 @@ export const ManifestSchema = z
   .strict();
 
 export type Manifest = z.infer<typeof ManifestSchema>;
+
+/** Resolve a manifest's `runsOn` to a concrete branch name, applying the default. */
+export function resolveRunsOn(manifest: Pick<Manifest, "runsOn">): string {
+  return manifest.runsOn ?? DEFAULT_RUNS_ON;
+}
 
 /** Error thrown when a manifest fails structural or semantic validation. */
 export class ManifestError extends Error {


### PR DESCRIPTION
## Summary
- Export `DEFAULT_RUNS_ON = "main"` and `resolveRunsOn(manifest)` from `packages/core/src/manifest.ts` so epic #1286 sub-issues share one canonical default.
- `branch-guard.ts` now imports these from `manifest` and re-exports `DEFAULT_RUNS_ON` for existing callers (tests unchanged).

## Test plan
- [x] `bun typecheck`
- [x] `bun lint`
- [x] `bun test` (5001 pass, 0 fail)
- [x] Added `resolveRunsOn` unit tests in `manifest.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)