### PR TITLE
fix(db): delete orphan transition rows when work item is deleted (closes #1352)

### DIFF
--- a/packages/daemon/src/db/work-items.spec.ts
+++ b/packages/daemon/src/db/work-items.spec.ts
@@ -163,6 +163,15 @@ describe("WorkItemDb", () => {
       const db = createDb();
       expect(db.deleteWorkItem("missing")).toBe(false);
     });
+
+    test("removes transition rows when work item is deleted", () => {
+      const db = createDb();
+      const item = db.createWorkItem({ issueNumber: 1 });
+      db.updateWorkItem(item.id, { phase: "review" });
+      expect(db.listTransitions(item.id).length).toBeGreaterThan(0);
+      db.deleteWorkItem(item.id);
+      expect(db.listTransitions(item.id)).toHaveLength(0);
+    });
   });
 
   describe("listWorkItems", () => {

--- a/packages/daemon/src/db/work-items.spec.ts
+++ b/packages/daemon/src/db/work-items.spec.ts
@@ -171,6 +171,9 @@ describe("WorkItemDb", () => {
       expect(db.listTransitions(item.id).length).toBeGreaterThan(0);
       db.deleteWorkItem(item.id);
       expect(db.listTransitions(item.id)).toHaveLength(0);
+      const rawDb: Database = (db as unknown as { db: Database }).db;
+      const row = rawDb.query("SELECT COUNT(*) as c FROM work_items WHERE id = ?").get(item.id) as { c: number } | null;
+      expect(row?.c ?? 0).toBe(0);
     });
   });
 

--- a/packages/daemon/src/db/work-items.ts
+++ b/packages/daemon/src/db/work-items.ts
@@ -309,6 +309,7 @@ export class WorkItemDb {
   }
 
   deleteWorkItem(id: string): boolean {
+    this.db.query("DELETE FROM work_item_transitions WHERE work_item_id = ?").run(id);
     this.db.query("DELETE FROM work_items WHERE id = ?").run(id);
     return (this.db.query<{ c: number }, []>("SELECT changes() as c").get()?.c ?? 0) > 0;
   }

--- a/packages/daemon/src/db/work-items.ts
+++ b/packages/daemon/src/db/work-items.ts
@@ -309,9 +309,11 @@ export class WorkItemDb {
   }
 
   deleteWorkItem(id: string): boolean {
-    this.db.query("DELETE FROM work_item_transitions WHERE work_item_id = ?").run(id);
-    this.db.query("DELETE FROM work_items WHERE id = ?").run(id);
-    return (this.db.query<{ c: number }, []>("SELECT changes() as c").get()?.c ?? 0) > 0;
+    return this.db.transaction(() => {
+      this.db.query("DELETE FROM work_item_transitions WHERE work_item_id = ?").run(id);
+      this.db.query("DELETE FROM work_items WHERE id = ?").run(id);
+      return (this.db.query<{ c: number }, []>("SELECT changes() as c").get()?.c ?? 0) > 0;
+    })();
   }
 
   listWorkItems(filter?: { phase?: string }): WorkItem[] {


### PR DESCRIPTION
## Summary
- `deleteWorkItem` now runs `DELETE FROM work_item_transitions WHERE work_item_id = ?` before removing the work item row, preventing unbounded accumulation of orphan transition records
- No schema changes required — explicit DELETE avoids the need for `PRAGMA foreign_keys = ON`

## Test plan
- Added test: creates a work item, triggers a phase transition, deletes the item, asserts `listTransitions` returns an empty array
- All existing `deleteWorkItem` tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)