### PR TITLE
fix(gc): skip unregistered provider servers instead of aborting (fixes #1398)

### DIFF
--- a/packages/command/src/commands/gc.spec.ts
+++ b/packages/command/src/commands/gc.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { IpcCallError } from "@mcp-cli/core";
+import { IPC_ERROR, IpcCallError } from "@mcp-cli/core";
 import type { GcDeps } from "./gc";
 import { cmdGc, defaultGcDeps, parseDuration, parseGcArgs, runGc } from "./gc";
 
@@ -273,6 +273,32 @@ describe("runGc worktrees", () => {
     expect(claudeCallCount).toBeGreaterThan(0);
     // Must not emit the fatal "Cannot reach daemon" error
     expect(d.errors.some((e) => e.includes("Cannot reach daemon"))).toBe(false);
+  });
+
+  test("skips provider when IpcCallError has SERVER_NOT_FOUND code (#1398)", async () => {
+    const responses = makeWorktreeResponses();
+    let claudeCallCount = 0;
+    const d = makeDeps({
+      execResponses: responses,
+      callTool: async (tool) => {
+        if (tool === "claude_session_list") {
+          claudeCallCount++;
+          return [];
+        }
+        throw new IpcCallError({
+          code: IPC_ERROR.SERVER_NOT_FOUND,
+          message: 'Server "_acp" not found',
+          data: undefined,
+        });
+      },
+    });
+
+    await runGc({ dryRun: false, olderThanMs: 86_400_000, branchesOnly: false, worktreesOnly: true }, d);
+
+    expect(d.logs.length + d.errors.length).toBeGreaterThan(0);
+    expect(claudeCallCount).toBeGreaterThan(0);
+    expect(d.errors.some((e) => e.includes("Cannot reach daemon"))).toBe(false);
+    expect(d.errors.some((e) => e.includes("not found"))).toBe(false);
   });
 
   test("live mode fails closed when session list throws", async () => {

--- a/packages/command/src/commands/gc.spec.ts
+++ b/packages/command/src/commands/gc.spec.ts
@@ -301,6 +301,25 @@ describe("runGc worktrees", () => {
     expect(d.errors.some((e) => e.includes("not found"))).toBe(false);
   });
 
+  test("does NOT skip provider when IpcCallError is 'Method not found' from a healthy server", async () => {
+    const responses = makeWorktreeResponses();
+    const d = makeDeps({
+      execResponses: responses,
+      callTool: async (tool) => {
+        if (tool === "claude_session_list") return [];
+        throw new IpcCallError({
+          code: IPC_ERROR.METHOD_NOT_FOUND,
+          message: "Method not found",
+          data: undefined,
+        });
+      },
+    });
+
+    await runGc({ dryRun: false, olderThanMs: 86_400_000, branchesOnly: false, worktreesOnly: true }, d);
+
+    expect(d.errors.some((e) => e.includes("Method not found"))).toBe(true);
+  });
+
   test("live mode fails closed when session list throws", async () => {
     const responses = makeWorktreeResponses();
     const d = makeDeps({

--- a/packages/command/src/commands/worktree-commands.ts
+++ b/packages/command/src/commands/worktree-commands.ts
@@ -5,7 +5,7 @@
  * that any provider can add to its command dispatch.
  */
 
-import { IpcCallError, WorktreeError, listMcxWorktrees, pruneWorktrees } from "@mcp-cli/core";
+import { IPC_ERROR, IpcCallError, WorktreeError, listMcxWorktrees, pruneWorktrees } from "@mcp-cli/core";
 import type { WorktreeShimDeps } from "@mcp-cli/core";
 import { c, formatToolResult } from "../output";
 
@@ -43,12 +43,17 @@ export async function getAllActiveSessionWorktrees(
       }
     } catch (e) {
       if (e instanceof IpcCallError) {
-        // Only skip when the error indicates the provider server is disconnected
-        // or unreachable — a disconnected server has no active sessions, so it
-        // is safe to skip. Re-throw for logic errors (invalid-params, internal, etc.)
-        // that indicate a real problem with the call itself.
+        // Skip when the provider server is absent or disconnected — it can't
+        // have active sessions, so skipping is safe.  Re-throw for logic
+        // errors (invalid-params, internal, etc.) that indicate a real
+        // problem with the call itself.
+        //
+        // Primary: structured error code from the daemon (SERVER_NOT_FOUND).
+        // Fallback: substring match for older daemons that don't set the code.
+        if (e.code === IPC_ERROR.SERVER_NOT_FOUND) continue;
         const msg = e.message.toLowerCase();
         if (
+          msg.includes("not found") ||
           msg.includes("not connected") ||
           msg.includes("disconnected") ||
           msg.includes("not reachable") ||

--- a/packages/command/src/commands/worktree-commands.ts
+++ b/packages/command/src/commands/worktree-commands.ts
@@ -53,7 +53,7 @@ export async function getAllActiveSessionWorktrees(
         if (e.code === IPC_ERROR.SERVER_NOT_FOUND) continue;
         const msg = e.message.toLowerCase();
         if (
-          msg.includes("not found") ||
+          (msg.includes("server") && msg.includes("not found")) ||
           msg.includes("not connected") ||
           msg.includes("disconnected") ||
           msg.includes("not reachable") ||

--- a/packages/daemon/src/server-pool.ts
+++ b/packages/daemon/src/server-pool.ts
@@ -23,7 +23,7 @@ import type {
   ServerStatus,
   ToolInfo,
 } from "@mcp-cli/core";
-import { consoleLogger, formatToolSignature } from "@mcp-cli/core";
+import { IPC_ERROR, consoleLogger, formatToolSignature } from "@mcp-cli/core";
 import {
   CONNECT_INITIAL_DELAY_MS,
   CONNECT_MAX_DELAY_MS,
@@ -271,7 +271,7 @@ export class ServerPool {
     if (pending) await pending;
 
     const conn = this.connections.get(name);
-    if (!conn) throw new Error(`Server "${name}" not found`);
+    if (!conn) throw Object.assign(new Error(`Server "${name}" not found`), { code: IPC_ERROR.SERVER_NOT_FOUND });
 
     // Virtual servers cannot be reconnected via config — they must be
     // re-registered by the daemon code that manages them (e.g., ClaudeServer, AliasServer).
@@ -518,7 +518,8 @@ export class ServerPool {
       if (pending) await pending;
 
       const conn = this.connections.get(serverName);
-      if (!conn) throw new Error(`Server "${serverName}" not found`);
+      if (!conn)
+        throw Object.assign(new Error(`Server "${serverName}" not found`), { code: IPC_ERROR.SERVER_NOT_FOUND });
 
       // Return cached tools if we have any (from connect or SQLite)
       if (conn.tools.size > 0) return [...conn.tools.values()];


### PR DESCRIPTION
## Summary
- `mcx gc` aborted entirely when a provider virtual server (e.g. `_acp`) wasn't registered — the `IpcCallError` didn't match any recognized "disconnected" message patterns, so gc treated it as a fatal error
- Fix: match on the structured `IPC_ERROR.SERVER_NOT_FOUND` error code (primary), with `"not found"` substring match as a legacy fallback for older daemons that don't set the code
- Tag `server-pool.ts` "not found" throws with the correct `IPC_ERROR.SERVER_NOT_FOUND` code so `toIpcError` preserves it through the IPC wire

## Test plan
- [x] New regression test: `skips provider when IpcCallError has SERVER_NOT_FOUND code (#1398)` — mocks `acp_session_list` throwing `IpcCallError` with `SERVER_NOT_FOUND` code, verifies gc completes without aborting
- [x] Existing test `skips disconnected provider when IpcCallError indicates server not connected` still passes (message-based fallback path)
- [x] All 5490 tests pass, 0 failures
- [x] Pre-commit hooks pass (typecheck + lint + test + coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)