### PR TITLE
fix(sites): add browser lifecycle mutex to prevent reset-during-start race (fixes #1597)

### DIFF
--- a/packages/daemon/src/site-worker.ts
+++ b/packages/daemon/src/site-worker.ts
@@ -21,6 +21,7 @@ import { isAbsolute } from "node:path";
 import { SITE_SERVER_NAME } from "@mcp-cli/core";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { createBrowserLock } from "./site/browser-lock";
 import type { BrowserEngine, BrowserEngineName, SiteSpec } from "./site/browser/engine";
 import { removeCall as catalogRemoveCall, upsertCall as catalogUpsertCall, loadCatalog } from "./site/catalog";
 import {
@@ -70,6 +71,11 @@ const sniffer = new Sniffer(vault);
 let browser: BrowserEngine | null = null;
 let browserEngineName: BrowserEngineName | null = null;
 const sitesOpenInBrowser = new Set<string>();
+
+// Serialises all operations that read-modify-write the `browser` module global,
+// preventing a concurrent observer handler from clearing the ref during start-up
+// (when browser is truthy but isRunning() is still false). See #1597.
+const withBrowserLock = createBrowserLock();
 
 // ── Lazy browser load ──
 
@@ -224,7 +230,10 @@ function handleDescribe(args: Record<string, unknown>): ToolResult {
 }
 
 async function handleCall(args: Record<string, unknown>): Promise<ToolResult> {
-  resetIfBrowserDied();
+  const browserSnapshot = await withBrowserLock(async () => {
+    resetIfBrowserDied();
+    return browser;
+  });
   const site = requireSite(args.site as string);
   const callName = args.call as string;
   const catalog = loadCatalog(site.name, site.seed ?? site.name);
@@ -248,7 +257,7 @@ async function handleCall(args: Record<string, unknown>): Promise<ToolResult> {
       site: site.name,
       resolved,
       audHints: call.audHints,
-      onWiggle: browser ? async () => void (await browser?.wiggle(site.name)) : undefined,
+      onWiggle: browserSnapshot ? async () => void (await browserSnapshot.wiggle(site.name)) : undefined,
     });
     result = await applyJqOutput(call, result);
     return ok(result);
@@ -295,42 +304,46 @@ function resetIfBrowserDied(): void {
 }
 
 async function handleBrowserStart(args: Record<string, unknown>): Promise<ToolResult> {
-  resetIfBrowserDied();
-  const siteNames =
-    (args.sites as string[] | undefined) ??
-    listSites()
-      .filter((s) => s.enabled)
-      .map((s) => s.name);
-  const sites = siteNames.map((n) => requireSite(n));
-  if (sites.length === 0) return error("No sites configured");
+  return withBrowserLock(async () => {
+    resetIfBrowserDied();
+    const siteNames =
+      (args.sites as string[] | undefined) ??
+      listSites()
+        .filter((s) => s.enabled)
+        .map((s) => s.name);
+    const sites = siteNames.map((n) => requireSite(n));
+    if (sites.length === 0) return error("No sites configured");
 
-  const engine = (sites[0].browser?.engine ?? "playwright") as BrowserEngineName;
-  // Per-site engine mixing isn't supported in one context. Flag it clearly.
-  for (const s of sites) {
-    if ((s.browser?.engine ?? "playwright") !== engine) {
-      return error(
-        `All sites opened in one browser must use the same engine. Mixed: ${engine} vs ${s.browser?.engine}`,
-      );
+    const engine = (sites[0].browser?.engine ?? "playwright") as BrowserEngineName;
+    // Per-site engine mixing isn't supported in one context. Flag it clearly.
+    for (const s of sites) {
+      if ((s.browser?.engine ?? "playwright") !== engine) {
+        return error(
+          `All sites opened in one browser must use the same engine. Mixed: ${engine} vs ${s.browser?.engine}`,
+        );
+      }
+      sniffer.configureSite(s.name, s.captureMode ?? "firehose", s.captureFilters);
     }
-    sniffer.configureSite(s.name, s.captureMode ?? "firehose", s.captureFilters);
-  }
 
-  const eng = await loadBrowser(engine);
-  const specs = sites.map(siteSpecFor);
-  const startResults = await eng.start(specs, sniffer.asEvents());
-  for (const s of sites) sitesOpenInBrowser.add(s.name);
+    const eng = await loadBrowser(engine);
+    const specs = sites.map(siteSpecFor);
+    const startResults = await eng.start(specs, sniffer.asEvents());
+    for (const s of sites) sitesOpenInBrowser.add(s.name);
 
-  return ok({ ok: true, engine, sites: eng.getSiteNames(), results: startResults });
+    return ok({ ok: true, engine, sites: eng.getSiteNames(), results: startResults });
+  });
 }
 
 async function handleDisconnect(): Promise<ToolResult> {
-  resetIfBrowserDied();
-  if (!browser) return ok({ ok: true, note: "browser was not running" });
-  await browser.stop();
-  browser = null;
-  browserEngineName = null;
-  sitesOpenInBrowser.clear();
-  return ok({ ok: true });
+  return withBrowserLock(async () => {
+    resetIfBrowserDied();
+    if (!browser) return ok({ ok: true, note: "browser was not running" });
+    await browser.stop();
+    browser = null;
+    browserEngineName = null;
+    sitesOpenInBrowser.clear();
+    return ok({ ok: true });
+  });
 }
 
 function handleSniff(args: Record<string, unknown>): ToolResult {
@@ -361,27 +374,36 @@ function handleSniff(args: Record<string, unknown>): ToolResult {
 }
 
 async function handleWiggle(args: Record<string, unknown>): Promise<ToolResult> {
-  resetIfBrowserDied();
-  if (!browser) return error("Browser is not running. Start it with site_browser_start.");
+  const snapshot = await withBrowserLock(async () => {
+    resetIfBrowserDied();
+    return browser;
+  });
+  if (!snapshot) return error("Browser is not running. Start it with site_browser_start.");
   const site = args.site as string | undefined;
-  const touched = await browser.wiggle(site);
+  const touched = await snapshot.wiggle(site);
   return ok({ ok: true, touched });
 }
 
 async function handleEval(args: Record<string, unknown>): Promise<ToolResult> {
-  resetIfBrowserDied();
-  if (!browser) return error("Browser is not running. Start it with site_browser_start.");
+  const snapshot = await withBrowserLock(async () => {
+    resetIfBrowserDied();
+    return browser;
+  });
+  if (!snapshot) return error("Browser is not running. Start it with site_browser_start.");
   const code = args.code as string;
   if (!code) return error("Missing 'code'");
   const site = args.site as string | undefined;
-  return ok({ result: await browser.evalInPage(code, site) });
+  return ok({ result: await snapshot.evalInPage(code, site) });
 }
 
 async function handleColdStart(args: Record<string, unknown>): Promise<ToolResult> {
-  resetIfBrowserDied();
-  if (!browser) return error("Browser is not running. Start it with site_browser_start.");
+  const snapshot = await withBrowserLock(async () => {
+    resetIfBrowserDied();
+    return browser;
+  });
+  if (!snapshot) return error("Browser is not running. Start it with site_browser_start.");
   const site = args.site as string | undefined;
-  return ok(await browser.coldStart(site));
+  return ok(await snapshot.coldStart(site));
 }
 
 async function dispatch(name: string, args: Record<string, unknown>): Promise<ToolResult> {

--- a/packages/daemon/src/site-worker.ts
+++ b/packages/daemon/src/site-worker.ts
@@ -77,6 +77,13 @@ const sitesOpenInBrowser = new Set<string>();
 // (when browser is truthy but isRunning() is still false). See #1597.
 const withBrowserLock = createBrowserLock();
 
+async function snapshotBrowser(): Promise<BrowserEngine | null> {
+  return withBrowserLock(async () => {
+    resetIfBrowserDied();
+    return browser;
+  });
+}
+
 // ── Lazy browser load ──
 
 async function loadBrowser(engine: BrowserEngineName): Promise<BrowserEngine> {
@@ -230,10 +237,7 @@ function handleDescribe(args: Record<string, unknown>): ToolResult {
 }
 
 async function handleCall(args: Record<string, unknown>): Promise<ToolResult> {
-  const browserSnapshot = await withBrowserLock(async () => {
-    resetIfBrowserDied();
-    return browser;
-  });
+  const browserSnapshot = await snapshotBrowser();
   const site = requireSite(args.site as string);
   const callName = args.call as string;
   const catalog = loadCatalog(site.name, site.seed ?? site.name);
@@ -257,7 +261,12 @@ async function handleCall(args: Record<string, unknown>): Promise<ToolResult> {
       site: site.name,
       resolved,
       audHints: call.audHints,
-      onWiggle: browserSnapshot ? async () => void (await browserSnapshot.wiggle(site.name)) : undefined,
+      onWiggle: browserSnapshot
+        ? async () => {
+            const current = await snapshotBrowser();
+            if (current) await current.wiggle(site.name);
+          }
+        : undefined,
     });
     result = await applyJqOutput(call, result);
     return ok(result);
@@ -374,10 +383,7 @@ function handleSniff(args: Record<string, unknown>): ToolResult {
 }
 
 async function handleWiggle(args: Record<string, unknown>): Promise<ToolResult> {
-  const snapshot = await withBrowserLock(async () => {
-    resetIfBrowserDied();
-    return browser;
-  });
+  const snapshot = await snapshotBrowser();
   if (!snapshot) return error("Browser is not running. Start it with site_browser_start.");
   const site = args.site as string | undefined;
   const touched = await snapshot.wiggle(site);
@@ -385,10 +391,7 @@ async function handleWiggle(args: Record<string, unknown>): Promise<ToolResult> 
 }
 
 async function handleEval(args: Record<string, unknown>): Promise<ToolResult> {
-  const snapshot = await withBrowserLock(async () => {
-    resetIfBrowserDied();
-    return browser;
-  });
+  const snapshot = await snapshotBrowser();
   if (!snapshot) return error("Browser is not running. Start it with site_browser_start.");
   const code = args.code as string;
   if (!code) return error("Missing 'code'");
@@ -397,10 +400,7 @@ async function handleEval(args: Record<string, unknown>): Promise<ToolResult> {
 }
 
 async function handleColdStart(args: Record<string, unknown>): Promise<ToolResult> {
-  const snapshot = await withBrowserLock(async () => {
-    resetIfBrowserDied();
-    return browser;
-  });
+  const snapshot = await snapshotBrowser();
   if (!snapshot) return error("Browser is not running. Start it with site_browser_start.");
   const site = args.site as string | undefined;
   return ok(await snapshot.coldStart(site));

--- a/packages/daemon/src/site-worker.ts
+++ b/packages/daemon/src/site-worker.ts
@@ -21,7 +21,7 @@ import { isAbsolute } from "node:path";
 import { SITE_SERVER_NAME } from "@mcp-cli/core";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
-import { createBrowserLock } from "./site/browser-lock";
+import { createBrowserLock, withDeadline } from "./site/browser-lock";
 import type { BrowserEngine, BrowserEngineName, SiteSpec } from "./site/browser/engine";
 import { removeCall as catalogRemoveCall, upsertCall as catalogUpsertCall, loadCatalog } from "./site/catalog";
 import {
@@ -327,7 +327,7 @@ async function handleBrowserStart(args: Record<string, unknown>): Promise<ToolRe
 
     const eng = await loadBrowser(engine);
     const specs = sites.map(siteSpecFor);
-    const startResults = await eng.start(specs, sniffer.asEvents());
+    const startResults = await withDeadline(60_000, "browser start", eng.start(specs, sniffer.asEvents()));
     for (const s of sites) sitesOpenInBrowser.add(s.name);
 
     return ok({ ok: true, engine, sites: eng.getSiteNames(), results: startResults });
@@ -338,7 +338,7 @@ async function handleDisconnect(): Promise<ToolResult> {
   return withBrowserLock(async () => {
     resetIfBrowserDied();
     if (!browser) return ok({ ok: true, note: "browser was not running" });
-    await browser.stop();
+    await withDeadline(30_000, "browser stop", browser.stop());
     browser = null;
     browserEngineName = null;
     sitesOpenInBrowser.clear();

--- a/packages/daemon/src/site/browser-lock.spec.ts
+++ b/packages/daemon/src/site/browser-lock.spec.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import { createBrowserLock } from "./browser-lock";
+
+describe("createBrowserLock", () => {
+  test("sequential calls execute in order", async () => {
+    const withLock = createBrowserLock();
+    const results: number[] = [];
+    await withLock(async () => {
+      results.push(1);
+    });
+    await withLock(async () => {
+      results.push(2);
+    });
+    expect(results).toEqual([1, 2]);
+  });
+
+  test("concurrent calls are serialized — second waits for first to finish", async () => {
+    const withLock = createBrowserLock();
+    const order: string[] = [];
+
+    let resolveFirst!: () => void;
+    const firstDone = new Promise<void>((r) => {
+      resolveFirst = r;
+    });
+
+    const first = withLock(async () => {
+      order.push("first:start");
+      await firstDone;
+      order.push("first:end");
+    });
+
+    // Yield so first has a chance to acquire the lock before second enqueues.
+    await Promise.resolve();
+
+    const second = withLock(async () => {
+      order.push("second:start");
+    });
+
+    // Second should not have started yet (first still holds the lock).
+    expect(order).toEqual(["first:start"]);
+
+    resolveFirst();
+    await Promise.all([first, second]);
+
+    expect(order).toEqual(["first:start", "first:end", "second:start"]);
+  });
+
+  test("lock is released after throw so subsequent callers proceed", async () => {
+    const withLock = createBrowserLock();
+    await expect(
+      withLock(async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    // Should not deadlock — the next caller proceeds normally.
+    const result = await withLock(async () => "ok");
+    expect(result).toBe("ok");
+  });
+
+  test("models the reset-during-start race: observer cannot clear browser while start holds the lock", async () => {
+    const withLock = createBrowserLock();
+
+    // Simulate module-level state.
+    let isRunning = false;
+    class FakeEngine {}
+    const fakeEngine = new FakeEngine();
+    let browserRef: FakeEngine | null = null;
+
+    function resetIfDied() {
+      if (browserRef && !isRunning) {
+        browserRef = null;
+      }
+    }
+
+    // Simulate handleBrowserStart holding the lock across the async start.
+    let resolveStart!: () => void;
+    const startDone = new Promise<void>((r) => {
+      resolveStart = r;
+    });
+
+    const startTask = withLock(async () => {
+      resetIfDied();
+      browserRef = fakeEngine; // loadBrowser assigns the ref
+      await startDone; // eng.start() — async gap where observer would race
+      isRunning = true;
+    });
+
+    // Yield so startTask acquires the lock.
+    await Promise.resolve();
+
+    // Simulate a concurrent observer (e.g. handleWiggle) trying to reset.
+    const observerTask = withLock(async () => {
+      resetIfDied();
+      return browserRef;
+    });
+
+    // At this point startTask holds the lock; observerTask is queued.
+    // browserRef is truthy but isRunning is still false —
+    // without the lock the observer would clear browserRef here.
+    expect(browserRef === fakeEngine).toBe(true);
+    expect(isRunning).toBe(false);
+
+    // Finish the start.
+    resolveStart();
+    await startTask;
+
+    const observerSaw = await observerTask;
+
+    // isRunning=true by the time observer runs → reset does NOT fire.
+    expect(observerSaw === fakeEngine).toBe(true);
+    expect(browserRef === fakeEngine).toBe(true);
+  });
+});

--- a/packages/daemon/src/site/browser-lock.ts
+++ b/packages/daemon/src/site/browser-lock.ts
@@ -1,0 +1,21 @@
+/**
+ * Creates a serial async mutex. All callers queue behind the previous holder;
+ * no two calls execute concurrently. The lock is released in `finally` so
+ * throws still unblock waiting callers.
+ */
+export function createBrowserLock() {
+  let lock: Promise<void> = Promise.resolve();
+  return async function withBrowserLock<T>(fn: () => Promise<T>): Promise<T> {
+    const prev = lock;
+    let release!: () => void;
+    lock = new Promise<void>((r) => {
+      release = r;
+    });
+    try {
+      await prev;
+      return await fn();
+    } finally {
+      release();
+    }
+  };
+}

--- a/packages/daemon/src/site/browser-lock.ts
+++ b/packages/daemon/src/site/browser-lock.ts
@@ -19,3 +19,20 @@ export function createBrowserLock() {
     }
   };
 }
+
+/**
+ * Races `work` against a deadline. Rejects with a descriptive error if `ms`
+ * elapses first, ensuring the lock is released by the caller's `finally`.
+ * The timeout handle is always cleared to avoid keeping the event loop alive.
+ */
+export async function withDeadline<T>(ms: number, label: string, work: Promise<T>): Promise<T> {
+  let id: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    id = setTimeout(() => reject(new Error(`${label} timed out after ${ms / 1000}s`)), ms);
+  });
+  try {
+    return await Promise.race([work, timeout]);
+  } finally {
+    clearTimeout(id);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `createBrowserLock()` — a serial async mutex in `packages/daemon/src/site/browser-lock.ts` that serialises browser lifecycle writes across await points
- `handleBrowserStart` and `handleDisconnect` run their full bodies under the lock, preventing a concurrent observer from seeing `browser` truthy but `isRunning() === false` during start-up
- Observer handlers (`handleWiggle`, `handleEval`, `handleCall`, `handleColdStart`) snapshot the `browser` ref under the lock then release it, so they can't race the start-up window

## Test plan
- [x] `browser-lock.spec.ts`: 4 unit tests covering sequential ordering, concurrency serialization, throw-recovery, and the specific reset-during-start scenario modelled from the issue
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — 5775 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)