### PR TITLE
fix(sites): open fresh tabs and surface nav errors on browser start

### DIFF
--- a/packages/daemon/src/site-worker.ts
+++ b/packages/daemon/src/site-worker.ts
@@ -279,10 +279,10 @@ async function handleBrowserStart(args: Record<string, unknown>): Promise<ToolRe
 
   const eng = await loadBrowser(engine);
   const specs = sites.map(siteSpecFor);
-  await eng.start(specs, sniffer.asEvents());
+  const startResults = await eng.start(specs, sniffer.asEvents());
   for (const s of sites) sitesOpenInBrowser.add(s.name);
 
-  return ok({ ok: true, engine, sites: eng.getSiteNames() });
+  return ok({ ok: true, engine, sites: eng.getSiteNames(), results: startResults });
 }
 
 async function handleDisconnect(): Promise<ToolResult> {

--- a/packages/daemon/src/site/browser/engine.ts
+++ b/packages/daemon/src/site/browser/engine.ts
@@ -56,9 +56,19 @@ export interface ColdStartResult {
   reloaded: boolean;
 }
 
+export interface StartSiteResult {
+  site: string;
+  url: string;
+  status: "navigated" | "failed" | "already-running";
+  error?: string;
+}
+
 export interface BrowserEngine {
-  /** Idempotent; subsequent calls are a no-op. `events` is wired for the lifetime. */
-  start(sites: SiteSpec[], events: BrowserEvents): Promise<void>;
+  /**
+   * Idempotent; if already running, returns each pinned site with status `already-running`.
+   * `events` is wired for the lifetime.
+   */
+  start(sites: SiteSpec[], events: BrowserEvents): Promise<StartSiteResult[]>;
   stop(): Promise<void>;
   isRunning(): boolean;
   /** Names of sites currently pinned to a tab/window. */

--- a/packages/daemon/src/site/browser/playwright.spec.ts
+++ b/packages/daemon/src/site/browser/playwright.spec.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import type { SiteSpec } from "./engine";
+import { type OpenPageLike, openSitesInContext } from "./playwright";
+
+function fakePage(opts: { failGoto?: string } = {}): OpenPageLike & {
+  gotoCalls: string[];
+  broughtToFront: number;
+} {
+  const page = {
+    gotoCalls: [] as string[],
+    broughtToFront: 0,
+    async goto(url: string): Promise<unknown> {
+      page.gotoCalls.push(url);
+      if (opts.failGoto) throw new Error(opts.failGoto);
+      return null;
+    },
+    async bringToFront(): Promise<void> {
+      page.broughtToFront++;
+    },
+  };
+  return page;
+}
+
+function fakeCtx(pages: ReturnType<typeof fakePage>[]): {
+  newPage: () => Promise<ReturnType<typeof fakePage>>;
+  created: ReturnType<typeof fakePage>[];
+} {
+  const ctx = {
+    created: [] as ReturnType<typeof fakePage>[],
+    newPage: async () => {
+      const p = pages.shift();
+      if (!p) throw new Error("test fakeCtx ran out of prepared pages");
+      ctx.created.push(p);
+      return p;
+    },
+  };
+  return ctx;
+}
+
+const spec = (name: string, extra: Partial<SiteSpec> = {}): SiteSpec => ({
+  name,
+  url: `https://${name}.test/home`,
+  profileDir: `/tmp/${name}`,
+  ...extra,
+});
+
+describe("openSitesInContext — #1588 regression", () => {
+  test("allocates a fresh page per site, navigates each, and brings first to front", async () => {
+    const p1 = fakePage();
+    const p2 = fakePage();
+    const ctx = fakeCtx([p1, p2]);
+    const pinned = new Map<string, OpenPageLike>();
+
+    const results = await openSitesInContext(ctx, [spec("teams"), spec("owa")], (page, name) => {
+      pinned.set(name, page);
+    });
+
+    expect(ctx.created).toEqual([p1, p2]); // fresh pages, not reused
+    expect(p1.gotoCalls).toEqual(["https://teams.test/home"]);
+    expect(p2.gotoCalls).toEqual(["https://owa.test/home"]);
+    expect(p1.broughtToFront).toBe(1); // first site focused
+    expect(p2.broughtToFront).toBe(0); // subsequent sites not focused
+    expect(pinned.get("teams")).toBe(p1);
+    expect(pinned.get("owa")).toBe(p2);
+    expect(results).toEqual([
+      { site: "teams", url: "https://teams.test/home", status: "navigated" },
+      { site: "owa", url: "https://owa.test/home", status: "navigated" },
+    ]);
+  });
+
+  test("records per-site failure without aborting sibling navigation", async () => {
+    const p1 = fakePage({ failGoto: "net::ERR_NAME_NOT_RESOLVED" });
+    const p2 = fakePage();
+    const ctx = fakeCtx([p1, p2]);
+
+    const results = await openSitesInContext(ctx, [spec("teams"), spec("owa")], () => {});
+
+    expect(results).toEqual([
+      {
+        site: "teams",
+        url: "https://teams.test/home",
+        status: "failed",
+        error: "net::ERR_NAME_NOT_RESOLVED",
+      },
+      { site: "owa", url: "https://owa.test/home", status: "navigated" },
+    ]);
+    expect(p2.gotoCalls).toEqual(["https://owa.test/home"]); // owa still navigated
+    expect(p1.broughtToFront).toBe(1); // bringToFront still called on failed first site
+  });
+
+  test("still invokes onPage before navigation so listeners catch early requests", async () => {
+    const p1 = fakePage();
+    const ctx = fakeCtx([p1]);
+    const order: string[] = [];
+    p1.goto = async (url: string) => {
+      order.push(`goto:${url}`);
+      return null;
+    };
+
+    await openSitesInContext(ctx, [spec("teams")], (_page, name) => {
+      order.push(`attach:${name}`);
+    });
+
+    expect(order).toEqual(["attach:teams", "goto:https://teams.test/home"]);
+  });
+});

--- a/packages/daemon/src/site/browser/playwright.ts
+++ b/packages/daemon/src/site/browser/playwright.ts
@@ -26,6 +26,7 @@ import type {
   CapturedResponse,
   ColdStartResult,
   SiteSpec,
+  StartSiteResult,
 } from "./engine";
 
 function isTextual(contentType: string): boolean {
@@ -39,6 +40,58 @@ function isTextual(contentType: string): boolean {
   );
 }
 
+/**
+ * Minimal BrowserContext surface used by {@link openSitesInContext}. Exists so
+ * the loop can be unit-tested against fakes without spawning real Chromium.
+ */
+export interface OpenCtxLike {
+  newPage(): Promise<OpenPageLike>;
+}
+
+export interface OpenPageLike {
+  goto(url: string, opts?: { waitUntil?: string }): Promise<unknown>;
+  bringToFront(): Promise<void>;
+}
+
+/**
+ * Open a fresh tab per site and navigate it. Exported for unit tests.
+ *
+ * Why fresh tabs: reusing `ctx.pages()` picks up tabs restored from the
+ * persistent Chrome profile, which leaves the user staring at a blank
+ * foreground tab while navigation happens off-screen (#1588).
+ *
+ * The first site is brought to front so the user sees something load.
+ * Navigation errors are recorded per site and do not abort the loop.
+ */
+export async function openSitesInContext<P extends OpenPageLike>(
+  ctx: { newPage(): Promise<P> },
+  sites: SiteSpec[],
+  onPage: (page: P, siteName: string) => void,
+): Promise<StartSiteResult[]> {
+  const results: StartSiteResult[] = [];
+  for (const [i, s] of sites.entries()) {
+    const page = await ctx.newPage();
+    onPage(page, s.name);
+
+    try {
+      await page.goto(s.url, { waitUntil: "domcontentloaded" });
+      results.push({ site: s.name, url: s.url, status: "navigated" });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`[site] goto failed site=${s.name} url=${s.url}: ${message}`);
+      results.push({ site: s.name, url: s.url, status: "failed", error: message });
+    }
+    if (i === 0) {
+      try {
+        await page.bringToFront();
+      } catch {
+        // Window may have been closed during navigation; non-fatal.
+      }
+    }
+  }
+  return results;
+}
+
 export class PlaywrightBrowserEngine implements BrowserEngine {
   private context: BrowserContext | null = null;
   private pages = new Map<string, Page>();
@@ -47,8 +100,14 @@ export class PlaywrightBrowserEngine implements BrowserEngine {
   private lock: Promise<unknown> = Promise.resolve();
   private events: BrowserEvents = {};
 
-  async start(sites: SiteSpec[], events: BrowserEvents): Promise<void> {
-    if (this.context) return;
+  async start(sites: SiteSpec[], events: BrowserEvents): Promise<StartSiteResult[]> {
+    if (this.context) {
+      return [...this.pages.entries()].map(([name, page]) => ({
+        site: name,
+        url: page.url(),
+        status: "already-running" as const,
+      }));
+    }
     this.events = events;
     for (const s of sites) this.siteSpecs.set(s.name, s);
 
@@ -99,20 +158,23 @@ export class PlaywrightBrowserEngine implements BrowserEngine {
       });
     }
 
-    const usedPages = new Set<Page>();
-    for (const s of sites) {
-      const page = ctx.pages().find((p) => !usedPages.has(p)) ?? (await ctx.newPage());
-      usedPages.add(page);
-      this.pages.set(s.name, page);
-
-      this.attachListeners(page, s.name);
-
-      try {
-        await page.goto(s.url, { waitUntil: "domcontentloaded" });
-      } catch {
-        // Navigation failures are non-fatal — the page is still useful for auth.
+    // If the user closes the browser window without going through stop(), the
+    // Playwright context disconnects. Clear our handles so a subsequent start()
+    // launches a fresh browser instead of silently no-op'ing on a dead context.
+    ctx.on("close", () => {
+      if (this.context === ctx) {
+        this.context = null;
+        this.pages.clear();
+        this.siteSpecs.clear();
+        this.events = {};
       }
-    }
+    });
+
+    const results = await openSitesInContext(ctx, sites, (page, name) => {
+      this.pages.set(name, page);
+      this.attachListeners(page, name);
+    });
+    return results;
   }
 
   private attachListeners(page: Page, siteName: string): void {


### PR DESCRIPTION
## Summary
Fixes #1588 — `mcx site browser teams` was opening Chrome with a blank foreground tab so auth never completed, and all downstream `mcx site call teams ...` invocations returned 401.

Root causes addressed:
- **Page reuse picked up session-restored tabs.** `ctx.pages()` returns tabs restored from the persistent Chrome profile, so navigation landed in a hidden background tab. Now every site gets a fresh `ctx.newPage()`.
- **No focus on the new tab.** First site now gets `page.bringToFront()`.
- **Silent `goto` failures.** Navigation errors were swallowed with no breadcrumb. Now logged to stderr AND returned per-site in the `site_browser_start` payload (`{ site, url, status, error }`).
- **Dead-context idempotency leak.** Closing Chrome via the X button (not `mcx site disconnect`) left `this.context` truthy but disconnected, so subsequent `mcx site browser` silently no-op'd. Added `ctx.on("close")` that clears the handles.

Per-site loop extracted to `openSitesInContext` so it's unit-testable against fake browser contexts — three regression tests cover fresh-page allocation, bringToFront-on-first, and per-site failure isolation.

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test packages/daemon/src/site/browser/playwright.spec.ts` — 3 new tests pass
- [x] `bun test` — full suite: 5487 pass, 0 fail
- [x] Verified binary build succeeds (`bun run build`)
- [ ] Manual smoke: `mcx site disconnect && mcx site browser teams` with a persistent Chrome profile containing restored tabs — verify Teams loads in the foreground tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)