### PR TITLE
fix(patcher): harden atomicity and error handling (fixes #1827)

### DIFF
--- a/packages/core/src/claude-patch/patcher.spec.ts
+++ b/packages/core/src/claude-patch/patcher.spec.ts
@@ -225,6 +225,18 @@ describe("updatePatchedClaude", () => {
     const stagingFiles = readdirSync(storeDir).filter((f) => f.includes(".staging."));
     expect(stagingFiles).toHaveLength(0);
   });
+
+  test("entitlements extraction failure does not leave a staging file", async () => {
+    const sourcePath = makeFakeClaudeBinary(tmpDir, "2.1.121");
+    const deps = makeFakeDeps({
+      extractEntitlements: async () => {
+        throw new Error("simulated entitlements failure");
+      },
+    });
+    await expect(updatePatchedClaude({ sourcePath, storeDir }, deps)).rejects.toThrow(/entitlements/);
+    const stagingFiles = readdirSync(storeDir).filter((f) => f.includes(".staging."));
+    expect(stagingFiles).toHaveLength(0);
+  });
 });
 
 describe("readCurrentPatchedMeta", () => {

--- a/packages/core/src/claude-patch/patcher.spec.ts
+++ b/packages/core/src/claude-patch/patcher.spec.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { copyFileSync, existsSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdtempSync, readFileSync, readdirSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { sha256Hex } from "../manifest-lock";
@@ -187,10 +187,43 @@ describe("updatePatchedClaude", () => {
         throw new Error("simulated smoke test failure");
       },
     });
-    expect(updatePatchedClaude({ sourcePath, storeDir }, deps)).rejects.toThrow(/smoke/);
+    await expect(updatePatchedClaude({ sourcePath, storeDir }, deps)).rejects.toThrow(/smoke/);
     // No metadata or current link should exist after a failed smoke.
     expect(existsSync(join(storeDir, "current"))).toBe(false);
     expect(existsSync(join(storeDir, "2.1.121.meta.json"))).toBe(false);
+    // Staging file should be cleaned up on smoke failure.
+    const stagingFiles = readdirSync(storeDir).filter((f) => f.includes(".staging."));
+    expect(stagingFiles).toHaveLength(0);
+  });
+
+  test("smoke test failure does not corrupt an existing patched binary", async () => {
+    const sourcePath = makeFakeClaudeBinary(tmpDir, "2.1.121");
+    const deps = makeFakeDeps();
+    // First patch succeeds.
+    await updatePatchedClaude({ sourcePath, storeDir }, deps);
+    const goodBytes = readFileSync(join(storeDir, "2.1.121.patched"));
+
+    // Second run with failing smoke — force to bypass idempotency check.
+    deps.smokeTest = async () => {
+      throw new Error("simulated smoke test failure");
+    };
+    await expect(updatePatchedClaude({ sourcePath, storeDir, force: true }, deps)).rejects.toThrow(/smoke/);
+
+    // The published binary must still be the good copy from the first run.
+    const afterBytes = readFileSync(join(storeDir, "2.1.121.patched"));
+    expect(Buffer.compare(goodBytes, afterBytes)).toBe(0);
+  });
+
+  test("resign failure does not leave a staging file", async () => {
+    const sourcePath = makeFakeClaudeBinary(tmpDir, "2.1.121");
+    const deps = makeFakeDeps({
+      resignBinary: async () => {
+        throw new Error("simulated resign failure");
+      },
+    });
+    await expect(updatePatchedClaude({ sourcePath, storeDir }, deps)).rejects.toThrow(/resign/);
+    const stagingFiles = readdirSync(storeDir).filter((f) => f.includes(".staging."));
+    expect(stagingFiles).toHaveLength(0);
   });
 });
 

--- a/packages/core/src/claude-patch/patcher.ts
+++ b/packages/core/src/claude-patch/patcher.ts
@@ -134,6 +134,9 @@ function updateCurrentLink(linkPath: string, target: string): void {
     renameSync(tmp, linkPath);
   } catch {
     // Symlink may fail on some filesystems; fall back to a plain pointer file.
+    // Remove any partial symlink first — writeFileSync follows symlinks, so
+    // writing through a dangling symlink would corrupt the target binary.
+    rmSync(tmp, { force: true });
     writeFileSync(tmp, target, { mode: 0o644 });
     renameSync(tmp, linkPath);
   }
@@ -184,6 +187,9 @@ export async function defaultResignBinary(binPath: string, entitlementsPath: str
     ["--force", "--sign", "-", "--options=runtime", "--entitlements", entitlementsPath, binPath],
     { encoding: "utf-8", timeout: 30_000 },
   );
+  if (result.error) {
+    throw new Error(`codesign --force failed: ${result.error.message}`);
+  }
   if (result.status !== 0) {
     throw new Error(`codesign --force failed: ${result.stderr.trim() || `exit ${result.status}`}`);
   }
@@ -368,9 +374,12 @@ export async function updatePatchedClaude(
     throw new Error(`strategy ${strategy.id} validation failed: ${validation.reason}`);
   }
 
-  // Write the patched bytes, then re-sign.
-  deps.writeBytesAtomic(patchedPath, patched);
-  chmodSync(patchedPath, 0o755);
+  // Stage to a temporary path so a failed resign/smoke doesn't leave a
+  // broken binary at the published path (a concurrent reader could get a
+  // partial file during the window).
+  const stagingPath = `${patchedPath}.staging.${process.pid}`;
+  deps.writeBytesAtomic(stagingPath, patched);
+  chmodSync(stagingPath, 0o755);
 
   // Extract entitlements from the source (must be done before re-signing the copy,
   // since codesign reads them off the source's existing signature).
@@ -378,7 +387,10 @@ export async function updatePatchedClaude(
   const entPath = join(tmpdir(), `mcx-entitlements-${process.pid}-${Date.now()}.plist`);
   writeFileSync(entPath, entitlements, { mode: 0o600 });
   try {
-    await deps.resignBinary(patchedPath, entPath);
+    await deps.resignBinary(stagingPath, entPath);
+  } catch (err) {
+    rmSync(stagingPath, { force: true });
+    throw err;
   } finally {
     try {
       rmSync(entPath, { force: true });
@@ -387,8 +399,16 @@ export async function updatePatchedClaude(
     }
   }
 
-  // Smoke test before publishing.
-  await deps.smokeTest(patchedPath);
+  // Smoke test the staging copy before promoting.
+  try {
+    await deps.smokeTest(stagingPath);
+  } catch (err) {
+    rmSync(stagingPath, { force: true });
+    throw err;
+  }
+
+  // Atomic rename from staging → published path.
+  renameSync(stagingPath, patchedPath);
 
   // Write metadata + update current link last (atomicity: if anything above
   // fails, the previous current link still points at the previous patched copy).

--- a/packages/core/src/claude-patch/patcher.ts
+++ b/packages/core/src/claude-patch/patcher.ts
@@ -374,41 +374,32 @@ export async function updatePatchedClaude(
     throw new Error(`strategy ${strategy.id} validation failed: ${validation.reason}`);
   }
 
-  // Stage to a temporary path so a failed resign/smoke doesn't leave a
-  // broken binary at the published path (a concurrent reader could get a
-  // partial file during the window).
+  // Stage to a temporary path so any failure (entitlements extraction,
+  // resign, smoke test, or final promote) doesn't leave a broken binary
+  // at the published path or an orphaned staging file.
   const stagingPath = `${patchedPath}.staging.${process.pid}`;
   deps.writeBytesAtomic(stagingPath, patched);
   chmodSync(stagingPath, 0o755);
-
-  // Extract entitlements from the source (must be done before re-signing the copy,
-  // since codesign reads them off the source's existing signature).
-  const entitlements = await deps.extractEntitlements(sourcePath);
-  const entPath = join(tmpdir(), `mcx-entitlements-${process.pid}-${Date.now()}.plist`);
-  writeFileSync(entPath, entitlements, { mode: 0o600 });
   try {
-    await deps.resignBinary(stagingPath, entPath);
-  } catch (err) {
-    rmSync(stagingPath, { force: true });
-    throw err;
-  } finally {
+    const entitlements = await deps.extractEntitlements(sourcePath);
+    const entPath = join(tmpdir(), `mcx-entitlements-${process.pid}-${Date.now()}.plist`);
+    writeFileSync(entPath, entitlements, { mode: 0o600 });
     try {
-      rmSync(entPath, { force: true });
-    } catch {
-      // ignore
+      await deps.resignBinary(stagingPath, entPath);
+    } finally {
+      try {
+        rmSync(entPath, { force: true });
+      } catch {
+        // ignore
+      }
     }
-  }
 
-  // Smoke test the staging copy before promoting.
-  try {
     await deps.smokeTest(stagingPath);
+    renameSync(stagingPath, patchedPath);
   } catch (err) {
     rmSync(stagingPath, { force: true });
     throw err;
   }
-
-  // Atomic rename from staging → published path.
-  renameSync(stagingPath, patchedPath);
 
   // Write metadata + update current link last (atomicity: if anything above
   // fails, the previous current link still points at the previous patched copy).


### PR DESCRIPTION
## Summary
- **updateCurrentLink**: `rmSync` dangling symlink before fallback `writeFileSync` to prevent symlink-follow corruption of the target binary
- **defaultResignBinary**: check `result.error` (ENOENT) before `result.status` so missing `codesign` surfaces a useful error message instead of null-access
- **Staging path for patched binary**: write + resign + smoke-test to a `.staging.<pid>` temp path, then atomic `renameSync` to the published path — prevents concurrent readers from seeing a partial/broken binary during the resign/smoke window

## Test plan
- [x] Existing 31 patcher tests still pass
- [x] New test: smoke failure cleans up staging file and does not corrupt an existing good binary
- [x] New test: resign failure cleans up staging file
- [x] Full suite: 6602 pass, 0 fail
- [x] `bun typecheck` clean
- [x] `bun lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)