### PR TITLE
fix(events): apply session.response/responseTail gating in backfill loop (fixes #1688)

### DIFF
--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -2993,6 +2993,132 @@ describe("IpcServer HTTP transport", () => {
       expect(buffer).not.toContain("session.result");
       expect(buffer).toContain("pr.merged");
     });
+
+    test("backfill session.response excluded by default (no responseTail)", async () => {
+      const db = new Database(":memory:");
+      const eventLog = new EventLog(db);
+      const bus = new EventBus(eventLog);
+      socketPath = tmpSocket();
+      server = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, {
+        ...opts(),
+        eventBus: bus,
+      });
+      server.start(socketPath);
+
+      bus.publish({ src: "test", event: "session.response", category: "session", sessionId: "s1", chunk: "secret" });
+      bus.publish({ src: "test", event: "session.result", category: "session", sessionId: "s1" });
+
+      const controller = new AbortController();
+      const res = await fetch("http://localhost/events?since=0", {
+        method: "GET",
+        unix: socketPath,
+        signal: controller.signal,
+      } as RequestInit);
+
+      expect(res.status).toBe(200);
+      if (!res.body) throw new Error("Expected response body");
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+
+      let buffer = "";
+      const deadline = Date.now() + 2_000;
+      while (Date.now() < deadline) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        if (buffer.includes("session.result")) break;
+      }
+
+      controller.abort();
+      reader.releaseLock();
+
+      expect(buffer).not.toContain("session.response");
+      expect(buffer).toContain("session.result");
+    });
+
+    test("backfill session.response included when responseTail matches", async () => {
+      const db = new Database(":memory:");
+      const eventLog = new EventLog(db);
+      const bus = new EventBus(eventLog);
+      socketPath = tmpSocket();
+      server = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, {
+        ...opts(),
+        eventBus: bus,
+      });
+      server.start(socketPath);
+
+      bus.publish({ src: "test", event: "session.response", category: "session", sessionId: "s1", chunk: "hello" });
+      bus.publish({ src: "test", event: "session.result", category: "session", sessionId: "s1" });
+
+      const controller = new AbortController();
+      const res = await fetch("http://localhost/events?since=0&responseTail=s1", {
+        method: "GET",
+        unix: socketPath,
+        signal: controller.signal,
+      } as RequestInit);
+
+      expect(res.status).toBe(200);
+      if (!res.body) throw new Error("Expected response body");
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+
+      let buffer = "";
+      const deadline = Date.now() + 2_000;
+      while (Date.now() < deadline) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        if (buffer.includes("session.result")) break;
+      }
+
+      controller.abort();
+      reader.releaseLock();
+
+      expect(buffer).toContain("session.response");
+      expect(buffer).toContain("session.result");
+    });
+
+    test("backfill session.response excluded when responseTail is different session", async () => {
+      const db = new Database(":memory:");
+      const eventLog = new EventLog(db);
+      const bus = new EventBus(eventLog);
+      socketPath = tmpSocket();
+      server = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, {
+        ...opts(),
+        eventBus: bus,
+      });
+      server.start(socketPath);
+
+      bus.publish({ src: "test", event: "session.response", category: "session", sessionId: "s1", chunk: "secret" });
+      bus.publish({ src: "test", event: "session.result", category: "session", sessionId: "s1" });
+
+      const controller = new AbortController();
+      const res = await fetch("http://localhost/events?since=0&responseTail=other-session", {
+        method: "GET",
+        unix: socketPath,
+        signal: controller.signal,
+      } as RequestInit);
+
+      expect(res.status).toBe(200);
+      if (!res.body) throw new Error("Expected response body");
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+
+      let buffer = "";
+      const deadline = Date.now() + 2_000;
+      while (Date.now() < deadline) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        if (buffer.includes("session.result")) break;
+      }
+
+      controller.abort();
+      reader.releaseLock();
+
+      expect(buffer).not.toContain("session.response");
+      expect(buffer).toContain("session.result");
+    });
   });
 
   // -- GET /events NDJSON endpoint tests (ring-buffer / pushEvent path) --

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -1496,6 +1496,14 @@ export class IpcServer {
       const responseTail = url.searchParams.get("responseTail");
       const eventFilter = buildEventFilter(url.searchParams);
 
+      const shouldDeliver = (event: { event: string; sessionId?: string }) => {
+        if (eventFilter !== null && !eventFilter(event as Record<string, unknown>)) return false;
+        if (event.event === "session.response") {
+          return responseTail !== null && event.sessionId === responseTail;
+        }
+        return true;
+      };
+
       const bus = this.eventBus;
 
       if (bus.subscriberCount >= IpcServer.MAX_EVENT_BUS_SUBSCRIBERS) {
@@ -1565,13 +1573,7 @@ export class IpcServer {
                   cleanup();
                 }
               },
-              (event) => {
-                if (eventFilter !== null && !eventFilter(event as Record<string, unknown>)) return false;
-                if (event.event === "session.response") {
-                  return responseTail !== null && event.sessionId === responseTail;
-                }
-                return true;
-              },
+              (event) => shouldDeliver(event),
             );
             subscriberGauge.inc();
 
@@ -1582,7 +1584,7 @@ export class IpcServer {
                 const batch = eventLog.getSince(cursor, 1000);
                 for (const event of batch) {
                   highWaterMark = event.seq;
-                  if (eventFilter !== null && !eventFilter(event as Record<string, unknown>)) continue;
+                  if (!shouldDeliver(event)) continue;
                   if (controller.desiredSize !== null && controller.desiredSize <= 0) {
                     this.logger.warn("[events] slow consumer during backfill, dropping subscriber");
                     metrics.counter("mcpd_event_bus_slow_drops_total").inc();


### PR DESCRIPTION
## Summary
- The durable-log backfill loop was missing the `session.response` / `responseTail` gating that the live EventBus subscriber already applied
- Any client connecting with `?since=<seq>` and no `responseTail` would receive all historical `session.response` payloads, leaking session output
- Factored a shared `shouldDeliver(event, responseTail)` helper used by both the live callback and the backfill loop

## Test plan
- Added 3 new tests in `ipc-server.spec.ts`:
  - `backfill session.response excluded by default (no responseTail)` — verifies historical `session.response` events are suppressed when no `responseTail` param is set
  - `backfill session.response included when responseTail matches` — verifies they are delivered when `responseTail` matches the session ID
  - `backfill session.response excluded when responseTail is different session` — verifies cross-session isolation
- All 137 ipc-server tests pass; full suite 5784/5784 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)