### PR TITLE
test(monitor): add onCiEvent empty-checks guard test (closes #1693)

### DIFF
--- a/packages/daemon/src/github/work-item-poller.spec.ts
+++ b/packages/daemon/src/github/work-item-poller.spec.ts
@@ -1083,6 +1083,22 @@ describe("WorkItemPoller", () => {
     expect(secondStarted).toHaveLength(1);
   });
 
+  test("onCiEvent is not called when ciChecks is empty", async () => {
+    db.createWorkItem({ id: "#15", prNumber: 15, ciStatus: "none" });
+
+    const ciEvents: CiEvent[] = [];
+    const poller = new WorkItemPoller({
+      db,
+      logger: SILENT_LOGGER,
+      fetchPRs: async () => [makePRStatus({ number: 15, ciState: null, ciChecks: [] })],
+      detectRepo: async () => TEST_REPO,
+      onCiEvent: (e) => ciEvents.push(e),
+    });
+
+    await poller.poll();
+    expect(ciEvents).toHaveLength(0);
+  });
+
   test("CI state survives poller restart — no duplicate ci.started, correct observedDurationMs", async () => {
     db.createWorkItem({ id: "#20", prNumber: 20, prState: "open", ciStatus: "running" });
 


### PR DESCRIPTION
## Summary
- Issue #1693 required 5 `onCiEvent` integration tests in `work-item-poller.spec.ts`
- Tests 1–4 were already present (added since the issue was filed): `ci.started`+`ci.running` on first poll, `ci.finished` on completion, no re-emit regression guard, and re-run detection
- This PR adds the missing 5th test: `onCiEvent is not called when ciChecks is empty`

## Test plan
- [x] New test verifies `onCiEvent` is never invoked when `PRStatus.ciChecks` is empty
- [x] `bun test packages/daemon/src/github/work-item-poller.spec.ts` — 46 pass (was 45)
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean, no fixes applied
- [x] Pre-commit hooks passed (typecheck + lint + test + coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)