### PR TITLE
refactor(git): ensureCoreBareUnset returns discriminated union (closes #2003)

### DIFF
--- a/packages/core/src/git.spec.ts
+++ b/packages/core/src/git.spec.ts
@@ -125,7 +125,7 @@ describe("ensureCoreBareUnset", () => {
         return { stdout: "", exitCode: 0 };
       });
 
-      expect(ensureCoreBareUnset(cwd, exec)).toBe(true);
+      expect(ensureCoreBareUnset(cwd, exec)).toBe("removed");
       expect(calls).toHaveLength(2);
       expect(calls[1]).toEqual(["git", "-C", cwd, "config", "--local", "--unset", "core.bare"]);
     } finally {
@@ -145,7 +145,7 @@ describe("ensureCoreBareUnset", () => {
         return { stdout: "", exitCode: 0 };
       });
 
-      expect(ensureCoreBareUnset(cwd, exec)).toBe(true);
+      expect(ensureCoreBareUnset(cwd, exec)).toBe("removed");
       expect(calls).toHaveLength(2);
       expect(calls[1]).toEqual(["git", "-C", cwd, "config", "--local", "--unset", "core.bare"]);
     } finally {
@@ -153,29 +153,29 @@ describe("ensureCoreBareUnset", () => {
     }
   });
 
-  test("returns false when key is already absent", () => {
+  test("returns absent when key is already absent", () => {
     const cwd = makeFakeWorktree();
     try {
       const exec: ExecFn = mock(() => ({ stdout: "", exitCode: 1 }));
-      expect(ensureCoreBareUnset(cwd, exec)).toBe(false);
+      expect(ensureCoreBareUnset(cwd, exec)).toBe("absent");
       expect(exec).toHaveBeenCalledTimes(1);
     } finally {
       rmSync(cwd, { recursive: true });
     }
   });
 
-  test("does nothing for bare repo (no .git entry)", () => {
+  test("returns absent for bare repo (no .git entry)", () => {
     const cwd = makeFakeBareRepo();
     try {
       const exec: ExecFn = mock(() => ({ stdout: "", exitCode: 0 }));
-      expect(ensureCoreBareUnset(cwd, exec)).toBe(false);
+      expect(ensureCoreBareUnset(cwd, exec)).toBe("absent");
       expect(exec).toHaveBeenCalledTimes(0);
     } finally {
       rmSync(cwd, { recursive: true });
     }
   });
 
-  test("falls back to setting false when unset fails and re-read confirms true", () => {
+  test("returns fallback when unset fails and re-read confirms key still present", () => {
     const cwd = makeFakeWorktree();
     try {
       const calls: string[][] = [];
@@ -188,7 +188,7 @@ describe("ensureCoreBareUnset", () => {
         return { stdout: "", exitCode: 0 }; // fallback set
       });
 
-      expect(ensureCoreBareUnset(cwd, exec)).toBe(false);
+      expect(ensureCoreBareUnset(cwd, exec)).toBe("fallback");
       expect(calls).toHaveLength(4);
       expect(calls[2]).toEqual(["git", "-C", cwd, "config", "--local", "core.bare"]); // re-read
       expect(calls[3]).toEqual(["git", "-C", cwd, "config", "--local", "core.bare", "false"]); // fallback
@@ -197,7 +197,7 @@ describe("ensureCoreBareUnset", () => {
     }
   });
 
-  test("no fallback when unset fails but re-read shows key gone (benign race)", () => {
+  test("returns removed when unset fails but re-read shows key gone (benign race)", () => {
     const cwd = makeFakeWorktree();
     try {
       const calls: string[][] = [];
@@ -215,7 +215,7 @@ describe("ensureCoreBareUnset", () => {
         return { stdout: "", exitCode: 0 };
       });
 
-      expect(ensureCoreBareUnset(cwd, exec)).toBe(true);
+      expect(ensureCoreBareUnset(cwd, exec)).toBe("removed");
       expect(calls).toHaveLength(3); // read, unset, re-read — no fallback set
     } finally {
       rmSync(cwd, { recursive: true });

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -46,6 +46,15 @@ export function isCoreBareSet(cwd: string, exec: ExecFn): boolean {
   return exitCode === 0 && stdout.trim() === "true";
 }
 
+/** Discriminated result from {@link ensureCoreBareUnset}. */
+export type CoreBareUnsetResult =
+  /** Key was present and successfully removed (or was already gone via a benign race). */
+  | "removed"
+  /** Key was already absent — nothing to do. */
+  | "absent"
+  /** `--unset` failed and the key is still present; set to `false` as a last resort. */
+  | "fallback";
+
 /**
  * Remove the `core.bare` config key entirely, regardless of its current value.
  *
@@ -55,25 +64,28 @@ export function isCoreBareSet(cwd: string, exec: ExecFn): boolean {
  * bug. Removing the key eliminates the attack surface: if the key doesn't exist,
  * nothing can flip it. See #1860.
  *
- * Returns true if the key was present and successfully removed.
+ * Returns a {@link CoreBareUnsetResult} discriminating three outcomes:
+ * - `"removed"` — key was present and successfully removed (metric as a heal)
+ * - `"absent"` — key was already absent, no-op
+ * - `"fallback"` — `--unset` failed, key set to `false` as last resort (warn: structural fix incomplete)
  */
-export function ensureCoreBareUnset(cwd: string, exec: ExecFn): boolean {
-  if (!existsSync(join(cwd, ".git"))) return false;
-  const { stdout, exitCode } = exec(["git", "-C", cwd, "config", "--local", "core.bare"]);
-  if (exitCode !== 0) return false; // key already absent
+export function ensureCoreBareUnset(cwd: string, exec: ExecFn): CoreBareUnsetResult {
+  if (!existsSync(join(cwd, ".git"))) return "absent";
+  const { exitCode } = exec(["git", "-C", cwd, "config", "--local", "core.bare"]);
+  if (exitCode !== 0) return "absent"; // key already absent
   const unset = exec(["git", "-C", cwd, "config", "--local", "--unset", "core.bare"]);
-  if (unset.exitCode === 0) return true;
+  if (unset.exitCode === 0) return "removed";
   // --unset failed. Re-read to distinguish "key gone (benign race)" from
   // "key still present (real failure)". Without this re-read the fallback
   // would recreate the key, defeating the structural fix.
   const recheck = exec(["git", "-C", cwd, "config", "--local", "core.bare"]);
-  if (recheck.exitCode !== 0) return true; // key gone — race resolved
+  if (recheck.exitCode !== 0) return "removed"; // key gone — race resolved
   // Key stubbornly present (locked file, permission issue, etc.).
   // Last resort: ensure it's at least "false" so git ops don't break.
   if (recheck.stdout.trim() !== "false") {
     exec(["git", "-C", cwd, "config", "--local", "core.bare", "false"]);
   }
-  return false;
+  return "fallback";
 }
 
 /**

--- a/packages/core/src/worktree-shim.ts
+++ b/packages/core/src/worktree-shim.ts
@@ -146,8 +146,11 @@ export function createWorktree(opts: WorktreeCreateOptions, deps: WorktreeShimDe
         `[shim] core.bare flipped to true by: git worktree add ${worktreePath} (repo=${repoRoot}) — see #1330`,
       );
     }
-    if (ensureCoreBareUnset(repoRoot, (cmd) => deps.exec(cmd))) {
+    const addResult2 = ensureCoreBareUnset(repoRoot, (cmd) => deps.exec(cmd));
+    if (addResult2 === "removed") {
       deps.printInfo("Removed core.bare key after worktree add");
+    } else if (addResult2 === "fallback") {
+      deps.printError("[shim] core.bare key could not be removed after worktree add — set to false as fallback");
     }
     deps.printInfo(`Created worktree: ${worktreePath}`);
     return {
@@ -179,8 +182,11 @@ export function createWorktree(opts: WorktreeCreateOptions, deps: WorktreeShimDe
       `[shim] core.bare flipped to true by: git worktree add ${worktreePath} (repo=${repoRoot}) — see #1330`,
     );
   }
-  if (ensureCoreBareUnset(repoRoot, (cmd) => deps.exec(cmd))) {
+  const addResult4 = ensureCoreBareUnset(repoRoot, (cmd) => deps.exec(cmd));
+  if (addResult4 === "removed") {
     deps.printInfo("Removed core.bare key after worktree add");
+  } else if (addResult4 === "fallback") {
+    deps.printError("[shim] core.bare key could not be removed after worktree add — set to false as fallback");
   }
   deps.printInfo(`Created worktree: ${worktreePath}`);
   return {
@@ -282,8 +288,11 @@ function removeWorktreeWithVerification(
       `[shim] core.bare flipped to true by: git worktree remove ${worktreePath} (repo=${repoRoot}) — see #1330`,
     );
   }
-  if (ensureCoreBareUnset(repoRoot, (cmd) => deps.exec(cmd))) {
+  const removeResult1 = ensureCoreBareUnset(repoRoot, (cmd) => deps.exec(cmd));
+  if (removeResult1 === "removed") {
     deps.printInfo("Removed core.bare key after worktree removal");
+  } else if (removeResult1 === "fallback") {
+    deps.printError("[shim] core.bare key could not be removed after worktree removal — set to false as fallback");
   }
 
   // Verify: directory must actually be gone
@@ -315,8 +324,11 @@ function removeWorktreeWithVerification(
       `[shim] core.bare flipped to true by: git worktree remove --force ${worktreePath} (repo=${repoRoot}) — see #1330`,
     );
   }
-  if (ensureCoreBareUnset(repoRoot, (cmd) => deps.exec(cmd))) {
+  const removeResult2 = ensureCoreBareUnset(repoRoot, (cmd) => deps.exec(cmd));
+  if (removeResult2 === "removed") {
     deps.printInfo("Removed core.bare key after worktree removal");
+  } else if (removeResult2 === "fallback") {
+    deps.printError("[shim] core.bare key could not be removed after worktree removal — set to false as fallback");
   }
 
   if (!existsSync(worktreePath)) {
@@ -539,8 +551,13 @@ export async function pruneWorktrees(opts: WorktreePruneOptions): Promise<Worktr
   // Individual per-removal fixes can be undone by subsequent removals in the
   // same batch. This ensures the repo is in a valid state when we return. #1206
   if (pruned > 0) {
-    if (ensureCoreBareUnset(repoRoot, (cmd) => deps.exec(cmd))) {
+    const batchResult = ensureCoreBareUnset(repoRoot, (cmd) => deps.exec(cmd));
+    if (batchResult === "removed") {
       deps.printInfo("Removed core.bare key after batch worktree prune");
+    } else if (batchResult === "fallback") {
+      deps.printError(
+        "[shim] core.bare key could not be removed after batch worktree prune — set to false as fallback",
+      );
     }
   }
 

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -186,10 +186,15 @@ export function sweepCoreBare(
       else if (s.cwd) roots.add(s.cwd);
     }
     for (const root of roots) {
-      if (ensureCoreBareUnset(root, (cmd) => gitOps.exec(cmd))) {
+      const sweepResult = ensureCoreBareUnset(root, (cmd) => gitOps.exec(cmd));
+      if (sweepResult === "removed") {
         logger.warn(`[mcpd] Removed core.bare key from ${root} (sweep) — see #1860`);
         metrics.counter("mcpd_core_bare_healed_total", { source: "sweep" }).inc();
         healed++;
+      } else if (sweepResult === "fallback") {
+        logger.warn(
+          `[mcpd] core.bare key could not be removed from ${root} (sweep) — set to false as fallback — see #1860`,
+        );
       }
     }
   } catch (err) {
@@ -244,9 +249,12 @@ export function pruneOrphanedWorktrees(
             `[mcpd] core.bare flipped to true by: git worktree remove ${worktreePath} (repo=${repoRoot}) — see #1330`,
           );
         }
-        if (ensureCoreBareUnset(repoRoot, (cmd) => gitOps.exec(cmd))) {
+        const removeResult = ensureCoreBareUnset(repoRoot, (cmd) => gitOps.exec(cmd));
+        if (removeResult === "removed") {
           logger.warn("[mcpd] Removed core.bare key after worktree removal");
           metrics.counter("mcpd_core_bare_healed_total", { source: "worktree_remove" }).inc();
+        } else if (removeResult === "fallback") {
+          logger.warn("[mcpd] core.bare key could not be removed after worktree removal — set to false as fallback");
         }
         affectedRepoRoots.add(repoRoot);
         pruned++;
@@ -261,8 +269,11 @@ export function pruneOrphanedWorktrees(
               logger.warn(
                 `[mcpd] core.bare flipped to true by: git branch -d ${branch} (repo=${repoRoot}) — see #1330`,
               );
-              if (ensureCoreBareUnset(repoRoot, (cmd) => gitOps.exec(cmd))) {
+              const branchDeleteResult = ensureCoreBareUnset(repoRoot, (cmd) => gitOps.exec(cmd));
+              if (branchDeleteResult === "removed") {
                 metrics.counter("mcpd_core_bare_healed_total", { source: "branch_delete" }).inc();
+              } else if (branchDeleteResult === "fallback") {
+                logger.warn("[mcpd] core.bare key could not be removed after branch delete — set to false as fallback");
               }
             }
             logger.info(`[mcpd] Deleted branch: ${branch} (merged)`);
@@ -275,9 +286,14 @@ export function pruneOrphanedWorktrees(
       // Final guard: check core.bare after all removals complete. Individual
       // per-removal fixes can be undone by subsequent removals. #1206
       for (const root of affectedRepoRoots) {
-        if (ensureCoreBareUnset(root, (cmd) => gitOps.exec(cmd))) {
+        const batchResult = ensureCoreBareUnset(root, (cmd) => gitOps.exec(cmd));
+        if (batchResult === "removed") {
           logger.warn("[mcpd] Removed core.bare key after batch worktree prune");
           metrics.counter("mcpd_core_bare_healed_total", { source: "worktree_remove" }).inc();
+        } else if (batchResult === "fallback") {
+          logger.warn(
+            "[mcpd] core.bare key could not be removed after batch worktree prune — set to false as fallback",
+          );
         }
       }
       logger.info(`[mcpd] Pruned ${pruned} orphaned worktree${pruned === 1 ? "" : "s"}`);


### PR DESCRIPTION
## Summary
- Changed `ensureCoreBareUnset` return type from `boolean` to `"removed" | "absent" | "fallback"` (`CoreBareUnsetResult`)
- Updated all 9 call sites (4 in `daemon/src/index.ts`, 5 in `core/src/worktree-shim.ts`) to handle the three outcomes
- Metrics increment only on `"removed"` (genuine heal); `"fallback"` emits a warn log without incrementing the counter; `"absent"` is silently ignored

## Test plan
- [ ] `packages/core/src/git.spec.ts` — 6 tests updated to assert `"removed"`, `"absent"`, or `"fallback"` strings
- [ ] `packages/core/src/worktree-shim.spec.ts` — existing log assertions (`"Removed core.bare key after worktree add"`, `"batch worktree prune"`) still hold since mock exec returns exit 0 for `--unset` → `"removed"` path
- [ ] `packages/daemon/src/index.spec.ts` — counter tests unchanged; mock exec returns exit 0 → `"removed"` path, counters still increment
- [ ] `bun typecheck` — clean
- [ ] `bun lint` — clean (linter auto-fixed 2 files)
- [ ] `bun test` — 7035 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)