### PR TITLE
fix(phases/done): report merged:true when worktree blocks local branch delete (fixes #1539)

### DIFF
--- a/.claude/phases/done.ts
+++ b/.claude/phases/done.ts
@@ -14,7 +14,7 @@
 import { defineAlias, z } from "mcp-cli";
 
 type MergeResult =
-  | { ok: true; prNumber: number }
+  | { ok: true; prNumber: number; localCleanup?: string }
   | {
       ok: false;
       reason:
@@ -89,6 +89,22 @@ function mergePr(prNumber: number): MergeResult {
   });
   if (mergeProc.exitCode !== 0) {
     const stderr = new TextDecoder().decode(mergeProc.stderr);
+    // Local branch delete fails when an impl worktree holds the branch open.
+    // The GitHub merge may have already succeeded — check before reporting failure.
+    if (/used by worktree|cannot delete branch.*checked out/i.test(stderr)) {
+      const viewProc = Bun.spawnSync({
+        cmd: ["gh", "pr", "view", String(prNumber), "--json", "state", "-q", ".state"],
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      if (new TextDecoder().decode(viewProc.stdout).trim() === "MERGED") {
+        return {
+          ok: true,
+          prNumber,
+          localCleanup: "skipped: worktree holds branch (bye impl session to prune)",
+        };
+      }
+    }
     if (/not mergeable|conflict/i.test(stderr)) {
       return {
         ok: false,
@@ -123,6 +139,7 @@ defineAlias({
     merged: z.boolean(),
     prNumber: z.number(),
     issueNumber: z.number(),
+    localCleanup: z.string().optional(),
     error: z
       .object({
         reason: z.string(),
@@ -184,6 +201,11 @@ defineAlias({
     Bun.spawnSync({ cmd: ["git", "config", "core.bare", "false"] });
     Bun.spawnSync({ cmd: ["git", "pull"] });
 
-    return { merged: true, prNumber: work.prNumber, issueNumber: work.issueNumber };
+    return {
+      merged: true,
+      prNumber: work.prNumber,
+      issueNumber: work.issueNumber,
+      ...(result.localCleanup ? { localCleanup: result.localCleanup } : {}),
+    };
   },
 });


### PR DESCRIPTION
## Summary
- When `gh pr merge --delete-branch` merges on GitHub but the local branch delete fails because an impl session's worktree holds the branch, the phase now returns `merged: true` with a `localCleanup` field instead of `merged: false` / `reason: "merge_failed"`
- Detects the `"used by worktree"` / `"cannot delete branch.*checked out"` error pattern in stderr, then verifies the PR's GitHub state via `gh pr view --json state`; only promotes to success if state is `MERGED`
- Adds `localCleanup?: string` to both the `MergeResult` type and the `defineAlias` output schema so orchestrators can observe the skipped cleanup and act on it (e.g., `mcx claude bye <impl-session>`)

## Test plan
- [ ] `bun typecheck` — passes
- [ ] `bun lint` — passes (580 files, no fixes applied)
- [ ] `bun test` — 5489 pass, 0 fail across 231 files
- [ ] Behavior: worktree-holds-branch path returns `{ merged: true, localCleanup: "skipped: worktree holds branch (bye impl session to prune)" }` instead of `merge_failed`
- [ ] Behavior: non-worktree failures still fall through to `conflicts`, `missing_required_check`, or `merge_failed` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)