### PR TITLE
test(monitor): add --timeout integration test against never-resolving stream (closes #1565)

### DIFF
--- a/packages/command/src/commands/monitor.spec.ts
+++ b/packages/command/src/commands/monitor.spec.ts
@@ -581,6 +581,50 @@ describe("cmdMonitor", () => {
     expect(exitCalls).toEqual([0]);
   });
 
+  test("--timeout aborts never-resolving stream and exits 0", async () => {
+    let abortCalled = false;
+    let resolveStream: (() => void) | undefined;
+
+    async function* hangingStream(): AsyncGenerator<MonitorEvent> {
+      await new Promise<void>((resolve) => {
+        resolveStream = resolve;
+      });
+    }
+
+    const exitCalls: number[] = [];
+    let capturedTimerFn: (() => void) | undefined;
+
+    const deps: MonitorDeps = {
+      openEventStream: () => ({
+        events: hangingStream(),
+        abort: () => {
+          abortCalled = true;
+          resolveStream?.();
+        },
+      }),
+      isTTY: true,
+      writeStdout: () => {},
+      writeStderr: () => {},
+      exit: (code) => {
+        exitCalls.push(code);
+        return undefined as never;
+      },
+      onSigint: () => {},
+      onStdoutError: () => {},
+      createTimeout: (fn, _ms) => {
+        capturedTimerFn = fn;
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      },
+    };
+
+    const promise = cmdMonitor(["--timeout", "1"], deps);
+    capturedTimerFn?.();
+    await promise;
+
+    expect(abortCalled).toBe(true);
+    expect(exitCalls).toEqual([0]);
+  });
+
   test("non-EPIPE stdout errors do not trigger finish", async () => {
     let capturedErrHandler: ((err: Error) => void) | undefined;
     const exitCalls: number[] = [];

--- a/packages/command/src/commands/monitor.ts
+++ b/packages/command/src/commands/monitor.ts
@@ -36,6 +36,7 @@ export interface MonitorDeps {
   exit: (code: number) => never;
   onSigint: (fn: () => void) => void;
   onStdoutError: (fn: (err: Error) => void) => void;
+  createTimeout?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
 }
 
 const defaultDeps: MonitorDeps = {
@@ -240,7 +241,9 @@ export async function cmdMonitor(args: string[], deps?: Partial<MonitorDeps>): P
   };
 
   if (parsed.timeout !== undefined) {
-    timeoutId = setTimeout(() => finish(0), parsed.timeout * 1000);
+    timeoutId = (d.createTimeout ?? setTimeout)(() => finish(0), parsed.timeout * 1000) as ReturnType<
+      typeof setTimeout
+    >;
   }
 
   d.onSigint(() => finish(0));


### PR DESCRIPTION
## Summary
- Adds `createTimeout` optional dep to `MonitorDeps` so tests can synchronously fire the timeout callback without real timer waits
- New test in `describe("cmdMonitor")` verifies that `--timeout` on a never-resolving stream calls `abort()` and exits with code 0
- Production code uses `d.createTimeout ?? setTimeout` with a cast to keep the existing `timeoutId` type unchanged

## Test plan
- [x] New test `--timeout aborts never-resolving stream and exits 0` passes
- [x] All 44 tests in `monitor.spec.ts` pass
- [x] Full suite: 7036 pass, 0 fail
- [x] `bun typecheck` passes
- [x] `bun lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)