### PR TITLE
fix(monitor): retry pr.merged derive when work item not yet created (fixes #1666)

### DIFF
--- a/packages/daemon/src/derived-events.spec.ts
+++ b/packages/daemon/src/derived-events.spec.ts
@@ -4,7 +4,7 @@ import type { MonitorEvent, MonitorEventInput } from "@mcp-cli/core";
 import { PHASE_CHANGED } from "@mcp-cli/core";
 import { WorkItemDb } from "./db/work-items";
 import { DerivedEventPublisher } from "./derived-events";
-import { DEFAULT_RULES, prMergedToDone } from "./derived-rules";
+import { DEFAULT_RULES, isDerivedPending, prMergedToDone } from "./derived-rules";
 import type { DerivedCtx, DerivedRule } from "./derived-rules";
 import { EventBus } from "./event-bus";
 import { EventLog } from "./event-log";
@@ -49,7 +49,7 @@ describe("prMergedToDone rule", () => {
     const wi = workItemDb.createWorkItem({ prNumber: 42, phase: "qa" });
     const result = prMergedToDone.apply(stampEvent(prMergedInput(), 5), ctx);
 
-    if (!result) throw new Error("expected non-null result");
+    if (!result || isDerivedPending(result)) throw new Error("expected non-null, non-pending result");
     expect(result.event).toBe(PHASE_CHANGED);
     expect(result.category).toBe("work_item");
     expect(result.workItemId).toBe(wi.id);
@@ -79,12 +79,14 @@ describe("prMergedToDone rule", () => {
     expect(prMergedToDone.apply(stampEvent(prMergedInput(), 5), ctx)).toBeNull();
   });
 
-  test("returns null when no work item for PR", () => {
+  test("returns pending when no work item for PR", () => {
     const db = freshDb();
     const workItemDb = new WorkItemDb(db);
     const ctx: DerivedCtx = { workItemDb, bus: new EventBus() };
 
-    expect(prMergedToDone.apply(stampEvent(prMergedInput(999), 5), ctx)).toBeNull();
+    const result = prMergedToDone.apply(stampEvent(prMergedInput(999), 5), ctx);
+    if (!isDerivedPending(result)) throw new Error("expected pending result");
+    expect(result.reason).toContain("999");
   });
 
   test("second invocation is a no-op after phase transitions to done", () => {
@@ -143,19 +145,100 @@ describe("DerivedEventPublisher", () => {
     expect(received[0].event).toBe("pr.merged");
   });
 
-  test("does not publish when no work item exists", () => {
+  test("schedules retry when no work item exists (pending)", async () => {
     const db = freshDb();
     const bus = new EventBus();
     const workItemDb = new WorkItemDb(db);
 
     const received: MonitorEvent[] = [];
     bus.subscribe((e) => received.push(e));
-    const pub = new DerivedEventPublisher({ bus, rules: DEFAULT_RULES, workItemDb, db });
+    const pub = new DerivedEventPublisher({ bus, rules: DEFAULT_RULES, workItemDb, db, retryBaseMs: 10 });
 
-    bus.publish(prMergedInput(999));
+    bus.publish(prMergedInput(42));
+
+    // Work item created after event fires — the retry should pick it up
+    workItemDb.createWorkItem({ prNumber: 42, phase: "qa" });
+
+    // Poll until the derived event appears (retry fires at ~10ms)
+    const deadline = Date.now() + 2000;
+    while (received.length < 2 && Date.now() < deadline) {
+      await Bun.sleep(5);
+    }
+
     pub.dispose();
 
+    expect(received).toHaveLength(2);
+    expect(received[0].event).toBe("pr.merged");
+    expect(received[1].event).toBe(PHASE_CHANGED);
+    expect(received[1].to).toBe("done");
+  });
+
+  test("retry succeeds and updates DB", async () => {
+    const db = freshDb();
+    const bus = new EventBus();
+    const workItemDb = new WorkItemDb(db);
+
+    const pub = new DerivedEventPublisher({ bus, rules: DEFAULT_RULES, workItemDb, db, retryBaseMs: 10 });
+
+    bus.publish(prMergedInput(42));
+    const wi = workItemDb.createWorkItem({ prNumber: 42, phase: "qa" });
+
+    const deadline = Date.now() + 2000;
+    while (workItemDb.getWorkItem(wi.id)?.phase !== "done" && Date.now() < deadline) {
+      await Bun.sleep(5);
+    }
+
+    pub.dispose();
+
+    expect(workItemDb.getWorkItem(wi.id)?.phase).toBe("done");
+  });
+
+  test("retry exhaustion: drops event after max retries", async () => {
+    const db = freshDb();
+    const bus = new EventBus();
+    const workItemDb = new WorkItemDb(db);
+
+    const received: MonitorEvent[] = [];
+    bus.subscribe((e) => received.push(e));
+    const pub = new DerivedEventPublisher({ bus, rules: DEFAULT_RULES, workItemDb, db, retryBaseMs: 10 });
+
+    // Fire pr.merged with no work item — never create one
+    bus.publish(prMergedInput(999));
+
+    // Wait long enough for all 3 retries to exhaust (10 + 20 + 40 = 70ms, give margin)
+    const deadline = Date.now() + 2000;
+    while (Date.now() < deadline) {
+      await Bun.sleep(10);
+      // Break early once we're well past all retries
+      if (Date.now() > deadline - 1500) break;
+    }
+
+    pub.dispose();
+
+    // Only the original pr.merged event — no derived event produced
     expect(received).toHaveLength(1);
+    expect(received[0].event).toBe("pr.merged");
+  });
+
+  test("dispose cancels pending retries", async () => {
+    const db = freshDb();
+    const bus = new EventBus();
+    const workItemDb = new WorkItemDb(db);
+
+    const received: MonitorEvent[] = [];
+    bus.subscribe((e) => received.push(e));
+    // Use long retry delay so we can dispose before it fires
+    const pub = new DerivedEventPublisher({ bus, rules: DEFAULT_RULES, workItemDb, db, retryBaseMs: 5000 });
+
+    bus.publish(prMergedInput(42));
+    pub.dispose();
+
+    // Create work item after dispose — retry should never fire
+    workItemDb.createWorkItem({ prNumber: 42, phase: "qa" });
+    await Bun.sleep(50);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].event).toBe("pr.merged");
   });
 
   test("updates work item phase in DB", () => {
@@ -378,5 +461,60 @@ describe("DerivedEventPublisher", () => {
 
     const derived = received.find((e) => e.event === "test.derived");
     expect(derived?.src).toBe("daemon.derived");
+  });
+
+  // ── Retry-specific integration tests ──
+
+  test("retry does not re-derive if work item created with non-QA phase", async () => {
+    const db = freshDb();
+    const bus = new EventBus();
+    const workItemDb = new WorkItemDb(db);
+
+    const received: MonitorEvent[] = [];
+    bus.subscribe((e) => received.push(e));
+    const pub = new DerivedEventPublisher({ bus, rules: DEFAULT_RULES, workItemDb, db, retryBaseMs: 10 });
+
+    bus.publish(prMergedInput(42));
+
+    // Create work item in "done" phase — retry should find it but skip (null, not pending)
+    workItemDb.createWorkItem({ prNumber: 42, phase: "done" });
+
+    await Bun.sleep(100);
+    pub.dispose();
+
+    // Only the original pr.merged — no derived event
+    expect(received).toHaveLength(1);
+  });
+
+  test("pending rule does not cause infinite loop via depth cap on retried events", async () => {
+    const db = freshDb();
+    const bus = new EventBus();
+    const workItemDb = new WorkItemDb(db);
+
+    const received: MonitorEvent[] = [];
+    bus.subscribe((e) => received.push(e));
+
+    let retryCount = 0;
+    const alwaysPending: DerivedRule = {
+      name: "always-pending",
+      match: (e) => e.event === "pr.merged",
+      apply: () => {
+        retryCount++;
+        return { pending: true, reason: "always pending" };
+      },
+    };
+
+    const pub = new DerivedEventPublisher({ bus, rules: [alwaysPending], workItemDb, db, retryBaseMs: 10 });
+
+    bus.publish(prMergedInput(42));
+
+    // Wait for all retries to exhaust
+    await Bun.sleep(200);
+    pub.dispose();
+
+    // 1 initial + 3 retries = 4 total apply calls
+    expect(retryCount).toBe(4);
+    // Only the original event — no derived events
+    expect(received).toHaveLength(1);
   });
 });

--- a/packages/daemon/src/derived-events.spec.ts
+++ b/packages/daemon/src/derived-events.spec.ts
@@ -486,6 +486,36 @@ describe("DerivedEventPublisher", () => {
     expect(received).toHaveLength(1);
   });
 
+  test("retry catches rule exceptions instead of crashing", async () => {
+    const db = freshDb();
+    const bus = new EventBus();
+    const workItemDb = new WorkItemDb(db);
+
+    const received: MonitorEvent[] = [];
+    bus.subscribe((e) => received.push(e));
+
+    let applyCalls = 0;
+    const failOnRetry: DerivedRule = {
+      name: "fail-on-retry",
+      match: (e) => e.event === "pr.merged",
+      apply: () => {
+        applyCalls++;
+        if (applyCalls === 1) return { pending: true, reason: "not ready" };
+        throw new Error("kaboom in retry");
+      },
+    };
+
+    const pub = new DerivedEventPublisher({ bus, rules: [failOnRetry], workItemDb, db, retryBaseMs: 10 });
+
+    bus.publish(prMergedInput(42));
+
+    await Bun.sleep(200);
+    pub.dispose();
+
+    expect(applyCalls).toBe(2);
+    expect(received).toHaveLength(1);
+  });
+
   test("pending rule does not cause infinite loop via depth cap on retried events", async () => {
     const db = freshDb();
     const bus = new EventBus();

--- a/packages/daemon/src/derived-events.ts
+++ b/packages/daemon/src/derived-events.ts
@@ -1,11 +1,16 @@
 import type { Database } from "bun:sqlite";
 import type { MonitorEvent, MonitorEventInput } from "@mcp-cli/core";
 import type { WorkItemDb } from "./db/work-items";
+import { isDerivedPending } from "./derived-rules";
 import type { DerivedRule } from "./derived-rules";
 import type { EventBus } from "./event-bus";
+import { metrics } from "./metrics";
 
 // Causal chain length beyond which derived events are dropped to prevent infinite loops.
 const MAX_DERIVED_DEPTH = 4;
+
+const MAX_RETRIES = 3;
+const RETRY_BASE_MS = 500;
 
 export class DerivedEventPublisher {
   private readonly bus: EventBus;
@@ -13,17 +18,32 @@ export class DerivedEventPublisher {
   private readonly ctx: { workItemDb: WorkItemDb; bus: EventBus };
   private readonly db: Database;
   private readonly subId: number;
+  private readonly pendingTimers = new Set<ReturnType<typeof setTimeout>>();
+  private disposed = false;
 
-  constructor(opts: { bus: EventBus; rules: DerivedRule[]; workItemDb: WorkItemDb; db: Database }) {
+  constructor(opts: {
+    bus: EventBus;
+    rules: DerivedRule[];
+    workItemDb: WorkItemDb;
+    db: Database;
+    /** Override base delay for retries (ms). Exposed for testing. */
+    retryBaseMs?: number;
+  }) {
     this.bus = opts.bus;
     this.rules = opts.rules;
     this.ctx = { workItemDb: opts.workItemDb, bus: opts.bus };
     this.db = opts.db;
+    if (opts.retryBaseMs !== undefined) this._retryBaseMs = opts.retryBaseMs;
     this.subId = this.bus.subscribe((event) => this.handleEvent(event));
   }
 
+  private _retryBaseMs = RETRY_BASE_MS;
+
   dispose(): void {
+    this.disposed = true;
     this.bus.unsubscribe(this.subId);
+    for (const timer of this.pendingTimers) clearTimeout(timer);
+    this.pendingTimers.clear();
   }
 
   private handleEvent(event: MonitorEvent): void {
@@ -32,6 +52,7 @@ export class DerivedEventPublisher {
 
     const chain = [...causedBy, event.seq];
     const outputs: MonitorEventInput[] = [];
+    const pending: Array<{ rule: DerivedRule; reason: string }> = [];
 
     // All rule mutations run in one transaction: either all DB writes commit or none do.
     // bus.publish is called AFTER commit so subscribers never observe events inside an open transaction.
@@ -39,12 +60,71 @@ export class DerivedEventPublisher {
       for (const rule of this.rules) {
         if (!rule.match(event)) continue;
         const out = rule.apply(event, this.ctx);
-        if (out) outputs.push({ ...out, src: "daemon.derived", causedBy: chain });
+        if (isDerivedPending(out)) {
+          pending.push({ rule, reason: out.reason });
+        } else if (out) {
+          outputs.push({ ...out, src: "daemon.derived", causedBy: chain });
+        }
       }
     })();
 
     for (const input of outputs) {
       this.bus.publish(input);
     }
+
+    if (pending.length > 0) {
+      for (const { rule, reason } of pending) {
+        console.warn(`[DerivedEvents] rule "${rule.name}" pending: ${reason} — scheduling retry`);
+        metrics.counter("mcpd_derived_retries_total", { rule: rule.name }).inc();
+        this.scheduleRetry(event, rule, 0);
+      }
+    }
+  }
+
+  private scheduleRetry(event: MonitorEvent, rule: DerivedRule, attempt: number): void {
+    if (this.disposed || attempt >= MAX_RETRIES) {
+      if (attempt >= MAX_RETRIES) {
+        console.error(
+          `[DerivedEvents] rule "${rule.name}" exhausted ${MAX_RETRIES} retries for event seq=${event.seq} — event dropped`,
+        );
+        metrics.counter("mcpd_derived_retries_exhausted_total", { rule: rule.name }).inc();
+      }
+      return;
+    }
+
+    const delay = this._retryBaseMs * 2 ** attempt;
+    const timer = setTimeout(() => {
+      this.pendingTimers.delete(timer);
+      if (this.disposed) return;
+
+      const chain = [...(event.causedBy ?? []), event.seq];
+      const outputs: MonitorEventInput[] = [];
+      let stillPending = false;
+
+      this.db.transaction(() => {
+        if (!rule.match(event)) return;
+        const out = rule.apply(event, this.ctx);
+        if (isDerivedPending(out)) {
+          stillPending = true;
+        } else if (out) {
+          outputs.push({ ...out, src: "daemon.derived", causedBy: chain });
+        }
+      })();
+
+      for (const input of outputs) {
+        this.bus.publish(input);
+      }
+
+      if (outputs.length > 0) {
+        console.warn(`[DerivedEvents] rule "${rule.name}" succeeded on retry ${attempt + 1}`);
+      }
+
+      if (stillPending) {
+        metrics.counter("mcpd_derived_retries_total", { rule: rule.name }).inc();
+        this.scheduleRetry(event, rule, attempt + 1);
+      }
+    }, delay);
+
+    this.pendingTimers.add(timer);
   }
 }

--- a/packages/daemon/src/derived-events.ts
+++ b/packages/daemon/src/derived-events.ts
@@ -97,31 +97,39 @@ export class DerivedEventPublisher {
       this.pendingTimers.delete(timer);
       if (this.disposed) return;
 
-      const chain = [...(event.causedBy ?? []), event.seq];
-      const outputs: MonitorEventInput[] = [];
-      let stillPending = false;
+      try {
+        const chain = [...(event.causedBy ?? []), event.seq];
+        const outputs: MonitorEventInput[] = [];
+        let stillPending = false;
 
-      this.db.transaction(() => {
-        if (!rule.match(event)) return;
-        const out = rule.apply(event, this.ctx);
-        if (isDerivedPending(out)) {
-          stillPending = true;
-        } else if (out) {
-          outputs.push({ ...out, src: "daemon.derived", causedBy: chain });
+        this.db.transaction(() => {
+          if (!rule.match(event)) return;
+          const out = rule.apply(event, this.ctx);
+          if (isDerivedPending(out)) {
+            stillPending = true;
+          } else if (out) {
+            outputs.push({ ...out, src: "daemon.derived", causedBy: chain });
+          }
+        })();
+
+        for (const input of outputs) {
+          this.bus.publish(input);
         }
-      })();
 
-      for (const input of outputs) {
-        this.bus.publish(input);
-      }
+        if (outputs.length > 0) {
+          console.warn(`[DerivedEvents] rule "${rule.name}" succeeded on retry ${attempt + 1}`);
+        }
 
-      if (outputs.length > 0) {
-        console.warn(`[DerivedEvents] rule "${rule.name}" succeeded on retry ${attempt + 1}`);
-      }
-
-      if (stillPending) {
-        metrics.counter("mcpd_derived_retries_total", { rule: rule.name }).inc();
-        this.scheduleRetry(event, rule, attempt + 1);
+        if (stillPending) {
+          metrics.counter("mcpd_derived_retries_total", { rule: rule.name }).inc();
+          this.scheduleRetry(event, rule, attempt + 1);
+        }
+      } catch (err) {
+        console.error(
+          `[DerivedEvents] rule "${rule.name}" threw during retry ${attempt + 1} for event seq=${event.seq}:`,
+          err,
+        );
+        metrics.counter("mcpd_derived_retry_failures_total", { rule: rule.name }).inc();
       }
     }, delay);
 

--- a/packages/daemon/src/derived-rules.ts
+++ b/packages/daemon/src/derived-rules.ts
@@ -23,7 +23,7 @@ export function isDerivedPending(r: DeriveResult): r is DerivedPending {
 export interface DerivedRule {
   name: string;
   match: (event: MonitorEvent) => boolean;
-  /** Mutates DB state and returns the event to emit, pending to retry, or null to skip. Publisher stamps src and causedBy. */
+  /** Mutates DB state and returns the event to emit, pending to retry, or null to skip. Publisher stamps src and causedBy. A rule returning `pending` must be safe to retry: either perform no side effects before returning pending, or ensure all mutations are idempotent. */
   apply: (event: MonitorEvent, ctx: DerivedCtx) => DeriveResult;
 }
 

--- a/packages/daemon/src/derived-rules.ts
+++ b/packages/daemon/src/derived-rules.ts
@@ -8,11 +8,23 @@ export interface DerivedCtx {
   bus: EventBus;
 }
 
+/** Signal that the rule cannot apply yet but should be retried (e.g. work item not yet created). */
+export interface DerivedPending {
+  pending: true;
+  reason: string;
+}
+
+export type DeriveResult = MonitorEventInput | DerivedPending | null;
+
+export function isDerivedPending(r: DeriveResult): r is DerivedPending {
+  return r !== null && "pending" in r && r.pending === true;
+}
+
 export interface DerivedRule {
   name: string;
   match: (event: MonitorEvent) => boolean;
-  /** Mutates DB state and returns the event to emit, or null to skip. Publisher stamps src and causedBy. */
-  apply: (event: MonitorEvent, ctx: DerivedCtx) => MonitorEventInput | null;
+  /** Mutates DB state and returns the event to emit, pending to retry, or null to skip. Publisher stamps src and causedBy. */
+  apply: (event: MonitorEvent, ctx: DerivedCtx) => DeriveResult;
 }
 
 export const prMergedToDone: DerivedRule = {
@@ -21,7 +33,8 @@ export const prMergedToDone: DerivedRule = {
   apply: (e, ctx) => {
     const prNumber = e.prNumber as number;
     const wi = ctx.workItemDb.getWorkItemByPr(prNumber);
-    if (!wi || wi.phase !== "qa") return null;
+    if (!wi) return { pending: true, reason: `no work item for PR #${prNumber}` };
+    if (wi.phase !== "qa") return null;
     ctx.workItemDb.updateWorkItem(wi.id, { phase: "done" });
     return {
       src: "daemon.derived",


### PR DESCRIPTION
## Summary
- When `pr.merged` fires before the work item row exists in the DB, the `prMergedToDone` derive rule now returns a `{ pending: true }` signal instead of silently returning `null`
- `DerivedEventPublisher` retries pending rules with exponential backoff (500ms → 1s → 2s, 3 attempts max), with logging and metrics (`mcpd_derived_retries_total`, `mcpd_derived_retries_exhausted_total`)
- Pending timers are cancelled on `dispose()` to prevent leaks; depth cap still applies to prevent infinite loops

## Test plan
- [x] Rule returns `pending` when no work item exists for PR (was `null`)
- [x] Rule still returns `null` for wrong phase (idempotent skip)
- [x] Publisher retries and succeeds when work item created after event fires
- [x] Retry updates DB phase to `done`
- [x] Retry exhaustion after 3 attempts drops event with error log
- [x] `dispose()` cancels pending retries
- [x] Retry with non-QA work item does not produce derived event
- [x] Always-pending rule capped at 4 total apply calls (1 initial + 3 retries)
- [x] All 26 derived-events tests pass; full suite (5780 tests) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)