### PR TITLE
fix(daemon): make liveBuffer overflow tests deterministic (fixes #1820, closes #1810)

### DIFF
--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -3120,6 +3120,72 @@ describe("IpcServer HTTP transport", () => {
       expect(buffer).toContain("session.result");
     });
 
+    /**
+     * Shared setup for liveBuffer overflow tests. Installs a one-shot
+     * BACKFILL_YIELD_FN that publishes {@link count} events during the
+     * first backfill yield, guaranteeing they land in liveBuffer.
+     * Returns a restore function for use in `finally`.
+     */
+    function installOverflowHook(
+      bus: EventBus,
+      overrides: Record<string, unknown>,
+      opts: { count: number; event: string; baseNumber: number },
+    ): () => void {
+      const saved: Record<string, unknown> = {};
+      for (const key of Object.keys(overrides)) {
+        saved[key] = (IpcServer as unknown as Record<string, unknown>)[key];
+        (IpcServer as unknown as Record<string, unknown>)[key] = overrides[key];
+      }
+      const origYieldFn = IpcServer.BACKFILL_YIELD_FN;
+      let fired = false;
+      IpcServer.BACKFILL_YIELD_FN = async () => {
+        if (!fired) {
+          fired = true;
+          for (let i = 0; i < opts.count; i++) {
+            bus.publish({ src: "test", event: opts.event, category: "work_item", prNumber: opts.baseNumber + i });
+          }
+        }
+      };
+      return () => {
+        for (const [key, val] of Object.entries(saved)) {
+          (IpcServer as unknown as Record<string, unknown>)[key] = val;
+        }
+        IpcServer.BACKFILL_YIELD_FN = origYieldFn;
+      };
+    }
+
+    async function readUntilGap(socketPath: string): Promise<Record<string, unknown>[]> {
+      const controller = new AbortController();
+      const res = await fetch("http://localhost/events?since=0", {
+        method: "GET",
+        unix: socketPath,
+        signal: controller.signal,
+      } as RequestInit);
+      expect(res.status).toBe(200);
+      if (!res.body) throw new Error("Expected response body");
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+      const deadline = Date.now() + 5_000;
+      while (Date.now() < deadline) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        if (buffer.includes('"t":"gap"')) break;
+      }
+      controller.abort();
+      reader.releaseLock();
+      const parsed: Array<Record<string, unknown>> = [];
+      for (const l of buffer.split("\n").filter((s) => s.startsWith("{"))) {
+        try {
+          parsed.push(JSON.parse(l) as Record<string, unknown>);
+        } catch {
+          /* partial chunk */
+        }
+      }
+      return parsed;
+    }
+
     test("liveBuffer overflow emits gap control message when entry cap is exceeded (#1589)", async () => {
       const db = new Database(":memory:");
       const eventLog = new EventLog(db);
@@ -3131,61 +3197,15 @@ describe("IpcServer HTTP transport", () => {
       });
       server.start(socketPath);
 
-      // One backfill event: enough for the loop to yield once (batch.length === batchSize).
       bus.publish({ src: "test", event: "session.result", category: "session", sessionId: "s0" });
 
-      const origMaxEntries = IpcServer.LIVE_BUFFER_MAX_ENTRIES;
-      const origBatchSize = IpcServer.BACKFILL_BATCH_SIZE;
-      const origYieldFn = IpcServer.BACKFILL_YIELD_FN;
-      (IpcServer as unknown as Record<string, unknown>).LIVE_BUFFER_MAX_ENTRIES = 5;
-      IpcServer.BACKFILL_BATCH_SIZE = 1;
-
-      // Inject overflow events at the first backfill yield — guaranteed to land in
-      // liveBuffer (backfill still in progress) without any event-loop timing race.
-      let eventsPublished = false;
-      IpcServer.BACKFILL_YIELD_FN = async () => {
-        if (!eventsPublished) {
-          eventsPublished = true;
-          for (let i = 0; i < 20; i++) {
-            bus.publish({ src: "test", event: "pr.merged", category: "work_item", prNumber: 900 + i });
-          }
-        }
-        await new Promise<void>((r) => setTimeout(r, 0));
-      };
-
-      const controller = new AbortController();
+      const restore = installOverflowHook(
+        bus,
+        { LIVE_BUFFER_MAX_ENTRIES: 5, BACKFILL_BATCH_SIZE: 1 },
+        { count: 20, event: "pr.merged", baseNumber: 900 },
+      );
       try {
-        const res = await fetch("http://localhost/events?since=0", {
-          method: "GET",
-          unix: socketPath,
-          signal: controller.signal,
-        } as RequestInit);
-
-        expect(res.status).toBe(200);
-        if (!res.body) throw new Error("Expected response body");
-        const reader = res.body.getReader();
-        const decoder = new TextDecoder();
-
-        let buffer = "";
-        const deadline = Date.now() + 5_000;
-        while (Date.now() < deadline) {
-          const { value, done } = await reader.read();
-          if (done) break;
-          buffer += decoder.decode(value, { stream: true });
-          if (buffer.includes('"t":"gap"')) break;
-        }
-
-        controller.abort();
-        reader.releaseLock();
-
-        const parsed: Array<Record<string, unknown>> = [];
-        for (const l of buffer.split("\n").filter((s) => s.startsWith("{"))) {
-          try {
-            parsed.push(JSON.parse(l) as Record<string, unknown>);
-          } catch {
-            /* partial chunk */
-          }
-        }
+        const parsed = await readUntilGap(socketPath);
         const gapLines = parsed.filter((o) => o.t === "gap");
         expect(gapLines.length).toBe(1);
         expect(typeof gapLines[0]?.dropped).toBe("number");
@@ -3193,9 +3213,7 @@ describe("IpcServer HTTP transport", () => {
         expect(gapLines[0]?.firstDroppedSeq).toBeDefined();
         expect(gapLines[0]?.lastDroppedSeq).toBeDefined();
       } finally {
-        (IpcServer as unknown as Record<string, unknown>).LIVE_BUFFER_MAX_ENTRIES = origMaxEntries;
-        IpcServer.BACKFILL_BATCH_SIZE = origBatchSize;
-        IpcServer.BACKFILL_YIELD_FN = origYieldFn;
+        restore();
       }
     });
 
@@ -3210,70 +3228,22 @@ describe("IpcServer HTTP transport", () => {
       });
       server.start(socketPath);
 
-      // One backfill event: enough for the loop to yield once (batch.length === batchSize).
       bus.publish({ src: "test", event: "session.result", category: "session", sessionId: "s0" });
 
-      const origMaxBytes = IpcServer.LIVE_BUFFER_MAX_BYTES;
-      const origBatchSize = IpcServer.BACKFILL_BATCH_SIZE;
-      const origYieldFn = IpcServer.BACKFILL_YIELD_FN;
-      (IpcServer as unknown as Record<string, unknown>).LIVE_BUFFER_MAX_BYTES = 500;
-      IpcServer.BACKFILL_BATCH_SIZE = 1;
-
-      // Inject overflow events at the first backfill yield — guaranteed to land in
-      // liveBuffer (backfill still in progress) without any event-loop timing race.
-      let eventsPublished = false;
-      IpcServer.BACKFILL_YIELD_FN = async () => {
-        if (!eventsPublished) {
-          eventsPublished = true;
-          for (let i = 0; i < 20; i++) {
-            bus.publish({ src: "test", event: "pr.merged", category: "work_item", prNumber: 800 + i });
-          }
-        }
-        await new Promise<void>((r) => setTimeout(r, 0));
-      };
-
-      const controller = new AbortController();
+      const restore = installOverflowHook(
+        bus,
+        { LIVE_BUFFER_MAX_BYTES: 500, BACKFILL_BATCH_SIZE: 1 },
+        { count: 20, event: "pr.merged", baseNumber: 800 },
+      );
       try {
-        const res = await fetch("http://localhost/events?since=0", {
-          method: "GET",
-          unix: socketPath,
-          signal: controller.signal,
-        } as RequestInit);
-
-        expect(res.status).toBe(200);
-        if (!res.body) throw new Error("Expected response body");
-        const reader = res.body.getReader();
-        const decoder = new TextDecoder();
-
-        let buffer = "";
-        const deadline = Date.now() + 5_000;
-        while (Date.now() < deadline) {
-          const { value, done } = await reader.read();
-          if (done) break;
-          buffer += decoder.decode(value, { stream: true });
-          if (buffer.includes('"t":"gap"')) break;
-        }
-
-        controller.abort();
-        reader.releaseLock();
-
-        const parsed: Array<Record<string, unknown>> = [];
-        for (const l of buffer.split("\n").filter((s) => s.startsWith("{"))) {
-          try {
-            parsed.push(JSON.parse(l) as Record<string, unknown>);
-          } catch {
-            /* partial chunk */
-          }
-        }
+        const parsed = await readUntilGap(socketPath);
         const gapLines = parsed.filter((o) => o.t === "gap");
         expect(gapLines.length).toBe(1);
         expect(gapLines[0]?.dropped as number).toBeGreaterThan(0);
         expect(gapLines[0]?.firstDroppedSeq).toBeDefined();
         expect(gapLines[0]?.lastDroppedSeq).toBeDefined();
       } finally {
-        (IpcServer as unknown as Record<string, unknown>).LIVE_BUFFER_MAX_BYTES = origMaxBytes;
-        IpcServer.BACKFILL_BATCH_SIZE = origBatchSize;
-        IpcServer.BACKFILL_YIELD_FN = origYieldFn;
+        restore();
       }
     });
 

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -3131,21 +3131,27 @@ describe("IpcServer HTTP transport", () => {
       });
       server.start(socketPath);
 
-      // Pre-populate events for backfill. Force a tiny batch size so backfill yields
-      // many times — that guarantees the test's synchronous publish loop after
-      // `await fetch()` lands inside the backfill window (not after `liveBuffer = null`),
-      // regardless of how Bun orders fetch resolution against the backfill's
-      // `setTimeout(0)` yields. Without this, the publish loop occasionally races
-      // backfill completion and the gap message never fires (sprint-47 retro flake).
-      const backfillCount = 200;
-      for (let i = 0; i < backfillCount; i++) {
-        bus.publish({ src: "test", event: "session.result", category: "session", sessionId: `s${i}` });
-      }
+      // One backfill event: enough for the loop to yield once (batch.length === batchSize).
+      bus.publish({ src: "test", event: "session.result", category: "session", sessionId: "s0" });
 
       const origMaxEntries = IpcServer.LIVE_BUFFER_MAX_ENTRIES;
       const origBatchSize = IpcServer.BACKFILL_BATCH_SIZE;
+      const origYieldFn = IpcServer.BACKFILL_YIELD_FN;
       (IpcServer as unknown as Record<string, unknown>).LIVE_BUFFER_MAX_ENTRIES = 5;
       IpcServer.BACKFILL_BATCH_SIZE = 1;
+
+      // Inject overflow events at the first backfill yield — guaranteed to land in
+      // liveBuffer (backfill still in progress) without any event-loop timing race.
+      let eventsPublished = false;
+      IpcServer.BACKFILL_YIELD_FN = async () => {
+        if (!eventsPublished) {
+          eventsPublished = true;
+          for (let i = 0; i < 20; i++) {
+            bus.publish({ src: "test", event: "pr.merged", category: "work_item", prNumber: 900 + i });
+          }
+        }
+        await new Promise<void>((r) => setTimeout(r, 0));
+      };
 
       const controller = new AbortController();
       try {
@@ -3160,21 +3166,12 @@ describe("IpcServer HTTP transport", () => {
         const reader = res.body.getReader();
         const decoder = new TextDecoder();
 
-        // Flood live events while backfill is in progress. Because start() is async
-        // and yields between batches, these land in the liveBuffer.
-        for (let i = 0; i < 20; i++) {
-          bus.publish({ src: "test", event: "pr.merged", category: "work_item", prNumber: 900 + i });
-        }
-
         let buffer = "";
         const deadline = Date.now() + 5_000;
         while (Date.now() < deadline) {
           const { value, done } = await reader.read();
           if (done) break;
           buffer += decoder.decode(value, { stream: true });
-          // Wait for the gap control message specifically. With BACKFILL_BATCH_SIZE=1
-          // the live publishes are also written to eventLog, so they re-emerge as
-          // backfill rows; "pr.merged" alone doesn't prove the gap path executed.
           if (buffer.includes('"t":"gap"')) break;
         }
 
@@ -3198,6 +3195,7 @@ describe("IpcServer HTTP transport", () => {
       } finally {
         (IpcServer as unknown as Record<string, unknown>).LIVE_BUFFER_MAX_ENTRIES = origMaxEntries;
         IpcServer.BACKFILL_BATCH_SIZE = origBatchSize;
+        IpcServer.BACKFILL_YIELD_FN = origYieldFn;
       }
     });
 
@@ -3212,18 +3210,27 @@ describe("IpcServer HTTP transport", () => {
       });
       server.start(socketPath);
 
-      // Tiny batch size + small backfill: same fix as the entry-cap test above —
-      // forces many `setTimeout(0)` yields so the test's synchronous publish loop
-      // is guaranteed to land in `liveBuffer` before backfill completes.
-      const backfillCount = 200;
-      for (let i = 0; i < backfillCount; i++) {
-        bus.publish({ src: "test", event: "session.result", category: "session", sessionId: `s${i}` });
-      }
+      // One backfill event: enough for the loop to yield once (batch.length === batchSize).
+      bus.publish({ src: "test", event: "session.result", category: "session", sessionId: "s0" });
 
       const origMaxBytes = IpcServer.LIVE_BUFFER_MAX_BYTES;
       const origBatchSize = IpcServer.BACKFILL_BATCH_SIZE;
+      const origYieldFn = IpcServer.BACKFILL_YIELD_FN;
       (IpcServer as unknown as Record<string, unknown>).LIVE_BUFFER_MAX_BYTES = 500;
       IpcServer.BACKFILL_BATCH_SIZE = 1;
+
+      // Inject overflow events at the first backfill yield — guaranteed to land in
+      // liveBuffer (backfill still in progress) without any event-loop timing race.
+      let eventsPublished = false;
+      IpcServer.BACKFILL_YIELD_FN = async () => {
+        if (!eventsPublished) {
+          eventsPublished = true;
+          for (let i = 0; i < 20; i++) {
+            bus.publish({ src: "test", event: "pr.merged", category: "work_item", prNumber: 800 + i });
+          }
+        }
+        await new Promise<void>((r) => setTimeout(r, 0));
+      };
 
       const controller = new AbortController();
       try {
@@ -3238,19 +3245,12 @@ describe("IpcServer HTTP transport", () => {
         const reader = res.body.getReader();
         const decoder = new TextDecoder();
 
-        for (let i = 0; i < 20; i++) {
-          bus.publish({ src: "test", event: "pr.merged", category: "work_item", prNumber: 800 + i });
-        }
-
         let buffer = "";
         const deadline = Date.now() + 5_000;
         while (Date.now() < deadline) {
           const { value, done } = await reader.read();
           if (done) break;
           buffer += decoder.decode(value, { stream: true });
-          // Wait for the gap control message specifically. With BACKFILL_BATCH_SIZE=1
-          // the live publishes are also written to eventLog, so they re-emerge as
-          // backfill rows; "pr.merged" alone doesn't prove the gap path executed.
           if (buffer.includes('"t":"gap"')) break;
         }
 
@@ -3273,6 +3273,7 @@ describe("IpcServer HTTP transport", () => {
       } finally {
         (IpcServer as unknown as Record<string, unknown>).LIVE_BUFFER_MAX_BYTES = origMaxBytes;
         IpcServer.BACKFILL_BATCH_SIZE = origBatchSize;
+        IpcServer.BACKFILL_YIELD_FN = origYieldFn;
       }
     });
 

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -1431,9 +1431,9 @@ export class IpcServer {
   /** Backfill batch size for /events `since=<seq>` replay. Test-mutable. */
   static BACKFILL_BATCH_SIZE = 1000;
   /**
-   * Optional async hook called at each backfill yield point. When set, replaces
-   * the default `setTimeout(0)` yield. Tests inject live events here to
-   * guarantee they land in `liveBuffer` without relying on event-loop timing.
+   * Optional async hook called at each backfill yield point. Runs *before* the
+   * default `setTimeout(0)` yield (never replaces it). Tests inject live events
+   * here to guarantee they land in `liveBuffer` during the backfill window.
    */
   static BACKFILL_YIELD_FN: (() => Promise<void>) | null = null;
 
@@ -1727,7 +1727,8 @@ export class IpcServer {
                 if (batch.length < batchSize) break;
                 cursor = batch[batch.length - 1]?.seq ?? cursor;
                 // Yield to the event loop between batches so other IPC work isn't starved.
-                await (IpcServer.BACKFILL_YIELD_FN?.() ?? new Promise<void>((r) => setTimeout(r, 0)));
+                await IpcServer.BACKFILL_YIELD_FN?.();
+                await new Promise<void>((r) => setTimeout(r, 0));
               }
               // Drain buffered live events; seq-based HWM drops overlaps.
               const buffered = liveBuffer ?? [];

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -1428,15 +1428,14 @@ export class IpcServer {
   static readonly LIVE_BUFFER_MAX_ENTRIES = 10_000;
   /** Max UTF-8 byte size of liveBuffer during backfill before dropping oldest (#1589). */
   static readonly LIVE_BUFFER_MAX_BYTES = 10 * 1024 * 1024; // 10 MB
-  /**
-   * Backfill batch size for /events `since=<seq>` replay. Smaller values yield
-   * more often (one `setTimeout(0)` per batch), giving live publishes during
-   * backfill more chances to land in `liveBuffer`. Test-mutable so the
-   * `liveBuffer overflow` tests can guarantee a publish-during-backfill window
-   * without depending on Bun event-loop ordering between fetch resolution
-   * and the next backfill yield (#1589 / sprint-47 retro flake).
-   */
+  /** Backfill batch size for /events `since=<seq>` replay. Test-mutable. */
   static BACKFILL_BATCH_SIZE = 1000;
+  /**
+   * Optional async hook called at each backfill yield point. When set, replaces
+   * the default `setTimeout(0)` yield. Tests inject live events here to
+   * guarantee they land in `liveBuffer` without relying on event-loop timing.
+   */
+  static BACKFILL_YIELD_FN: (() => Promise<void>) | null = null;
 
   /**
    * Handle GET /logs — Server-Sent Events stream for real-time log tailing.
@@ -1728,7 +1727,7 @@ export class IpcServer {
                 if (batch.length < batchSize) break;
                 cursor = batch[batch.length - 1]?.seq ?? cursor;
                 // Yield to the event loop between batches so other IPC work isn't starved.
-                await new Promise<void>((r) => setTimeout(r, 0));
+                await (IpcServer.BACKFILL_YIELD_FN?.() ?? new Promise<void>((r) => setTimeout(r, 0)));
               }
               // Drain buffered live events; seq-based HWM drops overlaps.
               const buffered = liveBuffer ?? [];


### PR DESCRIPTION
## Summary

- Adds `static BACKFILL_YIELD_FN: (() => Promise<void>) | null = null` to `IpcServer` as a test injection point at each backfill yield
- Replaces the previous approach of publishing events after `await fetch()` (timing-dependent) with synchronous injection inside the hook — guaranteed to land in `liveBuffer` regardless of event-loop ordering
- Reduces pre-populated backfill from 200 events to 1 (just enough for one yield to occur); tests run faster

**Root cause**: The two `liveBuffer overflow` tests published 20 events synchronously after `await fetch()` resolved, relying on the assumption that the backfill was still in progress. With `BACKFILL_BATCH_SIZE=1` and 200 backfill events, the 200 `setTimeout(0)` callbacks could all complete before the Unix socket round-trip finished, leaving `liveBuffer = null` when the events were published — no overflow, no gap message.

## Test plan

- [x] `bun test packages/daemon/src/ipc-server.spec.ts` — 144 pass, 0 fail
- [x] Both `liveBuffer overflow` tests pass (entry cap + byte cap)
- [x] `bun test` full suite — 6331 pass, 0 fail
- [x] `bun typecheck` — no errors
- [x] `bun lint` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)