### PR TITLE
feat(ci): add phase drift guard check (fixes #1384)

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -57,6 +57,9 @@ if $has_source; then
   echo "  lint:shell..."
   bun run lint:shell
 
+  echo "  check:phase-drift..."
+  bun run check:phase-drift
+
   echo "  test + coverage..."
   if ! bun run test:coverage; then
     echo "  (test failures logged to ~/.mcp-cli/test-failures.log)"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lint": "bun install && bunx biome check --write .",
     "lint:check": "bun install && bunx biome check .",
     "lint:shell": "bun scripts/check-shell-injection.ts",
+    "check:phase-drift": "bun scripts/check-phase-drift.ts",
     "test": "bun install && bun test",
     "test:coverage": "bun scripts/check-coverage.ts",
     "dev:daemon": "bun packages/daemon/src/main.ts",

--- a/scripts/check-phase-drift.spec.ts
+++ b/scripts/check-phase-drift.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { check } from "./check-phase-drift.ts";
+
+describe("check-phase-drift", () => {
+  test("passes when assertNoDrift is in the run block", () => {
+    const source = `
+    if (sub === "run") {
+      const argv = args.slice(1);
+      assertNoDrift(d);
+      await runPhase(argv, d);
+      return;
+    }`;
+    expect(check(source)).toEqual({ ok: true, reason: "assertNoDrift/detectDrift found at line 4" });
+  });
+
+  test("passes when detectDrift is in the run block", () => {
+    const source = `
+    if (sub === "run") {
+      const result = detectDrift(d);
+      if (!result.ok) throw new Error("drift");
+      return;
+    }`;
+    expect(check(source)).toEqual({ ok: true, reason: "assertNoDrift/detectDrift found at line 3" });
+  });
+
+  test("passes with single-quoted run check", () => {
+    const source = `
+    if (sub === 'run') {
+      assertNoDrift(d);
+      return;
+    }`;
+    expect(check(source)).toEqual({ ok: true, reason: "assertNoDrift/detectDrift found at line 3" });
+  });
+
+  test("fails when drift call is missing from run block", () => {
+    const source = `
+    if (sub === "run") {
+      const argv = args.slice(1);
+      await runPhase(argv, d);
+      return;
+    }`;
+    const result = check(source);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("does not call assertNoDrift");
+  });
+
+  test("fails when run block is not found", () => {
+    const source = `
+    if (sub === "list") {
+      listPhases();
+      return;
+    }`;
+    const result = check(source);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("Could not find");
+  });
+
+  test("ignores assertNoDrift outside the run block", () => {
+    const source = `
+    if (sub === "install") {
+      assertNoDrift(d);
+      return;
+    }
+    if (sub === "run") {
+      await runPhase(argv, d);
+      return;
+    }`;
+    const result = check(source);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("does not call assertNoDrift");
+  });
+});

--- a/scripts/check-phase-drift.ts
+++ b/scripts/check-phase-drift.ts
@@ -1,0 +1,81 @@
+#!/usr/bin/env bun
+/**
+ * CI guard: the `sub === "run"` block in phase.ts must call assertNoDrift
+ * (or detectDrift) before dispatching. Prevents future refactors from
+ * silently dropping the drift check.
+ *
+ * Exit codes:
+ *   0 — drift guard found in the run block
+ *   1 — drift guard missing or run block not found
+ */
+
+const PHASE_PATH = new URL("../packages/command/src/commands/phase.ts", import.meta.url).pathname;
+
+const RUN_BLOCK_START = /if\s*\(\s*sub\s*===\s*["']run["']\s*\)/;
+const DRIFT_CALL = /\b(assertNoDrift|detectDrift)\s*\(/;
+
+export function check(source: string): { ok: boolean; reason: string } {
+  const lines = source.split("\n");
+
+  let runBlockLine = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (RUN_BLOCK_START.test(lines[i])) {
+      runBlockLine = i;
+      break;
+    }
+  }
+
+  if (runBlockLine === -1) {
+    return { ok: false, reason: 'Could not find `sub === "run"` block in phase.ts' };
+  }
+
+  let depth = 0;
+  let entered = false;
+  for (let i = runBlockLine; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (DRIFT_CALL.test(line)) {
+      return { ok: true, reason: `assertNoDrift/detectDrift found at line ${i + 1}` };
+    }
+
+    for (const ch of line) {
+      if (ch === "{") {
+        depth++;
+        entered = true;
+      } else if (ch === "}") {
+        depth--;
+      }
+    }
+
+    if (entered && depth === 0) break;
+  }
+
+  return {
+    ok: false,
+    reason: `The "run" block (line ${runBlockLine + 1}) does not call assertNoDrift or detectDrift`,
+  };
+}
+
+async function main(): Promise<void> {
+  const file = Bun.file(PHASE_PATH);
+  if (!(await file.exists())) {
+    process.stderr.write(`phase.ts not found at ${PHASE_PATH}\n`);
+    process.exit(1);
+  }
+
+  const source = await file.text();
+  const result = check(source);
+
+  if (result.ok) {
+    process.stderr.write(`Phase drift guard OK: ${result.reason}\n`);
+    process.exit(0);
+  }
+
+  process.stderr.write("\n  Phase drift guard FAILED\n\n");
+  process.stderr.write(`  ${result.reason}\n\n`);
+  process.stderr.write('  The "run" subcommand in phase.ts must call assertNoDrift()\n');
+  process.stderr.write("  before dispatching to prevent silent execution on stale lockfiles.\n\n");
+  process.exit(1);
+}
+
+if (import.meta.main) main();


### PR DESCRIPTION
## Summary
- Adds `scripts/check-phase-drift.ts` — a grep-based CI check that asserts the `sub === "run"` block in `phase.ts` calls `assertNoDrift` or `detectDrift` before dispatching
- Wired into `package.json` as `bun run check:phase-drift` and added to the pre-commit hook (runs after `lint:shell`)
- Exports the `check()` function for unit testing; `main()` guarded by `import.meta.main`

## Test plan
- [x] `bun run check:phase-drift` passes against current `phase.ts` (finds `assertNoDrift` at line 700)
- [x] 6 unit tests in `scripts/check-phase-drift.spec.ts` covering: assertNoDrift present, detectDrift present, single-quoted variant, missing call, missing run block, call outside run block
- [x] `bun run typecheck` passes
- [x] `bun run lint:check` passes
- [x] Pre-commit hook runs the check in the source-changes tier

Also filed #1422 for a pre-existing test failure in `check-shell-injection.spec.ts` discovered during this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)