### PR TITLE
fix(ci): fire CI on all branch pushes + add concurrency group (fixes #1506)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,18 @@
 name: CI
 on:
   push:
-    branches: [main]
+    branches: ['**']
   pull_request:
     branches: [main]
   workflow_dispatch:
+
+# Deduplicate runs per branch: head_ref is set for pull_request (source branch),
+# ref_name for push. Both resolve to the same branch name, so a push + PR event
+# for the same commit share one group. Cancel stale runs on force-push, but let
+# every main merge complete.
+concurrency:
+  group: ci-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 jobs:
   check:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 # for the same commit share one group. Cancel stale runs on force-push, but let
 # every main merge complete.
 concurrency:
-  group: ci-${{ github.head_ref || github.ref_name }}
+  group: ci-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 jobs:


### PR DESCRIPTION
## Summary
- Broadens push trigger from `[main]` to `['**']` so every branch push fires CI, providing a reliable fallback when GitHub drops `pull_request` events on rapid force-pushes
- Adds concurrency group keyed on branch name (`head_ref || ref_name`) to deduplicate push + pull_request runs and cancel stale force-push runs
- Preserves full runs on main (`cancel-in-progress: false` when `ref_name == 'main'`)

## Test plan
- [x] Pushed branch — CI fired via `push` event (run 24856617606)
- [x] Force-pushed — concurrency group cancelled stale run, new run started (run 24856633176 replaced cancelled 24856617606)
- [x] Verified main branch runs are unaffected (recent runs all completed successfully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)