### PR TITLE
fix: forward --dry-run to phase command dispatch (fixes #1396)

### DIFF
--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -156,7 +156,7 @@ async function main(): Promise<void> {
 
   // --dry-run is only valid for call (and shorthand call forms handled in the default branch)
   // and for commands that opt in (gc).
-  if (dryRun && command && command !== "call" && command !== "gc") {
+  if (dryRun && command && command !== "call" && command !== "gc" && command !== "phase") {
     const isShorthand =
       !command.startsWith("-") &&
       (splitServerTool(command) !== null || (cleanArgs.length >= 2 && !cleanArgs[1].startsWith("-")));
@@ -293,9 +293,12 @@ async function main(): Promise<void> {
         await cmdGc(cleanArgs.slice(1), { dryRun: _dryRun });
         break;
 
-      case "phase":
-        await cmdPhase(cleanArgs.slice(1));
+      case "phase": {
+        const phaseArgs = cleanArgs.slice(1);
+        if (_dryRun) phaseArgs.push("--dry-run");
+        await cmdPhase(phaseArgs);
         break;
+      }
 
       case "auth":
         await cmdAuth(cleanArgs.slice(1));

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -155,13 +155,13 @@ async function main(): Promise<void> {
   }
 
   // --dry-run is only valid for call (and shorthand call forms handled in the default branch)
-  // and for commands that opt in (gc).
+  // and for commands that opt in (gc, phase run).
   if (dryRun && command && command !== "call" && command !== "gc" && command !== "phase") {
     const isShorthand =
       !command.startsWith("-") &&
       (splitServerTool(command) !== null || (cleanArgs.length >= 2 && !cleanArgs[1].startsWith("-")));
     if (!isShorthand) {
-      printError(`--dry-run is only supported for the 'call' command, not '${command}'`);
+      printError(`--dry-run is only supported for 'call', 'gc', and 'phase run', not '${command}'`);
       process.exit(1);
     }
   }
@@ -295,7 +295,7 @@ async function main(): Promise<void> {
 
       case "phase": {
         const phaseArgs = cleanArgs.slice(1);
-        if (_dryRun) phaseArgs.push("--dry-run");
+        if (_dryRun && phaseArgs[0] === "run") phaseArgs.push("--dry-run");
         await cmdPhase(phaseArgs);
         break;
       }


### PR DESCRIPTION
## Summary
- `main.ts` strips `--dry-run` globally via `extractDryRunFlag` before dispatch, so `mcx phase run <name> --dry-run` never reached the dry-run runner.
- Add `phase` to the dry-run allowlist and re-inject `--dry-run` into argv before calling `cmdPhase` so `argv.includes("--dry-run")` checks in `phase.ts` see the flag.

## Test plan
- [x] Manual repro: `bun dev:mcx -- phase run impl --dry-run` now reaches the handler (errors on missing work item, matching issue note).
- [x] `bun typecheck` / `bun lint` / full `bun test` (3693 pass / 0 fail) via pre-commit hook.
- [x] Existing phase.spec.ts suite (100 tests) still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)