### PR TITLE
fix(aliases): honor __cwd magic arg in MCP alias calls (fixes #1324)

### DIFF
--- a/packages/daemon/src/alias-server.spec.ts
+++ b/packages/daemon/src/alias-server.spec.ts
@@ -3,7 +3,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { ALIAS_SERVER_NAME, silentLogger } from "@mcp-cli/core";
 import { testOptions } from "../../../test/test-options";
-import { AliasServer, buildAliasToolCache } from "./alias-server";
+import { ALIAS_MCP_CWD_ARG, AliasServer, buildAliasToolCache, extractMagicCwd } from "./alias-server";
 import { StateDb } from "./db/state";
 import { ServerPool } from "./server-pool";
 import { makeConfig, makeMockTransport } from "./test-helpers";
@@ -164,6 +164,37 @@ describe("buildAliasToolCache", () => {
     const db = { listAliases: () => [] };
     const tools = buildAliasToolCache(db as never);
     expect(tools.size).toBe(0);
+  });
+});
+
+// -- extractMagicCwd --
+
+describe("extractMagicCwd", () => {
+  test("returns undefined cwd and empty args for undefined input", () => {
+    expect(extractMagicCwd(undefined)).toEqual({ cwd: undefined, sanitizedArgs: {} });
+  });
+
+  test("returns undefined cwd when magic arg missing", () => {
+    expect(extractMagicCwd({ foo: "bar" })).toEqual({ cwd: undefined, sanitizedArgs: { foo: "bar" } });
+  });
+
+  test("extracts string cwd and strips magic arg", () => {
+    const result = extractMagicCwd({ [ALIAS_MCP_CWD_ARG]: "/repo", foo: "bar" });
+    expect(result.cwd).toBe("/repo");
+    expect(result.sanitizedArgs).toEqual({ foo: "bar" });
+    expect(ALIAS_MCP_CWD_ARG in result.sanitizedArgs).toBe(false);
+  });
+
+  test("ignores non-string cwd values but still strips the key", () => {
+    const result = extractMagicCwd({ [ALIAS_MCP_CWD_ARG]: 123, foo: "bar" });
+    expect(result.cwd).toBeUndefined();
+    expect(result.sanitizedArgs).toEqual({ foo: "bar" });
+  });
+
+  test("ignores empty-string cwd", () => {
+    const result = extractMagicCwd({ [ALIAS_MCP_CWD_ARG]: "" });
+    expect(result.cwd).toBeUndefined();
+    expect(result.sanitizedArgs).toEqual({});
   });
 });
 

--- a/packages/daemon/src/alias-server.ts
+++ b/packages/daemon/src/alias-server.ts
@@ -45,6 +45,30 @@ class Semaphore {
   }
 }
 
+/**
+ * Magic argument name used by MCP callers to pass their cwd through the
+ * CallToolRequest (which has no native cwd field). Stripped before the
+ * arguments reach the alias handler.
+ */
+export const ALIAS_MCP_CWD_ARG = "__cwd";
+
+/**
+ * Extract the `__cwd` magic argument from MCP tool call arguments.
+ * Returns the cwd (if valid) and a copy of the args with `__cwd` removed.
+ * Non-string `__cwd` values are ignored and stripped silently.
+ */
+export function extractMagicCwd(args: Record<string, unknown> | undefined): {
+  cwd: string | undefined;
+  sanitizedArgs: Record<string, unknown>;
+} {
+  if (!args || !(ALIAS_MCP_CWD_ARG in args)) {
+    return { cwd: undefined, sanitizedArgs: args ?? {} };
+  }
+  const { [ALIAS_MCP_CWD_ARG]: raw, ...rest } = args;
+  const cwd = typeof raw === "string" && raw.length > 0 ? raw : undefined;
+  return { cwd, sanitizedArgs: rest };
+}
+
 /** Serializable tool definition */
 export interface AliasToolDef {
   name: string;
@@ -114,8 +138,13 @@ export class AliasServer {
         };
       }
 
+      // The MCP CallToolRequest schema has no cwd field. Callers (e.g. Claude
+      // Code via `mcx serve`) pass a `__cwd` magic argument so ctx.state
+      // resolves to the correct repo root instead of the NO_REPO_ROOT bucket.
+      const { cwd, sanitizedArgs } = extractMagicCwd(args);
+
       try {
-        const result = await this.executeInSubprocess(aliasDef, args ?? {}, undefined, undefined);
+        const result = await this.executeInSubprocess(aliasDef, sanitizedArgs, undefined, cwd);
         const text = typeof result === "string" ? result : JSON.stringify(result, null, 2);
         return { content: [{ type: "text" as const, text }] };
       } catch (err) {


### PR DESCRIPTION
## Summary
- MCP `CallToolRequest` has no `cwd` field, so aliases invoked via the MCP path (Claude Code → `mcx serve` → `_aliases`) executed with `cwd=undefined`, collapsing all `ctx.state` writes into the `NO_REPO_ROOT` (`__none__`) bucket.
- Accept a `__cwd` magic argument in tool call arguments; `AliasServer` strips it before forwarding to the alias handler and passes it to `executeInSubprocess`, so repo-scoped `ctx.state` resolves correctly — same path `mcx call` uses via the IPC `cwd` field (#1307).
- Non-string / empty `__cwd` values are ignored but still stripped so the alias never sees the magic key.

## Test plan
- [x] `bun typecheck`
- [x] `bun lint`
- [x] `bun test` (5003 pass, 0 fail)
- [x] New unit tests for `extractMagicCwd` cover: missing arg, present string cwd, non-string values, empty string, undefined input

🤖 Generated with [Claude Code](https://claude.com/claude-code)