### PR TITLE
fix(monitor): bound liveBuffer and yield during backfill (fixes #1589)

### DIFF
--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -3131,55 +3131,65 @@ describe("IpcServer HTTP transport", () => {
       });
       server.start(socketPath);
 
-      // Pre-populate enough events so backfill takes real time (multiple batches).
-      // We need the backfill loop to be active while we flood liveBuffer.
-      const backfillCount = 2500;
+      // Pre-populate enough events so backfill spans many batches (10 × 1000 = 9 yield
+      // points). Live events published after `await fetch()` are guaranteed to land during
+      // a backfill yield, making the test timing-independent.
+      const backfillCount = 10_000;
       for (let i = 0; i < backfillCount; i++) {
         bus.publish({ src: "test", event: "session.result", category: "session", sessionId: `s${i}` });
       }
 
-      // Temporarily lower the cap so we can trigger overflow without publishing 10k events.
       const origMaxEntries = IpcServer.LIVE_BUFFER_MAX_ENTRIES;
       (IpcServer as unknown as Record<string, unknown>).LIVE_BUFFER_MAX_ENTRIES = 5;
 
       const controller = new AbortController();
-      const res = await fetch("http://localhost/events?since=0", {
-        method: "GET",
-        unix: socketPath,
-        signal: controller.signal,
-      } as RequestInit);
+      try {
+        const res = await fetch("http://localhost/events?since=0", {
+          method: "GET",
+          unix: socketPath,
+          signal: controller.signal,
+        } as RequestInit);
 
-      expect(res.status).toBe(200);
-      if (!res.body) throw new Error("Expected response body");
-      const reader = res.body.getReader();
-      const decoder = new TextDecoder();
+        expect(res.status).toBe(200);
+        if (!res.body) throw new Error("Expected response body");
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
 
-      // Flood live events while backfill is in progress. Because start() is async
-      // and yields between batches, some of these will land in the liveBuffer.
-      for (let i = 0; i < 20; i++) {
-        bus.publish({ src: "test", event: "pr.merged", category: "work_item", prNumber: 900 + i });
+        // Flood live events while backfill is in progress. Because start() is async
+        // and yields between batches, these land in the liveBuffer.
+        for (let i = 0; i < 20; i++) {
+          bus.publish({ src: "test", event: "pr.merged", category: "work_item", prNumber: 900 + i });
+        }
+
+        let buffer = "";
+        const deadline = Date.now() + 5_000;
+        while (Date.now() < deadline) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          if (buffer.includes("pr.merged")) break;
+        }
+
+        controller.abort();
+        reader.releaseLock();
+
+        const parsed: Array<Record<string, unknown>> = [];
+        for (const l of buffer.split("\n").filter((s) => s.startsWith("{"))) {
+          try {
+            parsed.push(JSON.parse(l) as Record<string, unknown>);
+          } catch {
+            /* partial chunk */
+          }
+        }
+        const gapLines = parsed.filter((o) => o.t === "gap");
+        expect(gapLines.length).toBe(1);
+        expect(typeof gapLines[0]?.dropped).toBe("number");
+        expect(gapLines[0]?.dropped as number).toBeGreaterThan(0);
+        expect(gapLines[0]?.firstDroppedSeq).toBeDefined();
+        expect(gapLines[0]?.lastDroppedSeq).toBeDefined();
+      } finally {
+        (IpcServer as unknown as Record<string, unknown>).LIVE_BUFFER_MAX_ENTRIES = origMaxEntries;
       }
-
-      let buffer = "";
-      const deadline = Date.now() + 5_000;
-      while (Date.now() < deadline) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        // Wait until we see a live event (confirms backfill + drain completed)
-        if (buffer.includes("pr.merged")) break;
-      }
-
-      controller.abort();
-      reader.releaseLock();
-      (IpcServer as unknown as Record<string, unknown>).LIVE_BUFFER_MAX_ENTRIES = origMaxEntries;
-
-      // Should contain the gap control message
-      const lines = buffer.split("\n").filter((l) => l.startsWith("{"));
-      const gapLines = lines.map((l) => JSON.parse(l) as Record<string, unknown>).filter((o) => o.t === "gap");
-      expect(gapLines.length).toBe(1);
-      expect(typeof gapLines[0]?.dropped).toBe("number");
-      expect(gapLines[0]?.dropped as number).toBeGreaterThan(0);
     });
 
     test("liveBuffer overflow emits gap control message when byte cap is exceeded (#1589)", async () => {
@@ -3193,48 +3203,59 @@ describe("IpcServer HTTP transport", () => {
       });
       server.start(socketPath);
 
-      const backfillCount = 2500;
+      const backfillCount = 10_000;
       for (let i = 0; i < backfillCount; i++) {
         bus.publish({ src: "test", event: "session.result", category: "session", sessionId: `s${i}` });
       }
 
-      // Set byte cap very low (500 bytes) while keeping entry cap high
       const origMaxBytes = IpcServer.LIVE_BUFFER_MAX_BYTES;
       (IpcServer as unknown as Record<string, unknown>).LIVE_BUFFER_MAX_BYTES = 500;
 
       const controller = new AbortController();
-      const res = await fetch("http://localhost/events?since=0", {
-        method: "GET",
-        unix: socketPath,
-        signal: controller.signal,
-      } as RequestInit);
+      try {
+        const res = await fetch("http://localhost/events?since=0", {
+          method: "GET",
+          unix: socketPath,
+          signal: controller.signal,
+        } as RequestInit);
 
-      expect(res.status).toBe(200);
-      if (!res.body) throw new Error("Expected response body");
-      const reader = res.body.getReader();
-      const decoder = new TextDecoder();
+        expect(res.status).toBe(200);
+        if (!res.body) throw new Error("Expected response body");
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
 
-      for (let i = 0; i < 20; i++) {
-        bus.publish({ src: "test", event: "pr.merged", category: "work_item", prNumber: 800 + i });
+        for (let i = 0; i < 20; i++) {
+          bus.publish({ src: "test", event: "pr.merged", category: "work_item", prNumber: 800 + i });
+        }
+
+        let buffer = "";
+        const deadline = Date.now() + 5_000;
+        while (Date.now() < deadline) {
+          const { value, done } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          if (buffer.includes("pr.merged")) break;
+        }
+
+        controller.abort();
+        reader.releaseLock();
+
+        const parsed: Array<Record<string, unknown>> = [];
+        for (const l of buffer.split("\n").filter((s) => s.startsWith("{"))) {
+          try {
+            parsed.push(JSON.parse(l) as Record<string, unknown>);
+          } catch {
+            /* partial chunk */
+          }
+        }
+        const gapLines = parsed.filter((o) => o.t === "gap");
+        expect(gapLines.length).toBe(1);
+        expect(gapLines[0]?.dropped as number).toBeGreaterThan(0);
+        expect(gapLines[0]?.firstDroppedSeq).toBeDefined();
+        expect(gapLines[0]?.lastDroppedSeq).toBeDefined();
+      } finally {
+        (IpcServer as unknown as Record<string, unknown>).LIVE_BUFFER_MAX_BYTES = origMaxBytes;
       }
-
-      let buffer = "";
-      const deadline = Date.now() + 5_000;
-      while (Date.now() < deadline) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        if (buffer.includes("pr.merged")) break;
-      }
-
-      controller.abort();
-      reader.releaseLock();
-      (IpcServer as unknown as Record<string, unknown>).LIVE_BUFFER_MAX_BYTES = origMaxBytes;
-
-      const lines = buffer.split("\n").filter((l) => l.startsWith("{"));
-      const gapLines = lines.map((l) => JSON.parse(l) as Record<string, unknown>).filter((o) => o.t === "gap");
-      expect(gapLines.length).toBe(1);
-      expect(gapLines[0]?.dropped as number).toBeGreaterThan(0);
     });
 
     test("large backfill does not block concurrent IPC requests (#1589)", async () => {

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -3119,6 +3119,165 @@ describe("IpcServer HTTP transport", () => {
       expect(buffer).not.toContain("session.response");
       expect(buffer).toContain("session.result");
     });
+
+    test("liveBuffer overflow emits gap control message when entry cap is exceeded (#1589)", async () => {
+      const db = new Database(":memory:");
+      const eventLog = new EventLog(db);
+      const bus = new EventBus(eventLog);
+      socketPath = tmpSocket();
+      server = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, {
+        ...opts(),
+        eventBus: bus,
+      });
+      server.start(socketPath);
+
+      // Pre-populate enough events so backfill takes real time (multiple batches).
+      // We need the backfill loop to be active while we flood liveBuffer.
+      const backfillCount = 2500;
+      for (let i = 0; i < backfillCount; i++) {
+        bus.publish({ src: "test", event: "session.result", category: "session", sessionId: `s${i}` });
+      }
+
+      // Temporarily lower the cap so we can trigger overflow without publishing 10k events.
+      const origMaxEntries = IpcServer.LIVE_BUFFER_MAX_ENTRIES;
+      (IpcServer as unknown as Record<string, unknown>).LIVE_BUFFER_MAX_ENTRIES = 5;
+
+      const controller = new AbortController();
+      const res = await fetch("http://localhost/events?since=0", {
+        method: "GET",
+        unix: socketPath,
+        signal: controller.signal,
+      } as RequestInit);
+
+      expect(res.status).toBe(200);
+      if (!res.body) throw new Error("Expected response body");
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+
+      // Flood live events while backfill is in progress. Because start() is async
+      // and yields between batches, some of these will land in the liveBuffer.
+      for (let i = 0; i < 20; i++) {
+        bus.publish({ src: "test", event: "pr.merged", category: "work_item", prNumber: 900 + i });
+      }
+
+      let buffer = "";
+      const deadline = Date.now() + 5_000;
+      while (Date.now() < deadline) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        // Wait until we see a live event (confirms backfill + drain completed)
+        if (buffer.includes("pr.merged")) break;
+      }
+
+      controller.abort();
+      reader.releaseLock();
+      (IpcServer as unknown as Record<string, unknown>).LIVE_BUFFER_MAX_ENTRIES = origMaxEntries;
+
+      // Should contain the gap control message
+      const lines = buffer.split("\n").filter((l) => l.startsWith("{"));
+      const gapLines = lines.map((l) => JSON.parse(l) as Record<string, unknown>).filter((o) => o.t === "gap");
+      expect(gapLines.length).toBe(1);
+      expect(typeof gapLines[0]?.dropped).toBe("number");
+      expect(gapLines[0]?.dropped as number).toBeGreaterThan(0);
+    });
+
+    test("liveBuffer overflow emits gap control message when byte cap is exceeded (#1589)", async () => {
+      const db = new Database(":memory:");
+      const eventLog = new EventLog(db);
+      const bus = new EventBus(eventLog);
+      socketPath = tmpSocket();
+      server = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, {
+        ...opts(),
+        eventBus: bus,
+      });
+      server.start(socketPath);
+
+      const backfillCount = 2500;
+      for (let i = 0; i < backfillCount; i++) {
+        bus.publish({ src: "test", event: "session.result", category: "session", sessionId: `s${i}` });
+      }
+
+      // Set byte cap very low (500 bytes) while keeping entry cap high
+      const origMaxBytes = IpcServer.LIVE_BUFFER_MAX_BYTES;
+      (IpcServer as unknown as Record<string, unknown>).LIVE_BUFFER_MAX_BYTES = 500;
+
+      const controller = new AbortController();
+      const res = await fetch("http://localhost/events?since=0", {
+        method: "GET",
+        unix: socketPath,
+        signal: controller.signal,
+      } as RequestInit);
+
+      expect(res.status).toBe(200);
+      if (!res.body) throw new Error("Expected response body");
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+
+      for (let i = 0; i < 20; i++) {
+        bus.publish({ src: "test", event: "pr.merged", category: "work_item", prNumber: 800 + i });
+      }
+
+      let buffer = "";
+      const deadline = Date.now() + 5_000;
+      while (Date.now() < deadline) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        if (buffer.includes("pr.merged")) break;
+      }
+
+      controller.abort();
+      reader.releaseLock();
+      (IpcServer as unknown as Record<string, unknown>).LIVE_BUFFER_MAX_BYTES = origMaxBytes;
+
+      const lines = buffer.split("\n").filter((l) => l.startsWith("{"));
+      const gapLines = lines.map((l) => JSON.parse(l) as Record<string, unknown>).filter((o) => o.t === "gap");
+      expect(gapLines.length).toBe(1);
+      expect(gapLines[0]?.dropped as number).toBeGreaterThan(0);
+    });
+
+    test("large backfill does not block concurrent IPC requests (#1589)", async () => {
+      const db = new Database(":memory:");
+      const eventLog = new EventLog(db);
+      const bus = new EventBus(eventLog);
+      socketPath = tmpSocket();
+      server = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, {
+        ...opts(),
+        eventBus: bus,
+      });
+      server.start(socketPath);
+
+      // Pre-populate a large backlog
+      for (let i = 0; i < 5000; i++) {
+        bus.publish({ src: "test", event: "session.result", category: "session", sessionId: `s${i}` });
+      }
+
+      // Start a backfill stream — the async yields let us interleave IPC.
+      const streamController = new AbortController();
+      const streamRes = fetch("http://localhost/events?since=0", {
+        method: "GET",
+        unix: socketPath,
+        signal: streamController.signal,
+      } as RequestInit);
+
+      // Immediately issue a concurrent IPC request (status endpoint).
+      // If backfill blocked the event loop, this would time out.
+      const statusRes = await fetch("http://localhost/rpc", {
+        method: "POST",
+        unix: socketPath,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ method: "status", params: {} }),
+      } as RequestInit);
+
+      expect(statusRes.status).toBe(200);
+      const statusBody = (await statusRes.json()) as { result?: unknown };
+      expect(statusBody.result).toBeDefined();
+
+      // Clean up the stream
+      streamController.abort();
+      await streamRes.catch(() => {});
+    });
   });
 
   // -- GET /events NDJSON endpoint tests (ring-buffer / pushEvent path) --

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -1391,6 +1391,10 @@ export class IpcServer {
   private static readonly EVENTBUS_HEARTBEAT_MS = 15_000;
   /** Prune EventBus subscribers that haven't delivered an event in this window (#1557). */
   private static readonly EVENTBUS_SUB_TTL_MS = 10 * 60_000;
+  /** Max entries in liveBuffer during backfill before dropping oldest (#1589). */
+  static readonly LIVE_BUFFER_MAX_ENTRIES = 10_000;
+  /** Max byte size of liveBuffer during backfill before dropping oldest (#1589). */
+  static readonly LIVE_BUFFER_MAX_BYTES = 10 * 1024 * 1024; // 10 MB
 
   /**
    * Handle GET /logs — Server-Sent Events stream for real-time log tailing.
@@ -1567,14 +1571,21 @@ export class IpcServer {
       // when the consumer falls more than 1 MB behind (live or backfill).
       const stream = new ReadableStream(
         {
-          start: (controller) => {
+          start: async (controller) => {
             // Flush an initial newline so Bun sends response headers immediately.
             // Without this, headers are buffered until the first event arrives.
             controller.enqueue(encoder.encode("\n"));
 
             // Buffer live events during backfill to avoid gaps or duplicates.
+            // Bounded: whichever of entry count or byte size is hit first triggers
+            // drop-oldest eviction. Overflow emits a gap control message. (#1589)
             let liveBuffer: Array<string> | null = sinceSeq !== null && eventLog ? [] : null;
+            let liveBufferBytes = 0;
+            let liveBufferDropped = 0;
             let highWaterMark = 0;
+
+            const maxEntries = IpcServer.LIVE_BUFFER_MAX_ENTRIES;
+            const maxBytes = IpcServer.LIVE_BUFFER_MAX_BYTES;
 
             subId = bus.subscribe(
               (_event, serialized) => {
@@ -1594,7 +1605,17 @@ export class IpcServer {
                 try {
                   const line = `${serialized}\n`;
                   if (liveBuffer !== null) {
+                    // Evict oldest entries while buffer exceeds either cap.
+                    while (
+                      liveBuffer.length > 0 &&
+                      (liveBuffer.length >= maxEntries || liveBufferBytes + line.length > maxBytes)
+                    ) {
+                      const evicted = liveBuffer.shift();
+                      if (evicted) liveBufferBytes -= evicted.length;
+                      liveBufferDropped++;
+                    }
                     liveBuffer.push(line);
+                    liveBufferBytes += line.length;
                   } else {
                     controller.enqueue(encoder.encode(line));
                   }
@@ -1608,6 +1629,7 @@ export class IpcServer {
             subscriberGauge.inc();
 
             // Backfill from durable log when client provides a valid cursor.
+            // Async: yields between batches so the event loop stays responsive. (#1589)
             if (sinceSeq !== null && !Number.isNaN(sinceSeq) && sinceSeq >= 0 && eventLog) {
               let cursor = sinceSeq;
               while (true) {
@@ -1635,10 +1657,23 @@ export class IpcServer {
                 }
                 if (batch.length < 1000) break;
                 cursor = batch[batch.length - 1]?.seq ?? cursor;
+                // Yield to the event loop between batches so other IPC work isn't starved.
+                await new Promise<void>((r) => setTimeout(r, 0));
               }
               // Drain buffered live events; seq-based HWM drops overlaps.
               const buffered = liveBuffer ?? [];
               liveBuffer = null;
+
+              // Emit gap control message if liveBuffer overflowed during backfill.
+              if (liveBufferDropped > 0) {
+                try {
+                  controller.enqueue(encoder.encode(`${JSON.stringify({ t: "gap", dropped: liveBufferDropped })}\n`));
+                } catch {
+                  cleanup();
+                  return;
+                }
+              }
+
               for (const line of buffered) {
                 if (controller.desiredSize !== null && controller.desiredSize <= 0) {
                   this.logger.warn("[events] slow consumer during backfill drain, dropping subscriber");

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -1579,9 +1579,13 @@ export class IpcServer {
             // Buffer live events during backfill to avoid gaps or duplicates.
             // Bounded: whichever of entry count or byte size is hit first triggers
             // drop-oldest eviction. Overflow emits a gap control message. (#1589)
-            let liveBuffer: Array<string> | null = sinceSeq !== null && eventLog ? [] : null;
+            let liveBuffer: Array<{ line: string; seq: number | undefined }> | null =
+              sinceSeq !== null && eventLog ? [] : null;
             let liveBufferBytes = 0;
             let liveBufferDropped = 0;
+            let liveBufferHead = 0;
+            let firstDroppedSeq: number | undefined;
+            let lastDroppedSeq: number | undefined;
             let highWaterMark = 0;
 
             const maxEntries = IpcServer.LIVE_BUFFER_MAX_ENTRIES;
@@ -1605,17 +1609,40 @@ export class IpcServer {
                 try {
                   const line = `${serialized}\n`;
                   if (liveBuffer !== null) {
-                    // Evict oldest entries while buffer exceeds either cap.
+                    const lineLen = line.length;
+                    let seq: number | undefined;
+                    try {
+                      const p = JSON.parse(serialized) as Record<string, unknown>;
+                      seq = typeof p.seq === "number" ? p.seq : undefined;
+                    } catch {
+                      /* non-JSON event — skip seq tracking */
+                    }
+                    // Reject single events that exceed the byte cap on their own.
+                    if (liveBufferHead >= liveBuffer.length && lineLen > maxBytes) {
+                      liveBufferDropped++;
+                      if (seq !== undefined) {
+                        firstDroppedSeq ??= seq;
+                        lastDroppedSeq = seq;
+                      }
+                      return;
+                    }
+                    // Evict from head while buffer exceeds either cap (O(1) via head pointer).
                     while (
-                      liveBuffer.length > 0 &&
-                      (liveBuffer.length >= maxEntries || liveBufferBytes + line.length > maxBytes)
+                      liveBufferHead < liveBuffer.length &&
+                      (liveBuffer.length - liveBufferHead >= maxEntries || liveBufferBytes + lineLen > maxBytes)
                     ) {
-                      const evicted = liveBuffer.shift();
-                      if (evicted) liveBufferBytes -= evicted.length;
+                      const evicted = liveBuffer[liveBufferHead];
+                      if (!evicted) break;
+                      liveBufferBytes -= evicted.line.length;
+                      if (evicted.seq !== undefined) {
+                        firstDroppedSeq ??= evicted.seq;
+                        lastDroppedSeq = evicted.seq;
+                      }
+                      liveBufferHead++;
                       liveBufferDropped++;
                     }
-                    liveBuffer.push(line);
-                    liveBufferBytes += line.length;
+                    liveBuffer.push({ line, seq });
+                    liveBufferBytes += lineLen;
                   } else {
                     controller.enqueue(encoder.encode(line));
                   }
@@ -1662,19 +1689,25 @@ export class IpcServer {
               }
               // Drain buffered live events; seq-based HWM drops overlaps.
               const buffered = liveBuffer ?? [];
+              const drainStart = liveBufferHead;
               liveBuffer = null;
 
               // Emit gap control message if liveBuffer overflowed during backfill.
               if (liveBufferDropped > 0) {
+                const gap: Record<string, unknown> = { t: "gap", dropped: liveBufferDropped };
+                if (firstDroppedSeq !== undefined) gap.firstDroppedSeq = firstDroppedSeq;
+                if (lastDroppedSeq !== undefined) gap.lastDroppedSeq = lastDroppedSeq;
                 try {
-                  controller.enqueue(encoder.encode(`${JSON.stringify({ t: "gap", dropped: liveBufferDropped })}\n`));
+                  controller.enqueue(encoder.encode(`${JSON.stringify(gap)}\n`));
                 } catch {
                   cleanup();
                   return;
                 }
               }
 
-              for (const line of buffered) {
+              for (let i = drainStart; i < buffered.length; i++) {
+                const entry = buffered[i];
+                if (!entry) continue;
                 if (controller.desiredSize !== null && controller.desiredSize <= 0) {
                   this.logger.warn("[events] slow consumer during backfill drain, dropping subscriber");
                   metrics.counter("mcpd_event_bus_slow_drops_total").inc();
@@ -1687,10 +1720,8 @@ export class IpcServer {
                   return;
                 }
                 try {
-                  const parsed = JSON.parse(line) as Record<string, unknown>;
-                  const seq = typeof parsed.seq === "number" ? parsed.seq : undefined;
-                  if (seq !== undefined && seq <= highWaterMark) continue;
-                  controller.enqueue(encoder.encode(line));
+                  if (entry.seq !== undefined && entry.seq <= highWaterMark) continue;
+                  controller.enqueue(encoder.encode(entry.line));
                 } catch {
                   cleanup();
                   return;


### PR DESCRIPTION
## Summary
- Cap `liveBuffer` at 10k entries / 10 MB (whichever hits first) with drop-oldest eviction during backfill. Emit a `{"t":"gap","dropped":N}` control message after drain so clients know events were lost.
- Make the backfill loop `async` and yield (`setTimeout(0)`) between 1000-event batches so the event loop stays responsive for concurrent IPC requests.
- Three new tests: entry-cap overflow, byte-cap overflow, and concurrent IPC during large backfill.

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — all 6001 tests pass, 0 failures
- [x] New test: liveBuffer overflow emits gap control message when entry cap exceeded
- [x] New test: liveBuffer overflow emits gap control message when byte cap exceeded
- [x] New test: large backfill does not block concurrent IPC requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)