### PR TITLE
fix(compat): enforce Bun >=1.2.18 with startup version check (fixes #1413)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@theshadow27/mcp-cli",
+  "engines": {
+    "bun": ">=1.2.18"
+  },
   "version": "1.5.1",
   "description": "MCP CLI — call MCP server tools from the command line with zero context overhead",
   "type": "module",

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -21,9 +21,12 @@ import {
   PING_TIMEOUT_MS,
   ProtocolMismatchError,
   VERSION,
+  assertBunVersion,
   maybeShowTelemetryNotice,
   recordCommand,
 } from "@mcp-cli/core";
+
+assertBunVersion();
 import { cmdAdd, cmdAddJson } from "./commands/add";
 import { cmdAgent } from "./commands/agent";
 import { cmdAlias } from "./commands/alias";

--- a/packages/control/src/main.tsx
+++ b/packages/control/src/main.tsx
@@ -5,7 +5,10 @@
  * TUI for managing the mcpd daemon: connection status, auth, logs.
  */
 
+import { assertBunVersion } from "@mcp-cli/core";
 import { render } from "ink";
+
+assertBunVersion();
 import React from "react";
 import { App } from "./app.js";
 

--- a/packages/core/src/bun-version.spec.ts
+++ b/packages/core/src/bun-version.spec.ts
@@ -13,8 +13,8 @@ describe("assertBunVersion", () => {
     const stderrSpy = spyOn(process.stderr, "write").mockImplementation(() => true);
 
     try {
-      // Current Bun version must be >= 1.2.18 for tests to run at all
       expect(() => assertBunVersion(MIN_BUN_VERSION)).not.toThrow();
+      expect(stderrSpy).not.toHaveBeenCalled();
     } finally {
       exitSpy.mockRestore();
       stderrSpy.mockRestore();
@@ -51,6 +51,68 @@ describe("assertBunVersion", () => {
     try {
       // Any currently-shipping Bun (>=1.2.18) should satisfy a >=1.2.0 requirement
       expect(() => assertBunVersion("1.2.0")).not.toThrow();
+      expect(stderrSpy).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+      stderrSpy.mockRestore();
+    }
+  });
+
+  // Boundary tests using the injectable `current` parameter
+  it("exits when injected version is one patch below minimum", () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+    const stderrSpy = spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    try {
+      expect(() => assertBunVersion("1.2.18", "1.2.17")).toThrow("process.exit called");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+    } finally {
+      exitSpy.mockRestore();
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it("does not exit when injected version exactly matches minimum", () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+    const stderrSpy = spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    try {
+      expect(() => assertBunVersion("1.2.18", "1.2.18")).not.toThrow();
+      expect(stderrSpy).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it("does not exit for a canary build at the exact minimum version", () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+    const stderrSpy = spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    try {
+      expect(() => assertBunVersion("1.2.18", "1.2.18-canary.20250401")).not.toThrow();
+      expect(stderrSpy).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it("exits for a canary build below the minimum version", () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+    const stderrSpy = spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    try {
+      expect(() => assertBunVersion("1.2.18", "1.2.17-canary.20250401")).toThrow("process.exit called");
+      expect(exitSpy).toHaveBeenCalledWith(1);
     } finally {
       exitSpy.mockRestore();
       stderrSpy.mockRestore();

--- a/packages/core/src/bun-version.spec.ts
+++ b/packages/core/src/bun-version.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, spyOn } from "bun:test";
+import { MIN_BUN_VERSION, assertBunVersion } from "./bun-version";
+
+describe("assertBunVersion", () => {
+  it("MIN_BUN_VERSION is 1.2.18", () => {
+    expect(MIN_BUN_VERSION).toBe("1.2.18");
+  });
+
+  it("does not exit when current Bun version meets the minimum", () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+    const stderrSpy = spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    try {
+      // Current Bun version must be >= 1.2.18 for tests to run at all
+      expect(() => assertBunVersion(MIN_BUN_VERSION)).not.toThrow();
+    } finally {
+      exitSpy.mockRestore();
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it("exits 1 with a clear message when version is too old", () => {
+    const messages: string[] = [];
+    const stderrSpy = spyOn(process.stderr, "write").mockImplementation((msg) => {
+      messages.push(String(msg));
+      return true;
+    });
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+
+    try {
+      expect(() => assertBunVersion("999.0.0")).toThrow("process.exit called");
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      expect(messages.join("")).toContain("requires Bun >=999.0.0");
+      expect(messages.join("")).toContain("bun upgrade");
+    } finally {
+      stderrSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
+
+  it("does not exit when minimum is a known-older Bun release", () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit called");
+    });
+    const stderrSpy = spyOn(process.stderr, "write").mockImplementation(() => true);
+
+    try {
+      // Any currently-shipping Bun (>=1.2.18) should satisfy a >=1.2.0 requirement
+      expect(() => assertBunVersion("1.2.0")).not.toThrow();
+    } finally {
+      exitSpy.mockRestore();
+      stderrSpy.mockRestore();
+    }
+  });
+});

--- a/packages/core/src/bun-version.ts
+++ b/packages/core/src/bun-version.ts
@@ -5,10 +5,15 @@ export const MIN_BUN_VERSION = "1.2.18";
 /**
  * Exits with a clear error if the running Bun version is older than minVersion.
  * Call this at the top of each entry-point main() before any other work.
+ *
+ * @param current - injectable for testing; defaults to Bun.version
  */
-export function assertBunVersion(minVersion: string = MIN_BUN_VERSION): void {
-  const current = Bun.version;
-  if (compareVersions(current, minVersion) > 0) {
+export function assertBunVersion(minVersion: string = MIN_BUN_VERSION, current: string = Bun.version): void {
+  // Strip pre-release/build metadata: 1.2.18-canary.X satisfies >=1.2.18.
+  const currentBase = current.split(/[-+]/)[0];
+  // compareVersions(a, b) returns positive if b > a (see upgrade.ts JSDoc — non-standard).
+  // So > 0 here means minVersion > currentBase, i.e. the running Bun is too old.
+  if (compareVersions(currentBase, minVersion) > 0) {
     process.stderr.write(
       `error: mcp-cli requires Bun >=${minVersion}, found ${current}\n  upgrade with: bun upgrade\n`,
     );

--- a/packages/core/src/bun-version.ts
+++ b/packages/core/src/bun-version.ts
@@ -1,0 +1,17 @@
+import { compareVersions } from "./upgrade";
+
+export const MIN_BUN_VERSION = "1.2.18";
+
+/**
+ * Exits with a clear error if the running Bun version is older than minVersion.
+ * Call this at the top of each entry-point main() before any other work.
+ */
+export function assertBunVersion(minVersion: string = MIN_BUN_VERSION): void {
+  const current = Bun.version;
+  if (compareVersions(current, minVersion) > 0) {
+    process.stderr.write(
+      `error: mcp-cli requires Bun >=${minVersion}, found ${current}\n  upgrade with: bun upgrade\n`,
+    );
+    process.exit(1);
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -38,3 +38,4 @@ export * from "./work-item";
 export * from "./telemetry";
 export * from "./phase-source";
 export * from "./mcp-proxy";
+export * from "./bun-version";

--- a/packages/daemon/src/main.ts
+++ b/packages/daemon/src/main.ts
@@ -5,7 +5,10 @@
  * isn't penalized by untestable process-level boilerplate.
  */
 
+import { assertBunVersion } from "@mcp-cli/core";
 import { startDaemon } from "./index";
+
+assertBunVersion();
 
 /**
  * Worker entries that can be dispatched via argv in compiled binaries.


### PR DESCRIPTION
## Summary
- Add `assertBunVersion()` in `packages/core/src/bun-version.ts` that checks `Bun.version` at startup and exits with a clear error + upgrade hint when the version is too old
- Call it as the first thing in all three entry points (`mcx`, `mcpd`, `mcpctl`)
- Add `"engines": { "bun": ">=1.2.18" }` to `package.json` so tooling can detect the requirement before running

## Test plan
- [x] `bun test packages/core/src/bun-version.spec.ts` — 4 tests covering: MIN_BUN_VERSION constant, no-exit on meeting minimum, exits 1 with clear message on too-old version, no-exit on older minimum
- [x] `bun --bun tsc -b` — no TypeScript errors
- [x] `bunx biome check` — no lint errors
- [x] Full test suite: 5098 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)