### PR TITLE
feat(claude): add --reason flag to mcx claude interrupt (fixes #1607)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -1953,6 +1953,46 @@ describe("mcx claude interrupt", () => {
     }
   });
 
+  test("passes reason to tool when --reason flag is provided", async () => {
+    const callTool: ClaudeDeps["callTool"] = mock(async (tool: string) => {
+      if (tool === "claude_session_list") return toolResult(SESSION_LIST);
+      return toolResult({ interrupted: true });
+    });
+    const deps = makeDeps({ callTool });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["interrupt", "def", "--reason", "Wrong path, abandon it"], deps);
+      expect(callTool).toHaveBeenCalledWith("claude_interrupt", {
+        sessionId: "def67890-aaaa-bbbb-cccc-dddddddddddd",
+        reason: "Wrong path, abandon it",
+      });
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("passes reason to tool when -r flag is provided", async () => {
+    const callTool: ClaudeDeps["callTool"] = mock(async (tool: string) => {
+      if (tool === "claude_session_list") return toolResult(SESSION_LIST);
+      return toolResult({ interrupted: true });
+    });
+    const deps = makeDeps({ callTool });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["interrupt", "def", "-r", "Stop editing"], deps);
+      expect(callTool).toHaveBeenCalledWith("claude_interrupt", {
+        sessionId: "def67890-aaaa-bbbb-cccc-dddddddddddd",
+        reason: "Stop editing",
+      });
+    } finally {
+      console.log = origLog;
+    }
+  });
+
   test("errors when no session specified", async () => {
     const deps = makeDeps();
     await expect(cmdClaude(["interrupt"], deps)).rejects.toThrow(ExitError);

--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -1997,6 +1997,26 @@ describe("mcx claude interrupt", () => {
     const deps = makeDeps();
     await expect(cmdClaude(["interrupt"], deps)).rejects.toThrow(ExitError);
   });
+
+  test("errors when --reason flag has no value", async () => {
+    const deps = makeDeps();
+    await expect(cmdClaude(["interrupt", "def", "--reason"], deps)).rejects.toThrow(ExitError);
+  });
+
+  test("errors when -r flag has no value", async () => {
+    const deps = makeDeps();
+    await expect(cmdClaude(["interrupt", "def", "-r"], deps)).rejects.toThrow(ExitError);
+  });
+
+  test("errors on unknown flag", async () => {
+    const deps = makeDeps();
+    await expect(cmdClaude(["interrupt", "def", "--typo"], deps)).rejects.toThrow(ExitError);
+  });
+
+  test("errors on duplicate positional argument", async () => {
+    const deps = makeDeps();
+    await expect(cmdClaude(["interrupt", "def", "extra"], deps)).rejects.toThrow(ExitError);
+  });
 });
 
 // ── log ──

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -1224,9 +1224,19 @@ async function claudeInterrupt(args: string[], d: ClaudeDeps): Promise<void> {
   let reason: string | undefined;
 
   for (let i = 0; i < args.length; i++) {
-    if ((args[i] === "--reason" || args[i] === "-r") && i + 1 < args.length) {
+    if (args[i] === "--reason" || args[i] === "-r") {
+      if (i + 1 >= args.length) {
+        d.printError(`${args[i]} requires a value`);
+        d.exit(1);
+      }
       reason = args[++i];
-    } else if (!args[i].startsWith("-")) {
+    } else if (args[i].startsWith("-")) {
+      d.printError(`Unknown flag: ${args[i]}\nUsage: mcx claude interrupt <session-id> [--reason <text>]`);
+      d.exit(1);
+    } else if (sessionPrefix !== undefined) {
+      d.printError(`Unexpected argument: ${args[i]}\nUsage: mcx claude interrupt <session-id> [--reason <text>]`);
+      d.exit(1);
+    } else {
       sessionPrefix = args[i];
     }
   }

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -1220,15 +1220,26 @@ export function parseByeResult(result: unknown): ByeResult {
 export { cleanupWorktree } from "@mcp-cli/core";
 
 async function claudeInterrupt(args: string[], d: ClaudeDeps): Promise<void> {
-  const sessionPrefix = args[0];
+  let sessionPrefix: string | undefined;
+  let reason: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    if ((args[i] === "--reason" || args[i] === "-r") && i + 1 < args.length) {
+      reason = args[++i];
+    } else if (!args[i].startsWith("-")) {
+      sessionPrefix = args[i];
+    }
+  }
 
   if (!sessionPrefix) {
-    d.printError("Usage: mcx claude interrupt <session-id>");
+    d.printError("Usage: mcx claude interrupt <session-id> [--reason <text>]");
     d.exit(1);
   }
 
   const sessionId = await resolveSessionId(sessionPrefix, d);
-  const result = await d.callTool("claude_interrupt", { sessionId });
+  const toolArgs: Record<string, unknown> = { sessionId };
+  if (reason) toolArgs.reason = reason;
+  const result = await d.callTool("claude_interrupt", toolArgs);
   console.log(formatToolResult(result));
 }
 
@@ -1988,7 +1999,7 @@ Usage:
   mcx claude send <session> <message>      Send follow-up prompt (non-blocking)
   mcx claude wait [session] [--all]        Block until a session event occurs
   mcx claude bye <session>                 End session and stop process
-  mcx claude interrupt <session>           Interrupt the current turn
+  mcx claude interrupt <session> [--reason <text>]  Interrupt the current turn
   mcx claude approve <session>              Approve latest pending permission request
   mcx claude deny <session>                Deny latest pending permission request
   mcx claude log <session> [--last N]      View session transcript

--- a/packages/core/src/agent-tools.ts
+++ b/packages/core/src/agent-tools.ts
@@ -206,6 +206,11 @@ export function buildAgentTools(opts: BuildAgentToolsOptions): readonly AgentToo
         type: "object" as const,
         properties: {
           sessionId: { ...sessionIdProp, description: "Session ID or unique prefix to interrupt" },
+          reason: {
+            type: "string" as const,
+            description:
+              "Optional reason for the interruption. When provided, it is prepended to the next send so the session understands why it was interrupted.",
+          },
           ...ov("interrupt")?.extraProperties,
         },
         required: ["sessionId"] as const,

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -301,7 +301,8 @@ function handleInterrupt(
 ): {
   content: Array<{ type: "text"; text: string }>;
 } {
-  server.interrupt(args.sessionId as string);
+  const reason = typeof args.reason === "string" ? args.reason : undefined;
+  server.interrupt(args.sessionId as string, reason);
   return { content: [{ type: "text", text: JSON.stringify({ interrupted: true }) }] };
 }
 

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -1237,6 +1237,43 @@ describe("ClaudeWsServer", () => {
     }
   });
 
+  test("bare interrupt clears a previously set pending reason", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    const port = await server.start();
+
+    server.prepareSession("test-session", { prompt: "Hello" });
+    server.spawnClaude("test-session");
+
+    const ws = await connectMockClaude(port, "test-session");
+    try {
+      await waitForMessage(ws);
+      ws.send(systemInitMessage("test-session"));
+      await Bun.sleep(10);
+      ws.send(resultMessage("test-session"));
+      await Bun.sleep(10);
+
+      // Set a reason via first interrupt
+      const firstInterruptPromise = waitForMessage(ws);
+      server.interrupt("test-session", "Wrong path");
+      await firstInterruptPromise;
+
+      // Bare interrupt should clear the pending reason
+      const secondInterruptPromise = waitForMessage(ws);
+      server.interrupt("test-session");
+      await secondInterruptPromise;
+
+      // sendPrompt should not prepend the stale reason
+      const msgPromise = waitForMessage(ws);
+      server.sendPrompt("test-session", "Next instruction");
+      const msg = await msgPromise;
+      const parsed = JSON.parse(msg.trim());
+      expect(parsed.message.content).toBe("Next instruction");
+    } finally {
+      ws.close();
+    }
+  });
+
   test("interrupt without reason does not affect sendPrompt", async () => {
     const ms = mockSpawn();
     server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -1161,6 +1161,114 @@ describe("ClaudeWsServer", () => {
     }
   });
 
+  test("interrupt with reason prepends context to next sendPrompt", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    const port = await server.start();
+
+    server.prepareSession("test-session", { prompt: "Hello" });
+    server.spawnClaude("test-session");
+
+    const ws = await connectMockClaude(port, "test-session");
+    try {
+      await waitForMessage(ws);
+      ws.send(systemInitMessage("test-session"));
+      await Bun.sleep(10);
+      ws.send(resultMessage("test-session"));
+      await Bun.sleep(10);
+
+      // Consume the interrupt control_request, then listen for the user message
+      const interruptPromise = waitForMessage(ws);
+      server.interrupt("test-session", "Wrong path, abandon it");
+      await interruptPromise;
+
+      const msgPromise = waitForMessage(ws);
+      server.sendPrompt("test-session", "Do something else");
+
+      const msg = await msgPromise;
+      const parsed = JSON.parse(msg.trim());
+      expect(parsed.type).toBe("user");
+      expect(parsed.message.content).toBe("[Interrupt context: Wrong path, abandon it]\n\nDo something else");
+    } finally {
+      ws.close();
+    }
+  });
+
+  test("interrupt reason is consumed on first sendPrompt only", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    const port = await server.start();
+
+    server.prepareSession("test-session", { prompt: "Hello" });
+    server.spawnClaude("test-session");
+
+    const ws = await connectMockClaude(port, "test-session");
+    try {
+      await waitForMessage(ws);
+      ws.send(systemInitMessage("test-session"));
+      await Bun.sleep(10);
+      ws.send(resultMessage("test-session"));
+      await Bun.sleep(10);
+
+      // Consume the interrupt control_request
+      const interruptPromise = waitForMessage(ws);
+      server.interrupt("test-session", "Stop that");
+      await interruptPromise;
+
+      // First send: reason prepended
+      const firstMsgPromise = waitForMessage(ws);
+      server.sendPrompt("test-session", "First follow-up");
+      const firstMsg = await firstMsgPromise;
+      const firstParsed = JSON.parse(firstMsg.trim());
+      expect(firstParsed.message.content).toContain("[Interrupt context: Stop that]");
+
+      // Session goes idle again
+      ws.send(resultMessage("test-session"));
+      await Bun.sleep(10);
+
+      // Second send: no reason prepended
+      const secondMsgPromise = waitForMessage(ws);
+      server.sendPrompt("test-session", "Second follow-up");
+      const secondMsg = await secondMsgPromise;
+      const secondParsed = JSON.parse(secondMsg.trim());
+      expect(secondParsed.message.content).toBe("Second follow-up");
+    } finally {
+      ws.close();
+    }
+  });
+
+  test("interrupt without reason does not affect sendPrompt", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    const port = await server.start();
+
+    server.prepareSession("test-session", { prompt: "Hello" });
+    server.spawnClaude("test-session");
+
+    const ws = await connectMockClaude(port, "test-session");
+    try {
+      await waitForMessage(ws);
+      ws.send(systemInitMessage("test-session"));
+      await Bun.sleep(10);
+      ws.send(resultMessage("test-session"));
+      await Bun.sleep(10);
+
+      // Consume the interrupt control_request
+      const interruptPromise = waitForMessage(ws);
+      server.interrupt("test-session");
+      await interruptPromise;
+
+      const msgPromise = waitForMessage(ws);
+      server.sendPrompt("test-session", "Plain message");
+
+      const msg = await msgPromise;
+      const parsed = JSON.parse(msg.trim());
+      expect(parsed.message.content).toBe("Plain message");
+    } finally {
+      ws.close();
+    }
+  });
+
   test("waitForEvent resolves on session:result", async () => {
     const ms = mockSpawn();
     server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -930,9 +930,9 @@ export class ClaudeWsServer {
 
     const session = this.getSession(sessionId);
     const pendingReason = session.pendingInterruptReason;
-    session.pendingInterruptReason = null;
     const effective = pendingReason ? `[Interrupt context: ${pendingReason}]\n\n${message}` : message;
     const outbound = session.state.queuePrompt(effective);
+    session.pendingInterruptReason = null;
     this.sendToWs(session, outbound);
     this.addTranscript(session, "outbound", { type: "user", message: { role: "user", content: effective } });
     this.recordSessionProgress(sessionId, session);

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -344,6 +344,12 @@ interface WsSession {
    * Reset only on clearSession (respawn = fresh work cycle).
    */
   workCompleted: boolean;
+  /**
+   * Reason provided with the last interrupt call. Prepended to the next sendPrompt
+   * so the session sees why it was interrupted before the new instruction.
+   * Cleared after it is consumed by sendPrompt or when the session is cleared/ended.
+   */
+  pendingInterruptReason: string | null;
 }
 
 interface WsData {
@@ -649,6 +655,7 @@ export class ClaudeWsServer {
         createdAt: s.spawnedAt ? new Date(`${s.spawnedAt}Z`).getTime() : Date.now(),
         pendingImmediate: false, // Restored sessions have no new events
         workCompleted: false,
+        pendingInterruptReason: null,
         traceparent: null,
         stuckDetector: null,
       });
@@ -700,6 +707,7 @@ export class ClaudeWsServer {
       createdAt: Date.now(),
       pendingImmediate: false,
       workCompleted: false,
+      pendingInterruptReason: null,
       traceparent: null,
       stuckDetector: null,
     });
@@ -921,9 +929,12 @@ export class ClaudeWsServer {
     }
 
     const session = this.getSession(sessionId);
-    const outbound = session.state.queuePrompt(message);
+    const pendingReason = session.pendingInterruptReason;
+    session.pendingInterruptReason = null;
+    const effective = pendingReason ? `[Interrupt context: ${pendingReason}]\n\n${message}` : message;
+    const outbound = session.state.queuePrompt(effective);
     this.sendToWs(session, outbound);
-    this.addTranscript(session, "outbound", { type: "user", message: { role: "user", content: message } });
+    this.addTranscript(session, "outbound", { type: "user", message: { role: "user", content: effective } });
     this.recordSessionProgress(sessionId, session);
   }
 
@@ -935,11 +946,14 @@ export class ClaudeWsServer {
     this.recordSessionProgress(sessionId, session);
   }
 
-  /** Interrupt the current turn. */
-  interrupt(sessionId: string): void {
+  /** Interrupt the current turn. If reason is provided, it is prepended to the next sendPrompt. */
+  interrupt(sessionId: string, reason?: string): void {
     const session = this.getSession(sessionId);
     const outbound = session.state.interrupt();
     this.sendToWs(session, outbound);
+    if (reason) {
+      session.pendingInterruptReason = reason;
+    }
   }
 
   /**
@@ -1000,6 +1014,7 @@ export class ClaudeWsServer {
     if (session.clearing) return;
     session.clearing = true;
     session.workCompleted = false;
+    session.pendingInterruptReason = null;
 
     // Reset state machine (preserves cumulative cost/tokens)
     const events = session.state.resetForClear();

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -951,9 +951,7 @@ export class ClaudeWsServer {
     const session = this.getSession(sessionId);
     const outbound = session.state.interrupt();
     this.sendToWs(session, outbound);
-    if (reason) {
-      session.pendingInterruptReason = reason;
-    }
+    session.pendingInterruptReason = reason ?? null;
   }
 
   /**


### PR DESCRIPTION
## Summary
- Adds `--reason <text>` (or `-r <text>`) flag to `mcx claude interrupt <session>`
- When provided, the reason is stored as a pending interrupt context on the session
- The next `sendPrompt` prepends `[Interrupt context: <reason>]` to the message so the session understands why it was interrupted before receiving the new instruction
- Reason is consumed once (single-use) and cleared on `/clear`

## Test plan
- [x] `claude.spec.ts`: tests for `--reason` and `-r` flags pass correct args to `claude_interrupt` tool
- [x] `ws-server.spec.ts`: three new tests verify reason prepending, single-use consumption, and no-reason passthrough
- [x] Full test suite: 6342 pass, 0 fail
- [x] TypeCheck and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)