### PR TITLE
fix(command): remove duplicate monitor entry in printUsage, verify completions (fixes #1566)

### DIFF
--- a/packages/command/src/commands/completions.spec.ts
+++ b/packages/command/src/commands/completions.spec.ts
@@ -28,6 +28,7 @@ describe("SUBCOMMANDS", () => {
     "alias",
     "run",
     "logs",
+    "monitor",
     "typegen",
     "restart",
     "shutdown",

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -940,9 +940,8 @@ Aliases:
 Utility:
   mcx search/install/update           Registry search and install
   mcx gc [--dry-run]                  Prune merged branches + stale worktrees
-  mcx monitor [flags]                 Stream unified daemon events
+  mcx monitor [flags]                 Stream unified daemon events (--json for NDJSON)
   mcx logs <server> [-f]              View server stderr
-  mcx monitor [flags]                 Stream daemon events as NDJSON (| jq friendly)
   mcx mail <subcommand>               Inter-session messaging
   mcx note <subcommand>               Tool annotations
   mcx serve                           Run as stdio MCP server


### PR DESCRIPTION
## Summary
- Removed duplicate `mcx monitor [flags]` line from `printUsage()` in `main.ts` — it appeared twice (lines 943 and 945), now merged into one clear entry with the `--json` hint
- Confirmed `monitor` was already present in `SUBCOMMANDS` in `completions.ts` — shell completions were correct
- Confirmed `mcx monitor --help` already documents all required flags (`--subscribe`, `--session`, `--pr`, `--work-item`, `--type`, `--src`, `--phase`, `--since`, `--until`, `--timeout`, `--max-events`, `--json`)
- Added `monitor` to the expected subcommands list in `completions.spec.ts` to lock the invariant

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test packages/command/src/commands/completions.spec.ts` passes (90 tests, including new monitor assertion)
- [x] `bun test packages/command/src/commands/monitor.spec.ts` passes (all 90 tests)
- [x] Full pre-commit hook suite passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)