### PR TITLE
refactor(timeout): extract DEFAULT_TIMEOUT_MS constant to prevent magic-number drift (closes #1416)

### DIFF
--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -12,6 +12,7 @@ import { existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import type { AgentFeatures, AgentProvider, MailMessage } from "@mcp-cli/core";
 import {
+  DEFAULT_TIMEOUT_MS,
   PROMPT_IPC_TIMEOUT_MS,
   WorktreeError,
   buildHookEnv,
@@ -1008,7 +1009,7 @@ async function agentWait(
   // without waiting for the orphaned wait — daemon has its own timeout.
   let result: unknown;
   if (mailTo) {
-    const totalMs = timeout ?? 270_000;
+    const totalMs = timeout ?? DEFAULT_TIMEOUT_MS;
     const pollStart = Date.now();
     const mailPoll = pollMailUntil(d, mailTo, totalMs, pollStart);
     const winner = await Promise.race([
@@ -1581,7 +1582,7 @@ function printSpawnUsage(
     "  --model, -m <name>         Model (default: provider default)",
     "  --cwd <path>               Working directory",
     "  --wait                     Block until result",
-    "  --timeout <ms>             Max wait time (default: 270000)",
+    `  --timeout <ms>             Max wait time (default: ${DEFAULT_TIMEOUT_MS})`,
     "  --json                     Output raw JSON",
   ];
 

--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS } from "@mcp-cli/core";
 import { WORKTREE_CONFIG_FILENAME } from "@mcp-cli/core/worktree-config";
 import { _resetJqStateForTesting } from "../jq/index";
 import { ExitError } from "../test-helpers";
@@ -2066,22 +2067,22 @@ describe("parseWaitArgs", () => {
     expect(result.error).toBe("--timeout requires a value in ms");
   });
 
-  test("rejects --timeout > 299000ms (cache TTL cap)", () => {
-    const result = parseWaitArgs(["--timeout", "300000"]);
+  test("rejects --timeout > MAX_TIMEOUT_MS (cache TTL cap)", () => {
+    const result = parseWaitArgs(["--timeout", String(MAX_TIMEOUT_MS + 1)]);
     expect(result.error).toContain("exceeds 4:59 cache-safe limit");
-    expect(result.error).toContain("300000ms");
+    expect(result.error).toContain(`${MAX_TIMEOUT_MS + 1}ms`);
   });
 
-  test("accepts --timeout at cache-safe boundary (299000)", () => {
-    const result = parseWaitArgs(["--timeout", "299000"]);
+  test("accepts --timeout at cache-safe boundary (MAX_TIMEOUT_MS)", () => {
+    const result = parseWaitArgs(["--timeout", String(MAX_TIMEOUT_MS)]);
     expect(result.error).toBeUndefined();
-    expect(result.timeout).toBe(299000);
+    expect(result.timeout).toBe(MAX_TIMEOUT_MS);
   });
 
-  test("accepts recommended --timeout 270000", () => {
-    const result = parseWaitArgs(["--timeout", "270000"]);
+  test("accepts recommended --timeout DEFAULT_TIMEOUT_MS", () => {
+    const result = parseWaitArgs(["--timeout", String(DEFAULT_TIMEOUT_MS)]);
     expect(result.error).toBeUndefined();
-    expect(result.timeout).toBe(270000);
+    expect(result.timeout).toBe(DEFAULT_TIMEOUT_MS);
   });
 
   test("parses --after flag", () => {

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -9,6 +9,7 @@ import { dirname, resolve } from "node:path";
 import {
   CLAUDE_SERVER_NAME,
   DEFAULT_TIMEOUT_MS,
+  MAX_TIMEOUT_MS,
   PROMPT_IPC_TIMEOUT_MS,
   WorktreeError,
   cleanupWorktree,
@@ -1415,7 +1416,7 @@ export function parseWaitArgs(args: string[]): WaitArgs {
         timeout = Number(val);
         if (Number.isNaN(timeout)) {
           error = "--timeout must be a number";
-        } else if (timeout > 299_000) {
+        } else if (timeout > MAX_TIMEOUT_MS) {
           error = `--timeout ${timeout}ms exceeds 4:59 cache-safe limit.\nThe Claude Code prompt cache has a 5-minute TTL; waits >= 5 minutes cause the\nnext turn to re-process full context at full input-token price.\nUse --timeout ${DEFAULT_TIMEOUT_MS} (4:30) or loop with shorter waits.`;
         }
       }

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -8,6 +8,7 @@
 import { dirname, resolve } from "node:path";
 import {
   CLAUDE_SERVER_NAME,
+  DEFAULT_TIMEOUT_MS,
   PROMPT_IPC_TIMEOUT_MS,
   WorktreeError,
   cleanupWorktree,
@@ -1415,7 +1416,7 @@ export function parseWaitArgs(args: string[]): WaitArgs {
         if (Number.isNaN(timeout)) {
           error = "--timeout must be a number";
         } else if (timeout > 299_000) {
-          error = `--timeout ${timeout}ms exceeds 4:59 cache-safe limit.\nThe Claude Code prompt cache has a 5-minute TTL; waits >= 5 minutes cause the\nnext turn to re-process full context at full input-token price.\nUse --timeout 270000 (4:30) or loop with shorter waits.`;
+          error = `--timeout ${timeout}ms exceeds 4:59 cache-safe limit.\nThe Claude Code prompt cache has a 5-minute TTL; waits >= 5 minutes cause the\nnext turn to re-process full context at full input-token price.\nUse --timeout ${DEFAULT_TIMEOUT_MS} (4:30) or loop with shorter waits.`;
         }
       }
     } else if (arg === "--after") {
@@ -1566,7 +1567,7 @@ async function claudeWait(args: string[], d: ClaudeDeps): Promise<void> {
   // without waiting for the orphaned claude_wait (daemon has its own timeout).
   let result: unknown;
   if (parsed.mailTo) {
-    const totalMs = parsed.timeout ?? 270_000;
+    const totalMs = parsed.timeout ?? DEFAULT_TIMEOUT_MS;
     const pollStart = Date.now();
     const mailPoll = pollMailUntil(d, parsed.mailTo, totalMs, pollStart);
     const winner = await Promise.race([
@@ -1838,7 +1839,7 @@ Options:
   --model, -m <name>         Model: opus, sonnet, haiku, or full ID (default: opus)
   --cwd <path>               Working directory for the session
   --wait                     Block until Claude produces a result
-  --timeout <ms>             Max wait time in ms (default: 270000, only with --wait)
+  --timeout <ms>             Max wait time in ms (default: ${DEFAULT_TIMEOUT_MS}, only with --wait)
 
 Examples:
   mcx claude spawn --task "run the test suite and fix failures"
@@ -1882,7 +1883,7 @@ Spawn options:
   --resume <id>               Resume a previous session
   --allow <tools...>          Pre-approved tool patterns (default: Read Glob Grep Write Edit)
   --cwd <path>                Working directory for Claude
-  --timeout <ms>              Max wait time (default: 270000, only with --wait)
+  --timeout <ms>              Max wait time (default: ${DEFAULT_TIMEOUT_MS}, only with --wait)
 
 Resume options:
   --fresh                     Use git-context prompt instead of conversation history
@@ -1890,7 +1891,7 @@ Resume options:
   --model, -m <name>          Model to use: opus, sonnet, haiku, or full ID
   --allow <tools...>          Pre-approved tool patterns
   --wait                      Block until Claude produces a result
-  --timeout <ms>              Max wait time (default: 270000, only with --wait)
+  --timeout <ms>              Max wait time (default: ${DEFAULT_TIMEOUT_MS}, only with --wait)
 
 Send options:
   --wait                      Block until Claude produces a result
@@ -1900,7 +1901,7 @@ List/Wait options:
 
 Wait options:
   --after <seq>               Sequence cursor for race-free polling (from previous response)
-  --timeout, -t <ms>          Max wait time (default: 270000)
+  --timeout, -t <ms>          Max wait time (default: ${DEFAULT_TIMEOUT_MS})
 
 Approve/Deny options:
   --request-id, -r <id>       Specific request ID (auto-detects latest if omitted)

--- a/packages/core/src/agent-tools.ts
+++ b/packages/core/src/agent-tools.ts
@@ -10,6 +10,8 @@
  * but the definitions are generated from a single source of truth.
  */
 
+import { DEFAULT_TIMEOUT_MS } from "./constants";
+
 // ---------------------------------------------------------------------------
 // JSON Schema helpers (matches the shape MCP SDK expects)
 // ---------------------------------------------------------------------------
@@ -69,7 +71,7 @@ const sessionIdProp: JsonSchemaProperty = {
 
 const timeoutProp: JsonSchemaProperty = {
   type: "number",
-  description: "Max wait time in ms (default: 270000)",
+  description: `Max wait time in ms (default: ${DEFAULT_TIMEOUT_MS})`,
 };
 
 const limitProp: JsonSchemaProperty = {

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -227,7 +227,10 @@ export const DAEMON_DEV_SCRIPT = "packages/daemon/src/main.ts";
 /** IPC timeout for prompt-like commands (claude send/wait, codex) that may take minutes (ms) */
 export const PROMPT_IPC_TIMEOUT_MS = 330_000;
 
-/** Default wait timeout in ms. Stays below the 5-minute prompt-cache TTL (299000ms cap). */
+/** Maximum allowed wait timeout in ms. Values above this cause a prompt-cache miss on the next turn. */
+export const MAX_TIMEOUT_MS = 299_000;
+
+/** Default wait timeout in ms. Well below the 5-minute prompt-cache TTL; enforced by MAX_TIMEOUT_MS. */
 export const DEFAULT_TIMEOUT_MS = 270_000;
 
 /**

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -227,6 +227,9 @@ export const DAEMON_DEV_SCRIPT = "packages/daemon/src/main.ts";
 /** IPC timeout for prompt-like commands (claude send/wait, codex) that may take minutes (ms) */
 export const PROMPT_IPC_TIMEOUT_MS = 330_000;
 
+/** Default wait timeout in ms. Stays below the 5-minute prompt-cache TTL (299000ms cap). */
+export const DEFAULT_TIMEOUT_MS = 270_000;
+
 /**
  * Default WebSocket port for Claude Code SDK sessions (survives daemon restarts).
  * Chosen to be below Linux's ephemeral range (32768–60999) and above the

--- a/packages/daemon/src/acp-session-worker.ts
+++ b/packages/daemon/src/acp-session-worker.ts
@@ -14,7 +14,7 @@
  */
 
 import { AcpSession, type AcpSessionConfig } from "@mcp-cli/acp";
-import { ACP_SERVER_NAME, type AgentSessionEvent } from "@mcp-cli/core";
+import { ACP_SERVER_NAME, type AgentSessionEvent, DEFAULT_TIMEOUT_MS } from "@mcp-cli/core";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { ACP_TOOLS } from "./acp-session/tools";
@@ -187,7 +187,7 @@ async function handlePrompt(args: Record<string, unknown>): Promise<{
   isError?: boolean;
 }> {
   const prompt = args.prompt as string;
-  const timeoutMs = (args.timeout as number) ?? 270_000;
+  const timeoutMs = (args.timeout as number) ?? DEFAULT_TIMEOUT_MS;
   let sessionId = args.sessionId as string | undefined;
 
   if (sessionId) {
@@ -364,7 +364,7 @@ async function handleWait(args: Record<string, unknown>): Promise<{
   isError?: boolean;
 }> {
   const sessionId = args.sessionId as string | undefined;
-  const timeoutMs = (args.timeout as number) ?? 270_000;
+  const timeoutMs = (args.timeout as number) ?? DEFAULT_TIMEOUT_MS;
   const afterSeq = args.afterSeq as number | undefined;
 
   // afterSeq cursor: check buffer first, then block until a new event arrives

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -16,6 +16,7 @@
 
 import {
   CLAUDE_SERVER_NAME,
+  DEFAULT_TIMEOUT_MS,
   type LiveSpan,
   type SessionInfo,
   type WorkItemEvent,
@@ -148,7 +149,7 @@ async function handlePrompt(
   isError?: boolean;
 }> {
   const prompt = args.prompt as string;
-  const timeoutMs = (args.timeout as number) ?? 270_000;
+  const timeoutMs = (args.timeout as number) ?? DEFAULT_TIMEOUT_MS;
 
   let sessionId = args.sessionId as string | undefined;
 
@@ -375,7 +376,7 @@ async function handleWait(
   isError?: boolean;
 }> {
   const sessionId = (args.sessionId as string | undefined) ?? null;
-  const timeoutMs = (args.timeout as number) ?? 270_000;
+  const timeoutMs = (args.timeout as number) ?? DEFAULT_TIMEOUT_MS;
   const afterSeq = args.afterSeq as number | undefined;
   const repoRoot = args.repoRoot as string | undefined;
   const scopeRoot = args.scopeRoot as string | undefined;

--- a/packages/daemon/src/codex-session-worker.ts
+++ b/packages/daemon/src/codex-session-worker.ts
@@ -19,7 +19,7 @@
  */
 
 import { CodexSession, type CodexSessionConfig } from "@mcp-cli/codex";
-import { type AgentSessionEvent, CODEX_SERVER_NAME } from "@mcp-cli/core";
+import { type AgentSessionEvent, CODEX_SERVER_NAME, DEFAULT_TIMEOUT_MS } from "@mcp-cli/core";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { CODEX_TOOLS } from "./codex-session/tools";
@@ -192,7 +192,7 @@ async function handlePrompt(args: Record<string, unknown>): Promise<{
   isError?: boolean;
 }> {
   const prompt = args.prompt as string;
-  const timeoutMs = (args.timeout as number) ?? 270_000;
+  const timeoutMs = (args.timeout as number) ?? DEFAULT_TIMEOUT_MS;
   let sessionId = args.sessionId as string | undefined;
 
   if (sessionId) {
@@ -373,7 +373,7 @@ async function handleWait(args: Record<string, unknown>): Promise<{
   isError?: boolean;
 }> {
   const sessionId = args.sessionId as string | undefined;
-  const timeoutMs = (args.timeout as number) ?? 270_000;
+  const timeoutMs = (args.timeout as number) ?? DEFAULT_TIMEOUT_MS;
   const afterSeq = args.afterSeq as number | undefined;
 
   // afterSeq cursor: check buffer first, then block until a new event arrives

--- a/packages/daemon/src/mock-session-worker.ts
+++ b/packages/daemon/src/mock-session-worker.ts
@@ -15,7 +15,7 @@
  */
 
 import { resolve } from "node:path";
-import { type AgentSessionEvent, MOCK_SERVER_NAME } from "@mcp-cli/core";
+import { type AgentSessionEvent, DEFAULT_TIMEOUT_MS, MOCK_SERVER_NAME } from "@mcp-cli/core";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { MOCK_TOOLS } from "./mock-session/tools";
@@ -374,7 +374,7 @@ function handleTranscript(args: Record<string, unknown>): ToolResult {
 
 async function handleWait(args: Record<string, unknown>): Promise<ToolResult> {
   const sessionId = args.sessionId as string | undefined;
-  const timeoutMs = (args.timeout as number) ?? 270_000;
+  const timeoutMs = (args.timeout as number) ?? DEFAULT_TIMEOUT_MS;
   const afterSeq = args.afterSeq as number | undefined;
 
   // afterSeq cursor: check buffer first, then block

--- a/packages/daemon/src/opencode-session-worker.ts
+++ b/packages/daemon/src/opencode-session-worker.ts
@@ -13,7 +13,7 @@
  *   4. Worker sends MCP JSON-RPC responses + DB event messages back
  */
 
-import { type AgentSessionEvent, OPENCODE_SERVER_NAME } from "@mcp-cli/core";
+import { type AgentSessionEvent, DEFAULT_TIMEOUT_MS, OPENCODE_SERVER_NAME } from "@mcp-cli/core";
 import { OpenCodeSession, type OpenCodeSessionConfig } from "@mcp-cli/opencode";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
@@ -187,7 +187,7 @@ async function handlePrompt(args: Record<string, unknown>): Promise<{
   isError?: boolean;
 }> {
   const prompt = args.prompt as string;
-  const timeoutMs = (args.timeout as number) ?? 270_000;
+  const timeoutMs = (args.timeout as number) ?? DEFAULT_TIMEOUT_MS;
   let sessionId = args.sessionId as string | undefined;
 
   if (sessionId) {
@@ -362,7 +362,7 @@ async function handleWait(args: Record<string, unknown>): Promise<{
   isError?: boolean;
 }> {
   const sessionId = args.sessionId as string | undefined;
-  const timeoutMs = (args.timeout as number) ?? 270_000;
+  const timeoutMs = (args.timeout as number) ?? DEFAULT_TIMEOUT_MS;
   const afterSeq = args.afterSeq as number | undefined;
 
   // afterSeq cursor: check buffer first, then block until a new event arrives

--- a/packages/daemon/src/opencode-session/tools.ts
+++ b/packages/daemon/src/opencode-session/tools.ts
@@ -5,6 +5,8 @@
  * and the main thread (tool cache for ServerPool).
  */
 
+import { DEFAULT_TIMEOUT_MS } from "@mcp-cli/core";
+
 export const OPENCODE_TOOLS = [
   {
     name: "opencode_prompt",
@@ -36,7 +38,7 @@ export const OPENCODE_TOOLS = [
         },
         worktree: { type: "string", description: "Git worktree name for isolation" },
         repoRoot: { type: "string", description: "Repository root for worktree cleanup" },
-        timeout: { type: "number", description: "Max wait time in ms (default: 270000)" },
+        timeout: { type: "number", description: `Max wait time in ms (default: ${DEFAULT_TIMEOUT_MS})` },
         wait: { type: "boolean", description: "Block until result (default: false)" },
       },
       required: ["prompt"],
@@ -102,7 +104,7 @@ export const OPENCODE_TOOLS = [
       type: "object" as const,
       properties: {
         sessionId: { type: "string", description: "Session ID to wait on (omit for any session)" },
-        timeout: { type: "number", description: "Max wait time in ms (default: 270000)" },
+        timeout: { type: "number", description: `Max wait time in ms (default: ${DEFAULT_TIMEOUT_MS})` },
         afterSeq: {
           type: "number",
           description: "Return events after this sequence number. Enables race-free polling.",


### PR DESCRIPTION
## Summary
- Add `DEFAULT_TIMEOUT_MS = 270_000` to `packages/core/src/constants.ts` with a doc comment explaining the cache-TTL rationale
- Replace all 9 hardcoded `270_000` fallback literals across 5 daemon workers (`claude`, `acp`, `opencode`, `codex`, `mock`) and 2 command files (`claude.ts`, `agent.ts`)
- Update help text strings and description properties to use template literals so they stay in sync when the constant changes

## Test plan
- [x] `bun typecheck` — passes (0 errors)
- [x] `bun lint` — passes (4 files auto-fixed for import ordering)
- [x] `bun test` — 5344 tests pass, 0 fail
- [x] Pre-commit hook passed (coverage thresholds met)
- [x] Verified zero remaining `270_000` or `270000` literals outside of tests via grep

🤖 Generated with [Claude Code](https://claude.com/claude-code)