### PR TITLE
fix(alias): expose repoRoot on AliasContext so phase scripts find sprint plans correctly (fixes #1958)

### DIFF
--- a/.claude/phases/impl.ts
+++ b/.claude/phases/impl.ts
@@ -100,7 +100,7 @@ defineAlias({
       if (stateModel === "opus" || stateModel === "sonnet") {
         model = stateModel;
       } else {
-        const planModel = findModelInSprintPlan(work.issueNumber, process.cwd());
+        const planModel = findModelInSprintPlan(work.issueNumber, ctx.repoRoot ?? process.cwd());
         model = planModel ?? pickModel(input.labels);
       }
     }

--- a/.claude/phases/impl.ts
+++ b/.claude/phases/impl.ts
@@ -21,7 +21,7 @@
  * session ID after spawn; write worktree_path once the worktree is known;
  * delete session_id on spawn failure so next entry re-spawns cleanly.
  */
-import { findModelInSprintPlan } from "@mcp-cli/core";
+import { NO_REPO_ROOT, findModelInSprintPlan } from "@mcp-cli/core";
 import { defineAlias, z } from "mcp-cli";
 
 type Provider = "claude" | "copilot" | "gemini" | `acp:${string}`;
@@ -100,7 +100,8 @@ defineAlias({
       if (stateModel === "opus" || stateModel === "sonnet") {
         model = stateModel;
       } else {
-        const planModel = findModelInSprintPlan(work.issueNumber, ctx.repoRoot ?? process.cwd());
+        const planModel =
+          ctx.repoRoot !== NO_REPO_ROOT ? findModelInSprintPlan(work.issueNumber, ctx.repoRoot) : null;
         model = planModel ?? pickModel(input.labels);
       }
     }

--- a/.claude/phases/review.ts
+++ b/.claude/phases/review.ts
@@ -86,7 +86,7 @@ defineAlias({
       if (input.model) {
         model = input.model;
       } else {
-        const planModel = work.issueNumber != null ? findModelInSprintPlan(work.issueNumber, process.cwd()) : null;
+        const planModel = work.issueNumber != null ? findModelInSprintPlan(work.issueNumber, ctx.repoRoot ?? process.cwd()) : null;
         model = planModel ?? "sonnet";
       }
 

--- a/.claude/phases/review.ts
+++ b/.claude/phases/review.ts
@@ -22,7 +22,7 @@
  * for a new round (so the handler spawns a fresh reviewer rather than reading
  * the previous reviewer's comment).
  */
-import { findModelInSprintPlan } from "@mcp-cli/core";
+import { NO_REPO_ROOT, findModelInSprintPlan } from "@mcp-cli/core";
 import { defineAlias, z } from "mcp-cli";
 import { gh } from "./gh";
 
@@ -86,7 +86,10 @@ defineAlias({
       if (input.model) {
         model = input.model;
       } else {
-        const planModel = work.issueNumber != null ? findModelInSprintPlan(work.issueNumber, ctx.repoRoot ?? process.cwd()) : null;
+        const planModel =
+          work.issueNumber != null && ctx.repoRoot !== NO_REPO_ROOT
+            ? findModelInSprintPlan(work.issueNumber, ctx.repoRoot)
+            : null;
         model = planModel ?? "sonnet";
       }
 

--- a/packages/command/src/alias-runner.ts
+++ b/packages/command/src/alias-runner.ts
@@ -69,6 +69,7 @@ export async function runAlias(aliasPath: string, cliArgs: Record<string, string
       state: createAliasState({ repoRoot, namespace: aliasUserNamespace(aliasName) }),
       globalState: createAliasState({ repoRoot, namespace: GLOBAL_STATE_NAMESPACE }),
       workItem: null,
+      repoRoot,
       signal: controller.signal,
       waitForEvent: createWaitForEvent({ signal: controller.signal }),
     };

--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -2701,9 +2701,16 @@ phases:
       },
     );
 
-    expect(logs.length).toBeGreaterThan(0);
-    const parsed = JSON.parse(logs[0]);
-    expect(parsed.repoRoot).toBe(capturedRoot);
+    const jsonLog = logs.find((l) => {
+      try {
+        return JSON.parse(l).repoRoot !== undefined;
+      } catch {
+        return false;
+      }
+    });
+    expect(jsonLog).toBeDefined();
+    // biome-ignore lint/style/noNonNullAssertion: guarded by toBeDefined() above
+    expect(JSON.parse(jsonLog!).repoRoot).toBe(capturedRoot);
   }, 30_000);
 });
 

--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -2642,6 +2642,71 @@ defineAlias(({ z }) => ({
   }, 30_000);
 });
 
+describe("executePhase passes ctx.repoRoot from findGitRoot (#1958)", () => {
+  const repoRootAlias = `
+import { defineAlias } from "mcp-cli";
+
+defineAlias(({ z }) => ({
+  name: "check-repo-root",
+  description: "returns ctx.repoRoot",
+  input: z.object({}).default({}),
+  output: z.object({ repoRoot: z.string().optional() }),
+  fn: async (_input, ctx) => ({ repoRoot: ctx.repoRoot }),
+}));
+`.trim();
+
+  const manifestSimple = `
+runsOn: main
+initial: check-repo-root
+phases:
+  check-repo-root:
+    source: ./check-repo-root.ts
+    next: []
+`.trim();
+
+  test("ctx.repoRoot equals findGitRoot result, not process.cwd()", async () => {
+    writeFileSync(join(dir, ".mcx.yaml"), manifestSimple);
+    writeFileSync(join(dir, "check-repo-root.ts"), repoRootAlias);
+    const { deps: installDeps } = makeDriftDeps(dir);
+    await cmdPhase(["install"], installDeps);
+
+    const capturedRoot = "/fake/repo/root";
+    const logs: string[] = [];
+    await executePhase(
+      ["check-repo-root"],
+      {
+        ...makeDriftDeps(dir).deps,
+        log: (m) => logs.push(m),
+        logError: () => {},
+        exit: ((c: number) => {
+          throw new Error(`exit(${c})`);
+        }) as (code: number) => never,
+      },
+      {
+        ipcCall: (async (method: string) => {
+          if (method === "getWorkItem") return null;
+          if (method === "aliasStateGet") return { value: undefined };
+          if (method === "aliasStateSet") return { ok: true };
+          if (method === "aliasStateAll") return { entries: {} };
+          return null;
+        }) as unknown as typeof import("@mcp-cli/core").ipcCall,
+        exec: (cmd) => {
+          if (cmd.includes("rev-parse") && cmd.includes("--is-inside-work-tree"))
+            return { stdout: "true", exitCode: 0 };
+          if (cmd.includes("symbolic-ref")) return { stdout: "main\n", exitCode: 0 };
+          return { stdout: "", exitCode: 0 };
+        },
+        findGitRoot: () => capturedRoot,
+        now: () => new Date("2026-04-14T00:00:00Z"),
+      },
+    );
+
+    expect(logs.length).toBeGreaterThan(0);
+    const parsed = JSON.parse(logs[0]);
+    expect(parsed.repoRoot).toBe(capturedRoot);
+  }, 30_000);
+});
+
 describe("auto-detects --from for repair↔qa cycles without explicit flag (#1746)", () => {
   const stubAlias = `
 import { defineAlias, z } from "mcp-cli";

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -887,6 +887,7 @@ async function runPhase(argv: string[], d: PhaseInstallDeps): Promise<void> {
     state: {} as AliasStateAccessor, // overwritten by wrapDryRunContext
     globalState: {} as AliasStateAccessor, // overwritten by wrapDryRunContext
     workItem: null,
+    repoRoot: findGitRoot(cwd) ?? NO_REPO_ROOT,
     signal: controller.signal,
     waitForEvent: createWaitForEvent({ signal: controller.signal }),
   };

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -1264,6 +1264,7 @@ export async function executePhase(
     state,
     globalState: createAliasState({ repoRoot, namespace: GLOBAL_STATE_NAMESPACE, call: ex.ipcCall }),
     workItem,
+    repoRoot,
     signal: phaseController.signal,
     waitForEvent: createWaitForEvent({ signal: phaseController.signal }),
   };

--- a/packages/core/src/alias-bundle.spec.ts
+++ b/packages/core/src/alias-bundle.spec.ts
@@ -287,6 +287,7 @@ describe("bundleAlias", () => {
         state: stubState,
         globalState: stubState,
         workItem: null,
+        repoRoot: "__none__",
         signal: new AbortController().signal,
         waitForEvent: async () => {
           throw new Error("not in test");
@@ -412,6 +413,7 @@ describe("executeAliasBundled", () => {
         state: stubState,
         globalState: stubState,
         workItem: null,
+        repoRoot: "__none__",
         signal: new AbortController().signal,
         waitForEvent: async () => {
           throw new Error("not in test");
@@ -452,6 +454,7 @@ describe("executeAliasBundled", () => {
           state: stubState,
           globalState: stubState,
           workItem: null,
+          repoRoot: "__none__",
           signal: new AbortController().signal,
           waitForEvent: async () => {
             throw new Error("not in test");
@@ -494,6 +497,7 @@ describe("executeAliasBundled", () => {
           state: stubState,
           globalState: stubState,
           workItem: null,
+          repoRoot: "__none__",
           signal: new AbortController().signal,
           waitForEvent: async () => {
             throw new Error("not in test");
@@ -537,6 +541,7 @@ describe("executeAliasBundled", () => {
         state: stubState,
         globalState: stubState,
         workItem: null,
+        repoRoot: "__none__",
         signal: new AbortController().signal,
         waitForEvent: async () => {
           throw new Error("not in test");
@@ -577,6 +582,7 @@ describe("executeAliasBundled", () => {
         state: stubState,
         globalState: stubState,
         workItem: null,
+        repoRoot: "__none__",
         signal: new AbortController().signal,
         waitForEvent: async () => {
           throw new Error("not in test");
@@ -606,6 +612,7 @@ describe("executeAliasBundled", () => {
         state: stubState,
         globalState: stubState,
         workItem: null,
+        repoRoot: "__none__",
         signal: new AbortController().signal,
         waitForEvent: async () => {
           throw new Error("not in test");

--- a/packages/core/src/alias-dry-run.spec.ts
+++ b/packages/core/src/alias-dry-run.spec.ts
@@ -65,6 +65,7 @@ describe("wrapDryRunContext", () => {
       state: { get: async () => undefined, all: async () => ({}), set: async () => {}, delete: async () => {} },
       globalState: { get: async () => undefined, all: async () => ({}), set: async () => {}, delete: async () => {} },
       workItem: null,
+      repoRoot: "__none__",
       signal: new AbortController().signal,
       waitForEvent: async () => {
         throw new Error("not in test");
@@ -96,6 +97,7 @@ describe("wrapDryRunContext", () => {
       state: { get: async () => undefined, all: async () => ({}), set: async () => {}, delete: async () => {} },
       globalState: { get: async () => undefined, all: async () => ({}), set: async () => {}, delete: async () => {} },
       workItem: null,
+      repoRoot: "__none__",
       signal: new AbortController().signal,
       waitForEvent: async () => {
         throw new Error("not in test");

--- a/packages/core/src/alias.ts
+++ b/packages/core/src/alias.ts
@@ -148,6 +148,13 @@ export interface AliasContext {
    */
   workItem: AliasWorkItemInfo | null;
   /**
+   * Absolute path to the git repository root for the current invocation.
+   * Resolved from the caller's cwd via findGitRoot, so it is correct even
+   * when the alias or phase is invoked from a subdirectory. Falls back to
+   * NO_REPO_ROOT ("__no_repo__") when the caller is not inside a git repo.
+   */
+  repoRoot?: string;
+  /**
    * Cancellation signal for this alias invocation. Fires on SIGINT, SIGTERM,
    * or daemon shutdown. Aliases that do long-running work should check this
    * signal and abort gracefully. `waitForEvent` is wired to this signal

--- a/packages/core/src/alias.ts
+++ b/packages/core/src/alias.ts
@@ -151,9 +151,9 @@ export interface AliasContext {
    * Absolute path to the git repository root for the current invocation.
    * Resolved from the caller's cwd via findGitRoot, so it is correct even
    * when the alias or phase is invoked from a subdirectory. Falls back to
-   * NO_REPO_ROOT ("__no_repo__") when the caller is not inside a git repo.
+   * NO_REPO_ROOT ("__none__") when the caller is not inside a git repo.
    */
-  repoRoot?: string;
+  repoRoot: string;
   /**
    * Cancellation signal for this alias invocation. Fires on SIGINT, SIGTERM,
    * or daemon shutdown. Aliases that do long-running work should check this

--- a/packages/daemon/src/alias-executor.spec.ts
+++ b/packages/daemon/src/alias-executor.spec.ts
@@ -278,3 +278,63 @@ describe("alias-executor subprocess protocol", () => {
     expect(stderr).toContain("MORE NOISE");
   });
 });
+
+describe("alias-executor ctx.repoRoot (#1958)", () => {
+  test("ctx.repoRoot is populated from cwd via findGitRoot, not NO_REPO_ROOT", async () => {
+    const dir = makeTmpDir();
+    const scriptPath = join(dir, "repo-root.ts");
+    writeFileSync(
+      scriptPath,
+      [
+        'import { defineAlias, z } from "mcp-cli";',
+        "defineAlias({",
+        '  name: "repo-root",',
+        "  input: z.object({}).default({}),",
+        "  fn: (_input, ctx) => ({ repoRoot: ctx.repoRoot }),",
+        "});",
+      ].join("\n"),
+    );
+
+    const { js } = await bundleAlias(scriptPath);
+    // Pass the worktree as cwd — it is a real git repo so findGitRoot resolves it
+    const { stdout, exitCode } = await runExecutor({
+      bundledJs: js,
+      input: {},
+      isDefineAlias: true,
+      cwd: import.meta.dir,
+    });
+
+    expect(exitCode).toBe(0);
+    const { result } = JSON.parse(stdout) as { result: { repoRoot: string } };
+    expect(result.repoRoot).toBeTruthy();
+    expect(result.repoRoot).not.toBe("__none__");
+  });
+
+  test("ctx.repoRoot falls back to NO_REPO_ROOT when cwd is not in a git repo", async () => {
+    const dir = makeTmpDir();
+    const scriptPath = join(dir, "repo-root-none.ts");
+    writeFileSync(
+      scriptPath,
+      [
+        'import { defineAlias, z } from "mcp-cli";',
+        "defineAlias({",
+        '  name: "repo-root-none",',
+        "  input: z.object({}).default({}),",
+        "  fn: (_input, ctx) => ({ repoRoot: ctx.repoRoot }),",
+        "});",
+      ].join("\n"),
+    );
+
+    const { js } = await bundleAlias(scriptPath);
+    const { stdout, exitCode } = await runExecutor({
+      bundledJs: js,
+      input: {},
+      isDefineAlias: true,
+      cwd: dir, // tmpdir is not a git repo
+    });
+
+    expect(exitCode).toBe(0);
+    const { result } = JSON.parse(stdout) as { result: { repoRoot: string } };
+    expect(result.repoRoot).toBe("__none__");
+  });
+});

--- a/packages/daemon/src/alias-executor.ts
+++ b/packages/daemon/src/alias-executor.ts
@@ -169,6 +169,7 @@ async function main(): Promise<void> {
     state: createAliasState({ repoRoot, namespace: aliasUserNamespace(currentAlias) }),
     globalState: createAliasState({ repoRoot, namespace: GLOBAL_STATE_NAMESPACE }),
     workItem: workItem ?? null,
+    repoRoot,
     signal: controller.signal,
     waitForEvent: createWaitForEvent({ signal: controller.signal }),
   };


### PR DESCRIPTION
## Summary
- Adds `repoRoot?: string` field to `AliasContext` in `packages/core/src/alias.ts`, populated from the already-computed `findGitRoot` result
- `executePhase` (`packages/command/src/commands/phase.ts`) and `alias-executor` (`packages/daemon/src/alias-executor.ts`) now set `ctx.repoRoot`
- Phase scripts `impl.ts` and `review.ts` use `ctx.repoRoot ?? process.cwd()` when calling `findModelInSprintPlan`, fixing the silent null return when invoked from a subdirectory

## Test plan
- [ ] New test in `phase.spec.ts`: "executePhase passes ctx.repoRoot from findGitRoot (#1958)" — verifies `ctx.repoRoot` equals the `findGitRoot` return value, not `process.cwd()`
- [ ] All 6830 existing tests pass (`bun test`)
- [ ] TypeScript, lint, coverage thresholds all green via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)