### PR TITLE
fix(containment): use homedir() instead of process.cwd() in symlink test (fixes #1687)

### DIFF
--- a/packages/daemon/src/claude-session/containment.spec.ts
+++ b/packages/daemon/src/claude-session/containment.spec.ts
@@ -609,6 +609,7 @@ describe("ContainmentGuard — symlink path traversal", () => {
     // process.cwd() because the latter may be under /private/tmp (e.g. in a QA worktree),
     // which would cause resolveRealpath to return a path that passes the prefix check.
     const linkPath = join("/tmp", `mcp-containment-test-${process.pid}`);
+    rmSync(linkPath, { force: true }); // guard against EEXIST from a crashed prior run
     symlinkSync(homedir(), linkPath);
     try {
       const g = new ContainmentGuard("/unrelated/worktree");

--- a/packages/daemon/src/claude-session/containment.spec.ts
+++ b/packages/daemon/src/claude-session/containment.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { ContainmentGuard } from "./containment";
 
@@ -605,9 +605,11 @@ describe("ContainmentGuard — symlink path traversal", () => {
 
   test("denies Write to /tmp symlink pointing outside allowed prefixes", () => {
     // Nominal path starts with /tmp/ so old resolve()-based check would allow it,
-    // but real target is process.cwd() (the project dir, not under any allowed prefix).
+    // but real target is outside any allowed prefix. We use homedir() instead of
+    // process.cwd() because the latter may be under /private/tmp (e.g. in a QA worktree),
+    // which would cause resolveRealpath to return a path that passes the prefix check.
     const linkPath = join("/tmp", `mcp-containment-test-${process.pid}`);
-    symlinkSync(process.cwd(), linkPath);
+    symlinkSync(homedir(), linkPath);
     try {
       const g = new ContainmentGuard("/unrelated/worktree");
       const r = g.evaluate("Write", { file_path: join(linkPath, "evil.ts") });


### PR DESCRIPTION
## Summary
- The symlink traversal test used `process.cwd()` as the symlink target, which fails when the test runner's CWD is under `/private/tmp` (e.g. a QA worktree) — `resolveRealpath` resolves to a path under `ALLOWED_EXTERNAL_PREFIXES`, making the guard allow instead of deny
- Replaced with `homedir()` which always exists on the filesystem and is guaranteed to never be under `/tmp`/`/private/tmp` on any platform
- Added `homedir` to the existing `node:os` import

## Test plan
- [x] `bun test packages/daemon/src/claude-session/containment.spec.ts` — 78 pass
- [x] `bun test` full suite — 6463 pass, 0 fail
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)