### PR TITLE
fix(sites): exclude failed bearer on 401 retry to avoid re-picking stale credential (fixes #1599)

### DIFF
--- a/packages/daemon/src/site/credentials.spec.ts
+++ b/packages/daemon/src/site/credentials.spec.ts
@@ -93,4 +93,27 @@ describe("CredentialVault", () => {
     const v = new CredentialVault();
     expect(v.pickCredentialFor("https://x", "GET", [], "demo")).toBeNull();
   });
+
+  test("pickCredentialFor excludes listed bearer tokens", () => {
+    const v = new CredentialVault();
+    const tokenA = makeJwt({ aud: "https://a.example/", iat: 100 });
+    const tokenB = makeJwt({ aud: "https://b.example/", iat: 200 });
+    v.noteRequest("demo", req("https://a.example/v1", "GET", tokenA));
+    v.noteRequest("demo", req("https://b.example/v1", "GET", tokenB));
+
+    // Without exclusion, b.example wins (higher iat).
+    expect(v.pickCredentialFor("https://target.example/v1", "GET", [], "demo")?.aud).toBe("https://b.example/");
+
+    // Excluding tokenB falls back to tokenA.
+    const pick = v.pickCredentialFor("https://target.example/v1", "GET", [], "demo", {
+      excludeBearers: [tokenB],
+    });
+    expect(pick?.aud).toBe("https://a.example/");
+
+    // Excluding both returns null.
+    const none = v.pickCredentialFor("https://target.example/v1", "GET", [], "demo", {
+      excludeBearers: [tokenA, tokenB],
+    });
+    expect(none).toBeNull();
+  });
 });

--- a/packages/daemon/src/site/credentials.ts
+++ b/packages/daemon/src/site/credentials.ts
@@ -103,8 +103,10 @@ export class CredentialVault {
     targetMethod = "GET",
     audHints: string[] = [],
     site?: string,
+    opts?: { excludeBearers?: string[] },
   ): Credential | null {
-    const all = this.getAll(site);
+    const excludedBearers = new Set(opts?.excludeBearers ?? []);
+    const all = this.getAll(site).filter((c) => !excludedBearers.has(c.bearer));
     if (all.length === 0) return null;
 
     let target: URL;

--- a/packages/daemon/src/site/proxy.spec.ts
+++ b/packages/daemon/src/site/proxy.spec.ts
@@ -32,8 +32,8 @@ describe("proxyCall", () => {
     vault.noteRequest("demo", authReq("https://a.example/v1", tokenA));
     vault.noteRequest("demo", authReq("https://b.example/v1", tokenB));
 
-    // First fetch returns 401. After onWiggle, ensure the vault picks a different aud;
-    // we do this by clearing the vault and re-noting only token B so the "fresh" credential differs.
+    // First fetch returns 401. onWiggle simulates a token refresh for B (new bearer, higher iat).
+    // After wiggle, re-pick must find the refreshed B (different bearer) and retry successfully.
     let call = 0;
     globalThis.fetch = mock(async () => {
       call += 1;
@@ -45,8 +45,10 @@ describe("proxyCall", () => {
     }) as unknown as typeof fetch;
 
     const onWiggle = async (): Promise<void> => {
+      // Simulate a token refresh: new bearer with higher iat.
+      const refreshedTokenB = makeJwt({ aud: "https://b.example/", iat: 300 });
       vault.clear("demo");
-      vault.noteRequest("demo", authReq("https://b.example/v1", tokenB));
+      vault.noteRequest("demo", authReq("https://b.example/v1", refreshedTokenB));
     };
 
     const resolved: ResolvedCall = {
@@ -97,6 +99,43 @@ describe("proxyCall", () => {
     // Injected bearer always wins over any callHeaders Authorization.
     expect(Object.keys(headerObj).filter((k) => k.toLowerCase() === "authorization")).toHaveLength(1);
     expect(headerObj.authorization).toBe(`Bearer ${cred.bearer}`);
+  });
+
+  test("401 retry excludes the failed bearer so it picks a different credential", async () => {
+    const vault = new CredentialVault();
+    // Two creds with matching aud hints — tie broken by iat, stale cred wins first.
+    // Without wiggle refreshing the stale token, re-pick must fall through to the other cred.
+    const staleToken = makeJwt({ aud: "https://stale.example/", iat: 200 });
+    const otherToken = makeJwt({ aud: "https://other.example/", iat: 100 });
+    vault.noteRequest("demo", authReq("https://stale.example/v1", staleToken));
+    vault.noteRequest("demo", authReq("https://other.example/v1", otherToken));
+
+    let call = 0;
+    globalThis.fetch = mock(async () => {
+      call += 1;
+      if (call === 1) return new Response("Unauthorized", { status: 401 });
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const resolved: ResolvedCall = {
+      url: "https://target.example/v1/resource",
+      method: "GET",
+      headers: {},
+      consumedParams: [],
+      residualParams: [],
+    };
+
+    // Both auds match the hints — stale wins by iat. No wiggle refresh, so stale bearer is excluded
+    // on retry and other.example is used instead.
+    const result = await proxyCall(vault, {
+      site: "demo",
+      resolved,
+      audHints: ["stale.example", "other.example"],
+    });
+
+    expect(result.status).toBe(200);
+    expect(result.usedAud).toBe("https://other.example/");
+    expect(call).toBe(2);
   });
 
   test("throws when no credentials exist", async () => {

--- a/packages/daemon/src/site/proxy.ts
+++ b/packages/daemon/src/site/proxy.ts
@@ -91,9 +91,10 @@ export async function proxyCall(vault: CredentialVault, opts: ProxyCallOptions):
     } catch {
       // Wiggle is advisory — don't fail the retry just because wiggle failed.
     }
+    const failedBearer = pick.bearer;
     const fresh = aud
-      ? (vault.getAll(site).find((c) => c.aud === aud) ?? null)
-      : vault.pickCredentialFor(resolved.url, resolved.method, audHints, site);
+      ? (vault.getAll(site).find((c) => c.aud === aud && c.bearer !== failedBearer) ?? null)
+      : vault.pickCredentialFor(resolved.url, resolved.method, audHints, site, { excludeBearers: [failedBearer] });
     if (fresh) {
       usedAud = fresh.aud;
       merged = mergeHeaders(fresh.headers, fresh.bearer, resolved.headers);


### PR DESCRIPTION
## Summary
- `proxy.ts`: track the bearer token that caused a 401 and pass it as `excludeBearers` to the re-pick, so a tied credential can't re-select the same dead token
- `credentials.ts`: extend `pickCredentialFor` with `opts?: { excludeBearers?: string[] }` — filters candidates before scoring
- If wiggle truly refreshes the failing aud (new bearer string), re-pick can still select it; exclusion only blocks the exact stale token

## Test plan
- `proxy.spec.ts`: new test verifies that when two auds tie on `audHints` scoring and the winner returns 401, the retry uses the other credential (different bearer) — confirms the stale-bearer exclusion path
- `proxy.spec.ts`: existing `usedAud` test updated — `onWiggle` now uses a genuinely refreshed token (`iat=300`) to confirm wiggle-refreshed creds can still be retried
- `credentials.spec.ts`: new test for `pickCredentialFor` with `excludeBearers` — verifies fallback, and that excluding all bearers returns null
- All 7037 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)