### PR TITLE
fix(db): allow explicit null to clear merge_state_status in upsertWorkItem (fixes #1699)

### DIFF
--- a/packages/daemon/src/db/work-items.spec.ts
+++ b/packages/daemon/src/db/work-items.spec.ts
@@ -281,6 +281,35 @@ describe("WorkItemDb", () => {
       expect(updated.branch).toBe("feat/x");
       expect(updated.prNumber).toBe(100);
     });
+
+    test("mergeStateStatus: explicit null clears existing value", () => {
+      const db = createDb();
+      db.upsertWorkItem({ id: "pr:200", prNumber: 200, mergeStateStatus: "BLOCKED" });
+      const before = db.getWorkItem("pr:200");
+      expect(before?.mergeStateStatus).toBe("BLOCKED");
+
+      const cleared = db.upsertWorkItem({ id: "pr:200", mergeStateStatus: null });
+      expect(cleared.mergeStateStatus).toBeNull();
+    });
+
+    test("mergeStateStatus: absent key preserves existing value", () => {
+      const db = createDb();
+      db.upsertWorkItem({ id: "pr:201", prNumber: 201, mergeStateStatus: "BLOCKED" });
+
+      // upsert without mergeStateStatus key at all — should keep "BLOCKED"
+      const kept = db.upsertWorkItem({ id: "pr:201" });
+      expect(kept.mergeStateStatus).toBe("BLOCKED");
+    });
+
+    test("mergeStateStatus: round-trips a value through successive upserts", () => {
+      const db = createDb();
+      db.upsertWorkItem({ id: "pr:202", prNumber: 202 });
+      db.upsertWorkItem({ id: "pr:202", mergeStateStatus: "CLEAN" });
+      expect(db.getWorkItem("pr:202")?.mergeStateStatus).toBe("CLEAN");
+
+      db.upsertWorkItem({ id: "pr:202", mergeStateStatus: null });
+      expect(db.getWorkItem("pr:202")?.mergeStateStatus).toBeNull();
+    });
   });
 
   describe("unique constraints", () => {

--- a/packages/daemon/src/db/work-items.ts
+++ b/packages/daemon/src/db/work-items.ts
@@ -82,6 +82,10 @@ function rowToWorkItem(row: WorkItemRow): WorkItem {
   };
 }
 
+// Sentinel string used in upsertWorkItem to distinguish "explicitly set to null"
+// from "field not provided" (which should leave the column unchanged via COALESCE).
+const NULL_SENTINEL = "__NULL__";
+
 // ---------- DB class ----------
 
 export class WorkItemDb {
@@ -452,7 +456,7 @@ export class WorkItemDb {
            ci_run_id          = COALESCE($ci_run_id, ci_run_id),
            ci_summary         = COALESCE($ci_summary, ci_summary),
            review_status      = COALESCE($review_status, review_status),
-           merge_state_status = COALESCE($merge_state_status, merge_state_status),
+           merge_state_status = CASE WHEN $merge_state_status = '__NULL__' THEN NULL ELSE COALESCE($merge_state_status, merge_state_status) END,
            phase              = COALESCE($phase, phase),
            updated_at         = datetime('now')`,
       )
@@ -467,7 +471,7 @@ export class WorkItemDb {
         $ci_run_id: item.ciRunId ?? null,
         $ci_summary: item.ciSummary ?? null,
         $review_status: item.reviewStatus ?? null,
-        $merge_state_status: item.mergeStateStatus ?? null,
+        $merge_state_status: "mergeStateStatus" in item ? (item.mergeStateStatus ?? NULL_SENTINEL) : null,
         $phase: item.phase ?? null,
       });
 


### PR DESCRIPTION
## Summary

- The `upsertWorkItem` query used `COALESCE($merge_state_status, merge_state_status)` which made it impossible to clear `merge_state_status` to NULL: passing `mergeStateStatus: null` silently retained the old column value.
- Introduces a `NULL_SENTINEL` string (`"__NULL__"`) to distinguish an explicit `null` (clear the field) from an absent key (keep old value via COALESCE). The SQL now uses `CASE WHEN $merge_state_status = '__NULL__' THEN NULL ELSE COALESCE(…) END`.
- All other fields are unchanged — they still use COALESCE since clearing them isn't a documented requirement.

## Test plan

- [x] `upsertWorkItem({ id, mergeStateStatus: null })` now clears an existing `BLOCKED` → `null`
- [x] `upsertWorkItem({ id })` (key absent) still preserves existing `BLOCKED`
- [x] round-trip: set `CLEAN`, then clear to `null` — both transitions correct
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test packages/daemon/src/db/work-items.spec.ts` — 49 pass, 0 fail
- [x] Pre-commit hook suite: 3982 pass, 0 fail, coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)