### PR TITLE
fix(phases): impl.ts reads model from sprint plan (fixes #1437)

### DIFF
--- a/.claude/phases/impl.ts
+++ b/.claude/phases/impl.ts
@@ -9,11 +9,19 @@
  * The handler is idempotent on re-entry: if `session_id` is already set in
  * state, it returns the existing session plus `action: "in-flight"`.
  *
+ * Model resolution order (first match wins):
+ *   1. `input.model` — explicit override from the orchestrator
+ *   2. `ctx.state.get("model")` — pre-populated by a prior call or mcx track
+ *   3. Sprint plan table — reads the latest `.claude/sprints/sprint-*.md` and
+ *      locates the Model column for this issue number (fixes #1437)
+ *   4. `pickModel(labels)` — label-based heuristic fallback
+ *
  * State writes (this handler): model, provider, labels, session_id sentinel.
  * Orchestrator responsibility: replace session_id "pending:*" with the real
  * session ID after spawn; write worktree_path once the worktree is known;
  * delete session_id on spawn failure so next entry re-spawns cleanly.
  */
+import { findModelInSprintPlan } from "@mcp-cli/core";
 import { defineAlias, z } from "mcp-cli";
 
 type Provider = "claude" | "copilot" | "gemini" | `acp:${string}`;
@@ -46,6 +54,7 @@ defineAlias({
   input: z.object({
     provider: ProviderSchema.default("claude"),
     labels: z.array(z.string()).default([]),
+    model: z.enum(["opus", "sonnet"]).optional(),
   }),
   output: z.object({
     action: z.enum(["spawn", "in-flight"]),
@@ -77,7 +86,20 @@ defineAlias({
       };
     }
 
-    const model = pickModel(input.labels);
+    // Resolve model: explicit input → pre-set state → sprint plan → label heuristic
+    let model: "opus" | "sonnet";
+    if (input.model) {
+      model = input.model;
+    } else {
+      const stateModel = await ctx.state.get<string>("model");
+      if (stateModel === "opus" || stateModel === "sonnet") {
+        model = stateModel;
+      } else {
+        const planModel = findModelInSprintPlan(work.issueNumber, process.cwd());
+        model = planModel ?? pickModel(input.labels);
+      }
+    }
+
     const provider = input.provider;
     const allowTools = ["Read", "Glob", "Grep", "Write", "Edit", "Bash", "ExitPlanMode", "EnterPlanMode"];
     const prompt = `/implement ${work.issueNumber}`;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,3 +39,4 @@ export * from "./telemetry";
 export * from "./phase-source";
 export * from "./mcp-proxy";
 export * from "./bun-version";
+export * from "./sprint-plan";

--- a/packages/core/src/sprint-plan.spec.ts
+++ b/packages/core/src/sprint-plan.spec.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { findModelInSprintPlan, parseModelFromSprintTable } from "./sprint-plan";
+
+const SPRINT_TABLE = `# Sprint 38
+
+## Issues
+
+| # | Title | Scrutiny | Batch | Model | Category |
+|---|-------|----------|-------|-------|----------|
+| **1441** | feat: worktree containment | high | 1 | opus | anchor |
+| **1437** | fix(phases): impl model | low | 2 | sonnet | DX |
+| **1426** | bug: session balloons | medium | 2 | opus | containment |
+| **1385** | fix: truncate forceMessage | low | 2 | sonnet | polish |
+`;
+
+describe("parseModelFromSprintTable", () => {
+  test("returns model for matching issue (bold formatting)", () => {
+    expect(parseModelFromSprintTable(SPRINT_TABLE, 1437)).toBe("sonnet");
+  });
+
+  test("returns opus for opus-assigned issue", () => {
+    expect(parseModelFromSprintTable(SPRINT_TABLE, 1441)).toBe("opus");
+  });
+
+  test("returns null when issue not in table", () => {
+    expect(parseModelFromSprintTable(SPRINT_TABLE, 9999)).toBeNull();
+  });
+
+  test("returns null for empty string", () => {
+    expect(parseModelFromSprintTable("", 1437)).toBeNull();
+  });
+
+  test("returns null when no Model column", () => {
+    const noModel = "| # | Title | Scrutiny |\n|---|-------|----------|\n| 1437 | foo | low |\n";
+    expect(parseModelFromSprintTable(noModel, 1437)).toBeNull();
+  });
+
+  test("handles plain (non-bold) issue numbers", () => {
+    const plain = "| # | Title | Model |\n|---|-------|-------|\n| 1437 | foo | sonnet |\n";
+    expect(parseModelFromSprintTable(plain, 1437)).toBe("sonnet");
+  });
+
+  test("is case-insensitive for model value", () => {
+    const upper = "| # | Title | Model |\n|---|-------|-------|\n| 1437 | foo | Sonnet |\n";
+    expect(parseModelFromSprintTable(upper, 1437)).toBe("sonnet");
+  });
+
+  test("returns null for unknown model values", () => {
+    const bad = "| # | Title | Model |\n|---|-------|-------|\n| 1437 | foo | gpt4 |\n";
+    expect(parseModelFromSprintTable(bad, 1437)).toBeNull();
+  });
+
+  test("handles multiple tables — picks correct one", () => {
+    const twoTables =
+      "## Batch 1\n\n| # | Title | Model |\n|---|-------|-------|\n| 1000 | other | opus |\n\n## Batch 2\n\n| # | Title | Model |\n|---|-------|-------|\n| 1437 | impl | sonnet |\n";
+    expect(parseModelFromSprintTable(twoTables, 1437)).toBe("sonnet");
+  });
+});
+
+describe("findModelInSprintPlan", () => {
+  let tmpDir: string;
+  let sprintDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "sprint-plan-test-"));
+    sprintDir = join(tmpDir, ".claude", "sprints");
+    mkdirSync(sprintDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("returns model from the latest sprint file", () => {
+    writeFileSync(join(sprintDir, "sprint-37.md"), SPRINT_TABLE.replace("1437", "9999"));
+    writeFileSync(join(sprintDir, "sprint-38.md"), SPRINT_TABLE);
+    expect(findModelInSprintPlan(1437, tmpDir)).toBe("sonnet");
+  });
+
+  test("falls back to an older sprint if not in latest", () => {
+    writeFileSync(join(sprintDir, "sprint-37.md"), SPRINT_TABLE);
+    writeFileSync(
+      join(sprintDir, "sprint-38.md"),
+      "| # | Title | Model |\n|---|-------|-------|\n| 9999 | other | opus |\n",
+    );
+    expect(findModelInSprintPlan(1437, tmpDir)).toBe("sonnet");
+  });
+
+  test("returns null when no sprint files exist", () => {
+    expect(findModelInSprintPlan(1437, tmpDir)).toBeNull();
+  });
+
+  test("returns null when sprint dir does not exist", () => {
+    expect(findModelInSprintPlan(1437, join(tmpDir, "nonexistent"))).toBeNull();
+  });
+
+  test("returns null when issue is not in any sprint", () => {
+    writeFileSync(join(sprintDir, "sprint-38.md"), SPRINT_TABLE);
+    expect(findModelInSprintPlan(9999, tmpDir)).toBeNull();
+  });
+
+  test("ignores non-sprint files in the directory", () => {
+    writeFileSync(join(sprintDir, "notes.md"), SPRINT_TABLE);
+    writeFileSync(
+      join(sprintDir, "sprint-38.md"),
+      "| # | Title | Model |\n|---|-------|-------|\n| 1437 | foo | opus |\n",
+    );
+    expect(findModelInSprintPlan(1437, tmpDir)).toBe("opus");
+  });
+});

--- a/packages/core/src/sprint-plan.ts
+++ b/packages/core/src/sprint-plan.ts
@@ -1,0 +1,100 @@
+/**
+ * Utilities for reading the sprint plan markdown file.
+ *
+ * Sprint plans live at `.claude/sprints/sprint-<N>.md` and contain a markdown
+ * table with a `#` column (issue number) and a `Model` column (opus/sonnet).
+ * The impl phase uses these to pick the right model per issue (#1437).
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Parse the Model column from a sprint plan markdown table for the given issue.
+ *
+ * Handles issue numbers formatted as plain "1437" or bold "**1437**".
+ * Multiple tables per file are supported — each non-table line between
+ * table blocks resets column state so the next table header is picked up.
+ *
+ * Returns "opus" | "sonnet" | null.
+ */
+export function parseModelFromSprintTable(text: string, issueNumber: number): "opus" | "sonnet" | null {
+  let modelColIdx = -1;
+  let issueColIdx = -1;
+
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("|")) {
+      // Exiting a table block — reset so the next table header is picked up.
+      if (modelColIdx >= 0) {
+        modelColIdx = -1;
+        issueColIdx = -1;
+      }
+      continue;
+    }
+
+    const cols = trimmed
+      .split("|")
+      .slice(1, -1)
+      .map((c) => c.trim());
+
+    // Separator row (e.g. "|---|-------|")
+    if (cols.every((c) => /^[-: ]+$/.test(c))) continue;
+
+    if (modelColIdx === -1) {
+      // Header row — locate the # and Model columns
+      const mIdx = cols.findIndex((c) => c.toLowerCase() === "model");
+      const iIdx = cols.findIndex((c) => c === "#");
+      if (mIdx >= 0 && iIdx >= 0) {
+        modelColIdx = mIdx;
+        issueColIdx = iIdx;
+      }
+      continue;
+    }
+
+    // Data row — match the target issue number
+    const issueCell = cols[issueColIdx] ?? "";
+    const numMatch = issueCell.match(/\d+/);
+    if (!numMatch || Number.parseInt(numMatch[0], 10) !== issueNumber) continue;
+
+    const modelCell = (cols[modelColIdx] ?? "").toLowerCase().trim();
+    if (modelCell === "opus" || modelCell === "sonnet") return modelCell;
+  }
+
+  return null;
+}
+
+/**
+ * Scan `.claude/sprints/sprint-*.md` files (latest sprint first) and return
+ * the model declared for the given issue number, or null if not found.
+ */
+export function findModelInSprintPlan(issueNumber: number, repoRoot: string): "opus" | "sonnet" | null {
+  const sprintDir = join(repoRoot, ".claude", "sprints");
+  let files: string[];
+  try {
+    files = readdirSync(sprintDir).filter((f) => /^sprint-\d+\.md$/.test(f));
+  } catch {
+    return null;
+  }
+  if (files.length === 0) return null;
+
+  // Sort descending so the most recent sprint is checked first.
+  files.sort((a, b) => {
+    const numA = Number.parseInt(a.match(/(\d+)/)?.[1] ?? "0", 10);
+    const numB = Number.parseInt(b.match(/(\d+)/)?.[1] ?? "0", 10);
+    return numB - numA;
+  });
+
+  for (const file of files) {
+    let text: string;
+    try {
+      text = readFileSync(join(sprintDir, file), "utf-8");
+    } catch {
+      continue;
+    }
+    const model = parseModelFromSprintTable(text, issueNumber);
+    if (model !== null) return model;
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

- Extract `parseModelFromSprintTable` + `findModelInSprintPlan` into `packages/core/src/sprint-plan.ts` so they are unit-testable
- Wire `findModelInSprintPlan` into `impl.ts` with a four-level priority chain: explicit `input.model` → `ctx.state.get("model")` → sprint plan table → `pickModel(labels)` heuristic
- Add optional `model` input to `impl.ts` schema so orchestrators can override without touching state or sprint files

## Test plan

- [x] 15 new unit tests in `packages/core/src/sprint-plan.spec.ts` covering table parsing (bold/plain issue numbers, case-insensitive model, multi-table files, unknown values) and file discovery (latest-sprint-first, fallback to older, missing dir)
- [x] Full test suite passes (5233 tests, 0 failures)
- [x] `bun typecheck` and `bun lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)