### PR TITLE
test(phases): extract phase logic into *-fn.ts and add unit tests (closes #1960)

### DIFF
--- a/.claude/phases/done-fn.ts
+++ b/.claude/phases/done-fn.ts
@@ -1,0 +1,127 @@
+/** Core done-phase logic, extracted for testability via dependency injection. */
+
+import type { GhResult } from "./gh";
+
+export type MergeResult =
+  | { ok: true; prNumber: number; localCleanup?: string }
+  | {
+      ok: false;
+      reason:
+        | "ci_not_green"
+        | "missing_qa_pass"
+        | "conflicts"
+        | "missing_required_check"
+        | "merge_failed";
+      nextAction: string;
+      detail?: string;
+    };
+
+export interface MergePrDeps {
+  gh(args: string[]): Promise<GhResult>;
+  prMerge(prNumber: number, flags: string[]): Promise<GhResult>;
+  prView(prNumber: number, fields: string, jqExpr?: string): Promise<string>;
+  spawn(cmd: string[], opts?: { timeoutMs?: number }): Promise<GhResult>;
+}
+
+export async function mergePr(prNumber: number, deps: MergePrDeps): Promise<MergeResult> {
+  // Guard 1 + Guard 2 in parallel: fetch labels and CI status concurrently.
+  const [labelOut, ciOut] = await Promise.all([
+    deps.gh(["pr", "view", String(prNumber), "--json", "labels", "-q", ".labels[].name"]),
+    deps.gh([
+      "pr", "view", String(prNumber),
+      "--json", "statusCheckRollup",
+      "-q", '[.statusCheckRollup[] | select(.conclusion != "SUCCESS")] | length',
+    ]),
+  ]);
+
+  if (labelOut.exitCode !== 0) {
+    return {
+      ok: false,
+      reason: "merge_failed",
+      nextAction: `gh pr view labels failed for PR #${prNumber}; check gh auth and retry`,
+      detail: labelOut.stderr,
+    };
+  }
+  if (ciOut.exitCode !== 0) {
+    return {
+      ok: false,
+      reason: "merge_failed",
+      nextAction: `gh pr view statusCheckRollup failed for PR #${prNumber}; check gh auth and retry`,
+      detail: ciOut.stderr,
+    };
+  }
+
+  const labels = labelOut.stdout.split(/\r?\n/).map((l) => l.trim());
+  if (!labels.includes("qa:pass")) {
+    return {
+      ok: false,
+      reason: "missing_qa_pass",
+      nextAction: `spawn qa for PR #${prNumber}; do not transition to done until qa:pass is set`,
+    };
+  }
+  if (labels.includes("qa:fail")) {
+    return {
+      ok: false,
+      reason: "missing_qa_pass",
+      nextAction: `PR #${prNumber} has both qa:pass and qa:fail; remove the stale label before merge`,
+    };
+  }
+
+  const ungreen = Number.parseInt(ciOut.stdout, 10);
+  if (!Number.isFinite(ungreen) || ungreen > 0) {
+    return {
+      ok: false,
+      reason: "ci_not_green",
+      nextAction: `wait for CI to go green on PR #${prNumber}; rerun failing checks if flaky, otherwise send repair`,
+    };
+  }
+
+  await deps.spawn(["git", "config", "core.bare", "false"]);
+
+  const mergeResult = await deps.prMerge(prNumber, ["--squash", "--delete-branch"]);
+  if (mergeResult.exitCode !== 0) {
+    const stderr = mergeResult.stderr;
+    // Signal kill (e.g. timeout SIGTERM exit 143) or worktree branch-delete
+    // failure may mean the merge actually succeeded on GitHub's side.
+    const maybeSucceeded =
+      /used by worktree|cannot delete branch.*checked out/i.test(stderr) ||
+      mergeResult.exitCode >= 128;
+    if (maybeSucceeded) {
+      try {
+        const stateOut = await deps.prView(prNumber, "state", ".state");
+        if (stateOut === "MERGED") {
+          return {
+            ok: true,
+            prNumber,
+            localCleanup: "skipped: worktree holds branch (bye impl session to prune)",
+          };
+        }
+      } catch {
+        /* prView failed — fall through to error classification */
+      }
+    }
+    if (/not mergeable|conflict/i.test(stderr)) {
+      return {
+        ok: false,
+        reason: "conflicts",
+        nextAction: "spawn one-shot rebase worker for branch; do not rebase from orchestrator cwd",
+        detail: stderr,
+      };
+    }
+    if (/required check|required status/i.test(stderr)) {
+      return {
+        ok: false,
+        reason: "missing_required_check",
+        nextAction: "inspect branch-protection required checks; re-run the missing check",
+        detail: stderr,
+      };
+    }
+    return {
+      ok: false,
+      reason: "merge_failed",
+      nextAction: "read the gh pr merge stderr and retry",
+      detail: stderr,
+    };
+  }
+  return { ok: true, prNumber };
+}

--- a/.claude/phases/done.ts
+++ b/.claude/phases/done.ts
@@ -13,123 +13,7 @@
  */
 import { defineAlias, z } from "mcp-cli";
 import { gh, prMerge, prView, spawn } from "./gh";
-
-type MergeResult =
-  | { ok: true; prNumber: number; localCleanup?: string }
-  | {
-      ok: false;
-      reason:
-        | "ci_not_green"
-        | "missing_qa_pass"
-        | "conflicts"
-        | "missing_required_check"
-        | "merge_failed";
-      nextAction: string;
-      detail?: string;
-    };
-
-async function mergePr(prNumber: number): Promise<MergeResult> {
-  // Guard 1 + Guard 2 in parallel: fetch labels and CI status concurrently.
-  const [labelOut, ciOut] = await Promise.all([
-    gh(["pr", "view", String(prNumber), "--json", "labels", "-q", ".labels[].name"]),
-    gh([
-      "pr", "view", String(prNumber),
-      "--json", "statusCheckRollup",
-      "-q", '[.statusCheckRollup[] | select(.conclusion != "SUCCESS")] | length',
-    ]),
-  ]);
-
-  if (labelOut.exitCode !== 0) {
-    return {
-      ok: false,
-      reason: "merge_failed",
-      nextAction: `gh pr view labels failed for PR #${prNumber}; check gh auth and retry`,
-      detail: labelOut.stderr,
-    };
-  }
-  if (ciOut.exitCode !== 0) {
-    return {
-      ok: false,
-      reason: "merge_failed",
-      nextAction: `gh pr view statusCheckRollup failed for PR #${prNumber}; check gh auth and retry`,
-      detail: ciOut.stderr,
-    };
-  }
-
-  const labels = labelOut.stdout.split(/\r?\n/).map((l) => l.trim());
-  if (!labels.includes("qa:pass")) {
-    return {
-      ok: false,
-      reason: "missing_qa_pass",
-      nextAction: `spawn qa for PR #${prNumber}; do not transition to done until qa:pass is set`,
-    };
-  }
-  if (labels.includes("qa:fail")) {
-    return {
-      ok: false,
-      reason: "missing_qa_pass",
-      nextAction: `PR #${prNumber} has both qa:pass and qa:fail; remove the stale label before merge`,
-    };
-  }
-
-  const ungreen = Number.parseInt(ciOut.stdout, 10);
-  if (!Number.isFinite(ungreen) || ungreen > 0) {
-    return {
-      ok: false,
-      reason: "ci_not_green",
-      nextAction: `wait for CI to go green on PR #${prNumber}; rerun failing checks if flaky, otherwise send repair`,
-    };
-  }
-
-  await spawn(["git", "config", "core.bare", "false"]);
-
-  const mergeResult = await prMerge(prNumber, ["--squash", "--delete-branch"]);
-  if (mergeResult.exitCode !== 0) {
-    const stderr = mergeResult.stderr;
-    // Signal kill (e.g. timeout SIGTERM exit 143) or worktree branch-delete
-    // failure may mean the merge actually succeeded on GitHub's side.
-    const maybeSucceeded =
-      /used by worktree|cannot delete branch.*checked out/i.test(stderr) ||
-      mergeResult.exitCode >= 128;
-    if (maybeSucceeded) {
-      try {
-        const stateOut = await prView(prNumber, "state", ".state");
-        if (stateOut === "MERGED") {
-          return {
-            ok: true,
-            prNumber,
-            localCleanup: "skipped: worktree holds branch (bye impl session to prune)",
-          };
-        }
-      } catch {
-        /* prView failed — fall through to error classification */
-      }
-    }
-    if (/not mergeable|conflict/i.test(stderr)) {
-      return {
-        ok: false,
-        reason: "conflicts",
-        nextAction: "spawn one-shot rebase worker for branch; do not rebase from orchestrator cwd",
-        detail: stderr,
-      };
-    }
-    if (/required check|required status/i.test(stderr)) {
-      return {
-        ok: false,
-        reason: "missing_required_check",
-        nextAction: "inspect branch-protection required checks; re-run the missing check",
-        detail: stderr,
-      };
-    }
-    return {
-      ok: false,
-      reason: "merge_failed",
-      nextAction: "read the gh pr merge stderr and retry",
-      detail: stderr,
-    };
-  }
-  return { ok: true, prNumber };
-}
+import { mergePr } from "./done-fn";
 
 defineAlias({
   name: "phase-done",
@@ -162,7 +46,7 @@ defineAlias({
       );
     }
 
-    const result = await mergePr(work.prNumber);
+    const result = await mergePr(work.prNumber, { gh, prMerge, prView, spawn });
     if (!result.ok) {
       return {
         merged: false,

--- a/.claude/phases/gh.ts
+++ b/.claude/phases/gh.ts
@@ -15,7 +15,7 @@ export interface GhResult {
 }
 
 /** A function with the same signature as the top-level `gh()` — injectable for tests. */
-export type GhRunner = (args: string[], opts?: { timeoutMs?: number }) => Promise<GhResult>;
+export type GhRunner = (args: string[], opts?: { timeoutMs?: number; sigkillDelayMs?: number }) => Promise<GhResult>;
 
 export async function gh(
   args: string[],
@@ -34,7 +34,7 @@ async function runGh(args: string[], timeoutMs: number, sigkillDelayMs: number):
 
   let sigkillTimer: ReturnType<typeof setTimeout> | undefined;
   const timer = setTimeout(() => {
-    proc.kill();
+    try { proc.kill(); } catch { /* already exited */ }
     sigkillTimer = setTimeout(() => {
       try { proc.kill(9); } catch { /* already exited */ }
     }, sigkillDelayMs);
@@ -121,7 +121,7 @@ export async function spawn(
   const proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "pipe" });
   let sigkillTimer: ReturnType<typeof setTimeout> | undefined;
   const timer = setTimeout(() => {
-    proc.kill();
+    try { proc.kill(); } catch { /* already exited */ }
     sigkillTimer = setTimeout(() => {
       try { proc.kill(9); } catch { /* already exited */ }
     }, sigkillDelayMs);

--- a/.claude/phases/gh.ts
+++ b/.claude/phases/gh.ts
@@ -6,6 +6,7 @@
  */
 
 const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_SIGKILL_DELAY_MS = 5_000;
 
 export interface GhResult {
   stdout: string;
@@ -13,15 +14,19 @@ export interface GhResult {
   exitCode: number;
 }
 
+/** A function with the same signature as the top-level `gh()` — injectable for tests. */
+export type GhRunner = (args: string[], opts?: { timeoutMs?: number }) => Promise<GhResult>;
+
 export async function gh(
   args: string[],
-  opts?: { timeoutMs?: number },
+  opts?: { timeoutMs?: number; sigkillDelayMs?: number },
 ): Promise<GhResult> {
   const timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-  return runGh(args, timeoutMs);
+  const sigkillDelayMs = opts?.sigkillDelayMs ?? DEFAULT_SIGKILL_DELAY_MS;
+  return runGh(args, timeoutMs, sigkillDelayMs);
 }
 
-async function runGh(args: string[], timeoutMs: number): Promise<GhResult> {
+async function runGh(args: string[], timeoutMs: number, sigkillDelayMs: number): Promise<GhResult> {
   const proc = Bun.spawn(["gh", ...args], {
     stdout: "pipe",
     stderr: "pipe",
@@ -32,7 +37,7 @@ async function runGh(args: string[], timeoutMs: number): Promise<GhResult> {
     proc.kill();
     sigkillTimer = setTimeout(() => {
       try { proc.kill(9); } catch { /* already exited */ }
-    }, 5_000);
+    }, sigkillDelayMs);
   }, timeoutMs);
 
   const [stdout, stderr, exitCode] = await Promise.all([
@@ -47,55 +52,79 @@ async function runGh(args: string[], timeoutMs: number): Promise<GhResult> {
   return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode };
 }
 
-export async function prView(prNumber: number, fields: string, jqExpr?: string): Promise<string> {
+export async function prView(
+  prNumber: number,
+  fields: string,
+  jqExpr?: string,
+  _gh: GhRunner = gh,
+): Promise<string> {
   const args = ["pr", "view", String(prNumber), "--json", fields];
   if (jqExpr) args.push("-q", jqExpr);
-  const result = await gh(args);
+  const result = await _gh(args);
   if (result.exitCode !== 0) {
     throw new Error(`gh pr view ${prNumber} failed (exit ${result.exitCode}): ${result.stderr}`);
   }
   return result.stdout;
 }
 
-export async function prList(opts: { head?: string; json?: string; jq?: string }): Promise<string> {
+export async function prList(
+  opts: { head?: string; json?: string; jq?: string },
+  _gh: GhRunner = gh,
+): Promise<string> {
   const args = ["pr", "list"];
   if (opts.head) args.push("--head", opts.head);
   if (opts.json) args.push("--json", opts.json);
   if (opts.jq) args.push("-q", opts.jq);
-  const result = await gh(args);
+  const result = await _gh(args);
   if (result.exitCode !== 0) {
     throw new Error(`gh pr list failed (exit ${result.exitCode}): ${result.stderr}`);
   }
   return result.stdout;
 }
 
-export async function prEdit(prNumber: number, flags: string[]): Promise<void> {
-  const result = await gh(["pr", "edit", String(prNumber), ...flags]);
+export async function prEdit(
+  prNumber: number,
+  flags: string[],
+  _gh: GhRunner = gh,
+): Promise<void> {
+  const result = await _gh(["pr", "edit", String(prNumber), ...flags]);
   if (result.exitCode !== 0) {
     throw new Error(`gh pr edit ${prNumber} failed (exit ${result.exitCode}): ${result.stderr}`);
   }
 }
 
-export async function prMerge(prNumber: number, flags: string[]): Promise<GhResult> {
-  return gh(["pr", "merge", String(prNumber), ...flags]);
+export async function prMerge(
+  prNumber: number,
+  flags: string[],
+  _gh: GhRunner = gh,
+): Promise<GhResult> {
+  return _gh(["pr", "merge", String(prNumber), ...flags]);
 }
 
-export async function prComment(prNumber: number, body: string): Promise<void> {
-  const result = await gh(["pr", "comment", String(prNumber), "--body", body]);
+export async function prComment(
+  prNumber: number,
+  body: string,
+  _gh: GhRunner = gh,
+): Promise<void> {
+  const result = await _gh(["pr", "comment", String(prNumber), "--body", body]);
   if (result.exitCode !== 0) {
     throw new Error(`gh pr comment ${prNumber} failed (exit ${result.exitCode}): ${result.stderr}`);
   }
 }
 
-export async function spawn(cmd: string[], opts?: { timeoutMs?: number }): Promise<GhResult> {
+export async function spawn(
+  cmd: string[],
+  opts?: { timeoutMs?: number; sigkillDelayMs?: number },
+): Promise<GhResult> {
   const timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const sigkillDelayMs = opts?.sigkillDelayMs ?? DEFAULT_SIGKILL_DELAY_MS;
   const proc = Bun.spawn(cmd, { stdout: "pipe", stderr: "pipe" });
   let sigkillTimer: ReturnType<typeof setTimeout> | undefined;
   const timer = setTimeout(() => {
     proc.kill();
     sigkillTimer = setTimeout(() => {
       try { proc.kill(9); } catch { /* already exited */ }
-    }, 5_000);
+    }, sigkillDelayMs);
   }, timeoutMs);
   const [stdout, stderr, exitCode] = await Promise.all([
     new Response(proc.stdout).text(),

--- a/.claude/phases/needs-attention-fn.ts
+++ b/.claude/phases/needs-attention-fn.ts
@@ -1,0 +1,88 @@
+/** Core needs-attention-phase logic, extracted for testability via dependency injection. */
+
+export interface NeedsAttentionWork {
+  id: string;
+  prNumber: number;
+  issueNumber: number;
+}
+
+export interface NeedsAttentionState {
+  get<T>(key: string): Promise<T | undefined>;
+}
+
+export interface NeedsAttentionDeps {
+  prEdit(prNumber: number, flags: string[]): Promise<void>;
+  prComment(prNumber: number, body: string): Promise<void>;
+  updateWorkItemPhase(id: string, phase: string): Promise<void>;
+}
+
+export interface NeedsAttentionResult {
+  prNumber: number;
+  issueNumber: number;
+  reviewRound: number;
+  repairRound: number;
+  qaFailRound: number;
+  commented: boolean;
+}
+
+export function buildNeedsAttentionBody(
+  prNumber: number,
+  reviewRound: number,
+  repairRound: number,
+  qaFailRound: number,
+  triage: string,
+): string {
+  return [
+    "## 🚩 Needs attention",
+    "",
+    `Automated sprint pipeline exhausted its round caps on PR #${prNumber}.`,
+    "",
+    "| Round type | Count |",
+    "|------------|-------|",
+    `| Review     | ${reviewRound} |`,
+    `| Repair     | ${repairRound} |`,
+    `| QA fail    | ${qaFailRound} |`,
+    "",
+    `Triage scrutiny was **${triage}**. An operator should decide between: refining the issue spec, taking over the PR manually, or closing it.`,
+  ].join("\n");
+}
+
+export async function runNeedsAttention(
+  work: NeedsAttentionWork,
+  state: NeedsAttentionState,
+  deps: NeedsAttentionDeps,
+): Promise<NeedsAttentionResult> {
+  const reviewRound = (await state.get<number>("review_round")) ?? 0;
+  const repairRound = (await state.get<number>("repair_round")) ?? 0;
+  const qaFailRound = (await state.get<number>("qa_fail_round")) ?? 0;
+  const triage = (await state.get<string>("triage_scrutiny")) ?? "unknown";
+
+  await Promise.all(
+    ["qa:pass", "qa:fail"].map((label) => deps.prEdit(work.prNumber, ["--remove-label", label]).catch(() => {})),
+  );
+
+  const body = buildNeedsAttentionBody(work.prNumber, reviewRound, repairRound, qaFailRound, triage);
+
+  let commented = false;
+  try {
+    await deps.prComment(work.prNumber, body);
+    commented = true;
+  } catch {
+    /* best-effort */
+  }
+
+  try {
+    await deps.updateWorkItemPhase(work.id, "needs-attention");
+  } catch {
+    /* non-fatal */
+  }
+
+  return {
+    prNumber: work.prNumber,
+    issueNumber: work.issueNumber,
+    reviewRound,
+    repairRound,
+    qaFailRound,
+    commented,
+  };
+}

--- a/.claude/phases/needs-attention.ts
+++ b/.claude/phases/needs-attention.ts
@@ -9,6 +9,7 @@
  */
 import { defineAlias, z } from "mcp-cli";
 import { prComment, prEdit } from "./gh";
+import { runNeedsAttention } from "./needs-attention-fn";
 
 defineAlias({
   name: "phase-needs-attention",
@@ -36,51 +37,15 @@ defineAlias({
       );
     }
 
-    const reviewRound = (await ctx.state.get<number>("review_round")) ?? 0;
-    const repairRound = (await ctx.state.get<number>("repair_round")) ?? 0;
-    const qaFailRound = (await ctx.state.get<number>("qa_fail_round")) ?? 0;
-    const triage = (await ctx.state.get<string>("triage_scrutiny")) ?? "unknown";
-
-    // Strip stale qa: labels in parallel — best-effort, label may already be absent.
-    await Promise.all(
-      ["qa:pass", "qa:fail"].map((label) => prEdit(work.prNumber, ["--remove-label", label]).catch(() => {})),
+    return runNeedsAttention(
+      { id: work.id, prNumber: work.prNumber, issueNumber: work.issueNumber },
+      ctx.state,
+      {
+        prEdit,
+        prComment,
+        updateWorkItemPhase: (id, phase) =>
+          ctx.mcp._work_items.work_items_update({ id, phase }),
+      },
     );
-
-    const body = [
-      "## 🚩 Needs attention",
-      "",
-      `Automated sprint pipeline exhausted its round caps on PR #${work.prNumber}.`,
-      "",
-      "| Round type | Count |",
-      "|------------|-------|",
-      `| Review     | ${reviewRound} |`,
-      `| Repair     | ${repairRound} |`,
-      `| QA fail    | ${qaFailRound} |`,
-      "",
-      `Triage scrutiny was **${triage}**. An operator should decide between: refining the issue spec, taking over the PR manually, or closing it.`,
-    ].join("\n");
-
-    let commented = false;
-    try {
-      await prComment(work.prNumber, body);
-      commented = true;
-    } catch {
-      /* best-effort — escalation still proceeds */
-    }
-
-    try {
-      await ctx.mcp._work_items.work_items_update({ id: work.id, phase: "needs-attention" });
-    } catch {
-      /* non-fatal */
-    }
-
-    return {
-      prNumber: work.prNumber,
-      issueNumber: work.issueNumber,
-      reviewRound,
-      repairRound,
-      qaFailRound,
-      commented,
-    };
   },
 });

--- a/.claude/phases/qa-fn.ts
+++ b/.claude/phases/qa-fn.ts
@@ -1,0 +1,115 @@
+/** Core qa-phase logic, extracted for testability via dependency injection. */
+
+import type { GhResult } from "./gh";
+
+export const QA_FAIL_CAP = 2;
+
+export interface QaWork {
+  id: string;
+  prNumber: number;
+  branch: string;
+  issueNumber: number;
+}
+
+export interface QaState {
+  get<T>(key: string): Promise<T | undefined>;
+  set(key: string, value: unknown): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+
+export interface QaDeps {
+  gh(args: string[]): Promise<GhResult>;
+  prEdit(prNumber: number, flags: string[]): Promise<void>;
+}
+
+export type QaResult =
+  | {
+      action: "spawn";
+      reason: string;
+      model: "sonnet";
+      command: string[];
+      prompt: string;
+      allowTools: string[];
+    }
+  | { action: "wait"; reason: string; model: "sonnet"; prompt: string }
+  | { action: "goto"; target: "done" | "repair" | "needs-attention"; reason: string; model: "sonnet"; prompt: string; round?: number };
+
+export async function readQaLabels(
+  prNumber: number,
+  deps: Pick<QaDeps, "gh">,
+): Promise<{ hasPass: boolean; hasFail: boolean }> {
+  const result = await deps.gh(["pr", "view", String(prNumber), "--json", "labels", "-q", ".labels[].name"]);
+  if (result.exitCode !== 0) return { hasPass: false, hasFail: false };
+  const names = new Set(result.stdout.split(/\r?\n/).map((l) => l.trim()));
+  return { hasPass: names.has("qa:pass"), hasFail: names.has("qa:fail") };
+}
+
+async function removeLabel(prNumber: number, label: string, deps: Pick<QaDeps, "prEdit">): Promise<void> {
+  try {
+    await deps.prEdit(prNumber, ["--remove-label", label]);
+  } catch {
+    /* best-effort */
+  }
+}
+
+export async function runQa(
+  input: { provider: string },
+  work: QaWork,
+  state: QaState,
+  deps: QaDeps,
+): Promise<QaResult> {
+  const sessionId = await state.get<string>("qa_session_id");
+  const qaModel = "sonnet" as const;
+  const qaPrompt = `/qa ${work.issueNumber} (PR ${work.prNumber}, branch ${work.branch})`;
+
+  if (!sessionId) {
+    const worktreePath = await state.get<string>("worktree_path");
+    const allowTools = ["Read", "Glob", "Grep", "Write", "Edit", "Bash"];
+    const cmdBase = input.provider.startsWith("acp:")
+      ? ["mcx", "acp", "spawn", "--agent", input.provider.slice(4)]
+      : ["mcx", input.provider, "spawn"];
+    const worktreeFlags = worktreePath ? ["--cwd", worktreePath] : ["--worktree"];
+    const command = [...cmdBase, ...worktreeFlags, "--model", qaModel, "-t", qaPrompt, "--allow", ...allowTools];
+    await state.set("qa_session_id", `pending:${Date.now()}`);
+    return {
+      action: "spawn",
+      reason: "qa session starting",
+      model: qaModel,
+      command,
+      prompt: qaPrompt,
+      allowTools,
+    };
+  }
+
+  const { hasPass, hasFail } = await readQaLabels(work.prNumber, deps);
+  if (!hasPass && !hasFail) {
+    return { action: "wait", reason: "qa:pass / qa:fail label not set yet", model: qaModel, prompt: qaPrompt };
+  }
+
+  if (hasPass) {
+    if (hasFail) await removeLabel(work.prNumber, "qa:fail", deps);
+    return { action: "goto", target: "done", reason: "qa:pass → done", model: qaModel, prompt: qaPrompt };
+  }
+
+  const round = ((await state.get<number>("qa_fail_round")) ?? 0) + 1;
+  if (round > QA_FAIL_CAP) {
+    return {
+      action: "goto",
+      target: "needs-attention",
+      reason: `qa fail cap (${QA_FAIL_CAP}) exceeded — escalating`,
+      round: round - 1,
+      model: qaModel,
+      prompt: qaPrompt,
+    };
+  }
+  await state.set("qa_fail_round", round);
+  await state.set("previous_phase", "qa");
+  return {
+    action: "goto",
+    target: "repair",
+    reason: `qa:fail round ${round} → repair`,
+    round,
+    model: qaModel,
+    prompt: qaPrompt,
+  };
+}

--- a/.claude/phases/qa.ts
+++ b/.claude/phases/qa.ts
@@ -16,8 +16,7 @@
  */
 import { defineAlias, z } from "mcp-cli";
 import { gh, prEdit } from "./gh";
-
-const QA_FAIL_CAP = 2;
+import { runQa } from "./qa-fn";
 
 const ProviderSchema = z
   .string()
@@ -25,21 +24,6 @@ const ProviderSchema = z
     (v) => v === "claude" || v === "copilot" || v === "gemini" || v.startsWith("acp:"),
     { message: 'provider must be "claude", "copilot", "gemini", or "acp:<agent>"' },
   );
-
-async function readQaLabels(prNumber: number): Promise<{ hasPass: boolean; hasFail: boolean }> {
-  const result = await gh(["pr", "view", String(prNumber), "--json", "labels", "-q", ".labels[].name"]);
-  if (result.exitCode !== 0) return { hasPass: false, hasFail: false };
-  const names = new Set(result.stdout.split(/\r?\n/).map((l) => l.trim()));
-  return { hasPass: names.has("qa:pass"), hasFail: names.has("qa:fail") };
-}
-
-async function removeLabel(prNumber: number, label: string): Promise<void> {
-  try {
-    await prEdit(prNumber, ["--remove-label", label]);
-  } catch {
-    /* best-effort — label may already be absent */
-  }
-}
 
 defineAlias({
   name: "phase-qa",
@@ -72,66 +56,11 @@ defineAlias({
       );
     }
 
-    const sessionId = await ctx.state.get<string>("qa_session_id");
-
-    const qaModel = "sonnet" as const;
-    const qaPrompt = `/qa ${work.issueNumber} (PR ${work.prNumber}, branch ${work.branch})`;
-
-    if (!sessionId) {
-      const worktreePath = await ctx.state.get<string>("worktree_path");
-      const allowTools = ["Read", "Glob", "Grep", "Write", "Edit", "Bash"];
-      const cmdBase = input.provider.startsWith("acp:")
-        ? ["mcx", "acp", "spawn", "--agent", input.provider.slice(4)]
-        : ["mcx", input.provider, "spawn"];
-      const worktreeFlags = worktreePath ? ["--cwd", worktreePath] : ["--worktree"];
-      const command = [...cmdBase, ...worktreeFlags, "--model", qaModel, "-t", qaPrompt, "--allow", ...allowTools];
-      // Write sentinel before returning — prevents re-spawn on retry.
-      // Orchestrator replaces with real session ID after spawn.
-      await ctx.state.set("qa_session_id", `pending:${Date.now()}`);
-      return {
-        action: "spawn" as const,
-        reason: "qa session starting",
-        model: qaModel,
-        command,
-        prompt: qaPrompt,
-        allowTools,
-      };
-    }
-
-    const { hasPass, hasFail } = await readQaLabels(work.prNumber);
-    if (!hasPass && !hasFail) {
-      return { action: "wait" as const, reason: "qa:pass / qa:fail label not set yet", model: qaModel, prompt: qaPrompt };
-    }
-
-    // Label hygiene: pass is the authoritative verdict when both are present
-    // (the most recent QA round set it). Strip the stale counterpart on
-    // every verdict so merge gates can trust "pass xor fail" (see #1303).
-    if (hasPass) {
-      if (hasFail) await removeLabel(work.prNumber, "qa:fail");
-      return { action: "goto" as const, target: "done" as const, reason: "qa:pass → done", model: qaModel, prompt: qaPrompt };
-    }
-    // hasFail only — no stale pass possible (we would have returned above).
-
-    const round = ((await ctx.state.get<number>("qa_fail_round")) ?? 0) + 1;
-    if (round > QA_FAIL_CAP) {
-      return {
-        action: "goto" as const,
-        target: "needs-attention" as const,
-        reason: `qa fail cap (${QA_FAIL_CAP}) exceeded — escalating`,
-        round: round - 1,
-        model: qaModel,
-        prompt: qaPrompt,
-      };
-    }
-    await ctx.state.set("qa_fail_round", round);
-    await ctx.state.set("previous_phase", "qa");
-    return {
-      action: "goto" as const,
-      target: "repair" as const,
-      reason: `qa:fail round ${round} → repair`,
-      round,
-      model: qaModel,
-      prompt: qaPrompt,
-    };
+    return runQa(
+      input,
+      { id: work.id, prNumber: work.prNumber, branch: work.branch, issueNumber: work.issueNumber },
+      ctx.state,
+      { gh, prEdit },
+    );
   },
 });

--- a/.claude/phases/repair-fn.ts
+++ b/.claude/phases/repair-fn.ts
@@ -1,0 +1,99 @@
+/** Core repair-phase logic, extracted for testability via dependency injection. */
+
+export const REPAIR_ROUND_CAP = 3;
+
+export interface RepairWork {
+  id: string;
+  prNumber: number;
+}
+
+export interface RepairState {
+  get<T>(key: string): Promise<T | undefined>;
+  set(key: string, value: unknown): Promise<void>;
+  delete(key: string): Promise<void>;
+}
+
+export interface RepairDeps {
+  prEdit(prNumber: number, flags: string[]): Promise<void>;
+}
+
+export type RepairResult =
+  | { action: "in-flight"; reason: string; round: number; model: "opus"; prompt?: string }
+  | { action: "goto"; target: "needs-attention"; reason: string; round: number }
+  | {
+      action: "spawn";
+      reason: string;
+      round: number;
+      model: "opus";
+      command: string[];
+      prompt: string;
+      allowTools: string[];
+    };
+
+export function buildRepairPrompt(prNumber: number, previousPhase: "review" | "qa"): string {
+  return previousPhase === "qa"
+    ? `Repair PR #${prNumber}. Read the qa:fail comment: gh pr view ${prNumber} --comments. Address every blocker. Push to existing branch.`
+    : `Repair PR #${prNumber}. Read the adversarial review sticky comment: gh pr view ${prNumber} --comments. Fix all 🔴 and 🟡. Push to existing branch.`;
+}
+
+export async function runRepair(
+  input: { provider: string },
+  work: RepairWork,
+  state: RepairState,
+  deps: RepairDeps,
+): Promise<RepairResult> {
+  const existingSession = await state.get<string>("repair_session_id");
+  if (existingSession) {
+    const round = (await state.get<number>("repair_round")) ?? 1;
+    const storedPrompt = await state.get<string>("repair_prompt");
+    return {
+      action: "in-flight",
+      reason: `repair session in flight (round ${round})`,
+      round,
+      model: "opus",
+      ...(storedPrompt ? { prompt: storedPrompt } : {}),
+    };
+  }
+
+  const prevRound = (await state.get<number>("repair_round")) ?? 0;
+  const round = prevRound + 1;
+  if (round > REPAIR_ROUND_CAP) {
+    return {
+      action: "goto",
+      target: "needs-attention",
+      reason: `repair cap (${REPAIR_ROUND_CAP}) exceeded — escalating`,
+      round: prevRound,
+    };
+  }
+
+  const previous = ((await state.get<string>("previous_phase")) ?? "review") as "review" | "qa";
+  const worktreePath = await state.get<string>("worktree_path");
+  const prompt = buildRepairPrompt(work.prNumber, previous);
+  const allowTools = ["Read", "Glob", "Grep", "Write", "Edit", "Bash", "ExitPlanMode", "EnterPlanMode"];
+  const cmdBase = input.provider.startsWith("acp:")
+    ? ["mcx", "acp", "spawn", "--agent", input.provider.slice(4)]
+    : ["mcx", input.provider, "spawn"];
+  const worktreeFlags = worktreePath ? ["--cwd", worktreePath] : ["--worktree"];
+  const command = [...cmdBase, ...worktreeFlags, "--model", "opus", "-t", prompt, "--allow", ...allowTools];
+
+  await state.delete("qa_session_id");
+  try {
+    await deps.prEdit(work.prNumber, ["--remove-label", "qa:fail"]);
+  } catch {
+    /* best-effort */
+  }
+
+  await state.set("repair_round", round);
+  await state.set("repair_prompt", prompt);
+  await state.set("repair_session_id", `pending:${Date.now()}`);
+
+  return {
+    action: "spawn",
+    reason: `repair round ${round}, triggered by ${previous}`,
+    round,
+    model: "opus",
+    command,
+    prompt,
+    allowTools,
+  };
+}

--- a/.claude/phases/repair.ts
+++ b/.claude/phases/repair.ts
@@ -16,16 +16,7 @@
  */
 import { defineAlias, z } from "mcp-cli";
 import { prEdit } from "./gh";
-
-const REPAIR_ROUND_CAP = 3;
-
-async function removeLabel(prNumber: number, label: string): Promise<void> {
-  try {
-    await prEdit(prNumber, ["--remove-label", label]);
-  } catch {
-    /* best-effort — label may already be absent */
-  }
-}
+import { runRepair } from "./repair-fn";
 
 const ProviderSchema = z
   .string()
@@ -63,67 +54,11 @@ defineAlias({
       );
     }
 
-    // In-flight guard — repair session already running; don't spawn a second.
-    const existingSession = await ctx.state.get<string>("repair_session_id");
-    if (existingSession) {
-      const round = (await ctx.state.get<number>("repair_round")) ?? 1;
-      const storedPrompt = await ctx.state.get<string>("repair_prompt");
-      return {
-        action: "in-flight" as const,
-        reason: `repair session in flight (round ${round})`,
-        round,
-        model: "opus" as const,
-        ...(storedPrompt ? { prompt: storedPrompt } : {}),
-      };
-    }
-
-    const prevRound = (await ctx.state.get<number>("repair_round")) ?? 0;
-    const round = prevRound + 1;
-    if (round > REPAIR_ROUND_CAP) {
-      return {
-        action: "goto" as const,
-        target: "needs-attention" as const,
-        reason: `repair cap (${REPAIR_ROUND_CAP}) exceeded — escalating`,
-        round: prevRound,
-      };
-    }
-
-    const previous = ((await ctx.state.get<string>("previous_phase")) ?? "review") as "review" | "qa";
-    const worktreePath = await ctx.state.get<string>("worktree_path");
-
-    const prompt =
-      previous === "qa"
-        ? `Repair PR #${work.prNumber}. Read the qa:fail comment: gh pr view ${work.prNumber} --comments. Address every blocker. Push to existing branch.`
-        : `Repair PR #${work.prNumber}. Read the adversarial review sticky comment: gh pr view ${work.prNumber} --comments. Fix all 🔴 and 🟡. Push to existing branch.`;
-
-    const allowTools = ["Read", "Glob", "Grep", "Write", "Edit", "Bash", "ExitPlanMode", "EnterPlanMode"];
-    const cmdBase = input.provider.startsWith("acp:")
-      ? ["mcx", "acp", "spawn", "--agent", input.provider.slice(4)]
-      : ["mcx", input.provider, "spawn"];
-    const worktreeFlags = worktreePath ? ["--cwd", worktreePath] : ["--worktree"];
-    const command = [...cmdBase, ...worktreeFlags, "--model", "opus", "-t", prompt, "--allow", ...allowTools];
-
-    // Clear stale QA state so the qa phase re-spawns fresh after repair.
-    // Without this, qa sees the old qa:fail label and loops back to repair
-    // instead of running a new QA session (sprint 36 hit this on #1412).
-    await ctx.state.delete("qa_session_id");
-    await removeLabel(work.prNumber, "qa:fail");
-
-    // Persist round, sentinel, and prompt before returning. The prompt is
-    // stored so in-flight re-entry can return it without recomputing state
-    // (repair_prompt is read in the in-flight guard above — see #1922).
-    await ctx.state.set("repair_round", round);
-    await ctx.state.set("repair_prompt", prompt);
-    await ctx.state.set("repair_session_id", `pending:${Date.now()}`);
-
-    return {
-      action: "spawn" as const,
-      reason: `repair round ${round}, triggered by ${previous}`,
-      round,
-      model: "opus" as const,
-      command,
-      prompt,
-      allowTools,
-    };
+    return runRepair(
+      input,
+      { id: work.id, prNumber: work.prNumber },
+      ctx.state,
+      { prEdit },
+    );
   },
 });

--- a/.claude/phases/review-fn.ts
+++ b/.claude/phases/review-fn.ts
@@ -1,0 +1,115 @@
+/** Core review-phase logic, extracted for testability via dependency injection. */
+
+import type { GhResult } from "./gh";
+
+export const REVIEW_ROUND_CAP = 2;
+
+export interface ReviewWork {
+  id: string;
+  prNumber: number;
+  branch: string;
+  issueNumber: number | null;
+}
+
+export interface ReviewState {
+  get<T>(key: string): Promise<T | undefined>;
+  set(key: string, value: unknown): Promise<void>;
+}
+
+export interface ReviewDeps {
+  gh(args: string[]): Promise<GhResult>;
+  findModelInSprintPlan(issueNumber: number, repoRoot: string): "opus" | "sonnet" | null;
+}
+
+export type ReviewResult =
+  | {
+      action: "spawn";
+      reason: string;
+      round: number;
+      command: string[];
+      prompt: string;
+      allowTools: string[];
+      model: "opus" | "sonnet";
+    }
+  | { action: "wait"; reason: string; round: number; model?: "opus" | "sonnet" }
+  | { action: "goto"; target: "repair" | "qa"; reason: string; round: number; model?: "opus" | "sonnet" };
+
+export async function scanReviewComments(
+  prNumber: number,
+  deps: Pick<ReviewDeps, "gh">,
+): Promise<{ found: boolean; hasBlockers: boolean; summary: string }> {
+  const result = await deps.gh(["pr", "view", String(prNumber), "--json", "comments", "-q", ".comments[].body"]);
+  if (result.exitCode !== 0) return { found: false, hasBlockers: false, summary: "gh pr view failed" };
+  const sticky = result.stdout.split(/\n{2,}/).reverse().find((b) => b.includes("## Adversarial Review"));
+  if (!sticky) return { found: false, hasBlockers: false, summary: "no sticky comment yet" };
+  const hasBlockers = /🔴|🟡/.test(sticky);
+  return { found: true, hasBlockers, summary: hasBlockers ? "blockers remain" : "all clear" };
+}
+
+export async function runReview(
+  input: { provider: string; model?: "opus" | "sonnet" },
+  work: ReviewWork,
+  state: ReviewState,
+  deps: ReviewDeps,
+  repoRoot: string,
+): Promise<ReviewResult> {
+  const round = (await state.get<number>("review_round")) ?? 1;
+  const sessionId = await state.get<string>("review_session_id");
+
+  if (!sessionId) {
+    let model: "opus" | "sonnet";
+    if (input.model) {
+      model = input.model;
+    } else {
+      const planModel =
+        work.issueNumber != null && repoRoot !== "__none__"
+          ? deps.findModelInSprintPlan(work.issueNumber, repoRoot)
+          : null;
+      model = planModel ?? "sonnet";
+    }
+
+    const allowTools = ["Read", "Glob", "Grep", "Write", "Edit", "Bash"];
+    const prompt = `/adversarial-review (PR ${work.prNumber}, branch ${work.branch}, round ${round})`;
+    const cmdBase = input.provider.startsWith("acp:")
+      ? ["mcx", "acp", "spawn", "--agent", input.provider.slice(4)]
+      : ["mcx", input.provider, "spawn"];
+    const command = [...cmdBase, "--worktree", "--model", model, "-t", prompt, "--allow", ...allowTools];
+
+    await state.set("review_round", round);
+    await state.set("review_model", model);
+    await state.set("review_session_id", `pending:${Date.now()}`);
+    return {
+      action: "spawn",
+      reason: `review round ${round} starting`,
+      round,
+      command,
+      prompt,
+      allowTools,
+      model,
+    };
+  }
+
+  const storedModel = (await state.get<string>("review_model")) as "opus" | "sonnet" | null;
+  const scan = await scanReviewComments(work.prNumber, deps);
+  if (!scan.found) {
+    return { action: "wait", reason: scan.summary, round, ...(storedModel ? { model: storedModel } : {}) };
+  }
+
+  if (!scan.hasBlockers) {
+    return { action: "goto", target: "qa", reason: "review clean → qa", round, ...(storedModel ? { model: storedModel } : {}) };
+  }
+
+  if (round >= REVIEW_ROUND_CAP) {
+    return {
+      action: "goto",
+      target: "qa",
+      reason: `review round cap (${REVIEW_ROUND_CAP}) reached; deferring remaining items to qa`,
+      round,
+      ...(storedModel ? { model: storedModel } : {}),
+    };
+  }
+
+  await state.set("review_round", round + 1);
+  await state.set("previous_phase", "review");
+  return { action: "goto", target: "repair", reason: "blockers remain → repair", round, ...(storedModel ? { model: storedModel } : {}) };
+}

--- a/.claude/phases/review-fn.ts
+++ b/.claude/phases/review-fn.ts
@@ -40,8 +40,9 @@ export async function scanReviewComments(
 ): Promise<{ found: boolean; hasBlockers: boolean; summary: string }> {
   const result = await deps.gh(["pr", "view", String(prNumber), "--json", "comments", "-q", ".comments[].body"]);
   if (result.exitCode !== 0) return { found: false, hasBlockers: false, summary: "gh pr view failed" };
-  const sticky = result.stdout.split(/\n{2,}/).reverse().find((b) => b.includes("## Adversarial Review"));
-  if (!sticky) return { found: false, hasBlockers: false, summary: "no sticky comment yet" };
+  const lastIdx = result.stdout.lastIndexOf("## Adversarial Review");
+  if (lastIdx === -1) return { found: false, hasBlockers: false, summary: "no sticky comment yet" };
+  const sticky = result.stdout.slice(lastIdx);
   const hasBlockers = /🔴|🟡/.test(sticky);
   return { found: true, hasBlockers, summary: hasBlockers ? "blockers remain" : "all clear" };
 }

--- a/.claude/phases/review.ts
+++ b/.claude/phases/review.ts
@@ -25,8 +25,7 @@
 import { NO_REPO_ROOT, findModelInSprintPlan } from "@mcp-cli/core";
 import { defineAlias, z } from "mcp-cli";
 import { gh } from "./gh";
-
-const REVIEW_ROUND_CAP = 2;
+import { runReview } from "./review-fn";
 
 const ProviderSchema = z
   .string()
@@ -34,15 +33,6 @@ const ProviderSchema = z
     (v) => v === "claude" || v === "copilot" || v === "gemini" || v.startsWith("acp:"),
     { message: 'provider must be "claude", "copilot", "gemini", or "acp:<agent>"' },
   );
-
-async function scanReviewComments(prNumber: number): Promise<{ found: boolean; hasBlockers: boolean; summary: string }> {
-  const result = await gh(["pr", "view", String(prNumber), "--json", "comments", "-q", ".comments[].body"]);
-  if (result.exitCode !== 0) return { found: false, hasBlockers: false, summary: "gh pr view failed" };
-  const sticky = result.stdout.split(/\n{2,}/).reverse().find((b) => b.includes("## Adversarial Review"));
-  if (!sticky) return { found: false, hasBlockers: false, summary: "no sticky comment yet" };
-  const hasBlockers = /🔴|🟡/.test(sticky);
-  return { found: true, hasBlockers, summary: hasBlockers ? "blockers remain" : "all clear" };
-}
 
 defineAlias({
   name: "phase-review",
@@ -75,73 +65,12 @@ defineAlias({
       );
     }
 
-    const round = (await ctx.state.get<number>("review_round")) ?? 1;
-    const sessionId = await ctx.state.get<string>("review_session_id");
-
-    // No session yet → spawn one.
-    if (!sessionId) {
-      // Model resolution: explicit input → sprint plan → default sonnet.
-      // Mirrors impl.ts so plan-mandated opus picks get opus reviewers too.
-      let model: "opus" | "sonnet";
-      if (input.model) {
-        model = input.model;
-      } else {
-        const planModel =
-          work.issueNumber != null && ctx.repoRoot !== NO_REPO_ROOT
-            ? findModelInSprintPlan(work.issueNumber, ctx.repoRoot)
-            : null;
-        model = planModel ?? "sonnet";
-      }
-
-      const allowTools = ["Read", "Glob", "Grep", "Write", "Edit", "Bash"];
-      const prompt = `/adversarial-review (PR ${work.prNumber}, branch ${work.branch}, round ${round})`;
-      const cmdBase = input.provider.startsWith("acp:")
-        ? ["mcx", "acp", "spawn", "--agent", input.provider.slice(4)]
-        : ["mcx", input.provider, "spawn"];
-      const command = [...cmdBase, "--worktree", "--model", model, "-t", prompt, "--allow", ...allowTools];
-      // Persist round counter, model, and sentinel before returning — re-entry
-      // returns "wait" (not a new spawn) until the orchestrator clears
-      // review_session_id. Storing model lets wait/goto return it for safe
-      // single-call extraction by the orchestrator (see #1922).
-      await ctx.state.set("review_round", round);
-      await ctx.state.set("review_model", model);
-      await ctx.state.set("review_session_id", `pending:${Date.now()}`);
-      return {
-        action: "spawn" as const,
-        reason: `review round ${round} starting`,
-        round,
-        command,
-        prompt,
-        allowTools,
-        model,
-      };
-    }
-
-    // Session exists — check PR for sticky comment.
-    // Read stored model so all return paths include it (see #1922).
-    const storedModel = (await ctx.state.get<string>("review_model")) as "opus" | "sonnet" | null;
-    const scan = await scanReviewComments(work.prNumber);
-    if (!scan.found) {
-      return { action: "wait" as const, reason: scan.summary, round, ...(storedModel ? { model: storedModel } : {}) };
-    }
-
-    if (!scan.hasBlockers) {
-      return { action: "goto" as const, target: "qa" as const, reason: "review clean → qa", round, ...(storedModel ? { model: storedModel } : {}) };
-    }
-
-    // Blockers present. Cap exceeded → hand off to qa instead of looping.
-    if (round >= REVIEW_ROUND_CAP) {
-      return {
-        action: "goto" as const,
-        target: "qa" as const,
-        reason: `review round cap (${REVIEW_ROUND_CAP}) reached; deferring remaining items to qa`,
-        round,
-        ...(storedModel ? { model: storedModel } : {}),
-      };
-    }
-
-    await ctx.state.set("review_round", round + 1);
-    await ctx.state.set("previous_phase", "review");
-    return { action: "goto" as const, target: "repair" as const, reason: "blockers remain → repair", round, ...(storedModel ? { model: storedModel } : {}) };
+    return runReview(
+      input,
+      { id: work.id, prNumber: work.prNumber, branch: work.branch, issueNumber: work.issueNumber ?? null },
+      ctx.state,
+      { gh, findModelInSprintPlan },
+      ctx.repoRoot ?? NO_REPO_ROOT,
+    );
   },
 });

--- a/test/done-phase.spec.ts
+++ b/test/done-phase.spec.ts
@@ -1,0 +1,265 @@
+import { describe, expect, test } from "bun:test";
+import { type MergePrDeps, mergePr } from "../.claude/phases/done-fn";
+import type { GhResult } from "../.claude/phases/gh";
+
+function ok(stdout = ""): GhResult {
+  return { stdout, stderr: "", exitCode: 0 };
+}
+
+function fail(stderr = "oops", exitCode = 1): GhResult {
+  return { stdout: "", stderr, exitCode };
+}
+
+function makeDeps(overrides: Partial<MergePrDeps> = {}): MergePrDeps {
+  return {
+    gh: async (args) => {
+      // Default: labels returns qa:pass, CI returns 0 ungreen checks
+      if (args.includes("labels")) return ok("qa:pass");
+      if (args.includes("statusCheckRollup")) return ok("0");
+      return ok();
+    },
+    prMerge: async () => ok(),
+    prView: async () => "MERGED",
+    spawn: async () => ok(),
+    ...overrides,
+  };
+}
+
+// ── Guard failures ──
+
+describe("mergePr — label guard", () => {
+  test("missing qa:pass → missing_qa_pass", async () => {
+    const result = await mergePr(
+      100,
+      makeDeps({
+        gh: async (args) => {
+          if (args.includes("labels")) return ok("needs-review");
+          return ok("0");
+        },
+      }),
+    );
+    expect(result).toMatchObject({ ok: false, reason: "missing_qa_pass" });
+    if (!result.ok) expect(result.nextAction).toContain("spawn qa");
+  });
+
+  test("both qa:pass and qa:fail → missing_qa_pass (stale label)", async () => {
+    const result = await mergePr(
+      100,
+      makeDeps({
+        gh: async (args) => {
+          if (args.includes("labels")) return ok("qa:pass\nqa:fail");
+          return ok("0");
+        },
+      }),
+    );
+    expect(result).toMatchObject({ ok: false, reason: "missing_qa_pass" });
+    if (!result.ok) expect(result.nextAction).toContain("stale label");
+  });
+
+  test("gh labels call fails → merge_failed", async () => {
+    const result = await mergePr(
+      100,
+      makeDeps({
+        gh: async (args) => {
+          if (args.includes("labels")) return fail("auth required");
+          return ok("0");
+        },
+      }),
+    );
+    expect(result).toMatchObject({ ok: false, reason: "merge_failed" });
+    if (!result.ok) expect(result.detail).toBe("auth required");
+  });
+
+  test("gh CI call fails → merge_failed", async () => {
+    const result = await mergePr(
+      100,
+      makeDeps({
+        gh: async (args) => {
+          if (args.includes("labels")) return ok("qa:pass");
+          return fail("rate limited");
+        },
+      }),
+    );
+    expect(result).toMatchObject({ ok: false, reason: "merge_failed" });
+    if (!result.ok) expect(result.detail).toBe("rate limited");
+  });
+
+  test("ungreen CI checks → ci_not_green", async () => {
+    const result = await mergePr(
+      100,
+      makeDeps({
+        gh: async (args) => {
+          if (args.includes("labels")) return ok("qa:pass");
+          return ok("3");
+        },
+      }),
+    );
+    expect(result).toMatchObject({ ok: false, reason: "ci_not_green" });
+  });
+
+  test("non-numeric CI output → ci_not_green", async () => {
+    const result = await mergePr(
+      100,
+      makeDeps({
+        gh: async (args) => {
+          if (args.includes("labels")) return ok("qa:pass");
+          return ok("null");
+        },
+      }),
+    );
+    expect(result).toMatchObject({ ok: false, reason: "ci_not_green" });
+  });
+});
+
+// ── Successful merge ──
+
+describe("mergePr — success", () => {
+  test("all guards pass → ok: true", async () => {
+    const result = await mergePr(100, makeDeps());
+    expect(result).toMatchObject({ ok: true, prNumber: 100 });
+  });
+
+  test("prMerge called with correct flags", async () => {
+    let capturedPr: number | undefined;
+    let capturedFlags: string[] | undefined;
+    await mergePr(
+      42,
+      makeDeps({
+        prMerge: async (prNumber, flags) => {
+          capturedPr = prNumber;
+          capturedFlags = flags;
+          return ok();
+        },
+      }),
+    );
+    expect(capturedPr).toBe(42);
+    expect(capturedFlags).toEqual(["--squash", "--delete-branch"]);
+  });
+
+  test("spawn called to reset core.bare before merge", async () => {
+    const spawnCalls: string[][] = [];
+    await mergePr(
+      42,
+      makeDeps({
+        spawn: async (cmd) => {
+          spawnCalls.push(cmd);
+          return ok();
+        },
+      }),
+    );
+    expect(spawnCalls[0]).toEqual(["git", "config", "core.bare", "false"]);
+  });
+});
+
+// ── Merge failure classification ──
+
+describe("mergePr — merge failure paths", () => {
+  test("conflict error → conflicts", async () => {
+    const result = await mergePr(100, makeDeps({ prMerge: async () => fail("Pull Request is not mergeable") }));
+    expect(result).toMatchObject({ ok: false, reason: "conflicts" });
+    if (!result.ok) expect(result.detail).toContain("not mergeable");
+  });
+
+  test("'conflict' keyword → conflicts", async () => {
+    const result = await mergePr(100, makeDeps({ prMerge: async () => fail("merge conflict detected") }));
+    expect(result).toMatchObject({ ok: false, reason: "conflicts" });
+  });
+
+  test("required check error → missing_required_check", async () => {
+    const result = await mergePr(100, makeDeps({ prMerge: async () => fail("required check 'CI' has not passed") }));
+    expect(result).toMatchObject({ ok: false, reason: "missing_required_check" });
+  });
+
+  test("required status error → missing_required_check", async () => {
+    const result = await mergePr(100, makeDeps({ prMerge: async () => fail("Required status check not passing") }));
+    expect(result).toMatchObject({ ok: false, reason: "missing_required_check" });
+  });
+
+  test("generic failure → merge_failed", async () => {
+    const result = await mergePr(100, makeDeps({ prMerge: async () => fail("something unexpected") }));
+    expect(result).toMatchObject({ ok: false, reason: "merge_failed" });
+  });
+
+  test("SIGTERM exit code (143) → check PR state, if MERGED → ok", async () => {
+    const result = await mergePr(
+      100,
+      makeDeps({
+        prMerge: async () => ({ stdout: "", stderr: "killed", exitCode: 143 }),
+        prView: async () => "MERGED",
+      }),
+    );
+    // exitCode >= 128 triggers the maybeSucceeded path which always sets localCleanup
+    expect(result).toMatchObject({ ok: true, prNumber: 100 });
+    if (result.ok) expect(result.localCleanup).toContain("worktree");
+  });
+
+  test("worktree branch error → check PR state, if MERGED → ok with localCleanup", async () => {
+    const result = await mergePr(
+      100,
+      makeDeps({
+        prMerge: async () => fail("cannot delete branch 'feat/foo' used by worktree"),
+        prView: async () => "MERGED",
+      }),
+    );
+    expect(result).toMatchObject({ ok: true, prNumber: 100 });
+    if (result.ok) expect(result.localCleanup).toContain("worktree");
+  });
+
+  test("worktree branch error + PR not merged → merge_failed", async () => {
+    const result = await mergePr(
+      100,
+      makeDeps({
+        prMerge: async () => fail("cannot delete branch 'feat/foo' used by worktree"),
+        prView: async () => "OPEN",
+      }),
+    );
+    expect(result).toMatchObject({ ok: false, reason: "merge_failed" });
+  });
+
+  test("worktree branch error + prView throws → merge_failed fallthrough", async () => {
+    const result = await mergePr(
+      100,
+      makeDeps({
+        prMerge: async () => fail("cannot delete branch 'feat/foo' used by worktree"),
+        prView: async () => {
+          throw new Error("network error");
+        },
+      }),
+    );
+    expect(result).toMatchObject({ ok: false, reason: "merge_failed" });
+  });
+
+  test("SIGKILL exit code (137) triggers maybeSucceeded check", async () => {
+    const result = await mergePr(
+      100,
+      makeDeps({
+        prMerge: async () => ({ stdout: "", stderr: "killed", exitCode: 137 }),
+        prView: async () => "MERGED",
+      }),
+    );
+    expect(result).toMatchObject({ ok: true, prNumber: 100 });
+  });
+});
+
+// ── Guard order ──
+
+describe("mergePr — guard ordering", () => {
+  test("gh calls happen in parallel (both args captured)", async () => {
+    const capturedArgs: string[][] = [];
+    await mergePr(
+      100,
+      makeDeps({
+        gh: async (args) => {
+          capturedArgs.push(args);
+          if (args.includes("labels")) return ok("qa:pass");
+          return ok("0");
+        },
+      }),
+    );
+    // Both calls should have occurred
+    const hasLabels = capturedArgs.some((a) => a.includes("labels"));
+    const hasCi = capturedArgs.some((a) => a.includes("statusCheckRollup"));
+    expect(hasLabels).toBe(true);
+    expect(hasCi).toBe(true);
+  });
+});

--- a/test/gh-helpers.spec.ts
+++ b/test/gh-helpers.spec.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from "bun:test";
+import { type GhResult, gh, prComment, prEdit, prList, prMerge, prView, spawn } from "../.claude/phases/gh";
+
+function ok(stdout = ""): GhResult {
+  return { stdout, stderr: "", exitCode: 0 };
+}
+
+function fail(stderr = "oops"): GhResult {
+  return { stdout: "", stderr, exitCode: 1 };
+}
+
+// ── prView ──
+
+describe("prView — argument construction", () => {
+  test("builds args without jqExpr", async () => {
+    let captured: string[] | undefined;
+    await prView(42, "state,title", undefined, async (args) => {
+      captured = args;
+      return ok('{"state":"OPEN"}');
+    });
+    expect(captured).toEqual(["pr", "view", "42", "--json", "state,title"]);
+  });
+
+  test("builds args with jqExpr", async () => {
+    let captured: string[] | undefined;
+    await prView(42, "state", ".state", async (args) => {
+      captured = args;
+      return ok("OPEN");
+    });
+    expect(captured).toEqual(["pr", "view", "42", "--json", "state", "-q", ".state"]);
+  });
+
+  test("returns stdout on success", async () => {
+    const result = await prView(42, "state", ".state", async () => ok("MERGED"));
+    expect(result).toBe("MERGED");
+  });
+
+  test("throws on non-zero exit", async () => {
+    await expect(prView(42, "state", undefined, async () => fail("not found"))).rejects.toThrow(
+      "gh pr view 42 failed (exit 1): not found",
+    );
+  });
+});
+
+// ── prList ──
+
+describe("prList — argument construction", () => {
+  test("builds args with no opts", async () => {
+    let captured: string[] | undefined;
+    await prList({}, async (args) => {
+      captured = args;
+      return ok("[]");
+    });
+    expect(captured).toEqual(["pr", "list"]);
+  });
+
+  test("builds args with head", async () => {
+    let captured: string[] | undefined;
+    await prList({ head: "feat/my-branch" }, async (args) => {
+      captured = args;
+      return ok("[]");
+    });
+    expect(captured).toEqual(["pr", "list", "--head", "feat/my-branch"]);
+  });
+
+  test("builds args with json + jq", async () => {
+    let captured: string[] | undefined;
+    await prList({ json: "number,title", jq: ".[0].number" }, async (args) => {
+      captured = args;
+      return ok("123");
+    });
+    expect(captured).toEqual(["pr", "list", "--json", "number,title", "-q", ".[0].number"]);
+  });
+
+  test("throws on non-zero exit", async () => {
+    await expect(prList({}, async () => fail("auth failed"))).rejects.toThrow(
+      "gh pr list failed (exit 1): auth failed",
+    );
+  });
+});
+
+// ── prEdit ──
+
+describe("prEdit — argument construction", () => {
+  test("builds args with flags", async () => {
+    let captured: string[] | undefined;
+    await prEdit(99, ["--add-label", "qa:pass"], async (args) => {
+      captured = args;
+      return ok();
+    });
+    expect(captured).toEqual(["pr", "edit", "99", "--add-label", "qa:pass"]);
+  });
+
+  test("throws on non-zero exit", async () => {
+    await expect(prEdit(99, ["--add-label", "qa:pass"], async () => fail("forbidden"))).rejects.toThrow(
+      "gh pr edit 99 failed (exit 1): forbidden",
+    );
+  });
+});
+
+// ── prMerge ──
+
+describe("prMerge — argument construction", () => {
+  test("builds args with flags", async () => {
+    let captured: string[] | undefined;
+    await prMerge(77, ["--squash", "--delete-branch"], async (args) => {
+      captured = args;
+      return ok();
+    });
+    expect(captured).toEqual(["pr", "merge", "77", "--squash", "--delete-branch"]);
+  });
+
+  test("returns result even on non-zero exit (no throw)", async () => {
+    const result = await prMerge(77, [], async () => fail("conflict"));
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe("conflict");
+  });
+});
+
+// ── prComment ──
+
+describe("prComment — argument construction", () => {
+  test("builds args with body", async () => {
+    let captured: string[] | undefined;
+    await prComment(55, "hello world", async (args) => {
+      captured = args;
+      return ok();
+    });
+    expect(captured).toEqual(["pr", "comment", "55", "--body", "hello world"]);
+  });
+
+  test("throws on non-zero exit", async () => {
+    await expect(prComment(55, "body", async () => fail("rate limited"))).rejects.toThrow(
+      "gh pr comment 55 failed (exit 1): rate limited",
+    );
+  });
+});
+
+// ── SIGKILL escalation ──
+
+describe("spawn — timeout kills process", () => {
+  test("SIGTERM kills an ordinary slow process within timeout window", async () => {
+    const start = Date.now();
+    // sleep responds to SIGTERM immediately
+    const result = await spawn(["sleep", "60"], { timeoutMs: 100 });
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(2_000);
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  test("SIGKILL escalation: kills process that ignores SIGTERM", async () => {
+    const start = Date.now();
+    // Single-process bun script ignoring SIGTERM — pipe closes only on SIGKILL
+    const result = await spawn(["bun", "-e", "process.on('SIGTERM', () => {}); setInterval(() => {}, 60000)"], {
+      timeoutMs: 100,
+      sigkillDelayMs: 100,
+    });
+    const elapsed = Date.now() - start;
+    // Should be SIGKILL'd after ~200ms, not 60 seconds
+    expect(elapsed).toBeLessThan(3_000);
+    expect(result.exitCode).not.toBe(0);
+  }, 5000);
+});

--- a/test/needs-attention-phase.spec.ts
+++ b/test/needs-attention-phase.spec.ts
@@ -1,0 +1,182 @@
+import { describe, expect, test } from "bun:test";
+import {
+  type NeedsAttentionDeps,
+  type NeedsAttentionState,
+  type NeedsAttentionWork,
+  buildNeedsAttentionBody,
+  runNeedsAttention,
+} from "../.claude/phases/needs-attention-fn";
+
+function makeWork(overrides: Partial<NeedsAttentionWork> = {}): NeedsAttentionWork {
+  return { id: "#42", prNumber: 100, issueNumber: 42, ...overrides };
+}
+
+function makeState(initial: Record<string, unknown> = {}): NeedsAttentionState {
+  const store = new Map<string, unknown>(Object.entries(initial));
+  return {
+    get: async <T>(key: string) => store.get(key) as T | undefined,
+  };
+}
+
+function makeDeps(overrides: Partial<NeedsAttentionDeps> = {}): NeedsAttentionDeps {
+  return {
+    prEdit: async () => {},
+    prComment: async () => {},
+    updateWorkItemPhase: async () => {},
+    ...overrides,
+  };
+}
+
+// ── buildNeedsAttentionBody ──
+
+describe("buildNeedsAttentionBody — pure function", () => {
+  test("includes PR number", () => {
+    const body = buildNeedsAttentionBody(42, 2, 3, 1, "high");
+    expect(body).toContain("PR #42");
+  });
+
+  test("includes round counts", () => {
+    const body = buildNeedsAttentionBody(42, 2, 3, 1, "high");
+    expect(body).toContain("| Review     | 2 |");
+    expect(body).toContain("| Repair     | 3 |");
+    expect(body).toContain("| QA fail    | 1 |");
+  });
+
+  test("includes triage scrutiny level", () => {
+    const body = buildNeedsAttentionBody(42, 0, 0, 0, "low");
+    expect(body).toContain("**low**");
+  });
+
+  test("includes operator guidance", () => {
+    const body = buildNeedsAttentionBody(42, 0, 0, 0, "high");
+    expect(body).toContain("refining the issue spec");
+    expect(body).toContain("taking over the PR manually");
+  });
+
+  test("starts with needs attention header", () => {
+    const body = buildNeedsAttentionBody(42, 0, 0, 0, "unknown");
+    expect(body).toMatch(/^## 🚩 Needs attention/);
+  });
+});
+
+// ── runNeedsAttention ──
+
+describe("runNeedsAttention — state reading", () => {
+  test("reads round counts from state", async () => {
+    const result = await runNeedsAttention(
+      makeWork(),
+      makeState({ review_round: 2, repair_round: 3, qa_fail_round: 1 }),
+      makeDeps(),
+    );
+    expect(result.reviewRound).toBe(2);
+    expect(result.repairRound).toBe(3);
+    expect(result.qaFailRound).toBe(1);
+  });
+
+  test("defaults to 0 when state keys missing", async () => {
+    const result = await runNeedsAttention(makeWork(), makeState(), makeDeps());
+    expect(result.reviewRound).toBe(0);
+    expect(result.repairRound).toBe(0);
+    expect(result.qaFailRound).toBe(0);
+  });
+
+  test("returns correct prNumber and issueNumber", async () => {
+    const result = await runNeedsAttention(makeWork({ prNumber: 55, issueNumber: 99 }), makeState(), makeDeps());
+    expect(result.prNumber).toBe(55);
+    expect(result.issueNumber).toBe(99);
+  });
+});
+
+describe("runNeedsAttention — side effects", () => {
+  test("removes qa:pass and qa:fail labels in parallel", async () => {
+    const editCalls: Array<{ prNumber: number; flags: string[] }> = [];
+    await runNeedsAttention(
+      makeWork({ prNumber: 77 }),
+      makeState(),
+      makeDeps({
+        prEdit: async (prNumber, flags) => {
+          editCalls.push({ prNumber, flags });
+        },
+      }),
+    );
+    expect(editCalls.some((c) => c.prNumber === 77 && c.flags.includes("qa:pass"))).toBe(true);
+    expect(editCalls.some((c) => c.prNumber === 77 && c.flags.includes("qa:fail"))).toBe(true);
+  });
+
+  test("prEdit failure is swallowed (best-effort)", async () => {
+    await expect(
+      runNeedsAttention(
+        makeWork(),
+        makeState(),
+        makeDeps({
+          prEdit: async () => {
+            throw new Error("forbidden");
+          },
+        }),
+      ),
+    ).resolves.toBeDefined();
+  });
+
+  test("prComment called with body containing PR number", async () => {
+    let capturedBody: string | undefined;
+    await runNeedsAttention(
+      makeWork({ prNumber: 55 }),
+      makeState(),
+      makeDeps({
+        prComment: async (_, body) => {
+          capturedBody = body;
+        },
+      }),
+    );
+    expect(capturedBody).toContain("PR #55");
+  });
+
+  test("prComment success → commented: true", async () => {
+    const result = await runNeedsAttention(makeWork(), makeState(), makeDeps());
+    expect(result.commented).toBe(true);
+  });
+
+  test("prComment failure → commented: false (best-effort)", async () => {
+    const result = await runNeedsAttention(
+      makeWork(),
+      makeState(),
+      makeDeps({
+        prComment: async () => {
+          throw new Error("network error");
+        },
+      }),
+    );
+    expect(result.commented).toBe(false);
+  });
+
+  test("updateWorkItemPhase called with correct args", async () => {
+    let capturedId: string | undefined;
+    let capturedPhase: string | undefined;
+    await runNeedsAttention(
+      makeWork({ id: "#99" }),
+      makeState(),
+      makeDeps({
+        updateWorkItemPhase: async (id, phase) => {
+          capturedId = id;
+          capturedPhase = phase;
+        },
+      }),
+    );
+    expect(capturedId).toBe("#99");
+    expect(capturedPhase).toBe("needs-attention");
+  });
+
+  test("updateWorkItemPhase failure is swallowed (non-fatal)", async () => {
+    await expect(
+      runNeedsAttention(
+        makeWork(),
+        makeState(),
+        makeDeps({
+          updateWorkItemPhase: async () => {
+            throw new Error("ECONNREFUSED");
+          },
+        }),
+      ),
+    ).resolves.toBeDefined();
+  });
+});

--- a/test/qa-phase.spec.ts
+++ b/test/qa-phase.spec.ts
@@ -94,6 +94,7 @@ describe("runQa — spawn path", () => {
 
   test("spawn result includes model=sonnet", async () => {
     const result = await runQa({ provider: "claude" }, makeWork(), makeState(), makeDeps());
+    expect(result.action).toBe("spawn");
     if (result.action === "spawn") {
       expect(result.model).toBe("sonnet");
     }
@@ -106,6 +107,7 @@ describe("runQa — spawn path", () => {
       makeState(),
       makeDeps(),
     );
+    expect(result.action).toBe("spawn");
     if (result.action === "spawn") {
       expect(result.prompt).toContain("99");
       expect(result.prompt).toContain("PR 200");
@@ -114,6 +116,7 @@ describe("runQa — spawn path", () => {
 
   test("command uses --worktree when no worktree_path in state", async () => {
     const result = await runQa({ provider: "claude" }, makeWork(), makeState(), makeDeps());
+    expect(result.action).toBe("spawn");
     if (result.action === "spawn") {
       expect(result.command).toContain("--worktree");
     }
@@ -126,6 +129,7 @@ describe("runQa — spawn path", () => {
       makeState({ worktree_path: "/tmp/my-worktree" }),
       makeDeps(),
     );
+    expect(result.action).toBe("spawn");
     if (result.action === "spawn") {
       expect(result.command).toContain("--cwd");
       expect(result.command).toContain("/tmp/my-worktree");
@@ -134,6 +138,7 @@ describe("runQa — spawn path", () => {
 
   test("acp provider builds correct command", async () => {
     const result = await runQa({ provider: "acp:my-agent" }, makeWork(), makeState(), makeDeps());
+    expect(result.action).toBe("spawn");
     if (result.action === "spawn") {
       expect(result.command).toEqual(expect.arrayContaining(["mcx", "acp", "spawn", "--agent", "my-agent"]));
     }
@@ -245,6 +250,7 @@ describe("runQa — qa:fail verdict", () => {
       makeState({ qa_session_id: "sess_123", qa_fail_round: 1 }),
       makeDeps({ gh: async () => ok("qa:fail") }),
     );
+    expect(result).toMatchObject({ action: "goto", target: "repair" });
     if (result.action === "goto") {
       expect(result.round).toBe(2);
     }

--- a/test/qa-phase.spec.ts
+++ b/test/qa-phase.spec.ts
@@ -1,0 +1,252 @@
+import { describe, expect, test } from "bun:test";
+import type { GhResult } from "../.claude/phases/gh";
+import { QA_FAIL_CAP, type QaDeps, type QaState, type QaWork, readQaLabels, runQa } from "../.claude/phases/qa-fn";
+
+function ok(stdout = ""): GhResult {
+  return { stdout, stderr: "", exitCode: 0 };
+}
+
+function makeWork(overrides: Partial<QaWork> = {}): QaWork {
+  return {
+    id: "#42",
+    prNumber: 100,
+    branch: "feat/issue-42-test",
+    issueNumber: 42,
+    ...overrides,
+  };
+}
+
+function makeState(initial: Record<string, unknown> = {}): QaState {
+  const store = new Map<string, unknown>(Object.entries(initial));
+  return {
+    get: async <T>(key: string) => store.get(key) as T | undefined,
+    set: async (key, value) => {
+      store.set(key, value);
+    },
+    delete: async (key) => {
+      store.delete(key);
+    },
+  };
+}
+
+function makeDeps(overrides: Partial<QaDeps> = {}): QaDeps {
+  return {
+    gh: async () => ok(""),
+    prEdit: async () => {},
+    ...overrides,
+  };
+}
+
+// ── readQaLabels ──
+
+describe("readQaLabels — parsing", () => {
+  test("empty labels → hasPass: false, hasFail: false", async () => {
+    const result = await readQaLabels(100, { gh: async () => ok("") });
+    expect(result).toEqual({ hasPass: false, hasFail: false });
+  });
+
+  test("qa:pass only", async () => {
+    const result = await readQaLabels(100, { gh: async () => ok("qa:pass") });
+    expect(result).toEqual({ hasPass: true, hasFail: false });
+  });
+
+  test("qa:fail only", async () => {
+    const result = await readQaLabels(100, { gh: async () => ok("qa:fail") });
+    expect(result).toEqual({ hasPass: false, hasFail: true });
+  });
+
+  test("both qa:pass and qa:fail", async () => {
+    const result = await readQaLabels(100, { gh: async () => ok("qa:pass\nqa:fail") });
+    expect(result).toEqual({ hasPass: true, hasFail: true });
+  });
+
+  test("gh call fails → both false", async () => {
+    const result = await readQaLabels(100, {
+      gh: async () => ({ stdout: "", stderr: "not found", exitCode: 1 }),
+    });
+    expect(result).toEqual({ hasPass: false, hasFail: false });
+  });
+
+  test("labels with extra whitespace are trimmed", async () => {
+    const result = await readQaLabels(100, { gh: async () => ok("  qa:pass  \n  qa:fail  ") });
+    expect(result).toEqual({ hasPass: true, hasFail: true });
+  });
+
+  test("passes correct args to gh", async () => {
+    let captured: string[] | undefined;
+    await readQaLabels(99, {
+      gh: async (args) => {
+        captured = args;
+        return ok("");
+      },
+    });
+    expect(captured).toEqual(["pr", "view", "99", "--json", "labels", "-q", ".labels[].name"]);
+  });
+});
+
+// ── runQa — spawn path ──
+
+describe("runQa — spawn path", () => {
+  test("no session → action: spawn", async () => {
+    const result = await runQa({ provider: "claude" }, makeWork(), makeState(), makeDeps());
+    expect(result.action).toBe("spawn");
+  });
+
+  test("spawn result includes model=sonnet", async () => {
+    const result = await runQa({ provider: "claude" }, makeWork(), makeState(), makeDeps());
+    if (result.action === "spawn") {
+      expect(result.model).toBe("sonnet");
+    }
+  });
+
+  test("prompt includes issue and PR number", async () => {
+    const result = await runQa(
+      { provider: "claude" },
+      makeWork({ issueNumber: 99, prNumber: 200 }),
+      makeState(),
+      makeDeps(),
+    );
+    if (result.action === "spawn") {
+      expect(result.prompt).toContain("99");
+      expect(result.prompt).toContain("PR 200");
+    }
+  });
+
+  test("command uses --worktree when no worktree_path in state", async () => {
+    const result = await runQa({ provider: "claude" }, makeWork(), makeState(), makeDeps());
+    if (result.action === "spawn") {
+      expect(result.command).toContain("--worktree");
+    }
+  });
+
+  test("command uses --cwd when worktree_path is in state", async () => {
+    const result = await runQa(
+      { provider: "claude" },
+      makeWork(),
+      makeState({ worktree_path: "/tmp/my-worktree" }),
+      makeDeps(),
+    );
+    if (result.action === "spawn") {
+      expect(result.command).toContain("--cwd");
+      expect(result.command).toContain("/tmp/my-worktree");
+    }
+  });
+
+  test("acp provider builds correct command", async () => {
+    const result = await runQa({ provider: "acp:my-agent" }, makeWork(), makeState(), makeDeps());
+    if (result.action === "spawn") {
+      expect(result.command).toEqual(expect.arrayContaining(["mcx", "acp", "spawn", "--agent", "my-agent"]));
+    }
+  });
+
+  test("writes qa_session_id sentinel", async () => {
+    const writes: Record<string, unknown> = {};
+    const state = makeState();
+    const trackingState: QaState = {
+      get: state.get,
+      set: async (key, value) => {
+        writes[key] = value;
+        await state.set(key, value);
+      },
+      delete: state.delete,
+    };
+    await runQa({ provider: "claude" }, makeWork(), trackingState, makeDeps());
+    expect(String(writes.qa_session_id)).toMatch(/^pending:/);
+  });
+});
+
+// ── runQa — wait path ──
+
+describe("runQa — wait path", () => {
+  test("session set, no labels → wait", async () => {
+    const result = await runQa(
+      { provider: "claude" },
+      makeWork(),
+      makeState({ qa_session_id: "sess_123" }),
+      makeDeps({ gh: async () => ok("") }),
+    );
+    expect(result.action).toBe("wait");
+  });
+});
+
+// ── runQa — verdict paths ──
+
+describe("runQa — qa:pass verdict", () => {
+  test("qa:pass → goto done", async () => {
+    const result = await runQa(
+      { provider: "claude" },
+      makeWork(),
+      makeState({ qa_session_id: "sess_123" }),
+      makeDeps({ gh: async () => ok("qa:pass") }),
+    );
+    expect(result).toMatchObject({ action: "goto", target: "done" });
+  });
+
+  test("qa:pass + qa:fail → goto done, removes qa:fail", async () => {
+    const editCalls: Array<{ prNumber: number; flags: string[] }> = [];
+    const result = await runQa(
+      { provider: "claude" },
+      makeWork(),
+      makeState({ qa_session_id: "sess_123" }),
+      makeDeps({
+        gh: async () => ok("qa:pass\nqa:fail"),
+        prEdit: async (prNumber, flags) => {
+          editCalls.push({ prNumber, flags });
+        },
+      }),
+    );
+    expect(result).toMatchObject({ action: "goto", target: "done" });
+    expect(editCalls.some((c) => c.flags.includes("qa:fail") && c.flags.includes("--remove-label"))).toBe(true);
+  });
+});
+
+describe("runQa — qa:fail verdict", () => {
+  test("qa:fail below cap → goto repair", async () => {
+    const result = await runQa(
+      { provider: "claude" },
+      makeWork(),
+      makeState({ qa_session_id: "sess_123", qa_fail_round: 0 }),
+      makeDeps({ gh: async () => ok("qa:fail") }),
+    );
+    expect(result).toMatchObject({ action: "goto", target: "repair" });
+  });
+
+  test("qa:fail at cap → goto needs-attention", async () => {
+    const result = await runQa(
+      { provider: "claude" },
+      makeWork(),
+      makeState({ qa_session_id: "sess_123", qa_fail_round: QA_FAIL_CAP }),
+      makeDeps({ gh: async () => ok("qa:fail") }),
+    );
+    expect(result).toMatchObject({ action: "goto", target: "needs-attention" });
+    if (result.action === "goto") expect(result.reason).toContain("cap");
+  });
+
+  test("qa:fail writes qa_fail_round and previous_phase", async () => {
+    const writes: Record<string, unknown> = {};
+    const state = makeState({ qa_session_id: "sess_123" });
+    const trackingState: QaState = {
+      get: state.get,
+      set: async (key, value) => {
+        writes[key] = value;
+        await state.set(key, value);
+      },
+      delete: state.delete,
+    };
+    await runQa({ provider: "claude" }, makeWork(), trackingState, makeDeps({ gh: async () => ok("qa:fail") }));
+    expect(writes.qa_fail_round).toBe(1);
+    expect(writes.previous_phase).toBe("qa");
+  });
+
+  test("round count is cumulative across calls", async () => {
+    const result = await runQa(
+      { provider: "claude" },
+      makeWork(),
+      makeState({ qa_session_id: "sess_123", qa_fail_round: 1 }),
+      makeDeps({ gh: async () => ok("qa:fail") }),
+    );
+    if (result.action === "goto") {
+      expect(result.round).toBe(2);
+    }
+  });
+});

--- a/test/repair-phase.spec.ts
+++ b/test/repair-phase.spec.ts
@@ -75,6 +75,7 @@ describe("runRepair — in-flight", () => {
       makeState({ repair_session_id: "sess_abc", repair_round: 2 }),
       makeDeps(),
     );
+    expect(result.action).toBe("in-flight");
     if (result.action === "in-flight") {
       expect(result.round).toBe(2);
       expect(result.model).toBe("opus");
@@ -88,6 +89,7 @@ describe("runRepair — in-flight", () => {
       makeState({ repair_session_id: "sess_abc", repair_round: 1, repair_prompt: "Fix PR #42" }),
       makeDeps(),
     );
+    expect(result.action).toBe("in-flight");
     if (result.action === "in-flight") {
       expect(result.prompt).toBe("Fix PR #42");
     }
@@ -115,6 +117,7 @@ describe("runRepair — cap exceeded", () => {
       makeState({ repair_round: REPAIR_ROUND_CAP }),
       makeDeps(),
     );
+    expect(result).toMatchObject({ action: "goto", target: "needs-attention" });
     if (result.action === "goto") {
       expect(result.round).toBe(REPAIR_ROUND_CAP);
     }
@@ -131,6 +134,7 @@ describe("runRepair — spawn path", () => {
 
   test("spawn result model is opus", async () => {
     const result = await runRepair({ provider: "claude" }, makeWork(), makeState(), makeDeps());
+    expect(result.action).toBe("spawn");
     if (result.action === "spawn") {
       expect(result.model).toBe("opus");
     }
@@ -143,6 +147,7 @@ describe("runRepair — spawn path", () => {
       makeState({ previous_phase: "review" }),
       makeDeps(),
     );
+    expect(result.action).toBe("spawn");
     if (result.action === "spawn") {
       expect(result.prompt).toContain("adversarial review");
     }
@@ -150,6 +155,7 @@ describe("runRepair — spawn path", () => {
 
   test("previous_phase=qa → prompt references qa:fail", async () => {
     const result = await runRepair({ provider: "claude" }, makeWork(), makeState({ previous_phase: "qa" }), makeDeps());
+    expect(result.action).toBe("spawn");
     if (result.action === "spawn") {
       expect(result.prompt).toContain("qa:fail");
     }
@@ -157,6 +163,7 @@ describe("runRepair — spawn path", () => {
 
   test("default previous_phase is review", async () => {
     const result = await runRepair({ provider: "claude" }, makeWork(), makeState(), makeDeps());
+    expect(result.action).toBe("spawn");
     if (result.action === "spawn") {
       expect(result.prompt).toContain("adversarial review");
     }
@@ -164,6 +171,7 @@ describe("runRepair — spawn path", () => {
 
   test("command uses --worktree when no worktree_path", async () => {
     const result = await runRepair({ provider: "claude" }, makeWork(), makeState(), makeDeps());
+    expect(result.action).toBe("spawn");
     if (result.action === "spawn") {
       expect(result.command).toContain("--worktree");
     }
@@ -176,6 +184,7 @@ describe("runRepair — spawn path", () => {
       makeState({ worktree_path: "/tmp/my-worktree" }),
       makeDeps(),
     );
+    expect(result.action).toBe("spawn");
     if (result.action === "spawn") {
       expect(result.command).toContain("--cwd");
       expect(result.command).toContain("/tmp/my-worktree");
@@ -184,6 +193,7 @@ describe("runRepair — spawn path", () => {
 
   test("acp provider builds correct command", async () => {
     const result = await runRepair({ provider: "acp:my-agent" }, makeWork(), makeState(), makeDeps());
+    expect(result.action).toBe("spawn");
     if (result.action === "spawn") {
       expect(result.command).toEqual(expect.arrayContaining(["mcx", "acp", "spawn", "--agent", "my-agent"]));
     }
@@ -240,6 +250,7 @@ describe("runRepair — spawn path", () => {
 
   test("spawn includes reason with previous phase and round", async () => {
     const result = await runRepair({ provider: "claude" }, makeWork(), makeState({ previous_phase: "qa" }), makeDeps());
+    expect(result.action).toBe("spawn");
     if (result.action === "spawn") {
       expect(result.reason).toContain("round 1");
       expect(result.reason).toContain("qa");

--- a/test/repair-phase.spec.ts
+++ b/test/repair-phase.spec.ts
@@ -1,0 +1,248 @@
+import { describe, expect, test } from "bun:test";
+import {
+  REPAIR_ROUND_CAP,
+  type RepairDeps,
+  type RepairState,
+  type RepairWork,
+  buildRepairPrompt,
+  runRepair,
+} from "../.claude/phases/repair-fn";
+
+function makeWork(overrides: Partial<RepairWork> = {}): RepairWork {
+  return { id: "#42", prNumber: 100, ...overrides };
+}
+
+function makeState(initial: Record<string, unknown> = {}): RepairState {
+  const store = new Map<string, unknown>(Object.entries(initial));
+  return {
+    get: async <T>(key: string) => store.get(key) as T | undefined,
+    set: async (key, value) => {
+      store.set(key, value);
+    },
+    delete: async (key) => {
+      store.delete(key);
+    },
+  };
+}
+
+function makeDeps(overrides: Partial<RepairDeps> = {}): RepairDeps {
+  return {
+    prEdit: async () => {},
+    ...overrides,
+  };
+}
+
+// ── buildRepairPrompt ──
+
+describe("buildRepairPrompt — pure function", () => {
+  test("review previous_phase → mentions adversarial review comment", () => {
+    const prompt = buildRepairPrompt(42, "review");
+    expect(prompt).toContain("42");
+    expect(prompt).toContain("adversarial review");
+    expect(prompt).toContain("🔴");
+    expect(prompt).toContain("🟡");
+  });
+
+  test("qa previous_phase → mentions qa:fail comment", () => {
+    const prompt = buildRepairPrompt(42, "qa");
+    expect(prompt).toContain("42");
+    expect(prompt).toContain("qa:fail");
+  });
+
+  test("repair prompt includes PR number in gh command", () => {
+    const prompt = buildRepairPrompt(99, "review");
+    expect(prompt).toContain("gh pr view 99");
+  });
+});
+
+// ── runRepair — in-flight guard ──
+
+describe("runRepair — in-flight", () => {
+  test("existing session → action: in-flight", async () => {
+    const result = await runRepair(
+      { provider: "claude" },
+      makeWork(),
+      makeState({ repair_session_id: "sess_abc", repair_round: 2 }),
+      makeDeps(),
+    );
+    expect(result.action).toBe("in-flight");
+  });
+
+  test("in-flight includes round and model", async () => {
+    const result = await runRepair(
+      { provider: "claude" },
+      makeWork(),
+      makeState({ repair_session_id: "sess_abc", repair_round: 2 }),
+      makeDeps(),
+    );
+    if (result.action === "in-flight") {
+      expect(result.round).toBe(2);
+      expect(result.model).toBe("opus");
+    }
+  });
+
+  test("in-flight includes stored prompt", async () => {
+    const result = await runRepair(
+      { provider: "claude" },
+      makeWork(),
+      makeState({ repair_session_id: "sess_abc", repair_round: 1, repair_prompt: "Fix PR #42" }),
+      makeDeps(),
+    );
+    if (result.action === "in-flight") {
+      expect(result.prompt).toBe("Fix PR #42");
+    }
+  });
+});
+
+// ── runRepair — cap exceeded ──
+
+describe("runRepair — cap exceeded", () => {
+  test("round > cap → goto needs-attention", async () => {
+    const result = await runRepair(
+      { provider: "claude" },
+      makeWork(),
+      makeState({ repair_round: REPAIR_ROUND_CAP }),
+      makeDeps(),
+    );
+    expect(result).toMatchObject({ action: "goto", target: "needs-attention" });
+    if (result.action === "goto") expect(result.reason).toContain("cap");
+  });
+
+  test("cap goto includes previous round in result", async () => {
+    const result = await runRepair(
+      { provider: "claude" },
+      makeWork(),
+      makeState({ repair_round: REPAIR_ROUND_CAP }),
+      makeDeps(),
+    );
+    if (result.action === "goto") {
+      expect(result.round).toBe(REPAIR_ROUND_CAP);
+    }
+  });
+});
+
+// ── runRepair — spawn path ──
+
+describe("runRepair — spawn path", () => {
+  test("no session, round 0 → action: spawn", async () => {
+    const result = await runRepair({ provider: "claude" }, makeWork(), makeState(), makeDeps());
+    expect(result.action).toBe("spawn");
+  });
+
+  test("spawn result model is opus", async () => {
+    const result = await runRepair({ provider: "claude" }, makeWork(), makeState(), makeDeps());
+    if (result.action === "spawn") {
+      expect(result.model).toBe("opus");
+    }
+  });
+
+  test("previous_phase=review → prompt references adversarial review", async () => {
+    const result = await runRepair(
+      { provider: "claude" },
+      makeWork(),
+      makeState({ previous_phase: "review" }),
+      makeDeps(),
+    );
+    if (result.action === "spawn") {
+      expect(result.prompt).toContain("adversarial review");
+    }
+  });
+
+  test("previous_phase=qa → prompt references qa:fail", async () => {
+    const result = await runRepair({ provider: "claude" }, makeWork(), makeState({ previous_phase: "qa" }), makeDeps());
+    if (result.action === "spawn") {
+      expect(result.prompt).toContain("qa:fail");
+    }
+  });
+
+  test("default previous_phase is review", async () => {
+    const result = await runRepair({ provider: "claude" }, makeWork(), makeState(), makeDeps());
+    if (result.action === "spawn") {
+      expect(result.prompt).toContain("adversarial review");
+    }
+  });
+
+  test("command uses --worktree when no worktree_path", async () => {
+    const result = await runRepair({ provider: "claude" }, makeWork(), makeState(), makeDeps());
+    if (result.action === "spawn") {
+      expect(result.command).toContain("--worktree");
+    }
+  });
+
+  test("command uses --cwd when worktree_path is set", async () => {
+    const result = await runRepair(
+      { provider: "claude" },
+      makeWork(),
+      makeState({ worktree_path: "/tmp/my-worktree" }),
+      makeDeps(),
+    );
+    if (result.action === "spawn") {
+      expect(result.command).toContain("--cwd");
+      expect(result.command).toContain("/tmp/my-worktree");
+    }
+  });
+
+  test("acp provider builds correct command", async () => {
+    const result = await runRepair({ provider: "acp:my-agent" }, makeWork(), makeState(), makeDeps());
+    if (result.action === "spawn") {
+      expect(result.command).toEqual(expect.arrayContaining(["mcx", "acp", "spawn", "--agent", "my-agent"]));
+    }
+  });
+
+  test("writes repair_round, repair_prompt, repair_session_id", async () => {
+    const writes: Record<string, unknown> = {};
+    const state = makeState();
+    const trackingState: RepairState = {
+      get: state.get,
+      set: async (key, value) => {
+        writes[key] = value;
+        await state.set(key, value);
+      },
+      delete: state.delete,
+    };
+    await runRepair({ provider: "claude" }, makeWork(), trackingState, makeDeps());
+    expect(writes.repair_round).toBe(1);
+    expect(typeof writes.repair_prompt).toBe("string");
+    expect(String(writes.repair_session_id)).toMatch(/^pending:/);
+  });
+
+  test("clears qa_session_id before spawning", async () => {
+    const deletedKeys: string[] = [];
+    const state = makeState();
+    const trackingState: RepairState = {
+      get: state.get,
+      set: state.set,
+      delete: async (key) => {
+        deletedKeys.push(key);
+        await state.delete(key);
+      },
+    };
+    await runRepair({ provider: "claude" }, makeWork(), trackingState, makeDeps());
+    expect(deletedKeys).toContain("qa_session_id");
+  });
+
+  test("removes qa:fail label (best-effort)", async () => {
+    const editCalls: Array<{ prNumber: number; flags: string[] }> = [];
+    await runRepair(
+      { provider: "claude" },
+      makeWork({ prNumber: 55 }),
+      makeState(),
+      makeDeps({
+        prEdit: async (prNumber, flags) => {
+          editCalls.push({ prNumber, flags });
+        },
+      }),
+    );
+    expect(
+      editCalls.some((c) => c.prNumber === 55 && c.flags.includes("qa:fail") && c.flags.includes("--remove-label")),
+    ).toBe(true);
+  });
+
+  test("spawn includes reason with previous phase and round", async () => {
+    const result = await runRepair({ provider: "claude" }, makeWork(), makeState({ previous_phase: "qa" }), makeDeps());
+    if (result.action === "spawn") {
+      expect(result.reason).toContain("round 1");
+      expect(result.reason).toContain("qa");
+    }
+  });
+});

--- a/test/review-phase.spec.ts
+++ b/test/review-phase.spec.ts
@@ -52,8 +52,8 @@ describe("scanReviewComments — parsing", () => {
   });
 
   test("sticky comment with no blockers → found: true, hasBlockers: false", async () => {
-    // Single newlines within block — split(/\n{2,}/) keeps it as one chunk
-    const comment = "## Adversarial Review\n✅ All good\n✅ Looks clean";
+    // Realistic format: blank line between header and body (as gh pr view --comments produces)
+    const comment = "## Adversarial Review\n\n✅ All good\n✅ Looks clean";
     const result = await scanReviewComments(100, {
       gh: async () => ok(comment),
     });
@@ -61,8 +61,8 @@ describe("scanReviewComments — parsing", () => {
   });
 
   test("sticky comment with 🔴 → hasBlockers: true", async () => {
-    // Single newlines within block so header + emoji are in the same chunk
-    const comment = "## Adversarial Review\n🔴 Critical issue found";
+    // Realistic format: blank line between header and emoji (real gh output format)
+    const comment = "## Adversarial Review\n\n🔴 Critical issue found";
     const result = await scanReviewComments(100, {
       gh: async () => ok(comment),
     });
@@ -70,9 +70,23 @@ describe("scanReviewComments — parsing", () => {
   });
 
   test("sticky comment with 🟡 → hasBlockers: true", async () => {
-    const comment = "## Adversarial Review\n🟡 Warning: edge case missed";
+    // Realistic format: blank line between header and emoji
+    const comment = "## Adversarial Review\n\n🟡 Warning: edge case missed";
     const result = await scanReviewComments(100, {
       gh: async () => ok(comment),
+    });
+    expect(result).toMatchObject({ found: true, hasBlockers: true });
+  });
+
+  test("realistic gh output: blank-line-separated header and emoji content", async () => {
+    // Mirrors real 'gh pr view --json comments -q .comments[].body' output where
+    // paragraphs within a comment are separated by blank lines. The header block
+    // and the 🔴 items are in different split-chunks, so a naive split(/\n{2,}/)
+    // approach (the old code) would return hasBlockers: false — this test documents
+    // that the fix (lastIndexOf) handles it correctly.
+    const body = "## Adversarial Review\n\n🔴 Missing null check in foo.ts line 42\n\n🟡 Consider extracting helper";
+    const result = await scanReviewComments(100, {
+      gh: async () => ok(body),
     });
     expect(result).toMatchObject({ found: true, hasBlockers: true });
   });
@@ -84,10 +98,10 @@ describe("scanReviewComments — parsing", () => {
     expect(result).toEqual({ found: false, hasBlockers: false, summary: "gh pr view failed" });
   });
 
-  test("picks most recent sticky comment (reversed find)", async () => {
-    // Two separate sticky comments separated by \n\n; most recent (last) is clean
-    // Single newlines within each block so header+emoji are in the same chunk
-    const body = ["## Adversarial Review\n🔴 Old blocker", "## Adversarial Review\n✅ All resolved"].join("\n\n");
+  test("picks most recent sticky comment (lastIndexOf)", async () => {
+    // Two adversarial review comments in output; the last one (most recent) is clean.
+    // Realistic format with blank lines between header and body paragraphs.
+    const body = "## Adversarial Review\n\n🔴 Old blocker\n\n## Adversarial Review\n\n✅ All resolved";
     const result = await scanReviewComments(100, {
       gh: async () => ok(body),
     });
@@ -105,6 +119,7 @@ describe("runReview — spawn path", () => {
 
   test("default model is sonnet when no plan entry", async () => {
     const result = await runReview({ provider: "claude" }, makeWork(), makeState(), makeDeps(), "__none__");
+    expect(result.action).toBe("spawn");
     if (result.action === "spawn") {
       expect(result.model).toBe("sonnet");
     }
@@ -118,6 +133,7 @@ describe("runReview — spawn path", () => {
       makeDeps({ findModelInSprintPlan: () => "sonnet" }),
       "/some/root",
     );
+    expect(result.action).toBe("spawn");
     if (result.action === "spawn") {
       expect(result.model).toBe("opus");
     }
@@ -131,6 +147,7 @@ describe("runReview — spawn path", () => {
       makeDeps({ findModelInSprintPlan: () => "opus" }),
       "/some/root",
     );
+    expect(result.action).toBe("spawn");
     if (result.action === "spawn") {
       expect(result.model).toBe("opus");
     }
@@ -151,6 +168,7 @@ describe("runReview — spawn path", () => {
       "__none__",
     );
     expect(planCalled).toBe(false);
+    expect(result.action).toBe("spawn");
     if (result.action === "spawn") {
       expect(result.model).toBe("sonnet");
     }
@@ -158,6 +176,7 @@ describe("runReview — spawn path", () => {
 
   test("command includes correct provider", async () => {
     const result = await runReview({ provider: "claude" }, makeWork(), makeState(), makeDeps(), "__none__");
+    expect(result.action).toBe("spawn");
     if (result.action === "spawn") {
       expect(result.command).toContain("mcx");
       expect(result.command).toContain("claude");
@@ -167,6 +186,7 @@ describe("runReview — spawn path", () => {
 
   test("acp provider builds correct command", async () => {
     const result = await runReview({ provider: "acp:my-agent" }, makeWork(), makeState(), makeDeps(), "__none__");
+    expect(result.action).toBe("spawn");
     if (result.action === "spawn") {
       expect(result.command).toEqual(expect.arrayContaining(["mcx", "acp", "spawn", "--agent", "my-agent"]));
     }
@@ -180,6 +200,7 @@ describe("runReview — spawn path", () => {
       makeDeps(),
       "__none__",
     );
+    expect(result.action).toBe("spawn");
     if (result.action === "spawn") {
       expect(result.prompt).toContain("PR 42");
       expect(result.prompt).toContain("feat/foo");
@@ -227,6 +248,7 @@ describe("runReview — wait path", () => {
       makeDeps({ gh: async () => ok("comment without adversarial review") }),
       "__none__",
     );
+    expect(result.action).toBe("wait");
     if (result.action === "wait") {
       expect(result.model).toBe("opus");
     }
@@ -239,7 +261,7 @@ describe("runReview — goto qa (clean review)", () => {
       { provider: "claude" },
       makeWork(),
       makeState({ review_session_id: "sess_123", review_round: 1 }),
-      makeDeps({ gh: async () => ok("## Adversarial Review\n✅ All good") }),
+      makeDeps({ gh: async () => ok("## Adversarial Review\n\n✅ All good") }),
       "__none__",
     );
     expect(result).toMatchObject({ action: "goto", target: "qa" });
@@ -253,7 +275,7 @@ describe("runReview — goto repair (blockers present)", () => {
       { provider: "claude" },
       makeWork(),
       state,
-      makeDeps({ gh: async () => ok("## Adversarial Review\n🔴 Critical issue") }),
+      makeDeps({ gh: async () => ok("## Adversarial Review\n\n🔴 Critical issue") }),
       "__none__",
     );
     expect(result).toMatchObject({ action: "goto", target: "repair" });
@@ -264,7 +286,7 @@ describe("runReview — goto repair (blockers present)", () => {
       { provider: "claude" },
       makeWork(),
       makeState({ review_session_id: "sess_123", review_round: REVIEW_ROUND_CAP }),
-      makeDeps({ gh: async () => ok("## Adversarial Review\n🔴 Still failing") }),
+      makeDeps({ gh: async () => ok("## Adversarial Review\n\n🔴 Still failing") }),
       "__none__",
     );
     expect(result).toMatchObject({ action: "goto", target: "qa" });
@@ -287,7 +309,7 @@ describe("runReview — goto repair (blockers present)", () => {
       { provider: "claude" },
       makeWork(),
       trackingState,
-      makeDeps({ gh: async () => ok("## Adversarial Review\n🔴 Issue") }),
+      makeDeps({ gh: async () => ok("## Adversarial Review\n\n🔴 Issue") }),
       "__none__",
     );
     expect(writes.review_round).toBe(2);

--- a/test/review-phase.spec.ts
+++ b/test/review-phase.spec.ts
@@ -1,0 +1,296 @@
+import { describe, expect, test } from "bun:test";
+import type { GhResult } from "../.claude/phases/gh";
+import {
+  REVIEW_ROUND_CAP,
+  type ReviewDeps,
+  type ReviewState,
+  type ReviewWork,
+  runReview,
+  scanReviewComments,
+} from "../.claude/phases/review-fn";
+
+function ok(stdout = ""): GhResult {
+  return { stdout, stderr: "", exitCode: 0 };
+}
+
+function makeWork(overrides: Partial<ReviewWork> = {}): ReviewWork {
+  return {
+    id: "#42",
+    prNumber: 100,
+    branch: "feat/issue-42-test",
+    issueNumber: 42,
+    ...overrides,
+  };
+}
+
+function makeState(initial: Record<string, unknown> = {}): ReviewState {
+  const store = new Map<string, unknown>(Object.entries(initial));
+  return {
+    get: async <T>(key: string) => store.get(key) as T | undefined,
+    set: async (key, value) => {
+      store.set(key, value);
+    },
+  };
+}
+
+function makeDeps(overrides: Partial<ReviewDeps> = {}): ReviewDeps {
+  return {
+    gh: async () => ok(""),
+    findModelInSprintPlan: () => null,
+    ...overrides,
+  };
+}
+
+// ── scanReviewComments ──
+
+describe("scanReviewComments — parsing", () => {
+  test("no sticky comment → found: false", async () => {
+    const result = await scanReviewComments(100, {
+      gh: async () => ok("some other comment\n\nanother comment"),
+    });
+    expect(result).toEqual({ found: false, hasBlockers: false, summary: "no sticky comment yet" });
+  });
+
+  test("sticky comment with no blockers → found: true, hasBlockers: false", async () => {
+    // Single newlines within block — split(/\n{2,}/) keeps it as one chunk
+    const comment = "## Adversarial Review\n✅ All good\n✅ Looks clean";
+    const result = await scanReviewComments(100, {
+      gh: async () => ok(comment),
+    });
+    expect(result).toEqual({ found: true, hasBlockers: false, summary: "all clear" });
+  });
+
+  test("sticky comment with 🔴 → hasBlockers: true", async () => {
+    // Single newlines within block so header + emoji are in the same chunk
+    const comment = "## Adversarial Review\n🔴 Critical issue found";
+    const result = await scanReviewComments(100, {
+      gh: async () => ok(comment),
+    });
+    expect(result).toMatchObject({ found: true, hasBlockers: true });
+  });
+
+  test("sticky comment with 🟡 → hasBlockers: true", async () => {
+    const comment = "## Adversarial Review\n🟡 Warning: edge case missed";
+    const result = await scanReviewComments(100, {
+      gh: async () => ok(comment),
+    });
+    expect(result).toMatchObject({ found: true, hasBlockers: true });
+  });
+
+  test("gh call fails → found: false with error summary", async () => {
+    const result = await scanReviewComments(100, {
+      gh: async () => ({ stdout: "", stderr: "not found", exitCode: 1 }),
+    });
+    expect(result).toEqual({ found: false, hasBlockers: false, summary: "gh pr view failed" });
+  });
+
+  test("picks most recent sticky comment (reversed find)", async () => {
+    // Two separate sticky comments separated by \n\n; most recent (last) is clean
+    // Single newlines within each block so header+emoji are in the same chunk
+    const body = ["## Adversarial Review\n🔴 Old blocker", "## Adversarial Review\n✅ All resolved"].join("\n\n");
+    const result = await scanReviewComments(100, {
+      gh: async () => ok(body),
+    });
+    expect(result).toMatchObject({ found: true, hasBlockers: false });
+  });
+});
+
+// ── runReview — first entry (no session) ──
+
+describe("runReview — spawn path", () => {
+  test("no session → action: spawn", async () => {
+    const result = await runReview({ provider: "claude" }, makeWork(), makeState(), makeDeps(), "__none__");
+    expect(result.action).toBe("spawn");
+  });
+
+  test("default model is sonnet when no plan entry", async () => {
+    const result = await runReview({ provider: "claude" }, makeWork(), makeState(), makeDeps(), "__none__");
+    if (result.action === "spawn") {
+      expect(result.model).toBe("sonnet");
+    }
+  });
+
+  test("explicit model input overrides plan", async () => {
+    const result = await runReview(
+      { provider: "claude", model: "opus" },
+      makeWork(),
+      makeState(),
+      makeDeps({ findModelInSprintPlan: () => "sonnet" }),
+      "/some/root",
+    );
+    if (result.action === "spawn") {
+      expect(result.model).toBe("opus");
+    }
+  });
+
+  test("sprint plan model used when no explicit input", async () => {
+    const result = await runReview(
+      { provider: "claude" },
+      makeWork({ issueNumber: 42 }),
+      makeState(),
+      makeDeps({ findModelInSprintPlan: () => "opus" }),
+      "/some/root",
+    );
+    if (result.action === "spawn") {
+      expect(result.model).toBe("opus");
+    }
+  });
+
+  test("NO_REPO_ROOT skips sprint plan lookup", async () => {
+    let planCalled = false;
+    const result = await runReview(
+      { provider: "claude" },
+      makeWork({ issueNumber: 42 }),
+      makeState(),
+      makeDeps({
+        findModelInSprintPlan: () => {
+          planCalled = true;
+          return "opus";
+        },
+      }),
+      "__none__",
+    );
+    expect(planCalled).toBe(false);
+    if (result.action === "spawn") {
+      expect(result.model).toBe("sonnet");
+    }
+  });
+
+  test("command includes correct provider", async () => {
+    const result = await runReview({ provider: "claude" }, makeWork(), makeState(), makeDeps(), "__none__");
+    if (result.action === "spawn") {
+      expect(result.command).toContain("mcx");
+      expect(result.command).toContain("claude");
+      expect(result.command).toContain("spawn");
+    }
+  });
+
+  test("acp provider builds correct command", async () => {
+    const result = await runReview({ provider: "acp:my-agent" }, makeWork(), makeState(), makeDeps(), "__none__");
+    if (result.action === "spawn") {
+      expect(result.command).toEqual(expect.arrayContaining(["mcx", "acp", "spawn", "--agent", "my-agent"]));
+    }
+  });
+
+  test("prompt includes PR number, branch, and round", async () => {
+    const result = await runReview(
+      { provider: "claude" },
+      makeWork({ prNumber: 42, branch: "feat/foo" }),
+      makeState(),
+      makeDeps(),
+      "__none__",
+    );
+    if (result.action === "spawn") {
+      expect(result.prompt).toContain("PR 42");
+      expect(result.prompt).toContain("feat/foo");
+      expect(result.prompt).toContain("round 1");
+    }
+  });
+
+  test("writes review_round, review_model, review_session_id to state", async () => {
+    const state = makeState();
+    const writes: Record<string, unknown> = {};
+    const trackingState: ReviewState = {
+      get: state.get,
+      set: async (key, value) => {
+        writes[key] = value;
+        await state.set(key, value);
+      },
+    };
+    await runReview({ provider: "claude" }, makeWork(), trackingState, makeDeps(), "__none__");
+    expect(writes.review_round).toBe(1);
+    expect(writes.review_model).toBe("sonnet");
+    expect(typeof writes.review_session_id).toBe("string");
+    expect(String(writes.review_session_id)).toMatch(/^pending:/);
+  });
+});
+
+// ── runReview — re-entry (session set) ──
+
+describe("runReview — wait path", () => {
+  test("session set, no sticky comment → wait", async () => {
+    const result = await runReview(
+      { provider: "claude" },
+      makeWork(),
+      makeState({ review_session_id: "sess_123", review_round: 1 }),
+      makeDeps({ gh: async () => ok("just some comment") }),
+      "__none__",
+    );
+    expect(result.action).toBe("wait");
+  });
+
+  test("wait result includes stored model", async () => {
+    const result = await runReview(
+      { provider: "claude" },
+      makeWork(),
+      makeState({ review_session_id: "sess_123", review_round: 1, review_model: "opus" }),
+      makeDeps({ gh: async () => ok("comment without adversarial review") }),
+      "__none__",
+    );
+    if (result.action === "wait") {
+      expect(result.model).toBe("opus");
+    }
+  });
+});
+
+describe("runReview — goto qa (clean review)", () => {
+  test("sticky comment with no blockers → goto qa", async () => {
+    const result = await runReview(
+      { provider: "claude" },
+      makeWork(),
+      makeState({ review_session_id: "sess_123", review_round: 1 }),
+      makeDeps({ gh: async () => ok("## Adversarial Review\n✅ All good") }),
+      "__none__",
+    );
+    expect(result).toMatchObject({ action: "goto", target: "qa" });
+  });
+});
+
+describe("runReview — goto repair (blockers present)", () => {
+  test("blockers below cap → goto repair", async () => {
+    const state = makeState({ review_session_id: "sess_123", review_round: 1 });
+    const result = await runReview(
+      { provider: "claude" },
+      makeWork(),
+      state,
+      makeDeps({ gh: async () => ok("## Adversarial Review\n🔴 Critical issue") }),
+      "__none__",
+    );
+    expect(result).toMatchObject({ action: "goto", target: "repair" });
+  });
+
+  test("round cap reached with blockers → goto qa instead of repair", async () => {
+    const result = await runReview(
+      { provider: "claude" },
+      makeWork(),
+      makeState({ review_session_id: "sess_123", review_round: REVIEW_ROUND_CAP }),
+      makeDeps({ gh: async () => ok("## Adversarial Review\n🔴 Still failing") }),
+      "__none__",
+    );
+    expect(result).toMatchObject({ action: "goto", target: "qa" });
+    if (result.action === "goto") {
+      expect(result.reason).toContain("round cap");
+    }
+  });
+
+  test("blockers below cap increments review_round in state", async () => {
+    const writes: Record<string, unknown> = {};
+    const state = makeState({ review_session_id: "sess_123", review_round: 1 });
+    const trackingState: ReviewState = {
+      get: state.get,
+      set: async (key, value) => {
+        writes[key] = value;
+        await state.set(key, value);
+      },
+    };
+    await runReview(
+      { provider: "claude" },
+      makeWork(),
+      trackingState,
+      makeDeps({ gh: async () => ok("## Adversarial Review\n🔴 Issue") }),
+      "__none__",
+    );
+    expect(writes.review_round).toBe(2);
+    expect(writes.previous_phase).toBe("review");
+  });
+});


### PR DESCRIPTION
## Summary

- Extracts testable pure logic from all 5 phase scripts (`done`, `review`, `qa`, `repair`, `needs-attention`) into companion `*-fn.ts` files following the `triage-fn.ts` DI pattern; phase scripts delegate to extracted functions with real gh helpers wired as deps
- Refactors `gh.ts` to export `GhRunner` type, add optional `_gh` DI param to all helpers, and make `sigkillDelayMs` configurable in `runGh`/`spawn` for testability
- Adds 6 test files (113 tests total) covering: gh helper argument construction, error classification paths in `mergePr`, state machine paths for all phases, cap/round checks, SIGKILL escalation via a single-process bun script

## Test plan

- [x] `bun test test/gh-helpers.spec.ts` — prView/prList/prEdit/prMerge/prComment arg construction + error paths; SIGTERM and SIGKILL escalation
- [x] `bun test test/done-phase.spec.ts` — all `mergePr` paths: label guards, CI guard, success, worktree/SIGTERM/SIGKILL recovery, conflict/required-check/generic failure classification
- [x] `bun test test/review-phase.spec.ts` — `scanReviewComments` parsing, spawn path (model resolution, command construction, state writes), wait/goto-qa/goto-repair paths, round cap
- [x] `bun test test/qa-phase.spec.ts` — `readQaLabels` parsing, spawn path (worktree reuse), wait/pass/fail verdicts, fail cap
- [x] `bun test test/repair-phase.spec.ts` — `buildRepairPrompt` pure function, in-flight guard, cap check, spawn path (prompt/command by previous_phase, state writes, label cleanup)
- [x] `bun test test/needs-attention-phase.spec.ts` — `buildNeedsAttentionBody` pure function, state reading, label removal, comment posting, updateWorkItemPhase
- [x] Full suite: `bun test` — 7002 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)