### PR TITLE
feat(claude-wait): surface mail:received events via --mail-to (fixes #1359)

### DIFF
--- a/packages/command/src/commands/agent.spec.ts
+++ b/packages/command/src/commands/agent.spec.ts
@@ -1663,7 +1663,8 @@ describe("agent wait flags", () => {
 
   // --mail-to: surfaces mail:received events alongside session events (#1359)
   test("--mail-to wakes on incoming mail before session event", async () => {
-    // Session wait blocks forever; mail poll returns a message.
+    // Session wait blocks forever; mail poll returns a message dated in the future
+    // so it passes the HWM filter (createdAt > pollStart).
     const mailMsg = {
       id: 42,
       sender: "jacob",
@@ -1672,7 +1673,7 @@ describe("agent wait flags", () => {
       body: "CI broken",
       replyTo: null,
       read: false,
-      createdAt: "2026-04-12T22:47:00Z",
+      createdAt: new Date(Date.now() + 60_000).toISOString(),
     };
     const callTool = mock(() => new Promise(() => {})) as unknown as AgentDeps["callTool"];
     const deps = makeDeps({
@@ -1697,7 +1698,7 @@ describe("agent wait flags", () => {
       body: null,
       replyTo: null,
       read: false,
-      createdAt: "2026-04-12T22:47:00Z",
+      createdAt: new Date(Date.now() + 60_000).toISOString(),
     };
     const deps = makeDeps({
       callTool: mock(() => new Promise(() => {})) as unknown as AgentDeps["callTool"],
@@ -1723,6 +1724,55 @@ describe("agent wait flags", () => {
   test("--mail-to without value errors", async () => {
     const deps = makeDeps();
     await expect(cmdAgent(["claude", "wait", "--mail-to"], deps)).rejects.toThrow(ExitError);
+  });
+
+  test("--mail-to does not wake on pre-existing unread mail (HWM filter)", async () => {
+    // Mail with a past createdAt predates the wait and must be filtered out.
+    // The wait should fall through to the session event, not surface stale mail.
+    const staleMail = {
+      id: 1,
+      sender: "jacob",
+      recipient: "orchestrator",
+      subject: "old message",
+      body: null,
+      replyTo: null,
+      read: false,
+      createdAt: new Date(Date.now() - 60_000).toISOString(), // 1 min ago
+    };
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult({ event: { event: "session:result" }, sessions: [] })),
+      pollMail: mock(async () => staleMail),
+    });
+    await cmdAgent(["claude", "wait", "--mail-to", "orchestrator", "--timeout", "100"], deps);
+    const output = logCalls(deps).join("\n");
+    expect(output).not.toContain('"source": "mail"');
+  });
+
+  test("--mail-to continues polling when pollMail throws transiently", async () => {
+    // First call throws (IPC blip), second call returns new mail. Wait must succeed.
+    const newMail = {
+      id: 99,
+      sender: "qa",
+      recipient: "orchestrator",
+      subject: "tests passing",
+      body: null,
+      replyTo: null,
+      read: false,
+      createdAt: new Date(Date.now() + 60_000).toISOString(),
+    };
+    let calls = 0;
+    const deps = makeDeps({
+      callTool: mock(() => new Promise(() => {})) as unknown as AgentDeps["callTool"],
+      pollMail: mock(async () => {
+        if (calls++ === 0) throw new Error("ECONNREFUSED");
+        return newMail;
+      }),
+    });
+    await cmdAgent(["claude", "wait", "--mail-to", "orchestrator", "--timeout", "5000"], deps);
+    const output = logCalls(deps).join("\n");
+    const parsed = JSON.parse(output);
+    expect(parsed.source).toBe("mail");
+    expect(parsed.mail.id).toBe(99);
   });
 });
 

--- a/packages/command/src/commands/agent.spec.ts
+++ b/packages/command/src/commands/agent.spec.ts
@@ -30,6 +30,7 @@ function makeDeps(overrides?: Partial<AgentDeps>): AgentDeps {
     log: mock(() => {}),
     logError: mock(() => {}),
     exec: mock(() => ({ stdout: "", stderr: "", exitCode: 0 })),
+    pollMail: mock(async () => null),
     ...overrides,
   };
 }
@@ -1658,6 +1659,70 @@ describe("agent wait flags", () => {
       "codex_wait",
       expect.objectContaining({ sessionId: SESSION_LIST[0].sessionId }),
     );
+  });
+
+  // --mail-to: surfaces mail:received events alongside session events (#1359)
+  test("--mail-to wakes on incoming mail before session event", async () => {
+    // Session wait blocks forever; mail poll returns a message.
+    const mailMsg = {
+      id: 42,
+      sender: "jacob",
+      recipient: "orchestrator",
+      subject: "main is red",
+      body: "CI broken",
+      replyTo: null,
+      read: false,
+      createdAt: "2026-04-12T22:47:00Z",
+    };
+    const callTool = mock(() => new Promise(() => {})) as unknown as AgentDeps["callTool"];
+    const deps = makeDeps({
+      callTool,
+      pollMail: mock(async (recipient: string) => (recipient === "orchestrator" ? mailMsg : null)),
+    });
+    await cmdAgent(["claude", "wait", "--mail-to", "orchestrator", "--timeout", "5000"], deps);
+    const output = logCalls(deps).join("\n");
+    const parsed = JSON.parse(output);
+    expect(parsed.source).toBe("mail");
+    expect(parsed.mail.id).toBe(42);
+    expect(parsed.mail.subject).toBe("main is red");
+    expect(deps.pollMail).toHaveBeenCalledWith("orchestrator");
+  });
+
+  test("--mail-to --short emits compact mail line", async () => {
+    const mailMsg = {
+      id: 7,
+      sender: "qa",
+      recipient: "orchestrator",
+      subject: "PR #123 failing",
+      body: null,
+      replyTo: null,
+      read: false,
+      createdAt: "2026-04-12T22:47:00Z",
+    };
+    const deps = makeDeps({
+      callTool: mock(() => new Promise(() => {})) as unknown as AgentDeps["callTool"],
+      pollMail: mock(async () => mailMsg),
+    });
+    await cmdAgent(["claude", "wait", "--mail-to=orchestrator", "--short", "--timeout", "5000"], deps);
+    const output = logCalls(deps).join("\n");
+    expect(output).toBe("mail 7 qa PR #123 failing");
+  });
+
+  test("--mail-to falls through to session wait when no mail arrives", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult({ event: { event: "session:result" }, sessions: [] })),
+      pollMail: mock(async () => null),
+    });
+    await cmdAgent(["claude", "wait", "--mail-to", "orchestrator", "--timeout", "100"], deps);
+    expect(deps.callTool).toHaveBeenCalledWith("claude_wait", expect.objectContaining({ timeout: 100 }));
+    // Should have produced session-shape output, not a mail event
+    const output = logCalls(deps).join("\n");
+    expect(output).not.toContain('"source": "mail"');
+  });
+
+  test("--mail-to without value errors", async () => {
+    const deps = makeDeps();
+    await expect(cmdAgent(["claude", "wait", "--mail-to"], deps)).rejects.toThrow(ExitError);
   });
 });
 

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -185,17 +185,31 @@ export function makeDefaultDeps(provider: AgentProvider): AgentDeps {
  * Poll for unread mail addressed to `recipient` until one arrives or the
  * deadline expires. Non-consuming — does not markRead, so the caller can
  * still read the message via `mcx mail -u <recipient>` afterward.
+ *
+ * `afterMs` is a `Date.now()` snapshot taken before polling begins. Only
+ * mail with `createdAt` strictly after that timestamp is surfaced, so
+ * pre-existing unread messages do not cause false-positive wakeups.
+ *
+ * Transient `pollMail` errors (IPC blips, daemon restart) are swallowed
+ * and retried until the deadline; a single network hiccup will not kill
+ * the entire wait.
  */
 async function pollMailUntil(
   d: Pick<AgentDeps, "pollMail">,
   recipient: string,
   timeoutMs: number,
+  afterMs: number,
   pollIntervalMs = 2000,
 ): Promise<MailMessage | null> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const msg = await d.pollMail(recipient);
-    if (msg) return msg;
+    let msg: MailMessage | null = null;
+    try {
+      msg = await d.pollMail(recipient);
+    } catch {
+      // Transient IPC error — continue polling until deadline
+    }
+    if (msg && new Date(msg.createdAt).getTime() > afterMs) return msg;
     const remaining = deadline - Date.now();
     if (remaining <= 0) break;
     await Bun.sleep(Math.min(pollIntervalMs, remaining));
@@ -995,7 +1009,8 @@ async function agentWait(
   let result: unknown;
   if (mailTo) {
     const totalMs = timeout ?? 300_000;
-    const mailPoll = pollMailUntil(d, mailTo, totalMs);
+    const pollStart = Date.now();
+    const mailPoll = pollMailUntil(d, mailTo, totalMs, pollStart);
     const winner = await Promise.race([
       waitPromise.then((r) => ({ kind: "session" as const, result: r })),
       mailPoll.then((m) => ({ kind: "mail" as const, message: m })),

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -10,7 +10,7 @@
 
 import { existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
-import type { AgentFeatures, AgentProvider } from "@mcp-cli/core";
+import type { AgentFeatures, AgentProvider, MailMessage } from "@mcp-cli/core";
 import {
   PROMPT_IPC_TIMEOUT_MS,
   WorktreeError,
@@ -62,6 +62,12 @@ export interface AgentDeps extends SharedSessionDeps {
   log: (...args: unknown[]) => void;
   /** Write to stderr (default: console.error). Injected for testability. */
   logError: (...args: unknown[]) => void;
+  /**
+   * Return the oldest unread mail for `recipient`, or null. Non-consuming
+   * (does not markRead). Used by `mcx claude wait --mail-to` to surface
+   * mail arrival alongside session events (fixes #1359).
+   */
+  pollMail: (recipient: string) => Promise<MailMessage | null>;
 }
 
 function makeCallTool(provider: AgentProvider): (tool: string, args: Record<string, unknown>) => Promise<unknown> {
@@ -152,6 +158,12 @@ export function makeDefaultDeps(provider: AgentProvider): AgentDeps {
     ttyOpen: (args) => ttyOpen(args),
     log: console.log,
     logError: console.error,
+    pollMail: async (recipient) => {
+      const result = (await ipcCall("readMail", { recipient, unreadOnly: true, limit: 1 })) as {
+        messages: MailMessage[];
+      };
+      return result.messages[0] ?? null;
+    },
     exec: (cmd, opts) => {
       const result = Bun.spawnSync(cmd, {
         stdout: "pipe",
@@ -168,6 +180,37 @@ export function makeDefaultDeps(provider: AgentProvider): AgentDeps {
 }
 
 // ── Helpers ──
+
+/**
+ * Poll for unread mail addressed to `recipient` until one arrives or the
+ * deadline expires. Non-consuming — does not markRead, so the caller can
+ * still read the message via `mcx mail -u <recipient>` afterward.
+ */
+async function pollMailUntil(
+  d: Pick<AgentDeps, "pollMail">,
+  recipient: string,
+  timeoutMs: number,
+  pollIntervalMs = 2000,
+): Promise<MailMessage | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const msg = await d.pollMail(recipient);
+    if (msg) return msg;
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await Bun.sleep(Math.min(pollIntervalMs, remaining));
+  }
+  return null;
+}
+
+function emitMailEvent(msg: MailMessage, short: boolean, d: Pick<AgentDeps, "log">): void {
+  if (short) {
+    const subj = msg.subject ?? "(no subject)";
+    d.log(`mail ${msg.id} ${msg.sender} ${subj}`);
+    return;
+  }
+  d.log(JSON.stringify({ source: "mail", mail: msg }, null, 2));
+}
 
 /** Check if an error indicates the daemon is not running (ECONNREFUSED/ENOENT). */
 function isDaemonUnavailable(err: unknown): boolean {
@@ -881,6 +924,7 @@ async function agentWait(
   let afterSeq: number | undefined;
   let short = false;
   let all = false;
+  let mailTo: string | undefined;
   let error: string | undefined;
 
   for (let i = 0; i < args.length; i++) {
@@ -905,6 +949,14 @@ async function agentWait(
       short = true;
     } else if (arg === "--all" || (arg === "-a" && !hasFeature(provider, "agentSelect"))) {
       all = true;
+    } else if (arg === "--mail-to") {
+      const val = args[++i];
+      if (!val) error = "--mail-to requires a recipient name";
+      else mailTo = val;
+    } else if (arg.startsWith("--mail-to=")) {
+      const val = arg.slice("--mail-to=".length);
+      if (!val) error = "--mail-to requires a recipient name";
+      else mailTo = val;
     } else if (!arg.startsWith("-")) {
       sessionPrefix = arg;
     }
@@ -934,7 +986,28 @@ async function agentWait(
     }
   }
 
-  const result = await d.callTool(`${P}_wait`, toolArgs);
+  const waitPromise = d.callTool(`${P}_wait`, toolArgs);
+
+  // If --mail-to is set, race the session wait against a non-consuming mail poll
+  // so the caller wakes on incoming mail too (fixes #1359). Mail polling runs
+  // in parallel until either fires; on mail win we surface the event and return
+  // without waiting for the orphaned wait — daemon has its own timeout.
+  let result: unknown;
+  if (mailTo) {
+    const totalMs = timeout ?? 300_000;
+    const mailPoll = pollMailUntil(d, mailTo, totalMs);
+    const winner = await Promise.race([
+      waitPromise.then((r) => ({ kind: "session" as const, result: r })),
+      mailPoll.then((m) => ({ kind: "mail" as const, message: m })),
+    ]);
+    if (winner.kind === "mail" && winner.message) {
+      emitMailEvent(winner.message, short, d);
+      return;
+    }
+    result = winner.kind === "session" ? winner.result : await waitPromise;
+  } else {
+    result = await waitPromise;
+  }
   const text = formatToolResult(result);
 
   let data: unknown;

--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -2178,6 +2178,108 @@ describe("parseWaitArgs", () => {
   });
 });
 
+// ── claudeWait --mail-to behavioral tests ──
+
+describe("claudeWait --mail-to", () => {
+  test("wakes on incoming mail before session event", async () => {
+    // Session wait blocks forever; mail arrives with future createdAt (passes HWM filter).
+    const newMail = {
+      id: 42,
+      sender: "jacob",
+      recipient: "orchestrator",
+      subject: "main is red",
+      body: "CI broken",
+      replyTo: null,
+      read: false,
+      createdAt: new Date(Date.now() + 60_000).toISOString(),
+    };
+    const deps = makeDeps({
+      callTool: mock(() => new Promise(() => {})) as unknown as ClaudeDeps["callTool"],
+      pollMail: mock(async (recipient: string) => (recipient === "orchestrator" ? newMail : null)),
+    });
+    const origLog = console.log;
+    const logSpy = mock(() => {});
+    console.log = logSpy;
+    try {
+      await cmdClaude(["wait", "--mail-to", "orchestrator", "--timeout", "5000"], deps);
+    } finally {
+      console.log = origLog;
+    }
+    const output = (logSpy.mock.calls as unknown[][]).map((c) => String(c[0])).join("\n");
+    const parsed = JSON.parse(output);
+    expect(parsed.source).toBe("mail");
+    expect(parsed.mail.id).toBe(42);
+    expect(deps.pollMail).toHaveBeenCalledWith("orchestrator");
+  });
+
+  test("does not wake on pre-existing unread mail (HWM filter)", async () => {
+    // Mail created 1 minute ago predates the wait and must be ignored.
+    const staleMail = {
+      id: 1,
+      sender: "jacob",
+      recipient: "orchestrator",
+      subject: "old message",
+      body: null,
+      replyTo: null,
+      read: false,
+      createdAt: new Date(Date.now() - 60_000).toISOString(),
+    };
+    const deps = makeDeps({
+      callTool: mock(async () =>
+        toolResult({
+          event: { sessionId: "abc12345-1111-2222-3333-444444444444", event: "session:result" },
+          sessions: [],
+        }),
+      ),
+      pollMail: mock(async () => staleMail),
+    });
+    const origLog = console.log;
+    const logSpy = mock(() => {});
+    console.log = logSpy;
+    try {
+      await cmdClaude(["wait", "--mail-to", "orchestrator", "--timeout", "100"], deps);
+    } finally {
+      console.log = origLog;
+    }
+    const output = (logSpy.mock.calls as unknown[][]).map((c) => String(c[0])).join("\n");
+    expect(output).not.toContain('"source": "mail"');
+  });
+
+  test("continues polling when pollMail throws transiently", async () => {
+    // First call throws (IPC blip), second returns new mail. Wait must succeed.
+    const newMail = {
+      id: 77,
+      sender: "qa",
+      recipient: "orchestrator",
+      subject: "tests passing",
+      body: null,
+      replyTo: null,
+      read: false,
+      createdAt: new Date(Date.now() + 60_000).toISOString(),
+    };
+    let calls = 0;
+    const deps = makeDeps({
+      callTool: mock(() => new Promise(() => {})) as unknown as ClaudeDeps["callTool"],
+      pollMail: mock(async () => {
+        if (calls++ === 0) throw new Error("ECONNREFUSED");
+        return newMail;
+      }),
+    });
+    const origLog = console.log;
+    const logSpy = mock(() => {});
+    console.log = logSpy;
+    try {
+      await cmdClaude(["wait", "--mail-to", "orchestrator", "--timeout", "5000"], deps);
+    } finally {
+      console.log = origLog;
+    }
+    const output = (logSpy.mock.calls as unknown[][]).map((c) => String(c[0])).join("\n");
+    const parsed = JSON.parse(output);
+    expect(parsed.source).toBe("mail");
+    expect(parsed.mail.id).toBe(77);
+  });
+});
+
 // ── wait ──
 
 describe("mcx claude wait", () => {

--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -42,6 +42,7 @@ function makeDeps(overrides?: Partial<ClaudeDeps>): ClaudeDeps {
     ttyOpen: mock(async () => {}),
     getGitRoot: mock(() => null),
     getStaleDaemonWarning: mock(() => null),
+    pollMail: mock(async () => null),
     ...overrides,
   };
 }
@@ -2158,6 +2159,22 @@ describe("parseWaitArgs", () => {
     expect(result.any).toBe(false);
     expect(result.pr).toBeUndefined();
     expect(result.checks).toBe(false);
+  });
+
+  test("parses --mail-to <name>", () => {
+    const result = parseWaitArgs(["--mail-to", "orchestrator"]);
+    expect(result.mailTo).toBe("orchestrator");
+    expect(result.error).toBeUndefined();
+  });
+
+  test("parses --mail-to=<name>", () => {
+    const result = parseWaitArgs(["--mail-to=orchestrator"]);
+    expect(result.mailTo).toBe("orchestrator");
+  });
+
+  test("errors on missing --mail-to value", () => {
+    const result = parseWaitArgs(["--mail-to"]);
+    expect(result.error).toBe("--mail-to requires a recipient name");
   });
 });
 

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -1464,18 +1464,33 @@ export function parseWaitArgs(args: string[]): WaitArgs {
  * Poll for unread mail addressed to `recipient` until one arrives or the
  * deadline expires. Non-consuming — does not markRead, so the caller can
  * still read the message via `mcx mail -u <recipient>` afterward.
+ *
+ * `afterMs` is a `Date.now()` snapshot taken before polling begins. Only
+ * mail with `createdAt` strictly after that timestamp is surfaced, so
+ * pre-existing unread messages do not cause false-positive wakeups.
+ *
+ * Transient `pollMail` errors (IPC blips, daemon restart) are swallowed
+ * and retried until the deadline; a single network hiccup will not kill
+ * the entire wait.
+ *
  * Returns the message, or null on timeout.
  */
 async function pollMailUntil(
   d: Pick<ClaudeDeps, "pollMail">,
   recipient: string,
   timeoutMs: number,
+  afterMs: number,
   pollIntervalMs = 2000,
 ): Promise<MailMessage | null> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    const msg = await d.pollMail(recipient);
-    if (msg) return msg;
+    let msg: MailMessage | null = null;
+    try {
+      msg = await d.pollMail(recipient);
+    } catch {
+      // Transient IPC error — continue polling until deadline
+    }
+    if (msg && new Date(msg.createdAt).getTime() > afterMs) return msg;
     const remaining = deadline - Date.now();
     if (remaining <= 0) break;
     await Bun.sleep(Math.min(pollIntervalMs, remaining));
@@ -1548,7 +1563,8 @@ async function claudeWait(args: string[], d: ClaudeDeps): Promise<void> {
   let result: unknown;
   if (parsed.mailTo) {
     const totalMs = parsed.timeout ?? 300_000;
-    const mailPoll = pollMailUntil(d, parsed.mailTo, totalMs);
+    const pollStart = Date.now();
+    const mailPoll = pollMailUntil(d, parsed.mailTo, totalMs, pollStart);
     const winner = await Promise.race([
       waitPromise.then((r) => ({ kind: "session" as const, result: r })),
       mailPoll.then((m) => ({ kind: "mail" as const, message: m })),

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -35,7 +35,7 @@ import type { SharedSpawnArgs } from "./spawn-args";
 import { parseSharedSpawnArgs } from "./spawn-args";
 import { ttyOpen } from "./tty";
 
-import type { QuotaStatusResult, SessionInfo, WorkItem } from "@mcp-cli/core";
+import type { MailMessage, QuotaStatusResult, SessionInfo, WorkItem } from "@mcp-cli/core";
 
 // ── Dependency injection ──
 
@@ -65,6 +65,12 @@ export interface ClaudeDeps extends SharedSessionDeps {
   getGitRoot: () => string | null;
   /** Return a warning string if the running daemon is a stale build, null otherwise. */
   getStaleDaemonWarning: () => string | null;
+  /**
+   * Return the oldest unread mail for `recipient`, or null. Non-consuming
+   * (does not markRead). Used by `mcx claude wait --mail-to` to surface
+   * mail arrival alongside session events.
+   */
+  pollMail: (recipient: string) => Promise<MailMessage | null>;
 }
 
 /**
@@ -180,6 +186,12 @@ export const defaultDeps: ClaudeDeps = {
   ttyOpen: (args) => ttyOpen(args),
   getGitRoot,
   getStaleDaemonWarning,
+  pollMail: async (recipient) => {
+    const result = (await ipcCall("readMail", { recipient, unreadOnly: true, limit: 1 })) as {
+      messages: MailMessage[];
+    };
+    return result.messages[0] ?? null;
+  },
 };
 
 // ── Entry point ──
@@ -1375,6 +1387,8 @@ export interface WaitArgs {
   pr: number | undefined;
   /** Block until any tracked PR's CI completes. */
   checks: boolean;
+  /** Also wake on mail addressed to this recipient (non-consuming peek). */
+  mailTo: string | undefined;
   error: string | undefined;
 }
 
@@ -1387,6 +1401,7 @@ export function parseWaitArgs(args: string[]): WaitArgs {
   let any = false;
   let pr: number | undefined;
   let checks = false;
+  let mailTo: string | undefined;
   let error: string | undefined;
 
   for (let i = 0; i < args.length; i++) {
@@ -1423,12 +1438,58 @@ export function parseWaitArgs(args: string[]): WaitArgs {
       }
     } else if (arg === "--checks") {
       checks = true;
+    } else if (arg === "--mail-to") {
+      const val = args[++i];
+      if (!val) {
+        error = "--mail-to requires a recipient name";
+      } else {
+        mailTo = val;
+      }
+    } else if (arg.startsWith("--mail-to=")) {
+      const val = arg.slice("--mail-to=".length);
+      if (!val) {
+        error = "--mail-to requires a recipient name";
+      } else {
+        mailTo = val;
+      }
     } else if (!arg.startsWith("-")) {
       sessionPrefix = arg;
     }
   }
 
-  return { sessionPrefix, timeout, afterSeq, short, all, any, pr, checks, error };
+  return { sessionPrefix, timeout, afterSeq, short, all, any, pr, checks, mailTo, error };
+}
+
+/**
+ * Poll for unread mail addressed to `recipient` until one arrives or the
+ * deadline expires. Non-consuming — does not markRead, so the caller can
+ * still read the message via `mcx mail -u <recipient>` afterward.
+ * Returns the message, or null on timeout.
+ */
+async function pollMailUntil(
+  d: Pick<ClaudeDeps, "pollMail">,
+  recipient: string,
+  timeoutMs: number,
+  pollIntervalMs = 2000,
+): Promise<MailMessage | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const msg = await d.pollMail(recipient);
+    if (msg) return msg;
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await Bun.sleep(Math.min(pollIntervalMs, remaining));
+  }
+  return null;
+}
+
+function emitMailEvent(msg: MailMessage, short: boolean): void {
+  if (short) {
+    const subj = msg.subject ?? "(no subject)";
+    console.log(`mail ${msg.id} ${msg.sender} ${subj}`);
+    return;
+  }
+  console.log(JSON.stringify({ source: "mail", mail: msg }, null, 2));
 }
 
 async function claudeWait(args: string[], d: ClaudeDeps): Promise<void> {
@@ -1478,7 +1539,29 @@ async function claudeWait(args: string[], d: ClaudeDeps): Promise<void> {
     }
   }
 
-  const result = await d.callTool("claude_wait", toolArgs);
+  const waitPromise = d.callTool("claude_wait", toolArgs);
+
+  // If --mail-to is set, race the session wait against a non-consuming mail poll
+  // so the caller wakes on incoming mail too (fixes #1359). Mail polling runs
+  // in parallel until either fires; on mail win, we surface the event and return
+  // without waiting for the orphaned claude_wait (daemon has its own timeout).
+  let result: unknown;
+  if (parsed.mailTo) {
+    const totalMs = parsed.timeout ?? 300_000;
+    const mailPoll = pollMailUntil(d, parsed.mailTo, totalMs);
+    const winner = await Promise.race([
+      waitPromise.then((r) => ({ kind: "session" as const, result: r })),
+      mailPoll.then((m) => ({ kind: "mail" as const, message: m })),
+    ]);
+    if (winner.kind === "mail" && winner.message) {
+      emitMailEvent(winner.message, parsed.short);
+      return;
+    }
+    // Mail poll returned null (timed out) or session already won the race.
+    result = winner.kind === "session" ? winner.result : await waitPromise;
+  } else {
+    result = await waitPromise;
+  }
   const text = formatToolResult(result);
 
   // Parse daemon response


### PR DESCRIPTION
## Summary

- Adds opt-in `--mail-to <recipient>` flag to `mcx claude wait` that surfaces incoming mail as a wakeup event alongside session/work-item events.
- On mail win, emits `{ source: "mail", mail: {...} }` (JSON) or `mail <id> <sender> <subject>` (`--short`) and returns.
- Non-consuming: polls `readMail(unreadOnly)` — the message stays unread so `mcx mail -u <recipient>` still shows it.

## Scope

Implements only part 1 of #1359 (mail:received wakeup multiplexing). The `mcx mail` help-text cleanup and cross-swarm orchestrator↔orchestrator messaging (part 2 / follow-up comment) are explicitly deferred to sprint 35.

Implementation is client-side in `agentWait` / `claudeWait` — `Promise.race` between the existing `claude_wait` tool call and a 2s-interval mail poll. No daemon protocol changes.

## Test plan

- [x] `bun typecheck`
- [x] `bun lint`
- [x] `bun test` (5007 pass, 0 fail)
- [x] New tests: `--mail-to` parse args, mail wakes before session event, `--short` output, session-win fallthrough, missing-value error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)