### PR TITLE
fix(monitor): handle EPIPE so `mcx monitor | head -N` exits cleanly (fixes #1559)

### DIFF
--- a/packages/command/src/commands/monitor.spec.ts
+++ b/packages/command/src/commands/monitor.spec.ts
@@ -339,6 +339,7 @@ function makeStreamDeps(events: MonitorEvent[], overrides: Partial<MonitorDeps> 
       throw new Error(`exit(${code})`);
     },
     onSigint: () => {},
+    onStdoutError: () => {},
     ...overrides,
   };
 }
@@ -429,6 +430,7 @@ describe("cmdMonitor", () => {
         throw new Error(`exit:${code}`);
       },
       onSigint: () => {},
+      onStdoutError: () => {},
     };
     // Should not throw — AbortError is treated as clean exit
     await expect(cmdMonitor([], deps)).resolves.toBeUndefined();
@@ -452,6 +454,7 @@ describe("cmdMonitor", () => {
         throw new Error(`exit:${code}`);
       },
       onSigint: () => {},
+      onStdoutError: () => {},
     };
     await expect(cmdMonitor([], deps)).rejects.toThrow("exit:1");
     expect(stderr.join("")).toContain("connection refused");
@@ -476,9 +479,68 @@ describe("cmdMonitor", () => {
         throw new Error(`exit:${code}`);
       },
       onSigint: () => {},
+      onStdoutError: () => {},
     };
     // timeout=0 fires immediately; stream may already be exhausted — no crash is the assertion
     await cmdMonitor(["--timeout", "0"], deps);
     expect(typeof abortCalled).toBe("boolean");
+  });
+
+  test("EPIPE on stdout calls finish(0) via onStdoutError handler", async () => {
+    let capturedErrHandler: ((err: Error) => void) | undefined;
+    const exitCalls: number[] = [];
+
+    async function* emptyGen(): AsyncGenerator<MonitorEvent> {}
+
+    const deps: MonitorDeps = {
+      openEventStream: () => ({ events: emptyGen(), abort: () => {} }),
+      isTTY: true,
+      writeStdout: () => {},
+      writeStderr: () => {},
+      exit: (code) => {
+        exitCalls.push(code);
+        return undefined as never;
+      },
+      onSigint: () => {},
+      onStdoutError: (fn) => {
+        capturedErrHandler = fn;
+      },
+    };
+
+    await cmdMonitor([], deps);
+
+    expect(capturedErrHandler).toBeDefined();
+    const epipe = Object.assign(new Error("write EPIPE"), { code: "EPIPE" });
+    capturedErrHandler?.(epipe);
+    expect(exitCalls).toEqual([0]);
+  });
+
+  test("non-EPIPE stdout errors do not trigger finish", async () => {
+    let capturedErrHandler: ((err: Error) => void) | undefined;
+    const exitCalls: number[] = [];
+
+    async function* emptyGen(): AsyncGenerator<MonitorEvent> {}
+
+    const deps: MonitorDeps = {
+      openEventStream: () => ({ events: emptyGen(), abort: () => {} }),
+      isTTY: true,
+      writeStdout: () => {},
+      writeStderr: () => {},
+      exit: (code) => {
+        exitCalls.push(code);
+        return undefined as never;
+      },
+      onSigint: () => {},
+      onStdoutError: (fn) => {
+        capturedErrHandler = fn;
+      },
+    };
+
+    await cmdMonitor([], deps);
+
+    expect(capturedErrHandler).toBeDefined();
+    const otherErr = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    capturedErrHandler?.(otherErr);
+    expect(exitCalls).toHaveLength(0);
   });
 });

--- a/packages/command/src/commands/monitor.ts
+++ b/packages/command/src/commands/monitor.ts
@@ -35,6 +35,7 @@ export interface MonitorDeps {
   writeStderr: (line: string) => void;
   exit: (code: number) => never;
   onSigint: (fn: () => void) => void;
+  onStdoutError: (fn: (err: Error) => void) => void;
 }
 
 const defaultDeps: MonitorDeps = {
@@ -44,6 +45,7 @@ const defaultDeps: MonitorDeps = {
   writeStderr: (line) => process.stderr.write(line),
   exit: (code) => process.exit(code),
   onSigint: (fn) => process.once("SIGINT", fn),
+  onStdoutError: (fn) => process.stdout.on("error", fn),
 };
 
 export function parseMonitorArgs(args: string[]): MonitorArgs {
@@ -242,6 +244,9 @@ export async function cmdMonitor(args: string[], deps?: Partial<MonitorDeps>): P
   }
 
   d.onSigint(() => finish(0));
+  d.onStdoutError((err) => {
+    if ((err as Error & { code?: string }).code === "EPIPE") finish(0);
+  });
 
   let count = 0;
 


### PR DESCRIPTION
## Summary
- Adds `onStdoutError` to `MonitorDeps` (mirroring the existing `onSigint` pattern) so stdout error handling is dependency-injectable and testable
- Default dep wires `process.stdout.on("error", fn)` on the real process stdout
- When the error code is `"EPIPE"`, calls `finish(0)` — same clean-shutdown path as SIGINT and `--timeout`

## Test plan
- Added `"EPIPE on stdout calls finish(0) via onStdoutError handler"` — captures the registered handler, fires a simulated EPIPE, verifies `exit(0)` was called
- Added `"non-EPIPE stdout errors do not trigger finish"` — fires a non-EPIPE error, verifies `exit` was not called
- Updated all existing `MonitorDeps` literals in the test file to include the new `onStdoutError: () => {}` no-op
- All 40 monitor tests pass; full suite (5491 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)