### PR TITLE
feat(send): add --if-idle flag to reject busy sessions (fixes #1606)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -1602,6 +1602,61 @@ describe("mcx claude send", () => {
       console.log = origLog;
     }
   });
+
+  test("--if-idle passes ifIdle flag to daemon", async () => {
+    const callTool: ClaudeDeps["callTool"] = mock(async (tool: string) => {
+      if (tool === "claude_session_list") return toolResult(SESSION_LIST);
+      return toolResult({ sessionId: "abc12345-1111-2222-3333-444444444444" });
+    });
+    const deps = makeDeps({ callTool });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["send", "--if-idle", "abc", "do something"], deps);
+      expect(callTool).toHaveBeenCalledWith("claude_prompt", {
+        sessionId: "abc12345-1111-2222-3333-444444444444",
+        prompt: "do something",
+        ifIdle: true,
+      });
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("--if-idle exits non-zero when daemon returns isError", async () => {
+    const busyResponse = {
+      content: [
+        { type: "text", text: "send: session abc12345 is busy (state=active). Use without --if-idle to queue." },
+      ],
+      isError: true,
+    };
+    const callTool: ClaudeDeps["callTool"] = mock(async (tool: string) => {
+      if (tool === "claude_session_list") return toolResult(SESSION_LIST);
+      return busyResponse;
+    });
+    const deps = makeDeps({ callTool });
+
+    await expect(cmdClaude(["send", "--if-idle", "abc", "do something"], deps)).rejects.toThrow(ExitError);
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("busy"));
+  });
+
+  test("--if-idle does not exit when daemon returns success", async () => {
+    const callTool: ClaudeDeps["callTool"] = mock(async (tool: string) => {
+      if (tool === "claude_session_list") return toolResult(SESSION_LIST);
+      return toolResult({ sessionId: "abc12345-1111-2222-3333-444444444444" });
+    });
+    const deps = makeDeps({ callTool });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["send", "--if-idle", "abc", "do something"], deps);
+      expect(deps.exit).not.toHaveBeenCalled();
+    } finally {
+      console.log = origLog;
+    }
+  });
 });
 
 // ── bye ──

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -1063,10 +1063,13 @@ function joinSessionsToWorkItems(sessions: SessionInfo[], workItems: WorkItem[])
 
 async function claudeSend(args: string[], d: ClaudeDeps): Promise<void> {
   let wait = false;
+  let ifIdle = false;
   const rest: string[] = [];
   for (const arg of args) {
     if (arg === "--wait") {
       wait = true;
+    } else if (arg === "--if-idle") {
+      ifIdle = true;
     } else {
       rest.push(arg);
     }
@@ -1076,15 +1079,28 @@ async function claudeSend(args: string[], d: ClaudeDeps): Promise<void> {
   const message = rest.slice(1).join(" ").trim();
 
   if (!sessionPrefix || !message) {
-    d.printError("Usage: mcx claude send [--wait] <session-id> <message>");
+    d.printError("Usage: mcx claude send [--wait] [--if-idle] <session-id> <message>");
     d.exit(1);
   }
 
   const sessionId = await resolveSessionId(sessionPrefix, d);
   const toolArgs: Record<string, unknown> = { sessionId, prompt: message };
   if (wait) toolArgs.wait = true;
+  if (ifIdle) toolArgs.ifIdle = true;
 
   const result = await d.callTool("claude_prompt", toolArgs);
+
+  // When --if-idle is set, the daemon may return isError:true if the session is busy.
+  // Surface the error to stderr and exit non-zero so callers get a clear failure signal.
+  if (ifIdle) {
+    const r = result as { isError?: boolean; content?: Array<{ text?: string }> };
+    if (r?.isError) {
+      const text = r?.content?.[0]?.text ?? "session is busy";
+      d.printError(text);
+      d.exit(1);
+    }
+  }
+
   console.log(formatToolResult(result));
 }
 
@@ -2020,6 +2036,7 @@ Resume options:
 
 Send options:
   --wait                      Block until Claude produces a result
+  --if-idle                   Fail with exit code 1 if the session is busy instead of queuing
 
 List/Wait options:
   --all, -a                   Show all sessions (bypass repo scoping)

--- a/packages/command/src/help-claude.ts
+++ b/packages/command/src/help-claude.ts
@@ -49,7 +49,10 @@ registerHelp("claude send", {
   name: "mcx claude send",
   summary: "Send a follow-up prompt to a running session",
   usage: ["mcx claude send <session> <message>", "mcx claude send --wait <session> <message>"],
-  options: [["--wait", "Block until Claude produces a result"]],
+  options: [
+    ["--wait", "Block until Claude produces a result"],
+    ["--if-idle", "Exit non-zero if the session is busy instead of queuing the prompt"],
+  ],
   examples: ['mcx claude send abc123 "now run the tests"'],
 });
 

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -155,6 +155,20 @@ async function handlePrompt(
 
   if (sessionId) {
     // Follow-up prompt to existing session
+    if (args.ifIdle) {
+      const check = server.checkSessionIdle(sessionId);
+      if (check && !check.idle) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `send: session ${check.resolvedId.slice(0, 8)} is busy (state=${check.state}). Use without --if-idle to queue.`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
     server.sendPrompt(sessionId, prompt);
   } else {
     // New session

--- a/packages/daemon/src/claude-session/tools.ts
+++ b/packages/daemon/src/claude-session/tools.ts
@@ -34,6 +34,12 @@ export const CLAUDE_TOOLS = buildAgentTools({
             'Pass a UUID to resume that specific session (--resume <id>), or "continue" ' +
             "to resume the most recent conversation in the cwd (--continue).",
         },
+        ifIdle: {
+          type: "boolean",
+          description:
+            "When true, reject the prompt with isError if the target session is busy " +
+            "(active turn, connecting, awaiting permission). Only applies to follow-up prompts (sessionId required).",
+        },
       },
     },
     session_list: {

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -509,6 +509,78 @@ describe("ClaudeWsServer", () => {
     expect(status.state).toBe("connecting");
   });
 
+  test("checkSessionIdle returns not-idle for connecting session", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    await server.start();
+
+    server.prepareSession("s1", { prompt: "Hello" });
+    server.spawnClaude("s1");
+
+    const result = server.checkSessionIdle("s1");
+    expect(result).not.toBeNull();
+    expect(result?.idle).toBe(false);
+    expect(result?.state).toBe("connecting");
+    expect(result?.resolvedId).toBe("s1");
+  });
+
+  test("checkSessionIdle returns idle for idle session", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    const port = await server.start();
+
+    server.prepareSession("test-session", { prompt: "Hello" });
+    server.spawnClaude("test-session");
+
+    const ws = await connectMockClaude(port, "test-session");
+    try {
+      await waitForMessage(ws);
+      ws.send(systemInitMessage("test-session"));
+      ws.send(resultMessage("test-session"));
+      await pollUntil(() => server?.listSessions().some((s) => s.sessionId === "test-session" && s.state === "idle"));
+
+      const result = server.checkSessionIdle("test-session");
+      expect(result?.idle).toBe(true);
+      expect(result?.state).toBe("idle");
+    } finally {
+      ws.close();
+    }
+  });
+
+  test("checkSessionIdle returns null for unknown session", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    await server.start();
+
+    const result = server.checkSessionIdle("nonexistent");
+    expect(result).toBeNull();
+  });
+
+  test("checkSessionIdle resolves by prefix", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    const port = await server.start();
+
+    server.prepareSession("test-session-abc", { prompt: "Hello" });
+    server.spawnClaude("test-session-abc");
+
+    const ws = await connectMockClaude(port, "test-session-abc");
+    try {
+      await waitForMessage(ws);
+      ws.send(systemInitMessage("test-session-abc"));
+      ws.send(resultMessage("test-session-abc"));
+      await pollUntil(() =>
+        server?.listSessions().some((s) => s.sessionId === "test-session-abc" && s.state === "idle"),
+      );
+
+      const result = server.checkSessionIdle("test-session");
+      expect(result?.resolvedId).toBe("test-session-abc");
+      expect(result?.idle).toBe(true);
+    } finally {
+      ws.close();
+    }
+  });
+
   test("transcript stores messages up to limit", async () => {
     const ms = mockSpawn();
     server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -1118,6 +1118,24 @@ export class ClaudeWsServer {
     return [...this.sessions.entries()].map(([sessionId, s]) => this.buildSessionInfo(sessionId, s));
   }
 
+  /**
+   * Check whether a session is idle (safe to send a follow-up prompt).
+   * Returns the resolved session ID and current state, or null if not found.
+   * "Idle" means state is `idle` or `init` — no active turn, no pending permissions.
+   */
+  checkSessionIdle(sessionId: string): { resolvedId: string; state: SessionStateEnum; idle: boolean } | null {
+    let resolvedId: string;
+    try {
+      resolvedId = this.resolveSessionId(sessionId);
+    } catch {
+      return null;
+    }
+    const session = this.sessions.get(resolvedId);
+    if (!session) return null;
+    const state = session.state.state;
+    return { resolvedId, state, idle: state === "idle" || state === "init" };
+  }
+
   /** Get transcript for a session. Falls back to JSONL file when requesting more entries than the ring buffer holds. */
   getTranscript(sessionId: string, last?: number): TranscriptEntry[] {
     const session = this.getSession(sessionId);

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -1120,7 +1120,8 @@ export class ClaudeWsServer {
 
   /**
    * Check whether a session is idle (safe to send a follow-up prompt).
-   * Returns the resolved session ID and current state, or null if not found.
+   * Returns the resolved session ID and current state, or null if not found
+   * or the prefix is ambiguous.
    * "Idle" means state is `idle` or `init` — no active turn, no pending permissions.
    */
   checkSessionIdle(sessionId: string): { resolvedId: string; state: SessionStateEnum; idle: boolean } | null {


### PR DESCRIPTION
## Summary

- Adds `--if-idle` flag to `mcx claude send`: when set, the command exits non-zero with a clear message if the target session is busy (active turn, connecting, awaiting permission) instead of silently queuing the prompt
- TOCTOU-safe: daemon re-checks session state at the moment of enqueue via new `checkSessionIdle()` method on `ClaudeWsServer` — the CLI-side session list call and the daemon-side enqueue call are two separate checks, so a race of a few ms is acceptable per the issue spec
- Error message format: `send: session <id> is busy (state=<state>). Use without --if-idle to queue.`

## Test plan

- [x] `bun typecheck` passes
- [x] `bun lint` passes  
- [x] `bun test` — all 6344 tests pass
- [x] New CLI tests: `--if-idle` passes `ifIdle:true` flag to daemon, exits non-zero on `isError` response, no-ops on success
- [x] New ws-server tests: `checkSessionIdle` returns `idle:false` for connecting session, `idle:true` for idle session, `null` for unknown session, resolves by ID prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)