### PR TITLE
fix(daemon): suppress stuck detection during active tool calls (fixes #1799)

### DIFF
--- a/packages/daemon/src/claude-session/session-state.ts
+++ b/packages/daemon/src/claude-session/session-state.ts
@@ -82,6 +82,7 @@ export class SessionState {
   rateLimited = false;
   readonly pendingPermissions = new Map<string, CanUseToolMsg["request"]>();
   lastToolCall: { name: string; errorMessage?: string; at: number } | null = null;
+  hasActiveToolCall = false;
   private readonly genRequestId: RequestIdGenerator;
 
   /**
@@ -294,6 +295,7 @@ export class SessionState {
   }
 
   private handleResult(msg: NdjsonMessage): SessionEvent[] {
+    this.hasActiveToolCall = false;
     const successResult = ResultSuccess.safeParse(msg);
     if (successResult.success) {
       const r = successResult.data;
@@ -361,9 +363,11 @@ export class SessionState {
       const block = content[i];
       if (block.type === "tool_use" && typeof block.name === "string") {
         this.lastToolCall = { name: block.name, at: Date.now() };
+        this.hasActiveToolCall = true;
         return;
       }
     }
+    this.hasActiveToolCall = false;
   }
 
   private extractLastToolCallRaw(msg: NdjsonMessage): void {

--- a/packages/daemon/src/claude-session/stuck-detector.spec.ts
+++ b/packages/daemon/src/claude-session/stuck-detector.spec.ts
@@ -13,6 +13,7 @@ interface MockSnapshot {
   tokens: number;
   lastToolCall: { name: string; errorMessage?: string; at: number } | null;
   pendingPermissionCount: number;
+  hasActiveToolCall: boolean;
 }
 
 function setup(overrides?: Partial<MockSnapshot>) {
@@ -21,6 +22,7 @@ function setup(overrides?: Partial<MockSnapshot>) {
     tokens: 100,
     lastToolCall: null,
     pendingPermissionCount: 0,
+    hasActiveToolCall: false,
     ...overrides,
   };
   const events: StuckEvent[] = [];
@@ -223,6 +225,54 @@ describe("StuckDetector", () => {
     expect(events[1].tier).toBe(2);
   });
 
+  test("active tool call suppresses stuck events (false positive: long bun test)", async () => {
+    const { detector: d, snapshot, events } = setup({ hasActiveToolCall: true });
+    detector = d;
+    snapshot.lastToolCall = { name: "Bash", at: Date.now() };
+    d.recordProgress(100);
+
+    // Wait well past all thresholds — no event should fire while tool is active
+    await Bun.sleep(500);
+    expect(events.length).toBe(0);
+  });
+
+  test("stuck fires after active tool call completes with no progress (true positive: frozen session)", async () => {
+    const { detector: d, snapshot, events } = setup({ hasActiveToolCall: true });
+    detector = d;
+    snapshot.lastToolCall = { name: "Bash", at: Date.now() };
+    d.recordProgress(100);
+
+    // Tool active — no events
+    await Bun.sleep(150);
+    expect(events.length).toBe(0);
+
+    // Tool completes but session makes no progress (frozen)
+    snapshot.hasActiveToolCall = false;
+
+    await pollUntil(() => events.length >= 1, 2000);
+    expect(events[0].tier).toBe(1);
+    expect(events[0].lastTool).toBe("Bash");
+  });
+
+  test("active tool call resumes detection after tool completes with progress", async () => {
+    const { detector: d, snapshot, events } = setup({ hasActiveToolCall: true });
+    detector = d;
+    snapshot.lastToolCall = { name: "Bash", at: Date.now() };
+    d.recordProgress(100);
+
+    // Tool active — suppressed
+    await Bun.sleep(150);
+    expect(events.length).toBe(0);
+
+    // Tool completes, progress recorded (normal flow)
+    snapshot.hasActiveToolCall = false;
+    d.recordProgress(200);
+
+    // Timer reset — wait past threshold, should get tier 1
+    await pollUntil(() => events.length >= 1, 2000);
+    expect(events[0].tier).toBe(1);
+  });
+
   test("constructor throws on empty thresholdsMs", () => {
     expect(
       () =>
@@ -234,6 +284,7 @@ describe("StuckDetector", () => {
             tokens: 0,
             lastToolCall: null,
             pendingPermissionCount: 0,
+            hasActiveToolCall: false,
           }),
           () => {},
         ),
@@ -246,6 +297,7 @@ describe("StuckDetector", () => {
       tokens: 0,
       lastToolCall: null,
       pendingPermissionCount: 0,
+      hasActiveToolCall: false,
     });
     expect(() => new StuckDetector("s", { thresholdsMs: [100, 100], repeatMs: 300 }, makeSnapshot, () => {})).toThrow(
       "strictly ascending",
@@ -261,6 +313,7 @@ describe("StuckDetector", () => {
       tokens: 0,
       lastToolCall: null,
       pendingPermissionCount: 0,
+      hasActiveToolCall: false,
     });
     expect(() => new StuckDetector("s", { thresholdsMs: [0], repeatMs: 300 }, makeSnapshot, () => {})).toThrow(
       "positive finite number",
@@ -282,6 +335,7 @@ describe("StuckDetector", () => {
       tokens: 0,
       lastToolCall: null,
       pendingPermissionCount: 0,
+      hasActiveToolCall: false,
     });
     expect(() => new StuckDetector("s", { thresholdsMs: [100], repeatMs: 0 }, makeSnapshot, () => {})).toThrow(
       "repeatMs must be positive",

--- a/packages/daemon/src/claude-session/stuck-detector.ts
+++ b/packages/daemon/src/claude-session/stuck-detector.ts
@@ -24,6 +24,7 @@ interface SessionSnapshot {
   tokens: number;
   lastToolCall: { name: string; errorMessage?: string; at: number } | null;
   pendingPermissionCount: number;
+  hasActiveToolCall: boolean;
 }
 
 export class StuckDetector {
@@ -112,6 +113,11 @@ export class StuckDetector {
     const snapshot = this.getSnapshot();
 
     if (snapshot.pendingPermissionCount > 0 || snapshot.state === "waiting_permission") {
+      this.scheduleNext();
+      return;
+    }
+
+    if (snapshot.hasActiveToolCall) {
       this.scheduleNext();
       return;
     }

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -1836,6 +1836,7 @@ export class ClaudeWsServer {
           tokens: session.state.tokens,
           lastToolCall: session.state.lastToolCall,
           pendingPermissionCount: session.state.pendingPermissions.size,
+          hasActiveToolCall: session.state.hasActiveToolCall,
         }),
         (event) => this.handleStuckEvent(sessionId, session, event),
       );


### PR DESCRIPTION
## Summary

- Added `hasActiveToolCall` flag to `SessionState` — set when an assistant message contains a `tool_use` block, cleared when the next assistant message has none or on result
- `StuckDetector.evaluate()` now reschedules without emitting when `hasActiveToolCall` is true, using the same pattern as the existing permission-pending suppression
- Once the tool completes and the model resumes, stuck detection continues normally

## Test plan

- [x] **False positive suppressed**: test verifies no stuck event fires while `hasActiveToolCall` is true (simulates long `bun test`)
- [x] **True positive still fires**: test verifies stuck event fires after tool completes with no subsequent progress (frozen session)
- [x] **Progress reset after tool**: test verifies normal detection resumes with timer reset when tool completes and progress is recorded
- [x] All 21 stuck-detector tests pass (18 existing + 3 new)
- [x] All 424 claude-session tests pass
- [x] Full suite: 6048 pass, 0 related failures (1 pre-existing flaky in ipc-server.spec.ts → filed #1810)
- [x] typecheck, lint, coverage all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)