### PR TITLE
fix(alias-bundle): use generic timeout message in evalBundledJs (fixes #1744)

### DIFF
--- a/packages/core/src/alias-bundle.ts
+++ b/packages/core/src/alias-bundle.ts
@@ -218,7 +218,7 @@ async function evalBundledJs(
     await Promise.race([
       fn(injected, coreBarrel),
       new Promise<never>((_, reject) => {
-        timer = setTimeout(() => reject(new Error("extractMetadata timed out")), timeoutMs);
+        timer = setTimeout(() => reject(new Error("Alias eval timed out")), timeoutMs);
       }),
     ]).finally(() => clearTimeout(timer));
   } else {


### PR DESCRIPTION
## Summary
- `evalBundledJs` had a hardcoded `"extractMetadata timed out"` error message even though it is now a shared helper called by `executeAliasBundled`, `validateAliasBundled`, `extractMonitorMetadata`, and `extractMetadata`
- Changed message to `"Alias eval timed out"` — accurate for all callers

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes — no changes needed
- [x] `bun test packages/core/src/alias-bundle.spec.ts` — all 54 tests pass
- [x] No existing tests asserted on the old error string

🤖 Generated with [Claude Code](https://claude.com/claude-code)