### PR TITLE
fix(sites): reject malformed 'sites' arg in site_browser_start handler (fixes #1768)

### DIFF
--- a/packages/daemon/src/site-worker.ts
+++ b/packages/daemon/src/site-worker.ts
@@ -313,11 +313,17 @@ function resetIfBrowserDied(): void {
 async function handleBrowserStart(args: Record<string, unknown>): Promise<ToolResult> {
   return withBrowserLock(async () => {
     resetIfBrowserDied();
-    const siteNames = Array.isArray(args.sites)
-      ? (args.sites as string[])
-      : listSites()
-          .filter((s) => s.enabled)
-          .map((s) => s.name);
+    let siteNames: string[];
+    if ("sites" in args) {
+      if (!Array.isArray(args.sites) || !args.sites.every((s) => typeof s === "string")) {
+        return error("'sites' must be an array of site names");
+      }
+      siteNames = args.sites as string[];
+    } else {
+      siteNames = listSites()
+        .filter((s) => s.enabled)
+        .map((s) => s.name);
+    }
     const sites = siteNames.map((n) => requireSite(n));
     if (sites.length === 0) return error("No sites configured");
 


### PR DESCRIPTION
## Summary
- `handleBrowserStart` now uses `"sites" in args` to detect when the caller explicitly passed a `sites` value
- If `sites` is present but not a `string[]` (e.g. `sites: "atlassian"` or `sites: 42`), the handler returns `Error: 'sites' must be an array of site names` instead of silently opening all enabled sites
- If `sites` is absent, the fallback to all enabled sites is unchanged

## Test plan
- [x] `bun typecheck` — passes
- [x] `bun lint` — no issues
- [x] `bun test` — 42 site-related tests pass (`site-server.spec.ts` + `site.spec.ts`)
- Note: `handleBrowserStart` lives inside `site-worker.ts` which uses `declare const self: Worker` with module-level side effects, making it non-importable for direct unit tests. Validation logic is a two-condition guard that is correct by inspection and covered by passing typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)