### PR TITLE
fix(pr): surface gh pr view failures immediately during --wait polling (fixes #1822)

### DIFF
--- a/packages/command/src/commands/pr.spec.ts
+++ b/packages/command/src/commands/pr.spec.ts
@@ -173,6 +173,36 @@ describe("prMerge", () => {
     expect(errors.some((e) => e.includes("timed out"))).toBe(true);
   });
 
+  test("--wait exits immediately on gh pr view failure", async () => {
+    const errors: string[] = [];
+    const deps = makeDeps({
+      exec: (cmd) => {
+        if (cmd.includes("view")) return { stdout: "", stderr: "auth failure", exitCode: 1 };
+        return { stdout: "", stderr: "", exitCode: 0 };
+      },
+      printError: (m) => errors.push(m),
+    });
+    const err = await prMerge(["1", "--wait"], deps).catch((e) => e);
+    expect(err).toBeInstanceOf(ExitError);
+    expect((err as ExitError).code).toBe(1);
+    expect(errors.some((e) => e.includes("auth failure"))).toBe(true);
+  });
+
+  test("--wait exits immediately on gh pr view failure (no stderr)", async () => {
+    const errors: string[] = [];
+    const deps = makeDeps({
+      exec: (cmd) => {
+        if (cmd.includes("view")) return { stdout: "", stderr: "", exitCode: 2 };
+        return { stdout: "", stderr: "", exitCode: 0 };
+      },
+      printError: (m) => errors.push(m),
+    });
+    const err = await prMerge(["1", "--wait"], deps).catch((e) => e);
+    expect(err).toBeInstanceOf(ExitError);
+    expect((err as ExitError).code).toBe(2);
+    expect(errors.some((e) => e.includes("exited with code 2"))).toBe(true);
+  });
+
   test("--wait exits nonzero when PR is closed", async () => {
     const errors: string[] = [];
     const deps = makeDeps({

--- a/packages/command/src/commands/pr.ts
+++ b/packages/command/src/commands/pr.ts
@@ -131,28 +131,27 @@ export async function prMerge(args: string[], deps: Partial<PrDeps> = {}): Promi
   // Poll until PR reaches MERGED state
   const deadline = Date.now() + parsed.timeout;
   while (Date.now() < deadline) {
-    const { stdout: state, exitCode: viewExit } = d.exec([
-      "gh",
-      "pr",
-      "view",
-      prNum,
-      "--json",
-      "state",
-      "-q",
-      ".state",
-    ]);
+    const {
+      stdout: state,
+      stderr: viewStderr,
+      exitCode: viewExit,
+    } = d.exec(["gh", "pr", "view", prNum, "--json", "state", "-q", ".state"]);
 
-    if (viewExit === 0) {
-      const upper = state.toUpperCase();
-      if (upper === "MERGED") {
-        console.error(`PR #${prNum} merged.`);
-        return;
-      }
-      if (upper === "CLOSED") {
-        d.printError(`PR #${prNum} was closed without merging.`);
-        d.exit(1);
-        return;
-      }
+    if (viewExit !== 0) {
+      d.printError(viewStderr || `gh pr view exited with code ${viewExit}`);
+      d.exit(viewExit);
+      return;
+    }
+
+    const upper = state.toUpperCase();
+    if (upper === "MERGED") {
+      console.error(`PR #${prNum} merged.`);
+      return;
+    }
+    if (upper === "CLOSED") {
+      d.printError(`PR #${prNum} was closed without merging.`);
+      d.exit(1);
+      return;
     }
 
     const remaining = deadline - Date.now();


### PR DESCRIPTION
## Summary
- `gh pr view` non-zero exits during `--wait` polling were silently swallowed, causing the loop to run until the full timeout before reporting a generic timeout error
- Now destructures `stderr` from the view exec call and exits immediately with the original error message and exit code when `viewExit !== 0`
- Covers auth failures, network errors, bad PR numbers, rate limiting — any non-zero `gh pr view` exit

## Test plan
- [x] Added `--wait exits immediately on gh pr view failure` — verifies exit code and error message propagation (stderr case)
- [x] Added `--wait exits immediately on gh pr view failure (no stderr)` — verifies fallback message when stderr is empty
- [x] All 22 pr-spec tests pass
- [x] Full test suite passes (2 pre-existing offline integration test failures in `remote-helper.integration.spec.ts`, unrelated)
- [x] `bun typecheck` + `bun lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)