### PR TITLE
feat(claude-patch): patcher infrastructure + mcx claude patch-update (#1808)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -46,6 +46,14 @@ function makeDeps(overrides?: Partial<ClaudeDeps>): ClaudeDeps {
     getGitRoot: mock(() => null),
     getStaleDaemonWarning: mock(() => null),
     pollMail: mock(async () => null),
+    runPatchUpdate: mock(async () => ({
+      status: "noop" as const,
+      version: "2.1.119",
+      strategyId: "noop-pre-2.1.120",
+      sourcePath: "/usr/local/bin/claude",
+      sourceHash: "abc123",
+      reason: "no patch needed",
+    })),
     ...overrides,
   };
 }
@@ -4591,5 +4599,160 @@ describe("mcx claude <alias> --help", () => {
     const output = logCalls(deps).join("\n");
     expect(output).toContain("mcx claude worktrees");
     expect(output).not.toContain("No detailed help available");
+  });
+});
+
+describe("mcx claude patch-update", () => {
+  test("noop status logs the reason without exit code", async () => {
+    const deps = makeDeps();
+    await cmdClaude(["patch-update"], deps);
+    expect(logCalls(deps).join("\n")).toContain("needs no patch");
+    expect(deps.exit).not.toHaveBeenCalled();
+  });
+
+  test("patched status logs the destination + strategy + source hash", async () => {
+    const deps = makeDeps({
+      runPatchUpdate: mock(async () => ({
+        status: "patched" as const,
+        version: "2.1.121",
+        strategyId: "host-check-ipv6-loopback-v1",
+        sourcePath: "/usr/local/bin/claude",
+        sourceHash: "deadbeefcafebabe1234567890abcdef",
+        patchedPath: "/x/2.1.121.patched",
+        currentLink: "/x/current",
+      })),
+    });
+    await cmdClaude(["patch-update"], deps);
+    const out = logCalls(deps).join("\n");
+    expect(out).toContain("Patched claude 2.1.121");
+    expect(out).toContain("host-check-ipv6-loopback-v1");
+    expect(out).toContain("deadbeefcafe"); // truncated sha prefix
+  });
+
+  test("already-current status hints --force", async () => {
+    const deps = makeDeps({
+      runPatchUpdate: mock(async () => ({
+        status: "already-current" as const,
+        version: "2.1.121",
+        strategyId: "host-check-ipv6-loopback-v1",
+        sourcePath: "/usr/local/bin/claude",
+        sourceHash: "abc",
+        patchedPath: "/x/2.1.121.patched",
+        currentLink: "/x/current",
+      })),
+    });
+    await cmdClaude(["patch-update"], deps);
+    expect(logCalls(deps).join("\n")).toContain("already patched");
+    expect(logCalls(deps).join("\n")).toContain("--force");
+  });
+
+  test("unsupported status exits 2 with the patcher's reason", async () => {
+    const deps = makeDeps({
+      runPatchUpdate: mock(async () => ({
+        status: "unsupported" as const,
+        version: "9.9.9",
+        sourcePath: "/usr/local/bin/claude",
+        sourceHash: "abc",
+        reason: "No patch strategy registered for claude 9.9.9.",
+      })),
+    });
+    await expect(cmdClaude(["patch-update"], deps)).rejects.toThrow(ExitError);
+    const errCalls = (deps.printError as Mock<(s: string) => void>).mock.calls.map((c) => c[0]);
+    expect(errCalls.some((s) => s.includes("9.9.9"))).toBe(true);
+    expect(errCalls.some((s) => s.includes("No patch strategy"))).toBe(true);
+    expect(deps.exit).toHaveBeenCalledWith(2);
+  });
+
+  test("patcher exception exits 1 with formatted error", async () => {
+    const deps = makeDeps({
+      runPatchUpdate: mock(async () => {
+        throw new Error("boom");
+      }),
+    });
+    await expect(cmdClaude(["patch-update"], deps)).rejects.toThrow(ExitError);
+    const errCalls = (deps.printError as Mock<(s: string) => void>).mock.calls.map((c) => c[0]);
+    expect(errCalls.some((s) => s.includes("patch-update failed: boom"))).toBe(true);
+    expect(deps.exit).toHaveBeenCalledWith(1);
+  });
+
+  test("--json prints the outcome as JSON without human-readable lines", async () => {
+    const deps = makeDeps();
+    const captured: string[] = [];
+    const origLog = console.log;
+    console.log = (s: string) => {
+      captured.push(s);
+    };
+    try {
+      await cmdClaude(["patch-update", "--json"], deps);
+    } finally {
+      console.log = origLog;
+    }
+    expect(captured.length).toBe(1);
+    const parsed = JSON.parse(captured[0]);
+    expect(parsed.status).toBe("noop");
+  });
+
+  test("--force is forwarded to the patcher", async () => {
+    const calls: Array<{ force?: boolean; sourcePath?: string }> = [];
+    const deps = makeDeps({
+      runPatchUpdate: mock(async (opts) => {
+        calls.push({ force: opts?.force, sourcePath: opts?.sourcePath });
+        return {
+          status: "noop" as const,
+          version: "2.1.119",
+          strategyId: "noop-pre-2.1.120",
+          sourcePath: opts?.sourcePath ?? "/usr/local/bin/claude",
+          sourceHash: "x",
+          reason: "no patch needed",
+        };
+      }),
+    });
+    await cmdClaude(["patch-update", "--force"], deps);
+    expect(calls[0].force).toBe(true);
+  });
+
+  test("--source <path> overrides the default source binary", async () => {
+    const calls: Array<{ sourcePath?: string }> = [];
+    const deps = makeDeps({
+      runPatchUpdate: mock(async (opts) => {
+        calls.push({ sourcePath: opts?.sourcePath });
+        return {
+          status: "noop" as const,
+          version: "2.1.119",
+          strategyId: "noop-pre-2.1.120",
+          sourcePath: opts?.sourcePath ?? "/usr/local/bin/claude",
+          sourceHash: "x",
+          reason: "no patch needed",
+        };
+      }),
+    });
+    await cmdClaude(["patch-update", "--source", "/custom/claude"], deps);
+    expect(calls[0].sourcePath).toBe("/custom/claude");
+  });
+
+  test("--source=<path> form is also accepted", async () => {
+    const calls: Array<{ sourcePath?: string }> = [];
+    const deps = makeDeps({
+      runPatchUpdate: mock(async (opts) => {
+        calls.push({ sourcePath: opts?.sourcePath });
+        return {
+          status: "noop" as const,
+          version: "2.1.119",
+          strategyId: "noop-pre-2.1.120",
+          sourcePath: opts?.sourcePath ?? "/usr/local/bin/claude",
+          sourceHash: "x",
+          reason: "no patch needed",
+        };
+      }),
+    });
+    await cmdClaude(["patch-update", "--source=/abs/claude"], deps);
+    expect(calls[0].sourcePath).toBe("/abs/claude");
+  });
+
+  test("unknown argument exits 1 with a helpful error", async () => {
+    const deps = makeDeps();
+    await expect(cmdClaude(["patch-update", "--bogus"], deps)).rejects.toThrow(ExitError);
+    const errCalls = (deps.printError as Mock<(s: string) => void>).mock.calls.map((c) => c[0]);
+    expect(errCalls.some((s) => s.includes("--bogus"))).toBe(true);
   });
 });

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -25,6 +25,7 @@ import {
   readWorktreeConfig,
   resolveModelName,
   resolveWorktreePath,
+  updatePatchedClaude,
 } from "@mcp-cli/core";
 import { getStaleDaemonWarning, ipcCall } from "../daemon-lifecycle";
 import { applyJqFilter } from "../jq/index";
@@ -78,6 +79,8 @@ export interface ClaudeDeps extends SharedSessionDeps {
    * mail arrival alongside session events.
    */
   pollMail: (recipient: string) => Promise<MailMessage | null>;
+  /** Patcher entry point. Overridden in tests to avoid real codesign. */
+  runPatchUpdate: typeof updatePatchedClaude;
 }
 
 /**
@@ -200,6 +203,7 @@ export const defaultDeps: ClaudeDeps = {
     };
     return result.messages[0] ?? null;
   },
+  runPatchUpdate: updatePatchedClaude,
 };
 
 // ── Entry point ──
@@ -289,9 +293,12 @@ async function cmdClaudeInternal(args: string[], deps?: Partial<ClaudeDeps>): Pr
     case "deny":
       await claudeDeny(subArgs, d);
       break;
+    case "patch-update":
+      await claudePatchUpdate(subArgs, d);
+      break;
     default:
       d.printError(
-        `Unknown claude subcommand: ${sub}. Use "spawn", "resume", "ls", "send", "bye", "interrupt", "log", "wait", "approve", "deny", or "worktrees".`,
+        `Unknown claude subcommand: ${sub}. Use "spawn", "resume", "ls", "send", "bye", "interrupt", "log", "wait", "approve", "deny", "patch-update", or "worktrees".`,
       );
       d.exit(1);
   }
@@ -1241,6 +1248,75 @@ async function claudeDeny(args: string[], d: ClaudeDeps): Promise<void> {
   console.log(formatToolResult(result));
 }
 
+export interface PatchUpdateArgs {
+  force: boolean;
+  json: boolean;
+  sourcePath: string | undefined;
+}
+
+export function parsePatchUpdateArgs(args: string[], d: Pick<ClaudeDeps, "printError" | "exit">): PatchUpdateArgs {
+  let force = false;
+  let json = false;
+  let sourcePath: string | undefined;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--force") force = true;
+    else if (a === "--json") json = true;
+    else if (a === "--source") sourcePath = args[++i];
+    else if (a.startsWith("--source=")) sourcePath = a.slice("--source=".length);
+    else {
+      d.printError(`Unknown argument: ${a}`);
+      d.exit(1);
+    }
+  }
+  return { force, json, sourcePath };
+}
+
+/**
+ * `mcx claude patch-update` — refresh the patched copy of the user's claude
+ * binary so mcx-spawned sessions can connect to the local daemon. See #1808.
+ *
+ * Reads the user's installed claude (resolved via `which claude`), looks up
+ * the matching patch strategy by version, and writes a patched + ad-hoc
+ * re-signed copy under `~/.mcp-cli/claude-patched/`. The user's original
+ * binary is never modified. Idempotent — second call is a no-op.
+ */
+export async function claudePatchUpdate(args: string[], d: ClaudeDeps): Promise<void> {
+  const { force, json, sourcePath } = parsePatchUpdateArgs(args, d);
+
+  let outcome: Awaited<ReturnType<typeof updatePatchedClaude>>;
+  try {
+    outcome = await d.runPatchUpdate({ sourcePath, force });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    d.printError(`patch-update failed: ${msg}`);
+    return d.exit(1);
+  }
+
+  if (json) {
+    console.log(JSON.stringify(outcome, null, 2));
+    return;
+  }
+
+  switch (outcome.status) {
+    case "patched":
+      d.log(`Patched claude ${outcome.version} → ${outcome.patchedPath}`);
+      d.log(`Strategy: ${outcome.strategyId}`);
+      d.log(`Source: ${outcome.sourcePath} (sha256 ${outcome.sourceHash.slice(0, 12)}…)`);
+      break;
+    case "already-current":
+      d.log(`claude ${outcome.version} already patched (${outcome.strategyId}). Use --force to re-patch.`);
+      break;
+    case "noop":
+      d.log(`claude ${outcome.version} needs no patch (${outcome.reason}).`);
+      break;
+    case "unsupported":
+      d.printError(`claude ${outcome.version} is not supported by any registered patch strategy.`);
+      d.printError(outcome.reason);
+      d.exit(2);
+  }
+}
+
 export interface LogArgs {
   sessionPrefix: string | undefined;
   last: number;
@@ -1919,6 +1995,7 @@ Usage:
   mcx claude log <session> --full          Full output (no truncation)
   mcx claude worktrees                     List mcx-created worktrees
   mcx claude worktrees --prune             Remove orphaned worktrees + merged branches
+  mcx claude patch-update                  Refresh the patched copy used for mcx spawns (#1808)
 
 Spawn options:
   --task, -t "description"    Task prompt for Claude

--- a/packages/command/src/help-claude.ts
+++ b/packages/command/src/help-claude.ts
@@ -144,3 +144,23 @@ registerHelp("claude deny", {
     ["--message, -m <reason>", "Denial reason"],
   ],
 });
+
+registerHelp("claude patch-update", {
+  name: "mcx claude patch-update",
+  summary: "Refresh the patched copy of claude used for mcx-spawned sessions (see #1808)",
+  usage: [
+    "mcx claude patch-update",
+    "mcx claude patch-update --force",
+    "mcx claude patch-update --source /path/to/claude",
+    "mcx claude patch-update --json",
+  ],
+  options: [
+    ["--force", "Re-patch even if the cached copy looks current"],
+    ["--source <path>", "Use this binary as the source (default: `which claude`)"],
+    ["--json", "Output the outcome as structured JSON"],
+  ],
+  examples: [
+    "mcx claude patch-update                    # idempotent; runs after every claude auto-update",
+    "mcx claude patch-update --force            # rebuild the patched copy from scratch",
+  ],
+});

--- a/packages/core/src/claude-patch/index.ts
+++ b/packages/core/src/claude-patch/index.ts
@@ -1,0 +1,25 @@
+export {
+  BUILTIN_STRATEGIES,
+  STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1,
+  STRATEGY_NOOP_PRE_2_1_120,
+  compareVersion,
+  countOccurrences,
+  replaceAllBytes,
+  resolveStrategy,
+  type PatchStrategy,
+  type ValidateResult,
+} from "./strategies";
+export {
+  DEFAULT_DEPS,
+  defaultExtractEntitlements,
+  defaultResignBinary,
+  defaultSmokeTest,
+  defaultVersionResolver,
+  readCurrentPatchedMeta,
+  resolveSourceClaudePath,
+  updatePatchedClaude,
+  type PatchedMeta,
+  type PatcherDeps,
+  type UpdateOptions,
+  type UpdateOutcome,
+} from "./patcher";

--- a/packages/core/src/claude-patch/patcher.spec.ts
+++ b/packages/core/src/claude-patch/patcher.spec.ts
@@ -1,0 +1,307 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { copyFileSync, existsSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { sha256Hex } from "../manifest-lock";
+import {
+  defaultExtractEntitlements,
+  defaultResignBinary,
+  defaultSmokeTest,
+  defaultVersionResolver,
+  readCurrentPatchedMeta,
+  resolveSourceClaudePath,
+  updatePatchedClaude,
+} from "./patcher";
+import type { PatcherDeps } from "./patcher";
+
+const enc = new TextEncoder();
+
+function makeFakeDeps(overrides: Partial<PatcherDeps> = {}): PatcherDeps {
+  // Default fake deps that simulate a successful sign+smoke flow without
+  // touching real codesign or spawning claude.
+  return {
+    versionResolver: async () => "2.1.121",
+    extractEntitlements: async () => "<plist><dict/></plist>",
+    resignBinary: async () => {},
+    smokeTest: async () => {},
+    readBytes: (path) => new Uint8Array(readFileSync(path)),
+    writeBytesAtomic: (path, bytes) => {
+      writeFileSync(path, bytes, { mode: 0o755 });
+    },
+    ...overrides,
+  };
+}
+
+function makeFakeClaudeBinary(dir: string, version: string, hostOccurrences = 4): string {
+  const path = join(dir, "fake-claude");
+  // Synthetic binary with the target string at multiple sites, plus filler.
+  const parts: string[] = [`#!fake-claude version=${version}\n`];
+  for (let i = 0; i < hostOccurrences; i++) {
+    parts.push(`...filler${i}...claude-staging.fedstart.com...filler${i}...`);
+  }
+  parts.push("end-of-file");
+  writeFileSync(path, parts.join(""), { mode: 0o755 });
+  return path;
+}
+
+describe("updatePatchedClaude", () => {
+  let tmpDir: string;
+  let storeDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "patcher-test-"));
+    storeDir = join(tmpDir, "store");
+  });
+
+  afterAll(() => {
+    // Best-effort cleanup. Tests use unique tmpdirs so this is mostly a courtesy.
+  });
+
+  test("noop strategy for old versions", async () => {
+    const sourcePath = makeFakeClaudeBinary(tmpDir, "2.1.119");
+    const result = await updatePatchedClaude(
+      { sourcePath, storeDir },
+      makeFakeDeps({ versionResolver: async () => "2.1.119" }),
+    );
+    expect(result.status).toBe("noop");
+    if (result.status !== "noop") throw new Error("typeguard");
+    expect(result.strategyId).toBe("noop-pre-2.1.120");
+    // Store dir should not contain a patched binary.
+    expect(existsSync(join(storeDir, "current"))).toBe(false);
+  });
+
+  test("patches 2.1.121 binary end-to-end", async () => {
+    const sourcePath = makeFakeClaudeBinary(tmpDir, "2.1.121");
+    const result = await updatePatchedClaude({ sourcePath, storeDir }, makeFakeDeps());
+    expect(result.status).toBe("patched");
+    if (result.status !== "patched") throw new Error("typeguard");
+    expect(result.strategyId).toBe("host-check-ipv6-loopback-v1");
+    expect(existsSync(result.patchedPath)).toBe(true);
+    expect(existsSync(result.currentLink)).toBe(true);
+
+    const patched = new Uint8Array(readFileSync(result.patchedPath));
+    const decoded = new TextDecoder().decode(patched);
+    expect(decoded).not.toContain("claude-staging.fedstart.com");
+    expect(decoded.split("[000:000:000:000:000:0:0:1]").length - 1).toBe(4);
+  });
+
+  test("idempotent — second call returns already-current", async () => {
+    const sourcePath = makeFakeClaudeBinary(tmpDir, "2.1.121");
+    const deps = makeFakeDeps();
+    let signCount = 0;
+    deps.resignBinary = async () => {
+      signCount++;
+    };
+    await updatePatchedClaude({ sourcePath, storeDir }, deps);
+    expect(signCount).toBe(1);
+
+    const second = await updatePatchedClaude({ sourcePath, storeDir }, deps);
+    expect(second.status).toBe("already-current");
+    expect(signCount).toBe(1); // didn't re-sign
+  });
+
+  test("force re-patches even when cached", async () => {
+    const sourcePath = makeFakeClaudeBinary(tmpDir, "2.1.121");
+    const deps = makeFakeDeps();
+    let signCount = 0;
+    deps.resignBinary = async () => {
+      signCount++;
+    };
+    await updatePatchedClaude({ sourcePath, storeDir }, deps);
+    await updatePatchedClaude({ sourcePath, storeDir, force: true }, deps);
+    expect(signCount).toBe(2);
+  });
+
+  test("source-hash change triggers re-patch", async () => {
+    const sourcePath = makeFakeClaudeBinary(tmpDir, "2.1.121");
+    const deps = makeFakeDeps();
+    await updatePatchedClaude({ sourcePath, storeDir }, deps);
+
+    // Simulate auto-update by rewriting the source binary.
+    const newContent = `#!new-version\n${"claude-staging.fedstart.com\n".repeat(4)}different-filler-bytes-different-filler-bytes\n`;
+    writeFileSync(sourcePath, newContent, { mode: 0o755 });
+
+    let signCount = 0;
+    deps.resignBinary = async () => {
+      signCount++;
+    };
+    const second = await updatePatchedClaude({ sourcePath, storeDir }, deps);
+    expect(second.status).toBe("patched");
+    expect(signCount).toBe(1);
+  });
+
+  test("unsupported version returns unsupported outcome", async () => {
+    const sourcePath = makeFakeClaudeBinary(tmpDir, "9.9.9");
+    const result = await updatePatchedClaude(
+      { sourcePath, storeDir },
+      makeFakeDeps({ versionResolver: async () => "9.9.9" }),
+    );
+    expect(result.status).toBe("unsupported");
+    if (result.status !== "unsupported") throw new Error("typeguard");
+    expect(result.reason).toMatch(/No patch strategy/);
+    expect(result.reason).toMatch(/9\.9\.9/);
+  });
+
+  test("validation failure aborts the patch", async () => {
+    // Synthetic binary missing the source string — strategy will produce
+    // 0 replacements, validation will reject.
+    const sourcePath = join(tmpDir, "broken-claude");
+    writeFileSync(sourcePath, "no target string here", { mode: 0o755 });
+    const deps = makeFakeDeps({ versionResolver: async () => "2.1.121" });
+    expect(updatePatchedClaude({ sourcePath, storeDir }, deps)).rejects.toThrow(/validation failed/);
+  });
+
+  test("never modifies the source binary", async () => {
+    const sourcePath = makeFakeClaudeBinary(tmpDir, "2.1.121");
+    const beforeBytes = readFileSync(sourcePath);
+    const beforeHash = sha256Hex(new Uint8Array(beforeBytes));
+
+    await updatePatchedClaude({ sourcePath, storeDir }, makeFakeDeps());
+
+    const afterBytes = readFileSync(sourcePath);
+    const afterHash = sha256Hex(new Uint8Array(afterBytes));
+    expect(afterHash).toBe(beforeHash);
+  });
+
+  test("smoke test failure surfaces as error and does not publish", async () => {
+    const sourcePath = makeFakeClaudeBinary(tmpDir, "2.1.121");
+    const deps = makeFakeDeps({
+      smokeTest: async () => {
+        throw new Error("simulated smoke test failure");
+      },
+    });
+    expect(updatePatchedClaude({ sourcePath, storeDir }, deps)).rejects.toThrow(/smoke/);
+    // No metadata or current link should exist after a failed smoke.
+    expect(existsSync(join(storeDir, "current"))).toBe(false);
+    expect(existsSync(join(storeDir, "2.1.121.meta.json"))).toBe(false);
+  });
+});
+
+describe("readCurrentPatchedMeta", () => {
+  test("returns null when store is missing", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "patcher-meta-test-"));
+    expect(readCurrentPatchedMeta(join(tmp, "missing"))).toBeNull();
+  });
+
+  test("returns metadata after a successful update", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "patcher-meta-test-"));
+    const sourcePath = makeFakeClaudeBinary(tmp, "2.1.121");
+    const storeDir = join(tmp, "store");
+    await updatePatchedClaude({ sourcePath, storeDir }, makeFakeDeps());
+    const meta = readCurrentPatchedMeta(storeDir);
+    expect(meta).not.toBeNull();
+    expect(meta?.version).toBe("2.1.121");
+    expect(meta?.strategyId).toBe("host-check-ipv6-loopback-v1");
+    expect(meta?.sourcePath).toBe(sourcePath);
+  });
+
+  test("ignores malformed meta.json (returns null)", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "patcher-meta-test-"));
+    // Write a current symlink/pointer that targets a nonsense meta path.
+    const link = join(tmp, "current");
+    writeFileSync(link, join(tmp, "ghost.patched"), { mode: 0o644 });
+    writeFileSync(join(tmp, "ghost.meta.json"), "{ not valid json", { mode: 0o644 });
+    expect(readCurrentPatchedMeta(tmp)).toBeNull();
+  });
+
+  test("resolves a pointer-file fallback (non-symlink current)", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "patcher-meta-test-"));
+    // Write a pointer file (plain file) as `current` instead of a symlink.
+    writeFileSync(join(tmp, "1.2.3.patched"), "stub", { mode: 0o755 });
+    writeFileSync(
+      join(tmp, "1.2.3.meta.json"),
+      JSON.stringify({
+        version: "1.2.3",
+        strategyId: "test",
+        sourcePath: "/dev/null",
+        sourceHash: "deadbeef",
+        signedAt: "2026-01-01T00:00:00Z",
+      }),
+      { mode: 0o644 },
+    );
+    writeFileSync(join(tmp, "current"), join(tmp, "1.2.3.patched"), { mode: 0o644 });
+    const meta = readCurrentPatchedMeta(tmp);
+    expect(meta?.version).toBe("1.2.3");
+  });
+
+  test("resolves a relative symlink target", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "patcher-meta-test-"));
+    writeFileSync(join(tmp, "2.0.0.patched"), "stub", { mode: 0o755 });
+    writeFileSync(
+      join(tmp, "2.0.0.meta.json"),
+      JSON.stringify({
+        version: "2.0.0",
+        strategyId: "rel",
+        sourcePath: "/dev/null",
+        sourceHash: "abc",
+        signedAt: "2026-01-01T00:00:00Z",
+      }),
+      { mode: 0o644 },
+    );
+    symlinkSync("2.0.0.patched", join(tmp, "current"));
+    expect(readCurrentPatchedMeta(tmp)?.version).toBe("2.0.0");
+  });
+});
+
+// Default subprocess wrappers — exercised against `bun` (always present
+// while these tests run) and `/usr/bin/false` (POSIX standard error binary).
+describe("default subprocess wrappers", () => {
+  test("defaultVersionResolver parses version from `bun --version`", async () => {
+    const v = await defaultVersionResolver(process.execPath);
+    expect(v).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  test("defaultVersionResolver throws on non-zero exit", async () => {
+    expect(defaultVersionResolver("/usr/bin/false")).rejects.toThrow();
+  });
+
+  test("defaultVersionResolver throws on unparseable output", async () => {
+    // /bin/sh -c 'echo hello' exits 0 but emits no version.
+    const tmp = mkdtempSync(join(tmpdir(), "patcher-ver-test-"));
+    const stub = join(tmp, "stub");
+    writeFileSync(stub, "#!/bin/sh\necho 'hello world'\n", { mode: 0o755 });
+    expect(defaultVersionResolver(stub)).rejects.toThrow(/parse version/);
+  });
+
+  test("defaultSmokeTest passes for healthy binary", async () => {
+    await defaultSmokeTest(process.execPath);
+  });
+
+  test("defaultSmokeTest throws on non-zero exit", async () => {
+    expect(defaultSmokeTest("/usr/bin/false")).rejects.toThrow(/smoke test/);
+  });
+
+  test("resolveSourceClaudePath returns string or null", () => {
+    // Either claude is on PATH (returns abs path) or it's not (returns null).
+    // Both branches are valid; we only care that the function runs without throwing
+    // and returns one of the two expected shapes.
+    const result = resolveSourceClaudePath();
+    expect(result === null || (typeof result === "string" && result.length > 0)).toBe(true);
+  });
+});
+
+// codesign-dependent tests run only on macOS (where codesign exists and bun is signed).
+const isDarwin = process.platform === "darwin";
+const macOnly = isDarwin ? describe : describe.skip;
+
+macOnly("codesign integration (macOS only)", () => {
+  test("defaultExtractEntitlements returns a plist or empty string", async () => {
+    // Bun (the binary running this test) is codesigned on macOS distribution.
+    const ent = await defaultExtractEntitlements(process.execPath);
+    // Empty string is acceptable (bun may not declare entitlements); a plist is also fine.
+    expect(typeof ent).toBe("string");
+  });
+
+  test("defaultResignBinary signs a copy of bun successfully", async () => {
+    const tmp = mkdtempSync(join(tmpdir(), "patcher-codesign-test-"));
+    const copy = join(tmp, "bun-copy");
+    copyFileSync(process.execPath, copy);
+    const entPath = join(tmp, "entitlements.plist");
+    writeFileSync(entPath, '<plist version="1.0"><dict/></plist>', { mode: 0o600 });
+    await defaultResignBinary(copy, entPath);
+    // Verify the resigned copy still runs.
+    const r = spawnSync(copy, ["--version"], { encoding: "utf-8", timeout: 10_000 });
+    expect(r.status).toBe(0);
+  });
+});

--- a/packages/core/src/claude-patch/patcher.ts
+++ b/packages/core/src/claude-patch/patcher.ts
@@ -1,0 +1,389 @@
+/**
+ * Patched-claude binary store + orchestration.
+ *
+ * Hard rules (per issue #1808):
+ *  - Never modify the user's installed `claude` binary in place. Always
+ *    copy first; patch + re-sign the copy.
+ *  - The patched copy lives under `~/.mcp-cli/claude-patched/` and has
+ *    sidecar metadata so we can detect when the source has been auto-updated
+ *    (and therefore the patched copy is stale).
+ *  - The strategy registry is the only place version-specific patch logic
+ *    lives. The orchestrator stays version-agnostic.
+ */
+
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { options } from "../constants";
+import { sha256Hex } from "../manifest-lock";
+import { type PatchStrategy, resolveStrategy } from "./strategies";
+
+export interface PatcherDeps {
+  /** Resolve the version of a claude binary. Default: spawn `<bin> --version`. */
+  versionResolver: (binPath: string) => Promise<string>;
+  /** Extract entitlements from a signed Mach-O binary. macOS only. */
+  extractEntitlements: (binPath: string) => Promise<string>;
+  /** Re-sign a binary with an ad-hoc signature using extracted entitlements. macOS only. */
+  resignBinary: (binPath: string, entitlementsPath: string) => Promise<void>;
+  /** Run a smoke test on the patched binary (e.g. `<bin> --version` exits 0). */
+  smokeTest: (binPath: string) => Promise<void>;
+  /** Read source binary bytes. Override in tests. */
+  readBytes: (path: string) => Uint8Array;
+  /** Write patched binary bytes (atomic via temp+rename). Override in tests. */
+  writeBytesAtomic: (path: string, bytes: Uint8Array) => void;
+  /** Strategy registry. Defaults to BUILTIN_STRATEGIES. */
+  strategies?: readonly PatchStrategy[];
+}
+
+export interface UpdateOptions {
+  /** Path to source claude binary. Resolved via `which claude` if omitted. */
+  sourcePath?: string;
+  /** Override the patched-binary store directory. Defaults to options.CLAUDE_PATCHED_DIR. */
+  storeDir?: string;
+  /** Force re-patch even if the cached patched copy looks current. */
+  force?: boolean;
+}
+
+export type UpdateOutcome =
+  | {
+      status: "patched" | "already-current";
+      version: string;
+      strategyId: string;
+      sourcePath: string;
+      sourceHash: string;
+      patchedPath: string;
+      currentLink: string;
+    }
+  | {
+      status: "noop";
+      version: string;
+      strategyId: string;
+      sourcePath: string;
+      sourceHash: string;
+      reason: string;
+    }
+  | {
+      status: "unsupported";
+      version: string;
+      sourcePath: string;
+      sourceHash: string;
+      reason: string;
+    };
+
+export interface PatchedMeta {
+  version: string;
+  strategyId: string;
+  sourcePath: string;
+  sourceHash: string;
+  signedAt: string;
+}
+
+function patchedPathFor(storeDir: string, version: string): string {
+  return join(storeDir, `${version}.patched`);
+}
+
+function metaPathFor(storeDir: string, version: string): string {
+  return join(storeDir, `${version}.meta.json`);
+}
+
+function currentLinkFor(storeDir: string): string {
+  return join(storeDir, "current");
+}
+
+function readMeta(path: string): PatchedMeta | null {
+  if (!existsSync(path)) return null;
+  try {
+    const raw = readFileSync(path, "utf-8");
+    return JSON.parse(raw) as PatchedMeta;
+  } catch {
+    return null;
+  }
+}
+
+function writeMeta(path: string, meta: PatchedMeta): void {
+  writeFileSync(path, JSON.stringify(meta, null, 2), { mode: 0o644 });
+}
+
+/**
+ * Update the symlink at `linkPath` to point to `target` atomically.
+ * Atomic rename via temp symlink — works on POSIX; on platforms without
+ * symlink support this falls back to a pointer file containing the path.
+ */
+function updateCurrentLink(linkPath: string, target: string): void {
+  const tmp = `${linkPath}.tmp.${process.pid}`;
+  // Best-effort cleanup of any stale temp from a crashed previous run.
+  try {
+    rmSync(tmp, { force: true });
+  } catch {
+    // ignore
+  }
+  try {
+    symlinkSync(target, tmp);
+    renameSync(tmp, linkPath);
+  } catch {
+    // Symlink may fail on some filesystems; fall back to a plain pointer file.
+    writeFileSync(tmp, target, { mode: 0o644 });
+    renameSync(tmp, linkPath);
+  }
+}
+
+/**
+ * Default version resolver: spawn `<binPath> --version`, expect "X.Y.Z (...)" or similar.
+ */
+export async function defaultVersionResolver(binPath: string): Promise<string> {
+  const result = spawnSync(binPath, ["--version"], { encoding: "utf-8", timeout: 10_000 });
+  if (result.status !== 0) {
+    throw new Error(`${binPath} --version exited ${result.status}: ${result.stderr || result.stdout}`);
+  }
+  const out = (result.stdout || "").trim();
+  // Match the leading version token; tolerate suffixes like "(Claude Code)".
+  const m = out.match(/^(\d+(?:\.\d+){1,3})/);
+  if (!m) throw new Error(`Could not parse version from: ${out}`);
+  return m[1];
+}
+
+/**
+ * Extract entitlements from a signed Mach-O binary into an XML plist string.
+ * Wraps `codesign -d --entitlements :- <bin>`. macOS only.
+ */
+export async function defaultExtractEntitlements(binPath: string): Promise<string> {
+  const result = spawnSync("codesign", ["-d", "--entitlements", ":-", binPath], {
+    encoding: "utf-8",
+    timeout: 10_000,
+  });
+  // codesign writes the plist to stdout. Empty stdout is acceptable (no entitlements).
+  if (result.status !== 0) {
+    const stderr = result.stderr || "";
+    // codesign sometimes returns non-zero with the plist still on stdout; allow that.
+    if (!result.stdout) {
+      throw new Error(`codesign -d failed: ${stderr.trim() || `exit ${result.status}`}`);
+    }
+  }
+  return result.stdout || "";
+}
+
+/**
+ * Re-sign a binary with an ad-hoc signature, preserving entitlements.
+ * Wraps `codesign --force --sign - --options=runtime --entitlements <plist> <bin>`.
+ */
+export async function defaultResignBinary(binPath: string, entitlementsPath: string): Promise<void> {
+  const result = spawnSync(
+    "codesign",
+    ["--force", "--sign", "-", "--options=runtime", "--entitlements", entitlementsPath, binPath],
+    { encoding: "utf-8", timeout: 30_000 },
+  );
+  if (result.status !== 0) {
+    throw new Error(`codesign --force failed: ${result.stderr.trim() || `exit ${result.status}`}`);
+  }
+}
+
+/**
+ * Run `<binPath> --version` and assert exit 0. Catches the common "ad-hoc
+ * signing wrong on this filesystem / wrong arch" failure modes before we
+ * commit the patched copy.
+ */
+export async function defaultSmokeTest(binPath: string): Promise<void> {
+  const result = spawnSync(binPath, ["--version"], { encoding: "utf-8", timeout: 10_000 });
+  if (result.status !== 0) {
+    throw new Error(`smoke test failed: ${binPath} --version exited ${result.status}`);
+  }
+}
+
+export const DEFAULT_DEPS: PatcherDeps = {
+  versionResolver: defaultVersionResolver,
+  extractEntitlements: defaultExtractEntitlements,
+  resignBinary: defaultResignBinary,
+  smokeTest: defaultSmokeTest,
+  readBytes: (path) => new Uint8Array(readFileSync(path)),
+  writeBytesAtomic: (path, bytes) => {
+    const tmp = `${path}.tmp.${process.pid}`;
+    writeFileSync(tmp, bytes, { mode: 0o755 });
+    renameSync(tmp, path);
+  },
+};
+
+/**
+ * Resolve the path to the user's installed claude binary by spawning `which claude`.
+ * Returns null if claude is not on PATH.
+ */
+export function resolveSourceClaudePath(): string | null {
+  const r = spawnSync("which", ["claude"], { encoding: "utf-8", timeout: 5_000 });
+  if (r.status !== 0) return null;
+  const path = (r.stdout || "").trim();
+  return path || null;
+}
+
+/**
+ * Update the patched-claude store: detect the user's claude version, look
+ * up the matching strategy, copy + patch + re-sign if needed. Idempotent.
+ *
+ * Never modifies the source binary. The source path is opened read-only.
+ */
+export async function updatePatchedClaude(
+  opts: UpdateOptions = {},
+  depsOverride: Partial<PatcherDeps> = {},
+): Promise<UpdateOutcome> {
+  const deps: PatcherDeps = { ...DEFAULT_DEPS, ...depsOverride };
+  const sourcePath = opts.sourcePath ?? resolveSourceClaudePath();
+  if (!sourcePath) {
+    throw new Error("Could not locate `claude` on PATH. Set sourcePath or install Claude Code.");
+  }
+  if (!existsSync(sourcePath)) {
+    throw new Error(`Source claude binary not found: ${sourcePath}`);
+  }
+  const storeDir = opts.storeDir ?? options.CLAUDE_PATCHED_DIR;
+  mkdirSync(storeDir, { recursive: true });
+
+  const sourceBytes = deps.readBytes(sourcePath);
+  const sourceHash = sha256Hex(sourceBytes);
+  const version = await deps.versionResolver(sourcePath);
+
+  const strategy = resolveStrategy(version, deps.strategies);
+  if (!strategy) {
+    return {
+      status: "unsupported",
+      version,
+      sourcePath,
+      sourceHash,
+      reason: `No patch strategy registered for claude ${version}. File an issue at https://github.com/theshadow27/mcp-cli/issues with the version and the output of \`claude --version\`.`,
+    };
+  }
+
+  // Noop strategies don't write anything to the store — they signal that the
+  // caller should just spawn the source binary directly.
+  if (strategy.id.startsWith("noop")) {
+    return {
+      status: "noop",
+      version,
+      strategyId: strategy.id,
+      sourcePath,
+      sourceHash,
+      reason: strategy.description,
+    };
+  }
+
+  const patchedPath = patchedPathFor(storeDir, version);
+  const metaPath = metaPathFor(storeDir, version);
+  const linkPath = currentLinkFor(storeDir);
+
+  // Idempotency: if the cached patched copy matches this source, skip.
+  if (!opts.force) {
+    const existing = readMeta(metaPath);
+    if (
+      existing &&
+      existing.sourceHash === sourceHash &&
+      existing.strategyId === strategy.id &&
+      existsSync(patchedPath)
+    ) {
+      // Refresh the current link in case it drifted.
+      updateCurrentLink(linkPath, patchedPath);
+      return {
+        status: "already-current",
+        version,
+        strategyId: strategy.id,
+        sourcePath,
+        sourceHash,
+        patchedPath,
+        currentLink: linkPath,
+      };
+    }
+  }
+
+  // Apply the strategy.
+  const patched = strategy.apply(sourceBytes);
+  if (patched.length !== sourceBytes.length) {
+    throw new Error(
+      `strategy ${strategy.id} produced ${patched.length} bytes from ${sourceBytes.length} (must be length-preserving)`,
+    );
+  }
+  const validation = strategy.validate(patched);
+  if (!validation.ok) {
+    throw new Error(`strategy ${strategy.id} validation failed: ${validation.reason}`);
+  }
+
+  // Write the patched bytes, then re-sign.
+  deps.writeBytesAtomic(patchedPath, patched);
+  chmodSync(patchedPath, 0o755);
+
+  // Extract entitlements from the source (must be done before re-signing the copy,
+  // since codesign reads them off the source's existing signature).
+  const entitlements = await deps.extractEntitlements(sourcePath);
+  const entPath = join(tmpdir(), `mcx-entitlements-${process.pid}-${Date.now()}.plist`);
+  writeFileSync(entPath, entitlements, { mode: 0o600 });
+  try {
+    await deps.resignBinary(patchedPath, entPath);
+  } finally {
+    try {
+      rmSync(entPath, { force: true });
+    } catch {
+      // ignore
+    }
+  }
+
+  // Smoke test before publishing.
+  await deps.smokeTest(patchedPath);
+
+  // Write metadata + update current link last (atomicity: if anything above
+  // fails, the previous current link still points at the previous patched copy).
+  const meta: PatchedMeta = {
+    version,
+    strategyId: strategy.id,
+    sourcePath,
+    sourceHash,
+    signedAt: new Date().toISOString(),
+  };
+  writeMeta(metaPath, meta);
+  updateCurrentLink(linkPath, patchedPath);
+
+  return {
+    status: "patched",
+    version,
+    strategyId: strategy.id,
+    sourcePath,
+    sourceHash,
+    patchedPath,
+    currentLink: linkPath,
+  };
+}
+
+/**
+ * Read the metadata for the currently-active patched binary, if any.
+ * Returns null if no patched copy is registered (caller should spawn the
+ * source binary directly, falling back to the failure mode in #1808).
+ */
+export function readCurrentPatchedMeta(storeDir?: string): PatchedMeta | null {
+  const dir = storeDir ?? options.CLAUDE_PATCHED_DIR;
+  const link = currentLinkFor(dir);
+  if (!existsSync(link)) return null;
+
+  // Resolve the link to the patched binary, then look up its sibling meta.json.
+  let target: string;
+  try {
+    const stat = lstatSync(link);
+    if (stat.isSymbolicLink()) {
+      target = readlinkSync(link);
+      if (!target.startsWith("/")) target = join(dirname(link), target);
+    } else {
+      // Pointer file fallback (see updateCurrentLink).
+      target = readFileSync(link, "utf-8").trim();
+    }
+  } catch {
+    return null;
+  }
+
+  // The patched binary is named "<version>.patched"; meta is "<version>.meta.json".
+  const base = target.replace(/\.patched$/, "");
+  return readMeta(`${base}.meta.json`);
+}

--- a/packages/core/src/claude-patch/strategies.spec.ts
+++ b/packages/core/src/claude-patch/strategies.spec.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from "bun:test";
+import {
+  BUILTIN_STRATEGIES,
+  STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1,
+  STRATEGY_NOOP_PRE_2_1_120,
+  compareVersion,
+  countOccurrences,
+  replaceAllBytes,
+  resolveStrategy,
+} from "./strategies";
+
+const enc = new TextEncoder();
+
+describe("compareVersion", () => {
+  test("equal versions", () => {
+    expect(compareVersion("2.1.121", "2.1.121")).toBe(0);
+  });
+  test("less / greater on patch", () => {
+    expect(compareVersion("2.1.119", "2.1.120")).toBeLessThan(0);
+    expect(compareVersion("2.1.121", "2.1.120")).toBeGreaterThan(0);
+  });
+  test("less / greater on minor and major", () => {
+    expect(compareVersion("2.0.99", "2.1.0")).toBeLessThan(0);
+    expect(compareVersion("3.0.0", "2.99.99")).toBeGreaterThan(0);
+  });
+  test("missing segments treated as zero", () => {
+    expect(compareVersion("2", "2.0.0")).toBe(0);
+    expect(compareVersion("2.1", "2.1.0")).toBe(0);
+  });
+});
+
+describe("countOccurrences / replaceAllBytes", () => {
+  test("counts non-overlapping occurrences", () => {
+    const buf = enc.encode("aaaaaa");
+    expect(countOccurrences(buf, enc.encode("aa"))).toBe(3);
+  });
+  test("replaces all occurrences", () => {
+    const buf = enc.encode("foo bar foo bar foo");
+    const out = replaceAllBytes(buf, enc.encode("foo"), enc.encode("XYZ"));
+    expect(new TextDecoder().decode(out)).toBe("XYZ bar XYZ bar XYZ");
+  });
+  test("rejects length mismatch", () => {
+    expect(() => replaceAllBytes(enc.encode("hi"), enc.encode("h"), enc.encode("hi"))).toThrow();
+  });
+  test("does not mutate input", () => {
+    const buf = enc.encode("foo");
+    const original = new Uint8Array(buf);
+    replaceAllBytes(buf, enc.encode("foo"), enc.encode("bar"));
+    expect(buf).toEqual(original);
+  });
+});
+
+describe("STRATEGY_NOOP_PRE_2_1_120", () => {
+  test("matches versions below 2.1.120", () => {
+    expect(STRATEGY_NOOP_PRE_2_1_120.matches("2.1.119")).toBe(true);
+    expect(STRATEGY_NOOP_PRE_2_1_120.matches("2.1.91")).toBe(true);
+    expect(STRATEGY_NOOP_PRE_2_1_120.matches("1.99.99")).toBe(true);
+  });
+  test("does not match 2.1.120+", () => {
+    expect(STRATEGY_NOOP_PRE_2_1_120.matches("2.1.120")).toBe(false);
+    expect(STRATEGY_NOOP_PRE_2_1_120.matches("2.1.121")).toBe(false);
+  });
+  test("apply returns input unchanged (copy)", () => {
+    const buf = enc.encode("hello world");
+    const out = STRATEGY_NOOP_PRE_2_1_120.apply(buf);
+    expect(out).toEqual(buf);
+    expect(out).not.toBe(buf); // new buffer, not same reference
+  });
+  test("validate is always ok", () => {
+    expect(STRATEGY_NOOP_PRE_2_1_120.validate(new Uint8Array(0)).ok).toBe(true);
+  });
+});
+
+describe("STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1", () => {
+  test("matches 2.1.120 and 2.1.121", () => {
+    expect(STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1.matches("2.1.120")).toBe(true);
+    expect(STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1.matches("2.1.121")).toBe(true);
+  });
+  test("does not match earlier or later versions", () => {
+    expect(STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1.matches("2.1.119")).toBe(false);
+    expect(STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1.matches("2.1.122")).toBe(false);
+    expect(STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1.matches("2.2.0")).toBe(false);
+  });
+  test("apply replaces all 4 occurrences in a synthetic buffer", () => {
+    const synthetic = enc.encode(
+      "prefix...claude-staging.fedstart.com...middle...claude-staging.fedstart.com...more...claude-staging.fedstart.com...end...claude-staging.fedstart.com...tail",
+    );
+    const out = STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1.apply(synthetic);
+    const decoded = new TextDecoder().decode(out);
+    expect(decoded).not.toContain("claude-staging.fedstart.com");
+    expect(countOccurrences(out, enc.encode("[000:000:000:000:000:0:0:1]"))).toBe(4);
+  });
+  test("apply preserves length", () => {
+    const synthetic = enc.encode(`${"x".repeat(100)}claude-staging.fedstart.com${"y".repeat(100)}`);
+    const out = STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1.apply(synthetic);
+    expect(out.length).toBe(synthetic.length);
+  });
+  test("validate accepts correct count of replacements", () => {
+    const synthetic = enc.encode(`${"[000:000:000:000:000:0:0:1].".repeat(4)}filler`);
+    expect(STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1.validate(synthetic)).toEqual({ ok: true });
+  });
+  test("validate rejects unreplaced source occurrences", () => {
+    const synthetic = enc.encode("claude-staging.fedstart.com left over");
+    const result = STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1.validate(synthetic);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/unreplaced/);
+  });
+  test("validate rejects wrong replacement count", () => {
+    const synthetic = enc.encode("[000:000:000:000:000:0:0:1].".repeat(3));
+    const result = STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1.validate(synthetic);
+    expect(result.ok).toBe(false);
+    expect(result.reason).toMatch(/expected 4/);
+  });
+});
+
+describe("resolveStrategy", () => {
+  test("picks noop for old versions", () => {
+    expect(resolveStrategy("2.1.119")?.id).toBe("noop-pre-2.1.120");
+  });
+  test("picks ipv6 loopback for 2.1.120-2.1.121", () => {
+    expect(resolveStrategy("2.1.120")?.id).toBe("host-check-ipv6-loopback-v1");
+    expect(resolveStrategy("2.1.121")?.id).toBe("host-check-ipv6-loopback-v1");
+  });
+  test("returns null for unsupported newer versions", () => {
+    expect(resolveStrategy("2.1.122")).toBeNull();
+    expect(resolveStrategy("3.0.0")).toBeNull();
+  });
+  test("registry order is first-match-wins", () => {
+    const overlapping = [
+      { ...STRATEGY_NOOP_PRE_2_1_120, id: "first", matches: () => true },
+      { ...STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1, id: "second", matches: () => true },
+    ];
+    expect(resolveStrategy("2.1.121", overlapping)?.id).toBe("first");
+  });
+});
+
+describe("BUILTIN_STRATEGIES", () => {
+  test("includes both built-in strategies", () => {
+    expect(BUILTIN_STRATEGIES).toHaveLength(2);
+    expect(BUILTIN_STRATEGIES.map((s) => s.id)).toEqual(["noop-pre-2.1.120", "host-check-ipv6-loopback-v1"]);
+  });
+});

--- a/packages/core/src/claude-patch/strategies.ts
+++ b/packages/core/src/claude-patch/strategies.ts
@@ -1,0 +1,162 @@
+/**
+ * Patch strategies for the local `claude` binary.
+ *
+ * Background: starting in claude-code 2.1.120, the binary rejects `--sdk-url`
+ * unless the host is in a hardcoded allowlist. mcx spawns claude with a
+ * `--sdk-url` pointing at the local daemon, so post-2.1.120 binaries refuse
+ * to connect. See issue #1808 for the full reverse-engineering report.
+ *
+ * Each strategy is a pure byte transform that's length-preserving (so the
+ * Mach-O layout stays valid pre-resign). The patcher applies the matching
+ * strategy to a *copy* of the source binary — the user's installed claude
+ * is never modified in place.
+ *
+ * Adding a new strategy: append to BUILTIN_STRATEGIES with a `matches`
+ * predicate that's tighter than any later entry. Registry order matters —
+ * the first match wins.
+ */
+
+export interface ValidateResult {
+  ok: boolean;
+  reason?: string;
+}
+
+export interface PatchStrategy {
+  /** Stable identifier persisted in meta.json (e.g. "host-check-ipv6-loopback-v1"). */
+  id: string;
+  /** One-line human description for logs and `mcx claude patch-update` output. */
+  description: string;
+  /** Returns true if this strategy applies to the given claude version. */
+  matches: (version: string) => boolean;
+  /** Length-preserving byte transform. Returns a new buffer; does not mutate input. */
+  apply: (src: Uint8Array) => Uint8Array;
+  /** Sanity-check the patched bytes. Returns { ok: false, reason } on failure. */
+  validate: (patched: Uint8Array) => ValidateResult;
+}
+
+/**
+ * Compare semver-ish version strings (major.minor.patch, no prerelease).
+ * Returns negative/zero/positive like Array.sort. Non-numeric segments
+ * compare as 0 (so "2.1.121" vs "2.1.121-dev" treats both as equal).
+ */
+export function compareVersion(a: string, b: string): number {
+  const pa = a.split(".").map((s) => Number.parseInt(s, 10) || 0);
+  const pb = b.split(".").map((s) => Number.parseInt(s, 10) || 0);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const x = pa[i] ?? 0;
+    const y = pb[i] ?? 0;
+    if (x !== y) return x - y;
+  }
+  return 0;
+}
+
+/** Count non-overlapping byte-string occurrences in a buffer. */
+export function countOccurrences(haystack: Uint8Array, needle: Uint8Array): number {
+  if (needle.length === 0) return 0;
+  let count = 0;
+  let i = 0;
+  outer: while (i <= haystack.length - needle.length) {
+    for (let j = 0; j < needle.length; j++) {
+      if (haystack[i + j] !== needle[j]) {
+        i++;
+        continue outer;
+      }
+    }
+    count++;
+    i += needle.length;
+  }
+  return count;
+}
+
+/** Replace all non-overlapping occurrences of `find` with `replace` (must be equal length). */
+export function replaceAllBytes(buf: Uint8Array, find: Uint8Array, replace: Uint8Array): Uint8Array {
+  if (find.length !== replace.length) {
+    throw new Error(`replaceAllBytes: length mismatch (find=${find.length} replace=${replace.length})`);
+  }
+  const out = new Uint8Array(buf);
+  let i = 0;
+  outer: while (i <= out.length - find.length) {
+    for (let j = 0; j < find.length; j++) {
+      if (out[i + j] !== find[j]) {
+        i++;
+        continue outer;
+      }
+    }
+    out.set(replace, i);
+    i += find.length;
+  }
+  return out;
+}
+
+const enc = new TextEncoder();
+
+/**
+ * Strategy: no-op for versions before the host check was introduced.
+ * 2.1.119 and earlier accept `ws://localhost:...` directly — no patching needed.
+ */
+export const STRATEGY_NOOP_PRE_2_1_120: PatchStrategy = {
+  id: "noop-pre-2.1.120",
+  description: "No patch needed (claude < 2.1.120 accepts --sdk-url with any host).",
+  matches: (version) => compareVersion(version, "2.1.120") < 0,
+  apply: (src) => new Uint8Array(src),
+  validate: () => ({ ok: true }),
+};
+
+/**
+ * Strategy: rewrite the FedStart staging hostname to an IPv6-loopback literal.
+ *
+ * The 5-host allowlist is built at runtime from two sources: two hardcoded
+ * strings (`api.anthropic.com`, `api-staging.anthropic.com`) and three
+ * fedstart origins spread from `sL_` via `new URL(H).hostname`. We replace
+ * `claude-staging.fedstart.com` everywhere it appears (4 sites in 2.1.121:
+ * the source-code `sL_` array literal in two bundled copies, and two
+ * length-prefixed atoms in the binary string table). The replacement
+ * `[000:000:000:000:000:0:0:1]` is the same length (27 bytes) and
+ * canonicalizes to `[::1]` via WHATWG URL parsing.
+ *
+ * Validated end-to-end against 2.1.121 on 2026-04-27: full SDK protocol
+ * round-trip (init → assistant inference → clean close). See issue #1808.
+ */
+export const STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1: PatchStrategy = {
+  id: "host-check-ipv6-loopback-v1",
+  description: "Replace claude-staging.fedstart.com with [000:000:000:000:000:0:0:1] (canonicalizes to [::1]).",
+  matches: (version) => compareVersion(version, "2.1.120") >= 0 && compareVersion(version, "2.1.121") <= 0,
+  apply: (src) => {
+    const find = enc.encode("claude-staging.fedstart.com");
+    const replace = enc.encode("[000:000:000:000:000:0:0:1]");
+    return replaceAllBytes(src, find, replace);
+  },
+  validate: (patched) => {
+    const find = enc.encode("claude-staging.fedstart.com");
+    const replace = enc.encode("[000:000:000:000:000:0:0:1]");
+    const before = countOccurrences(patched, find);
+    const after = countOccurrences(patched, replace);
+    if (before !== 0) {
+      return { ok: false, reason: `${before} unreplaced occurrences of source string remain` };
+    }
+    if (after !== 4) {
+      return { ok: false, reason: `expected 4 replacement occurrences, found ${after}` };
+    }
+    return { ok: true };
+  },
+};
+
+export const BUILTIN_STRATEGIES: readonly PatchStrategy[] = [
+  STRATEGY_NOOP_PRE_2_1_120,
+  STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1,
+];
+
+/**
+ * Resolve the strategy for a given version. Returns null if no built-in
+ * strategy matches — caller should treat as "unsupported, file an issue".
+ */
+export function resolveStrategy(
+  version: string,
+  registry: readonly PatchStrategy[] = BUILTIN_STRATEGIES,
+): PatchStrategy | null {
+  for (const s of registry) {
+    if (s.matches(version)) return s;
+  }
+  return null;
+}

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -130,6 +130,8 @@ const _originalOptions = {
   SPRINT_STATE_PATH: join(MCP_CLI_DIR, "sprint-state.json"),
   /** Directory for site configs, catalogs, and browser profiles */
   SITES_DIR: join(MCP_CLI_DIR, "sites"),
+  /** Directory for patched copies of the user's claude binary (see issue #1808) */
+  CLAUDE_PATCHED_DIR: join(MCP_CLI_DIR, "claude-patched"),
 };
 export const options = { ..._originalOptions };
 export function _restoreOptions(): void {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,3 +51,4 @@ export * from "./phase-source";
 export * from "./mcp-proxy";
 export * from "./bun-version";
 export * from "./sprint-plan";
+export * from "./claude-patch";


### PR DESCRIPTION
## Summary

First slice (components 1–3 of 7) of #1808 — patcher infrastructure + user-facing command. Daemon integration lands in a follow-up.

- **Pluggable strategy registry** (`packages/core/src/claude-patch/strategies.ts`). Built-in entries: `noop-pre-2.1.120` (no patch needed) and `host-check-ipv6-loopback-v1` (replace `claude-staging.fedstart.com` with `[000:000:000:000:000:0:0:1]`, both canonicalize to `[::1]` via WHATWG URL parsing). Adding a new strategy for a future claude release is one append to `BUILTIN_STRATEGIES`.
- **Patcher orchestration** (`packages/core/src/claude-patch/patcher.ts`). Detects `claude --version` → resolves strategy → copies the user's binary to `~/.mcp-cli/claude-patched/<version>.patched` → applies length-preserving byte transform → ad-hoc re-signs with extracted entitlements (`codesign --force --sign - --options=runtime`) → smoke-tests → publishes via atomic `current` symlink. Idempotent (source-sha256 keyed).
- **`mcx claude patch-update`** subcommand — `--force`, `--source <path>`, `--json`. Loud unsupported-version error pointing back to #1808 if no strategy matches.

Hard rules from #1808 honored:
- The user's installed claude is **never modified in place** — patching always works on a copy under `~/.mcp-cli/claude-patched/`.
- Pluggable per-version strategies; default is `unsupported` with telemetry-able error message, not silent failure.
- No sudo, no `/etc/hosts`, no system keychain.

End-to-end validation (in #1808) showed this approach completes the full SDK protocol round-trip against a self-signed `[::1]` listener with `NODE_TLS_REJECT_UNAUTHORIZED=0`.

## Test plan

- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test packages/core/src/claude-patch/` — 46 tests, 78 expects, including:
  - strategy resolution / version-range matching / first-match-wins
  - byte transform length-preservation + validation
  - end-to-end patch on synthetic binary (no real codesign needed)
  - idempotency (no re-sign when source unchanged)
  - source-hash change triggers re-patch
  - `--force` overrides cache
  - source binary never mutated
  - smoke-test failure aborts publish
  - macOS-only: real `codesign` extract + resign of bun copy
- [x] `bun test packages/command/src/commands/claude.spec.ts -t patch-update` — 10 tests covering all subcommand paths (noop, patched, already-current, unsupported, exception, --json, --force, --source, --source=, unknown arg)
- [x] `bun scripts/check-coverage.ts` passes — patcher.ts at 92% lines, strategies.ts at 100%
- [ ] Daemon integration (#1808 components 4–7) follow-up: TLS WS listener on `[::1]`, spawn-target resolution from patched-binary store, `--sdk-url` shape change, auto-update detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)