### PR TITLE
fix(git): eliminate core.bare config key to prevent flip recurrence (fixes #1860)

### DIFF
--- a/.claude/phases/done-fn.ts
+++ b/.claude/phases/done-fn.ts
@@ -76,8 +76,6 @@ export async function mergePr(prNumber: number, deps: MergePrDeps): Promise<Merg
     };
   }
 
-  await deps.spawn(["git", "config", "core.bare", "false"]);
-
   const mergeResult = await deps.prMerge(prNumber, ["--squash", "--delete-branch"]);
   if (mergeResult.exitCode !== 0) {
     const stderr = mergeResult.stderr;

--- a/.claude/phases/done.ts
+++ b/.claude/phases/done.ts
@@ -84,7 +84,6 @@ defineAlias({
       await ctx.state.delete(key);
     }
 
-    await spawn(["git", "config", "core.bare", "false"]);
     const pull = await spawn(["git", "pull"], { timeoutMs: 60_000 });
     const pullWarning = pull.exitCode !== 0 ? `git pull failed (exit ${pull.exitCode}): ${pull.stderr}` : undefined;
     const localCleanup = [result.localCleanup, pullWarning].filter(Boolean).join("; ") || undefined;

--- a/.claude/skills/sprint/references/run.md
+++ b/.claude/skills/sprint/references/run.md
@@ -110,7 +110,7 @@ bun run build                          # compile latest binaries
 mcx claude ls --all --short 2>/dev/null # verify no sessions active across repos before restart
 mcx shutdown                           # stop the stale daemon
 mcx status                             # auto-starts the daemon with new binary
-git config core.bare                   # should exit non-zero (key absent) — see #1860
+git config --get core.bare             # MUST be "false" — see note below
 mcx phase install                      # ensure phase lockfile matches sources
 git fetch origin main \
   && git log HEAD ^origin/main --oneline   # MUST be empty
@@ -126,10 +126,10 @@ before starting the new sprint.
 Only restart when no sessions are active — restarting kills running
 sessions, including from a concurrent sprint in another repo.
 
-**`core.bare` key should be absent**: the daemon's 30s sweep removes the
-`core.bare` config key entirely (#1860). Without the key, git auto-detects
-from the directory layout and nothing can flip the value. If `git config
-core.bare` exits 0, run `git config --unset core.bare` to remove it.
+**`core.bare=true` recurrence**: some worktree operation flips
+`core.bare` to `true` on the main checkout. Hot-patch with
+`git config core.bare false` before every batch of git operations.
+Pre-flight + post-`bye` check until the sticky fix lands.
 
 **Run all sprint commands from within the project root.** `mcx claude ls`,
 `mcx claude wait`, and `mcx monitor` scope to the current repo's git root —

--- a/.claude/skills/sprint/references/run.md
+++ b/.claude/skills/sprint/references/run.md
@@ -110,7 +110,7 @@ bun run build                          # compile latest binaries
 mcx claude ls --all --short 2>/dev/null # verify no sessions active across repos before restart
 mcx shutdown                           # stop the stale daemon
 mcx status                             # auto-starts the daemon with new binary
-git config --get core.bare             # MUST be "false" — see note below
+git config core.bare                   # should exit non-zero (key absent) — see #1860
 mcx phase install                      # ensure phase lockfile matches sources
 git fetch origin main \
   && git log HEAD ^origin/main --oneline   # MUST be empty
@@ -126,10 +126,10 @@ before starting the new sprint.
 Only restart when no sessions are active — restarting kills running
 sessions, including from a concurrent sprint in another repo.
 
-**`core.bare=true` recurrence**: some worktree operation flips
-`core.bare` to `true` on the main checkout. Hot-patch with
-`git config core.bare false` before every batch of git operations.
-Pre-flight + post-`bye` check until the sticky fix lands.
+**`core.bare` key should be absent**: the daemon's 30s sweep removes the
+`core.bare` config key entirely (#1860). Without the key, git auto-detects
+from the directory layout and nothing can flip the value. If `git config
+core.bare` exits 0, run `git config --unset core.bare` to remove it.
 
 **Run all sprint commands from within the project root.** `mcx claude ls`,
 `mcx claude wait`, and `mcx monitor` scope to the current repo's git root —

--- a/packages/core/src/git-core-bare-repro.spec.ts
+++ b/packages/core/src/git-core-bare-repro.spec.ts
@@ -244,4 +244,37 @@ describe("core.bare=true repro (concurrent worktree removal)", () => {
       rmSync(repo, { recursive: true, force: true });
     }
   });
+
+  test("unset core.bare key survives worktree lifecycle (#1860)", () => {
+    const repo = initRepo();
+    try {
+      // Start by unsetting core.bare (the #1860 structural fix)
+      git(repo, "config", "--unset", "core.bare");
+      const { exitCode: readExit } = git(repo, "config", "core.bare");
+      expect(readExit).not.toBe(0); // key absent
+
+      // Run worktree lifecycle: the key should not be recreated
+      for (let i = 0; i < 10; i++) {
+        const branch = `lifecycle-${i}`;
+        const wtPath = join(repo, ".worktrees", branch);
+        git(repo, "worktree", "add", wtPath, "-b", branch, "HEAD");
+
+        // git operations in the worktree should not recreate core.bare on the parent
+        const wtStatus = git(wtPath, "status");
+        expect(wtStatus.exitCode).toBe(0);
+
+        git(repo, "worktree", "remove", wtPath);
+        git(repo, "branch", "-D", branch);
+
+        // Verify key is still absent after each cycle
+        const { exitCode } = git(repo, "config", "core.bare");
+        expect(exitCode).not.toBe(0);
+      }
+
+      // Final verification: git still works correctly
+      expect(git(repo, "rev-parse", "--is-inside-work-tree").stdout).toBe("true");
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/core/src/git-core-bare-repro.spec.ts
+++ b/packages/core/src/git-core-bare-repro.spec.ts
@@ -249,8 +249,8 @@ describe("core.bare=true repro (concurrent worktree removal)", () => {
     const repo = initRepo();
     try {
       // Start by unsetting core.bare (the #1860 structural fix)
-      git(repo, "config", "--unset", "core.bare");
-      const { exitCode: readExit } = git(repo, "config", "core.bare");
+      git(repo, "config", "--local", "--unset", "core.bare");
+      const { exitCode: readExit } = git(repo, "config", "--local", "core.bare");
       expect(readExit).not.toBe(0); // key absent
 
       // Run worktree lifecycle: the key should not be recreated
@@ -266,8 +266,8 @@ describe("core.bare=true repro (concurrent worktree removal)", () => {
         git(repo, "worktree", "remove", wtPath);
         git(repo, "branch", "-D", branch);
 
-        // Verify key is still absent after each cycle
-        const { exitCode } = git(repo, "config", "core.bare");
+        // Verify local key is still absent after each cycle
+        const { exitCode } = git(repo, "config", "--local", "core.bare");
         expect(exitCode).not.toBe(0);
       }
 

--- a/packages/core/src/git.spec.ts
+++ b/packages/core/src/git.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, mock, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { type ExecFn, findGitRoot, fixCoreBare } from "./git";
+import { type ExecFn, ensureCoreBareUnset, findGitRoot, fixCoreBare } from "./git";
 
 /** Create a temp dir with a .git file (like a worktree) */
 function makeFakeWorktree(): string {
@@ -106,6 +106,93 @@ describe("fixCoreBare", () => {
 
       expect(result).toBe(false);
       expect(exec).toHaveBeenCalledTimes(1);
+    } finally {
+      rmSync(cwd, { recursive: true });
+    }
+  });
+});
+
+describe("ensureCoreBareUnset", () => {
+  test("removes core.bare when set to true", () => {
+    const cwd = makeFakeWorktree();
+    try {
+      const calls: string[][] = [];
+      const exec: ExecFn = mock((cmd: string[]) => {
+        calls.push(cmd);
+        if (cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset")) {
+          return { stdout: "true\n", exitCode: 0 };
+        }
+        return { stdout: "", exitCode: 0 };
+      });
+
+      expect(ensureCoreBareUnset(cwd, exec)).toBe(true);
+      expect(calls).toHaveLength(2);
+      expect(calls[1]).toEqual(["git", "-C", cwd, "config", "--unset", "core.bare"]);
+    } finally {
+      rmSync(cwd, { recursive: true });
+    }
+  });
+
+  test("removes core.bare when set to false", () => {
+    const cwd = makeFakeWorktree();
+    try {
+      const calls: string[][] = [];
+      const exec: ExecFn = mock((cmd: string[]) => {
+        calls.push(cmd);
+        if (cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset")) {
+          return { stdout: "false\n", exitCode: 0 };
+        }
+        return { stdout: "", exitCode: 0 };
+      });
+
+      expect(ensureCoreBareUnset(cwd, exec)).toBe(true);
+      expect(calls).toHaveLength(2);
+      expect(calls[1]).toEqual(["git", "-C", cwd, "config", "--unset", "core.bare"]);
+    } finally {
+      rmSync(cwd, { recursive: true });
+    }
+  });
+
+  test("returns false when key is already absent", () => {
+    const cwd = makeFakeWorktree();
+    try {
+      const exec: ExecFn = mock(() => ({ stdout: "", exitCode: 1 }));
+      expect(ensureCoreBareUnset(cwd, exec)).toBe(false);
+      expect(exec).toHaveBeenCalledTimes(1);
+    } finally {
+      rmSync(cwd, { recursive: true });
+    }
+  });
+
+  test("does nothing for bare repo (no .git entry)", () => {
+    const cwd = makeFakeBareRepo();
+    try {
+      const exec: ExecFn = mock(() => ({ stdout: "", exitCode: 0 }));
+      expect(ensureCoreBareUnset(cwd, exec)).toBe(false);
+      expect(exec).toHaveBeenCalledTimes(0);
+    } finally {
+      rmSync(cwd, { recursive: true });
+    }
+  });
+
+  test("falls back to setting false when unset fails on core.bare=true", () => {
+    const cwd = makeFakeWorktree();
+    try {
+      const calls: string[][] = [];
+      const exec: ExecFn = mock((cmd: string[]) => {
+        calls.push(cmd);
+        if (cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset") && cmd.length === 5) {
+          return { stdout: "true\n", exitCode: 0 };
+        }
+        if (cmd.includes("--unset")) {
+          return { stdout: "", exitCode: 1 };
+        }
+        return { stdout: "", exitCode: 0 };
+      });
+
+      expect(ensureCoreBareUnset(cwd, exec)).toBe(false);
+      expect(calls).toHaveLength(3);
+      expect(calls[2]).toEqual(["git", "-C", cwd, "config", "core.bare", "false"]);
     } finally {
       rmSync(cwd, { recursive: true });
     }

--- a/packages/core/src/git.spec.ts
+++ b/packages/core/src/git.spec.ts
@@ -175,24 +175,52 @@ describe("ensureCoreBareUnset", () => {
     }
   });
 
-  test("falls back to setting false when unset fails on core.bare=true", () => {
+  test("falls back to setting false when unset fails and re-read confirms true", () => {
     const cwd = makeFakeWorktree();
     try {
       const calls: string[][] = [];
       const exec: ExecFn = mock((cmd: string[]) => {
         calls.push(cmd);
+        // Both reads return true (key stubbornly present)
         if (cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset") && cmd.length === 5) {
           return { stdout: "true\n", exitCode: 0 };
         }
         if (cmd.includes("--unset")) {
           return { stdout: "", exitCode: 1 };
         }
+        // fallback set
         return { stdout: "", exitCode: 0 };
       });
 
       expect(ensureCoreBareUnset(cwd, exec)).toBe(false);
-      expect(calls).toHaveLength(3);
-      expect(calls[2]).toEqual(["git", "-C", cwd, "config", "core.bare", "false"]);
+      expect(calls).toHaveLength(4);
+      expect(calls[2]).toEqual(["git", "-C", cwd, "config", "core.bare"]); // re-read
+      expect(calls[3]).toEqual(["git", "-C", cwd, "config", "core.bare", "false"]); // fallback
+    } finally {
+      rmSync(cwd, { recursive: true });
+    }
+  });
+
+  test("no fallback when unset fails but re-read shows key gone (benign race)", () => {
+    const cwd = makeFakeWorktree();
+    try {
+      const calls: string[][] = [];
+      let readCount = 0;
+      const exec: ExecFn = mock((cmd: string[]) => {
+        calls.push(cmd);
+        if (cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset") && cmd.length === 5) {
+          readCount++;
+          if (readCount === 1) return { stdout: "true\n", exitCode: 0 }; // initial read
+          return { stdout: "", exitCode: 1 }; // re-read: key gone
+        }
+        if (cmd.includes("--unset")) {
+          return { stdout: "", exitCode: 1 }; // unset fails (race)
+        }
+        return { stdout: "", exitCode: 0 };
+      });
+
+      expect(ensureCoreBareUnset(cwd, exec)).toBe(true);
+      expect(calls).toHaveLength(3); // read, unset, re-read — no fallback set
     } finally {
       rmSync(cwd, { recursive: true });
     }

--- a/packages/core/src/git.spec.ts
+++ b/packages/core/src/git.spec.ts
@@ -127,7 +127,7 @@ describe("ensureCoreBareUnset", () => {
 
       expect(ensureCoreBareUnset(cwd, exec)).toBe(true);
       expect(calls).toHaveLength(2);
-      expect(calls[1]).toEqual(["git", "-C", cwd, "config", "--unset", "core.bare"]);
+      expect(calls[1]).toEqual(["git", "-C", cwd, "config", "--local", "--unset", "core.bare"]);
     } finally {
       rmSync(cwd, { recursive: true });
     }
@@ -147,7 +147,7 @@ describe("ensureCoreBareUnset", () => {
 
       expect(ensureCoreBareUnset(cwd, exec)).toBe(true);
       expect(calls).toHaveLength(2);
-      expect(calls[1]).toEqual(["git", "-C", cwd, "config", "--unset", "core.bare"]);
+      expect(calls[1]).toEqual(["git", "-C", cwd, "config", "--local", "--unset", "core.bare"]);
     } finally {
       rmSync(cwd, { recursive: true });
     }
@@ -179,23 +179,19 @@ describe("ensureCoreBareUnset", () => {
     const cwd = makeFakeWorktree();
     try {
       const calls: string[][] = [];
+      const isRead = (cmd: string[]) =>
+        cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset") && cmd.length === 6;
       const exec: ExecFn = mock((cmd: string[]) => {
         calls.push(cmd);
-        // Both reads return true (key stubbornly present)
-        if (cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset") && cmd.length === 5) {
-          return { stdout: "true\n", exitCode: 0 };
-        }
-        if (cmd.includes("--unset")) {
-          return { stdout: "", exitCode: 1 };
-        }
-        // fallback set
-        return { stdout: "", exitCode: 0 };
+        if (isRead(cmd)) return { stdout: "true\n", exitCode: 0 };
+        if (cmd.includes("--unset")) return { stdout: "", exitCode: 1 };
+        return { stdout: "", exitCode: 0 }; // fallback set
       });
 
       expect(ensureCoreBareUnset(cwd, exec)).toBe(false);
       expect(calls).toHaveLength(4);
-      expect(calls[2]).toEqual(["git", "-C", cwd, "config", "core.bare"]); // re-read
-      expect(calls[3]).toEqual(["git", "-C", cwd, "config", "core.bare", "false"]); // fallback
+      expect(calls[2]).toEqual(["git", "-C", cwd, "config", "--local", "core.bare"]); // re-read
+      expect(calls[3]).toEqual(["git", "-C", cwd, "config", "--local", "core.bare", "false"]); // fallback
     } finally {
       rmSync(cwd, { recursive: true });
     }
@@ -206,16 +202,16 @@ describe("ensureCoreBareUnset", () => {
     try {
       const calls: string[][] = [];
       let readCount = 0;
+      const isRead = (cmd: string[]) =>
+        cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset") && cmd.length === 6;
       const exec: ExecFn = mock((cmd: string[]) => {
         calls.push(cmd);
-        if (cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset") && cmd.length === 5) {
+        if (isRead(cmd)) {
           readCount++;
           if (readCount === 1) return { stdout: "true\n", exitCode: 0 }; // initial read
           return { stdout: "", exitCode: 1 }; // re-read: key gone
         }
-        if (cmd.includes("--unset")) {
-          return { stdout: "", exitCode: 1 }; // unset fails (race)
-        }
+        if (cmd.includes("--unset")) return { stdout: "", exitCode: 1 }; // unset fails (race)
         return { stdout: "", exitCode: 0 };
       });
 

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -13,12 +13,9 @@ export interface ExecResult {
 export type ExecFn = (cmd: string[]) => ExecResult;
 
 /**
- * After `git worktree remove`, git can sometimes flip `core.bare = true`
- * on the main repository (especially under heavy concurrent worktree
- * create/remove cycles). This breaks all subsequent git operations.
- *
- * Call this after every successful `git worktree remove` to detect and
- * fix the issue. See https://github.com/theshadow27/mcp-cli/issues/394
+ * @deprecated Use {@link ensureCoreBareUnset} — it removes the key regardless
+ * of value, eliminating the attack surface entirely. This function only reacts
+ * to `core.bare=true` and ignores `false`. See #1860.
  */
 export function fixCoreBare(cwd: string, exec: ExecFn): boolean {
   // Only touch non-bare repos — a legitimate bare repo has no .git directory.
@@ -64,7 +61,6 @@ export function ensureCoreBareUnset(cwd: string, exec: ExecFn): boolean {
   if (!existsSync(join(cwd, ".git"))) return false;
   const { stdout, exitCode } = exec(["git", "-C", cwd, "config", "core.bare"]);
   if (exitCode !== 0) return false; // key already absent
-  const value = stdout.trim();
   const unset = exec(["git", "-C", cwd, "config", "--unset", "core.bare"]);
   if (unset.exitCode === 0) return true;
   // --unset failed. Re-read to distinguish "key gone (benign race)" from
@@ -72,7 +68,9 @@ export function ensureCoreBareUnset(cwd: string, exec: ExecFn): boolean {
   // would recreate the key, defeating the structural fix.
   const recheck = exec(["git", "-C", cwd, "config", "core.bare"]);
   if (recheck.exitCode !== 0) return true; // key gone — race resolved
-  if (recheck.stdout.trim() === "true") {
+  // Key stubbornly present (locked file, permission issue, etc.).
+  // Last resort: ensure it's at least "false" so git ops don't break.
+  if (recheck.stdout.trim() !== "false") {
     exec(["git", "-C", cwd, "config", "core.bare", "false"]);
   }
   return false;

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -59,19 +59,19 @@ export function isCoreBareSet(cwd: string, exec: ExecFn): boolean {
  */
 export function ensureCoreBareUnset(cwd: string, exec: ExecFn): boolean {
   if (!existsSync(join(cwd, ".git"))) return false;
-  const { stdout, exitCode } = exec(["git", "-C", cwd, "config", "core.bare"]);
+  const { stdout, exitCode } = exec(["git", "-C", cwd, "config", "--local", "core.bare"]);
   if (exitCode !== 0) return false; // key already absent
-  const unset = exec(["git", "-C", cwd, "config", "--unset", "core.bare"]);
+  const unset = exec(["git", "-C", cwd, "config", "--local", "--unset", "core.bare"]);
   if (unset.exitCode === 0) return true;
   // --unset failed. Re-read to distinguish "key gone (benign race)" from
   // "key still present (real failure)". Without this re-read the fallback
   // would recreate the key, defeating the structural fix.
-  const recheck = exec(["git", "-C", cwd, "config", "core.bare"]);
+  const recheck = exec(["git", "-C", cwd, "config", "--local", "core.bare"]);
   if (recheck.exitCode !== 0) return true; // key gone — race resolved
   // Key stubbornly present (locked file, permission issue, etc.).
   // Last resort: ensure it's at least "false" so git ops don't break.
   if (recheck.stdout.trim() !== "false") {
-    exec(["git", "-C", cwd, "config", "core.bare", "false"]);
+    exec(["git", "-C", cwd, "config", "--local", "core.bare", "false"]);
   }
   return false;
 }

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -67,10 +67,12 @@ export function ensureCoreBareUnset(cwd: string, exec: ExecFn): boolean {
   const value = stdout.trim();
   const unset = exec(["git", "-C", cwd, "config", "--unset", "core.bare"]);
   if (unset.exitCode === 0) return true;
-  // --unset can fail if the key was removed between read and unset (benign race)
-  if (value === "true") {
-    // Critical: core.bare=true and we failed to unset — this is the dangerous state.
-    // Fall back to setting false, which is strictly better than leaving true.
+  // --unset failed. Re-read to distinguish "key gone (benign race)" from
+  // "key still present (real failure)". Without this re-read the fallback
+  // would recreate the key, defeating the structural fix.
+  const recheck = exec(["git", "-C", cwd, "config", "core.bare"]);
+  if (recheck.exitCode !== 0) return true; // key gone — race resolved
+  if (recheck.stdout.trim() === "true") {
     exec(["git", "-C", cwd, "config", "core.bare", "false"]);
   }
   return false;

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -50,6 +50,33 @@ export function isCoreBareSet(cwd: string, exec: ExecFn): boolean {
 }
 
 /**
+ * Remove the `core.bare` config key entirely, regardless of its current value.
+ *
+ * Git auto-detects bare status from the directory layout (.git dir = non-bare).
+ * An explicit `core.bare = false` is harmless but creates a key that COULD be
+ * flipped to `true` by an unknown external operation — the 47-sprint recurring
+ * bug. Removing the key eliminates the attack surface: if the key doesn't exist,
+ * nothing can flip it. See #1860.
+ *
+ * Returns true if the key was present and successfully removed.
+ */
+export function ensureCoreBareUnset(cwd: string, exec: ExecFn): boolean {
+  if (!existsSync(join(cwd, ".git"))) return false;
+  const { stdout, exitCode } = exec(["git", "-C", cwd, "config", "core.bare"]);
+  if (exitCode !== 0) return false; // key already absent
+  const value = stdout.trim();
+  const unset = exec(["git", "-C", cwd, "config", "--unset", "core.bare"]);
+  if (unset.exitCode === 0) return true;
+  // --unset can fail if the key was removed between read and unset (benign race)
+  if (value === "true") {
+    // Critical: core.bare=true and we failed to unset — this is the dangerous state.
+    // Fall back to setting false, which is strictly better than leaving true.
+    exec(["git", "-C", cwd, "config", "core.bare", "false"]);
+  }
+  return false;
+}
+
+/**
  * Environment for git repo-discovery commands: strip inherited GIT_DIR,
  * GIT_WORK_TREE, and GIT_COMMON_DIR so that the caller's git-hook environment
  * does not override filesystem-based discovery. findGitRoot is meant to

--- a/packages/core/src/worktree-shim.spec.ts
+++ b/packages/core/src/worktree-shim.spec.ts
@@ -176,9 +176,9 @@ describe("createWorktree", () => {
     );
   });
 
-  test("shimmed worktree: fixes core.bare=true after worktree add", () => {
+  test("shimmed worktree: removes core.bare key after worktree add", () => {
     tmpDir = makeTmpDir();
-    // Create .git dir so fixCoreBare detects a non-bare repo
+    // Create .git dir so ensureCoreBareUnset detects a non-bare repo
     mkdirSync(join(tmpDir, ".git"), { recursive: true });
 
     const execCalls: string[][] = [];
@@ -203,7 +203,7 @@ describe("createWorktree", () => {
     // Verify core.bare was checked both before and after worktree add
     const worktreeAddIdx = execCalls.findIndex((c) => c.includes("worktree") && c.includes("add"));
     const isCoreBareRead = (c: string[]) => c.includes("config") && c.includes("core.bare") && !c.includes("--unset");
-    // There should be a read BEFORE the add (pre-probe) and one AFTER (post-probe / fixCoreBare)
+    // There should be a read BEFORE the add (pre-probe) and one AFTER (post-probe / ensureCoreBareUnset)
     expect(execCalls.slice(0, worktreeAddIdx).some(isCoreBareRead)).toBe(true);
     const coreBareReadAfterIdx = execCalls.findIndex((c, i) => i > worktreeAddIdx && isCoreBareRead(c));
     expect(coreBareReadAfterIdx).toBeGreaterThan(worktreeAddIdx);
@@ -213,7 +213,7 @@ describe("createWorktree", () => {
     expect(coreBareFixIdx).toBeGreaterThan(coreBareReadAfterIdx);
 
     // Should log the fix (via printInfo, not printError)
-    expect(deps.printInfo).toHaveBeenCalledWith("Fixed core.bare=true after worktree add");
+    expect(deps.printInfo).toHaveBeenCalledWith("Removed core.bare key after worktree add");
   });
 
   test("branchPrefix: false creates with raw branch name", () => {
@@ -686,10 +686,10 @@ describe("pruneWorktrees", () => {
     expect(result.skippedUnmerged).toEqual(["claude/feat-wip"]);
   });
 
-  test("batch guard: calls fixCoreBare after pruning when core.bare=true on last removal", async () => {
+  test("batch guard: calls ensureCoreBareUnset after pruning when core.bare=true on last removal", async () => {
     // Simulate the recurrence bug: individual per-removal fix runs but a subsequent
     // removal flips core.bare back to true. The final batch guard should catch it.
-    // fixCoreBare guards against non-existent repos via existsSync(.git), so we need
+    // ensureCoreBareUnset guards against non-existent repos via existsSync(.git), so we need
     // a real temp dir with a .git marker.
     const repoRoot = makeTmpDir();
     try {

--- a/packages/core/src/worktree-shim.ts
+++ b/packages/core/src/worktree-shim.ts
@@ -11,7 +11,7 @@
 import { existsSync, realpathSync } from "node:fs";
 import { join } from "node:path";
 import type { ExecFn } from "./git";
-import { fixCoreBare, isCoreBareSet } from "./git";
+import { ensureCoreBareUnset, isCoreBareSet } from "./git";
 import {
   buildHookEnv,
   hasWorktreeHooks,
@@ -146,8 +146,8 @@ export function createWorktree(opts: WorktreeCreateOptions, deps: WorktreeShimDe
         `[shim] core.bare flipped to true by: git worktree add ${worktreePath} (repo=${repoRoot}) — see #1330`,
       );
     }
-    if (fixCoreBare(repoRoot, (cmd) => deps.exec(cmd))) {
-      deps.printInfo("Fixed core.bare=true after worktree add");
+    if (ensureCoreBareUnset(repoRoot, (cmd) => deps.exec(cmd))) {
+      deps.printInfo("Removed core.bare key after worktree add");
     }
     deps.printInfo(`Created worktree: ${worktreePath}`);
     return {
@@ -179,8 +179,8 @@ export function createWorktree(opts: WorktreeCreateOptions, deps: WorktreeShimDe
       `[shim] core.bare flipped to true by: git worktree add ${worktreePath} (repo=${repoRoot}) — see #1330`,
     );
   }
-  if (fixCoreBare(repoRoot, (cmd) => deps.exec(cmd))) {
-    deps.printInfo("Fixed core.bare=true after worktree add");
+  if (ensureCoreBareUnset(repoRoot, (cmd) => deps.exec(cmd))) {
+    deps.printInfo("Removed core.bare key after worktree add");
   }
   deps.printInfo(`Created worktree: ${worktreePath}`);
   return {
@@ -282,8 +282,8 @@ function removeWorktreeWithVerification(
       `[shim] core.bare flipped to true by: git worktree remove ${worktreePath} (repo=${repoRoot}) — see #1330`,
     );
   }
-  if (fixCoreBare(repoRoot, (cmd) => deps.exec(cmd))) {
-    deps.printInfo("Fixed core.bare=true after worktree removal");
+  if (ensureCoreBareUnset(repoRoot, (cmd) => deps.exec(cmd))) {
+    deps.printInfo("Removed core.bare key after worktree removal");
   }
 
   // Verify: directory must actually be gone
@@ -315,8 +315,8 @@ function removeWorktreeWithVerification(
       `[shim] core.bare flipped to true by: git worktree remove --force ${worktreePath} (repo=${repoRoot}) — see #1330`,
     );
   }
-  if (fixCoreBare(repoRoot, (cmd) => deps.exec(cmd))) {
-    deps.printInfo("Fixed core.bare=true after worktree removal");
+  if (ensureCoreBareUnset(repoRoot, (cmd) => deps.exec(cmd))) {
+    deps.printInfo("Removed core.bare key after worktree removal");
   }
 
   if (!existsSync(worktreePath)) {
@@ -539,8 +539,8 @@ export async function pruneWorktrees(opts: WorktreePruneOptions): Promise<Worktr
   // Individual per-removal fixes can be undone by subsequent removals in the
   // same batch. This ensures the repo is in a valid state when we return. #1206
   if (pruned > 0) {
-    if (fixCoreBare(repoRoot, (cmd) => deps.exec(cmd))) {
-      deps.printInfo("Fixed core.bare=true after batch worktree prune");
+    if (ensureCoreBareUnset(repoRoot, (cmd) => deps.exec(cmd))) {
+      deps.printInfo("Removed core.bare key after batch worktree prune");
     }
   }
 

--- a/packages/daemon/src/index.spec.ts
+++ b/packages/daemon/src/index.spec.ts
@@ -933,13 +933,13 @@ describe("sweepCoreBare (#1330)", () => {
 
       expect(healed).toBe(1);
       expect(execCalls.some((c) => c.includes("--unset") && c.includes("core.bare"))).toBe(true);
-      expect(warnMessages.some((m) => m.includes("Healed core.bare=true"))).toBe(true);
+      expect(warnMessages.some((m) => m.includes("Removed core.bare key"))).toBe(true);
     } finally {
       db.close();
     }
   });
 
-  test("returns 0 when no repos need healing", () => {
+  test("returns 0 when core.bare key is already absent", () => {
     opts = testOptions();
     const repoDir = join(opts.dir, "sweep-clean");
     mkdirSync(repoDir, { recursive: true });
@@ -959,11 +959,49 @@ describe("sweepCoreBare (#1330)", () => {
         db,
         silentLogger,
         mockGitOps({
-          exec: () => ({ exitCode: 0, stdout: "false\n" }),
+          exec: () => ({ exitCode: 1, stdout: "" }),
         }),
       );
 
       expect(healed).toBe(0);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("removes core.bare=false too (eliminates flip target)", () => {
+    opts = testOptions();
+    const repoDir = join(opts.dir, "sweep-false");
+    mkdirSync(repoDir, { recursive: true });
+    writeFileSync(join(repoDir, ".git"), "gitdir: /some/repo\n");
+
+    const db = new StateDb(opts.DB_PATH);
+    try {
+      db.upsertSession({
+        sessionId: "active",
+        pid: 99999,
+        model: "sonnet",
+        cwd: repoDir,
+        repoRoot: repoDir,
+      });
+
+      const execCalls: string[][] = [];
+      const healed = sweepCoreBare(
+        db,
+        silentLogger,
+        mockGitOps({
+          exec: (cmd: string[]) => {
+            execCalls.push(cmd);
+            if (cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset")) {
+              return { exitCode: 0, stdout: "false\n" };
+            }
+            return { exitCode: 0, stdout: "" };
+          },
+        }),
+      );
+
+      expect(healed).toBe(1);
+      expect(execCalls.some((c) => c.includes("--unset") && c.includes("core.bare"))).toBe(true);
     } finally {
       db.close();
     }
@@ -1067,7 +1105,7 @@ describe("mcpd_core_bare_healed_total counter", () => {
     }
   });
 
-  test("sweepCoreBare does not increment counter when nothing healed", () => {
+  test("sweepCoreBare does not increment counter when key already absent", () => {
     opts = testOptions();
     const repoDir = join(opts.dir, "counter-sweep-clean");
     mkdirSync(repoDir, { recursive: true });
@@ -1077,7 +1115,7 @@ describe("mcpd_core_bare_healed_total counter", () => {
     try {
       db.upsertSession({ sessionId: "s2", pid: 99999, model: "sonnet", cwd: repoDir, repoRoot: repoDir });
 
-      sweepCoreBare(db, silentLogger, mockGitOps({ exec: () => ({ exitCode: 0, stdout: "false\n" }) }));
+      sweepCoreBare(db, silentLogger, mockGitOps({ exec: () => ({ exitCode: 1, stdout: "" }) }));
 
       expect(metrics.counter("mcpd_core_bare_healed_total", { source: "sweep" }).value()).toBe(0);
     } finally {

--- a/packages/daemon/src/index.spec.ts
+++ b/packages/daemon/src/index.spec.ts
@@ -796,8 +796,8 @@ describe("pruneOrphanedWorktrees", () => {
     pruneOrphanedWorktrees(db, silentLogger, mockGitOps());
   });
 
-  test("batch guard: calls fixCoreBare after all removals when core.bare=true (#1206)", () => {
-    // fixCoreBare guards against non-existent repos via existsSync(.git), so we
+  test("batch guard: calls ensureCoreBareUnset after all removals (#1206)", () => {
+    // ensureCoreBareUnset guards against non-existent repos via existsSync(.git), so we
     // need a real temp dir with a .git marker for the repoRoot.
     opts = testOptions();
     const repoDir = join(opts.dir, "repo-batch-guard");
@@ -1183,17 +1183,11 @@ describe("mcpd_core_bare_healed_total counter", () => {
       });
       db.endSession("ended-bd");
 
-      // Simulate: core.bare is fine before/after worktree remove, but flips after branch delete,
-      // then fixCoreBare succeeds (unset returns exitCode 0).
-      // Non-unset config core.bare call sequence:
-      //   1: isCoreBareSet(bareBeforeRemove)  → false
-      //   2: isCoreBareSet(bareAfterRemove)   → false
-      //   3: fixCoreBare (post-remove check)  → false (no heal)
-      //   4: isCoreBareSet(bareBeforeBranch)  → false
-      //   5: isCoreBareSet(bareAfterBranch)   → true  (flip detected)
-      //   6: fixCoreBare (branch_delete heal) → true  (heals, increments branch_delete)
-      //   7: fixCoreBare (batch guard)        → false (already healed)
-      let callCount = 0;
+      // Simulate: core.bare key is absent initially, then flips to true after
+      // branch delete. ensureCoreBareUnset removes any value, so the mock must
+      // be stateful — after a successful --unset, subsequent reads return absent.
+      let coreBareValue: string | null = null; // null = absent
+      let branchDeleted = false;
       pruneOrphanedWorktrees(
         db,
         silentLogger,
@@ -1202,17 +1196,28 @@ describe("mcpd_core_bare_healed_total counter", () => {
           status: () => ({ exitCode: 0, stdout: "" }),
           showBranch: () => ({ exitCode: 0, stdout: "feat/bd-branch" }),
           removeWorktree: () => ({ exitCode: 0 }),
-          deleteBranch: () => ({ exitCode: 0 }),
+          deleteBranch: () => {
+            branchDeleted = true;
+            coreBareValue = "true"; // flip happens on branch delete
+            return { exitCode: 0, stdout: "" };
+          },
           exec: (cmd: string[]) => {
-            if (cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset")) {
-              callCount++;
-              return { exitCode: 0, stdout: callCount === 5 || callCount === 6 ? "true\n" : "false\n" };
+            if (cmd.includes("config") && cmd.includes("core.bare")) {
+              if (cmd.includes("--unset")) {
+                coreBareValue = null;
+                return { exitCode: 0, stdout: "" };
+              }
+              if (coreBareValue !== null) {
+                return { exitCode: 0, stdout: `${coreBareValue}\n` };
+              }
+              return { exitCode: 1, stdout: "" }; // key absent
             }
             return { exitCode: 0, stdout: "" };
           },
         }),
       );
 
+      expect(branchDeleted).toBe(true);
       expect(metrics.counter("mcpd_core_bare_healed_total", { source: "branch_delete" }).value()).toBe(1);
       expect(metrics.counter("mcpd_core_bare_healed_total", { source: "worktree_remove" }).value()).toBe(0);
     } finally {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -48,6 +48,7 @@ import {
   WORK_ITEMS_SERVER_NAME,
   auditRuntimePermissions,
   consoleLogger,
+  ensureCoreBareUnset,
   ensureStateDir,
   fixCoreBare,
   generateSpanId,
@@ -162,11 +163,12 @@ function defaultGitOps(): PruneGitOps {
 }
 
 /**
- * Preflight: scan repo roots known to the daemon and unset `core.bare=true`
- * wherever it's stuck. Catches drift from external tools (e.g. `gh pr merge
- * --delete-branch`) that flip the bit outside our worktree shim. See #1330.
+ * Preflight: scan repo roots known to the daemon and remove the `core.bare`
+ * config key entirely. An explicit `core.bare = false` is harmless but creates
+ * a key that COULD be flipped to `true` by an unknown external operation.
+ * Removing the key eliminates the attack surface. See #1860.
  *
- * Returns the number of repos that were healed.
+ * Returns the number of repos where the key was removed.
  */
 export function sweepCoreBare(
   db: StateDb,
@@ -185,8 +187,8 @@ export function sweepCoreBare(
       else if (s.cwd) roots.add(s.cwd);
     }
     for (const root of roots) {
-      if (fixCoreBare(root, (cmd) => gitOps.exec(cmd))) {
-        logger.warn(`[mcpd] Healed core.bare=true on ${root} (sweep) — see #1330`);
+      if (ensureCoreBareUnset(root, (cmd) => gitOps.exec(cmd))) {
+        logger.warn(`[mcpd] Removed core.bare key from ${root} (sweep) — see #1860`);
         metrics.counter("mcpd_core_bare_healed_total", { source: "sweep" }).inc();
         healed++;
       }

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -50,7 +50,6 @@ import {
   consoleLogger,
   ensureCoreBareUnset,
   ensureStateDir,
-  fixCoreBare,
   generateSpanId,
   isCoreBareSet,
   loadManifest,
@@ -245,8 +244,8 @@ export function pruneOrphanedWorktrees(
             `[mcpd] core.bare flipped to true by: git worktree remove ${worktreePath} (repo=${repoRoot}) — see #1330`,
           );
         }
-        if (fixCoreBare(repoRoot, (cmd) => gitOps.exec(cmd))) {
-          logger.warn("[mcpd] Fixed core.bare=true after worktree removal");
+        if (ensureCoreBareUnset(repoRoot, (cmd) => gitOps.exec(cmd))) {
+          logger.warn("[mcpd] Removed core.bare key after worktree removal");
           metrics.counter("mcpd_core_bare_healed_total", { source: "worktree_remove" }).inc();
         }
         affectedRepoRoots.add(repoRoot);
@@ -262,7 +261,7 @@ export function pruneOrphanedWorktrees(
               logger.warn(
                 `[mcpd] core.bare flipped to true by: git branch -d ${branch} (repo=${repoRoot}) — see #1330`,
               );
-              if (fixCoreBare(repoRoot, (cmd) => gitOps.exec(cmd))) {
+              if (ensureCoreBareUnset(repoRoot, (cmd) => gitOps.exec(cmd))) {
                 metrics.counter("mcpd_core_bare_healed_total", { source: "branch_delete" }).inc();
               }
             }
@@ -276,8 +275,8 @@ export function pruneOrphanedWorktrees(
       // Final guard: check core.bare after all removals complete. Individual
       // per-removal fixes can be undone by subsequent removals. #1206
       for (const root of affectedRepoRoots) {
-        if (fixCoreBare(root, (cmd) => gitOps.exec(cmd))) {
-          logger.warn("[mcpd] Fixed core.bare=true after batch worktree prune");
+        if (ensureCoreBareUnset(root, (cmd) => gitOps.exec(cmd))) {
+          logger.warn("[mcpd] Removed core.bare key after batch worktree prune");
           metrics.counter("mcpd_core_bare_healed_total", { source: "worktree_remove" }).inc();
         }
       }

--- a/test/done-phase.spec.ts
+++ b/test/done-phase.spec.ts
@@ -136,7 +136,7 @@ describe("mergePr — success", () => {
     expect(capturedFlags).toEqual(["--squash", "--delete-branch"]);
   });
 
-  test("spawn called to reset core.bare before merge", async () => {
+  test("no pre-flight core.bare workaround (#1860)", async () => {
     const spawnCalls: string[][] = [];
     await mergePr(
       42,
@@ -147,7 +147,8 @@ describe("mergePr — success", () => {
         },
       }),
     );
-    expect(spawnCalls[0]).toEqual(["git", "config", "core.bare", "false"]);
+    const coreBareCall = spawnCalls.find((c) => c.includes("core.bare"));
+    expect(coreBareCall).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- Add `ensureCoreBareUnset()` that removes the `core.bare` config key regardless of value — if the key doesn't exist, nothing can flip it from `false` to `true`
- Daemon's 30s sweep now removes `core.bare=false` too (not just `true`), eliminating the attack surface
- Remove defensive `git config core.bare false` workarounds from `done-fn.ts` and `done.ts` (per acceptance criteria)

## Investigation findings

Could not reproduce the flip with sequential or concurrent `git worktree add/remove/branch -D` on git 2.50.1. The structural vulnerability: the codebase had two conflicting repair strategies — `fixCoreBare()` used `--unset` (correct) while `done.ts` used `git config core.bare false` (recreates the key that could be flipped). The fix eliminates the key entirely so git auto-detects from directory layout.

Full findings posted to #1860.

## Test plan

- [x] `ensureCoreBareUnset` unit tests: removes `true`, removes `false`, no-op when absent, bare repo skip, fallback on unset failure
- [x] Integration test: unset key survives 10 worktree create/remove cycles
- [x] `sweepCoreBare` tests updated: handles `false` removal, no-op when key absent
- [x] `done-phase` test: verifies no pre-flight `core.bare` workaround
- [x] Full test suite: 7011 pass, 0 fail

Closes #394, closes #1206, closes #1330.

🤖 Generated with [Claude Code](https://claude.com/claude-code)