### PR TITLE
feat(spawn): write null→initial transition when --work-item given (fixes #1623)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -1,8 +1,8 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS } from "@mcp-cli/core";
+import { DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS, isCommitted, readTransitionHistory } from "@mcp-cli/core";
 import { WORKTREE_CONFIG_FILENAME } from "@mcp-cli/core/worktree-config";
 import { _resetJqStateForTesting } from "../jq/index";
 import { ExitError } from "../test-helpers";
@@ -246,6 +246,27 @@ describe("parseSpawnArgs", () => {
   test("errors on missing --name value", () => {
     const result = parseSpawnArgs(["--name"]);
     expect(result.error).toBe("--name requires a value");
+  });
+
+  test("parses --work-item flag", () => {
+    const result = parseSpawnArgs(["--work-item", "#1570", "--task", "x"]);
+    expect(result.workItemId).toBe("#1570");
+    expect(result.error).toBeUndefined();
+  });
+
+  test("parses --work-item= equals form", () => {
+    const result = parseSpawnArgs(["--work-item=#1570", "--task", "x"]);
+    expect(result.workItemId).toBe("#1570");
+  });
+
+  test("errors on missing --work-item value", () => {
+    const result = parseSpawnArgs(["--work-item"]);
+    expect(result.error).toBe("--work-item requires an id");
+  });
+
+  test("workItemId defaults to undefined", () => {
+    const result = parseSpawnArgs(["--task", "x"]);
+    expect(result.workItemId).toBeUndefined();
   });
 });
 
@@ -734,6 +755,89 @@ describe("mcx claude spawn", () => {
     await expect(cmdClaude(["spawn", "--task", "fix"], deps)).rejects.toThrow(ExitError);
     expect(callTool).not.toHaveBeenCalled();
     expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("different build"));
+  });
+
+  test("writes null→initial transition when --work-item provided (#1623)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "spawn-transition-"));
+    try {
+      // Minimal manifest so loadManifest can find the initial phase
+      writeFileSync(
+        join(dir, ".mcx.yaml"),
+        "version: 1\nrunsOn: main\ninitial: impl\nphases:\n  impl:\n    source: ./impl.ts\n    next: []\n",
+      );
+
+      const callTool = mock(async () => toolResult({ sessionId: "s1" }));
+      const origLog = console.log;
+      console.log = mock(() => {});
+      try {
+        await cmdClaude(
+          ["spawn", "--task", "implement 1570", "--work-item", "#1570"],
+          makeDeps({ callTool, getGitRoot: mock(() => dir) }),
+        );
+      } finally {
+        console.log = origLog;
+      }
+
+      const logPath = join(dir, ".mcx", "transitions.jsonl");
+      const committed = readTransitionHistory(logPath, "#1570").filter(isCommitted);
+      expect(committed).toHaveLength(1);
+      expect(committed[0].from).toBeNull();
+      expect(committed[0].to).toBe("impl");
+      expect(committed[0].workItemId).toBe("#1570");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("transition write is idempotent — second spawn does not corrupt log (#1623)", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "spawn-transition-idem-"));
+    try {
+      writeFileSync(
+        join(dir, ".mcx.yaml"),
+        "version: 1\nrunsOn: main\ninitial: impl\nphases:\n  impl:\n    source: ./impl.ts\n    next: []\n",
+      );
+      mkdirSync(join(dir, ".mcx"), { recursive: true });
+
+      const callTool = mock(async () => toolResult({ sessionId: "s2" }));
+      const deps = makeDeps({ callTool, getGitRoot: mock(() => dir) });
+      const origLog = console.log;
+      console.log = mock(() => {});
+      try {
+        // First spawn
+        await cmdClaude(["spawn", "--task", "x", "--work-item", "#1570"], deps);
+        // Second spawn — must not throw or double-write a non-idempotent entry
+        await cmdClaude(["spawn", "--task", "x", "--work-item", "#1570"], deps);
+      } finally {
+        console.log = origLog;
+      }
+
+      const logPath = join(dir, ".mcx", "transitions.jsonl");
+      const committed = readTransitionHistory(logPath, "#1570").filter(isCommitted);
+      // Two committed entries: null→impl then impl→impl (idempotent self-loop)
+      expect(committed.length).toBeGreaterThanOrEqual(1);
+      // The first entry is always null→impl
+      expect(committed[0].from).toBeNull();
+      expect(committed[0].to).toBe("impl");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("spawn succeeds even when no .mcx.yaml exists (#1623)", async () => {
+    const callTool = mock(async () => toolResult({ sessionId: "s3" }));
+    const deps = makeDeps({
+      callTool,
+      getGitRoot: mock(() => "/nonexistent/repo/root"),
+    });
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      // Should not throw — missing manifest is silently ignored
+      await cmdClaude(["spawn", "--task", "x", "--work-item", "#1570"], deps);
+      expect(callTool).toHaveBeenCalledTimes(1);
+    } finally {
+      console.log = origLog;
+    }
   });
 });
 

--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -268,6 +268,12 @@ describe("parseSpawnArgs", () => {
     const result = parseSpawnArgs(["--task", "x"]);
     expect(result.workItemId).toBeUndefined();
   });
+
+  test("errors and does not consume next flag when --work-item value looks like a flag", () => {
+    const result = parseSpawnArgs(["--work-item", "--task", "x"]);
+    expect(result.error).toBe("--work-item requires an id");
+    expect(result.workItemId).toBeUndefined();
+  });
 });
 
 // ── resolveModelName ──

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -5,7 +5,7 @@
  * No dedicated IPC methods — the same tools work from any MCP client.
  */
 
-import { dirname, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import {
   CLAUDE_SERVER_NAME,
   DEFAULT_TIMEOUT_MS,
@@ -13,10 +13,12 @@ import {
   PROMPT_IPC_TIMEOUT_MS,
   WorktreeError,
   cleanupWorktree,
+  commitTransition,
   createWorktree,
   detectScope,
   getDefaultBranch,
   listMcxWorktrees,
+  loadManifest,
   parseWorktreeList,
   readWorktreeConfig,
   resolveModelName,
@@ -289,6 +291,8 @@ export interface SpawnArgs extends SharedSpawnArgs {
   headed: boolean;
   /** Human-readable session name. Auto-generated if omitted. */
   name: string | undefined;
+  /** Work item ID for transition log bookkeeping. When set, spawn writes a null→initial entry. */
+  workItemId: string | undefined;
 }
 
 export function parseSpawnArgs(args: string[]): SpawnArgs {
@@ -296,6 +300,7 @@ export function parseSpawnArgs(args: string[]): SpawnArgs {
   let resume: string | undefined;
   let headed = false;
   let name: string | undefined;
+  let workItemId: string | undefined;
   let extraError: string | undefined;
 
   const shared = parseSharedSpawnArgs(args, (arg, allArgs, i) => {
@@ -323,11 +328,21 @@ export function parseSpawnArgs(args: string[]): SpawnArgs {
       if (!name) extraError = "--name requires a value";
       return 1;
     }
+    if (arg === "--work-item") {
+      workItemId = allArgs[i + 1];
+      if (!workItemId) extraError = "--work-item requires an id";
+      return 1;
+    }
+    if (arg.startsWith("--work-item=")) {
+      workItemId = arg.slice("--work-item=".length);
+      if (!workItemId) extraError = "--work-item requires an id";
+      return 0;
+    }
     return undefined;
   });
 
   // shared.error wins: it reflects a bad shared flag; extraError covers provider-specific failures
-  return { ...shared, error: shared.error ?? extraError, worktree, resume, headed, name };
+  return { ...shared, error: shared.error ?? extraError, worktree, resume, headed, name, workItemId };
 }
 
 /**
@@ -354,6 +369,30 @@ export function buildHeadedCommand(parsed: SpawnArgs): string {
 function shellQuote(s: string): string {
   if (/^[a-zA-Z0-9._:/@=-]+$/.test(s)) return s;
   return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Write a null → manifest.initial transition entry for the given work item.
+ * Called after a successful spawn so downstream phases can infer "from" from
+ * the log rather than relying on the Tier-3 work_items.phase fallback (#1623).
+ *
+ * Best-effort: silently swallows all errors so a missing/mismatched manifest
+ * or a race with a concurrent spawn never blocks the spawn itself.
+ */
+function tryWriteInitialTransition(workItemId: string, gitRoot: string): void {
+  try {
+    const loaded = loadManifest(gitRoot);
+    if (!loaded) return;
+    commitTransition(join(gitRoot, ".mcx", "transitions.jsonl"), {
+      manifest: loaded.manifest,
+      from: null,
+      target: loaded.manifest.initial,
+      workItemId,
+      manifestPath: loaded.path,
+    });
+  } catch {
+    // Non-fatal: spawn succeeded; the transition entry is best-effort.
+  }
 }
 
 async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
@@ -433,6 +472,12 @@ async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
     d.printError(String(e));
     d.exit(1);
   }
+
+  // Write null → initial transition so downstream phases can infer "from"
+  // from the log rather than the Tier-3 work_items.phase fallback (#1623).
+  if (parsed.workItemId) {
+    tryWriteInitialTransition(parsed.workItemId, d.getGitRoot() ?? process.cwd());
+  }
 }
 
 async function claudeSpawnHeaded(parsed: SpawnArgs, d: ClaudeDeps): Promise<void> {
@@ -462,6 +507,11 @@ async function claudeSpawnHeaded(parsed: SpawnArgs, d: ClaudeDeps): Promise<void
   const command = cwd ? `cd ${shellQuote(cwd)} && ${buildHeadedCommand(parsed)}` : buildHeadedCommand(parsed);
 
   await d.ttyOpen([command]);
+
+  // Write null → initial transition after the terminal opens (#1623).
+  if (parsed.workItemId) {
+    tryWriteInitialTransition(parsed.workItemId, d.getGitRoot() ?? process.cwd());
+  }
 }
 
 // ── Resume ──
@@ -1841,6 +1891,7 @@ Options:
   --cwd <path>               Working directory for the session
   --wait                     Block until Claude produces a result
   --timeout <ms>             Max wait time in ms (default: 270000, only with --wait)
+  --work-item <id>           Work item ID (#N); writes null→initial transition on spawn
 
 Examples:
   mcx claude spawn --task "run the test suite and fix failures"

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -329,9 +329,13 @@ export function parseSpawnArgs(args: string[]): SpawnArgs {
       return 1;
     }
     if (arg === "--work-item") {
-      workItemId = allArgs[i + 1];
-      if (!workItemId) extraError = "--work-item requires an id";
-      return 1;
+      const next = allArgs[i + 1];
+      if (next && !next.startsWith("-")) {
+        workItemId = next;
+        return 1;
+      }
+      extraError = "--work-item requires an id";
+      return 0;
     }
     if (arg.startsWith("--work-item=")) {
       workItemId = arg.slice("--work-item=".length);


### PR DESCRIPTION
## Summary

- Adds `--work-item <id>` flag to `mcx claude spawn` (and headed spawn). After a successful spawn, a `null → manifest.initial` committed transition entry is written to `.mcx/transitions.jsonl` for the given work item.
- This fixes the root cause of #1623: when orchestrators use `mcx claude spawn` directly (bypassing `mcx phase run impl`), the transition log was empty, causing downstream `mcx phase run triage --work-item '#N'` to fail with `(initial) → triage is not an approved transition`.
- The write is best-effort — a missing `.mcx.yaml`, a manifest/graph mismatch, or any error is silently swallowed so the spawn itself is never blocked. The existing Tier-3 `work_items.phase` fallback (#1522) remains as a second-chance safety net.

## Test plan

- [x] `parseSpawnArgs` unit tests: `--work-item #N`, `--work-item=#N`, missing-value error, default-undefined
- [x] Integration test: spawn with `--work-item` writes `null → impl` committed entry to `transitions.jsonl`
- [x] Idempotency test: second spawn with same work item doesn't corrupt the log
- [x] Resilience test: spawn succeeds even when no `.mcx.yaml` exists (write silently skipped)
- [x] `bun typecheck` — no errors
- [x] `bun lint` — no issues
- [x] `bun test` — 5592 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)