### PR TITLE
feat(monitor): wire EventBus to IPC server live stream and fix seq space incompatibility (fixes #1570)

### DIFF
--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -2463,6 +2463,128 @@ describe("IpcServer HTTP transport", () => {
       expect(buffer).not.toContain("session.response");
       expect(buffer).toContain("mail.received");
     });
+
+    test("backfill→live handoff: no gap or duplicates when since=<seq> with pre-populated log", async () => {
+      const db = new Database(":memory:");
+      const eventLog = new EventLog(db);
+      const bus = new EventBus(eventLog);
+      socketPath = tmpSocket();
+
+      // Pre-populate 5 events before constructing the server
+      for (let i = 0; i < 5; i++) {
+        bus.publish({ src: "test", event: "session.result", category: "session", sessionId: `s${i}` });
+      }
+
+      server = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, {
+        ...opts(),
+        eventBus: bus,
+      });
+      server.start(socketPath);
+
+      const controller = new AbortController();
+      const res = await fetch("http://localhost/events?since=2", {
+        method: "GET",
+        unix: socketPath,
+        signal: controller.signal,
+      } as RequestInit);
+
+      expect(res.status).toBe(200);
+      if (!res.body) throw new Error("Expected response body");
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+
+      // Read until backfill arrives (it's enqueued synchronously with the flush newline)
+      let buffer = "";
+      const deadline1 = Date.now() + 2_000;
+      while (Date.now() < deadline1) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        // Backfill has 3 events (seq 3,4,5) — wait for all of them
+        if (buffer.split("\n").filter((l) => l.startsWith("{")).length >= 3) break;
+      }
+
+      // Now publish a live event after backfill is consumed
+      bus.publish({ src: "test", event: "pr.merged", category: "work_item", prNumber: 99 });
+
+      const deadline2 = Date.now() + 2_000;
+      while (Date.now() < deadline2) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        if (buffer.includes("pr.merged")) break;
+      }
+
+      controller.abort();
+      reader.releaseLock();
+
+      const lines = buffer.split("\n").filter((l) => l.startsWith("{"));
+      const events = lines.map((l) => JSON.parse(l) as { seq: number; event: string });
+
+      // Backfill (seq 3,4,5) + live (seq 6)
+      expect(events.length).toBe(4);
+      expect(events[0]?.seq).toBe(3);
+      expect(events[1]?.seq).toBe(4);
+      expect(events[2]?.seq).toBe(5);
+      expect(events[3]?.seq).toBe(6);
+      expect(events[3]?.event).toBe("pr.merged");
+
+      for (let i = 1; i < events.length; i++) {
+        expect(events[i]?.seq).toBe((events[i - 1]?.seq as number) + 1);
+      }
+    });
+
+    test("fresh EventLog, no backfill: live events arrive with monotonic seq starting at 1", async () => {
+      const db = new Database(":memory:");
+      const eventLog = new EventLog(db);
+      const bus = new EventBus(eventLog);
+      socketPath = tmpSocket();
+      server = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, {
+        ...opts(),
+        eventBus: bus,
+      });
+      server.start(socketPath);
+
+      const controller = new AbortController();
+      const res = await fetch("http://localhost/events", {
+        method: "GET",
+        unix: socketPath,
+        signal: controller.signal,
+      } as RequestInit);
+
+      expect(res.status).toBe(200);
+      if (!res.body) throw new Error("Expected response body");
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+
+      // Drain initial flush newline
+      await reader.read();
+
+      // Publish 3 live events
+      bus.publish({ src: "test", event: "session.result", category: "session", sessionId: "s1" });
+      bus.publish({ src: "test", event: "pr.merged", category: "work_item", prNumber: 1 });
+      bus.publish({ src: "test", event: "mail.received", category: "mail", mailId: 1, sender: "a", recipient: "b" });
+
+      let buffer = "";
+      const deadline = Date.now() + 2_000;
+      while (Date.now() < deadline) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        if (buffer.includes("mail.received")) break;
+      }
+
+      controller.abort();
+      reader.releaseLock();
+
+      const lines = buffer.split("\n").filter((l) => l.startsWith("{"));
+      const events = lines.map((l) => JSON.parse(l) as { seq: number; event: string });
+
+      expect(events.length).toBe(3);
+      expect(events[0]?.seq).toBe(1);
+      expect(events[1]?.seq).toBe(2);
+      expect(events[2]?.seq).toBe(3);
+    });
   });
 
   // -- GET /events NDJSON endpoint tests (ring-buffer / pushEvent path) --

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -183,6 +183,7 @@ export class IpcServer {
   /** Event stream infrastructure */
   private eventSeq = 0;
   private eventSubscribers = new Set<(event: Record<string, unknown>) => void>();
+  private eventBusSubId: number | null = null;
 
   constructor(
     private pool: ServerPool,
@@ -225,6 +226,23 @@ export class IpcServer {
     this.loadManifestFn = options.loadManifest ?? ((r) => loadManifest(r)?.manifest ?? null);
     this.drainTimeoutMs = options.drainTimeoutMs ?? 5_000;
     this.eventBus = options.eventBus ?? null;
+    if (this.eventBus) {
+      this.eventSeq = this.eventBus.currentSeq;
+      this.eventBusSubId = this.eventBus.subscribe((event) => {
+        this.eventSeq = event.seq;
+        const envelope = event as unknown as Record<string, unknown>;
+        const failed: ((e: Record<string, unknown>) => void)[] = [];
+        for (const cb of this.eventSubscribers) {
+          try {
+            cb(envelope);
+          } catch (err) {
+            this.logger.warn(`[events] subscriber threw, dropping: ${err}`);
+            failed.push(cb);
+          }
+        }
+        for (const cb of failed) this.eventSubscribers.delete(cb);
+      });
+    }
     this.workItemDb = new WorkItemDb(this.db.getDatabase());
     this.registerHandlers();
     // Prune expired ephemeral aliases on startup
@@ -338,6 +356,10 @@ export class IpcServer {
     if (this.drainTimer) {
       clearTimeout(this.drainTimer);
       this.drainTimer = null;
+    }
+    if (this.eventBusSubId !== null && this.eventBus) {
+      this.eventBus.unsubscribe(this.eventBusSubId);
+      this.eventBusSubId = null;
     }
     this.server?.stop(true);
     try {


### PR DESCRIPTION
## Summary
- Seed `IpcServer.eventSeq` from `EventBus.currentSeq` when EventBus is provided, so the ring-buffer path's seq counter starts where the durable EventLog left off — fixing the seq space split that caused all live events to be silently dropped after backfill
- Subscribe IpcServer to EventBus in the constructor to forward published events to `eventSubscribers`, closing the gap where EventBus events were persisted to SQLite but never delivered to `/events` NDJSON streams
- Unsubscribe from EventBus on `stop()` to prevent leaks across tests

## Test plan
- [x] Integration test: pre-populated EventLog (seq 1..5), connect with `?since=2`, verify backfill events (seq 3,4,5) followed by live event (seq 6) — no gap, no duplicates, monotonic ordering
- [x] Integration test: fresh EventLog with no backfill, verify live events arrive with monotonic seq starting at 1
- [x] All 5,491 existing tests pass (0 failures)
- [x] Typecheck, lint, coverage all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)