### PR TITLE
fix(gc): use git branch -D for squash-merged branches with confirmed PRs (fixes #1748)

### DIFF
--- a/packages/command/src/commands/gc.spec.ts
+++ b/packages/command/src/commands/gc.spec.ts
@@ -64,6 +64,7 @@ function makeDeps(
     execFallback?: (cmd: string[]) => { stdout: string; stderr: string; exitCode: number };
     callTool?: GcDeps["callTool"];
     mtimes?: Map<string, number>;
+    mergedPrBranches?: Set<string> | null;
   } = {},
 ): GcDeps & { logs: string[]; errors: string[]; execCalls: string[][] } {
   const logs: string[] = [];
@@ -84,6 +85,7 @@ function makeDeps(
     callTool: overrides.callTool ?? (async () => "[]"),
     exec,
     getMtime: (p) => overrides.mtimes?.get(p) ?? null,
+    queryMergedPrBranches: () => (overrides.mergedPrBranches !== undefined ? overrides.mergedPrBranches : null),
     printError: (m) => errors.push(m),
     log: (m) => logs.push(m),
     logError: (m) => errors.push(m),
@@ -161,6 +163,63 @@ describe("runGc branches", () => {
     // Only "stale" — feat is checked out by /other
     expect(d.logs.some((l) => l.includes("would delete 1 merged"))).toBe(true);
     expect(d.logs.some((l) => l.includes("stale"))).toBe(true);
+  });
+
+  test("uses -D for branches with a merged PR (squash-merge support)", async () => {
+    const responses = new Map<string, { stdout: string; stderr?: string; exitCode?: number }>();
+    responses.set("git -C /repo worktree list --porcelain", { stdout: "" });
+    responses.set("git -C /repo symbolic-ref refs/remotes/origin/HEAD", { stdout: "refs/remotes/origin/main" });
+    responses.set("git -C /repo branch --merged main", { stdout: "* main\n  squashed\n  regular\n" });
+    responses.set("git -C /repo branch --show-current", { stdout: "main" });
+    responses.set("git -C /repo fetch --prune", { stdout: "" });
+    responses.set("git -C /repo branch -D squashed", { stdout: "Deleted branch squashed" });
+    responses.set("git -C /repo branch -d regular", { stdout: "Deleted branch regular" });
+
+    const d = makeDeps({
+      execResponses: responses,
+      mergedPrBranches: new Set(["squashed"]),
+    });
+    await runGc({ dryRun: false, olderThanMs: 86_400_000, branchesOnly: true, worktreesOnly: false }, d);
+
+    expect(d.execCalls.some((c) => c.join(" ") === "git -C /repo branch -D squashed")).toBe(true);
+    expect(d.execCalls.some((c) => c.join(" ") === "git -C /repo branch -d regular")).toBe(true);
+    expect(d.errors.some((l) => l.includes("branches: deleted 2"))).toBe(true);
+  });
+
+  test("falls back to -d with warning when GitHub API is unavailable", async () => {
+    const responses = new Map<string, { stdout: string; stderr?: string; exitCode?: number }>();
+    responses.set("git -C /repo worktree list --porcelain", { stdout: "" });
+    responses.set("git -C /repo symbolic-ref refs/remotes/origin/HEAD", { stdout: "refs/remotes/origin/main" });
+    responses.set("git -C /repo branch --merged main", { stdout: "* main\n  squashed\n" });
+    responses.set("git -C /repo branch --show-current", { stdout: "main" });
+    responses.set("git -C /repo fetch --prune", { stdout: "" });
+    responses.set("git -C /repo branch -d squashed", {
+      stdout: "",
+      stderr: "not fully merged",
+      exitCode: 1,
+    });
+
+    const d = makeDeps({ execResponses: responses, mergedPrBranches: null });
+    await runGc({ dryRun: false, olderThanMs: 86_400_000, branchesOnly: true, worktreesOnly: false }, d);
+
+    expect(d.errors.some((e) => e.includes("GitHub API unavailable"))).toBe(true);
+    // Falls back to -d (which fails for this squash-merged branch)
+    expect(d.execCalls.some((c) => c.join(" ") === "git -C /repo branch -d squashed")).toBe(true);
+    expect(d.execCalls.some((c) => c[4] === "-D")).toBe(false);
+    expect(d.errors.some((e) => e.includes("1 failed"))).toBe(true);
+  });
+
+  test("no API warning when there are no branch candidates", async () => {
+    const responses = new Map<string, { stdout: string }>();
+    responses.set("git -C /repo worktree list --porcelain", { stdout: "" });
+    responses.set("git -C /repo symbolic-ref refs/remotes/origin/HEAD", { stdout: "refs/remotes/origin/main" });
+    responses.set("git -C /repo branch --merged main", { stdout: "* main\n" });
+    responses.set("git -C /repo branch --show-current", { stdout: "main" });
+
+    const d = makeDeps({ execResponses: responses, mergedPrBranches: null });
+    await runGc({ dryRun: true, olderThanMs: 86_400_000, branchesOnly: true, worktreesOnly: false }, d);
+
+    expect(d.errors.some((e) => e.includes("GitHub API"))).toBe(false);
   });
 });
 

--- a/packages/command/src/commands/gc.ts
+++ b/packages/command/src/commands/gc.ts
@@ -94,6 +94,8 @@ export interface GcDeps extends WorktreeShimDeps {
   callTool: (tool: string, args: Record<string, unknown>) => Promise<unknown>;
   /** Returns mtime (ms since epoch) for the given path, or null if it can't be stat'd. */
   getMtime: (path: string) => number | null;
+  /** Returns branch names that have a merged PR on GitHub, or null if the API is unavailable. */
+  queryMergedPrBranches: (cwd: string) => Set<string> | null;
   log: (msg: string) => void;
   logError: (msg: string) => void;
 }
@@ -132,6 +134,19 @@ export function defaultGcDeps(): GcDeps {
       // works here (worktree paths are directories).
       try {
         return statSync(path).mtimeMs;
+      } catch {
+        return null;
+      }
+    },
+    queryMergedPrBranches: (cwd) => {
+      const result = Bun.spawnSync(
+        ["gh", "pr", "list", "--state", "merged", "--json", "headRefName", "--limit", "500"],
+        { stdout: "pipe", stderr: "pipe", cwd },
+      );
+      if (result.exitCode !== 0) return null;
+      try {
+        const prs = JSON.parse(result.stdout.toString()) as Array<{ headRefName: string }>;
+        return new Set(prs.map((pr) => pr.headRefName));
       } catch {
         return null;
       }
@@ -285,6 +300,13 @@ export async function runGc(opts: GcOptions, deps: GcDeps): Promise<void> {
       (b) => b !== defaultBranch && b !== current && !checkedOut.has(b) && !worktreeDeletedBranches.has(b),
     );
 
+    // Query GitHub for branches with merged PRs — enables force-delete for
+    // squash/rebase-merged branches where `git branch -d` fails.
+    const mergedPrBranches = candidates.length > 0 ? deps.queryMergedPrBranches(cwd) : null;
+    if (candidates.length > 0 && !mergedPrBranches) {
+      deps.logError("gc: GitHub API unavailable — squash-merged branches may not be cleaned");
+    }
+
     if (opts.dryRun) {
       deps.log(`${prefix}branches: would delete ${candidates.length} merged`);
       for (const b of candidates) deps.log(`  ${c.red}-${c.reset} ${b}`);
@@ -292,7 +314,9 @@ export async function runGc(opts: GcOptions, deps: GcDeps): Promise<void> {
       let deleted = 0;
       const failed: string[] = [];
       for (const b of candidates) {
-        const { exitCode, stderr } = deps.exec(["git", "-C", cwd, "branch", "-d", b]);
+        const prConfirmed = mergedPrBranches?.has(b) ?? false;
+        const flag = prConfirmed ? "-D" : "-d";
+        const { exitCode, stderr } = deps.exec(["git", "-C", cwd, "branch", flag, b]);
         if (exitCode === 0) {
           deleted++;
         } else {


### PR DESCRIPTION
## Summary
- Query GitHub API (`gh pr list --state merged`) before branch deletion to identify branches with confirmed merged PRs
- Use `git branch -D` (force) for PR-confirmed branches where `git branch -d` fails due to squash/rebase merge commit mismatch
- Fall back to `git branch -d` (safe) with a warning when the GitHub API is unavailable
- Skip the API query entirely when there are no branch candidates (no unnecessary API calls)

## Test plan
- [x] New test: squash-merged branch gets `-D` while non-PR branch gets `-d`
- [x] New test: API unavailable falls back to `-d` with warning message
- [x] New test: no API warning emitted when there are zero candidates
- [x] All 38 gc tests pass
- [x] Full suite: 5917 pass, 0 fail
- [x] `bun typecheck` clean
- [x] `bun lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)