### PR TITLE
fix(phase): fall back to work_items.phase when transition log is empty (fixes #1522)

### DIFF
--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -1718,6 +1718,78 @@ defineAlias(({ z }) => ({
     expect(entries.filter((e) => e.status === "committed").length).toBe(2);
     expect(entries.filter((e) => e.status === "attempted").length).toBe(2);
   }, 30_000);
+
+  test("falls back to work_items.phase when transition log is empty (#1522)", async () => {
+    // Manifest with impl → triage flow (mirrors real sprint graph)
+    const manifest = `
+runsOn: main
+initial: impl
+phases:
+  impl:
+    source: ./impl.ts
+    next: [triage]
+  triage:
+    source: ./triage.ts
+    next: [done]
+  done:
+    source: ./impl.ts
+    next: []
+`.trim();
+    const triageAlias = `
+import { defineAlias, z } from "mcp-cli";
+defineAlias(({ z }) => ({
+  name: "triage",
+  description: "triage",
+  input: z.object({}).default({}),
+  output: z.object({ action: z.string() }),
+  fn: async () => ({ action: "done" }),
+}));
+`.trim();
+    writeFileSync(join(dir, ".mcx.yaml"), manifest);
+    writeFileSync(join(dir, "impl.ts"), phaseAlias);
+    writeFileSync(join(dir, "triage.ts"), triageAlias);
+    const { deps: installDeps } = makeDriftDeps(dir);
+    await cmdPhase(["install"], installDeps);
+
+    // work_items.phase = "impl" but transition log is empty (impl was manually spawned)
+    const ex = makeExecDeps({
+      workItem: {
+        id: "#1504",
+        issueNumber: 1504,
+        prNumber: null,
+        branch: "feat/1504",
+        prState: null,
+        prUrl: null,
+        ciStatus: "none",
+        ciRunId: null,
+        ciSummary: null,
+        reviewStatus: "pending",
+        phase: "impl",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    });
+    const errs: string[] = [];
+    let exitCode: number | undefined;
+    await executePhase(
+      ["triage", "--work-item", "#1504"],
+      {
+        ...makeDriftDeps(dir).deps,
+        log: () => {},
+        logError: (m) => errs.push(m),
+        exit: ((c: number) => {
+          exitCode = c;
+          throw new Error(`exit(${c})`);
+        }) as (code: number) => never,
+      },
+      { ipcCall: ex.ipcCall, exec: ex.exec, findGitRoot: ex.findGitRoot, now: ex.now },
+    ).catch(() => {});
+
+    // Must succeed: work_items.phase="impl" provides the implicit --from
+    expect(exitCode).toBeUndefined();
+    expect(errs.some((e) => e.includes("approved") && e.includes("impl") && e.includes("triage"))).toBe(true);
+    expect(errs.some((e) => e.includes("(initial)"))).toBe(false);
+  }, 30_000);
 });
 
 describe("spawnExec (#1408)", () => {

--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -1790,6 +1790,83 @@ defineAlias(({ z }) => ({
     expect(errs.some((e) => e.includes("approved") && e.includes("impl") && e.includes("triage"))).toBe(true);
     expect(errs.some((e) => e.includes("(initial)"))).toBe(false);
   }, 30_000);
+
+  test("ignores work_items.phase fallback when phase name not in manifest (#1636)", async () => {
+    // Manifest uses "impl" but daemon returns a work item with phase="implement" (mismatched)
+    // Should fall through to Rule 4 (initial enforcement) rather than UnknownPhaseError for "from"
+    const noopAlias = `
+import { defineAlias, z } from "mcp-cli";
+defineAlias(({ z }) => ({
+  name: "noop",
+  description: "noop",
+  input: z.object({}).default({}),
+  output: z.object({ action: z.string() }),
+  fn: async () => ({ action: "done" }),
+}));
+`.trim();
+    writeFileSync(
+      join(dir, ".mcx.yaml"),
+      `
+runsOn: main
+initial: impl
+phases:
+  impl:
+    source: ./impl2.ts
+    next: [triage]
+  triage:
+    source: ./triage2.ts
+    next: [done]
+  done:
+    source: ./impl2.ts
+    next: []
+`.trim(),
+    );
+    writeFileSync(join(dir, "impl2.ts"), noopAlias);
+    writeFileSync(join(dir, "triage2.ts"), noopAlias);
+    const { deps: installDeps } = makeDriftDeps(dir);
+    await cmdPhase(["install"], installDeps);
+
+    // work_items.phase = "implement" is NOT in the manifest (manifest has "impl")
+    const ex = makeExecDeps({
+      workItem: {
+        id: "#999",
+        issueNumber: 999,
+        prNumber: null,
+        branch: "feat/999",
+        prState: null,
+        prUrl: null,
+        ciStatus: "none",
+        ciRunId: null,
+        ciSummary: null,
+        reviewStatus: "pending",
+        phase: "implement",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    });
+    // validateTransition throws DisallowedTransitionError which propagates out of executePhase
+    // (cmdPhase catches it; here we capture it directly)
+    let caughtErr: unknown;
+    await executePhase(
+      ["triage", "--work-item", "#999"],
+      {
+        ...makeDriftDeps(dir).deps,
+        log: () => {},
+        logError: () => {},
+        exit: (() => {
+          throw new Error("exit");
+        }) as (code: number) => never,
+      },
+      { ipcCall: ex.ipcCall, exec: ex.exec, findGitRoot: ex.findGitRoot, now: ex.now },
+    ).catch((e) => {
+      caughtErr = e;
+    });
+
+    // Must fail with DisallowedTransitionError "(initial) → triage", NOT UnknownPhaseError for "implement"
+    expect(caughtErr).toBeInstanceOf(DisallowedTransitionError);
+    expect(String(caughtErr)).toContain("(initial)");
+    expect(String(caughtErr)).not.toContain("implement");
+  }, 30_000);
 });
 
 describe("spawnExec (#1408)", () => {

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -1000,6 +1000,27 @@ export async function executePhase(
     d.exit(1);
   }
 
+  // Fetch work item early — needed for resolvedFrom fallback (#1522).
+  // We do NOT auto-resolve the current branch to a work item — if the
+  // orchestrator doesn't pass --work-item, phases self-enforce by throwing
+  // from their own assertions (e.g. `if (!ctx.workItem) throw`).
+  let workItem: AliasWorkItemInfo | null = null;
+  if (parsed.workItemId !== null) {
+    try {
+      const wi = (await ex.ipcCall("getWorkItem", { id: parsed.workItemId })) as WorkItem | null;
+      if (!wi) {
+        d.logError(`work item "${parsed.workItemId}" not found`);
+        d.exit(1);
+      }
+      workItem = toAliasWorkItem(wi);
+    } catch (err) {
+      d.logError(
+        `failed to fetch work item "${parsed.workItemId}": ${err instanceof Error ? err.message : String(err)}`,
+      );
+      d.exit(1);
+    }
+  }
+
   // Pre-validate the transition with committed-only history so bogus
   // moves (unknown from, disallowed, un-forced regression) fail BEFORE
   // we spend cycles running the handler. The final commit below repeats
@@ -1008,8 +1029,19 @@ export async function executePhase(
   const logPath = transitionLogPath(cwd);
   const prior = readTransitionHistory(logPath, parsed.workItemId).filter(isCommitted);
   const priorTargets = historyTargets(prior);
+  // When --from is not given and transition history is empty, fall back to
+  // work_items.phase as the implicit "from" so manually-spawned impl sessions
+  // don't cause a spurious "(initial) → triage" rejection (#1522).
+  // Exception: when running the initial phase itself (first launch), keep
+  // from=null so Rule 4 (initial phase enforcement) still applies.
   const resolvedFrom =
-    parsed.from !== null ? parsed.from : priorTargets.length > 0 ? priorTargets[priorTargets.length - 1] : null;
+    parsed.from !== null
+      ? parsed.from
+      : priorTargets.length > 0
+        ? priorTargets[priorTargets.length - 1]
+        : parsed.target !== loaded.manifest.initial
+          ? (workItem?.phase ?? null)
+          : null;
   validateTransition({
     manifest: loaded.manifest,
     from: resolvedFrom,
@@ -1065,27 +1097,6 @@ export async function executePhase(
   const structured = isDefineAlias(srcText);
   const { js } = await d.bundleAlias(resolved);
 
-  // Fetch work item from the daemon if caller supplied one. We do NOT
-  // auto-resolve the current branch to a work item — if the orchestrator
-  // doesn't pass --work-item, phases self-enforce by throwing from their
-  // own assertions (e.g. `if (!ctx.workItem) throw`).
-  let workItem: AliasWorkItemInfo | null = null;
-  if (parsed.workItemId !== null) {
-    try {
-      const wi = (await ex.ipcCall("getWorkItem", { id: parsed.workItemId })) as WorkItem | null;
-      if (!wi) {
-        d.logError(`work item "${parsed.workItemId}" not found`);
-        d.exit(1);
-      }
-      workItem = toAliasWorkItem(wi);
-    } catch (err) {
-      d.logError(
-        `failed to fetch work item "${parsed.workItemId}": ${err instanceof Error ? err.message : String(err)}`,
-      );
-      d.exit(1);
-    }
-  }
-
   const repoRoot = ex.findGitRoot(cwd) ?? NO_REPO_ROOT;
   // State is namespaced by work-item id so every phase touching the same
   // item sees the same scratchpad (see sprint state declarations in
@@ -1137,7 +1148,7 @@ export async function executePhase(
   const txResult = phaseRun(
     {
       target: parsed.target,
-      from: parsed.from,
+      from: resolvedFrom,
       workItemId: parsed.workItemId,
       forceMessage: parsed.forceMessage,
     },

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -940,16 +940,20 @@ function toAliasWorkItem(w: WorkItem): AliasWorkItemInfo {
  *
  * Two-phase transition log (PR #1407 adversarial-review fix):
  *   1. Parse flags (transition + execution inputs)
- *   2. Pre-validate the transition against committed history so bogus
+ *   2. Fetch the work item from the daemon (if `--work-item` given).
+ *      Done early so `work_items.phase` can seed `resolvedFrom` when
+ *      the transition log is empty (#1522). Early-exit on missing id.
+ *   3. Pre-validate the transition against committed history so bogus
  *      moves fail fast before we bundle or dispatch anything.
- *   3. Append an `"attempted"` entry to `.mcx/transitions.jsonl`. This
+ *   4. Append an `"attempted"` entry to `.mcx/transitions.jsonl`. This
  *      captures attempt evidence from ANY branch, including cases that
  *      branch-guard rejects or handlers crash. Attempted entries are
- *      ignored by graph-walk / regression checks (#1407).
- *   4. Branch guard: refuse to dispatch outside the manifest's `runsOn`
+ *      ignored by graph-walk / regression checks (#1407). Note: early
+ *      exits before this point (unknown work-item id, unknown phase,
+ *      disallowed transition) are not captured in the audit log.
+ *   5. Branch guard: refuse to dispatch outside the manifest's `runsOn`
  *      branch. Attempt is already logged for audit.
- *   5. Bundle the phase source
- *   6. Fetch the work item from the daemon (if `--work-item` given)
+ *   6. Bundle the phase source
  *   7. Build a live AliasContext: real MCP proxy + daemon-backed state
  *      (namespaced by the work-item id)
  *   8. Execute the handler
@@ -1032,15 +1036,21 @@ export async function executePhase(
   // When --from is not given and transition history is empty, fall back to
   // work_items.phase as the implicit "from" so manually-spawned impl sessions
   // don't cause a spurious "(initial) → triage" rejection (#1522).
-  // Exception: when running the initial phase itself (first launch), keep
-  // from=null so Rule 4 (initial phase enforcement) still applies.
+  // Exceptions:
+  //   - target === manifest.initial: first launch of the initial phase; keep
+  //     from=null so Rule 4 (initial phase enforcement) still applies.
+  //   - workItem.phase not in manifest.phases: stale/mismatched phase name
+  //     (e.g. daemon stores "impl" but manifest declares "implement"); fall
+  //     back to null to preserve the original Rule 4 error path (#1636).
   const resolvedFrom =
     parsed.from !== null
       ? parsed.from
       : priorTargets.length > 0
         ? priorTargets[priorTargets.length - 1]
-        : parsed.target !== loaded.manifest.initial
-          ? (workItem?.phase ?? null)
+        : parsed.target !== loaded.manifest.initial &&
+            workItem?.phase != null &&
+            workItem.phase in loaded.manifest.phases
+          ? workItem.phase
           : null;
   validateTransition({
     manifest: loaded.manifest,
@@ -1053,9 +1063,10 @@ export async function executePhase(
   });
 
   // Two-phase log — append an "attempted" entry before branch-guard or
-  // handler dispatch so every invocation leaves an audit trail, even
-  // when branch-guard rejects or the handler crashes. Attempted entries
-  // are ignored by regression / graph-walk checks (#1407).
+  // handler dispatch. Captures audit evidence even when branch-guard
+  // rejects or the handler crashes. Does NOT cover early exits above
+  // (unknown work-item id, unknown/disallowed transition). Attempted
+  // entries are ignored by regression / graph-walk checks (#1407).
   appendAttempt(logPath, {
     workItemId: parsed.workItemId,
     from: resolvedFrom,


### PR DESCRIPTION
## Summary
- When `mcx phase run triage --work-item <id>` was called with an empty transition log (impl manually spawned, no `phase run impl` call), `resolvedFrom` fell back to `null`, causing a spurious `(initial) → triage` rejection
- Fix moves the work item fetch before pre-validation and uses `work_items.phase` as the implicit `--from` when transition history is empty and the target is not the initial phase
- Guard: `workItem.phase` is only used if it's declared in the loaded manifest (prevents `UnknownPhaseError` on phase-name mismatch between daemon and manifest — #1636)
- Also passes `resolvedFrom` to the commit step so the transition log records the correct from-phase

## Follow-ups
- #1635: `--no-execute` path still uses `phaseRun()` directly and doesn't get the work_items.phase fallback

## Test plan
- [x] New regression test: `executePhase(["triage", "--work-item"])` with empty log and `workItem.phase = "impl"` succeeds with `impl → triage` approval
- [x] New guard test: mismatched phase name (`workItem.phase = "implement"`, manifest uses `"impl"`) produces `DisallowedTransitionError("(initial)")` not `UnknownPhaseError`
- [x] All 122 `phase.spec.ts` tests pass (including idempotent self-loop, back-to-back, branch guard, handler crash audit trail)
- [x] Full test suite: 5490 pass, 0 fail
- [x] `bun typecheck` and `bun lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)