### PR TITLE
fix(sites): auto-restart _site worker after crash/sleep-wake (fixes #1600)

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -772,6 +772,12 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
         } catch (err) {
           logger.error(`[mcpd] Failed to start site server: ${err}`);
         }
+
+        siteServer.onRestarted = (client, transport) => {
+          const siteTools = buildSiteToolCache();
+          pool.registerVirtualServer(SITE_SERVER_NAME, client, transport, siteTools);
+          logger.info("[mcpd] Site server re-registered after crash recovery");
+        };
       })(),
     );
 

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -778,6 +778,10 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
           pool.registerVirtualServer(SITE_SERVER_NAME, client, transport, siteTools);
           logger.info("[mcpd] Site server re-registered after crash recovery");
         };
+        siteServer.onPermanentlyFailed = () => {
+          pool.unregisterVirtualServer(SITE_SERVER_NAME);
+          logger.error("[mcpd] Site server permanently failed — removed from pool; restart daemon to recover");
+        };
       })(),
     );
 

--- a/packages/daemon/src/site-server.spec.ts
+++ b/packages/daemon/src/site-server.spec.ts
@@ -38,12 +38,21 @@ describe("SITE_SERVER_NAME", () => {
   });
 });
 
+/** Extended fake Worker that also exposes a fireError() helper for testing crash detection. */
+type FakeWorker = Worker & { fireError: (event: ErrorEvent | Event) => void };
+
 /**
  * Fake Worker that responds to init with ready, and ignores everything else.
  * Lets us exercise SiteServer's handshake + failure paths without spawning a real worker.
+ *
+ * Also tracks error listeners registered via addEventListener so that tests can
+ * fire synthetic error events through the full attachCrashDetection path.
  */
-function makeFakeWorker(behavior: { replyReady?: boolean; replyErrorMessage?: string } = { replyReady: true }): Worker {
+function makeFakeWorker(
+  behavior: { replyReady?: boolean; replyErrorMessage?: string } = { replyReady: true },
+): FakeWorker {
   const listeners = new Map<string, ((event: MessageEvent | ErrorEvent | Event) => void) | null>();
+  const errorListeners: ((event: ErrorEvent | Event) => void)[] = [];
   const worker = {
     postMessage: mock((msg: unknown) => {
       const m = msg as { type?: string } | undefined;
@@ -60,8 +69,18 @@ function makeFakeWorker(behavior: { replyReady?: boolean; replyErrorMessage?: st
       }
     }),
     terminate: mock(() => {}),
-    addEventListener: mock(() => {}),
-    removeEventListener: mock(() => {}),
+    addEventListener: mock((type: string, fn: (e: ErrorEvent | Event) => void) => {
+      if (type === "error") errorListeners.push(fn);
+    }),
+    removeEventListener: mock((type: string, fn: (e: ErrorEvent | Event) => void) => {
+      if (type === "error") {
+        const idx = errorListeners.indexOf(fn);
+        if (idx >= 0) errorListeners.splice(idx, 1);
+      }
+    }),
+    fireError(event: ErrorEvent | Event) {
+      for (const fn of [...errorListeners]) fn(event);
+    },
     get onmessage() {
       return listeners.get("message") ?? null;
     },
@@ -75,7 +94,7 @@ function makeFakeWorker(behavior: { replyReady?: boolean; replyErrorMessage?: st
       listeners.set("error", fn);
     },
   };
-  return worker as unknown as Worker;
+  return worker as unknown as FakeWorker;
 }
 
 function mockWorkerFactory() {
@@ -196,5 +215,42 @@ describe("SiteServer crash recovery", () => {
 
     expect(restartedCalled).toBe(false);
     server = undefined;
+  });
+
+  test("attachCrashDetection fires onRestarted via real error event (not handleWorkerCrash cast)", async () => {
+    // This test exercises the full crash path:
+    //   worker error event → attachCrashDetection handler → handleWorkerCrash → onRestarted
+    // Previous tests bypassed attachCrashDetection by calling handleWorkerCrash directly.
+    let firstWorker: FakeWorker | undefined;
+    let spawnCount = 0;
+    const factory = (_path: string): Worker => {
+      const w = makeFakeWorker();
+      if (spawnCount === 0) firstWorker = w;
+      spawnCount++;
+      return w as unknown as Worker;
+    };
+
+    server = new SiteServer(undefined, instantClient, factory, silentLogger);
+    await server.start();
+    expect(firstWorker).toBeDefined();
+
+    let restartedCalled = false;
+    server.onRestarted = () => {
+      restartedCalled = true;
+    };
+
+    // Fire through the real addEventListener listener registered by attachCrashDetection
+    if (!firstWorker) throw new Error("factory never created a worker");
+    firstWorker.fireError(new ErrorEvent("error", { message: "chrome crashed" }));
+
+    // handleWorkerCrash is async and fire-and-forget from the event handler;
+    // poll until the restart completes or we hit the deadline.
+    const deadline = Date.now() + 2000;
+    while (!restartedCalled && Date.now() < deadline) {
+      await Bun.sleep(10);
+    }
+
+    expect(restartedCalled).toBe(true);
+    expect(spawnCount).toBe(2); // initial worker + restarted worker
   });
 });

--- a/packages/daemon/src/site-server.spec.ts
+++ b/packages/daemon/src/site-server.spec.ts
@@ -3,6 +3,7 @@ import { SITE_SERVER_NAME, silentLogger } from "@mcp-cli/core";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SiteServer, buildSiteToolCache, isWorkerEvent } from "./site-server";
 import { SITE_TOOLS } from "./site/tools";
+import type { WorkerClientTransport } from "./worker-transport";
 
 describe("isWorkerEvent (site)", () => {
   test("matches known event types", () => {
@@ -140,8 +141,8 @@ describe("SiteServer crash recovery", () => {
     server = new SiteServer(undefined, instantClient, mockWorkerFactory(), silentLogger);
     await server.start();
 
-    let restartedClient: unknown;
-    let restartedTransport: unknown;
+    let restartedClient: Client | null = null;
+    let restartedTransport: WorkerClientTransport | null = null;
     server.onRestarted = (c, t) => {
       restartedClient = c;
       restartedTransport = t;

--- a/packages/daemon/src/site-server.spec.ts
+++ b/packages/daemon/src/site-server.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { SITE_SERVER_NAME, silentLogger } from "@mcp-cli/core";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SiteServer, buildSiteToolCache, isWorkerEvent } from "./site-server";
 import { SITE_TOOLS } from "./site/tools";
 
@@ -59,6 +60,8 @@ function makeFakeWorker(behavior: { replyReady?: boolean; replyErrorMessage?: st
       }
     }),
     terminate: mock(() => {}),
+    addEventListener: mock(() => {}),
+    removeEventListener: mock(() => {}),
     get onmessage() {
       return listeners.get("message") ?? null;
     },
@@ -74,6 +77,16 @@ function makeFakeWorker(behavior: { replyReady?: boolean; replyErrorMessage?: st
   };
   return worker as unknown as Worker;
 }
+
+function mockWorkerFactory() {
+  return (_scriptPath: string): Worker => makeFakeWorker();
+}
+
+const instantClient = () =>
+  ({
+    connect: async () => {},
+    close: async () => {},
+  }) as unknown as Client;
 
 describe("SiteServer", () => {
   let server: SiteServer | undefined;
@@ -93,5 +106,95 @@ describe("SiteServer", () => {
     const workerFactory = (_path: string): Worker => makeFakeWorker({ replyReady: false });
     server = new SiteServer(undefined, undefined, workerFactory, silentLogger, 250);
     await expect(server.start()).rejects.toThrow(/timeout/);
+  });
+});
+
+describe("SiteServer crash recovery", () => {
+  let server: SiteServer | undefined;
+
+  afterEach(async () => {
+    await server?.stop();
+    server = undefined;
+  });
+
+  test("handleWorkerCrash auto-restarts and fires onRestarted", async () => {
+    server = new SiteServer(undefined, instantClient, mockWorkerFactory(), silentLogger);
+    await server.start();
+
+    let restartedClient: unknown;
+    let restartedTransport: unknown;
+    server.onRestarted = (c, t) => {
+      restartedClient = c;
+      restartedTransport = t;
+    };
+
+    const crash = (
+      server as unknown as { handleWorkerCrash: (reason: string) => Promise<void> }
+    ).handleWorkerCrash.bind(server);
+    await crash("test crash");
+
+    expect(restartedClient).not.toBeNull();
+    expect(restartedTransport).not.toBeNull();
+  });
+
+  test("handleWorkerCrash queues second crash during restart and retries", async () => {
+    server = new SiteServer(undefined, instantClient, mockWorkerFactory(), silentLogger);
+    await server.start();
+
+    let restartCount = 0;
+    server.onRestarted = () => {
+      restartCount++;
+    };
+
+    const crash = (
+      server as unknown as { handleWorkerCrash: (reason: string) => Promise<void> }
+    ).handleWorkerCrash.bind(server);
+
+    await Promise.all([crash("crash A"), crash("crash B")]);
+
+    expect(restartCount).toBe(2);
+  });
+
+  test("handleWorkerCrash gives up after too many crashes", async () => {
+    server = new SiteServer(undefined, instantClient, mockWorkerFactory(), silentLogger);
+    await server.start();
+
+    let restartCount = 0;
+    server.onRestarted = () => {
+      restartCount++;
+    };
+
+    const crash = (
+      server as unknown as { handleWorkerCrash: (reason: string) => Promise<void> }
+    ).handleWorkerCrash.bind(server);
+
+    // Crash MAX_CRASHES times (3) — all should succeed
+    for (let i = 0; i < 3; i++) {
+      await crash(`crash ${i}`);
+    }
+    expect(restartCount).toBe(3);
+
+    // 4th crash — rate-limited, no more restarts
+    await crash("crash 3");
+    expect(restartCount).toBe(3);
+  });
+
+  test("stop() prevents auto-restart on subsequent crash", async () => {
+    server = new SiteServer(undefined, instantClient, mockWorkerFactory(), silentLogger);
+    await server.start();
+    await server.stop();
+
+    let restartedCalled = false;
+    server.onRestarted = () => {
+      restartedCalled = true;
+    };
+
+    const crash = (
+      server as unknown as { handleWorkerCrash: (reason: string) => Promise<void> }
+    ).handleWorkerCrash.bind(server);
+    await crash("post-stop crash");
+
+    expect(restartedCalled).toBe(false);
+    server = undefined;
   });
 });

--- a/packages/daemon/src/site-server.ts
+++ b/packages/daemon/src/site-server.ts
@@ -11,6 +11,13 @@ import type { JsonSchema, Logger, ToolInfo } from "@mcp-cli/core";
 import { SITE_SERVER_NAME, consoleLogger, formatToolSignature } from "@mcp-cli/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { closeClientWithTimeout } from "./close-timeout";
+import {
+  DEFAULT_RESTART_POLICY,
+  type RestartPolicy,
+  getBackoffDelay,
+  maxAttempts,
+  shouldRestart,
+} from "./restart-policy";
 import { SITE_TOOLS } from "./site/tools";
 import { workerPath } from "./worker-path";
 import { WorkerClientTransport } from "./worker-transport";
@@ -46,6 +53,15 @@ export class SiteServer {
   private readonly clientFactory: ClientFactory;
   private readonly workerFactory: WorkerFactory;
   private readonly logger: Logger;
+  private readonly restartPolicy: RestartPolicy;
+  private readonly crashTimestamps: number[] = [];
+  private crashErrorHandler: ((event: ErrorEvent | Event) => void) | null = null;
+  private restartInProgress = false;
+  private pendingCrashReason: string | null = null;
+  private stopped = false;
+
+  /** Called after a successful auto-restart with the new client and transport. */
+  onRestarted?: (client: Client, transport: WorkerClientTransport) => void;
 
   /** Called on worker activity — lets the daemon reset its idle timer. */
   onActivity?: () => void;
@@ -56,10 +72,12 @@ export class SiteServer {
     workerFactory?: WorkerFactory,
     logger?: Logger,
     private handshakeTimeoutMs = 10_000,
+    restartPolicy?: RestartPolicy,
   ) {
     this.clientFactory = clientFactory ?? (() => new Client({ name: `mcp-cli/${SITE_SERVER_NAME}`, version: "0.1.0" }));
     this.workerFactory = workerFactory ?? ((scriptPath: string) => new Worker(scriptPath));
     this.logger = logger ?? consoleLogger;
+    this.restartPolicy = restartPolicy ?? DEFAULT_RESTART_POLICY;
   }
 
   async start(): Promise<{ client: Client; transport: WorkerClientTransport }> {
@@ -135,6 +153,7 @@ export class SiteServer {
       };
 
       worker.onerror = null;
+      this.attachCrashDetection(worker);
     } catch (err) {
       try {
         await this.client?.close();
@@ -156,15 +175,107 @@ export class SiteServer {
   }
 
   async stop(): Promise<void> {
+    this.stopped = true;
+    this.onRestarted = undefined;
     await closeClientWithTimeout(this.client);
     if (this.worker) {
-      this.worker.onmessage = null;
-      this.worker.onerror = null;
+      this.cleanupWorkerHandlers(this.worker);
       this.worker.terminate();
     }
     this.worker = null;
     this.transport = null;
     this.client = null;
+    this.crashTimestamps.length = 0;
+  }
+
+  // ── Crash detection ──
+
+  private cleanupWorkerHandlers(worker: Worker): void {
+    if (this.crashErrorHandler) {
+      worker.removeEventListener("error", this.crashErrorHandler);
+      this.crashErrorHandler = null;
+    }
+    worker.onmessage = null;
+    worker.onerror = null;
+  }
+
+  private attachCrashDetection(worker: Worker): void {
+    const handler = (event: ErrorEvent | Event) => {
+      if (this.worker !== worker) return;
+      const msg = event instanceof ErrorEvent ? event.message : "unknown error";
+      this.handleWorkerCrash(`worker error: ${msg}`);
+    };
+    this.crashErrorHandler = handler;
+    worker.addEventListener("error", handler);
+  }
+
+  private async handleWorkerCrash(reason: string): Promise<void> {
+    if (this.stopped) return;
+    if (this.restartInProgress) {
+      this.pendingCrashReason = reason;
+      return;
+    }
+    this.restartInProgress = true;
+
+    this.logger.error(`[site-server] Worker crash detected: ${reason}`);
+
+    await closeClientWithTimeout(this.client);
+
+    if (this.worker) {
+      this.cleanupWorkerHandlers(this.worker);
+      this.worker.terminate();
+    }
+    this.worker = null;
+    this.transport = null;
+    this.client = null;
+
+    if (!shouldRestart(this.crashTimestamps, this.restartPolicy)) {
+      this.logger.error(
+        `[site-server] ${this.crashTimestamps.length} crashes in ${this.restartPolicy.crashWindowMs / 1000}s — giving up auto-restart`,
+      );
+      this.stopped = true;
+      this.restartInProgress = false;
+      return;
+    }
+
+    const totalAttempts = maxAttempts(this.restartPolicy);
+    let lastErr: unknown;
+
+    try {
+      for (let attempt = 0; attempt < totalAttempts; attempt++) {
+        if (attempt > 0) {
+          const delay = getBackoffDelay(attempt, this.restartPolicy.backoffDelaysMs);
+          this.logger.warn(`[site-server] Retry ${attempt}/${totalAttempts - 1} after ${delay}ms...`);
+          await Bun.sleep(delay);
+        }
+
+        if (this.stopped) {
+          this.logger.info("[site-server] Server stopped during restart backoff — aborting");
+          return;
+        }
+
+        try {
+          this.logger.info("[site-server] Restarting worker...");
+          const { client, transport } = await this.start();
+          this.logger.info("[site-server] Worker restarted successfully");
+          this.onRestarted?.(client, transport);
+          return;
+        } catch (err) {
+          lastErr = err;
+          this.logger.error(`[site-server] Restart attempt ${attempt + 1} failed: ${err}`);
+        }
+      }
+
+      this.logger.error(`[site-server] All ${totalAttempts} restart attempts failed (last: ${lastErr}) — giving up`);
+      this.stopped = true;
+    } finally {
+      this.restartInProgress = false;
+      if (this.pendingCrashReason !== null && !this.stopped) {
+        const pending = this.pendingCrashReason;
+        this.pendingCrashReason = null;
+        await this.handleWorkerCrash(pending);
+      }
+    }
   }
 
   private handleWorkerEvent(event: WorkerEvent): void {

--- a/packages/daemon/src/site-server.ts
+++ b/packages/daemon/src/site-server.ts
@@ -84,6 +84,7 @@ export class SiteServer {
   }
 
   async start(): Promise<{ client: Client; transport: WorkerClientTransport }> {
+    this.stopped = false;
     if (this.worker) throw new Error("SiteServer.start() called while worker is already running");
     const worker = this.workerFactory(workerPath("site-worker.ts"));
     this.worker = worker;

--- a/packages/daemon/src/site-server.ts
+++ b/packages/daemon/src/site-server.ts
@@ -63,6 +63,9 @@ export class SiteServer {
   /** Called after a successful auto-restart with the new client and transport. */
   onRestarted?: (client: Client, transport: WorkerClientTransport) => void;
 
+  /** Called when the crash-restart loop exhausts its budget and gives up permanently. */
+  onPermanentlyFailed?: () => void;
+
   /** Called on worker activity — lets the daemon reset its idle timer. */
   onActivity?: () => void;
 
@@ -229,19 +232,22 @@ export class SiteServer {
     this.transport = null;
     this.client = null;
 
-    if (!shouldRestart(this.crashTimestamps, this.restartPolicy)) {
-      this.logger.error(
-        `[site-server] ${this.crashTimestamps.length} crashes in ${this.restartPolicy.crashWindowMs / 1000}s — giving up auto-restart`,
-      );
-      this.stopped = true;
-      this.restartInProgress = false;
-      return;
-    }
-
-    const totalAttempts = maxAttempts(this.restartPolicy);
-    let lastErr: unknown;
-
+    // Outer try/finally owns restartInProgress = false for ALL exit paths, including
+    // the shouldRestart early-return below (previously that path reset it manually,
+    // making the code fragile against future changes).
     try {
+      if (!shouldRestart(this.crashTimestamps, this.restartPolicy)) {
+        this.logger.error(
+          `[site-server] ${this.crashTimestamps.length} crashes in ${this.restartPolicy.crashWindowMs / 1000}s — giving up auto-restart`,
+        );
+        this.stopped = true;
+        this.onPermanentlyFailed?.();
+        return;
+      }
+
+      const totalAttempts = maxAttempts(this.restartPolicy);
+      let lastErr: unknown;
+
       for (let attempt = 0; attempt < totalAttempts; attempt++) {
         if (attempt > 0) {
           const delay = getBackoffDelay(attempt, this.restartPolicy.backoffDelaysMs);
@@ -254,20 +260,35 @@ export class SiteServer {
           return;
         }
 
+        // Separate start() from onRestarted so that a throw in the callback
+        // does NOT look like a failed start() and trigger a spurious retry
+        // against an already-running worker (which would leak the worker).
+        let startResult: { client: Client; transport: WorkerClientTransport } | undefined;
         try {
           this.logger.info("[site-server] Restarting worker...");
-          const { client, transport } = await this.start();
-          this.logger.info("[site-server] Worker restarted successfully");
-          this.onRestarted?.(client, transport);
-          return;
+          startResult = await this.start();
         } catch (err) {
           lastErr = err;
           this.logger.error(`[site-server] Restart attempt ${attempt + 1} failed: ${err}`);
+        }
+
+        if (startResult) {
+          this.logger.info("[site-server] Worker restarted successfully");
+          try {
+            this.onRestarted?.(startResult.client, startResult.transport);
+          } catch (err) {
+            // Registration callback failed — the worker is running but unregistered.
+            // Tear it down via stop() rather than leaving it as an orphan.
+            this.logger.error(`[site-server] onRestarted callback threw: ${err} — stopping server`);
+            await this.stop();
+          }
+          return;
         }
       }
 
       this.logger.error(`[site-server] All ${totalAttempts} restart attempts failed (last: ${lastErr}) — giving up`);
       this.stopped = true;
+      this.onPermanentlyFailed?.();
     } finally {
       this.restartInProgress = false;
       if (this.pendingCrashReason !== null && !this.stopped) {


### PR DESCRIPTION
## Summary
- Add crash detection + auto-restart to `SiteServer`, matching the existing pattern in `ClaudeServer` and `CodexServer`
- When the `_site` worker dies (e.g. macOS sleep/wake killing Chrome/Playwright), the worker is automatically restarted with exponential backoff (100ms → 500ms → 2000ms, up to 3 crashes per 60s window)
- Wire up `onRestarted` callback in the daemon to re-register the virtual server in the `ServerPool`, making recovery transparent to callers

## Test plan
- [x] Added 4 crash-recovery tests: auto-restart + onRestarted firing, queued concurrent crashes, crash-loop rate limiting, stop() preventing restart
- [x] All existing tests pass (10 tests in site-server.spec.ts, 5589 total)
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] Pre-commit hooks pass (typecheck + lint + test + coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)