### PR TITLE
fix(sites): open new tabs for sites added while browser is running (fixes #1594)

### DIFF
--- a/packages/command/src/commands/site.spec.ts
+++ b/packages/command/src/commands/site.spec.ts
@@ -258,6 +258,23 @@ describe("cmdSite", () => {
     expect(params.arguments.enabled).toBe(true);
   });
 
+  test("parseKv normalizes --chrome-profile to chromeProfile (#1594)", async () => {
+    const { deps, calls } = makeDeps();
+    await cmdSite(["add", "atlassian", "--url", "https://x.atlassian.net/", "--chrome-profile", "../../default"], deps);
+    const { params } = readLastCall(calls);
+    expect(params.tool).toBe("site_add");
+    expect(params.arguments.chromeProfile).toBe("../../default");
+    expect(params.arguments["chrome-profile"]).toBeUndefined();
+  });
+
+  test("parseKv normalizes --browser-engine to browserEngine", async () => {
+    const { deps, calls } = makeDeps();
+    await cmdSite(["add", "x", "--url", "https://x.com", "--browser-engine", "playwright"], deps);
+    const { params } = readLastCall(calls);
+    expect(params.arguments.browserEngine).toBe("playwright");
+    expect(params.arguments["browser-engine"]).toBeUndefined();
+  });
+
   test("parseKv coerces numbers and booleans", async () => {
     const { deps, calls } = makeDeps();
     await cmdSite(["call", "s", "c", "--n", "42", "--b", "true", "--f", "false"], deps);

--- a/packages/command/src/commands/site.ts
+++ b/packages/command/src/commands/site.ts
@@ -51,17 +51,22 @@ Flags:
   --help, -h       Show this help
 `;
 
+function kebabToCamel(s: string): string {
+  return s.replace(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+}
+
 function parseKv(args: string[]): { kv: Record<string, unknown>; rest: string[] } {
   const kv: Record<string, unknown> = {};
   const rest: string[] = [];
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (a.startsWith("--")) {
-      const key = a.slice(2);
-      if (key.includes("=")) {
-        const [k, v] = key.split("=", 2);
-        kv[k] = coerce(v);
+      const raw = a.slice(2);
+      if (raw.includes("=")) {
+        const [k, v] = raw.split("=", 2);
+        kv[kebabToCamel(k)] = coerce(v);
       } else {
+        const key = kebabToCamel(raw);
         const next = args[i + 1];
         if (next === undefined || next.startsWith("--")) {
           kv[key] = true;

--- a/packages/daemon/src/site/browser/engine.ts
+++ b/packages/daemon/src/site/browser/engine.ts
@@ -59,7 +59,7 @@ export interface ColdStartResult {
 export interface StartSiteResult {
   site: string;
   url: string;
-  status: "navigated" | "failed" | "already-running";
+  status: "navigated" | "failed" | "already-running" | "profile-mismatch";
   error?: string;
 }
 

--- a/packages/daemon/src/site/browser/playwright.spec.ts
+++ b/packages/daemon/src/site/browser/playwright.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { SiteSpec } from "./engine";
-import { type OpenPageLike, openSitesInContext } from "./playwright";
+import { type OpenPageLike, openSitesInContext, partitionSitesForRunningBrowser } from "./playwright";
 
 function fakePage(opts: { failGoto?: string } = {}): OpenPageLike & {
   gotoCalls: string[];
@@ -102,5 +102,60 @@ describe("openSitesInContext — #1588 regression", () => {
     });
 
     expect(order).toEqual(["attach:teams", "goto:https://teams.test/home"]);
+  });
+});
+
+describe("partitionSitesForRunningBrowser — #1594", () => {
+  const profile = "/tmp/profile/default";
+
+  test("already-open sites go to alreadyRunning", () => {
+    const { alreadyRunning, toOpen, profileMismatch } = partitionSitesForRunningBrowser(profile, new Set(["teams"]), [
+      spec("teams", { profileDir: profile }),
+    ]);
+    expect(alreadyRunning.map((s) => s.name)).toEqual(["teams"]);
+    expect(toOpen).toHaveLength(0);
+    expect(profileMismatch).toHaveLength(0);
+  });
+
+  test("new site with matching profile goes to toOpen", () => {
+    const { alreadyRunning, toOpen, profileMismatch } = partitionSitesForRunningBrowser(profile, new Set(["teams"]), [
+      spec("teams", { profileDir: profile }),
+      spec("owa", { profileDir: profile }),
+    ]);
+    expect(alreadyRunning.map((s) => s.name)).toEqual(["teams"]);
+    expect(toOpen.map((s) => s.name)).toEqual(["owa"]);
+    expect(profileMismatch).toHaveLength(0);
+  });
+
+  test("new site with different profile goes to profileMismatch", () => {
+    const otherProfile = "/tmp/other/default";
+    const { alreadyRunning, toOpen, profileMismatch } = partitionSitesForRunningBrowser(profile, new Set(["teams"]), [
+      spec("atlassian", { profileDir: otherProfile }),
+    ]);
+    expect(alreadyRunning).toHaveLength(0);
+    expect(toOpen).toHaveLength(0);
+    expect(profileMismatch.map((s) => s.name)).toEqual(["atlassian"]);
+  });
+
+  test("mixed batch: already-running + new-same-profile + mismatch", () => {
+    const otherProfile = "/tmp/other/default";
+    const { alreadyRunning, toOpen, profileMismatch } = partitionSitesForRunningBrowser(profile, new Set(["teams"]), [
+      spec("teams", { profileDir: profile }),
+      spec("owa", { profileDir: profile }),
+      spec("atlassian", { profileDir: otherProfile }),
+    ]);
+    expect(alreadyRunning.map((s) => s.name)).toEqual(["teams"]);
+    expect(toOpen.map((s) => s.name)).toEqual(["owa"]);
+    expect(profileMismatch.map((s) => s.name)).toEqual(["atlassian"]);
+  });
+
+  test("all-new same-profile sites go to toOpen", () => {
+    const { alreadyRunning, toOpen, profileMismatch } = partitionSitesForRunningBrowser(profile, new Set<string>(), [
+      spec("teams", { profileDir: profile }),
+      spec("owa", { profileDir: profile }),
+    ]);
+    expect(alreadyRunning).toHaveLength(0);
+    expect(toOpen.map((s) => s.name)).toEqual(["teams", "owa"]);
+    expect(profileMismatch).toHaveLength(0);
   });
 });

--- a/packages/daemon/src/site/browser/playwright.ts
+++ b/packages/daemon/src/site/browser/playwright.ts
@@ -54,6 +54,34 @@ export interface OpenPageLike {
 }
 
 /**
+ * Partition requested sites into three buckets for an already-running browser.
+ * Exported for unit tests.
+ *
+ * - alreadyRunning: already has a tab open
+ * - toOpen: new site whose profileDir matches the running browser's profileDir
+ * - profileMismatch: new site with a different profileDir (needs disconnect first)
+ */
+export function partitionSitesForRunningBrowser(
+  runningProfile: string,
+  openedSiteNames: ReadonlySet<string>,
+  requested: SiteSpec[],
+): { alreadyRunning: SiteSpec[]; toOpen: SiteSpec[]; profileMismatch: SiteSpec[] } {
+  const alreadyRunning: SiteSpec[] = [];
+  const toOpen: SiteSpec[] = [];
+  const profileMismatch: SiteSpec[] = [];
+  for (const s of requested) {
+    if (openedSiteNames.has(s.name)) {
+      alreadyRunning.push(s);
+    } else if (s.profileDir !== runningProfile) {
+      profileMismatch.push(s);
+    } else {
+      toOpen.push(s);
+    }
+  }
+  return { alreadyRunning, toOpen, profileMismatch };
+}
+
+/**
  * Open a fresh tab per site and navigate it. Exported for unit tests.
  *
  * Why fresh tabs: reusing `ctx.pages()` picks up tabs restored from the
@@ -102,11 +130,38 @@ export class PlaywrightBrowserEngine implements BrowserEngine {
 
   async start(sites: SiteSpec[], events: BrowserEvents): Promise<StartSiteResult[]> {
     if (this.context) {
-      return [...this.pages.entries()].map(([name, page]) => ({
-        site: name,
-        url: page.url(),
-        status: "already-running" as const,
-      }));
+      const runningProfile = [...this.siteSpecs.values()][0]?.profileDir ?? "";
+      const openedNames = new Set(this.pages.keys());
+      const { alreadyRunning, toOpen, profileMismatch } = partitionSitesForRunningBrowser(
+        runningProfile,
+        openedNames,
+        sites,
+      );
+
+      const results: StartSiteResult[] = [
+        ...alreadyRunning.map((s) => ({
+          site: s.name,
+          url: this.pages.get(s.name)?.url() ?? s.url,
+          status: "already-running" as const,
+        })),
+        ...profileMismatch.map((s) => ({
+          site: s.name,
+          url: s.url,
+          status: "profile-mismatch" as const,
+          error: `Browser is running with profileDir=${runningProfile}; this site uses ${s.profileDir}. Run site_disconnect first.`,
+        })),
+      ];
+
+      if (toOpen.length > 0) {
+        for (const s of toOpen) this.siteSpecs.set(s.name, s);
+        const newResults = await openSitesInContext(this.context, toOpen, (page, name) => {
+          this.pages.set(name, page);
+          this.attachListeners(page, name);
+        });
+        results.push(...newResults);
+      }
+
+      return results;
     }
     this.events = events;
     for (const s of sites) this.siteSpecs.set(s.name, s);

--- a/packages/daemon/src/site/browser/playwright.ts
+++ b/packages/daemon/src/site/browser/playwright.ts
@@ -148,7 +148,7 @@ export class PlaywrightBrowserEngine implements BrowserEngine {
           site: s.name,
           url: s.url,
           status: "profile-mismatch" as const,
-          error: `Browser is running with profileDir=${runningProfile}; this site uses ${s.profileDir}. Run site_disconnect first.`,
+          error: `Browser is running with profileDir=${runningProfile}; this site uses ${s.profileDir}. Run \`mcx site disconnect\` first.`,
         })),
       ];
 


### PR DESCRIPTION
## Summary
- When `site_browser_start` is called while a browser is already running, the engine now diffs the requested sites against the live pages map: already-open sites return `already-running`, new sites with a matching `profileDir` get a fresh tab opened, and new sites with a mismatched `profileDir` return a clear `profile-mismatch` error instead of being silently dropped
- Fixes the `--chrome-profile` (and any kebab-case flag) being silently dropped in `mcx site add` — `parseKv` now normalizes kebab-case to camelCase before sending to the daemon
- Exports `partitionSitesForRunningBrowser` helper for unit testability

## Test plan
- [ ] 5 new unit tests for `partitionSitesForRunningBrowser`: already-running, new-same-profile, profile-mismatch, mixed batch, all-new cases
- [ ] 2 new tests in `site.spec.ts` for `--chrome-profile` and `--browser-engine` kebab normalization
- [ ] Full suite: 5592 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)