### PR TITLE
fix(security): reject FIFOs and non-regular files in readFileWithLimit (fixes #1941)

### DIFF
--- a/packages/command/src/file-read.spec.ts
+++ b/packages/command/src/file-read.spec.ts
@@ -1,4 +1,5 @@
 import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import { mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { join, relative } from "node:path";
 import { readFileWithLimit, resolveAtPath } from "./file-read";
@@ -94,6 +95,24 @@ describe("path containment guard", () => {
 
   test("non-existent path outside allowed dirs is caught before ENOENT", () => {
     expect(() => readFileWithLimit("/nonexistent/path/file.txt")).toThrow(/outside the allowed directory/);
+  });
+});
+
+describe("non-regular file guard", () => {
+  test("rejects FIFOs (named pipes)", () => {
+    const fifoPath = join(TMP, "test.fifo");
+    rmSync(fifoPath, { force: true });
+    const result = spawnSync("mkfifo", [fifoPath]);
+    if (result.status !== 0) return; // mkfifo unavailable — skip
+    try {
+      expect(() => readFileWithLimit(fifoPath)).toThrow(/not a regular file/);
+    } finally {
+      rmSync(fifoPath, { force: true });
+    }
+  });
+
+  test("rejects directories", () => {
+    expect(() => readFileWithLimit(TMP)).toThrow(/not a regular file/);
   });
 });
 

--- a/packages/command/src/file-read.ts
+++ b/packages/command/src/file-read.ts
@@ -6,7 +6,7 @@
  * outside the user's working directory (#1899).
  */
 
-import { readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { resolve } from "node:path";
 import { isPathContained, resolveRealpath } from "@mcp-cli/core";
 
@@ -36,6 +36,11 @@ export function readFileWithLimit(path: string): string {
 
   if (!isPathAllowed(resolved)) {
     throw new Error(`Path "${path}" resolves to "${resolved}" which is outside the allowed directory (cwd)`);
+  }
+
+  const stat = statSync(resolved);
+  if (!stat.isFile()) {
+    throw new Error(`Path "${path}" is not a regular file`);
   }
 
   if (process.env.DEBUG) {


### PR DESCRIPTION
## Summary
- Add `statSync` check in `readFileWithLimit` after the path-containment guard to ensure the target is a regular file before any read attempt
- FIFOs, sockets, character devices, block devices, and directories now fail immediately with `Path "..." is not a regular file` instead of hanging the CLI
- Two new tests: FIFO rejection (via `mkfifo`) and directory rejection

## Test plan
- [x] `bun test packages/command/src/file-read.spec.ts` — all 23 tests pass (2 new: FIFO + directory guards)
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] Full suite via pre-commit hook — 4202 pass, 0 fail, coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)