### PR TITLE
fix(manifest): return null on lstat ENOENT race (fixes #1317)

### DIFF
--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -225,6 +225,8 @@ export function loadManifest(dir: string): { path: string; manifest: Manifest } 
     }
   } catch (err) {
     if (err instanceof ManifestError) throw err;
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return null;
     throw new ManifestError(`failed to stat: ${err instanceof Error ? err.message : String(err)}`, path);
   }
 


### PR DESCRIPTION
## Summary
- `loadManifest` now returns `null` when `lstatSync` hits `ENOENT`, matching the existing `readFileSync` ENOENT fallback.
- Fixes inconsistent behavior when the manifest file disappears between `findManifest` and the second syscall.

## Test plan
- [x] `bun typecheck`
- [x] `bun lint`
- [x] `bun test` (4998 pass / 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)