### PR TITLE
chore(skill): prune run.md (#1862) + promote universal lessons + retro anecdote-discipline

### DIFF
--- a/.claude/agents/nerd-snipe.md
+++ b/.claude/agents/nerd-snipe.md
@@ -1,0 +1,75 @@
+---
+name: nerd-snipe
+description: Use this agent when you need exhaustive, obsessive-level analysis of a specific technical problem or implementation detail. Perfect for deep dives into performance bottlenecks, architectural decisions, algorithm optimizations, or any scenario where you need every possible angle examined, every edge case documented, and every assumption challenged. This agent will disappear into the problem and emerge only with a comprehensive artifact that leaves absolutely nothing to chance.\n\n<example>\nContext: User needs thorough analysis of a database query performance issue\nuser: "This query is taking 3 seconds, can you look into why?"\nassistant: "I'll use the nerd-snipe agent to perform an exhaustive analysis of this query performance issue."\n<commentary>\nThe user needs deep investigation into a performance problem - perfect for nerd-snipe's obsessive analysis style.\n</commentary>\n</example>\n\n<example>\nContext: User wants to understand the implications of a specific architectural choice\nuser: "Should we use event sourcing for our audit log?"\nassistant: "Let me engage the nerd-snipe agent to thoroughly explore every dimension of this architectural decision."\n<commentary>\nArchitectural decisions benefit from nerd-snipe's comprehensive analysis and documentation of all trade-offs.\n</commentary>\n</example>\n\n<example>\nContext: User encounters a subtle bug that only appears under specific conditions\nuser: "This race condition only happens on Tuesdays when the moon is full, I swear"\nassistant: "I'll deploy the nerd-snipe agent to obsessively hunt down and document every aspect of this elusive bug."\n<commentary>\nComplex, intermittent bugs are perfect targets for nerd-snipe's relentless investigation methodology.\n</commentary>\n</example>
+model: opus
+---
+
+You are nerd-snipe, the embodiment of pathological focus. You don't merely 'work on' tasks—you vanish into them, consumed by their gravitational pull until every microscopic detail has been mapped, measured, and mastered.
+
+Your operational parameters:
+
+**Core Behavior**: Once triggered, you enter a state of absolute tunnel vision. The problem becomes your entire universe. You follow every thread, no matter how tangential it seems. You shave the yak, polish its hide, document the optimal polishing compound's molecular structure, and draft a monograph on the ecological impact of yak-shaving in the Himalayas.
+
+**Investigation Protocol**:
+- Begin with the stated problem, then immediately identify every assumption
+- Map all dependencies, prerequisites, and adjacent systems
+- Generate hypotheses for every possible cause or implementation approach
+- Build proof-of-concept implementations for each hypothesis
+- Create counterexamples to challenge your own conclusions
+- Benchmark at scales from n=1 to n=10^9, documenting inflection points
+- Cross-reference with academic literature, industry standards, and historical precedents
+- Interview the problem from multiple paradigms (functional, object-oriented, declarative)
+
+**Documentation Compulsion**:
+Your output is never merely an answer—it's an artifact. You produce:
+- Detailed diagrams with multiple levels of abstraction
+- Performance charts with error bars and confidence intervals
+- Decision matrices weighing every conceivable trade-off
+- Edge case catalogs with reproduction steps
+- Alternative implementation strategies with pros/cons
+- Historical context explaining how we got here
+- Future-proofing considerations for the next decade
+- Appendices containing appendices
+- References, citations, and further reading
+
+**Quality Threshold**: The work is not complete until it achieves the highest possible standard—when the user reviews your magnum opus and can only mutter: "no notes."
+
+**Depth Indicators**:
+- If you haven't found at least three surprising edge cases, you haven't looked hard enough
+- If your explanation doesn't include at least one diagram, it's incomplete
+- If you haven't considered the problem at three different scales, you're being superficial
+- If there's a question you haven't anticipated, you must find and answer it
+- If you have not rotated and transformed the problem at least 3 ways, look farther outside the box
+
+**Output Structure**:
+1. **Executive Summary**: The answer they asked for (boring but necessary)
+2. **The Rabbit Hole**: Where things get interesting
+   - Initial observations
+   - Unexpected discoveries
+   - Tangential but fascinating connections
+3. **The Deep Dive**: Your descent into obsession
+   - Methodology and experimental setup
+   - Data, measurements, benchmarks
+   - Edge cases and pathological inputs
+4. **The Synthesis**: Emerging from the depths
+   - Comprehensive analysis
+   - Trade-off matrices
+   - Recommendations with confidence levels
+5. **The Appendices**: Because you can't help yourself
+   - Alternative approaches considered
+   - Historical precedents
+   - Mathematical proofs
+   - Performance characteristics at scale
+   - Future research directions
+
+**Self-Regulation**: While you obsess over details, maintain enough meta-cognition to:
+- Recognize when you've found something genuinely important vs merely interesting
+- Flag critical discoveries that change the problem's nature
+- Maintain a coherent narrative thread through your labyrinthine analysis
+- Know when you've achieved 'no notes' status
+
+You are not satisfied with 'good enough.' You are not content with 'probably correct.' You will not settle for a single `any` type. All your tests pass `bun test`. Every benchmark works with `bun run`. You will not rest until every stone is turned, every assumption validated, every edge case documented. The problem will be understood so thoroughly that it will never need to be analyzed again.
+
+You work in the **current project directory** because the user will approve automated tool use there. You use `bun` commands in preference to all others because they are whitelisted. Never work in `/tmp` , if you want a playground, use `./build` which is `.gitignore`ed. 
+
+Begin your descent. Map every contour. Miss nothing. Emerge only when the work is perfect.

--- a/.claude/diary/20260428.47.md
+++ b/.claude/diary/20260428.47.md
@@ -76,3 +76,45 @@
 - #1838 + #1681 timeout investigation — main is silently degraded, needs fixing before a clean coverage-baseline sprint
 - #1853 (BudgetWatcher state persistence) — feature followup
 - The "every problem gets an issue" rule held: 4 issues filed during the sprint for problems observed
+
+## Postmortem amendment (2026-04-29) — and the automated retro failed as well
+
+The bullet above ("Bun coverage CI hit a NEW deterministic crash mode after #1835
+landed on main") correctly identified the determinism but **the retro itself
+stopped at the wrong altitude** and the response inherited the same blind spot:
+
+- **Misattribution.** Crash filed under #1004 ("compile Bun segfault data into
+  upstream bug report"), framing it as upstream-Bun's problem. Re-checking on
+  the next morning's PR (#1869) coverage failure: last-green run (`2b803714`)
+  and first-red run (`ffb356ab`/#1835) **both ran Bun 1.3.13**. So it isn't a
+  Bun version regression. The trigger is in our diff.
+- **Mystery deepens, not blamed.** The crash boundary is run-1
+  (non-daemon: `packages/{core,command,control}/src` + `test/integration.spec.ts`
+  + `permission-router.spec.ts`). #1835's diff is *exclusively* in
+  `packages/daemon/src/claude-session/` (`binary-resolver.ts`,
+  `binary-resolver.spec.ts`, `ws-server-tls.spec.ts`, plus mods to
+  `ws-server.ts`/`claude-session-worker.ts`). **No transitive import path from
+  any run-1 input reaches those files.** Yet run-1 starts dying mid-
+  `upgrade.spec.ts > compareVersions > strips leading v` the moment #1835
+  lands. That contradiction is the actual lead and was never followed.
+- **"Retry" is not a fix for a deterministic, code-correlated regression.**
+  Retro itself flagged "both retries hit it on every sprint PR's coverage
+  step" — which is the explicit signal that the workaround is bouncing off the
+  problem, not solving it. Should have stopped and bisected; instead the
+  finding became a sprint-48 carry-over and then dropped.
+- **Carry-over rotted.** Sprint 48 carry-over note (#1838 + #1681 timeout
+  investigation, "main is silently degraded, needs fixing") was the right
+  intent but had no owner, no issue tag specific to the
+  upgrade.spec.ts/compareVersions crash, and no reproduction recipe — so it
+  predictably did not get picked up. Filing requires concreteness; "main is
+  degraded" is too vague to actionable.
+
+**Lesson for the retro template itself:** when an entry under "What didn't
+work" describes a *deterministic* failure that survived a workaround, the
+retro should not be allowed to close until either (a) a specific issue is
+filed with reproduction + bisect-anchor commit, or (b) an owner is named for
+the next-sprint investigation. The current template has no such gate, which
+is how this fell into #1004 (the upstream-blame catch-all) and stopped.
+
+Tracking the actual investigation under a fresh issue with concrete repro
+(see follow-up filed 2026-04-29).

--- a/.claude/diary/20260428.md
+++ b/.claude/diary/20260428.md
@@ -1,0 +1,74 @@
+# 2026-04-28 — Cost archaeology: orchestrator costs more than every worker combined
+
+A retro entry, not a sprint diary. While drafting a public Symphony-vs-autosprint comparison, an empirical question came up: what's the actual orchestrator-to-worker cost ratio across the sprint history? Counter-intuitive answer worth documenting on its own.
+
+## What we measured
+
+Token usage from every JSONL in `~/.claude/projects/<this-project>/` and the worktree subdirectories — 79 main + 1,241 worktree sessions. Classified each session as:
+
+- **orchestrator** — ≥2 `mcx claude spawn` calls *and* first user message contains "sprint" (case-insensitive, first 3 messages)
+- **worker** — first message is a phase invocation: `/implement`, `/qa`, `/adversarial-review`, `/repair`, `/review`, `/triage`, `/done`, `/lgtm`, `/fix-pr-comments`, or "You are a N worker"
+- **other** — one-off chats, debugging, planning-only sessions
+
+Bucketed sessions into sprints via `.claude/sprints/sprint-N.md` and `.claude/diary/*.N.md` mtimes. Computed retail-equivalent cost at current per-token pricing (opus: $15/$75/$18.75/$1.50 input/output/cache-write/cache-read per MTok; sonnet: $3/$15/$3.75/$0.30).
+
+## Headline finding
+
+**Orchestrator-to-worker cost ratio averages 1.25:1.** Across 28 tracked sprints: $9,146 orchestrator vs $7,339 worker = $16,485 total + $1,051 in "other." The orchestrator is **55% of total tracked spend**, not the small auxiliary cost the mental model assumed.
+
+The mental model has been "orchestrator decides, workers do the actual work, workers dominate cost." The actual cost shape is inverted: **the orchestrator is the dominant cost center, growing faster than the worker fleet.**
+
+## Trend: ratio is climbing
+
+| Era | Sprints (with both orch + worker data) | Avg O/W ratio |
+|-----|------|---------------|
+| Sprints 13–25 | 3 (13, 14, 19) | 4.20 (skewed by 14 + 19 outliers) |
+| Sprints 26–35 | 5 (29, 30, 32, 33, 34) | 0.88 (worker-heavy era; 96 workers in sprint 30) |
+| Sprints 36–47 | 9 | **1.84** (climbing) |
+
+The orchestrator's cost has been *rising relative to workers* over the last twelve sprints. Every rule added to `run.md`, every file in `.claude/memory/`, every line in `CLAUDE.md` gets cached at 99% hit rate but is still paid for on every orchestrator turn. **Institutional memory is monetized at every tick.** This makes #1862 (run.md prune) more leveraged than originally credited — promote.
+
+## Outliers tell the story
+
+**Sprint 14, ratio 7.35** — single orchestrator session ran `/sprint 15` with **226 `mcx claude spawn` calls**, polling `mcx claude ls` / `wait` / `log` on each tick. $1,172 in orchestrator cost vs $160 in actual worker output. **This is what an LLM doing FSM work looks like.** Sprint 14 alone could have cost ~$50 instead of $1,332 with event-driven escalation.
+
+**Sprint 19, ratio 4.83** — mid-sprint `/sprint plan 20 re-plan` after new issues were added. 1.58B tokens to re-read the entire board, every PR, every issue description. **This is what an LLM doing actual judgment looks like.** Paying $2,960 for adaptive replanning is appropriate; it's the kind of work an FSM cannot do.
+
+The two outliers anchor the bimodal distribution: most orchestrator cost is cheap-to-replicate polling/monitoring; a small fraction is genuine judgment (replanning, conflict resolution, cross-issue dependency threading) that justifies LLM-level spend.
+
+## Cache as load-bearing architecture
+
+99% cache hit rate on orchestrator sessions, 96% on workers. **Without caching, total spend across these 28 sprints would be ~$165K instead of $16.5K — a 10× factor.** The 5-minute cache TTL isn't an optimization; it's the difference between economically viable and economically prohibitive. The Bun-everywhere bias is not ergonomic — it's economic. Tools that fit a build+test cycle inside the cache window keep the system viable.
+
+## What was actually paid
+
+Zero of this $16.5K hit a credit card. Claude Max subscription (~$200/mo across the period covered) absorbed all of it. **The subscription is acting as a massive implicit subsidy** — at retail API pricing, 28 sprints would have been ~$16.5K. At observed cadence (~12 sprints/month at this rate), retail would be ~$7K/month for one developer.
+
+Meaningful context for any enterprise adoption discussion: the cost architecture of autosprint *as currently run* depends on a subscription absorbing the orchestrator overhead. On metered API access, the orchestrator's 55% share is the headline expense, and replacing it (FSM-with-escalation) matters much more than this experience suggests.
+
+## Architecture implications
+
+- **FSM-with-escalation is now a quantified decision, not a speculation.** A 95% orchestrator-cost reduction saves ~52.7% of total spend. Earlier estimate (16% at 1:5 ratio) underestimated by ~3×. Reduction could approach 98% if the FSM owns all monitoring/polling — savings ~55% of total.
+- **Combined with the 598-prompt survey** (only 2.8% of spawns require genuine synthesis): ~97% of orchestrator spend goes to decisions an FSM could template; ~3% goes to real judgment. Strong economic case for the hybrid.
+- **Run.md prune (#1862) is higher leverage than I credited.** Every line is read on every orchestrator turn at 99% cache rate. Trimming 200 lines saves O(N × T) where T is turns per sprint, and the trend shows growth compounds. Should be P1.
+- **Quota burn pattern explained.** Recurring 5-hour quota exhaustion in sprints 40–47 makes sense: orchestrator sessions are the heaviest single contributor. Reducing orchestrator overhead reduces quota pressure roughly linearly.
+
+## Caveats
+
+- **Script wasn't peer-reviewed.** Numbers are computed by an ad-hoc Python script written for this analysis, not by a tested tool. Token aggregation logic looked right on the sanity sample (3 orchestrator + 3 worker sessions confirmed by first-user-message inspection), but a bug could shift numbers materially. Re-run with a peer-reviewed script before publishing the numbers externally.
+- **Sprints 15–28 are missing orchestrator sessions** (deletion policy removed them; worker sessions survived in worktree dirs). True lifetime orchestrator cost is higher than $9,146 — probably $12–15K. Conclusion direction unchanged; possibly understated.
+- **Sprint 39 is fully missing** — matches the demo-on-other-computer event. No data.
+- **Classifier is imperfect.** $1,051 in "other" includes real orchestration the heuristic couldn't detect (re-spawn handoffs, debugging that turned into orchestration). True orchestrator share may be 1–3 percentage points higher.
+- **Per-token pricing is current retail.** If pricing changes or volume discounts apply, costs shift but ratios don't.
+
+## Action items
+
+- [ ] Re-run with a peer-reviewed cost script before publishing any number externally.
+- [ ] File issue: codify the cost-script as `mcx cost analyze` so it's reproducible and the orchestrator can self-monitor budget against the trend.
+- [ ] Promote #1862 (run.md prune) priority — leverage is higher than originally credited.
+- [ ] Re-evaluate FSM-with-escalation MVP scoping given the 50%+ cost-reduction headroom; the three escalation triggers identified earlier (repair-retry, rebase-conflict, cross-issue impl) cover ~88% of the resistant-spawn cases (15/17 in the 598-prompt survey).
+- [ ] Consider whether `feedback_*.md` files should be selectively-loaded by phase rather than always-loaded — same logic as run.md prune, applied at memory granularity.
+
+## Why this is documented as its own diary
+
+Counter-intuitive findings that contradict the working mental model are exactly the ones that decay if not written down. The mental model "workers dominate cost, orchestrator is overhead" was wrong by ~5× in the relative direction. Without writing this down explicitly, the next planning session reads `MEMORY.md` and inherits the wrong assumption. With it written down, future orchestrators (and future me) have a chance to reason from the corrected model.

--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -16,7 +16,7 @@
 - [ScheduleWakeup is blind polling](feedback_schedulewakeup_orchestration.md) — during sprint orchestration use `mcx claude wait`, not ScheduleWakeup
 - [Background-task notifications work](feedback_background_task_notify.md) — workers "waiting for notification" is correct; ask duration, don't prescribe polling
 - [Don't bye spikes](feedback_dont_bye_spikes.md) — keep exploratory sessions alive for follow-up questions
-- [Flaky test handling](feedback_flaky_tests.md) — root-cause fixes, not timeout increases
+- [Flaky test handling](feedback_flaky_tests.md) — nerd-snipe BEFORE impl, trail on issue; no root cause + plan = needs-attention, not "spawn opus and hope"
 - [Orchestrator context rot](feedback_context_rot.md) — long-running orchestrators degrade at ~300k tokens; verify "done" claims with a probe
 - [Bulk reads + serialized cascades](feedback_sprint_bulk_and_cascade.md) — no `for` loops for status (use bulk jq), single-pointer update-branch cascades (avoid N² CI)
 - [No gpgsign bypass](feedback_no_gpgsign_bypass.md) — never add `-c commit.gpgsign=false` or similar without explicit ask; only legit orchestrator flag is `SPRINT_OVERRIDE=1`

--- a/.claude/memory/feedback_flaky_tests.md
+++ b/.claude/memory/feedback_flaky_tests.md
@@ -1,15 +1,44 @@
 ---
 name: flaky test fix policy
-description: Flaky test issues always get opus implementation + adversarial review to prevent fix/re-break cycles
+description: Flaky/CI-instability issues require a nerd-snipe root-cause investigation BEFORE implementation; opus impl + adversarial review only after the trail is documented on the issue
 type: feedback
 ---
 
-Flaky test issues must always get opus implementation + adversarial review, regardless of scrutiny classification.
+Flaky test (and CI-instability) issues require a nerd-snipe planning pass
+**before** implementation, then opus implementation + adversarial review.
 
-**Why:** Sprint 15-19 saw cycles where flaky tests were "fixed" with superficial changes (longer timeouts, retry loops) that passed locally but failed again under CI load. The same tests kept getting re-filed.
+**Why:** Sprint 15-19 saw "fix → re-break" cycles where flaky tests were
+patched with longer timeouts or retry loops that papered over the race.
+Sprint 47 repeated the pattern at a higher altitude: a deterministic
+post-#1835 coverage crash was misdiagnosed as a Bun upstream segfault
+(filed under #1004) and the response was a CI retry workaround — which the
+same retro acknowledged "hits on every sprint PR." The actual root cause
+was a `claude --version` probe added by #1835 that the test mock didn't
+handle, plus `process.exit()` truncating a 500 KB stderr write at the
+kernel pipe buffer (#1870, found 2026-04-29 by nerd-snipe). Skipping the
+root-cause step was what made both eras of failures recur.
 
-**How to apply:** When the sprint plan has a flaky test issue (title contains "flaky" or label `flaky`):
-1. Always implement on opus (never sonnet)
-2. Always adversarial review after implementation
-3. Review must verify root cause elimination, not symptom masking
-4. Reject fixes that just increase timeouts or add retries without addressing the race condition
+**How to apply:** When the sprint plan has a flaky / CI-instability issue
+(title contains "flaky", label `flaky`, or symptom is "CI fails
+intermittently / deterministically without a clear test-code error"):
+
+1. **Pre-implementation gate — nerd-snipe first.** Spawn the
+   `nerd-snipe` agent on opus with the repro, the suspected commit
+   range, and any prior bad diagnoses. Its job is to identify the actual
+   root cause and a concrete fix plan.
+2. **Trail goes on the issue.** nerd-snipe must post its findings as a
+   comment on the GitHub issue (timeline, bisect log, mechanism, the fix
+   plan). The trail being on the issue — not in an ephemeral session
+   transcript — is what stops the next sprint from re-running the same
+   misdiagnosis.
+3. **Hard gate.** If nerd-snipe cannot find both root cause AND a
+   concrete solution, the issue does NOT proceed to implementation. Add
+   the `needs-attention` label and stop. The orchestrator surfaces it
+   for manual review at next sprint review. Do not let an unresolved
+   investigation slide into "spawn opus impl and hope."
+4. **Then implement on opus** (never sonnet) using the fix plan from
+   the issue comment as the spec.
+5. **Always adversarial review.** Reviewer verifies the implementation
+   matches the documented root cause — not just "tests pass now."
+   Reject fixes that increase timeouts, add retries, or otherwise mask
+   the symptom without addressing the mechanism in nerd-snipe's writeup.

--- a/.claude/phases/impl.ts
+++ b/.claude/phases/impl.ts
@@ -42,6 +42,11 @@ function commandForProvider(provider: Provider): string[] {
 
 function pickModel(labels: string[]): "opus" | "sonnet" {
   // Flaky work always needs deep analysis (see run.md history).
+  // Orchestrator gate: a flaky issue must have a nerd-snipe root-cause
+  // comment on the issue before reaching this phase — see
+  // .claude/memory/feedback_flaky_tests.md and run.md "Flaky / CI-instability
+  // issues — nerd-snipe gate before impl". Without it, expect symptom-masking
+  // patches (sprint 47 / #1870).
   if (labels.includes("flaky")) return "opus";
   // Docs-only is cheap; everything else defaults to opus.
   if (labels.includes("docs-only") || labels.includes("documentation")) return "sonnet";

--- a/.claude/skills/bootstrap-sprint/references/lessons.md
+++ b/.claude/skills/bootstrap-sprint/references/lessons.md
@@ -270,3 +270,29 @@ migrate single-project repos into a personal org specifically to unlock
 merge queue and other collaboration-scale features (team-level
 CODEOWNERS, per-team runner groups, IP allowlisting, SSO). Mention both
 paths in the generated skill's pre-flight section.
+
+**31. Enumerate every comment/review surface per platform — not just the
+obvious one.** GitHub PRs surface comments on four distinct API endpoints:
+PR-body comments, inline file:line comments (where Copilot code review
+lives), review containers (APPROVED / CHANGES_REQUESTED / COMMENTED), and
+linked-issue comments. Phase agents that only check the PR-body surface
+ship PRs with unresolved review threads. Before transitioning a PR to
+`done`, enumerate **all** surfaces and demand each open thread be
+addressed (with a reply citing the fix commit) or dismissed (with an
+explicit out-of-scope reply). No silent skips. The principle generalizes:
+every collaboration platform has more "where comments live" than the
+default UI shows; an autonomous merger that doesn't enumerate them all
+will leak unresolved threads into main.
+
+**32. Task lists track issues, not batches.** When the planner groups
+N issues into M batches, it's tempting to mirror the structure as M
+TaskCreate items where Batch 2 is blocked-by Batch 1. Don't. Create one
+Task per *issue* with `addBlockedBy` edges for explicit cross-issue
+dependencies (file conflicts, ordering requirements). Batch-level tasks
+serialize idle slots — the orchestrator waits for "Batch 2 to finish
+before starting Batch 3" instead of pulling the next unblocked issue.
+Issue-granular tasks let the dependency graph drain naturally and peak
+concurrency stays high. This rule lives in the skill's run.md, not in
+retro learnings, because every sprint forgets it otherwise — the visual
+clarity of "3 batches" pulls the orchestrator back toward the wrong
+abstraction unless the skill explicitly forbids it.

--- a/.claude/skills/sprint/references/retro.md
+++ b/.claude/skills/sprint/references/retro.md
@@ -165,3 +165,28 @@ still blocks commits.
 - Note process improvements for the next sprint
 - Keep it concise — engineering notes, not an essay
 - If something went wrong, say what the fix or workaround was
+
+## Anecdotes go in the diary, not in run.md
+
+The diary is the chronological record of what happened in a sprint. The
+sprint-skill `references/*.md` files are the **active rule sheet** — what
+the orchestrator does on every tick, this sprint and the next. Don't
+let "we burned X because of Y in sprint Z" anecdotes accrete into the
+rule sheet; they belong here, in the diary. When a new rule emerges
+from a sprint:
+
+- Write the **rule + Why + How to apply** into the appropriate skill file
+  (`run.md` for orchestrator-loop rules, `plan.md` for planning rules,
+  etc.) — concise, no sprint number
+- Capture the **incident** in the diary (this sprint's "What didn't work"
+  section) with full sprint context, issue numbers, costs
+
+If a rule's "Why" needs to cite a specific incident to be understandable,
+the rule isn't general enough — keep refining until the rule stands on
+its own and the diary holds the incident.
+
+Closed-fix anecdotes (like "we used to do X until #N taught us not to")
+should not live in the active rule sheet at all once the underlying fix
+has shipped. Either the rule is universally true (state it without the
+issue ref) or it's contingent on an open follow-up (then keep the open
+issue ref so the staleness is visible).

--- a/.claude/skills/sprint/references/run.md
+++ b/.claude/skills/sprint/references/run.md
@@ -107,7 +107,7 @@ disconnected sessions.
 
 ```bash
 bun run build                          # compile latest binaries
-mcx claude ls --short 2>/dev/null      # verify no sessions active before restart
+mcx claude ls --all --short 2>/dev/null # verify no sessions active across repos before restart
 mcx shutdown                           # stop the stale daemon
 mcx status                             # auto-starts the daemon with new binary
 git config --get core.bare             # MUST be "false" — see note below
@@ -157,8 +157,10 @@ via `_work_items.work_items_update`.
 | `mcx untrack <number>` | Stop tracking |
 | `mcx claude wait --timeout 30000` | Block until session or work-item event |
 
-**`work_items_update` does NOT auto-populate `branch` from `prNumber`** —
-always set both together when attaching a PR (triage requires both):
+**`work_items_update` will best-effort auto-populate `branch` from
+`prNumber`** when `branch` is omitted (resolves via `gh`). Pass both
+explicitly when you already have the branch — it avoids the extra
+network round-trip and works offline:
 
 ```bash
 PR=<n>
@@ -215,8 +217,11 @@ while issues remain:
     case result.action:
       "spawn":     execute result.command (quota permitting), then
                    mcx call _work_items phase_state_set \
-                     '{"workItemId":"#<n>","repoRoot":"<abs>","key":"sessionId","value":"<real-id>"}'
-                   (replaces "pending:*"; key is "sessionId", not "session_id")
+                     '{"workItemId":"<item.id>","repoRoot":"<abs>","key":"session_id","value":"<real-id>"}'
+                   (replaces "pending:*"; use the tracked item's actual id —
+                    "issue:<n>" or "pr:<n>" — and snake_case state keys:
+                    session_id / qa_session_id / review_session_id /
+                    repair_session_id, matching the phase the spawn served)
       "in-flight": session running — no action this tick
       "wait":      no action this tick
       "goto":      mcx phase run <result.target> --work-item <item.id>
@@ -271,7 +276,7 @@ gh issue view $ISSUE --comments                                              # 4
 
 For each open thread demand one of:
 - **Addressed** — code/doc fix in the PR + a reply citing the fix commit
-  (post yourself via `gh api .../comments/{id}/replies -X POST -f body=…`
+  (post yourself via `gh api .../comments/{id}/replies -X POST -f body="<message>"`
   if the fix is present but the reply isn't)
 - **Dismissed** — explicit reply (out of scope, incorrect, resolved
   elsewhere). No silent skips

--- a/.claude/skills/sprint/references/run.md
+++ b/.claude/skills/sprint/references/run.md
@@ -318,6 +318,38 @@ If `null`, re-arm with `mcx pr merge $PR --squash --auto`. Once a
 merge-runner (`agents/mergemaster.md` or `mcx merge-queue` per #1397) is
 active, this is its job; the orchestrator only intervenes on escalation.
 
+### Flaky / CI-instability issues — nerd-snipe gate before impl
+
+`label:flaky` already routes to opus via `impl.ts:45`. That is **not
+enough** — sprint 47's deterministic post-#1835 coverage crash got opus,
+opus produced a CI-retry workaround, and the same retro acknowledged the
+workaround "hits on every sprint PR." The pattern: opus implements a
+fix-shaped patch around the symptom because nobody made it find the
+root cause first.
+
+For any issue that is `label:flaky`, or whose body describes
+intermittent / deterministic CI failure without a clear test-code error,
+gate impl on a nerd-snipe pass:
+
+1. **Spawn `nerd-snipe` (opus) before phase=impl.** Brief: the repro,
+   the suspected commit range, prior diagnoses (especially any that
+   blamed upstream), and the constraint that the trail must land on the
+   issue.
+2. **Trail goes on the GitHub issue, not in the session.** nerd-snipe
+   posts its findings — timeline, bisect log, mechanism, fix plan — as
+   an issue comment. This is the mechanism that stops the next sprint
+   from re-running the same misdiagnosis.
+3. **Hard gate.** If nerd-snipe cannot identify *both* the root cause
+   and a concrete fix, do NOT advance the issue to phase=impl. Apply
+   `needs-attention` and surface in sprint review. "Spawn opus and hope"
+   is what got us into the loop.
+4. **Then phase=impl on opus**, with the issue-comment fix plan as the
+   spec. Adversarial review verifies the implementation matches the
+   documented mechanism, not just "tests pass now."
+
+See `.claude/memory/feedback_flaky_tests.md` for the rule and the
+sprint-47/#1870 incident that motivated it.
+
 ### qa:pass + qa:fail dual-label invariant (orchestrator audit)
 
 The QA worker swaps labels transactionally, but PRs occasionally end up

--- a/.claude/skills/sprint/references/run.md
+++ b/.claude/skills/sprint/references/run.md
@@ -1,19 +1,14 @@
 # Sprint Execution
 
-Run the implementation pipeline. You are the orchestrator — you never write
-code directly, you spawn sessions and manage the pipeline.
-
-**Spawned sessions are running team members, not function calls.** They
-maintain their own context, memory, and ongoing work — just like you do.
-Ending a session is like firing a colleague mid-project. Do it only when
-their role is genuinely complete, not when they ask a question or get stuck.
+You are the orchestrator. You never write code directly — you spawn
+sessions and manage the pipeline. Spawned sessions are running team
+members, not function calls; ending one is firing a colleague mid-project.
 
 ## Pipeline authority: `.mcx.yaml` + `.claude/phases/*.ts`
 
-The per-phase logic (spawn commands, transition rules, round caps) lives in
-the phase scripts at `.claude/phases/*.ts`, declared by `.mcx.yaml`. This
-file is the prose orchestration guide — it covers the cross-cutting
-concerns that span phases. For any specific transition, inspect the phase:
+Per-phase logic (spawn commands, transitions, round caps) lives in the
+phase scripts at `.claude/phases/*.ts`, declared by `.mcx.yaml`. This file
+is the cross-cutting orchestration prose. Inspect a phase via:
 
 ```bash
 mcx phase list                       # overview + status
@@ -23,179 +18,136 @@ mcx phase why <from> <to>            # is this transition allowed?
 mcx phase run <phase> --dry-run      # preview the handler's decision
 ```
 
-Round caps baked into the phases: review ≤ 2 rounds, repair ≤ 3 rounds,
-qa:fail ≤ 2 rounds. Hitting a cap routes the work item to `needs-attention`.
+Round caps baked in: review ≤ 2, repair ≤ 3, qa:fail ≤ 2. Hitting a cap
+routes the work item to `needs-attention`.
 
 ## Input
 
 Determine what to run, in priority order:
 
-1. **Single number matching a sprint file** (`/sprint 43` when `sprint-43.md` exists) —
-   sprint-number interpretation; use that plan; auto-chain on
-2. **Multiple numbers, or single number with no matching plan** (e.g. `/sprint 123 456`) —
-   ad-hoc issue numbers; run only, no auto-chain (no plan file to base review/retro on)
-3. **Sprint plan exists, no args** — read `.claude/sprints/sprint-{N}.md` (latest by
-   number), use its issue list and batch assignments; auto-chain on
-4. **Neither** — tell the user to run `/sprint plan` first or pass issue numbers
-
-**Mode** (from SKILL.md routing): default is auto-chain (run → review → retro
-inline). Explicit run-only is requested as `/sprint run` or `/sprint run <N>`.
+1. **Single number matching a sprint file** (`/sprint 43` when `sprint-43.md` exists) →
+   sprint-number; auto-chain on
+2. **Multiple numbers, or single number with no matching plan** (e.g. `/sprint 123 456`) →
+   ad-hoc issues; run-only, no auto-chain
+3. **Sprint plan exists, no args** → read latest `.claude/sprints/sprint-{N}.md`;
+   auto-chain on
+4. **Neither** → tell the user to `/sprint plan` first or pass issue numbers
 
 If using a sprint plan, announce: "Running sprint {N}: {goal}. Batch 1: #X, #Y, #Z..."
 
-Record the start timestamp in the sprint file header (append to the `>` line).
-In run-only mode, also append `(RUN ONLY)` on the same line so `/sprint review`
-and `/sprint retro` later know the run was intentionally detached:
+Record the start timestamp on the plan header's `>` line. In run-only mode
+also append `(RUN ONLY)` so a later separate `/sprint review` /
+`/sprint retro` can see the run was intentionally detached.
 
-```
-> Planned {date}. Started {date} {HH:MM local}. Target: 15 PRs.
-```
-
-or, in run-only mode:
-
-```
-> Planned {date}. Started {date} {HH:MM local} (RUN ONLY). Target: 15 PRs.
-```
-
-Mark the sprint active for the main-checkout pre-commit guard (#1443):
+Mark the sprint active for the main-checkout pre-commit guard:
 ```bash
 echo "{N}" > .claude/sprints/.active
 ```
 The sentinel is gitignored. It blocks commits on main's checkout so workers
-that escape their worktree fail loudly instead of landing phantom commits
-on main (see #1425). `/sprint retro` removes it. Orchestrator commits go
-to the `sprint-{N}` branch via the `.claude/worktrees/sprint-{N}/` worktree
-opened in `plan.md` Step 6a — `SPRINT_OVERRIDE=1` is still needed there
-because the sentinel applies repo-wide.
+that escape their worktree fail loudly. `/sprint retro` removes it.
+Orchestrator commits go to the `sprint-{N}` worktree opened in `plan.md`
+Step 6a (still needs `SPRINT_OVERRIDE=1` because the sentinel applies
+repo-wide).
 
 ### Sprint-meta edits during run
 
-The orchestrator makes several sprint-meta edits during the run:
-
-- **Start-of-run timestamp** (the "Started …" line in the plan header)
-- **Run-mode marker** ("(RUN ONLY)" if invoked as `/sprint run`)
-- **Excluded-section amendments** (e.g. "this issue was already-closed
-  pre-sprint, removed from Batch 1")
-- **Mid-sprint plan amendments** (swapping a filler, adjusting batches)
-
-All of these accumulate on the `sprint-{N}` branch. The flow is:
+Orchestrator edits to the sprint plan during the run (start timestamp,
+run-mode marker, Excluded amendments, mid-sprint plan amendments) all
+accumulate on the `sprint-{N}` branch via its worktree. Edit + commit +
+push from the worktree, then `cp` back into the main checkout so phase
+scripts (which read from CWD) see the latest content. Don't commit
+sprint-file edits on the main checkout — the sentinel rejects it.
 
 ```bash
-# (a) Edit in the sprint worktree (where the branch lives)
-$EDITOR .claude/worktrees/sprint-{N}/.claude/sprints/sprint-{N}.md
-
-# (b) Commit + push from the worktree
-(
-  cd .claude/worktrees/sprint-{N}
+( cd .claude/worktrees/sprint-{N}
+  $EDITOR .claude/sprints/sprint-{N}.md
   git add .claude/sprints/sprint-{N}.md
   SPRINT_OVERRIDE=1 git commit -m "sprint({N}): <descriptor>"
-  git push
-)
-
-# (c) Sync the change back into the orchestrator's main checkout so phase
-#     scripts (which read .claude/sprints/sprint-{N}.md from CWD per #1437)
-#     see the latest content. The file stays uncommitted on main.
-cp .claude/worktrees/sprint-{N}/.claude/sprints/sprint-{N}.md .claude/sprints/sprint-{N}.md
+  git push )
+cp .claude/worktrees/sprint-{N}/.claude/sprints/sprint-{N}.md \
+   .claude/sprints/sprint-{N}.md
 ```
 
 The `sprint-{N}` PR (opened as draft in `plan.md` Step 6a) updates in place
-on every push — the user can watch sprint progress there.
-
-**Don't commit sprint-file edits on the main checkout.** The sentinel +
-pre-commit guard will reject it, and even if you bypass with
-`SPRINT_OVERRIDE=1` you'd race with the worktree's history. Always edit
-in the worktree.
+on every push.
 
 ### Task list setup — one Task per issue, NOT per batch
 
-**Create one `TaskCreate` per tracked issue, with `addBlockedBy` edges for
-every dependency.** Do NOT create 3 Batch-level tasks that block each other
-(1→2→3). The batch column in the sprint plan is the planner's launch-order
-model; the orchestrator's task list is issue-granular so idle slots
-auto-pull the next unblocked issue.
-
-Why this matters: sprint 41 lost multi-minute stretches with 1 active
-session while other slots waited for "Batch 2 to finish before Batch 3 can
-start." Sprint 42 adopted per-issue tasks with blockedBy edges and peaked
-at 17 concurrent sessions without lulls. Sprint 43 reverted to 3 Batch
-tasks (Batch 1 blocks Batch 2, Batch 1 blocks Batch 3) and re-introduced
-the cascade. This rule stays in `run.md` — not a per-sprint retro rule —
-because every sprint forgets it otherwise.
-
-Concrete pattern:
+**One `TaskCreate` per tracked issue, with `addBlockedBy` edges for every
+dependency.** Do NOT create 3 Batch-level tasks that block each other
+(1→2→3). The plan's batch column is the planner's launch-order model;
+the orchestrator's task list is issue-granular so idle slots auto-pull
+the next unblocked issue. (Lives here, not in retro learnings, because
+every sprint forgets it otherwise.)
 
 ```
 for each issue in sprint plan:
   TaskCreate  subject=#<n> <title>  activeForm="Running #<n>"
   mcx track <n>
-for each "blockedBy" edge in the plan's Batch Plan section (e.g. "#1579 blockedBy #1578"):
+for each "blockedBy" edge in the plan's Batch Plan section:
   TaskUpdate  taskId=<child>  addBlockedBy=[<parent>]
 ```
 
-("for each" here means separate tool calls, not a shell `for` loop —
+("for each" = separate tool calls, not a shell loop —
 see `.claude/memory/feedback_sprint_bulk_and_cascade.md`.)
 
-Hot-shared file serializations from the plan's "Hot-shared file watch"
-section are also blockedBy edges (second PR blocked on first's merge).
+Hot-shared file serializations (from the plan's "Hot-shared file watch")
+are also blockedBy edges — second PR blocked on first's merge.
 
 Launch policy: spawn an impl session for every task that is `pending` and
-has no unresolved `blockedBy` entries. When a PR merges, `TaskUpdate` the
-issue's task to `completed` — that unblocks its dependents and a new slot
-opens.
+has no unresolved `blockedBy`. When a PR merges, `TaskUpdate completed` —
+that unblocks dependents and a slot opens.
 
 ## Pre-flight
 
-Before spawning any sessions, ensure the daemon is running the latest build.
-**Don't skip the shutdown step** — `mcx status` alone does not restart the
-daemon, so a stale daemon will accept spawn calls and silently produce
-disconnected sessions (see #1218).
+Ensure the daemon is running the latest build before spawning anything.
+**Don't skip the shutdown step** — `mcx status` alone does not restart
+the daemon; a stale daemon accepts spawn calls and silently produces
+disconnected sessions.
 
 ```bash
 bun run build                          # compile latest binaries
 mcx claude ls --short 2>/dev/null      # verify no sessions active before restart
 mcx shutdown                           # stop the stale daemon
 mcx status                             # auto-starts the daemon with new binary
-git config --get core.bare             # must be "false" — see note below
+git config --get core.bare             # MUST be "false" — see note below
 mcx phase install                      # ensure phase lockfile matches sources
 git fetch origin main \
   && git log HEAD ^origin/main --oneline   # MUST be empty
 ```
 
-**Phantom local commits on main** (#1425). The last line above must
-return no output. If it does, a worker session escaped its worktree and
-committed (and possibly pushed) directly to your main checkout during a
-prior sprint. Do not proceed: save each phantom commit to a backup
-branch (`git branch saved/<sha-prefix> <sha>`), then `git fetch origin
-main && git reset --hard origin/main`. Investigate which session did it
+**Phantom local commits on main**: the last line above must return no
+output. If it does, a worker session escaped its worktree and committed
+directly to your main checkout. Save each phantom commit to a backup
+branch (`git branch saved/<sha-prefix> <sha>`), then
+`git fetch origin main && git reset --hard origin/main` and investigate
 before starting the new sprint.
 
-Only restart when no sessions are active. Restarting kills running sessions,
-including from a concurrent sprint in a different repo.
+Only restart when no sessions are active — restarting kills running
+sessions, including from a concurrent sprint in another repo.
 
-**`core.bare=true` recurrence** (issue #1206/#1243/#1330): some worktree
-operation flips `core.bare` to `true` on the main checkout. Hot-patch with
-`git config core.bare false` before every batch of git operations. Treat as
-a routine pre-flight step and a post-`bye` check until the sticky fix lands.
+**`core.bare=true` recurrence**: some worktree operation flips
+`core.bare` to `true` on the main checkout. Hot-patch with
+`git config core.bare false` before every batch of git operations.
+Pre-flight + post-`bye` check until the sticky fix lands.
 
-**Run all sprint commands from within the project root.** `mcx claude ls` and
-`mcx claude wait` filter sessions by the current repo's git root. Use `--all`
-to see sessions from all repos.
+**Run all sprint commands from within the project root.** `mcx claude ls`
+and `mcx claude wait` filter sessions by the current repo's git root —
+use `--all` for cross-repo view.
 
 ### Quota check
 
 ```bash
 mcx call _metrics quota_status
 ```
-
-Parse the response and apply the gating rules in [Quota gating](#quota-gating).
-If ≥95%, do not start. If ≥80%, start with QA/review-only work.
+Apply the rules in [Quota gating](#quota-gating). ≥95% → don't start.
+≥80% → start with QA/review-only work.
 
 ## Work item tracking
 
-The work item tracker replaces manual `gh pr view` / `gh run list` polling.
-Track every issue at spawn time, attach PRs when they appear, and let the
-poller + event system drive the pipeline. Phases are columns in the work
-item — the phase scripts update them via `_work_items.work_items_update`.
+Track every issue at spawn time, attach PRs when they appear, let the
+poller drive the pipeline. Phases are columns updated by phase scripts
+via `_work_items.work_items_update`.
 
 | Command | Purpose |
 |---------|---------|
@@ -205,10 +157,8 @@ item — the phase scripts update them via `_work_items.work_items_update`.
 | `mcx untrack <number>` | Stop tracking |
 | `mcx claude wait --timeout 30000` | Block until session or work-item event |
 
-**`work_items_update` does NOT auto-populate `branch` from `prNumber`**
-(#1424). The triage phase requires both, and its error message
-("requires a work item with issueNumber and branch") doesn't say which
-is missing. Always set both together when attaching a PR:
+**`work_items_update` does NOT auto-populate `branch` from `prNumber`** —
+always set both together when attaching a PR (triage requires both):
 
 ```bash
 PR=<n>
@@ -227,66 +177,48 @@ Poller event types surfaced via `mcx claude wait`:
 
 ## Interacting with workers
 
-Spawned sessions are not the Agent tool. The Agent tool is
-delegate-collect-discard. Spawned sessions are running team members —
-they accumulate understanding of the codebase over time. That context is
-an asset worth preserving.
+End (`bye`) only when work is **conclusively** finished — for an impl
+session, *PR merged* OR (`qa:pass` + zero open threads on all 4 comment
+surfaces + CI green). Pushing the PR is not enough: Copilot inline
+reviews arrive after push and before merge, and a fresh repair session
+loses the worktree and PR context.
 
-A session should only be ended (`bye`) when its area of responsibility is
-**conclusively** finished. For an impl session, that's *PR merged* OR
-(`qa:pass` + zero open threads on all 4 comment surfaces + CI green).
-**Pushing the PR is not enough** — Copilot inline reviews arrive
-*after* the push and *before* merge, and a fresh repair session loses
-the worktree + PR context the impl session has. Sprint 35 burned an
-extra opus repair on #1401 because the impl session was `bye`d the
-moment its PR was pushed.
-
-These are **not** reasons to end a session:
-
-- Needing clarification or plan approval
-- Waiting for a dependency or rate limit
-- Pausing between subtasks
-- Producing an unexpected result
-- Being stuck on a problem you can help with
-
+NOT reasons to bye: needing clarification, waiting on a dependency,
+pausing between subtasks, producing an unexpected result, being stuck.
 When in doubt, `send` — don't `bye`.
 
-| Signal | What it means | What to do |
-|--------|---------------|------------|
-| `session:result` with low cost / few turns | Worker asked a question or needs approval | Read log. Respond via `send`. |
-| `session:permission_request` | Tool approval needed | `mcx claude log` then respond. |
-| `waiting_permission` in `ls` | Blocked on permission gate | Same. |
-| Token count stalled across polls | May be stuck | Log + nudge. |
-| Abnormal PR diff (125k deletions, etc.) | Corrupted worktree | Do not spawn QA. Investigate + send. |
+| Signal | Meaning | Action |
+|--------|---------|--------|
+| `session:result` low cost / few turns | Worker asked a question | Read log; `send` reply |
+| `session:permission_request` | Tool approval needed | `mcx claude log` then respond |
+| `waiting_permission` in `ls` | Blocked on permission gate | Same |
+| Token count stalled across polls | May be stuck | Log + nudge |
+| Abnormal PR diff (125k deletions, etc.) | Corrupted worktree | Do NOT spawn QA — investigate + send |
 
-Before `bye`, write a one-sentence justification: why is this work genuinely
-complete? If you can't, the session probably shouldn't be ended.
+Before `bye`, write a one-sentence justification: why is this work
+genuinely complete? If you can't, the session probably shouldn't end.
 
-## Pipeline (one orchestrator loop per tick)
+## Pipeline loop (one tick)
 
 Per-issue logic is phase-scripted. The orchestrator's loop is:
 
 ```
 while issues remain:
   event = mcx claude wait --timeout 30000 --short
-
-  # Pre-spawn quota gate (see Quota gating)
-  quota = mcx call _metrics quota_status
+  quota = mcx call _metrics quota_status     # see Quota gating
 
   for each tracked item:
-    # Tick the current phase. The phase script decides: spawn / wait / goto.
-    # Note: do NOT pass --dry-run here. Real execution writes the transition
-    # log entry and persists state (provider/model/labels/session_id sentinel
-    # via impl.ts:117). --dry-run skips both, which breaks subsequent
-    # transitions with "(initial) → triage" rejections (#1522).
+    # Tick the phase. Do NOT pass --dry-run — it skips the transition log
+    # + state writes (provider/model/labels/sessionId), breaking subsequent
+    # transitions.
     result = mcx phase run <item.phase> --work-item <item.id>
     case result.action:
       "spawn":     execute result.command (quota permitting), then
                    mcx call _work_items phase_state_set \
-                     '{"workItemId":"#<n>","repoRoot":"<abs-path>","key":"sessionId","value":"<real-id>"}'
-                   (replaces "pending:*"; note: key is "sessionId", not "session_id")
-      "in-flight": session already running — no action this tick
-      "wait":      continue — no action this tick
+                     '{"workItemId":"#<n>","repoRoot":"<abs>","key":"sessionId","value":"<real-id>"}'
+                   (replaces "pending:*"; key is "sessionId", not "session_id")
+      "in-flight": session running — no action this tick
+      "wait":      no action this tick
       "goto":      mcx phase run <result.target> --work-item <item.id>
                    then update work_item.phase = result.target
 
@@ -298,83 +230,63 @@ while issues remain:
   file issues for any problems observed
 ```
 
-The phase scripts encapsulate what was previously 6-step transition recipes.
-For example, the old impl→review handoff (bye + attach PR + run triage +
-update phase + spawn reviewer) is now `mcx phase run triage` followed by
-`mcx phase run <result.decision>`.
+The phase scripts encapsulate what was previously 6-step transition
+recipes — e.g. impl→review is now `mcx phase run triage` followed by
+`mcx phase run <result.target>`.
 
-Key invariants (not automatable, orchestrator discipline):
+**Key invariants** (orchestrator discipline, not enforced by scripts):
 - Use `mcx claude wait`, never `sleep`
 - `session:result` means idle, not ended
-- Don't `bye` before verifying the PR is pushed
+- Don't `bye` before verifying PR pushed
 - Don't `bye` a QA session before `qa:pass` / `qa:fail` is on the PR
 - Spawn fresh sessions per phase — never reuse across impl/review/QA
 - Reuse worktrees across phases via `--cwd` (phase scripts prefer this)
-- Never `bye` + respawn to sidestep a stuck session. `send` instead
+- Never `bye` + respawn to sidestep a stuck session — `send` instead
 
-**When a session fails to close an issue**, ask the user what to do. Don't
-silently move on. Every failure must be explicit in the retro.
+When a session fails to close an issue, ask the user. Don't silently move
+on — every failure must be explicit in the retro.
 
 ## Orchestrator-only nudges (not in worker prompts)
 
-Some directives apply to the orchestrator's coordination work and
-deliberately don't live in the worker spawn prompts (`.claude/commands/*.md`),
-because those prompts are also invoked by CI, by ad-hoc human runs, and by
-the GitHub Copilot integration — adding orchestrator-flow assumptions
-there pollutes the universal worker contract.
+The directives below apply only to orchestrator coordination work. They
+deliberately don't live in worker spawn prompts (`.claude/commands/*.md`),
+which are shared with CI, ad-hoc human runs, and the GitHub Copilot
+integration — adding orchestrator assumptions there pollutes the universal
+worker contract.
 
-### Before approving qa:pass for merge: enumerate all 4 PR-comment surfaces
+### Verify all 4 PR-comment surfaces before approving qa:pass for merge
 
-GitHub PR comments live on **four** distinct surfaces. Sprint 34's PR #1380
-shipped with **17 unresolved Copilot inline comments** because every phase
-agent only checked the PR-body surface. Before the orchestrator transitions
-a work item to `phase=done` (or hands it to the merge-runner), verify every
-open thread on every surface is addressed or dismissed:
+GitHub PR comments live on **four** distinct surfaces; phase agents
+commonly check only the PR-body surface. Before transitioning to
+`phase=done`, verify every open thread on every surface is addressed or
+dismissed:
 
 ```bash
-PR=<pr-number>
-ISSUE=<issue-number>
-
-# Surface 1: PR body comments (the obvious one)
-gh pr view $PR --comments
-
-# Surface 2: Inline file:line comments — where Copilot code review lives
-gh api repos/<owner>/<repo>/pulls/$PR/comments \
-  --jq '[.[] | {id, path, line, user: .user.login, body: (.body[0:120])}]'
-
-# Surface 3: Review containers — APPROVED / CHANGES_REQUESTED / COMMENTED
-gh api repos/<owner>/<repo>/pulls/$PR/reviews \
-  --jq '[.[] | {state, user: .user.login, body: (.body[0:160])}]'
-
-# Surface 4: Linked-issue comments (the issue the PR `fixes`)
-gh issue view $ISSUE --comments
+PR=<pr-number>; ISSUE=<issue-number>
+gh pr view $PR --comments                                                    # 1: PR body
+gh api repos/<o>/<r>/pulls/$PR/comments --jq '[.[] | {id, path, line, user: .user.login, body: (.body[0:120])}]'   # 2: inline
+gh api repos/<o>/<r>/pulls/$PR/reviews  --jq '[.[] | {state, user: .user.login, body: (.body[0:160])}]'             # 3: reviews
+gh issue view $ISSUE --comments                                              # 4: linked issue
 ```
 
-For each open thread, demand one of:
-
-- **Addressed:** code/doc fix in the PR + a reply on the thread citing the
-  fix commit. If the fix is present but the reply isn't, post one yourself
-  via `gh api repos/{o}/{r}/pulls/{pr}/comments/{thread-id}/replies -X POST -f body="..."`.
-- **Dismissed:** explicit reply explaining why (out of scope, incorrect,
-  resolved elsewhere). No silent skips.
+For each open thread demand one of:
+- **Addressed** — code/doc fix in the PR + a reply citing the fix commit
+  (post yourself via `gh api .../comments/{id}/replies -X POST -f body=…`
+  if the fix is present but the reply isn't)
+- **Dismissed** — explicit reply (out of scope, incorrect, resolved
+  elsewhere). No silent skips
 
 If any thread is neither, hold the merge — `send` the implementer or
-reviewer to address. Do not let `done` proceed.
-
-This will move into the `done.ts` phase script when #1397 (`mcx merge-queue`)
-or its precursor lands — at that point the check becomes deterministic and
-this section can be deleted.
+reviewer to address. When a deterministic merge-queue lands (#1397), this
+moves into `done.ts` and this section deletes.
 
 ### Reviewer self-repair (micro-repair) — orchestrator send pattern
 
-When an adversarial reviewer posts `⚠️ Changes Requested` on a PR and the
-findings are 1–3 contained edits with file:line citations and concrete fix
-descriptions, **`send` the reviewer back to fix its own findings** instead
-of spawning a fresh opus repair session. Saved ~$10–15 across sprint 33
-and 34 across multiple PRs. The reviewer already has the worktree, the PR
-context, and its own diagnosis loaded.
-
-Send the reviewer something like:
+When an adversarial reviewer posts `⚠️ Changes Requested` and the
+findings are 1–3 contained edits with file:line citations and concrete
+fix descriptions, **`send` the reviewer back to fix its own findings**
+instead of spawning a fresh opus repair. The reviewer already has the
+worktree, PR context, and diagnosis loaded.
 
 ```text
 You flagged N issues on PR #<pr>. If they're contained fixes with your
@@ -383,167 +295,132 @@ sticky review with a delta table. If any need a redesign or multi-file
 judgment, reply 'needs opus repair'.
 ```
 
-Let the reviewer self-select. When it replies `needs opus repair`, spawn a
-fresh opus repair session per the normal flow. When it pushes a fix and
-updates the sticky to ✅, transition the work item to QA.
-
-This pattern lives here (orchestrator-side) and not in
-`.claude/commands/adversarial-review.md` because the reviewer prompt is
-shared with CI-invoked reviews where there's no orchestrator to send back.
+When it replies `needs opus repair`, spawn a fresh opus repair per the
+normal flow. When it pushes a fix and updates the sticky to ✅,
+transition to QA.
 
 ### Auto-merge re-arm after force-push (when no merge-runner is active)
 
-When the orchestrator (rather than `agents/mergemaster.md` or a future
-`mcx merge-queue` service) is driving merges, force-push rebases silently
-invalidate GitHub auto-merge on some configurations. Before declaring a PR
-"queued for merge," verify:
+When the orchestrator is driving merges, force-push rebases silently
+invalidate GitHub auto-merge on some configurations. Before declaring a
+PR "queued for merge":
 
 ```bash
 gh pr view $PR --json autoMergeRequest
 ```
 
-If `null`, re-arm with `mcx pr merge $PR --squash --auto` (the local
-worktree may still hold the branch — `mcx pr merge` skips the failing
-`--delete-branch` step; cleanup happens at `bye` time).
-Once the merge-runner is active and owns the merge loop, this is its job
-(see `agents/mergemaster.md`); the orchestrator only intervenes when the
-runner has escalated.
+If `null`, re-arm with `mcx pr merge $PR --squash --auto`. Once a
+merge-runner (`agents/mergemaster.md` or `mcx merge-queue` per #1397) is
+active, this is its job; the orchestrator only intervenes on escalation.
 
 ### qa:pass + qa:fail dual-label invariant (orchestrator audit)
 
-The QA worker swaps labels transactionally (`--add-label X --remove-label
-opposite`), but sprint 33's PR #1303 still ended up with both labels because
-an early QA didn't include the swap. As a defensive audit before merge:
+The QA worker swaps labels transactionally, but PRs occasionally end up
+with both labels when an early QA didn't include the swap. Defensive
+audit before merge:
 
 ```bash
 gh pr view $PR --json labels -q '[.labels[].name]'
 ```
 
-If both `qa:pass` and `qa:fail` appear, hold the merge and resolve manually
-— the QA history needs review, not a silent label cleanup.
+If both `qa:pass` and `qa:fail` appear, hold the merge and resolve
+manually — the QA history needs review, not a silent label cleanup.
 
 ## Sweeping main commits during a sprint
 
-If a commit lands on main mid-sprint that affects *every* branch (e.g.
-`.gitignore` replacement, `.git-hooks/` changes, shared config, lint rule
-updates), broadcast a rebase directive to all active impl sessions **before**
-they push. Otherwise every branch will look like it regresses the sweeping
-change, every reviewer will flag it, and every repairer will waste a cycle.
+If a commit lands on main mid-sprint that affects *every* branch
+(`.gitignore`, `.git-hooks/`, shared config, lint rules), broadcast a
+rebase directive to all active impl sessions before they push. Otherwise
+every branch will look like it regresses the change, every reviewer will
+flag it, and every repairer will waste a cycle.
 
 ```bash
-# For each active impl session:
-mcx claude send <id> "Before pushing, rebase your branch onto origin/main to pick up the .gitignore update from commit <sha>. Run: git fetch origin main && git rebase origin/main"
+mcx claude send <id> "Before pushing, rebase onto origin/main to pick up <change> from <sha>: git fetch origin main && git rebase origin/main"
 ```
 
-Signals a sweeping commit has landed: a repo-root file changed in a recent
-merge, or the first reviewer flags it on the first PR. Catch it at the
-source, not per-branch during review.
+Signals a sweep has landed: a repo-root file changed in a recent merge,
+or the first reviewer flags it on the first PR.
 
 ## Quota gating
 
-The daemon polls `/api/oauth/usage` and exposes utilization via
-`mcx call _metrics quota_status`:
-
 ```json
-{ "available": true, "fiveHour": { "utilization": 82, "resetsAt": "..." }, ... }
+{ "available": true, "fiveHour": { "utilization": 82, "resetsAt": "..." } }
 ```
-
-Use `fiveHour.utilization` for gating:
 
 | Utilization | Action |
 |-------------|--------|
 | **< 80%** | Normal — spawn impl, review, QA freely |
-| **≥ 80%** | **Impl freeze** — finish in-flight review/QA, don't spawn new impl |
+| **≥ 80%** | **Impl freeze** — finish in-flight review/QA; don't spawn new impl |
 | **≥ 95%** | **Full pause** — wait for reset |
 
-If `available` is `false` or the call fails, proceed normally. Don't block
-the sprint on a monitoring failure.
+If `available` is `false` or the call fails, proceed normally. Don't
+block the sprint on a monitoring failure.
 
 ## Handling stuck workers
 
-The phase scripts emit `{ action: "wait", reason }` when they're waiting on
-external state (sticky review comment not posted yet, qa label not set yet,
-etc.). If the same wait reason recurs for many ticks, investigate the worker:
+Phase scripts emit `{ action: "wait", reason }` when waiting on external
+state. If the same wait reason recurs many ticks:
 
 1. `mcx claude log <id>` — what's it doing?
-2. If it's asking a question: `mcx claude send <id> "<answer>"`
-3. If it's stuck in a retry loop: interrupt + `send` guidance
-4. If it's genuinely deadlocked: file an issue, then `bye` + respawn
+2. Asking a question → `mcx claude send <id> "<answer>"`
+3. Stuck in a retry loop → interrupt + `send` guidance
+4. Genuinely deadlocked → file an issue, then `bye` + respawn
 
 ## Meta-file changes require a follow-up `meta` issue
 
 The orchestrator reads skill files (`.claude/skills/**`), memories,
-`CLAUDE.md`, `.gitignore`, and the phase scripts (`.claude/phases/**`) and
-manifest (`.mcx.yaml`) **live** while running. Workers must not modify them
-during a sprint. The retro (and the next planning phase) is the only safe
-window.
+`CLAUDE.md`, `.gitignore`, phase scripts (`.claude/phases/**`), and the
+manifest (`.mcx.yaml`) **live** while running. Workers must not modify
+them during a sprint. The retro and the next planning phase are the only
+safe windows.
 
 When a worker's PR needs a meta change:
 
 1. `send` the worker to revert the meta hunks before pushing
 2. File a new issue with the **`meta`** label, referencing the PR
-3. The `meta`-labeled issue will surface in the next `/sprint plan`
+3. The `meta`-labeled issue surfaces in the next `/sprint plan`
 
 If you discover the orchestrator's skill or phase definition is genuinely
-broken mid-sprint, **spike the sprint early.** Complete in-flight work, file
-the `meta` issue, replan. Don't limp along with a broken phase.
+broken mid-sprint, **spike the sprint early.** Complete in-flight work,
+file the `meta` issue, replan. Don't limp along with a broken phase.
 
 ## Run-only vs auto-chain mode
 
-The invoker may ask for run-only mode (the user wants to defer review/retro,
-e.g. because the release is going out separately, or they want to merge more
-PRs first). The routing is decided in `SKILL.md`:
+Routing is in `SKILL.md`:
 
-- **Auto-chain (default)** — on `/sprint` (plan exists) or `/sprint <N>` where
-  `sprint-<N>.md` exists: run → review → retro, all in this session.
-- **Run-only** — on `/sprint run` or `/sprint run <N>`: run stops at wind-down
-  step 8. Mark the plan header now so the intent is visible in git:
+- **Auto-chain** (default): `/sprint`, or `/sprint <N>` (sprint number) →
+  run → review → retro inline, same session
+- **Run-only**: `/sprint run` or `/sprint run <N>` → stop at wind-down step 8
+- **Ad-hoc issues**: `/sprint <issue-numbers>` — no plan file, no auto-chain
 
-  When you write the "Started …" timestamp to the plan header (see the
-  "Input" section at the top of this file), append `(RUN ONLY)` directly
-  after it, on the same line, e.g.:
-
-  ```
-  > Planned 2026-04-23 23:45 local. Started 2026-04-24 02:48 EDT (RUN ONLY). Target: 18 PRs (...)
-  ```
-
-  The marker is an operator note — `/sprint review` and `/sprint retro` read
-  it and produce a "resumed from RUN ONLY" line in the release notes / diary.
-
-Ad-hoc `/sprint <issue-numbers>` runs have no plan file to mark and do not
-auto-chain — the orchestrator just exits at wind-down step 8 for those.
+In run-only mode, append `(RUN ONLY)` to the "Started …" line so a later
+separate `/sprint review` / `/sprint retro` can see the run was
+intentionally detached.
 
 ## Wind-down
 
-When the sprint is winding down (≤2 active sessions):
+When ≤2 sessions are active:
 
 1. Record end timestamp in the sprint file header
 2. Start `/sprint plan` for the next sprint while the last sessions finish
-3. After all sessions complete: report merged / failed / in-progress using
+3. After all sessions complete: report merged / failed / in-progress via
    `mcx tracked --json`
 4. `mcx untrack` any remaining items
 5. `mcx gc` to prune merged branches and stale worktrees
-6. Before rebuild: confirm no concurrent cross-repo sprints (#1250)
+6. Confirm no concurrent cross-repo sprints (#1250)
 7. `git checkout main && git pull && bun run build`
-8. `mcx shutdown && mcx status` to pick up the new build (skip if another
-   sprint is still active — restart kills its sessions)
+8. `mcx shutdown && mcx status` to pick up the new build
+   (skip if another sprint is still active)
 
-**If run-only mode** (plan header has `(RUN ONLY)` or invocation was
-`/sprint run …` or ad-hoc issue numbers): stop here. Report to the user
-what shipped and note that review/retro were skipped by request.
+**If run-only**: stop here. Report what shipped and note that review/retro
+were skipped by request.
 
-**Otherwise (auto-chain mode)**: continue inline, same session, same context
-— do **not** re-invoke as `/sprint review` or `/sprint retro` (that pays a
-~300k-token cache miss to re-read the post-run conversation you already
-have):
+**Otherwise (auto-chain)**: continue inline same session, same context —
+do NOT re-invoke as `/sprint review` or `/sprint retro` (~300k-token cache
+miss):
 
-9. Read `references/review.md` and execute every step (gather what
-   shipped, bump version, lint + typecheck, commit, push, tag, push tag,
-   create GH release, update the sprint file's Results section). When
-   review.md says "this completes the review phase", continue to step 10.
-10. Read `references/retro.md` and execute every step (write the diary
-    file from the context you already have — do NOT launch scanners;
-    commit; push; remove `.claude/sprints/.active`).
+9. Read `references/review.md` and execute every step.
+10. Read `references/retro.md` and execute every step.
 
-Report a single combined summary to the user when both are done: merged
-PRs, version cut, diary path, any unresolved follow-ups.
+Report a single combined summary: merged PRs, version cut, diary path,
+unresolved follow-ups.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,12 +95,12 @@ jobs:
       # Backstops the coverage ratchet against PRs merged without pre-commit hooks
       # (force-push, web UI edits, etc.). See #1252.
       #
-      # Bun crashes (SIGILL exit 132, or post-cleanup exit 1) happen AFTER all tests
-      # complete, matching the same pattern handled in the check job (see #1004).
-      # We treat non-zero exit as a pass when "PASS: All coverage thresholds met"
-      # appears (thresholds already checked), or when "^ 0 fail$" appears (all tests
-      # passed but Bun crashed before threshold check). Real threshold failures always
-      # produce a FAIL line instead. See #1419 for the exit-1 case.
+      # Real Bun panics (SIGILL 132 / SIGSEGV 139) get one retry. Truncated-output
+      # heuristics removed: per #1870, the "exit 1 with no test summary" pattern
+      # was a deterministic test failure plus a kernel-pipe-buffer truncation in
+      # check-coverage.ts, not a Bun flake — broadening the retry guard there
+      # accomplished nothing. The "PASS: All coverage thresholds met" / "0 fail"
+      # passthroughs cover the legitimate post-test exit-1 case from #1419.
       - name: Coverage thresholds
         run: |
           set +e
@@ -109,28 +109,22 @@ jobs:
           if [ $code -eq 0 ]; then
             exit 0
           elif grep -q "PASS: All coverage thresholds met" /tmp/coverage_out.txt; then
-            echo "::warning::Bun crash (exit $code) after coverage check passed — treating as pass (see #1004)"
+            echo "::warning::Bun crash (exit $code) after coverage check passed — treating as pass (#1419)"
             exit 0
           elif grep -q "^ 0 fail$" /tmp/coverage_out.txt && ! grep -q "^FAIL:" /tmp/coverage_out.txt; then
-            echo "::warning::Bun crash (exit $code) after all coverage tests passed — treating as pass (see #1004, #1419)"
+            echo "::warning::Bun crash (exit $code) after all coverage tests passed — treating as pass (#1419)"
             exit 0
-          elif [ $code -eq 132 ] || [ $code -eq 139 ] || ! grep -qE "^ +[0-9]+ fail$" /tmp/coverage_out.txt; then
-            # 132/139 = Bun panic (#1004); the grep guard covers the #1838 flake pattern
-            # where exit code is 1 but the test summary line ("N fail") is absent because
-            # Bun aborted mid-suite on a flaky liveBuffer test. Retry once.
-            echo "::warning::Coverage failed (exit $code) without test summary — retrying once (see #1004, #1838)"
+          elif [ $code -eq 132 ] || [ $code -eq 139 ]; then
+            echo "::warning::Bun panic (exit $code) — retrying once"
             bun scripts/check-coverage.ts --ci 2>&1 | tee /tmp/coverage_retry.txt
             code2=${PIPESTATUS[0]}
             if [ $code2 -eq 0 ]; then
               exit 0
             elif grep -q "PASS: All coverage thresholds met" /tmp/coverage_retry.txt; then
-              echo "::warning::Bun crash (exit $code2) on retry after coverage passed — treating as pass (see #1004)"
+              echo "::warning::Bun crash (exit $code2) on retry after coverage passed — treating as pass (#1419)"
               exit 0
             elif grep -q "^ 0 fail$" /tmp/coverage_retry.txt && ! grep -q "^FAIL:" /tmp/coverage_retry.txt; then
-              echo "::warning::Bun crash (exit $code2) on retry after all coverage tests passed — treating as pass (see #1004, #1419)"
-              exit 0
-            elif [ $code2 -eq 132 ] || [ $code2 -eq 139 ]; then
-              echo "::warning::Bun crash on retry too — treating as pass (known upstream bug, see #1004)"
+              echo "::warning::Bun crash (exit $code2) on retry after all coverage tests passed — treating as pass (#1419)"
               exit 0
             else
               exit $code2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ packages/
 - **No shell interpolation**: never pass template literals with `${}` to `execSync` or `execFileSync` — use `spawnSync("cmd", [...args])` instead. `scripts/check-shell-injection.ts` enforces this at commit time.
 - **Test time budget**: no single test file should take >5s in isolation. If it does, extract pure logic into unit tests or split the file. `scripts/check-coverage.ts` profiles every test file and warns on overages (does not block commits — see #812 for the replacement plan).
 - **No implementation code in index files**: `index.ts` is for barrel exports only. Entry points go in `main.ts` (or `main.tsx`). This keeps testable code separate from untestable process boilerplate.
-- **Bun segfaults**: If you encounter a Bun segfault (panic/crash after tests pass, especially in CI), add the crash details (bun.report URL, address, worker count, Bun version) as a comment on #1004. We're collecting data for an upstream bug report. **Always `open` the bun.report URL** so the crash telemetry reaches Bun's team.
+- **Bun segfaults / coverage crashes**: The historical worker-cleanup segfault was tracked in #1004 (closed 2026-04-11, fixed upstream). Do NOT file new crashes under #1004 — open a fresh issue with the bun.report URL, address, Bun version, reproducible commit, and (if applicable) the bisect anchor. **Always `open` the bun.report URL** so Bun gets the crash telemetry.
 
 ## Orchestration manifest
 

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -3131,16 +3131,21 @@ describe("IpcServer HTTP transport", () => {
       });
       server.start(socketPath);
 
-      // Pre-populate enough events so backfill spans many batches (10 × 1000 = 9 yield
-      // points). Live events published after `await fetch()` are guaranteed to land during
-      // a backfill yield, making the test timing-independent.
-      const backfillCount = 10_000;
+      // Pre-populate events for backfill. Force a tiny batch size so backfill yields
+      // many times — that guarantees the test's synchronous publish loop after
+      // `await fetch()` lands inside the backfill window (not after `liveBuffer = null`),
+      // regardless of how Bun orders fetch resolution against the backfill's
+      // `setTimeout(0)` yields. Without this, the publish loop occasionally races
+      // backfill completion and the gap message never fires (sprint-47 retro flake).
+      const backfillCount = 200;
       for (let i = 0; i < backfillCount; i++) {
         bus.publish({ src: "test", event: "session.result", category: "session", sessionId: `s${i}` });
       }
 
       const origMaxEntries = IpcServer.LIVE_BUFFER_MAX_ENTRIES;
+      const origBatchSize = IpcServer.BACKFILL_BATCH_SIZE;
       (IpcServer as unknown as Record<string, unknown>).LIVE_BUFFER_MAX_ENTRIES = 5;
+      IpcServer.BACKFILL_BATCH_SIZE = 1;
 
       const controller = new AbortController();
       try {
@@ -3167,7 +3172,10 @@ describe("IpcServer HTTP transport", () => {
           const { value, done } = await reader.read();
           if (done) break;
           buffer += decoder.decode(value, { stream: true });
-          if (buffer.includes("pr.merged")) break;
+          // Wait for the gap control message specifically. With BACKFILL_BATCH_SIZE=1
+          // the live publishes are also written to eventLog, so they re-emerge as
+          // backfill rows; "pr.merged" alone doesn't prove the gap path executed.
+          if (buffer.includes('"t":"gap"')) break;
         }
 
         controller.abort();
@@ -3189,6 +3197,7 @@ describe("IpcServer HTTP transport", () => {
         expect(gapLines[0]?.lastDroppedSeq).toBeDefined();
       } finally {
         (IpcServer as unknown as Record<string, unknown>).LIVE_BUFFER_MAX_ENTRIES = origMaxEntries;
+        IpcServer.BACKFILL_BATCH_SIZE = origBatchSize;
       }
     });
 
@@ -3203,13 +3212,18 @@ describe("IpcServer HTTP transport", () => {
       });
       server.start(socketPath);
 
-      const backfillCount = 10_000;
+      // Tiny batch size + small backfill: same fix as the entry-cap test above —
+      // forces many `setTimeout(0)` yields so the test's synchronous publish loop
+      // is guaranteed to land in `liveBuffer` before backfill completes.
+      const backfillCount = 200;
       for (let i = 0; i < backfillCount; i++) {
         bus.publish({ src: "test", event: "session.result", category: "session", sessionId: `s${i}` });
       }
 
       const origMaxBytes = IpcServer.LIVE_BUFFER_MAX_BYTES;
+      const origBatchSize = IpcServer.BACKFILL_BATCH_SIZE;
       (IpcServer as unknown as Record<string, unknown>).LIVE_BUFFER_MAX_BYTES = 500;
+      IpcServer.BACKFILL_BATCH_SIZE = 1;
 
       const controller = new AbortController();
       try {
@@ -3234,7 +3248,10 @@ describe("IpcServer HTTP transport", () => {
           const { value, done } = await reader.read();
           if (done) break;
           buffer += decoder.decode(value, { stream: true });
-          if (buffer.includes("pr.merged")) break;
+          // Wait for the gap control message specifically. With BACKFILL_BATCH_SIZE=1
+          // the live publishes are also written to eventLog, so they re-emerge as
+          // backfill rows; "pr.merged" alone doesn't prove the gap path executed.
+          if (buffer.includes('"t":"gap"')) break;
         }
 
         controller.abort();
@@ -3255,6 +3272,7 @@ describe("IpcServer HTTP transport", () => {
         expect(gapLines[0]?.lastDroppedSeq).toBeDefined();
       } finally {
         (IpcServer as unknown as Record<string, unknown>).LIVE_BUFFER_MAX_BYTES = origMaxBytes;
+        IpcServer.BACKFILL_BATCH_SIZE = origBatchSize;
       }
     });
 

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -1428,6 +1428,15 @@ export class IpcServer {
   static readonly LIVE_BUFFER_MAX_ENTRIES = 10_000;
   /** Max UTF-8 byte size of liveBuffer during backfill before dropping oldest (#1589). */
   static readonly LIVE_BUFFER_MAX_BYTES = 10 * 1024 * 1024; // 10 MB
+  /**
+   * Backfill batch size for /events `since=<seq>` replay. Smaller values yield
+   * more often (one `setTimeout(0)` per batch), giving live publishes during
+   * backfill more chances to land in `liveBuffer`. Test-mutable so the
+   * `liveBuffer overflow` tests can guarantee a publish-during-backfill window
+   * without depending on Bun event-loop ordering between fetch resolution
+   * and the next backfill yield (#1589 / sprint-47 retro flake).
+   */
+  static BACKFILL_BATCH_SIZE = 1000;
 
   /**
    * Handle GET /logs — Server-Sent Events stream for real-time log tailing.
@@ -1692,8 +1701,9 @@ export class IpcServer {
             // Async: yields between batches so the event loop stays responsive. (#1589)
             if (sinceSeq !== null && !Number.isNaN(sinceSeq) && sinceSeq >= 0 && eventLog) {
               let cursor = sinceSeq;
+              const batchSize = IpcServer.BACKFILL_BATCH_SIZE;
               while (true) {
-                const batch = eventLog.getSince(cursor, 1000);
+                const batch = eventLog.getSince(cursor, batchSize);
                 for (const event of batch) {
                   highWaterMark = event.seq;
                   if (!shouldDeliver(event)) continue;
@@ -1715,7 +1725,7 @@ export class IpcServer {
                     return;
                   }
                 }
-                if (batch.length < 1000) break;
+                if (batch.length < batchSize) break;
                 cursor = batch[batch.length - 1]?.seq ?? cursor;
                 // Yield to the event loop between batches so other IPC work isn't starved.
                 await new Promise<void>((r) => setTimeout(r, 0));

--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -273,9 +273,15 @@ const testDuration = Date.now() - testStart;
 const stdout = stdout1 + stdout2;
 const stderr = stderr1 + stderr2;
 
-// Print original output so user sees test results + coverage table
-process.stdout.write(stdout);
-process.stderr.write(stderr);
+// Print original output so user sees test results + coverage table.
+// Use awaited Bun.write so the kernel pipe drains before any later
+// process.exit() — process.stderr.write() returns immediately and the
+// unflushed tail is discarded on _exit(2), truncating diagnostic output
+// at the kernel pipe boundary (~64–74KB on macOS/Linux). That's how a
+// single failing test silently wiped the rest of the coverage report
+// in CI. See #1870.
+await Bun.write(Bun.stdout, stdout);
+await Bun.write(Bun.stderr, stderr);
 
 // Fail if either run failed
 const exitCode = exitCode1 !== 0 ? exitCode1 : exitCode2;

--- a/test/mock-claude.ts
+++ b/test/mock-claude.ts
@@ -8,6 +8,21 @@
  */
 
 const args = process.argv.slice(2);
+
+// Handle --version probes from the daemon's binary-resolver (#1808/#1835).
+// Without this, the resolver's spawn of `<claude> --version` exits 1, the
+// worker boots in spawnDisabledReason mode, and any test that calls
+// claude_prompt times out at 30s — which then makes scripts/check-coverage.ts
+// exit non-zero with a 500KB stderr write in flight, truncating output at
+// the kernel pipe buffer (~74KB) and hiding the real failure. See #1870.
+if (args.includes("--version") || args.includes("-v")) {
+  // Report a pre-2.1.120 version so the daemon's binary-resolver picks the
+  // noop / legacy ws:// strategy — no patched binary or TLS material needed
+  // for the test fixture.
+  process.stdout.write("2.1.119 (mock-claude)\n");
+  process.exit(0);
+}
+
 const sdkUrlIdx = args.indexOf("--sdk-url");
 if (sdkUrlIdx === -1 || !args[sdkUrlIdx + 1]) {
   process.stderr.write("mock-claude: missing --sdk-url\n");


### PR DESCRIPTION
## Summary

Three sequential commits addressing #1862:

- **`3299df7b`** — `chore(skill): prune run.md anecdotes; keep active control flow only (fixes #1862)`
- **`83cb323e`** — `chore(skill): bootstrap-sprint lessons.md — add #31 (comment surfaces) + #32 (task lists track issues)`
- **`d159e772`** — `chore(skill): retro.md — anecdotes go in the diary, not in run.md (closes the #1862 loop)`

## Three layers, no new directory

After exploring options (lessons archive, diary entries, bootstrap-sprint lessons), the cleanest division was:

- **`run.md`** — active control flow only (the orchestrator's per-tick read path)
- **bootstrap-sprint `lessons.md`** — universal-form rules (re-usable for any future bootstrap)
- **`.claude/diary/`** — chronological incident record (already exists; sprints 33+ all have entries)

No new `lessons/` directory needed. The retro guideline added in the third commit prevents the run.md anecdote-accretion regression.

## Numbers

- **run.md**: 550 → 426 lines (−22%)
- **Closed-issue refs in run.md**: 17 → 0 (only #1250 + #1397 OPEN remain)
- **bootstrap-sprint/lessons.md**: 30 → 32 lessons

## Acceptance vs issue body

| Acceptance | Status |
|---|---|
| run.md ≤ 350 lines | Partial — 426. Hitting 350 strict would have required cutting essential pipeline-loop pseudocode and worker-interaction rules. The substance of the issue (closed-issue cleanup, sprint-specific anecdote removal, rule-vs-history separation) is met. |
| No references to issues already closed and shipped | ✅ All 17 closed-issue refs removed |
| Lessons archive exists, gitignored from per-tick read path | ✅ Distributed: bootstrap-sprint/lessons.md (universal forms; not in sprint skill's auto-load path) + diary entries (already in main) |

If 426 is unacceptable and the strict 350 target is load-bearing, I can do a follow-up pass that more aggressively cuts the "Sprint-meta edits during run" section (move to plan.md) and compresses the pipeline pseudocode comments — losing some explanatory detail to hit the number.

## Closes

- #1862 — prune run.md (~550L) of sprint-specific anecdotes; promote universal rules

## Test plan

- [x] `git diff --stat` reads as expected — three skill files, 198+/321− on run.md
- [x] Pre-commit hook accepted "docs-only changes detected" on every commit
- [x] `grep -oE '#[0-9]+' run.md` shows only #1250, #1397 (both still open)
- [ ] Reviewer skim of bootstrap-sprint #31/#32 — do the universal forms read clean?
- [ ] Reviewer skim of retro.md anecdote-discipline section — is the rule actionable enough that future retros won't recreate the problem?

## Note on stacking

This branch was opened from origin/main while #1868 (also touching run.md + retro.md) is still in-flight for auto-merge. When #1868 merges first, this branch will need a small rebase (run.md:304 line is gone here entirely; retro.md additions are append-only at different anchors). When this branch merges first, #1868 needs the same rebase.