### PR TITLE
fix(work-items): validate initialPhase server-side against manifest (fixes #1351)

### DIFF
--- a/packages/command/src/commands/track.spec.ts
+++ b/packages/command/src/commands/track.spec.ts
@@ -67,7 +67,7 @@ describe("cmdTrack", () => {
     });
 
     await cmdTrack(["1135"], deps);
-    expect(captured).toEqual({ number: 1135 });
+    expect(captured).toEqual({ number: 1135, repoRoot: expect.any(String) });
   });
 
   test("tracks a branch", async () => {
@@ -81,7 +81,7 @@ describe("cmdTrack", () => {
     });
 
     await cmdTrack(["--branch", "feat/test"], deps);
-    expect(captured).toEqual({ branch: "feat/test" });
+    expect(captured).toEqual({ branch: "feat/test", repoRoot: expect.any(String) });
   });
 
   test("rejects missing args", async () => {
@@ -351,7 +351,7 @@ describe("formatWorkItemRow", () => {
           return cmdTrack(["1135"], deps);
         },
       );
-      expect(captured).toEqual({ number: 1135, initialPhase: "plan" });
+      expect(captured).toEqual({ number: 1135, initialPhase: "plan", repoRoot: expect.any(String) });
     });
 
     test("cmdTracked --json annotates phaseValid from manifest", async () => {

--- a/packages/command/src/commands/track.ts
+++ b/packages/command/src/commands/track.ts
@@ -55,7 +55,11 @@ export async function cmdTrack(args: string[], deps: TrackDeps = defaultDeps): P
       return deps.exit(1);
     }
     try {
-      const item = await deps.ipcCall("trackWorkItem", { branch, ...(initialPhase ? { initialPhase } : {}) });
+      const item = await deps.ipcCall("trackWorkItem", {
+        branch,
+        ...(initialPhase ? { initialPhase } : {}),
+        repoRoot: cwd,
+      });
       console.error(`Tracking branch ${branch} (${item.id})`);
     } catch (err) {
       printError(`Failed to track branch: ${err instanceof Error ? err.message : String(err)}`);
@@ -71,7 +75,11 @@ export async function cmdTrack(args: string[], deps: TrackDeps = defaultDeps): P
   }
 
   try {
-    const item = await deps.ipcCall("trackWorkItem", { number: num, ...(initialPhase ? { initialPhase } : {}) });
+    const item = await deps.ipcCall("trackWorkItem", {
+      number: num,
+      ...(initialPhase ? { initialPhase } : {}),
+      repoRoot: cwd,
+    });
     console.error(`Tracking #${num} (${item.id})`);
   } catch (err) {
     printError(`Failed to track #${num}: ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -438,6 +438,8 @@ export const TrackWorkItemParamsSchema = z
     branch: z.string().optional(),
     /** Optional starting phase (e.g. from manifest `initial:`). Default: "impl". */
     initialPhase: z.string().optional(),
+    /** Absolute path to the repo root; used server-side to locate a .mcx manifest for initialPhase validation. */
+    repoRoot: z.string().optional(),
   })
   .refine((p) => p.number != null || p.branch != null, {
     message: "Either number or branch is required",

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -2090,4 +2090,77 @@ describe("IpcServer HTTP transport", () => {
     expect(calls[0].cwd).toBe("/caller/repo");
     expect(calls[0].chain).toEqual(["parent"]);
   });
+
+  describe("trackWorkItem initialPhase server-side validation", () => {
+    const fakeManifest = {
+      version: 1,
+      phases: { impl: { source: "./impl.ts" }, review: { source: "./review.ts" } },
+    };
+
+    function startWithLoadManifest(loadManifest: (repoRoot: string) => unknown): void {
+      socketPath = tmpSocket();
+      server = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, {
+        ...opts(),
+        loadManifest: loadManifest as never,
+      });
+      server.start(socketPath);
+    }
+
+    test("rejects initialPhase not declared in manifest", async () => {
+      startWithLoadManifest(() => fakeManifest);
+
+      const res = await rpc("/rpc", {
+        id: "ti1",
+        method: "trackWorkItem",
+        params: { number: 42, initialPhase: "bogus", repoRoot: "/repo" },
+      });
+      const json = (await res.json()) as IpcResponse;
+      expect(json.error).toBeDefined();
+      expect(json.error?.message).toContain("unknown initialPhase");
+      expect(json.error?.message).toContain("bogus");
+      expect(json.error?.message).toContain("impl");
+    });
+
+    test("accepts initialPhase declared in manifest", async () => {
+      startWithLoadManifest(() => fakeManifest);
+
+      const res = await rpc("/rpc", {
+        id: "ti2",
+        method: "trackWorkItem",
+        params: { number: 43, initialPhase: "review", repoRoot: "/repo" },
+      });
+      const json = (await res.json()) as IpcResponse;
+      expect(json.error).toBeUndefined();
+      const item = json.result as { phase: string };
+      expect(item.phase).toBe("review");
+    });
+
+    test("accepts any initialPhase when repoRoot is absent (legacy)", async () => {
+      startWithLoadManifest(() => fakeManifest);
+
+      const res = await rpc("/rpc", {
+        id: "ti3",
+        method: "trackWorkItem",
+        params: { number: 44, initialPhase: "anything-goes" },
+      });
+      const json = (await res.json()) as IpcResponse;
+      expect(json.error).toBeUndefined();
+      const item = json.result as { phase: string };
+      expect(item.phase).toBe("anything-goes");
+    });
+
+    test("accepts any initialPhase when manifest is not found at repoRoot", async () => {
+      startWithLoadManifest(() => null);
+
+      const res = await rpc("/rpc", {
+        id: "ti4",
+        method: "trackWorkItem",
+        params: { number: 45, initialPhase: "free-form", repoRoot: "/no-manifest-here" },
+      });
+      const json = (await res.json()) as IpcResponse;
+      expect(json.error).toBeUndefined();
+      const item = json.result as { phase: string };
+      expect(item.phase).toBe("free-form");
+    });
+  });
 });

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -2093,11 +2093,12 @@ describe("IpcServer HTTP transport", () => {
 
   describe("trackWorkItem initialPhase server-side validation", () => {
     const fakeManifest = {
-      version: 1,
+      version: 1 as const,
+      initial: "impl",
       phases: { impl: { source: "./impl.ts" }, review: { source: "./review.ts" } },
     };
 
-    function startWithLoadManifest(loadManifest: (repoRoot: string) => unknown): void {
+    function startWithLoadManifest(loadManifest: (repoRoot: string) => typeof fakeManifest | null): void {
       socketPath = tmpSocket();
       server = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, {
         ...opts(),
@@ -2116,6 +2117,7 @@ describe("IpcServer HTTP transport", () => {
       });
       const json = (await res.json()) as IpcResponse;
       expect(json.error).toBeDefined();
+      expect(json.error?.code).toBe(IPC_ERROR.INVALID_PARAMS);
       expect(json.error?.message).toContain("unknown initialPhase");
       expect(json.error?.message).toContain("bogus");
       expect(json.error?.message).toContain("impl");

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -1117,7 +1117,10 @@ export class IpcServer {
         if (manifest) {
           const declared = Object.keys(manifest.phases);
           if (!declared.includes(initialPhase)) {
-            throw new Error(`unknown initialPhase "${initialPhase}". declared phases: ${declared.join(", ")}.`);
+            throw Object.assign(
+              new Error(`unknown initialPhase "${initialPhase}". declared phases: ${declared.join(", ")}.`),
+              { code: IPC_ERROR.INVALID_PARAMS },
+            );
           }
         }
       }

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -13,6 +13,7 @@ import type {
   IpcResponse,
   LiveSpan,
   Logger,
+  Manifest,
   ResolvedConfig,
   ServeInstanceInfo,
   ServerAuthStatus,
@@ -66,6 +67,7 @@ import {
   consoleLogger,
   hardenFile,
   isDefineAlias,
+  loadManifest,
   options,
   safeAliasPath,
   startSpan,
@@ -110,6 +112,7 @@ export class IpcServer {
   private getWsPortInfo: (() => { actual: number | null; expected: number }) | null = null;
   private getQuotaStatus: (() => IpcMethodResult["quotaStatus"]) | null = null;
   private resolveIssuePr: ((number: number) => Promise<{ prNumber: number | null }>) | null = null;
+  private loadManifestFn: ((repoRoot: string) => Manifest | null) | null = null;
   private aliasServer: AliasServer | null = null;
   private daemonId: string;
   private startedAt: number;
@@ -136,6 +139,8 @@ export class IpcServer {
       getQuotaStatus?: () => IpcMethodResult["quotaStatus"];
       /** Resolve an issue/PR number to its associated PR number via GitHub API. */
       resolveIssuePr?: (number: number) => Promise<{ prNumber: number | null }>;
+      /** Load a manifest from the given repo root; injected for testability. Defaults to core loadManifest. */
+      loadManifest?: (repoRoot: string) => Manifest | null;
     },
   ) {
     this.daemonId = options.daemonId;
@@ -149,6 +154,7 @@ export class IpcServer {
     this.getWsPortInfo = options.getWsPortInfo ?? null;
     this.getQuotaStatus = options.getQuotaStatus ?? null;
     this.resolveIssuePr = options.resolveIssuePr ?? null;
+    this.loadManifestFn = options.loadManifest ?? ((r) => loadManifest(r)?.manifest ?? null);
     this.drainTimeoutMs = options.drainTimeoutMs ?? 5_000;
     this.workItemDb = new WorkItemDb(this.db.getDatabase());
     this.registerHandlers();
@@ -1102,7 +1108,19 @@ export class IpcServer {
     // -- Work item tracking --
 
     this.handlers.set("trackWorkItem", async (params, _ctx) => {
-      const { number, branch, initialPhase } = TrackWorkItemParamsSchema.parse(params);
+      const { number, branch, initialPhase, repoRoot } = TrackWorkItemParamsSchema.parse(params);
+
+      // Validate initialPhase server-side when a manifest is available (#1351).
+      // When no manifest is present (repoRoot absent or manifest missing), accept any string.
+      if (initialPhase && repoRoot && this.loadManifestFn) {
+        const manifest = this.loadManifestFn(repoRoot);
+        if (manifest) {
+          const declared = Object.keys(manifest.phases);
+          if (!declared.includes(initialPhase)) {
+            throw new Error(`unknown initialPhase "${initialPhase}". declared phases: ${declared.join(", ")}.`);
+          }
+        }
+      }
 
       // Check if already tracked
       if (number) {
@@ -1121,8 +1139,6 @@ export class IpcServer {
 
       // Create the item immediately (non-blocking) so the caller isn't waiting on GitHub
       const id = number ? `#${number}` : `branch:${branch}`;
-      // initialPhase comes from the caller's manifest (#1287), so it's already identifier-validated.
-      // Cast to WorkItemPhase to satisfy the narrower type; DB stores arbitrary phase strings.
       const item = this.workItemDb.createWorkItem({
         id,
         issueNumber: number ?? null,


### PR DESCRIPTION
## Summary
- Added `repoRoot` to `TrackWorkItemParamsSchema` so callers can supply the repo path for manifest lookup
- `trackWorkItem` IPC handler now validates `initialPhase` against declared phases in the `.mcx` manifest when `repoRoot` is provided and a manifest exists; rejects unknown phases with an actionable error
- `mcx track` now always passes `repoRoot: cwd` alongside `initialPhase` so the server can validate

## Test plan
- [x] `ipc-server.spec.ts`: 4 new tests — rejects undeclared phase, accepts declared phase, accepts any phase without `repoRoot` (legacy), accepts any phase when manifest not found
- [x] `track.spec.ts`: updated 3 existing tests to include `repoRoot` in captured params
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — 5217 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)