### PR TITLE
fix(phase): apply resolvedFrom fallback to --no-execute path (fixes #1635)

### DIFF
--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -605,6 +605,59 @@ describe("cmdPhase dispatch", () => {
     expect(err).toContain("[FORCED]");
   });
 
+  test("run --no-execute falls back to last committed transition when --from omitted (#1635)", async () => {
+    // Prime the log with impl (initial → impl)
+    appendTransitionLog(transitionLogPath(dir), {
+      ts: "2026-01-01T00:00:00Z",
+      workItemId: "#77",
+      from: null,
+      to: "impl",
+      status: "committed",
+    });
+    const { err, code } = await catchExit(() =>
+      cmdPhase(["run", "qa", "--work-item", "#77", "--no-execute"], { cwd: () => dir }),
+    );
+    expect(code).toBeUndefined();
+    expect(err).toContain("approved");
+    expect(err).toContain("impl → qa");
+    expect(err).not.toContain("(initial)");
+  });
+
+  test("run --no-execute falls back to work_items.phase when transition log is empty (#1635)", async () => {
+    // No transition log — work_items.phase="impl" should serve as implicit --from
+    const mockIpcCall = async (method: string, params: unknown) => {
+      if (method === "getWorkItem") {
+        return {
+          id: "#88",
+          issueNumber: 88,
+          prNumber: null,
+          branch: "feat/88",
+          prState: null,
+          prUrl: null,
+          ciStatus: "none",
+          ciRunId: null,
+          ciSummary: null,
+          reviewStatus: "pending",
+          phase: "impl",
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-01T00:00:00Z",
+        };
+      }
+      return null;
+    };
+    const { err, code } = await catchExit(() =>
+      cmdPhase(
+        ["run", "qa", "--work-item", "#88", "--no-execute"],
+        { cwd: () => dir },
+        { ipcCall: mockIpcCall as unknown as typeof import("@mcp-cli/core").ipcCall },
+      ),
+    );
+    expect(code).toBeUndefined();
+    expect(err).toContain("approved");
+    expect(err).toContain("impl → qa");
+    expect(err).not.toContain("(initial)");
+  });
+
   test("run on unknown phase exits 1 with suggestions", async () => {
     const { code, err } = await catchExit(() => cmdPhase(["run", "qaa", "--from", "impl"], { cwd: () => dir }));
     expect(code).toBe(1);

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -571,7 +571,11 @@ function shortHash(s: string): string {
   return s.length > 40 ? `${s.slice(0, 37)}...` : s;
 }
 
-export async function cmdPhase(args: string[], deps?: Partial<PhaseInstallDeps>): Promise<void> {
+export async function cmdPhase(
+  args: string[],
+  deps?: Partial<PhaseInstallDeps>,
+  execDeps?: Partial<PhaseExecuteDeps>,
+): Promise<void> {
   const d: PhaseInstallDeps = { ...defaultDeps, ...deps };
   const sub = args[0];
 
@@ -712,7 +716,36 @@ export async function cmdPhase(args: string[], deps?: Partial<PhaseInstallDeps>)
       } else if (argv.includes("--no-execute")) {
         const filtered = argv.filter((a) => a !== "--no-execute");
         const opts = parsePhaseRunArgs(filtered);
-        const result = phaseRun(opts, { cwd: d.cwd() });
+        const cwd = d.cwd();
+        // Mirror the resolvedFrom fallback from executePhase (#1635):
+        // read history + optionally fetch work_items.phase so --from can be
+        // omitted when the transition log is empty (manually-spawned impl).
+        const ex: PhaseExecuteDeps = { ...defaultExecuteDeps, ...execDeps };
+        const manifestForFrom = loadManifest(cwd);
+        const priorTargets = manifestForFrom
+          ? historyTargets(readTransitionHistory(transitionLogPath(cwd), opts.workItemId).filter(isCommitted))
+          : [];
+        let workItemPhase: string | null = null;
+        if (opts.workItemId !== null && manifestForFrom) {
+          try {
+            const wi = (await ex.ipcCall("getWorkItem", { id: opts.workItemId })) as WorkItem | null;
+            if (wi) workItemPhase = wi.phase;
+          } catch {
+            // ignore; resolvedFrom falls back to null
+          }
+        }
+        const resolvedFrom =
+          opts.from !== null
+            ? opts.from
+            : priorTargets.length > 0
+              ? priorTargets[priorTargets.length - 1]
+              : manifestForFrom &&
+                  opts.target !== manifestForFrom.manifest.initial &&
+                  workItemPhase != null &&
+                  workItemPhase in manifestForFrom.manifest.phases
+                ? workItemPhase
+                : null;
+        const result = phaseRun({ ...opts, from: resolvedFrom }, { cwd });
         const source = result.manifest.phases[opts.target]?.source ?? "(unknown)";
         const tag = result.forced ? " [FORCED]" : "";
         const trail = result.from ?? "(initial)";

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -718,33 +718,31 @@ export async function cmdPhase(
         const opts = parsePhaseRunArgs(filtered);
         const cwd = d.cwd();
         // Mirror the resolvedFrom fallback from executePhase (#1635):
-        // read history + optionally fetch work_items.phase so --from can be
-        // omitted when the transition log is empty (manually-spawned impl).
-        const ex: PhaseExecuteDeps = { ...defaultExecuteDeps, ...execDeps };
-        const manifestForFrom = loadManifest(cwd);
-        const priorTargets = manifestForFrom
-          ? historyTargets(readTransitionHistory(transitionLogPath(cwd), opts.workItemId).filter(isCommitted))
-          : [];
-        let workItemPhase: string | null = null;
-        if (opts.workItemId !== null && manifestForFrom) {
-          try {
-            const wi = (await ex.ipcCall("getWorkItem", { id: opts.workItemId })) as WorkItem | null;
-            if (wi) workItemPhase = wi.phase;
-          } catch {
-            // ignore; resolvedFrom falls back to null
+        // Only do the expensive history-read + ipcCall when --from is absent.
+        let resolvedFrom: string | null = opts.from;
+        if (resolvedFrom === null) {
+          const manifestForFrom = d.loadManifest(cwd);
+          const priorTargets = manifestForFrom
+            ? historyTargets(readTransitionHistory(transitionLogPath(cwd), opts.workItemId).filter(isCommitted))
+            : [];
+          if (priorTargets.length > 0) {
+            resolvedFrom = priorTargets[priorTargets.length - 1];
+          } else if (opts.workItemId !== null && manifestForFrom) {
+            const ex: PhaseExecuteDeps = { ...defaultExecuteDeps, ...execDeps };
+            try {
+              const wi = (await ex.ipcCall("getWorkItem", { id: opts.workItemId })) as WorkItem | null;
+              if (
+                wi &&
+                opts.target !== manifestForFrom.manifest.initial &&
+                wi.phase in manifestForFrom.manifest.phases
+              ) {
+                resolvedFrom = wi.phase;
+              }
+            } catch {
+              // ignore; resolvedFrom stays null
+            }
           }
         }
-        const resolvedFrom =
-          opts.from !== null
-            ? opts.from
-            : priorTargets.length > 0
-              ? priorTargets[priorTargets.length - 1]
-              : manifestForFrom &&
-                  opts.target !== manifestForFrom.manifest.initial &&
-                  workItemPhase != null &&
-                  workItemPhase in manifestForFrom.manifest.phases
-                ? workItemPhase
-                : null;
         const result = phaseRun({ ...opts, from: resolvedFrom }, { cwd });
         const source = result.manifest.phases[opts.target]?.source ?? "(unknown)";
         const tag = result.forced ? " [FORCED]" : "";


### PR DESCRIPTION
## Summary
- The `--no-execute` path in `cmdPhase` called `phaseRun()` directly with `opts.from` (null when `--from` is omitted), bypassing the `resolvedFrom` fallback added in #1630 for `executePhase`
- Mirrors the same three-tier fallback into the `--no-execute` handler: explicit `--from` > last committed transition > `work_items.phase` (when log is empty, target ≠ initial, phase in manifest)
- Adds optional `execDeps?: Partial<PhaseExecuteDeps>` param to `cmdPhase` so `ipcCall` is injectable in tests

## Test plan
- [x] Added test: `--no-execute` uses last committed transition as implicit `--from` when `--from` omitted (history-based fallback)
- [x] Added test: `--no-execute` falls back to `work_items.phase` when transition log is empty (work-item fallback)
- [x] Existing `--no-execute` tests still pass (valid transition with explicit `--from`, forced transition)
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun test packages/command/src/commands/` — 1595 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)