### PR TITLE
fix(sites): assign browser only after eng.start() succeeds (fixes #1705)

### DIFF
--- a/packages/daemon/src/site-worker.ts
+++ b/packages/daemon/src/site-worker.ts
@@ -96,9 +96,7 @@ async function loadBrowser(engine: BrowserEngineName): Promise<BrowserEngine> {
   if (engine === "playwright") {
     try {
       const mod = await import("./site/browser/playwright");
-      browser = new mod.PlaywrightBrowserEngine();
-      browserEngineName = "playwright";
-      return browser;
+      return new mod.PlaywrightBrowserEngine();
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (/Cannot find (module|package)|ERR_MODULE_NOT_FOUND|Module not found/.test(msg)) {
@@ -337,6 +335,10 @@ async function handleBrowserStart(args: Record<string, unknown>): Promise<ToolRe
     const eng = await loadBrowser(engine);
     const specs = sites.map(siteSpecFor);
     const startResults = await withDeadline(60_000, "browser start", eng.start(specs, sniffer.asEvents()));
+    // Assign globals only after start() succeeds so a failed/timed-out start
+    // never leaves browser pointing at an unstarted engine.
+    browser = eng;
+    browserEngineName = engine;
     for (const s of sites) sitesOpenInBrowser.add(s.name);
 
     return ok({ ok: true, engine, sites: eng.getSiteNames(), results: startResults });

--- a/packages/daemon/src/site-worker.ts
+++ b/packages/daemon/src/site-worker.ts
@@ -340,7 +340,7 @@ async function handleBrowserStart(args: Record<string, unknown>): Promise<ToolRe
     } catch (err) {
       // eng.start() timed out or threw — stop the partially-launched process so
       // it doesn't leak, then re-throw so browser stays null.
-      await eng.stop().catch(() => {});
+      await withDeadline(5_000, "browser stop on failed start", eng.stop()).catch(() => {});
       throw err;
     }
     // Assign globals only after start() succeeds so a failed/timed-out start

--- a/packages/daemon/src/site-worker.ts
+++ b/packages/daemon/src/site-worker.ts
@@ -334,7 +334,15 @@ async function handleBrowserStart(args: Record<string, unknown>): Promise<ToolRe
 
     const eng = await loadBrowser(engine);
     const specs = sites.map(siteSpecFor);
-    const startResults = await withDeadline(60_000, "browser start", eng.start(specs, sniffer.asEvents()));
+    let startResults;
+    try {
+      startResults = await withDeadline(60_000, "browser start", eng.start(specs, sniffer.asEvents()));
+    } catch (err) {
+      // eng.start() timed out or threw — stop the partially-launched process so
+      // it doesn't leak, then re-throw so browser stays null.
+      await eng.stop().catch(() => {});
+      throw err;
+    }
     // Assign globals only after start() succeeds so a failed/timed-out start
     // never leaves browser pointing at an unstarted engine.
     browser = eng;

--- a/packages/daemon/src/site-worker.ts
+++ b/packages/daemon/src/site-worker.ts
@@ -22,7 +22,7 @@ import { SITE_SERVER_NAME } from "@mcp-cli/core";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { createBrowserLock, withDeadline } from "./site/browser-lock";
-import type { BrowserEngine, BrowserEngineName, SiteSpec } from "./site/browser/engine";
+import type { BrowserEngine, BrowserEngineName, SiteSpec, StartSiteResult } from "./site/browser/engine";
 import { removeCall as catalogRemoveCall, upsertCall as catalogUpsertCall, loadCatalog } from "./site/catalog";
 import {
   type SiteConfig,
@@ -334,7 +334,7 @@ async function handleBrowserStart(args: Record<string, unknown>): Promise<ToolRe
 
     const eng = await loadBrowser(engine);
     const specs = sites.map(siteSpecFor);
-    let startResults;
+    let startResults: StartSiteResult[];
     try {
       startResults = await withDeadline(60_000, "browser start", eng.start(specs, sniffer.asEvents()));
     } catch (err) {

--- a/packages/daemon/src/site/browser-lock.spec.ts
+++ b/packages/daemon/src/site/browser-lock.spec.ts
@@ -116,7 +116,7 @@ describe("createBrowserLock", () => {
 
     class FakeEngine {}
     const fakeEngine = new FakeEngine();
-    let browserRef: FakeEngine | null = null;
+    const browserRef: FakeEngine | null = null;
 
     // Simulate handleBrowserStart where eng.start() throws.
     await expect(

--- a/packages/daemon/src/site/browser-lock.spec.ts
+++ b/packages/daemon/src/site/browser-lock.spec.ts
@@ -116,7 +116,7 @@ describe("createBrowserLock", () => {
 
     class FakeEngine {}
     const fakeEngine = new FakeEngine();
-    const browserRef: FakeEngine | null = null;
+    let browserRef: FakeEngine | null = null;
 
     // Simulate handleBrowserStart where eng.start() throws.
     await expect(

--- a/packages/daemon/src/site/browser-lock.spec.ts
+++ b/packages/daemon/src/site/browser-lock.spec.ts
@@ -116,18 +116,28 @@ describe("createBrowserLock", () => {
 
     class FakeEngine {}
     const fakeEngine = new FakeEngine();
-    const browserRef: FakeEngine | null = null;
+    let browserRef: FakeEngine | null = null;
 
-    // Simulate handleBrowserStart where eng.start() throws.
+    // Success path: confirm browserRef can be assigned (models a prior successful start).
+    await withLock(async () => {
+      browserRef = fakeEngine;
+    });
+    expect(browserRef === fakeEngine).toBe(true);
+
+    // Reset to null to model a fresh browser-start attempt after a disconnect.
+    browserRef = null;
+
+    // Simulate handleBrowserStart where eng.start() throws before assignment.
     await expect(
       withLock(async () => {
         const eng = fakeEngine; // loadBrowser returns engine without setting browserRef
         void eng; // would call eng.start() here
         throw new Error("start timed out");
-        // browserRef is never assigned
+        // browserRef is never assigned — production code only assigns after start() resolves
       }),
     ).rejects.toThrow("start timed out");
 
+    // Failed start leaves browserRef null — the core invariant of #1705.
     expect(browserRef).toBeNull();
 
     // Lock is released; next caller can proceed.

--- a/packages/daemon/src/site/browser-lock.spec.ts
+++ b/packages/daemon/src/site/browser-lock.spec.ts
@@ -58,10 +58,10 @@ describe("createBrowserLock", () => {
     expect(result).toBe("ok");
   });
 
-  test("models the reset-during-start race: observer cannot clear browser while start holds the lock", async () => {
+  test("models the assign-after-start pattern: browser ref is null until start() resolves", async () => {
     const withLock = createBrowserLock();
 
-    // Simulate module-level state.
+    // Simulate module-level state (fixed pattern from #1705).
     let isRunning = false;
     class FakeEngine {}
     const fakeEngine = new FakeEngine();
@@ -73,7 +73,8 @@ describe("createBrowserLock", () => {
       }
     }
 
-    // Simulate handleBrowserStart holding the lock across the async start.
+    // Simulate handleBrowserStart: eng is created by loadBrowser (local only),
+    // browserRef is assigned only after eng.start() resolves.
     let resolveStart!: () => void;
     const startDone = new Promise<void>((r) => {
       resolveStart = r;
@@ -81,9 +82,10 @@ describe("createBrowserLock", () => {
 
     const startTask = withLock(async () => {
       resetIfDied();
-      browserRef = fakeEngine; // loadBrowser assigns the ref
-      await startDone; // eng.start() — async gap where observer would race
+      const eng = fakeEngine; // loadBrowser returns engine without setting browserRef
+      await startDone; // eng.start()
       isRunning = true;
+      browserRef = eng; // assign only after start succeeds
     });
 
     // Yield so startTask acquires the lock.
@@ -95,20 +97,41 @@ describe("createBrowserLock", () => {
       return browserRef;
     });
 
-    // At this point startTask holds the lock; observerTask is queued.
-    // browserRef is truthy but isRunning is still false —
-    // without the lock the observer would clear browserRef here.
-    expect(browserRef === fakeEngine).toBe(true);
+    // startTask holds the lock; browserRef is still null during start().
+    expect(browserRef).toBeNull();
     expect(isRunning).toBe(false);
 
-    // Finish the start.
     resolveStart();
     await startTask;
 
     const observerSaw = await observerTask;
 
-    // isRunning=true by the time observer runs → reset does NOT fire.
+    // Observer runs after start completes; browserRef is set and isRunning=true.
     expect(observerSaw === fakeEngine).toBe(true);
     expect(browserRef === fakeEngine).toBe(true);
+  });
+
+  test("models start() failure: browser ref stays null when start throws", async () => {
+    const withLock = createBrowserLock();
+
+    class FakeEngine {}
+    const fakeEngine = new FakeEngine();
+    const browserRef: FakeEngine | null = null;
+
+    // Simulate handleBrowserStart where eng.start() throws.
+    await expect(
+      withLock(async () => {
+        const eng = fakeEngine; // loadBrowser returns engine without setting browserRef
+        void eng; // would call eng.start() here
+        throw new Error("start timed out");
+        // browserRef is never assigned
+      }),
+    ).rejects.toThrow("start timed out");
+
+    expect(browserRef).toBeNull();
+
+    // Lock is released; next caller can proceed.
+    const result = await withLock(async () => browserRef);
+    expect(result).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- `loadBrowser` previously assigned the module-level `browser` ref immediately on construction, before `eng.start()` was called in `handleBrowserStart`
- If `eng.start()` threw or timed out (via the `withDeadline` 60s guard from #1704), `browser` would be non-null but point at an unstarted engine — recovery then depended on `isRunning()` returning `false` for the pre-start window, an untested implicit contract
- Fixed by moving `browser` and `browserEngineName` assignments into `handleBrowserStart`, strictly after `eng.start()` resolves; a failed start leaves the ref null and the next call starts clean

## Test plan

- [ ] Updated `browser-lock.spec.ts` to model the corrected assign-after-start pattern (browserRef is null *during* start, set only after success)
- [ ] Added test verifying browserRef stays null when `start()` throws
- [ ] `bun typecheck` passes
- [ ] `bun lint` passes
- [ ] `bun test` — 5809 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)