### PR TITLE
fix(sites): validate browser.profileDir is absolute or ~/… before use (fixes #1678)

### DIFF
--- a/packages/daemon/src/site-worker.ts
+++ b/packages/daemon/src/site-worker.ts
@@ -17,7 +17,6 @@
 
 import { existsSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
-import { isAbsolute } from "node:path";
 import { SITE_SERVER_NAME } from "@mcp-cli/core";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
@@ -31,6 +30,7 @@ import {
   getSiteForDomain,
   listSites,
   resolveSiteAsset,
+  validateProfileDir,
   validateSiteName,
   writeSiteConfig,
 } from "./site/config";
@@ -116,9 +116,7 @@ async function loadBrowser(engine: BrowserEngineName): Promise<BrowserEngine> {
 function resolveProfileDir(cfg: SiteConfig): string {
   const raw = cfg.browser?.profileDir;
   if (raw) {
-    if (!isAbsolute(raw) && !raw.startsWith("~/")) {
-      throw new Error(`browser.profileDir must be an absolute path or start with ~/; got: ${raw}`);
-    }
+    validateProfileDir(raw);
     return raw.startsWith("~/") ? raw.replace("~", homedir()) : raw;
   }
   const profile = cfg.browser?.chromeProfile ?? "default";

--- a/packages/daemon/src/site/config.spec.ts
+++ b/packages/daemon/src/site/config.spec.ts
@@ -66,6 +66,12 @@ describe("validateProfileDir", () => {
     expect(() => validateProfileDir("../sibling")).toThrow(/must be an absolute path or start with ~\//);
     expect(() => validateProfileDir("./local")).toThrow(/must be an absolute path or start with ~\//);
   });
+
+  test("rejects non-string input with a clear Error (not TypeError)", () => {
+    expect(() => validateProfileDir(42 as unknown as string)).toThrow(/must be a non-empty string/);
+    expect(() => validateProfileDir(null as unknown as string)).toThrow(/must be a non-empty string/);
+    expect(() => validateProfileDir(undefined as unknown as string)).toThrow(/must be a non-empty string/);
+  });
 });
 
 describe("writeSiteConfig validates name", () => {

--- a/packages/daemon/src/site/config.spec.ts
+++ b/packages/daemon/src/site/config.spec.ts
@@ -3,7 +3,15 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { _restoreOptions, options } from "@mcp-cli/core";
-import { domainMatches, getSite, getSiteForDomain, listSites, validateSiteName, writeSiteConfig } from "./config";
+import {
+  domainMatches,
+  getSite,
+  getSiteForDomain,
+  listSites,
+  validateProfileDir,
+  validateSiteName,
+  writeSiteConfig,
+} from "./config";
 
 let tmp: string;
 
@@ -42,9 +50,54 @@ describe("validateSiteName", () => {
   });
 });
 
+describe("validateProfileDir", () => {
+  test("accepts absolute paths", () => {
+    expect(() => validateProfileDir("/tmp/shared-profile")).not.toThrow();
+    expect(() => validateProfileDir("/home/user/.chrome")).not.toThrow();
+  });
+
+  test("accepts tilde-prefixed paths", () => {
+    expect(() => validateProfileDir("~/shared-profile")).not.toThrow();
+    expect(() => validateProfileDir("~/.mcp-cli/chrome")).not.toThrow();
+  });
+
+  test("rejects relative paths", () => {
+    expect(() => validateProfileDir("shared-profile")).toThrow(/must be an absolute path or start with ~\//);
+    expect(() => validateProfileDir("../sibling")).toThrow(/must be an absolute path or start with ~\//);
+    expect(() => validateProfileDir("./local")).toThrow(/must be an absolute path or start with ~\//);
+  });
+});
+
 describe("writeSiteConfig validates name", () => {
   test("rejects path-traversal names before touching disk", () => {
     expect(() => writeSiteConfig("../escape", { url: "https://x" })).toThrow(/Invalid site name/);
+  });
+
+  test("rejects relative browser.profileDir at write time", () => {
+    expect(() =>
+      writeSiteConfig("example", {
+        url: "https://example.com",
+        browser: { profileDir: "relative/path" },
+      }),
+    ).toThrow(/must be an absolute path or start with ~\//);
+  });
+
+  test("accepts absolute browser.profileDir at write time", () => {
+    expect(() =>
+      writeSiteConfig("example", {
+        url: "https://example.com",
+        browser: { profileDir: "/tmp/chrome-profile" },
+      }),
+    ).not.toThrow();
+  });
+
+  test("accepts tilde-prefixed browser.profileDir at write time", () => {
+    expect(() =>
+      writeSiteConfig("example2", {
+        url: "https://example2.com",
+        browser: { profileDir: "~/.mcp-cli/shared" },
+      }),
+    ).not.toThrow();
   });
 });
 

--- a/packages/daemon/src/site/config.ts
+++ b/packages/daemon/src/site/config.ts
@@ -26,6 +26,9 @@ export function validateSiteName(name: string): void {
 
 /** Reject browser.profileDir values that are not absolute or ~/…-relative. */
 export function validateProfileDir(raw: string): void {
+  if (typeof raw !== "string" || raw.length === 0) {
+    throw new Error(`browser.profileDir must be a non-empty string; got: ${typeof raw}`);
+  }
   if (!isAbsolute(raw) && !raw.startsWith("~/")) {
     throw new Error(`browser.profileDir must be an absolute path or start with ~/; got: ${raw}`);
   }

--- a/packages/daemon/src/site/config.ts
+++ b/packages/daemon/src/site/config.ts
@@ -8,7 +8,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join } from "node:path";
 import { siteConfigPath, sitePath, sitesDir } from "./paths";
 import { BUILTIN_SEEDS } from "./seeds";
 
@@ -21,6 +21,13 @@ export function validateSiteName(name: string): void {
     throw new Error(
       `Invalid site name '${name}'. Must be alphanumeric (plus -/_), 1–64 chars, and start with a letter or digit.`,
     );
+  }
+}
+
+/** Reject browser.profileDir values that are not absolute or ~/…-relative. */
+export function validateProfileDir(raw: string): void {
+  if (!isAbsolute(raw) && !raw.startsWith("~/")) {
+    throw new Error(`browser.profileDir must be an absolute path or start with ~/; got: ${raw}`);
   }
 }
 
@@ -129,6 +136,9 @@ export function getSite(name: string): SiteConfig | null {
 /** Write (or overwrite) a site's user config. Creates the directory if needed. */
 export function writeSiteConfig(name: string, config: PartialSiteConfig): void {
   validateSiteName(name);
+  if (config.browser?.profileDir !== undefined) {
+    validateProfileDir(config.browser.profileDir);
+  }
   const path = siteConfigPath(name);
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, JSON.stringify(config, null, 2));


### PR DESCRIPTION
## Summary
- Exports `validateProfileDir()` from `site/config.ts` as a shared, testable validator
- Adds write-time validation in `writeSiteConfig()` so a relative `profileDir` is rejected immediately (before the config is persisted), not only when the browser starts
- Refactors `resolveProfileDir()` in `site-worker.ts` to call the shared validator instead of duplicating the check

## Test plan
- [ ] `validateProfileDir()` unit tests: accepts `/absolute`, `~/tilde` paths; rejects `relative`, `../sibling`, `./local`
- [ ] `writeSiteConfig()` write-time validation tests: relative `profileDir` throws before touching disk; absolute and tilde paths accepted without error
- [ ] `bun typecheck` passes
- [ ] `bun lint` passes
- [ ] `bun test` — 5814 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)