### PR TITLE
feat(daemon): budget events — session, sprint, and quota threshold alerts (fixes #1587)

### DIFF
--- a/packages/command/src/commands/config.spec.ts
+++ b/packages/command/src/commands/config.spec.ts
@@ -3,15 +3,19 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { GetConfigResult, McpConfigFile, ServerConfig } from "@mcp-cli/core";
-import type { ConfigDeps } from "./config";
+import type { BudgetIpc, ConfigDeps } from "./config";
 import {
+  BUDGET_KEYS,
   cmdConfig,
+  configGetBudget,
   configGetDispatch,
   configGetServer,
+  configSetBudget,
   configSetDispatch,
   configSetServerArgs,
   configSetServerEnv,
   configSetServerUrl,
+  isBudgetKey,
   isCliOptionKey,
   maskConfig,
   maskValue,
@@ -988,3 +992,292 @@ function readConfigFrom(path: string): Record<string, unknown> {
     return {};
   }
 }
+
+// -- Budget config keys (#1587) --
+
+describe("isBudgetKey", () => {
+  it("recognizes valid budget keys", () => {
+    expect(isBudgetKey("budget.session-cap")).toBe(true);
+    expect(isBudgetKey("budget.sprint-cap")).toBe(true);
+    expect(isBudgetKey("budget.sprint-window-hours")).toBe(true);
+    expect(isBudgetKey("budget.quota-thresholds")).toBe(true);
+    expect(isBudgetKey("budget.quota-deadband")).toBe(true);
+  });
+
+  it("rejects non-budget keys", () => {
+    expect(isBudgetKey("trust-claude")).toBe(false);
+    expect(isBudgetKey("budget.unknown")).toBe(false);
+    expect(isBudgetKey("budget")).toBe(false);
+    expect(isBudgetKey("session-cap")).toBe(false);
+  });
+});
+
+describe("BUDGET_KEYS", () => {
+  it("maps CLI keys to BudgetConfig properties", () => {
+    expect(BUDGET_KEYS["budget.session-cap"]).toBe("sessionCap");
+    expect(BUDGET_KEYS["budget.sprint-cap"]).toBe("sprintCap");
+    expect(BUDGET_KEYS["budget.sprint-window-hours"]).toBe("sprintWindowMs");
+    expect(BUDGET_KEYS["budget.quota-thresholds"]).toBe("quotaThresholds");
+    expect(BUDGET_KEYS["budget.quota-deadband"]).toBe("quotaDeadband");
+  });
+
+  it("has exactly 5 keys", () => {
+    expect(Object.keys(BUDGET_KEYS)).toHaveLength(5);
+  });
+});
+
+// -- Budget IPC helper --
+
+function fakeBudgetIpc(config?: Partial<import("@mcp-cli/core").BudgetConfig>): {
+  ipc: BudgetIpc;
+  setCalls: Partial<import("@mcp-cli/core").BudgetConfig>[];
+} {
+  const defaults: import("@mcp-cli/core").BudgetConfig = {
+    sessionCap: 3.0,
+    sprintCap: 30.0,
+    sprintWindowMs: 4 * 60 * 60 * 1000,
+    quotaThresholds: [80, 95],
+    quotaDeadband: 5,
+    ...config,
+  };
+  const setCalls: Partial<import("@mcp-cli/core").BudgetConfig>[] = [];
+  return {
+    ipc: {
+      get: async () => defaults,
+      set: async (partial) => {
+        setCalls.push(partial);
+        return { ok: true as const };
+      },
+    },
+    setCalls,
+  };
+}
+
+// -- configGetBudget (#1587) --
+
+describe("configGetBudget", () => {
+  it("exits for unknown budget key", async () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("exit");
+    });
+    spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await configGetBudget("budget.unknown");
+    } catch {
+      // expected
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("gets session-cap", async () => {
+    const logs: string[] = [];
+    const { ipc } = fakeBudgetIpc({ sessionCap: 5.0 });
+
+    await configGetBudget("budget.session-cap", (m) => logs.push(m), ipc);
+
+    expect(logs).toEqual(["5"]);
+  });
+
+  it("gets sprint-cap", async () => {
+    const logs: string[] = [];
+    const { ipc } = fakeBudgetIpc({ sprintCap: 25.0 });
+
+    await configGetBudget("budget.sprint-cap", (m) => logs.push(m), ipc);
+
+    expect(logs).toEqual(["25"]);
+  });
+
+  it("converts sprint-window-hours from ms", async () => {
+    const logs: string[] = [];
+    const { ipc } = fakeBudgetIpc({ sprintWindowMs: 6 * 60 * 60 * 1000 });
+
+    await configGetBudget("budget.sprint-window-hours", (m) => logs.push(m), ipc);
+
+    expect(logs).toEqual(["6"]);
+  });
+
+  it("gets quota-thresholds as JSON array", async () => {
+    const logs: string[] = [];
+    const { ipc } = fakeBudgetIpc({ quotaThresholds: [50, 75, 90] });
+
+    await configGetBudget("budget.quota-thresholds", (m) => logs.push(m), ipc);
+
+    expect(logs).toEqual(["[50,75,90]"]);
+  });
+
+  it("gets quota-deadband", async () => {
+    const logs: string[] = [];
+    const { ipc } = fakeBudgetIpc({ quotaDeadband: 10 });
+
+    await configGetBudget("budget.quota-deadband", (m) => logs.push(m), ipc);
+
+    expect(logs).toEqual(["10"]);
+  });
+});
+
+// -- configSetBudget (#1587) --
+
+describe("configSetBudget", () => {
+  it("exits for unknown budget key", async () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("exit");
+    });
+    spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await configSetBudget("budget.unknown", "5");
+    } catch {
+      // expected
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("exits when value is missing", async () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("exit");
+    });
+    spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await configSetBudget("budget.session-cap", undefined);
+    } catch {
+      // expected
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("exits for invalid quota thresholds", async () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("exit");
+    });
+    spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await configSetBudget("budget.quota-thresholds", "abc,def");
+    } catch {
+      // expected
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("exits for out-of-range quota thresholds", async () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("exit");
+    });
+    spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await configSetBudget("budget.quota-thresholds", "50,150");
+    } catch {
+      // expected
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("exits for invalid sprint window", async () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("exit");
+    });
+    spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await configSetBudget("budget.sprint-window-hours", "0");
+    } catch {
+      // expected
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("exits for non-numeric sprint window", async () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("exit");
+    });
+    spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await configSetBudget("budget.sprint-window-hours", "abc");
+    } catch {
+      // expected
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("exits for negative number on numeric key", async () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("exit");
+    });
+    spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await configSetBudget("budget.session-cap", "-5");
+    } catch {
+      // expected
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("exits for non-numeric value on numeric key", async () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("exit");
+    });
+    spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await configSetBudget("budget.session-cap", "abc");
+    } catch {
+      // expected
+    }
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("sets session-cap via IPC", async () => {
+    const logs: string[] = [];
+    const { ipc, setCalls } = fakeBudgetIpc();
+
+    await configSetBudget("budget.session-cap", "5.0", (m) => logs.push(m), ipc);
+
+    expect(setCalls).toHaveLength(1);
+    expect(setCalls[0].sessionCap).toBe(5.0);
+    expect(logs).toEqual(["budget.session-cap = 5.0"]);
+  });
+
+  it("sets quota-thresholds via IPC", async () => {
+    const logs: string[] = [];
+    const { ipc, setCalls } = fakeBudgetIpc();
+
+    await configSetBudget("budget.quota-thresholds", "50,75,90", (m) => logs.push(m), ipc);
+
+    expect(setCalls).toHaveLength(1);
+    expect(setCalls[0].quotaThresholds).toEqual([50, 75, 90]);
+  });
+
+  it("sets sprint-window-hours converting to ms", async () => {
+    const logs: string[] = [];
+    const { ipc, setCalls } = fakeBudgetIpc();
+
+    await configSetBudget("budget.sprint-window-hours", "6", (m) => logs.push(m), ipc);
+
+    expect(setCalls).toHaveLength(1);
+    expect(setCalls[0].sprintWindowMs).toBe(6 * 60 * 60 * 1000);
+  });
+
+  it("sets quota-deadband via IPC", async () => {
+    const logs: string[] = [];
+    const { ipc, setCalls } = fakeBudgetIpc();
+
+    await configSetBudget("budget.quota-deadband", "10", (m) => logs.push(m), ipc);
+
+    expect(setCalls).toHaveLength(1);
+    expect(setCalls[0].quotaDeadband).toBe(10);
+  });
+});

--- a/packages/command/src/commands/config.ts
+++ b/packages/command/src/commands/config.ts
@@ -3,7 +3,7 @@
  * plus get/set for CLI options like trust-claude, and server config inspection/modification.
  */
 
-import type { GetConfigResult, McpConfigFile, ServerConfig } from "@mcp-cli/core";
+import type { BudgetConfig, GetConfigResult, McpConfigFile, ServerConfig } from "@mcp-cli/core";
 import { DEFAULT_CLAUDE_WS_PORT, ipcCall, isStdioConfig, readCliConfig, writeCliConfig } from "@mcp-cli/core";
 import { c, printError } from "../output";
 import { readConfigFile, writeConfigFile } from "./config-file";
@@ -121,6 +121,11 @@ export async function configGetDispatch(args: string[], deps: ConfigDeps = defau
     return;
   }
 
+  if (isBudgetKey(key)) {
+    await configGetBudget(key, deps.log);
+    return;
+  }
+
   await configGetServer(args, deps);
 }
 
@@ -145,6 +150,11 @@ export async function configSetDispatch(args: string[], deps: ConfigDeps = defau
 
   if (second === "args") {
     await configSetServerArgs(args, deps);
+    return;
+  }
+
+  if (isBudgetKey(first)) {
+    await configSetBudget(first, second, deps.log);
     return;
   }
 
@@ -412,6 +422,97 @@ export function maskValue(value: string): string {
   if (value.length <= 8) return "****";
   return `${value.slice(0, 4)}****${value.slice(-3)}`;
 }
+
+// -- Budget config (#1587) --
+
+const BUDGET_KEYS: Record<string, keyof BudgetConfig> = {
+  "budget.session-cap": "sessionCap",
+  "budget.sprint-cap": "sprintCap",
+  "budget.sprint-window-hours": "sprintWindowMs",
+  "budget.quota-thresholds": "quotaThresholds",
+  "budget.quota-deadband": "quotaDeadband",
+};
+
+export function isBudgetKey(key: string): boolean {
+  return key in BUDGET_KEYS;
+}
+
+export { BUDGET_KEYS };
+
+export interface BudgetIpc {
+  get: () => Promise<BudgetConfig>;
+  set: (partial: Partial<BudgetConfig>) => Promise<{ ok: true }>;
+}
+
+const defaultBudgetIpc: BudgetIpc = {
+  get: () => ipcCall("getBudgetConfig"),
+  set: (partial) => ipcCall("setBudgetConfig", partial),
+};
+
+export async function configGetBudget(
+  key: string,
+  log?: (msg: string) => void,
+  ipc: BudgetIpc = defaultBudgetIpc,
+): Promise<void> {
+  const prop = BUDGET_KEYS[key];
+  if (!prop) {
+    printError(`Unknown budget key: ${key}. Valid keys: ${Object.keys(BUDGET_KEYS).join(", ")}`);
+    process.exit(1);
+  }
+  const config = await ipc.get();
+  let value: number | number[] = config[prop];
+  if (prop === "sprintWindowMs") {
+    value = (value as number) / (60 * 60 * 1000);
+  }
+  (log ?? console.log)(Array.isArray(value) ? JSON.stringify(value) : String(value));
+}
+
+export async function configSetBudget(
+  key: string,
+  rawValue: string | undefined,
+  log?: (msg: string) => void,
+  ipc: BudgetIpc = defaultBudgetIpc,
+): Promise<void> {
+  const prop = BUDGET_KEYS[key];
+  if (!prop) {
+    printError(`Unknown budget key: ${key}. Valid keys: ${Object.keys(BUDGET_KEYS).join(", ")}`);
+    process.exit(1);
+  }
+  if (rawValue === undefined) {
+    printError(`Usage: mcx config set ${key} <value>`);
+    process.exit(1);
+  }
+
+  const partial: Partial<BudgetConfig> = {};
+
+  if (prop === "quotaThresholds") {
+    const thresholds = rawValue.split(",").map(Number);
+    if (thresholds.some((n) => Number.isNaN(n) || n < 0 || n > 100)) {
+      printError("Quota thresholds must be comma-separated numbers between 0 and 100");
+      process.exit(1);
+    }
+    partial.quotaThresholds = thresholds;
+  } else if (prop === "sprintWindowMs") {
+    const hours = Number(rawValue);
+    if (Number.isNaN(hours) || hours <= 0) {
+      printError("Sprint window must be a positive number of hours");
+      process.exit(1);
+    }
+    partial.sprintWindowMs = hours * 60 * 60 * 1000;
+  } else {
+    const num = Number(rawValue);
+    if (Number.isNaN(num) || num < 0) {
+      printError(`${key} must be a non-negative number`);
+      process.exit(1);
+    }
+    (partial as Record<string, number>)[prop] = num;
+  }
+
+  await ipc.set(partial);
+  (log ?? console.log)(`${key} = ${rawValue}`);
+}
+
+// -- Masking --
 
 /** Return a config object with sensitive values masked (for JSON output). */
 export function maskConfig(config: ServerConfig, showSecrets: boolean): ServerConfig {

--- a/packages/command/src/commands/monitor.spec.ts
+++ b/packages/command/src/commands/monitor.spec.ts
@@ -4,12 +4,15 @@ import {
   CHECKS_FAILED,
   CHECKS_PASSED,
   CHECKS_STARTED,
+  COST_SESSION_OVER_BUDGET,
+  COST_SPRINT_OVER_BUDGET,
   HEARTBEAT,
   MAIL_RECEIVED,
   PHASE_CHANGED,
   PR_CLOSED,
   PR_MERGED,
   PR_OPENED,
+  QUOTA_UTILIZATION_THRESHOLD,
   REVIEW_APPROVED,
   REVIEW_CHANGES_REQUESTED,
   SESSION_CLEARED,
@@ -157,6 +160,29 @@ describe("formatMonitorEvent", () => {
         recipient: "impl@sessions",
       }),
       makeEvent(HEARTBEAT, { category: "heartbeat", src: "daemon", seq: 4210 }),
+      makeEvent(COST_SESSION_OVER_BUDGET, {
+        category: "cost",
+        src: "daemon.budget-watcher",
+        sessionId: "fcfbc19dabc",
+        workItemId: "#1441",
+        cost: 3.25,
+        limit: 3.0,
+      }),
+      makeEvent(COST_SPRINT_OVER_BUDGET, {
+        category: "cost",
+        src: "daemon.budget-watcher",
+        totalCost: 31.5,
+        limit: 30.0,
+        sessionCount: 15,
+      }),
+      makeEvent(QUOTA_UTILIZATION_THRESHOLD, {
+        category: "quota",
+        src: "daemon.budget-watcher",
+        provider: "anthropic",
+        utilization: 82,
+        threshold: 80,
+        windowEnd: "2026-04-19T01:00:00Z",
+      }),
     ];
 
     for (const e of events) {
@@ -174,6 +200,46 @@ describe("formatMonitorEvent", () => {
     const line = formatMonitorEvent(e);
     expect(line.length).toBeLessThanOrEqual(200);
     expect(line).toContain("…");
+  });
+
+  test("cost.session_over_budget shows cost and limit", () => {
+    const e = makeEvent(COST_SESSION_OVER_BUDGET, {
+      category: "cost",
+      sessionId: "fcfbc19dabc",
+      workItemId: "#1441",
+      cost: 3.25,
+      limit: 3.0,
+    });
+    const line = formatMonitorEvent(e);
+    expect(line).toContain("$3.25");
+    expect(line).toContain("limit:$3.00");
+    expect(line).toContain("#1441");
+  });
+
+  test("cost.sprint_over_budget shows total and session count", () => {
+    const e = makeEvent(COST_SPRINT_OVER_BUDGET, {
+      category: "cost",
+      totalCost: 31.5,
+      limit: 30.0,
+      sessionCount: 15,
+    });
+    const line = formatMonitorEvent(e);
+    expect(line).toContain("$31.50");
+    expect(line).toContain("limit:$30.00");
+    expect(line).toContain("15 sessions");
+  });
+
+  test("quota.utilization_threshold shows provider and utilization", () => {
+    const e = makeEvent(QUOTA_UTILIZATION_THRESHOLD, {
+      category: "quota",
+      provider: "anthropic",
+      utilization: 82,
+      threshold: 80,
+    });
+    const line = formatMonitorEvent(e);
+    expect(line).toContain("anthropic");
+    expect(line).toContain("82%");
+    expect(line).toContain("threshold:80%");
   });
 
   test("unknown event type falls back to generic formatter", () => {

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -62,7 +62,9 @@ export type IpcMethod =
   | "aliasStateGet"
   | "aliasStateSet"
   | "aliasStateDelete"
-  | "aliasStateAll";
+  | "aliasStateAll"
+  | "getBudgetConfig"
+  | "setBudgetConfig";
 
 // -- Request/Response --
 
@@ -649,6 +651,16 @@ export interface PruneSpansResult {
   pruned: number;
 }
 
+// -- Budget config (#1587) --
+
+export interface BudgetConfig {
+  sessionCap: number;
+  sprintCap: number;
+  sprintWindowMs: number;
+  quotaThresholds: number[];
+  quotaDeadband: number;
+}
+
 // -- Method → Result type map --
 
 export interface IpcMethodResult {
@@ -700,6 +712,8 @@ export interface IpcMethodResult {
   aliasStateSet: AliasStateSetResult;
   aliasStateDelete: AliasStateDeleteResult;
   aliasStateAll: AliasStateAllResult;
+  getBudgetConfig: BudgetConfig;
+  setBudgetConfig: { ok: true };
 }
 
 // -- Error codes --

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -661,6 +661,14 @@ export interface BudgetConfig {
   quotaDeadband: number;
 }
 
+export const SetBudgetConfigParamsSchema = z.object({
+  sessionCap: z.number().nonnegative().optional(),
+  sprintCap: z.number().nonnegative().optional(),
+  sprintWindowMs: z.number().positive().optional(),
+  quotaThresholds: z.array(z.number().min(0).max(100)).optional(),
+  quotaDeadband: z.number().nonnegative().optional(),
+});
+
 // -- Method → Result type map --
 
 export interface IpcMethodResult {

--- a/packages/core/src/monitor-event.ts
+++ b/packages/core/src/monitor-event.ts
@@ -11,7 +11,17 @@
 
 // ── Event categories ──
 
-export type MonitorCategory = "session" | "work_item" | "ci" | "copilot" | "review" | "issue" | "mail" | "heartbeat";
+export type MonitorCategory =
+  | "session"
+  | "work_item"
+  | "ci"
+  | "copilot"
+  | "review"
+  | "issue"
+  | "mail"
+  | "heartbeat"
+  | "cost"
+  | "quota";
 
 // ── Session event names ──
 
@@ -68,6 +78,15 @@ export const ISSUE_COMMENT = "issue.comment" as const;
 // ── Mail event names ──
 
 export const MAIL_RECEIVED = "mail.received" as const;
+
+// ── Budget / cost event names (#1587) ──
+
+export const COST_SESSION_OVER_BUDGET = "cost.session_over_budget" as const;
+export const COST_SPRINT_OVER_BUDGET = "cost.sprint_over_budget" as const;
+
+// ── Quota event names (#1587) ──
+
+export const QUOTA_UTILIZATION_THRESHOLD = "quota.utilization_threshold" as const;
 
 // ── Heartbeat ──
 
@@ -303,6 +322,25 @@ const FORMATTERS: Partial<Record<string, Formatter>> = {
     const sender = typeof e.sender === "string" ? e.sender : "";
     const recipient = typeof e.recipient === "string" ? e.recipient : "";
     return join(sender, "→", recipient);
+  },
+
+  [COST_SESSION_OVER_BUDGET]: (e) => {
+    const limit = typeof e.limit === "number" ? `limit:$${e.limit.toFixed(2)}` : "";
+    return join(wi(e), sid(e), cost(e), limit);
+  },
+
+  [COST_SPRINT_OVER_BUDGET]: (e) => {
+    const total = typeof e.totalCost === "number" ? `$${(e.totalCost as number).toFixed(2)}` : "";
+    const limit = typeof e.limit === "number" ? `limit:$${e.limit.toFixed(2)}` : "";
+    const sessions = typeof e.sessionCount === "number" ? `${e.sessionCount} sessions` : "";
+    return join(total, limit, sessions);
+  },
+
+  [QUOTA_UTILIZATION_THRESHOLD]: (e) => {
+    const util = typeof e.utilization === "number" ? `${e.utilization.toFixed(0)}%` : "";
+    const thresh = typeof e.threshold === "number" ? `threshold:${e.threshold}%` : "";
+    const provider = typeof e.provider === "string" ? e.provider : "";
+    return join(provider, util, thresh);
   },
 
   [HEARTBEAT]: (e) => `seq:${e.seq}`,

--- a/packages/daemon/src/budget-watcher.spec.ts
+++ b/packages/daemon/src/budget-watcher.spec.ts
@@ -1,0 +1,404 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { MonitorEvent, MonitorEventInput } from "@mcp-cli/core";
+import {
+  COST_SESSION_OVER_BUDGET,
+  COST_SPRINT_OVER_BUDGET,
+  QUOTA_UTILIZATION_THRESHOLD,
+  SESSION_ENDED,
+  SESSION_IDLE,
+  SESSION_RESULT,
+} from "@mcp-cli/core";
+import { BudgetWatcher } from "./budget-watcher";
+import { StateDb } from "./db/state";
+import { EventBus } from "./event-bus";
+import type { QuotaPoller, QuotaStatus } from "./quota";
+
+const dbPaths: string[] = [];
+
+function tmpDbPath(): string {
+  const p = join(tmpdir(), `mcp-budget-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+  dbPaths.push(p);
+  return p;
+}
+
+function cleanupDbs(): void {
+  for (const p of dbPaths) {
+    for (const suffix of ["", "-wal", "-shm"]) {
+      try {
+        unlinkSync(`${p}${suffix}`);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+  dbPaths.length = 0;
+}
+
+function makeDb(): StateDb {
+  return new StateDb(tmpDbPath());
+}
+
+interface FakeQuotaPoller {
+  status: QuotaStatus | null;
+}
+
+function fakeQuotaPoller(status: QuotaStatus | null = null): FakeQuotaPoller & QuotaPoller {
+  return { status, start() {}, stop() {} } as unknown as FakeQuotaPoller & QuotaPoller;
+}
+
+function sessionResultEvent(sessionId: string, cost: number, workItemId?: string): MonitorEventInput {
+  return {
+    src: "daemon.claude-server",
+    event: SESSION_RESULT,
+    category: "session",
+    sessionId,
+    cost,
+    numTurns: 1,
+    tokens: 1000,
+    ...(workItemId ? { workItemId } : {}),
+  };
+}
+
+function sessionIdleEvent(sessionId: string, cost: number): MonitorEventInput {
+  return {
+    src: "daemon.claude-server",
+    event: SESSION_IDLE,
+    category: "session",
+    sessionId,
+    cost,
+  };
+}
+
+function sessionEndedEvent(sessionId: string): MonitorEventInput {
+  return {
+    src: "daemon.claude-server",
+    event: SESSION_ENDED,
+    category: "session",
+    sessionId,
+  };
+}
+
+function collectEvents(bus: EventBus, eventName: string): MonitorEvent[] {
+  const events: MonitorEvent[] = [];
+  bus.subscribe((e) => {
+    if (e.event === eventName) events.push(e);
+  });
+  return events;
+}
+
+// ── Session cost tests ──
+
+describe("BudgetWatcher — session cost", () => {
+  let watcher: BudgetWatcher;
+
+  afterEach(() => {
+    watcher?.dispose();
+    cleanupDbs();
+  });
+
+  test("fires cost.session_over_budget exactly once when cost crosses threshold", () => {
+    const bus = new EventBus();
+    const db = makeDb();
+    db.setBudgetConfig({ sessionCap: 2.0 });
+
+    const events = collectEvents(bus, COST_SESSION_OVER_BUDGET);
+    watcher = new BudgetWatcher({ bus, db, quotaPoller: fakeQuotaPoller(), quotaPollIntervalMs: 999_999 });
+
+    bus.publish(sessionResultEvent("s1", 1.5));
+    expect(events).toHaveLength(0);
+
+    bus.publish(sessionResultEvent("s1", 2.0));
+    expect(events).toHaveLength(1);
+    expect(events[0].sessionId).toBe("s1");
+    expect(events[0].cost).toBe(2.0);
+    expect(events[0].limit).toBe(2.0);
+
+    bus.publish(sessionResultEvent("s1", 3.5));
+    expect(events).toHaveLength(1);
+  });
+
+  test("different sessions get independent threshold tracking", () => {
+    const bus = new EventBus();
+    const db = makeDb();
+    db.setBudgetConfig({ sessionCap: 1.0 });
+
+    const events = collectEvents(bus, COST_SESSION_OVER_BUDGET);
+    watcher = new BudgetWatcher({ bus, db, quotaPoller: fakeQuotaPoller(), quotaPollIntervalMs: 999_999 });
+
+    bus.publish(sessionResultEvent("s1", 1.5));
+    bus.publish(sessionResultEvent("s2", 0.5));
+    expect(events).toHaveLength(1);
+    expect(events[0].sessionId).toBe("s1");
+
+    bus.publish(sessionResultEvent("s2", 1.5));
+    expect(events).toHaveLength(2);
+    expect(events[1].sessionId).toBe("s2");
+  });
+
+  test("session.ended cleans up tracking state", () => {
+    const bus = new EventBus();
+    const db = makeDb();
+    db.setBudgetConfig({ sessionCap: 2.0 });
+
+    const events = collectEvents(bus, COST_SESSION_OVER_BUDGET);
+    watcher = new BudgetWatcher({ bus, db, quotaPoller: fakeQuotaPoller(), quotaPollIntervalMs: 999_999 });
+
+    bus.publish(sessionResultEvent("s1", 2.5));
+    expect(events).toHaveLength(1);
+
+    bus.publish(sessionEndedEvent("s1"));
+
+    bus.publish(sessionResultEvent("s1", 2.5));
+    expect(events).toHaveLength(2);
+  });
+
+  test("includes workItemId in emitted event", () => {
+    const bus = new EventBus();
+    const db = makeDb();
+    db.setBudgetConfig({ sessionCap: 1.0 });
+
+    const events = collectEvents(bus, COST_SESSION_OVER_BUDGET);
+    watcher = new BudgetWatcher({ bus, db, quotaPoller: fakeQuotaPoller(), quotaPollIntervalMs: 999_999 });
+
+    bus.publish(sessionResultEvent("s1", 2.0, "#1441"));
+    expect(events).toHaveLength(1);
+    expect(events[0].workItemId).toBe("#1441");
+  });
+
+  test("uses default config when none set", () => {
+    const bus = new EventBus();
+    const db = makeDb();
+    const events = collectEvents(bus, COST_SESSION_OVER_BUDGET);
+    watcher = new BudgetWatcher({ bus, db, quotaPoller: fakeQuotaPoller(), quotaPollIntervalMs: 999_999 });
+
+    bus.publish(sessionResultEvent("s1", 3.0));
+    expect(events).toHaveLength(1);
+    expect(events[0].limit).toBe(3.0);
+  });
+});
+
+// ── Sprint cost tests ──
+
+describe("BudgetWatcher — sprint cost", () => {
+  let watcher: BudgetWatcher;
+
+  afterEach(() => {
+    watcher?.dispose();
+    cleanupDbs();
+  });
+
+  test("fires cost.sprint_over_budget based on active session costs", () => {
+    const bus = new EventBus();
+    const db = makeDb();
+    db.setBudgetConfig({ sprintCap: 5.0 });
+
+    db.upsertSession({ sessionId: "s1", state: "active" });
+    db.updateSessionCost("s1", 3.0, 1000);
+    db.upsertSession({ sessionId: "s2", state: "active" });
+    db.updateSessionCost("s2", 2.5, 500);
+
+    const events = collectEvents(bus, COST_SPRINT_OVER_BUDGET);
+    watcher = new BudgetWatcher({ bus, db, quotaPoller: fakeQuotaPoller(), quotaPollIntervalMs: 999_999 });
+
+    bus.publish(sessionResultEvent("s1", 3.0));
+    expect(events).toHaveLength(1);
+    expect(events[0].totalCost).toBeGreaterThanOrEqual(5.0);
+    expect(events[0].limit).toBe(5.0);
+    expect(events[0].sessionCount).toBeGreaterThanOrEqual(2);
+  });
+
+  test("fires only once per crossing", () => {
+    const bus = new EventBus();
+    const db = makeDb();
+    db.setBudgetConfig({ sprintCap: 5.0 });
+
+    db.upsertSession({ sessionId: "s1", state: "active" });
+    db.updateSessionCost("s1", 6.0, 1000);
+
+    const events = collectEvents(bus, COST_SPRINT_OVER_BUDGET);
+    watcher = new BudgetWatcher({ bus, db, quotaPoller: fakeQuotaPoller(), quotaPollIntervalMs: 999_999 });
+
+    bus.publish(sessionResultEvent("s1", 6.0));
+    bus.publish(sessionResultEvent("s1", 7.0));
+    expect(events).toHaveLength(1);
+  });
+
+  test("re-arms when total drops below threshold", () => {
+    const bus = new EventBus();
+    const db = makeDb();
+    db.setBudgetConfig({ sprintCap: 5.0 });
+
+    db.upsertSession({ sessionId: "s1", state: "active" });
+    db.updateSessionCost("s1", 6.0, 1000);
+
+    const events = collectEvents(bus, COST_SPRINT_OVER_BUDGET);
+    watcher = new BudgetWatcher({ bus, db, quotaPoller: fakeQuotaPoller(), quotaPollIntervalMs: 999_999 });
+
+    bus.publish(sessionResultEvent("s1", 6.0));
+    expect(events).toHaveLength(1);
+
+    db.updateSessionCost("s1", 2.0, 500);
+    bus.publish(sessionResultEvent("s1", 2.0));
+
+    db.updateSessionCost("s1", 6.0, 1500);
+    bus.publish(sessionResultEvent("s1", 6.0));
+    expect(events).toHaveLength(2);
+  });
+});
+
+// ── Quota hysteresis tests ──
+
+describe("BudgetWatcher — quota hysteresis", () => {
+  let watcher: BudgetWatcher;
+
+  afterEach(() => {
+    watcher?.dispose();
+    cleanupDbs();
+  });
+
+  test("fires at threshold, no re-fire mid-band, re-arms below deadband", () => {
+    const bus = new EventBus();
+    const db = makeDb();
+    db.setBudgetConfig({ quotaThresholds: [80], quotaDeadband: 5 });
+
+    const poller = fakeQuotaPoller();
+    const events = collectEvents(bus, QUOTA_UTILIZATION_THRESHOLD);
+    watcher = new BudgetWatcher({ bus, db, quotaPoller: poller, quotaPollIntervalMs: 999_999 });
+
+    const setUtil = (u: number) => {
+      poller.status = {
+        fiveHour: { utilization: u, resetsAt: "2026-04-19T01:00:00Z" },
+        sevenDay: null,
+        sevenDaySonnet: null,
+        sevenDayOpus: null,
+        extraUsage: null,
+        fetchedAt: Date.now(),
+      } as QuotaStatus;
+    };
+
+    setUtil(79);
+    watcher.checkQuota();
+    expect(events).toHaveLength(0);
+
+    setUtil(81);
+    watcher.checkQuota();
+    expect(events).toHaveLength(1);
+    expect(events[0].utilization).toBe(81);
+    expect(events[0].threshold).toBe(80);
+    expect(events[0].provider).toBe("anthropic");
+
+    setUtil(85);
+    watcher.checkQuota();
+    expect(events).toHaveLength(1);
+
+    setUtil(82);
+    watcher.checkQuota();
+    expect(events).toHaveLength(1);
+
+    setUtil(78);
+    watcher.checkQuota();
+    expect(events).toHaveLength(1);
+
+    setUtil(74);
+    watcher.checkQuota();
+    expect(events).toHaveLength(1);
+
+    setUtil(81);
+    watcher.checkQuota();
+    expect(events).toHaveLength(2);
+  });
+
+  test("supports multiple thresholds independently", () => {
+    const bus = new EventBus();
+    const db = makeDb();
+    db.setBudgetConfig({ quotaThresholds: [80, 95], quotaDeadband: 5 });
+
+    const poller = fakeQuotaPoller();
+    const events = collectEvents(bus, QUOTA_UTILIZATION_THRESHOLD);
+    watcher = new BudgetWatcher({ bus, db, quotaPoller: poller, quotaPollIntervalMs: 999_999 });
+
+    const setUtil = (u: number) => {
+      poller.status = {
+        fiveHour: { utilization: u, resetsAt: "2026-04-19T01:00:00Z" },
+        sevenDay: null,
+        sevenDaySonnet: null,
+        sevenDayOpus: null,
+        extraUsage: null,
+        fetchedAt: Date.now(),
+      } as QuotaStatus;
+    };
+
+    setUtil(82);
+    watcher.checkQuota();
+    expect(events).toHaveLength(1);
+    expect(events[0].threshold).toBe(80);
+
+    setUtil(96);
+    watcher.checkQuota();
+    expect(events).toHaveLength(2);
+    expect(events[1].threshold).toBe(95);
+  });
+
+  test("no events when quota poller has no status", () => {
+    const bus = new EventBus();
+    const db = makeDb();
+    const events = collectEvents(bus, QUOTA_UTILIZATION_THRESHOLD);
+    watcher = new BudgetWatcher({ bus, db, quotaPoller: fakeQuotaPoller(), quotaPollIntervalMs: 999_999 });
+
+    watcher.checkQuota();
+    expect(events).toHaveLength(0);
+  });
+});
+
+// ── Config from DB ──
+
+describe("BudgetWatcher — config", () => {
+  afterEach(() => cleanupDbs());
+
+  test("reads defaults when no config stored", () => {
+    const db = makeDb();
+    const config = db.getBudgetConfig();
+    expect(config.sessionCap).toBe(3.0);
+    expect(config.sprintCap).toBe(30.0);
+    expect(config.sprintWindowMs).toBe(4 * 60 * 60 * 1000);
+    expect(config.quotaThresholds).toEqual([80, 95]);
+    expect(config.quotaDeadband).toBe(5);
+  });
+
+  test("merges partial config with defaults", () => {
+    const db = makeDb();
+    db.setBudgetConfig({ sessionCap: 5.0 });
+    const config = db.getBudgetConfig();
+    expect(config.sessionCap).toBe(5.0);
+    expect(config.sprintCap).toBe(30.0);
+  });
+
+  test("persists full config after set", () => {
+    const db = makeDb();
+    db.setBudgetConfig({ sessionCap: 5.0, quotaThresholds: [50, 75, 90] });
+    const config = db.getBudgetConfig();
+    expect(config.sessionCap).toBe(5.0);
+    expect(config.quotaThresholds).toEqual([50, 75, 90]);
+  });
+});
+
+// ── Dispose ──
+
+describe("BudgetWatcher — dispose", () => {
+  afterEach(() => cleanupDbs());
+
+  test("unsubscribes from bus on dispose", () => {
+    const bus = new EventBus();
+    const db = makeDb();
+    const events = collectEvents(bus, COST_SESSION_OVER_BUDGET);
+    const watcher = new BudgetWatcher({ bus, db, quotaPoller: fakeQuotaPoller(), quotaPollIntervalMs: 999_999 });
+
+    watcher.dispose();
+
+    bus.publish(sessionResultEvent("s1", 5.0));
+    expect(events).toHaveLength(0);
+  });
+});

--- a/packages/daemon/src/budget-watcher.spec.ts
+++ b/packages/daemon/src/budget-watcher.spec.ts
@@ -178,6 +178,24 @@ describe("BudgetWatcher — session cost", () => {
     expect(events).toHaveLength(1);
     expect(events[0].limit).toBe(3.0);
   });
+
+  test("SESSION_IDLE triggers session budget check", () => {
+    const bus = new EventBus();
+    const db = makeDb();
+    db.setBudgetConfig({ sessionCap: 2.0 });
+
+    const events = collectEvents(bus, COST_SESSION_OVER_BUDGET);
+    watcher = new BudgetWatcher({ bus, db, quotaPoller: fakeQuotaPoller(), quotaPollIntervalMs: 999_999 });
+
+    bus.publish(sessionIdleEvent("s1", 1.0));
+    expect(events).toHaveLength(0);
+
+    bus.publish(sessionIdleEvent("s1", 2.5));
+    expect(events).toHaveLength(1);
+    expect(events[0].sessionId).toBe("s1");
+    expect(events[0].cost).toBe(2.5);
+    expect(events[0].limit).toBe(2.0);
+  });
 });
 
 // ── Sprint cost tests ──

--- a/packages/daemon/src/budget-watcher.ts
+++ b/packages/daemon/src/budget-watcher.ts
@@ -6,7 +6,7 @@ import {
   SESSION_IDLE,
   SESSION_RESULT,
 } from "@mcp-cli/core";
-import type { MonitorEvent } from "@mcp-cli/core";
+import type { BudgetConfig, MonitorEvent } from "@mcp-cli/core";
 import type { StateDb } from "./db/state";
 import type { EventBus } from "./event-bus";
 import type { QuotaPoller } from "./quota";
@@ -51,6 +51,7 @@ export class BudgetWatcher {
 
     const pollMs = opts.quotaPollIntervalMs ?? DEFAULT_QUOTA_POLL_MS;
     this.quotaTimer = setInterval(() => this.checkQuota(), pollMs);
+    this.quotaTimer.unref();
   }
 
   dispose(): void {
@@ -76,12 +77,12 @@ export class BudgetWatcher {
     if (cost <= 0) return;
 
     const workItemId = typeof event.workItemId === "string" ? event.workItemId : undefined;
-    this.checkSessionBudget(sessionId, cost, workItemId);
-    this.checkSprintBudget();
+    const config = this.db.getBudgetConfig();
+    this.checkSessionBudget(config, sessionId, cost, workItemId);
+    this.checkSprintBudget(config);
   }
 
-  private checkSessionBudget(sessionId: string, cost: number, workItemId?: string): void {
-    const config = this.db.getBudgetConfig();
+  private checkSessionBudget(config: BudgetConfig, sessionId: string, cost: number, workItemId?: string): void {
     let state = this.sessionCosts.get(sessionId);
     if (!state) {
       state = { cost: 0, fired: false, workItemId };
@@ -105,13 +106,9 @@ export class BudgetWatcher {
     }
   }
 
-  private checkSprintBudget(): void {
-    const config = this.db.getBudgetConfig();
+  private checkSprintBudget(config: BudgetConfig): void {
     const cutoffMs = Date.now() - config.sprintWindowMs;
-
-    const sessions = this.db.listSessions();
-    const windowSessions = sessions.filter((s) => new Date(s.spawnedAt).getTime() >= cutoffMs);
-    const totalCost = windowSessions.reduce((sum, s) => sum + s.totalCost, 0);
+    const { totalCost, sessionCount } = this.db.sprintCostSince(cutoffMs);
 
     if (totalCost >= config.sprintCap && !this.sprintFired) {
       this.sprintFired = true;
@@ -121,7 +118,7 @@ export class BudgetWatcher {
         category: "cost",
         totalCost,
         limit: config.sprintCap,
-        sessionCount: windowSessions.length,
+        sessionCount,
       });
     } else if (totalCost < config.sprintCap && this.sprintFired) {
       this.sprintFired = false;

--- a/packages/daemon/src/budget-watcher.ts
+++ b/packages/daemon/src/budget-watcher.ts
@@ -1,0 +1,162 @@
+import {
+  COST_SESSION_OVER_BUDGET,
+  COST_SPRINT_OVER_BUDGET,
+  QUOTA_UTILIZATION_THRESHOLD,
+  SESSION_ENDED,
+  SESSION_IDLE,
+  SESSION_RESULT,
+} from "@mcp-cli/core";
+import type { MonitorEvent } from "@mcp-cli/core";
+import type { StateDb } from "./db/state";
+import type { EventBus } from "./event-bus";
+import type { QuotaPoller } from "./quota";
+
+interface SessionCostState {
+  cost: number;
+  fired: boolean;
+  workItemId?: string;
+}
+
+const SESSION_EVENTS: ReadonlySet<string> = new Set([SESSION_RESULT, SESSION_IDLE, SESSION_ENDED]);
+
+const DEFAULT_QUOTA_POLL_MS = 60_000;
+
+export class BudgetWatcher {
+  private readonly bus: EventBus;
+  private readonly db: StateDb;
+  private readonly quotaPoller: QuotaPoller;
+  private readonly subId: number;
+  private readonly sessionCosts = new Map<string, SessionCostState>();
+  private sprintFired = false;
+  private readonly quotaArmed = new Map<number, boolean>();
+  private quotaTimer: ReturnType<typeof setInterval> | null = null;
+  private disposed = false;
+
+  constructor(opts: {
+    bus: EventBus;
+    db: StateDb;
+    quotaPoller: QuotaPoller;
+    quotaPollIntervalMs?: number;
+  }) {
+    this.bus = opts.bus;
+    this.db = opts.db;
+    this.quotaPoller = opts.quotaPoller;
+
+    const config = this.db.getBudgetConfig();
+    for (const t of config.quotaThresholds) {
+      this.quotaArmed.set(t, true);
+    }
+
+    this.subId = this.bus.subscribe((event) => this.handleEvent(event));
+
+    const pollMs = opts.quotaPollIntervalMs ?? DEFAULT_QUOTA_POLL_MS;
+    this.quotaTimer = setInterval(() => this.checkQuota(), pollMs);
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    this.bus.unsubscribe(this.subId);
+    if (this.quotaTimer) {
+      clearInterval(this.quotaTimer);
+      this.quotaTimer = null;
+    }
+  }
+
+  private handleEvent(event: MonitorEvent): void {
+    if (!SESSION_EVENTS.has(event.event)) return;
+    const sessionId = typeof event.sessionId === "string" ? event.sessionId : null;
+    if (!sessionId) return;
+
+    if (event.event === SESSION_ENDED) {
+      this.sessionCosts.delete(sessionId);
+      return;
+    }
+
+    const cost = typeof event.cost === "number" ? event.cost : 0;
+    if (cost <= 0) return;
+
+    const workItemId = typeof event.workItemId === "string" ? event.workItemId : undefined;
+    this.checkSessionBudget(sessionId, cost, workItemId);
+    this.checkSprintBudget();
+  }
+
+  private checkSessionBudget(sessionId: string, cost: number, workItemId?: string): void {
+    const config = this.db.getBudgetConfig();
+    let state = this.sessionCosts.get(sessionId);
+    if (!state) {
+      state = { cost: 0, fired: false, workItemId };
+      this.sessionCosts.set(sessionId, state);
+    }
+
+    state.cost = cost;
+    if (workItemId) state.workItemId = workItemId;
+
+    if (cost >= config.sessionCap && !state.fired) {
+      state.fired = true;
+      this.bus.publish({
+        src: "daemon.budget-watcher",
+        event: COST_SESSION_OVER_BUDGET,
+        category: "cost",
+        sessionId,
+        workItemId: state.workItemId,
+        cost,
+        limit: config.sessionCap,
+      });
+    }
+  }
+
+  private checkSprintBudget(): void {
+    const config = this.db.getBudgetConfig();
+    const cutoffMs = Date.now() - config.sprintWindowMs;
+
+    const sessions = this.db.listSessions();
+    const windowSessions = sessions.filter((s) => new Date(s.spawnedAt).getTime() >= cutoffMs);
+    const totalCost = windowSessions.reduce((sum, s) => sum + s.totalCost, 0);
+
+    if (totalCost >= config.sprintCap && !this.sprintFired) {
+      this.sprintFired = true;
+      this.bus.publish({
+        src: "daemon.budget-watcher",
+        event: COST_SPRINT_OVER_BUDGET,
+        category: "cost",
+        totalCost,
+        limit: config.sprintCap,
+        sessionCount: windowSessions.length,
+      });
+    } else if (totalCost < config.sprintCap && this.sprintFired) {
+      this.sprintFired = false;
+    }
+  }
+
+  checkQuota(): void {
+    if (this.disposed) return;
+    const status = this.quotaPoller.status;
+    if (!status?.fiveHour) return;
+
+    const utilization = status.fiveHour.utilization;
+    const config = this.db.getBudgetConfig();
+
+    for (const t of config.quotaThresholds) {
+      if (!this.quotaArmed.has(t)) this.quotaArmed.set(t, true);
+    }
+
+    for (const threshold of config.quotaThresholds) {
+      const armed = this.quotaArmed.get(threshold) ?? true;
+
+      if (utilization >= threshold && armed) {
+        this.quotaArmed.set(threshold, false);
+        this.bus.publish({
+          src: "daemon.budget-watcher",
+          event: QUOTA_UTILIZATION_THRESHOLD,
+          category: "quota",
+          provider: "anthropic",
+          utilization,
+          threshold,
+          windowEnd: status.fiveHour.resetsAt,
+        });
+      } else if (utilization < threshold - config.quotaDeadband && !armed) {
+        this.quotaArmed.set(threshold, true);
+      }
+    }
+  }
+}

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -12,6 +12,7 @@ import { unlinkSync } from "node:fs";
 import { resolve } from "node:path";
 import {
   type AliasType,
+  type BudgetConfig,
   type MailMessage,
   type MonitorAliasMetadata,
   type Span,
@@ -561,6 +562,32 @@ export class StateDb {
       "INSERT INTO daemon_state (key, value, updated_at) VALUES (?, ?, unixepoch()) ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
       [key, value],
     );
+  }
+
+  // -- Budget config (#1587) --
+
+  getBudgetConfig(): BudgetConfig {
+    const raw = this.getState("budget_config");
+    const defaults: BudgetConfig = {
+      sessionCap: 3.0,
+      sprintCap: 30.0,
+      sprintWindowMs: 4 * 60 * 60 * 1000,
+      quotaThresholds: [80, 95],
+      quotaDeadband: 5,
+    };
+    if (!raw) return defaults;
+    try {
+      const parsed = JSON.parse(raw) as Partial<BudgetConfig>;
+      return { ...defaults, ...parsed };
+    } catch {
+      return defaults;
+    }
+  }
+
+  setBudgetConfig(partial: Partial<BudgetConfig>): void {
+    const current = this.getBudgetConfig();
+    const merged = { ...current, ...partial };
+    this.setState("budget_config", JSON.stringify(merged));
   }
 
   // -- Auth tokens --

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -1218,6 +1218,16 @@ export class StateDb {
       .map(toSessionRow);
   }
 
+  sprintCostSince(cutoffMs: number): { totalCost: number; sessionCount: number } {
+    const cutoff = formatSqliteDatetime(cutoffMs);
+    const row = this.db
+      .query<{ total_cost: number; cnt: number }, [string]>(
+        "SELECT COALESCE(SUM(total_cost), 0) AS total_cost, COUNT(*) AS cnt FROM agent_sessions WHERE spawned_at >= ?",
+      )
+      .get(cutoff);
+    return { totalCost: row?.total_cost ?? 0, sessionCount: row?.cnt ?? 0 };
+  }
+
   pruneOldSessions(maxAgeDays = 30): number {
     const cutoff = formatSqliteDatetime(Date.now() - maxAgeDays * 24 * 60 * 60 * 1000);
     const result = this.db.run("DELETE FROM agent_sessions WHERE ended_at IS NOT NULL AND ended_at < ?", [cutoff]);

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -60,6 +60,7 @@ import {
 } from "@mcp-cli/core";
 import { AcpServer, buildAcpToolCache } from "./acp-server";
 import { AliasServer, buildAliasToolCache } from "./alias-server";
+import { BudgetWatcher } from "./budget-watcher";
 import { ClaudeServer, buildClaudeToolCache } from "./claude-server";
 import { CodexServer, buildCodexToolCache } from "./codex-server";
 import { configHash, loadConfig } from "./config/loader";
@@ -583,6 +584,9 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
   const mailEventBus = new EventBus(eventLog);
   mailServer.setEventBus(mailEventBus);
 
+  // Budget watcher: emits cost/quota threshold events (#1587)
+  const budgetWatcher = new BudgetWatcher({ bus: mailEventBus, db, quotaPoller });
+
   // Start IPC server
   const ipcServer = new IpcServer(pool, config, db, aliasServer, {
     daemonId,
@@ -1049,6 +1053,7 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
       clearInterval(metricsInterval);
       eventLog.stopPruning();
       quotaPoller.stop();
+      budgetWatcher.dispose();
       workItemPoller?.stop();
       copilotPoller?.stop();
       derivedPublisher?.dispose();

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -1335,6 +1335,15 @@ export class IpcServer {
       return { entries: this.db.listAliasState(repoRoot, parsed.namespace) };
     });
 
+    this.handlers.set("getBudgetConfig", async () => {
+      return this.db.getBudgetConfig();
+    });
+
+    this.handlers.set("setBudgetConfig", async (params) => {
+      this.db.setBudgetConfig(params as Partial<import("@mcp-cli/core").BudgetConfig>);
+      return { ok: true as const };
+    });
+
     this.handlers.set("shutdown", async (params, _ctx) => {
       const { force } = ShutdownParamsSchema.parse(params ?? {});
       // Check force BEFORE querying DB — --force is the escape hatch when DB is degraded

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -58,6 +58,7 @@ import {
   RestartServerParamsSchema,
   SaveAliasParamsSchema,
   SendMailParamsSchema,
+  SetBudgetConfigParamsSchema,
   SetNoteParamsSchema,
   ShutdownParamsSchema,
   TouchAliasParamsSchema,
@@ -1340,7 +1341,8 @@ export class IpcServer {
     });
 
     this.handlers.set("setBudgetConfig", async (params) => {
-      this.db.setBudgetConfig(params as Partial<import("@mcp-cli/core").BudgetConfig>);
+      const parsed = SetBudgetConfigParamsSchema.parse(params);
+      this.db.setBudgetConfig(parsed);
       return { ok: true as const };
     });
 


### PR DESCRIPTION
## Summary
- Add `cost.session_over_budget`, `cost.sprint_over_budget`, and `quota.utilization_threshold` events to the MonitorEvent system so the orchestrator can back off new spawns or warn before hard limits
- Implement `BudgetWatcher` class with per-session fire-once cost alerts, rolling-window sprint cost aggregation, and hysteresis-based quota tracking with configurable deadband
- Persist budget config (`sessionCap`, `sprintCap`, `sprintWindowMs`, `quotaThresholds`, `quotaDeadband`) in `daemon_state` table, exposed via `mcx config get/set budget.*` CLI keys and IPC methods

## Test plan
- [x] 15 BudgetWatcher unit tests: session fire-once, independent sessions, session.ended cleanup, workItemId propagation, default config, sprint threshold with active sessions, sprint fire-once, sprint re-arm, quota hysteresis sequence (79→81→85→82→78→74→81), multiple thresholds, no-status safety, config defaults/merge/persist, dispose unsubscribe
- [x] 3 monitor formatter tests for each new event type
- [x] 19 config.spec.ts tests: `isBudgetKey` validation, `BUDGET_KEYS` mapping, `configGetBudget` get paths + unknown key error, `configSetBudget` set paths + all validation errors (unknown key, missing value, invalid thresholds, out-of-range thresholds, invalid sprint window, negative/non-numeric values)
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun test` — 6209 pass, 0 fail
- [x] Coverage: config.ts 82.55%, monitor-event.ts 81.5% (both above 80% threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)