### PR TITLE
fix(claude): show scope hint in ls when sessions exist in other repos (fixes #1603)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -1159,6 +1159,52 @@ describe("mcx claude ls", () => {
     }
   });
 
+  test("shows scope hint when no sessions in current repo but sessions exist elsewhere", async () => {
+    let callCount = 0;
+    const deps = makeDeps({
+      callTool: mock(async (_tool: string, args: Record<string, unknown>) => {
+        callCount++;
+        // First call: scoped (repoRoot set) → no sessions
+        if (args?.repoRoot) return toolResult([]);
+        // Second call: unfiltered → sessions exist in another repo
+        return toolResult([SESSION_LIST[0]]);
+      }),
+      getGitRoot: mock(() => "/home/user/myrepo"),
+    });
+
+    const errSpy = mock(() => {});
+    const origErr = console.error;
+    console.error = errSpy;
+    try {
+      await cmdClaude(["ls"], deps);
+      const messages = errSpy.mock.calls.map((c: unknown[]) => (c as string[])[0]);
+      expect(messages).toContain("No active sessions in current scope.");
+      expect(messages.some((m: string) => m.includes("use --all to see them"))).toBe(true);
+      expect(callCount).toBe(2);
+    } finally {
+      console.error = origErr;
+    }
+  });
+
+  test("shows plain no-sessions when no sessions anywhere", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult([])),
+      getGitRoot: mock(() => "/home/user/myrepo"),
+    });
+
+    const errSpy = mock(() => {});
+    const origErr = console.error;
+    console.error = errSpy;
+    try {
+      await cmdClaude(["ls"], deps);
+      const messages = errSpy.mock.calls.map((c: unknown[]) => (c as string[])[0]);
+      expect(messages).toContain("No active sessions.");
+      expect(messages.every((m: string) => !m.includes("use --all"))).toBe(true);
+    } finally {
+      console.error = origErr;
+    }
+  });
+
   test("accepts 'list' alias", async () => {
     const deps = makeDeps({
       callTool: mock(async () => toolResult([])),

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -869,15 +869,21 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
 
   // Pass scopeRoot or repoRoot to daemon for server-side filtering unless --all
   const toolArgs: Record<string, unknown> = {};
+  let activeFilter: string | undefined;
   if (!showAll) {
     const scope = detectScope();
     if (scope) {
       toolArgs.scopeRoot = scope.root;
+      activeFilter = scope.root;
     } else {
       const gitRoot = d.getGitRoot();
-      if (gitRoot) toolArgs.repoRoot = gitRoot;
+      if (gitRoot) {
+        toolArgs.repoRoot = gitRoot;
+        activeFilter = gitRoot;
+      }
     }
   }
+  const filterLabel = toolArgs.scopeRoot ? "other scopes" : "other repos";
 
   // Fetch sessions and work items in parallel
   const [result, workItems] = await Promise.all([
@@ -922,7 +928,25 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
 
   if (sessions.length === 0) {
     if (quotaBanner) console.error(quotaBanner);
-    console.error("No active sessions.");
+    if (activeFilter) {
+      // Re-query without scope to check whether sessions exist elsewhere
+      let allCount = 0;
+      try {
+        const allResult = await d.callTool("claude_session_list", {});
+        const allSessions = JSON.parse(formatToolResult(allResult));
+        allCount = Array.isArray(allSessions) ? allSessions.length : 0;
+      } catch {
+        // ignore — fall through to plain message
+      }
+      if (allCount > 0) {
+        console.error("No active sessions in current scope.");
+        console.error(`(${allCount} session${allCount === 1 ? "" : "s"} in ${filterLabel} — use --all to see them)`);
+      } else {
+        console.error("No active sessions.");
+      }
+    } else {
+      console.error("No active sessions.");
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary
- When `mcx claude ls` is scoped to the current repo/scope and finds zero results, it now re-queries without a filter to detect sessions elsewhere
- If sessions exist in other repos/scopes, emits `No active sessions in current scope.` followed by `(N session(s) in other repos — use --all to see them)` — mirrors the identical pattern in `mcx claude wait`
- No behavior change when `--all` is passed or when there are truly no sessions anywhere

## Test plan
- [x] New test: `shows scope hint when no sessions in current repo but sessions exist elsewhere` — verifies two-call pattern and hint message
- [x] New test: `shows plain no-sessions when no sessions anywhere` — verifies no hint when unfiltered count is also 0
- [x] Existing `shows message when no sessions` test unchanged (getGitRoot returns null → no activeFilter → no second call)
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] Full `bun test` — 6333 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)