### PR TITLE
fix(auth): introduce OAuthCallbackTimeoutError for compile-safe timeout detection (fixes #1637)

### DIFF
--- a/packages/daemon/src/auth/callback-server.spec.ts
+++ b/packages/daemon/src/auth/callback-server.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { type CallbackServer, startCallbackServer } from "./callback-server";
+import { type CallbackServer, OAuthCallbackTimeoutError, startCallbackServer } from "./callback-server";
 
 describe("startCallbackServer", () => {
   let server: CallbackServer | undefined;
@@ -94,6 +94,7 @@ describe("startCallbackServer", () => {
 
       const [result] = await settled;
       expect(result.status).toBe("rejected");
+      expect((result as PromiseRejectedResult).reason).toBeInstanceOf(OAuthCallbackTimeoutError);
       expect((result as PromiseRejectedResult).reason.message).toContain("timeout");
     } finally {
       globalThis.setTimeout = origSetTimeout;

--- a/packages/daemon/src/auth/callback-server.ts
+++ b/packages/daemon/src/auth/callback-server.ts
@@ -29,6 +29,13 @@ const ERROR_HTML = `<!DOCTYPE html>
 <h2>Authentication Error</h2><p>No authorization code received.</p>
 </body></html>`;
 
+export class OAuthCallbackTimeoutError extends Error {
+  constructor() {
+    super("OAuth callback timeout (2 minutes)");
+    this.name = "OAuthCallbackTimeoutError";
+  }
+}
+
 export function startCallbackServer(preferredPort?: number): CallbackServer {
   // Promise executor runs synchronously, so these are assigned before use
   let resolveCode = (_code: string): void => {};
@@ -91,7 +98,7 @@ export function startCallbackServer(preferredPort?: number): CallbackServer {
     if (!stopped) {
       stopped = true;
       server.stop(true);
-      rejectCode(new Error("OAuth callback timeout (2 minutes)"));
+      rejectCode(new OAuthCallbackTimeoutError());
     }
   }, 120_000);
 

--- a/packages/daemon/src/auth/oauth-retry.spec.ts
+++ b/packages/daemon/src/auth/oauth-retry.spec.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { StateDb } from "../db/state";
 import { metrics } from "../metrics";
+import { OAuthCallbackTimeoutError } from "./callback-server";
 import type { CallbackServer } from "./callback-server";
 import type { KeychainTokens } from "./keychain";
 import { runOAuthFlowWithDcrRetry } from "./oauth-retry";
@@ -134,7 +135,7 @@ describe("runOAuthFlowWithDcrRetry", () => {
           callbackNum++;
           if (callbackNum === 1) {
             // First attempt: no callback received within the timeout window
-            return makeCallback(Promise.reject(new Error("OAuth callback timeout (2 minutes)")));
+            return makeCallback(Promise.reject(new OAuthCallbackTimeoutError()));
           }
           // Second attempt: user completes consent
           return makeCallback(Promise.resolve("code-fresh"));
@@ -180,7 +181,7 @@ describe("runOAuthFlowWithDcrRetry", () => {
         startCallbackServer: () => {
           callbackNum++;
           if (callbackNum === 1) {
-            return makeCallback(Promise.reject(new Error("OAuth callback timeout (2 minutes)")));
+            return makeCallback(Promise.reject(new OAuthCallbackTimeoutError()));
           }
           return makeCallback(Promise.resolve("code-fresh"));
         },
@@ -214,7 +215,7 @@ describe("runOAuthFlowWithDcrRetry", () => {
         },
         startCallbackServer: () => {
           callbackNum++;
-          if (callbackNum === 1) return makeCallback(Promise.reject(new Error("OAuth callback timeout (2 minutes)")));
+          if (callbackNum === 1) return makeCallback(Promise.reject(new OAuthCallbackTimeoutError()));
           return makeCallback(Promise.resolve("code-x"));
         },
       },
@@ -243,7 +244,7 @@ describe("runOAuthFlowWithDcrRetry", () => {
         {},
         {
           authFn: async () => "REDIRECT",
-          startCallbackServer: () => makeCallback(Promise.reject(new Error("OAuth callback timeout (2 minutes)"))),
+          startCallbackServer: () => makeCallback(Promise.reject(new OAuthCallbackTimeoutError())),
         },
       ),
     ).rejects.toThrow();
@@ -270,7 +271,7 @@ describe("runOAuthFlowWithDcrRetry", () => {
           authFn: async () => "REDIRECT",
           startCallbackServer: () => {
             callbackNum++;
-            return makeCallback(Promise.reject(new Error("OAuth callback timeout (2 minutes)")));
+            return makeCallback(Promise.reject(new OAuthCallbackTimeoutError()));
           },
         },
       ),

--- a/packages/daemon/src/auth/oauth-retry.ts
+++ b/packages/daemon/src/auth/oauth-retry.ts
@@ -12,7 +12,7 @@ import { auth } from "@modelcontextprotocol/sdk/client/auth.js";
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
 import type { StateDb } from "../db/state";
 import { metrics } from "../metrics";
-import { type CallbackServer, startCallbackServer } from "./callback-server";
+import { type CallbackServer, OAuthCallbackTimeoutError, startCallbackServer } from "./callback-server";
 import { DEFAULT_OAUTH_SCOPE, McpOAuthProvider, type OAuthProviderOpts } from "./oauth-provider";
 
 export interface OAuthRetryDeps {
@@ -69,7 +69,7 @@ export async function runOAuthFlowWithDcrRetry(
       }
       return "authenticated";
     } catch (err) {
-      const isTimeout = err instanceof Error && err.message.startsWith("OAuth callback timeout");
+      const isTimeout = err instanceof OAuthCallbackTimeoutError;
       if (isTimeout && attempt < MAX_RETRIES) {
         console.error(
           "[auth] OAuth callback timed out (possibly 5xx on authorize) — deleting cached client registration and retrying...",


### PR DESCRIPTION
## Summary
- Export `OAuthCallbackTimeoutError extends Error` from `callback-server.ts` and throw it in the 2-minute timeout branch instead of a plain `Error`
- Update `oauth-retry.ts` to detect timeouts via `err instanceof OAuthCallbackTimeoutError` instead of the fragile `err.message.startsWith("OAuth callback timeout")` string check
- Update both spec files to use `OAuthCallbackTimeoutError` in test stubs and assert the correct type in the callback-server timeout test

## Test plan
- [ ] `bun test packages/daemon/src/auth/callback-server.spec.ts` — timeout test now asserts `instanceof OAuthCallbackTimeoutError`
- [ ] `bun test packages/daemon/src/auth/oauth-retry.spec.ts` — all retry tests use typed error; all 21 tests pass
- [ ] `bun typecheck` — no errors
- [ ] `bun lint` — no issues
- [ ] Full suite: 6463 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)