### PR TITLE
perf(event-filter): memoize createEventMatcher to avoid per-event recompile (fixes #1727)

### DIFF
--- a/packages/core/src/event-filter.spec.ts
+++ b/packages/core/src/event-filter.spec.ts
@@ -119,6 +119,31 @@ describe("matchFilter", () => {
   });
 });
 
+// ── matchFilter memoization ──
+
+describe("matchFilter memoization", () => {
+  test("repeated calls with same spec object return correct results", () => {
+    const spec: EventFilterSpec = { type: "pr.*", src: "daemon.*" };
+    const events = [
+      makeEvent({ event: "pr.opened", src: "daemon.poller" }),
+      makeEvent({ event: "pr.merged", src: "daemon.poller" }),
+      makeEvent({ event: "session.result", src: "daemon.poller" }),
+      makeEvent({ event: "pr.closed", src: "user.script" }),
+    ];
+
+    expect(events.map((e) => matchFilter(e, spec))).toEqual([true, true, false, false]);
+  });
+
+  test("different spec objects with same shape are independent", () => {
+    const specA: EventFilterSpec = { type: "pr.*" };
+    const specB: EventFilterSpec = { type: "ci.*" };
+
+    const event = makeEvent({ event: "pr.opened" });
+    expect(matchFilter(event, specA)).toBe(true);
+    expect(matchFilter(event, specB)).toBe(false);
+  });
+});
+
 // ── filterSpecToStreamParams ──
 
 describe("filterSpecToStreamParams", () => {

--- a/packages/core/src/event-filter.ts
+++ b/packages/core/src/event-filter.ts
@@ -71,6 +71,8 @@ export function createEventMatcher(spec: EventFilterSpec): (event: MonitorEvent)
   };
 }
 
+const matcherCache = new WeakMap<EventFilterSpec, (event: MonitorEvent) => boolean>();
+
 /**
  * Test whether a monitor event matches an EventFilterSpec.
  *
@@ -78,7 +80,12 @@ export function createEventMatcher(spec: EventFilterSpec): (event: MonitorEvent)
  * (e.g. the server-side ipc-server filter) must handle that separately.
  */
 export function matchFilter(event: MonitorEvent, spec: EventFilterSpec): boolean {
-  return createEventMatcher(spec)(event);
+  let matcher = matcherCache.get(spec);
+  if (!matcher) {
+    matcher = createEventMatcher(spec);
+    matcherCache.set(spec, matcher);
+  }
+  return matcher(event);
 }
 
 /** Convert an EventFilterSpec to openEventStream query params. */
@@ -175,6 +182,8 @@ export function createWaitForEvent(opts?: {
         }, ms);
       }
 
+      const matcher = createEventMatcher(filter);
+
       (async () => {
         try {
           for await (const event of events) {
@@ -185,7 +194,7 @@ export function createWaitForEvent(opts?: {
               (event as Record<string, unknown>).t === "heartbeat"
             )
               continue;
-            if (matchFilter(event, filter)) {
+            if (matcher(event)) {
               settle(() => resolve(event));
               break;
             }

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -68,11 +68,11 @@ import {
   WaitForMailParamsSchema,
   bundleAlias,
   consoleLogger,
+  createEventMatcher,
   hardenFile,
   isDefineAlias,
   isDefineMonitor,
   loadManifest,
-  matchFilter,
   options,
   resolveRealpath,
   safeAliasPath,
@@ -149,10 +149,12 @@ export function buildEventFilter(params: URLSearchParams): ((event: Record<strin
     ...(phase ? { phase } : {}),
   };
 
+  const matcher = createEventMatcher(spec);
+
   return (event: Record<string, unknown>): boolean => {
     // Heartbeats always pass through — server-side keepalive, not a data filter concern
     if (event.category === "heartbeat" || event.event === "heartbeat") return true;
-    return matchFilter(event as MonitorEvent, spec);
+    return matcher(event as MonitorEvent);
   };
 }
 


### PR DESCRIPTION
## Summary
- Add a `WeakMap<EventFilterSpec, matcher>` cache in `matchFilter()` so repeated calls with the same spec object reuse the compiled matcher instead of rebuilding Set/RegExp patterns each time
- Pre-compile the matcher once in `buildEventFilter()` (ipc-server) and `createWaitForEvent()` (core) instead of delegating to `matchFilter` per event
- Add tests verifying correct behavior with repeated calls on same and different spec objects

## Test plan
- [x] New "matchFilter memoization" tests pass (same spec repeated, different spec independence)
- [x] All 6000 existing tests pass (0 failures)
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)