### PR TITLE
test(sites): use mkdtempSync + afterEach cleanup in resolve-playwright tests (fixes #1647)

### DIFF
--- a/packages/daemon/src/site/browser/resolve-playwright.spec.ts
+++ b/packages/daemon/src/site/browser/resolve-playwright.spec.ts
@@ -1,5 +1,5 @@
-import { afterEach, describe, expect, test } from "bun:test";
-import { existsSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -132,7 +132,15 @@ describe("resolvePlaywright", () => {
 });
 
 describe("_resolveBunBinary", () => {
-  const vendorDir = join(tmpdir(), "mcx-playwright-test-vendor");
+  let vendorDir: string;
+
+  beforeEach(() => {
+    vendorDir = mkdtempSync(join(tmpdir(), "mcx-playwright-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(vendorDir, { recursive: true, force: true });
+  });
 
   test("finds bun on PATH in test environment", () => {
     // bun is executing these tests, so Bun.which must resolve it
@@ -188,7 +196,15 @@ describe("_resolveBunBinary", () => {
 });
 
 describe("_defaultInstall", () => {
-  const vendorDir = join(tmpdir(), "mcx-playwright-test-vendor");
+  let vendorDir: string;
+
+  beforeEach(() => {
+    vendorDir = mkdtempSync(join(tmpdir(), "mcx-playwright-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(vendorDir, { recursive: true, force: true });
+  });
 
   test("wraps spawn ENOENT with Install manually message and preserves cause", async () => {
     // Use a path that cannot be a valid executable so Bun.spawn throws ENOENT.


### PR DESCRIPTION
## Summary
- Replace hardcoded `join(tmpdir(), "mcx-playwright-test-vendor")` with `mkdtempSync(join(tmpdir(), "mcx-playwright-test-"))` in `_resolveBunBinary` and `_defaultInstall` describe blocks — each test run gets a unique isolated dir, preventing collisions across parallel or repeated runs
- Add `afterEach(() => rmSync(vendorDir, { recursive: true, force: true }))` in both blocks — `_defaultInstall` creates a directory and `package.json` on disk; this cleans them up

## Test plan
- [ ] `bun test packages/daemon/src/site/browser/resolve-playwright.spec.ts` — 15 pass, 0 fail
- [ ] `bun typecheck` — clean
- [ ] `bun lint` — no fixes applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)