### PR TITLE
fix(claude-wait): cap --timeout at 299000ms (prompt cache TTL) (fixes #1341)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -2065,6 +2065,24 @@ describe("parseWaitArgs", () => {
     expect(result.error).toBe("--timeout requires a value in ms");
   });
 
+  test("rejects --timeout > 299000ms (cache TTL cap)", () => {
+    const result = parseWaitArgs(["--timeout", "300000"]);
+    expect(result.error).toContain("exceeds 4:59 cache-safe limit");
+    expect(result.error).toContain("300000ms");
+  });
+
+  test("accepts --timeout at cache-safe boundary (299000)", () => {
+    const result = parseWaitArgs(["--timeout", "299000"]);
+    expect(result.error).toBeUndefined();
+    expect(result.timeout).toBe(299000);
+  });
+
+  test("accepts recommended --timeout 270000", () => {
+    const result = parseWaitArgs(["--timeout", "270000"]);
+    expect(result.error).toBeUndefined();
+    expect(result.timeout).toBe(270000);
+  });
+
   test("parses --after flag", () => {
     const result = parseWaitArgs(["--after", "42"]);
     expect(result.afterSeq).toBe(42);

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -1412,7 +1412,11 @@ export function parseWaitArgs(args: string[]): WaitArgs {
         error = "--timeout requires a value in ms";
       } else {
         timeout = Number(val);
-        if (Number.isNaN(timeout)) error = "--timeout must be a number";
+        if (Number.isNaN(timeout)) {
+          error = "--timeout must be a number";
+        } else if (timeout > 299_000) {
+          error = `--timeout ${timeout}ms exceeds 4:59 cache-safe limit.\nThe Claude Code prompt cache has a 5-minute TTL; waits >= 5 minutes cause the\nnext turn to re-process full context at full input-token price.\nUse --timeout 270000 (4:30) or loop with shorter waits.`;
+        }
       }
     } else if (arg === "--after") {
       const val = args[++i];


### PR DESCRIPTION
## Summary
- `mcx claude wait --timeout N` now hard-refuses values > 299000ms (4:59)
- Error message points to 270000 (4:30) as the cache-safe recommended value and explains the 5-minute prompt cache TTL cost
- Validation happens in `parseWaitArgs`, so both the CLI error path and tests exercise it

## Test plan
- [x] New test: `--timeout 300000` rejected with "exceeds 4:59 cache-safe limit"
- [x] New test: `--timeout 299000` accepted (boundary)
- [x] New test: `--timeout 270000` accepted (recommended)
- [x] `bun typecheck` / `bun lint` / `bun test` all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)