### PR TITLE
fix(auth): auto-retry authorize 5xx via DCR refresh (fixes #1548)

### DIFF
--- a/packages/daemon/src/auth/oauth-provider.spec.ts
+++ b/packages/daemon/src/auth/oauth-provider.spec.ts
@@ -233,9 +233,8 @@ describe("McpOAuthProvider", () => {
       });
       const info = await provider.clientInformation();
 
-      // Keychain was NOT consulted for client_id — returns undefined so SDK does fresh DCR
+      // skipKeychainClientId short-circuits before loadKeychain() is reached
       expect(info).toBeUndefined();
-      // Keychain is still accessible for token lookup (not globally suppressed)
       expect(mockReadKeychain).not.toHaveBeenCalled();
       db.close();
     });

--- a/packages/daemon/src/auth/oauth-provider.spec.ts
+++ b/packages/daemon/src/auth/oauth-provider.spec.ts
@@ -219,6 +219,44 @@ describe("McpOAuthProvider", () => {
       expect(provider.callbackPort).toBeUndefined();
       db.close();
     });
+
+    test("skipKeychainClientId bypasses keychain fallback, returning undefined for fresh DCR", async () => {
+      const db = createDb();
+      // No SQLite entry; keychain holds a (potentially burned) client_id
+      mockReadKeychain.mockImplementation(() =>
+        Promise.resolve({ accessToken: "tok", expiresAt: Date.now() + 3600_000, clientId: "burned-kc-client" }),
+      );
+
+      const provider = new McpOAuthProvider("srv", "https://api.example.com", db, {
+        skipKeychainClientId: true,
+        readKeychain: mockReadKeychain,
+      });
+      const info = await provider.clientInformation();
+
+      // Keychain was NOT consulted for client_id — returns undefined so SDK does fresh DCR
+      expect(info).toBeUndefined();
+      // Keychain is still accessible for token lookup (not globally suppressed)
+      expect(mockReadKeychain).not.toHaveBeenCalled();
+      db.close();
+    });
+
+    test("skipKeychainClientId does not affect SQLite client info (SQLite still wins)", async () => {
+      const db = createDb();
+      db.saveClientInfo("srv", { client_id: "sqlite-client" });
+      mockReadKeychain.mockImplementation(() =>
+        Promise.resolve({ accessToken: "tok", expiresAt: Date.now() + 3600_000, clientId: "kc-client" }),
+      );
+
+      const provider = new McpOAuthProvider("srv", "https://api.example.com", db, {
+        skipKeychainClientId: true,
+        readKeychain: mockReadKeychain,
+      });
+      const info = await provider.clientInformation();
+
+      // SQLite row is still returned (only the keychain fallback is bypassed)
+      expect(info?.client_id).toBe("sqlite-client");
+      db.close();
+    });
   });
 
   // -- discoveryState() --

--- a/packages/daemon/src/auth/oauth-provider.ts
+++ b/packages/daemon/src/auth/oauth-provider.ts
@@ -44,6 +44,12 @@ export interface OAuthProviderOpts {
   /** OAuth scope from per-server config (highest priority in scope resolution). */
   scope?: string;
   readKeychain?: (url: string) => Promise<KeychainTokens | null>;
+  /**
+   * When true, skip the macOS Keychain fallback in clientInformation().
+   * Used by the DCR-retry path so a burned keychain client_id is not
+   * restored after deleteClientInfo() clears the SQLite row.
+   */
+  skipKeychainClientId?: boolean;
 }
 
 export class McpOAuthProvider implements OAuthClientProvider {
@@ -133,9 +139,13 @@ export class McpOAuthProvider implements OAuthClientProvider {
     if (dbInfo) return dbInfo;
 
     // 3. Check Keychain (Claude Code may have registered a client)
-    const kc = await this.loadKeychain();
-    if (kc) {
-      return { client_id: kc.clientId };
+    //    Skipped when skipKeychainClientId is set (DCR retry path — the
+    //    keychain entry may hold a burned client_id we just invalidated).
+    if (!this.opts.skipKeychainClientId) {
+      const kc = await this.loadKeychain();
+      if (kc) {
+        return { client_id: kc.clientId };
+      }
     }
 
     // 4. No client info → SDK will attempt dynamic registration

--- a/packages/daemon/src/auth/oauth-retry.spec.ts
+++ b/packages/daemon/src/auth/oauth-retry.spec.ts
@@ -3,7 +3,6 @@ import { unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { MetricsSnapshot } from "@mcp-cli/core";
-import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
 import { StateDb } from "../db/state";
 import { metrics } from "../metrics";
 import type { CallbackServer } from "./callback-server";
@@ -135,7 +134,7 @@ describe("runOAuthFlowWithDcrRetry", () => {
         startCallbackServer: () => {
           callbackNum++;
           if (callbackNum === 1) {
-            // First attempt: callback times out (authorize endpoint returned 5xx)
+            // First attempt: no callback received within the timeout window
             return makeCallback(Promise.reject(new Error("OAuth callback timeout (2 minutes)")));
           }
           // Second attempt: user completes consent
@@ -303,7 +302,7 @@ describe("runOAuthFlowWithDcrRetry", () => {
       ),
     ).rejects.toThrow("OAuth error: access_denied");
 
-    // Only one attempt — access_denied is not a 5xx
+    // Only one attempt — access_denied is not a timeout, no retry
     expect(callbackNum).toBe(1);
     db.close();
   });

--- a/packages/daemon/src/auth/oauth-retry.spec.ts
+++ b/packages/daemon/src/auth/oauth-retry.spec.ts
@@ -1,0 +1,278 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import { StateDb } from "../db/state";
+import type { CallbackServer } from "./callback-server";
+import { runOAuthFlowWithDcrRetry } from "./oauth-retry";
+
+function tmpDb(): string {
+  return join(tmpdir(), `mcp-cli-retry-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+}
+
+function cleanup(path: string): void {
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      unlinkSync(`${path}${suffix}`);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+function makeCallback(waitForCode: Promise<string>): CallbackServer {
+  return {
+    url: "http://localhost:9999/callback",
+    port: 9999,
+    waitForCode,
+    stop: () => {},
+  };
+}
+
+const SERVER = "test-srv";
+const SERVER_URL = "https://api.example.com";
+
+describe("runOAuthFlowWithDcrRetry", () => {
+  const dbPaths: string[] = [];
+
+  function createDb(): StateDb {
+    const p = tmpDb();
+    dbPaths.push(p);
+    return new StateDb(p);
+  }
+
+  afterEach(() => {
+    for (const p of dbPaths) cleanup(p);
+    dbPaths.length = 0;
+  });
+
+  // -- Happy path --
+
+  test("returns 'authenticated' on first attempt when code received", async () => {
+    const db = createDb();
+    let authCallCount = 0;
+
+    const result = await runOAuthFlowWithDcrRetry(
+      SERVER,
+      SERVER_URL,
+      db,
+      {},
+      {
+        authFn: async (_provider, opts) => {
+          authCallCount++;
+          if (opts.authorizationCode) return "AUTHORIZED";
+          return "REDIRECT";
+        },
+        startCallbackServer: () => makeCallback(Promise.resolve("code-abc")),
+      },
+    );
+
+    expect(result).toBe("authenticated");
+    // Two auth calls: REDIRECT phase + code exchange
+    expect(authCallCount).toBe(2);
+    db.close();
+  });
+
+  test("returns 'already_authorized' when provider tokens are valid", async () => {
+    const db = createDb();
+    let authCallCount = 0;
+    let callbackCreated = false;
+
+    const result = await runOAuthFlowWithDcrRetry(
+      SERVER,
+      SERVER_URL,
+      db,
+      {},
+      {
+        authFn: async () => {
+          authCallCount++;
+          return "AUTHORIZED";
+        },
+        startCallbackServer: () => {
+          callbackCreated = true;
+          // Promise is never awaited in the AUTHORIZED path — use a pending promise
+          return makeCallback(new Promise<string>(() => {}));
+        },
+      },
+    );
+
+    expect(result).toBe("already_authorized");
+    // Only one auth call — no code exchange needed
+    expect(authCallCount).toBe(1);
+    // Callback server was created (needed for redirect URL), but waitForCode never awaited
+    expect(callbackCreated).toBe(true);
+    db.close();
+  });
+
+  // -- Retry behavior --
+
+  test("retries after callback timeout, deletes client info, succeeds on second attempt", async () => {
+    const db = createDb();
+    db.saveClientInfo(SERVER, { client_id: "burned-client-A" });
+
+    let callbackNum = 0;
+    let authCallCount = 0;
+    const deletedClientsBetweenAttempts: string[] = [];
+
+    const result = await runOAuthFlowWithDcrRetry(
+      SERVER,
+      SERVER_URL,
+      db,
+      {},
+      {
+        authFn: async (_provider, opts) => {
+          authCallCount++;
+          if (opts.authorizationCode) return "AUTHORIZED";
+          // Capture db state at each REDIRECT call
+          const info = db.getClientInfo(SERVER);
+          if (info) deletedClientsBetweenAttempts.push(info.client_id);
+          return "REDIRECT";
+        },
+        startCallbackServer: () => {
+          callbackNum++;
+          if (callbackNum === 1) {
+            // First attempt: callback times out (authorize endpoint returned 5xx)
+            return makeCallback(Promise.reject(new Error("OAuth callback timeout (2 minutes)")));
+          }
+          // Second attempt: user completes consent
+          return makeCallback(Promise.resolve("code-fresh"));
+        },
+      },
+    );
+
+    expect(result).toBe("authenticated");
+    // First REDIRECT (timeout), Second REDIRECT, code exchange = 3 calls
+    expect(authCallCount).toBe(3);
+    // Client info was present on first attempt, deleted before second
+    expect(deletedClientsBetweenAttempts).toEqual(["burned-client-A"]);
+    // After retry the old client info is gone (new one would be saved by real SDK)
+    expect(db.getClientInfo(SERVER)).toBeUndefined();
+    db.close();
+  });
+
+  test("fails with clear message after two consecutive timeouts (no infinite loop)", async () => {
+    const db = createDb();
+    let callbackNum = 0;
+
+    await expect(
+      runOAuthFlowWithDcrRetry(
+        SERVER,
+        SERVER_URL,
+        db,
+        {},
+        {
+          authFn: async () => "REDIRECT",
+          startCallbackServer: () => {
+            callbackNum++;
+            return makeCallback(Promise.reject(new Error("OAuth callback timeout (2 minutes)")));
+          },
+        },
+      ),
+    ).rejects.toThrow("no recovery available");
+
+    // Exactly two callback servers created: initial attempt + one retry
+    expect(callbackNum).toBe(2);
+    db.close();
+  });
+
+  test("does not retry on non-timeout errors (e.g. OAuth error parameter)", async () => {
+    const db = createDb();
+    let callbackNum = 0;
+
+    await expect(
+      runOAuthFlowWithDcrRetry(
+        SERVER,
+        SERVER_URL,
+        db,
+        {},
+        {
+          authFn: async () => "REDIRECT",
+          startCallbackServer: () => {
+            callbackNum++;
+            return makeCallback(Promise.reject(new Error("OAuth error: access_denied")));
+          },
+        },
+      ),
+    ).rejects.toThrow("OAuth error: access_denied");
+
+    // Only one attempt — access_denied is not a 5xx
+    expect(callbackNum).toBe(1);
+    db.close();
+  });
+
+  test("regression: happy path makes exactly two auth calls, no client info deleted", async () => {
+    const db = createDb();
+    db.saveClientInfo(SERVER, { client_id: "live-client" });
+
+    let authCallCount = 0;
+
+    await runOAuthFlowWithDcrRetry(
+      SERVER,
+      SERVER_URL,
+      db,
+      {},
+      {
+        authFn: async (_provider, opts) => {
+          authCallCount++;
+          if (opts.authorizationCode) return "AUTHORIZED";
+          return "REDIRECT";
+        },
+        startCallbackServer: () => makeCallback(Promise.resolve("code-xyz")),
+      },
+    );
+
+    // No extra DCR churn
+    expect(authCallCount).toBe(2);
+    // Client info untouched
+    expect(db.getClientInfo(SERVER)?.client_id).toBe("live-client");
+    db.close();
+  });
+});
+
+// -- StateDb.deleteClientInfo --
+
+describe("StateDb.deleteClientInfo", () => {
+  const dbPaths: string[] = [];
+
+  function createDb(): StateDb {
+    const p = tmpDb();
+    dbPaths.push(p);
+    return new StateDb(p);
+  }
+
+  afterEach(() => {
+    for (const p of dbPaths) cleanup(p);
+    dbPaths.length = 0;
+  });
+
+  test("removes client info row", () => {
+    const db = createDb();
+    db.saveClientInfo("srv", { client_id: "to-delete" });
+    expect(db.getClientInfo("srv")).toBeDefined();
+
+    db.deleteClientInfo("srv");
+
+    expect(db.getClientInfo("srv")).toBeUndefined();
+    db.close();
+  });
+
+  test("no-ops when row does not exist", () => {
+    const db = createDb();
+    // Should not throw
+    expect(() => db.deleteClientInfo("nonexistent")).not.toThrow();
+    db.close();
+  });
+
+  test("only deletes the targeted server", () => {
+    const db = createDb();
+    db.saveClientInfo("srv-a", { client_id: "a" });
+    db.saveClientInfo("srv-b", { client_id: "b" });
+
+    db.deleteClientInfo("srv-a");
+
+    expect(db.getClientInfo("srv-a")).toBeUndefined();
+    expect(db.getClientInfo("srv-b")?.client_id).toBe("b");
+    db.close();
+  });
+});

--- a/packages/daemon/src/auth/oauth-retry.spec.ts
+++ b/packages/daemon/src/auth/oauth-retry.spec.ts
@@ -1,10 +1,13 @@
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import { unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import type { MetricsSnapshot } from "@mcp-cli/core";
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
 import { StateDb } from "../db/state";
+import { metrics } from "../metrics";
 import type { CallbackServer } from "./callback-server";
+import type { KeychainTokens } from "./keychain";
 import { runOAuthFlowWithDcrRetry } from "./oauth-retry";
 
 function tmpDb(): string {
@@ -121,9 +124,9 @@ describe("runOAuthFlowWithDcrRetry", () => {
       db,
       {},
       {
-        authFn: async (_provider, opts) => {
+        authFn: async (_provider, authOpts) => {
           authCallCount++;
-          if (opts.authorizationCode) return "AUTHORIZED";
+          if (authOpts.authorizationCode) return "AUTHORIZED";
           // Capture db state at each REDIRECT call
           const info = db.getClientInfo(SERVER);
           if (info) deletedClientsBetweenAttempts.push(info.client_id);
@@ -148,6 +151,110 @@ describe("runOAuthFlowWithDcrRetry", () => {
     expect(deletedClientsBetweenAttempts).toEqual(["burned-client-A"]);
     // After retry the old client info is gone (new one would be saved by real SDK)
     expect(db.getClientInfo(SERVER)).toBeUndefined();
+    db.close();
+  });
+
+  test("skips keychain client_id on retry so burned keychain entry does not restore zombie", async () => {
+    const db = createDb();
+    // No SQLite entry — keychain holds the only (burned) client_id
+    const keychainClientId = "burned-keychain-client";
+    const seenClientIds: Array<string | undefined> = [];
+
+    let callbackNum = 0;
+    await runOAuthFlowWithDcrRetry(
+      SERVER,
+      SERVER_URL,
+      db,
+      {
+        readKeychain: async (): Promise<KeychainTokens | null> =>
+          Promise.resolve({ accessToken: "tok", expiresAt: Date.now() + 3600_000, clientId: keychainClientId }),
+      },
+      {
+        authFn: async (provider, authOpts) => {
+          if (authOpts.authorizationCode) return "AUTHORIZED";
+          // Capture what clientInformation() returns for this attempt
+          const info = await (
+            provider as { clientInformation(): Promise<{ client_id?: string } | undefined> }
+          ).clientInformation();
+          seenClientIds.push(info?.client_id);
+          return "REDIRECT";
+        },
+        startCallbackServer: () => {
+          callbackNum++;
+          if (callbackNum === 1) {
+            return makeCallback(Promise.reject(new Error("OAuth callback timeout (2 minutes)")));
+          }
+          return makeCallback(Promise.resolve("code-fresh"));
+        },
+      },
+    );
+
+    // First attempt sees keychain client_id; second attempt skips it → undefined → fresh DCR
+    expect(seenClientIds[0]).toBe(keychainClientId);
+    expect(seenClientIds[1]).toBeUndefined();
+    db.close();
+  });
+
+  test("increments oauth_dcr_retry_total{outcome=success} metric on successful retry", async () => {
+    const db = createDb();
+    let callbackNum = 0;
+
+    const beforeSnap = metrics.toJSON();
+    const before =
+      beforeSnap.counters.find((c) => c.name === "oauth_dcr_retry_total" && c.labels?.outcome === "success")?.value ??
+      0;
+
+    await runOAuthFlowWithDcrRetry(
+      SERVER,
+      SERVER_URL,
+      db,
+      {},
+      {
+        authFn: async (_provider, authOpts) => {
+          if (authOpts.authorizationCode) return "AUTHORIZED";
+          return "REDIRECT";
+        },
+        startCallbackServer: () => {
+          callbackNum++;
+          if (callbackNum === 1) return makeCallback(Promise.reject(new Error("OAuth callback timeout (2 minutes)")));
+          return makeCallback(Promise.resolve("code-x"));
+        },
+      },
+    );
+
+    const afterSnap = metrics.toJSON();
+    const after =
+      afterSnap.counters.find((c) => c.name === "oauth_dcr_retry_total" && c.labels?.outcome === "success")?.value ?? 0;
+    expect(after - before).toBe(1);
+    db.close();
+  });
+
+  test("increments oauth_dcr_retry_total{outcome=double_timeout} metric on double failure", async () => {
+    const db = createDb();
+
+    const beforeSnap = metrics.toJSON();
+    const before =
+      beforeSnap.counters.find((c) => c.name === "oauth_dcr_retry_total" && c.labels?.outcome === "double_timeout")
+        ?.value ?? 0;
+
+    await expect(
+      runOAuthFlowWithDcrRetry(
+        SERVER,
+        SERVER_URL,
+        db,
+        {},
+        {
+          authFn: async () => "REDIRECT",
+          startCallbackServer: () => makeCallback(Promise.reject(new Error("OAuth callback timeout (2 minutes)"))),
+        },
+      ),
+    ).rejects.toThrow();
+
+    const afterSnap = metrics.toJSON();
+    const after =
+      afterSnap.counters.find((c) => c.name === "oauth_dcr_retry_total" && c.labels?.outcome === "double_timeout")
+        ?.value ?? 0;
+    expect(after - before).toBe(1);
     db.close();
   });
 

--- a/packages/daemon/src/auth/oauth-retry.spec.ts
+++ b/packages/daemon/src/auth/oauth-retry.spec.ts
@@ -2,7 +2,6 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { MetricsSnapshot } from "@mcp-cli/core";
 import { StateDb } from "../db/state";
 import { metrics } from "../metrics";
 import type { CallbackServer } from "./callback-server";

--- a/packages/daemon/src/auth/oauth-retry.ts
+++ b/packages/daemon/src/auth/oauth-retry.ts
@@ -1,29 +1,32 @@
 /**
- * OAuth flow orchestration with DCR retry on authorize 5xx.
+ * OAuth flow orchestration with DCR retry on callback timeout.
  *
- * When the authorize endpoint returns 5xx (detected post-hoc via callback
- * server timeout), the cached client registration is discarded and the flow
- * retries once with a fresh DCR. Atlassian and some other providers burn
- * client_ids after a small number of unused authorize attempts.
+ * When the callback server times out without receiving an authorization code
+ * (which may indicate a provider-side 5xx on the authorize endpoint), the
+ * cached client registration is discarded and the flow retries once with a
+ * fresh DCR. Atlassian and some other providers burn client_ids after a small
+ * number of unused authorize attempts.
  */
 
 import { auth } from "@modelcontextprotocol/sdk/client/auth.js";
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
 import type { StateDb } from "../db/state";
+import { metrics } from "../metrics";
 import { type CallbackServer, startCallbackServer } from "./callback-server";
-import { DEFAULT_OAUTH_SCOPE, McpOAuthProvider } from "./oauth-provider";
+import { DEFAULT_OAUTH_SCOPE, McpOAuthProvider, type OAuthProviderOpts } from "./oauth-provider";
 
 export interface OAuthRetryDeps {
   authFn?: (
     provider: OAuthClientProvider,
-    opts: { serverUrl: string; scope?: string; authorizationCode?: string },
+    authOpts: { serverUrl: string; scope?: string; authorizationCode?: string },
   ) => Promise<string>;
   startCallbackServer?: (port?: number) => CallbackServer;
 }
 
 /**
  * Run the OAuth authorization_code flow, retrying once with a fresh DCR if
- * the callback server times out (post-hoc 5xx detection).
+ * the callback server times out (post-hoc detection that the authorize
+ * endpoint may have returned 5xx).
  *
  * Returns "already_authorized" when the provider's cached tokens are still
  * valid, or "authenticated" after a successful code exchange.
@@ -32,21 +35,24 @@ export async function runOAuthFlowWithDcrRetry(
   server: string,
   serverUrl: string,
   db: StateDb,
-  opts: { clientId?: string; clientSecret?: string; callbackPort?: number; scope?: string },
+  opts: Pick<OAuthProviderOpts, "clientId" | "clientSecret" | "callbackPort" | "scope" | "readKeychain">,
   deps?: OAuthRetryDeps,
 ): Promise<"already_authorized" | "authenticated"> {
   const doAuth =
     deps?.authFn ??
-    ((provider: OAuthClientProvider, opts: { serverUrl: string; scope?: string; authorizationCode?: string }) =>
-      auth(provider, opts));
+    ((provider: OAuthClientProvider, authOpts: { serverUrl: string; scope?: string; authorizationCode?: string }) =>
+      auth(provider, authOpts));
   const makeCallback = deps?.startCallbackServer ?? startCallbackServer;
   const MAX_RETRIES = 1;
-  let retryCount = 0;
 
-  for (;;) {
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const skipKeychainClientId = attempt > 0;
     const callback = makeCallback(opts.callbackPort);
     try {
-      const provider = new McpOAuthProvider(server, serverUrl, db, opts);
+      const provider = new McpOAuthProvider(server, serverUrl, db, {
+        ...opts,
+        skipKeychainClientId,
+      });
       provider.setRedirectUrl(callback.url);
       const authScope = provider.getEffectiveScope() ?? DEFAULT_OAUTH_SCOPE;
 
@@ -58,21 +64,32 @@ export async function runOAuthFlowWithDcrRetry(
       // result === "REDIRECT" — browser opened; wait for the authorization code
       const code = await callback.waitForCode;
       await doAuth(provider, { serverUrl, authorizationCode: code });
+      if (skipKeychainClientId) {
+        metrics.counter("oauth_dcr_retry_total", { server, outcome: "success" }).inc();
+      }
       return "authenticated";
     } catch (err) {
       const isTimeout = err instanceof Error && err.message.startsWith("OAuth callback timeout");
-      if (isTimeout && retryCount < MAX_RETRIES) {
-        retryCount++;
-        console.error("[auth] authorize returned 5xx, retrying with fresh client registration...");
+      if (isTimeout && attempt < MAX_RETRIES) {
+        console.error(
+          "[auth] OAuth callback timed out (possibly 5xx on authorize) — deleting cached client registration and retrying...",
+        );
         db.deleteClientInfo(server);
         continue;
       }
       if (isTimeout) {
-        throw new Error("provider returned 5xx; no recovery available — authorization failed after DCR retry");
+        metrics.counter("oauth_dcr_retry_total", { server, outcome: "double_timeout" }).inc();
+        throw new Error(
+          "OAuth callback timed out twice; no recovery available — authorization failed after DCR retry",
+          { cause: err },
+        );
       }
       throw err;
     } finally {
       callback.stop();
     }
   }
+
+  // Unreachable — loop always returns or throws
+  throw new Error("runOAuthFlowWithDcrRetry: unexpected loop exit");
 }

--- a/packages/daemon/src/auth/oauth-retry.ts
+++ b/packages/daemon/src/auth/oauth-retry.ts
@@ -1,0 +1,78 @@
+/**
+ * OAuth flow orchestration with DCR retry on authorize 5xx.
+ *
+ * When the authorize endpoint returns 5xx (detected post-hoc via callback
+ * server timeout), the cached client registration is discarded and the flow
+ * retries once with a fresh DCR. Atlassian and some other providers burn
+ * client_ids after a small number of unused authorize attempts.
+ */
+
+import { auth } from "@modelcontextprotocol/sdk/client/auth.js";
+import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import type { StateDb } from "../db/state";
+import { type CallbackServer, startCallbackServer } from "./callback-server";
+import { DEFAULT_OAUTH_SCOPE, McpOAuthProvider } from "./oauth-provider";
+
+export interface OAuthRetryDeps {
+  authFn?: (
+    provider: OAuthClientProvider,
+    opts: { serverUrl: string; scope?: string; authorizationCode?: string },
+  ) => Promise<string>;
+  startCallbackServer?: (port?: number) => CallbackServer;
+}
+
+/**
+ * Run the OAuth authorization_code flow, retrying once with a fresh DCR if
+ * the callback server times out (post-hoc 5xx detection).
+ *
+ * Returns "already_authorized" when the provider's cached tokens are still
+ * valid, or "authenticated" after a successful code exchange.
+ */
+export async function runOAuthFlowWithDcrRetry(
+  server: string,
+  serverUrl: string,
+  db: StateDb,
+  opts: { clientId?: string; clientSecret?: string; callbackPort?: number; scope?: string },
+  deps?: OAuthRetryDeps,
+): Promise<"already_authorized" | "authenticated"> {
+  const doAuth =
+    deps?.authFn ??
+    ((provider: OAuthClientProvider, opts: { serverUrl: string; scope?: string; authorizationCode?: string }) =>
+      auth(provider, opts));
+  const makeCallback = deps?.startCallbackServer ?? startCallbackServer;
+  const MAX_RETRIES = 1;
+  let retryCount = 0;
+
+  for (;;) {
+    const callback = makeCallback(opts.callbackPort);
+    try {
+      const provider = new McpOAuthProvider(server, serverUrl, db, opts);
+      provider.setRedirectUrl(callback.url);
+      const authScope = provider.getEffectiveScope() ?? DEFAULT_OAUTH_SCOPE;
+
+      const result = await doAuth(provider, { serverUrl, scope: authScope });
+      if (result === "AUTHORIZED") {
+        return "already_authorized";
+      }
+
+      // result === "REDIRECT" — browser opened; wait for the authorization code
+      const code = await callback.waitForCode;
+      await doAuth(provider, { serverUrl, authorizationCode: code });
+      return "authenticated";
+    } catch (err) {
+      const isTimeout = err instanceof Error && err.message.startsWith("OAuth callback timeout");
+      if (isTimeout && retryCount < MAX_RETRIES) {
+        retryCount++;
+        console.error("[auth] authorize returned 5xx, retrying with fresh client registration...");
+        db.deleteClientInfo(server);
+        continue;
+      }
+      if (isTimeout) {
+        throw new Error("provider returned 5xx; no recovery available — authorization failed after DCR retry");
+      }
+      throw err;
+    } finally {
+      callback.stop();
+    }
+  }
+}

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -608,6 +608,10 @@ export class StateDb {
     );
   }
 
+  deleteClientInfo(serverName: string): void {
+    this.db.run("DELETE FROM oauth_clients WHERE server_name = ?", [serverName]);
+  }
+
   // -- PKCE code verifier --
 
   getVerifier(serverName: string): string | undefined {

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -74,11 +74,10 @@ import {
   startSpan,
   validateFreeformTsc,
 } from "@mcp-cli/core";
-import { auth } from "@modelcontextprotocol/sdk/client/auth.js";
 import { z } from "zod/v4";
 import type { AliasServer } from "./alias-server";
-import { startCallbackServer } from "./auth/callback-server";
-import { DEFAULT_OAUTH_SCOPE, McpOAuthProvider } from "./auth/oauth-provider";
+import { McpOAuthProvider } from "./auth/oauth-provider";
+import { runOAuthFlowWithDcrRetry } from "./auth/oauth-retry";
 import { getDaemonLogLines, subscribeDaemonLogs } from "./daemon-log";
 import type { StateDb } from "./db/state";
 import { WorkItemDb } from "./db/work-items";
@@ -656,47 +655,19 @@ export class IpcServer {
       const serverConfig = this.pool.getServerConfig(server);
       const { clientId, clientSecret, callbackPort, scope } = serverConfig ?? {};
 
-      // Start callback server for OAuth redirect (use configured port if available)
-      const callback = startCallbackServer(callbackPort);
-      try {
-        // Create provider with callback URL and config-level OAuth credentials
-        const provider = new McpOAuthProvider(server, serverUrl, poolDb, {
-          clientId,
-          clientSecret,
-          callbackPort,
-          scope,
-        });
-        provider.setRedirectUrl(callback.url);
+      const flowResult = await runOAuthFlowWithDcrRetry(server, serverUrl, poolDb, {
+        clientId,
+        clientSecret,
+        callbackPort,
+        scope,
+      });
 
-        // Pass configured scope to auth(), or DEFAULT_OAUTH_SCOPE as fallback.
-        // The SDK's cascade (resourceMetadata.scopes_supported → clientMetadata.scope)
-        // runs between these; DEFAULT_OAUTH_SCOPE kicks in when none of those exist
-        // (e.g. Atlassian, which requires scope=openid email profile but publishes
-        // no scopes_supported in its protected resource metadata).
-        const authScope = provider.getEffectiveScope() ?? DEFAULT_OAUTH_SCOPE;
+      await this.pool.restart(server);
 
-        // Run the SDK auth orchestrator
-        const result = await auth(provider, { serverUrl, scope: authScope });
-
-        if (result === "AUTHORIZED") {
-          // Already authorized (tokens were valid) — restart server to reconnect
-          await this.pool.restart(server);
-          return { ok: true, message: "Already authorized" };
-        }
-
-        // result === "REDIRECT" — browser was opened, wait for callback
-        const code = await callback.waitForCode;
-
-        // Exchange code for tokens (scope not passed — SDK reads from clientMetadata for token exchange)
-        await auth(provider, { serverUrl, authorizationCode: code });
-
-        // Reconnect with new tokens
-        await this.pool.restart(server);
-
-        return { ok: true, message: "Authenticated successfully" };
-      } finally {
-        callback.stop();
+      if (flowResult === "already_authorized") {
+        return { ok: true, message: "Already authorized" };
       }
+      return { ok: true, message: "Authenticated successfully" };
     });
 
     this.handlers.set("authStatus", async (params, _ctx) => {


### PR DESCRIPTION
## Summary
- Extracts OAuth flow into `auth/oauth-retry.ts` with injectable deps (`authFn`, `startCallbackServer`) for testability
- On callback-server timeout (post-hoc 5xx detection), deletes the cached DCR `client_id` from SQLite and retries once with fresh client registration; logs `[auth] authorize returned 5xx, retrying with fresh client registration...`
- Fails cleanly with `"no recovery available"` after two consecutive timeouts — no infinite loop
- Adds `StateDb.deleteClientInfo()` to complement the existing `saveClientInfo`/`getClientInfo` pair

## Test plan
- [x] `oauth-retry.spec.ts`: happy path (2 auth calls, no client deleted), `AUTHORIZED` short-circuit, timeout→retry→success with client deletion verified, double-timeout fails with clear message, non-timeout errors don't retry, regression: exactly 2 auth calls on success
- [x] `StateDb.deleteClientInfo`: removes row, no-ops on missing, only deletes targeted server
- [x] `bun typecheck` — passes
- [x] `bun lint` — passes
- [x] `bun test` — 5498 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)