### PR TITLE
fix(ci): restrict push trigger to main to prevent double-fired check-runs (fixes #1621)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,15 @@
 name: CI
 on:
   push:
-    branches: ['**']
+    branches: [main]
   pull_request:
     branches: [main]
   workflow_dispatch:
 
-# Deduplicate runs per branch: head_ref is set for pull_request (source branch),
-# ref_name for push. Both resolve to the same branch name, so a push + PR event
-# for the same commit share one group. Cancel stale runs on force-push, but let
-# every main merge complete.
+# Deduplicate runs per branch: cancel stale PR runs on force-push, but let every
+# main merge complete. Push triggers are restricted to main to avoid double-firing
+# (push + pull_request) on PR branches — the duplicate creates both CANCELLED and
+# SUCCESS check-runs on the same SHA, which blocks branch protection (#1621).
 concurrency:
   group: ci-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: ${{ github.ref_name != 'main' }}


### PR DESCRIPTION
## Summary
- Restricts CI `push` trigger from `['**']` to `[main]` so PR branches only get CI from the `pull_request` event
- Eliminates the double-trigger (push + pull_request) that caused both CANCELLED and SUCCESS check-runs on the same SHA, blocking branch protection
- Concurrency group retained — still cancels stale `pull_request`-triggered runs on force-push

## Test plan
- [ ] Verify CI runs on this PR (triggered by `pull_request` only, no duplicate cancelled run)
- [ ] Verify direct pushes to `main` still trigger CI
- [ ] Confirm `mergeStateStatus` is not BLOCKED when all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)