### PR TITLE
chore(ci): wire phase drift guard into CI check job (closes #1391)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: bun run typecheck
       - run: bun run lint:check
+      - name: Phase drift guard
+        run: bun run check:phase-drift
       # Split daemon tests into a separate invocation to avoid a non-deterministic
       # Bun v1.3.11 segfault that triggers when daemon worker-thread tests run in
       # the same process as all other tests. See #1004 for upstream tracking.


### PR DESCRIPTION
## Summary
- `scripts/check-phase-drift.ts` and its spec already existed but were never invoked in CI
- Adds a `Phase drift guard` step to the `check` job in `.github/workflows/ci.yml` that runs `bun run check:phase-drift` before the test steps
- The guard verifies the `sub === "run"` block in `phase.ts` still calls `assertNoDrift`/`detectDrift`, enforcing the security property at CI time

## Test plan
- [x] `bun run check:phase-drift` exits 0 (guard found at line 702 of phase.ts)
- [x] `bun typecheck` passes
- [x] `bun lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)