### PR TITLE
fix(tests): move comment-line case to shouldMatch in check-shell-injection.spec (closes #1422)

### DIFF
--- a/scripts/check-shell-injection.spec.ts
+++ b/scripts/check-shell-injection.spec.ts
@@ -14,6 +14,7 @@ describe("check-shell-injection pattern", () => {
     "execFileSync(`/bin/sh -c ${cmd}`)",
     "execSync(  `foo ${bar}`)",
     "execSync(`${cmd}`)",
+    "// execSync(`git commit -m ${msg}`)", // comment lines are flagged — regex can't distinguish
   ];
 
   const shouldNotMatch = [
@@ -23,7 +24,6 @@ describe("check-shell-injection pattern", () => {
     "execSync(`git add -A`, opts)",
     'spawnSync("git", ["commit", "-m", msg], opts)',
     'execFileSync("git", ["commit", "-m", msg], opts)',
-    "// execSync(`git commit -m ${msg}`)", // comment — but regex doesn't know; acceptable false positive
   ];
 
   for (const line of shouldMatch) {


### PR DESCRIPTION
## Summary
- The `shouldNotMatch` list in `scripts/check-shell-injection.spec.ts` included a commented-out `execSync` line that the regex correctly flags (it has no comment awareness)
- Moved the case to `shouldMatch` with an explanatory inline comment — this accurately documents the known limitation

## Test plan
- [ ] `bun typecheck` passes
- [ ] `bun lint` passes
- [ ] `bun test` passes (5099 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)