### PR TITLE
fix(event-filter): normalize ring-buffer heartbeat to standard MonitorEvent shape (fixes #1718)

### DIFF
--- a/packages/core/src/event-filter.spec.ts
+++ b/packages/core/src/event-filter.spec.ts
@@ -222,6 +222,17 @@ describe("createWaitForEvent", () => {
     expect(result.seq).toBe(2);
   });
 
+  test("empty-spec waitForEvent({}) skips normalized heartbeats, resolves with next real event", async () => {
+    // Regression for #1718: standard-shape heartbeats must not resolve empty-spec waitForEvent.
+    const hb = makeEvent({ event: "heartbeat", category: "heartbeat", seq: 1, src: "daemon" });
+    const target = makeEvent({ event: "pr.opened", category: "work_item", seq: 2 });
+
+    const waitFor = createWaitForEvent(() => fakeStream([hb, target]));
+    const result = await waitFor({});
+    expect(result.seq).toBe(2);
+    expect(result.event).toBe("pr.opened");
+  });
+
   test("rejects with WaitTimeoutError after timeoutMs", async () => {
     // Infinite stream that yields nothing matching
     const noise = makeEvent({ event: "pr.opened", category: "work_item" });

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -3401,7 +3401,10 @@ describe("IpcServer HTTP transport", () => {
       const hbLine = lines.find((l) => l.includes('"heartbeat"'));
       expect(hbLine).toBeDefined();
       const hb = JSON.parse(hbLine as string) as Record<string, unknown>;
-      expect(hb.t).toBe("heartbeat");
+      expect(hb.category).toBe("heartbeat");
+      expect(hb.event).toBe("heartbeat");
+      expect(hb.src).toBe("daemon");
+      expect(typeof hb.ts).toBe("string");
       expect(typeof hb.seq).toBe("number");
     } finally {
       Object.defineProperty(IpcServer, "HEARTBEAT_INTERVAL_MS", {

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -1808,7 +1808,7 @@ export class IpcServer {
 
         heartbeatTimer = setInterval(() => {
           if (Date.now() - lastWriteTime >= IpcServer.HEARTBEAT_INTERVAL_MS) {
-            const hb = `${JSON.stringify({ t: "heartbeat", seq: this.eventSeq })}\n`;
+            const hb = `${JSON.stringify({ category: "heartbeat", event: "heartbeat", seq: this.eventSeq, src: "daemon", ts: new Date().toISOString() })}\n`;
             try {
               controller.enqueue(encoder.encode(hb));
               lastWriteTime = Date.now();


### PR DESCRIPTION
## Summary

- Ring-buffer fallback path in `ipc-server.ts` was emitting heartbeats as `{"t":"heartbeat","seq":N}` — a non-standard shape that bypassed the `buildEventFilter` passthrough check and the client-side skip in `event-filter.ts`
- Changed the emitted shape to `{category:"heartbeat", event:"heartbeat", src:"daemon", ts:...}` so it matches the standard `MonitorEvent` envelope and all existing heartbeat guards fire correctly
- Empty-spec `waitForEvent({})` callers no longer receive heartbeat events as data

## Test plan

- [x] Updated `ipc-server.spec.ts` heartbeat test to assert new standard `category`/`event`/`src`/`ts` fields
- [x] Added regression test in `event-filter.spec.ts`: `waitForEvent({})` with empty spec skips normalized heartbeats and resolves with the next real event
- [x] Existing `{t:"heartbeat"}` defense-in-depth test retained (client-side guard stays as safety net)
- [x] Full test suite: 5915 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)