### PR TITLE
ci: retry coverage on truncated-output flake (#1838 workaround)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,8 +114,11 @@ jobs:
           elif grep -q "^ 0 fail$" /tmp/coverage_out.txt && ! grep -q "^FAIL:" /tmp/coverage_out.txt; then
             echo "::warning::Bun crash (exit $code) after all coverage tests passed — treating as pass (see #1004, #1419)"
             exit 0
-          elif [ $code -eq 132 ] || [ $code -eq 139 ]; then
-            echo "::warning::Bun crash (exit $code) — retrying once (see #1004)"
+          elif [ $code -eq 132 ] || [ $code -eq 139 ] || ! grep -qE "^ +[0-9]+ fail$" /tmp/coverage_out.txt; then
+            # 132/139 = Bun panic (#1004); the grep guard covers the #1838 flake pattern
+            # where exit code is 1 but the test summary line ("N fail") is absent because
+            # Bun aborted mid-suite on a flaky liveBuffer test. Retry once.
+            echo "::warning::Coverage failed (exit $code) without test summary — retrying once (see #1004, #1838)"
             bun scripts/check-coverage.ts --ci 2>&1 | tee /tmp/coverage_retry.txt
             code2=${PIPESTATUS[0]}
             if [ $code2 -eq 0 ]; then


### PR DESCRIPTION
## Summary

Three sprint-47 PRs (#1847, #1852, #1854) stalled overnight on the same flaky liveBuffer test (#1838). The flake aborts Bun with exit code 1 mid-suite, with no test summary line — the existing retry logic only fires on exit codes 132/139 (SIGILL/SIGSEGV) so it never retries.

This patch broadens the retry condition: if the coverage output lacks a trailing 'N fail' test-summary line (which Bun always prints on a clean exit, including real failures), retry once. Real failures still fail fast because they produce the summary.

## Why now

Sprint 47 orchestrator hit this same flake on every retry of every blocked PR. Without the retry broadened, the orchestrator's only options were 'wait and hope' or 'ship sprint with 7/10 PRs.' This unblocks the sprint without compromising the coverage gate.

## Why this is on a meta branch

Meta-branch convention per the orchestrator's run.md: between-sprint workflow / config fixes that don't fit a regular sprint slot. The real fix for #1838 (the flaky test itself) is product code and should land via a sprint-48 issue or a worker on the existing #1838 issue.

## Test plan
- [x] `bun lint` clean
- [x] CI runs on this branch — broadened retry should not change behavior on a passing build
- [ ] Once merged, rebase #1847/1852/1854 onto main; their retried CI should pass

## Followup

#1838 is the real flake fix. This PR only buys quiet for the orchestrator until that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)