### PR TITLE
fix(auth): stage DCR client info in memory until token exchange succeeds (fixes #1517)

### DIFF
--- a/packages/daemon/src/auth/oauth-provider.spec.ts
+++ b/packages/daemon/src/auth/oauth-provider.spec.ts
@@ -403,15 +403,57 @@ describe("McpOAuthProvider", () => {
       db.close();
     });
 
-    test("saveClientInformation persists to SQLite", () => {
+    test("saveClientInformation stages in memory, not SQLite", () => {
       const db = createDb();
       const provider = createProvider(db);
 
-      provider.saveClientInformation({ client_id: "saved-client" });
+      provider.saveClientInformation({ client_id: "staged-client" });
+
+      expect(db.getClientInfo("srv")).toBeUndefined();
+      db.close();
+    });
+
+    test("saveTokens flushes pending client info to SQLite", () => {
+      const db = createDb();
+      const provider = createProvider(db);
+
+      provider.saveClientInformation({ client_id: "staged-client", client_secret: "secret" });
+      expect(db.getClientInfo("srv")).toBeUndefined();
+
+      provider.saveTokens({ access_token: "tok", token_type: "Bearer" });
 
       const stored = db.getClientInfo("srv");
       expect(stored).toBeDefined();
-      expect(stored?.client_id).toBe("saved-client");
+      expect(stored?.client_id).toBe("staged-client");
+      expect(stored?.client_secret).toBe("secret");
+      db.close();
+    });
+
+    test("abandoned flow does not persist client info to new provider", async () => {
+      const db = createDb();
+      const provider1 = createProvider(db);
+
+      provider1.saveClientInformation({ client_id: "abandoned-client" });
+      // Flow abandoned — saveTokens never called
+
+      // New provider instance (simulates next auth attempt)
+      const provider2 = createProvider(db);
+      const info = await provider2.clientInformation();
+
+      // Should not find the abandoned client — falls through to undefined
+      expect(info).toBeUndefined();
+      db.close();
+    });
+
+    test("clientInformation returns staged info during same provider instance", async () => {
+      const db = createDb();
+      const provider = createProvider(db);
+
+      provider.saveClientInformation({ client_id: "in-flight-client" });
+      const info = await provider.clientInformation();
+
+      expect(info).toBeDefined();
+      expect(info?.client_id).toBe("in-flight-client");
       db.close();
     });
 

--- a/packages/daemon/src/auth/oauth-provider.spec.ts
+++ b/packages/daemon/src/auth/oauth-provider.spec.ts
@@ -327,6 +327,18 @@ describe("McpOAuthProvider", () => {
       db.close();
     });
 
+    test("invalidateCredentials('client') clears pending client info", async () => {
+      const db = createDb();
+      const provider = createProvider(db);
+
+      provider.saveClientInformation({ client_id: "staged-client" });
+      provider.invalidateCredentials("client");
+
+      const info = await provider.clientInformation();
+      expect(info).toBeUndefined();
+      db.close();
+    });
+
     test("invalidateCredentials('client') does not affect tokens or verifier", () => {
       const db = createDb();
       const provider = createProvider(db);
@@ -338,6 +350,18 @@ describe("McpOAuthProvider", () => {
 
       expect(db.getTokens("srv")?.access_token).toBe("tok");
       expect(db.getVerifier("srv")).toBe("pkce-123");
+      db.close();
+    });
+
+    test("invalidateCredentials('all') clears pending client info", async () => {
+      const db = createDb();
+      const provider = createProvider(db);
+
+      provider.saveClientInformation({ client_id: "staged-client" });
+      provider.invalidateCredentials("all");
+
+      const info = await provider.clientInformation();
+      expect(info).toBeUndefined();
       db.close();
     });
 
@@ -454,6 +478,28 @@ describe("McpOAuthProvider", () => {
 
       expect(info).toBeDefined();
       expect(info?.client_id).toBe("in-flight-client");
+      db.close();
+    });
+
+    test("saveTokens with pending client info is atomic (both or neither persist)", () => {
+      const db = createDb();
+      const provider = createProvider(db);
+
+      provider.saveClientInformation({ client_id: "atomic-client" });
+
+      const origMethod = db.saveClientInfoAndTokens.bind(db);
+      db.saveClientInfoAndTokens = () => {
+        throw new Error("simulated transactional save failure");
+      };
+
+      expect(() => {
+        provider.saveTokens({ access_token: "tok", token_type: "Bearer" });
+      }).toThrow("simulated transactional save failure");
+
+      expect(db.getClientInfo("srv")).toBeUndefined();
+      expect(db.getTokens("srv")).toBeUndefined();
+
+      db.saveClientInfoAndTokens = origMethod;
       db.close();
     });
 

--- a/packages/daemon/src/auth/oauth-provider.ts
+++ b/packages/daemon/src/auth/oauth-provider.ts
@@ -52,6 +52,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
   private _redirectUrl: string | undefined;
   private keychainCache: KeychainTokens | null | undefined; // undefined = not loaded
   private opts: OAuthProviderOpts;
+  private pendingClientInfo: OAuthClientInformationMixed | undefined;
 
   constructor(serverName: string, serverUrl: string, db: StateDb, opts?: OAuthProviderOpts) {
     this.serverName = serverName;
@@ -123,22 +124,28 @@ export class McpOAuthProvider implements OAuthClientProvider {
       return info;
     }
 
-    // 1. Check SQLite
+    // 1. Check in-memory staging (DCR result not yet confirmed by token exchange)
+    if (this.pendingClientInfo) return this.pendingClientInfo;
+
+    // 2. Check SQLite (confirmed client from a previous successful flow)
     const dbInfo = this.db.getClientInfo(this.serverName);
     if (dbInfo) return dbInfo;
 
-    // 2. Check Keychain (Claude Code may have registered a client)
+    // 3. Check Keychain (Claude Code may have registered a client)
     const kc = await this.loadKeychain();
     if (kc) {
       return { client_id: kc.clientId };
     }
 
-    // 3. No client info → SDK will attempt dynamic registration
+    // 4. No client info → SDK will attempt dynamic registration
     return undefined;
   }
 
   saveClientInformation(info: OAuthClientInformationMixed): void {
-    this.db.saveClientInfo(this.serverName, info);
+    // Stage in memory — only persist to SQLite once saveTokens() confirms
+    // the client can complete a flow. Prevents zombie client_ids from
+    // poisoning future auth attempts when the flow is abandoned mid-way.
+    this.pendingClientInfo = info;
   }
 
   async tokens(): Promise<OAuthTokens | undefined> {
@@ -166,6 +173,10 @@ export class McpOAuthProvider implements OAuthClientProvider {
   }
 
   saveTokens(tokens: OAuthTokens): void {
+    if (this.pendingClientInfo) {
+      this.db.saveClientInfo(this.serverName, this.pendingClientInfo);
+      this.pendingClientInfo = undefined;
+    }
     this.db.saveTokens(this.serverName, tokens);
   }
 

--- a/packages/daemon/src/auth/oauth-provider.ts
+++ b/packages/daemon/src/auth/oauth-provider.ts
@@ -6,7 +6,8 @@
  * 2. macOS Keychain (Claude Code's tokens — read-only)
  * 3. undefined → triggers SDK auth flow
  *
- * Writes always go to SQLite (never touch Keychain).
+ * DCR client info is staged in memory until token exchange succeeds,
+ * then persisted to SQLite atomically with tokens. Keychain is read-only.
  */
 
 import type { OAuthClientProvider, OAuthDiscoveryState } from "@modelcontextprotocol/sdk/client/auth.js";

--- a/packages/daemon/src/auth/oauth-provider.ts
+++ b/packages/daemon/src/auth/oauth-provider.ts
@@ -174,10 +174,11 @@ export class McpOAuthProvider implements OAuthClientProvider {
 
   saveTokens(tokens: OAuthTokens): void {
     if (this.pendingClientInfo) {
-      this.db.saveClientInfo(this.serverName, this.pendingClientInfo);
+      this.db.saveClientInfoAndTokens(this.serverName, this.pendingClientInfo, tokens);
       this.pendingClientInfo = undefined;
+    } else {
+      this.db.saveTokens(this.serverName, tokens);
     }
-    this.db.saveTokens(this.serverName, tokens);
   }
 
   redirectToAuthorization(authorizationUrl: URL): void {
@@ -243,7 +244,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
     switch (scope) {
       case "all":
         this.db.deleteTokens(this.serverName);
-        // Also clear keychain cache so we re-read
+        this.pendingClientInfo = undefined;
         this.keychainCache = undefined;
         break;
       case "tokens":
@@ -251,7 +252,7 @@ export class McpOAuthProvider implements OAuthClientProvider {
         this.keychainCache = undefined;
         break;
       case "client":
-        // Could clear client info but usually not needed
+        this.pendingClientInfo = undefined;
         break;
       case "verifier":
         // Verifier is ephemeral, no need to explicitly clear

--- a/packages/daemon/src/db/state.spec.ts
+++ b/packages/daemon/src/db/state.spec.ts
@@ -826,6 +826,38 @@ describe("StateDb", () => {
     });
   });
 
+  describe("saveClientInfoAndTokens", () => {
+    test("persists both client info and tokens atomically", () => {
+      const db = createDb();
+      db.saveClientInfoAndTokens(
+        "srv",
+        { client_id: "cid", client_secret: "sec" },
+        { access_token: "tok", token_type: "Bearer" },
+      );
+
+      expect(db.getClientInfo("srv")?.client_id).toBe("cid");
+      expect(db.getTokens("srv")?.access_token).toBe("tok");
+      db.close();
+    });
+
+    test("rolls back client info if token INSERT fails", () => {
+      const db = createDb();
+      // biome-ignore lint/complexity/useLiteralKeys: access private field for test
+      const rawDb = db["db"];
+      rawDb.run("DROP TABLE auth_tokens");
+      rawDb.run(
+        "CREATE TABLE auth_tokens (server_name TEXT PRIMARY KEY, access_token TEXT NOT NULL CHECK(length(access_token) > 1000))",
+      );
+
+      expect(() => {
+        db.saveClientInfoAndTokens("srv", { client_id: "cid" }, { access_token: "tok", token_type: "Bearer" });
+      }).toThrow();
+
+      expect(db.getClientInfo("srv")).toBeUndefined();
+      db.close();
+    });
+  });
+
   describe("oauth_verifiers", () => {
     test("saveVerifier and getVerifier round-trip", () => {
       const db = createDb();

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -565,6 +565,13 @@ export class StateDb {
     this.db.run("DELETE FROM auth_tokens WHERE server_name = ?", [serverName]);
   }
 
+  saveClientInfoAndTokens(serverName: string, info: OAuthClientInformationMixed, tokens: OAuthTokens): void {
+    this.db.transaction(() => {
+      this.saveClientInfo(serverName, info);
+      this.saveTokens(serverName, tokens);
+    })();
+  }
+
   // -- OAuth client registration --
 
   getClientInfo(serverName: string): OAuthClientInformationMixed | undefined {


### PR DESCRIPTION
## Summary
- `saveClientInformation()` now stages DCR results in memory (`pendingClientInfo`) instead of writing to SQLite immediately
- `saveTokens()` flushes the pending client info to SQLite alongside tokens, proving the client completed the OAuth flow
- `clientInformation()` checks the in-memory staging tier (after config-level, before SQLite) so in-flight flows still work
- Prevents zombie `client_id` entries in SQLite when flows are abandoned (user closes browser, provider 500s, daemon restarts)

## Test plan
- [x] `saveClientInformation` alone does NOT persist to SQLite
- [x] `saveClientInformation` + `saveTokens` DOES persist to SQLite (including client_secret)
- [x] Abandoned flow (no `saveTokens`) → new provider instance → `clientInformation()` returns `undefined`
- [x] In-flight flow → `clientInformation()` returns staged info on same provider instance
- [x] All 51 OAuth provider tests pass
- [x] Full test suite: 5492 pass, 0 fail
- [x] Typecheck, lint, coverage all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)