### PR TITLE
sprint(49): stabilize test suite + burn down older bugs

### DIFF
--- a/.claude/diary/20260430.49.md
+++ b/.claude/diary/20260430.49.md
@@ -1,0 +1,81 @@
+# 2026-04-30 — Test stabilization + older-bug burndown (Sprint 49)
+
+## What was done
+
+15 PRs merged, v1.8.3 released. Plus 11 close-as-done at plan time (4 dup
+clusters resolved, 4 already-fixed-in-main verifications, 3 untriageable
+or already-applied meta).
+
+**Test stability cluster fixes:**
+- containment.spec.ts /tmp cwd artifact (#1687, +4 dups: #1689 #1743 #1770 #1794) — switched symlink target from `process.cwd()` to `homedir()` (#1918)
+- server-pool SIGTERM/SIGKILL race (#1552, +3 dups: #1811 #1882 #1902) — replaced timing assumptions with deterministic exit-promise sync (#1925)
+- resolve-playwright "package missing" deterministic failure (#1910) — root cause was hardcoded `VENDOR_PKG` in error path; injected `vendorPkg` via DI for test-time override (#1916)
+- GET /events invalid-pr loop server leak (#1683) — moved server creation outside loop body (#1915)
+- ws-server `#1836 parallel` mock non-resolving exited promise (#1888) — replaced with resolved Promise (#1920)
+- Worktree-name uniqueness test (#1889) — counter-based UUID mock for determinism (#1921)
+- Migration idempotency test rigor + dead-local cleanup (#1893+#1894 bundle) — assert persistence of migration mark (#1923)
+- claude-only-subcommand dispatch regression test (#1911) — table-driven coverage (#1937)
+
+**Older-bug burndown (sprints 41-44 carry-over):**
+- Help formatter pad-cap alignment (#1772) — added minimum 2-space spacer for >32-char flags (#1914)
+- aliasState/phase_state repoRoot validation (#1525) — `path.isAbsolute()` rejection (#1917, fixed Copilot finding mid-flight: switched from `startsWith("/")` to `isAbsolute()` for cross-platform correctness)
+- OAuthCallbackTimeoutError typed class (#1637) — replaced string-prefix matching (#1919)
+- DEFAULT_TIMEOUT_MS regression restore (#1531) — reapplied across 10 files plus help text MAX_TIMEOUT_MS interpolation (#1938)
+- @file path traversal guard (#1899, security/high) — full adversarial-review cycle: round 1 caught home-dir allowlist defeating containment (~/.config/gh/hosts.yml + 20+ credential files); round 2 caught root-cwd bypass + 2 🟡; final fix is cwd-only by default with shared `isPathContained()` extracted into `core/fs.ts`. Filed #1929 follow-up for broader credential audit (#1926)
+
+**Sprint-48 followups:**
+- sessions.delete-before-await TOCTOU lint (#1897) — manual fix in ws-server.ts:terminateSession + new lint script `scripts/check-session-teardown.ts` with angle-bracket-aware brace tracking + 14-test spec; QA round 3 needed when first round of brace tracker missed `Promise<{...}>` return-type pattern (filed #1940 dup of #1935 inside QA) (#1930)
+- claude-status bundle: line/byte footprint, whitespace-trim target parsing, --help inclusion, error-msg suggestion (#1903+04+05+06) — single PR (#1927)
+
+**Also closed:**
+- Dups closed at plan time: #1689 #1743 #1770 #1794 (→ #1687); #1811 #1882 #1902 (→ #1552)
+- Already-fixed verifications: #1646 (resolve-playwright `{ cause: err }`), #1881 (parseSitesArg `!(i in sites)`), #1838 #1841 (liveBuffer determinization)
+- Untriageable: #1708 (sprint-42 wind-down flake, no test name)
+
+## What worked well
+
+- **First sprint on the new monitor-stream playbook** ran without polling. The harness `Monitor` tool surfaced ~28 actionable events across 21 spawned sessions; orchestrator drove the entire pipeline reactively from notifications. Previous sprints had an `mcx claude wait` polling loop running every 60s.
+- **One-pass close-as-dones**: 11 of 26 issues this sprint required zero spawn cost. Plan-time triage paid for itself in the first 30 minutes.
+- **Adversarial review cycle on #1899 worked exactly as designed**: round 1 found the architectural mismatch (denylist-over-allowlist defeats containment goal), round 2 found a real edge case (root-cwd bypass), and reviewer self-repair handled the contained 🔴+🟡 fixes without spawning a fresh opus. Final implementation is materially better than the first push.
+- **Wall-clock**: ~1h vs ~2h 30m–3h 30m estimate. Smaller individual changes + plan-time close-as-dones + monitor-stream parallelism compounded.
+- **Reviewer self-repair** fired once (round 2) — saved an opus repair spawn (~$8) for contained 1 🔴 + 2 🟡 fixes.
+
+## What didn't work
+
+- **`mcx phase run qa --work-item` returns no `.model` on re-entry, only on first call.** Filed #1922. Orchestrator naively called the phase twice (once for `.prompt`, once for `.model`) and got `--model null` for 5 spawned QA sessions before the bug was visible. Recovery: `phase_state_delete qa_session_id` + re-spawn with cached JSON. Workaround codified in this sprint's bash helpers; permanent fix is qa.ts (and review.ts/repair.ts by symmetry) returning `model+prompt` even when `action == "in-flight"`. **Concrete improvement filed (#1922).**
+- **Manual phase_state_set + manual spawn-command execution is verbose.** Each impl/qa/review/repair transition required 3-4 separate `mcx phase run + parse JSON + mcx claude spawn + phase_state_set` calls. The runtime-supports-in-handler-spawning issue (#1286) is the durable fix; until then, the orchestrator carries this glue. Documented as the current contract — not a hidden gotcha — but the bash helpers wrote themselves three times before settling.
+- **Monitor stream emits `pr.merge_state_changed` events with `state=null` payload at high volume** (~6-9 per cycle). Drowns the genuinely-actionable `session.idle` / `qa:pass`-bearing notifications. Filter rule needed: only emit when payload state is non-null, or fold into a single "merge state has changed" with a max-rate. **Concrete improvement: filter `pr.merge_state_changed` server-side in monitor producers, or have the orchestrator's jq filter drop `state == null` events.** TODO: file as a sprint-50 followup.
+- **Three QAs returned qa:pass before Copilot inline reviews fully landed**, requiring re-QA after the implementer fixed the comment: #1525 (5 isAbsolute threads), #1687 (EEXIST `rmSync`), #1889 (property-descriptor restore), #1910 (VENDOR_PKG vs resolvedVendorPkg). The fix per `feedback_review_pr_comments.md` is for QA to wait at least 8 minutes after PR push before voting. Most QAs got this right (#1910 noted "Push age: 496s") but the timing isn't enforced. **Concrete improvement: codify the 8-minute wait inside `/qa` command itself rather than relying on the QA agent to count it.** TODO: file as a sprint-50 followup.
+- **#1899 PR description out of sync with final implementation** generated 3 stale Copilot comments after the second cwd-only refactor. The PR description still referenced the round-1 home-dir + denylist design. QA rightly flagged them as unreplied; orchestrator dismissed via direct gh-api replies citing "PR description stale." **Concrete improvement: when reviewer self-repair lands, update the PR body in the same push.**
+- **#1897 needed 3 QA rounds.** Iris's lint script (`findAsyncMethods`) had a brace-tracker bug — first attempt counted `{` inside `Promise<{...}>` as method body start. Round 2 missed it (didn't add the test case Copilot specifically called out), round 3 fixed with angle-bracket depth tracking. Issue filed during QA (#1935, dup of itself filed by re-QA as #1940). **Concrete improvement: when QA cites a specific test case in the failure, the implementer must add that exact test before re-pushing.** TODO: lift this to a `/repair` rule.
+- **Orchestrator byed #1683's impl session before merge** (closed `ee5ce297` after PR pushed but before qa:pass). Per `run.md` this violates "End (`bye`) only when work is conclusively finished — for an impl session, *PR merged* OR (`qa:pass` + zero open threads + CI green)." It happened to work because QA passed cleanly on first try, but the rule exists for the case where a Copilot inline arrives after push and the impl session loses worktree+context. **Concrete improvement: orchestrator helper should check phase==done before bye-ing impl, not just "QA spawned."**
+
+## Patterns established
+
+- **Bulk-process idle PRs in a single shell function**: when 5 PRs all hit `session.idle` within a minute, advancing them through bind→triage→qa one at a time wastes turns. The `bind_and_qa` / `requeue_qa` helpers fold the full pipeline into a single bash function — write once, reuse across the sprint. The model=null bug forced this pattern (had to retry-spawn 5 sessions); it stuck because it's also faster.
+- **Reviewer self-repair scaling**: round-2 review on #1899 found 1 🔴 + 2 🟡, all contained. Send-the-reviewer-back saved a repair spawn. Pattern matches `feedback_review_pr_comments.md`'s "1-3 contained edits" gate. Cost: $0 marginal vs ~$8 for fresh opus repair.
+- **Direct gh-api replies for "PR description stale" Copilot threads**: when the PR has been substantially rewritten and Copilot's comments reference dead code paths, the orchestrator can resolve via `gh api .../comments/{id}/replies -X POST` directly without spawning a session. Saves a tick. Use sparingly — most threads still need the implementer to look.
+- **Switched sprint-container release flow from rebase+force-push to merge+plain-push** (review.md Step 4(a) and (d)). The rebase rewrote history of a branch other people had no upstream-clone of, but the `--force-with-lease` push tripped the destructive-action safety policy. Merge into the sprint branch is semantically equivalent for the squash-merge of the container PR (everything collapses into one commit anyway) and avoids the policy gate. Shipped in this sprint's retro commit; effective starting sprint 50.
+
+## Stats
+
+- **PRs merged**: 15/15 planned
+- **Issues closed**: 26 (15 sprint picks + 11 close-as-done at plan time)
+- **Adversarial reviews**: 1 (`#1899`, 2 rounds, 5 originals + 3 round-2 findings, all fixed)
+- **Repair rounds**: 1 fresh opus repair (#1899 round 1 → round 2 transition); 1 reviewer self-repair (#1899 round 2)
+- **QA rounds total**: 21 across 14 PRs (re-QAs needed: #1687, #1525, #1910, #1889, #1893, #1897 ×3, #1531, #1911, #1899)
+- **New issues filed during sprint**: 8 (#1922 #1929 #1934 #1935 #1936 #1940 + 2 from QA findings)
+- **Wall time**: ~1h 0m (planned ~2h 30m–3h 30m)
+- **Sprint cost**: not separately measured — opus on #1899 was ~$1.75 across impl+repair; sonnet PRs averaged $0.40-1.00; QA sessions ~$0.20-0.80 each. Total ~$25-35 estimated (well below quota: 5h util ended at single digits).
+
+## Followups for sprint 50 (carried into the planning context)
+
+- **#1922** qa.ts (and review.ts/repair.ts by symmetry) should return `.model` on `action: "in-flight"` re-entry — single-call DX for `mcx phase run` consumers
+- **Filter `pr.merge_state_changed` state=null noise** out of monitor stream (producer-side or filter-side)
+- **Codify 8-minute Copilot-wait inside `/qa`** rather than relying on QA agent discretion
+- **`/repair` rule**: when QA cites a specific test case in a failure, the new test must be added before re-push
+- **Orchestrator helper**: only `bye` impl session after `work_item.phase == done`, not "QA spawned"
+- **#1929** broader credential audit follow-up to #1899 (cwd-only is solid, but the broader set of credential files outside cwd are now blocked too — verify behavior under `~/.config/gh/`)
+- **#1934** server-pool closeAll flaky test (surfaced during #1897 QA) — likely pre-existing, needs nerd-snipe gate
+- **#1935 / #1940** findAsyncMethods now fixed in #1897 PR; close as resolved
+- **#1936** `scripts/*.spec.ts` excluded from `bun test` by `pathIgnorePatterns` — straightforward config tweak

--- a/.claude/skills/sprint/references/review.md
+++ b/.claude/skills/sprint/references/review.md
@@ -57,15 +57,19 @@ while later steps appear to succeed. Run them strictly in order, verifying
 each step before the next.
 
 ```bash
-# (a) Pull latest main into the sprint worktree, rebase the sprint branch
-#     onto it. Workers have been merging to main throughout the sprint —
-#     rebase picks those up so package.json is bumped on top of the
-#     latest version.
+# (a) Merge latest main into the sprint branch (no rebase — preserves
+#     forward-only push semantics, no force-push needed). Workers have
+#     been merging to main throughout the sprint; this brings their
+#     commits into the sprint branch so package.json is bumped on top
+#     of the latest version. The merge commit becomes part of the sprint
+#     branch's history; the eventual squash-merge of the sprint container
+#     PR collapses everything into a single commit on main, so the merge
+#     commit doesn't pollute main's history.
 (
   cd .claude/worktrees/sprint-{N}
   git fetch origin main
-  git rebase origin/main
-  # If rebase produces conflicts on .claude/sprints/sprint-{N}.md or the
+  git merge --no-edit origin/main
+  # If merge produces conflicts on .claude/sprints/sprint-{N}.md or the
   # diary file, that's a meta-file conflict — workers shouldn't be touching
   # those (per plan.md Step 3 rule 5). Investigate before proceeding.
 )
@@ -86,14 +90,14 @@ bun -e "
   bun typecheck     # catches TS errors before the hook does
 )
 
-# (d) Commit + force-push the sprint branch — SPRINT_OVERRIDE=1 bypasses
-#     the sprint-active pre-commit guard (#1443). Force-push (with-lease)
-#     is needed because the rebase rewrote history.
+# (d) Commit + push the sprint branch — SPRINT_OVERRIDE=1 bypasses the
+#     sprint-active pre-commit guard (#1443). Plain `git push` works
+#     because we merged (didn't rebase) — no history rewrite.
 (
   cd .claude/worktrees/sprint-{N}
   git add package.json
   SPRINT_OVERRIDE=1 git commit -m "release: vX.Y.Z"
-  git push --force-with-lease
+  git push
 )
 
 # (e) Verify the sprint PR picked up the release commit
@@ -111,9 +115,10 @@ always part of the sprint container.
 ### If the commit fails (pre-commit hook rejected it)
 
 1. Read the hook output — usually a lint/typecheck fix.
-2. Apply the fix in the sprint worktree, re-stage, re-commit.
-3. Force-push the sprint branch (`git push --force-with-lease`) — the
-   sprint container PR updates in place.
+2. Apply the fix in the sprint worktree, re-stage, re-commit (a fresh
+   commit, not `--amend` — the merge in step (a) is already pushed).
+3. Push the sprint branch (`git push`) — the sprint container PR updates
+   in place.
 4. **Do not tag yet.** Tagging happens in `retro.md` *after* the sprint PR
    merges. If a Release workflow gets triggered by an early tag push,
    cancel it, delete the tag (local + remote), and restart from there.

--- a/.claude/sprints/sprint-49.md
+++ b/.claude/sprints/sprint-49.md
@@ -1,6 +1,6 @@
 # Sprint 49
 
-> Planned 2026-04-30 EDT. Started 2026-04-30 18:07 EDT. Target: 15 PRs.
+> Planned 2026-04-30 EDT. Started 2026-04-30 18:07 EDT. Ended 2026-04-30 19:07 EDT (~1h 0m). Target: 15 PRs. Result: 15/15 merged.
 
 ## Goal
 

--- a/.claude/sprints/sprint-49.md
+++ b/.claude/sprints/sprint-49.md
@@ -1,6 +1,6 @@
 # Sprint 49
 
-> Planned 2026-04-30 EDT. Target: 15 PRs.
+> Planned 2026-04-30 EDT. Started 2026-04-30 18:07 EDT. Target: 15 PRs.
 
 ## Goal
 

--- a/.claude/sprints/sprint-49.md
+++ b/.claude/sprints/sprint-49.md
@@ -158,6 +158,23 @@ Order: pull from top.
 9. **Plan-time issue audit caught close-as-dones**: 11 issues already done or duplicates closed at plan time (no spawn cost).
 10. **Bundled PRs require explicit bundle marker in TaskCreate.** Don't spawn separate sessions for #1893+#1894 or the status bundle.
 
+## Results
+
+- **Released**: v1.8.3
+- **PRs merged**: 15/15 planned
+- **Issues closed**: 26 (15 sprint picks + 11 close-as-done at plan time)
+- **New issues filed during sprint**: 8 (#1922 qa phase model=null DX, #1929 home-dir denylist gaps follow-up, #1934 closeAll flaky, #1935 findAsyncMethods brace bug, #1936 scripts/*.spec.ts pathIgnorePatterns, #1940 dup of #1935, plus 2 from QA)
+- **Repair rounds**: 1 (#1899 — opus repair after adversarial review found home-dir allowlist defeated containment goal); 1 reviewer self-repair (#1899 round 2 — root-cwd bypass + 2 🟡)
+- **QA rounds total**: 21 across 14 PRs (5 PRs needed re-QA: #1687, #1525, #1910, #1889, #1893, #1897 ×3, #1531, #1911, #1899)
+- **Wall time**: ~1h 0m (planned ~2h 30m–3h 30m — beat estimate by 60%+)
+
+### Highlights
+
+- **Test stability cluster fixes shipped**: #1687 (containment /tmp cwd, +4 dups), #1552 (server-pool SIGTERM/SIGKILL, +3 dups), #1910 (resolve-playwright vendorPkg DI). Total: 8 flaky-test issues closed.
+- **Security pick #1899 went through full adversarial-review cycle**: round-1 caught home-dir allowlist defeating containment, round-2 caught root-cwd bypass. Final fix is cwd-only by default with shared `isPathContained()` primitive. Filed #1929 follow-up for broader credential audit.
+- **First sprint on monitor-stream playbook**: ~28 actionable events across 21 sessions; orchestrator never used `mcx claude wait` polling. Filed #1922 for qa.ts re-entry returning model=null (orchestrator bug recovered with `phase_state_delete` + re-spawn).
+- **Reviewer self-repair pattern fired once** (#1899 round 2 — 1 🔴 + 2 🟡 contained edits) — saved ~$8 vs fresh repair spawn.
+
 ## Tentative sprint 50 outline
 
 See `.claude/sprints/sprint-50.md` — drafted alongside this plan with

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "bun": ">=1.2.18"
   },
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "MCP CLI — call MCP server tools from the command line with zero context overhead",
   "type": "module",
   "workspaces": ["packages/*"],


### PR DESCRIPTION
Sprint 49 container PR. Accumulates every sprint-meta commit on the
`sprint-49` branch:

- plan + any mid-sprint amendments
- run-time edits (Started/Ended timestamps, Excluded section)
- Results summary
- retro diary file
- release commit (if a release is cut this sprint)

Marked **draft** until `/sprint retro` flips it ready and arms auto-merge.

## Sprint-49 plan summary

**Goal:** Stabilize the test suite + burn down older bugs (>3 sprints stale). First sprint to exercise the new `mcx monitor` stream playbook with diverse work.

**15 PRs**: 1 opus (security #1899) + 14 sonnet | 1 high / 6 medium / 8 low scrutiny

**12 close-as-done at plan time** (no spawn cost):
- Dups -> #1687: #1689, #1743, #1770, #1794
- Dups -> #1552: #1811, #1882, #1902
- Already fixed: #1646, #1881, #1838, #1841
- Untriageable: #1708
- Already-applied meta: #1907, #1908

Plus `.claude/sprints/sprint-50.md` sketch with ~50% capacity reserved for sprint-49 fallout.

Docs/skill-only by construction — pre-commit hooks should skip the test suite.