### PR TITLE
fix(monitor): accumulate per-item fetch errors into CopilotPoller _lastError (fixes #1735)

### DIFF
--- a/packages/daemon/src/github/copilot-poller.spec.ts
+++ b/packages/daemon/src/github/copilot-poller.spec.ts
@@ -690,6 +690,26 @@ describe("CopilotPoller", () => {
       expect(poller.lastError).toMatch(/^2\/3 items failed: network timeout$/);
     });
 
+    test("multiple sub-poll failures on one item count as one failed item", async () => {
+      workItemDb.createWorkItem({ id: "wi:1", prNumber: 42, prState: "open" });
+
+      const { poller } = makePoller({
+        fetchComments: async () => {
+          throw new Error("network timeout");
+        },
+        fetchReviews: async () => {
+          throw new Error("network timeout");
+        },
+        fetchIssueComments: async () => {
+          throw new Error("network timeout");
+        },
+      });
+
+      await poller.poll();
+
+      expect(poller.lastError).toMatch(/^1\/1 items failed: network timeout$/);
+    });
+
     test("auth error takes priority over fetch errors in lastError", async () => {
       workItemDb.createWorkItem({ id: "wi:1", prNumber: 42, prState: "open" });
       workItemDb.createWorkItem({ id: "wi:2", prNumber: 43, prState: "open" });
@@ -704,6 +724,68 @@ describe("CopilotPoller", () => {
       await poller.poll();
 
       expect(poller.lastError).toContain("auth/scope");
+    });
+
+    test("fetchReviews error surfaces in lastError", async () => {
+      workItemDb.createWorkItem({ id: "wi:1", prNumber: 42, prState: "open" });
+
+      const { poller } = makePoller({
+        fetchReviews: async () => {
+          throw new Error("reviews fetch failed");
+        },
+      });
+
+      await poller.poll();
+
+      expect(poller.lastError).toContain("reviews fetch failed");
+      expect(poller.lastError).toMatch(/^1\/1 items failed:/);
+    });
+
+    test("fetchIssueComments error on PR item surfaces in lastError", async () => {
+      workItemDb.createWorkItem({ id: "wi:1", prNumber: 42, prState: "open" });
+
+      const { poller } = makePoller({
+        fetchIssueComments: async () => {
+          throw new Error("PR comments fetch failed");
+        },
+      });
+
+      await poller.poll();
+
+      expect(poller.lastError).toContain("PR comments fetch failed");
+      expect(poller.lastError).toMatch(/^1\/1 items failed:/);
+    });
+
+    test("fetchIssueComments error on issue-only item surfaces in lastError", async () => {
+      workItemDb.createWorkItem({ id: "#99", issueNumber: 99, prNumber: null, prState: null });
+
+      const { poller } = makePoller({
+        fetchIssueComments: async () => {
+          throw new Error("issue comments fetch failed");
+        },
+      });
+
+      await poller.poll();
+
+      expect(poller.lastError).toContain("issue comments fetch failed");
+      expect(poller.lastError).toMatch(/^1\/1 items failed:/);
+    });
+
+    test("fetch errors from different endpoints show distinct messages", async () => {
+      workItemDb.createWorkItem({ id: "wi:1", prNumber: 42, prState: "open" });
+
+      const { poller } = makePoller({
+        fetchComments: async () => {
+          throw new Error("inline timeout");
+        },
+        fetchReviews: async () => {
+          throw new Error("reviews timeout");
+        },
+      });
+
+      await poller.poll();
+
+      expect(poller.lastError).toMatch(/^1\/1 items failed: inline timeout; reviews timeout$/);
     });
   });
 

--- a/packages/daemon/src/github/copilot-poller.spec.ts
+++ b/packages/daemon/src/github/copilot-poller.spec.ts
@@ -635,7 +635,7 @@ describe("CopilotPoller", () => {
       expect(events[0].author).toBe("unknown");
     });
 
-    test("partial poll failure: lastError reflects the error after mixed results", async () => {
+    test("partial poll failure: lastError reflects per-item fetch errors", async () => {
       workItemDb.createWorkItem({ id: "wi:1", prNumber: 42, prState: "open" });
       workItemDb.createWorkItem({ id: "wi:2", prNumber: 43, prState: "open" });
 
@@ -650,8 +650,60 @@ describe("CopilotPoller", () => {
 
       expect(events).toHaveLength(1);
       expect(events[0].prNumber).toBe(43);
-      // lastError is null because the overall poll succeeded (per-PR errors are logged but don't set _lastError)
+      expect(poller.lastError).toContain("network timeout");
+      expect(poller.lastError).toMatch(/^\d+\/\d+ items failed:/);
+    });
+
+    test("fetch errors clear after next fully clean poll", async () => {
+      workItemDb.createWorkItem({ id: "wi:1", prNumber: 42, prState: "open" });
+      let callCount = 0;
+      const { poller } = makePoller({
+        fetchComments: async () => {
+          callCount++;
+          if (callCount === 1) throw new Error("network timeout");
+          return okResult([]);
+        },
+      });
+
+      await poller.poll();
+      expect(poller.lastError).toContain("network timeout");
+
+      await poller.poll();
       expect(poller.lastError).toBeNull();
+    });
+
+    test("multiple fetch errors are accumulated with deduplication", async () => {
+      workItemDb.createWorkItem({ id: "wi:1", prNumber: 42, prState: "open" });
+      workItemDb.createWorkItem({ id: "wi:2", prNumber: 43, prState: "open" });
+      workItemDb.createWorkItem({ id: "wi:3", prNumber: 44, prState: "open" });
+
+      const { poller } = makePoller({
+        fetchComments: async (_repo, prNumber) => {
+          if (prNumber === 42) throw new Error("network timeout");
+          if (prNumber === 43) throw new Error("network timeout");
+          return okResult([]);
+        },
+      });
+
+      await poller.poll();
+
+      expect(poller.lastError).toMatch(/^2\/3 items failed: network timeout$/);
+    });
+
+    test("auth error takes priority over fetch errors in lastError", async () => {
+      workItemDb.createWorkItem({ id: "wi:1", prNumber: 42, prState: "open" });
+      workItemDb.createWorkItem({ id: "wi:2", prNumber: 43, prState: "open" });
+
+      const { poller } = makePoller({
+        fetchComments: async (_repo, prNumber) => {
+          if (prNumber === 42) throw new Error("network timeout");
+          throw new Error("GitHub API auth/scope error (403): Forbidden");
+        },
+      });
+
+      await poller.poll();
+
+      expect(poller.lastError).toContain("auth/scope");
     });
   });
 

--- a/packages/daemon/src/github/copilot-poller.ts
+++ b/packages/daemon/src/github/copilot-poller.ts
@@ -41,6 +41,7 @@ const REQUEST_TIMEOUT_MS = 10_000;
 interface PollItemResult {
   isRateLimit: boolean;
   authError?: string;
+  fetchError?: string;
 }
 
 export interface PRComment {
@@ -249,29 +250,37 @@ export class CopilotPoller {
       const repo = this._repo;
       let anyRateLimitLow = false;
       let anyAuthError: string | null = null;
+      const fetchErrors: string[] = [];
+      const totalItems = tracked.length + trackedIssues.length;
+
+      const collectResult = (r: PollItemResult): void => {
+        if (r.isRateLimit) anyRateLimitLow = true;
+        if (r.authError) anyAuthError = r.authError;
+        if (r.fetchError) fetchErrors.push(r.fetchError);
+      };
+
       for (const item of tracked) {
         if (this.stopped) return;
-        const r1 = await this.pollPR(repo, item, token);
-        if (r1.isRateLimit) anyRateLimitLow = true;
-        if (r1.authError) anyAuthError = r1.authError;
+        collectResult(await this.pollPR(repo, item, token));
         if (this.stopped) return;
-        const r2 = await this.pollReviews(repo, item, token);
-        if (r2.isRateLimit) anyRateLimitLow = true;
-        if (r2.authError) anyAuthError = r2.authError;
+        collectResult(await this.pollReviews(repo, item, token));
         if (this.stopped) return;
-        const r3 = await this.pollPRComments(repo, item, token);
-        if (r3.isRateLimit) anyRateLimitLow = true;
-        if (r3.authError) anyAuthError = r3.authError;
+        collectResult(await this.pollPRComments(repo, item, token));
       }
       for (const item of trackedIssues) {
         if (this.stopped) return;
-        const r4 = await this.pollIssueComments(repo, item, token);
-        if (r4.isRateLimit) anyRateLimitLow = true;
-        if (r4.authError) anyAuthError = r4.authError;
+        collectResult(await this.pollIssueComments(repo, item, token));
       }
       this.rateLimitBackoff = anyRateLimitLow;
 
-      this._lastError = anyAuthError;
+      if (anyAuthError) {
+        this._lastError = anyAuthError;
+      } else if (fetchErrors.length > 0) {
+        const unique = [...new Set(fetchErrors)];
+        this._lastError = `${fetchErrors.length}/${totalItems} items failed: ${unique.join("; ")}`;
+      } else {
+        this._lastError = null;
+      }
       this._pollCount++;
       this.adjustInterval([...tracked, ...trackedIssues]);
     } catch (err) {
@@ -295,7 +304,7 @@ export class CopilotPoller {
       this.logger.warn(`[mcpd] CopilotPoller failed to fetch comments for PR #${prNumber}: ${msg}`);
       if (msg.includes("rate limit")) return { isRateLimit: true };
       if (msg.includes("auth/scope") || msg.includes("auth failed")) return { isRateLimit: false, authError: msg };
-      return { isRateLimit: false };
+      return { isRateLimit: false, fetchError: msg };
     }
 
     if (result.rateLimitLow) {
@@ -368,7 +377,7 @@ export class CopilotPoller {
       this.logger.warn(`[mcpd] CopilotPoller failed to fetch reviews for PR #${prNumber}: ${msg}`);
       if (msg.includes("rate limit")) return { isRateLimit: true };
       if (msg.includes("auth/scope") || msg.includes("auth failed")) return { isRateLimit: false, authError: msg };
-      return { isRateLimit: false };
+      return { isRateLimit: false, fetchError: msg };
     }
 
     if (result.rateLimitLow) {
@@ -458,7 +467,7 @@ export class CopilotPoller {
       this.logger.warn(`[mcpd] CopilotPoller failed to fetch PR comments for PR #${prNumber}: ${msg}`);
       if (msg.includes("rate limit")) return { isRateLimit: true };
       if (msg.includes("auth/scope") || msg.includes("auth failed")) return { isRateLimit: false, authError: msg };
-      return { isRateLimit: false };
+      return { isRateLimit: false, fetchError: msg };
     }
 
     if (result.rateLimitLow) {
@@ -502,7 +511,7 @@ export class CopilotPoller {
       this.logger.warn(`[mcpd] CopilotPoller failed to fetch issue comments for #${issueNumber}: ${msg}`);
       if (msg.includes("rate limit")) return { isRateLimit: true };
       if (msg.includes("auth/scope") || msg.includes("auth failed")) return { isRateLimit: false, authError: msg };
-      return { isRateLimit: false };
+      return { isRateLimit: false, fetchError: msg };
     }
 
     if (result.rateLimitLow) {

--- a/packages/daemon/src/github/copilot-poller.ts
+++ b/packages/daemon/src/github/copilot-poller.ts
@@ -250,34 +250,38 @@ export class CopilotPoller {
       const repo = this._repo;
       let anyRateLimitLow = false;
       let anyAuthError: string | null = null;
-      const fetchErrors: string[] = [];
+      const failedItemIds = new Set<string>();
+      const fetchErrorMessages: string[] = [];
       const totalItems = tracked.length + trackedIssues.length;
 
-      const collectResult = (r: PollItemResult): void => {
+      const collectResult = (r: PollItemResult, itemId: string): void => {
         if (r.isRateLimit) anyRateLimitLow = true;
         if (r.authError) anyAuthError = r.authError;
-        if (r.fetchError) fetchErrors.push(r.fetchError);
+        if (r.fetchError) {
+          failedItemIds.add(itemId);
+          fetchErrorMessages.push(r.fetchError);
+        }
       };
 
       for (const item of tracked) {
         if (this.stopped) return;
-        collectResult(await this.pollPR(repo, item, token));
+        collectResult(await this.pollPR(repo, item, token), item.id);
         if (this.stopped) return;
-        collectResult(await this.pollReviews(repo, item, token));
+        collectResult(await this.pollReviews(repo, item, token), item.id);
         if (this.stopped) return;
-        collectResult(await this.pollPRComments(repo, item, token));
+        collectResult(await this.pollPRComments(repo, item, token), item.id);
       }
       for (const item of trackedIssues) {
         if (this.stopped) return;
-        collectResult(await this.pollIssueComments(repo, item, token));
+        collectResult(await this.pollIssueComments(repo, item, token), item.id);
       }
       this.rateLimitBackoff = anyRateLimitLow;
 
       if (anyAuthError) {
         this._lastError = anyAuthError;
-      } else if (fetchErrors.length > 0) {
-        const unique = [...new Set(fetchErrors)];
-        this._lastError = `${fetchErrors.length}/${totalItems} items failed: ${unique.join("; ")}`;
+      } else if (failedItemIds.size > 0) {
+        const unique = [...new Set(fetchErrorMessages)];
+        this._lastError = `${failedItemIds.size}/${totalItems} items failed: ${unique.join("; ")}`;
       } else {
         this._lastError = null;
       }


### PR DESCRIPTION
## Summary
- Per-PR/issue fetch errors (network timeouts, etc.) are now accumulated in `_lastError` instead of being silently dropped. Reports as `"N/M items failed: <deduplicated messages>"`.
- Auth errors still take priority over fetch errors in `_lastError`.
- `_lastError` is cleared to `null` only on fully clean polls (no auth or fetch errors).

## Test plan
- [x] Updated existing "partial poll failure" test to assert `lastError` contains the error message
- [x] New test: fetch errors clear after next fully clean poll
- [x] New test: multiple fetch errors accumulated with deduplication (`2/3 items failed: network timeout`)
- [x] New test: auth error takes priority over fetch errors
- [x] Full suite: 6001 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)