### PR TITLE
fix(work-items): canonicalize repoRoot in phase_state and aliasState handlers (fixes #1495)

### DIFF
--- a/packages/daemon/src/alias-state.spec.ts
+++ b/packages/daemon/src/alias-state.spec.ts
@@ -1,0 +1,210 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { IpcResponse } from "@mcp-cli/core";
+import { silentLogger } from "@mcp-cli/core";
+import { installDaemonLogCapture } from "./daemon-log";
+import { StateDb } from "./db/state";
+import { IpcServer } from "./ipc-server";
+
+installDaemonLogCapture();
+
+function tmpSocket(): string {
+  return join(tmpdir(), `mcp-alias-state-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sock`);
+}
+
+function tmpDbPath(): string {
+  return join(tmpdir(), `mcp-alias-state-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+}
+
+function cleanupDb(p: string): void {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      unlinkSync(p + suffix);
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+function mockPool() {
+  return {
+    listServers: () => [],
+    listTools: () => [],
+    getToolInfo: () => null,
+    grepTools: () => [],
+    callTool: async () => ({ content: [] }),
+    getServerUrl: () => null,
+    getDb: () => null,
+    restart: async () => {},
+    getStderrLines: () => [],
+    subscribeStderr: () => () => {},
+  };
+}
+
+function mockConfig() {
+  return { servers: new Map(), sources: [] } as never;
+}
+
+function serverOpts() {
+  return {
+    daemonId: "test-alias-state-daemon",
+    startedAt: Date.now(),
+    onActivity: () => {},
+    logger: silentLogger,
+  };
+}
+
+describe("aliasState IPC handlers — repoRoot canonicalization", () => {
+  let server: IpcServer | undefined;
+  let socketPath: string;
+  let db: StateDb | undefined;
+  let dbPath: string;
+
+  afterEach(() => {
+    server?.stop();
+    server = undefined;
+    try {
+      unlinkSync(socketPath);
+    } catch {
+      /* ignore */
+    }
+    db?.close();
+    db = undefined;
+    cleanupDb(dbPath);
+  });
+
+  function start(): { rpc: (body: unknown) => Promise<IpcResponse> } {
+    dbPath = tmpDbPath();
+    db = new StateDb(dbPath);
+    socketPath = tmpSocket();
+    server = new IpcServer(mockPool() as never, mockConfig(), db, null, serverOpts());
+    server.start(socketPath);
+
+    async function rpc(body: unknown): Promise<IpcResponse> {
+      const res = await fetch("http://localhost/rpc", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        unix: socketPath,
+      } as RequestInit);
+      return res.json() as Promise<IpcResponse>;
+    }
+
+    return { rpc };
+  }
+
+  test("aliasStateSet then aliasStateGet round-trips a value", async () => {
+    const { rpc } = start();
+
+    const setResp = await rpc({
+      id: "s1",
+      method: "aliasStateSet",
+      params: { repoRoot: "/test/repo", namespace: "ns1", key: "session", value: "abc" },
+    });
+    expect(setResp.error).toBeUndefined();
+    expect((setResp.result as { ok: boolean }).ok).toBe(true);
+
+    const getResp = await rpc({
+      id: "g1",
+      method: "aliasStateGet",
+      params: { repoRoot: "/test/repo", namespace: "ns1", key: "session" },
+    });
+    expect(getResp.error).toBeUndefined();
+    expect((getResp.result as { value: unknown }).value).toBe("abc");
+  });
+
+  test("trailing slash on set is canonicalized — get without slash returns the value", async () => {
+    const { rpc } = start();
+
+    await rpc({
+      id: "s2",
+      method: "aliasStateSet",
+      params: { repoRoot: "/test/repo/path/", namespace: "ns2", key: "k", value: "v" },
+    });
+
+    const getResp = await rpc({
+      id: "g2",
+      method: "aliasStateGet",
+      params: { repoRoot: "/test/repo/path", namespace: "ns2", key: "k" },
+    });
+    expect(getResp.error).toBeUndefined();
+    expect((getResp.result as { value: unknown }).value).toBe("v");
+  });
+
+  test("trailing slash on get is canonicalized — set without slash, get with slash returns the value", async () => {
+    const { rpc } = start();
+
+    await rpc({
+      id: "s3",
+      method: "aliasStateSet",
+      params: { repoRoot: "/test/repo/path", namespace: "ns3", key: "k", value: "v2" },
+    });
+
+    const getResp = await rpc({
+      id: "g3",
+      method: "aliasStateGet",
+      params: { repoRoot: "/test/repo/path/", namespace: "ns3", key: "k" },
+    });
+    expect(getResp.error).toBeUndefined();
+    expect((getResp.result as { value: unknown }).value).toBe("v2");
+  });
+
+  test("aliasStateDelete removes the entry", async () => {
+    const { rpc } = start();
+
+    await rpc({
+      id: "s4",
+      method: "aliasStateSet",
+      params: { repoRoot: "/test/repo", namespace: "ns4", key: "del-me", value: 42 },
+    });
+
+    const delResp = await rpc({
+      id: "d1",
+      method: "aliasStateDelete",
+      params: { repoRoot: "/test/repo", namespace: "ns4", key: "del-me" },
+    });
+    expect(delResp.error).toBeUndefined();
+    expect((delResp.result as { deleted: boolean }).deleted).toBe(true);
+
+    const getResp = await rpc({
+      id: "g4",
+      method: "aliasStateGet",
+      params: { repoRoot: "/test/repo", namespace: "ns4", key: "del-me" },
+    });
+    expect((getResp.result as { value: unknown }).value).toBeUndefined();
+  });
+
+  test("aliasStateAll lists all entries for namespace", async () => {
+    const { rpc } = start();
+
+    await rpc({
+      id: "s5a",
+      method: "aliasStateSet",
+      params: { repoRoot: "/repo", namespace: "ns5", key: "a", value: 1 },
+    });
+    await rpc({
+      id: "s5b",
+      method: "aliasStateSet",
+      params: { repoRoot: "/repo", namespace: "ns5", key: "b", value: 2 },
+    });
+
+    const allResp = await rpc({ id: "a1", method: "aliasStateAll", params: { repoRoot: "/repo/", namespace: "ns5" } });
+    expect(allResp.error).toBeUndefined();
+    const entries = (allResp.result as { entries: Record<string, unknown> }).entries;
+    expect(entries.a).toBe(1);
+    expect(entries.b).toBe(2);
+  });
+
+  test("empty repoRoot is rejected by Zod schema — returns IPC error", async () => {
+    const { rpc } = start();
+
+    const resp = await rpc({
+      id: "e1",
+      method: "aliasStateGet",
+      params: { repoRoot: "", namespace: "ns", key: "k" },
+    });
+    expect(resp.error).toBeDefined();
+  });
+});

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -317,6 +317,32 @@ export class StateDb {
       CREATE INDEX IF NOT EXISTS idx_spans_exported ON spans(exported_at, created_at);
       CREATE INDEX IF NOT EXISTS idx_spans_daemon ON spans(daemon_id);
     `);
+
+    // -- Canonicalize alias_state rows written with trailing-slash repo_root --
+    // path.resolve() was added in v1.6.3 to normalize repoRoot, but rows written
+    // before that fix used raw caller-supplied paths (e.g. "/repo/"). Strip trailing
+    // slashes from any such rows so they merge with their canonical counterparts.
+    // Rows that collide on (stripped_root, namespace, key) are deleted (the
+    // non-trailing-slash row is canonical and takes precedence by updated_at).
+    this.db.transaction(() => {
+      // Delete losers — trailing-slash rows where a canonical row already exists
+      this.db.run(`
+        DELETE FROM alias_state
+        WHERE repo_root LIKE '%/'
+          AND EXISTS (
+            SELECT 1 FROM alias_state AS canonical
+            WHERE canonical.repo_root = rtrim(alias_state.repo_root, '/')
+              AND canonical.namespace  = alias_state.namespace
+              AND canonical.key        = alias_state.key
+          )
+      `);
+      // Migrate winners — remaining trailing-slash rows have no conflict
+      this.db.run(`
+        UPDATE alias_state
+        SET repo_root = rtrim(repo_root, '/')
+        WHERE repo_root LIKE '%/'
+      `);
+    })();
   }
 
   // -- Tool cache --

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -865,6 +865,7 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
           });
 
           workItemsServer = new WorkItemsServer(workItemDb, {
+            stateDb: db,
             onTrack: () => workItemPoller?.pollNow(),
             loadManifest: (repoRoot) => {
               try {

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -5,6 +5,7 @@
  */
 
 import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
 import type {
   IpcError,
   IpcMethod,
@@ -1201,25 +1202,29 @@ export class IpcServer {
     // -- Alias state (per-work-item / per-alias scratchpad) --
 
     this.handlers.set("aliasStateGet", async (params, _ctx) => {
-      const { repoRoot, namespace, key } = AliasStateGetParamsSchema.parse(params);
-      return { value: this.db.getAliasState(repoRoot, namespace, key) };
+      const parsed = AliasStateGetParamsSchema.parse(params);
+      const repoRoot = resolve(parsed.repoRoot);
+      return { value: this.db.getAliasState(repoRoot, parsed.namespace, parsed.key) };
     });
 
     this.handlers.set("aliasStateSet", async (params, _ctx) => {
-      const { repoRoot, namespace, key, value } = AliasStateSetParamsSchema.parse(params);
-      this.db.setAliasState(repoRoot, namespace, key, value);
+      const parsed = AliasStateSetParamsSchema.parse(params);
+      const repoRoot = resolve(parsed.repoRoot);
+      this.db.setAliasState(repoRoot, parsed.namespace, parsed.key, parsed.value);
       return { ok: true as const };
     });
 
     this.handlers.set("aliasStateDelete", async (params, _ctx) => {
-      const { repoRoot, namespace, key } = AliasStateDeleteParamsSchema.parse(params);
-      const deleted = this.db.deleteAliasState(repoRoot, namespace, key);
+      const parsed = AliasStateDeleteParamsSchema.parse(params);
+      const repoRoot = resolve(parsed.repoRoot);
+      const deleted = this.db.deleteAliasState(repoRoot, parsed.namespace, parsed.key);
       return { ok: true as const, deleted };
     });
 
     this.handlers.set("aliasStateAll", async (params, _ctx) => {
-      const { repoRoot, namespace } = AliasStateAllParamsSchema.parse(params);
-      return { entries: this.db.listAliasState(repoRoot, namespace) };
+      const parsed = AliasStateAllParamsSchema.parse(params);
+      const repoRoot = resolve(parsed.repoRoot);
+      return { entries: this.db.listAliasState(repoRoot, parsed.namespace) };
     });
 
     this.handlers.set("shutdown", async (params, _ctx) => {

--- a/packages/daemon/src/work-items-server.spec.ts
+++ b/packages/daemon/src/work-items-server.spec.ts
@@ -2,13 +2,86 @@ import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, test } from "bun:test";
 import { WORK_ITEMS_SERVER_NAME } from "@mcp-cli/core";
 import { WorkItemDb } from "./db/work-items";
-import { WorkItemsServer, buildWorkItemsToolCache } from "./work-items-server";
+import { type PhaseStateStore, WorkItemsServer, buildWorkItemsToolCache } from "./work-items-server";
 
 function createWorkItemDb(): { db: WorkItemDb; raw: Database } {
   const raw = new Database(":memory:");
   raw.exec("PRAGMA journal_mode = WAL");
   const db = new WorkItemDb(raw);
   return { db, raw };
+}
+
+const ALIAS_STATE_MAX_VALUE_BYTES = 256 * 1024;
+
+function createPhaseStateStore(raw: Database): PhaseStateStore {
+  raw.exec(`
+    CREATE TABLE IF NOT EXISTS alias_state (
+      repo_root TEXT NOT NULL,
+      namespace TEXT NOT NULL,
+      key TEXT NOT NULL,
+      value_json TEXT NOT NULL,
+      updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+      PRIMARY KEY (repo_root, namespace, key)
+    )
+  `);
+  return {
+    getAliasState(repoRoot: string, namespace: string, key: string): unknown {
+      const row = raw
+        .query<{ value_json: string }, [string, string, string]>(
+          "SELECT value_json FROM alias_state WHERE repo_root = ? AND namespace = ? AND key = ?",
+        )
+        .get(repoRoot, namespace, key);
+      if (!row) return undefined;
+      try {
+        return JSON.parse(row.value_json);
+      } catch {
+        return undefined;
+      }
+    },
+    setAliasState(repoRoot: string, namespace: string, key: string, value: unknown): void {
+      if (value === undefined) {
+        throw new Error("alias state value cannot be undefined; use delete(key) to remove a key");
+      }
+      const json = JSON.stringify(value);
+      if (json === undefined) {
+        throw new Error("alias state value is not JSON-serialisable");
+      }
+      if (Buffer.byteLength(json, "utf-8") > ALIAS_STATE_MAX_VALUE_BYTES) {
+        throw new Error(`alias state value exceeds max size of ${ALIAS_STATE_MAX_VALUE_BYTES} bytes`);
+      }
+      raw.run(
+        `INSERT INTO alias_state (repo_root, namespace, key, value_json, updated_at)
+         VALUES (?, ?, ?, ?, unixepoch())
+         ON CONFLICT(repo_root, namespace, key) DO UPDATE SET
+           value_json = excluded.value_json, updated_at = excluded.updated_at`,
+        [repoRoot, namespace, key, json],
+      );
+    },
+    deleteAliasState(repoRoot: string, namespace: string, key: string): boolean {
+      const result = raw.run("DELETE FROM alias_state WHERE repo_root = ? AND namespace = ? AND key = ?", [
+        repoRoot,
+        namespace,
+        key,
+      ]);
+      return result.changes > 0;
+    },
+    listAliasState(repoRoot: string, namespace: string): Record<string, unknown> {
+      const rows = raw
+        .query<{ key: string; value_json: string }, [string, string]>(
+          "SELECT key, value_json FROM alias_state WHERE repo_root = ? AND namespace = ?",
+        )
+        .all(repoRoot, namespace);
+      const out: Record<string, unknown> = {};
+      for (const row of rows) {
+        try {
+          out[row.key] = JSON.parse(row.value_json);
+        } catch {
+          // match StateDb: silently drop unparseable rows
+        }
+      }
+      return out;
+    },
+  };
 }
 
 describe("WORK_ITEMS_SERVER_NAME", () => {
@@ -18,14 +91,18 @@ describe("WORK_ITEMS_SERVER_NAME", () => {
 });
 
 describe("buildWorkItemsToolCache", () => {
-  test("returns all 5 tools", () => {
+  test("returns all 9 tools", () => {
     const cache = buildWorkItemsToolCache();
-    expect(cache.size).toBe(5);
+    expect(cache.size).toBe(9);
     expect(cache.has("work_items_track")).toBe(true);
     expect(cache.has("work_items_untrack")).toBe(true);
     expect(cache.has("work_items_list")).toBe(true);
     expect(cache.has("work_items_get")).toBe(true);
     expect(cache.has("work_items_update")).toBe(true);
+    expect(cache.has("phase_state_get")).toBe(true);
+    expect(cache.has("phase_state_set")).toBe(true);
+    expect(cache.has("phase_state_delete")).toBe(true);
+    expect(cache.has("phase_state_list")).toBe(true);
   });
 
   test("each tool has correct server name", () => {
@@ -47,7 +124,7 @@ describe("WorkItemsServer", () => {
     rawDb = undefined;
   });
 
-  test("start() connects and listTools returns 5 tools", async () => {
+  test("start() connects and listTools returns 9 tools", async () => {
     const { db, raw } = createWorkItemDb();
     rawDb = raw;
     server = new WorkItemsServer(db);
@@ -55,13 +132,17 @@ describe("WorkItemsServer", () => {
     const { client } = await server.start();
     const { tools } = await client.listTools();
 
-    expect(tools).toHaveLength(5);
+    expect(tools).toHaveLength(9);
     const names = tools.map((t) => t.name);
     expect(names).toContain("work_items_track");
     expect(names).toContain("work_items_untrack");
     expect(names).toContain("work_items_list");
     expect(names).toContain("work_items_get");
     expect(names).toContain("work_items_update");
+    expect(names).toContain("phase_state_get");
+    expect(names).toContain("phase_state_set");
+    expect(names).toContain("phase_state_delete");
+    expect(names).toContain("phase_state_list");
   });
 
   test("work_items_track creates a new item by PR number", async () => {
@@ -938,5 +1019,283 @@ describe("WorkItemsServer", () => {
     const item = JSON.parse(content[0].text);
     expect(item.branch).toBe("explicit/branch");
     expect(resolverCalled).toBe(false);
+  });
+});
+
+describe("phase_state tools", () => {
+  let server: WorkItemsServer | undefined;
+  let rawDb: Database | undefined;
+
+  afterEach(async () => {
+    await server?.stop();
+    rawDb?.close();
+    server = undefined;
+    rawDb = undefined;
+  });
+
+  test("phase_state_set and phase_state_get round-trip a value", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    const stateDb = createPhaseStateStore(raw);
+    server = new WorkItemsServer(db, { stateDb });
+    const { client } = await server.start();
+
+    await client.callTool({ name: "work_items_track", arguments: { issueNumber: 1 } });
+
+    const setResult = await client.callTool({
+      name: "phase_state_set",
+      arguments: { workItemId: "issue:1", repoRoot: "/repo", key: "session_id", value: "abc-123" },
+    });
+    expect(setResult.isError).toBeFalsy();
+    const setBody = JSON.parse((setResult.content as Array<{ text: string }>)[0].text);
+    expect(setBody.ok).toBe(true);
+
+    const getResult = await client.callTool({
+      name: "phase_state_get",
+      arguments: { workItemId: "issue:1", repoRoot: "/repo", key: "session_id" },
+    });
+    expect(getResult.isError).toBeFalsy();
+    const getBody = JSON.parse((getResult.content as Array<{ text: string }>)[0].text);
+    expect(getBody.value).toBe("abc-123");
+  });
+
+  test("repoRoot is canonicalized — trailing slash and no slash resolve to same row", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    const stateDb = createPhaseStateStore(raw);
+    server = new WorkItemsServer(db, { stateDb });
+    const { client } = await server.start();
+
+    await client.callTool({ name: "work_items_track", arguments: { issueNumber: 20 } });
+
+    await client.callTool({
+      name: "phase_state_set",
+      arguments: { workItemId: "issue:20", repoRoot: "/repo/path/", key: "k", value: "v" },
+    });
+
+    const result = await client.callTool({
+      name: "phase_state_get",
+      arguments: { workItemId: "issue:20", repoRoot: "/repo/path", key: "k" },
+    });
+    expect(result.isError).toBeFalsy();
+    const body = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    expect(body.value).toBe("v");
+  });
+
+  test("namespace uses workitem:{id} — matches ctx.state in phase handlers", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    const stateDb = createPhaseStateStore(raw);
+    server = new WorkItemsServer(db, { stateDb });
+    const { client } = await server.start();
+
+    await client.callTool({ name: "work_items_track", arguments: { issueNumber: 10 } });
+
+    await client.callTool({
+      name: "phase_state_set",
+      arguments: { workItemId: "issue:10", repoRoot: "/repo", key: "session_id", value: "s10" },
+    });
+
+    const row = raw.query<{ namespace: string }, []>("SELECT namespace FROM alias_state LIMIT 1").get();
+    expect(row?.namespace).toBe("workitem:issue:10");
+  });
+
+  test("parallel work items are isolated — no cross-contamination", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    const stateDb = createPhaseStateStore(raw);
+    server = new WorkItemsServer(db, { stateDb });
+    const { client } = await server.start();
+
+    await client.callTool({ name: "work_items_track", arguments: { issueNumber: 1 } });
+    await client.callTool({ name: "work_items_track", arguments: { issueNumber: 2 } });
+
+    await client.callTool({
+      name: "phase_state_set",
+      arguments: { workItemId: "issue:1", repoRoot: "/repo", key: "session_id", value: "sess-1" },
+    });
+    await client.callTool({
+      name: "phase_state_set",
+      arguments: { workItemId: "issue:2", repoRoot: "/repo", key: "session_id", value: "sess-2" },
+    });
+
+    const get1 = await client.callTool({
+      name: "phase_state_get",
+      arguments: { workItemId: "issue:1", repoRoot: "/repo", key: "session_id" },
+    });
+    const get2 = await client.callTool({
+      name: "phase_state_get",
+      arguments: { workItemId: "issue:2", repoRoot: "/repo", key: "session_id" },
+    });
+
+    expect(JSON.parse((get1.content as Array<{ text: string }>)[0].text).value).toBe("sess-1");
+    expect(JSON.parse((get2.content as Array<{ text: string }>)[0].text).value).toBe("sess-2");
+  });
+
+  test("phase_state_get returns undefined for missing key", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    const stateDb = createPhaseStateStore(raw);
+    server = new WorkItemsServer(db, { stateDb });
+    const { client } = await server.start();
+
+    await client.callTool({ name: "work_items_track", arguments: { issueNumber: 2 } });
+
+    const result = await client.callTool({
+      name: "phase_state_get",
+      arguments: { workItemId: "issue:2", repoRoot: "/repo", key: "nonexistent" },
+    });
+    expect(result.isError).toBeFalsy();
+    const body = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    expect(body.value).toBeUndefined();
+  });
+
+  test("phase_state_list returns all keys for the work item", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    const stateDb = createPhaseStateStore(raw);
+    server = new WorkItemsServer(db, { stateDb });
+    const { client } = await server.start();
+
+    await client.callTool({ name: "work_items_track", arguments: { issueNumber: 3 } });
+
+    await client.callTool({
+      name: "phase_state_set",
+      arguments: { workItemId: "issue:3", repoRoot: "/repo", key: "session_id", value: "s1" },
+    });
+    await client.callTool({
+      name: "phase_state_set",
+      arguments: { workItemId: "issue:3", repoRoot: "/repo", key: "worktree", value: "/tmp/wt" },
+    });
+
+    const result = await client.callTool({
+      name: "phase_state_list",
+      arguments: { workItemId: "issue:3", repoRoot: "/repo" },
+    });
+    expect(result.isError).toBeFalsy();
+    const body = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    expect(body.count).toBe(2);
+    expect(body.entries.session_id).toBe("s1");
+    expect(body.entries.worktree).toBe("/tmp/wt");
+  });
+
+  test("phase_state_delete removes a key", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    const stateDb = createPhaseStateStore(raw);
+    server = new WorkItemsServer(db, { stateDb });
+    const { client } = await server.start();
+
+    await client.callTool({ name: "work_items_track", arguments: { issueNumber: 7 } });
+
+    await client.callTool({
+      name: "phase_state_set",
+      arguments: { workItemId: "issue:7", repoRoot: "/repo", key: "session_id", value: "to-delete" },
+    });
+
+    const delResult = await client.callTool({
+      name: "phase_state_delete",
+      arguments: { workItemId: "issue:7", repoRoot: "/repo", key: "session_id" },
+    });
+    expect(delResult.isError).toBeFalsy();
+    const delBody = JSON.parse((delResult.content as Array<{ text: string }>)[0].text);
+    expect(delBody.deleted).toBe(true);
+
+    const getResult = await client.callTool({
+      name: "phase_state_get",
+      arguments: { workItemId: "issue:7", repoRoot: "/repo", key: "session_id" },
+    });
+    const getBody = JSON.parse((getResult.content as Array<{ text: string }>)[0].text);
+    expect(getBody.value).toBeUndefined();
+  });
+
+  test("phase_state_delete returns false for nonexistent key", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    const stateDb = createPhaseStateStore(raw);
+    server = new WorkItemsServer(db, { stateDb });
+    const { client } = await server.start();
+
+    await client.callTool({ name: "work_items_track", arguments: { issueNumber: 8 } });
+
+    const result = await client.callTool({
+      name: "phase_state_delete",
+      arguments: { workItemId: "issue:8", repoRoot: "/repo", key: "nope" },
+    });
+    expect(result.isError).toBeFalsy();
+    const body = JSON.parse((result.content as Array<{ text: string }>)[0].text);
+    expect(body.deleted).toBe(false);
+  });
+
+  test("phase_state_get errors for nonexistent work item", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    const stateDb = createPhaseStateStore(raw);
+    server = new WorkItemsServer(db, { stateDb });
+    const { client } = await server.start();
+
+    const result = await client.callTool({
+      name: "phase_state_get",
+      arguments: { workItemId: "issue:999", repoRoot: "/repo", key: "x" },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ text: string }>)[0].text;
+    expect(text).toContain("Work item not found");
+  });
+
+  test("phase_state tools error when no stateDb configured", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    server = new WorkItemsServer(db);
+    const { client } = await server.start();
+
+    await client.callTool({ name: "work_items_track", arguments: { issueNumber: 5 } });
+
+    for (const toolName of ["phase_state_get", "phase_state_set", "phase_state_delete", "phase_state_list"] as const) {
+      const result = await client.callTool({
+        name: toolName,
+        arguments: { workItemId: "issue:5", repoRoot: "/repo", key: "x", value: "v" },
+      });
+      expect(result.isError).toBe(true);
+      const text = (result.content as Array<{ text: string }>)[0].text;
+      expect(text).toContain("not available");
+    }
+  });
+
+  test("phase_state_set rejects undefined value", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    const stateDb = createPhaseStateStore(raw);
+    server = new WorkItemsServer(db, { stateDb });
+    const { client } = await server.start();
+
+    await client.callTool({ name: "work_items_track", arguments: { issueNumber: 6 } });
+
+    const result = await client.callTool({
+      name: "phase_state_set",
+      arguments: { workItemId: "issue:6", repoRoot: "/repo", key: "k" },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ text: string }>)[0].text;
+    expect(text).toContain("value is required");
+  });
+
+  test("phase_state_set surfaces StateDb errors as isError response", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    const stateDb = createPhaseStateStore(raw);
+    server = new WorkItemsServer(db, { stateDb });
+    const { client } = await server.start();
+
+    await client.callTool({ name: "work_items_track", arguments: { issueNumber: 9 } });
+
+    const bigValue = "x".repeat(300 * 1024);
+    const result = await client.callTool({
+      name: "phase_state_set",
+      arguments: { workItemId: "issue:9", repoRoot: "/repo", key: "big", value: bigValue },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ text: string }>)[0].text;
+    expect(text).toContain("exceeds max size");
   });
 });

--- a/packages/daemon/src/work-items-server.spec.ts
+++ b/packages/daemon/src/work-items-server.spec.ts
@@ -1,8 +1,26 @@
 import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, test } from "bun:test";
+import { unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { WORK_ITEMS_SERVER_NAME } from "@mcp-cli/core";
+import { StateDb } from "./db/state";
 import { WorkItemDb } from "./db/work-items";
-import { type PhaseStateStore, WorkItemsServer, buildWorkItemsToolCache } from "./work-items-server";
+import { WorkItemsServer, buildWorkItemsToolCache } from "./work-items-server";
+
+function tmpDbPath(): string {
+  return join(tmpdir(), `mcp-wi-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+}
+
+function cleanupDb(p: string): void {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      unlinkSync(p + suffix);
+    } catch {
+      /* ignore */
+    }
+  }
+}
 
 function createWorkItemDb(): { db: WorkItemDb; raw: Database } {
   const raw = new Database(":memory:");
@@ -11,77 +29,13 @@ function createWorkItemDb(): { db: WorkItemDb; raw: Database } {
   return { db, raw };
 }
 
-const ALIAS_STATE_MAX_VALUE_BYTES = 256 * 1024;
-
-function createPhaseStateStore(raw: Database): PhaseStateStore {
-  raw.exec(`
-    CREATE TABLE IF NOT EXISTS alias_state (
-      repo_root TEXT NOT NULL,
-      namespace TEXT NOT NULL,
-      key TEXT NOT NULL,
-      value_json TEXT NOT NULL,
-      updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
-      PRIMARY KEY (repo_root, namespace, key)
-    )
-  `);
-  return {
-    getAliasState(repoRoot: string, namespace: string, key: string): unknown {
-      const row = raw
-        .query<{ value_json: string }, [string, string, string]>(
-          "SELECT value_json FROM alias_state WHERE repo_root = ? AND namespace = ? AND key = ?",
-        )
-        .get(repoRoot, namespace, key);
-      if (!row) return undefined;
-      try {
-        return JSON.parse(row.value_json);
-      } catch {
-        return undefined;
-      }
-    },
-    setAliasState(repoRoot: string, namespace: string, key: string, value: unknown): void {
-      if (value === undefined) {
-        throw new Error("alias state value cannot be undefined; use delete(key) to remove a key");
-      }
-      const json = JSON.stringify(value);
-      if (json === undefined) {
-        throw new Error("alias state value is not JSON-serialisable");
-      }
-      if (Buffer.byteLength(json, "utf-8") > ALIAS_STATE_MAX_VALUE_BYTES) {
-        throw new Error(`alias state value exceeds max size of ${ALIAS_STATE_MAX_VALUE_BYTES} bytes`);
-      }
-      raw.run(
-        `INSERT INTO alias_state (repo_root, namespace, key, value_json, updated_at)
-         VALUES (?, ?, ?, ?, unixepoch())
-         ON CONFLICT(repo_root, namespace, key) DO UPDATE SET
-           value_json = excluded.value_json, updated_at = excluded.updated_at`,
-        [repoRoot, namespace, key, json],
-      );
-    },
-    deleteAliasState(repoRoot: string, namespace: string, key: string): boolean {
-      const result = raw.run("DELETE FROM alias_state WHERE repo_root = ? AND namespace = ? AND key = ?", [
-        repoRoot,
-        namespace,
-        key,
-      ]);
-      return result.changes > 0;
-    },
-    listAliasState(repoRoot: string, namespace: string): Record<string, unknown> {
-      const rows = raw
-        .query<{ key: string; value_json: string }, [string, string]>(
-          "SELECT key, value_json FROM alias_state WHERE repo_root = ? AND namespace = ?",
-        )
-        .all(repoRoot, namespace);
-      const out: Record<string, unknown> = {};
-      for (const row of rows) {
-        try {
-          out[row.key] = JSON.parse(row.value_json);
-        } catch {
-          // match StateDb: silently drop unparseable rows
-        }
-      }
-      return out;
-    },
-  };
+/** Create a real StateDb (temp file) and a WorkItemDb sharing its underlying database — matches production wiring. */
+function createRealStateDbs(): { stateDb: StateDb; workItemDb: WorkItemDb; raw: Database; dbPath: string } {
+  const dbPath = tmpDbPath();
+  const stateDb = new StateDb(dbPath);
+  const raw = stateDb.getDatabase();
+  const workItemDb = new WorkItemDb(raw);
+  return { stateDb, workItemDb, raw, dbPath };
 }
 
 describe("WORK_ITEMS_SERVER_NAME", () => {
@@ -1024,20 +978,29 @@ describe("WorkItemsServer", () => {
 
 describe("phase_state tools", () => {
   let server: WorkItemsServer | undefined;
-  let rawDb: Database | undefined;
+  let stateDbInst: StateDb | undefined;
+  let dbPathToClean: string | undefined;
+  // rawWiDb tracks :memory: WorkItemDb instances used by no-stateDb tests
+  let rawWiDb: Database | undefined;
 
   afterEach(async () => {
     await server?.stop();
-    rawDb?.close();
+    stateDbInst?.close();
+    rawWiDb?.close();
     server = undefined;
-    rawDb = undefined;
+    stateDbInst = undefined;
+    rawWiDb = undefined;
+    if (dbPathToClean) {
+      cleanupDb(dbPathToClean);
+      dbPathToClean = undefined;
+    }
   });
 
   test("phase_state_set and phase_state_get round-trip a value", async () => {
-    const { db, raw } = createWorkItemDb();
-    rawDb = raw;
-    const stateDb = createPhaseStateStore(raw);
-    server = new WorkItemsServer(db, { stateDb });
+    const { stateDb, workItemDb, dbPath } = createRealStateDbs();
+    stateDbInst = stateDb;
+    dbPathToClean = dbPath;
+    server = new WorkItemsServer(workItemDb, { stateDb });
     const { client } = await server.start();
 
     await client.callTool({ name: "work_items_track", arguments: { issueNumber: 1 } });
@@ -1060,10 +1023,10 @@ describe("phase_state tools", () => {
   });
 
   test("repoRoot is canonicalized — trailing slash and no slash resolve to same row", async () => {
-    const { db, raw } = createWorkItemDb();
-    rawDb = raw;
-    const stateDb = createPhaseStateStore(raw);
-    server = new WorkItemsServer(db, { stateDb });
+    const { stateDb, workItemDb, dbPath } = createRealStateDbs();
+    stateDbInst = stateDb;
+    dbPathToClean = dbPath;
+    server = new WorkItemsServer(workItemDb, { stateDb });
     const { client } = await server.start();
 
     await client.callTool({ name: "work_items_track", arguments: { issueNumber: 20 } });
@@ -1082,11 +1045,29 @@ describe("phase_state tools", () => {
     expect(body.value).toBe("v");
   });
 
+  test("empty repoRoot is rejected — does not fall back to process.cwd()", async () => {
+    const { stateDb, workItemDb, dbPath } = createRealStateDbs();
+    stateDbInst = stateDb;
+    dbPathToClean = dbPath;
+    server = new WorkItemsServer(workItemDb, { stateDb });
+    const { client } = await server.start();
+
+    await client.callTool({ name: "work_items_track", arguments: { issueNumber: 99 } });
+
+    const result = await client.callTool({
+      name: "phase_state_set",
+      arguments: { workItemId: "issue:99", repoRoot: "", key: "k", value: "v" },
+    });
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ text: string }>)[0].text;
+    expect(text).toContain("required");
+  });
+
   test("namespace uses workitem:{id} — matches ctx.state in phase handlers", async () => {
-    const { db, raw } = createWorkItemDb();
-    rawDb = raw;
-    const stateDb = createPhaseStateStore(raw);
-    server = new WorkItemsServer(db, { stateDb });
+    const { stateDb, workItemDb, raw, dbPath } = createRealStateDbs();
+    stateDbInst = stateDb;
+    dbPathToClean = dbPath;
+    server = new WorkItemsServer(workItemDb, { stateDb });
     const { client } = await server.start();
 
     await client.callTool({ name: "work_items_track", arguments: { issueNumber: 10 } });
@@ -1101,10 +1082,10 @@ describe("phase_state tools", () => {
   });
 
   test("parallel work items are isolated — no cross-contamination", async () => {
-    const { db, raw } = createWorkItemDb();
-    rawDb = raw;
-    const stateDb = createPhaseStateStore(raw);
-    server = new WorkItemsServer(db, { stateDb });
+    const { stateDb, workItemDb, dbPath } = createRealStateDbs();
+    stateDbInst = stateDb;
+    dbPathToClean = dbPath;
+    server = new WorkItemsServer(workItemDb, { stateDb });
     const { client } = await server.start();
 
     await client.callTool({ name: "work_items_track", arguments: { issueNumber: 1 } });
@@ -1133,10 +1114,10 @@ describe("phase_state tools", () => {
   });
 
   test("phase_state_get returns undefined for missing key", async () => {
-    const { db, raw } = createWorkItemDb();
-    rawDb = raw;
-    const stateDb = createPhaseStateStore(raw);
-    server = new WorkItemsServer(db, { stateDb });
+    const { stateDb, workItemDb, dbPath } = createRealStateDbs();
+    stateDbInst = stateDb;
+    dbPathToClean = dbPath;
+    server = new WorkItemsServer(workItemDb, { stateDb });
     const { client } = await server.start();
 
     await client.callTool({ name: "work_items_track", arguments: { issueNumber: 2 } });
@@ -1151,10 +1132,10 @@ describe("phase_state tools", () => {
   });
 
   test("phase_state_list returns all keys for the work item", async () => {
-    const { db, raw } = createWorkItemDb();
-    rawDb = raw;
-    const stateDb = createPhaseStateStore(raw);
-    server = new WorkItemsServer(db, { stateDb });
+    const { stateDb, workItemDb, dbPath } = createRealStateDbs();
+    stateDbInst = stateDb;
+    dbPathToClean = dbPath;
+    server = new WorkItemsServer(workItemDb, { stateDb });
     const { client } = await server.start();
 
     await client.callTool({ name: "work_items_track", arguments: { issueNumber: 3 } });
@@ -1180,10 +1161,10 @@ describe("phase_state tools", () => {
   });
 
   test("phase_state_delete removes a key", async () => {
-    const { db, raw } = createWorkItemDb();
-    rawDb = raw;
-    const stateDb = createPhaseStateStore(raw);
-    server = new WorkItemsServer(db, { stateDb });
+    const { stateDb, workItemDb, dbPath } = createRealStateDbs();
+    stateDbInst = stateDb;
+    dbPathToClean = dbPath;
+    server = new WorkItemsServer(workItemDb, { stateDb });
     const { client } = await server.start();
 
     await client.callTool({ name: "work_items_track", arguments: { issueNumber: 7 } });
@@ -1210,10 +1191,10 @@ describe("phase_state tools", () => {
   });
 
   test("phase_state_delete returns false for nonexistent key", async () => {
-    const { db, raw } = createWorkItemDb();
-    rawDb = raw;
-    const stateDb = createPhaseStateStore(raw);
-    server = new WorkItemsServer(db, { stateDb });
+    const { stateDb, workItemDb, dbPath } = createRealStateDbs();
+    stateDbInst = stateDb;
+    dbPathToClean = dbPath;
+    server = new WorkItemsServer(workItemDb, { stateDb });
     const { client } = await server.start();
 
     await client.callTool({ name: "work_items_track", arguments: { issueNumber: 8 } });
@@ -1228,10 +1209,10 @@ describe("phase_state tools", () => {
   });
 
   test("phase_state_get errors for nonexistent work item", async () => {
-    const { db, raw } = createWorkItemDb();
-    rawDb = raw;
-    const stateDb = createPhaseStateStore(raw);
-    server = new WorkItemsServer(db, { stateDb });
+    const { stateDb, workItemDb, dbPath } = createRealStateDbs();
+    stateDbInst = stateDb;
+    dbPathToClean = dbPath;
+    server = new WorkItemsServer(workItemDb, { stateDb });
     const { client } = await server.start();
 
     const result = await client.callTool({
@@ -1245,7 +1226,7 @@ describe("phase_state tools", () => {
 
   test("phase_state tools error when no stateDb configured", async () => {
     const { db, raw } = createWorkItemDb();
-    rawDb = raw;
+    rawWiDb = raw;
     server = new WorkItemsServer(db);
     const { client } = await server.start();
 
@@ -1263,10 +1244,10 @@ describe("phase_state tools", () => {
   });
 
   test("phase_state_set rejects undefined value", async () => {
-    const { db, raw } = createWorkItemDb();
-    rawDb = raw;
-    const stateDb = createPhaseStateStore(raw);
-    server = new WorkItemsServer(db, { stateDb });
+    const { stateDb, workItemDb, dbPath } = createRealStateDbs();
+    stateDbInst = stateDb;
+    dbPathToClean = dbPath;
+    server = new WorkItemsServer(workItemDb, { stateDb });
     const { client } = await server.start();
 
     await client.callTool({ name: "work_items_track", arguments: { issueNumber: 6 } });
@@ -1281,10 +1262,10 @@ describe("phase_state tools", () => {
   });
 
   test("phase_state_set surfaces StateDb errors as isError response", async () => {
-    const { db, raw } = createWorkItemDb();
-    rawDb = raw;
-    const stateDb = createPhaseStateStore(raw);
-    server = new WorkItemsServer(db, { stateDb });
+    const { stateDb, workItemDb, dbPath } = createRealStateDbs();
+    stateDbInst = stateDb;
+    dbPathToClean = dbPath;
+    server = new WorkItemsServer(workItemDb, { stateDb });
     const { client } = await server.start();
 
     await client.callTool({ name: "work_items_track", arguments: { issueNumber: 9 } });

--- a/packages/daemon/src/work-items-server.ts
+++ b/packages/daemon/src/work-items-server.ts
@@ -5,6 +5,7 @@
  * Tools: track, untrack, list, get, update — mapping to WorkItemDb CRUD.
  */
 
+import { resolve } from "node:path";
 import type { Logger, Manifest, ToolInfo, WorkItem, WorkItemPhase } from "@mcp-cli/core";
 import { WORK_ITEMS_SERVER_NAME, canTransition, consoleLogger } from "@mcp-cli/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -13,6 +14,14 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import type { WorkItemDb } from "./db/work-items";
+
+/** Narrow interface for alias_state operations — avoids coupling to full StateDb. */
+export interface PhaseStateStore {
+  getAliasState(repoRoot: string, namespace: string, key: string): unknown;
+  setAliasState(repoRoot: string, namespace: string, key: string, value: unknown): void;
+  deleteAliasState(repoRoot: string, namespace: string, key: string): boolean;
+  listAliasState(repoRoot: string, namespace: string): Record<string, unknown>;
+}
 
 /** Derived from the work_items_update inputSchema — single source of truth. */
 let _updateKnownKeys: ReadonlySet<string> | null = null;
@@ -142,6 +151,62 @@ const TOOLS = [
       required: ["id"],
     },
   },
+  {
+    name: "phase_state_get",
+    description: "Read a single key from a work item's phase-scoped key-value store.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        workItemId: { type: "string", description: "Work item ID" },
+        repoRoot: { type: "string", description: "Absolute path to repo root" },
+        key: { type: "string", description: "State key to read" },
+      },
+      required: ["workItemId", "repoRoot", "key"],
+    },
+  },
+  {
+    name: "phase_state_set",
+    description:
+      "Write a key to a work item's phase-scoped key-value store. Value must be JSON-serialisable and under 256 KB.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        workItemId: { type: "string", description: "Work item ID" },
+        repoRoot: { type: "string", description: "Absolute path to repo root" },
+        key: { type: "string", description: "State key to write" },
+        value: {
+          type: ["string", "number", "boolean", "object", "array", "null"] as const,
+          description: "JSON-serialisable value to store (max 256 KB). Use phase_state_delete to remove.",
+        },
+      },
+      required: ["workItemId", "repoRoot", "key", "value"],
+    },
+  },
+  {
+    name: "phase_state_delete",
+    description: "Delete a key from a work item's phase-scoped key-value store.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        workItemId: { type: "string", description: "Work item ID" },
+        repoRoot: { type: "string", description: "Absolute path to repo root" },
+        key: { type: "string", description: "State key to delete" },
+      },
+      required: ["workItemId", "repoRoot", "key"],
+    },
+  },
+  {
+    name: "phase_state_list",
+    description: "List all key-value pairs in a work item's phase-scoped key-value store.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        workItemId: { type: "string", description: "Work item ID" },
+        repoRoot: { type: "string", description: "Absolute path to repo root" },
+      },
+      required: ["workItemId", "repoRoot"],
+    },
+  },
 ] as const;
 
 export class WorkItemsServer {
@@ -160,6 +225,9 @@ export class WorkItemsServer {
   /** Resolves a PR number to its head branch name. Injected for testability. */
   private resolveBranchFromPr: ((prNumber: number) => Promise<string | null>) | null;
 
+  /** Optional store for phase-scoped state (alias_state table). */
+  private stateDb: PhaseStateStore | null;
+
   private logger: Logger;
 
   constructor(
@@ -168,6 +236,7 @@ export class WorkItemsServer {
       onTrack?: () => void;
       loadManifest?: (repoRoot: string) => Manifest | null;
       resolveBranchFromPr?: (prNumber: number) => Promise<string | null>;
+      stateDb?: PhaseStateStore;
       logger?: Logger;
     },
   ) {
@@ -175,6 +244,7 @@ export class WorkItemsServer {
     this.onTrack = opts?.onTrack ?? null;
     this.loadManifestFn = opts?.loadManifest ?? null;
     this.resolveBranchFromPr = opts?.resolveBranchFromPr ?? null;
+    this.stateDb = opts?.stateDb ?? null;
     this.logger = opts?.logger ?? consoleLogger;
   }
 
@@ -316,7 +386,7 @@ export class WorkItemsServer {
                 content: [
                   {
                     type: "text" as const,
-                    text: `Unknown keys: ${unknownKeys.join(", ")}. work_items_update only accepts known keys (${accepted}). Phase-namespace state (session_id, qa_session_id, etc.) is stored separately — use phase handler ctx.state to read/write it.`,
+                    text: `Unknown keys: ${unknownKeys.join(", ")}. work_items_update only accepts known keys (${accepted}). Phase-namespace state (session_id, qa_session_id, etc.) is stored separately — use phase_state_get/set/list tools to read/write it.`,
                   },
                 ],
                 isError: true,
@@ -325,7 +395,8 @@ export class WorkItemsServer {
 
             const force = a.force === true;
             const forceReason = a.forceReason !== undefined ? String(a.forceReason) : undefined;
-            const repoRoot = a.repoRoot !== undefined ? String(a.repoRoot) : undefined;
+            // Canonicalize to remove trailing slashes and resolve symlinks in the key
+            const repoRoot = a.repoRoot !== undefined ? resolve(String(a.repoRoot)) : undefined;
 
             // Validate phase if a new phase is being set
             if (a.phase !== undefined) {
@@ -402,6 +473,123 @@ export class WorkItemsServer {
             }
 
             return { content: [{ type: "text" as const, text: JSON.stringify(updated) }] };
+          }
+
+          case "phase_state_get": {
+            if (!this.stateDb) {
+              return {
+                content: [{ type: "text" as const, text: "Phase state not available (no stateDb configured)" }],
+                isError: true,
+              };
+            }
+            const workItemId = String(a.workItemId ?? "");
+            const repoRoot = a.repoRoot !== undefined ? resolve(String(a.repoRoot)) : "";
+            const key = String(a.key ?? "");
+            if (!workItemId || !repoRoot || !key) {
+              return {
+                content: [{ type: "text" as const, text: "workItemId, repoRoot, and key are required" }],
+                isError: true,
+              };
+            }
+            if (!this.workItemDb.getWorkItem(workItemId)) {
+              return {
+                content: [{ type: "text" as const, text: `Work item not found: ${workItemId}` }],
+                isError: true,
+              };
+            }
+            const ns = `workitem:${workItemId}`;
+            const value = this.stateDb.getAliasState(repoRoot, ns, key);
+            return { content: [{ type: "text" as const, text: JSON.stringify({ key, value }) }] };
+          }
+
+          case "phase_state_set": {
+            if (!this.stateDb) {
+              return {
+                content: [{ type: "text" as const, text: "Phase state not available (no stateDb configured)" }],
+                isError: true,
+              };
+            }
+            const workItemId = String(a.workItemId ?? "");
+            const repoRoot = a.repoRoot !== undefined ? resolve(String(a.repoRoot)) : "";
+            const key = String(a.key ?? "");
+            if (!workItemId || !repoRoot || !key) {
+              return {
+                content: [{ type: "text" as const, text: "workItemId, repoRoot, and key are required" }],
+                isError: true,
+              };
+            }
+            if (a.value === undefined) {
+              return {
+                content: [{ type: "text" as const, text: "value is required; use phase_state_delete to remove a key" }],
+                isError: true,
+              };
+            }
+            if (!this.workItemDb.getWorkItem(workItemId)) {
+              return {
+                content: [{ type: "text" as const, text: `Work item not found: ${workItemId}` }],
+                isError: true,
+              };
+            }
+            const ns = `workitem:${workItemId}`;
+            this.stateDb.setAliasState(repoRoot, ns, key, a.value);
+            return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true, key }) }] };
+          }
+
+          case "phase_state_delete": {
+            if (!this.stateDb) {
+              return {
+                content: [{ type: "text" as const, text: "Phase state not available (no stateDb configured)" }],
+                isError: true,
+              };
+            }
+            const workItemId = String(a.workItemId ?? "");
+            const repoRoot = a.repoRoot !== undefined ? resolve(String(a.repoRoot)) : "";
+            const key = String(a.key ?? "");
+            if (!workItemId || !repoRoot || !key) {
+              return {
+                content: [{ type: "text" as const, text: "workItemId, repoRoot, and key are required" }],
+                isError: true,
+              };
+            }
+            if (!this.workItemDb.getWorkItem(workItemId)) {
+              return {
+                content: [{ type: "text" as const, text: `Work item not found: ${workItemId}` }],
+                isError: true,
+              };
+            }
+            const ns = `workitem:${workItemId}`;
+            const deleted = this.stateDb.deleteAliasState(repoRoot, ns, key);
+            return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true, key, deleted }) }] };
+          }
+
+          case "phase_state_list": {
+            if (!this.stateDb) {
+              return {
+                content: [{ type: "text" as const, text: "Phase state not available (no stateDb configured)" }],
+                isError: true,
+              };
+            }
+            const workItemId = String(a.workItemId ?? "");
+            const repoRoot = a.repoRoot !== undefined ? resolve(String(a.repoRoot)) : "";
+            if (!workItemId || !repoRoot) {
+              return {
+                content: [{ type: "text" as const, text: "workItemId and repoRoot are required" }],
+                isError: true,
+              };
+            }
+            if (!this.workItemDb.getWorkItem(workItemId)) {
+              return {
+                content: [{ type: "text" as const, text: `Work item not found: ${workItemId}` }],
+                isError: true,
+              };
+            }
+            const ns = `workitem:${workItemId}`;
+            const entries = this.stateDb.listAliasState(repoRoot, ns);
+            return {
+              content: [
+                { type: "text" as const, text: JSON.stringify({ entries, count: Object.keys(entries).length }) },
+              ],
+            };
           }
 
           default:

--- a/packages/daemon/src/work-items-server.ts
+++ b/packages/daemon/src/work-items-server.ts
@@ -395,8 +395,9 @@ export class WorkItemsServer {
 
             const force = a.force === true;
             const forceReason = a.forceReason !== undefined ? String(a.forceReason) : undefined;
-            // Canonicalize to remove trailing slashes and resolve symlinks in the key
-            const repoRoot = a.repoRoot !== undefined ? resolve(String(a.repoRoot)) : undefined;
+            // Canonicalize to remove trailing slashes — validate non-empty before resolve to avoid cwd fallback
+            const rawRepoRootUpdate = a.repoRoot !== undefined ? String(a.repoRoot).trim() : undefined;
+            const repoRoot = rawRepoRootUpdate ? resolve(rawRepoRootUpdate) : undefined;
 
             // Validate phase if a new phase is being set
             if (a.phase !== undefined) {
@@ -483,7 +484,8 @@ export class WorkItemsServer {
               };
             }
             const workItemId = String(a.workItemId ?? "");
-            const repoRoot = a.repoRoot !== undefined ? resolve(String(a.repoRoot)) : "";
+            const rawRepoRoot = String(a.repoRoot ?? "").trim();
+            const repoRoot = rawRepoRoot ? resolve(rawRepoRoot) : "";
             const key = String(a.key ?? "");
             if (!workItemId || !repoRoot || !key) {
               return {
@@ -510,7 +512,8 @@ export class WorkItemsServer {
               };
             }
             const workItemId = String(a.workItemId ?? "");
-            const repoRoot = a.repoRoot !== undefined ? resolve(String(a.repoRoot)) : "";
+            const rawRepoRoot = String(a.repoRoot ?? "").trim();
+            const repoRoot = rawRepoRoot ? resolve(rawRepoRoot) : "";
             const key = String(a.key ?? "");
             if (!workItemId || !repoRoot || !key) {
               return {
@@ -543,7 +546,8 @@ export class WorkItemsServer {
               };
             }
             const workItemId = String(a.workItemId ?? "");
-            const repoRoot = a.repoRoot !== undefined ? resolve(String(a.repoRoot)) : "";
+            const rawRepoRoot = String(a.repoRoot ?? "").trim();
+            const repoRoot = rawRepoRoot ? resolve(rawRepoRoot) : "";
             const key = String(a.key ?? "");
             if (!workItemId || !repoRoot || !key) {
               return {
@@ -570,7 +574,8 @@ export class WorkItemsServer {
               };
             }
             const workItemId = String(a.workItemId ?? "");
-            const repoRoot = a.repoRoot !== undefined ? resolve(String(a.repoRoot)) : "";
+            const rawRepoRoot = String(a.repoRoot ?? "").trim();
+            const repoRoot = rawRepoRoot ? resolve(rawRepoRoot) : "";
             if (!workItemId || !repoRoot) {
               return {
                 content: [{ type: "text" as const, text: "workItemId and repoRoot are required" }],


### PR DESCRIPTION
## Summary

- Restores \`phase_state_get/set/delete/list\` tools to \`WorkItemsServer\` — these were accidentally dropped by PR #1491 (containment fix had a merge conflict that wiped the c3046f9 changes)
- Applies \`path.resolve()\` to \`repoRoot\` in all four \`phase_state\` handlers so trailing slashes land in the same \`alias_state\` row (e.g. \`/repo/path/\` and \`/repo/path\` → same row). Note: \`path.resolve()\` normalizes trailing slashes and \`.\`/\`..\` components only; symlink canonicalization is a separate concern tracked in #1517.
- Validates \`repoRoot\` is non-empty **before** calling \`resolve()\` so an empty string does not silently fall back to \`process.cwd()\`
- Applies \`path.resolve()\` to \`repoRoot\` in all four \`aliasState*\` IPC handlers in \`ipc-server.ts\`
- Re-wires \`stateDb: db\` injection into \`WorkItemsServer\` in \`index.ts\` (was also lost in the regression)
- Applies \`path.resolve()\` to \`repoRoot\` in \`work_items_update\` (used for manifest loading — same canonicalization gap)
- Adds startup migration to normalize any pre-fix \`alias_state\` rows that were written with trailing slashes

## Test plan

- [x] New test: \`phase_state_set\` with trailing-slash repoRoot, \`phase_state_get\` without — both hit the same row
- [x] New test: \`phase_state_set\` with empty repoRoot returns error (not cwd fallback)
- [x] Restored full phase_state test suite from c3046f9 (round-trip, namespace verification, parallel isolation, delete, list, error paths)
- [x] Updated tool-count assertions from 5 → 9 in both \`buildWorkItemsToolCache\` and \`listTools\` tests
- [x] New: \`aliasState.spec.ts\` — IPC-layer tests verifying aliasState handlers canonicalize trailing slashes end-to-end
- [x] phase_state tests now inject real \`StateDb\` (temp file) instead of re-implementing the interface in the test helper
- [x] \`bun typecheck\` passes
- [x] \`bun lint\` passes
- [x] \`bun test\` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)