### PR TITLE
feat(claude): add mcx agent claude status one-shot session inspector (fixes #1609)

### DIFF
--- a/packages/command/src/commands/agent.spec.ts
+++ b/packages/command/src/commands/agent.spec.ts
@@ -499,6 +499,130 @@ describe("agent claude ls", () => {
   });
 });
 
+// ── Status ──
+
+const CLAUDE_SESSION = {
+  sessionId: "ccc11111-aaaa-bbbb-cccc-dddddddddddd",
+  name: "Alice",
+  provider: "claude",
+  state: "idle",
+  model: "claude-sonnet-4-6",
+  cwd: "/repo",
+  cost: 13.83,
+  tokens: 50000,
+  numTurns: 182,
+  pendingPermissions: 0,
+  pendingPermissionDetails: [],
+  worktree: null,
+  processAlive: true,
+  snapshotTs: Date.now() - 263_000,
+};
+
+describe("agent claude status", () => {
+  test("calls claude_session_list then claude_transcript", async () => {
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "claude_session_list") return toolResult([CLAUDE_SESSION]);
+        return toolResult([]);
+      }),
+    });
+    await cmdAgent(["claude", "status", "ccc11111"], deps);
+    expect(deps.callTool).toHaveBeenCalledWith("claude_session_list", {});
+    expect(deps.callTool).toHaveBeenCalledWith("claude_transcript", {
+      sessionId: CLAUDE_SESSION.sessionId,
+      limit: 150,
+    });
+  });
+
+  test("outputs session header line", async () => {
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "claude_session_list") return toolResult([CLAUDE_SESSION]);
+        return toolResult([]);
+      }),
+    });
+    await cmdAgent(["claude", "status", "ccc11111"], deps);
+    const output = logCalls(deps).join("\n");
+    expect(output).toContain("Alice");
+    expect(output).toContain("ccc11111");
+    expect(output).toContain("182 turns");
+  });
+
+  test("--json emits structured array", async () => {
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "claude_session_list") return toolResult([CLAUDE_SESSION]);
+        return toolResult([]);
+      }),
+    });
+    await cmdAgent(["claude", "status", "--json", "ccc11111"], deps);
+    const output = logCalls(deps).join("\n");
+    const parsed = JSON.parse(output);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed[0].sessionId).toBe(CLAUDE_SESSION.sessionId);
+    expect(parsed[0].status).toBeDefined();
+  });
+
+  test("comma-separated targets resolves both sessions", async () => {
+    const session2 = { ...CLAUDE_SESSION, sessionId: "ddd22222-aaaa-bbbb-cccc-dddddddddddd", name: "Bob" };
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "claude_session_list") return toolResult([CLAUDE_SESSION, session2]);
+        return toolResult([]);
+      }),
+    });
+    await cmdAgent(["claude", "status", "ccc11111,ddd22222"], deps);
+    const callArgs = (deps.callTool as ReturnType<typeof mock>).mock.calls;
+    const transcriptCalls = callArgs.filter((c) => c[0] === "claude_transcript");
+    expect(transcriptCalls).toHaveLength(2);
+  });
+
+  test("unknown target prints warning and exits non-zero when all unresolved", async () => {
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "claude_session_list") return toolResult([CLAUDE_SESSION]);
+        return toolResult([]);
+      }),
+    });
+    await expect(cmdAgent(["claude", "status", "zzzzzzz"], deps)).rejects.toThrow(ExitError);
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("zzzzzzz"));
+  });
+
+  test("partial resolution: warns on bad target, succeeds with good one", async () => {
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "claude_session_list") return toolResult([CLAUDE_SESSION]);
+        return toolResult([]);
+      }),
+    });
+    await cmdAgent(["claude", "status", "ccc11111,zzzzzzz"], deps);
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("zzzzzzz"));
+    // Should NOT exit non-zero since one resolved
+    const output = logCalls(deps).join("\n");
+    expect(output).toContain("ccc11111");
+  });
+
+  test("resolves by session name", async () => {
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "claude_session_list") return toolResult([CLAUDE_SESSION]);
+        return toolResult([]);
+      }),
+    });
+    await cmdAgent(["claude", "status", "Alice"], deps);
+    expect(deps.callTool).toHaveBeenCalledWith("claude_transcript", {
+      sessionId: CLAUDE_SESSION.sessionId,
+      limit: 150,
+    });
+  });
+
+  test("errors without target", async () => {
+    const deps = makeDeps();
+    await expect(cmdAgent(["claude", "status"], deps)).rejects.toThrow(ExitError);
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("Usage:"));
+  });
+});
+
 // ── OpenCode via agent ──
 
 describe("agent opencode spawn", () => {

--- a/packages/command/src/commands/agent.spec.ts
+++ b/packages/command/src/commands/agent.spec.ts
@@ -621,6 +621,31 @@ describe("agent claude status", () => {
     await expect(cmdAgent(["claude", "status"], deps)).rejects.toThrow(ExitError);
     expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("Usage:"));
   });
+
+  test("ambiguous name prints distinct error with candidates", async () => {
+    const session2 = { ...CLAUDE_SESSION, sessionId: "eee33333-aaaa-bbbb-cccc-dddddddddddd", name: "Alice" };
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "claude_session_list") return toolResult([CLAUDE_SESSION, session2]);
+        return toolResult([]);
+      }),
+    });
+    await expect(cmdAgent(["claude", "status", "Alice"], deps)).rejects.toThrow(ExitError);
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("Ambiguous"));
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("Alice"));
+  });
+
+  test("ambiguous UUID prefix prints distinct error with candidates", async () => {
+    const session2 = { ...CLAUDE_SESSION, sessionId: "ccc22222-aaaa-bbbb-cccc-dddddddddddd", name: "Bob" };
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "claude_session_list") return toolResult([CLAUDE_SESSION, session2]);
+        return toolResult([]);
+      }),
+    });
+    await expect(cmdAgent(["claude", "status", "ccc"], deps)).rejects.toThrow(ExitError);
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("Ambiguous"));
+  });
 });
 
 // ── OpenCode via agent ──

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -1548,7 +1548,12 @@ async function agentStatus(args: string[], provider: AgentProvider, d: AgentDeps
   let targets: string[] = [];
   for (const arg of r1) {
     if (!arg.startsWith("-")) {
-      targets = targets.concat(arg.split(",").filter(Boolean));
+      targets = targets.concat(
+        arg
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean),
+      );
     }
   }
 
@@ -1592,7 +1597,7 @@ async function agentStatus(args: string[], provider: AgentProvider, d: AgentDeps
     try {
       entries = JSON.parse(txText);
     } catch {
-      // empty transcript is fine
+      d.printError(`Warning: failed to parse transcript for session ${sessionId}`);
     }
     resolved.push({ session, entries });
   }

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -42,7 +42,14 @@ import {
   resolveSessionId,
   resolveWorktree,
 } from "./claude";
-import { colorState, extractContentSummary, formatAge, formatSessionShort } from "./session-display";
+import {
+  colorState,
+  extractContentSummary,
+  formatAge,
+  formatSessionShort,
+  formatStatusStanza,
+  walkTranscript,
+} from "./session-display";
 import { looksLikeToolName, parseSharedSpawnArgs } from "./spawn-args";
 import { ttyOpen } from "./tty";
 
@@ -347,9 +354,12 @@ export async function cmdAgent(args: string[], deps?: Partial<AgentDeps>): Promi
     case "deny":
       await agentDeny(subArgs, provider, d);
       break;
+    case "status":
+      await agentStatus(subArgs, provider, d);
+      break;
     default:
       d.printError(
-        `Unknown ${providerName} subcommand: ${sub}. Use "spawn", "ls", "send", "bye", "interrupt", "log", "wait", "resume", "approve", "deny", or "worktrees".`,
+        `Unknown ${providerName} subcommand: ${sub}. Use "spawn", "ls", "send", "bye", "interrupt", "log", "wait", "resume", "approve", "deny", "worktrees", or "status".`,
       );
       d.exit(1);
   }
@@ -1526,6 +1536,97 @@ async function agentDeny(args: string[], provider: AgentProvider, d: AgentDeps):
   if (message) toolArgs.message = message;
   const result = await d.callTool(`${P}_deny`, toolArgs);
   console.log(formatToolResult(result));
+}
+
+// ── Status ──
+
+async function agentStatus(args: string[], provider: AgentProvider, d: AgentDeps): Promise<void> {
+  const P = provider.toolPrefix;
+  const { json, rest: r1 } = extractJsonFlag(args);
+
+  // Collect comma-separated targets (may span multiple positional args)
+  let targets: string[] = [];
+  for (const arg of r1) {
+    if (!arg.startsWith("-")) {
+      targets = targets.concat(arg.split(",").filter(Boolean));
+    }
+  }
+
+  if (targets.length === 0) {
+    d.printError(`Usage: mcx agent ${provider.name} status <target>[,<target>...] [--json]`);
+    d.exit(1);
+    return;
+  }
+
+  // Fetch session list once, then resolve each target locally
+  const listResult = await d.callTool(`${P}_session_list`, {});
+  const listText = formatToolResult(listResult);
+  let allSessions: Array<Record<string, unknown>>;
+  try {
+    allSessions = JSON.parse(listText);
+  } catch {
+    d.printError("Failed to parse session list");
+    d.exit(1);
+    return;
+  }
+
+  const resolved: Array<{ session: Record<string, unknown>; entries: Array<Record<string, unknown>> }> = [];
+
+  for (const target of targets) {
+    const session = findSessionByTarget(allSessions, target);
+    if (!session) {
+      d.printError(`Warning: no session matching "${target}"`);
+      continue;
+    }
+    const sessionId = String(session.sessionId);
+    const txResult = await d.callTool(`${P}_transcript`, { sessionId, limit: 150 });
+    const txText = formatToolResult(txResult);
+    let entries: Array<Record<string, unknown>> = [];
+    try {
+      entries = JSON.parse(txText);
+    } catch {
+      // empty transcript is fine
+    }
+    resolved.push({ session, entries });
+  }
+
+  if (resolved.length === 0) {
+    d.exit(1);
+    return;
+  }
+
+  if (json) {
+    const output = resolved.map(({ session, entries }) => {
+      const stats = walkTranscript(entries as unknown as Parameters<typeof walkTranscript>[0]);
+      return { ...session, status: stats };
+    });
+    d.log(JSON.stringify(output, null, 2));
+    return;
+  }
+
+  for (let i = 0; i < resolved.length; i++) {
+    if (i > 0) d.log("");
+    const { session, entries } = resolved[i];
+    const stats = walkTranscript(entries as unknown as Parameters<typeof walkTranscript>[0]);
+    const lastTs =
+      entries.length > 0 ? ((entries[entries.length - 1] as { timestamp?: number }).timestamp ?? null) : null;
+    const lines = formatStatusStanza(session, stats, lastTs ?? null);
+    for (const line of lines) d.log(line);
+  }
+}
+
+/**
+ * Find a session by exact name (case-insensitive) or UUID prefix.
+ * Returns null if not found or ambiguous.
+ */
+function findSessionByTarget(sessions: Array<Record<string, unknown>>, target: string): Record<string, unknown> | null {
+  const lower = target.toLowerCase();
+  const nameMatches = sessions.filter((s) => typeof s.name === "string" && s.name.toLowerCase() === lower);
+  if (nameMatches.length === 1) return nameMatches[0];
+
+  const idMatches = sessions.filter((s) => typeof s.sessionId === "string" && s.sessionId.startsWith(target));
+  if (idMatches.length === 1) return idMatches[0];
+  return null;
 }
 
 function printAgentUsage(log: ((...args: unknown[]) => void) | undefined = console.log): void {

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -1700,6 +1700,7 @@ Usage:
   mcx agent ${name} approve <session> [req-id]  Approve pending permission request
   mcx agent ${name} deny <session> [req-id]     Deny pending permission request
   mcx agent ${name} worktrees [--prune]          List mcx-created worktrees
+  mcx agent ${name} status <target> [--json]     One-shot session inspector
 
 Run "mcx agent ${name} spawn --help" for spawn options.`);
 }

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -1563,7 +1563,9 @@ async function agentStatus(args: string[], provider: AgentProvider, d: AgentDeps
   const listText = formatToolResult(listResult);
   let allSessions: Array<Record<string, unknown>>;
   try {
-    allSessions = JSON.parse(listText);
+    const parsed: unknown = JSON.parse(listText);
+    if (!Array.isArray(parsed)) throw new Error("expected array");
+    allSessions = parsed as Array<Record<string, unknown>>;
   } catch {
     d.printError("Failed to parse session list");
     d.exit(1);
@@ -1573,11 +1575,16 @@ async function agentStatus(args: string[], provider: AgentProvider, d: AgentDeps
   const resolved: Array<{ session: Record<string, unknown>; entries: Array<Record<string, unknown>> }> = [];
 
   for (const target of targets) {
-    const session = findSessionByTarget(allSessions, target);
-    if (!session) {
-      d.printError(`Warning: no session matching "${target}"`);
+    const lookup = findSessionByTarget(allSessions, target);
+    if (!lookup.found) {
+      if (lookup.ambiguous) {
+        d.printError(`Ambiguous target "${target}": matches ${lookup.candidates.join(", ")}`);
+      } else {
+        d.printError(`Warning: no session matching "${target}"`);
+      }
       continue;
     }
+    const session = lookup.session;
     const sessionId = String(session.sessionId);
     const txResult = await d.callTool(`${P}_transcript`, { sessionId, limit: 150 });
     const txText = formatToolResult(txResult);
@@ -1615,18 +1622,29 @@ async function agentStatus(args: string[], provider: AgentProvider, d: AgentDeps
   }
 }
 
-/**
- * Find a session by exact name (case-insensitive) or UUID prefix.
- * Returns null if not found or ambiguous.
- */
-function findSessionByTarget(sessions: Array<Record<string, unknown>>, target: string): Record<string, unknown> | null {
+type SessionLookup =
+  | { found: true; session: Record<string, unknown> }
+  | { found: false; ambiguous: false }
+  | { found: false; ambiguous: true; candidates: string[] };
+
+/** Find a session by exact name (case-insensitive) or UUID prefix. */
+function findSessionByTarget(sessions: Array<Record<string, unknown>>, target: string): SessionLookup {
   const lower = target.toLowerCase();
   const nameMatches = sessions.filter((s) => typeof s.name === "string" && s.name.toLowerCase() === lower);
-  if (nameMatches.length === 1) return nameMatches[0];
+  if (nameMatches.length === 1) return { found: true, session: nameMatches[0] };
+  if (nameMatches.length > 1) {
+    const candidates = nameMatches.map((s) => `${s.name} (${String(s.sessionId).slice(0, 8)})`);
+    return { found: false, ambiguous: true, candidates };
+  }
 
   const idMatches = sessions.filter((s) => typeof s.sessionId === "string" && s.sessionId.startsWith(target));
-  if (idMatches.length === 1) return idMatches[0];
-  return null;
+  if (idMatches.length === 1) return { found: true, session: idMatches[0] };
+  if (idMatches.length > 1) {
+    const candidates = idMatches.map((s) => String(s.sessionId).slice(0, 8));
+    return { found: false, ambiguous: true, candidates };
+  }
+
+  return { found: false, ambiguous: false };
 }
 
 function printAgentUsage(log: ((...args: unknown[]) => void) | undefined = console.log): void {

--- a/packages/command/src/commands/session-display.spec.ts
+++ b/packages/command/src/commands/session-display.spec.ts
@@ -7,8 +7,10 @@ import {
   filterByRepo,
   formatAge,
   formatCost,
+  formatElapsed,
   formatLifecycleLine,
   formatSessionShort,
+  walkTranscript,
 } from "./session-display";
 
 describe("estimateCost", () => {
@@ -245,6 +247,159 @@ function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
     ...overrides,
   };
 }
+
+describe("formatElapsed", () => {
+  test("formats seconds as MM:SS", () => {
+    expect(formatElapsed(90_000)).toBe("1:30");
+    expect(formatElapsed(5_000)).toBe("0:05");
+  });
+
+  test("formats hours as HH:MM:SS", () => {
+    expect(formatElapsed(3_661_000)).toBe("1:01:01");
+  });
+});
+
+describe("walkTranscript", () => {
+  function makeUserMsg(text: string): TranscriptEntry {
+    return {
+      timestamp: Date.now(),
+      direction: "outbound",
+      message: {
+        type: "user",
+        message: { content: [{ type: "text", text }] },
+      },
+    };
+  }
+
+  function makeAssistantMsg(content: unknown[]): TranscriptEntry {
+    return {
+      timestamp: Date.now(),
+      direction: "inbound",
+      message: { type: "assistant", message: { content } },
+    };
+  }
+
+  function makeToolUse(name: string, input: Record<string, unknown>): Record<string, unknown> {
+    return { type: "tool_use", id: "tu1", name, input };
+  }
+
+  test("extracts last user prompt", () => {
+    const entries = [makeUserMsg("first"), makeUserMsg("second")];
+    const stats = walkTranscript(entries);
+    expect(stats.lastPrompt).toBe("second");
+  });
+
+  test("skips prompts with only tool_result blocks", () => {
+    const entries: TranscriptEntry[] = [
+      makeUserMsg("the real prompt"),
+      {
+        timestamp: Date.now(),
+        direction: "outbound",
+        message: {
+          type: "user",
+          message: { content: [{ type: "tool_result", tool_use_id: "x", content: "some output" }] },
+        },
+      },
+    ];
+    const stats = walkTranscript(entries);
+    expect(stats.lastPrompt).toBe("the real prompt");
+  });
+
+  test("extracts last assistant text as lastResult", () => {
+    const entries = [
+      makeAssistantMsg([{ type: "text", text: "first response" }]),
+      makeAssistantMsg([{ type: "text", text: "second response" }]),
+    ];
+    const stats = walkTranscript(entries);
+    expect(stats.lastResult).toBe("second response");
+  });
+
+  test("extracts lastResult from result type message", () => {
+    const entries: TranscriptEntry[] = [
+      {
+        timestamp: Date.now(),
+        direction: "inbound",
+        message: { type: "result", result: "Done! All tests pass." },
+      },
+    ];
+    const stats = walkTranscript(entries);
+    expect(stats.lastResult).toBe("Done! All tests pass.");
+  });
+
+  test("aggregates Read tool calls into directory footprint", () => {
+    const entries = [
+      makeAssistantMsg([makeToolUse("Read", { file_path: "/src/foo.ts" })]),
+      makeAssistantMsg([makeToolUse("Read", { file_path: "/src/bar.ts" })]),
+      makeAssistantMsg([makeToolUse("Read", { file_path: "/lib/baz.ts" })]),
+    ];
+    const stats = walkTranscript(entries);
+    const src = stats.directoryFootprint.find((e) => e.dir === "/src");
+    expect(src?.reads).toBe(2);
+    expect(src?.writes).toBe(0);
+    const lib = stats.directoryFootprint.find((e) => e.dir === "/lib");
+    expect(lib?.reads).toBe(1);
+  });
+
+  test("aggregates Write/Edit into directory footprint writes", () => {
+    const entries = [
+      makeAssistantMsg([makeToolUse("Write", { file_path: "/src/foo.ts", content: "x" })]),
+      makeAssistantMsg([makeToolUse("Edit", { file_path: "/src/bar.ts", old_string: "a", new_string: "b" })]),
+    ];
+    const stats = walkTranscript(entries);
+    const src = stats.directoryFootprint.find((e) => e.dir === "/src");
+    expect(src?.writes).toBe(2);
+    expect(src?.reads).toBe(0);
+  });
+
+  test("aggregates Bash commands by first token", () => {
+    const entries = [
+      makeAssistantMsg([makeToolUse("Bash", { command: "bun test foo.spec.ts" })]),
+      makeAssistantMsg([makeToolUse("Bash", { command: "bun test bar.spec.ts" })]),
+      makeAssistantMsg([makeToolUse("Bash", { command: "git status" })]),
+    ];
+    const stats = walkTranscript(entries);
+    const bun = stats.commandSummary.find((e) => e.cmd === "bun");
+    expect(bun?.count).toBe(2);
+    const git = stats.commandSummary.find((e) => e.cmd === "git");
+    expect(git?.count).toBe(1);
+  });
+
+  test("collects last N Grep/Glob queries", () => {
+    const entries = [
+      makeAssistantMsg([makeToolUse("Grep", { pattern: "foo", path: "/src" })]),
+      makeAssistantMsg([makeToolUse("Glob", { pattern: "**/*.ts" })]),
+      makeAssistantMsg([makeToolUse("Grep", { pattern: "bar" })]),
+      makeAssistantMsg([makeToolUse("Grep", { pattern: "baz" })]),
+    ];
+    const stats = walkTranscript(entries, 3);
+    expect(stats.lastQueries).toHaveLength(3);
+    expect(stats.lastQueries[0].pattern).toBe("**/*.ts");
+    expect(stats.lastQueries[1].pattern).toBe("bar");
+    expect(stats.lastQueries[2].pattern).toBe("baz");
+  });
+
+  test("sorts footprint by total activity descending", () => {
+    const entries = [
+      makeAssistantMsg([makeToolUse("Read", { file_path: "/a/f.ts" })]),
+      makeAssistantMsg([makeToolUse("Read", { file_path: "/b/f.ts" })]),
+      makeAssistantMsg([makeToolUse("Read", { file_path: "/b/g.ts" })]),
+      makeAssistantMsg([makeToolUse("Write", { file_path: "/b/h.ts", content: "" })]),
+    ];
+    const stats = walkTranscript(entries);
+    expect(stats.directoryFootprint[0].dir).toBe("/b");
+    expect(stats.directoryFootprint[0].reads).toBe(2);
+    expect(stats.directoryFootprint[0].writes).toBe(1);
+  });
+
+  test("returns empty stats for empty transcript", () => {
+    const stats = walkTranscript([]);
+    expect(stats.lastPrompt).toBeNull();
+    expect(stats.lastResult).toBeNull();
+    expect(stats.directoryFootprint).toHaveLength(0);
+    expect(stats.commandSummary).toHaveLength(0);
+    expect(stats.lastQueries).toHaveLength(0);
+  });
+});
 
 describe("formatLifecycleLine", () => {
   test("impl phase with no PR", () => {

--- a/packages/command/src/commands/session-display.spec.ts
+++ b/packages/command/src/commands/session-display.spec.ts
@@ -462,6 +462,17 @@ describe("walkTranscript", () => {
     expect(bun?.count).toBe(2);
     expect(bun?.lastOutput).toBe("PASS");
   });
+
+  test("empty Bash command string falls back to 'bash' key", () => {
+    const entries: TranscriptEntry[] = [
+      makeAssistantMsg([{ type: "tool_use", id: "b1", name: "Bash", input: { command: "" } }]),
+      makeAssistantMsg([{ type: "tool_use", id: "b2", name: "Bash", input: { command: "   " } }]),
+    ];
+    const stats = walkTranscript(entries);
+    const bash = stats.commandSummary.find((e) => e.cmd === "bash");
+    expect(bash).toBeDefined();
+    expect(bash?.count).toBe(2);
+  });
 });
 
 describe("formatLifecycleLine", () => {

--- a/packages/command/src/commands/session-display.spec.ts
+++ b/packages/command/src/commands/session-display.spec.ts
@@ -473,6 +473,15 @@ describe("walkTranscript", () => {
     expect(bash).toBeDefined();
     expect(bash?.count).toBe(2);
   });
+
+  test("lastQueryCount=0 returns empty lastQueries", () => {
+    const entries: TranscriptEntry[] = [
+      makeAssistantMsg([{ type: "tool_use", id: "g1", name: "Grep", input: { pattern: "foo" } }]),
+      makeAssistantMsg([{ type: "tool_use", id: "g2", name: "Glob", input: { pattern: "*.ts" } }]),
+    ];
+    const stats = walkTranscript(entries, 0);
+    expect(stats.lastQueries).toHaveLength(0);
+  });
 });
 
 describe("formatLifecycleLine", () => {

--- a/packages/command/src/commands/session-display.spec.ts
+++ b/packages/command/src/commands/session-display.spec.ts
@@ -399,6 +399,69 @@ describe("walkTranscript", () => {
     expect(stats.commandSummary).toHaveLength(0);
     expect(stats.lastQueries).toHaveLength(0);
   });
+
+  test("attributes Bash lastOutput by tool_use_id, not first-null heuristic", () => {
+    // Interleaved: bun → result, Read → result, git → result
+    // Verify bun gets its own output and git gets its own output (not crossed)
+    const entries: TranscriptEntry[] = [
+      makeAssistantMsg([{ type: "tool_use", id: "bash-1", name: "Bash", input: { command: "bun test foo.spec.ts" } }]),
+      {
+        timestamp: Date.now(),
+        direction: "outbound",
+        message: {
+          type: "user",
+          message: { content: [{ type: "tool_result", tool_use_id: "bash-1", content: "PASS 10 tests" }] },
+        },
+      },
+      makeAssistantMsg([{ type: "tool_use", id: "read-1", name: "Read", input: { file_path: "/src/foo.ts" } }]),
+      {
+        timestamp: Date.now(),
+        direction: "outbound",
+        message: {
+          type: "user",
+          message: { content: [{ type: "tool_result", tool_use_id: "read-1", content: "file contents" }] },
+        },
+      },
+      makeAssistantMsg([{ type: "tool_use", id: "bash-2", name: "Bash", input: { command: "git status" } }]),
+      {
+        timestamp: Date.now(),
+        direction: "outbound",
+        message: {
+          type: "user",
+          message: { content: [{ type: "tool_result", tool_use_id: "bash-2", content: "On branch main" }] },
+        },
+      },
+    ];
+    const stats = walkTranscript(entries);
+    const bun = stats.commandSummary.find((e) => e.cmd === "bun");
+    const git = stats.commandSummary.find((e) => e.cmd === "git");
+    expect(bun?.lastOutput).toBe("PASS 10 tests");
+    expect(git?.lastOutput).toBe("On branch main");
+    // Non-Bash tool_result must not bleed into any Bash command
+    expect(bun?.lastOutput).not.toContain("file contents");
+    expect(git?.lastOutput).not.toContain("file contents");
+  });
+
+  test("later Bash result overwrites lastOutput for same command key", () => {
+    const entries: TranscriptEntry[] = [
+      makeAssistantMsg([{ type: "tool_use", id: "b1", name: "Bash", input: { command: "bun test" } }]),
+      {
+        timestamp: Date.now(),
+        direction: "outbound",
+        message: { type: "user", message: { content: [{ type: "tool_result", tool_use_id: "b1", content: "FAIL" }] } },
+      },
+      makeAssistantMsg([{ type: "tool_use", id: "b2", name: "Bash", input: { command: "bun test" } }]),
+      {
+        timestamp: Date.now(),
+        direction: "outbound",
+        message: { type: "user", message: { content: [{ type: "tool_result", tool_use_id: "b2", content: "PASS" }] } },
+      },
+    ];
+    const stats = walkTranscript(entries);
+    const bun = stats.commandSummary.find((e) => e.cmd === "bun");
+    expect(bun?.count).toBe(2);
+    expect(bun?.lastOutput).toBe("PASS");
+  });
 });
 
 describe("formatLifecycleLine", () => {

--- a/packages/command/src/commands/session-display.ts
+++ b/packages/command/src/commands/session-display.ts
@@ -48,6 +48,8 @@ export function walkTranscript(entries: TranscriptEntry[], lastQueryCount = 3): 
   const dirReads = new Map<string, number>();
   const dirWrites = new Map<string, number>();
   const cmdMap = new Map<string, { count: number; lastOutput: string | null }>();
+  // Maps tool_use_id → cmdMap key so tool_results can be attributed to the right command
+  const bashToolUseIds = new Map<string, string>();
   const queries: QueryEntry[] = [];
 
   for (const entry of entries) {
@@ -97,6 +99,7 @@ export function walkTranscript(entries: TranscriptEntry[], lastQueryCount = 3): 
             const firstToken = input.command.trim().split(/\s+/)[0] ?? "bash";
             const existing = cmdMap.get(firstToken);
             cmdMap.set(firstToken, { count: (existing?.count ?? 0) + 1, lastOutput: existing?.lastOutput ?? null });
+            if (typeof b.id === "string") bashToolUseIds.set(b.id, firstToken);
           } else if ((name === "Grep" || name === "Glob") && typeof input.pattern === "string") {
             const q: QueryEntry = { tool: name, pattern: input.pattern };
             if (typeof input.path === "string") q.path = input.path;
@@ -106,20 +109,18 @@ export function walkTranscript(entries: TranscriptEntry[], lastQueryCount = 3): 
       }
     }
 
-    // Capture Bash tool results to attach to last command invocation
+    // Capture Bash tool results: match by tool_use_id to attribute to the right command
     if (entry.direction === "outbound" && type === "user" && entry.message.message) {
       const msg = entry.message.message as { content?: unknown };
       if (Array.isArray(msg.content)) {
         for (const block of msg.content) {
           if (!block || typeof block !== "object") continue;
           const b = block as Record<string, unknown>;
-          if (b.type !== "tool_result" || typeof b.content !== "string") continue;
-          // Find the last command that has no lastOutput yet and attach this result
-          for (const [cmd, entry_] of cmdMap) {
-            if (entry_.lastOutput === null) {
-              const trimmed = b.content.trim().slice(0, 200);
-              cmdMap.set(cmd, { ...entry_, lastOutput: trimmed });
-            }
+          if (b.type !== "tool_result" || typeof b.tool_use_id !== "string") continue;
+          const cmdKey = bashToolUseIds.get(b.tool_use_id);
+          if (cmdKey && typeof b.content === "string") {
+            const existing = cmdMap.get(cmdKey);
+            if (existing) cmdMap.set(cmdKey, { ...existing, lastOutput: b.content.trim().slice(0, 200) });
           }
         }
       }

--- a/packages/command/src/commands/session-display.ts
+++ b/packages/command/src/commands/session-display.ts
@@ -147,7 +147,7 @@ export function walkTranscript(entries: TranscriptEntry[], lastQueryCount = 3): 
     lastResult,
     directoryFootprint: footprint,
     commandSummary,
-    lastQueries: queries.slice(-lastQueryCount),
+    lastQueries: lastQueryCount === 0 ? [] : queries.slice(-lastQueryCount),
   };
 }
 
@@ -238,7 +238,7 @@ export function formatStatusStanza(
     lines.push("");
     lines.push("Command summary:");
     for (const { cmd, count, lastOutput } of stats.commandSummary) {
-      const last = lastOutput ? `  (last: ${lastOutput.slice(0, 60)}…)` : "";
+      const last = lastOutput ? `  (last: ${lastOutput.length > 60 ? `${lastOutput.slice(0, 60)}…` : lastOutput})` : "";
       lines.push(`  ${cmd.padEnd(20)} ${count} ${count === 1 ? "run" : "runs"}${last}`);
     }
   }

--- a/packages/command/src/commands/session-display.ts
+++ b/packages/command/src/commands/session-display.ts
@@ -6,6 +6,255 @@ import { dirname, resolve } from "node:path";
 import type { WorkItem } from "@mcp-cli/core";
 import { c } from "../output";
 
+// ── Transcript walker ──
+
+export interface DirectoryEntry {
+  dir: string;
+  reads: number;
+  writes: number;
+}
+
+export interface CommandEntry {
+  cmd: string;
+  count: number;
+  lastOutput: string | null;
+}
+
+export interface QueryEntry {
+  tool: string;
+  pattern: string;
+  path?: string;
+}
+
+export interface TranscriptStats {
+  lastPrompt: string | null;
+  lastResult: string | null;
+  directoryFootprint: DirectoryEntry[];
+  commandSummary: CommandEntry[];
+  lastQueries: QueryEntry[];
+}
+
+/**
+ * Walk transcript entries and extract derived metrics:
+ * - last user prompt text
+ * - last assistant/result text
+ * - directory footprint (Read/Edit/Write tool calls aggregated by dirname)
+ * - command summary (Bash tool calls aggregated by first token)
+ * - last N Grep/Glob queries
+ */
+export function walkTranscript(entries: TranscriptEntry[], lastQueryCount = 3): TranscriptStats {
+  let lastPrompt: string | null = null;
+  let lastResult: string | null = null;
+  const dirReads = new Map<string, number>();
+  const dirWrites = new Map<string, number>();
+  const cmdMap = new Map<string, { count: number; lastOutput: string | null }>();
+  const queries: QueryEntry[] = [];
+
+  for (const entry of entries) {
+    const type = entry.message.type;
+
+    // Last user prompt: outbound user message with text content (not tool results)
+    if (entry.direction === "outbound" && type === "user" && entry.message.message) {
+      const msg = entry.message.message as { content?: unknown };
+      const text = extractTextOnly(msg.content);
+      if (text) lastPrompt = text;
+    }
+
+    // Last result: inbound assistant message with text, or result message
+    if (entry.direction === "inbound") {
+      if (type === "assistant" && entry.message.message) {
+        const msg = entry.message.message as { content?: unknown };
+        const text = extractTextOnly(msg.content);
+        if (text) lastResult = text;
+      } else if (type === "result") {
+        const res = entry.message as { result?: string };
+        if (res.result) lastResult = res.result;
+      }
+    }
+
+    // Tool use: only in assistant messages
+    if (type === "assistant" && entry.message.message) {
+      const msg = entry.message.message as { content?: unknown };
+      if (Array.isArray(msg.content)) {
+        for (const block of msg.content) {
+          if (!block || typeof block !== "object") continue;
+          const b = block as Record<string, unknown>;
+          if (b.type !== "tool_use" || typeof b.name !== "string") continue;
+          const input = (b.input ?? {}) as Record<string, unknown>;
+
+          const name = b.name;
+
+          if (name === "Read" && typeof input.file_path === "string") {
+            const d = dirname(input.file_path);
+            dirReads.set(d, (dirReads.get(d) ?? 0) + 1);
+          } else if (
+            (name === "Edit" || name === "Write" || name === "MultiEdit") &&
+            typeof input.file_path === "string"
+          ) {
+            const d = dirname(input.file_path);
+            dirWrites.set(d, (dirWrites.get(d) ?? 0) + 1);
+          } else if (name === "Bash" && typeof input.command === "string") {
+            const firstToken = input.command.trim().split(/\s+/)[0] ?? "bash";
+            const existing = cmdMap.get(firstToken);
+            cmdMap.set(firstToken, { count: (existing?.count ?? 0) + 1, lastOutput: existing?.lastOutput ?? null });
+          } else if ((name === "Grep" || name === "Glob") && typeof input.pattern === "string") {
+            const q: QueryEntry = { tool: name, pattern: input.pattern };
+            if (typeof input.path === "string") q.path = input.path;
+            queries.push(q);
+          }
+        }
+      }
+    }
+
+    // Capture Bash tool results to attach to last command invocation
+    if (entry.direction === "outbound" && type === "user" && entry.message.message) {
+      const msg = entry.message.message as { content?: unknown };
+      if (Array.isArray(msg.content)) {
+        for (const block of msg.content) {
+          if (!block || typeof block !== "object") continue;
+          const b = block as Record<string, unknown>;
+          if (b.type !== "tool_result" || typeof b.content !== "string") continue;
+          // Find the last command that has no lastOutput yet and attach this result
+          for (const [cmd, entry_] of cmdMap) {
+            if (entry_.lastOutput === null) {
+              const trimmed = b.content.trim().slice(0, 200);
+              cmdMap.set(cmd, { ...entry_, lastOutput: trimmed });
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // Build directory footprint: merge reads + writes, sort by total activity desc
+  const allDirs = new Set([...dirReads.keys(), ...dirWrites.keys()]);
+  const footprint: DirectoryEntry[] = [];
+  for (const dir of allDirs) {
+    footprint.push({ dir, reads: dirReads.get(dir) ?? 0, writes: dirWrites.get(dir) ?? 0 });
+  }
+  footprint.sort((a, b) => b.reads + b.writes - (a.reads + a.writes));
+
+  // Command summary sorted by count desc
+  const commandSummary: CommandEntry[] = [];
+  for (const [cmd, { count, lastOutput }] of cmdMap) {
+    commandSummary.push({ cmd, count, lastOutput });
+  }
+  commandSummary.sort((a, b) => b.count - a.count);
+
+  return {
+    lastPrompt,
+    lastResult,
+    directoryFootprint: footprint,
+    commandSummary,
+    lastQueries: queries.slice(-lastQueryCount),
+  };
+}
+
+/** Extract only text blocks from content (skipping tool_use / tool_result). */
+function extractTextOnly(content: unknown): string | null {
+  if (typeof content === "string") return content.trim() || null;
+  if (!Array.isArray(content)) return null;
+  const parts: string[] = [];
+  for (const block of content) {
+    if (typeof block === "string") {
+      parts.push(block);
+    } else if (block && typeof block === "object") {
+      const b = block as Record<string, unknown>;
+      if (b.type === "text" && typeof b.text === "string") {
+        parts.push(b.text);
+      }
+      // skip tool_use / tool_result
+    }
+  }
+  const joined = parts.join(" ").trim();
+  return joined || null;
+}
+
+/** Format elapsed milliseconds as "HH:MM" or "MM:SS". */
+export function formatElapsed(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  if (h > 0) return `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+/**
+ * Format a session status stanza for human display.
+ * Returns lines to be printed (caller does d.log on each).
+ */
+export function formatStatusStanza(
+  session: Record<string, unknown>,
+  stats: TranscriptStats,
+  lastEntryTs: number | null,
+  now = Date.now(),
+): string[] {
+  const lines: string[] = [];
+
+  // Header: Alice (dca8b240) — idle 04:23 — $13.83 / 182 turns
+  const id = String(session.sessionId ?? "").slice(0, 8);
+  const name = typeof session.name === "string" && session.name ? session.name : null;
+  const sessionLabel = name ? `${c.bold}${name}${c.reset} (${c.cyan}${id}${c.reset})` : `${c.cyan}${id}${c.reset}`;
+  const state = String(session.state ?? "unknown");
+  const idleStr = lastEntryTs != null ? ` ${formatElapsed(now - lastEntryTs)}` : "";
+  const stateStr = `${colorState(state)}${idleStr}`;
+  const costStr = typeof session.cost === "number" && session.cost > 0 ? `$${session.cost.toFixed(2)}` : null;
+  const turns = typeof session.numTurns === "number" ? session.numTurns : null;
+  const metricParts: string[] = [];
+  if (costStr) metricParts.push(costStr);
+  if (turns != null) metricParts.push(`${turns} turns`);
+  const metrics = metricParts.length > 0 ? ` — ${metricParts.join(" / ")}` : "";
+  lines.push(`${sessionLabel} — ${stateStr}${metrics}`);
+
+  // Last prompt / result
+  if (stats.lastPrompt) {
+    const p = stats.lastPrompt.length > 120 ? `${stats.lastPrompt.slice(0, 120)}…` : stats.lastPrompt;
+    lines.push(`Last prompt: ${c.dim}"${p}"${c.reset}`);
+  }
+  if (stats.lastResult) {
+    const r = stats.lastResult.length > 120 ? `${stats.lastResult.slice(0, 120)}…` : stats.lastResult;
+    lines.push(`Last result:  ${c.dim}"${r}"${c.reset}`);
+  }
+
+  // Directory footprint
+  if (stats.directoryFootprint.length > 0) {
+    lines.push("");
+    lines.push("Directory footprint (read / write):");
+    const maxDir = Math.min(stats.directoryFootprint.length, 6);
+    const dirColWidth = Math.max(...stats.directoryFootprint.slice(0, maxDir).map((e) => e.dir.length), 10) + 2;
+    for (let i = 0; i < maxDir; i++) {
+      const { dir, reads, writes } = stats.directoryFootprint[i];
+      const r = reads > 0 ? `read ${reads}` : "";
+      const w = writes > 0 ? `wrote ${writes}` : "";
+      const rw = [r, w].filter(Boolean).join("  ");
+      lines.push(`  ${dir.padEnd(dirColWidth)} ${rw}`);
+    }
+  }
+
+  // Command summary
+  if (stats.commandSummary.length > 0) {
+    lines.push("");
+    lines.push("Command summary:");
+    for (const { cmd, count, lastOutput } of stats.commandSummary) {
+      const last = lastOutput ? `  (last: ${lastOutput.slice(0, 60)}…)` : "";
+      lines.push(`  ${cmd.padEnd(20)} ${count} ${count === 1 ? "run" : "runs"}${last}`);
+    }
+  }
+
+  // Last queries
+  if (stats.lastQueries.length > 0) {
+    lines.push("");
+    lines.push(`Last ${stats.lastQueries.length} quer${stats.lastQueries.length === 1 ? "y" : "ies"}:`);
+    for (const { tool, pattern, path } of stats.lastQueries) {
+      const pathSuffix = path ? ` ${path}` : "";
+      lines.push(`  ${tool.toLowerCase()} ${c.dim}"${pattern}"${pathSuffix}${c.reset}`);
+    }
+  }
+
+  return lines;
+}
+
 /** Transcript entry shape shared across providers. */
 export interface TranscriptEntry {
   timestamp: number;

--- a/packages/command/src/commands/session-display.ts
+++ b/packages/command/src/commands/session-display.ts
@@ -96,7 +96,7 @@ export function walkTranscript(entries: TranscriptEntry[], lastQueryCount = 3): 
             const d = dirname(input.file_path);
             dirWrites.set(d, (dirWrites.get(d) ?? 0) + 1);
           } else if (name === "Bash" && typeof input.command === "string") {
-            const firstToken = input.command.trim().split(/\s+/)[0] ?? "bash";
+            const firstToken = input.command.trim().split(/\s+/)[0] || "bash";
             const existing = cmdMap.get(firstToken);
             cmdMap.set(firstToken, { count: (existing?.count ?? 0) + 1, lastOutput: existing?.lastOutput ?? null });
             if (typeof b.id === "string") bashToolUseIds.set(b.id, firstToken);
@@ -171,7 +171,7 @@ function extractTextOnly(content: unknown): string | null {
   return joined || null;
 }
 
-/** Format elapsed milliseconds as "HH:MM" or "MM:SS". */
+/** Format elapsed milliseconds as "H:MM:SS" or "M:SS". */
 export function formatElapsed(ms: number): string {
   const totalSec = Math.floor(ms / 1000);
   const h = Math.floor(totalSec / 3600);


### PR DESCRIPTION
## Summary

- Adds `mcx agent claude status <target>[,<target>...]` (and `mcx claude status`) for one-shot session inspection that combines state, cost/turns, and transcript-derived metrics
- Transcript walker in `session-display.ts` extracts: last user prompt, last assistant result, directory footprint (Read/Edit/Write calls by dirname), command summary (Bash calls by first token), and last N Grep/Glob queries
- Batch semantics: comma-separated targets, warns on unresolvable, exits 0 if at least one resolved; `--json` mode emits a structured array for scripting

## Test plan

- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — 6428 pass, 0 fail
- [x] `walkTranscript` unit tests cover: Read/Edit/Write footprint aggregation, Bash command summary, Grep/Glob query collection, last prompt/result extraction, empty transcript
- [x] `agentStatus` tests cover: session list + transcript calls, header output, `--json` mode, comma-separated batch resolution, unknown target warning + non-zero exit, partial resolution, name-based lookup, missing target error

🤖 Generated with [Claude Code](https://claude.com/claude-code)