### PR TITLE
docs(spawn): document that spawn returns immediately; warn against backgrounding (closes #1604)

### DIFF
--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -1738,7 +1738,7 @@ function printProviderUsage(
   log(`mcx agent ${name} — manage ${label} sessions
 
 Usage:
-  mcx agent ${name} spawn --task "description"   Start a new session
+  mcx agent ${name} spawn --task "description"   Start a new session (returns immediately — do not background)
   mcx agent ${name} ls [--short] [--json]        List active sessions
   mcx agent ${name} send <session> <message>     Send follow-up prompt
   mcx agent ${name} wait [session]               Block until session event
@@ -1761,7 +1761,12 @@ function printSpawnUsage(
 ): void {
   const name = agentOverride ?? provider.name;
   const lines: string[] = [
-    `mcx agent ${name} spawn — Start a new ${agentOverride ?? providerDisplayName(provider)} session`,
+    `mcx agent ${name} spawn — Start a new ${agentOverride ?? providerDisplayName(provider)} session (returns immediately)`,
+    "",
+    "NOTE: spawn returns immediately with the new session ID. The session runs",
+    "asynchronously in the daemon. Do not invoke this command via a background",
+    "runner — it is wasteful and clutters the audit trail. To block on",
+    `completion, use: mcx agent ${name} wait <session-id>`,
     "",
     "Options:",
     `  --task, -t <string>        Task prompt for the session (required${hasFeature(provider, "resume") ? " unless --resume" : ""})`,

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -2083,7 +2083,7 @@ function printClaudeUsage(): void {
   console.log(`mcx claude — manage Claude Code sessions
 
 Usage:
-  mcx claude spawn --task "description"    Start a new Claude session (non-blocking)
+  mcx claude spawn --task "description"    Start a new Claude session (returns immediately — do not background)
   mcx claude spawn --headed --task "desc"  Start Claude in a visible terminal tab
   mcx claude spawn "description"           Shorthand (positional task)
   mcx claude resume <worktree-or-branch>   Resume with conversation history (--continue)

--- a/packages/command/src/help-claude.ts
+++ b/packages/command/src/help-claude.ts
@@ -3,7 +3,13 @@ import { registerHelp } from "./help";
 
 registerHelp("claude spawn", {
   name: "mcx claude spawn",
-  summary: "Start a new Claude Code session",
+  summary: "Start a new Claude Code session (returns immediately)",
+  notes: [
+    "NOTE: spawn returns immediately with the new session ID. The session runs",
+    "asynchronously in the daemon. Do not invoke this command via a background",
+    "runner — it is wasteful and clutters the audit trail. To block on",
+    "completion, use: mcx claude wait <session-id>",
+  ],
   usage: [
     'mcx claude spawn --task "description"',
     'mcx claude spawn --task "description" --allow Bash Read Write',

--- a/packages/command/src/help.spec.ts
+++ b/packages/command/src/help.spec.ts
@@ -163,4 +163,39 @@ describe("claude subcommand help registry", () => {
     const formatted = formatHelp(help);
     expect(formatted).toContain("mcp__grafana__*");
   });
+
+  test("spawn entry documents non-blocking behaviour and warns against backgrounding", async () => {
+    await import("./help-claude");
+    const help = getHelp("claude spawn");
+    if (!help) throw new Error("expected claude spawn help to be registered");
+    expect(help.summary).toContain("returns immediately");
+    const formatted = formatHelp(help);
+    expect(formatted).toContain("returns immediately");
+    expect(formatted).toContain("background");
+    expect(formatted).toContain("mcx claude wait");
+  });
+});
+
+describe("formatHelp notes field", () => {
+  test("renders notes between summary and Usage section", () => {
+    const output = formatHelp({
+      name: "mcx notecmd",
+      summary: "test note rendering",
+      notes: ["NOTE: this is important", "Do not do the thing."],
+      usage: ["mcx notecmd <arg>"],
+    });
+    const noteIdx = output.indexOf("NOTE: this is important");
+    const usageIdx = output.indexOf("Usage:");
+    expect(noteIdx).toBeGreaterThan(-1);
+    expect(usageIdx).toBeGreaterThan(noteIdx);
+  });
+
+  test("does not render Notes: section when notes is absent", () => {
+    const output = formatHelp({
+      name: "mcx nonotes",
+      summary: "no notes here",
+      usage: ["mcx nonotes"],
+    });
+    expect(output).not.toContain("NOTE:");
+  });
 });

--- a/packages/command/src/help.ts
+++ b/packages/command/src/help.ts
@@ -2,6 +2,7 @@ export interface CommandHelp {
   name: string;
   summary: string;
   usage: string[];
+  notes?: string[];
   options?: Array<[flag: string, description: string]>;
   examples?: string[];
 }
@@ -30,6 +31,14 @@ export function formatHelp(help: CommandHelp): string {
   const lines: string[] = [];
 
   lines.push(`${help.name} — ${help.summary}`);
+
+  if (help.notes && help.notes.length > 0) {
+    lines.push("");
+    for (const note of help.notes) {
+      lines.push(note);
+    }
+  }
+
   lines.push("");
   lines.push("Usage:");
   for (const u of help.usage) {


### PR DESCRIPTION
## Summary
- Adds an explicit NOTE to `mcx claude spawn --help` and `mcx agent <provider> spawn --help` stating that spawn returns immediately with the session ID and should not be run via a background runner
- Adds `notes?: string[]` field to `CommandHelp` interface; `formatHelp` renders it between the summary and `Usage:` section
- Updates the one-liner in `mcx claude --help` and `mcx agent <provider> --help` to say "returns immediately — do not background"

## Test plan
- [x] New test: `spawn entry documents non-blocking behaviour and warns against backgrounding` — verifies summary contains "returns immediately" and formatted output contains "background" and "mcx claude wait"
- [x] New tests: `formatHelp notes field` — verifies notes render before Usage and are omitted when absent
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] All 2037 command package tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)