### PR TITLE
chore(sites): update playwright.spec.ts comment — resolve() not normalize() (fixes #1769)

### DIFF
--- a/packages/daemon/src/site/browser/playwright.spec.ts
+++ b/packages/daemon/src/site/browser/playwright.spec.ts
@@ -160,8 +160,9 @@ describe("partitionSitesForRunningBrowser — #1594", () => {
   });
 
   test("trailing-slash profileDir is treated as matching the normalized running profile — #1671", () => {
-    // resolveProfileDir always runs normalize(), but guard against any string-format
-    // difference (trailing sep, doubled sep) sneaking through from external callers.
+    // resolveProfileDir resolves profile paths before comparing them, but guard
+    // against equivalent string-format differences (trailing sep, doubled sep)
+    // sneaking through from external callers.
     const profileWithSlash = `${profile}/`;
     const { toOpen, profileMismatch } = partitionSitesForRunningBrowser(profile, new Set<string>(), [
       spec("owa", { profileDir: profileWithSlash }),

--- a/packages/daemon/src/site/browser/playwright.spec.ts
+++ b/packages/daemon/src/site/browser/playwright.spec.ts
@@ -160,9 +160,9 @@ describe("partitionSitesForRunningBrowser — #1594", () => {
   });
 
   test("trailing-slash profileDir is treated as matching the normalized running profile — #1671", () => {
-    // resolveProfileDir resolves profile paths before comparing them, but guard
-    // against equivalent string-format differences (trailing sep, doubled sep)
-    // sneaking through from external callers.
+    // partitionSitesForRunningBrowser calls path.resolve() on both s.profileDir
+    // and runningProfile before comparing, so equivalent paths that differ only
+    // in string format (trailing sep, doubled sep) must still match.
     const profileWithSlash = `${profile}/`;
     const { toOpen, profileMismatch } = partitionSitesForRunningBrowser(profile, new Set<string>(), [
       spec("owa", { profileDir: profileWithSlash }),


### PR DESCRIPTION
## Summary
- Corrects inaccurate comment in `playwright.spec.ts` line ~163 that said `normalize()` when the implementation uses `path.resolve()`
- Discovered during QA of #1671 (Copilot review on PR #1764)

## Test plan
- [ ] `bun typecheck` — passes
- [ ] `bun lint` — passes (comment-only change, no fixes needed)
- [ ] `bun test packages/daemon/src/site/browser/playwright.spec.ts` — 9 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)