### PR TITLE
fix(test): stop leaking servers in invalid-pr loop tests (closes #1683)

### DIFF
--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -2198,8 +2198,8 @@ describe("IpcServer HTTP transport", () => {
     });
 
     test("GET /events with invalid pr returns 400", async () => {
+      startServerWithBus();
       for (const bad of ["abc", "1.5", "-1", "0", ""]) {
-        startServerWithBus();
         const res = await fetch(`http://localhost/events?pr=${encodeURIComponent(bad)}`, {
           method: "GET",
           unix: socketPath,
@@ -3309,8 +3309,8 @@ describe("IpcServer HTTP transport", () => {
   // -- GET /events NDJSON endpoint tests (ring-buffer / pushEvent path) --
 
   test("GET /events with invalid pr returns 400 on ring-buffer path", async () => {
+    startServer();
     for (const bad of ["abc", "1.5", "-1", "0", ""]) {
-      startServer();
       const res = await fetch(`http://localhost/events?pr=${encodeURIComponent(bad)}`, {
         method: "GET",
         unix: socketPath,


### PR DESCRIPTION
## Summary
- Moves `startServerWithBus()` outside the bad-value loop in the EventBus-path `GET /events with invalid pr returns 400` test — 4 previously leaked servers per run are now cleaned up by `afterEach`
- Applies the same fix to the ring-buffer-path sibling test (`startServer()` was also inside the loop)
- Same pattern as PR #1670 which fixed the `since=` tests

## Test plan
- [x] Both fixed tests still pass: `bun test --test-name-pattern "invalid pr"` → 2 pass
- [x] `bun typecheck` clean
- [x] `bun lint` clean
- [x] Pre-commit hook (typecheck + lint + coverage) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)