### PR TITLE
fix(phases): catch handler errors in phase run --dry-run (fixes #1349)

### DIFF
--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -314,6 +314,40 @@ defineAlias(({ z }) => ({
     expect(errs.some((e) => e.includes('unknown phase "nope"'))).toBe(true);
   });
 
+  test("run --dry-run formats handler errors with phase name (#1349)", async () => {
+    writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);
+    writeFileSync(
+      join(dir, "impl.ts"),
+      `
+import { defineAlias, z } from "mcp-cli";
+
+defineAlias(({ z }) => ({
+  name: "implement",
+  description: "impl",
+  input: z.object({}).optional(),
+  fn: async () => {
+    throw new Error("boom from handler");
+  },
+}));
+`.trim(),
+    );
+    const { deps: installDeps } = makeDriftDeps(dir);
+    await cmdPhase(["install"], installDeps);
+    const errs: string[] = [];
+    let code: number | undefined;
+    await cmdPhase(["run", "implement", "--dry-run"], {
+      cwd: () => dir,
+      log: () => {},
+      logError: (m) => errs.push(m),
+      exit: ((c: number) => {
+        code = c;
+        throw new Error("exit");
+      }) as (c: number) => never,
+    }).catch(() => {});
+    expect(code).toBe(1);
+    expect(errs.some((e) => e.includes('phase "implement" threw') && e.includes("boom from handler"))).toBe(true);
+  }, 15_000);
+
   test("run without --dry-run dispatches to transition enforcement", async () => {
     // Since #1293 merged, `run <target>` without --dry-run validates and records
     // the transition (transition-enforcement path), not the dry-run execution path.

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -812,7 +812,12 @@ async function runPhase(argv: string[], d: PhaseInstallDeps): Promise<void> {
   };
   const ctx = wrapDryRunContext(baseCtx, (line) => d.log(line));
 
-  await d.executeAliasBundled(js, structured ? {} : undefined, ctx, structured);
+  try {
+    await d.executeAliasBundled(js, structured ? {} : undefined, ctx, structured);
+  } catch (err) {
+    d.logError(`phase "${name}" threw: ${err instanceof Error ? err.message : String(err)}`);
+    d.exit(1);
+  }
 }
 
 function printPhaseHelp(d: PhaseInstallDeps): void {


### PR DESCRIPTION
## Summary
- Wrap `executeAliasBundled` in `runPhase` with try/catch, matching the `install` subcommand pattern.
- On throw, emit `phase "<name>" threw: <msg>` via `d.logError` and exit 1 instead of surfacing a raw Bun stack trace.

## Test plan
- [x] New spec: handler throws → structured error with phase name, exit 1
- [x] `bun typecheck`
- [x] `bun lint`
- [x] `bun test` (5059 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)