### PR TITLE
test(alias-bundle): cover evalBundledJs timeout path (fixes #1754)

### DIFF
--- a/packages/core/src/alias-bundle.spec.ts
+++ b/packages/core/src/alias-bundle.spec.ts
@@ -382,6 +382,22 @@ describe("extractMetadata", () => {
     const { js } = await bundleAlias(scriptPath);
     await expect(extractMetadata(js)).rejects.toThrow("did not call defineAlias");
   });
+
+  test("rejects with 'Alias eval timed out' when timeout fires", async () => {
+    const dir = makeTmpDir();
+    const scriptPath = join(dir, "hang.ts");
+    writeFileSync(
+      scriptPath,
+      [
+        'import { defineAlias, z } from "mcp-cli";',
+        "await new Promise(() => {});",
+        "defineAlias({ name: 'hang', description: 'forever', input: z.object({}), fn: () => {} });",
+      ].join("\n"),
+    );
+
+    const { js } = await bundleAlias(scriptPath);
+    await expect(extractMetadata(js, 1)).rejects.toThrow("Alias eval timed out");
+  });
 });
 
 describe("executeAliasBundled", () => {


### PR DESCRIPTION
## Summary
- Adds a test that calls `extractMetadata` with a 1ms timeout and a script that hangs at the top level via `await new Promise(() => {})`
- Asserts the rejection message is `"Alias eval timed out"` — catching any future regression to the message introduced by #1744
- No production code changes; test-only

## Test plan
- [ ] `bun test packages/core/src/alias-bundle.spec.ts` — 55 pass (was 54), new test exercises the timeout branch
- [ ] `bun typecheck && bun lint` — clean
- [ ] Full suite `bun test` — 7036 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)