### PR TITLE
fix(phase): prefer valid candidate in resolvedFrom when db and log disagree (fixes #1824)

### DIFF
--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -2178,6 +2178,242 @@ phases:
   });
 });
 
+describe("resolvedFrom prefers valid candidate when db and log disagree (#1824)", () => {
+  // Manifest: impl → triage → qa → done
+  const manifest1824 = `
+runsOn: main
+initial: impl
+phases:
+  impl:
+    source: ./impl.ts
+    next: [triage]
+  triage:
+    source: ./impl.ts
+    next: [qa]
+  qa:
+    source: ./impl.ts
+    next: [done]
+  done:
+    source: ./done1824.ts
+    next: []
+`.trim();
+
+  const doneAlias1824 = `
+import { defineAlias, z } from "mcp-cli";
+defineAlias(({ z }) => ({
+  name: "done",
+  description: "done",
+  input: z.object({}).default({}),
+  output: z.object({ action: z.string() }),
+  fn: async () => ({ action: "merged" }),
+}));
+`.trim();
+
+  function makeExecDeps1824(opts: { workItemPhase: string }) {
+    const ipcCall = async (method: string, params: unknown) => {
+      if (method === "getWorkItem") {
+        return {
+          id: "#1824",
+          issueNumber: 1824,
+          prNumber: null,
+          branch: "feat/1824",
+          prState: null,
+          prUrl: null,
+          ciStatus: "none",
+          ciRunId: null,
+          ciSummary: null,
+          reviewStatus: "pending",
+          phase: opts.workItemPhase,
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-01T00:00:00Z",
+        };
+      }
+      if (method === "aliasStateGet") return { value: undefined };
+      if (method === "aliasStateSet") return { ok: true };
+      if (method === "aliasStateDelete") return { ok: true };
+      if (method === "aliasStateAll") return { entries: {} };
+      if (method === "callTool") return { content: [{ type: "text", text: "{}" }] };
+      return null;
+    };
+    const exec = (cmd: string[]) => {
+      if (cmd.includes("rev-parse") && cmd.includes("--is-inside-work-tree")) return { stdout: "true", exitCode: 0 };
+      if (cmd.includes("symbolic-ref")) return { stdout: "main\n", exitCode: 0 };
+      return { stdout: "", exitCode: 0 };
+    };
+    return {
+      ipcCall: ipcCall as unknown as typeof import("@mcp-cli/core").ipcCall,
+      exec,
+      findGitRoot: () => dir,
+      now: () => new Date("2026-04-14T00:00:00Z"),
+    };
+  }
+
+  test("executePhase uses log tail when db is stale (auto-persist failure scenario)", async () => {
+    // Scenario: log committed impl→triage→qa, but auto-persist failed so
+    // work_items.phase is still "triage". Target "done" is reachable from "qa"
+    // (log tail) but NOT from "triage" (db). Must pick "qa" and succeed.
+    writeFileSync(join(dir, ".mcx.yaml"), manifest1824);
+    writeFileSync(join(dir, "impl.ts"), doneAlias1824);
+    writeFileSync(join(dir, "done1824.ts"), doneAlias1824);
+    const { deps: installDeps } = makeDriftDeps(dir);
+    await cmdPhase(["install"], installDeps);
+
+    appendTransitionLog(transitionLogPath(dir), {
+      ts: "2026-04-14T00:00:00Z",
+      workItemId: "#1824",
+      from: null,
+      to: "impl",
+      status: "committed",
+    });
+    appendTransitionLog(transitionLogPath(dir), {
+      ts: "2026-04-14T00:01:00Z",
+      workItemId: "#1824",
+      from: "impl",
+      to: "triage",
+      status: "committed",
+    });
+    appendTransitionLog(transitionLogPath(dir), {
+      ts: "2026-04-14T00:02:00Z",
+      workItemId: "#1824",
+      from: "triage",
+      to: "qa",
+      status: "committed",
+    });
+    // work_items.phase is stale at "triage" — auto-persist failed after the qa commit
+
+    const ex = makeExecDeps1824({ workItemPhase: "triage" });
+    const errs: string[] = [];
+    let exitCode: number | undefined;
+    await executePhase(
+      ["done", "--work-item", "#1824"],
+      {
+        ...makeDriftDeps(dir).deps,
+        log: () => {},
+        logError: (m) => errs.push(m),
+        exit: ((c: number) => {
+          exitCode = c;
+          throw new Error(`exit(${c})`);
+        }) as (code: number) => never,
+      },
+      { ipcCall: ex.ipcCall, exec: ex.exec, findGitRoot: ex.findGitRoot, now: ex.now },
+    ).catch(() => {});
+
+    // Before the fix this threw DisallowedTransitionError: triage → done
+    expect(exitCode).toBeUndefined();
+    expect(errs.some((e) => e.includes("approved") && e.includes("qa") && e.includes("done"))).toBe(true);
+  }, 30_000);
+
+  test("executePhase still uses db when log is stale (primary #1802 case preserved)", async () => {
+    // Scenario: log committed impl→triage, but force-update advanced db to "qa".
+    // Target "done" reachable from "qa" (db) but NOT from "triage" (log). Must pick "qa".
+    writeFileSync(join(dir, ".mcx.yaml"), manifest1824);
+    writeFileSync(join(dir, "impl.ts"), doneAlias1824);
+    writeFileSync(join(dir, "done1824.ts"), doneAlias1824);
+    const { deps: installDeps } = makeDriftDeps(dir);
+    await cmdPhase(["install"], installDeps);
+
+    appendTransitionLog(transitionLogPath(dir), {
+      ts: "2026-04-14T00:00:00Z",
+      workItemId: "#1824",
+      from: null,
+      to: "impl",
+      status: "committed",
+    });
+    appendTransitionLog(transitionLogPath(dir), {
+      ts: "2026-04-14T00:01:00Z",
+      workItemId: "#1824",
+      from: "impl",
+      to: "triage",
+      status: "committed",
+    });
+    // work_items.phase was force-advanced to "qa", log is stale at "triage"
+
+    const ex = makeExecDeps1824({ workItemPhase: "qa" });
+    const errs: string[] = [];
+    let exitCode: number | undefined;
+    await executePhase(
+      ["done", "--work-item", "#1824"],
+      {
+        ...makeDriftDeps(dir).deps,
+        log: () => {},
+        logError: (m) => errs.push(m),
+        exit: ((c: number) => {
+          exitCode = c;
+          throw new Error(`exit(${c})`);
+        }) as (code: number) => never,
+      },
+      { ipcCall: ex.ipcCall, exec: ex.exec, findGitRoot: ex.findGitRoot, now: ex.now },
+    ).catch(() => {});
+
+    expect(exitCode).toBeUndefined();
+    expect(errs.some((e) => e.includes("approved") && e.includes("qa") && e.includes("done"))).toBe(true);
+  }, 30_000);
+
+  test("--no-execute uses log tail when db is stale (#1824 inverse case)", async () => {
+    writeFileSync(join(dir, ".mcx.yaml"), manifest1824);
+    writeFileSync(join(dir, "impl.ts"), doneAlias1824);
+    writeFileSync(join(dir, "done1824.ts"), doneAlias1824);
+    const { deps: installDeps } = makeDriftDeps(dir);
+    await cmdPhase(["install"], installDeps);
+
+    appendTransitionLog(transitionLogPath(dir), {
+      ts: "2026-04-14T00:00:00Z",
+      workItemId: "#1824",
+      from: null,
+      to: "impl",
+      status: "committed",
+    });
+    appendTransitionLog(transitionLogPath(dir), {
+      ts: "2026-04-14T00:01:00Z",
+      workItemId: "#1824",
+      from: "impl",
+      to: "triage",
+      status: "committed",
+    });
+    appendTransitionLog(transitionLogPath(dir), {
+      ts: "2026-04-14T00:02:00Z",
+      workItemId: "#1824",
+      from: "triage",
+      to: "qa",
+      status: "committed",
+    });
+
+    const mockIpcCall = async (method: string) => {
+      if (method === "getWorkItem") {
+        return {
+          id: "#1824",
+          issueNumber: 1824,
+          prNumber: null,
+          branch: "feat/1824",
+          prState: null,
+          prUrl: null,
+          ciStatus: "none",
+          ciRunId: null,
+          ciSummary: null,
+          reviewStatus: "pending",
+          phase: "triage",
+          createdAt: "2026-01-01T00:00:00Z",
+          updatedAt: "2026-01-01T00:00:00Z",
+        };
+      }
+      return null;
+    };
+
+    const { err, code } = await catchExit(() =>
+      cmdPhase(
+        ["run", "done", "--work-item", "#1824", "--no-execute"],
+        { cwd: () => dir },
+        { ipcCall: mockIpcCall as unknown as typeof import("@mcp-cli/core").ipcCall },
+      ),
+    );
+
+    expect(code).toBeUndefined();
+    expect(err).toContain("approved");
+    expect(err).toContain("qa");
+    expect(err).toContain("done");
+  });
+});
+
 describe("executePhase auto-persists work_items.phase (#1745)", () => {
   const triageAlias = `
 import { defineAlias, z } from "mcp-cli";

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -720,14 +720,14 @@ export async function cmdPhase(
         const filtered = argv.filter((a) => a !== "--no-execute");
         const opts = parsePhaseRunArgs(filtered);
         const cwd = d.cwd();
-        // Mirror the resolvedFrom priority from executePhase (#1802):
-        // work_items.phase > log tail > null (same rationale as #1635).
+        // Mirror pickResolvedFrom from executePhase (#1802, #1824).
         let resolvedFrom: string | null = opts.from;
         if (resolvedFrom === null) {
           const manifestForFrom = d.loadManifest(cwd);
           const priorTargets = manifestForFrom
             ? historyTargets(readTransitionHistory(transitionLogPath(cwd), opts.workItemId).filter(isCommitted))
             : [];
+          let dbCandidate: string | null = null;
           if (opts.workItemId !== null && manifestForFrom) {
             const ex: PhaseExecuteDeps = { ...defaultExecuteDeps, ...execDeps };
             try {
@@ -737,15 +737,23 @@ export async function cmdPhase(
                 wi.phase in manifestForFrom.manifest.phases &&
                 (priorTargets.length > 0 || opts.target !== manifestForFrom.manifest.initial)
               ) {
-                resolvedFrom = wi.phase;
+                dbCandidate = wi.phase;
               }
             } catch {
-              // ignore; resolvedFrom stays null
+              // ignore; dbCandidate stays null
             }
           }
-          if (resolvedFrom === null && priorTargets.length > 0) {
-            resolvedFrom = priorTargets[priorTargets.length - 1];
-          }
+          const logCandidate = priorTargets.length > 0 ? priorTargets[priorTargets.length - 1] : null;
+          resolvedFrom = manifestForFrom
+            ? pickResolvedFrom(
+                dbCandidate,
+                logCandidate,
+                opts.target,
+                priorTargets,
+                manifestForFrom.manifest,
+                manifestForFrom.path,
+              )
+            : (dbCandidate ?? logCandidate);
         }
         const result = phaseRun({ ...opts, from: resolvedFrom }, { cwd });
         const source = result.manifest.phases[opts.target]?.source ?? "(unknown)";
@@ -1024,6 +1032,40 @@ function toAliasWorkItem(w: WorkItem): AliasWorkItemInfo {
  * state is "tried but did not complete", and a retry will not be blocked
  * by the transition log.
  */
+function isValidFrom(
+  from: string | null,
+  target: string,
+  history: string[],
+  manifest: Manifest,
+  manifestPath: string,
+): boolean {
+  try {
+    validateTransition({ manifest, from, target, history, force: null, manifestPath });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// When both db (work_items.phase) and log-tail candidates exist and differ,
+// prefer db when it yields a valid transition (primary case: force-updates skip
+// the log, #1802/#1823). Fall back to log tail otherwise — covers the inverse
+// case where auto-persist fails and leaves db stale (#1745/#1824) and the
+// neither-valid case where the log is audit-grade evidence.
+function pickResolvedFrom(
+  dbCandidate: string | null,
+  logCandidate: string | null,
+  target: string,
+  priorTargets: string[],
+  manifest: Manifest,
+  manifestPath: string,
+): string | null {
+  if (dbCandidate === null || logCandidate === null || dbCandidate === logCandidate) {
+    return dbCandidate ?? logCandidate;
+  }
+  return isValidFrom(dbCandidate, target, priorTargets, manifest, manifestPath) ? dbCandidate : logCandidate;
+}
+
 export async function executePhase(
   argv: string[],
   deps: Partial<PhaseInstallDeps>,
@@ -1087,24 +1129,25 @@ export async function executePhase(
   const logPath = transitionLogPath(cwd);
   const prior = readTransitionHistory(logPath, parsed.workItemId).filter(isCommitted);
   const priorTargets = historyTargets(prior);
-  // Resolve "from" phase. Priority (#1802):
+  // Resolve "from" phase (#1802, #1824):
   //   1. Explicit --from flag
-  //   2. work_items.phase — the column is the source of truth after
-  //      force-updates that skip the JSONL transition log. Guard: when
-  //      history is empty AND target === manifest.initial, keep from=null
-  //      so Rule 4 (initial-phase enforcement) still applies on first launch.
-  //   3. Transition log tail (committed entries only)
-  //   4. null (first transition / unknown)
+  //   2. pickResolvedFrom: when db (work_items.phase) and log tail differ,
+  //      prefer db if it yields a valid transition (force-update case, #1823);
+  //      fallback to log tail otherwise (stale-db / auto-persist-fail case, #1824).
+  //      Guard: skip db when history is empty AND target === manifest.initial so
+  //      Rule 4 (initial-phase enforcement) still applies on first launch.
+  //   3. null (first transition / unknown)
+  const dbCandidate =
+    workItem?.phase != null &&
+    workItem.phase in loaded.manifest.phases &&
+    (priorTargets.length > 0 || parsed.target !== loaded.manifest.initial)
+      ? workItem.phase
+      : null;
+  const logCandidate = priorTargets.length > 0 ? priorTargets[priorTargets.length - 1] : null;
   const resolvedFrom =
     parsed.from !== null
       ? parsed.from
-      : workItem?.phase != null &&
-          workItem.phase in loaded.manifest.phases &&
-          (priorTargets.length > 0 || parsed.target !== loaded.manifest.initial)
-        ? workItem.phase
-        : priorTargets.length > 0
-          ? priorTargets[priorTargets.length - 1]
-          : null;
+      : pickResolvedFrom(dbCandidate, logCandidate, parsed.target, priorTargets, loaded.manifest, loaded.path);
   try {
     validateTransition({
       manifest: loaded.manifest,

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -734,7 +734,7 @@ export async function cmdPhase(
               const wi = (await ex.ipcCall("getWorkItem", { id: opts.workItemId })) as WorkItem | null;
               if (
                 wi &&
-                wi.phase in manifestForFrom.manifest.phases &&
+                Object.hasOwn(manifestForFrom.manifest.phases, wi.phase) &&
                 (priorTargets.length > 0 || opts.target !== manifestForFrom.manifest.initial)
               ) {
                 dbCandidate = wi.phase;
@@ -1139,7 +1139,7 @@ export async function executePhase(
   //   3. null (first transition / unknown)
   const dbCandidate =
     workItem?.phase != null &&
-    workItem.phase in loaded.manifest.phases &&
+    Object.hasOwn(loaded.manifest.phases, workItem.phase) &&
     (priorTargets.length > 0 || parsed.target !== loaded.manifest.initial)
       ? workItem.phase
       : null;


### PR DESCRIPTION
## Summary
- When `work_items.phase` (db) and the transition log tail differ, `pickResolvedFrom` now picks whichever yields a valid transition to the target phase, rather than unconditionally preferring `work_items.phase`
- Fallback to log tail when db candidate is not valid — covers the inverse scenario from #1824 where `executePhase`'s auto-persist block (#1745) fails, leaving `work_items.phase` stale while the log is correct
- Primary #1823 behavior preserved: db still wins when it produces a valid transition (force-update case where log is stale)
- Fix applied to both `executePhase` and the `--no-execute` path

## Test plan
- [x] New test: `executePhase uses log tail when db is stale (auto-persist failure scenario)` — log at "qa", db stale at "triage", target "done"; confirmed "qa → done" approved
- [x] New test: `executePhase still uses db when log is stale (#1802 case preserved)` — db at "qa", log stale at "triage", target "done"; confirmed "qa → done" approved
- [x] New test: `--no-execute uses log tail when db is stale (#1824 inverse case)` — same scenario via `--no-execute` path
- [x] All 139 phase spec tests pass; full suite 6168 pass (1 pre-existing flaky failure in `ipc-server.spec.ts` unrelated to this change)
- [x] `bun typecheck` clean, `bun lint` clean, pre-commit hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)