### PR TITLE
fix(phases): return exitCode=1 on null/spawn-error in spawnExec (fixes #1408)

### DIFF
--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -37,6 +37,7 @@ import {
   phaseRun,
   resolvePhaseSource,
   shortestPhasePath,
+  spawnExec,
   transitionLogPath,
 } from "./phase";
 
@@ -1662,4 +1663,22 @@ defineAlias(({ z }) => ({
     expect(entries.filter((e) => e.status === "committed").length).toBe(2);
     expect(entries.filter((e) => e.status === "attempted").length).toBe(2);
   }, 30_000);
+});
+
+describe("spawnExec (#1408)", () => {
+  test("returns exitCode=1 and message when binary does not exist", () => {
+    const result = spawnExec(["/nonexistent/binary/that/cannot/be/found"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout.length).toBeGreaterThan(0);
+  });
+
+  test("returns exitCode from successful process", () => {
+    const result = spawnExec(["true"]);
+    expect(result.exitCode).toBe(0);
+  });
+
+  test("returns exitCode=1 for failing process", () => {
+    const result = spawnExec(["false"]);
+    expect(result.exitCode).toBe(1);
+  });
 });

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -854,17 +854,22 @@ export interface PhaseExecuteDeps {
   now: () => Date;
 }
 
-const defaultExecuteDeps: PhaseExecuteDeps = {
-  ipcCall,
-  exec: (cmd: string[]): ExecResult => {
-    const [bin, ...rest] = cmd;
+export function spawnExec(cmd: string[]): ExecResult {
+  const [bin, ...rest] = cmd;
+  try {
     const r = Bun.spawnSync([bin, ...rest], { stdout: "pipe", stderr: "pipe" });
     // `exitCode` is null when the child was terminated by a signal (e.g. SIGKILL).
     // Surface that as a failure — `?? 0` previously masked signal-killed processes
     // as success and let the branch guard wave through a git that never ran.
-    const exitCode = r.exitCode ?? 1;
-    return { stdout: new TextDecoder().decode(r.stdout), exitCode };
-  },
+    return { stdout: new TextDecoder().decode(r.stdout), exitCode: r.exitCode ?? 1 };
+  } catch (error) {
+    return { stdout: error instanceof Error ? error.message : String(error), exitCode: 1 };
+  }
+}
+
+const defaultExecuteDeps: PhaseExecuteDeps = {
+  ipcCall,
+  exec: spawnExec,
   findGitRoot,
   now: () => new Date(),
 };


### PR DESCRIPTION
## Summary
- Extracted `defaultExecuteDeps.exec` into exported `spawnExec()` to make it directly testable
- Added `try/catch` around `Bun.spawnSync` so missing/non-executable binaries return `exitCode: 1` instead of throwing
- `null` exitCode (signal-killed process) was already mapped to `1` in the previous fix; this PR adds the spawn-failure path and tests

## Test plan
- `spawnExec` returns `exitCode=1` and non-empty stdout when passed a non-existent binary path
- `spawnExec` returns `exitCode=0` for `true`
- `spawnExec` returns `exitCode=1` for `false`
- All 115 existing `phase.spec.ts` tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)