### PR TITLE
fix(session-display): fix MultiEdit footprint accumulation and Write UTF-8 byte count (fixes #1931, #1932)

### DIFF
--- a/packages/command/src/commands/session-display.spec.ts
+++ b/packages/command/src/commands/session-display.spec.ts
@@ -358,6 +358,38 @@ describe("walkTranscript", () => {
     expect(src?.reads).toBe(0);
   });
 
+  test("Write uses UTF-8 byte count not JS string length for non-ASCII content", () => {
+    // "café" is 4 JS chars but 5 UTF-8 bytes (é = 2 bytes)
+    const entries = [makeAssistantMsg([makeToolUse("Write", { file_path: "/src/foo.ts", content: "café" })])];
+    const stats = walkTranscript(entries);
+    const src = stats.directoryFootprint.find((e) => e.dir === "/src");
+    expect(src?.writes).toBe(5);
+  });
+
+  test("MultiEdit accumulates line counts from edits array", () => {
+    const entries = [
+      makeAssistantMsg([
+        makeToolUse("MultiEdit", {
+          file_path: "/src/foo.ts",
+          edits: [
+            { old_string: "a", new_string: "x\ny\nz" }, // 3 lines
+            { old_string: "b", new_string: "p\nq" }, // 2 lines
+          ],
+        }),
+      ]),
+    ];
+    const stats = walkTranscript(entries);
+    const src = stats.directoryFootprint.find((e) => e.dir === "/src");
+    expect(src?.writes).toBe(5); // 3 + 2, not 1
+  });
+
+  test("MultiEdit with empty edits array contributes 0 to footprint", () => {
+    const entries = [makeAssistantMsg([makeToolUse("MultiEdit", { file_path: "/src/foo.ts", edits: [] })])];
+    const stats = walkTranscript(entries);
+    const src = stats.directoryFootprint.find((e) => e.dir === "/src");
+    expect(src?.writes).toBe(0);
+  });
+
   test("aggregates Bash commands by first token", () => {
     const entries = [
       makeAssistantMsg([makeToolUse("Bash", { command: "bun test foo.spec.ts" })]),

--- a/packages/command/src/commands/session-display.ts
+++ b/packages/command/src/commands/session-display.ts
@@ -92,7 +92,7 @@ export function walkTranscript(entries: TranscriptEntry[], lastQueryCount = 3): 
             dirReads.set(d, (dirReads.get(d) ?? 0) + lines);
           } else if (name === "Write" && typeof input.file_path === "string") {
             const d = dirname(input.file_path);
-            const bytes = typeof input.content === "string" ? input.content.length : 0;
+            const bytes = typeof input.content === "string" ? new TextEncoder().encode(input.content).byteLength : 0;
             dirWrites.set(d, (dirWrites.get(d) ?? 0) + bytes);
           } else if (name === "Edit" && typeof input.file_path === "string") {
             const d = dirname(input.file_path);
@@ -100,7 +100,13 @@ export function walkTranscript(entries: TranscriptEntry[], lastQueryCount = 3): 
             dirWrites.set(d, (dirWrites.get(d) ?? 0) + lines);
           } else if (name === "MultiEdit" && typeof input.file_path === "string") {
             const d = dirname(input.file_path);
-            dirWrites.set(d, (dirWrites.get(d) ?? 0) + 1);
+            const lines = Array.isArray(input.edits)
+              ? (input.edits as Array<Record<string, unknown>>).reduce(
+                  (sum, e) => sum + (typeof e.new_string === "string" ? e.new_string.split("\n").length : 0),
+                  0,
+                )
+              : 0;
+            dirWrites.set(d, (dirWrites.get(d) ?? 0) + lines);
           } else if (name === "Bash" && typeof input.command === "string") {
             const firstToken = input.command.trim().split(/\s+/)[0] || "bash";
             const existing = cmdMap.get(firstToken);


### PR DESCRIPTION
## Summary
- **#1931**: `MultiEdit` in `walkTranscript()` now accumulates line counts from each edit's `new_string` (summing across the `edits` array), matching how `Edit` is counted. Previously it contributed a flat +1 per call regardless of content.
- **#1932**: `Write` tool footprint now uses `TextEncoder().encode(content).byteLength` for accurate UTF-8 byte counts instead of `String.length` which returns UTF-16 code units.

## Test plan
- [x] New test: `Write uses UTF-8 byte count not JS string length for non-ASCII content` — verifies "café" (4 JS chars, 5 UTF-8 bytes) counts as 5
- [x] New test: `MultiEdit accumulates line counts from edits array` — verifies 2 edits with 3+2 lines contributes 5 (not 1) to footprint
- [x] New test: `MultiEdit with empty edits array contributes 0 to footprint`
- [x] Full test suite: 6832 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)