### PR TITLE
refactor(timeout): restore DEFAULT_TIMEOUT_MS usage regressed by 1bdd857 (closes #1531)

### DIFF
--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -14,6 +14,7 @@ import type { AgentFeatures, AgentProvider, MailMessage } from "@mcp-cli/core";
 import { CLAUDE_SUB_ALIASES, formatHelp, getHelp, hasHelpFlag } from "../help";
 import "../help-claude";
 import {
+  DEFAULT_TIMEOUT_MS,
   PROMPT_IPC_TIMEOUT_MS,
   WorktreeError,
   buildHookEnv,
@@ -1081,7 +1082,7 @@ async function agentWait(
   // without waiting for the orphaned wait — daemon has its own timeout.
   let result: unknown;
   if (mailTo) {
-    const totalMs = timeout ?? 270_000;
+    const totalMs = timeout ?? DEFAULT_TIMEOUT_MS;
     const pollStart = Date.now();
     const mailPoll = pollMailUntil(d, mailTo, totalMs, pollStart);
     const winner = await Promise.race([
@@ -1769,7 +1770,7 @@ function printSpawnUsage(
     "  --model, -m <name>         Model (default: provider default)",
     "  --cwd <path>               Working directory",
     "  --wait                     Block until result",
-    "  --timeout <ms>             Max wait time (default: 270000)",
+    `  --timeout <ms>             Max wait time (default: ${DEFAULT_TIMEOUT_MS})`,
     "  --json                     Output raw JSON",
   ];
 

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -1822,7 +1822,7 @@ async function claudeWait(args: string[], d: ClaudeDeps): Promise<void> {
   // without waiting for the orphaned claude_wait (daemon has its own timeout).
   let result: unknown;
   if (parsed.mailTo) {
-    const totalMs = parsed.timeout ?? 270_000;
+    const totalMs = parsed.timeout ?? DEFAULT_TIMEOUT_MS;
     const pollStart = Date.now();
     const mailPoll = pollMailUntil(d, parsed.mailTo, totalMs, pollStart);
     const winner = await Promise.race([
@@ -2107,7 +2107,7 @@ Spawn options:
   --resume <id>               Resume a previous session
   --allow <tools...>          Pre-approved tool patterns (default: Read Glob Grep Write Edit)
   --cwd <path>                Working directory for Claude
-  --timeout <ms>              Max wait time (default: 270000, only with --wait)
+  --timeout <ms>              Max wait time (default: ${DEFAULT_TIMEOUT_MS}, only with --wait)
 
 Resume options:
   --fresh                     Use git-context prompt instead of conversation history
@@ -2115,7 +2115,7 @@ Resume options:
   --model, -m <name>          Model to use: opus, sonnet, haiku, or full ID
   --allow <tools...>          Pre-approved tool patterns
   --wait                      Block until Claude produces a result
-  --timeout <ms>              Max wait time (default: 270000, only with --wait)
+  --timeout <ms>              Max wait time (default: ${DEFAULT_TIMEOUT_MS}, only with --wait)
 
 Send options:
   --wait                      Block until Claude produces a result
@@ -2126,7 +2126,7 @@ List/Wait options:
 
 Wait options:
   --after <seq>               Sequence cursor for race-free polling (from previous response)
-  --timeout, -t <ms>          Max wait time (default: 270000)
+  --timeout, -t <ms>          Max wait time (default: ${DEFAULT_TIMEOUT_MS})
 
 Approve/Deny options:
   --request-id, -r <id>       Specific request ID (auto-detects latest if omitted)

--- a/packages/command/src/commands/pr.ts
+++ b/packages/command/src/commands/pr.ts
@@ -6,6 +6,7 @@
  * (#1800). Local cleanup is left to `mcx claude bye` → cleanupWorktree.
  */
 
+import { DEFAULT_TIMEOUT_MS } from "@mcp-cli/core";
 import { printError as defaultPrintError } from "../output";
 
 // ── Deps ──
@@ -51,7 +52,7 @@ export function parsePrMergeArgs(args: string[]): PrMergeArgs {
   let mergeCommit = false;
   let auto = false;
   let wait = false;
-  let timeout = 270_000;
+  let timeout = DEFAULT_TIMEOUT_MS;
   let error: string | undefined;
 
   for (let i = 0; i < args.length; i++) {
@@ -203,7 +204,7 @@ Merge strategy (default: --squash):
 Options:
   --auto                               Enable auto-merge (requires branch protection)
   --wait                               Block until the PR reaches MERGED state
-  --timeout, -t <ms>                   Max wait time (default: 270000)
+  --timeout, -t <ms>                   Max wait time (default: ${DEFAULT_TIMEOUT_MS})
 
 Unlike 'gh pr merge --delete-branch', 'mcx pr merge' never attempts local branch
 deletion. Use 'mcx claude bye' to clean up the worktree and local branch once

--- a/packages/command/src/help-claude.ts
+++ b/packages/command/src/help-claude.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_TIMEOUT_MS } from "@mcp-cli/core";
 import { registerHelp } from "./help";
 
 registerHelp("claude spawn", {
@@ -22,7 +23,7 @@ registerHelp("claude spawn", {
     ["--model, -m <name>", "Model: opus, sonnet, haiku, or full ID (default: opus)"],
     ["--cwd <path>", "Working directory for the session"],
     ["--wait", "Block until Claude produces a result"],
-    ["--timeout <ms>", "Max wait time in ms (default: 270000, only with --wait)"],
+    ["--timeout <ms>", `Max wait time in ms (default: ${DEFAULT_TIMEOUT_MS}, only with --wait)`],
     ["--work-item <id>", "Work item ID (#N); writes null→initial transition on spawn"],
   ],
   examples: [
@@ -94,7 +95,7 @@ registerHelp("claude wait", {
   summary: "Block until a session event occurs",
   usage: ["mcx claude wait <session>", "mcx claude wait --all", "mcx claude wait --pr 42", "mcx claude wait --checks"],
   options: [
-    ["--timeout, -t <ms>", "Max wait time in ms (default: 270000, max: 299000)"],
+    ["--timeout, -t <ms>", `Max wait time in ms (default: ${DEFAULT_TIMEOUT_MS}, max: 299000)`],
     ["--after <seq>", "Sequence cursor for race-free polling"],
     ["--short", "Compact output"],
     ["--all, -a", "Wait across all sessions (bypass repo scoping)"],
@@ -120,7 +121,7 @@ registerHelp("claude resume", {
     ["--model, -m <name>", "Model: opus, sonnet, haiku, or full ID"],
     ["--allow <tools...>", "Space-separated tool patterns to auto-approve"],
     ["--wait", "Block until Claude produces a result"],
-    ["--timeout <ms>", "Max wait time in ms (default: 270000)"],
+    ["--timeout <ms>", `Max wait time in ms (default: ${DEFAULT_TIMEOUT_MS})`],
   ],
 });
 

--- a/packages/command/src/help-claude.ts
+++ b/packages/command/src/help-claude.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_TIMEOUT_MS } from "@mcp-cli/core";
+import { DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS } from "@mcp-cli/core";
 import { registerHelp } from "./help";
 
 registerHelp("claude spawn", {
@@ -95,7 +95,7 @@ registerHelp("claude wait", {
   summary: "Block until a session event occurs",
   usage: ["mcx claude wait <session>", "mcx claude wait --all", "mcx claude wait --pr 42", "mcx claude wait --checks"],
   options: [
-    ["--timeout, -t <ms>", `Max wait time in ms (default: ${DEFAULT_TIMEOUT_MS}, max: 299000)`],
+    ["--timeout, -t <ms>", `Max wait time in ms (default: ${DEFAULT_TIMEOUT_MS}, max: ${MAX_TIMEOUT_MS})`],
     ["--after <seq>", "Sequence cursor for race-free polling"],
     ["--short", "Compact output"],
     ["--all, -a", "Wait across all sessions (bypass repo scoping)"],

--- a/packages/core/src/agent-tools.ts
+++ b/packages/core/src/agent-tools.ts
@@ -10,6 +10,8 @@
  * but the definitions are generated from a single source of truth.
  */
 
+import { DEFAULT_TIMEOUT_MS } from "./constants";
+
 // ---------------------------------------------------------------------------
 // JSON Schema helpers (matches the shape MCP SDK expects)
 // ---------------------------------------------------------------------------
@@ -69,7 +71,7 @@ const sessionIdProp: JsonSchemaProperty = {
 
 const timeoutProp: JsonSchemaProperty = {
   type: "number",
-  description: "Max wait time in ms (default: 270000)",
+  description: `Max wait time in ms (default: ${DEFAULT_TIMEOUT_MS})`,
 };
 
 const limitProp: JsonSchemaProperty = {

--- a/packages/daemon/src/acp-session-worker.ts
+++ b/packages/daemon/src/acp-session-worker.ts
@@ -14,7 +14,7 @@
  */
 
 import { AcpSession, type AcpSessionConfig } from "@mcp-cli/acp";
-import { ACP_SERVER_NAME, type AgentSessionEvent } from "@mcp-cli/core";
+import { ACP_SERVER_NAME, type AgentSessionEvent, DEFAULT_TIMEOUT_MS } from "@mcp-cli/core";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { ACP_TOOLS } from "./acp-session/tools";
@@ -187,7 +187,7 @@ async function handlePrompt(args: Record<string, unknown>): Promise<{
   isError?: boolean;
 }> {
   const prompt = args.prompt as string;
-  const timeoutMs = (args.timeout as number) ?? 270_000;
+  const timeoutMs = (args.timeout as number) ?? DEFAULT_TIMEOUT_MS;
   let sessionId = args.sessionId as string | undefined;
 
   if (sessionId) {
@@ -364,7 +364,7 @@ async function handleWait(args: Record<string, unknown>): Promise<{
   isError?: boolean;
 }> {
   const sessionId = args.sessionId as string | undefined;
-  const timeoutMs = (args.timeout as number) ?? 270_000;
+  const timeoutMs = (args.timeout as number) ?? DEFAULT_TIMEOUT_MS;
   const afterSeq = args.afterSeq as number | undefined;
 
   // afterSeq cursor: check buffer first, then block until a new event arrives

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -16,6 +16,7 @@
 
 import {
   CLAUDE_SERVER_NAME,
+  DEFAULT_TIMEOUT_MS,
   type LiveSpan,
   type SessionInfo,
   type WorkItemEvent,
@@ -149,7 +150,7 @@ export async function handlePrompt(
   isError?: boolean;
 }> {
   const prompt = args.prompt as string;
-  const timeoutMs = (args.timeout as number) ?? 270_000;
+  const timeoutMs = (args.timeout as number) ?? DEFAULT_TIMEOUT_MS;
 
   let sessionId = args.sessionId as string | undefined;
 
@@ -399,7 +400,7 @@ async function handleWait(
   isError?: boolean;
 }> {
   const sessionId = (args.sessionId as string | undefined) ?? null;
-  const timeoutMs = (args.timeout as number) ?? 270_000;
+  const timeoutMs = (args.timeout as number) ?? DEFAULT_TIMEOUT_MS;
   const afterSeq = args.afterSeq as number | undefined;
   const repoRoot = args.repoRoot as string | undefined;
   const scopeRoot = args.scopeRoot as string | undefined;

--- a/packages/daemon/src/codex-session-worker.ts
+++ b/packages/daemon/src/codex-session-worker.ts
@@ -19,7 +19,7 @@
  */
 
 import { CodexSession, type CodexSessionConfig } from "@mcp-cli/codex";
-import { type AgentSessionEvent, CODEX_SERVER_NAME } from "@mcp-cli/core";
+import { type AgentSessionEvent, CODEX_SERVER_NAME, DEFAULT_TIMEOUT_MS } from "@mcp-cli/core";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { CODEX_TOOLS } from "./codex-session/tools";
@@ -192,7 +192,7 @@ async function handlePrompt(args: Record<string, unknown>): Promise<{
   isError?: boolean;
 }> {
   const prompt = args.prompt as string;
-  const timeoutMs = (args.timeout as number) ?? 270_000;
+  const timeoutMs = (args.timeout as number) ?? DEFAULT_TIMEOUT_MS;
   let sessionId = args.sessionId as string | undefined;
 
   if (sessionId) {
@@ -373,7 +373,7 @@ async function handleWait(args: Record<string, unknown>): Promise<{
   isError?: boolean;
 }> {
   const sessionId = args.sessionId as string | undefined;
-  const timeoutMs = (args.timeout as number) ?? 270_000;
+  const timeoutMs = (args.timeout as number) ?? DEFAULT_TIMEOUT_MS;
   const afterSeq = args.afterSeq as number | undefined;
 
   // afterSeq cursor: check buffer first, then block until a new event arrives

--- a/packages/daemon/src/mock-session-worker.ts
+++ b/packages/daemon/src/mock-session-worker.ts
@@ -15,7 +15,7 @@
  */
 
 import { resolve } from "node:path";
-import { type AgentSessionEvent, MOCK_SERVER_NAME } from "@mcp-cli/core";
+import { type AgentSessionEvent, DEFAULT_TIMEOUT_MS, MOCK_SERVER_NAME } from "@mcp-cli/core";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { MOCK_TOOLS } from "./mock-session/tools";
@@ -374,7 +374,7 @@ function handleTranscript(args: Record<string, unknown>): ToolResult {
 
 async function handleWait(args: Record<string, unknown>): Promise<ToolResult> {
   const sessionId = args.sessionId as string | undefined;
-  const timeoutMs = (args.timeout as number) ?? 270_000;
+  const timeoutMs = (args.timeout as number) ?? DEFAULT_TIMEOUT_MS;
   const afterSeq = args.afterSeq as number | undefined;
 
   // afterSeq cursor: check buffer first, then block

--- a/packages/daemon/src/opencode-session-worker.ts
+++ b/packages/daemon/src/opencode-session-worker.ts
@@ -13,7 +13,7 @@
  *   4. Worker sends MCP JSON-RPC responses + DB event messages back
  */
 
-import { type AgentSessionEvent, OPENCODE_SERVER_NAME } from "@mcp-cli/core";
+import { type AgentSessionEvent, DEFAULT_TIMEOUT_MS, OPENCODE_SERVER_NAME } from "@mcp-cli/core";
 import { OpenCodeSession, type OpenCodeSessionConfig } from "@mcp-cli/opencode";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
@@ -187,7 +187,7 @@ async function handlePrompt(args: Record<string, unknown>): Promise<{
   isError?: boolean;
 }> {
   const prompt = args.prompt as string;
-  const timeoutMs = (args.timeout as number) ?? 270_000;
+  const timeoutMs = (args.timeout as number) ?? DEFAULT_TIMEOUT_MS;
   let sessionId = args.sessionId as string | undefined;
 
   if (sessionId) {
@@ -367,7 +367,7 @@ async function handleWait(args: Record<string, unknown>): Promise<{
   isError?: boolean;
 }> {
   const sessionId = args.sessionId as string | undefined;
-  const timeoutMs = (args.timeout as number) ?? 270_000;
+  const timeoutMs = (args.timeout as number) ?? DEFAULT_TIMEOUT_MS;
   const afterSeq = args.afterSeq as number | undefined;
 
   // afterSeq cursor: check buffer first, then block until a new event arrives


### PR DESCRIPTION
## Summary
- Commit `1bdd857` (fix(containment): resolve symlinks) accidentally reverted the `DEFAULT_TIMEOUT_MS` substitutions introduced by PR #1499
- Restores `DEFAULT_TIMEOUT_MS` import and usage across 10 files in daemon workers, command handlers, and help text
- Help-text strings now use template literals so they stay in sync automatically when the constant changes

## Files changed
- `packages/daemon/src/claude-session-worker.ts` — 2 literals → `DEFAULT_TIMEOUT_MS`
- `packages/daemon/src/codex-session-worker.ts` — 2 literals → `DEFAULT_TIMEOUT_MS`
- `packages/daemon/src/acp-session-worker.ts` — 2 literals → `DEFAULT_TIMEOUT_MS`
- `packages/daemon/src/opencode-session-worker.ts` — 2 literals → `DEFAULT_TIMEOUT_MS`
- `packages/daemon/src/mock-session-worker.ts` — 1 literal → `DEFAULT_TIMEOUT_MS`
- `packages/command/src/commands/claude.ts` — 1 literal + 3 help strings
- `packages/command/src/commands/agent.ts` — 1 literal + 1 help string
- `packages/command/src/commands/pr.ts` — 1 literal + 1 help string
- `packages/command/src/help-claude.ts` — 3 help strings
- `packages/core/src/agent-tools.ts` — 1 description string

## Test plan
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean (no fixes needed)
- [x] `bun test` — 6463 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)