### PR TITLE
fix(phase): actionable drift error — show locked→current hashes and recovery step (fixes #1747)

### DIFF
--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -641,15 +641,17 @@ describe("cmdPhase dispatch", () => {
     writeFileSync(join(dir, "qa.ts"), `${readFileSync(join(dir, "qa.ts"), "utf-8")}\n// tampered\n`);
     const { code, err } = await catchExit(() => cmdPhase(["run", "qa", "--from", "impl"], { cwd: () => dir }));
     expect(code).toBe(1);
-    expect(err).toContain("PHASE LOCKFILE DRIFT DETECTED");
+    expect(err).toContain("out of date");
     expect(err).toContain("qa.ts");
+    expect(err).toContain("mcx phase install");
   });
 
   test("run --dry-run aborts on drift before dispatch", async () => {
     writeFileSync(join(dir, "qa.ts"), `${readFileSync(join(dir, "qa.ts"), "utf-8")}\n// tampered\n`);
     const { code, err } = await catchExit(() => cmdPhase(["run", "qa", "--dry-run"], { cwd: () => dir }));
     expect(code).toBe(1);
-    expect(err).toContain("PHASE LOCKFILE DRIFT DETECTED");
+    expect(err).toContain("out of date");
+    expect(err).toContain("mcx phase install");
   });
 
   test("unknown subcommand exits 1", async () => {
@@ -1082,7 +1084,7 @@ phases:
 });
 
 describe("formatDriftWarning", () => {
-  test("contains stern security-review language and the hashes", () => {
+  test("shows locked→current hashes and actionable recovery instruction", () => {
     const msg = formatDriftWarning([
       {
         kind: "manifest",
@@ -1097,13 +1099,25 @@ describe("formatDriftWarning", () => {
         actual: "d".repeat(64),
       },
     ]);
-    expect(msg).toContain("PHASE LOCKFILE DRIFT DETECTED");
-    expect(msg).toContain("HASH MISMATCH");
-    expect(msg).toContain("aaaaaa");
-    expect(msg).toContain("bbbbbb");
-    expect(msg).toContain("malicious PR");
+    expect(msg).toContain("out of date");
+    expect(msg).toContain("locked aaaaaa → bbbbbb");
+    expect(msg).toContain("locked cccccc → dddddd");
     expect(msg).toContain("mcx phase install");
-    expect(msg).not.toMatch(/run `mcx phase install` to fix/);
+    expect(msg).toContain("stage and commit .mcx.lock");
+  });
+
+  test("single phase-source change names the file and shows both hashes", () => {
+    const msg = formatDriftWarning([
+      {
+        kind: "phase-source",
+        path: ".claude/phases/qa.ts",
+        expected: "20c6ac88".padEnd(64, "0"),
+        actual: "4f5e12bc".padEnd(64, "0"),
+      },
+    ]);
+    expect(msg).toContain(".claude/phases/qa.ts");
+    expect(msg).toContain("locked 20c6ac → 4f5e12");
+    expect(msg).toContain("mcx phase install");
   });
 
   test("labels phase-missing as NOT INSTALLED", () => {
@@ -1298,8 +1312,9 @@ describe("cmdPhase check", () => {
     await cmdPhase(["check"], deps).catch(() => {});
     expect(getExitCode()).toBe(1);
     const joined = errs.join("\n");
-    expect(joined).toContain("PHASE LOCKFILE DRIFT DETECTED");
+    expect(joined).toContain("out of date");
     expect(joined).toContain("impl.ts");
+    expect(joined).toContain("mcx phase install");
   }, 20_000);
 
   test("exits zero with `lockfile ok` when clean", async () => {

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -500,33 +500,42 @@ export function detectDrift(deps: DriftDeps): DriftResult {
 }
 
 /**
- * Render the stern drift warning. No "just run install" prompt — the user
- * must review the diff first, then regenerate the lockfile explicitly.
+ * Render an actionable drift warning that names each changed file, shows both
+ * hashes in "locked X → current Y" form, and tells the reader how to recover.
  */
 export function formatDriftWarning(entries: DriftEntry[]): string {
-  const header =
-    "PHASE LOCKFILE DRIFT DETECTED\n\nThe manifest or a phase source has changed since the last install:\n";
   const width = Math.max(20, ...entries.map((e) => e.path.length));
   const rows = entries
     .map((e) => {
-      const label = labelFor(e.kind);
-      const exp = shortHash(e.expected);
-      const act = shortHash(e.actual);
-      return `  ${e.path.padEnd(width)}  [${label}]  expected ${exp}, got ${act}`;
+      switch (e.kind) {
+        case "manifest":
+        case "phase-source": {
+          const exp = shortHash(e.expected);
+          const act = shortHash(e.actual);
+          return `  ${e.path.padEnd(width)}  locked ${exp} → ${act}`;
+        }
+        case "phase-missing":
+          return `  ${e.path.padEnd(width)}  [NOT INSTALLED] — phase in manifest but missing from lockfile`;
+        case "phase-extra":
+          return `  ${e.path.padEnd(width)}  [STALE LOCK ENTRY] — phase in lockfile but removed from manifest`;
+        case "corrupt-lockfile": {
+          const act = shortHash(e.actual);
+          return `  ${e.path.padEnd(width)}  [CORRUPT LOCKFILE] — ${act}`;
+        }
+      }
     })
     .join("\n");
-  const footer = `
-
-Phases will not execute until the lockfile is regenerated.
-
-Before regenerating:
-  - Review the diff. A malicious PR can inject phase source that runs at
-    orchestrator time with full shell/mcp access.
-  - Confirm the changes are intentional and reviewed.
-  - Understand that re-running install makes them executable.
-
-To regenerate after review:  mcx phase install`;
-  return `${header}\n${rows}${footer}`;
+  return [
+    "mcx phase: .mcx.lock is out of date",
+    "",
+    "Changes detected since last `mcx phase install`:",
+    "",
+    rows,
+    "",
+    "If this was intentional, run 'mcx phase install' to regenerate .mcx.lock,",
+    "then stage and commit .mcx.lock alongside the script change so future",
+    "orchestrators don't hit this error.",
+  ].join("\n");
 }
 
 /**
@@ -551,20 +560,6 @@ function assertNoDrift(d: PhaseInstallDeps): void {
       break;
   }
   d.exit(1);
-}
-
-function labelFor(kind: DriftKind): string {
-  switch (kind) {
-    case "manifest":
-    case "phase-source":
-      return "HASH MISMATCH";
-    case "phase-missing":
-      return "NOT INSTALLED";
-    case "phase-extra":
-      return "STALE LOCK ENTRY";
-    case "corrupt-lockfile":
-      return "CORRUPT LOCKFILE";
-  }
 }
 
 function shortHash(s: string): string {

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -501,7 +501,7 @@ export function detectDrift(deps: DriftDeps): DriftResult {
 
 /**
  * Render an actionable drift warning that names each changed file, shows both
- * hashes in "locked X → current Y" form, and tells the reader how to recover.
+ * hashes in "locked X → Y" form, and tells the reader how to recover.
  */
 export function formatDriftWarning(entries: DriftEntry[]): string {
   const width = Math.max(20, ...entries.map((e) => e.path.length));
@@ -514,10 +514,14 @@ export function formatDriftWarning(entries: DriftEntry[]): string {
           const act = shortHash(e.actual);
           return `  ${e.path.padEnd(width)}  locked ${exp} → ${act}`;
         }
-        case "phase-missing":
-          return `  ${e.path.padEnd(width)}  [NOT INSTALLED] — phase in manifest but missing from lockfile`;
-        case "phase-extra":
-          return `  ${e.path.padEnd(width)}  [STALE LOCK ENTRY] — phase in lockfile but removed from manifest`;
+        case "phase-missing": {
+          const detail = e.expected || "phase in manifest";
+          return `  ${e.path.padEnd(width)}  [NOT INSTALLED] — ${detail} but missing from lockfile`;
+        }
+        case "phase-extra": {
+          const detail = e.actual || "phase in lockfile";
+          return `  ${e.path.padEnd(width)}  [STALE LOCK ENTRY] — ${detail} but removed from manifest`;
+        }
         case "corrupt-lockfile": {
           const act = shortHash(e.actual);
           return `  ${e.path.padEnd(width)}  [CORRUPT LOCKFILE] — ${act}`;
@@ -526,14 +530,14 @@ export function formatDriftWarning(entries: DriftEntry[]): string {
     })
     .join("\n");
   return [
-    "mcx phase: .mcx.lock is out of date",
+    `mcx phase: ${LOCKFILE_NAME} is out of date`,
     "",
     "Changes detected since last `mcx phase install`:",
     "",
     rows,
     "",
-    "If this was intentional, run 'mcx phase install' to regenerate .mcx.lock,",
-    "then stage and commit .mcx.lock alongside the script change so future",
+    `If this was intentional, run \`mcx phase install\` to regenerate ${LOCKFILE_NAME},`,
+    `then stage and commit ${LOCKFILE_NAME} alongside the script change so future`,
     "orchestrators don't hit this error.",
   ].join("\n");
 }


### PR DESCRIPTION
## Summary
- Replaces the opaque `HASH MISMATCH` / `PHASE LOCKFILE DRIFT DETECTED` error with a structured message that names each changed file and shows `locked X → Y` for content-hash changes
- Footer replaced with a single actionable instruction: run `mcx phase install`, then stage and commit `.mcx.lock`
- Applies uniformly to `mcx phase run`, `mcx phase check`, and any other path that calls `formatDriftWarning`

## Test plan
- [x] `formatDriftWarning` unit tests updated to check for `"out of date"`, `"locked X → Y"`, `"mcx phase install"`, and `"stage and commit .mcx.lock"`; old assertions for `PHASE LOCKFILE DRIFT DETECTED` / `HASH MISMATCH` / `malicious PR` removed
- [x] Integration tests for `run` and `run --dry-run` tamper paths updated to check actionable message content
- [x] `mcx phase check` integration test updated
- [x] Full suite: 5915 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)