### PR TITLE
feat(phases): forward --arg key=val into dry-run ctx.args (fixes #1348)

### DIFF
--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -217,6 +217,76 @@ defineAlias(({ z }) => ({
     ]);
   }, 15_000);
 
+  test("run --dry-run --arg forwards key=val into ctx.args", async () => {
+    writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);
+    writeFileSync(
+      join(dir, "impl.ts"),
+      `
+import { defineAlias, z } from "mcp-cli";
+
+defineAlias(({ z }) => ({
+  name: "implement",
+  description: "impl",
+  input: z.object({}).optional(),
+  fn: async (_input, ctx) => {
+    await ctx.state.set("issue", ctx.args.issue);
+    await ctx.state.set("branch", ctx.args.branch);
+  },
+}));
+`.trim(),
+    );
+
+    const logs: string[] = [];
+    const errs: string[] = [];
+    await cmdPhase(["run", "implement", "--dry-run", "--arg", "issue=1296", "--arg", "branch=feat/x"], {
+      cwd: () => dir,
+      log: (m) => logs.push(m),
+      logError: (m) => errs.push(m),
+      exit: ((code: number) => {
+        throw new Error(`exit(${code})`);
+      }) as (code: number) => never,
+    });
+
+    expect(logs).toEqual([`[dry-run] ctx.state.set("issue", "1296")`, `[dry-run] ctx.state.set("branch", "feat/x")`]);
+    expect(errs).toEqual([]);
+  }, 15_000);
+
+  test("run --dry-run --arg errors on missing value", async () => {
+    writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);
+    writeFileSync(join(dir, "impl.ts"), simpleAlias);
+    const errs: string[] = [];
+    let code: number | undefined;
+    await cmdPhase(["run", "implement", "--dry-run", "--arg"], {
+      cwd: () => dir,
+      log: () => {},
+      logError: (m) => errs.push(m),
+      exit: ((c: number) => {
+        code = c;
+        throw new Error("exit");
+      }) as (c: number) => never,
+    }).catch(() => {});
+    expect(code).toBe(1);
+    expect(errs.some((e) => e.includes("--arg requires"))).toBe(true);
+  });
+
+  test("run --dry-run --arg errors on missing = separator", async () => {
+    writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);
+    writeFileSync(join(dir, "impl.ts"), simpleAlias);
+    const errs: string[] = [];
+    let code: number | undefined;
+    await cmdPhase(["run", "implement", "--dry-run", "--arg", "noequals"], {
+      cwd: () => dir,
+      log: () => {},
+      logError: (m) => errs.push(m),
+      exit: ((c: number) => {
+        code = c;
+        throw new Error("exit");
+      }) as (c: number) => never,
+    }).catch(() => {});
+    expect(code).toBe(1);
+    expect(errs.some((e) => e.includes("key=val"))).toBe(true);
+  });
+
   test("run errors on unknown phase", async () => {
     writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);
     writeFileSync(join(dir, "impl.ts"), simpleAlias);

--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -236,6 +236,9 @@ defineAlias(({ z }) => ({
 `.trim(),
     );
 
+    const { deps: installDeps } = makeDriftDeps(dir);
+    await cmdPhase(["install"], installDeps);
+
     const logs: string[] = [];
     const errs: string[] = [];
     await cmdPhase(["run", "implement", "--dry-run", "--arg", "issue=1296", "--arg", "branch=feat/x"], {
@@ -254,6 +257,8 @@ defineAlias(({ z }) => ({
   test("run --dry-run --arg errors on missing value", async () => {
     writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);
     writeFileSync(join(dir, "impl.ts"), simpleAlias);
+    const { deps: installDeps } = makeDriftDeps(dir);
+    await cmdPhase(["install"], installDeps);
     const errs: string[] = [];
     let code: number | undefined;
     await cmdPhase(["run", "implement", "--dry-run", "--arg"], {
@@ -272,6 +277,8 @@ defineAlias(({ z }) => ({
   test("run --dry-run --arg errors on missing = separator", async () => {
     writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);
     writeFileSync(join(dir, "impl.ts"), simpleAlias);
+    const { deps: installDeps } = makeDriftDeps(dir);
+    await cmdPhase(["install"], installDeps);
     const errs: string[] = [];
     let code: number | undefined;
     await cmdPhase(["run", "implement", "--dry-run", "--arg", "noequals"], {

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -735,7 +735,12 @@ async function runPhase(argv: string[], d: PhaseInstallDeps): Promise<void> {
         d.logError(`--arg value must be in key=val form, got: ${pair}`);
         d.exit(1);
       }
-      extraArgs[pair.slice(0, eq)] = pair.slice(eq + 1);
+      const key = pair.slice(0, eq);
+      if (!key) {
+        d.logError(`--arg key must be non-empty in key=val form, got: ${pair}`);
+        d.exit(1);
+      }
+      extraArgs[key] = pair.slice(eq + 1);
     } else if (a.startsWith("--")) {
       flags.add(a);
     } else {

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -721,9 +721,26 @@ export async function cmdPhase(args: string[], deps?: Partial<PhaseInstallDeps>)
 async function runPhase(argv: string[], d: PhaseInstallDeps): Promise<void> {
   const positional: string[] = [];
   const flags = new Set<string>();
-  for (const a of argv) {
-    if (a.startsWith("--")) flags.add(a);
-    else positional.push(a);
+  const extraArgs: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--arg") {
+      const pair = argv[++i];
+      if (!pair) {
+        d.logError("--arg requires a key=val argument");
+        d.exit(1);
+      }
+      const eq = pair.indexOf("=");
+      if (eq === -1) {
+        d.logError(`--arg value must be in key=val form, got: ${pair}`);
+        d.exit(1);
+      }
+      extraArgs[pair.slice(0, eq)] = pair.slice(eq + 1);
+    } else if (a.startsWith("--")) {
+      flags.add(a);
+    } else {
+      positional.push(a);
+    }
   }
   const name = positional[0];
   if (!name) {
@@ -777,7 +794,7 @@ async function runPhase(argv: string[], d: PhaseInstallDeps): Promise<void> {
   };
   const baseCtx: AliasContext = {
     mcp: {},
-    args: {},
+    args: extraArgs,
     file: (p) => Bun.file(p).text(),
     json: async (p) => JSON.parse(await Bun.file(p).text()),
     // Dry-run: use an in-memory no-op cache so producers still run but
@@ -808,8 +825,10 @@ Subcommands:
       --force <message> bypasses disallowed-transition and regression checks;
       unknown-phase errors are never bypassable.
 
-  mcx phase run <name> --dry-run
+  mcx phase run <name> --dry-run [--arg key=val ...]
       Execute a phase handler with side effects logged but not dispatched.
+      Use --arg to forward key=val pairs into ctx.args so dry-run exercises
+      the same code paths as real execution.
 
   mcx phase list [--json]
       List all phases declared in the manifest with install status.


### PR DESCRIPTION
## Summary
- Adds `--arg key=val` flag parsing to `mcx phase run <name> --dry-run` so phase handlers that branch on `ctx.args` values exercise the same code paths in dry-run as real execution
- Replaces the hardcoded `args: {}` in `baseCtx` with the parsed key-value pairs collected from `--arg` flags
- Updates help text to document the new flag

## Test plan
- [x] New test: `run --dry-run --arg forwards key=val into ctx.args` — verifies a handler reading `ctx.args.issue` and `ctx.args.branch` sees the forwarded values
- [x] New test: `run --dry-run --arg errors on missing value` — `--arg` with no following token exits 1
- [x] New test: `run --dry-run --arg errors on missing = separator` — `--arg noequals` exits 1
- [x] All 5003 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)