### PR TITLE
fix(tests): strip all GIT_* env vars in findGitRoot fixture setup (fixes #1347)

### DIFF
--- a/packages/core/src/git.spec.ts
+++ b/packages/core/src/git.spec.ts
@@ -126,8 +126,7 @@ function cleanGitEnv(): Record<string, string | undefined> {
 }
 
 describe("findGitRoot", () => {
-  // Strip hook-injected git env vars so fixture git calls work even under pre-commit.
-  const { GIT_DIR: _d, GIT_WORK_TREE: _w, GIT_INDEX_FILE: _i, ...cleanEnv } = process.env;
+  const cleanEnv = cleanGitEnv();
   const gitOpts = { env: cleanEnv, stdout: "ignore" as const, stderr: "ignore" as const };
 
   test("returns the repo root from a subdirectory inside a real repo", () => {


### PR DESCRIPTION
## Summary
- The `cleanEnv` destructuring in `findGitRoot` tests only stripped 3 of 5 hook-injected GIT_* vars (missing `GIT_COMMON_DIR` and `GIT_OBJECT_DIRECTORY`)
- When pre-commit hooks inject all 5 vars, the worktree and bare-repo fixture `git init`/`git worktree add` commands fail, causing 2 test failures
- Fixed by reusing the existing `cleanGitEnv()` helper which already strips all 5 vars

## Test plan
- [x] Reproduced failure: `GIT_DIR=.git GIT_COMMON_DIR=.git GIT_INDEX_FILE=.git/index GIT_OBJECT_DIRECTORY=.git/objects GIT_WORK_TREE=. bun test packages/core/src/git.spec.ts` — 2 failures before fix
- [x] Verified fix: same command passes all 9 tests after fix
- [x] Full suite: 5092 pass, 0 fail
- [x] Typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)