### PR TITLE
test(claude): routing regression for CLAUDE_ONLY_SUBCOMMANDS dispatch (closes #1911)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -1,4 +1,4 @@
-import { type Mock, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { type Mock, afterEach, describe, expect, mock, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -1,4 +1,4 @@
-import { type Mock, afterEach, describe, expect, mock, test } from "bun:test";
+import { type Mock, afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -8,10 +8,12 @@ import { _resetJqStateForTesting } from "../jq/index";
 import { ExitError } from "../test-helpers";
 import type { ClaudeDeps } from "./claude";
 import {
+  CLAUDE_ONLY_SUBCOMMANDS,
   MODEL_SHORTNAMES,
   buildHeadedCommand,
   buildResumePrompt,
   cmdClaude,
+  defaultDeps,
   defaultGetPrStatus,
   extractIssueNumber,
   formatQuotaBanner,
@@ -5073,5 +5075,52 @@ describe("mcx claude patch-update", () => {
     await expect(cmdClaude(["patch-update", "--bogus"], deps)).rejects.toThrow(ExitError);
     const errCalls = (deps.printError as Mock<(s: string) => void>).mock.calls.map((c) => c[0]);
     expect(errCalls.some((s) => s.includes("--bogus"))).toBe(true);
+  });
+});
+
+// ── CLAUDE_ONLY_SUBCOMMANDS routing regression (#1911) ──
+
+/**
+ * Capture log calls made via `defaultDeps.log` during `fn()`.
+ * `defaultDeps.log` is assigned `console.log` at module-init time, so
+ * reassigning `console.log` at test time does not intercept it. Patching
+ * the exported `defaultDeps.log` property directly does.
+ */
+async function captureDefaultLog(fn: () => Promise<void>): Promise<string[]> {
+  const captured: string[] = [];
+  const origLog = defaultDeps.log;
+  defaultDeps.log = (...args: unknown[]) => captured.push(args.map(String).join(" "));
+  try {
+    await fn();
+  } finally {
+    defaultDeps.log = origLog;
+  }
+  return captured;
+}
+
+describe("cmdClaude routing — CLAUDE_ONLY_SUBCOMMANDS regression", () => {
+  test("patch-update --help routes to internal handler without deps injection", async () => {
+    // Exercises the production routing path (no deps arg) via CLAUDE_ONLY_SUBCOMMANDS.
+    // Before #1909 this would fall through to cmdAgent which produced "Unknown claude subcommand".
+    const lines = await captureDefaultLog(() => cmdClaude(["patch-update", "--help"]));
+
+    const output = lines.join("\n");
+    expect(output).not.toContain("Unknown claude subcommand");
+    expect(output.toLowerCase()).toContain("patch-update");
+  });
+
+  test("every CLAUDE_ONLY_SUBCOMMANDS member routes to internal handler without deps injection", async () => {
+    // Structural guard: if a new claude-only subcommand is added to cmdClaudeInternal's
+    // switch but forgotten in CLAUDE_ONLY_SUBCOMMANDS, it would silently fall through to
+    // cmdAgent and produce "Unknown subcommand" for callers.
+    for (const sub of CLAUDE_ONLY_SUBCOMMANDS) {
+      // Use --help so we exercise routing without triggering IPC or real side effects.
+      const lines = await captureDefaultLog(() => cmdClaude([sub, "--help"]));
+
+      const output = lines.join("\n");
+      expect(output).not.toContain("Unknown claude subcommand");
+      // The internal help path emits something mentioning the subcommand.
+      expect(output.toLowerCase()).toContain(sub);
+    }
   });
 });

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -219,8 +219,10 @@ export const defaultDeps: ClaudeDeps = {
  * dispatcher. These must be handled by `cmdClaudeInternal` directly —
  * forwarding them to `cmdAgent` produces an "Unknown subcommand" error
  * because the agent dispatcher only knows the cross-provider verbs.
+ *
+ * Exported so tests can assert every member routes through `cmdClaudeInternal`.
  */
-const CLAUDE_ONLY_SUBCOMMANDS: ReadonlySet<string> = new Set(["patch-update"]);
+export const CLAUDE_ONLY_SUBCOMMANDS: ReadonlySet<string> = new Set(["patch-update"]);
 
 /**
  * `mcx claude` — thin alias that routes to `mcx agent claude` for shared


### PR DESCRIPTION
## Summary

- Exports `CLAUDE_ONLY_SUBCOMMANDS` from `claude.ts` so tests can assert every member is handled by the internal routing path
- Adds `captureDefaultLog` helper that patches `defaultDeps.log` directly (Bun's `console.log` writes via JSC, not `process.stdout.write`, so the helper must patch the exported dep rather than stdout)
- Adds two regression tests that call `cmdClaude` **without** deps injection (production routing path):
  1. `patch-update --help` reaches `cmdClaudeInternal` and emits help text, not "Unknown claude subcommand"
  2. Every member of `CLAUDE_ONLY_SUBCOMMANDS` routes correctly — structural guard for future additions

## Test plan

- `bun test packages/command/src/commands/claude.spec.ts --test-name-pattern "CLAUDE_ONLY"` — 2 pass
- `bun test` — 6465 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)