### PR TITLE
feat(permissions): support wildcard MCP tool patterns (mcp__server__*) (fixes #1695)

### DIFF
--- a/packages/permissions/CLAUDE.md
+++ b/packages/permissions/CLAUDE.md
@@ -13,17 +13,28 @@ This package extracts the permission matching logic that was previously embedded
 Rules use the `Tool(pattern)` format from Claude Code's settings:
 
 ```
-"Read"                  → exact tool match (all Read calls)
-"Bash(git:*)"           → wildcard: command starts with "git "
-"Bash(bun test)"        → exact: command is literally "bun test"
-"Bash(ls /foo/*)"       → exact: the * is a bash glob, NOT a wildcard
-"Read(src/**/*.ts)"     → file glob: matches TypeScript files in src/
-"mcp__echo__echo"       → MCP tool name (exact match)
+"Read"                       → exact tool match (all Read calls)
+"Bash(git:*)"                → wildcard: command starts with "git "
+"Bash(bun test)"             → exact: command is literally "bun test"
+"Bash(ls /foo/*)"            → exact: the * is a bash glob, NOT a wildcard
+"Read(src/**/*.ts)"          → file glob: matches TypeScript files in src/
+"mcp__echo__echo"            → MCP tool name (exact match)
+"mcp__atlassian__*"          → MCP tool wildcard: all tools from atlassian server
+"mcp__*"                     → MCP tool wildcard: all tools from any MCP server
 ```
 
-### Wildcard Marker
+### Wildcard Markers
 
-**Only `:*` is a wildcard.** Bare `*` is a valid bash character (like `ls /foo/*`) and is treated as literal. The `:*` suffix is Claude Code's native format meaning "this prefix with any arguments".
+**`:*` is the argument wildcard.** Bare `*` in a Bash argument pattern is a valid bash glob character (like `ls /foo/*`) and is treated as literal. The `:*` suffix is Claude Code's native format meaning "this prefix with any arguments".
+
+**`__*` is the tool-name wildcard.** Appending `__*` to an MCP tool prefix matches all tools whose name starts with that prefix. This maps to MCP's `mcp__server__tool` naming convention:
+
+- `mcp__atlassian__*` → allows every tool from the `atlassian` MCP server
+- `mcp__*` → allows every MCP tool from any server
+
+Only the `__*` suffix triggers prefix matching on tool names. A bare `*` at any other position (e.g., `Read*`) is not a wildcard and will only match the literal tool name `"Read*"` (which no real tool is named).
+
+Deny rules with `__*` wildcards work symmetrically — a server-level deny (`mcp__atlassian__*`) combined with a broader allow (`mcp__*`) will block all atlassian tools via the standard first-deny-wins logic.
 
 ### Evaluation Semantics
 

--- a/packages/permissions/src/evaluator.spec.ts
+++ b/packages/permissions/src/evaluator.spec.ts
@@ -395,6 +395,77 @@ describe("evaluate", () => {
     expect(evaluate(rules, req("mcp__echo__fail")).allow).toBe(false);
   });
 
+  // ── MCP tool wildcards (__*) ──
+
+  test("mcp__server__* matches all tools from that server", () => {
+    const rules: PermissionRule[] = [{ tool: "mcp__atlassian__*", action: "allow" }];
+    expect(evaluate(rules, req("mcp__atlassian__search")).allow).toBe(true);
+    expect(evaluate(rules, req("mcp__atlassian__get_issue")).allow).toBe(true);
+    expect(evaluate(rules, req("mcp__atlassian__create_issue")).allow).toBe(true);
+    expect(evaluate(rules, req("mcp__echo__echo")).allow).toBe(false);
+    expect(evaluate(rules, req("Read")).allow).toBe(false);
+  });
+
+  test("mcp__* matches every MCP tool from any server", () => {
+    const rules: PermissionRule[] = [{ tool: "mcp__*", action: "allow" }];
+    expect(evaluate(rules, req("mcp__echo__echo")).allow).toBe(true);
+    expect(evaluate(rules, req("mcp__atlassian__search")).allow).toBe(true);
+    expect(evaluate(rules, req("mcp__claude_ai_Google_Drive__authenticate")).allow).toBe(true);
+    expect(evaluate(rules, req("Read")).allow).toBe(false);
+    expect(evaluate(rules, req("Bash", { command: "echo hi" })).allow).toBe(false);
+  });
+
+  test("deny wildcard overrides specific allow", () => {
+    const rules: PermissionRule[] = [
+      { tool: "mcp__atlassian__*", action: "allow" },
+      { tool: "mcp__atlassian__delete_issue", action: "deny" },
+    ];
+    expect(evaluate(rules, req("mcp__atlassian__search")).allow).toBe(true);
+    expect(evaluate(rules, req("mcp__atlassian__create_issue")).allow).toBe(true);
+    expect(evaluate(rules, req("mcp__atlassian__delete_issue")).allow).toBe(false);
+  });
+
+  test("specific deny overrides broader allow (first deny wins)", () => {
+    const rules: PermissionRule[] = [
+      { tool: "mcp__*", action: "allow" },
+      { tool: "mcp__atlassian__delete_issue", action: "deny" },
+    ];
+    expect(evaluate(rules, req("mcp__atlassian__search")).allow).toBe(true);
+    expect(evaluate(rules, req("mcp__atlassian__delete_issue")).allow).toBe(false);
+    expect(evaluate(rules, req("mcp__echo__echo")).allow).toBe(true);
+  });
+
+  test("server wildcard deny blocks all tools from that server", () => {
+    const rules: PermissionRule[] = [
+      { tool: "mcp__*", action: "allow" },
+      { tool: "mcp__atlassian__*", action: "deny" },
+    ];
+    expect(evaluate(rules, req("mcp__echo__echo")).allow).toBe(true);
+    expect(evaluate(rules, req("mcp__atlassian__search")).allow).toBe(false);
+    expect(evaluate(rules, req("mcp__atlassian__get_issue")).allow).toBe(false);
+  });
+
+  test("mcp__server__* does not match adjacent server prefix", () => {
+    const rules: PermissionRule[] = [{ tool: "mcp__echo__*", action: "allow" }];
+    // "mcp__echoextra__tool" starts with "mcp__echo" but not "mcp__echo__"
+    expect(evaluate(rules, req("mcp__echoextra__tool")).allow).toBe(false);
+    expect(evaluate(rules, req("mcp__echo__echo")).allow).toBe(true);
+  });
+
+  test("server name containing multi-underscore works correctly", () => {
+    const rules: PermissionRule[] = [{ tool: "mcp__claude_ai_Google_Drive__*", action: "allow" }];
+    expect(evaluate(rules, req("mcp__claude_ai_Google_Drive__authenticate")).allow).toBe(true);
+    expect(evaluate(rules, req("mcp__claude_ai_Google_Drive__list_files")).allow).toBe(true);
+    expect(evaluate(rules, req("mcp__echo__echo")).allow).toBe(false);
+  });
+
+  test("bare * in tool name is not a wildcard (literal exact match)", () => {
+    const rules: PermissionRule[] = [{ tool: "Read*", action: "allow" }];
+    // "Read*" is literal — no tool is named "Read*"
+    expect(evaluate(rules, req("Read")).allow).toBe(false);
+    expect(evaluate(rules, req("ReadFile")).allow).toBe(false);
+  });
+
   // ── Read with glob pattern (from real settings) ──
 
   test("Read(//private/tmp/**) matches temp files", () => {

--- a/packages/permissions/src/evaluator.ts
+++ b/packages/permissions/src/evaluator.ts
@@ -10,7 +10,14 @@
 
 import { matchBashCommand } from "./bash-matcher";
 import { matchFilePath } from "./file-matcher";
-import { type PermissionRule, isWildcardPattern, parsePattern, toArgPrefix } from "./rule";
+import {
+  type PermissionRule,
+  isToolWildcard,
+  isWildcardPattern,
+  parsePattern,
+  toArgPrefix,
+  toToolPrefix,
+} from "./rule";
 
 export interface PermissionRequest {
   toolName: string;
@@ -49,7 +56,12 @@ function extractFilePath(input: Record<string, unknown>): string | null {
 function matchesRule(rule: PermissionRule, request: PermissionRequest): boolean {
   const { tool, argPattern } = parsePattern(rule.tool);
 
-  if (tool !== request.toolName) return false;
+  // Tool name matching: exact or tool-wildcard (__*)
+  if (isToolWildcard(tool)) {
+    if (!request.toolName.startsWith(toToolPrefix(tool))) return false;
+  } else {
+    if (tool !== request.toolName) return false;
+  }
   if (argPattern === null) return true;
 
   // For Bash-like tools, match against the command

--- a/packages/permissions/src/index.ts
+++ b/packages/permissions/src/index.ts
@@ -1,4 +1,12 @@
 export { evaluate, type PermissionRequest, type PermissionDecision } from "./evaluator";
-export { parsePattern, toArgPrefix, isWildcardPattern, type PermissionRule, type ParsedPattern } from "./rule";
+export {
+  parsePattern,
+  toArgPrefix,
+  isWildcardPattern,
+  isToolWildcard,
+  toToolPrefix,
+  type PermissionRule,
+  type ParsedPattern,
+} from "./rule";
 export { matchBashCommand, isCompoundCommand } from "./bash-matcher";
 export { matchFilePath } from "./file-matcher";

--- a/packages/permissions/src/rule.ts
+++ b/packages/permissions/src/rule.ts
@@ -39,6 +39,33 @@ export function isWildcardPattern(argPattern: string): boolean {
 }
 
 /**
+ * Check if a tool name is a tool-level wildcard (prefix match on the tool name itself).
+ *
+ * Only `__*` suffix is treated as a tool wildcard, matching MCP tool naming
+ * conventions (mcp__server__tool). A bare `*` in a tool name is never a wildcard.
+ *
+ * Examples:
+ * - "mcp__atlassian__*" → true (matches all atlassian MCP tools)
+ * - "mcp__*"            → true (matches every MCP tool from any server)
+ * - "mcp__echo__echo"   → false (exact tool name)
+ */
+export function isToolWildcard(tool: string): boolean {
+  return tool.endsWith("__*");
+}
+
+/**
+ * Convert a tool wildcard pattern to the prefix for `startsWith` matching.
+ * Only call this when `isToolWildcard()` returns true.
+ *
+ * Examples:
+ * - "mcp__atlassian__*" → "mcp__atlassian__"
+ * - "mcp__*"            → "mcp__"
+ */
+export function toToolPrefix(tool: string): string {
+  return tool.slice(0, -1); // remove trailing *
+}
+
+/**
  * Convert a wildcard argument pattern (ending in `:*`) to a prefix for matching.
  *
  * The `:*` suffix is Claude Code's native format meaning "this command prefix


### PR DESCRIPTION
## Summary

- Adds `__*` suffix as a tool-name wildcard in permission rules so agents can bulk-allow an entire MCP server (e.g., `mcp__atlassian__*`) without enumerating every tool individually
- `mcp__*` matches every MCP tool from any server; `mcp__atlassian__*` matches only that server's tools; exact matches remain unchanged and fast-pathed
- Deny rules with wildcards work symmetrically — first-deny-wins still holds, so `mcp__atlassian__delete_issue` deny can override a `mcp__atlassian__*` allow

## Test plan

- [x] `mcp__server__*` matches all tools from that server — `evaluator.spec.ts`
- [x] `mcp__*` matches every MCP tool from any server — `evaluator.spec.ts`
- [x] Deny wildcard overrides specific allow — `evaluator.spec.ts`
- [x] Specific deny overrides broader wildcard allow — `evaluator.spec.ts`
- [x] Server wildcard deny blocks all tools from that server — `evaluator.spec.ts`
- [x] Adjacent server prefix not falsely matched (`mcp__echo__*` does not match `mcp__echoextra__tool`) — `evaluator.spec.ts`
- [x] Multi-underscore server names work correctly (`mcp__claude_ai_Google_Drive__*`) — `evaluator.spec.ts`
- [x] Bare `*` in a non-`__` position is not a wildcard — `evaluator.spec.ts`
- [x] All 106 permissions package tests pass; full suite 5604 pass, 0 fail
- [x] Coverage thresholds met (100% on all permissions source files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)