### PR TITLE
release: v1.7.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "bun": ">=1.2.18"
   },
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "MCP CLI — call MCP server tools from the command line with zero context overhead",
   "type": "module",
   "workspaces": ["packages/*"],


### PR DESCRIPTION
Release v1.7.5 — sprint 45 ship. See `.claude/sprints/sprint-45.md` for what shipped.

Release notes will be posted on the GitHub release after the tag lands.