### PR TITLE
feat(pr): add `mcx pr merge` to avoid worktree branch-delete noise (fixes #1800)

### DIFF
--- a/packages/command/src/commands/completions.ts
+++ b/packages/command/src/commands/completions.ts
@@ -55,6 +55,7 @@ export const SUBCOMMANDS = [
   "help",
   "agent",
   "claude",
+  "pr",
   "track",
   "untrack",
   "tracked",

--- a/packages/command/src/commands/pr.spec.ts
+++ b/packages/command/src/commands/pr.spec.ts
@@ -158,23 +158,34 @@ describe("prMerge", () => {
     expect(calls).toBeGreaterThanOrEqual(3);
   });
 
-  test("--wait times out gracefully", async () => {
-    const stderrLines: string[] = [];
-    const origError = console.error;
-    console.error = (m: string) => stderrLines.push(m);
-    try {
-      const deps = makeDeps({
-        exec: (cmd) => {
-          if (cmd.includes("view")) return { stdout: "OPEN", stderr: "", exitCode: 0 };
-          return { stdout: "", stderr: "", exitCode: 0 };
-        },
-      });
-      await prMerge(["9", "--wait", "--timeout", "100"], deps);
-      // Should NOT throw — timeout is a graceful exit, not an error
-      expect(stderrLines.some((e) => e.includes("timed out"))).toBe(true);
-    } finally {
-      console.error = origError;
-    }
+  test("--wait times out with exit 124", async () => {
+    const errors: string[] = [];
+    const deps = makeDeps({
+      exec: (cmd) => {
+        if (cmd.includes("view")) return { stdout: "OPEN", stderr: "", exitCode: 0 };
+        return { stdout: "", stderr: "", exitCode: 0 };
+      },
+      printError: (m) => errors.push(m),
+    });
+    const err = await prMerge(["9", "--wait", "--timeout", "100"], deps).catch((e) => e);
+    expect(err).toBeInstanceOf(ExitError);
+    expect((err as ExitError).code).toBe(124);
+    expect(errors.some((e) => e.includes("timed out"))).toBe(true);
+  });
+
+  test("--wait exits nonzero when PR is closed", async () => {
+    const errors: string[] = [];
+    const deps = makeDeps({
+      exec: (cmd) => {
+        if (cmd.includes("view")) return { stdout: "CLOSED", stderr: "", exitCode: 0 };
+        return { stdout: "", stderr: "", exitCode: 0 };
+      },
+      printError: (m) => errors.push(m),
+    });
+    const err = await prMerge(["11", "--wait", "--timeout", "30000"], deps).catch((e) => e);
+    expect(err).toBeInstanceOf(ExitError);
+    expect((err as ExitError).code).toBe(1);
+    expect(errors.some((e) => e.includes("closed"))).toBe(true);
   });
 });
 

--- a/packages/command/src/commands/pr.spec.ts
+++ b/packages/command/src/commands/pr.spec.ts
@@ -1,0 +1,214 @@
+import { describe, expect, test } from "bun:test";
+import type { PrDeps } from "./pr";
+import { cmdPr, parsePrMergeArgs, prMerge } from "./pr";
+
+class ExitError extends Error {
+  code: number;
+  constructor(code: number) {
+    super(`exit(${code})`);
+    this.code = code;
+  }
+}
+
+function makeDeps(overrides: Partial<PrDeps> = {}): PrDeps {
+  return {
+    exec: () => ({ stdout: "", stderr: "", exitCode: 0 }),
+    printError: () => {},
+    exit: (code) => {
+      throw new ExitError(code);
+    },
+    sleep: () => Promise.resolve(),
+    ...overrides,
+  };
+}
+
+// ── parsePrMergeArgs ──
+
+describe("parsePrMergeArgs", () => {
+  test("parses PR number", () => {
+    const r = parsePrMergeArgs(["42"]);
+    expect(r.prNumber).toBe("42");
+    expect(r.squash).toBe(true); // default
+    expect(r.auto).toBe(false);
+    expect(r.wait).toBe(false);
+    expect(r.error).toBeUndefined();
+  });
+
+  test("defaults to squash when no strategy given", () => {
+    const r = parsePrMergeArgs(["1"]);
+    expect(r.squash).toBe(true);
+    expect(r.rebase).toBe(false);
+    expect(r.mergeCommit).toBe(false);
+  });
+
+  test("parses --rebase", () => {
+    const r = parsePrMergeArgs(["1", "--rebase"]);
+    expect(r.squash).toBe(false);
+    expect(r.rebase).toBe(true);
+  });
+
+  test("parses --merge", () => {
+    const r = parsePrMergeArgs(["1", "--merge"]);
+    expect(r.squash).toBe(false);
+    expect(r.mergeCommit).toBe(true);
+  });
+
+  test("parses --auto", () => {
+    const r = parsePrMergeArgs(["1", "--auto"]);
+    expect(r.auto).toBe(true);
+  });
+
+  test("parses --wait", () => {
+    const r = parsePrMergeArgs(["1", "--wait"]);
+    expect(r.wait).toBe(true);
+  });
+
+  test("parses --timeout", () => {
+    const r = parsePrMergeArgs(["1", "--timeout", "60000"]);
+    expect(r.timeout).toBe(60000);
+  });
+
+  test("errors when no PR number", () => {
+    const r = parsePrMergeArgs([]);
+    expect(r.error).toMatch(/Usage/);
+  });
+
+  test("errors on invalid timeout", () => {
+    const r = parsePrMergeArgs(["1", "--timeout", "notanumber"]);
+    expect(r.error).toMatch(/number/);
+  });
+});
+
+// ── prMerge ──
+
+describe("prMerge", () => {
+  test("calls gh pr merge with --squash, no --delete-branch", async () => {
+    const calls: string[][] = [];
+    const deps = makeDeps({
+      exec: (cmd) => {
+        calls.push(cmd);
+        return { stdout: "✓ Merged", stderr: "", exitCode: 0 };
+      },
+    });
+    await prMerge(["123"], deps);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain("gh");
+    expect(calls[0]).toContain("pr");
+    expect(calls[0]).toContain("merge");
+    expect(calls[0]).toContain("123");
+    expect(calls[0]).toContain("--squash");
+    expect(calls[0]).not.toContain("--delete-branch");
+  });
+
+  test("passes --auto when requested", async () => {
+    const calls: string[][] = [];
+    const deps = makeDeps({
+      exec: (cmd) => {
+        calls.push(cmd);
+        return { stdout: "", stderr: "", exitCode: 0 };
+      },
+    });
+    await prMerge(["5", "--auto"], deps);
+    expect(calls[0]).toContain("--auto");
+  });
+
+  test("never passes --delete-branch even with --auto", async () => {
+    const calls: string[][] = [];
+    const deps = makeDeps({
+      exec: (cmd) => {
+        calls.push(cmd);
+        return { stdout: "", stderr: "", exitCode: 0 };
+      },
+    });
+    await prMerge(["5", "--auto"], deps);
+    expect(calls[0]).not.toContain("--delete-branch");
+  });
+
+  test("exits with gh error code on failure", async () => {
+    const errors: string[] = [];
+    const deps = makeDeps({
+      exec: () => ({ stdout: "", stderr: "PR already merged", exitCode: 1 }),
+      printError: (m) => errors.push(m),
+    });
+    await expect(prMerge(["1"], deps)).rejects.toBeInstanceOf(ExitError);
+    expect(errors[0]).toContain("PR already merged");
+  });
+
+  test("exits with usage error when no PR number given", async () => {
+    const errors: string[] = [];
+    const deps = makeDeps({ printError: (m) => errors.push(m) });
+    await expect(prMerge([], deps)).rejects.toBeInstanceOf(ExitError);
+    expect(errors[0]).toMatch(/Usage/);
+  });
+
+  test("--wait polls until MERGED", async () => {
+    let calls = 0;
+    const deps = makeDeps({
+      exec: (cmd) => {
+        calls++;
+        if (cmd.includes("view")) {
+          // Return MERGED on second poll
+          return { stdout: calls >= 3 ? "MERGED" : "OPEN", stderr: "", exitCode: 0 };
+        }
+        return { stdout: "", stderr: "", exitCode: 0 };
+      },
+    });
+    await prMerge(["7", "--auto", "--wait", "--timeout", "30000"], deps);
+    // Should have called merge once + polled until MERGED
+    expect(calls).toBeGreaterThanOrEqual(3);
+  });
+
+  test("--wait times out gracefully", async () => {
+    const stderrLines: string[] = [];
+    const origError = console.error;
+    console.error = (m: string) => stderrLines.push(m);
+    try {
+      const deps = makeDeps({
+        exec: (cmd) => {
+          if (cmd.includes("view")) return { stdout: "OPEN", stderr: "", exitCode: 0 };
+          return { stdout: "", stderr: "", exitCode: 0 };
+        },
+      });
+      await prMerge(["9", "--wait", "--timeout", "100"], deps);
+      // Should NOT throw — timeout is a graceful exit, not an error
+      expect(stderrLines.some((e) => e.includes("timed out"))).toBe(true);
+    } finally {
+      console.error = origError;
+    }
+  });
+});
+
+// ── cmdPr ──
+
+describe("cmdPr", () => {
+  test("prints usage with no args", async () => {
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = (m: string) => logs.push(m);
+    try {
+      await cmdPr([]);
+      expect(logs.join("")).toContain("mcx pr");
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("routes to prMerge on 'merge' subcommand", async () => {
+    const calls: string[][] = [];
+    const deps = makeDeps({
+      exec: (cmd) => {
+        calls.push(cmd);
+        return { stdout: "", stderr: "", exitCode: 0 };
+      },
+    });
+    await cmdPr(["merge", "42"], deps);
+    expect(calls[0]).toContain("42");
+  });
+
+  test("exits on unknown subcommand", async () => {
+    const errors: string[] = [];
+    const deps = makeDeps({ printError: (m) => errors.push(m) });
+    await expect(cmdPr(["frobnicate"], deps)).rejects.toBeInstanceOf(ExitError);
+    expect(errors[0]).toContain("Unknown pr subcommand");
+  });
+});

--- a/packages/command/src/commands/pr.ts
+++ b/packages/command/src/commands/pr.ts
@@ -1,0 +1,203 @@
+/**
+ * `mcx pr` — GitHub PR helpers that are worktree-aware.
+ *
+ * Unlike `gh pr merge --delete-branch`, `mcx pr merge` never attempts local
+ * branch deletion, avoiding the "cannot delete branch used by worktree" error
+ * (#1800). Local cleanup is left to `mcx claude bye` → cleanupWorktree.
+ */
+
+import { printError as defaultPrintError } from "../output";
+
+// ── Deps ──
+
+export interface PrDeps {
+  exec: (cmd: string[]) => { stdout: string; stderr: string; exitCode: number };
+  printError: (msg: string) => void;
+  exit: (code: number) => never;
+  sleep: (ms: number) => Promise<void>;
+}
+
+export const defaultPrDeps: PrDeps = {
+  exec: (cmd) => {
+    const result = Bun.spawnSync(cmd, { stdout: "pipe", stderr: "pipe" });
+    return {
+      stdout: result.stdout.toString().trim(),
+      stderr: result.stderr.toString().trim(),
+      exitCode: result.exitCode ?? 1,
+    };
+  },
+  printError: defaultPrintError,
+  exit: (code) => process.exit(code),
+  sleep: (ms) => Bun.sleep(ms),
+};
+
+// ── Arg parsing ──
+
+export interface PrMergeArgs {
+  prNumber: string | undefined;
+  squash: boolean;
+  rebase: boolean;
+  mergeCommit: boolean;
+  auto: boolean;
+  wait: boolean;
+  timeout: number;
+  error: string | undefined;
+}
+
+export function parsePrMergeArgs(args: string[]): PrMergeArgs {
+  let prNumber: string | undefined;
+  let squash = false;
+  let rebase = false;
+  let mergeCommit = false;
+  let auto = false;
+  let wait = false;
+  let timeout = 270_000;
+  let error: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--squash") {
+      squash = true;
+    } else if (arg === "--rebase") {
+      rebase = true;
+    } else if (arg === "--merge") {
+      mergeCommit = true;
+    } else if (arg === "--auto") {
+      auto = true;
+    } else if (arg === "--wait") {
+      wait = true;
+    } else if (arg === "--timeout" || arg === "-t") {
+      const val = args[++i];
+      if (!val) {
+        error = "--timeout requires a value in ms";
+      } else {
+        timeout = Number(val);
+        if (Number.isNaN(timeout)) error = "--timeout must be a number";
+      }
+    } else if (!arg.startsWith("-")) {
+      prNumber = arg;
+    }
+  }
+
+  if (!prNumber && !error) {
+    error = "Usage: mcx pr merge <pr-number> [--squash] [--auto] [--wait]";
+  }
+
+  // Default to squash if no strategy given
+  if (!squash && !rebase && !mergeCommit) squash = true;
+
+  return { prNumber, squash, rebase, mergeCommit, auto, wait, timeout, error };
+}
+
+// ── Subcommands ──
+
+export async function prMerge(args: string[], deps: Partial<PrDeps> = {}): Promise<void> {
+  const d: PrDeps = { ...defaultPrDeps, ...deps };
+  const parsed = parsePrMergeArgs(args);
+
+  if (parsed.error) {
+    d.printError(parsed.error);
+    d.exit(1);
+  }
+
+  if (!parsed.prNumber) {
+    d.printError("Usage: mcx pr merge <pr-number>");
+    d.exit(1);
+  }
+  const prNum = parsed.prNumber;
+
+  // Build gh pr merge command.
+  // --delete-branch is intentionally omitted: it fails with "cannot delete branch
+  // used by worktree" when the branch is checked out in an active worktree (#1800).
+  // Local branch cleanup is handled by `mcx claude bye` → cleanupWorktree.
+  const mergeCmd = ["gh", "pr", "merge", prNum];
+  if (parsed.squash) mergeCmd.push("--squash");
+  else if (parsed.rebase) mergeCmd.push("--rebase");
+  else if (parsed.mergeCommit) mergeCmd.push("--merge");
+  if (parsed.auto) mergeCmd.push("--auto");
+
+  const { exitCode, stdout, stderr } = d.exec(mergeCmd);
+
+  if (exitCode !== 0) {
+    d.printError(stderr || `gh pr merge exited with code ${exitCode}`);
+    d.exit(exitCode);
+  }
+
+  if (stdout) console.log(stdout);
+  if (stderr) console.error(stderr);
+
+  if (!parsed.wait) return;
+
+  // Poll until PR reaches MERGED state
+  const deadline = Date.now() + parsed.timeout;
+  while (Date.now() < deadline) {
+    const { stdout: state, exitCode: viewExit } = d.exec([
+      "gh",
+      "pr",
+      "view",
+      prNum,
+      "--json",
+      "state",
+      "-q",
+      ".state",
+    ]);
+
+    if (viewExit === 0 && state.toUpperCase() === "MERGED") {
+      console.error(`PR #${prNum} merged.`);
+      return;
+    }
+
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await d.sleep(Math.min(10_000, remaining));
+  }
+
+  console.error(`PR #${prNum} not yet merged (timed out after ${parsed.timeout}ms).`);
+}
+
+// ── Entry point ──
+
+export async function cmdPr(args: string[], deps: Partial<PrDeps> = {}): Promise<void> {
+  const sub = args[0];
+
+  if (!sub || sub === "--help" || sub === "-h") {
+    printPrUsage();
+    return;
+  }
+
+  const subArgs = args.slice(1);
+
+  switch (sub) {
+    case "merge":
+      await prMerge(subArgs, deps);
+      break;
+    default: {
+      const d: Pick<PrDeps, "printError" | "exit"> = { ...defaultPrDeps, ...deps };
+      d.printError(`Unknown pr subcommand: ${sub}. Use "merge".`);
+      d.exit(1);
+    }
+  }
+}
+
+function printPrUsage(): void {
+  console.log(`mcx pr — worktree-aware GitHub PR helpers
+
+Usage:
+  mcx pr merge <pr>                    Merge PR without local-branch cleanup errors
+  mcx pr merge <pr> --auto             Enable auto-merge (merges when CI passes)
+  mcx pr merge <pr> --auto --wait      Enable auto-merge + block until merged
+
+Merge strategy (default: --squash):
+  --squash                             Squash and merge
+  --rebase                             Rebase and merge
+  --merge                              Create a merge commit
+
+Options:
+  --auto                               Enable auto-merge (requires branch protection)
+  --wait                               Block until the PR reaches MERGED state
+  --timeout, -t <ms>                   Max wait time (default: 270000)
+
+Unlike 'gh pr merge --delete-branch', 'mcx pr merge' never attempts local branch
+deletion. Use 'mcx claude bye' to clean up the worktree and local branch once
+the PR is merged.`);
+}

--- a/packages/command/src/commands/pr.ts
+++ b/packages/command/src/commands/pr.ts
@@ -142,9 +142,17 @@ export async function prMerge(args: string[], deps: Partial<PrDeps> = {}): Promi
       ".state",
     ]);
 
-    if (viewExit === 0 && state.toUpperCase() === "MERGED") {
-      console.error(`PR #${prNum} merged.`);
-      return;
+    if (viewExit === 0) {
+      const upper = state.toUpperCase();
+      if (upper === "MERGED") {
+        console.error(`PR #${prNum} merged.`);
+        return;
+      }
+      if (upper === "CLOSED") {
+        d.printError(`PR #${prNum} was closed without merging.`);
+        d.exit(1);
+        return;
+      }
     }
 
     const remaining = deadline - Date.now();
@@ -152,7 +160,8 @@ export async function prMerge(args: string[], deps: Partial<PrDeps> = {}): Promi
     await d.sleep(Math.min(10_000, remaining));
   }
 
-  console.error(`PR #${prNum} not yet merged (timed out after ${parsed.timeout}ms).`);
+  d.printError(`PR #${prNum} not yet merged (timed out after ${parsed.timeout}ms).`);
+  d.exit(124);
 }
 
 // ── Entry point ──

--- a/packages/command/src/commands/pr.ts
+++ b/packages/command/src/commands/pr.ts
@@ -80,7 +80,7 @@ export function parsePrMergeArgs(args: string[]): PrMergeArgs {
   }
 
   if (!prNumber && !error) {
-    error = "Usage: mcx pr merge <pr-number> [--squash] [--auto] [--wait]";
+    error = "Usage: mcx pr merge <pr-number> [--squash|--rebase|--merge] [--auto] [--wait] [--timeout/-t <ms>]";
   }
 
   // Default to squash if no strategy given

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -46,6 +46,7 @@ import { cmdMail } from "./commands/mail";
 import { cmdMonitor } from "./commands/monitor";
 import { cmdNote } from "./commands/note";
 import { cmdPhase } from "./commands/phase";
+import { cmdPr } from "./commands/pr";
 import { cmdRegistryDispatch } from "./commands/registry-cmd";
 import { cmdRemove } from "./commands/remove";
 import { cmdRun } from "./commands/run";
@@ -385,6 +386,10 @@ async function main(): Promise<void> {
 
       case "claude":
         await cmdClaude(cleanArgs.slice(1));
+        break;
+
+      case "pr":
+        await cmdPr(cleanArgs.slice(1));
         break;
 
       case "codex":
@@ -924,6 +929,7 @@ Tools:
 Sessions:
   mcx claude <subcommand>             Manage Claude Code sessions
   mcx agent <provider> <subcommand>   Manage agent sessions (codex, acp, opencode)
+  mcx pr merge <pr>                   Merge a PR (worktree-aware, no local-branch errors)
 
 Servers:
   mcx status                          Server/daemon status


### PR DESCRIPTION
## Summary

- Adds `mcx pr merge <n> [--squash|--rebase|--merge] [--auto] [--wait]` — a thin wrapper around `gh pr merge` that intentionally omits `--delete-branch`
- The `--delete-branch` flag fails with "cannot delete branch used by worktree" when an impl session's branch is still checked out in an active worktree (sprint-45 saw this on every merge because the rule is "don't bye until QA passes")
- Local branch cleanup is left to `mcx claude bye` → `cleanupWorktree`; remote branch cleanup is handled by GitHub's auto-delete setting
- Updates `run.md` to reference `mcx pr merge $PR --squash --auto` instead of `gh pr merge $PR --squash --delete-branch --auto`

## Test plan

- [x] `bun typecheck` — passes
- [x] `bun lint` — passes
- [x] New unit tests in `pr.spec.ts` (19 tests): arg parsing, `--squash` default, `--auto`, `--wait` polling, timeout, never-passes-`--delete-branch` assertion, error propagation
- [x] Full `bun test` suite — 6064 pass, 1 pre-existing flaky failure in `IpcServer HTTP transport` (passes in isolation, unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)