### PR TITLE
refactor(daemon): split ipc-server.ts into per-domain handler modules (fixes #1856)

### DIFF
--- a/packages/daemon/src/event-stream.ts
+++ b/packages/daemon/src/event-stream.ts
@@ -1,0 +1,579 @@
+/**
+ * HTTP streaming route handlers for the IPC server.
+ *
+ * Extracted from ipc-server.ts to keep the dispatcher thin.
+ * Handles:
+ *   GET /logs   — SSE stream for real-time log tailing
+ *   GET /events — NDJSON stream for the unified monitor event bus
+ */
+
+import type { Logger } from "@mcp-cli/core";
+import { getDaemonLogLines, subscribeDaemonLogs } from "./daemon-log";
+import type { EventBus } from "./event-bus";
+import { buildEventFilter } from "./ipc-filter";
+import { metrics } from "./metrics";
+import type { ServerPool } from "./server-pool";
+
+export class EventStreamServer {
+  /** Max concurrent EventBus subscribers (hard limit to avoid GC pressure). */
+  static readonly MAX_EVENT_BUS_SUBSCRIBERS = 64;
+  /** Heartbeat interval for the EventBus path — shorter for dead-peer detection (#1557). */
+  private static readonly EVENTBUS_HEARTBEAT_MS = 15_000;
+  /** Prune EventBus subscribers idle longer than this (#1557). */
+  private static readonly EVENTBUS_SUB_TTL_MS = 10 * 60_000;
+  /** Ring-buffer capacity for the fallback push path. */
+  private static readonly EVENT_RING_CAPACITY = 256;
+  /** Max entries in the backfill liveBuffer (#1589). Test-mutable. */
+  static LIVE_BUFFER_MAX_ENTRIES = 10_000;
+  /** Max bytes in the backfill liveBuffer (#1589). Test-mutable. */
+  static LIVE_BUFFER_MAX_BYTES = 10 * 1024 * 1024;
+  /** Backfill batch size. Test-mutable. */
+  static BACKFILL_BATCH_SIZE = 1000;
+  /**
+   * Optional async hook called at each backfill yield point.
+   * Tests inject live events here to guarantee they land in liveBuffer during the window.
+   */
+  static BACKFILL_YIELD_FN: (() => Promise<void>) | null = null;
+
+  /** Ring-buffer subscriber callbacks (fallback path when no EventBus). */
+  private eventSubscribers = new Set<(event: Record<string, unknown>) => void>();
+  private eventSeq = 0;
+  private eventBusSubId: number | null = null;
+
+  constructor(
+    private readonly eventBus: EventBus | null,
+    private readonly pool: ServerPool,
+    private readonly logger: Logger,
+    private readonly heartbeatIntervalMs = 30_000,
+  ) {
+    if (eventBus) {
+      this.eventSeq = eventBus.currentSeq;
+      this.eventBusSubId = eventBus.subscribe((event) => {
+        this.eventSeq = event.seq;
+        const envelope = event as unknown as Record<string, unknown>;
+        const failed: ((e: Record<string, unknown>) => void)[] = [];
+        for (const cb of this.eventSubscribers) {
+          try {
+            cb(envelope);
+          } catch (err) {
+            this.logger.warn(`[events] subscriber threw, dropping: ${err}`);
+            failed.push(cb);
+          }
+        }
+        for (const cb of failed) this.eventSubscribers.delete(cb);
+      });
+    }
+  }
+
+  /** Unsubscribe from EventBus (call from IpcServer.stop()). */
+  dispose(): void {
+    if (this.eventBusSubId !== null && this.eventBus) {
+      this.eventBus.unsubscribe(this.eventBusSubId);
+      this.eventBusSubId = null;
+    }
+  }
+
+  /**
+   * Push an event to all connected NDJSON event stream subscribers.
+   * Only used in the ring-buffer fallback path (no EventBus).
+   */
+  pushEvent(event: Record<string, unknown>): void {
+    const seq = ++this.eventSeq;
+    const envelope = { ...event, seq };
+    const failed: ((event: Record<string, unknown>) => void)[] = [];
+    for (const cb of this.eventSubscribers) {
+      try {
+        cb(envelope);
+      } catch (err) {
+        this.logger.warn(`[events] subscriber threw, dropping: ${err}`);
+        failed.push(cb);
+      }
+    }
+    for (const cb of failed) this.eventSubscribers.delete(cb);
+  }
+
+  /** Current event sequence number (for testing / status). */
+  get currentEventSeq(): number {
+    return this.eventSeq;
+  }
+
+  /** Number of active ring-buffer subscribers (for testing). */
+  get eventSubscriberCount(): number {
+    return this.eventSubscribers.size;
+  }
+
+  /**
+   * Handle GET /logs — Server-Sent Events stream for real-time log tailing.
+   *
+   * Query params:
+   *   server=<name>  — stream stderr from a specific MCP server
+   *   daemon=true    — stream daemon logs
+   *   lines=<n>      — number of initial backfill lines (default 50)
+   *   since=<ts>     — only backfill lines after this timestamp (ms)
+   */
+  handleLogsSSE(url: URL): Response {
+    const serverName = url.searchParams.get("server");
+    const isDaemon = url.searchParams.get("daemon") === "true";
+    const lines = Number(url.searchParams.get("lines") ?? "50");
+    const since = url.searchParams.has("since") ? Number(url.searchParams.get("since")) : undefined;
+
+    if (!serverName && !isDaemon) {
+      return new Response("Missing ?server=<name> or ?daemon=true", { status: 400 });
+    }
+
+    let unsubscribe: (() => void) | undefined;
+
+    const stream = new ReadableStream({
+      start: (controller) => {
+        const encoder = new TextEncoder();
+        const send = (entry: { timestamp: number; line: string }) => {
+          try {
+            const data = JSON.stringify({ timestamp: entry.timestamp, line: entry.line });
+            controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+          } catch {
+            // Stream closed — clean up
+            unsubscribe?.();
+          }
+        };
+
+        // Backfill initial lines
+        if (isDaemon) {
+          let backfill = getDaemonLogLines(lines);
+          if (since !== undefined) {
+            backfill = backfill.filter((l) => l.timestamp > since);
+          }
+          for (const entry of backfill) {
+            send(entry);
+          }
+        } else if (serverName) {
+          let backfill = this.pool.getStderrLines(serverName, since === undefined ? lines : undefined);
+          if (since !== undefined) {
+            backfill = backfill.filter((l) => l.timestamp > since);
+            if (backfill.length > lines) backfill = backfill.slice(-lines);
+          }
+          for (const entry of backfill) {
+            send(entry);
+          }
+        }
+
+        // Subscribe to new lines
+        if (isDaemon) {
+          unsubscribe = subscribeDaemonLogs((entry) => send(entry));
+        } else if (serverName) {
+          unsubscribe = this.pool.subscribeStderr((server, entry) => {
+            if (server !== serverName) return;
+            send(entry);
+          });
+        }
+      },
+      cancel: () => {
+        unsubscribe?.();
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        "content-type": "text/event-stream",
+        "cache-control": "no-cache",
+        connection: "keep-alive",
+      },
+    });
+  }
+
+  /**
+   * Handle GET /events — NDJSON stream for real-time event delivery.
+   *
+   * When an EventBus is configured (unified monitor architecture, #1512):
+   *   Uses EventBus subscriptions with session.response suppression and responseTail opt-in.
+   *
+   * Fallback (no EventBus, direct push via pushEvent()):
+   *   Uses ring-buffer based delivery with connected/heartbeat envelope,
+   *   plus durable log replay when since=<seq> is provided (#1513).
+   *
+   * Query params:
+   *   subscribe=<categories>   Comma-separated category filter
+   *   session=<id>             Filter to one session ID
+   *   pr=<n>                   Filter to one PR number
+   *   workItem=<id>            Filter to one work item ID
+   *   type=<glob>              Event name glob filter (comma-separated OR)
+   *   src=<pattern>            Source attribution glob filter
+   *   phase=<name>             Phase filter on work item phase
+   *   since=<seq>              Replay events after this cursor from the durable log (#1513)
+   *   responseTail=<sessionId> Include session.response chunks for this session only
+   */
+  handleEventsNDJSON(url: URL): Response {
+    const sinceParam = url.searchParams.get("since");
+    let sinceSeq: number | null = null;
+    if (sinceParam !== null) {
+      const parsed = Number(sinceParam);
+      if (sinceParam.trim() === "" || !Number.isInteger(parsed) || parsed < 0) {
+        return new Response("since must be a non-negative integer", { status: 400 });
+      }
+      sinceSeq = parsed;
+    }
+    const eventLog = this.eventBus?.eventLog ?? null;
+
+    const prRaw = url.searchParams.get("pr");
+    if (prRaw !== null && !(Number.isInteger(Number(prRaw)) && Number(prRaw) >= 1)) {
+      return new Response("pr must be a positive integer", { status: 400 });
+    }
+
+    if (sinceSeq !== null && !eventLog) {
+      return new Response("since parameter requires the durable event log; replay is not available on this daemon", {
+        status: 400,
+      });
+    }
+
+    // ── EventBus path (unified monitor architecture, #1512/#1515) ──
+    if (this.eventBus) {
+      const responseTail = url.searchParams.get("responseTail");
+      const eventFilter = buildEventFilter(url.searchParams);
+
+      const shouldDeliver = (event: { event: string; sessionId?: string }) => {
+        if (eventFilter !== null && !eventFilter(event as Record<string, unknown>)) return false;
+        if (event.event === "session.response") {
+          return responseTail !== null && event.sessionId === responseTail;
+        }
+        return true;
+      };
+
+      const bus = this.eventBus;
+
+      if (bus.subscriberCount >= EventStreamServer.MAX_EVENT_BUS_SUBSCRIBERS) {
+        this.logger.warn(
+          `[events] subscriber limit reached (${EventStreamServer.MAX_EVENT_BUS_SUBSCRIBERS}), rejecting connection`,
+        );
+        return new Response("too many event stream subscribers", { status: 503 });
+      }
+
+      let subId: number | null = null;
+      let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+
+      const encoder = new TextEncoder();
+      const subscriberGauge = metrics.gauge("mcpd_event_bus_subscribers");
+
+      const cleanup = () => {
+        if (subId !== null) {
+          bus.unsubscribe(subId);
+          subId = null;
+          subscriberGauge.dec();
+        }
+        if (heartbeatTimer !== undefined) {
+          clearInterval(heartbeatTimer);
+          heartbeatTimer = undefined;
+        }
+      };
+
+      const stream = new ReadableStream(
+        {
+          start: async (controller) => {
+            controller.enqueue(encoder.encode("\n"));
+
+            let liveBuffer: Array<{ line: string; bytes: number; seq: number | undefined }> | null =
+              sinceSeq !== null && eventLog ? [] : null;
+            let liveBufferBytes = 0;
+            let liveBufferDropped = 0;
+            let liveBufferHead = 0;
+            let firstDroppedSeq: number | undefined;
+            let lastDroppedSeq: number | undefined;
+            let highWaterMark = 0;
+
+            const maxEntries = EventStreamServer.LIVE_BUFFER_MAX_ENTRIES;
+            const maxBytes = EventStreamServer.LIVE_BUFFER_MAX_BYTES;
+
+            subId = bus.subscribe(
+              (_event, serialized) => {
+                if (controller.desiredSize !== null && controller.desiredSize <= 0) {
+                  this.logger.warn("[events] slow consumer detected, dropping subscriber");
+                  metrics.counter("mcpd_event_bus_slow_drops_total").inc();
+                  cleanup();
+                  try {
+                    controller.error(new Error("slow consumer"));
+                  } catch {
+                    // already closed
+                  }
+                  return;
+                }
+                try {
+                  const line = `${serialized}\n`;
+                  if (liveBuffer !== null) {
+                    const lineBytes = encoder.encode(line).byteLength;
+                    let seq: number | undefined;
+                    try {
+                      const p = JSON.parse(serialized) as Record<string, unknown>;
+                      seq = typeof p.seq === "number" ? p.seq : undefined;
+                    } catch {
+                      /* non-JSON event — skip seq tracking */
+                    }
+                    if (liveBufferHead >= liveBuffer.length && lineBytes > maxBytes) {
+                      liveBufferDropped++;
+                      if (seq !== undefined) {
+                        firstDroppedSeq ??= seq;
+                        lastDroppedSeq = seq;
+                      }
+                      return;
+                    }
+                    while (
+                      liveBufferHead < liveBuffer.length &&
+                      (liveBuffer.length - liveBufferHead >= maxEntries || liveBufferBytes + lineBytes > maxBytes)
+                    ) {
+                      const evicted = liveBuffer[liveBufferHead];
+                      if (!evicted) break;
+                      liveBufferBytes -= evicted.bytes;
+                      if (evicted.seq !== undefined) {
+                        firstDroppedSeq ??= evicted.seq;
+                        lastDroppedSeq = evicted.seq;
+                      }
+                      liveBufferHead++;
+                      liveBufferDropped++;
+                    }
+                    liveBuffer.push({ line, bytes: lineBytes, seq });
+                    liveBufferBytes += lineBytes;
+                  } else {
+                    controller.enqueue(encoder.encode(line));
+                  }
+                } catch {
+                  // Stream closed
+                  cleanup();
+                }
+              },
+              (event) => shouldDeliver(event),
+            );
+            subscriberGauge.inc();
+
+            if (sinceSeq !== null && !Number.isNaN(sinceSeq) && sinceSeq >= 0 && eventLog) {
+              let cursor = sinceSeq;
+              const batchSize = EventStreamServer.BACKFILL_BATCH_SIZE;
+              while (true) {
+                const batch = eventLog.getSince(cursor, batchSize);
+                for (const event of batch) {
+                  highWaterMark = event.seq;
+                  if (!shouldDeliver(event)) continue;
+                  if (controller.desiredSize !== null && controller.desiredSize <= 0) {
+                    this.logger.warn("[events] slow consumer during backfill, dropping subscriber");
+                    metrics.counter("mcpd_event_bus_slow_drops_total").inc();
+                    cleanup();
+                    try {
+                      controller.error(new Error("slow consumer"));
+                    } catch {
+                      // already closed
+                    }
+                    return;
+                  }
+                  try {
+                    controller.enqueue(encoder.encode(`${JSON.stringify(event)}\n`));
+                  } catch {
+                    cleanup();
+                    return;
+                  }
+                }
+                if (batch.length < batchSize) break;
+                cursor = batch[batch.length - 1]?.seq ?? cursor;
+                await EventStreamServer.BACKFILL_YIELD_FN?.();
+                await new Promise<void>((r) => setTimeout(r, 0));
+              }
+              const buffered = liveBuffer ?? [];
+              const drainStart = liveBufferHead;
+              liveBuffer = null;
+
+              if (liveBufferDropped > 0) {
+                const gap: Record<string, unknown> = { t: "gap", dropped: liveBufferDropped };
+                if (firstDroppedSeq !== undefined) gap.firstDroppedSeq = firstDroppedSeq;
+                if (lastDroppedSeq !== undefined) gap.lastDroppedSeq = lastDroppedSeq;
+                try {
+                  controller.enqueue(encoder.encode(`${JSON.stringify(gap)}\n`));
+                } catch {
+                  cleanup();
+                  return;
+                }
+              }
+
+              for (let i = drainStart; i < buffered.length; i++) {
+                const entry = buffered[i];
+                if (!entry) continue;
+                if (controller.desiredSize !== null && controller.desiredSize <= 0) {
+                  this.logger.warn("[events] slow consumer during backfill drain, dropping subscriber");
+                  metrics.counter("mcpd_event_bus_slow_drops_total").inc();
+                  cleanup();
+                  try {
+                    controller.error(new Error("slow consumer"));
+                  } catch {
+                    // already closed
+                  }
+                  return;
+                }
+                try {
+                  if (entry.seq !== undefined && entry.seq <= highWaterMark) continue;
+                  controller.enqueue(encoder.encode(entry.line));
+                } catch {
+                  cleanup();
+                  return;
+                }
+              }
+            }
+
+            heartbeatTimer = setInterval(() => {
+              try {
+                controller.enqueue(encoder.encode("\n"));
+              } catch {
+                cleanup();
+                return;
+              }
+              if (subId !== null) bus.touch(subId);
+              bus.pruneStale(EventStreamServer.EVENTBUS_SUB_TTL_MS);
+            }, EventStreamServer.EVENTBUS_HEARTBEAT_MS);
+            heartbeatTimer.unref();
+          },
+          cancel: cleanup,
+        },
+        new ByteLengthQueuingStrategy({ highWaterMark: 1024 * 1024 }),
+      );
+
+      return new Response(stream, {
+        headers: {
+          "content-type": "application/x-ndjson",
+          "cache-control": "no-cache",
+          connection: "keep-alive",
+        },
+      });
+    }
+
+    // ── Ring-buffer fallback path (direct pushEvent(), no EventBus) ──
+    const filter = buildEventFilter(url.searchParams);
+    const fallbackResponseTail = url.searchParams.get("responseTail");
+    const shouldDeliverFallback = (event: Record<string, unknown>) => {
+      if (filter !== null && !filter(event)) return false;
+      if (event.event === "session.response") {
+        return fallbackResponseTail !== null && event.sessionId === fallbackResponseTail;
+      }
+      return true;
+    };
+    const capacity = EventStreamServer.EVENT_RING_CAPACITY;
+    const ring: string[] = new Array(capacity);
+    let writeIdx = 0;
+    let dropped = 0;
+    let pending = false;
+    let unsubscribe: (() => void) | undefined;
+    let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+    let lastWriteTime = Date.now();
+
+    const encoder = new TextEncoder();
+
+    const cleanup = () => {
+      unsubscribe?.();
+      unsubscribe = undefined;
+      if (heartbeatTimer !== undefined) {
+        clearInterval(heartbeatTimer);
+        heartbeatTimer = undefined;
+      }
+    };
+
+    const stream = new ReadableStream({
+      start: (controller) => {
+        let highWaterMark = 0;
+
+        const flush = () => {
+          if (!pending) return;
+          pending = false;
+          const count = dropped > 0 ? capacity : writeIdx;
+          const start = dropped > 0 ? dropped % capacity : 0;
+          for (let i = 0; i < count; i++) {
+            const line = ring[(start + i) % capacity] as string;
+            try {
+              controller.enqueue(encoder.encode(line));
+            } catch {
+              cleanup();
+              return;
+            }
+          }
+          writeIdx = 0;
+          dropped = 0;
+        };
+
+        const enqueue = (line: string, seq?: number) => {
+          if (seq !== undefined && seq <= highWaterMark) return;
+          if (seq !== undefined) highWaterMark = seq;
+          if (writeIdx < capacity) {
+            ring[writeIdx++] = line;
+          } else {
+            ring[dropped % capacity] = line;
+            dropped++;
+          }
+          pending = true;
+          lastWriteTime = Date.now();
+          queueMicrotask(flush);
+        };
+
+        controller.enqueue(encoder.encode(`${JSON.stringify({ t: "connected", seq: this.eventSeq })}\n`));
+        lastWriteTime = Date.now();
+
+        let liveBuffer: Array<{ line: string; seq: number | undefined }> | null = null;
+        const subscriber = (event: Record<string, unknown>) => {
+          if (!shouldDeliverFallback(event)) return;
+          const line = `${JSON.stringify(event)}\n`;
+          const seq = typeof event.seq === "number" ? event.seq : undefined;
+          if (liveBuffer !== null) {
+            liveBuffer.push({ line, seq });
+          } else {
+            enqueue(line, seq);
+          }
+        };
+
+        this.eventSubscribers.add(subscriber);
+        unsubscribe = () => {
+          this.eventSubscribers.delete(subscriber);
+        };
+
+        if (sinceSeq !== null && !Number.isNaN(sinceSeq) && sinceSeq >= 0 && eventLog) {
+          liveBuffer = [];
+          let cursor = sinceSeq;
+          while (true) {
+            const batch = eventLog.getSince(cursor, 1000);
+            for (const event of batch) {
+              highWaterMark = event.seq;
+              if (!shouldDeliverFallback(event as Record<string, unknown>)) continue;
+              const line = `${JSON.stringify(event)}\n`;
+              try {
+                controller.enqueue(encoder.encode(line));
+              } catch {
+                cleanup();
+                return;
+              }
+            }
+            if (batch.length < 1000) break;
+            cursor = batch[batch.length - 1]?.seq ?? cursor;
+          }
+          const buffered = liveBuffer;
+          liveBuffer = null;
+          for (const { line, seq } of buffered) {
+            enqueue(line, seq);
+          }
+          lastWriteTime = Date.now();
+        }
+
+        heartbeatTimer = setInterval(() => {
+          if (Date.now() - lastWriteTime >= this.heartbeatIntervalMs) {
+            const hb = `${JSON.stringify({ category: "heartbeat", event: "heartbeat", seq: this.eventSeq, src: "daemon", ts: new Date().toISOString() })}\n`;
+            try {
+              controller.enqueue(encoder.encode(hb));
+              lastWriteTime = Date.now();
+            } catch {
+              cleanup();
+            }
+          }
+        }, this.heartbeatIntervalMs);
+        heartbeatTimer.unref();
+      },
+      cancel: cleanup,
+    });
+
+    return new Response(stream, {
+      headers: {
+        "content-type": "application/x-ndjson",
+        "transfer-encoding": "chunked",
+        "cache-control": "no-cache",
+        connection: "keep-alive",
+      },
+    });
+  }
+}

--- a/packages/daemon/src/event-stream.ts
+++ b/packages/daemon/src/event-stream.ts
@@ -23,11 +23,14 @@ export class EventStreamServer {
   private static readonly EVENTBUS_SUB_TTL_MS = 10 * 60_000;
   /** Ring-buffer capacity for the fallback push path. */
   private static readonly EVENT_RING_CAPACITY = 256;
-  /** Max entries in the backfill liveBuffer (#1589). Test-mutable. */
+  /**
+   * Test-mutable statics — all four are proxied via static getter/setter pairs on IpcServer
+   * so that tests can patch IpcServer.X and have the change take effect without importing
+   * EventStreamServer directly.  If you rename or remove any of these, update the
+   * corresponding accessor on IpcServer as well.
+   */
   static LIVE_BUFFER_MAX_ENTRIES = 10_000;
-  /** Max bytes in the backfill liveBuffer (#1589). Test-mutable. */
   static LIVE_BUFFER_MAX_BYTES = 10 * 1024 * 1024;
-  /** Backfill batch size. Test-mutable. */
   static BACKFILL_BATCH_SIZE = 1000;
   /**
    * Optional async hook called at each backfill yield point.

--- a/packages/daemon/src/handler-types.ts
+++ b/packages/daemon/src/handler-types.ts
@@ -1,0 +1,8 @@
+import type { LiveSpan } from "@mcp-cli/core";
+import type { IpcMethod } from "@mcp-cli/core";
+
+export interface RequestContext {
+  span: LiveSpan;
+}
+
+export type RequestHandler = (params: unknown, ctx: RequestContext) => Promise<unknown>;

--- a/packages/daemon/src/handler-types.ts
+++ b/packages/daemon/src/handler-types.ts
@@ -1,5 +1,4 @@
 import type { LiveSpan } from "@mcp-cli/core";
-import type { IpcMethod } from "@mcp-cli/core";
 
 export interface RequestContext {
   span: LiveSpan;

--- a/packages/daemon/src/handlers/alias.spec.ts
+++ b/packages/daemon/src/handlers/alias.spec.ts
@@ -1,0 +1,311 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { IpcMethod } from "@mcp-cli/core";
+import type { RequestHandler } from "../handler-types";
+import { AliasHandlers } from "./alias";
+
+function invoke(map: Map<IpcMethod, RequestHandler>, method: IpcMethod): RequestHandler {
+  const h = map.get(method);
+  if (!h) throw new Error(`Handler "${method}" not registered`);
+  return h;
+}
+
+function makeTmpDir(): string {
+  const dir = join(tmpdir(), `alias-spec-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function mockDb(overrides: Record<string, unknown> = {}) {
+  const aliases = new Map<
+    string,
+    {
+      name: string;
+      filePath: string;
+      aliasType: string;
+      expiresAt: null | number;
+      runCount: number;
+      lastRunAt: null;
+      scope: null;
+      description: string;
+    }
+  >();
+  return {
+    listAliases: () => [...aliases.values()],
+    getAlias: (name: string) => aliases.get(name) ?? undefined,
+    saveAlias: (name: string, filePath: string, description?: string, aliasType?: string, ...rest: unknown[]) => {
+      aliases.set(name, {
+        name,
+        filePath,
+        description: description ?? "",
+        aliasType: aliasType ?? "freeform",
+        expiresAt: null,
+        runCount: 0,
+        lastRunAt: null,
+        scope: null,
+      });
+    },
+    deleteAlias: (name: string) => {
+      aliases.delete(name);
+    },
+    touchAliasExpiry: () => {},
+    recordAliasRun: (name: string) => {
+      const a = aliases.get(name);
+      if (a) a.runCount += 1;
+      return a?.runCount ?? 1;
+    },
+    ...overrides,
+  } as never;
+}
+
+function mockAliasServer(overrides: Record<string, unknown> = {}) {
+  return {
+    refresh: async () => {},
+    validateInSubprocess: async () => ({
+      valid: true,
+      errors: [],
+      warnings: [],
+      description: undefined,
+      inputSchema: undefined,
+      outputSchema: undefined,
+      monitorDefs: undefined,
+    }),
+    extractMonitorsInSubprocess: async () => [],
+    callToolWithChain: async () => ({ content: [] }),
+    ...overrides,
+  } as never;
+}
+
+const mockLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+} as never;
+
+function buildHandlers(
+  db = mockDb(),
+  aliasServer = mockAliasServer(),
+  onAliasChanged?: (name: string) => void,
+): Map<IpcMethod, RequestHandler> {
+  const map = new Map<IpcMethod, RequestHandler>();
+  new AliasHandlers(db, aliasServer, mockLogger, onAliasChanged).register(map);
+  return map;
+}
+
+describe("AliasHandlers – listAliases", () => {
+  test("returns db result", async () => {
+    const aliases = [
+      {
+        name: "foo",
+        description: "bar",
+        filePath: "/tmp/foo.ts",
+        aliasType: "freeform",
+        expiresAt: null,
+        runCount: 0,
+        lastRunAt: null,
+        scope: null,
+      },
+    ];
+    const map = buildHandlers(mockDb({ listAliases: () => aliases }));
+    const result = await invoke(map, "listAliases")(undefined, {} as never);
+    expect(result).toEqual(aliases);
+  });
+});
+
+describe("AliasHandlers – getAlias", () => {
+  test("returns null for missing alias", async () => {
+    const map = buildHandlers(mockDb({ getAlias: () => undefined }));
+    const result = await invoke(map, "getAlias")({ name: "missing" }, {} as never);
+    expect(result).toBeNull();
+  });
+
+  test("reads script from file and returns alias with script", async () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const filePath = join(tmpDir, "hello.ts");
+      writeFileSync(filePath, 'console.log("hello")', "utf-8");
+      const map = buildHandlers(
+        mockDb({
+          getAlias: () => ({
+            name: "hello",
+            filePath,
+            description: "test",
+            aliasType: "freeform",
+            expiresAt: null,
+            runCount: 0,
+            lastRunAt: null,
+            scope: null,
+          }),
+        }),
+      );
+      const result = (await invoke(map, "getAlias")({ name: "hello" }, {} as never)) as { script: string };
+      expect(result.script).toBe('console.log("hello")');
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test("returns empty script when file is gone", async () => {
+    const map = buildHandlers(
+      mockDb({
+        getAlias: () => ({
+          name: "gone",
+          filePath: "/nonexistent/path/gone.ts",
+          description: "",
+          aliasType: "freeform",
+          expiresAt: null,
+          runCount: 0,
+          lastRunAt: null,
+          scope: null,
+        }),
+      }),
+    );
+    const result = (await invoke(map, "getAlias")({ name: "gone" }, {} as never)) as { script: string };
+    expect(result.script).toBe("");
+  });
+});
+
+describe("AliasHandlers – saveAlias (core path)", () => {
+  test("freeform script creates file and saves to db", async () => {
+    // We can't easily test the full bundleAlias path in a unit test,
+    // but we can verify the handler returns ok and triggers the alias server refresh.
+    // saveAlias will throw when bundleAlias fails, but the catch branch saves without bundle.
+    let savedName: string | undefined;
+    let refreshCalled = false;
+    const db = mockDb({
+      getAlias: () => undefined,
+      saveAlias: (name: string) => {
+        savedName = name;
+      },
+    });
+    const as = mockAliasServer({
+      refresh: async () => {
+        refreshCalled = true;
+      },
+    });
+
+    // We test the error/fallback path since bundleAlias requires a real file on disk.
+    // The handler catches bundle failures and still calls saveAlias.
+    const map = buildHandlers(db, as);
+    const result = (await invoke(map, "saveAlias")(
+      { name: "myscript", script: 'console.log("hi")', description: "test" },
+      {} as never,
+    )) as { ok: boolean; validationErrors?: string[] };
+
+    // Either succeeds or falls into bundle-failed path — either way ok:true
+    expect(result.ok).toBe(true);
+    expect(savedName).toBe("myscript");
+    expect(refreshCalled).toBe(true);
+  });
+
+  test("refuses to overwrite permanent alias with ephemeral one", async () => {
+    const db = mockDb({
+      getAlias: () => ({
+        name: "permanent",
+        filePath: "/tmp/permanent.ts",
+        description: "",
+        aliasType: "freeform",
+        expiresAt: null, // null = permanent
+        runCount: 0,
+        lastRunAt: null,
+        scope: null,
+      }),
+    });
+    const map = buildHandlers(db);
+    const result = (await invoke(map, "saveAlias")(
+      { name: "permanent", script: 'console.log("x")', description: "", expiresAt: Date.now() + 60_000 },
+      {} as never,
+    )) as { ok: boolean; reason?: string };
+    expect(result.ok).toBe(false);
+    expect(result.reason).toBe("permanent_alias_exists");
+  });
+});
+
+describe("AliasHandlers – deleteAlias", () => {
+  test("removes file from db and refreshes alias server", async () => {
+    let deletedName: string | undefined;
+    let refreshCalled = false;
+    const db = mockDb({
+      getAlias: () => ({
+        name: "todel",
+        filePath: "/nonexistent/todel.ts",
+        description: "",
+        aliasType: "freeform",
+        expiresAt: null,
+        runCount: 0,
+        lastRunAt: null,
+        scope: null,
+      }),
+      deleteAlias: (name: string) => {
+        deletedName = name;
+      },
+    });
+    const as = mockAliasServer({
+      refresh: async () => {
+        refreshCalled = true;
+      },
+    });
+    const map = buildHandlers(db, as);
+    const result = (await invoke(map, "deleteAlias")({ name: "todel" }, {} as never)) as { ok: boolean };
+    expect(result.ok).toBe(true);
+    expect(deletedName).toBe("todel");
+    expect(refreshCalled).toBe(true);
+  });
+
+  test("returns ok even when alias does not exist", async () => {
+    const map = buildHandlers(mockDb({ getAlias: () => undefined }));
+    const result = (await invoke(map, "deleteAlias")({ name: "noop" }, {} as never)) as { ok: boolean };
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("AliasHandlers – touchAlias", () => {
+  test("calls db.touchAliasExpiry and returns ok", async () => {
+    let touchedName: string | undefined;
+    let touchedExpiry: number | undefined;
+    const db = mockDb({
+      touchAliasExpiry: (name: string, expiresAt: number) => {
+        touchedName = name;
+        touchedExpiry = expiresAt;
+      },
+    });
+    const map = buildHandlers(db);
+    const expiry = Date.now() + 3600_000;
+    const result = (await invoke(map, "touchAlias")({ name: "myalias", expiresAt: expiry }, {} as never)) as {
+      ok: boolean;
+    };
+    expect(result.ok).toBe(true);
+    expect(touchedName).toBe("myalias");
+    expect(touchedExpiry).toBe(expiry);
+  });
+});
+
+describe("AliasHandlers – recordAliasRun", () => {
+  test("increments run count and returns it", async () => {
+    const db = mockDb({ recordAliasRun: () => 5 });
+    const map = buildHandlers(db);
+    const result = (await invoke(map, "recordAliasRun")({ name: "myalias" }, {} as never)) as {
+      ok: boolean;
+      runCount: number;
+    };
+    expect(result.ok).toBe(true);
+    expect(result.runCount).toBe(5);
+  });
+});
+
+describe("AliasHandlers – checkAlias", () => {
+  test("returns valid=false for missing alias", async () => {
+    const map = buildHandlers(mockDb({ getAlias: () => undefined }));
+    const result = (await invoke(map, "checkAlias")({ name: "nope" }, {} as never)) as {
+      valid: boolean;
+      aliasType: string;
+      errors: string[];
+      warnings: string[];
+    };
+    expect(result.valid).toBe(false);
+    expect(result.errors[0]).toContain("not found");
+  });
+});

--- a/packages/daemon/src/handlers/alias.ts
+++ b/packages/daemon/src/handlers/alias.ts
@@ -1,0 +1,253 @@
+import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+  CheckAliasParamsSchema,
+  DeleteAliasParamsSchema,
+  GetAliasParamsSchema,
+  RecordAliasRunParamsSchema,
+  SaveAliasParamsSchema,
+  TouchAliasParamsSchema,
+  bundleAlias,
+  isDefineAlias,
+  isDefineMonitor,
+  options,
+  safeAliasPath,
+  validateFreeformTsc,
+} from "@mcp-cli/core";
+import type { IpcMethod, Logger } from "@mcp-cli/core";
+import type { AliasServer } from "../alias-server";
+import type { StateDb } from "../db/state";
+import type { RequestHandler } from "../handler-types";
+
+export class AliasHandlers {
+  constructor(
+    private db: StateDb,
+    private aliasServer: AliasServer | null,
+    private logger: Logger,
+    private onAliasChanged?: (name: string) => void,
+  ) {}
+
+  register(handlers: Map<IpcMethod, RequestHandler>): void {
+    handlers.set("listAliases", async (_params, _ctx) => {
+      return this.db.listAliases();
+    });
+
+    handlers.set("getAlias", async (params, _ctx) => {
+      const { name } = GetAliasParamsSchema.parse(params);
+      const alias = this.db.getAlias(name);
+      if (!alias) return null;
+      try {
+        const script = readFileSync(alias.filePath, "utf-8");
+        return { ...alias, script };
+      } catch {
+        return { ...alias, script: "" };
+      }
+    });
+
+    handlers.set("saveAlias", async (params, _ctx) => {
+      const parsed = SaveAliasParamsSchema.parse(params);
+      const { name, script, description, expiresAt } = parsed;
+      // If the caller did not supply `scope`, preserve the existing row's scope.
+      // An explicit `null` clears scope; an explicit string sets it.
+      const scopeProvided =
+        typeof params === "object" && params !== null && Object.prototype.hasOwnProperty.call(params, "scope");
+      const filePath = safeAliasPath(name);
+      mkdirSync(options.ALIASES_DIR, { recursive: true });
+      const wasMonitor = this.db.getAlias(name)?.aliasType === "defineMonitor";
+
+      // Guard: refuse to overwrite a permanent alias with an ephemeral one.
+      // This check must happen BEFORE writeFileSync to protect the file on disk.
+      if (expiresAt != null) {
+        const existing = this.db.getAlias(name);
+        if (existing && existing.expiresAt === null) {
+          return { ok: false, reason: "permanent_alias_exists" };
+        }
+      }
+
+      // When caller didn't supply scope, pass scopeProvided=false so the SQL
+      // UPDATE branch preserves the existing row's scope atomically (no TOCTOU).
+      const scope: string | null = scopeProvided ? (parsed.scope ?? null) : null;
+
+      const isMonitor = isDefineMonitor(script);
+      const isStructured = !isMonitor && isDefineAlias(script);
+
+      let finalScript: string;
+      if (isStructured || isMonitor) {
+        // defineAlias and defineMonitor scripts get everything via the virtual module — no auto-import
+        finalScript = script;
+      } else {
+        // Freeform: auto-prepend import if not present (existing behavior)
+        const hasImport = /import\s.*from\s+["']mcp-cli["']/.test(script);
+        finalScript = hasImport ? script : `import { mcp, args, file, json } from "mcp-cli";\n${script}`;
+      }
+
+      writeFileSync(filePath, finalScript, "utf-8");
+
+      const aliasType = isMonitor ? "defineMonitor" : isStructured ? "defineAlias" : "freeform";
+      const warnings: string[] = [];
+      const validationErrors: string[] = [];
+
+      // Bundle the alias and extract metadata
+      try {
+        const { js, sourceHash } = await bundleAlias(filePath);
+
+        if (isStructured) {
+          if (!this.aliasServer) throw new Error("Alias server not initialized");
+          const validation = await this.aliasServer.validateInSubprocess(js);
+          if (!validation.valid) {
+            validationErrors.push(...validation.errors);
+          }
+          if (validation.warnings.length > 0) {
+            warnings.push(...validation.warnings);
+          }
+          this.db.saveAlias(
+            name,
+            filePath,
+            validation.description || description,
+            aliasType,
+            validation.inputSchema ? JSON.stringify(validation.inputSchema) : undefined,
+            validation.outputSchema ? JSON.stringify(validation.outputSchema) : undefined,
+            js,
+            sourceHash,
+            expiresAt,
+            scope ?? null,
+            scopeProvided,
+            validation.monitorDefs ? JSON.stringify(validation.monitorDefs) : undefined,
+          );
+        } else {
+          // Mixed scripts (defineAlias + defineMonitor in the same file) are not supported.
+          // The file was classified as defineMonitor (isMonitor=true), so defineAlias content
+          // would be silently ignored. Reject early with a clear validation error instead.
+          if (isMonitor && isDefineAlias(finalScript)) {
+            validationErrors.push(
+              "Script contains both defineAlias() and defineMonitor(). Mixed scripts are not supported — use one pattern per file.",
+            );
+          }
+          // Freeform: extract monitor definitions in subprocess if sentinel detected
+          let monitorDefsJson: string | undefined;
+          if (isDefineMonitor(finalScript) && this.aliasServer) {
+            try {
+              const monitorDefs = await this.aliasServer.extractMonitorsInSubprocess(js);
+              if (monitorDefs.length > 0) monitorDefsJson = JSON.stringify(monitorDefs);
+            } catch (err) {
+              this.logger.warn(
+                `[saveAlias] extractMonitorMetadata failed for "${name}": ${err instanceof Error ? err.message : String(err)}`,
+              );
+            }
+          }
+          this.db.saveAlias(
+            name,
+            filePath,
+            description,
+            aliasType,
+            undefined,
+            undefined,
+            js,
+            sourceHash,
+            expiresAt,
+            scope ?? null,
+            scopeProvided,
+            monitorDefsJson,
+          );
+        }
+      } catch (err) {
+        // Bundle/extraction failed — save without bundle
+        validationErrors.push(`Bundle failed: ${err instanceof Error ? err.message : String(err)}`);
+        this.db.saveAlias(
+          name,
+          filePath,
+          description,
+          aliasType,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          expiresAt,
+          scope ?? null,
+          scopeProvided,
+          undefined,
+          false,
+        );
+      }
+
+      // Refresh virtual alias server so new tool is immediately visible
+      await this.aliasServer?.refresh();
+      if (isMonitor || wasMonitor) this.onAliasChanged?.(name);
+      const result: { ok: true; filePath: string; warnings?: string[]; validationErrors?: string[] } = {
+        ok: true,
+        filePath,
+      };
+      if (warnings.length > 0) result.warnings = warnings;
+      if (validationErrors.length > 0) result.validationErrors = validationErrors;
+      return result;
+    });
+
+    handlers.set("deleteAlias", async (params, _ctx) => {
+      const { name } = DeleteAliasParamsSchema.parse(params);
+      const alias = this.db.getAlias(name);
+      if (alias) {
+        try {
+          unlinkSync(alias.filePath);
+        } catch {
+          // file already gone, fine
+        }
+        this.db.deleteAlias(name);
+      }
+      // Refresh virtual alias server so deleted tool is removed
+      await this.aliasServer?.refresh();
+      if (alias?.aliasType === "defineMonitor") this.onAliasChanged?.(name);
+      return { ok: true };
+    });
+
+    handlers.set("touchAlias", async (params, _ctx) => {
+      const { name, expiresAt } = TouchAliasParamsSchema.parse(params);
+      this.db.touchAliasExpiry(name, expiresAt);
+      return { ok: true };
+    });
+
+    handlers.set("recordAliasRun", async (params, _ctx) => {
+      const { name } = RecordAliasRunParamsSchema.parse(params);
+      const runCount = this.db.recordAliasRun(name);
+      return { ok: true, runCount };
+    });
+
+    handlers.set("checkAlias", async (params, _ctx) => {
+      const { name } = CheckAliasParamsSchema.parse(params);
+      const alias = this.db.getAlias(name);
+      if (!alias) {
+        return { valid: false, aliasType: "freeform", errors: [`Alias "${name}" not found`], warnings: [] };
+      }
+
+      if (alias.aliasType !== "defineAlias") {
+        // Freeform aliases — try bundling to check for syntax errors
+        try {
+          await bundleAlias(alias.filePath);
+        } catch (err) {
+          return {
+            valid: false,
+            aliasType: "freeform",
+            errors: [`Bundle failed: ${err instanceof Error ? err.message : String(err)}`],
+            warnings: [],
+          };
+        }
+
+        // Run tsc --noEmit for type-level diagnostics (warnings only)
+        const tsc = await validateFreeformTsc(alias.filePath);
+        return { valid: true, aliasType: "freeform", errors: [], warnings: tsc.warnings };
+      }
+
+      // defineAlias — full validation
+      try {
+        const { js } = await bundleAlias(alias.filePath);
+        if (!this.aliasServer) throw new Error("Alias server not initialized");
+        return await this.aliasServer.validateInSubprocess(js);
+      } catch (err) {
+        return {
+          valid: false,
+          aliasType: "defineAlias",
+          errors: [`Validation failed: ${err instanceof Error ? err.message : String(err)}`],
+          warnings: [],
+        };
+      }
+    });
+  }
+}

--- a/packages/daemon/src/handlers/auth.spec.ts
+++ b/packages/daemon/src/handlers/auth.spec.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+import { IPC_ERROR } from "@mcp-cli/core";
+import type { IpcMethod } from "@mcp-cli/core";
+import type { RequestHandler } from "../handler-types";
+import { AuthHandlers } from "./auth";
+
+function invoke(map: Map<IpcMethod, RequestHandler>, method: IpcMethod): RequestHandler {
+  const h = map.get(method);
+  if (!h) throw new Error(`Handler "${method}" not registered`);
+  return h;
+}
+
+function mockPool(overrides: Record<string, unknown> = {}) {
+  return {
+    listServers: () => [],
+    getServerUrl: () => null,
+    getDb: () => null,
+    getServerConfig: () => null,
+    getCachedTools: () => [],
+    callTool: async () => ({ content: [] }),
+    listTools: async () => [],
+    restart: async () => {},
+    ...overrides,
+  } as never;
+}
+
+const mockLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+} as never;
+
+function buildHandlers(pool = mockPool()): Map<IpcMethod, RequestHandler> {
+  const map = new Map<IpcMethod, RequestHandler>();
+  new AuthHandlers(pool, mockLogger).register(map);
+  return map;
+}
+
+describe("AuthHandlers – triggerAuth", () => {
+  test("throws SERVER_NOT_FOUND when no serverUrl and no auth tool", async () => {
+    const map = buildHandlers(
+      mockPool({
+        getServerUrl: () => null,
+        listTools: async () => [{ name: "search", description: "" }],
+      }),
+    );
+    const err = await invoke(map, "triggerAuth")({ server: "myserver" }, {} as never).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as { code?: number }).code).toBe(IPC_ERROR.SERVER_NOT_FOUND);
+  });
+
+  test("calls callTool('auth') when no serverUrl but has auth tool", async () => {
+    let calledWith: unknown;
+    const map = buildHandlers(
+      mockPool({
+        getServerUrl: () => null,
+        listTools: async () => [{ name: "auth", description: "" }],
+        callTool: async (server: string, tool: string, args: unknown) => {
+          calledWith = { server, tool, args };
+          return { content: [{ type: "text", text: "authenticated" }], isError: false };
+        },
+      }),
+    );
+    const result = (await invoke(map, "triggerAuth")({ server: "myserver" }, {} as never)) as {
+      ok: boolean;
+      message: string;
+    };
+    expect(result.ok).toBe(true);
+    expect(result.message).toBe("authenticated");
+    expect((calledWith as { tool: string }).tool).toBe("auth");
+  });
+
+  test("throws INTERNAL_ERROR when auth tool returns isError=true", async () => {
+    const map = buildHandlers(
+      mockPool({
+        getServerUrl: () => null,
+        listTools: async () => [{ name: "auth", description: "" }],
+        callTool: async () => ({ content: [{ type: "text", text: "bad creds" }], isError: true }),
+      }),
+    );
+    const err = await invoke(map, "triggerAuth")({ server: "myserver" }, {} as never).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as { code?: number }).code).toBe(IPC_ERROR.INTERNAL_ERROR);
+  });
+});
+
+describe("AuthHandlers – authStatus", () => {
+  test("returns all servers when no server filter", async () => {
+    const map = buildHandlers(
+      mockPool({
+        listServers: () => [
+          { name: "s1", transport: "stdio", toolCount: 0 },
+          { name: "s2", transport: "stdio", toolCount: 0 },
+        ],
+        getServerUrl: () => null,
+        getCachedTools: () => [],
+      }),
+    );
+    const result = (await invoke(map, "authStatus")(undefined, {} as never)) as { servers: { server: string }[] };
+    expect(result.servers).toHaveLength(2);
+    expect(result.servers.map((s) => s.server)).toEqual(["s1", "s2"]);
+  });
+
+  test("throws SERVER_NOT_FOUND for unknown server", async () => {
+    const map = buildHandlers(
+      mockPool({
+        listServers: () => [{ name: "s1", transport: "stdio", toolCount: 0 }],
+      }),
+    );
+    const err = await invoke(map, "authStatus")({ server: "unknown" }, {} as never).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as { code?: number }).code).toBe(IPC_ERROR.SERVER_NOT_FOUND);
+  });
+
+  test("returns auth_tool support for stdio server with auth tool cached", async () => {
+    const map = buildHandlers(
+      mockPool({
+        listServers: () => [{ name: "s1", transport: "stdio", toolCount: 1 }],
+        getServerUrl: () => null,
+        getCachedTools: () => [{ name: "auth", description: "" }],
+      }),
+    );
+    const result = (await invoke(map, "authStatus")({ server: "s1" }, {} as never)) as {
+      servers: { server: string; authSupport: string; status: string }[];
+    };
+    expect(result.servers[0].authSupport).toBe("auth_tool");
+    expect(result.servers[0].status).toBe("unknown");
+  });
+
+  test("returns none authSupport for stdio server without auth tool", async () => {
+    const map = buildHandlers(
+      mockPool({
+        listServers: () => [{ name: "s1", transport: "stdio", toolCount: 1 }],
+        getServerUrl: () => null,
+        getCachedTools: () => [{ name: "search", description: "" }],
+      }),
+    );
+    const result = (await invoke(map, "authStatus")({ server: "s1" }, {} as never)) as {
+      servers: { authSupport: string }[];
+    };
+    expect(result.servers[0].authSupport).toBe("none");
+  });
+});

--- a/packages/daemon/src/handlers/auth.spec.ts
+++ b/packages/daemon/src/handlers/auth.spec.ts
@@ -33,7 +33,7 @@ const mockLogger = {
 
 function buildHandlers(pool = mockPool()): Map<IpcMethod, RequestHandler> {
   const map = new Map<IpcMethod, RequestHandler>();
-  new AuthHandlers(pool, mockLogger).register(map);
+  new AuthHandlers(pool).register(map);
   return map;
 }
 

--- a/packages/daemon/src/handlers/auth.ts
+++ b/packages/daemon/src/handlers/auth.ts
@@ -1,0 +1,145 @@
+import { AuthStatusParamsSchema, IPC_ERROR, TriggerAuthParamsSchema } from "@mcp-cli/core";
+import type { IpcMethod, Logger, ServerAuthStatus } from "@mcp-cli/core";
+import { McpOAuthProvider } from "../auth/oauth-provider";
+import { runOAuthFlowWithDcrRetry } from "../auth/oauth-retry";
+import type { RequestHandler } from "../handler-types";
+import type { ServerPool } from "../server-pool";
+
+export class AuthHandlers {
+  constructor(
+    private pool: ServerPool,
+    private logger: Logger,
+  ) {}
+
+  register(handlers: Map<IpcMethod, RequestHandler>): void {
+    handlers.set("triggerAuth", async (params, _ctx) => {
+      const { server } = TriggerAuthParamsSchema.parse(params);
+      const serverUrl = this.pool.getServerUrl(server);
+
+      // Non-remote server — check for `auth` tool convention
+      if (!serverUrl) {
+        let tools: Awaited<ReturnType<ServerPool["listTools"]>>;
+        try {
+          tools = await this.pool.listTools(server);
+        } catch {
+          tools = [];
+        }
+        const hasAuthTool = tools.some((t) => t.name === "auth");
+        if (!hasAuthTool) {
+          throw Object.assign(
+            new Error(`Server "${server}" not found or does not support auth (no OAuth endpoint and no "auth" tool)`),
+            { code: IPC_ERROR.SERVER_NOT_FOUND },
+          );
+        }
+
+        const result = (await this.pool.callTool(server, "auth", {})) as {
+          content?: Array<{ type?: string; text?: string }>;
+          isError?: boolean;
+        };
+        const text =
+          result.content
+            ?.filter((c) => c.type === "text")
+            .map((c) => c.text)
+            .join("\n") ?? "";
+        if (result.isError) {
+          throw Object.assign(new Error(text || "auth tool returned an error"), {
+            code: IPC_ERROR.INTERNAL_ERROR,
+          });
+        }
+        return { ok: true, message: text || "Authenticated via auth tool" };
+      }
+
+      const poolDb = this.pool.getDb();
+      if (!poolDb) {
+        throw Object.assign(new Error("Database not available"), { code: IPC_ERROR.INTERNAL_ERROR });
+      }
+
+      // Read OAuth config from server configuration
+      const serverConfig = this.pool.getServerConfig(server);
+      const { clientId, clientSecret, callbackPort, scope } = serverConfig ?? {};
+
+      const flowResult = await runOAuthFlowWithDcrRetry(server, serverUrl, poolDb, {
+        clientId,
+        clientSecret,
+        callbackPort,
+        scope,
+      });
+
+      await this.pool.restart(server);
+
+      if (flowResult === "already_authorized") {
+        return { ok: true, message: "Already authorized" };
+      }
+      return { ok: true, message: "Authenticated successfully" };
+    });
+
+    handlers.set("authStatus", async (params, _ctx) => {
+      const { server } = AuthStatusParamsSchema.parse(params ?? {});
+      const allServers = this.pool.listServers();
+      const filtered = server ? allServers.filter((s) => s.name === server) : allServers;
+
+      if (server && filtered.length === 0) {
+        throw Object.assign(new Error(`Server "${server}" not found`), { code: IPC_ERROR.SERVER_NOT_FOUND });
+      }
+
+      const poolDb = this.pool.getDb();
+      const results: ServerAuthStatus[] = [];
+
+      for (const srv of filtered) {
+        const serverUrl = this.pool.getServerUrl(srv.name);
+        let authSupport: ServerAuthStatus["authSupport"] = "none";
+        let status: ServerAuthStatus["status"] = "unknown";
+        let expiresAt: number | undefined;
+
+        if (serverUrl) {
+          // Remote server — check for OAuth tokens via provider (includes keychain fallback)
+          authSupport = "oauth";
+          if (poolDb) {
+            const serverConfig = this.pool.getServerConfig(srv.name);
+            const provider = new McpOAuthProvider(srv.name, serverUrl, poolDb, {
+              clientId: serverConfig?.clientId,
+              clientSecret: serverConfig?.clientSecret,
+              scope: serverConfig?.scope,
+            });
+            const tokens = await provider.tokens();
+            if (tokens) {
+              // Check raw expires_at from DB for accurate expiry detection
+              const rawExpiry = poolDb.getTokenExpiry(srv.name);
+              if (rawExpiry !== null && rawExpiry <= Date.now()) {
+                status = "expired";
+                expiresAt = rawExpiry;
+              } else {
+                status = "authenticated";
+                if (rawExpiry !== null) {
+                  expiresAt = rawExpiry;
+                } else if (tokens.expires_in !== undefined && tokens.expires_in > 0) {
+                  // Keychain token with expiry info
+                  expiresAt = Date.now() + tokens.expires_in * 1000;
+                }
+              }
+            } else {
+              status = "not_authenticated";
+            }
+          }
+        } else if (srv.transport !== "virtual") {
+          // Stdio server — only check cached tools, never spawn the process
+          const cachedTools = this.pool.getCachedTools(srv.name);
+          if (cachedTools?.some((t) => t.name === "auth")) {
+            authSupport = "auth_tool";
+            status = "unknown"; // can't check without calling it
+          }
+        }
+
+        results.push({
+          server: srv.name,
+          transport: srv.transport,
+          authSupport,
+          status,
+          ...(expiresAt !== undefined && { expiresAt }),
+        });
+      }
+
+      return { servers: results };
+    });
+  }
+}

--- a/packages/daemon/src/handlers/auth.ts
+++ b/packages/daemon/src/handlers/auth.ts
@@ -1,15 +1,12 @@
 import { AuthStatusParamsSchema, IPC_ERROR, TriggerAuthParamsSchema } from "@mcp-cli/core";
-import type { IpcMethod, Logger, ServerAuthStatus } from "@mcp-cli/core";
+import type { IpcMethod, ServerAuthStatus } from "@mcp-cli/core";
 import { McpOAuthProvider } from "../auth/oauth-provider";
 import { runOAuthFlowWithDcrRetry } from "../auth/oauth-retry";
 import type { RequestHandler } from "../handler-types";
 import type { ServerPool } from "../server-pool";
 
 export class AuthHandlers {
-  constructor(
-    private pool: ServerPool,
-    private logger: Logger,
-  ) {}
+  constructor(private pool: ServerPool) {}
 
   register(handlers: Map<IpcMethod, RequestHandler>): void {
     handlers.set("triggerAuth", async (params, _ctx) => {

--- a/packages/daemon/src/handlers/budget.spec.ts
+++ b/packages/daemon/src/handlers/budget.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import type { IpcMethod } from "@mcp-cli/core";
+import type { RequestHandler } from "../handler-types";
+import { BudgetHandlers } from "./budget";
+
+function invoke(map: Map<IpcMethod, RequestHandler>, method: IpcMethod): RequestHandler {
+  const h = map.get(method);
+  if (!h) throw new Error(`Handler "${method}" not registered`);
+  return h;
+}
+
+function mockDb(overrides: Partial<{ getBudgetConfig: () => unknown; setBudgetConfig: (cfg: unknown) => void }> = {}) {
+  return {
+    getBudgetConfig: () => ({ weekly: 10, monthly: 40 }),
+    setBudgetConfig: () => {},
+    ...overrides,
+  } as never;
+}
+
+function buildHandlers(db = mockDb()): Map<IpcMethod, RequestHandler> {
+  const map = new Map<IpcMethod, RequestHandler>();
+  new BudgetHandlers(db).register(map);
+  return map;
+}
+
+describe("BudgetHandlers", () => {
+  test("getBudgetConfig returns db result", async () => {
+    const cfg = { weekly: 5, monthly: 20 };
+    const map = buildHandlers(mockDb({ getBudgetConfig: () => cfg }));
+    const result = await invoke(map, "getBudgetConfig")(undefined, {} as never);
+    expect(result).toEqual(cfg);
+  });
+
+  test("setBudgetConfig calls db.setBudgetConfig", async () => {
+    let saved: unknown;
+    const map = buildHandlers(
+      mockDb({
+        setBudgetConfig: (cfg) => {
+          saved = cfg;
+        },
+      }),
+    );
+    const result = await invoke(map, "setBudgetConfig")({ weekly: 3 }, {} as never);
+    expect(result).toEqual({ ok: true });
+    expect(saved).toBeTruthy();
+  });
+
+  test("setBudgetConfig rejects invalid params", async () => {
+    const map = buildHandlers();
+    await expect(invoke(map, "setBudgetConfig")("not-an-object", {} as never)).rejects.toThrow();
+  });
+});

--- a/packages/daemon/src/handlers/budget.ts
+++ b/packages/daemon/src/handlers/budget.ts
@@ -1,0 +1,17 @@
+import { SetBudgetConfigParamsSchema } from "@mcp-cli/core";
+import type { IpcMethod } from "@mcp-cli/core";
+import type { StateDb } from "../db/state";
+import type { RequestHandler } from "../handler-types";
+
+export class BudgetHandlers {
+  constructor(private db: StateDb) {}
+
+  register(handlers: Map<IpcMethod, RequestHandler>): void {
+    handlers.set("getBudgetConfig", async () => this.db.getBudgetConfig());
+    handlers.set("setBudgetConfig", async (params) => {
+      const parsed = SetBudgetConfigParamsSchema.parse(params);
+      this.db.setBudgetConfig(parsed);
+      return { ok: true as const };
+    });
+  }
+}

--- a/packages/daemon/src/handlers/config.spec.ts
+++ b/packages/daemon/src/handlers/config.spec.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import type { IpcMethod, ResolvedConfig } from "@mcp-cli/core";
+import { IPC_ERROR } from "@mcp-cli/core";
+import type { RequestHandler } from "../handler-types";
+import { ConfigHandlers } from "./config";
+
+function invoke(map: Map<IpcMethod, RequestHandler>, method: IpcMethod): RequestHandler {
+  const h = map.get(method);
+  if (!h) throw new Error(`Handler "${method}" not registered`);
+  return h;
+}
+
+function mockPool(servers: { name: string; transport: string; toolCount: number }[] = []) {
+  return {
+    listServers: () => servers,
+  } as never;
+}
+
+function mockConfig(overrides: Partial<ResolvedConfig> = {}): ResolvedConfig {
+  return {
+    servers: new Map(),
+    sources: [],
+    ...overrides,
+  };
+}
+
+function buildHandlers(
+  pool = mockPool(),
+  config = mockConfig(),
+  onReload: (() => Promise<void>) | null = null,
+): Map<IpcMethod, RequestHandler> {
+  const map = new Map<IpcMethod, RequestHandler>();
+  new ConfigHandlers(pool, config, onReload).register(map);
+  return map;
+}
+
+describe("ConfigHandlers", () => {
+  test("getConfig returns empty servers when config has no servers", async () => {
+    const map = buildHandlers();
+    const result = (await invoke(map, "getConfig")(undefined, {} as never)) as {
+      servers: Record<string, unknown>;
+      sources: unknown[];
+    };
+    expect(result.servers).toEqual({});
+    expect(result.sources).toEqual([]);
+  });
+
+  test("getConfig merges pool status into server entries", async () => {
+    const config = mockConfig({
+      servers: new Map([
+        [
+          "my-server",
+          {
+            name: "my-server",
+            config: { command: "npx", args: [] },
+            source: { file: "/home/user/.claude.json", scope: "user" },
+          },
+        ],
+      ]),
+      sources: [{ file: "/home/user/.claude.json", scope: "user" as const }],
+    });
+    const pool = mockPool([{ name: "my-server", transport: "stdio", toolCount: 5 }]);
+    const map = buildHandlers(pool, config);
+    const result = (await invoke(map, "getConfig")(undefined, {} as never)) as {
+      servers: Record<string, { transport: string; source: string; scope: string; toolCount: number }>;
+      sources: unknown[];
+    };
+    expect(result.servers["my-server"]).toEqual({
+      transport: "stdio",
+      source: "/home/user/.claude.json",
+      scope: "user",
+      toolCount: 5,
+    });
+    expect(result.sources).toHaveLength(1);
+  });
+
+  test("getConfig uses unknown transport and 0 toolCount when server not in pool", async () => {
+    const config = mockConfig({
+      servers: new Map([
+        [
+          "offline-server",
+          {
+            name: "offline-server",
+            config: { command: "npx", args: [] },
+            source: { file: "/etc/mcp.json", scope: "project" },
+          },
+        ],
+      ]),
+    });
+    const map = buildHandlers(mockPool([]), config);
+    const result = (await invoke(map, "getConfig")(undefined, {} as never)) as {
+      servers: Record<string, { transport: string; toolCount: number }>;
+    };
+    expect(result.servers["offline-server"].transport).toBe("unknown");
+    expect(result.servers["offline-server"].toolCount).toBe(0);
+  });
+
+  test("reloadConfig calls onReloadConfig and returns ok", async () => {
+    let called = false;
+    const map = buildHandlers(mockPool(), mockConfig(), async () => {
+      called = true;
+    });
+    const result = (await invoke(map, "reloadConfig")(undefined, {} as never)) as { ok: boolean };
+    expect(result.ok).toBe(true);
+    expect(called).toBe(true);
+  });
+
+  test("reloadConfig throws INTERNAL_ERROR when no reload fn", async () => {
+    const map = buildHandlers(mockPool(), mockConfig(), null);
+    await expect(invoke(map, "reloadConfig")(undefined, {} as never)).rejects.toMatchObject({
+      code: IPC_ERROR.INTERNAL_ERROR,
+    });
+  });
+});

--- a/packages/daemon/src/handlers/config.ts
+++ b/packages/daemon/src/handlers/config.ts
@@ -1,0 +1,40 @@
+import { IPC_ERROR } from "@mcp-cli/core";
+import type { IpcMethod, ResolvedConfig } from "@mcp-cli/core";
+import type { RequestHandler } from "../handler-types";
+import type { ServerPool } from "../server-pool";
+
+export class ConfigHandlers {
+  constructor(
+    private pool: ServerPool,
+    private config: ResolvedConfig,
+    private onReloadConfig: (() => Promise<void>) | null,
+  ) {}
+
+  register(handlers: Map<IpcMethod, RequestHandler>): void {
+    handlers.set("getConfig", async () => {
+      const servers: Record<string, { transport: string; source: string; scope: string; toolCount: number }> = {};
+      const statusMap = new Map(this.pool.listServers().map((s) => [s.name, s]));
+      for (const [name, resolved] of this.config.servers) {
+        const status = statusMap.get(name);
+        servers[name] = {
+          transport: status?.transport ?? "unknown",
+          source: resolved.source.file,
+          scope: resolved.source.scope,
+          toolCount: status?.toolCount ?? 0,
+        };
+      }
+      return {
+        servers,
+        sources: this.config.sources,
+      };
+    });
+
+    handlers.set("reloadConfig", async () => {
+      if (!this.onReloadConfig) {
+        throw Object.assign(new Error("Config reload not available"), { code: IPC_ERROR.INTERNAL_ERROR });
+      }
+      await this.onReloadConfig();
+      return { ok: true };
+    });
+  }
+}

--- a/packages/daemon/src/handlers/event.spec.ts
+++ b/packages/daemon/src/handlers/event.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import type { IpcMethod } from "@mcp-cli/core";
+import { IPC_ERROR } from "@mcp-cli/core";
+import type { RequestHandler } from "../handler-types";
+import { EventHandlers } from "./event";
+
+function invoke(map: Map<IpcMethod, RequestHandler>, method: IpcMethod): RequestHandler {
+  const h = map.get(method);
+  if (!h) throw new Error(`Handler "${method}" not registered`);
+  return h;
+}
+
+function mockEventBus() {
+  return {
+    publish: (input: unknown) => ({ seq: 1, ...(input as object) }),
+  } as never;
+}
+
+function buildHandlers(bus = mockEventBus()): Map<IpcMethod, RequestHandler> {
+  const map = new Map<IpcMethod, RequestHandler>();
+  new EventHandlers(bus).register(map);
+  return map;
+}
+
+describe("EventHandlers", () => {
+  test("publishEvent publishes to eventBus", async () => {
+    const map = buildHandlers();
+    const result = (await invoke(map, "publishEvent")(
+      { src: "test", event: "test.event", category: "session" },
+      {} as never,
+    )) as { ok: boolean; seq: number };
+    expect(result.ok).toBe(true);
+    expect(result.seq).toBe(1);
+  });
+
+  test("publishEvent throws when no eventBus", async () => {
+    const map = buildHandlers(null as never);
+    await expect(
+      invoke(map, "publishEvent")({ src: "test", event: "test.event", category: "session" }, {} as never),
+    ).rejects.toMatchObject({ code: IPC_ERROR.INTERNAL_ERROR });
+  });
+});

--- a/packages/daemon/src/handlers/event.ts
+++ b/packages/daemon/src/handlers/event.ts
@@ -1,0 +1,28 @@
+import { IPC_ERROR, PublishEventParamsSchema } from "@mcp-cli/core";
+import type { IpcMethod, MonitorEventInput } from "@mcp-cli/core";
+import type { EventBus } from "../event-bus";
+import type { RequestHandler } from "../handler-types";
+
+export class EventHandlers {
+  constructor(private eventBus: EventBus | null) {}
+
+  register(handlers: Map<IpcMethod, RequestHandler>): void {
+    handlers.set("publishEvent", async (params) => {
+      const parsed = PublishEventParamsSchema.parse(params);
+      if (!this.eventBus) {
+        throw Object.assign(new Error("EventBus not available"), { code: IPC_ERROR.INTERNAL_ERROR });
+      }
+      const input: MonitorEventInput = {
+        ...(parsed.extra && parsed.extra),
+        src: parsed.src,
+        event: parsed.event,
+        category: parsed.category,
+        ...(parsed.sessionId !== undefined && { sessionId: parsed.sessionId }),
+        ...(parsed.workItemId !== undefined && { workItemId: parsed.workItemId }),
+        ...(parsed.prNumber !== undefined && { prNumber: parsed.prNumber }),
+      };
+      const published = this.eventBus.publish(input);
+      return { ok: true as const, seq: published.seq };
+    });
+  }
+}

--- a/packages/daemon/src/handlers/mail.spec.ts
+++ b/packages/daemon/src/handlers/mail.spec.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from "bun:test";
+import type { IpcMethod, MailMessage } from "@mcp-cli/core";
+import type { RequestHandler } from "../handler-types";
+import { MailHandlers } from "./mail";
+
+function invoke(map: Map<IpcMethod, RequestHandler>, method: IpcMethod): RequestHandler {
+  const h = map.get(method);
+  if (!h) throw new Error(`Handler "${method}" not registered`);
+  return h;
+}
+
+// Minimal in-memory mail store
+function makeMailDb() {
+  let nextId = 1;
+  const messages = new Map<number, MailMessage>();
+
+  return {
+    insertMail(sender: string, recipient: string, subject?: string, body?: string, replyTo?: number): number {
+      const id = nextId++;
+      messages.set(id, {
+        id,
+        sender,
+        recipient,
+        subject: subject ?? null,
+        body: body ?? null,
+        replyTo: replyTo ?? null,
+        read: false,
+        createdAt: new Date().toISOString(),
+      } as unknown as MailMessage);
+      return id;
+    },
+    readMail(recipient?: string, unreadOnly?: boolean, limit?: number): MailMessage[] {
+      let list = [...messages.values()];
+      if (recipient) list = list.filter((m) => m.recipient === recipient);
+      if (unreadOnly) list = list.filter((m) => !m.read);
+      if (limit !== undefined) list = list.slice(0, limit);
+      return list;
+    },
+    getNextUnread(recipient?: string): MailMessage | undefined {
+      for (const m of messages.values()) {
+        if (!m.read && (!recipient || m.recipient === recipient)) return m;
+      }
+      return undefined;
+    },
+    markMailRead(id: number): void {
+      const m = messages.get(id);
+      if (m) (m as unknown as Record<string, unknown>).read = true;
+    },
+    getMailById(id: number): MailMessage | undefined {
+      return messages.get(id);
+    },
+  };
+}
+
+function buildHandlers(
+  overrides: Partial<ReturnType<typeof makeMailDb>> = {},
+  isDraining = () => false,
+): Map<IpcMethod, RequestHandler> {
+  const db = { ...makeMailDb(), ...overrides } as never;
+  const map = new Map<IpcMethod, RequestHandler>();
+  new MailHandlers(db, null, isDraining).register(map);
+  return map;
+}
+
+describe("MailHandlers", () => {
+  describe("sendMail", () => {
+    test("inserts mail and returns id", async () => {
+      const map = buildHandlers();
+      const result = (await invoke(map, "sendMail")(
+        { sender: "alice", recipient: "bob", subject: "hi", body: "hello" },
+        {} as never,
+      )) as { id: number };
+      expect(result.id).toBe(1);
+    });
+
+    test("second send gets incremented id", async () => {
+      const map = buildHandlers();
+      const ctx = {} as never;
+      await invoke(map, "sendMail")({ sender: "a", recipient: "b" }, ctx);
+      const r2 = (await invoke(map, "sendMail")({ sender: "a", recipient: "c" }, ctx)) as { id: number };
+      expect(r2.id).toBe(2);
+    });
+  });
+
+  describe("readMail", () => {
+    test("returns all messages when no filter", async () => {
+      const map = buildHandlers();
+      const ctx = {} as never;
+      await invoke(map, "sendMail")({ sender: "a", recipient: "b" }, ctx);
+      await invoke(map, "sendMail")({ sender: "a", recipient: "c" }, ctx);
+      const result = (await invoke(map, "readMail")(undefined, ctx)) as { messages: MailMessage[] };
+      expect(result.messages.length).toBe(2);
+    });
+
+    test("filters by recipient", async () => {
+      const map = buildHandlers();
+      const ctx = {} as never;
+      await invoke(map, "sendMail")({ sender: "a", recipient: "bob" }, ctx);
+      await invoke(map, "sendMail")({ sender: "a", recipient: "carol" }, ctx);
+      const result = (await invoke(map, "readMail")({ recipient: "bob" }, ctx)) as { messages: MailMessage[] };
+      expect(result.messages.length).toBe(1);
+      expect(result.messages[0].recipient).toBe("bob");
+    });
+
+    test("filters unread only", async () => {
+      const map = buildHandlers();
+      const ctx = {} as never;
+      await invoke(map, "sendMail")({ sender: "a", recipient: "b" }, ctx);
+      await invoke(map, "markRead")({ id: 1 }, ctx);
+      await invoke(map, "sendMail")({ sender: "a", recipient: "b" }, ctx);
+      const result = (await invoke(map, "readMail")({ unreadOnly: true }, ctx)) as { messages: MailMessage[] };
+      expect(result.messages.length).toBe(1);
+      expect(result.messages[0].id).toBe(2);
+    });
+  });
+
+  describe("waitForMail", () => {
+    test("returns message immediately when one is available", async () => {
+      const map = buildHandlers();
+      const ctx = {} as never;
+      await invoke(map, "sendMail")({ sender: "a", recipient: "b", body: "urgent" }, ctx);
+      const result = (await invoke(map, "waitForMail")({ recipient: "b", timeout: 5 }, ctx)) as {
+        message: MailMessage | null;
+      };
+      expect(result.message).not.toBeNull();
+      expect((result.message as MailMessage).recipient).toBe("b");
+    });
+
+    test("marks message as read after returning it", async () => {
+      const map = buildHandlers();
+      const ctx = {} as never;
+      await invoke(map, "sendMail")({ sender: "a", recipient: "b" }, ctx);
+      await invoke(map, "waitForMail")({ recipient: "b", timeout: 5 }, ctx);
+      // Second call should find no unread messages
+      const result = (await invoke(map, "waitForMail")({ recipient: "b", timeout: 1 }, ctx)) as {
+        message: MailMessage | null;
+      };
+      expect(result.message).toBeNull();
+    });
+
+    test("returns null when no message arrives within timeout", async () => {
+      const map = buildHandlers();
+      const result = (await invoke(map, "waitForMail")({ recipient: "nobody", timeout: 1 }, {} as never)) as {
+        message: MailMessage | null;
+      };
+      expect(result.message).toBeNull();
+    });
+
+    test("returns null immediately when draining", async () => {
+      const map = buildHandlers({}, () => true);
+      const ctx = {} as never;
+      await invoke(map, "sendMail")({ sender: "a", recipient: "b" }, ctx);
+      const result = (await invoke(map, "waitForMail")({ recipient: "b", timeout: 30 }, ctx)) as {
+        message: MailMessage | null;
+      };
+      expect(result.message).toBeNull();
+    });
+  });
+
+  describe("replyToMail", () => {
+    test("sends reply to original sender with Re: subject", async () => {
+      const map = buildHandlers();
+      const ctx = {} as never;
+      await invoke(map, "sendMail")({ sender: "alice", recipient: "bob", subject: "hello" }, ctx);
+      const result = (await invoke(map, "replyToMail")({ id: 1, sender: "bob", body: "hi back" }, ctx)) as {
+        id: number;
+      };
+      expect(result.id).toBe(2);
+    });
+
+    test("uses explicit subject when provided", async () => {
+      const mailDb = makeMailDb();
+      const map = new Map<IpcMethod, RequestHandler>();
+      new MailHandlers(mailDb as never, null, () => false).register(map);
+      const ctx = {} as never;
+      await invoke(map, "sendMail")({ sender: "alice", recipient: "bob", subject: "topic" }, ctx);
+      await invoke(map, "replyToMail")({ id: 1, sender: "bob", body: "reply", subject: "custom subject" }, ctx);
+      const msgs = mailDb.readMail("alice", false);
+      expect(msgs[0].subject).toBe("custom subject");
+    });
+
+    test("throws INVALID_PARAMS when original message not found", async () => {
+      const map = buildHandlers();
+      await expect(
+        invoke(map, "replyToMail")({ id: 99, sender: "bob", body: "reply" }, {} as never),
+      ).rejects.toMatchObject({ message: "Mail message 99 not found" });
+    });
+  });
+
+  describe("markRead", () => {
+    test("marks message read", async () => {
+      const map = buildHandlers();
+      const ctx = {} as never;
+      await invoke(map, "sendMail")({ sender: "a", recipient: "b" }, ctx);
+      await invoke(map, "markRead")({ id: 1 }, ctx);
+      const result = (await invoke(map, "readMail")({ unreadOnly: true }, ctx)) as { messages: MailMessage[] };
+      expect(result.messages.length).toBe(0);
+    });
+
+    test("returns empty object", async () => {
+      const map = buildHandlers();
+      const ctx = {} as never;
+      await invoke(map, "sendMail")({ sender: "a", recipient: "b" }, ctx);
+      const result = await invoke(map, "markRead")({ id: 1 }, ctx);
+      expect(result).toEqual({});
+    });
+  });
+});

--- a/packages/daemon/src/handlers/mail.ts
+++ b/packages/daemon/src/handlers/mail.ts
@@ -1,0 +1,74 @@
+import {
+  IPC_ERROR,
+  MarkReadParamsSchema,
+  ReadMailParamsSchema,
+  ReplyToMailParamsSchema,
+  SendMailParamsSchema,
+  WaitForMailParamsSchema,
+} from "@mcp-cli/core";
+import type { IpcMethod } from "@mcp-cli/core";
+import type { StateDb } from "../db/state";
+import type { EventBus } from "../event-bus";
+import type { RequestHandler } from "../handler-types";
+import { publishMailReceived } from "../mail-events";
+
+export class MailHandlers {
+  constructor(
+    private readonly db: StateDb,
+    private readonly eventBus: EventBus | null,
+    private readonly isDraining: () => boolean,
+  ) {}
+
+  register(handlers: Map<IpcMethod, RequestHandler>): void {
+    handlers.set("sendMail", async (params, _ctx) => {
+      const { sender, recipient, subject, body, replyTo } = SendMailParamsSchema.parse(params);
+      const id = this.db.insertMail(sender, recipient, subject, body, replyTo);
+      publishMailReceived(this.eventBus, { mailId: id, sender, recipient });
+      return { id };
+    });
+
+    handlers.set("readMail", async (params, _ctx) => {
+      const { recipient, unreadOnly, limit } = ReadMailParamsSchema.parse(params ?? {});
+      const messages = this.db.readMail(recipient, unreadOnly, limit);
+      return { messages };
+    });
+
+    handlers.set("waitForMail", async (params, _ctx) => {
+      const { recipient, timeout } = WaitForMailParamsSchema.parse(params ?? {});
+      // Server-side timeout capped at 30s to stay under IPC client's 60s timeout
+      const maxWait = Math.min((timeout ?? 30) * 1000, 30_000);
+      const deadline = Date.now() + maxWait;
+
+      while (Date.now() < deadline) {
+        if (this.isDraining()) return { message: null };
+        const msg = this.db.getNextUnread(recipient);
+        if (msg) {
+          this.db.markMailRead(msg.id);
+          return { message: msg };
+        }
+        await Bun.sleep(500);
+      }
+      return { message: null };
+    });
+
+    handlers.set("replyToMail", async (params, _ctx) => {
+      const { id, sender, body, subject } = ReplyToMailParamsSchema.parse(params);
+      const original = this.db.getMailById(id);
+      if (!original) {
+        throw Object.assign(new Error(`Mail message ${id} not found`), {
+          code: IPC_ERROR.INVALID_PARAMS,
+        });
+      }
+      const replySubject = subject ?? (original.subject ? `Re: ${original.subject}` : undefined);
+      const newId = this.db.insertMail(sender, original.sender, replySubject, body, id);
+      publishMailReceived(this.eventBus, { mailId: newId, sender, recipient: original.sender });
+      return { id: newId };
+    });
+
+    handlers.set("markRead", async (params, _ctx) => {
+      const { id } = MarkReadParamsSchema.parse(params);
+      this.db.markMailRead(id);
+      return {};
+    });
+  }
+}

--- a/packages/daemon/src/handlers/note.spec.ts
+++ b/packages/daemon/src/handlers/note.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import type { IpcMethod } from "@mcp-cli/core";
+import type { RequestHandler } from "../handler-types";
+import { NoteHandlers } from "./note";
+
+function invoke(map: Map<IpcMethod, RequestHandler>, method: IpcMethod): RequestHandler {
+  const h = map.get(method);
+  if (!h) throw new Error(`Handler "${method}" not registered`);
+  return h;
+}
+
+function mockDb(overrides: Record<string, unknown> = {}) {
+  const notes = new Map<string, string>();
+  return {
+    setNote: (server: string, tool: string, note: string) => {
+      notes.set(`${server}\0${tool}`, note);
+    },
+    getNote: (server: string, tool: string) => notes.get(`${server}\0${tool}`) ?? null,
+    listNotes: () => [],
+    deleteNote: () => false,
+    ...overrides,
+  } as never;
+}
+
+function buildHandlers(db = mockDb()): Map<IpcMethod, RequestHandler> {
+  const map = new Map<IpcMethod, RequestHandler>();
+  new NoteHandlers(db).register(map);
+  return map;
+}
+
+describe("NoteHandlers", () => {
+  test("setNote then getNote returns note", async () => {
+    const map = buildHandlers();
+    await invoke(map, "setNote")({ server: "s1", tool: "t1", note: "hello" }, {} as never);
+    const result = (await invoke(map, "getNote")({ server: "s1", tool: "t1" }, {} as never)) as { note: string | null };
+    expect(result.note).toBe("hello");
+  });
+
+  test("getNote returns null for unknown tool", async () => {
+    const map = buildHandlers();
+    const result = (await invoke(map, "getNote")({ server: "s1", tool: "missing" }, {} as never)) as {
+      note: string | null;
+    };
+    expect(result.note).toBeNull();
+  });
+
+  test("listNotes delegates to db", async () => {
+    const notes = [{ serverName: "s1", toolName: "t1", note: "hi" }];
+    const map = buildHandlers(mockDb({ listNotes: () => notes }));
+    const result = await invoke(map, "listNotes")(undefined, {} as never);
+    expect(result).toEqual(notes);
+  });
+
+  test("deleteNote returns ok with deleted flag", async () => {
+    const map = buildHandlers(mockDb({ deleteNote: () => true }));
+    const result = (await invoke(map, "deleteNote")({ server: "s1", tool: "t1" }, {} as never)) as {
+      ok: boolean;
+      deleted: boolean;
+    };
+    expect(result.ok).toBe(true);
+    expect(result.deleted).toBe(true);
+  });
+});

--- a/packages/daemon/src/handlers/note.ts
+++ b/packages/daemon/src/handlers/note.ts
@@ -1,0 +1,27 @@
+import { DeleteNoteParamsSchema, GetNoteParamsSchema, SetNoteParamsSchema } from "@mcp-cli/core";
+import type { IpcMethod } from "@mcp-cli/core";
+import type { StateDb } from "../db/state";
+import type { RequestHandler } from "../handler-types";
+
+export class NoteHandlers {
+  constructor(private db: StateDb) {}
+
+  register(handlers: Map<IpcMethod, RequestHandler>): void {
+    handlers.set("setNote", async (params) => {
+      const { server, tool, note } = SetNoteParamsSchema.parse(params);
+      this.db.setNote(server, tool, note);
+      return { ok: true as const };
+    });
+    handlers.set("getNote", async (params) => {
+      const { server, tool } = GetNoteParamsSchema.parse(params);
+      const note = this.db.getNote(server, tool);
+      return { note: note ?? null };
+    });
+    handlers.set("listNotes", async () => this.db.listNotes());
+    handlers.set("deleteNote", async (params) => {
+      const { server, tool } = DeleteNoteParamsSchema.parse(params);
+      const deleted = this.db.deleteNote(server, tool);
+      return { ok: true as const, deleted };
+    });
+  }
+}

--- a/packages/daemon/src/handlers/serve.spec.ts
+++ b/packages/daemon/src/handlers/serve.spec.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+import type { IpcMethod, Logger, ServeInstanceInfo } from "@mcp-cli/core";
+import type { RequestHandler } from "../handler-types";
+import { ServeHandlers } from "./serve";
+
+function invoke(map: Map<IpcMethod, RequestHandler>, method: IpcMethod): RequestHandler {
+  const h = map.get(method);
+  if (!h) throw new Error(`Handler "${method}" not registered`);
+  return h;
+}
+
+function noopLogger(): Logger {
+  return {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  } as never;
+}
+
+const noopKill = async (_pid: number, _logger: Logger) => {};
+
+function buildHandlers(killPidFn = noopKill): {
+  map: Map<IpcMethod, RequestHandler>;
+  instances: Map<string, ServeInstanceInfo>;
+} {
+  const instances = new Map<string, ServeInstanceInfo>();
+  const map = new Map<IpcMethod, RequestHandler>();
+  new ServeHandlers(instances, noopLogger(), killPidFn).register(map);
+  return { map, instances };
+}
+
+const ctx = {} as never;
+
+describe("ServeHandlers", () => {
+  describe("registerServe", () => {
+    test("adds instance to map", async () => {
+      const { map, instances } = buildHandlers();
+      const result = (await invoke(map, "registerServe")(
+        { instanceId: "inst-1", pid: 1234, tools: ["tool-a"] },
+        ctx,
+      )) as { ok: boolean };
+      expect(result.ok).toBe(true);
+      expect(instances.has("inst-1")).toBe(true);
+      expect(instances.get("inst-1")?.pid).toBe(1234);
+    });
+
+    test("records startedAt timestamp", async () => {
+      const { map, instances } = buildHandlers();
+      const before = Date.now();
+      await invoke(map, "registerServe")({ instanceId: "i1", pid: 111, tools: [] }, ctx);
+      const after = Date.now();
+      expect(instances.get("i1")?.startedAt).toBeGreaterThanOrEqual(before);
+      expect(instances.get("i1")?.startedAt).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe("unregisterServe", () => {
+    test("removes existing instance", async () => {
+      const { map, instances } = buildHandlers();
+      await invoke(map, "registerServe")({ instanceId: "i1", pid: 111, tools: [] }, ctx);
+      const result = (await invoke(map, "unregisterServe")({ instanceId: "i1" }, ctx)) as { ok: boolean };
+      expect(result.ok).toBe(true);
+      expect(instances.has("i1")).toBe(false);
+    });
+
+    test("no-ops when instance does not exist", async () => {
+      const { map } = buildHandlers();
+      const result = (await invoke(map, "unregisterServe")({ instanceId: "missing" }, ctx)) as { ok: boolean };
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe("listServeInstances", () => {
+    test("returns registered instances with live PIDs", async () => {
+      const { map } = buildHandlers();
+      await invoke(map, "registerServe")({ instanceId: "a", pid: process.pid, tools: ["x"] }, ctx);
+      await invoke(map, "registerServe")({ instanceId: "b", pid: process.pid, tools: ["y"] }, ctx);
+      const list = (await invoke(map, "listServeInstances")(undefined, ctx)) as ServeInstanceInfo[];
+      expect(list.length).toBe(2);
+      expect(list.map((i) => i.instanceId).sort()).toEqual(["a", "b"]);
+    });
+
+    test("prunes instances with dead PIDs", async () => {
+      const { map } = buildHandlers();
+      await invoke(map, "registerServe")({ instanceId: "alive", pid: process.pid, tools: [] }, ctx);
+      await invoke(map, "registerServe")({ instanceId: "dead", pid: 2_000_000_000, tools: [] }, ctx);
+      const list = (await invoke(map, "listServeInstances")(undefined, ctx)) as ServeInstanceInfo[];
+      expect(list.map((i) => i.instanceId)).toContain("alive");
+      expect(list.map((i) => i.instanceId)).not.toContain("dead");
+    });
+  });
+
+  describe("killServe", () => {
+    test("throws INVALID_PARAMS when no selector given", async () => {
+      const { map } = buildHandlers();
+      await expect(invoke(map, "killServe")({}, ctx)).rejects.toMatchObject({
+        message: "Specify instanceId, pid, all, or staleHours",
+      });
+    });
+
+    test("throws SERVER_NOT_FOUND for unknown instanceId", async () => {
+      const { map } = buildHandlers();
+      await expect(invoke(map, "killServe")({ instanceId: "nonexistent" }, ctx)).rejects.toMatchObject({
+        message: 'Serve instance "nonexistent" not found',
+      });
+    });
+
+    test("throws SERVER_NOT_FOUND when no instance matches pid", async () => {
+      const { map } = buildHandlers();
+      await expect(invoke(map, "killServe")({ pid: 99999999 }, ctx)).rejects.toMatchObject({
+        message: "No serve instance with PID 99999999",
+      });
+    });
+
+    test("kills all instances when all=true", async () => {
+      const { map, instances } = buildHandlers();
+      // Use process.pid so instances survive pruneStaleInstances; noopKill prevents actual SIGTERM
+      instances.set("x", { instanceId: "x", pid: process.pid, tools: [], startedAt: Date.now() });
+      instances.set("y", { instanceId: "y", pid: process.pid, tools: [], startedAt: Date.now() });
+      const result = (await invoke(map, "killServe")({ all: true }, ctx)) as { killed: number };
+      expect(result.killed).toBe(2);
+      expect(instances.size).toBe(0);
+    });
+
+    test("staleHours filters by age", async () => {
+      const { map, instances } = buildHandlers();
+      // Use process.pid so instances survive pruneStaleInstances; noopKill prevents actual SIGTERM
+      instances.set("fresh", { instanceId: "fresh", pid: process.pid, tools: [], startedAt: Date.now() });
+      instances.set("stale", { instanceId: "stale", pid: process.pid, tools: [], startedAt: 0 });
+      const result = (await invoke(map, "killServe")({ staleHours: 1 }, ctx)) as { killed: number };
+      expect(result.killed).toBe(1);
+      expect(instances.has("stale")).toBe(false);
+      expect(instances.has("fresh")).toBe(true);
+    });
+
+    test("kills by instanceId and removes from map", async () => {
+      const { map, instances } = buildHandlers();
+      instances.set("target", { instanceId: "target", pid: process.pid, tools: [], startedAt: Date.now() });
+      const result = (await invoke(map, "killServe")({ instanceId: "target" }, ctx)) as { killed: number };
+      expect(result.killed).toBe(1);
+      expect(instances.has("target")).toBe(false);
+    });
+  });
+});

--- a/packages/daemon/src/handlers/serve.ts
+++ b/packages/daemon/src/handlers/serve.ts
@@ -1,0 +1,97 @@
+import {
+  IPC_ERROR,
+  KillServeParamsSchema,
+  RegisterServeParamsSchema,
+  UnregisterServeParamsSchema,
+} from "@mcp-cli/core";
+import type { IpcMethod, Logger, ServeInstanceInfo } from "@mcp-cli/core";
+import type { RequestHandler } from "../handler-types";
+import { killPid } from "../process-util";
+
+export class ServeHandlers {
+  private readonly killPidFn: (pid: number, logger: Logger) => Promise<void>;
+
+  constructor(
+    private readonly serveInstances: Map<string, ServeInstanceInfo>,
+    private readonly logger: Logger,
+    killPidFn?: (pid: number, logger: Logger) => Promise<void>,
+  ) {
+    this.killPidFn = killPidFn ?? killPid;
+  }
+
+  /** Remove serve instances whose PID is no longer alive. */
+  pruneStaleInstances(): void {
+    for (const [id, info] of this.serveInstances) {
+      try {
+        process.kill(info.pid, 0);
+      } catch {
+        this.serveInstances.delete(id);
+      }
+    }
+  }
+
+  register(handlers: Map<IpcMethod, RequestHandler>): void {
+    handlers.set("registerServe", async (params, _ctx) => {
+      const { instanceId, pid, tools } = RegisterServeParamsSchema.parse(params);
+      this.serveInstances.set(instanceId, { instanceId, pid, tools, startedAt: Date.now() });
+      return { ok: true as const };
+    });
+
+    handlers.set("unregisterServe", async (params, _ctx) => {
+      const { instanceId } = UnregisterServeParamsSchema.parse(params);
+      this.serveInstances.delete(instanceId);
+      return { ok: true as const };
+    });
+
+    handlers.set("listServeInstances", async (_params, _ctx) => {
+      this.pruneStaleInstances();
+      return [...this.serveInstances.values()];
+    });
+
+    handlers.set("killServe", async (params, _ctx) => {
+      const { instanceId, pid, all, staleHours } = KillServeParamsSchema.parse(params ?? {});
+
+      if (!instanceId && pid == null && !all && staleHours == null) {
+        throw Object.assign(new Error("Specify instanceId, pid, all, or staleHours"), {
+          code: IPC_ERROR.INVALID_PARAMS,
+        });
+      }
+
+      this.pruneStaleInstances();
+
+      const targets: ServeInstanceInfo[] = [];
+      if (staleHours != null) {
+        const cutoff = Date.now() - staleHours * 60 * 60 * 1000;
+        for (const inst of this.serveInstances.values()) {
+          if (inst.startedAt < cutoff) targets.push(inst);
+        }
+      } else if (all) {
+        targets.push(...this.serveInstances.values());
+      } else if (instanceId) {
+        const inst = this.serveInstances.get(instanceId);
+        if (!inst) {
+          throw Object.assign(new Error(`Serve instance "${instanceId}" not found`), {
+            code: IPC_ERROR.SERVER_NOT_FOUND,
+          });
+        }
+        targets.push(inst);
+      } else if (pid != null) {
+        for (const inst of this.serveInstances.values()) {
+          if (inst.pid === pid) targets.push(inst);
+        }
+        if (targets.length === 0) {
+          throw Object.assign(new Error(`No serve instance with PID ${pid}`), {
+            code: IPC_ERROR.SERVER_NOT_FOUND,
+          });
+        }
+      }
+
+      for (const inst of targets) {
+        await this.killPidFn(inst.pid, this.logger);
+        this.serveInstances.delete(inst.instanceId);
+      }
+
+      return { killed: targets.length };
+    });
+  }
+}

--- a/packages/daemon/src/handlers/status.ts
+++ b/packages/daemon/src/handlers/status.ts
@@ -1,0 +1,53 @@
+import { BUILD_VERSION, PROTOCOL_VERSION } from "@mcp-cli/core";
+import type { IpcMethod, ServeInstanceInfo } from "@mcp-cli/core";
+import { options } from "@mcp-cli/core";
+import type { StateDb } from "../db/state";
+import type { RequestHandler } from "../handler-types";
+import { getPortHolder } from "../port-holder";
+import type { ServerPool } from "../server-pool";
+import type { ServeHandlers } from "./serve";
+
+export class StatusHandler {
+  constructor(
+    private readonly pool: ServerPool,
+    private readonly db: StateDb,
+    private readonly serveHandlers: ServeHandlers,
+    private readonly serveInstances: Map<string, ServeInstanceInfo>,
+    private readonly getWsPortInfo: (() => { actual: number | null; expected: number }) | null,
+  ) {}
+
+  register(handlers: Map<IpcMethod, RequestHandler>): void {
+    handlers.set("status", async (_params, _ctx) => {
+      const servers = this.pool.listServers();
+      const usageStats = this.db.getUsageStats();
+
+      for (const server of servers) {
+        const serverStats = usageStats.filter((s) => s.serverName === server.name);
+        if (serverStats.length > 0) {
+          server.callCount = serverStats.reduce((sum, s) => sum + s.callCount, 0);
+          server.errorCount = serverStats.reduce((sum, s) => sum + s.errorCount, 0);
+          const totalDuration = serverStats.reduce((sum, s) => sum + s.totalDurationMs, 0);
+          server.avgDurationMs = Math.round(totalDuration / server.callCount);
+        }
+      }
+
+      const wsPortInfo = this.getWsPortInfo?.();
+      const hasMismatch = wsPortInfo != null && wsPortInfo.actual != null && wsPortInfo.actual !== wsPortInfo.expected;
+      const wsPortHolder = hasMismatch ? await getPortHolder(wsPortInfo.expected) : null;
+      this.serveHandlers.pruneStaleInstances();
+      return {
+        pid: process.pid,
+        uptime: process.uptime(),
+        protocolVersion: PROTOCOL_VERSION,
+        daemonVersion: BUILD_VERSION,
+        servers,
+        dbPath: options.DB_PATH,
+        usageStats,
+        wsPort: wsPortInfo?.actual ?? null,
+        wsPortExpected: wsPortInfo?.expected,
+        wsPortHolder,
+        serveInstances: [...this.serveInstances.values()],
+      };
+    });
+  }
+}

--- a/packages/daemon/src/handlers/telemetry.spec.ts
+++ b/packages/daemon/src/handlers/telemetry.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import type { IpcMethod } from "@mcp-cli/core";
+import type { RequestHandler } from "../handler-types";
+import { TelemetryHandlers } from "./telemetry";
+
+function invoke(map: Map<IpcMethod, RequestHandler>, method: IpcMethod): RequestHandler {
+  const h = map.get(method);
+  if (!h) throw new Error(`Handler "${method}" not registered`);
+  return h;
+}
+
+function mockDb(overrides: Record<string, unknown> = {}) {
+  return {
+    getSpans: () => [],
+    markSpansExported: () => 0,
+    pruneSpans: () => 0,
+    ...overrides,
+  } as never;
+}
+
+function buildHandlers(db = mockDb()): Map<IpcMethod, RequestHandler> {
+  const map = new Map<IpcMethod, RequestHandler>();
+  new TelemetryHandlers(db).register(map);
+  return map;
+}
+
+describe("TelemetryHandlers", () => {
+  test("getSpans delegates to db", async () => {
+    const spans = [{ traceId: "abc" }];
+    const map = buildHandlers(mockDb({ getSpans: () => spans }));
+    const result = (await invoke(map, "getSpans")(undefined, {} as never)) as { spans: unknown[] };
+    expect(result.spans).toEqual(spans);
+  });
+
+  test("markSpansExported delegates to db", async () => {
+    const map = buildHandlers(mockDb({ markSpansExported: () => 3 }));
+    const result = (await invoke(map, "markSpansExported")({ ids: [1, 2, 3] }, {} as never)) as {
+      marked: number;
+    };
+    expect(result.marked).toBe(3);
+  });
+
+  test("pruneSpans delegates to db", async () => {
+    const map = buildHandlers(mockDb({ pruneSpans: () => 5 }));
+    const result = (await invoke(map, "pruneSpans")({ before: 1000 }, {} as never)) as { pruned: number };
+    expect(result.pruned).toBe(5);
+  });
+
+  test("pruneSpans works with no params", async () => {
+    const map = buildHandlers();
+    const result = (await invoke(map, "pruneSpans")(undefined, {} as never)) as { pruned: number };
+    expect(result.pruned).toBe(0);
+  });
+});

--- a/packages/daemon/src/handlers/telemetry.ts
+++ b/packages/daemon/src/handlers/telemetry.ts
@@ -1,0 +1,24 @@
+import { GetSpansParamsSchema, MarkSpansExportedParamsSchema, PruneSpansParamsSchema } from "@mcp-cli/core";
+import type { IpcMethod } from "@mcp-cli/core";
+import type { StateDb } from "../db/state";
+import type { RequestHandler } from "../handler-types";
+
+export class TelemetryHandlers {
+  constructor(private db: StateDb) {}
+
+  register(handlers: Map<IpcMethod, RequestHandler>): void {
+    handlers.set("getSpans", async (params) => {
+      const { since, limit, unexported } = GetSpansParamsSchema.parse(params ?? {});
+      return { spans: this.db.getSpans({ since, limit, unexported }) };
+    });
+    handlers.set("markSpansExported", async (params) => {
+      const { ids } = MarkSpansExportedParamsSchema.parse(params);
+      const marked = this.db.markSpansExported(ids);
+      return { marked };
+    });
+    handlers.set("pruneSpans", async (params) => {
+      const { before } = PruneSpansParamsSchema.parse(params ?? {});
+      return { pruned: this.db.pruneSpans(before) };
+    });
+  }
+}

--- a/packages/daemon/src/handlers/tool.spec.ts
+++ b/packages/daemon/src/handlers/tool.spec.ts
@@ -67,7 +67,7 @@ function buildHandlers(
   aliasServer = mockAliasServer(),
 ): Map<IpcMethod, RequestHandler> {
   const map = new Map<IpcMethod, RequestHandler>();
-  new ToolHandlers(pool, db, aliasServer, "daemon-1", mockLogger).register(map);
+  new ToolHandlers(pool, db, aliasServer, "daemon-1").register(map);
   return map;
 }
 

--- a/packages/daemon/src/handlers/tool.spec.ts
+++ b/packages/daemon/src/handlers/tool.spec.ts
@@ -1,0 +1,211 @@
+import { describe, expect, test } from "bun:test";
+import type { IpcMethod } from "@mcp-cli/core";
+import type { RequestHandler } from "../handler-types";
+import { ToolHandlers } from "./tool";
+
+function invoke(map: Map<IpcMethod, RequestHandler>, method: IpcMethod): RequestHandler {
+  const h = map.get(method);
+  if (!h) throw new Error(`Handler "${method}" not registered`);
+  return h;
+}
+
+function mockPool(overrides: Record<string, unknown> = {}) {
+  return {
+    listServers: () => [],
+    getServerUrl: () => null,
+    getDb: () => null,
+    getServerConfig: () => null,
+    getCachedTools: () => [],
+    callTool: async () => ({ content: [] }),
+    listTools: async () => [],
+    getToolInfo: async (server: string, tool: string) => ({ server, name: tool, description: "", inputSchema: {} }),
+    grepTools: async () => [],
+    restart: async () => {},
+    ...overrides,
+  } as never;
+}
+
+function mockDb(overrides: Record<string, unknown> = {}) {
+  return {
+    getNote: () => null,
+    listNotes: () => [],
+    recordUsage: () => {},
+    recordSpan: () => {},
+    ...overrides,
+  } as never;
+}
+
+function mockAliasServer(overrides: Record<string, unknown> = {}) {
+  return {
+    callToolWithChain: async () => ({ content: [] }),
+    ...overrides,
+  } as never;
+}
+
+const mockLogger = {
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  debug: () => {},
+} as never;
+
+function mockCtx() {
+  return {
+    span: {
+      child: () => ({
+        setAttribute: () => {},
+        setStatus: () => {},
+        end: () => ({ durationMs: 10, traceId: "abc", parentSpanId: null }),
+      }),
+    },
+  } as never;
+}
+
+function buildHandlers(
+  pool = mockPool(),
+  db = mockDb(),
+  aliasServer = mockAliasServer(),
+): Map<IpcMethod, RequestHandler> {
+  const map = new Map<IpcMethod, RequestHandler>();
+  new ToolHandlers(pool, db, aliasServer, "daemon-1", mockLogger).register(map);
+  return map;
+}
+
+describe("ToolHandlers – listTools", () => {
+  test("delegates to pool.listTools", async () => {
+    const tools = [{ server: "s1", name: "search", description: "search it", inputSchema: {} }];
+    const map = buildHandlers(mockPool({ listTools: async () => tools }));
+    const result = await invoke(map, "listTools")(undefined, {} as never);
+    expect(result).toEqual(tools);
+  });
+
+  test("passes server filter to pool", async () => {
+    let receivedServer: unknown;
+    const map = buildHandlers(
+      mockPool({
+        listTools: async (server: unknown) => {
+          receivedServer = server;
+          return [];
+        },
+      }),
+    );
+    await invoke(map, "listTools")({ server: "myserver" }, {} as never);
+    expect(receivedServer).toBe("myserver");
+  });
+});
+
+describe("ToolHandlers – getToolInfo", () => {
+  test("returns tool info without note when db has no note", async () => {
+    const info = { server: "s1", name: "search", description: "search it", inputSchema: {} };
+    const map = buildHandlers(mockPool({ getToolInfo: async () => info }), mockDb({ getNote: () => null }));
+    const result = await invoke(map, "getToolInfo")({ server: "s1", tool: "search" }, {} as never);
+    expect(result).toEqual(info);
+  });
+
+  test("enriches result with note from db", async () => {
+    const info = { server: "s1", name: "search", description: "search it", inputSchema: {} };
+    const map = buildHandlers(mockPool({ getToolInfo: async () => info }), mockDb({ getNote: () => "my note" }));
+    const result = (await invoke(map, "getToolInfo")({ server: "s1", tool: "search" }, {} as never)) as {
+      note?: string;
+    };
+    expect(result.note).toBe("my note");
+  });
+});
+
+describe("ToolHandlers – grepTools", () => {
+  test("returns matched tools enriched with notes from db", async () => {
+    const tools = [{ server: "s1", name: "search", description: "search it", inputSchema: {} }];
+    const notes = [{ serverName: "s1", toolName: "search", note: "useful" }];
+    const map = buildHandlers(
+      mockPool({ grepTools: async () => tools }),
+      mockDb({ listNotes: () => notes, getNote: () => null }),
+    );
+    const result = (await invoke(map, "grepTools")({ pattern: "search" }, {} as never)) as { note?: string }[];
+    expect(result[0].note).toBe("useful");
+  });
+
+  test("returns empty array when no tools match", async () => {
+    const map = buildHandlers(mockPool({ grepTools: async () => [] }));
+    const result = (await invoke(map, "grepTools")({ pattern: "nomatch" }, {} as never)) as unknown[];
+    expect(result).toHaveLength(0);
+  });
+
+  test("note-matched tools are fetched and included in results", async () => {
+    const notes = [{ serverName: "s2", toolName: "deploy", note: "deploys to prod" }];
+    const extraInfo = { server: "s2", name: "deploy", description: "", inputSchema: {} };
+    const map = buildHandlers(
+      mockPool({
+        grepTools: async () => [],
+        getToolInfo: async () => extraInfo,
+      }),
+      mockDb({ listNotes: () => notes, getNote: () => null }),
+    );
+    const result = (await invoke(map, "grepTools")({ pattern: "prod" }, {} as never)) as {
+      name: string;
+      note: string;
+    }[];
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("deploy");
+    expect(result[0].note).toBe("deploys to prod");
+  });
+});
+
+describe("ToolHandlers – callTool", () => {
+  test("records usage on success", async () => {
+    let usageRecorded = false;
+    const map = buildHandlers(
+      mockPool({ callTool: async () => ({ content: [{ type: "text", text: "ok" }] }) }),
+      mockDb({
+        recordUsage: () => {
+          usageRecorded = true;
+        },
+        recordSpan: () => {},
+      }),
+    );
+    const result = (await invoke(map, "callTool")(
+      { server: "s1", tool: "search", arguments: { q: "test" } },
+      mockCtx(),
+    )) as { content: unknown[] };
+    expect(result.content).toHaveLength(1);
+    expect(usageRecorded).toBe(true);
+  });
+
+  test("records usage and rethrows on failure", async () => {
+    let usageRecorded = false;
+    const map = buildHandlers(
+      mockPool({
+        callTool: async () => {
+          throw new Error("tool failed");
+        },
+      }),
+      mockDb({
+        recordUsage: () => {
+          usageRecorded = true;
+        },
+        recordSpan: () => {},
+      }),
+    );
+    const err = await invoke(map, "callTool")({ server: "s1", tool: "search", arguments: {} }, mockCtx()).catch(
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toBe("tool failed");
+    expect(usageRecorded).toBe(true);
+  });
+});
+
+describe("ToolHandlers – restartServer", () => {
+  test("calls pool.restart and returns ok", async () => {
+    let restartedServer: string | undefined;
+    const map = buildHandlers(
+      mockPool({
+        restart: async (server: string) => {
+          restartedServer = server;
+        },
+      }),
+    );
+    const result = (await invoke(map, "restartServer")({ server: "s1" }, {} as never)) as { ok: boolean };
+    expect(result.ok).toBe(true);
+    expect(restartedServer).toBe("s1");
+  });
+});

--- a/packages/daemon/src/handlers/tool.ts
+++ b/packages/daemon/src/handlers/tool.ts
@@ -6,7 +6,7 @@ import {
   ListToolsParamsSchema,
   RestartServerParamsSchema,
 } from "@mcp-cli/core";
-import type { IpcMethod, Logger } from "@mcp-cli/core";
+import type { IpcMethod } from "@mcp-cli/core";
 import type { AliasServer } from "../alias-server";
 import type { StateDb } from "../db/state";
 import type { RequestHandler } from "../handler-types";
@@ -19,7 +19,6 @@ export class ToolHandlers {
     private db: StateDb,
     private aliasServer: AliasServer | null,
     private daemonId: string,
-    private logger: Logger,
   ) {}
 
   register(handlers: Map<IpcMethod, RequestHandler>): void {

--- a/packages/daemon/src/handlers/tool.ts
+++ b/packages/daemon/src/handlers/tool.ts
@@ -1,0 +1,131 @@
+import {
+  ALIAS_SERVER_NAME,
+  CallToolParamsSchema,
+  GetToolInfoParamsSchema,
+  GrepToolsParamsSchema,
+  ListToolsParamsSchema,
+  RestartServerParamsSchema,
+} from "@mcp-cli/core";
+import type { IpcMethod, Logger } from "@mcp-cli/core";
+import type { AliasServer } from "../alias-server";
+import type { StateDb } from "../db/state";
+import type { RequestHandler } from "../handler-types";
+import { metrics } from "../metrics";
+import type { ServerPool } from "../server-pool";
+
+export class ToolHandlers {
+  constructor(
+    private pool: ServerPool,
+    private db: StateDb,
+    private aliasServer: AliasServer | null,
+    private daemonId: string,
+    private logger: Logger,
+  ) {}
+
+  register(handlers: Map<IpcMethod, RequestHandler>): void {
+    handlers.set("listTools", async (params, _ctx) => {
+      const { server } = ListToolsParamsSchema.parse(params ?? {});
+      return this.pool.listTools(server);
+    });
+
+    handlers.set("getToolInfo", async (params, _ctx) => {
+      const { server, tool } = GetToolInfoParamsSchema.parse(params);
+      const info = await this.pool.getToolInfo(server, tool);
+      const note = this.db.getNote(server, tool);
+      return note ? { ...info, note } : info;
+    });
+
+    handlers.set("grepTools", async (params, _ctx) => {
+      const { pattern } = GrepToolsParamsSchema.parse(params);
+      const tools = await this.pool.grepTools(pattern);
+
+      // Enrich matched tools with notes and check if any notes match the pattern
+      const allNotes = this.db.listNotes();
+      const noteMap = new Map(allNotes.map((n) => [`${n.serverName}\0${n.toolName}`, n.note]));
+
+      // Add notes to already-matched tools
+      const enriched = tools.map((t) => {
+        const note = noteMap.get(`${t.server}\0${t.name}`);
+        return note ? { ...t, note } : t;
+      });
+
+      // Find tools that match via note content but weren't already matched
+      const matchedKeys = new Set(tools.map((t) => `${t.server}\0${t.name}`));
+      const regex = new RegExp(
+        pattern
+          .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+          .replace(/\*/g, ".*")
+          .replace(/\?/g, "."),
+        "i",
+      );
+      const noteMatches = allNotes.filter(
+        (n) => !matchedKeys.has(`${n.serverName}\0${n.toolName}`) && regex.test(n.note),
+      );
+
+      // For note-matched tools, fetch their full ToolInfo
+      for (const n of noteMatches) {
+        try {
+          const info = await this.pool.getToolInfo(n.serverName, n.toolName);
+          enriched.push({ ...info, note: n.note });
+        } catch {
+          // Tool no longer exists — skip
+        }
+      }
+
+      return enriched;
+    });
+
+    handlers.set("callTool", async (params, ctx) => {
+      const { server, tool, arguments: args, timeoutMs, callChain, cwd } = CallToolParamsSchema.parse(params);
+      const toolSpan = ctx.span.child(`tool.${server}.${tool}`);
+      toolSpan.setAttribute("tool.server", server);
+      toolSpan.setAttribute("tool.name", tool);
+      if (callChain) toolSpan.setAttribute("alias.callChainDepth", callChain.length);
+      const toolLabels = { server, tool };
+      try {
+        // Route every _aliases call through the alias server directly so the
+        // caller's cwd (for repo-root scoping) and optional callChain reach
+        // the executor subprocess. The pool route has no cwd channel.
+        const result =
+          server === ALIAS_SERVER_NAME && this.aliasServer
+            ? await this.aliasServer.callToolWithChain(tool, args, callChain ?? [], cwd, timeoutMs)
+            : await this.pool.callTool(server, tool, args, timeoutMs);
+        toolSpan.setStatus("OK");
+        const finished = toolSpan.end();
+        // Dual-write: usage_stats (Phase 1 compat) + spans table
+        this.db.recordUsage(server, tool, finished.durationMs, true, undefined, {
+          daemonId: this.daemonId,
+          traceId: finished.traceId,
+          parentId: finished.parentSpanId,
+        });
+        this.db.recordSpan(finished, this.daemonId);
+        metrics.counter("mcpd_tool_calls_total", toolLabels).inc();
+        metrics.histogram("mcpd_tool_call_duration_ms", toolLabels).observe(finished.durationMs);
+        return result;
+      } catch (err) {
+        toolSpan.setStatus("ERROR");
+        toolSpan.setAttribute("error.message", err instanceof Error ? err.message : String(err));
+        const finished = toolSpan.end();
+        this.db.recordUsage(
+          server,
+          tool,
+          finished.durationMs,
+          false,
+          err instanceof Error ? err.message : String(err),
+          { daemonId: this.daemonId, traceId: finished.traceId, parentId: finished.parentSpanId },
+        );
+        this.db.recordSpan(finished, this.daemonId);
+        metrics.counter("mcpd_tool_calls_total", toolLabels).inc();
+        metrics.counter("mcpd_tool_errors_total", toolLabels).inc();
+        metrics.histogram("mcpd_tool_call_duration_ms", toolLabels).observe(finished.durationMs);
+        throw err;
+      }
+    });
+
+    handlers.set("restartServer", async (params, _ctx) => {
+      const { server } = RestartServerParamsSchema.parse(params ?? {});
+      await this.pool.restart(server);
+      return { ok: true };
+    });
+  }
+}

--- a/packages/daemon/src/handlers/work-item.spec.ts
+++ b/packages/daemon/src/handlers/work-item.spec.ts
@@ -1,0 +1,278 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import type { IpcMethod } from "@mcp-cli/core";
+import { WorkItemDb } from "../db/work-items";
+import type { RequestHandler } from "../handler-types";
+import { WorkItemHandlers } from "./work-item";
+
+function invoke(map: Map<IpcMethod, RequestHandler>, method: IpcMethod): RequestHandler {
+  const h = map.get(method);
+  if (!h) throw new Error(`Handler "${method}" not registered`);
+  return h;
+}
+
+function noopLogger() {
+  return {
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+    debug: () => {},
+  };
+}
+
+/** Minimal in-memory mock of the StateDb alias state methods. */
+function makeAliasStateDb() {
+  const store = new Map<string, unknown>();
+  const key = (root: string, ns: string, k: string) => `${root}\0${ns}\0${k}`;
+  return {
+    getAliasState(root: string, ns: string, k: string): unknown {
+      return store.get(key(root, ns, k));
+    },
+    setAliasState(root: string, ns: string, k: string, v: unknown): void {
+      store.set(key(root, ns, k), v);
+    },
+    deleteAliasState(root: string, ns: string, k: string): boolean {
+      const existed = store.has(key(root, ns, k));
+      store.delete(key(root, ns, k));
+      return existed;
+    },
+    listAliasState(root: string, ns: string): Record<string, unknown> {
+      const prefix = `${root}\0${ns}\0`;
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of store) {
+        if (k.startsWith(prefix)) {
+          out[k.slice(prefix.length)] = v;
+        }
+      }
+      return out;
+    },
+  };
+}
+
+function buildHandlers() {
+  const sqliteDb = new Database(":memory:");
+  const workItemDb = new WorkItemDb(sqliteDb);
+  const aliasDb = makeAliasStateDb();
+  const map = new Map<IpcMethod, RequestHandler>();
+  new WorkItemHandlers(workItemDb, aliasDb as never, null, null, noopLogger() as never).register(map);
+  return { map, workItemDb, aliasDb };
+}
+
+const ctx = {} as never;
+
+describe("WorkItemHandlers", () => {
+  describe("trackWorkItem", () => {
+    test("creates work item by issue number", async () => {
+      const { map } = buildHandlers();
+      const result = (await invoke(map, "trackWorkItem")({ number: 42 }, ctx)) as { id: string; issueNumber: number };
+      expect(result.id).toBe("#42");
+      expect(result.issueNumber).toBe(42);
+    });
+
+    test("creates work item by branch", async () => {
+      const { map } = buildHandlers();
+      const result = (await invoke(map, "trackWorkItem")({ branch: "feat/my-feature" }, ctx)) as {
+        id: string;
+        branch: string;
+      };
+      expect(result.id).toBe("branch:feat/my-feature");
+      expect(result.branch).toBe("feat/my-feature");
+    });
+
+    test("returns existing item when issue already tracked", async () => {
+      const { map } = buildHandlers();
+      const r1 = (await invoke(map, "trackWorkItem")({ number: 10 }, ctx)) as { id: string };
+      const r2 = (await invoke(map, "trackWorkItem")({ number: 10 }, ctx)) as { id: string };
+      expect(r1.id).toBe(r2.id);
+    });
+
+    test("returns existing item when branch already tracked", async () => {
+      const { map } = buildHandlers();
+      const r1 = (await invoke(map, "trackWorkItem")({ branch: "fix/bug" }, ctx)) as { id: string };
+      const r2 = (await invoke(map, "trackWorkItem")({ branch: "fix/bug" }, ctx)) as { id: string };
+      expect(r1.id).toBe(r2.id);
+    });
+
+    test("respects initialPhase when provided", async () => {
+      const { map } = buildHandlers();
+      const result = (await invoke(map, "trackWorkItem")({ number: 5, initialPhase: "review" }, ctx)) as {
+        phase: string;
+      };
+      expect(result.phase).toBe("review");
+    });
+
+    test("validates initialPhase against manifest when loadManifestFn provided", async () => {
+      const sqliteDb = new Database(":memory:");
+      const workItemDb = new WorkItemDb(sqliteDb);
+      const map = new Map<IpcMethod, RequestHandler>();
+      new WorkItemHandlers(
+        workItemDb,
+        makeAliasStateDb() as never,
+        null,
+        (_root: string) => ({ phases: { impl: {}, review: {} } }) as never,
+        noopLogger() as never,
+      ).register(map);
+      await expect(
+        invoke(map, "trackWorkItem")({ number: 1, initialPhase: "unknown-phase", repoRoot: "/repo" }, ctx),
+      ).rejects.toThrow(/unknown initialPhase/);
+    });
+  });
+
+  describe("untrackWorkItem", () => {
+    test("deletes by issue number", async () => {
+      const { map } = buildHandlers();
+      await invoke(map, "trackWorkItem")({ number: 7 }, ctx);
+      const result = (await invoke(map, "untrackWorkItem")({ number: 7 }, ctx)) as { ok: boolean; deleted: boolean };
+      expect(result.ok).toBe(true);
+      expect(result.deleted).toBe(true);
+    });
+
+    test("returns deleted=false when not found by number", async () => {
+      const { map } = buildHandlers();
+      const result = (await invoke(map, "untrackWorkItem")({ number: 99 }, ctx)) as { ok: boolean; deleted: boolean };
+      expect(result.ok).toBe(true);
+      expect(result.deleted).toBe(false);
+    });
+
+    test("deletes by branch", async () => {
+      const { map } = buildHandlers();
+      await invoke(map, "trackWorkItem")({ branch: "my-branch" }, ctx);
+      const result = (await invoke(map, "untrackWorkItem")({ branch: "my-branch" }, ctx)) as {
+        ok: boolean;
+        deleted: boolean;
+      };
+      expect(result.ok).toBe(true);
+      expect(result.deleted).toBe(true);
+    });
+
+    test("returns deleted=false when branch not found", async () => {
+      const { map } = buildHandlers();
+      const result = (await invoke(map, "untrackWorkItem")({ branch: "no-such-branch" }, ctx)) as {
+        ok: boolean;
+        deleted: boolean;
+      };
+      expect(result.ok).toBe(true);
+      expect(result.deleted).toBe(false);
+    });
+  });
+
+  describe("listWorkItems", () => {
+    test("returns all tracked items", async () => {
+      const { map } = buildHandlers();
+      await invoke(map, "trackWorkItem")({ number: 1 }, ctx);
+      await invoke(map, "trackWorkItem")({ number: 2 }, ctx);
+      const result = (await invoke(map, "listWorkItems")(undefined, ctx)) as Array<{ id: string }>;
+      expect(result.length).toBe(2);
+    });
+
+    test("filters by phase", async () => {
+      const { map } = buildHandlers();
+      await invoke(map, "trackWorkItem")({ number: 1, initialPhase: "impl" }, ctx);
+      await invoke(map, "trackWorkItem")({ number: 2, initialPhase: "review" }, ctx);
+      const result = (await invoke(map, "listWorkItems")({ phase: "review" }, ctx)) as Array<{ phase: string }>;
+      expect(result.length).toBe(1);
+      expect(result[0].phase).toBe("review");
+    });
+
+    test("returns empty array when no items", async () => {
+      const { map } = buildHandlers();
+      const result = (await invoke(map, "listWorkItems")(undefined, ctx)) as unknown[];
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getWorkItem", () => {
+    test("returns item by id", async () => {
+      const { map } = buildHandlers();
+      await invoke(map, "trackWorkItem")({ number: 3 }, ctx);
+      const result = (await invoke(map, "getWorkItem")({ id: "#3" }, ctx)) as { id: string } | null;
+      expect(result?.id).toBe("#3");
+    });
+
+    test("returns item by issue number", async () => {
+      const { map } = buildHandlers();
+      await invoke(map, "trackWorkItem")({ number: 4 }, ctx);
+      const result = (await invoke(map, "getWorkItem")({ number: 4 }, ctx)) as { issueNumber: number } | null;
+      expect(result?.issueNumber).toBe(4);
+    });
+
+    test("returns item by branch", async () => {
+      const { map } = buildHandlers();
+      await invoke(map, "trackWorkItem")({ branch: "some-branch" }, ctx);
+      const result = (await invoke(map, "getWorkItem")({ branch: "some-branch" }, ctx)) as { branch: string } | null;
+      expect(result?.branch).toBe("some-branch");
+    });
+
+    test("returns null when not found", async () => {
+      const { map } = buildHandlers();
+      const result = await invoke(map, "getWorkItem")({ id: "#999" }, ctx);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("aliasStateGet / aliasStateSet / aliasStateDelete / aliasStateAll", () => {
+    const repoRoot = "/tmp/test-repo";
+    const namespace = "my-alias";
+
+    test("set then get returns value", async () => {
+      const { map } = buildHandlers();
+      await invoke(map, "aliasStateSet")({ repoRoot, namespace, key: "k1", value: { x: 1 } }, ctx);
+      const result = (await invoke(map, "aliasStateGet")({ repoRoot, namespace, key: "k1" }, ctx)) as {
+        value: unknown;
+      };
+      expect(result.value).toEqual({ x: 1 });
+    });
+
+    test("get returns undefined for missing key", async () => {
+      const { map } = buildHandlers();
+      const result = (await invoke(map, "aliasStateGet")({ repoRoot, namespace, key: "missing" }, ctx)) as {
+        value: unknown;
+      };
+      expect(result.value).toBeUndefined();
+    });
+
+    test("delete removes key and returns deleted=true", async () => {
+      const { map } = buildHandlers();
+      await invoke(map, "aliasStateSet")({ repoRoot, namespace, key: "toDelete", value: 42 }, ctx);
+      const del = (await invoke(map, "aliasStateDelete")({ repoRoot, namespace, key: "toDelete" }, ctx)) as {
+        ok: boolean;
+        deleted: boolean;
+      };
+      expect(del.ok).toBe(true);
+      expect(del.deleted).toBe(true);
+      const get = (await invoke(map, "aliasStateGet")({ repoRoot, namespace, key: "toDelete" }, ctx)) as {
+        value: unknown;
+      };
+      expect(get.value).toBeUndefined();
+    });
+
+    test("delete returns deleted=false when key not present", async () => {
+      const { map } = buildHandlers();
+      const result = (await invoke(map, "aliasStateDelete")({ repoRoot, namespace, key: "nope" }, ctx)) as {
+        ok: boolean;
+        deleted: boolean;
+      };
+      expect(result.ok).toBe(true);
+      expect(result.deleted).toBe(false);
+    });
+
+    test("aliasStateAll returns all entries for namespace", async () => {
+      const { map } = buildHandlers();
+      await invoke(map, "aliasStateSet")({ repoRoot, namespace, key: "a", value: 1 }, ctx);
+      await invoke(map, "aliasStateSet")({ repoRoot, namespace, key: "b", value: 2 }, ctx);
+      await invoke(map, "aliasStateSet")({ repoRoot, namespace: "other", key: "a", value: 99 }, ctx);
+      const result = (await invoke(map, "aliasStateAll")({ repoRoot, namespace }, ctx)) as {
+        entries: Record<string, unknown>;
+      };
+      expect(result.entries).toEqual({ a: 1, b: 2 });
+    });
+
+    test("aliasStateAll returns empty object when no entries", async () => {
+      const { map } = buildHandlers();
+      const result = (await invoke(map, "aliasStateAll")({ repoRoot, namespace: "empty" }, ctx)) as {
+        entries: Record<string, unknown>;
+      };
+      expect(result.entries).toEqual({});
+    });
+  });
+});

--- a/packages/daemon/src/handlers/work-item.ts
+++ b/packages/daemon/src/handlers/work-item.ts
@@ -1,0 +1,178 @@
+import { resolve } from "node:path";
+import {
+  AliasStateAllParamsSchema,
+  AliasStateDeleteParamsSchema,
+  AliasStateGetParamsSchema,
+  AliasStateSetParamsSchema,
+  GetWorkItemParamsSchema,
+  IPC_ERROR,
+  ListWorkItemsParamsSchema,
+  TrackWorkItemParamsSchema,
+  UntrackWorkItemParamsSchema,
+  resolveRealpath,
+} from "@mcp-cli/core";
+import type { IpcMethod, Logger, Manifest, WorkItemPhase } from "@mcp-cli/core";
+import type { StateDb } from "../db/state";
+import type { WorkItemDb } from "../db/work-items";
+import type { RequestHandler } from "../handler-types";
+
+export class WorkItemHandlers {
+  constructor(
+    private readonly workItemDb: WorkItemDb,
+    private readonly db: StateDb,
+    private readonly resolveIssuePr: ((number: number) => Promise<{ prNumber: number | null }>) | null,
+    private readonly loadManifestFn: ((repoRoot: string) => Manifest | null) | null,
+    private readonly logger: Logger,
+  ) {}
+
+  /**
+   * Fire-and-forget: resolve PR number via GitHub API and update the work item.
+   * Handles UNIQUE constraint collisions by merging with an existing item that
+   * already tracks the same PR number.
+   */
+  private resolveAndUpdateWorkItem(itemId: string, issueNumber: number): void {
+    if (!this.resolveIssuePr) return;
+    this.resolveIssuePr(issueNumber)
+      .then((resolved) => {
+        if (!resolved.prNumber) return;
+
+        // Check for UNIQUE constraint: another item may already track this PR
+        const existingByPr = this.workItemDb.getWorkItemByPr(resolved.prNumber);
+        if (existingByPr && existingByPr.id !== itemId) {
+          this.logger.info(
+            `[mcpd] PR #${resolved.prNumber} already tracked by ${existingByPr.id}, skipping update for ${itemId}`,
+          );
+          return;
+        }
+
+        this.workItemDb.updateWorkItem(itemId, { prNumber: resolved.prNumber });
+        this.logger.info(`[mcpd] Resolved #${issueNumber} → PR #${resolved.prNumber}`);
+      })
+      .catch((err) => {
+        this.logger.warn(
+          `[mcpd] Failed to resolve PR for #${issueNumber}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+  }
+
+  register(handlers: Map<IpcMethod, RequestHandler>): void {
+    handlers.set("trackWorkItem", async (params, _ctx) => {
+      const { number, branch, initialPhase, repoRoot } = TrackWorkItemParamsSchema.parse(params);
+
+      // Validate initialPhase server-side when a manifest is available (#1351).
+      // When no manifest is present (repoRoot absent or manifest missing), accept any string.
+      if (initialPhase && repoRoot && this.loadManifestFn) {
+        const manifest = this.loadManifestFn(repoRoot);
+        if (manifest) {
+          const declared = Object.keys(manifest.phases);
+          if (!declared.includes(initialPhase)) {
+            throw Object.assign(
+              new Error(`unknown initialPhase "${initialPhase}". declared phases: ${declared.join(", ")}.`),
+              { code: IPC_ERROR.INVALID_PARAMS },
+            );
+          }
+        }
+      }
+
+      // Check if already tracked
+      if (number) {
+        const existing = this.workItemDb.getWorkItemByIssue(number) ?? this.workItemDb.getWorkItem(`#${number}`);
+        if (existing) {
+          // Backfill: if prNumber is null, kick off background re-resolution
+          if (existing.prNumber === null && this.resolveIssuePr) {
+            this.resolveAndUpdateWorkItem(existing.id, number);
+          }
+          return existing;
+        }
+      } else if (branch) {
+        const existing = this.workItemDb.getWorkItemByBranch(branch);
+        if (existing) return existing;
+      }
+
+      // Create the item immediately (non-blocking) so the caller isn't waiting on GitHub
+      const id = number ? `#${number}` : `branch:${branch}`;
+      const item = this.workItemDb.createWorkItem({
+        id,
+        issueNumber: number ?? null,
+        prNumber: null,
+        branch: branch ?? null,
+        ...(initialPhase ? { phase: initialPhase as WorkItemPhase } : {}),
+      });
+
+      // Fire-and-forget: resolve PR number in the background
+      if (number && this.resolveIssuePr) {
+        this.resolveAndUpdateWorkItem(id, number);
+      }
+
+      return item;
+    });
+
+    handlers.set("untrackWorkItem", async (params, _ctx) => {
+      const { number, branch } = UntrackWorkItemParamsSchema.parse(params);
+
+      if (branch) {
+        const existing = this.workItemDb.getWorkItemByBranch(branch) ?? this.workItemDb.getWorkItem(`branch:${branch}`);
+        if (existing) {
+          this.workItemDb.deleteWorkItem(existing.id);
+          return { ok: true as const, deleted: true };
+        }
+        return { ok: true as const, deleted: false };
+      }
+
+      // Number-based lookup (number is guaranteed non-null when branch is absent per schema refine)
+      const num = number as number;
+      const existing =
+        this.workItemDb.getWorkItemByPr(num) ??
+        this.workItemDb.getWorkItemByIssue(num) ??
+        this.workItemDb.getWorkItem(`#${num}`);
+      if (existing) {
+        this.workItemDb.deleteWorkItem(existing.id);
+        return { ok: true as const, deleted: true };
+      }
+      return { ok: true as const, deleted: false };
+    });
+
+    handlers.set("listWorkItems", async (params, _ctx) => {
+      const { phase } = ListWorkItemsParamsSchema.parse(params ?? {});
+      return this.workItemDb.listWorkItems(phase ? { phase } : undefined);
+    });
+
+    handlers.set("getWorkItem", async (params, _ctx) => {
+      const { id, number, branch } = GetWorkItemParamsSchema.parse(params);
+      if (id) return this.workItemDb.getWorkItem(id);
+      if (number !== undefined) {
+        return this.workItemDb.getWorkItemByPr(number) ?? this.workItemDb.getWorkItemByIssue(number);
+      }
+      if (branch) return this.workItemDb.getWorkItemByBranch(branch);
+      return null;
+    });
+
+    // -- Alias state (per-work-item / per-alias scratchpad) --
+
+    handlers.set("aliasStateGet", async (params, _ctx) => {
+      const parsed = AliasStateGetParamsSchema.parse(params);
+      const repoRoot = resolveRealpath(resolve(parsed.repoRoot));
+      return { value: this.db.getAliasState(repoRoot, parsed.namespace, parsed.key) };
+    });
+
+    handlers.set("aliasStateSet", async (params, _ctx) => {
+      const parsed = AliasStateSetParamsSchema.parse(params);
+      const repoRoot = resolveRealpath(resolve(parsed.repoRoot));
+      this.db.setAliasState(repoRoot, parsed.namespace, parsed.key, parsed.value);
+      return { ok: true as const };
+    });
+
+    handlers.set("aliasStateDelete", async (params, _ctx) => {
+      const parsed = AliasStateDeleteParamsSchema.parse(params);
+      const repoRoot = resolveRealpath(resolve(parsed.repoRoot));
+      const deleted = this.db.deleteAliasState(repoRoot, parsed.namespace, parsed.key);
+      return { ok: true as const, deleted };
+    });
+
+    handlers.set("aliasStateAll", async (params, _ctx) => {
+      const parsed = AliasStateAllParamsSchema.parse(params);
+      const repoRoot = resolveRealpath(resolve(parsed.repoRoot));
+      return { entries: this.db.listAliasState(repoRoot, parsed.namespace) };
+    });
+  }
+}

--- a/packages/daemon/src/handlers/work-item.ts
+++ b/packages/daemon/src/handlers/work-item.ts
@@ -27,8 +27,8 @@ export class WorkItemHandlers {
 
   /**
    * Fire-and-forget: resolve PR number via GitHub API and update the work item.
-   * Handles UNIQUE constraint collisions by merging with an existing item that
-   * already tracks the same PR number.
+   * Handles UNIQUE constraint collisions by skipping if an item already
+   * tracks the same PR number.
    */
   private resolveAndUpdateWorkItem(itemId: string, issueNumber: number): void {
     if (!this.resolveIssuePr) return;

--- a/packages/daemon/src/ipc-filter.ts
+++ b/packages/daemon/src/ipc-filter.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared event-filter logic used by the IPC server's streaming endpoints.
+ * Extracted from ipc-server.ts to break the event-stream ↔ ipc-server circular dependency.
+ */
+
+import { type EventFilterSpec, type MonitorEvent, createEventMatcher } from "@mcp-cli/core";
+
+/**
+ * Build a server-side predicate from GET /events query params.
+ * Returns null if no filters are specified (pass-through).
+ *
+ * Uses createEventMatcher() from core for the shared EventFilterSpec semantics.
+ * Heartbeats always pass through (server-side keepalive behaviour).
+ */
+export function buildEventFilter(params: URLSearchParams): ((event: Record<string, unknown>) => boolean) | null {
+  const subscribeRaw = params.get("subscribe");
+  const session = params.get("session");
+  const prRaw = params.get("pr");
+  const workItem = params.get("workItem");
+  const typeRaw = params.get("type");
+  const srcRaw = params.get("src");
+  const phase = params.get("phase");
+
+  if (!subscribeRaw && !session && prRaw === null && !workItem && !typeRaw && !srcRaw && !phase) {
+    return null;
+  }
+
+  const prNumber = prRaw !== null ? Number(prRaw) : null;
+  if (prNumber !== null && !(Number.isInteger(prNumber) && prNumber >= 1)) {
+    return () => false;
+  }
+
+  const spec: EventFilterSpec = {
+    ...(subscribeRaw
+      ? {
+          subscribe: subscribeRaw
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean) as EventFilterSpec["subscribe"],
+        }
+      : {}),
+    ...(session ? { session } : {}),
+    ...(prNumber !== null ? { pr: prNumber } : {}),
+    ...(workItem ? { workItem } : {}),
+    ...(typeRaw
+      ? {
+          type: typeRaw
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean),
+        }
+      : {}),
+    ...(srcRaw ? { src: srcRaw } : {}),
+    ...(phase ? { phase } : {}),
+  };
+
+  const matcher = createEventMatcher(spec);
+
+  return (event: Record<string, unknown>): boolean => {
+    // Heartbeats always pass through — server-side keepalive, not a data filter concern
+    if (event.category === "heartbeat" || event.event === "heartbeat") return true;
+    return matcher(event as MonitorEvent);
+  };
+}

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -3595,6 +3595,7 @@ describe("IpcServer HTTP transport", () => {
       Object.defineProperty(IpcServer, "HEARTBEAT_INTERVAL_MS", {
         value: origInterval ?? 30_000,
         configurable: true,
+        writable: true,
       });
     }
   });

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -2,10 +2,10 @@
  * HTTP-over-Unix-socket IPC server.
  *
  * Listens on ~/.mcp-cli/mcpd.sock for JSON requests from the `mcx` CLI.
+ * Handler logic lives in per-domain modules under ./handlers/.
  */
 
-import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { unlinkSync } from "node:fs";
 import type {
   IpcError,
   IpcMethod,
@@ -17,149 +17,45 @@ import type {
   Manifest,
   ResolvedConfig,
   ServeInstanceInfo,
-  ServerAuthStatus,
-  ToolInfo,
-  WorkItemPhase,
 } from "@mcp-cli/core";
 import {
-  ALIAS_SERVER_NAME,
-  AliasStateAllParamsSchema,
-  AliasStateDeleteParamsSchema,
-  AliasStateGetParamsSchema,
-  AliasStateSetParamsSchema,
-  AuthStatusParamsSchema,
   BUILD_VERSION,
-  CallToolParamsSchema,
-  CheckAliasParamsSchema,
-  DeleteAliasParamsSchema,
-  DeleteNoteParamsSchema,
-  type EventFilterSpec,
-  GetAliasParamsSchema,
   GetDaemonLogsParamsSchema,
   GetLogsParamsSchema,
-  GetNoteParamsSchema,
-  GetSpansParamsSchema,
-  GetToolInfoParamsSchema,
-  GetWorkItemParamsSchema,
-  GrepToolsParamsSchema,
   IPC_ERROR,
-  KillServeParamsSchema,
-  ListToolsParamsSchema,
-  ListWorkItemsParamsSchema,
-  MarkReadParamsSchema,
-  MarkSpansExportedParamsSchema,
-  type MonitorEvent,
-  type MonitorEventInput,
   PROTOCOL_VERSION,
-  PruneSpansParamsSchema,
-  PublishEventParamsSchema,
-  ReadMailParamsSchema,
-  RecordAliasRunParamsSchema,
-  RegisterServeParamsSchema,
-  ReplyToMailParamsSchema,
-  RestartServerParamsSchema,
-  SaveAliasParamsSchema,
-  SendMailParamsSchema,
-  SetBudgetConfigParamsSchema,
-  SetNoteParamsSchema,
   ShutdownParamsSchema,
-  TouchAliasParamsSchema,
-  TrackWorkItemParamsSchema,
-  TriggerAuthParamsSchema,
-  UnregisterServeParamsSchema,
-  UntrackWorkItemParamsSchema,
-  WaitForMailParamsSchema,
-  bundleAlias,
   consoleLogger,
-  createEventMatcher,
   hardenFile,
-  isDefineAlias,
-  isDefineMonitor,
-  loadManifest,
   options,
-  resolveRealpath,
-  safeAliasPath,
   startSpan,
-  validateFreeformTsc,
 } from "@mcp-cli/core";
 import { z } from "zod/v4";
 import type { AliasServer } from "./alias-server";
-import { McpOAuthProvider } from "./auth/oauth-provider";
-import { runOAuthFlowWithDcrRetry } from "./auth/oauth-retry";
-import { getDaemonLogLines, subscribeDaemonLogs } from "./daemon-log";
+import { getDaemonLogLines } from "./daemon-log";
 import type { StateDb } from "./db/state";
 import { WorkItemDb } from "./db/work-items";
 import type { EventBus } from "./event-bus";
-import { publishMailReceived } from "./mail-events";
+import { EventStreamServer } from "./event-stream";
+import type { RequestContext, RequestHandler } from "./handler-types";
+import { AliasHandlers } from "./handlers/alias";
+import { AuthHandlers } from "./handlers/auth";
+import { BudgetHandlers } from "./handlers/budget";
+import { ConfigHandlers } from "./handlers/config";
+import { EventHandlers } from "./handlers/event";
+import { MailHandlers } from "./handlers/mail";
+import { NoteHandlers } from "./handlers/note";
+import { ServeHandlers } from "./handlers/serve";
+import { TelemetryHandlers } from "./handlers/telemetry";
+import { ToolHandlers } from "./handlers/tool";
+import { WorkItemHandlers } from "./handlers/work-item";
 import { metrics } from "./metrics";
 import { getPortHolder } from "./port-holder";
-import { killPid } from "./process-util";
 import type { ServerPool } from "./server-pool";
 
-/** Per-request context passed to every handler (fixes race condition on shared state). */
-export interface RequestContext {
-  span: LiveSpan;
-}
-
-type RequestHandler = (params: unknown, ctx: RequestContext) => Promise<unknown>;
-
-/**
- * Build a server-side predicate from GET /events query params.
- * Returns null if no filters are specified (pass-through).
- *
- * Uses matchFilter() from core for the shared EventFilterSpec semantics.
- * Heartbeats always pass through (server-side keepalive behaviour).
- */
-export function buildEventFilter(params: URLSearchParams): ((event: Record<string, unknown>) => boolean) | null {
-  const subscribeRaw = params.get("subscribe");
-  const session = params.get("session");
-  const prRaw = params.get("pr");
-  const workItem = params.get("workItem");
-  const typeRaw = params.get("type");
-  const srcRaw = params.get("src");
-  const phase = params.get("phase");
-
-  if (!subscribeRaw && !session && prRaw === null && !workItem && !typeRaw && !srcRaw && !phase) {
-    return null;
-  }
-
-  const prNumber = prRaw !== null ? Number(prRaw) : null;
-  if (prNumber !== null && !(Number.isInteger(prNumber) && prNumber >= 1)) {
-    return () => false;
-  }
-
-  const spec: EventFilterSpec = {
-    ...(subscribeRaw
-      ? {
-          subscribe: subscribeRaw
-            .split(",")
-            .map((s) => s.trim())
-            .filter(Boolean) as EventFilterSpec["subscribe"],
-        }
-      : {}),
-    ...(session ? { session } : {}),
-    ...(prNumber !== null ? { pr: prNumber } : {}),
-    ...(workItem ? { workItem } : {}),
-    ...(typeRaw
-      ? {
-          type: typeRaw
-            .split(",")
-            .map((s) => s.trim())
-            .filter(Boolean),
-        }
-      : {}),
-    ...(srcRaw ? { src: srcRaw } : {}),
-    ...(phase ? { phase } : {}),
-  };
-
-  const matcher = createEventMatcher(spec);
-
-  return (event: Record<string, unknown>): boolean => {
-    // Heartbeats always pass through — server-side keepalive, not a data filter concern
-    if (event.category === "heartbeat" || event.event === "heartbeat") return true;
-    return matcher(event as MonitorEvent);
-  };
-}
+// Re-export for backward compat with existing tests and external code.
+export { buildEventFilter } from "./ipc-filter";
+export type { RequestContext } from "./handler-types";
 
 export class IpcServer {
   private server: ReturnType<typeof Bun.serve> | null = null;
@@ -173,32 +69,22 @@ export class IpcServer {
   private shutdownScheduled = false;
   private drainTimer: ReturnType<typeof setTimeout> | null = null;
   private drainTimeoutMs: number;
-
-  private workItemDb: WorkItemDb;
   private serveInstances = new Map<string, ServeInstanceInfo>();
   private onReloadConfig: (() => Promise<void>) | null = null;
   private getWsPortInfo: (() => { actual: number | null; expected: number }) | null = null;
   private getQuotaStatus: (() => IpcMethodResult["quotaStatus"]) | null = null;
-  private resolveIssuePr: ((number: number) => Promise<{ prNumber: number | null }>) | null = null;
-  private loadManifestFn: ((repoRoot: string) => Manifest | null) | null = null;
-  private aliasServer: AliasServer | null = null;
-  private eventBus: EventBus | null = null;
-  private onAliasChanged: ((name: string) => void) | null = null;
   private daemonId: string;
   private startedAt: number;
   private logger: Logger;
-
-  /** Event stream infrastructure */
-  private eventSeq = 0;
-  private eventSubscribers = new Set<(event: Record<string, unknown>) => void>();
-  private eventBusSubId: number | null = null;
+  private eventStream: EventStreamServer;
+  private serveHandlers: ServeHandlers;
 
   constructor(
     private pool: ServerPool,
     private config: ResolvedConfig,
     private db: StateDb,
     aliasServer: AliasServer | null,
-    options: {
+    opts: {
       daemonId: string;
       startedAt: number;
       onActivity: () => void;
@@ -206,57 +92,40 @@ export class IpcServer {
       onShutdown?: () => void;
       onReloadConfig?: () => Promise<void>;
       logger?: Logger;
-      /** Returns the current and expected WS port for status reporting. */
       getWsPortInfo?: () => { actual: number | null; expected: number };
-      /** Max ms to wait for in-flight requests before forcing shutdown (default 5000) */
       drainTimeoutMs?: number;
-      /** Returns current quota status for the quotaStatus IPC method. */
       getQuotaStatus?: () => IpcMethodResult["quotaStatus"];
-      /** Resolve an issue/PR number to its associated PR number via GitHub API. */
       resolveIssuePr?: (number: number) => Promise<{ prNumber: number | null }>;
-      /** Load a manifest from the given repo root; injected for testability. Defaults to core loadManifest. */
       loadManifest?: (repoRoot: string) => Manifest | null;
-      /** Event bus for unified monitor stream; mail events are published here. */
       eventBus?: EventBus;
-      /** Called after an alias is saved/deleted so monitor aliases can be restarted. */
       onAliasChanged?: (name: string) => void;
     },
   ) {
-    this.daemonId = options.daemonId;
-    this.startedAt = options.startedAt;
-    this.onActivity = options.onActivity;
-    this.onRequestComplete = options.onRequestComplete ?? (() => {});
-    this.onShutdown = options.onShutdown ?? (() => process.exit(0));
-    this.onReloadConfig = options.onReloadConfig ?? null;
-    this.aliasServer = aliasServer;
-    this.logger = options.logger ?? consoleLogger;
-    this.getWsPortInfo = options.getWsPortInfo ?? null;
-    this.getQuotaStatus = options.getQuotaStatus ?? null;
-    this.resolveIssuePr = options.resolveIssuePr ?? null;
-    this.loadManifestFn = options.loadManifest ?? ((r) => loadManifest(r)?.manifest ?? null);
-    this.drainTimeoutMs = options.drainTimeoutMs ?? 5_000;
-    this.onAliasChanged = options.onAliasChanged ?? null;
-    this.eventBus = options.eventBus ?? null;
-    if (this.eventBus) {
-      this.eventSeq = this.eventBus.currentSeq;
-      this.eventBusSubId = this.eventBus.subscribe((event) => {
-        this.eventSeq = event.seq;
-        const envelope = event as unknown as Record<string, unknown>;
-        const failed: ((e: Record<string, unknown>) => void)[] = [];
-        for (const cb of this.eventSubscribers) {
-          try {
-            cb(envelope);
-          } catch (err) {
-            this.logger.warn(`[events] subscriber threw, dropping: ${err}`);
-            failed.push(cb);
-          }
-        }
-        for (const cb of failed) this.eventSubscribers.delete(cb);
-      });
-    }
-    this.workItemDb = new WorkItemDb(this.db.getDatabase());
-    this.registerHandlers();
-    // Prune expired ephemeral aliases on startup
+    this.daemonId = opts.daemonId;
+    this.startedAt = opts.startedAt;
+    this.onActivity = opts.onActivity;
+    this.onRequestComplete = opts.onRequestComplete ?? (() => {});
+    this.onShutdown = opts.onShutdown ?? (() => process.exit(0));
+    this.onReloadConfig = opts.onReloadConfig ?? null;
+    this.logger = opts.logger ?? consoleLogger;
+    this.getWsPortInfo = opts.getWsPortInfo ?? null;
+    this.getQuotaStatus = opts.getQuotaStatus ?? null;
+    this.drainTimeoutMs = opts.drainTimeoutMs ?? 5_000;
+
+    const workItemDb = new WorkItemDb(this.db.getDatabase());
+    const eventBus = opts.eventBus ?? null;
+
+    this.eventStream = new EventStreamServer(eventBus, this.pool, this.logger, IpcServer.HEARTBEAT_INTERVAL_MS);
+    this.serveHandlers = new ServeHandlers(this.serveInstances, this.logger);
+
+    this.registerHandlers({
+      aliasServer,
+      workItemDb,
+      eventBus,
+      resolveIssuePr: opts.resolveIssuePr ?? null,
+      loadManifestFn: opts.loadManifest ?? null,
+      onAliasChanged: opts.onAliasChanged ?? null,
+    });
     this.db.pruneExpiredAliases();
   }
 
@@ -264,7 +133,6 @@ export class IpcServer {
   start(socketPath = options.SOCKET_PATH): void {
     this.socketPath = socketPath;
 
-    // Remove stale socket file
     try {
       unlinkSync(socketPath);
     } catch {
@@ -278,27 +146,22 @@ export class IpcServer {
 
     this.server = Bun.serve({
       unix: socketPath,
-      // idleTimeout is a valid Bun runtime option not yet in @types/bun@1.3.12.
-      // Disabled (0) so NDJSON/SSE streaming connections stay open indefinitely.
       ...({ idleTimeout: 0 } as Record<string, unknown>),
       async fetch(req) {
         const url = new URL(req.url);
 
-        // GET /metrics — Prometheus text exposition format
         if (url.pathname === "/metrics" && req.method === "GET") {
           return new Response(metrics.toPrometheusText(), {
             headers: { "content-type": "text/plain; version=0.0.4; charset=utf-8" },
           });
         }
 
-        // GET /logs — SSE stream for real-time log tailing
         if (url.pathname === "/logs" && req.method === "GET") {
-          return self.handleLogsSSE(url);
+          return self.eventStream.handleLogsSSE(url);
         }
 
-        // GET /events — NDJSON stream for unified monitor event bus (#1515)
         if (url.pathname === "/events" && req.method === "GET") {
-          return self.handleEventsNDJSON(url);
+          return self.eventStream.handleEventsNDJSON(url);
         }
 
         if (req.method !== "POST") {
@@ -326,7 +189,6 @@ export class IpcServer {
           return Response.json(error, { status: 400 });
         }
 
-        // Reject new requests while draining (except the shutdown request itself already dispatched)
         if (self.draining && request.method !== "shutdown") {
           onRequestComplete();
           self.inflightCount--;
@@ -356,9 +218,7 @@ export class IpcServer {
       },
     });
 
-    // Restrict socket to owner-only access (0600)
     hardenFile(socketPath);
-
     this.logger.info(`[ipc] Listening on ${socketPath}`);
   }
 
@@ -368,10 +228,7 @@ export class IpcServer {
       clearTimeout(this.drainTimer);
       this.drainTimer = null;
     }
-    if (this.eventBusSubId !== null && this.eventBus) {
-      this.eventBus.unsubscribe(this.eventBusSubId);
-      this.eventBusSubId = null;
-    }
+    this.eventStream.dispose();
     this.server?.stop(true);
     try {
       unlinkSync(this.socketPath);
@@ -380,60 +237,48 @@ export class IpcServer {
     }
   }
 
-  /**
-   * Fire-and-forget: resolve PR number via GitHub API and update the work item.
-   * Handles UNIQUE constraint collisions by merging with an existing item that
-   * already tracks the same PR number.
-   */
-  private resolveAndUpdateWorkItem(itemId: string, issueNumber: number): void {
-    if (!this.resolveIssuePr) return;
-    this.resolveIssuePr(issueNumber)
-      .then((resolved) => {
-        if (!resolved.prNumber) return;
+  // -- Delegation to EventStreamServer (for test compatibility) --
 
-        // Check for UNIQUE constraint: another item may already track this PR
-        const existingByPr = this.workItemDb.getWorkItemByPr(resolved.prNumber);
-        if (existingByPr && existingByPr.id !== itemId) {
-          this.logger.info(
-            `[mcpd] PR #${resolved.prNumber} already tracked by ${existingByPr.id}, skipping update for ${itemId}`,
-          );
-          return;
-        }
-
-        this.workItemDb.updateWorkItem(itemId, { prNumber: resolved.prNumber });
-        this.logger.info(`[mcpd] Resolved #${issueNumber} → PR #${resolved.prNumber}`);
-      })
-      .catch((err) => {
-        this.logger.warn(
-          `[mcpd] Failed to resolve PR for #${issueNumber}: ${err instanceof Error ? err.message : String(err)}`,
-        );
-      });
+  pushEvent(event: Record<string, unknown>): void {
+    this.eventStream.pushEvent(event);
   }
 
-  /** If draining and no requests in flight, trigger shutdown on next tick (lets Bun flush responses) */
-  private checkDrain(): void {
-    if (this.draining && this.inflightCount === 0 && !this.shutdownScheduled) {
-      this.shutdownScheduled = true;
-      if (this.drainTimer) {
-        clearTimeout(this.drainTimer);
-        this.drainTimer = null;
-      }
-      // Defer to next event-loop turn so Bun can finish writing the HTTP response
-      setTimeout(() => this.onShutdown(), 0);
-    }
+  get currentEventSeq(): number {
+    return this.eventStream.currentEventSeq;
   }
 
-  /** Start a drain timeout — force shutdown after drainTimeoutMs even if requests are stuck */
-  private startDrainTimeout(): void {
-    this.drainTimer = setTimeout(() => {
-      if (!this.shutdownScheduled) {
-        this.logger.warn(
-          `[ipc] Drain timeout (${this.drainTimeoutMs}ms) — forcing shutdown with ${this.inflightCount} request(s) still in-flight`,
-        );
-        this.shutdownScheduled = true;
-        this.onShutdown();
-      }
-    }, this.drainTimeoutMs);
+  get eventSubscriberCount(): number {
+    return this.eventStream.eventSubscriberCount;
+  }
+
+  /** Test-mutable: patch before construction to change heartbeat cadence. */
+  static HEARTBEAT_INTERVAL_MS = 30_000;
+  static get MAX_EVENT_BUS_SUBSCRIBERS() {
+    return EventStreamServer.MAX_EVENT_BUS_SUBSCRIBERS;
+  }
+  static get LIVE_BUFFER_MAX_ENTRIES() {
+    return EventStreamServer.LIVE_BUFFER_MAX_ENTRIES;
+  }
+  static set LIVE_BUFFER_MAX_ENTRIES(v: number) {
+    EventStreamServer.LIVE_BUFFER_MAX_ENTRIES = v;
+  }
+  static get LIVE_BUFFER_MAX_BYTES() {
+    return EventStreamServer.LIVE_BUFFER_MAX_BYTES;
+  }
+  static set LIVE_BUFFER_MAX_BYTES(v: number) {
+    EventStreamServer.LIVE_BUFFER_MAX_BYTES = v;
+  }
+  static get BACKFILL_BATCH_SIZE() {
+    return EventStreamServer.BACKFILL_BATCH_SIZE;
+  }
+  static set BACKFILL_BATCH_SIZE(v: number) {
+    EventStreamServer.BACKFILL_BATCH_SIZE = v;
+  }
+  static get BACKFILL_YIELD_FN() {
+    return EventStreamServer.BACKFILL_YIELD_FN;
+  }
+  static set BACKFILL_YIELD_FN(v: (() => Promise<void>) | null) {
+    EventStreamServer.BACKFILL_YIELD_FN = v;
   }
 
   // -- Dispatch --
@@ -446,7 +291,6 @@ export class IpcServer {
       });
     }
 
-    // Create a per-request span (child of caller's traceparent, or root)
     const span = startSpan(`ipc.${request.method}`, {
       parentTraceparent: request.traceparent,
       onFallback: () => metrics.counter("mcpd_trace_fallback_root_total").inc(),
@@ -477,9 +321,55 @@ export class IpcServer {
     }
   }
 
+  private checkDrain(): void {
+    if (this.draining && this.inflightCount === 0 && !this.shutdownScheduled) {
+      this.shutdownScheduled = true;
+      if (this.drainTimer) {
+        clearTimeout(this.drainTimer);
+        this.drainTimer = null;
+      }
+      setTimeout(() => this.onShutdown(), 0);
+    }
+  }
+
+  private startDrainTimeout(): void {
+    this.drainTimer = setTimeout(() => {
+      if (!this.shutdownScheduled) {
+        this.logger.warn(
+          `[ipc] Drain timeout (${this.drainTimeoutMs}ms) — forcing shutdown with ${this.inflightCount} request(s) still in-flight`,
+        );
+        this.shutdownScheduled = true;
+        this.onShutdown();
+      }
+    }, this.drainTimeoutMs);
+  }
+
   // -- Handler registration --
 
-  private registerHandlers(): void {
+  private registerHandlers(deps: {
+    aliasServer: AliasServer | null;
+    workItemDb: WorkItemDb;
+    eventBus: EventBus | null;
+    resolveIssuePr: ((n: number) => Promise<{ prNumber: number | null }>) | null;
+    loadManifestFn: ((repoRoot: string) => Manifest | null) | null;
+    onAliasChanged: ((name: string) => void) | null;
+  }): void {
+    new AuthHandlers(this.pool, this.logger).register(this.handlers);
+    new AliasHandlers(this.db, deps.aliasServer, this.logger, deps.onAliasChanged ?? undefined).register(this.handlers);
+    new WorkItemHandlers(deps.workItemDb, this.db, deps.resolveIssuePr, deps.loadManifestFn, this.logger).register(
+      this.handlers,
+    );
+    this.serveHandlers.register(this.handlers);
+    new BudgetHandlers(this.db).register(this.handlers);
+    new EventHandlers(deps.eventBus).register(this.handlers);
+    new TelemetryHandlers(this.db).register(this.handlers);
+    new ConfigHandlers(this.pool, this.config, this.onReloadConfig).register(this.handlers);
+    new MailHandlers(this.db, deps.eventBus, () => this.draining).register(this.handlers);
+    new NoteHandlers(this.db).register(this.handlers);
+    new ToolHandlers(this.pool, this.db, deps.aliasServer, this.daemonId, this.logger).register(this.handlers);
+
+    // -- Core infrastructure handlers --
+
     this.handlers.set("ping", async (_params, _ctx) => ({
       pong: true,
       time: Date.now(),
@@ -490,7 +380,6 @@ export class IpcServer {
       const servers = this.pool.listServers();
       const usageStats = this.db.getUsageStats();
 
-      // Compute per-server aggregates
       for (const server of servers) {
         const serverStats = usageStats.filter((s) => s.serverName === server.name);
         if (serverStats.length > 0) {
@@ -504,7 +393,7 @@ export class IpcServer {
       const wsPortInfo = this.getWsPortInfo?.();
       const hasMismatch = wsPortInfo != null && wsPortInfo.actual != null && wsPortInfo.actual !== wsPortInfo.expected;
       const wsPortHolder = hasMismatch ? await getPortHolder(wsPortInfo.expected) : null;
-      this.pruneStaleServeInstances();
+      this.serveHandlers.pruneStaleInstances();
       return {
         pid: process.pid,
         uptime: process.uptime(),
@@ -522,486 +411,9 @@ export class IpcServer {
 
     this.handlers.set("listServers", async (_params, _ctx) => this.pool.listServers());
 
-    this.handlers.set("listTools", async (params, _ctx) => {
-      const { server } = ListToolsParamsSchema.parse(params ?? {});
-      return this.pool.listTools(server);
-    });
-
-    this.handlers.set("getToolInfo", async (params, _ctx) => {
-      const { server, tool } = GetToolInfoParamsSchema.parse(params);
-      const info = await this.pool.getToolInfo(server, tool);
-      const note = this.db.getNote(server, tool);
-      return note ? { ...info, note } : info;
-    });
-
-    this.handlers.set("grepTools", async (params, _ctx) => {
-      const { pattern } = GrepToolsParamsSchema.parse(params);
-      const tools = await this.pool.grepTools(pattern);
-
-      // Enrich matched tools with notes and check if any notes match the pattern
-      const allNotes = this.db.listNotes();
-      const noteMap = new Map(allNotes.map((n) => [`${n.serverName}\0${n.toolName}`, n.note]));
-
-      // Add notes to already-matched tools
-      const enriched = tools.map((t) => {
-        const note = noteMap.get(`${t.server}\0${t.name}`);
-        return note ? { ...t, note } : t;
-      });
-
-      // Find tools that match via note content but weren't already matched
-      const matchedKeys = new Set(tools.map((t) => `${t.server}\0${t.name}`));
-      const regex = new RegExp(
-        pattern
-          .replace(/[.+^${}()|[\]\\]/g, "\\$&")
-          .replace(/\*/g, ".*")
-          .replace(/\?/g, "."),
-        "i",
-      );
-      const noteMatches = allNotes.filter(
-        (n) => !matchedKeys.has(`${n.serverName}\0${n.toolName}`) && regex.test(n.note),
-      );
-
-      // For note-matched tools, fetch their full ToolInfo
-      for (const n of noteMatches) {
-        try {
-          const info = await this.pool.getToolInfo(n.serverName, n.toolName);
-          enriched.push({ ...info, note: n.note });
-        } catch {
-          // Tool no longer exists — skip
-        }
-      }
-
-      return enriched;
-    });
-
-    this.handlers.set("callTool", async (params, ctx) => {
-      const { server, tool, arguments: args, timeoutMs, callChain, cwd } = CallToolParamsSchema.parse(params);
-      const toolSpan = ctx.span.child(`tool.${server}.${tool}`);
-      toolSpan.setAttribute("tool.server", server);
-      toolSpan.setAttribute("tool.name", tool);
-      if (callChain) toolSpan.setAttribute("alias.callChainDepth", callChain.length);
-      const toolLabels = { server, tool };
-      try {
-        // Route every _aliases call through the alias server directly so the
-        // caller's cwd (for repo-root scoping) and optional callChain reach
-        // the executor subprocess. The pool route has no cwd channel.
-        const result =
-          server === ALIAS_SERVER_NAME && this.aliasServer
-            ? await this.aliasServer.callToolWithChain(tool, args, callChain ?? [], cwd, timeoutMs)
-            : await this.pool.callTool(server, tool, args, timeoutMs);
-        toolSpan.setStatus("OK");
-        const finished = toolSpan.end();
-        // Dual-write: usage_stats (Phase 1 compat) + spans table
-        this.db.recordUsage(server, tool, finished.durationMs, true, undefined, {
-          daemonId: this.daemonId,
-          traceId: finished.traceId,
-          parentId: finished.parentSpanId,
-        });
-        this.db.recordSpan(finished, this.daemonId);
-        metrics.counter("mcpd_tool_calls_total", toolLabels).inc();
-        metrics.histogram("mcpd_tool_call_duration_ms", toolLabels).observe(finished.durationMs);
-        return result;
-      } catch (err) {
-        toolSpan.setStatus("ERROR");
-        toolSpan.setAttribute("error.message", err instanceof Error ? err.message : String(err));
-        const finished = toolSpan.end();
-        this.db.recordUsage(
-          server,
-          tool,
-          finished.durationMs,
-          false,
-          err instanceof Error ? err.message : String(err),
-          { daemonId: this.daemonId, traceId: finished.traceId, parentId: finished.parentSpanId },
-        );
-        this.db.recordSpan(finished, this.daemonId);
-        metrics.counter("mcpd_tool_calls_total", toolLabels).inc();
-        metrics.counter("mcpd_tool_errors_total", toolLabels).inc();
-        metrics.histogram("mcpd_tool_call_duration_ms", toolLabels).observe(finished.durationMs);
-        throw err;
-      }
-    });
-
-    this.handlers.set("triggerAuth", async (params, _ctx) => {
-      const { server } = TriggerAuthParamsSchema.parse(params);
-      const serverUrl = this.pool.getServerUrl(server);
-
-      // Non-remote server — check for `auth` tool convention
-      if (!serverUrl) {
-        let tools: ToolInfo[];
-        try {
-          tools = await this.pool.listTools(server);
-        } catch {
-          tools = [];
-        }
-        const hasAuthTool = tools.some((t) => t.name === "auth");
-        if (!hasAuthTool) {
-          throw Object.assign(
-            new Error(`Server "${server}" not found or does not support auth (no OAuth endpoint and no "auth" tool)`),
-            { code: IPC_ERROR.SERVER_NOT_FOUND },
-          );
-        }
-
-        const result = (await this.pool.callTool(server, "auth", {})) as {
-          content?: Array<{ type?: string; text?: string }>;
-          isError?: boolean;
-        };
-        const text =
-          result.content
-            ?.filter((c) => c.type === "text")
-            .map((c) => c.text)
-            .join("\n") ?? "";
-        if (result.isError) {
-          throw Object.assign(new Error(text || "auth tool returned an error"), {
-            code: IPC_ERROR.INTERNAL_ERROR,
-          });
-        }
-        return { ok: true, message: text || "Authenticated via auth tool" };
-      }
-
-      const poolDb = this.pool.getDb();
-      if (!poolDb) {
-        throw Object.assign(new Error("Database not available"), { code: IPC_ERROR.INTERNAL_ERROR });
-      }
-
-      // Read OAuth config from server configuration
-      const serverConfig = this.pool.getServerConfig(server);
-      const { clientId, clientSecret, callbackPort, scope } = serverConfig ?? {};
-
-      const flowResult = await runOAuthFlowWithDcrRetry(server, serverUrl, poolDb, {
-        clientId,
-        clientSecret,
-        callbackPort,
-        scope,
-      });
-
-      await this.pool.restart(server);
-
-      if (flowResult === "already_authorized") {
-        return { ok: true, message: "Already authorized" };
-      }
-      return { ok: true, message: "Authenticated successfully" };
-    });
-
-    this.handlers.set("authStatus", async (params, _ctx) => {
-      const { server } = AuthStatusParamsSchema.parse(params ?? {});
-      const allServers = this.pool.listServers();
-      const filtered = server ? allServers.filter((s) => s.name === server) : allServers;
-
-      if (server && filtered.length === 0) {
-        throw Object.assign(new Error(`Server "${server}" not found`), { code: IPC_ERROR.SERVER_NOT_FOUND });
-      }
-
-      const poolDb = this.pool.getDb();
-      const results: ServerAuthStatus[] = [];
-
-      for (const srv of filtered) {
-        const serverUrl = this.pool.getServerUrl(srv.name);
-        let authSupport: ServerAuthStatus["authSupport"] = "none";
-        let status: ServerAuthStatus["status"] = "unknown";
-        let expiresAt: number | undefined;
-
-        if (serverUrl) {
-          // Remote server — check for OAuth tokens via provider (includes keychain fallback)
-          authSupport = "oauth";
-          if (poolDb) {
-            const serverConfig = this.pool.getServerConfig(srv.name);
-            const provider = new McpOAuthProvider(srv.name, serverUrl, poolDb, {
-              clientId: serverConfig?.clientId,
-              clientSecret: serverConfig?.clientSecret,
-              scope: serverConfig?.scope,
-            });
-            const tokens = await provider.tokens();
-            if (tokens) {
-              // Check raw expires_at from DB for accurate expiry detection
-              const rawExpiry = poolDb.getTokenExpiry(srv.name);
-              if (rawExpiry !== null && rawExpiry <= Date.now()) {
-                status = "expired";
-                expiresAt = rawExpiry;
-              } else {
-                status = "authenticated";
-                if (rawExpiry !== null) {
-                  expiresAt = rawExpiry;
-                } else if (tokens.expires_in !== undefined && tokens.expires_in > 0) {
-                  // Keychain token with expiry info
-                  expiresAt = Date.now() + tokens.expires_in * 1000;
-                }
-              }
-            } else {
-              status = "not_authenticated";
-            }
-          }
-        } else if (srv.transport !== "virtual") {
-          // Stdio server — only check cached tools, never spawn the process
-          const cachedTools = this.pool.getCachedTools(srv.name);
-          if (cachedTools?.some((t) => t.name === "auth")) {
-            authSupport = "auth_tool";
-            status = "unknown"; // can't check without calling it
-          }
-        }
-
-        results.push({
-          server: srv.name,
-          transport: srv.transport,
-          authSupport,
-          status,
-          ...(expiresAt !== undefined && { expiresAt }),
-        });
-      }
-
-      return { servers: results };
-    });
-
-    this.handlers.set("restartServer", async (params, _ctx) => {
-      const { server } = RestartServerParamsSchema.parse(params ?? {});
-      await this.pool.restart(server);
-      return { ok: true };
-    });
-
-    this.handlers.set("getConfig", async (_params, _ctx) => {
-      const servers: Record<string, { transport: string; source: string; scope: string; toolCount: number }> = {};
-      const statusMap = new Map(this.pool.listServers().map((s) => [s.name, s]));
-      for (const [name, resolved] of this.config.servers) {
-        const status = statusMap.get(name);
-        servers[name] = {
-          transport: status?.transport ?? "unknown",
-          source: resolved.source.file,
-          scope: resolved.source.scope,
-          toolCount: status?.toolCount ?? 0,
-        };
-      }
-      return {
-        servers,
-        sources: this.config.sources,
-      };
-    });
-
-    this.handlers.set("listAliases", async (_params, _ctx) => {
-      return this.db.listAliases();
-    });
-
-    this.handlers.set("getAlias", async (params, _ctx) => {
-      const { name } = GetAliasParamsSchema.parse(params);
-      const alias = this.db.getAlias(name);
-      if (!alias) return null;
-      try {
-        const script = readFileSync(alias.filePath, "utf-8");
-        return { ...alias, script };
-      } catch {
-        return { ...alias, script: "" };
-      }
-    });
-
-    this.handlers.set("saveAlias", async (params, _ctx) => {
-      const parsed = SaveAliasParamsSchema.parse(params);
-      const { name, script, description, expiresAt } = parsed;
-      // If the caller did not supply `scope`, preserve the existing row's scope.
-      // An explicit `null` clears scope; an explicit string sets it.
-      const scopeProvided =
-        typeof params === "object" && params !== null && Object.prototype.hasOwnProperty.call(params, "scope");
-      const filePath = safeAliasPath(name);
-      mkdirSync(options.ALIASES_DIR, { recursive: true });
-      const wasMonitor = this.db.getAlias(name)?.aliasType === "defineMonitor";
-
-      // Guard: refuse to overwrite a permanent alias with an ephemeral one.
-      // This check must happen BEFORE writeFileSync to protect the file on disk.
-      if (expiresAt != null) {
-        const existing = this.db.getAlias(name);
-        if (existing && existing.expiresAt === null) {
-          return { ok: false, reason: "permanent_alias_exists" };
-        }
-      }
-
-      // When caller didn't supply scope, pass scopeProvided=false so the SQL
-      // UPDATE branch preserves the existing row's scope atomically (no TOCTOU).
-      const scope: string | null = scopeProvided ? (parsed.scope ?? null) : null;
-
-      const isMonitor = isDefineMonitor(script);
-      const isStructured = !isMonitor && isDefineAlias(script);
-
-      let finalScript: string;
-      if (isStructured || isMonitor) {
-        // defineAlias and defineMonitor scripts get everything via the virtual module — no auto-import
-        finalScript = script;
-      } else {
-        // Freeform: auto-prepend import if not present (existing behavior)
-        const hasImport = /import\s.*from\s+["']mcp-cli["']/.test(script);
-        finalScript = hasImport ? script : `import { mcp, args, file, json } from "mcp-cli";\n${script}`;
-      }
-
-      writeFileSync(filePath, finalScript, "utf-8");
-
-      const aliasType = isMonitor ? "defineMonitor" : isStructured ? "defineAlias" : "freeform";
-      const warnings: string[] = [];
-      const validationErrors: string[] = [];
-
-      // Bundle the alias and extract metadata
-      try {
-        const { js, sourceHash } = await bundleAlias(filePath);
-
-        if (isStructured) {
-          if (!this.aliasServer) throw new Error("Alias server not initialized");
-          const validation = await this.aliasServer.validateInSubprocess(js);
-          if (!validation.valid) {
-            validationErrors.push(...validation.errors);
-          }
-          if (validation.warnings.length > 0) {
-            warnings.push(...validation.warnings);
-          }
-          this.db.saveAlias(
-            name,
-            filePath,
-            validation.description || description,
-            aliasType,
-            validation.inputSchema ? JSON.stringify(validation.inputSchema) : undefined,
-            validation.outputSchema ? JSON.stringify(validation.outputSchema) : undefined,
-            js,
-            sourceHash,
-            expiresAt,
-            scope ?? null,
-            scopeProvided,
-            validation.monitorDefs ? JSON.stringify(validation.monitorDefs) : undefined,
-          );
-        } else {
-          // Mixed scripts (defineAlias + defineMonitor in the same file) are not supported.
-          // The file was classified as defineMonitor (isMonitor=true), so defineAlias content
-          // would be silently ignored. Reject early with a clear validation error instead.
-          if (isMonitor && isDefineAlias(finalScript)) {
-            validationErrors.push(
-              "Script contains both defineAlias() and defineMonitor(). Mixed scripts are not supported — use one pattern per file.",
-            );
-          }
-          // Freeform: extract monitor definitions in subprocess if sentinel detected
-          let monitorDefsJson: string | undefined;
-          if (isDefineMonitor(finalScript) && this.aliasServer) {
-            try {
-              const monitorDefs = await this.aliasServer.extractMonitorsInSubprocess(js);
-              if (monitorDefs.length > 0) monitorDefsJson = JSON.stringify(monitorDefs);
-            } catch (err) {
-              this.logger.warn(
-                `[saveAlias] extractMonitorMetadata failed for "${name}": ${err instanceof Error ? err.message : String(err)}`,
-              );
-            }
-          }
-          this.db.saveAlias(
-            name,
-            filePath,
-            description,
-            aliasType,
-            undefined,
-            undefined,
-            js,
-            sourceHash,
-            expiresAt,
-            scope ?? null,
-            scopeProvided,
-            monitorDefsJson,
-          );
-        }
-      } catch (err) {
-        // Bundle/extraction failed — save without bundle
-        validationErrors.push(`Bundle failed: ${err instanceof Error ? err.message : String(err)}`);
-        this.db.saveAlias(
-          name,
-          filePath,
-          description,
-          aliasType,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          expiresAt,
-          scope ?? null,
-          scopeProvided,
-          undefined,
-          false,
-        );
-      }
-
-      // Refresh virtual alias server so new tool is immediately visible
-      await this.aliasServer?.refresh();
-      if (isMonitor || wasMonitor) this.onAliasChanged?.(name);
-      const result: { ok: true; filePath: string; warnings?: string[]; validationErrors?: string[] } = {
-        ok: true,
-        filePath,
-      };
-      if (warnings.length > 0) result.warnings = warnings;
-      if (validationErrors.length > 0) result.validationErrors = validationErrors;
-      return result;
-    });
-
-    this.handlers.set("deleteAlias", async (params, _ctx) => {
-      const { name } = DeleteAliasParamsSchema.parse(params);
-      const alias = this.db.getAlias(name);
-      if (alias) {
-        try {
-          unlinkSync(alias.filePath);
-        } catch {
-          // file already gone, fine
-        }
-        this.db.deleteAlias(name);
-      }
-      // Refresh virtual alias server so deleted tool is removed
-      await this.aliasServer?.refresh();
-      if (alias?.aliasType === "defineMonitor") this.onAliasChanged?.(name);
-      return { ok: true };
-    });
-
-    this.handlers.set("touchAlias", async (params, _ctx) => {
-      const { name, expiresAt } = TouchAliasParamsSchema.parse(params);
-      this.db.touchAliasExpiry(name, expiresAt);
-      return { ok: true };
-    });
-
-    this.handlers.set("recordAliasRun", async (params, _ctx) => {
-      const { name } = RecordAliasRunParamsSchema.parse(params);
-      const runCount = this.db.recordAliasRun(name);
-      return { ok: true, runCount };
-    });
-
-    this.handlers.set("checkAlias", async (params, _ctx) => {
-      const { name } = CheckAliasParamsSchema.parse(params);
-      const alias = this.db.getAlias(name);
-      if (!alias) {
-        return { valid: false, aliasType: "freeform", errors: [`Alias "${name}" not found`], warnings: [] };
-      }
-
-      if (alias.aliasType !== "defineAlias") {
-        // Freeform aliases — try bundling to check for syntax errors
-        try {
-          await bundleAlias(alias.filePath);
-        } catch (err) {
-          return {
-            valid: false,
-            aliasType: "freeform",
-            errors: [`Bundle failed: ${err instanceof Error ? err.message : String(err)}`],
-            warnings: [],
-          };
-        }
-
-        // Run tsc --noEmit for type-level diagnostics (warnings only)
-        const tsc = await validateFreeformTsc(alias.filePath);
-        return { valid: true, aliasType: "freeform", errors: [], warnings: tsc.warnings };
-      }
-
-      // defineAlias — full validation
-      try {
-        const { js } = await bundleAlias(alias.filePath);
-        if (!this.aliasServer) throw new Error("Alias server not initialized");
-        return await this.aliasServer.validateInSubprocess(js);
-      } catch (err) {
-        return {
-          valid: false,
-          aliasType: "defineAlias",
-          errors: [`Validation failed: ${err instanceof Error ? err.message : String(err)}`],
-          warnings: [],
-        };
-      }
-    });
-
     this.handlers.set("getLogs", async (params, _ctx) => {
       const { server, limit, since } = GetLogsParamsSchema.parse(params);
 
-      // Fast path: in-memory ring buffer (no since filter)
       if (since === undefined) {
         const lines = this.pool.getStderrLines(server, limit);
         return {
@@ -1010,7 +422,6 @@ export class IpcServer {
         };
       }
 
-      // Fall back to DB for since-filtered queries
       const dbLogs = this.db.getServerLogs(server, limit, since);
       return {
         server,
@@ -1028,67 +439,6 @@ export class IpcServer {
         lines = lines.filter((l) => l.timestamp > since);
       }
       return { lines };
-    });
-
-    // -- Mail handlers --
-
-    this.handlers.set("sendMail", async (params, _ctx) => {
-      const { sender, recipient, subject, body, replyTo } = SendMailParamsSchema.parse(params);
-      const id = this.db.insertMail(sender, recipient, subject, body, replyTo);
-      publishMailReceived(this.eventBus, { mailId: id, sender, recipient });
-      return { id };
-    });
-
-    this.handlers.set("readMail", async (params, _ctx) => {
-      const { recipient, unreadOnly, limit } = ReadMailParamsSchema.parse(params ?? {});
-      const messages = this.db.readMail(recipient, unreadOnly, limit);
-      return { messages };
-    });
-
-    this.handlers.set("waitForMail", async (params, _ctx) => {
-      const { recipient, timeout } = WaitForMailParamsSchema.parse(params ?? {});
-      // Server-side timeout capped at 30s to stay under IPC client's 60s timeout
-      const maxWait = Math.min((timeout ?? 30) * 1000, 30_000);
-      const deadline = Date.now() + maxWait;
-
-      while (Date.now() < deadline) {
-        if (this.draining) return { message: null };
-        const msg = this.db.getNextUnread(recipient);
-        if (msg) {
-          this.db.markMailRead(msg.id);
-          return { message: msg };
-        }
-        await Bun.sleep(500);
-      }
-      return { message: null };
-    });
-
-    this.handlers.set("replyToMail", async (params, _ctx) => {
-      const { id, sender, body, subject } = ReplyToMailParamsSchema.parse(params);
-      const original = this.db.getMailById(id);
-      if (!original) {
-        throw Object.assign(new Error(`Mail message ${id} not found`), {
-          code: IPC_ERROR.INVALID_PARAMS,
-        });
-      }
-      const replySubject = subject ?? (original.subject ? `Re: ${original.subject}` : undefined);
-      const newId = this.db.insertMail(sender, original.sender, replySubject, body, id);
-      publishMailReceived(this.eventBus, { mailId: newId, sender, recipient: original.sender });
-      return { id: newId };
-    });
-
-    this.handlers.set("markRead", async (params, _ctx) => {
-      const { id } = MarkReadParamsSchema.parse(params);
-      this.db.markMailRead(id);
-      return {};
-    });
-
-    this.handlers.set("reloadConfig", async (_params, _ctx) => {
-      if (!this.onReloadConfig) {
-        throw Object.assign(new Error("Config reload not available"), { code: IPC_ERROR.INTERNAL_ERROR });
-      }
-      await this.onReloadConfig();
-      return { ok: true };
     });
 
     this.handlers.set("getMetrics", async (_params, _ctx) => {
@@ -1110,265 +460,8 @@ export class IpcServer {
       return this.getQuotaStatus();
     });
 
-    // -- Span handlers --
-
-    this.handlers.set("getSpans", async (params, _ctx) => {
-      const { since, limit, unexported } = GetSpansParamsSchema.parse(params ?? {});
-      return { spans: this.db.getSpans({ since, limit, unexported }) };
-    });
-
-    this.handlers.set("markSpansExported", async (params, _ctx) => {
-      const { ids } = MarkSpansExportedParamsSchema.parse(params);
-      const marked = this.db.markSpansExported(ids);
-      return { marked };
-    });
-
-    this.handlers.set("pruneSpans", async (params, _ctx) => {
-      const { before } = PruneSpansParamsSchema.parse(params ?? {});
-      return { pruned: this.db.pruneSpans(before) };
-    });
-
-    // -- Serve instance tracking --
-
-    this.handlers.set("registerServe", async (params, _ctx) => {
-      const { instanceId, pid, tools } = RegisterServeParamsSchema.parse(params);
-      this.serveInstances.set(instanceId, { instanceId, pid, tools, startedAt: Date.now() });
-      return { ok: true as const };
-    });
-
-    this.handlers.set("unregisterServe", async (params, _ctx) => {
-      const { instanceId } = UnregisterServeParamsSchema.parse(params);
-      this.serveInstances.delete(instanceId);
-      return { ok: true as const };
-    });
-
-    this.handlers.set("listServeInstances", async (_params, _ctx) => {
-      this.pruneStaleServeInstances();
-      return [...this.serveInstances.values()];
-    });
-
-    this.handlers.set("killServe", async (params, _ctx) => {
-      const { instanceId, pid, all, staleHours } = KillServeParamsSchema.parse(params ?? {});
-
-      if (!instanceId && pid == null && !all && staleHours == null) {
-        throw Object.assign(new Error("Specify instanceId, pid, all, or staleHours"), {
-          code: IPC_ERROR.INVALID_PARAMS,
-        });
-      }
-
-      this.pruneStaleServeInstances();
-
-      const targets: ServeInstanceInfo[] = [];
-      if (staleHours != null) {
-        const cutoff = Date.now() - staleHours * 60 * 60 * 1000;
-        for (const inst of this.serveInstances.values()) {
-          if (inst.startedAt < cutoff) targets.push(inst);
-        }
-      } else if (all) {
-        targets.push(...this.serveInstances.values());
-      } else if (instanceId) {
-        const inst = this.serveInstances.get(instanceId);
-        if (!inst) {
-          throw Object.assign(new Error(`Serve instance "${instanceId}" not found`), {
-            code: IPC_ERROR.SERVER_NOT_FOUND,
-          });
-        }
-        targets.push(inst);
-      } else if (pid != null) {
-        for (const inst of this.serveInstances.values()) {
-          if (inst.pid === pid) targets.push(inst);
-        }
-        if (targets.length === 0) {
-          throw Object.assign(new Error(`No serve instance with PID ${pid}`), {
-            code: IPC_ERROR.SERVER_NOT_FOUND,
-          });
-        }
-      }
-
-      for (const inst of targets) {
-        await killPid(inst.pid, this.logger);
-        this.serveInstances.delete(inst.instanceId);
-      }
-
-      return { killed: targets.length };
-    });
-
-    // -- Note handlers --
-
-    this.handlers.set("setNote", async (params, _ctx) => {
-      const { server, tool, note } = SetNoteParamsSchema.parse(params);
-      this.db.setNote(server, tool, note);
-      return { ok: true as const };
-    });
-
-    this.handlers.set("getNote", async (params, _ctx) => {
-      const { server, tool } = GetNoteParamsSchema.parse(params);
-      const note = this.db.getNote(server, tool);
-      return { note: note ?? null };
-    });
-
-    this.handlers.set("listNotes", async (_params, _ctx) => {
-      return this.db.listNotes();
-    });
-
-    this.handlers.set("deleteNote", async (params, _ctx) => {
-      const { server, tool } = DeleteNoteParamsSchema.parse(params);
-      const deleted = this.db.deleteNote(server, tool);
-      return { ok: true as const, deleted };
-    });
-
-    // -- Work item tracking --
-
-    this.handlers.set("trackWorkItem", async (params, _ctx) => {
-      const { number, branch, initialPhase, repoRoot } = TrackWorkItemParamsSchema.parse(params);
-
-      // Validate initialPhase server-side when a manifest is available (#1351).
-      // When no manifest is present (repoRoot absent or manifest missing), accept any string.
-      if (initialPhase && repoRoot && this.loadManifestFn) {
-        const manifest = this.loadManifestFn(repoRoot);
-        if (manifest) {
-          const declared = Object.keys(manifest.phases);
-          if (!declared.includes(initialPhase)) {
-            throw Object.assign(
-              new Error(`unknown initialPhase "${initialPhase}". declared phases: ${declared.join(", ")}.`),
-              { code: IPC_ERROR.INVALID_PARAMS },
-            );
-          }
-        }
-      }
-
-      // Check if already tracked
-      if (number) {
-        const existing = this.workItemDb.getWorkItemByIssue(number) ?? this.workItemDb.getWorkItem(`#${number}`);
-        if (existing) {
-          // 🔴 Backfill: if prNumber is null, kick off background re-resolution
-          if (existing.prNumber === null && this.resolveIssuePr) {
-            this.resolveAndUpdateWorkItem(existing.id, number);
-          }
-          return existing;
-        }
-      } else if (branch) {
-        const existing = this.workItemDb.getWorkItemByBranch(branch);
-        if (existing) return existing;
-      }
-
-      // Create the item immediately (non-blocking) so the caller isn't waiting on GitHub
-      const id = number ? `#${number}` : `branch:${branch}`;
-      const item = this.workItemDb.createWorkItem({
-        id,
-        issueNumber: number ?? null,
-        prNumber: null,
-        branch: branch ?? null,
-        ...(initialPhase ? { phase: initialPhase as WorkItemPhase } : {}),
-      });
-
-      // Fire-and-forget: resolve PR number in the background
-      if (number && this.resolveIssuePr) {
-        this.resolveAndUpdateWorkItem(id, number);
-      }
-
-      return item;
-    });
-
-    this.handlers.set("untrackWorkItem", async (params, _ctx) => {
-      const { number, branch } = UntrackWorkItemParamsSchema.parse(params);
-
-      if (branch) {
-        const existing = this.workItemDb.getWorkItemByBranch(branch) ?? this.workItemDb.getWorkItem(`branch:${branch}`);
-        if (existing) {
-          this.workItemDb.deleteWorkItem(existing.id);
-          return { ok: true as const, deleted: true };
-        }
-        return { ok: true as const, deleted: false };
-      }
-
-      // Number-based lookup (number is guaranteed non-null when branch is absent per schema refine)
-      const num = number as number;
-      const existing =
-        this.workItemDb.getWorkItemByPr(num) ??
-        this.workItemDb.getWorkItemByIssue(num) ??
-        this.workItemDb.getWorkItem(`#${num}`);
-      if (existing) {
-        this.workItemDb.deleteWorkItem(existing.id);
-        return { ok: true as const, deleted: true };
-      }
-      return { ok: true as const, deleted: false };
-    });
-
-    this.handlers.set("listWorkItems", async (params, _ctx) => {
-      const { phase } = ListWorkItemsParamsSchema.parse(params ?? {});
-      return this.workItemDb.listWorkItems(phase ? { phase } : undefined);
-    });
-
-    this.handlers.set("getWorkItem", async (params, _ctx) => {
-      const { id, number, branch } = GetWorkItemParamsSchema.parse(params);
-      if (id) return this.workItemDb.getWorkItem(id);
-      if (number !== undefined) {
-        return this.workItemDb.getWorkItemByPr(number) ?? this.workItemDb.getWorkItemByIssue(number);
-      }
-      if (branch) return this.workItemDb.getWorkItemByBranch(branch);
-      return null;
-    });
-
-    // -- Alias state (per-work-item / per-alias scratchpad) --
-
-    this.handlers.set("aliasStateGet", async (params, _ctx) => {
-      const parsed = AliasStateGetParamsSchema.parse(params);
-      const repoRoot = resolveRealpath(resolve(parsed.repoRoot));
-      return { value: this.db.getAliasState(repoRoot, parsed.namespace, parsed.key) };
-    });
-
-    this.handlers.set("aliasStateSet", async (params, _ctx) => {
-      const parsed = AliasStateSetParamsSchema.parse(params);
-      const repoRoot = resolveRealpath(resolve(parsed.repoRoot));
-      this.db.setAliasState(repoRoot, parsed.namespace, parsed.key, parsed.value);
-      return { ok: true as const };
-    });
-
-    this.handlers.set("aliasStateDelete", async (params, _ctx) => {
-      const parsed = AliasStateDeleteParamsSchema.parse(params);
-      const repoRoot = resolveRealpath(resolve(parsed.repoRoot));
-      const deleted = this.db.deleteAliasState(repoRoot, parsed.namespace, parsed.key);
-      return { ok: true as const, deleted };
-    });
-
-    this.handlers.set("aliasStateAll", async (params, _ctx) => {
-      const parsed = AliasStateAllParamsSchema.parse(params);
-      const repoRoot = resolveRealpath(resolve(parsed.repoRoot));
-      return { entries: this.db.listAliasState(repoRoot, parsed.namespace) };
-    });
-
-    this.handlers.set("getBudgetConfig", async () => {
-      return this.db.getBudgetConfig();
-    });
-
-    this.handlers.set("setBudgetConfig", async (params) => {
-      const parsed = SetBudgetConfigParamsSchema.parse(params);
-      this.db.setBudgetConfig(parsed);
-      return { ok: true as const };
-    });
-
-    this.handlers.set("publishEvent", async (params, _ctx) => {
-      const parsed = PublishEventParamsSchema.parse(params);
-      if (!this.eventBus) {
-        throw Object.assign(new Error("EventBus not available"), { code: IPC_ERROR.INTERNAL_ERROR });
-      }
-      const input: MonitorEventInput = {
-        ...(parsed.extra && parsed.extra),
-        src: parsed.src,
-        event: parsed.event,
-        category: parsed.category,
-        ...(parsed.sessionId !== undefined && { sessionId: parsed.sessionId }),
-        ...(parsed.workItemId !== undefined && { workItemId: parsed.workItemId }),
-        ...(parsed.prNumber !== undefined && { prNumber: parsed.prNumber }),
-      };
-      const published = this.eventBus.publish(input);
-      return { ok: true as const, seq: published.seq };
-    });
-
     this.handlers.set("shutdown", async (params, _ctx) => {
       const { force } = ShutdownParamsSchema.parse(params ?? {});
-      // Check force BEFORE querying DB — --force is the escape hatch when DB is degraded
       if (!force) {
         const activeSessions = this.db.listSessions(true);
         if (activeSessions.length > 0) {
@@ -1379,586 +472,10 @@ export class IpcServer {
           };
         }
       }
-      // Enter drain mode — onShutdown fires after all in-flight responses are sent
       this.draining = true;
       this.startDrainTimeout();
       return { ok: true };
     });
-  }
-
-  /**
-   * Push an event to all connected NDJSON event stream subscribers.
-   * Each event is assigned a monotonically increasing sequence number.
-   * The envelope shape is `{ t: string, seq: number, ...payload }` —
-   * callers supply the full object including `t`.
-   */
-  pushEvent(event: Record<string, unknown>): void {
-    const seq = ++this.eventSeq;
-    const envelope = { ...event, seq };
-    const failed: ((event: Record<string, unknown>) => void)[] = [];
-    for (const cb of this.eventSubscribers) {
-      try {
-        cb(envelope);
-      } catch (err) {
-        this.logger.warn(`[events] subscriber threw, dropping: ${err}`);
-        failed.push(cb);
-      }
-    }
-    for (const cb of failed) this.eventSubscribers.delete(cb);
-  }
-
-  /** Current event sequence number (for testing / status). */
-  get currentEventSeq(): number {
-    return this.eventSeq;
-  }
-
-  /** Number of active event stream subscribers (for testing). */
-  get eventSubscriberCount(): number {
-    return this.eventSubscribers.size;
-  }
-
-  private static readonly EVENT_RING_CAPACITY = 256;
-  private static readonly HEARTBEAT_INTERVAL_MS = 30_000;
-  static readonly MAX_EVENT_BUS_SUBSCRIBERS = 64;
-  /** Heartbeat interval for the EventBus NDJSON path — shorter to detect dead peers faster (#1557). */
-  private static readonly EVENTBUS_HEARTBEAT_MS = 15_000;
-  /** Prune EventBus subscribers that haven't delivered an event in this window (#1557). */
-  private static readonly EVENTBUS_SUB_TTL_MS = 10 * 60_000;
-  /** Max entries in liveBuffer during backfill before dropping oldest (#1589). */
-  static readonly LIVE_BUFFER_MAX_ENTRIES = 10_000;
-  /** Max UTF-8 byte size of liveBuffer during backfill before dropping oldest (#1589). */
-  static readonly LIVE_BUFFER_MAX_BYTES = 10 * 1024 * 1024; // 10 MB
-  /** Backfill batch size for /events `since=<seq>` replay. Test-mutable. */
-  static BACKFILL_BATCH_SIZE = 1000;
-  /**
-   * Optional async hook called at each backfill yield point. Runs *before* the
-   * default `setTimeout(0)` yield (never replaces it). Tests inject live events
-   * here to guarantee they land in `liveBuffer` during the backfill window.
-   */
-  static BACKFILL_YIELD_FN: (() => Promise<void>) | null = null;
-
-  /**
-   * Handle GET /logs — Server-Sent Events stream for real-time log tailing.
-   *
-   * Query params:
-   *   server=<name>  — stream stderr from a specific MCP server
-   *   daemon=true    — stream daemon logs
-   *   lines=<n>      — number of initial backfill lines (default 50)
-   *   since=<ts>     — only backfill lines after this timestamp (ms)
-   */
-  private handleLogsSSE(url: URL): Response {
-    const serverName = url.searchParams.get("server");
-    const isDaemon = url.searchParams.get("daemon") === "true";
-    const lines = Number(url.searchParams.get("lines") ?? "50");
-    const since = url.searchParams.has("since") ? Number(url.searchParams.get("since")) : undefined;
-
-    if (!serverName && !isDaemon) {
-      return new Response("Missing ?server=<name> or ?daemon=true", { status: 400 });
-    }
-
-    let unsubscribe: (() => void) | undefined;
-
-    const stream = new ReadableStream({
-      start: (controller) => {
-        const encoder = new TextEncoder();
-        const send = (entry: { timestamp: number; line: string }) => {
-          try {
-            const data = JSON.stringify({ timestamp: entry.timestamp, line: entry.line });
-            controller.enqueue(encoder.encode(`data: ${data}\n\n`));
-          } catch {
-            // Stream closed — clean up
-            unsubscribe?.();
-          }
-        };
-
-        // Backfill initial lines
-        if (isDaemon) {
-          let backfill = getDaemonLogLines(lines);
-          if (since !== undefined) {
-            backfill = backfill.filter((l) => l.timestamp > since);
-          }
-          for (const entry of backfill) {
-            send(entry);
-          }
-        } else if (serverName) {
-          let backfill = this.pool.getStderrLines(serverName, since === undefined ? lines : undefined);
-          if (since !== undefined) {
-            backfill = backfill.filter((l) => l.timestamp > since);
-            if (backfill.length > lines) backfill = backfill.slice(-lines);
-          }
-          for (const entry of backfill) {
-            send(entry);
-          }
-        }
-
-        // Subscribe to new lines
-        if (isDaemon) {
-          unsubscribe = subscribeDaemonLogs((entry) => send(entry));
-        } else if (serverName) {
-          unsubscribe = this.pool.subscribeStderr((server, entry) => {
-            if (server !== serverName) return;
-            send(entry);
-          });
-        }
-      },
-      cancel: () => {
-        unsubscribe?.();
-      },
-    });
-
-    return new Response(stream, {
-      headers: {
-        "content-type": "text/event-stream",
-        "cache-control": "no-cache",
-        connection: "keep-alive",
-      },
-    });
-  }
-
-  /**
-   * Handle GET /events — NDJSON stream for real-time event delivery.
-   *
-   * When an EventBus is configured (unified monitor architecture, #1512):
-   *   Uses EventBus subscriptions with session.response suppression and responseTail opt-in.
-   *
-   * Fallback (no EventBus, direct push via pushEvent()):
-   *   Uses ring-buffer based delivery with connected/heartbeat envelope,
-   *   plus durable log replay when since=<seq> is provided (#1513).
-   *
-   * Query params:
-   *   subscribe=<categories>   Comma-separated category filter (session,work_item,mail)
-   *   session=<id>             Filter to one session ID
-   *   pr=<n>                   Filter to one PR number
-   *   workItem=<id>            Filter to one work item ID
-   *   type=<glob>              Event name glob filter (comma-separated OR, e.g. "pr.*,session.idle")
-   *   src=<pattern>            Source attribution glob filter (e.g. "daemon.*")
-   *   phase=<name>             Phase filter on work item phase
-   *   since=<seq>              Replay events after this cursor from the durable log,
-   *                            then seamlessly switch to live delivery (#1513)
-   *   responseTail=<sessionId> Include session.response chunks for this session only
-   *
-   * Each event is emitted as one JSON line followed by a newline character.
-   * session.response events are excluded by default unless responseTail matches.
-   */
-  private handleEventsNDJSON(url: URL): Response {
-    const sinceParam = url.searchParams.get("since");
-    let sinceSeq: number | null = null;
-    if (sinceParam !== null) {
-      const parsed = Number(sinceParam);
-      if (sinceParam.trim() === "" || !Number.isInteger(parsed) || parsed < 0) {
-        return new Response("since must be a non-negative integer", { status: 400 });
-      }
-      sinceSeq = parsed;
-    }
-    const eventLog = this.eventBus?.eventLog ?? null;
-
-    const prRaw = url.searchParams.get("pr");
-    if (prRaw !== null && !(Number.isInteger(Number(prRaw)) && Number(prRaw) >= 1)) {
-      return new Response("pr must be a positive integer", { status: 400 });
-    }
-
-    // Return 400 rather than silently delivering a live-only stream when the client
-    // provides a valid since cursor but the durable event log is unavailable (#1558).
-    // sinceSeq is guaranteed non-negative integer here (invalid values returned 400 above).
-    if (sinceSeq !== null && !eventLog) {
-      return new Response("since parameter requires the durable event log; replay is not available on this daemon", {
-        status: 400,
-      });
-    }
-
-    // ── EventBus path (unified monitor architecture, #1512/#1515) ──
-    if (this.eventBus) {
-      const responseTail = url.searchParams.get("responseTail");
-      const eventFilter = buildEventFilter(url.searchParams);
-
-      const shouldDeliver = (event: { event: string; sessionId?: string }) => {
-        if (eventFilter !== null && !eventFilter(event as Record<string, unknown>)) return false;
-        if (event.event === "session.response") {
-          return responseTail !== null && event.sessionId === responseTail;
-        }
-        return true;
-      };
-
-      const bus = this.eventBus;
-
-      if (bus.subscriberCount >= IpcServer.MAX_EVENT_BUS_SUBSCRIBERS) {
-        this.logger.warn(
-          `[events] subscriber limit reached (${IpcServer.MAX_EVENT_BUS_SUBSCRIBERS}), rejecting connection`,
-        );
-        return new Response("too many event stream subscribers", { status: 503 });
-      }
-
-      let subId: number | null = null;
-      let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
-
-      const encoder = new TextEncoder();
-      const subscriberGauge = metrics.gauge("mcpd_event_bus_subscribers");
-
-      // Shared cleanup: unsubscribe from EventBus, update gauge, and clear heartbeat timer.
-      const cleanup = () => {
-        if (subId !== null) {
-          bus.unsubscribe(subId);
-          subId = null;
-          subscriberGauge.dec();
-        }
-        if (heartbeatTimer !== undefined) {
-          clearInterval(heartbeatTimer);
-          heartbeatTimer = undefined;
-        }
-      };
-
-      // Use byte-based backpressure so desiredSize reflects buffered bytes, not chunk count.
-      // 1 MB high-water mark: desiredSize stays positive for normal traffic, goes ≤ 0 only
-      // when the consumer falls more than 1 MB behind (live or backfill).
-      const stream = new ReadableStream(
-        {
-          start: async (controller) => {
-            // Flush an initial newline so Bun sends response headers immediately.
-            // Without this, headers are buffered until the first event arrives.
-            controller.enqueue(encoder.encode("\n"));
-
-            // Buffer live events during backfill to avoid gaps or duplicates.
-            // Bounded: whichever of entry count or byte size is hit first triggers
-            // drop-oldest eviction. Overflow emits a gap control message. (#1589)
-            let liveBuffer: Array<{ line: string; bytes: number; seq: number | undefined }> | null =
-              sinceSeq !== null && eventLog ? [] : null;
-            let liveBufferBytes = 0;
-            let liveBufferDropped = 0;
-            let liveBufferHead = 0;
-            let firstDroppedSeq: number | undefined;
-            let lastDroppedSeq: number | undefined;
-            let highWaterMark = 0;
-
-            const maxEntries = IpcServer.LIVE_BUFFER_MAX_ENTRIES;
-            const maxBytes = IpcServer.LIVE_BUFFER_MAX_BYTES;
-
-            subId = bus.subscribe(
-              (_event, serialized) => {
-                // Backpressure guard: if the stream's internal queue is full, the
-                // consumer is too slow. Disconnect rather than buffer unboundedly.
-                if (controller.desiredSize !== null && controller.desiredSize <= 0) {
-                  this.logger.warn("[events] slow consumer detected, dropping subscriber");
-                  metrics.counter("mcpd_event_bus_slow_drops_total").inc();
-                  cleanup();
-                  try {
-                    controller.error(new Error("slow consumer"));
-                  } catch {
-                    // already closed
-                  }
-                  return;
-                }
-                try {
-                  const line = `${serialized}\n`;
-                  if (liveBuffer !== null) {
-                    const lineBytes = encoder.encode(line).byteLength;
-                    let seq: number | undefined;
-                    try {
-                      const p = JSON.parse(serialized) as Record<string, unknown>;
-                      seq = typeof p.seq === "number" ? p.seq : undefined;
-                    } catch {
-                      /* non-JSON event — skip seq tracking */
-                    }
-                    // Reject single events that exceed the byte cap on their own.
-                    if (liveBufferHead >= liveBuffer.length && lineBytes > maxBytes) {
-                      liveBufferDropped++;
-                      if (seq !== undefined) {
-                        firstDroppedSeq ??= seq;
-                        lastDroppedSeq = seq;
-                      }
-                      return;
-                    }
-                    // Evict from head while buffer exceeds either cap (O(1) via head pointer).
-                    while (
-                      liveBufferHead < liveBuffer.length &&
-                      (liveBuffer.length - liveBufferHead >= maxEntries || liveBufferBytes + lineBytes > maxBytes)
-                    ) {
-                      const evicted = liveBuffer[liveBufferHead];
-                      if (!evicted) break;
-                      liveBufferBytes -= evicted.bytes;
-                      if (evicted.seq !== undefined) {
-                        firstDroppedSeq ??= evicted.seq;
-                        lastDroppedSeq = evicted.seq;
-                      }
-                      liveBufferHead++;
-                      liveBufferDropped++;
-                    }
-                    liveBuffer.push({ line, bytes: lineBytes, seq });
-                    liveBufferBytes += lineBytes;
-                  } else {
-                    controller.enqueue(encoder.encode(line));
-                  }
-                } catch {
-                  // Stream closed
-                  cleanup();
-                }
-              },
-              (event) => shouldDeliver(event),
-            );
-            subscriberGauge.inc();
-
-            // Backfill from durable log when client provides a valid cursor.
-            // Async: yields between batches so the event loop stays responsive. (#1589)
-            if (sinceSeq !== null && !Number.isNaN(sinceSeq) && sinceSeq >= 0 && eventLog) {
-              let cursor = sinceSeq;
-              const batchSize = IpcServer.BACKFILL_BATCH_SIZE;
-              while (true) {
-                const batch = eventLog.getSince(cursor, batchSize);
-                for (const event of batch) {
-                  highWaterMark = event.seq;
-                  if (!shouldDeliver(event)) continue;
-                  if (controller.desiredSize !== null && controller.desiredSize <= 0) {
-                    this.logger.warn("[events] slow consumer during backfill, dropping subscriber");
-                    metrics.counter("mcpd_event_bus_slow_drops_total").inc();
-                    cleanup();
-                    try {
-                      controller.error(new Error("slow consumer"));
-                    } catch {
-                      // already closed
-                    }
-                    return;
-                  }
-                  try {
-                    controller.enqueue(encoder.encode(`${JSON.stringify(event)}\n`));
-                  } catch {
-                    cleanup();
-                    return;
-                  }
-                }
-                if (batch.length < batchSize) break;
-                cursor = batch[batch.length - 1]?.seq ?? cursor;
-                // Yield to the event loop between batches so other IPC work isn't starved.
-                await IpcServer.BACKFILL_YIELD_FN?.();
-                await new Promise<void>((r) => setTimeout(r, 0));
-              }
-              // Drain buffered live events; seq-based HWM drops overlaps.
-              const buffered = liveBuffer ?? [];
-              const drainStart = liveBufferHead;
-              liveBuffer = null;
-
-              // Emit gap control message if liveBuffer overflowed during backfill.
-              if (liveBufferDropped > 0) {
-                const gap: Record<string, unknown> = { t: "gap", dropped: liveBufferDropped };
-                if (firstDroppedSeq !== undefined) gap.firstDroppedSeq = firstDroppedSeq;
-                if (lastDroppedSeq !== undefined) gap.lastDroppedSeq = lastDroppedSeq;
-                try {
-                  controller.enqueue(encoder.encode(`${JSON.stringify(gap)}\n`));
-                } catch {
-                  cleanup();
-                  return;
-                }
-              }
-
-              for (let i = drainStart; i < buffered.length; i++) {
-                const entry = buffered[i];
-                if (!entry) continue;
-                if (controller.desiredSize !== null && controller.desiredSize <= 0) {
-                  this.logger.warn("[events] slow consumer during backfill drain, dropping subscriber");
-                  metrics.counter("mcpd_event_bus_slow_drops_total").inc();
-                  cleanup();
-                  try {
-                    controller.error(new Error("slow consumer"));
-                  } catch {
-                    // already closed
-                  }
-                  return;
-                }
-                try {
-                  if (entry.seq !== undefined && entry.seq <= highWaterMark) continue;
-                  controller.enqueue(encoder.encode(entry.line));
-                } catch {
-                  cleanup();
-                  return;
-                }
-              }
-            }
-
-            // Periodic heartbeat newline to detect dead peers (#1557).
-            // On success, touch the subscriber so quiet-but-live streams aren't pruned (#1649).
-            // On write failure, cleanup unsubscribes and stops the timer.
-            // Also prunes stale EventBus subscribers on each tick as a secondary defense.
-            heartbeatTimer = setInterval(() => {
-              try {
-                controller.enqueue(encoder.encode("\n"));
-              } catch {
-                cleanup();
-                return;
-              }
-              if (subId !== null) bus.touch(subId);
-              bus.pruneStale(IpcServer.EVENTBUS_SUB_TTL_MS);
-            }, IpcServer.EVENTBUS_HEARTBEAT_MS);
-            heartbeatTimer.unref();
-          },
-          cancel: cleanup,
-        },
-        new ByteLengthQueuingStrategy({ highWaterMark: 1024 * 1024 }),
-      );
-
-      return new Response(stream, {
-        headers: {
-          "content-type": "application/x-ndjson",
-          "cache-control": "no-cache",
-          connection: "keep-alive",
-        },
-      });
-    }
-
-    // ── Ring-buffer fallback path (direct pushEvent(), no EventBus) ──
-    const filter = buildEventFilter(url.searchParams);
-    const fallbackResponseTail = url.searchParams.get("responseTail");
-    const shouldDeliverFallback = (event: Record<string, unknown>) => {
-      if (filter !== null && !filter(event)) return false;
-      if (event.event === "session.response") {
-        return fallbackResponseTail !== null && event.sessionId === fallbackResponseTail;
-      }
-      return true;
-    };
-    const capacity = IpcServer.EVENT_RING_CAPACITY;
-    const ring: string[] = new Array(capacity);
-    let writeIdx = 0;
-    let dropped = 0;
-    let pending = false;
-    let unsubscribe: (() => void) | undefined;
-    let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
-    let lastWriteTime = Date.now();
-
-    const encoder = new TextEncoder();
-
-    // Hoisted so both start and cancel can share it
-    const cleanup = () => {
-      unsubscribe?.();
-      unsubscribe = undefined;
-      if (heartbeatTimer !== undefined) {
-        clearInterval(heartbeatTimer);
-        heartbeatTimer = undefined;
-      }
-    };
-
-    const stream = new ReadableStream({
-      start: (controller) => {
-        // Track the highest seq sent so live events can skip duplicates
-        // after backfill.
-        let highWaterMark = 0;
-
-        const flush = () => {
-          if (!pending) return;
-          pending = false;
-          const count = dropped > 0 ? capacity : writeIdx;
-          const start = dropped > 0 ? dropped % capacity : 0;
-          for (let i = 0; i < count; i++) {
-            const line = ring[(start + i) % capacity] as string;
-            try {
-              controller.enqueue(encoder.encode(line));
-            } catch {
-              cleanup();
-              return;
-            }
-          }
-          writeIdx = 0;
-          dropped = 0;
-        };
-
-        const enqueue = (line: string, seq?: number) => {
-          if (seq !== undefined && seq <= highWaterMark) return;
-          if (seq !== undefined) highWaterMark = seq;
-          if (writeIdx < capacity) {
-            ring[writeIdx++] = line;
-          } else {
-            ring[dropped % capacity] = line;
-            dropped++;
-          }
-          pending = true;
-          lastWriteTime = Date.now();
-          queueMicrotask(flush);
-        };
-
-        // Flush a "connected" line to force response headers out immediately
-        controller.enqueue(encoder.encode(`${JSON.stringify({ t: "connected", seq: this.eventSeq })}\n`));
-        lastWriteTime = Date.now();
-
-        // Subscribe to live events BEFORE backfilling so nothing is missed
-        // during the gap between query and subscription. Live events are
-        // buffered during backfill and drained after to preserve ordering.
-        let liveBuffer: Array<{ line: string; seq: number | undefined }> | null = null;
-        const subscriber = (event: Record<string, unknown>) => {
-          if (!shouldDeliverFallback(event)) return;
-          const line = `${JSON.stringify(event)}\n`;
-          const seq = typeof event.seq === "number" ? event.seq : undefined;
-          if (liveBuffer !== null) {
-            liveBuffer.push({ line, seq });
-          } else {
-            enqueue(line, seq);
-          }
-        };
-
-        this.eventSubscribers.add(subscriber);
-        unsubscribe = () => {
-          this.eventSubscribers.delete(subscriber);
-        };
-
-        // Backfill from durable log when client provides a valid cursor
-        if (sinceSeq !== null && !Number.isNaN(sinceSeq) && sinceSeq >= 0 && eventLog) {
-          liveBuffer = [];
-          let cursor = sinceSeq;
-          while (true) {
-            const batch = eventLog.getSince(cursor, 1000);
-            for (const event of batch) {
-              highWaterMark = event.seq;
-              if (!shouldDeliverFallback(event as Record<string, unknown>)) continue;
-              const line = `${JSON.stringify(event)}\n`;
-              try {
-                controller.enqueue(encoder.encode(line));
-              } catch {
-                cleanup();
-                return;
-              }
-            }
-            if (batch.length < 1000) break;
-            cursor = batch[batch.length - 1]?.seq ?? cursor;
-          }
-          // Drain buffered live events; HWM dedup in enqueue() drops overlaps.
-          const buffered = liveBuffer;
-          liveBuffer = null;
-          for (const { line, seq } of buffered) {
-            enqueue(line, seq);
-          }
-          lastWriteTime = Date.now();
-        }
-
-        heartbeatTimer = setInterval(() => {
-          if (Date.now() - lastWriteTime >= IpcServer.HEARTBEAT_INTERVAL_MS) {
-            const hb = `${JSON.stringify({ category: "heartbeat", event: "heartbeat", seq: this.eventSeq, src: "daemon", ts: new Date().toISOString() })}\n`;
-            try {
-              controller.enqueue(encoder.encode(hb));
-              lastWriteTime = Date.now();
-            } catch {
-              cleanup();
-            }
-          }
-        }, IpcServer.HEARTBEAT_INTERVAL_MS);
-        heartbeatTimer.unref();
-      },
-      cancel: cleanup,
-    });
-
-    return new Response(stream, {
-      headers: {
-        "content-type": "application/x-ndjson",
-        "transfer-encoding": "chunked",
-        "cache-control": "no-cache",
-        connection: "keep-alive",
-      },
-    });
-  }
-
-  /** Remove serve instances whose PID is no longer alive. */
-  private pruneStaleServeInstances(): void {
-    for (const [id, info] of this.serveInstances) {
-      try {
-        process.kill(info.pid, 0);
-      } catch {
-        this.serveInstances.delete(id);
-      }
-    }
   }
 }
 

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -19,7 +19,6 @@ import type {
   ServeInstanceInfo,
 } from "@mcp-cli/core";
 import {
-  BUILD_VERSION,
   GetDaemonLogsParamsSchema,
   GetLogsParamsSchema,
   IPC_ERROR,
@@ -256,7 +255,7 @@ export class IpcServer {
    * HEARTBEAT_INTERVAL_MS is owned here; patch it before constructing IpcServer and
    * the value is forwarded to EventStreamServer at construction time.
    *
-   * The remaining four (MAX_EVENT_BUS_SUBSCRIBERS, LIVE_BUFFER_MAX_ENTRIES,
+   * The remaining five (MAX_EVENT_BUS_SUBSCRIBERS, LIVE_BUFFER_MAX_ENTRIES,
    * LIVE_BUFFER_MAX_BYTES, BACKFILL_BATCH_SIZE, BACKFILL_YIELD_FN) are proxy
    * getter/setter pairs that read/write EventStreamServer's statics directly —
    * mutating them takes effect immediately on any live instance.
@@ -364,7 +363,7 @@ export class IpcServer {
     onAliasChanged: ((name: string) => void) | null;
   }): void {
     const serveHandlers = new ServeHandlers(this.serveInstances, this.logger);
-    new AuthHandlers(this.pool, this.logger).register(this.handlers);
+    new AuthHandlers(this.pool).register(this.handlers);
     new AliasHandlers(this.db, deps.aliasServer, this.logger, deps.onAliasChanged ?? undefined).register(this.handlers);
     new WorkItemHandlers(deps.workItemDb, this.db, deps.resolveIssuePr, deps.loadManifestFn, this.logger).register(
       this.handlers,
@@ -376,7 +375,7 @@ export class IpcServer {
     new ConfigHandlers(this.pool, this.config, this.onReloadConfig).register(this.handlers);
     new MailHandlers(this.db, deps.eventBus, () => this.draining).register(this.handlers);
     new NoteHandlers(this.db).register(this.handlers);
-    new ToolHandlers(this.pool, this.db, deps.aliasServer, this.daemonId, this.logger).register(this.handlers);
+    new ToolHandlers(this.pool, this.db, deps.aliasServer, this.daemonId).register(this.handlers);
     new StatusHandler(this.pool, this.db, serveHandlers, this.serveInstances, this.getWsPortInfo).register(
       this.handlers,
     );

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -47,11 +47,11 @@ import { EventHandlers } from "./handlers/event";
 import { MailHandlers } from "./handlers/mail";
 import { NoteHandlers } from "./handlers/note";
 import { ServeHandlers } from "./handlers/serve";
+import { StatusHandler } from "./handlers/status";
 import { TelemetryHandlers } from "./handlers/telemetry";
 import { ToolHandlers } from "./handlers/tool";
 import { WorkItemHandlers } from "./handlers/work-item";
 import { metrics } from "./metrics";
-import { getPortHolder } from "./port-holder";
 import type { ServerPool } from "./server-pool";
 
 // Re-export for backward compat with existing tests and external code.
@@ -78,7 +78,6 @@ export class IpcServer {
   private startedAt: number;
   private logger: Logger;
   private eventStream: EventStreamServer;
-  private serveHandlers: ServeHandlers;
 
   constructor(
     private pool: ServerPool,
@@ -117,7 +116,6 @@ export class IpcServer {
     const eventBus = opts.eventBus ?? null;
 
     this.eventStream = new EventStreamServer(eventBus, this.pool, this.logger, IpcServer.HEARTBEAT_INTERVAL_MS);
-    this.serveHandlers = new ServeHandlers(this.serveInstances, this.logger);
 
     this.registerHandlers({
       aliasServer,
@@ -252,7 +250,17 @@ export class IpcServer {
     return this.eventStream.eventSubscriberCount;
   }
 
-  /** Test-mutable: patch before construction to change heartbeat cadence. */
+  /**
+   * Test-mutable statics.
+   *
+   * HEARTBEAT_INTERVAL_MS is owned here; patch it before constructing IpcServer and
+   * the value is forwarded to EventStreamServer at construction time.
+   *
+   * The remaining four (MAX_EVENT_BUS_SUBSCRIBERS, LIVE_BUFFER_MAX_ENTRIES,
+   * LIVE_BUFFER_MAX_BYTES, BACKFILL_BATCH_SIZE, BACKFILL_YIELD_FN) are proxy
+   * getter/setter pairs that read/write EventStreamServer's statics directly —
+   * mutating them takes effect immediately on any live instance.
+   */
   static HEARTBEAT_INTERVAL_MS = 30_000;
   static get MAX_EVENT_BUS_SUBSCRIBERS() {
     return EventStreamServer.MAX_EVENT_BUS_SUBSCRIBERS;
@@ -355,12 +363,13 @@ export class IpcServer {
     loadManifestFn: ((repoRoot: string) => Manifest | null) | null;
     onAliasChanged: ((name: string) => void) | null;
   }): void {
+    const serveHandlers = new ServeHandlers(this.serveInstances, this.logger);
     new AuthHandlers(this.pool, this.logger).register(this.handlers);
     new AliasHandlers(this.db, deps.aliasServer, this.logger, deps.onAliasChanged ?? undefined).register(this.handlers);
     new WorkItemHandlers(deps.workItemDb, this.db, deps.resolveIssuePr, deps.loadManifestFn, this.logger).register(
       this.handlers,
     );
-    this.serveHandlers.register(this.handlers);
+    serveHandlers.register(this.handlers);
     new BudgetHandlers(this.db).register(this.handlers);
     new EventHandlers(deps.eventBus).register(this.handlers);
     new TelemetryHandlers(this.db).register(this.handlers);
@@ -368,6 +377,9 @@ export class IpcServer {
     new MailHandlers(this.db, deps.eventBus, () => this.draining).register(this.handlers);
     new NoteHandlers(this.db).register(this.handlers);
     new ToolHandlers(this.pool, this.db, deps.aliasServer, this.daemonId, this.logger).register(this.handlers);
+    new StatusHandler(this.pool, this.db, serveHandlers, this.serveInstances, this.getWsPortInfo).register(
+      this.handlers,
+    );
 
     // -- Core infrastructure handlers --
 
@@ -376,39 +388,6 @@ export class IpcServer {
       time: Date.now(),
       protocolVersion: PROTOCOL_VERSION,
     }));
-
-    this.handlers.set("status", async (_params, _ctx) => {
-      const servers = this.pool.listServers();
-      const usageStats = this.db.getUsageStats();
-
-      for (const server of servers) {
-        const serverStats = usageStats.filter((s) => s.serverName === server.name);
-        if (serverStats.length > 0) {
-          server.callCount = serverStats.reduce((sum, s) => sum + s.callCount, 0);
-          server.errorCount = serverStats.reduce((sum, s) => sum + s.errorCount, 0);
-          const totalDuration = serverStats.reduce((sum, s) => sum + s.totalDurationMs, 0);
-          server.avgDurationMs = Math.round(totalDuration / server.callCount);
-        }
-      }
-
-      const wsPortInfo = this.getWsPortInfo?.();
-      const hasMismatch = wsPortInfo != null && wsPortInfo.actual != null && wsPortInfo.actual !== wsPortInfo.expected;
-      const wsPortHolder = hasMismatch ? await getPortHolder(wsPortInfo.expected) : null;
-      this.serveHandlers.pruneStaleInstances();
-      return {
-        pid: process.pid,
-        uptime: process.uptime(),
-        protocolVersion: PROTOCOL_VERSION,
-        daemonVersion: BUILD_VERSION,
-        servers,
-        dbPath: options.DB_PATH,
-        usageStats,
-        wsPort: wsPortInfo?.actual ?? null,
-        wsPortExpected: wsPortInfo?.expected,
-        wsPortHolder,
-        serveInstances: [...this.serveInstances.values()],
-      };
-    });
 
     this.handlers.set("listServers", async (_params, _ctx) => this.pool.listServers());
 
@@ -477,6 +456,14 @@ export class IpcServer {
       this.startDrainTimeout();
       return { ok: true };
     });
+
+    // Catch duplicate registrations (silently-overwritten handlers are invisible bugs).
+    const EXPECTED = 51;
+    if (this.handlers.size !== EXPECTED) {
+      throw new Error(
+        `Handler count mismatch after registration: expected ${EXPECTED}, got ${this.handlers.size}. A handler was duplicated or omitted.`,
+      );
+    }
   }
 }
 

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -27,6 +27,7 @@ import {
   ShutdownParamsSchema,
   consoleLogger,
   hardenFile,
+  loadManifest,
   options,
   startSpan,
 } from "@mcp-cli/core";
@@ -123,7 +124,7 @@ export class IpcServer {
       workItemDb,
       eventBus,
       resolveIssuePr: opts.resolveIssuePr ?? null,
-      loadManifestFn: opts.loadManifest ?? null,
+      loadManifestFn: opts.loadManifest ?? ((r) => loadManifest(r)?.manifest ?? null),
       onAliasChanged: opts.onAliasChanged ?? null,
     });
     this.db.pruneExpiredAliases();

--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -114,7 +114,7 @@ const EXCLUSIONS: Record<string, string> = {
 
   // Daemon internals — connection lifecycle requires integration
   "daemon/src/server-pool.ts": "51% coverage, connection lifecycle (#45/#51)",
-  "daemon/src/ipc-server.ts": "59% coverage, handler logic (#46)",
+
   "daemon/src/config/watcher.ts": "47% coverage, FS watcher loop (#48)",
 
   // ACP server — worker crash/restart lifecycle requires integration with real Worker threads


### PR DESCRIPTION
## Summary
- Extract 11 handler classes into `packages/daemon/src/handlers/` (auth, alias, work-item, serve, budget, event, telemetry, config, mail, note, tool) each with a co-located `*.spec.ts`
- Extract streaming HTTP routes (GET /logs, GET /events) into `EventStreamServer` in `event-stream.ts`; extract `buildEventFilter` into `ipc-filter.ts` (re-exported for backward compat)
- `ipc-server.ts` shrinks from 1,983 → 500 lines; all domain modules are < 400 lines each

## Test plan
- [x] 95 new unit tests across all handler modules (`packages/daemon/src/handlers/`)
- [x] All 144 existing `ipc-server.spec.ts` tests still pass (including overflow, heartbeat, and auth tests)
- [x] Removed `ipc-server.ts` exclusion from `scripts/check-coverage.ts`; coverage thresholds met
- [x] `bun typecheck` clean
- [x] `bun lint` clean (biome)
- [x] Pre-commit hook: 4196 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)