### PR TITLE
feat(lint): add args-bounds check for unbounded args[++i] (fixes #1900)

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -64,6 +64,9 @@ if $has_source; then
   echo "  lint:shell..."
   bun run lint:shell
 
+  echo "  lint:args-bounds..."
+  bun run lint:args-bounds
+
   echo "  lint:timeouts..."
   bun run lint:timeouts
 
@@ -91,6 +94,9 @@ elif $has_config; then
 
   echo "  lint:shell..."
   bun run lint:shell
+
+  echo "  lint:args-bounds..."
+  bun run lint:args-bounds
 
   echo "  lint:timeouts..."
   bun run lint:timeouts

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lint": "bun install && bunx biome check --write .",
     "lint:check": "bun install && bunx biome check .",
     "lint:shell": "bun scripts/check-shell-injection.ts",
+    "lint:args-bounds": "bun scripts/check-args-bounds.ts",
     "lint:timeouts": "bun scripts/check-test-timeouts.ts",
     "lint:teardown": "bun scripts/check-session-teardown.ts",
     "check:phase-drift": "bun scripts/check-phase-drift.ts",

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -1370,8 +1370,13 @@ export function parsePatchUpdateArgs(args: string[], d: Pick<ClaudeDeps, "printE
     const a = args[i];
     if (a === "--force") force = true;
     else if (a === "--json") json = true;
-    else if (a === "--source") sourcePath = args[++i];
-    else if (a.startsWith("--source=")) sourcePath = a.slice("--source=".length);
+    else if (a === "--source") {
+      if (i + 1 >= args.length) {
+        d.printError("--source requires a value");
+        d.exit(1);
+      }
+      sourcePath = args[++i];
+    } else if (a.startsWith("--source=")) sourcePath = a.slice("--source=".length);
     else {
       d.printError(`Unknown argument: ${a}`);
       d.exit(1);
@@ -1445,7 +1450,12 @@ export function parseApproveArgs(
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--request-id" || args[i] === "-r") {
-      requestId = args[++i];
+      const val = args[++i];
+      if (!val) {
+        d.printError("--request-id requires a value");
+        d.exit(1);
+      }
+      requestId = val;
     } else if (!args[i].startsWith("-")) {
       positional.push(args[i]);
     }
@@ -1475,9 +1485,19 @@ export function parseDenyArgs(
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--request-id" || args[i] === "-r") {
-      requestId = args[++i];
+      const val = args[++i];
+      if (!val) {
+        d.printError("--request-id requires a value");
+        d.exit(1);
+      }
+      requestId = val;
     } else if (args[i] === "--message" || args[i] === "-m") {
-      message = args[++i];
+      const val = args[++i];
+      if (!val) {
+        d.printError("--message requires a value");
+        d.exit(1);
+      }
+      message = val;
     } else if (!args[i].startsWith("-")) {
       positional.push(args[i]);
     }

--- a/packages/command/src/commands/export.ts
+++ b/packages/command/src/commands/export.ts
@@ -33,6 +33,7 @@ export async function cmdExport(args: string[]): Promise<void> {
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg === "--scope" || arg === "-s") {
+      if (i + 1 >= args.length) throw new Error("--scope requires a value");
       scope = parseScope(args[++i], CONFIG_SCOPES_NO_LOCAL);
     } else if (arg === "--server") {
       const val = args[++i];

--- a/packages/command/src/commands/import.ts
+++ b/packages/command/src/commands/import.ts
@@ -239,6 +239,7 @@ export async function cmdImport(args: string[]): Promise<void> {
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg === "--scope" || arg === "-s") {
+      if (i + 1 >= args.length) throw new Error("--scope requires a value");
       scope = parseScope(args[++i], CONFIG_SCOPES_NO_LOCAL);
     } else if (arg === "--claude" || arg === "-c") {
       claude = true;
@@ -398,6 +399,7 @@ export async function cmdAddFromClaudeDesktop(
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg === "--scope" || arg === "-s") {
+      if (i + 1 >= args.length) throw new Error("--scope requires a value");
       scope = parseScope(args[++i], CONFIG_SCOPES_NO_LOCAL);
     } else if (arg === "--help" || arg === "-h") {
       console.log(`mcx add-from-claude-desktop — import servers from Claude Desktop

--- a/packages/command/src/commands/remove.ts
+++ b/packages/command/src/commands/remove.ts
@@ -20,6 +20,7 @@ export function parseRemoveArgs(args: string[]): { name: string; scope: ConfigSc
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg === "--scope" || arg === "-s") {
+      if (i + 1 >= args.length) throw new Error("--scope requires a value");
       scope = parseScope(args[++i], CONFIG_SCOPES);
     } else if (!arg.startsWith("-")) {
       positional.push(arg);

--- a/scripts/check-args-bounds.spec.ts
+++ b/scripts/check-args-bounds.spec.ts
@@ -40,6 +40,12 @@ describe("check-args-bounds isSafe()", () => {
       const lines = ["  val = args[++i]; // ?? should this be nullish?"];
       expect(isSafe(lines, 0)).toBe(false);
     });
+
+    test("comment containing i + 1 and args.length is not a bounds guard", () => {
+      // Rule 3 must strip inline comments before testing for a bounds comparison
+      const lines = ["  // TODO: add i + 1 < args.length check here", "  val = args[++i];"];
+      expect(isSafe(lines, 1)).toBe(false);
+    });
   });
 
   describe("safe cases", () => {

--- a/scripts/check-args-bounds.spec.ts
+++ b/scripts/check-args-bounds.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "bun:test";
+import { isSafe } from "./check-args-bounds";
+
+/**
+ * Unit tests for the args bounds lint rule's safety-check logic.
+ * We test isSafe() directly rather than spawning the script.
+ */
+
+describe("check-args-bounds isSafe()", () => {
+  describe("violations (unsafe)", () => {
+    test("bare assignment, no check", () => {
+      const lines = ["  scope = parseScope(args[++i], CONFIG_SCOPES);"];
+      expect(isSafe(lines, 0)).toBe(false);
+    });
+
+    test("next line checks a different variable", () => {
+      const lines = ["  requestId = args[++i];", "  } else if (!args[i].startsWith('-')) {"];
+      expect(isSafe(lines, 0)).toBe(false);
+    });
+
+    test("subsequent line is unrelated else-if branch", () => {
+      const lines = ["  sourcePath = args[++i];", "  else if (a.startsWith('--source=')) sourcePath = a.slice(9);"];
+      expect(isSafe(lines, 0)).toBe(false);
+    });
+  });
+
+  describe("safe cases", () => {
+    test("explicit bounds check 3 lines before", () => {
+      const lines = ["  if (i + 1 >= args.length) {", "    d.exit(1);", "  }", "  rawReason = args[++i];"];
+      expect(isSafe(lines, 3)).toBe(true);
+    });
+
+    test("while condition with i + 1 < args.length", () => {
+      const lines = ["  while (i + 1 < args.length && looksLikeToolName(args[i + 1])) {", "    allow.push(args[++i]);"];
+      expect(isSafe(lines, 1)).toBe(true);
+    });
+
+    test("null coalescing on same line", () => {
+      const lines = ["  from = args[++i] ?? null;"];
+      expect(isSafe(lines, 0)).toBe(true);
+    });
+
+    test("truthy pre-check on preceding line", () => {
+      const lines = ["  if (arg === '--cloud-id' && args[i + 1]) {", "    cloudId = args[++i];"];
+      expect(isSafe(lines, 1)).toBe(true);
+    });
+
+    test("post-check: if (!val) after const assignment", () => {
+      const lines = ["  const val = args[++i];", "  if (!val) {"];
+      expect(isSafe(lines, 0)).toBe(true);
+    });
+
+    test("post-check: if (!subscribe) after assignment", () => {
+      const lines = ["  subscribe = args[++i];", "  if (!subscribe) {"];
+      expect(isSafe(lines, 0)).toBe(true);
+    });
+
+    test("post-check: if (val === undefined)", () => {
+      const lines = ["  const val = args[++i];", "  if (val === undefined) {"];
+      expect(isSafe(lines, 0)).toBe(true);
+    });
+
+    test("post-check: if (val === null)", () => {
+      const lines = ["  const val = args[++i];", "  if (val === null) {"];
+      expect(isSafe(lines, 0)).toBe(true);
+    });
+
+    test("post-check: if (val == null)", () => {
+      const lines = ["  const val = args[++i];", "  if (val == null) {"];
+      expect(isSafe(lines, 0)).toBe(true);
+    });
+
+    test("bounds check exactly 6 lines before (boundary)", () => {
+      const lines = [
+        "  if (i + 1 >= args.length) throw new Error();",
+        "  // comment 1",
+        "  // comment 2",
+        "  // comment 3",
+        "  // comment 4",
+        "  // comment 5",
+        "  val = args[++i];",
+      ];
+      expect(isSafe(lines, 6)).toBe(true);
+    });
+
+    test("truthy pre-check on same line via args[i + 1]", () => {
+      const lines = ["  if (args[i + 1]) val = args[++i];"];
+      expect(isSafe(lines, 0)).toBe(true);
+    });
+  });
+});

--- a/scripts/check-args-bounds.spec.ts
+++ b/scripts/check-args-bounds.spec.ts
@@ -34,6 +34,12 @@ describe("check-args-bounds isSafe()", () => {
       const lines = ["  const next = args[i + 1];", "  val = args[++i];"];
       expect(isSafe(lines, 1)).toBe(false);
     });
+
+    test("?? in a comment is not a null-coalescing guard", () => {
+      // Rule 1 must require ?? adjacent to args[++i], not anywhere on the line
+      const lines = ["  val = args[++i]; // ?? should this be nullish?"];
+      expect(isSafe(lines, 0)).toBe(false);
+    });
   });
 
   describe("safe cases", () => {
@@ -97,6 +103,12 @@ describe("check-args-bounds isSafe()", () => {
 
     test("truthy pre-check on same line via args[i + 1]", () => {
       const lines = ["  if (args[i + 1]) val = args[++i];"];
+      expect(isSafe(lines, 0)).toBe(true);
+    });
+
+    test("same-line ternary bounds check", () => {
+      // Rule 3 must include the current line (j <= lineIdx) to catch this pattern
+      const lines = ["  val = i + 1 < args.length ? args[++i] : null;"];
       expect(isSafe(lines, 0)).toBe(true);
     });
   });

--- a/scripts/check-args-bounds.spec.ts
+++ b/scripts/check-args-bounds.spec.ts
@@ -22,6 +22,18 @@ describe("check-args-bounds isSafe()", () => {
       const lines = ["  sourcePath = args[++i];", "  else if (a.startsWith('--source=')) sourcePath = a.slice(9);"];
       expect(isSafe(lines, 0)).toBe(false);
     });
+
+    test("post-check matches longer identifier with same suffix (word-boundary)", () => {
+      // 'id' should not match 'requestId === undefined'
+      const lines = ["  id = args[++i];", "  if (requestId === undefined) {"];
+      expect(isSafe(lines, 0)).toBe(false);
+    });
+
+    test("bare args[i + 1] read is not a guard", () => {
+      // Reading args[i + 1] into a variable is not a truthy pre-check
+      const lines = ["  const next = args[i + 1];", "  val = args[++i];"];
+      expect(isSafe(lines, 1)).toBe(false);
+    });
   });
 
   describe("safe cases", () => {

--- a/scripts/check-args-bounds.ts
+++ b/scripts/check-args-bounds.ts
@@ -1,0 +1,149 @@
+#!/usr/bin/env bun
+/**
+ * Lint rule: flag args[++i] accesses without proper bounds checking.
+ *
+ * Hand-rolled argument parsers that do `args[++i]` without a prior bounds
+ * check silently produce `undefined` when `i` is already at the last position.
+ * This causes subtle bugs where missing required flags go undetected.
+ *
+ * A line is considered SAFE if ANY of the following hold:
+ *   1. Null coalescing on the same line:  ??
+ *   2. Truthy pre-check: current or preceding line contains args[i + 1]
+ *   3. Explicit bounds check in the preceding 6 lines: both `i + 1` and
+ *      `args.length` appear on the same line
+ *   4. Post-check on the assigned variable: the line assigns args[++i] to a
+ *      variable, and one of the next 2 lines checks that variable with
+ *      `!varName`, `varName === undefined`, `varName === null`, or
+ *      `varName == null`
+ *
+ * Usage:  bun scripts/check-args-bounds.ts
+ *
+ * Exit codes:
+ *   0 — no violations found
+ *   1 — violations found
+ */
+
+import { Glob } from "bun";
+
+const PACKAGES_DIR = new URL("../packages/", import.meta.url).pathname;
+const SCRIPTS_DIR = new URL("../scripts/", import.meta.url).pathname;
+const TEST_DIR = new URL("../test/", import.meta.url).pathname;
+
+/** Matches any args[++i] access. */
+const ACCESS_PATTERN = /args\[\+\+i\]/;
+
+/** Matches a variable assignment from args[++i], e.g. `const val = args[++i]` or `foo = args[++i]`. */
+const ASSIGN_PATTERN = /\b(\w+)\s*=\s*args\[\+\+i\]/;
+
+/** Matches an explicit `i + 1` token (with optional whitespace). */
+const I_PLUS_1 = /\bi\s*\+\s*1\b/;
+
+export interface Violation {
+  file: string;
+  line: number;
+  text: string;
+}
+
+/**
+ * Returns true if the args[++i] access on line `lineIdx` is safe.
+ *
+ * @param lines   Full array of lines from the file.
+ * @param lineIdx Zero-based index of the line containing args[++i].
+ */
+export function isSafe(lines: string[], lineIdx: number): boolean {
+  const line = lines[lineIdx];
+
+  // Rule 1: null coalescing on same line
+  if (line.includes("??")) return true;
+
+  // Rule 2: truthy pre-check — current or preceding line contains args[i + 1]
+  if (line.includes("args[i + 1]")) return true;
+  if (lineIdx > 0 && lines[lineIdx - 1].includes("args[i + 1]")) return true;
+
+  // Rule 3: explicit bounds check anywhere in the preceding 6 lines
+  const lookback = Math.max(0, lineIdx - 6);
+  for (let j = lookback; j < lineIdx; j++) {
+    if (I_PLUS_1.test(lines[j]) && lines[j].includes("args.length")) return true;
+  }
+
+  // Rule 4: post-check on assigned variable
+  const assignMatch = ASSIGN_PATTERN.exec(line);
+  if (assignMatch) {
+    const varName = assignMatch[1];
+    const lookahead = Math.min(lines.length - 1, lineIdx + 2);
+    for (let j = lineIdx + 1; j <= lookahead; j++) {
+      const next = lines[j];
+      if (
+        next.includes(`!${varName}`) ||
+        next.includes(`${varName} === undefined`) ||
+        next.includes(`${varName} === null`) ||
+        next.includes(`${varName} == null`)
+      ) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+async function scanDir(dir: string): Promise<Violation[]> {
+  const violations: Violation[] = [];
+  const glob = new Glob("**/*.ts");
+
+  for await (const relPath of glob.scan({ cwd: dir, absolute: false })) {
+    // Skip declaration files, node_modules, and this script + its tests
+    if (relPath.endsWith(".d.ts") || relPath.includes("node_modules")) continue;
+    if (relPath === "check-args-bounds.ts" || relPath === "check-args-bounds.spec.ts") continue;
+
+    const absPath = `${dir}${relPath}`;
+    const file = Bun.file(absPath);
+    const content = await file.text();
+    const lines = content.split("\n");
+
+    for (let i = 0; i < lines.length; i++) {
+      if (!ACCESS_PATTERN.test(lines[i])) continue;
+      if (!isSafe(lines, i)) {
+        violations.push({
+          file: absPath,
+          line: i + 1,
+          text: lines[i].trim(),
+        });
+      }
+    }
+  }
+
+  return violations;
+}
+
+async function main(): Promise<void> {
+  const dirs = [PACKAGES_DIR, SCRIPTS_DIR, TEST_DIR];
+  const allViolations: Violation[] = [];
+
+  for (const dir of dirs) {
+    const violations = await scanDir(dir);
+    allViolations.push(...violations);
+  }
+
+  if (allViolations.length === 0) {
+    process.stderr.write("No args bounds violations found.\n");
+    process.exit(0);
+  }
+
+  process.stderr.write(`\n  Args bounds risk: ${allViolations.length} violation(s) found\n\n`);
+  process.stderr.write("  args[++i] without a prior bounds check silently produces undefined.\n");
+  process.stderr.write("  Add a bounds check before accessing the next argument.\n\n");
+
+  for (const v of allViolations) {
+    process.stderr.write(`  ${v.file}:${v.line}\n`);
+    process.stderr.write(`    ${v.text}\n\n`);
+  }
+
+  process.stderr.write("  Bad:   val = args[++i];\n");
+  process.stderr.write("  Good:  if (i + 1 < args.length) val = args[++i];\n");
+  process.stderr.write("  Good:  val = args[++i] ?? defaultValue;\n\n");
+
+  process.exit(1);
+}
+
+main();

--- a/scripts/check-args-bounds.ts
+++ b/scripts/check-args-bounds.ts
@@ -9,8 +9,9 @@
  * A line is considered SAFE if ANY of the following hold:
  *   1. Null coalescing immediately after args[++i]:  args[++i] ??
  *   2. Truthy pre-check: current or preceding line contains args[i + 1]
- *   3. Explicit bounds check in the preceding 6 lines: both `i + 1` and
- *      `args.length` appear on the same line
+ *   3. Explicit bounds comparison on the current line or in the preceding 6 lines:
+ *      `i + 1 <|<=|>|>= args.length` or the reversed form — inline comments stripped
+ *      first so `// i + 1 < args.length` is not treated as a guard
  *   4. Post-check on the assigned variable: the line assigns args[++i] to a
  *      variable, and one of the next 2 lines checks that variable with
  *      `!varName`, `varName === undefined`, `varName === null`, or
@@ -35,8 +36,8 @@ const ACCESS_PATTERN = /args\[\+\+i\]/;
 /** Matches a variable assignment from args[++i], e.g. `const val = args[++i]` or `foo = args[++i]`. */
 const ASSIGN_PATTERN = /\b(\w+)\s*=\s*args\[\+\+i\]/;
 
-/** Matches an explicit `i + 1` token (with optional whitespace). */
-const I_PLUS_1 = /\bi\s*\+\s*1\b/;
+/** Matches a real bounds comparison between `i + 1` and `args.length` in either order. */
+const BOUNDS_EXPR = /\bi\s*\+\s*1\s*[<>]=?\s*args\.length\b|\bargs\.length\s*[<>]=?\s*\bi\s*\+\s*1\b/;
 
 export interface Violation {
   file: string;
@@ -64,11 +65,11 @@ export function isSafe(lines: string[], lineIdx: number): boolean {
   if (TRUTHY_PRE_CHECK.test(line)) return true;
   if (lineIdx > 0 && TRUTHY_PRE_CHECK.test(lines[lineIdx - 1])) return true;
 
-  // Rule 3: explicit bounds check in the preceding 6 lines *or on the current line*
-  // (includes same-line ternary: `val = i + 1 < args.length ? args[++i] : null`)
+  // Rule 3: explicit bounds comparison on the current line or in the preceding 6 lines.
+  // Strip inline comments before matching so `// i + 1 < args.length` is not a guard.
   const lookback = Math.max(0, lineIdx - 6);
   for (let j = lookback; j <= lineIdx; j++) {
-    if (I_PLUS_1.test(lines[j]) && lines[j].includes("args.length")) return true;
+    if (BOUNDS_EXPR.test(lines[j].replace(/\/\/.*$/, ""))) return true;
   }
 
   // Rule 4: post-check on assigned variable

--- a/scripts/check-args-bounds.ts
+++ b/scripts/check-args-bounds.ts
@@ -7,7 +7,7 @@
  * This causes subtle bugs where missing required flags go undetected.
  *
  * A line is considered SAFE if ANY of the following hold:
- *   1. Null coalescing on the same line:  ??
+ *   1. Null coalescing immediately after args[++i]:  args[++i] ??
  *   2. Truthy pre-check: current or preceding line contains args[i + 1]
  *   3. Explicit bounds check in the preceding 6 lines: both `i + 1` and
  *      `args.length` appear on the same line
@@ -53,8 +53,9 @@ export interface Violation {
 export function isSafe(lines: string[], lineIdx: number): boolean {
   const line = lines[lineIdx];
 
-  // Rule 1: null coalescing on same line
-  if (line.includes("??")) return true;
+  // Rule 1: null coalescing immediately after args[++i] — not anywhere on the line,
+  // which would match `??` in comments or on unrelated sub-expressions.
+  if (/args\[\+\+i\]\s*\?\?/.test(line)) return true;
 
   // Rule 2: truthy pre-check — current or preceding line uses args[i + 1] as a guard
   // Must appear in a boolean context: `&& args[i + 1]`, `|| args[i + 1]`,
@@ -63,9 +64,10 @@ export function isSafe(lines: string[], lineIdx: number): boolean {
   if (TRUTHY_PRE_CHECK.test(line)) return true;
   if (lineIdx > 0 && TRUTHY_PRE_CHECK.test(lines[lineIdx - 1])) return true;
 
-  // Rule 3: explicit bounds check anywhere in the preceding 6 lines
+  // Rule 3: explicit bounds check in the preceding 6 lines *or on the current line*
+  // (includes same-line ternary: `val = i + 1 < args.length ? args[++i] : null`)
   const lookback = Math.max(0, lineIdx - 6);
-  for (let j = lookback; j < lineIdx; j++) {
+  for (let j = lookback; j <= lineIdx; j++) {
     if (I_PLUS_1.test(lines[j]) && lines[j].includes("args.length")) return true;
   }
 

--- a/scripts/check-args-bounds.ts
+++ b/scripts/check-args-bounds.ts
@@ -56,9 +56,12 @@ export function isSafe(lines: string[], lineIdx: number): boolean {
   // Rule 1: null coalescing on same line
   if (line.includes("??")) return true;
 
-  // Rule 2: truthy pre-check — current or preceding line contains args[i + 1]
-  if (line.includes("args[i + 1]")) return true;
-  if (lineIdx > 0 && lines[lineIdx - 1].includes("args[i + 1]")) return true;
+  // Rule 2: truthy pre-check — current or preceding line uses args[i + 1] as a guard
+  // Must appear in a boolean context: `&& args[i + 1]`, `|| args[i + 1]`,
+  // `if (args[i + 1]`, or `while (... args[i + 1]` — not a bare read like `const x = args[i + 1]`.
+  const TRUTHY_PRE_CHECK = /(?:&&|\|\||if\s*\(|while\s*\()[^)]*args\[i\s*\+\s*1\]/;
+  if (TRUTHY_PRE_CHECK.test(line)) return true;
+  if (lineIdx > 0 && TRUTHY_PRE_CHECK.test(lines[lineIdx - 1])) return true;
 
   // Rule 3: explicit bounds check anywhere in the preceding 6 lines
   const lookback = Math.max(0, lineIdx - 6);
@@ -74,10 +77,9 @@ export function isSafe(lines: string[], lineIdx: number): boolean {
     for (let j = lineIdx + 1; j <= lookahead; j++) {
       const next = lines[j];
       if (
-        next.includes(`!${varName}`) ||
-        next.includes(`${varName} === undefined`) ||
-        next.includes(`${varName} === null`) ||
-        next.includes(`${varName} == null`)
+        new RegExp(`!\\b${varName}\\b`).test(next) ||
+        new RegExp(`\\b${varName}\\b\\s*===?\\s*(undefined|null)\\b`).test(next) ||
+        new RegExp(`\\b(undefined|null)\\s*===?\\s*\\b${varName}\\b`).test(next)
       ) {
         return true;
       }
@@ -146,4 +148,4 @@ async function main(): Promise<void> {
   process.exit(1);
 }
 
-main();
+if (import.meta.main) main();


### PR DESCRIPTION
## Summary

- Adds `scripts/check-args-bounds.ts`: a new lint script (modeled after `check-shell-injection.ts`) that detects `args[++i]` accesses without a bounds guard — the pattern behind the silent `--reason` bug in #1898
- Adds `scripts/check-args-bounds.spec.ts`: 14 unit tests covering all safe and unsafe patterns detected by the `isSafe()` function
- Registers `lint:args-bounds` in `package.json` and adds it to both tiers of the pre-commit hook
- Fixes 8 pre-existing violations across `export.ts`, `remove.ts`, `import.ts` (×2), and `claude.ts` (parsePatchUpdateArgs, parseApproveArgs, parseDenyArgs ×2)

The check classifies a line as safe if any of: `??` on the same line, `args[i + 1]` truthy pre-check, explicit `i + 1 / args.length` bounds check in the preceding 6 lines, or a falsy/null post-check on the assigned variable within the next 2 lines.

## Test plan

- [x] `bun run lint:args-bounds` exits 0 on the patched codebase
- [x] `bun test` (command package) — 2036 pass, 0 fail
- [x] `bun typecheck` — no errors
- [x] `bun run lint:check` — no errors
- [x] Spec: 14/14 unit tests pass (`cd scripts && bun test check-args-bounds.spec.ts`)
- [x] Pre-commit hook ran all checks including the new `lint:args-bounds` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)