### PR TITLE
fix(phase): prefer work_items.phase over stale transition log (fixes #1802)

### DIFF
--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -506,6 +506,35 @@ describe("phaseRun", () => {
   });
 });
 
+async function catchExit(fn: () => Promise<unknown>): Promise<{ code: number | undefined; out: string; err: string }> {
+  const origExit = process.exit;
+  const origLog = console.log;
+  const origErr = console.error;
+  let exitCode: number | undefined;
+  let out = "";
+  let err = "";
+  process.exit = ((c?: number) => {
+    exitCode = c;
+    throw new Error("__exit__");
+  }) as typeof process.exit;
+  console.log = (...a: unknown[]) => {
+    out += `${a.join(" ")}\n`;
+  };
+  console.error = (...a: unknown[]) => {
+    err += `${a.join(" ")}\n`;
+  };
+  try {
+    await fn().catch((e) => {
+      if ((e as Error).message !== "__exit__") throw e;
+    });
+  } finally {
+    process.exit = origExit;
+    console.log = origLog;
+    console.error = origErr;
+  }
+  return { code: exitCode, out, err };
+}
+
 describe("cmdPhase dispatch", () => {
   beforeEach(async () => {
     writeFileSync(join(dir, ".mcx.yaml"), manifestYaml);
@@ -526,37 +555,6 @@ describe("cmdPhase dispatch", () => {
     const { deps } = makeDriftDeps(dir);
     await cmdPhase(["install"], deps);
   });
-
-  async function catchExit(
-    fn: () => Promise<unknown>,
-  ): Promise<{ code: number | undefined; out: string; err: string }> {
-    const origExit = process.exit;
-    const origLog = console.log;
-    const origErr = console.error;
-    let exitCode: number | undefined;
-    let out = "";
-    let err = "";
-    process.exit = ((c?: number) => {
-      exitCode = c;
-      throw new Error("__exit__");
-    }) as typeof process.exit;
-    console.log = (...a: unknown[]) => {
-      out += `${a.join(" ")}\n`;
-    };
-    console.error = (...a: unknown[]) => {
-      err += `${a.join(" ")}\n`;
-    };
-    try {
-      await fn().catch((e) => {
-        if ((e as Error).message !== "__exit__") throw e;
-      });
-    } finally {
-      process.exit = origExit;
-      console.log = origLog;
-      console.error = origErr;
-    }
-    return { code: exitCode, out, err };
-  }
 
   test("no args prints usage", async () => {
     const { out, code } = await catchExit(() => cmdPhase([]));
@@ -2004,37 +2002,6 @@ phases:
 });
 
 describe("work_items.phase wins over stale transition log (#1802)", () => {
-  async function catchExit1802(
-    fn: () => Promise<unknown>,
-  ): Promise<{ code: number | undefined; out: string; err: string }> {
-    const origExit = process.exit;
-    const origLog = console.log;
-    const origErr = console.error;
-    let exitCode: number | undefined;
-    let out = "";
-    let err = "";
-    process.exit = ((c?: number) => {
-      exitCode = c;
-      throw new Error("__exit__");
-    }) as typeof process.exit;
-    console.log = (...a: unknown[]) => {
-      out += `${a.join(" ")}\n`;
-    };
-    console.error = (...a: unknown[]) => {
-      err += `${a.join(" ")}\n`;
-    };
-    try {
-      await fn().catch((e) => {
-        if ((e as Error).message !== "__exit__") throw e;
-      });
-    } finally {
-      process.exit = origExit;
-      console.log = origLog;
-      console.error = origErr;
-    }
-    return { code: exitCode, out, err };
-  }
-
   function makeExecDeps1802(opts: { workItem: Record<string, unknown> }) {
     const calls: Array<{ method: string; params: unknown }> = [];
     const ipcCall = async (method: string, params: unknown) => {
@@ -2196,7 +2163,7 @@ phases:
       }
       return null;
     };
-    const { err, code } = await catchExit1802(() =>
+    const { err, code } = await catchExit(() =>
       cmdPhase(
         ["run", "done", "--work-item", "#1727", "--no-execute"],
         { cwd: () => dir },

--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -2003,6 +2003,214 @@ phases:
   }, 30_000);
 });
 
+describe("work_items.phase wins over stale transition log (#1802)", () => {
+  async function catchExit1802(
+    fn: () => Promise<unknown>,
+  ): Promise<{ code: number | undefined; out: string; err: string }> {
+    const origExit = process.exit;
+    const origLog = console.log;
+    const origErr = console.error;
+    let exitCode: number | undefined;
+    let out = "";
+    let err = "";
+    process.exit = ((c?: number) => {
+      exitCode = c;
+      throw new Error("__exit__");
+    }) as typeof process.exit;
+    console.log = (...a: unknown[]) => {
+      out += `${a.join(" ")}\n`;
+    };
+    console.error = (...a: unknown[]) => {
+      err += `${a.join(" ")}\n`;
+    };
+    try {
+      await fn().catch((e) => {
+        if ((e as Error).message !== "__exit__") throw e;
+      });
+    } finally {
+      process.exit = origExit;
+      console.log = origLog;
+      console.error = origErr;
+    }
+    return { code: exitCode, out, err };
+  }
+
+  function makeExecDeps1802(opts: { workItem: Record<string, unknown> }) {
+    const calls: Array<{ method: string; params: unknown }> = [];
+    const ipcCall = async (method: string, params: unknown) => {
+      calls.push({ method, params });
+      if (method === "getWorkItem") return opts.workItem;
+      if (method === "aliasStateGet") return { value: undefined };
+      if (method === "aliasStateSet") return { ok: true };
+      if (method === "aliasStateDelete") return { ok: true };
+      if (method === "aliasStateAll") return { entries: {} };
+      if (method === "callTool") return { content: [{ type: "text", text: "{}" }] };
+      return null;
+    };
+    const exec = (cmd: string[]) => {
+      if (cmd.includes("rev-parse") && cmd.includes("--is-inside-work-tree")) return { stdout: "true", exitCode: 0 };
+      if (cmd.includes("symbolic-ref")) return { stdout: "main\n", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    };
+    return {
+      ipcCall: ipcCall as unknown as typeof import("@mcp-cli/core").ipcCall,
+      exec,
+      findGitRoot: () => dir,
+      now: () => new Date("2026-04-14T00:00:00Z"),
+      calls,
+    };
+  }
+
+  const doneAlias = `
+import { defineAlias, z } from "mcp-cli";
+defineAlias(({ z }) => ({
+  name: "done",
+  description: "done",
+  input: z.object({}).default({}),
+  output: z.object({ action: z.string() }),
+  fn: async () => ({ action: "merged" }),
+}));
+`.trim();
+
+  const manifest1802 = `
+runsOn: main
+initial: impl
+phases:
+  impl:
+    source: ./impl.ts
+    next: [triage]
+  triage:
+    source: ./impl.ts
+    next: [qa]
+  qa:
+    source: ./impl.ts
+    next: [done]
+  done:
+    source: ./done.ts
+    next: []
+`.trim();
+
+  test("executePhase uses work_items.phase over stale log after force-update", async () => {
+    writeFileSync(join(dir, ".mcx.yaml"), manifest1802);
+    writeFileSync(join(dir, "impl.ts"), doneAlias);
+    writeFileSync(join(dir, "done.ts"), doneAlias);
+    const { deps: installDeps } = makeDriftDeps(dir);
+    await cmdPhase(["install"], installDeps);
+
+    // Simulate: log says last committed target was "triage", but
+    // work_items_update force=true moved the column to "qa".
+    appendTransitionLog(transitionLogPath(dir), {
+      ts: "2026-04-14T00:00:00Z",
+      workItemId: "#1727",
+      from: null,
+      to: "impl",
+      status: "committed",
+    });
+    appendTransitionLog(transitionLogPath(dir), {
+      ts: "2026-04-14T00:01:00Z",
+      workItemId: "#1727",
+      from: "impl",
+      to: "triage",
+      status: "committed",
+    });
+    // No "qa" entry — the force-update only touched the column.
+
+    const ex = makeExecDeps1802({
+      workItem: {
+        id: "#1727",
+        issueNumber: 1727,
+        prNumber: 100,
+        branch: "feat/1727",
+        prState: "open",
+        prUrl: null,
+        ciStatus: "none",
+        ciRunId: null,
+        ciSummary: null,
+        reviewStatus: "pending",
+        phase: "qa",
+        createdAt: "2026-01-01T00:00:00Z",
+        updatedAt: "2026-01-01T00:00:00Z",
+      },
+    });
+    const errs: string[] = [];
+    let exitCode: number | undefined;
+    await executePhase(
+      ["done", "--work-item", "#1727"],
+      {
+        ...makeDriftDeps(dir).deps,
+        log: () => {},
+        logError: (m) => errs.push(m),
+        exit: ((c: number) => {
+          exitCode = c;
+          throw new Error(`exit(${c})`);
+        }) as (code: number) => never,
+      },
+      { ipcCall: ex.ipcCall, exec: ex.exec, findGitRoot: ex.findGitRoot, now: ex.now },
+    ).catch(() => {});
+
+    // Before the fix this threw DisallowedTransitionError: triage → done
+    expect(exitCode).toBeUndefined();
+    expect(errs.some((e) => e.includes("approved") && e.includes("qa") && e.includes("done"))).toBe(true);
+  }, 30_000);
+
+  test("--no-execute uses work_items.phase over stale log after force-update", async () => {
+    writeFileSync(join(dir, ".mcx.yaml"), manifest1802);
+    writeFileSync(join(dir, "impl.ts"), doneAlias);
+    writeFileSync(join(dir, "done.ts"), doneAlias);
+    const { deps: installDeps } = makeDriftDeps(dir);
+    await cmdPhase(["install"], installDeps);
+
+    // Same stale-log scenario as above
+    appendTransitionLog(transitionLogPath(dir), {
+      ts: "2026-04-14T00:00:00Z",
+      workItemId: "#1727",
+      from: null,
+      to: "impl",
+      status: "committed",
+    });
+    appendTransitionLog(transitionLogPath(dir), {
+      ts: "2026-04-14T00:01:00Z",
+      workItemId: "#1727",
+      from: "impl",
+      to: "triage",
+      status: "committed",
+    });
+
+    const mockIpcCall = async (method: string) => {
+      if (method === "getWorkItem") {
+        return {
+          id: "#1727",
+          issueNumber: 1727,
+          prNumber: 100,
+          branch: "feat/1727",
+          prState: "open",
+          prUrl: null,
+          ciStatus: "none",
+          ciRunId: null,
+          ciSummary: null,
+          reviewStatus: "pending",
+          phase: "qa",
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-01T00:00:00Z",
+        };
+      }
+      return null;
+    };
+    const { err, code } = await catchExit1802(() =>
+      cmdPhase(
+        ["run", "done", "--work-item", "#1727", "--no-execute"],
+        { cwd: () => dir },
+        { ipcCall: mockIpcCall as unknown as typeof import("@mcp-cli/core").ipcCall },
+      ),
+    );
+
+    expect(code).toBeUndefined();
+    expect(err).toContain("approved");
+    expect(err).toContain("qa");
+    expect(err).toContain("done");
+  });
+});
+
 describe("executePhase auto-persists work_items.phase (#1745)", () => {
   const triageAlias = `
 import { defineAlias, z } from "mcp-cli";

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -720,30 +720,31 @@ export async function cmdPhase(
         const filtered = argv.filter((a) => a !== "--no-execute");
         const opts = parsePhaseRunArgs(filtered);
         const cwd = d.cwd();
-        // Mirror the resolvedFrom fallback from executePhase (#1635):
-        // Only do the expensive history-read + ipcCall when --from is absent.
+        // Mirror the resolvedFrom priority from executePhase (#1802):
+        // work_items.phase > log tail > null (same rationale as #1635).
         let resolvedFrom: string | null = opts.from;
         if (resolvedFrom === null) {
           const manifestForFrom = d.loadManifest(cwd);
           const priorTargets = manifestForFrom
             ? historyTargets(readTransitionHistory(transitionLogPath(cwd), opts.workItemId).filter(isCommitted))
             : [];
-          if (priorTargets.length > 0) {
-            resolvedFrom = priorTargets[priorTargets.length - 1];
-          } else if (opts.workItemId !== null && manifestForFrom) {
+          if (opts.workItemId !== null && manifestForFrom) {
             const ex: PhaseExecuteDeps = { ...defaultExecuteDeps, ...execDeps };
             try {
               const wi = (await ex.ipcCall("getWorkItem", { id: opts.workItemId })) as WorkItem | null;
               if (
                 wi &&
-                opts.target !== manifestForFrom.manifest.initial &&
-                wi.phase in manifestForFrom.manifest.phases
+                wi.phase in manifestForFrom.manifest.phases &&
+                (priorTargets.length > 0 || opts.target !== manifestForFrom.manifest.initial)
               ) {
                 resolvedFrom = wi.phase;
               }
             } catch {
               // ignore; resolvedFrom stays null
             }
+          }
+          if (resolvedFrom === null && priorTargets.length > 0) {
+            resolvedFrom = priorTargets[priorTargets.length - 1];
           }
         }
         const result = phaseRun({ ...opts, from: resolvedFrom }, { cwd });
@@ -1086,24 +1087,23 @@ export async function executePhase(
   const logPath = transitionLogPath(cwd);
   const prior = readTransitionHistory(logPath, parsed.workItemId).filter(isCommitted);
   const priorTargets = historyTargets(prior);
-  // When --from is not given and transition history is empty, fall back to
-  // work_items.phase as the implicit "from" so manually-spawned impl sessions
-  // don't cause a spurious "(initial) → triage" rejection (#1522).
-  // Exceptions:
-  //   - target === manifest.initial: first launch of the initial phase; keep
-  //     from=null so Rule 4 (initial phase enforcement) still applies.
-  //   - workItem.phase not in manifest.phases: stale/mismatched phase name
-  //     (e.g. daemon stores "impl" but manifest declares "implement"); fall
-  //     back to null to preserve the original Rule 4 error path (#1636).
+  // Resolve "from" phase. Priority (#1802):
+  //   1. Explicit --from flag
+  //   2. work_items.phase — the column is the source of truth after
+  //      force-updates that skip the JSONL transition log. Guard: when
+  //      history is empty AND target === manifest.initial, keep from=null
+  //      so Rule 4 (initial-phase enforcement) still applies on first launch.
+  //   3. Transition log tail (committed entries only)
+  //   4. null (first transition / unknown)
   const resolvedFrom =
     parsed.from !== null
       ? parsed.from
-      : priorTargets.length > 0
-        ? priorTargets[priorTargets.length - 1]
-        : parsed.target !== loaded.manifest.initial &&
-            workItem?.phase != null &&
-            workItem.phase in loaded.manifest.phases
-          ? workItem.phase
+      : workItem?.phase != null &&
+          workItem.phase in loaded.manifest.phases &&
+          (priorTargets.length > 0 || parsed.target !== loaded.manifest.initial)
+        ? workItem.phase
+        : priorTargets.length > 0
+          ? priorTargets[priorTargets.length - 1]
           : null;
   validateTransition({
     manifest: loaded.manifest,


### PR DESCRIPTION
## Summary
- After `work_items_update` with `force=true`, the `work_items.phase` column and the JSONL transition log (`.mcx/transitions.jsonl`) can diverge — the column updates but the log doesn't get a new entry
- `mcx phase run` previously read "from" primarily from the log tail, causing `DisallowedTransitionError` on valid transitions when the log was stale (sprint 45 hit this 2-3 times)
- Fix: reorder `resolvedFrom` priority so `work_items.phase` takes precedence over the transition log tail when the phase is a declared manifest phase. The log tail becomes the fallback for cases without a work item. Applied to both the `executePhase` and `--no-execute` code paths

## Test plan
- [x] New test: `executePhase uses work_items.phase over stale log after force-update` — primes log at "triage", sets column to "qa", runs `done` phase → succeeds (previously threw DisallowedTransitionError)
- [x] New test: `--no-execute uses work_items.phase over stale log after force-update` — same divergence scenario through the `--no-execute` path
- [x] Existing test: `falls back to work_items.phase when transition log is empty (#1522)` — still passes
- [x] Existing test: `ignores work_items.phase fallback when phase name not in manifest (#1636)` — still passes
- [x] Full suite: 6054 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)