### PR TITLE
feat(phases): detect and report cycles in manifest phase graph (closes #1344)

### DIFF
--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -723,6 +723,52 @@ describe("explainTransition", () => {
     expect(r.kind).toBe("disallowed");
     expect(r.message).toContain("already");
   });
+
+  test("cycle: from-phase is in a cycle but cannot reach to-phase", () => {
+    // Graph: start → a → b → a (cycle between a and b), start → c → done
+    // Asking: a → done — a is in a cycle (a→b→a) and cannot reach done,
+    // but done is reachable from start and start can reach a.
+    // Reverse path: done ← start is not reachable, so this should be disallowed.
+    // Use a different setup: start → cycle-a → cycle-b → cycle-a (cycle),
+    // start → exit; exit can reach cycle-a (making cycle-a a "regression" target)
+    // Actually: setup where cycle-a is in cycle and exit can reach cycle-a:
+    // cycle-a → cycle-b → cycle-a, and cycle-a → exit (one-way out).
+    // Ask: exit → cycle-a: exit is NOT in a cycle → regression (correct).
+    //
+    // For kind:"cycle": need from IN a cycle, to NOT reachable from from,
+    // but to CAN reach from.
+    // Example: left → right → left (cycle), and entry → left (entry reaches left).
+    // Ask: left → entry: left IS in cycle, no forward path, entry→left exists.
+    const cycleManifest = loadTestManifest(
+      `
+initial: entry
+phases:
+  entry:
+    source: ./entry.ts
+    next: [left]
+  left:
+    source: ./left.ts
+    next: [right]
+  right:
+    source: ./right.ts
+    next: [left]
+`.trim(),
+    );
+    const r = explainTransition(cycleManifest, "left", "entry");
+    expect(r.legal).toBe(false);
+    expect(r.kind).toBe("cycle");
+    expect(r.message).toContain("cycle");
+    expect(r.message).toContain("entry");
+    expect(r.path).toBeDefined();
+  });
+
+  test("regression stays regression when from-phase is NOT in a cycle", () => {
+    // done is terminal (not in a cycle), so done → impl is a plain regression
+    const r = explainTransition(m, "done", "impl");
+    expect(r.legal).toBe(false);
+    expect(r.kind).toBe("regression");
+    expect(r.message).toContain("regress");
+  });
 });
 
 describe("buildPhaseList / formatPhaseTable", () => {

--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -725,20 +725,9 @@ describe("explainTransition", () => {
   });
 
   test("cycle: from-phase is in a cycle but cannot reach to-phase", () => {
-    // Graph: start → a → b → a (cycle between a and b), start → c → done
-    // Asking: a → done — a is in a cycle (a→b→a) and cannot reach done,
-    // but done is reachable from start and start can reach a.
-    // Reverse path: done ← start is not reachable, so this should be disallowed.
-    // Use a different setup: start → cycle-a → cycle-b → cycle-a (cycle),
-    // start → exit; exit can reach cycle-a (making cycle-a a "regression" target)
-    // Actually: setup where cycle-a is in cycle and exit can reach cycle-a:
-    // cycle-a → cycle-b → cycle-a, and cycle-a → exit (one-way out).
-    // Ask: exit → cycle-a: exit is NOT in a cycle → regression (correct).
-    //
-    // For kind:"cycle": need from IN a cycle, to NOT reachable from from,
-    // but to CAN reach from.
-    // Example: left → right → left (cycle), and entry → left (entry reaches left).
-    // Ask: left → entry: left IS in cycle, no forward path, entry→left exists.
+    // Manifest: entry → left → right → left (left/right form a cycle).
+    // Asking left → entry: left is in a cycle, has no forward path to entry,
+    // but entry can reach left — should return kind:"cycle", not "regression".
     const cycleManifest = loadTestManifest(
       `
 initial: entry

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -53,6 +53,7 @@ import {
   ipcCall,
   isCommitted,
   isDefineAlias,
+  isPhaseInCycle,
   loadManifest,
   parseLockfile,
   readAllTransitions,
@@ -1351,7 +1352,7 @@ export function formatPhaseShow(info: PhaseShowInfo): string[] {
 
 export interface PhaseWhyResult {
   legal: boolean;
-  kind: "direct" | "indirect" | "unknown-phase" | "disallowed" | "regression";
+  kind: "direct" | "indirect" | "unknown-phase" | "disallowed" | "regression" | "cycle";
   from: string;
   to: string;
   path?: string[];
@@ -1429,6 +1430,16 @@ export function explainTransition(manifest: Manifest, from: string, to: string):
 
   const reverse = shortestPhasePath(manifest, to, from);
   if (reverse) {
+    if (isPhaseInCycle(manifest, from)) {
+      return {
+        legal: false,
+        kind: "cycle",
+        from,
+        to,
+        path: reverse,
+        message: `"${from}" is part of a cycle and has no forward path to "${to}" (${to} → ${from} reachable via: ${reverse.join(" → ")}). If this transition is intended, add "${to}" to phase "${from}"'s next: list.`,
+      };
+    }
     return {
       legal: false,
       kind: "regression",

--- a/packages/core/src/manifest.spec.ts
+++ b/packages/core/src/manifest.spec.ts
@@ -6,7 +6,9 @@ import {
   DEFAULT_RUNS_ON,
   MANIFEST_FILENAMES,
   ManifestError,
+  detectCycles,
   findManifest,
+  isPhaseInCycle,
   loadManifest,
   parseManifestText,
   resolveRunsOn,
@@ -289,5 +291,159 @@ describe("resolveRunsOn", () => {
 
   test("returns explicit runsOn when set", () => {
     expect(resolveRunsOn({ runsOn: "develop" })).toBe("develop");
+  });
+});
+
+describe("detectCycles", () => {
+  test("returns empty array for a DAG", () => {
+    const m = validateManifest(
+      {
+        initial: "a",
+        phases: {
+          a: { source: "./a.ts", next: ["b"] },
+          b: { source: "./b.ts", next: ["c"] },
+          c: { source: "./c.ts", next: [] },
+        },
+      },
+      "/tmp/x",
+    );
+    expect(detectCycles(m)).toEqual([]);
+  });
+
+  test("detects a direct 2-node cycle", () => {
+    const m = validateManifest(
+      {
+        initial: "review",
+        phases: {
+          review: { source: "./r.ts", next: ["repair"] },
+          repair: { source: "./p.ts", next: ["review"] },
+        },
+      },
+      "/tmp/x",
+    );
+    const cycles = detectCycles(m);
+    expect(cycles.length).toBeGreaterThan(0);
+    const flat = cycles.flat();
+    expect(flat).toContain("review");
+    expect(flat).toContain("repair");
+  });
+
+  test("detects a longer cycle", () => {
+    const m = validateManifest(
+      {
+        initial: "a",
+        phases: {
+          a: { source: "./a.ts", next: ["b"] },
+          b: { source: "./b.ts", next: ["c"] },
+          c: { source: "./c.ts", next: ["a"] },
+        },
+      },
+      "/tmp/x",
+    );
+    const cycles = detectCycles(m);
+    expect(cycles.length).toBeGreaterThan(0);
+    const cycle = cycles[0];
+    expect(cycle[0]).toBe(cycle[cycle.length - 1]);
+  });
+
+  test("cycle paths are closed (first === last)", () => {
+    const m = validateManifest(
+      {
+        initial: "review",
+        phases: {
+          review: { source: "./r.ts", next: ["repair"] },
+          repair: { source: "./p.ts", next: ["review", "done"] },
+          done: { source: "./d.ts", next: [] },
+        },
+      },
+      "/tmp/x",
+    );
+    const cycles = detectCycles(m);
+    for (const cycle of cycles) {
+      expect(cycle[0]).toBe(cycle[cycle.length - 1]);
+    }
+  });
+});
+
+describe("isPhaseInCycle", () => {
+  test("returns false for phases with no outgoing edges", () => {
+    const m = validateManifest(
+      {
+        initial: "a",
+        phases: {
+          a: { source: "./a.ts", next: ["b"] },
+          b: { source: "./b.ts", next: [] },
+        },
+      },
+      "/tmp/x",
+    );
+    expect(isPhaseInCycle(m, "b")).toBe(false);
+  });
+
+  test("returns false for a phase in a DAG", () => {
+    const m = validateManifest(
+      {
+        initial: "a",
+        phases: {
+          a: { source: "./a.ts", next: ["b"] },
+          b: { source: "./b.ts", next: ["c"] },
+          c: { source: "./c.ts", next: [] },
+        },
+      },
+      "/tmp/x",
+    );
+    expect(isPhaseInCycle(m, "a")).toBe(false);
+    expect(isPhaseInCycle(m, "b")).toBe(false);
+  });
+
+  test("returns true for phases in a 2-node cycle", () => {
+    const m = validateManifest(
+      {
+        initial: "review",
+        phases: {
+          review: { source: "./r.ts", next: ["repair"] },
+          repair: { source: "./p.ts", next: ["review"] },
+        },
+      },
+      "/tmp/x",
+    );
+    expect(isPhaseInCycle(m, "review")).toBe(true);
+    expect(isPhaseInCycle(m, "repair")).toBe(true);
+  });
+
+  test("returns true for phases in a longer cycle", () => {
+    const m = validateManifest(
+      {
+        initial: "a",
+        phases: {
+          a: { source: "./a.ts", next: ["b"] },
+          b: { source: "./b.ts", next: ["c"] },
+          c: { source: "./c.ts", next: ["a"] },
+        },
+      },
+      "/tmp/x",
+    );
+    expect(isPhaseInCycle(m, "a")).toBe(true);
+    expect(isPhaseInCycle(m, "b")).toBe(true);
+    expect(isPhaseInCycle(m, "c")).toBe(true);
+  });
+
+  test("returns false for a phase that can reach a cycle but is not in it", () => {
+    const m = validateManifest(
+      {
+        initial: "start",
+        phases: {
+          start: { source: "./s.ts", next: ["review"] },
+          review: { source: "./r.ts", next: ["repair"] },
+          repair: { source: "./p.ts", next: ["review", "done"] },
+          done: { source: "./d.ts", next: [] },
+        },
+      },
+      "/tmp/x",
+    );
+    expect(isPhaseInCycle(m, "start")).toBe(false);
+    expect(isPhaseInCycle(m, "done")).toBe(false);
+    expect(isPhaseInCycle(m, "review")).toBe(true);
+    expect(isPhaseInCycle(m, "repair")).toBe(true);
   });
 });

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -262,18 +262,21 @@ export function detectCycles(manifest: Manifest): string[][] {
 
 /**
  * Returns true if the given phase is part of at least one cycle (i.e., it
- * can reach itself through one or more other phases).
+ * can reach itself, whether directly via a self-loop or through other phases).
  */
 export function isPhaseInCycle(manifest: Manifest, phase: string): boolean {
   const neighbors = manifest.phases[phase]?.next ?? [];
   const queue = [...neighbors];
   const seen = new Set<string>();
-  while (queue.length > 0) {
-    const node = queue.shift() as string;
+  let head = 0;
+  while (head < queue.length) {
+    const node = queue[head++];
     if (node === phase) return true;
     if (seen.has(node)) continue;
     seen.add(node);
-    queue.push(...(manifest.phases[node]?.next ?? []));
+    for (const next of manifest.phases[node]?.next ?? []) {
+      queue.push(next);
+    }
   }
   return false;
 }

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -220,6 +220,65 @@ export function validateManifest(raw: unknown, path: string): Manifest {
 }
 
 /**
+ * Detect all cycles in the phase graph using DFS back-edge detection.
+ * Returns each cycle as a closed path array: `[a, b, ..., a]` where the
+ * last element repeats the first. A manifest with no cycles returns `[]`.
+ *
+ * Cycles are intentional in many sprint manifests (e.g. review → repair →
+ * review). This function lets callers inspect or report them without
+ * treating them as errors.
+ */
+export function detectCycles(manifest: Manifest): string[][] {
+  const visited = new Set<string>();
+  const onStack = new Set<string>();
+  const cycles: string[][] = [];
+
+  function dfs(node: string, stack: string[]): void {
+    visited.add(node);
+    onStack.add(node);
+    stack.push(node);
+
+    for (const next of manifest.phases[node]?.next ?? []) {
+      if (!visited.has(next)) {
+        dfs(next, stack);
+      } else if (onStack.has(next)) {
+        const cycleStart = stack.indexOf(next);
+        cycles.push([...stack.slice(cycleStart), next]);
+      }
+    }
+
+    stack.pop();
+    onStack.delete(node);
+  }
+
+  for (const phase of Object.keys(manifest.phases)) {
+    if (!visited.has(phase)) {
+      dfs(phase, []);
+    }
+  }
+
+  return cycles;
+}
+
+/**
+ * Returns true if the given phase is part of at least one cycle (i.e., it
+ * can reach itself through one or more other phases).
+ */
+export function isPhaseInCycle(manifest: Manifest, phase: string): boolean {
+  const neighbors = manifest.phases[phase]?.next ?? [];
+  const queue = [...neighbors];
+  const seen = new Set<string>();
+  while (queue.length > 0) {
+    const node = queue.shift() as string;
+    if (node === phase) return true;
+    if (seen.has(node)) continue;
+    seen.add(node);
+    queue.push(...(manifest.phases[node]?.next ?? []));
+  }
+  return false;
+}
+
+/**
  * Load and validate a manifest from `dir`. Returns null if no manifest file
  * exists. Throws ManifestError on parse, size, or validation failure.
  */


### PR DESCRIPTION
## Summary
- Adds `detectCycles(manifest)` to `core/src/manifest.ts`: DFS back-edge detection returning all cycle paths as closed arrays (`[a, b, ..., a]`)
- Adds `isPhaseInCycle(manifest, phase)`: BFS check returning whether a phase participates in any cycle
- Adds `kind: "cycle"` to `PhaseWhyResult`; `explainTransition` now returns `kind: "cycle"` (instead of `kind: "regression"`) when the `from` phase is itself in a cycle — avoids the misleading "can only transition forward" message when the source has no clear linear ordering

## Test plan
- [x] `detectCycles` tests: DAG returns empty, 2-node cycle detected, longer 3-node cycle detected, closed-path invariant holds
- [x] `isPhaseInCycle` tests: terminal phase → false, DAG phases → false, 2-node/3-node cycle members → true, phase that can *reach* a cycle but isn't *in* one → false
- [x] `explainTransition` cycle test: phase in cycle with no forward path → `kind: "cycle"`, message includes target name and guidance
- [x] Regression still fires when `from` is NOT in a cycle (e.g. terminal `done` phase)
- [x] Full test suite: 5224 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)