### PR TITLE
feat(ipc): add streaming NDJSON event transport over Unix socket (fixes #1511)

### DIFF
--- a/packages/core/src/ipc-client.ts
+++ b/packages/core/src/ipc-client.ts
@@ -195,3 +195,53 @@ export function openLogStream(params: {
 
   return { entries: iterate(), abort: () => controller.abort() };
 }
+
+/**
+ * Open an NDJSON stream to the daemon's GET /events endpoint.
+ * Returns an async iterable of parsed event objects plus an abort function.
+ */
+export function openEventStream(params?: {
+  since?: number;
+}): { events: AsyncIterable<Record<string, unknown>>; abort: () => void } {
+  const qs = new URLSearchParams();
+  if (params?.since !== undefined) qs.set("since", String(params.since));
+
+  const controller = new AbortController();
+  const qsStr = qs.toString();
+  const url = `http://localhost/events${qsStr ? `?${qsStr}` : ""}`;
+
+  async function* iterate(): AsyncGenerator<Record<string, unknown>> {
+    const res = await fetch(url, {
+      method: "GET",
+      unix: options.SOCKET_PATH,
+      signal: controller.signal,
+    } as RequestInit);
+
+    if (!res.ok) {
+      throw new Error(`Event stream error: ${res.status} ${await res.text()}`);
+    }
+
+    const body = res.body;
+    if (!body) throw new Error("No response body");
+
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    for await (const chunk of body) {
+      buffer += decoder.decode(chunk as Uint8Array, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        if (!line) continue;
+        try {
+          yield JSON.parse(line) as Record<string, unknown>;
+        } catch {
+          // Skip malformed NDJSON lines
+        }
+      }
+    }
+  }
+
+  return { events: iterate(), abort: () => controller.abort() };
+}

--- a/packages/core/src/ipc-client.ts
+++ b/packages/core/src/ipc-client.ts
@@ -241,6 +241,15 @@ export function openEventStream(params?: {
         }
       }
     }
+    // Flush any trailing bytes buffered by the streaming decoder
+    const trailing = decoder.decode();
+    if (trailing) {
+      try {
+        yield JSON.parse(trailing) as Record<string, unknown>;
+      } catch {
+        // Ignore incomplete trailing data
+      }
+    }
   }
 
   return { events: iterate(), abort: () => controller.abort() };

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -2395,52 +2395,51 @@ describe("IpcServer HTTP transport", () => {
   });
 
   test("GET /events heartbeat fires after silence", async () => {
-    // Create server with short heartbeat for testing
     socketPath = tmpSocket();
     const origInterval = (IpcServer as unknown as Record<string, number>).HEARTBEAT_INTERVAL_MS;
 
     // Patch the static for this test — 200ms heartbeat
     Object.defineProperty(IpcServer, "HEARTBEAT_INTERVAL_MS", { value: 200, configurable: true });
 
-    server = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, opts());
-    server.start(socketPath);
+    try {
+      server = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, opts());
+      server.start(socketPath);
 
-    const controller = new AbortController();
-    const res = await fetch("http://localhost/events", {
-      method: "GET",
-      unix: socketPath,
-      signal: controller.signal,
-    } as RequestInit);
+      const controller = new AbortController();
+      const res = await fetch("http://localhost/events", {
+        method: "GET",
+        unix: socketPath,
+        signal: controller.signal,
+      } as RequestInit);
 
-    if (!res.body) throw new Error("Expected response body");
-    const reader = res.body.getReader();
-    const decoder = new TextDecoder();
+      if (!res.body) throw new Error("Expected response body");
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
 
-    // Wait for heartbeat
-    let buffer = "";
-    const deadline = Date.now() + 2_000;
-    while (Date.now() < deadline) {
-      const { value, done } = await reader.read();
-      if (done) break;
-      buffer += decoder.decode(value, { stream: true });
-      if (buffer.includes("heartbeat")) break;
+      // Wait for heartbeat
+      let buffer = "";
+      const deadline = Date.now() + 2_000;
+      while (Date.now() < deadline) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        if (buffer.includes("heartbeat")) break;
+      }
+
+      controller.abort();
+      reader.releaseLock();
+
+      const lines = buffer.split("\n").filter(Boolean);
+      const hbLine = lines.find((l) => l.includes('"heartbeat"'));
+      expect(hbLine).toBeDefined();
+      const hb = JSON.parse(hbLine as string) as Record<string, unknown>;
+      expect(hb.t).toBe("heartbeat");
+      expect(typeof hb.seq).toBe("number");
+    } finally {
+      Object.defineProperty(IpcServer, "HEARTBEAT_INTERVAL_MS", {
+        value: origInterval ?? 30_000,
+        configurable: true,
+      });
     }
-
-    controller.abort();
-    reader.releaseLock();
-
-    // Restore
-    Object.defineProperty(IpcServer, "HEARTBEAT_INTERVAL_MS", {
-      value: origInterval ?? 30_000,
-      configurable: true,
-    });
-
-    const lines = buffer.split("\n").filter(Boolean);
-    // Find heartbeat line (skip connected line)
-    const hbLine = lines.find((l) => l.includes('"heartbeat"'));
-    expect(hbLine).toBeDefined();
-    const hb = JSON.parse(hbLine as string) as Record<string, unknown>;
-    expect(hb.t).toBe("heartbeat");
-    expect(typeof hb.seq).toBe("number");
   });
 });

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -2330,17 +2330,68 @@ describe("IpcServer HTTP transport", () => {
     } as RequestInit);
 
     expect(res.status).toBe(200);
+    if (!server) throw new Error("server not started");
+    expect(server.eventSubscriberCount).toBe(1);
 
-    // Abort the stream
+    // Abort the stream and poll until cleanup propagates
     controller.abort();
-
-    // Give cleanup a tick to run
-    await new Promise((r) => setTimeout(r, 50));
+    await pollUntil(() => server?.eventSubscriberCount === 0);
 
     // Pushing an event after abort should not throw
-    if (!server) throw new Error("server not started");
     const s = server;
     expect(() => s.pushEvent({ t: "after-abort" })).not.toThrow();
+  });
+
+  test("GET /events ring buffer preserves FIFO order after overflow", async () => {
+    startServer();
+    if (!server) throw new Error("server not started");
+
+    const controller = new AbortController();
+    const res = await fetch("http://localhost/events", {
+      method: "GET",
+      unix: socketPath,
+      signal: controller.signal,
+    } as RequestInit);
+
+    if (!res.body) throw new Error("Expected response body");
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+
+    // Push capacity + 10 events (256 + 10 = 266) to force ring overflow
+    const CAPACITY = 256;
+    const TOTAL = CAPACITY + 10;
+    for (let i = 0; i < TOTAL; i++) {
+      server.pushEvent({ t: "overflow-test", n: i });
+    }
+
+    // Collect all lines (connected + TOTAL events; oldest 10 dropped, 256 remain)
+    let buffer = "";
+    const deadline = Date.now() + 3_000;
+    while (Date.now() < deadline) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const count = buffer.split("\n").filter(Boolean).length;
+      // connected + 256 events
+      if (count >= CAPACITY + 1) break;
+    }
+
+    controller.abort();
+    reader.releaseLock();
+
+    const lines = buffer
+      .split("\n")
+      .filter(Boolean)
+      .filter((l) => l.includes('"overflow-test"'));
+
+    expect(lines.length).toBe(CAPACITY);
+
+    // Events must arrive in ascending n order (FIFO, oldest surviving = n:10)
+    const ns = lines.map((l) => (JSON.parse(l) as Record<string, unknown>).n as number);
+    expect(ns[0]).toBe(10); // first 10 were dropped
+    for (let i = 1; i < ns.length; i++) {
+      expect(ns[i]).toBe((ns[i - 1] as number) + 1);
+    }
   });
 
   test("GET /events heartbeat fires after silence", async () => {

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -2165,4 +2165,231 @@ describe("IpcServer HTTP transport", () => {
       expect(item.phase).toBe("free-form");
     });
   });
+
+  // -- NDJSON /events endpoint tests --
+
+  test("GET /events returns NDJSON content-type", async () => {
+    startServer();
+
+    const controller = new AbortController();
+    const res = await fetch("http://localhost/events", {
+      method: "GET",
+      unix: socketPath,
+      signal: controller.signal,
+    } as RequestInit);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("application/x-ndjson");
+
+    controller.abort();
+  });
+
+  test("GET /events delivers pushed events as NDJSON lines", async () => {
+    startServer();
+
+    const controller = new AbortController();
+    const res = await fetch("http://localhost/events", {
+      method: "GET",
+      unix: socketPath,
+      signal: controller.signal,
+    } as RequestInit);
+
+    expect(res.status).toBe(200);
+    if (!res.body) throw new Error("Expected response body");
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+
+    // Push a synthetic event
+    if (!server) throw new Error("server not started");
+    server.pushEvent({ t: "test", data: "hello" });
+
+    let buffer = "";
+    const deadline = Date.now() + 2_000;
+    while (Date.now() < deadline) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      if (buffer.includes("hello")) break;
+    }
+
+    controller.abort();
+    reader.releaseLock();
+
+    const lines = buffer.split("\n").filter(Boolean);
+    // First line is the "connected" event, second is our pushed event
+    expect(lines.length).toBeGreaterThanOrEqual(2);
+    const connected = JSON.parse(lines[0] as string) as Record<string, unknown>;
+    expect(connected.t).toBe("connected");
+    const parsed = JSON.parse(lines[1] as string) as Record<string, unknown>;
+    expect(parsed.t).toBe("test");
+    expect(parsed.data).toBe("hello");
+    expect(typeof parsed.seq).toBe("number");
+    expect(parsed.seq).toBe(1);
+  });
+
+  test("GET /events supports multiple concurrent subscribers", async () => {
+    startServer();
+
+    const controllers = [new AbortController(), new AbortController()];
+    const responses = await Promise.all(
+      controllers.map((c) =>
+        fetch("http://localhost/events", {
+          method: "GET",
+          unix: socketPath,
+          signal: c.signal,
+        } as RequestInit),
+      ),
+    );
+
+    for (const res of responses) {
+      expect(res.status).toBe(200);
+    }
+
+    const readers = responses.map((r) => {
+      if (!r.body) throw new Error("Expected response body");
+      return r.body.getReader();
+    });
+    const decoder = new TextDecoder();
+
+    if (!server) throw new Error("server not started");
+    server.pushEvent({ t: "broadcast", value: 42 });
+
+    for (const reader of readers) {
+      let buffer = "";
+      const deadline = Date.now() + 2_000;
+      while (Date.now() < deadline) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        if (buffer.includes("broadcast")) break;
+      }
+      const lines = buffer.split("\n").filter(Boolean);
+      // Find the broadcast event (skip connected line)
+      const broadcastLine = lines.find((l) => l.includes("broadcast"));
+      expect(broadcastLine).toBeDefined();
+      const parsed = JSON.parse(broadcastLine as string) as Record<string, unknown>;
+      expect(parsed.t).toBe("broadcast");
+      expect(parsed.value).toBe(42);
+      reader.releaseLock();
+    }
+
+    for (const c of controllers) c.abort();
+  });
+
+  test("GET /events assigns monotonically increasing seq numbers", async () => {
+    startServer();
+
+    const controller = new AbortController();
+    const res = await fetch("http://localhost/events", {
+      method: "GET",
+      unix: socketPath,
+      signal: controller.signal,
+    } as RequestInit);
+
+    if (!res.body) throw new Error("Expected response body");
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+
+    if (!server) throw new Error("server not started");
+    server.pushEvent({ t: "a" });
+    server.pushEvent({ t: "b" });
+    server.pushEvent({ t: "c" });
+
+    let buffer = "";
+    const deadline = Date.now() + 2_000;
+    while (Date.now() < deadline) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const linesSoFar = buffer.split("\n").filter(Boolean);
+      // connected + 3 events = 4 lines
+      if (linesSoFar.length >= 4) break;
+    }
+
+    controller.abort();
+    reader.releaseLock();
+
+    const lines = buffer.split("\n").filter(Boolean);
+    // Skip connected line, take the 3 event lines
+    const eventLines = lines.filter((l) => !l.includes('"connected"'));
+    expect(eventLines.length).toBeGreaterThanOrEqual(3);
+    const seqs = eventLines.map((l) => (JSON.parse(l) as Record<string, unknown>).seq as number);
+    expect(seqs[0]).toBeLessThan(seqs[1] as number);
+    expect(seqs[1]).toBeLessThan(seqs[2] as number);
+  });
+
+  test("GET /events cleans up subscriber on abort", async () => {
+    startServer();
+
+    const controller = new AbortController();
+    const res = await fetch("http://localhost/events", {
+      method: "GET",
+      unix: socketPath,
+      signal: controller.signal,
+    } as RequestInit);
+
+    expect(res.status).toBe(200);
+
+    // Abort the stream
+    controller.abort();
+
+    // Give cleanup a tick to run
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Pushing an event after abort should not throw
+    if (!server) throw new Error("server not started");
+    const s = server;
+    expect(() => s.pushEvent({ t: "after-abort" })).not.toThrow();
+  });
+
+  test("GET /events heartbeat fires after silence", async () => {
+    // Create server with short heartbeat for testing
+    socketPath = tmpSocket();
+    const origInterval = (IpcServer as unknown as Record<string, number>).HEARTBEAT_INTERVAL_MS;
+
+    // Patch the static for this test — 200ms heartbeat
+    Object.defineProperty(IpcServer, "HEARTBEAT_INTERVAL_MS", { value: 200, configurable: true });
+
+    server = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, opts());
+    server.start(socketPath);
+
+    const controller = new AbortController();
+    const res = await fetch("http://localhost/events", {
+      method: "GET",
+      unix: socketPath,
+      signal: controller.signal,
+    } as RequestInit);
+
+    if (!res.body) throw new Error("Expected response body");
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+
+    // Wait for heartbeat
+    let buffer = "";
+    const deadline = Date.now() + 2_000;
+    while (Date.now() < deadline) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      if (buffer.includes("heartbeat")) break;
+    }
+
+    controller.abort();
+    reader.releaseLock();
+
+    // Restore
+    Object.defineProperty(IpcServer, "HEARTBEAT_INTERVAL_MS", {
+      value: origInterval ?? 30_000,
+      configurable: true,
+    });
+
+    const lines = buffer.split("\n").filter(Boolean);
+    // Find heartbeat line (skip connected line)
+    const hbLine = lines.find((l) => l.includes('"heartbeat"'));
+    expect(hbLine).toBeDefined();
+    const hb = JSON.parse(hbLine as string) as Record<string, unknown>;
+    expect(hb.t).toBe("heartbeat");
+    expect(typeof hb.seq).toBe("number");
+  });
 });

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -118,6 +118,10 @@ export class IpcServer {
   private startedAt: number;
   private logger: Logger;
 
+  /** Event stream infrastructure */
+  private eventSeq = 0;
+  private eventSubscribers = new Set<(event: Record<string, unknown>) => void>();
+
   constructor(
     private pool: ServerPool,
     private config: ResolvedConfig,
@@ -193,6 +197,11 @@ export class IpcServer {
         // GET /logs — SSE stream for real-time log tailing
         if (url.pathname === "/logs" && req.method === "GET") {
           return self.handleLogsSSE(url);
+        }
+
+        // GET /events — NDJSON stream for real-time event delivery
+        if (url.pathname === "/events" && req.method === "GET") {
+          return self.handleEventsNDJSON(url);
         }
 
         if (req.method !== "POST") {
@@ -1239,6 +1248,131 @@ export class IpcServer {
       this.draining = true;
       this.startDrainTimeout();
       return { ok: true };
+    });
+  }
+
+  /**
+   * Push an event to all connected NDJSON event stream subscribers.
+   * Each event is assigned a monotonically increasing sequence number.
+   * The envelope shape is `{ t: string, seq: number, ...payload }` —
+   * callers supply the full object including `t`.
+   */
+  pushEvent(event: Record<string, unknown>): void {
+    const seq = ++this.eventSeq;
+    const envelope = { ...event, seq };
+    for (const cb of this.eventSubscribers) {
+      cb(envelope);
+    }
+  }
+
+  /** Current event sequence number (for testing / status). */
+  get currentEventSeq(): number {
+    return this.eventSeq;
+  }
+
+  private static readonly EVENT_RING_CAPACITY = 256;
+  private static readonly HEARTBEAT_INTERVAL_MS = 30_000;
+
+  /**
+   * Handle GET /events — NDJSON stream for real-time event delivery.
+   *
+   * Query params:
+   *   since=<seq>  — reserved for future replay (#1513), currently ignored
+   */
+  private handleEventsNDJSON(_url: URL): Response {
+    const capacity = IpcServer.EVENT_RING_CAPACITY;
+    const ring: string[] = new Array(capacity);
+    let writeIdx = 0;
+    let dropped = 0;
+    let pending = false;
+    let unsubscribe: (() => void) | undefined;
+    let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+    let lastWriteTime = Date.now();
+
+    const encoder = new TextEncoder();
+
+    const stream = new ReadableStream({
+      start: (controller) => {
+        const flush = () => {
+          if (!pending) return;
+          pending = false;
+          const count = dropped > 0 ? capacity : writeIdx;
+          const start = dropped > 0 ? writeIdx : 0;
+          for (let i = 0; i < count; i++) {
+            const line = ring[(start + i) % capacity] as string;
+            try {
+              controller.enqueue(encoder.encode(line));
+            } catch {
+              cleanup();
+              return;
+            }
+          }
+          writeIdx = 0;
+          dropped = 0;
+        };
+
+        const enqueue = (line: string) => {
+          if (writeIdx < capacity) {
+            ring[writeIdx++] = line;
+          } else {
+            ring[dropped % capacity] = line;
+            dropped++;
+          }
+          pending = true;
+          lastWriteTime = Date.now();
+          queueMicrotask(flush);
+        };
+
+        const cleanup = () => {
+          unsubscribe?.();
+          unsubscribe = undefined;
+          if (heartbeatTimer !== undefined) {
+            clearInterval(heartbeatTimer);
+            heartbeatTimer = undefined;
+          }
+        };
+
+        // Flush a "connected" line to force response headers out immediately
+        controller.enqueue(encoder.encode(`${JSON.stringify({ t: "connected", seq: this.eventSeq })}\n`));
+        lastWriteTime = Date.now();
+
+        const subscriber = (event: Record<string, unknown>) => {
+          enqueue(`${JSON.stringify(event)}\n`);
+        };
+
+        this.eventSubscribers.add(subscriber);
+        unsubscribe = () => {
+          this.eventSubscribers.delete(subscriber);
+        };
+
+        heartbeatTimer = setInterval(() => {
+          if (Date.now() - lastWriteTime >= IpcServer.HEARTBEAT_INTERVAL_MS) {
+            const hb = `${JSON.stringify({ t: "heartbeat", seq: this.eventSeq })}\n`;
+            try {
+              controller.enqueue(encoder.encode(hb));
+              lastWriteTime = Date.now();
+            } catch {
+              cleanup();
+            }
+          }
+        }, IpcServer.HEARTBEAT_INTERVAL_MS);
+      },
+      cancel: () => {
+        unsubscribe?.();
+        if (heartbeatTimer !== undefined) {
+          clearInterval(heartbeatTimer);
+          heartbeatTimer = undefined;
+        }
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        "content-type": "application/x-ndjson",
+        "transfer-encoding": "chunked",
+        "cache-control": "no-cache",
+        connection: "keep-alive",
+      },
     });
   }
 

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -1260,14 +1260,26 @@ export class IpcServer {
   pushEvent(event: Record<string, unknown>): void {
     const seq = ++this.eventSeq;
     const envelope = { ...event, seq };
+    const failed: ((event: Record<string, unknown>) => void)[] = [];
     for (const cb of this.eventSubscribers) {
-      cb(envelope);
+      try {
+        cb(envelope);
+      } catch (err) {
+        this.logger.warn(`[events] subscriber threw, dropping: ${err}`);
+        failed.push(cb);
+      }
     }
+    for (const cb of failed) this.eventSubscribers.delete(cb);
   }
 
   /** Current event sequence number (for testing / status). */
   get currentEventSeq(): number {
     return this.eventSeq;
+  }
+
+  /** Number of active event stream subscribers (for testing). */
+  get eventSubscriberCount(): number {
+    return this.eventSubscribers.size;
   }
 
   private static readonly EVENT_RING_CAPACITY = 256;
@@ -1291,13 +1303,23 @@ export class IpcServer {
 
     const encoder = new TextEncoder();
 
+    // Hoisted so both start and cancel can share it
+    const cleanup = () => {
+      unsubscribe?.();
+      unsubscribe = undefined;
+      if (heartbeatTimer !== undefined) {
+        clearInterval(heartbeatTimer);
+        heartbeatTimer = undefined;
+      }
+    };
+
     const stream = new ReadableStream({
       start: (controller) => {
         const flush = () => {
           if (!pending) return;
           pending = false;
           const count = dropped > 0 ? capacity : writeIdx;
-          const start = dropped > 0 ? writeIdx : 0;
+          const start = dropped > 0 ? dropped % capacity : 0;
           for (let i = 0; i < count; i++) {
             const line = ring[(start + i) % capacity] as string;
             try {
@@ -1321,15 +1343,6 @@ export class IpcServer {
           pending = true;
           lastWriteTime = Date.now();
           queueMicrotask(flush);
-        };
-
-        const cleanup = () => {
-          unsubscribe?.();
-          unsubscribe = undefined;
-          if (heartbeatTimer !== undefined) {
-            clearInterval(heartbeatTimer);
-            heartbeatTimer = undefined;
-          }
         };
 
         // Flush a "connected" line to force response headers out immediately
@@ -1356,14 +1369,9 @@ export class IpcServer {
             }
           }
         }, IpcServer.HEARTBEAT_INTERVAL_MS);
+        heartbeatTimer.unref();
       },
-      cancel: () => {
-        unsubscribe?.();
-        if (heartbeatTimer !== undefined) {
-          clearInterval(heartbeatTimer);
-          heartbeatTimer = undefined;
-        }
-      },
+      cancel: cleanup,
     });
 
     return new Response(stream, {


### PR DESCRIPTION
## Summary
- Adds `GET /events` NDJSON streaming endpoint to the daemon IPC server with 30s heartbeat, bounded ring buffer (256 slots, drop-oldest) for back-pressure, and multiple concurrent subscriber support
- Adds `openEventStream()` client helper in `@mcp-cli/core` that returns an `AsyncIterable<Record<string, unknown>>` with abort support
- Envelope shape `{ t: string, seq: number, ...payload }` designed to be extensible for #1512's `MonitorEvent` wrapper without breaking the wire format

## Test plan
- [x] `GET /events` returns 200 with `content-type: application/x-ndjson`
- [x] Initial `connected` line flushed on stream open (proves headers sent immediately)
- [x] Pushed synthetic events received as valid NDJSON with monotonically increasing `seq`
- [x] Multiple concurrent subscribers both receive broadcast events
- [x] Heartbeat fires after idle period with `{ t: "heartbeat", seq: <latest> }`
- [x] Clean subscriber cleanup on abort — no leaked timers, no throw on post-abort push
- [x] Full suite: 5353 tests pass, typecheck clean, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)