### PR TITLE
feat(monitor): server-side filter pushdown with glob matching on /events (fixes #1573)

### DIFF
--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -2722,6 +2722,249 @@ describe("IpcServer HTTP transport", () => {
       c2.abort();
       reader2?.releaseLock();
     });
+
+    test("type glob filter matches event names with wildcards", async () => {
+      const { bus } = startServerWithBus();
+
+      const controller = new AbortController();
+      const res = await fetch("http://localhost/events?type=pr.*", {
+        method: "GET",
+        unix: socketPath,
+        signal: controller.signal,
+      } as RequestInit);
+
+      if (!res.body) throw new Error("Expected response body");
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+
+      await reader.read(); // drain initial flush
+
+      bus.publish({ src: "test", event: "session.result", category: "session", sessionId: "s1" });
+      bus.publish({ src: "test", event: "pr.merged", category: "work_item", prNumber: 42 });
+      bus.publish({ src: "test", event: "pr.opened", category: "work_item", prNumber: 43 });
+
+      let buffer = "";
+      const deadline = Date.now() + 2_000;
+      while (Date.now() < deadline) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        if (buffer.includes("pr.opened")) break;
+      }
+
+      controller.abort();
+      reader.releaseLock();
+
+      expect(buffer).not.toContain("session.result");
+      expect(buffer).toContain("pr.merged");
+      expect(buffer).toContain("pr.opened");
+    });
+
+    test("type glob supports comma-separated OR patterns", async () => {
+      const { bus } = startServerWithBus();
+
+      const controller = new AbortController();
+      const res = await fetch(`http://localhost/events?type=${encodeURIComponent("pr.*,mail.received")}`, {
+        method: "GET",
+        unix: socketPath,
+        signal: controller.signal,
+      } as RequestInit);
+
+      if (!res.body) throw new Error("Expected response body");
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+
+      await reader.read(); // drain initial flush
+
+      bus.publish({ src: "test", event: "session.result", category: "session", sessionId: "s1" });
+      bus.publish({ src: "test", event: "pr.merged", category: "work_item", prNumber: 42 });
+      bus.publish({
+        src: "test",
+        event: "mail.received",
+        category: "mail",
+        mailId: 1,
+        sender: "a",
+        recipient: "b",
+      });
+
+      let buffer = "";
+      const deadline = Date.now() + 2_000;
+      while (Date.now() < deadline) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        if (buffer.includes("mail.received")) break;
+      }
+
+      controller.abort();
+      reader.releaseLock();
+
+      expect(buffer).not.toContain("session.result");
+      expect(buffer).toContain("pr.merged");
+      expect(buffer).toContain("mail.received");
+    });
+
+    test("src glob filter matches source attribution with wildcards", async () => {
+      const { bus } = startServerWithBus();
+
+      const controller = new AbortController();
+      const res = await fetch(`http://localhost/events?src=${encodeURIComponent("daemon.*")}`, {
+        method: "GET",
+        unix: socketPath,
+        signal: controller.signal,
+      } as RequestInit);
+
+      if (!res.body) throw new Error("Expected response body");
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+
+      await reader.read(); // drain initial flush
+
+      // Publish non-matching first, then matching — if filter works, only the match arrives
+      bus.publish({ src: "external.hook", event: "pr.opened", category: "work_item", prNumber: 43 });
+      bus.publish({ src: "daemon.poller", event: "pr.merged", category: "work_item", prNumber: 42 });
+
+      let buffer = "";
+      const deadline = Date.now() + 2_000;
+      while (Date.now() < deadline) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        if (buffer.includes("pr.merged")) break;
+      }
+
+      controller.abort();
+      reader.releaseLock();
+
+      expect(buffer).toContain("pr.merged");
+      expect(buffer).not.toContain("pr.opened");
+    });
+
+    test("phase filter matches phase field on events", async () => {
+      const { bus } = startServerWithBus();
+
+      const controller = new AbortController();
+      const res = await fetch("http://localhost/events?phase=review", {
+        method: "GET",
+        unix: socketPath,
+        signal: controller.signal,
+      } as RequestInit);
+
+      if (!res.body) throw new Error("Expected response body");
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+
+      await reader.read(); // drain initial flush
+
+      bus.publish({
+        src: "test",
+        event: "phase.changed",
+        category: "work_item",
+        phase: "impl",
+        workItemId: "#1",
+      } as never);
+      bus.publish({
+        src: "test",
+        event: "phase.changed",
+        category: "work_item",
+        phase: "review",
+        workItemId: "#2",
+      } as never);
+
+      let buffer = "";
+      const deadline = Date.now() + 2_000;
+      while (Date.now() < deadline) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        if (buffer.includes("#2")) break;
+      }
+
+      controller.abort();
+      reader.releaseLock();
+
+      expect(buffer).not.toContain("#1");
+      expect(buffer).toContain("#2");
+    });
+
+    test("combined filters are conjunctive (AND across axes)", async () => {
+      const { bus } = startServerWithBus();
+
+      const controller = new AbortController();
+      const res = await fetch("http://localhost/events?subscribe=work_item&pr=42", {
+        method: "GET",
+        unix: socketPath,
+        signal: controller.signal,
+      } as RequestInit);
+
+      if (!res.body) throw new Error("Expected response body");
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+
+      await reader.read(); // drain initial flush
+
+      bus.publish({ src: "test", event: "pr.merged", category: "work_item", prNumber: 99 });
+      bus.publish({ src: "test", event: "session.result", category: "session", sessionId: "s1" });
+      bus.publish({ src: "test", event: "pr.opened", category: "work_item", prNumber: 42 });
+
+      let buffer = "";
+      const deadline = Date.now() + 2_000;
+      while (Date.now() < deadline) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        if (buffer.includes("pr.opened")) break;
+      }
+
+      controller.abort();
+      reader.releaseLock();
+
+      expect(buffer).not.toContain("pr.merged");
+      expect(buffer).not.toContain("session.result");
+      expect(buffer).toContain("pr.opened");
+    });
+
+    test("backfill from durable log respects filters", async () => {
+      const db = new Database(":memory:");
+      const eventLog = new EventLog(db);
+      const bus = new EventBus(eventLog);
+      socketPath = tmpSocket();
+      server = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, {
+        ...opts(),
+        eventBus: bus,
+      });
+      server.start(socketPath);
+
+      bus.publish({ src: "test", event: "session.result", category: "session", sessionId: "s1" });
+      bus.publish({ src: "test", event: "pr.merged", category: "work_item", prNumber: 42 });
+
+      const controller = new AbortController();
+      const res = await fetch("http://localhost/events?since=0&subscribe=work_item", {
+        method: "GET",
+        unix: socketPath,
+        signal: controller.signal,
+      } as RequestInit);
+
+      expect(res.status).toBe(200);
+      if (!res.body) throw new Error("Expected response body");
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+
+      let buffer = "";
+      const deadline = Date.now() + 2_000;
+      while (Date.now() < deadline) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        if (buffer.includes("pr.merged")) break;
+      }
+
+      controller.abort();
+      reader.releaseLock();
+
+      expect(buffer).not.toContain("session.result");
+      expect(buffer).toContain("pr.merged");
+    });
   });
 
   // -- GET /events NDJSON endpoint tests (ring-buffer / pushEvent path) --
@@ -3151,5 +3394,12 @@ describe("buildEventFilter", () => {
     const filter = buildEventFilter(params({ type: "*" }));
     expect(filter?.({ category: "session" })).toBe(false);
     expect(filter?.({ event: "session.result", category: "session" })).toBe(true);
+  });
+
+  test("heartbeat events bypass all filters", () => {
+    const filter = buildEventFilter(params({ subscribe: "session", pr: "42", type: "session.*" }));
+    expect(filter).not.toBeNull();
+    expect(filter?.({ category: "heartbeat", event: "heartbeat" })).toBe(true);
+    expect(filter?.({ category: "heartbeat", event: "heartbeat", src: "daemon" })).toBe(true);
   });
 });

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -1476,16 +1476,6 @@ export class IpcServer {
 
     // ── EventBus path (unified monitor architecture, #1512/#1515) ──
     if (this.eventBus) {
-      const subscribeFilter = url.searchParams.get("subscribe");
-      if (
-        subscribeFilter !== null &&
-        subscribeFilter
-          .split(",")
-          .map((s) => s.trim())
-          .filter(Boolean).length === 0
-      ) {
-        return new Response("subscribe must not be empty", { status: 400 });
-      }
       const responseTail = url.searchParams.get("responseTail");
       const eventFilter = buildEventFilter(url.searchParams);
 

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -139,6 +139,7 @@ export function buildEventFilter(params: URLSearchParams): ((event: Record<strin
   const srcPattern = srcRaw ? globToRegex(srcRaw) : null;
 
   return (event: Record<string, unknown>): boolean => {
+    if (event.category === "heartbeat" || event.event === "heartbeat") return true;
     if (categories && !categories.has(event.category as string)) return false;
     if (session && event.sessionId !== session) return false;
     if (prNumber !== null && event.prNumber !== prNumber) return false;
@@ -1453,8 +1454,8 @@ export class IpcServer {
    *   session=<id>             Filter to one session ID
    *   pr=<n>                   Filter to one PR number
    *   workItem=<id>            Filter to one work item ID
-   *   type=<glob>              Event name filter (exact match; future: glob)
-   *   src=<pattern>            Source attribution filter (exact match; future: glob)
+   *   type=<glob>              Event name glob filter (comma-separated OR, e.g. "pr.*,session.idle")
+   *   src=<pattern>            Source attribution glob filter (e.g. "daemon.*")
    *   phase=<name>             Phase filter on work item phase
    *   since=<seq>              Replay events after this cursor from the durable log,
    *                            then seamlessly switch to live delivery (#1513)
@@ -1476,23 +1477,17 @@ export class IpcServer {
     // ── EventBus path (unified monitor architecture, #1512/#1515) ──
     if (this.eventBus) {
       const subscribeFilter = url.searchParams.get("subscribe");
-      const sessionFilter = url.searchParams.get("session");
-      const prFilter = url.searchParams.has("pr") ? Number(url.searchParams.get("pr")) : undefined;
-      const workItemFilter = url.searchParams.get("workItem");
-      const typeFilter = url.searchParams.get("type");
-      const srcFilter = url.searchParams.get("src");
-      const responseTail = url.searchParams.get("responseTail");
-
-      const categoryList = subscribeFilter
-        ? subscribeFilter
-            .split(",")
-            .map((s) => s.trim())
-            .filter((s) => s.length > 0)
-        : null;
-      if (categoryList !== null && categoryList.length === 0) {
+      if (
+        subscribeFilter !== null &&
+        subscribeFilter
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean).length === 0
+      ) {
         return new Response("subscribe must not be empty", { status: 400 });
       }
-      const categories = categoryList ? new Set(categoryList) : null;
+      const responseTail = url.searchParams.get("responseTail");
+      const eventFilter = buildEventFilter(url.searchParams);
 
       const bus = this.eventBus;
 
@@ -1564,14 +1559,7 @@ export class IpcServer {
                 }
               },
               (event) => {
-                // session.response: excluded by default; opt-in only when responseTail matches.
-                // All other filters still apply first, even for session.response.
-                if (categories !== null && !categories.has(event.category)) return false;
-                if (sessionFilter !== null && event.sessionId !== sessionFilter) return false;
-                if (prFilter !== undefined && event.prNumber !== prFilter) return false;
-                if (workItemFilter !== null && event.workItemId !== workItemFilter) return false;
-                if (typeFilter !== null && event.event !== typeFilter) return false;
-                if (srcFilter !== null && event.src !== srcFilter) return false;
+                if (eventFilter !== null && !eventFilter(event as Record<string, unknown>)) return false;
                 if (event.event === "session.response") {
                   return responseTail !== null && event.sessionId === responseTail;
                 }
@@ -1587,6 +1575,7 @@ export class IpcServer {
                 const batch = eventLog.getSince(cursor, 1000);
                 for (const event of batch) {
                   highWaterMark = event.seq;
+                  if (eventFilter !== null && !eventFilter(event as Record<string, unknown>)) continue;
                   if (controller.desiredSize !== null && controller.desiredSize <= 0) {
                     this.logger.warn("[events] slow consumer during backfill, dropping subscriber");
                     metrics.counter("mcpd_event_bus_slow_drops_total").inc();


### PR DESCRIPTION
## Summary
- Refactored EventBus path to use the existing `buildEventFilter()` predicate instead of a duplicated inline filter, enabling **glob matching** for `type` and `src` params (e.g. `type=pr.*,session.idle`, `src=daemon.*`) and adding **phase filtering** that was previously missing
- Added **heartbeat bypass** to `buildEventFilter()` so heartbeat events always pass through regardless of active filters
- Applied filter to **EventBus backfill path** so replayed events from the durable log also respect filters (was previously unfiltered)

## Test plan
- [x] Unit test: heartbeat events bypass all filters (`buildEventFilter` suite)
- [x] Integration test: type glob filter matches event names with wildcards (EventBus path)
- [x] Integration test: comma-separated OR patterns for type glob
- [x] Integration test: src glob filter with wildcard matching
- [x] Integration test: phase filter on events
- [x] Integration test: combined filters are conjunctive (AND across axes)
- [x] Integration test: backfill from durable log respects filters
- [x] All existing 132 ipc-server tests pass
- [x] Full suite: 5,592 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)