### PR TITLE
feat(phases): wire detectDrift into mcx phase run before dispatch (fixes #1346)

### DIFF
--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -192,6 +192,9 @@ defineAlias(({ z }) => ({
 `.trim(),
     );
 
+    const { deps: installDeps } = makeDriftDeps(dir);
+    await cmdPhase(["install"], installDeps);
+
     const logs: string[] = [];
     const errs: string[] = [];
     await cmdPhase(["run", "implement", "--dry-run"], {
@@ -213,6 +216,8 @@ defineAlias(({ z }) => ({
   test("run errors on unknown phase", async () => {
     writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);
     writeFileSync(join(dir, "impl.ts"), simpleAlias);
+    const { deps: installDeps } = makeDriftDeps(dir);
+    await cmdPhase(["install"], installDeps);
     const errs: string[] = [];
     let code: number | undefined;
     await cmdPhase(["run", "nope", "--dry-run"], {
@@ -233,6 +238,8 @@ defineAlias(({ z }) => ({
     // the transition (transition-enforcement path), not the dry-run execution path.
     writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);
     writeFileSync(join(dir, "impl.ts"), simpleAlias);
+    const { deps: installDeps } = makeDriftDeps(dir);
+    await cmdPhase(["install"], installDeps);
     const errs: string[] = [];
     let code: number | undefined;
     await cmdPhase(["run", "implement"], {
@@ -380,8 +387,24 @@ describe("phaseRun", () => {
 });
 
 describe("cmdPhase dispatch", () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     writeFileSync(join(dir, ".mcx.yaml"), manifestYaml);
+    const srcs: [string, string][] = [
+      ["impl.ts", "impl"],
+      ["review.ts", "adversarial-review"],
+      ["repair.ts", "repair"],
+      ["qa.ts", "qa"],
+      ["na.ts", "needs-attention"],
+      ["done.ts", "done"],
+    ];
+    for (const [file, name] of srcs) {
+      writeFileSync(
+        join(dir, file),
+        `import { defineAlias, z } from "mcp-cli";\ndefineAlias(({ z }) => ({ name: ${JSON.stringify(name)}, description: "d", input: z.object({}).optional(), fn: async () => {} }));\n`,
+      );
+    }
+    const { deps } = makeDriftDeps(dir);
+    await cmdPhase(["install"], deps);
   });
 
   async function catchExit(
@@ -494,10 +517,27 @@ describe("cmdPhase dispatch", () => {
     try {
       const { code, err } = await withCwd(empty, () => catchExit(() => cmdPhase(["run", "qa"])));
       expect(code).toBe(1);
-      expect(err).toContain("no .mcx.yaml");
+      // drift-check fires first; no-lockfile precedes no-manifest when both are absent
+      expect(err).toContain("no .mcx.lock");
     } finally {
       rmSync(empty, { recursive: true, force: true });
     }
+  });
+
+  test("run aborts with drift warning when phase source is tampered", async () => {
+    // Mutate a phase source after install — drift check must block dispatch
+    writeFileSync(join(dir, "qa.ts"), `${readFileSync(join(dir, "qa.ts"), "utf-8")}\n// tampered\n`);
+    const { code, err } = await withCwd(dir, () => catchExit(() => cmdPhase(["run", "qa", "--from", "impl"])));
+    expect(code).toBe(1);
+    expect(err).toContain("PHASE LOCKFILE DRIFT DETECTED");
+    expect(err).toContain("qa.ts");
+  });
+
+  test("run --dry-run aborts on drift before dispatch", async () => {
+    writeFileSync(join(dir, "qa.ts"), `${readFileSync(join(dir, "qa.ts"), "utf-8")}\n// tampered\n`);
+    const { code, err } = await withCwd(dir, () => catchExit(() => cmdPhase(["run", "qa", "--dry-run"])));
+    expect(code).toBe(1);
+    expect(err).toContain("PHASE LOCKFILE DRIFT DETECTED");
   });
 
   test("unknown subcommand exits 1", async () => {

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -455,6 +455,30 @@ To regenerate after review:  mcx phase install`;
   return `${header}\n${rows}${footer}`;
 }
 
+/**
+ * Shared drift-abort used by `check` and `run`. Any non-ok status exits 1
+ * with a message; callers resume normal flow only when drift status is ok.
+ *
+ * Wired into `run` so malicious phase-source mutations cannot execute: the
+ * lockfile must match the on-disk manifest + sources before dispatch.
+ */
+function assertNoDrift(d: PhaseInstallDeps): void {
+  const result = detectDrift(d);
+  if (result.status === "ok") return;
+  switch (result.status) {
+    case "no-lockfile":
+      d.logError(`no ${LOCKFILE_NAME} — run \`mcx phase install\` to create one`);
+      break;
+    case "no-manifest":
+      d.logError("no .mcx.yaml or .mcx.json in this repo");
+      break;
+    case "drift":
+      d.logError(formatDriftWarning(result.entries));
+      break;
+  }
+  d.exit(1);
+}
+
 function labelFor(kind: DriftKind): string {
   switch (kind) {
     case "manifest":
@@ -518,24 +542,8 @@ export async function cmdPhase(args: string[], deps?: Partial<PhaseInstallDeps>)
     }
 
     if (sub === "check") {
-      const result = detectDrift(d);
-      switch (result.status) {
-        case "no-lockfile":
-          d.logError(`no ${LOCKFILE_NAME} — run \`mcx phase install\` to create one`);
-          d.exit(1);
-          break;
-        case "no-manifest":
-          d.logError("no .mcx.yaml or .mcx.json in this repo");
-          d.exit(1);
-          break;
-        case "drift":
-          d.logError(formatDriftWarning(result.entries));
-          d.exit(1);
-          break;
-        case "ok":
-          d.log("lockfile ok");
-          break;
-      }
+      assertNoDrift(d);
+      d.log("lockfile ok");
       return;
     }
 
@@ -612,6 +620,7 @@ export async function cmdPhase(args: string[], deps?: Partial<PhaseInstallDeps>)
 
     if (sub === "run") {
       const argv = args.slice(1);
+      assertNoDrift(d);
       if (argv.includes("--dry-run")) {
         await runPhase(argv, d);
       } else {


### PR DESCRIPTION
## Summary
- Extracted drift abort into an `assertNoDrift` helper reused by both `phase check` and `phase run`. Any non-ok drift status (no-lockfile, no-manifest, drift) now exits 1 with the stern warning before dispatch.
- Covers both paths under `phase run`: `--dry-run` (alias execution preview) and the transition-enforcement path. A malicious or accidental phase-source mutation between `install` and `run` can no longer execute silently.
- Coordinates with #1368 (O_EXCL transition-log lockfile): drift is checked in `cmdPhase` before `phaseRun` is invoked, so the transition-log lock never protects a tampered source.

## Test plan
- [x] `bun typecheck`
- [x] `bun lint`
- [x] `bun test` — 5000 pass, 0 fail
- [x] New: `run aborts with drift warning when phase source is tampered` — mutates `qa.ts` after install, expects exit 1 + drift banner
- [x] New: `run --dry-run aborts on drift before dispatch` — same scenario on the dry-run path
- [x] Existing `cmdPhase dispatch` tests updated to install a lockfile in `beforeEach` (required now that `run` enforces drift)
- [x] `run with no manifest exits 1` expectation shifted from `no .mcx.yaml` to `no .mcx.lock` — drift check fires first when neither lockfile nor manifest exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)