### PR TITLE
feat(cli): add help dispatcher for subcommands (fixes #1518)

### DIFF
--- a/packages/command/src/commands/agent.spec.ts
+++ b/packages/command/src/commands/agent.spec.ts
@@ -1889,3 +1889,43 @@ describe("agent deny", () => {
     await expect(cmdAgent(["codex", "deny"], deps)).rejects.toThrow(ExitError);
   });
 });
+
+// ── help dispatcher (production path) ──
+
+describe("help dispatcher", () => {
+  test("claude wait --help prints help via registry (production path)", async () => {
+    const deps = makeDeps();
+    await cmdAgent(["claude", "wait", "--help"], deps);
+    const output = logCalls(deps).join("\n");
+    expect(output).toContain("mcx claude wait");
+    expect(output).toContain("--timeout");
+    expect(output).toContain("--all");
+    expect(deps.callTool).not.toHaveBeenCalled();
+  });
+
+  test("claude bye --all --help shows help instead of ending sessions", async () => {
+    const deps = makeDeps();
+    await cmdAgent(["claude", "bye", "--all", "--help"], deps);
+    const output = logCalls(deps).join("\n");
+    expect(output).toContain("mcx claude bye");
+    expect(deps.callTool).not.toHaveBeenCalled();
+  });
+
+  test("non-claude provider uses providerName for help lookup", async () => {
+    const deps = makeDeps();
+    await cmdAgent(["codex", "wait", "--help"], deps);
+    const output = logCalls(deps).join("\n");
+    expect(output).toContain("No detailed help available");
+    expect(output).toContain("codex");
+    expect(deps.callTool).not.toHaveBeenCalled();
+  });
+
+  test("unregistered subcommand with --help shows fallback message", async () => {
+    const deps = makeDeps();
+    await cmdAgent(["claude", "bogus", "--help"], deps);
+    const output = logCalls(deps).join("\n");
+    expect(output).toContain("No detailed help available");
+    expect(output).toContain("claude");
+    expect(deps.callTool).not.toHaveBeenCalled();
+  });
+});

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -11,6 +11,8 @@
 import { existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import type { AgentFeatures, AgentProvider, MailMessage } from "@mcp-cli/core";
+import { formatHelp, getHelp, hasHelpFlag } from "../help";
+import "../help-claude";
 import {
   PROMPT_IPC_TIMEOUT_MS,
   WorktreeError,
@@ -294,42 +296,51 @@ export async function cmdAgent(args: string[], deps?: Partial<AgentDeps>): Promi
     return;
   }
 
+  const subArgs = args.slice(2);
+  if (sub !== "spawn" && hasHelpFlag(subArgs)) {
+    const help = getHelp(`claude ${sub}`);
+    if (help) {
+      d.log(formatHelp(help));
+      return;
+    }
+  }
+
   switch (sub) {
     case "spawn":
-      await agentSpawn(args.slice(2), provider, agentOverride, d);
+      await agentSpawn(subArgs, provider, agentOverride, d);
       break;
     case "ls":
     case "list":
-      await agentList(args.slice(2), provider, agentOverride, d);
+      await agentList(subArgs, provider, agentOverride, d);
       break;
     case "send":
-      await agentSend(args.slice(2), provider, d);
+      await agentSend(subArgs, provider, d);
       break;
     case "bye":
     case "quit":
-      await agentBye(args.slice(2), provider, d);
+      await agentBye(subArgs, provider, d);
       break;
     case "interrupt":
-      await agentInterrupt(args.slice(2), provider, d);
+      await agentInterrupt(subArgs, provider, d);
       break;
     case "log":
-      await agentLog(args.slice(2), provider, d);
+      await agentLog(subArgs, provider, d);
       break;
     case "wait":
-      await agentWait(args.slice(2), provider, agentOverride, d);
+      await agentWait(subArgs, provider, agentOverride, d);
       break;
     case "resume":
-      await agentResume(args.slice(2), provider, agentOverride, d);
+      await agentResume(subArgs, provider, agentOverride, d);
       break;
     case "worktrees":
     case "wt":
-      await agentWorktrees(args.slice(2), provider, d);
+      await agentWorktrees(subArgs, provider, d);
       break;
     case "approve":
-      await agentApprove(args.slice(2), provider, d);
+      await agentApprove(subArgs, provider, d);
       break;
     case "deny":
-      await agentDeny(args.slice(2), provider, d);
+      await agentDeny(subArgs, provider, d);
       break;
     default:
       d.printError(
@@ -451,11 +462,10 @@ async function agentSpawn(
   agentOverride: string | undefined,
   d: AgentDeps,
 ): Promise<void> {
-  if (args.includes("--help") || args.includes("-h")) {
+  if (hasHelpFlag(args)) {
     printSpawnUsage(provider, agentOverride, d.log);
     return;
   }
-
   const parsed = parseAgentSpawnArgs(args, provider, agentOverride);
 
   if (parsed.error) {

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -298,11 +298,14 @@ export async function cmdAgent(args: string[], deps?: Partial<AgentDeps>): Promi
 
   const subArgs = args.slice(2);
   if (sub !== "spawn" && hasHelpFlag(subArgs)) {
-    const help = getHelp(`claude ${sub}`);
+    const help = getHelp(`${providerName} ${sub}`);
     if (help) {
       d.log(formatHelp(help));
       return;
     }
+    d.log(`No detailed help available for "mcx agent ${providerName} ${sub}".`);
+    d.log(`Run "mcx agent ${providerName} --help" for available subcommands.`);
+    return;
   }
 
   switch (sub) {

--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { type Mock, afterEach, describe, expect, mock, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -34,6 +34,7 @@ import { colorState, extractContentSummary, formatSessionShort } from "./session
 function makeDeps(overrides?: Partial<ClaudeDeps>): ClaudeDeps {
   return {
     callTool: mock(async () => ({ content: [{ type: "text", text: "[]" }] })),
+    log: mock(() => {}),
     printError: mock(() => {}),
     exit: mock((code: number) => {
       throw new ExitError(code);
@@ -47,6 +48,10 @@ function makeDeps(overrides?: Partial<ClaudeDeps>): ClaudeDeps {
     pollMail: mock(async () => null),
     ...overrides,
   };
+}
+
+function logCalls(deps: ClaudeDeps): string[] {
+  return (deps.log as Mock<(...a: unknown[]) => void>).mock.calls.map((c) => String(c[0]));
 }
 
 function toolResult(data: unknown): { content: Array<{ type: "text"; text: string }> } {
@@ -579,22 +584,14 @@ describe("mcx claude spawn", () => {
   test("--help prints usage and does not call tool", async () => {
     const callTool = mock(async () => toolResult({ success: true }));
     const deps = makeDeps({ callTool });
-
-    const logSpy = mock(() => {});
-    const origLog = console.log;
-    console.log = logSpy;
-    try {
-      await cmdClaude(["spawn", "--help"], deps);
-      expect(callTool).not.toHaveBeenCalled();
-      const output = logSpy.mock.calls.map((c) => (c as string[])[0]).join("\n");
-      expect(output).toContain("mcx claude spawn");
-      expect(output).toContain("--task");
-      expect(output).toContain("--worktree");
-      expect(output).toContain("--allow");
-      expect(output).toContain("Examples:");
-    } finally {
-      console.log = origLog;
-    }
+    await cmdClaude(["spawn", "--help"], deps);
+    expect(callTool).not.toHaveBeenCalled();
+    const output = logCalls(deps).join("\n");
+    expect(output).toContain("mcx claude spawn");
+    expect(output).toContain("--task");
+    expect(output).toContain("--worktree");
+    expect(output).toContain("--allow");
+    expect(output).toContain("Examples:");
   });
 
   test("calls claude_prompt with task", async () => {
@@ -2416,20 +2413,12 @@ describe("mcx claude wait", () => {
   test("--help prints usage and does not call tool", async () => {
     const callTool = mock(async () => toolResult({ success: true }));
     const deps = makeDeps({ callTool });
-
-    const logSpy = mock(() => {});
-    const origLog = console.log;
-    console.log = logSpy;
-    try {
-      await cmdClaude(["wait", "--help"], deps);
-      expect(callTool).not.toHaveBeenCalled();
-      const output = logSpy.mock.calls.map((c) => (c as string[])[0]).join("\n");
-      expect(output).toContain("mcx claude wait");
-      expect(output).toContain("--timeout");
-      expect(output).toContain("--all");
-    } finally {
-      console.log = origLog;
-    }
+    await cmdClaude(["wait", "--help"], deps);
+    expect(callTool).not.toHaveBeenCalled();
+    const output = logCalls(deps).join("\n");
+    expect(output).toContain("mcx claude wait");
+    expect(output).toContain("--timeout");
+    expect(output).toContain("--all");
   });
 
   test("calls claude_wait with no args (any session)", async () => {

--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -565,7 +565,7 @@ describe("cmdClaude", () => {
     try {
       await cmdClaude(["spawn", "--help"]);
       const output = logSpy.mock.calls.map((c) => (c as string[])[0]).join("\n");
-      // cmdAgent's spawn help uses "mcx agent claude spawn" format
+      // Spawn uses provider-specific help via agentSpawn, not the generic registry
       expect(output).toContain("mcx agent claude spawn");
     } finally {
       console.log = origLog;
@@ -2413,6 +2413,25 @@ describe("claudeWait --mail-to", () => {
 // ── wait ──
 
 describe("mcx claude wait", () => {
+  test("--help prints usage and does not call tool", async () => {
+    const callTool = mock(async () => toolResult({ success: true }));
+    const deps = makeDeps({ callTool });
+
+    const logSpy = mock(() => {});
+    const origLog = console.log;
+    console.log = logSpy;
+    try {
+      await cmdClaude(["wait", "--help"], deps);
+      expect(callTool).not.toHaveBeenCalled();
+      const output = logSpy.mock.calls.map((c) => (c as string[])[0]).join("\n");
+      expect(output).toContain("mcx claude wait");
+      expect(output).toContain("--timeout");
+      expect(output).toContain("--all");
+    } finally {
+      console.log = origLog;
+    }
+  });
+
   test("calls claude_wait with no args (any session)", async () => {
     const callTool = mock(async () =>
       toolResult({

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -63,6 +63,7 @@ export interface SharedSessionDeps {
 }
 
 export interface ClaudeDeps extends SharedSessionDeps {
+  log: (...args: unknown[]) => void;
   getDiffStats: (worktreePath: string) => Promise<string | null>;
   getPrStatus: (worktreePath: string) => Promise<PrStatus | null>;
   /** Open a command in a terminal tab/window. Used for --headed spawn. */
@@ -173,6 +174,7 @@ export const defaultDeps: ClaudeDeps = {
     const timeoutMs = needsLongTimeout ? PROMPT_IPC_TIMEOUT_MS : undefined;
     return ipcCall("callTool", { server: CLAUDE_SERVER_NAME, tool, arguments: args }, { timeoutMs });
   },
+  log: console.log,
   printError: defaultPrintError,
   exit: (code) => process.exit(code),
   getDiffStats: defaultGetDiffStats,
@@ -238,14 +240,14 @@ async function cmdClaudeInternal(args: string[], deps?: Partial<ClaudeDeps>): Pr
   }
 
   const subArgs = args.slice(1);
-  if (hasHelpFlag(subArgs)) {
+  if (sub !== "spawn" && hasHelpFlag(subArgs)) {
     const help = getHelp(`claude ${sub}`);
     if (help) {
-      console.log(formatHelp(help));
+      d.log(formatHelp(help));
       return;
     }
-    console.log(`No detailed help available for "mcx claude ${sub}".`);
-    console.log('Run "mcx claude --help" for available subcommands.');
+    d.log(`No detailed help available for "mcx claude ${sub}".`);
+    d.log('Run "mcx claude --help" for available subcommands.');
     return;
   }
 
@@ -414,6 +416,17 @@ function tryWriteInitialTransition(workItemId: string, gitRoot: string): void {
 }
 
 async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
+  if (hasHelpFlag(args)) {
+    const spawnHelp = getHelp("claude spawn");
+    if (spawnHelp) {
+      d.log(formatHelp(spawnHelp));
+    } else {
+      d.log('No detailed help available for "mcx claude spawn".');
+      d.log('Run "mcx claude --help" for available subcommands.');
+    }
+    return;
+  }
+
   const parsed = parseSpawnArgs(args);
 
   if (parsed.error) {

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -244,6 +244,9 @@ async function cmdClaudeInternal(args: string[], deps?: Partial<ClaudeDeps>): Pr
       console.log(formatHelp(help));
       return;
     }
+    console.log(`No detailed help available for "mcx claude ${sub}".`);
+    console.log('Run "mcx claude --help" for available subcommands.');
+    return;
   }
 
   switch (sub) {

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -6,6 +6,8 @@
  */
 
 import { dirname, join, resolve } from "node:path";
+import { formatHelp, getHelp, hasHelpFlag } from "../help";
+import "../help-claude";
 import {
   CLAUDE_SERVER_NAME,
   DEFAULT_TIMEOUT_MS,
@@ -235,42 +237,51 @@ async function cmdClaudeInternal(args: string[], deps?: Partial<ClaudeDeps>): Pr
     return;
   }
 
+  const subArgs = args.slice(1);
+  if (hasHelpFlag(subArgs)) {
+    const help = getHelp(`claude ${sub}`);
+    if (help) {
+      console.log(formatHelp(help));
+      return;
+    }
+  }
+
   switch (sub) {
     case "spawn":
-      await claudeSpawn(args.slice(1), d);
+      await claudeSpawn(subArgs, d);
       break;
     case "ls":
     case "list":
-      await claudeList(args.slice(1), d);
+      await claudeList(subArgs, d);
       break;
     case "send":
-      await claudeSend(args.slice(1), d);
+      await claudeSend(subArgs, d);
       break;
     case "bye":
     case "quit":
-      await claudeBye(args.slice(1), d);
+      await claudeBye(subArgs, d);
       break;
     case "interrupt":
-      await claudeInterrupt(args.slice(1), d);
+      await claudeInterrupt(subArgs, d);
       break;
     case "log":
-      await claudeLog(args.slice(1), d);
+      await claudeLog(subArgs, d);
       break;
     case "wait":
-      await claudeWait(args.slice(1), d);
+      await claudeWait(subArgs, d);
       break;
     case "resume":
-      await claudeResume(args.slice(1), d);
+      await claudeResume(subArgs, d);
       break;
     case "worktrees":
     case "wt":
-      await claudeWorktrees(args.slice(1), d);
+      await claudeWorktrees(subArgs, d);
       break;
     case "approve":
-      await claudeApprove(args.slice(1), d);
+      await claudeApprove(subArgs, d);
       break;
     case "deny":
-      await claudeDeny(args.slice(1), d);
+      await claudeDeny(subArgs, d);
       break;
     default:
       d.printError(
@@ -400,11 +411,6 @@ function tryWriteInitialTransition(workItemId: string, gitRoot: string): void {
 }
 
 async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
-  if (args.includes("--help") || args.includes("-h")) {
-    printSpawnUsage();
-    return;
-  }
-
   const parsed = parseSpawnArgs(args);
 
   if (parsed.error) {
@@ -1871,39 +1877,6 @@ export async function getActiveSessionWorktrees(listTool: string, d: SharedSessi
 }
 
 // ── Usage ──
-
-function printSpawnUsage(): void {
-  console.log(`mcx claude spawn — Start a new Claude Code session
-
-Usage:
-  mcx claude spawn --task "description"
-  mcx claude spawn --task "description" --allow Bash Read Write
-  mcx claude spawn --task "description" --worktree my-feature
-  mcx claude spawn --headed --task "description"
-
-Options:
-  --task, -t <string>        Task prompt for the session (required unless --resume)
-  --worktree, -w [name]      Run in a git worktree for branch isolation
-                             Auto-generates a name if omitted
-  --allow <tools...>         Space-separated tool patterns to auto-approve
-                             e.g. Bash Read Write Edit Glob Grep Skill
-                             Supports globs: mcp__grafana__*
-  --headed                   Open in a visible terminal tab (via tty)
-  --name, -n <name>          Human-readable session name (auto-generated if omitted)
-  --resume <id>              Resume a previous session by ID
-  --model, -m <name>         Model: opus, sonnet, haiku, or full ID (default: opus)
-  --cwd <path>               Working directory for the session
-  --wait                     Block until Claude produces a result
-  --timeout <ms>             Max wait time in ms (default: 270000, only with --wait)
-  --work-item <id>           Work item ID (#N); writes null→initial transition on spawn
-
-Examples:
-  mcx claude spawn --task "run the test suite and fix failures"
-  mcx claude spawn --allow Bash Read Write --task "monitor prod health"
-  mcx claude spawn -w fix-auth -t "fix the auth bug in issue #42"
-  mcx claude spawn --headed --task "interactive debugging session"
-  mcx claude spawn --resume abc123 --task "continue where you left off"`);
-}
 
 function printClaudeUsage(): void {
   console.log(`mcx claude — manage Claude Code sessions

--- a/packages/command/src/commands/gc.spec.ts
+++ b/packages/command/src/commands/gc.spec.ts
@@ -64,6 +64,7 @@ function makeDeps(
     execFallback?: (cmd: string[]) => { stdout: string; stderr: string; exitCode: number };
     callTool?: GcDeps["callTool"];
     mtimes?: Map<string, number>;
+    mergedPrBranches?: Set<string> | null;
   } = {},
 ): GcDeps & { logs: string[]; errors: string[]; execCalls: string[][] } {
   const logs: string[] = [];
@@ -84,6 +85,7 @@ function makeDeps(
     callTool: overrides.callTool ?? (async () => "[]"),
     exec,
     getMtime: (p) => overrides.mtimes?.get(p) ?? null,
+    queryMergedPrBranches: () => (overrides.mergedPrBranches !== undefined ? overrides.mergedPrBranches : null),
     printError: (m) => errors.push(m),
     log: (m) => logs.push(m),
     logError: (m) => errors.push(m),
@@ -161,6 +163,63 @@ describe("runGc branches", () => {
     // Only "stale" — feat is checked out by /other
     expect(d.logs.some((l) => l.includes("would delete 1 merged"))).toBe(true);
     expect(d.logs.some((l) => l.includes("stale"))).toBe(true);
+  });
+
+  test("uses -D for branches with a merged PR (squash-merge support)", async () => {
+    const responses = new Map<string, { stdout: string; stderr?: string; exitCode?: number }>();
+    responses.set("git -C /repo worktree list --porcelain", { stdout: "" });
+    responses.set("git -C /repo symbolic-ref refs/remotes/origin/HEAD", { stdout: "refs/remotes/origin/main" });
+    responses.set("git -C /repo branch --merged main", { stdout: "* main\n  squashed\n  regular\n" });
+    responses.set("git -C /repo branch --show-current", { stdout: "main" });
+    responses.set("git -C /repo fetch --prune", { stdout: "" });
+    responses.set("git -C /repo branch -D squashed", { stdout: "Deleted branch squashed" });
+    responses.set("git -C /repo branch -d regular", { stdout: "Deleted branch regular" });
+
+    const d = makeDeps({
+      execResponses: responses,
+      mergedPrBranches: new Set(["squashed"]),
+    });
+    await runGc({ dryRun: false, olderThanMs: 86_400_000, branchesOnly: true, worktreesOnly: false }, d);
+
+    expect(d.execCalls.some((c) => c.join(" ") === "git -C /repo branch -D squashed")).toBe(true);
+    expect(d.execCalls.some((c) => c.join(" ") === "git -C /repo branch -d regular")).toBe(true);
+    expect(d.errors.some((l) => l.includes("branches: deleted 2"))).toBe(true);
+  });
+
+  test("falls back to -d with warning when GitHub API is unavailable", async () => {
+    const responses = new Map<string, { stdout: string; stderr?: string; exitCode?: number }>();
+    responses.set("git -C /repo worktree list --porcelain", { stdout: "" });
+    responses.set("git -C /repo symbolic-ref refs/remotes/origin/HEAD", { stdout: "refs/remotes/origin/main" });
+    responses.set("git -C /repo branch --merged main", { stdout: "* main\n  squashed\n" });
+    responses.set("git -C /repo branch --show-current", { stdout: "main" });
+    responses.set("git -C /repo fetch --prune", { stdout: "" });
+    responses.set("git -C /repo branch -d squashed", {
+      stdout: "",
+      stderr: "not fully merged",
+      exitCode: 1,
+    });
+
+    const d = makeDeps({ execResponses: responses, mergedPrBranches: null });
+    await runGc({ dryRun: false, olderThanMs: 86_400_000, branchesOnly: true, worktreesOnly: false }, d);
+
+    expect(d.errors.some((e) => e.includes("GitHub API unavailable"))).toBe(true);
+    // Falls back to -d (which fails for this squash-merged branch)
+    expect(d.execCalls.some((c) => c.join(" ") === "git -C /repo branch -d squashed")).toBe(true);
+    expect(d.execCalls.some((c) => c[4] === "-D")).toBe(false);
+    expect(d.errors.some((e) => e.includes("1 failed"))).toBe(true);
+  });
+
+  test("no API warning when there are no branch candidates", async () => {
+    const responses = new Map<string, { stdout: string }>();
+    responses.set("git -C /repo worktree list --porcelain", { stdout: "" });
+    responses.set("git -C /repo symbolic-ref refs/remotes/origin/HEAD", { stdout: "refs/remotes/origin/main" });
+    responses.set("git -C /repo branch --merged main", { stdout: "* main\n" });
+    responses.set("git -C /repo branch --show-current", { stdout: "main" });
+
+    const d = makeDeps({ execResponses: responses, mergedPrBranches: null });
+    await runGc({ dryRun: true, olderThanMs: 86_400_000, branchesOnly: true, worktreesOnly: false }, d);
+
+    expect(d.errors.some((e) => e.includes("GitHub API"))).toBe(false);
   });
 });
 

--- a/packages/command/src/commands/gc.ts
+++ b/packages/command/src/commands/gc.ts
@@ -94,6 +94,8 @@ export interface GcDeps extends WorktreeShimDeps {
   callTool: (tool: string, args: Record<string, unknown>) => Promise<unknown>;
   /** Returns mtime (ms since epoch) for the given path, or null if it can't be stat'd. */
   getMtime: (path: string) => number | null;
+  /** Returns branch names that have a merged PR on GitHub, or null if the API is unavailable. */
+  queryMergedPrBranches: (cwd: string) => Set<string> | null;
   log: (msg: string) => void;
   logError: (msg: string) => void;
 }
@@ -132,6 +134,19 @@ export function defaultGcDeps(): GcDeps {
       // works here (worktree paths are directories).
       try {
         return statSync(path).mtimeMs;
+      } catch {
+        return null;
+      }
+    },
+    queryMergedPrBranches: (cwd) => {
+      const result = Bun.spawnSync(
+        ["gh", "pr", "list", "--state", "merged", "--json", "headRefName", "--limit", "500"],
+        { stdout: "pipe", stderr: "pipe", cwd },
+      );
+      if (result.exitCode !== 0) return null;
+      try {
+        const prs = JSON.parse(result.stdout.toString()) as Array<{ headRefName: string }>;
+        return new Set(prs.map((pr) => pr.headRefName));
       } catch {
         return null;
       }
@@ -285,6 +300,13 @@ export async function runGc(opts: GcOptions, deps: GcDeps): Promise<void> {
       (b) => b !== defaultBranch && b !== current && !checkedOut.has(b) && !worktreeDeletedBranches.has(b),
     );
 
+    // Query GitHub for branches with merged PRs — enables force-delete for
+    // squash/rebase-merged branches where `git branch -d` fails.
+    const mergedPrBranches = candidates.length > 0 ? deps.queryMergedPrBranches(cwd) : null;
+    if (candidates.length > 0 && !mergedPrBranches) {
+      deps.logError("gc: GitHub API unavailable — squash-merged branches may not be cleaned");
+    }
+
     if (opts.dryRun) {
       deps.log(`${prefix}branches: would delete ${candidates.length} merged`);
       for (const b of candidates) deps.log(`  ${c.red}-${c.reset} ${b}`);
@@ -292,7 +314,9 @@ export async function runGc(opts: GcOptions, deps: GcDeps): Promise<void> {
       let deleted = 0;
       const failed: string[] = [];
       for (const b of candidates) {
-        const { exitCode, stderr } = deps.exec(["git", "-C", cwd, "branch", "-d", b]);
+        const prConfirmed = mergedPrBranches?.has(b) ?? false;
+        const flag = prConfirmed ? "-D" : "-d";
+        const { exitCode, stderr } = deps.exec(["git", "-C", cwd, "branch", flag, b]);
         if (exitCode === 0) {
           deleted++;
         } else {

--- a/packages/command/src/help-claude.ts
+++ b/packages/command/src/help-claude.ts
@@ -1,0 +1,143 @@
+import { registerHelp } from "./help";
+
+registerHelp("claude spawn", {
+  name: "mcx claude spawn",
+  summary: "Start a new Claude Code session",
+  usage: [
+    'mcx claude spawn --task "description"',
+    'mcx claude spawn --task "description" --allow Bash Read Write',
+    'mcx claude spawn --task "description" --worktree my-feature',
+    'mcx claude spawn --headed --task "description"',
+  ],
+  options: [
+    ["--task, -t <string>", "Task prompt for the session (required unless --resume)"],
+    ["--worktree, -w [name]", "Run in a git worktree for branch isolation"],
+    ["--allow <tools...>", "Space-separated tool patterns to auto-approve"],
+    ["--headed", "Open in a visible terminal tab (via tty)"],
+    ["--name, -n <name>", "Human-readable session name (auto-generated if omitted)"],
+    ["--resume <id>", "Resume a previous session by ID"],
+    ["--model, -m <name>", "Model: opus, sonnet, haiku, or full ID (default: opus)"],
+    ["--cwd <path>", "Working directory for the session"],
+    ["--wait", "Block until Claude produces a result"],
+    ["--timeout <ms>", "Max wait time in ms (default: 270000, only with --wait)"],
+    ["--work-item <id>", "Work item ID (#N); writes null→initial transition on spawn"],
+  ],
+  examples: [
+    'mcx claude spawn --task "run the test suite and fix failures"',
+    'mcx claude spawn --allow Bash Read Write --task "monitor prod health"',
+    'mcx claude spawn -w fix-auth -t "fix the auth bug in issue #42"',
+    'mcx claude spawn --headed --task "interactive debugging session"',
+  ],
+});
+
+registerHelp("claude ls", {
+  name: "mcx claude ls",
+  summary: "List active Claude Code sessions",
+  usage: ["mcx claude ls", "mcx claude ls --all", "mcx claude ls --pr"],
+  options: [
+    ["--json", "Output raw JSON"],
+    ["--short", "Compact one-line-per-session format"],
+    ["--pr", "Show PR status for worktree sessions"],
+    ["--all, -a", "Show all sessions (bypass repo scoping)"],
+  ],
+});
+
+registerHelp("claude send", {
+  name: "mcx claude send",
+  summary: "Send a follow-up prompt to a running session",
+  usage: ["mcx claude send <session> <message>", "mcx claude send --wait <session> <message>"],
+  options: [["--wait", "Block until Claude produces a result"]],
+  examples: ['mcx claude send abc123 "now run the tests"'],
+});
+
+registerHelp("claude bye", {
+  name: "mcx claude bye",
+  summary: "End a session and stop the process",
+  usage: ['mcx claude bye <session> "wrap up"', "mcx claude bye --all", "mcx claude bye <session> --keep-worktree"],
+  options: [
+    ["--keep, --keep-worktree", "Preserve worktree after session ends"],
+    ["--all, -a", "End all sessions in scope"],
+  ],
+});
+
+registerHelp("claude interrupt", {
+  name: "mcx claude interrupt",
+  summary: "Interrupt the current turn of a session",
+  usage: ["mcx claude interrupt <session>"],
+});
+
+registerHelp("claude log", {
+  name: "mcx claude log",
+  summary: "View session transcript",
+  usage: [
+    "mcx claude log <session>",
+    "mcx claude log <session> --last 50",
+    "mcx claude log <session> --json --jq '.[]'",
+  ],
+  options: [
+    ["--last, -n, --tail <N>", "Show last N entries (default: 20)"],
+    ["--json", "Output raw JSON"],
+    ["--full", "Full output (no truncation)"],
+    ["--jq <filter>", "Apply jq filter to JSON output"],
+    ["--compact", "Compact output mode"],
+  ],
+});
+
+registerHelp("claude wait", {
+  name: "mcx claude wait",
+  summary: "Block until a session event occurs",
+  usage: ["mcx claude wait <session>", "mcx claude wait --all", "mcx claude wait --pr 42", "mcx claude wait --checks"],
+  options: [
+    ["--timeout, -t <ms>", "Max wait time in ms (default: 270000, max: 299000)"],
+    ["--after <seq>", "Sequence cursor for race-free polling"],
+    ["--short", "Compact output"],
+    ["--all, -a", "Wait across all sessions (bypass repo scoping)"],
+    ["--any", "Race session + work item events (return whichever fires first)"],
+    ["--pr <number>", "Block until a specific PR changes state"],
+    ["--checks", "Block until any tracked PR's CI completes"],
+    ["--mail-to <recipient>", "Also wake on mail addressed to recipient"],
+  ],
+});
+
+registerHelp("claude resume", {
+  name: "mcx claude resume",
+  summary: "Resume a session in a worktree",
+  usage: [
+    "mcx claude resume <worktree>",
+    "mcx claude resume <worktree> <session>",
+    "mcx claude resume <worktree> --fresh",
+    "mcx claude resume --all",
+  ],
+  options: [
+    ["--fresh", "Use git-context prompt instead of conversation history"],
+    ["--all", "Resume all orphaned worktrees (batch mode)"],
+    ["--model, -m <name>", "Model: opus, sonnet, haiku, or full ID"],
+    ["--allow <tools...>", "Space-separated tool patterns to auto-approve"],
+    ["--wait", "Block until Claude produces a result"],
+    ["--timeout <ms>", "Max wait time in ms (default: 270000)"],
+  ],
+});
+
+registerHelp("claude worktrees", {
+  name: "mcx claude worktrees",
+  summary: "List or prune mcx-created worktrees",
+  usage: ["mcx claude worktrees", "mcx claude worktrees --prune"],
+  options: [["--prune", "Remove orphaned worktrees and merged branches"]],
+});
+
+registerHelp("claude approve", {
+  name: "mcx claude approve",
+  summary: "Approve the latest pending permission request",
+  usage: ["mcx claude approve <session>", "mcx claude approve <session> --request-id <id>"],
+  options: [["--request-id, -r <id>", "Specific request ID (auto-detects latest if omitted)"]],
+});
+
+registerHelp("claude deny", {
+  name: "mcx claude deny",
+  summary: "Deny the latest pending permission request",
+  usage: ["mcx claude deny <session>", 'mcx claude deny <session> --message "not allowed"'],
+  options: [
+    ["--request-id, -r <id>", "Specific request ID (auto-detects latest if omitted)"],
+    ["--message, -m <reason>", "Denial reason"],
+  ],
+});

--- a/packages/command/src/help-claude.ts
+++ b/packages/command/src/help-claude.ts
@@ -11,8 +11,11 @@ registerHelp("claude spawn", {
   ],
   options: [
     ["--task, -t <string>", "Task prompt for the session (required unless --resume)"],
-    ["--worktree, -w [name]", "Run in a git worktree for branch isolation"],
-    ["--allow <tools...>", "Space-separated tool patterns to auto-approve"],
+    ["--worktree, -w [name]", "Run in a git worktree for branch isolation (auto-generates name if omitted)"],
+    [
+      "--allow <tools...>",
+      "Space-separated tool patterns to auto-approve (e.g. Bash Read Write Edit Glob Grep Skill; supports globs: mcp__grafana__*)",
+    ],
     ["--headed", "Open in a visible terminal tab (via tty)"],
     ["--name, -n <name>", "Human-readable session name (auto-generated if omitted)"],
     ["--resume <id>", "Resume a previous session by ID"],

--- a/packages/command/src/help.spec.ts
+++ b/packages/command/src/help.spec.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import { type CommandHelp, formatHelp, getHelp, hasHelpFlag, registerHelp } from "./help";
+
+describe("hasHelpFlag", () => {
+  test("detects --help", () => {
+    expect(hasHelpFlag(["--timeout", "30", "--help"])).toBe(true);
+  });
+
+  test("detects -h", () => {
+    expect(hasHelpFlag(["-h"])).toBe(true);
+  });
+
+  test("returns false when absent", () => {
+    expect(hasHelpFlag(["--timeout", "30"])).toBe(false);
+  });
+
+  test("returns false for empty args", () => {
+    expect(hasHelpFlag([])).toBe(false);
+  });
+});
+
+describe("registerHelp / getHelp", () => {
+  test("round-trips a help entry", () => {
+    const entry: CommandHelp = {
+      name: "mcx test",
+      summary: "test command",
+      usage: ["mcx test <arg>"],
+    };
+    registerHelp("__test_roundtrip", entry);
+    expect(getHelp("__test_roundtrip")).toBe(entry);
+  });
+
+  test("returns undefined for unregistered key", () => {
+    expect(getHelp("__nonexistent")).toBeUndefined();
+  });
+});
+
+describe("formatHelp", () => {
+  test("formats minimal entry (no options, no examples)", () => {
+    const output = formatHelp({
+      name: "mcx foo",
+      summary: "do the thing",
+      usage: ["mcx foo <arg>"],
+    });
+    expect(output).toContain("mcx foo — do the thing");
+    expect(output).toContain("Usage:");
+    expect(output).toContain("  mcx foo <arg>");
+    expect(output).not.toContain("Options:");
+    expect(output).not.toContain("Examples:");
+  });
+
+  test("formats entry with options", () => {
+    const output = formatHelp({
+      name: "mcx bar",
+      summary: "bar things",
+      usage: ["mcx bar [flags]"],
+      options: [
+        ["--verbose", "Enable verbose output"],
+        ["--timeout <ms>", "Max wait time"],
+      ],
+    });
+    expect(output).toContain("Options:");
+    expect(output).toContain("--verbose");
+    expect(output).toContain("Enable verbose output");
+    expect(output).toContain("--timeout <ms>");
+    expect(output).toContain("Max wait time");
+  });
+
+  test("formats entry with examples", () => {
+    const output = formatHelp({
+      name: "mcx baz",
+      summary: "baz stuff",
+      usage: ["mcx baz"],
+      examples: ['mcx baz --flag "value"'],
+    });
+    expect(output).toContain("Examples:");
+    expect(output).toContain('mcx baz --flag "value"');
+  });
+
+  test("aligns option columns", () => {
+    const output = formatHelp({
+      name: "mcx align",
+      summary: "alignment test",
+      usage: ["mcx align"],
+      options: [
+        ["-s", "short flag"],
+        ["--very-long-flag <val>", "long flag"],
+      ],
+    });
+    const lines = output.split("\n");
+    const shortLine = lines.find((l) => l.includes("-s"));
+    const longLine = lines.find((l) => l.includes("--very-long-flag"));
+    expect(shortLine).toBeDefined();
+    expect(longLine).toBeDefined();
+    const shortDescIdx = shortLine?.indexOf("short flag") ?? -1;
+    const longDescIdx = longLine?.indexOf("long flag") ?? -1;
+    expect(shortDescIdx).toBe(longDescIdx);
+  });
+});
+
+describe("claude subcommand help registry", () => {
+  // Import side-effects register all entries
+  test("all claude subcommands are registered", async () => {
+    await import("./help-claude");
+    const subcommands = [
+      "spawn",
+      "ls",
+      "send",
+      "bye",
+      "interrupt",
+      "log",
+      "wait",
+      "resume",
+      "worktrees",
+      "approve",
+      "deny",
+    ];
+    for (const sub of subcommands) {
+      const help = getHelp(`claude ${sub}`);
+      expect(help).toBeDefined();
+      expect(help?.name).toContain(sub);
+      expect(help?.usage.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/command/src/help.spec.ts
+++ b/packages/command/src/help.spec.ts
@@ -122,4 +122,26 @@ describe("claude subcommand help registry", () => {
       expect(help?.usage.length).toBeGreaterThan(0);
     }
   });
+
+  test("unregistered subcommand returns undefined (fallthrough)", async () => {
+    await import("./help-claude");
+    expect(getHelp("claude bogus")).toBeUndefined();
+    expect(getHelp("codex wait")).toBeUndefined();
+  });
+
+  test("spawn entry includes worktree auto-generate hint", async () => {
+    await import("./help-claude");
+    const help = getHelp("claude spawn");
+    if (!help) throw new Error("expected claude spawn help to be registered");
+    const formatted = formatHelp(help);
+    expect(formatted).toContain("auto-generates name if omitted");
+  });
+
+  test("spawn entry includes allow glob hint", async () => {
+    await import("./help-claude");
+    const help = getHelp("claude spawn");
+    if (!help) throw new Error("expected claude spawn help to be registered");
+    const formatted = formatHelp(help);
+    expect(formatted).toContain("mcp__grafana__*");
+  });
 });

--- a/packages/command/src/help.ts
+++ b/packages/command/src/help.ts
@@ -1,0 +1,52 @@
+export interface CommandHelp {
+  name: string;
+  summary: string;
+  usage: string[];
+  options?: Array<[flag: string, description: string]>;
+  examples?: string[];
+}
+
+const registry = new Map<string, CommandHelp>();
+
+export function registerHelp(key: string, help: CommandHelp): void {
+  registry.set(key, help);
+}
+
+export function getHelp(key: string): CommandHelp | undefined {
+  return registry.get(key);
+}
+
+export function hasHelpFlag(args: readonly string[]): boolean {
+  return args.includes("--help") || args.includes("-h");
+}
+
+export function formatHelp(help: CommandHelp): string {
+  const lines: string[] = [];
+
+  lines.push(`${help.name} — ${help.summary}`);
+  lines.push("");
+  lines.push("Usage:");
+  for (const u of help.usage) {
+    lines.push(`  ${u}`);
+  }
+
+  if (help.options && help.options.length > 0) {
+    lines.push("");
+    lines.push("Options:");
+    const flagWidth = Math.max(...help.options.map(([f]) => f.length));
+    const pad = Math.min(flagWidth + 2, 32);
+    for (const [flag, desc] of help.options) {
+      lines.push(`  ${flag.padEnd(pad)}${desc}`);
+    }
+  }
+
+  if (help.examples && help.examples.length > 0) {
+    lines.push("");
+    lines.push("Examples:");
+    for (const ex of help.examples) {
+      lines.push(`  ${ex}`);
+    }
+  }
+
+  return lines.join("\n");
+}

--- a/packages/core/src/alias-bundle.ts
+++ b/packages/core/src/alias-bundle.ts
@@ -218,7 +218,7 @@ async function evalBundledJs(
     await Promise.race([
       fn(injected, coreBarrel),
       new Promise<never>((_, reject) => {
-        timer = setTimeout(() => reject(new Error("extractMetadata timed out")), timeoutMs);
+        timer = setTimeout(() => reject(new Error("Alias eval timed out")), timeoutMs);
       }),
     ]).finally(() => clearTimeout(timer));
   } else {

--- a/packages/core/src/event-filter.spec.ts
+++ b/packages/core/src/event-filter.spec.ts
@@ -222,6 +222,17 @@ describe("createWaitForEvent", () => {
     expect(result.seq).toBe(2);
   });
 
+  test("empty-spec waitForEvent({}) skips normalized heartbeats, resolves with next real event", async () => {
+    // Regression for #1718: standard-shape heartbeats must not resolve empty-spec waitForEvent.
+    const hb = makeEvent({ event: "heartbeat", category: "heartbeat", seq: 1, src: "daemon" });
+    const target = makeEvent({ event: "pr.opened", category: "work_item", seq: 2 });
+
+    const waitFor = createWaitForEvent(() => fakeStream([hb, target]));
+    const result = await waitFor({});
+    expect(result.seq).toBe(2);
+    expect(result.event).toBe("pr.opened");
+  });
+
   test("rejects with WaitTimeoutError after timeoutMs", async () => {
     // Infinite stream that yields nothing matching
     const noise = makeEvent({ event: "pr.opened", category: "work_item" });

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -1684,6 +1684,11 @@ export class StateDb {
       .run(prNumber, hash);
   }
 
+  deleteCopilotCommentState(workItemNumber: number): boolean {
+    const result = this.db.run("DELETE FROM copilot_comment_state WHERE pr_number = ?", [workItemNumber]);
+    return result.changes > 0;
+  }
+
   close(): void {
     this.db.close();
   }

--- a/packages/daemon/src/github/copilot-poller.spec.ts
+++ b/packages/daemon/src/github/copilot-poller.spec.ts
@@ -419,6 +419,89 @@ describe("CopilotPoller", () => {
       // After successful poll, backoff should be cleared
       expect(poller.lastError).toBeNull();
     });
+
+    test("primary rate-limit error (remaining==0) does not set lastError", async () => {
+      workItemDb.createWorkItem({ id: "wi:1", prNumber: 42, prState: "open" });
+      const { poller } = makePoller({
+        fetchComments: async () => {
+          throw new Error("GitHub API rate limit exhausted (403)");
+        },
+      });
+
+      await poller.poll();
+
+      expect(poller.lastError).toBeNull();
+    });
+
+    test("secondary rate-limit error (retry-after) does not set lastError", async () => {
+      workItemDb.createWorkItem({ id: "wi:1", prNumber: 42, prState: "open" });
+      const { poller } = makePoller({
+        fetchComments: async () => {
+          throw new Error("GitHub API secondary rate limit (403): retry after 60s");
+        },
+      });
+
+      await poller.poll();
+
+      expect(poller.lastError).toBeNull();
+    });
+
+    test("auth/scope 403 does NOT trigger backoff and sets lastError", async () => {
+      workItemDb.createWorkItem({ id: "wi:1", prNumber: 42, prState: "open" });
+      const { poller } = makePoller({
+        fetchComments: async () => {
+          throw new Error("GitHub API auth/scope error (403): Forbidden");
+        },
+      });
+
+      await poller.poll();
+
+      expect(poller.lastError).toContain("auth/scope");
+    });
+
+    test("auth/scope error on reviews sets lastError without backoff", async () => {
+      workItemDb.createWorkItem({ id: "wi:1", prNumber: 42, prState: "open" });
+      const { poller } = makePoller({
+        fetchReviews: async () => {
+          throw new Error("GitHub API auth/scope error (403): Resource not accessible by personal access token");
+        },
+      });
+
+      await poller.poll();
+
+      expect(poller.lastError).toContain("auth/scope");
+    });
+
+    test("401 auth failure sets lastError without backoff", async () => {
+      workItemDb.createWorkItem({ id: "wi:1", prNumber: 42, prState: "open" });
+      const { poller } = makePoller({
+        fetchComments: async () => {
+          throw new Error("GitHub API auth failed (401) — token cache cleared");
+        },
+      });
+
+      await poller.poll();
+
+      expect(poller.lastError).toContain("auth failed");
+    });
+
+    test("auth/scope error clears after next successful poll", async () => {
+      workItemDb.createWorkItem({ id: "wi:1", prNumber: 42, prState: "open" });
+      let callCount = 0;
+      const { poller } = makePoller({
+        fetchComments: async () => {
+          callCount++;
+          if (callCount === 1) throw new Error("GitHub API auth/scope error (403): Forbidden");
+          return okResult([]);
+        },
+      });
+
+      await poller.poll();
+      expect(poller.lastError).toContain("auth/scope");
+
+      await poller.poll();
+      expect(poller.lastError).toBeNull();
+    });
   });
 
   // ── Coalesced event integration (mocked) ──

--- a/packages/daemon/src/github/copilot-poller.spec.ts
+++ b/packages/daemon/src/github/copilot-poller.spec.ts
@@ -125,6 +125,10 @@ function createStateDb(db: Database) {
            last_poll_ts = excluded.last_poll_ts`,
       ).run(prNumber, hash);
     },
+    deleteCopilotCommentState(workItemNumber: number): boolean {
+      const result = db.run("DELETE FROM copilot_comment_state WHERE pr_number = ?", [workItemNumber]);
+      return result.changes > 0;
+    },
   };
 }
 
@@ -968,6 +972,78 @@ describe("CopilotPoller", () => {
       await poller.poll();
 
       expect(fetched).not.toContain(99);
+    });
+  });
+
+  // ── State cleanup on terminal PRs (#1736) ──
+
+  describe("copilot state cleanup", () => {
+    test("merged PR state row is deleted on next poll", async () => {
+      workItemDb.createWorkItem({ id: "wi:1", prNumber: 42, prState: "merged" });
+      stateDb.updateSeenCommentIds(42, [1001, 1002, 1003]);
+      stateDb.updateSeenReviewIds(42, [5001]);
+
+      const { poller } = makePoller();
+      await poller.poll();
+
+      expect(stateDb.getSeenCommentIds(42)).toEqual([]);
+      expect(stateDb.getSeenReviewIds(42)).toEqual([]);
+    });
+
+    test("closed PR state row is deleted on next poll", async () => {
+      workItemDb.createWorkItem({ id: "wi:2", prNumber: 55, prState: "closed" });
+      stateDb.updateSeenCommentIds(55, [2001]);
+
+      const { poller } = makePoller();
+      await poller.poll();
+
+      expect(stateDb.getSeenCommentIds(55)).toEqual([]);
+    });
+
+    test("done-phase PR state row is deleted on next poll", async () => {
+      workItemDb.createWorkItem({ id: "wi:done-pr", prNumber: 88, prState: "open", phase: "done" });
+      stateDb.updateSeenCommentIds(88, [4001]);
+
+      const { poller } = makePoller();
+      await poller.poll();
+
+      expect(stateDb.getSeenCommentIds(88)).toEqual([]);
+    });
+
+    test("open PR state is preserved (dedup still works)", async () => {
+      workItemDb.createWorkItem({ id: "wi:3", prNumber: 77, prState: "open" });
+      stateDb.updateSeenCommentIds(77, [3001]);
+
+      const { poller } = makePoller({
+        fetchComments: async () => okResult([makeComment({ id: 3001 }), makeComment({ id: 3002 })]),
+      });
+      await poller.poll();
+
+      const stored = stateDb.getSeenCommentIds(77);
+      expect(stored).toContain(3001);
+      expect(stored).toContain(3002);
+    });
+
+    test("done-phase issue state is deleted on next poll", async () => {
+      workItemDb.createWorkItem({ id: "#99", issueNumber: 99, prNumber: null, prState: null, phase: "done" });
+      stateDb.updateSeenIssueCommentIds(99, [8001, 8002]);
+
+      const { poller } = makePoller();
+      await poller.poll();
+
+      expect(stateDb.getSeenIssueCommentIds(99)).toEqual([]);
+    });
+
+    test("active issue state is preserved", async () => {
+      workItemDb.createWorkItem({ id: "#50", issueNumber: 50, prNumber: null, prState: null, phase: "impl" });
+      stateDb.updateSeenIssueCommentIds(50, [9001]);
+
+      const { poller } = makePoller({
+        fetchIssueComments: async () => okIssueCommentResult([makeIssueComment({ id: 9001 })]),
+      });
+      await poller.poll();
+
+      expect(stateDb.getSeenIssueCommentIds(50)).toContain(9001);
     });
   });
 });

--- a/packages/daemon/src/github/copilot-poller.ts
+++ b/packages/daemon/src/github/copilot-poller.ts
@@ -38,6 +38,11 @@ const REQUEST_TIMEOUT_MS = 10_000;
 
 // ── Types ──
 
+interface PollItemResult {
+  isRateLimit: boolean;
+  authError?: string;
+}
+
 export interface PRComment {
   id: number;
   path: string;
@@ -232,21 +237,30 @@ export class CopilotPoller {
 
       const repo = this._repo;
       let anyRateLimitLow = false;
+      let anyAuthError: string | null = null;
       for (const item of tracked) {
         if (this.stopped) return;
-        if (await this.pollPR(repo, item, token)) anyRateLimitLow = true;
+        const r1 = await this.pollPR(repo, item, token);
+        if (r1.isRateLimit) anyRateLimitLow = true;
+        if (r1.authError) anyAuthError = r1.authError;
         if (this.stopped) return;
-        if (await this.pollReviews(repo, item, token)) anyRateLimitLow = true;
+        const r2 = await this.pollReviews(repo, item, token);
+        if (r2.isRateLimit) anyRateLimitLow = true;
+        if (r2.authError) anyAuthError = r2.authError;
         if (this.stopped) return;
-        if (await this.pollPRComments(repo, item, token)) anyRateLimitLow = true;
+        const r3 = await this.pollPRComments(repo, item, token);
+        if (r3.isRateLimit) anyRateLimitLow = true;
+        if (r3.authError) anyAuthError = r3.authError;
       }
       for (const item of trackedIssues) {
         if (this.stopped) return;
-        if (await this.pollIssueComments(repo, item, token)) anyRateLimitLow = true;
+        const r4 = await this.pollIssueComments(repo, item, token);
+        if (r4.isRateLimit) anyRateLimitLow = true;
+        if (r4.authError) anyAuthError = r4.authError;
       }
       this.rateLimitBackoff = anyRateLimitLow;
 
-      this._lastError = null;
+      this._lastError = anyAuthError;
       this._pollCount++;
       this.adjustInterval([...tracked, ...trackedIssues]);
     } catch (err) {
@@ -259,7 +273,7 @@ export class CopilotPoller {
     }
   }
 
-  private async pollPR(repo: RepoInfo, item: WorkItem, token: string): Promise<boolean> {
+  private async pollPR(repo: RepoInfo, item: WorkItem, token: string): Promise<PollItemResult> {
     const prNumber = item.prNumber as number;
 
     let result: FetchCommentsResult;
@@ -267,9 +281,10 @@ export class CopilotPoller {
       result = await this.fetchCommentsFn(repo, prNumber, token);
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
-      const isRateLimit = msg.includes("rate limit");
       this.logger.warn(`[mcpd] CopilotPoller failed to fetch comments for PR #${prNumber}: ${msg}`);
-      return isRateLimit;
+      if (msg.includes("rate limit")) return { isRateLimit: true };
+      if (msg.includes("auth/scope") || msg.includes("auth failed")) return { isRateLimit: false, authError: msg };
+      return { isRateLimit: false };
     }
 
     if (result.rateLimitLow) {
@@ -279,7 +294,7 @@ export class CopilotPoller {
     // Filter out threaded replies — only top-level review comments matter
     const comments = result.comments.filter((c) => c.in_reply_to_id == null);
 
-    if (this.stopped) return result.rateLimitLow;
+    if (this.stopped) return { isRateLimit: result.rateLimitLow };
 
     const seenIds = new Set(this.stateDb.getSeenCommentIds(prNumber));
     const currentIds = comments.map((c) => c.id);
@@ -290,7 +305,7 @@ export class CopilotPoller {
         const mergedSeenIds = [...new Set([...seenIds, ...currentIds])];
         this.stateDb.updateSeenCommentIds(prNumber, mergedSeenIds);
       }
-      return result.rateLimitLow;
+      return { isRateLimit: result.rateLimitLow };
     }
 
     // Group new comments by author
@@ -328,10 +343,10 @@ export class CopilotPoller {
     // Update seen IDs with full union
     const unionIds = [...new Set([...seenIds, ...currentIds])];
     this.stateDb.updateSeenCommentIds(prNumber, unionIds);
-    return result.rateLimitLow;
+    return { isRateLimit: result.rateLimitLow };
   }
 
-  private async pollReviews(repo: RepoInfo, item: WorkItem, token: string): Promise<boolean> {
+  private async pollReviews(repo: RepoInfo, item: WorkItem, token: string): Promise<PollItemResult> {
     const prNumber = item.prNumber as number;
 
     let result: FetchReviewsResult;
@@ -340,7 +355,9 @@ export class CopilotPoller {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this.logger.warn(`[mcpd] CopilotPoller failed to fetch reviews for PR #${prNumber}: ${msg}`);
-      return msg.includes("rate limit");
+      if (msg.includes("rate limit")) return { isRateLimit: true };
+      if (msg.includes("auth/scope") || msg.includes("auth failed")) return { isRateLimit: false, authError: msg };
+      return { isRateLimit: false };
     }
 
     if (result.rateLimitLow) {
@@ -348,7 +365,7 @@ export class CopilotPoller {
     }
 
     const reviews = result.reviews;
-    if (this.stopped) return result.rateLimitLow;
+    if (this.stopped) return { isRateLimit: result.rateLimitLow };
 
     const seenIds = new Set(this.stateDb.getSeenReviewIds(prNumber));
     const currentIds = reviews.map((r) => r.id);
@@ -416,10 +433,10 @@ export class CopilotPoller {
       const unionIds = [...new Set([...seenIds, ...currentIds])];
       this.stateDb.updateSeenReviewIds(prNumber, unionIds);
     }
-    return result.rateLimitLow;
+    return { isRateLimit: result.rateLimitLow };
   }
 
-  private async pollPRComments(repo: RepoInfo, item: WorkItem, token: string): Promise<boolean> {
+  private async pollPRComments(repo: RepoInfo, item: WorkItem, token: string): Promise<PollItemResult> {
     const prNumber = item.prNumber as number;
 
     let result: FetchIssueCommentsResult;
@@ -428,7 +445,9 @@ export class CopilotPoller {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this.logger.warn(`[mcpd] CopilotPoller failed to fetch PR comments for PR #${prNumber}: ${msg}`);
-      return msg.includes("rate limit");
+      if (msg.includes("rate limit")) return { isRateLimit: true };
+      if (msg.includes("auth/scope") || msg.includes("auth failed")) return { isRateLimit: false, authError: msg };
+      return { isRateLimit: false };
     }
 
     if (result.rateLimitLow) {
@@ -436,7 +455,7 @@ export class CopilotPoller {
     }
 
     const comments = result.comments;
-    if (this.stopped) return result.rateLimitLow;
+    if (this.stopped) return { isRateLimit: result.rateLimitLow };
 
     const seenIds = new Set(this.stateDb.getSeenPRCommentIds(prNumber));
     const currentIds = comments.map((c) => c.id);
@@ -458,10 +477,10 @@ export class CopilotPoller {
       const unionIds = [...new Set([...seenIds, ...currentIds])];
       this.stateDb.updateSeenPRCommentIds(prNumber, unionIds);
     }
-    return result.rateLimitLow;
+    return { isRateLimit: result.rateLimitLow };
   }
 
-  private async pollIssueComments(repo: RepoInfo, item: WorkItem, token: string): Promise<boolean> {
+  private async pollIssueComments(repo: RepoInfo, item: WorkItem, token: string): Promise<PollItemResult> {
     const issueNumber = item.issueNumber as number;
 
     let result: FetchIssueCommentsResult;
@@ -470,7 +489,9 @@ export class CopilotPoller {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       this.logger.warn(`[mcpd] CopilotPoller failed to fetch issue comments for #${issueNumber}: ${msg}`);
-      return msg.includes("rate limit");
+      if (msg.includes("rate limit")) return { isRateLimit: true };
+      if (msg.includes("auth/scope") || msg.includes("auth failed")) return { isRateLimit: false, authError: msg };
+      return { isRateLimit: false };
     }
 
     if (result.rateLimitLow) {
@@ -478,7 +499,7 @@ export class CopilotPoller {
     }
 
     const comments = result.comments;
-    if (this.stopped) return result.rateLimitLow;
+    if (this.stopped) return { isRateLimit: result.rateLimitLow };
 
     const seenIds = new Set(this.stateDb.getSeenIssueCommentIds(issueNumber));
     const currentIds = comments.map((c) => c.id);
@@ -499,7 +520,7 @@ export class CopilotPoller {
       const unionIds = [...new Set([...seenIds, ...currentIds])];
       this.stateDb.updateSeenIssueCommentIds(issueNumber, unionIds);
     }
-    return result.rateLimitLow;
+    return { isRateLimit: result.rateLimitLow };
   }
 
   private adjustInterval(tracked: WorkItem[]): void {
@@ -572,7 +593,15 @@ async function fetchPaginated<T>(startUrl: string, token: string): Promise<Fetch
       if (remaining !== null && Number.parseInt(remaining, 10) === 0) {
         throw new Error("GitHub API rate limit exhausted (403)");
       }
-      throw new Error(`GitHub API forbidden (403): ${response.statusText}`);
+      const retryAfter = response.headers.get("retry-after");
+      if (retryAfter !== null) {
+        const retryAfterSeconds = Number.parseInt(retryAfter, 10);
+        if (Number.isNaN(retryAfterSeconds)) {
+          throw new Error(`GitHub API secondary rate limit (403): retry after ${retryAfter}`);
+        }
+        throw new Error(`GitHub API secondary rate limit (403): retry after ${retryAfterSeconds}s`);
+      }
+      throw new Error(`GitHub API auth/scope error (403): ${response.statusText}`);
     }
 
     if (!response.ok) {

--- a/packages/daemon/src/github/copilot-poller.ts
+++ b/packages/daemon/src/github/copilot-poller.ts
@@ -218,6 +218,17 @@ export class CopilotPoller {
         (item) => item.prNumber === null && item.issueNumber !== null && item.phase !== "done",
       );
 
+      for (const item of allItems) {
+        if (
+          item.prNumber !== null &&
+          (item.prState === "merged" || item.prState === "closed" || item.phase === "done")
+        ) {
+          this.stateDb.deleteCopilotCommentState(item.prNumber);
+        } else if (item.prNumber === null && item.issueNumber !== null && item.phase === "done") {
+          this.stateDb.deleteCopilotCommentState(item.issueNumber);
+        }
+      }
+
       if (tracked.length === 0 && trackedIssues.length === 0) {
         this._lastError = null;
         this._pollCount++;

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -3455,6 +3455,111 @@ describe("IpcServer HTTP transport", () => {
     expect(events.every((e) => e.category === "session")).toBe(true);
     expect(events.find((e) => e.event === "mail.received")).toBeUndefined();
   });
+
+  test("ring-buffer: session.response excluded from live delivery without responseTail", async () => {
+    startServer();
+
+    const controller = new AbortController();
+    const res = await fetch("http://localhost/events", {
+      method: "GET",
+      unix: socketPath,
+      signal: controller.signal,
+    } as RequestInit);
+
+    expect(res.status).toBe(200);
+    if (!res.body) throw new Error("Expected response body");
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+
+    if (!server) throw new Error("server not started");
+    server.pushEvent({ event: "session.response", category: "session", sessionId: "s1", chunk: "secret" });
+    server.pushEvent({ event: "session.result", category: "session", sessionId: "s1" });
+
+    let buffer = "";
+    const deadline = Date.now() + 2_000;
+    while (Date.now() < deadline) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      if (buffer.includes("session.result")) break;
+    }
+
+    controller.abort();
+    reader.releaseLock();
+
+    expect(buffer).not.toContain("session.response");
+    expect(buffer).toContain("session.result");
+  });
+
+  test("ring-buffer: session.response included in live delivery when responseTail matches", async () => {
+    startServer();
+
+    const controller = new AbortController();
+    const res = await fetch("http://localhost/events?responseTail=s1", {
+      method: "GET",
+      unix: socketPath,
+      signal: controller.signal,
+    } as RequestInit);
+
+    expect(res.status).toBe(200);
+    if (!res.body) throw new Error("Expected response body");
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+
+    if (!server) throw new Error("server not started");
+    server.pushEvent({ event: "session.response", category: "session", sessionId: "s1", chunk: "hello" });
+    server.pushEvent({ event: "session.result", category: "session", sessionId: "s1" });
+
+    let buffer = "";
+    const deadline = Date.now() + 2_000;
+    while (Date.now() < deadline) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      if (buffer.includes("session.result")) break;
+    }
+
+    controller.abort();
+    reader.releaseLock();
+
+    expect(buffer).toContain("session.response");
+    expect(buffer).toContain("session.result");
+  });
+
+  test("ring-buffer: session.response excluded when responseTail is different session", async () => {
+    startServer();
+
+    const controller = new AbortController();
+    const res = await fetch("http://localhost/events?responseTail=other-session", {
+      method: "GET",
+      unix: socketPath,
+      signal: controller.signal,
+    } as RequestInit);
+
+    expect(res.status).toBe(200);
+    if (!res.body) throw new Error("Expected response body");
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+
+    if (!server) throw new Error("server not started");
+    server.pushEvent({ event: "session.response", category: "session", sessionId: "s1", chunk: "secret" });
+    server.pushEvent({ event: "session.result", category: "session", sessionId: "s1" });
+
+    let buffer = "";
+    const deadline = Date.now() + 2_000;
+    while (Date.now() < deadline) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      if (buffer.includes("session.result")) break;
+    }
+
+    controller.abort();
+    reader.releaseLock();
+
+    expect(buffer).not.toContain("session.response");
+    expect(buffer).toContain("session.result");
+  });
 });
 
 // ── buildEventFilter unit tests ──

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -3401,7 +3401,10 @@ describe("IpcServer HTTP transport", () => {
       const hbLine = lines.find((l) => l.includes('"heartbeat"'));
       expect(hbLine).toBeDefined();
       const hb = JSON.parse(hbLine as string) as Record<string, unknown>;
-      expect(hb.t).toBe("heartbeat");
+      expect(hb.category).toBe("heartbeat");
+      expect(hb.event).toBe("heartbeat");
+      expect(hb.src).toBe("daemon");
+      expect(typeof hb.ts).toBe("string");
       expect(typeof hb.seq).toBe("number");
     } finally {
       Object.defineProperty(IpcServer, "HEARTBEAT_INTERVAL_MS", {

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -1817,7 +1817,7 @@ export class IpcServer {
 
         heartbeatTimer = setInterval(() => {
           if (Date.now() - lastWriteTime >= IpcServer.HEARTBEAT_INTERVAL_MS) {
-            const hb = `${JSON.stringify({ t: "heartbeat", seq: this.eventSeq })}\n`;
+            const hb = `${JSON.stringify({ category: "heartbeat", event: "heartbeat", seq: this.eventSeq, src: "daemon", ts: new Date().toISOString() })}\n`;
             try {
               controller.enqueue(encoder.encode(hb));
               lastWriteTime = Date.now();

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -1695,6 +1695,14 @@ export class IpcServer {
 
     // ── Ring-buffer fallback path (direct pushEvent(), no EventBus) ──
     const filter = buildEventFilter(url.searchParams);
+    const fallbackResponseTail = url.searchParams.get("responseTail");
+    const shouldDeliverFallback = (event: Record<string, unknown>) => {
+      if (filter !== null && !filter(event)) return false;
+      if (event.event === "session.response") {
+        return fallbackResponseTail !== null && event.sessionId === fallbackResponseTail;
+      }
+      return true;
+    };
     const capacity = IpcServer.EVENT_RING_CAPACITY;
     const ring: string[] = new Array(capacity);
     let writeIdx = 0;
@@ -1763,7 +1771,7 @@ export class IpcServer {
         // buffered during backfill and drained after to preserve ordering.
         let liveBuffer: Array<{ line: string; seq: number | undefined }> | null = null;
         const subscriber = (event: Record<string, unknown>) => {
-          if (filter && !filter(event)) return;
+          if (!shouldDeliverFallback(event)) return;
           const line = `${JSON.stringify(event)}\n`;
           const seq = typeof event.seq === "number" ? event.seq : undefined;
           if (liveBuffer !== null) {
@@ -1785,9 +1793,10 @@ export class IpcServer {
           while (true) {
             const batch = eventLog.getSince(cursor, 1000);
             for (const event of batch) {
+              highWaterMark = event.seq;
+              if (!shouldDeliverFallback(event as Record<string, unknown>)) continue;
               const line = `${JSON.stringify(event)}\n`;
               try {
-                highWaterMark = event.seq;
                 controller.enqueue(encoder.encode(line));
               } catch {
                 cleanup();


### PR DESCRIPTION
## Summary
- Adds centralized help registry (`help.ts`) with `CommandHelp` type, `formatHelp()` formatter, and `hasHelpFlag()` utility
- Registers help descriptors for all 11 claude subcommands (spawn, ls, send, bye, interrupt, log, wait, resume, worktrees, approve, deny)
- Dispatcher intercept in `cmdClaudeInternal()` and `cmdAgent()` catches `--help`/`-h` before delegating to command handlers — no more silent ignoring
- Removes redundant per-command `--help` check from `claudeSpawn()` (now handled by dispatcher); preserves `agentSpawn()` provider-specific help for non-claude providers

## Test plan
- [x] `help.spec.ts`: 11 tests covering `hasHelpFlag()`, registry round-trip, `formatHelp()` output (minimal, with options, with examples, column alignment), and all 11 subcommand registrations
- [x] `claude.spec.ts`: new test for `mcx claude wait --help` (the original repro case) — verifies help is printed and no tool call is made
- [x] Existing `spawn --help` tests updated and passing (both production path via cmdAgent and test path via deps injection)
- [x] All 5926 tests pass, typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)