### PR TITLE
fix(monitor): null cascadeHead on non-actionable merge state transitions (fixes #1696)

### DIFF
--- a/packages/daemon/src/github/work-item-poller.spec.ts
+++ b/packages/daemon/src/github/work-item-poller.spec.ts
@@ -662,7 +662,10 @@ describe("WorkItemPoller", () => {
     await poller.poll();
 
     const dirtyEvt = events.find((e) => e.type === "pr:merge_state_changed" && e.prNumber === 50);
-    expect(dirtyEvt?.type === "pr:merge_state_changed" && dirtyEvt.cascadeHead).toBeNull();
+    expect(dirtyEvt).toBeDefined();
+    if (!dirtyEvt || dirtyEvt.type !== "pr:merge_state_changed")
+      throw new Error("Expected pr:merge_state_changed event for PR 50");
+    expect(dirtyEvt.cascadeHead).toBeNull();
   });
 
   test("cascadeHead is null on null→UNKNOWN transition", async () => {
@@ -685,7 +688,10 @@ describe("WorkItemPoller", () => {
     await poller.poll();
 
     const unknownEvt = events.find((e) => e.type === "pr:merge_state_changed" && e.prNumber === 52);
-    expect(unknownEvt?.type === "pr:merge_state_changed" && unknownEvt.cascadeHead).toBeNull();
+    expect(unknownEvt).toBeDefined();
+    if (!unknownEvt || unknownEvt.type !== "pr:merge_state_changed")
+      throw new Error("Expected pr:merge_state_changed event for PR 52");
+    expect(unknownEvt.cascadeHead).toBeNull();
   });
 
   test("cascadeHead is null on HAS_HOOKS transition", async () => {
@@ -707,7 +713,10 @@ describe("WorkItemPoller", () => {
     await poller.poll();
 
     const hooksEvt = events.find((e) => e.type === "pr:merge_state_changed" && e.prNumber === 54);
-    expect(hooksEvt?.type === "pr:merge_state_changed" && hooksEvt.cascadeHead).toBeNull();
+    expect(hooksEvt).toBeDefined();
+    if (!hooksEvt || hooksEvt.type !== "pr:merge_state_changed")
+      throw new Error("Expected pr:merge_state_changed event for PR 54");
+    expect(hooksEvt.cascadeHead).toBeNull();
   });
 
   test("cascadeHead is null on UNSTABLE transition", async () => {
@@ -725,7 +734,10 @@ describe("WorkItemPoller", () => {
     await poller.poll();
 
     const unstableEvt = events.find((e) => e.type === "pr:merge_state_changed");
-    expect(unstableEvt?.type === "pr:merge_state_changed" && unstableEvt.cascadeHead).toBeNull();
+    expect(unstableEvt).toBeDefined();
+    if (!unstableEvt || unstableEvt.type !== "pr:merge_state_changed")
+      throw new Error("Expected pr:merge_state_changed event for PR 56");
+    expect(unstableEvt.cascadeHead).toBeNull();
   });
 
   test("cascadeHead is non-null when PR transitions to BEHIND with auto-merge", async () => {
@@ -743,7 +755,10 @@ describe("WorkItemPoller", () => {
     await poller.poll();
 
     const behindEvt = events.find((e) => e.type === "pr:merge_state_changed");
-    expect(behindEvt?.type === "pr:merge_state_changed" && behindEvt.cascadeHead).toBe(57);
+    expect(behindEvt).toBeDefined();
+    if (!behindEvt || behindEvt.type !== "pr:merge_state_changed")
+      throw new Error("Expected pr:merge_state_changed event for PR 57");
+    expect(behindEvt.cascadeHead).toBe(57);
   });
 
   // ── Phase 2 enrichment (#1576) ──

--- a/packages/daemon/src/github/work-item-poller.spec.ts
+++ b/packages/daemon/src/github/work-item-poller.spec.ts
@@ -641,6 +641,111 @@ describe("WorkItemPoller", () => {
     }
   });
 
+  test("cascadeHead is null on non-actionable DIRTY transition even when other PR is CLEAN/BEHIND", async () => {
+    // PR 50 starts BEHIND, transitions to DIRTY (non-actionable)
+    // PR 51 is CLEAN with auto-merge — would normally be the cascade head
+    db.createWorkItem({ id: "pr:50", prNumber: 50, mergeStateStatus: "BEHIND" });
+    db.createWorkItem({ id: "pr:51", prNumber: 51, mergeStateStatus: "UNKNOWN" });
+
+    const events: WorkItemEvent[] = [];
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => [
+        makePRStatus({ number: 50, mergeStateStatus: "DIRTY", autoMergeEnabled: true }),
+        makePRStatus({ number: 51, mergeStateStatus: "CLEAN", autoMergeEnabled: true }),
+      ],
+      detectRepo: async () => TEST_REPO,
+      onEvent: (e) => events.push(e),
+    });
+
+    await poller.poll();
+
+    const dirtyEvt = events.find((e) => e.type === "pr:merge_state_changed" && e.prNumber === 50);
+    expect(dirtyEvt?.type === "pr:merge_state_changed" && dirtyEvt.cascadeHead).toBeNull();
+  });
+
+  test("cascadeHead is null on null→UNKNOWN transition", async () => {
+    db.createWorkItem({ id: "pr:52", prNumber: 52 });
+    // Add a CLEAN armed PR to ensure cascadeHead would be non-null if not gated
+    db.createWorkItem({ id: "pr:53", prNumber: 53, mergeStateStatus: "BEHIND" });
+
+    const events: WorkItemEvent[] = [];
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => [
+        makePRStatus({ number: 52, mergeStateStatus: "UNKNOWN", autoMergeEnabled: false }),
+        makePRStatus({ number: 53, mergeStateStatus: "BEHIND", autoMergeEnabled: true }),
+      ],
+      detectRepo: async () => TEST_REPO,
+      onEvent: (e) => events.push(e),
+    });
+
+    await poller.poll();
+
+    const unknownEvt = events.find((e) => e.type === "pr:merge_state_changed" && e.prNumber === 52);
+    expect(unknownEvt?.type === "pr:merge_state_changed" && unknownEvt.cascadeHead).toBeNull();
+  });
+
+  test("cascadeHead is null on HAS_HOOKS transition", async () => {
+    db.createWorkItem({ id: "pr:54", prNumber: 54, mergeStateStatus: "BEHIND" });
+    db.createWorkItem({ id: "pr:55", prNumber: 55, mergeStateStatus: "UNKNOWN" });
+
+    const events: WorkItemEvent[] = [];
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => [
+        makePRStatus({ number: 54, mergeStateStatus: "HAS_HOOKS", autoMergeEnabled: true }),
+        makePRStatus({ number: 55, mergeStateStatus: "BEHIND", autoMergeEnabled: true }),
+      ],
+      detectRepo: async () => TEST_REPO,
+      onEvent: (e) => events.push(e),
+    });
+
+    await poller.poll();
+
+    const hooksEvt = events.find((e) => e.type === "pr:merge_state_changed" && e.prNumber === 54);
+    expect(hooksEvt?.type === "pr:merge_state_changed" && hooksEvt.cascadeHead).toBeNull();
+  });
+
+  test("cascadeHead is null on UNSTABLE transition", async () => {
+    db.createWorkItem({ id: "pr:56", prNumber: 56, mergeStateStatus: "CLEAN" });
+
+    const events: WorkItemEvent[] = [];
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => [makePRStatus({ number: 56, mergeStateStatus: "UNSTABLE", autoMergeEnabled: true })],
+      detectRepo: async () => TEST_REPO,
+      onEvent: (e) => events.push(e),
+    });
+
+    await poller.poll();
+
+    const unstableEvt = events.find((e) => e.type === "pr:merge_state_changed");
+    expect(unstableEvt?.type === "pr:merge_state_changed" && unstableEvt.cascadeHead).toBeNull();
+  });
+
+  test("cascadeHead is non-null when PR transitions to BEHIND with auto-merge", async () => {
+    db.createWorkItem({ id: "pr:57", prNumber: 57, mergeStateStatus: "UNKNOWN" });
+
+    const events: WorkItemEvent[] = [];
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => [makePRStatus({ number: 57, mergeStateStatus: "BEHIND", autoMergeEnabled: true })],
+      detectRepo: async () => TEST_REPO,
+      onEvent: (e) => events.push(e),
+    });
+
+    await poller.poll();
+
+    const behindEvt = events.find((e) => e.type === "pr:merge_state_changed");
+    expect(behindEvt?.type === "pr:merge_state_changed" && behindEvt.cascadeHead).toBe(57);
+  });
+
   // ── Phase 2 enrichment (#1576) ──
 
   test("pr:opened carries branch, base, commits, srcChurn", async () => {

--- a/packages/daemon/src/github/work-item-poller.ts
+++ b/packages/daemon/src/github/work-item-poller.ts
@@ -279,12 +279,16 @@ export class WorkItemPoller {
     if (newMergeState !== (item.mergeStateStatus ?? null)) {
       patch.mergeStateStatus = newMergeState;
       changed = true;
+      // Only propagate cascadeHead when the new state is actionable (CLEAN or BEHIND with
+      // auto-merge armed). Non-actionable transitions (DIRTY, UNKNOWN, HAS_HOOKS, UNSTABLE)
+      // must not carry a cascadeHead or orchestrators may issue spurious update-branch calls.
+      const isActionable = (newMergeState === "CLEAN" || newMergeState === "BEHIND") && status.autoMergeEnabled;
       this.onEvent({
         type: "pr:merge_state_changed",
         prNumber,
         from: item.mergeStateStatus ?? null,
         to: newMergeState,
-        cascadeHead,
+        cascadeHead: isActionable ? cascadeHead : null,
       });
     }
 

--- a/packages/daemon/src/github/work-item-poller.ts
+++ b/packages/daemon/src/github/work-item-poller.ts
@@ -280,7 +280,7 @@ export class WorkItemPoller {
       patch.mergeStateStatus = newMergeState;
       changed = true;
       // Only propagate cascadeHead when the new state is actionable (CLEAN or BEHIND with
-      // auto-merge armed). Non-actionable transitions (DIRTY, UNKNOWN, HAS_HOOKS, UNSTABLE)
+      // auto-merge armed). Non-actionable transitions (DIRTY, UNKNOWN, HAS_HOOKS, UNSTABLE, BLOCKED)
       // must not carry a cascadeHead or orchestrators may issue spurious update-branch calls.
       const isActionable = (newMergeState === "CLEAN" || newMergeState === "BEHIND") && status.autoMergeEnabled;
       this.onEvent({


### PR DESCRIPTION
## Summary
- `pr:merge_state_changed` events now emit `cascadeHead: null` when the transitioning PR's new merge state is not actionable (`DIRTY`, `UNKNOWN`, `HAS_HOOKS`, `UNSTABLE`)
- `cascadeHead` is only non-null when the new state is `CLEAN` or `BEHIND` **and** the PR has auto-merge enabled
- Prevents orchestrators from issuing spurious `update-branch` calls during CI churn (e.g., `BEHIND→DIRTY` transitions)

## Test plan
- [x] `cascadeHead is null on non-actionable DIRTY transition` — even when another PR is CLEAN/BEHIND and would be the cascade head
- [x] `cascadeHead is null on null→UNKNOWN transition`
- [x] `cascadeHead is null on HAS_HOOKS transition`
- [x] `cascadeHead is null on UNSTABLE transition`
- [x] `cascadeHead is non-null when PR transitions to BEHIND with auto-merge` — confirms the happy path still works
- [x] All existing cascadeHead tests pass unchanged (BEHIND→CLEAN, multi-PR CLEAN selection, no-auto-merge null)
- [x] Full test suite: 5786 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)