### PR TITLE
feat(monitor): enrich session.idle/result with cost, turns, tokens, resultPreview (fixes #1575)

### DIFF
--- a/packages/core/src/monitor-event.ts
+++ b/packages/core/src/monitor-event.ts
@@ -118,8 +118,8 @@ const FORMATTERS: Partial<Record<string, Formatter>> = {
         ? e.resultPreview
         : typeof e.result === "string"
           ? e.result.replace(/\n/g, " ")
-          : "";
-    const preview = raw ? `  "${cap(raw, 60)}"` : "";
+          : undefined;
+    const preview = typeof raw === "string" ? `  "${cap(raw, 60)}"` : "";
     return join(wi(e), sid(e), cost(e), turns(e)) + preview;
   },
 

--- a/packages/core/src/monitor-event.ts
+++ b/packages/core/src/monitor-event.ts
@@ -28,6 +28,7 @@ export const SESSION_CONTAINMENT_WARNING = "session.containment_warning" as cons
 export const SESSION_CONTAINMENT_DENIED = "session.containment_denied" as const;
 export const SESSION_CONTAINMENT_ESCALATED = "session.containment_escalated" as const;
 export const SESSION_CONTAINMENT_RESET = "session.containment_reset" as const;
+export const SESSION_IDLE = "session.idle" as const;
 
 // ── Work item event names ──
 
@@ -112,7 +113,18 @@ type Formatter = (e: MonitorEvent) => string;
 
 const FORMATTERS: Partial<Record<string, Formatter>> = {
   [SESSION_RESULT]: (e) => {
-    const preview = typeof e.result === "string" ? `  "${cap(e.result.replace(/\n/g, " "), 60)}"` : "";
+    const raw =
+      typeof e.resultPreview === "string"
+        ? e.resultPreview
+        : typeof e.result === "string"
+          ? e.result.replace(/\n/g, " ")
+          : "";
+    const preview = raw ? `  "${cap(raw, 60)}"` : "";
+    return join(wi(e), sid(e), cost(e), turns(e)) + preview;
+  },
+
+  [SESSION_IDLE]: (e) => {
+    const preview = typeof e.resultPreview === "string" ? `  "${cap(e.resultPreview, 60)}"` : "";
     return join(wi(e), sid(e), cost(e), turns(e)) + preview;
   },
 

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -3823,7 +3823,7 @@ describe("monitor event mapping", () => {
       expect(events[1].resultPreview).toBe("line one line two line three");
     });
 
-    test("session:result with empty result omits resultPreview from session.idle", () => {
+    test("session:result with empty result preserves empty resultPreview on both events", () => {
       const server = makeServer();
       const events = collect(server);
 

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -3751,7 +3751,7 @@ describe("monitor event mapping", () => {
   }
 
   describe("publishSessionMonitorEvent", () => {
-    test("session:result maps to session.result with cost/tokens/numTurns", () => {
+    test("session:result emits session.result + session.idle with cost/tokens/numTurns/resultPreview", () => {
       const server = makeServer();
       const events = collect(server);
 
@@ -3763,15 +3763,87 @@ describe("monitor event mapping", () => {
         result: "done",
       });
 
-      expect(events).toHaveLength(1);
-      expect(events[0].src).toBe("daemon.claude-server");
-      expect(events[0].event).toBe("session.result");
-      expect(events[0].category).toBe("session");
-      expect(events[0].sessionId).toBe("s1");
-      expect(events[0].cost).toBe(0.42);
-      expect(events[0].tokens).toBe(1234);
-      expect(events[0].numTurns).toBe(3);
-      expect(events[0].result).toBe("done");
+      expect(events).toHaveLength(2);
+
+      const resultEvt = events[0];
+      expect(resultEvt.src).toBe("daemon.claude-server");
+      expect(resultEvt.event).toBe("session.result");
+      expect(resultEvt.category).toBe("session");
+      expect(resultEvt.sessionId).toBe("s1");
+      expect(resultEvt.cost).toBe(0.42);
+      expect(resultEvt.tokens).toBe(1234);
+      expect(resultEvt.numTurns).toBe(3);
+      expect(resultEvt.result).toBe("done");
+      expect(resultEvt.resultPreview).toBe("done");
+
+      const idleEvt = events[1];
+      expect(idleEvt.src).toBe("daemon.claude-server");
+      expect(idleEvt.event).toBe("session.idle");
+      expect(idleEvt.category).toBe("session");
+      expect(idleEvt.sessionId).toBe("s1");
+      expect(idleEvt.cost).toBe(0.42);
+      expect(idleEvt.tokens).toBe(1234);
+      expect(idleEvt.numTurns).toBe(3);
+      expect(idleEvt.resultPreview).toBe("done");
+      expect(idleEvt.result).toBeUndefined();
+    });
+
+    test("resultPreview truncates long result to ≤200 chars with ellipsis", () => {
+      const server = makeServer();
+      const events = collect(server);
+      const longResult = "a".repeat(300);
+
+      priv(server).publishSessionMonitorEvent("s1a", {
+        type: "session:result",
+        cost: 0,
+        tokens: 0,
+        numTurns: 1,
+        result: longResult,
+      });
+
+      const preview = events[0].resultPreview as string;
+      expect(preview.length).toBe(200);
+      expect(preview.endsWith("…")).toBe(true);
+      expect(preview.slice(0, 199)).toBe("a".repeat(199));
+    });
+
+    test("resultPreview collapses newlines to spaces", () => {
+      const server = makeServer();
+      const events = collect(server);
+
+      priv(server).publishSessionMonitorEvent("s1b", {
+        type: "session:result",
+        cost: 0,
+        tokens: 0,
+        numTurns: 1,
+        result: "line one\nline two\nline three",
+      });
+
+      expect(events[0].resultPreview).toBe("line one line two line three");
+      expect(events[1].resultPreview).toBe("line one line two line three");
+    });
+
+    test("session:result with empty result omits resultPreview from session.idle", () => {
+      const server = makeServer();
+      const events = collect(server);
+
+      priv(server).publishSessionMonitorEvent("s1c", {
+        type: "session:result",
+        cost: 1.0,
+        tokens: 500,
+        numTurns: 5,
+        result: "",
+      });
+
+      expect(events).toHaveLength(2);
+      // empty string is falsy but still a string — resultPreview is ""
+      expect(events[0].resultPreview).toBe("");
+      expect(events[1].resultPreview).toBe("");
+      // cost/tokens/numTurns present on idle
+      expect(events[1].cost).toBe(1.0);
+      expect(events[1].tokens).toBe(500);
+      expect(events[1].numTurns).toBe(5);
+      expect(events[1].result).toBeUndefined();
     });
 
     test("session:ended maps to session.ended with no extra fields", () => {

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -38,6 +38,7 @@ import {
   SESSION_DISCONNECTED,
   SESSION_ENDED,
   SESSION_ERROR,
+  SESSION_IDLE,
   SESSION_MODEL_CHANGED,
   SESSION_PERMISSION_REQUEST,
   SESSION_RATE_LIMITED,
@@ -1673,6 +1674,10 @@ export class ClaudeWsServer {
     if ("tokens" in event) input.tokens = event.tokens;
     if ("numTurns" in event) input.numTurns = event.numTurns;
     if ("result" in event) input.result = event.result;
+    if ("result" in event && typeof event.result === "string") {
+      const flat = event.result.replace(/\n/g, " ");
+      input.resultPreview = flat.length > 200 ? `${flat.slice(0, 199)}…` : flat;
+    }
     if ("errors" in event) input.errors = event.errors;
     if ("requestId" in event) input.requestId = event.requestId;
     if ("toolName" in event) input.toolName = event.toolName;
@@ -1682,6 +1687,20 @@ export class ClaudeWsServer {
     if ("reason" in event) input.reason = event.reason;
 
     this.onMonitorEvent(input);
+
+    if (event.type === "session:result") {
+      const idleInput: MonitorEventInput = {
+        src: "daemon.claude-server",
+        event: SESSION_IDLE,
+        category: "session",
+        sessionId,
+      };
+      if ("cost" in event) idleInput.cost = event.cost;
+      if ("tokens" in event) idleInput.tokens = event.tokens;
+      if ("numTurns" in event) idleInput.numTurns = event.numTurns;
+      if (input.resultPreview !== undefined) idleInput.resultPreview = input.resultPreview;
+      this.onMonitorEvent(idleInput);
+    }
   }
 
   private static readonly WORK_ITEM_EVENT_MAP: Record<string, string> = {


### PR DESCRIPTION
## Summary

- Adds `SESSION_IDLE` (`"session.idle"`) monitor event constant and formatter to `monitor-event.ts`
- `publishSessionMonitorEvent` now emits **two** events when `session:result` fires: `session.result` (unchanged shape + new `resultPreview` field) and the new `session.idle` (carries `cost`/`tokens`/`numTurns`/`resultPreview`, no full `result` text)
- `resultPreview` = first ≤200 chars of result text with newlines collapsed to spaces and a trailing `…` if truncated — omitted entirely for events where no result is available

## Test plan

- [x] Updated existing test: `session:result emits session.result + session.idle with cost/tokens/numTurns/resultPreview` — verifies both events fire with correct fields and that `session.idle` omits the full `result`
- [x] New test: `resultPreview truncates long result to ≤200 chars with ellipsis`
- [x] New test: `resultPreview collapses newlines to spaces`
- [x] New test: `session:result with empty result — resultPreview is ""` and cost/tokens still present on idle event
- [x] Full suite: 5588 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)