### PR TITLE
fix(ci): handle Bun SIGSEGV (exit 139) in coverage job (closes #1446)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
             echo "::warning::Bun crash (exit $code) after all coverage tests passed — treating as pass (see #1004, #1419)"
             exit 0
           elif [ $code -eq 132 ] || [ $code -eq 139 ]; then
-            echo "::warning::Bun segfault (exit $code) — retrying once (see #1004)"
+            echo "::warning::Bun crash (exit $code) — retrying once (see #1004)"
             bun scripts/check-coverage.ts --ci 2>&1 | tee /tmp/coverage_retry.txt
             code2=${PIPESTATUS[0]}
             if [ $code2 -eq 0 ]; then
@@ -117,7 +117,7 @@ jobs:
               echo "::warning::Bun crash (exit $code2) on retry after all coverage tests passed — treating as pass (see #1004, #1419)"
               exit 0
             elif [ $code2 -eq 132 ] || [ $code2 -eq 139 ]; then
-              echo "::warning::Bun segfault on retry too — treating as pass (known upstream bug, see #1004)"
+              echo "::warning::Bun crash on retry too — treating as pass (known upstream bug, see #1004)"
               exit 0
             else
               exit $code2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,8 +104,8 @@ jobs:
           elif grep -q "^ 0 fail$" /tmp/coverage_out.txt && ! grep -q "^FAIL:" /tmp/coverage_out.txt; then
             echo "::warning::Bun crash (exit $code) after all coverage tests passed — treating as pass (see #1004, #1419)"
             exit 0
-          elif [ $code -eq 132 ]; then
-            echo "::warning::Bun segfault (exit 132) — retrying once (see #1004)"
+          elif [ $code -eq 132 ] || [ $code -eq 139 ]; then
+            echo "::warning::Bun segfault (exit $code) — retrying once (see #1004)"
             bun scripts/check-coverage.ts --ci 2>&1 | tee /tmp/coverage_retry.txt
             code2=${PIPESTATUS[0]}
             if [ $code2 -eq 0 ]; then
@@ -116,7 +116,7 @@ jobs:
             elif grep -q "^ 0 fail$" /tmp/coverage_retry.txt && ! grep -q "^FAIL:" /tmp/coverage_retry.txt; then
               echo "::warning::Bun crash (exit $code2) on retry after all coverage tests passed — treating as pass (see #1004, #1419)"
               exit 0
-            elif [ $code2 -eq 132 ]; then
+            elif [ $code2 -eq 132 ] || [ $code2 -eq 139 ]; then
               echo "::warning::Bun segfault on retry too — treating as pass (known upstream bug, see #1004)"
               exit 0
             else


### PR DESCRIPTION
## Summary
- Adds exit code 139 (SIGSEGV) to the segfault retry branch in the coverage thresholds step alongside the existing exit 132 (SIGILL) handler
- Updates the retry-loop inner check the same way so a second segfault on retry is also treated as pass
- Fixes the warning message to print the actual exit code rather than hardcoding 132

## Test plan
- [ ] CI workflow change only — no unit-testable logic
- [ ] Verified diff targets both the first-run and retry-run elif branches
- [ ] Matches the structure already in place for exit 132

🤖 Generated with [Claude Code](https://claude.com/claude-code)