### PR TITLE
fix(alias): strip export blocks and import.meta from bundled output (fixes #1410)

### DIFF
--- a/packages/core/src/alias-bundle.spec.ts
+++ b/packages/core/src/alias-bundle.spec.ts
@@ -117,13 +117,7 @@ describe("stripModuleSyntax", () => {
   });
 
   test("strips multi-line export default statement", () => {
-    const input = [
-      "var x = 1;",
-      "export default defineAlias({",
-      '  name: "test",',
-      "  fn: () => x",
-      "});",
-    ].join("\n");
+    const input = ["var x = 1;", "export default defineAlias({", '  name: "test",', "  fn: () => x", "});"].join("\n");
     expect(stripModuleSyntax(input).trim()).toBe("var x = 1;");
   });
 

--- a/packages/core/src/alias-bundle.spec.ts
+++ b/packages/core/src/alias-bundle.spec.ts
@@ -8,6 +8,7 @@ import {
   executeAliasBundled,
   extractMetadata,
   stripMcpCliImport,
+  stripModuleSyntax,
   stubProxy,
   validateAliasBundled,
 } from "./alias-bundle";
@@ -84,6 +85,50 @@ describe("stripMcpCliImport", () => {
     const input = `import { defineAlias } from 'mcp-cli';\nconsole.log("hello");`;
     const result = stripMcpCliImport(input);
     expect(result.trim()).toBe('console.log("hello");');
+  });
+});
+
+describe("stripModuleSyntax", () => {
+  test("strips single-line export block", () => {
+    const input = "var x = 1;\nexport { x as default };";
+    expect(stripModuleSyntax(input).trim()).toBe("var x = 1;");
+  });
+
+  test("strips multi-line export block", () => {
+    const input = "var x = 1;\nexport {\n  x as default\n};";
+    expect(stripModuleSyntax(input).trim()).toBe("var x = 1;");
+  });
+
+  test("strips export default statement", () => {
+    const input = "var x = 1;\nexport default x;";
+    expect(stripModuleSyntax(input).trim()).toBe("var x = 1;");
+  });
+
+  test("replaces import.meta with empty object", () => {
+    const input = "var url = import.meta.url;\nconsole.log(url);";
+    expect(stripModuleSyntax(input)).toContain("({}).url");
+    expect(stripModuleSyntax(input)).not.toContain("import.meta");
+  });
+
+  test("handles Bun.build typical output with import + export", () => {
+    const input = [
+      "// @bun",
+      'import { defineAlias, z } from "mcp-cli";',
+      'var define_test_default = defineAlias({ name: "test", fn: () => 42 });',
+      "export {",
+      "  define_test_default as default",
+      "};",
+    ].join("\n");
+    const result = stripModuleSyntax(input);
+    expect(result).not.toContain("import");
+    expect(result).not.toContain("export");
+    expect(result).toContain("define_test_default");
+  });
+
+  test("backwards compat alias stripMcpCliImport works", () => {
+    const input = `import { z } from "mcp-cli";\nexport { z as default };`;
+    const result = stripMcpCliImport(input);
+    expect(result.trim()).toBe("");
   });
 });
 
@@ -351,6 +396,43 @@ describe("executeAliasBundled", () => {
       true,
     );
     expect(result).toEqual({ message: "hello" });
+  });
+
+  test("executes export default defineAlias script (issue #1410)", async () => {
+    const dir = makeTmpDir();
+    const scriptPath = join(dir, "export-default.ts");
+    writeFileSync(
+      scriptPath,
+      [
+        'import { defineAlias, z } from "mcp-cli";',
+        "export default defineAlias({",
+        '  name: "test-define",',
+        '  description: "test",',
+        "  input: z.object({ msg: z.string() }),",
+        "  handler: async (input) => ({ echoed: input.msg }),",
+        "  fn: async (input) => ({ echoed: input.msg }),",
+        "});",
+      ].join("\n"),
+    );
+
+    const { js } = await bundleAlias(scriptPath);
+    const result = await executeAliasBundled(
+      js,
+      { msg: "hi" },
+      {
+        mcp: stubProxy,
+        args: {},
+        file: async () => "",
+        json: async () => null,
+        cache: async (_k, p) => p(),
+        state: stubState,
+        globalState: stubState,
+        workItem: null,
+      },
+      true,
+    );
+
+    expect(result).toEqual({ echoed: "hi" });
   });
 
   test("freeform script returns undefined", async () => {

--- a/packages/core/src/alias-bundle.spec.ts
+++ b/packages/core/src/alias-bundle.spec.ts
@@ -86,6 +86,18 @@ describe("stripMcpCliImport", () => {
     const result = stripMcpCliImport(input);
     expect(result.trim()).toBe('console.log("hello");');
   });
+
+  test("strips side-effect import", () => {
+    const input = `import "mcp-cli";\nconsole.log("hello");`;
+    const result = stripMcpCliImport(input);
+    expect(result.trim()).toBe('console.log("hello");');
+  });
+
+  test("strips side-effect import with single quotes", () => {
+    const input = `import 'mcp-cli';\nconsole.log("hello");`;
+    const result = stripMcpCliImport(input);
+    expect(result.trim()).toBe('console.log("hello");');
+  });
 });
 
 describe("stripModuleSyntax", () => {
@@ -101,6 +113,22 @@ describe("stripModuleSyntax", () => {
 
   test("strips export default statement", () => {
     const input = "var x = 1;\nexport default x;";
+    expect(stripModuleSyntax(input).trim()).toBe("var x = 1;");
+  });
+
+  test("strips multi-line export default statement", () => {
+    const input = [
+      "var x = 1;",
+      "export default defineAlias({",
+      '  name: "test",',
+      "  fn: () => x",
+      "});",
+    ].join("\n");
+    expect(stripModuleSyntax(input).trim()).toBe("var x = 1;");
+  });
+
+  test("strips side-effect import of mcp-cli", () => {
+    const input = `import "mcp-cli";\nvar x = 1;`;
     expect(stripModuleSyntax(input).trim()).toBe("var x = 1;");
   });
 

--- a/packages/core/src/alias-bundle.ts
+++ b/packages/core/src/alias-bundle.ts
@@ -93,15 +93,18 @@ export function stripModuleSyntax(bundledJs: string): string {
   // ESM: import { ... } from "mcp-cli";  or  import ... from "mcp-cli";
   // Uses [^;]*? to handle multi-line imports from Bun.build (e.g. import {\n  defineAlias,\n  z\n} from "mcp-cli";)
   const esmPattern = /^import\b[^;]*?from\s+["']mcp-cli["'];?[ \t]*$/gms;
+  // Side-effect import: import "mcp-cli";
+  const esmSideEffectPattern = /^import\s+["']mcp-cli["'];?[ \t]*$/gm;
   // CJS: var/const/let { ... } = require("mcp-cli");
   const cjsPattern = /^(?:var|const|let)\s+.*=\s*require\(["']mcp-cli["']\);?\s*$/gm;
   // export { ... };  (possibly multi-line, as Bun.build emits for default exports)
   const exportBlockPattern = /^export\s*\{[^}]*\};?[ \t]*$/gms;
-  // export default <expr>;
-  const exportDefaultPattern = /^export\s+default\b[^;]*;?[ \t]*$/gm;
+  // export default <expr>; — dotall so it matches multi-line (e.g. export default defineAlias({\n...\n});)
+  const exportDefaultPattern = /^export\s+default\b[^;]*;[ \t]*$/gms;
 
   return bundledJs
     .replace(esmPattern, "")
+    .replace(esmSideEffectPattern, "")
     .replace(cjsPattern, "")
     .replace(exportBlockPattern, "")
     .replace(exportDefaultPattern, "")

--- a/packages/core/src/alias-bundle.ts
+++ b/packages/core/src/alias-bundle.ts
@@ -3,7 +3,7 @@
  *
  * Replaces the Worker + bun.plugin() virtual module approach with:
  * 1. Bun.build to bundle alias scripts (externalizing "mcp-cli")
- * 2. stripMcpCliImport to remove the external import from bundled output
+ * 2. stripModuleSyntax to remove module-level constructs from bundled output
  * 3. AsyncFunction eval with injected dependencies
  *
  * This eliminates segfaults caused by concurrent import() with cache-busting
@@ -81,24 +81,35 @@ export async function computeSourceHash(sourcePath: string): Promise<string> {
 }
 
 /**
- * Strip the "mcp-cli" import/require from Bun.build output.
+ * Strip module syntax from Bun.build output so it can run inside AsyncFunction.
  *
- * Bun.build with external: ["mcp-cli"] produces either:
- * - ESM: import { defineAlias, z, ... } from "mcp-cli";
- * - CJS: var/const { ... } = require("mcp-cli");
- *
- * We remove these lines so the bundled code can be eval'd with
- * injected dependencies.
+ * Removes:
+ * 1. "mcp-cli" imports (ESM and CJS) — dependencies are injected at eval time
+ * 2. export blocks (`export { ... };` and `export default ...`) — Bun.build adds
+ *    these for the module's default export, but AsyncFunction bodies aren't modules
+ * 3. import.meta references — replaced with a plain object stub
  */
-export function stripMcpCliImport(bundledJs: string): string {
+export function stripModuleSyntax(bundledJs: string): string {
   // ESM: import { ... } from "mcp-cli";  or  import ... from "mcp-cli";
   // Uses [^;]*? to handle multi-line imports from Bun.build (e.g. import {\n  defineAlias,\n  z\n} from "mcp-cli";)
   const esmPattern = /^import\b[^;]*?from\s+["']mcp-cli["'];?[ \t]*$/gms;
   // CJS: var/const/let { ... } = require("mcp-cli");
   const cjsPattern = /^(?:var|const|let)\s+.*=\s*require\(["']mcp-cli["']\);?\s*$/gm;
+  // export { ... };  (possibly multi-line, as Bun.build emits for default exports)
+  const exportBlockPattern = /^export\s*\{[^}]*\};?[ \t]*$/gms;
+  // export default <expr>;
+  const exportDefaultPattern = /^export\s+default\b[^;]*;?[ \t]*$/gm;
 
-  return bundledJs.replace(esmPattern, "").replace(cjsPattern, "");
+  return bundledJs
+    .replace(esmPattern, "")
+    .replace(cjsPattern, "")
+    .replace(exportBlockPattern, "")
+    .replace(exportDefaultPattern, "")
+    .replace(/\bimport\.meta\b/g, "({})");
 }
+
+/** @deprecated Use stripModuleSyntax — kept for backwards compatibility of test imports */
+export const stripMcpCliImport = stripModuleSyntax;
 
 /**
  * Eval bundled alias JS with injected context, capturing any defineAlias call.
@@ -116,7 +127,7 @@ async function evalBundledJs(
   },
   timeoutMs?: number,
 ): Promise<AliasDefinition | null> {
-  const stripped = stripMcpCliImport(bundledJs);
+  const stripped = stripModuleSyntax(bundledJs);
 
   let captured: AliasDefinition | null = null;
 


### PR DESCRIPTION
## Summary
- Extends `stripMcpCliImport` (renamed to `stripModuleSyntax`) to also strip `export { ... }` blocks, `export default` statements, and replace `import.meta` with `({})` — all module-level constructs that are syntax errors inside `AsyncFunction` eval
- Adds 7 new unit tests for the stripping behavior plus an integration test reproducing the exact `export default defineAlias(...)` pattern from the issue
- Keeps `stripMcpCliImport` as a backwards-compat alias

## Test plan
- [x] New `stripModuleSyntax` unit tests: export blocks, export default, import.meta, combined Bun.build output
- [x] Integration test: `export default defineAlias(...)` script bundles and executes correctly
- [x] All 5079 existing tests pass (0 failures)
- [x] Typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)