### PR TITLE
feat(phases): clearer missing-field errors + auto-populate branch (fixes #1424)

### DIFF
--- a/.claude/phases/done.ts
+++ b/.claude/phases/done.ts
@@ -133,8 +133,16 @@ defineAlias({
   }),
   fn: async (_input, ctx) => {
     const work = ctx.workItem;
-    if (!work || work.prNumber == null || work.issueNumber == null) {
-      throw new Error("phase-done requires a work item with prNumber and issueNumber");
+    if (!work) {
+      throw new Error("phase-done requires a work item (got: null)");
+    }
+    const missing: string[] = [];
+    if (work.prNumber == null) missing.push("prNumber");
+    if (work.issueNumber == null) missing.push("issueNumber");
+    if (missing.length > 0) {
+      throw new Error(
+        `phase-done requires ${missing.map((f) => `'${f}'`).join(" and ")} on the work item ${work.id} (missing: ${missing.join(", ")})`,
+      );
     }
 
     const result = mergePr(work.prNumber);

--- a/.claude/phases/needs-attention.ts
+++ b/.claude/phases/needs-attention.ts
@@ -23,8 +23,16 @@ defineAlias({
   }),
   fn: async (_input, ctx) => {
     const work = ctx.workItem;
-    if (!work || work.prNumber == null || work.issueNumber == null) {
-      throw new Error("phase-needs-attention requires a work item with prNumber and issueNumber");
+    if (!work) {
+      throw new Error("phase-needs-attention requires a work item (got: null)");
+    }
+    const missing: string[] = [];
+    if (work.prNumber == null) missing.push("prNumber");
+    if (work.issueNumber == null) missing.push("issueNumber");
+    if (missing.length > 0) {
+      throw new Error(
+        `phase-needs-attention requires ${missing.map((f) => `'${f}'`).join(" and ")} on the work item ${work.id} (missing: ${missing.join(", ")})`,
+      );
     }
 
     const reviewRound = (await ctx.state.get<number>("review_round")) ?? 0;

--- a/.claude/phases/qa.ts
+++ b/.claude/phases/qa.ts
@@ -63,8 +63,17 @@ defineAlias({
   }),
   fn: async (input, ctx) => {
     const work = ctx.workItem;
-    if (!work || work.prNumber == null || work.branch == null || work.issueNumber == null) {
-      throw new Error("phase-qa requires a work item with issueNumber, branch, prNumber");
+    if (!work) {
+      throw new Error("phase-qa requires a work item (got: null)");
+    }
+    const missing: string[] = [];
+    if (work.issueNumber == null) missing.push("issueNumber");
+    if (work.branch == null) missing.push("branch");
+    if (work.prNumber == null) missing.push("prNumber");
+    if (missing.length > 0) {
+      throw new Error(
+        `phase-qa requires ${missing.map((f) => `'${f}'`).join(" and ")} on the work item ${work.id} (missing: ${missing.join(", ")})`,
+      );
     }
 
     const sessionId = await ctx.state.get<string>("qa_session_id");

--- a/.claude/phases/repair.ts
+++ b/.claude/phases/repair.ts
@@ -50,8 +50,11 @@ defineAlias({
   }),
   fn: async (input, ctx) => {
     const work = ctx.workItem;
-    if (!work || work.prNumber == null) {
-      throw new Error("phase-repair requires a work item with prNumber");
+    if (!work) {
+      throw new Error("phase-repair requires a work item (got: null)");
+    }
+    if (work.prNumber == null) {
+      throw new Error(`phase-repair requires 'prNumber' on the work item ${work.id} (missing: prNumber)`);
     }
 
     // In-flight guard — repair session already running; don't spawn a second.

--- a/.claude/phases/repair.ts
+++ b/.claude/phases/repair.ts
@@ -53,8 +53,12 @@ defineAlias({
     if (!work) {
       throw new Error("phase-repair requires a work item (got: null)");
     }
-    if (work.prNumber == null) {
-      throw new Error(`phase-repair requires 'prNumber' on the work item ${work.id} (missing: prNumber)`);
+    const missing: string[] = [];
+    if (work.prNumber == null) missing.push("prNumber");
+    if (missing.length > 0) {
+      throw new Error(
+        `phase-repair requires ${missing.map((f) => `'${f}'`).join(" and ")} on the work item ${work.id} (missing: ${missing.join(", ")})`,
+      );
     }
 
     // In-flight guard — repair session already running; don't spawn a second.

--- a/.claude/phases/review.ts
+++ b/.claude/phases/review.ts
@@ -60,8 +60,16 @@ defineAlias({
   }),
   fn: async (input, ctx) => {
     const work = ctx.workItem;
-    if (!work || work.prNumber == null || work.branch == null) {
-      throw new Error("phase-review requires a work item with prNumber and branch");
+    if (!work) {
+      throw new Error("phase-review requires a work item (got: null)");
+    }
+    const missing: string[] = [];
+    if (work.prNumber == null) missing.push("prNumber");
+    if (work.branch == null) missing.push("branch");
+    if (missing.length > 0) {
+      throw new Error(
+        `phase-review requires ${missing.map((f) => `'${f}'`).join(" and ")} on the work item ${work.id} (missing: ${missing.join(", ")})`,
+      );
     }
 
     const round = (await ctx.state.get<number>("review_round")) ?? 1;

--- a/.claude/phases/triage.ts
+++ b/.claude/phases/triage.ts
@@ -27,8 +27,16 @@ defineAlias({
   }),
   fn: async (input, ctx) => {
     const work = ctx.workItem;
-    if (!work || work.issueNumber == null || work.branch == null) {
-      throw new Error("phase-triage requires a work item with issueNumber and branch");
+    if (!work) {
+      throw new Error("phase-triage requires a work item (got: null)");
+    }
+    const missing: string[] = [];
+    if (work.issueNumber == null) missing.push("issueNumber");
+    if (work.branch == null) missing.push("branch");
+    if (missing.length > 0) {
+      throw new Error(
+        `phase-triage requires ${missing.map((f) => `'${f}'`).join(" and ")} on the work item ${work.id} (missing: ${missing.join(", ")})`,
+      );
     }
 
     // Resolve PR number via gh. Work item's prNumber is authoritative when set.

--- a/.mcx.lock
+++ b/.mcx.lock
@@ -29,7 +29,7 @@
     {
       "name": "repair",
       "resolvedPath": ".claude/phases/repair.ts",
-      "contentHash": "dd75cd5637a8481abfe3ab8447e9fd3719eefc0c62ddb457989f83559f56eb54",
+      "contentHash": "824566acb436e05cd7f38db20d2dafbb3784f7faf8020ab0c9e51f5069a07ef1",
       "schemaHash": "6087a7acbe537a99be7fc67a113aa452d2c3278063982cd662c14d0f61ec77bf"
     },
     {

--- a/.mcx.lock
+++ b/.mcx.lock
@@ -5,7 +5,7 @@
     {
       "name": "done",
       "resolvedPath": ".claude/phases/done.ts",
-      "contentHash": "490c20788b900ad3388b3dc8b74f961d332203e3d9b7eafc5c144f307d46f93e",
+      "contentHash": "398f0542f9a47f27067a8c4c371312f059d2b02248eaba310df6b6d412fd957b",
       "schemaHash": "9372884f31b3b15e6e376bde8800b6a47f97230a4e3faf96f0948d1255b64262"
     },
     {
@@ -17,31 +17,31 @@
     {
       "name": "needs-attention",
       "resolvedPath": ".claude/phases/needs-attention.ts",
-      "contentHash": "a75d70a8fcaa6812ba4bc3ede150f95ef048d0bf0b4f5cf468d4d1afb8f46c10",
+      "contentHash": "bda9ee83b3ad735e90e4e77e7cff658eda27d3d4dfda1b7c74e991f7b401ba19",
       "schemaHash": "acee09becf66bc4ce4a92a0a0533840eb0c988f0f2eb0f6eac3a77227ed5267a"
     },
     {
       "name": "qa",
       "resolvedPath": ".claude/phases/qa.ts",
-      "contentHash": "f0e08e9c4c2095b0bceb204f384c7fc4d28109b5fee400607513dbed86a2d4f8",
+      "contentHash": "20c6ac88fa2617869fe72559f2cea9e3c75cb587eb8ea26e3097cb120ace5155",
       "schemaHash": "66b1bd5b7c26aa20da4c2ff6e00833f356f498cfd11db3c91a465677355b4682"
     },
     {
       "name": "repair",
       "resolvedPath": ".claude/phases/repair.ts",
-      "contentHash": "e2748f7129c1c6cb3659c06208c3d0be1b84e6137396de9e84898e408ed38017",
+      "contentHash": "dd75cd5637a8481abfe3ab8447e9fd3719eefc0c62ddb457989f83559f56eb54",
       "schemaHash": "6087a7acbe537a99be7fc67a113aa452d2c3278063982cd662c14d0f61ec77bf"
     },
     {
       "name": "review",
       "resolvedPath": ".claude/phases/review.ts",
-      "contentHash": "092c9d2ee3485e70bf54ba233c304b30f7a59dc49e21f529a3f1eaf48af6e76a",
+      "contentHash": "aa4f1a4d739024598a370232e642449c3b31f03958bb017fe63740e7e8fed337",
       "schemaHash": "cdfdf6e6f31057a2d3dd8add0c4ed9680db448709e1c099e401edfe9debb274b"
     },
     {
       "name": "triage",
       "resolvedPath": ".claude/phases/triage.ts",
-      "contentHash": "a9faf0bec46033aba32f303011f3a31c587ca6628a1278356973f924204619ae",
+      "contentHash": "e857549d1c4703ff32576cd3a2960b4aa29f94129217fd66addd5acc209b7759",
       "schemaHash": "413c819e04458a7974767cb5940778bf30622d01836e4d80722689870103a728"
     }
   ]

--- a/packages/daemon/src/db/work-items.ts
+++ b/packages/daemon/src/db/work-items.ts
@@ -222,6 +222,21 @@ export class WorkItemDb {
     return row ? rowToWorkItem(row) : null;
   }
 
+  /**
+   * Atomically set `branch` only when it is currently NULL. Returns true if
+   * the row was updated, false if the row is missing or already has a branch.
+   *
+   * Closes the TOCTOU window in the auto-populate flow (#1424 round 3): a
+   * concurrent writer setting an explicit branch between a read and this
+   * call cannot be clobbered because the WHERE clause filters on branch IS NULL.
+   */
+  setBranchIfNull(id: string, branch: string): boolean {
+    const result = this.db
+      .prepare("UPDATE work_items SET branch = $branch, updated_at = datetime('now') WHERE id = $id AND branch IS NULL")
+      .run({ $id: id, $branch: branch });
+    return result.changes > 0;
+  }
+
   updateWorkItem(id: string, patch: Partial<WorkItem>, opts?: { forced?: boolean; forceReason?: string }): WorkItem {
     const existing = this.getWorkItem(id);
     if (!existing) {

--- a/packages/daemon/src/github/resolve-branch.spec.ts
+++ b/packages/daemon/src/github/resolve-branch.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { resolveBranchFromPr } from "./resolve-branch";
+
+const repo = { owner: "octo", repo: "cat" };
+
+function fakeProc(opts: {
+  stdout?: string;
+  exitCode?: number;
+  exitDelayMs?: number;
+  killable?: boolean;
+}): ReturnType<typeof Bun.spawn> {
+  let killed = false;
+  let resolveExit: (code: number) => void;
+  const exited = new Promise<number>((resolve) => {
+    resolveExit = resolve;
+  });
+  const timer = setTimeout(() => {
+    if (!killed) resolveExit(opts.exitCode ?? 0);
+  }, opts.exitDelayMs ?? 0);
+
+  return {
+    exited,
+    kill: () => {
+      killed = true;
+      clearTimeout(timer);
+      resolveExit(143); // SIGTERM conventional
+    },
+    stdout: new Response(opts.stdout ?? "").body,
+    stderr: new Response("").body,
+  } as unknown as ReturnType<typeof Bun.spawn>;
+}
+
+describe("resolveBranchFromPr", () => {
+  test("returns trimmed branch name on success", async () => {
+    let receivedArgs: string[] = [];
+    const spawn = ((args: string[]) => {
+      receivedArgs = args;
+      return fakeProc({ stdout: "feat/my-branch\n" });
+    }) as unknown as typeof Bun.spawn;
+
+    const branch = await resolveBranchFromPr(42, { repo, spawn });
+
+    expect(branch).toBe("feat/my-branch");
+    expect(receivedArgs).toContain("--repo");
+    expect(receivedArgs).toContain("octo/cat");
+    expect(receivedArgs).toContain("42");
+  });
+
+  test("returns null on non-zero exit", async () => {
+    const spawn = (() => fakeProc({ exitCode: 1, stdout: "" })) as unknown as typeof Bun.spawn;
+    const branch = await resolveBranchFromPr(42, { repo, spawn });
+    expect(branch).toBeNull();
+  });
+
+  test("returns null on empty stdout", async () => {
+    const spawn = (() => fakeProc({ stdout: "   \n" })) as unknown as typeof Bun.spawn;
+    const branch = await resolveBranchFromPr(42, { repo, spawn });
+    expect(branch).toBeNull();
+  });
+
+  test("kills subprocess on timeout and returns null", async () => {
+    let killCalled = false;
+    const spawn = (() => {
+      const proc = fakeProc({ stdout: "late/branch", exitDelayMs: 500 });
+      const origKill = proc.kill.bind(proc);
+      proc.kill = () => {
+        killCalled = true;
+        origKill();
+      };
+      return proc;
+    }) as unknown as typeof Bun.spawn;
+
+    const branch = await resolveBranchFromPr(42, { repo, spawn, timeoutMs: 20 });
+
+    expect(killCalled).toBe(true);
+    expect(branch).toBeNull();
+  });
+
+  test("passes --repo flag so cwd-based repo inference is never used", async () => {
+    let receivedArgs: string[] = [];
+    const spawn = ((args: string[]) => {
+      receivedArgs = args;
+      return fakeProc({ stdout: "main" });
+    }) as unknown as typeof Bun.spawn;
+
+    await resolveBranchFromPr(1, { repo: { owner: "alice", repo: "tools" }, spawn });
+
+    const repoIdx = receivedArgs.indexOf("--repo");
+    expect(repoIdx).toBeGreaterThan(-1);
+    expect(receivedArgs[repoIdx + 1]).toBe("alice/tools");
+  });
+});

--- a/packages/daemon/src/github/resolve-branch.spec.ts
+++ b/packages/daemon/src/github/resolve-branch.spec.ts
@@ -76,6 +76,28 @@ describe("resolveBranchFromPr", () => {
     expect(branch).toBeNull();
   });
 
+  test("returns null when spawn throws (e.g., gh not installed)", async () => {
+    const spawn = (() => {
+      throw new Error("gh: command not found");
+    }) as unknown as typeof Bun.spawn;
+
+    let debugMsg: string | undefined;
+    const logger = {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+      debug: (msg: string) => {
+        debugMsg = msg;
+      },
+    };
+
+    const branch = await resolveBranchFromPr(42, { repo, spawn, logger });
+
+    expect(branch).toBeNull();
+    expect(debugMsg).toContain("spawn failed");
+    expect(debugMsg).toContain("gh: command not found");
+  });
+
   test("passes --repo flag so cwd-based repo inference is never used", async () => {
     let receivedArgs: string[] = [];
     const spawn = ((args: string[]) => {

--- a/packages/daemon/src/github/resolve-branch.ts
+++ b/packages/daemon/src/github/resolve-branch.ts
@@ -1,0 +1,62 @@
+/**
+ * Resolve a PR number to its head branch name via `gh pr view`.
+ *
+ * Used by WorkItemsServer to auto-populate `branch` on a work item when
+ * only `prNumber` is known (see #1424). Three safety guarantees:
+ *
+ * 1. **Timeout**: the gh subprocess is killed after `timeoutMs` (default 5s)
+ *    so a daemon IPC slot can't hang on an interactive auth prompt.
+ * 2. **Explicit repo**: `--repo owner/repo` is always passed so the lookup
+ *    is never ambiguous on the daemon's cwd (which may differ from the
+ *    work item's repo).
+ * 3. **Best-effort**: any failure — non-zero exit, timeout, empty stdout —
+ *    returns null. Callers treat null as "branch not known" and continue.
+ */
+import type { RepoInfo } from "./graphql-client";
+
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+export interface ResolveBranchOptions {
+  repo: RepoInfo;
+  timeoutMs?: number;
+  /** Injected for tests — defaults to Bun.spawn. */
+  spawn?: typeof Bun.spawn;
+}
+
+export async function resolveBranchFromPr(prNumber: number, opts: ResolveBranchOptions): Promise<string | null> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const spawn = opts.spawn ?? Bun.spawn;
+  const proc = spawn(
+    [
+      "gh",
+      "pr",
+      "view",
+      String(prNumber),
+      "--repo",
+      `${opts.repo.owner}/${opts.repo.repo}`,
+      "--json",
+      "headRefName",
+      "-q",
+      ".headRefName",
+    ],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+
+  const timer = setTimeout(() => {
+    try {
+      proc.kill();
+    } catch {
+      // Already exited — ignore.
+    }
+  }, timeoutMs);
+
+  try {
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) return null;
+    const stdout = await new Response(proc.stdout as ReadableStream).text();
+    const branch = stdout.trim();
+    return branch.length > 0 ? branch : null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/packages/daemon/src/github/resolve-branch.ts
+++ b/packages/daemon/src/github/resolve-branch.ts
@@ -2,16 +2,20 @@
  * Resolve a PR number to its head branch name via `gh pr view`.
  *
  * Used by WorkItemsServer to auto-populate `branch` on a work item when
- * only `prNumber` is known (see #1424). Three safety guarantees:
+ * only `prNumber` is known (see #1424). Four safety guarantees:
  *
  * 1. **Timeout**: the gh subprocess is killed after `timeoutMs` (default 5s)
  *    so a daemon IPC slot can't hang on an interactive auth prompt.
  * 2. **Explicit repo**: `--repo owner/repo` is always passed so the lookup
  *    is never ambiguous on the daemon's cwd (which may differ from the
  *    work item's repo).
- * 3. **Best-effort**: any failure — non-zero exit, timeout, empty stdout —
- *    returns null. Callers treat null as "branch not known" and continue.
+ * 3. **Both streams drained**: stdout and stderr are consumed concurrently
+ *    so a chatty gh can't block on pipe backpressure.
+ * 4. **Best-effort**: any failure — spawn throws, non-zero exit, timeout,
+ *    empty stdout — returns null. Callers treat null as "branch not known"
+ *    and continue.
  */
+import type { Logger } from "@mcp-cli/core";
 import type { RepoInfo } from "./graphql-client";
 
 const DEFAULT_TIMEOUT_MS = 5_000;
@@ -21,26 +25,37 @@ export interface ResolveBranchOptions {
   timeoutMs?: number;
   /** Injected for tests — defaults to Bun.spawn. */
   spawn?: typeof Bun.spawn;
+  /** Optional logger — stderr from failed gh calls is forwarded at debug level. */
+  logger?: Logger;
 }
 
 export async function resolveBranchFromPr(prNumber: number, opts: ResolveBranchOptions): Promise<string | null> {
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const spawn = opts.spawn ?? Bun.spawn;
-  const proc = spawn(
-    [
-      "gh",
-      "pr",
-      "view",
-      String(prNumber),
-      "--repo",
-      `${opts.repo.owner}/${opts.repo.repo}`,
-      "--json",
-      "headRefName",
-      "-q",
-      ".headRefName",
-    ],
-    { stdout: "pipe", stderr: "pipe" },
-  );
+
+  let proc: ReturnType<typeof Bun.spawn>;
+  try {
+    proc = spawn(
+      [
+        "gh",
+        "pr",
+        "view",
+        String(prNumber),
+        "--repo",
+        `${opts.repo.owner}/${opts.repo.repo}`,
+        "--json",
+        "headRefName",
+        "-q",
+        ".headRefName",
+      ],
+      { stdout: "pipe", stderr: "pipe" },
+    );
+  } catch (err) {
+    // `gh` not installed, ENOMEM, EMFILE, etc. Best-effort contract:
+    // spawn failure is indistinguishable from "branch not known".
+    opts.logger?.debug?.(`[resolve-branch] spawn failed: ${err instanceof Error ? err.message : String(err)}`);
+    return null;
+  }
 
   const timer = setTimeout(() => {
     try {
@@ -51,9 +66,19 @@ export async function resolveBranchFromPr(prNumber: number, opts: ResolveBranchO
   }, timeoutMs);
 
   try {
+    // Drain both streams concurrently with `exited`. Leaving stderr un-read
+    // can stall gh on pipe backpressure if it emits enough warnings.
+    const stdoutPromise = new Response(proc.stdout as ReadableStream).text();
+    const stderrPromise = new Response(proc.stderr as ReadableStream).text();
     const exitCode = await proc.exited;
-    if (exitCode !== 0) return null;
-    const stdout = await new Response(proc.stdout as ReadableStream).text();
+    const [stdout, stderr] = await Promise.all([stdoutPromise, stderrPromise]);
+
+    if (exitCode !== 0) {
+      if (stderr.trim().length > 0) {
+        opts.logger?.debug?.(`[resolve-branch] gh exit ${exitCode}: ${stderr.trim()}`);
+      }
+      return null;
+    }
     const branch = stdout.trim();
     return branch.length > 0 ? branch : null;
   } finally {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -105,6 +105,26 @@ export function acquirePidLock(logger: Logger): number {
 }
 
 /**
+ * Resolve a PR number to its head branch name via `gh pr view`.
+ *
+ * Returns null when gh fails or the PR is not found. Best-effort: callers
+ * should treat a null return as "branch not known" rather than a hard error.
+ * Used by WorkItemsServer to auto-populate `branch` on a work item when only
+ * `prNumber` is known (see #1424).
+ */
+export async function resolveBranchFromPr(prNumber: number): Promise<string | null> {
+  const proc = Bun.spawn(["gh", "pr", "view", String(prNumber), "--json", "headRefName", "-q", ".headRefName"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) return null;
+  const stdout = await new Response(proc.stdout as ReadableStream).text();
+  const branch = stdout.trim();
+  return branch.length > 0 ? branch : null;
+}
+
+/**
  * Write PID data to the already-locked PID file descriptor.
  */
 function writePidData(fd: number, data: Record<string, unknown>): void {
@@ -850,6 +870,8 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
                 return null;
               }
             },
+            resolveBranchFromPr,
+            logger,
           });
           const {
             client: workItemsClient,

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -66,6 +66,7 @@ import { closeDaemonLogFile, installDaemonLogCapture, installDaemonLogFile } fro
 import { StateDb } from "./db/state";
 import { WorkItemDb } from "./db/work-items";
 import { type RepoInfo, detectRepo, resolveNumber } from "./github/graphql-client";
+import { resolveBranchFromPr } from "./github/resolve-branch";
 import { WorkItemPoller } from "./github/work-item-poller";
 import { IpcServer } from "./ipc-server";
 import { MailServer, buildMailToolCache } from "./mail-server";
@@ -102,26 +103,6 @@ export function acquirePidLock(logger: Logger): number {
   // Now that we hold the lock, truncate to clear any previous content
   ftruncateSync(fd, 0);
   return fd;
-}
-
-/**
- * Resolve a PR number to its head branch name via `gh pr view`.
- *
- * Returns null when gh fails or the PR is not found. Best-effort: callers
- * should treat a null return as "branch not known" rather than a hard error.
- * Used by WorkItemsServer to auto-populate `branch` on a work item when only
- * `prNumber` is known (see #1424).
- */
-export async function resolveBranchFromPr(prNumber: number): Promise<string | null> {
-  const proc = Bun.spawn(["gh", "pr", "view", String(prNumber), "--json", "headRefName", "-q", ".headRefName"], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const exitCode = await proc.exited;
-  if (exitCode !== 0) return null;
-  const stdout = await new Response(proc.stdout as ReadableStream).text();
-  const branch = stdout.trim();
-  return branch.length > 0 ? branch : null;
 }
 
 /**
@@ -870,7 +851,20 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
                 return null;
               }
             },
-            resolveBranchFromPr,
+            resolveBranchFromPr: async (prNumber: number) => {
+              // Re-use the cached repo detected from daemon startup cwd so the
+              // --repo flag is always explicit (avoids `gh pr view` resolving
+              // against an ambiguous cwd). Returns null when repo detection
+              // fails; caller treats that as "branch not known" and continues.
+              if (!cachedRepo) {
+                try {
+                  cachedRepo = await detectRepo(process.cwd());
+                } catch {
+                  return null;
+                }
+              }
+              return resolveBranchFromPr(prNumber, { repo: cachedRepo });
+            },
             logger,
           });
           const {

--- a/packages/daemon/src/work-items-server.spec.ts
+++ b/packages/daemon/src/work-items-server.spec.ts
@@ -766,4 +766,88 @@ describe("WorkItemsServer", () => {
     const item = JSON.parse(content[0].text);
     expect(item.branch).toBeNull();
   });
+
+  test("work_items_update does not clobber branch written during async resolve (TOCTOU)", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    server = new WorkItemsServer(db, {
+      resolveBranchFromPr: async () => {
+        // Simulate a concurrent explicit-branch write landing during the
+        // gh subprocess await, then resolve with a "stale" value.
+        await gate;
+        return "resolved/from-gh";
+      },
+    });
+    const { client } = await server.start();
+    await client.callTool({ name: "work_items_track", arguments: { issueNumber: 77 } });
+
+    const slowUpdate = client.callTool({
+      name: "work_items_update",
+      arguments: { id: "issue:77", prNumber: 88 },
+    });
+
+    // Simulate the concurrent explicit-branch write committing directly to
+    // the DB while the slow update is awaiting its resolver. The guard
+    // re-reads after the await and must not overwrite this value.
+    db.updateWorkItem("issue:77", { branch: "explicit/winner" });
+    release();
+
+    const result = await slowUpdate;
+    expect(result.isError).toBeFalsy();
+    const final = db.getWorkItem("issue:77");
+    expect(final?.branch).toBe("explicit/winner");
+  });
+
+  test("work_items_track auto-populates branch from prNumber (#1449)", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    const calls: number[] = [];
+    server = new WorkItemsServer(db, {
+      resolveBranchFromPr: async (pr) => {
+        calls.push(pr);
+        return "feat/from-track";
+      },
+    });
+    const { client } = await server.start();
+
+    const result = await client.callTool({
+      name: "work_items_track",
+      arguments: { prNumber: 1420 },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const content = result.content as Array<{ type: string; text: string }>;
+    const item = JSON.parse(content[0].text);
+    expect(item.prNumber).toBe(1420);
+    expect(item.branch).toBe("feat/from-track");
+    expect(calls).toEqual([1420]);
+  });
+
+  test("work_items_track does not auto-resolve when branch is explicitly provided", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    let resolverCalled = false;
+    server = new WorkItemsServer(db, {
+      resolveBranchFromPr: async () => {
+        resolverCalled = true;
+        return "auto";
+      },
+    });
+    const { client } = await server.start();
+
+    const result = await client.callTool({
+      name: "work_items_track",
+      arguments: { prNumber: 99, branch: "explicit/branch" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const content = result.content as Array<{ type: string; text: string }>;
+    const item = JSON.parse(content[0].text);
+    expect(item.branch).toBe("explicit/branch");
+    expect(resolverCalled).toBe(false);
+  });
 });

--- a/packages/daemon/src/work-items-server.spec.ts
+++ b/packages/daemon/src/work-items-server.spec.ts
@@ -802,6 +802,30 @@ describe("WorkItemsServer", () => {
     expect(final?.branch).toBe("explicit/winner");
   });
 
+  test("work_items_update treats branch=null as absent (no 'null' string coercion)", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    server = new WorkItemsServer(db);
+    const { client } = await server.start();
+    await client.callTool({
+      name: "work_items_track",
+      arguments: { issueNumber: 55, branch: "feat/existing" },
+    });
+
+    // Sending `branch: null` must not overwrite the existing branch with the
+    // literal string "null" (round-3 Copilot inline comment).
+    const result = await client.callTool({
+      name: "work_items_update",
+      arguments: { id: "issue:55", branch: null, ciStatus: "passed" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const content = result.content as Array<{ type: string; text: string }>;
+    const item = JSON.parse(content[0].text);
+    expect(item.branch).toBe("feat/existing");
+    expect(item.ciStatus).toBe("passed");
+  });
+
   test("work_items_track auto-populates branch from prNumber (#1449)", async () => {
     const { db, raw } = createWorkItemDb();
     rawDb = raw;

--- a/packages/daemon/src/work-items-server.spec.ts
+++ b/packages/daemon/src/work-items-server.spec.ts
@@ -643,4 +643,127 @@ describe("WorkItemsServer", () => {
     expect(last.forced).toBe(true);
     expect(last.forceReason).toBe("test reopen");
   });
+
+  test("work_items_update auto-populates branch from prNumber when item has no branch (#1424)", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    const calls: number[] = [];
+    server = new WorkItemsServer(db, {
+      resolveBranchFromPr: async (pr) => {
+        calls.push(pr);
+        return "feat/auto-resolved";
+      },
+    });
+    const { client } = await server.start();
+    await client.callTool({ name: "work_items_track", arguments: { issueNumber: 1378 } });
+
+    const result = await client.callTool({
+      name: "work_items_update",
+      arguments: { id: "issue:1378", prNumber: 1420 },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const content = result.content as Array<{ type: string; text: string }>;
+    const item = JSON.parse(content[0].text);
+    expect(item.prNumber).toBe(1420);
+    expect(item.branch).toBe("feat/auto-resolved");
+    expect(calls).toEqual([1420]);
+  });
+
+  test("work_items_update explicit branch wins over auto-resolve", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    let resolverCalled = false;
+    server = new WorkItemsServer(db, {
+      resolveBranchFromPr: async () => {
+        resolverCalled = true;
+        return "auto";
+      },
+    });
+    const { client } = await server.start();
+    await client.callTool({ name: "work_items_track", arguments: { issueNumber: 42 } });
+
+    const result = await client.callTool({
+      name: "work_items_update",
+      arguments: { id: "issue:42", prNumber: 99, branch: "explicit/branch" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const content = result.content as Array<{ type: string; text: string }>;
+    const item = JSON.parse(content[0].text);
+    expect(item.branch).toBe("explicit/branch");
+    expect(resolverCalled).toBe(false);
+  });
+
+  test("work_items_update does not auto-resolve when branch already set", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    let resolverCalled = false;
+    server = new WorkItemsServer(db, {
+      resolveBranchFromPr: async () => {
+        resolverCalled = true;
+        return "auto";
+      },
+    });
+    const { client } = await server.start();
+    await client.callTool({
+      name: "work_items_track",
+      arguments: { issueNumber: 10, branch: "existing" },
+    });
+
+    const result = await client.callTool({
+      name: "work_items_update",
+      arguments: { id: "issue:10", prNumber: 20 },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const content = result.content as Array<{ type: string; text: string }>;
+    const item = JSON.parse(content[0].text);
+    expect(item.branch).toBe("existing");
+    expect(resolverCalled).toBe(false);
+  });
+
+  test("work_items_update tolerates resolver failure", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    server = new WorkItemsServer(db, {
+      resolveBranchFromPr: async () => {
+        throw new Error("gh not found");
+      },
+      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+    });
+    const { client } = await server.start();
+    await client.callTool({ name: "work_items_track", arguments: { issueNumber: 1 } });
+
+    const result = await client.callTool({
+      name: "work_items_update",
+      arguments: { id: "issue:1", prNumber: 2 },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const content = result.content as Array<{ type: string; text: string }>;
+    const item = JSON.parse(content[0].text);
+    expect(item.prNumber).toBe(2);
+    expect(item.branch).toBeNull();
+  });
+
+  test("work_items_update does not auto-resolve when resolver returns null", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    server = new WorkItemsServer(db, {
+      resolveBranchFromPr: async () => null,
+    });
+    const { client } = await server.start();
+    await client.callTool({ name: "work_items_track", arguments: { issueNumber: 5 } });
+
+    const result = await client.callTool({
+      name: "work_items_update",
+      arguments: { id: "issue:5", prNumber: 6 },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const content = result.content as Array<{ type: string; text: string }>;
+    const item = JSON.parse(content[0].text);
+    expect(item.branch).toBeNull();
+  });
 });

--- a/packages/daemon/src/work-items-server.ts
+++ b/packages/daemon/src/work-items-server.ts
@@ -235,9 +235,10 @@ export class WorkItemsServer {
             // Auto-populate branch when prNumber is known but branch isn't —
             // fires on the initial track call too, not just update (#1449).
             if (prNumber != null && item.branch == null) {
-              const resolvedBranch = await this.maybeResolveBranch(id, prNumber);
-              if (resolvedBranch) {
-                item = this.workItemDb.updateWorkItem(id, { branch: resolvedBranch });
+              const wrote = await this.maybeResolveAndSetBranch(id, prNumber);
+              if (wrote) {
+                const refreshed = this.workItemDb.getWorkItem(id);
+                if (refreshed) item = refreshed;
               }
             }
 
@@ -348,19 +349,27 @@ export class WorkItemsServer {
             if (a.ciRunId !== undefined) patch.ciRunId = requireInt(a.ciRunId, "ciRunId");
             if (a.ciSummary !== undefined) patch.ciSummary = String(a.ciSummary);
             if (a.reviewStatus !== undefined) patch.reviewStatus = String(a.reviewStatus) as WorkItem["reviewStatus"];
-            if (a.branch !== undefined) patch.branch = String(a.branch);
+            // Treat `null` the same as absent — otherwise String(null) persists the literal
+            // string "null" as the branch (round-3 Copilot inline comment).
+            if (a.branch != null) patch.branch = String(a.branch);
             if (a.issueNumber !== undefined) patch.issueNumber = requireInt(a.issueNumber, "issueNumber");
 
-            // Auto-populate branch when prNumber is being set and neither the patch nor the
-            // existing item has a branch. Best-effort: a resolver failure is logged but does
-            // not fail the update. See #1424 for the DX rationale.
+            let updated = this.workItemDb.updateWorkItem(id, patch, { forced: force, forceReason });
+
+            // Auto-populate branch when prNumber is being set and the patch didn't
+            // supply a branch. Runs AFTER the main update so the helper's atomic
+            // `setBranchIfNull` sees the latest row state and skips if another
+            // writer won the race. Best-effort: a resolver failure is logged but
+            // does not fail the update. See #1424 for the DX rationale.
             const newPrNumber = patch.prNumber;
             if (newPrNumber != null && patch.branch === undefined) {
-              const resolved = await this.maybeResolveBranch(id, newPrNumber);
-              if (resolved) patch.branch = resolved;
+              const wrote = await this.maybeResolveAndSetBranch(id, newPrNumber);
+              if (wrote) {
+                const refreshed = this.workItemDb.getWorkItem(id);
+                if (refreshed) updated = refreshed;
+              }
             }
 
-            const updated = this.workItemDb.updateWorkItem(id, patch, { forced: force, forceReason });
             return { content: [{ type: "text" as const, text: JSON.stringify(updated) }] };
           }
 
@@ -384,30 +393,30 @@ export class WorkItemsServer {
   }
 
   /**
-   * Best-effort branch resolution for a work item that has a prNumber but no branch.
+   * Best-effort branch auto-populate: resolves a branch for the given PR and
+   * writes it to the row ONLY if branch is still NULL at commit time.
    *
-   * Used by both `work_items_track` and `work_items_update`. Re-reads the work item
-   * *after* the async gh call to close the TOCTOU window where a concurrent explicit
-   * `branch` write could be clobbered by the resolved value (see #1424 review round 2).
-   * Returns the resolved branch only if the item still has no branch at write time.
+   * The atomic `setBranchIfNull` (WHERE branch IS NULL) closes the TOCTOU
+   * window across the async gh call — a concurrent writer that set an
+   * explicit branch during the await wins because the UPDATE's WHERE
+   * filter drops our row (#1424 review round 3).
+   *
+   * Returns true when the branch was written, false on any failure or skip.
    */
-  private async maybeResolveBranch(id: string, prNumber: number): Promise<string | null> {
-    if (!this.resolveBranchFromPr) return null;
+  private async maybeResolveAndSetBranch(id: string, prNumber: number): Promise<boolean> {
+    if (!this.resolveBranchFromPr) return false;
     const existing = this.workItemDb.getWorkItem(id);
-    if (!existing || existing.branch != null) return null;
+    if (!existing || existing.branch != null) return false;
     let resolved: string | null = null;
     try {
       resolved = await this.resolveBranchFromPr(prNumber);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this.logger.warn(`[mcpd] Failed to resolve branch for PR #${prNumber}: ${msg}`);
-      return null;
+      return false;
     }
-    if (!resolved) return null;
-    // Re-read: another update may have set branch while we awaited gh.
-    const current = this.workItemDb.getWorkItem(id);
-    if (!current || current.branch != null) return null;
-    return resolved;
+    if (!resolved) return false;
+    return this.workItemDb.setBranchIfNull(id, resolved);
   }
 
   async stop(): Promise<void> {

--- a/packages/daemon/src/work-items-server.ts
+++ b/packages/daemon/src/work-items-server.ts
@@ -5,8 +5,8 @@
  * Tools: track, untrack, list, get, update — mapping to WorkItemDb CRUD.
  */
 
-import type { Manifest, ToolInfo, WorkItem, WorkItemPhase } from "@mcp-cli/core";
-import { WORK_ITEMS_SERVER_NAME, canTransition } from "@mcp-cli/core";
+import type { Logger, Manifest, ToolInfo, WorkItem, WorkItemPhase } from "@mcp-cli/core";
+import { WORK_ITEMS_SERVER_NAME, canTransition, consoleLogger } from "@mcp-cli/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
@@ -146,16 +146,25 @@ export class WorkItemsServer {
   /** Resolves a manifest for a given repo root, or returns null. Injected for testability. */
   private loadManifestFn: ((repoRoot: string) => Manifest | null) | null;
 
+  /** Resolves a PR number to its head branch name. Injected for testability. */
+  private resolveBranchFromPr: ((prNumber: number) => Promise<string | null>) | null;
+
+  private logger: Logger;
+
   constructor(
     workItemDb: WorkItemDb,
     opts?: {
       onTrack?: () => void;
       loadManifest?: (repoRoot: string) => Manifest | null;
+      resolveBranchFromPr?: (prNumber: number) => Promise<string | null>;
+      logger?: Logger;
     },
   ) {
     this.workItemDb = workItemDb;
     this.onTrack = opts?.onTrack ?? null;
     this.loadManifestFn = opts?.loadManifest ?? null;
+    this.resolveBranchFromPr = opts?.resolveBranchFromPr ?? null;
+    this.logger = opts?.logger ?? consoleLogger;
   }
 
   async start(): Promise<{ client: Client; transport: Transport; tools: Map<string, ToolInfo> }> {
@@ -331,6 +340,23 @@ export class WorkItemsServer {
             if (a.reviewStatus !== undefined) patch.reviewStatus = String(a.reviewStatus) as WorkItem["reviewStatus"];
             if (a.branch !== undefined) patch.branch = String(a.branch);
             if (a.issueNumber !== undefined) patch.issueNumber = requireInt(a.issueNumber, "issueNumber");
+
+            // Auto-populate branch when prNumber is being set and neither the patch nor the
+            // existing item has a branch. Best-effort: a resolver failure is logged but does
+            // not fail the update. See #1424 for the DX rationale.
+            const newPrNumber = patch.prNumber;
+            if (newPrNumber != null && patch.branch === undefined && this.resolveBranchFromPr) {
+              const existing = this.workItemDb.getWorkItem(id);
+              if (existing && existing.branch == null) {
+                try {
+                  const branch = await this.resolveBranchFromPr(newPrNumber);
+                  if (branch) patch.branch = branch;
+                } catch (err) {
+                  const msg = err instanceof Error ? err.message : String(err);
+                  this.logger.warn(`[mcpd] Failed to resolve branch for PR #${newPrNumber}: ${msg}`);
+                }
+              }
+            }
 
             const updated = this.workItemDb.updateWorkItem(id, patch, { forced: force, forceReason });
             return { content: [{ type: "text" as const, text: JSON.stringify(updated) }] };

--- a/packages/daemon/src/work-items-server.ts
+++ b/packages/daemon/src/work-items-server.ts
@@ -223,7 +223,7 @@ export class WorkItemsServer {
               existing?.id ?? (prNumber ? `pr:${prNumber}` : issueNumber ? `issue:${issueNumber}` : `branch:${branch}`);
 
             // Atomic upsert — avoids TOCTOU race between concurrent track calls
-            const item = this.workItemDb.upsertWorkItem({
+            let item = this.workItemDb.upsertWorkItem({
               id,
               issueNumber: issueNumber ?? undefined,
               prNumber: prNumber ?? undefined,
@@ -231,6 +231,16 @@ export class WorkItemsServer {
               prUrl: a.prUrl !== undefined ? String(a.prUrl) : undefined,
               phase: (a.phase as WorkItemPhase | undefined) ?? (existing ? undefined : "impl"),
             });
+
+            // Auto-populate branch when prNumber is known but branch isn't —
+            // fires on the initial track call too, not just update (#1449).
+            if (prNumber != null && item.branch == null) {
+              const resolvedBranch = await this.maybeResolveBranch(id, prNumber);
+              if (resolvedBranch) {
+                item = this.workItemDb.updateWorkItem(id, { branch: resolvedBranch });
+              }
+            }
+
             this.onTrack?.();
             return { content: [{ type: "text" as const, text: JSON.stringify(item) }] };
           }
@@ -345,17 +355,9 @@ export class WorkItemsServer {
             // existing item has a branch. Best-effort: a resolver failure is logged but does
             // not fail the update. See #1424 for the DX rationale.
             const newPrNumber = patch.prNumber;
-            if (newPrNumber != null && patch.branch === undefined && this.resolveBranchFromPr) {
-              const existing = this.workItemDb.getWorkItem(id);
-              if (existing && existing.branch == null) {
-                try {
-                  const branch = await this.resolveBranchFromPr(newPrNumber);
-                  if (branch) patch.branch = branch;
-                } catch (err) {
-                  const msg = err instanceof Error ? err.message : String(err);
-                  this.logger.warn(`[mcpd] Failed to resolve branch for PR #${newPrNumber}: ${msg}`);
-                }
-              }
+            if (newPrNumber != null && patch.branch === undefined) {
+              const resolved = await this.maybeResolveBranch(id, newPrNumber);
+              if (resolved) patch.branch = resolved;
             }
 
             const updated = this.workItemDb.updateWorkItem(id, patch, { forced: force, forceReason });
@@ -379,6 +381,33 @@ export class WorkItemsServer {
     await this.client.connect(clientTransport);
 
     return { client: this.client, transport: this.clientTransport, tools: buildWorkItemsToolCache() };
+  }
+
+  /**
+   * Best-effort branch resolution for a work item that has a prNumber but no branch.
+   *
+   * Used by both `work_items_track` and `work_items_update`. Re-reads the work item
+   * *after* the async gh call to close the TOCTOU window where a concurrent explicit
+   * `branch` write could be clobbered by the resolved value (see #1424 review round 2).
+   * Returns the resolved branch only if the item still has no branch at write time.
+   */
+  private async maybeResolveBranch(id: string, prNumber: number): Promise<string | null> {
+    if (!this.resolveBranchFromPr) return null;
+    const existing = this.workItemDb.getWorkItem(id);
+    if (!existing || existing.branch != null) return null;
+    let resolved: string | null = null;
+    try {
+      resolved = await this.resolveBranchFromPr(prNumber);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`[mcpd] Failed to resolve branch for PR #${prNumber}: ${msg}`);
+      return null;
+    }
+    if (!resolved) return null;
+    // Re-read: another update may have set branch while we awaited gh.
+    const current = this.workItemDb.getWorkItem(id);
+    if (!current || current.branch != null) return null;
+    return resolved;
   }
 
   async stop(): Promise<void> {


### PR DESCRIPTION
## Summary

- Phase errors now name the specific missing field(s) and the work item id. Orchestrators hitting the sprint-35 papercut can see whether it's `branch`, `issueNumber`, or `prNumber` that's null instead of reading "requires issueNumber and branch" and guessing.
- `work_items_update` auto-populates `branch` via `gh pr view <n> --json headRefName` when `prNumber` is set and neither the patch nor the existing work item has a branch. Best-effort: resolver failures are logged, not fatal.
- Applied consistently across all 6 phases (`triage`, `review`, `qa`, `repair`, `done`, `needs-attention`) so this DX fix covers the whole pipeline, not just the reported triage case.

## Test plan

- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun test` — 5104 pass, 0 fail, 22 todo (Bun segfault after tests passed — logged to #1004)
- [x] `bun dev:mcx -- phase install` — all 7 phases bundle successfully
- [x] Added 5 new specs in `work-items-server.spec.ts` covering: auto-fill on track-then-update flow, explicit branch wins, existing branch not overwritten, resolver throw tolerated, null resolver return tolerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)