### PR TITLE
feat(claude): claude-binary override + lower-bound patcher matcher

### DIFF
--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -215,7 +215,17 @@ export const defaultDeps: ClaudeDeps = {
 // ── Entry point ──
 
 /**
- * `mcx claude` — thin alias that routes to `mcx agent claude`.
+ * Subcommands that exist only on `mcx claude`, not in the generic agent
+ * dispatcher. These must be handled by `cmdClaudeInternal` directly —
+ * forwarding them to `cmdAgent` produces an "Unknown subcommand" error
+ * because the agent dispatcher only knows the cross-provider verbs.
+ */
+const CLAUDE_ONLY_SUBCOMMANDS: ReadonlySet<string> = new Set(["patch-update"]);
+
+/**
+ * `mcx claude` — thin alias that routes to `mcx agent claude` for shared
+ * subcommands (spawn/ls/send/...), and dispatches claude-only subcommands
+ * (patch-update) through the internal handler.
  *
  * Kept as a top-level command because orchestration workflows, memory files,
  * and CLAUDE.md all reference `mcx claude` directly.
@@ -231,8 +241,7 @@ export async function cmdClaude(args: string[], deps?: Partial<ClaudeDeps>): Pro
     return;
   }
 
-  if (deps) {
-    // Direct dispatch for testing with injected deps
+  if (deps || CLAUDE_ONLY_SUBCOMMANDS.has(sub)) {
     await cmdClaudeInternal(args, deps);
     return;
   }

--- a/packages/command/src/commands/config.ts
+++ b/packages/command/src/commands/config.ts
@@ -87,13 +87,14 @@ async function configSources(deps: ConfigDeps): Promise<void> {
 
 // -- CLI option keys --
 
-const VALID_KEYS = ["trust-claude", "terminal", "ws-port"] as const;
+const VALID_KEYS = ["trust-claude", "terminal", "ws-port", "claude-binary"] as const;
 type ConfigKey = (typeof VALID_KEYS)[number];
 
-const KEY_MAP: Record<ConfigKey, "trustClaude" | "terminal" | "wsPort"> = {
+const KEY_MAP: Record<ConfigKey, "trustClaude" | "terminal" | "wsPort" | "claudeBinary"> = {
   "trust-claude": "trustClaude",
   terminal: "terminal",
   "ws-port": "wsPort",
+  "claude-binary": "claudeBinary",
 };
 
 /** Keys whose values are stored as booleans (vs strings) */

--- a/packages/core/src/claude-patch/patcher.spec.ts
+++ b/packages/core/src/claude-patch/patcher.spec.ts
@@ -15,6 +15,17 @@ import {
 } from "./patcher";
 import type { PatcherDeps } from "./patcher";
 
+/** Unset an env var properly (assigning undefined would coerce to string "undefined"). */
+function unsetEnv(key: string): void {
+  delete process.env[key];
+}
+
+/** Restore an env var captured by `process.env.X` to its original state. */
+function restoreEnv(key: string, prev: string | undefined): void {
+  if (prev === undefined) unsetEnv(key);
+  else process.env[key] = prev;
+}
+
 const enc = new TextEncoder();
 
 function makeFakeDeps(overrides: Partial<PatcherDeps> = {}): PatcherDeps {
@@ -132,10 +143,15 @@ describe("updatePatchedClaude", () => {
   });
 
   test("unsupported version returns unsupported outcome", async () => {
+    // The built-in registry has no gaps (noop covers <2.1.120, ipv6-loopback
+    // covers everything from 2.1.120 onward), so to exercise the "unsupported"
+    // path we inject an empty strategy registry. This still validates the
+    // patcher's failure mode for the real-world case where a future claude
+    // release ships a check that no registered strategy can handle.
     const sourcePath = makeFakeClaudeBinary(tmpDir, "9.9.9");
     const result = await updatePatchedClaude(
       { sourcePath, storeDir },
-      makeFakeDeps({ versionResolver: async () => "9.9.9" }),
+      makeFakeDeps({ versionResolver: async () => "9.9.9", strategies: [] }),
     );
     expect(result.status).toBe("unsupported");
     if (result.status !== "unsupported") throw new Error("typeguard");
@@ -276,8 +292,104 @@ describe("default subprocess wrappers", () => {
     // Either claude is on PATH (returns abs path) or it's not (returns null).
     // Both branches are valid; we only care that the function runs without throwing
     // and returns one of the two expected shapes.
-    const result = resolveSourceClaudePath();
-    expect(result === null || (typeof result === "string" && result.length > 0)).toBe(true);
+    const prev = process.env.MCX_CLAUDE_BINARY;
+    unsetEnv("MCX_CLAUDE_BINARY");
+    try {
+      const result = resolveSourceClaudePath();
+      expect(result === null || (typeof result === "string" && result.length > 0)).toBe(true);
+    } finally {
+      restoreEnv("MCX_CLAUDE_BINARY", prev);
+    }
+  });
+
+  test("resolveSourceClaudePath honors MCX_CLAUDE_BINARY when the file exists", () => {
+    // Use bun's own binary as the override target — guaranteed to exist on the
+    // path running this test, and is an executable file so the existsSync check
+    // passes.
+    const prev = process.env.MCX_CLAUDE_BINARY;
+    process.env.MCX_CLAUDE_BINARY = process.execPath;
+    try {
+      expect(resolveSourceClaudePath()).toBe(process.execPath);
+    } finally {
+      restoreEnv("MCX_CLAUDE_BINARY", prev);
+    }
+  });
+
+  test("resolveSourceClaudePath throws when MCX_CLAUDE_BINARY points at a missing file", () => {
+    const prev = process.env.MCX_CLAUDE_BINARY;
+    process.env.MCX_CLAUDE_BINARY = "/nonexistent/path/to/claude";
+    try {
+      expect(() => resolveSourceClaudePath()).toThrow(/does not exist/);
+    } finally {
+      restoreEnv("MCX_CLAUDE_BINARY", prev);
+    }
+  });
+
+  test("resolveSourceClaudePath ignores empty MCX_CLAUDE_BINARY and falls back to PATH", () => {
+    const prev = process.env.MCX_CLAUDE_BINARY;
+    process.env.MCX_CLAUDE_BINARY = "   ";
+    try {
+      const result = resolveSourceClaudePath();
+      expect(result === null || (typeof result === "string" && result.length > 0)).toBe(true);
+    } finally {
+      restoreEnv("MCX_CLAUDE_BINARY", prev);
+    }
+  });
+
+  test("resolveSourceClaudePath honors claudeBinary from the config file when env is unset", () => {
+    const prev = process.env.MCX_CLAUDE_BINARY;
+    unsetEnv("MCX_CLAUDE_BINARY");
+    const cfgPath = join(mkdtempSync(join(tmpdir(), "rsc-cfg-")), "config.json");
+    writeFileSync(cfgPath, JSON.stringify({ claudeBinary: process.execPath }));
+    try {
+      expect(resolveSourceClaudePath(cfgPath)).toBe(process.execPath);
+    } finally {
+      restoreEnv("MCX_CLAUDE_BINARY", prev);
+    }
+  });
+
+  test("resolveSourceClaudePath: env wins over config file", () => {
+    const prev = process.env.MCX_CLAUDE_BINARY;
+    process.env.MCX_CLAUDE_BINARY = process.execPath;
+    const cfgPath = join(mkdtempSync(join(tmpdir(), "rsc-cfg-")), "config.json");
+    writeFileSync(cfgPath, JSON.stringify({ claudeBinary: "/this/should/be/ignored" }));
+    try {
+      // env wins → returns process.execPath, not the (nonexistent) config path
+      expect(resolveSourceClaudePath(cfgPath)).toBe(process.execPath);
+    } finally {
+      restoreEnv("MCX_CLAUDE_BINARY", prev);
+    }
+  });
+
+  test("resolveSourceClaudePath throws when config claudeBinary points at a missing file", () => {
+    const prev = process.env.MCX_CLAUDE_BINARY;
+    unsetEnv("MCX_CLAUDE_BINARY");
+    const cfgPath = join(mkdtempSync(join(tmpdir(), "rsc-cfg-")), "config.json");
+    writeFileSync(cfgPath, JSON.stringify({ claudeBinary: "/nonexistent/path/to/claude" }));
+    try {
+      expect(() => resolveSourceClaudePath(cfgPath)).toThrow(/does not exist/);
+    } finally {
+      restoreEnv("MCX_CLAUDE_BINARY", prev);
+    }
+  });
+
+  test("resolveSourceClaudePath silently falls through when config file is missing or malformed", () => {
+    const prev = process.env.MCX_CLAUDE_BINARY;
+    unsetEnv("MCX_CLAUDE_BINARY");
+    const dir = mkdtempSync(join(tmpdir(), "rsc-cfg-"));
+    const missingPath = join(dir, "this-file-does-not-exist.json");
+    const malformedPath = join(dir, "malformed-cfg.json");
+    writeFileSync(malformedPath, "{ not valid json");
+    try {
+      // Both paths must not throw — they fall through to PATH lookup,
+      // which returns either a path or null depending on the test env.
+      const r1 = resolveSourceClaudePath(missingPath);
+      const r2 = resolveSourceClaudePath(malformedPath);
+      expect(r1 === null || typeof r1 === "string").toBe(true);
+      expect(r2 === null || typeof r2 === "string").toBe(true);
+    } finally {
+      restoreEnv("MCX_CLAUDE_BINARY", prev);
+    }
   });
 });
 

--- a/packages/core/src/claude-patch/patcher.ts
+++ b/packages/core/src/claude-patch/patcher.ts
@@ -215,14 +215,69 @@ export const DEFAULT_DEPS: PatcherDeps = {
 };
 
 /**
- * Resolve the path to the user's installed claude binary by spawning `which claude`.
- * Returns null if claude is not on PATH.
+ * Resolve the path to the claude binary mcx should use.
+ *
+ * Lookup order:
+ *   1. `MCX_CLAUDE_BINARY` env — per-process override. Useful for one-off
+ *      testing or scripts that want to point at a specific binary without
+ *      mutating persistent config.
+ *   2. `claudeBinary` in `~/.mcp-cli/config.json` — persistent override. Lets
+ *      users pin mcx-spawned workers to a known-good version (e.g. an
+ *      archived 2.1.119) while leaving their interactive `claude` on PATH
+ *      free to auto-update. Set via `mcx config set claude-binary <path>`.
+ *      Useful when a new claude release introduces a Remote-Control gate
+ *      that mcx hasn't yet caught up to (see #1808 / strategies.ts).
+ *   3. `which claude` on PATH — default for regular use.
+ *
+ * Returns null if none resolves. Both overrides are rejected if the file
+ * doesn't exist, so a stale value fails loudly rather than silently falling
+ * back to PATH.
+ *
+ * The config-file lookup is best-effort: if the config file is missing or
+ * malformed, we silently fall through to PATH rather than throwing.
+ *
+ * `configPathOverride` is for tests — production callers pass nothing and
+ * the real `~/.mcp-cli/config.json` is read.
  */
-export function resolveSourceClaudePath(): string | null {
+export function resolveSourceClaudePath(configPathOverride?: string): string | null {
+  const envOverride = process.env.MCX_CLAUDE_BINARY?.trim();
+  if (envOverride) {
+    if (existsSync(envOverride)) return envOverride;
+    throw new Error(
+      `MCX_CLAUDE_BINARY="${envOverride}" does not exist. Unset it or point it at an installed claude binary.`,
+    );
+  }
+
+  const configOverride = readConfigClaudeBinary(configPathOverride ?? options.MCP_CLI_CONFIG_PATH)?.trim();
+  if (configOverride) {
+    if (existsSync(configOverride)) return configOverride;
+    throw new Error(
+      `claude-binary in ~/.mcp-cli/config.json points at "${configOverride}", which does not exist. Update or unset via \`mcx config set claude-binary <path>\`.`,
+    );
+  }
+
   const r = spawnSync("which", ["claude"], { encoding: "utf-8", timeout: 5_000 });
   if (r.status !== 0) return null;
   const path = (r.stdout || "").trim();
   return path || null;
+}
+
+/**
+ * Read `claudeBinary` from the CLI config file. Returns null on any error
+ * (missing file, malformed JSON, missing field) — callers fall through to
+ * the next resolution step rather than failing.
+ *
+ * We read the file directly here instead of importing `readCliConfig` to
+ * avoid a circular dep (cli-config → telemetry → patcher).
+ */
+function readConfigClaudeBinary(configPath: string): string | null {
+  try {
+    const text = readFileSync(configPath, "utf-8");
+    const parsed = JSON.parse(text) as { claudeBinary?: unknown };
+    return typeof parsed.claudeBinary === "string" ? parsed.claudeBinary : null;
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/packages/core/src/claude-patch/strategies.spec.ts
+++ b/packages/core/src/claude-patch/strategies.spec.ts
@@ -72,14 +72,19 @@ describe("STRATEGY_NOOP_PRE_2_1_120", () => {
 });
 
 describe("STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1", () => {
-  test("matches 2.1.120 and 2.1.121", () => {
+  test("matches 2.1.120 and every later version (no upper bound)", () => {
     expect(STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1.matches("2.1.120")).toBe(true);
     expect(STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1.matches("2.1.121")).toBe(true);
+    expect(STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1.matches("2.1.122")).toBe(true);
+    expect(STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1.matches("2.1.123")).toBe(true);
+    expect(STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1.matches("2.1.999")).toBe(true);
+    expect(STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1.matches("2.2.0")).toBe(true);
+    expect(STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1.matches("3.0.0")).toBe(true);
   });
-  test("does not match earlier or later versions", () => {
+  test("does not match versions before the host check existed", () => {
     expect(STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1.matches("2.1.119")).toBe(false);
-    expect(STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1.matches("2.1.122")).toBe(false);
-    expect(STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1.matches("2.2.0")).toBe(false);
+    expect(STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1.matches("2.1.0")).toBe(false);
+    expect(STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1.matches("1.99.99")).toBe(false);
   });
   test("apply replaces all 4 occurrences in a synthetic buffer", () => {
     const synthetic = enc.encode(
@@ -117,13 +122,13 @@ describe("resolveStrategy", () => {
   test("picks noop for old versions", () => {
     expect(resolveStrategy("2.1.119")?.id).toBe("noop-pre-2.1.120");
   });
-  test("picks ipv6 loopback for 2.1.120-2.1.121", () => {
+  test("picks ipv6 loopback for every 2.1.120+ version", () => {
     expect(resolveStrategy("2.1.120")?.id).toBe("host-check-ipv6-loopback-v1");
     expect(resolveStrategy("2.1.121")?.id).toBe("host-check-ipv6-loopback-v1");
-  });
-  test("returns null for unsupported newer versions", () => {
-    expect(resolveStrategy("2.1.122")).toBeNull();
-    expect(resolveStrategy("3.0.0")).toBeNull();
+    expect(resolveStrategy("2.1.122")?.id).toBe("host-check-ipv6-loopback-v1");
+    expect(resolveStrategy("2.1.123")?.id).toBe("host-check-ipv6-loopback-v1");
+    expect(resolveStrategy("2.2.0")?.id).toBe("host-check-ipv6-loopback-v1");
+    expect(resolveStrategy("3.0.0")?.id).toBe("host-check-ipv6-loopback-v1");
   });
   test("registry order is first-match-wins", () => {
     const overlapping = [

--- a/packages/core/src/claude-patch/strategies.ts
+++ b/packages/core/src/claude-patch/strategies.ts
@@ -115,13 +115,21 @@ export const STRATEGY_NOOP_PRE_2_1_120: PatchStrategy = {
  * `[000:000:000:000:000:0:0:1]` is the same length (27 bytes) and
  * canonicalizes to `[::1]` via WHATWG URL parsing.
  *
- * Validated end-to-end against 2.1.121 on 2026-04-27: full SDK protocol
- * round-trip (init → assistant inference → clean close). See issue #1808.
+ * Version match policy: lower bound only (≥ 2.1.120, when the host check
+ * was introduced). No upper bound — Anthropic ships claude-code patch
+ * releases multiple times per day, and bumping a version tuple every
+ * release is unsustainable. `validate` is the safety net: it asserts
+ * exactly 4 replacements, so a release that reshapes the binary fails
+ * loudly at patch time rather than producing a silently-broken copy.
+ *
+ * Validated end-to-end against 2.1.121 on 2026-04-27 and 2.1.123 on
+ * 2026-04-30: full SDK protocol round-trip (init → assistant inference →
+ * clean close). See issue #1808.
  */
 export const STRATEGY_HOST_CHECK_IPV6_LOOPBACK_V1: PatchStrategy = {
   id: "host-check-ipv6-loopback-v1",
   description: "Replace claude-staging.fedstart.com with [000:000:000:000:000:0:0:1] (canonicalizes to [::1]).",
-  matches: (version) => compareVersion(version, "2.1.120") >= 0 && compareVersion(version, "2.1.121") <= 0,
+  matches: (version) => compareVersion(version, "2.1.120") >= 0,
   apply: (src) => {
     const find = enc.encode("claude-staging.fedstart.com");
     const replace = enc.encode("[000:000:000:000:000:0:0:1]");

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -91,6 +91,14 @@ export interface CliConfig {
   telemetry?: boolean;
   /** Whether the first-run telemetry notice has been shown */
   telemetryNoticeShown?: boolean;
+  /**
+   * Path to the claude binary mcx-spawned workers should use. When set,
+   * overrides `which claude` so workers can be pinned to a known-good version
+   * (e.g. an archived 2.1.119) while the user's interactive `claude` on PATH
+   * keeps auto-updating. The `MCX_CLAUDE_BINARY` env var takes precedence.
+   * Set via: `mcx config set claude-binary /path/to/claude`.
+   */
+  claudeBinary?: string;
   /** Phase execution configuration */
   phase?: PhaseConfig;
   /** Session metrics configuration (#1610). Default: enabled. */

--- a/packages/daemon/src/claude-session/binary-resolver.spec.ts
+++ b/packages/daemon/src/claude-session/binary-resolver.spec.ts
@@ -50,21 +50,25 @@ describe("resolveClaudeForSpawn", () => {
     expect(r.error).toMatch(/exit 137/);
   });
 
-  test('noop strategy (claude < 2.1.120) → resolved with no TLS, binaryPath="claude" (PATH lookup preserved)', async () => {
+  test("noop strategy (claude < 2.1.120) → resolved with no TLS, binaryPath = resolved sourcePath", async () => {
     const r = await resolveClaudeForSpawn(makeDeps({ versionResolver: async () => "2.1.119" }));
     expect(isResolved(r)).toBe(true);
     if (!isResolved(r)) throw new Error("typeguard");
-    // Preserves legacy PATH-resolved spawn — never an absolute path.
-    expect(r.binaryPath).toBe("claude");
+    // binaryPath now matches sourcePath so config / env overrides actually
+    // pin the spawn target; previously this returned the literal string
+    // "claude" and PATH-resolved at spawn time, silently bypassing overrides.
+    expect(r.binaryPath).toBe("/usr/local/bin/claude");
+    expect(r.binaryPath).toBe(r.sourcePath);
     expect(r.tlsConfig).toBeNull();
     expect(r.strategyId).toBe("noop-pre-2.1.120");
     expect(r.version).toBe("2.1.119");
-    // sourcePath is informational only — `which claude` result, not the spawn target.
     expect(r.sourcePath).toBe("/usr/local/bin/claude");
   });
 
   test("unsupported version → unsupported-version error", async () => {
-    const r = await resolveClaudeForSpawn(makeDeps({ versionResolver: async () => "9.9.9" }));
+    // Inject empty registry — built-in registry has no gaps so "unsupported"
+    // is otherwise unreachable. See strategies.ts for the rationale.
+    const r = await resolveClaudeForSpawn(makeDeps({ versionResolver: async () => "9.9.9", strategies: [] }));
     expect(isResolved(r)).toBe(false);
     if (isResolved(r)) throw new Error("typeguard");
     expect(r.reason).toBe("unsupported-version");

--- a/packages/daemon/src/claude-session/binary-resolver.ts
+++ b/packages/daemon/src/claude-session/binary-resolver.ts
@@ -28,6 +28,7 @@
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import {
+  type PatchStrategy,
   type PatchedMeta,
   defaultVersionResolver,
   options,
@@ -78,6 +79,8 @@ export interface ResolverDeps {
   patchedStoreDir?: string;
   /** Default: generate or load the cached cert under `~/.mcp-cli/tls/`. */
   ensureCert?: () => SelfSignedMaterial;
+  /** Default: BUILTIN_STRATEGIES. Override for tests. */
+  strategies?: readonly PatchStrategy[];
 }
 
 export function isResolved(r: ClaudeResolution): r is ResolvedClaude {
@@ -111,7 +114,7 @@ export async function resolveClaudeForSpawn(deps: ResolverDeps = {}): Promise<Cl
     };
   }
 
-  const strategy = resolveStrategy(version);
+  const strategy = resolveStrategy(version, deps.strategies);
   if (!strategy) {
     return {
       error: `claude ${version} is not supported by any registered patch strategy. Upgrade mcx (which ships a strategy registry that's tested against new claude releases), or file an issue at https://github.com/theshadow27/mcp-cli/issues with the version.`,
@@ -120,13 +123,16 @@ export async function resolveClaudeForSpawn(deps: ResolverDeps = {}): Promise<Cl
     };
   }
 
-  // noop strategy: no patching needed. Spawn via PATH lookup (legacy
-  // behavior) so symlink/wrapper rewrites between resolver and spawn keep
-  // working — `which` is consulted only to detect *whether* claude exists,
-  // never to pin the resolved path.
+  // noop strategy: no patching needed. Use the resolved sourcePath directly —
+  // it already accounts for `MCX_CLAUDE_BINARY` env, the `claudeBinary` config
+  // override, and `which claude` fallback. Earlier versions returned the
+  // literal string "claude" here so symlink/wrapper rewrites between resolver
+  // and spawn would take effect; that pattern is now subsumed by the override
+  // mechanism, and the literal-"claude" form would silently bypass the user's
+  // configured pin (e.g. an archived 2.1.119) when PATH points elsewhere.
   if (strategy.id.startsWith("noop")) {
     return {
-      binaryPath: "claude",
+      binaryPath: sourcePath,
       tlsConfig: null,
       strategyId: strategy.id,
       version,


### PR DESCRIPTION
## Summary

Pin mcx-spawned workers to a known-good claude binary while letting the user's interactive `claude` on PATH auto-update. Plus two latent bugs surfaced while testing.

Discovered today: with a freshly-installed claude 2.1.123 (auto-updated from PATH), every `mcx claude spawn` was failing on this work-account machine. Three independent issues compounded:
- The patcher only knew about 2.1.120-2.1.121 (#1808's original strategy was version-pinned)
- Even with the version range widened, work-account org-policy gates the binary's RC mode after the host-allowlist patch passes
- `mcx claude patch-update` (which exists since #1808) wasn't actually reachable from the CLI — `cmdClaude` forwarded all invocations to `cmdAgent` which has no claude-only subcommand handling

## Changes

### 1. Patcher matcher: lower-bound only (`strategies.ts`)
`host-check-ipv6-loopback-v1` now matches every claude `>= 2.1.120` with no upper bound. Anthropic ships multiple claude-code patch releases per day; bumping a version tuple per release is unsustainable. The `validate` step (asserts exactly 4× `claude-staging.fedstart.com` → IPv6-loopback rewrites) is the safety net — a future release that reshapes the binary fails loudly at patch time rather than producing a silently-broken copy. Validated end-to-end against 2.1.123.

### 2. `MCX_CLAUDE_BINARY` env + `claude-binary` config override (`patcher.ts`, `config.ts`, `commands/config.ts`)
Lookup order: env → config → `which claude`. Useful when a new claude release introduces a gate the patcher doesn't yet handle (e.g. the work-account org-policy check observed on 2.1.123) — set `mcx config set claude-binary /path/to/claude-2.1.119` to pin workers while leaving PATH-claude free to auto-update.

### 3. Bug fixes uncovered while wiring (1) + (2)

**`mcx claude patch-update` dispatch routing.** `cmdClaude` forwarded every non-test invocation to `cmdAgent`, which doesn't know about claude-only subcommands. `patch-update` was unreachable in production despite existing in `cmdClaudeInternal`'s dispatch since #1808. Routes claude-only subcommands through the internal handler.

**Noop branch ignored resolved sourcePath.** `binary-resolver.ts` returned `binaryPath: "claude"` for the noop strategy, expecting PATH lookup at spawn time. With the new override mechanism this would silently bypass an explicit pin. Now uses the resolved `sourcePath`.

## Test plan

- [x] `bun typecheck` clean
- [x] `bun lint:check` clean  
- [x] 62 tests across affected files pass (added 7 new tests for override paths)
- [x] Full suite: 6462 pass, 1 unrelated pre-existing playwright flake
- [x] End-to-end manual verification: `mcx config set claude-binary /path/to/claude-2.1.119` → `mcx shutdown` → `mcx claude spawn --task ... --model haiku` returns READY response

🤖 Generated with [Claude Code](https://claude.com/claude-code)