### PR TITLE
fix(quota): reset _errorLogged when error type changes (fixes #1378)

### DIFF
--- a/packages/daemon/src/quota.spec.ts
+++ b/packages/daemon/src/quota.spec.ts
@@ -295,6 +295,64 @@ describe("QuotaPoller", () => {
     expect(poller.status?.fiveHour?.utilization).toBe(42);
   });
 
+  test("logs new error when error type changes (rate-limit → other)", async () => {
+    const warnings: string[] = [];
+    let callCount = 0;
+    const poller = new QuotaPoller({
+      intervalMs: 20,
+      logger: {
+        info: () => {},
+        warn: (msg: string) => warnings.push(msg),
+        error: () => {},
+        debug: () => {},
+      },
+      readToken: async () => fakeToken,
+      fetchUsage: async () => {
+        callCount++;
+        if (callCount <= 2) throw new Error("Quota API returned 429: rate_limit_error");
+        throw new Error("network timeout");
+      },
+    });
+
+    poller.start();
+    await Bun.sleep(250);
+    poller.stop();
+
+    const rateLimitWarnings = warnings.filter((w) => w.includes("rate-limited"));
+    const fetchFailedWarnings = warnings.filter((w) => w.includes("Quota fetch failed"));
+    expect(rateLimitWarnings.length).toBe(1);
+    expect(fetchFailedWarnings.length).toBe(1);
+  });
+
+  test("logs new error when error type changes (other → rate-limit)", async () => {
+    const warnings: string[] = [];
+    let callCount = 0;
+    const poller = new QuotaPoller({
+      intervalMs: 20,
+      logger: {
+        info: () => {},
+        warn: (msg: string) => warnings.push(msg),
+        error: () => {},
+        debug: () => {},
+      },
+      readToken: async () => fakeToken,
+      fetchUsage: async () => {
+        callCount++;
+        if (callCount <= 2) throw new Error("network timeout");
+        throw new Error("Quota API returned 429: rate_limit_error");
+      },
+    });
+
+    poller.start();
+    await Bun.sleep(250);
+    poller.stop();
+
+    const rateLimitWarnings = warnings.filter((w) => w.includes("rate-limited"));
+    const fetchFailedWarnings = warnings.filter((w) => w.includes("Quota fetch failed"));
+    expect(fetchFailedWarnings.length).toBe(1);
+    expect(rateLimitWarnings.length).toBe(1);
+  });
+
   test("start is idempotent", async () => {
     let calls = 0;
     const poller = new QuotaPoller({

--- a/packages/daemon/src/quota.ts
+++ b/packages/daemon/src/quota.ts
@@ -124,6 +124,7 @@ export class QuotaPoller {
   private _status: QuotaStatus | null = null;
   private _lastError: string | null = null;
   private _errorLogged = false;
+  private _lastErrorType: "rate-limit" | "other" | null = null;
   private _backoffMs: number | null = null;
   private logger: Logger;
   private intervalMs: number;
@@ -195,6 +196,7 @@ export class QuotaPoller {
       this._status = status;
       this._lastError = null;
       this._errorLogged = false;
+      this._lastErrorType = null;
       this._backoffMs = null;
 
       this.checkThresholds(status);
@@ -202,9 +204,13 @@ export class QuotaPoller {
       const msg = err instanceof Error ? err.message : String(err);
       this._lastError = msg;
 
-      if (isRateLimitError(msg)) {
-        // Exponential backoff on rate limit — don't keep adding to the flood.
-        // Preserves last cached _status; consumers read .lastError for the reason.
+      const errorType = isRateLimitError(msg) ? "rate-limit" : "other";
+      if (this._lastErrorType !== errorType) {
+        this._errorLogged = false;
+      }
+      this._lastErrorType = errorType;
+
+      if (errorType === "rate-limit") {
         const next = this._backoffMs == null ? this.intervalMs * 2 : this._backoffMs * 2;
         this._backoffMs = Math.min(next, MAX_BACKOFF_MS);
         if (!this._errorLogged) {
@@ -212,7 +218,6 @@ export class QuotaPoller {
           this._errorLogged = true;
         }
       } else {
-        // Non-rate-limit error — stay on normal cadence, log once.
         this._backoffMs = null;
         if (!this._errorLogged) {
           this.logger.warn(`[mcpd] Quota fetch failed: ${msg}`);


### PR DESCRIPTION
## Summary
- Track `_lastErrorType` (`"rate-limit" | "other" | null`) in `QuotaPoller` to detect when error type changes
- Reset `_errorLogged` flag when the error type transitions (e.g., rate-limit → network error), so the new error gets logged
- Added two tests covering both transition directions (rate-limit → other, other → rate-limit)

## Test plan
- [x] Existing quota tests still pass (17 tests)
- [x] New test: rate-limit error followed by network error → both get logged
- [x] New test: network error followed by rate-limit error → both get logged
- [x] Repeated same-type errors still only log once (existing test)
- [x] Full test suite passes (5072 tests)
- [x] Typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)