### PR TITLE
fix(ci): run scripts/*.spec.ts in CI (fixes #1484)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ jobs:
       - run: bun run lint:check
       - name: Phase drift guard
         run: bun run check:phase-drift
+      # scripts/*.spec.ts are excluded from pathIgnorePatterns in bunfig.toml so that
+      # `bun test` auto-discovery doesn't scan scripts/. We override that exclusion via
+      # --path-ignore-patterns so the 10 scripts specs run in CI.
+      - name: Test (scripts)
+        run: bun test --path-ignore-patterns=".claude/**,dist/**,.git-hooks/**" ./scripts/*.spec.ts
       # Split daemon tests into a separate invocation to avoid a non-deterministic
       # Bun v1.3.11 segfault that triggers when daemon worker-thread tests run in
       # the same process as all other tests. See #1004 for upstream tracking.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
       - run: bun run lint:check
       - name: Phase drift guard
         run: bun run check:phase-drift
-      # scripts/*.spec.ts are excluded from pathIgnorePatterns in bunfig.toml so that
-      # `bun test` auto-discovery doesn't scan scripts/. We override that exclusion via
-      # --path-ignore-patterns so the 10 scripts specs run in CI.
+      # scripts/** is ignored by default via pathIgnorePatterns in bunfig.toml so that
+      # `bun test` auto-discovery doesn't scan scripts/. This step overrides that
+      # ignore list via --path-ignore-patterns so the 10 scripts specs run in CI.
       - name: Test (scripts)
         run: bun test --path-ignore-patterns=".claude/**,dist/**,.git-hooks/**" ./scripts/*.spec.ts
       # Split daemon tests into a separate invocation to avoid a non-deterministic


### PR DESCRIPTION
## Summary
- 10 spec files in `scripts/` (168 tests) were never executed in CI because `bunfig.toml`'s `pathIgnorePatterns = ["scripts/**", ...]` blocks even explicit path arguments to `bun test`
- Adds a dedicated **Test (scripts)** CI step that uses `--path-ignore-patterns` to override the bunfig exclusion, keeping the default `bun test` auto-discovery behavior unchanged
- All 168 scripts tests pass locally in 205ms

## Test plan
- [x] `bun test --path-ignore-patterns=".claude/**,dist/**,.git-hooks/**" ./scripts/*.spec.ts` — 168 pass, 0 fail
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] Pre-commit hook passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)