### PR TITLE
feat(coalesce): add max-key cap + oldest-flush eviction to CoalescingPublisher (fixes #1659)

### DIFF
--- a/packages/daemon/src/coalesce.spec.ts
+++ b/packages/daemon/src/coalesce.spec.ts
@@ -1,11 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import { CoalescingPublisher } from "./coalesce";
-import type { Clock } from "./coalesce";
+import type { Clock, CoalescerMetrics } from "./coalesce";
 
 class FakeClock implements Clock {
   private timers = new Map<number, { fn: () => void; fireAt: number }>();
   private _now = 0;
   private nextId = 0;
+
+  now(): number {
+    return this._now;
+  }
 
   setTimeout(fn: () => void, ms: number): Timer {
     const id = ++this.nextId;
@@ -36,12 +40,42 @@ function collectEmissions<T>(): { emissions: T[]; emit: (e: T) => void } {
   return { emissions, emit: (e: T) => emissions.push(e) };
 }
 
+function fakeMetrics(): CoalescerMetrics & {
+  pendingKeysValue: () => number;
+  overflowValue: () => number;
+  emitErrorsValue: () => number;
+} {
+  let pending = 0;
+  let overflow = 0;
+  let errors = 0;
+  return {
+    pendingKeys: {
+      set(n: number) {
+        pending = n;
+      },
+    },
+    overflowTotal: {
+      inc(n = 1) {
+        overflow += n;
+      },
+    },
+    emitErrors: {
+      inc(n = 1) {
+        errors += n;
+      },
+    },
+    pendingKeysValue: () => pending,
+    overflowValue: () => overflow,
+    emitErrorsValue: () => errors,
+  };
+}
+
 describe("CoalescingPublisher", () => {
   describe("last-wins policy", () => {
     test("rapid submissions produce one emission after window", () => {
       const clock = new FakeClock();
       const { emissions, emit } = collectEmissions<string>();
-      const pub = new CoalescingPublisher(emit, clock);
+      const pub = new CoalescingPublisher(emit, { clock });
 
       pub.submit("k1", "a", { mode: "last-wins", windowMs: 50 });
       pub.submit("k1", "b", { mode: "last-wins", windowMs: 50 });
@@ -56,7 +90,7 @@ describe("CoalescingPublisher", () => {
     test("different keys emit independently", () => {
       const clock = new FakeClock();
       const { emissions, emit } = collectEmissions<string>();
-      const pub = new CoalescingPublisher(emit, clock);
+      const pub = new CoalescingPublisher(emit, { clock });
 
       pub.submit("k1", "a", { mode: "last-wins", windowMs: 50 });
       pub.submit("k2", "b", { mode: "last-wins", windowMs: 50 });
@@ -71,7 +105,7 @@ describe("CoalescingPublisher", () => {
     test("uses default 500ms window when windowMs omitted", () => {
       const clock = new FakeClock();
       const { emissions, emit } = collectEmissions<string>();
-      const pub = new CoalescingPublisher(emit, clock);
+      const pub = new CoalescingPublisher(emit, { clock });
 
       pub.submit("k1", "x", { mode: "last-wins" });
       expect(emissions).toHaveLength(0);
@@ -85,11 +119,10 @@ describe("CoalescingPublisher", () => {
     test("first submission's windowMs is authoritative for re-submissions", () => {
       const clock = new FakeClock();
       const { emissions, emit } = collectEmissions<string>();
-      const pub = new CoalescingPublisher(emit, clock);
+      const pub = new CoalescingPublisher(emit, { clock });
 
       pub.submit("k1", "a", { mode: "last-wins", windowMs: 100 });
       clock.advance(50);
-      // Re-submit with a much larger window — should still use the original 100ms.
       pub.submit("k1", "b", { mode: "last-wins", windowMs: 5000 });
       clock.advance(100);
       expect(emissions).toEqual(["b"]);
@@ -101,7 +134,7 @@ describe("CoalescingPublisher", () => {
     test("folds events in order and emits once at window close", () => {
       const clock = new FakeClock();
       const { emissions, emit } = collectEmissions<number>();
-      const pub = new CoalescingPublisher(emit, clock);
+      const pub = new CoalescingPublisher(emit, { clock });
       const merge = (a: number, b: number) => a + b;
 
       pub.submit("k1", 1, { mode: "merge", merge, windowMs: 50 });
@@ -121,7 +154,7 @@ describe("CoalescingPublisher", () => {
         lastStatus: string;
       }
       const { emissions, emit } = collectEmissions<Stats>();
-      const pub = new CoalescingPublisher(emit, clock);
+      const pub = new CoalescingPublisher(emit, { clock });
 
       const merge = (a: Stats, b: Stats): Stats => ({
         count: a.count + b.count,
@@ -140,7 +173,7 @@ describe("CoalescingPublisher", () => {
     test("merge throws removes the pending entry — no zombie", () => {
       const clock = new FakeClock();
       const { emissions, emit } = collectEmissions<number>();
-      const pub = new CoalescingPublisher(emit, clock);
+      const pub = new CoalescingPublisher(emit, { clock });
 
       pub.submit("k1", 1, { mode: "merge", merge: (a, b) => a + b, windowMs: 100 });
       expect(pub.pendingCount).toBe(1);
@@ -150,7 +183,6 @@ describe("CoalescingPublisher", () => {
       };
       expect(() => pub.submit("k1", 2, { mode: "merge", merge: badMerge, windowMs: 100 })).toThrow("merge failed");
 
-      // Entry must be gone — no zombie with a dead timer.
       expect(pub.pendingCount).toBe(0);
       clock.advance(200);
       expect(emissions).toHaveLength(0);
@@ -162,7 +194,7 @@ describe("CoalescingPublisher", () => {
     test("emits immediately without windowing", () => {
       const clock = new FakeClock();
       const { emissions, emit } = collectEmissions<string>();
-      const pub = new CoalescingPublisher(emit, clock);
+      const pub = new CoalescingPublisher(emit, { clock });
 
       pub.submit("k1", "immediate", { mode: "never" });
       expect(emissions).toEqual(["immediate"]);
@@ -172,7 +204,7 @@ describe("CoalescingPublisher", () => {
     test("flushes pending state for that key before emitting", () => {
       const clock = new FakeClock();
       const { emissions, emit } = collectEmissions<string>();
-      const pub = new CoalescingPublisher(emit, clock);
+      const pub = new CoalescingPublisher(emit, { clock });
 
       pub.submit("k1", "pending-val", { mode: "last-wins", windowMs: 200 });
       expect(emissions).toHaveLength(0);
@@ -186,7 +218,7 @@ describe("CoalescingPublisher", () => {
     test("does not affect other keys", () => {
       const clock = new FakeClock();
       const { emissions, emit } = collectEmissions<string>();
-      const pub = new CoalescingPublisher(emit, clock);
+      const pub = new CoalescingPublisher(emit, { clock });
 
       pub.submit("k1", "a", { mode: "last-wins", windowMs: 200 });
       pub.submit("k2", "b", { mode: "last-wins", windowMs: 200 });
@@ -205,7 +237,7 @@ describe("CoalescingPublisher", () => {
     test("flush(key) emits pending event for that key immediately", () => {
       const clock = new FakeClock();
       const { emissions, emit } = collectEmissions<string>();
-      const pub = new CoalescingPublisher(emit, clock);
+      const pub = new CoalescingPublisher(emit, { clock });
 
       pub.submit("k1", "val", { mode: "last-wins", windowMs: 5000 });
       expect(emissions).toHaveLength(0);
@@ -218,7 +250,7 @@ describe("CoalescingPublisher", () => {
     test("flush() with no key flushes all pending keys", () => {
       const clock = new FakeClock();
       const { emissions, emit } = collectEmissions<string>();
-      const pub = new CoalescingPublisher(emit, clock);
+      const pub = new CoalescingPublisher(emit, { clock });
 
       pub.submit("k1", "a", { mode: "last-wins", windowMs: 5000 });
       pub.submit("k2", "b", { mode: "last-wins", windowMs: 5000 });
@@ -232,7 +264,7 @@ describe("CoalescingPublisher", () => {
     test("flush(key) is a no-op for unknown keys", () => {
       const clock = new FakeClock();
       const { emissions, emit } = collectEmissions<string>();
-      const pub = new CoalescingPublisher(emit, clock);
+      const pub = new CoalescingPublisher(emit, { clock });
 
       pub.flush("nonexistent");
       expect(emissions).toHaveLength(0);
@@ -240,9 +272,12 @@ describe("CoalescingPublisher", () => {
 
     test("emit throws during flush propagates error and clears entry", () => {
       const clock = new FakeClock();
-      const pub = new CoalescingPublisher<string>(() => {
-        throw new Error("emit failed");
-      }, clock);
+      const pub = new CoalescingPublisher<string>(
+        () => {
+          throw new Error("emit failed");
+        },
+        { clock },
+      );
 
       pub.submit("k1", "a", { mode: "last-wins", windowMs: 100 });
       expect(() => pub.flush("k1")).toThrow("emit failed");
@@ -255,7 +290,7 @@ describe("CoalescingPublisher", () => {
     test("clears all timers without emitting", () => {
       const clock = new FakeClock();
       const { emissions, emit } = collectEmissions<string>();
-      const pub = new CoalescingPublisher(emit, clock);
+      const pub = new CoalescingPublisher(emit, { clock });
 
       pub.submit("k1", "a", { mode: "last-wins", windowMs: 50 });
       pub.submit("k2", "b", { mode: "last-wins", windowMs: 50 });
@@ -271,13 +306,228 @@ describe("CoalescingPublisher", () => {
     test("submit is a no-op after dispose", () => {
       const clock = new FakeClock();
       const { emissions, emit } = collectEmissions<string>();
-      const pub = new CoalescingPublisher(emit, clock);
+      const pub = new CoalescingPublisher(emit, { clock });
 
       pub.dispose();
       pub.submit("k1", "ignored", { mode: "last-wins", windowMs: 50 });
       pub.submit("k1", "also-ignored", { mode: "never" });
       expect(emissions).toHaveLength(0);
       expect(pub.pendingCount).toBe(0);
+    });
+  });
+
+  describe("maxKeys cap", () => {
+    test("flushes oldest key when cap is reached", () => {
+      const clock = new FakeClock();
+      const { emissions, emit } = collectEmissions<string>();
+      const pub = new CoalescingPublisher(emit, { clock, maxKeys: 3 });
+
+      pub.submit("k1", "a", { mode: "last-wins", windowMs: 1000 });
+      pub.submit("k2", "b", { mode: "last-wins", windowMs: 1000 });
+      pub.submit("k3", "c", { mode: "last-wins", windowMs: 1000 });
+      expect(pub.pendingCount).toBe(3);
+      expect(emissions).toHaveLength(0);
+
+      pub.submit("k4", "d", { mode: "last-wins", windowMs: 1000 });
+      expect(pub.pendingCount).toBe(3);
+      expect(emissions).toEqual(["a"]);
+
+      pub.dispose();
+    });
+
+    test("re-submitting existing key does not trigger eviction", () => {
+      const clock = new FakeClock();
+      const { emissions, emit } = collectEmissions<string>();
+      const pub = new CoalescingPublisher(emit, { clock, maxKeys: 2 });
+
+      pub.submit("k1", "a", { mode: "last-wins", windowMs: 1000 });
+      pub.submit("k2", "b", { mode: "last-wins", windowMs: 1000 });
+      pub.submit("k1", "a2", { mode: "last-wins", windowMs: 1000 });
+
+      expect(pub.pendingCount).toBe(2);
+      expect(emissions).toHaveLength(0);
+      pub.dispose();
+    });
+
+    test("evicts multiple oldest keys under sustained pressure", () => {
+      const clock = new FakeClock();
+      const { emissions, emit } = collectEmissions<string>();
+      const pub = new CoalescingPublisher(emit, { clock, maxKeys: 2 });
+
+      pub.submit("k1", "a", { mode: "last-wins", windowMs: 1000 });
+      pub.submit("k2", "b", { mode: "last-wins", windowMs: 1000 });
+      pub.submit("k3", "c", { mode: "last-wins", windowMs: 1000 });
+      pub.submit("k4", "d", { mode: "last-wins", windowMs: 1000 });
+
+      expect(emissions).toEqual(["a", "b"]);
+      expect(pub.pendingCount).toBe(2);
+      pub.dispose();
+    });
+
+    test("increments overflow counter on eviction", () => {
+      const clock = new FakeClock();
+      const { emissions, emit } = collectEmissions<string>();
+      const m = fakeMetrics();
+      const pub = new CoalescingPublisher(emit, { clock, maxKeys: 1, metrics: m });
+
+      pub.submit("k1", "a", { mode: "last-wins", windowMs: 1000 });
+      expect(m.overflowValue()).toBe(0);
+
+      pub.submit("k2", "b", { mode: "last-wins", windowMs: 1000 });
+      expect(m.overflowValue()).toBe(1);
+      expect(emissions).toEqual(["a"]);
+
+      pub.dispose();
+    });
+  });
+
+  describe("maxWaitMs starvation protection", () => {
+    test("emits within maxWaitMs even under continuous re-submits", () => {
+      const clock = new FakeClock();
+      const { emissions, emit } = collectEmissions<string>();
+      const pub = new CoalescingPublisher(emit, { clock });
+
+      pub.submit("k1", "v1", { mode: "last-wins", windowMs: 100, maxWaitMs: 250 });
+      clock.advance(80);
+      pub.submit("k1", "v2", { mode: "last-wins", windowMs: 100, maxWaitMs: 250 });
+      clock.advance(80);
+      pub.submit("k1", "v3", { mode: "last-wins", windowMs: 100, maxWaitMs: 250 });
+      clock.advance(80);
+      // Now at t=240. remainingMs = 250 - 240 = 10, which is < windowMs (100).
+      pub.submit("k1", "v4", { mode: "last-wins", windowMs: 100, maxWaitMs: 250 });
+
+      expect(emissions).toHaveLength(0);
+      clock.advance(10);
+      expect(emissions).toEqual(["v4"]);
+      pub.dispose();
+    });
+
+    test("maxWaitMs does not affect first submission (no existing entry)", () => {
+      const clock = new FakeClock();
+      const { emissions, emit } = collectEmissions<string>();
+      const pub = new CoalescingPublisher(emit, { clock });
+
+      pub.submit("k1", "first", { mode: "last-wins", windowMs: 100, maxWaitMs: 50 });
+      expect(emissions).toHaveLength(0);
+      clock.advance(99);
+      expect(emissions).toHaveLength(0);
+      clock.advance(1);
+      expect(emissions).toEqual(["first"]);
+      pub.dispose();
+    });
+
+    test("maxWaitMs clamps to 0 when deadline has passed", () => {
+      const clock = new FakeClock();
+      const { emissions, emit } = collectEmissions<string>();
+      const pub = new CoalescingPublisher(emit, { clock });
+
+      pub.submit("k1", "v1", { mode: "last-wins", windowMs: 100, maxWaitMs: 50 });
+      clock.advance(60);
+      pub.submit("k1", "v2", { mode: "last-wins", windowMs: 100, maxWaitMs: 50 });
+
+      // maxWaitMs deadline already passed (pendingAt=0 + 50 = 50, now=60), timer set to 0
+      clock.advance(0);
+      expect(emissions).toEqual(["v2"]);
+      pub.dispose();
+    });
+
+    test("maxWaitMs works with merge mode", () => {
+      const clock = new FakeClock();
+      const { emissions, emit } = collectEmissions<number>();
+      const pub = new CoalescingPublisher(emit, { clock });
+      const merge = (a: number, b: number) => a + b;
+
+      pub.submit("k1", 1, { mode: "merge", merge, windowMs: 100, maxWaitMs: 150 });
+      clock.advance(80);
+      pub.submit("k1", 2, { mode: "merge", merge, windowMs: 100, maxWaitMs: 150 });
+      clock.advance(70);
+      // At t=150, deadline hit. Timer was set to min(100, 150-80) = 70.
+      expect(emissions).toEqual([3]);
+      pub.dispose();
+    });
+  });
+
+  describe("metrics", () => {
+    test("tracks pending keys gauge through lifecycle", () => {
+      const clock = new FakeClock();
+      const { emissions, emit } = collectEmissions<string>();
+      const m = fakeMetrics();
+      const pub = new CoalescingPublisher(emit, { clock, metrics: m });
+
+      expect(m.pendingKeysValue()).toBe(0);
+
+      pub.submit("k1", "a", { mode: "last-wins", windowMs: 100 });
+      expect(m.pendingKeysValue()).toBe(1);
+
+      pub.submit("k2", "b", { mode: "last-wins", windowMs: 100 });
+      expect(m.pendingKeysValue()).toBe(2);
+
+      clock.advance(100);
+      expect(m.pendingKeysValue()).toBe(0);
+      expect(emissions).toHaveLength(2);
+      pub.dispose();
+    });
+
+    test("pending keys gauge set to 0 on dispose", () => {
+      const clock = new FakeClock();
+      const { emit } = collectEmissions<string>();
+      const m = fakeMetrics();
+      const pub = new CoalescingPublisher(emit, { clock, metrics: m });
+
+      pub.submit("k1", "a", { mode: "last-wins", windowMs: 1000 });
+      expect(m.pendingKeysValue()).toBe(1);
+
+      pub.dispose();
+      expect(m.pendingKeysValue()).toBe(0);
+    });
+
+    test("emit errors counter increments on throw", () => {
+      const clock = new FakeClock();
+      const m = fakeMetrics();
+      const pub = new CoalescingPublisher<string>(
+        () => {
+          throw new Error("boom");
+        },
+        { clock, metrics: m },
+      );
+
+      pub.submit("k1", "a", { mode: "last-wins", windowMs: 100 });
+      expect(() => pub.flush("k1")).toThrow("boom");
+      expect(m.emitErrorsValue()).toBe(1);
+      pub.dispose();
+    });
+
+    test("emit errors counter increments on timer-driven flush failure", () => {
+      const clock = new FakeClock();
+      const m = fakeMetrics();
+      const pub = new CoalescingPublisher<string>(
+        () => {
+          throw new Error("timer boom");
+        },
+        { clock, metrics: m },
+      );
+
+      pub.submit("k1", "a", { mode: "last-wins", windowMs: 50 });
+      clock.advance(50);
+      expect(m.emitErrorsValue()).toBe(1);
+      pub.dispose();
+    });
+
+    test("pending gauge updates on merge-throw cleanup", () => {
+      const clock = new FakeClock();
+      const { emit } = collectEmissions<number>();
+      const m = fakeMetrics();
+      const pub = new CoalescingPublisher(emit, { clock, metrics: m });
+
+      pub.submit("k1", 1, { mode: "merge", merge: (a, b) => a + b, windowMs: 100 });
+      expect(m.pendingKeysValue()).toBe(1);
+
+      const badMerge = (_a: number, _b: number): number => {
+        throw new Error("bad");
+      };
+      expect(() => pub.submit("k1", 2, { mode: "merge", merge: badMerge, windowMs: 100 })).toThrow("bad");
+      expect(m.pendingKeysValue()).toBe(0);
+      pub.dispose();
     });
   });
 });

--- a/packages/daemon/src/coalesce.ts
+++ b/packages/daemon/src/coalesce.ts
@@ -44,7 +44,11 @@ export class CoalescingPublisher<T> {
   constructor(emit: (event: T) => void, opts: CoalescerOptions = {}) {
     this.emit = emit;
     this.clock = opts.clock ?? systemClock;
-    this.maxKeys = opts.maxKeys ?? DEFAULT_MAX_KEYS;
+    const maxKeys = opts.maxKeys ?? DEFAULT_MAX_KEYS;
+    if (!Number.isFinite(maxKeys) || maxKeys < 1) {
+      throw new RangeError(`CoalescingPublisher: maxKeys must be a positive integer, got ${maxKeys}`);
+    }
+    this.maxKeys = Math.trunc(maxKeys);
     this.metrics = opts.metrics ?? null;
   }
 
@@ -53,7 +57,12 @@ export class CoalescingPublisher<T> {
 
     if (opts.mode === "never") {
       this.flushKey(key);
-      this.emit(event);
+      try {
+        this.emit(event);
+      } catch (err) {
+        this.metrics?.emitErrors.inc();
+        throw err;
+      }
       return;
     }
 
@@ -75,8 +84,11 @@ export class CoalescingPublisher<T> {
     } else if (this.pending.size >= this.maxKeys) {
       const oldest = this.pending.keys().next();
       if (!oldest.done) {
-        this.flushKey(oldest.value);
-        this.metrics?.overflowTotal.inc();
+        try {
+          this.flushKey(oldest.value);
+        } finally {
+          this.metrics?.overflowTotal.inc();
+        }
       }
     }
 

--- a/packages/daemon/src/coalesce.ts
+++ b/packages/daemon/src/coalesce.ts
@@ -1,32 +1,51 @@
 export type SubmitOptions<T> =
-  | { mode: "last-wins"; windowMs?: number }
-  | { mode: "merge"; merge: (a: T, b: T) => T; windowMs?: number }
+  | { mode: "last-wins"; windowMs?: number; maxWaitMs?: number }
+  | { mode: "merge"; merge: (a: T, b: T) => T; windowMs?: number; maxWaitMs?: number }
   | { mode: "never" };
 
 export interface Clock {
   setTimeout(fn: () => void, ms: number): Timer;
   clearTimeout(timer: Timer): void;
+  now(): number;
+}
+
+export interface CoalescerMetrics {
+  pendingKeys: { set(n: number): void };
+  overflowTotal: { inc(n?: number): void };
+  emitErrors: { inc(n?: number): void };
+}
+
+export interface CoalescerOptions {
+  clock?: Clock;
+  maxKeys?: number;
+  metrics?: CoalescerMetrics;
 }
 
 interface PendingEntry<T> {
   event: T;
   timer: Timer;
   windowMs: number;
+  pendingAt: number;
 }
 
 const DEFAULT_WINDOW_MS = 500;
+const DEFAULT_MAX_KEYS = 10_000;
 
-const systemClock: Clock = { setTimeout, clearTimeout };
+const systemClock: Clock = { setTimeout, clearTimeout, now: Date.now };
 
 export class CoalescingPublisher<T> {
   private readonly pending = new Map<string, PendingEntry<T>>();
   private readonly emit: (event: T) => void;
   private readonly clock: Clock;
+  private readonly maxKeys: number;
+  private readonly metrics: CoalescerMetrics | null;
   private disposed = false;
 
-  constructor(emit: (event: T) => void, clock: Clock = systemClock) {
+  constructor(emit: (event: T) => void, opts: CoalescerOptions = {}) {
     this.emit = emit;
-    this.clock = clock;
+    this.clock = opts.clock ?? systemClock;
+    this.maxKeys = opts.maxKeys ?? DEFAULT_MAX_KEYS;
+    this.metrics = opts.metrics ?? null;
   }
 
   submit(key: string, event: T, opts: SubmitOptions<T>): void {
@@ -48,15 +67,27 @@ export class CoalescingPublisher<T> {
         try {
           value = opts.merge(existing.event, event);
         } catch (err) {
-          // Don't leave a zombie entry with a cleared timer.
           this.pending.delete(key);
+          this.updatePendingGauge();
           throw err;
         }
       }
+    } else if (this.pending.size >= this.maxKeys) {
+      const oldest = this.pending.keys().next();
+      if (!oldest.done) {
+        this.flushKey(oldest.value);
+        this.metrics?.overflowTotal.inc();
+      }
     }
 
-    // Lock window duration on first submission; re-submissions don't change it.
     const effectiveWindowMs = existing?.windowMs ?? windowMs;
+    const pendingAt = existing?.pendingAt ?? this.clock.now();
+
+    let timerMs = effectiveWindowMs;
+    if (opts.maxWaitMs !== undefined && existing) {
+      const remainingMs = pendingAt + opts.maxWaitMs - this.clock.now();
+      timerMs = Math.min(effectiveWindowMs, Math.max(0, remainingMs));
+    }
 
     const timer = this.clock.setTimeout(() => {
       try {
@@ -64,8 +95,9 @@ export class CoalescingPublisher<T> {
       } catch (err) {
         console.error("[CoalescingPublisher] emit error for key", key, ":", err);
       }
-    }, effectiveWindowMs);
-    this.pending.set(key, { event: value, timer, windowMs: effectiveWindowMs });
+    }, timerMs);
+    this.pending.set(key, { event: value, timer, windowMs: effectiveWindowMs, pendingAt });
+    this.updatePendingGauge();
   }
 
   flush(key?: string): void {
@@ -84,6 +116,7 @@ export class CoalescingPublisher<T> {
       this.clock.clearTimeout(entry.timer);
     }
     this.pending.clear();
+    this.updatePendingGauge();
   }
 
   get pendingCount(): number {
@@ -95,6 +128,16 @@ export class CoalescingPublisher<T> {
     if (!entry) return;
     this.clock.clearTimeout(entry.timer);
     this.pending.delete(key);
-    this.emit(entry.event);
+    this.updatePendingGauge();
+    try {
+      this.emit(entry.event);
+    } catch (err) {
+      this.metrics?.emitErrors.inc();
+      throw err;
+    }
+  }
+
+  private updatePendingGauge(): void {
+    this.metrics?.pendingKeys.set(this.pending.size);
   }
 }

--- a/packages/daemon/src/event-bus.ts
+++ b/packages/daemon/src/event-bus.ts
@@ -12,7 +12,7 @@
  */
 
 import type { MonitorEvent, MonitorEventInput } from "@mcp-cli/core";
-import type { SubmitOptions } from "./coalesce";
+import type { CoalescerOptions, SubmitOptions } from "./coalesce";
 import { CoalescingPublisher } from "./coalesce";
 import type { EventLog } from "./event-log";
 import { metrics } from "./metrics";
@@ -149,7 +149,14 @@ export class EventBus {
 
   private getCoalescer(): CoalescingPublisher<MonitorEventInput> {
     if (!this.coalescer) {
-      this.coalescer = new CoalescingPublisher((input) => this.publish(input));
+      const opts: CoalescerOptions = {
+        metrics: {
+          pendingKeys: metrics.gauge("mcpd_coalescer_pending_keys"),
+          overflowTotal: metrics.counter("mcpd_coalescer_overflow_total"),
+          emitErrors: metrics.counter("mcpd_coalescer_emit_errors_total"),
+        },
+      };
+      this.coalescer = new CoalescingPublisher((input) => this.publish(input), opts);
     }
     return this.coalescer;
   }


### PR DESCRIPTION
## Summary
- **Max-key cap**: `maxKeys` constructor option (default 10,000) with oldest-key eviction when exceeded, plus `coalescer_overflow_total` counter
- **Starvation protection**: `maxWaitMs` per-submit option tracks `pendingAt` timestamp per entry; timer fires no later than `pendingAt + maxWaitMs` even under continuous re-submits
- **Prometheus metrics**: `mcpd_coalescer_pending_keys` gauge, `mcpd_coalescer_overflow_total` counter, `mcpd_coalescer_emit_errors_total` counter — wired into EventBus's coalescer via dependency injection

## Test plan
- [x] maxKeys cap: submitting beyond cap flushes oldest key (insertion order), counter stays at cap
- [x] Re-submitting existing key does not trigger eviction
- [x] Sustained pressure evicts multiple oldest keys in order
- [x] Overflow counter increments on each eviction
- [x] maxWaitMs: event emits within maxWaitMs under continuous re-submits
- [x] maxWaitMs does not affect first submission (only kicks in on re-submit)
- [x] maxWaitMs clamps timer to 0 when deadline has already passed
- [x] maxWaitMs works with merge mode
- [x] Pending keys gauge tracks lifecycle (submit → flush → dispose)
- [x] Emit errors counter increments on both flush-driven and timer-driven failures
- [x] All 29 coalesce tests pass; full suite (4087 tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)