### PR TITLE
fix(claude): thread deps through status case in cmdClaudeInternal (fixes #1933)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -5143,3 +5143,35 @@ describe("cmdClaude routing — CLAUDE_ONLY_SUBCOMMANDS regression", () => {
     }
   });
 });
+
+// ── DI threading for status (#1933) ──
+
+describe("cmdClaude status — DI threading", () => {
+  const FAKE_SESSION = {
+    sessionId: "ccc11111-aaaa-bbbb-cccc-dddddddddddd",
+    name: "Alice",
+    state: "idle",
+    model: "claude-opus-4",
+    cost: 0,
+    tokens: 0,
+    numTurns: 0,
+    cwd: "/repo",
+    worktree: null,
+    repoRoot: null,
+    createdAt: Date.now(),
+  };
+
+  test("injected callTool is used for status subcommand via cmdClaude with deps", async () => {
+    const callTool = mock(async (tool: string) => {
+      if (tool === "claude_session_list") return toolResult([FAKE_SESSION]);
+      return toolResult([]);
+    });
+    const deps = makeDeps({ callTool });
+    await cmdClaude(["status", "ccc11111"], deps);
+    expect(callTool).toHaveBeenCalledWith("claude_session_list", {});
+    expect(callTool).toHaveBeenCalledWith("claude_transcript", {
+      sessionId: FAKE_SESSION.sessionId,
+      limit: 150,
+    });
+  });
+});

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -315,7 +315,7 @@ async function cmdClaudeInternal(args: string[], deps?: Partial<ClaudeDeps>): Pr
       break;
     case "status": {
       const { cmdAgent } = await import("./agent");
-      await cmdAgent(["claude", sub, ...subArgs]);
+      await cmdAgent(["claude", sub, ...subArgs], d);
       break;
     }
     default:


### PR DESCRIPTION
## Summary
- The `status` case in `cmdClaudeInternal` was calling `cmdAgent(["claude", sub, ...subArgs])` without forwarding the merged deps object `d`, causing injected deps (callTool, printError, etc.) to be silently ignored for this subcommand
- One-line fix: pass `d` as the second argument to `cmdAgent` — `ClaudeDeps` is structurally compatible with `Partial<AgentDeps>` so no type changes needed
- Added a regression test in `claude.spec.ts` verifying that the injected `callTool` is actually invoked when `status` is called through `cmdClaude` with deps

## Test plan
- [x] New test `cmdClaude status — DI threading` confirms injected `callTool` receives `claude_session_list` and `claude_transcript` calls
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun test` — 6847 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)