### PR TITLE
feat(phases): mcx phase log to audit transitions (fixes #1327)

### DIFF
--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -6,6 +6,7 @@ import {
   DisallowedTransitionError,
   RegressionError,
   UnknownPhaseError,
+  appendTransitionLog,
   historyTargets,
   parseLockfile,
   readTransitionHistory,
@@ -25,8 +26,11 @@ import {
   cmdPhase,
   detectDrift,
   explainTransition,
+  filterTransitionLog,
   formatDriftWarning,
   formatPhaseTable,
+  formatTransitionLog,
+  parsePhaseLogArgs,
   parsePhaseRunArgs,
   phaseRun,
   resolvePhaseSource,
@@ -994,6 +998,115 @@ describe("formatDriftWarning", () => {
     ]);
     expect(msg).not.toContain(longErr);
     expect(msg).toContain("...");
+  });
+});
+
+describe("parsePhaseLogArgs", () => {
+  test("defaults to no filters", () => {
+    expect(parsePhaseLogArgs([])).toEqual({ workItemId: null, forcedOnly: false, json: false });
+  });
+
+  test("parses flags", () => {
+    expect(parsePhaseLogArgs(["--work-item", "#42", "--forced-only", "--json"])).toEqual({
+      workItemId: "#42",
+      forcedOnly: true,
+      json: true,
+    });
+    expect(parsePhaseLogArgs(["--work-item=#99"])).toEqual({
+      workItemId: "#99",
+      forcedOnly: false,
+      json: false,
+    });
+  });
+
+  test("rejects unknown flag", () => {
+    expect(() => parsePhaseLogArgs(["--nope"])).toThrow(/unknown argument/);
+  });
+
+  test("rejects bare --work-item", () => {
+    expect(() => parsePhaseLogArgs(["--work-item"])).toThrow(/--work-item requires/);
+  });
+});
+
+describe("filterTransitionLog", () => {
+  const sample = [
+    { ts: "t1", workItemId: "#1", from: null, to: "impl" },
+    { ts: "t2", workItemId: "#2", from: null, to: "impl", forceMessage: "retry" },
+    { ts: "t3", workItemId: "#1", from: "impl", to: "qa" },
+  ];
+
+  test("newest first by default", () => {
+    expect(filterTransitionLog(sample, {}).map((e) => e.ts)).toEqual(["t3", "t2", "t1"]);
+  });
+
+  test("filters by workItemId", () => {
+    expect(filterTransitionLog(sample, { workItemId: "#1" }).map((e) => e.ts)).toEqual(["t3", "t1"]);
+  });
+
+  test("forcedOnly keeps entries with forceMessage", () => {
+    const r = filterTransitionLog(sample, { forcedOnly: true });
+    expect(r.length).toBe(1);
+    expect(r[0].forceMessage).toBe("retry");
+  });
+});
+
+describe("formatTransitionLog", () => {
+  test("renders header + rows with FORCED marker", () => {
+    const out = formatTransitionLog([
+      { ts: "2026-01-01T00:00:00Z", workItemId: "#1", from: "impl", to: "qa", forceMessage: "urgent" },
+    ]);
+    expect(out[0]).toContain("TIMESTAMP");
+    expect(out[1]).toContain("impl → qa");
+    expect(out[1]).toContain("FORCED: urgent");
+  });
+});
+
+describe("cmdPhase log", () => {
+  test("prints nothing-recorded message when log is empty", async () => {
+    const { deps, errs } = makeDriftDeps(dir);
+    await cmdPhase(["log"], deps);
+    expect(errs.some((e) => e.includes("no transitions recorded"))).toBe(true);
+  });
+
+  test("prints entries newest-first and honors --forced-only and --work-item", async () => {
+    const log = transitionLogPath(dir);
+    appendTransitionLog(log, { ts: "2026-01-01T00:00:00Z", workItemId: "#1", from: null, to: "impl" });
+    appendTransitionLog(log, {
+      ts: "2026-01-01T00:01:00Z",
+      workItemId: "#2",
+      from: null,
+      to: "impl",
+      forceMessage: "retry",
+    });
+    appendTransitionLog(log, { ts: "2026-01-01T00:02:00Z", workItemId: "#1", from: "impl", to: "qa" });
+
+    const a = makeDriftDeps(dir);
+    await cmdPhase(["log"], a.deps);
+    expect(a.logs.length).toBe(4);
+    expect(a.logs[1]).toContain("2026-01-01T00:02:00Z");
+
+    const b = makeDriftDeps(dir);
+    await cmdPhase(["log", "--forced-only"], b.deps);
+    expect(b.logs.length).toBe(2);
+    expect(b.logs[1]).toContain("FORCED: retry");
+
+    const c = makeDriftDeps(dir);
+    await cmdPhase(["log", "--work-item", "#1"], c.deps);
+    expect(c.logs.length).toBe(3);
+    expect(c.logs[1]).toContain("impl → qa");
+    expect(c.logs[2]).toContain("(initial) → impl");
+  });
+
+  test("--json emits raw JSONL newest first", async () => {
+    const log = transitionLogPath(dir);
+    appendTransitionLog(log, { ts: "t1", workItemId: "#1", from: null, to: "impl" });
+    appendTransitionLog(log, { ts: "t2", workItemId: "#1", from: "impl", to: "qa", forceMessage: "x" });
+    const { deps, logs } = makeDriftDeps(dir);
+    await cmdPhase(["log", "--json"], deps);
+    expect(logs.length).toBe(2);
+    const first = JSON.parse(logs[0]);
+    expect(first.ts).toBe("t2");
+    expect(first.forceMessage).toBe("x");
   });
 });
 

--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -1026,6 +1026,10 @@ describe("parsePhaseLogArgs", () => {
   test("rejects bare --work-item", () => {
     expect(() => parsePhaseLogArgs(["--work-item"])).toThrow(/--work-item requires/);
   });
+
+  test("rejects --work-item= with empty value", () => {
+    expect(() => parsePhaseLogArgs(["--work-item="])).toThrow(/--work-item requires/);
+  });
 });
 
 describe("filterTransitionLog", () => {
@@ -1063,9 +1067,9 @@ describe("formatTransitionLog", () => {
 
 describe("cmdPhase log", () => {
   test("prints nothing-recorded message when log is empty", async () => {
-    const { deps, errs } = makeDriftDeps(dir);
+    const { deps, logs } = makeDriftDeps(dir);
     await cmdPhase(["log"], deps);
-    expect(errs.some((e) => e.includes("no transitions recorded"))).toBe(true);
+    expect(logs.some((l) => l.includes("no transitions recorded"))).toBe(true);
   });
 
   test("prints entries newest-first and honors --forced-only and --work-item", async () => {

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -28,6 +28,7 @@ import {
   ManifestError,
   type ManifestState,
   RegressionError,
+  type TransitionLogEntry,
   UnknownPhaseError,
   bundleAlias,
   canonicalJson,
@@ -38,6 +39,7 @@ import {
   isDefineAlias,
   loadManifest,
   parseLockfile,
+  readAllTransitions,
   serializeLockfile,
   sha256Hex,
   suggestPhases,
@@ -256,6 +258,69 @@ export function parsePhaseRunArgs(args: string[]): PhaseRunOptions {
     throw new Error("--force requires a non-empty justification message");
   }
   return { target, from, workItemId, forceMessage: forceSeen ? (forceMessage as string) : null };
+}
+
+export interface PhaseLogOptions {
+  workItemId: string | null;
+  forcedOnly: boolean;
+  json: boolean;
+}
+
+export function parsePhaseLogArgs(args: string[]): PhaseLogOptions {
+  let workItemId: string | null = null;
+  let forcedOnly = false;
+  let json = false;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--work-item") {
+      workItemId = args[++i] ?? null;
+      if (workItemId === null) throw new Error("--work-item requires an id");
+    } else if (a.startsWith("--work-item=")) {
+      workItemId = a.slice("--work-item=".length);
+    } else if (a === "--forced-only") {
+      forcedOnly = true;
+    } else if (a === "--json") {
+      json = true;
+    } else {
+      throw new Error(`unknown argument: ${a}`);
+    }
+  }
+  return { workItemId, forcedOnly, json };
+}
+
+/** Apply filters from options; return newest-first. */
+export function filterTransitionLog(
+  entries: readonly TransitionLogEntry[],
+  opts: { workItemId?: string | null; forcedOnly?: boolean },
+): TransitionLogEntry[] {
+  const out: TransitionLogEntry[] = [];
+  for (const e of entries) {
+    if (opts.workItemId !== undefined && opts.workItemId !== null && e.workItemId !== opts.workItemId) continue;
+    if (opts.forcedOnly && !e.forceMessage) continue;
+    out.push(e);
+  }
+  return out.reverse();
+}
+
+/** Render transition entries as a human-readable table, newest first. */
+export function formatTransitionLog(entries: readonly TransitionLogEntry[]): string[] {
+  const rows = entries.map((e) => [
+    e.ts,
+    e.workItemId ?? "—",
+    `${e.from ?? "(initial)"} → ${e.to}`,
+    e.forceMessage ? `FORCED: ${e.forceMessage}` : "",
+  ]);
+  const headers = ["TIMESTAMP", "WORK-ITEM", "TRANSITION", "NOTE"];
+  const widths = headers.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i].length)));
+  const out: string[] = [];
+  const pad = (row: string[]) =>
+    row
+      .map((c, i) => c.padEnd(widths[i]))
+      .join("  ")
+      .trimEnd();
+  out.push(pad(headers));
+  for (const r of rows) out.push(pad(r));
+  return out;
 }
 
 export function transitionLogPath(repoDir: string): string {
@@ -599,6 +664,19 @@ export async function cmdPhase(args: string[], deps?: Partial<PhaseInstallDeps>)
       return;
     }
 
+    if (sub === "log") {
+      const opts = parsePhaseLogArgs(args.slice(1));
+      const entries = filterTransitionLog(readAllTransitions(transitionLogPath(d.cwd())), opts);
+      if (opts.json) {
+        for (const e of entries) d.log(JSON.stringify(e));
+      } else if (entries.length === 0) {
+        d.logError("no transitions recorded");
+      } else {
+        for (const line of formatTransitionLog(entries)) d.log(line);
+      }
+      return;
+    }
+
     if (sub === "run") {
       const argv = args.slice(1);
       assertNoDrift(d);
@@ -740,7 +818,12 @@ Subcommands:
       legal transitions, source preview, last install time.
 
   mcx phase why <from> <to> [--json]
-      Explain whether a transition is legal, via direct edge or shortest path.`);
+      Explain whether a transition is legal, via direct edge or shortest path.
+
+  mcx phase log [--work-item <id>] [--forced-only] [--json]
+      Print transitions from .mcx/transitions.jsonl, newest first.
+      --forced-only shows only entries with a --force justification.
+      --json emits one JSON object per line for piping.`);
 }
 
 export interface PhaseListRow {

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -274,9 +274,10 @@ export function parsePhaseLogArgs(args: string[]): PhaseLogOptions {
     const a = args[i];
     if (a === "--work-item") {
       workItemId = args[++i] ?? null;
-      if (workItemId === null) throw new Error("--work-item requires an id");
+      if (!workItemId) throw new Error("--work-item requires a non-empty id");
     } else if (a.startsWith("--work-item=")) {
       workItemId = a.slice("--work-item=".length);
+      if (!workItemId) throw new Error("--work-item requires a non-empty id");
     } else if (a === "--forced-only") {
       forcedOnly = true;
     } else if (a === "--json") {
@@ -670,7 +671,7 @@ export async function cmdPhase(args: string[], deps?: Partial<PhaseInstallDeps>)
       if (opts.json) {
         for (const e of entries) d.log(JSON.stringify(e));
       } else if (entries.length === 0) {
-        d.logError("no transitions recorded");
+        d.log("no transitions recorded");
       } else {
         for (const line of formatTransitionLog(entries)) d.log(line);
       }

--- a/packages/core/src/phase-transition.spec.ts
+++ b/packages/core/src/phase-transition.spec.ts
@@ -11,6 +11,7 @@ import {
   commitTransition,
   historyTargets,
   levenshtein,
+  readAllTransitions,
   readTransitionHistory,
   suggestPhases,
   validateTransition,
@@ -257,6 +258,20 @@ describe("transition log I/O", () => {
     });
     expect(historyTargets(entries)).toEqual(["impl", "qa"]);
     expect(corrupt).toEqual([{ line: 2, text: "not-json" }]);
+  });
+
+  test("readAllTransitions returns every entry regardless of workItemId", () => {
+    const log = join(dir, "transitions.jsonl");
+    appendTransitionLog(log, { ts: "t1", workItemId: "#1", from: null, to: "impl" });
+    appendTransitionLog(log, { ts: "t2", workItemId: "#2", from: null, to: "impl" });
+    appendTransitionLog(log, { ts: "t3", workItemId: null, from: "impl", to: "qa" });
+    const all = readAllTransitions(log);
+    expect(all.length).toBe(3);
+    expect(all.map((e) => e.ts)).toEqual(["t1", "t2", "t3"]);
+  });
+
+  test("readAllTransitions on missing file returns empty", () => {
+    expect(readAllTransitions(join(dir, "nope.jsonl"))).toEqual([]);
   });
 
   test("records force message", () => {

--- a/packages/core/src/phase-transition.ts
+++ b/packages/core/src/phase-transition.ts
@@ -237,7 +237,7 @@ export function readTransitionHistory(
 
 /**
  * Read every transition log entry from a JSONL file, oldest first.
- * Missing file → empty array. Malformed lines skipped silently.
+ * Missing file → empty array. Malformed lines are warned to stderr and skipped.
  */
 export function readAllTransitions(logPath: string): TransitionLogEntry[] {
   let text: string;
@@ -248,12 +248,15 @@ export function readAllTransitions(logPath: string): TransitionLogEntry[] {
     throw err;
   }
   const out: TransitionLogEntry[] = [];
-  for (const line of text.split("\n")) {
+  const lines = text.split("\n");
+  const onCorrupt = defaultOnCorruptLine(logPath);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
     if (!line) continue;
     try {
       out.push(JSON.parse(line) as TransitionLogEntry);
-    } catch {
-      // skip corrupt line
+    } catch (err) {
+      onCorrupt(i + 1, line, err);
     }
   }
   return out;

--- a/packages/core/src/phase-transition.ts
+++ b/packages/core/src/phase-transition.ts
@@ -235,6 +235,30 @@ export function readTransitionHistory(
   return out;
 }
 
+/**
+ * Read every transition log entry from a JSONL file, oldest first.
+ * Missing file → empty array. Malformed lines skipped silently.
+ */
+export function readAllTransitions(logPath: string): TransitionLogEntry[] {
+  let text: string;
+  try {
+    text = readFileSync(logPath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return [];
+    throw err;
+  }
+  const out: TransitionLogEntry[] = [];
+  for (const line of text.split("\n")) {
+    if (!line) continue;
+    try {
+      out.push(JSON.parse(line) as TransitionLogEntry);
+    } catch {
+      // skip corrupt line
+    }
+  }
+  return out;
+}
+
 /** Return the `to` field of every history entry, oldest first. */
 export function historyTargets(entries: readonly TransitionLogEntry[]): string[] {
   return entries.map((e) => e.to);


### PR DESCRIPTION
## Summary
- Add `mcx phase log [--work-item <id>] [--forced-only] [--json]` so `--force` justifications recorded by #1322 are observable, newest-first.
- Add `readAllTransitions()` in core (sibling to `readTransitionHistory`) for unfiltered log reads.
- Table output with FORCED marker; `--json` emits raw JSONL for piping.

## Test plan
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun test` — 5011 pass, 0 fail
- [x] Unit tests: `parsePhaseLogArgs`, `filterTransitionLog`, `formatTransitionLog`, `readAllTransitions`, and `cmdPhase log` (empty, --forced-only, --work-item, --json).

🤖 Generated with [Claude Code](https://claude.com/claude-code)