### PR TITLE
fix(daemon): sticky core.bare guard + op instrumentation (fixes #1330)

### DIFF
--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -39,6 +39,17 @@ export function fixCoreBare(cwd: string, exec: ExecFn): boolean {
 }
 
 /**
+ * Read-only probe: returns true when `core.bare` is set to "true" on the repo.
+ * Used to instrument git ops — compare before/after to detect which operation
+ * flipped the bit. See #1330.
+ */
+export function isCoreBareSet(cwd: string, exec: ExecFn): boolean {
+  if (!existsSync(join(cwd, ".git"))) return false;
+  const { stdout, exitCode } = exec(["git", "-C", cwd, "config", "core.bare"]);
+  return exitCode === 0 && stdout.trim() === "true";
+}
+
+/**
  * Environment for git repo-discovery commands: strip inherited GIT_DIR,
  * GIT_WORK_TREE, and GIT_COMMON_DIR so that the caller's git-hook environment
  * does not override filesystem-based discovery. findGitRoot is meant to

--- a/packages/core/src/worktree-shim.spec.ts
+++ b/packages/core/src/worktree-shim.spec.ts
@@ -199,16 +199,17 @@ describe("createWorktree", () => {
     const result = createWorktree({ name: "my-feat", repoRoot: tmpDir, branchPrefix: "claude/" }, deps);
     expect(result.shimmed).toBe(true);
 
-    // Verify core.bare was checked after worktree add
-    const coreBareReadIdx = execCalls.findIndex(
-      (c) => c.includes("config") && c.includes("core.bare") && !c.includes("--unset"),
-    );
+    // Verify core.bare was checked both before and after worktree add
     const worktreeAddIdx = execCalls.findIndex((c) => c.includes("worktree") && c.includes("add"));
-    expect(coreBareReadIdx).toBeGreaterThan(worktreeAddIdx);
+    const isCoreBareRead = (c: string[]) => c.includes("config") && c.includes("core.bare") && !c.includes("--unset");
+    // There should be a read BEFORE the add (pre-probe) and one AFTER (post-probe / fixCoreBare)
+    expect(execCalls.slice(0, worktreeAddIdx).some(isCoreBareRead)).toBe(true);
+    const coreBareReadAfterIdx = execCalls.findIndex((c, i) => i > worktreeAddIdx && isCoreBareRead(c));
+    expect(coreBareReadAfterIdx).toBeGreaterThan(worktreeAddIdx);
 
     // Verify it was fixed (core.bare unset)
     const coreBareFixIdx = execCalls.findIndex((c) => c.includes("--unset") && c.includes("core.bare"));
-    expect(coreBareFixIdx).toBeGreaterThan(coreBareReadIdx);
+    expect(coreBareFixIdx).toBeGreaterThan(coreBareReadAfterIdx);
 
     // Should log the fix
     expect(deps.printError).toHaveBeenCalledWith("Fixed core.bare=true after worktree add");

--- a/packages/core/src/worktree-shim.ts
+++ b/packages/core/src/worktree-shim.ts
@@ -11,7 +11,7 @@
 import { existsSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import type { ExecFn } from "./git";
-import { fixCoreBare } from "./git";
+import { fixCoreBare, isCoreBareSet } from "./git";
 import {
   buildHookEnv,
   hasWorktreeHooks,
@@ -132,9 +132,15 @@ export function createWorktree(opts: WorktreeCreateOptions, deps: WorktreeShimDe
   // Case 2: branchPrefix: false — create with raw branch name
   if (wtConfig?.branchPrefix === false) {
     const worktreePath = resolveWorktreePath(repoRoot, name, wtConfig);
+    const bareBeforeAdd2 = isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd));
     const { exitCode, stderr } = deps.exec(["git", "worktree", "add", worktreePath, "-b", name, "HEAD"]);
     if (exitCode !== 0) {
       throw new WorktreeError(`Failed to create worktree: ${stderr}`);
+    }
+    if (!bareBeforeAdd2 && isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd))) {
+      deps.printError(
+        `[shim] core.bare flipped to true by: git worktree add ${worktreePath} (repo=${repoRoot}) — see #1330`,
+      );
     }
     if (fixCoreBare(repoRoot, (cmd) => deps.exec(cmd))) {
       deps.printError("Fixed core.bare=true after worktree add");
@@ -159,9 +165,15 @@ export function createWorktree(opts: WorktreeCreateOptions, deps: WorktreeShimDe
   // Case 4: Shim creates worktree with prefixed branch name
   const worktreePath = resolveWorktreePath(repoRoot, name, wtConfig);
   const gitBranch = branchPrefix ? `${branchPrefix}${name}` : name;
+  const bareBeforeAdd4 = isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd));
   const { exitCode, stderr } = deps.exec(["git", "worktree", "add", worktreePath, "-b", gitBranch, "HEAD"]);
   if (exitCode !== 0) {
     throw new WorktreeError(`Failed to create worktree: ${stderr}`);
+  }
+  if (!bareBeforeAdd4 && isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd))) {
+    deps.printError(
+      `[shim] core.bare flipped to true by: git worktree add ${worktreePath} (repo=${repoRoot}) — see #1330`,
+    );
   }
   if (fixCoreBare(repoRoot, (cmd) => deps.exec(cmd))) {
     deps.printError("Fixed core.bare=true after worktree add");
@@ -206,8 +218,14 @@ export function cleanupWorktree(worktree: string, cwd: string, deps: WorktreeShi
         deps.printError(`Worktree teardown hook failed for: ${worktreePath}: ${hookStderr}`);
       }
     } else {
+      const bareBeforeCleanup = isCoreBareSet(effectiveRoot, (cmd) => deps.exec(cmd));
       const { exitCode: removeExit } = deps.exec(["git", "-C", effectiveRoot, "worktree", "remove", worktreePath]);
       if (removeExit === 0) {
+        if (!bareBeforeCleanup && isCoreBareSet(effectiveRoot, (cmd) => deps.exec(cmd))) {
+          deps.printError(
+            `[shim] core.bare flipped to true by: git worktree remove ${worktreePath} (repo=${effectiveRoot}) — see #1330`,
+          );
+        }
         if (fixCoreBare(effectiveRoot, (cmd) => deps.exec(cmd))) {
           deps.printError("Fixed core.bare=true after worktree removal");
         }
@@ -238,8 +256,12 @@ export function cleanupWorktree(worktree: string, cwd: string, deps: WorktreeShi
 /** Delete a branch if it's been merged (git branch -d is safe — refuses unmerged). */
 function deleteIfMerged(branch: string, repoRoot: string, deps: WorktreeShimDeps): boolean {
   if (!branch) return false;
+  const bareBeforeDelete = isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd));
   const { exitCode } = deps.exec(["git", "-C", repoRoot, "branch", "-d", branch]);
   if (exitCode === 0) {
+    if (!bareBeforeDelete && isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd))) {
+      deps.printError(`[shim] core.bare flipped to true by: git branch -d ${branch} (repo=${repoRoot}) — see #1330`);
+    }
     deps.printError(`Deleted branch: ${branch} (merged)`);
     return true;
   }
@@ -403,8 +425,14 @@ export async function pruneWorktrees(opts: WorktreePruneOptions): Promise<Worktr
         deps.printError(`Worktree teardown hook failed for: ${wt.path}: ${hookStderr}`);
       }
     } else {
+      const bareBeforePrune = isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd));
       const { exitCode: removeExit } = deps.exec(["git", "-C", repoRoot, "worktree", "remove", wt.path]);
       if (removeExit === 0) {
+        if (!bareBeforePrune && isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd))) {
+          deps.printError(
+            `[shim] core.bare flipped to true by: git worktree remove ${wt.path} (repo=${repoRoot}) — see #1330`,
+          );
+        }
         if (fixCoreBare(repoRoot, (cmd) => deps.exec(cmd))) {
           deps.printError("Fixed core.bare=true after worktree removal");
         }

--- a/packages/daemon/src/index.spec.ts
+++ b/packages/daemon/src/index.spec.ts
@@ -968,6 +968,44 @@ describe("sweepCoreBare (#1330)", () => {
     }
   });
 
+  test("uses cwd fallback when repoRoot is not set (legacy sessions)", () => {
+    opts = testOptions();
+    const repoDir = join(opts.dir, "sweep-cwd-fallback");
+    mkdirSync(repoDir, { recursive: true });
+    writeFileSync(join(repoDir, ".git"), "gitdir: /some/repo\n");
+
+    const db = new StateDb(opts.DB_PATH);
+    try {
+      db.upsertSession({
+        sessionId: "legacy",
+        pid: 99999,
+        model: "sonnet",
+        cwd: repoDir,
+      });
+
+      const execCalls: string[][] = [];
+      const healed = sweepCoreBare(
+        db,
+        silentLogger,
+        mockGitOps({
+          exec: (cmd: string[]) => {
+            execCalls.push(cmd);
+            if (cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset")) {
+              return { exitCode: 0, stdout: "true\n" };
+            }
+            return { exitCode: 0, stdout: "" };
+          },
+        }),
+      );
+
+      expect(healed).toBe(1);
+      expect(execCalls.some((c) => c.includes(repoDir))).toBe(true);
+      expect(execCalls.some((c) => c.includes("--unset") && c.includes("core.bare"))).toBe(true);
+    } finally {
+      db.close();
+    }
+  });
+
   test("survives when db has no sessions", () => {
     opts = testOptions();
     const db = new StateDb(opts.DB_PATH);

--- a/packages/daemon/src/index.spec.ts
+++ b/packages/daemon/src/index.spec.ts
@@ -18,7 +18,7 @@ import { pollUntil, rpc } from "../../../test/harness";
 import { testOptions } from "../../../test/test-options";
 import { StateDb } from "./db/state";
 import type { DaemonHandle, PruneGitOps } from "./index";
-import { pruneOrphanedWorktrees, startDaemon } from "./index";
+import { pruneOrphanedWorktrees, startDaemon, sweepCoreBare } from "./index";
 
 setDefaultTimeout(15_000);
 
@@ -838,6 +838,142 @@ describe("pruneOrphanedWorktrees", () => {
       expect(unsetCalls.length).toBeGreaterThanOrEqual(1);
       // And logged a warning
       expect(warnMessages.some((m) => m.includes("core.bare"))).toBe(true);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("instrumentation: logs which op flipped core.bare (#1330)", () => {
+    // Simulate core.bare being flipped to true *by* the worktree remove op —
+    // before=false, after=true. Warning should identify the op.
+    opts = testOptions();
+    const repoDir = join(opts.dir, "repo-instrument");
+    mkdirSync(repoDir, { recursive: true });
+    writeFileSync(join(repoDir, ".git"), "gitdir: /some/repo\n");
+
+    const db = new StateDb(opts.DB_PATH);
+    try {
+      db.upsertSession({ sessionId: "e1", pid: 99999, model: "sonnet", cwd: repoDir, worktree: "wt-e1" });
+      db.endSession("e1");
+
+      const warnMessages: string[] = [];
+      const logger = { ...silentLogger, warn: (msg: string) => warnMessages.push(msg) };
+
+      let removed = false;
+      pruneOrphanedWorktrees(
+        db,
+        logger,
+        mockGitOps({
+          pathExists: () => true,
+          removeWorktree: () => {
+            removed = true;
+            return { exitCode: 0 };
+          },
+          exec: (cmd: string[]) => {
+            if (cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset")) {
+              // Flip only after removeWorktree runs
+              return { exitCode: 0, stdout: removed ? "true\n" : "false\n" };
+            }
+            return { exitCode: 0, stdout: "" };
+          },
+        }),
+      );
+
+      expect(warnMessages.some((m) => m.includes("flipped") && m.includes("worktree remove"))).toBe(true);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+describe("sweepCoreBare (#1330)", () => {
+  let opts: ReturnType<typeof testOptions> | undefined;
+
+  afterEach(() => {
+    if (opts) {
+      opts[Symbol.dispose]();
+      opts = undefined;
+    }
+  });
+
+  test("heals stuck core.bare=true on repos from active + ended sessions", () => {
+    opts = testOptions();
+    const repoDir = join(opts.dir, "sweep-repo");
+    mkdirSync(repoDir, { recursive: true });
+    writeFileSync(join(repoDir, ".git"), "gitdir: /some/repo\n");
+
+    const db = new StateDb(opts.DB_PATH);
+    try {
+      db.upsertSession({
+        sessionId: "active",
+        pid: 99999,
+        model: "sonnet",
+        cwd: repoDir,
+        repoRoot: repoDir,
+      });
+
+      const execCalls: string[][] = [];
+      const warnMessages: string[] = [];
+      const logger = { ...silentLogger, warn: (msg: string) => warnMessages.push(msg) };
+
+      const healed = sweepCoreBare(
+        db,
+        logger,
+        mockGitOps({
+          exec: (cmd: string[]) => {
+            execCalls.push(cmd);
+            if (cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset")) {
+              return { exitCode: 0, stdout: "true\n" };
+            }
+            return { exitCode: 0, stdout: "" };
+          },
+        }),
+      );
+
+      expect(healed).toBe(1);
+      expect(execCalls.some((c) => c.includes("--unset") && c.includes("core.bare"))).toBe(true);
+      expect(warnMessages.some((m) => m.includes("Healed core.bare=true"))).toBe(true);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("returns 0 when no repos need healing", () => {
+    opts = testOptions();
+    const repoDir = join(opts.dir, "sweep-clean");
+    mkdirSync(repoDir, { recursive: true });
+    writeFileSync(join(repoDir, ".git"), "gitdir: /some/repo\n");
+
+    const db = new StateDb(opts.DB_PATH);
+    try {
+      db.upsertSession({
+        sessionId: "active",
+        pid: 99999,
+        model: "sonnet",
+        cwd: repoDir,
+        repoRoot: repoDir,
+      });
+
+      const healed = sweepCoreBare(
+        db,
+        silentLogger,
+        mockGitOps({
+          exec: () => ({ exitCode: 0, stdout: "false\n" }),
+        }),
+      );
+
+      expect(healed).toBe(0);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("survives when db has no sessions", () => {
+    opts = testOptions();
+    const db = new StateDb(opts.DB_PATH);
+    try {
+      const healed = sweepCoreBare(db, silentLogger, mockGitOps());
+      expect(healed).toBe(0);
     } finally {
       db.close();
     }

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -47,6 +47,7 @@ import {
   ensureStateDir,
   fixCoreBare,
   generateSpanId,
+  isCoreBareSet,
   loadManifest,
   options,
   pruneExpiredCache,
@@ -145,6 +146,40 @@ function defaultGitOps(): PruneGitOps {
   };
 }
 
+/**
+ * Preflight: scan repo roots known to the daemon and unset `core.bare=true`
+ * wherever it's stuck. Catches drift from external tools (e.g. `gh pr merge
+ * --delete-branch`) that flip the bit outside our worktree shim. See #1330.
+ *
+ * Returns the number of repos that were healed.
+ */
+export function sweepCoreBare(
+  db: StateDb,
+  logger: Logger = consoleLogger,
+  gitOps: PruneGitOps = defaultGitOps(),
+): number {
+  let healed = 0;
+  try {
+    const roots = new Set<string>();
+    for (const s of db.listSessions(true)) {
+      if (s.repoRoot) roots.add(s.repoRoot);
+      else if (s.cwd) roots.add(s.cwd);
+    }
+    for (const s of db.listSessions(false)) {
+      if (s.repoRoot) roots.add(s.repoRoot);
+    }
+    for (const root of roots) {
+      if (fixCoreBare(root, (cmd) => gitOps.exec(cmd))) {
+        logger.warn(`[mcpd] Healed core.bare=true on ${root} (sweep) — see #1330`);
+        healed++;
+      }
+    }
+  } catch (err) {
+    logger.error(`[mcpd] core.bare sweep failed: ${err}`);
+  }
+  return healed;
+}
+
 /** Remove worktrees from ended sessions that are clean and have no active session. */
 export function pruneOrphanedWorktrees(
   db: StateDb,
@@ -181,19 +216,34 @@ export function pruneOrphanedWorktrees(
       const branchResult = gitOps.showBranch(worktreePath);
       const branch = branchResult.exitCode === 0 ? branchResult.stdout.trim() : null;
 
-      // Remove worktree
+      // Remove worktree — instrument to detect which op flips core.bare (#1330).
+      const bareBeforeRemove = isCoreBareSet(repoRoot, (cmd) => gitOps.exec(cmd));
       const removeResult = gitOps.removeWorktree(repoRoot, worktreePath);
       if (removeResult.exitCode === 0) {
+        const bareAfterRemove = isCoreBareSet(repoRoot, (cmd) => gitOps.exec(cmd));
+        if (!bareBeforeRemove && bareAfterRemove) {
+          logger.warn(
+            `[mcpd] core.bare flipped to true by: git worktree remove ${worktreePath} (repo=${repoRoot}) — see #1330`,
+          );
+        }
         if (fixCoreBare(repoRoot, (cmd) => gitOps.exec(cmd))) {
           logger.warn("[mcpd] Fixed core.bare=true after worktree removal");
         }
         affectedRepoRoots.add(repoRoot);
         pruned++;
         logger.info(`[mcpd] Pruned orphaned worktree: ${worktreePath}`);
-        // Delete merged branch
+        // Delete merged branch — also instrumented.
         if (branch) {
+          const bareBeforeBranch = isCoreBareSet(repoRoot, (cmd) => gitOps.exec(cmd));
           const deleteResult = gitOps.deleteBranch(repoRoot, branch);
           if (deleteResult.exitCode === 0) {
+            const bareAfterBranch = isCoreBareSet(repoRoot, (cmd) => gitOps.exec(cmd));
+            if (!bareBeforeBranch && bareAfterBranch) {
+              logger.warn(
+                `[mcpd] core.bare flipped to true by: git branch -d ${branch} (repo=${repoRoot}) — see #1330`,
+              );
+              fixCoreBare(repoRoot, (cmd) => gitOps.exec(cmd));
+            }
             logger.info(`[mcpd] Deleted branch: ${branch} (merged)`);
           }
         }
@@ -343,6 +393,11 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
   // Warn if runtime state permissions have been loosened
   auditRuntimePermissions(logger);
 
+  // Preflight: heal any core.bare=true drift on known repos before any
+  // subsequent git op touches them. External tools like `gh pr merge
+  // --delete-branch` can flip the bit outside our shim. See #1330.
+  sweepCoreBare(db, logger);
+
   // Create server pool
   const pool = new ServerPool(config, db, undefined, logger);
 
@@ -390,12 +445,15 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
 
   // Periodically prune sessions whose processes have exited (every 30s).
   // This ensures dead sessions are cleaned up promptly, not just at idle-timeout boundary.
+  // Also sweep core.bare so external flips (e.g. from `gh pr merge`) self-heal
+  // within 30s regardless of origin. See #1330.
   const pruneInterval = setInterval(() => {
     claudeServer.pruneDeadSessions();
     codexServer?.pruneDeadSessions();
     acpServer?.pruneDeadSessions();
     opencodeServer?.pruneDeadSessions();
     mockServer.pruneDeadSessions();
+    sweepCoreBare(db, logger);
   }, 30_000);
 
   // Update uptime and server gauges periodically

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -167,6 +167,7 @@ export function sweepCoreBare(
     }
     for (const s of db.listSessions(false)) {
       if (s.repoRoot) roots.add(s.repoRoot);
+      else if (s.cwd) roots.add(s.cwd);
     }
     for (const root of roots) {
       if (fixCoreBare(root, (cmd) => gitOps.exec(cmd))) {


### PR DESCRIPTION
## Summary
- Add `sweepCoreBare` self-heal: runs at daemon startup and every 30s on the existing prune interval, unsetting `core.bare=true` on all repoRoots known to the daemon. Covers drift from external tools (e.g. `gh pr merge --delete-branch`) that flip the bit outside our worktree shim.
- Instrument the two suspected call sites in `pruneOrphanedWorktrees` (`git worktree remove`, `git branch -d`) with before/after probes. If `core.bare` flips during the op, log a warn line naming the op + repo — concrete telemetry for the next recurrence.
- New read-only helper `isCoreBareSet` in `packages/core/src/git.ts`.

This is the third recurrence (#1206 → #1243 → #1330). Prior fixes only ran inside the worktree shim; the new sweep runs regardless of trigger, so even when external `gh` operations flip the bit, the daemon heals it within 30s.

## Test plan
- [x] `bun typecheck`
- [x] `bun lint`
- [x] `bun test` (5002 pass, 0 fail)
- [x] New tests: sweep heals stuck repos, no-op when clean, survives empty db, op-flip attribution log

🤖 Generated with [Claude Code](https://claude.com/claude-code)