### PR TITLE
fix(quota): exponential backoff on rate-limit errors (fixes #1329)

### DIFF
--- a/packages/daemon/src/quota.spec.ts
+++ b/packages/daemon/src/quota.spec.ts
@@ -217,6 +217,81 @@ describe("QuotaPoller", () => {
     poller.stop();
   });
 
+  test("applies exponential backoff on rate-limit error", async () => {
+    const warnings: string[] = [];
+    let calls = 0;
+    const poller = new QuotaPoller({
+      intervalMs: 20,
+      logger: {
+        info: () => {},
+        warn: (msg: string) => warnings.push(msg),
+        error: () => {},
+        debug: () => {},
+      },
+      readToken: async () => fakeToken,
+      fetchUsage: async () => {
+        calls++;
+        throw new Error(
+          'Quota API returned 429: {"error":{"type":"rate_limit_error","message":"Rate limited. Please try again later."}}',
+        );
+      },
+    });
+
+    poller.start();
+    await Bun.sleep(120);
+    poller.stop();
+
+    // With base interval of 20ms and backoff doubling (40ms, 80ms, ...), we should
+    // see fewer calls than without backoff (which would be ~6 in 120ms).
+    expect(calls).toBeLessThanOrEqual(4);
+    expect(poller.backoffMs).toBeGreaterThanOrEqual(40);
+    expect(poller.lastError).toContain("rate_limit_error");
+    expect(warnings.some((w) => w.includes("rate-limited") && w.includes("backing off"))).toBe(true);
+  });
+
+  test("preserves last cached status during rate-limit", async () => {
+    let callCount = 0;
+    const poller = new QuotaPoller({
+      intervalMs: 20,
+      readToken: async () => fakeToken,
+      fetchUsage: async () => {
+        callCount++;
+        if (callCount === 1) return parseUsageResponse(SAMPLE_RESPONSE);
+        throw new Error("Quota API returned 429: rate_limit_error");
+      },
+    });
+
+    poller.start();
+    await Bun.sleep(120);
+    poller.stop();
+
+    // Cached status from first successful fetch is still available
+    expect(poller.status?.fiveHour?.utilization).toBe(42);
+    expect(poller.lastError).toContain("429");
+  });
+
+  test("resets backoff after successful fetch", async () => {
+    let callCount = 0;
+    const poller = new QuotaPoller({
+      intervalMs: 20,
+      readToken: async () => fakeToken,
+      fetchUsage: async () => {
+        callCount++;
+        if (callCount <= 2) throw new Error("Quota API returned 429: rate_limit_error");
+        return parseUsageResponse(SAMPLE_RESPONSE);
+      },
+    });
+
+    poller.start();
+    // Wait long enough for: fail(20ms base) → backoff(40ms) → fail → backoff(80ms) → success
+    await Bun.sleep(250);
+    poller.stop();
+
+    expect(poller.lastError).toBeNull();
+    expect(poller.backoffMs).toBeNull();
+    expect(poller.status?.fiveHour?.utilization).toBe(42);
+  });
+
   test("start is idempotent", async () => {
     let calls = 0;
     const poller = new QuotaPoller({

--- a/packages/daemon/src/quota.spec.ts
+++ b/packages/daemon/src/quota.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { silentLogger } from "@mcp-cli/core";
 import type { ClaudeOAuthToken } from "./auth/keychain";
 import { QuotaPoller, type QuotaStatus, parseUsageResponse } from "./quota";
 
@@ -253,6 +254,7 @@ describe("QuotaPoller", () => {
     let callCount = 0;
     const poller = new QuotaPoller({
       intervalMs: 20,
+      logger: silentLogger,
       readToken: async () => fakeToken,
       fetchUsage: async () => {
         callCount++;
@@ -274,6 +276,7 @@ describe("QuotaPoller", () => {
     let callCount = 0;
     const poller = new QuotaPoller({
       intervalMs: 20,
+      logger: silentLogger,
       readToken: async () => fakeToken,
       fetchUsage: async () => {
         callCount++;

--- a/packages/daemon/src/quota.ts
+++ b/packages/daemon/src/quota.ts
@@ -108,15 +108,23 @@ export async function fetchQuotaUsage(token: ClaudeOAuthToken): Promise<QuotaSta
 }
 
 const DEFAULT_POLL_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+const MAX_BACKOFF_MS = 60 * 60 * 1000; // 1 hour cap on rate-limit backoff
 const WARN_THRESHOLD = 80;
 const CRITICAL_THRESHOLD = 95;
+
+/** Detect whether an error looks like a rate-limit response (HTTP 429 or Anthropic rate_limit_error). */
+function isRateLimitError(msg: string): boolean {
+  return msg.includes("429") || msg.includes("rate_limit_error") || /rate[- ]?limit/i.test(msg);
+}
 
 /** Periodic quota poller. Fetches usage on an interval and logs warnings. */
 export class QuotaPoller {
   private timer: Timer | null = null;
+  private running = false;
   private _status: QuotaStatus | null = null;
   private _lastError: string | null = null;
   private _errorLogged = false;
+  private _backoffMs: number | null = null;
   private logger: Logger;
   private intervalMs: number;
   /** Injected token reader for testing. */
@@ -146,19 +154,33 @@ export class QuotaPoller {
     return this._lastError;
   }
 
+  /** Current backoff delay in ms (null if not backing off). Exposed for testing/observability. */
+  get backoffMs(): number | null {
+    return this._backoffMs;
+  }
+
   /** Start polling. Does an immediate first fetch. */
   start(): void {
-    if (this.timer) return;
-    this.poll();
-    this.timer = setInterval(() => this.poll(), this.intervalMs);
+    if (this.running) return;
+    this.running = true;
+    void this.tick();
   }
 
   /** Stop polling. */
   stop(): void {
+    this.running = false;
     if (this.timer) {
-      clearInterval(this.timer);
+      clearTimeout(this.timer);
       this.timer = null;
     }
+  }
+
+  private async tick(): Promise<void> {
+    if (!this.running) return;
+    await this.poll();
+    if (!this.running) return;
+    const delay = this._backoffMs ?? this.intervalMs;
+    this.timer = setTimeout(() => this.tick(), delay);
   }
 
   private async poll(): Promise<void> {
@@ -173,15 +195,29 @@ export class QuotaPoller {
       this._status = status;
       this._lastError = null;
       this._errorLogged = false;
+      this._backoffMs = null;
 
       this.checkThresholds(status);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this._lastError = msg;
-      // Log once on first failure, then stay silent to avoid spam
-      if (!this._errorLogged) {
-        this.logger.warn(`[mcpd] Quota fetch failed: ${msg}`);
-        this._errorLogged = true;
+
+      if (isRateLimitError(msg)) {
+        // Exponential backoff on rate limit — don't keep adding to the flood.
+        // Preserves last cached _status; consumers read .lastError for the reason.
+        const next = this._backoffMs == null ? this.intervalMs * 2 : this._backoffMs * 2;
+        this._backoffMs = Math.min(next, MAX_BACKOFF_MS);
+        if (!this._errorLogged) {
+          this.logger.warn(`[mcpd] Quota rate-limited; backing off to ${Math.round(this._backoffMs / 1000)}s: ${msg}`);
+          this._errorLogged = true;
+        }
+      } else {
+        // Non-rate-limit error — stay on normal cadence, log once.
+        this._backoffMs = null;
+        if (!this._errorLogged) {
+          this.logger.warn(`[mcpd] Quota fetch failed: ${msg}`);
+          this._errorLogged = true;
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- `QuotaPoller` now applies exponential backoff (up to 1h) when the usage endpoint returns 429 / `rate_limit_error`, instead of hammering every 5 minutes.
- Last cached `status` is preserved across rate-limit errors; consumers read `lastError` for the reason.
- Switched from `setInterval` to `setTimeout` chaining so the inter-poll delay can be dynamic.

## Context / scope
The reported error string `\"Failed to load usage data:\"` does not exist in this repo; a grep shows `daemon/src/quota.ts` is the sole caller of `/api/oauth/usage`, instantiated once at 5-min intervals, and every CLI path (`mcx status`, `mcx claude ls`) reads via IPC cached path. So mcx is likely not the *origin* of the flood the issue describes — but when we *are* rate-limited (by us or another tool in the user's env), we should back off, which is what the issue's \"Expected behavior\" section calls for.

## Test plan
- [x] New tests: exponential backoff fires on 429, cached status preserved, backoff resets after a successful fetch.
- [x] Existing quota + metrics-server tests still pass.
- [x] `bun typecheck`, `bun lint`, `bun test` (5001 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)