### PR TITLE
perf(test): collapse 204s suite to 16s (12.8×) — fix WS port retry tax + enable --parallel

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint:timeouts": "bun scripts/check-test-timeouts.ts",
     "lint:teardown": "bun scripts/check-session-teardown.ts",
     "check:phase-drift": "bun scripts/check-phase-drift.ts",
-    "test": "bun install && bun test",
+    "test": "bun install && bun test --parallel",
     "test:coverage": "bun scripts/check-coverage.ts",
     "dev:daemon": "bun packages/daemon/src/main.ts",
     "dev:mcx": "bun packages/command/src/main.ts",

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -453,10 +453,12 @@ export class ClaudeWsServer {
     this.spawn = deps?.spawn ?? defaultSpawn;
     this.killTimeoutMs = deps?.killTimeoutMs ?? KILL_TIMEOUT_MS;
     this.logger = deps?.logger ?? consoleLogger;
-    // 5 attempts with exponential backoff (50/100/200/400/800ms = 1550ms total),
-    // down from 10×500ms = 5000ms. The previous default was the dominant tax on
-    // every daemon spawn whenever port 19275 was held by another daemon —
-    // it contributed ~94s to the test suite via daemon-integration.spec.ts.
+    // 5 retries with exponential backoff (50/100/200/400/800ms = 1550ms total
+    // across 5 sleeps; the loop also performs 1 initial attempt for 6 binds in
+    // the worst case). Down from 10 retries × 500ms = 5000ms. The previous
+    // default was the dominant tax on every daemon spawn whenever port 19275
+    // was held by another daemon — it contributed ~94s to the test suite via
+    // daemon-integration.spec.ts.
     this.portRetryCount = deps?.portRetryCount ?? 5;
     this.portRetryDelayMs = deps?.portRetryDelayMs ?? 50;
     this.reclaimIntervalMs = deps?.reclaimIntervalMs ?? PORT_RECLAIM_INTERVAL_MS;
@@ -525,8 +527,8 @@ export class ClaudeWsServer {
           if (!isAddrInUse(err)) throw err;
           if (attempt < this.portRetryCount) {
             // Exponential backoff bounded by portRetryDelayMs × 2^attempt.
-            // With defaults (50ms × {1,2,4,8,16}) total wait is ~1.55s for
-            // 5 attempts vs the previous fixed 5×500ms = 2.5s schedule.
+            // With defaults (50ms × {1,2,4,8,16}) total wait is ~1.55s across
+            // 5 retries, vs the previous fixed 10×500ms = 5s schedule.
             await Bun.sleep(this.portRetryDelayMs * 2 ** attempt);
             continue;
           }

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -453,8 +453,12 @@ export class ClaudeWsServer {
     this.spawn = deps?.spawn ?? defaultSpawn;
     this.killTimeoutMs = deps?.killTimeoutMs ?? KILL_TIMEOUT_MS;
     this.logger = deps?.logger ?? consoleLogger;
-    this.portRetryCount = deps?.portRetryCount ?? 10;
-    this.portRetryDelayMs = deps?.portRetryDelayMs ?? 500;
+    // 5 attempts with exponential backoff (50/100/200/400/800ms = 1550ms total),
+    // down from 10×500ms = 5000ms. The previous default was the dominant tax on
+    // every daemon spawn whenever port 19275 was held by another daemon —
+    // it contributed ~94s to the test suite via daemon-integration.spec.ts.
+    this.portRetryCount = deps?.portRetryCount ?? 5;
+    this.portRetryDelayMs = deps?.portRetryDelayMs ?? 50;
     this.reclaimIntervalMs = deps?.reclaimIntervalMs ?? PORT_RECLAIM_INTERVAL_MS;
     this.connectTimeoutMs = deps?.connectTimeoutMs ?? CONNECT_TIMEOUT_MS;
     this.stuckConfig = deps?.stuckConfig ?? DEFAULT_STUCK_CONFIG;
@@ -506,8 +510,9 @@ export class ClaudeWsServer {
 
   /** Start the WebSocket server. Returns the assigned port.
    *  If `port` is provided and non-zero, tries that port first;
-   *  retries up to MAX_PORT_RETRIES times with backoff before falling back
-   *  to a random OS-assigned port on EADDRINUSE. */
+   *  retries up to portRetryCount times with exponential backoff
+   *  (portRetryDelayMs × 2^attempt) before falling back to a random
+   *  OS-assigned port on EADDRINUSE. */
   async start(port?: number): Promise<number> {
     const requestedPort = port ?? 0;
 
@@ -519,7 +524,10 @@ export class ClaudeWsServer {
         } catch (err) {
           if (!isAddrInUse(err)) throw err;
           if (attempt < this.portRetryCount) {
-            await Bun.sleep(this.portRetryDelayMs);
+            // Exponential backoff bounded by portRetryDelayMs × 2^attempt.
+            // With defaults (50ms × {1,2,4,8,16}) total wait is ~1.55s for
+            // 5 attempts vs the previous fixed 5×500ms = 2.5s schedule.
+            await Bun.sleep(this.portRetryDelayMs * 2 ** attempt);
             continue;
           }
           // All retries exhausted — fall back to random port

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -290,6 +290,17 @@ export function pruneOrphanedWorktrees(
 /** Per-phase timeout for shutdown steps (ms). Prevents any single phase from hanging the process. */
 const SHUTDOWN_PHASE_TIMEOUT_MS = 5_000;
 
+/**
+ * Tighter timeout for `awaitPendingServers`. We don't actually need to wait
+ * for in-flight virtual server startups during shutdown — abandoning them
+ * is fine because the rest of the shutdown sequence tears down DB/IPC/pool
+ * regardless. The previous 5s budget meant SIGTERM during a slow startup
+ * (e.g. ws-server port retry) blocked exit by up to 5s. The new ws-server
+ * retry schedule maxes out around 1.55s, so 2s gives normal startups room
+ * to finish without making SIGTERM feel hung.
+ */
+const SHUTDOWN_PENDING_TIMEOUT_MS = 2_000;
+
 /** Race a promise against a deadline. Returns "timeout" if the deadline is reached. */
 async function withPhaseTimeout<T>(
   promise: Promise<T>,
@@ -1114,10 +1125,13 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
       } catch (err) {
         logger.error(`[mcpd] Error stopping IPC server: ${err}`);
       }
-      // Wait for any in-progress virtual server startups before stopping them
+      // Wait briefly for any in-progress virtual server startups before stopping
+      // them. Don't block shutdown on slow startups — the subsequent
+      // server.stop() calls handle the in-flight case, and dropping the wait
+      // means SIGTERM exits promptly even if a worker is mid-port-retry.
       let phase = performance.now();
       try {
-        await withPhaseTimeout(pool.awaitPendingServers(), SHUTDOWN_PHASE_TIMEOUT_MS, "awaitPendingServers", logger);
+        await withPhaseTimeout(pool.awaitPendingServers(), SHUTDOWN_PENDING_TIMEOUT_MS, "awaitPendingServers", logger);
       } catch (err) {
         logger.error(`[mcpd] Error awaiting pending servers: ${err}`);
       }

--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -36,14 +36,11 @@ const PER_FILE_TIME_BUDGET_MS = 5_000;
  * Uses sequential sum (not parallel wall time) for reproducibility across machines.
  * Ratchet this down as optimizations land. Warns but never blocks commits.
  *
- * Parallel wall time (measured at concurrency=14 on 14-core Apple Silicon):
- *   ~100s for all 159 files, ~65s for 153 non-excluded files.
- *   The #690 target of <25s parallel wall time is infeasible with the current
- *   test count (~153 non-excluded files). Each file has ~200-300ms of Bun
- *   process startup overhead alone. Achieving <25s would require either:
- *   (a) an in-process test runner (no per-file subprocess), or
- *   (b) reducing to ~80 test files via aggressive consolidation.
- *   Neither is justified given that parallel wall time is not user-facing.
+ * Parallel wall time on 16-core Apple Silicon (post wsPort + --parallel fixes):
+ *   ~16s for the full suite. The previous "~100s parallel wall is the floor"
+ *   conclusion was wrong — it didn't account for the 5s WS-port retry tax that
+ *   daemon-integration.spec.ts paid on every spawn. The earlier "infeasible
+ *   <25s" comment in this file was based on that bug. See PR description.
  */
 const AGGREGATE_TIME_BUDGET_MS = 39_000;
 
@@ -55,7 +52,8 @@ const PROFILE_CONCURRENCY = Math.max(4, Math.min(navigator.hardwareConcurrency ?
  * These are intentionally slow integration/stress tests that spawn real daemons.
  */
 const TIMING_EXCLUSIONS: Record<string, string> = {
-  "test/daemon-integration.spec.ts": "Full daemon lifecycle integration tests",
+  "test/daemon-integration.spec.ts":
+    "Full daemon lifecycle integration tests (~12s post wsPort fix; ~22 daemon spawns)",
   "test/stress.spec.ts": "Stress tests spawning real CLI processes",
   "test/transport-errors.spec.ts": "Live daemon transport error integration tests",
   "packages/daemon/src/index.spec.ts": "13 in-process daemon instances for startup/shutdown/idle/reload",
@@ -220,7 +218,14 @@ const nonDaemonPaths = [...packageDirs, ...topLevelTestFiles, ...RUN1_DAEMON_UNI
 
 const testStart = Date.now();
 
-// Run 1: non-daemon tests with --coverage (produces the coverage table we parse)
+// Run 1: non-daemon tests with --coverage (produces the coverage table we parse).
+// NOTE: --parallel cannot be combined with --coverage — Bun's parallel workers
+// each emit their own coverage table and `bun test` reports only the worker
+// that finishes last, attributing 0 lines/funcs to files exercised in other
+// workers. That made global line coverage drop from 93.94% to 87.49% with
+// 35 files falsely flagged below the 80% per-file floor. The dev `bun test`
+// command uses --parallel for speed (no --coverage there), and this script
+// stays sequential for accurate coverage aggregation.
 const proc1 = Bun.spawn(["bun", "test", "--coverage", ...nonDaemonPaths], {
   stdout: "pipe",
   stderr: "pipe",
@@ -246,10 +251,15 @@ if (skipRun2) {
   const daemonTestFiles = readdirSync(resolve(import.meta.dir, "../test"))
     .filter((f) => f.endsWith(".spec.ts") && !RUN1_TEST_FILES.has(`test/${f}`))
     .map((f) => `test/${f}`);
-  const proc2 = Bun.spawn(["bun", "test", "--timeout", "60000", "packages/daemon/src", ...daemonTestFiles], {
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+  // Run 2: daemon tests. --parallel is safe here because no --coverage flag,
+  // and ws-server's port-retry tax has been reduced (see ws-server.ts).
+  const proc2 = Bun.spawn(
+    ["bun", "test", "--parallel", "--timeout", "60000", "packages/daemon/src", ...daemonTestFiles],
+    {
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  );
 
   // Process-level deadline: if run-2 hangs (e.g. daemon teardown bug), kill it
   // rather than blocking pre-commit indefinitely. 300s is generous enough for

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -58,6 +58,14 @@ export async function startTestDaemon(
   // Write servers.json so daemon has config to load
   writeFileSync(join(dir, "servers.json"), JSON.stringify({ mcpServers: servers }));
 
+  // Force a random WebSocket port. Without this, every test daemon tries to bind
+  // DEFAULT_CLAUDE_WS_PORT (19275) and — when the user's dev daemon or another
+  // test daemon already holds it — burns multi-second port retries in ws-server
+  // before falling back. Multiplied across ~22 daemon spawns in
+  // daemon-integration.spec.ts that's tens of seconds of test wall time.
+  // Production keeps the well-known port; only test daemons opt in to wsPort: 0.
+  writeFileSync(join(dir, "config.json"), JSON.stringify({ wsPort: 0 }));
+
   const proc = Bun.spawn(["bun", resolve("packages/daemon/src/main.ts")], {
     stdout: "ignore",
     stderr: "pipe",


### PR DESCRIPTION
## Summary

Two specific bugs were dominating the test suite wall time. This PR fixes both, plus the production-side root causes that were leaking into shutdown latency.

| Configuration | Wall (this branch) | Speedup |
|---|---|---|
| `bun test` (sequential, baseline) | 204s | — |
| `bun test --parallel` only | ~103s | 2.0× |
| `--parallel` + `wsPort: 0` in test harness | **15.6–15.9s** | **12.8×** |

Validated across three back-to-back full-suite runs on a 16-core M-class. 7035 pass, 0 fail, no flakes.

## Root causes

**#1 — WS port retry tax (~94s of the 204s).** `test/harness.ts` left `wsPort` at the default `19275`. When the user's dev daemon (or another concurrent test daemon) already held that port, `claude-session/ws-server.ts` burned `10×500ms = 5s` in `Bun.sleep` retries before falling back. Multiplied across ~22 daemon spawns in `test/daemon-integration.spec.ts` that's ~110s of pure sleep. Reproduced empirically — SIGTERM→exit dropped from **3885ms → 19ms** when `wsPort: 0` is passed.

**#2 — `bun test --parallel` not enabled.** Bun supports `--parallel` (implies `--isolate`); package.json's `test` script was running everything sequentially. Adding `--parallel` (one char) gives ~2× wall on its own.

## Changes

### Test harness fixes (Tier 1)
- `test/harness.ts`: write `{"wsPort": 0}` to each test daemon's `config.json` — random OS-assigned port, no contention with the user's dev daemon or other parallel test daemons.
- `package.json`: `bun test` → `bun test --parallel`.

### Production fixes (Tier 2)
- `ws-server.ts`: port-retry default `10×500ms = 5s` → `5×exponential (50/100/200/400/800ms = 1.55s)`. Tests that override `portRetryCount: 0` are unaffected.
- `index.ts`: shutdown `awaitPendingServers` timeout `5s → 2s`. Prevents SIGTERM blocking 5s when a worker is mid-startup.

### Coverage script (`scripts/check-coverage.ts`)
- Run 1 (`--coverage`) stays sequential. `--parallel --coverage` fragments per-file coverage attribution — line coverage falsely drops 93.94% → 87.49%. Comment explains so the next reader doesn't re-add `--parallel` here.
- Run 2 (daemon tests, no `--coverage`) does use `--parallel`.
- Updated outdated comments and TIMING_EXCLUSIONS reasons.

## Deferred

Tier 3 from the original investigation — injecting a clock into `StuckDetector` for virtual-time tests — is filed as **#2012**. Saves <500ms wall (off the critical path now) and requires rewriting all 19 tests; better as its own PR.

## Coverage parity

| | main | this branch |
|---|---|---|
| Function coverage | 91.39% | 91.39% |
| Line coverage | 93.94% | 93.94% |
| Coverage check wall | ~210s | 47s |
| `bun test` wall | 204s | 16s |

## Test plan

- [x] Reproduce baseline: `bun test` ≈ 204s, daemon-integration.spec.ts ≈ 97s
- [x] Reproduce 5s retry tax: SIGTERM→exit = 3885ms when port 19275 contended
- [x] Confirm fix: SIGTERM→exit = 19ms with `wsPort: 0`
- [x] `bun test --parallel` × 3 consecutive: 15.6 / 15.9 / 15.9s, 7035 pass
- [x] `bun typecheck`, `bun lint`, `lint:shell`, `lint:timeouts` clean
- [x] `bun scripts/check-coverage.ts --ci` PASS, identical numbers to main
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)