### PR TITLE
feat(sites/teams): port send_message + fix dead-context + jq_input regressions

### DIFF
--- a/packages/daemon/src/site-worker.ts
+++ b/packages/daemon/src/site-worker.ts
@@ -202,6 +202,7 @@ function handleDescribe(args: Record<string, unknown>): ToolResult {
 }
 
 async function handleCall(args: Record<string, unknown>): Promise<ToolResult> {
+  resetIfBrowserDied();
   const site = requireSite(args.site as string);
   const callName = args.call as string;
   const catalog = loadCatalog(site.name, site.seed ?? site.name);
@@ -257,7 +258,22 @@ function handleRemoveCall(args: Record<string, unknown>): ToolResult {
   return ok({ ok: true, removed });
 }
 
+/**
+ * If the engine's underlying browser closed unexpectedly (user clicked X,
+ * Chrome crashed, network disconnect), PlaywrightBrowserEngine's `ctx.on("close")`
+ * listener clears its internal state but nothing notifies this outer module —
+ * so `browser` stays truthy while every call fails. Detect and reset.
+ */
+function resetIfBrowserDied(): void {
+  if (browser && !browser.isRunning()) {
+    browser = null;
+    browserEngineName = null;
+    sitesOpenInBrowser.clear();
+  }
+}
+
 async function handleBrowserStart(args: Record<string, unknown>): Promise<ToolResult> {
+  resetIfBrowserDied();
   const siteNames =
     (args.sites as string[] | undefined) ??
     listSites()
@@ -286,6 +302,7 @@ async function handleBrowserStart(args: Record<string, unknown>): Promise<ToolRe
 }
 
 async function handleDisconnect(): Promise<ToolResult> {
+  resetIfBrowserDied();
   if (!browser) return ok({ ok: true, note: "browser was not running" });
   await browser.stop();
   browser = null;
@@ -322,6 +339,7 @@ function handleSniff(args: Record<string, unknown>): ToolResult {
 }
 
 async function handleWiggle(args: Record<string, unknown>): Promise<ToolResult> {
+  resetIfBrowserDied();
   if (!browser) return error("Browser is not running. Start it with site_browser_start.");
   const site = args.site as string | undefined;
   const touched = await browser.wiggle(site);
@@ -329,6 +347,7 @@ async function handleWiggle(args: Record<string, unknown>): Promise<ToolResult> 
 }
 
 async function handleEval(args: Record<string, unknown>): Promise<ToolResult> {
+  resetIfBrowserDied();
   if (!browser) return error("Browser is not running. Start it with site_browser_start.");
   const code = args.code as string;
   if (!code) return error("Missing 'code'");
@@ -337,6 +356,7 @@ async function handleEval(args: Record<string, unknown>): Promise<ToolResult> {
 }
 
 async function handleColdStart(args: Record<string, unknown>): Promise<ToolResult> {
+  resetIfBrowserDied();
   if (!browser) return error("Browser is not running. Start it with site_browser_start.");
   const site = args.site as string | undefined;
   return ok(await browser.coldStart(site));

--- a/packages/daemon/src/site/resolver.spec.ts
+++ b/packages/daemon/src/site/resolver.spec.ts
@@ -60,4 +60,21 @@ describe("resolve", () => {
     const r = resolve(call, { extra: "yes" });
     expect(r.url).toBe("https://api.example.com/v1/things?fixed=1&extra=yes");
   });
+
+  test("POST with jq_input leaves body undefined so applyJqInput can shape it", () => {
+    const call: NamedCall = {
+      ...POST_CALL,
+      jq_input: ".body_default + {q: .params.q}",
+      body_default: { baseline: true },
+    };
+    const r = resolve(call, { q: "hi", size: 3 });
+    expect(r.body).toBeUndefined();
+    expect(r.residualParams).toEqual(["q", "size"]);
+  });
+
+  test("POST with jq_input still honors explicit rawBody override", () => {
+    const call: NamedCall = { ...POST_CALL, jq_input: ".body_default" };
+    const r = resolve(call, { q: "ignored" }, "explicit-body");
+    expect(r.body).toBe("explicit-body");
+  });
 });

--- a/packages/daemon/src/site/resolver.ts
+++ b/packages/daemon/src/site/resolver.ts
@@ -54,7 +54,10 @@ export function resolve(
   let body: string | undefined;
   if (rawBody !== undefined) {
     body = rawBody;
-  } else if (isBodyMethod && residualEntries.length > 0) {
+  } else if (isBodyMethod && residualEntries.length > 0 && !call.jq_input) {
+    // When the call declares jq_input, the body comes from the jq template
+    // in transforms.ts (applyJqInput) — don't short-circuit with a naive
+    // residual dump, since applyJqInput skips if a body is already set.
     body = JSON.stringify(Object.fromEntries(residualEntries));
   } else if (!isBodyMethod && residualEntries.length > 0) {
     const qs = new URLSearchParams();

--- a/packages/daemon/src/site/seeds/teams/catalog.json
+++ b/packages/daemon/src/site/seeds/teams/catalog.json
@@ -302,8 +302,8 @@
         "EnableSuggestion": true,
         "SupportedRecourseDisplayTypes": ["Suggestion", "ServiceSideRecourseLink"]
       },
-      "cvid": "dc970193-3c8a-47d0-b0e5-2a65fdb8ff20",
-      "logicalId": "462b56ad-86e6-4ba3-877c-3e11f0143f51",
+      "cvid": "00000000-0000-0000-0000-000000000000",
+      "logicalId": "00000000-0000-0000-0000-000000000001",
       "scenario": {
         "Dimensions": [
           {
@@ -334,7 +334,7 @@
           {
             "@odata.type": "Microsoft.OutlookServices.Message",
             "Id": "",
-            "ClientThreadId": "19:a2dae14c-c008-4117-88d7-49a13d0e235a_d0938f3c-ef54-45ab-a2c4-9095a7fcc5c1@unq.gbl.spaces"
+            "ClientThreadId": "19:00000000-0000-0000-0000-000000000001_00000000-0000-0000-0000-000000000002@unq.gbl.spaces"
           }
         ]
       }
@@ -351,5 +351,60 @@
     },
     "jq_input": "{ EntityRequests: [{ entityType: \"File\", contentSources: [\"OneDriveBusiness\",\"Exchange\"], fields: [\"FileName\",\"FileType\",\"HitHighlightedSummary\",\"LastModifiedTime\",\"LinkingUrl\",\"ModifiedBy\",\"Path\",\"Title\",\"SpWebUrl\",\"FileExtension\"], query: { queryString: .q, displayQueryString: .q }, size: (.size // 15), from: 0 }] }",
     "jq_output": "{ total: ((.EntitySets // []) | map(select(.EntityType==\"File\")) | first | .ResultSets[0].Total), hits: ((.EntitySets // []) | map(select(.EntityType==\"File\")) | first | .ResultSets[0].Results // [] | map(.Source | { title: .Title, fileName: .FileName, fileType: .FileType, summary: .HitHighlightedSummary, modified: .LastModifiedTime, modifiedBy: (.ModifiedBy // {}).DisplayName, url: .LinkingUrl })) }"
+  },
+  "send_message": {
+    "name": "send_message",
+    "url": "https://teams.cloud.microsoft/api/chatsvc/amer/v1/users/ME/conversations/:threadId/messages",
+    "method": "POST",
+    "description": "Send a message to a chat thread. Returns 201 with OriginalArrivalTime on success.",
+    "paramDocs": {
+      "threadId": "required — 48:notes (self-chat), 19:abc@thread.v2 (channel/group), 19:abc@unq.gbl.spaces (1:1)",
+      "content": "required — message body, HTML wrapped in <p> tags, e.g. '<p>hello</p>'",
+      "messagetype": "required — 'RichText/Html' for HTML content, or 'Text' for plain text",
+      "contenttype": "required — 'text'"
+    },
+    "audHints": ["ic3.teams.office.com", "chatsvcagg.teams.microsoft.com"]
+  },
+  "calendar_view": {
+    "name": "calendar_view",
+    "url": "https://teams.cloud.microsoft/api/mt/emea/v2.0/me/calendars/default/calendarView?StartDate=:startDate&EndDate=:endDate&shouldDecryptData=true",
+    "method": "GET",
+    "description": "Calendar events for a date range. Returns subject, start/end, organizer, location, online-meeting flag.",
+    "paramDocs": {
+      "startDate": "required — ISO 8601 UTC datetime, e.g. 2026-04-16T00:00:00.000Z",
+      "endDate": "required — ISO 8601 UTC datetime, e.g. 2026-04-17T00:00:00.000Z"
+    },
+    "jq_output": "[.value[] | {subject, start: .startTime, end: .endTime, organizer: .organizerName, location, online: .isOnlineMeeting, showAs, response: .myResponseType}]"
+  },
+  "org_chart": {
+    "name": "org_chart",
+    "url": "https://nam.loki.delve.office.com/api/v1/organization?smtp=:email&personaType=User",
+    "method": "GET",
+    "description": "Org chart for a person: management chain up to CEO plus direct reports. Each entry includes displayName, jobTitle, department, smtp, aadObjectId.",
+    "headers": {
+      "X-ClientType": "Teams",
+      "X-ClientFeature": "LivePersonaCard",
+      "X-ClientScenario": "ManagersAndDirects",
+      "Accept": "application/json"
+    },
+    "paramDocs": {
+      "email": "required — the person's SMTP address (e.g. first.last@example.com)"
+    },
+    "audHints": ["loki.delve.office.com"]
+  },
+  "person_profile": {
+    "name": "person_profile",
+    "url": "https://nam.loki.delve.office.com/api/v2/person?smtp=:email&personaType=User&locale=en-us",
+    "method": "GET",
+    "description": "Detailed profile for a person: full name, phone numbers, email, department, job title, office location, company.",
+    "headers": {
+      "X-ClientType": "Teams",
+      "X-ClientFeature": "LivePersonaCard",
+      "Accept": "application/json"
+    },
+    "paramDocs": {
+      "email": "required — the person's SMTP address (e.g. first.last@example.com)"
+    },
+    "audHints": ["loki.delve.office.com"]
   }
 }

--- a/packages/daemon/src/site/seeds/teams/search-template.json
+++ b/packages/daemon/src/site/seeds/teams/search-template.json
@@ -136,8 +136,8 @@
     "EnableSuggestion": true,
     "SupportedRecourseDisplayTypes": ["Suggestion", "ServiceSideRecourseLink"]
   },
-  "cvid": "dc970193-3c8a-47d0-b0e5-2a65fdb8ff20",
-  "logicalId": "462b56ad-86e6-4ba3-877c-3e11f0143f51",
+  "cvid": "00000000-0000-0000-0000-000000000000",
+  "logicalId": "00000000-0000-0000-0000-000000000001",
   "scenario": {
     "Dimensions": [
       { "DimensionName": "QueryType", "DimensionValue": "All" },
@@ -157,7 +157,7 @@
       {
         "@odata.type": "Microsoft.OutlookServices.Message",
         "Id": "",
-        "ClientThreadId": "19:a2dae14c-c008-4117-88d7-49a13d0e235a_d0938f3c-ef54-45ab-a2c4-9095a7fcc5c1@unq.gbl.spaces"
+        "ClientThreadId": "19:00000000-0000-0000-0000-000000000001_00000000-0000-0000-0000-000000000002@unq.gbl.spaces"
       }
     ]
   }


### PR DESCRIPTION
## Summary

The wudo-mcp → mcp-cli port dropped 4 Teams calls. This restores them + fixes 3 collateral bugs found during smoke-testing.

### Ported calls

| Call | What it does |
|---|---|
| `send_message` | POST to `:threadId/messages`. Supports 48:notes (self), 19:…@thread.v2 (group), 19:…@unq.gbl.spaces (1:1). **Smoke-tested: 201 to notes thread, message visible in Teams.** |
| `calendar_view` | Date-range calendar events (subject, start/end, organizer, location, online flag). Has `jq_output` shaping. |
| `org_chart` | Loki persona-card org chart (management chain up to CEO + direct reports). |
| `person_profile` | Loki detailed profile (name, phone, email, dept, job title, office). |

### Collateral fixes

1. **Dead-context reset (#1588 follow-up).** When Chrome closes outside of `site_disconnect`, `PlaywrightBrowserEngine.ctx.on("close")` clears engine-internal state but `site-worker.ts`'s module-level `browser` ref stayed truthy. Every subsequent handler passed its `!browser` guard but failed weirdly downstream (`wiggle` → `"no-wiggle-configured"` instead of `"Browser not running"`). Added `resetIfBrowserDied()` called at the top of every browser-dependent handler.

2. **Resolver / `jq_input` interaction.** For POST calls with a `jq_input` template, the resolver auto-built a naive JSON body from residual params, which caused `applyJqInput` to skip the template via its `if (resolved.body !== undefined)` guard. `search_teams` was sending `{"q":"Cancun"}` to Substrate instead of the full query shape → 400 Bad Request. Resolver now skips residual body construction when `call.jq_input` is set. `rawBody` still wins. **Smoke-tested: 200 OK, 2167 hits on `search_teams --q "Cancun"`.**

3. **Scrub captured GBG-specific identifiers.** `cvid` + `logicalId` correlation IDs and a `ClientThreadId` containing two AAD object IDs (user identities) were captured from a live session and checked into the teams seed. Replaced with all-zero placeholders. Public Substrate `SourceId` and Microsoft's existing `ABBAABBA-...` `RankingModelId` placeholder stay as-is.

## Test plan
- [x] `bun typecheck`
- [x] `bun lint`
- [x] `bun test packages/daemon/src/site` — 68/68 pass (2 new resolver regression tests)
- [x] `bun run build` succeeds
- [x] Smoke: `mcx site call teams send_message --threadId 48:notes --content "<p>test</p>" --messagetype RichText/Html --contenttype text` → 201
- [x] Smoke: `mcx site call teams search_teams --q "Cancun"` → 200 / 2167 hits (real results shape)
- [x] Smoke: `mcx site wiggle teams` → touched search/persona/organization/compose

🤖 Generated with [Claude Code](https://claude.com/claude-code)