### PR TITLE
fix(repair): clear review_session_id on spawn to prevent stale sentinel wedge (fixes #1993)

### DIFF
--- a/.claude/phases/repair-fn.ts
+++ b/.claude/phases/repair-fn.ts
@@ -76,6 +76,7 @@ export async function runRepair(
   const worktreeFlags = worktreePath ? ["--cwd", worktreePath] : ["--worktree"];
   const command = [...cmdBase, ...worktreeFlags, "--model", "opus", "-t", prompt, "--allow", ...allowTools];
 
+  // Clear both phase sentinels so review re-entry always spawns fresh rather than reading a stale pending:* id.
   await state.delete("qa_session_id");
   await state.delete("review_session_id");
   try {

--- a/.claude/phases/repair-fn.ts
+++ b/.claude/phases/repair-fn.ts
@@ -77,6 +77,7 @@ export async function runRepair(
   const command = [...cmdBase, ...worktreeFlags, "--model", "opus", "-t", prompt, "--allow", ...allowTools];
 
   await state.delete("qa_session_id");
+  await state.delete("review_session_id");
   try {
     await deps.prEdit(work.prNumber, ["--remove-label", "qa:fail"]);
   } catch {

--- a/test/repair-phase.spec.ts
+++ b/test/repair-phase.spec.ts
@@ -216,7 +216,7 @@ describe("runRepair — spawn path", () => {
     expect(String(writes.repair_session_id)).toMatch(/^pending:/);
   });
 
-  test("clears qa_session_id before spawning", async () => {
+  test("deletes qa_session_id on spawn", async () => {
     const deletedKeys: string[] = [];
     const state = makeState();
     const trackingState: RepairState = {
@@ -231,7 +231,7 @@ describe("runRepair — spawn path", () => {
     expect(deletedKeys).toContain("qa_session_id");
   });
 
-  test("clears review_session_id before spawning", async () => {
+  test("deletes review_session_id on spawn", async () => {
     const deletedKeys: string[] = [];
     const state = makeState({ review_session_id: "pending:999" });
     const trackingState: RepairState = {

--- a/test/repair-phase.spec.ts
+++ b/test/repair-phase.spec.ts
@@ -231,6 +231,21 @@ describe("runRepair — spawn path", () => {
     expect(deletedKeys).toContain("qa_session_id");
   });
 
+  test("clears review_session_id before spawning", async () => {
+    const deletedKeys: string[] = [];
+    const state = makeState({ review_session_id: "pending:999" });
+    const trackingState: RepairState = {
+      get: state.get,
+      set: state.set,
+      delete: async (key) => {
+        deletedKeys.push(key);
+        await state.delete(key);
+      },
+    };
+    await runRepair({ provider: "claude" }, makeWork(), trackingState, makeDeps());
+    expect(deletedKeys).toContain("review_session_id");
+  });
+
   test("removes qa:fail label (best-effort)", async () => {
     const editCalls: Array<{ prNumber: number; flags: string[] }> = [];
     await runRepair(


### PR DESCRIPTION
## Summary
- Adds `await state.delete("review_session_id")` alongside the existing `qa_session_id` delete in `runRepair`, so a prior round's `pending:*` sentinel is always cleared before a new repair session spawns
- Eliminates the orchestrator-crash window where review re-entry would skip spawning and re-route on a stale comment
- One new unit test verifies `review_session_id` is in the deleted keys set on a spawn path

## Test plan
- [x] `bun test test/repair-phase.spec.ts` — 21/21 pass (was 20 before)
- [x] Full suite `bun test` — 7005 pass, 0 fail
- [x] Pre-commit hook: typecheck + lint + coverage all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)