### PR TITLE
fix(sites): three-way profileDir error when two sites requested (fixes #1671)

### DIFF
--- a/packages/daemon/src/site-worker.ts
+++ b/packages/daemon/src/site-worker.ts
@@ -17,6 +17,7 @@
 
 import { existsSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
+import { resolve as resolvePath } from "node:path";
 import { SITE_SERVER_NAME } from "@mcp-cli/core";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
@@ -115,7 +116,8 @@ function resolveProfileDir(cfg: SiteConfig): string {
   const raw = cfg.browser?.profileDir;
   if (raw) {
     validateProfileDir(raw);
-    return raw.startsWith("~/") ? raw.replace("~", homedir()) : raw;
+    const expanded = raw.startsWith("~/") ? raw.replace("~", homedir()) : raw;
+    return resolvePath(expanded);
   }
   const profile = cfg.browser?.chromeProfile ?? "default";
   if (/[/\\]/.test(profile) || profile.split("/").some((seg) => seg === "..")) {
@@ -311,11 +313,11 @@ function resetIfBrowserDied(): void {
 async function handleBrowserStart(args: Record<string, unknown>): Promise<ToolResult> {
   return withBrowserLock(async () => {
     resetIfBrowserDied();
-    const siteNames =
-      (args.sites as string[] | undefined) ??
-      listSites()
-        .filter((s) => s.enabled)
-        .map((s) => s.name);
+    const siteNames = Array.isArray(args.sites)
+      ? (args.sites as string[])
+      : listSites()
+          .filter((s) => s.enabled)
+          .map((s) => s.name);
     const sites = siteNames.map((n) => requireSite(n));
     if (sites.length === 0) return error("No sites configured");
 

--- a/packages/daemon/src/site/browser/playwright.spec.ts
+++ b/packages/daemon/src/site/browser/playwright.spec.ts
@@ -158,4 +158,15 @@ describe("partitionSitesForRunningBrowser — #1594", () => {
     expect(toOpen.map((s) => s.name)).toEqual(["teams", "owa"]);
     expect(profileMismatch).toHaveLength(0);
   });
+
+  test("trailing-slash profileDir is treated as matching the normalized running profile — #1671", () => {
+    // resolveProfileDir always runs normalize(), but guard against any string-format
+    // difference (trailing sep, doubled sep) sneaking through from external callers.
+    const profileWithSlash = `${profile}/`;
+    const { toOpen, profileMismatch } = partitionSitesForRunningBrowser(profile, new Set<string>(), [
+      spec("owa", { profileDir: profileWithSlash }),
+    ]);
+    expect(toOpen.map((s) => s.name)).toEqual(["owa"]);
+    expect(profileMismatch).toHaveLength(0);
+  });
 });

--- a/packages/daemon/src/site/browser/playwright.ts
+++ b/packages/daemon/src/site/browser/playwright.ts
@@ -11,6 +11,7 @@
  */
 
 import { existsSync, mkdirSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
 import type {
   BrowserContext,
   Page,
@@ -72,7 +73,7 @@ export function partitionSitesForRunningBrowser(
   for (const s of requested) {
     if (openedSiteNames.has(s.name)) {
       alreadyRunning.push(s);
-    } else if (s.profileDir !== runningProfile) {
+    } else if (resolvePath(s.profileDir) !== resolvePath(runningProfile)) {
       profileMismatch.push(s);
     } else {
       toOpen.push(s);
@@ -170,7 +171,7 @@ export class PlaywrightBrowserEngine implements BrowserEngine {
 
     // A single persistent Playwright context has exactly one user-data directory.
     // Sites opened together must agree on profileDir; mixed profiles need separate start() calls.
-    const profileDirs = [...new Set(sites.map((s) => s.profileDir))];
+    const profileDirs = [...new Set(sites.map((s) => resolvePath(s.profileDir)))];
     if (profileDirs.length > 1) {
       throw new Error(
         `PlaywrightBrowserEngine.start: all sites opened together must share one profileDir. Got ${profileDirs.length}: ${profileDirs.join(", ")}`,


### PR DESCRIPTION
## Summary

- **Array.isArray guard in `handleBrowserStart`**: the previous `?? listSites()` nullish-coalescing fell through for `null` (not just `undefined`), so a direct `site_browser_start` call with `sites: null` would inject all enabled sites — including any implicit `default` site — even when specific sites were intended. Changed to `Array.isArray(args.sites)` which handles null correctly.
- **`path.resolve()` normalization in `resolveProfileDir`**: explicit `profileDir` values from user config can carry a trailing separator after tilde-expansion (e.g., `"~/.mcp-cli/sites/default/"` → `"/Users/user/.mcp-cli/sites/default/"`). This produced a string distinct from the `path.join`-normalized value emitted by `siteBrowserProfileDir`, causing the Set dedup in `start()` to count the same logical directory twice. Fixed by running `path.resolve()` on the expanded path.
- **`path.resolve()` in `partitionSitesForRunningBrowser` and the cold-start dedup**: apply the same normalization at comparison/dedup time as a belt-and-suspenders guard for any profileDir strings that arrive without going through `resolveProfileDir`.

## Test plan

- [x] New test: `partitionSitesForRunningBrowser` treats a trailing-slash `profileDir` as matching the normalized running profile (routes to `toOpen`, not `profileMismatch`) — #1671
- [x] All 9 `playwright.spec.ts` tests pass
- [x] Full suite: 5915 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)