### PR TITLE
fix(monitor): gate session.response in ring-buffer fallback live path (fixes #1680)

### DIFF
--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -3455,6 +3455,111 @@ describe("IpcServer HTTP transport", () => {
     expect(events.every((e) => e.category === "session")).toBe(true);
     expect(events.find((e) => e.event === "mail.received")).toBeUndefined();
   });
+
+  test("ring-buffer: session.response excluded from live delivery without responseTail", async () => {
+    startServer();
+
+    const controller = new AbortController();
+    const res = await fetch("http://localhost/events", {
+      method: "GET",
+      unix: socketPath,
+      signal: controller.signal,
+    } as RequestInit);
+
+    expect(res.status).toBe(200);
+    if (!res.body) throw new Error("Expected response body");
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+
+    if (!server) throw new Error("server not started");
+    server.pushEvent({ event: "session.response", category: "session", sessionId: "s1", chunk: "secret" });
+    server.pushEvent({ event: "session.result", category: "session", sessionId: "s1" });
+
+    let buffer = "";
+    const deadline = Date.now() + 2_000;
+    while (Date.now() < deadline) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      if (buffer.includes("session.result")) break;
+    }
+
+    controller.abort();
+    reader.releaseLock();
+
+    expect(buffer).not.toContain("session.response");
+    expect(buffer).toContain("session.result");
+  });
+
+  test("ring-buffer: session.response included in live delivery when responseTail matches", async () => {
+    startServer();
+
+    const controller = new AbortController();
+    const res = await fetch("http://localhost/events?responseTail=s1", {
+      method: "GET",
+      unix: socketPath,
+      signal: controller.signal,
+    } as RequestInit);
+
+    expect(res.status).toBe(200);
+    if (!res.body) throw new Error("Expected response body");
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+
+    if (!server) throw new Error("server not started");
+    server.pushEvent({ event: "session.response", category: "session", sessionId: "s1", chunk: "hello" });
+    server.pushEvent({ event: "session.result", category: "session", sessionId: "s1" });
+
+    let buffer = "";
+    const deadline = Date.now() + 2_000;
+    while (Date.now() < deadline) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      if (buffer.includes("session.result")) break;
+    }
+
+    controller.abort();
+    reader.releaseLock();
+
+    expect(buffer).toContain("session.response");
+    expect(buffer).toContain("session.result");
+  });
+
+  test("ring-buffer: session.response excluded when responseTail is different session", async () => {
+    startServer();
+
+    const controller = new AbortController();
+    const res = await fetch("http://localhost/events?responseTail=other-session", {
+      method: "GET",
+      unix: socketPath,
+      signal: controller.signal,
+    } as RequestInit);
+
+    expect(res.status).toBe(200);
+    if (!res.body) throw new Error("Expected response body");
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+
+    if (!server) throw new Error("server not started");
+    server.pushEvent({ event: "session.response", category: "session", sessionId: "s1", chunk: "secret" });
+    server.pushEvent({ event: "session.result", category: "session", sessionId: "s1" });
+
+    let buffer = "";
+    const deadline = Date.now() + 2_000;
+    while (Date.now() < deadline) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      if (buffer.includes("session.result")) break;
+    }
+
+    controller.abort();
+    reader.releaseLock();
+
+    expect(buffer).not.toContain("session.response");
+    expect(buffer).toContain("session.result");
+  });
 });
 
 // ── buildEventFilter unit tests ──

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -1695,6 +1695,14 @@ export class IpcServer {
 
     // ── Ring-buffer fallback path (direct pushEvent(), no EventBus) ──
     const filter = buildEventFilter(url.searchParams);
+    const fallbackResponseTail = url.searchParams.get("responseTail");
+    const shouldDeliverFallback = (event: Record<string, unknown>) => {
+      if (filter !== null && !filter(event)) return false;
+      if (event.event === "session.response") {
+        return fallbackResponseTail !== null && event.sessionId === fallbackResponseTail;
+      }
+      return true;
+    };
     const capacity = IpcServer.EVENT_RING_CAPACITY;
     const ring: string[] = new Array(capacity);
     let writeIdx = 0;
@@ -1763,7 +1771,7 @@ export class IpcServer {
         // buffered during backfill and drained after to preserve ordering.
         let liveBuffer: Array<{ line: string; seq: number | undefined }> | null = null;
         const subscriber = (event: Record<string, unknown>) => {
-          if (filter && !filter(event)) return;
+          if (!shouldDeliverFallback(event)) return;
           const line = `${JSON.stringify(event)}\n`;
           const seq = typeof event.seq === "number" ? event.seq : undefined;
           if (liveBuffer !== null) {
@@ -1785,9 +1793,10 @@ export class IpcServer {
           while (true) {
             const batch = eventLog.getSince(cursor, 1000);
             for (const event of batch) {
+              highWaterMark = event.seq;
+              if (!shouldDeliverFallback(event as Record<string, unknown>)) continue;
               const line = `${JSON.stringify(event)}\n`;
               try {
-                highWaterMark = event.seq;
                 controller.enqueue(encoder.encode(line));
               } catch {
                 cleanup();


### PR DESCRIPTION
## Summary
- The ring-buffer fallback `/events` subscriber (used when no EventBus is present) previously only applied `buildEventFilter` but did not gate `session.response` events by `responseTail`, inconsistent with the EventBus path's `shouldDeliver` contract
- Introduces a `shouldDeliverFallback` predicate in the ring-buffer path that applies both the category filter and the `session.response`/`responseTail` gate
- Also applies the predicate defensively in the fallback backfill loop for consistency

## Test plan
- [x] 3 new ring-buffer path tests: excluded without `responseTail`, included when `responseTail` matches, excluded when `responseTail` is a different session
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] Full test suite: 5917 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)