### PR TITLE
fix(daemon): prevent bye from destroying worktree used by another session (fixes #1837)

### DIFF
--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -1532,6 +1532,36 @@ describe("ClaudeWsServer", () => {
     expect(result).toEqual({ worktree: null, cwd: null, repoRoot: null });
   });
 
+  test("bye suppresses worktree cleanup when another session shares the same worktree (#1837)", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    await server.start();
+
+    // Simulate parallel-spawn race: two sessions claim the same worktree
+    server.prepareSession("ghost-session", {
+      prompt: "Hello",
+      worktree: "claude-shared",
+      cwd: "/repo/.claude/worktrees/claude-shared",
+      repoRoot: "/repo",
+    });
+    server.prepareSession("active-session", {
+      prompt: "Hello",
+      worktree: "claude-shared",
+      cwd: "/repo/.claude/worktrees/claude-shared",
+      repoRoot: "/repo",
+    });
+
+    // Bye the ghost — worktree should be suppressed because active-session still uses it
+    const ghostResult = await server.bye("ghost-session");
+    expect(ghostResult.worktree).toBeNull();
+    expect(ghostResult.cwd).toBeNull();
+
+    // Bye the remaining session — worktree should be returned for cleanup
+    const activeResult = await server.bye("active-session");
+    expect(activeResult.worktree).toBe("claude-shared");
+    expect(activeResult.cwd).toBe("/repo/.claude/worktrees/claude-shared");
+  });
+
   test("sessionCount tracks active sessions", async () => {
     const ms = mockSpawn();
     server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -1590,6 +1590,36 @@ describe("ClaudeWsServer", () => {
     expect(nonNullCount).toBe(1);
   });
 
+  test("bye does NOT suppress cleanup when same worktree name is in different repos (#1837)", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    await server.start();
+
+    server.prepareSession("session-a", {
+      prompt: "Hello",
+      worktree: "claude-shared",
+      cwd: "/repo-a/.claude/worktrees/claude-shared",
+      repoRoot: "/repo-a",
+    });
+    server.prepareSession("session-b", {
+      prompt: "Hello",
+      worktree: "claude-shared",
+      cwd: "/repo-b/.claude/worktrees/claude-shared",
+      repoRoot: "/repo-b",
+    });
+
+    // Bye session-a — should NOT be suppressed because session-b is in a different repo/cwd
+    const resultA = await server.bye("session-a");
+    expect(resultA.worktree).toBe("claude-shared");
+    expect(resultA.cwd).toBe("/repo-a/.claude/worktrees/claude-shared");
+    expect(resultA.repoRoot).toBe("/repo-a");
+
+    const resultB = await server.bye("session-b");
+    expect(resultB.worktree).toBe("claude-shared");
+    expect(resultB.cwd).toBe("/repo-b/.claude/worktrees/claude-shared");
+    expect(resultB.repoRoot).toBe("/repo-b");
+  });
+
   test("sessionCount tracks active sessions", async () => {
     const ms = mockSpawn();
     server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -1555,11 +1555,39 @@ describe("ClaudeWsServer", () => {
     const ghostResult = await server.bye("ghost-session");
     expect(ghostResult.worktree).toBeNull();
     expect(ghostResult.cwd).toBeNull();
+    expect(ghostResult.repoRoot).toBeNull();
 
     // Bye the remaining session — worktree should be returned for cleanup
     const activeResult = await server.bye("active-session");
     expect(activeResult.worktree).toBe("claude-shared");
     expect(activeResult.cwd).toBe("/repo/.claude/worktrees/claude-shared");
+    expect(activeResult.repoRoot).toBe("/repo");
+  });
+
+  test("bye with concurrent calls on shared worktree: exactly one returns worktree for cleanup (#1837)", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    await server.start();
+
+    server.prepareSession("ghost-session", {
+      prompt: "Hello",
+      worktree: "claude-shared",
+      cwd: "/repo/.claude/worktrees/claude-shared",
+      repoRoot: "/repo",
+    });
+    server.prepareSession("active-session", {
+      prompt: "Hello",
+      worktree: "claude-shared",
+      cwd: "/repo/.claude/worktrees/claude-shared",
+      repoRoot: "/repo",
+    });
+
+    // Concurrent byes — one must suppress, the other must return the worktree
+    const [ghostResult, activeResult] = await Promise.all([server.bye("ghost-session"), server.bye("active-session")]);
+
+    const worktrees = [ghostResult.worktree, activeResult.worktree];
+    const nonNullCount = worktrees.filter((w) => w !== null).length;
+    expect(nonNullCount).toBe(1);
   });
 
   test("sessionCount tracks active sessions", async () => {

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -1119,9 +1119,10 @@ export class ClaudeWsServer {
     // Guard: suppress worktree cleanup if another session references the same worktree.
     // Parallel spawn can assign the same worktree to multiple sessions (#1836);
     // without this check, bye on a dead ghost destroys a live session's working dir (#1837).
+    // Match by cwd (full path), not just worktree name — names aren't unique across repos.
     if (info.worktree) {
       for (const [otherId, other] of this.sessions) {
-        if (other.worktree === info.worktree) {
+        if (other.worktree === info.worktree && (other.config.cwd ?? null) === info.cwd) {
           this.logger.warn(
             `[_claude] bye ${resolvedId.slice(0, 8)}: worktree "${info.worktree}" also claimed by session ${otherId.slice(0, 8)} — skipping cleanup`,
           );

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -1103,11 +1103,28 @@ export class ClaudeWsServer {
       });
     }
 
-    const info = {
+    const info: { worktree: string | null; cwd: string | null; repoRoot: string | null } = {
       worktree: session.worktree,
       cwd: session.config.cwd ?? null,
       repoRoot: session.config.repoRoot ?? null,
     };
+
+    // Guard: suppress worktree cleanup if another session references the same worktree.
+    // Parallel spawn can assign the same worktree to multiple sessions (#1836);
+    // without this check, bye on a dead ghost destroys a live session's working dir (#1837).
+    if (info.worktree) {
+      for (const [otherId, other] of this.sessions) {
+        if (otherId !== resolvedId && other.worktree === info.worktree) {
+          this.logger.warn(
+            `[_claude] bye ${resolvedId.slice(0, 8)}: worktree "${info.worktree}" also claimed by session ${otherId.slice(0, 8)} — skipping cleanup`,
+          );
+          info.worktree = null;
+          info.cwd = null;
+          break;
+        }
+      }
+    }
+
     const reason = message ? `Session ended: ${message}` : "Session ended by user";
     await this.terminateSession(resolvedId, session, reason);
     return info;

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -1109,17 +1109,25 @@ export class ClaudeWsServer {
       repoRoot: session.config.repoRoot ?? null,
     };
 
+    // Remove from map before the guard scan so that concurrent bye() calls on sessions
+    // sharing the same worktree don't see each other and both suppress — which would
+    // leave the worktree orphaned. JS is single-threaded: this delete is visible to any
+    // bye() that starts after the next await. terminateSession's own sessions.delete is
+    // now a no-op but kept for safety.
+    this.sessions.delete(resolvedId);
+
     // Guard: suppress worktree cleanup if another session references the same worktree.
     // Parallel spawn can assign the same worktree to multiple sessions (#1836);
     // without this check, bye on a dead ghost destroys a live session's working dir (#1837).
     if (info.worktree) {
       for (const [otherId, other] of this.sessions) {
-        if (otherId !== resolvedId && other.worktree === info.worktree) {
+        if (other.worktree === info.worktree) {
           this.logger.warn(
             `[_claude] bye ${resolvedId.slice(0, 8)}: worktree "${info.worktree}" also claimed by session ${otherId.slice(0, 8)} — skipping cleanup`,
           );
           info.worktree = null;
           info.cwd = null;
+          info.repoRoot = null;
           break;
         }
       }


### PR DESCRIPTION
## Summary
- When parallel spawn assigns the same worktree to multiple sessions (#1836), `bye` on a dead ghost would delete the worktree out from under an active session
- Added a guard in `ClaudeWsServer.bye()` that scans all other sessions before returning worktree info — if another session references the same worktree, the cleanup is suppressed and only the dead session record is removed
- The last session ended that references a shared worktree will still trigger the cleanup correctly

## Test plan
- [x] New test: `bye suppresses worktree cleanup when another session shares the same worktree (#1837)` — verifies ghost bye nulls worktree, and subsequent bye on remaining session returns it
- [x] Existing test `bye returns worktree info` still passes (non-shared case unchanged)
- [x] Full suite: 6338 tests pass, 0 failures
- [x] Typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)