### PR TITLE
feat: session.stuck event with lastTool, lastToolError, tokenDelta (fixes #1585)

### DIFF
--- a/packages/core/src/monitor-event.ts
+++ b/packages/core/src/monitor-event.ts
@@ -29,6 +29,7 @@ export const SESSION_CONTAINMENT_DENIED = "session.containment_denied" as const;
 export const SESSION_CONTAINMENT_ESCALATED = "session.containment_escalated" as const;
 export const SESSION_CONTAINMENT_RESET = "session.containment_reset" as const;
 export const SESSION_IDLE = "session.idle" as const;
+export const SESSION_STUCK = "session.stuck" as const;
 
 // ── Work item event names ──
 
@@ -182,6 +183,14 @@ const FORMATTERS: Partial<Record<string, Formatter>> = {
   [SESSION_CONTAINMENT_WARNING]: (e) => {
     const reason = typeof e.reason === "string" ? cap(e.reason, 60) : "";
     return join(wi(e), sid(e), `strikes:${e.strikes ?? "?"}`, reason);
+  },
+
+  [SESSION_STUCK]: (e) => {
+    const tier = typeof e.tier === "number" ? `tier:${e.tier}` : "";
+    const since = typeof e.sinceMs === "number" ? `${Math.round(e.sinceMs / 1000)}s` : "";
+    const tool = typeof e.lastTool === "string" ? e.lastTool : "";
+    const err = typeof e.lastToolError === "string" ? cap(e.lastToolError, 40) : "";
+    return join(wi(e), sid(e), tier, since, tool, err);
   },
 
   [SESSION_CONTAINMENT_DENIED]: (e) => {

--- a/packages/daemon/src/claude-session/session-state.spec.ts
+++ b/packages/daemon/src/claude-session/session-state.spec.ts
@@ -959,4 +959,122 @@ describe("SessionState", () => {
       expect(session.parseMismatch).toBe(false);
     });
   });
+
+  // ── lastToolCall tracking (#1585) ──
+
+  describe("lastToolCall", () => {
+    test("starts null", () => {
+      const session = new SessionState("sess-1");
+      expect(session.lastToolCall).toBeNull();
+    });
+
+    test("extracts tool name from assistant message with tool_use block", () => {
+      const session = initSession();
+      session.handleMessage({
+        type: "assistant",
+        message: {
+          id: "msg-t1",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [
+            { type: "text", text: "Let me run that." },
+            { type: "tool_use", id: "tu-1", name: "Bash", input: { command: "echo hi" } },
+          ],
+          stop_reason: "tool_use",
+          usage: { input_tokens: 50, output_tokens: 30 },
+        },
+        parent_tool_use_id: null,
+        uuid: "uuid-t1",
+        session_id: "sess-1",
+      });
+
+      expect(session.lastToolCall).not.toBeNull();
+      expect(session.lastToolCall?.name).toBe("Bash");
+      expect(session.lastToolCall?.at).toBeGreaterThan(0);
+    });
+
+    test("tracks the last tool_use block when multiple are present", () => {
+      const session = initSession();
+      session.handleMessage({
+        type: "assistant",
+        message: {
+          id: "msg-t2",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [
+            { type: "tool_use", id: "tu-1", name: "Read", input: { file: "a.ts" } },
+            { type: "tool_use", id: "tu-2", name: "Write", input: { file: "b.ts", content: "" } },
+          ],
+          stop_reason: "tool_use",
+          usage: { input_tokens: 50, output_tokens: 30 },
+        },
+        parent_tool_use_id: null,
+        uuid: "uuid-t2",
+        session_id: "sess-1",
+      });
+
+      expect(session.lastToolCall?.name).toBe("Write");
+    });
+
+    test("no tool_use blocks leaves lastToolCall unchanged", () => {
+      const session = initSession();
+      session.handleMessage(ASSISTANT_MSG);
+      expect(session.lastToolCall).toBeNull();
+    });
+
+    test("permission denial sets errorMessage on lastToolCall", () => {
+      const session = initSession();
+
+      // Simulate tool use followed by permission request
+      session.handleMessage({
+        type: "assistant",
+        message: {
+          id: "msg-t3",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [{ type: "tool_use", id: "tu-1", name: "Bash", input: { command: "rm -rf /" } }],
+          stop_reason: "tool_use",
+          usage: { input_tokens: 50, output_tokens: 30 },
+        },
+        parent_tool_use_id: null,
+        uuid: "uuid-t3",
+        session_id: "sess-1",
+      });
+      expect(session.lastToolCall?.name).toBe("Bash");
+      expect(session.lastToolCall?.errorMessage).toBeUndefined();
+
+      session.handleMessage(CAN_USE_TOOL);
+      session.respondToPermission("req-1", false, "No matching rule for tool: Bash");
+
+      expect(session.lastToolCall?.errorMessage).toBe("No matching rule for tool: Bash");
+    });
+
+    test("permission approval does not set errorMessage", () => {
+      const session = initSession();
+
+      session.handleMessage({
+        type: "assistant",
+        message: {
+          id: "msg-t4",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [{ type: "tool_use", id: "tu-1", name: "Read", input: { file: "a.ts" } }],
+          stop_reason: "tool_use",
+          usage: { input_tokens: 50, output_tokens: 30 },
+        },
+        parent_tool_use_id: null,
+        uuid: "uuid-t4",
+        session_id: "sess-1",
+      });
+
+      session.handleMessage(CAN_USE_TOOL);
+      session.respondToPermission("req-1", true);
+
+      expect(session.lastToolCall?.errorMessage).toBeUndefined();
+    });
+  });
 });

--- a/packages/daemon/src/claude-session/session-state.spec.ts
+++ b/packages/daemon/src/claude-session/session-state.spec.ts
@@ -1052,6 +1052,34 @@ describe("SessionState", () => {
       expect(session.lastToolCall?.errorMessage).toBe("No matching rule for tool: Bash");
     });
 
+    test("permission denial does not set errorMessage when tool_name mismatches lastToolCall", () => {
+      const session = initSession();
+
+      // lastToolCall is "Bash", but the permission request is for "Write" (mismatch)
+      session.handleMessage({
+        type: "assistant",
+        message: {
+          id: "msg-t3b",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-4-6",
+          content: [{ type: "tool_use", id: "tu-1", name: "Bash", input: { command: "ls" } }],
+          stop_reason: "tool_use",
+          usage: { input_tokens: 50, output_tokens: 30 },
+        },
+        parent_tool_use_id: null,
+        uuid: "uuid-t3b",
+        session_id: "sess-1",
+      });
+      expect(session.lastToolCall?.name).toBe("Bash");
+
+      session.handleMessage(CAN_USE_TOOL_2);
+      session.respondToPermission("req-2", false, "Not allowed");
+
+      expect(session.lastToolCall?.name).toBe("Bash");
+      expect(session.lastToolCall?.errorMessage).toBeUndefined();
+    });
+
     test("permission approval does not set errorMessage", () => {
       const session = initSession();
 

--- a/packages/daemon/src/claude-session/session-state.ts
+++ b/packages/daemon/src/claude-session/session-state.ts
@@ -81,6 +81,7 @@ export class SessionState {
   numTurns = 0;
   rateLimited = false;
   readonly pendingPermissions = new Map<string, CanUseToolMsg["request"]>();
+  lastToolCall: { name: string; errorMessage?: string; at: number } | null = null;
   private readonly genRequestId: RequestIdGenerator;
 
   /**
@@ -147,7 +148,11 @@ export class SessionState {
     if (allow) {
       return permissionAllow(requestId, request.input);
     }
-    return permissionDeny(requestId, message ?? "Denied by session controller");
+    const denyMessage = message ?? "Denied by session controller";
+    if (this.lastToolCall) {
+      this.lastToolCall.errorMessage = denyMessage;
+    }
+    return permissionDeny(requestId, denyMessage);
   }
 
   /** Build an interrupt control request. */
@@ -249,6 +254,7 @@ export class SessionState {
       this.state = "active";
       const usage = strict.data.message.usage;
       this.tokens += usage.input_tokens + usage.output_tokens;
+      this.extractLastToolCall(strict.data.message.content);
       const events: SessionEvent[] = [{ type: "session:response", message: strict.data }];
       if (strict.data.error === "rate_limit") {
         this.rateLimited = true;
@@ -266,6 +272,7 @@ export class SessionState {
       if (usage) {
         this.tokens += usage.input_tokens + usage.output_tokens;
       }
+      this.extractLastToolCallRaw(msg);
       const assistant = buildFallbackAssistant(msg, loose.data);
       const events: SessionEvent[] = [{ type: "session:response", message: assistant }];
       if (assistant.error === "rate_limit") {
@@ -343,6 +350,24 @@ export class SessionState {
 
     // unreachable: ResultFallback only requires type:"result", already confirmed by dispatch
     return [];
+  }
+
+  private extractLastToolCall(content: Record<string, unknown>[]): void {
+    for (let i = content.length - 1; i >= 0; i--) {
+      const block = content[i];
+      if (block.type === "tool_use" && typeof block.name === "string") {
+        this.lastToolCall = { name: block.name, at: Date.now() };
+        return;
+      }
+    }
+  }
+
+  private extractLastToolCallRaw(msg: NdjsonMessage): void {
+    const rawMsg = (msg as Record<string, unknown>).message as Record<string, unknown> | undefined;
+    if (!rawMsg) return;
+    const content = rawMsg.content;
+    if (!Array.isArray(content)) return;
+    this.extractLastToolCall(content as Record<string, unknown>[]);
   }
 
   private handleControlRequest(msg: NdjsonMessage): SessionEvent[] {

--- a/packages/daemon/src/claude-session/session-state.ts
+++ b/packages/daemon/src/claude-session/session-state.ts
@@ -149,7 +149,7 @@ export class SessionState {
       return permissionAllow(requestId, request.input);
     }
     const denyMessage = message ?? "Denied by session controller";
-    if (this.lastToolCall) {
+    if (this.lastToolCall && request.tool_name === this.lastToolCall.name) {
       // errorMessage only captures permission denials. MCP tool execution errors
       // (e.g. tool throws, non-zero exit) are not visible at the NDJSON layer —
       // they flow through the MCP transport in server-pool and would need separate

--- a/packages/daemon/src/claude-session/session-state.ts
+++ b/packages/daemon/src/claude-session/session-state.ts
@@ -150,6 +150,10 @@ export class SessionState {
     }
     const denyMessage = message ?? "Denied by session controller";
     if (this.lastToolCall) {
+      // errorMessage only captures permission denials. MCP tool execution errors
+      // (e.g. tool throws, non-zero exit) are not visible at the NDJSON layer —
+      // they flow through the MCP transport in server-pool and would need separate
+      // wiring to surface here (tracked in #1585 follow-up).
       this.lastToolCall.errorMessage = denyMessage;
     }
     return permissionDeny(requestId, denyMessage);

--- a/packages/daemon/src/claude-session/stuck-detector.spec.ts
+++ b/packages/daemon/src/claude-session/stuck-detector.spec.ts
@@ -222,4 +222,21 @@ describe("StuckDetector", () => {
     await pollUntil(() => events.length >= 2, 2000);
     expect(events[1].tier).toBe(2);
   });
+
+  test("constructor throws on empty thresholdsMs", () => {
+    expect(
+      () =>
+        new StuckDetector(
+          "test-session",
+          { thresholdsMs: [], repeatMs: 300 },
+          () => ({
+            state: "active" as SessionStateEnum,
+            tokens: 0,
+            lastToolCall: null,
+            pendingPermissionCount: 0,
+          }),
+          () => {},
+        ),
+    ).toThrow("thresholdsMs must be non-empty");
+  });
 });

--- a/packages/daemon/src/claude-session/stuck-detector.spec.ts
+++ b/packages/daemon/src/claude-session/stuck-detector.spec.ts
@@ -239,4 +239,34 @@ describe("StuckDetector", () => {
         ),
     ).toThrow("thresholdsMs must be non-empty");
   });
+
+  test("constructor throws on non-ascending thresholdsMs", () => {
+    const makeSnapshot = () => ({
+      state: "active" as SessionStateEnum,
+      tokens: 0,
+      lastToolCall: null,
+      pendingPermissionCount: 0,
+    });
+    expect(() => new StuckDetector("s", { thresholdsMs: [100, 100], repeatMs: 300 }, makeSnapshot, () => {})).toThrow(
+      "strictly ascending",
+    );
+    expect(() => new StuckDetector("s", { thresholdsMs: [200, 100], repeatMs: 300 }, makeSnapshot, () => {})).toThrow(
+      "strictly ascending",
+    );
+  });
+
+  test("constructor throws on non-positive repeatMs", () => {
+    const makeSnapshot = () => ({
+      state: "active" as SessionStateEnum,
+      tokens: 0,
+      lastToolCall: null,
+      pendingPermissionCount: 0,
+    });
+    expect(() => new StuckDetector("s", { thresholdsMs: [100], repeatMs: 0 }, makeSnapshot, () => {})).toThrow(
+      "repeatMs must be positive",
+    );
+    expect(() => new StuckDetector("s", { thresholdsMs: [100], repeatMs: -1 }, makeSnapshot, () => {})).toThrow(
+      "repeatMs must be positive",
+    );
+  });
 });

--- a/packages/daemon/src/claude-session/stuck-detector.spec.ts
+++ b/packages/daemon/src/claude-session/stuck-detector.spec.ts
@@ -1,0 +1,225 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import type { SessionStateEnum } from "@mcp-cli/core";
+import { pollUntil } from "../../../../test/harness";
+import { StuckDetector, type StuckDetectorConfig, type StuckEvent } from "./stuck-detector";
+
+const FAST_CONFIG: StuckDetectorConfig = {
+  thresholdsMs: [100, 200, 300],
+  repeatMs: 300,
+};
+
+interface MockSnapshot {
+  state: SessionStateEnum;
+  tokens: number;
+  lastToolCall: { name: string; errorMessage?: string; at: number } | null;
+  pendingPermissionCount: number;
+}
+
+function setup(overrides?: Partial<MockSnapshot>) {
+  const snapshot: MockSnapshot = {
+    state: "active",
+    tokens: 100,
+    lastToolCall: null,
+    pendingPermissionCount: 0,
+    ...overrides,
+  };
+  const events: StuckEvent[] = [];
+  const detector = new StuckDetector(
+    "test-session",
+    FAST_CONFIG,
+    () => snapshot,
+    (e) => events.push(e),
+  );
+  return { detector, snapshot, events };
+}
+
+describe("StuckDetector", () => {
+  let detector: StuckDetector | null = null;
+
+  afterEach(() => {
+    detector?.dispose();
+    detector = null;
+  });
+
+  test("fires tier 1 after first threshold", async () => {
+    const { detector: d, events } = setup();
+    detector = d;
+    d.recordProgress(100);
+
+    await pollUntil(() => events.length >= 1, 2000);
+    expect(events[0].tier).toBe(1);
+    expect(events[0].sessionId).toBe("test-session");
+    expect(events[0].sinceMs).toBeGreaterThanOrEqual(90);
+  });
+
+  test("escalates through tiers 1→2→3", async () => {
+    const { detector: d, events } = setup();
+    detector = d;
+    d.recordProgress(100);
+
+    await pollUntil(() => events.length >= 3, 2000);
+    expect(events[0].tier).toBe(1);
+    expect(events[1].tier).toBe(2);
+    expect(events[2].tier).toBe(3);
+  });
+
+  test("repeats tier 3 after all thresholds exhausted", async () => {
+    const { detector: d, events } = setup();
+    detector = d;
+    d.recordProgress(100);
+
+    await pollUntil(() => events.length >= 4, 3000);
+    expect(events[2].tier).toBe(3);
+    expect(events[3].tier).toBe(3);
+  });
+
+  test("progress resets timer — no stuck event fires", async () => {
+    const { detector: d, events } = setup();
+    detector = d;
+    d.recordProgress(100);
+
+    // Keep recording progress faster than the threshold
+    const interval = setInterval(() => d.recordProgress(100), 50);
+    await Bun.sleep(250);
+    clearInterval(interval);
+
+    expect(events.length).toBe(0);
+  });
+
+  test("progress resets tier counter — restarts from tier 1", async () => {
+    const { detector: d, events } = setup();
+    detector = d;
+    d.recordProgress(100);
+
+    // Wait for tier 1
+    await pollUntil(() => events.length >= 1, 2000);
+    expect(events[0].tier).toBe(1);
+
+    // Record progress — should reset
+    d.recordProgress(200);
+
+    // Next event should be tier 1 again, not tier 2
+    await pollUntil(() => events.length >= 2, 2000);
+    expect(events[1].tier).toBe(1);
+  });
+
+  test("permission request suspends detection", async () => {
+    const { detector: d, snapshot, events } = setup();
+    detector = d;
+
+    // Start with permission pending
+    snapshot.pendingPermissionCount = 1;
+    snapshot.state = "waiting_permission";
+    d.recordProgress(100);
+
+    // Wait well past threshold — should not fire
+    await Bun.sleep(250);
+    expect(events.length).toBe(0);
+
+    // Clear permission — detector should eventually fire
+    snapshot.pendingPermissionCount = 0;
+    snapshot.state = "active";
+
+    await pollUntil(() => events.length >= 1, 2000);
+    expect(events[0].tier).toBe(1);
+  });
+
+  test("non-active state stops detection", async () => {
+    const { detector: d, snapshot, events } = setup({ state: "idle" });
+    detector = d;
+    d.recordProgress(100);
+
+    await Bun.sleep(250);
+    expect(events.length).toBe(0);
+  });
+
+  test("tokenDelta tracks token changes between emissions", async () => {
+    const { detector: d, snapshot, events } = setup();
+    detector = d;
+    d.recordProgress(100);
+
+    // Add some tokens before tier 1 fires
+    snapshot.tokens = 112;
+
+    await pollUntil(() => events.length >= 1, 2000);
+    expect(events[0].tokenDelta).toBe(12);
+
+    // No more tokens before tier 2
+    await pollUntil(() => events.length >= 2, 2000);
+    expect(events[1].tokenDelta).toBe(0);
+  });
+
+  test("lastTool and lastToolError from snapshot", async () => {
+    const { detector: d, snapshot, events } = setup();
+    detector = d;
+    snapshot.lastToolCall = { name: "Monitor", errorMessage: "No matching rule", at: Date.now() };
+    d.recordProgress(100);
+
+    await pollUntil(() => events.length >= 1, 2000);
+    expect(events[0].lastTool).toBe("Monitor");
+    expect(events[0].lastToolError).toBe("No matching rule");
+  });
+
+  test("dispose prevents further emissions", async () => {
+    const { detector: d, events } = setup();
+    detector = d;
+    d.recordProgress(100);
+
+    d.dispose();
+    expect(d.isDisposed).toBe(true);
+
+    await Bun.sleep(200);
+    expect(events.length).toBe(0);
+  });
+
+  test("dispose is idempotent", () => {
+    const { detector: d } = setup();
+    detector = d;
+    d.dispose();
+    d.dispose();
+    expect(d.isDisposed).toBe(true);
+  });
+
+  test("no timer leak after dispose", async () => {
+    const { detector: d, events } = setup();
+    detector = d;
+    d.recordProgress(100);
+
+    // Dispose mid-flight
+    d.dispose();
+
+    // Wait past all thresholds
+    await Bun.sleep(500);
+    expect(events.length).toBe(0);
+  });
+
+  test("recordProgress after dispose is a no-op", async () => {
+    const { detector: d, events } = setup();
+    detector = d;
+    d.dispose();
+    d.recordProgress(100);
+
+    await Bun.sleep(200);
+    expect(events.length).toBe(0);
+  });
+
+  test("no duplicate emissions on flapping", async () => {
+    const { detector: d, events, snapshot } = setup();
+    detector = d;
+    d.recordProgress(100);
+
+    // Let tier 1 fire
+    await pollUntil(() => events.length >= 1, 2000);
+
+    // Flap: permission blocks, then unblocks rapidly
+    snapshot.state = "waiting_permission";
+    snapshot.pendingPermissionCount = 1;
+    await Bun.sleep(30);
+    snapshot.state = "active";
+    snapshot.pendingPermissionCount = 0;
+
+    // Should eventually get tier 2, not a duplicate tier 1
+    await pollUntil(() => events.length >= 2, 2000);
+    expect(events[1].tier).toBe(2);
+  });
+});

--- a/packages/daemon/src/claude-session/stuck-detector.spec.ts
+++ b/packages/daemon/src/claude-session/stuck-detector.spec.ts
@@ -255,6 +255,27 @@ describe("StuckDetector", () => {
     );
   });
 
+  test("constructor throws on non-positive thresholdsMs values", () => {
+    const makeSnapshot = () => ({
+      state: "active" as SessionStateEnum,
+      tokens: 0,
+      lastToolCall: null,
+      pendingPermissionCount: 0,
+    });
+    expect(() => new StuckDetector("s", { thresholdsMs: [0], repeatMs: 300 }, makeSnapshot, () => {})).toThrow(
+      "positive finite number",
+    );
+    expect(() => new StuckDetector("s", { thresholdsMs: [-100], repeatMs: 300 }, makeSnapshot, () => {})).toThrow(
+      "positive finite number",
+    );
+    expect(
+      () => new StuckDetector("s", { thresholdsMs: [Number.POSITIVE_INFINITY], repeatMs: 300 }, makeSnapshot, () => {}),
+    ).toThrow("positive finite number");
+    expect(
+      () => new StuckDetector("s", { thresholdsMs: [100, 0, 300], repeatMs: 300 }, makeSnapshot, () => {}),
+    ).toThrow("positive finite number");
+  });
+
   test("constructor throws on non-positive repeatMs", () => {
     const makeSnapshot = () => ({
       state: "active" as SessionStateEnum,

--- a/packages/daemon/src/claude-session/stuck-detector.ts
+++ b/packages/daemon/src/claude-session/stuck-detector.ts
@@ -46,6 +46,16 @@ export class StuckDetector {
     if (config.thresholdsMs.length === 0) {
       throw new Error("StuckDetectorConfig.thresholdsMs must be non-empty");
     }
+    for (let i = 1; i < config.thresholdsMs.length; i++) {
+      if (config.thresholdsMs[i] <= config.thresholdsMs[i - 1]) {
+        throw new Error(
+          `StuckDetectorConfig.thresholdsMs must be strictly ascending (index ${i}: ${config.thresholdsMs[i]} <= ${config.thresholdsMs[i - 1]})`,
+        );
+      }
+    }
+    if (config.repeatMs <= 0) {
+      throw new Error(`StuckDetectorConfig.repeatMs must be positive (got ${config.repeatMs})`);
+    }
     this.sessionId = sessionId;
     this.config = config;
     this.getSnapshot = getSnapshot;

--- a/packages/daemon/src/claude-session/stuck-detector.ts
+++ b/packages/daemon/src/claude-session/stuck-detector.ts
@@ -46,6 +46,13 @@ export class StuckDetector {
     if (config.thresholdsMs.length === 0) {
       throw new Error("StuckDetectorConfig.thresholdsMs must be non-empty");
     }
+    for (let i = 0; i < config.thresholdsMs.length; i++) {
+      if (!Number.isFinite(config.thresholdsMs[i]) || config.thresholdsMs[i] <= 0) {
+        throw new Error(
+          `StuckDetectorConfig.thresholdsMs[${i}] must be a positive finite number (got ${config.thresholdsMs[i]})`,
+        );
+      }
+    }
     for (let i = 1; i < config.thresholdsMs.length; i++) {
       if (config.thresholdsMs[i] <= config.thresholdsMs[i - 1]) {
         throw new Error(

--- a/packages/daemon/src/claude-session/stuck-detector.ts
+++ b/packages/daemon/src/claude-session/stuck-detector.ts
@@ -1,0 +1,134 @@
+import type { SessionStateEnum } from "@mcp-cli/core";
+
+export interface StuckEvent {
+  sessionId: string;
+  tier: number;
+  sinceMs: number;
+  tokenDelta: number;
+  lastTool: string | null;
+  lastToolError: string | null;
+}
+
+export interface StuckDetectorConfig {
+  thresholdsMs: number[];
+  repeatMs: number;
+}
+
+export const DEFAULT_STUCK_CONFIG: StuckDetectorConfig = {
+  thresholdsMs: [90_000, 180_000, 300_000],
+  repeatMs: 300_000,
+};
+
+interface SessionSnapshot {
+  state: SessionStateEnum;
+  tokens: number;
+  lastToolCall: { name: string; errorMessage?: string; at: number } | null;
+  pendingPermissionCount: number;
+}
+
+export class StuckDetector {
+  private timer: Timer | null = null;
+  private lastProgressAt = 0;
+  private emissionCount = 0;
+  private tokenSnapshot = 0;
+  private disposed = false;
+  private readonly config: StuckDetectorConfig;
+  private readonly sessionId: string;
+  private readonly getSnapshot: () => SessionSnapshot;
+  private readonly onStuck: (event: StuckEvent) => void;
+
+  constructor(
+    sessionId: string,
+    config: StuckDetectorConfig,
+    getSnapshot: () => SessionSnapshot,
+    onStuck: (event: StuckEvent) => void,
+  ) {
+    this.sessionId = sessionId;
+    this.config = config;
+    this.getSnapshot = getSnapshot;
+    this.onStuck = onStuck;
+  }
+
+  get isDisposed(): boolean {
+    return this.disposed;
+  }
+
+  get currentTier(): number {
+    return this.tierForEmission(this.emissionCount);
+  }
+
+  recordProgress(tokens: number): void {
+    if (this.disposed) return;
+    this.lastProgressAt = Date.now();
+    this.emissionCount = 0;
+    this.tokenSnapshot = tokens;
+    this.scheduleNext();
+  }
+
+  stop(): void {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  dispose(): void {
+    this.stop();
+    this.disposed = true;
+  }
+
+  private scheduleNext(): void {
+    this.stop();
+    const delayMs = this.nextDelayMs(this.emissionCount);
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      this.evaluate();
+    }, delayMs);
+  }
+
+  private evaluate(): void {
+    if (this.disposed) return;
+
+    const snapshot = this.getSnapshot();
+
+    if (snapshot.pendingPermissionCount > 0 || snapshot.state === "waiting_permission") {
+      this.scheduleNext();
+      return;
+    }
+
+    if (snapshot.state !== "active") {
+      return;
+    }
+
+    const elapsed = Date.now() - this.lastProgressAt;
+    const nextTier = this.tierForEmission(this.emissionCount);
+
+    const tokenDelta = snapshot.tokens - this.tokenSnapshot;
+    this.tokenSnapshot = snapshot.tokens;
+    this.emissionCount++;
+
+    this.onStuck({
+      sessionId: this.sessionId,
+      tier: nextTier,
+      sinceMs: elapsed,
+      tokenDelta,
+      lastTool: snapshot.lastToolCall?.name ?? null,
+      lastToolError: snapshot.lastToolCall?.errorMessage ?? null,
+    });
+
+    this.scheduleNext();
+  }
+
+  private tierForEmission(emissionCount: number): number {
+    return Math.min(emissionCount + 1, this.config.thresholdsMs.length);
+  }
+
+  private nextDelayMs(emissionCount: number): number {
+    const { thresholdsMs, repeatMs } = this.config;
+    if (emissionCount === 0) return thresholdsMs[0];
+    if (emissionCount < thresholdsMs.length) {
+      return thresholdsMs[emissionCount] - thresholdsMs[emissionCount - 1];
+    }
+    return repeatMs;
+  }
+}

--- a/packages/daemon/src/claude-session/stuck-detector.ts
+++ b/packages/daemon/src/claude-session/stuck-detector.ts
@@ -43,6 +43,9 @@ export class StuckDetector {
     getSnapshot: () => SessionSnapshot,
     onStuck: (event: StuckEvent) => void,
   ) {
+    if (config.thresholdsMs.length === 0) {
+      throw new Error("StuckDetectorConfig.thresholdsMs must be non-empty");
+    }
     this.sessionId = sessionId;
     this.config = config;
     this.getSnapshot = getSnapshot;
@@ -59,7 +62,7 @@ export class StuckDetector {
 
   recordProgress(tokens: number): void {
     if (this.disposed) return;
-    this.lastProgressAt = Date.now();
+    this.lastProgressAt = performance.now();
     this.emissionCount = 0;
     this.tokenSnapshot = tokens;
     this.scheduleNext();
@@ -100,7 +103,7 @@ export class StuckDetector {
       return;
     }
 
-    const elapsed = Date.now() - this.lastProgressAt;
+    const elapsed = performance.now() - this.lastProgressAt;
     const nextTier = this.tierForEmission(this.emissionCount);
 
     const tokenDelta = snapshot.tokens - this.tokenSnapshot;
@@ -116,6 +119,7 @@ export class StuckDetector {
       lastToolError: snapshot.lastToolCall?.errorMessage ?? null,
     });
 
+    if (this.disposed) return;
     this.scheduleNext();
   }
 

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -4220,3 +4220,148 @@ describe("monitor event mapping", () => {
     });
   });
 });
+
+// ── Stuck detector integration (#1585) ──
+
+describe("stuck detector integration", () => {
+  let server: ClaudeWsServer | undefined;
+
+  afterEach(() => {
+    server?.stop();
+    server = undefined;
+  });
+
+  test("session.stuck fires after stall threshold", async () => {
+    const spawnState = mockSpawn();
+    const monitorEvents: MonitorEventInput[] = [];
+    server = new ClaudeWsServer({
+      spawn: spawnState.spawn,
+      logger: silentLogger,
+      stuckConfig: { thresholdsMs: [100, 200, 300], repeatMs: 300 },
+    });
+    server.onMonitorEvent = (input) => monitorEvents.push(input);
+
+    const port = await server.start();
+    const sessionId = "stuck-test-1";
+    server.prepareSession(sessionId, { prompt: "test", permissionStrategy: "auto" });
+    server.spawnClaude(sessionId);
+
+    // Connect and drive to active state
+    const ws = await connectMockClaude(port, sessionId);
+    await waitForMessage(ws);
+    ws.send(systemInitMessage(sessionId));
+    ws.send(assistantMessage(sessionId));
+    await pollUntil(() => server?.listSessions().some((s) => s.state === "active"));
+
+    // Now session is active — wait for stuck event
+    await pollUntil(() => monitorEvents.some((e) => e.event === "session.stuck"), 2000);
+
+    const stuckEvt = monitorEvents.find((e) => e.event === "session.stuck");
+    expect(stuckEvt).toBeDefined();
+    expect(stuckEvt?.tier).toBe(1);
+    expect(stuckEvt?.sessionId).toBe(sessionId);
+    expect(typeof stuckEvt?.sinceMs).toBe("number");
+
+    ws.close();
+  });
+
+  test("no timer leak after session:result", async () => {
+    const spawnState = mockSpawn();
+    const monitorEvents: MonitorEventInput[] = [];
+    server = new ClaudeWsServer({
+      spawn: spawnState.spawn,
+      logger: silentLogger,
+      stuckConfig: { thresholdsMs: [100, 200, 300], repeatMs: 300 },
+    });
+    server.onMonitorEvent = (input) => monitorEvents.push(input);
+
+    const port = await server.start();
+    const sessionId = "stuck-leak-test";
+    server.prepareSession(sessionId, { prompt: "test", permissionStrategy: "auto" });
+    server.spawnClaude(sessionId);
+
+    const ws = await connectMockClaude(port, sessionId);
+    await waitForMessage(ws);
+    ws.send(systemInitMessage(sessionId));
+    ws.send(assistantMessage(sessionId));
+    await pollUntil(() => server?.listSessions().some((s) => s.state === "active"));
+
+    // Send result — session goes idle, stuck detector should be disposed
+    ws.send(resultMessage(sessionId));
+    await pollUntil(() => server?.listSessions().some((s) => s.state === "idle"));
+
+    const stuckBefore = monitorEvents.filter((e) => e.event === "session.stuck").length;
+
+    // Wait past all thresholds — no stuck events should fire
+    await Bun.sleep(400);
+    const stuckAfter = monitorEvents.filter((e) => e.event === "session.stuck").length;
+    expect(stuckAfter).toBe(stuckBefore);
+
+    ws.close();
+  });
+
+  test("no timer leak after session:ended via bye", async () => {
+    const spawnState = mockSpawn();
+    const monitorEvents: MonitorEventInput[] = [];
+    server = new ClaudeWsServer({
+      spawn: spawnState.spawn,
+      logger: silentLogger,
+      stuckConfig: { thresholdsMs: [150, 300, 450], repeatMs: 450 },
+    });
+    server.onMonitorEvent = (input) => monitorEvents.push(input);
+
+    const port = await server.start();
+    const sessionId = "stuck-bye-test";
+    server.prepareSession(sessionId, { prompt: "test", permissionStrategy: "auto" });
+    server.spawnClaude(sessionId);
+
+    const ws = await connectMockClaude(port, sessionId);
+    await waitForMessage(ws);
+    ws.send(systemInitMessage(sessionId));
+    ws.send(assistantMessage(sessionId));
+    await pollUntil(() => server?.listSessions().some((s) => s.state === "active"));
+
+    // End session via bye — terminateSession disposes detector
+    await server.bye(sessionId);
+
+    const stuckBefore = monitorEvents.filter((e) => e.event === "session.stuck").length;
+    await Bun.sleep(400);
+    const stuckAfter = monitorEvents.filter((e) => e.event === "session.stuck").length;
+    expect(stuckAfter).toBe(stuckBefore);
+
+    ws.close();
+  });
+
+  test("stuck event includes workItemId from session config", async () => {
+    const spawnState = mockSpawn();
+    const monitorEvents: MonitorEventInput[] = [];
+    server = new ClaudeWsServer({
+      spawn: spawnState.spawn,
+      logger: silentLogger,
+      stuckConfig: { thresholdsMs: [80, 160, 240], repeatMs: 240 },
+    });
+    server.onMonitorEvent = (input) => monitorEvents.push(input);
+
+    const port = await server.start();
+    const sessionId = "stuck-wi-test";
+    server.prepareSession(sessionId, {
+      prompt: "test",
+      permissionStrategy: "auto",
+      worktree: "/tmp/wt-1585",
+    });
+    server.spawnClaude(sessionId);
+
+    const ws = await connectMockClaude(port, sessionId);
+    await waitForMessage(ws);
+    ws.send(systemInitMessage(sessionId));
+    ws.send(assistantMessage(sessionId));
+    await pollUntil(() => server?.listSessions().some((s) => s.state === "active"));
+
+    await pollUntil(() => monitorEvents.some((e) => e.event === "session.stuck"), 2000);
+
+    const stuckEvt = monitorEvents.find((e) => e.event === "session.stuck");
+    expect(stuckEvt?.workItemId).toBe("/tmp/wt-1585");
+
+    ws.close();
+  });
+});

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -4364,4 +4364,32 @@ describe("stuck detector integration", () => {
 
     ws.close();
   });
+
+  test("waitForEvent resolves with stuck diagnostic fields", async () => {
+    const spawnState = mockSpawn();
+    server = new ClaudeWsServer({
+      spawn: spawnState.spawn,
+      logger: silentLogger,
+      stuckConfig: { thresholdsMs: [80, 160, 240], repeatMs: 240 },
+    });
+
+    const port = await server.start();
+    const sessionId = "stuck-waiter-test";
+    server.prepareSession(sessionId, { prompt: "test", permissionStrategy: "auto" });
+    server.spawnClaude(sessionId);
+
+    const ws = await connectMockClaude(port, sessionId);
+    await waitForMessage(ws);
+    ws.send(systemInitMessage(sessionId));
+    ws.send(assistantMessage(sessionId));
+    await pollUntil(() => server?.listSessions().some((s) => s.state === "active"));
+
+    const waitedEvent = await server.waitForEvent(sessionId, 2000);
+    expect(waitedEvent.event).toBe("session:stuck");
+    expect(typeof waitedEvent.tier).toBe("number");
+    expect(typeof waitedEvent.sinceMs).toBe("number");
+    expect(typeof waitedEvent.tokenDelta).toBe("number");
+
+    ws.close();
+  });
 });

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -45,6 +45,7 @@ import {
   SESSION_PERMISSION_REQUEST,
   SESSION_RATE_LIMITED,
   SESSION_RESULT,
+  SESSION_STUCK,
   consoleLogger,
   generateSessionName,
 } from "@mcp-cli/core";
@@ -57,6 +58,7 @@ import type { CanUseToolRequest, PermissionRule, PermissionStrategy } from "./pe
 import { PermissionRouter } from "./permission-router";
 import type { SessionEvent } from "./session-state";
 import { IGNORED_TYPES, SessionState } from "./session-state";
+import { DEFAULT_STUCK_CONFIG, StuckDetector, type StuckDetectorConfig, type StuckEvent } from "./stuck-detector";
 
 // ── Constants ──
 
@@ -318,6 +320,8 @@ interface WsSession {
   createdAt: number;
   /** W3C traceparent used for the last spawn — reused on respawn after clear. */
   traceparent: string | null;
+  /** Per-session idle watchdog — detects stalled sessions (#1585). */
+  stuckDetector: StuckDetector | null;
   /**
    * Whether this session has an unreported actionable state (idle or waiting_permission).
    * Set to true when the session transitions to an actionable state via a real event.
@@ -377,6 +381,7 @@ export class ClaudeWsServer {
   private readonly portRetryDelayMs: number;
   private readonly reclaimIntervalMs: number;
   private readonly connectTimeoutMs: number;
+  private readonly stuckConfig: StuckDetectorConfig;
   private eventSeq = 0;
   private readonly eventBuffer: BufferedEvent[] = [];
   private nextRequestId = 1;
@@ -396,6 +401,7 @@ export class ClaudeWsServer {
     portRetryDelayMs?: number;
     reclaimIntervalMs?: number;
     connectTimeoutMs?: number;
+    stuckConfig?: StuckDetectorConfig;
   }) {
     this.spawn = deps?.spawn ?? defaultSpawn;
     this.killTimeoutMs = deps?.killTimeoutMs ?? KILL_TIMEOUT_MS;
@@ -404,6 +410,7 @@ export class ClaudeWsServer {
     this.portRetryDelayMs = deps?.portRetryDelayMs ?? 500;
     this.reclaimIntervalMs = deps?.reclaimIntervalMs ?? PORT_RECLAIM_INTERVAL_MS;
     this.connectTimeoutMs = deps?.connectTimeoutMs ?? CONNECT_TIMEOUT_MS;
+    this.stuckConfig = deps?.stuckConfig ?? DEFAULT_STUCK_CONFIG;
   }
 
   /** Current event sequence number (monotonically increasing). */
@@ -592,6 +599,7 @@ export class ClaudeWsServer {
         pendingImmediate: false, // Restored sessions have no new events
         workCompleted: false,
         traceparent: null,
+        stuckDetector: null,
       });
       restored++;
       this.logger.info(`[_claude] Restored session ${s.sessionId} (state: disconnected, pid: ${s.pid})`);
@@ -642,6 +650,7 @@ export class ClaudeWsServer {
       pendingImmediate: false,
       workCompleted: false,
       traceparent: null,
+      stuckDetector: null,
     });
     return name;
   }
@@ -843,6 +852,7 @@ export class ClaudeWsServer {
     const outbound = session.state.queuePrompt(message);
     this.sendToWs(session, outbound);
     this.addTranscript(session, "outbound", { type: "user", message: { role: "user", content: message } });
+    this.recordSessionProgress(sessionId, session);
   }
 
   /** Respond to a pending permission request. */
@@ -850,6 +860,7 @@ export class ClaudeWsServer {
     const session = this.getSession(sessionId);
     const outbound = session.state.respondToPermission(requestId, allow, message);
     this.sendToWs(session, outbound);
+    this.recordSessionProgress(sessionId, session);
   }
 
   /** Interrupt the current turn. */
@@ -1507,9 +1518,14 @@ export class ClaudeWsServer {
       case "session:init":
         // Capture Claude Code's own session ID for JSONL file lookup
         session.claudeSessionId = event.sessionId;
+        this.recordSessionProgress(sessionId, session);
+        break;
+      case "session:response":
+        this.recordSessionProgress(sessionId, session);
         break;
       case "session:permission_request":
         session.pendingImmediate = true;
+        this.recordSessionProgress(sessionId, session);
         try {
           this.resolveEventWaiters(sessionId, {
             sessionId,
@@ -1529,6 +1545,7 @@ export class ClaudeWsServer {
       case "session:result":
         session.pendingImmediate = true;
         session.workCompleted = true;
+        this.disposeStuckDetector(session);
         try {
           this.resolveEventWaiters(sessionId, {
             sessionId,
@@ -1557,6 +1574,7 @@ export class ClaudeWsServer {
       case "session:error":
         session.pendingImmediate = true;
         session.workCompleted = true;
+        this.disposeStuckDetector(session);
         try {
           this.resolveEventWaiters(sessionId, {
             sessionId,
@@ -1581,6 +1599,7 @@ export class ClaudeWsServer {
         }
         break;
       case "session:cleared":
+        this.disposeStuckDetector(session);
         try {
           this.resolveEventWaiters(sessionId, {
             sessionId,
@@ -1612,6 +1631,7 @@ export class ClaudeWsServer {
         }
         break;
       case "session:disconnected":
+        this.disposeStuckDetector(session);
         try {
           this.resolveEventWaiters(sessionId, {
             sessionId,
@@ -1785,6 +1805,61 @@ export class ClaudeWsServer {
 
     session.state.respondToPermission(requestId, decision.allow, decision.message);
     this.sendToWs(session, outbound);
+  }
+
+  // ── Stuck detection (#1585) ──
+
+  private ensureStuckDetector(sessionId: string, session: WsSession): StuckDetector {
+    if (!session.stuckDetector || session.stuckDetector.isDisposed) {
+      session.stuckDetector = new StuckDetector(
+        sessionId,
+        this.stuckConfig,
+        () => ({
+          state: session.state.state,
+          tokens: session.state.tokens,
+          lastToolCall: session.state.lastToolCall,
+          pendingPermissionCount: session.state.pendingPermissions.size,
+        }),
+        (event) => this.handleStuckEvent(sessionId, session, event),
+      );
+    }
+    return session.stuckDetector;
+  }
+
+  private recordSessionProgress(sessionId: string, session: WsSession): void {
+    const detector = this.ensureStuckDetector(sessionId, session);
+    detector.recordProgress(session.state.tokens);
+  }
+
+  private disposeStuckDetector(session: WsSession): void {
+    if (session.stuckDetector) {
+      session.stuckDetector.dispose();
+      session.stuckDetector = null;
+    }
+  }
+
+  private handleStuckEvent(sessionId: string, session: WsSession, event: StuckEvent): void {
+    const workItemId = session.config.worktree ?? undefined;
+
+    this.resolveEventWaiters(sessionId, {
+      sessionId,
+      event: "session:stuck",
+    });
+
+    if (this.onMonitorEvent) {
+      this.onMonitorEvent({
+        src: "daemon.claude-server",
+        event: SESSION_STUCK,
+        category: "session",
+        sessionId,
+        workItemId,
+        tier: event.tier,
+        sinceMs: event.sinceMs,
+        tokenDelta: event.tokenDelta,
+        lastTool: event.lastTool,
+        lastToolError: event.lastToolError,
+      });
+    }
   }
 
   // ── Helpers ──
@@ -2021,6 +2096,9 @@ export class ClaudeWsServer {
    * close WS, kill process, remove from sessions map.
    */
   private async terminateSession(sessionId: string, session: WsSession, errorMessage: string): Promise<void> {
+    // Dispose stuck detector before ending
+    this.disposeStuckDetector(session);
+
     // End state machine (idempotent — returns [] if already ended)
     const events = session.state.end();
     for (const event of events) {

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -253,6 +253,12 @@ export interface SessionWaitEvent {
   requestId?: string;
   toolName?: string;
   strikes?: number;
+  /** Stuck-event fields (present when event === "session:stuck"). */
+  tier?: number;
+  sinceMs?: number;
+  tokenDelta?: number;
+  lastTool?: string | null;
+  lastToolError?: string | null;
   /** Full session snapshot at the time of the event (same fields as claude_session_list). */
   session?: SessionInfo;
 }
@@ -1844,6 +1850,11 @@ export class ClaudeWsServer {
     this.resolveEventWaiters(sessionId, {
       sessionId,
       event: "session:stuck",
+      tier: event.tier,
+      sinceMs: event.sinceMs,
+      tokenDelta: event.tokenDelta,
+      lastTool: event.lastTool,
+      lastToolError: event.lastToolError,
     });
 
     if (this.onMonitorEvent) {

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -1468,6 +1468,13 @@ export class ClaudeWsServer {
         );
       }
 
+      // tool_progress and stream_event are ignored by the state machine but
+      // represent active execution — treat them as progress to prevent false
+      // stuck-detector fires during long-running tools or streaming responses.
+      if (msg.type === "tool_progress" || msg.type === "stream_event") {
+        this.recordSessionProgress(sessionId, session);
+      }
+
       // Log unrecognized message types (not in IGNORED_TYPES, not a known handler).
       // This helps detect new CLI message types that the daemon should handle.
       if (events.length === 0 && !session.state.parseMismatch && !KNOWN_MSG_TYPES.has(msg.type)) {
@@ -1851,29 +1858,35 @@ export class ClaudeWsServer {
   private handleStuckEvent(sessionId: string, session: WsSession, event: StuckEvent): void {
     const workItemId = session.config.worktree ?? undefined;
 
-    this.resolveEventWaiters(sessionId, {
-      sessionId,
-      event: "session:stuck",
-      tier: event.tier,
-      sinceMs: event.sinceMs,
-      tokenDelta: event.tokenDelta,
-      lastTool: event.lastTool,
-      lastToolError: event.lastToolError,
-    });
-
-    if (this.onMonitorEvent) {
-      this.onMonitorEvent({
-        src: "daemon.claude-server",
-        event: SESSION_STUCK,
-        category: "session",
+    try {
+      this.resolveEventWaiters(sessionId, {
         sessionId,
-        workItemId,
+        event: "session:stuck",
         tier: event.tier,
         sinceMs: event.sinceMs,
         tokenDelta: event.tokenDelta,
         lastTool: event.lastTool,
         lastToolError: event.lastToolError,
       });
+
+      if (this.onMonitorEvent) {
+        this.onMonitorEvent({
+          src: "daemon.claude-server",
+          event: SESSION_STUCK,
+          category: "session",
+          sessionId,
+          workItemId,
+          tier: event.tier,
+          sinceMs: event.sinceMs,
+          tokenDelta: event.tokenDelta,
+          lastTool: event.lastTool,
+          lastToolError: event.lastToolError,
+        });
+      }
+    } catch (err) {
+      this.logger.error(
+        `[_claude] Failed to handle stuck session event for ${sessionId}: ${err instanceof Error ? err.stack : err}`,
+      );
     }
   }
 

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -1344,6 +1344,10 @@ export class ClaudeWsServer {
     const prevState = session.state.state;
     session.ws = null;
 
+    // Dispose immediately — handleSessionEvent is not invoked from this path,
+    // so the session:disconnected case there would never fire.
+    this.disposeStuckDetector(session);
+
     if (session.keepAliveTimer) {
       clearInterval(session.keepAliveTimer);
       session.keepAliveTimer = null;


### PR DESCRIPTION
## Summary
- Emit `session.stuck` monitor event at escalating tiers (90s / 180s / 300s, then repeat) when a session stalls with no token/tool progress
- `StuckDetector` class with explicit `dispose()` owns all timer handles — disposed on every exit path: `session:result`, `session:error`, `session:ended`, `session:disconnected`, `session:cleared`, and `terminateSession`
- Track `lastToolCall` (name + errorMessage from permission denials) on `SessionState` for stuck event payload
- Watchdog pauses while session is `waiting_permission` (not stuck, just blocked on user)

## Test plan
- [x] 14 unit tests for `StuckDetector`: tier escalation, progress reset, permission suspension, dispose/leak prevention, tokenDelta tracking, flapping
- [x] 6 `lastToolCall` unit tests in session-state.spec.ts: extraction from tool_use blocks, error from permission denial
- [x] 4 integration tests in ws-server.spec.ts: stuck event fires after threshold, no timer leak after session:result, no timer leak after bye (session:ended), workItemId propagation
- [x] typecheck, lint, full test suite (5938 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)