### PR TITLE
fix(alias-bundle): externalize @mcp-cli/core so phase scripts can import it

### DIFF
--- a/.mcx.lock
+++ b/.mcx.lock
@@ -11,7 +11,7 @@
     {
       "name": "impl",
       "resolvedPath": ".claude/phases/impl.ts",
-      "contentHash": "09104e973e4b36364a1d2618b8b76342d4d4a6c69f3d50d8de341d27486869c5",
+      "contentHash": "b1209bf621da7a8ff5ea923b3ae4185ad640b2a888a498d87b97e6aa60e7ace4",
       "schemaHash": "ed4e8c293093075a364653d8c077f44d68157174b7b276fbdfafb9f31fc1207d"
     },
     {

--- a/packages/core/src/alias-bundle.spec.ts
+++ b/packages/core/src/alias-bundle.spec.ts
@@ -152,6 +152,69 @@ describe("stripModuleSyntax", () => {
     const result = stripMcpCliImport(input);
     expect(result.trim()).toBe("");
   });
+
+  describe("@mcp-cli/core rewrite", () => {
+    test("rewrites named ESM import", () => {
+      const input = `import { findModelInSprintPlan } from "@mcp-cli/core";\nconst m = findModelInSprintPlan(1, ".");`;
+      const result = stripModuleSyntax(input);
+      expect(result).toContain("const { findModelInSprintPlan } = __mcp_core__;");
+      expect(result).not.toContain("@mcp-cli/core");
+    });
+
+    test("rewrites multiple named imports", () => {
+      const input = `import { foo, bar, baz } from "@mcp-cli/core";\nfoo();`;
+      const result = stripModuleSyntax(input);
+      expect(result).toContain("const { foo, bar, baz } = __mcp_core__;");
+    });
+
+    test("rewrites multi-line named imports (Bun.build output)", () => {
+      const input = `import {\n  findModelInSprintPlan,\n  parseModelFromSprintTable\n} from "@mcp-cli/core";\nfoo();`;
+      const result = stripModuleSyntax(input);
+      expect(result).toMatch(/const \{\s*findModelInSprintPlan, parseModelFromSprintTable\s*\} = __mcp_core__;/);
+    });
+
+    test("rewrites aliased imports (X as Y)", () => {
+      const input = `import { findModelInSprintPlan as find } from "@mcp-cli/core";\nfind(1, ".");`;
+      const result = stripModuleSyntax(input);
+      expect(result).toContain("const { findModelInSprintPlan: find } = __mcp_core__;");
+    });
+
+    test("rewrites namespace import", () => {
+      const input = `import * as core from "@mcp-cli/core";\ncore.foo();`;
+      const result = stripModuleSyntax(input);
+      expect(result).toContain("const core = __mcp_core__;");
+    });
+
+    test("rewrites default import", () => {
+      const input = `import core from "@mcp-cli/core";\ncore.foo();`;
+      const result = stripModuleSyntax(input);
+      expect(result).toContain("const core = __mcp_core__.default ?? __mcp_core__;");
+    });
+
+    test("drops side-effect import", () => {
+      const input = `import "@mcp-cli/core";\nvar x = 1;`;
+      expect(stripModuleSyntax(input).trim()).toBe("var x = 1;");
+    });
+
+    test("rewrites CJS named require", () => {
+      const input = `var { foo } = require("@mcp-cli/core");\nfoo();`;
+      const result = stripModuleSyntax(input);
+      expect(result).toContain("var { foo } = __mcp_core__;");
+    });
+
+    test("rewrites CJS namespace require", () => {
+      const input = `const core = require("@mcp-cli/core");\ncore.foo();`;
+      const result = stripModuleSyntax(input);
+      expect(result).toContain("const core = __mcp_core__;");
+    });
+
+    test("preserves mcp-cli stripping alongside core rewrite", () => {
+      const input = `import { defineAlias } from "mcp-cli";\nimport { findModelInSprintPlan } from "@mcp-cli/core";\nfoo();`;
+      const result = stripModuleSyntax(input);
+      expect(result).not.toContain('from "mcp-cli"');
+      expect(result).toContain("const { findModelInSprintPlan } = __mcp_core__;");
+    });
+  });
 });
 
 describe("bundleAlias", () => {
@@ -184,6 +247,49 @@ describe("bundleAlias", () => {
     writeFileSync(scriptPath, "this is not valid typescript {{{");
 
     await expect(bundleAlias(scriptPath)).rejects.toThrow();
+  });
+
+  test("externalizes @mcp-cli/core (end-to-end)", async () => {
+    const dir = makeTmpDir();
+    const scriptPath = join(dir, "core-import.ts");
+    writeFileSync(
+      scriptPath,
+      [
+        'import { defineAlias, z } from "mcp-cli";',
+        'import { findModelInSprintPlan } from "@mcp-cli/core";',
+        "defineAlias({",
+        '  name: "core-import-test",',
+        "  input: z.object({}),",
+        "  fn: () => ({ hasFn: typeof findModelInSprintPlan === 'function' }),",
+        "});",
+      ].join("\n"),
+    );
+
+    const { js } = await bundleAlias(scriptPath);
+    // The bundled output should reference @mcp-cli/core (externalized, not inlined)
+    expect(js).toContain("@mcp-cli/core");
+    // After strip, the import is rewritten to use __mcp_core__
+    const stripped = stripModuleSyntax(js);
+    expect(stripped).toContain("__mcp_core__");
+    expect(stripped).not.toMatch(/import[^;]*from\s*["']@mcp-cli\/core["']/);
+
+    // Execute and verify the core function is reachable at runtime
+    const result = await executeAliasBundled(
+      js,
+      {},
+      {
+        mcp: stubProxy,
+        args: {},
+        file: async () => "",
+        json: async () => null,
+        cache: async (_k, p) => p(),
+        state: stubState,
+        globalState: stubState,
+        workItem: null,
+      },
+      true,
+    );
+    expect(result).toEqual({ hasFn: true });
   });
 });
 

--- a/packages/core/src/alias-bundle.ts
+++ b/packages/core/src/alias-bundle.ts
@@ -56,7 +56,11 @@ export async function bundleAlias(sourcePath: string): Promise<BundleResult> {
 
   const result = await Bun.build({
     entrypoints: [sourcePath],
-    external: ["mcp-cli"],
+    // "mcp-cli" is the virtual alias-sdk module (injected at eval time).
+    // "@mcp-cli/core" is this package — externalizing lets phase scripts
+    // import core utilities (e.g. findModelInSprintPlan) and have them
+    // resolved at eval time rather than bundled into the script.
+    external: ["mcp-cli", "@mcp-cli/core"],
     target: "bun",
   });
 
@@ -83,29 +87,57 @@ export async function computeSourceHash(sourcePath: string): Promise<string> {
 /**
  * Strip module syntax from Bun.build output so it can run inside AsyncFunction.
  *
- * Removes:
- * 1. "mcp-cli" imports (ESM and CJS) — dependencies are injected at eval time
- * 2. export blocks (`export { ... };` and `export default ...`) — Bun.build adds
- *    these for the module's default export, but AsyncFunction bodies aren't modules
- * 3. import.meta references — replaced with a plain object stub
+ * Handles:
+ * 1. "mcp-cli" imports (ESM and CJS) — stripped; deps injected at eval time
+ * 2. "@mcp-cli/core" imports — rewritten to destructure from `__mcp_core__`,
+ *    which is the live core module passed into the AsyncFunction at eval time
+ * 3. export blocks (`export { ... };` and `export default ...`) — Bun.build
+ *    emits these; AsyncFunction bodies aren't modules, so they must go
+ * 4. import.meta — replaced with a plain object stub
  */
 export function stripModuleSyntax(bundledJs: string): string {
   // ESM: import { ... } from "mcp-cli";  or  import ... from "mcp-cli";
-  // Uses [^;]*? to handle multi-line imports from Bun.build (e.g. import {\n  defineAlias,\n  z\n} from "mcp-cli";)
-  const esmPattern = /^import\b[^;]*?from\s+["']mcp-cli["'];?[ \t]*$/gms;
-  // Side-effect import: import "mcp-cli";
-  const esmSideEffectPattern = /^import\s+["']mcp-cli["'];?[ \t]*$/gm;
-  // CJS: var/const/let { ... } = require("mcp-cli");
-  const cjsPattern = /^(?:var|const|let)\s+.*=\s*require\(["']mcp-cli["']\);?\s*$/gm;
-  // export { ... };  (possibly multi-line, as Bun.build emits for default exports)
+  const mcpCliEsm = /^import\b[^;]*?from\s+["']mcp-cli["'];?[ \t]*$/gms;
+  const mcpCliEsmSideEffect = /^import\s+["']mcp-cli["'];?[ \t]*$/gm;
+  const mcpCliCjs = /^(?:var|const|let)\s+.*=\s*require\(["']mcp-cli["']\);?\s*$/gm;
+
+  // @mcp-cli/core: rewrite (don't strip) so named imports resolve at eval.
+  // import { X, Y } from "@mcp-cli/core"  →  const { X, Y } = __mcp_core__;
+  // Aliased specifiers ({ X as Y }) are converted to JS destructure ({ X: Y }).
+  const coreEsmNamed = /^import\s*(\{[^}]*\})\s*from\s*["']@mcp-cli\/core["'];?[ \t]*$/gms;
+  // import * as core from "@mcp-cli/core"  →  const core = __mcp_core__;
+  const coreEsmNamespace = /^import\s*\*\s*as\s*(\w+)\s*from\s*["']@mcp-cli\/core["'];?[ \t]*$/gms;
+  // import core from "@mcp-cli/core"  →  const core = __mcp_core__.default ?? __mcp_core__;
+  const coreEsmDefault = /^import\s+(\w+)\s+from\s*["']@mcp-cli\/core["'];?[ \t]*$/gms;
+  // Side-effect import: import "@mcp-cli/core";  →  drop
+  const coreEsmSideEffect = /^import\s+["']@mcp-cli\/core["'];?[ \t]*$/gm;
+  // CJS: var/const/let <binding> = require("@mcp-cli/core");
+  const coreCjs = /^(var|const|let)\s+(\{[^}]*\}|\w+)\s*=\s*require\(["']@mcp-cli\/core["']\);?[ \t]*$/gm;
+
   const exportBlockPattern = /^export\s*\{[^}]*\};?[ \t]*$/gms;
-  // export default <expr>; — dotall so it matches multi-line (e.g. export default defineAlias({\n...\n});)
   const exportDefaultPattern = /^export\s+default\b[^;]*;[ \t]*$/gms;
 
+  const rewriteCoreNamed = (_m: string, specifiers: string): string => {
+    // Convert { X as Y, Z } → { X: Y, Z } for JS destructure syntax.
+    const inner = specifiers
+      .slice(1, -1)
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+      .map((s) => s.replace(/\s+as\s+/, ": "))
+      .join(", ");
+    return `const { ${inner} } = __mcp_core__;`;
+  };
+
   return bundledJs
-    .replace(esmPattern, "")
-    .replace(esmSideEffectPattern, "")
-    .replace(cjsPattern, "")
+    .replace(mcpCliEsm, "")
+    .replace(mcpCliEsmSideEffect, "")
+    .replace(mcpCliCjs, "")
+    .replace(coreEsmNamed, rewriteCoreNamed)
+    .replace(coreEsmNamespace, "const $1 = __mcp_core__;")
+    .replace(coreEsmDefault, "const $1 = __mcp_core__.default ?? __mcp_core__;")
+    .replace(coreEsmSideEffect, "")
+    .replace(coreCjs, "$1 $2 = __mcp_core__;")
     .replace(exportBlockPattern, "")
     .replace(exportDefaultPattern, "")
     .replace(/\bimport\.meta\b/g, "({})");
@@ -132,6 +164,12 @@ async function evalBundledJs(
 ): Promise<AliasDefinition | null> {
   const stripped = stripModuleSyntax(bundledJs);
 
+  // Lazy-load the @mcp-cli/core barrel at eval time. alias-bundle.ts is part
+  // of core and re-exported from ./index, so static `import * as` would
+  // self-cycle; dynamic import defers resolution until all sibling modules
+  // are initialized.
+  const coreBarrel = await import("./index");
+
   let captured: AliasDefinition | null = null;
 
   const injected = {
@@ -151,18 +189,18 @@ async function evalBundledJs(
   };
 
   const code = `const { defineAlias, z, mcp, args, file, json, parsePythonRepr } = __mcp_inject__;\n${stripped}`;
-  const fn = new AsyncFunction("__mcp_inject__", code);
+  const fn = new AsyncFunction("__mcp_inject__", "__mcp_core__", code);
 
   if (timeoutMs !== undefined) {
     let timer: ReturnType<typeof setTimeout> | undefined;
     await Promise.race([
-      fn(injected),
+      fn(injected, coreBarrel),
       new Promise<never>((_, reject) => {
         timer = setTimeout(() => reject(new Error("extractMetadata timed out")), timeoutMs);
       }),
     ]).finally(() => clearTimeout(timer));
   } else {
-    await fn(injected);
+    await fn(injected, coreBarrel);
   }
 
   return captured;


### PR DESCRIPTION
## Summary
- PR #1487 added `import { findModelInSprintPlan } from "@mcp-cli/core"` in `.claude/phases/impl.ts`, but the alias bundler only externalized `"mcp-cli"` — so `mcx phase install` failed with `Bundle failed` and `/sprint 39` couldn't launch.
- Extends the bundler to treat `@mcp-cli/core` as external: imports are rewritten into destructures from an injected `__mcp_core__` reference (lazy-imported via the `./index` barrel at eval time to dodge the circular-load with alias-bundle.ts itself).
- Covers named / namespace / default / side-effect / CJS import shapes plus the `{ X as Y }` alias form. 10 new unit tests + 1 end-to-end test (bundle → strip → execute a script that calls a real `@mcp-cli/core` export).
- Also syncs `.mcx.lock` — impl's contentHash was stale because prior installs failed.

## Why this happened
The AsyncFunction body used to run bundled alias scripts can't contain ES `import` statements and has no `require` available. Prior code only handled the virtual `"mcp-cli"` module; any other external surfaced as a raw `import` and parse-errored. `@mcp-cli/core` can't self-import statically (alias-bundle.ts is re-exported from `./index`), hence the `await import("./index")` deferral.

## Test plan
- [x] `bun test packages/core/src/alias-bundle.spec.ts` — 49 pass
- [x] `bun test packages/core/src/alias-bundle.spec.ts packages/daemon/src/alias-executor.spec.ts` — 57 pass
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun run build && mcx shutdown && mcx status && mcx phase install` — all 7 phases install; impl status `ok`
- [ ] CI green on this PR before `/sprint 39` resumes

🤖 Generated with [Claude Code](https://claude.com/claude-code)