### PR TITLE
fix(sites): wiggle() passes siteName (not raw site) to withPage() (fixes #1661)

### DIFF
--- a/packages/daemon/src/site/browser/playwright.ts
+++ b/packages/daemon/src/site/browser/playwright.ts
@@ -414,7 +414,7 @@ export class PlaywrightBrowserEngine implements BrowserEngine {
       const exported: unknown = require(wigglePath);
       const wiggleFn = ((exported as Record<string, unknown>)?.default ?? exported) as unknown;
       if (typeof wiggleFn !== "function") throw new Error(`wiggle module at '${wigglePath}' must export a function`);
-      return this.withPage(site, (page) => (wiggleFn as (page: Page) => Promise<string[]>)(page));
+      return this.withPage(siteName, (page) => (wiggleFn as (page: Page) => Promise<string[]>)(page));
     }
 
     if (spec?.wiggleSrc) {
@@ -425,7 +425,7 @@ export class PlaywrightBrowserEngine implements BrowserEngine {
       const exported: unknown = mod.exports;
       const wiggleFn = ((exported as Record<string, unknown>)?.default ?? exported) as unknown;
       if (typeof wiggleFn !== "function") throw new Error(`embedded wiggle for '${siteName}' must export a function`);
-      return this.withPage(site, (page) => (wiggleFn as (page: Page) => Promise<string[]>)(page));
+      return this.withPage(siteName, (page) => (wiggleFn as (page: Page) => Promise<string[]>)(page));
     }
 
     return ["no-wiggle-configured"];


### PR DESCRIPTION
## Summary
- `wiggle()` normalized `site` to `siteName` for the `siteSpecs` lookup but then passed the original (possibly `undefined`) `site` to both `withPage()` calls
- When `site` is `undefined` and multiple pages are open, `withPage(undefined)` falls through to `context.pages()[0]` which can diverge from `pages.keys()[0]`, causing spec/page mismatch
- Both `withPage(site, ...)` calls changed to `withPage(siteName, ...)` so spec lookup and page resolution are always consistent

## Test plan
- [ ] `bun typecheck` — pass
- [ ] `bun lint` — pass
- [ ] `bun test packages/daemon/src/site/browser/playwright.spec.ts` — 9 pass
- [ ] Full pre-commit hook suite — pass
- Note: `PlaywrightBrowserEngine` internals require real Playwright to test; the fix is correct by inspection and the existing exported-function tests are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)