### PR TITLE
fix(monitor): publish work-item monitor events directly on main thread (fixes #1618)

### DIFF
--- a/packages/daemon/src/claude-server.spec.ts
+++ b/packages/daemon/src/claude-server.spec.ts
@@ -1663,6 +1663,19 @@ describe("forwardWorkItemEvent", () => {
     }
   });
 
+  test("checks:started without runId omits runId from monitor event", () => {
+    const { server, dispose } = makeServer();
+    try {
+      const events = collect(server);
+      server.forwardWorkItemEvent({ type: "checks:started", prNumber: 13 });
+      expect(events[0].event).toBe("checks.started");
+      expect(events[0].prNumber).toBe(13);
+      expect(events[0].runId).toBeUndefined();
+    } finally {
+      dispose();
+    }
+  });
+
   test("checks:passed maps to checks.passed", () => {
     const { server, dispose } = makeServer();
     try {
@@ -1675,7 +1688,7 @@ describe("forwardWorkItemEvent", () => {
     }
   });
 
-  test("review:approved maps reviewer field", () => {
+  test("review:approved maps to review.approved with prNumber", () => {
     const { server, dispose } = makeServer();
     try {
       const events = collect(server);
@@ -1724,9 +1737,21 @@ describe("forwardWorkItemEvent", () => {
     }
   });
 
-  test("no onMonitorEvent callback — does not throw", () => {
+  test("undefined onMonitorEvent — does not throw", () => {
     const { server, dispose } = makeServer();
     try {
+      expect(() => {
+        server.forwardWorkItemEvent({ type: "pr:merged", prNumber: 1 });
+      }).not.toThrow();
+    } finally {
+      dispose();
+    }
+  });
+
+  test("null onMonitorEvent at runtime — does not throw", () => {
+    const { server, dispose } = makeServer();
+    try {
+      (server as unknown as { onMonitorEvent: null }).onMonitorEvent = null;
       expect(() => {
         server.forwardWorkItemEvent({ type: "pr:merged", prNumber: 1 });
       }).not.toThrow();

--- a/packages/daemon/src/claude-server.spec.ts
+++ b/packages/daemon/src/claude-server.spec.ts
@@ -1,6 +1,6 @@
 import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { CLAUDE_SERVER_NAME, capturingLogger, silentLogger } from "@mcp-cli/core";
-import type { MonitorEvent } from "@mcp-cli/core";
+import type { MonitorEvent, MonitorEventInput, WorkItemEvent } from "@mcp-cli/core";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { ToolListChangedNotificationSchema } from "@modelcontextprotocol/sdk/types.js";
 import { testOptions } from "../../../test/test-options";
@@ -1572,5 +1572,179 @@ describe("monitor event bridge integration", () => {
     expect(seqs).toEqual([1, 2, 3, 4, 5]);
 
     db.close();
+  });
+});
+
+// ── forwardWorkItemEvent direct main-thread publish (#1618) ──
+
+describe("forwardWorkItemEvent", () => {
+  function makeServer(): { server: ClaudeServer; db: StateDb; dispose: () => void } {
+    const opts = testOptions();
+    const db = new StateDb(opts.DB_PATH);
+    const server = new ClaudeServer(db, undefined, undefined, silentLogger);
+    return {
+      server,
+      db,
+      dispose: () => {
+        db.close();
+        opts[Symbol.dispose]();
+      },
+    };
+  }
+
+  function collect(server: ClaudeServer): MonitorEventInput[] {
+    const events: MonitorEventInput[] = [];
+    server.onMonitorEvent = (input) => events.push(input);
+    return events;
+  }
+
+  test("pr:opened publishes directly without starting worker", () => {
+    const { server, dispose } = makeServer();
+    try {
+      const events = collect(server);
+      server.forwardWorkItemEvent({ type: "pr:opened", prNumber: 42 });
+      expect(events).toHaveLength(1);
+      expect(events[0].src).toBe("daemon.work-item-poller");
+      expect(events[0].event).toBe("pr.opened");
+      expect(events[0].category).toBe("work_item");
+      expect(events[0].prNumber).toBe(42);
+    } finally {
+      dispose();
+    }
+  });
+
+  test("pr:merged maps to pr.merged with prNumber", () => {
+    const { server, dispose } = makeServer();
+    try {
+      const events = collect(server);
+      server.forwardWorkItemEvent({ type: "pr:merged", prNumber: 55 });
+      expect(events).toHaveLength(1);
+      expect(events[0].event).toBe("pr.merged");
+      expect(events[0].prNumber).toBe(55);
+    } finally {
+      dispose();
+    }
+  });
+
+  test("pr:closed maps to pr.closed", () => {
+    const { server, dispose } = makeServer();
+    try {
+      const events = collect(server);
+      server.forwardWorkItemEvent({ type: "pr:closed", prNumber: 77 });
+      expect(events[0].event).toBe("pr.closed");
+      expect(events[0].prNumber).toBe(77);
+    } finally {
+      dispose();
+    }
+  });
+
+  test("checks:failed maps failedJob field", () => {
+    const { server, dispose } = makeServer();
+    try {
+      const events = collect(server);
+      server.forwardWorkItemEvent({ type: "checks:failed", prNumber: 7, failedJob: "typecheck" });
+      expect(events[0].event).toBe("checks.failed");
+      expect(events[0].prNumber).toBe(7);
+      expect(events[0].failedJob).toBe("typecheck");
+    } finally {
+      dispose();
+    }
+  });
+
+  test("checks:started maps runId field", () => {
+    const { server, dispose } = makeServer();
+    try {
+      const events = collect(server);
+      server.forwardWorkItemEvent({ type: "checks:started", prNumber: 12, runId: 9876 });
+      expect(events[0].event).toBe("checks.started");
+      expect(events[0].runId).toBe(9876);
+    } finally {
+      dispose();
+    }
+  });
+
+  test("checks:passed maps to checks.passed", () => {
+    const { server, dispose } = makeServer();
+    try {
+      const events = collect(server);
+      server.forwardWorkItemEvent({ type: "checks:passed", prNumber: 33 });
+      expect(events[0].event).toBe("checks.passed");
+      expect(events[0].prNumber).toBe(33);
+    } finally {
+      dispose();
+    }
+  });
+
+  test("review:approved maps reviewer field", () => {
+    const { server, dispose } = makeServer();
+    try {
+      const events = collect(server);
+      server.forwardWorkItemEvent({ type: "review:approved", prNumber: 44 });
+      expect(events[0].event).toBe("review.approved");
+      expect(events[0].prNumber).toBe(44);
+    } finally {
+      dispose();
+    }
+  });
+
+  test("review:changes_requested maps reviewer field", () => {
+    const { server, dispose } = makeServer();
+    try {
+      const events = collect(server);
+      server.forwardWorkItemEvent({ type: "review:changes_requested", prNumber: 99, reviewer: "alice" });
+      expect(events[0].event).toBe("review.changes_requested");
+      expect(events[0].reviewer).toBe("alice");
+    } finally {
+      dispose();
+    }
+  });
+
+  test("phase:changed maps itemId to workItemId with from/to", () => {
+    const { server, dispose } = makeServer();
+    try {
+      const events = collect(server);
+      server.forwardWorkItemEvent({ type: "phase:changed", itemId: "wi-123", from: "impl", to: "review" });
+      expect(events[0].event).toBe("phase.changed");
+      expect(events[0].workItemId).toBe("wi-123");
+      expect(events[0].from).toBe("impl");
+      expect(events[0].to).toBe("review");
+    } finally {
+      dispose();
+    }
+  });
+
+  test("unmapped event type is silently dropped", () => {
+    const { server, dispose } = makeServer();
+    try {
+      const events = collect(server);
+      server.forwardWorkItemEvent({ type: "unknown:event" } as unknown as WorkItemEvent);
+      expect(events).toHaveLength(0);
+    } finally {
+      dispose();
+    }
+  });
+
+  test("no onMonitorEvent callback — does not throw", () => {
+    const { server, dispose } = makeServer();
+    try {
+      expect(() => {
+        server.forwardWorkItemEvent({ type: "pr:merged", prNumber: 1 });
+      }).not.toThrow();
+    } finally {
+      dispose();
+    }
+  });
+
+  test("worker null during crash — monitor event still fires", () => {
+    const { server, dispose } = makeServer();
+    try {
+      const events = collect(server);
+      // worker is null because start() was never called
+      server.forwardWorkItemEvent({ type: "pr:opened", prNumber: 5 });
+      expect(events).toHaveLength(1);
+      expect(events[0].event).toBe("pr.opened");
+    } finally {
+      dispose();
+    }
   });
 });

--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -10,7 +10,22 @@
  */
 
 import type { JsonSchema, LiveSpan, Logger, MonitorEventInput, ToolInfo, WorkItemEvent } from "@mcp-cli/core";
-import { CLAUDE_SERVER_NAME, consoleLogger, formatToolSignature, silentLogger, startSpan } from "@mcp-cli/core";
+import {
+  CHECKS_FAILED,
+  CHECKS_PASSED,
+  CHECKS_STARTED,
+  CLAUDE_SERVER_NAME,
+  PHASE_CHANGED,
+  PR_CLOSED,
+  PR_MERGED,
+  PR_OPENED,
+  REVIEW_APPROVED,
+  REVIEW_CHANGES_REQUESTED,
+  consoleLogger,
+  formatToolSignature,
+  silentLogger,
+  startSpan,
+} from "@mcp-cli/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { CLAUDE_TOOLS } from "./claude-session/tools";
 import { closeClientWithTimeout } from "./close-timeout";
@@ -429,8 +444,42 @@ export class ClaudeServer {
     this.crashTimestamps.length = 0;
   }
 
-  /** Forward a work item event from the poller to the session worker. */
+  private static readonly WORK_ITEM_EVENT_MAP: Record<string, string> = {
+    "pr:opened": PR_OPENED,
+    "pr:merged": PR_MERGED,
+    "pr:closed": PR_CLOSED,
+    "checks:started": CHECKS_STARTED,
+    "checks:passed": CHECKS_PASSED,
+    "checks:failed": CHECKS_FAILED,
+    "review:approved": REVIEW_APPROVED,
+    "review:changes_requested": REVIEW_CHANGES_REQUESTED,
+    "phase:changed": PHASE_CHANGED,
+  };
+
+  /**
+   * Forward a work item event from the poller.
+   *
+   * Publishes the monitor event directly on the main thread (no worker round-trip),
+   * then forwards to the worker so active sessions can resolve work-item waiters.
+   * Direct publish prevents silent drops when the worker is null during crash/restart.
+   */
   forwardWorkItemEvent(event: WorkItemEvent): void {
+    const mapped = ClaudeServer.WORK_ITEM_EVENT_MAP[event.type];
+    if (mapped && this.onMonitorEvent) {
+      const input: MonitorEventInput = {
+        src: "daemon.work-item-poller",
+        event: mapped,
+        category: "work_item",
+      };
+      if ("prNumber" in event) input.prNumber = event.prNumber;
+      if ("failedJob" in event) input.failedJob = event.failedJob;
+      if ("reviewer" in event) input.reviewer = event.reviewer;
+      if ("itemId" in event) input.workItemId = event.itemId;
+      if ("from" in event) input.from = event.from;
+      if ("to" in event) input.to = event.to;
+      if ("runId" in event) input.runId = event.runId;
+      this.onMonitorEvent(input);
+    }
     this.worker?.postMessage({ type: "work_item_event", event });
   }
 

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, mock, test } from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import type { MonitorEventInput, WorkItemEvent } from "@mcp-cli/core";
+import type { MonitorEventInput } from "@mcp-cli/core";
 import { silentLogger } from "@mcp-cli/core";
 import { serialize } from "./ndjson";
 import type { SessionEvent } from "./session-state";
@@ -3728,12 +3728,11 @@ describe("restoreSessions", () => {
   });
 });
 
-// ── publishSessionMonitorEvent / publishWorkItemMonitorEvent mapping (#1567) ──
+// ── publishSessionMonitorEvent mapping (#1567) ──
 
 describe("monitor event mapping", () => {
   type WsServerPrivate = {
     publishSessionMonitorEvent: (sessionId: string, event: SessionEvent) => void;
-    publishWorkItemMonitorEvent: (event: WorkItemEvent) => void;
   };
 
   function makeServer(): ClaudeWsServer {
@@ -3960,141 +3959,6 @@ describe("monitor event mapping", () => {
       expect(events[0].category).toBe("session");
       expect(events[0].strikes).toBe(0);
       expect(events[0].reason).toBe("operator reset");
-    });
-  });
-
-  describe("publishWorkItemMonitorEvent", () => {
-    test("pr:opened maps to pr.opened with prNumber", () => {
-      const server = makeServer();
-      const events = collect(server);
-
-      priv(server).publishWorkItemMonitorEvent({ type: "pr:opened", prNumber: 42 });
-
-      expect(events).toHaveLength(1);
-      expect(events[0].src).toBe("daemon.work-item-poller");
-      expect(events[0].event).toBe("pr.opened");
-      expect(events[0].category).toBe("work_item");
-      expect(events[0].prNumber).toBe(42);
-    });
-
-    test("checks:failed maps to checks.failed with failedJob", () => {
-      const server = makeServer();
-      const events = collect(server);
-
-      priv(server).publishWorkItemMonitorEvent({ type: "checks:failed", prNumber: 7, failedJob: "typecheck" });
-
-      expect(events[0].event).toBe("checks.failed");
-      expect(events[0].prNumber).toBe(7);
-      expect(events[0].failedJob).toBe("typecheck");
-    });
-
-    test("review:changes_requested maps with reviewer", () => {
-      const server = makeServer();
-      const events = collect(server);
-
-      priv(server).publishWorkItemMonitorEvent({ type: "review:changes_requested", prNumber: 99, reviewer: "alice" });
-
-      expect(events[0].event).toBe("review.changes_requested");
-      expect(events[0].reviewer).toBe("alice");
-    });
-
-    test("phase:changed maps itemId to workItemId with from/to", () => {
-      const server = makeServer();
-      const events = collect(server);
-
-      priv(server).publishWorkItemMonitorEvent({ type: "phase:changed", itemId: "wi-123", from: "impl", to: "review" });
-
-      expect(events[0].event).toBe("phase.changed");
-      expect(events[0].workItemId).toBe("wi-123");
-      expect(events[0].from).toBe("impl");
-      expect(events[0].to).toBe("review");
-    });
-
-    test("unmapped work-item event type is silently dropped", () => {
-      const server = makeServer();
-      const events = collect(server);
-
-      priv(server).publishWorkItemMonitorEvent({ type: "unknown:event" } as never);
-
-      expect(events).toHaveLength(0);
-    });
-
-    test("null onMonitorEvent callback causes silent drop", () => {
-      const server = makeServer();
-      server.onMonitorEvent = null;
-
-      expect(() => {
-        priv(server).publishWorkItemMonitorEvent({ type: "pr:merged", prNumber: 1 });
-      }).not.toThrow();
-    });
-
-    test("pr:merged maps to pr.merged with prNumber", () => {
-      const server = makeServer();
-      const events = collect(server);
-
-      priv(server).publishWorkItemMonitorEvent({ type: "pr:merged", prNumber: 55 });
-
-      expect(events).toHaveLength(1);
-      expect(events[0].event).toBe("pr.merged");
-      expect(events[0].category).toBe("work_item");
-      expect(events[0].prNumber).toBe(55);
-    });
-
-    test("pr:closed maps to pr.closed with prNumber", () => {
-      const server = makeServer();
-      const events = collect(server);
-
-      priv(server).publishWorkItemMonitorEvent({ type: "pr:closed", prNumber: 77 });
-
-      expect(events).toHaveLength(1);
-      expect(events[0].event).toBe("pr.closed");
-      expect(events[0].prNumber).toBe(77);
-    });
-
-    test("checks:started maps to checks.started with prNumber and runId", () => {
-      const server = makeServer();
-      const events = collect(server);
-
-      priv(server).publishWorkItemMonitorEvent({ type: "checks:started", prNumber: 12, runId: 9876 });
-
-      expect(events).toHaveLength(1);
-      expect(events[0].event).toBe("checks.started");
-      expect(events[0].prNumber).toBe(12);
-      expect(events[0].runId).toBe(9876);
-    });
-
-    test("checks:started without runId emits no runId field", () => {
-      const server = makeServer();
-      const events = collect(server);
-
-      priv(server).publishWorkItemMonitorEvent({ type: "checks:started", prNumber: 13 });
-
-      expect(events).toHaveLength(1);
-      expect(events[0].event).toBe("checks.started");
-      expect(events[0].prNumber).toBe(13);
-      expect(events[0].runId).toBeUndefined();
-    });
-
-    test("checks:passed maps to checks.passed with prNumber", () => {
-      const server = makeServer();
-      const events = collect(server);
-
-      priv(server).publishWorkItemMonitorEvent({ type: "checks:passed", prNumber: 33 });
-
-      expect(events).toHaveLength(1);
-      expect(events[0].event).toBe("checks.passed");
-      expect(events[0].prNumber).toBe(33);
-    });
-
-    test("review:approved maps to review.approved with prNumber", () => {
-      const server = makeServer();
-      const events = collect(server);
-
-      priv(server).publishWorkItemMonitorEvent({ type: "review:approved", prNumber: 44 });
-
-      expect(events).toHaveLength(1);
-      expect(events[0].event).toBe("review.approved");
-      expect(events[0].prNumber).toBe(44);
     });
   });
 });

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -21,15 +21,6 @@ import type {
   WorkItemEvent,
 } from "@mcp-cli/core";
 import {
-  CHECKS_FAILED,
-  CHECKS_PASSED,
-  CHECKS_STARTED,
-  PHASE_CHANGED,
-  PR_CLOSED,
-  PR_MERGED,
-  PR_OPENED,
-  REVIEW_APPROVED,
-  REVIEW_CHANGES_REQUESTED,
   SESSION_CLEARED,
   SESSION_CONTAINMENT_DENIED,
   SESSION_CONTAINMENT_ESCALATED,
@@ -1285,8 +1276,6 @@ export class ClaudeWsServer {
     // Buffer the event so waiters registered after dispatch can still see it
     this.workItemBuffer.push({ event: waitEvent, ts: Date.now() });
     this.trimWorkItemBuffer();
-
-    this.publishWorkItemMonitorEvent(event);
   }
 
   /** Find and consume a buffered work item event matching the given filters. */
@@ -1680,40 +1669,6 @@ export class ClaudeWsServer {
     if ("model" in event) input.model = (event as { model: string }).model;
     if ("strikes" in event) input.strikes = event.strikes;
     if ("reason" in event) input.reason = event.reason;
-
-    this.onMonitorEvent(input);
-  }
-
-  private static readonly WORK_ITEM_EVENT_MAP: Record<string, string> = {
-    "pr:opened": PR_OPENED,
-    "pr:merged": PR_MERGED,
-    "pr:closed": PR_CLOSED,
-    "checks:started": CHECKS_STARTED,
-    "checks:passed": CHECKS_PASSED,
-    "checks:failed": CHECKS_FAILED,
-    "review:approved": REVIEW_APPROVED,
-    "review:changes_requested": REVIEW_CHANGES_REQUESTED,
-    "phase:changed": PHASE_CHANGED,
-  };
-
-  private publishWorkItemMonitorEvent(event: WorkItemEvent): void {
-    if (!this.onMonitorEvent) return;
-    const mapped = ClaudeWsServer.WORK_ITEM_EVENT_MAP[event.type];
-    if (!mapped) return;
-
-    const input: MonitorEventInput = {
-      src: "daemon.work-item-poller",
-      event: mapped,
-      category: "work_item",
-    };
-
-    if ("prNumber" in event) input.prNumber = event.prNumber;
-    if ("failedJob" in event) input.failedJob = event.failedJob;
-    if ("reviewer" in event) input.reviewer = event.reviewer;
-    if ("itemId" in event) input.workItemId = event.itemId;
-    if ("from" in event) input.from = event.from;
-    if ("to" in event) input.to = event.to;
-    if ("runId" in event) input.runId = event.runId;
 
     this.onMonitorEvent(input);
   }


### PR DESCRIPTION
## Summary
- Moves `WORK_ITEM_EVENT_MAP` and work-item→monitor translation from `ClaudeWsServer` (worker thread) to `ClaudeServer` (main thread)
- `forwardWorkItemEvent` now publishes the monitor event directly via `onMonitorEvent` on the main thread before forwarding to the worker for session waiter dispatch — eliminating 2× `structuredClone` round-trips
- Fixes silent event loss during worker crash/restart: the previous `this.worker?.postMessage(...)` optional chain silently dropped events when the worker was null; direct publish always fires

## Test plan
- [x] Removed `publishWorkItemMonitorEvent` describe block from `ws-server.spec.ts` (method deleted from `ClaudeWsServer`)
- [x] Added 12 new unit tests in `claude-server.spec.ts` covering all 9 work-item event types, unmapped type drop, null callback safety, and worker-null case
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun test` — 5585 pass, 0 fail (233 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)