### PR TITLE
feat(phase): mcx phase advance --work-item (closes #1944)

### DIFF
--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -20,11 +20,14 @@ import {
   validateManifest,
 } from "@mcp-cli/core";
 import {
+  type AdvanceChainEntry,
+  type AdvanceResult,
   type PhaseInstallDeps,
   buildPhaseList,
   buildPhaseShow,
   checkStateSubset,
   cmdPhase,
+  cmdPhaseAdvance,
   detectDrift,
   executePhase,
   explainTransition,
@@ -32,6 +35,7 @@ import {
   formatDriftWarning,
   formatPhaseTable,
   formatTransitionLog,
+  parsePhaseAdvanceArgs,
   parsePhaseExecuteArgs,
   parsePhaseLogArgs,
   parsePhaseRunArgs,
@@ -2912,5 +2916,413 @@ describe("spawnExec (#1408)", () => {
   test("returns exitCode=1 for failing process", () => {
     const result = spawnExec(["false"]);
     expect(result.exitCode).toBe(1);
+  });
+});
+
+// ── parsePhaseAdvanceArgs ──────────────────────────────────────────────────
+
+describe("parsePhaseAdvanceArgs (#1944)", () => {
+  test("parses --work-item flag", () => {
+    expect(parsePhaseAdvanceArgs(["--work-item", "#42"])).toEqual({ workItemId: "#42" });
+  });
+
+  test("parses --work-item= form", () => {
+    expect(parsePhaseAdvanceArgs(["--work-item=#42"])).toEqual({ workItemId: "#42" });
+  });
+
+  test("throws when --work-item is missing", () => {
+    expect(() => parsePhaseAdvanceArgs([])).toThrow("Usage: mcx phase advance --work-item <id>");
+  });
+
+  test("throws when --work-item has no value", () => {
+    expect(() => parsePhaseAdvanceArgs(["--work-item"])).toThrow("--work-item requires an id");
+  });
+
+  test("throws on unknown flag", () => {
+    expect(() => parsePhaseAdvanceArgs(["--work-item", "#1", "--bogus"])).toThrow("unknown flag: --bogus");
+  });
+});
+
+// ── cmdPhaseAdvance integration ────────────────────────────────────────────
+
+describe("cmdPhaseAdvance — action-chain dispatch (#1944)", () => {
+  let advDir: string;
+
+  const advManifestYaml = `
+initial: impl
+phases:
+  impl:
+    source: ./impl.ts
+    next: [triage, qa, needs-attention]
+  triage:
+    source: ./triage.ts
+    next: [impl, qa, needs-attention]
+  qa:
+    source: ./qa.ts
+    next: [done, needs-attention]
+  needs-attention:
+    source: ./na.ts
+    next: [impl, done]
+  done:
+    source: ./done.ts
+    next: []
+`.trim();
+
+  const stubSource = (name: string) =>
+    `import { defineAlias, z } from "mcp-cli";\ndefineAlias(({ z }) => ({ name: ${JSON.stringify(name)}, description: "d", input: z.object({}).optional(), fn: async () => {} }));\n`;
+
+  beforeEach(async () => {
+    out = [];
+    err = [];
+    advDir = mkdtempSync(join(tmpdir(), "mcx-advance-"));
+    writeFileSync(join(advDir, ".mcx.yaml"), advManifestYaml);
+    for (const [file, name] of [
+      ["impl.ts", "impl"],
+      ["triage.ts", "triage"],
+      ["qa.ts", "qa"],
+      ["na.ts", "needs-attention"],
+      ["done.ts", "done"],
+    ] as [string, string][]) {
+      writeFileSync(join(advDir, file), stubSource(name));
+    }
+    const { deps } = makeDriftDeps(advDir);
+    await cmdPhase(["install"], deps);
+  });
+
+  afterEach(() => {
+    rmSync(advDir, { recursive: true, force: true });
+  });
+
+  function makeWorkItem(phase: string) {
+    return {
+      id: "#42",
+      issueNumber: 42,
+      prNumber: null,
+      branch: "feat/42",
+      prState: null,
+      prUrl: null,
+      ciStatus: "none",
+      ciRunId: null,
+      ciSummary: null,
+      reviewStatus: "pending",
+      phase,
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+    };
+  }
+
+  function makeExecDeps(
+    actionOutputs: Record<string, unknown>[],
+    opts: {
+      spawnOutput?: string;
+      spawnExitCode?: number;
+      stateSetIsError?: boolean;
+      stateSetThrows?: boolean;
+      workItemPhase?: string;
+    } = {},
+  ) {
+    const {
+      spawnOutput = JSON.stringify({ sessionId: "session-abc12345-xyz" }),
+      spawnExitCode = 0,
+      stateSetIsError = false,
+      stateSetThrows = false,
+      workItemPhase = "impl",
+    } = opts;
+
+    let callIdx = 0;
+    const outputs = actionOutputs;
+
+    return {
+      deps: {
+        cwd: () => advDir,
+        log: (m: string) => out.push(m),
+        logError: (m: string) => err.push(m),
+        exit: (code: number): never => {
+          throw new ExitCapture(code);
+        },
+        executeAliasBundled: async () => {
+          const output = outputs[callIdx++] ?? { action: "wait" };
+          return output;
+        },
+      } as Partial<PhaseInstallDeps>,
+      execDeps: {
+        ipcCall: (async (method: string, params?: unknown) => {
+          const p = params as Record<string, unknown> | undefined;
+          if (method === "getWorkItem") return makeWorkItem(workItemPhase);
+          if (method === "callTool" && (p as { tool?: string } | undefined)?.tool === "phase_state_set") {
+            if (stateSetThrows) throw new Error("state_set network error");
+            return stateSetIsError ? { isError: true, content: ["failed"] } : { content: [] };
+          }
+          return null;
+        }) as unknown as typeof import("@mcp-cli/core").ipcCall,
+        exec: (cmd: string[]) => {
+          if (cmd.includes("--is-inside-work-tree")) return { stdout: "true\n", exitCode: 0 };
+          if (cmd.includes("symbolic-ref")) return { stdout: "main\n", exitCode: 0 };
+          if (cmd.includes("--is-bare-repository")) return { stdout: "false\n", exitCode: 0 };
+          // Spawn command (mcx claude spawn ...)
+          return { stdout: spawnOutput, exitCode: spawnExitCode };
+        },
+        findGitRoot: () => advDir,
+        now: () => new Date(),
+        readCliConfig: () => ({}),
+      },
+    };
+  }
+
+  class ExitCapture extends Error {
+    constructor(public readonly code: number) {
+      super(`exit(${code})`);
+    }
+  }
+
+  let out: string[];
+  let err: string[];
+
+  async function runAdvance(
+    workItemId: string,
+    actionOutputs: Record<string, unknown>[],
+    advOpts: Parameters<typeof makeExecDeps>[1] = {},
+  ): Promise<{ out: string[]; err: string[]; exitCode: number | null }> {
+    const { deps, execDeps } = makeExecDeps(actionOutputs, advOpts);
+    let exitCode: number | null = null;
+    await cmdPhaseAdvance(["--work-item", workItemId], deps, execDeps).catch((e) => {
+      if (e instanceof ExitCapture) exitCode = e.code;
+      else throw e;
+    });
+    return { out, err, exitCode };
+  }
+
+  test("wait action — exits 0 and prints chain JSON", async () => {
+    const { out: o, err: e, exitCode } = await runAdvance("#42", [{ action: "wait" }]);
+    expect(exitCode).toBeNull();
+    const result = JSON.parse(o[0]) as AdvanceResult;
+    expect(result.workItemId).toBe("#42");
+    expect(result.chain).toHaveLength(1);
+    expect(result.chain[0]).toEqual({ phase: "impl", action: "wait" });
+    expect(result.final.action).toBe("wait");
+    expect(e.some((l) => l.includes("wait"))).toBe(true);
+  });
+
+  test("in-flight action — exits 0 and includes sessionId", async () => {
+    const { out: o, exitCode } = await runAdvance("#42", [
+      { action: "in-flight", sessionId: "existing-session-id-xyz" },
+    ]);
+    expect(exitCode).toBeNull();
+    const result = JSON.parse(o[0]) as AdvanceResult;
+    expect(result.final.action).toBe("in-flight");
+    expect(result.final.sessionId).toBe("existing-session-id-xyz");
+  });
+
+  test("in-flight without sessionId — exits 0", async () => {
+    const { out: o, exitCode } = await runAdvance("#42", [{ action: "in-flight" }]);
+    expect(exitCode).toBeNull();
+    const result = JSON.parse(o[0]) as AdvanceResult;
+    expect(result.final.action).toBe("in-flight");
+    expect(result.final.sessionId).toBeUndefined();
+  });
+
+  test("goto then wait — chain of 2", async () => {
+    const {
+      out: o,
+      err: e,
+      exitCode,
+    } = await runAdvance("#42", [{ action: "goto", target: "triage" }, { action: "wait" }], { workItemPhase: "impl" });
+    expect(exitCode).toBeNull();
+    const result = JSON.parse(o[0]) as AdvanceResult;
+    expect(result.chain).toHaveLength(2);
+    expect(result.chain[0]).toEqual({ phase: "impl", action: "goto", target: "triage" });
+    expect(result.chain[1]).toEqual({ phase: "triage", action: "wait" });
+    expect(result.final.phase).toBe("triage");
+    expect(e.some((l) => l.includes("impl → triage (goto)"))).toBe(true);
+  });
+
+  test("goto then spawn — records sessionId via state_set", async () => {
+    const spawnOutput = JSON.stringify({ sessionId: "new-session-uuid-12345678" });
+    const {
+      out: o,
+      err: e,
+      exitCode,
+    } = await runAdvance(
+      "#42",
+      [
+        { action: "goto", target: "qa" },
+        { action: "spawn", command: ["mcx", "claude", "spawn", "--task", "run qa"] },
+      ],
+      { workItemPhase: "impl", spawnOutput },
+    );
+    expect(exitCode).toBeNull();
+    const result = JSON.parse(o[0]) as AdvanceResult;
+    expect(result.chain).toHaveLength(2);
+    expect(result.chain[1].action).toBe("spawn");
+    expect(result.chain[1].sessionId).toBe("new-session-uuid-12345678");
+    expect(result.final.phase).toBe("qa");
+    expect(e.some((l) => l.includes("qa: spawned"))).toBe(true);
+  });
+
+  test("spawn on impl — state key is session_id (not impl_session_id)", async () => {
+    let capturedKey: string | undefined;
+    const { deps, execDeps } = makeExecDeps([
+      { action: "spawn", command: ["mcx", "claude", "spawn", "--task", "run impl"] },
+    ]);
+    const origIpc = execDeps.ipcCall;
+    execDeps.ipcCall = (async (method: string, params?: unknown) => {
+      const p = params as { tool?: string; arguments?: { key?: string } } | undefined;
+      if (method === "callTool" && p?.tool === "phase_state_set") {
+        capturedKey = p.arguments?.key;
+      }
+      return (origIpc as (m: string, p?: unknown) => Promise<unknown>)(method, params);
+    }) as unknown as typeof import("@mcp-cli/core").ipcCall;
+    await cmdPhaseAdvance(["--work-item", "#42"], deps, execDeps).catch(() => {});
+    expect(capturedKey).toBe("session_id");
+  });
+
+  test("spawn on qa — state key is qa_session_id", async () => {
+    // Prime the log so impl→qa is committed, allowing qa self-loop (idempotent re-entry).
+    appendTransitionLog(transitionLogPath(advDir), {
+      ts: "2026-01-01T00:00:00Z",
+      workItemId: "#42",
+      from: null,
+      to: "impl",
+      status: "committed",
+    });
+    appendTransitionLog(transitionLogPath(advDir), {
+      ts: "2026-01-01T00:00:01Z",
+      workItemId: "#42",
+      from: "impl",
+      to: "qa",
+      status: "committed",
+    });
+    let capturedKey: string | undefined;
+    const { deps, execDeps } = makeExecDeps(
+      [{ action: "spawn", command: ["mcx", "claude", "spawn", "--task", "run qa"] }],
+      { workItemPhase: "qa" },
+    );
+    const origIpc = execDeps.ipcCall;
+    execDeps.ipcCall = (async (method: string, params?: unknown) => {
+      const p = params as { tool?: string; arguments?: { key?: string } } | undefined;
+      if (method === "callTool" && p?.tool === "phase_state_set") {
+        capturedKey = p.arguments?.key;
+      }
+      return (origIpc as (m: string, p?: unknown) => Promise<unknown>)(method, params);
+    }) as unknown as typeof import("@mcp-cli/core").ipcCall;
+    await cmdPhaseAdvance(["--work-item", "#42"], deps, execDeps).catch(() => {});
+    expect(capturedKey).toBe("qa_session_id");
+  });
+
+  test("phase can override state key via stateKey field", async () => {
+    let capturedKey: string | undefined;
+    const { deps, execDeps } = makeExecDeps([
+      { action: "spawn", command: ["mcx", "claude", "spawn", "--task", "run impl"], stateKey: "custom_key" },
+    ]);
+    const origIpc = execDeps.ipcCall;
+    execDeps.ipcCall = (async (method: string, params?: unknown) => {
+      const p = params as { tool?: string; arguments?: { key?: string } } | undefined;
+      if (method === "callTool" && p?.tool === "phase_state_set") {
+        capturedKey = p.arguments?.key;
+      }
+      return (origIpc as (m: string, p?: unknown) => Promise<unknown>)(method, params);
+    }) as unknown as typeof import("@mcp-cli/core").ipcCall;
+    await cmdPhaseAdvance(["--work-item", "#42"], deps, execDeps).catch(() => {});
+    expect(capturedKey).toBe("custom_key");
+  });
+
+  test("spawn fails — exits non-zero, no phase_state_set called", async () => {
+    let stateSetCalled = false;
+    const { deps, execDeps } = makeExecDeps(
+      [{ action: "spawn", command: ["mcx", "claude", "spawn", "--task", "fail"] }],
+      { spawnExitCode: 1, spawnOutput: "connection refused" },
+    );
+    const origIpc = execDeps.ipcCall;
+    execDeps.ipcCall = (async (method: string, params?: unknown) => {
+      const p = params as { tool?: string } | undefined;
+      if (method === "callTool" && p?.tool === "phase_state_set") {
+        stateSetCalled = true;
+      }
+      return (origIpc as (m: string, p?: unknown) => Promise<unknown>)(method, params);
+    }) as unknown as typeof import("@mcp-cli/core").ipcCall;
+    let exitCode: number | null = null;
+    await cmdPhaseAdvance(["--work-item", "#42"], deps, execDeps).catch((e) => {
+      if (e instanceof ExitCapture) exitCode = e.code;
+      else throw e;
+    });
+    expect(exitCode).not.toBe(null);
+    expect(exitCode).not.toBe(0);
+    expect(stateSetCalled).toBe(false);
+  });
+
+  test("spawn succeeds but phase_state_set fails — exits non-zero, sessionId in stderr", async () => {
+    const {
+      out: o,
+      err: e,
+      exitCode,
+    } = await runAdvance("#42", [{ action: "spawn", command: ["mcx", "claude", "spawn", "--task", "run impl"] }], {
+      stateSetIsError: true,
+    });
+    expect(exitCode).not.toBe(null);
+    expect(exitCode).not.toBe(0);
+    // sessionId must be visible in stderr for manual recovery
+    expect(e.some((l) => l.includes("session-abc12345-xyz"))).toBe(true);
+    expect(e.some((l) => l.includes("CRITICAL"))).toBe(true);
+  });
+
+  test("phase_state_set throws — exits non-zero, sessionId in stderr", async () => {
+    const { err: e, exitCode } = await runAdvance(
+      "#42",
+      [{ action: "spawn", command: ["mcx", "claude", "spawn", "--task", "run impl"] }],
+      { stateSetThrows: true },
+    );
+    expect(exitCode).not.toBe(null);
+    expect(exitCode).not.toBe(0);
+    expect(e.some((l) => l.includes("session-abc12345-xyz"))).toBe(true);
+  });
+
+  test("unknown action — exits non-zero with informative message", async () => {
+    const { err: e, exitCode } = await runAdvance("#42", [{ action: "reboot" }]);
+    expect(exitCode).not.toBe(null);
+    expect(exitCode).not.toBe(0);
+    expect(e.some((l) => l.includes("unknown action") && l.includes("reboot"))).toBe(true);
+  });
+
+  test("cycle — 8 iterations triggers cap, exits 2", async () => {
+    // A→B→A→B... cycle: alternating goto, never settles
+    const cycleOutputs = Array.from({ length: 10 }, (_, i) =>
+      i % 2 === 0 ? { action: "goto", target: "triage" } : { action: "goto", target: "impl" },
+    );
+    const { err: e, exitCode } = await runAdvance("#42", cycleOutputs, { workItemPhase: "impl" });
+    expect(exitCode).toBe(2);
+    expect(e.some((l) => l.includes("cap hit"))).toBe(true);
+  });
+
+  test("missing --work-item — exits 1 with usage message", async () => {
+    const { err: e, exitCode } = await runAdvance("", [], {});
+    // The advance fn is called with no args in this case - test direct
+    const errs: string[] = [];
+    let code: number | null = null;
+    await cmdPhaseAdvance(
+      [],
+      {
+        cwd: () => advDir,
+        log: () => {},
+        logError: (m) => errs.push(m),
+        exit: (c): never => {
+          code = c;
+          throw new ExitCapture(c);
+        },
+      },
+      {
+        ipcCall: (async (_method: string) => null) as unknown as typeof import("@mcp-cli/core").ipcCall,
+        exec: () => ({ stdout: "", exitCode: 0 }),
+        findGitRoot: () => advDir,
+        now: () => new Date(),
+        readCliConfig: () => ({}),
+      },
+    ).catch(() => {});
+    expect(code as unknown as number).toBe(1);
+    expect(errs.some((m) => m.includes("Usage"))).toBe(true);
+  });
+
+  test("help text includes advance subcommand", async () => {
+    const { out: o } = await catchExit(() => cmdPhase(["--help"]));
+    expect(o).toContain("advance");
   });
 });

--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -3212,7 +3212,7 @@ phases:
   test("phase can override state key via stateKey field", async () => {
     let capturedKey: string | undefined;
     const { deps, execDeps } = makeExecDeps([
-      { action: "spawn", command: ["mcx", "claude", "spawn", "--task", "run impl"], stateKey: "custom_key" },
+      { action: "spawn", command: ["mcx", "claude", "spawn", "--task", "run impl"], stateKey: "custom_session_id" },
     ]);
     const origIpc = execDeps.ipcCall;
     execDeps.ipcCall = (async (method: string, params?: unknown) => {
@@ -3223,7 +3223,7 @@ phases:
       return (origIpc as (m: string, p?: unknown) => Promise<unknown>)(method, params);
     }) as unknown as typeof import("@mcp-cli/core").ipcCall;
     await cmdPhaseAdvance(["--work-item", "#42"], deps, execDeps).catch(() => {});
-    expect(capturedKey).toBe("custom_key");
+    expect(capturedKey).toBe("custom_session_id");
   });
 
   test("spawn fails — exits non-zero, no phase_state_set called", async () => {
@@ -3324,5 +3324,88 @@ phases:
   test("help text includes advance subcommand", async () => {
     const { out: o } = await catchExit(() => cmdPhase(["--help"]));
     expect(o).toContain("advance");
+  });
+
+  test("goto without target — exits non-zero with informative message", async () => {
+    const { err: e, exitCode } = await runAdvance("#42", [{ action: "goto" }]);
+    expect(exitCode).not.toBe(null);
+    expect(exitCode).not.toBe(0);
+    expect(e.some((l) => l.includes("goto") && l.includes("without a target"))).toBe(true);
+  });
+
+  test("goto to self — exits non-zero with handler-bug message", async () => {
+    const { err: e, exitCode } = await runAdvance("#42", [{ action: "goto", target: "impl" }]);
+    expect(exitCode).not.toBe(null);
+    expect(exitCode).not.toBe(0);
+    expect(e.some((l) => l.includes("goto-to-self"))).toBe(true);
+  });
+
+  test("spawn with empty command array — exits non-zero", async () => {
+    const { err: e, exitCode } = await runAdvance("#42", [{ action: "spawn", command: [] }]);
+    expect(exitCode).not.toBe(null);
+    expect(exitCode).not.toBe(0);
+    expect(e.some((l) => l.includes("without a command"))).toBe(true);
+  });
+
+  test("spawn with non-mcx command root — exits non-zero", async () => {
+    const { err: e, exitCode } = await runAdvance("#42", [{ action: "spawn", command: ["bash", "-c", "echo bad"] }]);
+    expect(exitCode).not.toBe(null);
+    expect(exitCode).not.toBe(0);
+    expect(e.some((l) => l.includes("bash") && l.includes("only"))).toBe(true);
+  });
+
+  test("in-flight with pending sentinel — exits non-zero with orphan warning", async () => {
+    const { err: e, exitCode } = await runAdvance("#42", [{ action: "in-flight", sessionId: "pending:1716000000000" }]);
+    expect(exitCode).not.toBe(null);
+    expect(exitCode).not.toBe(0);
+    expect(e.some((l) => l.includes("pending:") && l.includes("orphan"))).toBe(true);
+  });
+
+  test("stateKey with forbidden pattern — exits non-zero", async () => {
+    const { err: e, exitCode } = await runAdvance("#42", [
+      { action: "spawn", command: ["mcx", "claude", "spawn", "--task", "x"], stateKey: "branch" },
+    ]);
+    expect(exitCode).not.toBe(null);
+    expect(exitCode).not.toBe(0);
+    expect(e.some((l) => l.includes("stateKey") && l.includes("branch"))).toBe(true);
+  });
+
+  test("spawn success echoes sessionId to stderr before phase_state_set", async () => {
+    const events: Array<{ type: "log" | "state_set" }> = [];
+    const { deps, execDeps } = makeExecDeps([
+      { action: "spawn", command: ["mcx", "claude", "spawn", "--task", "run impl"] },
+    ]);
+    const origIpc = execDeps.ipcCall;
+    execDeps.ipcCall = (async (method: string, params?: unknown) => {
+      const p = params as { tool?: string } | undefined;
+      if (method === "callTool" && p?.tool === "phase_state_set") {
+        events.push({ type: "state_set" });
+      }
+      return (origIpc as (m: string, p?: unknown) => Promise<unknown>)(method, params);
+    }) as unknown as typeof import("@mcp-cli/core").ipcCall;
+    await cmdPhaseAdvance(
+      ["--work-item", "#42"],
+      {
+        ...deps,
+        logError: (m) => {
+          if (m.includes("session-abc12345-xyz")) events.push({ type: "log" });
+        },
+      },
+      execDeps,
+    ).catch(() => {});
+    const logIdx = events.findIndex((e) => e.type === "log");
+    const stateSetIdx = events.findIndex((e) => e.type === "state_set");
+    expect(logIdx).not.toBe(-1);
+    expect(stateSetIdx).not.toBe(-1);
+    expect(logIdx).toBeLessThan(stateSetIdx);
+  });
+
+  test("cap hit — error message names stranded phase", async () => {
+    const cycleOutputs = Array.from({ length: 10 }, (_, i) =>
+      i % 2 === 0 ? { action: "goto", target: "triage" } : { action: "goto", target: "impl" },
+    );
+    const { err: e, exitCode } = await runAdvance("#42", cycleOutputs, { workItemPhase: "impl" });
+    expect(exitCode).toBe(2);
+    expect(e.some((l) => l.includes("stranded"))).toBe(true);
   });
 });

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -711,6 +711,11 @@ export async function cmdPhase(
       return;
     }
 
+    if (sub === "advance") {
+      await cmdPhaseAdvance(args.slice(1), d, execDeps);
+      return;
+    }
+
     if (sub === "run") {
       const argv = args.slice(1);
       assertNoDrift(d);
@@ -1350,6 +1355,225 @@ export async function executePhase(
   }
 }
 
+// ── phase advance ──────────────────────────────────────────────────────────
+
+export function parsePhaseAdvanceArgs(args: string[]): { workItemId: string } {
+  let workItemId: string | null = null;
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--work-item") {
+      workItemId = args[++i] ?? null;
+      if (!workItemId) throw new Error("--work-item requires an id");
+    } else if (a.startsWith("--work-item=")) {
+      workItemId = a.slice("--work-item=".length);
+      if (!workItemId) throw new Error("--work-item requires an id");
+    } else {
+      throw new Error(`unknown flag: ${a}`);
+    }
+  }
+  if (!workItemId) throw new Error("Usage: mcx phase advance --work-item <id>");
+  return { workItemId };
+}
+
+export interface AdvanceChainEntry {
+  phase: string;
+  action: string;
+  target?: string;
+  sessionId?: string;
+}
+
+export interface AdvanceResult {
+  workItemId: string;
+  chain: AdvanceChainEntry[];
+  final: AdvanceChainEntry;
+}
+
+const ADVANCE_MAX_ITERATIONS = 8;
+
+class PhaseAdvanceExitError extends Error {
+  constructor(public readonly code: number) {
+    super(`phase exited with code ${code}`);
+  }
+}
+
+export async function cmdPhaseAdvance(
+  args: string[],
+  deps: Partial<PhaseInstallDeps>,
+  execDeps?: Partial<PhaseExecuteDeps>,
+): Promise<void> {
+  const d: PhaseInstallDeps = { ...defaultDeps, ...deps };
+  const ex: PhaseExecuteDeps = { ...defaultExecuteDeps, ...execDeps };
+
+  let opts: { workItemId: string };
+  try {
+    opts = parsePhaseAdvanceArgs(args);
+  } catch (err) {
+    d.logError(err instanceof Error ? err.message : String(err));
+    d.exit(1);
+  }
+
+  let workItem: WorkItem;
+  try {
+    const wi = (await ex.ipcCall("getWorkItem", { id: opts.workItemId })) as WorkItem | null;
+    if (!wi) {
+      d.logError(`work item "${opts.workItemId}" not found`);
+      d.exit(1);
+    }
+    workItem = wi;
+  } catch (err) {
+    d.logError(`failed to fetch work item "${opts.workItemId}": ${err instanceof Error ? err.message : String(err)}`);
+    d.exit(1);
+  }
+
+  assertNoDrift(d);
+
+  const chain: AdvanceChainEntry[] = [];
+  let currentPhase: string = workItem.phase;
+
+  for (let i = 0; i < ADVANCE_MAX_ITERATIONS; i++) {
+    let capturedOutput: string | null = null;
+
+    const captureDeps: Partial<PhaseInstallDeps> = {
+      ...deps,
+      log: (msg: string) => {
+        capturedOutput = msg;
+      },
+      exit: (code: number): never => {
+        throw new PhaseAdvanceExitError(code);
+      },
+    };
+
+    try {
+      await executePhase([currentPhase, "--work-item", opts.workItemId], captureDeps, execDeps);
+    } catch (err) {
+      if (err instanceof PhaseAdvanceExitError) {
+        d.logError(`phase "${currentPhase}" failed (exit ${err.code})`);
+        d.exit(err.code);
+      }
+      throw err;
+    }
+
+    let output: Record<string, unknown>;
+    try {
+      output = capturedOutput ? (JSON.parse(capturedOutput) as Record<string, unknown>) : {};
+    } catch {
+      d.logError(`phase "${currentPhase}" returned non-JSON output: ${capturedOutput}`);
+      d.exit(1);
+    }
+
+    const action = output.action as string | undefined;
+
+    if (action === "wait") {
+      const entry: AdvanceChainEntry = { phase: currentPhase, action: "wait" };
+      chain.push(entry);
+      d.logError(`${currentPhase}: wait`);
+      const result: AdvanceResult = { workItemId: opts.workItemId, chain, final: entry };
+      d.log(JSON.stringify(result, null, 2));
+      return;
+    }
+
+    if (action === "in-flight") {
+      const sessionId = output.sessionId as string | undefined;
+      const entry: AdvanceChainEntry = {
+        phase: currentPhase,
+        action: "in-flight",
+        ...(sessionId && { sessionId }),
+      };
+      chain.push(entry);
+      d.logError(`${currentPhase}: in-flight${sessionId ? ` (${sessionId.slice(0, 8)})` : ""}`);
+      const result: AdvanceResult = { workItemId: opts.workItemId, chain, final: entry };
+      d.log(JSON.stringify(result, null, 2));
+      return;
+    }
+
+    if (action === "goto") {
+      const target = output.target as string | undefined;
+      if (!target) {
+        d.logError(`phase "${currentPhase}" returned "goto" without a target`);
+        d.exit(1);
+      }
+      const entry: AdvanceChainEntry = { phase: currentPhase, action: "goto", target };
+      chain.push(entry);
+      d.logError(`${currentPhase} → ${target} (goto)`);
+      currentPhase = target;
+      continue;
+    }
+
+    if (action === "spawn") {
+      const command = output.command as string[] | undefined;
+      if (!command || !Array.isArray(command) || command.length === 0) {
+        d.logError(`phase "${currentPhase}" returned "spawn" without a command`);
+        d.exit(1);
+      }
+
+      const spawnResult = ex.exec(command);
+      if (spawnResult.exitCode !== 0) {
+        d.logError(`spawn command failed (exit ${spawnResult.exitCode ?? "signal"}): ${spawnResult.stdout.trim()}`);
+        d.exit(spawnResult.exitCode !== null ? spawnResult.exitCode : 1);
+      }
+
+      let sessionId: string;
+      try {
+        const parsed = JSON.parse(spawnResult.stdout.trim()) as { sessionId?: string };
+        if (!parsed.sessionId) throw new Error("no sessionId in output");
+        sessionId = parsed.sessionId;
+      } catch {
+        d.logError(`failed to parse sessionId from spawn output: ${spawnResult.stdout.trim()}`);
+        d.exit(1);
+      }
+
+      const stateKey =
+        (output.stateKey as string | undefined) ??
+        (currentPhase === "impl" ? "session_id" : `${currentPhase}_session_id`);
+
+      const repoRoot = ex.findGitRoot(d.cwd()) ?? d.cwd();
+      try {
+        const setResult = (await ex.ipcCall("callTool", {
+          server: "_work_items",
+          tool: "phase_state_set",
+          arguments: { workItemId: opts.workItemId, key: stateKey, value: sessionId, repoRoot },
+        })) as { isError?: boolean; content?: unknown } | null;
+
+        if (setResult?.isError) {
+          d.logError(
+            `CRITICAL: spawn succeeded (sessionId=${sessionId}) but phase_state_set failed: ${JSON.stringify(setResult.content ?? setResult)}`,
+          );
+          d.logError(
+            `To recover: mcx call _work_items phase_state_set '{"workItemId":"${opts.workItemId}","key":"${stateKey}","value":"${sessionId}","repoRoot":"${repoRoot}"}'`,
+          );
+          d.exit(1);
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        d.logError(`CRITICAL: spawn succeeded (sessionId=${sessionId}) but phase_state_set failed: ${msg}`);
+        d.logError(
+          `To recover: mcx call _work_items phase_state_set '{"workItemId":"${opts.workItemId}","key":"${stateKey}","value":"${sessionId}","repoRoot":"${repoRoot}"}'`,
+        );
+        d.exit(1);
+      }
+
+      const entry: AdvanceChainEntry = { phase: currentPhase, action: "spawn", sessionId };
+      chain.push(entry);
+      d.logError(`${currentPhase}: spawned ${sessionId.slice(0, 8)}`);
+      const result: AdvanceResult = { workItemId: opts.workItemId, chain, final: entry };
+      d.log(JSON.stringify(result, null, 2));
+      return;
+    }
+
+    d.logError(
+      `phase "${currentPhase}" returned unknown action: "${action ?? "(none)"}". Expected: wait, in-flight, goto, spawn`,
+    );
+    d.exit(1);
+  }
+
+  // Hard cap hit — dump the chain to stderr for debugging
+  const chainStr = chain.map((e) => `${e.phase}(${e.action}${e.target ? `→${e.target}` : ""})`).join(" | ");
+  d.logError(
+    `phase advance cap hit (${ADVANCE_MAX_ITERATIONS} iterations): possible cycle in phase graph\nchain: ${chainStr}`,
+  );
+  d.exit(2);
+}
+
 function printPhaseHelp(d: PhaseInstallDeps): void {
   d.log(`mcx phase — orchestration phase graph
 
@@ -1387,6 +1611,12 @@ Subcommands:
 
   mcx phase why <from> <to> [--json]
       Explain whether a transition is legal, via direct edge or shortest path.
+
+  mcx phase advance --work-item <id>
+      Run the work item's current phase, follow action chain (goto / spawn),
+      and stop at the first wait / in-flight. Single command replaces the
+      5-step orchestrator sequence of phase run + update + spawn + state_set.
+      Exits 0 on wait/in-flight/spawn; exits 2 on cycle cap (8 iterations).
 
   mcx phase log [--work-item <id>] [--forced-only] [--json]
       Print transitions from .mcx/transitions.jsonl, newest first.

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -1489,7 +1489,7 @@ export async function cmdPhaseAdvance(
     }
 
     if (action === "in-flight") {
-      const sessionId = output.sessionId as string | undefined;
+      const sessionId = typeof output.sessionId === "string" ? output.sessionId : undefined;
       // A pending:* sentinel means the phase handler wrote its spawn marker but
       // the orchestrator never replaced it with a real session ID (phase_state_set
       // failed on a prior run). The session may be running as an orphan.
@@ -1512,7 +1512,7 @@ export async function cmdPhaseAdvance(
     }
 
     if (action === "goto") {
-      const target = output.target as string | undefined;
+      const target = typeof output.target === "string" ? output.target : undefined;
       if (!target) {
         d.logError(`phase "${currentPhase}" returned "goto" without a target`);
         d.exit(1);
@@ -1531,7 +1531,7 @@ export async function cmdPhaseAdvance(
     }
 
     if (action === "spawn") {
-      const command = output.command as string[] | undefined;
+      const command = Array.isArray(output.command) ? (output.command as string[]) : undefined;
       if (!command || !Array.isArray(command) || command.length === 0) {
         d.logError(`phase "${currentPhase}" returned "spawn" without a command`);
         d.exit(1);
@@ -1543,7 +1543,7 @@ export async function cmdPhaseAdvance(
         d.exit(1);
       }
 
-      const rawStateKey = output.stateKey as string | undefined;
+      const rawStateKey = typeof output.stateKey === "string" ? output.stateKey : undefined;
       const derivedStateKey = currentPhase === "impl" ? "session_id" : `${currentPhase}_session_id`;
       const stateKey = rawStateKey ?? derivedStateKey;
       const stateKeyPattern = /^([a-z][a-z0-9]*_)?session_id$/;
@@ -1562,8 +1562,8 @@ export async function cmdPhaseAdvance(
 
       let sessionId: string;
       try {
-        const parsed = JSON.parse(spawnResult.stdout.trim()) as { sessionId?: string };
-        if (!parsed.sessionId) throw new Error("no sessionId in output");
+        const parsed = JSON.parse(spawnResult.stdout.trim()) as Record<string, unknown>;
+        if (typeof parsed.sessionId !== "string" || !parsed.sessionId) throw new Error("no sessionId in output");
         sessionId = parsed.sessionId;
       } catch {
         d.logError(`failed to parse sessionId from spawn output: ${spawnResult.stdout.trim()}`);

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -1425,18 +1425,21 @@ export async function cmdPhaseAdvance(
     d.exit(1);
   }
 
-  assertNoDrift(d);
-
   const chain: AdvanceChainEntry[] = [];
   let currentPhase: string = workItem.phase;
 
   for (let i = 0; i < ADVANCE_MAX_ITERATIONS; i++) {
-    let capturedOutput: string | null = null;
+    // Re-check drift on every iteration: a phase handler has full shell/MCP
+    // access and could trigger `phase install`, invalidating the lockfile
+    // before the next executePhase call.
+    assertNoDrift(d);
+
+    const logCaptures: string[] = [];
 
     const captureDeps: Partial<PhaseInstallDeps> = {
       ...deps,
       log: (msg: string) => {
-        capturedOutput = msg;
+        logCaptures.push(msg);
       },
       exit: (code: number): never => {
         throw new PhaseAdvanceExitError(code);
@@ -1451,6 +1454,19 @@ export async function cmdPhaseAdvance(
         d.exit(err.code);
       }
       throw err;
+    }
+
+    // Use the last log call that parses as JSON — guards against any future
+    // preamble logs being added to executePhase without breaking capture.
+    let capturedOutput: string | null = null;
+    for (let j = logCaptures.length - 1; j >= 0; j--) {
+      try {
+        JSON.parse(logCaptures[j]);
+        capturedOutput = logCaptures[j];
+        break;
+      } catch {
+        // not JSON, keep scanning backwards
+      }
     }
 
     let output: Record<string, unknown>;
@@ -1474,6 +1490,15 @@ export async function cmdPhaseAdvance(
 
     if (action === "in-flight") {
       const sessionId = output.sessionId as string | undefined;
+      // A pending:* sentinel means the phase handler wrote its spawn marker but
+      // the orchestrator never replaced it with a real session ID (phase_state_set
+      // failed on a prior run). The session may be running as an orphan.
+      if (sessionId?.startsWith("pending:")) {
+        d.logError(
+          `phase "${currentPhase}" returned in-flight with a pending sentinel (${sessionId}) — a previous spawn may have succeeded but the session ID was not recorded. Check for orphan sessions with \`mcx claude ls --all\`, then either record the real sessionId with \`mcx call _work_items phase_state_set\` or clear the sentinel to allow re-spawn.`,
+        );
+        d.exit(1);
+      }
       const entry: AdvanceChainEntry = {
         phase: currentPhase,
         action: "in-flight",
@@ -1492,6 +1517,12 @@ export async function cmdPhaseAdvance(
         d.logError(`phase "${currentPhase}" returned "goto" without a target`);
         d.exit(1);
       }
+      if (target === currentPhase) {
+        d.logError(
+          `phase "${currentPhase}" returned goto-to-self — this is a handler bug, not a cycle. Check the phase script.`,
+        );
+        d.exit(1);
+      }
       const entry: AdvanceChainEntry = { phase: currentPhase, action: "goto", target };
       chain.push(entry);
       d.logError(`${currentPhase} → ${target} (goto)`);
@@ -1503,6 +1534,23 @@ export async function cmdPhaseAdvance(
       const command = output.command as string[] | undefined;
       if (!command || !Array.isArray(command) || command.length === 0) {
         d.logError(`phase "${currentPhase}" returned "spawn" without a command`);
+        d.exit(1);
+      }
+      if (command[0] !== "mcx") {
+        d.logError(
+          `phase "${currentPhase}" returned "spawn" with an unexpected command root "${command[0]}" — only "mcx" commands are allowed`,
+        );
+        d.exit(1);
+      }
+
+      const rawStateKey = output.stateKey as string | undefined;
+      const derivedStateKey = currentPhase === "impl" ? "session_id" : `${currentPhase}_session_id`;
+      const stateKey = rawStateKey ?? derivedStateKey;
+      const stateKeyPattern = /^([a-z][a-z0-9]*_)?session_id$/;
+      if (!stateKeyPattern.test(stateKey)) {
+        d.logError(
+          `phase "${currentPhase}" returned stateKey "${stateKey}" which does not match the required pattern (e.g. "session_id", "qa_session_id")`,
+        );
         d.exit(1);
       }
 
@@ -1522,11 +1570,13 @@ export async function cmdPhaseAdvance(
         d.exit(1);
       }
 
-      const stateKey =
-        (output.stateKey as string | undefined) ??
-        (currentPhase === "impl" ? "session_id" : `${currentPhase}_session_id`);
+      // Echo sessionId to stderr immediately so it is visible even if the
+      // phase_state_set call below fails and the recovery hint is malformed.
+      d.logError(`${currentPhase}: spawn succeeded — sessionId=${sessionId}`);
 
       const repoRoot = ex.findGitRoot(d.cwd()) ?? d.cwd();
+      const recoverPayload = JSON.stringify({ workItemId: opts.workItemId, key: stateKey, value: sessionId, repoRoot });
+      const recoverCmd = `mcx call _work_items phase_state_set '${recoverPayload.replace(/'/g, "'\\''")}'`;
       try {
         const setResult = (await ex.ipcCall("callTool", {
           server: "_work_items",
@@ -1538,17 +1588,13 @@ export async function cmdPhaseAdvance(
           d.logError(
             `CRITICAL: spawn succeeded (sessionId=${sessionId}) but phase_state_set failed: ${JSON.stringify(setResult.content ?? setResult)}`,
           );
-          d.logError(
-            `To recover: mcx call _work_items phase_state_set '{"workItemId":"${opts.workItemId}","key":"${stateKey}","value":"${sessionId}","repoRoot":"${repoRoot}"}'`,
-          );
+          d.logError(`To recover: ${recoverCmd}`);
           d.exit(1);
         }
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         d.logError(`CRITICAL: spawn succeeded (sessionId=${sessionId}) but phase_state_set failed: ${msg}`);
-        d.logError(
-          `To recover: mcx call _work_items phase_state_set '{"workItemId":"${opts.workItemId}","key":"${stateKey}","value":"${sessionId}","repoRoot":"${repoRoot}"}'`,
-        );
+        d.logError(`To recover: ${recoverCmd}`);
         d.exit(1);
       }
 
@@ -1566,10 +1612,12 @@ export async function cmdPhaseAdvance(
     d.exit(1);
   }
 
-  // Hard cap hit — dump the chain to stderr for debugging
+  // Hard cap hit — work item is stranded at the current phase with no session.
   const chainStr = chain.map((e) => `${e.phase}(${e.action}${e.target ? `→${e.target}` : ""})`).join(" | ");
   d.logError(
-    `phase advance cap hit (${ADVANCE_MAX_ITERATIONS} iterations): possible cycle in phase graph\nchain: ${chainStr}`,
+    `phase advance cap hit (${ADVANCE_MAX_ITERATIONS} iterations): possible cycle in phase graph\n` +
+      `work item "${opts.workItemId}" is stranded at phase "${currentPhase}" — manual intervention required\n` +
+      `chain: ${chainStr}`,
   );
   d.exit(2);
 }


### PR DESCRIPTION
## Summary
- Adds `mcx phase advance --work-item <id>` subcommand that chains phase runs until quiescent
- Follows the action chain (`goto` → next phase, `spawn` → exec command + `phase_state_set`, `wait`/`in-flight` → stop)
- Hard cap at 8 iterations to defeat handler-graph cycles; exits 2 on cap-hit

## Test plan
- [x] `parsePhaseAdvanceArgs` unit tests (all flag forms, missing/unknown flags)
- [x] `wait` action — exits 0, chain JSON to stdout
- [x] `in-flight` action — exits 0, includes existing sessionId
- [x] `goto` → `wait` chain — 2-step chain
- [x] `goto` → `spawn` chain — records sessionId via `phase_state_set`
- [x] `impl` phase → state key is `session_id` (not `impl_session_id`)
- [x] `qa` phase → state key is `qa_session_id`
- [x] Phase can override state key via `stateKey` field in spawn output
- [x] Spawn fails → exits non-zero, no `phase_state_set` called
- [x] Spawn succeeds + `phase_state_set` fails → exits non-zero, sessionId visible in stderr for manual recovery
- [x] `phase_state_set` throws → same recovery path
- [x] Unknown action → exits non-zero with informative message
- [x] Cycle (8 iterations with valid back-edges) → exits 2 with "cap hit" in stderr
- [x] Help text includes `advance` subcommand
- [x] All 7055 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)