### PR TITLE
feat(daemon): pin GIT_DIR/GIT_WORK_TREE on worker spawn (fixes #1442)

### DIFF
--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -1406,6 +1406,60 @@ describe("ClaudeWsServer", () => {
     expect(ms.lastOpts.env).toBeUndefined();
   });
 
+  test("spawnClaude pins GIT_DIR and GIT_WORK_TREE when worktree and cwd are both set", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    await server.start();
+
+    const worktreePath = "/repo/.claude/worktrees/my-tree";
+    server.prepareSession("wt-pinned-session", {
+      prompt: "Hello",
+      worktree: "my-tree",
+      cwd: worktreePath,
+    });
+    server.spawnClaude("wt-pinned-session");
+
+    expect(ms.lastOpts.env).toMatchObject({
+      GIT_DIR: `${worktreePath}/.git`,
+      GIT_WORK_TREE: worktreePath,
+    });
+  });
+
+  test("spawnClaude does not pin GIT_DIR when only worktree name is set (no cwd)", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    await server.start();
+
+    server.prepareSession("wt-name-only-session", {
+      prompt: "Hello",
+      worktree: "my-tree",
+    });
+    server.spawnClaude("wt-name-only-session");
+
+    expect(ms.lastOpts.env).toBeUndefined();
+  });
+
+  test("spawnClaude includes both TRACEPARENT and GIT pins when all are set", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    await server.start();
+
+    const worktreePath = "/repo/.claude/worktrees/my-tree";
+    const tp = `00-${"c".repeat(32)}-${"d".repeat(16)}-01`;
+    server.prepareSession("wt-trace-session", {
+      prompt: "Hello",
+      worktree: "my-tree",
+      cwd: worktreePath,
+    });
+    server.spawnClaude("wt-trace-session", tp);
+
+    expect(ms.lastOpts.env).toEqual({
+      TRACEPARENT: tp,
+      GIT_DIR: `${worktreePath}/.git`,
+      GIT_WORK_TREE: worktreePath,
+    });
+  });
+
   test("bye returns null worktree for non-worktree session", async () => {
     const ms = mockSpawn();
     server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -642,12 +642,22 @@ export class ClaudeWsServer {
       }
     }
 
+    const envOverrides: Record<string, string | undefined> = {};
+    if (traceparent) envOverrides.TRACEPARENT = traceparent;
+    // Pin GIT_DIR/GIT_WORK_TREE so the worker cannot escape its worktree via
+    // git even if cwd drifts. Only applies when a pre-created worktree is in
+    // use (both cwd and worktree name are set — see comment at --worktree flag
+    // above).
+    if (session.config.cwd && session.config.worktree) {
+      envOverrides.GIT_DIR = `${session.config.cwd}/.git`;
+      envOverrides.GIT_WORK_TREE = session.config.cwd;
+    }
     const proc = this.spawn(cmd, {
       cwd: session.config.cwd,
       stdout: "ignore",
       stderr: "pipe",
       stdin: "ignore",
-      env: traceparent ? { TRACEPARENT: traceparent } : undefined,
+      env: Object.keys(envOverrides).length > 0 ? envOverrides : undefined,
     });
 
     session.pid = proc.pid;


### PR DESCRIPTION
## Summary
- Sets `GIT_DIR=<cwd>/.git` and `GIT_WORK_TREE=<cwd>` in the spawned worker's environment when a session has a pre-created worktree (`config.cwd` + `config.worktree` both set)
- Git then rejects cross-worktree writes regardless of cwd drift — cheap partial mitigation for #1425
- No change to sessions without a worktree; read-only git ops (log, diff) still work since the linked `.git` file can resolve all objects

## Test plan
- [x] `spawnClaude` pins `GIT_DIR` and `GIT_WORK_TREE` when both `cwd` and `worktree` are configured
- [x] No git pins when only `worktree` name is set (no `cwd`) — claude will create the worktree, path unknown at spawn time
- [x] `TRACEPARENT` and git pins are both present when all three are set
- [x] Existing TRACEPARENT and worktree flag tests unchanged (145 tests pass in ws-server.spec.ts)
- [x] Full suite: 5102 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)