### PR TITLE
feat(metrics): add core_bare_healed_total counter with source label (fixes #1366)

### DIFF
--- a/packages/daemon/src/index.spec.ts
+++ b/packages/daemon/src/index.spec.ts
@@ -1020,9 +1020,9 @@ describe("sweepCoreBare (#1330)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// core_bare_healed_total counter tests
+// mcpd_core_bare_healed_total counter tests
 // ---------------------------------------------------------------------------
-describe("core_bare_healed_total counter", () => {
+describe("mcpd_core_bare_healed_total counter", () => {
   let opts: ReturnType<typeof testOptions> | undefined;
 
   beforeEach(() => {
@@ -1060,8 +1060,8 @@ describe("core_bare_healed_total counter", () => {
         }),
       );
 
-      expect(metrics.counter("core_bare_healed_total", { source: "sweep" }).value()).toBe(1);
-      expect(metrics.counter("core_bare_healed_total", { source: "worktree_remove" }).value()).toBe(0);
+      expect(metrics.counter("mcpd_core_bare_healed_total", { source: "sweep" }).value()).toBe(1);
+      expect(metrics.counter("mcpd_core_bare_healed_total", { source: "worktree_remove" }).value()).toBe(0);
     } finally {
       db.close();
     }
@@ -1079,7 +1079,7 @@ describe("core_bare_healed_total counter", () => {
 
       sweepCoreBare(db, silentLogger, mockGitOps({ exec: () => ({ exitCode: 0, stdout: "false\n" }) }));
 
-      expect(metrics.counter("core_bare_healed_total", { source: "sweep" }).value()).toBe(0);
+      expect(metrics.counter("mcpd_core_bare_healed_total", { source: "sweep" }).value()).toBe(0);
     } finally {
       db.close();
     }
@@ -1121,7 +1121,62 @@ describe("core_bare_healed_total counter", () => {
         }),
       );
 
-      expect(metrics.counter("core_bare_healed_total", { source: "worktree_remove" }).value()).toBeGreaterThan(0);
+      expect(metrics.counter("mcpd_core_bare_healed_total", { source: "worktree_remove" }).value()).toBeGreaterThan(0);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("pruneOrphanedWorktrees increments branch_delete counter when core.bare flips after branch deletion", () => {
+    opts = testOptions();
+    const repoDir = join(opts.dir, "counter-branch-delete-repo");
+    mkdirSync(repoDir, { recursive: true });
+    writeFileSync(join(repoDir, ".git"), "gitdir: /some/repo\n");
+
+    const db = new StateDb(opts.DB_PATH);
+    try {
+      db.upsertSession({
+        sessionId: "ended-bd",
+        pid: 99999,
+        model: "sonnet",
+        cwd: repoDir,
+        repoRoot: repoDir,
+        worktree: "bd-wt",
+      });
+      db.endSession("ended-bd");
+
+      // Simulate: core.bare is fine before/after worktree remove, but flips after branch delete,
+      // then fixCoreBare succeeds (unset returns exitCode 0).
+      // Non-unset config core.bare call sequence:
+      //   1: isCoreBareSet(bareBeforeRemove)  → false
+      //   2: isCoreBareSet(bareAfterRemove)   → false
+      //   3: fixCoreBare (post-remove check)  → false (no heal)
+      //   4: isCoreBareSet(bareBeforeBranch)  → false
+      //   5: isCoreBareSet(bareAfterBranch)   → true  (flip detected)
+      //   6: fixCoreBare (branch_delete heal) → true  (heals, increments branch_delete)
+      //   7: fixCoreBare (batch guard)        → false (already healed)
+      let callCount = 0;
+      pruneOrphanedWorktrees(
+        db,
+        silentLogger,
+        mockGitOps({
+          pathExists: () => true,
+          status: () => ({ exitCode: 0, stdout: "" }),
+          showBranch: () => ({ exitCode: 0, stdout: "feat/bd-branch" }),
+          removeWorktree: () => ({ exitCode: 0 }),
+          deleteBranch: () => ({ exitCode: 0 }),
+          exec: (cmd: string[]) => {
+            if (cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset")) {
+              callCount++;
+              return { exitCode: 0, stdout: callCount === 5 || callCount === 6 ? "true\n" : "false\n" };
+            }
+            return { exitCode: 0, stdout: "" };
+          },
+        }),
+      );
+
+      expect(metrics.counter("mcpd_core_bare_healed_total", { source: "branch_delete" }).value()).toBe(1);
+      expect(metrics.counter("mcpd_core_bare_healed_total", { source: "worktree_remove" }).value()).toBe(0);
     } finally {
       db.close();
     }

--- a/packages/daemon/src/index.spec.ts
+++ b/packages/daemon/src/index.spec.ts
@@ -9,7 +9,7 @@
  * - Mocked git ops for worktree prune tests (no subprocess overhead)
  * - Tighter pollUntil deadlines
  */
-import { afterAll, afterEach, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { ALIAS_SERVER_NAME, CLAUDE_SERVER_NAME, PROTOCOL_VERSION, silentLogger } from "@mcp-cli/core";
@@ -19,6 +19,7 @@ import { testOptions } from "../../../test/test-options";
 import { StateDb } from "./db/state";
 import type { DaemonHandle, PruneGitOps } from "./index";
 import { pruneOrphanedWorktrees, startDaemon, sweepCoreBare } from "./index";
+import { metrics } from "./metrics";
 
 setDefaultTimeout(15_000);
 
@@ -1012,6 +1013,115 @@ describe("sweepCoreBare (#1330)", () => {
     try {
       const healed = sweepCoreBare(db, silentLogger, mockGitOps());
       expect(healed).toBe(0);
+    } finally {
+      db.close();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// core_bare_healed_total counter tests
+// ---------------------------------------------------------------------------
+describe("core_bare_healed_total counter", () => {
+  let opts: ReturnType<typeof testOptions> | undefined;
+
+  beforeEach(() => {
+    metrics.reset();
+  });
+
+  afterEach(() => {
+    metrics.reset();
+    if (opts) {
+      opts[Symbol.dispose]();
+      opts = undefined;
+    }
+  });
+
+  test("sweepCoreBare increments counter with source=sweep", () => {
+    opts = testOptions();
+    const repoDir = join(opts.dir, "counter-sweep-repo");
+    mkdirSync(repoDir, { recursive: true });
+    writeFileSync(join(repoDir, ".git"), "gitdir: /some/repo\n");
+
+    const db = new StateDb(opts.DB_PATH);
+    try {
+      db.upsertSession({ sessionId: "s1", pid: 99999, model: "sonnet", cwd: repoDir, repoRoot: repoDir });
+
+      sweepCoreBare(
+        db,
+        silentLogger,
+        mockGitOps({
+          exec: (cmd: string[]) => {
+            if (cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset")) {
+              return { exitCode: 0, stdout: "true\n" };
+            }
+            return { exitCode: 0, stdout: "" };
+          },
+        }),
+      );
+
+      expect(metrics.counter("core_bare_healed_total", { source: "sweep" }).value()).toBe(1);
+      expect(metrics.counter("core_bare_healed_total", { source: "worktree_remove" }).value()).toBe(0);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("sweepCoreBare does not increment counter when nothing healed", () => {
+    opts = testOptions();
+    const repoDir = join(opts.dir, "counter-sweep-clean");
+    mkdirSync(repoDir, { recursive: true });
+    writeFileSync(join(repoDir, ".git"), "gitdir: /some/repo\n");
+
+    const db = new StateDb(opts.DB_PATH);
+    try {
+      db.upsertSession({ sessionId: "s2", pid: 99999, model: "sonnet", cwd: repoDir, repoRoot: repoDir });
+
+      sweepCoreBare(db, silentLogger, mockGitOps({ exec: () => ({ exitCode: 0, stdout: "false\n" }) }));
+
+      expect(metrics.counter("core_bare_healed_total", { source: "sweep" }).value()).toBe(0);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("pruneOrphanedWorktrees increments worktree_remove counter when core.bare healed after removal", () => {
+    opts = testOptions();
+    const repoDir = join(opts.dir, "counter-prune-repo");
+    mkdirSync(repoDir, { recursive: true });
+    writeFileSync(join(repoDir, ".git"), "gitdir: /some/repo\n");
+
+    const db = new StateDb(opts.DB_PATH);
+    try {
+      db.upsertSession({
+        sessionId: "ended-wt",
+        pid: 99999,
+        model: "sonnet",
+        cwd: repoDir,
+        repoRoot: repoDir,
+        worktree: "wt",
+      });
+      db.endSession("ended-wt");
+
+      pruneOrphanedWorktrees(
+        db,
+        silentLogger,
+        mockGitOps({
+          pathExists: () => true,
+          status: () => ({ exitCode: 0, stdout: "" }),
+          showBranch: () => ({ exitCode: 0, stdout: "" }),
+          removeWorktree: () => ({ exitCode: 0 }),
+          deleteBranch: () => ({ exitCode: 1 }),
+          exec: (cmd: string[]) => {
+            if (cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset")) {
+              return { exitCode: 0, stdout: "true\n" };
+            }
+            return { exitCode: 0, stdout: "" };
+          },
+        }),
+      );
+
+      expect(metrics.counter("core_bare_healed_total", { source: "worktree_remove" }).value()).toBeGreaterThan(0);
     } finally {
       db.close();
     }

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -175,6 +175,7 @@ export function sweepCoreBare(
     for (const root of roots) {
       if (fixCoreBare(root, (cmd) => gitOps.exec(cmd))) {
         logger.warn(`[mcpd] Healed core.bare=true on ${root} (sweep) — see #1330`);
+        metrics.counter("core_bare_healed_total", { source: "sweep" }).inc();
         healed++;
       }
     }
@@ -232,6 +233,7 @@ export function pruneOrphanedWorktrees(
         }
         if (fixCoreBare(repoRoot, (cmd) => gitOps.exec(cmd))) {
           logger.warn("[mcpd] Fixed core.bare=true after worktree removal");
+          metrics.counter("core_bare_healed_total", { source: "worktree_remove" }).inc();
         }
         affectedRepoRoots.add(repoRoot);
         pruned++;
@@ -246,7 +248,9 @@ export function pruneOrphanedWorktrees(
               logger.warn(
                 `[mcpd] core.bare flipped to true by: git branch -d ${branch} (repo=${repoRoot}) — see #1330`,
               );
-              fixCoreBare(repoRoot, (cmd) => gitOps.exec(cmd));
+              if (fixCoreBare(repoRoot, (cmd) => gitOps.exec(cmd))) {
+                metrics.counter("core_bare_healed_total", { source: "branch_delete" }).inc();
+              }
             }
             logger.info(`[mcpd] Deleted branch: ${branch} (merged)`);
           }
@@ -260,6 +264,7 @@ export function pruneOrphanedWorktrees(
       for (const root of affectedRepoRoots) {
         if (fixCoreBare(root, (cmd) => gitOps.exec(cmd))) {
           logger.warn("[mcpd] Fixed core.bare=true after batch worktree prune");
+          metrics.counter("core_bare_healed_total", { source: "worktree_remove" }).inc();
         }
       }
       logger.info(`[mcpd] Pruned ${pruned} orphaned worktree${pruned === 1 ? "" : "s"}`);

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -175,7 +175,7 @@ export function sweepCoreBare(
     for (const root of roots) {
       if (fixCoreBare(root, (cmd) => gitOps.exec(cmd))) {
         logger.warn(`[mcpd] Healed core.bare=true on ${root} (sweep) — see #1330`);
-        metrics.counter("core_bare_healed_total", { source: "sweep" }).inc();
+        metrics.counter("mcpd_core_bare_healed_total", { source: "sweep" }).inc();
         healed++;
       }
     }
@@ -233,7 +233,7 @@ export function pruneOrphanedWorktrees(
         }
         if (fixCoreBare(repoRoot, (cmd) => gitOps.exec(cmd))) {
           logger.warn("[mcpd] Fixed core.bare=true after worktree removal");
-          metrics.counter("core_bare_healed_total", { source: "worktree_remove" }).inc();
+          metrics.counter("mcpd_core_bare_healed_total", { source: "worktree_remove" }).inc();
         }
         affectedRepoRoots.add(repoRoot);
         pruned++;
@@ -249,7 +249,7 @@ export function pruneOrphanedWorktrees(
                 `[mcpd] core.bare flipped to true by: git branch -d ${branch} (repo=${repoRoot}) — see #1330`,
               );
               if (fixCoreBare(repoRoot, (cmd) => gitOps.exec(cmd))) {
-                metrics.counter("core_bare_healed_total", { source: "branch_delete" }).inc();
+                metrics.counter("mcpd_core_bare_healed_total", { source: "branch_delete" }).inc();
               }
             }
             logger.info(`[mcpd] Deleted branch: ${branch} (merged)`);
@@ -264,7 +264,7 @@ export function pruneOrphanedWorktrees(
       for (const root of affectedRepoRoots) {
         if (fixCoreBare(root, (cmd) => gitOps.exec(cmd))) {
           logger.warn("[mcpd] Fixed core.bare=true after batch worktree prune");
-          metrics.counter("core_bare_healed_total", { source: "worktree_remove" }).inc();
+          metrics.counter("mcpd_core_bare_healed_total", { source: "worktree_remove" }).inc();
         }
       }
       logger.info(`[mcpd] Pruned ${pruned} orphaned worktree${pruned === 1 ? "" : "s"}`);


### PR DESCRIPTION
## Summary
- Adds \`mcpd_core_bare_healed_total\` Prometheus counter with a \`source\` label to the daemon metrics (following the \`mcpd_\` prefix convention)
- Increments with \`source=sweep\` in \`sweepCoreBare()\` whenever a repo is healed
- Increments with \`source=worktree_remove\` in \`pruneOrphanedWorktrees()\` post-removal and in the batch final guard
- Increments with \`source=branch_delete\` in \`pruneOrphanedWorktrees()\` when \`core.bare\` flips after a branch deletion and \`fixCoreBare\` heals it

## Test plan
- [x] \`source=sweep\`: test verifies counter increments to 1 when a repo needs healing
- [x] \`source=sweep\` zero case: test verifies no increment when nothing needs healing
- [x] \`source=worktree_remove\`: test verifies counter increments when core.bare heals after worktree removal
- [x] \`source=branch_delete\`: test verifies counter increments when core.bare flips after branch deletion (simulates the exact call-sequence: calls 5/6 of non-unset config checks return true)
- [x] 39 tests pass total (4 new counter tests, 35 existing)
- [x] \`bun typecheck\`, \`bun lint\`, \`bun test\` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)