### PR TITLE
feat(git-hooks): sprint-active guard on main (fixes #1443)

### DIFF
--- a/.claude/skills/sprint/references/retro.md
+++ b/.claude/skills/sprint/references/retro.md
@@ -75,10 +75,21 @@ Use this template exactly:
 ## Commit and push
 
 ```bash
+# SPRINT_OVERRIDE=1 bypasses the sprint-active pre-commit guard (#1443).
 git add .claude/diary/{filename}
-git commit -m "retro: sprint {N} — {short title}"
+SPRINT_OVERRIDE=1 git commit -m "retro: sprint {N} — {short title}"
 git push origin main
 ```
+
+## Clear the sprint-active sentinel
+
+```bash
+rm -f .claude/sprints/.active
+```
+
+This lifts the pre-commit guard (#1443) so post-sprint maintenance commits
+on main no longer need `SPRINT_OVERRIDE=1`. Do it only after the retro push
+succeeds — a stuck sentinel on a dead sprint still blocks commits.
 
 ## Guidelines
 

--- a/.claude/skills/sprint/references/review.md
+++ b/.claude/skills/sprint/references/review.md
@@ -60,8 +60,9 @@ bun lint          # applies biome fixes (e.g. package.json array collapse)
 bun typecheck     # catches TS errors before the hook does
 
 # (c) Commit — capture the sha so we only tag if this actually succeeded
+# SPRINT_OVERRIDE=1 bypasses the sprint-active pre-commit guard (#1443).
 git add package.json
-git commit -m "release: vX.Y.Z"
+SPRINT_OVERRIDE=1 git commit -m "release: vX.Y.Z"
 RELEASE_SHA=$(git rev-parse HEAD)
 git log -1 --oneline "$RELEASE_SHA"   # verify it's the release commit
 

--- a/.claude/skills/sprint/references/run.md
+++ b/.claude/skills/sprint/references/run.md
@@ -42,6 +42,15 @@ Record the start timestamp in the sprint file header (append to the `>` line):
 > Planned {date}. Started {date} {HH:MM local}. Target: 15 PRs.
 ```
 
+Mark the sprint active for the main-checkout pre-commit guard (#1443):
+```bash
+echo "{N}" > .claude/sprints/.active
+```
+The sentinel is gitignored. It blocks commits on main's checkout so workers
+that escape their worktree fail loudly instead of landing phantom commits
+on main (see #1425). `/sprint retro` removes it. Orchestrator commits
+(sprint-plan updates, release, retro) must set `SPRINT_OVERRIDE=1`.
+
 ## Pre-flight
 
 Before spawning any sessions, ensure the daemon is running the latest build.

--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -8,6 +8,14 @@
 
 set -euo pipefail
 
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Sprint-active guard (#1425, #1443) — reject commits to main's checkout
+# while a sprint is active. Worktree commits and overrides are allowed.
+# shellcheck source=sprint-active.sh
+source "$HOOK_DIR/sprint-active.sh"
+sprint_active_check || exit 1
+
 # Get list of staged files (excludes deleted files)
 staged_files=$(git diff --cached --name-only --diff-filter=d)
 
@@ -40,7 +48,6 @@ if [ -z "${SKIP_PRIVACY_CHECK:-}" ]; then
 fi
 
 # Classify staged files into tiers
-HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 # shellcheck source=classify.sh
 source "$HOOK_DIR/classify.sh"
 classify_files <<< "$staged_files"

--- a/.git-hooks/sprint-active.sh
+++ b/.git-hooks/sprint-active.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# sprint_active_check: reactive safety net for #1425 / #1443.
+#
+# Blocks commits to the main checkout while a sprint is active. Workers
+# must commit to their own worktree — any commit reaching main's cwd
+# during a sprint is a containment failure by default.
+#
+# Skips when:
+#   - Running inside a worktree (git-dir != git-common-dir)
+#   - No sentinel file at .claude/sprints/.active
+#   - SPRINT_OVERRIDE=1 (orchestrator release/retro/plan commits)
+#
+# The sentinel is created by /sprint (run phase) on start and removed
+# by /sprint retro after the retro commit is pushed.
+#
+# Usage (from pre-commit):
+#   source .git-hooks/sprint-active.sh
+#   sprint_active_check || exit 1
+
+sprint_active_check() {
+  local git_dir git_common_dir
+  git_dir=$(git rev-parse --git-dir 2>/dev/null) || return 0
+  git_common_dir=$(git rev-parse --git-common-dir 2>/dev/null) || return 0
+
+  # Normalize to absolute paths — git may return relative in main, absolute in worktree.
+  local abs_git_dir abs_git_common_dir
+  abs_git_dir=$(cd "$git_dir" 2>/dev/null && pwd) || return 0
+  abs_git_common_dir=$(cd "$git_common_dir" 2>/dev/null && pwd) || return 0
+
+  # Worktree: git-dir points at <main>/.git/worktrees/<name>, common-dir at <main>/.git.
+  if [ "$abs_git_dir" != "$abs_git_common_dir" ]; then
+    return 0
+  fi
+
+  local toplevel sentinel
+  toplevel=$(git rev-parse --show-toplevel 2>/dev/null) || return 0
+  sentinel="$toplevel/.claude/sprints/.active"
+
+  if [ ! -f "$sentinel" ]; then
+    return 0
+  fi
+
+  if [ -n "${SPRINT_OVERRIDE:-}" ]; then
+    echo "pre-commit: SPRINT_OVERRIDE=1 — allowing commit to main during active sprint" >&2
+    return 0
+  fi
+
+  local sprint_num
+  sprint_num=$(tr -d '[:space:]' < "$sentinel" 2>/dev/null)
+  echo "pre-commit: sprint ${sprint_num:-?} is active — refusing commit to main's checkout" >&2
+  echo >&2
+  echo "Workers must commit to their own worktree. A commit reaching main's" >&2
+  echo "cwd during a sprint is a containment failure (see #1425, #1443)." >&2
+  echo >&2
+  echo "Sentinel: $sentinel" >&2
+  echo "Cleared by: /sprint retro (after retro commit pushes)." >&2
+  echo >&2
+  echo "If this is an orchestrator commit (release, retro, sprint-plan update)," >&2
+  echo "bypass with:" >&2
+  echo "  SPRINT_OVERRIDE=1 git commit ..." >&2
+  return 1
+}

--- a/.git-hooks/sprint-active.sh
+++ b/.git-hooks/sprint-active.sh
@@ -40,7 +40,7 @@ sprint_active_check() {
     return 0
   fi
 
-  if [ -n "${SPRINT_OVERRIDE:-}" ]; then
+  if [ "${SPRINT_OVERRIDE:-}" = "1" ]; then
     echo "pre-commit: SPRINT_OVERRIDE=1 — allowing commit to main during active sprint" >&2
     return 0
   fi

--- a/.git-hooks/sprint-active.spec.ts
+++ b/.git-hooks/sprint-active.spec.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const SPRINT_ACTIVE_SH = resolve(import.meta.dir, "sprint-active.sh");
+
+type RunResult = { code: number; stdout: string; stderr: string };
+
+async function runCheck(cwd: string, env: Record<string, string> = {}): Promise<RunResult> {
+  const script = `
+    set -u
+    source "${SPRINT_ACTIVE_SH}"
+    if sprint_active_check; then
+      echo "ALLOW"
+      exit 0
+    else
+      echo "BLOCK"
+      exit 1
+    fi
+  `;
+  const proc = Bun.spawn(["bash", "-c", script], {
+    cwd,
+    env: { ...process.env, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr] = await Promise.all([new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+  const code = await proc.exited;
+  return { code, stdout, stderr };
+}
+
+async function sh(cwd: string, cmd: string[]): Promise<void> {
+  const proc = Bun.spawn(cmd, { cwd, stdout: "pipe", stderr: "pipe" });
+  const code = await proc.exited;
+  if (code !== 0) {
+    const err = await new Response(proc.stderr).text();
+    throw new Error(`${cmd.join(" ")} (cwd=${cwd}) exited ${code}: ${err}`);
+  }
+}
+
+describe("sprint_active_check", () => {
+  let root: string;
+  let main: string;
+  let worktree: string;
+
+  beforeEach(async () => {
+    root = mkdtempSync(join(tmpdir(), "sprint-active-"));
+    main = join(root, "main");
+    worktree = join(root, "wt");
+    mkdirSync(main, { recursive: true });
+    await sh(main, ["git", "init", "-q", "-b", "main"]);
+    await sh(main, ["git", "config", "user.email", "t@example.com"]);
+    await sh(main, ["git", "config", "user.name", "Test"]);
+    await sh(main, ["git", "config", "commit.gpgsign", "false"]);
+    writeFileSync(join(main, "README.md"), "init\n");
+    await sh(main, ["git", "add", "README.md"]);
+    await sh(main, ["git", "commit", "-qm", "init"]);
+    await sh(main, ["git", "worktree", "add", "-q", worktree, "-b", "feature"]);
+    mkdirSync(join(main, ".claude", "sprints"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("allows commit on main when no sentinel exists", async () => {
+    const result = await runCheck(main);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("ALLOW");
+  });
+
+  test("blocks commit on main when sentinel exists", async () => {
+    writeFileSync(join(main, ".claude", "sprints", ".active"), "37\n");
+    const result = await runCheck(main);
+    expect(result.code).toBe(1);
+    expect(result.stdout).toContain("BLOCK");
+    expect(result.stderr).toContain("sprint 37 is active");
+    expect(result.stderr).toContain("SPRINT_OVERRIDE=1");
+  });
+
+  test("allows commit on main when sentinel exists but SPRINT_OVERRIDE is set", async () => {
+    writeFileSync(join(main, ".claude", "sprints", ".active"), "37\n");
+    const result = await runCheck(main, { SPRINT_OVERRIDE: "1" });
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("ALLOW");
+    expect(result.stderr).toContain("SPRINT_OVERRIDE=1");
+  });
+
+  test("allows commit in worktree even when sentinel exists", async () => {
+    writeFileSync(join(main, ".claude", "sprints", ".active"), "37\n");
+    const result = await runCheck(worktree);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("ALLOW");
+  });
+
+  test("allows commit in worktree when sentinel does not exist", async () => {
+    const result = await runCheck(worktree);
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("ALLOW");
+  });
+
+  test("handles empty sentinel file gracefully", async () => {
+    writeFileSync(join(main, ".claude", "sprints", ".active"), "");
+    const result = await runCheck(main);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("sprint ? is active");
+  });
+
+  test("no-ops outside a git repo", async () => {
+    const nonRepo = mkdtempSync(join(tmpdir(), "non-repo-"));
+    try {
+      const result = await runCheck(nonRepo);
+      expect(result.code).toBe(0);
+      expect(result.stdout).toContain("ALLOW");
+    } finally {
+      rmSync(nonRepo, { recursive: true, force: true });
+    }
+  });
+});

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ test-timings.json
 
 # Phase runtime state (ephemeral per sprint)
 .mcx/
+
+# Sprint-active sentinel (pre-commit guard, #1443)
+.claude/sprints/.active


### PR DESCRIPTION
## Summary

Reactive safety net for #1425 / #1443 — if containment fails and a worker escapes its worktree, the main checkout's pre-commit hook refuses the commit instead of accepting a phantom commit on main.

- `.git-hooks/sprint-active.sh` exports `sprint_active_check`: no-op in worktrees (`git-dir` != `git-common-dir`), blocks on main when `.claude/sprints/.active` exists, allows when `SPRINT_OVERRIDE=1`.
- `pre-commit` invokes the guard first so stale sprint state is caught before expensive typecheck/test work.
- Sprint skill references updated: `run.md` creates the sentinel on start; `retro.md` removes it after the retro push; `review.md` + `retro.md` set `SPRINT_OVERRIDE=1` on their intentional main commits.
- Sentinel gitignored — local-only state.

## Design notes

- **Main detection:** `git rev-parse --git-dir` equals `git rev-parse --git-common-dir` only in the main checkout; in a linked worktree, `--git-dir` points at `<common>/worktrees/<name>`.
- **Sentinel:** `.claude/sprints/.active` — presence alone is the signal; contents are the sprint number (diagnostic only). Empty file → "sprint ? is active".
- **Safe default:** no sentinel → allow. A fresh clone or pre-rollout repo behaves exactly as before.
- **Out of scope** (follow-ups acceptable): installing the hook for humans outside `npm install` — `core.hooksPath = .git-hooks` is set by the `prepare` script and is already in use by the repo.

## Test plan

- [x] `bun typecheck`
- [x] `bun lint:check` (clean after biome auto-fix)
- [x] `bun lint:shell`
- [x] `bun check:phase-drift`
- [x] `bun test` — 5099 pass / 0 fail / 212 files (post-suite segfault is #1004, unrelated; telemetry logged)
- [x] Direct test on current checkout: `sprint_active_check` returns 0 in this worktree
- [x] New `.git-hooks/sprint-active.spec.ts` — 7 tests: no-sentinel main, sentinel main, override main, sentinel worktree, no-sentinel worktree, empty sentinel, non-git-repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)