### PR TITLE
fix(gc): skip disconnected provider servers instead of aborting prune (fixes #1465)

### DIFF
--- a/packages/command/src/commands/gc.spec.ts
+++ b/packages/command/src/commands/gc.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { IpcCallError } from "@mcp-cli/core";
 import type { GcDeps } from "./gc";
 import { cmdGc, defaultGcDeps, parseDuration, parseGcArgs, runGc } from "./gc";
 
@@ -244,6 +245,34 @@ describe("runGc worktrees", () => {
     expect(d.logs.some((l) => l.includes("would remove 1"))).toBe(true);
     expect(d.logs.some((l) => l.includes("wt-b"))).toBe(true);
     expect(d.logs.some((l) => l.includes("wt-a") && l.includes("- "))).toBe(false);
+  });
+
+  test("live mode continues when a provider returns IpcCallError (server not connected)", async () => {
+    // Regression for #1465: if _acp (or any provider) is not connected, calling
+    // acp_session_list throws IpcCallError. gc should skip that provider (no
+    // active sessions possible on a disconnected server) rather than aborting.
+    const responses = makeWorktreeResponses();
+    let claudeCallCount = 0;
+    const d = makeDeps({
+      execResponses: responses,
+      callTool: async (tool) => {
+        if (tool === "claude_session_list") {
+          claudeCallCount++;
+          return [];
+        }
+        // All other providers are unreachable at the IPC level (server not connected)
+        throw new IpcCallError({ code: -32000, message: "server not connected", data: undefined });
+      },
+    });
+
+    await runGc({ dryRun: true, olderThanMs: 86_400_000, branchesOnly: false, worktreesOnly: true }, d);
+
+    // Must NOT abort — gc should proceed despite provider IpcCallErrors
+    expect(d.logs.some((l) => l.includes("would remove"))).toBe(true);
+    // The daemon-reachable provider was still called
+    expect(claudeCallCount).toBeGreaterThan(0);
+    // Must not emit the fatal "Cannot reach daemon" error
+    expect(d.errors.some((e) => e.includes("Cannot reach daemon"))).toBe(false);
   });
 
   test("live mode fails closed when session list throws", async () => {

--- a/packages/command/src/commands/gc.spec.ts
+++ b/packages/command/src/commands/gc.spec.ts
@@ -247,7 +247,7 @@ describe("runGc worktrees", () => {
     expect(d.logs.some((l) => l.includes("wt-a") && l.includes("- "))).toBe(false);
   });
 
-  test("live mode continues when a provider returns IpcCallError (server not connected)", async () => {
+  test("skips disconnected provider when IpcCallError indicates server not connected", async () => {
     // Regression for #1465: if _acp (or any provider) is not connected, calling
     // acp_session_list throws IpcCallError. gc should skip that provider (no
     // active sessions possible on a disconnected server) rather than aborting.

--- a/packages/command/src/commands/worktree-commands.ts
+++ b/packages/command/src/commands/worktree-commands.ts
@@ -42,10 +42,22 @@ export async function getAllActiveSessionWorktrees(
         if (s.worktree) combined.add(s.worktree);
       }
     } catch (e) {
-      // IpcCallError means the daemon is reachable but this provider server is
-      // not connected. A disconnected server has no active sessions, so it is
-      // safe to skip rather than aborting the entire gc.
-      if (e instanceof IpcCallError) continue;
+      if (e instanceof IpcCallError) {
+        // Only skip when the error indicates the provider server is disconnected
+        // or unreachable — a disconnected server has no active sessions, so it
+        // is safe to skip. Re-throw for logic errors (invalid-params, internal, etc.)
+        // that indicate a real problem with the call itself.
+        const msg = e.message.toLowerCase();
+        if (
+          msg.includes("not connected") ||
+          msg.includes("disconnected") ||
+          msg.includes("not reachable") ||
+          msg.includes("unreachable")
+        ) {
+          continue;
+        }
+        throw e;
+      }
       if (failClosed) {
         throw new Error(`Cannot reach daemon to query ${tool}. Aborting prune to prevent destroying active worktrees.`);
       }

--- a/packages/command/src/commands/worktree-commands.ts
+++ b/packages/command/src/commands/worktree-commands.ts
@@ -5,7 +5,7 @@
  * that any provider can add to its command dispatch.
  */
 
-import { WorktreeError, listMcxWorktrees, pruneWorktrees } from "@mcp-cli/core";
+import { IpcCallError, WorktreeError, listMcxWorktrees, pruneWorktrees } from "@mcp-cli/core";
 import type { WorktreeShimDeps } from "@mcp-cli/core";
 import { c, formatToolResult } from "../output";
 
@@ -41,7 +41,11 @@ export async function getAllActiveSessionWorktrees(
       for (const s of sessions) {
         if (s.worktree) combined.add(s.worktree);
       }
-    } catch {
+    } catch (e) {
+      // IpcCallError means the daemon is reachable but this provider server is
+      // not connected. A disconnected server has no active sessions, so it is
+      // safe to skip rather than aborting the entire gc.
+      if (e instanceof IpcCallError) continue;
       if (failClosed) {
         throw new Error(`Cannot reach daemon to query ${tool}. Aborting prune to prevent destroying active worktrees.`);
       }


### PR DESCRIPTION
## Summary
- `mcx gc` was aborting with "Cannot reach daemon to query acp_session_list" even when the daemon was healthy — because `_acp` (or any provider) wasn't connected
- `IpcCallError` means the daemon received the request but the specific provider server isn't connected; a disconnected server has no active sessions, so skipping it is safe
- Non-`IpcCallError` errors (network failures) still trigger the fail-closed abort as before

## Test plan
- [x] Added test: `live mode continues when a provider returns IpcCallError (server not connected)` — verifies gc proceeds when some providers throw `IpcCallError` while others succeed
- [x] Existing `live mode fails closed when session list throws` still passes — generic network errors still abort
- [x] Full test suite: 5214 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)