### PR TITLE
fix(work-items): reject unknown keys in work_items_update (fixes #1445)

### DIFF
--- a/packages/daemon/src/work-items-server.spec.ts
+++ b/packages/daemon/src/work-items-server.spec.ts
@@ -851,6 +851,71 @@ describe("WorkItemsServer", () => {
     expect(calls).toEqual([1420]);
   });
 
+  test("work_items_update rejects unknown keys (#1445)", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    server = new WorkItemsServer(db);
+    const { client } = await server.start();
+    await client.callTool({ name: "work_items_track", arguments: { prNumber: 42 } });
+
+    const result = await client.callTool({
+      name: "work_items_update",
+      arguments: { id: "pr:42", qa_session_id: "abc-123", session_id: "def-456" },
+    });
+
+    expect(result.isError).toBe(true);
+    const content = result.content as Array<{ type: string; text: string }>;
+    expect(content[0].text).toContain("Unknown keys");
+    expect(content[0].text).toContain("qa_session_id");
+    expect(content[0].text).toContain("session_id");
+    expect(content[0].text).toContain("Phase-namespace state");
+  });
+
+  test("work_items_update rejects mix of known and unknown keys (#1445)", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    server = new WorkItemsServer(db);
+    const { client } = await server.start();
+    await client.callTool({ name: "work_items_track", arguments: { prNumber: 42 } });
+
+    const result = await client.callTool({
+      name: "work_items_update",
+      arguments: { id: "pr:42", ciStatus: "passed", model: "opus" },
+    });
+
+    expect(result.isError).toBe(true);
+    const content = result.content as Array<{ type: string; text: string }>;
+    expect(content[0].text).toContain("model");
+    // Only "model" should be listed as unknown, not "ciStatus"
+    expect(content[0].text).toMatch(/^Unknown keys: model\./);
+  });
+
+  test("work_items_update accepts all known keys without error", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    server = new WorkItemsServer(db);
+    const { client } = await server.start();
+    await client.callTool({ name: "work_items_track", arguments: { prNumber: 42 } });
+
+    const result = await client.callTool({
+      name: "work_items_update",
+      arguments: {
+        id: "pr:42",
+        phase: "review",
+        ciStatus: "passed",
+        reviewStatus: "approved",
+        prState: "open",
+        prUrl: "https://example.com",
+        ciRunId: 123,
+        ciSummary: "all green",
+        branch: "feat/test",
+        issueNumber: 99,
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+  });
+
   test("work_items_track does not auto-resolve when branch is explicitly provided", async () => {
     const { db, raw } = createWorkItemDb();
     rawDb = raw;

--- a/packages/daemon/src/work-items-server.ts
+++ b/packages/daemon/src/work-items-server.ts
@@ -14,6 +14,23 @@ import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import type { WorkItemDb } from "./db/work-items";
 
+const WORK_ITEMS_UPDATE_KNOWN_KEYS = new Set([
+  "id",
+  "phase",
+  "repoRoot",
+  "force",
+  "forceReason",
+  "prNumber",
+  "prState",
+  "prUrl",
+  "ciStatus",
+  "ciRunId",
+  "ciSummary",
+  "reviewStatus",
+  "branch",
+  "issueNumber",
+]);
+
 /** Parse a value to integer, returning undefined if absent or NaN. */
 function parseIntOrUndefined(value: unknown): number | undefined {
   if (value === undefined) return undefined;
@@ -290,6 +307,19 @@ export class WorkItemsServer {
             const id = String(a.id ?? "");
             if (!id) {
               return { content: [{ type: "text" as const, text: "id is required" }], isError: true };
+            }
+
+            const unknownKeys = Object.keys(a).filter((k) => !WORK_ITEMS_UPDATE_KNOWN_KEYS.has(k));
+            if (unknownKeys.length > 0) {
+              return {
+                content: [
+                  {
+                    type: "text" as const,
+                    text: `Unknown keys: ${unknownKeys.join(", ")}. work_items_update only accepts work-item columns (${[...WORK_ITEMS_UPDATE_KNOWN_KEYS].filter((k) => k !== "id").join(", ")}). Phase-namespace state (session_id, qa_session_id, etc.) is stored separately — use phase handler ctx.state to read/write it.`,
+                  },
+                ],
+                isError: true,
+              };
             }
 
             const force = a.force === true;

--- a/packages/daemon/src/work-items-server.ts
+++ b/packages/daemon/src/work-items-server.ts
@@ -14,22 +14,16 @@ import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import type { WorkItemDb } from "./db/work-items";
 
-const WORK_ITEMS_UPDATE_KNOWN_KEYS = new Set([
-  "id",
-  "phase",
-  "repoRoot",
-  "force",
-  "forceReason",
-  "prNumber",
-  "prState",
-  "prUrl",
-  "ciStatus",
-  "ciRunId",
-  "ciSummary",
-  "reviewStatus",
-  "branch",
-  "issueNumber",
-]);
+/** Derived from the work_items_update inputSchema — single source of truth. */
+let _updateKnownKeys: ReadonlySet<string> | null = null;
+function updateKnownKeys(): ReadonlySet<string> {
+  if (!_updateKnownKeys) {
+    const updateTool = TOOLS.find((t) => t.name === "work_items_update");
+    if (!updateTool) throw new Error("work_items_update tool definition missing");
+    _updateKnownKeys = new Set(Object.keys(updateTool.inputSchema.properties));
+  }
+  return _updateKnownKeys;
+}
 
 /** Parse a value to integer, returning undefined if absent or NaN. */
 function parseIntOrUndefined(value: unknown): number | undefined {
@@ -309,13 +303,20 @@ export class WorkItemsServer {
               return { content: [{ type: "text" as const, text: "id is required" }], isError: true };
             }
 
-            const unknownKeys = Object.keys(a).filter((k) => !WORK_ITEMS_UPDATE_KNOWN_KEYS.has(k));
+            const known = updateKnownKeys();
+            const unknownKeys = Object.keys(a)
+              .filter((k) => !known.has(k))
+              .sort();
             if (unknownKeys.length > 0) {
+              const accepted = [...known]
+                .filter((k) => k !== "id")
+                .sort()
+                .join(", ");
               return {
                 content: [
                   {
                     type: "text" as const,
-                    text: `Unknown keys: ${unknownKeys.join(", ")}. work_items_update only accepts work-item columns (${[...WORK_ITEMS_UPDATE_KNOWN_KEYS].filter((k) => k !== "id").join(", ")}). Phase-namespace state (session_id, qa_session_id, etc.) is stored separately — use phase handler ctx.state to read/write it.`,
+                    text: `Unknown keys: ${unknownKeys.join(", ")}. work_items_update only accepts known keys (${accepted}). Phase-namespace state (session_id, qa_session_id, etc.) is stored separately — use phase handler ctx.state to read/write it.`,
                   },
                 ],
                 isError: true,


### PR DESCRIPTION
## Summary
- `work_items_update` now validates all incoming keys against the known set and returns an actionable error for unrecognized keys
- Error message explicitly mentions phase-namespace state (session_id, qa_session_id, etc.) and points callers to `ctx.state` for reading/writing phase state
- Prevents silent data loss when orchestrators pass phase-namespace keys expecting them to persist

## Follow-up
- Phase state read/write tools (`phase_state_get/set/list`) deferred to #1468 — requires passing `StateDb` into `WorkItemsServer` constructor

## Test plan
- [x] Unknown keys (e.g. `qa_session_id`, `session_id`) → error with descriptive message
- [x] Mix of known + unknown keys → error listing only the unknown keys
- [x] All known keys accepted without error
- [x] Existing tests still pass (5216 tests, 0 failures)
- [x] Typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)