### PR TITLE
fix(daemon): bound eventSubscribers Set and close streams on dispose (fixes #1961, fixes #1962)

### DIFF
--- a/packages/daemon/src/event-stream.ts
+++ b/packages/daemon/src/event-stream.ts
@@ -42,6 +42,9 @@ export class EventStreamServer {
   private eventSubscribers = new Set<(event: Record<string, unknown>) => void>();
   private eventSeq = 0;
   private eventBusSubId: number | null = null;
+  private disposed = false;
+  /** Active stream cleanup+close callbacks registered for graceful shutdown (#1962). */
+  private readonly activeCleanups = new Set<() => void>();
 
   constructor(
     private readonly eventBus: EventBus | null,
@@ -68,12 +71,22 @@ export class EventStreamServer {
     }
   }
 
-  /** Unsubscribe from EventBus (call from IpcServer.stop()). */
+  /** Unsubscribe from EventBus and close all active streams (call from IpcServer.stop()). */
   dispose(): void {
+    this.disposed = true;
     if (this.eventBusSubId !== null && this.eventBus) {
       this.eventBus.unsubscribe(this.eventBusSubId);
       this.eventBusSubId = null;
     }
+    for (const fn of this.activeCleanups) {
+      fn();
+    }
+    this.activeCleanups.clear();
+  }
+
+  /** Number of active streams tracked for graceful shutdown (for testing). */
+  get activeStreamCount(): number {
+    return this.activeCleanups.size;
   }
 
   /**
@@ -115,6 +128,10 @@ export class EventStreamServer {
    *   since=<ts>     — only backfill lines after this timestamp (ms)
    */
   handleLogsSSE(url: URL): Response {
+    if (this.disposed) {
+      return new Response("daemon shutting down", { status: 503 });
+    }
+
     const serverName = url.searchParams.get("server");
     const isDaemon = url.searchParams.get("daemon") === "true";
     const lines = Number(url.searchParams.get("lines") ?? "50");
@@ -125,6 +142,7 @@ export class EventStreamServer {
     }
 
     let unsubscribe: (() => void) | undefined;
+    let disposeCleanup: (() => void) | undefined;
 
     const stream = new ReadableStream({
       start: (controller) => {
@@ -136,8 +154,20 @@ export class EventStreamServer {
           } catch {
             // Stream closed — clean up
             unsubscribe?.();
+            if (disposeCleanup) this.activeCleanups.delete(disposeCleanup);
           }
         };
+
+        disposeCleanup = () => {
+          unsubscribe?.();
+          unsubscribe = undefined;
+          try {
+            controller.close();
+          } catch {
+            // already closed
+          }
+        };
+        this.activeCleanups.add(disposeCleanup);
 
         // Backfill initial lines
         if (isDaemon) {
@@ -171,6 +201,7 @@ export class EventStreamServer {
       },
       cancel: () => {
         unsubscribe?.();
+        if (disposeCleanup) this.activeCleanups.delete(disposeCleanup);
       },
     });
 
@@ -205,6 +236,10 @@ export class EventStreamServer {
    *   responseTail=<sessionId> Include session.response chunks for this session only
    */
   handleEventsNDJSON(url: URL): Response {
+    if (this.disposed) {
+      return new Response("daemon shutting down", { status: 503 });
+    }
+
     const sinceParam = url.searchParams.get("since");
     let sinceSeq: number | null = null;
     if (sinceParam !== null) {
@@ -251,6 +286,7 @@ export class EventStreamServer {
 
       let subId: number | null = null;
       let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+      let disposeCleanupEb: (() => void) | undefined;
 
       const encoder = new TextEncoder();
       const subscriberGauge = metrics.gauge("mcpd_event_bus_subscribers");
@@ -265,12 +301,26 @@ export class EventStreamServer {
           clearInterval(heartbeatTimer);
           heartbeatTimer = undefined;
         }
+        if (disposeCleanupEb) {
+          this.activeCleanups.delete(disposeCleanupEb);
+          disposeCleanupEb = undefined;
+        }
       };
 
       const stream = new ReadableStream(
         {
           start: async (controller) => {
             controller.enqueue(encoder.encode("\n"));
+
+            disposeCleanupEb = () => {
+              cleanup();
+              try {
+                controller.close();
+              } catch {
+                // already closed
+              }
+            };
+            this.activeCleanups.add(disposeCleanupEb);
 
             let liveBuffer: Array<{ line: string; bytes: number; seq: number | undefined }> | null =
               sinceSeq !== null && eventLog ? [] : null;
@@ -442,6 +492,13 @@ export class EventStreamServer {
     }
 
     // ── Ring-buffer fallback path (direct pushEvent(), no EventBus) ──
+    if (this.eventSubscribers.size >= EventStreamServer.MAX_EVENT_BUS_SUBSCRIBERS) {
+      this.logger.warn(
+        `[events] ring-buffer subscriber limit reached (${EventStreamServer.MAX_EVENT_BUS_SUBSCRIBERS}), rejecting connection`,
+      );
+      return new Response("too many event stream subscribers", { status: 503 });
+    }
+
     const filter = buildEventFilter(url.searchParams);
     const fallbackResponseTail = url.searchParams.get("responseTail");
     const shouldDeliverFallback = (event: Record<string, unknown>) => {
@@ -459,6 +516,7 @@ export class EventStreamServer {
     let unsubscribe: (() => void) | undefined;
     let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
     let lastWriteTime = Date.now();
+    let disposeCleanupRb: (() => void) | undefined;
 
     const encoder = new TextEncoder();
 
@@ -469,11 +527,25 @@ export class EventStreamServer {
         clearInterval(heartbeatTimer);
         heartbeatTimer = undefined;
       }
+      if (disposeCleanupRb) {
+        this.activeCleanups.delete(disposeCleanupRb);
+        disposeCleanupRb = undefined;
+      }
     };
 
     const stream = new ReadableStream({
       start: (controller) => {
         let highWaterMark = 0;
+
+        disposeCleanupRb = () => {
+          cleanup();
+          try {
+            controller.close();
+          } catch {
+            // already closed
+          }
+        };
+        this.activeCleanups.add(disposeCleanupRb);
 
         const flush = () => {
           if (!pending) return;

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -3809,20 +3809,69 @@ describe("IpcServer HTTP transport", () => {
     // Disposing removes all entries from the active set immediately.
     expect(server.activeStreamCount).toBe(0);
 
-    // The stream should close cleanly (done=true) within a bounded timeout.
+    // Drain all chunks until EOF, bounded by 2s. Promise.race on each read prevents
+    // the test from hanging if the stream never closes.
+    let closed = false;
     const deadline = Date.now() + 2_000;
-    let done = false;
-    while (Date.now() < deadline) {
-      const result = await reader.read();
-      if (result.done) {
-        done = true;
-        break;
-      }
+    while (!closed && Date.now() < deadline) {
+      const remaining = deadline - Date.now();
+      const chunk = await Promise.race([
+        reader.read(),
+        Bun.sleep(remaining).then(() => ({ done: true as const, value: undefined, timedOut: true })),
+      ]);
+      if ((chunk as { timedOut?: boolean }).timedOut) break;
+      if (chunk.done) closed = true;
     }
     reader.releaseLock();
     controller.abort();
 
-    expect(done).toBe(true);
+    expect(closed).toBe(true);
+  });
+
+  test("dispose() closes active /logs SSE streams (#1962)", async () => {
+    startServer();
+    if (!server) throw new Error("server not started");
+
+    // Emit a daemon log line so the stream has backfill data on connect.
+    // Without an immediate enqueue in start(), Bun defers the ReadableStream
+    // start() callback until a read is pending — the backfill ensures it runs
+    // eagerly so activeCleanups is populated before fetch() resolves.
+    console.error(`ipc-logs-dispose-test-${Date.now()}`);
+
+    const controller = new AbortController();
+    const res = await fetch("http://localhost/logs?daemon=true", {
+      method: "GET",
+      unix: socketPath,
+      signal: controller.signal,
+    } as RequestInit);
+    expect(res.status).toBe(200);
+    if (!res.body) throw new Error("Expected response body");
+    const reader = res.body.getReader();
+
+    await pollUntil(() => server?.activeStreamCount === 1);
+    expect(server.activeStreamCount).toBe(1);
+
+    const es = (server as unknown as { eventStream: EventStreamServer }).eventStream;
+    es.dispose();
+
+    expect(server.activeStreamCount).toBe(0);
+
+    // Drain all chunks until EOF, bounded by 2s.
+    let closed = false;
+    const deadline = Date.now() + 2_000;
+    while (!closed && Date.now() < deadline) {
+      const remaining = deadline - Date.now();
+      const chunk = await Promise.race([
+        reader.read(),
+        Bun.sleep(remaining).then(() => ({ done: true as const, value: undefined, timedOut: true })),
+      ]);
+      if ((chunk as { timedOut?: boolean }).timedOut) break;
+      if (chunk.done) closed = true;
+    }
+    reader.releaseLock();
+    controller.abort();
+
+    expect(closed).toBe(true);
   });
 
   test("EventStreamServer.dispose() rejects new /events and /logs connections (#1962)", () => {

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -11,6 +11,7 @@ import { installDaemonLogCapture } from "./daemon-log";
 import { StateDb } from "./db/state";
 import { EventBus } from "./event-bus";
 import { EventLog } from "./event-log";
+import { EventStreamServer } from "./event-stream";
 import { IpcServer } from "./ipc-server";
 import { metrics } from "./metrics";
 
@@ -3748,6 +3749,97 @@ describe("IpcServer HTTP transport", () => {
 
     expect(buffer).not.toContain("session.response");
     expect(buffer).toContain("session.result");
+  });
+
+  test("ring-buffer: rejects connection when subscriber cap is reached (#1961)", async () => {
+    startServer();
+    if (!server) throw new Error("server not started");
+
+    const controllers: AbortController[] = [];
+    const limit = IpcServer.MAX_EVENT_BUS_SUBSCRIBERS;
+
+    // Fill up to the cap
+    for (let i = 0; i < limit; i++) {
+      const c = new AbortController();
+      controllers.push(c);
+      const res = await fetch("http://localhost/events", {
+        method: "GET",
+        unix: socketPath,
+        signal: c.signal,
+      } as RequestInit);
+      expect(res.status).toBe(200);
+    }
+
+    await pollUntil(() => server?.eventSubscriberCount === limit);
+
+    // One more should be rejected
+    const overflow = await fetch("http://localhost/events", {
+      method: "GET",
+      unix: socketPath,
+    } as RequestInit);
+    expect(overflow.status).toBe(503);
+
+    // Clean up
+    for (const c of controllers) c.abort();
+    await pollUntil(() => server?.eventSubscriberCount === 0);
+  });
+
+  test("dispose() closes active ring-buffer /events streams (#1962)", async () => {
+    startServer();
+    if (!server) throw new Error("server not started");
+
+    const controller = new AbortController();
+    const res = await fetch("http://localhost/events", {
+      method: "GET",
+      unix: socketPath,
+      signal: controller.signal,
+    } as RequestInit);
+    expect(res.status).toBe(200);
+    if (!res.body) throw new Error("Expected response body");
+    const reader = res.body.getReader();
+
+    await pollUntil(() => server?.activeStreamCount === 1);
+    expect(server.activeStreamCount).toBe(1);
+
+    // Dispose just the EventStreamServer — the Bun HTTP server stays up so we
+    // can verify the stream terminates cleanly without an abrupt socket close.
+    const es = (server as unknown as { eventStream: EventStreamServer }).eventStream;
+    es.dispose();
+
+    // Disposing removes all entries from the active set immediately.
+    expect(server.activeStreamCount).toBe(0);
+
+    // The stream should close cleanly (done=true) within a bounded timeout.
+    const deadline = Date.now() + 2_000;
+    let done = false;
+    while (Date.now() < deadline) {
+      const result = await reader.read();
+      if (result.done) {
+        done = true;
+        break;
+      }
+    }
+    reader.releaseLock();
+    controller.abort();
+
+    expect(done).toBe(true);
+  });
+
+  test("EventStreamServer.dispose() rejects new /events and /logs connections (#1962)", () => {
+    // Direct unit test — no network needed.
+    const es = new (
+      EventStreamServer as unknown as new (
+        ...args: unknown[]
+      ) => { dispose(): void; handleEventsNDJSON(u: URL): Response; handleLogsSSE(u: URL): Response }
+    )(null, mockPool(), silentLogger, 30_000);
+
+    es.dispose();
+
+    const eventsRes = es.handleEventsNDJSON(new URL("http://localhost/events"));
+    expect(eventsRes.status).toBe(503);
+
+    const logsRes = es.handleLogsSSE(new URL("http://localhost/logs?daemon=true"));
+    expect(logsRes.status).toBe(503);
   });
 });
 

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -249,6 +249,10 @@ export class IpcServer {
     return this.eventStream.eventSubscriberCount;
   }
 
+  get activeStreamCount(): number {
+    return this.eventStream.activeStreamCount;
+  }
+
   /**
    * Test-mutable statics.
    *


### PR DESCRIPTION
## Summary

- **#1961**: Enforce `MAX_EVENT_BUS_SUBSCRIBERS` (64) on the ring-buffer fallback path in `handleEventsNDJSON`. Previously only the EventBus path had this guard; the fallback `eventSubscribers` Set was unbounded. Now returns 503 with a warning log when the cap is exceeded.
- **#1962**: `dispose()` now signals all active `/events` and `/logs` stream controllers to close cleanly. Each stream registers a cleanup+close callback on open and deregisters on cancel; `dispose()` iterates and calls all registered callbacks. New `disposed` flag causes both handlers to return 503 immediately for any new connections after shutdown.
- Expose `activeStreamCount` getter on `EventStreamServer` (and `IpcServer` proxy) for test observability.

## Test plan

- [x] `ring-buffer: rejects connection when subscriber cap is reached (#1961)` — fills 64 subscribers, verifies 65th gets 503
- [x] `dispose() closes active ring-buffer /events streams (#1962)` — connects a stream, calls `dispose()` directly on `EventStreamServer`, verifies `activeStreamCount` drops to 0 and reader receives clean EOF
- [x] `EventStreamServer.dispose() rejects new /events and /logs connections (#1962)` — direct unit test, no network: calls `dispose()`, verifies both handlers return 503
- [x] All 147 tests in `ipc-server.spec.ts` pass
- [x] Full pre-commit hook passes (typecheck + lint + coverage)

Note: filed #1978 for a pre-existing flaky `AcpSession.approve()` timeout that fired during first pre-commit run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)