### PR TITLE
fix(phase): check gh exitCode in findPr to surface operational failures (fixes #1849)

### DIFF
--- a/.claude/phases/triage.ts
+++ b/.claude/phases/triage.ts
@@ -51,6 +51,10 @@ defineAlias({
           stdout: "pipe",
           stderr: "pipe",
         });
+        if (proc.exitCode !== 0) {
+          const err = new TextDecoder().decode(proc.stderr).trim();
+          throw new Error(`gh pr list failed (exit ${proc.exitCode}): ${err}`);
+        }
         const out = new TextDecoder().decode(proc.stdout).trim();
         const n = Number.parseInt(out, 10);
         return Number.isFinite(n) ? n : null;

--- a/test/triage-phase.spec.ts
+++ b/test/triage-phase.spec.ts
@@ -327,6 +327,42 @@ describe("runTriage — replay", () => {
   });
 });
 
+// ── findPr throws (exit code check from #1849) ──
+
+describe("runTriage — findPr throws", () => {
+  test("findPr throwing on first call propagates to caller", async () => {
+    await expect(
+      runTriage(
+        { labels: [] },
+        makeWork(),
+        makeDeps({
+          findPr: () => {
+            throw new Error("gh pr list failed (exit 1): authentication required");
+          },
+        }),
+      ),
+    ).rejects.toThrow("gh pr list failed (exit 1): authentication required");
+  });
+
+  test("findPr throwing inside waitForEvent path is re-thrown (not caught as WaitTimeoutError)", async () => {
+    let calls = 0;
+    await expect(
+      runTriage(
+        { labels: [] },
+        makeWork(),
+        makeDeps({
+          findPr: () => {
+            calls++;
+            if (calls === 1) return null;
+            throw new Error("gh pr list failed (exit 1): network timeout");
+          },
+          waitForEvent: async () => ({ event: "session.result" }),
+        }),
+      ),
+    ).rejects.toThrow("gh pr list failed (exit 1): network timeout");
+  });
+});
+
 // ── Validation ──
 
 describe("runTriage — validation", () => {


### PR DESCRIPTION
## Summary
- `findPr` in `.claude/phases/triage.ts` now checks `proc.exitCode !== 0` after `gh pr list`
- On failure, throws with the stderr text so auth errors, network timeouts, and missing `gh` are visible instead of silently returning `null`
- Matches the existing error-handling pattern used in `runEstimate`

## Test plan
- [ ] All 6331 existing tests pass (`bun test`)
- [ ] Typecheck passes (`bun typecheck`)
- [ ] Lint passes (`bun lint`)
- [ ] Behavioral: `findPr` throwing propagates through `runTriage` (not caught by the `WaitTimeoutError` handler), so misconfigured environments fail loudly rather than looping on `waitForEvent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)