### PR TITLE
feat(daemon): lifecycle events — worker.ratelimited, daemon.restarted, daemon.config_reloaded, gc.pruned (fixes #1586)

### DIFF
--- a/packages/command/src/commands/gc.ts
+++ b/packages/command/src/commands/gc.ts
@@ -283,7 +283,10 @@ export async function runGc(opts: GcOptions, deps: GcDeps): Promise<GcResult> {
       const tooRecent = recentSkipped.length > 0 ? `, skipped ${recentSkipped.length} too recent` : "";
       deps.logError(`worktrees: removed ${result.pruned}${unmerged}${tooRecent}`);
       if (result.pruned > 0) {
-        gcResult.prunedWorktrees = result.removable.slice(0, result.pruned);
+        gcResult.prunedWorktrees = result.prunedNames;
+        for (const b of result.deletedBranches) {
+          if (!gcResult.deletedBranches.includes(b)) gcResult.deletedBranches.push(b);
+        }
       }
     }
   }

--- a/packages/command/src/commands/gc.ts
+++ b/packages/command/src/commands/gc.ts
@@ -8,6 +8,7 @@
 
 import { statSync } from "node:fs";
 import {
+  GC_PRUNED,
   WorktreeError,
   type WorktreeShimDeps,
   getDefaultBranch,
@@ -158,12 +159,18 @@ export function defaultGcDeps(): GcDeps {
   };
 }
 
+export interface GcResult {
+  prunedWorktrees: string[];
+  deletedBranches: string[];
+}
+
 /**
  * Core gc logic — pure enough to test with injected deps.
  */
-export async function runGc(opts: GcOptions, deps: GcDeps): Promise<void> {
+export async function runGc(opts: GcOptions, deps: GcDeps): Promise<GcResult> {
   const { cwd } = deps;
   const prefix = opts.dryRun ? `${c.dim}[dry-run]${c.reset} ` : "";
+  const gcResult: GcResult = { prunedWorktrees: [], deletedBranches: [] };
 
   // Branches deleted during the worktree phase — skipped by the branch phase
   // to avoid "not found" false failures on the second `git branch -d`.
@@ -190,7 +197,7 @@ export async function runGc(opts: GcOptions, deps: GcDeps): Promise<void> {
     } catch (e) {
       if (!opts.dryRun) {
         deps.logError(`gc: ${e instanceof Error ? e.message : String(e)}`);
-        return;
+        return gcResult;
       }
       // dry-run: degrade gracefully — warn and continue with empty set.
       deps.logError("gc: active-session filter skipped — daemon unreachable (dry-run)");
@@ -204,7 +211,7 @@ export async function runGc(opts: GcOptions, deps: GcDeps): Promise<void> {
       listed = listMcxWorktrees(cwd, deps);
     } catch (e) {
       deps.logError(`gc: ${e instanceof WorktreeError ? e.message : String(e)}`);
-      return;
+      return gcResult;
     }
 
     const recentSkipped: string[] = [];
@@ -275,6 +282,9 @@ export async function runGc(opts: GcOptions, deps: GcDeps): Promise<void> {
       const unmerged = result.skippedUnmerged.length > 0 ? `, skipped ${result.skippedUnmerged.length} unmerged` : "";
       const tooRecent = recentSkipped.length > 0 ? `, skipped ${recentSkipped.length} too recent` : "";
       deps.logError(`worktrees: removed ${result.pruned}${unmerged}${tooRecent}`);
+      if (result.pruned > 0) {
+        gcResult.prunedWorktrees = result.removable.slice(0, result.pruned);
+      }
     }
   }
 
@@ -320,6 +330,7 @@ export async function runGc(opts: GcOptions, deps: GcDeps): Promise<void> {
         const { exitCode, stderr } = deps.exec(["git", "-C", cwd, "branch", flag, b]);
         if (exitCode === 0) {
           deleted++;
+          gcResult.deletedBranches.push(b);
         } else {
           failed.push(`${b}: ${stderr.trim()}`);
         }
@@ -328,6 +339,8 @@ export async function runGc(opts: GcOptions, deps: GcDeps): Promise<void> {
       for (const f of failed) deps.logError(`  ${f}`);
     }
   }
+
+  return gcResult;
 }
 
 function getMergedBranches(deps: WorktreeShimDeps, cwd: string, defaultBranch: string): string[] {
@@ -364,5 +377,22 @@ export async function cmdGc(args: string[], overrides: { dryRun?: boolean } = {}
     process.exit(1);
   }
   if (overrides.dryRun) opts.dryRun = true;
-  await runGc(opts, defaultGcDeps());
+  const result = await runGc(opts, defaultGcDeps());
+
+  if (!opts.dryRun && (result.prunedWorktrees.length > 0 || result.deletedBranches.length > 0)) {
+    try {
+      await ipcCall("publishEvent", {
+        src: "cli.gc",
+        event: GC_PRUNED,
+        category: "gc",
+        extra: {
+          worktrees: result.prunedWorktrees,
+          branches: result.deletedBranches,
+          reason: "manual",
+        },
+      });
+    } catch {
+      // Best-effort: daemon may be unavailable
+    }
+  }
 }

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -8,6 +8,7 @@
 import { z } from "zod/v4";
 import type { AliasType } from "./alias";
 import type { MonitorAliasMetadata } from "./alias-bundle";
+import { MONITOR_CATEGORIES } from "./monitor-event";
 import type { PlanProtocolCapability } from "./plan";
 import type { SpanEvent } from "./trace";
 import type { WorkItem } from "./work-item";
@@ -509,7 +510,7 @@ export interface AliasStateAllResult {
 export const PublishEventParamsSchema = z.object({
   src: z.string().min(1),
   event: z.string().min(1),
-  category: z.string().min(1),
+  category: z.enum(MONITOR_CATEGORIES),
   sessionId: z.string().optional(),
   workItemId: z.string().optional(),
   prNumber: z.number().optional(),

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -62,7 +62,8 @@ export type IpcMethod =
   | "aliasStateGet"
   | "aliasStateSet"
   | "aliasStateDelete"
-  | "aliasStateAll";
+  | "aliasStateAll"
+  | "publishEvent";
 
 // -- Request/Response --
 
@@ -505,6 +506,21 @@ export interface AliasStateAllResult {
   entries: Record<string, unknown>;
 }
 
+export const PublishEventParamsSchema = z.object({
+  src: z.string().min(1),
+  event: z.string().min(1),
+  category: z.string().min(1),
+  sessionId: z.string().optional(),
+  workItemId: z.string().optional(),
+  prNumber: z.number().optional(),
+  extra: z.record(z.string(), z.unknown()).optional(),
+});
+
+export interface PublishEventResult {
+  ok: true;
+  seq: number;
+}
+
 // -- Result types for methods without a named interface --
 
 export interface PingResult {
@@ -700,6 +716,7 @@ export interface IpcMethodResult {
   aliasStateSet: AliasStateSetResult;
   aliasStateDelete: AliasStateDeleteResult;
   aliasStateAll: AliasStateAllResult;
+  publishEvent: PublishEventResult;
 }
 
 // -- Error codes --

--- a/packages/core/src/monitor-event.spec.ts
+++ b/packages/core/src/monitor-event.spec.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import type { MonitorEvent } from "./monitor-event";
+import {
+  DAEMON_CONFIG_RELOADED,
+  DAEMON_RESTARTED,
+  GC_PRUNED,
+  WORKER_RATELIMITED,
+  formatMonitorEvent,
+} from "./monitor-event";
+
+function makeEvent(overrides: Partial<MonitorEvent> & { event: string }): MonitorEvent {
+  return {
+    seq: 1,
+    ts: new Date().toISOString(),
+    src: "test",
+    category: "daemon",
+    ...overrides,
+  };
+}
+
+describe("formatMonitorEvent — lifecycle events", () => {
+  test("worker.ratelimited includes provider and retry", () => {
+    const line = formatMonitorEvent(
+      makeEvent({
+        event: WORKER_RATELIMITED,
+        category: "worker",
+        sessionId: "sess-abc123",
+        provider: "anthropic",
+        retryAfterMs: 30000,
+      }),
+    );
+    expect(line).toContain("worker.ratelimited");
+    expect(line).toContain("anthropic");
+    expect(line).toContain("retry in 30s");
+    expect(line).toContain("sess-abc");
+  });
+
+  test("worker.ratelimited without retryAfterMs omits retry", () => {
+    const line = formatMonitorEvent(
+      makeEvent({
+        event: WORKER_RATELIMITED,
+        category: "worker",
+        sessionId: "sess-x",
+        provider: "anthropic",
+      }),
+    );
+    expect(line).toContain("anthropic");
+    expect(line).not.toContain("retry in");
+  });
+
+  test("daemon.restarted shows reason and seq range", () => {
+    const line = formatMonitorEvent(
+      makeEvent({
+        event: DAEMON_RESTARTED,
+        reason: "start",
+        seqBefore: 42,
+        seqAfter: 43,
+      }),
+    );
+    expect(line).toContain("daemon.restarted");
+    expect(line).toContain("start");
+    expect(line).toContain("seq:42");
+    expect(line).toContain("→43");
+  });
+
+  test("daemon.config_reloaded shows changed keys", () => {
+    const line = formatMonitorEvent(
+      makeEvent({
+        event: DAEMON_CONFIG_RELOADED,
+        changedKeys: ["server-a", "server-b"],
+      }),
+    );
+    expect(line).toContain("daemon.config_reloaded");
+    expect(line).toContain("server-a, server-b");
+  });
+
+  test("daemon.config_reloaded with path shows truncated path", () => {
+    const line = formatMonitorEvent(
+      makeEvent({
+        event: DAEMON_CONFIG_RELOADED,
+        path: "/home/user/.mcp-cli/servers.json",
+        changedKeys: ["x"],
+      }),
+    );
+    expect(line).toContain("daemon.config_reloaded");
+    expect(line).toContain("servers.json");
+  });
+
+  test("gc.pruned shows worktree and branch counts", () => {
+    const line = formatMonitorEvent(
+      makeEvent({
+        event: GC_PRUNED,
+        category: "gc",
+        worktrees: ["wt-a", "wt-b"],
+        branches: ["br-1"],
+        reason: "manual",
+      }),
+    );
+    expect(line).toContain("gc.pruned");
+    expect(line).toContain("2wt");
+    expect(line).toContain("1br");
+    expect(line).toContain("manual");
+  });
+
+  test("gc.pruned with empty arrays shows 0 counts", () => {
+    const line = formatMonitorEvent(
+      makeEvent({
+        event: GC_PRUNED,
+        category: "gc",
+        worktrees: [],
+        branches: [],
+      }),
+    );
+    expect(line).toContain("0wt");
+    expect(line).toContain("0br");
+  });
+});

--- a/packages/core/src/monitor-event.spec.ts
+++ b/packages/core/src/monitor-event.spec.ts
@@ -63,6 +63,19 @@ describe("formatMonitorEvent — lifecycle events", () => {
     expect(line).toContain("→43");
   });
 
+  test("daemon.restarted falls back to seq when seqAfter absent", () => {
+    const line = formatMonitorEvent(
+      makeEvent({
+        seq: 5,
+        event: DAEMON_RESTARTED,
+        reason: "start",
+        seqBefore: 4,
+      }),
+    );
+    expect(line).toContain("seq:4");
+    expect(line).toContain("→5");
+  });
+
   test("daemon.config_reloaded shows changed keys", () => {
     const line = formatMonitorEvent(
       makeEvent({

--- a/packages/core/src/monitor-event.ts
+++ b/packages/core/src/monitor-event.ts
@@ -338,7 +338,8 @@ const FORMATTERS: Partial<Record<string, Formatter>> = {
   [DAEMON_RESTARTED]: (e) => {
     const reason = typeof e.reason === "string" ? e.reason : "";
     const before = typeof e.seqBefore === "number" ? `seq:${e.seqBefore}` : "";
-    const after = typeof e.seqAfter === "number" ? `→${e.seqAfter}` : "";
+    const seqAfter = typeof e.seqAfter === "number" ? e.seqAfter : e.seq;
+    const after = typeof seqAfter === "number" ? `→${seqAfter}` : "";
     return join(reason, before + after);
   },
 

--- a/packages/core/src/monitor-event.ts
+++ b/packages/core/src/monitor-event.ts
@@ -11,18 +11,21 @@
 
 // ── Event categories ──
 
-export type MonitorCategory =
-  | "session"
-  | "work_item"
-  | "ci"
-  | "copilot"
-  | "review"
-  | "issue"
-  | "mail"
-  | "heartbeat"
-  | "worker"
-  | "daemon"
-  | "gc";
+export const MONITOR_CATEGORIES = [
+  "session",
+  "work_item",
+  "ci",
+  "copilot",
+  "review",
+  "issue",
+  "mail",
+  "heartbeat",
+  "worker",
+  "daemon",
+  "gc",
+] as const;
+
+export type MonitorCategory = (typeof MONITOR_CATEGORIES)[number];
 
 // ── Session event names ──
 

--- a/packages/core/src/monitor-event.ts
+++ b/packages/core/src/monitor-event.ts
@@ -11,7 +11,18 @@
 
 // ── Event categories ──
 
-export type MonitorCategory = "session" | "work_item" | "ci" | "copilot" | "review" | "issue" | "mail" | "heartbeat";
+export type MonitorCategory =
+  | "session"
+  | "work_item"
+  | "ci"
+  | "copilot"
+  | "review"
+  | "issue"
+  | "mail"
+  | "heartbeat"
+  | "worker"
+  | "daemon"
+  | "gc";
 
 // ── Session event names ──
 
@@ -65,6 +76,19 @@ export const ISSUE_COMMENT = "issue.comment" as const;
 // ── Mail event names ──
 
 export const MAIL_RECEIVED = "mail.received" as const;
+
+// ── Worker event names (#1586) ──
+
+export const WORKER_RATELIMITED = "worker.ratelimited" as const;
+
+// ── Daemon lifecycle event names (#1586) ──
+
+export const DAEMON_RESTARTED = "daemon.restarted" as const;
+export const DAEMON_CONFIG_RELOADED = "daemon.config_reloaded" as const;
+
+// ── GC event names (#1586) ──
+
+export const GC_PRUNED = "gc.pruned" as const;
 
 // ── Heartbeat ──
 
@@ -300,6 +324,32 @@ const FORMATTERS: Partial<Record<string, Formatter>> = {
     const sender = typeof e.sender === "string" ? e.sender : "";
     const recipient = typeof e.recipient === "string" ? e.recipient : "";
     return join(sender, "→", recipient);
+  },
+
+  [WORKER_RATELIMITED]: (e) => {
+    const retry = typeof e.retryAfterMs === "number" ? `retry in ${Math.round(e.retryAfterMs / 1000)}s` : "";
+    const provider = typeof e.provider === "string" ? e.provider : "";
+    return join(sid(e), provider, retry);
+  },
+
+  [DAEMON_RESTARTED]: (e) => {
+    const reason = typeof e.reason === "string" ? e.reason : "";
+    const before = typeof e.seqBefore === "number" ? `seq:${e.seqBefore}` : "";
+    const after = typeof e.seqAfter === "number" ? `→${e.seqAfter}` : "";
+    return join(reason, before + after);
+  },
+
+  [DAEMON_CONFIG_RELOADED]: (e) => {
+    const keys = Array.isArray(e.changedKeys) ? (e.changedKeys as string[]).join(", ") : "";
+    const path = typeof e.path === "string" ? e.path : "";
+    return join(path && cap(path, 40), keys && `keys: ${keys}`);
+  },
+
+  [GC_PRUNED]: (e) => {
+    const wt = Array.isArray(e.worktrees) ? `${(e.worktrees as string[]).length}wt` : "";
+    const br = Array.isArray(e.branches) ? `${(e.branches as string[]).length}br` : "";
+    const reason = typeof e.reason === "string" ? e.reason : "";
+    return join(wt, br, reason);
   },
 
   [HEARTBEAT]: (e) => `seq:${e.seq}`,

--- a/packages/core/src/worktree-shim.spec.ts
+++ b/packages/core/src/worktree-shim.spec.ts
@@ -619,6 +619,7 @@ describe("pruneWorktrees", () => {
     });
 
     expect(result.pruned).toBe(1);
+    expect(result.prunedNames).toEqual(["feat-done"]);
     expect(result.skippedUnmerged).toEqual([]);
   });
 

--- a/packages/core/src/worktree-shim.ts
+++ b/packages/core/src/worktree-shim.ts
@@ -83,6 +83,8 @@ export interface WorktreePruneResult {
   pruned: number;
   /** Names of worktrees that would be or were removed. */
   removable: string[];
+  /** Names of worktrees that were actually removed (empty in dry-run). */
+  prunedNames: string[];
   skippedUnmerged: string[];
   /** Branches that were deleted (empty in dry-run). */
   deletedBranches: Set<string>;
@@ -457,6 +459,7 @@ export async function pruneWorktrees(opts: WorktreePruneOptions): Promise<Worktr
 
   let pruned = 0;
   const removable: string[] = [];
+  const prunedNames: string[] = [];
   const skippedUnmerged: string[] = [];
   const deletedBranches = new Set<string>();
   // Resolve symlinks on cwd — macOS does not resolve them in process.cwd(),
@@ -512,6 +515,7 @@ export async function pruneWorktrees(opts: WorktreePruneOptions): Promise<Worktr
       if (hookExit === 0 && !existsSync(wt.path)) {
         deps.printInfo(`Removed worktree via hook: ${wt.path}`);
         pruned++;
+        prunedNames.push(wtName);
         if (wt.branch && deleteIfSafeToDelete(wt.branch, repoRoot, deps)) {
           deletedBranches.add(wt.branch);
         }
@@ -523,6 +527,7 @@ export async function pruneWorktrees(opts: WorktreePruneOptions): Promise<Worktr
     } else {
       if (removeWorktreeWithVerification(repoRoot, wt.path, deps)) {
         pruned++;
+        prunedNames.push(wtName);
         if (wt.branch && deleteIfSafeToDelete(wt.branch, repoRoot, deps)) {
           deletedBranches.add(wt.branch);
         }
@@ -539,7 +544,7 @@ export async function pruneWorktrees(opts: WorktreePruneOptions): Promise<Worktr
     }
   }
 
-  return { pruned, removable, skippedUnmerged, deletedBranches };
+  return { pruned, removable, prunedNames, skippedUnmerged, deletedBranches };
 }
 
 // ── Errors ──

--- a/packages/daemon/src/claude-session/session-state.spec.ts
+++ b/packages/daemon/src/claude-session/session-state.spec.ts
@@ -888,7 +888,7 @@ describe("SessionState", () => {
 
       expect(events).toHaveLength(2);
       expect(events[0].type).toBe("session:response");
-      expect(events[1]).toEqual({ type: "session:rate_limited", sessionId: "sess-1" });
+      expect(events[1]).toMatchObject({ type: "session:rate_limited", sessionId: "sess-1" });
       expect(session.rateLimited).toBe(true);
     });
 
@@ -934,7 +934,37 @@ describe("SessionState", () => {
       expect(session.rateLimited).toBe(true);
       expect(session.parseMismatch).toBe(true);
       expect(events).toHaveLength(2);
-      expect(events[1]).toEqual({ type: "session:rate_limited", sessionId: "test-rl" });
+      expect(events[1]).toMatchObject({ type: "session:rate_limited", sessionId: "test-rl" });
+    });
+
+    test("retryAfterMs extracted from raw message", () => {
+      const session = initSession();
+      const events = session.handleMessage({
+        ...ASSISTANT_RATE_LIMITED,
+        retry_after_ms: 30000,
+      });
+
+      expect(events).toHaveLength(2);
+      expect(events[1]).toMatchObject({
+        type: "session:rate_limited",
+        sessionId: "sess-1",
+        retryAfterMs: 30000,
+      });
+    });
+
+    test("retryAfterMs converts retry_after seconds to ms", () => {
+      const session = initSession();
+      const events = session.handleMessage({
+        ...ASSISTANT_RATE_LIMITED,
+        retry_after: 30,
+      });
+
+      expect(events).toHaveLength(2);
+      expect(events[1]).toMatchObject({
+        type: "session:rate_limited",
+        sessionId: "sess-1",
+        retryAfterMs: 30000,
+      });
     });
   });
 

--- a/packages/daemon/src/claude-session/session-state.ts
+++ b/packages/daemon/src/claude-session/session-state.ts
@@ -36,7 +36,7 @@ export type SessionEvent =
   | { type: "session:permission_request"; requestId: string; request: CanUseToolMsg["request"] }
   | { type: "session:result"; cost: number; tokens: number; numTurns: number; result: string }
   | { type: "session:error"; errors: string[]; cost: number }
-  | { type: "session:rate_limited"; sessionId: string }
+  | { type: "session:rate_limited"; sessionId: string; retryAfterMs?: number }
   | { type: "session:disconnected"; reason: string }
   | { type: "session:ended" }
   | { type: "session:cleared" }
@@ -263,7 +263,8 @@ export class SessionState {
       const events: SessionEvent[] = [{ type: "session:response", message: strict.data }];
       if (strict.data.error === "rate_limit") {
         this.rateLimited = true;
-        events.push({ type: "session:rate_limited", sessionId: this.sessionId });
+        const retryAfterMs = extractRetryAfterMs(msg);
+        events.push({ type: "session:rate_limited", sessionId: this.sessionId, retryAfterMs });
       }
       return events;
     }
@@ -282,7 +283,8 @@ export class SessionState {
       const events: SessionEvent[] = [{ type: "session:response", message: assistant }];
       if (assistant.error === "rate_limit") {
         this.rateLimited = true;
-        events.push({ type: "session:rate_limited", sessionId: this.sessionId });
+        const retryAfterMs = extractRetryAfterMs(msg);
+        events.push({ type: "session:rate_limited", sessionId: this.sessionId, retryAfterMs });
       }
       return events;
     }
@@ -404,6 +406,12 @@ export class SessionState {
       },
     ];
   }
+}
+
+function extractRetryAfterMs(msg: NdjsonMessage): number | undefined {
+  if (typeof msg.retry_after_ms === "number") return msg.retry_after_ms;
+  if (typeof msg.retry_after === "number") return msg.retry_after * 1000;
+  return undefined;
 }
 
 /**

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -3952,7 +3952,7 @@ describe("monitor event mapping", () => {
       expect(events[0].model).toBe("claude-opus-4-7");
     });
 
-    test("session:rate_limited maps to session.rate_limited", () => {
+    test("session:rate_limited does not emit duplicate session event (worker.ratelimited is canonical)", () => {
       const server = makeServer();
       const events = collect(server);
 
@@ -3961,9 +3961,7 @@ describe("monitor event mapping", () => {
         sessionId: "s10",
       });
 
-      expect(events).toHaveLength(1);
-      expect(events[0].event).toBe("session.rate_limited");
-      expect(events[0].sessionId).toBe("s10");
+      expect(events).toHaveLength(0);
     });
 
     test("session:disconnected maps to session.disconnected with reason", () => {

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -46,6 +46,7 @@ import {
   SESSION_RATE_LIMITED,
   SESSION_RESULT,
   SESSION_STUCK,
+  WORKER_RATELIMITED,
   consoleLogger,
   generateSessionName,
 } from "@mcp-cli/core";
@@ -1711,6 +1712,13 @@ export class ClaudeWsServer {
         } catch (err) {
           logErr("resolveEventWaiters failed", err);
         }
+        this.onMonitorEvent?.({
+          src: "daemon.claude-server",
+          event: WORKER_RATELIMITED,
+          category: "worker",
+          sessionId,
+          provider: "anthropic",
+        });
         break;
       case "session:disconnected":
         this.disposeStuckDetector(session);

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -43,7 +43,6 @@ import {
   SESSION_IDLE,
   SESSION_MODEL_CHANGED,
   SESSION_PERMISSION_REQUEST,
-  SESSION_RATE_LIMITED,
   SESSION_RESULT,
   SESSION_STUCK,
   WORKER_RATELIMITED,
@@ -1718,6 +1717,8 @@ export class ClaudeWsServer {
           category: "worker",
           sessionId,
           provider: "anthropic",
+          ...("retryAfterMs" in event &&
+            typeof event.retryAfterMs === "number" && { retryAfterMs: event.retryAfterMs }),
         });
         break;
       case "session:disconnected":
@@ -1759,7 +1760,6 @@ export class ClaudeWsServer {
     "session:error": SESSION_ERROR,
     "session:cleared": SESSION_CLEARED,
     "session:model_changed": SESSION_MODEL_CHANGED,
-    "session:rate_limited": SESSION_RATE_LIMITED,
     "session:disconnected": SESSION_DISCONNECTED,
     "session:ended": SESSION_ENDED,
     "session:containment_warning": SESSION_CONTAINMENT_WARNING,

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -562,9 +562,9 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
     event: DAEMON_RESTARTED,
     category: "daemon",
     seqBefore,
+    seqAfter: seqBefore + 1,
     reason: "start",
   });
-  restartedEvent.seqAfter = restartedEvent.seq;
   logger.info(`[mcpd] Published daemon.restarted (seqBefore=${seqBefore}, seqAfter=${restartedEvent.seqAfter})`);
 
   // Watch config files for hot reload

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -32,8 +32,10 @@ import {
   BUILD_VERSION,
   CLAUDE_SERVER_NAME,
   CODEX_SERVER_NAME,
+  DAEMON_CONFIG_RELOADED,
   DAEMON_IDLE_TIMEOUT_MS,
   DAEMON_READY_SIGNAL,
+  DAEMON_RESTARTED,
   DEFAULT_CLAUDE_WS_PORT,
   MAIL_SERVER_NAME,
   METRICS_SERVER_NAME,
@@ -549,9 +551,26 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
     }, idleTimeoutMs);
   }
 
+  const eventLog = new EventLog(db.getDatabase());
+  const seqBefore = eventLog.currentSeq();
+  eventLog.startPruning();
+  const mailEventBus = new EventBus(eventLog);
+  mailServer.setEventBus(mailEventBus);
+
+  const restartedEvent = mailEventBus.publish({
+    src: "daemon",
+    event: DAEMON_RESTARTED,
+    category: "daemon",
+    seqBefore,
+    seqAfter: seqBefore + 1,
+    reason: "start",
+  });
+  logger.info(`[mcpd] Published daemon.restarted (seqBefore=${seqBefore}, seqAfter=${restartedEvent.seq})`);
+
   // Watch config files for hot reload
   const watcher = new ConfigWatcher(config, (event) => {
     const { added, removed, changed } = pool.updateConfig(event.config);
+    const changedKeys = [...added, ...removed, ...changed];
     const parts: string[] = [];
     if (added.length) parts.push(`added: ${added.join(", ")}`);
     if (removed.length) parts.push(`removed: ${removed.join(", ")}`);
@@ -561,6 +580,12 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
     } else {
       logger.info("[mcpd] Config reloaded (no server changes)");
     }
+    mailEventBus.publish({
+      src: "daemon",
+      event: DAEMON_CONFIG_RELOADED,
+      category: "daemon",
+      changedKeys,
+    });
     // Update PID file with new hash (use locked fd if available)
     const updatedPid = {
       pid: process.pid,
@@ -577,11 +602,6 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
     }
   });
   watcher.start();
-
-  const eventLog = new EventLog(db.getDatabase());
-  eventLog.startPruning();
-  const mailEventBus = new EventBus(eventLog);
-  mailServer.setEventBus(mailEventBus);
 
   // Start IPC server
   const ipcServer = new IpcServer(pool, config, db, aliasServer, {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -562,10 +562,10 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
     event: DAEMON_RESTARTED,
     category: "daemon",
     seqBefore,
-    seqAfter: seqBefore + 1,
     reason: "start",
   });
-  logger.info(`[mcpd] Published daemon.restarted (seqBefore=${seqBefore}, seqAfter=${restartedEvent.seq})`);
+  restartedEvent.seqAfter = restartedEvent.seq;
+  logger.info(`[mcpd] Published daemon.restarted (seqBefore=${seqBefore}, seqAfter=${restartedEvent.seqAfter})`);
 
   // Watch config files for hot reload
   const watcher = new ConfigWatcher(config, (event) => {
@@ -580,12 +580,14 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
     } else {
       logger.info("[mcpd] Config reloaded (no server changes)");
     }
-    mailEventBus.publish({
-      src: "daemon",
-      event: DAEMON_CONFIG_RELOADED,
-      category: "daemon",
-      changedKeys,
-    });
+    if (changedKeys.length > 0) {
+      mailEventBus.publish({
+        src: "daemon",
+        event: DAEMON_CONFIG_RELOADED,
+        category: "daemon",
+        changedKeys,
+      });
+    }
     // Update PID file with new hash (use locked fd if available)
     const updatedPid = {
       pid: process.pid,

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -1343,13 +1343,13 @@ export class IpcServer {
         throw Object.assign(new Error("EventBus not available"), { code: IPC_ERROR.INTERNAL_ERROR });
       }
       const input: MonitorEventInput = {
+        ...(parsed.extra && parsed.extra),
         src: parsed.src,
         event: parsed.event,
-        category: parsed.category as MonitorEventInput["category"],
-        ...(parsed.sessionId && { sessionId: parsed.sessionId }),
-        ...(parsed.workItemId && { workItemId: parsed.workItemId }),
+        category: parsed.category,
+        ...(parsed.sessionId !== undefined && { sessionId: parsed.sessionId }),
+        ...(parsed.workItemId !== undefined && { workItemId: parsed.workItemId }),
         ...(parsed.prNumber !== undefined && { prNumber: parsed.prNumber }),
-        ...(parsed.extra && parsed.extra),
       };
       const published = this.eventBus.publish(input);
       return { ok: true as const, seq: published.seq };

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -49,8 +49,10 @@ import {
   MarkReadParamsSchema,
   MarkSpansExportedParamsSchema,
   type MonitorEvent,
+  type MonitorEventInput,
   PROTOCOL_VERSION,
   PruneSpansParamsSchema,
+  PublishEventParamsSchema,
   ReadMailParamsSchema,
   RecordAliasRunParamsSchema,
   RegisterServeParamsSchema,
@@ -1333,6 +1335,24 @@ export class IpcServer {
       const parsed = AliasStateAllParamsSchema.parse(params);
       const repoRoot = resolveRealpath(resolve(parsed.repoRoot));
       return { entries: this.db.listAliasState(repoRoot, parsed.namespace) };
+    });
+
+    this.handlers.set("publishEvent", async (params, _ctx) => {
+      const parsed = PublishEventParamsSchema.parse(params);
+      if (!this.eventBus) {
+        throw Object.assign(new Error("EventBus not available"), { code: IPC_ERROR.INTERNAL_ERROR });
+      }
+      const input: MonitorEventInput = {
+        src: parsed.src,
+        event: parsed.event,
+        category: parsed.category as MonitorEventInput["category"],
+        ...(parsed.sessionId && { sessionId: parsed.sessionId }),
+        ...(parsed.workItemId && { workItemId: parsed.workItemId }),
+        ...(parsed.prNumber !== undefined && { prNumber: parsed.prNumber }),
+        ...(parsed.extra && parsed.extra),
+      };
+      const published = this.eventBus.publish(input);
+      return { ok: true as const, seq: published.seq };
     });
 
     this.handlers.set("shutdown", async (params, _ctx) => {

--- a/packages/daemon/src/lifecycle-events.spec.ts
+++ b/packages/daemon/src/lifecycle-events.spec.ts
@@ -5,7 +5,6 @@ import {
   DAEMON_RESTARTED,
   GC_PRUNED,
   type MonitorEvent,
-  type MonitorEventInput,
   WORKER_RATELIMITED,
 } from "@mcp-cli/core";
 import { ConfigWatcher } from "./config/watcher";
@@ -45,9 +44,9 @@ describe("daemon.restarted", () => {
       event: DAEMON_RESTARTED,
       category: "daemon",
       seqBefore,
-      seqAfter: seqBefore + 1,
       reason: "start",
     });
+    restartedEvent.seqAfter = restartedEvent.seq;
 
     expect(restartedEvent.seq).toBe(4);
     expect(restartedEvent.seqBefore).toBe(3);
@@ -68,9 +67,9 @@ describe("daemon.restarted", () => {
       event: DAEMON_RESTARTED,
       category: "daemon",
       seqBefore,
-      seqAfter: seqBefore + 1,
       reason: "start",
     });
+    event.seqAfter = event.seq;
 
     expect(event.seq).toBe(1);
     expect(event.seqBefore).toBe(0);
@@ -81,14 +80,14 @@ describe("daemon.restarted", () => {
     const log = freshLog();
     const bus = new EventBus(log);
 
-    bus.publish({
+    const restartedEvent = bus.publish({
       src: "daemon",
       event: DAEMON_RESTARTED,
       category: "daemon",
       seqBefore: 0,
-      seqAfter: 1,
       reason: "start",
     });
+    restartedEvent.seqAfter = restartedEvent.seq;
 
     const events = log.getSince(0);
     expect(events).toHaveLength(1);

--- a/packages/daemon/src/lifecycle-events.spec.ts
+++ b/packages/daemon/src/lifecycle-events.spec.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import {
   DAEMON_CONFIG_RELOADED,
   DAEMON_RESTARTED,
@@ -11,14 +11,27 @@ import { ConfigWatcher } from "./config/watcher";
 import { EventBus } from "./event-bus";
 import { EventLog } from "./event-log";
 
+const openDbs: Database[] = [];
+afterEach(() => {
+  for (const db of openDbs)
+    try {
+      db.close();
+    } catch {
+      /* already closed */
+    }
+  openDbs.length = 0;
+});
+
 function freshLog(): EventLog {
   const db = new Database(":memory:");
+  openDbs.push(db);
   db.exec("PRAGMA journal_mode = WAL");
   return new EventLog(db);
 }
 
 function freshDb(): Database {
   const db = new Database(":memory:");
+  openDbs.push(db);
   db.exec("PRAGMA journal_mode = WAL");
   return db;
 }
@@ -38,15 +51,18 @@ describe("daemon.restarted", () => {
     const seqBefore = log2.currentSeq();
     expect(seqBefore).toBe(3);
 
+    const received: MonitorEvent[] = [];
     const bus2 = new EventBus(log2);
+    bus2.subscribe((e) => received.push(e));
+
     const restartedEvent = bus2.publish({
       src: "daemon",
       event: DAEMON_RESTARTED,
       category: "daemon",
       seqBefore,
+      seqAfter: seqBefore + 1,
       reason: "start",
     });
-    restartedEvent.seqAfter = restartedEvent.seq;
 
     expect(restartedEvent.seq).toBe(4);
     expect(restartedEvent.seqBefore).toBe(3);
@@ -54,6 +70,9 @@ describe("daemon.restarted", () => {
     expect(restartedEvent.reason).toBe("start");
     expect(restartedEvent.event).toBe(DAEMON_RESTARTED);
     expect(restartedEvent.category).toBe("daemon");
+
+    expect(received).toHaveLength(1);
+    expect(received[0].seqAfter).toBe(4);
   });
 
   test("daemon.restarted is first event after fresh start (seqBefore=0)", () => {
@@ -67,32 +86,33 @@ describe("daemon.restarted", () => {
       event: DAEMON_RESTARTED,
       category: "daemon",
       seqBefore,
+      seqAfter: seqBefore + 1,
       reason: "start",
     });
-    event.seqAfter = event.seq;
 
     expect(event.seq).toBe(1);
     expect(event.seqBefore).toBe(0);
     expect(event.seqAfter).toBe(1);
   });
 
-  test("daemon.restarted is persisted and retrievable via getSince", () => {
+  test("daemon.restarted is persisted and retrievable via getSince with seqAfter", () => {
     const log = freshLog();
     const bus = new EventBus(log);
 
-    const restartedEvent = bus.publish({
+    bus.publish({
       src: "daemon",
       event: DAEMON_RESTARTED,
       category: "daemon",
       seqBefore: 0,
+      seqAfter: 1,
       reason: "start",
     });
-    restartedEvent.seqAfter = restartedEvent.seq;
 
     const events = log.getSince(0);
     expect(events).toHaveLength(1);
     expect(events[0].event).toBe(DAEMON_RESTARTED);
     expect(events[0].seqBefore).toBe(0);
+    expect(events[0].seqAfter).toBe(1);
     expect(events[0].reason).toBe("start");
   });
 });

--- a/packages/daemon/src/lifecycle-events.spec.ts
+++ b/packages/daemon/src/lifecycle-events.spec.ts
@@ -1,0 +1,213 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import {
+  DAEMON_CONFIG_RELOADED,
+  DAEMON_RESTARTED,
+  GC_PRUNED,
+  type MonitorEvent,
+  type MonitorEventInput,
+  WORKER_RATELIMITED,
+} from "@mcp-cli/core";
+import { ConfigWatcher } from "./config/watcher";
+import { EventBus } from "./event-bus";
+import { EventLog } from "./event-log";
+
+function freshLog(): EventLog {
+  const db = new Database(":memory:");
+  db.exec("PRAGMA journal_mode = WAL");
+  return new EventLog(db);
+}
+
+function freshDb(): Database {
+  const db = new Database(":memory:");
+  db.exec("PRAGMA journal_mode = WAL");
+  return db;
+}
+
+describe("daemon.restarted", () => {
+  test("seqBefore/seqAfter continuity across simulated restart", () => {
+    const db = freshDb();
+    const log1 = new EventLog(db);
+    const bus1 = new EventBus(log1);
+
+    bus1.publish({ src: "test", event: "session.result", category: "session" });
+    bus1.publish({ src: "test", event: "session.result", category: "session" });
+    bus1.publish({ src: "test", event: "session.result", category: "session" });
+    expect(bus1.currentSeq).toBe(3);
+
+    const log2 = new EventLog(db);
+    const seqBefore = log2.currentSeq();
+    expect(seqBefore).toBe(3);
+
+    const bus2 = new EventBus(log2);
+    const restartedEvent = bus2.publish({
+      src: "daemon",
+      event: DAEMON_RESTARTED,
+      category: "daemon",
+      seqBefore,
+      seqAfter: seqBefore + 1,
+      reason: "start",
+    });
+
+    expect(restartedEvent.seq).toBe(4);
+    expect(restartedEvent.seqBefore).toBe(3);
+    expect(restartedEvent.seqAfter).toBe(4);
+    expect(restartedEvent.reason).toBe("start");
+    expect(restartedEvent.event).toBe(DAEMON_RESTARTED);
+    expect(restartedEvent.category).toBe("daemon");
+  });
+
+  test("daemon.restarted is first event after fresh start (seqBefore=0)", () => {
+    const log = freshLog();
+    const seqBefore = log.currentSeq();
+    expect(seqBefore).toBe(0);
+
+    const bus = new EventBus(log);
+    const event = bus.publish({
+      src: "daemon",
+      event: DAEMON_RESTARTED,
+      category: "daemon",
+      seqBefore,
+      seqAfter: seqBefore + 1,
+      reason: "start",
+    });
+
+    expect(event.seq).toBe(1);
+    expect(event.seqBefore).toBe(0);
+    expect(event.seqAfter).toBe(1);
+  });
+
+  test("daemon.restarted is persisted and retrievable via getSince", () => {
+    const log = freshLog();
+    const bus = new EventBus(log);
+
+    bus.publish({
+      src: "daemon",
+      event: DAEMON_RESTARTED,
+      category: "daemon",
+      seqBefore: 0,
+      seqAfter: 1,
+      reason: "start",
+    });
+
+    const events = log.getSince(0);
+    expect(events).toHaveLength(1);
+    expect(events[0].event).toBe(DAEMON_RESTARTED);
+    expect(events[0].seqBefore).toBe(0);
+    expect(events[0].reason).toBe("start");
+  });
+});
+
+describe("daemon.config_reloaded", () => {
+  test("ConfigWatcher.diffServers detects added, removed, and changed servers", () => {
+    type ServerMap = Parameters<typeof ConfigWatcher.diffServers>[0];
+    const oldServers = new Map([
+      ["server-a", { config: { command: "a" } }],
+      ["server-b", { config: { command: "b" } }],
+      ["server-c", { config: { command: "c" } }],
+    ]) as unknown as ServerMap;
+
+    const newServers = new Map([
+      ["server-a", { config: { command: "a" } }],
+      ["server-b", { config: { command: "b-modified" } }],
+      ["server-d", { config: { command: "d" } }],
+    ]) as unknown as ServerMap;
+
+    const diff = ConfigWatcher.diffServers(oldServers, newServers);
+
+    expect(diff.added).toEqual(["server-d"]);
+    expect(diff.removed).toEqual(["server-c"]);
+    expect(diff.changed).toEqual(["server-b"]);
+  });
+
+  test("changedKeys is the union of added, removed, and changed", () => {
+    const bus = new EventBus();
+    const received: MonitorEvent[] = [];
+    bus.subscribe((e) => received.push(e));
+
+    const added = ["new-server"];
+    const removed = ["old-server"];
+    const changed = ["modified-server"];
+    const changedKeys = [...added, ...removed, ...changed];
+
+    bus.publish({
+      src: "daemon",
+      event: DAEMON_CONFIG_RELOADED,
+      category: "daemon",
+      changedKeys,
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].event).toBe(DAEMON_CONFIG_RELOADED);
+    expect(received[0].changedKeys).toEqual(["new-server", "old-server", "modified-server"]);
+  });
+});
+
+describe("worker.ratelimited", () => {
+  test("event shape includes provider and sessionId", () => {
+    const bus = new EventBus();
+    const received: MonitorEvent[] = [];
+    bus.subscribe((e) => received.push(e));
+
+    bus.publish({
+      src: "daemon.claude-server",
+      event: WORKER_RATELIMITED,
+      category: "worker",
+      sessionId: "sess-42",
+      provider: "anthropic",
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].event).toBe(WORKER_RATELIMITED);
+    expect(received[0].category).toBe("worker");
+    expect(received[0].sessionId).toBe("sess-42");
+    expect(received[0].provider).toBe("anthropic");
+  });
+});
+
+describe("gc.pruned", () => {
+  test("event carries worktrees and branches arrays", () => {
+    const bus = new EventBus();
+    const received: MonitorEvent[] = [];
+    bus.subscribe((e) => received.push(e));
+
+    bus.publish({
+      src: "cli.gc",
+      event: GC_PRUNED,
+      category: "gc",
+      worktrees: ["claude-abc123", "claude-def456"],
+      branches: ["feat/issue-100-foo"],
+      reason: "manual",
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].event).toBe(GC_PRUNED);
+    expect(received[0].category).toBe("gc");
+    expect(received[0].worktrees).toEqual(["claude-abc123", "claude-def456"]);
+    expect(received[0].branches).toEqual(["feat/issue-100-foo"]);
+    expect(received[0].reason).toBe("manual");
+  });
+
+  test("gc.pruned is silent when nothing was pruned (no event published)", () => {
+    const bus = new EventBus();
+    const received: MonitorEvent[] = [];
+    bus.subscribe((e) => received.push(e));
+
+    // Simulate: gc ran but pruned nothing — no event should be published
+    const prunedWorktrees: string[] = [];
+    const deletedBranches: string[] = [];
+
+    if (prunedWorktrees.length > 0 || deletedBranches.length > 0) {
+      bus.publish({
+        src: "cli.gc",
+        event: GC_PRUNED,
+        category: "gc",
+        worktrees: prunedWorktrees,
+        branches: deletedBranches,
+        reason: "manual",
+      });
+    }
+
+    expect(received).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Surface 4 daemon lifecycle events as monitor events: `worker.ratelimited`, `daemon.restarted`, `daemon.config_reloaded`, `gc.pruned`
- Add `publishEvent` IPC method so CLI-side commands (gc) can publish events to the daemon's EventBus
- `daemon.restarted` fires once per boot with `seqBefore`/`seqAfter` for orchestrator replay continuity
- `gc.pruned` fires only when gc actually removes something; no-op runs are silent

## Test plan
- [x] Unit test: seqBefore/seqAfter continuity across simulated restart (EventLog + EventBus)
- [x] Unit test: ConfigWatcher.diffServers detects added/removed/changed servers for changedKeys
- [x] Unit test: all 4 event shapes verified via EventBus publish/subscribe
- [x] Unit test: gc.pruned silent on no-op (no event published when nothing pruned)
- [x] Unit test: formatMonitorEvent formatters for all 4 new events
- [x] All 6174+ tests pass, typecheck clean, lint clean, coverage ≥80% for monitor-event.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)