### PR TITLE
ci: upgrade actions/upload-artifact from v4 to v7 (fixes #1656)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           fi
       - name: Upload test logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bun-test-logs-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/test_*.txt
@@ -137,7 +137,7 @@ jobs:
           fi
       - name: Upload coverage logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: bun-coverage-logs-${{ github.run_id }}-${{ github.run_attempt }}
           path: /tmp/coverage_*.txt


### PR DESCRIPTION
## Summary
- Upgrades `actions/upload-artifact` from `@v4` to `@v7` in both the `check` and `coverage` jobs
- `@v7` (released 2026-04-10) runs on Node.js 24, eliminating the GitHub deprecation warning
- No behavioral changes — same artifact names, retention, and `if-no-files-found: ignore` settings

## Test plan
- [ ] CI passes on this PR (upload-artifact steps complete without Node.js 20 deprecation warning)
- [ ] Artifacts `bun-test-logs-*` and `bun-coverage-logs-*` are uploaded successfully under the new action version

🤖 Generated with [Claude Code](https://claude.com/claude-code)