### PR TITLE
fix(status): guard null extraUsage.utilization in printQuotaStatus (fixes #1973)

### DIFF
--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -773,9 +773,8 @@ function printQuotaStatus(quota: QuotaStatusResult | null): void {
     console.log(`  7d opus:    ${quota.sevenDayOpus.utilization}% used`);
   }
   if (quota.extraUsage) {
-    console.log(
-      `  Extra:      ${quota.extraUsage.utilization.toFixed(1)}% ($${quota.extraUsage.usedCredits} / $${quota.extraUsage.monthlyLimit})`,
-    );
+    const util = quota.extraUsage.utilization != null ? `${quota.extraUsage.utilization.toFixed(1)}%` : "0%";
+    console.log(`  Extra:      ${util} ($${quota.extraUsage.usedCredits} / $${quota.extraUsage.monthlyLimit})`);
   }
   if (quota.lastError) {
     console.error(`  Last error: ${quota.lastError}`);

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -315,8 +315,8 @@ export interface QuotaExtraUsage {
   isEnabled: boolean;
   monthlyLimit: number;
   usedCredits: number;
-  /** Percentage of extra usage budget consumed (0-100). */
-  utilization: number;
+  /** Percentage of extra usage budget consumed (0-100). Null when usedCredits is 0. */
+  utilization: number | null;
 }
 
 export interface QuotaStatusResult {

--- a/packages/daemon/src/quota.spec.ts
+++ b/packages/daemon/src/quota.spec.ts
@@ -58,6 +58,23 @@ describe("parseUsageResponse", () => {
     expect(result.fiveHour).toEqual({ utilization: 10, resetsAt: "2026-04-08T12:00:00Z" });
     expect(result.sevenDay).toBeNull();
   });
+
+  test("preserves null utilization in extra_usage (zero credits used)", () => {
+    const result = parseUsageResponse({
+      extra_usage: {
+        is_enabled: true,
+        monthly_limit: 50000,
+        used_credits: 0,
+        utilization: null,
+      },
+    });
+    expect(result.extraUsage).toEqual({
+      isEnabled: true,
+      monthlyLimit: 50000,
+      usedCredits: 0,
+      utilization: null,
+    });
+  });
 });
 
 describe("QuotaPoller", () => {

--- a/packages/daemon/src/quota.ts
+++ b/packages/daemon/src/quota.ts
@@ -27,8 +27,8 @@ export interface ExtraUsageBucket {
   isEnabled: boolean;
   monthlyLimit: number;
   usedCredits: number;
-  /** Percentage of extra usage budget consumed (0-100). */
-  utilization: number;
+  /** Percentage of extra usage budget consumed (0-100). Null when usedCredits is 0. */
+  utilization: number | null;
 }
 
 /** Parsed quota status from the usage endpoint. */
@@ -52,7 +52,7 @@ interface RawUsageResponse {
     is_enabled: boolean;
     monthly_limit: number;
     used_credits: number;
-    utilization: number;
+    utilization: number | null;
   } | null;
 }
 
@@ -62,7 +62,10 @@ function parseBucket(raw: { utilization: number; resets_at: string } | null | un
 }
 
 function parseExtraUsage(
-  raw: { is_enabled: boolean; monthly_limit: number; used_credits: number; utilization: number } | null | undefined,
+  raw:
+    | { is_enabled: boolean; monthly_limit: number; used_credits: number; utilization: number | null }
+    | null
+    | undefined,
 ): ExtraUsageBucket | null {
   if (!raw) return null;
   return {


### PR DESCRIPTION
## Summary
- `mcx status` crashed with `TypeError: A.extraUsage.utilization.toFixed` when `utilization` was `null` (API returns null when usedCredits is 0)
- Updated `QuotaExtraUsage` interface in `core/ipc.ts` and `ExtraUsageBucket` in `daemon/quota.ts` to type `utilization` as `number | null`
- Guard in `printQuotaStatus` now renders "0%" instead of crashing when utilization is null

## Test plan
- [ ] Added unit test in `quota.spec.ts`: `preserves null utilization in extra_usage (zero credits used)` — verifies `parseUsageResponse` correctly passes `null` through
- [ ] Full test suite passes: 7005 pass, 0 fail
- [ ] TypeScript typecheck passes with updated types

🤖 Generated with [Claude Code](https://claude.com/claude-code)