### PR TITLE
fix(monitor): clean up copilot_comment_state rows when PR is terminal (fixes #1736)

### DIFF
--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -1684,6 +1684,11 @@ export class StateDb {
       .run(prNumber, hash);
   }
 
+  deleteCopilotCommentState(prNumber: number): boolean {
+    const result = this.db.run("DELETE FROM copilot_comment_state WHERE pr_number = ?", [prNumber]);
+    return result.changes > 0;
+  }
+
   close(): void {
     this.db.close();
   }

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -1684,8 +1684,8 @@ export class StateDb {
       .run(prNumber, hash);
   }
 
-  deleteCopilotCommentState(prNumber: number): boolean {
-    const result = this.db.run("DELETE FROM copilot_comment_state WHERE pr_number = ?", [prNumber]);
+  deleteCopilotCommentState(workItemNumber: number): boolean {
+    const result = this.db.run("DELETE FROM copilot_comment_state WHERE pr_number = ?", [workItemNumber]);
     return result.changes > 0;
   }
 

--- a/packages/daemon/src/github/copilot-poller.spec.ts
+++ b/packages/daemon/src/github/copilot-poller.spec.ts
@@ -125,8 +125,8 @@ function createStateDb(db: Database) {
            last_poll_ts = excluded.last_poll_ts`,
       ).run(prNumber, hash);
     },
-    deleteCopilotCommentState(prNumber: number): boolean {
-      const result = db.run("DELETE FROM copilot_comment_state WHERE pr_number = ?", [prNumber]);
+    deleteCopilotCommentState(workItemNumber: number): boolean {
+      const result = db.run("DELETE FROM copilot_comment_state WHERE pr_number = ?", [workItemNumber]);
       return result.changes > 0;
     },
   };
@@ -915,6 +915,16 @@ describe("CopilotPoller", () => {
       await poller.poll();
 
       expect(stateDb.getSeenCommentIds(55)).toEqual([]);
+    });
+
+    test("done-phase PR state row is deleted on next poll", async () => {
+      workItemDb.createWorkItem({ id: "wi:done-pr", prNumber: 88, prState: "open", phase: "done" });
+      stateDb.updateSeenCommentIds(88, [4001]);
+
+      const { poller } = makePoller();
+      await poller.poll();
+
+      expect(stateDb.getSeenCommentIds(88)).toEqual([]);
     });
 
     test("open PR state is preserved (dedup still works)", async () => {

--- a/packages/daemon/src/github/copilot-poller.spec.ts
+++ b/packages/daemon/src/github/copilot-poller.spec.ts
@@ -125,6 +125,10 @@ function createStateDb(db: Database) {
            last_poll_ts = excluded.last_poll_ts`,
       ).run(prNumber, hash);
     },
+    deleteCopilotCommentState(prNumber: number): boolean {
+      const result = db.run("DELETE FROM copilot_comment_state WHERE pr_number = ?", [prNumber]);
+      return result.changes > 0;
+    },
   };
 }
 
@@ -885,6 +889,68 @@ describe("CopilotPoller", () => {
       await poller.poll();
 
       expect(fetched).not.toContain(99);
+    });
+  });
+
+  // ── State cleanup on terminal PRs (#1736) ──
+
+  describe("copilot state cleanup", () => {
+    test("merged PR state row is deleted on next poll", async () => {
+      workItemDb.createWorkItem({ id: "wi:1", prNumber: 42, prState: "merged" });
+      stateDb.updateSeenCommentIds(42, [1001, 1002, 1003]);
+      stateDb.updateSeenReviewIds(42, [5001]);
+
+      const { poller } = makePoller();
+      await poller.poll();
+
+      expect(stateDb.getSeenCommentIds(42)).toEqual([]);
+      expect(stateDb.getSeenReviewIds(42)).toEqual([]);
+    });
+
+    test("closed PR state row is deleted on next poll", async () => {
+      workItemDb.createWorkItem({ id: "wi:2", prNumber: 55, prState: "closed" });
+      stateDb.updateSeenCommentIds(55, [2001]);
+
+      const { poller } = makePoller();
+      await poller.poll();
+
+      expect(stateDb.getSeenCommentIds(55)).toEqual([]);
+    });
+
+    test("open PR state is preserved (dedup still works)", async () => {
+      workItemDb.createWorkItem({ id: "wi:3", prNumber: 77, prState: "open" });
+      stateDb.updateSeenCommentIds(77, [3001]);
+
+      const { poller } = makePoller({
+        fetchComments: async () => okResult([makeComment({ id: 3001 }), makeComment({ id: 3002 })]),
+      });
+      await poller.poll();
+
+      const stored = stateDb.getSeenCommentIds(77);
+      expect(stored).toContain(3001);
+      expect(stored).toContain(3002);
+    });
+
+    test("done-phase issue state is deleted on next poll", async () => {
+      workItemDb.createWorkItem({ id: "#99", issueNumber: 99, prNumber: null, prState: null, phase: "done" });
+      stateDb.updateSeenIssueCommentIds(99, [8001, 8002]);
+
+      const { poller } = makePoller();
+      await poller.poll();
+
+      expect(stateDb.getSeenIssueCommentIds(99)).toEqual([]);
+    });
+
+    test("active issue state is preserved", async () => {
+      workItemDb.createWorkItem({ id: "#50", issueNumber: 50, prNumber: null, prState: null, phase: "impl" });
+      stateDb.updateSeenIssueCommentIds(50, [9001]);
+
+      const { poller } = makePoller({
+        fetchIssueComments: async () => okIssueCommentResult([makeIssueComment({ id: 9001 })]),
+      });
+      await poller.poll();
+
+      expect(stateDb.getSeenIssueCommentIds(50)).toContain(9001);
     });
   });
 });

--- a/packages/daemon/src/github/copilot-poller.ts
+++ b/packages/daemon/src/github/copilot-poller.ts
@@ -214,12 +214,13 @@ export class CopilotPoller {
       );
 
       for (const item of allItems) {
-        const prTerminal = item.prNumber !== null && (item.prState === "merged" || item.prState === "closed");
-        const issueTerminal = item.prNumber === null && item.issueNumber !== null && item.phase === "done";
-        if (prTerminal) {
-          this.stateDb.deleteCopilotCommentState(item.prNumber as number);
-        } else if (issueTerminal) {
-          this.stateDb.deleteCopilotCommentState(item.issueNumber as number);
+        if (
+          item.prNumber !== null &&
+          (item.prState === "merged" || item.prState === "closed" || item.phase === "done")
+        ) {
+          this.stateDb.deleteCopilotCommentState(item.prNumber);
+        } else if (item.prNumber === null && item.issueNumber !== null && item.phase === "done") {
+          this.stateDb.deleteCopilotCommentState(item.issueNumber);
         }
       }
 

--- a/packages/daemon/src/github/copilot-poller.ts
+++ b/packages/daemon/src/github/copilot-poller.ts
@@ -213,6 +213,16 @@ export class CopilotPoller {
         (item) => item.prNumber === null && item.issueNumber !== null && item.phase !== "done",
       );
 
+      for (const item of allItems) {
+        const prTerminal = item.prNumber !== null && (item.prState === "merged" || item.prState === "closed");
+        const issueTerminal = item.prNumber === null && item.issueNumber !== null && item.phase === "done";
+        if (prTerminal) {
+          this.stateDb.deleteCopilotCommentState(item.prNumber as number);
+        } else if (issueTerminal) {
+          this.stateDb.deleteCopilotCommentState(item.issueNumber as number);
+        }
+      }
+
       if (tracked.length === 0 && trackedIssues.length === 0) {
         this._lastError = null;
         this._pollCount++;


### PR DESCRIPTION
## Summary
- Adds `deleteCopilotCommentState(prNumber)` to `StateDb` — deletes the row from `copilot_comment_state` for a given PR/issue number
- CopilotPoller now calls this on every poll for work items whose PR is merged/closed or whose issue phase is `done`, preventing unbounded blob growth
- No schema migration, no blob format change — just row deletion when the data is no longer needed

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — all 5919 tests pass (5 new)
- [x] New tests verify: merged PR state deleted, closed PR state deleted, open PR state preserved (dedup holds), done-phase issue state deleted, active issue state preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)