### PR TITLE
fix(work-items-server): add phase_state_delete to unknown-key error message (fixes #1524)

### DIFF
--- a/packages/daemon/src/work-items-server.spec.ts
+++ b/packages/daemon/src/work-items-server.spec.ts
@@ -951,6 +951,7 @@ describe("WorkItemsServer", () => {
     expect(content[0].text).toContain("qa_session_id");
     expect(content[0].text).toContain("session_id");
     expect(content[0].text).toContain("Phase-namespace state");
+    expect(content[0].text).toContain("phase_state_get/set/delete/list");
   });
 
   test("work_items_update rejects mix of known and unknown keys (#1445)", async () => {

--- a/packages/daemon/src/work-items-server.ts
+++ b/packages/daemon/src/work-items-server.ts
@@ -389,7 +389,7 @@ export class WorkItemsServer {
                 content: [
                   {
                     type: "text" as const,
-                    text: `Unknown keys: ${unknownKeys.join(", ")}. work_items_update only accepts known keys (${accepted}). Phase-namespace state (session_id, qa_session_id, etc.) is stored separately — use phase_state_get/set/list tools to read/write it.`,
+                    text: `Unknown keys: ${unknownKeys.join(", ")}. work_items_update only accepts known keys (${accepted}). Phase-namespace state (session_id, qa_session_id, etc.) is stored separately — use phase_state_get/set/delete/list tools to read/write it.`,
                   },
                 ],
                 isError: true,


### PR DESCRIPTION
## Summary
- Adds `phase_state_delete` to the error message shown when `work_items_update` is called with unknown keys
- The previous message listed only `phase_state_get/set/list`, omitting `phase_state_delete` and misleading callers who want to remove a key

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test packages/daemon/src/work-items-server.spec.ts` — 59 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)