### PR TITLE
feat(daemon): TLS WSS listener for [::1] (#1808 component 5)

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -132,6 +132,8 @@ const _originalOptions = {
   SITES_DIR: join(MCP_CLI_DIR, "sites"),
   /** Directory for patched copies of the user's claude binary (see issue #1808) */
   CLAUDE_PATCHED_DIR: join(MCP_CLI_DIR, "claude-patched"),
+  /** Directory for self-signed TLS material used by the local WSS listener (see issue #1808) */
+  TLS_DIR: join(MCP_CLI_DIR, "tls"),
 };
 export const options = { ..._originalOptions };
 export function _restoreOptions(): void {

--- a/packages/daemon/src/claude-session/ws-server-tls.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server-tls.spec.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { silentLogger } from "@mcp-cli/core";
+import { ensureSelfSignedCert } from "../tls/self-signed";
+import type { SpawnFn } from "./ws-server";
+import { ClaudeWsServer } from "./ws-server";
+
+// ── Mock spawn (lifted from ws-server.spec.ts to keep this file standalone) ──
+
+function mockSpawn(): {
+  spawn: SpawnFn;
+  killed: boolean;
+  lastCmd: string[];
+  lastOpts: { cwd?: string; env?: Record<string, string | undefined> };
+} {
+  let exitResolve: (code: number) => void = () => {};
+  const state = {
+    spawn: ((cmd: string[], opts: { cwd?: string; env?: Record<string, string | undefined> }) => {
+      state.lastCmd = cmd;
+      state.lastOpts = { cwd: opts?.cwd, env: opts?.env };
+      return {
+        pid: 12345,
+        exited: new Promise<number>((r) => {
+          exitResolve = r;
+        }),
+        kill: () => {
+          state.killed = true;
+          exitResolve(143);
+        },
+      };
+    }) as SpawnFn,
+    killed: false,
+    lastCmd: [] as string[],
+    lastOpts: {} as { cwd?: string; env?: Record<string, string | undefined> },
+  };
+  return state;
+}
+
+describe("ClaudeWsServer (TLS mode, #1808)", () => {
+  let server: ClaudeWsServer | undefined;
+
+  afterEach(() => {
+    server?.stop();
+    server = undefined;
+  });
+
+  test("isTls reports false in plain ws:// mode", async () => {
+    server = new ClaudeWsServer({ spawn: mockSpawn().spawn, logger: silentLogger });
+    expect(server.isTls).toBe(false);
+  });
+
+  test("isTls reports true when tlsConfig is provided", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ws-tls-"));
+    const { cert, key } = ensureSelfSignedCert({ dir, validityDays: 7 });
+    server = new ClaudeWsServer({
+      spawn: mockSpawn().spawn,
+      logger: silentLogger,
+      tlsConfig: { cert, key },
+    });
+    expect(server.isTls).toBe(true);
+  });
+
+  test("plain mode emits ws:// sdk-url and no NODE_TLS_REJECT_UNAUTHORIZED in env", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    const port = await server.start();
+    server.prepareSession("plain-session", { prompt: "hi" });
+    server.spawnClaude("plain-session");
+
+    expect(ms.lastCmd).toContain(`ws://localhost:${port}/session/plain-session`);
+    expect(ms.lastCmd.some((s) => s.startsWith("wss://"))).toBe(false);
+    // Env may be undefined or present without our override.
+    const env = ms.lastOpts.env ?? {};
+    expect(env.NODE_TLS_REJECT_UNAUTHORIZED).toBeUndefined();
+  });
+
+  test("TLS mode emits wss://[::1] sdk-url and sets NODE_TLS_REJECT_UNAUTHORIZED=0", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ws-tls-"));
+    const { cert, key } = ensureSelfSignedCert({ dir, validityDays: 7 });
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({
+      spawn: ms.spawn,
+      logger: silentLogger,
+      tlsConfig: { cert, key },
+    });
+    const port = await server.start();
+    server.prepareSession("tls-session", { prompt: "hi" });
+    server.spawnClaude("tls-session");
+
+    expect(ms.lastCmd).toContain(`wss://[::1]:${port}/session/tls-session`);
+    expect(ms.lastCmd.some((s) => s === `ws://localhost:${port}/session/tls-session`)).toBe(false);
+    const env = ms.lastOpts.env ?? {};
+    expect(env.NODE_TLS_REJECT_UNAUTHORIZED).toBe("0");
+  });
+
+  test("TLS mode binds on [::1] and accepts a wss:// upgrade", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "ws-tls-"));
+    const { cert, key } = ensureSelfSignedCert({ dir, validityDays: 7 });
+    server = new ClaudeWsServer({
+      spawn: mockSpawn().spawn,
+      logger: silentLogger,
+      tlsConfig: { cert, key },
+    });
+    const port = await server.start();
+
+    // Register a session so the server's path-routing matches.
+    server.prepareSession("conn-test", { prompt: "hi" });
+
+    // Subprocess client trusts the cert via NODE_TLS_REJECT_UNAUTHORIZED=0.
+    // Mid-process env mutation is not load-bearing for the Bun WS client in
+    // every code path, so a subprocess gives a deterministic check.
+    const url = `wss://[::1]:${port}/session/conn-test`;
+    const scriptPath = join(dir, "client.ts");
+    writeFileSync(
+      scriptPath,
+      `const ws = new WebSocket(${JSON.stringify(url)});
+const deadline = Date.now() + 4000;
+while (Date.now() < deadline && ws.readyState === WebSocket.CONNECTING) {
+  await Bun.sleep(20);
+}
+if (ws.readyState !== WebSocket.OPEN) {
+  process.stderr.write('readyState=' + ws.readyState + '\\n');
+  process.exit(1);
+}
+ws.close();
+process.stdout.write('OK');
+`,
+    );
+    const proc = Bun.spawn({
+      cmd: ["bun", scriptPath],
+      env: { ...process.env, NODE_TLS_REJECT_UNAUTHORIZED: "0" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("OK");
+    expect(exitCode).toBe(0);
+  });
+
+  test("TLS mode rejects plain ws:// upgrade attempts", async () => {
+    // Sanity: a plain ws client cannot connect to a TLS server. Keeps the
+    // expectation explicit so a misconfigured deployment fails loud.
+    const dir = mkdtempSync(join(tmpdir(), "ws-tls-"));
+    const { cert, key } = ensureSelfSignedCert({ dir, validityDays: 7 });
+    server = new ClaudeWsServer({
+      spawn: mockSpawn().spawn,
+      logger: silentLogger,
+      tlsConfig: { cert, key },
+    });
+    const port = await server.start();
+    server.prepareSession("plain-fail", { prompt: "hi" });
+
+    const url = `ws://[::1]:${port}/session/plain-fail`;
+    const scriptPath = join(dir, "client-plain.ts");
+    writeFileSync(
+      scriptPath,
+      `const ws = new WebSocket(${JSON.stringify(url)});
+const deadline = Date.now() + 2500;
+while (Date.now() < deadline && ws.readyState === WebSocket.CONNECTING) {
+  await Bun.sleep(20);
+}
+process.stdout.write('readyState=' + ws.readyState);
+`,
+    );
+    const proc = Bun.spawn({
+      cmd: ["bun", scriptPath],
+      env: { ...process.env },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+    // Either CLOSED(3) on rejection or stuck CONNECTING(0) past the deadline.
+    expect(stdout).not.toContain("readyState=1");
+  });
+});

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -399,6 +399,16 @@ export class ClaudeWsServer {
   /** Called to forward monitor events to the main thread's EventBus (#1567). */
   onMonitorEvent: ((input: MonitorEventInput) => void) | null = null;
 
+  /**
+   * Optional TLS material. When set, `Bun.serve` runs in HTTPS mode and binds
+   * on `[::1]` instead of the default. Patched-claude (#1808) requires
+   * `wss://` and an IPv6 hostname that maps onto an entry in its allowlist.
+   * When null, the server keeps its previous plain-`ws://` behavior — the
+   * daemon flips this on once it resolves to a patched binary.
+   */
+  private readonly tlsConfig: { cert: string; key: string } | null;
+  private readonly hostname: string | undefined;
+
   constructor(deps?: {
     spawn?: SpawnFn;
     killTimeoutMs?: number;
@@ -408,6 +418,10 @@ export class ClaudeWsServer {
     reclaimIntervalMs?: number;
     connectTimeoutMs?: number;
     stuckConfig?: StuckDetectorConfig;
+    /** Self-signed cert + key. When provided, server runs as wss://. */
+    tlsConfig?: { cert: string; key: string } | null;
+    /** Override the bind hostname. Defaults to `::1` when TLS is set, otherwise unset (Bun default). */
+    hostname?: string;
   }) {
     this.spawn = deps?.spawn ?? defaultSpawn;
     this.killTimeoutMs = deps?.killTimeoutMs ?? KILL_TIMEOUT_MS;
@@ -417,6 +431,13 @@ export class ClaudeWsServer {
     this.reclaimIntervalMs = deps?.reclaimIntervalMs ?? PORT_RECLAIM_INTERVAL_MS;
     this.connectTimeoutMs = deps?.connectTimeoutMs ?? CONNECT_TIMEOUT_MS;
     this.stuckConfig = deps?.stuckConfig ?? DEFAULT_STUCK_CONFIG;
+    this.tlsConfig = deps?.tlsConfig ?? null;
+    this.hostname = deps?.hostname ?? (this.tlsConfig ? "::1" : undefined);
+  }
+
+  /** True when the server is running in TLS (wss://) mode. */
+  get isTls(): boolean {
+    return this.tlsConfig !== null;
   }
 
   /** Current event sequence number (monotonically increasing). */
@@ -428,6 +449,8 @@ export class ClaudeWsServer {
   private createServer(p: number): ReturnType<typeof Bun.serve> {
     return Bun.serve<WsData>({
       port: p,
+      ...(this.hostname !== undefined ? { hostname: this.hostname } : {}),
+      ...(this.tlsConfig ? { tls: this.tlsConfig } : {}),
       fetch: (req, server) => {
         const url = new URL(req.url);
         const match = url.pathname.match(/^\/session\/([^/]+)$/);
@@ -673,10 +696,17 @@ export class ClaudeWsServer {
     const port = this.port;
     if (!port) throw new Error("WS server not started");
 
+    // When TLS is active, the spawn URL must use `wss://` and an IPv6 host
+    // that maps onto a hostname in claude's allowlist (post-2.1.120). The
+    // patcher (#1808) rewrites `claude-staging.fedstart.com` so that the
+    // allowlist contains the canonicalized form of `[::1]`.
+    const sdkUrl = this.tlsConfig
+      ? `wss://[::1]:${port}/session/${sessionId}`
+      : `ws://localhost:${port}/session/${sessionId}`;
     const cmd = [
       "claude",
       "--sdk-url",
-      `ws://localhost:${port}/session/${sessionId}`,
+      sdkUrl,
       "--permission-mode",
       "default",
       "-p",
@@ -718,6 +748,16 @@ export class ClaudeWsServer {
     if (session.config.cwd && session.config.worktree) {
       envOverrides.GIT_DIR = `${session.config.cwd}/.git`;
       envOverrides.GIT_WORK_TREE = session.config.cwd;
+    }
+    // In TLS mode the spawn URL is `wss://[::1]:...` against our self-signed
+    // cert. Bun's WebSocket client doesn't honor NODE_EXTRA_CA_CERTS or per-
+    // request `rejectUnauthorized: false`, so we widen trust globally for the
+    // spawned process. This also disables CA validation for any HTTPS the
+    // spawned claude makes (Anthropic API, web search). Issue #1829 tracks
+    // the strict-mode upgrade that detects when our cert is in the system
+    // keychain and uses `NODE_USE_SYSTEM_CA=1` instead.
+    if (this.tlsConfig) {
+      envOverrides.NODE_TLS_REJECT_UNAUTHORIZED = "0";
     }
     const proc = this.spawn(cmd, {
       cwd: session.config.cwd,

--- a/packages/daemon/src/tls/self-signed.spec.ts
+++ b/packages/daemon/src/tls/self-signed.spec.ts
@@ -1,0 +1,272 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { certPaths, ensureSelfSignedCert, generateSelfSignedCert, isCertFresh, readCachedCert } from "./self-signed";
+
+function freshDir(): string {
+  return mkdtempSync(join(tmpdir(), "tls-test-"));
+}
+
+describe("certPaths", () => {
+  test("derives cert.pem and key.pem under the given dir", () => {
+    const p = certPaths("/some/dir");
+    expect(p.certPath).toBe("/some/dir/cert.pem");
+    expect(p.keyPath).toBe("/some/dir/key.pem");
+  });
+});
+
+describe("generateSelfSignedCert", () => {
+  test("writes cert + key with PEM markers", () => {
+    const dir = freshDir();
+    const m = generateSelfSignedCert(dir, { commonName: "localhost", validityDays: 30 });
+    expect(m.cert).toContain("-----BEGIN CERTIFICATE-----");
+    expect(m.key).toMatch(/-----BEGIN (RSA )?PRIVATE KEY-----/);
+    expect(existsSync(m.certPath)).toBe(true);
+    expect(existsSync(m.keyPath)).toBe(true);
+  });
+
+  test("cert SAN includes ::1, 127.0.0.1, and localhost", () => {
+    const dir = freshDir();
+    const { certPath } = generateSelfSignedCert(dir, {
+      commonName: "localhost",
+      validityDays: 30,
+    });
+    const r = spawnSync("openssl", ["x509", "-in", certPath, "-noout", "-text"], { encoding: "utf-8" });
+    expect(r.status).toBe(0);
+    const out = r.stdout;
+    expect(out).toContain("IP Address:0:0:0:0:0:0:0:1");
+    expect(out).toContain("IP Address:127.0.0.1");
+    expect(out).toContain("DNS:localhost");
+  });
+
+  test("key file is mode 0600", () => {
+    const dir = freshDir();
+    const { keyPath } = generateSelfSignedCert(dir, { commonName: "localhost", validityDays: 30 });
+    const mode = statSync(keyPath).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+});
+
+describe("isCertFresh", () => {
+  test("returns false when file is missing", () => {
+    expect(isCertFresh("/nonexistent/path/cert.pem", 60)).toBe(false);
+  });
+
+  test("returns true for a freshly generated cert with renew window of 1 day", () => {
+    const dir = freshDir();
+    const { certPath } = generateSelfSignedCert(dir, { commonName: "localhost", validityDays: 30 });
+    expect(isCertFresh(certPath, 24 * 60 * 60)).toBe(true);
+  });
+
+  test("returns false when cert is within the renew window", () => {
+    const dir = freshDir();
+    const { certPath } = generateSelfSignedCert(dir, { commonName: "localhost", validityDays: 1 });
+    // A 1-day cert is "expiring within 7 days" → not fresh.
+    expect(isCertFresh(certPath, 7 * 24 * 60 * 60)).toBe(false);
+  });
+
+  test("returns false for unparseable PEM file", () => {
+    const dir = freshDir();
+    const certPath = join(dir, "cert.pem");
+    writeFileSync(certPath, "not actually a cert", { mode: 0o644 });
+    expect(isCertFresh(certPath, 60)).toBe(false);
+  });
+});
+
+describe("ensureSelfSignedCert", () => {
+  test("generates on first call when dir is empty", () => {
+    const dir = freshDir();
+    const m = ensureSelfSignedCert({ dir, validityDays: 30 });
+    expect(m.cert).toContain("-----BEGIN CERTIFICATE-----");
+    expect(existsSync(m.certPath)).toBe(true);
+  });
+
+  test("reuses cached cert on second call (no regeneration)", () => {
+    const dir = freshDir();
+    const first = ensureSelfSignedCert({ dir, validityDays: 30 });
+    const second = ensureSelfSignedCert({ dir, validityDays: 30 });
+    expect(second.cert).toBe(first.cert);
+    expect(second.key).toBe(first.key);
+  });
+
+  test("regenerates when force=true", () => {
+    const dir = freshDir();
+    const first = ensureSelfSignedCert({ dir, validityDays: 30 });
+    const second = ensureSelfSignedCert({ dir, validityDays: 30, force: true });
+    // Self-signed RSA generation produces different keys each call, so cert and key both differ.
+    expect(second.cert).not.toBe(first.cert);
+    expect(second.key).not.toBe(first.key);
+  });
+
+  test("regenerates when cached cert is within the renew window", () => {
+    const dir = freshDir();
+    // First, write a 1-day cert.
+    const first = ensureSelfSignedCert({ dir, validityDays: 1, renewWithinSeconds: 60 });
+    // Then ask for a cert that must be valid for at least 7 days — old one fails the check.
+    const second = ensureSelfSignedCert({ dir, validityDays: 30, renewWithinSeconds: 7 * 24 * 60 * 60 });
+    expect(second.cert).not.toBe(first.cert);
+  });
+
+  test("regenerates when cached cert is unparseable", () => {
+    const dir = freshDir();
+    // Plant garbage that mimics the cached layout.
+    const { certPath, keyPath } = certPaths(dir);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(certPath, "garbage", { mode: 0o644 });
+    writeFileSync(keyPath, "garbage", { mode: 0o600 });
+    const m = ensureSelfSignedCert({ dir, validityDays: 30 });
+    expect(m.cert).toContain("-----BEGIN CERTIFICATE-----");
+  });
+
+  test("rejects renewWithinSeconds <= 0", () => {
+    const dir = freshDir();
+    expect(() => ensureSelfSignedCert({ dir, renewWithinSeconds: 0 })).toThrow();
+    expect(() => ensureSelfSignedCert({ dir, renewWithinSeconds: -1 })).toThrow();
+  });
+});
+
+describe("readCachedCert", () => {
+  test("returns null when no cert is cached", () => {
+    const dir = freshDir();
+    expect(readCachedCert(dir)).toBeNull();
+  });
+
+  test("returns null when only one of cert/key exists", () => {
+    const dir = freshDir();
+    const { certPath } = certPaths(dir);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(certPath, "stub", { mode: 0o644 });
+    expect(readCachedCert(dir)).toBeNull();
+  });
+
+  test("returns material when both files exist", () => {
+    const dir = freshDir();
+    const generated = ensureSelfSignedCert({ dir, validityDays: 30 });
+    const cached = readCachedCert(dir);
+    expect(cached?.cert).toBe(generated.cert);
+    expect(cached?.key).toBe(generated.key);
+  });
+});
+
+describe("integration: Bun.serve TLS handshake on [::1]", () => {
+  // The spawned claude process trusts our loopback cert via
+  // `NODE_TLS_REJECT_UNAUTHORIZED=0`. The cleaner option (NODE_EXTRA_CA_CERTS
+  // additive trust) is not honored by Bun's WebSocket client today —
+  // verified against bun 1.3.13: `WebSocketUpgradeClient.zig:281-306` only
+  // pulls a custom CA from an explicit `ssl_config` constructor option,
+  // and `SSL_CTX_set_default_verify_paths` is never called in the tree.
+  // System-keychain trust + `NODE_USE_SYSTEM_CA=1` is the secure-by-default
+  // upgrade — see issue #1829 for the daemon power-on-self-test that
+  // detects when system trust is in place and prefers it automatically.
+  test("subprocess with NODE_TLS_REJECT_UNAUTHORIZED=0 connects to wss://[::1]", async () => {
+    const dir = freshDir();
+    const { cert, key } = ensureSelfSignedCert({ dir, validityDays: 30 });
+
+    let opened = false;
+    const server = Bun.serve({
+      hostname: "::1",
+      port: 0,
+      tls: { cert, key },
+      fetch(req, srv) {
+        if (srv.upgrade(req)) return;
+        return new Response("ok");
+      },
+      websocket: {
+        open() {
+          opened = true;
+        },
+        message() {},
+        close() {},
+      },
+    });
+    try {
+      const port = server.port as number;
+      const url = `wss://[::1]:${port}/`;
+      const scriptPath = join(dir, "client.ts");
+      writeFileSync(
+        scriptPath,
+        `const ws = new WebSocket(${JSON.stringify(url)});
+const deadline = Date.now() + 4000;
+while (Date.now() < deadline && ws.readyState === WebSocket.CONNECTING) {
+  await Bun.sleep(20);
+}
+if (ws.readyState !== WebSocket.OPEN) {
+  process.stderr.write('readyState=' + ws.readyState + '\\n');
+  process.exit(1);
+}
+ws.close();
+process.stdout.write('OK');
+`,
+      );
+      const proc = Bun.spawn({
+        cmd: ["bun", scriptPath],
+        env: { ...process.env, NODE_TLS_REJECT_UNAUTHORIZED: "0" },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+      expect(stderr).toBe("");
+      expect(stdout).toBe("OK");
+      expect(exitCode).toBe(0);
+      const handlerDeadline = Date.now() + 1_000;
+      while (!opened && Date.now() < handlerDeadline) {
+        await Bun.sleep(20);
+      }
+      expect(opened).toBe(true);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("subprocess without trust override rejects the self-signed cert", async () => {
+    // Negative control: confirms we're actually exercising the trust path
+    // and not accidentally running with a permissive default elsewhere.
+    const dir = freshDir();
+    const { cert, key } = ensureSelfSignedCert({ dir, validityDays: 30 });
+
+    const server = Bun.serve({
+      hostname: "::1",
+      port: 0,
+      tls: { cert, key },
+      fetch(req, srv) {
+        if (srv.upgrade(req)) return;
+        return new Response("ok");
+      },
+      websocket: { open() {}, message() {}, close() {} },
+    });
+    try {
+      const port = server.port as number;
+      const url = `wss://[::1]:${port}/`;
+      const scriptPath = join(dir, "client-negative.ts");
+      writeFileSync(
+        scriptPath,
+        `const ws = new WebSocket(${JSON.stringify(url)});
+const deadline = Date.now() + 4000;
+while (Date.now() < deadline && ws.readyState === WebSocket.CONNECTING) {
+  await Bun.sleep(20);
+}
+process.stdout.write('readyState=' + ws.readyState);
+`,
+      );
+      const { NODE_EXTRA_CA_CERTS: _ignoredExtra, NODE_TLS_REJECT_UNAUTHORIZED: _ignoredReject, ...env } = process.env;
+      const proc = Bun.spawn({
+        cmd: ["bun", scriptPath],
+        env,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
+      // Without the trust override, the client either errors out (CLOSED=3)
+      // or never gets past CONNECTING within the deadline. Either is "not OPEN".
+      expect(stdout).not.toContain("readyState=1");
+    } finally {
+      server.stop(true);
+    }
+  });
+});

--- a/packages/daemon/src/tls/self-signed.ts
+++ b/packages/daemon/src/tls/self-signed.ts
@@ -1,0 +1,192 @@
+/**
+ * Self-signed cert for the local WSS listener (issue #1808).
+ *
+ * mcpd binds a TLS WebSocket on `[::1]` so that mcx-spawned `claude` (which
+ * post-2.1.120 enforces a host allowlist + `wss://`) can reach the daemon
+ * via the patched-binary IPv6-loopback hostname. The cert is purely for
+ * local loopback — never exposed to the network — and is regenerated
+ * automatically when missing or near expiry.
+ *
+ * SANs include `IP:::1`, `IP:127.0.0.1`, and `DNS:localhost` so the same
+ * cert works for any local address the daemon ends up serving on.
+ *
+ * No prod dependency added: shells out to `openssl`, which ships with macOS
+ * and is available on every CI image we run on. If `openssl` is missing,
+ * `ensureSelfSignedCert` throws a clear actionable error.
+ */
+
+import { spawnSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { options } from "@mcp-cli/core";
+
+/** Result of a successful certificate ensure call. */
+export interface SelfSignedMaterial {
+  cert: string;
+  key: string;
+  certPath: string;
+  keyPath: string;
+}
+
+export interface EnsureOptions {
+  /** Override the directory where the cert+key are cached. Default: `options.TLS_DIR`. */
+  dir?: string;
+  /** Force regeneration even if a valid cert is on disk. */
+  force?: boolean;
+  /** Common name for the cert subject. Default: "localhost". */
+  commonName?: string;
+  /** Cert lifetime in days (`-days` flag to `openssl req`). Default: 365. */
+  validityDays?: number;
+  /**
+   * Regenerate if the cached cert expires within this many seconds. Default:
+   * 7 days. Tuned so daemon restarts don't churn certs but auto-rotation
+   * happens before any real-world expiry pain. Lower bound enforced by the
+   * test suite (must be > 0).
+   */
+  renewWithinSeconds?: number;
+}
+
+const DEFAULT_RENEW_WITHIN_SECONDS = 7 * 24 * 60 * 60;
+const DEFAULT_VALIDITY_DAYS = 365;
+const DEFAULT_COMMON_NAME = "localhost";
+
+/**
+ * Resolve the cert paths for a given dir. Exported for tests / consumers
+ * that need to point Bun.serve at the on-disk PEM files.
+ */
+export function certPaths(dir: string): { certPath: string; keyPath: string } {
+  return {
+    certPath: join(dir, "cert.pem"),
+    keyPath: join(dir, "key.pem"),
+  };
+}
+
+/** Throws if `openssl` is not on PATH. */
+function assertOpensslAvailable(): void {
+  const r = spawnSync("openssl", ["version"], { encoding: "utf-8", timeout: 5_000 });
+  if (r.status !== 0) {
+    throw new Error(
+      "openssl is required for the local WSS listener but was not found on PATH. " +
+        "Install via your package manager (e.g. `brew install openssl`) and retry.",
+    );
+  }
+}
+
+/**
+ * Returns true if the cert at `certPath` exists, parses, and won't expire
+ * within `renewWithinSeconds`. Any failure is treated as "needs regeneration".
+ */
+export function isCertFresh(certPath: string, renewWithinSeconds: number): boolean {
+  if (!existsSync(certPath)) return false;
+  // `openssl x509 -checkend <secs>` exits 0 if cert NOT expiring within that window.
+  const r = spawnSync("openssl", ["x509", "-checkend", String(renewWithinSeconds), "-noout", "-in", certPath], {
+    encoding: "utf-8",
+    timeout: 5_000,
+  });
+  return r.status === 0;
+}
+
+/**
+ * Generate a fresh self-signed cert + key into `dir`. Overwrites existing
+ * files. Returns the on-disk PEM contents alongside their paths.
+ */
+export function generateSelfSignedCert(
+  dir: string,
+  opts: Required<Pick<EnsureOptions, "commonName" | "validityDays">>,
+): SelfSignedMaterial {
+  assertOpensslAvailable();
+  mkdirSync(dir, { recursive: true });
+  const { certPath, keyPath } = certPaths(dir);
+
+  // SANs cover both loopback IPs and the canonical hostname. ``-addext`` lets
+  // us emit them inline without an external openssl.cnf.
+  const args = [
+    "req",
+    "-x509",
+    "-newkey",
+    "rsa:2048",
+    "-nodes",
+    "-keyout",
+    keyPath,
+    "-out",
+    certPath,
+    "-days",
+    String(opts.validityDays),
+    "-subj",
+    `/CN=${opts.commonName}`,
+    "-addext",
+    "subjectAltName=IP:::1,IP:127.0.0.1,DNS:localhost",
+  ];
+
+  const r = spawnSync("openssl", args, { encoding: "utf-8", timeout: 30_000 });
+  if (r.status !== 0) {
+    throw new Error(`openssl req failed: ${r.stderr.trim() || `exit ${r.status}`}`);
+  }
+
+  // Restrict key permissions even though it's only loopback material — the
+  // file ends up in `~/.mcp-cli/tls/key.pem` and we don't want bystander
+  // processes reading it.
+  try {
+    chmodSync(keyPath, 0o600);
+    chmodSync(certPath, 0o644);
+  } catch {
+    // chmod is best-effort; on platforms where it fails the file is still
+    // usable via the same user.
+  }
+
+  const cert = readFileSync(certPath, "utf-8");
+  const key = readFileSync(keyPath, "utf-8");
+  return { cert, key, certPath, keyPath };
+}
+
+/**
+ * Idempotently make sure a usable self-signed cert exists in `dir`. If the
+ * cached cert is missing, unparseable, or about to expire, a new one is
+ * generated. The returned object is suitable for direct use as the `tls`
+ * field of `Bun.serve`.
+ */
+export function ensureSelfSignedCert(opts: EnsureOptions = {}): SelfSignedMaterial {
+  const dir = opts.dir ?? options.TLS_DIR;
+  const renewWithinSeconds = opts.renewWithinSeconds ?? DEFAULT_RENEW_WITHIN_SECONDS;
+  const commonName = opts.commonName ?? DEFAULT_COMMON_NAME;
+  const validityDays = opts.validityDays ?? DEFAULT_VALIDITY_DAYS;
+  if (renewWithinSeconds <= 0) {
+    throw new Error(`renewWithinSeconds must be > 0, got ${renewWithinSeconds}`);
+  }
+
+  mkdirSync(dir, { recursive: true });
+  const { certPath, keyPath } = certPaths(dir);
+
+  if (!opts.force && existsSync(keyPath) && isCertFresh(certPath, renewWithinSeconds)) {
+    return {
+      cert: readFileSync(certPath, "utf-8"),
+      key: readFileSync(keyPath, "utf-8"),
+      certPath,
+      keyPath,
+    };
+  }
+
+  return generateSelfSignedCert(dir, { commonName, validityDays });
+}
+
+/**
+ * Read and return the cached cert without regenerating. Returns null when
+ * the cert is missing or unparseable. Useful for callers that only want to
+ * use a cert if one already exists (e.g. a status command that doesn't want
+ * to silently provision one).
+ */
+export function readCachedCert(dir?: string): SelfSignedMaterial | null {
+  const resolved = dir ?? options.TLS_DIR;
+  const { certPath, keyPath } = certPaths(resolved);
+  if (!existsSync(certPath) || !existsSync(keyPath)) return null;
+  try {
+    return {
+      cert: readFileSync(certPath, "utf-8"),
+      key: readFileSync(keyPath, "utf-8"),
+      certPath,
+      keyPath,
+    };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Component 5 of #1808 — adds the cert-generation infra and opt-in TLS support to `ClaudeWsServer` so mcpd can serve `wss://[::1]:<port>/session/<id>` against a self-signed loopback cert. Required because patched-claude (#1808) only accepts `--sdk-url` whose host is in its allowlist *and* whose scheme is `wss://` / `https://`.

- **`packages/daemon/src/tls/self-signed.ts`** — `ensureSelfSignedCert()` shells out to `openssl req` to generate cert+key under `~/.mcp-cli/tls/`, cached and idempotent. SAN: `IP:::1, IP:127.0.0.1, DNS:localhost`. Auto-rotates inside a 7-day renew window. No new prod dep — `openssl` is on every dev machine + CI image we use.
- **`ClaudeWsServer`** — new optional `tlsConfig: { cert, key }` constructor arg. When set, `Bun.serve` runs in TLS mode bound on `::1`, the spawn URL becomes `wss://[::1]:<port>/...`, and `NODE_TLS_REJECT_UNAUTHORIZED=0` is added to the spawn env. When unset, every existing code path is bit-identical to before.

The `NODE_TLS_REJECT_UNAUTHORIZED=0` choice is deliberate-but-imperfect: Bun's WS client doesn't honor `NODE_EXTRA_CA_CERTS` (verified against bun 1.3.13 — `WebSocketUpgradeClient.zig:281-306` only reads CA from an explicit `ssl_config`, and `SSL_CTX_set_default_verify_paths` is never called in the tree). **Issue #1829** tracks the strict-mode upgrade: detect when the cert is in the system keychain via daemon power-on-self-test and prefer `NODE_USE_SYSTEM_CA=1` so Anthropic API + web search keep full validation.

## What this PR does NOT do

- Does not flip TLS on for any caller — `ClaudeWsServer` defaults to plain `ws://localhost` mode unchanged. Daemon wiring (which sessions get TLS, gated on patched-binary detection per #1808 component 4+6) ships separately so this PR's blast radius is contained.

## Test plan

- [x] `bun typecheck` clean
- [x] `bun lint` clean (no `setTimeout`-as-wait, no shell interpolation)
- [x] `bun scripts/check-coverage.ts` passes
- [x] `bun test ./packages/daemon/src/tls/` — 19 cases:
  - cert+key PEM markers, SAN contents (`IP Address:0:0:0:0:0:0:0:1`, `IP Address:127.0.0.1`, `DNS:localhost`), 0600 key mode
  - `isCertFresh` for fresh / expired / unparseable / missing
  - `ensureSelfSignedCert` first-call generation, idempotent reuse, force re-gen, renew-window re-gen, unparseable re-gen, validation guards
  - `readCachedCert` paths
  - subprocess integration: `wss://[::1]` handshake completes with `NODE_TLS_REJECT_UNAUTHORIZED=0`; without trust override the same handshake is rejected (negative control)
- [x] `bun test ./packages/daemon/src/claude-session/ws-server-tls.spec.ts` — 6 cases covering `isTls` flag, spawn URL shape (plain vs TLS), env override presence/absence, `[::1]` binding accepts wss://, plain ws:// rejected against TLS server
- [x] Existing `ws-server.spec.ts` — 153 cases all green (no regressions in plain-mode behavior)

## Followups

- #1829 — daemon power-on-self-test: prefer `NODE_USE_SYSTEM_CA=1` over `NODE_TLS_REJECT_UNAUTHORIZED=0` when our cert is system-trusted
- Daemon wiring (component 4 + 6 of #1808): spawn-target resolution from the patched-binary store + flipping `tlsConfig` on at session boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)