### PR TITLE
sprint(53): clear sprint-52 carry-over, tighten orchestrator hygiene, back-fill test gaps

### DIFF
--- a/.claude/diary/20260517.53.md
+++ b/.claude/diary/20260517.53.md
@@ -1,0 +1,195 @@
+# 2026-05-17 — Flake gate held, mechanism caught at QA, user PR mid-flight (Sprint 53)
+
+## What was done
+
+12 PRs merged + 1 already-done detected at run-time, v1.8.7 released.
+Wall-clock: 72 minutes (18:22 → 19:34 EST).
+
+**Sprint-52 carry-over (flakes):**
+- `isOurProcess` tri-state + EPERM-safe liveness checks (#1980 → PR #2038) —
+  opus nerd-snipe identified `getProcessStartTime` returning null on `ps`
+  failure as one bug, opus impl shipped it, QA caught the bigger issue (PID
+  recycling between precondition check and closeAll → test asserts on bare
+  PID identity, not original-process identity), opus repair added the
+  identity-based assertion + EPERM-safe `isProcessAlive` helper.
+- Same identity-based assertion applied to the sibling disconnect test
+  (#1987 → PR #2041) — straight-shot fix once #1980 fix was on main.
+
+**Sprint-52 carry-over (DX):**
+- `prepare-npm.ts` now restores `.gitkeep` post-build instead of unlinking
+  it (#1996 → PR #2031) — Copilot caught that the initial `.npmignore`
+  approach didn't work because `files: ["bin/"]` in each platform
+  `package.json` overrides `.npmignore`; repair removed the dead
+  `.npmignore` files.
+- `ensureCoreBareUnset` returns a discriminated union (`removed | absent |
+  fallback`) instead of `boolean` (#2003 → PR #2029) — 9 call sites updated.
+
+**Orchestrator hygiene:**
+- `mcx phase advance --work-item` subcommand (#1944 → PR #2035) — only
+  "feature" pick of the sprint; sonnet impl + sonnet review found 2
+  blockers + 7 should-fixes, reviewer self-repaired all 9, then QA caught
+  one remaining unguarded `slice()` cast (Copilot thread); sonnet round-2
+  repair landed runtime type guards across 5 destinations.
+
+**Sites bugs:**
+- `wiggle()` passes `siteName` not raw `site` to `withPage` (#1661 → PR #2027)
+- Proxy 401 retry excludes the failed bearer (#1599 → PR #2032)
+
+**Permissions parity:**
+- Bare `mcp__server` server-wide wildcard rule (#1703 → PR #2028) —
+  Copilot caught `isBareMcpServerPattern("mcp__*")` collision with global
+  `__*` wildcard; opus repair added `!rest.includes("*")` guard.
+
+**Test back-fills:**
+- `alias-bundle` timeout path (#1754 → PR #2026)
+- `cmdMonitor --timeout` integration test (#1565 → PR #2030)
+- `GET /events?since=` backfill+live+cleanup integration test (#1572 → PR
+  #2033)
+- Ring-buffer fallback `responseTail` gate coverage (#1759 → PR #2039)
+
+**Also closed (already-done detected at run-time):**
+- #1645 — sonnet impl session opened the issue, ran a code search, and
+  found PR #1641's secondary squash commit (2026-04-23, `07cad5d`) had
+  already added `_resolveBunBinary` with the ordered probe. Closed the
+  issue itself, opened up the #1661 serialization slot.
+
+**Excluded (caught at run start, plan-time triage missed):**
+- #1948 (PR #1976), #1933 (PR #1989) — both merged 2026-05-04 ~02:30 UTC,
+  about 12h before the sprint plan was finalized at 10:25 EDT (14:25 UTC).
+  The plan-time triage Step matched titles against open issues but didn't
+  re-check state at sprint start. Documented in the plan's `## Excluded`
+  amendment.
+
+**Carry-over:**
+- PR #2037 (`scripts: am-i-done step runner + doing-it-wrong rule engine`,
+  user-pushed mid-sprint) stayed with the user. QA round 1 caught 5 biome
+  violations + 4 unreplied Copilot threads; user took over for the
+  biome fix. QA round 2 still showed 4 unreplied threads on design
+  questions about the am-i-done semantics — left with user.
+
+## What worked well
+
+- **Event-driven orchestration via `Monitor`** — the persistent
+  `mcx monitor --subscribe session,work_item` stream + grep filter for
+  load-bearing events worked smoothly across ~30 sessions over 72 min.
+  Zero polling, zero stale state. Cache stayed warm the whole sprint.
+- **Reviewer self-repair pattern (run.md)** — d9177cfa flagged 2 blockers
+  + 7 should-fixes on #1944, then `send` brought it back to fix its own
+  diagnosis. All 9 landed in commit `9d5491d`, sticky moved ⚠️ → ✅. Saved
+  one fresh opus repair spawn.
+- **Nerd-snipe `mcx claude spawn` shape (not Agent tool)** — c636d03a ran
+  for ~5 min producing a substantive findings comment on #1980 with
+  timeline + mechanism + concrete 5-line fix. The `do NOT invoke the Agent
+  tool yourself` line in the prompt prevented the sub-context invisibility
+  pattern from sprint 52.
+- **Triage scrutiny routing** — every low-scrutiny (sonnet impl, test-only
+  or contained fix) routed `goto qa`, every high-scrutiny (#1944 was the
+  only high) routed `goto review`. Routing matched outcome quality.
+- **`bundle.spec.ts`-style identity-test pattern** — #1980's fix pattern
+  (capture start time at setup, assert on identity post-action) transferred
+  cleanly to #1987. The "match the mechanism" rule from `run.md` paid out:
+  same root cause, parallel fix, no second nerd-snipe needed.
+
+## What didn't work
+
+- **My cwd-persistence mental model broke and I direct-committed the plan
+  file to main.** Early in pre-flight I `cd`'d into the sprint-53 worktree;
+  the `cd` did persist for a while, but a later compound `cd ... && ...`
+  command silently reset cwd back to main checkout. Subsequent `git add`
+  + `git commit` ran from main checkout with `SPRINT_OVERRIDE=1` and
+  pushed the plan file to main as `2e3a7cc`. The commit's message claimed
+  to add an "Excluded" section that the file content didn't include — a
+  misleading historical commit. At review-time merge of `origin/main` into
+  `sprint-53`, this produced an add/add conflict on `.claude/sprints/sprint-53.md`
+  that I had to resolve manually. **Fix:** verify `pwd` before every
+  compound shell command that includes `git commit`; never rely on
+  `cd`-persistence across Bash tool invocations as a primary mechanism.
+  File-an-issue follow-up: the `SPRINT_OVERRIDE=1` flag should be scoped
+  to commits made *within* the sprint worktree, not globally.
+
+- **`mcx claude ls --all --short` hangs on empty result set** (filed #2025).
+  Run.md Pre-flight Step 2 calls this command verbatim. The user noticed
+  before I did. JSON variant and per-repo variant both work; only the
+  non-JSON `--all --short` path hangs. Probably a `.join()` on a 0-length
+  array in the text formatter, but I didn't dig. P1 because it silently
+  hangs sprint orchestration.
+
+- **Plan-time triage missed two already-done picks** (#1948, #1933) —
+  both merged ~12h before plan finalization. Plus #1645 detected only
+  at run-time by the worker itself. **Fix:** plan.md Step's "verify still
+  open" check needs to also verify `closedAt` is null at *sprint start*
+  not at plan time. (Actually for #1948/#1933, the plan author would have
+  done the right thing if they'd re-run their check just-in-time at start.
+  This is a discipline rule, not a tooling fix — see Stats.)
+
+- **Nerd-snipe diagnosis on #1980 was partially correct but missed the
+  test-level issue.** It correctly identified one race (`isOurProcess`
+  returning null when `ps` fails, treated as "recycled"), and the fix for
+  that mechanism is sound. But the actual test failure on every CI run
+  was a *separate* race: the `sleep` precondition dies mid-test, its PID
+  gets recycled, and the bare-PID `isAlive` assertion sees the recycled
+  process as alive. The nerd-snipe never ran the failing test locally to
+  reproduce — it bisected from CI logs. **Lesson for nerd-snipe prompt:**
+  add "reproduce locally before claiming a fix" to the spawn template in
+  `investigations.md`. The QA session 76183806 ran the test under load
+  and caught the actual mechanism; without QA we would have shipped an
+  incomplete fix.
+
+- **Every PR before #2038 hit the #940 flake at least once.** The flake
+  was the dominant sprint bottleneck — ~15 of the ~20 CI runs failed on
+  this exact test. Reruns mostly cleared it (the flake is ~30-50%), but
+  added wall-clock and required manual `gh run rerun`. The whole point of
+  the sprint was to *fix* this flake, but we couldn't escape it during
+  the sprint itself. **Mitigation that worked:** flip `qa:fail` → `qa:pass`
+  on the second clean CI run when the QA session explicitly diagnoses the
+  failure as the known flake. Hand-applied this pattern for #1572 and
+  #1661.
+
+- **One worker tried to invoke `Edit`/`Write` despite being told it was
+  a nerd-snipe (no impl tools).** c636d03a kept asking for Edit
+  permission, then Write. I had to `deny` + `send` a forceful "your role
+  is investigation only" message before it complied. The nerd-snipe spawn
+  template should explicitly enumerate forbidden tools, not rely on
+  `--allow` enumeration. (Filed as observation; not a follow-up issue
+  since the deny path eventually worked.)
+
+- **`mcx claude bye` partial parse failure** — my early loop used
+  `tail -1` on bye output, which is a JSON object spanning multiple
+  lines, so the trailing `}` was all I saw, masking the actual `ended: true`
+  response. Cosmetic, not load-bearing; fixed mid-sprint by using
+  `jq -r '"ended=\(.ended)..."'`.
+
+## Patterns established
+
+- **Identity-based liveness in tests** — replaces bare `isAlive(pid)`
+  assertions when the test kills a child process. Capture
+  `getProcessStartTime(pid)` at setup, then after the kill verify either
+  start-time mismatch (recycled) or `getProcessStartTime → null` (dead).
+  This is the pattern in `server-pool.spec.ts:1747` and `:1709` after
+  PR #2038 + PR #2041. Future test fixes for child-process kill races
+  should follow it.
+- **`pr.review_comment_posted` reactive triage** — Copilot inline comments
+  fire on `mcx monitor` as `pr.review_comment_posted` events. Per-event
+  cost to GET the comment body, classify (real bug / style / dismissable),
+  and either spawn repair or reply-dismiss is ~1 lookup. Worked well this
+  sprint for catching real bugs (.npmignore precedence on #1996, bare
+  wildcard handling on #1703) that the impl + QA both missed.
+
+## Stats
+
+- **PRs merged**: 12 + #2037 carry-over with user
+- **Issues closed**: 13 (12 sprint + #1645 already-done)
+- **Issues dropped**: 2 (#1948, #1933 — already merged in sprint-52
+  close, plan-time triage missed them)
+- **New issues filed**: 3 (#2025 ls-all-short hang, #2040 test coverage
+  gap on null paths, plus runtime followups inside repair commits)
+- **Repair rounds**: 4 (#1703, #1996, #1944 r1+r2, #1980)
+- **Reviewer self-repair rounds**: 1 (#1944 → 9 fixes in 1 commit)
+- **Adversarial reviews**: 1 (#1944, scrutiny=high)
+- **Flake-induced CI reruns**: ~6 manual `gh run rerun` calls before
+  #2038 merged
+- **Wall-clock**: 72 min start → last merge
+- **Sprint cost** (rough, summing observed session.result events):
+  ~$40-45 across ~30 sessions
+- **Quota peak**: 31% of 5-hour window
+- **Concurrent sessions max**: 10 (Batch 1 + Batch 2/3 unblocked spawns)

--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -26,6 +26,7 @@
 - [Don't touch parallel #1808 worktrees](feedback_parallel_p1_session.md) — user runs #1808 in a direct claude session; never blanket-prune; don't bye sessions you didn't spawn
 - [Verify auto-merge actually fired](feedback_verify_merge_actually_fired.md) — after qa:pass + `gh pr merge --auto`, poll until state=MERGED; QA verdict + auto-merge queue ≠ proof of merge
 - [Repair → QA transition](feedback_phase_repair_to_qa.md) — after repair pushes, advance via `phase=qa` write, NOT by re-ticking `mcx phase run repair`; the latter spawns a new repair round
+- [Worktree hooksPath inheritance](feedback_worktree_hookspath_inheritance.md) — mcp-cli base repo's local core.hooksPath is absolute; worktrees inherit it and pre-commit silently no-ops. Set `git config core.hooksPath .git-hooks` after creating any new worktree.
 
 ## Orchestration (non-sprint, general facts)
 - Orchestrator must never implement directly — always delegate to spawned sessions.

--- a/.claude/memory/feedback_worktree_hookspath_inheritance.md
+++ b/.claude/memory/feedback_worktree_hookspath_inheritance.md
@@ -1,0 +1,16 @@
+---
+name: worktree-hookspath-inheritance
+description: "mcp-cli base repo's core.hooksPath is set to an absolute path pointing at .git/hooks (samples-only) — worktrees inherit this and their pre-commit doesn't run"
+metadata: 
+  node_type: memory
+  type: feedback
+  originSessionId: 2185dcf7-de50-45f7-b18b-f6da8d458a5a
+---
+
+mcp-cli's base repo `<repo-root>/.git/config` has `core.hooksPath = <repo-root>/.git/hooks` (the default samples-only directory). Worktrees created from it inherit that local config value, so their pre-commit hook never runs the checked-in `.git-hooks/pre-commit`. The `prepare` script (`bun install` → `git config core.hooksPath .git-hooks`) sets a relative path but the absolute path in the base wins.
+
+**Why:** Caught during PR #2037 — first commit's pre-commit silently did nothing because hooksPath pointed at the samples dir. CI then failed on biome lint that should have been caught locally.
+
+**How to apply:** When creating a new worktree on mcp-cli, immediately run `git config core.hooksPath .git-hooks` in the worktree before the first commit. Or fix the base repo's local config to use the relative path. Don't trust `bun install`'s prepare to fix it in worktrees.
+
+See also: [[feedback_no_gpgsign_bypass]] for other pre-commit-related correctness gotchas.

--- a/.claude/sprints/sprint-53.md
+++ b/.claude/sprints/sprint-53.md
@@ -1,6 +1,6 @@
 # Sprint 53
 
-> Planned 2026-05-04 10:25 EDT. Target: 15 PRs.
+> Planned 2026-05-04 10:25 EDT. Started 2026-05-17 18:22 EST. Target: 15 PRs.
 
 ## Goal
 

--- a/.claude/sprints/sprint-53.md
+++ b/.claude/sprints/sprint-53.md
@@ -1,6 +1,6 @@
 # Sprint 53
 
-> Planned 2026-05-04 10:25 EDT. Started 2026-05-17 18:22 EST. Target: 15 PRs.
+> Planned 2026-05-04 10:25 EDT. Started 2026-05-17 18:22 EST. Ended 2026-05-17 19:34 EST. Target: 15 PRs. Merged: 12 + 1 already-done.
 
 ## Goal
 

--- a/.claude/sprints/sprint-53.md
+++ b/.claude/sprints/sprint-53.md
@@ -224,3 +224,29 @@ call to retro.
 10. **Plan-time triage step**: every issue verified open + reproducible
     before slotting. Caught zero already-done this sprint, but the
     discipline matters more in long sprints.
+
+## Results
+
+- **Released**: v1.8.7 (patch — feature add `mcx phase advance` is a
+  subcommand, not new top-level)
+- **PRs merged**: 12 (#2026, #2027, #2028, #2029, #2030, #2031, #2032,
+  #2033, #2035, #2038, #2039, #2041)
+- **Issues closed**: 13 (12 fixed + #1645 already-done detected at
+  run-time)
+- **Issues dropped**: 2 (#1948, #1933 — both merged in sprint-52 close
+  ~12h before plan finalization; plan-time triage missed them)
+- **New issues filed**: 3+ (issue #2025 — `mcx claude ls --all --short`
+  hang, #2040 — test coverage gap for the #1980 null paths, plus
+  several Copilot follow-ups discovered during repair)
+- **Repair rounds**: 4 (round-1 each on #1703 — Copilot caught real
+  bug; #1996 — Copilot caught .npmignore precedence bug; #1944 —
+  reviewer self-repair (9 fixes) then sonnet round 2 for remaining
+  slice() guard; #1980 — QA caught wrong root cause from nerd-snipe,
+  opus added identity-based test assertion)
+- **Carry-over**: PR #2037 (user-pushed mid-sprint — am-i-done MVP)
+  remained with user at sprint close.
+- **Wall-clock**: 72 minutes start to last merge (18:22 → 19:34 EST)
+- **Flake-induced CI rounds**: Every single PR that landed before
+  #2038 (the #1980 fix) hit the `#940` flake at least once and
+  required a CI rerun. The flake was the dominant sprint bottleneck —
+  see Retro.

--- a/.claude/sprints/sprint-53.md
+++ b/.claude/sprints/sprint-53.md
@@ -39,6 +39,13 @@ and a deliberate cluster of test back-fills (#1759, #1754, #1565,
 15 work items. 2 high (opus), 3 medium (sonnet), 10 low (sonnet) — a
 deliberate skew toward small wins after sprint 52's opus-heavy profile.
 
+## Excluded (amended at run start)
+
+- **#1948** — already merged at sprint-52 close (PR #1976, 2026-05-04 02:19 UTC). Plan-time triage missed this because the merge landed ~12h before plan finalization. Removed from Batch 1.
+- **#1933** — already merged at sprint-52 close (PR #1989, 2026-05-04 02:55 UTC). Same root cause. Removed from Batch 2.
+
+Net: 13 work items (2 opus / 11 sonnet). 4 remaining in Batch 1: #1980, #1996, #2003, #1944.
+
 ## Batch Plan
 
 ### Batch 1 (immediate)

--- a/.claude/sprints/sprint-53.md
+++ b/.claude/sprints/sprint-53.md
@@ -1,0 +1,218 @@
+# Sprint 53
+
+> Planned 2026-05-04 10:25 EDT. Target: 15 PRs.
+
+## Goal
+
+**"Clear sprint-52 carry-over (#1996, #2003, #1980, #1987 with progressive-posting nerd-snipe), tighten orchestrator hygiene (#1944, #1933, #1948), and back-fill the test gaps the last two sprints filed."**
+
+Sprint 52 closed the 47-sprint `core.bare` epic and held the line on
+flake-gate discipline (both #1980 and #1987 routed to `needs-attention`
+when nerd-snipe stalled at the 600s watchdog). Sprint 53 picks them
+back up with a tightened nerd-snipe prompt — progressive-posting every
+N turns + bisect plan delivered first — so the watchdog can't claim
+agents that are making real progress. Plus the obvious carry-overs
+(#1996 .gitkeep deletions, #2003 ensureCoreBareUnset return ambiguity)
+and a deliberate cluster of test back-fills (#1759, #1754, #1565,
+#1572) that the last two sprints filed but didn't get to.
+
+## Issues
+
+| #    | Title                                                            | Scrutiny | Batch | Model  | Category                  |
+|------|------------------------------------------------------------------|----------|-------|--------|---------------------------|
+| 1980 | flaky: server-pool closeAll kills stdio child processes          | high     | 1     | opus   | sprint-52 carry-over (needs-attention; nerd-snipe-gated via `mcx claude spawn`, see #2009) |
+| 1987 | flaky: disconnect SIGTERM race (server-pool.spec.ts:1708)        | high     | 2     | opus   | sprint-52 carry-over (needs-attention; nerd-snipe-gated via `mcx claude spawn`, see #2009) |
+| 1996 | build: bun scripts/build.ts stages npm/*/bin/.gitkeep deletions  | low      | 1     | sonnet | sprint-52 carry-over (DX) |
+| 2003 | refactor(git): ensureCoreBareUnset return value ambiguity        | medium   | 1     | sonnet | sprint-52 carry-over (#1860 follow-up) |
+| 1944 | feat(phase): mcx phase advance --work-item                       | medium   | 1     | sonnet | orchestrator hygiene      |
+| 1933 | refactor(claude): cmdClaudeInternal status case bypasses DI      | low      | 2     | sonnet | orchestrator hygiene      |
+| 1948 | session.permission_request fires for auto-approved tools         | medium   | 1     | sonnet | orchestrator noise        |
+| 1645 | fix(sites): _defaultInstall uses execPath in compiled mode       | low      | 2     | sonnet | sites bug                 |
+| 1661 | fix(sites): wiggle() passes raw site param to withPage()         | low      | 3     | sonnet | sites bug                 |
+| 1599 | fix(sites): proxy 401-retry picks same stale credential          | low      | 3     | sonnet | sites bug                 |
+| 1703 | feat(permissions): bare `mcp__server` server-wide wildcard       | low      | 3     | sonnet | permissions parity        |
+| 1572 | test(monitor): GET /events?since= backfill integration test      | low      | 2     | sonnet | test back-fill            |
+| 1759 | test: backfill path coverage for ring-buffer fallback gate       | low      | 3     | sonnet | test back-fill            |
+| 1565 | test(monitor): cmdMonitor --timeout integration test             | low      | 2     | sonnet | test back-fill            |
+| 1754 | test(alias-bundle): timeout path coverage for evalBundledJs      | low      | 3     | sonnet | test back-fill            |
+
+15 work items. 2 high (opus), 3 medium (sonnet), 10 low (sonnet) — a
+deliberate skew toward small wins after sprint 52's opus-heavy profile.
+
+## Batch Plan
+
+### Batch 1 (immediate)
+#1980, #1996, #2003, #1944, #1948
+
+### Batch 2 (backfill)
+#1987, #1933, #1645, #1572, #1565
+
+### Batch 3 (backfill)
+#1759, #1754, #1599, #1661, #1703
+
+### Cross-issue dependencies (addBlockedBy edges)
+
+- #1987 blockedBy #1980 — both touch `packages/daemon/src/server-pool.{ts,spec.ts}`. Naturally serializes via the nerd-snipe gate; second PR rebases on the first's fix.
+- #1759 blockedBy #1572 — both touch `packages/daemon/src/ipc-server.spec.ts`. Land the bigger backfill integration test first; the ring-buffer fallback test rebases.
+- #1661 blockedBy #1645 — both touch `packages/daemon/src/site/browser/playwright.ts` (or adjacent install/wiggle helpers). Serialize.
+
+### Flake nerd-snipe gate (corrected spawn shape — see #2009)
+
+Both #1980 and #1987 are `label:flaky,needs-attention` with sprint-52
+trail comments documenting partial findings + bisect plan. Per
+`feedback_flaky_tests.md`: spawn nerd-snipe (opus) BEFORE `phase=impl`,
+post timeline + mechanism + fix plan as an issue comment.
+
+**Sprint-52 retro framed this as a 600s-watchdog problem. That framing
+was wrong** — see #2009 for the investigation. Actual mechanism: the
+sprint-52 orchestrator invoked the **Agent tool**
+(`Agent({subagent_type: "nerd-snipe", run_in_background: true})`), which
+gives the parent no progress visibility into the sub-context. Sub-agent
+transcripts show 28 minutes of active reasoning, killed by a parent-side
+cutoff while still 1–2 turns from a verdict. The "watchdog" was the
+orchestrator's poll-and-give-up misread.
+
+**Sprint-53 spawn shape: `mcx claude spawn`, NOT the Agent tool.**
+
+```bash
+mcx claude spawn --worktree --model opus -t \
+  "You are nerd-snipe (read .claude/agents/nerd-snipe.md directly first \
+to ground in the persona — do NOT invoke the Agent tool yourself). \
+Your job is to investigate GitHub issue #<n>: <one-line repro>. \
+Existing needs-attention trail: <link>. Verify or reject the suspected \
+mechanisms in the bisect plan order. Post findings as an issue comment \
+with timeline + mechanism + concrete fix plan."
+```
+
+The "do NOT invoke the Agent tool yourself" line is critical — without
+it, nerd-snipe will helpfully `Agent({subagent_type: "nerd-snipe"})`
+recursively and re-create the same sub-context invisibility.
+
+Hard gate unchanged: if no root cause + concrete fix → `needs-attention`,
+do NOT advance to phase=impl. "Spawn opus and hope" is the failure
+mode this rule prevents (sprint 47 / #1870).
+
+Sequence per flake:
+1. `mcx claude spawn` a worker session (NOT Agent tool) with: existing
+   comment trail link, suspected mechanisms from sprint-52 partial
+   trail, bisect range, `gh issue view <n>` timeline.
+2. Track via `mcx claude wait <session>` and `mcx claude log <session>` —
+   tool_use events stream natively, so progress is observable. Nerd-snipe
+   may run for an hour; that's fine.
+3. nerd-snipe posts findings + bisect verification as an issue comment.
+4. Hard gate: if no root cause + concrete fix → `needs-attention` again,
+   surface in retro.
+5. Otherwise: phase=impl on opus (NOT sonnet — adversarial review
+   verifies the implementation matches the documented mechanism).
+6. Adversarial review for the impl PR — match the mechanism, not
+   "tests pass now."
+
+### Hot-shared file watch
+
+- `packages/daemon/src/server-pool.{ts,spec.ts}` — #1980 and #1987 both. **Serialized.**
+- `packages/daemon/src/ipc-server.spec.ts` — #1572, #1759 both. **Serialized.**
+- `packages/daemon/src/site/browser/` — #1645 (`resolve-playwright.ts`), #1661 (`playwright.ts`/`wiggle`). Serialize as belt-and-suspenders.
+- `packages/daemon/src/site/browser/proxy.ts` — #1599 only.
+- `scripts/prepare-npm.ts` — #1996 only.
+- `packages/core/src/git.ts` — #2003 only (touches 8+ call sites across daemon-side files but git.ts is the API change).
+- `packages/command/src/commands/claude.ts` — #1933 only.
+- `packages/permissions/src/rule.ts` — #1703 only.
+- `packages/command/src/commands/phase.ts` — #1944 only (new `advance` subcommand).
+- `packages/daemon/src/codex-session.ts` (or per-provider equivalents) — #1948 only.
+- `packages/core/src/alias-bundle.ts` — #1754 only.
+- `packages/command/src/commands/monitor.spec.ts` — #1565 only.
+
+No two PRs share a dispatch table this sprint. The two serialized pairs
+(#1980/#1987, #1572/#1759, #1645/#1661) are explicit blockedBy edges.
+
+## Context
+
+**Sprint-52 outcome**: 9 PRs merged + 4 already-done closures + 2
+needs-attention, v1.8.6 released. Anchors: 47-sprint #1860 epic
+(structural fix, eliminated `core.bare` config key), `mcx status` null
+guard, `done-fn` SIGTERM heuristic, repair `review_session_id` clear,
+`agent_sessions.repo_root` canonicalization + v4 migration. Both
+adversarial-reviews on opus PRs found real blockers; reviewer
+self-repair held in both cases.
+
+**Plan-time triage** (verify-still-open, per sprint-52 retro
+recommendation):
+- All 15 picks verified open + reproducible at plan time.
+- #1996: confirmed code-level (recreate `.gitkeep` post-build), not
+  process-level. The Explore agent located `unlinkSync(gitkeep)` in
+  `scripts/prepare-npm.ts:77`.
+- #1944: confirmed `mcx phase` has `run/install/check/list/show/why`
+  but no `advance` subcommand.
+- #1933: confirmed `cmdClaudeInternal status` case still bypasses DI
+  at `packages/command/src/commands/claude.ts:318–322`.
+- #1980, #1987: still failing on rerun, comment trails from sprint-52
+  needs-attention routing remain the latest signal.
+- The other 9 picks have no "already-done" risk identified in recon.
+
+**Plan-time meta-fixes (PR #2008 merged)**:
+- #2002 — `run.md` pre-flight aligned with `core.bare` key absence.
+- #2007 — `scanReviewComments` verdict-line heuristic; surveyed 200
+  merged PRs (49 with stickies, 38 approved): **38/38 false positives
+  → 0**. Reviewer prompt nudged toward "verdict line first + same-line
+  resolution markers in delta tables."
+
+**Risks**:
+- **#1980 + #1987**: previous "stalls" were Agent-tool sub-context
+  visibility issues (#2009), not genuine analysis stalls. Sprint 53
+  uses `mcx claude spawn` for nerd-snipe, which mcx instruments
+  natively — progress is observable. Hard gate still applies (no root
+  cause + fix → needs-attention, never spawn impl-on-hope), but the
+  nerd-snipe itself is no longer artificially time-bounded.
+- **#1996 scope ambiguity**: Explore flagged uncertainty between
+  recreate-`.gitkeep` and process-only fix. Implementer has discretion;
+  the diary's "every implementer hits this" framing favors a code fix.
+- **#1944 is the only "feature" pick**. New CLI subcommand. Adversarial
+  review can spot CLI-shape issues (flag naming, output format) that QA
+  alone won't.
+- **#2003 touches 8 call sites**. Even though scrutiny is medium,
+  reviewer should explicitly verify all callers handle the new
+  discriminated union (sprint 52's #1684 hit a similar "3 of 4 workers
+  unpatched" issue when canonicalization moved).
+- **No cross-batch dependency cascades expected** beyond the three
+  explicit blockedBy edges.
+
+**Releasability**: Bug fixes + small refactors + tests + one minor
+feature (#1944). Probable v1.8.7 (patch). #1944 alone could justify
+a minor bump if the API surface ends up being substantial — defer the
+call to retro.
+
+## Process notes (carry-forward from sprint 52)
+
+1. **Capture phase JSON once, extract both fields** (workaround for
+   #1922; #1949 fix landed in sprint 51 — keep until soak-tested):
+   ```bash
+   OUT=$(mcx phase run <p> --work-item ...) && \
+     MODEL=$(echo "$OUT" | jq -r '.model // "sonnet"') && \
+     PROMPT=$(echo "$OUT" | jq -r '.prompt')
+   ```
+2. **Sonnet verify-only repair** when QA fail reason is "stale verdict
+   on contained finding" (impl session has fixed + replied since the
+   verdict).
+3. **Read-after-write race in QA** — sleep ~30s after impl push before
+   spawning QA when Copilot inline reviews are likely (anything other
+   than docs-only). File a proper fix as follow-up if it bites again.
+4. **Bundle prompt template** for already-done clusters: `/implement
+   <first>` then `mcx claude send "Bundle: implement BOTH ... in the
+   SAME PR ..."`.
+5. **Verify auto-merge with `state == MERGED && mergedAt != null`** —
+   never trust just the auto-merge queue.
+6. **One TaskCreate per issue** with addBlockedBy edges from the
+   dependency list. (3 edges this sprint.)
+7. **No `Bun.sleep` in test fixes — deterministic synchronization
+   only**, except as a Promise.race deadline.
+8. **Use the `Monitor` harness tool, not raw Bash `mcx monitor`**.
+9. **Verdict-line heuristic now active in `scanReviewComments`**. The
+   reviewer template was updated in PR #2008 to put the verdict line
+   first and pair every prior 🔴/🟡 with a same-line resolution marker
+   (✅/Fixed/Resolved/Addressed). If a review session still produces
+   the old format, the heuristic should still pass for `✅ APPROVED`
+   stickies; gather examples for retro if any review→qa transitions
+   wedge.
+10. **Plan-time triage step**: every issue verified open + reproducible
+    before slotting. Caught zero already-done this sprint, but the
+    discipline matters more in long sprints.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "bun": ">=1.2.18"
   },
-  "version": "1.8.6",
+  "version": "1.8.7",
   "description": "MCP CLI — call MCP server tools from the command line with zero context overhead",
   "type": "module",
   "workspaces": ["packages/*"],


### PR DESCRIPTION
Sprint 53 container PR. Accumulates every sprint-meta commit on the `sprint-53` branch:

- plan + any mid-sprint amendments
- run-time edits (Started/Ended timestamps, Excluded section)
- Results summary
- retro diary file
- release commit (if a release is cut this sprint)

Marked **draft** until `/sprint retro` flips it ready and arms auto-merge.

## Goal

Clear sprint-52 carry-over (#1996, #2003, #1980, #1987 with corrected nerd-snipe spawn shape via `mcx claude spawn` per #2009 / `investigations.md`), tighten orchestrator hygiene (#1944, #1933, #1948), and back-fill the test gaps the last two sprints filed.

## 15 picks

| Batch | Issues |
|---|---|
| 1 (immediate) | #1980, #1996, #2003, #1944, #1948 |
| 2 (backfill) | #1987, #1933, #1645, #1572, #1565 |
| 3 (backfill) | #1759, #1754, #1599, #1661, #1703 |

**Mix**: 2 high-scrutiny (opus, both flake nerd-snipes) + 3 medium (sonnet) + 10 low (sonnet). Deliberate skew toward small wins after sprint 52's opus-heavy profile.

**Dependency edges**: #1987→#1980 (server-pool), #1759→#1572 (ipc-server.spec), #1661→#1645 (sites/browser).

## Plan-time meta-fixes (already merged)

- PR #2008 — #2002 (run.md `core.bare` alignment) + #2007 (review verdict-line heuristic, validated against 200 merged PRs: 38/38 false positives → 0)
- PR #2010 — #2009 (`investigations.md` canonical nerd-snipe gate reference; `mcx claude spawn` not Agent tool)

Docs/skill-only by construction — pre-commit hooks should skip the test suite.