### PR TITLE
fix(claude): default spawn cwd to caller's process.cwd() (fixes #1331)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -576,7 +576,37 @@ describe("mcx claude spawn", () => {
     console.log = logSpy;
     try {
       await cmdClaude(["spawn", "--task", "fix the bug"], deps);
-      expect(callTool).toHaveBeenCalledWith("claude_prompt", { prompt: "fix the bug" });
+      expect(callTool).toHaveBeenCalledWith("claude_prompt", { prompt: "fix the bug", cwd: process.cwd() });
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("defaults cwd to caller's process.cwd() when not provided (#1331)", async () => {
+    const callTool = mock(async () => toolResult({ success: true }));
+    const deps = makeDeps({ callTool });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["spawn", "--task", "x"], deps);
+      const toolCalls = callTool.mock.calls as unknown as Array<[string, Record<string, unknown>]>;
+      expect(toolCalls[0][1].cwd).toBe(process.cwd());
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("explicit --cwd overrides default", async () => {
+    const callTool = mock(async () => toolResult({ success: true }));
+    const deps = makeDeps({ callTool });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["spawn", "--task", "x", "--cwd", "/tmp/elsewhere"], deps);
+      const toolCalls = callTool.mock.calls as unknown as Array<[string, Record<string, unknown>]>;
+      expect(toolCalls[0][1].cwd).toBe("/tmp/elsewhere");
     } finally {
       console.log = origLog;
     }
@@ -614,6 +644,7 @@ describe("mcx claude spawn", () => {
       expect(callTool).toHaveBeenCalledWith("claude_prompt", {
         prompt: "continue",
         sessionId: "abc123",
+        cwd: process.cwd(),
       });
     } finally {
       console.log = origLog;
@@ -631,6 +662,7 @@ describe("mcx claude spawn", () => {
       expect(callTool).toHaveBeenCalledWith("claude_prompt", {
         prompt: "Continue from where you left off.",
         sessionId: "abc123",
+        cwd: process.cwd(),
       });
     } finally {
       console.log = origLog;
@@ -645,7 +677,7 @@ describe("mcx claude spawn", () => {
     console.log = mock(() => {});
     try {
       await cmdClaude(["spawn", "--task", "fix", "--wait"], deps);
-      expect(callTool).toHaveBeenCalledWith("claude_prompt", { prompt: "fix", wait: true });
+      expect(callTool).toHaveBeenCalledWith("claude_prompt", { prompt: "fix", wait: true, cwd: process.cwd() });
     } finally {
       console.log = origLog;
     }
@@ -677,6 +709,7 @@ describe("mcx claude spawn", () => {
       expect(callTool).toHaveBeenCalledWith("claude_prompt", {
         prompt: "fix",
         model: "claude-sonnet-4-6",
+        cwd: process.cwd(),
       });
     } finally {
       console.log = origLog;
@@ -2742,7 +2775,7 @@ describe("mcx claude lifecycle (spawn → ls → send → log → bye)", () => {
     try {
       // 1. Spawn
       await cmdClaude(["spawn", "--task", "lifecycle test"], deps);
-      expect(callTool).toHaveBeenCalledWith("claude_prompt", { prompt: "lifecycle test" });
+      expect(callTool).toHaveBeenCalledWith("claude_prompt", { prompt: "lifecycle test", cwd: process.cwd() });
       expect(sessions).toHaveLength(1);
       expect(sessions[0].state).toBe("active");
 

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -378,7 +378,9 @@ async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
   };
   if (parsed.resume) toolArgs.sessionId = parsed.resume;
   if (parsed.allow.length > 0) toolArgs.allowedTools = parsed.allow;
+  // Without this, sessions inherit daemon cwd instead of caller's shell (#1331).
   if (parsed.cwd) toolArgs.cwd = parsed.cwd;
+  else if (!parsed.worktree) toolArgs.cwd = process.cwd();
   if (parsed.timeout) toolArgs.timeout = parsed.timeout;
   if (parsed.model) toolArgs.model = parsed.model;
   if (parsed.name) toolArgs.name = parsed.name;


### PR DESCRIPTION
## Summary
- `mcx claude spawn` without `--cwd` now defaults to `process.cwd()` (the caller's shell), matching standard Unix child-process expectations.
- Previously sessions inherited the daemon's cwd (the repo where `mcpd` was started), causing orchestrators spawning workers from other repos to silently land in mcp-cli.
- `--worktree` continues to set `cwd` to the worktree path; explicit `--cwd` still overrides.

## Test plan
- [x] New spec: `defaults cwd to caller's process.cwd() when not provided (#1331)`
- [x] New spec: `explicit --cwd overrides default`
- [x] Updated existing spawn specs to expect the new `cwd` field
- [x] `bun typecheck` / `bun lint` / `bun test` (5002 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)