### PR TITLE
fix(clone): eliminate stderr noise and ReadableStream race in remote-protocol error paths (fixes #1825)

### DIFF
--- a/packages/clone/src/engine/__tests__/remote-helper.integration.spec.ts
+++ b/packages/clone/src/engine/__tests__/remote-helper.integration.spec.ts
@@ -288,15 +288,16 @@ describe("t5801 error handling", () => {
       handleImport: async () => "done\n",
       handleExport: async () => "ok refs/heads/main\n\n",
     };
+    const errors: string[] = [];
     const stdin = streamFrom("list\n\n");
     const { stream, result } = collectStream();
-    await runProtocol(stdin, stream, handlers, { marksDir: MARKS_DIR });
+    await runProtocol(stdin, stream, handlers, { marksDir: MARKS_DIR, onError: (msg) => errors.push(msg) });
     // Stub-oracle only: bare "\n" is a blank terminator with zero status
     // lines. A real list handler should emit `@refs/... HEAD\n\n`; a real
     // error path per git-remote-helpers(1) has no list-failure syntax and
-    // needs the caller-side exit decision from #1211/#1212. Stderr diagnostic
-    // is not asserted here but is load-bearing — do not drop it in refactors.
+    // needs the caller-side exit decision from #1211/#1212.
     expect(result()).toBe("\n");
+    expect(errors[0]).toContain("provider unreachable");
   });
 
   test("t5801-33: provider push failure writes safe terminator and resolves", async () => {
@@ -307,15 +308,16 @@ describe("t5801 error handling", () => {
         throw new Error("push rejected: offline");
       },
     };
+    const errors: string[] = [];
     const stdin = streamFrom("export\nstream-payload\n");
     const { stream, result } = collectStream();
-    await runProtocol(stdin, stream, handlers, { marksDir: MARKS_DIR });
+    await runProtocol(stdin, stream, handlers, { marksDir: MARKS_DIR, onError: (msg) => errors.push(msg) });
     // Stub-oracle only: git-remote-helpers(1) requires per-ref
     // `ok <refname>\n` or `error <refname> <reason>\n` followed by a blank
     // line. Bare "\n" leaves git with no status for any ref. #1212 must
-    // replace this with real per-ref error status lines. Stderr diagnostic is
-    // not asserted here but is load-bearing — do not drop it in refactors.
+    // replace this with real per-ref error status lines.
     expect(result()).toBe("\n");
+    expect(errors[0]).toContain("push rejected: offline");
   });
 
   test.todo(

--- a/packages/clone/src/engine/__tests__/remote-helper.integration.spec.ts
+++ b/packages/clone/src/engine/__tests__/remote-helper.integration.spec.ts
@@ -297,6 +297,7 @@ describe("t5801 error handling", () => {
     // error path per git-remote-helpers(1) has no list-failure syntax and
     // needs the caller-side exit decision from #1211/#1212.
     expect(result()).toBe("\n");
+    expect(errors).toHaveLength(1);
     expect(errors[0]).toContain("provider unreachable");
   });
 
@@ -317,6 +318,7 @@ describe("t5801 error handling", () => {
     // line. Bare "\n" leaves git with no status for any ref. #1212 must
     // replace this with real per-ref error status lines.
     expect(result()).toBe("\n");
+    expect(errors).toHaveLength(1);
     expect(errors[0]).toContain("push rejected: offline");
   });
 

--- a/packages/clone/src/engine/remote-protocol.spec.ts
+++ b/packages/clone/src/engine/remote-protocol.spec.ts
@@ -208,6 +208,54 @@ describe("remote-protocol", () => {
     expect(output).toContain("listing-2");
   });
 
+  test("list error: calls onError with message and writes blank terminator", async () => {
+    const errors: string[] = [];
+    const handlers = makeHandlers({
+      list: async () => {
+        throw new Error("provider unreachable");
+      },
+    });
+    const stdin = streamFrom("list\n\n");
+    const { stream, result } = collectStream();
+    await runProtocol(stdin, stream, handlers, { marksDir: MARKS_DIR, onError: (msg) => errors.push(msg) });
+    expect(result()).toBe("\n");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("list failed");
+    expect(errors[0]).toContain("provider unreachable");
+  });
+
+  test("import error: calls onError with message and writes done terminator", async () => {
+    const errors: string[] = [];
+    const handlers = makeHandlers({
+      handleImport: async () => {
+        throw new Error("import broken");
+      },
+    });
+    const stdin = streamFrom("import refs/heads/main\n\n");
+    const { stream, result } = collectStream();
+    await runProtocol(stdin, stream, handlers, { marksDir: MARKS_DIR, onError: (msg) => errors.push(msg) });
+    expect(result()).toBe("done\n");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("import failed");
+    expect(errors[0]).toContain("import broken");
+  });
+
+  test("export error: calls onError with message and writes blank terminator", async () => {
+    const errors: string[] = [];
+    const handlers = makeHandlers({
+      handleExport: async () => {
+        throw new Error("push rejected: offline");
+      },
+    });
+    const stdin = streamFrom("export\nsome-data\n");
+    const { stream, result } = collectStream();
+    await runProtocol(stdin, stream, handlers, { marksDir: MARKS_DIR, onError: (msg) => errors.push(msg) });
+    expect(result()).toBe("\n");
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("export failed");
+    expect(errors[0]).toContain("push rejected: offline");
+  });
+
   test("import followed by other command", async () => {
     let importedRefs: string[] = [];
     let listCalled = false;

--- a/packages/clone/src/engine/remote-protocol.ts
+++ b/packages/clone/src/engine/remote-protocol.ts
@@ -150,11 +150,14 @@ export async function runProtocol(
           const response = await handlers.handleExport(exportStream);
           await writeLine(writer, response);
         } catch (err) {
-          // Cancel the stream before releaseLock() fires in the finally block.
-          // Without this, exportStream's pull() may call reader.read() after the
-          // lock is released, causing a "reader not attached" TypeError under high
-          // CPU contention (the race that caused the intermittent t5801-33 failure).
-          await exportStream.cancel("handler-error");
+          // Best-effort cancel: exportStream.cancel() throws if the handler held a
+          // reader lock when it threw (locked stream). Swallow that so the original
+          // error always reaches logError + the terminator write below.
+          try {
+            await exportStream.cancel("handler-error");
+          } catch {
+            /* locked */
+          }
           logError(`git-remote-mcx: export failed: ${errorMessage(err)}\n`);
           await writeLine(writer, "\n");
           return;

--- a/packages/clone/src/engine/remote-protocol.ts
+++ b/packages/clone/src/engine/remote-protocol.ts
@@ -14,6 +14,7 @@ export interface RemoteHelperHandlers {
 
 export interface ProtocolOptions {
   marksDir: string;
+  onError?: (message: string) => void;
 }
 
 /** Read a single line from a ReadableStream reader, stripping the trailing newline. */
@@ -71,6 +72,7 @@ export async function runProtocol(
   const reader = stdin.getReader();
   const writer = stdout.getWriter();
   const buffer = { remainder: "" };
+  const logError = options.onError ?? ((msg: string) => process.stderr.write(msg));
 
   try {
     while (true) {
@@ -97,7 +99,7 @@ export async function runProtocol(
           const response = await handlers.list(forPush);
           await writeLine(writer, `${response}\n`);
         } catch (err) {
-          process.stderr.write(`git-remote-mcx: list failed: ${errorMessage(err)}\n`);
+          logError(`git-remote-mcx: list failed: ${errorMessage(err)}\n`);
           await writeLine(writer, "\n");
           return;
         }
@@ -121,7 +123,7 @@ export async function runProtocol(
           const response = await handlers.handleImport(refs);
           await writeLine(writer, response);
         } catch (err) {
-          process.stderr.write(`git-remote-mcx: import failed: ${errorMessage(err)}\n`);
+          logError(`git-remote-mcx: import failed: ${errorMessage(err)}\n`);
           await writeLine(writer, "done\n");
           return;
         }
@@ -148,7 +150,12 @@ export async function runProtocol(
           const response = await handlers.handleExport(exportStream);
           await writeLine(writer, response);
         } catch (err) {
-          process.stderr.write(`git-remote-mcx: export failed: ${errorMessage(err)}\n`);
+          // Cancel the stream before releaseLock() fires in the finally block.
+          // Without this, exportStream's pull() may call reader.read() after the
+          // lock is released, causing a "reader not attached" TypeError under high
+          // CPU contention (the race that caused the intermittent t5801-33 failure).
+          await exportStream.cancel("handler-error");
+          logError(`git-remote-mcx: export failed: ${errorMessage(err)}\n`);
           await writeLine(writer, "\n");
           return;
         }


### PR DESCRIPTION
## Summary

- **Injects `onError` callback into `ProtocolOptions`** so callers (and tests) can capture error messages instead of receiving them on stderr as unattributed noise; falls back to `process.stderr.write` when not provided
- **Cancels `exportStream` on handler error** before `releaseLock()` fires in the `finally` block, closing the pull-after-releaseLock race that produced intermittent "1 failure with no named test" under high CPU contention (the Bun C++/Zig ReadableStream scheduler can defer `pull()` past the JS microtask that releases the lock)
- **Makes error paths testable**: t5801-32 and t5801-33 now pass `onError` and assert on captured messages; three new unit tests cover list/import/export error paths in `remote-protocol.spec.ts`

## Test plan

- [x] `bun test packages/clone/src/engine/remote-protocol.spec.ts packages/clone/src/engine/__tests__/remote-helper.integration.spec.ts` — 33 pass, 0 fail
- [x] Full `bun test` suite — 6487 pass, 0 fail (261 files)
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean, no fixes applied
- [x] Pre-commit hook passed (typecheck + lint + test + coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)