### PR TITLE
fix(phases): use ephemeral in-memory state for unbound phase runs (fixes #1409)

### DIFF
--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -42,6 +42,7 @@ import {
   commitTransition,
   createAliasCache,
   createAliasState,
+  createEphemeralState,
   createMcpProxy,
   executeAliasBundled,
   extractMetadata,
@@ -1081,18 +1082,19 @@ export async function executePhase(
   const repoRoot = ex.findGitRoot(cwd) ?? NO_REPO_ROOT;
   // State is namespaced by work-item id so every phase touching the same
   // item sees the same scratchpad (see sprint state declarations in
-  // .mcx.yaml). When no work item is bound we fall back to a
-  // `phase:<target>:unbound` namespace — writes still persist through the
-  // daemon (createAliasState always hits SQLite), but they land in a
-  // separate bucket that won't collide with work-item scoped state.
-  const stateNamespace = workItem ? `workitem:${workItem.id}` : `phase:${parsed.target}:unbound`;
+  // .mcx.yaml). When no work item is bound we use an in-memory ephemeral
+  // state that is discarded after the process exits, preventing cross-run
+  // state leaks between unrelated invocations.
+  const state = workItem
+    ? createAliasState({ repoRoot, namespace: `workitem:${workItem.id}`, call: ex.ipcCall })
+    : createEphemeralState();
   const ctx: AliasContext = {
     mcp: createMcpProxy({ call: ex.ipcCall, cwd }),
     args: parsed.args,
     file: (p) => Bun.file(p).text(),
     json: async (p) => JSON.parse(await Bun.file(p).text()),
     cache: createAliasCache(`phase:${parsed.target}`),
-    state: createAliasState({ repoRoot, namespace: stateNamespace, call: ex.ipcCall }),
+    state,
     globalState: createAliasState({ repoRoot, namespace: GLOBAL_STATE_NAMESPACE, call: ex.ipcCall }),
     workItem,
   };

--- a/packages/core/src/alias-state.spec.ts
+++ b/packages/core/src/alias-state.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { GLOBAL_STATE_NAMESPACE, NO_REPO_ROOT, createAliasState } from "./alias-state";
+import { GLOBAL_STATE_NAMESPACE, NO_REPO_ROOT, createAliasState, createEphemeralState } from "./alias-state";
 import type { IpcMethod, IpcMethodResult } from "./ipc";
 
 type Call = { method: string; params: unknown };
@@ -99,5 +99,41 @@ describe("createAliasState", () => {
   test("exports stable sentinels", () => {
     expect(GLOBAL_STATE_NAMESPACE).toBe("__global__");
     expect(NO_REPO_ROOT).toBe("__none__");
+  });
+});
+
+describe("createEphemeralState", () => {
+  test("set then get round-trips in memory", async () => {
+    const s = createEphemeralState();
+    await s.set("k", { x: 1 });
+    expect(await s.get<{ x: number }>("k")).toEqual({ x: 1 });
+  });
+
+  test("get returns undefined for missing key", async () => {
+    const s = createEphemeralState();
+    expect(await s.get("missing")).toBeUndefined();
+  });
+
+  test("separate instances are isolated", async () => {
+    const a = createEphemeralState();
+    const b = createEphemeralState();
+    await a.set("k", "a-value");
+    await b.set("k", "b-value");
+    expect(await a.get<string>("k")).toBe("a-value");
+    expect(await b.get<string>("k")).toBe("b-value");
+  });
+
+  test("delete removes a key", async () => {
+    const s = createEphemeralState();
+    await s.set("k", 1);
+    await s.delete("k");
+    expect(await s.get("k")).toBeUndefined();
+  });
+
+  test("all returns every key", async () => {
+    const s = createEphemeralState();
+    await s.set("a", 1);
+    await s.set("b", 2);
+    expect(await s.all()).toEqual({ a: 1, b: 2 });
   });
 });

--- a/packages/core/src/alias-state.ts
+++ b/packages/core/src/alias-state.ts
@@ -40,6 +40,28 @@ export interface AliasStateOptions {
  * read, so anything JSON-serialisable round-trips cleanly. Structured-schema
  * validation is a no-op today; the manifest (#1286) will wire in a validator.
  */
+/**
+ * No-op accessor that discards writes and returns empty reads.
+ * Used when no work item is bound so state never leaks between unrelated runs.
+ */
+export function createEphemeralState(): AliasStateAccessor {
+  const store = new Map<string, unknown>();
+  return {
+    async get<T = unknown>(key: string): Promise<T | undefined> {
+      return store.get(key) as T | undefined;
+    },
+    async set(key: string, value: unknown): Promise<void> {
+      store.set(key, value);
+    },
+    async delete(key: string): Promise<void> {
+      store.delete(key);
+    },
+    async all(): Promise<Record<string, unknown>> {
+      return Object.fromEntries(store);
+    },
+  };
+}
+
 export function createAliasState(opts: AliasStateOptions): AliasStateAccessor {
   const call = opts.call ?? ipcCall;
   const { repoRoot, namespace } = opts;

--- a/packages/core/src/alias-state.ts
+++ b/packages/core/src/alias-state.ts
@@ -34,34 +34,41 @@ export interface AliasStateOptions {
 }
 
 /**
+ * In-memory accessor scoped to this accessor instance / process lifetime.
+ * Values are JSON-cloned on write to match daemon-backed serialization
+ * semantics. Used when no work item is bound so state never leaks between
+ * unrelated runs via shared daemon-backed storage.
+ */
+export function createEphemeralState(): AliasStateAccessor {
+  const store = new Map<string, unknown>();
+  return {
+    async get<T = unknown>(key: string): Promise<T | undefined> {
+      const raw = store.get(key);
+      return raw === undefined ? undefined : (JSON.parse(raw as string) as T);
+    },
+    async set(key: string, value: unknown): Promise<void> {
+      store.set(key, JSON.stringify(value));
+    },
+    async delete(key: string): Promise<void> {
+      store.delete(key);
+    },
+    async all(): Promise<Record<string, unknown>> {
+      const entries: Record<string, unknown> = {};
+      for (const [k, v] of store) {
+        entries[k] = JSON.parse(v as string);
+      }
+      return entries;
+    },
+  };
+}
+
+/**
  * Build an accessor bound to a specific (repoRoot, namespace) scope.
  *
  * The accessor serialises values with JSON.stringify on set and JSON.parse on
  * read, so anything JSON-serialisable round-trips cleanly. Structured-schema
  * validation is a no-op today; the manifest (#1286) will wire in a validator.
  */
-/**
- * No-op accessor that discards writes and returns empty reads.
- * Used when no work item is bound so state never leaks between unrelated runs.
- */
-export function createEphemeralState(): AliasStateAccessor {
-  const store = new Map<string, unknown>();
-  return {
-    async get<T = unknown>(key: string): Promise<T | undefined> {
-      return store.get(key) as T | undefined;
-    },
-    async set(key: string, value: unknown): Promise<void> {
-      store.set(key, value);
-    },
-    async delete(key: string): Promise<void> {
-      store.delete(key);
-    },
-    async all(): Promise<Record<string, unknown>> {
-      return Object.fromEntries(store);
-    },
-  };
-}
-
 export function createAliasState(opts: AliasStateOptions): AliasStateAccessor {
   const call = opts.call ?? ipcCall;
   const { repoRoot, namespace } = opts;


### PR DESCRIPTION
## Summary
- When `mcx phase run` is invoked without `--work-item`, state was persisted under a stable `phase:<target>:unbound` namespace in SQLite, causing cross-run state leaks between unrelated invocations
- Added `createEphemeralState()` — an in-memory no-op accessor that lives only for the duration of the process, ensuring complete isolation
- Unbound runs now get an ephemeral state instead of a daemon-persisted one

## Test plan
- [x] Added 5 tests for `createEphemeralState`: set/get round-trip, missing key, instance isolation, delete, all()
- [x] Typecheck passes
- [x] Lint passes
- [x] Full test suite passes (5195 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)