### PR TITLE
fix(daemon): prevent parallel spawn race producing ghost sessions (fixes #1836)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -148,13 +148,21 @@ describe("parseSpawnArgs", () => {
     expect(result.worktree).toStartWith("claude-");
   });
 
-  test("auto-generated worktree names are unique across rapid calls (#1836)", () => {
-    const names = new Set<string>();
-    for (let i = 0; i < 50; i++) {
-      const result = parseSpawnArgs(["--worktree", "--task", "x"]);
-      const wt = result.worktree ?? "";
-      expect(names.has(wt)).toBe(false);
-      names.add(wt);
+  test("auto-generated worktree names are unique even when Date.now is frozen (#1836)", () => {
+    // Freeze Date.now to reproduce the same-millisecond condition that caused
+    // collisions with the old `claude-${Date.now().toString(36)}` scheme.
+    const orig = Date.now;
+    Date.now = () => 1_745_913_600_000;
+    try {
+      const names = new Set<string>();
+      for (let i = 0; i < 50; i++) {
+        const result = parseSpawnArgs(["--worktree", "--task", "x"]);
+        const wt = result.worktree ?? "";
+        expect(names.has(wt)).toBe(false);
+        names.add(wt);
+      }
+    } finally {
+      Date.now = orig;
     }
   });
 

--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -148,6 +148,16 @@ describe("parseSpawnArgs", () => {
     expect(result.worktree).toStartWith("claude-");
   });
 
+  test("auto-generated worktree names are unique across rapid calls (#1836)", () => {
+    const names = new Set<string>();
+    for (let i = 0; i < 50; i++) {
+      const result = parseSpawnArgs(["--worktree", "--task", "x"]);
+      const wt = result.worktree ?? "";
+      expect(names.has(wt)).toBe(false);
+      names.add(wt);
+    }
+  });
+
   test("parses -w shorthand", () => {
     const result = parseSpawnArgs(["-w", "feat", "-t", "x"]);
     expect(result.worktree).toBe("feat");

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -340,8 +340,9 @@ export function parseSpawnArgs(args: string[]): SpawnArgs {
         worktree = next;
         return 1;
       }
-      // Auto-generate worktree name
-      worktree = `claude-${Date.now().toString(36)}`;
+      // Auto-generate worktree name — use random UUID to avoid collisions
+      // when multiple spawns run in the same millisecond (#1836)
+      worktree = `claude-${crypto.randomUUID().slice(0, 8)}`;
       return 0;
     }
     if (arg === "--resume") {

--- a/packages/daemon/src/claude-session-worker.spec.ts
+++ b/packages/daemon/src/claude-session-worker.spec.ts
@@ -1,5 +1,8 @@
-import { describe, expect, test } from "bun:test";
-import { matchesRepoRoot, matchesScopeRoot } from "./claude-session-worker";
+import { afterEach, describe, expect, test } from "bun:test";
+import { silentLogger } from "@mcp-cli/core";
+import { handlePrompt, matchesRepoRoot, matchesScopeRoot } from "./claude-session-worker";
+import type { SpawnFn } from "./claude-session/ws-server";
+import { ClaudeWsServer } from "./claude-session/ws-server";
 
 // ── matchesScopeRoot ──
 
@@ -79,5 +82,38 @@ describe("matchesRepoRoot", () => {
     // Ghost sessions (crashed workers) with both fields null are invisible to filtered waits.
     // They remain visible when no filter is active (repoRoot=undefined path above).
     expect(matchesRepoRoot({ repoRoot: null, cwd: null }, "/repo/a")).toBe(false);
+  });
+});
+
+// ── handlePrompt spawn-failure path (#1836) ──
+
+describe("handlePrompt spawn failure (#1836)", () => {
+  let server: ClaudeWsServer | undefined;
+  const origPostMessage = (globalThis as Record<string, unknown>).postMessage;
+
+  afterEach(async () => {
+    await server?.stop();
+    server = undefined;
+    (globalThis as Record<string, unknown>).postMessage = origPostMessage;
+  });
+
+  test("cleans up ghost session and posts db:end when spawnClaude throws", async () => {
+    const failingSpawn: SpawnFn = () => {
+      throw new Error("spawn failed: too many processes");
+    };
+    server = new ClaudeWsServer({ spawn: failingSpawn, logger: silentLogger });
+    await server.start();
+
+    const messages: unknown[] = [];
+    (globalThis as Record<string, unknown>).postMessage = (msg: unknown) => messages.push(msg);
+
+    // handlePrompt re-throws after cleanup so the IPC layer can return an error response
+    await expect(handlePrompt(server, { prompt: "hello", cwd: "/tmp/wt" })).rejects.toThrow("spawn failed");
+
+    // Ghost must be removed from the in-memory sessions map
+    expect(server.listSessions()).toHaveLength(0);
+
+    // db:end must be posted so the parent worker can mark the DB row ended
+    expect(messages.some((m) => (m as { type: string }).type === "db:end")).toBe(true);
   });
 });

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -211,7 +211,15 @@ async function handlePrompt(
       },
     });
 
-    const pid = server.spawnClaude(sessionId, workerSpan?.traceparent());
+    let pid: number;
+    try {
+      pid = server.spawnClaude(sessionId, workerSpan?.traceparent());
+    } catch (err) {
+      // Spawn failed — clean up the session to avoid ghost entries (#1836).
+      server.removeUnspawnedSession(sessionId);
+      self.postMessage({ type: "db:end", sessionId });
+      throw err;
+    }
 
     // Capture pidStartTime here in the worker thread (off the main event loop)
     // so the parent doesn't need to do a blocking ps(1) call per session.

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -141,7 +141,7 @@ async function handleToolCall(
   }
 }
 
-async function handlePrompt(
+export async function handlePrompt(
   server: ClaudeWsServer,
   args: Record<string, unknown>,
 ): Promise<{

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -4391,3 +4391,130 @@ describe("stuck detector integration", () => {
     ws.close();
   });
 });
+
+// ── #1836: parallel spawn race ──
+
+describe("parallel spawn (#1836)", () => {
+  let server: ClaudeWsServer | undefined;
+
+  afterEach(() => {
+    server?.stop();
+    server = undefined;
+  });
+
+  test("prepareSession pre-populates state.cwd from config", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    await server.start();
+
+    server.prepareSession("cwd-pre-pop", { prompt: "Hello", cwd: "/my/worktree" });
+    const sessions = server.listSessions();
+    expect(sessions[0].cwd).toBe("/my/worktree");
+  });
+
+  test("removeUnspawnedSession removes session from map", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    await server.start();
+
+    server.prepareSession("dead-session", { prompt: "Hello", cwd: "/tmp/wt" });
+    expect(server.listSessions()).toHaveLength(1);
+
+    server.removeUnspawnedSession("dead-session");
+    expect(server.listSessions()).toHaveLength(0);
+  });
+
+  test("removeUnspawnedSession is no-op for unknown session", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    await server.start();
+
+    server.removeUnspawnedSession("nonexistent");
+    expect(server.listSessions()).toHaveLength(0);
+  });
+
+  test("3 concurrent sessions all connect successfully", async () => {
+    let spawnCount = 0;
+    const spawnFn: SpawnFn = () => {
+      spawnCount++;
+      const pid = 10000 + spawnCount;
+      return {
+        pid,
+        exited: new Promise<number>(() => {}),
+        kill: () => {},
+      };
+    };
+    server = new ClaudeWsServer({ spawn: spawnFn, logger: silentLogger });
+    const port = await server.start();
+
+    const sessionIds = ["s-parallel-1", "s-parallel-2", "s-parallel-3"];
+
+    for (const id of sessionIds) {
+      server.prepareSession(id, {
+        prompt: `Task for ${id}`,
+        cwd: `/worktree/${id}`,
+        worktree: id,
+      });
+      server.spawnClaude(id);
+    }
+
+    expect(server.listSessions()).toHaveLength(3);
+
+    // All sessions should show cwd from config (not null)
+    for (const info of server.listSessions()) {
+      expect(info.cwd).not.toBeNull();
+      expect(info.state).toBe("connecting");
+    }
+
+    // Connect each mock client sequentially to avoid message-delivery race
+    // in the test harness (server sends user message on open; if we
+    // Promise.all the connections, a message can arrive before the next
+    // waitForMessage sets its handler).
+    const wsConnections: WebSocket[] = [];
+    for (const id of sessionIds) {
+      const ws = await connectMockClaude(port, id);
+      const msg = await waitForMessage(ws);
+      expect(msg).toContain('"type":"user"');
+      wsConnections.push(ws);
+    }
+
+    // Send system/init from all 3 and verify they all reach init state
+    for (let i = 0; i < sessionIds.length; i++) {
+      wsConnections[i].send(systemInitMessage(sessionIds[i]));
+    }
+    await pollUntil(() => {
+      const sessions = server?.listSessions() ?? [];
+      return sessions.every((s) => s.state === "init");
+    }, 2_000);
+
+    const sessions = server.listSessions();
+    expect(sessions).toHaveLength(3);
+    for (const s of sessions) {
+      expect(s.state).toBe("init");
+      expect(s.cwd).not.toBeNull();
+    }
+
+    for (const ws of wsConnections) ws.close();
+  });
+
+  test("spawnClaude failure — removeUnspawnedSession cleans up ghost", async () => {
+    const failingSpawn: SpawnFn = () => {
+      throw new Error("spawn failed: too many processes");
+    };
+    server = new ClaudeWsServer({ spawn: failingSpawn, logger: silentLogger });
+    await server.start();
+
+    server.prepareSession("fail-session", { prompt: "Hello", cwd: "/tmp/wt" });
+    expect(server.listSessions()).toHaveLength(1);
+
+    // spawnClaude should throw — caller (handlePrompt) catches and cleans up
+    const srv = server;
+    expect(() => srv?.spawnClaude("fail-session")).toThrow("spawn failed");
+
+    // Session is still in map until caller cleans up
+    expect(server.listSessions()).toHaveLength(1);
+
+    server.removeUnspawnedSession("fail-session");
+    expect(server.listSessions()).toHaveLength(0);
+  });
+});

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -4433,7 +4433,7 @@ describe("parallel spawn (#1836)", () => {
     expect(server.listSessions()).toHaveLength(0);
   });
 
-  test("3 concurrent sessions all connect successfully", async () => {
+  test("3 sessions prepared before any spawn — all coexist with cwd set (#1836)", async () => {
     let spawnCount = 0;
     const spawnFn: SpawnFn = () => {
       spawnCount++;
@@ -4449,12 +4449,16 @@ describe("parallel spawn (#1836)", () => {
 
     const sessionIds = ["s-parallel-1", "s-parallel-2", "s-parallel-3"];
 
+    // Prepare all sessions before spawning any — mirrors the interleaved ordering
+    // that occurs during parallel `mcx claude spawn` calls (#1836).
     for (const id of sessionIds) {
       server.prepareSession(id, {
         prompt: `Task for ${id}`,
         cwd: `/worktree/${id}`,
         worktree: id,
       });
+    }
+    for (const id of sessionIds) {
       server.spawnClaude(id);
     }
 

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -665,6 +665,9 @@ export class ClaudeWsServer {
   /** Prepare a session and return the assigned name. */
   prepareSession(sessionId: string, config: SessionConfig): string {
     const state = new SessionState(sessionId);
+    // Pre-populate state.cwd from config so session info shows the correct
+    // cwd even if the Claude process never connects (#1836).
+    if (config.cwd) state.cwd = config.cwd;
     const router = new PermissionRouter(config.permissionStrategy ?? "auto", config.permissionRules);
 
     // Auto-generate a name if not explicitly provided
@@ -1111,6 +1114,17 @@ export class ClaudeWsServer {
     const reason = message ? `Session ended: ${message}` : "Session ended by user";
     await this.terminateSession(resolvedId, session, reason);
     return info;
+  }
+
+  /**
+   * Remove a session that was prepared but never successfully spawned.
+   * Unlike terminateSession, this is synchronous and skips process/WS cleanup
+   * since the session never had a process or connection (#1836).
+   */
+  removeUnspawnedSession(sessionId: string): void {
+    const session = this.sessions.get(sessionId);
+    if (!session) return;
+    this.sessions.delete(sessionId);
   }
 
   /** List all sessions. */


### PR DESCRIPTION
## Summary
- **Worktree name collision**: replaced `Date.now().toString(36)` with `crypto.randomUUID().slice(0,8)` so parallel spawns within the same millisecond get unique names
- **Dead session cwd=null**: pre-populate `SessionState.cwd` from config at `prepareSession` time so session info shows the correct cwd even if the Claude process never connects
- **Ghost session cleanup**: when `spawnClaude` throws, `handlePrompt` now removes the session via `removeUnspawnedSession` + posts `db:end` to the parent, preventing zombie entries

## Test plan
- [x] `parseSpawnArgs` uniqueness test: 50 rapid auto-generated worktree names are all unique
- [x] `prepareSession` pre-populates `state.cwd` from config
- [x] `removeUnspawnedSession` removes session from map; no-op for unknown session
- [x] 3 concurrent sessions all prepare, spawn, connect via WS, and reach `init` state with non-null cwd
- [x] spawn failure → `removeUnspawnedSession` cleans up the ghost session
- [x] All 6337 existing tests pass (typecheck + lint + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)