### PR TITLE
refactor(core): flip compareVersions to standard convention (closes #1430)

### DIFF
--- a/packages/core/src/bun-version.ts
+++ b/packages/core/src/bun-version.ts
@@ -11,9 +11,7 @@ export const MIN_BUN_VERSION = "1.2.18";
 export function assertBunVersion(minVersion: string = MIN_BUN_VERSION, current: string = Bun.version): void {
   // Strip pre-release/build metadata: 1.2.18-canary.X satisfies >=1.2.18.
   const currentBase = current.split(/[-+]/)[0];
-  // compareVersions(a, b) returns positive if b > a (see upgrade.ts JSDoc — non-standard).
-  // So > 0 here means minVersion > currentBase, i.e. the running Bun is too old.
-  if (compareVersions(currentBase, minVersion) > 0) {
+  if (compareVersions(minVersion, currentBase) > 0) {
     process.stderr.write(
       `error: mcp-cli requires Bun >=${minVersion}, found ${current}\n  upgrade with: bun upgrade\n`,
     );

--- a/packages/core/src/upgrade.spec.ts
+++ b/packages/core/src/upgrade.spec.ts
@@ -17,15 +17,15 @@ describe("compareVersions", () => {
     expect(compareVersions("1.0.0", "1.0.0")).toBe(0);
   });
 
-  test("newer remote returns positive", () => {
-    expect(compareVersions("1.0.0", "1.1.0")).toBeGreaterThan(0);
-    expect(compareVersions("1.0.0", "2.0.0")).toBeGreaterThan(0);
-    expect(compareVersions("1.0.0", "1.0.1")).toBeGreaterThan(0);
+  test("a > b returns positive", () => {
+    expect(compareVersions("1.1.0", "1.0.0")).toBeGreaterThan(0);
+    expect(compareVersions("2.0.0", "1.0.0")).toBeGreaterThan(0);
+    expect(compareVersions("1.0.1", "1.0.0")).toBeGreaterThan(0);
   });
 
-  test("older remote returns negative", () => {
-    expect(compareVersions("2.0.0", "1.0.0")).toBeLessThan(0);
-    expect(compareVersions("1.1.0", "1.0.0")).toBeLessThan(0);
+  test("a < b returns negative", () => {
+    expect(compareVersions("1.0.0", "2.0.0")).toBeLessThan(0);
+    expect(compareVersions("1.0.0", "1.1.0")).toBeLessThan(0);
   });
 
   test("strips leading v", () => {
@@ -35,15 +35,15 @@ describe("compareVersions", () => {
 
   test("ignores build metadata", () => {
     expect(compareVersions("1.0.0+12345", "1.0.0+67890")).toBe(0);
-    expect(compareVersions("1.0.0+12345", "1.1.0")).toBeGreaterThan(0);
+    expect(compareVersions("1.1.0", "1.0.0+12345")).toBeGreaterThan(0);
   });
 
   test("pre-release is less than release (semver)", () => {
-    // 1.0.0-dev < 1.0.0 → b > a → positive
-    expect(compareVersions("1.0.0-dev", "1.0.0")).toBeGreaterThan(0);
-    expect(compareVersions("1.0.0-dev", "1.1.0")).toBeGreaterThan(0);
-    // release > pre-release → negative
-    expect(compareVersions("1.0.0", "1.0.0-dev")).toBeLessThan(0);
+    // 1.0.0-dev < 1.0.0 → a < b → negative
+    expect(compareVersions("1.0.0-dev", "1.0.0")).toBeLessThan(0);
+    expect(compareVersions("1.0.0-dev", "1.1.0")).toBeLessThan(0);
+    // release > pre-release → positive
+    expect(compareVersions("1.0.0", "1.0.0-dev")).toBeGreaterThan(0);
     // both pre-release with same core → equal
     expect(compareVersions("1.0.0-alpha", "1.0.0-beta")).toBe(0);
   });

--- a/packages/core/src/upgrade.ts
+++ b/packages/core/src/upgrade.ts
@@ -50,8 +50,8 @@ export function selectAsset(platform: string = process.platform, arch: string = 
 }
 
 /**
- * Compare two semver-ish version strings.
- * Returns positive if b > a, negative if a > b, 0 if equal.
+ * Compare two semver-ish version strings (standard convention).
+ * Returns positive if a > b, negative if b > a, 0 if equal.
  * Strips leading 'v' and ignores build metadata (+epoch).
  * Pre-release versions (e.g. 1.0.0-dev) are ordered before their
  * release counterparts per semver: 1.0.0-dev < 1.0.0.
@@ -73,13 +73,13 @@ export function compareVersions(a: string, b: string): number {
   const len = Math.max(pa.parts.length, pb.parts.length);
 
   for (let i = 0; i < len; i++) {
-    const diff = (pb.parts[i] ?? 0) - (pa.parts[i] ?? 0);
+    const diff = (pa.parts[i] ?? 0) - (pb.parts[i] ?? 0);
     if (diff !== 0) return diff;
   }
 
   // Equal core versions: a pre-release is less than no pre-release
-  if (pa.prerelease !== null && pb.prerelease === null) return 1; // b > a
-  if (pa.prerelease === null && pb.prerelease !== null) return -1; // a > b
+  if (pa.prerelease !== null && pb.prerelease === null) return -1; // a < b
+  if (pa.prerelease === null && pb.prerelease !== null) return 1; // a > b
   return 0;
 }
 
@@ -184,7 +184,7 @@ export async function checkForUpdate(
       return {
         current: currentVersion,
         latest: cached.latest,
-        updateAvailable: compareVersions(currentVersion, cached.latest) > 0,
+        updateAvailable: compareVersions(cached.latest, currentVersion) > 0,
         asset,
       };
     }
@@ -196,7 +196,7 @@ export async function checkForUpdate(
   return {
     current: currentVersion,
     latest: release.version,
-    updateAvailable: compareVersions(currentVersion, release.version) > 0,
+    updateAvailable: compareVersions(release.version, currentVersion) > 0,
     asset,
   };
 }


### PR DESCRIPTION
## Summary
- Flips `compareVersions(a, b)` to standard C-style convention: positive means `a > b` (was: positive means `b > a`)
- Updates all three call sites by swapping argument order so observable behavior is unchanged
- Removes the defensive polarity comment from `bun-version.ts` — the call site is now self-documenting

## Test plan
- [ ] Updated `upgrade.spec.ts` assertions and descriptions to match standard polarity — all 31 tests pass
- [ ] `bun-version.spec.ts` boundary tests (patch-below, exact-match, canary) unchanged and passing
- [ ] `bun typecheck`, `bun lint`, full pre-commit suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)