### PR TITLE
feat(sites): add OWA seed with jq transforms and fetch filter (fixes #1455)

### DIFF
--- a/packages/daemon/src/site/seeds.spec.ts
+++ b/packages/daemon/src/site/seeds.spec.ts
@@ -42,3 +42,36 @@ describe("built-in teams seed", () => {
     }
   });
 });
+
+describe("built-in owa seed", () => {
+  test("listSites includes owa with merged seed config", () => {
+    const names = listSites().map((s) => s.name);
+    expect(names).toContain("owa");
+    const owa = getSite("owa");
+    expect(owa?.url).toBe("https://outlook.cloud.microsoft/mail/");
+    expect(owa?.domains).toContain("*.outlook.cloud.microsoft");
+    expect(owa?.domains).toContain("substrate.office.com");
+    expect(owa?.browser?.engine).toBe("playwright");
+  });
+
+  test("loadCatalog seeds owa catalog on first read", () => {
+    const catalog = loadCatalog("owa", "owa");
+    const names = Object.keys(catalog);
+    expect(names).toContain("inbox");
+    expect(names).toContain("read_mail");
+    for (const call of Object.values(catalog)) {
+      expect(call.name).toBeTruthy();
+      expect(call.url).toMatch(/^https?:\/\//);
+      expect(call.method).toBe("POST");
+    }
+  });
+
+  test("all owa calls declare fetchFilter and jq transforms", () => {
+    const catalog = loadCatalog("owa", "owa");
+    for (const call of Object.values(catalog)) {
+      expect(call.fetchFilter).toBe("owa-urlpostdata");
+      expect(call.jq_input).toBeTruthy();
+      expect(call.jq_output).toBeTruthy();
+    }
+  });
+});

--- a/packages/daemon/src/site/seeds/owa/catalog.json
+++ b/packages/daemon/src/site/seeds/owa/catalog.json
@@ -1,0 +1,93 @@
+{
+  "inbox": {
+    "name": "inbox",
+    "url": "https://outlook.cloud.microsoft/owa/service.svc?action=FindConversation&app=Mail",
+    "method": "POST",
+    "description": "List inbox conversations, newest first.",
+    "paramDocs": {
+      "count": "optional — max conversations, default 20",
+      "offset": "optional — pagination offset, default 0"
+    },
+    "headers": {
+      "x-owa-canary": "",
+      "x-req-source": "Mail"
+    },
+    "audHints": ["outlook.cloud.microsoft"],
+    "fetchFilter": "owa-urlpostdata",
+    "jq_input": ".params as $p | { Header: { RequestServerVersion: \"V2018_01_08\", TimeZoneContext: { TimeZoneDefinition: { Id: \"UTC\" } } }, Body: { SortOrder: [{ Order: \"Descending\", Path: { FieldURI: \"DateTimeReceived\", __type: \"PropertyUri:#Exchange\" }, __type: \"SortResults:#Exchange\" }], ParentFolderId: { BaseFolderId: { __type: \"DistinguishedFolderId:#Exchange\", Id: \"inbox\" } }, MailboxScope: \"PrimaryOnly\", ConversationShape: { BaseShape: \"IdOnly\", AdditionalProperties: [{ FieldURI: \"ConversationTopic\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"ConversationLastDeliveryTime\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"ConversationUniqueSenders\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"ConversationPreview\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"ConversationHasAttachments\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"ConversationFlagStatus\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"ConversationUnreadCount\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"ConversationMessageCount\", __type: \"PropertyUri:#Exchange\" }] }, Paging: { __type: \"IndexedPageView:#Exchange\", BasePoint: \"Beginning\", Offset: ($p.offset // 0), MaxEntriesReturned: ($p.count // 20) } } }",
+    "jq_output": "{ total: .Body.TotalConversationsInView, conversations: [.Body.Conversations[]? | { id: .ConversationId.Id, topic: .ConversationTopic, from: ([.UniqueSenders[]?] | join(\", \")), preview: .Preview, received: .LastDeliveryTime, unread: .UnreadCount, messages: .MessageCount, hasAttachments: .HasAttachments, flagged: (.FlagStatus == \"Flagged\") }] }"
+  },
+  "read_mail": {
+    "name": "read_mail",
+    "url": "https://outlook.cloud.microsoft/owa/service.svc?action=GetConversationItems&app=Mail",
+    "method": "POST",
+    "description": "Fetch all items in a conversation thread.",
+    "paramDocs": {
+      "conversationId": "required — ConversationId from inbox results"
+    },
+    "headers": {
+      "x-owa-canary": "",
+      "x-req-source": "Mail"
+    },
+    "audHints": ["outlook.cloud.microsoft"],
+    "fetchFilter": "owa-urlpostdata",
+    "jq_input": ".params as $p | { Header: { RequestServerVersion: \"V2018_01_08\", TimeZoneContext: { TimeZoneDefinition: { Id: \"UTC\" } } }, Body: { Conversations: [{ ConversationId: { Id: $p.conversationId } }], ItemShape: { BaseShape: \"IdOnly\", AdditionalProperties: [{ FieldURI: \"ItemBody\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"From\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"Sender\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"Subject\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"DateTimeReceived\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"DateTimeSent\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"HasAttachments\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"Importance\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"IsRead\", __type: \"PropertyUri:#Exchange\" }], BodyType: \"Text\" }, MaxItemsToReturn: 50, SortOrder: \"DateOrderAscending\" } }",
+    "jq_output": "{ conversation: [.Body.Conversations[0]?.ConversationNodes[]?.Items[]? | { id: .ItemId.Id, subject: .Subject, from: .From.Mailbox.Name, email: .From.Mailbox.EmailAddress, sent: .DateTimeSent, body: .Body.Value, importance: .Importance, read: .IsRead, hasAttachments: .HasAttachments }] }"
+  },
+  "react_to_mail": {
+    "name": "react_to_mail",
+    "url": "https://outlook.cloud.microsoft/owa/service.svc?action=PerformReactionOperation&app=Mail",
+    "method": "POST",
+    "description": "React to a mail item (like, love, celebrate, laugh, sad, angry).",
+    "paramDocs": {
+      "itemId": "required — ItemId of the message",
+      "reaction": "required — one of: like, heart, celebrate, laugh, sad, angry",
+      "action": "optional — 'add' (default) or 'remove'"
+    },
+    "headers": {
+      "x-owa-canary": "",
+      "x-req-source": "Mail"
+    },
+    "audHints": ["outlook.cloud.microsoft"],
+    "fetchFilter": "owa-urlpostdata",
+    "jq_input": ".params as $p | { Header: { RequestServerVersion: \"V2018_01_08\" }, Body: { ItemId: { Id: $p.itemId }, ReactionType: $p.reaction, Action: ($p.action // \"add\") } }",
+    "jq_output": "{ success: (.Body.ResponseClass == \"Success\") }"
+  },
+  "respond_meeting": {
+    "name": "respond_meeting",
+    "url": "https://outlook.cloud.microsoft/owa/service.svc?action=RespondToCalendarEvent&app=Mail",
+    "method": "POST",
+    "description": "Accept, tentatively accept, or decline a meeting invitation.",
+    "paramDocs": {
+      "itemId": "required — ItemId of the meeting request",
+      "response": "required — one of: Accept, TentativelyAccept, Decline",
+      "message": "optional — response message body"
+    },
+    "headers": {
+      "x-owa-canary": "",
+      "x-req-source": "Mail"
+    },
+    "audHints": ["outlook.cloud.microsoft"],
+    "fetchFilter": "owa-urlpostdata",
+    "jq_input": ".params as $p | { Header: { RequestServerVersion: \"V2018_01_08\" }, Body: { EventId: { Id: $p.itemId }, Response: $p.response, SendResponse: true, Body: (if $p.message then { Value: $p.message, BodyType: \"Text\" } else null end) } }",
+    "jq_output": "{ success: (.Body.ResponseClass == \"Success\") }"
+  },
+  "trash_conversation": {
+    "name": "trash_conversation",
+    "url": "https://outlook.cloud.microsoft/owa/service.svc?action=ApplyConversationAction&app=Mail",
+    "method": "POST",
+    "description": "Move a conversation to trash, mark as read, or flag it.",
+    "paramDocs": {
+      "conversationId": "required — ConversationId from inbox results",
+      "action": "optional — 'delete' (default), 'read', or 'flag'"
+    },
+    "headers": {
+      "x-owa-canary": "",
+      "x-req-source": "Mail"
+    },
+    "audHints": ["outlook.cloud.microsoft"],
+    "fetchFilter": "owa-urlpostdata",
+    "jq_input": ".params as $p | { Header: { RequestServerVersion: \"V2018_01_08\" }, Body: { ConversationActions: [{ Action: (if $p.action == \"read\" then \"AlwaysMove\" elif $p.action == \"flag\" then \"Flag\" else \"Move\" end), ConversationId: { Id: $p.conversationId }, DestinationFolderId: (if ($p.action // \"delete\") == \"delete\" then { BaseFolderId: { __type: \"DistinguishedFolderId:#Exchange\", Id: \"deleteditems\" } } else null end), IsRead: (if $p.action == \"read\" then true else null end), Flag: (if $p.action == \"flag\" then { FlagStatus: \"Flagged\", __type: \"FlagType:#Exchange\" } else null end) }] } }",
+    "jq_output": "{ success: (.Body.ResponseClass == \"Success\") }"
+  }
+}

--- a/packages/daemon/src/site/seeds/owa/config.json
+++ b/packages/daemon/src/site/seeds/owa/config.json
@@ -1,0 +1,11 @@
+{
+  "url": "https://outlook.cloud.microsoft/mail/",
+  "domains": ["*.outlook.cloud.microsoft", "outlook.cloud.microsoft", "substrate.office.com"],
+  "captureMode": "filtered",
+  "captureFilters": {
+    "match": ["owa/service\\.svc", "searchservice"],
+    "skip": ["telemetry", "sessiondata", "pimg"]
+  },
+  "wiggle": "wiggle.js",
+  "seed": "owa"
+}

--- a/packages/daemon/src/site/seeds/owa/wiggle.js
+++ b/packages/daemon/src/site/seeds/owa/wiggle.js
@@ -1,0 +1,35 @@
+/**
+ * OWA wiggle sequence: navigate to inbox to refresh auth tokens.
+ *
+ * @param {import('playwright').Page} page
+ * @returns {Promise<string[]>} touched token families
+ */
+module.exports = async function wiggle(page) {
+  const touched = [];
+
+  try {
+    await page.goto("https://outlook.cloud.microsoft/mail/", {
+      waitUntil: "domcontentloaded",
+      timeout: 10000,
+    });
+    await page.waitForTimeout(3000);
+    touched.push("inbox");
+  } catch {}
+
+  try {
+    const compose = page.locator('[aria-label="New mail"]').first();
+    if ((await compose.count()) > 0) {
+      await compose.click({ timeout: 2000 });
+      await page.waitForTimeout(1000);
+      touched.push("compose");
+
+      const discard = page.locator('[aria-label="Discard"]').first();
+      if ((await discard.count()) > 0) {
+        await discard.click({ timeout: 2000 });
+        await page.waitForTimeout(500);
+      }
+    }
+  } catch {}
+
+  return touched;
+};


### PR DESCRIPTION
## Summary
- Adds built-in OWA seed (`packages/daemon/src/site/seeds/owa/`) with config, catalog, and wiggle script
- Catalog includes 5 named calls: `inbox`, `read_mail`, `react_to_mail`, `respond_meeting`, `trash_conversation` — all using `jq_input`/`jq_output` for request/response shaping and `fetchFilter: "owa-urlpostdata"` for OWA's header-encoded body convention
- The `jq_input`, `jq_output`, and `fetchFilter` infrastructure was already implemented and wired in `site-worker.ts` → `transforms.ts`; this PR adds the seed that exercises it for Outlook

## Test plan
- [x] New seed tests in `seeds.spec.ts`: site config loads correctly, catalog contains expected calls, all calls declare fetchFilter + jq transforms
- [x] Existing transforms tests pass (16/16) — `applyJqInput`, `applyFetchFilter`, `applyJqOutput` all green
- [x] Full test suite passes (5350/5350, 0 failures)
- [x] Typecheck clean, lint clean
- [ ] Manual: `mcx site call owa inbox` returns shaped conversation list on a logged-in session

🤖 Generated with [Claude Code](https://claude.com/claude-code)