### PR TITLE
sprint(52): sprint-51 follow-ups + flake nerd-snipes + #1860 core.bare epic

### DIFF
--- a/.claude/diary/20260504.52.md
+++ b/.claude/diary/20260504.52.md
@@ -1,0 +1,162 @@
+# 2026-05-04 — 47-sprint core.bare epic + flake gate held the line (Sprint 52)
+
+## What was done
+
+9 PRs merged, v1.8.6 released.
+
+**Headline — 47-sprint `core.bare=true` epic (#1860 → #1998):**
+- Structural fix: `ensureCoreBareUnset()` removes the key entirely; daemon
+  sweep deletes both `true` and `false` values; if the key doesn't exist
+  nothing can flip it. Closes #394, #1206, #1330 (3 prior workarounds).
+- Opus impl could not reproduce the flip locally on git 2.50.1; chose a
+  defensive structural fix over a speculative race-condition patch. Honest
+  call.
+- Adversarial review found 2 blockers: (a) only the daemon sweep was
+  migrated, 8 call sites in `worktree-shim.ts` + `daemon/index.ts` still
+  used the old `fixCoreBare` (which sets the key to false); (b) `getGitRoot`
+  read without `--local` could pick up global config.
+- Reviewer self-repaired both rounds; copilot caught a 3rd finding (read
+  vs unset asymmetry) which reviewer also self-repaired. Final cost: $13.16
+  (impl $7.49 + review $5.48 + qa $0.46).
+
+**Flake nerd-snipe gate (#1980, #1987):**
+- Both flakies recurred 4 days after sprint 51 closed their predecessors
+  (#1934, #1902). Per `feedback_flaky_tests.md`, spawned nerd-snipe (opus)
+  before impl. **Both stalled at the 600s watchdog** before reaching a
+  verdict — partial transcripts showed real analysis (cachedChildPid
+  lifecycle, getProcessStartTime non-determinism, DI patterns) but no
+  concrete root cause + fix.
+- Routed both to **needs-attention** with stall-summary comments documenting
+  the partial findings, the suspected mechanisms, and a bisect plan for
+  next sprint. **Did NOT spawn impl on opus to "hope"** — that's the
+  failure mode this rule exists to prevent.
+
+**Sprint-51 follow-ups:**
+- #1973 / #1995 — null-guard for `extraUsage.utilization` (mcx status no
+  longer crashes when usedCredits is 0).
+- #1974 / #1997 — work-item-poller now requires closing keywords for PR
+  auto-binding + skips sprint container branches. Copilot caught 2 follow-up
+  issues (page-size false negatives, over-broad sprint regex), both fixed.
+- #1992 / #2000 — `done-fn` always polls PR state on non-zero merge exit
+  (Go's graceful SIGTERM exits 1, not 143). Copilot caught 2 substantive
+  findings (deterministic short-circuit ordering + cleanup-needed signal),
+  both fixed.
+- #1993 / #1999 — `repair-fn` clears `review_session_id` alongside
+  `qa_session_id` on spawn, preventing stale-sentinel wedge.
+- #1684 / #2006 — `agent_sessions.repo_root` canonicalized at write (in
+  `processSessionUpsert` covering all 4 providers via abstract base class)
+  AND read (in `getGitRoot()` per Copilot's read-side regression catch),
+  plus a v4 migration backfill. Adversarial review found the 4-providers
+  scope and the read-side asymmetry; reviewer self-repaired both.
+
+**Fillers / hardening:**
+- #1634 / #2001 — `Bun.sleep(0)` → `await exitedPromise` (deterministic
+  microtask synchronization, after Copilot caught that `Promise.resolve()`
+  alone wasn't enough).
+- #1769 / #2004 — playwright.spec comment correction (the function doing
+  the path comparison is `partitionSitesForRunningBrowser`, not the
+  originally-cited `resolveProfileDir` or `normalize`).
+- #1647 / #2005 — `mkdtempSync` + `afterEach` cleanup for resolve-playwright
+  tests; eliminates the hardcoded `/tmp/mcx-playwright-test-vendor` collision.
+
+**Also closed:**
+- #1903, #1904, #1905, #1906 — the entire `mcx claude status` cluster bundle
+  was already fixed by PR #1927 + sprint-51's #1989. Implementer verified
+  the code state and closed all 4 in 20 turns / $0.30. Plan-time triage
+  missed these (would have saved a slot).
+
+## What worked well
+
+- **Reviewer self-repair held up.** Both high-scrutiny PRs (#1860, #1684)
+  routed to opus review, found real blockers, reviewer fixed its own
+  findings without spawning a separate repair session. Kept review costs
+  bounded and avoided the cold-start tax of a fresh opus repair.
+- **nerd-snipe hard gate honored, even though uncomfortable.** Both
+  agents stalled, both got `needs-attention` with public partial trails,
+  both stayed off opus impl. The discipline cost us 2 issues this sprint,
+  but the alternative (spawn opus and hope) would have cost ~$15 of opus
+  burn AND landed a speculative patch around symptoms. Saving that
+  pattern for the iteration that has the time/tooling to bisect properly
+  was the right call.
+- **User pacing (2-3 implementers, ~9h budget) was sustainable.** Sprint
+  ran ~5h10m, burned ~$28, never hit quota throttling. No missed events,
+  no orphan workers. The cap forced sequencing on Batch 2/3 which
+  surfaced the build-side-effect bug consistently enough to file (#1996).
+- **Bundle "verify already-done" pattern.** #1903-1906 closure was a
+  20-turn no-PR resolution. Cheaper than spawning fresh impls one at a
+  time would have been. Worth keeping the bundle prompt for any
+  cluster of related issues — sometimes the "implementer" is really an
+  archeologist.
+
+## What didn't work
+
+- **`bun scripts/build.ts` stages `npm/*/bin/.gitkeep` deletions on every
+  implementer (#1996).** 8 worktrees this sprint, all needed manual
+  `git restore --staged` after push. Implementers never noticed (the gh
+  warning blends into other output); only the orchestrator's post-push
+  status check caught it. **Fix**: identify the build step that touches
+  `npm/*/bin/` and either skip `.gitkeep` from cleanup or recreate after.
+- **nerd-snipe 600s watchdog killed both flake investigations
+  before completion.** The agents were producing real analysis but the
+  watchdog measures "no progress" by stream cadence; deep code-reading
+  bursts of thinking trigger it. **Action**: file separate issue for
+  watchdog-budget tunability or progressive-posting requirement; for
+  next sprint's nerd-snipes, add explicit "post incremental findings
+  every N turns even if intermediate" to the prompt.
+- **Phase regex bug (#2007) blocked review→qa transition twice.**
+  `scanReviewComments` greps `/🔴|🟡/` over the entire sticky comment;
+  delta tables show prior-issue emojis as historical entries, the regex
+  matches them, the script routes to repair instead of qa. Hit on #1860
+  and #1684. Fix: anchor to a verdict line (`✅ APPROVED` near the top)
+  instead of any-emoji-anywhere. Manual force-advance was the workaround.
+- **Worker modified meta file (#1998 reviewer touched
+  `.claude/skills/sprint/references/run.md`).** Caught it during the
+  Copilot review pass, reverted the hunk, filed #2002 to apply the
+  prose update properly in the next sprint. The meta-file rule needs
+  better worker-side enforcement — currently it relies entirely on the
+  orchestrator noticing in `gh pr view --json files`.
+- **Two recurring flakies that sprint 51 thought were fixed.** #1934
+  closed 2026-05-01 → recurred as #1980 by 2026-05-04. #1902 closed
+  2026-04-30 → recurred as #1987 by 2026-05-04. Both were closed after
+  the originally-failing CI re-run passed; nobody verified the underlying
+  race was actually addressed. Pattern: a single passing rerun is not
+  evidence of a fix for a flake. A closed flake should require either
+  (a) a documented mechanism that explains the failure or (b) N
+  consecutive green runs across diverse conditions.
+- **Plan-time triage missed 4 already-done issues (#1903-1906).** They
+  were on the plan as "claude status cluster bundle" but the cluster was
+  already resolved upstream. Loose: $0.30 + 1 worker slot. Tight:
+  plan.md should add a "verify each issue is still open and reproducible"
+  step before slotting.
+
+## Patterns established
+
+- **Stall-summary template for nerd-snipe failures.** When a nerd-snipe
+  agent fails to reach a verdict, post a comment to the issue with
+  (a) timeline of what was investigated, (b) partial findings (with
+  "NOT verified" disclaimer), (c) why it stalled, (d) recommended
+  next steps including bisect range. Keeps the trail public and
+  actionable. Used on #1980 and #1987.
+- **`needs-attention` label as terminal state for unresolved issues.**
+  Created the label this sprint (it didn't exist). Distinct from
+  `wontfix` (which implies "we won't ever fix") — `needs-attention`
+  means "we tried and the current tooling isn't sufficient; here's
+  the trail; pick this up with a different approach."
+- **Force-advance with `forceReason`** for phase-script bugs that
+  would otherwise wedge progress. Used on #1980/#1987 (impl→needs-
+  attention), #1860 (review→qa, regex bug), #1684 (review→qa, regex
+  bug). The `forceReason` is durable in the work-item state, audit-
+  trail-wise.
+
+## Stats
+
+- **PRs merged**: 9
+- **Issues closed**: 13 (9 via merged PRs + 4 already-done #1903/#1904/#1905/#1906)
+- **Issues routed to needs-attention**: 2 (#1980, #1987)
+- **Adversarial reviews**: 2 (#1860, #1684); both Changes-Requested → reviewer self-repair → APPROVED
+- **Copilot inline findings**: ~12 across 6 PRs; all substantive, all addressed
+- **New issues filed**: 3 (#1996 build .gitkeep deletions, #2002 meta run.md update, #2007 phase regex)
+- **Failed/dropped**: 0 (the 2 needs-attention are deferred, not dropped)
+- **Sprint cost**: ~$28 worker quota
+- **Sprint duration**: ~5h10m (00:13 EDT → 05:23 EDT)
+- **Implementer cap held**: 2-3 active impls per user request; never exceeded

--- a/.claude/sprints/sprint-52.md
+++ b/.claude/sprints/sprint-52.md
@@ -1,0 +1,195 @@
+# Sprint 52
+
+> Planned 2026-05-04 00:00 EDT. Target: 11 PRs (15 work items; 4 bundled).
+
+## Goal
+
+**"Close sprint-51 follow-ups + kill the 2 recurring server-pool flakies
+with proper nerd-snipe-gated repairs + take a real swing at #1860's
+47-sprint `core.bare=true` epic. Plus a 4-issue claude-status cluster
+bundle and a few filler quick wins."**
+
+Sprint 51 was a "ratchet" sprint that landed 12 PRs (v1.8.5) and filed 7
+follow-up issues. Sprint 52 closes those, but the headline work is
+infrastructure: two server-pool flakies recurred mid-sprint 51 (one each
+blocked #1936 and #1892's CI), and the `core.bare=true` flip has
+defensive workarounds in two phase scripts after 47 sprints of recurrences.
+Time to root-cause both classes.
+
+## Issues
+
+| # | Title | Scrutiny | Batch | Model | Category |
+|---|-------|----------|-------|-------|----------|
+| 1980 | flaky: server-pool closeAll kills stdio child processes | high | 1 | opus | sprint-51 follow-up + nerd-snipe gate |
+| 1987 | flaky: disconnect SIGTERM race (server-pool.spec.ts:1708) | high | 1 | opus | sprint-51 follow-up + nerd-snipe gate |
+| 1860 | core.bare=true root-cause (47 sprints of workarounds #394/#1206/#1243/#1330) | high | 1 | opus | heavy epic |
+| 1973 | mcx status crashes on null extraUsage.utilization | low | 1 | sonnet | sprint-51 follow-up (DX) |
+| 1974 | work-item-poller auto-binds sprint-container PRs to every issue | medium | 1 | sonnet | sprint-51 follow-up (orchestrator hygiene) |
+| 1992 | done-fn.ts SIGTERM exit-code misses Go-graceful exits | low | 2 | sonnet | sprint-51 follow-up |
+| 1993 | repair-fn.ts review_session_id not cleared on repair spawn | low | 2 | sonnet | sprint-51 follow-up |
+| 1903+1904+1905+1906 | claude status cluster (call count + whitespace + help + subcommand) | low | 2 | sonnet | bundled, backlog |
+| 1684 | agent_sessions.repo_root not canonicalized (#1526 follow-up) | low | 2 | sonnet | DB hardening |
+| 1634 | Bun.sleep(0) comment accuracy in opencode-process.spec.ts | low | 3 | sonnet | filler (trivial) |
+| 1769 | playwright.spec.ts test comment update | low | 3 | sonnet | filler (trivial) |
+| 1647 | resolve-playwright tests hardcode /tmp paths and leak temp dirs | low | 3 | sonnet | filler |
+
+15 work items, 11 PRs after the #1903+#1904+#1905+#1906 bundle.
+
+## Batch Plan
+
+### Batch 1 (immediate)
+#1980, #1987, #1860, #1973, #1974
+
+### Batch 2 (backfill)
+#1992, #1993, #1903+#1904+#1905+#1906, #1684
+
+### Batch 3 (backfill)
+#1634, #1769, #1647
+
+### Cross-issue dependencies (addBlockedBy edges)
+
+None this sprint — every issue touches independent files. The
+sprint-51 cross-bundle blockedBy edges aren't repeating because we're
+not bundling on shared files.
+
+### Flake nerd-snipe gate (mandatory, per `feedback_flaky_tests.md`)
+
+Both #1980 and #1987 are `label:flaky`. The orchestrator's flaky-handling
+rule says: spawn `nerd-snipe` (opus) BEFORE `phase=impl`, post the
+timeline + bisect log + mechanism + fix plan as an **issue comment**.
+The trail goes on the GitHub issue, not in the session transcript, so
+the next sprint can't re-misdiagnose. If nerd-snipe cannot identify
+*both* the root cause and a concrete fix, apply `needs-attention` and
+do NOT advance to phase=impl — "spawn opus and hope" is the failure
+mode this rule exists to prevent (sprint 47 / #1870 incident).
+
+Sequence per flake:
+1. Spawn `nerd-snipe` agent (opus) with: repro, suspected commit
+   range, prior diagnoses, `gh issue view` timeline.
+2. nerd-snipe posts findings as an issue comment.
+3. **Hard gate**: if no root cause + concrete fix → `needs-attention`,
+   surface in retro.
+4. Otherwise: phase=impl on opus (NOT sonnet — adversarial review
+   verifies the implementation matches the documented mechanism).
+5. Adversarial review for the impl PR — verify it matches the
+   mechanism, not just "tests pass now."
+
+### Hot-shared file watch
+
+- `.claude/phases/done.ts` — #1992 only
+- `.claude/phases/repair.ts` — #1993 only
+- `packages/command/src/commands/claude.ts` — #1903+#1904+#1905+#1906
+  bundle only (no other picks touch this; the bundle is internally
+  serialized as one PR)
+- `packages/daemon/src/server-pool.ts` and `server-pool.spec.ts` —
+  #1980 and #1987 may both touch this. Serialize naturally via the
+  nerd-snipe gate: #1980 nerd-snipe → #1987 nerd-snipe → impls (with
+  rebase between, the second PR picks up the first's fix). Orchestrator
+  to broadcast a rebase directive when the first lands.
+- `packages/daemon/src/db/state.ts` — #1684 only
+- `packages/core/src/cli-config.ts` (or wherever quota status renders) —
+  #1973 only
+- `packages/daemon/src/work-item-poller.ts` — #1974 only
+
+No two PRs share a dispatch table this sprint.
+
+## Context
+
+**Sprint-51 outcome**: 12 PRs merged + 3 issues closed-as-already-done,
+v1.8.5 released. Anchors landed clean — patcher hardening (#1827),
+session.permission_blocked event (#1948), event-stream guards (#1961+#1962),
+DB v3 migration regression (#1892), AliasContext.repoRoot threading
+(#1958), phase-script test extraction (#1960). Adversarial review on
+#1958 and #1960 each spawned ~3 contained findings that landed cleanly.
+
+**Plan-time triage closed 2 issues** (verified against current main):
+- #1988 — `setTimeout(fn, delay, arg)` 3-arg form already handled by
+  sprint 51's #1985 commit `0b16d1f` (`extractDelayArg` finds the 2nd
+  positional arg).
+- #1991 — `scanReviewComments` parsing bug already fixed inline by
+  sprint 51's #1990 commit `39303a1` (`lastIndexOf + slice` rewrite).
+
+**Carry-over signals**:
+- **Server-pool flakies are persistent**: #1934 closed 2026-05-01, recurred
+  as #1980 by 2026-05-04. #1902 closed 2026-04-30, recurred as #1987 by
+  2026-05-04. Same tests, same race patterns. Memory rule says
+  nerd-snipe-gate before impl — sprint 50 / 51 didn't apply it on these
+  because they surfaced as collateral on unrelated PRs (CI rerun fixed
+  the surface and the underlying bug was filed for "later"). Sprint 52
+  is later.
+- **#1860 is a 47-sprint debt**. Two phase scripts have `git config core.bare
+  false` defensive pre-flights. The memory file calls it out as "until
+  sticky fix lands." Worth a dedicated opus session with a deep-investigation
+  prompt — the suspect is `git worktree remove` interaction with daemon-held
+  worktrees, but no one has run it down.
+- **Orchestrator hygiene is at stake on #1974**. Sprint 51 hit it: every
+  issue tracked during setup got auto-bound to PR #1972 (the sprint container)
+  because the container body lists every issue. Cosmetic at impl time but
+  hazardous at retro auto-merge. A closing-keyword filter (`fixes #N` /
+  `closes #N` only) plus container-PR exemption is the natural fix.
+
+**Risks**:
+- **3 opus picks** (#1980, #1987, #1860) — same opus burn profile as sprint 51
+  (which peaked at 96% 5h utilization). Pacing matters: stagger the opus
+  spawns, don't run all 3 in parallel. Quota memory: prefer 270s waits over
+  ≥300s to keep prompt cache warm during gaps.
+- **#1860 may be unboundedly hard**. The proposal is "dedicated initiative."
+  If the opus session can't find a concrete root cause in 1-2 hours, downgrade
+  to "document findings + improve workaround" rather than chasing forever.
+  Apply needs-attention rather than wedging the sprint.
+- **Two flakies, one file**. #1980 and #1987 both target `server-pool.spec.ts`.
+  Nerd-snipe both before impl, then land impls in dependency order
+  (whichever fix is easier first; rebase the second).
+- **Spread across 8+ distinct file areas**. Same shape as sprint 51 — small
+  PRs, no cross-area bleed expected.
+
+**Releasability**: Sprint 52 picks are mostly patch (bug fixes + small
+refactors + tests). #1860 *could* be major if the root cause requires a
+public-API change, but more likely it's an internal daemon fix — patch.
+Probable v1.8.6 at retro unless something unexpected surfaces. No
+minor-bump candidates.
+
+## Process notes (carry-forward from sprint 51)
+
+1. **Capture phase JSON once, extract both fields** (workaround for
+   #1922; codified through sprint 51 — kept until #1922's fix #1949 is
+   confirmed soak-tested):
+   ```bash
+   OUT=$(mcx phase run <p> --work-item ...) && \
+     MODEL=$(echo "$OUT" | jq -r '.model // "sonnet"') && \
+     PROMPT=$(echo "$OUT" | jq -r '.prompt')
+   ```
+2. **Sonnet verify-only repair** when QA fail reason is "stale verdict
+   on contained finding" (impl session has fixed + replied since the
+   verdict). New pattern from sprint 51 — saved $1+ on #1827 vs the
+   default-opus repair flow. Detect: qa:fail body cites threads that
+   have reply chains AND the cited fix exists in `git diff
+   origin/main...HEAD`. Spawn sonnet manually with a verify+label-swap
+   prompt (~12 turns / $0.20).
+3. **Read-after-write race in QA** — sprint 51 hit it 5 times. QA
+   spawned within seconds of impl push read pre-reply state. **Workaround
+   for sprint 52**: sleep ~30s after impl push before spawning QA when
+   Copilot inline reviews are likely (i.e. anything other than docs-only).
+   File a proper fix as a follow-up if it bites again.
+4. **Bundle prompt template**: spawn `/implement <first-issue>` then
+   immediately `mcx claude send "Bundle: implement BOTH ... in the SAME
+   PR ..."`. Used 4× in sprint 51 without a single bundle splitting.
+5. **8-minute wait before QA vote after PR push** still applies until
+   #1907 (deferred) lands inline-dismiss.
+6. **Verify auto-merge with `state == MERGED && mergedAt != null`** —
+   never trust just the auto-merge queue.
+7. **One TaskCreate per issue (or per bundled-PR)** with addBlockedBy
+   edges from the dependency list. (None this sprint, but the rule stands.)
+8. **No `Bun.sleep` in test fixes — deterministic synchronization only**
+   *except* as a Promise.race deadline (sprint 51 #1979 established this
+   as acceptable when the read winning is what makes the test pass; the
+   sleep is the safety bailout). AbortController is preferred where
+   feasible.
+9. **Use the `Monitor` harness tool, not raw Bash `mcx monitor`** —
+   per #1947. `references/run.md` leads with the `Monitor` form.
+10. **Permission_request event filter is stale** post-#1948. The
+    Monitor stream subscribes on `session.permission_request` which now
+    fires for every Edit/Write/Bash. ~30+ noise events in sprint 51.
+    Run.md filter should swap to `session.permission_blocked`. **This
+    is a meta change; apply via `meta/run-md-permission-blocked-filter`
+    branch in Step 1a or defer to retro.**

--- a/.claude/sprints/sprint-52.md
+++ b/.claude/sprints/sprint-52.md
@@ -1,6 +1,6 @@
 # Sprint 52
 
-> Planned 2026-05-04 00:00 EDT. Target: 11 PRs (15 work items; 4 bundled).
+> Planned 2026-05-04 00:00 EDT. Started 2026-05-04 00:13 EDT. Target: 11 PRs (15 work items; 4 bundled).
 
 ## Goal
 

--- a/.claude/sprints/sprint-52.md
+++ b/.claude/sprints/sprint-52.md
@@ -1,6 +1,6 @@
 # Sprint 52
 
-> Planned 2026-05-04 00:00 EDT. Started 2026-05-04 00:13 EDT. Target: 11 PRs (15 work items; 4 bundled).
+> Planned 2026-05-04 00:00 EDT. Started 2026-05-04 00:13 EDT. Ended 2026-05-04 05:23 EDT. Target: 11 PRs (15 work items; 4 bundled). Result: 9 PRs merged + 4 already-done closures + 2 needs-attention.
 
 ## Goal
 

--- a/.claude/sprints/sprint-52.md
+++ b/.claude/sprints/sprint-52.md
@@ -193,3 +193,25 @@ minor-bump candidates.
     Run.md filter should swap to `session.permission_blocked`. **This
     is a meta change; apply via `meta/run-md-permission-blocked-filter`
     branch in Step 1a or defer to retro.**
+
+## Results
+
+- **Released**: v1.8.6
+- **PRs merged**: 9
+  - #1995 (#1973) fix(status): guard null extraUsage.utilization
+  - #1997 (#1974) fix(poller): closing-keyword filter for PR auto-binding
+  - #1999 (#1993) fix(repair): clear review_session_id on spawn
+  - #2001 (#1634) fix(test): replace Bun.sleep(0) with await on exitedPromise
+  - #1998 (#1860) fix(git): eliminate core.bare config key — **47-sprint epic**, closes #394 / #1206 / #1330
+  - #2004 (#1769) chore(sites): playwright.spec.ts comment correction
+  - #2000 (#1992) fix(done): always poll PR state on non-zero merge exit
+  - #2005 (#1647) test(sites): mkdtempSync + afterEach for resolve-playwright
+  - #2006 (#1684) fix(state): canonicalize agent_sessions.repo_root + v4 migration
+- **Issues closed**: 13 (9 via merged PRs + 4 already-done #1903/#1904/#1905/#1906)
+- **Issues routed to needs-attention**: 2 (#1980, #1987 — server-pool flakies; nerd-snipe agents stalled at 600s watchdog before reaching root cause; partial findings + bisect plan posted)
+- **New issues filed**: 4
+  - #1996 — `bun scripts/build.ts` stages npm/*/bin/.gitkeep deletions (hit every implementer this sprint)
+  - #2002 — meta: align run.md pre-flight with #1860 structural fix (split from #1998)
+  - #2007 — phase: scanReviewComments matches 🔴 in delta tables, blocks APPROVED reviews
+  - (#1996, #2002, #2007 above; plus needs-attention comments on #1980/#1987 = 2 trail entries, not new issues)
+- **Cost**: ~$28 in worker quota (impl + review + qa + nerd-snipes + repairs)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "bun": ">=1.2.18"
   },
-  "version": "1.8.5",
+  "version": "1.8.6",
   "description": "MCP CLI — call MCP server tools from the command line with zero context overhead",
   "type": "module",
   "workspaces": ["packages/*"],


### PR DESCRIPTION
Sprint 52 container PR. Accumulates every sprint-meta commit on the
`sprint-52` branch:

- plan + any mid-sprint amendments
- run-time edits (Started/Ended timestamps, Excluded section)
- Results summary
- retro diary file
- release commit (if a release is cut this sprint)

Marked **draft** until `/sprint retro` flips it ready and arms auto-merge.

## Goal

**Close sprint-51 follow-ups + kill the 2 recurring server-pool flakies
with proper nerd-snipe-gated repairs + take a real swing at #1860's
47-sprint `core.bare=true` epic.**

## Plan summary

11 PRs (15 work items, 4 bundled into one PR), 3 opus heavies (#1980, #1987,
#1860 — the two flakies gated through nerd-snipe before phase=impl), 8
sonnet quick wins. See `.claude/sprints/sprint-52.md` for the full table,
batch plan, hot-shared-file watch, and the flake-nerd-snipe gate.

Plan-time triage closed 2 issues as already-fixed in sprint 51's PRs:
#1988 (extractDelayArg in #1985), #1991 (scanReviewComments rewrite in #1990).

Docs/skill-only by construction — pre-commit hooks should skip the test suite.