### PR TITLE
fix(daemon): handle manifest-declared phases in canTransition (fixes #1797)

### DIFF
--- a/packages/core/src/work-item.spec.ts
+++ b/packages/core/src/work-item.spec.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "bun:test";
-import { WORK_ITEM_PHASES, type WorkItemPhase, canTransition, createWorkItem, reachablePhases } from "./work-item";
+import {
+  WORK_ITEM_PHASES,
+  type WorkItemPhase,
+  canTransition,
+  createWorkItem,
+  isStandardPhase,
+  reachablePhases,
+} from "./work-item";
 
 describe("canTransition", () => {
   const allowed: [WorkItemPhase, WorkItemPhase][] = [
@@ -43,6 +50,15 @@ describe("canTransition", () => {
       expect(canTransition(from, to)).toBe(false);
     });
   }
+
+  it("returns false for unknown source phase instead of throwing", () => {
+    expect(canTransition("triage" as WorkItemPhase, "qa")).toBe(false);
+    expect(canTransition("needs-attention" as WorkItemPhase, "done")).toBe(false);
+  });
+
+  it("returns false for unknown target phase", () => {
+    expect(canTransition("impl", "triage" as WorkItemPhase)).toBe(false);
+  });
 });
 
 describe("reachablePhases", () => {
@@ -57,11 +73,28 @@ describe("reachablePhases", () => {
   it("returns repair, qa, done from review", () => {
     expect([...reachablePhases("review")].sort()).toEqual(["done", "qa", "repair"]);
   });
+
+  it("returns empty array for unknown phase", () => {
+    expect(reachablePhases("triage" as WorkItemPhase)).toEqual([]);
+  });
 });
 
 describe("WORK_ITEM_PHASES", () => {
   it("contains all five phases in pipeline order", () => {
     expect(WORK_ITEM_PHASES).toEqual(["impl", "review", "repair", "qa", "done"]);
+  });
+});
+
+describe("isStandardPhase", () => {
+  it("returns true for all standard phases", () => {
+    for (const phase of WORK_ITEM_PHASES) {
+      expect(isStandardPhase(phase)).toBe(true);
+    }
+  });
+
+  it("returns false for manifest-declared phases", () => {
+    expect(isStandardPhase("triage")).toBe(false);
+    expect(isStandardPhase("needs-attention")).toBe(false);
   });
 });
 

--- a/packages/core/src/work-item.ts
+++ b/packages/core/src/work-item.ts
@@ -92,18 +92,26 @@ const VALID_TRANSITIONS: Record<WorkItemPhase, ReadonlySet<WorkItemPhase>> = {
   done: new Set(), // terminal
 };
 
-/** Check whether a phase transition is allowed. */
+/** Check whether a phase transition is allowed. Returns false for unknown phases. */
 export function canTransition(from: WorkItemPhase, to: WorkItemPhase): boolean {
-  return VALID_TRANSITIONS[from].has(to);
+  return VALID_TRANSITIONS[from]?.has(to) ?? false;
 }
 
-/** Return all phases reachable from the given phase. */
+/** Return all phases reachable from the given phase. Empty for unknown phases. */
 export function reachablePhases(from: WorkItemPhase): readonly WorkItemPhase[] {
-  return [...VALID_TRANSITIONS[from]] as WorkItemPhase[];
+  const transitions = VALID_TRANSITIONS[from];
+  return transitions ? ([...transitions] as WorkItemPhase[]) : [];
 }
 
 /** All work item phases in pipeline order. */
 export const WORK_ITEM_PHASES: readonly WorkItemPhase[] = ["impl", "review", "repair", "qa", "done"];
+
+const WORK_ITEM_PHASE_SET: ReadonlySet<string> = new Set(WORK_ITEM_PHASES);
+
+/** Check whether a phase string is one of the hardcoded standard phases. */
+export function isStandardPhase(phase: string): phase is WorkItemPhase {
+  return WORK_ITEM_PHASE_SET.has(phase);
+}
 
 /** Create a new WorkItem with sensible defaults. */
 export function createWorkItem(id: string, phase?: WorkItemPhase): WorkItem {

--- a/packages/daemon/src/work-items-server.spec.ts
+++ b/packages/daemon/src/work-items-server.spec.ts
@@ -651,6 +651,41 @@ describe("WorkItemsServer", () => {
     expect(last.forceReason).toBe("undeclared bypass");
   });
 
+  test("work_items_update from manifest-declared phase without manifest skips hardcoded validation (#1797)", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    const manifest = {
+      version: 1 as const,
+      initial: "impl",
+      phases: {
+        impl: { source: "./impl.ts", next: ["triage"] },
+        triage: { source: "./triage.ts", next: ["qa"] },
+        qa: { source: "./qa.ts", next: ["done"] },
+        done: { source: "./done.ts", next: [] },
+      },
+    };
+    server = new WorkItemsServer(db, { loadManifest: () => manifest });
+    const { client } = await server.start();
+    await client.callTool({ name: "work_items_track", arguments: { prNumber: 1797 } });
+
+    // Move to "triage" (manifest phase, not in hardcoded graph)
+    const toTriage = await client.callTool({
+      name: "work_items_update",
+      arguments: { id: "pr:1797", phase: "triage", repoRoot: "/tmp/repo" },
+    });
+    expect(toTriage.isError).toBeFalsy();
+
+    // Now update WITHOUT repoRoot — manifest not loaded.
+    // Before #1797 fix this would throw: undefined is not an object (evaluating 'vq[$].has')
+    const toQa = await client.callTool({
+      name: "work_items_update",
+      arguments: { id: "pr:1797", phase: "qa" },
+    });
+    expect(toQa.isError).toBeFalsy();
+    const content = toQa.content as Array<{ type: string; text: string }>;
+    expect(JSON.parse(content[0].text).phase).toBe("qa");
+  });
+
   test("work_items_update force=true bypasses legacy transition check and logs forced", async () => {
     const { db, raw } = createWorkItemDb();
     rawDb = raw;

--- a/packages/daemon/src/work-items-server.ts
+++ b/packages/daemon/src/work-items-server.ts
@@ -7,7 +7,7 @@
 
 import { resolve } from "node:path";
 import type { Logger, Manifest, ToolInfo, WorkItem, WorkItemPhase } from "@mcp-cli/core";
-import { WORK_ITEMS_SERVER_NAME, canTransition, consoleLogger, resolveRealpath } from "@mcp-cli/core";
+import { WORK_ITEMS_SERVER_NAME, canTransition, consoleLogger, isStandardPhase, resolveRealpath } from "@mcp-cli/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
@@ -432,7 +432,11 @@ export class WorkItemsServer {
                     };
                   }
                   // Manifest-driven mode: skip the hardcoded transition graph.
-                } else if (existing.phase !== newPhase && !canTransition(existing.phase, newPhase as WorkItemPhase)) {
+                } else if (
+                  isStandardPhase(existing.phase) &&
+                  existing.phase !== newPhase &&
+                  !canTransition(existing.phase, newPhase as WorkItemPhase)
+                ) {
                   return {
                     content: [
                       {


### PR DESCRIPTION
## Summary
- `canTransition()` crashed with `undefined is not an object (evaluating 'vq[$].has')` when the `from` phase was a manifest-declared phase (e.g. `triage`, `needs-attention`) not present in the hardcoded `VALID_TRANSITIONS` map
- Made `canTransition` and `reachablePhases` return safe defaults (`false` / `[]`) for unknown phases instead of crashing
- Added `isStandardPhase()` guard in the server validation so that when an item already has a manifest-declared phase and no manifest is loaded (no `repoRoot`), the hardcoded transition check is skipped rather than crashing
- The hardcoded check still applies when `existing.phase` is a standard phase — no change in behavior for non-manifest workflows

## Test plan
- [x] `canTransition("triage", "qa")` returns `false` instead of throwing
- [x] `canTransition("needs-attention", "done")` returns `false` instead of throwing
- [x] `reachablePhases("triage")` returns `[]` instead of throwing
- [x] `isStandardPhase` correctly identifies standard vs manifest-declared phases
- [x] Integration test: item at manifest phase `triage` → update to `qa` without `repoRoot` succeeds (previously crashed)
- [x] All existing transition tests still pass (6052 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)