### PR TITLE
chore(meta): #2009 — investigations.md (canonical nerd-snipe gate reference)

### DIFF
--- a/.claude/diary/20260504.52.md
+++ b/.claude/diary/20260504.52.md
@@ -22,14 +22,41 @@
 **Flake nerd-snipe gate (#1980, #1987):**
 - Both flakies recurred 4 days after sprint 51 closed their predecessors
   (#1934, #1902). Per `feedback_flaky_tests.md`, spawned nerd-snipe (opus)
-  before impl. **Both stalled at the 600s watchdog** before reaching a
-  verdict — partial transcripts showed real analysis (cachedChildPid
-  lifecycle, getProcessStartTime non-determinism, DI patterns) but no
-  concrete root cause + fix.
-- Routed both to **needs-attention** with stall-summary comments documenting
-  the partial findings, the suspected mechanisms, and a bisect plan for
-  next sprint. **Did NOT spawn impl on opus to "hope"** — that's the
-  failure mode this rule exists to prevent.
+  before impl. Both routed to **needs-attention** with stall-summary
+  comments and a bisect plan, on the assumption that the 600s watchdog
+  killed them mid-investigation.
+
+  **POSTHOC CORRECTION (2026-05-04 plan-time of sprint 53):**
+  the framing above is wrong. The orchestrator invoked the **Agent tool**
+  (`Agent({subagent_type: "nerd-snipe", run_in_background: true})`),
+  not `mcx claude spawn`. Sub-agent transcripts show:
+  - #1980 sub-agent ran 28 minutes (04:15:59 → 04:44:16Z), last
+    `tool_use` at 04:28 (~12 min in), still actively reasoning
+    ("OK, let me think about this completely differently. What if
+    `client.close()` inside disconnect throws/rejects…").
+  - #1987 sub-agent identical shape, ended at exactly 04:44:16.138Z —
+    synchronized parent-side cutoff, not independent timeout.
+  - Orchestrator posted "stalled at ~10 min" comments at 06:16:15Z,
+    ~92 minutes after the actual cutoff.
+
+  Real mechanism: **Agent-tool background calls give the parent no
+  progress visibility into the sub-context.** Parent polled, saw no
+  output (because the sub-context is a separate JSONL under
+  `subagents/`, not streamed back), decided "stalled," posted
+  needs-attention. The watchdog framing was the parent's misread.
+  Sub-agents were probably 1–2 turns away from a verdict when killed.
+
+  **The fix is not a longer watchdog** (#2009 originally framed it
+  that way; corrected to "use mcx claude spawn instead of Agent
+  tool"). mcx-spawned workers stream tool_use events natively;
+  progress is observable. The Agent tool is the wrong shape for any
+  long-running task where the parent needs to track progress.
+
+- Did NOT spawn impl on opus to "hope" — that part of the rule was
+  honored regardless. The trail comments still capture genuine
+  partial findings (cachedChildPid lifecycle, getProcessStartTime
+  non-determinism, DI patterns) and a bisect plan; sprint 53 picks
+  up from there with a corrected spawn shape.
 
 **Sprint-51 follow-ups:**
 - #1973 / #1995 — null-guard for `extraUsage.utilization` (mcx status no
@@ -96,13 +123,15 @@
   warning blends into other output); only the orchestrator's post-push
   status check caught it. **Fix**: identify the build step that touches
   `npm/*/bin/` and either skip `.gitkeep` from cleanup or recreate after.
-- **nerd-snipe 600s watchdog killed both flake investigations
-  before completion.** The agents were producing real analysis but the
-  watchdog measures "no progress" by stream cadence; deep code-reading
-  bursts of thinking trigger it. **Action**: file separate issue for
-  watchdog-budget tunability or progressive-posting requirement; for
-  next sprint's nerd-snipes, add explicit "post incremental findings
-  every N turns even if intermediate" to the prompt.
+- **Used the Agent tool for nerd-snipe instead of `mcx claude spawn`.**
+  Sub-agent transcripts (`subagents/agent-*.jsonl`) show 28 minutes of
+  active reasoning, killed by a synchronized parent-side cutoff while
+  still 1–2 turns from verdict. The orchestrator had no progress
+  visibility because Agent-tool background calls don't stream tool_use
+  events back to the parent. **Action filed as #2009** (corrected to
+  "use `mcx claude spawn` for nerd-snipe; pass persona inline" — NOT
+  watchdog tunability, which would just kick the can down the road).
+  `feedback_flaky_tests.md` updated to specify the correct spawn shape.
 - **Phase regex bug (#2007) blocked review→qa transition twice.**
   `scanReviewComments` greps `/🔴|🟡/` over the entire sticky comment;
   delta tables show prior-issue emojis as historical entries, the regex

--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -16,7 +16,7 @@
 - [ScheduleWakeup is blind polling](feedback_schedulewakeup_orchestration.md) — during sprint orchestration use `mcx claude wait`, not ScheduleWakeup
 - [Background-task notifications work](feedback_background_task_notify.md) — workers "waiting for notification" is correct; ask duration, don't prescribe polling
 - [Don't bye spikes](feedback_dont_bye_spikes.md) — keep exploratory sessions alive for follow-up questions
-- [Flaky test handling](feedback_flaky_tests.md) — nerd-snipe BEFORE impl, trail on issue; no root cause + plan = needs-attention, not "spawn opus and hope"
+- [Flaky test handling](feedback_flaky_tests.md) — stub pointer; canonical rule lives in repo at `.claude/skills/sprint/references/investigations.md` (load-bearing — `mcx claude spawn`, NOT Agent tool, see #2009)
 - [Orchestrator context rot](feedback_context_rot.md) — long-running orchestrators degrade at ~300k tokens; verify "done" claims with a probe
 - [Bulk reads + serialized cascades](feedback_sprint_bulk_and_cascade.md) — no `for` loops for status (use bulk jq), single-pointer update-branch cascades (avoid N² CI)
 - [No gpgsign bypass](feedback_no_gpgsign_bypass.md) — never add `-c commit.gpgsign=false` or similar without explicit ask; only legit orchestrator flag is `SPRINT_OVERRIDE=1`
@@ -32,7 +32,7 @@
 - **Meta files (`.claude/skills/**`, `.claude/memory/**`, `CLAUDE.md`, `.gitignore`) are orchestrator + retro only.** Never spawn a worker to modify them during a sprint. Sprint 32 had two PRs touching `run.md` in parallel and the orchestrator read inconsistent versions for ~20 minutes. Meta changes go through the retro + next-plan workflow.
 - Never use `git worktree remove --force` — let the safety check catch uncommitted work.
 - `mcx claude ls` and `wait` filter by current repo; use `--all` for cross-repo view.
-- Recurring: `core.bare=true` flips mid-operation (#1206/#1243/#1330) — hot-patch with `git config core.bare false` before git ops until sticky fix lands.
+- `core.bare` arc closed in sprint 52 / #1860 / PR #1998 — `ensureCoreBareUnset()` removes the key entirely; daemon sweep deletes both true/false. Pre-flight invariant: `git config --local core.bare` should exit non-zero (key absent). The `git config core.bare false` hot-patch is no longer needed.
 
 ## Skills
 - `/sprint` — lifecycle: plan, run, review, retro. Detailed rules in `.claude/skills/sprint/references/*.md`.

--- a/.claude/memory/feedback_flaky_tests.md
+++ b/.claude/memory/feedback_flaky_tests.md
@@ -1,44 +1,27 @@
 ---
-name: flaky test fix policy
-description: Flaky/CI-instability issues require a nerd-snipe root-cause investigation BEFORE implementation; opus impl + adversarial review only after the trail is documented on the issue
+name: flaky test fix policy (pointer to canonical reference)
+description: Flaky / CI-instability / recurring issues need a nerd-snipe investigation BEFORE impl. Canonical rule lives in repo at .claude/skills/sprint/references/investigations.md (load-bearing); this memory is a stub pointer.
 type: feedback
+originSessionId: 484a037b-9f1e-468c-aa12-32fd92da0c26
 ---
+The full rule (when to apply, spawn shape, hard gate, post-gate flow)
+lives in the **repo**, not in user memory:
 
-Flaky test (and CI-instability) issues require a nerd-snipe planning pass
-**before** implementation, then opus implementation + adversarial review.
+→ `.claude/skills/sprint/references/investigations.md`
 
-**Why:** Sprint 15-19 saw "fix → re-break" cycles where flaky tests were
-patched with longer timeouts or retry loops that papered over the race.
-Sprint 47 repeated the pattern at a higher altitude: a deterministic
-post-#1835 coverage crash was misdiagnosed as a Bun upstream segfault
-(filed under #1004) and the response was a CI retry workaround — which the
-same retro acknowledged "hits on every sprint PR." The actual root cause
-was a `claude --version` probe added by #1835 that the test mock didn't
-handle, plus `process.exit()` truncating a 500 KB stderr write at the
-kernel pipe buffer (#1870, found 2026-04-29 by nerd-snipe). Skipping the
-root-cause step was what made both eras of failures recur.
+Why this is a stub: load-bearing sprint rules need to be in the repo so
+every Claude session working on this project sees the same rule. User
+memory is per-user and not committed.
 
-**How to apply:** When the sprint plan has a flaky / CI-instability issue
-(title contains "flaky", label `flaky`, or symptom is "CI fails
-intermittently / deterministically without a clear test-code error"):
+Quick summary for context:
 
-1. **Pre-implementation gate — nerd-snipe first.** Spawn the
-   `nerd-snipe` agent on opus with the repro, the suspected commit
-   range, and any prior bad diagnoses. Its job is to identify the actual
-   root cause and a concrete fix plan.
-2. **Trail goes on the issue.** nerd-snipe must post its findings as a
-   comment on the GitHub issue (timeline, bisect log, mechanism, the fix
-   plan). The trail being on the issue — not in an ephemeral session
-   transcript — is what stops the next sprint from re-running the same
-   misdiagnosis.
-3. **Hard gate.** If nerd-snipe cannot find both root cause AND a
-   concrete solution, the issue does NOT proceed to implementation. Add
-   the `needs-attention` label and stop. The orchestrator surfaces it
-   for manual review at next sprint review. Do not let an unresolved
-   investigation slide into "spawn opus impl and hope."
-4. **Then implement on opus** (never sonnet) using the fix plan from
-   the issue comment as the spec.
-5. **Always adversarial review.** Reviewer verifies the implementation
-   matches the documented root cause — not just "tests pass now."
-   Reject fixes that increase timeouts, add retries, or otherwise mask
-   the symptom without addressing the mechanism in nerd-snipe's writeup.
+- Flaky / recurring / unclear-mechanism issues require a nerd-snipe pass
+  BEFORE phase=impl (sprint 47 / #1870 incident motivated the rule).
+- **Spawn via `mcx claude spawn`** with persona inlined in the prompt.
+  Do NOT use `Agent({subagent_type: "nerd-snipe"})` — that creates a
+  sub-context the orchestrator can't see (sprint 52 / #1980 / #1987
+  incident, tracked as #2009).
+- Worker posts findings as a GitHub issue comment (timeline + bisect +
+  mechanism + concrete fix plan).
+- Hard gate: no root cause + fix → `needs-attention`, never spawn impl
+  on hope.

--- a/.claude/skills/sprint/SKILL.md
+++ b/.claude/skills/sprint/SKILL.md
@@ -48,6 +48,7 @@ The sprint number threads through all phases:
 - `references/review.md` — release + changelog phase
 - `references/retro.md` — retrospective / diary phase
 - `references/introspection.md` — periodic code-first introspection (sprints ending in 7)
+- `references/investigations.md` — nerd-snipe gate before impl (flakies, recurring bugs, perf/security findings); load-bearing spawn shape (`mcx claude spawn`, NOT Agent tool — see #2009)
 
 **Per-phase logic is defined in `.mcx.yaml` + `.claude/phases/*.ts`**, not
 in `run.md`. Inspect a phase with `mcx phase show <name>` or preview its

--- a/.claude/skills/sprint/references/investigations.md
+++ b/.claude/skills/sprint/references/investigations.md
@@ -1,0 +1,152 @@
+# Investigations: nerd-snipe gate before impl
+
+Some issues need root-cause work BEFORE a fix can land. Flaky tests are
+the canonical case (sprint 15-19, 47, 50, 51, 52 all hit the "fix →
+re-break" pattern when implementations skipped root-cause), but the
+pattern generalizes to:
+
+- **Flaky tests / CI instability** (`label:flaky`, or a closed bug
+  re-opening with the same symptom)
+- **Deterministic failures with unclear mechanism** (the test fails
+  every run but no one knows why)
+- **Recurring bugs** that have already been "fixed" once and came back
+- **Perf regressions** without an obvious patch
+- **Security findings** where the wrong fix can mask the underlying
+  exposure
+
+The orchestrator's job for these is to gate implementation behind a
+documented investigation. This file is the canonical reference; both
+`plan.md` (when classifying picks) and `run.md` (when spawning) point
+here.
+
+## When to apply
+
+Add the investigation gate when ANY of these is true for the issue:
+
+- Title or label contains "flaky" or `flaky`
+- Issue body cites a CI failure that the reporter cannot reproduce locally
+- A previous closure for the same root symptom exists (grep
+  `gh issue list --state closed --search "<test-name>"`)
+- The repro is non-deterministic, environment-sensitive, or
+  intermittent
+- The reporter explicitly asks for an investigation before a fix
+
+If none of these are true, run the issue through the normal impl phase.
+The gate is for issues where the wrong fix is worse than no fix.
+
+## The gate
+
+1. **Spawn a nerd-snipe worker** (see "Spawn shape" below).
+2. **Worker posts findings as a GitHub issue comment.** Timeline,
+   bisect log, mechanism, concrete fix plan. The trail being on the
+   issue — not in an ephemeral session transcript — is what stops the
+   next sprint from re-running the same misdiagnosis.
+3. **Hard gate**: if the worker cannot produce both root cause AND a
+   concrete fix plan, the issue does NOT proceed to implementation.
+   Apply `needs-attention` and stop. Surface in retro. **Do not let an
+   unresolved investigation slide into "spawn opus impl and hope"** —
+   that is the failure mode this rule prevents (sprint 47 / #1870
+   incident).
+4. **Then implement on opus** (never sonnet) using the issue comment
+   as the spec.
+5. **Always adversarial review** for the impl PR. The reviewer's job
+   is to verify the implementation matches the documented mechanism —
+   not just that "tests pass now." Reject fixes that increase
+   timeouts, add retries, or otherwise mask the symptom without
+   addressing the mechanism in the writeup.
+
+## Spawn shape (load-bearing — see #2009)
+
+**Use `mcx claude spawn`, NOT the Agent tool / `subagent_type: "nerd-snipe"`.**
+
+```bash
+mcx claude spawn --worktree --model opus -t "$(cat <<'PROMPT'
+You are nerd-snipe (read .claude/agents/nerd-snipe.md directly first to
+ground in the persona — do NOT invoke the Agent tool yourself).
+
+Your job is to investigate GitHub issue #<n>: <one-line repro>.
+
+Existing context:
+- Bisect range: <commit-range>
+- Prior diagnoses (must rule out or confirm): <links>
+- Existing needs-attention trail (if any): <link>
+
+Verify or reject each suspected mechanism in order. Post findings as a
+GitHub issue comment with:
+  - Timeline of what was investigated
+  - Bisect log
+  - Confirmed mechanism (or "no root cause found, here is what was
+    ruled out")
+  - Concrete fix plan (or "no concrete fix yet — recommend
+    needs-attention")
+
+If you cannot produce both root cause AND a concrete fix plan, post
+the partial trail and stop. Do not propose a speculative patch.
+PROMPT
+)"
+```
+
+**Why `mcx claude spawn` and not the Agent tool**: the Agent tool
+spawns a sub-context inside the orchestrator's session. Background
+Agent calls give the parent **no progress visibility** — sub-agent
+tool_use events go to a separate JSONL under `subagents/`, not
+streamed back. Sprint 52 routed both #1980 and #1987 to
+`needs-attention` with "watchdog killed at ~10 min" comments;
+investigation in #2009 showed the sub-agents had actually run for 28
+minutes of active reasoning and were 1–2 turns from a verdict when
+the orchestrator's poll-and-give-up cut them off.
+
+mcx-spawned workers stream tool_use events natively. `mcx claude wait
+<session>` and `mcx claude log <session>` give genuine progress
+signal. Nerd-snipe can run for an hour; that is fine. The "session
+looks idle" framing was an Agent-tool artifact.
+
+The "do NOT invoke the Agent tool yourself" line in the prompt is
+critical. Without it, nerd-snipe will helpfully
+`Agent({subagent_type: "nerd-snipe"})` recursively and re-create the
+same sub-context invisibility.
+
+## Tracking the worker
+
+Once spawned:
+
+```bash
+# wait for it to finish (event-driven, not blind polling)
+mcx claude wait <session-id>
+
+# read the final transcript
+mcx claude log <session-id> --tail 200
+
+# or stream events live
+mcx monitor --src <session-id> --json --type session.text
+```
+
+The orchestrator reads the issue comment after the worker exits.
+Trust the comment, not the session transcript — the comment is the
+durable record.
+
+## After the gate
+
+| Outcome | Action |
+|---------|--------|
+| Root cause + fix plan in comment | `phase=impl` on opus |
+| Partial findings, no concrete fix | apply `needs-attention`, surface in retro |
+| Already-fixed by a prior PR | close issue with a link |
+| Repro reveals a different bug | file new issue, close original as duplicate-of-new |
+
+## Why this lives in references/, not in MEMORY
+
+User-level memory (`~/.claude/projects/.../memory/`) is per-user and
+not committed. Load-bearing sprint rules — the ones the orchestrator
+needs every time — must live in the repo so every Claude session
+working on this project sees the same rule. Memory entries can
+re-state or summarize repo-level rules but cannot be the source of
+truth for them.
+
+## See also
+
+- `plan.md` — apply the gate at issue classification time
+- `run.md` — invoke the gate when impl phase fires for a flagged issue
+- `references/mcx-claude.md` — `mcx claude spawn` / `wait` / `log` details
+- Issue #2009 — the spawn-shape decision
+- `.claude/diary/20260504.52.md` — the sprint-52 incident that drove the correction

--- a/.claude/skills/sprint/references/plan.md
+++ b/.claude/skills/sprint/references/plan.md
@@ -216,6 +216,15 @@ Rules:
    definitions across concurrent sessions (observed in sprint 32 when `/qa`
    and a docs PR both edited `run.md`). If an issue is pure meta, defer it
    to retro or a user-led cleanup pass.
+6. **Flaky / recurring / unclear-mechanism issues need a nerd-snipe gate
+   before impl** — see [`references/investigations.md`](investigations.md).
+   The gate is mandatory and uses a specific spawn shape (`mcx claude
+   spawn` with persona inlined, NOT the Agent tool / `subagent_type` —
+   see #2009 for the sprint-52 incident that locked this in). Mark such
+   issues `high` scrutiny in the plan table even if the eventual fix is
+   small; the gate's hard-fail outcome is `needs-attention`, which the
+   planner needs to be willing to accept (sprint 52 paid 2 slots for
+   this on #1980 and #1987).
 
 Split picks into:
 - **Goal issues** (10-12): aligned with the sprint thesis

--- a/.claude/skills/sprint/references/run.md
+++ b/.claude/skills/sprint/references/run.md
@@ -431,34 +431,33 @@ loop; until it lands, the orchestrator owns it.
 ### Flaky / CI-instability issues — nerd-snipe gate before impl
 
 `label:flaky` already routes to opus via `impl.ts:45`. That is **not
-enough** — sprint 47's deterministic post-#1835 coverage crash got opus,
-opus produced a CI-retry workaround, and the same retro acknowledged the
-workaround "hits on every sprint PR." The pattern: opus implements a
-fix-shaped patch around the symptom because nobody made it find the
-root cause first.
+enough** on its own — sprint 47's deterministic post-#1835 coverage
+crash got opus, opus produced a CI-retry workaround, and the same retro
+acknowledged the workaround "hits on every sprint PR." The pattern:
+opus implements a fix-shaped patch around the symptom because nobody
+made it find the root cause first.
 
-For any issue that is `label:flaky`, or whose body describes
-intermittent / deterministic CI failure without a clear test-code error,
-gate impl on a nerd-snipe pass:
+**The full rule (load-bearing) is in
+[`references/investigations.md`](investigations.md).** Read it before
+spawning anything for a flaky / recurring / intermittent issue. The
+short version:
 
-1. **Spawn `nerd-snipe` (opus) before phase=impl.** Brief: the repro,
-   the suspected commit range, prior diagnoses (especially any that
-   blamed upstream), and the constraint that the trail must land on the
-   issue.
-2. **Trail goes on the GitHub issue, not in the session.** nerd-snipe
-   posts its findings — timeline, bisect log, mechanism, fix plan — as
-   an issue comment. This is the mechanism that stops the next sprint
-   from re-running the same misdiagnosis.
-3. **Hard gate.** If nerd-snipe cannot identify *both* the root cause
-   and a concrete fix, do NOT advance the issue to phase=impl. Apply
-   `needs-attention` and surface in sprint review. "Spawn opus and hope"
-   is what got us into the loop.
-4. **Then phase=impl on opus**, with the issue-comment fix plan as the
-   spec. Adversarial review verifies the implementation matches the
-   documented mechanism, not just "tests pass now."
+1. Spawn the nerd-snipe via **`mcx claude spawn` with the persona
+   inlined** in the prompt (NOT `Agent({subagent_type: "nerd-snipe"})` —
+   that creates a sub-context the orchestrator can't observe; sprint 52
+   was bitten by exactly this on #1980 and #1987, see #2009).
+2. Worker posts findings as a GitHub issue comment (timeline + bisect +
+   mechanism + concrete fix plan).
+3. **Hard gate** — no root cause + concrete fix → `needs-attention`,
+   never spawn impl-on-hope.
+4. Then `phase=impl` on opus with the issue comment as the spec, plus
+   adversarial review verifying the impl matches the documented
+   mechanism (not just "tests pass now").
 
-See `.claude/memory/feedback_flaky_tests.md` for the rule and the
-sprint-47/#1870 incident that motivated it.
+The same gate applies to any non-flaky issue whose body describes a
+recurring symptom, an unclear failure mechanism, or a perf/security
+finding where the wrong fix masks the underlying exposure. See
+`investigations.md` for "when to apply" and the full spawn template.
 
 ### qa:pass + qa:fail dual-label invariant (orchestrator audit)
 


### PR DESCRIPTION
Promotes the nerd-snipe-before-impl gate to a canonical, load-bearing repo reference. Closes #2009.

## Why

Sprint-52 routed #1980 and #1987 to `needs-attention` with comments saying nerd-snipe "stalled at ~10 min before the watchdog killed it." Sprint-53 plan-time investigation showed that framing was wrong — the orchestrator had used the **Agent tool** (`subagent_type: "nerd-snipe"`, `run_in_background: true`), not `mcx claude spawn`. Sub-agent transcripts under `~/.claude/projects/.../subagents/agent-*.jsonl` show:

- 28 minutes of active reasoning (last `tool_use` at ~12 min, still emitting text at ~28 min)
- Synchronized parent-side cutoff (both sub-agents ended at exactly 04:44:16Z)
- Orchestrator posted "stalled at 10 min" comments at 06:16Z, ~92 minutes after the actual cutoff

Background Agent-tool calls give the parent no progress visibility — sub-agent tool_use events go to a separate JSONL, not streamed back. mcx-spawned workers stream natively.

## Changes

- **New:** `.claude/skills/sprint/references/investigations.md` — canonical reference for the nerd-snipe gate. Generalizes beyond flakies to any "needs root-cause first" issue (recurring bugs, perf regressions, unclear mechanisms, security findings). Specifies the spawn shape and "do NOT invoke the Agent tool yourself" prompt requirement.
- `plan.md` Rule 6 — flaky/recurring/unclear issues need the gate; mark `high` scrutiny even if the eventual fix is small.
- `run.md` — trimmed Flaky section, re-points at `investigations.md` as the load-bearing source.
- `SKILL.md` — references list updated.
- `.claude/memory/feedback_flaky_tests.md` — slimmed to a stub pointer. Load-bearing sprint rules belong in the repo, not in per-user memory.
- `MEMORY.md` index reflects the stub.
- `.claude/diary/20260504.52.md` — posthoc-correction block added so future retro-mining doesn't propagate the wrong "watchdog" framing.

## Why a meta PR (not a sprint pick)

`.claude/skills/**`, `.claude/memory/**`, `CLAUDE.md` are read live by the orchestrator every tick. Per `plan.md` Step 1a, meta changes land between sprints via a `meta/<descriptor>` branch. This needs to be in main before sprint 53's run kicks off so the corrected gate is what runs for #1980 and #1987.

🤖 Generated with [Claude Code](https://claude.com/claude-code)