### PR TITLE
fix(ipc): validate repoRoot is absolute in aliasState* and phase_state_* handlers (fixes #1525)

### DIFF
--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -481,7 +481,10 @@ export const GetWorkItemParamsSchema = z
 // -- Alias state schemas --
 
 const AliasStateScope = z.object({
-  repoRoot: z.string().min(1),
+  repoRoot: z
+    .string()
+    .min(1)
+    .refine((v) => v.startsWith("/"), { message: "repoRoot must be an absolute path" }),
   namespace: z.string().min(1),
 });
 

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -5,6 +5,7 @@
  * Encoding: JSON request/response bodies
  */
 
+import { isAbsolute } from "node:path";
 import { z } from "zod/v4";
 import type { AliasType } from "./alias";
 import type { MonitorAliasMetadata } from "./alias-bundle";
@@ -484,7 +485,7 @@ const AliasStateScope = z.object({
   repoRoot: z
     .string()
     .min(1)
-    .refine((v) => v.startsWith("/"), { message: "repoRoot must be an absolute path" }),
+    .refine((v) => isAbsolute(v), { message: "repoRoot must be an absolute path" }),
   namespace: z.string().min(1),
 });
 

--- a/packages/daemon/src/alias-state.spec.ts
+++ b/packages/daemon/src/alias-state.spec.ts
@@ -261,4 +261,16 @@ describe("aliasState IPC handlers — repoRoot canonicalization", () => {
     });
     expect(resp.error).toBeDefined();
   });
+
+  test("relative repoRoot is rejected — returns IPC error with clear message", async () => {
+    const { rpc } = start();
+
+    for (const method of ["aliasStateGet", "aliasStateSet", "aliasStateDelete", "aliasStateAll"] as const) {
+      const params: Record<string, unknown> = { repoRoot: "../other-repo", namespace: "ns", key: "k" };
+      if (method === "aliasStateSet") params.value = "x";
+      const resp = await rpc({ id: `rel-${method}`, method, params });
+      expect(resp.error).toBeDefined();
+      expect(String(resp.error?.message ?? "")).toContain("absolute");
+    }
+  });
 });

--- a/packages/daemon/src/work-items-server.spec.ts
+++ b/packages/daemon/src/work-items-server.spec.ts
@@ -1392,6 +1392,26 @@ describe("phase_state tools", () => {
     }
   });
 
+  test("relative repoRoot is rejected — returns isError with clear message", async () => {
+    const { stateDb, workItemDb, dbPath } = createRealStateDbs();
+    stateDbInst = stateDb;
+    dbPathToClean = dbPath;
+    server = new WorkItemsServer(workItemDb, { stateDb });
+    const { client } = await server.start();
+
+    await client.callTool({ name: "work_items_track", arguments: { issueNumber: 100 } });
+
+    for (const toolName of ["phase_state_get", "phase_state_set", "phase_state_delete", "phase_state_list"] as const) {
+      const result = await client.callTool({
+        name: toolName,
+        arguments: { workItemId: "issue:100", repoRoot: "../other-repo", key: "k", value: "v" },
+      });
+      expect(result.isError).toBe(true);
+      const text = (result.content as Array<{ text: string }>)[0].text;
+      expect(text).toContain("absolute");
+    }
+  });
+
   test("phase_state_set rejects undefined value", async () => {
     const { stateDb, workItemDb, dbPath } = createRealStateDbs();
     stateDbInst = stateDb;

--- a/packages/daemon/src/work-items-server.ts
+++ b/packages/daemon/src/work-items-server.ts
@@ -496,6 +496,12 @@ export class WorkItemsServer {
             }
             const workItemId = String(a.workItemId ?? "");
             const rawRepoRoot = String(a.repoRoot ?? "").trim();
+            if (rawRepoRoot && !rawRepoRoot.startsWith("/")) {
+              return {
+                content: [{ type: "text" as const, text: "repoRoot must be an absolute path" }],
+                isError: true,
+              };
+            }
             const repoRoot = rawRepoRoot ? resolveRealpath(resolve(rawRepoRoot)) : "";
             const key = String(a.key ?? "");
             if (!workItemId || !repoRoot || !key) {
@@ -524,6 +530,12 @@ export class WorkItemsServer {
             }
             const workItemId = String(a.workItemId ?? "");
             const rawRepoRoot = String(a.repoRoot ?? "").trim();
+            if (rawRepoRoot && !rawRepoRoot.startsWith("/")) {
+              return {
+                content: [{ type: "text" as const, text: "repoRoot must be an absolute path" }],
+                isError: true,
+              };
+            }
             const repoRoot = rawRepoRoot ? resolveRealpath(resolve(rawRepoRoot)) : "";
             const key = String(a.key ?? "");
             if (!workItemId || !repoRoot || !key) {
@@ -558,6 +570,12 @@ export class WorkItemsServer {
             }
             const workItemId = String(a.workItemId ?? "");
             const rawRepoRoot = String(a.repoRoot ?? "").trim();
+            if (rawRepoRoot && !rawRepoRoot.startsWith("/")) {
+              return {
+                content: [{ type: "text" as const, text: "repoRoot must be an absolute path" }],
+                isError: true,
+              };
+            }
             const repoRoot = rawRepoRoot ? resolveRealpath(resolve(rawRepoRoot)) : "";
             const key = String(a.key ?? "");
             if (!workItemId || !repoRoot || !key) {
@@ -586,6 +604,12 @@ export class WorkItemsServer {
             }
             const workItemId = String(a.workItemId ?? "");
             const rawRepoRoot = String(a.repoRoot ?? "").trim();
+            if (rawRepoRoot && !rawRepoRoot.startsWith("/")) {
+              return {
+                content: [{ type: "text" as const, text: "repoRoot must be an absolute path" }],
+                isError: true,
+              };
+            }
             const repoRoot = rawRepoRoot ? resolveRealpath(resolve(rawRepoRoot)) : "";
             if (!workItemId || !repoRoot) {
               return {

--- a/packages/daemon/src/work-items-server.ts
+++ b/packages/daemon/src/work-items-server.ts
@@ -5,7 +5,7 @@
  * Tools: track, untrack, list, get, update — mapping to WorkItemDb CRUD.
  */
 
-import { resolve } from "node:path";
+import { isAbsolute, resolve } from "node:path";
 import type { Logger, Manifest, ToolInfo, WorkItem, WorkItemPatch, WorkItemPhase } from "@mcp-cli/core";
 import { WORK_ITEMS_SERVER_NAME, canTransition, consoleLogger, isStandardPhase, resolveRealpath } from "@mcp-cli/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -496,7 +496,7 @@ export class WorkItemsServer {
             }
             const workItemId = String(a.workItemId ?? "");
             const rawRepoRoot = String(a.repoRoot ?? "").trim();
-            if (rawRepoRoot && !rawRepoRoot.startsWith("/")) {
+            if (rawRepoRoot && !isAbsolute(rawRepoRoot)) {
               return {
                 content: [{ type: "text" as const, text: "repoRoot must be an absolute path" }],
                 isError: true,
@@ -530,7 +530,7 @@ export class WorkItemsServer {
             }
             const workItemId = String(a.workItemId ?? "");
             const rawRepoRoot = String(a.repoRoot ?? "").trim();
-            if (rawRepoRoot && !rawRepoRoot.startsWith("/")) {
+            if (rawRepoRoot && !isAbsolute(rawRepoRoot)) {
               return {
                 content: [{ type: "text" as const, text: "repoRoot must be an absolute path" }],
                 isError: true,
@@ -570,7 +570,7 @@ export class WorkItemsServer {
             }
             const workItemId = String(a.workItemId ?? "");
             const rawRepoRoot = String(a.repoRoot ?? "").trim();
-            if (rawRepoRoot && !rawRepoRoot.startsWith("/")) {
+            if (rawRepoRoot && !isAbsolute(rawRepoRoot)) {
               return {
                 content: [{ type: "text" as const, text: "repoRoot must be an absolute path" }],
                 isError: true,
@@ -604,7 +604,7 @@ export class WorkItemsServer {
             }
             const workItemId = String(a.workItemId ?? "");
             const rawRepoRoot = String(a.repoRoot ?? "").trim();
-            if (rawRepoRoot && !rawRepoRoot.startsWith("/")) {
+            if (rawRepoRoot && !isAbsolute(rawRepoRoot)) {
               return {
                 content: [{ type: "text" as const, text: "repoRoot must be an absolute path" }],
                 isError: true,


### PR DESCRIPTION
## Summary
- Added `.refine()` to `AliasStateScope.repoRoot` in `packages/core/src/ipc.ts` — relative paths are now rejected at Zod parse time for all `aliasState*` IPC handlers
- Added explicit absolute path check in all four `phase_state_*` handlers in `packages/daemon/src/work-items-server.ts` before calling `resolve()`, returning a clear error message (`"repoRoot must be an absolute path"`)
- Both surfaces previously accepted relative paths like `"../other-repo"` which `path.resolve()` silently made absolute relative to the daemon's cwd, risking the same logical repoRoot mapping to different `alias_state` rows across restarts

## Test plan
- [x] Added test in `alias-state.spec.ts`: relative `repoRoot` is rejected for all four `aliasState*` methods with an error containing "absolute"
- [x] Added test in `work-items-server.spec.ts`: relative `repoRoot` is rejected for all four `phase_state_*` tools with `isError: true` and message containing "absolute"
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test packages/daemon/src/alias-state.spec.ts packages/daemon/src/work-items-server.spec.ts` — 72 tests pass
- [x] Full `bun test` — exit code 0 (Bun segfault on worker teardown unrelated to this change; crash report submitted to bun.report)

🤖 Generated with [Claude Code](https://claude.com/claude-code)