### PR TITLE
feat(phases): add installedAt field to LockedPhase for accurate per-phase install time (fixes #1343)

### DIFF
--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -160,6 +160,7 @@ describe("cmdPhase install — integration", () => {
     expect(lock.phases[0].resolvedPath).toBe("impl.ts");
     expect(lock.phases[0].contentHash).toMatch(/^[a-f0-9]{64}$/);
     expect(lock.phases[0].schemaHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(lock.phases[0].installedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
     expect(logs.some((l) => l.includes("Installed 1 phase"))).toBe(true);
   }, 15_000);
 
@@ -804,6 +805,52 @@ describe("buildPhaseShow", () => {
     const full = buildPhaseShow("implement", m.phases.implement, m, null, dir, true);
     expect(full.preview.length).toBeGreaterThan(20);
     expect(full.previewTruncated).toBe(false);
+  });
+
+  test("reads installedAt from locked phase, not lockfile mtime", () => {
+    writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);
+    writeFileSync(join(dir, "impl.ts"), simpleAlias);
+    const m = loadTestManifest(simpleManifest);
+    const ts = "2024-01-15T10:30:00.000Z";
+    const lock = parseLockfile(
+      JSON.stringify({
+        version: 1,
+        manifestHash: "a".repeat(64),
+        phases: [
+          {
+            name: "implement",
+            resolvedPath: "impl.ts",
+            contentHash: "b".repeat(64),
+            schemaHash: "",
+            installedAt: ts,
+          },
+        ],
+      }),
+    );
+    const info = buildPhaseShow("implement", m.phases.implement, m, lock, dir, false);
+    expect(info.lastInstalled).toBe(ts);
+  });
+
+  test("returns null lastInstalled when locked phase has no installedAt", () => {
+    writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);
+    writeFileSync(join(dir, "impl.ts"), simpleAlias);
+    const m = loadTestManifest(simpleManifest);
+    const lock = parseLockfile(
+      JSON.stringify({
+        version: 1,
+        manifestHash: "a".repeat(64),
+        phases: [
+          {
+            name: "implement",
+            resolvedPath: "impl.ts",
+            contentHash: "b".repeat(64),
+            schemaHash: "",
+          },
+        ],
+      }),
+    );
+    const info = buildPhaseShow("implement", m.phases.implement, m, lock, dir, false);
+    expect(info.lastInstalled).toBeNull();
   });
 });
 

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -15,7 +15,7 @@
  *   - RegressionError
  */
 
-import { existsSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { isAbsolute, join, relative, resolve as resolvePath } from "node:path";
 import {
   type AliasContext,
@@ -204,6 +204,7 @@ export async function installPhases(cwd: string, deps: PhaseInstallDeps): Promis
       resolvedPath: rel === "" ? "." : rel,
       contentHash,
       schemaHash,
+      installedAt: new Date().toISOString(),
     });
   }
 
@@ -1303,15 +1304,7 @@ export function buildPhaseShow(
   } catch {
     // unresolvable source (e.g. remote)
   }
-  let lastInstalled: string | null = null;
-  if (lock) {
-    try {
-      const st = statSync(resolvePath(cwd, LOCKFILE_NAME));
-      lastInstalled = st.mtime.toISOString();
-    } catch {
-      // ignore
-    }
-  }
+  const lastInstalled = locked?.installedAt ?? null;
   return {
     name,
     source: phase.source,

--- a/packages/core/src/manifest-lock.ts
+++ b/packages/core/src/manifest-lock.ts
@@ -24,6 +24,8 @@ export const LockedPhaseSchema = z
     contentHash: z.string().regex(/^[a-f0-9]{64}$/),
     /** sha256 of the extracted output-schema JSON, or empty string if none. */
     schemaHash: z.string().regex(/^([a-f0-9]{64}|)$/),
+    /** ISO 8601 timestamp of when this phase was last installed. Optional for backward compat. */
+    installedAt: z.string().datetime().optional(),
   })
   .strict();
 export type LockedPhase = z.infer<typeof LockedPhaseSchema>;


### PR DESCRIPTION
## Summary
- Adds `installedAt: z.string().datetime().optional()` to `LockedPhaseSchema` — optional for backward compat with existing lockfiles
- `mcx phase install` now writes `new Date().toISOString()` per-phase at install time, stored in `.mcx.lock`
- `buildPhaseShow` reads `locked.installedAt ?? null` instead of `statSync(lockfile).mtime`, eliminating false timestamps from git checkout, CI cache restore, or any phase install touching a different phase

## Test plan
- [x] Existing install test asserts `installedAt` is written with ISO 8601 format
- [x] `buildPhaseShow` test asserts it reads `installedAt` from the locked phase entry
- [x] Test confirms `lastInstalled` is `null` when locked phase has no `installedAt` (backward compat)
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — 122 phase tests pass, 675 core tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)