### PR TITLE
feat(phases): wire real handler execution for `mcx phase run` (fixes #1381)

### DIFF
--- a/packages/command/src/alias-runner.ts
+++ b/packages/command/src/alias-runner.ts
@@ -13,23 +13,21 @@ import { basename, resolve } from "node:path";
 import {
   type AliasContext,
   GLOBAL_STATE_NAMESPACE,
-  type McpProxy,
   NO_REPO_ROOT,
   aliasUserNamespace,
   bundleAlias,
   createAliasCache,
   createAliasState,
+  createMcpProxy,
   executeAliasBundled,
-  extractContent,
   findGitRoot,
-  ipcCall,
   isDefineAlias,
   options,
 } from "@mcp-cli/core";
 import type { z } from "zod/v4";
 
 export async function runAlias(aliasPath: string, cliArgs: Record<string, string>, jsonInput?: string): Promise<void> {
-  const mcpProxy = createMcpProxy();
+  const mcpProxy = createMcpProxy({ cwd: () => process.cwd() });
 
   // Defense-in-depth: verify the alias path is inside the aliases directory
   const resolved = resolve(aliasPath);
@@ -120,26 +118,6 @@ export function formatAliasOutput(output: unknown): string | undefined {
   if (output === undefined || output === null) return undefined;
   if (typeof output === "string") return output;
   return JSON.stringify(output, null, 2);
-}
-
-function createMcpProxy(): McpProxy {
-  return new Proxy({} as McpProxy, {
-    get(_target, serverName: string) {
-      return new Proxy({} as Record<string, (args?: Record<string, unknown>) => Promise<unknown>>, {
-        get(_inner, toolName: string) {
-          return async (toolArgs?: Record<string, unknown>) => {
-            const result = await ipcCall("callTool", {
-              server: serverName,
-              tool: toolName,
-              arguments: toolArgs ?? {},
-              cwd: process.cwd(),
-            });
-            return extractContent(result);
-          };
-        },
-      });
-    },
-  });
 }
 
 // extractContent is now imported from @mcp-cli/core and re-exported for test compatibility

--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -1548,7 +1548,7 @@ phases:
     expect(errs.some((e) => e.includes('work item "#999" not found'))).toBe(true);
   }, 30_000);
 
-  test("transition is committed even when handler throws (idempotent re-entry)", async () => {
+  test("handler crash leaves only an 'attempted' entry — no committed transition (#1407)", async () => {
     const throwAlias = `
 import { defineAlias, z } from "mcp-cli";
 defineAlias(({ z }) => ({
@@ -1581,11 +1581,85 @@ defineAlias(({ z }) => ({
     ).catch(() => {});
 
     expect(code).toBe(1);
-    expect(errs.some((e) => e.includes("approved"))).toBe(true);
     expect(errs.some((e) => e.includes('phase "implement" failed'))).toBe(true);
-    // Transition log recorded the attempt so the orchestrator can see it.
+    // "approved" is only logged on successful commit, never on crash.
+    expect(errs.some((e) => e.includes("approved"))).toBe(false);
+    // Log contains the attempted entry (audit trail) but NOT a committed one.
     const { readFileSync: rfs } = require("node:fs");
-    const log = rfs(join(dir, ".mcx", "transitions.jsonl"), "utf-8");
-    expect(log).toContain('"to":"implement"');
+    const raw = rfs(join(dir, ".mcx", "transitions.jsonl"), "utf-8") as string;
+    const entries = raw
+      .split("\n")
+      .filter((l) => l.length > 0)
+      .map((l) => JSON.parse(l) as { to: string; status?: string });
+    const attempted = entries.filter((e) => e.status === "attempted");
+    const committed = entries.filter((e) => e.status === "committed");
+    expect(attempted.length).toBe(1);
+    expect(attempted[0].to).toBe("implement");
+    expect(committed.length).toBe(0);
+  }, 30_000);
+
+  test("back-to-back executePhase calls do not trip RegressionError (#1407)", async () => {
+    writeFileSync(join(dir, ".mcx.yaml"), manifestMain);
+    writeFileSync(join(dir, "impl.ts"), phaseAlias);
+    await install();
+
+    const store = new Map<string, unknown>();
+    const workItem = {
+      id: "#42",
+      issueNumber: 42,
+      prNumber: null,
+      branch: "feat/42",
+      prState: null,
+      prUrl: null,
+      ciStatus: "none" as const,
+      ciRunId: null,
+      ciSummary: null,
+      reviewStatus: "pending" as const,
+      phase: "implement",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    };
+
+    const run = async () => {
+      const ex = makeExecDeps({ workItem, stateStore: store });
+      const logs: string[] = [];
+      const errs: string[] = [];
+      let code: number | undefined;
+      await executePhase(
+        ["implement", "--work-item", "#42"],
+        {
+          ...makeDriftDeps(dir).deps,
+          log: (m) => logs.push(m),
+          logError: (m) => errs.push(m),
+          exit: ((c: number) => {
+            code = c;
+            throw new Error(`exit(${c})`);
+          }) as (code: number) => never,
+        },
+        { ipcCall: ex.ipcCall, exec: ex.exec, findGitRoot: ex.findGitRoot, now: ex.now },
+      ).catch(() => {});
+      return { logs, errs, code };
+    };
+
+    const first = await run();
+    expect(first.code).toBeUndefined();
+    expect(first.logs.join("\n")).toContain('"action": "spawn"');
+
+    // Second call on the same manifest/work-item must NOT throw
+    // RegressionError. Handler self-checks state and returns "in-flight".
+    const second = await run();
+    expect(second.code).toBeUndefined();
+    expect(second.errs.some((e) => e.toLowerCase().includes("regress"))).toBe(false);
+    expect(second.logs.join("\n")).toContain('"action": "in-flight"');
+
+    // Both runs committed to the log (idempotent self-loop allowed).
+    const { readFileSync: rfs } = require("node:fs");
+    const raw = rfs(join(dir, ".mcx", "transitions.jsonl"), "utf-8") as string;
+    const entries = raw
+      .split("\n")
+      .filter((l) => l.length > 0)
+      .map((l) => JSON.parse(l) as { status?: string; to: string });
+    expect(entries.filter((e) => e.status === "committed").length).toBe(2);
+    expect(entries.filter((e) => e.status === "attempted").length).toBe(2);
   }, 30_000);
 });

--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -25,11 +25,13 @@ import {
   checkStateSubset,
   cmdPhase,
   detectDrift,
+  executePhase,
   explainTransition,
   filterTransitionLog,
   formatDriftWarning,
   formatPhaseTable,
   formatTransitionLog,
+  parsePhaseExecuteArgs,
   parsePhaseLogArgs,
   parsePhaseRunArgs,
   phaseRun,
@@ -348,16 +350,17 @@ defineAlias(({ z }) => ({
     expect(errs.some((e) => e.includes('phase "implement" threw') && e.includes("boom from handler"))).toBe(true);
   }, 15_000);
 
-  test("run without --dry-run dispatches to transition enforcement", async () => {
-    // Since #1293 merged, `run <target>` without --dry-run validates and records
-    // the transition (transition-enforcement path), not the dry-run execution path.
+  test("run --no-execute dispatches to transition enforcement only", async () => {
+    // #1381 wired real handler execution on `run <target>` without --dry-run.
+    // `--no-execute` is the escape hatch for orchestrators that want to log
+    // the transition separately from dispatch.
     writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);
     writeFileSync(join(dir, "impl.ts"), simpleAlias);
     const { deps: installDeps } = makeDriftDeps(dir);
     await cmdPhase(["install"], installDeps);
     const errs: string[] = [];
     let code: number | undefined;
-    await cmdPhase(["run", "implement"], {
+    await cmdPhase(["run", "implement", "--no-execute"], {
       cwd: () => dir,
       log: () => {},
       logError: (m) => errs.push(m),
@@ -594,16 +597,18 @@ describe("cmdPhase dispatch", () => {
     }
   });
 
-  test("run prints approval on valid transition", async () => {
-    const { err, code } = await withCwd(dir, () => catchExit(() => cmdPhase(["run", "qa", "--from", "impl"])));
+  test("run --no-execute prints approval on valid transition", async () => {
+    const { err, code } = await withCwd(dir, () =>
+      catchExit(() => cmdPhase(["run", "qa", "--from", "impl", "--no-execute"])),
+    );
     expect(code).toBeUndefined();
     expect(err).toContain("approved");
     expect(err).toContain("impl → qa");
   });
 
-  test("run with --force tags output", async () => {
+  test("run --no-execute with --force tags output", async () => {
     const { err } = await withCwd(dir, () =>
-      catchExit(() => cmdPhase(["run", "repair", "--from", "impl", "--force", "emergency"])),
+      catchExit(() => cmdPhase(["run", "repair", "--from", "impl", "--force", "emergency", "--no-execute"])),
     );
     expect(err).toContain("[FORCED]");
   });
@@ -1261,4 +1266,326 @@ describe("cmdPhase check", () => {
     expect(getExitCode()).toBe(1);
     expect(errs.some((e) => e.includes("no .mcx.lock"))).toBe(true);
   });
+});
+
+describe("parsePhaseExecuteArgs", () => {
+  test("extracts --arg pairs, leaves transition flags for parsePhaseRunArgs", () => {
+    const parsed = parsePhaseExecuteArgs([
+      "impl",
+      "--from",
+      "qa",
+      "--work-item",
+      "#42",
+      "--arg",
+      "provider=claude",
+      "--arg",
+      "labels=flaky",
+    ]);
+    expect(parsed.target).toBe("impl");
+    expect(parsed.from).toBe("qa");
+    expect(parsed.workItemId).toBe("#42");
+    expect(parsed.args).toEqual({ provider: "claude", labels: "flaky" });
+    expect(parsed.inputJson).toBeNull();
+  });
+
+  test("--input carries JSON payload", () => {
+    const parsed = parsePhaseExecuteArgs(["impl", "--input", '{"provider":"copilot"}']);
+    expect(parsed.inputJson).toBe('{"provider":"copilot"}');
+  });
+
+  test("--input=<json> equals form works", () => {
+    const parsed = parsePhaseExecuteArgs(["impl", '--input={"x":1}']);
+    expect(parsed.inputJson).toBe('{"x":1}');
+  });
+
+  test("--arg without = fails", () => {
+    expect(() => parsePhaseExecuteArgs(["impl", "--arg", "noequals"])).toThrow(/key=val/);
+  });
+
+  test("--arg with empty key fails", () => {
+    expect(() => parsePhaseExecuteArgs(["impl", "--arg", "=val"])).toThrow(/non-empty/);
+  });
+});
+
+describe("executePhase (real handler dispatch, #1381)", () => {
+  function makeExecDeps(opts: {
+    branch?: string;
+    workItem?: Record<string, unknown> | null;
+    ipcRecord?: { calls: Array<{ method: string; params: unknown }> };
+    stateStore?: Map<string, unknown>;
+  }) {
+    const branch = opts.branch ?? "main";
+    const stateStore = opts.stateStore ?? new Map<string, unknown>();
+    const calls = opts.ipcRecord?.calls ?? [];
+    const ipcCall = async (method: string, params: unknown) => {
+      calls.push({ method, params });
+      switch (method) {
+        case "getWorkItem":
+          return opts.workItem ?? null;
+        case "aliasStateGet": {
+          const p = params as { namespace: string; key: string };
+          return { value: stateStore.get(`${p.namespace}:${p.key}`) };
+        }
+        case "aliasStateSet": {
+          const p = params as { namespace: string; key: string; value: unknown };
+          stateStore.set(`${p.namespace}:${p.key}`, p.value);
+          return { ok: true };
+        }
+        case "aliasStateDelete": {
+          const p = params as { namespace: string; key: string };
+          stateStore.delete(`${p.namespace}:${p.key}`);
+          return { ok: true };
+        }
+        case "aliasStateAll":
+          return { entries: {} };
+        case "callTool": {
+          const p = params as { server: string; tool: string; arguments: unknown };
+          return { content: [{ type: "text", text: JSON.stringify({ server: p.server, tool: p.tool }) }] };
+        }
+        default:
+          return null;
+      }
+    };
+    const exec = (cmd: string[]) => {
+      // Emulate git for branch-guard: `git -C <cwd> symbolic-ref --short HEAD`
+      if (cmd.includes("rev-parse") && cmd.includes("--is-inside-work-tree")) {
+        return { stdout: "true", exitCode: 0 };
+      }
+      if (cmd.includes("symbolic-ref")) {
+        return { stdout: `${branch}\n`, exitCode: 0 };
+      }
+      return { stdout: "", exitCode: 0 };
+    };
+    return {
+      ipcCall: ipcCall as unknown as typeof import("@mcp-cli/core").ipcCall,
+      exec,
+      findGitRoot: () => dir,
+      now: () => new Date("2026-04-14T00:00:00Z"),
+      stateStore,
+      calls,
+    };
+  }
+
+  const phaseAlias = `
+import { defineAlias, z } from "mcp-cli";
+
+defineAlias(({ z }) => ({
+  name: "implement",
+  description: "impl",
+  input: z.object({ issue: z.number().optional() }).default({}),
+  output: z.object({ action: z.string(), sessionId: z.string().optional() }),
+  fn: async (input, ctx) => {
+    const existing = await ctx.state.get("session_id");
+    if (existing) {
+      return { action: "in-flight", sessionId: String(existing) };
+    }
+    await ctx.state.set("session_id", "sess-123");
+    await ctx.mcp._work_items.work_items_update({ id: ctx.workItem?.id ?? "none", phase: "impl" });
+    return { action: "spawn", sessionId: "sess-123" };
+  },
+}));
+`.trim();
+
+  const manifestMain = `
+runsOn: main
+initial: implement
+phases:
+  implement:
+    source: ./impl.ts
+    next: []
+`.trim();
+
+  async function install() {
+    const { deps: installDeps } = makeDriftDeps(dir);
+    await cmdPhase(["install"], installDeps);
+  }
+
+  test("executes handler with real ctx and prints structured JSON to stdout", async () => {
+    writeFileSync(join(dir, ".mcx.yaml"), manifestMain);
+    writeFileSync(join(dir, "impl.ts"), phaseAlias);
+    await install();
+
+    const ex = makeExecDeps({
+      workItem: {
+        id: "#42",
+        issueNumber: 42,
+        prNumber: null,
+        branch: "feat/42",
+        prState: null,
+        prUrl: null,
+        ciStatus: "none",
+        ciRunId: null,
+        ciSummary: null,
+        reviewStatus: "pending",
+        phase: "implement",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    });
+    const logs: string[] = [];
+    const errs: string[] = [];
+    await executePhase(
+      ["implement", "--work-item", "#42"],
+      {
+        ...makeDriftDeps(dir).deps,
+        log: (m) => logs.push(m),
+        logError: (m) => errs.push(m),
+        exit: ((c: number) => {
+          throw new Error(`exit(${c})`);
+        }) as (code: number) => never,
+      },
+      { ipcCall: ex.ipcCall, exec: ex.exec, findGitRoot: ex.findGitRoot, now: ex.now },
+    );
+
+    // Transition approval surfaced to stderr.
+    expect(errs.some((e) => e.includes("approved") && e.includes("implement"))).toBe(true);
+    // Structured handler return surfaced to stdout as JSON.
+    const stdout = logs.join("\n");
+    expect(stdout).toContain('"action": "spawn"');
+    expect(stdout).toContain('"sessionId": "sess-123"');
+    // State was persisted under workitem:<id>.
+    expect(ex.stateStore.get("workitem:#42:session_id")).toBe("sess-123");
+    // MCP proxy dispatched a callTool.
+    const callToolInvocations = ex.calls.filter((c) => c.method === "callTool");
+    expect(callToolInvocations.length).toBe(1);
+    expect((callToolInvocations[0].params as { server: string }).server).toBe("_work_items");
+  }, 30_000);
+
+  test("re-entry is idempotent — returns in-flight when state already set", async () => {
+    writeFileSync(join(dir, ".mcx.yaml"), manifestMain);
+    writeFileSync(join(dir, "impl.ts"), phaseAlias);
+    await install();
+
+    const store = new Map<string, unknown>([["workitem:#42:session_id", "sess-existing"]]);
+    const ex = makeExecDeps({
+      workItem: {
+        id: "#42",
+        issueNumber: 42,
+        prNumber: null,
+        branch: "feat/42",
+        prState: null,
+        prUrl: null,
+        ciStatus: "none",
+        ciRunId: null,
+        ciSummary: null,
+        reviewStatus: "pending",
+        phase: "implement",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+      stateStore: store,
+    });
+    const logs: string[] = [];
+    await executePhase(
+      ["implement", "--work-item", "#42"],
+      {
+        ...makeDriftDeps(dir).deps,
+        log: (m) => logs.push(m),
+        logError: () => {},
+        exit: ((c: number) => {
+          throw new Error(`exit(${c})`);
+        }) as (code: number) => never,
+      },
+      { ipcCall: ex.ipcCall, exec: ex.exec, findGitRoot: ex.findGitRoot, now: ex.now },
+    );
+
+    const stdout = logs.join("\n");
+    expect(stdout).toContain('"action": "in-flight"');
+    expect(stdout).toContain('"sessionId": "sess-existing"');
+    // No MCP call on re-entry — handler took the short path.
+    expect(ex.calls.some((c) => c.method === "callTool")).toBe(false);
+  }, 30_000);
+
+  test("branch guard fires when runsOn does not match current branch", async () => {
+    writeFileSync(join(dir, ".mcx.yaml"), manifestMain);
+    writeFileSync(join(dir, "impl.ts"), phaseAlias);
+    await install();
+
+    const ex = makeExecDeps({ branch: "feat/x" });
+    const errs: string[] = [];
+    let code: number | undefined;
+    await executePhase(
+      ["implement"],
+      {
+        ...makeDriftDeps(dir).deps,
+        log: () => {},
+        logError: (m) => errs.push(m),
+        exit: ((c: number) => {
+          code = c;
+          throw new Error("exit");
+        }) as (code: number) => never,
+      },
+      { ipcCall: ex.ipcCall, exec: ex.exec, findGitRoot: ex.findGitRoot, now: ex.now },
+    ).catch(() => {});
+
+    expect(code).toBe(1);
+    expect(errs.some((e) => e.includes("phases only run from branch"))).toBe(true);
+  }, 30_000);
+
+  test("missing work item for --work-item id exits 1", async () => {
+    writeFileSync(join(dir, ".mcx.yaml"), manifestMain);
+    writeFileSync(join(dir, "impl.ts"), phaseAlias);
+    await install();
+
+    const ex = makeExecDeps({ workItem: null });
+    const errs: string[] = [];
+    let code: number | undefined;
+    await executePhase(
+      ["implement", "--work-item", "#999"],
+      {
+        ...makeDriftDeps(dir).deps,
+        log: () => {},
+        logError: (m) => errs.push(m),
+        exit: ((c: number) => {
+          code = c;
+          throw new Error("exit");
+        }) as (code: number) => never,
+      },
+      { ipcCall: ex.ipcCall, exec: ex.exec, findGitRoot: ex.findGitRoot, now: ex.now },
+    ).catch(() => {});
+
+    expect(code).toBe(1);
+    expect(errs.some((e) => e.includes('work item "#999" not found'))).toBe(true);
+  }, 30_000);
+
+  test("transition is committed even when handler throws (idempotent re-entry)", async () => {
+    const throwAlias = `
+import { defineAlias, z } from "mcp-cli";
+defineAlias(({ z }) => ({
+  name: "implement",
+  description: "impl",
+  input: z.object({}).default({}),
+  output: z.object({}),
+  fn: async () => { throw new Error("handler boom"); },
+}));
+`.trim();
+    writeFileSync(join(dir, ".mcx.yaml"), manifestMain);
+    writeFileSync(join(dir, "impl.ts"), throwAlias);
+    await install();
+
+    const ex = makeExecDeps({});
+    const errs: string[] = [];
+    let code: number | undefined;
+    await executePhase(
+      ["implement"],
+      {
+        ...makeDriftDeps(dir).deps,
+        log: () => {},
+        logError: (m) => errs.push(m),
+        exit: ((c: number) => {
+          code = c;
+          throw new Error("exit");
+        }) as (code: number) => never,
+      },
+      { ipcCall: ex.ipcCall, exec: ex.exec, findGitRoot: ex.findGitRoot, now: ex.now },
+    ).catch(() => {});
+
+    expect(code).toBe(1);
+    expect(errs.some((e) => e.includes("approved"))).toBe(true);
+    expect(errs.some((e) => e.includes('phase "implement" failed'))).toBe(true);
+    // Transition log recorded the attempt so the orchestrator can see it.
+    const { readFileSync: rfs } = require("node:fs");
+    const log = rfs(join(dir, ".mcx", "transitions.jsonl"), "utf-8");
+    expect(log).toContain('"to":"implement"');
+  }, 30_000);
 });

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -19,7 +19,10 @@ import { existsSync, readFileSync, renameSync, statSync, writeFileSync } from "n
 import { isAbsolute, join, relative, resolve as resolvePath } from "node:path";
 import {
   type AliasContext,
+  type AliasWorkItemInfo,
+  BranchGuardError,
   DisallowedTransitionError,
+  GLOBAL_STATE_NAMESPACE,
   LOCKFILE_NAME,
   LOCKFILE_VERSION,
   type LockedPhase,
@@ -27,15 +30,24 @@ import {
   type Manifest,
   ManifestError,
   type ManifestState,
+  type McpProxy,
+  NO_REPO_ROOT,
   RegressionError,
   type TransitionLogEntry,
   UnknownPhaseError,
+  type WorkItem,
   bundleAlias,
   canonicalJson,
+  checkRunsOn,
   commitTransition,
+  createAliasCache,
+  createAliasState,
   executeAliasBundled,
+  extractContent,
   extractMetadata,
+  findGitRoot,
   hashFileSync,
+  ipcCall,
   isDefineAlias,
   loadManifest,
   parseLockfile,
@@ -46,6 +58,7 @@ import {
   wrapDryRunContext,
 } from "@mcp-cli/core";
 import type { AliasMetadata } from "@mcp-cli/core";
+import type { ExecFn, ExecResult } from "@mcp-cli/core";
 import { printError } from "../output";
 
 export interface PhaseInstallDeps {
@@ -683,13 +696,16 @@ export async function cmdPhase(args: string[], deps?: Partial<PhaseInstallDeps>)
       assertNoDrift(d);
       if (argv.includes("--dry-run")) {
         await runPhase(argv, d);
-      } else {
-        const opts = parsePhaseRunArgs(argv);
+      } else if (argv.includes("--no-execute")) {
+        const filtered = argv.filter((a) => a !== "--no-execute");
+        const opts = parsePhaseRunArgs(filtered);
         const result = phaseRun(opts, { cwd: d.cwd() });
         const source = result.manifest.phases[opts.target]?.source ?? "(unknown)";
         const tag = result.forced ? " [FORCED]" : "";
         const trail = result.from ?? "(initial)";
         d.logError(`approved${tag}: ${trail} → ${opts.target} (${source})`);
+      } else {
+        await executePhase(argv, d);
       }
       return;
     }
@@ -820,6 +836,274 @@ async function runPhase(argv: string[], d: PhaseInstallDeps): Promise<void> {
   }
 }
 
+/**
+ * Optional dependencies for real phase execution.
+ *
+ * Tests inject stubs for `ipcCall` and `exec` to avoid requiring a running
+ * daemon or real git. Production code falls through to `defaultExecuteDeps`
+ * which uses the real daemon IPC and `Bun.spawnSync`.
+ */
+export interface PhaseExecuteDeps {
+  ipcCall: typeof ipcCall;
+  exec: ExecFn;
+  findGitRoot: (cwd: string) => string | null;
+  now: () => Date;
+}
+
+const defaultExecuteDeps: PhaseExecuteDeps = {
+  ipcCall,
+  exec: (cmd: string[]): ExecResult => {
+    const [bin, ...rest] = cmd;
+    const r = Bun.spawnSync([bin, ...rest], { stdout: "pipe", stderr: "pipe" });
+    return { stdout: new TextDecoder().decode(r.stdout), exitCode: r.exitCode ?? 0 };
+  },
+  findGitRoot,
+  now: () => new Date(),
+};
+
+export interface PhaseExecuteArgs {
+  target: string;
+  from: string | null;
+  workItemId: string | null;
+  forceMessage: string | null;
+  args: Record<string, string>;
+  inputJson: string | null;
+}
+
+/**
+ * Parse `mcx phase run <target>` without `--dry-run` / `--no-execute`.
+ * Supports transition flags (--from, --work-item, --force) plus execution
+ * inputs: `--arg key=val` pairs and `--input <json>` for the handler input.
+ */
+export function parsePhaseExecuteArgs(argv: string[]): PhaseExecuteArgs {
+  const passthrough: string[] = [];
+  const cliArgs: Record<string, string> = {};
+  let inputJson: string | null = null;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--arg") {
+      const pair = argv[++i];
+      if (!pair) throw new Error("--arg requires a key=val argument");
+      const eq = pair.indexOf("=");
+      if (eq === -1) throw new Error(`--arg value must be in key=val form, got: ${pair}`);
+      const key = pair.slice(0, eq);
+      if (!key) throw new Error(`--arg key must be non-empty in key=val form, got: ${pair}`);
+      cliArgs[key] = pair.slice(eq + 1);
+    } else if (a.startsWith("--arg=")) {
+      const pair = a.slice("--arg=".length);
+      const eq = pair.indexOf("=");
+      if (eq === -1) throw new Error(`--arg value must be in key=val form, got: ${pair}`);
+      const key = pair.slice(0, eq);
+      if (!key) throw new Error(`--arg key must be non-empty in key=val form, got: ${pair}`);
+      cliArgs[key] = pair.slice(eq + 1);
+    } else if (a === "--input") {
+      inputJson = argv[++i] ?? null;
+      if (inputJson === null) throw new Error("--input requires a JSON argument");
+    } else if (a.startsWith("--input=")) {
+      inputJson = a.slice("--input=".length);
+    } else {
+      passthrough.push(a);
+    }
+  }
+  const opts = parsePhaseRunArgs(passthrough);
+  return { ...opts, args: cliArgs, inputJson };
+}
+
+function toAliasWorkItem(w: WorkItem): AliasWorkItemInfo {
+  return {
+    id: w.id,
+    issueNumber: w.issueNumber,
+    prNumber: w.prNumber,
+    branch: w.branch,
+    phase: w.phase,
+  };
+}
+
+function makeRealMcpProxy(ipcCaller: typeof ipcCall, cwd: string): McpProxy {
+  return new Proxy({} as McpProxy, {
+    get(_t, serverName: string) {
+      return new Proxy({} as Record<string, (a?: Record<string, unknown>) => Promise<unknown>>, {
+        get(_i, toolName: string) {
+          return async (toolArgs?: Record<string, unknown>) => {
+            const result = await ipcCaller("callTool", {
+              server: serverName,
+              tool: toolName,
+              arguments: toolArgs ?? {},
+              cwd,
+            });
+            return extractContent(result);
+          };
+        },
+      });
+    },
+  });
+}
+
+/**
+ * Execute a phase handler with a real context (issue #1381).
+ *
+ * Flow:
+ *   1. Parse flags (transition + execution inputs)
+ *   2. Branch guard: refuse to run outside the manifest's `runsOn` branch
+ *   3. Commit the transition via `phaseRun` (same as --no-execute path)
+ *   4. Bundle the phase source
+ *   5. Fetch the work item from the daemon (if `--work-item` given)
+ *   6. Build a live AliasContext: real MCP proxy + daemon-backed state
+ *      (namespaced by the work-item id, so state writes persist per-item)
+ *   7. Execute the handler and emit its structured return on stdout
+ *
+ * The transition is committed before execution so a handler crash doesn't
+ * leave the graph inconsistent; handlers are idempotent on re-entry
+ * (see `.claude/phases/impl.ts` — if `session_id` is set, returns
+ * `in-flight` instead of re-spawning).
+ */
+export async function executePhase(
+  argv: string[],
+  deps: Partial<PhaseInstallDeps>,
+  execDeps?: Partial<PhaseExecuteDeps>,
+): Promise<void> {
+  const d: PhaseInstallDeps = { ...defaultDeps, ...deps };
+  const ex: PhaseExecuteDeps = { ...defaultExecuteDeps, ...execDeps };
+  const cwd = d.cwd();
+
+  let parsed: PhaseExecuteArgs;
+  try {
+    parsed = parsePhaseExecuteArgs(argv);
+  } catch (err) {
+    d.logError(err instanceof Error ? err.message : String(err));
+    d.exit(1);
+  }
+
+  const loaded = d.loadManifest(cwd);
+  if (!loaded) {
+    d.logError("no .mcx.yaml or .mcx.json in this repo");
+    d.exit(1);
+  }
+
+  // Validate + commit the transition before branch-guarding, so
+  // unknown-phase and disallowed-transition errors fail fast without
+  // requiring a real git checkout. The transition log records intent;
+  // branch-guard below gates actual code execution.
+  const txResult = phaseRun(
+    {
+      target: parsed.target,
+      from: parsed.from,
+      workItemId: parsed.workItemId,
+      forceMessage: parsed.forceMessage,
+    },
+    { cwd, now: ex.now },
+  );
+  const source = txResult.manifest.phases[parsed.target]?.source ?? "(unknown)";
+  const tag = txResult.forced ? " [FORCED]" : "";
+  const trail = txResult.from ?? "(initial)";
+  d.logError(`approved${tag}: ${trail} → ${parsed.target} (${source})`);
+
+  // Branch guard — phases execute with full shell/mcp access, so refuse to
+  // dispatch from any branch other than the manifest's `runsOn`. Fires
+  // after transition commit so the intent is still logged on refusal.
+  try {
+    checkRunsOn({ cwd, manifest: loaded.manifest, exec: ex.exec });
+  } catch (err) {
+    if (err instanceof BranchGuardError) {
+      d.logError(err.message);
+      d.exit(1);
+    }
+    throw err;
+  }
+
+  const phase = loaded.manifest.phases[parsed.target];
+  // phaseRun would have thrown UnknownPhaseError if the target was invalid,
+  // so `phase` is defined here.
+
+  let resolved: string;
+  try {
+    resolved = resolvePhaseSource(phase.source, cwd);
+  } catch (err) {
+    d.logError(`phase "${parsed.target}": ${err instanceof Error ? err.message : String(err)}`);
+    d.exit(1);
+  }
+
+  let srcText: string;
+  try {
+    srcText = await d.readFile(resolved);
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e?.code === "ENOENT") d.logError(`phase "${parsed.target}": source ${phase.source} not found`);
+    else d.logError(`phase "${parsed.target}": cannot read ${phase.source}: ${e?.message ?? String(err)}`);
+    d.exit(1);
+  }
+  const structured = isDefineAlias(srcText);
+  const { js } = await d.bundleAlias(resolved);
+
+  // Fetch work item from the daemon if caller supplied one. We do NOT
+  // auto-resolve the current branch to a work item — if the orchestrator
+  // doesn't pass --work-item, phases self-enforce by throwing from their
+  // own assertions (e.g. `if (!ctx.workItem) throw`).
+  let workItem: AliasWorkItemInfo | null = null;
+  if (parsed.workItemId !== null) {
+    try {
+      const wi = (await ex.ipcCall("getWorkItem", { id: parsed.workItemId })) as WorkItem | null;
+      if (!wi) {
+        d.logError(`work item "${parsed.workItemId}" not found`);
+        d.exit(1);
+      }
+      workItem = toAliasWorkItem(wi);
+    } catch (err) {
+      d.logError(
+        `failed to fetch work item "${parsed.workItemId}": ${err instanceof Error ? err.message : String(err)}`,
+      );
+      d.exit(1);
+    }
+  }
+
+  const repoRoot = ex.findGitRoot(cwd) ?? NO_REPO_ROOT;
+  // State is namespaced by work-item id so every phase touching the same
+  // item sees the same scratchpad (see sprint state declarations in
+  // .mcx.yaml). When no work item is bound, writes are discarded into an
+  // ephemeral namespace so the handler doesn't fault on missing state.
+  const stateNamespace = workItem ? `workitem:${workItem.id}` : `phase:${parsed.target}:unbound`;
+  const ctx: AliasContext = {
+    mcp: makeRealMcpProxy(ex.ipcCall, cwd),
+    args: parsed.args,
+    file: (p) => Bun.file(p).text(),
+    json: async (p) => JSON.parse(await Bun.file(p).text()),
+    cache: createAliasCache(`phase:${parsed.target}`),
+    state: createAliasState({ repoRoot, namespace: stateNamespace, call: ex.ipcCall }),
+    globalState: createAliasState({ repoRoot, namespace: GLOBAL_STATE_NAMESPACE, call: ex.ipcCall }),
+    workItem,
+  };
+
+  let input: unknown;
+  if (parsed.inputJson !== null && parsed.inputJson !== "") {
+    try {
+      input = JSON.parse(parsed.inputJson);
+    } catch {
+      // Fall through to raw string; schema will reject if it needs an object.
+      input = parsed.inputJson;
+    }
+  } else if (Object.keys(parsed.args).length > 0) {
+    input = parsed.args;
+  } else {
+    input = {};
+  }
+
+  let output: unknown;
+  try {
+    output = await d.executeAliasBundled(js, structured ? input : undefined, ctx, structured);
+  } catch (err) {
+    d.logError(`phase "${parsed.target}" failed: ${err instanceof Error ? err.message : String(err)}`);
+    d.exit(1);
+  }
+
+  if (output !== undefined && output !== null) {
+    if (typeof output === "string") {
+      d.log(output);
+    } else {
+      d.log(JSON.stringify(output, null, 2));
+    }
+  }
+}
+
 function printPhaseHelp(d: PhaseInstallDeps): void {
   d.log(`mcx phase — orchestration phase graph
 
@@ -831,9 +1115,17 @@ Subcommands:
       Verify .mcx.lock matches the manifest and phase sources. Exits non-zero on drift.
 
   mcx phase run <target> [--from <current>] [--work-item <id>] [--force <message>]
-      Validate and record a phase transition against .mcx.{yaml,json}.
-      --force <message> bypasses disallowed-transition and regression checks;
-      unknown-phase errors are never bypassable.
+                          [--arg key=val ...] [--input <json>]
+      Validate and record the transition, then execute the phase handler
+      with a live ctx (daemon-backed state, real MCP proxy, work-item info).
+      Structured return is printed to stdout as JSON so the orchestrator
+      can pipe it: e.g. \`action: "spawn" | "wait" | "goto"\` for sprint
+      phases. --force <message> bypasses disallowed-transition and
+      regression checks; unknown-phase errors are never bypassable.
+
+  mcx phase run <target> --no-execute [--from ...] [--work-item ...] [--force ...]
+      Validate + log the transition without executing the handler. Use
+      when the orchestrator wants to record intent separately from dispatch.
 
   mcx phase run <name> --dry-run [--arg key=val ...]
       Execute a phase handler with side effects logged but not dispatched.

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -30,7 +30,6 @@ import {
   type Manifest,
   ManifestError,
   type ManifestState,
-  type McpProxy,
   NO_REPO_ROOT,
   RegressionError,
   type TransitionLogEntry,
@@ -43,8 +42,8 @@ import {
   commitTransition,
   createAliasCache,
   createAliasState,
+  createMcpProxy,
   executeAliasBundled,
-  extractContent,
   extractMetadata,
   findGitRoot,
   hashFileSync,
@@ -860,7 +859,11 @@ const defaultExecuteDeps: PhaseExecuteDeps = {
   exec: (cmd: string[]): ExecResult => {
     const [bin, ...rest] = cmd;
     const r = Bun.spawnSync([bin, ...rest], { stdout: "pipe", stderr: "pipe" });
-    return { stdout: new TextDecoder().decode(r.stdout), exitCode: r.exitCode ?? 0 };
+    // `exitCode` is null when the child was terminated by a signal (e.g. SIGKILL).
+    // Surface that as a failure — `?? 0` previously masked signal-killed processes
+    // as success and let the branch guard wave through a git that never ran.
+    const exitCode = r.exitCode ?? 1;
+    return { stdout: new TextDecoder().decode(r.stdout), exitCode };
   },
   findGitRoot,
   now: () => new Date(),
@@ -924,44 +927,29 @@ function toAliasWorkItem(w: WorkItem): AliasWorkItemInfo {
   };
 }
 
-function makeRealMcpProxy(ipcCaller: typeof ipcCall, cwd: string): McpProxy {
-  return new Proxy({} as McpProxy, {
-    get(_t, serverName: string) {
-      return new Proxy({} as Record<string, (a?: Record<string, unknown>) => Promise<unknown>>, {
-        get(_i, toolName: string) {
-          return async (toolArgs?: Record<string, unknown>) => {
-            const result = await ipcCaller("callTool", {
-              server: serverName,
-              tool: toolName,
-              arguments: toolArgs ?? {},
-              cwd,
-            });
-            return extractContent(result);
-          };
-        },
-      });
-    },
-  });
-}
-
 /**
  * Execute a phase handler with a real context (issue #1381).
  *
  * Two-phase transition log (PR #1407 adversarial-review fix):
  *   1. Parse flags (transition + execution inputs)
- *   2. Append an `"attempted"` entry to `.mcx/transitions.jsonl`. This
+ *   2. Pre-validate the transition against committed history so bogus
+ *      moves fail fast before we bundle or dispatch anything.
+ *   3. Append an `"attempted"` entry to `.mcx/transitions.jsonl`. This
  *      captures attempt evidence from ANY branch, including cases that
  *      branch-guard rejects or handlers crash. Attempted entries are
  *      ignored by graph-walk / regression checks (#1407).
- *   3. Branch guard: refuse to dispatch outside the manifest's `runsOn`
+ *   4. Branch guard: refuse to dispatch outside the manifest's `runsOn`
  *      branch. Attempt is already logged for audit.
- *   4. Bundle the phase source
- *   5. Fetch the work item from the daemon (if `--work-item` given)
- *   6. Build a live AliasContext: real MCP proxy + daemon-backed state
+ *   5. Bundle the phase source
+ *   6. Fetch the work item from the daemon (if `--work-item` given)
+ *   7. Build a live AliasContext: real MCP proxy + daemon-backed state
  *      (namespaced by the work-item id)
- *   7. Execute the handler
- *   8. On success: `commitTransition` writes a `"committed"` entry.
- *      `validateTransition` now accepts an idempotent self-loop
+ *   8. Execute the handler
+ *   9. On success (and only on success): `commitTransition` writes a
+ *      `"committed"` entry. The transition commit runs AFTER the handler
+ *      and branch guard, so failed or rejected runs leave only the
+ *      `"attempted"` audit entry — retries are not blocked.
+ *      `validateTransition` accepts an idempotent self-loop
  *      (`from === target && tail === target`) so handlers can be re-run
  *      without tripping `RegressionError` — handlers are expected to
  *      self-check state and return `"in-flight"` when already running.
@@ -1093,11 +1081,13 @@ export async function executePhase(
   const repoRoot = ex.findGitRoot(cwd) ?? NO_REPO_ROOT;
   // State is namespaced by work-item id so every phase touching the same
   // item sees the same scratchpad (see sprint state declarations in
-  // .mcx.yaml). When no work item is bound, writes are discarded into an
-  // ephemeral namespace so the handler doesn't fault on missing state.
+  // .mcx.yaml). When no work item is bound we fall back to a
+  // `phase:<target>:unbound` namespace — writes still persist through the
+  // daemon (createAliasState always hits SQLite), but they land in a
+  // separate bucket that won't collide with work-item scoped state.
   const stateNamespace = workItem ? `workitem:${workItem.id}` : `phase:${parsed.target}:unbound`;
   const ctx: AliasContext = {
-    mcp: makeRealMcpProxy(ex.ipcCall, cwd),
+    mcp: createMcpProxy({ call: ex.ipcCall, cwd }),
     args: parsed.args,
     file: (p) => Bun.file(p).text(),
     json: async (p) => JSON.parse(await Bun.file(p).text()),

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -36,6 +36,7 @@ import {
   type TransitionLogEntry,
   UnknownPhaseError,
   type WorkItem,
+  appendAttempt,
   bundleAlias,
   canonicalJson,
   checkRunsOn,
@@ -47,14 +48,18 @@ import {
   extractMetadata,
   findGitRoot,
   hashFileSync,
+  historyTargets,
   ipcCall,
+  isCommitted,
   isDefineAlias,
   loadManifest,
   parseLockfile,
   readAllTransitions,
+  readTransitionHistory,
   serializeLockfile,
   sha256Hex,
   suggestPhases,
+  validateTransition,
   wrapDryRunContext,
 } from "@mcp-cli/core";
 import type { AliasMetadata } from "@mcp-cli/core";
@@ -942,20 +947,28 @@ function makeRealMcpProxy(ipcCaller: typeof ipcCall, cwd: string): McpProxy {
 /**
  * Execute a phase handler with a real context (issue #1381).
  *
- * Flow:
+ * Two-phase transition log (PR #1407 adversarial-review fix):
  *   1. Parse flags (transition + execution inputs)
- *   2. Branch guard: refuse to run outside the manifest's `runsOn` branch
- *   3. Commit the transition via `phaseRun` (same as --no-execute path)
+ *   2. Append an `"attempted"` entry to `.mcx/transitions.jsonl`. This
+ *      captures attempt evidence from ANY branch, including cases that
+ *      branch-guard rejects or handlers crash. Attempted entries are
+ *      ignored by graph-walk / regression checks (#1407).
+ *   3. Branch guard: refuse to dispatch outside the manifest's `runsOn`
+ *      branch. Attempt is already logged for audit.
  *   4. Bundle the phase source
  *   5. Fetch the work item from the daemon (if `--work-item` given)
  *   6. Build a live AliasContext: real MCP proxy + daemon-backed state
- *      (namespaced by the work-item id, so state writes persist per-item)
- *   7. Execute the handler and emit its structured return on stdout
+ *      (namespaced by the work-item id)
+ *   7. Execute the handler
+ *   8. On success: `commitTransition` writes a `"committed"` entry.
+ *      `validateTransition` now accepts an idempotent self-loop
+ *      (`from === target && tail === target`) so handlers can be re-run
+ *      without tripping `RegressionError` — handlers are expected to
+ *      self-check state and return `"in-flight"` when already running.
  *
- * The transition is committed before execution so a handler crash doesn't
- * leave the graph inconsistent; handlers are idempotent on re-entry
- * (see `.claude/phases/impl.ts` — if `session_id` is set, returns
- * `in-flight` instead of re-spawning).
+ * If the handler crashes, no committed entry is written: the work item
+ * state is "tried but did not complete", and a retry will not be blocked
+ * by the transition log.
  */
 export async function executePhase(
   argv: string[],
@@ -980,27 +993,52 @@ export async function executePhase(
     d.exit(1);
   }
 
-  // Validate + commit the transition before branch-guarding, so
-  // unknown-phase and disallowed-transition errors fail fast without
-  // requiring a real git checkout. The transition log records intent;
-  // branch-guard below gates actual code execution.
-  const txResult = phaseRun(
-    {
-      target: parsed.target,
-      from: parsed.from,
-      workItemId: parsed.workItemId,
-      forceMessage: parsed.forceMessage,
-    },
-    { cwd, now: ex.now },
-  );
-  const source = txResult.manifest.phases[parsed.target]?.source ?? "(unknown)";
-  const tag = txResult.forced ? " [FORCED]" : "";
-  const trail = txResult.from ?? "(initial)";
-  d.logError(`approved${tag}: ${trail} → ${parsed.target} (${source})`);
+  const phase = loaded.manifest.phases[parsed.target];
+  if (!phase) {
+    d.logError(
+      `unknown phase "${parsed.target}".${(() => {
+        const s = suggestPhases(parsed.target, Object.keys(loaded.manifest.phases));
+        return s.length > 0 ? ` did you mean: ${s.join(", ")}?` : "";
+      })()}`,
+    );
+    d.exit(1);
+  }
 
-  // Branch guard — phases execute with full shell/mcp access, so refuse to
-  // dispatch from any branch other than the manifest's `runsOn`. Fires
-  // after transition commit so the intent is still logged on refusal.
+  // Pre-validate the transition with committed-only history so bogus
+  // moves (unknown from, disallowed, un-forced regression) fail BEFORE
+  // we spend cycles running the handler. The final commit below repeats
+  // this under the transition lock; pre-check is a fail-fast guard, not
+  // the source of truth.
+  const logPath = transitionLogPath(cwd);
+  const prior = readTransitionHistory(logPath, parsed.workItemId).filter(isCommitted);
+  const priorTargets = historyTargets(prior);
+  const resolvedFrom =
+    parsed.from !== null ? parsed.from : priorTargets.length > 0 ? priorTargets[priorTargets.length - 1] : null;
+  validateTransition({
+    manifest: loaded.manifest,
+    from: resolvedFrom,
+    target: parsed.target,
+    history: priorTargets,
+    workItemId: parsed.workItemId,
+    force: parsed.forceMessage !== null ? { message: parsed.forceMessage } : null,
+    manifestPath: loaded.path,
+  });
+
+  // Two-phase log — append an "attempted" entry before branch-guard or
+  // handler dispatch so every invocation leaves an audit trail, even
+  // when branch-guard rejects or the handler crashes. Attempted entries
+  // are ignored by regression / graph-walk checks (#1407).
+  appendAttempt(logPath, {
+    workItemId: parsed.workItemId,
+    from: resolvedFrom,
+    target: parsed.target,
+    forceMessage: parsed.forceMessage,
+    now: ex.now,
+  });
+
+  // Branch guard — phases execute with full shell/mcp access, so refuse
+  // to dispatch from any branch other than the manifest's `runsOn`. The
+  // attempt entry above captured the intent for audit.
   try {
     checkRunsOn({ cwd, manifest: loaded.manifest, exec: ex.exec });
   } catch (err) {
@@ -1010,10 +1048,6 @@ export async function executePhase(
     }
     throw err;
   }
-
-  const phase = loaded.manifest.phases[parsed.target];
-  // phaseRun would have thrown UnknownPhaseError if the target was invalid,
-  // so `phase` is defined here.
 
   let resolved: string;
   try {
@@ -1091,9 +1125,29 @@ export async function executePhase(
   try {
     output = await d.executeAliasBundled(js, structured ? input : undefined, ctx, structured);
   } catch (err) {
+    // No committed entry — only the "attempted" record remains, so a
+    // retry is not gated by this failure (#1407).
     d.logError(`phase "${parsed.target}" failed: ${err instanceof Error ? err.message : String(err)}`);
     d.exit(1);
   }
+
+  // Handler succeeded — commit the transition. Idempotent self-loop
+  // (`from === target && tail === target`) is accepted by
+  // validateTransition so successive `phase run <X>` calls don't
+  // trip RegressionError.
+  const txResult = phaseRun(
+    {
+      target: parsed.target,
+      from: parsed.from,
+      workItemId: parsed.workItemId,
+      forceMessage: parsed.forceMessage,
+    },
+    { cwd, now: ex.now },
+  );
+  const source = phase.source ?? "(unknown)";
+  const tag = txResult.forced ? " [FORCED]" : "";
+  const trail = txResult.from ?? "(initial)";
+  d.logError(`approved${tag}: ${trail} → ${parsed.target} (${source})`);
 
   if (output !== undefined && output !== null) {
     if (typeof output === "string") {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,3 +37,4 @@ export * from "./upgrade";
 export * from "./work-item";
 export * from "./telemetry";
 export * from "./phase-source";
+export * from "./mcp-proxy";

--- a/packages/core/src/mcp-proxy.ts
+++ b/packages/core/src/mcp-proxy.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared MCP proxy factory.
+ *
+ * Builds the `mcp.server.tool(args)` proxy used by both the standalone alias
+ * runner and `mcx phase run`. Both call sites previously carried a private
+ * copy of this Proxy wiring; centralising it here ensures a single source of
+ * truth for the IPC shape (`callTool` params) and response extraction.
+ */
+
+import { type McpProxy, extractContent } from "./alias";
+import { ipcCall } from "./ipc-client";
+
+export interface CreateMcpProxyOptions {
+  /**
+   * Working directory forwarded as `cwd` to the daemon so server config
+   * resolution (`.mcp.json`, env expansion) picks the right repo. Can be a
+   * literal string or a thunk when the caller wants to defer to `process.cwd()`
+   * at call time.
+   */
+  cwd: string | (() => string);
+  /**
+   * IPC caller. Defaults to the real `ipcCall`; tests inject a stub to avoid
+   * needing a running daemon.
+   */
+  call?: typeof ipcCall;
+}
+
+export function createMcpProxy(opts: CreateMcpProxyOptions): McpProxy {
+  const call = opts.call ?? ipcCall;
+  const resolveCwd = typeof opts.cwd === "function" ? opts.cwd : () => opts.cwd as string;
+  return new Proxy({} as McpProxy, {
+    get(_target, serverName: string) {
+      return new Proxy({} as Record<string, (args?: Record<string, unknown>) => Promise<unknown>>, {
+        get(_inner, toolName: string) {
+          return async (toolArgs?: Record<string, unknown>) => {
+            const result = await call("callTool", {
+              server: serverName,
+              tool: toolName,
+              arguments: toolArgs ?? {},
+              cwd: resolveCwd(),
+            });
+            return extractContent(result);
+          };
+        },
+      });
+    },
+  });
+}

--- a/packages/core/src/phase-transition.ts
+++ b/packages/core/src/phase-transition.ts
@@ -19,6 +19,22 @@ import { appendFileSync, closeSync, mkdirSync, openSync, readFileSync, statSync,
 import { dirname } from "node:path";
 import type { Manifest } from "./manifest";
 
+/**
+ * Lifecycle status of a transition log entry.
+ *
+ * - `"attempted"`: intent was logged but the phase handler has not (yet)
+ *   committed. Written before branch-guard / handler dispatch so attempts
+ *   from feature branches or crashed handlers leave an audit trail.
+ *   IGNORED by regression / graph-walk checks.
+ * - `"committed"`: the phase handler ran to completion and the transition
+ *   is now part of the work item's authoritative history.
+ *
+ * Legacy entries (written before issue #1381 re-entry fix) omit `status`;
+ * readers treat missing `status` as `"committed"` for back-compat so old
+ * logs continue to gate transitions the same way.
+ */
+export type TransitionStatus = "attempted" | "committed";
+
 /** One record in the transition log. JSONL on disk. */
 export interface TransitionLogEntry {
   /** ISO-8601 UTC timestamp. */
@@ -31,6 +47,13 @@ export interface TransitionLogEntry {
   to: string;
   /** When `--force` was used, the justification text. */
   forceMessage?: string;
+  /** Two-phase commit status. Missing → "committed" (legacy). */
+  status?: TransitionStatus;
+}
+
+/** True when `entry` should gate future transitions (committed or legacy). */
+export function isCommitted(entry: TransitionLogEntry): boolean {
+  return entry.status !== "attempted";
 }
 
 export class UnknownPhaseError extends Error {
@@ -158,6 +181,16 @@ export function validateTransition(input: ValidateTransitionInput): {
     return { from, target, forced: true };
   }
 
+  // Rule 2b: idempotent self-loop — a committed `X → X` where the most
+  // recent committed target is already `X` is a no-op re-entry, not a
+  // regression. Handlers are expected to be idempotent (they self-check
+  // state and return "in-flight" when already running), so calling
+  // `phase run X` twice in a row must not blow up with RegressionError.
+  // See PR #1407 adversarial review.
+  if (from !== null && from === target && history.length > 0 && history[history.length - 1] === target) {
+    return { from, target, forced: false };
+  }
+
   // Rule 3: unknown from — bypassable via --force above.
   if (from !== null && !declared.includes(from)) {
     throw new UnknownPhaseError(from, suggestPhases(from, declared));
@@ -271,6 +304,37 @@ export function historyTargets(entries: readonly TransitionLogEntry[]): string[]
 export function appendTransitionLog(logPath: string, entry: TransitionLogEntry): void {
   mkdirSync(dirname(logPath), { recursive: true });
   appendFileSync(logPath, `${JSON.stringify(entry)}\n`, "utf-8");
+}
+
+/**
+ * Log an "attempted" entry without validation. Unlike `commitTransition`,
+ * this never throws on regression / disallowed transitions — the point of
+ * an attempt record is to capture intent from any branch or context,
+ * including cases that will fail branch-guard or crash during dispatch.
+ * Attempted entries are IGNORED by graph-walk and regression checks
+ * (see `commitTransition`); they exist purely for audit (#1407).
+ */
+export function appendAttempt(
+  logPath: string,
+  input: {
+    workItemId: string | null;
+    from: string | null;
+    target: string;
+    forceMessage?: string | null;
+    now?: () => Date;
+  },
+): TransitionLogEntry {
+  const ts = (input.now?.() ?? new Date()).toISOString();
+  const entry: TransitionLogEntry = {
+    ts,
+    workItemId: input.workItemId,
+    from: input.from,
+    to: input.target,
+    status: "attempted",
+    ...(input.forceMessage ? { forceMessage: input.forceMessage } : {}),
+  };
+  appendTransitionLog(logPath, entry);
+  return entry;
 }
 
 /**
@@ -402,7 +466,9 @@ export function commitTransition(logPath: string, input: CommitTransitionInput):
   return withTransitionLock(
     logPath,
     () => {
-      const history = readTransitionHistory(logPath, workItemId, onCorrupt);
+      // Validation considers only committed entries; "attempted" entries
+      // are audit-only and must not gate future transitions (#1407).
+      const history = readTransitionHistory(logPath, workItemId, onCorrupt).filter(isCommitted);
       const targets = historyTargets(history);
 
       let from = input.from;
@@ -426,6 +492,7 @@ export function commitTransition(logPath: string, input: CommitTransitionInput):
         workItemId,
         from: decision.from,
         to: decision.target,
+        status: "committed",
         ...(force ? { forceMessage: force.message } : {}),
       };
       appendTransitionLog(logPath, entry);


### PR DESCRIPTION
## Summary
- `mcx phase run <target>` (no `--dry-run`) now executes the phase handler with a live `AliasContext`: daemon-backed state namespaced by work-item id, real MCP proxy, and `--work-item` resolved via IPC. Structured returns stream to stdout as JSON.
- `--no-execute` is the new escape hatch for orchestrators that want to record the transition separately from dispatch.
- `--arg key=val` and `--input <json>` carry handler inputs through, mirroring the dry-run runner.

## Adversarial-review resolution — two-phase transition log (#1407)

The first revision committed the transition to `.mcx/transitions.jsonl` **before** the handler ran. The reviewer flagged that this corrupted the audit log (logging never-happened transitions) and — more critically — broke re-entry: once `impl` was in history, a second `phase run impl` hit `RegressionError` because the real `.mcx.yaml` declares `impl.next = [triage]` (no self-loop).

Fix landed in `403f621d`:
- **`status: "attempted" | "committed"`** field on every transition log entry. Legacy entries (no `status`) are treated as `"committed"` for back-compat.
- **`"attempted"` entries** are appended before branch-guard / handler dispatch so every invocation leaves an audit trail (including crashes and wrong-branch attempts). They are **ignored** by graph-walk and regression checks.
- **`"committed"` entries** land only after the handler returns successfully. These drive `validateTransition`.
- **Idempotent self-loop rule** in `validateTransition`: `from === target && tail === target` is now a no-op re-entry, not a regression. Handlers are expected to be idempotent (self-check state, return `"in-flight"`), so successive `phase run X` calls must not trip `RegressionError`.
- **Pre-validation** runs before the `"attempted"` append, so unknown-phase / disallowed / un-forced-regression fail fast without wasting cycles on the handler.

### Trade-off
We deliberately emit TWO log lines per successful run (one `"attempted"`, one `"committed"`). The alternative — only committing, no attempt record — would lose audit evidence for branch-guard rejections and handler crashes, which was the author's original motivation for logging before execution. Two lines per run is cheap; lost audit evidence is not.

### Handler crash → retry
Handler throws → no `"committed"` entry. A retry re-enters cleanly because the transition log has only `"attempted"` entries for this work item, and those don't gate validation.

## Test plan
- [x] `bun typecheck`
- [x] `bun lint`
- [x] `bun test` (5070 pass, 0 fail)
- [x] `executePhase` tests cover:
  - real ctx dispatch (state persist + MCP call)
  - re-entry when state indicates in-flight (handler short-path)
  - branch-guard rejection on non-`runsOn` branches
  - missing work-item 404
  - handler-crash path — only `"attempted"` logged, no `"committed"` (updated invariant)
  - **new**: back-to-back `executePhase` calls on the same manifest/work-item don't trip `RegressionError` (idempotent self-loop)

## Notes
- Scope matches #1381: execute + emit JSON. Out of scope per the issue: `onIdle`/`keepAlive` re-entry cadence, pre-spawn quota gates. The CLI does **not** invoke spawn commands itself — that stays with the orchestrator.
- Existing tests that asserted the old transition-only behaviour were updated to pass `--no-execute`.
- Rebased on `origin/main` (picks up #1349, #1383, #1402).

## Remaining review nits (not addressed in this revision)
The 🟡/🔵 points from the review remain open — none are correctness blockers, filing follow-ups is appropriate:
- `Bun.spawnSync` in `defaultExecuteDeps.exec` has no `timeout:` option
- Silent JSON→string fallthrough on `--input` parse failure
- Asymmetric `cwd` forwarding on IPC methods
- `stateNamespace` using `:` delimiter

🤖 Generated with [Claude Code](https://claude.com/claude-code)