### PR TITLE
fix(core): exclude __resetNagStateForTests from public barrel export (fixes #1354)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,7 +23,15 @@ export * from "./branch-guard";
 export * from "./manifest";
 export * from "./manifest-lock";
 export * from "./phase-transition";
-export * from "./worktree-config";
+export type { WorktreeHooksConfig } from "./worktree-config";
+export {
+  WORKTREE_CONFIG_FILENAME,
+  readWorktreeConfig,
+  resolveWorktreeBase,
+  resolveWorktreePath,
+  buildHookEnv,
+  hasWorktreeHooks,
+} from "./worktree-config";
 export * from "./worktree-shim";
 export * from "./plan";
 export * from "./claude-plan-adapter";


### PR DESCRIPTION
## Summary
- Replaces `export * from "./worktree-config"` in the core barrel with explicit named exports, omitting `__resetNagStateForTests`
- The test helper was leaking into the public API surface, inviting misuse by downstream consumers
- The spec file already imports `__resetNagStateForTests` directly from `./worktree-config` and required no changes

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `packages/core/src/worktree-config.spec.ts` — all 28 tests pass with the direct import
- [x] Full pre-commit suite passed (coverage, shell injection, phase-drift checks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)