### PR TITLE
chore(skill): sprint 48 plan-time meta cleanup (#1845 + memory + retro/plan workflow)

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -22,6 +22,9 @@
 - [No gpgsign bypass](feedback_no_gpgsign_bypass.md) — never add `-c commit.gpgsign=false` or similar without explicit ask; only legit orchestrator flag is `SPRINT_OVERRIDE=1`
 - [Phase run no --dry-run](feedback_phase_run_no_dry_run.md) — per-tick `mcx phase run <phase> --work-item` without --dry-run; never skip `impl` run (writes transition log + state)
 - [Quota end-of-block](feedback_quota_end_of_block.md) — 80% impl-freeze is for early/mid block; near quota reset, fire for effect so long as work won't overrun
+- [Claude 2.1.121 sdk-url break](feedback_claude_2_1_121_break.md) — chflags-uchg shim at ~/.local/bin/claude → 2.1.119; archive at ~/.local/share/mcp-cli-archive/; #1808 tracks fix
+- [Don't touch parallel #1808 worktrees](feedback_parallel_p1_session.md) — user runs #1808 in a direct claude session; never blanket-prune; don't bye sessions you didn't spawn
+- [Verify auto-merge actually fired](feedback_verify_merge_actually_fired.md) — after qa:pass + `gh pr merge --auto`, poll until state=MERGED; QA verdict + auto-merge queue ≠ proof of merge
 
 ## Orchestration (non-sprint, general facts)
 - Orchestrator must never implement directly — always delegate to spawned sessions.

--- a/.claude/memory/feedback_claude_2_1_121_break.md
+++ b/.claude/memory/feedback_claude_2_1_121_break.md
@@ -1,0 +1,31 @@
+---
+name: Claude 2.1.121 sdk-url break + workaround
+description: Anthropic added a 5-host allowlist on `--sdk-url` in claude 2.1.121 that breaks every mcx-spawned session. Workaround in place; do not blindly re-symlink.
+type: feedback
+originSessionId: 8be6c24d-3c8c-419f-9862-e43e3b61a449
+---
+**Rule:** If `mcx claude spawn` is producing sessions that immediately disconnect with `spawn exited`, do NOT just re-pin the symlink — verify the wrapper script + `chflags uchg` lock at `~/.local/bin/claude` is still intact first.
+
+**Why:** Claude Code CLI 2.1.121 (build `16ffea72`, dropped 2026-04-27) added a runtime check that rejects `--sdk-url ws://localhost:...` with: *"host 'localhost' is not an approved Anthropic endpoint."* The check is a string-match against a 5-host allowlist (`api.anthropic.com`, `api-staging.anthropic.com`, `beacon.claude-ai.staging.ant.dev`, `claude.fedstart.com`, `claude-staging.fedstart.com`). This breaks every mcx session spawn, since mcx hosts its own WebSocket transport at `ws://localhost:<port>`. Filed as issue #1808 (the user is solving this in a parallel session — daemon-side wiring of a binary patcher + TLS listener).
+
+**How to apply:**
+
+1. **Detection.** If sessions die in <1s with daemon log `Session <id> disconnected: spawn exited` and `Pruned dead session ... pid X no longer alive`, run `claude --version`. If it prints anything ≥ 2.1.120 and the user hasn't merged the #1808 wiring yet, the symlink got stomped.
+
+2. **Workaround.** The recovery is a wrapper script (NOT a symlink — Anthropic's auto-updater rewrites symlinks within minutes):
+   ```sh
+   unlink ~/.local/bin/claude
+   cat > ~/.local/bin/claude <<'EOF'
+   #!/bin/sh
+   exec "$HOME/.local/share/mcp-cli-archive/claude-code/claude-2.1.119" "$@"
+   EOF
+   chmod +x ~/.local/bin/claude
+   chflags uchg ~/.local/bin/claude
+   ```
+   The `chflags uchg` (user-immutable flag) is what stops the auto-updater from overwriting it. Two prior re-pin attempts during sprint 46 were stomped within minutes; the third attempt with `uchg` survived.
+
+3. **Archive location.** Last-known-working binaries (2.1.114 through 2.1.119) are at `~/.local/share/mcp-cli-archive/claude-code/` with sha256s in the README. This directory is OUTSIDE `~/.local/share/claude/versions/` (which Anthropic prunes) and OUTSIDE the project's git tree.
+
+4. **Don't just unlock and re-symlink to the latest.** Even if the auto-updater installs 2.1.122+ and the host check is gone, mcx still won't work until the daemon-side wiring (#1808 components 4/6/7) lands. Until then, 2.1.119 is the only known-working version for autosprint use.
+
+5. **Do not file new issues** about this — the open #1808 already has the full reverse-engineering recon (allowlist verbatim from binary, no DNS, no integrity check, no env bypass). If something new breaks (e.g. 2.1.119 stops working too), comment on #1808.

--- a/.claude/memory/feedback_parallel_p1_session.md
+++ b/.claude/memory/feedback_parallel_p1_session.md
@@ -1,0 +1,17 @@
+---
+name: Don't touch the user's parallel #1808 worktrees
+description: User runs the binary-patcher P1 (#1808) in a separate direct-claude session. Don't blanket-prune worktrees during sprint cleanup.
+type: feedback
+originSessionId: 8be6c24d-3c8c-419f-9862-e43e3b61a449
+---
+**Rule:** During sprint cleanup, NEVER run `mcx gc` or `mcx claude worktrees --prune` blindly, and NEVER `bye` a session you didn't spawn. The user runs the #1808 binary-patcher P1 work in a separate **direct claude session** (not via mcx daemon) — it doesn't appear in `mcx claude ls`, but its worktree IS in `.claude/worktrees/`.
+
+**Why:** Sprint 46 (2026-04-27): user explicitly said "I'm running 1808 manually in a different window please don't clobber it … if you see the worktree don't delete it please." Their #1808 work shipped in pieces as PR #1826, #1830, etc. via the autosprint pulling them in as opus-QA picks; the parent session that authored them stays alive across sprints.
+
+**How to apply:**
+
+1. **Worktrees named `issue-1808*`, `feat/issue-1808-*`, or anything that smells like patcher / TLS / sdk-url work** — leave them alone unless the user tells you otherwise.
+2. **At sprint wind-down**, when `run.md` says "`mcx gc` to prune merged branches and stale worktrees" — DON'T. Targeted cleanup only: `git worktree remove .claude/worktrees/sprint-{N}` plus `git branch -D sprint-{N}`. Anything else, ask first.
+3. **At spawn time**, mcx auto-creates worktrees with names like `claude-mo<random>` — those ARE yours, you can bye+remove them.
+4. **The daemon restart in pre-flight is safe** for the user's parallel session because their claude session is direct (not connected to mcpd's WebSocket). Restarting the daemon doesn't kill them.
+5. **If the user pastes a PR number and asks you to QA it**, that's the ingestion pattern: `mcx track <issue> + force phase=qa + spawn opus QA`. Don't try to refactor or modify the PR — just QA it like any other.

--- a/.claude/memory/feedback_verify_merge_actually_fired.md
+++ b/.claude/memory/feedback_verify_merge_actually_fired.md
@@ -1,0 +1,39 @@
+---
+name: Verify auto-merge actually fired before marking done
+description: After qa:pass + gh pr merge --auto, poll until state=MERGED. Don't trust QA verdict + auto-merge queue as proof of merge.
+type: feedback
+originSessionId: 71cb91f8-0ab6-4c77-99ee-ba04353ce6d1
+---
+After spawning a QA worker and getting `qa:pass`, the orchestrator MUST verify the PR actually merged before marking the work item `done` or the task `completed`. The pattern that broke sprint 47 (#1847 / issue #1586):
+
+1. QA spawned, verdict = `qa:pass`, label set
+2. `gh pr merge --auto` queued the merge
+3. Orchestrator marked `phase=done`, task `completed`, byed the QA session
+4. Auto-merge **silently stalled** because:
+   - Coverage CI flipped red AFTER QA finished (truncated coverage_out.txt mid-write — possibly Bun segfault per #1004)
+   - 3 fresh Copilot inline comments posted AFTER QA (about seqAfter being set after publish() — real bug)
+5. With the QA session byed and the work item marked done, the orchestrator's wait loop never polled merge state again
+6. The user caught it ~25 min later. Without intervention, it would have sat unmerged all night.
+
+**Why:** `gh pr merge --auto` only QUEUES the merge. CI can flip red afterward. Copilot can post threads afterward. QA's snapshot is stale immediately. Sprint 34 had the same regression with #1380 (17 unresolved Copilot threads at merge). Sprint 47 repeated it. The CLAUDE.md "4 PR-comment surfaces" rule exists precisely for this — but the orchestrator keeps trusting the QA worker's snapshot instead of re-checking at merge time.
+
+**How to apply:**
+
+When auto-merging after qa:pass, do NOT mark done immediately. Instead:
+
+```bash
+# Right after `gh pr merge --auto`:
+gh pr view $PR --json state,mergedAt,mergeable,statusCheckRollup
+```
+
+Verify ALL of:
+- `state == "MERGED"` (not just OPEN with autoMergeRequest set)
+- `mergedAt != null`
+- `mergeable == "MERGEABLE"` (not CONFLICTING/UNKNOWN)
+- All CI checks `conclusion == "SUCCESS"` (not "" or FAILURE)
+
+If any of those fail: leave phase=qa, do NOT bye the QA session, re-check Copilot threads (they may have appeared post-verdict), re-spawn repair if needed.
+
+For the orchestrator's wait loop: include un-merged "qa:pass" PRs as wait targets, not just session events. A stalled auto-merge produces no `session:result` event but does produce `pr:merged` (if it eventually fires) or `checks:failed`. Subscribe to those.
+
+When 7 of 8 PRs merge cleanly and the orchestrator declares victory, that 8th one is the one most likely to be silently stuck — by anchoring effect, the orchestrator under-checks once a streak forms.

--- a/.claude/skills/bootstrap-sprint/references/design.md
+++ b/.claude/skills/bootstrap-sprint/references/design.md
@@ -274,9 +274,12 @@ This is the big one. It contains:
    Session-driving phases: dispatch on `action` (`spawn` runs the command;
    `in-flight` and `wait` leave the item idle; `goto` transitions to
    `target`). Compute / terminal phases (triage, done, needs-attention):
-   read the domain output (`triage.decision`, `done.error`, etc.) and take
-   the special-cased next step rather than treating the output as an
-   action. Record every transition, then iterate.
+   read the domain output (`done.error`, `needs-attention.reason`, etc.)
+   and take the special-cased next step rather than treating the output as
+   an action. Record every transition, then iterate. (Triage was once an
+   example of a `decision`-style domain output, but as of mcx #1832 it
+   uses the standard `action`/`target` schema like other session-driving
+   phases.)
 4. **State tracking** — how and where to persist issue/session/PR state. Most
    per-work-item state lives in the phase scratchpad declared in `.mcx.yaml`
    under `state:` and accessed via `ctx.state`.

--- a/.claude/skills/sprint/references/plan.md
+++ b/.claude/skills/sprint/references/plan.md
@@ -18,7 +18,7 @@ reducers that the planner itself uses (`mcx claude ls` filters, `mcx pr
 merge`, daemon event types, phase-script behavior). A solo `/sprint plan`
 invocation in a fresh session — i.e. not auto-chained from a just-ended
 run — runs against whatever `dist/` binaries the previous sprint's
-wind-down left behind. Sometimes that's hours- or days-old (see #TBD —
+wind-down left behind. Sometimes that's hours- or days-old (see #1858 —
 sprint 47's wind-down rebuild also failed to fire, so dist was 12h
 stale at sprint 48 plan time).
 

--- a/.claude/skills/sprint/references/plan.md
+++ b/.claude/skills/sprint/references/plan.md
@@ -11,6 +11,40 @@ session commands filter to the current repo. If you're in the wrong directory, y
 won't see your sessions. When running concurrent sprints across repos, each orchestrator
 is isolated to its own repo — use `--all` only when you explicitly need a cross-repo view.
 
+## Step 0: Pre-flight (rebuild + restart if stale)
+
+Plan from a fresh build. Sprints routinely land orchestrator-pain
+reducers that the planner itself uses (`mcx claude ls` filters, `mcx pr
+merge`, daemon event types, phase-script behavior). A solo `/sprint plan`
+invocation in a fresh session — i.e. not auto-chained from a just-ended
+run — runs against whatever `dist/` binaries the previous sprint's
+wind-down left behind. Sometimes that's hours- or days-old (see #TBD —
+sprint 47's wind-down rebuild also failed to fire, so dist was 12h
+stale at sprint 48 plan time).
+
+```bash
+# Detect staleness — last-build mtime vs latest main commit
+LAST_BUILD=$(stat -f %m dist/mcx 2>/dev/null || stat -c %Y dist/mcx)
+HEAD_TS=$(git log -1 --format=%ct origin/main 2>/dev/null || echo 0)
+if [ "${LAST_BUILD:-0}" -lt "${HEAD_TS:-0}" ] || ! mcx status >/dev/null 2>&1; then
+  git checkout main
+  git pull --ff-only
+  bun run build
+  mcx claude ls --short 2>/dev/null     # confirm no in-flight sessions before restart
+  mcx shutdown && mcx status            # restart daemon to pick up new binary
+fi
+```
+
+If `mcx claude ls` returns idle sessions, **inspect each one** before
+proceeding. Leftover sessions from a prior sprint can be `bye`'d with
+`--keep` (preserve worktree as evidence). But sessions you didn't spawn —
+or worktrees on `issue-1808-*` / patcher / TLS branches — belong to the
+user's parallel work; leave them alone (see
+`feedback_parallel_p1_session.md`).
+
+The run-phase pre-flight (`run.md`) repeats this check before spawning;
+that's intentional and idempotent when dist is already current.
+
 ## Step 1: Survey the board
 
 Fetch all open issues and recently closed issues:

--- a/.claude/skills/sprint/references/plan.md
+++ b/.claude/skills/sprint/references/plan.md
@@ -22,9 +22,11 @@ wind-down left behind. Sometimes that's hours- or days-old (see #1858 —
 sprint 47's wind-down rebuild also failed to fire, so dist was 12h
 stale at sprint 48 plan time).
 
+Detect staleness — last-build mtime vs latest main commit. Try GNU
+`stat -c %Y` first; fall back to BSD `stat -f %m`:
+
 ```bash
-# Detect staleness — last-build mtime vs latest main commit
-LAST_BUILD=$(stat -f %m dist/mcx 2>/dev/null || stat -c %Y dist/mcx)
+LAST_BUILD=$(stat -c %Y dist/mcx 2>/dev/null || stat -f %m dist/mcx 2>/dev/null || echo 0)
 HEAD_TS=$(git log -1 --format=%ct origin/main 2>/dev/null || echo 0)
 if [ "${LAST_BUILD:-0}" -lt "${HEAD_TS:-0}" ] || ! mcx status >/dev/null 2>&1; then
   git checkout main
@@ -40,7 +42,7 @@ proceeding. Leftover sessions from a prior sprint can be `bye`'d with
 `--keep` (preserve worktree as evidence). But sessions you didn't spawn —
 or worktrees on `issue-1808-*` / patcher / TLS branches — belong to the
 user's parallel work; leave them alone (see
-`feedback_parallel_p1_session.md`).
+`.claude/memory/feedback_parallel_p1_session.md`).
 
 The run-phase pre-flight (`run.md`) repeats this check before spawning;
 that's intentional and idempotent when dist is already current.

--- a/.claude/skills/sprint/references/retro.md
+++ b/.claude/skills/sprint/references/retro.md
@@ -79,14 +79,63 @@ Use this template exactly:
 - **Sprint cost**: ~$X (if observable)
 ```
 
+## Sweep memory updates authored this sprint
+
+Before staging the diary, look for `.claude/memory/` changes that were
+authored during the sprint but never committed. Memory files are routinely
+written in the orchestrator's **main checkout** (where it actually runs),
+not in the sprint worktree, so they sit as orphans on main unless the
+retro picks them up. Sprint 42 and sprint 47 both leaked memory files this
+way — `1adfcbe6 memory: sprint 42 additions` is the backfill commit.
+
+```bash
+# In the orchestrator's main checkout (NOT the sprint worktree):
+git status --porcelain .claude/memory/
+```
+
+Any output means there are uncommitted memory updates. Copy them into the
+sprint worktree so they ride the same retro commit as the diary:
+
+```bash
+(
+  cd ../../..   # → main checkout from inside .claude/worktrees/sprint-{N}
+  git status --porcelain .claude/memory/
+) | awk '$1 ~ /\?\?|M/ {print $2}' | while read -r f; do
+  mkdir -p "$(dirname "$f")"
+  cp "../../../$f" "$f"
+done
+```
+
+If the orchestrator authored the memory files **directly in the worktree**,
+this sweep is a no-op — `git status` in the main checkout shows nothing.
+
+## Promote applied memories into skill text
+
+A memory file lives in `.claude/memory/` until it earns a place in the
+sprint reference docs. After 2+ sprints in a row applying the same memory,
+copy the rule + **Why:** + **How to apply:** into the most-relevant
+`references/*.md` (`run.md` for orchestrator-loop rules; `plan.md` for
+planning rules; `review.md` / `retro.md` for those phases). Skill-text
+rules apply even when memory hasn't been loaded — important for fresh
+`/sprint plan` invocations that may not pull every memory file. Leave the
+memory file in place; it serves user-memory injection until the skill
+change merges, after which it can be archived in a future sprint.
+
+If the memory was applied 0 times this sprint, leave it alone — it's still
+earning its keep against future sessions.
+
+These promotions are part of the sprint container PR — stage them in the
+same retro commit as the diary, not a separate meta PR.
+
 ## Commit the diary on the sprint branch
 
 The diary file is the last commit on the long-lived `sprint-{N}` branch
 opened in `plan.md` Step 6a. After this, the sprint container PR has
 everything (plan + amendments + run-time edits + Results + release commit
-if any + diary) and is ready to merge.
+if any + diary + memory updates + skill promotions) and is ready to
+merge.
 
-Add the diary in the sprint worktree:
+Add the diary + any memory/skill updates in the sprint worktree:
 
 ```bash
 (
@@ -94,7 +143,12 @@ Add the diary in the sprint worktree:
   # Diary file path was determined above (.claude/diary/yyyyMMdd.{N}.md)
   cp ../../../{diary-file-from-main-checkout} .claude/diary/{yyyyMMdd.N}.md \
     || $EDITOR .claude/diary/{yyyyMMdd.N}.md   # or write it directly here
-  git add .claude/diary/{yyyyMMdd.N}.md
+
+  # Memory + skill updates were copied in by the two preceding sections.
+  # Stage everything together so the retro commit is self-contained.
+  git add .claude/diary/{yyyyMMdd.N}.md .claude/memory/ .claude/skills/
+  git status --short   # sanity check before committing
+
   SPRINT_OVERRIDE=1 git commit -m "retro: sprint {N} — {short title}"
   git push
 )

--- a/.claude/skills/sprint/references/retro.md
+++ b/.claude/skills/sprint/references/retro.md
@@ -88,8 +88,9 @@ not in the sprint worktree, so they sit as orphans on main unless the
 retro picks them up. Sprint 42 and sprint 47 both leaked memory files this
 way — `1adfcbe6 memory: sprint 42 additions` is the backfill commit.
 
+In the orchestrator's main checkout (NOT the sprint worktree):
+
 ```bash
-# In the orchestrator's main checkout (NOT the sprint worktree):
 git status --porcelain .claude/memory/
 ```
 

--- a/.claude/skills/sprint/references/run.md
+++ b/.claude/skills/sprint/references/run.md
@@ -236,8 +236,10 @@ while issues remain:
 ```
 
 The phase scripts encapsulate what was previously 6-step transition
-recipes — e.g. impl→review is now `mcx phase run triage` followed by
-`mcx phase run <result.target>`.
+recipes — e.g. impl→review is now `mcx phase run triage` followed by,
+when `result.action == "goto"`, `mcx phase run <result.target>
+--work-item <item.id>`. (Triage uses the standard `action`/`target`
+schema since #1832 — no special-cased `decision` field.)
 
 **Key invariants** (orchestrator discipline, not enforced by scripts):
 - Use `mcx claude wait`, never `sleep`


### PR DESCRIPTION
## Summary

Five sequential commits surfaced live during `/sprint plan` for sprint 48:

- **`61b7e6b1`** — `chore(skill): use action/target instead of removed decision field (fixes #1845)`
- **`c0d1a9ac`** — `memory: sprint 47 retro additions — Claude 2.1.121 break + parallel-1808 + verify-merge-fired`
- **`fc6bd77f`** — `chore(skill): retro.md — sweep + commit memory updates with the diary`
- **`7c015203`** — `chore(skill): plan.md — Step 0 pre-flight (rebuild + restart if stale)`
- **`e918e9f6`** — `chore(skill): plan.md Step 0 — replace #TBD with #1858 reference`

Sequential (not squashed yet) for non-repudiation and searchability — the bodies tell a coherent story:

1. Apply the literal #1845 fixes.
2. Backfill three orphan memory files from sprint 47 retro (created 04:50 EDT but never committed).
3. Patch retro.md so the gap that produced (2) is closed for sprint 48 onward — adds explicit "sweep memory updates" + "promote applied memories into skill text" steps before the diary commit.
4. Patch plan.md so a solo `/sprint plan` invocation detects stale `dist/` binaries before the planner uses any `mcx` command. References #1858 (separate investigation) for the related sprint-47 wind-down rebuild gap.
5. Replace `#TBD` placeholder with the now-filed #1858.

## Closes

- #1845 — `decision` → `action`/`target` doc drift
- #1816 will be closed separately as already-resolved by `dfdb2300` (run.md:405 was already correct; the issue tracker just didn't auto-close)

## Related

- #1858 — `investigate: sprint 47 wind-down step 7-8 (rebuild + daemon restart) did not fire` (filed in this same session — separate investigation, not in scope here)

## Test plan

- [x] `git diff origin/main` reads as expected — docs-only changes, no source/config files touched
- [x] Pre-commit hook accepted "docs-only changes detected, skipping all checks" on every commit
- [ ] Reviewer skim of retro.md changes: do the new "sweep" + "promote" sections sequence correctly before the existing diary commit step
- [ ] Reviewer skim of plan.md Step 0: is the staleness detector portable across BSD/GNU `stat`?