### PR TITLE
lint: enforce sessions.delete before await in session-teardown methods (fixes #1897)

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -67,6 +67,9 @@ if $has_source; then
   echo "  lint:timeouts..."
   bun run lint:timeouts
 
+  echo "  lint:teardown..."
+  bun run lint:teardown
+
   echo "  check:phase-drift..."
   bun run check:phase-drift
 
@@ -91,6 +94,9 @@ elif $has_config; then
 
   echo "  lint:timeouts..."
   bun run lint:timeouts
+
+  echo "  lint:teardown..."
+  bun run lint:teardown
 
   echo "Config checks passed (tests skipped)."
 else

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "lint:check": "bun install && bunx biome check .",
     "lint:shell": "bun scripts/check-shell-injection.ts",
     "lint:timeouts": "bun scripts/check-test-timeouts.ts",
+    "lint:teardown": "bun scripts/check-session-teardown.ts",
     "check:phase-drift": "bun scripts/check-phase-drift.ts",
     "test": "bun install && bun test",
     "test:coverage": "bun scripts/check-coverage.ts",

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -1128,8 +1128,8 @@ export class ClaudeWsServer {
     // Remove from map before the guard scan so that concurrent bye() calls on sessions
     // sharing the same worktree don't see each other and both suppress — which would
     // leave the worktree orphaned. JS is single-threaded: this delete is visible to any
-    // bye() that starts after the next await. terminateSession's own sessions.delete is
-    // now a no-op but kept for safety.
+    // bye() that starts after the next await. terminateSession also deletes before its
+    // first await (idempotent here, primary for all other call sites).
     this.sessions.delete(resolvedId);
 
     // Guard: suppress worktree cleanup if another session references the same worktree.
@@ -2338,6 +2338,12 @@ export class ClaudeWsServer {
     }
     session.ws = null;
 
+    // Remove from map before any await so concurrent bye() or terminateSession()
+    // calls that start after the next microtask turn won't find the session in the
+    // map. JS is single-threaded: this delete is visible to any caller that begins
+    // after this point. Idempotent when bye() already deleted it.
+    this.sessions.delete(sessionId);
+
     // Kill process and await exit.
     // Null refs first so the proc.exited handler skips the stale exit
     // and no other path can signal a recycled PID.
@@ -2355,9 +2361,6 @@ export class ClaudeWsServer {
       session.pid = null;
       await this.killRawPid(pid, session.pidStartTime);
     }
-
-    // Remove from map
-    this.sessions.delete(sessionId);
   }
 }
 

--- a/scripts/check-session-teardown.spec.ts
+++ b/scripts/check-session-teardown.spec.ts
@@ -41,6 +41,39 @@ describe("findAsyncMethods", () => {
     expect(methods[0].endLine).toBe(6);
   });
 
+  test("finds method with multi-line object return type (Promise<{...}>)", () => {
+    // Regression: '{' inside the generic return type annotation must not be
+    // treated as the body start. The real body '{' comes after '}>' closes.
+    const lines = [
+      "async function handlePrompt(args: Record<string, unknown>): Promise<{",
+      "  content: Array<{ type: string }>;",
+      "  isError?: boolean;",
+      "}> {",
+      "  this.sessions.delete(id);",
+      "  await this.work();",
+      "}",
+    ];
+    const methods = findAsyncMethods(lines);
+    expect(methods).toHaveLength(1);
+    expect(methods[0].name).toBe("handlePrompt");
+    expect(methods[0].startLine).toBe(0);
+    expect(methods[0].endLine).toBe(6);
+  });
+
+  test("finds method with inline object return type (Promise<{ x: string }>)", () => {
+    const lines = [
+      "  async start(): Promise<{ client: Client; transport: Transport }> {",
+      "    await this.connect();",
+      "    return { client: this.client, transport: this.transport };",
+      "  }",
+    ];
+    const methods = findAsyncMethods(lines);
+    expect(methods).toHaveLength(1);
+    expect(methods[0].name).toBe("start");
+    expect(methods[0].startLine).toBe(0);
+    expect(methods[0].endLine).toBe(3);
+  });
+
   test("does not find non-async methods", () => {
     const lines = ["class Foo {", "  delete(id: string): void {", "    this.sessions.delete(id);", "  }", "}"];
     expect(findAsyncMethods(lines)).toHaveLength(0);

--- a/scripts/check-session-teardown.spec.ts
+++ b/scripts/check-session-teardown.spec.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from "bun:test";
+import { checkMethodViolation, findAsyncMethods } from "./check-session-teardown";
+
+describe("findAsyncMethods", () => {
+  test("finds a simple async method", () => {
+    const lines = ["class Foo {", "  async bar(x: string): Promise<void> {", "    await something();", "  }", "}"];
+    const methods = findAsyncMethods(lines);
+    expect(methods).toHaveLength(1);
+    expect(methods[0].name).toBe("bar");
+    expect(methods[0].startLine).toBe(1);
+    expect(methods[0].endLine).toBe(3);
+  });
+
+  test("finds method with access modifiers", () => {
+    const lines = [
+      "class Foo {",
+      "  private async terminateSession(id: string, s: Session): Promise<void> {",
+      "    await this.kill();",
+      "  }",
+      "}",
+    ];
+    const methods = findAsyncMethods(lines);
+    expect(methods).toHaveLength(1);
+    expect(methods[0].name).toBe("terminateSession");
+  });
+
+  test("finds method with multi-line signature", () => {
+    const lines = [
+      "  async bye(",
+      "    sessionId: string,",
+      "    message?: string,",
+      "  ): Promise<void> {",
+      "    this.sessions.delete(sessionId);",
+      "    await this.terminate();",
+      "  }",
+    ];
+    const methods = findAsyncMethods(lines);
+    expect(methods).toHaveLength(1);
+    expect(methods[0].name).toBe("bye");
+    expect(methods[0].startLine).toBe(0);
+    expect(methods[0].endLine).toBe(6);
+  });
+
+  test("does not find non-async methods", () => {
+    const lines = ["class Foo {", "  delete(id: string): void {", "    this.sessions.delete(id);", "  }", "}"];
+    expect(findAsyncMethods(lines)).toHaveLength(0);
+  });
+
+  test("does not find anonymous async arrow functions", () => {
+    const lines = [
+      "  proc.exited.then(async () => {",
+      "    await drainDone;",
+      "    this.sessions.delete(id);",
+      "  });",
+    ];
+    expect(findAsyncMethods(lines)).toHaveLength(0);
+  });
+
+  test("does not find async keyword in comments", () => {
+    const lines = ["  // async fakeMethod(x: string) {", "  //   await something();", "  // }"];
+    expect(findAsyncMethods(lines)).toHaveLength(0);
+  });
+
+  test("finds multiple async methods in sequence", () => {
+    const lines = [
+      "  async foo(): Promise<void> {",
+      "    await a();",
+      "  }",
+      "  async bar(): Promise<void> {",
+      "    await b();",
+      "  }",
+    ];
+    const methods = findAsyncMethods(lines);
+    expect(methods).toHaveLength(2);
+    expect(methods[0].name).toBe("foo");
+    expect(methods[1].name).toBe("bar");
+  });
+});
+
+describe("checkMethodViolation", () => {
+  test("no violation: delete before await", () => {
+    const lines = [
+      "  async bye(sessionId: string): Promise<void> {",
+      "    const info = this.extract(sessionId);",
+      "    this.sessions.delete(sessionId);",
+      "    await this.terminate(sessionId);",
+      "  }",
+    ];
+    const method = { name: "bye", startLine: 0, endLine: 4 };
+    expect(checkMethodViolation(lines, method)).toBeNull();
+  });
+
+  test("violation: delete after first await", () => {
+    const lines = [
+      "  private async terminateSession(id: string): Promise<void> {",
+      "    this.endState();",
+      "    await this.killProc();",
+      "    this.sessions.delete(id);",
+      "  }",
+    ];
+    const method = { name: "terminateSession", startLine: 0, endLine: 4 };
+    const result = checkMethodViolation(lines, method);
+    expect(result).not.toBeNull();
+    expect(result?.awaitLine).toBe(2); // 0-indexed line 2
+    expect(result?.deleteLine).toBe(3); // 0-indexed line 3
+  });
+
+  test("no violation: delete but no await", () => {
+    const lines = ["  removeUnspawned(id: string): void {", "    this.sessions.delete(id);", "  }"];
+    const method = { name: "removeUnspawned", startLine: 0, endLine: 2 };
+    expect(checkMethodViolation(lines, method)).toBeNull();
+  });
+
+  test("no violation: await but no delete", () => {
+    const lines = ["  async stop(): Promise<void> {", "    await this.killAll();", "  }"];
+    const method = { name: "stop", startLine: 0, endLine: 2 };
+    expect(checkMethodViolation(lines, method)).toBeNull();
+  });
+
+  test("no violation: await comment does not count", () => {
+    const lines = [
+      "  async foo(): Promise<void> {",
+      "    // await something(); ← this is not real",
+      "    this.sessions.delete(id);",
+      "    await this.realWork();",
+      "  }",
+    ];
+    const method = { name: "foo", startLine: 0, endLine: 4 };
+    // The comment line with 'await' should not count as the first await.
+    // So delete at line 2 is before real await at line 3 → no violation.
+    expect(checkMethodViolation(lines, method)).toBeNull();
+  });
+
+  test("no violation: inline comment await does not count as first await", () => {
+    const lines = [
+      "  async foo(): Promise<void> {",
+      "    const x = 1; // await happens later",
+      "    this.sessions.delete(id);",
+      "    await this.realWork();",
+      "  }",
+    ];
+    const method = { name: "foo", startLine: 0, endLine: 4 };
+    expect(checkMethodViolation(lines, method)).toBeNull();
+  });
+
+  test("violation: delete after second await still detected", () => {
+    const lines = [
+      "  private async cleanup(id: string): Promise<void> {",
+      "    await this.firstStep();",
+      "    await this.secondStep();",
+      "    this.sessions.delete(id);",
+      "  }",
+    ];
+    const method = { name: "cleanup", startLine: 0, endLine: 4 };
+    const result = checkMethodViolation(lines, method);
+    expect(result).not.toBeNull();
+    // Reports the FIRST await (line 1), not the second
+    expect(result?.awaitLine).toBe(1);
+    expect(result?.deleteLine).toBe(3);
+  });
+});

--- a/scripts/check-session-teardown.ts
+++ b/scripts/check-session-teardown.ts
@@ -83,14 +83,20 @@ export function findAsyncMethods(lines: string[]): MethodRegion[] {
 
     // Scan forward from the match position to find the opening '{' of the body.
     // Track paren depth to skip past the parameter list and return type annotation.
+    // Track angle-bracket depth to skip '{' inside generic return types like
+    // Promise<{ result: string }> — the '{' inside '<>' is not the body start.
     let bodyStart = -1;
+    let bodyStartCol = -1; // column of the '{' within lines[bodyStart]
     let parenDepth = 0;
     let seenOpenParen = false;
+    let angleBracketDepth = 0;
 
     outer: for (let j = i; j < Math.min(i + 20, lines.length); j++) {
       // On the first line, start scanning from the match position to avoid
       // false-positive '{' in code before the matched signature.
       const segment = j === i ? line.slice(m.index) : lines[j];
+      // segmentOffset: how many characters to add to ci to get the column in lines[j].
+      const segmentOffset = j === i ? m.index : 0;
       for (let ci = 0; ci < segment.length; ci++) {
         const ch = segment[ci];
         if (ch === "(") {
@@ -98,8 +104,13 @@ export function findAsyncMethods(lines: string[]): MethodRegion[] {
           seenOpenParen = true;
         } else if (ch === ")") {
           parenDepth--;
-        } else if (ch === "{" && seenOpenParen && parenDepth === 0) {
+        } else if (ch === "<") {
+          angleBracketDepth++;
+        } else if (ch === ">") {
+          if (angleBracketDepth > 0) angleBracketDepth--;
+        } else if (ch === "{" && seenOpenParen && parenDepth === 0 && angleBracketDepth === 0) {
           bodyStart = j;
+          bodyStartCol = segmentOffset + ci;
           break outer;
         } else if (ch === "=" && segment[ci + 1] === ">" && seenOpenParen && parenDepth === 0) {
           // Concise arrow function without braces — skip.
@@ -113,11 +124,15 @@ export function findAsyncMethods(lines: string[]): MethodRegion[] {
       continue;
     }
 
-    // Count braces to find the matching closing brace of the method body.
+    // Count braces from the body-start '{' to find the matching closing brace.
+    // Start at bodyStartCol (not line start) so that return-type '}' characters
+    // that appear earlier on the same line as the body '{' are not counted.
     let depth = 0;
     let endLine = -1;
     for (let k = bodyStart; k < lines.length; k++) {
-      for (const ch of lines[k]) {
+      const startCol = k === bodyStart ? bodyStartCol : 0;
+      for (let c = startCol; c < lines[k].length; c++) {
+        const ch = lines[k][c];
         if (ch === "{") depth++;
         else if (ch === "}") {
           depth--;

--- a/scripts/check-session-teardown.ts
+++ b/scripts/check-session-teardown.ts
@@ -1,0 +1,228 @@
+#!/usr/bin/env bun
+/**
+ * Lint rule: this.sessions.delete must precede the first await in async methods.
+ *
+ * Background: JS is single-threaded but async. In an async method, code before
+ * the first `await` runs atomically. Once an `await` yields, other microtasks
+ * can run. If a method removes a session from the map only after an `await`,
+ * a concurrent teardown call that starts during that yield will still see the
+ * session in the map — a TOCTOU race that can cause double-cleanup or orphaned
+ * worktrees (see #1837, fixed in #1895).
+ *
+ * The invariant: this.sessions.delete must appear before the first `await`
+ * in any async method that calls it, so any concurrent call starting after
+ * that await finds the map already updated.
+ *
+ * Usage:  bun scripts/check-session-teardown.ts
+ *
+ * Exit codes:
+ *   0 — no violations found
+ *   1 — violations found
+ */
+
+import { Glob } from "bun";
+
+const PACKAGES_DIR = new URL("../packages/", import.meta.url).pathname;
+
+interface Violation {
+  file: string;
+  methodLine: number; // 1-indexed
+  methodName: string;
+  awaitLine: number; // 1-indexed, first await before the delete
+  deleteLine: number; // 1-indexed, the out-of-order delete
+}
+
+// Matches async method/function signatures (not anonymous arrow functions).
+// Handles optional access modifiers before async.
+const ASYNC_METHOD_RE =
+  /\b(?:(?:private|public|protected|static|override|abstract)\s+)*async\s+(?:function\s+)?(\w+)\s*\(/;
+
+const SESSIONS_DELETE_RE = /\bthis\.sessions\.delete\s*\(/;
+const AWAIT_RE = /\bawait\b/;
+
+function isCommentLine(line: string): boolean {
+  const t = line.trim();
+  return t.startsWith("//") || t.startsWith("*") || t.startsWith("/*");
+}
+
+function stripInlineComment(line: string): string {
+  const idx = line.indexOf("//");
+  return idx !== -1 ? line.slice(0, idx) : line;
+}
+
+interface MethodRegion {
+  name: string;
+  startLine: number; // 0-indexed
+  endLine: number; // 0-indexed
+}
+
+/**
+ * Find all async method/function regions in the source lines.
+ * Each region covers from the signature line to the closing brace.
+ * Exported for testing.
+ */
+export function findAsyncMethods(lines: string[]): MethodRegion[] {
+  const regions: MethodRegion[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    if (isCommentLine(line)) {
+      i++;
+      continue;
+    }
+
+    const m = ASYNC_METHOD_RE.exec(line);
+    if (!m) {
+      i++;
+      continue;
+    }
+
+    const methodName = m[1];
+
+    // Scan forward from the match position to find the opening '{' of the body.
+    // Track paren depth to skip past the parameter list and return type annotation.
+    let bodyStart = -1;
+    let parenDepth = 0;
+    let seenOpenParen = false;
+
+    outer: for (let j = i; j < Math.min(i + 20, lines.length); j++) {
+      // On the first line, start scanning from the match position to avoid
+      // false-positive '{' in code before the matched signature.
+      const segment = j === i ? line.slice(m.index) : lines[j];
+      for (let ci = 0; ci < segment.length; ci++) {
+        const ch = segment[ci];
+        if (ch === "(") {
+          parenDepth++;
+          seenOpenParen = true;
+        } else if (ch === ")") {
+          parenDepth--;
+        } else if (ch === "{" && seenOpenParen && parenDepth === 0) {
+          bodyStart = j;
+          break outer;
+        } else if (ch === "=" && segment[ci + 1] === ">" && seenOpenParen && parenDepth === 0) {
+          // Concise arrow function without braces — skip.
+          break outer;
+        }
+      }
+    }
+
+    if (bodyStart === -1) {
+      i++;
+      continue;
+    }
+
+    // Count braces to find the matching closing brace of the method body.
+    let depth = 0;
+    let endLine = -1;
+    for (let k = bodyStart; k < lines.length; k++) {
+      for (const ch of lines[k]) {
+        if (ch === "{") depth++;
+        else if (ch === "}") {
+          depth--;
+          if (depth === 0) {
+            endLine = k;
+            break;
+          }
+        }
+      }
+      if (endLine !== -1) break;
+    }
+
+    if (endLine !== -1) {
+      regions.push({ name: methodName, startLine: i, endLine });
+      // Skip past the method body — nested async functions are checked
+      // as part of this region, not as independent top-level regions.
+      i = endLine + 1;
+    } else {
+      i++;
+    }
+  }
+
+  return regions;
+}
+
+/**
+ * Check a method region for the TOCTOU violation: sessions.delete after await.
+ * Returns the 0-indexed line numbers of the first await and the violating delete,
+ * or null if there is no violation.
+ * Exported for testing.
+ */
+export function checkMethodViolation(
+  lines: string[],
+  region: MethodRegion,
+): { awaitLine: number; deleteLine: number } | null {
+  let firstAwaitLine = -1;
+
+  for (let i = region.startLine; i <= region.endLine; i++) {
+    const line = lines[i];
+    if (isCommentLine(line)) continue;
+    const stripped = stripInlineComment(line);
+
+    if (firstAwaitLine === -1 && AWAIT_RE.test(stripped)) {
+      firstAwaitLine = i;
+    }
+
+    if (firstAwaitLine !== -1 && SESSIONS_DELETE_RE.test(stripped)) {
+      return { awaitLine: firstAwaitLine, deleteLine: i };
+    }
+  }
+
+  return null;
+}
+
+async function scanDir(dir: string): Promise<Violation[]> {
+  const violations: Violation[] = [];
+  const glob = new Glob("**/*.ts");
+
+  for await (const relPath of glob.scan({ cwd: dir, absolute: false })) {
+    if (relPath.endsWith(".d.ts") || relPath.includes("node_modules")) continue;
+
+    const absPath = `${dir}${relPath}`;
+    const content = await Bun.file(absPath).text();
+    const lines = content.split("\n");
+
+    for (const method of findAsyncMethods(lines)) {
+      const v = checkMethodViolation(lines, method);
+      if (v) {
+        violations.push({
+          file: absPath,
+          methodLine: method.startLine + 1,
+          methodName: method.name,
+          awaitLine: v.awaitLine + 1,
+          deleteLine: v.deleteLine + 1,
+        });
+      }
+    }
+  }
+
+  return violations;
+}
+
+async function main(): Promise<void> {
+  const violations = await scanDir(PACKAGES_DIR);
+
+  if (violations.length === 0) {
+    process.stderr.write("No session-teardown TOCTOU violations found.\n");
+    process.exit(0);
+  }
+
+  process.stderr.write(`\n  Session teardown TOCTOU: ${violations.length} violation(s) found\n\n`);
+  process.stderr.write("  this.sessions.delete must appear before the first await in async methods.\n");
+  process.stderr.write("  After an await, concurrent callers can race to see the session in the map.\n\n");
+
+  for (const v of violations) {
+    process.stderr.write(`  ${v.file}:${v.methodLine} — async ${v.methodName}()\n`);
+    process.stderr.write(`    first await at line ${v.awaitLine}\n`);
+    process.stderr.write(`    sessions.delete at line ${v.deleteLine} (must come first)\n\n`);
+  }
+
+  process.stderr.write("  Fix: move this.sessions.delete before the first await.\n\n");
+
+  process.exit(1);
+}
+
+if (import.meta.main) {
+  main();
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/check-session-teardown.ts`: a lint rule that flags any async method where `this.sessions.delete` appears after the first `await` (TOCTOU violation — concurrent callers can race to find the session still in the map during the yield window)
- Fixes the pre-existing violation in `terminateSession()`: moved `this.sessions.delete(sessionId)` from after the kill awaits to before the first `await`, consistent with the invariant established by `bye()` in #1895
- Wires the new check into `package.json` (`lint:teardown`) and `.git-hooks/pre-commit` (runs in both source and config tiers)

## Test plan

- [x] `bun run lint:teardown` — passes (zero violations after the ws-server.ts fix)
- [x] `bun run typecheck` — clean
- [x] `bun run lint:check` — clean  
- [x] 14 unit tests in `scripts/check-session-teardown.spec.ts` covering: method detection, multi-line signatures, anonymous arrow exclusion, comment stripping, delete-before-await (OK), delete-after-await (violation), delete-after-second-await (violation), no-delete/no-await cases
- [x] `bun test packages/core packages/command packages/control` — 3447 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)