### PR TITLE
fix(phase): remove circular "in lockfile but missing from lockfile" message (fixes #1767)

### DIFF
--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -1122,9 +1122,11 @@ describe("formatDriftWarning", () => {
 
   test("labels phase-missing as NOT INSTALLED", () => {
     const msg = formatDriftWarning([
-      { kind: "phase-missing", path: "phases/qa.ts", expected: 'phase "qa" in lockfile', actual: "(not installed)" },
+      { kind: "phase-missing", path: "phases/qa.ts", expected: '"qa"', actual: "(not installed)" },
     ]);
     expect(msg).toContain("NOT INSTALLED");
+    expect(msg).toContain('"qa" but missing from lockfile');
+    expect(msg).not.toContain("in lockfile but missing from lockfile");
   });
 
   test("labels phase-extra as STALE LOCK ENTRY", () => {

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -488,7 +488,7 @@ export function detectDrift(deps: DriftDeps): DriftResult {
       entries.push({
         kind: "phase-missing",
         path: manifest.phases[name].source,
-        expected: `phase "${name}" in lockfile`,
+        expected: `"${name}"`,
         actual: "(not installed)",
       });
     }


### PR DESCRIPTION
## Summary
- `detectDrift` was setting `expected` for `phase-missing` entries to `phase "X" in lockfile`
- `formatDriftWarning` then appended `but missing from lockfile`, producing the contradictory: `phase "X" in lockfile but missing from lockfile`
- Fixed by setting `expected` to just `"X"` — the renderer's suffix is now self-sufficient

## Test plan
- Updated the existing `formatDriftWarning` `phase-missing` test to use the corrected `expected` value
- Added assertion that the output contains `"qa" but missing from lockfile`
- Added assertion that the output does NOT contain `in lockfile but missing from lockfile`
- All 6001 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)