### PR TITLE
sprint(51): sprint-50 ratchet — burn down lint/event-stream/async-gh follow-ups + dropped items

### DIFF
--- a/.claude/diary/20260503.51.md
+++ b/.claude/diary/20260503.51.md
@@ -1,0 +1,229 @@
+# 2026-05-03 — Sprint-50 ratchet (Sprint 51)
+
+## What was done
+
+12 PRs merged, v1.8.5 released. Sprint completed inside one 5h quota window
+(started 19:50 EDT, ended 23:45 EDT — ~4 hours wall clock).
+
+**Sprint-50 follow-up cluster (the "ratchet"):**
+- Patcher atomicity hardening (#1827 / PR #1975) — single outer try/finally
+  around staging lifecycle, guards `extractEntitlements` /
+  `writeFileSync(entPath)` / `renameSync` failure paths so `.staging.<pid>`
+  doesn't leak. Copilot caught the leak in round 1; impl session addressed it
+  inline before QA r1 verdict.
+- New `session.permission_blocked` event (#1948 / PR #1976) — `permission_request`
+  was firing for every tool incl. auto-approved; new event signals only when
+  strategy=delegate actually blocks. Backward-compat (request still fires for
+  all). Run.md still filters on the old event — mid-sprint cleanup deferred to
+  meta change.
+- Event-stream subscriber cap + dispose closes streams (#1961+#1962 / PR #1979)
+  — bounds the fallback path's `eventSubscribers` Set at 64 (returns 503
+  +warn), and `dispose()` walks `activeCleanups` to close /events AND /logs
+  controllers. QA r1 caught a hanging `reader.read()` test loop and the
+  missing /logs counterpart; repair (sonnet) replaced the loop with a
+  `Promise.race(reader.read(), Bun.sleep(remaining))` deadline pattern.
+- Args-bounds lint Rule 2 + escape hatch (#1967+#1968+#1969 / PR #1986) —
+  6-line lookback window, alt-bounds expressions (`>=`, `<=` strict variants),
+  `// lint-allow-args-bounds:` end-of-line escape. Round 1 Copilot caught a
+  `args[i+1] && y` RHS false-negative; repair anchored the regex to `^\s*`.
+  Rides on #1936 enabling `scripts/*.spec.ts` to run.
+- `scripts/*.spec.ts` enabled (#1936 / PR #1977) — single-line bunfig change
+  removing `scripts/**` from `pathIgnorePatterns`. Worker initially expanded
+  scope into `check-args-bounds.ts` and `check-test-timeouts.ts` (other
+  sprint-51 issues' territory); orchestrator caught it via `mcx claude log` +
+  scope-correction send. Final PR was correctly minimal.
+- check-test-timeouts callback regex + multi-line (#1632+#1633 / PR #1985) —
+  `findViolations(content)` does paren-depth tracking across newlines;
+  `extractDelayArg` correctly finds the 2nd positional arg (Copilot caught
+  the "last comma" bug exposed by `setTimeout(fn, 50, arg)` 3-arg form).
+- claude.ts status case DI (#1933 / PR #1989) — one-line fix forwarding the
+  merged `ClaudeDeps` to `cmdAgent` in the `status` case. Hot-shared file with
+  #1931+#1932; serialized via blockedBy edge in the plan; landed second.
+- AbstractWorkerServer dedicated spec (#1956 / PR #1982) — 10 tests via
+  `StubWorkerServer`/`SpyWorkerServer` minimal subclass; no real Worker
+  threads. QA r1 read comments 12s before the impl session's reply landed
+  on Copilot thread #3179154914 — first instance of the read-after-write
+  race pattern that recurred multiple times this sprint.
+- DB legacy v3 migration regression (#1892 / PR #1981) — single-line fix in
+  `db/state.ts:112`: `version = 3` → `version = 2` for legacy detection so
+  v3 symlink canonicalization runs on first open.
+- Phase script extraction + tests (#1960 / PR #1990) — 5 new `*-fn.ts` files
+  matching the `triage-fn.ts` DI pattern from sprint 50, parent `*.ts`
+  delegate. **Heaviest PR of the sprint** ($6.37 impl + $5.34 review-r1+r2).
+  Reviewer found and the impl fixed (in the same PR) `scanReviewComments`'s
+  parsing bug (#1991): `split(/\n{2,}/) + reverse + find` was isolating the
+  header into its own chunk and never seeing 🔴/🟡 items, making the review
+  gate decorative — replaced with `lastIndexOf("## Adversarial Review") +
+  slice`.
+- Status-footprint cluster (#1931+#1932 / PR #1983) — MultiEdit `edits`
+  array reduce instead of `+1`-per-call; UTF-8 byte count for Write
+  size accumulator.
+- AliasContext.repoRoot for sprint plan lookup (#1958 / PR #1984) — high-
+  scrutiny refactor (5 files / 3 packages). Reviewer caught 3 🔴 (wrong
+  JSDoc sentinel `__no_repo__` vs `__none__`, `alias-runner.ts` producer
+  gap, dry-run `baseCtx` producer gap) plus 3 🟡; impl session landed all
+  fixes in commit `fa3cff0` and promoted `repoRoot?: string` to required.
+
+**Also closed (no PR):**
+- #1928 — `containment.spec.ts` symlink CWD-sensitivity already fixed inline
+  in commit `ee9bd82` (`homedir()` instead of `process.cwd()`). Detected by
+  the implementer on read.
+- #1374 — `sweepCoreBare` cwd-fallback test already exists at
+  `index.spec.ts:972` covering the `else if (s.cwd)` branch (landed via
+  PR #1363, not the originally-intended PR). Closed by impl with explanation.
+- #1881 — `parseSitesArg` sparse-array check already landed inline at
+  `site-worker.ts:320` during PR #1878. Closed by user 2026-04-30, three
+  days before plan was authored. Plan-time triage missed it.
+
+**Pre-sprint meta-fix that rode in:**
+- PR #1971 (chore(skill): lead with Monitor harness tool in run.md, fixes
+  #1947) — landed before sprint start; Monitor as default for the
+  orchestrator stream is now the documented baseline.
+
+## What worked well
+
+- **Triage-driven phase routing was clean.** 10 of 12 PRs went `impl →
+  triage → qa` (low scrutiny by metrics: small diffs, single package,
+  no risk areas). Only 2 went `impl → triage → review` (#1958 with
+  5 files / 3 packages; #1960 with 1031 LOC churn) — and those are
+  exactly the two PRs the reviewer caught substantive issues in.
+  Triage's metrics-based routing was 100% accurate this sprint.
+- **Sonnet verify-only repair on #1827.** When Eve's QA r1 returned
+  qa:fail for "Copilot thread unreplied + staged fix uncommitted" but
+  the impl had since pushed `f1cf276` and replied, the standard repair
+  flow would spawn opus ($1-2) to redo work that was already done.
+  Spawning sonnet manually with a "verify+label-swap" prompt finished
+  in 12 turns / $0.19. Pattern is worth codifying — see "Patterns".
+- **Send-correction beats bye-respawn for scope creep.** Bob (#1936)
+  drifted into editing `scripts/check-args-bounds.ts` and
+  `scripts/check-test-timeouts.ts` early — files owned by other open
+  sprint-51 issues (#1967–#1969 and #1632/#1633). Caught by tailing
+  `mcx claude log` while spawning the next wave. One scope-correction
+  `mcx claude send` re-aimed the session at bunfig.toml only; no
+  respawn, no lost context. Final PR shipped clean.
+- **Bundled PRs.** Four bundles landed as one PR each: #1961+#1962
+  (event-stream), #1967+#1968+#1969 (args-bounds rules), #1931+#1932
+  (status footprint), #1632+#1633 (check-test-timeouts). Bundling halved
+  the QA/review session count for these. The hot-shared-file watch in
+  the plan correctly serialized the only cross-bundle conflict
+  (#1933 blockedBy #1931+#1932 on `claude.ts`).
+- **Plan-time + run-time already-done sweeps.** Plan-time triage closed
+  6 issues as already-done in main (#1690, #1883, #1935, #1940, #1965,
+  #1966) before spawning anything. Run-time triage caught 2 more
+  (#1928, #1374) on first read. Total: 8 issues handled at zero
+  implementation cost. The "verify still open before spawning" check
+  is cheap insurance.
+- **Async event stream notifications.** The persistent Monitor on
+  `mcx monitor --subscribe session,work_item --json` (filtered) drove
+  every transition this sprint. ~14 sessions across 4 hours, no
+  `sleep`, no `mcx claude wait` polling, no cache misses between ticks.
+  The pre-enriched payloads (`cost`, `turns`, `resultPreview`,
+  `cascadeHead`) collapsed the orchestrator's lookup-loop to ~1
+  follow-up call per actionable event.
+- **Daemon restart caught a stale-protocol mismatch early.** Pre-flight
+  `bun run build` + `mcx shutdown` + `mcx daemon restart` cycle exposed
+  a protocol-hash mismatch (`2493be5c → f7545924`) on the first `mcx
+  status` call, fixed by `mcx daemon restart`. Without that cycle the
+  sprint would have spawned sessions against a stale daemon.
+
+## What didn't work
+
+- **Read-after-write race in QA caused 5 false `qa:fail`s.** Pattern:
+  impl session pushes commit + Copilot thread reply → QA fetches comments
+  seconds later → reads pre-reply state → fails on "thread unreplied" or
+  "fix not committed." Hit on #1948 (Frank), #1956 (Pam r1, gap was 12s),
+  #1986 (7efad378 r1), and on flaky-test artifacts that were already
+  filed (#1936 → #1980, #1892 → #1987 — though the flake itself was
+  legit, the re-verify after CI rerun was a stale verdict). Each one
+  required a "send the QA back to re-verify" round, costing ~$0.30–
+  $0.65 per re-verify. **Fix to consider next sprint**: gate QA spawn
+  on `gh pr view <pr> --json updatedAt` being older than the impl
+  session's last `pushedAt`, or equivalently sleep ~30s in the qa.ts
+  spawn handler when the impl session is still idle (heuristic that
+  Copilot/post-push events are still landing).
+- **Sprint-container PR auto-binding (#1974).** `mcx track` resolved
+  every sprint-51 issue's `prNumber` to PR #1972 (the sprint container
+  itself), because #1972's body lists every issue in the sprint and the
+  poller's keyword-match resolver treats any `#NNNN` mention as a
+  binding signal. `mcx untrack && mcx track` cleared bindings briefly,
+  but the next poll cycle re-bound them. Cosmetic during impl, but at
+  retro merge time the container PR's squash will cascade-mark every
+  issue `done` even if their actual fix PRs didn't land. Filed for
+  closing-keyword-only resolution (`fixes #N` / `closes #N` rather
+  than bare mention) + sprint-container exemption.
+- **CI flakies blocked 2 PRs (#1980, #1987).** Both server-pool tests:
+  `closeAll kills all stdio child processes` (blocked #1936 / PR #1977),
+  `disconnect/SIGTERM race` at server-pool.spec.ts:1708 (blocked #1892
+  / PR #1981). CI rerun fixed both. Memory rule
+  (`feedback_flaky_tests.md`) says nerd-snipe BEFORE impl — these
+  surfaced mid-sprint as collateral, so they were filed but not
+  gated. They WILL come back — they're the next sprint's first
+  needs-attention candidates if not picked up directly.
+- **Permission_request event is now noise.** Post-#1948 merge,
+  `session.permission_request` fires for every Edit/Write/Bash
+  tool call (auto-approved or not). Run.md's stream filter still
+  includes `session.permission_request` — every routine tool call
+  now lands as an in-conversation notification. Counted ~30+ noise
+  events from #1958, #1960, and #1933 implementers. Run.md filter
+  needs to swap to `session.permission_blocked` next sprint;
+  meta-files-during-sprint rule kept it out of this sprint's scope.
+- **`work_items_update` UNIQUE constraint on bundled PRs.** When
+  binding both #1961 and #1962 to PR #1979, the second `work_items_update`
+  failed: `UNIQUE constraint failed: work_items.pr_number`. The PR
+  closed both via `fixes #1961, fixes #1962` body keywords, so the
+  bundle worked end-to-end, but `mcx phase run done` for the second
+  issue failed (`prNumber missing`) and required `mcx untrack` after
+  GitHub closed the issue. Same pattern hit #1932 / PR #1983, #1633
+  / PR #1985, #1968+#1969 / PR #1986. Should file: bundled-PR support
+  in work_items (multi-issue per PR) is the natural next step.
+- **`mcx status` crashes on null `extraUsage.utilization`** (#1973,
+  filed pre-flight). Output renders correctly through the quota lines
+  then `Error: null is not an object (evaluating 'A.extraUsage.utilization.toFixed')`.
+  Cosmetic — exits non-zero but everything else worked.
+
+## Patterns established
+
+- **Verify-only sonnet repair when QA fail reason is "stale verdict on
+  contained finding."** Detect: qa:fail body cites threads that have
+  reply chains in `gh api .../pulls/<pr>/comments` AND the cited fix
+  exists in `git diff origin/main...HEAD`. If so, spawn sonnet (not
+  the phase script's default opus) with a 4-step prompt: pull → confirm
+  fix → confirm reply → label swap. Saves $1+ per case and finishes in
+  <15 turns. Hit on #1827 this sprint, will recur whenever Copilot or
+  reviewer feedback overlaps with QA gating.
+- **Sprint-meta plan amendments commit on the sprint worktree, not main
+  checkout.** All four amendments this sprint (start timestamp, drop
+  #1881 from Excluded, end timestamp, Results section) followed the
+  `cd .claude/worktrees/sprint-51 && commit && push && cp back to main
+  checkout` pattern in `run.md` — never tripped the sprint-active
+  sentinel. The single quirk: `git push` in the worktree rebased
+  `package.json` line ordering on lint after biome ran in the worktree
+  — explicit `bun lint && bun typecheck` before commit avoided the
+  pre-commit hook reject loop.
+- **Bundle prompt template.** When spawning impl for a bundled PR
+  (e.g. #1961+#1962), spawn with `/implement <first-issue>` then
+  immediately `mcx claude send` a "Bundle: implement BOTH ... in the
+  SAME PR" message. The implementer reliably lands both. Used 4× this
+  sprint without a single bundle splitting into separate PRs.
+
+## Stats
+
+- **PRs merged**: 12
+- **Issues closed**: 14 (12 via PR + #1928 + #1374; #1881 was already
+  closed pre-sprint)
+- **Adversarial reviews**: 2 sticky reviews posted (1 on #1958, 1 on
+  #1960 — both went round-1 ⚠️ + post-fix ✅), 9 substantive findings
+  fixed total
+- **Copilot inline reviews addressed**: 16 across 8 PRs (each fix
+  cycle cost ~$0.5–1.5 to address + reply)
+- **CI re-runs**: 2 (both for filed flakies, not implementation issues)
+- **Failed/dropped**: 0 implementation failures; 1 plan-time miss
+  (#1881 — closed before plan was authored)
+- **New issues filed during sprint**: 7 — #1973, #1974, #1980, #1987,
+  #1991 (fixed inline in #1990 — closeable), #1992, #1993
+- **Sprint cost**: ~$36 across 30+ sessions; heaviest single session
+  was Bob/#1960 impl at $6.37 cumulative; second heaviest was Bob's
+  #1960 round-2 repair after reviewer feedback at $6.37→$8.05 delta
+- **Quota peak**: 5h 96% (just before reset at 03:10 UTC); sonnet pool
+  13%
+- **Wall clock**: 19:50 EDT → 23:55 EDT (~4 hours)

--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -22,7 +22,7 @@
 - [No gpgsign bypass](feedback_no_gpgsign_bypass.md) — never add `-c commit.gpgsign=false` or similar without explicit ask; only legit orchestrator flag is `SPRINT_OVERRIDE=1`
 - [Phase run no --dry-run](feedback_phase_run_no_dry_run.md) — per-tick `mcx phase run <phase> --work-item` without --dry-run; never skip `impl` run (writes transition log + state)
 - [Quota end-of-block](feedback_quota_end_of_block.md) — 80% impl-freeze is for early/mid block; near quota reset, fire for effect so long as work won't overrun
-- [Claude 2.1.121 sdk-url break](feedback_claude_2_1_121_break.md) — chflags-uchg shim at ~/.local/bin/claude → 2.1.119; archive at ~/.local/share/mcp-cli-archive/; #1808 tracks fix
+- [Claude 2.1.121 sdk-url break](feedback_claude_2_1_121_break.md) — pinned via `claudeBinary` config → archive 2.1.119 (chflags-uchg locked); user's PATH `claude` symlink auto-updates freely; #1808 tracks fix
 - [Don't touch parallel #1808 worktrees](feedback_parallel_p1_session.md) — user runs #1808 in a direct claude session; never blanket-prune; don't bye sessions you didn't spawn
 - [Verify auto-merge actually fired](feedback_verify_merge_actually_fired.md) — after qa:pass + `gh pr merge --auto`, poll until state=MERGED; QA verdict + auto-merge queue ≠ proof of merge
 - [Repair → QA transition](feedback_phase_repair_to_qa.md) — after repair pushes, advance via `phase=qa` write, NOT by re-ticking `mcx phase run repair`; the latter spawns a new repair round

--- a/.claude/memory/feedback_claude_2_1_121_break.md
+++ b/.claude/memory/feedback_claude_2_1_121_break.md
@@ -1,31 +1,47 @@
 ---
 name: Claude 2.1.121 sdk-url break + workaround
-description: Anthropic added a 5-host allowlist on `--sdk-url` in claude 2.1.121 that breaks every mcx-spawned session. Workaround in place; do not blindly re-symlink.
+description: Anthropic added a 5-host allowlist on `--sdk-url` in claude 2.1.121 that breaks every mcx-spawned session. Pin via `claudeBinary` config; user's local PATH `claude` advances freely.
 type: feedback
 originSessionId: 8be6c24d-3c8c-419f-9862-e43e3b61a449
 ---
-**Rule:** If `mcx claude spawn` is producing sessions that immediately disconnect with `spawn exited`, do NOT just re-pin the symlink — verify the wrapper script + `chflags uchg` lock at `~/.local/bin/claude` is still intact first.
+**Rule:** mcx-spawned claude sessions must use a known-working pre-2.1.121 binary (currently 2.1.119). The user's interactive `~/.local/bin/claude` is a normal symlink that auto-updates — it does NOT serve mcx anymore.
 
 **Why:** Claude Code CLI 2.1.121 (build `16ffea72`, dropped 2026-04-27) added a runtime check that rejects `--sdk-url ws://localhost:...` with: *"host 'localhost' is not an approved Anthropic endpoint."* The check is a string-match against a 5-host allowlist (`api.anthropic.com`, `api-staging.anthropic.com`, `beacon.claude-ai.staging.ant.dev`, `claude.fedstart.com`, `claude-staging.fedstart.com`). This breaks every mcx session spawn, since mcx hosts its own WebSocket transport at `ws://localhost:<port>`. Filed as issue #1808 (the user is solving this in a parallel session — daemon-side wiring of a binary patcher + TLS listener).
 
+**Current pinning mechanism (sprint 51 plan, 2026-05-03):**
+
+mcx now resolves the spawn binary in this precedence order (see `packages/daemon/src/claude-session/binary-resolver.ts` and `packages/core/src/config.ts:101`):
+
+1. `MCX_CLAUDE_BINARY` env var (per-process override)
+2. `claudeBinary` config field in `~/.mcp-cli/config.json` ← **this is what's pinned now**
+3. `which claude` on PATH (fallback)
+
+The pinned config value is:
+```
+claudeBinary = ~/.local/share/mcp-cli-archive/claude-code/claude-2.1.119
+```
+
+The user's `~/.local/bin/claude` is now a normal symlink to `~/.local/share/claude/versions/<latest>` and auto-updates freely (interactive `claude` benefits from upstream bugfixes). The chflags-uchg wrapper-script approach was retired 2026-05-03 — no longer needed.
+
+**Archive integrity:**
+
+Five binaries at `~/.local/share/mcp-cli-archive/claude-code/` (2.1.114, 2.1.116, 2.1.117, 2.1.118, 2.1.119) are protected by `chflags uchg` against accidental `rm`. SHA-256 digests in the archive's `README.txt`:
+- `claude-2.1.119` → `31db3444309d5d0f8b85e8782e2dcd86f31f7e48c1a1e83d69b09268c7b4f9a2`
+
+The archive is OUTSIDE `~/.local/share/claude/versions/` (which Anthropic prunes — 2.1.119 was already pruned there as of 2026-05-03; the archive is the only surviving copy on this machine).
+
 **How to apply:**
 
-1. **Detection.** If sessions die in <1s with daemon log `Session <id> disconnected: spawn exited` and `Pruned dead session ... pid X no longer alive`, run `claude --version`. If it prints anything ≥ 2.1.120 and the user hasn't merged the #1808 wiring yet, the symlink got stomped.
-
-2. **Workaround.** The recovery is a wrapper script (NOT a symlink — Anthropic's auto-updater rewrites symlinks within minutes):
+1. **Detection.** If sessions die in <1s with daemon log `Session <id> disconnected: spawn exited` and `Pruned dead session ... pid X no longer alive`, run:
    ```sh
-   unlink ~/.local/bin/claude
-   cat > ~/.local/bin/claude <<'EOF'
-   #!/bin/sh
-   exec "$HOME/.local/share/mcp-cli-archive/claude-code/claude-2.1.119" "$@"
-   EOF
-   chmod +x ~/.local/bin/claude
-   chflags uchg ~/.local/bin/claude
+   mcx config get claude-binary           # should print archive path
+   "$(mcx config get claude-binary | awk -F= '{print $2}' | xargs)" --version
+   # → 2.1.119 (Claude Code)
    ```
-   The `chflags uchg` (user-immutable flag) is what stops the auto-updater from overwriting it. Two prior re-pin attempts during sprint 46 were stomped within minutes; the third attempt with `uchg` survived.
+   If `claudeBinary` is unset or stale, restore via `mcx config set claude-binary ~/.local/share/mcp-cli-archive/claude-code/claude-2.1.119` then `mcx shutdown && mcx status`.
 
-3. **Archive location.** Last-known-working binaries (2.1.114 through 2.1.119) are at `~/.local/share/mcp-cli-archive/claude-code/` with sha256s in the README. This directory is OUTSIDE `~/.local/share/claude/versions/` (which Anthropic prunes) and OUTSIDE the project's git tree.
+2. **If the archive copy is missing** (binary deleted despite uchg lock — extremely unlikely): the archive `README.txt` lists prior versions back to 2.1.114. Use the most recent surviving binary; update `claudeBinary` config; restart daemon.
 
-4. **Don't just unlock and re-symlink to the latest.** Even if the auto-updater installs 2.1.122+ and the host check is gone, mcx still won't work until the daemon-side wiring (#1808 components 4/6/7) lands. Until then, 2.1.119 is the only known-working version for autosprint use.
+3. **Don't re-pin `~/.local/bin/claude` to 2.1.119.** That was the old workaround. The current setup deliberately keeps the user's interactive `claude` advancing — config-based pinning is the supported path.
 
-5. **Do not file new issues** about this — the open #1808 already has the full reverse-engineering recon (allowlist verbatim from binary, no DNS, no integrity check, no env bypass). If something new breaks (e.g. 2.1.119 stops working too), comment on #1808.
+4. **Don't file new issues** about this — #1808 has the full reverse-engineering recon. If something new breaks (e.g. 2.1.119 stops working too), comment on #1808 and fall back to 2.1.118 from the archive.

--- a/.claude/sprints/sprint-51.md
+++ b/.claude/sprints/sprint-51.md
@@ -190,3 +190,28 @@ unless one of the medium picks expands. No minor-bump candidates.
   2.1.114–2.1.119 protected with `chflags uchg`. Memory updated:
   `feedback_claude_2_1_121_break.md`. Not a code change — purely
   orchestrator-side state.
+
+## Results
+
+- **Released**: v1.8.5 (patch — all small fixes + tests + refactors; one additive monitor event)
+- **PRs merged**: 12 — #1975 (#1827), #1976 (#1948), #1977 (#1936), #1979 (#1961+#1962), #1981 (#1892), #1982 (#1956), #1983 (#1931+#1932), #1984 (#1958), #1985 (#1632+#1633), #1986 (#1967+#1968+#1969), #1989 (#1933), #1990 (#1960)
+- **Issues closed**: 14 (12 via PR + #1928 already-fixed inline + #1374 already-tested inline)
+- **Issues dropped**: 1 (#1881 — closed 2026-04-30 inline in PR #1878 before plan was authored; missed by plan-time triage, recorded in Excluded section)
+- **New issues filed**:
+  - **#1973** — `mcx status` crashes on null `extraUsage.utilization` (DX papercut, pre-flight)
+  - **#1974** — work-item-poller auto-binds sprint-container PRs to every issue in the sprint (caused stale bindings on every `mcx track` during setup; cosmetic during impl, hazardous at retro auto-merge)
+  - **#1980** — flaky: server-pool `closeAll kills all stdio child processes` fails intermittently (blocked #1936 CI, filed by QA)
+  - **#1987** — flaky: server-pool disconnect/SIGTERM race (blocked #1892 CI, filed by QA)
+  - **#1991** — `scanReviewComments` parsing bug: header chunk isolation prevents 🔴 detection on real `gh pr view` output (review gate was decorative; root cause analysis from #1960 reviewer; **fixed inline in PR #1990 via `lastIndexOf + slice` rewrite** — issue can be closed)
+  - **#1992** — `done-fn.ts` `exitCode >= 128` SIGTERM detection misses Go-graceful-shutdown exits (pre-existing, filed by reviewer)
+  - **#1993** — `repair-fn.ts` `review_session_id` not cleared on repair spawn (pre-existing, filed by reviewer)
+
+### Round counts
+- **Repair rounds**: 4 — #1827 r1 (verify-only, sonnet), #1948 r1 (opus), #1961+#1962 r1 (sonnet, after QA r1 fail)
+- **Review rounds**: 2 on #1958, 2 on #1960 (both: round-1 ⚠️ + post-fix ✅ stickies)
+- **QA rounds**: 1 most issues; 2 on #1948, #1961+#1962, #1986, #1981, #1977, #1982 (latter 4 due to QA running before async writes were visible — read-after-write race pattern, see retro)
+- **CI re-runs**: 2 (both for unrelated flakies #1980 on PR #1977, #1987 on PR #1981)
+
+### Cost
+- **Total session cost** (sum of session $ at end-of-sprint): ≈$36 across 30+ sessions, dominated by the #1960 implementation ($6.37) and adversarial review ($2.80 + $2.54)
+- **Quota**: peak 5h utilization 96%, sonnet pool 13%; sprint completed inside one 5h window (started 19:50 EDT, ended 23:45 EDT)

--- a/.claude/sprints/sprint-51.md
+++ b/.claude/sprints/sprint-51.md
@@ -46,7 +46,14 @@ work is one — `claude-patch` atomicity (#1827, the #1808 cluster).
 #1892, #1956, #1958, #1931+#1932, #1928
 
 ### Batch 3 (backfill)
-#1933, #1960, #1632+#1633, #1374, #1881
+#1933, #1960, #1632+#1633, #1374
+
+### Excluded (run-time, plan-time triage misses)
+
+- **#1881** — closed 2026-04-30 by user as already-done; sparse-array
+  index check landed inline in PR #1878 at `site-worker.ts:320`. Plan
+  was authored 2026-05-03 and missed the closure. Sprint target
+  reduced 15 → 14 PRs.
 
 ### Cross-issue dependencies (addBlockedBy edges)
 

--- a/.claude/sprints/sprint-51.md
+++ b/.claude/sprints/sprint-51.md
@@ -1,6 +1,6 @@
 # Sprint 51
 
-> Planned 2026-05-03 14:31 EDT. Target: 15 PRs.
+> Planned 2026-05-03 14:31 EDT. Started 2026-05-03 19:50 EDT. Target: 15 PRs.
 
 ## Goal
 

--- a/.claude/sprints/sprint-51.md
+++ b/.claude/sprints/sprint-51.md
@@ -1,0 +1,185 @@
+# Sprint 51
+
+> Planned 2026-05-03 14:31 EDT. Target: 15 PRs.
+
+## Goal
+
+**"Sprint-50 ratchet — burn down the immediate follow-up cluster
+(args-bounds lint #1900, daemon-split event-stream #1856, async-gh
+phase #1865, worker-base #1857, status-footprint cluster #1903–06),
+clear the 3 dropped items, and pick off DB-hardening + a security
+heavy. Show that sprint-50's anchors leave clean leaf-nodes, not
+half-finished landings."**
+
+Sprint 51 is a deliberate "tidy the wake" sprint. Sprint 50 landed
+six structural changes that each spawned 1–4 follow-ups during
+adversarial review or QA. Some are already-done (#1690, #1883, #1935
+closed at plan time). The rest cluster cleanly into bundles. Heavy
+work is one — `claude-patch` atomicity (#1827, the #1808 cluster).
+
+## Issues
+
+| # | Title | Scrutiny | Batch | Model | Category |
+|---|-------|----------|-------|-------|----------|
+| 1827 | claude-patch: harden atomicity and error handling in patcher | high | 1 | opus | heavy (#1808) |
+| 1948 | session.permission_request fires for auto-approved tools | medium | 1 | sonnet | sprint-50 follow-up |
+| 1961+1962 | event-stream: bound subscribers + dispose() closes streams | medium | 1 | sonnet | sprint-50 follow-up (#1856) |
+| 1967+1968+1969 | args-bounds lint: Rule 2 / Rule 3 / escape hatch | medium | 1 | sonnet | sprint-50 follow-up (#1900) |
+| 1936 | scripts/*.spec.ts excluded from bun test by pathIgnorePatterns | low | 1 | sonnet | filler (unblocks 1967–69 tests) |
+| 1892 | legacy DBs skip v3 symlink canonicalization regression | medium | 2 | sonnet | DB hardening |
+| 1956 | test: dedicated spec for AbstractWorkerServer base class | low | 2 | sonnet | sprint-50 follow-up (#1857) |
+| 1958 | phase model lookup: use findGitRoot instead of process.cwd() | low | 2 | sonnet | sprint-50 follow-up (#1865) |
+| 1931+1932 | claude status footprint: MultiEdit accumulation + UTF-16 byte count | low | 2 | sonnet | sprint-50 follow-up (#1903) |
+| 1928 | containment.spec.ts symlink traversal CWD-sensitive | low | 2 | sonnet | dropped (sprint 50) |
+| 1933 | refactor(claude): cmdClaudeInternal status case bypasses DI | low | 3 | sonnet | sprint-50 follow-up (#1903) |
+| 1960 | test: phase-script integration tests for async gh helper | medium | 3 | sonnet | sprint-50 follow-up (#1865) |
+| 1632+1633 | check-test-timeouts: callback regex + multi-line patterns | low | 3 | sonnet | dropped (sprint 50) |
+| 1374 | sweepCoreBare: missing test for cwd fallback path (#1330) | low | 3 | sonnet | filler |
+| 1881 | parseSitesArg sparse-array check bypassed by extra props | low | 3 | sonnet | filler (security; small) |
+
+## Batch Plan
+
+### Batch 1 (immediate)
+#1827, #1948, #1961+#1962, #1967+#1968+#1969, #1936
+
+### Batch 2 (backfill)
+#1892, #1956, #1958, #1931+#1932, #1928
+
+### Batch 3 (backfill)
+#1933, #1960, #1632+#1633, #1374, #1881
+
+### Cross-issue dependencies (addBlockedBy edges)
+
+- #1933 blockedBy #1931+#1932 (both touch `cmdClaudeInternal` status
+  case in `packages/command/src/commands/claude.ts:316`. The two small
+  bugs land first; the DI refactor rebases on top.)
+- #1960 blockedBy #1958 (both touch `.claude/phases/*.ts`. #1958's
+  small `findGitRoot` fix lands first; the integration-test scaffolding
+  rebases on top so it doesn't conflict on `process.cwd()` call sites.)
+- #1967+#1968+#1969 effectively blockedBy #1936 (lands in same batch,
+  but #1936 unblocks the script test runner so the args-bounds bundle
+  can ship tests that actually run in CI — orchestrator should land
+  #1936 first if both are PR-ready in the same window).
+
+### Hot-shared file watch
+
+- `packages/command/src/commands/claude.ts` — touched by #1931+#1932
+  bundle and #1933 (cmdClaudeInternal status case). Serialized via the
+  blockedBy edge; orchestrator should not start #1933 until #1931+#1932
+  is merged or about to merge.
+- `scripts/check-args-bounds.ts` — touched by #1967+#1968+#1969 bundle
+  (internally serialized as one PR).
+- `scripts/check-test-timeouts.ts` — touched by #1632+#1633 bundle
+  (internally serialized).
+- `packages/daemon/src/event-stream.ts` — touched by #1961+#1962 bundle
+  (internally serialized; the dispose-closes-streams change subsumes
+  the subscribe-cap change's locking semantics).
+- `.claude/phases/*.ts` — #1958 (small) → #1960 (test scaffold).
+  blockedBy edge enforces order.
+- `packages/daemon/src/db/state.ts` — #1892 only.
+- `packages/core/src/claude-patch/patcher.ts` — #1827 only.
+- `bunfig.toml` — #1936 only.
+
+No two PRs share a dispatch table this sprint, so the sprint-33
+duplicate-`case` hazard does not apply.
+
+## Context
+
+**Sprint-50 outcome**: 10 PRs merged + 2 closed-without-PR, v1.8.4
+released. Anchors landed clean — async-gh phase ticks (#1865), daemon
+ipc-server split (#1856), AbstractWorkerServer extraction (#1857),
+args-bounds lint (#1900), and the security follow-ups (#1929/#1941).
+Adversarial review on #1857 and QA on #1856 each spawned a tight
+2-issue follow-up cluster (#1961+#1962, #1956). The status-footprint
+sprint-50 PR (#1927) shipped with three known leaf-nodes
+(#1931/#1932/#1933) deliberately deferred for batching.
+
+**Plan-time triage closed 6 issues** (verified against current main):
+- #1935 + #1940 — angleBracketDepth fix already in
+  `scripts/check-session-teardown.ts:86–111`
+- #1690 — `ci_run_states` table + load/upsert methods already in
+  `packages/daemon/src/db/work-items.ts:229+454+473`
+- #1883 — `version = version + 1` bumped in upsertWorkItem ON CONFLICT
+  branches (`work-items.ts:302, 353`)
+- #1965 — duplicate of #1961
+- #1966 — duplicate of #1962
+
+**Carry-over signals**:
+- **#1808 cluster** (claude 2.1.121 sdk-url break): #1827 is the
+  patcher hardening from #1826's adversarial review. Heavy slot.
+  Other #1808 work (#1829, #1831) deferred.
+- **DB hardening**: #1892 is a real data-integrity regression — legacy
+  DBs get stamped at v3 without ever running v3's symlink
+  canonicalization migration. Single-PR fix.
+- **Orchestrator UX**: #1948 is a sprint-50-discovered noise issue —
+  `session.permission_request` fires for auto-approved tools, which
+  the orchestrator then has to filter or react to incorrectly. Two
+  proposed designs in the issue body; pick at impl time.
+- **Script tests not running**: #1936 (`scripts/**` in
+  `pathIgnorePatterns`) means `scripts/*.spec.ts` is silently skipped.
+  Sprint-50's #1900 lint shipped without test enforcement; sprint 51
+  fixes the test-runner gap, then the #1967-69 bundle adds tests that
+  actually run.
+
+**Risks**:
+- **One opus pick (#1827)** — adversarial-review surface area is the
+  patcher in `packages/core/src/claude-patch/patcher.ts`. Three
+  defensive items (atomic write, symlink-follow, missing error check).
+  No structural rewrite expected.
+- **#1933 refactor on hot file**: cmdClaudeInternal in `claude.ts` is
+  touched by 4 sprint-50 cluster issues (#1931, #1932, #1933, #1948).
+  The blockedBy edge serializes #1931+#1932 → #1933; #1948 lives in a
+  different file (event-emit path), so cross-bundle conflicts should
+  be rare.
+- **Spread across many small files**: 15 PRs across 8 distinct file
+  areas (claude.ts, event-stream.ts, args-bounds.ts, test-timeouts.ts,
+  containment.spec.ts, db/state.ts, patcher.ts, sites parser).
+  Orchestrator should keep PRs small and focused — no cross-area
+  bleed.
+
+**Releasability**: Sprint 51 is a polish sprint — all 15 picks are
+patch-level (bug fixes + small refactors). Probable v1.8.5 at retro
+unless one of the medium picks expands. No minor-bump candidates.
+
+## Process notes (carry-forward from sprint 50)
+
+1. **Capture phase JSON once, extract both fields** (workaround for
+   #1922; codified in sprint 50's run, kept until #1922's sprint-49
+   fix #1949 is fully soak-tested):
+   ```bash
+   OUT=$(mcx phase run <p> --work-item ...) && \
+     MODEL=$(echo "$OUT" | jq -r '.model // "sonnet"') && \
+     PROMPT=$(echo "$OUT" | jq -r '.prompt')
+   ```
+2. **Reviewer self-repair on contained findings** — keep using; saved
+   a repair spawn on #1899 in sprint 49 and on #1857 in sprint 50.
+3. **Bundled PRs for related issues** — sprint 51 bundles:
+   #1961+#1962, #1967+#1968+#1969, #1931+#1932, #1632+#1633.
+4. **8-minute wait before QA vote after PR push** — orchestrator should
+   remind QA agents until #1907 (deferred) lands inline-dismiss.
+5. **Verify auto-merge with `state == MERGED && mergedAt != null`** —
+   never trust just the auto-merge queue.
+6. **One TaskCreate per issue (or per bundled-PR)** with addBlockedBy
+   edges from the dependency list above.
+7. **No `Bun.sleep` in test fixes** — deterministic synchronization
+   only.
+8. **Use the `Monitor` harness tool, not raw Bash `mcx monitor`** —
+   per #1947 (meta PR #1971, queued for auto-merge at plan time).
+   `references/run.md` now leads with the `Monitor` form.
+
+## Pre-sprint meta-fixes applied
+
+- **#1947** — `references/run.md` now leads with the `Monitor` harness
+  tool form, demotes raw Bash `--max-events 1` to fallback, deletes
+  the file-redirection long-lived form. Applied via
+  `meta/run-md-monitor-tool` branch (PR #1971; auto-merge armed at
+  plan time).
+- **Machine-local claude pin migration**: `~/.local/bin/claude` was
+  retired from being the mcx-spawn target. mcx now resolves the spawn
+  binary via `claudeBinary` config (set to
+  `~/.local/share/mcp-cli-archive/claude-code/claude-2.1.119`). The
+  user's interactive `claude` advances freely (auto-updater rotates
+  the symlink to whatever Anthropic ships). Archive binaries
+  2.1.114–2.1.119 protected with `chflags uchg`. Memory updated:
+  `feedback_claude_2_1_121_break.md`. Not a code change — purely
+  orchestrator-side state.

--- a/.claude/sprints/sprint-51.md
+++ b/.claude/sprints/sprint-51.md
@@ -1,6 +1,6 @@
 # Sprint 51
 
-> Planned 2026-05-03 14:31 EDT. Started 2026-05-03 19:50 EDT. Target: 15 PRs.
+> Planned 2026-05-03 14:31 EDT. Started 2026-05-03 19:50 EDT. Ended 2026-05-03 23:45 EDT. Target: 15 PRs (12 merged, 3 already-done at run-time).
 
 ## Goal
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "bun": ">=1.2.18"
   },
-  "version": "1.8.4",
+  "version": "1.8.5",
   "description": "MCP CLI — call MCP server tools from the command line with zero context overhead",
   "type": "module",
   "workspaces": ["packages/*"],


### PR DESCRIPTION
Sprint 51 container PR. Accumulates every sprint-meta commit on the `sprint-51` branch:

- plan + any mid-sprint amendments
- run-time edits (Started/Ended timestamps, Excluded section)
- Results summary
- retro diary file
- release commit (if a release is cut this sprint)

Marked **draft** until `/sprint retro` flips it ready and arms auto-merge.

## Goal

**Sprint-50 ratchet — burn down the immediate follow-up cluster (args-bounds lint #1900, daemon-split event-stream #1856, async-gh phase #1865, worker-base #1857, status-footprint cluster #1903–06), clear the 3 dropped items, and pick off DB-hardening + a security heavy.**

## Plan summary

15 PRs, 1 heavy (#1827 patcher), 5 medium, 9 quick. See `.claude/sprints/sprint-51.md` for the full table, batch plan, dependency edges, and hot-shared-file watch.

Plan-time triage closed 6 issues as already-done in main or duplicates: #1935, #1940, #1690, #1883, #1965, #1966.

Docs/skill-only by construction — pre-commit hooks should skip the test suite.