### PR TITLE
fix(help): add minimum spacer when flag exceeds pad cap (fixes #1772)

### DIFF
--- a/packages/command/src/help.spec.ts
+++ b/packages/command/src/help.spec.ts
@@ -96,6 +96,25 @@ describe("formatHelp", () => {
     const longDescIdx = longLine?.indexOf("long flag") ?? -1;
     expect(shortDescIdx).toBe(longDescIdx);
   });
+
+  test("long flag exceeding pad cap still has spacer before description", () => {
+    // Flag longer than 32 chars triggers pad cap — without fix, desc runs together with flag
+    const longFlag = "--this-flag-is-definitely-longer-than-32-chars <val>";
+    const output = formatHelp({
+      name: "mcx longflag",
+      summary: "long flag test",
+      usage: ["mcx longflag"],
+      options: [
+        [longFlag, "the description"],
+        ["--short", "other desc"],
+      ],
+    });
+    const lines = output.split("\n");
+    const longLine = lines.find((l) => l.includes(longFlag));
+    expect(longLine).toBeDefined();
+    // Must have at least 2 spaces between flag and description
+    expect(longLine).toMatch(new RegExp(`${longFlag}\\s{2,}the description`));
+  });
 });
 
 describe("claude subcommand help registry", () => {

--- a/packages/command/src/help.ts
+++ b/packages/command/src/help.ts
@@ -42,7 +42,8 @@ export function formatHelp(help: CommandHelp): string {
     const flagWidth = Math.max(...help.options.map(([f]) => f.length));
     const pad = Math.min(flagWidth + 2, 32);
     for (const [flag, desc] of help.options) {
-      lines.push(`  ${flag.padEnd(pad)}${desc}`);
+      const spacer = flag.length >= pad ? "  " : " ".repeat(pad - flag.length);
+      lines.push(`  ${flag}${spacer}${desc}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- `formatHelp()` used `flag.padEnd(pad)` where `pad` is capped at 32 — flags longer than 32 chars got no padding at all, causing the description to run immediately after the flag text with no separator
- Now uses a 2-space fallback spacer (`"  "`) whenever `flag.length >= pad`, guaranteeing a visible column break regardless of flag length

## Test plan
- Added `packages/command/src/help.spec.ts`: "long flag exceeding pad cap still has spacer before description" — verifies flags >32 chars produce at least 2 spaces before the description text
- All 15 tests in `help.spec.ts` pass
- `bun typecheck`, `bun lint`, full pre-commit suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)