### PR TITLE
fix(phases): truncate long NOTE column in phase log table (fixes #1385)

### DIFF
--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -1170,7 +1170,7 @@ describe("formatTransitionLog", () => {
     const out = formatTransitionLog([
       { ts: "2026-01-01T00:00:00Z", workItemId: "#1", from: "impl", to: "qa", forceMessage: longMsg },
     ]);
-    const noteCell = out[1].slice(out[1].lastIndexOf("  ")).trim();
+    const noteCell = out[1].slice(out[0].indexOf("NOTE")).trim();
     expect(noteCell.length).toBeLessThanOrEqual(60);
     expect(noteCell.endsWith("…")).toBe(true);
   });

--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -1164,6 +1164,24 @@ describe("formatTransitionLog", () => {
     expect(out[1]).toContain("impl → qa");
     expect(out[1]).toContain("FORCED: urgent");
   });
+
+  test("truncates NOTE column at 60 chars with ellipsis", () => {
+    const longMsg = "a".repeat(80);
+    const out = formatTransitionLog([
+      { ts: "2026-01-01T00:00:00Z", workItemId: "#1", from: "impl", to: "qa", forceMessage: longMsg },
+    ]);
+    const noteCell = out[1].slice(out[1].lastIndexOf("  ")).trim();
+    expect(noteCell.length).toBeLessThanOrEqual(60);
+    expect(noteCell.endsWith("…")).toBe(true);
+  });
+
+  test("does not truncate NOTE shorter than 60 chars", () => {
+    const out = formatTransitionLog([
+      { ts: "2026-01-01T00:00:00Z", workItemId: "#1", from: "impl", to: "qa", forceMessage: "short msg" },
+    ]);
+    expect(out[1]).toContain("FORCED: short msg");
+    expect(out[1]).not.toContain("…");
+  });
 });
 
 describe("cmdPhase log", () => {

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -322,13 +322,19 @@ export function filterTransitionLog(
   return out.reverse();
 }
 
+const NOTE_MAX_WIDTH = 60;
+
+function truncateNote(s: string): string {
+  return s.length > NOTE_MAX_WIDTH ? `${s.slice(0, NOTE_MAX_WIDTH - 1)}…` : s;
+}
+
 /** Render transition entries as a human-readable table, newest first. */
 export function formatTransitionLog(entries: readonly TransitionLogEntry[]): string[] {
   const rows = entries.map((e) => [
     e.ts,
     e.workItemId ?? "—",
     `${e.from ?? "(initial)"} → ${e.to}`,
-    e.forceMessage ? `FORCED: ${e.forceMessage}` : "",
+    truncateNote(e.forceMessage ? `FORCED: ${e.forceMessage}` : ""),
   ]);
   const headers = ["TIMESTAMP", "WORK-ITEM", "TRANSITION", "NOTE"];
   const widths = headers.map((h, i) => Math.max(h.length, ...rows.map((r) => r[i].length)));


### PR DESCRIPTION
## Summary
- Caps the NOTE column in `formatTransitionLog` table output at 60 characters, appending `…` when truncated
- JSONL output (`--json`) is unaffected — raw `forceMessage` values remain untouched
- Introduces a module-level `NOTE_MAX_WIDTH = 60` constant for easy adjustment

## Test plan
- Added test: long forceMessage (80 chars) is truncated to ≤60 chars with trailing `…`
- Added test: short forceMessage (<60 chars) renders without truncation
- Existing `renders header + rows with FORCED marker` test continues to pass
- `bun typecheck`, `bun lint`, `bun test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)