### PR TITLE
feat: worktree containment enforcement — tiered deny/strike policy (fixes #1441)

### DIFF
--- a/packages/daemon/src/claude-session/containment.spec.ts
+++ b/packages/daemon/src/claude-session/containment.spec.ts
@@ -159,6 +159,19 @@ describe("ContainmentGuard — file writes outside worktree", () => {
     expect(r.action).toBe("allow");
     expect(r.strikes).toBe(0);
   });
+
+  test("allows Write to //private/tmp (double-slash normalized by resolve)", () => {
+    const g = guard();
+    const r = g.evaluate("Write", { file_path: "//private/tmp/test.json" });
+    expect(r.action).toBe("allow");
+    expect(r.strikes).toBe(0);
+  });
+
+  test("allows shell redirect to //tmp (double-slash normalized)", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: 'echo "x" > //tmp/scratch.txt' });
+    expect(r.action).toBe("allow");
+  });
 });
 
 // ── Read outside worktree (warn only) ──

--- a/packages/daemon/src/claude-session/containment.spec.ts
+++ b/packages/daemon/src/claude-session/containment.spec.ts
@@ -1,0 +1,257 @@
+import { describe, expect, test } from "bun:test";
+import { ContainmentGuard } from "./containment";
+
+const WORKTREE = "/Users/test/repo/.claude/worktrees/my-worktree";
+
+function guard(): ContainmentGuard {
+  return new ContainmentGuard(WORKTREE);
+}
+
+// ── No-op for in-worktree operations ──
+
+describe("ContainmentGuard — in-worktree operations", () => {
+  test("allows Bash without git commands", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "ls -la" });
+    expect(r.action).toBe("allow");
+    expect(r.event).toBeUndefined();
+  });
+
+  test("allows git commit inside worktree (no explicit path)", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "git commit -m 'test'" });
+    expect(r.action).toBe("allow");
+  });
+
+  test("allows Write inside worktree", () => {
+    const g = guard();
+    const r = g.evaluate("Write", { file_path: `${WORKTREE}/src/main.ts` });
+    expect(r.action).toBe("allow");
+  });
+
+  test("allows Edit inside worktree", () => {
+    const g = guard();
+    const r = g.evaluate("Edit", { file_path: `${WORKTREE}/package.json`, old_string: "a", new_string: "b" });
+    expect(r.action).toBe("allow");
+  });
+
+  test("allows Read inside worktree", () => {
+    const g = guard();
+    const r = g.evaluate("Read", { file_path: `${WORKTREE}/README.md` });
+    expect(r.action).toBe("allow");
+  });
+
+  test("allows Glob inside worktree", () => {
+    const g = guard();
+    const r = g.evaluate("Glob", { path: `${WORKTREE}/src`, pattern: "**/*.ts" });
+    expect(r.action).toBe("allow");
+  });
+
+  test("allows unknown tools (no file_path)", () => {
+    const g = guard();
+    const r = g.evaluate("Agent", { prompt: "do something" });
+    expect(r.action).toBe("allow");
+  });
+});
+
+// ── Git write commands outside worktree ──
+
+describe("ContainmentGuard — git writes outside worktree", () => {
+  test("denies git -C <outside> commit on first attempt", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "git -C /Users/test/repo commit -m 'bad'" });
+    expect(r.action).toBe("deny");
+    expect(r.event).toBe("session:containment_denied");
+    expect(r.reason).toContain("git commit");
+    expect(r.strikes).toBe(0); // git writes don't increment strikes
+  });
+
+  test("denies cd <outside> && git push", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "cd /Users/test/repo && git push origin main" });
+    expect(r.action).toBe("deny");
+    expect(r.event).toBe("session:containment_denied");
+  });
+
+  test("denies cd <outside> && git checkout", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "cd /Users/test/repo && git checkout -b feat/bad" });
+    expect(r.action).toBe("deny");
+  });
+
+  test("allows git -C <inside-worktree> commit", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: `git -C ${WORKTREE}/subdir commit -m 'ok'` });
+    expect(r.action).toBe("allow");
+  });
+
+  test("allows git log outside worktree (read-only)", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "git -C /Users/test/repo log --oneline" });
+    expect(r.action).toBe("allow");
+  });
+
+  test("allows git status outside worktree (read-only)", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "git -C /Users/test/repo status" });
+    expect(r.action).toBe("allow");
+  });
+
+  test("allows git diff outside worktree (read-only)", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "git -C /Users/test/repo diff" });
+    expect(r.action).toBe("allow");
+  });
+});
+
+// ── Write/Edit outside worktree (strike-counted) ──
+
+describe("ContainmentGuard — file writes outside worktree", () => {
+  test("denies Write outside worktree with strike 1", () => {
+    const g = guard();
+    const r = g.evaluate("Write", { file_path: "/Users/test/repo/src/main.ts" });
+    expect(r.action).toBe("deny");
+    expect(r.event).toBe("session:containment_denied");
+    expect(r.strikes).toBe(1);
+  });
+
+  test("denies Edit outside worktree with strike 2", () => {
+    const g = guard();
+    g.evaluate("Write", { file_path: "/Users/test/repo/a.ts" });
+    const r = g.evaluate("Edit", { file_path: "/Users/test/repo/b.ts" });
+    expect(r.action).toBe("deny");
+    expect(r.strikes).toBe(2);
+  });
+
+  test("escalates on 3rd strike", () => {
+    const g = guard();
+    g.evaluate("Write", { file_path: "/Users/test/repo/a.ts" });
+    g.evaluate("Write", { file_path: "/Users/test/repo/b.ts" });
+    const r = g.evaluate("Edit", { file_path: "/Users/test/repo/c.ts" });
+    expect(r.action).toBe("deny");
+    expect(r.event).toBe("session:containment_escalated");
+    expect(r.strikes).toBe(3);
+    expect(g.escalated).toBe(true);
+  });
+
+  test("after escalation, all tool calls denied", () => {
+    const g = guard();
+    g.evaluate("Write", { file_path: "/Users/test/repo/a.ts" });
+    g.evaluate("Write", { file_path: "/Users/test/repo/b.ts" });
+    g.evaluate("Edit", { file_path: "/Users/test/repo/c.ts" });
+
+    // Even in-worktree calls are denied after escalation
+    const r = g.evaluate("Write", { file_path: `${WORKTREE}/ok.ts` });
+    expect(r.action).toBe("deny");
+    expect(r.event).toBe("session:containment_escalated");
+  });
+
+  test("allows Write to /tmp (no strike)", () => {
+    const g = guard();
+    const r = g.evaluate("Write", { file_path: "/tmp/scratch.txt" });
+    expect(r.action).toBe("allow");
+    expect(r.strikes).toBe(0);
+  });
+
+  test("allows Write to /private/tmp (macOS)", () => {
+    const g = guard();
+    const r = g.evaluate("Write", { file_path: "/private/tmp/test.json" });
+    expect(r.action).toBe("allow");
+    expect(r.strikes).toBe(0);
+  });
+});
+
+// ── Read outside worktree (warn only) ──
+
+describe("ContainmentGuard — reads outside worktree", () => {
+  test("warns on Read outside worktree (no strike)", () => {
+    const g = guard();
+    const r = g.evaluate("Read", { file_path: "/Users/test/repo/CLAUDE.md" });
+    expect(r.action).toBe("warn");
+    expect(r.event).toBe("session:containment_warning");
+    expect(r.strikes).toBe(0);
+  });
+
+  test("warns on Grep outside worktree (no strike)", () => {
+    const g = guard();
+    const r = g.evaluate("Grep", { path: "/Users/test/repo", pattern: "foo" });
+    expect(r.action).toBe("warn");
+    expect(r.event).toBe("session:containment_warning");
+    expect(r.strikes).toBe(0);
+  });
+
+  test("warns on Glob outside worktree (no strike)", () => {
+    const g = guard();
+    const r = g.evaluate("Glob", { path: "/Users/test/repo", pattern: "**/*.ts" });
+    expect(r.action).toBe("warn");
+    expect(r.event).toBe("session:containment_warning");
+  });
+
+  test("multiple read warnings don't escalate", () => {
+    const g = guard();
+    for (let i = 0; i < 10; i++) {
+      g.evaluate("Read", { file_path: `/Users/test/repo/file${i}.ts` });
+    }
+    expect(g.strikes).toBe(0);
+    expect(g.escalated).toBe(false);
+  });
+});
+
+// ── Edge cases ──
+
+describe("ContainmentGuard — edge cases", () => {
+  test("handles trailing slash in worktree root", () => {
+    const g = new ContainmentGuard(`${WORKTREE}/`);
+    const r = g.evaluate("Write", { file_path: `${WORKTREE}/src/ok.ts` });
+    expect(r.action).toBe("allow");
+  });
+
+  test("handles worktree root itself as path", () => {
+    const g = guard();
+    const r = g.evaluate("Read", { file_path: WORKTREE });
+    expect(r.action).toBe("allow");
+  });
+
+  test("prevents path traversal via prefix overlap", () => {
+    const g = new ContainmentGuard("/Users/test/repo/.claude/worktrees/abc");
+    const r = g.evaluate("Write", { file_path: "/Users/test/repo/.claude/worktrees/abcdef/evil.ts" });
+    expect(r.action).toBe("deny");
+    expect(r.strikes).toBe(1);
+  });
+
+  test("handles empty command in Bash", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "" });
+    expect(r.action).toBe("allow");
+  });
+
+  test("handles missing command in Bash", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", {});
+    expect(r.action).toBe("allow");
+  });
+
+  test("handles missing file_path in Write", () => {
+    const g = guard();
+    const r = g.evaluate("Write", {});
+    expect(r.action).toBe("allow");
+  });
+
+  test("git commands with flags before subcommand", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "git -C /Users/test/repo --no-pager commit -m 'bad'" });
+    expect(r.action).toBe("deny");
+  });
+
+  test("piped git commands outside worktree", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "cd /Users/test/repo && git add . && git commit -m 'bad'" });
+    expect(r.action).toBe("deny");
+  });
+
+  test("git read-only commands in pipes are allowed", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "git -C /Users/test/repo log | head -5" });
+    expect(r.action).toBe("allow");
+  });
+});

--- a/packages/daemon/src/claude-session/containment.spec.ts
+++ b/packages/daemon/src/claude-session/containment.spec.ts
@@ -255,3 +255,237 @@ describe("ContainmentGuard — edge cases", () => {
     expect(r.action).toBe("allow");
   });
 });
+
+// ── Adversarial: Bash file write bypass vectors ──
+
+describe("ContainmentGuard — bash file write detection", () => {
+  test("denies shell redirect > to outside path", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: 'echo "pwned" > /Users/test/repo/evil.ts' });
+    expect(r.action).toBe("deny");
+    expect(r.strikes).toBe(1);
+  });
+
+  test("denies shell append >> to outside path", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: 'echo "pwned" >> /Users/test/repo/evil.ts' });
+    expect(r.action).toBe("deny");
+    expect(r.strikes).toBe(1);
+  });
+
+  test("allows shell redirect to worktree path", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: `echo "ok" > ${WORKTREE}/output.txt` });
+    expect(r.action).toBe("allow");
+  });
+
+  test("allows shell redirect to /tmp", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: 'echo "scratch" > /tmp/scratch.txt' });
+    expect(r.action).toBe("allow");
+  });
+
+  test("denies cp to outside path", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: `cp ${WORKTREE}/file.ts /Users/test/repo/file.ts` });
+    expect(r.action).toBe("deny");
+    expect(r.strikes).toBe(1);
+  });
+
+  test("denies mv to outside path", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: `mv ${WORKTREE}/file.ts /Users/test/repo/file.ts` });
+    expect(r.action).toBe("deny");
+    expect(r.strikes).toBe(1);
+  });
+
+  test("denies tee to outside path", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "cat something | tee /Users/test/repo/output.log" });
+    expect(r.action).toBe("deny");
+    expect(r.strikes).toBe(1);
+  });
+
+  test("denies ln to outside path", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: `ln -s ${WORKTREE}/file.ts /Users/test/repo/link.ts` });
+    expect(r.action).toBe("deny");
+    expect(r.strikes).toBe(1);
+  });
+
+  test("denies rsync to outside path", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: `rsync -a ${WORKTREE}/src/ /Users/test/repo/src/` });
+    expect(r.action).toBe("deny");
+    expect(r.strikes).toBe(1);
+  });
+
+  test("denies install to outside path", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: `install -m 755 ${WORKTREE}/bin/mcx /usr/local/bin/mcx` });
+    expect(r.action).toBe("deny");
+    expect(r.strikes).toBe(1);
+  });
+
+  test("allows cp between worktree paths", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: `cp ${WORKTREE}/a.ts ${WORKTREE}/b.ts` });
+    expect(r.action).toBe("allow");
+  });
+
+  test("bash write strikes accumulate like Write/Edit", () => {
+    const g = guard();
+    g.evaluate("Bash", { command: 'echo "1" > /Users/test/repo/a.ts' });
+    g.evaluate("Bash", { command: "cp /Users/test/repo/x.ts /Users/test/repo/y.ts" });
+    const r = g.evaluate("Bash", { command: 'echo "3" > /Users/test/repo/c.ts' });
+    expect(r.action).toBe("deny");
+    expect(r.event).toBe("session:containment_escalated");
+    expect(r.strikes).toBe(3);
+    expect(g.escalated).toBe(true);
+  });
+
+  test("bash write strikes mix with Write/Edit strikes", () => {
+    const g = guard();
+    g.evaluate("Write", { file_path: "/Users/test/repo/a.ts" });
+    g.evaluate("Bash", { command: 'echo "2" > /Users/test/repo/b.ts' });
+    const r = g.evaluate("Edit", { file_path: "/Users/test/repo/c.ts" });
+    expect(r.strikes).toBe(3);
+    expect(g.escalated).toBe(true);
+  });
+
+  test("chained commands: denies if any segment writes outside", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: `ls ${WORKTREE} && cp ${WORKTREE}/a.ts /Users/test/repo/a.ts` });
+    expect(r.action).toBe("deny");
+    expect(r.strikes).toBe(1);
+  });
+});
+
+// ── Adversarial: --work-tree / --git-dir bypass vectors ──
+
+describe("ContainmentGuard — git --work-tree and --git-dir", () => {
+  test("denies git --work-tree=/outside commit", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "git --work-tree=/Users/test/repo commit -m 'escape'" });
+    expect(r.action).toBe("deny");
+    expect(r.event).toBe("session:containment_denied");
+  });
+
+  test("denies git --work-tree /outside commit (space-separated)", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "git --work-tree /Users/test/repo commit -m 'escape'" });
+    expect(r.action).toBe("deny");
+  });
+
+  test("denies git --git-dir=/outside/.git commit", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "git --git-dir=/Users/test/repo/.git commit -m 'escape'" });
+    expect(r.action).toBe("deny");
+  });
+
+  test("denies git --git-dir /outside/.git commit (space-separated)", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "git --git-dir /Users/test/repo/.git commit -m 'escape'" });
+    expect(r.action).toBe("deny");
+  });
+
+  test("allows git --work-tree=<inside-worktree> commit", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: `git --work-tree=${WORKTREE} commit -m 'ok'` });
+    expect(r.action).toBe("allow");
+  });
+
+  test("allows git --git-dir=<inside-worktree>/.git commit", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: `git --git-dir=${WORKTREE}/.git commit -m 'ok'` });
+    expect(r.action).toBe("allow");
+  });
+});
+
+// ── Adversarial: env var prefix bypass vectors ──
+
+describe("ContainmentGuard — env var prefix bypass", () => {
+  test("denies GIT_DIR=/outside git commit", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "GIT_DIR=/Users/test/repo/.git git commit -m 'escape'" });
+    expect(r.action).toBe("deny");
+    expect(r.event).toBe("session:containment_denied");
+  });
+
+  test("denies GIT_WORK_TREE=/outside git commit", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "GIT_WORK_TREE=/Users/test/repo git commit -m 'escape'" });
+    expect(r.action).toBe("deny");
+  });
+
+  test("denies combined GIT_DIR + GIT_WORK_TREE env vars", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", {
+      command: "GIT_DIR=/Users/test/repo/.git GIT_WORK_TREE=/Users/test/repo git commit -m 'escape'",
+    });
+    expect(r.action).toBe("deny");
+  });
+
+  test("allows GIT_DIR pointing inside worktree", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: `GIT_DIR=${WORKTREE}/.git git commit -m 'ok'` });
+    expect(r.action).toBe("allow");
+  });
+
+  test("extractGitSubcommand skips env var assignments to find git", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "FOO=bar GIT_DIR=/Users/test/repo/.git git commit -m 'escape'" });
+    expect(r.action).toBe("deny");
+  });
+});
+
+// ── Adversarial: pushd / subshell cd patterns ──
+
+describe("ContainmentGuard — pushd and subshell cd", () => {
+  test("denies pushd <outside> && git commit", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "pushd /Users/test/repo && git commit -m 'escape'" });
+    expect(r.action).toBe("deny");
+    expect(r.event).toBe("session:containment_denied");
+  });
+
+  test("denies subshell (cd <outside> && git commit)", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "(cd /Users/test/repo && git commit -m 'escape')" });
+    expect(r.action).toBe("deny");
+  });
+
+  test("denies bash -c 'cd <outside> && git commit'", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "bash -c 'cd /Users/test/repo && git commit -m escape'" });
+    expect(r.action).toBe("deny");
+  });
+
+  test("allows pushd <inside-worktree> && git commit", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: `pushd ${WORKTREE} && git commit -m 'ok'` });
+    expect(r.action).toBe("allow");
+  });
+
+  test("denies pushd <outside> ; git push (semicolon separator)", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "pushd /Users/test/repo; git push origin main" });
+    expect(r.action).toBe("deny");
+  });
+});
+
+// ── Adversarial: git clone and worktree add ──
+
+describe("ContainmentGuard — git clone and worktree add", () => {
+  test("denies git clone to outside path via -C", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "git -C /Users/test/repo clone https://example.com/repo.git" });
+    expect(r.action).toBe("deny");
+  });
+
+  test("denies git worktree add targeting outside via -C", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "git -C /Users/test/repo worktree add ../escape-hatch" });
+    expect(r.action).toBe("deny");
+  });
+});

--- a/packages/daemon/src/claude-session/containment.ts
+++ b/packages/daemon/src/claude-session/containment.ts
@@ -1,13 +1,4 @@
-/**
- * Worktree containment enforcement for Claude Code sessions.
- *
- * Intercepts can_use_tool permission requests and applies tiered policy:
- * - Git writes outside worktree → hard deny (first attempt)
- * - Write/Edit outside worktree → strike-counted (3-strike cap → hard stop)
- * - Read/cd outside worktree → warn only (no strike)
- *
- * See #1441 for design rationale.
- */
+// Worktree containment enforcement — see #1441 for design rationale.
 
 import { resolve } from "node:path";
 
@@ -48,61 +39,110 @@ const GIT_WRITE_SUBCOMMANDS = new Set([
   "rm",
   "switch",
   "restore",
+  "clone",
+  "worktree",
 ]);
 
 const GIT_CMD_PATTERN = /\bgit\b/;
 
-/**
- * Extract the git subcommand from a shell command string.
- * Handles: git commit, git -C /path commit, git --no-pager commit, etc.
- * Returns null if not a git command or subcommand is unrecognized.
- */
 function extractGitSubcommand(command: string): string | null {
   if (!GIT_CMD_PATTERN.test(command)) return null;
 
-  // Tokenize naively — good enough for detecting subcommands.
-  // We don't need a full shell parser; false negatives are acceptable
-  // (the GIT_DIR/GIT_WORK_TREE env pinning is the true guardrail).
   const tokens = command.split(/[;&|]+/).flatMap((seg) => seg.trim().split(/\s+/));
   for (let i = 0; i < tokens.length; i++) {
-    if (tokens[i] !== "git" && !tokens[i]?.endsWith("/git")) continue;
+    const tok = tokens[i] ?? "";
+    // Skip env var assignments before the command (VAR=val git ...)
+    if (tok.includes("=") && !tok.startsWith("-")) continue;
+    if (tok !== "git" && !tok.endsWith("/git")) continue;
 
-    // Skip flags and -C/--git-dir arguments after "git"
     let j = i + 1;
     while (j < tokens.length) {
-      const tok = tokens[j] ?? "";
-      if (tok === "-C" || tok === "--git-dir" || tok === "--work-tree") {
-        j += 2; // skip flag + its argument
-      } else if (tok.startsWith("-")) {
+      const t = tokens[j] ?? "";
+      if (t === "-C" || t === "--git-dir" || t === "--work-tree") {
+        j += 2;
+      } else if (t.startsWith("--work-tree=") || t.startsWith("--git-dir=")) {
+        j++;
+      } else if (t.startsWith("-")) {
         j++;
       } else {
-        return tok;
+        return t;
       }
     }
   }
   return null;
 }
 
-/**
- * Check whether a Bash command explicitly targets a path outside the worktree
- * via `git -C <path>` or `cd <path> &&`.
- */
 function bashTargetsOutsidePath(command: string, worktreeRoot: string): boolean {
+  const outsideWorktree = (p: string) => {
+    const t = resolve(p);
+    return !t.startsWith(`${worktreeRoot}/`) && t !== worktreeRoot;
+  };
+
   // git -C <path>
   const gitCMatch = command.match(/\bgit\s+-C\s+(\S+)/);
-  if (gitCMatch?.[1]) {
-    const target = resolve(gitCMatch[1]);
-    if (!target.startsWith(worktreeRoot)) return true;
-  }
+  if (gitCMatch?.[1] && outsideWorktree(gitCMatch[1])) return true;
 
-  // cd <path> && git ...
-  const cdMatch = command.match(/\bcd\s+(\S+)\s*[;&|]/);
-  if (cdMatch?.[1]) {
-    const target = resolve(cdMatch[1]);
-    if (!target.startsWith(worktreeRoot) && GIT_CMD_PATTERN.test(command)) return true;
-  }
+  // git --work-tree=<path> or git --work-tree <path>
+  const wtEqMatch = command.match(/--work-tree=(\S+)/);
+  if (wtEqMatch?.[1] && outsideWorktree(wtEqMatch[1])) return true;
+  const wtSpaceMatch = command.match(/--work-tree\s+(\S+)/);
+  if (wtSpaceMatch?.[1] && !wtSpaceMatch[1].startsWith("-") && outsideWorktree(wtSpaceMatch[1])) return true;
+
+  // git --git-dir=<path> or git --git-dir <path>
+  const gdEqMatch = command.match(/--git-dir=(\S+)/);
+  if (gdEqMatch?.[1] && outsideWorktree(gdEqMatch[1])) return true;
+  const gdSpaceMatch = command.match(/--git-dir\s+(\S+)/);
+  if (gdSpaceMatch?.[1] && !gdSpaceMatch[1].startsWith("-") && outsideWorktree(gdSpaceMatch[1])) return true;
+
+  // GIT_DIR=<path> or GIT_WORK_TREE=<path> env var prefixes
+  const envDirMatch = command.match(/\bGIT_DIR=(\S+)/);
+  if (envDirMatch?.[1] && outsideWorktree(envDirMatch[1])) return true;
+  const envWtMatch = command.match(/\bGIT_WORK_TREE=(\S+)/);
+  if (envWtMatch?.[1] && outsideWorktree(envWtMatch[1])) return true;
+
+  // cd / pushd <path> followed by a command separator
+  const cdMatch = command.match(/\b(?:cd|pushd)\s+(\S+)\s*[;&|)]/);
+  if (cdMatch?.[1] && outsideWorktree(cdMatch[1]) && GIT_CMD_PATTERN.test(command)) return true;
+
+  // bash -c "cd <path> && ..." or subshell (cd <path> && ...)
+  const subshellCdMatch = command.match(/(?:bash\s+-c\s+["']|[(])\s*cd\s+(\S+)/);
+  if (subshellCdMatch?.[1] && outsideWorktree(subshellCdMatch[1]) && GIT_CMD_PATTERN.test(command)) return true;
 
   return false;
+}
+
+// ── Bash file write detection ──
+
+const SHELL_WRITE_CMDS = new Set(["cp", "mv", "tee", "ln", "install", "rsync"]);
+
+function extractBashWriteTargets(command: string): string[] {
+  const targets: string[] = [];
+
+  // Shell redirects: > /path or >> /path (only absolute paths)
+  for (const m of command.matchAll(/>{1,2}\s*(\/\S+)/g)) {
+    if (m[1]) targets.push(m[1]);
+  }
+
+  // Common write commands with absolute path arguments
+  // Split on command separators to handle chained commands
+  const segments = command.split(/[;&|]+/);
+  for (const seg of segments) {
+    const tokens = seg.trim().split(/\s+/);
+    // Skip env var assignments
+    let cmdIdx = 0;
+    while (cmdIdx < tokens.length && tokens[cmdIdx]?.includes("=") && !tokens[cmdIdx]?.startsWith("-")) cmdIdx++;
+    const cmd = tokens[cmdIdx];
+    if (!cmd || !SHELL_WRITE_CMDS.has(cmd)) continue;
+
+    // Extract absolute path arguments (skip flags)
+    for (let k = cmdIdx + 1; k < tokens.length; k++) {
+      const t = tokens[k] ?? "";
+      if (t.startsWith("-")) continue;
+      if (t.startsWith("/")) targets.push(t);
+    }
+  }
+
+  return targets;
 }
 
 // ── File path extraction ──
@@ -187,26 +227,28 @@ export class ContainmentGuard {
     const command = typeof input.command === "string" ? input.command : "";
     if (!command) return { action: "allow", reason: "", strikes: this._strikes };
 
+    // Check git write commands
     const subcommand = extractGitSubcommand(command);
-    if (!subcommand) return { action: "allow", reason: "", strikes: this._strikes };
-
-    // Only enforce on git write subcommands
-    if (!GIT_WRITE_SUBCOMMANDS.has(subcommand)) {
-      return { action: "allow", reason: "", strikes: this._strikes };
+    if (subcommand && GIT_WRITE_SUBCOMMANDS.has(subcommand)) {
+      if (bashTargetsOutsidePath(command, this.worktreeRoot)) {
+        return {
+          action: "deny",
+          reason: `Git write command "git ${subcommand}" targets path outside worktree ${this.worktreeRoot}. This is never allowed.`,
+          event: "session:containment_denied",
+          strikes: this._strikes,
+        };
+      }
     }
 
-    // Check if the command explicitly targets outside the worktree
-    if (bashTargetsOutsidePath(command, this.worktreeRoot)) {
-      return {
-        action: "deny",
-        reason: `Git write command "git ${subcommand}" targets path outside worktree ${this.worktreeRoot}. This is never allowed.`,
-        event: "session:containment_denied",
-        strikes: this._strikes,
-      };
+    // Check shell file writes (redirects, cp, mv, tee, ln, etc.)
+    const writeTargets = extractBashWriteTargets(command);
+    for (const target of writeTargets) {
+      if (isAllowedExternalPath(target)) continue;
+      if (isPathOutside(target, this.worktreeRoot)) {
+        return this.evaluateFileAccess("Bash", target);
+      }
     }
 
-    // Git write commands without explicit external path are allowed —
-    // the GIT_DIR/GIT_WORK_TREE env vars pin git to the worktree.
     return { action: "allow", reason: "", strikes: this._strikes };
   }
 

--- a/packages/daemon/src/claude-session/containment.ts
+++ b/packages/daemon/src/claude-session/containment.ts
@@ -1,0 +1,250 @@
+/**
+ * Worktree containment enforcement for Claude Code sessions.
+ *
+ * Intercepts can_use_tool permission requests and applies tiered policy:
+ * - Git writes outside worktree → hard deny (first attempt)
+ * - Write/Edit outside worktree → strike-counted (3-strike cap → hard stop)
+ * - Read/cd outside worktree → warn only (no strike)
+ *
+ * See #1441 for design rationale.
+ */
+
+import { resolve } from "node:path";
+
+// ── Types ──
+
+export type ContainmentAction = "allow" | "deny" | "warn";
+
+export type ContainmentEventType =
+  | "session:containment_warning"
+  | "session:containment_denied"
+  | "session:containment_escalated";
+
+export interface ContainmentResult {
+  action: ContainmentAction;
+  reason: string;
+  event?: ContainmentEventType;
+  /** Current gray-zone strike count after this evaluation. */
+  strikes: number;
+}
+
+// ── Git command classification ──
+
+const GIT_WRITE_SUBCOMMANDS = new Set([
+  "add",
+  "checkout",
+  "commit",
+  "merge",
+  "rebase",
+  "reset",
+  "push",
+  "branch",
+  "cherry-pick",
+  "stash",
+  "tag",
+  "revert",
+  "am",
+  "mv",
+  "rm",
+  "switch",
+  "restore",
+]);
+
+const GIT_CMD_PATTERN = /\bgit\b/;
+
+/**
+ * Extract the git subcommand from a shell command string.
+ * Handles: git commit, git -C /path commit, git --no-pager commit, etc.
+ * Returns null if not a git command or subcommand is unrecognized.
+ */
+function extractGitSubcommand(command: string): string | null {
+  if (!GIT_CMD_PATTERN.test(command)) return null;
+
+  // Tokenize naively — good enough for detecting subcommands.
+  // We don't need a full shell parser; false negatives are acceptable
+  // (the GIT_DIR/GIT_WORK_TREE env pinning is the true guardrail).
+  const tokens = command.split(/[;&|]+/).flatMap((seg) => seg.trim().split(/\s+/));
+  for (let i = 0; i < tokens.length; i++) {
+    if (tokens[i] !== "git" && !tokens[i]?.endsWith("/git")) continue;
+
+    // Skip flags and -C/--git-dir arguments after "git"
+    let j = i + 1;
+    while (j < tokens.length) {
+      const tok = tokens[j] ?? "";
+      if (tok === "-C" || tok === "--git-dir" || tok === "--work-tree") {
+        j += 2; // skip flag + its argument
+      } else if (tok.startsWith("-")) {
+        j++;
+      } else {
+        return tok;
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Check whether a Bash command explicitly targets a path outside the worktree
+ * via `git -C <path>` or `cd <path> &&`.
+ */
+function bashTargetsOutsidePath(command: string, worktreeRoot: string): boolean {
+  // git -C <path>
+  const gitCMatch = command.match(/\bgit\s+-C\s+(\S+)/);
+  if (gitCMatch?.[1]) {
+    const target = resolve(gitCMatch[1]);
+    if (!target.startsWith(worktreeRoot)) return true;
+  }
+
+  // cd <path> && git ...
+  const cdMatch = command.match(/\bcd\s+(\S+)\s*[;&|]/);
+  if (cdMatch?.[1]) {
+    const target = resolve(cdMatch[1]);
+    if (!target.startsWith(worktreeRoot) && GIT_CMD_PATTERN.test(command)) return true;
+  }
+
+  return false;
+}
+
+// ── File path extraction ──
+
+function extractFilePath(toolName: string, input: Record<string, unknown>): string | null {
+  if (toolName === "Write" || toolName === "Edit" || toolName === "Read") {
+    const fp = input.file_path;
+    return typeof fp === "string" ? fp : null;
+  }
+  if (toolName === "Glob" || toolName === "Grep") {
+    const p = input.path;
+    return typeof p === "string" ? p : null;
+  }
+  return null;
+}
+
+function isPathOutside(filePath: string, worktreeRoot: string): boolean {
+  const resolved = resolve(filePath);
+  return !resolved.startsWith(`${worktreeRoot}/`) && resolved !== worktreeRoot;
+}
+
+// ── Allowed external paths ──
+
+const ALLOWED_EXTERNAL_PREFIXES = ["/tmp", "/var/tmp", "/private/tmp"];
+
+function isAllowedExternalPath(filePath: string): boolean {
+  const resolved = resolve(filePath);
+  return ALLOWED_EXTERNAL_PREFIXES.some((p) => resolved.startsWith(`${p}/`) || resolved === p);
+}
+
+// ── Guard ──
+
+const MAX_STRIKES = 3;
+
+export class ContainmentGuard {
+  readonly worktreeRoot: string;
+  private _strikes = 0;
+  private _escalated = false;
+
+  constructor(worktreeRoot: string) {
+    // Normalize: strip trailing slash for consistent prefix comparison
+    this.worktreeRoot = worktreeRoot.replace(/\/+$/, "");
+  }
+
+  get strikes(): number {
+    return this._strikes;
+  }
+
+  get escalated(): boolean {
+    return this._escalated;
+  }
+
+  /**
+   * Evaluate a tool call against containment policy.
+   * Returns allow for in-worktree operations or when no worktree is set.
+   */
+  evaluate(toolName: string, input: Record<string, unknown>): ContainmentResult {
+    if (this._escalated) {
+      return {
+        action: "deny",
+        reason: "Session escalated: containment limit reached (3 strikes). All tool calls denied.",
+        event: "session:containment_escalated",
+        strikes: this._strikes,
+      };
+    }
+
+    // Bash tool — check for git write commands outside worktree
+    if (toolName === "Bash") {
+      return this.evaluateBash(input);
+    }
+
+    // File-path tools
+    const filePath = extractFilePath(toolName, input);
+    if (filePath && isPathOutside(filePath, this.worktreeRoot)) {
+      return this.evaluateFileAccess(toolName, filePath);
+    }
+
+    return { action: "allow", reason: "", strikes: this._strikes };
+  }
+
+  private evaluateBash(input: Record<string, unknown>): ContainmentResult {
+    const command = typeof input.command === "string" ? input.command : "";
+    if (!command) return { action: "allow", reason: "", strikes: this._strikes };
+
+    const subcommand = extractGitSubcommand(command);
+    if (!subcommand) return { action: "allow", reason: "", strikes: this._strikes };
+
+    // Only enforce on git write subcommands
+    if (!GIT_WRITE_SUBCOMMANDS.has(subcommand)) {
+      return { action: "allow", reason: "", strikes: this._strikes };
+    }
+
+    // Check if the command explicitly targets outside the worktree
+    if (bashTargetsOutsidePath(command, this.worktreeRoot)) {
+      return {
+        action: "deny",
+        reason: `Git write command "git ${subcommand}" targets path outside worktree ${this.worktreeRoot}. This is never allowed.`,
+        event: "session:containment_denied",
+        strikes: this._strikes,
+      };
+    }
+
+    // Git write commands without explicit external path are allowed —
+    // the GIT_DIR/GIT_WORK_TREE env vars pin git to the worktree.
+    return { action: "allow", reason: "", strikes: this._strikes };
+  }
+
+  private evaluateFileAccess(toolName: string, filePath: string): ContainmentResult {
+    const resolved = resolve(filePath);
+
+    // Read-class tools: warn only, no strike
+    if (toolName === "Read" || toolName === "Glob" || toolName === "Grep") {
+      return {
+        action: "warn",
+        reason: `${toolName} targets ${resolved} outside worktree ${this.worktreeRoot}. Reads are allowed but monitored.`,
+        event: "session:containment_warning",
+        strikes: this._strikes,
+      };
+    }
+
+    // Write/Edit: strike-counted gray zone
+    // Allow /tmp writes without penalty
+    if (isAllowedExternalPath(filePath)) {
+      return { action: "allow", reason: "", strikes: this._strikes };
+    }
+
+    this._strikes++;
+    if (this._strikes >= MAX_STRIKES) {
+      this._escalated = true;
+      return {
+        action: "deny",
+        reason: `${toolName} targets ${resolved} outside worktree ${this.worktreeRoot}. Strike ${this._strikes}/${MAX_STRIKES} — session escalated. All further tool calls will be denied.`,
+        event: "session:containment_escalated",
+        strikes: this._strikes,
+      };
+    }
+
+    return {
+      action: "deny",
+      reason: `${toolName} targets ${resolved} outside worktree ${this.worktreeRoot}. Strike ${this._strikes}/${MAX_STRIKES}. Write/Edit outside worktree is denied.`,
+      event: "session:containment_denied",
+      strikes: this._strikes,
+    };
+  }
+}

--- a/packages/daemon/src/claude-session/containment.ts
+++ b/packages/daemon/src/claude-session/containment.ts
@@ -1,4 +1,4 @@
-// Worktree containment enforcement — see #1441 for design rationale.
+// Worktree containment enforcement — see #1441 for design.
 
 import { resolve } from "node:path";
 
@@ -73,40 +73,37 @@ function extractGitSubcommand(command: string): string | null {
 }
 
 function bashTargetsOutsidePath(command: string, worktreeRoot: string): boolean {
-  const outsideWorktree = (p: string) => {
-    const t = resolve(p);
-    return !t.startsWith(`${worktreeRoot}/`) && t !== worktreeRoot;
-  };
+  const outside = (p: string) => isPathOutside(p, worktreeRoot);
 
   // git -C <path>
   const gitCMatch = command.match(/\bgit\s+-C\s+(\S+)/);
-  if (gitCMatch?.[1] && outsideWorktree(gitCMatch[1])) return true;
+  if (gitCMatch?.[1] && outside(gitCMatch[1])) return true;
 
   // git --work-tree=<path> or git --work-tree <path>
   const wtEqMatch = command.match(/--work-tree=(\S+)/);
-  if (wtEqMatch?.[1] && outsideWorktree(wtEqMatch[1])) return true;
+  if (wtEqMatch?.[1] && outside(wtEqMatch[1])) return true;
   const wtSpaceMatch = command.match(/--work-tree\s+(\S+)/);
-  if (wtSpaceMatch?.[1] && !wtSpaceMatch[1].startsWith("-") && outsideWorktree(wtSpaceMatch[1])) return true;
+  if (wtSpaceMatch?.[1] && !wtSpaceMatch[1].startsWith("-") && outside(wtSpaceMatch[1])) return true;
 
   // git --git-dir=<path> or git --git-dir <path>
   const gdEqMatch = command.match(/--git-dir=(\S+)/);
-  if (gdEqMatch?.[1] && outsideWorktree(gdEqMatch[1])) return true;
+  if (gdEqMatch?.[1] && outside(gdEqMatch[1])) return true;
   const gdSpaceMatch = command.match(/--git-dir\s+(\S+)/);
-  if (gdSpaceMatch?.[1] && !gdSpaceMatch[1].startsWith("-") && outsideWorktree(gdSpaceMatch[1])) return true;
+  if (gdSpaceMatch?.[1] && !gdSpaceMatch[1].startsWith("-") && outside(gdSpaceMatch[1])) return true;
 
   // GIT_DIR=<path> or GIT_WORK_TREE=<path> env var prefixes
   const envDirMatch = command.match(/\bGIT_DIR=(\S+)/);
-  if (envDirMatch?.[1] && outsideWorktree(envDirMatch[1])) return true;
+  if (envDirMatch?.[1] && outside(envDirMatch[1])) return true;
   const envWtMatch = command.match(/\bGIT_WORK_TREE=(\S+)/);
-  if (envWtMatch?.[1] && outsideWorktree(envWtMatch[1])) return true;
+  if (envWtMatch?.[1] && outside(envWtMatch[1])) return true;
 
   // cd / pushd <path> followed by a command separator
   const cdMatch = command.match(/\b(?:cd|pushd)\s+(\S+)\s*[;&|)]/);
-  if (cdMatch?.[1] && outsideWorktree(cdMatch[1]) && GIT_CMD_PATTERN.test(command)) return true;
+  if (cdMatch?.[1] && outside(cdMatch[1]) && GIT_CMD_PATTERN.test(command)) return true;
 
   // bash -c "cd <path> && ..." or subshell (cd <path> && ...)
   const subshellCdMatch = command.match(/(?:bash\s+-c\s+["']|[(])\s*cd\s+(\S+)/);
-  if (subshellCdMatch?.[1] && outsideWorktree(subshellCdMatch[1]) && GIT_CMD_PATTERN.test(command)) return true;
+  if (subshellCdMatch?.[1] && outside(subshellCdMatch[1]) && GIT_CMD_PATTERN.test(command)) return true;
 
   return false;
 }

--- a/packages/daemon/src/claude-session/session-state.ts
+++ b/packages/daemon/src/claude-session/session-state.ts
@@ -40,7 +40,10 @@ export type SessionEvent =
   | { type: "session:disconnected"; reason: string }
   | { type: "session:ended" }
   | { type: "session:cleared" }
-  | { type: "session:model_changed"; model: string };
+  | { type: "session:model_changed"; model: string }
+  | { type: "session:containment_warning"; toolName: string; reason: string; strikes: number }
+  | { type: "session:containment_denied"; toolName: string; reason: string; strikes: number }
+  | { type: "session:containment_escalated"; toolName: string; reason: string; strikes: number };
 
 // ── Outbound message (string ready to send over WS) ──
 

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -16,6 +16,7 @@ import type { AgentPermissionRequest, Logger, SessionInfo, SessionStateEnum, Wor
 import { consoleLogger, generateSessionName } from "@mcp-cli/core";
 import type { ServerWebSocket } from "bun";
 import { killPid } from "../process-util";
+import { ContainmentGuard } from "./containment";
 import type { NdjsonMessage } from "./ndjson";
 import { keepAlive, parseFrame, permissionAllow, permissionDeny, setModelRequest, userMessage } from "./ndjson";
 import type { CanUseToolRequest, PermissionRule, PermissionStrategy } from "./permission-router";
@@ -270,6 +271,7 @@ interface WsSession {
   proc: { kill: (signal?: number) => void; exited: Promise<number> } | null;
   spawnAlive: boolean;
   worktree: string | null;
+  containment: ContainmentGuard | null;
   resultWaiters: ResultWaiter[];
   keepAliveTimer: Timer | null;
   clearing: boolean;
@@ -534,6 +536,7 @@ export class ClaudeWsServer {
         proc: null,
         spawnAlive: false,
         worktree: s.worktree,
+        containment: s.worktree && s.cwd ? new ContainmentGuard(s.cwd) : null,
         resultWaiters: [],
         keepAliveTimer: null,
         clearing: false,
@@ -582,6 +585,7 @@ export class ClaudeWsServer {
       proc: null,
       spawnAlive: false,
       worktree: config.worktree ?? null,
+      containment: config.worktree && config.cwd ? new ContainmentGuard(config.cwd) : null,
       resultWaiters: [],
       keepAliveTimer: null,
       clearing: false,
@@ -1440,7 +1444,7 @@ export class ClaudeWsServer {
         } catch (err) {
           logErr("resolveEventWaiters failed", err);
         }
-        this.handlePermissionRequest(session, event.requestId, event.request).catch((err) => {
+        this.handlePermissionRequest(sessionId, session, event.requestId, event.request).catch((err) => {
           this.logger.error(
             `[_claude] Permission evaluation failed for session ${sessionId}: ${err instanceof Error ? err.stack : err}`,
           );
@@ -1539,14 +1543,53 @@ export class ClaudeWsServer {
           logErr("resolveEventWaiters failed", err);
         }
         break;
+      case "session:containment_warning":
+      case "session:containment_denied":
+      case "session:containment_escalated":
+        this.logger.warn(`[_claude] Containment ${event.type.split(":")[1]} for session ${sessionId}: ${event.reason}`);
+        try {
+          session.pendingImmediate = true;
+          this.resolveEventWaiters(sessionId, {
+            sessionId,
+            event: event.type,
+            toolName: event.toolName,
+            result: event.reason,
+          });
+        } catch (err) {
+          logErr("resolveEventWaiters failed", err);
+        }
+        break;
     }
   }
 
   private async handlePermissionRequest(
+    sessionId: string,
     session: WsSession,
     requestId: string,
     request: CanUseToolRequest,
   ): Promise<void> {
+    // Containment check — runs before permission router for worktree sessions
+    if (session.containment) {
+      const result = session.containment.evaluate(request.tool_name, request.input);
+      if (result.event) {
+        const containmentEvent = {
+          type: result.event,
+          toolName: request.tool_name,
+          reason: result.reason,
+          strikes: result.strikes,
+        } as const;
+        this.handleSessionEvent(sessionId, session, containmentEvent);
+      }
+      if (result.action === "deny") {
+        session.state.respondToPermission(requestId, false, result.reason);
+        this.sendToWs(
+          session,
+          permissionDeny(requestId, result.reason, result.event === "session:containment_escalated"),
+        );
+        return;
+      }
+    }
+
     if (session.router.strategy === "delegate") {
       return;
     }

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -216,6 +216,7 @@ export interface SessionWaitEvent {
   errors?: string[];
   requestId?: string;
   toolName?: string;
+  strikes?: number;
   /** Full session snapshot at the time of the event (same fields as claude_session_list). */
   session?: SessionInfo;
 }
@@ -1554,6 +1555,7 @@ export class ClaudeWsServer {
             event: event.type,
             toolName: event.toolName,
             result: event.reason,
+            strikes: event.strikes,
           });
         } catch (err) {
           logErr("resolveEventWaiters failed", err);


### PR DESCRIPTION
## Summary
- Adds `ContainmentGuard` class that intercepts `can_use_tool` permission requests for worktree sessions and enforces a tiered containment policy:
  - **Git writes** (commit, push, checkout, etc.) targeting outside worktree → hard deny on first attempt
  - **Write/Edit** to paths outside worktree → strike-counted with 3-strike escalation to hard stop
  - **Read/Glob/Grep** outside worktree → warn only (no strike, no deny)
  - `/tmp` writes always allowed without penalty
- Surfaces `session:containment_warning`, `session:containment_denied`, and `session:containment_escalated` events to orchestrator via event waiters (`mcx claude wait`)
- 33 unit tests covering all tiers, edge cases, and escalation behavior

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — all 5246 tests pass (0 failures), including 33 new containment tests
- [x] Verified: containment guard only activates when both `worktree` and `cwd` are set on the session config
- [x] Verified: path traversal prevention (prefix overlap e.g. `abc` vs `abcdef`)
- [x] Verified: escalated sessions deny all subsequent tool calls including in-worktree ones

🤖 Generated with [Claude Code](https://claude.com/claude-code)