### PR TITLE
fix(phases): remove dead stubState from runPhase baseCtx (fixes #1350)

### DIFF
--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -19,6 +19,7 @@ import { existsSync, readFileSync, renameSync, statSync, writeFileSync } from "n
 import { isAbsolute, join, relative, resolve as resolvePath } from "node:path";
 import {
   type AliasContext,
+  type AliasStateAccessor,
   type AliasWorkItemInfo,
   BranchGuardError,
   DisallowedTransitionError,
@@ -811,12 +812,6 @@ async function runPhase(argv: string[], d: PhaseInstallDeps): Promise<void> {
 
   const { js } = await d.bundleAlias(resolved);
 
-  const stubState = {
-    get: async () => undefined,
-    all: async () => ({}),
-    set: async () => {},
-    delete: async () => {},
-  };
   const baseCtx: AliasContext = {
     mcp: {},
     args: extraArgs,
@@ -826,8 +821,8 @@ async function runPhase(argv: string[], d: PhaseInstallDeps): Promise<void> {
     // nothing is written to ~/.mcp-cli/cache — avoids caching `undefined`
     // (the dry-run proxy return value) and corrupting real cache entries.
     cache: async (_k, producer) => producer() as Promise<never>,
-    state: stubState,
-    globalState: stubState,
+    state: {} as AliasStateAccessor, // overwritten by wrapDryRunContext
+    globalState: {} as AliasStateAccessor, // overwritten by wrapDryRunContext
     workItem: null,
   };
   const ctx = wrapDryRunContext(baseCtx, (line) => d.log(line));


### PR DESCRIPTION
## Summary
- `runPhase` constructed a local `stubState` object and assigned it to `state`/`globalState` in `baseCtx`, but `wrapDryRunContext` unconditionally overwrites both fields — making `stubState` dead code
- Removed `stubState` entirely and replaced with `{} as AliasStateAccessor` placeholders, matching the existing `mcp: {}` pattern
- Added `AliasStateAccessor` to the type imports from `@mcp-cli/core`

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes — no changes needed
- [x] `bun test packages/command/src/commands/phase.spec.ts` — 112 tests pass
- [x] Pre-commit hook ran full check suite and committed cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)