### PR TITLE
fix(db): stamp legacy DBs at v2 so v3 symlink canonicalization runs (fixes #1892)

### DIFF
--- a/packages/daemon/src/db/state.spec.ts
+++ b/packages/daemon/src/db/state.spec.ts
@@ -1,6 +1,6 @@
 import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, test } from "bun:test";
-import { unlinkSync } from "node:fs";
+import { mkdirSync, realpathSync, symlinkSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { _restoreOptions, options } from "@mcp-cli/core";
@@ -1891,6 +1891,57 @@ describe("StateDb", () => {
         .get("state")?.version;
       expect(version).toBe(3);
       db.close();
+    });
+
+    test("legacy DB with symlink repo_root gets canonicalized on first open (#1892)", () => {
+      const p = tmpDb();
+      paths.push(p);
+
+      // Create a real dir and a symlink to it.
+      const realDir = join(tmpdir(), `mcp-cli-real-${Date.now()}`);
+      const symlinkDir = join(tmpdir(), `mcp-cli-link-${Date.now()}`);
+      mkdirSync(realDir, { recursive: true });
+      symlinkSync(realDir, symlinkDir);
+
+      try {
+        const canonical = realpathSync(symlinkDir);
+
+        // Build a legacy DB (tool_cache present, no schema_versions row).
+        const { Database } = require("bun:sqlite");
+        const raw = new Database(p, { create: true });
+        raw.exec("PRAGMA journal_mode = WAL");
+        raw.exec("CREATE TABLE tool_cache (server_name TEXT PRIMARY KEY)");
+        // alias_state must exist for the v3 step to find rows.
+        raw.exec(
+          "CREATE TABLE alias_state (repo_root TEXT NOT NULL, namespace TEXT NOT NULL, key TEXT NOT NULL, value_json TEXT NOT NULL, updated_at INTEGER NOT NULL DEFAULT (unixepoch()), PRIMARY KEY (repo_root, namespace, key))",
+        );
+        raw.run("INSERT INTO alias_state (repo_root, namespace, key, value_json) VALUES (?, ?, ?, ?)", [
+          symlinkDir,
+          "ns",
+          "k",
+          '"val"',
+        ]);
+        raw.close();
+
+        // First open: legacy detection stamps at v2, then v3 runs and canonicalizes.
+        const db = new StateDb(p);
+        // Row should now be accessible under the canonical (real) path.
+        expect(db.getAliasState(canonical, "ns", "k")).toBe("val");
+        // Symlink path should no longer have a row.
+        expect(db.getAliasState(symlinkDir, "ns", "k")).toBeUndefined();
+        db.close();
+      } finally {
+        try {
+          unlinkSync(symlinkDir);
+        } catch {
+          // ignore
+        }
+        try {
+          unlinkSync(realDir);
+        } catch {
+          // ignore — rmdir not needed for test correctness
+        }
+      }
     });
 
     test("legacy DB missing tables gets them created (handles half-migrated DBs from old try/catch failures)", () => {

--- a/packages/daemon/src/db/state.spec.ts
+++ b/packages/daemon/src/db/state.spec.ts
@@ -1,6 +1,6 @@
 import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, test } from "bun:test";
-import { mkdirSync, realpathSync, symlinkSync, unlinkSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { _restoreOptions, options } from "@mcp-cli/core";
@@ -1897,10 +1897,10 @@ describe("StateDb", () => {
       const p = tmpDb();
       paths.push(p);
 
-      // Create a real dir and a symlink to it.
-      const realDir = join(tmpdir(), `mcp-cli-real-${Date.now()}`);
-      const symlinkDir = join(tmpdir(), `mcp-cli-link-${Date.now()}`);
-      mkdirSync(realDir, { recursive: true });
+      // Create a real dir and a symlink to it. Use mkdtempSync for a unique base
+      // to avoid collisions when tests run in parallel.
+      const realDir = mkdtempSync(join(tmpdir(), "mcp-cli-real-"));
+      const symlinkDir = join(tmpdir(), `mcp-cli-link-${Date.now()}-${Math.random().toString(36).slice(2)}`);
       symlinkSync(realDir, symlinkDir);
 
       try {
@@ -1936,11 +1936,7 @@ describe("StateDb", () => {
         } catch {
           // ignore
         }
-        try {
-          unlinkSync(realDir);
-        } catch {
-          // ignore — rmdir not needed for test correctness
-        }
+        rmSync(realDir, { recursive: true, force: true });
       }
     });
 

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -109,7 +109,11 @@ export class StateDb {
         // Existing DB — run schema DDL idempotently to recover any tables the old
         // try/catch code silently failed to create (e.g. copilot_comment_state).
         this.applyV1Schema();
-        version = 3;
+        // Stamp at v2 (not v3) so the v3 symlink-canonicalization step runs on first
+        // open of any legacy DB — fixes the regression introduced by #1887 where
+        // legacy DBs were stamped directly at v3, bypassing the canonicalization that
+        // previously ran unconditionally on every boot (#1892).
+        version = 2;
       } else {
         // Fresh DB, or ancient DB that only has claude_sessions.
         // Rename claude_sessions → agent_sessions before v1 creates the table fresh.


### PR DESCRIPTION
## Summary
- Legacy databases (detected by `tool_cache` presence) were stamped directly at schema version 3 in the #1887 migration, bypassing the v3 symlink `repo_root` canonicalization step entirely
- Before #1887, this cleanup ran unconditionally on every daemon boot; under the versioned scheme, any legacy DB that had symlink rows would never get them fixed
- Fix: stamp legacy DBs at v2 instead so the existing v3 migration step runs normally on first open — one-line change, no logic duplication

## Test plan
- Added regression test: builds a raw legacy DB with a symlink `repo_root` row, opens it via `StateDb`, and asserts the row is accessible under the canonical (real) path and absent under the symlink path
- All 529 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)