### PR TITLE
fix(containment): resolve relative paths against session cwd, not daemon cwd (fixes #1480)

### DIFF
--- a/packages/daemon/src/claude-session/containment.spec.ts
+++ b/packages/daemon/src/claude-session/containment.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { resolve } from "node:path";
 import { ContainmentGuard } from "./containment";
 
 const WORKTREE = "/Users/test/repo/.claude/worktrees/my-worktree";
@@ -508,10 +509,9 @@ describe("ContainmentGuard — git clone and worktree add", () => {
 describe("ContainmentGuard — relative path resolution", () => {
   test("relative traversal in Write resolves against worktree root, not daemon cwd", () => {
     const g = guard();
-    // ../../.. from WORKTREE lands at /Users, which is outside the worktree
     const r = g.evaluate("Write", { file_path: "../../../etc/passwd" });
     expect(r.action).toBe("deny");
-    expect(r.reason).toContain("/etc/passwd");
+    expect(r.reason).toContain(resolve(WORKTREE, "../../../etc/passwd"));
   });
 
   test("relative path inside worktree resolves correctly", () => {
@@ -525,7 +525,7 @@ describe("ContainmentGuard — relative path resolution", () => {
     const g = guard();
     const r = g.evaluate("Read", { file_path: "../../../../etc/hosts" });
     expect(r.action).toBe("warn");
-    expect(r.reason).toContain("/etc/hosts");
+    expect(r.reason).toContain(resolve(WORKTREE, "../../../../etc/hosts"));
   });
 
   test("relative traversal in Edit resolves against worktree root", () => {

--- a/packages/daemon/src/claude-session/containment.spec.ts
+++ b/packages/daemon/src/claude-session/containment.spec.ts
@@ -502,3 +502,42 @@ describe("ContainmentGuard — git clone and worktree add", () => {
     expect(r.action).toBe("deny");
   });
 });
+
+// ── Relative path resolution — uses session cwd, not daemon cwd ──
+
+describe("ContainmentGuard — relative path resolution", () => {
+  test("relative traversal in Write resolves against worktree root, not daemon cwd", () => {
+    const g = guard();
+    // ../../.. from WORKTREE lands at /Users, which is outside the worktree
+    const r = g.evaluate("Write", { file_path: "../../../etc/passwd" });
+    expect(r.action).toBe("deny");
+    expect(r.reason).toContain("/etc/passwd");
+  });
+
+  test("relative path inside worktree resolves correctly", () => {
+    const g = guard();
+    // ./src/main.ts resolves to WORKTREE/src/main.ts — allowed
+    const r = g.evaluate("Write", { file_path: "./src/main.ts" });
+    expect(r.action).toBe("allow");
+  });
+
+  test("relative traversal in Read resolves against worktree root", () => {
+    const g = guard();
+    const r = g.evaluate("Read", { file_path: "../../../../etc/hosts" });
+    expect(r.action).toBe("warn");
+    expect(r.reason).toContain("/etc/hosts");
+  });
+
+  test("relative traversal in Edit resolves against worktree root", () => {
+    const g = guard();
+    const r = g.evaluate("Edit", { file_path: "../../evil.ts", old_string: "a", new_string: "b" });
+    expect(r.action).toBe("deny");
+  });
+
+  test("relative path to /tmp resolves correctly and is allowed for writes", () => {
+    // A relative path that happens to land in /tmp after resolution is allowed
+    const g = new ContainmentGuard("/tmp/worktree");
+    const r = g.evaluate("Write", { file_path: "./output.txt" });
+    expect(r.action).toBe("allow");
+  });
+});

--- a/packages/daemon/src/claude-session/containment.ts
+++ b/packages/daemon/src/claude-session/containment.ts
@@ -157,7 +157,7 @@ function extractFilePath(toolName: string, input: Record<string, unknown>): stri
 }
 
 function isPathOutside(filePath: string, worktreeRoot: string): boolean {
-  const resolved = resolve(filePath);
+  const resolved = resolve(worktreeRoot, filePath);
   return !resolved.startsWith(`${worktreeRoot}/`) && resolved !== worktreeRoot;
 }
 
@@ -165,8 +165,8 @@ function isPathOutside(filePath: string, worktreeRoot: string): boolean {
 
 const ALLOWED_EXTERNAL_PREFIXES = ["/tmp", "/var/tmp", "/private/tmp"];
 
-function isAllowedExternalPath(filePath: string): boolean {
-  const resolved = resolve(filePath);
+function isAllowedExternalPath(filePath: string, sessionCwd: string): boolean {
+  const resolved = resolve(sessionCwd, filePath);
   return ALLOWED_EXTERNAL_PREFIXES.some((p) => resolved.startsWith(`${p}/`) || resolved === p);
 }
 
@@ -240,7 +240,7 @@ export class ContainmentGuard {
     // Check shell file writes (redirects, cp, mv, tee, ln, etc.)
     const writeTargets = extractBashWriteTargets(command);
     for (const target of writeTargets) {
-      if (isAllowedExternalPath(target)) continue;
+      if (isAllowedExternalPath(target, this.worktreeRoot)) continue;
       if (isPathOutside(target, this.worktreeRoot)) {
         return this.evaluateFileAccess("Bash", target);
       }
@@ -250,7 +250,7 @@ export class ContainmentGuard {
   }
 
   private evaluateFileAccess(toolName: string, filePath: string): ContainmentResult {
-    const resolved = resolve(filePath);
+    const resolved = resolve(this.worktreeRoot, filePath);
 
     // Read-class tools: warn only, no strike
     if (toolName === "Read" || toolName === "Glob" || toolName === "Grep") {
@@ -264,7 +264,7 @@ export class ContainmentGuard {
 
     // Write/Edit: strike-counted gray zone
     // Allow /tmp writes without penalty
-    if (isAllowedExternalPath(filePath)) {
+    if (isAllowedExternalPath(filePath, this.worktreeRoot)) {
       return { action: "allow", reason: "", strikes: this._strikes };
     }
 

--- a/packages/daemon/src/claude-session/containment.ts
+++ b/packages/daemon/src/claude-session/containment.ts
@@ -165,8 +165,8 @@ function isPathOutside(filePath: string, worktreeRoot: string): boolean {
 
 const ALLOWED_EXTERNAL_PREFIXES = ["/tmp", "/var/tmp", "/private/tmp"];
 
-function isAllowedExternalPath(filePath: string, sessionCwd: string): boolean {
-  const resolved = resolve(sessionCwd, filePath);
+function isAllowedExternalPath(filePath: string, baseDir: string): boolean {
+  const resolved = resolve(baseDir, filePath);
   return ALLOWED_EXTERNAL_PREFIXES.some((p) => resolved.startsWith(`${p}/`) || resolved === p);
 }
 


### PR DESCRIPTION
## Summary
- `isPathOutside` and `isAllowedExternalPath` were calling `resolve(filePath)` which resolves relative paths against the daemon's `process.cwd()`, not the session's working directory
- Fixed by using `resolve(worktreeRoot, filePath)` so relative traversals like `../../../etc/passwd` are evaluated against the session's worktree root
- Also fixed `evaluateFileAccess` which used the same broken `resolve(filePath)` in error message construction

## Test plan
- Added 5 new tests in `containment.spec.ts` under "relative path resolution" covering:
  - Relative traversal in `Write` (`../../../etc/passwd`) → deny with correct resolved path in reason
  - Relative path inside worktree (`./src/main.ts`) → allow
  - Relative traversal in `Read` (`../../../../etc/hosts`) → warn with correct resolved path
  - Relative traversal in `Edit` → deny
  - `/tmp`-based worktree with relative write → allow (tmp exception still works)
- All 72 containment tests pass; full suite (5341 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)