### PR TITLE
fix(work-items): null clears nullable fields instead of coercing to 0 or "null" (fixes #1505)

### DIFF
--- a/packages/daemon/src/work-items-server.spec.ts
+++ b/packages/daemon/src/work-items-server.spec.ts
@@ -802,7 +802,7 @@ describe("WorkItemsServer", () => {
     expect(final?.branch).toBe("explicit/winner");
   });
 
-  test("work_items_update treats branch=null as absent (no 'null' string coercion)", async () => {
+  test("work_items_update branch=null clears the branch field (#1505)", async () => {
     const { db, raw } = createWorkItemDb();
     rawDb = raw;
     server = new WorkItemsServer(db);
@@ -812,8 +812,6 @@ describe("WorkItemsServer", () => {
       arguments: { issueNumber: 55, branch: "feat/existing" },
     });
 
-    // Sending `branch: null` must not overwrite the existing branch with the
-    // literal string "null" (round-3 Copilot inline comment).
     const result = await client.callTool({
       name: "work_items_update",
       arguments: { id: "issue:55", branch: null, ciStatus: "passed" },
@@ -822,8 +820,57 @@ describe("WorkItemsServer", () => {
     expect(result.isError).toBeFalsy();
     const content = result.content as Array<{ type: string; text: string }>;
     const item = JSON.parse(content[0].text);
-    expect(item.branch).toBe("feat/existing");
+    // null clears the field — does NOT persist the literal string "null"
+    expect(item.branch).toBeNull();
     expect(item.ciStatus).toBe("passed");
+  });
+
+  test("work_items_update prNumber=null clears the prNumber field (#1505)", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    server = new WorkItemsServer(db);
+    const { client } = await server.start();
+    await client.callTool({ name: "work_items_track", arguments: { prNumber: 999 } });
+
+    const result = await client.callTool({
+      name: "work_items_update",
+      arguments: { id: "pr:999", prNumber: null, prState: null },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const content = result.content as Array<{ type: string; text: string }>;
+    const item = JSON.parse(content[0].text);
+    // null must clear to SQL NULL, not coerce to 0 or the string "null"
+    expect(item.prNumber).toBeNull();
+    expect(item.prState).toBeNull();
+  });
+
+  test("work_items_update nullable fields coerce to null, not 0 or 'null' (#1505)", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    server = new WorkItemsServer(db);
+    const { client } = await server.start();
+    // Track by issue only so the ID is "issue:88"
+    await client.callTool({ name: "work_items_track", arguments: { issueNumber: 88 } });
+    // Set some nullable fields to non-null values first
+    await client.callTool({
+      name: "work_items_update",
+      arguments: { id: "issue:88", prNumber: 42, ciRunId: 7, ciSummary: "ok", prUrl: "https://example.com/42" },
+    });
+
+    // Now clear them all with null
+    const result = await client.callTool({
+      name: "work_items_update",
+      arguments: { id: "issue:88", prNumber: null, ciRunId: null, ciSummary: null, prUrl: null },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const content = result.content as Array<{ type: string; text: string }>;
+    const item = JSON.parse(content[0].text);
+    expect(item.prNumber).toBeNull();
+    expect(item.ciRunId).toBeNull();
+    expect(item.ciSummary).toBeNull();
+    expect(item.prUrl).toBeNull();
   });
 
   test("work_items_track auto-populates branch from prNumber (#1449)", async () => {

--- a/packages/daemon/src/work-items-server.ts
+++ b/packages/daemon/src/work-items-server.ts
@@ -121,23 +121,26 @@ const TOOLS = [
           type: "string",
           description: "Human-readable reason recorded in the transition log when force=true.",
         },
-        prNumber: { type: "number", description: "PR number" },
-        prState: { type: "string", enum: ["draft", "open", "merged", "closed"], description: "PR state" },
-        prUrl: { type: "string", description: "PR URL" },
+        prNumber: { type: ["number", "null"], description: "PR number; null clears the field" },
+        prState: {
+          anyOf: [{ type: "string", enum: ["draft", "open", "merged", "closed"] }, { type: "null" }],
+          description: "PR state; null clears the field",
+        },
+        prUrl: { type: ["string", "null"], description: "PR URL; null clears the field" },
         ciStatus: {
           type: "string",
           enum: ["none", "pending", "running", "passed", "failed"],
           description: "CI status",
         },
-        ciRunId: { type: "number", description: "CI run ID" },
-        ciSummary: { type: "string", description: "CI summary text" },
+        ciRunId: { type: ["number", "null"], description: "CI run ID; null clears the field" },
+        ciSummary: { type: ["string", "null"], description: "CI summary text; null clears the field" },
         reviewStatus: {
           type: "string",
           enum: ["none", "pending", "approved", "changes_requested"],
           description: "Review status",
         },
-        branch: { type: "string", description: "Branch name" },
-        issueNumber: { type: "number", description: "Issue number" },
+        branch: { type: ["string", "null"], description: "Branch name; null clears the field" },
+        issueNumber: { type: ["number", "null"], description: "Issue number; null clears the field" },
       },
       required: ["id"],
     },
@@ -373,17 +376,21 @@ export class WorkItemsServer {
 
             const patch: Partial<WorkItem> = {};
             if (a.phase !== undefined) patch.phase = String(a.phase) as WorkItemPhase;
-            if (a.prNumber !== undefined) patch.prNumber = requireInt(a.prNumber, "prNumber");
-            if (a.prState !== undefined) patch.prState = String(a.prState) as WorkItem["prState"];
-            if (a.prUrl !== undefined) patch.prUrl = String(a.prUrl);
-            if (a.ciStatus !== undefined) patch.ciStatus = String(a.ciStatus) as WorkItem["ciStatus"];
-            if (a.ciRunId !== undefined) patch.ciRunId = requireInt(a.ciRunId, "ciRunId");
-            if (a.ciSummary !== undefined) patch.ciSummary = String(a.ciSummary);
-            if (a.reviewStatus !== undefined) patch.reviewStatus = String(a.reviewStatus) as WorkItem["reviewStatus"];
-            // Treat `null` the same as absent — otherwise String(null) persists the literal
-            // string "null" as the branch (round-3 Copilot inline comment).
-            if (a.branch != null) patch.branch = String(a.branch);
-            if (a.issueNumber !== undefined) patch.issueNumber = requireInt(a.issueNumber, "issueNumber");
+            // For nullable fields: explicit null clears the field (stores SQL NULL).
+            // undefined means "not provided — leave unchanged".
+            if (a.prNumber !== undefined)
+              patch.prNumber = a.prNumber === null ? null : requireInt(a.prNumber, "prNumber");
+            if (a.prState !== undefined)
+              patch.prState = a.prState === null ? null : (String(a.prState) as WorkItem["prState"]);
+            if (a.prUrl !== undefined) patch.prUrl = a.prUrl === null ? null : String(a.prUrl);
+            // ciStatus and reviewStatus are non-nullable (default "none"); skip null.
+            if (a.ciStatus != null) patch.ciStatus = String(a.ciStatus) as WorkItem["ciStatus"];
+            if (a.ciRunId !== undefined) patch.ciRunId = a.ciRunId === null ? null : requireInt(a.ciRunId, "ciRunId");
+            if (a.ciSummary !== undefined) patch.ciSummary = a.ciSummary === null ? null : String(a.ciSummary);
+            if (a.reviewStatus != null) patch.reviewStatus = String(a.reviewStatus) as WorkItem["reviewStatus"];
+            if (a.branch !== undefined) patch.branch = a.branch === null ? null : String(a.branch);
+            if (a.issueNumber !== undefined)
+              patch.issueNumber = a.issueNumber === null ? null : requireInt(a.issueNumber, "issueNumber");
 
             let updated = this.workItemDb.updateWorkItem(id, patch, { forced: force, forceReason });
 


### PR DESCRIPTION
## Summary

- `prNumber: null` was silently coercing to `0` via `Number(null) === 0`, and `prState: null` was becoming the string `"null"` via `String(null)`
- For all nullable `WorkItem` fields (`prNumber`, `prState`, `prUrl`, `ciRunId`, `ciSummary`, `branch`, `issueNumber`), explicit `null` now stores SQL `NULL` to clear the field; `undefined` continues to mean "leave unchanged"
- Non-nullable fields (`ciStatus`, `reviewStatus`) silently skip `null` inputs (unchanged behavior)
- JSON Schema updated to declare nullable fields with `type: ["...", "null"]` so callers know null is accepted

## Test plan

- [x] Existing `branch=null` test updated to expect null (clearing), matching the new consistent semantics
- [x] New test: `prNumber: null` and `prState: null` clear those fields to null (not 0 or "null")
- [x] New test: `prNumber=null, ciRunId=null, ciSummary=null, prUrl=null` all clear to null after being set
- [x] Full test suite: 5349 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)