### PR TITLE
fix(test): make worktree-name uniqueness test deterministic (closes #1889)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -152,18 +152,34 @@ describe("parseSpawnArgs", () => {
   test("auto-generated worktree names are unique even when Date.now is frozen (#1836)", () => {
     // Freeze Date.now to reproduce the same-millisecond condition that caused
     // collisions with the old `claude-${Date.now().toString(36)}` scheme.
-    const orig = Date.now;
+    // Mock crypto.randomUUID to a deterministic counter so the test is never
+    // probabilistically flaky (original relied on 8 hex chars never colliding
+    // across 50 calls — ~1-in-3.5M chance of false failure, see #1889).
+    const origDateNow = Date.now;
     Date.now = () => 1_745_913_600_000;
+    const origRandomUUID = globalThis.crypto.randomUUID;
+    let callCount = 0;
+    Object.defineProperty(globalThis.crypto, "randomUUID", {
+      value: () => {
+        const prefix = callCount.toString(16).padStart(8, "0");
+        callCount++;
+        return `${prefix}-0000-4000-8000-000000000000`;
+      },
+      configurable: true,
+      writable: true,
+    });
     try {
-      const names = new Set<string>();
       for (let i = 0; i < 50; i++) {
         const result = parseSpawnArgs(["--worktree", "--task", "x"]);
-        const wt = result.worktree ?? "";
-        expect(names.has(wt)).toBe(false);
-        names.add(wt);
+        expect(result.worktree).toBe(`claude-${i.toString(16).padStart(8, "0")}`);
       }
     } finally {
-      Date.now = orig;
+      Date.now = origDateNow;
+      Object.defineProperty(globalThis.crypto, "randomUUID", {
+        value: origRandomUUID,
+        configurable: true,
+        writable: true,
+      });
     }
   });
 

--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -157,7 +157,10 @@ describe("parseSpawnArgs", () => {
     // across 50 calls — ~1-in-3.5M chance of false failure, see #1889).
     const origDateNow = Date.now;
     Date.now = () => 1_745_913_600_000;
-    const origRandomUUID = globalThis.crypto.randomUUID;
+    // Capture the full own-property descriptor so we restore exactly what existed.
+    // If randomUUID is inherited (no own descriptor), deleting the shadowing own
+    // property we install is the correct restore path.
+    const origDescriptor = Object.getOwnPropertyDescriptor(globalThis.crypto, "randomUUID");
     let callCount = 0;
     Object.defineProperty(globalThis.crypto, "randomUUID", {
       value: () => {
@@ -175,11 +178,11 @@ describe("parseSpawnArgs", () => {
       }
     } finally {
       Date.now = origDateNow;
-      Object.defineProperty(globalThis.crypto, "randomUUID", {
-        value: origRandomUUID,
-        configurable: true,
-        writable: true,
-      });
+      if (origDescriptor) {
+        Object.defineProperty(globalThis.crypto, "randomUUID", origDescriptor);
+      } else {
+        Reflect.deleteProperty(globalThis.crypto, "randomUUID");
+      }
     }
   });
 


### PR DESCRIPTION
## Summary
- Replaced the probabilistic uniqueness test (50 random 8-hex-char values never colliding, ~1-in-3.5M flake risk) with a deterministic mock of `crypto.randomUUID`
- Mock uses a sequential counter so each of the 50 calls returns a predictable value and the test asserts exact expected names instead of just checking for set membership
- No production code changes — test-only fix

## Test plan
- [x] The modified test in `claude.spec.ts` passes with exact name assertions
- [x] `bun typecheck` passes
- [x] `bun lint` passes (no fixes applied)
- [x] Full pre-commit hook suite passes (333 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)