### PR TITLE
fix(monitor): bridge worker-thread monitor events to daemon EventBus (fixes #1567)

### DIFF
--- a/packages/daemon/src/claude-server.spec.ts
+++ b/packages/daemon/src/claude-server.spec.ts
@@ -1,10 +1,12 @@
 import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { CLAUDE_SERVER_NAME, capturingLogger, silentLogger } from "@mcp-cli/core";
+import type { MonitorEvent } from "@mcp-cli/core";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types.js";
 import { testOptions } from "../../../test/test-options";
 import { ClaudeServer, WORKER_EVENT_TYPES, buildClaudeToolCache, isWorkerEvent } from "./claude-server";
 import { StateDb } from "./db/state";
+import { EventBus } from "./event-bus";
 import { MetricsCollector } from "./metrics";
 
 // ── WORKER_EVENT_TYPES exhaustiveness ──
@@ -23,6 +25,7 @@ describe("WORKER_EVENT_TYPES", () => {
       "db:end",
       "metrics:inc",
       "metrics:observe",
+      "monitor:event",
     ];
     expect(WORKER_EVENT_TYPES.size).toBe(expected.length);
     for (const t of expected) {
@@ -42,10 +45,16 @@ describe("isWorkerEvent", () => {
     expect(isWorkerEvent({ type: "db:end", sessionId: "s1" })).toBe(true);
   });
 
-  test("matches metrics and ready event types", () => {
+  test("matches metrics, ready, and monitor event types", () => {
     expect(isWorkerEvent({ type: "metrics:inc", name: "foo" })).toBe(true);
     expect(isWorkerEvent({ type: "metrics:observe", name: "foo", value: 1 })).toBe(true);
     expect(isWorkerEvent({ type: "ready", port: 3000 })).toBe(true);
+    expect(
+      isWorkerEvent({
+        type: "monitor:event",
+        input: { src: "daemon.claude-server", event: "session.result", category: "session" },
+      }),
+    ).toBe(true);
   });
 
   test("rejects JSON-RPC messages (even though they have no matching type)", () => {
@@ -821,6 +830,68 @@ describe("ClaudeServer", () => {
     expect(activityCount).toBe(3);
   });
 
+  // ── monitor:event bridge (#1567) ──
+
+  test("monitor:event forwards input to onMonitorEvent callback", () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new ClaudeServer(db, undefined, undefined, silentLogger);
+
+    const received: Array<{ src: string; event: string; category: string }> = [];
+    server.onMonitorEvent = (input) => received.push(input);
+
+    const handle = (server as unknown as { handleWorkerEvent: (e: unknown) => void }).handleWorkerEvent.bind(server);
+    handle({
+      type: "monitor:event",
+      input: { src: "daemon.claude-server", event: "session.result", category: "session", sessionId: "s1" },
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].event).toBe("session.result");
+    expect(received[0].src).toBe("daemon.claude-server");
+  });
+
+  test("monitor:event is safe when onMonitorEvent is not set", () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new ClaudeServer(db, undefined, undefined, silentLogger);
+
+    const handle = (server as unknown as { handleWorkerEvent: (e: unknown) => void }).handleWorkerEvent.bind(server);
+    expect(() => {
+      handle({
+        type: "monitor:event",
+        input: { src: "daemon.claude-server", event: "session.ended", category: "session" },
+      });
+    }).not.toThrow();
+  });
+
+  test("monitor:event preserves extra fields (cost, tokens, prNumber)", () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new ClaudeServer(db, undefined, undefined, silentLogger);
+
+    const received: Array<Record<string, unknown>> = [];
+    server.onMonitorEvent = (input) => received.push(input);
+
+    const handle = (server as unknown as { handleWorkerEvent: (e: unknown) => void }).handleWorkerEvent.bind(server);
+    handle({
+      type: "monitor:event",
+      input: {
+        src: "daemon.claude-server",
+        event: "session.result",
+        category: "session",
+        sessionId: "s1",
+        cost: 0.05,
+        tokens: 1234,
+        numTurns: 3,
+      },
+    });
+
+    expect(received[0].cost).toBe(0.05);
+    expect(received[0].tokens).toBe(1234);
+    expect(received[0].numTurns).toBe(3);
+  });
+
   // ── Worker crash + idle timeout interaction ──
 
   test("orphaned sessions are cleaned up after worker crash+restart", async () => {
@@ -1334,5 +1405,86 @@ describe("session persistence", () => {
 
     expect(activityCount).toBe(0);
     expect(server.hasActiveSessions()).toBe(false);
+  });
+});
+
+// ── monitor:event bridge integration (#1567) ──
+// Verifies the full round-trip: worker postMessage → handleWorkerEvent → onMonitorEvent → EventBus → subscriber
+
+describe("monitor event bridge integration", () => {
+  test("worker monitor:event reaches EventBus subscribers with correct seq", () => {
+    using opts = testOptions();
+    const db = new StateDb(opts.DB_PATH);
+    const server = new ClaudeServer(db, undefined, undefined, silentLogger);
+    const bus = new EventBus();
+
+    server.onMonitorEvent = (input) => bus.publish(input);
+
+    const received: MonitorEvent[] = [];
+    bus.subscribe((e) => received.push(e));
+
+    const handle = (server as unknown as { handleWorkerEvent: (e: unknown) => void }).handleWorkerEvent.bind(server);
+
+    handle({
+      type: "monitor:event",
+      input: {
+        src: "daemon.claude-server",
+        event: "session.result",
+        category: "session",
+        sessionId: "s1",
+        cost: 0.42,
+      },
+    });
+    handle({
+      type: "monitor:event",
+      input: {
+        src: "daemon.work-item-poller",
+        event: "pr.merged",
+        category: "work_item",
+        prNumber: 99,
+      },
+    });
+
+    expect(received).toHaveLength(2);
+    expect(received[0].seq).toBe(1);
+    expect(received[0].event).toBe("session.result");
+    expect(received[0].cost).toBe(0.42);
+    expect(received[0].sessionId).toBe("s1");
+    expect(received[1].seq).toBe(2);
+    expect(received[1].event).toBe("pr.merged");
+    expect(received[1].prNumber).toBe(99);
+    expect(typeof received[0].ts).toBe("string");
+
+    db.close();
+  });
+
+  test("seq is monotonic across session and work-item events from worker", () => {
+    using opts = testOptions();
+    const db = new StateDb(opts.DB_PATH);
+    const server = new ClaudeServer(db, undefined, undefined, silentLogger);
+    const bus = new EventBus();
+
+    server.onMonitorEvent = (input) => bus.publish(input);
+
+    const seqs: number[] = [];
+    bus.subscribe((e) => seqs.push(e.seq));
+
+    const handle = (server as unknown as { handleWorkerEvent: (e: unknown) => void }).handleWorkerEvent.bind(server);
+
+    for (let i = 0; i < 5; i++) {
+      handle({
+        type: "monitor:event",
+        input: {
+          src: "daemon.claude-server",
+          event: i % 2 === 0 ? "session.result" : "session.ended",
+          category: "session",
+          sessionId: `s${i}`,
+        },
+      });
+    }
+
+    expect(seqs).toEqual([1, 2, 3, 4, 5]);
+
+    db.close();
   });
 });

--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -9,7 +9,7 @@
  * Follows the same pattern as AliasServer (alias-server.ts).
  */
 
-import type { JsonSchema, LiveSpan, Logger, ToolInfo, WorkItemEvent } from "@mcp-cli/core";
+import type { JsonSchema, LiveSpan, Logger, MonitorEventInput, ToolInfo, WorkItemEvent } from "@mcp-cli/core";
 import { CLAUDE_SERVER_NAME, consoleLogger, formatToolSignature, silentLogger, startSpan } from "@mcp-cli/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { CLAUDE_TOOLS } from "./claude-session/tools";
@@ -95,7 +95,21 @@ interface ReadyMessage {
   port: number;
 }
 
-type WorkerEvent = DbUpsert | DbState | DbCost | DbDisconnected | DbEnd | DbMetric | DbHistogram | ReadyMessage;
+interface MonitorEventMessage {
+  type: "monitor:event";
+  input: MonitorEventInput;
+}
+
+type WorkerEvent =
+  | DbUpsert
+  | DbState
+  | DbCost
+  | DbDisconnected
+  | DbEnd
+  | DbMetric
+  | DbHistogram
+  | ReadyMessage
+  | MonitorEventMessage;
 
 /** Compile-time exhaustiveness: TS errors if a WorkerEvent["type"] member is missing. */
 const WORKER_EVENT_TYPE_MAP: Record<WorkerEvent["type"], true> = {
@@ -107,6 +121,7 @@ const WORKER_EVENT_TYPE_MAP: Record<WorkerEvent["type"], true> = {
   "db:end": true,
   "metrics:inc": true,
   "metrics:observe": true,
+  "monitor:event": true,
 };
 
 /** Explicit set of known worker event types — prevents ambiguous routing with MCP messages. */
@@ -159,6 +174,9 @@ export class ClaudeServer {
 
   /** Called on worker activity (session events) — lets the daemon reset its idle timer. */
   onActivity?: () => void;
+
+  /** Called when the worker publishes a monitor event — bridges to the daemon's EventBus (#1567). */
+  onMonitorEvent?: (input: MonitorEventInput) => void;
 
   constructor(
     db: StateDb,
@@ -728,6 +746,9 @@ export class ClaudeServer {
         break;
       case "metrics:observe":
         this.metrics.histogram(event.name, event.labels).observe(event.value);
+        break;
+      case "monitor:event":
+        this.onMonitorEvent?.(event.input);
         break;
     }
   }

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -658,9 +658,9 @@ function forwardSessionEvent(sessionId: string, event: SessionEvent): void {
 async function startServer(wsPort?: number, quiet?: boolean): Promise<number> {
   // Start WebSocket server
   wsServer = new ClaudeWsServer({ logger: quiet ? silentLogger : undefined });
-  const port = await wsServer.start(wsPort);
   wsServer.onSessionEvent = forwardSessionEvent;
   wsServer.onMonitorEvent = (input) => self.postMessage({ type: "monitor:event", input });
+  const port = await wsServer.start(wsPort);
 
   // Start MCP Server
   mcpServer = new Server({ name: CLAUDE_SERVER_NAME, version: "0.1.0" }, { capabilities: { tools: {} } });

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -35,7 +35,6 @@ import {
   type WorkItemWaitEvent,
   compactifyEntry,
 } from "./claude-session/ws-server";
-import { EventBus } from "./event-bus";
 import { aggregatePlans } from "./plan-aggregator";
 import { getProcessStartTime } from "./process-identity";
 import { createIsControlMessage } from "./worker-control-message";
@@ -661,7 +660,7 @@ async function startServer(wsPort?: number, quiet?: boolean): Promise<number> {
   wsServer = new ClaudeWsServer({ logger: quiet ? silentLogger : undefined });
   const port = await wsServer.start(wsPort);
   wsServer.onSessionEvent = forwardSessionEvent;
-  wsServer.eventBus = new EventBus();
+  wsServer.onMonitorEvent = (input) => self.postMessage({ type: "monitor:event", input });
 
   // Start MCP Server
   mcpServer = new Server({ name: CLAUDE_SERVER_NAME, version: "0.1.0" }, { capabilities: { tools: {} } });

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import type { MonitorEventInput, WorkItemEvent } from "@mcp-cli/core";
 import { silentLogger } from "@mcp-cli/core";
 import { serialize } from "./ndjson";
 import type { SessionEvent } from "./session-state";
@@ -3721,6 +3722,183 @@ describe("restoreSessions", () => {
       const result = await promise;
       expect(result.workItemEvent.type).toBe("checks:passed");
       expect("prNumber" in result.workItemEvent && result.workItemEvent.prNumber).toBe(42);
+    });
+  });
+});
+
+// ── publishSessionMonitorEvent / publishWorkItemMonitorEvent mapping (#1567) ──
+
+describe("monitor event mapping", () => {
+  type WsServerPrivate = {
+    publishSessionMonitorEvent: (sessionId: string, event: SessionEvent) => void;
+    publishWorkItemMonitorEvent: (event: WorkItemEvent) => void;
+  };
+
+  function makeServer(): ClaudeWsServer {
+    return new ClaudeWsServer({ logger: silentLogger });
+  }
+
+  function collect(server: ClaudeWsServer): MonitorEventInput[] {
+    const events: MonitorEventInput[] = [];
+    server.onMonitorEvent = (input) => events.push(input);
+    return events;
+  }
+
+  function priv(server: ClaudeWsServer): WsServerPrivate {
+    return server as unknown as WsServerPrivate;
+  }
+
+  describe("publishSessionMonitorEvent", () => {
+    test("session:result maps to session.result with cost/tokens/numTurns", () => {
+      const server = makeServer();
+      const events = collect(server);
+
+      priv(server).publishSessionMonitorEvent("s1", {
+        type: "session:result",
+        cost: 0.42,
+        tokens: 1234,
+        numTurns: 3,
+        result: "done",
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0].src).toBe("daemon.claude-server");
+      expect(events[0].event).toBe("session.result");
+      expect(events[0].category).toBe("session");
+      expect(events[0].sessionId).toBe("s1");
+      expect(events[0].cost).toBe(0.42);
+      expect(events[0].tokens).toBe(1234);
+      expect(events[0].numTurns).toBe(3);
+      expect(events[0].result).toBe("done");
+    });
+
+    test("session:ended maps to session.ended with no extra fields", () => {
+      const server = makeServer();
+      const events = collect(server);
+
+      priv(server).publishSessionMonitorEvent("s2", { type: "session:ended" });
+
+      expect(events).toHaveLength(1);
+      expect(events[0].event).toBe("session.ended");
+      expect(events[0].cost).toBeUndefined();
+      expect(events[0].tokens).toBeUndefined();
+    });
+
+    test("session:containment_warning maps with strikes and reason", () => {
+      const server = makeServer();
+      const events = collect(server);
+
+      priv(server).publishSessionMonitorEvent("s3", {
+        type: "session:containment_warning",
+        toolName: "bash",
+        reason: "not allowed",
+        strikes: 2,
+      });
+
+      expect(events[0].event).toBe("session.containment_warning");
+      expect(events[0].strikes).toBe(2);
+      expect(events[0].reason).toBe("not allowed");
+    });
+
+    test("session:permission_request extracts toolName from request.tool_name", () => {
+      const server = makeServer();
+      const events = collect(server);
+
+      priv(server).publishSessionMonitorEvent("s4", {
+        type: "session:permission_request",
+        requestId: "req1",
+        request: { tool_name: "bash", input: {} } as never,
+      });
+
+      expect(events[0].event).toBe("session.permission_request");
+      expect(events[0].toolName).toBe("bash");
+    });
+
+    test("unmapped session event type is silently dropped", () => {
+      const server = makeServer();
+      const events = collect(server);
+
+      priv(server).publishSessionMonitorEvent("s5", {
+        type: "session:response",
+        message: {} as never,
+      });
+
+      expect(events).toHaveLength(0);
+    });
+
+    test("null onMonitorEvent callback causes silent drop", () => {
+      const server = makeServer();
+      server.onMonitorEvent = null;
+
+      expect(() => {
+        priv(server).publishSessionMonitorEvent("s6", { type: "session:ended" });
+      }).not.toThrow();
+    });
+  });
+
+  describe("publishWorkItemMonitorEvent", () => {
+    test("pr:opened maps to pr.opened with prNumber", () => {
+      const server = makeServer();
+      const events = collect(server);
+
+      priv(server).publishWorkItemMonitorEvent({ type: "pr:opened", prNumber: 42 });
+
+      expect(events).toHaveLength(1);
+      expect(events[0].src).toBe("daemon.work-item-poller");
+      expect(events[0].event).toBe("pr.opened");
+      expect(events[0].category).toBe("work_item");
+      expect(events[0].prNumber).toBe(42);
+    });
+
+    test("checks:failed maps to checks.failed with failedJob", () => {
+      const server = makeServer();
+      const events = collect(server);
+
+      priv(server).publishWorkItemMonitorEvent({ type: "checks:failed", prNumber: 7, failedJob: "typecheck" });
+
+      expect(events[0].event).toBe("checks.failed");
+      expect(events[0].prNumber).toBe(7);
+      expect(events[0].failedJob).toBe("typecheck");
+    });
+
+    test("review:changes_requested maps with reviewer", () => {
+      const server = makeServer();
+      const events = collect(server);
+
+      priv(server).publishWorkItemMonitorEvent({ type: "review:changes_requested", prNumber: 99, reviewer: "alice" });
+
+      expect(events[0].event).toBe("review.changes_requested");
+      expect(events[0].reviewer).toBe("alice");
+    });
+
+    test("phase:changed maps itemId to workItemId with from/to", () => {
+      const server = makeServer();
+      const events = collect(server);
+
+      priv(server).publishWorkItemMonitorEvent({ type: "phase:changed", itemId: "wi-123", from: "impl", to: "review" });
+
+      expect(events[0].event).toBe("phase.changed");
+      expect(events[0].workItemId).toBe("wi-123");
+      expect(events[0].from).toBe("impl");
+      expect(events[0].to).toBe("review");
+    });
+
+    test("unmapped work-item event type is silently dropped", () => {
+      const server = makeServer();
+      const events = collect(server);
+
+      priv(server).publishWorkItemMonitorEvent({ type: "unknown:event" } as never);
+
+      expect(events).toHaveLength(0);
+    });
+
+    test("null onMonitorEvent callback causes silent drop", () => {
+      const server = makeServer();
+      server.onMonitorEvent = null;
+
+      expect(() => {
+        priv(server).publishWorkItemMonitorEvent({ type: "pr:merged", prNumber: 1 });
+      }).not.toThrow();
     });
   });
 });

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -46,7 +46,6 @@ import {
   generateSessionName,
 } from "@mcp-cli/core";
 import type { ServerWebSocket } from "bun";
-import type { EventBus } from "../event-bus";
 import { killPid } from "../process-util";
 import { ContainmentGuard } from "./containment";
 import type { NdjsonMessage } from "./ndjson";
@@ -383,8 +382,8 @@ export class ClaudeWsServer {
   /** Called when session events occur (for DB updates). */
   onSessionEvent: ((sessionId: string, event: SessionEvent) => void) | null = null;
 
-  /** Optional event bus for unified monitor event stream (#1512). */
-  eventBus: EventBus | null = null;
+  /** Called to forward monitor events to the main thread's EventBus (#1567). */
+  onMonitorEvent: ((input: MonitorEventInput) => void) | null = null;
 
   constructor(deps?: {
     spawn?: SpawnFn;
@@ -1659,7 +1658,7 @@ export class ClaudeWsServer {
   };
 
   private publishSessionMonitorEvent(sessionId: string, event: SessionEvent): void {
-    if (!this.eventBus) return;
+    if (!this.onMonitorEvent) return;
     const mapped = ClaudeWsServer.SESSION_EVENT_MAP[event.type];
     if (!mapped) return;
 
@@ -1682,7 +1681,7 @@ export class ClaudeWsServer {
     if ("strikes" in event) input.strikes = event.strikes;
     if ("reason" in event) input.reason = event.reason;
 
-    this.eventBus.publish(input);
+    this.onMonitorEvent(input);
   }
 
   private static readonly WORK_ITEM_EVENT_MAP: Record<string, string> = {
@@ -1698,7 +1697,7 @@ export class ClaudeWsServer {
   };
 
   private publishWorkItemMonitorEvent(event: WorkItemEvent): void {
-    if (!this.eventBus) return;
+    if (!this.onMonitorEvent) return;
     const mapped = ClaudeWsServer.WORK_ITEM_EVENT_MAP[event.type];
     if (!mapped) return;
 
@@ -1716,7 +1715,7 @@ export class ClaudeWsServer {
     if ("to" in event) input.to = event.to;
     if ("runId" in event) input.runId = event.runId;
 
-    this.eventBus.publish(input);
+    this.onMonitorEvent(input);
   }
 
   private async handlePermissionRequest(

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -616,6 +616,7 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
 
   // Reset idle timer on Claude/Codex/ACP session worker events (db:upsert, db:state, db:cost)
   claudeServer.onActivity = () => resetIdleTimer();
+  claudeServer.onMonitorEvent = (input) => mailEventBus.publish(input);
   if (codexServer) {
     codexServer.onActivity = () => resetIdleTimer();
   }

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -6,7 +6,9 @@ import { join } from "node:path";
 import type { IpcResponse } from "@mcp-cli/core";
 import { IPC_ERROR, PROTOCOL_VERSION, options, silentLogger } from "@mcp-cli/core";
 import { testOptions } from "../../../test/test-options";
+import { ClaudeServer } from "./claude-server";
 import { installDaemonLogCapture } from "./daemon-log";
+import { StateDb } from "./db/state";
 import { EventBus } from "./event-bus";
 import { EventLog } from "./event-log";
 import { IpcServer } from "./ipc-server";
@@ -2426,6 +2428,73 @@ describe("IpcServer HTTP transport", () => {
       expect(lines.length).toBe(2);
       const seqs = lines.map((l) => (JSON.parse(l) as Record<string, unknown>).seq as number);
       expect(seqs[0]).toBeLessThan(seqs[1] as number);
+    });
+
+    test("worker monitor:event round-trips to GET /events subscriber (#1567)", async () => {
+      const bus = new EventBus();
+      socketPath = tmpSocket();
+      server = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, {
+        ...opts(),
+        eventBus: bus,
+      });
+      server.start(socketPath);
+
+      // Simulate the bridge: ClaudeServer.onMonitorEvent publishes to the daemon bus
+      const bridgedDb = new StateDb(testOptions().DB_PATH);
+      const claudeServer = new ClaudeServer(bridgedDb, undefined, undefined, silentLogger);
+      claudeServer.onMonitorEvent = (input) => bus.publish(input);
+
+      const controller = new AbortController();
+      const res = await fetch("http://localhost/events", {
+        method: "GET",
+        unix: socketPath,
+        signal: controller.signal,
+      } as RequestInit);
+
+      expect(res.status).toBe(200);
+      if (!res.body) throw new Error("Expected response body");
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+
+      await reader.read(); // drain initial flush
+
+      // Simulate worker posting a monitor:event message
+      const handle = (claudeServer as unknown as { handleWorkerEvent: (e: unknown) => void }).handleWorkerEvent.bind(
+        claudeServer,
+      );
+      handle({
+        type: "monitor:event",
+        input: {
+          src: "daemon.claude-server",
+          event: "session.result",
+          category: "session",
+          sessionId: "bridge-test",
+          cost: 1.23,
+          numTurns: 5,
+        },
+      });
+
+      let buffer = "";
+      const deadline = Date.now() + 2_000;
+      while (Date.now() < deadline) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        if (buffer.includes("session.result")) break;
+      }
+
+      controller.abort();
+      reader.releaseLock();
+      bridgedDb.close();
+
+      const line = buffer.trim().split("\n")[0];
+      const parsed = JSON.parse(line ?? "{}") as Record<string, unknown>;
+      expect(parsed.event).toBe("session.result");
+      expect(parsed.sessionId).toBe("bridge-test");
+      expect(parsed.cost).toBe(1.23);
+      expect(parsed.numTurns).toBe(5);
+      expect(parsed.seq).toBe(1);
+      expect(typeof parsed.ts).toBe("string");
     });
 
     test("responseTail does not bypass category filter", async () => {

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -2440,7 +2440,8 @@ describe("IpcServer HTTP transport", () => {
       server.start(socketPath);
 
       // Simulate the bridge: ClaudeServer.onMonitorEvent publishes to the daemon bus
-      const bridgedDb = new StateDb(testOptions().DB_PATH);
+      using bridgedOpts = testOptions();
+      const bridgedDb = new StateDb(bridgedOpts.DB_PATH);
       const claudeServer = new ClaudeServer(bridgedDb, undefined, undefined, silentLogger);
       claudeServer.onMonitorEvent = (input) => bus.publish(input);
 


### PR DESCRIPTION
## Summary
- **Removed the isolated worker-thread `EventBus`** — session and work-item monitor events were being published to a bus with no subscribers, silently dropping all events from `GET /events`
- **Added `onMonitorEvent` callback chain**: `ClaudeWsServer` → `postMessage("monitor:event")` → `ClaudeServer.handleWorkerEvent` → `onMonitorEvent` → `mailEventBus.publish()` — events now reach `/events` subscribers with correct monotonic seq from the main-thread bus
- **Seq monotonicity preserved**: `MonitorEventInput` (no seq/ts) crosses the worker boundary; seq is assigned solely by the main-thread `EventBus` with `EventLog`

## Test plan
- [x] Unit tests: `monitor:event` forwarded via `onMonitorEvent` callback, safe when callback not set, preserves extra fields (cost, tokens, prNumber)
- [x] Integration test: full round-trip from `handleWorkerEvent(monitor:event)` → `EventBus` → `GET /events` NDJSON subscriber verifying seq, ts, and all fields
- [x] Seq monotonicity test: 5 sequential worker events produce seq 1–5 on the daemon bus
- [x] `WORKER_EVENT_TYPES` exhaustiveness test updated for `monitor:event`
- [x] `isWorkerEvent` test covers `monitor:event`
- [x] Full test suite: 5495 pass, 0 fail
- [x] Typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)