### PR TITLE
fix(monitor): rename copilot.inline_posted → pr.review_comment_posted (fixes #1737)

### DIFF
--- a/packages/core/src/monitor-event.ts
+++ b/packages/core/src/monitor-event.ts
@@ -44,16 +44,13 @@ export const REVIEW_APPROVED = "review.approved" as const;
 export const REVIEW_CHANGES_REQUESTED = "review.changes_requested" as const;
 export const PHASE_CHANGED = "phase.changed" as const;
 export const PR_MERGE_STATE_CHANGED = "pr.merge_state_changed" as const;
+export const PR_REVIEW_COMMENT_POSTED = "pr.review_comment_posted" as const;
 
 // ── CI run event names (#1577) ──
 
 export const CI_STARTED = "ci.started" as const;
 export const CI_RUNNING = "ci.running" as const;
 export const CI_FINISHED = "ci.finished" as const;
-
-// ── Copilot event names (#1578) ──
-
-export const COPILOT_INLINE_POSTED = "copilot.inline_posted" as const;
 
 // ── Review event names (#1579) ──
 
@@ -271,7 +268,7 @@ const FORMATTERS: Partial<Record<string, Formatter>> = {
     return join(wi(e), pr(e), `${from} → ${to}`, head);
   },
 
-  [COPILOT_INLINE_POSTED]: (e) => {
+  [PR_REVIEW_COMMENT_POSTED]: (e) => {
     const author = typeof e.author === "string" ? e.author : "";
     const count = typeof e.newCount === "number" ? `${e.newCount} comment${e.newCount === 1 ? "" : "s"}` : "";
     const first = typeof e.firstLine === "string" ? e.firstLine : "";

--- a/packages/daemon/src/github/copilot-poller.spec.ts
+++ b/packages/daemon/src/github/copilot-poller.spec.ts
@@ -2,9 +2,9 @@ import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { MonitorEventInput } from "@mcp-cli/core";
 import {
-  COPILOT_INLINE_POSTED,
   ISSUE_COMMENT,
   PR_COMMENT,
+  PR_REVIEW_COMMENT_POSTED,
   REVIEW_APPROVED,
   REVIEW_CHANGES_REQUESTED,
   REVIEW_COMMENTED,
@@ -134,7 +134,7 @@ describe("CopilotPoller", () => {
 
       expect(events).toHaveLength(1);
       const evt = events[0];
-      expect(evt.event).toBe(COPILOT_INLINE_POSTED);
+      expect(evt.event).toBe(PR_REVIEW_COMMENT_POSTED);
       expect(evt.prNumber).toBe(42);
       expect(evt.newCount).toBe(2);
       expect(evt.commentIds).toEqual([1001, 1002]);
@@ -338,7 +338,7 @@ describe("CopilotPoller", () => {
 
       const reviewEvents = events.filter((e) => e.event === REVIEW_APPROVED);
       expect(reviewEvents).toHaveLength(2);
-      const inlineEvents = events.filter((e) => e.event === COPILOT_INLINE_POSTED);
+      const inlineEvents = events.filter((e) => e.event === PR_REVIEW_COMMENT_POSTED);
       expect(inlineEvents).toHaveLength(0);
     });
   });
@@ -501,7 +501,7 @@ describe("CopilotPoller", () => {
 
       await poller.poll();
 
-      const inlineEvents = events.filter((e) => e.event === COPILOT_INLINE_POSTED);
+      const inlineEvents = events.filter((e) => e.event === PR_REVIEW_COMMENT_POSTED);
       expect(inlineEvents).toHaveLength(1);
       expect(inlineEvents[0].prNumber).toBe(21);
     });
@@ -514,7 +514,7 @@ describe("CopilotPoller", () => {
 
       await poller.poll();
 
-      const inlineEvents = events.filter((e) => e.event === COPILOT_INLINE_POSTED);
+      const inlineEvents = events.filter((e) => e.event === PR_REVIEW_COMMENT_POSTED);
       expect(inlineEvents).toHaveLength(0);
     });
   });
@@ -582,7 +582,7 @@ describe("CopilotPoller", () => {
 
       await poller.poll();
 
-      const inlineEvents = events.filter((e) => e.event === COPILOT_INLINE_POSTED);
+      const inlineEvents = events.filter((e) => e.event === PR_REVIEW_COMMENT_POSTED);
       expect(inlineEvents).toHaveLength(0);
       expect(poller.lastError).toBeNull();
     });
@@ -650,8 +650,8 @@ describe("CopilotPoller", () => {
 
       await poller.poll();
 
-      const pr42 = events.filter((e) => e.event === COPILOT_INLINE_POSTED && e.prNumber === 42);
-      const pr43 = events.filter((e) => e.event === COPILOT_INLINE_POSTED && e.prNumber === 43);
+      const pr42 = events.filter((e) => e.event === PR_REVIEW_COMMENT_POSTED && e.prNumber === 42);
+      const pr43 = events.filter((e) => e.event === PR_REVIEW_COMMENT_POSTED && e.prNumber === 43);
       expect(pr42).toHaveLength(1);
       expect(pr42[0].commentIds).toEqual([1001]);
       expect(pr43).toHaveLength(1);

--- a/packages/daemon/src/github/copilot-poller.ts
+++ b/packages/daemon/src/github/copilot-poller.ts
@@ -3,7 +3,7 @@
  *
  * Polls `GET /repos/{owner}/{repo}/pulls/{n}/comments` for each tracked PR,
  * tracks which comment IDs have been seen (persisted to SQLite), and emits
- * `copilot.inline_posted` events with only the diff (new comments).
+ * `pr.review_comment_posted` events with only the diff (new comments).
  *
  * Adaptive cadence: 10s when active work items exist, 60s idle, 300s after merge.
  * Respects GitHub API rate limits: backs off to 300s when remaining < 500.
@@ -11,9 +11,9 @@
 
 import type { Logger } from "@mcp-cli/core";
 import {
-  COPILOT_INLINE_POSTED,
   ISSUE_COMMENT,
   PR_COMMENT,
+  PR_REVIEW_COMMENT_POSTED,
   REVIEW_APPROVED,
   REVIEW_CHANGES_REQUESTED,
   REVIEW_COMMENTED,
@@ -56,8 +56,8 @@ export interface PRComment {
 }
 
 export interface CopilotInlineEvent {
-  event: typeof COPILOT_INLINE_POSTED;
-  category: "copilot";
+  event: typeof PR_REVIEW_COMMENT_POSTED;
+  category: "work_item";
   workItemId: string;
   prNumber: number;
   newCount: number;
@@ -355,8 +355,8 @@ export class CopilotPoller {
 
       this.onEvent({
         src: "daemon.copilot-poller",
-        event: COPILOT_INLINE_POSTED,
-        category: "copilot",
+        event: PR_REVIEW_COMMENT_POSTED,
+        category: "work_item",
         workItemId: item.id,
         prNumber,
         newCount: authorComments.length,

--- a/packages/daemon/src/github/copilot-poller.ts
+++ b/packages/daemon/src/github/copilot-poller.ts
@@ -55,7 +55,7 @@ export interface PRComment {
   pull_request_url?: string;
 }
 
-export interface CopilotInlineEvent {
+export interface PRReviewCommentPostedEvent {
   event: typeof PR_REVIEW_COMMENT_POSTED;
   category: "work_item";
   workItemId: string;

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -962,7 +962,7 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
             logger,
             onEvent: (event) => {
               if (event.event === PR_REVIEW_COMMENT_POSTED) {
-                const key = `copilot:${event.prNumber}:${event.author}`;
+                const key = `${event.event}:${event.prNumber}:${event.author}`;
                 mailEventBus.publishCoalesced(event, key, {
                   mode: "merge",
                   merge: (a, b) => {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -32,7 +32,6 @@ import {
   BUILD_VERSION,
   CLAUDE_SERVER_NAME,
   CODEX_SERVER_NAME,
-  COPILOT_INLINE_POSTED,
   DAEMON_IDLE_TIMEOUT_MS,
   DAEMON_READY_SIGNAL,
   DEFAULT_CLAUDE_WS_PORT,
@@ -41,6 +40,7 @@ import {
   MOCK_SERVER_NAME,
   OPENCODE_SERVER_NAME,
   PROTOCOL_VERSION,
+  PR_REVIEW_COMMENT_POSTED,
   SITE_SERVER_NAME,
   TRACING_SERVER_NAME,
   WORK_ITEMS_SERVER_NAME,
@@ -961,7 +961,7 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
             stateDb: db,
             logger,
             onEvent: (event) => {
-              if (event.event === COPILOT_INLINE_POSTED) {
+              if (event.event === PR_REVIEW_COMMENT_POSTED) {
                 const key = `copilot:${event.prNumber}:${event.author}`;
                 mailEventBus.publishCoalesced(event, key, {
                   mode: "merge",


### PR DESCRIPTION
## Summary

- Renames `COPILOT_INLINE_POSTED` (`"copilot.inline_posted"`, category `"copilot"`) to `PR_REVIEW_COMMENT_POSTED` (`"pr.review_comment_posted"`, category `"work_item"`)
- The old name was misleading: it fired for **all** inline review comment authors, including human reviewers — category `"copilot"` was wrong for human-authored comments
- Consumers wanting bot-only filtering can check the `author` field (e.g. `author.includes("copilot")`)

## Test plan

- [x] All 63 `copilot-poller.spec.ts` tests pass with updated assertions
- [x] `bun typecheck` passes (no dangling references to removed constant)
- [x] `bun lint` passes (import ordering auto-fixed)
- [x] Full test suite passes (1 pre-existing flaky test in `ipc-server.spec.ts` filed as #1841)

🤖 Generated with [Claude Code](https://claude.com/claude-code)