### PR TITLE
fix(test): remove scripts/** from pathIgnorePatterns so spec files run (fixes #1936)

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -6,4 +6,4 @@
 # configured threshold. This broke CI (see #1181).
 
 # Prune directories that should not be scanned for tests
-pathIgnorePatterns = ["scripts/**", ".claude/**", "dist/**", ".git-hooks/**"]
+pathIgnorePatterns = [".claude/**", "dist/**", ".git-hooks/**"]


### PR DESCRIPTION
## Summary
- Removes `scripts/**` from `pathIgnorePatterns` in `bunfig.toml`
- This was silently blocking all 13 `scripts/*.spec.ts` files from running — even when passed as an explicit path to `bun test`
- All 13 spec files now run correctly under both `bun test` (discovery) and `bun test scripts/<file>.spec.ts` (explicit)

## Test plan
- [x] `bun test scripts/check-session-teardown.spec.ts` — previously printed "The following filters did not match any test files", now passes 16 tests
- [x] `bun test scripts/` — discovers and runs all 13 spec files (223 tests total)
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun run test:coverage` passes — scripts are not yet included in coverage measurement (that's tracked separately in #1967-69 and #1632-33, which will add the exports needed to reach per-file thresholds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)