### PR TITLE
fix(sites): validate chromeProfile in siteBrowserProfileDir (fixes #1677)

### DIFF
--- a/packages/daemon/src/site/paths.spec.ts
+++ b/packages/daemon/src/site/paths.spec.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { _restoreOptions, options } from "@mcp-cli/core";
+import { siteBrowserProfileDir } from "./paths";
+
+beforeEach(() => {
+  const tmp = join(tmpdir(), `mcp-cli-paths-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`);
+  options.SITES_DIR = join(tmp, "sites");
+});
+
+afterEach(() => {
+  _restoreOptions();
+});
+
+describe("siteBrowserProfileDir", () => {
+  test("accepts a simple profile name", () => {
+    expect(() => siteBrowserProfileDir("mysite", "default")).not.toThrow();
+    expect(() => siteBrowserProfileDir("mysite", "work")).not.toThrow();
+    expect(() => siteBrowserProfileDir("mysite", "profile-1")).not.toThrow();
+  });
+
+  test("returns a path under the site chromium directory", () => {
+    const dir = siteBrowserProfileDir("mysite", "default");
+    expect(dir).toMatch(/mysite[\\/]chromium[\\/]default/);
+  });
+
+  test("rejects profile containing forward slash", () => {
+    expect(() => siteBrowserProfileDir("mysite", "../../default")).toThrow(/Invalid chromeProfile/);
+    expect(() => siteBrowserProfileDir("mysite", "foo/bar")).toThrow(/Invalid chromeProfile/);
+  });
+
+  test("rejects profile containing backslash", () => {
+    expect(() => siteBrowserProfileDir("mysite", "foo\\bar")).toThrow(/Invalid chromeProfile/);
+  });
+
+  test("rejects profile that is '..' alone", () => {
+    expect(() => siteBrowserProfileDir("mysite", "..")).toThrow(/Invalid chromeProfile/);
+  });
+
+  test("error message mentions path separators and '..' segments", () => {
+    expect(() => siteBrowserProfileDir("mysite", "../../default")).toThrow(/no path separators or '\.\.'/);
+  });
+});

--- a/packages/daemon/src/site/paths.ts
+++ b/packages/daemon/src/site/paths.ts
@@ -33,11 +33,15 @@ export function siteCapturesDir(site: string): string {
   return join(sitePath(site), "captures");
 }
 
-export function siteBrowserProfileDir(site: string, profile: string): string {
-  if (/[/\\]/.test(profile) || profile.split("/").some((seg) => seg === "..")) {
+function validateChromeProfileName(profile: string): void {
+  if (/[/\\]/.test(profile) || profile === "..") {
     throw new Error(
       `Invalid chromeProfile: must be a simple name (no path separators or '..' segments); got: ${profile}`,
     );
   }
+}
+
+export function siteBrowserProfileDir(site: string, profile: string): string {
+  validateChromeProfileName(profile);
   return join(sitePath(site), "chromium", profile);
 }

--- a/packages/daemon/src/site/paths.ts
+++ b/packages/daemon/src/site/paths.ts
@@ -34,5 +34,10 @@ export function siteCapturesDir(site: string): string {
 }
 
 export function siteBrowserProfileDir(site: string, profile: string): string {
+  if (/[/\\]/.test(profile) || profile.split("/").some((seg) => seg === "..")) {
+    throw new Error(
+      `Invalid chromeProfile: must be a simple name (no path separators or '..' segments); got: ${profile}`,
+    );
+  }
   return join(sitePath(site), "chromium", profile);
 }


### PR DESCRIPTION
## Summary

- Adds path traversal validation directly in `siteBrowserProfileDir` (`packages/daemon/src/site/paths.ts`), at the point where `path.join` is called with the untrusted `chromeProfile` value
- Defense-in-depth: the existing check in `resolveProfileDir` (`site-worker.ts`) guards the primary call path, but any future caller that uses `siteBrowserProfileDir` directly would bypass it — this closes that gap
- Rejects profile values containing `/`, `\`, or bare `..` segments with a clear error: `Invalid chromeProfile: must be a simple name (no path separators or '..' segments)`

## Test plan

- [x] New `packages/daemon/src/site/paths.spec.ts` covers: simple names accepted, path returned under site chromium dir, forward slash rejected, backslash rejected, bare `..` rejected, error message content
- [x] All 5814 existing tests pass (`bun test`)
- [x] TypeScript clean (`bun typecheck`)
- [x] Lint clean (`bun lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)