### PR TITLE
fix(claude): status bundle — footprint line counts, help text, error message (fixes #1903, #1904, #1905, #1906)

### DIFF
--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -311,9 +311,14 @@ async function cmdClaudeInternal(args: string[], deps?: Partial<ClaudeDeps>): Pr
     case "patch-update":
       await claudePatchUpdate(subArgs, d);
       break;
+    case "status": {
+      const { cmdAgent } = await import("./agent");
+      await cmdAgent(["claude", sub, ...subArgs]);
+      break;
+    }
     default:
       d.printError(
-        `Unknown claude subcommand: ${sub}. Use "spawn", "resume", "ls", "send", "bye", "interrupt", "log", "wait", "approve", "deny", "patch-update", or "worktrees".`,
+        `Unknown claude subcommand: ${sub}. Use "spawn", "resume", "ls", "send", "bye", "interrupt", "log", "wait", "approve", "deny", "patch-update", "worktrees", or "status".`,
       );
       d.exit(1);
   }
@@ -2094,6 +2099,7 @@ Usage:
   mcx claude log <session> --json          Raw JSON transcript output
   mcx claude log <session> --json --jq '.' Apply jq filter to JSON output
   mcx claude log <session> --full          Full output (no truncation)
+  mcx claude status <target>[,<target>...] [--json]  One-shot session inspector
   mcx claude worktrees                     List mcx-created worktrees
   mcx claude worktrees --prune             Remove orphaned worktrees + merged branches
   mcx claude patch-update                  Refresh the patched copy used for mcx spawns (#1808)

--- a/packages/command/src/commands/session-display.spec.ts
+++ b/packages/command/src/commands/session-display.spec.ts
@@ -326,28 +326,35 @@ describe("walkTranscript", () => {
     expect(stats.lastResult).toBe("Done! All tests pass.");
   });
 
-  test("aggregates Read tool calls into directory footprint", () => {
+  test("aggregates Read line counts into directory footprint", () => {
     const entries = [
-      makeAssistantMsg([makeToolUse("Read", { file_path: "/src/foo.ts" })]),
-      makeAssistantMsg([makeToolUse("Read", { file_path: "/src/bar.ts" })]),
-      makeAssistantMsg([makeToolUse("Read", { file_path: "/lib/baz.ts" })]),
+      makeAssistantMsg([makeToolUse("Read", { file_path: "/src/foo.ts", limit: 100 })]),
+      makeAssistantMsg([makeToolUse("Read", { file_path: "/src/bar.ts", limit: 50 })]),
+      makeAssistantMsg([makeToolUse("Read", { file_path: "/lib/baz.ts", limit: 200 })]),
     ];
     const stats = walkTranscript(entries);
     const src = stats.directoryFootprint.find((e) => e.dir === "/src");
-    expect(src?.reads).toBe(2);
+    expect(src?.reads).toBe(150); // 100 + 50
     expect(src?.writes).toBe(0);
     const lib = stats.directoryFootprint.find((e) => e.dir === "/lib");
-    expect(lib?.reads).toBe(1);
+    expect(lib?.reads).toBe(200);
   });
 
-  test("aggregates Write/Edit into directory footprint writes", () => {
+  test("Read without limit defaults to 2000 lines", () => {
+    const entries = [makeAssistantMsg([makeToolUse("Read", { file_path: "/src/foo.ts" })])];
+    const stats = walkTranscript(entries);
+    const src = stats.directoryFootprint.find((e) => e.dir === "/src");
+    expect(src?.reads).toBe(2000);
+  });
+
+  test("aggregates Write byte count and Edit line count into directory footprint writes", () => {
     const entries = [
-      makeAssistantMsg([makeToolUse("Write", { file_path: "/src/foo.ts", content: "x" })]),
-      makeAssistantMsg([makeToolUse("Edit", { file_path: "/src/bar.ts", old_string: "a", new_string: "b" })]),
+      makeAssistantMsg([makeToolUse("Write", { file_path: "/src/foo.ts", content: "hello world" })]), // 11 bytes
+      makeAssistantMsg([makeToolUse("Edit", { file_path: "/src/bar.ts", old_string: "a", new_string: "x\ny\nz" })]), // 3 lines
     ];
     const stats = walkTranscript(entries);
     const src = stats.directoryFootprint.find((e) => e.dir === "/src");
-    expect(src?.writes).toBe(2);
+    expect(src?.writes).toBe(14); // 11 bytes + 3 lines
     expect(src?.reads).toBe(0);
   });
 
@@ -380,15 +387,15 @@ describe("walkTranscript", () => {
 
   test("sorts footprint by total activity descending", () => {
     const entries = [
-      makeAssistantMsg([makeToolUse("Read", { file_path: "/a/f.ts" })]),
-      makeAssistantMsg([makeToolUse("Read", { file_path: "/b/f.ts" })]),
-      makeAssistantMsg([makeToolUse("Read", { file_path: "/b/g.ts" })]),
-      makeAssistantMsg([makeToolUse("Write", { file_path: "/b/h.ts", content: "" })]),
+      makeAssistantMsg([makeToolUse("Read", { file_path: "/a/f.ts", limit: 10 })]),
+      makeAssistantMsg([makeToolUse("Read", { file_path: "/b/f.ts", limit: 10 })]),
+      makeAssistantMsg([makeToolUse("Read", { file_path: "/b/g.ts", limit: 10 })]),
+      makeAssistantMsg([makeToolUse("Write", { file_path: "/b/h.ts", content: "hello" })]),
     ];
     const stats = walkTranscript(entries);
     expect(stats.directoryFootprint[0].dir).toBe("/b");
-    expect(stats.directoryFootprint[0].reads).toBe(2);
-    expect(stats.directoryFootprint[0].writes).toBe(1);
+    expect(stats.directoryFootprint[0].reads).toBe(20); // 2 × 10
+    expect(stats.directoryFootprint[0].writes).toBe(5); // "hello".length
   });
 
   test("returns empty stats for empty transcript", () => {

--- a/packages/command/src/commands/session-display.ts
+++ b/packages/command/src/commands/session-display.ts
@@ -88,11 +88,17 @@ export function walkTranscript(entries: TranscriptEntry[], lastQueryCount = 3): 
 
           if (name === "Read" && typeof input.file_path === "string") {
             const d = dirname(input.file_path);
-            dirReads.set(d, (dirReads.get(d) ?? 0) + 1);
-          } else if (
-            (name === "Edit" || name === "Write" || name === "MultiEdit") &&
-            typeof input.file_path === "string"
-          ) {
+            const lines = typeof input.limit === "number" ? input.limit : 2000;
+            dirReads.set(d, (dirReads.get(d) ?? 0) + lines);
+          } else if (name === "Write" && typeof input.file_path === "string") {
+            const d = dirname(input.file_path);
+            const bytes = typeof input.content === "string" ? input.content.length : 0;
+            dirWrites.set(d, (dirWrites.get(d) ?? 0) + bytes);
+          } else if (name === "Edit" && typeof input.file_path === "string") {
+            const d = dirname(input.file_path);
+            const lines = typeof input.new_string === "string" ? input.new_string.split("\n").length : 0;
+            dirWrites.set(d, (dirWrites.get(d) ?? 0) + lines);
+          } else if (name === "MultiEdit" && typeof input.file_path === "string") {
             const d = dirname(input.file_path);
             dirWrites.set(d, (dirWrites.get(d) ?? 0) + 1);
           } else if (name === "Bash" && typeof input.command === "string") {
@@ -221,7 +227,7 @@ export function formatStatusStanza(
   // Directory footprint
   if (stats.directoryFootprint.length > 0) {
     lines.push("");
-    lines.push("Directory footprint (read / write):");
+    lines.push("Directory footprint (read / write lines):");
     const maxDir = Math.min(stats.directoryFootprint.length, 6);
     const dirColWidth = Math.max(...stats.directoryFootprint.slice(0, maxDir).map((e) => e.dir.length), 10) + 2;
     for (let i = 0; i < maxDir; i++) {

--- a/packages/command/src/help-claude.ts
+++ b/packages/command/src/help-claude.ts
@@ -148,6 +148,14 @@ registerHelp("claude deny", {
   ],
 });
 
+registerHelp("claude status", {
+  name: "mcx claude status",
+  summary: "One-shot session inspector — show transcript metrics for one or more sessions",
+  usage: ["mcx claude status <target>", "mcx claude status <target1>,<target2>", "mcx claude status <target> --json"],
+  options: [["--json", "Output raw JSON instead of formatted display"]],
+  examples: ["mcx claude status Alice", "mcx claude status Alice,Bob", "mcx claude status abc123 --json"],
+});
+
 registerHelp("claude patch-update", {
   name: "mcx claude patch-update",
   summary: "Refresh the patched copy of claude used for mcx-spawned sessions (see #1808)",


### PR DESCRIPTION
## Summary

- **#1903**: `walkTranscript()` directory footprint now accumulates real line/byte counts instead of call counts: Read uses `input.limit` (defaulting to 2000), Write uses `input.content.length` (bytes), Edit uses `input.new_string.split("\\n").length` (lines). Header updated to "Directory footprint (read / write lines):".
- **#1904**: Target whitespace trimming already present — `.map((s) => s.trim())` was in `agentStatus()` at agent.ts:1602. No code change needed; closing as confirmed fix.
- **#1905/#1906**: Added `status` to `printClaudeUsage()`, `cmdClaudeInternal` switch (forwards to `cmdAgent`), the unknown-subcommand error message, and `registerHelp("claude status", ...)` in `help-claude.ts`.

## Test plan

- [x] Updated `session-display.spec.ts`: read line count accumulation, Write byte count, Edit line count, default-2000 fallback, sort-by-total tests all pass
- [x] `bun typecheck` clean
- [x] `bun lint` clean
- [x] Full test suite: 6464 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)