### PR TITLE
feat(phase): migrate triage.ts from polling to ctx.waitForEvent (fixes #1832)

### DIFF
--- a/.claude/phases/triage-fn.ts
+++ b/.claude/phases/triage-fn.ts
@@ -1,0 +1,136 @@
+/**
+ * Core triage logic, extracted for testability.
+ *
+ * The defineAlias wrapper in triage.ts constructs TriageDeps from the
+ * AliasContext and delegates here.
+ */
+
+export interface TriageEventFilter {
+  type?: string | string[];
+  workItem?: string;
+}
+
+export interface TriageEvent {
+  event: string;
+  prNumber?: number;
+  [key: string]: unknown;
+}
+
+export interface TriageWork {
+  id: string;
+  issueNumber: number | null;
+  prNumber: number | null;
+  branch: string | null;
+}
+
+export interface TriageDeps {
+  findPr(branch: string): number | null;
+  runEstimate(prNumber: number): {
+    scrutiny: "low" | "high";
+    reasons: string[];
+    metrics?: Record<string, unknown>;
+  };
+  waitForEvent(
+    filter: TriageEventFilter,
+    opts?: { timeoutMs?: number; since?: number },
+  ): Promise<TriageEvent>;
+  stateGet<T>(key: string): Promise<T | undefined>;
+  stateSet(key: string, value: unknown): Promise<void>;
+  updateWorkItem(id: string, prNumber: number): Promise<void>;
+}
+
+export type TriageResult =
+  | {
+      action: "goto";
+      target: "review" | "qa";
+      reason: string;
+      scrutiny: "low" | "high";
+      prNumber: number;
+      metrics?: Record<string, unknown>;
+    }
+  | { action: "wait"; reason: string };
+
+const WAIT_TIMEOUT_MS = 30_000;
+
+export async function runTriage(
+  input: { labels: string[]; since?: number },
+  work: TriageWork,
+  deps: TriageDeps,
+): Promise<TriageResult> {
+  const missing: string[] = [];
+  if (work.issueNumber == null) missing.push("issueNumber");
+  if (work.branch == null) missing.push("branch");
+  if (missing.length > 0) {
+    throw new Error(
+      `phase-triage requires ${missing.map((f) => `'${f}'`).join(" and ")} on the work item ${work.id} (missing: ${missing.join(", ")})`,
+    );
+  }
+
+  let prNumber = work.prNumber;
+  if (prNumber == null) {
+    prNumber = deps.findPr(work.branch!);
+  }
+
+  if (prNumber == null) {
+    try {
+      const event = await deps.waitForEvent(
+        { type: ["pr.opened", "session.result"], workItem: work.id },
+        { timeoutMs: WAIT_TIMEOUT_MS, since: input.since },
+      );
+      if (event.prNumber != null) {
+        prNumber = event.prNumber;
+      } else {
+        prNumber = deps.findPr(work.branch!);
+      }
+      if (prNumber == null) {
+        return {
+          action: "wait",
+          reason: `event ${event.event} received but no PR found for ${work.branch}`,
+        };
+      }
+    } catch (err: unknown) {
+      if (err instanceof Error && err.name === "WaitTimeoutError") {
+        return {
+          action: "wait",
+          reason: `no PR found for branch ${work.branch}, waiting for pr.opened or session.result`,
+        };
+      }
+      throw err;
+    }
+  }
+
+  const raw = deps.runEstimate(prNumber);
+
+  const labels =
+    input.labels.length > 0
+      ? input.labels
+      : ((await deps.stateGet<string>("labels")) ?? "")
+          .split(",")
+          .map((l) => l.trim())
+          .filter((l) => l.length > 0);
+  const isFlaky = labels.includes("flaky");
+  const scrutiny = isFlaky ? "high" : raw.scrutiny;
+  const reasons =
+    isFlaky && raw.scrutiny !== "high"
+      ? [...raw.reasons, "label:flaky forces high scrutiny"]
+      : raw.reasons;
+  const decision = scrutiny === "high" ? "review" : "qa";
+
+  await deps.stateSet("triage_scrutiny", scrutiny);
+  await deps.stateSet("triage_reasons", reasons.join("; "));
+
+  try {
+    await deps.updateWorkItem(work.id, prNumber);
+  } catch {
+    // work_items server unavailable — caller handles via CLI
+  }
+
+  return {
+    action: "goto",
+    target: decision,
+    reason: reasons.join("; "),
+    scrutiny,
+    prNumber,
+    metrics: raw.metrics,
+  };
+}

--- a/.claude/phases/triage-fn.ts
+++ b/.claude/phases/triage-fn.ts
@@ -1,9 +1,4 @@
-/**
- * Core triage logic, extracted for testability.
- *
- * The defineAlias wrapper in triage.ts constructs TriageDeps from the
- * AliasContext and delegates here.
- */
+/** Core triage logic, extracted for testability via dependency injection. */
 
 export interface TriageEventFilter {
   type?: string | string[];
@@ -50,16 +45,16 @@ export type TriageResult =
     }
   | { action: "wait"; reason: string };
 
-const WAIT_TIMEOUT_MS = 30_000;
+const DEFAULT_TIMEOUT_MS = 30_000;
 
 export async function runTriage(
-  input: { labels: string[]; since?: number },
+  input: { labels: string[]; since?: number; timeoutMs?: number },
   work: TriageWork,
   deps: TriageDeps,
 ): Promise<TriageResult> {
   const missing: string[] = [];
   if (work.issueNumber == null) missing.push("issueNumber");
-  if (work.branch == null) missing.push("branch");
+  if (!work.branch) missing.push("branch");
   if (missing.length > 0) {
     throw new Error(
       `phase-triage requires ${missing.map((f) => `'${f}'`).join(" and ")} on the work item ${work.id} (missing: ${missing.join(", ")})`,
@@ -73,9 +68,10 @@ export async function runTriage(
 
   if (prNumber == null) {
     try {
+      const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
       const event = await deps.waitForEvent(
         { type: ["pr.opened", "session.result"], workItem: work.id },
-        { timeoutMs: WAIT_TIMEOUT_MS, since: input.since },
+        { timeoutMs, since: input.since },
       );
       if (event.prNumber != null) {
         prNumber = event.prNumber;
@@ -121,8 +117,11 @@ export async function runTriage(
 
   try {
     await deps.updateWorkItem(work.id, prNumber);
-  } catch {
-    // work_items server unavailable — caller handles via CLI
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (!/ECONNREFUSED|ENOTFOUND|ETIMEDOUT|unavailable/i.test(msg)) {
+      throw err;
+    }
   }
 
   return {

--- a/.claude/phases/triage.ts
+++ b/.claude/phases/triage.ts
@@ -1,28 +1,30 @@
 /**
- * Phase: triage — pure compute, no session spawn.
+ * Phase: triage — decides scrutiny level and next phase (review or qa).
  *
- * Runs .claude/skills/estimate/triage.ts against the PR, decides scrutiny,
- * updates the work item, and returns the next phase (review for high
- * scrutiny, qa for low). Flaky-labeled issues are forced to high scrutiny
- * per run.md.
+ * When the PR exists: runs the estimate, applies flaky-label override,
+ * returns { action: "goto", target: "review" | "qa" }.
+ *
+ * When no PR found: waits for pr.opened or session.result via
+ * ctx.waitForEvent (#1832). On timeout: returns { action: "wait" }.
  *
  * State writes: triage_scrutiny, triage_reasons.
  */
 import { defineAlias, z } from "mcp-cli";
-
-const DecisionSchema = z.enum(["review", "qa"]);
+import { runTriage } from "./triage-fn";
 
 defineAlias({
   name: "phase-triage",
   description: "Sprint phase: post-implementation triage, decide scrutiny.",
   input: z.object({
     labels: z.array(z.string()).default([]),
+    since: z.number().optional(),
   }),
   output: z.object({
-    scrutiny: z.enum(["low", "high"]),
-    decision: DecisionSchema,
-    reasons: z.array(z.string()),
-    prNumber: z.number(),
+    action: z.enum(["goto", "wait"]),
+    target: z.enum(["review", "qa"]).optional(),
+    reason: z.string(),
+    scrutiny: z.enum(["low", "high"]).optional(),
+    prNumber: z.number().optional(),
     metrics: z.record(z.string(), z.unknown()).optional(),
   }),
   fn: async (input, ctx) => {
@@ -30,78 +32,58 @@ defineAlias({
     if (!work) {
       throw new Error("phase-triage requires a work item (got: null)");
     }
-    const missing: string[] = [];
-    if (work.issueNumber == null) missing.push("issueNumber");
-    if (work.branch == null) missing.push("branch");
-    if (missing.length > 0) {
-      throw new Error(
-        `phase-triage requires ${missing.map((f) => `'${f}'`).join(" and ")} on the work item ${work.id} (missing: ${missing.join(", ")})`,
-      );
-    }
 
-    // Resolve PR number via gh. Work item's prNumber is authoritative when set.
-    let prNumber = work.prNumber;
-    if (prNumber == null) {
-      const proc = Bun.spawnSync({
-        cmd: ["gh", "pr", "list", "--head", work.branch, "--json", "number", "-q", ".[0].number"],
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const out = new TextDecoder().decode(proc.stdout).trim();
-      const n = Number.parseInt(out, 10);
-      if (!Number.isFinite(n)) throw new Error(`no PR found for branch ${work.branch}`);
-      prNumber = n;
-    }
-
-    // Run triage.ts --pr N --json.
-    const triageProc = Bun.spawnSync({
-      cmd: ["bun", ".claude/skills/estimate/triage.ts", "--pr", String(prNumber), "--json"],
-      stdout: "pipe",
-      stderr: "pipe",
+    return runTriage(input, work, {
+      findPr(branch: string): number | null {
+        const proc = Bun.spawnSync({
+          cmd: [
+            "gh",
+            "pr",
+            "list",
+            "--head",
+            branch,
+            "--json",
+            "number",
+            "-q",
+            ".[0].number",
+          ],
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const out = new TextDecoder().decode(proc.stdout).trim();
+        const n = Number.parseInt(out, 10);
+        return Number.isFinite(n) ? n : null;
+      },
+      runEstimate(prNumber: number) {
+        const proc = Bun.spawnSync({
+          cmd: [
+            "bun",
+            ".claude/skills/estimate/triage.ts",
+            "--pr",
+            String(prNumber),
+            "--json",
+          ],
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        if (proc.exitCode !== 0) {
+          const err = new TextDecoder().decode(proc.stderr);
+          throw new Error(`triage.ts failed: ${err}`);
+        }
+        return JSON.parse(new TextDecoder().decode(proc.stdout)) as {
+          scrutiny: "low" | "high";
+          reasons: string[];
+          metrics?: Record<string, unknown>;
+        };
+      },
+      waitForEvent(filter, opts) {
+        return ctx.waitForEvent(filter, opts);
+      },
+      stateGet: (key) => ctx.state.get(key),
+      stateSet: (key, value) => ctx.state.set(key, value),
+      async updateWorkItem(id, prNumber) {
+        await ctx.mcp._work_items.work_items_update({ id, prNumber });
+      },
     });
-    if (triageProc.exitCode !== 0) {
-      const err = new TextDecoder().decode(triageProc.stderr);
-      throw new Error(`triage.ts failed: ${err}`);
-    }
-    const raw = JSON.parse(new TextDecoder().decode(triageProc.stdout)) as {
-      scrutiny: "low" | "high";
-      reasons: string[];
-      metrics?: Record<string, unknown>;
-    };
-
-    // Flaky issues are always high scrutiny — adversarial review required.
-    // Labels come from input when the orchestrator passes them explicitly;
-    // otherwise fall back to the comma-separated string impl.ts wrote to state.
-    const labels = input.labels.length > 0
-      ? input.labels
-      : ((await ctx.state.get<string>("labels")) ?? "")
-          .split(",")
-          .map((l) => l.trim())
-          .filter((l) => l.length > 0);
-    const isFlaky = labels.includes("flaky");
-    const scrutiny = isFlaky ? "high" : raw.scrutiny;
-    const reasons = isFlaky && raw.scrutiny !== "high" ? [...raw.reasons, "label:flaky forces high scrutiny"] : raw.reasons;
-    const decision: z.infer<typeof DecisionSchema> = scrutiny === "high" ? "review" : "qa";
-
-    await ctx.state.set("triage_scrutiny", scrutiny);
-    await ctx.state.set("triage_reasons", reasons.join("; "));
-
-    // Persist PR number on the work item for the poller.
-    try {
-      await ctx.mcp._work_items.work_items_update({
-        id: work.id,
-        prNumber,
-      });
-    } catch {
-      // work_items server unavailable — caller handles via CLI.
-    }
-
-    return {
-      scrutiny,
-      decision,
-      reasons,
-      prNumber,
-      metrics: raw.metrics,
-    };
   },
 });

--- a/.claude/phases/triage.ts
+++ b/.claude/phases/triage.ts
@@ -18,6 +18,7 @@ defineAlias({
   input: z.object({
     labels: z.array(z.string()).default([]),
     since: z.number().optional(),
+    timeoutMs: z.number().optional(),
   }),
   output: z.object({
     action: z.enum(["goto", "wait"]),

--- a/test/triage-phase.spec.ts
+++ b/test/triage-phase.spec.ts
@@ -141,6 +141,22 @@ describe("runTriage — PR available", () => {
   });
 });
 
+describe("runTriage — runEstimate failure", () => {
+  test("runEstimate error propagates to caller", async () => {
+    await expect(
+      runTriage(
+        { labels: [] },
+        makeWork({ prNumber: 100 }),
+        makeDeps({
+          runEstimate: () => {
+            throw new Error("triage.ts failed: exit code 1");
+          },
+        }),
+      ),
+    ).rejects.toThrow("triage.ts failed: exit code 1");
+  });
+});
+
 // ── (a) Event arrives during wait → resolved with event ──
 
 describe("runTriage — waitForEvent", () => {
@@ -273,6 +289,24 @@ describe("runTriage — replay", () => {
     expect(capturedOpts).toEqual({ timeoutMs: 30_000, since: 42 });
   });
 
+  test("timeoutMs input overrides default", async () => {
+    let capturedOpts: unknown;
+
+    await runTriage(
+      { labels: [], timeoutMs: 5_000 },
+      makeWork(),
+      makeDeps({
+        findPr: () => null,
+        waitForEvent: async (_filter, opts) => {
+          capturedOpts = opts;
+          throw makeTimeoutError();
+        },
+      }),
+    );
+
+    expect(capturedOpts).toMatchObject({ timeoutMs: 5_000 });
+  });
+
   test("replayed event with prNumber resolves triage", async () => {
     const result = await runTriage(
       { labels: [], since: 10 },
@@ -304,6 +338,10 @@ describe("runTriage — validation", () => {
     await expect(runTriage({ labels: [] }, makeWork({ branch: null }), makeDeps())).rejects.toThrow("branch");
   });
 
+  test("throws when branch is empty string", async () => {
+    await expect(runTriage({ labels: [] }, makeWork({ branch: "" }), makeDeps())).rejects.toThrow("branch");
+  });
+
   test("throws when both missing — lists both", async () => {
     await expect(runTriage({ labels: [] }, makeWork({ issueNumber: null, branch: null }), makeDeps())).rejects.toThrow(
       "issueNumber' and 'branch'",
@@ -330,16 +368,29 @@ describe("runTriage — state", () => {
     expect(stateWrites.triage_reasons).toBe("small; clean");
   });
 
-  test("updateWorkItem failure is swallowed", async () => {
+  test("updateWorkItem connectivity failure is swallowed", async () => {
     const result = await runTriage(
       { labels: [] },
       makeWork({ prNumber: 100 }),
       makeDeps({
         runEstimate: () => ({ scrutiny: "low", reasons: ["ok"] }),
-        updateWorkItem: () => Promise.reject(new Error("unavailable")),
+        updateWorkItem: () => Promise.reject(new Error("ECONNREFUSED")),
       }),
     );
     expect(result.action).toBe("goto");
+  });
+
+  test("updateWorkItem non-connectivity error is re-thrown", async () => {
+    await expect(
+      runTriage(
+        { labels: [] },
+        makeWork({ prNumber: 100 }),
+        makeDeps({
+          runEstimate: () => ({ scrutiny: "low", reasons: ["ok"] }),
+          updateWorkItem: () => Promise.reject(new Error("schema validation failed")),
+        }),
+      ),
+    ).rejects.toThrow("schema validation failed");
   });
 
   test("updateWorkItem called with correct args", async () => {

--- a/test/triage-phase.spec.ts
+++ b/test/triage-phase.spec.ts
@@ -1,0 +1,359 @@
+import { describe, expect, test } from "bun:test";
+import { type TriageDeps, type TriageWork, runTriage } from "../.claude/phases/triage-fn";
+
+function makeWork(overrides: Partial<TriageWork> = {}): TriageWork {
+  return {
+    id: "#42",
+    issueNumber: 42,
+    prNumber: null,
+    branch: "feat/issue-42-test",
+    ...overrides,
+  };
+}
+
+function makeDeps(overrides: Partial<TriageDeps> = {}): TriageDeps {
+  return {
+    findPr: () => null,
+    runEstimate: () => ({ scrutiny: "low" as const, reasons: ["small diff"] }),
+    waitForEvent: () => Promise.reject(new Error("waitForEvent not configured")),
+    stateGet: () => Promise.resolve(undefined),
+    stateSet: () => Promise.resolve(),
+    updateWorkItem: () => Promise.resolve(),
+    ...overrides,
+  };
+}
+
+function makeTimeoutError(): Error {
+  const err = new Error("waitForEvent timed out after 30000ms");
+  err.name = "WaitTimeoutError";
+  return err;
+}
+
+// ── Happy paths ──
+
+describe("runTriage — PR available", () => {
+  test("PR on work item — immediate triage, returns goto", async () => {
+    const result = await runTriage(
+      { labels: [] },
+      makeWork({ prNumber: 100 }),
+      makeDeps({
+        runEstimate: () => ({ scrutiny: "low", reasons: ["small diff"] }),
+      }),
+    );
+    expect(result).toMatchObject({
+      action: "goto",
+      target: "qa",
+      scrutiny: "low",
+      prNumber: 100,
+    });
+  });
+
+  test("PR found via findPr — returns goto", async () => {
+    const result = await runTriage(
+      { labels: [] },
+      makeWork(),
+      makeDeps({
+        findPr: () => 101,
+        runEstimate: () => ({ scrutiny: "high", reasons: ["large diff"] }),
+      }),
+    );
+    expect(result).toMatchObject({
+      action: "goto",
+      target: "review",
+      scrutiny: "high",
+      prNumber: 101,
+    });
+  });
+
+  test("high scrutiny → target is review", async () => {
+    const result = await runTriage(
+      { labels: [] },
+      makeWork({ prNumber: 100 }),
+      makeDeps({
+        runEstimate: () => ({ scrutiny: "high", reasons: ["complex"] }),
+      }),
+    );
+    expect(result).toMatchObject({ action: "goto", target: "review" });
+  });
+
+  test("low scrutiny → target is qa", async () => {
+    const result = await runTriage(
+      { labels: [] },
+      makeWork({ prNumber: 100 }),
+      makeDeps({
+        runEstimate: () => ({ scrutiny: "low", reasons: ["trivial"] }),
+      }),
+    );
+    expect(result).toMatchObject({ action: "goto", target: "qa" });
+  });
+
+  test("flaky label forces high scrutiny", async () => {
+    const result = await runTriage(
+      { labels: ["flaky"] },
+      makeWork({ prNumber: 100 }),
+      makeDeps({
+        runEstimate: () => ({ scrutiny: "low", reasons: ["small diff"] }),
+      }),
+    );
+    expect(result).toMatchObject({
+      action: "goto",
+      target: "review",
+      scrutiny: "high",
+    });
+    if (result.action === "goto") {
+      expect(result.reason).toContain("label:flaky");
+    }
+  });
+
+  test("flaky label from state when input labels empty", async () => {
+    const result = await runTriage(
+      { labels: [] },
+      makeWork({ prNumber: 100 }),
+      makeDeps({
+        runEstimate: () => ({ scrutiny: "low", reasons: ["ok"] }),
+        stateGet: async <T>(key: string): Promise<T | undefined> =>
+          (key === "labels" ? "flaky" : undefined) as T | undefined,
+      }),
+    );
+    expect(result).toMatchObject({
+      action: "goto",
+      target: "review",
+      scrutiny: "high",
+    });
+  });
+
+  test("metrics passed through from estimate", async () => {
+    const metrics = { files: 3, additions: 42 };
+    const result = await runTriage(
+      { labels: [] },
+      makeWork({ prNumber: 100 }),
+      makeDeps({
+        runEstimate: () => ({
+          scrutiny: "low",
+          reasons: ["ok"],
+          metrics,
+        }),
+      }),
+    );
+    if (result.action === "goto") {
+      expect(result.metrics).toEqual(metrics);
+    }
+  });
+});
+
+// ── (a) Event arrives during wait → resolved with event ──
+
+describe("runTriage — waitForEvent", () => {
+  test("event arrives with prNumber → triage completes", async () => {
+    const result = await runTriage(
+      { labels: [] },
+      makeWork(),
+      makeDeps({
+        findPr: () => null,
+        waitForEvent: async () => ({ event: "pr.opened", prNumber: 200 }),
+        runEstimate: () => ({ scrutiny: "low", reasons: ["ok"] }),
+      }),
+    );
+    expect(result).toMatchObject({
+      action: "goto",
+      prNumber: 200,
+    });
+  });
+
+  test("event arrives without prNumber, re-lookup succeeds", async () => {
+    let calls = 0;
+    const result = await runTriage(
+      { labels: [] },
+      makeWork(),
+      makeDeps({
+        findPr: () => {
+          calls++;
+          return calls >= 2 ? 201 : null;
+        },
+        waitForEvent: async () => ({ event: "session.result" }),
+        runEstimate: () => ({ scrutiny: "low", reasons: ["ok"] }),
+      }),
+    );
+    expect(result).toMatchObject({
+      action: "goto",
+      prNumber: 201,
+    });
+  });
+
+  test("event arrives but re-lookup still fails → wait", async () => {
+    const result = await runTriage(
+      { labels: [] },
+      makeWork(),
+      makeDeps({
+        findPr: () => null,
+        waitForEvent: async () => ({ event: "session.result" }),
+      }),
+    );
+    expect(result).toMatchObject({ action: "wait" });
+    if (result.action === "wait") {
+      expect(result.reason).toContain("no PR found");
+    }
+  });
+});
+
+// ── (b) Timeout elapses with no matching event → wait returned ──
+
+describe("runTriage — timeout", () => {
+  test("WaitTimeoutError → returns wait action", async () => {
+    const result = await runTriage(
+      { labels: [] },
+      makeWork(),
+      makeDeps({
+        findPr: () => null,
+        waitForEvent: () => Promise.reject(makeTimeoutError()),
+      }),
+    );
+    expect(result).toMatchObject({ action: "wait" });
+    if (result.action === "wait") {
+      expect(result.reason).toContain("waiting for pr.opened or session.result");
+    }
+  });
+
+  test("non-WaitTimeoutError is re-thrown", async () => {
+    await expect(
+      runTriage(
+        { labels: [] },
+        makeWork(),
+        makeDeps({
+          findPr: () => null,
+          waitForEvent: () => Promise.reject(new Error("connection refused")),
+        }),
+      ),
+    ).rejects.toThrow("connection refused");
+  });
+});
+
+// ── (c) Replay path — since parameter for backfill window ──
+
+describe("runTriage — replay", () => {
+  test("waitForEvent receives correct filter and timeout", async () => {
+    let capturedFilter: unknown;
+    let capturedOpts: unknown;
+
+    await runTriage(
+      { labels: [] },
+      makeWork({ id: "#99" }),
+      makeDeps({
+        findPr: () => null,
+        waitForEvent: async (filter, opts) => {
+          capturedFilter = filter;
+          capturedOpts = opts;
+          throw makeTimeoutError();
+        },
+      }),
+    );
+
+    expect(capturedFilter).toEqual({
+      type: ["pr.opened", "session.result"],
+      workItem: "#99",
+    });
+    expect(capturedOpts).toMatchObject({ timeoutMs: 30_000 });
+  });
+
+  test("since parameter passes through for backfill replay", async () => {
+    let capturedOpts: unknown;
+
+    await runTriage(
+      { labels: [], since: 42 },
+      makeWork(),
+      makeDeps({
+        findPr: () => null,
+        waitForEvent: async (_filter, opts) => {
+          capturedOpts = opts;
+          throw makeTimeoutError();
+        },
+      }),
+    );
+
+    expect(capturedOpts).toEqual({ timeoutMs: 30_000, since: 42 });
+  });
+
+  test("replayed event with prNumber resolves triage", async () => {
+    const result = await runTriage(
+      { labels: [], since: 10 },
+      makeWork(),
+      makeDeps({
+        findPr: () => null,
+        waitForEvent: async () => ({
+          event: "pr.opened",
+          prNumber: 300,
+        }),
+        runEstimate: () => ({ scrutiny: "low", reasons: ["ok"] }),
+      }),
+    );
+    expect(result).toMatchObject({
+      action: "goto",
+      prNumber: 300,
+    });
+  });
+});
+
+// ── Validation ──
+
+describe("runTriage — validation", () => {
+  test("throws when issueNumber missing", async () => {
+    await expect(runTriage({ labels: [] }, makeWork({ issueNumber: null }), makeDeps())).rejects.toThrow("issueNumber");
+  });
+
+  test("throws when branch missing", async () => {
+    await expect(runTriage({ labels: [] }, makeWork({ branch: null }), makeDeps())).rejects.toThrow("branch");
+  });
+
+  test("throws when both missing — lists both", async () => {
+    await expect(runTriage({ labels: [] }, makeWork({ issueNumber: null, branch: null }), makeDeps())).rejects.toThrow(
+      "issueNumber' and 'branch'",
+    );
+  });
+});
+
+// ── State writes ─��
+
+describe("runTriage — state", () => {
+  test("writes triage_scrutiny and triage_reasons", async () => {
+    const stateWrites: Record<string, unknown> = {};
+    await runTriage(
+      { labels: [] },
+      makeWork({ prNumber: 100 }),
+      makeDeps({
+        runEstimate: () => ({ scrutiny: "low", reasons: ["small", "clean"] }),
+        stateSet: async (key, value) => {
+          stateWrites[key] = value;
+        },
+      }),
+    );
+    expect(stateWrites.triage_scrutiny).toBe("low");
+    expect(stateWrites.triage_reasons).toBe("small; clean");
+  });
+
+  test("updateWorkItem failure is swallowed", async () => {
+    const result = await runTriage(
+      { labels: [] },
+      makeWork({ prNumber: 100 }),
+      makeDeps({
+        runEstimate: () => ({ scrutiny: "low", reasons: ["ok"] }),
+        updateWorkItem: () => Promise.reject(new Error("unavailable")),
+      }),
+    );
+    expect(result.action).toBe("goto");
+  });
+
+  test("updateWorkItem called with correct args", async () => {
+    let calledWith: { id: string; prNumber: number } | undefined;
+    await runTriage(
+      { labels: [] },
+      makeWork({ id: "#55", prNumber: 100 }),
+      makeDeps({
+        runEstimate: () => ({ scrutiny: "low", reasons: ["ok"] }),
+        updateWorkItem: async (id, prNumber) => {
+          calledWith = { id, prNumber };
+        },
+      }),
+    );
+    expect(calledWith).toEqual({ id: "#55", prNumber: 100 });
+  });
+});


### PR DESCRIPTION
## Summary
- Migrates `.claude/phases/triage.ts` from throwing when no PR found to event-driven waiting via `ctx.waitForEvent({ type: ["pr.opened", "session.result"], workItem })` with 30s timeout
- Aligns triage output schema with the standard `action`-based pattern (`goto`/`wait`) used by `review.ts`, `qa.ts`, and other phases — replaces the non-standard `{ decision, scrutiny, reasons }` shape
- Extracts core logic into `triage-fn.ts` with dependency injection for testability (no `mock.module()` per project rules)
- Adds optional `since` input parameter for backfill replay to close the race window between PR check and event subscription

## Test plan
- [x] 21 unit tests in `test/triage-phase.spec.ts` covering:
  - Happy paths: PR on work item, PR via findPr, high/low scrutiny, flaky label override (input + state), metrics passthrough
  - (a) Event arrives during wait: prNumber on event, re-lookup after session.result, re-lookup still fails → wait
  - (b) Timeout: WaitTimeoutError → `{ action: "wait" }`, non-timeout errors re-thrown
  - (c) Replay: filter/timeout verification, `since` passthrough, replayed event resolves triage
  - Validation: missing issueNumber, branch, both
  - State: triage_scrutiny/triage_reasons writes, updateWorkItem failure swallowed
- [x] `bun typecheck` passes
- [x] `bun lint` passes (no fixes needed)
- [x] Full test suite: 6185 pass, 2 pre-existing fail (ipc-server.spec.ts gap control — unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)