### PR TITLE
fix(ci): upload Bun crash logs as artifacts (fixes #1393)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,14 @@ jobs:
           else
             exit $code
           fi
+      - name: Upload test logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bun-test-logs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: /tmp/test_*.txt
+          if-no-files-found: ignore
+          retention-days: 30
 
   coverage:
     runs-on: ubuntu-latest
@@ -109,6 +117,14 @@ jobs:
           else
             exit $code
           fi
+      - name: Upload coverage logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bun-coverage-logs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: /tmp/coverage_*.txt
+          if-no-files-found: ignore
+          retention-days: 30
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `upload-artifact` steps to `check` and `coverage` CI jobs so Bun crash stderr (including `bun.report` URLs) is persisted as downloadable artifacts
- Uses `if: always()` to capture logs even when steps fail or are retried
- 30-day retention, `if-no-files-found: ignore` so clean runs don't error

## Test plan
- [ ] CI workflow syntax is valid (GitHub Actions will validate on PR)
- [ ] On a segfault run, artifacts named `bun-test-logs-*` / `bun-coverage-logs-*` appear in the Actions UI
- [ ] On a clean run, no artifact upload errors (ignore mode handles missing files)
- [ ] `gh run download --name bun-test-logs-*` retrieves logs for aggregation

🤖 Generated with [Claude Code](https://claude.com/claude-code)