### PR TITLE
feat(monitor): add session.permission_blocked event for blocking-only permission requests (fixes #1948)

### DIFF
--- a/packages/core/src/monitor-event.ts
+++ b/packages/core/src/monitor-event.ts
@@ -34,6 +34,7 @@ export type MonitorCategory = (typeof MONITOR_CATEGORIES)[number];
 export const SESSION_RESULT = "session.result" as const;
 export const SESSION_RESPONSE = "session.response" as const;
 export const SESSION_PERMISSION_REQUEST = "session.permission_request" as const;
+export const SESSION_PERMISSION_BLOCKED = "session.permission_blocked" as const;
 export const SESSION_ENDED = "session.ended" as const;
 export const SESSION_DISCONNECTED = "session.disconnected" as const;
 export const SESSION_ERROR = "session.error" as const;
@@ -197,6 +198,11 @@ const FORMATTERS: Partial<Record<string, Formatter>> = {
   },
 
   [SESSION_PERMISSION_REQUEST]: (e) => {
+    const tool = typeof e.toolName === "string" ? e.toolName : "";
+    return join(wi(e), sid(e), tool);
+  },
+
+  [SESSION_PERMISSION_BLOCKED]: (e) => {
     const tool = typeof e.toolName === "string" ? e.toolName : "";
     return join(wi(e), sid(e), tool);
   },

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -1628,13 +1628,12 @@ describe("ClaudeWsServer", () => {
       await waitForMessage(ws);
       ws.send(systemInitMessage("perm-blocked-1"));
       ws.send(canUseToolMessage("req-blocked-1"));
-      await pollUntil(() =>
-        server?.listSessions().some((s) => s.sessionId === "perm-blocked-1" && s.state === "waiting_permission"),
-      );
+      await pollUntil(() => monitorEvents.some((e) => e.event === SESSION_PERMISSION_BLOCKED));
 
       const blocked = monitorEvents.find((e) => e.event === SESSION_PERMISSION_BLOCKED);
       expect(blocked).toBeDefined();
       expect(blocked?.sessionId).toBe("perm-blocked-1");
+      expect(blocked?.requestId).toBe("req-blocked-1");
       expect(blocked?.toolName).toBe("Bash");
       expect(blocked?.category).toBe("session");
     } finally {
@@ -1681,9 +1680,7 @@ describe("ClaudeWsServer", () => {
       await waitForMessage(ws);
       ws.send(systemInitMessage("perm-req-1"));
       ws.send(canUseToolMessage("req-req-1"));
-      await pollUntil(() =>
-        server?.listSessions().some((s) => s.sessionId === "perm-req-1" && s.state === "waiting_permission"),
-      );
+      await pollUntil(() => monitorEvents.some((e) => e.event === SESSION_PERMISSION_BLOCKED));
 
       expect(monitorEvents.some((e) => e.event === SESSION_PERMISSION_REQUEST)).toBe(true);
     } finally {

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -3,7 +3,7 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { MonitorEventInput, WorkItemEvent } from "@mcp-cli/core";
-import { silentLogger } from "@mcp-cli/core";
+import { SESSION_PERMISSION_BLOCKED, SESSION_PERMISSION_REQUEST, silentLogger } from "@mcp-cli/core";
 import { serialize } from "./ndjson";
 import type { SessionEvent } from "./session-state";
 import type { SpawnFn, WaitResult } from "./ws-server";
@@ -1609,6 +1609,86 @@ describe("ClaudeWsServer", () => {
     void server.bye("test-session");
 
     await expect(eventPromise).rejects.toThrow("Session ended by user");
+  });
+
+  // ── session.permission_blocked monitor event (#1948) ──
+
+  test("session.permission_blocked fires when strategy=delegate and tool not containment-denied", async () => {
+    const ms = mockSpawn();
+    const monitorEvents: MonitorEventInput[] = [];
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    server.onMonitorEvent = (e) => monitorEvents.push(e);
+    const port = await server.start();
+
+    server.prepareSession("perm-blocked-1", { prompt: "test", permissionStrategy: "delegate" });
+    server.spawnClaude("perm-blocked-1");
+
+    const ws = await connectMockClaude(port, "perm-blocked-1");
+    try {
+      await waitForMessage(ws);
+      ws.send(systemInitMessage("perm-blocked-1"));
+      ws.send(canUseToolMessage("req-blocked-1"));
+      await pollUntil(() =>
+        server?.listSessions().some((s) => s.sessionId === "perm-blocked-1" && s.state === "waiting_permission"),
+      );
+
+      const blocked = monitorEvents.find((e) => e.event === SESSION_PERMISSION_BLOCKED);
+      expect(blocked).toBeDefined();
+      expect(blocked?.sessionId).toBe("perm-blocked-1");
+      expect(blocked?.toolName).toBe("Bash");
+      expect(blocked?.category).toBe("session");
+    } finally {
+      ws.close();
+    }
+  });
+
+  test("session.permission_blocked does not fire when strategy=auto", async () => {
+    const ms = mockSpawn();
+    const monitorEvents: MonitorEventInput[] = [];
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    server.onMonitorEvent = (e) => monitorEvents.push(e);
+    const port = await server.start();
+
+    server.prepareSession("perm-auto-1", { prompt: "test", permissionStrategy: "auto" });
+    server.spawnClaude("perm-auto-1");
+
+    const ws = await connectMockClaude(port, "perm-auto-1");
+    try {
+      await waitForMessage(ws);
+      ws.send(systemInitMessage("perm-auto-1"));
+      ws.send(canUseToolMessage("req-auto-1"));
+      // Wait for permission_request monitor event (auto-approved)
+      await pollUntil(() => monitorEvents.some((e) => e.event === SESSION_PERMISSION_REQUEST));
+
+      expect(monitorEvents.some((e) => e.event === SESSION_PERMISSION_BLOCKED)).toBe(false);
+    } finally {
+      ws.close();
+    }
+  });
+
+  test("session.permission_request still fires for all strategies (informational)", async () => {
+    const ms = mockSpawn();
+    const monitorEvents: MonitorEventInput[] = [];
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    server.onMonitorEvent = (e) => monitorEvents.push(e);
+    const port = await server.start();
+
+    server.prepareSession("perm-req-1", { prompt: "test", permissionStrategy: "delegate" });
+    server.spawnClaude("perm-req-1");
+
+    const ws = await connectMockClaude(port, "perm-req-1");
+    try {
+      await waitForMessage(ws);
+      ws.send(systemInitMessage("perm-req-1"));
+      ws.send(canUseToolMessage("req-req-1"));
+      await pollUntil(() =>
+        server?.listSessions().some((s) => s.sessionId === "perm-req-1" && s.state === "waiting_permission"),
+      );
+
+      expect(monitorEvents.some((e) => e.event === SESSION_PERMISSION_REQUEST)).toBe(true);
+    } finally {
+      ws.close();
+    }
   });
 
   test("bye returns worktree info", async () => {

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -1982,6 +1982,7 @@ export class ClaudeWsServer {
         event: SESSION_PERMISSION_BLOCKED,
         category: "session",
         sessionId,
+        requestId,
         toolName: request.tool_name,
       });
       return;

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -42,6 +42,7 @@ import {
   SESSION_ERROR,
   SESSION_IDLE,
   SESSION_MODEL_CHANGED,
+  SESSION_PERMISSION_BLOCKED,
   SESSION_PERMISSION_REQUEST,
   SESSION_RESULT,
   SESSION_STUCK,
@@ -1976,6 +1977,13 @@ export class ClaudeWsServer {
     }
 
     if (session.router.strategy === "delegate") {
+      this.onMonitorEvent?.({
+        src: "daemon.claude-server",
+        event: SESSION_PERMISSION_BLOCKED,
+        category: "session",
+        sessionId,
+        toolName: request.tool_name,
+      });
       return;
     }
 


### PR DESCRIPTION
## Summary
- Adds `session.permission_blocked` monitor event that fires only when a permission request is actually blocking (strategy=`delegate`)
- `session.permission_request` continues to fire for all tool requests as an informational event
- Orchestrators can now filter `mcx monitor` on `session.permission_blocked` instead of `session.permission_request` to eliminate noise from auto-approved tools (Edit, Write, Read, etc.)

## Changes
- `packages/core/src/monitor-event.ts`: adds `SESSION_PERMISSION_BLOCKED` constant and formatter
- `packages/daemon/src/claude-session/ws-server.ts`: emits `session.permission_blocked` in `handlePermissionRequest` when `strategy === "delegate"` (after containment check, before early return)
- `packages/daemon/src/claude-session/ws-server.spec.ts`: 3 new integration tests covering the event fires for delegate, does not fire for auto, and permission_request still fires for all strategies

## Test plan
- [x] `session.permission_blocked` fires with correct `sessionId`, `toolName`, `category` when strategy=`delegate`
- [x] `session.permission_blocked` does NOT fire when strategy=`auto`  
- [x] `session.permission_request` still fires for all strategies (backward compatible)
- [x] Full test suite: 6603 pass, 0 fail
- [x] typecheck clean, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)