### PR TITLE
fix(alias): dispatch worker entries via argv in compiled binaries (fixes #1411)

### DIFF
--- a/packages/daemon/src/main.spec.ts
+++ b/packages/daemon/src/main.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { resolveWorkerEntry } from "./main";
+
+describe("resolveWorkerEntry", () => {
+  test("returns module path for ./alias-executor.ts", () => {
+    expect(resolveWorkerEntry(["/path/to/mcpd", "./alias-executor.ts"])).toBe("./alias-executor.ts");
+  });
+
+  test("returns module path for absolute path ending in alias-executor.ts", () => {
+    expect(resolveWorkerEntry(["/path/to/mcpd", "/some/dir/alias-executor.ts"])).toBe("./alias-executor.ts");
+  });
+
+  test("returns undefined for normal daemon startup (no args)", () => {
+    expect(resolveWorkerEntry(["/path/to/mcpd"])).toBeUndefined();
+  });
+
+  test("returns undefined for empty argv", () => {
+    expect(resolveWorkerEntry([])).toBeUndefined();
+  });
+
+  test("returns undefined for unrecognized worker path", () => {
+    expect(resolveWorkerEntry(["/path/to/mcpd", "./not-a-worker.ts"])).toBeUndefined();
+  });
+});

--- a/packages/daemon/src/main.ts
+++ b/packages/daemon/src/main.ts
@@ -7,6 +7,29 @@
 
 import { startDaemon } from "./index";
 
+/**
+ * Worker entries that can be dispatched via argv in compiled binaries.
+ *
+ * In compiled mode, Bun.spawn([process.execPath, './alias-executor.ts'])
+ * re-invokes the mcpd binary with the worker path as an argument. Without
+ * this dispatch, the binary unconditionally starts a second daemon (#1411).
+ */
+const WORKER_ENTRIES: Record<string, string> = {
+  "alias-executor.ts": "./alias-executor.ts",
+};
+
+/** Check if argv indicates a worker subprocess dispatch. */
+export function resolveWorkerEntry(argv: string[]): string | undefined {
+  const lastArg = argv.at(-1);
+  if (!lastArg) return undefined;
+  for (const [suffix, modulePath] of Object.entries(WORKER_ENTRIES)) {
+    if (lastArg === `./${suffix}` || lastArg.endsWith(`/${suffix}`)) {
+      return modulePath;
+    }
+  }
+  return undefined;
+}
+
 async function main(): Promise<void> {
   // Prevent EPIPE on stderr from crashing the daemon when the parent
   // terminal disconnects. This is a safety net — individual write sites
@@ -44,8 +67,13 @@ async function main(): Promise<void> {
 }
 
 if (import.meta.main) {
-  main().catch((err) => {
-    console.error("[mcpd] Fatal:", err);
-    process.exit(1);
-  });
+  const workerEntry = resolveWorkerEntry(process.argv);
+  if (workerEntry) {
+    import(workerEntry);
+  } else {
+    main().catch((err) => {
+      console.error("[mcpd] Fatal:", err);
+      process.exit(1);
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- In compiled binaries, `spawnExecutor()` re-invokes `process.execPath` (the mcpd binary) with `./alias-executor.ts` as an argument, but `main.ts` unconditionally starts a daemon — so the subprocess starts a second daemon instead of running the executor
- Added `resolveWorkerEntry()` argv dispatch at the top of `main.ts`: if the last argv element matches a known worker entry, dynamically imports it instead of calling `startDaemon()`
- Extensible via `WORKER_ENTRIES` map for any future subprocess workers that use the same `Bun.spawn([process.execPath, path])` pattern

## Test plan
- [x] Added `main.spec.ts` with 5 tests covering: `./alias-executor.ts` match, absolute path match, no-args daemon startup, empty argv, and unrecognized worker paths
- [x] `bun typecheck` passes
- [x] `bun lint` passes — no fixes needed
- [x] `bun test` — all 5077 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)