### PR TITLE
feat(daemon): event-sourced per-session metrics (closes #1610)

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -93,6 +93,12 @@ export interface CliConfig {
   telemetryNoticeShown?: boolean;
   /** Phase execution configuration */
   phase?: PhaseConfig;
+  /** Session metrics configuration (#1610). Default: enabled. */
+  metrics?: {
+    session?: {
+      enabled?: boolean;
+    };
+  };
 }
 
 /** Claude Code project settings (.claude/settings.local.json) */

--- a/packages/core/src/monitor-event.spec.ts
+++ b/packages/core/src/monitor-event.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import type { MonitorEvent } from "./monitor-event";
+import {
+  HEARTBEAT,
+  METRIC_SESSION_COMMAND_HIST,
+  METRIC_SESSION_FOOTPRINT,
+  METRIC_SESSION_QUERIES,
+  SESSION_TOOL_USE,
+  formatMonitorEvent,
+} from "./monitor-event";
+
+function event(overrides: Partial<MonitorEvent> & { event: string }): MonitorEvent {
+  return {
+    seq: 1,
+    ts: "2025-01-01T12:00:00.000Z",
+    src: "test",
+    category: "session",
+    ...overrides,
+  };
+}
+
+describe("formatMonitorEvent", () => {
+  test("formats session.tool_use with tool name and file path", () => {
+    const line = formatMonitorEvent(
+      event({
+        event: SESSION_TOOL_USE,
+        sessionId: "abcdef1234567890",
+        toolName: "Read",
+        filePath: "/src/foo.ts",
+      }),
+    );
+    expect(line).toContain("session.tool_use");
+    expect(line).toContain("abcdef12");
+    expect(line).toContain("Read");
+    expect(line).toContain("/src/foo.ts");
+  });
+
+  test("formats metric.session.footprint with dir count and ratio", () => {
+    const line = formatMonitorEvent(
+      event({
+        event: METRIC_SESSION_FOOTPRINT,
+        sessionId: "abcdef1234567890",
+        footprint: [
+          { dir: "/src", read: 100, wrote: 50, files: 3 },
+          { dir: "/test", read: 200, wrote: 0, files: 2 },
+        ],
+        readWriteRatio: 6,
+      }),
+    );
+    expect(line).toContain("metric.session.footprint");
+    expect(line).toContain("2 dir(s)");
+    expect(line).toContain("rw:6");
+  });
+
+  test("formats metric.session.command_hist with command count", () => {
+    const line = formatMonitorEvent(
+      event({
+        event: METRIC_SESSION_COMMAND_HIST,
+        sessionId: "abcdef1234567890",
+        commands: [{ cmd: "bun test", runs: 3 }],
+      }),
+    );
+    expect(line).toContain("metric.session.command_hist");
+    expect(line).toContain("1 command(s)");
+  });
+
+  test("formats metric.session.queries with query count", () => {
+    const line = formatMonitorEvent(
+      event({
+        event: METRIC_SESSION_QUERIES,
+        sessionId: "abcdef1234567890",
+        recent: [
+          { tool: "Grep", pattern: "foo" },
+          { tool: "Glob", pattern: "*.ts" },
+        ],
+      }),
+    );
+    expect(line).toContain("metric.session.queries");
+    expect(line).toContain("2 recent query(ies)");
+  });
+
+  test("formats heartbeat", () => {
+    const line = formatMonitorEvent(event({ event: HEARTBEAT, category: "heartbeat", seq: 42 }));
+    expect(line).toContain("heartbeat");
+    expect(line).toContain("seq:42");
+  });
+
+  test("falls back for unknown event types", () => {
+    const line = formatMonitorEvent(event({ event: "custom.unknown", sessionId: "s1", extra: "data" }));
+    expect(line).toContain("custom.unknown");
+    expect(line).toContain("sessionId:");
+  });
+
+  test("caps output at 200 characters", () => {
+    const line = formatMonitorEvent(
+      event({
+        event: SESSION_TOOL_USE,
+        sessionId: "abcdef1234567890",
+        toolName: "Read",
+        filePath: "/very/long/path".repeat(20),
+      }),
+    );
+    expect(line.length).toBeLessThanOrEqual(200);
+  });
+});

--- a/packages/core/src/monitor-event.ts
+++ b/packages/core/src/monitor-event.ts
@@ -30,6 +30,13 @@ export const SESSION_CONTAINMENT_ESCALATED = "session.containment_escalated" as 
 export const SESSION_CONTAINMENT_RESET = "session.containment_reset" as const;
 export const SESSION_IDLE = "session.idle" as const;
 export const SESSION_STUCK = "session.stuck" as const;
+export const SESSION_TOOL_USE = "session.tool_use" as const;
+
+// ── Session metric event names (#1610) ──
+
+export const METRIC_SESSION_FOOTPRINT = "metric.session.footprint" as const;
+export const METRIC_SESSION_COMMAND_HIST = "metric.session.command_hist" as const;
+export const METRIC_SESSION_QUERIES = "metric.session.queries" as const;
 
 // ── Work item event names ──
 
@@ -300,6 +307,28 @@ const FORMATTERS: Partial<Record<string, Formatter>> = {
     const sender = typeof e.sender === "string" ? e.sender : "";
     const recipient = typeof e.recipient === "string" ? e.recipient : "";
     return join(sender, "→", recipient);
+  },
+
+  [SESSION_TOOL_USE]: (e) => {
+    const tool = typeof e.toolName === "string" ? e.toolName : "";
+    const fp = typeof e.filePath === "string" ? cap(e.filePath, 40) : "";
+    return join(sid(e), tool, fp);
+  },
+
+  [METRIC_SESSION_FOOTPRINT]: (e) => {
+    const dirs = Array.isArray(e.footprint) ? (e.footprint as unknown[]).length : 0;
+    const ratio = typeof e.readWriteRatio === "number" ? `rw:${e.readWriteRatio}` : "";
+    return join(sid(e), `${dirs} dir(s)`, ratio);
+  },
+
+  [METRIC_SESSION_COMMAND_HIST]: (e) => {
+    const cmds = Array.isArray(e.commands) ? (e.commands as unknown[]).length : 0;
+    return join(sid(e), `${cmds} command(s)`);
+  },
+
+  [METRIC_SESSION_QUERIES]: (e) => {
+    const n = Array.isArray(e.recent) ? (e.recent as unknown[]).length : 0;
+    return join(sid(e), `${n} recent query(ies)`);
   },
 
   [HEARTBEAT]: (e) => `seq:${e.seq}`,

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -11,7 +11,7 @@
 
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import type {
   AgentPermissionRequest,
   Logger,
@@ -46,6 +46,7 @@ import {
   SESSION_RATE_LIMITED,
   SESSION_RESULT,
   SESSION_STUCK,
+  SESSION_TOOL_USE,
   consoleLogger,
   generateSessionName,
 } from "@mcp-cli/core";
@@ -1604,6 +1605,7 @@ export class ClaudeWsServer {
         break;
       case "session:response":
         this.recordSessionProgress(sessionId, session);
+        this.emitToolUseEvents(sessionId, event.message);
         break;
       case "session:permission_request":
         session.pendingImmediate = true;
@@ -1759,6 +1761,23 @@ export class ClaudeWsServer {
     "session:containment_escalated": SESSION_CONTAINMENT_ESCALATED,
     "session:containment_reset": SESSION_CONTAINMENT_RESET,
   };
+
+  private emitToolUseEvents(sessionId: string, msg: { message: { content: Record<string, unknown>[] } }): void {
+    if (!this.onMonitorEvent) return;
+    for (const block of msg.message.content) {
+      if (block.type !== "tool_use" || typeof block.name !== "string") continue;
+      const input = (block.input ?? {}) as Record<string, unknown>;
+      const extracted = extractToolFields(block.name, input);
+      this.onMonitorEvent({
+        src: "daemon.claude-server",
+        event: SESSION_TOOL_USE,
+        category: "session",
+        sessionId,
+        toolName: block.name,
+        ...extracted,
+      });
+    }
+  }
 
   private publishSessionMonitorEvent(sessionId: string, event: SessionEvent): void {
     if (!this.onMonitorEvent) return;
@@ -2361,6 +2380,82 @@ async function drainStderr(stream: ReadableStream<Uint8Array>, lines: string[]):
 
 function isAddrInUse(err: unknown): boolean {
   return err instanceof Error && "code" in err && (err as { code: string }).code === "EADDRINUSE";
+}
+
+// ── Tool-use field extraction (#1610) ──
+
+const CONTENT_SCAN_LIMIT = 1_000_000;
+
+function countNewlines(s: string): number {
+  let count = 0;
+  const len = Math.min(s.length, CONTENT_SCAN_LIMIT);
+  for (let i = 0; i < len; i++) {
+    if (s.charCodeAt(i) === 10) count++;
+  }
+  return count + 1;
+}
+
+export function extractToolFields(toolName: string, input: Record<string, unknown>): Record<string, unknown> {
+  const fields: Record<string, unknown> = {};
+  switch (toolName) {
+    case "Read": {
+      const fp = input.file_path;
+      if (typeof fp === "string") {
+        fields.filePath = fp;
+        fields.dirPath = dirname(fp);
+      }
+      fields.linesHint = typeof input.limit === "number" ? input.limit : 2000;
+      break;
+    }
+    case "Write": {
+      const fp = input.file_path;
+      if (typeof fp === "string") {
+        fields.filePath = fp;
+        fields.dirPath = dirname(fp);
+      }
+      fields.linesHint = typeof input.content === "string" ? countNewlines(input.content) : 1;
+      fields.isWrite = true;
+      break;
+    }
+    case "Edit": {
+      const fp = input.file_path;
+      if (typeof fp === "string") {
+        fields.filePath = fp;
+        fields.dirPath = dirname(fp);
+      }
+      fields.linesHint = typeof input.new_string === "string" ? countNewlines(input.new_string) : 1;
+      fields.isWrite = true;
+      break;
+    }
+    case "Bash": {
+      if (typeof input.command === "string") {
+        fields.command = input.command;
+        const tokens = input.command.trim().split(/\s+/);
+        fields.cmdGroup = tokens.slice(0, 2).join(" ");
+      }
+      break;
+    }
+    case "Grep": {
+      if (typeof input.pattern === "string") fields.pattern = input.pattern;
+      if (typeof input.path === "string") fields.searchPath = input.path;
+      break;
+    }
+    case "Glob": {
+      if (typeof input.pattern === "string") fields.pattern = input.pattern;
+      if (typeof input.path === "string") fields.searchPath = input.path;
+      break;
+    }
+    case "NotebookEdit": {
+      const fp = input.file_path;
+      if (typeof fp === "string") {
+        fields.filePath = fp;
+        fields.dirPath = dirname(fp);
+      }
+      fields.isWrite = true;
+      break;
+    }
+  }
+  return fields;
 }
 
 // ── Default spawn ──

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -182,6 +182,12 @@ export class StateDb {
         PRIMARY KEY (repo_root, namespace, key)
       );
 
+      CREATE TABLE IF NOT EXISTS session_metrics (
+        session_id TEXT PRIMARY KEY,
+        metrics_json TEXT NOT NULL,
+        updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+      );
+
     `);
 
     // -- Additive migrations (new columns on existing tables) --

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -86,6 +86,7 @@ import { OpenCodeServer, buildOpenCodeToolCache } from "./opencode-server";
 import { reapOrphanedSessions } from "./orphan-reaper";
 import { QuotaPoller } from "./quota";
 import { ServerPool } from "./server-pool";
+import { SessionMetricsAggregator } from "./session-metrics";
 import { SiteServer, buildSiteToolCache } from "./site-server";
 import { TracingServer } from "./tracing-server";
 import { WorkItemsServer } from "./work-items-server";
@@ -583,6 +584,17 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
   const mailEventBus = new EventBus(eventLog);
   mailServer.setEventBus(mailEventBus);
 
+  // Session metrics aggregator (#1610) — on by default, opt-out via config
+  let sessionMetricsAgg: SessionMetricsAggregator | null = null;
+  const cliCfg = readCliConfig();
+  if (cliCfg.metrics?.session?.enabled !== false) {
+    sessionMetricsAgg = new SessionMetricsAggregator({
+      bus: mailEventBus,
+      db: db.database,
+    });
+    logger.info("[mcpd] Session metrics aggregator started");
+  }
+
   // Start IPC server
   const ipcServer = new IpcServer(pool, config, db, aliasServer, {
     daemonId,
@@ -1052,6 +1064,7 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
       workItemPoller?.stop();
       copilotPoller?.stop();
       derivedPublisher?.dispose();
+      sessionMetricsAgg?.dispose();
       if (monitorRuntime) {
         const monPhase = performance.now();
         await withPhaseTimeout(monitorRuntime.stopAll(), SHUTDOWN_PHASE_TIMEOUT_MS, "monitorRuntime.stopAll", logger);

--- a/packages/daemon/src/session-metrics.spec.ts
+++ b/packages/daemon/src/session-metrics.spec.ts
@@ -1,0 +1,607 @@
+import { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { MonitorEvent, MonitorEventInput } from "@mcp-cli/core";
+import {
+  METRIC_SESSION_COMMAND_HIST,
+  METRIC_SESSION_FOOTPRINT,
+  METRIC_SESSION_QUERIES,
+  SESSION_DISCONNECTED,
+  SESSION_ENDED,
+  SESSION_IDLE,
+  SESSION_TOOL_USE,
+} from "@mcp-cli/core";
+import { EventBus } from "./event-bus";
+import { SessionMetricsAggregator, createFreshState, deserializeState, serializeState } from "./session-metrics";
+
+function defined<T>(value: T | undefined | null, label = "value"): T {
+  expect(value).toBeDefined();
+  expect(value).not.toBeNull();
+  return value as T;
+}
+
+function freshDb(): Database {
+  const db = new Database(":memory:");
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS session_metrics (
+      session_id TEXT PRIMARY KEY,
+      metrics_json TEXT NOT NULL,
+      updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+    )
+  `);
+  return db;
+}
+
+function toolUse(sessionId: string, toolName: string, extra: Record<string, unknown> = {}): MonitorEventInput {
+  return {
+    src: "daemon.claude-server",
+    event: SESSION_TOOL_USE,
+    category: "session",
+    sessionId,
+    toolName,
+    ...extra,
+  };
+}
+
+function sessionEnd(sessionId: string): MonitorEventInput {
+  return {
+    src: "daemon.claude-server",
+    event: SESSION_ENDED,
+    category: "session",
+    sessionId,
+  };
+}
+
+function sessionIdle(sessionId: string): MonitorEventInput {
+  return {
+    src: "daemon.claude-server",
+    event: SESSION_IDLE,
+    category: "session",
+    sessionId,
+  };
+}
+
+describe("SessionMetricsAggregator", () => {
+  let db: Database;
+  let bus: EventBus;
+  let agg: SessionMetricsAggregator;
+  let received: MonitorEvent[];
+
+  beforeEach(() => {
+    db = freshDb();
+    bus = new EventBus();
+    received = [];
+    agg = new SessionMetricsAggregator({ bus, db, coalesceWindowMs: 500 });
+    bus.subscribe((e) => received.push(e));
+  });
+
+  afterEach(() => {
+    agg.dispose();
+    db.close();
+  });
+
+  describe("directory footprint", () => {
+    test("accumulates read lines by directory", () => {
+      bus.publish(
+        toolUse("s1", "Read", {
+          filePath: "/src/foo.ts",
+          dirPath: "/src",
+          linesHint: 100,
+        }),
+      );
+      bus.publish(
+        toolUse("s1", "Read", {
+          filePath: "/src/bar.ts",
+          dirPath: "/src",
+          linesHint: 200,
+        }),
+      );
+
+      const state = defined(agg.getState("s1"));
+      const dir = defined(state.dirFootprint.get("/src"));
+      expect(dir.read).toBe(300);
+      expect(dir.wrote).toBe(0);
+    });
+
+    test("accumulates write lines by directory", () => {
+      bus.publish(
+        toolUse("s1", "Write", {
+          filePath: "/src/new.ts",
+          dirPath: "/src",
+          linesHint: 50,
+          isWrite: true,
+        }),
+      );
+
+      const state = defined(agg.getState("s1"));
+      const dir = defined(state.dirFootprint.get("/src"));
+      expect(dir.read).toBe(0);
+      expect(dir.wrote).toBe(50);
+    });
+
+    test("counts unique files per directory", () => {
+      bus.publish(
+        toolUse("s1", "Read", {
+          filePath: "/src/foo.ts",
+          dirPath: "/src",
+          linesHint: 100,
+        }),
+      );
+      bus.publish(
+        toolUse("s1", "Read", {
+          filePath: "/src/foo.ts",
+          dirPath: "/src",
+          linesHint: 100,
+        }),
+      );
+      bus.publish(
+        toolUse("s1", "Read", {
+          filePath: "/src/bar.ts",
+          dirPath: "/src",
+          linesHint: 50,
+        }),
+      );
+
+      const state = defined(agg.getState("s1"));
+      const dir = defined(state.dirFootprint.get("/src"));
+      expect(dir.fileSet.size).toBe(2);
+    });
+
+    test("emits coalesced footprint event", () => {
+      bus.publish(
+        toolUse("s1", "Read", {
+          filePath: "/src/foo.ts",
+          dirPath: "/src",
+          linesHint: 100,
+        }),
+      );
+
+      bus.flushCoalesced("metric:s1:footprint");
+
+      const footprintEvents = received.filter((e) => e.event === METRIC_SESSION_FOOTPRINT);
+      expect(footprintEvents).toHaveLength(1);
+      const fp = footprintEvents[0];
+      expect(fp.sessionId).toBe("s1");
+      expect(fp.footprint).toEqual([{ dir: "/src", read: 100, wrote: 0, files: 1 }]);
+      expect(fp.readWriteRatio).toBeNull();
+    });
+
+    test("computes readWriteRatio when writes exist", () => {
+      bus.publish(
+        toolUse("s1", "Read", {
+          filePath: "/src/foo.ts",
+          dirPath: "/src",
+          linesHint: 200,
+        }),
+      );
+      bus.publish(
+        toolUse("s1", "Write", {
+          filePath: "/src/out.ts",
+          dirPath: "/src",
+          linesHint: 100,
+          isWrite: true,
+        }),
+      );
+
+      bus.flushCoalesced("metric:s1:footprint");
+
+      const fp = defined(received.find((e) => e.event === METRIC_SESSION_FOOTPRINT));
+      expect(fp.readWriteRatio).toBe(2);
+    });
+  });
+
+  describe("command history", () => {
+    test("groups Bash commands by cmdGroup", () => {
+      bus.publish(toolUse("s1", "Bash", { cmdGroup: "bun test", command: "bun test --bail" }));
+      bus.publish(toolUse("s1", "Bash", { cmdGroup: "bun test", command: "bun test" }));
+      bus.publish(toolUse("s1", "Bash", { cmdGroup: "git status", command: "git status" }));
+
+      const state = defined(agg.getState("s1"));
+      expect(state.commandHist.get("bun test")).toBe(2);
+      expect(state.commandHist.get("git status")).toBe(1);
+    });
+
+    test("emits coalesced command_hist event", () => {
+      bus.publish(toolUse("s1", "Bash", { cmdGroup: "bun test", command: "bun test" }));
+
+      bus.flushCoalesced("metric:s1:commands");
+
+      const cmdEvents = received.filter((e) => e.event === METRIC_SESSION_COMMAND_HIST);
+      expect(cmdEvents).toHaveLength(1);
+      expect(cmdEvents[0].commands).toEqual([{ cmd: "bun test", runs: 1 }]);
+    });
+  });
+
+  describe("recent queries ring buffer", () => {
+    test("stores Grep queries", () => {
+      bus.publish(toolUse("s1", "Grep", { pattern: "foo", searchPath: "/src" }));
+
+      const state = defined(agg.getState("s1"));
+      expect(state.queries).toHaveLength(1);
+      expect(state.queries[0]).toEqual({
+        tool: "Grep",
+        pattern: "foo",
+        path: "/src",
+      });
+    });
+
+    test("stores Glob queries", () => {
+      bus.publish(toolUse("s1", "Glob", { pattern: "**/*.ts", searchPath: "/src" }));
+
+      const state = defined(agg.getState("s1"));
+      expect(state.queries).toHaveLength(1);
+      expect(state.queries[0].tool).toBe("Glob");
+    });
+
+    test("evicts oldest entries when exceeding max", () => {
+      const agg2 = new SessionMetricsAggregator({
+        bus,
+        db,
+        maxQueries: 3,
+        coalesceWindowMs: 500,
+      });
+
+      for (let i = 0; i < 5; i++) {
+        bus.publish(toolUse("s2", "Grep", { pattern: `p${i}`, searchPath: "/src" }));
+      }
+
+      const state = defined(agg2.getState("s2"));
+      expect(state.queries).toHaveLength(3);
+      expect(state.queries[0].pattern).toBe("p2");
+      expect(state.queries[2].pattern).toBe("p4");
+
+      agg2.dispose();
+    });
+
+    test("emits coalesced queries event", () => {
+      bus.publish(toolUse("s1", "Grep", { pattern: "foo", searchPath: "/src" }));
+
+      bus.flushCoalesced("metric:s1:queries");
+
+      const qEvents = received.filter((e) => e.event === METRIC_SESSION_QUERIES);
+      expect(qEvents).toHaveLength(1);
+      expect((qEvents[0].recent as unknown[]).length).toBe(1);
+    });
+  });
+
+  describe("read depth", () => {
+    test("tracks read count per file", () => {
+      bus.publish(
+        toolUse("s1", "Read", {
+          filePath: "/src/foo.ts",
+          dirPath: "/src",
+          linesHint: 100,
+        }),
+      );
+      bus.publish(
+        toolUse("s1", "Read", {
+          filePath: "/src/foo.ts",
+          dirPath: "/src",
+          linesHint: 50,
+        }),
+      );
+
+      const state = defined(agg.getState("s1"));
+      const rd = defined(state.readDepth.get("/src/foo.ts"));
+      expect(rd.readCount).toBe(2);
+      expect(rd.linesReadTotal).toBe(150);
+    });
+
+    test("tracks max lines per file", () => {
+      bus.publish(
+        toolUse("s1", "Read", {
+          filePath: "/src/foo.ts",
+          dirPath: "/src",
+          linesHint: 100,
+        }),
+      );
+      bus.publish(
+        toolUse("s1", "Read", {
+          filePath: "/src/foo.ts",
+          dirPath: "/src",
+          linesHint: 2000,
+        }),
+      );
+
+      const state = defined(agg.getState("s1"));
+      const rd = defined(state.readDepth.get("/src/foo.ts"));
+      expect(rd.maxLines).toBe(2000);
+    });
+
+    test("does not count writes in read depth", () => {
+      bus.publish(
+        toolUse("s1", "Write", {
+          filePath: "/src/foo.ts",
+          dirPath: "/src",
+          linesHint: 100,
+          isWrite: true,
+        }),
+      );
+
+      const state = defined(agg.getState("s1"));
+      expect(state.readDepth.has("/src/foo.ts")).toBe(false);
+    });
+  });
+
+  describe("state timing", () => {
+    test("transitions to active on tool_use", () => {
+      bus.publish(toolUse("s1", "Read", { filePath: "/f", dirPath: "/", linesHint: 1 }));
+
+      const state = defined(agg.getState("s1"));
+      expect(state.currentState.state).toBe("active");
+    });
+
+    test("transitions to idle on session.idle", () => {
+      bus.publish(toolUse("s1", "Read", { filePath: "/f", dirPath: "/", linesHint: 1 }));
+      bus.publish(sessionIdle("s1"));
+
+      const state = defined(agg.getState("s1"));
+      expect(state.currentState.state).toBe("idle");
+    });
+  });
+
+  describe("session lifecycle", () => {
+    test("cleans up memory on session.ended", () => {
+      bus.publish(toolUse("s1", "Read", { filePath: "/f", dirPath: "/", linesHint: 1 }));
+      expect(agg.sessionCount).toBe(1);
+
+      bus.publish(sessionEnd("s1"));
+      expect(agg.sessionCount).toBe(0);
+    });
+
+    test("cleans up on session.disconnected", () => {
+      bus.publish(toolUse("s1", "Read", { filePath: "/f", dirPath: "/", linesHint: 1 }));
+
+      bus.publish({
+        src: "daemon.claude-server",
+        event: SESSION_DISCONNECTED,
+        category: "session",
+        sessionId: "s1",
+      });
+
+      expect(agg.sessionCount).toBe(0);
+    });
+
+    test("persists metrics to DB on session end", () => {
+      bus.publish(
+        toolUse("s1", "Read", {
+          filePath: "/src/foo.ts",
+          dirPath: "/src",
+          linesHint: 100,
+        }),
+      );
+      bus.publish(sessionEnd("s1"));
+
+      const row = db
+        .query<{ metrics_json: string }, [string]>("SELECT metrics_json FROM session_metrics WHERE session_id = ?")
+        .get("s1");
+
+      const validRow = defined(row);
+      const parsed = JSON.parse(validRow.metrics_json);
+      expect(parsed.dirFootprint).toHaveLength(1);
+      expect(parsed.dirFootprint[0].dir).toBe("/src");
+      expect(parsed.hasToolCalls).toBe(true);
+    });
+
+    test("does not persist sessions with no tool calls", () => {
+      bus.publish(sessionEnd("s1"));
+
+      const row = db
+        .query<{ metrics_json: string }, [string]>("SELECT metrics_json FROM session_metrics WHERE session_id = ?")
+        .get("s1");
+
+      expect(row).toBeNull();
+    });
+
+    test("loads persisted state on reconnect", () => {
+      bus.publish(
+        toolUse("s1", "Read", {
+          filePath: "/src/foo.ts",
+          dirPath: "/src",
+          linesHint: 100,
+        }),
+      );
+      bus.publish(toolUse("s1", "Bash", { cmdGroup: "bun test", command: "bun test" }));
+      bus.publish(sessionEnd("s1"));
+      expect(agg.sessionCount).toBe(0);
+
+      bus.publish(
+        toolUse("s1", "Read", {
+          filePath: "/src/bar.ts",
+          dirPath: "/src",
+          linesHint: 50,
+        }),
+      );
+
+      const state = defined(agg.getState("s1"));
+      expect(defined(state.dirFootprint.get("/src")).read).toBe(150);
+      expect(state.commandHist.get("bun test")).toBe(1);
+    });
+
+    test("flushes metric events on session end", () => {
+      bus.publish(
+        toolUse("s1", "Read", {
+          filePath: "/src/foo.ts",
+          dirPath: "/src",
+          linesHint: 100,
+        }),
+      );
+      bus.publish(sessionEnd("s1"));
+
+      const footprintEvents = received.filter((e) => e.event === METRIC_SESSION_FOOTPRINT);
+      expect(footprintEvents.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("multi-session isolation", () => {
+    test("sessions do not share state", () => {
+      bus.publish(
+        toolUse("s1", "Read", {
+          filePath: "/a/foo.ts",
+          dirPath: "/a",
+          linesHint: 100,
+        }),
+      );
+      bus.publish(
+        toolUse("s2", "Read", {
+          filePath: "/b/bar.ts",
+          dirPath: "/b",
+          linesHint: 200,
+        }),
+      );
+
+      const s1 = defined(agg.getState("s1"));
+      const s2 = defined(agg.getState("s2"));
+      expect(s1.dirFootprint.has("/a")).toBe(true);
+      expect(s1.dirFootprint.has("/b")).toBe(false);
+      expect(s2.dirFootprint.has("/b")).toBe(true);
+      expect(s2.dirFootprint.has("/a")).toBe(false);
+    });
+  });
+
+  describe("dispose", () => {
+    test("persists all active sessions to DB", () => {
+      bus.publish(toolUse("s1", "Read", { filePath: "/f", dirPath: "/", linesHint: 1 }));
+      bus.publish(toolUse("s2", "Read", { filePath: "/g", dirPath: "/", linesHint: 1 }));
+
+      agg.dispose();
+
+      const rows = db.query<{ session_id: string }, []>("SELECT session_id FROM session_metrics").all();
+      expect(rows).toHaveLength(2);
+    });
+  });
+});
+
+describe("serializeState / deserializeState", () => {
+  test("round-trips a full state", () => {
+    const state = createFreshState("s1");
+    state.hasToolCalls = true;
+    state.dirFootprint.set("/src", {
+      read: 100,
+      wrote: 50,
+      fileSet: new Set(["/src/a.ts", "/src/b.ts"]),
+    });
+    state.commandHist.set("bun test", 3);
+    state.queries.push({ tool: "Grep", pattern: "foo", path: "/src" });
+    state.readDepth.set("/src/a.ts", {
+      readCount: 2,
+      linesReadTotal: 200,
+      maxLines: 150,
+    });
+    state.stateAccum.set("active", 5000);
+    state.stateAccum.set("idle", 2000);
+
+    const json = serializeState(state);
+    const restored = deserializeState("s1", JSON.parse(json));
+
+    expect(restored.hasToolCalls).toBe(true);
+    const srcDir = defined(restored.dirFootprint.get("/src"));
+    expect(srcDir.read).toBe(100);
+    expect(srcDir.wrote).toBe(50);
+    expect(srcDir.fileSet.size).toBe(2);
+    expect(restored.commandHist.get("bun test")).toBe(3);
+    expect(restored.queries).toHaveLength(1);
+    expect(defined(restored.readDepth.get("/src/a.ts")).readCount).toBe(2);
+    expect(restored.stateAccum.get("active")).toBe(5000);
+    expect(restored.stateAccum.get("idle")).toBe(2000);
+  });
+
+  test("handles empty state", () => {
+    const state = createFreshState("s1");
+    const json = serializeState(state);
+    const restored = deserializeState("s1", JSON.parse(json));
+
+    expect(restored.dirFootprint.size).toBe(0);
+    expect(restored.commandHist.size).toBe(0);
+    expect(restored.queries).toHaveLength(0);
+    expect(restored.readDepth.size).toBe(0);
+  });
+});
+
+describe("extractToolFields", () => {
+  let extractToolFields: (toolName: string, input: Record<string, unknown>) => Record<string, unknown>;
+
+  beforeEach(async () => {
+    const mod = await import("./claude-session/ws-server");
+    extractToolFields = mod.extractToolFields;
+  });
+
+  test("Read extracts filePath, dirPath, linesHint", () => {
+    const fields = extractToolFields("Read", {
+      file_path: "/src/foo.ts",
+      limit: 50,
+    });
+    expect(fields.filePath).toBe("/src/foo.ts");
+    expect(fields.dirPath).toBe("/src");
+    expect(fields.linesHint).toBe(50);
+    expect(fields.isWrite).toBeUndefined();
+  });
+
+  test("Read defaults linesHint to 2000", () => {
+    const fields = extractToolFields("Read", { file_path: "/src/foo.ts" });
+    expect(fields.linesHint).toBe(2000);
+  });
+
+  test("Write marks isWrite and counts lines", () => {
+    const fields = extractToolFields("Write", {
+      file_path: "/src/out.ts",
+      content: "line1\nline2\nline3",
+    });
+    expect(fields.filePath).toBe("/src/out.ts");
+    expect(fields.isWrite).toBe(true);
+    expect(fields.linesHint).toBe(3);
+  });
+
+  test("Edit marks isWrite and counts new_string lines", () => {
+    const fields = extractToolFields("Edit", {
+      file_path: "/src/foo.ts",
+      new_string: "a\nb",
+    });
+    expect(fields.isWrite).toBe(true);
+    expect(fields.linesHint).toBe(2);
+  });
+
+  test("Bash extracts command and cmdGroup", () => {
+    const fields = extractToolFields("Bash", {
+      command: "bun test --bail",
+    });
+    expect(fields.command).toBe("bun test --bail");
+    expect(fields.cmdGroup).toBe("bun test");
+  });
+
+  test("Bash handles single-token commands", () => {
+    const fields = extractToolFields("Bash", { command: "ls" });
+    expect(fields.cmdGroup).toBe("ls");
+  });
+
+  test("Grep extracts pattern and searchPath", () => {
+    const fields = extractToolFields("Grep", {
+      pattern: "foo.*bar",
+      path: "/src",
+    });
+    expect(fields.pattern).toBe("foo.*bar");
+    expect(fields.searchPath).toBe("/src");
+  });
+
+  test("Glob extracts pattern and searchPath", () => {
+    const fields = extractToolFields("Glob", {
+      pattern: "**/*.ts",
+      path: "/src",
+    });
+    expect(fields.pattern).toBe("**/*.ts");
+    expect(fields.searchPath).toBe("/src");
+  });
+
+  test("NotebookEdit marks isWrite", () => {
+    const fields = extractToolFields("NotebookEdit", {
+      file_path: "/src/nb.ipynb",
+    });
+    expect(fields.filePath).toBe("/src/nb.ipynb");
+    expect(fields.isWrite).toBe(true);
+  });
+
+  test("unknown tool returns empty fields", () => {
+    const fields = extractToolFields("CustomTool", { data: "value" });
+    expect(Object.keys(fields)).toHaveLength(0);
+  });
+});

--- a/packages/daemon/src/session-metrics.spec.ts
+++ b/packages/daemon/src/session-metrics.spec.ts
@@ -459,6 +459,70 @@ describe("SessionMetricsAggregator", () => {
     });
   });
 
+  describe("TTL pruning", () => {
+    test("prunes stale rows on construction", () => {
+      db.exec(
+        `INSERT INTO session_metrics (session_id, metrics_json, updated_at)
+         VALUES ('old', '{}', unixepoch() - 86400 * 60)`,
+      );
+      db.exec(
+        `INSERT INTO session_metrics (session_id, metrics_json, updated_at)
+         VALUES ('recent', '{}', unixepoch() - 86400 * 5)`,
+      );
+
+      const agg2 = new SessionMetricsAggregator({ bus, db, coalesceWindowMs: 500, pruneAfterDays: 30 });
+      const rows = db.query<{ session_id: string }, []>("SELECT session_id FROM session_metrics").all();
+      expect(rows).toHaveLength(1);
+      expect(rows[0].session_id).toBe("recent");
+      agg2.dispose();
+    });
+  });
+
+  describe("maxPaths cap", () => {
+    test("evicts oldest dirFootprint entry when maxPaths exceeded", () => {
+      const agg2 = new SessionMetricsAggregator({ bus, db, maxPaths: 3, coalesceWindowMs: 500 });
+
+      for (let i = 0; i < 5; i++) {
+        bus.publish(toolUse("s1", "Read", { filePath: `/d${i}/f.ts`, dirPath: `/d${i}`, linesHint: 10 }));
+      }
+
+      const state = defined(agg2.getState("s1"));
+      expect(state.dirFootprint.size).toBe(3);
+      expect(state.dirFootprint.has("/d0")).toBe(false);
+      expect(state.dirFootprint.has("/d1")).toBe(false);
+      expect(state.dirFootprint.has("/d4")).toBe(true);
+      agg2.dispose();
+    });
+
+    test("evicts oldest readDepth entry when maxPaths exceeded", () => {
+      const agg2 = new SessionMetricsAggregator({ bus, db, maxPaths: 3, coalesceWindowMs: 500 });
+
+      for (let i = 0; i < 5; i++) {
+        bus.publish(toolUse("s1", "Read", { filePath: `/src/f${i}.ts`, dirPath: "/src", linesHint: 10 }));
+      }
+
+      const state = defined(agg2.getState("s1"));
+      expect(state.readDepth.size).toBe(3);
+      expect(state.readDepth.has("/src/f0.ts")).toBe(false);
+      expect(state.readDepth.has("/src/f1.ts")).toBe(false);
+      expect(state.readDepth.has("/src/f4.ts")).toBe(true);
+      agg2.dispose();
+    });
+  });
+
+  describe("persist failure retention", () => {
+    test("retains in-memory state when DB write fails", () => {
+      bus.publish(toolUse("s1", "Read", { filePath: "/f", dirPath: "/", linesHint: 1 }));
+
+      db.exec("DROP TABLE session_metrics");
+
+      bus.publish(sessionEnd("s1"));
+
+      expect(agg.sessionCount).toBe(1);
+      expect(agg.getState("s1")?.hasToolCalls).toBe(true);
+    });
+  });
+
   describe("dispose", () => {
     test("persists all active sessions to DB", () => {
       bus.publish(toolUse("s1", "Read", { filePath: "/f", dirPath: "/", linesHint: 1 }));
@@ -515,6 +579,73 @@ describe("serializeState / deserializeState", () => {
     expect(restored.commandHist.size).toBe(0);
     expect(restored.queries).toHaveLength(0);
     expect(restored.readDepth.size).toBe(0);
+  });
+});
+
+describe("extractToolFields → aggregator integration", () => {
+  let db: Database;
+  let bus: EventBus;
+  let agg: SessionMetricsAggregator;
+  let extractToolFields: (toolName: string, input: Record<string, unknown>) => Record<string, unknown>;
+
+  beforeEach(async () => {
+    db = freshDb();
+    bus = new EventBus();
+    agg = new SessionMetricsAggregator({ bus, db, coalesceWindowMs: 500 });
+    const mod = await import("./claude-session/ws-server");
+    extractToolFields = mod.extractToolFields;
+  });
+
+  afterEach(() => {
+    agg.dispose();
+    db.close();
+  });
+
+  test("extractToolFields output flows through bus into aggregator state", () => {
+    const readInput = { file_path: "/src/foo.ts", limit: 50 };
+    const readFields = extractToolFields("Read", readInput);
+    bus.publish({
+      src: "daemon.claude-server",
+      event: SESSION_TOOL_USE,
+      category: "session",
+      sessionId: "int-s1",
+      toolName: "Read",
+      ...readFields,
+    });
+
+    const bashInput = { command: "bun test --bail" };
+    const bashFields = extractToolFields("Bash", bashInput);
+    bus.publish({
+      src: "daemon.claude-server",
+      event: SESSION_TOOL_USE,
+      category: "session",
+      sessionId: "int-s1",
+      toolName: "Bash",
+      ...bashFields,
+    });
+
+    const grepInput = { pattern: "handleEvent", path: "/src" };
+    const grepFields = extractToolFields("Grep", grepInput);
+    bus.publish({
+      src: "daemon.claude-server",
+      event: SESSION_TOOL_USE,
+      category: "session",
+      sessionId: "int-s1",
+      toolName: "Grep",
+      ...grepFields,
+    });
+
+    const state = defined(agg.getState("int-s1"));
+
+    expect(state.dirFootprint.has("/src")).toBe(true);
+    expect(defined(state.dirFootprint.get("/src")).read).toBe(50);
+
+    expect(defined(state.readDepth.get("/src/foo.ts")).readCount).toBe(1);
+
+    expect(state.commandHist.get("bun test")).toBe(1);
+
+    expect(state.queries).toHaveLength(1);
+    expect(state.queries[0]).toEqual({ tool: "Grep", pattern: "handleEvent", path: "/src" });
   });
 });
 

--- a/packages/daemon/src/session-metrics.ts
+++ b/packages/daemon/src/session-metrics.ts
@@ -95,16 +95,21 @@ export interface SessionMetricsAggregatorOpts {
   bus: EventBus;
   db: Database;
   maxQueries?: number;
+  maxPaths?: number;
   coalesceWindowMs?: number;
+  pruneAfterDays?: number;
 }
 
 const DEFAULT_MAX_QUERIES = 20;
+const DEFAULT_MAX_PATHS = 1000;
 const DEFAULT_COALESCE_WINDOW_MS = 500;
+const DEFAULT_PRUNE_AFTER_DAYS = 30;
 
 export class SessionMetricsAggregator {
   private readonly bus: EventBus;
   private readonly db: Database;
   private readonly maxQueries: number;
+  private readonly maxPaths: number;
   private readonly coalesceWindowMs: number;
   private readonly sessions = new Map<string, SessionMetricState>();
   private readonly subId: number;
@@ -112,19 +117,27 @@ export class SessionMetricsAggregator {
 
   private readonly saveStmt: ReturnType<Database["prepare"]>;
   private readonly loadStmt: ReturnType<Database["prepare"]>;
-  private readonly deleteStmt: ReturnType<Database["prepare"]>;
+  private readonly pruneStmt: ReturnType<Database["prepare"]>;
 
   constructor(opts: SessionMetricsAggregatorOpts) {
     this.bus = opts.bus;
     this.db = opts.db;
     this.maxQueries = opts.maxQueries ?? DEFAULT_MAX_QUERIES;
+    this.maxPaths = opts.maxPaths ?? DEFAULT_MAX_PATHS;
     this.coalesceWindowMs = opts.coalesceWindowMs ?? DEFAULT_COALESCE_WINDOW_MS;
 
     this.saveStmt = this.db.prepare(
       "INSERT OR REPLACE INTO session_metrics (session_id, metrics_json, updated_at) VALUES (?, ?, unixepoch())",
     );
     this.loadStmt = this.db.prepare("SELECT metrics_json FROM session_metrics WHERE session_id = ?");
-    this.deleteStmt = this.db.prepare("DELETE FROM session_metrics WHERE session_id = ?");
+    this.pruneStmt = this.db.prepare("DELETE FROM session_metrics WHERE updated_at < unixepoch() - ?");
+
+    const pruneAfterDays = opts.pruneAfterDays ?? DEFAULT_PRUNE_AFTER_DAYS;
+    try {
+      this.pruneStmt.run(pruneAfterDays * 86400);
+    } catch {
+      // best-effort cleanup — don't block startup
+    }
 
     this.subId = this.bus.subscribe((event) => this.handleEvent(event), isRelevantEvent);
   }
@@ -190,6 +203,9 @@ export class SessionMetricsAggregator {
     if (dirPath) {
       let entry = state.dirFootprint.get(dirPath);
       if (!entry) {
+        if (state.dirFootprint.size >= this.maxPaths) {
+          evictOldest(state.dirFootprint);
+        }
         entry = { read: 0, wrote: 0, fileSet: new Set() };
         state.dirFootprint.set(dirPath, entry);
       }
@@ -220,6 +236,9 @@ export class SessionMetricsAggregator {
     if (filePath && !isWrite) {
       let rd = state.readDepth.get(filePath);
       if (!rd) {
+        if (state.readDepth.size >= this.maxPaths) {
+          evictOldest(state.readDepth);
+        }
         rd = { readCount: 0, linesReadTotal: 0, maxLines: 0 };
         state.readDepth.set(filePath, rd);
       }
@@ -258,8 +277,9 @@ export class SessionMetricsAggregator {
     this.accumulateStateTime(state);
     this.emitAllMetrics(sessionId, state);
     this.flushCoalesced(sessionId);
-    this.persistSession(sessionId, state);
-    this.sessions.delete(sessionId);
+    if (this.persistSession(sessionId, state)) {
+      this.sessions.delete(sessionId);
+    }
   }
 
   // ── Metric emission (coalesced) ──
@@ -349,12 +369,14 @@ export class SessionMetricsAggregator {
 
   // ── Persistence ──
 
-  private persistSession(sessionId: string, state: SessionMetricState): void {
-    if (!state.hasToolCalls) return;
+  private persistSession(sessionId: string, state: SessionMetricState): boolean {
+    if (!state.hasToolCalls) return true;
     try {
       this.saveStmt.run(sessionId, serializeState(state));
+      return true;
     } catch (err) {
       console.error(`[SessionMetrics] Failed to persist metrics for ${sessionId}:`, err);
+      return false;
     }
   }
 
@@ -371,6 +393,11 @@ export class SessionMetricsAggregator {
 }
 
 // ── Pure helpers ──
+
+function evictOldest<V>(map: Map<string, V>): void {
+  const first = map.keys().next();
+  if (!first.done) map.delete(first.value);
+}
 
 export function createFreshState(sessionId: string): SessionMetricState {
   return {

--- a/packages/daemon/src/session-metrics.ts
+++ b/packages/daemon/src/session-metrics.ts
@@ -1,0 +1,441 @@
+import type { Database } from "bun:sqlite";
+import type { MonitorEvent, MonitorEventInput } from "@mcp-cli/core";
+import {
+  METRIC_SESSION_COMMAND_HIST,
+  METRIC_SESSION_FOOTPRINT,
+  METRIC_SESSION_QUERIES,
+  SESSION_DISCONNECTED,
+  SESSION_ENDED,
+  SESSION_IDLE,
+  SESSION_PERMISSION_REQUEST,
+  SESSION_RESULT,
+  SESSION_TOOL_USE,
+} from "@mcp-cli/core";
+import type { EventBus } from "./event-bus";
+
+// ── Aggregator state types ──
+
+export interface DirFootprintEntry {
+  dir: string;
+  read: number;
+  wrote: number;
+  files: number;
+}
+
+export interface CommandEntry {
+  cmd: string;
+  runs: number;
+}
+
+export interface QueryEntry {
+  tool: string;
+  pattern: string;
+  path?: string;
+}
+
+export interface FileReadDepthEntry {
+  filePath: string;
+  readCount: number;
+  linesReadTotal: number;
+  maxLines: number;
+}
+
+interface DirAccum {
+  read: number;
+  wrote: number;
+  fileSet: Set<string>;
+}
+
+interface ReadDepthAccum {
+  readCount: number;
+  linesReadTotal: number;
+  maxLines: number;
+}
+
+export interface SessionMetricState {
+  sessionId: string;
+  dirFootprint: Map<string, DirAccum>;
+  commandHist: Map<string, number>;
+  queries: QueryEntry[];
+  readDepth: Map<string, ReadDepthAccum>;
+  currentState: { state: string; enteredAt: number };
+  stateAccum: Map<string, number>;
+  hasToolCalls: boolean;
+}
+
+// ── Serialization types (for DB persistence) ──
+
+interface SerializedState {
+  dirFootprint: Array<{ dir: string; read: number; wrote: number; files: string[] }>;
+  commandHist: Array<{ cmd: string; runs: number }>;
+  queries: QueryEntry[];
+  readDepth: Array<{ filePath: string; readCount: number; linesReadTotal: number; maxLines: number }>;
+  stateAccum: Record<string, number>;
+  hasToolCalls: boolean;
+}
+
+// ── Matched events ──
+
+const MATCHED_EVENTS: ReadonlySet<string> = new Set([
+  SESSION_TOOL_USE,
+  SESSION_RESULT,
+  SESSION_IDLE,
+  SESSION_ENDED,
+  SESSION_DISCONNECTED,
+  SESSION_PERMISSION_REQUEST,
+]);
+
+function isRelevantEvent(event: MonitorEvent): boolean {
+  return event.category === "session" && MATCHED_EVENTS.has(event.event);
+}
+
+// ── Aggregator ──
+
+export interface SessionMetricsAggregatorOpts {
+  bus: EventBus;
+  db: Database;
+  maxQueries?: number;
+  coalesceWindowMs?: number;
+}
+
+const DEFAULT_MAX_QUERIES = 20;
+const DEFAULT_COALESCE_WINDOW_MS = 500;
+
+export class SessionMetricsAggregator {
+  private readonly bus: EventBus;
+  private readonly db: Database;
+  private readonly maxQueries: number;
+  private readonly coalesceWindowMs: number;
+  private readonly sessions = new Map<string, SessionMetricState>();
+  private readonly subId: number;
+  private disposed = false;
+
+  private readonly saveStmt: ReturnType<Database["prepare"]>;
+  private readonly loadStmt: ReturnType<Database["prepare"]>;
+  private readonly deleteStmt: ReturnType<Database["prepare"]>;
+
+  constructor(opts: SessionMetricsAggregatorOpts) {
+    this.bus = opts.bus;
+    this.db = opts.db;
+    this.maxQueries = opts.maxQueries ?? DEFAULT_MAX_QUERIES;
+    this.coalesceWindowMs = opts.coalesceWindowMs ?? DEFAULT_COALESCE_WINDOW_MS;
+
+    this.saveStmt = this.db.prepare(
+      "INSERT OR REPLACE INTO session_metrics (session_id, metrics_json, updated_at) VALUES (?, ?, unixepoch())",
+    );
+    this.loadStmt = this.db.prepare("SELECT metrics_json FROM session_metrics WHERE session_id = ?");
+    this.deleteStmt = this.db.prepare("DELETE FROM session_metrics WHERE session_id = ?");
+
+    this.subId = this.bus.subscribe((event) => this.handleEvent(event), isRelevantEvent);
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.bus.unsubscribe(this.subId);
+    for (const [sessionId, state] of this.sessions) {
+      this.persistSession(sessionId, state);
+    }
+    this.sessions.clear();
+  }
+
+  getState(sessionId: string): SessionMetricState | undefined {
+    return this.sessions.get(sessionId);
+  }
+
+  get sessionCount(): number {
+    return this.sessions.size;
+  }
+
+  // ── Event dispatch ──
+
+  private handleEvent(event: MonitorEvent): void {
+    if (this.disposed) return;
+    const sessionId = event.sessionId as string | undefined;
+    if (!sessionId) return;
+
+    switch (event.event) {
+      case SESSION_TOOL_USE:
+        this.handleToolUse(sessionId, event);
+        break;
+      case SESSION_RESULT:
+      case SESSION_IDLE:
+        this.handleStateTransition(sessionId, "idle");
+        break;
+      case SESSION_PERMISSION_REQUEST:
+        this.handleStateTransition(sessionId, "waiting_permission");
+        break;
+      case SESSION_ENDED:
+      case SESSION_DISCONNECTED:
+        this.handleSessionEnd(sessionId);
+        break;
+    }
+  }
+
+  // ── Tool-use aggregation ──
+
+  private handleToolUse(sessionId: string, event: MonitorEvent): void {
+    const state = this.getOrCreate(sessionId);
+    state.hasToolCalls = true;
+
+    this.accumulateStateTime(state);
+    state.currentState = { state: "active", enteredAt: Date.now() };
+
+    const toolName = event.toolName as string;
+    const dirPath = event.dirPath as string | undefined;
+    const filePath = event.filePath as string | undefined;
+    const linesHint = (event.linesHint as number) ?? 0;
+    const isWrite = event.isWrite === true;
+
+    if (dirPath) {
+      let entry = state.dirFootprint.get(dirPath);
+      if (!entry) {
+        entry = { read: 0, wrote: 0, fileSet: new Set() };
+        state.dirFootprint.set(dirPath, entry);
+      }
+      if (isWrite) {
+        entry.wrote += linesHint;
+      } else {
+        entry.read += linesHint;
+      }
+      if (filePath) entry.fileSet.add(filePath);
+    }
+
+    if (typeof event.cmdGroup === "string") {
+      const cmdGroup = event.cmdGroup as string;
+      state.commandHist.set(cmdGroup, (state.commandHist.get(cmdGroup) ?? 0) + 1);
+    }
+
+    if ((toolName === "Grep" || toolName === "Glob") && typeof event.pattern === "string") {
+      state.queries.push({
+        tool: toolName,
+        pattern: event.pattern as string,
+        path: event.searchPath as string | undefined,
+      });
+      if (state.queries.length > this.maxQueries) {
+        state.queries = state.queries.slice(-this.maxQueries);
+      }
+    }
+
+    if (filePath && !isWrite) {
+      let rd = state.readDepth.get(filePath);
+      if (!rd) {
+        rd = { readCount: 0, linesReadTotal: 0, maxLines: 0 };
+        state.readDepth.set(filePath, rd);
+      }
+      rd.readCount++;
+      rd.linesReadTotal += linesHint;
+      rd.maxLines = Math.max(rd.maxLines, linesHint);
+    }
+
+    this.emitFootprint(sessionId, state);
+    this.emitCommandHist(sessionId, state);
+    this.emitQueries(sessionId, state);
+  }
+
+  // ── State timing ──
+
+  private handleStateTransition(sessionId: string, newState: string): void {
+    const state = this.sessions.get(sessionId);
+    if (!state) return;
+    this.accumulateStateTime(state);
+    state.currentState = { state: newState, enteredAt: Date.now() };
+  }
+
+  private accumulateStateTime(state: SessionMetricState): void {
+    const elapsed = Date.now() - state.currentState.enteredAt;
+    if (elapsed > 0) {
+      const prev = state.stateAccum.get(state.currentState.state) ?? 0;
+      state.stateAccum.set(state.currentState.state, prev + elapsed);
+    }
+  }
+
+  // ── Session end ──
+
+  private handleSessionEnd(sessionId: string): void {
+    const state = this.sessions.get(sessionId);
+    if (!state) return;
+    this.accumulateStateTime(state);
+    this.emitAllMetrics(sessionId, state);
+    this.flushCoalesced(sessionId);
+    this.persistSession(sessionId, state);
+    this.sessions.delete(sessionId);
+  }
+
+  // ── Metric emission (coalesced) ──
+
+  private emitFootprint(sessionId: string, state: SessionMetricState): void {
+    const footprint: DirFootprintEntry[] = [];
+    for (const [dir, data] of state.dirFootprint) {
+      footprint.push({ dir, read: data.read, wrote: data.wrote, files: data.fileSet.size });
+    }
+    if (footprint.length === 0) return;
+
+    const totalRead = footprint.reduce((s, f) => s + f.read, 0);
+    const totalWrote = footprint.reduce((s, f) => s + f.wrote, 0);
+
+    this.bus.publishCoalesced(
+      {
+        src: "daemon.metric",
+        event: METRIC_SESSION_FOOTPRINT,
+        category: "session",
+        sessionId,
+        footprint,
+        readWriteRatio: totalWrote > 0 ? +(totalRead / totalWrote).toFixed(2) : null,
+      } satisfies MonitorEventInput,
+      `metric:${sessionId}:footprint`,
+      { mode: "last-wins", windowMs: this.coalesceWindowMs },
+    );
+  }
+
+  private emitCommandHist(sessionId: string, state: SessionMetricState): void {
+    if (state.commandHist.size === 0) return;
+    const commands: CommandEntry[] = [];
+    for (const [cmd, runs] of state.commandHist) {
+      commands.push({ cmd, runs });
+    }
+
+    this.bus.publishCoalesced(
+      {
+        src: "daemon.metric",
+        event: METRIC_SESSION_COMMAND_HIST,
+        category: "session",
+        sessionId,
+        commands,
+      } satisfies MonitorEventInput,
+      `metric:${sessionId}:commands`,
+      { mode: "last-wins", windowMs: this.coalesceWindowMs },
+    );
+  }
+
+  private emitQueries(sessionId: string, state: SessionMetricState): void {
+    if (state.queries.length === 0) return;
+
+    this.bus.publishCoalesced(
+      {
+        src: "daemon.metric",
+        event: METRIC_SESSION_QUERIES,
+        category: "session",
+        sessionId,
+        recent: state.queries,
+      } satisfies MonitorEventInput,
+      `metric:${sessionId}:queries`,
+      { mode: "last-wins", windowMs: this.coalesceWindowMs },
+    );
+  }
+
+  private emitAllMetrics(sessionId: string, state: SessionMetricState): void {
+    this.emitFootprint(sessionId, state);
+    this.emitCommandHist(sessionId, state);
+    this.emitQueries(sessionId, state);
+  }
+
+  private flushCoalesced(sessionId: string): void {
+    this.bus.flushCoalesced(`metric:${sessionId}:footprint`);
+    this.bus.flushCoalesced(`metric:${sessionId}:commands`);
+    this.bus.flushCoalesced(`metric:${sessionId}:queries`);
+  }
+
+  // ── State management ──
+
+  private getOrCreate(sessionId: string): SessionMetricState {
+    let state = this.sessions.get(sessionId);
+    if (state) return state;
+
+    state = this.tryLoadFromDb(sessionId) ?? createFreshState(sessionId);
+    this.sessions.set(sessionId, state);
+    return state;
+  }
+
+  // ── Persistence ──
+
+  private persistSession(sessionId: string, state: SessionMetricState): void {
+    if (!state.hasToolCalls) return;
+    try {
+      this.saveStmt.run(sessionId, serializeState(state));
+    } catch (err) {
+      console.error(`[SessionMetrics] Failed to persist metrics for ${sessionId}:`, err);
+    }
+  }
+
+  private tryLoadFromDb(sessionId: string): SessionMetricState | null {
+    try {
+      const row = this.loadStmt.get(sessionId) as { metrics_json: string } | null;
+      if (!row) return null;
+      const saved = JSON.parse(row.metrics_json) as SerializedState;
+      return deserializeState(sessionId, saved);
+    } catch {
+      return null;
+    }
+  }
+}
+
+// ── Pure helpers ──
+
+export function createFreshState(sessionId: string): SessionMetricState {
+  return {
+    sessionId,
+    dirFootprint: new Map(),
+    commandHist: new Map(),
+    queries: [],
+    readDepth: new Map(),
+    currentState: { state: "active", enteredAt: Date.now() },
+    stateAccum: new Map(),
+    hasToolCalls: false,
+  };
+}
+
+export function serializeState(state: SessionMetricState): string {
+  const obj: SerializedState = {
+    dirFootprint: Array.from(state.dirFootprint.entries()).map(([dir, d]) => ({
+      dir,
+      read: d.read,
+      wrote: d.wrote,
+      files: Array.from(d.fileSet),
+    })),
+    commandHist: Array.from(state.commandHist.entries()).map(([cmd, runs]) => ({
+      cmd,
+      runs,
+    })),
+    queries: state.queries,
+    readDepth: Array.from(state.readDepth.entries()).map(([filePath, d]) => ({
+      filePath,
+      readCount: d.readCount,
+      linesReadTotal: d.linesReadTotal,
+      maxLines: d.maxLines,
+    })),
+    stateAccum: Object.fromEntries(state.stateAccum),
+    hasToolCalls: state.hasToolCalls,
+  };
+  return JSON.stringify(obj);
+}
+
+export function deserializeState(sessionId: string, saved: SerializedState): SessionMetricState {
+  const state = createFreshState(sessionId);
+  state.hasToolCalls = saved.hasToolCalls;
+
+  for (const entry of saved.dirFootprint) {
+    state.dirFootprint.set(entry.dir, {
+      read: entry.read,
+      wrote: entry.wrote,
+      fileSet: new Set(entry.files),
+    });
+  }
+  for (const entry of saved.commandHist) {
+    state.commandHist.set(entry.cmd, entry.runs);
+  }
+  state.queries = saved.queries ?? [];
+  for (const entry of saved.readDepth) {
+    state.readDepth.set(entry.filePath, {
+      readCount: entry.readCount,
+      linesReadTotal: entry.linesReadTotal,
+      maxLines: entry.maxLines,
+    });
+  }
+  if (saved.stateAccum) {
+    for (const [k, v] of Object.entries(saved.stateAccum)) {
+      state.stateAccum.set(k, v);
+    }
+  }
+  return state;
+}


### PR DESCRIPTION
## Summary
- Add `SessionMetricsAggregator` that subscribes to EventBus and derives per-session metrics (directory footprint, command histogram, query ring buffer, read depth, time-in-state) from `session.tool_use` events emitted by ws-server
- Metrics are coalesced at 500ms windows via `publishCoalesced`, persisted to SQLite on session end, and lazily reconstructed from DB on daemon restart/reconnect
- On by default; opt-out via `metrics.session.enabled: false` in CLI config

## Test plan
- [x] 36 unit tests in `session-metrics.spec.ts` covering all aggregators, coalescing, lifecycle, serialization, and `extractToolFields`
- [x] 7 unit tests in `monitor-event.spec.ts` covering new formatters and 200-char cap
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (4077 pass, 0 fail)
- [x] Coverage at 91.46% functions, 93.94% lines — all thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)