### PR TITLE
feat(phase): phase.allowBranchOverride config for local POC testing (fixes #1775)

### DIFF
--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -1593,6 +1593,70 @@ phases:
     expect(errs.some((e) => e.includes("phases only run from branch"))).toBe(true);
   }, 30_000);
 
+  test("phase.allowBranchOverride in config bypasses guard and prints one-line warning", async () => {
+    writeFileSync(join(dir, ".mcx.yaml"), manifestMain);
+    writeFileSync(join(dir, "impl.ts"), phaseAlias);
+    await install();
+
+    const ex = makeExecDeps({ branch: "feat/poc" });
+    const errs: string[] = [];
+    const logs: string[] = [];
+    await executePhase(
+      ["implement"],
+      {
+        ...makeDriftDeps(dir).deps,
+        log: (m) => logs.push(m),
+        logError: (m) => errs.push(m),
+        exit: ((c: number) => {
+          throw new Error(`unexpected exit ${c}`);
+        }) as (code: number) => never,
+      },
+      {
+        ipcCall: ex.ipcCall,
+        exec: ex.exec,
+        findGitRoot: ex.findGitRoot,
+        now: ex.now,
+        readCliConfig: () => ({ phase: { allowBranchOverride: ["feat/poc"] } }),
+      },
+    );
+
+    // One-line warning printed to stderr, handler executed successfully
+    expect(errs.some((e) => e.includes("install-security boundary not enforced"))).toBe(true);
+    expect(logs.some((l) => l.includes('"action"'))).toBe(true);
+  }, 30_000);
+
+  test("phase.allowBranchOverride containing runsOn branch exits with error", async () => {
+    writeFileSync(join(dir, ".mcx.yaml"), manifestMain);
+    writeFileSync(join(dir, "impl.ts"), phaseAlias);
+    await install();
+
+    const ex = makeExecDeps({ branch: "main" });
+    const errs: string[] = [];
+    let code: number | undefined;
+    await executePhase(
+      ["implement"],
+      {
+        ...makeDriftDeps(dir).deps,
+        log: () => {},
+        logError: (m) => errs.push(m),
+        exit: ((c: number) => {
+          code = c;
+          throw new Error("exit");
+        }) as (code: number) => never,
+      },
+      {
+        ipcCall: ex.ipcCall,
+        exec: ex.exec,
+        findGitRoot: ex.findGitRoot,
+        now: ex.now,
+        readCliConfig: () => ({ phase: { allowBranchOverride: ["main"] } }),
+      },
+    ).catch(() => {});
+
+    expect(code).toBe(1);
+    expect(errs.some((e) => e.includes("runsOn branch"))).toBe(true);
+  }, 30_000);
+
   test("missing work item for --work-item id exits 1", async () => {
     writeFileSync(join(dir, ".mcx.yaml"), manifestMain);
     writeFileSync(join(dir, "impl.ts"), phaseAlias);

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -22,6 +22,7 @@ import {
   type AliasStateAccessor,
   type AliasWorkItemInfo,
   BranchGuardError,
+  type CliConfig,
   DisallowedTransitionError,
   GLOBAL_STATE_NAMESPACE,
   LOCKFILE_NAME,
@@ -58,7 +59,9 @@ import {
   loadManifest,
   parseLockfile,
   readAllTransitions,
+  readCliConfig,
   readTransitionHistory,
+  resolveRunsOn,
   serializeLockfile,
   sha256Hex,
   suggestPhases,
@@ -872,6 +875,7 @@ export interface PhaseExecuteDeps {
   exec: ExecFn;
   findGitRoot: (cwd: string) => string | null;
   now: () => Date;
+  readCliConfig: () => CliConfig;
 }
 
 export function spawnExec(cmd: string[]): ExecResult {
@@ -892,6 +896,7 @@ const defaultExecuteDeps: PhaseExecuteDeps = {
   exec: spawnExec,
   findGitRoot,
   now: () => new Date(),
+  readCliConfig,
 };
 
 export interface PhaseExecuteArgs {
@@ -1095,14 +1100,36 @@ export async function executePhase(
   // Branch guard — phases execute with full shell/mcp access, so refuse
   // to dispatch from any branch other than the manifest's `runsOn`. The
   // attempt entry above captured the intent for audit.
+  // phase.allowBranchOverride in ~/.mcp-cli/config.json can list feature branches
+  // for local POC/testing; those branches bypass the guard with a warning.
+  const allowBranches = ex.readCliConfig().phase?.allowBranchOverride ?? [];
+  if (allowBranches.length > 0) {
+    const expected = resolveRunsOn(loaded.manifest);
+    if (allowBranches.includes(expected)) {
+      d.logError(
+        `phase.allowBranchOverride in ~/.mcp-cli/config.json contains "${expected}" which is the manifest's runsOn branch.\n` +
+          `The allow-list is for feature branches only — remove "${expected}" from the list.`,
+      );
+      d.exit(1);
+    }
+  }
+  let branchGuardWarning: string | null = null;
   try {
-    checkRunsOn({ cwd, manifest: loaded.manifest, exec: ex.exec });
+    ({ warning: branchGuardWarning } = checkRunsOn({
+      cwd,
+      manifest: loaded.manifest,
+      exec: ex.exec,
+      allowBranches,
+    }));
   } catch (err) {
     if (err instanceof BranchGuardError) {
       d.logError(err.message);
       d.exit(1);
     }
     throw err;
+  }
+  if (branchGuardWarning) {
+    d.logError(branchGuardWarning);
   }
 
   let resolved: string;

--- a/packages/core/src/branch-guard.spec.ts
+++ b/packages/core/src/branch-guard.spec.ts
@@ -155,4 +155,66 @@ describe("checkRunsOn", () => {
   test("DEFAULT_RUNS_ON is main", () => {
     expect(DEFAULT_RUNS_ON).toBe("main");
   });
+
+  test("passes with no warning when on expected branch (allowBranches irrelevant)", () => {
+    const exec = mockExec({
+      "git -C /repo rev-parse --is-inside-work-tree": OK("true\n"),
+      "git -C /repo symbolic-ref --short HEAD": OK("main\n"),
+    });
+    const result = checkRunsOn({ cwd: CWD, manifest: manifest(), exec, allowBranches: ["feat/x"] });
+    expect(result).toEqual({ warning: null });
+  });
+
+  describe("allowBranches", () => {
+    test("bypasses guard with one-line warning when current branch is in list", () => {
+      const exec = mockExec({
+        "git -C /repo rev-parse --is-inside-work-tree": OK("true\n"),
+        "git -C /repo symbolic-ref --short HEAD": OK("feat/poc\n"),
+      });
+      const result = checkRunsOn({
+        cwd: CWD,
+        manifest: manifest(),
+        exec,
+        allowBranches: ["feat/poc"],
+      });
+      expect(result.warning).toBeTypeOf("string");
+      expect(result.warning).toContain('phases running from branch "feat/poc"');
+      expect(result.warning).toContain('"main"');
+      expect(result.warning).toContain("install-security boundary not enforced");
+    });
+
+    test("still throws when current branch is not in the list", () => {
+      const exec = mockExec({
+        "git -C /repo rev-parse --is-inside-work-tree": OK("true\n"),
+        "git -C /repo symbolic-ref --short HEAD": OK("feat/other\n"),
+      });
+      expect(() => checkRunsOn({ cwd: CWD, manifest: manifest(), exec, allowBranches: ["feat/poc"] })).toThrow(
+        BranchGuardError,
+      );
+    });
+
+    test("bypass works when list contains multiple branches", () => {
+      const exec = mockExec({
+        "git -C /repo rev-parse --is-inside-work-tree": OK("true\n"),
+        "git -C /repo symbolic-ref --short HEAD": OK("feat/b\n"),
+      });
+      const result = checkRunsOn({
+        cwd: CWD,
+        manifest: manifest(),
+        exec,
+        allowBranches: ["feat/a", "feat/b"],
+      });
+      expect(result.warning).toContain('phases running from branch "feat/b"');
+    });
+
+    test("does not bypass for detached HEAD even if list is non-empty", () => {
+      const exec = mockExec({
+        "git -C /repo rev-parse --is-inside-work-tree": OK("true\n"),
+        "git -C /repo symbolic-ref --short HEAD": FAIL,
+      });
+      expect(() => checkRunsOn({ cwd: CWD, manifest: manifest(), exec, allowBranches: ["feat/poc"] })).toThrow(
+        BranchGuardError,
+      );
+    });
+  });
 });

--- a/packages/core/src/branch-guard.ts
+++ b/packages/core/src/branch-guard.ts
@@ -70,13 +70,29 @@ function describe(cb: CurrentBranch): string {
 /**
  * Verify the repo at `cwd` is on the manifest's `runsOn` branch.
  * Throws `BranchGuardError` with a user-facing refusal message on mismatch.
+ *
+ * If `allowBranches` (from `phase.allowBranchOverride` in ~/.mcp-cli/config.json)
+ * contains the current branch name, the guard is bypassed and a one-line warning
+ * is returned. The list must not include the `runsOn` branch — that validation is
+ * the caller's responsibility (phase.ts validates before calling here).
  */
-export function checkRunsOn(opts: { cwd: string; manifest: Pick<Manifest, "runsOn">; exec: ExecFn }): void {
+export function checkRunsOn(opts: {
+  cwd: string;
+  manifest: Pick<Manifest, "runsOn">;
+  exec: ExecFn;
+  allowBranches?: string[];
+}): { warning: string | null } {
   const expected = resolveRunsOn(opts.manifest);
   const cb = currentBranch(opts.cwd, opts.exec);
 
   if (cb.kind === "branch" && cb.name === expected) {
-    return;
+    return { warning: null };
+  }
+
+  if (cb.kind === "branch" && opts.allowBranches?.includes(cb.name)) {
+    return {
+      warning: `WARNING: phases running from branch "${cb.name}", not "${expected}" — install-security boundary not enforced`,
+    };
   }
 
   const actualDesc = describe(cb);

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -54,6 +54,16 @@ export interface McpConfigFile {
   mcpServers?: ServerConfigMap;
 }
 
+/** Phase execution configuration */
+export interface PhaseConfig {
+  /**
+   * Feature branches allowed to bypass the runsOn guard for local POC/testing.
+   * Must not contain the manifest's runsOn branch (typically "main") — add only
+   * short-lived feature branches you own. Set via ~/.mcp-cli/config.json.
+   */
+  allowBranchOverride?: string[];
+}
+
 /** Configuration for ephemeral (auto-saved) aliases */
 export interface EphemeralAliasConfig {
   /** Enable auto-saving long CLI calls as ephemeral aliases (default: true) */
@@ -81,6 +91,8 @@ export interface CliConfig {
   telemetry?: boolean;
   /** Whether the first-run telemetry notice has been shown */
   telemetryNoticeShown?: boolean;
+  /** Phase execution configuration */
+  phase?: PhaseConfig;
 }
 
 /** Claude Code project settings (.claude/settings.local.json) */


### PR DESCRIPTION
## Summary
- Adds `phase.allowBranchOverride: string[]` to `~/.mcp-cli/config.json` — lists feature branches allowed to bypass the `runsOn` branch guard for local POC/testing, without touching the manifest or CI config
- Prints a one-line warning to stderr on every invocation when the bypass is active: `WARNING: phases running from branch "<X>", not "main" — install-security boundary not enforced`
- Anti-footgun: if the list contains the manifest's `runsOn` branch (typically `main`), execution exits with a clear error message — the list is for feature branches only

## Design
No env var, no CLI flag, no `.mcx.yaml` schema change. The `phase.allowBranchOverride` is in `~/.mcp-cli/config.json` (per-dev, not committed), keeping per-dev opt-in scoped separately from the manifest's `runsOn` (which targets orchestrator/CI consumers per #1773).

`checkRunsOn` in `branch-guard.ts` accepts `allowBranches?: string[]`; the call site in `phase.ts` reads the config and validates. `readCliConfig` is injectable via `PhaseExecuteDeps` for test isolation.

## Test plan
- [ ] `bun test packages/core/src/branch-guard.spec.ts` — 5 new unit tests: bypass with one-line warning, list with multiple branches, non-listed branch still throws, detached HEAD not bypassed, on-expected-branch ignores list
- [ ] `bun test packages/command/src/commands/phase.spec.ts` — 2 new integration tests: config bypass → handler runs + warning in stderr; config contains runsOn → exits 1 with clear error
- [ ] Full suite: `bun test` — 6005 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)