### PR TITLE
fix(daemon): restore BudgetWatcher state on daemon restart (fixes #1853)

### DIFF
--- a/packages/daemon/src/budget-watcher.spec.ts
+++ b/packages/daemon/src/budget-watcher.spec.ts
@@ -14,6 +14,7 @@ import {
 import { BudgetWatcher } from "./budget-watcher";
 import { StateDb } from "./db/state";
 import { EventBus } from "./event-bus";
+import { EventLog } from "./event-log";
 import type { QuotaPoller, QuotaStatus } from "./quota";
 
 const dbPaths: string[] = [];
@@ -418,5 +419,199 @@ describe("BudgetWatcher — dispose", () => {
 
     bus.publish(sessionResultEvent("s1", 5.0));
     expect(events).toHaveLength(0);
+  });
+});
+
+// ── Reconcile (daemon restart state restoration) ──
+
+function makeDbWithLog(): { db: StateDb; eventLog: EventLog } {
+  const db = makeDb();
+  const eventLog = new EventLog(db.database);
+  return { db, eventLog };
+}
+
+function loggedEvent(partial: Partial<MonitorEvent> & { event: string; category: string }): MonitorEvent {
+  return {
+    seq: 0,
+    ts: new Date().toISOString(),
+    src: "daemon.budget-watcher",
+    ...partial,
+  } as MonitorEvent;
+}
+
+describe("BudgetWatcher — reconcile", () => {
+  let watcher: BudgetWatcher | null = null;
+
+  afterEach(() => {
+    watcher?.dispose();
+    watcher = null;
+    cleanupDbs();
+  });
+
+  test("returns 0 when no eventLog provided", () => {
+    const db = makeDb();
+    const bus = new EventBus();
+    watcher = new BudgetWatcher({ bus, db, quotaPoller: fakeQuotaPoller(), quotaPollIntervalMs: 999_999 });
+    expect(watcher.reconcile()).toBe(0);
+  });
+
+  test("returns 0 on empty event log", () => {
+    const { db, eventLog } = makeDbWithLog();
+    const bus = new EventBus();
+    watcher = new BudgetWatcher({ bus, db, quotaPoller: fakeQuotaPoller(), quotaPollIntervalMs: 999_999, eventLog });
+    expect(watcher.reconcile()).toBe(0);
+  });
+
+  test("returns count of events replayed", () => {
+    const { db, eventLog } = makeDbWithLog();
+    eventLog.append(loggedEvent({ event: COST_SESSION_OVER_BUDGET, category: "cost", sessionId: "s1", cost: 2.5 }));
+    eventLog.append(loggedEvent({ event: COST_SPRINT_OVER_BUDGET, category: "cost" }));
+    const bus = new EventBus();
+    watcher = new BudgetWatcher({ bus, db, quotaPoller: fakeQuotaPoller(), quotaPollIntervalMs: 999_999, eventLog });
+    expect(watcher.reconcile()).toBe(2);
+  });
+
+  test("session budget not re-fired after restart when COST_SESSION_OVER_BUDGET is in the log", () => {
+    const { db, eventLog } = makeDbWithLog();
+    db.setBudgetConfig({ sessionCap: 2.0 });
+    eventLog.append(loggedEvent({ event: COST_SESSION_OVER_BUDGET, category: "cost", sessionId: "s1", cost: 2.5 }));
+
+    const bus = new EventBus();
+    const fired = collectEvents(bus, COST_SESSION_OVER_BUDGET);
+    watcher = new BudgetWatcher({ bus, db, quotaPoller: fakeQuotaPoller(), quotaPollIntervalMs: 999_999, eventLog });
+    watcher.reconcile();
+
+    bus.publish(sessionResultEvent("s1", 3.0));
+    expect(fired).toHaveLength(0);
+  });
+
+  test("session budget fires normally for sessions not seen in the log", () => {
+    const { db, eventLog } = makeDbWithLog();
+    db.setBudgetConfig({ sessionCap: 2.0 });
+    eventLog.append(loggedEvent({ event: COST_SESSION_OVER_BUDGET, category: "cost", sessionId: "s1", cost: 2.5 }));
+
+    const bus = new EventBus();
+    const fired = collectEvents(bus, COST_SESSION_OVER_BUDGET);
+    watcher = new BudgetWatcher({ bus, db, quotaPoller: fakeQuotaPoller(), quotaPollIntervalMs: 999_999, eventLog });
+    watcher.reconcile();
+
+    // s2 has no prior log entry — should fire normally
+    bus.publish(sessionResultEvent("s2", 3.0));
+    expect(fired).toHaveLength(1);
+    expect(fired[0].sessionId).toBe("s2");
+  });
+
+  test("SESSION_ENDED in log clears session state so it re-fires on restart", () => {
+    const { db, eventLog } = makeDbWithLog();
+    db.setBudgetConfig({ sessionCap: 2.0 });
+    eventLog.append(loggedEvent({ event: COST_SESSION_OVER_BUDGET, category: "cost", sessionId: "s1", cost: 2.5 }));
+    eventLog.append(loggedEvent({ event: SESSION_ENDED, category: "session", sessionId: "s1" }));
+
+    const bus = new EventBus();
+    const fired = collectEvents(bus, COST_SESSION_OVER_BUDGET);
+    watcher = new BudgetWatcher({ bus, db, quotaPoller: fakeQuotaPoller(), quotaPollIntervalMs: 999_999, eventLog });
+    watcher.reconcile();
+
+    // s1 ended before restart — re-fires on new crossing
+    bus.publish(sessionResultEvent("s1", 3.0));
+    expect(fired).toHaveLength(1);
+  });
+
+  test("sprint budget not re-fired after restart when COST_SPRINT_OVER_BUDGET is in the log", () => {
+    const { db, eventLog } = makeDbWithLog();
+    db.setBudgetConfig({ sprintCap: 5.0 });
+
+    db.upsertSession({ sessionId: "s1", state: "active" });
+    db.updateSessionCost("s1", 6.0, 1000);
+
+    eventLog.append(loggedEvent({ event: COST_SPRINT_OVER_BUDGET, category: "cost" }));
+
+    const bus = new EventBus();
+    const fired = collectEvents(bus, COST_SPRINT_OVER_BUDGET);
+    watcher = new BudgetWatcher({ bus, db, quotaPoller: fakeQuotaPoller(), quotaPollIntervalMs: 999_999, eventLog });
+    watcher.reconcile();
+
+    bus.publish(sessionResultEvent("s1", 6.0));
+    expect(fired).toHaveLength(0);
+  });
+
+  test("sprint budget re-arms during reconcile if current cost has since dropped below cap", () => {
+    const { db, eventLog } = makeDbWithLog();
+    db.setBudgetConfig({ sprintCap: 5.0 });
+
+    // Costs are now below the cap
+    db.upsertSession({ sessionId: "s1", state: "active" });
+    db.updateSessionCost("s1", 2.0, 500);
+
+    eventLog.append(loggedEvent({ event: COST_SPRINT_OVER_BUDGET, category: "cost" }));
+
+    const bus = new EventBus();
+    const fired = collectEvents(bus, COST_SPRINT_OVER_BUDGET);
+    watcher = new BudgetWatcher({ bus, db, quotaPoller: fakeQuotaPoller(), quotaPollIntervalMs: 999_999, eventLog });
+    watcher.reconcile();
+
+    // Cost was re-armed (current cost < cap), so crossing fires again
+    db.updateSessionCost("s1", 6.0, 1500);
+    bus.publish(sessionResultEvent("s1", 6.0));
+    expect(fired).toHaveLength(1);
+  });
+
+  test("quota threshold not re-fired after restart when QUOTA_UTILIZATION_THRESHOLD is in the log", () => {
+    const { db, eventLog } = makeDbWithLog();
+    db.setBudgetConfig({ quotaThresholds: [80], quotaDeadband: 5 });
+    eventLog.append(loggedEvent({ event: QUOTA_UTILIZATION_THRESHOLD, category: "quota", threshold: 80 }));
+
+    const poller = fakeQuotaPoller();
+    const bus = new EventBus();
+    const fired = collectEvents(bus, QUOTA_UTILIZATION_THRESHOLD);
+    watcher = new BudgetWatcher({ bus, db, quotaPoller: poller, quotaPollIntervalMs: 999_999, eventLog });
+    watcher.reconcile();
+
+    poller.status = {
+      fiveHour: { utilization: 85, resetsAt: "2026-04-29T01:00:00Z" },
+      sevenDay: null,
+      sevenDaySonnet: null,
+      sevenDayOpus: null,
+      extraUsage: null,
+      fetchedAt: Date.now(),
+    } as QuotaStatus;
+
+    watcher.checkQuota();
+    expect(fired).toHaveLength(0);
+  });
+
+  test("quota threshold re-arms after reconcile if utilization drops below deadband", () => {
+    const { db, eventLog } = makeDbWithLog();
+    db.setBudgetConfig({ quotaThresholds: [80], quotaDeadband: 5 });
+    eventLog.append(loggedEvent({ event: QUOTA_UTILIZATION_THRESHOLD, category: "quota", threshold: 80 }));
+
+    const poller = fakeQuotaPoller();
+    const bus = new EventBus();
+    const fired = collectEvents(bus, QUOTA_UTILIZATION_THRESHOLD);
+    watcher = new BudgetWatcher({ bus, db, quotaPoller: poller, quotaPollIntervalMs: 999_999, eventLog });
+    watcher.reconcile();
+
+    // Utilization drops below deadband — re-arms
+    poller.status = {
+      fiveHour: { utilization: 70, resetsAt: "2026-04-29T01:00:00Z" },
+      sevenDay: null,
+      sevenDaySonnet: null,
+      sevenDayOpus: null,
+      extraUsage: null,
+      fetchedAt: Date.now(),
+    } as QuotaStatus;
+    watcher.checkQuota();
+
+    // Now fires again at 85
+    poller.status = {
+      fiveHour: { utilization: 85, resetsAt: "2026-04-29T01:00:00Z" },
+      sevenDay: null,
+      sevenDaySonnet: null,
+      sevenDayOpus: null,
+      extraUsage: null,
+      fetchedAt: Date.now(),
+    } as QuotaStatus;
+    watcher.checkQuota();
+    expect(fired).toHaveLength(1);
   });
 });

--- a/packages/daemon/src/budget-watcher.ts
+++ b/packages/daemon/src/budget-watcher.ts
@@ -21,6 +21,13 @@ interface SessionCostState {
 const SESSION_EVENTS: ReadonlySet<string> = new Set([SESSION_RESULT, SESSION_IDLE, SESSION_ENDED]);
 
 const DEFAULT_QUOTA_POLL_MS = 60_000;
+const RECONCILE_BATCH_SIZE = 1000;
+const RECONCILE_EVENTS = [
+  COST_SESSION_OVER_BUDGET,
+  COST_SPRINT_OVER_BUDGET,
+  SESSION_ENDED,
+  QUOTA_UTILIZATION_THRESHOLD,
+] as const;
 
 export class BudgetWatcher {
   private readonly bus: EventBus;
@@ -44,7 +51,12 @@ export class BudgetWatcher {
     this.bus = opts.bus;
     this.db = opts.db;
     this.quotaPoller = opts.quotaPoller;
-    this.eventLog = opts.eventLog ?? null;
+
+    const busEventLog = opts.bus.eventLog ?? null;
+    if (opts.eventLog && busEventLog && opts.eventLog !== busEventLog) {
+      throw new Error("BudgetWatcher: opts.eventLog and opts.bus.eventLog must match when both are provided");
+    }
+    this.eventLog = opts.eventLog ?? busEventLog ?? null;
 
     const config = this.db.getBudgetConfig();
     for (const t of config.quotaThresholds) {
@@ -75,18 +87,22 @@ export class BudgetWatcher {
   reconcile(): number {
     if (!this.eventLog) return 0;
 
+    const targetSeq = this.eventLog.currentSeq();
+    if (targetSeq === 0) return 0;
+
     let replayed = 0;
     let cursor = 0;
 
-    while (true) {
-      const events = this.eventLog.getSince(cursor);
+    while (cursor < targetSeq) {
+      const events = this.eventLog.getSince(cursor, RECONCILE_BATCH_SIZE, { events: RECONCILE_EVENTS });
       if (events.length === 0) break;
       for (const event of events) {
+        if (event.seq > targetSeq) break;
         this.applyReplayEvent(event);
         replayed++;
         cursor = event.seq;
       }
-      if (events.length < 1000) break;
+      if (events.length < RECONCILE_BATCH_SIZE) break;
     }
 
     // Re-arm sprint if costs have dropped below the cap since the last crossing.

--- a/packages/daemon/src/budget-watcher.ts
+++ b/packages/daemon/src/budget-watcher.ts
@@ -9,6 +9,7 @@ import {
 import type { BudgetConfig, MonitorEvent } from "@mcp-cli/core";
 import type { StateDb } from "./db/state";
 import type { EventBus } from "./event-bus";
+import type { EventLog } from "./event-log";
 import type { QuotaPoller } from "./quota";
 
 interface SessionCostState {
@@ -25,6 +26,7 @@ export class BudgetWatcher {
   private readonly bus: EventBus;
   private readonly db: StateDb;
   private readonly quotaPoller: QuotaPoller;
+  private readonly eventLog: EventLog | null;
   private readonly subId: number;
   private readonly sessionCosts = new Map<string, SessionCostState>();
   private sprintFired = false;
@@ -37,10 +39,12 @@ export class BudgetWatcher {
     db: StateDb;
     quotaPoller: QuotaPoller;
     quotaPollIntervalMs?: number;
+    eventLog?: EventLog;
   }) {
     this.bus = opts.bus;
     this.db = opts.db;
     this.quotaPoller = opts.quotaPoller;
+    this.eventLog = opts.eventLog ?? null;
 
     const config = this.db.getBudgetConfig();
     for (const t of config.quotaThresholds) {
@@ -60,6 +64,71 @@ export class BudgetWatcher {
     if (this.quotaTimer) {
       clearInterval(this.quotaTimer);
       this.quotaTimer = null;
+    }
+  }
+
+  /**
+   * Replay persisted events to restore in-memory budget state across daemon restarts.
+   * Call once after construction, before the daemon starts handling live requests.
+   * Returns the number of events replayed.
+   */
+  reconcile(): number {
+    if (!this.eventLog) return 0;
+
+    let replayed = 0;
+    let cursor = 0;
+
+    while (true) {
+      const events = this.eventLog.getSince(cursor);
+      if (events.length === 0) break;
+      for (const event of events) {
+        this.applyReplayEvent(event);
+        replayed++;
+        cursor = event.seq;
+      }
+      if (events.length < 1000) break;
+    }
+
+    // Re-arm sprint if costs have dropped below the cap since the last crossing.
+    if (this.sprintFired) {
+      const config = this.db.getBudgetConfig();
+      const cutoffMs = Date.now() - config.sprintWindowMs;
+      const { totalCost } = this.db.sprintCostSince(cutoffMs);
+      if (totalCost < config.sprintCap) {
+        this.sprintFired = false;
+      }
+    }
+
+    return replayed;
+  }
+
+  private applyReplayEvent(event: MonitorEvent): void {
+    const sessionId = typeof event.sessionId === "string" ? event.sessionId : null;
+
+    switch (event.event) {
+      case COST_SESSION_OVER_BUDGET: {
+        if (!sessionId) break;
+        let state = this.sessionCosts.get(sessionId);
+        if (!state) {
+          state = { cost: 0, fired: false };
+          this.sessionCosts.set(sessionId, state);
+        }
+        state.fired = true;
+        if (typeof event.cost === "number") state.cost = event.cost;
+        if (typeof event.workItemId === "string") state.workItemId = event.workItemId;
+        break;
+      }
+      case COST_SPRINT_OVER_BUDGET:
+        this.sprintFired = true;
+        break;
+      case SESSION_ENDED:
+        if (sessionId) this.sessionCosts.delete(sessionId);
+        break;
+      case QUOTA_UTILIZATION_THRESHOLD: {
+        const threshold = typeof event.threshold === "number" ? event.threshold : null;
+        if (threshold !== null) this.quotaArmed.set(threshold, false);
+        break;
+      }
     }
   }
 

--- a/packages/daemon/src/event-log.ts
+++ b/packages/daemon/src/event-log.ts
@@ -81,12 +81,20 @@ export class EventLog {
     return result.seq;
   }
 
-  getSince(afterSeq: number, limit = 1000): MonitorEvent[] {
-    const rows = this.db
-      .query<{ seq: number; payload: string }, [number, number]>(
-        "SELECT seq, payload FROM monitor_events WHERE seq > ? ORDER BY seq ASC LIMIT ?",
-      )
-      .all(afterSeq, limit);
+  getSince(afterSeq: number, limit = 1000, opts?: { events?: readonly string[] }): MonitorEvent[] {
+    let rows: { seq: number; payload: string }[];
+
+    if (opts?.events?.length) {
+      const placeholders = opts.events.map(() => "?").join(", ");
+      const sql = `SELECT seq, payload FROM monitor_events WHERE seq > ? AND event IN (${placeholders}) ORDER BY seq ASC LIMIT ?`;
+      rows = this.db.prepare(sql).all(afterSeq, ...opts.events, limit) as { seq: number; payload: string }[];
+    } else {
+      rows = this.db
+        .query<{ seq: number; payload: string }, [number, number]>(
+          "SELECT seq, payload FROM monitor_events WHERE seq > ? ORDER BY seq ASC LIMIT ?",
+        )
+        .all(afterSeq, limit);
+    }
 
     // Overlay the authoritative seq from the DB column — payload stores seq=0 placeholder.
     return rows.map((r) => ({ ...(JSON.parse(r.payload) as MonitorEvent), seq: r.seq }));

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -609,7 +609,11 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
 
   // Budget watcher: emits cost/quota threshold events (#1587)
   // mailEventBus + eventLog are already created on origin/main earlier in this function (#1586).
-  const budgetWatcher = new BudgetWatcher({ bus: mailEventBus, db, quotaPoller });
+  const budgetWatcher = new BudgetWatcher({ bus: mailEventBus, db, quotaPoller, eventLog });
+  const budgetReconciled = budgetWatcher.reconcile();
+  if (budgetReconciled > 0) {
+    logger.info(`[mcpd] Budget watcher reconciliation replayed ${budgetReconciled} event(s)`);
+  }
 
   // Session metrics aggregator (#1610) — on by default, opt-out via config
   let sessionMetricsAgg: SessionMetricsAggregator | null = null;


### PR DESCRIPTION
## Summary

- Adds `BudgetWatcher.reconcile()` that replays persisted events from the EventLog on daemon startup to rebuild in-memory budget state (`sessionCosts` fired flags, `sprintFired`, `quotaArmed`)
- Sprint budget is re-armed during reconcile if the current sprint cost has since dropped below the cap (avoids suppressing legitimate re-crossings)
- `index.ts` now passes `eventLog` to BudgetWatcher and calls `reconcile()` after construction, logging the replay count

## Test plan

- [x] `reconcile()` returns 0 with no eventLog or empty log
- [x] `reconcile()` returns count of events replayed
- [x] Session budget not re-fired after restart when `COST_SESSION_OVER_BUDGET` is in the log for that session
- [x] Session budget fires normally for sessions not in the log
- [x] `SESSION_ENDED` in log clears session state so crossing can re-fire after restart
- [x] Sprint budget not re-fired after restart when `COST_SPRINT_OVER_BUDGET` is in the log and cost is still above cap
- [x] Sprint budget re-arms during reconcile when current cost has dropped below cap
- [x] Quota threshold not re-fired after restart when `QUOTA_UTILIZATION_THRESHOLD` is in the log
- [x] Quota threshold re-arms correctly after reconcile when utilization drops below deadband
- [x] All 6341 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)