### PR TITLE
test(db): strengthen migration idempotency test + fix dead version local (fixes #1893, fixes #1894)

### DIFF
--- a/packages/daemon/src/db/state.spec.ts
+++ b/packages/daemon/src/db/state.spec.ts
@@ -1941,7 +1941,8 @@ describe("StateDb", () => {
       const db1 = new StateDb(p);
 
       // Downgrade schema_version to 1 and insert a trailing-slash row while the
-      // DB is still open (avoids a second migrate() call on re-open).
+      // DB is still open — accessing db1's raw handle avoids opening a second
+      // StateDb (which would re-run migrate() and reset version back to 3).
       // biome-ignore lint/complexity/useLiteralKeys: access private field for test
       const raw = db1["db"];
       raw.run("UPDATE schema_versions SET version = 1 WHERE name = 'state'");

--- a/packages/daemon/src/db/state.spec.ts
+++ b/packages/daemon/src/db/state.spec.ts
@@ -1936,23 +1936,31 @@ describe("StateDb", () => {
     test("data migrations run exactly once (not on every boot)", () => {
       const p = tmpDb();
       paths.push(p);
+
+      // Open fresh DB — migrations run v0→v3, schema_version lands at 3.
       const db1 = new StateDb(p);
 
-      // Insert alias_state with trailing slash — this should be canonicalized by v2
+      // Downgrade schema_version to 1 and insert a trailing-slash row while the
+      // DB is still open (avoids a second migrate() call on re-open).
       // biome-ignore lint/complexity/useLiteralKeys: access private field for test
-      db1["db"].run(
+      const raw = db1["db"];
+      raw.run("UPDATE schema_versions SET version = 1 WHERE name = 'state'");
+      raw.run(
         "INSERT INTO alias_state (repo_root, namespace, key, value_json, updated_at) VALUES (?, ?, ?, ?, unixepoch())",
         ["/repo/", "ns", "k", '"val"'],
       );
       db1.close();
 
-      // Re-open — v2 already ran, so the trailing-slash row persists as-is
-      // (not re-canonicalized, because migrations don't re-run)
+      // Re-open — v2 runs because schema_version was 1; row should be canonicalized.
       const db2 = new StateDb(p);
-      // The row should still have the trailing slash because v2 already ran on first boot
-      // (when there was no data). The trailing-slash row was inserted AFTER v2 ran.
-      expect(db2.getAliasState("/repo/", "ns", "k")).toBe("val");
+      expect(db2.getAliasState("/repo", "ns", "k")).toBe("val");
+      expect(db2.getAliasState("/repo/", "ns", "k")).toBeUndefined();
       db2.close();
+
+      // Re-open again — migrations do NOT re-run; canonical row persists unchanged.
+      const db3 = new StateDb(p);
+      expect(db3.getAliasState("/repo", "ns", "k")).toBe("val");
+      db3.close();
     });
 
     test("all expected tables are created on fresh DB", () => {

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -199,6 +199,7 @@ export class StateDb {
         }
         this.setSchemaVersion(CONSUMER, 3);
       })();
+      version = 3;
     }
   }
 


### PR DESCRIPTION
## Summary
- **#1893**: Rewrites the "data migrations run exactly once" test to actually prove idempotency: open DB to v3, force `schema_version=1`, insert a trailing-slash row, reopen (v2 canonicalizes it), assert the canonical form is present and the trailing-slash variant is gone, then reopen a third time to verify no re-run.
- **#1894**: Adds `version = 3` after the `if (version < 3)` block in `StateDb.migrate()` so the local variable tracks the live version throughout and doesn't mislead readers.

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test packages/daemon/src/db/state.spec.ts` — 150 pass, 0 fail
- [x] Pre-commit hook (typecheck + lint + test + coverage) passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)