### PR TITLE
fix(test): repair replacement character in triage-phase.spec.ts State writes header (fixes #1850)

### DIFF
--- a/test/triage-phase.spec.ts
+++ b/test/triage-phase.spec.ts
@@ -349,7 +349,7 @@ describe("runTriage — validation", () => {
   });
 });
 
-// ── State writes ─��
+// ── State writes ──
 
 describe("runTriage — state", () => {
   test("writes triage_scrutiny and triage_reasons", async () => {


### PR DESCRIPTION
## Summary
- Replaces two U+FFFD Unicode replacement characters at the end of the `// ── State writes ─<U+FFFD><U+FFFD>` section header in `test/triage-phase.spec.ts` line 352
- Corrected to `// ── State writes ──`, matching all other section headers in the file
- Flagged originally by Copilot in PR #1844 inline thread 3151752786

## Test plan
- [x] Confirmed malformed bytes (EF BF BD EF BF BD) via hexdump before fix
- [x] Confirmed correct bytes (E2 94 80 E2 94 80) via hexdump after fix
- [x] `bun typecheck` passes
- [x] `bun lint` passes — no fixes applied
- [x] `bun test test/triage-phase.spec.ts` — 25 tests pass, 0 fail
- [x] Pre-commit hook ran full check suite and committed cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)