### PR TITLE
fix(phases): return model+prompt on re-entry; reject --model null early (fixes #1922)

### DIFF
--- a/.claude/phases/done.ts
+++ b/.claude/phases/done.ts
@@ -189,11 +189,13 @@ defineAlias({
       "triage_reasons",
       "review_round",
       "repair_round",
+      "repair_prompt",
       "qa_fail_round",
       "previous_phase",
       "provider",
       "labels",
       "model",
+      "review_model",
     ]) {
       await ctx.state.delete(key);
     }

--- a/.claude/phases/qa.ts
+++ b/.claude/phases/qa.ts
@@ -57,6 +57,7 @@ defineAlias({
     target: z.enum(["done", "repair", "needs-attention"]).optional(),
     reason: z.string(),
     round: z.number().optional(),
+    model: z.enum(["opus", "sonnet"]).optional(),
     command: z.array(z.string()).optional(),
     prompt: z.string().optional(),
     allowTools: z.array(z.string()).optional(),
@@ -78,30 +79,33 @@ defineAlias({
 
     const sessionId = await ctx.state.get<string>("qa_session_id");
 
+    const qaModel = "sonnet" as const;
+    const qaPrompt = `/qa ${work.issueNumber} (PR ${work.prNumber}, branch ${work.branch})`;
+
     if (!sessionId) {
       const worktreePath = await ctx.state.get<string>("worktree_path");
       const allowTools = ["Read", "Glob", "Grep", "Write", "Edit", "Bash"];
-      const prompt = `/qa ${work.issueNumber} (PR ${work.prNumber}, branch ${work.branch})`;
       const cmdBase = input.provider.startsWith("acp:")
         ? ["mcx", "acp", "spawn", "--agent", input.provider.slice(4)]
         : ["mcx", input.provider, "spawn"];
       const worktreeFlags = worktreePath ? ["--cwd", worktreePath] : ["--worktree"];
-      const command = [...cmdBase, ...worktreeFlags, "--model", "sonnet", "-t", prompt, "--allow", ...allowTools];
+      const command = [...cmdBase, ...worktreeFlags, "--model", qaModel, "-t", qaPrompt, "--allow", ...allowTools];
       // Write sentinel before returning — prevents re-spawn on retry.
       // Orchestrator replaces with real session ID after spawn.
       await ctx.state.set("qa_session_id", `pending:${Date.now()}`);
       return {
         action: "spawn" as const,
         reason: "qa session starting",
+        model: qaModel,
         command,
-        prompt,
+        prompt: qaPrompt,
         allowTools,
       };
     }
 
     const { hasPass, hasFail } = readQaLabels(work.prNumber);
     if (!hasPass && !hasFail) {
-      return { action: "wait" as const, reason: "qa:pass / qa:fail label not set yet" };
+      return { action: "wait" as const, reason: "qa:pass / qa:fail label not set yet", model: qaModel, prompt: qaPrompt };
     }
 
     // Label hygiene: pass is the authoritative verdict when both are present
@@ -109,7 +113,7 @@ defineAlias({
     // every verdict so merge gates can trust "pass xor fail" (see #1303).
     if (hasPass) {
       if (hasFail) removeLabel(work.prNumber, "qa:fail");
-      return { action: "goto" as const, target: "done" as const, reason: "qa:pass → done" };
+      return { action: "goto" as const, target: "done" as const, reason: "qa:pass → done", model: qaModel, prompt: qaPrompt };
     }
     // hasFail only — no stale pass possible (we would have returned above).
 
@@ -120,6 +124,8 @@ defineAlias({
         target: "needs-attention" as const,
         reason: `qa fail cap (${QA_FAIL_CAP}) exceeded — escalating`,
         round: round - 1,
+        model: qaModel,
+        prompt: qaPrompt,
       };
     }
     await ctx.state.set("qa_fail_round", round);
@@ -129,6 +135,8 @@ defineAlias({
       target: "repair" as const,
       reason: `qa:fail round ${round} → repair`,
       round,
+      model: qaModel,
+      prompt: qaPrompt,
     };
   },
 });

--- a/.claude/phases/repair.ts
+++ b/.claude/phases/repair.ts
@@ -44,6 +44,7 @@ defineAlias({
     target: z.enum(["needs-attention"]).optional(),
     reason: z.string(),
     round: z.number(),
+    model: z.enum(["opus", "sonnet"]).optional(),
     command: z.array(z.string()).optional(),
     prompt: z.string().optional(),
     allowTools: z.array(z.string()).optional(),
@@ -65,10 +66,13 @@ defineAlias({
     const existingSession = await ctx.state.get<string>("repair_session_id");
     if (existingSession) {
       const round = (await ctx.state.get<number>("repair_round")) ?? 1;
+      const storedPrompt = await ctx.state.get<string>("repair_prompt");
       return {
         action: "in-flight" as const,
         reason: `repair session in flight (round ${round})`,
         round,
+        model: "opus" as const,
+        ...(storedPrompt ? { prompt: storedPrompt } : {}),
       };
     }
 
@@ -104,15 +108,18 @@ defineAlias({
     await ctx.state.delete("qa_session_id");
     removeLabel(work.prNumber, "qa:fail");
 
-    // Persist round and sentinel before returning. Orchestrator replaces
-    // repair_session_id with real session ID; deletes on spawn failure.
+    // Persist round, sentinel, and prompt before returning. The prompt is
+    // stored so in-flight re-entry can return it without recomputing state
+    // (repair_prompt is read in the in-flight guard above — see #1922).
     await ctx.state.set("repair_round", round);
+    await ctx.state.set("repair_prompt", prompt);
     await ctx.state.set("repair_session_id", `pending:${Date.now()}`);
 
     return {
       action: "spawn" as const,
       reason: `repair round ${round}, triggered by ${previous}`,
       round,
+      model: "opus" as const,
       command,
       prompt,
       allowTools,

--- a/.claude/phases/review.ts
+++ b/.claude/phases/review.ts
@@ -101,9 +101,12 @@ defineAlias({
         ? ["mcx", "acp", "spawn", "--agent", input.provider.slice(4)]
         : ["mcx", input.provider, "spawn"];
       const command = [...cmdBase, "--worktree", "--model", model, "-t", prompt, "--allow", ...allowTools];
-      // Persist round counter and sentinel before returning — re-entry returns
-      // "wait" (not a new spawn) until the orchestrator clears review_session_id.
+      // Persist round counter, model, and sentinel before returning — re-entry
+      // returns "wait" (not a new spawn) until the orchestrator clears
+      // review_session_id. Storing model lets wait/goto return it for safe
+      // single-call extraction by the orchestrator (see #1922).
       await ctx.state.set("review_round", round);
+      await ctx.state.set("review_model", model);
       await ctx.state.set("review_session_id", `pending:${Date.now()}`);
       return {
         action: "spawn" as const,
@@ -117,13 +120,15 @@ defineAlias({
     }
 
     // Session exists — check PR for sticky comment.
+    // Read stored model so all return paths include it (see #1922).
+    const storedModel = (await ctx.state.get<string>("review_model")) as "opus" | "sonnet" | null;
     const scan = scanReviewComments(work.prNumber);
     if (!scan.found) {
-      return { action: "wait" as const, reason: scan.summary, round };
+      return { action: "wait" as const, reason: scan.summary, round, ...(storedModel ? { model: storedModel } : {}) };
     }
 
     if (!scan.hasBlockers) {
-      return { action: "goto" as const, target: "qa" as const, reason: "review clean → qa", round };
+      return { action: "goto" as const, target: "qa" as const, reason: "review clean → qa", round, ...(storedModel ? { model: storedModel } : {}) };
     }
 
     // Blockers present. Cap exceeded → hand off to qa instead of looping.
@@ -133,11 +138,12 @@ defineAlias({
         target: "qa" as const,
         reason: `review round cap (${REVIEW_ROUND_CAP}) reached; deferring remaining items to qa`,
         round,
+        ...(storedModel ? { model: storedModel } : {}),
       };
     }
 
     await ctx.state.set("review_round", round + 1);
     await ctx.state.set("previous_phase", "review");
-    return { action: "goto" as const, target: "repair" as const, reason: "blockers remain → repair", round };
+    return { action: "goto" as const, target: "repair" as const, reason: "blockers remain → repair", round, ...(storedModel ? { model: storedModel } : {}) };
   },
 });

--- a/packages/command/src/commands/spawn-args.spec.ts
+++ b/packages/command/src/commands/spawn-args.spec.ts
@@ -82,6 +82,21 @@ describe("parseSharedSpawnArgs", () => {
     expect(result.error).toBe("--model requires a value");
   });
 
+  it("errors on --model null (jq null coercion guard)", () => {
+    const result = parseSharedSpawnArgs(["--model", "null", "--task", "x"]);
+    expect(result.error).toMatch(/not a valid model name/);
+  });
+
+  it("errors on --model none", () => {
+    const result = parseSharedSpawnArgs(["--model", "none", "--task", "x"]);
+    expect(result.error).toMatch(/not a valid model name/);
+  });
+
+  it("errors on --model undefined", () => {
+    const result = parseSharedSpawnArgs(["--model", "undefined", "--task", "x"]);
+    expect(result.error).toMatch(/not a valid model name/);
+  });
+
   it("errors on empty --allow", () => {
     const result = parseSharedSpawnArgs(["--allow", "--task", "x"]);
     expect(result.error).toBe("--allow requires at least one tool pattern");

--- a/packages/command/src/commands/spawn-args.spec.ts
+++ b/packages/command/src/commands/spawn-args.spec.ts
@@ -97,6 +97,11 @@ describe("parseSharedSpawnArgs", () => {
     expect(result.error).toMatch(/not a valid model name/);
   });
 
+  it("errors on --model followed by another flag (not silently accepted)", () => {
+    const result = parseSharedSpawnArgs(["--model", "--task", "x"]);
+    expect(result.error).toBe("--model requires a value");
+  });
+
   it("errors on empty --allow", () => {
     const result = parseSharedSpawnArgs(["--allow", "--task", "x"]);
     expect(result.error).toBe("--allow requires at least one tool pattern");

--- a/packages/command/src/commands/spawn-args.ts
+++ b/packages/command/src/commands/spawn-args.ts
@@ -94,6 +94,8 @@ export function parseSharedSpawnArgs(
       const val = args[++i];
       if (!val) {
         error = "--model requires a value";
+      } else if (val.toLowerCase() === "null" || val.toLowerCase() === "none" || val.toLowerCase() === "undefined") {
+        error = `--model "${val}" is not a valid model name (use: opus, sonnet, haiku, or a full model ID)`;
       } else {
         model = resolveModelName(val);
       }

--- a/packages/command/src/commands/spawn-args.ts
+++ b/packages/command/src/commands/spawn-args.ts
@@ -92,7 +92,7 @@ export function parseSharedSpawnArgs(
       }
     } else if (arg === "--model" || arg === "-m") {
       const val = args[++i];
-      if (!val) {
+      if (!val || val.startsWith("-")) {
         error = "--model requires a value";
       } else if (val.toLowerCase() === "null" || val.toLowerCase() === "none" || val.toLowerCase() === "undefined") {
         error = `--model "${val}" is not a valid model name (use: opus, sonnet, haiku, or a full model ID)`;


### PR DESCRIPTION
## Summary

- **qa.ts**: adds `model` field to output schema; returns `model: "sonnet"` and `prompt` on *all* action paths (spawn/wait/goto) — re-entry from a double-call is now idempotent and the orchestrator can always extract `.model` safely
- **repair.ts**: adds `model` to output schema; stores `repair_prompt` in state on spawn; returns `model: "opus"` + stored prompt in the `in-flight` guard so callers get usable spawn parameters without a re-spawn
- **review.ts**: stores `review_model` in state on first spawn; reads and returns it on wait/goto paths — model is no longer missing from re-entry responses
- **spawn-args.ts**: rejects `--model null` / `--model none` / `--model undefined` at parse time with a descriptive error, preventing sessions that immediately error with "model is null"

## Test plan

- [x] `bun typecheck` — clean
- [x] `bun lint` — clean (no fixes applied)
- [x] `bun test` — 6487 pass, 0 fail
- [x] 3 new tests in `spawn-args.spec.ts` covering `null`/`none`/`undefined` model rejection
- [x] Existing `--model` missing-value test still passes with preserved error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)