### PR TITLE
feat(sites): browser-mediated named HTTP calls for web apps (#1452)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "@theshadow27/mcp-cli-darwin-x64": "0.0.0",
         "@theshadow27/mcp-cli-linux-arm64": "0.0.0",
         "@theshadow27/mcp-cli-linux-x64": "0.0.0",
+        "playwright": "^1.58.0",
       },
     },
     "packages/acp": {
@@ -249,6 +250,8 @@
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
     "get-east-asian-width": ["get-east-asian-width@1.5.0", "", {}, "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA=="],
@@ -336,6 +339,10 @@
     "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
 
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "@theshadow27/mcp-cli-darwin-arm64": "0.0.0",
     "@theshadow27/mcp-cli-darwin-x64": "0.0.0",
     "@theshadow27/mcp-cli-linux-x64": "0.0.0",
-    "@theshadow27/mcp-cli-linux-arm64": "0.0.0"
+    "@theshadow27/mcp-cli-linux-arm64": "0.0.0",
+    "playwright": "^1.58.0"
   },
   "files": ["bin/", "packages/*/src/**", "packages/*/package.json", "tsconfig*.json", "!**/*.spec.ts", "!**/test/**"],
   "scripts": {

--- a/packages/command/src/commands/site.spec.ts
+++ b/packages/command/src/commands/site.spec.ts
@@ -1,0 +1,286 @@
+import { describe, expect, mock, test } from "bun:test";
+import { type SiteDeps, cmdSite } from "./site";
+
+function makeDeps(ipcReply: unknown = { content: [{ type: "text", text: "[]" }] }): {
+  deps: SiteDeps;
+  calls: Array<{ method: string; params: unknown }>;
+  stdout: string[];
+  stderr: string[];
+  exitCode: number | null;
+} {
+  const calls: Array<{ method: string; params: unknown }> = [];
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  let exitCode: number | null = null;
+  const deps: SiteDeps = {
+    ipcCall: mock(async (method: string, params: unknown) => {
+      calls.push({ method, params });
+      return ipcReply;
+    }) as unknown as SiteDeps["ipcCall"],
+    log: (m) => stdout.push(m),
+    logError: (m) => stderr.push(m),
+    exit: ((code: number) => {
+      exitCode = code;
+      throw new Error(`__exit_${code}__`);
+    }) as SiteDeps["exit"],
+  };
+  return {
+    deps,
+    calls,
+    stdout,
+    stderr,
+    get exitCode() {
+      return exitCode;
+    },
+  };
+}
+
+function readLastCall(calls: Array<{ method: string; params: unknown }>): {
+  method: string;
+  params: { server: string; tool: string; arguments: Record<string, unknown> };
+} {
+  const last = calls[calls.length - 1];
+  return {
+    method: last.method,
+    params: last.params as { server: string; tool: string; arguments: Record<string, unknown> },
+  };
+}
+
+describe("cmdSite", () => {
+  test("help prints when no subcommand", async () => {
+    const { deps, stdout, calls } = makeDeps();
+    await cmdSite([], deps);
+    expect(stdout[0]).toContain("mcx site");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("list dispatches to site_list", async () => {
+    const { deps, calls } = makeDeps();
+    await cmdSite(["list"], deps);
+    const { params } = readLastCall(calls);
+    expect(params.server).toBe("_site");
+    expect(params.tool).toBe("site_list");
+  });
+
+  test("show dispatches to site_show with name", async () => {
+    const { deps, calls } = makeDeps({ content: [{ type: "text", text: '{"name":"x"}' }] });
+    await cmdSite(["show", "x"], deps);
+    const { params } = readLastCall(calls);
+    expect(params.tool).toBe("site_show");
+    expect(params.arguments.name).toBe("x");
+  });
+
+  test("add parses --url and --domains as comma list", async () => {
+    const { deps, calls } = makeDeps();
+    await cmdSite(["add", "example", "--url", "https://example.com", "--domains", "a.com,b.com"], deps);
+    const { params } = readLastCall(calls);
+    expect(params.tool).toBe("site_add");
+    expect(params.arguments.url).toBe("https://example.com");
+    expect(params.arguments.domains).toEqual(["a.com", "b.com"]);
+  });
+
+  test("call puts --k v flags into params, --body into body", async () => {
+    const { deps, calls } = makeDeps();
+    await cmdSite(["call", "teams", "get_thing", "--id", "42", "--body", "raw=stuff"], deps);
+    const { params } = readLastCall(calls);
+    expect(params.tool).toBe("site_call");
+    expect(params.arguments.call).toBe("get_thing");
+    expect(params.arguments.params).toEqual({ id: 42 });
+    expect(params.arguments.body).toBe("raw=stuff");
+  });
+
+  test("browser with no sites calls site_browser_start with no args", async () => {
+    const { deps, calls } = makeDeps();
+    await cmdSite(["browser"], deps);
+    const { params } = readLastCall(calls);
+    expect(params.tool).toBe("site_browser_start");
+    expect(params.arguments).toEqual({});
+  });
+
+  test("browser with site names passes sites array", async () => {
+    const { deps, calls } = makeDeps();
+    await cmdSite(["browser", "teams", "github"], deps);
+    const { params } = readLastCall(calls);
+    expect(params.arguments.sites).toEqual(["teams", "github"]);
+  });
+
+  test("disconnect dispatches to site_disconnect", async () => {
+    const { deps, calls } = makeDeps();
+    await cmdSite(["disconnect"], deps);
+    expect(readLastCall(calls).params.tool).toBe("site_disconnect");
+  });
+
+  test("unknown subcommand exits with code 1", async () => {
+    const { deps, stderr } = makeDeps();
+    let caught: unknown;
+    try {
+      await cmdSite(["bogus"], deps);
+    } catch (e) {
+      caught = e;
+    }
+    expect(String(caught)).toContain("__exit_1__");
+    expect(stderr.join("\n")).toContain("Unknown subcommand");
+  });
+
+  test("remove dispatches to site_remove", async () => {
+    const { deps, calls } = makeDeps();
+    await cmdSite(["remove", "x"], deps);
+    expect(readLastCall(calls).params.tool).toBe("site_remove");
+    expect(readLastCall(calls).params.arguments.name).toBe("x");
+  });
+
+  test("rm alias dispatches to site_remove", async () => {
+    const { deps, calls } = makeDeps();
+    await cmdSite(["rm", "x"], deps);
+    expect(readLastCall(calls).params.tool).toBe("site_remove");
+  });
+
+  test("ls alias dispatches to site_list", async () => {
+    const { deps, calls } = makeDeps();
+    await cmdSite(["ls"], deps);
+    expect(readLastCall(calls).params.tool).toBe("site_list");
+  });
+
+  test("calls dispatches to site_calls", async () => {
+    const { deps, calls } = makeDeps();
+    await cmdSite(["calls", "teams"], deps);
+    expect(readLastCall(calls).params.tool).toBe("site_calls");
+    expect(readLastCall(calls).params.arguments.site).toBe("teams");
+  });
+
+  test("describe dispatches to site_describe", async () => {
+    const { deps, calls } = makeDeps();
+    await cmdSite(["describe", "teams", "get_messages"], deps);
+    expect(readLastCall(calls).params.tool).toBe("site_describe");
+    expect(readLastCall(calls).params.arguments.call).toBe("get_messages");
+  });
+
+  test("add-call dispatches to site_add_call", async () => {
+    const { deps, calls } = makeDeps();
+    await cmdSite(["add-call", "teams", "get_x", "--url", "https://t/x", "--method", "GET"], deps);
+    expect(readLastCall(calls).params.tool).toBe("site_add_call");
+    expect(readLastCall(calls).params.arguments.name).toBe("get_x");
+    expect(readLastCall(calls).params.arguments.url).toBe("https://t/x");
+  });
+
+  test("remove-call dispatches to site_remove_call", async () => {
+    const { deps, calls } = makeDeps();
+    await cmdSite(["remove-call", "teams", "get_x"], deps);
+    expect(readLastCall(calls).params.tool).toBe("site_remove_call");
+  });
+
+  test("stop alias dispatches to site_disconnect", async () => {
+    const { deps, calls } = makeDeps();
+    await cmdSite(["stop"], deps);
+    expect(readLastCall(calls).params.tool).toBe("site_disconnect");
+  });
+
+  test("sniff with --mode passes mode through", async () => {
+    const { deps, calls } = makeDeps();
+    await cmdSite(["sniff", "teams", "--mode", "firehose", "--limit", "5"], deps);
+    const { params } = readLastCall(calls);
+    expect(params.tool).toBe("site_sniff");
+    expect(params.arguments.mode).toBe("firehose");
+    expect(params.arguments.limit).toBe(5);
+  });
+
+  test("wiggle without site passes empty args", async () => {
+    const { deps, calls } = makeDeps();
+    await cmdSite(["wiggle"], deps);
+    expect(readLastCall(calls).params.tool).toBe("site_wiggle");
+    expect(readLastCall(calls).params.arguments).toEqual({});
+  });
+
+  test("wiggle with site passes site arg", async () => {
+    const { deps, calls } = makeDeps();
+    await cmdSite(["wiggle", "teams"], deps);
+    expect(readLastCall(calls).params.arguments.site).toBe("teams");
+  });
+
+  test("eval joins remaining args into code", async () => {
+    const { deps, calls } = makeDeps();
+    await cmdSite(["eval", "teams", "document", "title"], deps);
+    const { params } = readLastCall(calls);
+    expect(params.tool).toBe("site_eval");
+    expect(params.arguments.code).toBe("document title");
+  });
+
+  test("cold-start without site passes empty args", async () => {
+    const { deps, calls } = makeDeps();
+    await cmdSite(["cold-start"], deps);
+    expect(readLastCall(calls).params.tool).toBe("site_cold_start");
+    expect(readLastCall(calls).params.arguments).toEqual({});
+  });
+
+  test("cold-start with site passes site arg", async () => {
+    const { deps, calls } = makeDeps();
+    await cmdSite(["cold-start", "teams"], deps);
+    expect(readLastCall(calls).params.arguments.site).toBe("teams");
+  });
+
+  test("missing required args emit usage error and exit 1", async () => {
+    for (const input of [
+      ["show"],
+      ["calls"],
+      ["describe", "x"],
+      ["remove"],
+      ["call", "x"],
+      ["add-call", "x"],
+      ["remove-call", "x"],
+      ["eval", "x"],
+      ["add"],
+      ["sniff"],
+    ]) {
+      const { deps, stderr } = makeDeps();
+      let caught: unknown;
+      try {
+        await cmdSite(input, deps);
+      } catch (e) {
+        caught = e;
+      }
+      expect(String(caught)).toContain("__exit_1__");
+      expect(stderr.join("\n")).toContain("usage:");
+    }
+  });
+
+  test("--json flag still prints JSON for string responses", async () => {
+    const { deps, stdout } = makeDeps({ content: [{ type: "text", text: "plain-text" }] });
+    await cmdSite(["eval", "s", "x", "--json"], deps);
+    // When --json is set, even strings are wrapped in JSON.stringify
+    expect(stdout[0]).toContain('"plain-text"');
+  });
+
+  test("parseKv handles --key=value", async () => {
+    const { deps, calls } = makeDeps();
+    await cmdSite(["add", "example", "--url=https://a.com", "--enabled=true"], deps);
+    const { params } = readLastCall(calls);
+    expect(params.arguments.url).toBe("https://a.com");
+    expect(params.arguments.enabled).toBe(true);
+  });
+
+  test("parseKv coerces numbers and booleans", async () => {
+    const { deps, calls } = makeDeps();
+    await cmdSite(["call", "s", "c", "--n", "42", "--b", "true", "--f", "false"], deps);
+    const { params } = readLastCall(calls);
+    expect(params.arguments.params).toEqual({ n: 42, b: true, f: false });
+  });
+
+  test("help subcommand prints help", async () => {
+    const { deps, stdout, calls } = makeDeps();
+    await cmdSite(["help"], deps);
+    expect(stdout[0]).toContain("mcx site");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("isError result exits with code 1", async () => {
+    const { deps, stderr } = makeDeps({ content: [{ type: "text", text: "Error: boom" }], isError: true });
+    let caught: unknown;
+    try {
+      await cmdSite(["list"], deps);
+    } catch (e) {
+      caught = e;
+    }
+    expect(String(caught)).toContain("__exit_1__");
+    expect(stderr.join("\n")).toContain("Error: boom");
+  });
+});

--- a/packages/command/src/commands/site.ts
+++ b/packages/command/src/commands/site.ts
@@ -1,0 +1,249 @@
+/**
+ * `mcx site` — browser-mediated named HTTP calls for web apps.
+ *
+ * Each subcommand is a thin wrapper over a tool on the `_site` virtual MCP server.
+ * See `packages/daemon/src/site/` for config/catalog/browser internals.
+ */
+
+import type { IpcMethod, IpcMethodResult } from "@mcp-cli/core";
+import { SITE_SERVER_NAME } from "@mcp-cli/core";
+import { ipcCall as defaultIpcCall } from "../daemon-lifecycle";
+import { extractJsonFlag } from "../parse";
+
+export interface SiteDeps {
+  ipcCall: <M extends IpcMethod>(method: M, params?: unknown) => Promise<IpcMethodResult[M]>;
+  log: (msg: string) => void;
+  logError: (msg: string) => void;
+  exit: (code: number) => never;
+}
+
+const defaultDeps: SiteDeps = {
+  ipcCall: defaultIpcCall,
+  log: (m) => console.log(m),
+  logError: (m) => console.error(m),
+  exit: (c) => process.exit(c) as never,
+};
+
+const HELP = `mcx site — browser-mediated named HTTP calls for web apps
+
+Usage:
+  mcx sites                               List configured sites (alias for 'mcx site list')
+  mcx site list                           List configured sites
+  mcx site show <name>                    Show a site's config
+  mcx site add <name> --url <u> [...]     Create or update a site
+  mcx site remove <name>                  Remove a user-configured site
+
+  mcx site calls <site>                   List named calls in a site's catalog
+  mcx site describe <site> <call>         Show a call's definition
+  mcx site call <site> <call> [--k v ...] Invoke a named call
+  mcx site add-call <site> <name> --url <u> [--method M] [...]
+  mcx site remove-call <site> <call>
+
+  mcx site browser [sites...]             Launch browser and open tabs (auth)
+  mcx site disconnect                     Stop the browser
+  mcx site sniff <site> [--mode M] [--filter RE] [--limit N]
+  mcx site wiggle [site]                  Run the site's keep-alive script
+  mcx site eval <site> <code>             Evaluate JS in the site's page
+  mcx site cold-start [site]              Clear storage and reload
+
+Flags:
+  --json, -j       Output raw JSON
+  --help, -h       Show this help
+`;
+
+function parseKv(args: string[]): { kv: Record<string, unknown>; rest: string[] } {
+  const kv: Record<string, unknown> = {};
+  const rest: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a.startsWith("--")) {
+      const key = a.slice(2);
+      if (key.includes("=")) {
+        const [k, v] = key.split("=", 2);
+        kv[k] = coerce(v);
+      } else {
+        const next = args[i + 1];
+        if (next === undefined || next.startsWith("--")) {
+          kv[key] = true;
+        } else {
+          kv[key] = coerce(next);
+          i++;
+        }
+      }
+    } else {
+      rest.push(a);
+    }
+  }
+  return { kv, rest };
+}
+
+function coerce(v: string): string | number | boolean {
+  if (v === "true") return true;
+  if (v === "false") return false;
+  if (/^-?\d+(\.\d+)?$/.test(v)) return Number(v);
+  return v;
+}
+
+/** Extract the first text-content item from an MCP tool result, parsing JSON when possible. */
+function unwrap(result: unknown): unknown {
+  const r = result as { content?: Array<{ type: string; text?: string }>; isError?: boolean } | undefined;
+  const first = r?.content?.[0];
+  const text = first?.text ?? "";
+  if (r?.isError) return { _error: text };
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+async function callSiteTool(deps: SiteDeps, tool: string, args: Record<string, unknown>): Promise<unknown> {
+  const raw = await deps.ipcCall("callTool", { server: SITE_SERVER_NAME, tool, arguments: args });
+  return unwrap(raw);
+}
+
+function emit(deps: SiteDeps, data: unknown, json: boolean): void {
+  if (data && typeof data === "object" && "_error" in (data as Record<string, unknown>)) {
+    deps.logError(String((data as { _error: unknown })._error));
+    deps.exit(1);
+  }
+  if (json || typeof data !== "string") {
+    deps.log(JSON.stringify(data, null, 2));
+  } else {
+    deps.log(data);
+  }
+}
+
+export async function cmdSite(args: string[], depsOverride?: Partial<SiteDeps>): Promise<void> {
+  const deps: SiteDeps = { ...defaultDeps, ...depsOverride };
+  const { json, rest: afterJson } = extractJsonFlag(args);
+
+  if (afterJson.length === 0 || afterJson[0] === "help" || afterJson[0] === "--help" || afterJson[0] === "-h") {
+    deps.log(HELP);
+    return;
+  }
+
+  const sub = afterJson[0];
+  const subArgs = afterJson.slice(1);
+
+  switch (sub) {
+    case "list":
+    case "ls":
+      emit(deps, await callSiteTool(deps, "site_list", {}), json);
+      return;
+
+    case "show": {
+      const name = subArgs[0];
+      if (!name) return fail(deps, "usage: mcx site show <name>");
+      emit(deps, await callSiteTool(deps, "site_show", { name }), json);
+      return;
+    }
+
+    case "add": {
+      const name = subArgs[0];
+      if (!name) return fail(deps, "usage: mcx site add <name> --url <url> [--domains a,b,...]");
+      const { kv } = parseKv(subArgs.slice(1));
+      if (typeof kv.domains === "string") kv.domains = kv.domains.split(",");
+      emit(deps, await callSiteTool(deps, "site_add", { name, ...kv }), json);
+      return;
+    }
+
+    case "remove":
+    case "rm": {
+      const name = subArgs[0];
+      if (!name) return fail(deps, "usage: mcx site remove <name>");
+      emit(deps, await callSiteTool(deps, "site_remove", { name }), json);
+      return;
+    }
+
+    case "calls": {
+      const site = subArgs[0];
+      if (!site) return fail(deps, "usage: mcx site calls <site>");
+      emit(deps, await callSiteTool(deps, "site_calls", { site }), json);
+      return;
+    }
+
+    case "describe": {
+      const site = subArgs[0];
+      const call = subArgs[1];
+      if (!site || !call) return fail(deps, "usage: mcx site describe <site> <call>");
+      emit(deps, await callSiteTool(deps, "site_describe", { site, call }), json);
+      return;
+    }
+
+    case "call": {
+      const site = subArgs[0];
+      const call = subArgs[1];
+      if (!site || !call) return fail(deps, "usage: mcx site call <site> <call> [--param value ...]");
+      const { kv } = parseKv(subArgs.slice(2));
+      const { body, ...params } = kv;
+      emit(deps, await callSiteTool(deps, "site_call", { site, call, params, body }), json);
+      return;
+    }
+
+    case "add-call": {
+      const site = subArgs[0];
+      const name = subArgs[1];
+      if (!site || !name)
+        return fail(deps, "usage: mcx site add-call <site> <name> --url <u> [--method M] [--description ...]");
+      const { kv } = parseKv(subArgs.slice(2));
+      emit(deps, await callSiteTool(deps, "site_add_call", { site, name, ...kv }), json);
+      return;
+    }
+
+    case "remove-call": {
+      const site = subArgs[0];
+      const call = subArgs[1];
+      if (!site || !call) return fail(deps, "usage: mcx site remove-call <site> <call>");
+      emit(deps, await callSiteTool(deps, "site_remove_call", { site, call }), json);
+      return;
+    }
+
+    case "browser": {
+      const sites = subArgs.length > 0 ? subArgs : undefined;
+      emit(deps, await callSiteTool(deps, "site_browser_start", sites ? { sites } : {}), json);
+      return;
+    }
+
+    case "disconnect":
+    case "stop":
+      emit(deps, await callSiteTool(deps, "site_disconnect", {}), json);
+      return;
+
+    case "sniff": {
+      const site = subArgs[0];
+      if (!site) return fail(deps, "usage: mcx site sniff <site> [--mode M] [--filter RE] [--limit N]");
+      const { kv } = parseKv(subArgs.slice(1));
+      emit(deps, await callSiteTool(deps, "site_sniff", { site, ...kv }), json);
+      return;
+    }
+
+    case "wiggle": {
+      const site = subArgs[0];
+      emit(deps, await callSiteTool(deps, "site_wiggle", site ? { site } : {}), json);
+      return;
+    }
+
+    case "eval": {
+      const site = subArgs[0];
+      const code = subArgs.slice(1).join(" ");
+      if (!site || !code) return fail(deps, "usage: mcx site eval <site> <code>");
+      emit(deps, await callSiteTool(deps, "site_eval", { site, code }), json);
+      return;
+    }
+
+    case "cold-start": {
+      const site = subArgs[0];
+      emit(deps, await callSiteTool(deps, "site_cold_start", site ? { site } : {}), json);
+      return;
+    }
+
+    default:
+      return fail(deps, `Unknown subcommand: ${sub}\n\n${HELP}`);
+  }
+}
+
+function fail(deps: SiteDeps, msg: string): void {
+  deps.logError(msg);
+  deps.exit(1);
+}

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -51,6 +51,7 @@ import { cmdRun } from "./commands/run";
 import { cmdScope } from "./commands/scope";
 import { cmdServe } from "./commands/serve";
 import { cmdServeKill } from "./commands/serve-kill";
+import { cmdSite } from "./commands/site";
 import { cmdSpans } from "./commands/spans";
 import { cmdTelemetry } from "./commands/telemetry";
 import { cmdTrack, cmdTracked, cmdUntrack } from "./commands/track";
@@ -335,6 +336,14 @@ async function main(): Promise<void> {
 
       case "mail":
         await cmdMail(cleanArgs.slice(1));
+        break;
+
+      case "site":
+        await cmdSite(cleanArgs.slice(1));
+        break;
+
+      case "sites":
+        await cmdSite(["list", ...cleanArgs.slice(1)]);
         break;
 
       case "note":

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -128,6 +128,8 @@ const _originalOptions = {
   EPHEMERAL_ALIAS_PROMOTION_THRESHOLD: 3,
   /** Sprint state file path (pause/resume state) */
   SPRINT_STATE_PATH: join(MCP_CLI_DIR, "sprint-state.json"),
+  /** Directory for site configs, catalogs, and browser profiles */
+  SITES_DIR: join(MCP_CLI_DIR, "sites"),
 };
 export const options = { ..._originalOptions };
 export function _restoreOptions(): void {
@@ -244,3 +246,4 @@ export const MAIL_SERVER_NAME = "_mail";
 export const WORK_ITEMS_SERVER_NAME = "_work_items";
 export const MOCK_SERVER_NAME = "_mock";
 export const TRACING_SERVER_NAME = "_tracing";
+export const SITE_SERVER_NAME = "_site";

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -428,7 +428,9 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
   // Mock server: always available (no external binary needed)
   const mockServer = new MockServer(db, daemonId, undefined, logger);
 
-  // Site server: always available. Worker is lightweight; Playwright is lazy-loaded only if a browser tool is invoked.
+  // Site server: always started. The worker itself is lightweight — Playwright (and its ~200MB install)
+  // is only loaded via dynamic import the first time a browser-dependent tool runs. Users with no
+  // browser tool invocation pay the worker startup cost but nothing more.
   const siteServer = new SiteServer(daemonId, undefined, undefined, logger);
 
   // Start quota poller for proactive usage monitoring
@@ -611,6 +613,8 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
     opencodeServer.onActivity = () => resetIdleTimer();
   }
   mockServer.onActivity = () => resetIdleTimer();
+  // Site browser sessions can sit idle during interactive login — keep the daemon alive.
+  siteServer.onActivity = () => resetIdleTimer();
 
   // Start idle timer
   resetIdleTimer();

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -40,6 +40,7 @@ import {
   MOCK_SERVER_NAME,
   OPENCODE_SERVER_NAME,
   PROTOCOL_VERSION,
+  SITE_SERVER_NAME,
   TRACING_SERVER_NAME,
   WORK_ITEMS_SERVER_NAME,
   auditRuntimePermissions,
@@ -76,6 +77,7 @@ import { OpenCodeServer, buildOpenCodeToolCache } from "./opencode-server";
 import { reapOrphanedSessions } from "./orphan-reaper";
 import { QuotaPoller } from "./quota";
 import { ServerPool } from "./server-pool";
+import { SiteServer, buildSiteToolCache } from "./site-server";
 import { TracingServer } from "./tracing-server";
 import { WorkItemsServer } from "./work-items-server";
 
@@ -426,6 +428,9 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
   // Mock server: always available (no external binary needed)
   const mockServer = new MockServer(db, daemonId, undefined, logger);
 
+  // Site server: always available. Worker is lightweight; Playwright is lazy-loaded only if a browser tool is invoked.
+  const siteServer = new SiteServer(daemonId, undefined, undefined, logger);
+
   // Start quota poller for proactive usage monitoring
   const quotaPoller = new QuotaPoller({ logger });
   quotaPoller.start();
@@ -739,6 +744,20 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
     );
 
     pool.registerPendingVirtualServer(
+      SITE_SERVER_NAME,
+      (async () => {
+        try {
+          const { client: siteClient, transport: siteTransport } = await siteServer.start();
+          const siteTools = buildSiteToolCache();
+          pool.registerVirtualServer(SITE_SERVER_NAME, siteClient, siteTransport, siteTools);
+          logger.info("[mcpd] Site server started");
+        } catch (err) {
+          logger.error(`[mcpd] Failed to start site server: ${err}`);
+        }
+      })(),
+    );
+
+    pool.registerPendingVirtualServer(
       METRICS_SERVER_NAME,
       (async () => {
         try {
@@ -913,6 +932,7 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
           [ACP_SERVER_NAME, acpServer],
           [OPENCODE_SERVER_NAME, opencodeServer],
           [MOCK_SERVER_NAME, mockServer],
+          [SITE_SERVER_NAME, siteServer],
           [ALIAS_SERVER_NAME, aliasServer],
           [METRICS_SERVER_NAME, metricsServer],
           [TRACING_SERVER_NAME, tracingServer],

--- a/packages/daemon/src/site-server.spec.ts
+++ b/packages/daemon/src/site-server.spec.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { SITE_SERVER_NAME, silentLogger } from "@mcp-cli/core";
+import { SiteServer, buildSiteToolCache, isWorkerEvent } from "./site-server";
+import { SITE_TOOLS } from "./site/tools";
+
+describe("isWorkerEvent (site)", () => {
+  test("matches known event types", () => {
+    expect(isWorkerEvent({ type: "ready" })).toBe(true);
+    expect(isWorkerEvent({ type: "error", message: "x" })).toBe(true);
+  });
+
+  test("rejects unknown types and non-objects", () => {
+    expect(isWorkerEvent({ type: "db:upsert" })).toBe(false);
+    expect(isWorkerEvent({})).toBe(false);
+    expect(isWorkerEvent(null)).toBe(false);
+    expect(isWorkerEvent("ready")).toBe(false);
+  });
+});
+
+describe("buildSiteToolCache", () => {
+  test("returns a ToolInfo for every defined tool", () => {
+    const cache = buildSiteToolCache();
+    expect(cache.size).toBe(SITE_TOOLS.length);
+    for (const def of SITE_TOOLS) {
+      const info = cache.get(def.name);
+      expect(info).toBeDefined();
+      expect(info?.server).toBe(SITE_SERVER_NAME);
+      expect(info?.description).toBe(def.description);
+      expect(info?.signature).toBeTruthy();
+    }
+  });
+});
+
+describe("SITE_SERVER_NAME", () => {
+  test("is _site", () => {
+    expect(SITE_SERVER_NAME).toBe("_site");
+  });
+});
+
+/**
+ * Fake Worker that responds to init with ready, and ignores everything else.
+ * Lets us exercise SiteServer's handshake + failure paths without spawning a real worker.
+ */
+function makeFakeWorker(behavior: { replyReady?: boolean; replyErrorMessage?: string } = { replyReady: true }): Worker {
+  const listeners = new Map<string, ((event: MessageEvent | ErrorEvent | Event) => void) | null>();
+  const worker = {
+    postMessage: mock((msg: unknown) => {
+      const m = msg as { type?: string } | undefined;
+      if (m?.type === "init") {
+        queueMicrotask(() => {
+          const onmessage = listeners.get("message");
+          if (!onmessage) return;
+          if (behavior.replyErrorMessage) {
+            onmessage({ data: { type: "error", message: behavior.replyErrorMessage } } as MessageEvent);
+          } else if (behavior.replyReady) {
+            onmessage({ data: { type: "ready" } } as MessageEvent);
+          }
+        });
+      }
+    }),
+    terminate: mock(() => {}),
+    get onmessage() {
+      return listeners.get("message") ?? null;
+    },
+    set onmessage(fn) {
+      listeners.set("message", fn);
+    },
+    get onerror() {
+      return listeners.get("error") ?? null;
+    },
+    set onerror(fn) {
+      listeners.set("error", fn);
+    },
+  };
+  return worker as unknown as Worker;
+}
+
+describe("SiteServer", () => {
+  let server: SiteServer | undefined;
+
+  afterEach(async () => {
+    await server?.stop();
+    server = undefined;
+  });
+
+  test("rejects on worker error message", async () => {
+    const workerFactory = (_path: string): Worker => makeFakeWorker({ replyErrorMessage: "boom" });
+    server = new SiteServer(undefined, undefined, workerFactory, silentLogger, 500);
+    await expect(server.start()).rejects.toThrow(/boom/);
+  });
+
+  test("rejects on handshake timeout when no ready arrives", async () => {
+    const workerFactory = (_path: string): Worker => makeFakeWorker({ replyReady: false });
+    server = new SiteServer(undefined, undefined, workerFactory, silentLogger, 250);
+    await expect(server.start()).rejects.toThrow(/timeout/);
+  });
+});

--- a/packages/daemon/src/site-server.ts
+++ b/packages/daemon/src/site-server.ts
@@ -1,0 +1,192 @@
+/**
+ * Virtual MCP server that exposes the site-worker's tools to the ServerPool.
+ *
+ * Mirrors MockServer / CodexServer: spawns a Bun Worker, waits for the
+ * "ready" handshake, and connects an MCP Client over WorkerClientTransport.
+ * The worker is started lazily (only when any site is configured) so users
+ * without sites pay no startup cost.
+ */
+
+import type { JsonSchema, Logger, ToolInfo } from "@mcp-cli/core";
+import { SITE_SERVER_NAME, consoleLogger, formatToolSignature } from "@mcp-cli/core";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { closeClientWithTimeout } from "./close-timeout";
+import { SITE_TOOLS } from "./site/tools";
+import { workerPath } from "./worker-path";
+import { WorkerClientTransport } from "./worker-transport";
+
+interface ReadyMessage {
+  type: "ready";
+}
+interface ErrorMessage {
+  type: "error";
+  message: string;
+}
+
+type WorkerEvent = ReadyMessage | ErrorMessage;
+
+const WORKER_EVENT_TYPES: ReadonlySet<string> = new Set<WorkerEvent["type"]>(["ready", "error"]);
+
+export function isWorkerEvent(data: unknown): data is WorkerEvent {
+  return (
+    typeof data === "object" &&
+    data !== null &&
+    "type" in data &&
+    WORKER_EVENT_TYPES.has((data as { type: string }).type)
+  );
+}
+
+type ClientFactory = () => Client;
+type WorkerFactory = (scriptPath: string) => Worker;
+
+export class SiteServer {
+  private worker: Worker | null = null;
+  private transport: WorkerClientTransport | null = null;
+  private client: Client | null = null;
+  private readonly clientFactory: ClientFactory;
+  private readonly workerFactory: WorkerFactory;
+  private readonly logger: Logger;
+
+  /** Called on worker activity — lets the daemon reset its idle timer. */
+  onActivity?: () => void;
+
+  constructor(
+    private daemonId?: string,
+    clientFactory?: ClientFactory,
+    workerFactory?: WorkerFactory,
+    logger?: Logger,
+    private handshakeTimeoutMs = 10_000,
+  ) {
+    this.clientFactory = clientFactory ?? (() => new Client({ name: `mcp-cli/${SITE_SERVER_NAME}`, version: "0.1.0" }));
+    this.workerFactory = workerFactory ?? ((scriptPath: string) => new Worker(scriptPath));
+    this.logger = logger ?? consoleLogger;
+  }
+
+  async start(): Promise<{ client: Client; transport: WorkerClientTransport }> {
+    if (this.worker) throw new Error("SiteServer.start() called while worker is already running");
+    const worker = this.workerFactory(workerPath("site-worker.ts"));
+    this.worker = worker;
+
+    // Wait for the worker to report ready
+    await new Promise<void>((resolve, reject) => {
+      let settled = false;
+      const cleanup = (): boolean => {
+        if (settled) return false;
+        settled = true;
+        try {
+          worker.terminate();
+        } catch {
+          /* already dead */
+        }
+        this.worker = null;
+        return true;
+      };
+      const timeout = setTimeout(() => {
+        if (cleanup()) reject(new Error(`Site worker startup timeout (${this.handshakeTimeoutMs}ms)`));
+      }, this.handshakeTimeoutMs);
+
+      worker.onmessage = (event: MessageEvent) => {
+        if (event.data?.type === "ready") {
+          settled = true;
+          clearTimeout(timeout);
+          resolve();
+        } else if (event.data?.type === "error") {
+          clearTimeout(timeout);
+          if (cleanup()) reject(new Error(`Site worker init failed: ${event.data.message}`));
+        }
+      };
+      worker.onerror = (event: ErrorEvent | Event) => {
+        clearTimeout(timeout);
+        const msg = event instanceof ErrorEvent ? event.message : String(event);
+        if (cleanup()) reject(new Error(`Site worker error: ${msg}`));
+      };
+      worker.postMessage({ type: "init", daemonId: this.daemonId });
+    });
+
+    try {
+      this.transport = new WorkerClientTransport(this.worker);
+      this.client = this.clientFactory();
+
+      let handshakeTimer: ReturnType<typeof setTimeout> | undefined;
+      let connectResolved = false;
+      await Promise.race([
+        this.client.connect(this.transport).then((r) => {
+          connectResolved = true;
+          return r;
+        }),
+        new Promise<never>((_, reject) => {
+          handshakeTimer = setTimeout(() => {
+            if (connectResolved) return;
+            reject(new Error(`Site MCP handshake timeout (${this.handshakeTimeoutMs}ms)`));
+          }, this.handshakeTimeoutMs);
+        }),
+      ]);
+      clearTimeout(handshakeTimer);
+
+      // Intercept site-level DB events on their way through (none today, but keeps the pattern aligned with other backends).
+      const transportHandler = worker.onmessage;
+      worker.onmessage = (event: MessageEvent) => {
+        const data = event.data;
+        if (isWorkerEvent(data)) {
+          this.handleWorkerEvent(data);
+          return;
+        }
+        transportHandler?.call(worker, event);
+      };
+
+      worker.onerror = null;
+    } catch (err) {
+      try {
+        await this.client?.close();
+      } catch {
+        /* ignore */
+      }
+      try {
+        worker.terminate();
+      } catch {
+        /* already dead */
+      }
+      this.worker = null;
+      this.transport = null;
+      this.client = null;
+      throw err;
+    }
+
+    return { client: this.client, transport: this.transport };
+  }
+
+  async stop(): Promise<void> {
+    await closeClientWithTimeout(this.client);
+    if (this.worker) {
+      this.worker.onmessage = null;
+      this.worker.onerror = null;
+      this.worker.terminate();
+    }
+    this.worker = null;
+    this.transport = null;
+    this.client = null;
+  }
+
+  private handleWorkerEvent(event: WorkerEvent): void {
+    if (event.type === "error") {
+      this.logger.error(`[site-server] worker error: ${event.message}`);
+    }
+    this.onActivity?.();
+  }
+}
+
+/** Build static ToolInfo for pre-populating the pool's tool cache (mcx ls works before the worker boots). */
+export function buildSiteToolCache(): Map<string, ToolInfo> {
+  const tools = new Map<string, ToolInfo>();
+  for (const def of SITE_TOOLS) {
+    const inputSchema = def.inputSchema as JsonSchema;
+    tools.set(def.name, {
+      name: def.name,
+      server: SITE_SERVER_NAME,
+      description: def.description,
+      inputSchema,
+      signature: formatToolSignature(def.name, inputSchema),
+    });
+  }
+  return tools;
+}

--- a/packages/daemon/src/site-worker.ts
+++ b/packages/daemon/src/site-worker.ts
@@ -27,6 +27,7 @@ import {
   getSiteForDomain,
   listSites,
   resolveSiteAsset,
+  validateSiteName,
   writeSiteConfig,
 } from "./site/config";
 import { CredentialVault, summarizeCredential } from "./site/credentials";
@@ -76,10 +77,21 @@ async function loadBrowser(engine: BrowserEngineName): Promise<BrowserEngine> {
     );
   }
   if (engine === "playwright") {
-    const mod = await import("./site/browser/playwright");
-    browser = new mod.PlaywrightBrowserEngine();
-    browserEngineName = "playwright";
-    return browser;
+    try {
+      const mod = await import("./site/browser/playwright");
+      browser = new mod.PlaywrightBrowserEngine();
+      browserEngineName = "playwright";
+      return browser;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (/Cannot find (module|package)|ERR_MODULE_NOT_FOUND|Module not found/.test(msg)) {
+        throw new Error(
+          "Playwright is not installed. Sites with browser tools require the optional 'playwright' dependency: run `bun add -D playwright` and retry.",
+          { cause: err instanceof Error ? err : undefined },
+        );
+      }
+      throw err;
+    }
   }
   throw new Error(`Browser engine '${engine}' is not yet implemented. Use 'playwright'.`);
 }
@@ -131,7 +143,11 @@ function handleShow(args: Record<string, unknown>): ToolResult {
 
 function handleAdd(args: Record<string, unknown>): ToolResult {
   const name = args.name as string;
-  if (!name) return error("Missing 'name'");
+  try {
+    validateSiteName(name);
+  } catch (err) {
+    return error(err instanceof Error ? err.message : String(err));
+  }
   const existing = getSite(name);
   const { name: _omit, ...existingWithoutName } = existing ?? {};
   const merged: Record<string, unknown> = {
@@ -157,6 +173,11 @@ function handleAdd(args: Record<string, unknown>): ToolResult {
 
 function handleRemove(args: Record<string, unknown>): ToolResult {
   const name = args.name as string;
+  try {
+    validateSiteName(name);
+  } catch (err) {
+    return error(err instanceof Error ? err.message : String(err));
+  }
   const dir = sitePath(name);
   if (!existsSync(dir)) return error(`Site '${name}' has no user directory`);
   rmSync(dir, { recursive: true, force: true });

--- a/packages/daemon/src/site-worker.ts
+++ b/packages/daemon/src/site-worker.ts
@@ -36,6 +36,7 @@ import { proxyCall } from "./site/proxy";
 import { resolve as resolveCall } from "./site/resolver";
 import { Sniffer } from "./site/sniffer";
 import { SITE_TOOLS, SITE_TOOL_NAMES } from "./site/tools";
+import { applyFetchFilter, applyJqInput, applyJqOutput } from "./site/transforms";
 import { createIsControlMessage } from "./worker-control-message";
 import { WorkerServerTransport } from "./worker-transport";
 
@@ -213,17 +214,20 @@ async function handleCall(args: Record<string, unknown>): Promise<ToolResult> {
   let resolved: ReturnType<typeof resolveCall>;
   try {
     resolved = resolveCall(call, params, rawBody);
+    resolved = await applyJqInput(call, params, resolved);
+    resolved = applyFetchFilter(call, resolved);
   } catch (err) {
     return error(err instanceof Error ? err.message : String(err));
   }
 
   try {
-    const result = await proxyCall(vault, {
+    let result = await proxyCall(vault, {
       site: site.name,
       resolved,
       audHints: call.audHints,
       onWiggle: browser ? async () => void (await browser?.wiggle(site.name)) : undefined,
     });
+    result = await applyJqOutput(call, result);
     return ok(result);
   } catch (err) {
     return error(err instanceof Error ? err.message : String(err));

--- a/packages/daemon/src/site-worker.ts
+++ b/packages/daemon/src/site-worker.ts
@@ -1,0 +1,415 @@
+/**
+ * Bun Worker hosting the `_site` virtual MCP server.
+ *
+ * Sites are web-app targets with per-site named-call catalogs, credential
+ * vaults, and optional browser-mediated auth. Pure-HTTP tools run without
+ * touching the browser. The browser engine (Playwright today) is loaded only
+ * via dynamic import the first time a browser-dependent tool is invoked —
+ * this keeps `mcpd` startup fast and Playwright off the hot path for users
+ * who never configure a site.
+ *
+ * Protocol:
+ *   1. Parent sends: { type: "init" }
+ *   2. Worker starts MCP Server, responds: { type: "ready" }
+ *   3. Parent sends MCP JSON-RPC messages (via WorkerClientTransport)
+ *   4. Worker sends MCP JSON-RPC responses back
+ */
+
+import { existsSync, rmSync } from "node:fs";
+import { SITE_SERVER_NAME } from "@mcp-cli/core";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import type { BrowserEngine, BrowserEngineName, SiteSpec } from "./site/browser/engine";
+import { removeCall as catalogRemoveCall, upsertCall as catalogUpsertCall, loadCatalog } from "./site/catalog";
+import {
+  type SiteConfig,
+  getSite,
+  getSiteForDomain,
+  listSites,
+  resolveSiteAsset,
+  writeSiteConfig,
+} from "./site/config";
+import { CredentialVault, summarizeCredential } from "./site/credentials";
+import { siteBrowserProfileDir, sitePath } from "./site/paths";
+import { proxyCall } from "./site/proxy";
+import { resolve as resolveCall } from "./site/resolver";
+import { Sniffer } from "./site/sniffer";
+import { SITE_TOOLS, SITE_TOOL_NAMES } from "./site/tools";
+import { createIsControlMessage } from "./worker-control-message";
+import { WorkerServerTransport } from "./worker-transport";
+
+// ── Control messages ──
+
+interface InitMessage {
+  type: "init";
+  daemonId?: string;
+}
+
+interface ToolsChangedMessage {
+  type: "tools_changed";
+}
+
+type ControlMessage = InitMessage | ToolsChangedMessage;
+const CONTROL_MESSAGE_TYPES: ReadonlySet<string> = new Set<ControlMessage["type"]>(["init", "tools_changed"]);
+const isControlMessage = createIsControlMessage<ControlMessage>(CONTROL_MESSAGE_TYPES);
+
+declare const self: Worker;
+
+let mcpServer: Server | null = null;
+let transport: WorkerServerTransport | null = null;
+
+// ── Runtime singletons ──
+
+const vault = new CredentialVault();
+const sniffer = new Sniffer(vault);
+let browser: BrowserEngine | null = null;
+let browserEngineName: BrowserEngineName | null = null;
+const sitesOpenInBrowser = new Set<string>();
+
+// ── Lazy browser load ──
+
+async function loadBrowser(engine: BrowserEngineName): Promise<BrowserEngine> {
+  if (browser && browserEngineName === engine) return browser;
+  if (browser && browserEngineName !== engine) {
+    throw new Error(
+      `Browser already running with engine '${browserEngineName}'. Stop it with site_disconnect before switching to '${engine}'.`,
+    );
+  }
+  if (engine === "playwright") {
+    const mod = await import("./site/browser/playwright");
+    browser = new mod.PlaywrightBrowserEngine();
+    browserEngineName = "playwright";
+    return browser;
+  }
+  throw new Error(`Browser engine '${engine}' is not yet implemented. Use 'playwright'.`);
+}
+
+function siteSpecFor(cfg: SiteConfig): SiteSpec {
+  const profile = cfg.browser?.chromeProfile ?? "default";
+  const wiggleRel = cfg.wiggle;
+  const wigglePath = wiggleRel ? resolveSiteAsset(cfg.name, cfg.seed ?? cfg.name, wiggleRel) : null;
+  return {
+    name: cfg.name,
+    url: cfg.url,
+    blockProtocols: cfg.blockProtocols,
+    profileDir: siteBrowserProfileDir(cfg.name, profile),
+    wigglePath: wigglePath ?? undefined,
+  };
+}
+
+function requireSite(name: string): SiteConfig {
+  const s = getSite(name);
+  if (!s) throw new Error(`Unknown site: ${name}`);
+  return s;
+}
+
+// ── Tool handlers ──
+
+type ToolResult = { content: Array<{ type: "text"; text: string }>; isError?: boolean };
+
+function ok(data: unknown): ToolResult {
+  const text = typeof data === "string" ? data : JSON.stringify(data, null, 2);
+  return { content: [{ type: "text", text }] };
+}
+
+function error(message: string): ToolResult {
+  return { content: [{ type: "text", text: `Error: ${message}` }], isError: true };
+}
+
+function handleList(): ToolResult {
+  return ok(
+    listSites().map((s) => ({ name: s.name, url: s.url, enabled: s.enabled, engine: s.browser?.engine, seed: s.seed })),
+  );
+}
+
+function handleShow(args: Record<string, unknown>): ToolResult {
+  const name = args.name as string;
+  const site = getSite(name);
+  if (!site) return error(`Unknown site: ${name}`);
+  return ok(site);
+}
+
+function handleAdd(args: Record<string, unknown>): ToolResult {
+  const name = args.name as string;
+  if (!name) return error("Missing 'name'");
+  const existing = getSite(name);
+  const { name: _omit, ...existingWithoutName } = existing ?? {};
+  const merged: Record<string, unknown> = {
+    ...existingWithoutName,
+    ...(args.url !== undefined ? { url: args.url } : {}),
+    ...(args.domains !== undefined ? { domains: args.domains } : {}),
+    ...(args.enabled !== undefined ? { enabled: args.enabled } : {}),
+    ...(args.captureMode !== undefined ? { captureMode: args.captureMode } : {}),
+    ...(args.blockProtocols !== undefined ? { blockProtocols: args.blockProtocols } : {}),
+    ...(args.wiggle !== undefined ? { wiggle: args.wiggle } : {}),
+    ...(args.seed !== undefined ? { seed: args.seed } : {}),
+  };
+  if (args.browserEngine !== undefined || args.chromeProfile !== undefined) {
+    merged.browser = {
+      ...(existing?.browser ?? {}),
+      ...(args.browserEngine !== undefined ? { engine: args.browserEngine } : {}),
+      ...(args.chromeProfile !== undefined ? { chromeProfile: args.chromeProfile } : {}),
+    };
+  }
+  writeSiteConfig(name, merged);
+  return ok({ ok: true, site: getSite(name) });
+}
+
+function handleRemove(args: Record<string, unknown>): ToolResult {
+  const name = args.name as string;
+  const dir = sitePath(name);
+  if (!existsSync(dir)) return error(`Site '${name}' has no user directory`);
+  rmSync(dir, { recursive: true, force: true });
+  return ok({ ok: true, removed: name });
+}
+
+function handleCalls(args: Record<string, unknown>): ToolResult {
+  const site = requireSite(args.site as string);
+  const catalog = loadCatalog(site.name, site.seed ?? site.name);
+  return ok(
+    Object.values(catalog).map((c) => ({ name: c.name, method: c.method, url: c.url, description: c.description })),
+  );
+}
+
+function handleDescribe(args: Record<string, unknown>): ToolResult {
+  const site = requireSite(args.site as string);
+  const catalog = loadCatalog(site.name, site.seed ?? site.name);
+  const call = catalog[args.call as string];
+  if (!call) return error(`Unknown call '${args.call}' for site '${site.name}'`);
+  return ok(call);
+}
+
+async function handleCall(args: Record<string, unknown>): Promise<ToolResult> {
+  const site = requireSite(args.site as string);
+  const callName = args.call as string;
+  const catalog = loadCatalog(site.name, site.seed ?? site.name);
+  const call = catalog[callName];
+  if (!call) return error(`Unknown call '${callName}' for site '${site.name}'`);
+
+  const params = (args.params as Record<string, unknown>) ?? {};
+  const rawBody = args.body as string | undefined;
+
+  let resolved: ReturnType<typeof resolveCall>;
+  try {
+    resolved = resolveCall(call, params, rawBody);
+  } catch (err) {
+    return error(err instanceof Error ? err.message : String(err));
+  }
+
+  try {
+    const result = await proxyCall(vault, {
+      site: site.name,
+      resolved,
+      audHints: call.audHints,
+      onWiggle: browser ? async () => void (await browser?.wiggle(site.name)) : undefined,
+    });
+    return ok(result);
+  } catch (err) {
+    return error(err instanceof Error ? err.message : String(err));
+  }
+}
+
+function handleAddCall(args: Record<string, unknown>): ToolResult {
+  const site = requireSite(args.site as string);
+  const name = args.name as string;
+  const url = args.url as string;
+  if (!name || !url) return error("Missing 'name' or 'url'");
+  const call = {
+    name,
+    url,
+    method: ((args.method as string) ?? "GET").toUpperCase(),
+    description: args.description as string | undefined,
+    headers: args.headers as Record<string, string> | undefined,
+    audHints: args.audHints as string[] | undefined,
+  };
+  catalogUpsertCall(site.name, call, site.seed ?? site.name);
+  return ok({ ok: true, call });
+}
+
+function handleRemoveCall(args: Record<string, unknown>): ToolResult {
+  const site = requireSite(args.site as string);
+  const removed = catalogRemoveCall(site.name, args.call as string, site.seed ?? site.name);
+  return ok({ ok: true, removed });
+}
+
+async function handleBrowserStart(args: Record<string, unknown>): Promise<ToolResult> {
+  const siteNames =
+    (args.sites as string[] | undefined) ??
+    listSites()
+      .filter((s) => s.enabled)
+      .map((s) => s.name);
+  const sites = siteNames.map((n) => requireSite(n));
+  if (sites.length === 0) return error("No sites configured");
+
+  const engine = (sites[0].browser?.engine ?? "playwright") as BrowserEngineName;
+  // Per-site engine mixing isn't supported in one context. Flag it clearly.
+  for (const s of sites) {
+    if ((s.browser?.engine ?? "playwright") !== engine) {
+      return error(
+        `All sites opened in one browser must use the same engine. Mixed: ${engine} vs ${s.browser?.engine}`,
+      );
+    }
+    sniffer.configureSite(s.name, s.captureMode ?? "firehose", s.captureFilters);
+  }
+
+  const eng = await loadBrowser(engine);
+  const specs = sites.map(siteSpecFor);
+  await eng.start(specs, sniffer.asEvents());
+  for (const s of sites) sitesOpenInBrowser.add(s.name);
+
+  return ok({ ok: true, engine, sites: eng.getSiteNames() });
+}
+
+async function handleDisconnect(): Promise<ToolResult> {
+  if (!browser) return ok({ ok: true, note: "browser was not running" });
+  await browser.stop();
+  browser = null;
+  browserEngineName = null;
+  sitesOpenInBrowser.clear();
+  return ok({ ok: true });
+}
+
+function handleSniff(args: Record<string, unknown>): ToolResult {
+  const site = requireSite(args.site as string);
+  if (args.mode !== undefined) {
+    const mode = args.mode as "off" | "filtered" | "firehose";
+    sniffer.setMode(site.name, mode);
+  }
+  const filter = args.filter as string | undefined;
+  const limit = (args.limit as number | undefined) ?? 50;
+  return ok({
+    site: site.name,
+    mode: sniffer.getMode(site.name),
+    recentRequests: sniffer
+      .getRecentRequests(filter)
+      .filter((r) => r.site === site.name)
+      .slice(-limit),
+    recentResponses: sniffer
+      .getRecentResponses(filter)
+      .filter((r) => r.site === site.name)
+      .slice(-limit),
+    recentWsFrames: sniffer
+      .getRecentWsFrames(filter)
+      .filter((r) => r.site === site.name)
+      .slice(-limit),
+    credentials: vault.getAll(site.name).map(summarizeCredential),
+  });
+}
+
+async function handleWiggle(args: Record<string, unknown>): Promise<ToolResult> {
+  if (!browser) return error("Browser is not running. Start it with site_browser_start.");
+  const site = args.site as string | undefined;
+  const touched = await browser.wiggle(site);
+  return ok({ ok: true, touched });
+}
+
+async function handleEval(args: Record<string, unknown>): Promise<ToolResult> {
+  if (!browser) return error("Browser is not running. Start it with site_browser_start.");
+  const code = args.code as string;
+  if (!code) return error("Missing 'code'");
+  const site = args.site as string | undefined;
+  return ok({ result: await browser.evalInPage(code, site) });
+}
+
+async function handleColdStart(args: Record<string, unknown>): Promise<ToolResult> {
+  if (!browser) return error("Browser is not running. Start it with site_browser_start.");
+  const site = args.site as string | undefined;
+  return ok(await browser.coldStart(site));
+}
+
+async function dispatch(name: string, args: Record<string, unknown>): Promise<ToolResult> {
+  if (!SITE_TOOL_NAMES.has(name)) return error(`Unknown tool: ${name}`);
+  try {
+    switch (name) {
+      case "site_list":
+        return handleList();
+      case "site_show":
+        return handleShow(args);
+      case "site_add":
+        return handleAdd(args);
+      case "site_remove":
+        return handleRemove(args);
+      case "site_calls":
+        return handleCalls(args);
+      case "site_describe":
+        return handleDescribe(args);
+      case "site_call":
+        return await handleCall(args);
+      case "site_add_call":
+        return handleAddCall(args);
+      case "site_remove_call":
+        return handleRemoveCall(args);
+      case "site_browser_start":
+        return await handleBrowserStart(args);
+      case "site_disconnect":
+        return await handleDisconnect();
+      case "site_sniff":
+        return handleSniff(args);
+      case "site_wiggle":
+        return await handleWiggle(args);
+      case "site_eval":
+        return await handleEval(args);
+      case "site_cold_start":
+        return await handleColdStart(args);
+      default:
+        return error(`Unhandled tool: ${name}`);
+    }
+  } catch (err) {
+    return error(err instanceof Error ? err.message : String(err));
+  }
+}
+
+// Silence unused warnings for helpers that will be wired up when mcx auth integration lands (#1454 follow-up).
+void getSiteForDomain;
+void sitesOpenInBrowser;
+
+// ── Server startup ──
+
+async function startServer(): Promise<void> {
+  mcpServer = new Server({ name: SITE_SERVER_NAME, version: "0.1.0" }, { capabilities: { tools: {} } });
+
+  mcpServer.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: SITE_TOOLS.map((t) => ({
+      name: t.name,
+      description: t.description,
+      inputSchema: t.inputSchema,
+    })),
+  }));
+
+  mcpServer.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+    return dispatch(name, args ?? {});
+  });
+
+  transport = new WorkerServerTransport(self);
+  await mcpServer.connect(transport);
+
+  const transportHandler = self.onmessage;
+  self.onmessage = async (event: MessageEvent): Promise<void> => {
+    const data = event.data;
+    if (isControlMessage(data)) {
+      if (data.type === "tools_changed") {
+        await mcpServer?.notification({ method: "notifications/tools/list_changed" });
+      }
+      return;
+    }
+    transportHandler?.call(self, event);
+  };
+}
+
+// ── Initial message handler ──
+
+self.onmessage = async (event: MessageEvent): Promise<void> => {
+  const data = event.data;
+  if (isControlMessage(data) && data.type === "init") {
+    try {
+      await startServer();
+      self.postMessage({ type: "ready" });
+    } catch (err) {
+      mcpServer = null;
+      transport = null;
+      const message = err instanceof Error ? err.message : String(err);
+      self.postMessage({ type: "error", message });
+    }
+  }
+};

--- a/packages/daemon/src/site/browser/engine.ts
+++ b/packages/daemon/src/site/browser/engine.ts
@@ -1,0 +1,85 @@
+/**
+ * BrowserEngine abstraction — decouples site-worker tool handlers from the
+ * concrete browser driver (Playwright today, Bun.WebView planned).
+ *
+ * Types here must be plain JS / JSON-shaped so adapters can be plugged in
+ * without leaking Playwright's type surface. Heavy deps (playwright) live
+ * only inside adapter implementations loaded via dynamic import.
+ */
+
+export interface SiteSpec {
+  name: string;
+  url: string;
+  blockProtocols?: string[];
+  /** Absolute path to a wiggle.js module (exports default `async (page) => string[]`). Optional. */
+  wigglePath?: string;
+  /** Profile dir the adapter should use for this site's user data. */
+  profileDir: string;
+}
+
+export interface CapturedRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  postData: string | null;
+  resourceType: string;
+}
+
+export interface CapturedResponse {
+  url: string;
+  method: string;
+  status: number;
+  contentType: string;
+  headers: Record<string, string>;
+  bodyBytes: number;
+  /** When the content-type is textual, body is a string. Otherwise null (only metadata is captured). */
+  bodyText: string | null;
+  requestHeaders: Record<string, string>;
+  requestPostData: string | null;
+}
+
+export interface CapturedWsFrame {
+  wsUrl: string;
+  direction: "tx" | "rx";
+  bytes: number;
+  payload: string;
+}
+
+export interface BrowserEvents {
+  onRequest?: (site: string, req: CapturedRequest) => void;
+  onResponse?: (site: string, resp: CapturedResponse) => void;
+  onWsFrame?: (site: string, frame: CapturedWsFrame) => void;
+}
+
+export interface ColdStartResult {
+  cleared: string[];
+  reloaded: boolean;
+}
+
+export interface BrowserEngine {
+  /** Idempotent; subsequent calls are a no-op. `events` is wired for the lifetime. */
+  start(sites: SiteSpec[], events: BrowserEvents): Promise<void>;
+  stop(): Promise<void>;
+  isRunning(): boolean;
+  /** Names of sites currently pinned to a tab/window. */
+  getSiteNames(): string[];
+  /** Clear non-cookie storage for the site's origin and reload. */
+  coldStart(site?: string): Promise<ColdStartResult>;
+  /** Run the site's wiggle module in the page context; returns whatever the script returns. */
+  wiggle(site?: string): Promise<string[]>;
+  /** Evaluate an expression in the page's JS context. Results must be JSON-serializable. */
+  evalInPage(code: string, site?: string): Promise<unknown>;
+  getUrl(site?: string): Promise<string>;
+  getTitle(site?: string): Promise<string>;
+  getHtml(site?: string): Promise<string>;
+}
+
+/** The single concrete engine name users configure in site.config.browser.engine. */
+export type BrowserEngineName = "playwright" | "webview";
+
+export class BrowserEngineUnavailable extends Error {
+  constructor(engine: BrowserEngineName, detail: string) {
+    super(`Browser engine '${engine}' is unavailable: ${detail}`);
+    this.name = "BrowserEngineUnavailable";
+  }
+}

--- a/packages/daemon/src/site/browser/playwright.ts
+++ b/packages/daemon/src/site/browser/playwright.ts
@@ -1,0 +1,304 @@
+/**
+ * Playwright-backed BrowserEngine adapter.
+ *
+ * Launches a single persistent Chrome context with one tab per configured
+ * site. Requests, responses, and WebSocket frames are forwarded to
+ * BrowserEvents so the credential vault + sniffer can observe them.
+ *
+ * IMPORTANT: this file is only imported via dynamic `import()` inside the
+ * site-worker. Static imports would force every daemon startup to load
+ * Playwright's heavy binding module. See `../../site-worker.ts`.
+ */
+
+import { existsSync, mkdirSync } from "node:fs";
+import type {
+  BrowserContext,
+  Page,
+  Request as PwRequest,
+  Response as PwResponse,
+  WebSocket as PwWebSocket,
+} from "playwright";
+import { chromium } from "playwright";
+import type {
+  BrowserEngine,
+  BrowserEvents,
+  CapturedRequest,
+  CapturedResponse,
+  ColdStartResult,
+  SiteSpec,
+} from "./engine";
+
+function isTextual(contentType: string): boolean {
+  if (!contentType) return true;
+  return (
+    contentType.includes("json") ||
+    contentType.startsWith("text/") ||
+    contentType.includes("xml") ||
+    contentType.includes("javascript") ||
+    contentType.includes("form")
+  );
+}
+
+export class PlaywrightBrowserEngine implements BrowserEngine {
+  private context: BrowserContext | null = null;
+  private pages = new Map<string, Page>();
+  private siteSpecs = new Map<string, SiteSpec>();
+  /** Serializes browser calls to avoid cross-interleaved operations on the same page. */
+  private lock: Promise<unknown> = Promise.resolve();
+  private events: BrowserEvents = {};
+
+  async start(sites: SiteSpec[], events: BrowserEvents): Promise<void> {
+    if (this.context) return;
+    this.events = events;
+    for (const s of sites) this.siteSpecs.set(s.name, s);
+
+    // Playwright requires a real directory to persist — use the first site's profile as the context root.
+    // When multiple sites share a profile dir (they shouldn't, but may), Playwright merges them.
+    if (sites.length === 0) throw new Error("PlaywrightBrowserEngine.start: at least one site is required");
+    const profileDir = sites[0].profileDir;
+    mkdirSync(profileDir, { recursive: true });
+
+    const ctx = await chromium.launchPersistentContext(profileDir, {
+      channel: "chrome",
+      headless: false,
+      viewport: { width: 1280, height: 900 },
+      args: [
+        "--disable-blink-features=AutomationControlled",
+        "--disable-background-timer-throttling",
+        "--disable-backgrounding-occluded-windows",
+        "--disable-renderer-backgrounding",
+      ],
+    });
+    this.context = ctx;
+
+    const blockedPatterns: RegExp[] = [];
+    for (const s of sites) {
+      for (const proto of s.blockProtocols ?? []) {
+        const escaped = proto.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        blockedPatterns.push(new RegExp(`^${escaped.replace(/:\/\/$/, ":")}`));
+      }
+    }
+    if (blockedPatterns.length > 0) {
+      await ctx.route("**/*", async (route) => {
+        const url = route.request().url();
+        if (blockedPatterns.some((re) => re.test(url))) {
+          await route.abort();
+          return;
+        }
+        await route.continue();
+      });
+    }
+
+    const usedPages = new Set<Page>();
+    for (const s of sites) {
+      const page = ctx.pages().find((p) => !usedPages.has(p)) ?? (await ctx.newPage());
+      usedPages.add(page);
+      this.pages.set(s.name, page);
+
+      this.attachListeners(page, s.name);
+
+      try {
+        await page.goto(s.url, { waitUntil: "domcontentloaded" });
+      } catch {
+        // Navigation failures are non-fatal — the page is still useful for auth.
+      }
+    }
+  }
+
+  private attachListeners(page: Page, siteName: string): void {
+    page.on("request", (req: PwRequest) => {
+      try {
+        const captured: CapturedRequest = {
+          url: req.url(),
+          method: req.method(),
+          headers: req.headers(),
+          postData: req.postData() ?? null,
+          resourceType: req.resourceType(),
+        };
+        this.events.onRequest?.(siteName, captured);
+      } catch {
+        // Never let listener errors propagate into the page.
+      }
+    });
+
+    page.on("response", (resp: PwResponse) => {
+      void this.handleResponse(resp, siteName);
+    });
+
+    page.on("websocket", (ws: PwWebSocket) => {
+      const wsUrl = ws.url();
+      const forward = (direction: "tx" | "rx", payload: string | Buffer): void => {
+        try {
+          const payloadStr = typeof payload === "string" ? payload : payload.toString("utf-8");
+          const bytes = typeof payload === "string" ? Buffer.byteLength(payload) : payload.length;
+          this.events.onWsFrame?.(siteName, { wsUrl, direction, bytes, payload: payloadStr });
+        } catch {
+          // Ignore — capture is best-effort.
+        }
+      };
+      ws.on("framesent", (d) => forward("tx", d.payload));
+      ws.on("framereceived", (d) => forward("rx", d.payload));
+    });
+  }
+
+  private async handleResponse(resp: PwResponse, siteName: string): Promise<void> {
+    try {
+      const req = resp.request();
+      const headers = resp.headers();
+      const contentType = headers["content-type"] ?? "";
+      const textual = isTextual(contentType);
+
+      let bodyText: string | null = null;
+      let bodyBytes = 0;
+      try {
+        if (textual) {
+          const buf = await resp.body();
+          bodyBytes = buf.length;
+          bodyText = buf.toString("utf-8");
+        } else {
+          const buf = await resp.body().catch(() => Buffer.alloc(0));
+          bodyBytes = buf.length;
+        }
+      } catch {
+        // Body may be unavailable on redirects/cancelled requests — keep metadata.
+      }
+
+      const captured: CapturedResponse = {
+        url: resp.url(),
+        method: req.method(),
+        status: resp.status(),
+        contentType,
+        headers,
+        bodyBytes,
+        bodyText,
+        requestHeaders: req.headers(),
+        requestPostData: req.postData() ?? null,
+      };
+      this.events.onResponse?.(siteName, captured);
+    } catch {
+      // Never propagate capture errors.
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (!this.context) return;
+    try {
+      await this.context.close();
+    } catch {
+      // Context may already be dead.
+    }
+    this.context = null;
+    this.pages.clear();
+    this.siteSpecs.clear();
+    this.events = {};
+  }
+
+  isRunning(): boolean {
+    return this.context !== null;
+  }
+
+  getSiteNames(): string[] {
+    return [...this.pages.keys()];
+  }
+
+  private async withPage<T>(site: string | undefined, fn: (page: Page) => Promise<T>): Promise<T> {
+    const prev = this.lock;
+    let release!: () => void;
+    this.lock = new Promise<void>((r) => {
+      release = r;
+    });
+    try {
+      await prev;
+      if (!this.context) throw new Error("Browser not started");
+      let page: Page | undefined;
+      if (site) page = this.pages.get(site);
+      if (!page) {
+        if (this.pages.size === 1) {
+          page = this.pages.values().next().value;
+        } else {
+          page = this.context.pages()[0] ?? (await this.context.newPage());
+        }
+      }
+      if (!page) throw new Error("No browser page available");
+      return await fn(page);
+    } finally {
+      release();
+    }
+  }
+
+  async coldStart(site?: string): Promise<ColdStartResult> {
+    const cleared: string[] = [];
+    await this.withPage(site, async (page) => {
+      const origin = new URL(page.url()).origin;
+      try {
+        const cdp = await page.context().newCDPSession(page);
+        await cdp.send("Storage.clearDataForOrigin", {
+          origin,
+          storageTypes:
+            "appcache,cache_storage,file_systems,indexeddb,local_storage,service_workers,shader_cache,websql,cachestorage",
+        });
+        cleared.push(`storage-for-origin:${origin}`);
+      } catch {
+        // clearDataForOrigin is best-effort.
+      }
+      try {
+        await page.evaluate(() => {
+          try {
+            window.localStorage.clear();
+          } catch {
+            /* localStorage may be blocked by the page */
+          }
+          try {
+            window.sessionStorage.clear();
+          } catch {
+            /* sessionStorage may be blocked */
+          }
+        });
+        cleared.push("window-storage");
+      } catch {
+        // evaluate may fail mid-navigation.
+      }
+      try {
+        await page.reload({ waitUntil: "domcontentloaded" });
+      } catch {
+        // Reload is best-effort.
+      }
+    });
+    return { cleared, reloaded: true };
+  }
+
+  async wiggle(site?: string): Promise<string[]> {
+    const siteName = site ?? [...this.pages.keys()][0];
+    if (!siteName) return ["no-site"];
+
+    const spec = this.siteSpecs.get(siteName);
+    const wigglePath = spec?.wigglePath;
+    if (!wigglePath || !existsSync(wigglePath)) return ["no-wiggle-configured"];
+
+    // Fresh-require so edits to wiggle.js take effect without restarting the worker.
+    try {
+      delete require.cache[require.resolve(wigglePath)];
+    } catch {
+      // Non-CJS resolvers may not populate require.cache — that's fine.
+    }
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const wiggleFn = require(wigglePath) as (page: Page) => Promise<string[]>;
+    return this.withPage(site, (page) => wiggleFn(page));
+  }
+
+  async evalInPage(code: string, site?: string): Promise<unknown> {
+    return this.withPage(site, (page) => page.evaluate(code));
+  }
+
+  async getUrl(site?: string): Promise<string> {
+    return this.withPage(site, async (page) => page.url());
+  }
+
+  async getTitle(site?: string): Promise<string> {
+    return this.withPage(site, async (page) => page.title());
+  }
+
+  async getHtml(site?: string): Promise<string> {
+    return this.withPage(site, async (page) => page.content());
+  }
+}

--- a/packages/daemon/src/site/browser/playwright.ts
+++ b/packages/daemon/src/site/browser/playwright.ts
@@ -52,10 +52,17 @@ export class PlaywrightBrowserEngine implements BrowserEngine {
     this.events = events;
     for (const s of sites) this.siteSpecs.set(s.name, s);
 
-    // Playwright requires a real directory to persist — use the first site's profile as the context root.
-    // When multiple sites share a profile dir (they shouldn't, but may), Playwright merges them.
     if (sites.length === 0) throw new Error("PlaywrightBrowserEngine.start: at least one site is required");
-    const profileDir = sites[0].profileDir;
+
+    // A single persistent Playwright context has exactly one user-data directory.
+    // Sites opened together must agree on profileDir; mixed profiles need separate start() calls.
+    const profileDirs = [...new Set(sites.map((s) => s.profileDir))];
+    if (profileDirs.length > 1) {
+      throw new Error(
+        `PlaywrightBrowserEngine.start: all sites opened together must share one profileDir. Got ${profileDirs.length}: ${profileDirs.join(", ")}`,
+      );
+    }
+    const profileDir = profileDirs[0];
     mkdirSync(profileDir, { recursive: true });
 
     const ctx = await chromium.launchPersistentContext(profileDir, {
@@ -74,8 +81,11 @@ export class PlaywrightBrowserEngine implements BrowserEngine {
     const blockedPatterns: RegExp[] = [];
     for (const s of sites) {
       for (const proto of s.blockProtocols ?? []) {
-        const escaped = proto.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        blockedPatterns.push(new RegExp(`^${escaped.replace(/:\/\/$/, ":")}`));
+        // Normalize "msteams://" / "msteams:" → "msteams", then build a regex that
+        // matches both the colon-only and the colon-slash-slash forms.
+        const normalized = proto.replace(/:\/\/$/, "").replace(/:$/, "");
+        const escaped = normalized.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        blockedPatterns.push(new RegExp(`^${escaped}:(?:\\/\\/)?`));
       }
     }
     if (blockedPatterns.length > 0) {

--- a/packages/daemon/src/site/catalog.spec.ts
+++ b/packages/daemon/src/site/catalog.spec.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { _restoreOptions, options } from "@mcp-cli/core";
+import { loadCatalog, removeCall, upsertCall } from "./catalog";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = join(tmpdir(), `mcp-cli-site-cat-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  mkdirSync(tmp, { recursive: true });
+  options.SITES_DIR = join(tmp, "sites");
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+  _restoreOptions();
+});
+
+describe("catalog", () => {
+  test("seeds empty catalog when file is missing and no seed exists", () => {
+    const cat = loadCatalog("brand-new");
+    expect(cat).toEqual({});
+  });
+
+  test("upsert + remove round-trip", () => {
+    upsertCall("demo", { name: "get_thing", method: "GET", url: "https://demo.example/:id" });
+    expect(loadCatalog("demo").get_thing).toBeDefined();
+
+    const removed = removeCall("demo", "get_thing");
+    expect(removed).toBe(true);
+    expect(loadCatalog("demo").get_thing).toBeUndefined();
+  });
+
+  test("remove returns false for missing call", () => {
+    upsertCall("demo", { name: "a", method: "GET", url: "https://demo.example" });
+    expect(removeCall("demo", "nonexistent")).toBe(false);
+  });
+
+  test("persists changes across reloads", () => {
+    upsertCall("persist", { name: "one", method: "GET", url: "https://persist.example/a" });
+    upsertCall("persist", { name: "two", method: "POST", url: "https://persist.example/b" });
+    const cat = loadCatalog("persist");
+    expect(Object.keys(cat).sort()).toEqual(["one", "two"]);
+  });
+});

--- a/packages/daemon/src/site/catalog.ts
+++ b/packages/daemon/src/site/catalog.ts
@@ -1,0 +1,99 @@
+/**
+ * Named-call catalog: per-site JSON file mapping short names to HTTP requests.
+ *
+ * On first read, if the user's catalog.json is missing, the built-in seed
+ * (site/seeds/<seed>/catalog.json) is copied in. Users and the sniffer both
+ * mutate the catalog in place; manual edits are expected.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { siteCatalogPath } from "./paths";
+
+export interface NamedCall {
+  name: string;
+  url: string;
+  method: string;
+  description?: string;
+  paramDocs?: Record<string, string>;
+  /** Optional jq expression to transform input params into the request body. */
+  jq_input?: string;
+  /** Default body template (often a `search-template.json` imported by name). */
+  body_default?: unknown;
+  /** Optional jq expression to transform the response before returning. */
+  jq_output?: string;
+  headers?: Record<string, string>;
+  /** Hostname hints used for credential audience matching. */
+  audHints?: string[];
+  /**
+   * Named fetch filter applied MCP-side before proxying. Transforms the
+   * constructed {url, method, headers, body} before it hits the credential proxy.
+   * e.g. "owa-urlpostdata" encodes the body into an x-owa-urlpostdata header.
+   */
+  fetchFilter?: string;
+}
+
+export type Catalog = Record<string, NamedCall>;
+
+const SEEDS_DIR = join(__dirname, "seeds");
+
+function loadSeed(seedName: string): Catalog {
+  const catalogPath = join(SEEDS_DIR, seedName, "catalog.json");
+  if (!existsSync(catalogPath)) return {};
+  try {
+    const raw = JSON.parse(readFileSync(catalogPath, "utf-8")) as Catalog;
+    // Inline body_default from search-template.json when the seed defers it.
+    for (const call of Object.values(raw)) {
+      if (call.body_default === null) {
+        const templatePath = join(SEEDS_DIR, seedName, "search-template.json");
+        if (existsSync(templatePath)) {
+          try {
+            call.body_default = JSON.parse(readFileSync(templatePath, "utf-8"));
+          } catch {
+            // Leave body_default as null.
+          }
+        }
+      }
+    }
+    return raw;
+  } catch {
+    return {};
+  }
+}
+
+export function loadCatalog(site: string, seedName?: string): Catalog {
+  const file = siteCatalogPath(site);
+  mkdirSync(dirname(file), { recursive: true });
+
+  if (!existsSync(file)) {
+    const seed = loadSeed(seedName ?? site);
+    writeFileSync(file, JSON.stringify(seed, null, 2));
+    return { ...seed };
+  }
+  try {
+    return JSON.parse(readFileSync(file, "utf-8")) as Catalog;
+  } catch (e) {
+    throw new Error(`Failed to parse ${file}: ${e instanceof Error ? e.message : e}`);
+  }
+}
+
+export function saveCatalog(site: string, catalog: Catalog): void {
+  const file = siteCatalogPath(site);
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, JSON.stringify(catalog, null, 2));
+}
+
+export function upsertCall(site: string, call: NamedCall, seedName?: string): Catalog {
+  const catalog = loadCatalog(site, seedName);
+  catalog[call.name] = call;
+  saveCatalog(site, catalog);
+  return catalog;
+}
+
+export function removeCall(site: string, name: string, seedName?: string): boolean {
+  const catalog = loadCatalog(site, seedName);
+  if (!(name in catalog)) return false;
+  delete catalog[name];
+  saveCatalog(site, catalog);
+  return true;
+}

--- a/packages/daemon/src/site/catalog.ts
+++ b/packages/daemon/src/site/catalog.ts
@@ -35,7 +35,7 @@ export interface NamedCall {
 
 export type Catalog = Record<string, NamedCall>;
 
-const SEEDS_DIR = join(__dirname, "seeds");
+const SEEDS_DIR = join(import.meta.dir, "seeds");
 
 function loadSeed(seedName: string): Catalog {
   const catalogPath = join(SEEDS_DIR, seedName, "catalog.json");

--- a/packages/daemon/src/site/config.spec.ts
+++ b/packages/daemon/src/site/config.spec.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { _restoreOptions, options } from "@mcp-cli/core";
+import { domainMatches, getSite, getSiteForDomain, listSites, writeSiteConfig } from "./config";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = join(tmpdir(), `mcp-cli-site-cfg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  mkdirSync(tmp, { recursive: true });
+  options.SITES_DIR = join(tmp, "sites");
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+  _restoreOptions();
+});
+
+describe("domainMatches", () => {
+  test("exact match", () => {
+    expect(domainMatches("foo.com", "foo.com")).toBe(true);
+  });
+  test("wildcard prefix", () => {
+    expect(domainMatches("a.b.foo.com", "*.foo.com")).toBe(true);
+    expect(domainMatches("foo.com", "*.foo.com")).toBe(true);
+    expect(domainMatches("notfoo.com", "*.foo.com")).toBe(false);
+  });
+});
+
+describe("writeSiteConfig + getSite", () => {
+  test("round-trips a user-only site", () => {
+    writeSiteConfig("example", { url: "https://example.com", domains: ["example.com"], enabled: true });
+    const site = getSite("example");
+    expect(site?.url).toBe("https://example.com");
+    expect(site?.enabled).toBe(true);
+    expect(site?.browser?.engine).toBe("playwright");
+    expect(site?.browser?.chromeProfile).toBe("default");
+  });
+
+  test("returns null for unknown site", () => {
+    expect(getSite("nope")).toBeNull();
+  });
+
+  test("listSites returns sorted unique set", () => {
+    writeSiteConfig("z-site", { url: "https://z.example", domains: ["z.example"] });
+    writeSiteConfig("a-site", { url: "https://a.example", domains: ["a.example"] });
+    const names = listSites().map((s) => s.name);
+    expect(names).toContain("a-site");
+    expect(names).toContain("z-site");
+    expect(names.indexOf("a-site")).toBeLessThan(names.indexOf("z-site"));
+  });
+
+  test("user config overrides browser.engine", () => {
+    writeSiteConfig("wv", { url: "https://wv.example", domains: ["wv.example"], browser: { engine: "webview" } });
+    expect(getSite("wv")?.browser?.engine).toBe("webview");
+  });
+
+  test("getSiteForDomain matches enabled site only", () => {
+    writeSiteConfig("on", { url: "https://on.example", domains: ["*.on.example"], enabled: true });
+    writeSiteConfig("off", { url: "https://off.example", domains: ["*.off.example"], enabled: false });
+    expect(getSiteForDomain("a.on.example")).toBe("on");
+    expect(getSiteForDomain("a.off.example")).toBeNull();
+  });
+});

--- a/packages/daemon/src/site/config.spec.ts
+++ b/packages/daemon/src/site/config.spec.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { _restoreOptions, options } from "@mcp-cli/core";
-import { domainMatches, getSite, getSiteForDomain, listSites, writeSiteConfig } from "./config";
+import { domainMatches, getSite, getSiteForDomain, listSites, validateSiteName, writeSiteConfig } from "./config";
 
 let tmp: string;
 
@@ -16,6 +16,36 @@ beforeEach(() => {
 afterEach(() => {
   rmSync(tmp, { recursive: true, force: true });
   _restoreOptions();
+});
+
+describe("validateSiteName", () => {
+  test("accepts plain alphanumerics and hyphens/underscores", () => {
+    expect(() => validateSiteName("teams")).not.toThrow();
+    expect(() => validateSiteName("my-site_2")).not.toThrow();
+  });
+
+  test("rejects path traversal and separators", () => {
+    expect(() => validateSiteName("..")).toThrow(/Invalid site name/);
+    expect(() => validateSiteName("../etc")).toThrow(/Invalid site name/);
+    expect(() => validateSiteName("a/b")).toThrow(/Invalid site name/);
+    expect(() => validateSiteName("a\\b")).toThrow(/Invalid site name/);
+  });
+
+  test("rejects empty or leading punctuation", () => {
+    expect(() => validateSiteName("")).toThrow();
+    expect(() => validateSiteName("-leading")).toThrow(/Invalid site name/);
+    expect(() => validateSiteName("_leading")).toThrow(/Invalid site name/);
+  });
+
+  test("rejects names over 64 chars", () => {
+    expect(() => validateSiteName("a".repeat(65))).toThrow(/Invalid site name/);
+  });
+});
+
+describe("writeSiteConfig validates name", () => {
+  test("rejects path-traversal names before touching disk", () => {
+    expect(() => writeSiteConfig("../escape", { url: "https://x" })).toThrow(/Invalid site name/);
+  });
 });
 
 describe("domainMatches", () => {

--- a/packages/daemon/src/site/config.ts
+++ b/packages/daemon/src/site/config.ts
@@ -11,6 +11,18 @@ import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from 
 import { dirname, join } from "node:path";
 import { siteConfigPath, sitePath, sitesDir } from "./paths";
 
+const SITE_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/;
+
+/** Reject site names that could escape SITES_DIR (path traversal) or collide with special FS entries. */
+export function validateSiteName(name: string): void {
+  if (!name || typeof name !== "string") throw new Error("Site name is required");
+  if (!SITE_NAME_RE.test(name)) {
+    throw new Error(
+      `Invalid site name '${name}'. Must be alphanumeric (plus -/_), 1–64 chars, and start with a letter or digit.`,
+    );
+  }
+}
+
 export interface BrowserConfig {
   /** Browser engine adapter. Defaults to "playwright". */
   engine?: "playwright" | "webview";
@@ -42,7 +54,7 @@ export interface SiteConfig {
 
 export type PartialSiteConfig = Partial<SiteConfig>;
 
-const SEEDS_DIR = join(__dirname, "seeds");
+const SEEDS_DIR = join(import.meta.dir, "seeds");
 
 function loadBuiltinSeeds(): Record<string, PartialSiteConfig> {
   const seeds: Record<string, PartialSiteConfig> = {};
@@ -118,6 +130,7 @@ export function getSite(name: string): SiteConfig | null {
 
 /** Write (or overwrite) a site's user config. Creates the directory if needed. */
 export function writeSiteConfig(name: string, config: PartialSiteConfig): void {
+  validateSiteName(name);
   const path = siteConfigPath(name);
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, JSON.stringify(config, null, 2));

--- a/packages/daemon/src/site/config.ts
+++ b/packages/daemon/src/site/config.ts
@@ -1,0 +1,154 @@
+/**
+ * Site configuration loader.
+ *
+ * A site = a configured web app target with its own URL, credential pool,
+ * named-call catalog, and optional wiggle script. Loaded from
+ * `~/.mcp-cli/sites/<name>/config.json`, merged with any built-in seed
+ * bundled at `site/seeds/<name>/config.json`.
+ */
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { siteConfigPath, sitePath, sitesDir } from "./paths";
+
+export interface BrowserConfig {
+  /** Browser engine adapter. Defaults to "playwright". */
+  engine?: "playwright" | "webview";
+  /** Profile directory name under sites/<name>/chromium/. Defaults to "default". */
+  chromeProfile?: string;
+}
+
+export interface CaptureFilters {
+  match: string[];
+  skip: string[];
+}
+
+export interface SiteConfig {
+  name: string;
+  enabled: boolean;
+  url: string;
+  /** Hostname glob patterns (e.g. "*.example.com") matched against request URLs for credential routing. */
+  domains: string[];
+  /** Custom protocols to block in the browser (e.g. "msteams://") to keep users inside the tab. */
+  blockProtocols?: string[];
+  captureMode?: "off" | "filtered" | "firehose";
+  captureFilters?: CaptureFilters;
+  /** Path (relative to the site dir or built-in seed) to a JS keep-alive script. */
+  wiggle?: string;
+  /** Built-in seed name to fall back to if local files are missing. Defaults to the site name. */
+  seed?: string;
+  browser?: BrowserConfig;
+}
+
+export type PartialSiteConfig = Partial<SiteConfig>;
+
+const SEEDS_DIR = join(__dirname, "seeds");
+
+function loadBuiltinSeeds(): Record<string, PartialSiteConfig> {
+  const seeds: Record<string, PartialSiteConfig> = {};
+  if (!existsSync(SEEDS_DIR)) return seeds;
+  for (const entry of readdirSync(SEEDS_DIR, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const cfgPath = join(SEEDS_DIR, entry.name, "config.json");
+    if (!existsSync(cfgPath)) continue;
+    try {
+      seeds[entry.name] = JSON.parse(readFileSync(cfgPath, "utf-8")) as PartialSiteConfig;
+    } catch {
+      // Skip malformed seeds silently — they can't poison other sites.
+    }
+  }
+  return seeds;
+}
+
+function loadUserSiteConfig(site: string): PartialSiteConfig | null {
+  const path = siteConfigPath(site);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf-8")) as PartialSiteConfig;
+  } catch {
+    return null;
+  }
+}
+
+function mergeConfig(name: string, seed: PartialSiteConfig, user: PartialSiteConfig | null): SiteConfig {
+  const merged: PartialSiteConfig = { ...seed, ...(user ?? {}) };
+  return {
+    name,
+    enabled: merged.enabled ?? true,
+    url: merged.url ?? "",
+    domains: merged.domains ?? [],
+    blockProtocols: merged.blockProtocols,
+    captureMode: merged.captureMode,
+    captureFilters: merged.captureFilters,
+    wiggle: merged.wiggle,
+    seed: merged.seed ?? name,
+    browser: {
+      engine: merged.browser?.engine ?? "playwright",
+      chromeProfile: merged.browser?.chromeProfile ?? "default",
+    },
+  };
+}
+
+/** List all configured sites — both user-configured (under SITES_DIR) and built-in seeds. */
+export function listSites(): SiteConfig[] {
+  const seeds = loadBuiltinSeeds();
+  const names = new Set<string>(Object.keys(seeds));
+
+  const sitesRoot = sitesDir();
+  if (existsSync(sitesRoot)) {
+    for (const entry of readdirSync(sitesRoot, { withFileTypes: true })) {
+      if (entry.isDirectory()) names.add(entry.name);
+    }
+  }
+
+  const out: SiteConfig[] = [];
+  for (const name of [...names].sort()) {
+    out.push(mergeConfig(name, seeds[name] ?? {}, loadUserSiteConfig(name)));
+  }
+  return out;
+}
+
+/** Load a single site's config, merging built-in seed with user overrides. Returns null if neither exists. */
+export function getSite(name: string): SiteConfig | null {
+  const seeds = loadBuiltinSeeds();
+  const user = loadUserSiteConfig(name);
+  if (!seeds[name] && !user && !existsSync(sitePath(name))) return null;
+  return mergeConfig(name, seeds[name] ?? {}, user);
+}
+
+/** Write (or overwrite) a site's user config. Creates the directory if needed. */
+export function writeSiteConfig(name: string, config: PartialSiteConfig): void {
+  const path = siteConfigPath(name);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(config, null, 2));
+}
+
+/** Match a hostname against a glob pattern ("*.foo.com" matches "a.foo.com" and "a.b.foo.com"). */
+export function domainMatches(hostname: string, pattern: string): boolean {
+  if (pattern === hostname) return true;
+  if (pattern.startsWith("*.")) {
+    const suffix = pattern.slice(1);
+    return hostname.endsWith(suffix) || hostname === pattern.slice(2);
+  }
+  return false;
+}
+
+/** Return the site name whose domains match the given hostname, or null. */
+export function getSiteForDomain(hostname: string): string | null {
+  for (const site of listSites()) {
+    if (!site.enabled) continue;
+    for (const pattern of site.domains) {
+      if (domainMatches(hostname, pattern)) return site.name;
+    }
+  }
+  return null;
+}
+
+/** Resolve a seed-relative file path (e.g. wiggle script), checking user dir first then built-in seed. */
+export function resolveSiteAsset(site: string, seedName: string, relPath: string): string | null {
+  const userPath = join(sitePath(site), relPath);
+  if (existsSync(userPath)) return userPath;
+  const seedPath = join(SEEDS_DIR, seedName, relPath);
+  if (existsSync(seedPath)) return seedPath;
+  return null;
+}

--- a/packages/daemon/src/site/credentials.spec.ts
+++ b/packages/daemon/src/site/credentials.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+import type { CapturedRequest } from "./browser/engine";
+import { CredentialVault, decodeJwt } from "./credentials";
+
+function makeJwt(claims: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
+  return `${header}.${payload}.`;
+}
+
+function req(url: string, method = "GET", token?: string): CapturedRequest {
+  return {
+    url,
+    method,
+    resourceType: "xhr",
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+    postData: null,
+  };
+}
+
+describe("decodeJwt", () => {
+  test("returns claims for valid payload", () => {
+    const token = makeJwt({ aud: "https://foo/", iat: 1 });
+    expect(decodeJwt(token)?.aud).toBe("https://foo/");
+  });
+
+  test("returns null for garbage", () => {
+    expect(decodeJwt("not-a-jwt")).toBeNull();
+  });
+});
+
+describe("CredentialVault", () => {
+  test("noteRequest captures Bearer tokens by aud", () => {
+    const v = new CredentialVault();
+    const token = makeJwt({ aud: "https://api.example.com/", iat: 100 });
+    v.noteRequest("demo", req("https://api.example.com/v1/things", "GET", token));
+
+    const all = v.getAll("demo");
+    expect(all).toHaveLength(1);
+    expect(all[0].aud).toBe("https://api.example.com/");
+  });
+
+  test("ignores non-Bearer auth", () => {
+    const v = new CredentialVault();
+    v.noteRequest("demo", {
+      url: "https://x.example",
+      method: "GET",
+      resourceType: "xhr",
+      headers: { authorization: "Basic abc" },
+      postData: null,
+    });
+    expect(v.getAll("demo")).toHaveLength(0);
+  });
+
+  test("keeps fresher bearer on duplicate aud", () => {
+    const v = new CredentialVault();
+    const older = makeJwt({ aud: "https://api.example.com/", iat: 100 });
+    const newer = makeJwt({ aud: "https://api.example.com/", iat: 200 });
+    v.noteRequest("demo", req("https://api.example.com/a", "GET", older));
+    v.noteRequest("demo", req("https://api.example.com/a", "GET", newer));
+
+    const creds = v.getAll("demo");
+    expect(creds).toHaveLength(1);
+    expect(creds[0].claims.iat).toBe(200);
+    expect(creds[0].observations).toBe(2);
+  });
+
+  test("pickCredentialFor prefers matching aud hint", () => {
+    const v = new CredentialVault();
+    v.noteRequest(
+      "demo",
+      req("https://api.example.com/a", "GET", makeJwt({ aud: "https://api.example.com/", iat: 1 })),
+    );
+    v.noteRequest(
+      "demo",
+      req("https://other.example.com/b", "GET", makeJwt({ aud: "https://other.example.com/", iat: 2 })),
+    );
+
+    const pick = v.pickCredentialFor("https://api.example.com/a/b", "GET", ["api.example.com"], "demo");
+    expect(pick?.aud).toBe("https://api.example.com/");
+  });
+
+  test("pickCredentialFor returns null for empty vault", () => {
+    const v = new CredentialVault();
+    expect(v.pickCredentialFor("https://x", "GET", [], "demo")).toBeNull();
+  });
+});

--- a/packages/daemon/src/site/credentials.spec.ts
+++ b/packages/daemon/src/site/credentials.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { CapturedRequest } from "./browser/engine";
-import { CredentialVault, decodeJwt } from "./credentials";
+import { CredentialVault, decodeJwt, summarizeCredential } from "./credentials";
 
 function makeJwt(claims: Record<string, unknown>): string {
   const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
@@ -78,6 +78,15 @@ describe("CredentialVault", () => {
 
     const pick = v.pickCredentialFor("https://api.example.com/a/b", "GET", ["api.example.com"], "demo");
     expect(pick?.aud).toBe("https://api.example.com/");
+  });
+
+  test("summarizeCredential does not include bearer token material", () => {
+    const v = new CredentialVault();
+    const token = makeJwt({ aud: "https://api.example.com/", iat: 1, upn: "me@x.com" });
+    v.noteRequest("demo", req("https://api.example.com/a", "GET", token));
+    const summary = summarizeCredential(v.getAll("demo")[0]);
+    expect("bearerPrefix" in summary).toBe(false);
+    expect(JSON.stringify(summary)).not.toContain(token.slice(0, 16));
   });
 
   test("pickCredentialFor returns null for empty vault", () => {

--- a/packages/daemon/src/site/credentials.ts
+++ b/packages/daemon/src/site/credentials.ts
@@ -1,0 +1,212 @@
+/**
+ * Per-site credential vault. Captures Bearer tokens from observed requests,
+ * indexes them by JWT `aud`, and picks the best match for a target URL.
+ *
+ * Scoring (pickCredentialFor):
+ *   +2000 aud hint substring match
+ *   +1000 same host
+ *   +10 per matching path segment from root
+ *   +5   aud path-last-segment appears in target path
+ *   +2   method match
+ *   +(iat / 1e12) freshness tiebreak
+ */
+
+import type { CapturedRequest } from "./browser/engine";
+
+export interface JwtClaims {
+  aud?: string;
+  iss?: string;
+  exp?: number;
+  iat?: number;
+  scp?: string;
+  tid?: string;
+  oid?: string;
+  upn?: string;
+  appid?: string;
+  ver?: string | number;
+  [k: string]: unknown;
+}
+
+export interface Credential {
+  aud: string;
+  bearer: string;
+  claims: JwtClaims;
+  headers: Record<string, string>;
+  sampleUrl: string;
+  sampleMethod: string;
+  lastSeenAt: string;
+  observations: number;
+}
+
+export class CredentialVault {
+  private tables = new Map<string, Map<string, Credential>>();
+
+  private tableFor(site: string): Map<string, Credential> {
+    let t = this.tables.get(site);
+    if (!t) {
+      t = new Map();
+      this.tables.set(site, t);
+    }
+    return t;
+  }
+
+  noteRequest(site: string, req: CapturedRequest): void {
+    const authz = req.headers.authorization ?? req.headers.Authorization;
+    if (!authz || !/^bearer /i.test(authz)) return;
+
+    const token = authz.slice(7).trim();
+    const claims = decodeJwt(token);
+    if (!claims) return;
+
+    // Skip odd token versions (e.g. Exchange callback tokens embed a user access token and are 10KB+).
+    const ver = String(claims.ver ?? "");
+    if (ver && !ver.startsWith("1.") && !ver.startsWith("2.")) return;
+
+    const aud = typeof claims.aud === "string" ? claims.aud : "unknown";
+    const table = this.tableFor(site);
+    const prev = table.get(aud);
+
+    let cred: Credential = {
+      aud,
+      bearer: token,
+      claims,
+      headers: sanitizeHeaders(req.headers),
+      sampleUrl: req.url,
+      sampleMethod: req.method,
+      lastSeenAt: new Date().toISOString(),
+      observations: (prev?.observations ?? 0) + 1,
+    };
+    // If the new token is older than the existing one, keep the existing bearer but bump observations.
+    if (prev?.claims.iat && typeof claims.iat === "number" && claims.iat < prev.claims.iat) {
+      cred = {
+        ...cred,
+        bearer: prev.bearer,
+        claims: prev.claims,
+        headers: prev.headers,
+        sampleUrl: prev.sampleUrl,
+        sampleMethod: prev.sampleMethod,
+      };
+    }
+    table.set(aud, cred);
+  }
+
+  getAll(site?: string): Credential[] {
+    const iatSort = (a: Credential, b: Credential): number => (b.claims.iat ?? 0) - (a.claims.iat ?? 0);
+    if (site) return [...this.tableFor(site).values()].sort(iatSort);
+    const all: Credential[] = [];
+    for (const t of this.tables.values()) all.push(...t.values());
+    return all.sort(iatSort);
+  }
+
+  pickCredentialFor(
+    targetUrl: string,
+    targetMethod = "GET",
+    audHints: string[] = [],
+    site?: string,
+  ): Credential | null {
+    const all = this.getAll(site);
+    if (all.length === 0) return null;
+
+    let target: URL;
+    try {
+      target = new URL(targetUrl);
+    } catch {
+      return all[0];
+    }
+    const targetSegs = target.pathname.split("/").filter(Boolean);
+    const targetPathLower = target.pathname.toLowerCase();
+    const hintsLower = audHints.map((h) => h.toLowerCase()).filter(Boolean);
+
+    let best: Credential | null = null;
+    let bestScore = -1;
+
+    for (const c of all) {
+      let sample: URL;
+      try {
+        sample = new URL(c.sampleUrl);
+      } catch {
+        continue;
+      }
+      let score = 0;
+      if (hintsLower.length > 0) {
+        const audLower = c.aud.toLowerCase();
+        if (hintsLower.some((h) => audLower.includes(h))) score += 2000;
+      }
+      if (sample.host === target.host) score += 1000;
+
+      const sampleSegs = sample.pathname.split("/").filter(Boolean);
+      for (let i = 0; i < Math.min(targetSegs.length, sampleSegs.length); i++) {
+        if (sampleSegs[i] === targetSegs[i]) score += 10;
+        else break;
+      }
+
+      try {
+        const audUrl = c.aud.startsWith("http") ? new URL(c.aud) : null;
+        if (audUrl) {
+          const audSegs = audUrl.pathname.split("/").filter(Boolean);
+          const last = audSegs[audSegs.length - 1];
+          if (last && last.length >= 4 && targetPathLower.includes(last.toLowerCase())) score += 5;
+        }
+      } catch {
+        // aud may not be a URL; ignore.
+      }
+
+      if ((c.sampleMethod || "").toUpperCase() === targetMethod.toUpperCase()) score += 2;
+      score += (c.claims.iat ?? 0) / 1e12;
+
+      if (score > bestScore) {
+        bestScore = score;
+        best = c;
+      }
+    }
+    return best;
+  }
+
+  clear(site?: string): void {
+    if (site) this.tables.delete(site);
+    else this.tables.clear();
+  }
+}
+
+export function decodeJwt(token: string): JwtClaims | null {
+  const parts = token.split(".");
+  if (parts.length < 2) return null;
+  try {
+    const b64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4);
+    return JSON.parse(Buffer.from(padded, "base64").toString("utf-8")) as JwtClaims;
+  } catch {
+    return null;
+  }
+}
+
+function sanitizeHeaders(h: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(h)) {
+    out[k.toLowerCase()] = v.length > 8000 ? `${v.slice(0, 8000)}…(truncated)` : v;
+  }
+  return out;
+}
+
+export function summarizeCredential(c: Credential): Record<string, unknown> {
+  const now = Math.floor(Date.now() / 1000);
+  const expiresInSec = typeof c.claims.exp === "number" ? c.claims.exp - now : null;
+  return {
+    aud: c.aud,
+    upn: c.claims.upn,
+    tid: c.claims.tid,
+    oid: c.claims.oid,
+    scp: c.claims.scp,
+    appid: c.claims.appid,
+    iss: c.claims.iss,
+    exp: c.claims.exp,
+    expiresInSec,
+    lastSeenAt: c.lastSeenAt,
+    observations: c.observations,
+    sampleMethod: c.sampleMethod,
+    sampleUrl: c.sampleUrl,
+    bearerPrefix: `${c.bearer.slice(0, 16)}…`,
+    bearerBytes: c.bearer.length,
+    headersPresent: Object.keys(c.headers),
+  };
+}

--- a/packages/daemon/src/site/credentials.ts
+++ b/packages/daemon/src/site/credentials.ts
@@ -205,7 +205,6 @@ export function summarizeCredential(c: Credential): Record<string, unknown> {
     observations: c.observations,
     sampleMethod: c.sampleMethod,
     sampleUrl: c.sampleUrl,
-    bearerPrefix: `${c.bearer.slice(0, 16)}…`,
     bearerBytes: c.bearer.length,
     headersPresent: Object.keys(c.headers),
   };

--- a/packages/daemon/src/site/paths.ts
+++ b/packages/daemon/src/site/paths.ts
@@ -1,0 +1,38 @@
+/**
+ * Filesystem paths for the `site` backend.
+ *
+ * Everything lives under options.SITES_DIR (`~/.mcp-cli/sites/` by default).
+ * Per-site directory layout:
+ *   sites/<name>/
+ *     config.json     — user-authored overrides merged with built-in seed
+ *     catalog.json    — named HTTP calls
+ *     captures/       — API sniffer output
+ *     chromium/<profile>/  — browser user data (one dir per chromeProfile)
+ */
+
+import { join } from "node:path";
+import { options } from "@mcp-cli/core";
+
+export function sitesDir(): string {
+  return options.SITES_DIR;
+}
+
+export function sitePath(site: string): string {
+  return join(sitesDir(), site);
+}
+
+export function siteConfigPath(site: string): string {
+  return join(sitePath(site), "config.json");
+}
+
+export function siteCatalogPath(site: string): string {
+  return join(sitePath(site), "catalog.json");
+}
+
+export function siteCapturesDir(site: string): string {
+  return join(sitePath(site), "captures");
+}
+
+export function siteBrowserProfileDir(site: string, profile: string): string {
+  return join(sitePath(site), "chromium", profile);
+}

--- a/packages/daemon/src/site/proxy.spec.ts
+++ b/packages/daemon/src/site/proxy.spec.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { CapturedRequest } from "./browser/engine";
+import { CredentialVault } from "./credentials";
+import { proxyCall } from "./proxy";
+import type { ResolvedCall } from "./resolver";
+
+function makeJwt(claims: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+  const payload = Buffer.from(JSON.stringify(claims)).toString("base64url");
+  return `${header}.${payload}.`;
+}
+
+function authReq(url: string, token: string): CapturedRequest {
+  return { url, method: "GET", resourceType: "xhr", headers: { authorization: `Bearer ${token}` }, postData: null };
+}
+
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  // noop — each test installs its own fetch mock
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("proxyCall", () => {
+  test("usedAud reflects the credential that authorized the final fetch after 401 retry", async () => {
+    const vault = new CredentialVault();
+    const tokenA = makeJwt({ aud: "https://a.example/", iat: 100 });
+    const tokenB = makeJwt({ aud: "https://b.example/", iat: 200 });
+    vault.noteRequest("demo", authReq("https://a.example/v1", tokenA));
+    vault.noteRequest("demo", authReq("https://b.example/v1", tokenB));
+
+    // First fetch returns 401. After onWiggle, ensure the vault picks a different aud;
+    // we do this by clearing the vault and re-noting only token B so the "fresh" credential differs.
+    let call = 0;
+    globalThis.fetch = mock(async () => {
+      call += 1;
+      if (call === 1) return new Response("", { status: 401 });
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const onWiggle = async (): Promise<void> => {
+      vault.clear("demo");
+      vault.noteRequest("demo", authReq("https://b.example/v1", tokenB));
+    };
+
+    const resolved: ResolvedCall = {
+      url: "https://b.example/v1/thing",
+      method: "GET",
+      headers: {},
+      consumedParams: [],
+      residualParams: [],
+    };
+
+    const result = await proxyCall(vault, { site: "demo", resolved, audHints: ["b.example"], onWiggle });
+
+    expect(result.status).toBe(200);
+    // Before the fix, this was pick.aud (whatever won the first selection).
+    // After the fix, it must be fresh.aud — the one that actually authorized the successful call.
+    expect(result.usedAud).toBe("https://b.example/");
+  });
+
+  test("throws when no credentials exist", async () => {
+    const vault = new CredentialVault();
+    const resolved: ResolvedCall = {
+      url: "https://x.example/v1",
+      method: "GET",
+      headers: {},
+      consumedParams: [],
+      residualParams: [],
+    };
+    await expect(proxyCall(vault, { site: "demo", resolved })).rejects.toThrow(/No credentials available/);
+  });
+});

--- a/packages/daemon/src/site/proxy.ts
+++ b/packages/daemon/src/site/proxy.ts
@@ -1,0 +1,100 @@
+/**
+ * Site call proxy: takes a ResolvedCall, picks a credential from the vault,
+ * injects Bearer + passthrough headers, fetches, and returns the parsed response.
+ *
+ * 401s are retried once, optionally after running the site's wiggle script to
+ * refresh tokens. If the caller doesn't pass `onWiggle`, the retry still happens
+ * but without a token-refresh hook.
+ */
+
+import type { CredentialVault } from "./credentials";
+import type { ResolvedCall } from "./resolver";
+
+export interface ProxyCallOptions {
+  site: string;
+  resolved: ResolvedCall;
+  audHints?: string[];
+  /** Optional explicit aud to force credential selection. */
+  aud?: string;
+  /** Called once before the retry attempt; gives callers a chance to refresh tokens. */
+  onWiggle?: () => Promise<void>;
+}
+
+export interface ProxyCallResult {
+  status: number;
+  url: string;
+  method: string;
+  usedAud: string;
+  responseHeaders: Record<string, string>;
+  body: unknown;
+}
+
+const STRIP_HEADERS = new Set(["host", "content-length", "connection"]);
+
+function mergeHeaders(
+  credHeaders: Record<string, string>,
+  bearer: string,
+  callHeaders: Record<string, string>,
+): Record<string, string> {
+  const merged: Record<string, string> = { ...credHeaders, authorization: `Bearer ${bearer}`, ...callHeaders };
+  for (const k of Object.keys(merged)) {
+    if (STRIP_HEADERS.has(k.toLowerCase())) delete merged[k];
+  }
+  return merged;
+}
+
+async function doFetch(
+  url: string,
+  method: string,
+  headers: Record<string, string>,
+  body?: string,
+): Promise<{ status: number; headers: Record<string, string>; parsed: unknown }> {
+  const r = await fetch(url, { method, headers, body });
+  const rawText = await r.text();
+  let parsed: unknown = rawText;
+  try {
+    parsed = JSON.parse(rawText);
+  } catch {
+    // Non-JSON bodies are returned as a plain string.
+  }
+  return { status: r.status, parsed, headers: Object.fromEntries(r.headers.entries()) };
+}
+
+export async function proxyCall(vault: CredentialVault, opts: ProxyCallOptions): Promise<ProxyCallResult> {
+  const { site, resolved, audHints = [], aud, onWiggle } = opts;
+
+  const pick = aud
+    ? (vault.getAll(site).find((c) => c.aud === aud) ?? null)
+    : vault.pickCredentialFor(resolved.url, resolved.method, audHints, site);
+
+  if (!pick) {
+    throw new Error(`No credentials available for site '${site}'. Run 'mcx site browser ${site}' and complete login.`);
+  }
+
+  let merged = mergeHeaders(pick.headers, pick.bearer, resolved.headers);
+  let result = await doFetch(resolved.url, resolved.method, merged, resolved.body);
+
+  if (result.status === 401) {
+    try {
+      await onWiggle?.();
+    } catch {
+      // Wiggle is advisory — don't fail the retry just because wiggle failed.
+    }
+    const fresh = aud
+      ? (vault.getAll(site).find((c) => c.aud === aud) ?? null)
+      : vault.pickCredentialFor(resolved.url, resolved.method, audHints, site);
+    if (fresh) {
+      merged = mergeHeaders(fresh.headers, fresh.bearer, resolved.headers);
+      result = await doFetch(resolved.url, resolved.method, merged, resolved.body);
+    }
+  }
+
+  return {
+    status: result.status,
+    url: resolved.url,
+    method: resolved.method,
+    usedAud: pick.aud,
+    responseHeaders: result.headers,
+    body: result.parsed,
+  };
+}

--- a/packages/daemon/src/site/proxy.ts
+++ b/packages/daemon/src/site/proxy.ts
@@ -71,6 +71,7 @@ export async function proxyCall(vault: CredentialVault, opts: ProxyCallOptions):
     throw new Error(`No credentials available for site '${site}'. Run 'mcx site browser ${site}' and complete login.`);
   }
 
+  let usedAud = pick.aud;
   let merged = mergeHeaders(pick.headers, pick.bearer, resolved.headers);
   let result = await doFetch(resolved.url, resolved.method, merged, resolved.body);
 
@@ -84,6 +85,7 @@ export async function proxyCall(vault: CredentialVault, opts: ProxyCallOptions):
       ? (vault.getAll(site).find((c) => c.aud === aud) ?? null)
       : vault.pickCredentialFor(resolved.url, resolved.method, audHints, site);
     if (fresh) {
+      usedAud = fresh.aud;
       merged = mergeHeaders(fresh.headers, fresh.bearer, resolved.headers);
       result = await doFetch(resolved.url, resolved.method, merged, resolved.body);
     }
@@ -93,7 +95,7 @@ export async function proxyCall(vault: CredentialVault, opts: ProxyCallOptions):
     status: result.status,
     url: resolved.url,
     method: resolved.method,
-    usedAud: pick.aud,
+    usedAud,
     responseHeaders: result.headers,
     body: result.parsed,
   };

--- a/packages/daemon/src/site/resolver.spec.ts
+++ b/packages/daemon/src/site/resolver.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import type { NamedCall } from "./catalog";
+import { resolve } from "./resolver";
+
+const GET_CALL: NamedCall = {
+  name: "get_thing",
+  method: "GET",
+  url: "https://api.example.com/v1/things/:thingId",
+};
+
+const POST_CALL: NamedCall = {
+  name: "make_thing",
+  method: "POST",
+  url: "https://api.example.com/v1/things",
+  headers: { "x-custom": "1" },
+};
+
+describe("resolve", () => {
+  test("substitutes URL path params with encoding", () => {
+    const r = resolve(GET_CALL, { thingId: "a b/c" });
+    expect(r.url).toBe("https://api.example.com/v1/things/a%20b%2Fc");
+    expect(r.consumedParams).toEqual(["thingId"]);
+    expect(r.residualParams).toEqual([]);
+    expect(r.body).toBeUndefined();
+  });
+
+  test("throws on missing URL param", () => {
+    expect(() => resolve(GET_CALL, {})).toThrow(/Missing required URL param/);
+  });
+
+  test("GET residual params flow to query string", () => {
+    const r = resolve(GET_CALL, { thingId: "abc", limit: 10, q: "hi" });
+    expect(r.url).toMatch(/\?limit=10&q=hi$/);
+    expect(r.residualParams).toContain("limit");
+    expect(r.residualParams).toContain("q");
+  });
+
+  test("POST residual params go to JSON body with content-type default", () => {
+    const r = resolve(POST_CALL, { name: "foo", count: 3 });
+    expect(r.body).toBe(JSON.stringify({ name: "foo", count: 3 }));
+    expect(r.headers["content-type"]).toBe("application/json");
+    expect(r.headers["x-custom"]).toBe("1");
+  });
+
+  test("explicit raw body overrides residual body construction", () => {
+    const r = resolve(POST_CALL, { ignored: "x" }, "raw=payload", {
+      "content-type": "application/x-www-form-urlencoded",
+    });
+    expect(r.body).toBe("raw=payload");
+    expect(r.headers["content-type"]).toBe("application/x-www-form-urlencoded");
+  });
+
+  test("null/undefined params are dropped", () => {
+    const r = resolve(GET_CALL, { thingId: "x", a: null, b: undefined, c: 0 });
+    expect(r.residualParams).toEqual(["c"]);
+  });
+
+  test("preserves existing query string when appending", () => {
+    const call: NamedCall = { name: "x", method: "GET", url: "https://api.example.com/v1/things?fixed=1" };
+    const r = resolve(call, { extra: "yes" });
+    expect(r.url).toBe("https://api.example.com/v1/things?fixed=1&extra=yes");
+  });
+});

--- a/packages/daemon/src/site/resolver.ts
+++ b/packages/daemon/src/site/resolver.ts
@@ -1,0 +1,74 @@
+/**
+ * Pure request resolver for NamedCall → concrete HTTP request.
+ *
+ * Split out from catalog.ts so it's trivially unit-testable without touching
+ * the filesystem. `:foo` in the URL is replaced with encodeURIComponent(params.foo);
+ * unconsumed params go to the query string (GET/DELETE/HEAD) or JSON body
+ * (POST/PUT/PATCH) unless an explicit raw body is provided.
+ */
+
+import type { NamedCall } from "./catalog";
+
+export interface ResolvedCall {
+  url: string;
+  method: string;
+  body?: string;
+  headers: Record<string, string>;
+  consumedParams: string[];
+  residualParams: string[];
+}
+
+const URL_PARAM_RE = /:(\w+)/g;
+const BODY_METHOD_RE = /^(POST|PUT|PATCH)$/i;
+
+export function resolve(
+  call: NamedCall,
+  params: Record<string, unknown>,
+  rawBody?: string,
+  extraHeaders?: Record<string, string>,
+): ResolvedCall {
+  const consumed: string[] = [];
+
+  let url = call.url.replace(URL_PARAM_RE, (_match, name: string): string => {
+    const value = params[name];
+    if (value === undefined || value === null) {
+      const provided = Object.keys(params).join(", ") || "(none)";
+      throw new Error(`Missing required URL param ':${name}' for call '${call.name}'. Provided: ${provided}`);
+    }
+    consumed.push(name);
+    return encodeURIComponent(String(value));
+  });
+
+  const residualEntries: [string, unknown][] = [];
+  const residual: string[] = [];
+  for (const [k, v] of Object.entries(params)) {
+    if (consumed.includes(k)) continue;
+    if (v === undefined || v === null) continue;
+    residualEntries.push([k, v]);
+    residual.push(k);
+  }
+
+  const method = (call.method || "GET").toUpperCase();
+  const isBodyMethod = BODY_METHOD_RE.test(method);
+
+  let body: string | undefined;
+  if (rawBody !== undefined) {
+    body = rawBody;
+  } else if (isBodyMethod && residualEntries.length > 0) {
+    body = JSON.stringify(Object.fromEntries(residualEntries));
+  } else if (!isBodyMethod && residualEntries.length > 0) {
+    const qs = new URLSearchParams();
+    for (const [k, v] of residualEntries) qs.set(k, String(v));
+    url = url + (url.includes("?") ? "&" : "?") + qs.toString();
+  }
+
+  const headers: Record<string, string> = {
+    ...(call.headers ?? {}),
+    ...(extraHeaders ?? {}),
+  };
+  if (body !== undefined && !Object.keys(headers).some((k) => k.toLowerCase() === "content-type")) {
+    headers["content-type"] = "application/json";
+  }
+
+  return { url, method, body, headers, consumedParams: consumed, residualParams: residual };
+}

--- a/packages/daemon/src/site/seeds.spec.ts
+++ b/packages/daemon/src/site/seeds.spec.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { _restoreOptions, options } from "@mcp-cli/core";
+import { loadCatalog } from "./catalog";
+import { getSite, listSites } from "./config";
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = join(tmpdir(), `mcp-cli-site-seed-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  mkdirSync(tmp, { recursive: true });
+  options.SITES_DIR = join(tmp, "sites");
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+  _restoreOptions();
+});
+
+describe("built-in teams seed", () => {
+  test("listSites includes teams with merged seed config", () => {
+    const names = listSites().map((s) => s.name);
+    expect(names).toContain("teams");
+    const teams = getSite("teams");
+    expect(teams?.url).toBe("https://teams.cloud.microsoft/v2/");
+    expect(teams?.domains).toContain("*.teams.microsoft.com");
+    expect(teams?.blockProtocols).toContain("msteams://");
+    expect(teams?.browser?.engine).toBe("playwright");
+    expect(teams?.browser?.chromeProfile).toBe("default");
+  });
+
+  test("loadCatalog seeds teams catalog on first read", () => {
+    const catalog = loadCatalog("teams", "teams");
+    const names = Object.keys(catalog);
+    expect(names.length).toBeGreaterThan(0);
+    for (const call of Object.values(catalog)) {
+      expect(call.name).toBeTruthy();
+      expect(call.url).toMatch(/^https?:\/\//);
+      expect(call.method).toBeTruthy();
+    }
+  });
+});

--- a/packages/daemon/src/site/seeds/teams/catalog.json
+++ b/packages/daemon/src/site/seeds/teams/catalog.json
@@ -1,0 +1,355 @@
+{
+  "list_updates": {
+    "name": "list_updates",
+    "url": "https://teams.cloud.microsoft/api/csa/amer/api/v3/teams/users/me/updates",
+    "method": "GET",
+    "description": "Everything in the sidebar: chats, teams, channels, conversation folders.",
+    "paramDocs": {
+      "isPrefetch": "optional bool, default false",
+      "enableMembershipSummary": "optional bool, default true"
+    }
+  },
+  "discover": {
+    "name": "discover",
+    "url": "https://teams.cloud.microsoft/api/csa/amer/api/v1/teams/users/me/discover",
+    "method": "GET",
+    "description": "Discover feed — teams/channels suggested to the user.",
+    "paramDocs": {
+      "pageSize": "default 7",
+      "continuationToken": "pagination cursor"
+    }
+  },
+  "pinned_channels": {
+    "name": "pinned_channels",
+    "url": "https://teams.cloud.microsoft/api/csa/amer/api/v1/teams/users/me/pinnedChannels",
+    "method": "GET",
+    "description": "User's pinned channels."
+  },
+  "get_messages": {
+    "name": "get_messages",
+    "url": "https://teams.cloud.microsoft/api/chatsvc/amer/v1/users/ME/conversations/:threadId/messages",
+    "method": "GET",
+    "description": "Fetch messages in a chat or channel thread.",
+    "paramDocs": {
+      "threadId": "required — e.g. 19:abc@thread.v2 or 19:uid1_uid2@unq.gbl.spaces",
+      "pageSize": "default 20, max 200",
+      "view": "default 'msnp24Equivalent|supportsMessageProperties'",
+      "startTime": "epoch ms — use 1 for the beginning",
+      "syncState": "delta token from a previous response's _metadata.syncState"
+    },
+    "audHints": ["ic3.teams.office.com", "chatsvcagg.teams.microsoft.com"]
+  },
+  "consumption_horizons": {
+    "name": "consumption_horizons",
+    "url": "https://teams.cloud.microsoft/api/chatsvc/amer/v1/threads/:threadId/consumptionhorizons",
+    "method": "GET",
+    "description": "Read positions / seen markers for a thread.",
+    "paramDocs": {
+      "threadId": "required — the thread id"
+    },
+    "audHints": ["ic3.teams.office.com", "chatsvcagg.teams.microsoft.com"]
+  },
+  "thread_replies": {
+    "name": "thread_replies",
+    "url": "https://teams.cloud.microsoft/api/chatsvc/amer/v1/users/ME/conversations/:threadId;messageid=:messageId/messages",
+    "method": "GET",
+    "description": "Replies to a specific parent message (channel thread).",
+    "paramDocs": {
+      "threadId": "channel thread id",
+      "messageId": "parent message id",
+      "pageSize": "default 200"
+    },
+    "audHints": ["ic3.teams.office.com", "chatsvcagg.teams.microsoft.com"]
+  },
+  "user_fetch": {
+    "name": "user_fetch",
+    "url": "https://teams.cloud.microsoft/api/mt/emea/beta/users/fetch",
+    "method": "POST",
+    "description": "Resolve userIds / emails to display names + avatars.",
+    "paramDocs": {
+      "_body": "JSON body: array of identifiers, e.g. [{ mri: '8:orgid:<guid>' }]."
+    }
+  },
+  "search_teams": {
+    "name": "search_teams",
+    "url": "https://substrate.office.com/searchservice/api/v2/query",
+    "method": "POST",
+    "description": "Substrate search across Teams chat messages.",
+    "paramDocs": {
+      "q": "required — plain-text query",
+      "size": "optional — max hits, default 3"
+    },
+    "jq_input": ".params as $p | .body_default | .AnswerEntityRequests[].Query.QueryString = $p.q | (.EntityRequests[] | select(.query != null)).query.displayQueryString = $p.q | (.EntityRequests[] | select(.query != null)).query.queryString = $p.q | (.EntityRequests[] | select(.Query != null)).Query.DisplayQueryString = $p.q | (.EntityRequests[] | select(.Query != null)).Query.QueryString = $p.q | (.EntityRequests[] | select(.entityType == \"Message\")).query.queryString = (\"NOT (isClientSoftDeleted:TRUE) AND \" + $p.q) | (.EntityRequests[] | select(.entityType == \"Message\")).size = ($p.size // 3)",
+    "jq_output": "{ total: ((.EntitySets // []) | map(select(.EntityType==\"Message\")) | first | .ResultSets[0].Total), hits: ((.EntitySets // []) | map(select(.EntityType==\"Message\")) | first | .ResultSets[0].Results // [] | map(.Source | { id: .Id, threadId: .ClientThreadId, from: .From.EmailAddress.Name, preview: .Preview, dateTime: .DateTimeSent, hasAttachments: .HasAttachments })) }",
+    "body_default": {
+      "AnswerEntityRequests": [
+        {
+          "Query": {
+            "QueryString": "merge"
+          },
+          "EntityTypes": ["Event"],
+          "Size": 5,
+          "From": 0,
+          "EnableAsyncResolution": true
+        }
+      ],
+      "EntityRequests": [
+        {
+          "entityType": "Message",
+          "contentSources": ["Teams"],
+          "fields": [
+            "Extension_SkypeSpaces_ConversationPost_Extension_FromSkypeInternalId_String",
+            "Extension_SkypeSpaces_ConversationPost_Extension_FileData_String",
+            "Extension_SkypeSpaces_ConversationPost_Extension_ThreadType_String",
+            "Extension_SkypeSpaces_ConversationPost_Extension_SkypeGroupId_String",
+            "Extension_SkypeSpaces_ConversationPost_Extension_SenderTenantId_String",
+            "Extension_SkypeSpaces_ConversationPost_Extension_ParentMessageId_String",
+            "Extension_SkypeSpaces_ConversationPost_Extension_ImageSrc_String",
+            "Extension_SkypeSpaces_ConversationPost_Extension_AmsReferences_StringArray"
+          ],
+          "propertySet": "Optimized",
+          "query": {
+            "queryString": "NOT (isClientSoftDeleted:TRUE) AND merge",
+            "displayQueryString": "merge"
+          },
+          "size": 3,
+          "topResultsCount": 3
+        },
+        {
+          "contentSources": ["OneDriveBusiness", "Exchange"],
+          "EnableQueryUnderstanding": false,
+          "EnableSpeller": false,
+          "EntityType": "File",
+          "extendedQueries": [
+            {
+              "SearchProvider": "SharePoint",
+              "Query": {
+                "SourceId": "8413CD39-2156-4E00-B54D-11EFD9ABDB89",
+                "EnableQueryRules": false,
+                "TrimDuplicates": false,
+                "BypassResultTypes": true,
+                "ProcessBestBets": false,
+                "ProcessPersonalFavorites": false,
+                "EnableInterleaving": false,
+                "EnableMultiGeo": true,
+                "RankingModelId": "ABBAABBA-AAAA-AAAA-CCCC-000000000426",
+                "Culture": 1033
+              }
+            }
+          ],
+          "Fields": [
+            "DefaultEncodingUrl",
+            "FileName",
+            "FileType",
+            "HitHighlightedSummary",
+            "LastModifiedTime",
+            "LinkingUrl",
+            "ModifiedBy",
+            "OriginalPath",
+            "Path",
+            "Title",
+            "ServerRedirectedPreviewUrl",
+            "SpWebUrl",
+            "ChannelGroupId",
+            "FileExtension",
+            "VisualizationAccessURL",
+            "LastSharedWithMailboxOwnerByDisplayName",
+            "LastSharedWithMailboxOwnerDateTime",
+            "FileContextType",
+            "ClassicAttachmentVisualizationUrl",
+            "UniqueId"
+          ],
+          "From": 0,
+          "HitHighlight": {
+            "HitHighlightedProperties": ["HitHighlightedSummary"],
+            "SummaryLength": 200
+          },
+          "IdFormat": "EwsId",
+          "ParserType": "None",
+          "PropertySet": "Optimized",
+          "Query": {
+            "QueryString": "merge",
+            "DisplayQueryString": "merge"
+          },
+          "RefiningQueries": [
+            {
+              "RefinerString": "or(andnot(IsDocument:true,Title:or(OneNote_DeletedPages,OneNote_RecycleBin),SecondaryFileExtension:onetoc2,FileExtension:vtt,ContentClass:ExternalLink,and(ContentClass:STS_List_DocumentLibrary,SiteTemplateId:21),FileType:or(aspx,htm,html,mhtml),and(ContentTypeId:0x0101009D1CB255DA76424F860D91F20E6C4118*,PromotedState:2)),ContentTypeId:or(0x010100F3754F12A9B6490D9622A01FE9D8F012,0x0120D520A808*),SecondaryFileExtension:or(wmv,avi,mpg,asf,mp4,ogg,ogv,webm,mov),FileType:or(ai,bmp,dib,dst,emb,eps,gif,ico,jpeg,jpg,odg,png,rle,svg,tiff,webp,wmf,wpd))"
+            }
+          ],
+          "ResultsMerge": {
+            "Type": "Interleaved"
+          },
+          "size": 3,
+          "Sort": [
+            {
+              "Field": "PersonalScore",
+              "SortDirection": "Desc"
+            }
+          ],
+          "EnableResultAnnotations": true,
+          "AnnotationsCount": 1
+        },
+        {
+          "entityType": "People",
+          "Filter": {
+            "And": [
+              {
+                "Or": [
+                  {
+                    "Term": {
+                      "Flags": "NonHidden"
+                    }
+                  }
+                ]
+              },
+              {
+                "Or": [
+                  {
+                    "Term": {
+                      "PeopleType": "Person"
+                    }
+                  },
+                  {
+                    "Term": {
+                      "PeopleType": "Other"
+                    }
+                  }
+                ]
+              },
+              {
+                "Or": [
+                  {
+                    "Term": {
+                      "PeopleSubtype": "OrganizationUser"
+                    }
+                  },
+                  {
+                    "Term": {
+                      "PeopleSubtype": "MTOUser"
+                    }
+                  },
+                  {
+                    "Term": {
+                      "PeopleSubtype": "Guest"
+                    }
+                  },
+                  {
+                    "Term": {
+                      "PeopleSubtype": "Room"
+                    }
+                  },
+                  {
+                    "Term": {
+                      "PeopleSubtype": "PersonalContact"
+                    }
+                  },
+                  {
+                    "Term": {
+                      "PeopleSubtype": "ImplicitContact"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "contentSources": ["Exchange"],
+          "query": {
+            "queryString": "merge",
+            "displayQueryString": "merge"
+          },
+          "size": 8
+        },
+        {
+          "entityType": "Chat",
+          "contentSources": ["Teams"],
+          "propertySet": "Optimized",
+          "fields": [],
+          "query": {
+            "queryString": "merge",
+            "displayQueryString": "merge"
+          },
+          "extendedQueries": [
+            {
+              "query": {}
+            }
+          ],
+          "from": 0,
+          "size": 3
+        },
+        {
+          "entityType": "TeamsChannel",
+          "contentSources": ["Teams"],
+          "HitHighlight": {
+            "HitHighlightedProperties": ["HitHighlightedSummary"],
+            "SummaryLength": 200
+          },
+          "fields": [],
+          "query": {
+            "queryString": "merge",
+            "displayQueryString": "merge"
+          },
+          "extendedQueries": [
+            {
+              "query": {}
+            }
+          ],
+          "from": 0,
+          "size": 3
+        }
+      ],
+      "QueryAlterationOptions": {
+        "EnableAlteration": true,
+        "EnableSuggestion": true,
+        "SupportedRecourseDisplayTypes": ["Suggestion", "ServiceSideRecourseLink"]
+      },
+      "cvid": "dc970193-3c8a-47d0-b0e5-2a65fdb8ff20",
+      "logicalId": "462b56ad-86e6-4ba3-877c-3e11f0143f51",
+      "scenario": {
+        "Dimensions": [
+          {
+            "DimensionName": "QueryType",
+            "DimensionValue": "All"
+          },
+          {
+            "DimensionName": "FormFactor",
+            "DimensionValue": "general.web.reactSearch"
+          }
+        ],
+        "Name": "powerbar"
+      },
+      "WholePageRankingOptions": {
+        "EntityResultTypeRankingOptions": [
+          {
+            "MaxEntitySetCount": 1,
+            "ResultType": "Answer"
+          }
+        ],
+        "EnableEnrichedRanking": true,
+        "EnableLayoutHints": true,
+        "SupportedSerpRegions": ["MainLine"],
+        "SupportedRankingVersion": "V3"
+      },
+      "Context": {
+        "EntityContext": [
+          {
+            "@odata.type": "Microsoft.OutlookServices.Message",
+            "Id": "",
+            "ClientThreadId": "19:a2dae14c-c008-4117-88d7-49a13d0e235a_d0938f3c-ef54-45ab-a2c4-9095a7fcc5c1@unq.gbl.spaces"
+          }
+        ]
+      }
+    }
+  },
+  "search_files": {
+    "name": "search_files",
+    "url": "https://substrate.office.com/searchservice/api/v2/query",
+    "method": "POST",
+    "description": "Substrate search across files (OneDrive, SharePoint).",
+    "paramDocs": {
+      "q": "required — the search query",
+      "size": "optional — max hits, default 15"
+    },
+    "jq_input": "{ EntityRequests: [{ entityType: \"File\", contentSources: [\"OneDriveBusiness\",\"Exchange\"], fields: [\"FileName\",\"FileType\",\"HitHighlightedSummary\",\"LastModifiedTime\",\"LinkingUrl\",\"ModifiedBy\",\"Path\",\"Title\",\"SpWebUrl\",\"FileExtension\"], query: { queryString: .q, displayQueryString: .q }, size: (.size // 15), from: 0 }] }",
+    "jq_output": "{ total: ((.EntitySets // []) | map(select(.EntityType==\"File\")) | first | .ResultSets[0].Total), hits: ((.EntitySets // []) | map(select(.EntityType==\"File\")) | first | .ResultSets[0].Results // [] | map(.Source | { title: .Title, fileName: .FileName, fileType: .FileType, summary: .HitHighlightedSummary, modified: .LastModifiedTime, modifiedBy: (.ModifiedBy // {}).DisplayName, url: .LinkingUrl })) }"
+  }
+}

--- a/packages/daemon/src/site/seeds/teams/config.json
+++ b/packages/daemon/src/site/seeds/teams/config.json
@@ -1,0 +1,18 @@
+{
+  "url": "https://teams.cloud.microsoft/v2/",
+  "domains": [
+    "*.teams.microsoft.com",
+    "*.teams.cloud.microsoft",
+    "*.office.com",
+    "substrate.office.com",
+    "*.loki.delve.office.com"
+  ],
+  "blockProtocols": ["msteams://"],
+  "captureMode": "firehose",
+  "captureFilters": {
+    "match": ["api/chatsvc", "ng\\.msg\\.teams", "asyncgw\\.teams", "api/csa", "api/mt"],
+    "skip": ["imgo", "profilepicturev2", "mergedProfilePicturev2"]
+  },
+  "wiggle": "wiggle.js",
+  "seed": "teams"
+}

--- a/packages/daemon/src/site/seeds/teams/search-template.json
+++ b/packages/daemon/src/site/seeds/teams/search-template.json
@@ -1,0 +1,164 @@
+{
+  "AnswerEntityRequests": [
+    {
+      "Query": { "QueryString": "merge" },
+      "EntityTypes": ["Event"],
+      "Size": 5,
+      "From": 0,
+      "EnableAsyncResolution": true
+    }
+  ],
+  "EntityRequests": [
+    {
+      "entityType": "Message",
+      "contentSources": ["Teams"],
+      "fields": [
+        "Extension_SkypeSpaces_ConversationPost_Extension_FromSkypeInternalId_String",
+        "Extension_SkypeSpaces_ConversationPost_Extension_FileData_String",
+        "Extension_SkypeSpaces_ConversationPost_Extension_ThreadType_String",
+        "Extension_SkypeSpaces_ConversationPost_Extension_SkypeGroupId_String",
+        "Extension_SkypeSpaces_ConversationPost_Extension_SenderTenantId_String",
+        "Extension_SkypeSpaces_ConversationPost_Extension_ParentMessageId_String",
+        "Extension_SkypeSpaces_ConversationPost_Extension_ImageSrc_String",
+        "Extension_SkypeSpaces_ConversationPost_Extension_AmsReferences_StringArray"
+      ],
+      "propertySet": "Optimized",
+      "query": { "queryString": "NOT (isClientSoftDeleted:TRUE) AND merge", "displayQueryString": "merge" },
+      "size": 3,
+      "topResultsCount": 3
+    },
+    {
+      "contentSources": ["OneDriveBusiness", "Exchange"],
+      "EnableQueryUnderstanding": false,
+      "EnableSpeller": false,
+      "EntityType": "File",
+      "extendedQueries": [
+        {
+          "SearchProvider": "SharePoint",
+          "Query": {
+            "SourceId": "8413CD39-2156-4E00-B54D-11EFD9ABDB89",
+            "EnableQueryRules": false,
+            "TrimDuplicates": false,
+            "BypassResultTypes": true,
+            "ProcessBestBets": false,
+            "ProcessPersonalFavorites": false,
+            "EnableInterleaving": false,
+            "EnableMultiGeo": true,
+            "RankingModelId": "ABBAABBA-AAAA-AAAA-CCCC-000000000426",
+            "Culture": 1033
+          }
+        }
+      ],
+      "Fields": [
+        "DefaultEncodingUrl",
+        "FileName",
+        "FileType",
+        "HitHighlightedSummary",
+        "LastModifiedTime",
+        "LinkingUrl",
+        "ModifiedBy",
+        "OriginalPath",
+        "Path",
+        "Title",
+        "ServerRedirectedPreviewUrl",
+        "SpWebUrl",
+        "ChannelGroupId",
+        "FileExtension",
+        "VisualizationAccessURL",
+        "LastSharedWithMailboxOwnerByDisplayName",
+        "LastSharedWithMailboxOwnerDateTime",
+        "FileContextType",
+        "ClassicAttachmentVisualizationUrl",
+        "UniqueId"
+      ],
+      "From": 0,
+      "HitHighlight": { "HitHighlightedProperties": ["HitHighlightedSummary"], "SummaryLength": 200 },
+      "IdFormat": "EwsId",
+      "ParserType": "None",
+      "PropertySet": "Optimized",
+      "Query": { "QueryString": "merge", "DisplayQueryString": "merge" },
+      "RefiningQueries": [
+        {
+          "RefinerString": "or(andnot(IsDocument:true,Title:or(OneNote_DeletedPages,OneNote_RecycleBin),SecondaryFileExtension:onetoc2,FileExtension:vtt,ContentClass:ExternalLink,and(ContentClass:STS_List_DocumentLibrary,SiteTemplateId:21),FileType:or(aspx,htm,html,mhtml),and(ContentTypeId:0x0101009D1CB255DA76424F860D91F20E6C4118*,PromotedState:2)),ContentTypeId:or(0x010100F3754F12A9B6490D9622A01FE9D8F012,0x0120D520A808*),SecondaryFileExtension:or(wmv,avi,mpg,asf,mp4,ogg,ogv,webm,mov),FileType:or(ai,bmp,dib,dst,emb,eps,gif,ico,jpeg,jpg,odg,png,rle,svg,tiff,webp,wmf,wpd))"
+        }
+      ],
+      "ResultsMerge": { "Type": "Interleaved" },
+      "size": 3,
+      "Sort": [{ "Field": "PersonalScore", "SortDirection": "Desc" }],
+      "EnableResultAnnotations": true,
+      "AnnotationsCount": 1
+    },
+    {
+      "entityType": "People",
+      "Filter": {
+        "And": [
+          { "Or": [{ "Term": { "Flags": "NonHidden" } }] },
+          { "Or": [{ "Term": { "PeopleType": "Person" } }, { "Term": { "PeopleType": "Other" } }] },
+          {
+            "Or": [
+              { "Term": { "PeopleSubtype": "OrganizationUser" } },
+              { "Term": { "PeopleSubtype": "MTOUser" } },
+              { "Term": { "PeopleSubtype": "Guest" } },
+              { "Term": { "PeopleSubtype": "Room" } },
+              { "Term": { "PeopleSubtype": "PersonalContact" } },
+              { "Term": { "PeopleSubtype": "ImplicitContact" } }
+            ]
+          }
+        ]
+      },
+      "contentSources": ["Exchange"],
+      "query": { "queryString": "merge", "displayQueryString": "merge" },
+      "size": 8
+    },
+    {
+      "entityType": "Chat",
+      "contentSources": ["Teams"],
+      "propertySet": "Optimized",
+      "fields": [],
+      "query": { "queryString": "merge", "displayQueryString": "merge" },
+      "extendedQueries": [{ "query": {} }],
+      "from": 0,
+      "size": 3
+    },
+    {
+      "entityType": "TeamsChannel",
+      "contentSources": ["Teams"],
+      "HitHighlight": { "HitHighlightedProperties": ["HitHighlightedSummary"], "SummaryLength": 200 },
+      "fields": [],
+      "query": { "queryString": "merge", "displayQueryString": "merge" },
+      "extendedQueries": [{ "query": {} }],
+      "from": 0,
+      "size": 3
+    }
+  ],
+  "QueryAlterationOptions": {
+    "EnableAlteration": true,
+    "EnableSuggestion": true,
+    "SupportedRecourseDisplayTypes": ["Suggestion", "ServiceSideRecourseLink"]
+  },
+  "cvid": "dc970193-3c8a-47d0-b0e5-2a65fdb8ff20",
+  "logicalId": "462b56ad-86e6-4ba3-877c-3e11f0143f51",
+  "scenario": {
+    "Dimensions": [
+      { "DimensionName": "QueryType", "DimensionValue": "All" },
+      { "DimensionName": "FormFactor", "DimensionValue": "general.web.reactSearch" }
+    ],
+    "Name": "powerbar"
+  },
+  "WholePageRankingOptions": {
+    "EntityResultTypeRankingOptions": [{ "MaxEntitySetCount": 1, "ResultType": "Answer" }],
+    "EnableEnrichedRanking": true,
+    "EnableLayoutHints": true,
+    "SupportedSerpRegions": ["MainLine"],
+    "SupportedRankingVersion": "V3"
+  },
+  "Context": {
+    "EntityContext": [
+      {
+        "@odata.type": "Microsoft.OutlookServices.Message",
+        "Id": "",
+        "ClientThreadId": "19:a2dae14c-c008-4117-88d7-49a13d0e235a_d0938f3c-ef54-45ab-a2c4-9095a7fcc5c1@unq.gbl.spaces"
+      }
+    ]
+  }
+}

--- a/packages/daemon/src/site/seeds/teams/wiggle.js
+++ b/packages/daemon/src/site/seeds/teams/wiggle.js
@@ -1,0 +1,79 @@
+/**
+ * Teams wiggle sequence: refreshes all token families by exercising the UI.
+ * Search for self → persona card → Organization tab → chat bubble.
+ *
+ * @param {import('playwright').Page} page
+ * @returns {Promise<string[]>} touched token families
+ */
+module.exports = async function wiggle(page) {
+  const touched = [];
+
+  // --- Search + Loki persona card sequence ---
+  try {
+    const search = page.locator('[data-tid="AUTOSUGGEST_INPUT"]').first();
+    if ((await search.count()) > 0) {
+      const homeUser = (process.env.HOME ?? "").split("/").pop() ?? "";
+      const searchTerm = homeUser.replace(/[^a-zA-Z0-9._-]/g, "") || "me";
+
+      await search.click({ timeout: 2000 });
+      await search.fill(searchTerm);
+      await page.waitForTimeout(3000);
+      touched.push("search");
+
+      const topHit = page.locator('[data-tid^="AUTOSUGGEST_SUGGESTION_TOPHITS"]').first();
+      if ((await topHit.count()) > 0) {
+        await topHit.hover({ timeout: 2000 });
+        await page.waitForTimeout(500);
+
+        const lpcBtn = page.locator('[data-tid="AUTOSUGGEST_ACTION_PERSONLPC"]').first();
+        if ((await lpcBtn.count()) > 0) {
+          await lpcBtn.click({ timeout: 2000 });
+          await page.waitForTimeout(3000);
+          touched.push("persona");
+
+          const orgTab = page.locator('[role="tab"]', { hasText: "Organization" }).first();
+          if ((await orgTab.count()) > 0) {
+            await orgTab.click({ timeout: 2000 });
+            await page.waitForTimeout(3000);
+            touched.push("organization");
+          }
+
+          const chatBtn = page.locator('[id*="lpc"] button[aria-label^="Start a chat"]').first();
+          if ((await chatBtn.count()) > 0) {
+            await chatBtn.click({ timeout: 2000 });
+            await page.waitForTimeout(1000);
+            touched.push("compose");
+          } else {
+            const closeBtn = page.locator('button[aria-label="Close"]').last();
+            await closeBtn.click({ timeout: 2000 }).catch(() => {});
+            await search.press("Escape").catch(() => {});
+          }
+        }
+      }
+
+      if (!touched.includes("persona")) {
+        await search.press("Escape").catch(() => {});
+      }
+    }
+  } catch {}
+
+  // Compose box fallback
+  if (!touched.includes("compose")) {
+    try {
+      const compose = page
+        .locator('[data-tid="ckeditor-replyConversation"], [data-tid="newMessageCommands"], [role="textbox"]')
+        .first();
+      if ((await compose.count()) > 0) {
+        await compose.click({ timeout: 2000 });
+        touched.push("compose");
+      }
+    } catch {}
+  }
+
+  // Click away to unfocus
+  try {
+    await page.locator("body").click({ position: { x: 10, y: 10 }, timeout: 1000 });
+  } catch {}
+
+  return touched;
+};

--- a/packages/daemon/src/site/sniffer.spec.ts
+++ b/packages/daemon/src/site/sniffer.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import { CredentialVault } from "./credentials";
+import { Sniffer } from "./sniffer";
+
+describe("Sniffer", () => {
+  test("filtered mode without configureSite() treats missing filters as match-all", () => {
+    const vault = new CredentialVault();
+    const sniffer = new Sniffer(vault);
+    sniffer.setMode("teams", "filtered");
+    const events = sniffer.asEvents();
+
+    events.onRequest?.("teams", {
+      url: "https://teams.example/api/x",
+      method: "GET",
+      headers: {},
+      postData: null,
+      resourceType: "xhr",
+    });
+
+    // Before the fix, this was silently dropped (empty filter set → returns false).
+    const recent = sniffer.getRecentRequests();
+    expect(recent).toHaveLength(1);
+  });
+
+  test("invalid regex filter falls back to substring match instead of throwing", () => {
+    const vault = new CredentialVault();
+    const sniffer = new Sniffer(vault);
+    sniffer.setMode("teams", "off");
+    const events = sniffer.asEvents();
+
+    events.onRequest?.("teams", {
+      url: "https://teams.example/api/chat",
+      method: "GET",
+      headers: {},
+      postData: null,
+      resourceType: "xhr",
+    });
+
+    // `[` is an unclosed character class — invalid regex.
+    expect(() => sniffer.getRecentRequests("[invalid")).not.toThrow();
+    // Falls back to literal substring match against "[invalid" → no hits, but no throw.
+    expect(sniffer.getRecentRequests("[invalid")).toEqual([]);
+
+    // Valid substring filter works through the regex path.
+    expect(sniffer.getRecentRequests("chat")).toHaveLength(1);
+  });
+});

--- a/packages/daemon/src/site/sniffer.ts
+++ b/packages/daemon/src/site/sniffer.ts
@@ -1,0 +1,262 @@
+/**
+ * Sniffer: consumes BrowserEvents, feeds the credential vault, and optionally
+ * writes request/response artifacts to disk for later `mcx site calls` curation.
+ *
+ * Modes:
+ *   off       — events are observed for credentials only; no disk writes, no rings.
+ *   filtered  — only URLs matching the site's captureFilters.match (and not skip) are kept.
+ *   firehose  — everything is kept.
+ *
+ * This module is pure TypeScript — no Playwright imports.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { BrowserEvents, CapturedRequest, CapturedResponse, CapturedWsFrame } from "./browser/engine";
+import type { CaptureFilters } from "./config";
+import type { CredentialVault } from "./credentials";
+import { siteCapturesDir } from "./paths";
+
+export type CaptureMode = "off" | "filtered" | "firehose";
+
+export interface RequestRecord {
+  at: string;
+  site: string;
+  method: string;
+  url: string;
+  resourceType: string;
+  headers: Record<string, string>;
+  postData: string | null;
+}
+
+export interface ResponseRecord {
+  at: string;
+  site: string;
+  url: string;
+  method: string;
+  status: number;
+  contentType: string;
+  bytes: number;
+  savedFile: string | null;
+  isText: boolean;
+}
+
+export interface WsFrameRecord {
+  at: string;
+  site: string;
+  wsUrl: string;
+  direction: "tx" | "rx";
+  bytes: number;
+  preview: string;
+  savedFile: string | null;
+}
+
+const RING_SIZE = 500;
+const WS_LIST_SIZE = 50;
+
+function tsToken(): string {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function shortHash(s: string): string {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  return (h >>> 0).toString(16).padStart(8, "0");
+}
+
+function compileFilters(filters: CaptureFilters | undefined): { match: RegExp[]; skip: RegExp[] } {
+  return {
+    match: (filters?.match ?? []).map((p) => new RegExp(p, "i")),
+    skip: (filters?.skip ?? []).map((p) => new RegExp(p, "i")),
+  };
+}
+
+export class Sniffer {
+  private modes = new Map<string, CaptureMode>();
+  private filters = new Map<string, { match: RegExp[]; skip: RegExp[] }>();
+  private reqRing: RequestRecord[] = [];
+  private respRing: ResponseRecord[] = [];
+  private wsFrameRing: WsFrameRecord[] = [];
+  private wsList: Array<{ site: string; url: string; openedAt: string; frames: number }> = [];
+
+  constructor(private vault: CredentialVault) {}
+
+  configureSite(site: string, mode: CaptureMode, filters?: CaptureFilters): void {
+    this.modes.set(site, mode);
+    this.filters.set(site, compileFilters(filters));
+  }
+
+  getMode(site: string): CaptureMode {
+    return this.modes.get(site) ?? "off";
+  }
+
+  setMode(site: string, mode: CaptureMode): void {
+    this.modes.set(site, mode);
+  }
+
+  asEvents(): BrowserEvents {
+    return {
+      onRequest: (site, req) => this.handleRequest(site, req),
+      onResponse: (site, resp) => this.handleResponse(site, resp),
+      onWsFrame: (site, frame) => this.handleWsFrame(site, frame),
+    };
+  }
+
+  getRecentRequests(filter?: string): RequestRecord[] {
+    return filterRing(this.reqRing, filter, (r) => [r.url]);
+  }
+
+  getRecentResponses(filter?: string): ResponseRecord[] {
+    return filterRing(this.respRing, filter, (r) => [r.url]);
+  }
+
+  getRecentWsFrames(filter?: string): WsFrameRecord[] {
+    return filterRing(this.wsFrameRing, filter, (f) => [f.wsUrl, f.preview]);
+  }
+
+  private passesFilter(site: string, url: string): boolean {
+    const f = this.filters.get(site);
+    if (!f) return false;
+    if (f.skip.some((re) => re.test(url))) return false;
+    if (f.match.length === 0) return true;
+    return f.match.some((re) => re.test(url));
+  }
+
+  private handleRequest(site: string, req: CapturedRequest): void {
+    try {
+      this.vault.noteRequest(site, req);
+    } catch {
+      // Credential capture must not break observability.
+    }
+
+    const mode = this.getMode(site);
+    if (mode === "off") {
+      pushRing(this.reqRing, {
+        at: tsToken(),
+        site,
+        method: req.method,
+        url: req.url,
+        resourceType: req.resourceType,
+        headers: {},
+        postData: null,
+      });
+      return;
+    }
+    if (mode === "filtered" && !this.passesFilter(site, req.url)) return;
+
+    pushRing(this.reqRing, {
+      at: tsToken(),
+      site,
+      method: req.method,
+      url: req.url,
+      resourceType: req.resourceType,
+      headers: req.headers,
+      postData: req.postData,
+    });
+  }
+
+  private handleResponse(site: string, resp: CapturedResponse): void {
+    const mode = this.getMode(site);
+    if (mode === "off") return;
+    if (mode === "filtered" && !this.passesFilter(site, resp.url)) return;
+
+    const at = tsToken();
+    const dir = siteCapturesDir(site);
+    let savedFile: string | null = null;
+    try {
+      mkdirSync(dir, { recursive: true });
+      const file = join(dir, `${at}-${resp.method}-${shortHash(resp.url)}.json`);
+      const record = {
+        _meta: {
+          at,
+          url: resp.url,
+          method: resp.method,
+          status: resp.status,
+          contentType: resp.contentType,
+          bytes: resp.bodyBytes,
+        },
+        requestHeaders: resp.requestHeaders,
+        requestPostData: resp.requestPostData,
+        responseHeaders: resp.headers,
+        body:
+          resp.bodyText !== null
+            ? tryParseJson(resp.bodyText, resp.contentType)
+            : { _binary: true, _bytes: resp.bodyBytes, _contentType: resp.contentType },
+      };
+      writeFileSync(file, JSON.stringify(record, null, 2));
+      savedFile = file;
+    } catch {
+      // Capture is best-effort.
+    }
+
+    pushRing(this.respRing, {
+      at,
+      site,
+      url: resp.url,
+      method: resp.method,
+      status: resp.status,
+      contentType: resp.contentType,
+      bytes: resp.bodyBytes,
+      savedFile,
+      isText: resp.bodyText !== null,
+    });
+  }
+
+  private handleWsFrame(site: string, frame: CapturedWsFrame): void {
+    const mode = this.getMode(site);
+    if (mode === "off") return;
+
+    const existing = this.wsList.find((w) => w.site === site && w.url === frame.wsUrl);
+    if (!existing) {
+      this.wsList.push({ site, url: frame.wsUrl, openedAt: tsToken(), frames: 1 });
+      if (this.wsList.length > WS_LIST_SIZE) this.wsList.shift();
+    } else {
+      existing.frames++;
+    }
+
+    const at = tsToken();
+    let savedFile: string | null = null;
+    if (mode === "firehose") {
+      try {
+        const dir = siteCapturesDir(site);
+        mkdirSync(dir, { recursive: true });
+        savedFile = join(dir, `${at}-ws-${frame.direction}-${shortHash(frame.wsUrl)}.txt`);
+        writeFileSync(savedFile, frame.payload);
+      } catch {
+        savedFile = null;
+      }
+    }
+
+    pushRing(this.wsFrameRing, {
+      at,
+      site,
+      wsUrl: frame.wsUrl,
+      direction: frame.direction,
+      bytes: frame.bytes,
+      preview: frame.payload.slice(0, 400),
+      savedFile,
+    });
+  }
+}
+
+function pushRing<T>(ring: T[], item: T): void {
+  ring.push(item);
+  if (ring.length > RING_SIZE) ring.shift();
+}
+
+function filterRing<T>(ring: T[], filter: string | undefined, fields: (entry: T) => string[]): T[] {
+  if (!filter) return [...ring];
+  const re = new RegExp(filter, "i");
+  return ring.filter((entry) => fields(entry).some((f) => re.test(f)));
+}
+
+function tryParseJson(text: string, contentType: string): unknown {
+  if (contentType.includes("json")) {
+    try {
+      return JSON.parse(text);
+    } catch {
+      return { _unparsedJson: text.slice(0, 200_000) };
+    }
+  }
+  return { _text: text.slice(0, 200_000) };
+}

--- a/packages/daemon/src/site/sniffer.ts
+++ b/packages/daemon/src/site/sniffer.ts
@@ -3,9 +3,11 @@
  * writes request/response artifacts to disk for later `mcx site calls` curation.
  *
  * Modes:
- *   off       — events are observed for credentials only; no disk writes, no rings.
- *   filtered  — only URLs matching the site's captureFilters.match (and not skip) are kept.
- *   firehose  — everything is kept.
+ *   off       — events are observed for credentials only; no disk writes. Lightweight
+ *                request-metadata ring entries are still kept (URL/method/resourceType, no headers).
+ *   filtered  — URLs matching the site's captureFilters.match (and not skip) are written to disk
+ *                and kept in rings with full headers/body.
+ *   firehose  — everything is kept, including WebSocket frames.
  *
  * This module is pure TypeScript — no Playwright imports.
  */
@@ -115,8 +117,10 @@ export class Sniffer {
   }
 
   private passesFilter(site: string, url: string): boolean {
+    // No filters configured yet (site never configureSite'd) — treat as match-all so
+    // switching to `filtered` mode before start-up doesn't silently drop captures.
     const f = this.filters.get(site);
-    if (!f) return false;
+    if (!f) return true;
     if (f.skip.some((re) => re.test(url))) return false;
     if (f.match.length === 0) return true;
     return f.match.some((re) => re.test(url));
@@ -246,7 +250,14 @@ function pushRing<T>(ring: T[], item: T): void {
 
 function filterRing<T>(ring: T[], filter: string | undefined, fields: (entry: T) => string[]): T[] {
   if (!filter) return [...ring];
-  const re = new RegExp(filter, "i");
+  let re: RegExp;
+  try {
+    re = new RegExp(filter, "i");
+  } catch {
+    // Invalid regex from user input — fall back to substring match (case-insensitive).
+    const needle = filter.toLowerCase();
+    return ring.filter((entry) => fields(entry).some((f) => f.toLowerCase().includes(needle)));
+  }
   return ring.filter((entry) => fields(entry).some((f) => re.test(f)));
 }
 

--- a/packages/daemon/src/site/tools.ts
+++ b/packages/daemon/src/site/tools.ts
@@ -1,0 +1,213 @@
+/**
+ * MCP tool definitions for the `_site` virtual server.
+ *
+ * Single source of truth — both the worker (registers these) and the daemon
+ * (pre-populates the ServerPool tool cache so `mcx ls` works before the
+ * worker has booted) import this list.
+ */
+
+export interface SiteToolDef {
+  name: string;
+  description: string;
+  inputSchema: {
+    type: "object";
+    properties: Record<
+      string,
+      { type: string; description?: string; items?: unknown; properties?: unknown; enum?: string[] }
+    >;
+    required?: string[];
+  };
+}
+
+export const SITE_TOOLS: SiteToolDef[] = [
+  {
+    name: "site_list",
+    description: "List all configured sites, including built-in seeds and user-configured sites.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "site_show",
+    description: "Show the merged config for a single site.",
+    inputSchema: {
+      type: "object",
+      properties: { name: { type: "string", description: "Site name" } },
+      required: ["name"],
+    },
+  },
+  {
+    name: "site_add",
+    description:
+      "Create or update a site. Only the supplied fields are written; existing fields are preserved. " +
+      "Required on first creation: url and domains.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "Site name (filesystem-safe identifier)" },
+        url: { type: "string", description: "Landing URL the browser should open" },
+        domains: {
+          type: "array",
+          items: { type: "string" },
+          description: "Hostname glob patterns for credential routing",
+        },
+        enabled: { type: "boolean", description: "Defaults to true" },
+        captureMode: { type: "string", enum: ["off", "filtered", "firehose"] },
+        blockProtocols: {
+          type: "array",
+          items: { type: "string" },
+          description: "Custom protocols to block (e.g. msteams://)",
+        },
+        browserEngine: {
+          type: "string",
+          enum: ["playwright", "webview"],
+          description: "Browser engine. Defaults to playwright.",
+        },
+        chromeProfile: { type: "string", description: "Profile directory name. Defaults to 'default'." },
+        wiggle: { type: "string", description: "Path (relative to site dir) to a wiggle.js keep-alive module" },
+        seed: { type: "string", description: "Built-in seed name to inherit from" },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "site_remove",
+    description: "Remove a user-configured site (does not delete built-in seeds).",
+    inputSchema: {
+      type: "object",
+      properties: { name: { type: "string" } },
+      required: ["name"],
+    },
+  },
+  {
+    name: "site_calls",
+    description: "List named HTTP calls configured for a site's catalog.",
+    inputSchema: {
+      type: "object",
+      properties: { site: { type: "string" } },
+      required: ["site"],
+    },
+  },
+  {
+    name: "site_describe",
+    description: "Show the full definition of a single named call.",
+    inputSchema: {
+      type: "object",
+      properties: { site: { type: "string" }, call: { type: "string" } },
+      required: ["site", "call"],
+    },
+  },
+  {
+    name: "site_call",
+    description:
+      "Invoke a named HTTP call through the credential proxy. The browser must be running " +
+      "and have authenticated at least once for this site's origin. Returns the response body and metadata.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        site: { type: "string" },
+        call: { type: "string" },
+        params: {
+          type: "object",
+          description:
+            "URL/query/body parameters; :foo in the URL is substituted first, residuals go to query or JSON body",
+        },
+        body: { type: "string", description: "Raw body string (overrides residual body construction)" },
+      },
+      required: ["site", "call"],
+    },
+  },
+  {
+    name: "site_add_call",
+    description: "Add or update a named call in a site's catalog.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        site: { type: "string" },
+        name: { type: "string" },
+        url: { type: "string", description: "Template URL, e.g. https://api.x.com/v1/things/:id" },
+        method: { type: "string", description: "HTTP method; defaults to GET" },
+        description: { type: "string" },
+        headers: { type: "object" },
+        audHints: {
+          type: "array",
+          items: { type: "string" },
+          description: "Substrings to prefer when selecting a credential by aud",
+        },
+      },
+      required: ["site", "name", "url"],
+    },
+  },
+  {
+    name: "site_remove_call",
+    description: "Remove a named call from a site's catalog.",
+    inputSchema: {
+      type: "object",
+      properties: { site: { type: "string" }, call: { type: "string" } },
+      required: ["site", "call"],
+    },
+  },
+  {
+    name: "site_browser_start",
+    description:
+      "Launch the browser and open a tab per configured site so the user can complete login. " +
+      "Idempotent — subsequent calls return the running state. Lazily loads Playwright.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sites: {
+          type: "array",
+          items: { type: "string" },
+          description: "Site names to open; defaults to all enabled sites",
+        },
+      },
+    },
+  },
+  {
+    name: "site_disconnect",
+    description: "Stop the running browser and release its resources.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "site_sniff",
+    description:
+      "Control and inspect API capture. Without mode, returns recent requests/responses for the given site. " +
+      "With mode, updates the capture mode (off | filtered | firehose).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        site: { type: "string" },
+        mode: { type: "string", enum: ["off", "filtered", "firehose"] },
+        filter: { type: "string", description: "Regex to filter recent records by URL" },
+        limit: { type: "number", description: "Max records to return per kind (default 50)" },
+      },
+      required: ["site"],
+    },
+  },
+  {
+    name: "site_wiggle",
+    description: "Run the site's wiggle.js keep-alive script in the browser page.",
+    inputSchema: {
+      type: "object",
+      properties: { site: { type: "string" } },
+    },
+  },
+  {
+    name: "site_eval",
+    description: "Evaluate a JavaScript expression in the site's page context.",
+    inputSchema: {
+      type: "object",
+      properties: { site: { type: "string" }, code: { type: "string" } },
+      required: ["code"],
+    },
+  },
+  {
+    name: "site_cold_start",
+    description: "Clear non-cookie storage for a site's origin and reload the page.",
+    inputSchema: {
+      type: "object",
+      properties: { site: { type: "string" } },
+    },
+  },
+];
+
+/** Set of valid tool names — used by the worker to reject unknown tool calls fast. */
+export const SITE_TOOL_NAMES: ReadonlySet<string> = new Set(SITE_TOOLS.map((t) => t.name));

--- a/packages/daemon/src/site/tools.ts
+++ b/packages/daemon/src/site/tools.ts
@@ -38,7 +38,7 @@ export const SITE_TOOLS: SiteToolDef[] = [
     name: "site_add",
     description:
       "Create or update a site. Only the supplied fields are written; existing fields are preserved. " +
-      "Required on first creation: url and domains.",
+      "For a brand-new site you'll typically want to pass url + domains as well, but only name is required by the schema.",
     inputSchema: {
       type: "object",
       properties: {
@@ -58,8 +58,8 @@ export const SITE_TOOLS: SiteToolDef[] = [
         },
         browserEngine: {
           type: "string",
-          enum: ["playwright", "webview"],
-          description: "Browser engine. Defaults to playwright.",
+          enum: ["playwright"],
+          description: "Browser engine. Only 'playwright' is implemented today; 'webview' is tracked in #1453.",
         },
         chromeProfile: { type: "string", description: "Profile directory name. Defaults to 'default'." },
         wiggle: { type: "string", description: "Path (relative to site dir) to a wiggle.js keep-alive module" },

--- a/packages/daemon/src/site/transforms.spec.ts
+++ b/packages/daemon/src/site/transforms.spec.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "bun:test";
+import type { NamedCall } from "./catalog";
+import type { ProxyCallResult } from "./proxy";
+import type { ResolvedCall } from "./resolver";
+import { FETCH_FILTERS, type JqRunner, applyFetchFilter, applyJqInput, applyJqOutput } from "./transforms";
+
+const BASE_CALL: NamedCall = { name: "t", url: "https://e.example/x", method: "POST" };
+const BASE_RESOLVED: ResolvedCall = {
+  url: "https://e.example/x",
+  method: "POST",
+  headers: {},
+  consumedParams: [],
+  residualParams: [],
+};
+const BASE_RESULT: ProxyCallResult = {
+  status: 200,
+  url: "https://e.example/x",
+  method: "POST",
+  usedAud: "aud",
+  responseHeaders: {},
+  body: {},
+};
+
+const recordingJq = (impl: (expr: string, input: string) => string) => {
+  const calls: Array<{ expr: string; input: string }> = [];
+  const runner: JqRunner = async (expr, input) => {
+    calls.push({ expr, input });
+    return impl(expr, input);
+  };
+  return { runner, calls };
+};
+
+describe("applyJqInput", () => {
+  test("no-op when body already resolved", async () => {
+    const call: NamedCall = { ...BASE_CALL, jq_input: "." };
+    const { runner, calls } = recordingJq(() => "{}");
+    const out = await applyJqInput(call, {}, { ...BASE_RESOLVED, body: "keep" }, runner);
+    expect(out.body).toBe("keep");
+    expect(calls).toHaveLength(0);
+  });
+
+  test("no-op when jq_input not set", async () => {
+    const { runner, calls } = recordingJq(() => "{}");
+    const out = await applyJqInput(BASE_CALL, { q: "foo" }, BASE_RESOLVED, runner);
+    expect(out.body).toBeUndefined();
+    expect(calls).toHaveLength(0);
+  });
+
+  test("shapes body from params + body_default", async () => {
+    const call: NamedCall = {
+      ...BASE_CALL,
+      jq_input: ".body_default + {query: .params.q}",
+      body_default: { limit: 10 },
+    };
+    const { runner, calls } = recordingJq(() => JSON.stringify({ limit: 10, query: "hi" }));
+    const out = await applyJqInput(call, { q: "hi" }, BASE_RESOLVED, runner);
+    expect(out.body).toBe('{"limit":10,"query":"hi"}');
+    expect(out.headers["content-type"]).toBe("application/json");
+    expect(calls[0].input).toBe(JSON.stringify({ params: { q: "hi" }, body_default: { limit: 10 } }));
+  });
+
+  test("passes null body_default when call omits it", async () => {
+    const call: NamedCall = { ...BASE_CALL, jq_input: "." };
+    const { runner, calls } = recordingJq(() => "null");
+    await applyJqInput(call, { x: 1 }, BASE_RESOLVED, runner);
+    expect(calls[0].input).toBe(JSON.stringify({ params: { x: 1 }, body_default: null }));
+  });
+
+  test("preserves caller-supplied content-type header", async () => {
+    const call: NamedCall = { ...BASE_CALL, jq_input: "." };
+    const { runner } = recordingJq(() => "a=b");
+    const out = await applyJqInput(call, {}, { ...BASE_RESOLVED, headers: { "Content-Type": "text/plain" } }, runner);
+    expect(out.headers["Content-Type"]).toBe("text/plain");
+    expect(out.headers["content-type"]).toBeUndefined();
+  });
+
+  test("propagates jq runner errors", async () => {
+    const call: NamedCall = { ...BASE_CALL, jq_input: "boom" };
+    const runner: JqRunner = async () => {
+      throw new Error("jq exited 3: parse error");
+    };
+    await expect(applyJqInput(call, {}, BASE_RESOLVED, runner)).rejects.toThrow(/parse error/);
+  });
+});
+
+describe("applyFetchFilter", () => {
+  test("no-op when fetchFilter not set", () => {
+    expect(applyFetchFilter(BASE_CALL, BASE_RESOLVED)).toEqual(BASE_RESOLVED);
+  });
+
+  test("throws on unknown filter", () => {
+    const call: NamedCall = { ...BASE_CALL, fetchFilter: "nope" };
+    expect(() => applyFetchFilter(call, BASE_RESOLVED)).toThrow(/Unknown fetchFilter 'nope'/);
+  });
+
+  test("owa-urlpostdata moves body into x-owa-urlpostdata header", () => {
+    const call: NamedCall = { ...BASE_CALL, fetchFilter: "owa-urlpostdata" };
+    const resolved: ResolvedCall = { ...BASE_RESOLVED, body: '{"a":1,"b":"x y"}' };
+    const out = applyFetchFilter(call, resolved);
+    expect(out.body).toBeUndefined();
+    expect(out.headers["x-owa-urlpostdata"]).toBe(encodeURIComponent('{"a":1,"b":"x y"}'));
+  });
+
+  test("owa-urlpostdata leaves empty body untouched", () => {
+    const call: NamedCall = { ...BASE_CALL, fetchFilter: "owa-urlpostdata" };
+    const out = applyFetchFilter(call, BASE_RESOLVED);
+    expect(out.body).toBeUndefined();
+    expect(out.headers["x-owa-urlpostdata"]).toBeUndefined();
+  });
+
+  test("FETCH_FILTERS registry exposes owa-urlpostdata", () => {
+    expect(typeof FETCH_FILTERS["owa-urlpostdata"]).toBe("function");
+  });
+});
+
+describe("applyJqOutput", () => {
+  test("no-op when jq_output not set", async () => {
+    const { runner, calls } = recordingJq(() => "x");
+    const out = await applyJqOutput(BASE_CALL, BASE_RESULT, runner);
+    expect(out).toEqual(BASE_RESULT);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("no-op when body is null", async () => {
+    const call: NamedCall = { ...BASE_CALL, jq_output: "." };
+    const { runner, calls } = recordingJq(() => "x");
+    const out = await applyJqOutput(call, { ...BASE_RESULT, body: null }, runner);
+    expect(out.body).toBeNull();
+    expect(calls).toHaveLength(0);
+  });
+
+  test("parses JSON jq output into a value", async () => {
+    const call: NamedCall = { ...BASE_CALL, jq_output: "{total: .count}" };
+    const { runner, calls } = recordingJq(() => '{"total":5}');
+    const out = await applyJqOutput(call, { ...BASE_RESULT, body: { count: 5 } }, runner);
+    expect(out.body).toEqual({ total: 5 });
+    expect(calls[0].input).toBe(JSON.stringify({ count: 5 }));
+  });
+
+  test("falls back to trimmed string when jq output is not JSON", async () => {
+    const call: NamedCall = { ...BASE_CALL, jq_output: ".name" };
+    const { runner } = recordingJq(() => "hello\n");
+    const out = await applyJqOutput(call, { ...BASE_RESULT, body: { name: "hello" } }, runner);
+    expect(out.body).toBe("hello");
+  });
+
+  test("preserves all non-body fields", async () => {
+    const call: NamedCall = { ...BASE_CALL, jq_output: "." };
+    const { runner } = recordingJq(() => '{"x":1}');
+    const out = await applyJqOutput(
+      call,
+      { ...BASE_RESULT, status: 201, usedAud: "a", responseHeaders: { etag: "W/x" } },
+      runner,
+    );
+    expect(out.status).toBe(201);
+    expect(out.usedAud).toBe("a");
+    expect(out.responseHeaders.etag).toBe("W/x");
+  });
+});

--- a/packages/daemon/src/site/transforms.ts
+++ b/packages/daemon/src/site/transforms.ts
@@ -1,0 +1,111 @@
+/**
+ * Named-call transforms that run around resolver/proxy.
+ *
+ * The resolver is pure (params → ResolvedCall) and the proxy is credential-
+ * focused (ResolvedCall → response). The in-between is catalog-declarative:
+ *
+ *   - `jq_input`    reshape params (plus optional `body_default`) into a body
+ *                   when the resolver didn't produce one
+ *   - `fetchFilter` rewrite the final {url, method, headers, body} tuple
+ *                   before it hits the proxy — e.g. OWA's x-owa-urlpostdata
+ *   - `jq_output`   reshape the proxy's response body before returning
+ *
+ * The jq runner is injectable so tests don't need the external `jq` binary.
+ */
+
+import type { NamedCall } from "./catalog";
+import type { ProxyCallResult } from "./proxy";
+import type { ResolvedCall } from "./resolver";
+
+/** Injection point for the jq binary so tests don't require it. */
+export type JqRunner = (expression: string, input: string) => Promise<string>;
+
+/** Default runner: shells out to the external `jq` binary via Bun.spawn. */
+export const bunJqRunner: JqRunner = async (expression, input) => {
+  const proc = Bun.spawn(["jq", "-c", expression], {
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (!proc.stdin) throw new Error("jq spawn did not expose stdin");
+  proc.stdin.write(input);
+  await proc.stdin.end();
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    throw new Error(`jq exited ${exitCode}: ${stderr.trim()}`);
+  }
+  return stdout;
+};
+
+/**
+ * If the call declares `jq_input` and the resolver produced no body, shape a
+ * body from `{ params, body_default }` via jq. Otherwise returns unchanged.
+ */
+export async function applyJqInput(
+  call: NamedCall,
+  params: Record<string, unknown>,
+  resolved: ResolvedCall,
+  jq: JqRunner = bunJqRunner,
+): Promise<ResolvedCall> {
+  if (resolved.body !== undefined || !call.jq_input) return resolved;
+  const input = JSON.stringify({ params, body_default: call.body_default ?? null });
+  const body = (await jq(call.jq_input, input)).trim();
+  const headers = { ...resolved.headers };
+  if (!Object.keys(headers).some((k) => k.toLowerCase() === "content-type")) {
+    headers["content-type"] = "application/json";
+  }
+  return { ...resolved, body, headers };
+}
+
+/** Synchronous rewrite of a ResolvedCall. */
+type FetchFilter = (resolved: ResolvedCall) => ResolvedCall;
+
+/**
+ * Named registry. Catalog entries pick one via `fetchFilter`; unknown names
+ * fail loudly in applyFetchFilter rather than silently misrouting.
+ */
+export const FETCH_FILTERS: Record<string, FetchFilter> = {
+  /** OWA posts JSON bodies as URL-encoded values in the x-owa-urlpostdata header. */
+  "owa-urlpostdata": (r) => {
+    if (!r.body) return r;
+    const headers = { ...r.headers };
+    headers["x-owa-urlpostdata"] = encodeURIComponent(r.body);
+    return { ...r, body: undefined, headers };
+  },
+};
+
+export function applyFetchFilter(call: NamedCall, resolved: ResolvedCall): ResolvedCall {
+  if (!call.fetchFilter) return resolved;
+  const filter = FETCH_FILTERS[call.fetchFilter];
+  if (!filter) {
+    throw new Error(
+      `Unknown fetchFilter '${call.fetchFilter}' on call '${call.name}'. Known: ${Object.keys(FETCH_FILTERS).join(", ") || "(none)"}`,
+    );
+  }
+  return filter(resolved);
+}
+
+/**
+ * If the call declares `jq_output` and the proxy returned a non-null body,
+ * reshape it. jq stdout that parses as JSON is returned as a value; otherwise
+ * the trimmed text is returned verbatim.
+ */
+export async function applyJqOutput(
+  call: NamedCall,
+  result: ProxyCallResult,
+  jq: JqRunner = bunJqRunner,
+): Promise<ProxyCallResult> {
+  if (!call.jq_output || result.body === undefined || result.body === null) return result;
+  const shaped = await jq(call.jq_output, JSON.stringify(result.body));
+  let body: unknown;
+  try {
+    body = JSON.parse(shaped);
+  } catch {
+    body = shaped.trim();
+  }
+  return { ...result, body };
+}

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -136,7 +136,15 @@ const daemonWorkers = [
   "packages/daemon/src/claude-session-worker.ts",
   "packages/daemon/src/codex-session-worker.ts",
   "packages/daemon/src/mock-session-worker.ts",
+  "packages/daemon/src/site-worker.ts",
 ];
+
+// Packages excluded from bundling — resolved at runtime from node_modules.
+// playwright ships with a large optional-dep tree (electron, chromium-bidi, etc.)
+// that can't bundle cleanly; the site-worker loads it via dynamic import only
+// when a browser tool is actually invoked.
+const daemonExternal = ["playwright", "playwright-core", "electron", "chromium-bidi"];
+const externalFlags = daemonExternal.flatMap((p) => ["--external", p]);
 
 interface BinaryBuildConfig {
   entrypoint: string;
@@ -216,7 +224,7 @@ if (releaseMode) {
     const suffix = target.replace("bun-", "");
     console.log(`Building for ${suffix}...`);
     await Promise.all([
-      $`bun build --compile --minify ${defineFlag} ${compiledFlag} ${versionFlag} ${epochFlag} --target=${target} packages/daemon/src/main.ts ${daemonWorkers} --outfile dist/mcpd-${suffix}`,
+      $`bun build --compile --minify ${defineFlag} ${compiledFlag} ${versionFlag} ${epochFlag} ${externalFlags} --target=${target} packages/daemon/src/main.ts ${daemonWorkers} --outfile dist/mcpd-${suffix}`,
       buildBinary(mcxConfig, `dist/mcx-${suffix}`, target),
       buildBinary(mcpctlConfig, `dist/mcpctl-${suffix}`, target),
     ]);
@@ -235,7 +243,7 @@ if (releaseMode) {
 } else {
   // Dev build: current platform, simple names
   await Promise.all([
-    $`bun build --compile --minify ${defineFlag} ${compiledFlag} ${versionFlag} ${epochFlag} packages/daemon/src/main.ts ${daemonWorkers} --outfile dist/mcpd`,
+    $`bun build --compile --minify ${defineFlag} ${compiledFlag} ${versionFlag} ${epochFlag} ${externalFlags} packages/daemon/src/main.ts ${daemonWorkers} --outfile dist/mcpd`,
     buildBinary(mcxConfig, "dist/mcx"),
     buildBinary(mcpctlConfig, "dist/mcpctl"),
   ]);


### PR DESCRIPTION
Closes #1452 (baseline). Follow-up: #1453 (Bun.WebView adapter).

## Summary

- Adds the `_site` virtual MCP server and the `mcx site` command group.
- Follows the existing worker pattern (claude/codex/opencode/mock) — `WorkerClientTransport` over `postMessage`, no port-based IPC.
- Playwright is loaded via dynamic `import()` the first time a browser-dependent tool is invoked. Users without sites pay zero startup cost.
- `BrowserEngine` abstraction under `packages/daemon/src/site/browser/` lets future adapters (Bun.WebView) slot in.
- Teams seed included (`packages/daemon/src/site/seeds/teams/`) to validate end-to-end.

## Architecture

```
packages/daemon/src/
  site-server.ts       daemon-side virtual MCP server
  site-worker.ts       Bun Worker hosting MCP Server; dispatches tools
  site/
    config.ts          per-site config loader (seed + user override)
    catalog.ts         named HTTP call catalog
    resolver.ts        NamedCall → ResolvedCall (pure)
    proxy.ts           resolved call + credential vault → fetch
    credentials.ts     Bearer token vault, scored selection
    sniffer.ts         off/filtered/firehose capture, disk artifacts
    tools.ts           MCP tool definitions (single source of truth)
    paths.ts           filesystem layout
    browser/
      engine.ts        BrowserEngine + BrowserEvents interface
      playwright.ts    Playwright adapter (lazy-imported)
    seeds/teams/       built-in seed
packages/command/src/commands/
  site.ts              mcx site subcommands
```

## UX

```
mcx sites                               # alias for `mcx site list`
mcx site list
mcx site show <name>
mcx site add <name> --url <u> [--domains a,b,...]
mcx site remove <name>
mcx site calls <site>
mcx site describe <site> <call>
mcx site call <site> <call> [--k v ...] [--body raw]
mcx site add-call <site> <name> --url <u> [--method M]
mcx site remove-call <site> <call>
mcx site browser [sites...]             # launch browser for auth
mcx site disconnect
mcx site sniff <site> [--mode off|filtered|firehose] [--filter RE] [--limit N]
mcx site wiggle [site]
mcx site eval <site> <code>
mcx site cold-start [site]
```

## Resolved open questions from #1452

- Chromium profile: configurable per site via `browser.chromeProfile` (default `"default"`), stored at `sites/<name>/chromium/<profile>/`.
- Credential-proxy lifetime: starts on `site_browser_start`, stops on `site_disconnect` or daemon shutdown.
- Concurrency: serialized in the worker (single Playwright context, one page per site).

## Out of scope (filed follow-ups)

- #1453 — Bun.WebView browser engine adapter (zero-dep on macOS)
- `mcx auth <site>` → `site_auth` tool wiring (use `mcx site browser` today)

## Test plan

- [x] `bun typecheck` — clean
- [x] `bun lint:check` — clean
- [x] `bun test packages/daemon/src/site/ packages/daemon/src/site-server.spec.ts packages/command/src/commands/site.spec.ts` — 62 pass, 0 fail
- [x] `bun scripts/check-coverage.ts` — all thresholds met
- [x] Full `bun test` — 5145 pass, 0 fail, 22 todo
- [ ] Manual end-to-end: `mcx sites` → `mcx site browser teams` → login → `mcx site call teams get_messages --threadId ...` (to be done after merging, requires Playwright runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)