### PR TITLE
feat(monitor): ci.started/running/finished with per-check conclusions and allGreen (fixes #1577)

### DIFF
--- a/packages/core/src/monitor-event.ts
+++ b/packages/core/src/monitor-event.ts
@@ -235,7 +235,8 @@ const FORMATTERS: Partial<Record<string, Formatter>> = {
 
   [CI_FINISHED]: (e) => {
     const green = e.allGreen === true ? "✓ all green" : "✗ failed";
-    const dur = typeof e.durationMs === "number" ? `${Math.round((e.durationMs as number) / 1000)}s` : "";
+    const dur =
+      typeof e.observedDurationMs === "number" ? `${Math.round((e.observedDurationMs as number) / 1000)}s` : "";
     return join(wi(e), pr(e), green, dur);
   },
 

--- a/packages/core/src/monitor-event.ts
+++ b/packages/core/src/monitor-event.ts
@@ -11,7 +11,7 @@
 
 // ── Event categories ──
 
-export type MonitorCategory = "session" | "work_item" | "mail" | "heartbeat";
+export type MonitorCategory = "session" | "work_item" | "ci" | "mail" | "heartbeat";
 
 // ── Session event names ──
 
@@ -42,6 +42,12 @@ export const CHECKS_FAILED = "checks.failed" as const;
 export const REVIEW_APPROVED = "review.approved" as const;
 export const REVIEW_CHANGES_REQUESTED = "review.changes_requested" as const;
 export const PHASE_CHANGED = "phase.changed" as const;
+
+// ── CI run event names (#1577) ──
+
+export const CI_STARTED = "ci.started" as const;
+export const CI_RUNNING = "ci.running" as const;
+export const CI_FINISHED = "ci.finished" as const;
 
 // ── Mail event names ──
 
@@ -215,6 +221,22 @@ const FORMATTERS: Partial<Record<string, Formatter>> = {
     const from = typeof e.from === "string" ? e.from : "";
     const to = typeof e.to === "string" ? e.to : "";
     return join(wi(e), from && to ? `${from} → ${to}` : from || to);
+  },
+
+  [CI_STARTED]: (e) => {
+    const checks = Array.isArray(e.checks) ? (e.checks as string[]).join(", ") : "";
+    return join(wi(e), pr(e), checks);
+  },
+
+  [CI_RUNNING]: (e) => {
+    const inProgress = Array.isArray(e.inProgress) ? (e.inProgress as string[]).join(", ") : "";
+    return join(wi(e), pr(e), inProgress && `running: ${inProgress}`);
+  },
+
+  [CI_FINISHED]: (e) => {
+    const green = e.allGreen === true ? "✓ all green" : "✗ failed";
+    const dur = typeof e.durationMs === "number" ? `${Math.round((e.durationMs as number) / 1000)}s` : "";
+    return join(wi(e), pr(e), green, dur);
   },
 
   [MAIL_RECEIVED]: (e) => {

--- a/packages/daemon/src/github/ci-events.spec.ts
+++ b/packages/daemon/src/github/ci-events.spec.ts
@@ -1,0 +1,210 @@
+import { describe, expect, test } from "bun:test";
+import { type CiEvent, type CiRunState, computeCiTransitions, isGreenConclusion } from "./ci-events";
+import type { CiCheck } from "./graphql-client";
+
+const SUITE_ID = 1000;
+const PR = 42;
+const WI = "#100";
+const T0 = 1_000_000;
+
+function check(name: string, status: string, conclusion: string | null, suiteId = SUITE_ID): CiCheck {
+  return { name, status, conclusion, checkSuiteId: suiteId };
+}
+
+describe("computeCiTransitions", () => {
+  test("emits ci.started + ci.running on first poll with in-progress checks", () => {
+    const checks = [
+      check("check", "IN_PROGRESS", null),
+      check("coverage", "QUEUED", null),
+      check("build", "QUEUED", null),
+    ];
+    const { events, state } = computeCiTransitions(PR, WI, null, checks, T0);
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toEqual({
+      type: "ci.started",
+      prNumber: PR,
+      workItemId: WI,
+      checks: ["check", "coverage", "build"],
+    });
+    expect(events[1]).toEqual({
+      type: "ci.running",
+      prNumber: PR,
+      workItemId: WI,
+      inProgress: ["check", "coverage", "build"],
+      completed: [],
+    });
+    expect(state).not.toBeNull();
+    expect(state?.suiteId).toBe(SUITE_ID);
+    expect(state?.emittedStarted).toBe(true);
+    expect(state?.emittedFinished).toBe(false);
+  });
+
+  test("emits ci.started + ci.finished when all checks are already terminal", () => {
+    const checks = [
+      check("check", "COMPLETED", "SUCCESS"),
+      check("coverage", "COMPLETED", "SUCCESS"),
+      check("build", "COMPLETED", "SUCCESS"),
+    ];
+    const { events, state } = computeCiTransitions(PR, WI, null, checks, T0);
+
+    expect(events).toHaveLength(2);
+    expect(events[0].type).toBe("ci.started");
+    expect(events[1]).toEqual({
+      type: "ci.finished",
+      prNumber: PR,
+      workItemId: WI,
+      checks: [
+        { name: "check", conclusion: "success" },
+        { name: "coverage", conclusion: "success" },
+        { name: "build", conclusion: "success" },
+      ],
+      allGreen: true,
+      durationMs: 0,
+    });
+    expect(state?.emittedFinished).toBe(true);
+  });
+
+  test("transitions from running to finished", () => {
+    // First poll: started + running
+    const runningChecks = [check("check", "IN_PROGRESS", null), check("build", "COMPLETED", "SUCCESS")];
+    const r1 = computeCiTransitions(PR, WI, null, runningChecks, T0);
+
+    // Second poll: all terminal
+    const finishedChecks = [check("check", "COMPLETED", "SUCCESS"), check("build", "COMPLETED", "SUCCESS")];
+    const r2 = computeCiTransitions(PR, WI, r1.state, finishedChecks, T0 + 60_000);
+
+    expect(r2.events).toHaveLength(1);
+    expect(r2.events[0]).toEqual({
+      type: "ci.finished",
+      prNumber: PR,
+      workItemId: WI,
+      checks: [
+        { name: "check", conclusion: "success" },
+        { name: "build", conclusion: "success" },
+      ],
+      allGreen: true,
+      durationMs: 60_000,
+    });
+  });
+
+  test("re-run with new suiteId resets state and emits new ci.started", () => {
+    // First run completes
+    const firstRunChecks = [check("check", "COMPLETED", "SUCCESS", 1000)];
+    const r1 = computeCiTransitions(PR, WI, null, firstRunChecks, T0);
+    expect(r1.state?.emittedFinished).toBe(true);
+
+    // Re-run with new suiteId
+    const reRunChecks = [check("check", "IN_PROGRESS", null, 2000)];
+    const r2 = computeCiTransitions(PR, WI, r1.state, reRunChecks, T0 + 120_000);
+
+    expect(r2.events).toHaveLength(2);
+    expect(r2.events[0].type).toBe("ci.started");
+    expect(r2.events[1].type).toBe("ci.running");
+    expect(r2.state?.suiteId).toBe(2000);
+    expect(r2.state?.startedAt).toBe(T0 + 120_000);
+  });
+
+  test("no duplicate ci.started on same-run re-poll", () => {
+    const checks = [check("check", "IN_PROGRESS", null)];
+    const r1 = computeCiTransitions(PR, WI, null, checks, T0);
+    expect(r1.events.some((e) => e.type === "ci.started")).toBe(true);
+
+    // Same suite, same state — no new ci.started
+    const r2 = computeCiTransitions(PR, WI, r1.state, checks, T0 + 30_000);
+    expect(r2.events.some((e) => e.type === "ci.started")).toBe(false);
+    expect(r2.events).toHaveLength(1);
+    expect(r2.events[0].type).toBe("ci.running");
+  });
+
+  test("no duplicate ci.finished on re-poll after terminal", () => {
+    const checks = [check("check", "COMPLETED", "SUCCESS")];
+    const r1 = computeCiTransitions(PR, WI, null, checks, T0);
+    expect(r1.state?.emittedFinished).toBe(true);
+
+    const r2 = computeCiTransitions(PR, WI, r1.state, checks, T0 + 30_000);
+    expect(r2.events).toHaveLength(0);
+  });
+
+  test("allGreen false when any check fails", () => {
+    const checks = [check("check", "COMPLETED", "SUCCESS"), check("build", "COMPLETED", "FAILURE")];
+    const { events } = computeCiTransitions(PR, WI, null, checks, T0);
+
+    const finished = events.find((e) => e.type === "ci.finished");
+    expect(finished).toBeDefined();
+    expect((finished as Extract<CiEvent, { type: "ci.finished" }>).allGreen).toBe(false);
+  });
+
+  test("allGreen false when a check is cancelled", () => {
+    const checks = [check("check", "COMPLETED", "SUCCESS"), check("build", "COMPLETED", "CANCELLED")];
+    const { events } = computeCiTransitions(PR, WI, null, checks, T0);
+
+    const finished = events.find((e) => e.type === "ci.finished");
+    expect((finished as Extract<CiEvent, { type: "ci.finished" }>).allGreen).toBe(false);
+  });
+
+  test("allGreen true when checks are success or skipped", () => {
+    const checks = [check("check", "COMPLETED", "SUCCESS"), check("optional", "SKIPPED", "SKIPPED")];
+    const { events } = computeCiTransitions(PR, WI, null, checks, T0);
+
+    const finished = events.find((e) => e.type === "ci.finished");
+    expect((finished as Extract<CiEvent, { type: "ci.finished" }>).allGreen).toBe(true);
+  });
+
+  test("returns empty events when no checks provided", () => {
+    const { events, state } = computeCiTransitions(PR, WI, null, [], T0);
+    expect(events).toHaveLength(0);
+    expect(state).toBeNull();
+  });
+
+  test("returns empty events when no check has suiteId", () => {
+    const checks = [{ name: "check", status: "IN_PROGRESS", conclusion: null, checkSuiteId: null }];
+    const { events, state } = computeCiTransitions(PR, WI, null, checks, T0);
+    expect(events).toHaveLength(0);
+    expect(state).toBeNull();
+  });
+
+  test("running event separates in-progress from completed checks", () => {
+    const checks = [
+      check("check", "IN_PROGRESS", null),
+      check("coverage", "COMPLETED", "SUCCESS"),
+      check("build", "QUEUED", null),
+    ];
+    const r1 = computeCiTransitions(PR, WI, null, checks, T0);
+
+    const running = r1.events.find((e) => e.type === "ci.running");
+    expect(running).toBeDefined();
+    const r = running as Extract<CiEvent, { type: "ci.running" }>;
+    expect(r.inProgress).toEqual(["check", "build"]);
+    expect(r.completed).toEqual(["coverage"]);
+  });
+
+  test("durationMs is computed from startedAt to finished poll", () => {
+    const running = [check("check", "IN_PROGRESS", null)];
+    const r1 = computeCiTransitions(PR, WI, null, running, 10_000);
+
+    const finished = [check("check", "COMPLETED", "SUCCESS")];
+    const r2 = computeCiTransitions(PR, WI, r1.state, finished, 192_000);
+
+    const ev = r2.events.find((e) => e.type === "ci.finished") as Extract<CiEvent, { type: "ci.finished" }>;
+    expect(ev.durationMs).toBe(182_000);
+  });
+
+  test("null conclusion defaults to failure in ci.finished", () => {
+    const checks = [check("check", "COMPLETED", null)];
+    const { events } = computeCiTransitions(PR, WI, null, checks, T0);
+
+    const finished = events.find((e) => e.type === "ci.finished") as Extract<CiEvent, { type: "ci.finished" }>;
+    expect(finished.checks[0].conclusion).toBe("failure");
+    expect(finished.allGreen).toBe(false);
+  });
+});
+
+describe("isGreenConclusion", () => {
+  test("success is green", () => expect(isGreenConclusion("success")).toBe(true));
+  test("skipped is green", () => expect(isGreenConclusion("skipped")).toBe(true));
+  test("neutral is green", () => expect(isGreenConclusion("neutral")).toBe(true));
+  test("failure is not green", () => expect(isGreenConclusion("failure")).toBe(false));
+  test("cancelled is not green", () => expect(isGreenConclusion("cancelled")).toBe(false));
+  test("timed_out is not green", () => expect(isGreenConclusion("timed_out")).toBe(false));
+});

--- a/packages/daemon/src/github/ci-events.spec.ts
+++ b/packages/daemon/src/github/ci-events.spec.ts
@@ -60,7 +60,7 @@ describe("computeCiTransitions", () => {
         { name: "build", conclusion: "success" },
       ],
       allGreen: true,
-      durationMs: 0,
+      observedDurationMs: 0,
     });
     expect(state?.emittedFinished).toBe(true);
   });
@@ -84,7 +84,7 @@ describe("computeCiTransitions", () => {
         { name: "build", conclusion: "success" },
       ],
       allGreen: true,
-      durationMs: 60_000,
+      observedDurationMs: 60_000,
     });
   });
 
@@ -144,7 +144,8 @@ describe("computeCiTransitions", () => {
   });
 
   test("allGreen true when checks are success or skipped", () => {
-    const checks = [check("check", "COMPLETED", "SUCCESS"), check("optional", "SKIPPED", "SKIPPED")];
+    // GitHub returns status=COMPLETED + conclusion=SKIPPED for skipped checks
+    const checks = [check("check", "COMPLETED", "SUCCESS"), check("optional", "COMPLETED", "SKIPPED")];
     const { events } = computeCiTransitions(PR, WI, null, checks, T0);
 
     const finished = events.find((e) => e.type === "ci.finished");
@@ -179,7 +180,7 @@ describe("computeCiTransitions", () => {
     expect(r.completed).toEqual(["coverage"]);
   });
 
-  test("durationMs is computed from startedAt to finished poll", () => {
+  test("observedDurationMs is computed from startedAt to finished poll", () => {
     const running = [check("check", "IN_PROGRESS", null)];
     const r1 = computeCiTransitions(PR, WI, null, running, 10_000);
 
@@ -187,7 +188,28 @@ describe("computeCiTransitions", () => {
     const r2 = computeCiTransitions(PR, WI, r1.state, finished, 192_000);
 
     const ev = r2.events.find((e) => e.type === "ci.finished") as Extract<CiEvent, { type: "ci.finished" }>;
-    expect(ev.durationMs).toBe(182_000);
+    expect(ev.observedDurationMs).toBe(182_000);
+  });
+
+  test("picks highest suiteId from mixed-suite checks (multi-workflow repos)", () => {
+    // Coverage workflow (suiteId 999) + CI workflow (suiteId 1000) mixed in response
+    const checks = [check("coverage", "COMPLETED", "SUCCESS", 999), check("check", "IN_PROGRESS", null, 1000)];
+    const { state } = computeCiTransitions(PR, WI, null, checks, T0);
+    expect(state?.suiteId).toBe(1000); // max, not first
+  });
+
+  test("detects re-run when new suiteId appears mixed with old-suite checks", () => {
+    // First run finishes with suiteId 1000
+    const firstRun = [check("check", "COMPLETED", "SUCCESS", 1000)];
+    const r1 = computeCiTransitions(PR, WI, null, firstRun, T0);
+    expect(r1.state?.emittedFinished).toBe(true);
+
+    // Re-run: CI has new suite 2000, but coverage still reports old suite 999 first
+    const reRunMixed = [check("coverage", "COMPLETED", "SUCCESS", 999), check("check", "IN_PROGRESS", null, 2000)];
+    const r2 = computeCiTransitions(PR, WI, r1.state, reRunMixed, T0 + 60_000);
+
+    expect(r2.state?.suiteId).toBe(2000);
+    expect(r2.events.some((e) => e.type === "ci.started")).toBe(true);
   });
 
   test("null conclusion defaults to failure in ci.finished", () => {

--- a/packages/daemon/src/github/ci-events.spec.ts
+++ b/packages/daemon/src/github/ci-events.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { type CiEvent, type CiRunState, computeCiTransitions, isGreenConclusion } from "./ci-events";
+import { type CiEvent, computeCiTransitions, isGreenConclusion } from "./ci-events";
 import type { CiCheck } from "./graphql-client";
 
 const SUITE_ID = 1000;

--- a/packages/daemon/src/github/ci-events.ts
+++ b/packages/daemon/src/github/ci-events.ts
@@ -16,7 +16,7 @@ export type CiEvent =
       workItemId: string;
       checks: CiCheckConclusion[];
       allGreen: boolean;
-      durationMs: number;
+      observedDurationMs: number;
     };
 
 // ── Per-PR run state ──
@@ -26,15 +26,14 @@ export interface CiRunState {
   startedAt: number;
   emittedStarted: boolean;
   emittedFinished: boolean;
-  lastChecks: Map<string, { status: string; conclusion: string | null }>;
 }
 
 // ── Terminal / green helpers ──
 
-const TERMINAL_STATUSES = new Set(["COMPLETED", "CANCELLED", "TIMED_OUT", "STALE", "SKIPPED"]);
-
+// GitHub CheckRun status enum only produces "COMPLETED" as a terminal state.
+// Conclusions (CANCELLED, TIMED_OUT, STALE, SKIPPED) are separate fields.
 function isTerminal(status: string): boolean {
-  return TERMINAL_STATUSES.has(status);
+  return status === "COMPLETED";
 }
 
 export function isGreenConclusion(conclusion: string): boolean {
@@ -59,13 +58,8 @@ export function computeCiTransitions(
   const events: CiEvent[] = [];
 
   const state: CiRunState = isNewRun
-    ? { suiteId, startedAt: now, emittedStarted: false, emittedFinished: false, lastChecks: new Map() }
-    : { ...prev, lastChecks: new Map(prev.lastChecks) };
-
-  // Update check snapshot
-  for (const c of checks) {
-    state.lastChecks.set(c.name, { status: c.status, conclusion: c.conclusion });
-  }
+    ? { suiteId, startedAt: now, emittedStarted: false, emittedFinished: false }
+    : { ...prev };
 
   const allTerminal = checks.every((c) => isTerminal(c.status));
   const checkNames = checks.map((c) => c.name);
@@ -83,8 +77,8 @@ export function computeCiTransitions(
       conclusion: (c.conclusion ?? "FAILURE").toLowerCase(),
     }));
     const allGreen = conclusions.every((c) => isGreenConclusion(c.conclusion));
-    const durationMs = now - state.startedAt;
-    events.push({ type: "ci.finished", prNumber, workItemId, checks: conclusions, allGreen, durationMs });
+    const observedDurationMs = now - state.startedAt;
+    events.push({ type: "ci.finished", prNumber, workItemId, checks: conclusions, allGreen, observedDurationMs });
     state.emittedFinished = true;
   } else if (!allTerminal && state.emittedStarted && !state.emittedFinished) {
     // ci.running — in between started and finished
@@ -96,9 +90,15 @@ export function computeCiTransitions(
   return { events, state };
 }
 
+// Pick the highest suiteId across all checks. GitHub databaseIds are monotonically
+// increasing, so the max correctly identifies the most-recent workflow run even when
+// checks from multiple suites (multiple workflow files) appear in the same response.
 function resolveSuiteId(checks: readonly CiCheck[]): number | null {
+  let max: number | null = null;
   for (const c of checks) {
-    if (c.checkSuiteId !== null) return c.checkSuiteId;
+    if (c.checkSuiteId !== null && (max === null || c.checkSuiteId > max)) {
+      max = c.checkSuiteId;
+    }
   }
-  return null;
+  return max;
 }

--- a/packages/daemon/src/github/ci-events.ts
+++ b/packages/daemon/src/github/ci-events.ts
@@ -1,0 +1,104 @@
+import type { CiCheck } from "./graphql-client";
+
+// ── Event types ──
+
+export interface CiCheckConclusion {
+  name: string;
+  conclusion: string;
+}
+
+export type CiEvent =
+  | { type: "ci.started"; prNumber: number; workItemId: string; checks: string[] }
+  | { type: "ci.running"; prNumber: number; workItemId: string; inProgress: string[]; completed: string[] }
+  | {
+      type: "ci.finished";
+      prNumber: number;
+      workItemId: string;
+      checks: CiCheckConclusion[];
+      allGreen: boolean;
+      durationMs: number;
+    };
+
+// ── Per-PR run state ──
+
+export interface CiRunState {
+  suiteId: number;
+  startedAt: number;
+  emittedStarted: boolean;
+  emittedFinished: boolean;
+  lastChecks: Map<string, { status: string; conclusion: string | null }>;
+}
+
+// ── Terminal / green helpers ──
+
+const TERMINAL_STATUSES = new Set(["COMPLETED", "CANCELLED", "TIMED_OUT", "STALE", "SKIPPED"]);
+
+function isTerminal(status: string): boolean {
+  return TERMINAL_STATUSES.has(status);
+}
+
+export function isGreenConclusion(conclusion: string): boolean {
+  return conclusion === "success" || conclusion === "skipped" || conclusion === "neutral";
+}
+
+// ── State machine ──
+
+export function computeCiTransitions(
+  prNumber: number,
+  workItemId: string,
+  prev: CiRunState | null,
+  checks: readonly CiCheck[],
+  now: number,
+): { events: CiEvent[]; state: CiRunState | null } {
+  if (checks.length === 0) return { events: [], state: prev };
+
+  const suiteId = resolveSuiteId(checks);
+  if (suiteId === null) return { events: [], state: prev };
+
+  const isNewRun = prev === null || prev.suiteId !== suiteId;
+  const events: CiEvent[] = [];
+
+  const state: CiRunState = isNewRun
+    ? { suiteId, startedAt: now, emittedStarted: false, emittedFinished: false, lastChecks: new Map() }
+    : { ...prev, lastChecks: new Map(prev.lastChecks) };
+
+  // Update check snapshot
+  for (const c of checks) {
+    state.lastChecks.set(c.name, { status: c.status, conclusion: c.conclusion });
+  }
+
+  const allTerminal = checks.every((c) => isTerminal(c.status));
+  const checkNames = checks.map((c) => c.name);
+
+  // ci.started — once per run
+  if (!state.emittedStarted) {
+    events.push({ type: "ci.started", prNumber, workItemId, checks: checkNames });
+    state.emittedStarted = true;
+  }
+
+  if (allTerminal && !state.emittedFinished) {
+    // ci.finished — once per run, when all checks reach terminal
+    const conclusions: CiCheckConclusion[] = checks.map((c) => ({
+      name: c.name,
+      conclusion: (c.conclusion ?? "FAILURE").toLowerCase(),
+    }));
+    const allGreen = conclusions.every((c) => isGreenConclusion(c.conclusion));
+    const durationMs = now - state.startedAt;
+    events.push({ type: "ci.finished", prNumber, workItemId, checks: conclusions, allGreen, durationMs });
+    state.emittedFinished = true;
+  } else if (!allTerminal && state.emittedStarted && !state.emittedFinished) {
+    // ci.running — in between started and finished
+    const inProgress = checks.filter((c) => !isTerminal(c.status)).map((c) => c.name);
+    const completed = checks.filter((c) => isTerminal(c.status)).map((c) => c.name);
+    events.push({ type: "ci.running", prNumber, workItemId, inProgress, completed });
+  }
+
+  return { events, state };
+}
+
+function resolveSuiteId(checks: readonly CiCheck[]): number | null {
+  for (const c of checks) {
+    if (c.checkSuiteId !== null) return c.checkSuiteId;
+  }
+  return null;
+}

--- a/packages/daemon/src/github/graphql-client.ts
+++ b/packages/daemon/src/github/graphql-client.ts
@@ -21,6 +21,7 @@ export interface CiCheck {
   name: string;
   status: string;
   conclusion: string | null;
+  checkSuiteId: number | null;
 }
 
 export interface Review {
@@ -82,6 +83,7 @@ export function buildQuery(prNumbers: readonly number[]): string {
                     name
                     conclusion
                     status
+                    checkSuite { databaseId }
                   }
                 }
               }
@@ -127,6 +129,7 @@ interface RawCheckRun {
   name?: string;
   conclusion?: string | null;
   status?: string;
+  checkSuite?: { databaseId?: number | null } | null;
 }
 
 interface RawReview {
@@ -174,6 +177,7 @@ function parsePR(raw: RawPR): PRStatus {
       name: n.name,
       status: n.status ?? "QUEUED",
       conclusion: n.conclusion ?? null,
+      checkSuiteId: n.checkSuite?.databaseId ?? null,
     }));
 
   const reviews: Review[] = (raw.reviews?.nodes ?? [])

--- a/packages/daemon/src/github/work-item-poller.spec.ts
+++ b/packages/daemon/src/github/work-item-poller.spec.ts
@@ -151,8 +151,8 @@ describe("WorkItemPoller", () => {
           number: 7,
           ciState: "FAILURE",
           ciChecks: [
-            { name: "lint", status: "COMPLETED", conclusion: "SUCCESS" },
-            { name: "test", status: "COMPLETED", conclusion: "FAILURE" },
+            { name: "lint", status: "COMPLETED", conclusion: "SUCCESS", checkSuiteId: 100 },
+            { name: "test", status: "COMPLETED", conclusion: "FAILURE", checkSuiteId: 100 },
           ],
         }),
       ],

--- a/packages/daemon/src/github/work-item-poller.spec.ts
+++ b/packages/daemon/src/github/work-item-poller.spec.ts
@@ -2,7 +2,8 @@ import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { WorkItemEvent } from "@mcp-cli/core";
 import { WorkItemDb } from "../db/work-items";
-import type { PRStatus, RepoInfo } from "./graphql-client";
+import type { CiEvent } from "./ci-events";
+import type { CiCheck, PRStatus, RepoInfo } from "./graphql-client";
 import { WorkItemPoller } from "./work-item-poller";
 
 const SILENT_LOGGER = { info() {}, warn() {}, error() {}, debug() {} };
@@ -680,6 +681,191 @@ describe("WorkItemPoller", () => {
     await poller.poll();
     const pushed = events.find((e) => e.type === "pr:pushed");
     expect(pushed?.type === "pr:pushed" && pushed.filesTruncated).toBe(true);
+  });
+
+  // ── CI run event integration tests ──
+
+  function ciCheck(name: string, status: string, conclusion: string | null, suiteId = 100): CiCheck {
+    return { name, status, conclusion, checkSuiteId: suiteId };
+  }
+
+  test("onCiEvent receives ci.started + ci.running on first poll with in-progress checks", async () => {
+    db.createWorkItem({ id: "#10", prNumber: 10, ciStatus: "none" });
+
+    const ciEvents: CiEvent[] = [];
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => [
+        makePRStatus({
+          number: 10,
+          ciState: "PENDING",
+          ciChecks: [ciCheck("check", "IN_PROGRESS", null), ciCheck("build", "QUEUED", null)],
+        }),
+      ],
+      detectRepo: async () => TEST_REPO,
+      onCiEvent: (e) => ciEvents.push(e),
+    });
+
+    await poller.poll();
+
+    expect(ciEvents).toHaveLength(2);
+    expect(ciEvents[0].type).toBe("ci.started");
+    expect(ciEvents[1].type).toBe("ci.running");
+  });
+
+  test("onCiEvent receives ci.finished when all checks become COMPLETED", async () => {
+    db.createWorkItem({ id: "#11", prNumber: 11, ciStatus: "none" });
+
+    let pollNum = 0;
+    const ciEvents: CiEvent[] = [];
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => {
+        pollNum++;
+        if (pollNum === 1) {
+          return [
+            makePRStatus({
+              number: 11,
+              ciState: "PENDING",
+              ciChecks: [ciCheck("check", "IN_PROGRESS", null)],
+            }),
+          ];
+        }
+        return [
+          makePRStatus({
+            number: 11,
+            ciState: "SUCCESS",
+            ciChecks: [ciCheck("check", "COMPLETED", "SUCCESS")],
+          }),
+        ];
+      },
+      detectRepo: async () => TEST_REPO,
+      onCiEvent: (e) => ciEvents.push(e),
+    });
+
+    await poller.poll();
+    await poller.poll();
+
+    const types = ciEvents.map((e) => e.type);
+    expect(types).toContain("ci.started");
+    expect(types).toContain("ci.finished");
+    const finished = ciEvents.find((e) => e.type === "ci.finished");
+    expect((finished as Extract<CiEvent, { type: "ci.finished" }>).allGreen).toBe(true);
+  });
+
+  test("re-polling finished checks does NOT re-emit ci.started", async () => {
+    db.createWorkItem({ id: "#12", prNumber: 12, ciStatus: "none" });
+
+    const completedChecks = [ciCheck("check", "COMPLETED", "SUCCESS")];
+    const ciEvents: CiEvent[] = [];
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => [makePRStatus({ number: 12, ciState: "SUCCESS", ciChecks: completedChecks })],
+      detectRepo: async () => TEST_REPO,
+      onCiEvent: (e) => ciEvents.push(e),
+    });
+
+    await poller.poll();
+    expect(ciEvents.filter((e) => e.type === "ci.started")).toHaveLength(1);
+    expect(ciEvents.filter((e) => e.type === "ci.finished")).toHaveLength(1);
+
+    ciEvents.length = 0;
+
+    // Second poll — same completed checks, should NOT re-emit
+    await poller.poll();
+    expect(ciEvents).toHaveLength(0);
+
+    // Third poll — still stable
+    await poller.poll();
+    expect(ciEvents).toHaveLength(0);
+  });
+
+  test("new suiteId triggers a new ci.started (re-run detection)", async () => {
+    db.createWorkItem({ id: "#13", prNumber: 13, ciStatus: "none" });
+
+    let pollNum = 0;
+    const ciEvents: CiEvent[] = [];
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => {
+        pollNum++;
+        if (pollNum === 1) {
+          return [
+            makePRStatus({
+              number: 13,
+              ciState: "SUCCESS",
+              ciChecks: [ciCheck("check", "COMPLETED", "SUCCESS", 100)],
+            }),
+          ];
+        }
+        return [
+          makePRStatus({
+            number: 13,
+            ciState: "PENDING",
+            ciChecks: [ciCheck("check", "IN_PROGRESS", null, 200)],
+          }),
+        ];
+      },
+      detectRepo: async () => TEST_REPO,
+      onCiEvent: (e) => ciEvents.push(e),
+    });
+
+    await poller.poll();
+    const firstStarted = ciEvents.filter((e) => e.type === "ci.started");
+    expect(firstStarted).toHaveLength(1);
+
+    ciEvents.length = 0;
+
+    await poller.poll();
+    const secondStarted = ciEvents.filter((e) => e.type === "ci.started");
+    expect(secondStarted).toHaveLength(1);
+  });
+
+  test("CI state cleaned up on PR merge", async () => {
+    db.createWorkItem({ id: "#14", prNumber: 14, prState: "open", ciStatus: "none" });
+
+    let pollNum = 0;
+    const ciEvents: CiEvent[] = [];
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => {
+        pollNum++;
+        if (pollNum === 1) {
+          return [
+            makePRStatus({
+              number: 14,
+              state: "OPEN",
+              ciState: "SUCCESS",
+              ciChecks: [ciCheck("check", "COMPLETED", "SUCCESS")],
+            }),
+          ];
+        }
+        return [
+          makePRStatus({
+            number: 14,
+            state: "MERGED",
+            ciState: "SUCCESS",
+            ciChecks: [ciCheck("check", "COMPLETED", "SUCCESS")],
+          }),
+        ];
+      },
+      detectRepo: async () => TEST_REPO,
+      onCiEvent: (e) => ciEvents.push(e),
+    });
+
+    await poller.poll();
+    expect(ciEvents.filter((e) => e.type === "ci.finished")).toHaveLength(1);
+
+    ciEvents.length = 0;
+
+    // PR merged — CI state should be cleaned up, but no duplicate events
+    await poller.poll();
+    expect(ciEvents).toHaveLength(0);
   });
 });
 

--- a/packages/daemon/src/github/work-item-poller.ts
+++ b/packages/daemon/src/github/work-item-poller.ts
@@ -188,6 +188,12 @@ export class WorkItemPoller {
         this.reconcile(item, status);
       }
 
+      // Prune ciRunStates for PR numbers no longer tracked (e.g., work item untracked via prNumber clear)
+      const trackedPrNums = new Set(prNumbers);
+      for (const pr of this.ciRunStates.keys()) {
+        if (!trackedPrNums.has(pr)) this.ciRunStates.delete(pr);
+      }
+
       this._lastError = null;
       this._pollCount++;
       this.adjustInterval(hasActive);

--- a/packages/daemon/src/github/work-item-poller.ts
+++ b/packages/daemon/src/github/work-item-poller.ts
@@ -13,6 +13,7 @@ import type { Logger, WorkItemEvent } from "@mcp-cli/core";
 import { computeSrcChurn, consoleLogger } from "@mcp-cli/core";
 import type { CiStatus, PrState, ReviewStatus, WorkItem } from "@mcp-cli/core";
 import type { WorkItemDb } from "../db/work-items";
+import { type CiEvent, type CiRunState, computeCiTransitions } from "./ci-events";
 import { type FetchPRsOptions, type PRStatus, type RepoInfo, detectRepo, fetchTrackedPRs } from "./graphql-client";
 
 export { computeSrcChurn };
@@ -31,6 +32,10 @@ export interface WorkItemPollerOptions {
   detectRepo?: (cwd?: string) => Promise<RepoInfo>;
   /** Called on each work item event. */
   onEvent?: (event: WorkItemEvent) => void;
+  /** Called on each CI run event (ci.started / ci.running / ci.finished). */
+  onCiEvent?: (event: CiEvent) => void;
+  /** Injected for testing — override Date.now(). */
+  now?: () => number;
 }
 
 export class WorkItemPoller {
@@ -49,6 +54,9 @@ export class WorkItemPoller {
   private detectRepoFn: NonNullable<WorkItemPollerOptions["detectRepo"]>;
   private onEvent: (event: WorkItemEvent) => void;
   private lastRateLimitWarnMs = 0;
+  private onCiEvent: (event: CiEvent) => void;
+  private nowFn: () => number;
+  private readonly ciRunStates = new Map<number, CiRunState>();
 
   constructor(opts: WorkItemPollerOptions) {
     this.db = opts.db;
@@ -58,6 +66,8 @@ export class WorkItemPoller {
     this.fetchPRs = opts.fetchPRs ?? fetchTrackedPRs;
     this.detectRepoFn = opts.detectRepo ?? detectRepo;
     this.onEvent = opts.onEvent ?? (() => {});
+    this.onCiEvent = opts.onCiEvent ?? (() => {});
+    this.nowFn = opts.now ?? (() => Date.now());
   }
 
   get lastError(): string | null {
@@ -248,6 +258,24 @@ export class WorkItemPoller {
     if (changed) {
       this.db.updateWorkItem(item.id, patch);
       this.logger.info(`[mcpd] Work item ${item.id} (PR #${prNumber}) updated: ${JSON.stringify(patch)}`);
+    }
+
+    // CI run events — separate from the coarse checks:started/passed/failed above
+    if (status.ciChecks.length > 0) {
+      const prev = this.ciRunStates.get(prNumber) ?? null;
+      const { events: ciEvents, state: ciState } = computeCiTransitions(
+        prNumber,
+        item.id,
+        prev,
+        status.ciChecks,
+        this.nowFn(),
+      );
+      if (ciState) {
+        this.ciRunStates.set(prNumber, ciState);
+      }
+      for (const ev of ciEvents) {
+        this.onCiEvent(ev);
+      }
     }
   }
 

--- a/packages/daemon/src/github/work-item-poller.ts
+++ b/packages/daemon/src/github/work-item-poller.ts
@@ -270,7 +270,10 @@ export class WorkItemPoller {
         status.ciChecks,
         this.nowFn(),
       );
-      if (ciState) {
+      if (ciState?.emittedFinished) {
+        // Run is complete — drop state to prevent unbounded map growth
+        this.ciRunStates.delete(prNumber);
+      } else if (ciState) {
         this.ciRunStates.set(prNumber, ciState);
       }
       for (const ev of ciEvents) {

--- a/packages/daemon/src/github/work-item-poller.ts
+++ b/packages/daemon/src/github/work-item-poller.ts
@@ -270,15 +270,17 @@ export class WorkItemPoller {
         status.ciChecks,
         this.nowFn(),
       );
-      if (ciState?.emittedFinished) {
-        // Run is complete — drop state to prevent unbounded map growth
-        this.ciRunStates.delete(prNumber);
-      } else if (ciState) {
+      if (ciState) {
         this.ciRunStates.set(prNumber, ciState);
       }
       for (const ev of ciEvents) {
         this.onCiEvent(ev);
       }
+    }
+
+    // Clean up CI state when PR is no longer active
+    if (newPrState === "merged" || newPrState === "closed") {
+      this.ciRunStates.delete(prNumber);
     }
   }
 

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -70,6 +70,7 @@ import { DerivedEventPublisher } from "./derived-events";
 import { DEFAULT_RULES } from "./derived-rules";
 import { EventBus } from "./event-bus";
 import { EventLog } from "./event-log";
+import type { CiEvent } from "./github/ci-events";
 import { type RepoInfo, detectRepo, resolveNumber } from "./github/graphql-client";
 import { resolveBranchFromPr } from "./github/resolve-branch";
 import { WorkItemPoller } from "./github/work-item-poller";
@@ -846,6 +847,7 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
             db: workItemDb,
             logger,
             onEvent: (event) => claudeServer.forwardWorkItemEvent(event),
+            onCiEvent: (event) => publishCiEvent(mailEventBus, event),
           });
 
           // Wire the alias executor's work-item resolver — resolves the caller
@@ -949,6 +951,33 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
     );
   }
 
+  function publishCiEvent(bus: EventBus, event: CiEvent): void {
+    const base = {
+      src: "daemon.work-item-poller",
+      event: event.type,
+      category: "ci" as const,
+      prNumber: event.prNumber,
+      workItemId: event.workItemId,
+    };
+    const coalesceKey = `ci:${event.prNumber}`;
+
+    if (event.type === "ci.started") {
+      bus.publish({ ...base, checks: event.checks });
+    } else if (event.type === "ci.running") {
+      bus.publishCoalesced({ ...base, inProgress: event.inProgress, completed: event.completed }, coalesceKey, {
+        mode: "last-wins",
+        windowMs: 500,
+      });
+    } else {
+      // ci.finished — flush pending ci.running, then publish immediately
+      bus.publishCoalesced(
+        { ...base, checks: event.checks, allGreen: event.allGreen, durationMs: event.durationMs },
+        coalesceKey,
+        { mode: "never" },
+      );
+    }
+  }
+
   // Graceful shutdown — re-entrant safe
   let _isShuttingDown = false;
   let _resolveShutdown!: () => void;
@@ -968,6 +997,7 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
       quotaPoller.stop();
       workItemPoller?.stop();
       derivedPublisher?.dispose();
+      mailEventBus.disposeCoalescer();
       try {
         watcher.stop();
       } catch (err) {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -971,7 +971,7 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
     } else {
       // ci.finished — flush pending ci.running, then publish immediately
       bus.publishCoalesced(
-        { ...base, checks: event.checks, allGreen: event.allGreen, durationMs: event.durationMs },
+        { ...base, checks: event.checks, allGreen: event.allGreen, observedDurationMs: event.observedDurationMs },
         coalesceKey,
         { mode: "never" },
       );


### PR DESCRIPTION
## Summary

- Emit explicit `ci.started`, `ci.running`, `ci.finished` events per CI run per PR, keyed by CheckSuite `databaseId` to detect re-runs
- `ci.running` coalesced via `CoalescingPublisher` with 500ms `last-wins` window; `ci.finished` flushes pending `ci.running` then publishes immediately (`mode: "never"`)
- `allGreen` is deterministic: `success`/`skipped`/`neutral` = green; everything else (including `cancelled`) = failing
- `observedDurationMs` derived from first poll that detects the run to the poll that sees all checks terminal
- **Repair (f8da4f29):** Fixed infinite duplicate `ci.started`/`ci.finished` on re-poll — retain finished CI state in the map instead of deleting it; clean up only on PR merge/close. Added 5 integration tests for `onCiEvent` in `work-item-poller.spec.ts`.

Rebased onto main (base branch `feat/issue-1574-coalescing-publisher` was already merged). Supersedes #1674.

## Test plan

- [x] 22 unit tests for the CI state machine (`ci-events.spec.ts`)
- [x] 5 integration tests for `onCiEvent` in `work-item-poller.spec.ts`:
  - `ci.started` + `ci.running` on first poll with in-progress checks
  - `ci.finished` fires when all checks become COMPLETED
  - Re-polling finished checks does NOT re-emit `ci.started` (the regression fix)
  - New suiteId triggers a new `ci.started` (re-run detection)
  - CI state cleaned up on PR merge
- [x] Full suite: 5625 pass, 0 fail
- [x] Typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)