### PR TITLE
retro: sprint 39 — clear the way

### DIFF
--- a/.claude/diary/20260419.39.md
+++ b/.claude/diary/20260419.39.md
@@ -1,0 +1,76 @@
+# 2026-04-19 — Clear the way (Sprint 39)
+
+## What was done
+
+13 PRs merged, v1.6.2 released. 22 items resolved against target 20.
+
+**Containment hardening (sprint 38 follow-ups):**
+- Resolve relative paths against session cwd, not daemon cwd (#1480 → #1490)
+- Symlink realpath with iterative dirname walk for multi-segment missing paths; prefix check runs against realpath so `/tmp/link → /etc/passwd` denies (#1481 → #1491)
+- `ContainmentGuard.reset()` + `mcx claude send --containment-reset` for 3-strike recovery without daemon restart (#1482 → #1494)
+- Bash write detection extended to `sed -i`, `dd of=`, `curl -o`, `wget -O`, plus quoted-path variants; `sed` script-token false-deny fixed (#1475 → #1503)
+
+**Monitor-epic prep:**
+- `phase_state_get/set/list/delete` tools on `_work_items` virtual server, namespaced to `workitem:${id}` (matches `ctx.state` in handlers); `installedAt` timestamp on `LockedPhase` (#1468 → #1492, #1343 → #1496)
+
+**Dangling PRs (sprint 37/38 tails):**
+- `mcx import` falls back to `~/.claude.json` (#1412 → #1429, 4 Copilot comments addressed)
+- CI uploads test/coverage logs as artifacts (#1393 → #1399, rebased after 2-month staleness)
+
+**Rough edges:**
+- `mcx claude bye` no longer deletes branch while PR is open; no misleading `Error:` prefix (#1255 → #1498)
+- `GIT_*` env isolation moved to suite-level `beforeEach/afterEach` (#1314 → #1497)
+- `DEFAULT_TIMEOUT_MS` constant extracted (#1416 → #1499)
+- `scripts/*.spec.ts` now run in CI (#1484 → #1493)
+
+**Pre-flight blocker fix (shipped before batch 1 started):**
+- Alias bundler now externalizes `@mcp-cli/core`; static imports rewrite to destructure from injected `__mcp_core__` at eval time (#1489). PR #1487 in sprint 38 tail had landed an `@mcp-cli/core` import in `impl.ts` that the bundler didn't support — `mcx phase install` was broken and `/sprint 39` couldn't start until it shipped.
+
+**Also closed:**
+- #1267 (pull.spec.ts cleanEnv) — worker verified already fixed by earlier #1253
+- #1302 (t5801 handler errors) — already fixed by #1304
+- #1356 (biome escape) — pure GitHub API config, no code change needed
+- Planning-time closures: #1488, #1425, #1301, #1306, #1309, #1315 (dups of #1302)
+
+## What worked well
+
+- **Parallel merge authority (sprint 38 ruleset change) paid off.** No single-pointer rebase cascade. Per-PR land time: minutes. Auto-merge queue drained cleanly.
+- **Reviewer self-repair kept saving opus.** Yuri (#1499) and June (#1494) fixed their own adversarial-review findings without fresh sessions. Frank's review of #1492 caught the namespace mismatch Carol then fixed. Estimate: ~$8 saved.
+- **QA finding real bugs beyond the original issue scope was the right behavior.** Eve's QA on #1491 surfaced 2 additional containment bypasses that Bob's initial fix missed (multi-segment dirname walk, allowed-prefix realpath check). Four repair rounds, but each addressed a concrete security gap — not noise.
+- **Low-touch run** (user's own assessment): no meaningful interventions until the review-push failure at the end. 20+ sessions, orchestrator drove for hours without needing direction.
+- **Pre-flight discipline caught the #1489 blocker early.** If I'd spawned batch 1 with a broken phase pipeline, the whole sprint would have stalled waiting for drift detection to fire. Instead the fix landed as its own clean PR with tests.
+- **Memory housekeeping at sprint boundary.** Promoted `qa:ci-pending` (worker-filed mid-sprint) into `qa.md` Step 5c so it's enforced at QA time, not just as general advice. Kept `no-gpgsign-bypass` in memory because it's cross-cutting (any git commit, not just QA).
+
+## What didn't work
+
+- **Direct push to main blocked at release time.** `git push origin main` rejected by branch protection; no admin-bypass existed for release commits. Had to route v1.6.2 through PR #1507, wait for CI green, then `gh pr merge --admin`. Adds ~3 minutes of CI wait at every sprint end. **Fix:** user added admin bypass to ruleset post-release. `review.md` and `retro.md` still document `git push origin main` as the release path; both are valid again, but a note documenting the bypass is worth adding next planning pass. Also: `gh pr merge --admin` doesn't wait for in-progress CI (fails with a misleading "clean status, add --auto" message) — required waiting for green before retrying.
+
+- **CI doesn't fire on rapid force-pushes to existing PRs** (#1506). PR #1491 force-pushed 3 times rapidly; only the first two triggered the `pull_request` event. Third commit (`d8b9025f`) required `gh workflow run ci.yml --ref <branch>` to trigger CI, which meant adding `workflow_dispatch:` to the workflow triggers first. Separate gap from #899 (which is about pre-PR-creation pushes). Filed as #1506.
+
+- **`mcx gc` third recurrence.** Sprint 34: "daemon unreachable" (#1398). Sprint 39: "Server `_acp` not found" on the same command. Third time. Commented on #1398 with fresh evidence; this belongs on sprint 40 as an opus investigation (may close WONTFIX if no repro).
+
+- **`mcx untrack` and `work_items_update` rejected their own emitted formats.** `tracked --json` emits `#1255` / `pr:1186`; `untrack` rejects both with "Invalid number." `work_items_update` with `prNumber: null` writes `0` instead of clearing. Filed as #1504 and #1505.
+
+- **Premature `qa:fail` on pending CI** (led to the `qa-ci-pending` memory → promoted to `qa.md`). Eve applied `qa:fail` on PR #1399 while CI was in-progress; CI went green minutes later requiring a correction pass.
+
+- **Worktree cleanup noise during sprint end.** `mcx gc` failing (see above) left ~6 stale worktrees that `git worktree prune` had to clean up manually. Not blocking, just friction.
+
+- **Sprint 38 retro didn't catch the `@mcp-cli/core` bundler gap.** PR #1487 landed with a broken import that would have shown up on the very next sprint start. A "what did we ship that we didn't verify in a fresh phase install" checklist at retro time would have caught it. **Fix:** future retros should include `mcx phase install` as a smoke test before marking a sprint done.
+
+## Patterns established
+
+- **Reviewer self-repair by default, opus repair on request.** Reviewer gets "fix your own findings or reply `needs opus repair`." Carol/June/Yuri all self-repaired; no one escalated. This is now SOP for sprint 40.
+- **OWA-as-first-real-user.** Sprint 40 carries #1455 + #1460 as the matched pair to make OWA endpoints work end-to-end. User identified it as imminent use during sprint 39 wind-down.
+- **Epic decomposition before batch 1.** Sprint 40 plan calls for an opus session to break #1486 into 3-5 sub-issues *before* any epic work starts. Learning from sprint 38's containment anchor, which over-scoped on the first day.
+- **Workflow_dispatch is the CI emergency trigger.** Now added to `ci.yml` (as part of debugging #1491). Worth documenting in `run.md`.
+
+## Stats
+
+- **PRs merged**: 13 (+ sprint 40 plan + 2 meta-only housekeeping commits rolled into PR #1507)
+- **Issues closed**: 9 (3 verified-already-done during sprint + 6 planning-time dups)
+- **Adversarial reviews**: 3 rounds across #1492, #1494, #1499 — all found blockers, all resolved via self-repair
+- **Failed/dropped**: 0
+- **Sprint cost**: ~$30-35 across 30 sessions (estimated from session census)
+- **New issues filed during sprint**: 5 (#1504, #1505, #1506, #1508, + comment on #1398) — follow-up debt acknowledged in sprint 40 risks
+- **Repair rounds**: 4 on #1491 (all productive), 1 each on #1492/#1494/#1499, 0 elsewhere
+- **Wall clock**: started 01:14 EDT 2026-04-19, paused for #1489 bundler fix (~1h), resumed and ran batches concurrently, wind-down ~14:30 UTC. Active sprint time ~4 hours against target ~2h — the #1491 QA-found-extra-bugs arc was the tail.


### PR DESCRIPTION
Sprint 39 retrospective. Docs-only (new file in `.claude/diary/`). Direct push to main blocked by ruleset 13509324's `pull_request` rule; admin bypass doesn't cover git-CLI push auth. Routing through PR.

See #1508 for the CI-skip-for-docs issue that would eliminate the wait.