### PR TITLE
feat(permissions): support bare mcp__server server-wide wildcard (fixes #1703)

### DIFF
--- a/packages/permissions/CLAUDE.md
+++ b/packages/permissions/CLAUDE.md
@@ -19,22 +19,29 @@ Rules use the `Tool(pattern)` format from Claude Code's settings:
 "Bash(ls /foo/*)"            → exact: the * is a bash glob, NOT a wildcard
 "Read(src/**/*.ts)"          → file glob: matches TypeScript files in src/
 "mcp__echo__echo"            → MCP tool name (exact match)
-"mcp__atlassian__*"          → MCP tool wildcard: all tools from atlassian server
+"mcp__atlassian__*"          → MCP tool wildcard: all tools from atlassian server (with __*)
+"mcp__atlassian"             → MCP server wildcard: all tools from atlassian server (bare form, equivalent to mcp__atlassian__*)
 "mcp__*"                     → MCP tool wildcard: all tools from any MCP server
 ```
+
+Both `mcp__server` and `mcp__server__*` are equivalent server-wide wildcards — they match identically. The bare form mirrors Claude Code's documented syntax; use whichever you copy from the docs.
 
 ### Wildcard Markers
 
 **`:*` is the argument wildcard.** Bare `*` in a Bash argument pattern is a valid bash glob character (like `ls /foo/*`) and is treated as literal. The `:*` suffix is Claude Code's native format meaning "this prefix with any arguments".
 
-**`__*` is the tool-name wildcard.** Appending `__*` to an MCP tool prefix matches all tools whose name starts with that prefix. This maps to MCP's `mcp__server__tool` naming convention:
+**`__*` or bare server name are the tool-name wildcards.** Two equivalent forms match all tools from an MCP server:
 
-- `mcp__atlassian__*` → allows every tool from the `atlassian` MCP server
+- `mcp__atlassian__*` — explicit wildcard suffix (Claude Code docs form 1)
+- `mcp__atlassian` — bare server name, no suffix (Claude Code docs form 2)
+
+Both produce identical evaluation results. The bare form is recognized when the pattern starts with `mcp__`, has a non-empty server name, and contains no `__` in the server segment.
+
 - `mcp__*` → allows every MCP tool from any server
 
-Only the `__*` suffix triggers prefix matching on tool names. A bare `*` at any other position (e.g., `Read*`) is not a wildcard and will only match the literal tool name `"Read*"` (which no real tool is named).
+Only `__*` or a bare `mcp__<server>` pattern trigger prefix matching on tool names. A bare `*` at any other position (e.g., `Read*`) is not a wildcard and will only match the literal tool name `"Read*"` (which no real tool is named).
 
-Deny rules with `__*` wildcards work symmetrically — a server-level deny (`mcp__atlassian__*`) combined with a broader allow (`mcp__*`) will block all atlassian tools via the standard first-deny-wins logic.
+Deny rules with server wildcards work symmetrically — a server-level deny (`mcp__atlassian__*` or `mcp__atlassian`) combined with a broader allow (`mcp__*`) will block all atlassian tools via the standard first-deny-wins logic.
 
 ### Evaluation Semantics
 

--- a/packages/permissions/src/evaluator.spec.ts
+++ b/packages/permissions/src/evaluator.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { type PermissionRequest, evaluate } from "./evaluator";
-import type { PermissionRule } from "./rule";
+import { type PermissionRule, isBareMcpServerPattern } from "./rule";
 
 function req(toolName: string, input: Record<string, unknown> = {}): PermissionRequest {
   return { toolName, input };
@@ -498,6 +498,16 @@ describe("evaluate", () => {
     ];
     expect(evaluate(rules, req("mcp__puppeteer__screenshot")).allow).toBe(true);
     expect(evaluate(rules, req("mcp__puppeteer__navigate")).allow).toBe(false);
+  });
+
+  test("mcp__* is not a bare server pattern (it is a tool wildcard)", () => {
+    const rules: PermissionRule[] = [{ tool: "mcp__*", action: "allow" }];
+    // mcp__* is handled by isToolWildcard, not isBareMcpServerPattern
+    expect(evaluate(rules, req("mcp__echo__echo")).allow).toBe(true);
+    expect(evaluate(rules, req("mcp__atlassian__search")).allow).toBe(true);
+
+    // Direct contract test on the exported helper
+    expect(isBareMcpServerPattern("mcp__*")).toBe(false);
   });
 
   test("bare server does not match adjacent server prefix", () => {

--- a/packages/permissions/src/evaluator.spec.ts
+++ b/packages/permissions/src/evaluator.spec.ts
@@ -459,6 +459,54 @@ describe("evaluate", () => {
     expect(evaluate(rules, req("mcp__echo__echo")).allow).toBe(false);
   });
 
+  // ── Bare MCP server pattern (mcp__server without __*) ──
+
+  test("mcp__server matches every tool from that server", () => {
+    const rules: PermissionRule[] = [{ tool: "mcp__puppeteer", action: "allow" }];
+    expect(evaluate(rules, req("mcp__puppeteer__navigate")).allow).toBe(true);
+    expect(evaluate(rules, req("mcp__puppeteer__screenshot")).allow).toBe(true);
+    expect(evaluate(rules, req("mcp__echo__echo")).allow).toBe(false);
+    expect(evaluate(rules, req("Read")).allow).toBe(false);
+  });
+
+  test("mcp__server and mcp__server__* produce identical results", () => {
+    const bare: PermissionRule[] = [{ tool: "mcp__atlassian", action: "allow" }];
+    const starred: PermissionRule[] = [{ tool: "mcp__atlassian__*", action: "allow" }];
+    const tools = ["mcp__atlassian__search", "mcp__atlassian__get_issue", "mcp__echo__echo", "Read"];
+    for (const tool of tools) {
+      expect(evaluate(bare, req(tool)).allow).toBe(evaluate(starred, req(tool)).allow);
+    }
+  });
+
+  test("mcp__ alone (no server name) does not match anything", () => {
+    const rules: PermissionRule[] = [{ tool: "mcp__", action: "allow" }];
+    expect(evaluate(rules, req("mcp__echo__echo")).allow).toBe(false);
+    expect(evaluate(rules, req("mcp__atlassian__search")).allow).toBe(false);
+  });
+
+  test("multi-underscore server names work with bare form", () => {
+    const rules: PermissionRule[] = [{ tool: "mcp__claude_ai_Google_Drive", action: "allow" }];
+    expect(evaluate(rules, req("mcp__claude_ai_Google_Drive__authenticate")).allow).toBe(true);
+    expect(evaluate(rules, req("mcp__claude_ai_Google_Drive__list_files")).allow).toBe(true);
+    expect(evaluate(rules, req("mcp__echo__echo")).allow).toBe(false);
+  });
+
+  test("bare server allow + specific tool deny (first-deny-wins)", () => {
+    const rules: PermissionRule[] = [
+      { tool: "mcp__puppeteer", action: "allow" },
+      { tool: "mcp__puppeteer__navigate", action: "deny" },
+    ];
+    expect(evaluate(rules, req("mcp__puppeteer__screenshot")).allow).toBe(true);
+    expect(evaluate(rules, req("mcp__puppeteer__navigate")).allow).toBe(false);
+  });
+
+  test("bare server does not match adjacent server prefix", () => {
+    const rules: PermissionRule[] = [{ tool: "mcp__echo", action: "allow" }];
+    // "mcp__echoextra__tool" starts with "mcp__echo" but not "mcp__echo__"
+    expect(evaluate(rules, req("mcp__echoextra__tool")).allow).toBe(false);
+    expect(evaluate(rules, req("mcp__echo__echo")).allow).toBe(true);
+  });
+
   test("bare * in tool name is not a wildcard (literal exact match)", () => {
     const rules: PermissionRule[] = [{ tool: "Read*", action: "allow" }];
     // "Read*" is literal — no tool is named "Read*"

--- a/packages/permissions/src/evaluator.ts
+++ b/packages/permissions/src/evaluator.ts
@@ -12,6 +12,7 @@ import { matchBashCommand } from "./bash-matcher";
 import { matchFilePath } from "./file-matcher";
 import {
   type PermissionRule,
+  isBareMcpServerPattern,
   isToolWildcard,
   isWildcardPattern,
   parsePattern,
@@ -56,9 +57,12 @@ function extractFilePath(input: Record<string, unknown>): string | null {
 function matchesRule(rule: PermissionRule, request: PermissionRequest): boolean {
   const { tool, argPattern } = parsePattern(rule.tool);
 
-  // Tool name matching: exact or tool-wildcard (__*)
+  // Tool name matching: exact, tool-wildcard (__*), or bare MCP server pattern
   if (isToolWildcard(tool)) {
     if (!request.toolName.startsWith(toToolPrefix(tool))) return false;
+  } else if (isBareMcpServerPattern(tool)) {
+    // "mcp__server" is equivalent to "mcp__server__*" — prefix-match with "__" appended
+    if (!request.toolName.startsWith(`${tool}__`)) return false;
   } else {
     if (tool !== request.toolName) return false;
   }

--- a/packages/permissions/src/index.ts
+++ b/packages/permissions/src/index.ts
@@ -4,6 +4,7 @@ export {
   toArgPrefix,
   isWildcardPattern,
   isToolWildcard,
+  isBareMcpServerPattern,
   toToolPrefix,
   type PermissionRule,
   type ParsedPattern,

--- a/packages/permissions/src/rule.ts
+++ b/packages/permissions/src/rule.ts
@@ -54,6 +54,30 @@ export function isToolWildcard(tool: string): boolean {
 }
 
 /**
+ * Check if a tool name is a bare MCP server pattern (server-wide wildcard without `__*`).
+ *
+ * Claude Code documents two equivalent ways to allow all tools from an MCP server:
+ * `mcp__server` (bare) and `mcp__server__*`. This function detects the bare form.
+ *
+ * Rules:
+ * - Must start with "mcp__"
+ * - Server name (the part after "mcp__") must be non-empty
+ * - Must not contain "__" in the server name segment (that would make it exact or `__*`)
+ *
+ * Examples:
+ * - "mcp__puppeteer"             → true  (server-wide wildcard, equivalent to mcp__puppeteer__*)
+ * - "mcp__claude_ai_Google_Drive"→ true  (single underscores in server name are fine)
+ * - "mcp__"                      → false (no server name)
+ * - "mcp__echo__echo"            → false (has tool segment → exact match)
+ * - "mcp__atlassian__*"          → false (handled by isToolWildcard)
+ */
+export function isBareMcpServerPattern(tool: string): boolean {
+  if (!tool.startsWith("mcp__")) return false;
+  const rest = tool.slice(5); // strip "mcp__"
+  return rest.length > 0 && !rest.includes("__");
+}
+
+/**
  * Convert a tool wildcard pattern to the prefix for `startsWith` matching.
  * Only call this when `isToolWildcard()` returns true.
  *

--- a/packages/permissions/src/rule.ts
+++ b/packages/permissions/src/rule.ts
@@ -74,7 +74,7 @@ export function isToolWildcard(tool: string): boolean {
 export function isBareMcpServerPattern(tool: string): boolean {
   if (!tool.startsWith("mcp__")) return false;
   const rest = tool.slice(5); // strip "mcp__"
-  return rest.length > 0 && !rest.includes("__");
+  return rest.length > 0 && !rest.includes("__") && !rest.includes("*");
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `isBareMcpServerPattern()` to `rule.ts` — detects `mcp__<server>` patterns (no `__*` suffix, non-empty server name, no `__` in server segment)
- Extends `matchesRule()` in `evaluator.ts` to treat bare server patterns as prefix wildcards (`mcp__server` → prefix-match with `mcp__server__`)
- `mcp__server` and `mcp__server__*` now produce byte-identical evaluation results; `mcp__` alone (no server) still matches nothing

## Test plan
- [x] `mcp__server` matches every tool from that server
- [x] `mcp__server` and `mcp__server__*` produce identical results across a shared tool matrix
- [x] `mcp__` alone does NOT match anything (fail-closed)
- [x] Multi-underscore server names (`mcp__claude_ai_Google_Drive`) work correctly
- [x] Deny rule on a specific tool overrides bare-server allow (first-deny-wins)
- [x] Adjacent server prefix not matched (`mcp__echo` does not match `mcp__echoextra__tool`)
- [x] `bun typecheck`, `bun lint`, `bun test` all pass (7041 pass, 0 fail)
- [x] `packages/permissions/CLAUDE.md` updated to document both equivalent forms

🤖 Generated with [Claude Code](https://claude.com/claude-code)