### PR TITLE
fix(resolve-playwright): inject vendorPkg for deterministic post-install check (fixes #1910)

### DIFF
--- a/packages/daemon/src/site/browser/resolve-playwright.spec.ts
+++ b/packages/daemon/src/site/browser/resolve-playwright.spec.ts
@@ -121,6 +121,9 @@ describe("resolvePlaywright", () => {
     const result = resolvePlaywright({
       candidates: ["/nonexistent/path/playwright"],
       install: () => ({ exitCode: 0, stderr: "" }),
+      // Force the post-install existence check to fail regardless of whether
+      // playwright is already installed in the real vendor dir on this machine.
+      vendorPkg: "/nonexistent/vendor/playwright",
     });
 
     await expect(result).rejects.toThrow(/package not found/);

--- a/packages/daemon/src/site/browser/resolve-playwright.ts
+++ b/packages/daemon/src/site/browser/resolve-playwright.ts
@@ -105,7 +105,7 @@ async function doResolve(opts?: {
 
   const mod = await import(resolvedVendorPkg);
   if (!mod.chromium) {
-    throw new Error(`playwright installed but chromium export is missing at ${VENDOR_PKG}`);
+    throw new Error(`playwright installed but chromium export is missing at ${resolvedVendorPkg}`);
   }
   return mod.chromium as BrowserType;
 }

--- a/packages/daemon/src/site/browser/resolve-playwright.ts
+++ b/packages/daemon/src/site/browser/resolve-playwright.ts
@@ -49,6 +49,8 @@ let pending: Promise<BrowserType> | null = null;
 export function resolvePlaywright(opts?: {
   candidates?: string[];
   install?: (vendorDir: string) => { exitCode: number; stderr: string } | Promise<{ exitCode: number; stderr: string }>;
+  /** Override the path checked after a successful install. Defaults to VENDOR_PKG. For testing only. */
+  vendorPkg?: string;
 }): Promise<BrowserType> {
   if (!pending) {
     pending = doResolve(opts).catch((err) => {
@@ -62,6 +64,7 @@ export function resolvePlaywright(opts?: {
 async function doResolve(opts?: {
   candidates?: string[];
   install?: (vendorDir: string) => { exitCode: number; stderr: string } | Promise<{ exitCode: number; stderr: string }>;
+  vendorPkg?: string;
 }): Promise<BrowserType> {
   const candidates = opts?.candidates ?? playwrightCandidates();
 
@@ -90,16 +93,17 @@ async function doResolve(opts?: {
     );
   }
 
-  if (!existsSync(VENDOR_PKG)) {
+  const resolvedVendorPkg = opts?.vendorPkg ?? VENDOR_PKG;
+  if (!existsSync(resolvedVendorPkg)) {
     throw new Error(
-      `playwright install succeeded but package not found at ${VENDOR_PKG}. ` +
+      `playwright install succeeded but package not found at ${resolvedVendorPkg}. ` +
         `Install manually: cd ${VENDOR_DIR} && bun add playwright`,
     );
   }
 
   console.error("[site] playwright installed successfully");
 
-  const mod = await import(VENDOR_PKG);
+  const mod = await import(resolvedVendorPkg);
   if (!mod.chromium) {
     throw new Error(`playwright installed but chromium export is missing at ${VENDOR_PKG}`);
   }


### PR DESCRIPTION
## Summary
- The test "surfaces useful error when install succeeds but package missing" failed on machines where playwright is already installed in `~/.mcp-cli/vendor/playwright/` — `existsSync(VENDOR_PKG)` returned true after the mock install, so the code resolved instead of rejecting
- Added a `vendorPkg` injectable option to `resolvePlaywright` (consistent with the existing DI pattern already used by `install` and `_resolveBunBinary`), letting callers override the path checked after a successful install
- Updated the test to pass `vendorPkg: "/nonexistent/vendor/playwright"` so the post-install check always fails regardless of real machine state

## Test plan
- [x] `bun test packages/daemon/src/site/browser/resolve-playwright.spec.ts` — 15 pass, 0 fail (was 14 pass, 1 fail before)
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] Pre-commit hook passed (typecheck + lint + test + coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)