### PR TITLE
fix(mail): wire EventBus into MailServer so in-process sends publish monitor events (fixes #1544)

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -576,6 +576,7 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
   const eventLog = new EventLog(db.getDatabase());
   eventLog.startPruning();
   const mailEventBus = new EventBus(eventLog);
+  mailServer.setEventBus(mailEventBus);
 
   // Start IPC server
   const ipcServer = new IpcServer(pool, config, db, aliasServer, {

--- a/packages/daemon/src/mail-server.spec.ts
+++ b/packages/daemon/src/mail-server.spec.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { MAIL_SERVER_NAME } from "@mcp-cli/core";
+import { MAIL_RECEIVED, MAIL_SERVER_NAME, type MonitorEvent } from "@mcp-cli/core";
 import { testOptions } from "../../../test/test-options";
 import { StateDb } from "./db/state";
+import { EventBus } from "./event-bus";
 import { MailServer, buildMailToolCache } from "./mail-server";
 
 describe("MAIL_SERVER_NAME", () => {
@@ -220,5 +221,90 @@ describe("MailServer", () => {
     expect(result.isError).toBe(true);
     const content = result.content as Array<{ type: string; text: string }>;
     expect(content[0].text).toContain("Unknown tool");
+  });
+
+  test("_mail_send publishes monitor event when EventBus is set", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    const bus = new EventBus();
+    server = new MailServer(db, bus);
+
+    const events: MonitorEvent[] = [];
+    bus.subscribe((e) => events.push(e));
+
+    const { client } = await server.start();
+    await client.callTool({
+      name: "_mail_send",
+      arguments: { sender: "alice", recipient: "bob", body: "hello" },
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].event).toBe(MAIL_RECEIVED);
+    expect(events[0].sender).toBe("alice");
+    expect(events[0].recipient).toBe("bob");
+  });
+
+  test("_mail_reply publishes monitor event when EventBus is set", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    const bus = new EventBus();
+    server = new MailServer(db, bus);
+
+    const events: MonitorEvent[] = [];
+    bus.subscribe((e) => events.push(e));
+
+    const { client } = await server.start();
+
+    const sendResult = await client.callTool({
+      name: "_mail_send",
+      arguments: { sender: "alice", recipient: "bob", subject: "hi", body: "original" },
+    });
+    const sendContent = sendResult.content as Array<{ type: string; text: string }>;
+    const { id } = JSON.parse(sendContent[0].text) as { id: number };
+
+    events.length = 0; // reset after send
+
+    await client.callTool({
+      name: "_mail_reply",
+      arguments: { id, sender: "bob", body: "reply" },
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].event).toBe(MAIL_RECEIVED);
+    expect(events[0].sender).toBe("bob");
+    expect(events[0].recipient).toBe("alice");
+  });
+
+  test("_mail_send does not throw when no EventBus is set", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new MailServer(db); // no EventBus
+
+    const { client } = await server.start();
+    const result = await client.callTool({
+      name: "_mail_send",
+      arguments: { sender: "alice", recipient: "bob", body: "hello" },
+    });
+    expect(result.isError).toBeFalsy();
+  });
+
+  test("setEventBus wires events after construction", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new MailServer(db);
+
+    const bus = new EventBus();
+    const events: MonitorEvent[] = [];
+    bus.subscribe((e) => events.push(e));
+    server.setEventBus(bus);
+
+    const { client } = await server.start();
+    await client.callTool({
+      name: "_mail_send",
+      arguments: { sender: "alice", recipient: "carol", body: "hi" },
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0].event).toBe(MAIL_RECEIVED);
   });
 });

--- a/packages/daemon/src/mail-server.ts
+++ b/packages/daemon/src/mail-server.ts
@@ -13,6 +13,8 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import type { StateDb } from "./db/state";
+import type { EventBus } from "./event-bus";
+import { publishMailReceived } from "./mail-events";
 
 const TOOLS = [
   {
@@ -76,7 +78,14 @@ export class MailServer {
   private clientTransport: Transport | null = null;
   private stopped = false;
 
-  constructor(private db: StateDb) {}
+  constructor(
+    private db: StateDb,
+    private eventBus: EventBus | null = null,
+  ) {}
+
+  setEventBus(eventBus: EventBus): void {
+    this.eventBus = eventBus;
+  }
 
   async start(): Promise<{ client: Client; transport: Transport; tools: Map<string, ToolInfo> }> {
     if (this.server) {
@@ -113,6 +122,7 @@ export class MailServer {
             const body = a.body !== undefined ? String(a.body) : undefined;
             const replyTo = a.replyTo !== undefined ? Number(a.replyTo) : undefined;
             const id = this.db.insertMail(sender, recipient, subject, body, replyTo);
+            publishMailReceived(this.eventBus, { mailId: id, sender, recipient });
             return { content: [{ type: "text" as const, text: JSON.stringify({ id }) }] };
           }
 
@@ -160,6 +170,7 @@ export class MailServer {
             const subject =
               a.subject !== undefined ? String(a.subject) : original.subject ? `Re: ${original.subject}` : undefined;
             const newId = this.db.insertMail(sender, original.sender, subject, body, id);
+            publishMailReceived(this.eventBus, { mailId: newId, sender, recipient: original.sender });
             return { content: [{ type: "text" as const, text: JSON.stringify({ id: newId }) }] };
           }
 


### PR DESCRIPTION
## Summary
- `MailServer._mail_send` and `_mail_reply` handlers now call `publishMailReceived()` after `db.insertMail()`, closing the gap where in-process mail sends were invisible to the unified monitor event stream
- Added `EventBus | null` constructor parameter and `setEventBus()` setter to `MailServer` for dependency injection
- `index.ts` calls `mailServer.setEventBus(mailEventBus)` after the bus is initialized (bus is created at line ~578, `MailServer` construction at ~419 is unchanged — setter bridges the ordering gap)

## Test plan
- [x] 4 new tests in `mail-server.spec.ts`: `_mail_send` publishes event, `_mail_reply` publishes event with correct sender/recipient, graceful no-op when no bus set, `setEventBus()` wires events after construction
- [x] All 16 mail-server tests pass
- [x] Full suite: 5785 pass, 0 fail
- [x] `bun typecheck` clean
- [x] `bun lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)