### PR TITLE
fix(worktree): verify removal before claiming success, retry with --force (fixes #1749)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -1856,7 +1856,7 @@ describe("mcx claude bye", () => {
     }
   });
 
-  test("reports failure when git worktree remove fails", async () => {
+  test("reports success when directory is absent even if git remove fails", async () => {
     const callTool: ClaudeDeps["callTool"] = mock(async (tool: string) => {
       if (tool === "claude_session_list") return toolResult(SESSION_LIST);
       return toolResult({ ended: true, worktree: "claude-locked", cwd: "/repo" });
@@ -1874,7 +1874,8 @@ describe("mcx claude bye", () => {
     try {
       await cmdClaude(["bye", "def"], deps);
       const errOutput = printError.mock.calls.map((c: unknown[]) => c[0]).join("\n");
-      expect(errOutput).toContain("Failed to remove worktree:");
+      // Directory doesn't exist on disk → verified removed regardless of exit code
+      expect(errOutput).toContain("Removed worktree:");
     } finally {
       console.log = origLog;
     }
@@ -3187,6 +3188,7 @@ describe("mcx claude bye branch cleanup", () => {
       if (cmd.includes("--show-current")) return { stdout: "feat/issue-42", stderr: "", exitCode: 0 };
       if (cmd.includes("remove")) return { stdout: "", stderr: "", exitCode: 0 };
       if (cmd.includes("-d")) return { stdout: "", stderr: "", exitCode: 0 };
+      if (cmd.includes("rev-parse") && cmd.includes("--verify")) return { stdout: "", stderr: "", exitCode: 1 };
       return { stdout: "", stderr: "", exitCode: 0 };
     });
     const printError = mock(() => {});
@@ -3344,6 +3346,7 @@ describe("mcx claude worktrees", () => {
       if (cmd.includes("status")) return { stdout: "", stderr: "", exitCode: 0 };
       if (cmd.includes("remove")) return { stdout: "", stderr: "", exitCode: 0 };
       if (cmd.includes("-d")) return { stdout: "", stderr: "", exitCode: 0 };
+      if (cmd.includes("rev-parse") && cmd.includes("--verify")) return { stdout: "", stderr: "", exitCode: 1 };
       return { stdout: "", stderr: "", exitCode: 0 };
     });
     const printError = mock(() => {});
@@ -3527,6 +3530,7 @@ describe("mcx claude worktrees", () => {
       if (cmd.includes("status")) return { stdout: "", stderr: "", exitCode: 0 };
       if (cmd.includes("remove")) return { stdout: "", stderr: "", exitCode: 0 };
       if (cmd.includes("-d")) return { stdout: "", stderr: "", exitCode: 0 };
+      if (cmd.includes("rev-parse") && cmd.includes("--verify")) return { stdout: "", stderr: "", exitCode: 1 };
       return { stdout: "", stderr: "", exitCode: 0 };
     });
     const printError = mock(() => {});

--- a/packages/core/src/worktree-shim.spec.ts
+++ b/packages/core/src/worktree-shim.spec.ts
@@ -427,6 +427,34 @@ describe("cleanupWorktree", () => {
     expect(msgs.some((m) => m.includes("Removed worktree"))).toBe(true);
   });
 
+  test("corrupted worktree: skips --force when non-force removal fails", () => {
+    tmpDir = makeTmpDir();
+    const worktreeBase = join(tmpDir, ".claude", "worktrees");
+    const worktreePath = join(worktreeBase, "corrupt-stuck-wt");
+    mkdirSync(worktreePath, { recursive: true });
+
+    let forceAttempted = false;
+    const exec = mock((cmd: string[]) => {
+      if (cmd.includes("status") && cmd.includes("--porcelain"))
+        return { stdout: "", stderr: "fatal: not a git repository", exitCode: 128 };
+      if (cmd.includes("remove") && cmd.includes("--force")) {
+        forceAttempted = true;
+        return { stdout: "", stderr: "", exitCode: 0 };
+      }
+      if (cmd.includes("remove")) return { stdout: "", stderr: "", exitCode: 1 }; // non-force fails; dir stays
+      if (cmd.includes("core.bare")) return { stdout: "false", stderr: "", exitCode: 0 };
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const printError = mock(() => {});
+
+    cleanupWorktree("corrupt-stuck-wt", worktreePath, { exec, printError }, tmpDir);
+
+    const msgs = (printError as ReturnType<typeof mock>).mock.calls.map((c: unknown[]) => c[0] as string);
+    expect(forceAttempted).toBe(false);
+    expect(msgs.some((m) => m.includes("skipping --force because cleanliness could not be verified"))).toBe(true);
+    expect(msgs.some((m) => m.startsWith("Removed worktree"))).toBe(false);
+  });
+
   test("branch delete reports success only after rev-parse verification", () => {
     const exec = mock((cmd: string[]) => {
       if (cmd.includes("status") && cmd.includes("--porcelain")) return { stdout: "", stderr: "", exitCode: 0 };

--- a/packages/core/src/worktree-shim.spec.ts
+++ b/packages/core/src/worktree-shim.spec.ts
@@ -236,16 +236,29 @@ describe("createWorktree", () => {
 // ── cleanupWorktree ──
 
 describe("cleanupWorktree", () => {
-  test("removes clean worktree and deletes merged branch", () => {
-    const execResults: Record<string, { stdout: string; stderr: string; exitCode: number }> = {};
-    const exec = mock((cmd: string[]) => {
-      if (cmd.includes("status")) return { stdout: "", stderr: "", exitCode: 0 };
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir && existsSync(tmpDir)) rmSync(tmpDir, { recursive: true });
+  });
+
+  // Helper: builds an exec mock that handles the standard git commands.
+  // worktreePath doesn't exist on disk, so existsSync returns false → verified removed.
+  function happyExec() {
+    return mock((cmd: string[]) => {
+      if (cmd.includes("status") && cmd.includes("--porcelain")) return { stdout: "", stderr: "", exitCode: 0 };
       if (cmd.includes("--show-current")) return { stdout: "feat/my-branch", stderr: "", exitCode: 0 };
       if (cmd.includes("remove")) return { stdout: "", stderr: "", exitCode: 0 };
       if (cmd.includes("-d")) return { stdout: "", stderr: "", exitCode: 0 };
+      // rev-parse --verify: branch gone after -d → exit 1
+      if (cmd.includes("rev-parse") && cmd.includes("--verify")) return { stdout: "", stderr: "", exitCode: 1 };
       if (cmd.includes("core.bare")) return { stdout: "false", stderr: "", exitCode: 0 };
       return { stdout: "", stderr: "", exitCode: 0 };
     });
+  }
+
+  test("removes clean worktree and deletes merged branch", () => {
+    const exec = happyExec();
     const printError = mock(() => {});
 
     cleanupWorktree("my-wt", "/repo/.claude/worktrees/my-wt", { exec, printError }, "/repo");
@@ -271,11 +284,12 @@ describe("cleanupWorktree", () => {
     expect(removeCalls.length).toBe(0);
   });
 
-  test("no-ops when worktree is already gone", () => {
+  test("no-ops when worktree is already gone and directory absent", () => {
     const exec = mock(() => ({ stdout: "", stderr: "", exitCode: 128 }));
     const printError = mock(() => {});
 
     cleanupWorktree("my-wt", "/repo/.claude/worktrees/my-wt", { exec, printError }, "/repo");
+    // Path doesn't exist on disk → no removal attempted, no messages
     expect(printError).not.toHaveBeenCalled();
   });
 
@@ -289,11 +303,11 @@ describe("cleanupWorktree", () => {
 
   test("trims branch name before deleting", () => {
     const exec = mock((cmd: string[]) => {
-      if (cmd.includes("status")) return { stdout: "", stderr: "", exitCode: 0 };
-      // Simulate git returning branch with trailing newline
+      if (cmd.includes("status") && cmd.includes("--porcelain")) return { stdout: "", stderr: "", exitCode: 0 };
       if (cmd.includes("--show-current")) return { stdout: "feat/my-branch\n", stderr: "", exitCode: 0 };
       if (cmd.includes("remove")) return { stdout: "", stderr: "", exitCode: 0 };
       if (cmd.includes("-d")) return { stdout: "", stderr: "", exitCode: 0 };
+      if (cmd.includes("rev-parse") && cmd.includes("--verify")) return { stdout: "", stderr: "", exitCode: 1 };
       if (cmd.includes("core.bare")) return { stdout: "false", stderr: "", exitCode: 0 };
       return { stdout: "", stderr: "", exitCode: 0 };
     });
@@ -307,17 +321,16 @@ describe("cleanupWorktree", () => {
     );
     expect(deleteCalls.length).toBe(1);
     expect(deleteCalls[0][0] as string[]).toContain("feat/my-branch");
-    // Should NOT contain trailing newline
     expect(deleteCalls[0][0] as string[]).not.toContain("feat/my-branch\n");
   });
 
   test("handles trailing newline in git status --porcelain for clean repo", () => {
     const exec = mock((cmd: string[]) => {
-      // Simulate git returning just a newline for clean repo
-      if (cmd.includes("status")) return { stdout: "\n", stderr: "", exitCode: 0 };
+      if (cmd.includes("status") && cmd.includes("--porcelain")) return { stdout: "\n", stderr: "", exitCode: 0 };
       if (cmd.includes("--show-current")) return { stdout: "feat/branch", stderr: "", exitCode: 0 };
       if (cmd.includes("remove")) return { stdout: "", stderr: "", exitCode: 0 };
       if (cmd.includes("-d")) return { stdout: "", stderr: "", exitCode: 0 };
+      if (cmd.includes("rev-parse") && cmd.includes("--verify")) return { stdout: "", stderr: "", exitCode: 1 };
       if (cmd.includes("core.bare")) return { stdout: "false", stderr: "", exitCode: 0 };
       return { stdout: "", stderr: "", exitCode: 0 };
     });
@@ -325,8 +338,116 @@ describe("cleanupWorktree", () => {
 
     cleanupWorktree("my-wt", "/repo/.claude/worktrees/my-wt", { exec, printError }, "/repo");
 
-    // Should treat "\n" as clean and proceed to remove
     expect(printError).toHaveBeenCalledWith(expect.stringContaining("Removed worktree"));
+  });
+
+  test("retries with --force when directory persists after exit-0 remove", () => {
+    // Create a real temp dir so existsSync returns true after the first remove
+    tmpDir = makeTmpDir();
+    const worktreeBase = join(tmpDir, ".claude", "worktrees");
+    const worktreePath = join(worktreeBase, "stubborn-wt");
+    mkdirSync(worktreePath, { recursive: true });
+
+    let forceAttempted = false;
+    const exec = mock((cmd: string[]) => {
+      if (cmd.includes("status") && cmd.includes("--porcelain")) return { stdout: "", stderr: "", exitCode: 0 };
+      if (cmd.includes("--show-current")) return { stdout: "feat/branch", stderr: "", exitCode: 0 };
+      if (cmd.includes("remove") && cmd.includes("--force")) {
+        forceAttempted = true;
+        // Simulate --force succeeding: remove the dir so existsSync returns false
+        rmSync(worktreePath, { recursive: true });
+        return { stdout: "", stderr: "", exitCode: 0 };
+      }
+      if (cmd.includes("remove")) return { stdout: "", stderr: "", exitCode: 0 }; // exit 0 but dir stays
+      if (cmd.includes("-d")) return { stdout: "", stderr: "", exitCode: 0 };
+      if (cmd.includes("rev-parse") && cmd.includes("--verify")) return { stdout: "", stderr: "", exitCode: 1 };
+      if (cmd.includes("core.bare")) return { stdout: "false", stderr: "", exitCode: 0 };
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const printError = mock(() => {});
+
+    cleanupWorktree("stubborn-wt", worktreePath, { exec, printError }, tmpDir);
+
+    expect(forceAttempted).toBe(true);
+    expect(printError).toHaveBeenCalledWith(expect.stringContaining("Removed worktree (--force)"));
+    expect(printError).toHaveBeenCalledWith(expect.stringContaining("Deleted branch"));
+  });
+
+  test("reports failure with diagnostics when both remove attempts fail", () => {
+    tmpDir = makeTmpDir();
+    const worktreeBase = join(tmpDir, ".claude", "worktrees");
+    const worktreePath = join(worktreeBase, "stuck-wt");
+    mkdirSync(worktreePath, { recursive: true });
+
+    const exec = mock((cmd: string[]) => {
+      if (cmd.includes("status") && cmd.includes("--porcelain")) return { stdout: "", stderr: "", exitCode: 0 };
+      if (cmd.includes("--show-current")) return { stdout: "feat/branch", stderr: "", exitCode: 0 };
+      // Both remove attempts fail (dir stays on disk)
+      if (cmd.includes("remove") && cmd.includes("--force"))
+        return { stdout: "", stderr: "fatal: cannot force remove", exitCode: 1 };
+      if (cmd.includes("remove")) return { stdout: "", stderr: "is dirty", exitCode: 1 };
+      if (cmd.includes("core.bare")) return { stdout: "false", stderr: "", exitCode: 0 };
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const printError = mock(() => {});
+
+    cleanupWorktree("stuck-wt", worktreePath, { exec, printError }, tmpDir);
+
+    const msgs = (printError as ReturnType<typeof mock>).mock.calls.map((c: unknown[]) => c[0] as string);
+    expect(msgs.some((m) => m.includes("Failed to remove worktree"))).toBe(true);
+    expect(msgs.some((m) => m.includes("fatal: cannot force remove"))).toBe(true);
+    // Should NOT have printed "Removed worktree" or "Deleted branch"
+    expect(msgs.some((m) => m.startsWith("Removed worktree"))).toBe(false);
+    expect(msgs.some((m) => m.startsWith("Deleted branch"))).toBe(false);
+  });
+
+  test("attempts removal when git status fails but directory exists (corrupted worktree)", () => {
+    tmpDir = makeTmpDir();
+    const worktreeBase = join(tmpDir, ".claude", "worktrees");
+    const worktreePath = join(worktreeBase, "corrupt-wt");
+    mkdirSync(worktreePath, { recursive: true });
+
+    const exec = mock((cmd: string[]) => {
+      // git status fails (corrupted .git file)
+      if (cmd.includes("status") && cmd.includes("--porcelain"))
+        return { stdout: "", stderr: "fatal: not a git repository", exitCode: 128 };
+      if (cmd.includes("remove") && !cmd.includes("--force")) {
+        rmSync(worktreePath, { recursive: true });
+        return { stdout: "", stderr: "", exitCode: 0 };
+      }
+      if (cmd.includes("core.bare")) return { stdout: "false", stderr: "", exitCode: 0 };
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const printError = mock(() => {});
+
+    cleanupWorktree("corrupt-wt", worktreePath, { exec, printError }, tmpDir);
+
+    const msgs = (printError as ReturnType<typeof mock>).mock.calls.map((c: unknown[]) => c[0] as string);
+    expect(msgs.some((m) => m.includes("git status failed in worktree"))).toBe(true);
+    expect(msgs.some((m) => m.includes("Removed worktree"))).toBe(true);
+  });
+
+  test("branch delete reports success only after rev-parse verification", () => {
+    const exec = mock((cmd: string[]) => {
+      if (cmd.includes("status") && cmd.includes("--porcelain")) return { stdout: "", stderr: "", exitCode: 0 };
+      if (cmd.includes("--show-current")) return { stdout: "zombie-branch", stderr: "", exitCode: 0 };
+      if (cmd.includes("remove")) return { stdout: "", stderr: "", exitCode: 0 };
+      if (cmd.includes("-d")) return { stdout: "", stderr: "", exitCode: 0 };
+      // Branch still exists after -d (rev-parse succeeds → branch NOT gone)
+      if (cmd.includes("rev-parse") && cmd.includes("--verify")) return { stdout: "abc123", stderr: "", exitCode: 0 };
+      if (cmd.includes("core.bare")) return { stdout: "false", stderr: "", exitCode: 0 };
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const printError = mock(() => {});
+
+    cleanupWorktree("my-wt", "/repo/.claude/worktrees/my-wt", { exec, printError }, "/repo");
+
+    const msgs = (printError as ReturnType<typeof mock>).mock.calls.map((c: unknown[]) => c[0] as string);
+    // Worktree was removed (path doesn't exist on disk)
+    expect(msgs.some((m) => m.startsWith("Removed worktree"))).toBe(true);
+    // Branch should NOT be claimed as deleted — verification failed
+    expect(msgs.some((m) => m.startsWith("Deleted branch"))).toBe(false);
+    expect(msgs.some((m) => m.includes("branch still exists"))).toBe(true);
   });
 });
 
@@ -425,6 +546,7 @@ describe("pruneWorktrees", () => {
       if (cmd.includes("status")) return { stdout: "", stderr: "", exitCode: 0 }; // clean
       if (cmd.includes("remove")) return { stdout: "", stderr: "", exitCode: 0 };
       if (cmd.includes("-d")) return { stdout: "", stderr: "", exitCode: 0 };
+      if (cmd.includes("rev-parse") && cmd.includes("--verify")) return { stdout: "", stderr: "", exitCode: 1 };
       if (cmd.includes("core.bare")) return { stdout: "false", stderr: "", exitCode: 0 };
       return { stdout: "", stderr: "", exitCode: 0 };
     });
@@ -538,6 +660,7 @@ describe("pruneWorktrees", () => {
         if (cmd.includes("status")) return { stdout: "", stderr: "", exitCode: 0 };
         if (cmd.includes("worktree") && cmd.includes("remove")) return { stdout: "", stderr: "", exitCode: 0 };
         if (cmd.includes("branch") && cmd.includes("-d")) return { stdout: "", stderr: "", exitCode: 0 };
+        if (cmd.includes("rev-parse") && cmd.includes("--verify")) return { stdout: "", stderr: "", exitCode: 1 };
         // Simulate core.bare=true after all removals complete
         if (cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset")) {
           return { stdout: "true", stderr: "", exitCode: 0 };

--- a/packages/core/src/worktree-shim.ts
+++ b/packages/core/src/worktree-shim.ts
@@ -200,7 +200,17 @@ export function cleanupWorktree(worktree: string, cwd: string, deps: WorktreeShi
 
   // Check for uncommitted changes (trim to handle trailing newline from some git versions)
   const { stdout: rawStatus, exitCode: statusExit } = deps.exec(["git", "-C", worktreePath, "status", "--porcelain"]);
-  if (statusExit !== 0) return;
+  if (statusExit !== 0) {
+    // git status failed — worktree may be corrupted or partially removed.
+    // Attempt removal anyway rather than silently leaving it registered.
+    if (existsSync(worktreePath)) {
+      deps.printError(
+        `Warning: git status failed in worktree (exit ${statusExit}), attempting removal: ${worktreePath}`,
+      );
+      removeWorktreeWithVerification(effectiveRoot, worktreePath, deps);
+    }
+    return;
+  }
   const status = rawStatus.trim();
 
   if (status === "") {
@@ -211,28 +221,17 @@ export function cleanupWorktree(worktree: string, cwd: string, deps: WorktreeShi
     if (hasWorktreeHooks(wtConfig) && wtConfig.teardown) {
       const hookEnv = buildHookEnv({ branch: worktree, path: worktreePath, cwd: effectiveRoot });
       const { exitCode: hookExit, stderr: hookStderr } = deps.exec(["sh", "-c", wtConfig.teardown], { env: hookEnv });
-      if (hookExit === 0) {
+      if (hookExit === 0 && !existsSync(worktreePath)) {
         deps.printError(`Removed worktree via hook: ${worktreePath}`);
         deleteIfSafeToDelete(branch, effectiveRoot, deps);
+      } else if (hookExit === 0) {
+        deps.printError(`Worktree teardown hook returned success but directory still exists: ${worktreePath}`);
       } else {
         deps.printError(`Worktree teardown hook failed for: ${worktreePath}: ${hookStderr}`);
       }
     } else {
-      const bareBeforeCleanup = isCoreBareSet(effectiveRoot, (cmd) => deps.exec(cmd));
-      const { exitCode: removeExit } = deps.exec(["git", "-C", effectiveRoot, "worktree", "remove", worktreePath]);
-      if (removeExit === 0) {
-        if (!bareBeforeCleanup && isCoreBareSet(effectiveRoot, (cmd) => deps.exec(cmd))) {
-          deps.printError(
-            `[shim] core.bare flipped to true by: git worktree remove ${worktreePath} (repo=${effectiveRoot}) — see #1330`,
-          );
-        }
-        if (fixCoreBare(effectiveRoot, (cmd) => deps.exec(cmd))) {
-          deps.printError("Fixed core.bare=true after worktree removal");
-        }
-        deps.printError(`Removed worktree: ${worktreePath}`);
+      if (removeWorktreeWithVerification(effectiveRoot, worktreePath, deps)) {
         deleteIfSafeToDelete(branch, effectiveRoot, deps);
-      } else {
-        deps.printError(`Failed to remove worktree: ${worktreePath}`);
       }
     }
   } else {
@@ -253,6 +252,54 @@ export function cleanupWorktree(worktree: string, cwd: string, deps: WorktreeShi
   }
 }
 
+/**
+ * Attempt `git worktree remove`, verify the directory is actually gone,
+ * and retry with --force if needed. Only prints success after verification.
+ * Returns true if the directory was verified removed.
+ */
+function removeWorktreeWithVerification(repoRoot: string, worktreePath: string, deps: WorktreeShimDeps): boolean {
+  const bareBeforeCleanup = isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd));
+  const { exitCode: removeExit, stderr: removeStderr } = deps.exec([
+    "git",
+    "-C",
+    repoRoot,
+    "worktree",
+    "remove",
+    worktreePath,
+  ]);
+
+  if (removeExit === 0 && !bareBeforeCleanup && isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd))) {
+    deps.printError(
+      `[shim] core.bare flipped to true by: git worktree remove ${worktreePath} (repo=${repoRoot}) — see #1330`,
+    );
+  }
+  if (fixCoreBare(repoRoot, (cmd) => deps.exec(cmd))) {
+    deps.printError("Fixed core.bare=true after worktree removal");
+  }
+
+  // Verify: directory must actually be gone
+  if (!existsSync(worktreePath)) {
+    deps.printError(`Removed worktree: ${worktreePath}`);
+    return true;
+  }
+
+  // Directory persists despite exit 0, or initial remove failed — retry with --force
+  const { stderr: forceStderr } = deps.exec(["git", "-C", repoRoot, "worktree", "remove", "--force", worktreePath]);
+  if (fixCoreBare(repoRoot, (cmd) => deps.exec(cmd))) {
+    deps.printError("Fixed core.bare=true after worktree removal");
+  }
+
+  if (!existsSync(worktreePath)) {
+    deps.printError(`Removed worktree (--force): ${worktreePath}`);
+    return true;
+  }
+
+  // Both attempts failed — report with diagnostics
+  const stderr = forceStderr || removeStderr;
+  deps.printError(`Failed to remove worktree: ${worktreePath}${stderr ? ` (${stderr})` : ""}`);
+  return false;
+}
+
 /** Delete a branch if git branch -d considers it safe (merged into HEAD or upstream). */
 function deleteIfSafeToDelete(branch: string, repoRoot: string, deps: WorktreeShimDeps): boolean {
   if (!branch) return false;
@@ -262,8 +309,21 @@ function deleteIfSafeToDelete(branch: string, repoRoot: string, deps: WorktreeSh
     if (!bareBeforeDelete && isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd))) {
       deps.printError(`[shim] core.bare flipped to true by: git branch -d ${branch} (repo=${repoRoot}) — see #1330`);
     }
-    deps.printError(`Deleted branch: ${branch} (safe)`);
-    return true;
+    // Verify the branch is actually gone
+    const { exitCode: verifyExit } = deps.exec([
+      "git",
+      "-C",
+      repoRoot,
+      "rev-parse",
+      "--verify",
+      `refs/heads/${branch}`,
+    ]);
+    if (verifyExit !== 0) {
+      deps.printError(`Deleted branch: ${branch} (safe)`);
+      return true;
+    }
+    deps.printError(`Warning: git branch -d returned success but branch still exists: ${branch}`);
+    return false;
   }
   return false;
 }
@@ -415,28 +475,19 @@ export async function pruneWorktrees(opts: WorktreePruneOptions): Promise<Worktr
     if (hasWorktreeHooks(wtConfig) && wtConfig.teardown) {
       const hookEnv = buildHookEnv({ branch: wtName, path: wt.path, cwd: repoRoot });
       const { exitCode: hookExit, stderr: hookStderr } = deps.exec(["sh", "-c", wtConfig.teardown], { env: hookEnv });
-      if (hookExit === 0) {
+      if (hookExit === 0 && !existsSync(wt.path)) {
         deps.printError(`Removed worktree via hook: ${wt.path}`);
         pruned++;
         if (wt.branch && deleteIfSafeToDelete(wt.branch, repoRoot, deps)) {
           deletedBranches.add(wt.branch);
         }
+      } else if (hookExit === 0) {
+        deps.printError(`Worktree teardown hook returned success but directory still exists: ${wt.path}`);
       } else {
         deps.printError(`Worktree teardown hook failed for: ${wt.path}: ${hookStderr}`);
       }
     } else {
-      const bareBeforePrune = isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd));
-      const { exitCode: removeExit } = deps.exec(["git", "-C", repoRoot, "worktree", "remove", wt.path]);
-      if (removeExit === 0) {
-        if (!bareBeforePrune && isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd))) {
-          deps.printError(
-            `[shim] core.bare flipped to true by: git worktree remove ${wt.path} (repo=${repoRoot}) — see #1330`,
-          );
-        }
-        if (fixCoreBare(repoRoot, (cmd) => deps.exec(cmd))) {
-          deps.printError("Fixed core.bare=true after worktree removal");
-        }
-        deps.printError(`Removed worktree: ${wt.path}`);
+      if (removeWorktreeWithVerification(repoRoot, wt.path, deps)) {
         pruned++;
         if (wt.branch && deleteIfSafeToDelete(wt.branch, repoRoot, deps)) {
           deletedBranches.add(wt.branch);

--- a/packages/core/src/worktree-shim.ts
+++ b/packages/core/src/worktree-shim.ts
@@ -207,7 +207,7 @@ export function cleanupWorktree(worktree: string, cwd: string, deps: WorktreeShi
       deps.printError(
         `Warning: git status failed in worktree (exit ${statusExit}), attempting removal: ${worktreePath}`,
       );
-      removeWorktreeWithVerification(effectiveRoot, worktreePath, deps);
+      removeWorktreeWithVerification(effectiveRoot, worktreePath, deps, false);
     }
     return;
   }
@@ -257,7 +257,12 @@ export function cleanupWorktree(worktree: string, cwd: string, deps: WorktreeShi
  * and retry with --force if needed. Only prints success after verification.
  * Returns true if the directory was verified removed.
  */
-function removeWorktreeWithVerification(repoRoot: string, worktreePath: string, deps: WorktreeShimDeps): boolean {
+function removeWorktreeWithVerification(
+  repoRoot: string,
+  worktreePath: string,
+  deps: WorktreeShimDeps,
+  allowForce = true,
+): boolean {
   const bareBeforeCleanup = isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd));
   const { exitCode: removeExit, stderr: removeStderr } = deps.exec([
     "git",
@@ -283,8 +288,29 @@ function removeWorktreeWithVerification(repoRoot: string, worktreePath: string, 
     return true;
   }
 
+  if (!allowForce) {
+    deps.printError(
+      `Warning: worktree still exists after non-force removal; skipping --force because cleanliness could not be verified: ${worktreePath}`,
+    );
+    return false;
+  }
+
   // Directory persists despite exit 0, or initial remove failed — retry with --force
-  const { stderr: forceStderr } = deps.exec(["git", "-C", repoRoot, "worktree", "remove", "--force", worktreePath]);
+  const bareBeforeForce = isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd));
+  const { exitCode: forceExit, stderr: forceStderr } = deps.exec([
+    "git",
+    "-C",
+    repoRoot,
+    "worktree",
+    "remove",
+    "--force",
+    worktreePath,
+  ]);
+  if (forceExit === 0 && !bareBeforeForce && isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd))) {
+    deps.printError(
+      `[shim] core.bare flipped to true by: git worktree remove --force ${worktreePath} (repo=${repoRoot}) — see #1330`,
+    );
+  }
   if (fixCoreBare(repoRoot, (cmd) => deps.exec(cmd))) {
     deps.printError("Fixed core.bare=true after worktree removal");
   }
@@ -295,8 +321,14 @@ function removeWorktreeWithVerification(repoRoot: string, worktreePath: string, 
   }
 
   // Both attempts failed — report with diagnostics
-  const stderr = forceStderr || removeStderr;
-  deps.printError(`Failed to remove worktree: ${worktreePath}${stderr ? ` (${stderr})` : ""}`);
+  const rawStderr = forceStderr || removeStderr;
+  const stderrSummary = rawStderr
+    ? ` (${rawStderr
+        .trim()
+        .replace(/\s*\n\s*/g, "; ")
+        .slice(0, 200)})`
+    : "";
+  deps.printError(`Failed to remove worktree: ${worktreePath}${stderrSummary}`);
   return false;
 }
 


### PR DESCRIPTION
## Summary
- `cleanupWorktree` now verifies directories are actually gone (`existsSync`) before printing "Removed worktree" — previously it trusted `git worktree remove` exit codes blindly
- Retries with `--force` when directories survive an exit-0 remove; includes stderr in failure diagnostics
- Handles corrupted worktrees (git status fails but directory exists) by attempting removal instead of silently skipping
- `deleteIfSafeToDelete` verifies branches via `rev-parse --verify` before claiming "Deleted branch"
- Same verification pattern applied to `pruneWorktrees` and hook-based teardown paths

## Test plan
- [x] Existing happy-path tests pass (clean worktree removal + branch deletion)
- [x] New test: directory persists after exit-0 → retries with `--force`, verifies removal
- [x] New test: both remove and force-remove fail → prints diagnostic error with stderr
- [x] New test: corrupted worktree (git status fails, dir exists) → attempts removal
- [x] New test: branch verification — `git branch -d` returns 0 but branch persists → warns instead of claiming success
- [x] All 5918 tests pass, coverage thresholds met
- [x] `bun typecheck` + `bun lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)