### PR TITLE
fix(test): resolve exited promise on kill in #1836 parallel session mock (fixes #1888)

### DIFF
--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -4743,10 +4743,19 @@ describe("parallel spawn (#1836)", () => {
     const spawnFn: SpawnFn = () => {
       spawnCount++;
       const pid = 10000 + spawnCount;
+      let resolveExited: ((code: number) => void) | undefined;
+      let killed = false;
+      const exited = new Promise<number>((resolve) => {
+        resolveExited = resolve;
+      });
       return {
         pid,
-        exited: new Promise<number>(() => {}),
-        kill: () => {},
+        exited,
+        kill: () => {
+          if (killed) return;
+          killed = true;
+          resolveExited?.(0);
+        },
       };
     };
     server = new ClaudeWsServer({ spawn: spawnFn, logger: silentLogger });


### PR DESCRIPTION
## Summary
- The custom `spawnFn` in the `"3 sessions prepared before any spawn"` test had a never-resolving `exited` promise and a no-op `kill()`, causing ~7s of unnecessary delay per session during `afterEach` cleanup
- Each mock process now uses a per-invocation closure so `kill()` resolves its own `exited` promise, matching the `mockSpawn()` helper pattern
- Cleanup is now immediate instead of waiting for SIGTERM + SIGKILL timeouts

## Test plan
- [x] `bun test packages/daemon/src/claude-session/ws-server.spec.ts` — all 199 tests pass in under 5s
- [x] `bun typecheck` — no errors
- [x] `bun lint` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)