### PR TITLE
refactor(worktree): rename deleteIfMerged → deleteIfSafeToDelete, label (merged) → (safe) (fixes #1500)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -3092,7 +3092,7 @@ describe("mcx claude bye branch cleanup", () => {
       expect(branchCalls.length).toBe(1);
       expect(branchCalls[0][0]).toContain("feat/issue-42");
       const errOutput = printError.mock.calls.map((c: unknown[]) => c[0]).join("\n");
-      expect(errOutput).toContain("Deleted branch: feat/issue-42 (merged)");
+      expect(errOutput).toContain("Deleted branch: feat/issue-42 (safe)");
     } finally {
       console.log = origLog;
     }
@@ -3244,7 +3244,7 @@ describe("mcx claude worktrees", () => {
       await cmdClaude(["worktrees", "--prune"], deps);
       const errOutput = printError.mock.calls.map((c: unknown[]) => c[0]).join("\n");
       expect(errOutput).toContain("Removed worktree:");
-      expect(errOutput).toContain("Deleted branch: feat/orphan (merged)");
+      expect(errOutput).toContain("Deleted branch: feat/orphan (safe)");
       expect(errOutput).toContain("Pruned 1 worktree.");
     } finally {
       console.log = origLog;
@@ -3427,7 +3427,7 @@ describe("mcx claude worktrees", () => {
       await cmdClaude(["worktrees", "--prune"], deps);
       const errOutput = printError.mock.calls.map((c: unknown[]) => c[0]).join("\n");
       expect(errOutput).toContain("Removed worktree:");
-      expect(errOutput).toContain("Deleted branch: feat/done (merged)");
+      expect(errOutput).toContain("Deleted branch: feat/done (safe)");
       expect(errOutput).toContain("Pruned 1 worktree.");
     } finally {
       console.log = origLog;

--- a/packages/command/src/commands/gc.spec.ts
+++ b/packages/command/src/commands/gc.spec.ts
@@ -350,7 +350,7 @@ describe("runGc worktrees", () => {
   });
 
   test("default mode: worktree-phase branch deletions don't cause false branch-phase failures", async () => {
-    // Regression: when the worktree phase's deleteIfMerged removes a branch,
+    // Regression: when the worktree phase's deleteIfSafeToDelete removes a branch,
     // the branch phase must skip it rather than trying `git branch -d` again
     // and reporting a false failure.
     const responses = makeWorktreeResponses();

--- a/packages/core/src/worktree-shim.ts
+++ b/packages/core/src/worktree-shim.ts
@@ -213,7 +213,7 @@ export function cleanupWorktree(worktree: string, cwd: string, deps: WorktreeShi
       const { exitCode: hookExit, stderr: hookStderr } = deps.exec(["sh", "-c", wtConfig.teardown], { env: hookEnv });
       if (hookExit === 0) {
         deps.printError(`Removed worktree via hook: ${worktreePath}`);
-        deleteIfMerged(branch, effectiveRoot, deps);
+        deleteIfSafeToDelete(branch, effectiveRoot, deps);
       } else {
         deps.printError(`Worktree teardown hook failed for: ${worktreePath}: ${hookStderr}`);
       }
@@ -230,7 +230,7 @@ export function cleanupWorktree(worktree: string, cwd: string, deps: WorktreeShi
           deps.printError("Fixed core.bare=true after worktree removal");
         }
         deps.printError(`Removed worktree: ${worktreePath}`);
-        deleteIfMerged(branch, effectiveRoot, deps);
+        deleteIfSafeToDelete(branch, effectiveRoot, deps);
       } else {
         deps.printError(`Failed to remove worktree: ${worktreePath}`);
       }
@@ -253,8 +253,8 @@ export function cleanupWorktree(worktree: string, cwd: string, deps: WorktreeShi
   }
 }
 
-/** Delete a branch if it's been merged (git branch -d is safe — refuses unmerged). */
-function deleteIfMerged(branch: string, repoRoot: string, deps: WorktreeShimDeps): boolean {
+/** Delete a branch if git branch -d considers it safe (merged into HEAD or upstream). */
+function deleteIfSafeToDelete(branch: string, repoRoot: string, deps: WorktreeShimDeps): boolean {
   if (!branch) return false;
   const bareBeforeDelete = isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd));
   const { exitCode } = deps.exec(["git", "-C", repoRoot, "branch", "-d", branch]);
@@ -262,7 +262,7 @@ function deleteIfMerged(branch: string, repoRoot: string, deps: WorktreeShimDeps
     if (!bareBeforeDelete && isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd))) {
       deps.printError(`[shim] core.bare flipped to true by: git branch -d ${branch} (repo=${repoRoot}) — see #1330`);
     }
-    deps.printError(`Deleted branch: ${branch} (merged)`);
+    deps.printError(`Deleted branch: ${branch} (safe)`);
     return true;
   }
   return false;
@@ -418,7 +418,7 @@ export async function pruneWorktrees(opts: WorktreePruneOptions): Promise<Worktr
       if (hookExit === 0) {
         deps.printError(`Removed worktree via hook: ${wt.path}`);
         pruned++;
-        if (wt.branch && deleteIfMerged(wt.branch, repoRoot, deps)) {
+        if (wt.branch && deleteIfSafeToDelete(wt.branch, repoRoot, deps)) {
           deletedBranches.add(wt.branch);
         }
       } else {
@@ -438,7 +438,7 @@ export async function pruneWorktrees(opts: WorktreePruneOptions): Promise<Worktr
         }
         deps.printError(`Removed worktree: ${wt.path}`);
         pruned++;
-        if (wt.branch && deleteIfMerged(wt.branch, repoRoot, deps)) {
+        if (wt.branch && deleteIfSafeToDelete(wt.branch, repoRoot, deps)) {
           deletedBranches.add(wt.branch);
         }
       }


### PR DESCRIPTION
## Summary
- Renamed private function `deleteIfMerged` → `deleteIfSafeToDelete` in `packages/core/src/worktree-shim.ts` (4 call sites + definition)
- Changed log label from `(merged)` → `(safe)` to accurately reflect that `git branch -d` succeeds for both upstream-merged and HEAD-merged cases
- Updated docstring to remove the misleading "upstream reachability" framing

## Test plan
- [x] Updated 3 `expect(errOutput).toContain(...)` assertions in `claude.spec.ts` to use `(safe)` label
- [x] Updated comment in `gc.spec.ts` referencing old function name
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — 5347 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)