### PR TITLE
fix(monitor): use current-time sentinel for missing updatedAt in cascade-head FIFO (fixes #1698)

### DIFF
--- a/packages/daemon/src/github/cascade-head.spec.ts
+++ b/packages/daemon/src/github/cascade-head.spec.ts
@@ -96,9 +96,10 @@ describe("computeCascadeHead", () => {
 
   test("PR with current-time sentinel updatedAt loses FIFO to legitimately older PRs", () => {
     // Simulates a PR whose updatedAt was missing and got the now() fallback.
-    const nowSentinel = new Date(Date.now()).toISOString();
+    const older = new Date(Date.now() - 60_000).toISOString().replace(/\.\d{3}Z$/, "Z");
+    const nowSentinel = new Date(Date.now()).toISOString().replace(/\.\d{3}Z$/, "Z");
     const prs = [
-      pr(1, "BEHIND", true, "2024-01-01T00:00:00Z"), // oldest — should win
+      pr(1, "BEHIND", true, older), // legitimately older — should win
       pr(2, "BEHIND", true, nowSentinel), // missing updatedAt fallback — should lose
     ];
     expect(computeCascadeHead(prs)).toBe(1);

--- a/packages/daemon/src/github/cascade-head.spec.ts
+++ b/packages/daemon/src/github/cascade-head.spec.ts
@@ -93,4 +93,14 @@ describe("computeCascadeHead", () => {
     const prs = [pr(1, "UNSTABLE", true, "2024-01-01T00:00:00Z"), pr(2, "BEHIND", true, "2024-01-01T00:01:00Z")];
     expect(computeCascadeHead(prs)).toBe(2);
   });
+
+  test("PR with current-time sentinel updatedAt loses FIFO to legitimately older PRs", () => {
+    // Simulates a PR whose updatedAt was missing and got the now() fallback.
+    const nowSentinel = new Date(Date.now()).toISOString();
+    const prs = [
+      pr(1, "BEHIND", true, "2024-01-01T00:00:00Z"), // oldest — should win
+      pr(2, "BEHIND", true, nowSentinel), // missing updatedAt fallback — should lose
+    ];
+    expect(computeCascadeHead(prs)).toBe(1);
+  });
 });

--- a/packages/daemon/src/github/graphql-client.spec.ts
+++ b/packages/daemon/src/github/graphql-client.spec.ts
@@ -345,6 +345,33 @@ describe("fetchTrackedPRs", () => {
     expect(result[0].files).toHaveLength(100);
   });
 
+  test("updatedAt missing falls back to current time, not epoch", async () => {
+    const before = new Date(Date.now() - 1000).toISOString();
+    const body = {
+      data: {
+        repository: {
+          pr20: {
+            number: 20,
+            state: "OPEN",
+            isDraft: false,
+            mergeable: "UNKNOWN",
+            // updatedAt intentionally absent
+            commits: { nodes: [] },
+            reviews: { nodes: [] },
+          },
+        },
+      },
+    };
+
+    const result = await fetchTrackedPRs(repo, [20], { getToken: mockGetToken, fetch: mockFetch(body) });
+
+    expect(result).toHaveLength(1);
+    const after = new Date(Date.now() + 1000).toISOString();
+    expect(result[0].updatedAt > before).toBe(true);
+    expect(result[0].updatedAt < after).toBe(true);
+    expect(result[0].updatedAt).not.toBe(new Date(0).toISOString());
+  });
+
   test("logs warning when rateLimit.remaining drops below 500", async () => {
     const body = {
       data: {

--- a/packages/daemon/src/github/graphql-client.spec.ts
+++ b/packages/daemon/src/github/graphql-client.spec.ts
@@ -346,7 +346,7 @@ describe("fetchTrackedPRs", () => {
   });
 
   test("updatedAt missing falls back to current time, not epoch", async () => {
-    const before = new Date(Date.now() - 1000).toISOString();
+    const before = Date.now() - 1000;
     const body = {
       data: {
         repository: {
@@ -366,10 +366,11 @@ describe("fetchTrackedPRs", () => {
     const result = await fetchTrackedPRs(repo, [20], { getToken: mockGetToken, fetch: mockFetch(body) });
 
     expect(result).toHaveLength(1);
-    const after = new Date(Date.now() + 1000).toISOString();
-    expect(result[0].updatedAt > before).toBe(true);
-    expect(result[0].updatedAt < after).toBe(true);
-    expect(result[0].updatedAt).not.toBe(new Date(0).toISOString());
+    const after = Date.now() + 1000;
+    const updatedAtMs = Date.parse(result[0].updatedAt);
+    expect(updatedAtMs).toBeGreaterThan(before);
+    expect(updatedAtMs).toBeLessThan(after);
+    expect(updatedAtMs).not.toBe(0); // not epoch
   });
 
   test("logs warning when rateLimit.remaining drops below 500", async () => {

--- a/packages/daemon/src/github/graphql-client.ts
+++ b/packages/daemon/src/github/graphql-client.ts
@@ -213,7 +213,7 @@ function parsePR(raw: RawPR): PRStatus {
     mergeable: (raw.mergeable as PRStatus["mergeable"]) ?? "UNKNOWN",
     mergeStateStatus: (raw.mergeStateStatus as MergeStateStatus) ?? "UNKNOWN",
     autoMergeEnabled: raw.autoMergeRequest != null,
-    updatedAt: raw.updatedAt ?? new Date(0).toISOString(),
+    updatedAt: raw.updatedAt ?? new Date(Date.now()).toISOString(),
     ciState: rollup?.state ?? null,
     ciChecks,
     reviews,

--- a/packages/daemon/src/github/graphql-client.ts
+++ b/packages/daemon/src/github/graphql-client.ts
@@ -213,7 +213,7 @@ function parsePR(raw: RawPR): PRStatus {
     mergeable: (raw.mergeable as PRStatus["mergeable"]) ?? "UNKNOWN",
     mergeStateStatus: (raw.mergeStateStatus as MergeStateStatus) ?? "UNKNOWN",
     autoMergeEnabled: raw.autoMergeRequest != null,
-    updatedAt: raw.updatedAt ?? new Date(Date.now()).toISOString(),
+    updatedAt: raw.updatedAt ?? new Date(Date.now()).toISOString().replace(/\.\d{3}Z$/, "Z"),
     ciState: rollup?.state ?? null,
     ciChecks,
     reviews,


### PR DESCRIPTION
## Summary
- Replace epoch fallback (`new Date(0)`) with current-time sentinel (`new Date(Date.now())`) for missing `updatedAt` in `graphql-client.ts`
- Epoch caused PRs with missing `updatedAt` to permanently win FIFO ordering in cascade-head selection; current-time sorts them last instead
- Added tests covering the fallback behavior in both `graphql-client.spec.ts` and `cascade-head.spec.ts`

## Test plan
- [x] `updatedAt missing falls back to current time, not epoch` — verifies the fallback timestamp is near-now, not 1970
- [x] `PR with current-time sentinel updatedAt loses FIFO to legitimately older PRs` — verifies cascade ordering is correct
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] Full test suite: 5810 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)