### PR TITLE
feat(alias): wire AbortSignal cancellation into waitForEvent (fixes #1714)

### DIFF
--- a/packages/command/src/alias-runner.ts
+++ b/packages/command/src/alias-runner.ts
@@ -28,48 +28,57 @@ import {
 import type { z } from "zod/v4";
 
 export async function runAlias(aliasPath: string, cliArgs: Record<string, string>, jsonInput?: string): Promise<void> {
-  const mcpProxy = createMcpProxy({ cwd: () => process.cwd() });
+  const controller = new AbortController();
+  const onSigint = () => controller.abort();
+  process.once("SIGINT", onSigint);
 
-  // Defense-in-depth: verify the alias path is inside the aliases directory
-  const resolved = resolve(aliasPath);
-  if (!resolved.startsWith(`${options.ALIASES_DIR}/`)) {
-    throw new Error(`Refusing to execute alias outside aliases directory: ${resolved}`);
-  }
+  try {
+    const mcpProxy = createMcpProxy({ cwd: () => process.cwd() });
 
-  // Read the source to determine alias type
-  const source = await Bun.file(aliasPath).text();
-  const isStructured = isDefineAlias(source);
-
-  // Bundle the alias
-  const { js } = await bundleAlias(aliasPath);
-
-  // Derive alias name from filename (e.g. "my-alias.ts" → "my-alias")
-  const aliasName = basename(aliasPath, ".ts");
-
-  const repoRoot = findGitRoot() ?? NO_REPO_ROOT;
-  const ctx: AliasContext = {
-    mcp: mcpProxy,
-    args: cliArgs,
-    file: (path: string) => Bun.file(path).text(),
-    json: async (path: string) => JSON.parse(await Bun.file(path).text()),
-    cache: createAliasCache(aliasName),
-    state: createAliasState({ repoRoot, namespace: aliasUserNamespace(aliasName) }),
-    globalState: createAliasState({ repoRoot, namespace: GLOBAL_STATE_NAMESPACE }),
-    workItem: null,
-    waitForEvent: createWaitForEvent(),
-  };
-
-  if (isStructured) {
-    // Parse input for defineAlias handler
-    const input = parseAliasInput(undefined, jsonInput, cliArgs);
-    const output = await executeAliasBundled(js, input, ctx, true);
-    const formatted = formatAliasOutput(output);
-    if (formatted !== undefined) {
-      console.log(formatted);
+    // Defense-in-depth: verify the alias path is inside the aliases directory
+    const resolved = resolve(aliasPath);
+    if (!resolved.startsWith(`${options.ALIASES_DIR}/`)) {
+      throw new Error(`Refusing to execute alias outside aliases directory: ${resolved}`);
     }
-  } else {
-    // Freeform: side effects execute during eval
-    await executeAliasBundled(js, undefined, ctx, false);
+
+    // Read the source to determine alias type
+    const source = await Bun.file(aliasPath).text();
+    const isStructured = isDefineAlias(source);
+
+    // Bundle the alias
+    const { js } = await bundleAlias(aliasPath);
+
+    // Derive alias name from filename (e.g. "my-alias.ts" → "my-alias")
+    const aliasName = basename(aliasPath, ".ts");
+
+    const repoRoot = findGitRoot() ?? NO_REPO_ROOT;
+    const ctx: AliasContext = {
+      mcp: mcpProxy,
+      args: cliArgs,
+      file: (path: string) => Bun.file(path).text(),
+      json: async (path: string) => JSON.parse(await Bun.file(path).text()),
+      cache: createAliasCache(aliasName),
+      state: createAliasState({ repoRoot, namespace: aliasUserNamespace(aliasName) }),
+      globalState: createAliasState({ repoRoot, namespace: GLOBAL_STATE_NAMESPACE }),
+      workItem: null,
+      signal: controller.signal,
+      waitForEvent: createWaitForEvent(controller.signal),
+    };
+
+    if (isStructured) {
+      // Parse input for defineAlias handler
+      const input = parseAliasInput(undefined, jsonInput, cliArgs);
+      const output = await executeAliasBundled(js, input, ctx, true);
+      const formatted = formatAliasOutput(output);
+      if (formatted !== undefined) {
+        console.log(formatted);
+      }
+    } else {
+      // Freeform: side effects execute during eval
+      await executeAliasBundled(js, undefined, ctx, false);
+    }
+  } finally {
+    process.off("SIGINT", onSigint);
   }
 }
 

--- a/packages/command/src/alias-runner.ts
+++ b/packages/command/src/alias-runner.ts
@@ -29,8 +29,14 @@ import type { z } from "zod/v4";
 
 export async function runAlias(aliasPath: string, cliArgs: Record<string, string>, jsonInput?: string): Promise<void> {
   const controller = new AbortController();
-  const onSigint = () => controller.abort();
-  process.once("SIGINT", onSigint);
+  const onSignal = (sig: string) => {
+    controller.abort();
+    process.off("SIGINT", onSignal);
+    process.off("SIGTERM", onSignal);
+    process.kill(process.pid, sig);
+  };
+  process.once("SIGINT", onSignal);
+  process.once("SIGTERM", onSignal);
 
   try {
     const mcpProxy = createMcpProxy({ cwd: () => process.cwd() });
@@ -62,7 +68,7 @@ export async function runAlias(aliasPath: string, cliArgs: Record<string, string
       globalState: createAliasState({ repoRoot, namespace: GLOBAL_STATE_NAMESPACE }),
       workItem: null,
       signal: controller.signal,
-      waitForEvent: createWaitForEvent(controller.signal),
+      waitForEvent: createWaitForEvent({ signal: controller.signal }),
     };
 
     if (isStructured) {
@@ -78,7 +84,8 @@ export async function runAlias(aliasPath: string, cliArgs: Record<string, string
       await executeAliasBundled(js, undefined, ctx, false);
     }
   } finally {
-    process.off("SIGINT", onSigint);
+    process.off("SIGINT", onSignal);
+    process.off("SIGTERM", onSignal);
   }
 }
 

--- a/packages/command/src/alias-runner.ts
+++ b/packages/command/src/alias-runner.ts
@@ -29,14 +29,16 @@ import type { z } from "zod/v4";
 
 export async function runAlias(aliasPath: string, cliArgs: Record<string, string>, jsonInput?: string): Promise<void> {
   const controller = new AbortController();
-  const onSignal = (sig: string) => {
+  const onSignal = (sig: NodeJS.Signals) => {
     controller.abort();
-    process.off("SIGINT", onSignal);
-    process.off("SIGTERM", onSignal);
+    process.off("SIGINT", onInt);
+    process.off("SIGTERM", onTerm);
     process.kill(process.pid, sig);
   };
-  process.once("SIGINT", onSignal);
-  process.once("SIGTERM", onSignal);
+  const onInt = () => onSignal("SIGINT");
+  const onTerm = () => onSignal("SIGTERM");
+  process.once("SIGINT", onInt);
+  process.once("SIGTERM", onTerm);
 
   try {
     const mcpProxy = createMcpProxy({ cwd: () => process.cwd() });
@@ -84,8 +86,8 @@ export async function runAlias(aliasPath: string, cliArgs: Record<string, string
       await executeAliasBundled(js, undefined, ctx, false);
     }
   } finally {
-    process.off("SIGINT", onSignal);
-    process.off("SIGTERM", onSignal);
+    process.off("SIGINT", onInt);
+    process.off("SIGTERM", onTerm);
   }
 }
 

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -821,8 +821,14 @@ async function runPhase(argv: string[], d: PhaseInstallDeps): Promise<void> {
   const { js } = await d.bundleAlias(resolved);
 
   const controller = new AbortController();
-  const onSigint = () => controller.abort();
-  process.once("SIGINT", onSigint);
+  const onSignal = (sig: string) => {
+    controller.abort();
+    process.off("SIGINT", onSignal);
+    process.off("SIGTERM", onSignal);
+    process.kill(process.pid, sig);
+  };
+  process.once("SIGINT", onSignal);
+  process.once("SIGTERM", onSignal);
 
   const baseCtx: AliasContext = {
     mcp: {},
@@ -837,7 +843,7 @@ async function runPhase(argv: string[], d: PhaseInstallDeps): Promise<void> {
     globalState: {} as AliasStateAccessor, // overwritten by wrapDryRunContext
     workItem: null,
     signal: controller.signal,
-    waitForEvent: createWaitForEvent(controller.signal),
+    waitForEvent: createWaitForEvent({ signal: controller.signal }),
   };
   const ctx = wrapDryRunContext(baseCtx, (line) => d.log(line));
 
@@ -847,7 +853,8 @@ async function runPhase(argv: string[], d: PhaseInstallDeps): Promise<void> {
     d.logError(`phase "${name}" threw: ${err instanceof Error ? err.message : String(err)}`);
     d.exit(1);
   } finally {
-    process.off("SIGINT", onSigint);
+    process.off("SIGINT", onSignal);
+    process.off("SIGTERM", onSignal);
   }
 }
 
@@ -1126,8 +1133,14 @@ export async function executePhase(
     ? createAliasState({ repoRoot, namespace: `workitem:${workItem.id}`, call: ex.ipcCall })
     : createEphemeralState();
   const phaseController = new AbortController();
-  const onPhaseSigint = () => phaseController.abort();
-  process.once("SIGINT", onPhaseSigint);
+  const onPhaseSignal = (sig: string) => {
+    phaseController.abort();
+    process.off("SIGINT", onPhaseSignal);
+    process.off("SIGTERM", onPhaseSignal);
+    process.kill(process.pid, sig);
+  };
+  process.once("SIGINT", onPhaseSignal);
+  process.once("SIGTERM", onPhaseSignal);
 
   const ctx: AliasContext = {
     mcp: createMcpProxy({ call: ex.ipcCall, cwd }),
@@ -1139,7 +1152,7 @@ export async function executePhase(
     globalState: createAliasState({ repoRoot, namespace: GLOBAL_STATE_NAMESPACE, call: ex.ipcCall }),
     workItem,
     signal: phaseController.signal,
-    waitForEvent: createWaitForEvent(phaseController.signal),
+    waitForEvent: createWaitForEvent({ signal: phaseController.signal }),
   };
 
   let input: unknown;
@@ -1165,7 +1178,8 @@ export async function executePhase(
     d.logError(`phase "${parsed.target}" failed: ${err instanceof Error ? err.message : String(err)}`);
     d.exit(1);
   } finally {
-    process.off("SIGINT", onPhaseSigint);
+    process.off("SIGINT", onPhaseSignal);
+    process.off("SIGTERM", onPhaseSignal);
   }
 
   // Handler succeeded — commit the transition. Idempotent self-loop

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -821,14 +821,16 @@ async function runPhase(argv: string[], d: PhaseInstallDeps): Promise<void> {
   const { js } = await d.bundleAlias(resolved);
 
   const controller = new AbortController();
-  const onSignal = (sig: string) => {
+  const onSignal = (sig: NodeJS.Signals) => {
     controller.abort();
-    process.off("SIGINT", onSignal);
-    process.off("SIGTERM", onSignal);
+    process.off("SIGINT", onInt);
+    process.off("SIGTERM", onTerm);
     process.kill(process.pid, sig);
   };
-  process.once("SIGINT", onSignal);
-  process.once("SIGTERM", onSignal);
+  const onInt = () => onSignal("SIGINT");
+  const onTerm = () => onSignal("SIGTERM");
+  process.once("SIGINT", onInt);
+  process.once("SIGTERM", onTerm);
 
   const baseCtx: AliasContext = {
     mcp: {},
@@ -853,8 +855,8 @@ async function runPhase(argv: string[], d: PhaseInstallDeps): Promise<void> {
     d.logError(`phase "${name}" threw: ${err instanceof Error ? err.message : String(err)}`);
     d.exit(1);
   } finally {
-    process.off("SIGINT", onSignal);
-    process.off("SIGTERM", onSignal);
+    process.off("SIGINT", onInt);
+    process.off("SIGTERM", onTerm);
   }
 }
 
@@ -1133,14 +1135,16 @@ export async function executePhase(
     ? createAliasState({ repoRoot, namespace: `workitem:${workItem.id}`, call: ex.ipcCall })
     : createEphemeralState();
   const phaseController = new AbortController();
-  const onPhaseSignal = (sig: string) => {
+  const onPhaseSignal = (sig: NodeJS.Signals) => {
     phaseController.abort();
-    process.off("SIGINT", onPhaseSignal);
-    process.off("SIGTERM", onPhaseSignal);
+    process.off("SIGINT", onPhaseInt);
+    process.off("SIGTERM", onPhaseTerm);
     process.kill(process.pid, sig);
   };
-  process.once("SIGINT", onPhaseSignal);
-  process.once("SIGTERM", onPhaseSignal);
+  const onPhaseInt = () => onPhaseSignal("SIGINT");
+  const onPhaseTerm = () => onPhaseSignal("SIGTERM");
+  process.once("SIGINT", onPhaseInt);
+  process.once("SIGTERM", onPhaseTerm);
 
   const ctx: AliasContext = {
     mcp: createMcpProxy({ call: ex.ipcCall, cwd }),
@@ -1178,8 +1182,8 @@ export async function executePhase(
     d.logError(`phase "${parsed.target}" failed: ${err instanceof Error ? err.message : String(err)}`);
     d.exit(1);
   } finally {
-    process.off("SIGINT", onPhaseSignal);
-    process.off("SIGTERM", onPhaseSignal);
+    process.off("SIGINT", onPhaseInt);
+    process.off("SIGTERM", onPhaseTerm);
   }
 
   // Handler succeeded — commit the transition. Idempotent self-loop

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -820,6 +820,10 @@ async function runPhase(argv: string[], d: PhaseInstallDeps): Promise<void> {
 
   const { js } = await d.bundleAlias(resolved);
 
+  const controller = new AbortController();
+  const onSigint = () => controller.abort();
+  process.once("SIGINT", onSigint);
+
   const baseCtx: AliasContext = {
     mcp: {},
     args: extraArgs,
@@ -832,7 +836,8 @@ async function runPhase(argv: string[], d: PhaseInstallDeps): Promise<void> {
     state: {} as AliasStateAccessor, // overwritten by wrapDryRunContext
     globalState: {} as AliasStateAccessor, // overwritten by wrapDryRunContext
     workItem: null,
-    waitForEvent: createWaitForEvent(),
+    signal: controller.signal,
+    waitForEvent: createWaitForEvent(controller.signal),
   };
   const ctx = wrapDryRunContext(baseCtx, (line) => d.log(line));
 
@@ -841,6 +846,8 @@ async function runPhase(argv: string[], d: PhaseInstallDeps): Promise<void> {
   } catch (err) {
     d.logError(`phase "${name}" threw: ${err instanceof Error ? err.message : String(err)}`);
     d.exit(1);
+  } finally {
+    process.off("SIGINT", onSigint);
   }
 }
 
@@ -1118,6 +1125,10 @@ export async function executePhase(
   const state = workItem
     ? createAliasState({ repoRoot, namespace: `workitem:${workItem.id}`, call: ex.ipcCall })
     : createEphemeralState();
+  const phaseController = new AbortController();
+  const onPhaseSigint = () => phaseController.abort();
+  process.once("SIGINT", onPhaseSigint);
+
   const ctx: AliasContext = {
     mcp: createMcpProxy({ call: ex.ipcCall, cwd }),
     args: parsed.args,
@@ -1127,7 +1138,8 @@ export async function executePhase(
     state,
     globalState: createAliasState({ repoRoot, namespace: GLOBAL_STATE_NAMESPACE, call: ex.ipcCall }),
     workItem,
-    waitForEvent: createWaitForEvent(),
+    signal: phaseController.signal,
+    waitForEvent: createWaitForEvent(phaseController.signal),
   };
 
   let input: unknown;
@@ -1152,6 +1164,8 @@ export async function executePhase(
     // retry is not gated by this failure (#1407).
     d.logError(`phase "${parsed.target}" failed: ${err instanceof Error ? err.message : String(err)}`);
     d.exit(1);
+  } finally {
+    process.off("SIGINT", onPhaseSigint);
   }
 
   // Handler succeeded — commit the transition. Idempotent self-loop

--- a/packages/core/src/alias-bundle.spec.ts
+++ b/packages/core/src/alias-bundle.spec.ts
@@ -287,6 +287,7 @@ describe("bundleAlias", () => {
         state: stubState,
         globalState: stubState,
         workItem: null,
+        signal: new AbortController().signal,
         waitForEvent: async () => {
           throw new Error("not in test");
         },
@@ -411,6 +412,7 @@ describe("executeAliasBundled", () => {
         state: stubState,
         globalState: stubState,
         workItem: null,
+        signal: new AbortController().signal,
         waitForEvent: async () => {
           throw new Error("not in test");
         },
@@ -450,6 +452,7 @@ describe("executeAliasBundled", () => {
           state: stubState,
           globalState: stubState,
           workItem: null,
+          signal: new AbortController().signal,
           waitForEvent: async () => {
             throw new Error("not in test");
           },
@@ -491,6 +494,7 @@ describe("executeAliasBundled", () => {
           state: stubState,
           globalState: stubState,
           workItem: null,
+          signal: new AbortController().signal,
           waitForEvent: async () => {
             throw new Error("not in test");
           },
@@ -533,6 +537,7 @@ describe("executeAliasBundled", () => {
         state: stubState,
         globalState: stubState,
         workItem: null,
+        signal: new AbortController().signal,
         waitForEvent: async () => {
           throw new Error("not in test");
         },
@@ -572,6 +577,7 @@ describe("executeAliasBundled", () => {
         state: stubState,
         globalState: stubState,
         workItem: null,
+        signal: new AbortController().signal,
         waitForEvent: async () => {
           throw new Error("not in test");
         },
@@ -600,6 +606,7 @@ describe("executeAliasBundled", () => {
         state: stubState,
         globalState: stubState,
         workItem: null,
+        signal: new AbortController().signal,
         waitForEvent: async () => {
           throw new Error("not in test");
         },

--- a/packages/core/src/alias-dry-run.spec.ts
+++ b/packages/core/src/alias-dry-run.spec.ts
@@ -65,6 +65,7 @@ describe("wrapDryRunContext", () => {
       state: { get: async () => undefined, all: async () => ({}), set: async () => {}, delete: async () => {} },
       globalState: { get: async () => undefined, all: async () => ({}), set: async () => {}, delete: async () => {} },
       workItem: null,
+      signal: new AbortController().signal,
       waitForEvent: async () => {
         throw new Error("not in test");
       },
@@ -95,6 +96,7 @@ describe("wrapDryRunContext", () => {
       state: { get: async () => undefined, all: async () => ({}), set: async () => {}, delete: async () => {} },
       globalState: { get: async () => undefined, all: async () => ({}), set: async () => {}, delete: async () => {} },
       workItem: null,
+      signal: new AbortController().signal,
       waitForEvent: async () => {
         throw new Error("not in test");
       },

--- a/packages/core/src/alias.ts
+++ b/packages/core/src/alias.ts
@@ -148,15 +148,22 @@ export interface AliasContext {
    */
   workItem: AliasWorkItemInfo | null;
   /**
+   * Cancellation signal for this alias invocation. Fires on SIGINT, SIGTERM,
+   * or daemon shutdown. Aliases that do long-running work should check this
+   * signal and abort gracefully. `waitForEvent` is wired to this signal
+   * automatically — a fired signal causes an in-progress wait to reject
+   * immediately with `AbortError`.
+   */
+  signal?: AbortSignal;
+  /**
    * Wait for the first monitor event that matches `filter`.
    *
    * Resolves with the matching event. Rejects with `WaitTimeoutError` if
-   * `opts.timeoutMs` elapses, or with an `Error` if the underlying event
-   * stream ends or errors before a matching event is observed. The
-   * underlying event stream subscription is always cleaned up on
-   * resolve/reject — no leaked subscribers.
-   *
-   * Cancellation via AbortSignal is not yet supported — see #1714.
+   * `opts.timeoutMs` elapses, or with a `DOMException("AbortError")` if
+   * `ctx.signal` fires, or with an `Error` if the underlying event stream
+   * ends or errors before a matching event is observed. The underlying event
+   * stream subscription is always cleaned up on resolve/reject — no leaked
+   * subscribers.
    */
   waitForEvent(filter: EventFilterSpec, opts?: { timeoutMs?: number; since?: number }): Promise<MonitorEvent>;
 }

--- a/packages/core/src/alias.ts
+++ b/packages/core/src/alias.ts
@@ -152,9 +152,9 @@ export interface AliasContext {
    * or daemon shutdown. Aliases that do long-running work should check this
    * signal and abort gracefully. `waitForEvent` is wired to this signal
    * automatically — a fired signal causes an in-progress wait to reject
-   * immediately with `AbortError`.
+   * immediately with `signal.reason` (an AbortError by default).
    */
-  signal?: AbortSignal;
+  signal: AbortSignal;
   /**
    * Wait for the first monitor event that matches `filter`.
    *

--- a/packages/core/src/alias.ts
+++ b/packages/core/src/alias.ts
@@ -159,8 +159,8 @@ export interface AliasContext {
    * Wait for the first monitor event that matches `filter`.
    *
    * Resolves with the matching event. Rejects with `WaitTimeoutError` if
-   * `opts.timeoutMs` elapses, or with a `DOMException("AbortError")` if
-   * `ctx.signal` fires, or with an `Error` if the underlying event stream
+   * `opts.timeoutMs` elapses, or with a `DOMException` with name `"AbortError"`
+   * if `ctx.signal` fires, or with an `Error` if the underlying event stream
    * ends or errors before a matching event is observed. The underlying event
    * stream subscription is always cleaned up on resolve/reject — no leaked
    * subscribers.

--- a/packages/core/src/event-filter.spec.ts
+++ b/packages/core/src/event-filter.spec.ts
@@ -227,7 +227,7 @@ describe("createWaitForEvent", () => {
     const hb = makeEvent({ event: "heartbeat", category: "heartbeat", seq: 1, src: "daemon" });
     const target = makeEvent({ event: "pr.opened", category: "work_item", seq: 2 });
 
-    const waitFor = createWaitForEvent(() => fakeStream([hb, target]));
+    const waitFor = createWaitForEvent({ openStream: () => fakeStream([hb, target]) });
     const result = await waitFor({});
     expect(result.seq).toBe(2);
     expect(result.event).toBe("pr.opened");

--- a/packages/core/src/event-filter.spec.ts
+++ b/packages/core/src/event-filter.spec.ts
@@ -190,7 +190,7 @@ describe("createWaitForEvent", () => {
     const target = makeEvent({ event: "ci.finished", category: "ci" });
     const noise = makeEvent({ event: "pr.opened", category: "work_item" });
 
-    const waitFor = createWaitForEvent(() => fakeStream([noise, target]));
+    const waitFor = createWaitForEvent({ openStream: () => fakeStream([noise, target]) });
     const result = await waitFor({ type: "ci.finished" });
     expect(result).toEqual(target);
   });
@@ -199,7 +199,7 @@ describe("createWaitForEvent", () => {
     const e1 = makeEvent({ event: "pr.opened", category: "work_item", seq: 1 });
     const e2 = makeEvent({ event: "pr.merged", category: "work_item", seq: 2 });
 
-    const waitFor = createWaitForEvent(() => fakeStream([e1, e2]));
+    const waitFor = createWaitForEvent({ openStream: () => fakeStream([e1, e2]) });
     const result = await waitFor({ type: "pr.merged" });
     expect(result.seq).toBe(2);
   });
@@ -208,7 +208,7 @@ describe("createWaitForEvent", () => {
     const hb = makeEvent({ event: "heartbeat", category: "heartbeat", seq: 1 });
     const target = makeEvent({ event: "ci.finished", category: "ci", seq: 2 });
 
-    const waitFor = createWaitForEvent(() => fakeStream([hb, target]));
+    const waitFor = createWaitForEvent({ openStream: () => fakeStream([hb, target]) });
     const result = await waitFor({ type: "ci.*" });
     expect(result.seq).toBe(2);
   });
@@ -217,7 +217,7 @@ describe("createWaitForEvent", () => {
     const ringHb = { t: "heartbeat", seq: 99 } as unknown as MonitorEvent;
     const target = makeEvent({ event: "ci.finished", category: "ci", seq: 2 });
 
-    const waitFor = createWaitForEvent(() => fakeStream([ringHb, target]));
+    const waitFor = createWaitForEvent({ openStream: () => fakeStream([ringHb, target]) });
     const result = await waitFor({ type: "ci.*" });
     expect(result.seq).toBe(2);
   });
@@ -247,13 +247,13 @@ describe("createWaitForEvent", () => {
       await blockPromise; // block so timeout fires
     }
 
-    const waitFor = createWaitForEvent(() => ({ events: infinite(), abort: resolveBlock }));
+    const waitFor = createWaitForEvent({ openStream: () => ({ events: infinite(), abort: resolveBlock }) });
     await expect(waitFor({ type: "ci.finished" }, { timeoutMs: 20 })).rejects.toThrow(WaitTimeoutError);
   });
 
   test("rejects when stream ends without matching event", async () => {
     const e = makeEvent({ event: "pr.opened", category: "work_item" });
-    const waitFor = createWaitForEvent(() => fakeStream([e]));
+    const waitFor = createWaitForEvent({ openStream: () => fakeStream([e]) });
     await expect(waitFor({ type: "ci.finished" })).rejects.toThrow("ended without matching event");
   });
 
@@ -263,7 +263,7 @@ describe("createWaitForEvent", () => {
     const controller = new AbortController();
     controller.abort();
 
-    const waitFor = createWaitForEvent(controller.signal);
+    const waitFor = createWaitForEvent({ signal: controller.signal });
     await expect(waitFor({ type: "ci.finished" })).rejects.toMatchObject({ name: "AbortError" });
   });
 
@@ -280,7 +280,7 @@ describe("createWaitForEvent", () => {
       yield makeEvent({ event: "never-reached" }); // abort fires before blockPromise resolves
     }
 
-    const waitFor = createWaitForEvent(() => ({ events: blocking(), abort: resolveBlock }), controller.signal);
+    const waitFor = createWaitForEvent({ openStream: () => ({ events: blocking(), abort: resolveBlock }), signal: controller.signal });
     const waitPromise = waitFor({ type: "ci.finished" });
 
     controller.abort();
@@ -300,7 +300,7 @@ describe("createWaitForEvent", () => {
     } as unknown as AbortSignal;
 
     const target = makeEvent({ event: "ci.finished", category: "ci" });
-    const waitFor = createWaitForEvent(() => fakeStream([target]), mockSignal);
+    const waitFor = createWaitForEvent({ openStream: () => fakeStream([target]), signal: mockSignal });
     await waitFor({ type: "ci.finished" });
 
     expect(listeners).toHaveLength(0);
@@ -330,8 +330,36 @@ describe("createWaitForEvent", () => {
       await blockPromise;
     }
 
-    const waitFor = createWaitForEvent(() => ({ events: infinite(), abort: resolveBlock }), mockSignal);
+    const waitFor = createWaitForEvent({ openStream: () => ({ events: infinite(), abort: resolveBlock }), signal: mockSignal });
     await expect(waitFor({ type: "ci.finished" }, { timeoutMs: 20 })).rejects.toThrow(WaitTimeoutError);
     expect(listeners).toHaveLength(0);
+  });
+
+  test("abort after resolve — settled flag prevents second rejection", async () => {
+    const controller = new AbortController();
+    const target = makeEvent({ event: "ci.finished", category: "ci" });
+    const waitFor = createWaitForEvent({ openStream: () => fakeStream([target]), signal: controller.signal });
+    const result = await waitFor({ type: "ci.finished" });
+    expect(result).toEqual(target);
+    // Aborting after resolution must be a no-op (no unhandled rejection, no throw)
+    controller.abort();
+  });
+
+  test("abort after timeout — settled flag prevents second rejection", async () => {
+    const controller = new AbortController();
+
+    let resolveBlock!: () => void;
+    const blockPromise = new Promise<void>((r) => {
+      resolveBlock = r;
+    });
+
+    async function* infinite(): AsyncGenerator<MonitorEvent> {
+      await blockPromise;
+    }
+
+    const waitFor = createWaitForEvent({ openStream: () => ({ events: infinite(), abort: resolveBlock }), signal: controller.signal });
+    await expect(waitFor({ type: "ci.finished" }, { timeoutMs: 10 })).rejects.toThrow(WaitTimeoutError);
+    // Aborting after timeout resolution must be a no-op
+    controller.abort();
   });
 });

--- a/packages/core/src/event-filter.spec.ts
+++ b/packages/core/src/event-filter.spec.ts
@@ -280,7 +280,10 @@ describe("createWaitForEvent", () => {
       yield makeEvent({ event: "never-reached" }); // abort fires before blockPromise resolves
     }
 
-    const waitFor = createWaitForEvent({ openStream: () => ({ events: blocking(), abort: resolveBlock }), signal: controller.signal });
+    const waitFor = createWaitForEvent({
+      openStream: () => ({ events: blocking(), abort: resolveBlock }),
+      signal: controller.signal,
+    });
     const waitPromise = waitFor({ type: "ci.finished" });
 
     controller.abort();
@@ -330,9 +333,38 @@ describe("createWaitForEvent", () => {
       await blockPromise;
     }
 
-    const waitFor = createWaitForEvent({ openStream: () => ({ events: infinite(), abort: resolveBlock }), signal: mockSignal });
+    const waitFor = createWaitForEvent({
+      openStream: () => ({ events: infinite(), abort: resolveBlock }),
+      signal: mockSignal,
+    });
     await expect(waitFor({ type: "ci.finished" }, { timeoutMs: 20 })).rejects.toThrow(WaitTimeoutError);
     expect(listeners).toHaveLength(0);
+  });
+
+  test("signal aborted between listener registration and check — no missed abort", async () => {
+    const abortReason = new DOMException("The operation was aborted", "AbortError");
+    let listener: (() => void) | undefined;
+    let aborted = false;
+    const racySignal = {
+      get aborted() {
+        return aborted;
+      },
+      reason: abortReason,
+      addEventListener(_event: string, fn: () => void) {
+        listener = fn;
+        aborted = true;
+      },
+      removeEventListener(_event: string, _fn: () => void) {
+        listener = undefined;
+      },
+    } as unknown as AbortSignal;
+
+    const target = makeEvent({ event: "ci.finished", category: "ci" });
+    const waitFor = createWaitForEvent({
+      openStream: () => fakeStream([target]),
+      signal: racySignal,
+    });
+    await expect(waitFor({ type: "ci.finished" })).rejects.toMatchObject({ name: "AbortError" });
   });
 
   test("abort after resolve — settled flag prevents second rejection", async () => {
@@ -353,11 +385,15 @@ describe("createWaitForEvent", () => {
       resolveBlock = r;
     });
 
-    async function* infinite(): AsyncGenerator<MonitorEvent> {
+    async function* hanging(): AsyncGenerator<MonitorEvent> {
+      yield makeEvent({ event: "noise" });
       await blockPromise;
     }
 
-    const waitFor = createWaitForEvent({ openStream: () => ({ events: infinite(), abort: resolveBlock }), signal: controller.signal });
+    const waitFor = createWaitForEvent({
+      openStream: () => ({ events: hanging(), abort: resolveBlock }),
+      signal: controller.signal,
+    });
     await expect(waitFor({ type: "ci.finished" }, { timeoutMs: 10 })).rejects.toThrow(WaitTimeoutError);
     // Aborting after timeout resolution must be a no-op
     controller.abort();

--- a/packages/core/src/event-filter.spec.ts
+++ b/packages/core/src/event-filter.spec.ts
@@ -256,4 +256,82 @@ describe("createWaitForEvent", () => {
     const waitFor = createWaitForEvent(() => fakeStream([e]));
     await expect(waitFor({ type: "ci.finished" })).rejects.toThrow("ended without matching event");
   });
+
+  // ── AbortSignal cancellation ──
+
+  test("pre-aborted signal → immediate AbortError rejection", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const waitFor = createWaitForEvent(controller.signal);
+    await expect(waitFor({ type: "ci.finished" })).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  test("signal fires while waiting → AbortError rejection", async () => {
+    const controller = new AbortController();
+
+    let resolveBlock!: () => void;
+    const blockPromise = new Promise<void>((r) => {
+      resolveBlock = r;
+    });
+
+    async function* blocking(): AsyncGenerator<MonitorEvent> {
+      await blockPromise;
+      yield makeEvent({ event: "never-reached" }); // abort fires before blockPromise resolves
+    }
+
+    const waitFor = createWaitForEvent(() => ({ events: blocking(), abort: resolveBlock }), controller.signal);
+    const waitPromise = waitFor({ type: "ci.finished" });
+
+    controller.abort();
+    await expect(waitPromise).rejects.toMatchObject({ name: "AbortError" });
+  });
+
+  test("abort listener removed on normal resolution — no leaked listeners", async () => {
+    let listeners: (() => void)[] = [];
+    const mockSignal = {
+      aborted: false,
+      addEventListener(_: string, fn: () => void) {
+        listeners.push(fn);
+      },
+      removeEventListener(_: string, fn: () => void) {
+        listeners = listeners.filter((l) => l !== fn);
+      },
+    } as unknown as AbortSignal;
+
+    const target = makeEvent({ event: "ci.finished", category: "ci" });
+    const waitFor = createWaitForEvent(() => fakeStream([target]), mockSignal);
+    await waitFor({ type: "ci.finished" });
+
+    expect(listeners).toHaveLength(0);
+  });
+
+  test("abort listener removed on timeout — no leaked listeners", async () => {
+    let listeners: (() => void)[] = [];
+    const mockSignal = {
+      aborted: false,
+      addEventListener(_: string, fn: () => void) {
+        listeners.push(fn);
+      },
+      removeEventListener(_: string, fn: () => void) {
+        listeners = listeners.filter((l) => l !== fn);
+      },
+    } as unknown as AbortSignal;
+
+    const noise = makeEvent({ event: "pr.opened", category: "work_item" });
+
+    let resolveBlock!: () => void;
+    const blockPromise = new Promise<void>((r) => {
+      resolveBlock = r;
+    });
+
+    async function* infinite(): AsyncGenerator<MonitorEvent> {
+      yield noise;
+      await blockPromise;
+    }
+
+    const waitFor = createWaitForEvent(() => ({ events: infinite(), abort: resolveBlock }), mockSignal);
+    await expect(waitFor({ type: "ci.finished" }, { timeoutMs: 20 })).rejects.toThrow(WaitTimeoutError);
+    expect(listeners).toHaveLength(0);
+  });
 });

--- a/packages/core/src/event-filter.ts
+++ b/packages/core/src/event-filter.ts
@@ -105,17 +105,14 @@ export function filterSpecToStreamParams(spec: EventFilterSpec): {
 type OpenStreamFn = typeof openEventStream;
 
 /**
- * Create a `waitForEvent` function bound to an optional AbortSignal.
+ * Create a `waitForEvent` function.
  *
- * The first argument is polymorphic:
- *   - omitted / undefined  → use real event stream, no cancellation
- *   - AbortSignal          → use real event stream, cancel on signal
- *   - function             → inject a fake stream (tests only)
+ * `opts.signal` — when provided and fires, the in-progress wait rejects with
+ * `signal.reason` (a DOMException AbortError when `abort()` is called with no
+ * args). If already aborted at call time, rejection is immediate. The abort
+ * listener is removed on any resolution path — no leaked listeners.
  *
- * When a `signal` is provided and fires, the in-progress wait rejects with a
- * `DOMException("The operation was aborted", "AbortError")`. If the signal is
- * already aborted at call time, rejection is immediate. The abort listener is
- * removed from the signal on any resolution path — no leaked listeners.
+ * `opts.openStream` — injectable for testing (default: the real openEventStream).
  *
  * Stream is always torn down on resolve or reject — no leaked subscribers.
  *
@@ -123,19 +120,16 @@ type OpenStreamFn = typeof openEventStream;
  * the action they intend to await. Without `since`, there is a 10–100ms
  * window between the call and the daemon's subscription where a matching
  * event could be missed, causing the caller to block until timeout.
- *
- * `openStream` is injectable for testing (default: the real openEventStream).
  */
-export function createWaitForEvent(
-  openStreamOrSignal?: OpenStreamFn | AbortSignal,
-  signalArg?: AbortSignal,
-): (filter: EventFilterSpec, opts?: { timeoutMs?: number; since?: number }) => Promise<MonitorEvent> {
-  const openStream: OpenStreamFn = typeof openStreamOrSignal === "function" ? openStreamOrSignal : openEventStream;
-  const signal: AbortSignal | undefined = typeof openStreamOrSignal === "function" ? signalArg : openStreamOrSignal;
+export function createWaitForEvent(opts?: {
+  openStream?: OpenStreamFn;
+  signal?: AbortSignal;
+}): (filter: EventFilterSpec, opts?: { timeoutMs?: number; since?: number }) => Promise<MonitorEvent> {
+  const { openStream = openEventStream, signal } = opts ?? {};
 
   return (filter, opts) => {
     if (signal?.aborted) {
-      return Promise.reject(new DOMException("The operation was aborted", "AbortError"));
+      return Promise.reject(signal.reason ?? new DOMException("The operation was aborted", "AbortError"));
     }
 
     return new Promise<MonitorEvent>((resolve, reject) => {
@@ -148,7 +142,7 @@ export function createWaitForEvent(
       let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
       function onAbort() {
-        settle(() => reject(new DOMException("The operation was aborted", "AbortError")));
+        settle(() => reject(signal!.reason ?? new DOMException("The operation was aborted", "AbortError")));
       }
 
       const cleanup = () => {
@@ -168,7 +162,7 @@ export function createWaitForEvent(
         }
       };
 
-      signal?.addEventListener("abort", onAbort, { once: true });
+      signal?.addEventListener("abort", onAbort);
 
       if (opts?.timeoutMs !== undefined) {
         const ms = opts.timeoutMs;

--- a/packages/core/src/event-filter.ts
+++ b/packages/core/src/event-filter.ts
@@ -105,10 +105,17 @@ export function filterSpecToStreamParams(spec: EventFilterSpec): {
 type OpenStreamFn = typeof openEventStream;
 
 /**
- * Create a `waitForEvent` function.
+ * Create a `waitForEvent` function bound to an optional AbortSignal.
  *
- * Opens an event stream, waits for the first event matching `filter`, then
- * aborts the stream. Rejects with `WaitTimeoutError` if `timeoutMs` elapses.
+ * The first argument is polymorphic:
+ *   - omitted / undefined  → use real event stream, no cancellation
+ *   - AbortSignal          → use real event stream, cancel on signal
+ *   - function             → inject a fake stream (tests only)
+ *
+ * When a `signal` is provided and fires, the in-progress wait rejects with a
+ * `DOMException("The operation was aborted", "AbortError")`. If the signal is
+ * already aborted at call time, rejection is immediate. The abort listener is
+ * removed from the signal on any resolution path — no leaked listeners.
  *
  * Stream is always torn down on resolve or reject — no leaked subscribers.
  *
@@ -117,14 +124,20 @@ type OpenStreamFn = typeof openEventStream;
  * window between the call and the daemon's subscription where a matching
  * event could be missed, causing the caller to block until timeout.
  *
- * Cancellation via AbortSignal is not yet supported — see #1714.
- *
  * `openStream` is injectable for testing (default: the real openEventStream).
  */
 export function createWaitForEvent(
-  openStream: OpenStreamFn = openEventStream,
+  openStreamOrSignal?: OpenStreamFn | AbortSignal,
+  signalArg?: AbortSignal,
 ): (filter: EventFilterSpec, opts?: { timeoutMs?: number; since?: number }) => Promise<MonitorEvent> {
+  const openStream: OpenStreamFn = typeof openStreamOrSignal === "function" ? openStreamOrSignal : openEventStream;
+  const signal: AbortSignal | undefined = typeof openStreamOrSignal === "function" ? signalArg : openStreamOrSignal;
+
   return (filter, opts) => {
+    if (signal?.aborted) {
+      return Promise.reject(new DOMException("The operation was aborted", "AbortError"));
+    }
+
     return new Promise<MonitorEvent>((resolve, reject) => {
       const { events, abort: abortStream } = openStream({
         since: opts?.since,
@@ -134,7 +147,12 @@ export function createWaitForEvent(
       let settled = false;
       let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
+      function onAbort() {
+        settle(() => reject(new DOMException("The operation was aborted", "AbortError")));
+      }
+
       const cleanup = () => {
+        signal?.removeEventListener("abort", onAbort);
         if (timeoutId !== undefined) {
           clearTimeout(timeoutId);
           timeoutId = undefined;
@@ -149,6 +167,8 @@ export function createWaitForEvent(
           fn();
         }
       };
+
+      signal?.addEventListener("abort", onAbort, { once: true });
 
       if (opts?.timeoutMs !== undefined) {
         const ms = opts.timeoutMs;

--- a/packages/core/src/event-filter.ts
+++ b/packages/core/src/event-filter.ts
@@ -128,10 +128,6 @@ export function createWaitForEvent(opts?: {
   const { openStream = openEventStream, signal } = opts ?? {};
 
   return (filter, opts) => {
-    if (signal?.aborted) {
-      return Promise.reject(signal.reason ?? new DOMException("The operation was aborted", "AbortError"));
-    }
-
     return new Promise<MonitorEvent>((resolve, reject) => {
       const { events, abort: abortStream } = openStream({
         since: opts?.since,
@@ -142,7 +138,7 @@ export function createWaitForEvent(opts?: {
       let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
       function onAbort() {
-        settle(() => reject(signal!.reason ?? new DOMException("The operation was aborted", "AbortError")));
+        settle(() => reject(signal?.reason ?? new DOMException("The operation was aborted", "AbortError")));
       }
 
       const cleanup = () => {
@@ -162,7 +158,15 @@ export function createWaitForEvent(opts?: {
         }
       };
 
+      // Register listener BEFORE checking aborted state — a signal that
+      // fires between the check and registration is caught by the listener,
+      // and a pre-aborted signal is caught by the post-registration check.
       signal?.addEventListener("abort", onAbort);
+
+      if (signal?.aborted) {
+        settle(() => reject(signal.reason ?? new DOMException("The operation was aborted", "AbortError")));
+        return;
+      }
 
       if (opts?.timeoutMs !== undefined) {
         const ms = opts.timeoutMs;

--- a/packages/daemon/src/alias-executor.ts
+++ b/packages/daemon/src/alias-executor.ts
@@ -139,6 +139,13 @@ async function main(): Promise<void> {
   // Build the updated chain including the current alias
   const updatedChain = [...chain, currentAlias];
 
+  // Wire cancellation: SIGINT from the terminal or SIGTERM from the daemon
+  // killing this subprocess both abort waitForEvent calls.
+  const controller = new AbortController();
+  const onSignal = () => controller.abort();
+  process.once("SIGINT", onSignal);
+  process.once("SIGTERM", onSignal);
+
   // Scope state to the caller's repo — NOT the daemon's cwd. Without an
   // explicit cwd from the caller, every alias invocation via the MCP server
   // would collapse into the NO_REPO_ROOT bucket (see PR #1307 review).
@@ -155,11 +162,17 @@ async function main(): Promise<void> {
     state: createAliasState({ repoRoot, namespace: aliasUserNamespace(currentAlias) }),
     globalState: createAliasState({ repoRoot, namespace: GLOBAL_STATE_NAMESPACE }),
     workItem: workItem ?? null,
-    waitForEvent: createWaitForEvent(),
+    signal: controller.signal,
+    waitForEvent: createWaitForEvent(controller.signal),
   };
 
-  const result = await executeAliasBundled(bundledJs, input, ctx, isDefineAlias);
-  process.stdout.write(JSON.stringify({ result: result ?? null }));
+  try {
+    const result = await executeAliasBundled(bundledJs, input, ctx, isDefineAlias);
+    process.stdout.write(JSON.stringify({ result: result ?? null }));
+  } finally {
+    process.off("SIGINT", onSignal);
+    process.off("SIGTERM", onSignal);
+  }
 }
 
 main().catch((err) => {

--- a/packages/daemon/src/alias-executor.ts
+++ b/packages/daemon/src/alias-executor.ts
@@ -142,14 +142,16 @@ async function main(): Promise<void> {
   // Wire cancellation: SIGINT from the terminal or SIGTERM from the daemon
   // killing this subprocess both abort waitForEvent calls.
   const controller = new AbortController();
-  const onSignal = (sig: string) => {
+  const onSignal = (sig: NodeJS.Signals) => {
     controller.abort();
-    process.off("SIGINT", onSignal);
-    process.off("SIGTERM", onSignal);
+    process.off("SIGINT", onInt);
+    process.off("SIGTERM", onTerm);
     process.kill(process.pid, sig);
   };
-  process.once("SIGINT", onSignal);
-  process.once("SIGTERM", onSignal);
+  const onInt = () => onSignal("SIGINT");
+  const onTerm = () => onSignal("SIGTERM");
+  process.once("SIGINT", onInt);
+  process.once("SIGTERM", onTerm);
 
   // Scope state to the caller's repo — NOT the daemon's cwd. Without an
   // explicit cwd from the caller, every alias invocation via the MCP server
@@ -175,8 +177,8 @@ async function main(): Promise<void> {
     const result = await executeAliasBundled(bundledJs, input, ctx, isDefineAlias);
     process.stdout.write(JSON.stringify({ result: result ?? null }));
   } finally {
-    process.off("SIGINT", onSignal);
-    process.off("SIGTERM", onSignal);
+    process.off("SIGINT", onInt);
+    process.off("SIGTERM", onTerm);
   }
 }
 

--- a/packages/daemon/src/alias-executor.ts
+++ b/packages/daemon/src/alias-executor.ts
@@ -142,7 +142,12 @@ async function main(): Promise<void> {
   // Wire cancellation: SIGINT from the terminal or SIGTERM from the daemon
   // killing this subprocess both abort waitForEvent calls.
   const controller = new AbortController();
-  const onSignal = () => controller.abort();
+  const onSignal = (sig: string) => {
+    controller.abort();
+    process.off("SIGINT", onSignal);
+    process.off("SIGTERM", onSignal);
+    process.kill(process.pid, sig);
+  };
   process.once("SIGINT", onSignal);
   process.once("SIGTERM", onSignal);
 
@@ -163,7 +168,7 @@ async function main(): Promise<void> {
     globalState: createAliasState({ repoRoot, namespace: GLOBAL_STATE_NAMESPACE }),
     workItem: workItem ?? null,
     signal: controller.signal,
-    waitForEvent: createWaitForEvent(controller.signal),
+    waitForEvent: createWaitForEvent({ signal: controller.signal }),
   };
 
   try {


### PR DESCRIPTION
## Summary

- **`createWaitForEvent`** now accepts an optional `{ openStream?, signal? }` opts object. Pre-aborted signals reject immediately; in-flight waits reject with a `DOMException` with name `"AbortError"` on fire; abort listener removed from signal on any resolution path — no leaked listeners.
- **`AliasContext`** gains `signal: AbortSignal` (required) — wired to `waitForEvent` automatically, also available for alias authors doing long-running work.
- **`alias-runner.ts`**: creates `AbortController` per invocation, `SIGINT`/`SIGTERM` → abort via per-signal wrappers, listener removed in `finally`.
- **`alias-executor.ts`** (daemon subprocess): wires both `SIGINT` and `SIGTERM` → abort via per-signal wrappers, listener removed in `finally`.
- **`phase.ts`**: wires `SIGINT`/`SIGTERM` → abort in both the dry-run (`runPhase`) and real-execution (`executePhase`) paths.

## Test plan

- [x] `createWaitForEvent` — pre-aborted signal → immediate `AbortError` rejection
- [x] `createWaitForEvent` — signal fires while waiting → `AbortError` rejection
- [x] `createWaitForEvent` — abort listener removed on normal resolution (mock signal, verify listener array is empty)
- [x] `createWaitForEvent` — abort listener removed on timeout (mock signal, verify listener array is empty)
- [x] All 5918 existing tests pass (`bun test`)
- [x] `bun typecheck` and `bun lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)