### PR TITLE
fix(jq): surface actionable error when --jq receives non-JSON response (fixes #1414)

### DIFF
--- a/packages/command/src/jq/index.ts
+++ b/packages/command/src/jq/index.ts
@@ -80,6 +80,22 @@ export async function applyJqFilter(data: unknown, filter: string): Promise<unkn
 }
 
 // ============================================================================
+// JQ parse error diagnostics
+// ============================================================================
+
+/**
+ * Build a user-friendly error message when --jq receives non-JSON text.
+ * Returns an array of lines suitable for printing to stderr.
+ */
+export function jqParseErrorHints(text: string): string[] {
+  const preview = text.slice(0, 120).replace(/\n/g, " ");
+  return [
+    `--jq filter requires JSON but the response is plain text: "${preview}..."`,
+    "The server may have truncated or transformed the response. Try adding raw:true to the tool arguments, or use a server-side jq parameter if the tool supports one.",
+  ];
+}
+
+// ============================================================================
 // Structure Analysis (ported from phoenix-octovalve)
 // ============================================================================
 

--- a/packages/command/src/jq/jq.spec.ts
+++ b/packages/command/src/jq/jq.spec.ts
@@ -7,6 +7,7 @@ import {
   analyzeStructure,
   applyJqFilter,
   generateAnalysis,
+  jqParseErrorHints,
 } from "./index";
 
 describe("applyJqFilter", () => {
@@ -80,6 +81,31 @@ describe("analyzeStructure", () => {
   test("handles nested objects", () => {
     const paths = analyzeStructure({ a: { b: { c: 42 } } });
     expect(paths.get("a.b.c")).toMatchObject({ type: "number", count: 1 });
+  });
+});
+
+describe("jqParseErrorHints", () => {
+  test("returns hints for truncated server response", () => {
+    const text = "Response too large (81.8KB). Structure analysis:\n\n  entities[].contacts: array";
+    const hints = jqParseErrorHints(text);
+    expect(hints).toHaveLength(2);
+    expect(hints[0]).toContain("--jq filter requires JSON");
+    expect(hints[0]).toContain("Response too large");
+    expect(hints[1]).toContain("raw:true");
+    expect(hints[1]).toContain("server-side jq");
+  });
+
+  test("truncates long previews to 120 chars", () => {
+    const text = "x".repeat(200);
+    const hints = jqParseErrorHints(text);
+    expect(hints[0]).toContain(`"${"x".repeat(120)}..."`);
+  });
+
+  test("replaces newlines in preview", () => {
+    const text = "line1\nline2\nline3";
+    const hints = jqParseErrorHints(text);
+    expect(hints[0]).toContain("line1 line2 line3");
+    expect(hints[0]).not.toContain("\n");
   });
 });
 

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -70,7 +70,7 @@ import { checkDeprecatedName } from "./deprecation";
 import { maybeAutoSaveEphemeral } from "./ephemeral";
 import { readFileWithLimit } from "./file-read";
 import { maybeShowFirstRunPrompt } from "./first-run";
-import { SIZE_HINT, SIZE_OK, applyJqFilter, generateAnalysis } from "./jq/index";
+import { SIZE_HINT, SIZE_OK, applyJqFilter, generateAnalysis, jqParseErrorHints } from "./jq/index";
 import {
   extractErrorMessage,
   formatToolResult,
@@ -556,8 +556,16 @@ async function cmdCall(args: string[]): Promise<void> {
   // Explicit --jq filter: apply client-side regardless of size/env
   if (jqFilter) {
     const formatted = formatToolResult(result);
+    let data: unknown;
     try {
-      const data = JSON.parse(formatted);
+      data = JSON.parse(formatted);
+    } catch {
+      for (const hint of jqParseErrorHints(formatted)) {
+        printError(hint);
+      }
+      process.exit(1);
+    }
+    try {
       const filtered = await applyJqFilter(data, jqFilter);
       console.log(JSON.stringify(filtered, null, 2));
     } catch (err) {


### PR DESCRIPTION
## Summary
- When `--jq` receives non-JSON (e.g., server-side "Response too large" truncation), mcx now shows a clear error explaining the response is plain text, with suggestions to use `raw:true` or server-side `jq` parameter
- Extracted `jqParseErrorHints()` helper for testability — previews the first 120 chars of the response with newlines collapsed
- Previously showed cryptic `JSON Parse error: Unexpected identifier "Response"` which caused users to lose confidence in `--jq` and fall back to piping through system jq

## Test plan
- [x] 3 new unit tests for `jqParseErrorHints` (truncated response, long preview, newline handling)
- [x] Full test suite passes (5075 tests, 0 failures)
- [x] TypeScript typecheck passes
- [x] Lint passes
- [x] Coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)