### PR TITLE
fix: inject manifest loader in track deps (fixes #1402)

### DIFF
--- a/packages/command/src/commands/track.spec.ts
+++ b/packages/command/src/commands/track.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import type { IpcMethod, IpcMethodResult, WorkItem } from "@mcp-cli/core";
+import type { IpcMethod, IpcMethodResult, Manifest, WorkItem } from "@mcp-cli/core";
+import { loadManifest } from "@mcp-cli/core";
 import type { TrackDeps } from "./track";
 import { cmdTrack, cmdTracked, cmdUntrack, formatWorkItemRow } from "./track";
 
@@ -23,8 +24,17 @@ function makeDeps(overrides: Partial<Record<IpcMethod, unknown>> = {}): TrackDep
     exit: (code: number): never => {
       throw new ExitError(code);
     },
+    loadManifest: () => null,
   };
 }
+
+const realManifestLoader = (dir: string): Manifest | null => {
+  try {
+    return loadManifest(dir)?.manifest ?? null;
+  } catch {
+    return null;
+  }
+};
 
 function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
   return {
@@ -327,12 +337,15 @@ describe("formatWorkItemRow", () => {
     test("cmdTrack passes initialPhase from manifest", async () => {
       let captured: unknown;
       const item = makeWorkItem();
-      const deps = makeDeps({
-        trackWorkItem: (params: unknown) => {
-          captured = params;
-          return item;
-        },
-      });
+      const deps = {
+        ...makeDeps({
+          trackWorkItem: (params: unknown) => {
+            captured = params;
+            return item;
+          },
+        }),
+        loadManifest: realManifestLoader,
+      };
 
       await withManifestDir(
         "version: 1\ninitial: plan\nphases:\n  plan: { source: ./p.ts, next: [build] }\n  build: { source: ./b.ts }\n",
@@ -346,7 +359,7 @@ describe("formatWorkItemRow", () => {
         makeWorkItem({ phase: "plan" as unknown as WorkItem["phase"] }),
         makeWorkItem({ id: "#2", phase: "impl" }),
       ];
-      const deps = makeDeps({ listWorkItems: items });
+      const deps = { ...makeDeps({ listWorkItems: items }), loadManifest: realManifestLoader };
 
       const logs: string[] = [];
       const origLog = console.log;
@@ -366,12 +379,15 @@ describe("formatWorkItemRow", () => {
 
     test("cmdTracked --phase warns when phase is not declared, but still queries", async () => {
       let captured: unknown;
-      const deps = makeDeps({
-        listWorkItems: (params: unknown) => {
-          captured = params;
-          return [];
-        },
-      });
+      const deps = {
+        ...makeDeps({
+          listWorkItems: (params: unknown) => {
+            captured = params;
+            return [];
+          },
+        }),
+        loadManifest: realManifestLoader,
+      };
       const errs: string[] = [];
       const origErr = console.error;
       console.error = (msg: string) => errs.push(msg);

--- a/packages/command/src/commands/track.ts
+++ b/packages/command/src/commands/track.ts
@@ -25,11 +25,13 @@ function tryLoadManifest(dir: string): Manifest | null {
 export interface TrackDeps {
   ipcCall: <M extends IpcMethod>(method: M, params?: unknown) => Promise<IpcMethodResult[M]>;
   exit: (code: number) => never;
+  loadManifest?: (dir: string) => Manifest | null;
 }
 
 const defaultDeps: TrackDeps = {
   ipcCall,
   exit: (code) => process.exit(code),
+  loadManifest: tryLoadManifest,
 };
 
 // -- mcx track --
@@ -40,7 +42,7 @@ export async function cmdTrack(args: string[], deps: TrackDeps = defaultDeps): P
     return;
   }
 
-  const manifest = tryLoadManifest(process.cwd());
+  const manifest = (deps.loadManifest ?? tryLoadManifest)(process.cwd());
   const initialPhase = manifest?.initial;
 
   if (args[0] === "--branch") {
@@ -132,7 +134,7 @@ export async function cmdTracked(args: string[], deps: TrackDeps = defaultDeps):
   const jsonFlag = args.includes("--json");
   const phaseIdx = args.indexOf("--phase");
   let phase: string | undefined;
-  const manifest = tryLoadManifest(process.cwd());
+  const manifest = (deps.loadManifest ?? tryLoadManifest)(process.cwd());
   const declaredPhases = manifest ? Object.keys(manifest.phases) : null;
 
   if (phaseIdx >= 0) {


### PR DESCRIPTION
## Summary
- `cmdTrack`/`cmdTracked` loaded `.mcx.yaml` from `process.cwd()`, so when tests ran from the repo root the real manifest's `initial: impl` leaked into tracked params and broke two assertions.
- Thread `loadManifest` through `TrackDeps`; spec helper defaults to a null loader, and the three manifest integration tests opt back in via a real loader.

## Test plan
- [x] `bun test packages/command/src/commands/track.spec.ts` — 31 pass, 0 fail
- [x] `bun typecheck`
- [x] `bun lint`
- [x] `bun test` — 5058 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)