### PR TITLE
fix(auth): reject zombie keychain entries with no usable tokens (fixes #1546)

### DIFF
--- a/packages/daemon/src/auth/keychain.spec.ts
+++ b/packages/daemon/src/auth/keychain.spec.ts
@@ -146,6 +146,47 @@ describe("readKeychainTokens", () => {
     expect(result?.refreshToken).toBe("refresh-tok");
   });
 
+  test("returns null for zombie entry (expiresAt=0, empty accessToken, no refreshToken)", async () => {
+    if (originalPlatform !== "darwin") return;
+    const keychainData = {
+      mcpOAuth: {
+        "atlassian|1eb778bd626fb68d": {
+          serverName: "atlassian",
+          serverUrl: "https://mcp.atlassian.com/v1/mcp",
+          accessToken: "",
+          refreshToken: null,
+          expiresAt: 0,
+          clientId: "zombie-id",
+        },
+      },
+    };
+
+    const result = await withSpawnMock(["echo", JSON.stringify(keychainData)], () =>
+      readKeychainTokens("https://mcp.atlassian.com/v1/mcp"),
+    );
+    expect(result).toBeNull();
+  });
+
+  test("returns null for entry with accessToken but no expiresAt and no refreshToken", async () => {
+    if (originalPlatform !== "darwin") return;
+    const keychainData = {
+      mcpOAuth: {
+        "srv|b": {
+          serverName: "srv",
+          serverUrl: "https://api.example.com",
+          accessToken: "some-token",
+          expiresAt: 0,
+          clientId: "cid",
+        },
+      },
+    };
+
+    const result = await withSpawnMock(["echo", JSON.stringify(keychainData)], () =>
+      readKeychainTokens("https://api.example.com"),
+    );
+    expect(result).toBeNull();
+  });
+
   test("returns null on malformed JSON", async () => {
     if (originalPlatform !== "darwin") return;
     const result = await withSpawnMock(["echo", "not-valid-json{{{"], () =>

--- a/packages/daemon/src/auth/keychain.ts
+++ b/packages/daemon/src/auth/keychain.ts
@@ -68,11 +68,12 @@ export async function readKeychainTokens(serverUrl: string): Promise<KeychainTok
     // Find entry matching our server URL
     for (const entry of Object.values(mcpOAuth)) {
       if (entry.serverUrl === serverUrl) {
-        // Check if token is expired
-        if (entry.expiresAt && entry.expiresAt < Date.now()) {
-          // Token expired but we may still have a refresh token
-          if (!entry.refreshToken) return null;
-        }
+        // An entry is usable if it has a refresh token (we can refresh)
+        // or a non-expired access token. Entries with only a clientId and
+        // empty/zero tokens are pre-authorization artifacts — return null
+        // so the SDK falls through to dynamic client registration.
+        const hasAccessToken = !!entry.accessToken && !!entry.expiresAt && entry.expiresAt > Date.now();
+        if (!entry.refreshToken && !hasAccessToken) return null;
 
         return {
           accessToken: entry.accessToken,


### PR DESCRIPTION
## Summary
- Replace the expiry-only guard in `readKeychainTokens` with a usability check: an entry must have either a `refreshToken` or a non-expired `accessToken` to be returned
- Entries with `expiresAt=0` and empty `accessToken` (pre-authorization artifacts from incomplete OAuth flows) now correctly return `null`, allowing the SDK to fall through to dynamic client registration
- Fixes the P0 where a stale `clientId` from a zombie keychain entry permanently blocked Atlassian auth

## Test plan
- [x] New test: zombie entry (`expiresAt=0`, `accessToken=""`, `refreshToken=null`, `clientId` present) → returns `null`
- [x] New test: entry with access token but `expiresAt=0` and no refresh token → returns `null`
- [x] Existing regression: expired token with `refreshToken` still returns (refresh flow works)
- [x] Existing regression: valid non-expired token returns normally
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test packages/daemon/src/auth/keychain.spec.ts` — 10/10 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)