### PR TITLE
test(phases): add combined --json + --work-item test for phase log (closes #1386)

### DIFF
--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -1213,6 +1213,24 @@ describe("cmdPhase log", () => {
     expect(first.ts).toBe("t2");
     expect(first.forceMessage).toBe("x");
   });
+
+  test("--json + --work-item filters by work item and emits JSONL", async () => {
+    const log = transitionLogPath(dir);
+    appendTransitionLog(log, { ts: "t1", workItemId: "#1", from: null, to: "impl" });
+    appendTransitionLog(log, { ts: "t2", workItemId: "#2", from: null, to: "impl" });
+    appendTransitionLog(log, { ts: "t3", workItemId: "#1", from: "impl", to: "qa", forceMessage: "retry" });
+    appendTransitionLog(log, { ts: "t4", workItemId: "#2", from: "impl", to: "qa" });
+    const { deps, logs } = makeDriftDeps(dir);
+    await cmdPhase(["log", "--json", "--work-item", "#1"], deps);
+    expect(logs.length).toBe(2);
+    const entries = logs.map((l) => JSON.parse(l));
+    expect(entries[0].ts).toBe("t3");
+    expect(entries[0].workItemId).toBe("#1");
+    expect(entries[0].forceMessage).toBe("retry");
+    expect(entries[1].ts).toBe("t1");
+    expect(entries[1].workItemId).toBe("#1");
+    expect(entries.every((e) => e.workItemId === "#1")).toBe(true);
+  });
 });
 
 describe("cmdPhase check", () => {


### PR DESCRIPTION
## Summary
- Adds a new test in `describe("cmdPhase log")` that exercises `--json` and `--work-item` together
- Test appends entries for `#1` and `#2`, calls `cmdPhase(["log", "--json", "--work-item", "#1"])`, and asserts only `#1` entries are emitted as JSONL newest-first

## Test plan
- [x] New test passes: `bun test packages/command/src/commands/phase.spec.ts --testNamePattern="cmdPhase log"`
- [x] Full suite passes: 5214 pass, 0 fail
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] Pre-commit hook passes (typecheck + lint + test + coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)