### PR TITLE
feat(containment): add reset() and mcx claude send --containment-reset (closes #1482)

### DIFF
--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -988,10 +988,17 @@ async function claudeSend(args: string[], d: ClaudeDeps): Promise<void> {
   }
 
   const sessionPrefix = rest[0];
+
+  if (containmentReset && rest.length > 1) {
+    d.printError("mcx claude send --containment-reset takes no message argument");
+    d.exit(1);
+  }
+
   const message = containmentReset ? "/containment-reset" : rest.slice(1).join(" ").trim();
 
   if (!sessionPrefix || !message) {
-    d.printError("Usage: mcx claude send [--wait] [--containment-reset] <session-id> [message]");
+    d.printError("Usage: mcx claude send [--wait] <session-id> <message>");
+    d.printError("       mcx claude send --containment-reset <session-id>");
     d.exit(1);
   }
 

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -975,20 +975,23 @@ function joinSessionsToWorkItems(sessions: SessionInfo[], workItems: WorkItem[])
 
 async function claudeSend(args: string[], d: ClaudeDeps): Promise<void> {
   let wait = false;
+  let containmentReset = false;
   const rest: string[] = [];
   for (const arg of args) {
     if (arg === "--wait") {
       wait = true;
+    } else if (arg === "--containment-reset") {
+      containmentReset = true;
     } else {
       rest.push(arg);
     }
   }
 
   const sessionPrefix = rest[0];
-  const message = rest.slice(1).join(" ").trim();
+  const message = containmentReset ? "/containment-reset" : rest.slice(1).join(" ").trim();
 
   if (!sessionPrefix || !message) {
-    d.printError("Usage: mcx claude send [--wait] <session-id> <message>");
+    d.printError("Usage: mcx claude send [--wait] [--containment-reset] <session-id> [message]");
     d.exit(1);
   }
 

--- a/packages/daemon/src/claude-session/containment.spec.ts
+++ b/packages/daemon/src/claude-session/containment.spec.ts
@@ -487,6 +487,52 @@ describe("ContainmentGuard — pushd and subshell cd", () => {
   });
 });
 
+// ── Reset ──
+
+describe("ContainmentGuard — reset", () => {
+  test("reset clears strikes and allows tool calls again", () => {
+    const g = guard();
+    g.evaluate("Write", { file_path: "/Users/test/repo/a.ts" });
+    g.evaluate("Write", { file_path: "/Users/test/repo/b.ts" });
+    expect(g.strikes).toBe(2);
+
+    g.reset();
+    expect(g.strikes).toBe(0);
+    expect(g.escalated).toBe(false);
+
+    const r = g.evaluate("Write", { file_path: `${WORKTREE}/ok.ts` });
+    expect(r.action).toBe("allow");
+  });
+
+  test("reset after escalation re-enables tool calls", () => {
+    const g = guard();
+    g.evaluate("Write", { file_path: "/Users/test/repo/a.ts" });
+    g.evaluate("Write", { file_path: "/Users/test/repo/b.ts" });
+    g.evaluate("Edit", { file_path: "/Users/test/repo/c.ts" });
+    expect(g.escalated).toBe(true);
+
+    g.reset();
+    expect(g.escalated).toBe(false);
+    expect(g.strikes).toBe(0);
+
+    const r = g.evaluate("Write", { file_path: `${WORKTREE}/ok.ts` });
+    expect(r.action).toBe("allow");
+  });
+
+  test("strikes accumulate again after reset", () => {
+    const g = guard();
+    g.evaluate("Write", { file_path: "/Users/test/repo/a.ts" });
+    g.evaluate("Write", { file_path: "/Users/test/repo/b.ts" });
+    g.evaluate("Edit", { file_path: "/Users/test/repo/c.ts" });
+    g.reset();
+
+    const r = g.evaluate("Write", { file_path: "/Users/test/repo/d.ts" });
+    expect(r.action).toBe("deny");
+    expect(r.strikes).toBe(1);
+    expect(g.escalated).toBe(false);
+  });
+});
+
 // ── Adversarial: git clone and worktree add ──
 
 describe("ContainmentGuard — git clone and worktree add", () => {

--- a/packages/daemon/src/claude-session/containment.ts
+++ b/packages/daemon/src/claude-session/containment.ts
@@ -9,7 +9,8 @@ export type ContainmentAction = "allow" | "deny" | "warn";
 export type ContainmentEventType =
   | "session:containment_warning"
   | "session:containment_denied"
-  | "session:containment_escalated";
+  | "session:containment_escalated"
+  | "session:containment_reset";
 
 export interface ContainmentResult {
   action: ContainmentAction;
@@ -190,6 +191,12 @@ export class ContainmentGuard {
 
   get escalated(): boolean {
     return this._escalated;
+  }
+
+  /** Reset strikes and escalation state, allowing the session to resume. */
+  reset(): void {
+    this._strikes = 0;
+    this._escalated = false;
   }
 
   /**

--- a/packages/daemon/src/claude-session/session-state.ts
+++ b/packages/daemon/src/claude-session/session-state.ts
@@ -43,7 +43,8 @@ export type SessionEvent =
   | { type: "session:model_changed"; model: string }
   | { type: "session:containment_warning"; toolName: string; reason: string; strikes: number }
   | { type: "session:containment_denied"; toolName: string; reason: string; strikes: number }
-  | { type: "session:containment_escalated"; toolName: string; reason: string; strikes: number };
+  | { type: "session:containment_escalated"; toolName: string; reason: string; strikes: number }
+  | { type: "session:containment_reset"; reason: string; strikes: number };
 
 // ── Outbound message (string ready to send over WS) ──
 

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -1626,7 +1626,6 @@ export class ClaudeWsServer {
       case "session:containment_reset":
         this.logger.info(`[_claude] Containment reset for session ${sessionId}: ${event.reason}`);
         try {
-          session.pendingImmediate = true;
           this.resolveEventWaiters(sessionId, {
             sessionId,
             event: event.type,

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -782,6 +782,12 @@ export class ClaudeWsServer {
   sendPrompt(sessionId: string, message: string): void {
     const trimmed = message.trim();
 
+    // Intercept /containment-reset — clear strikes and escalation without restarting session
+    if (trimmed === "/containment-reset") {
+      this.resetContainment(sessionId);
+      return;
+    }
+
     // Intercept /clear — kill process and respawn for fresh context
     if (trimmed === "/clear") {
       this.clearSession(sessionId).catch((err) => {
@@ -820,6 +826,22 @@ export class ClaudeWsServer {
     const session = this.getSession(sessionId);
     const outbound = session.state.interrupt();
     this.sendToWs(session, outbound);
+  }
+
+  /** Reset containment strikes and escalation so the session can resume tool use. */
+  resetContainment(sessionId: string): void {
+    const session = this.getSession(sessionId);
+    if (!session.containment) {
+      this.logger.warn(`[_claude] resetContainment called on session ${sessionId} with no containment guard`);
+      return;
+    }
+    session.containment.reset();
+    this.logger.info(`[_claude] Containment reset for session ${sessionId}`);
+    this.handleSessionEvent(sessionId, session, {
+      type: "session:containment_reset",
+      reason: "Containment guard reset by orchestrator",
+      strikes: 0,
+    });
   }
 
   /**
@@ -1594,6 +1616,20 @@ export class ClaudeWsServer {
             sessionId,
             event: event.type,
             toolName: event.toolName,
+            result: event.reason,
+            strikes: event.strikes,
+          });
+        } catch (err) {
+          logErr("resolveEventWaiters failed", err);
+        }
+        break;
+      case "session:containment_reset":
+        this.logger.info(`[_claude] Containment reset for session ${sessionId}: ${event.reason}`);
+        try {
+          session.pendingImmediate = true;
+          this.resolveEventWaiters(sessionId, {
+            sessionId,
+            event: event.type,
             result: event.reason,
             strikes: event.strikes,
           });


### PR DESCRIPTION
## Summary
- Adds `ContainmentGuard.reset()` to clear strikes and escalation state, allowing a bricked session to resume without full teardown
- Wires reset through `ClaudeWsServer.resetContainment()` which fires a `session:containment_reset` event visible to `mcx claude wait`
- Adds `mcx claude send --containment-reset <session-id>` as the orchestrator-facing command (no message argument required)

## Test plan
- [x] `ContainmentGuard.reset()` clears strikes and escalation — new unit tests in `containment.spec.ts` cover reset from 2-strike state, escalated state, and re-accumulation after reset
- [x] `bun typecheck` — no errors
- [x] `bun lint` — no issues
- [x] `bun test` — 5339 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)