### PR TITLE
fix(process): isOurProcess returns tri-state to prevent flaky kill skip (fixes #1980)

### DIFF
--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -313,9 +313,17 @@ export class ClaudeServer extends AbstractWorkerServer {
       if (row.state === "ended") return false;
       if (row.pid != null) {
         if (row.pidStartTime != null) {
-          if (!isOurProcess(row.pid, row.pidStartTime)) {
+          const ownership = isOurProcess(row.pid, row.pidStartTime);
+          if (ownership === false) {
             this.logger.warn(
-              `[claude-server] Skipping restore of session ${row.sessionId} — pid ${row.pid} is dead or recycled`,
+              `[claude-server] Skipping restore of session ${row.sessionId} — pid ${row.pid} has been recycled`,
+            );
+            this.db.endSession(row.sessionId);
+            return false;
+          }
+          if (ownership === null && !isProcessAlive(row.pid)) {
+            this.logger.warn(
+              `[claude-server] Skipping restore of session ${row.sessionId} — pid ${row.pid} is no longer alive`,
             );
             this.db.endSession(row.sessionId);
             return false;

--- a/packages/daemon/src/orphan-reaper.ts
+++ b/packages/daemon/src/orphan-reaper.ts
@@ -17,7 +17,7 @@ import { isOurProcess as defaultIsOurProcess } from "./process-identity";
 
 interface ReaperDeps {
   /** Injectable for testing — defaults to the real isOurProcess. */
-  isOurProcess?: (pid: number, storedStartTimeMs: number) => boolean;
+  isOurProcess?: (pid: number, storedStartTimeMs: number) => boolean | null;
 }
 
 /**
@@ -47,14 +47,23 @@ export function reapOrphanedSessions(db: StateDb, logger: Logger = consoleLogger
     }
 
     if (pidStartTime != null) {
-      // We have a stored start time — verify PID ownership
-      if (checkIsOurProcess(pid, pidStartTime)) {
-        // Process is alive and matches — preserve for restoreActiveSessions
+      const ownership = checkIsOurProcess(pid, pidStartTime);
+      if (ownership === true) {
         logger.info(`[mcpd] Preserving active session ${sessionId} (pid ${pid} still alive)`);
         continue;
       }
-      // PID is dead or recycled — clean up DB record
-      logger.warn(`[mcpd] Cleaning up stale session ${sessionId} — pid ${pid} is dead or recycled`);
+      if (ownership === null) {
+        // Can't verify via start time (ps failed) — fall back to bare liveness check
+        try {
+          process.kill(pid, 0);
+          logger.info(`[mcpd] Preserving active session ${sessionId} (pid ${pid} alive, ownership uncertain)`);
+          continue;
+        } catch {
+          logger.warn(`[mcpd] Cleaning up stale session ${sessionId} — pid ${pid} is no longer alive`);
+        }
+      } else {
+        logger.warn(`[mcpd] Cleaning up stale session ${sessionId} — pid ${pid} is dead or recycled`);
+      }
     } else {
       // Legacy session without start time — check bare liveness
       try {

--- a/packages/daemon/src/orphan-reaper.ts
+++ b/packages/daemon/src/orphan-reaper.ts
@@ -15,6 +15,16 @@ import { consoleLogger } from "@mcp-cli/core";
 import type { StateDb } from "./db/state";
 import { isOurProcess as defaultIsOurProcess } from "./process-identity";
 
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "EPERM") return true;
+    return false;
+  }
+}
+
 interface ReaperDeps {
   /** Injectable for testing — defaults to the real isOurProcess. */
   isOurProcess?: (pid: number, storedStartTimeMs: number) => boolean | null;
@@ -53,28 +63,21 @@ export function reapOrphanedSessions(db: StateDb, logger: Logger = consoleLogger
         continue;
       }
       if (ownership === null) {
-        // Can't verify via start time (ps failed) — fall back to bare liveness check
-        try {
-          process.kill(pid, 0);
+        if (isProcessAlive(pid)) {
           logger.info(`[mcpd] Preserving active session ${sessionId} (pid ${pid} alive, ownership uncertain)`);
           continue;
-        } catch {
-          logger.warn(`[mcpd] Cleaning up stale session ${sessionId} — pid ${pid} is no longer alive`);
         }
+        logger.warn(`[mcpd] Cleaning up stale session ${sessionId} — pid ${pid} is no longer alive`);
       } else {
         logger.warn(`[mcpd] Cleaning up stale session ${sessionId} — pid ${pid} is dead or recycled`);
       }
     } else {
       // Legacy session without start time — check bare liveness
-      try {
-        process.kill(pid, 0); // signal 0 = existence check, no kill
-        // Process is alive — preserve it
+      if (isProcessAlive(pid)) {
         logger.info(`[mcpd] Preserving active session ${sessionId} (pid ${pid} still alive, no start time)`);
         continue;
-      } catch {
-        // Process is dead — clean up
-        logger.warn(`[mcpd] Cleaning up stale session ${sessionId} — pid ${pid} is no longer alive`);
       }
+      logger.warn(`[mcpd] Cleaning up stale session ${sessionId} — pid ${pid} is no longer alive`);
     }
 
     db.endSession(sessionId);

--- a/packages/daemon/src/process-identity.spec.ts
+++ b/packages/daemon/src/process-identity.spec.ts
@@ -101,8 +101,8 @@ describe("isOurProcess", () => {
     expect(isOurProcess(process.pid, startTime as number)).toBe(true);
   });
 
-  test("returns false for a dead PID", () => {
-    expect(isOurProcess(2147483647, Date.now())).toBe(false);
+  test("returns null for a dead PID (indeterminate — ps fails)", () => {
+    expect(isOurProcess(2147483647, Date.now())).toBeNull();
   });
 
   test("returns false when start time doesn't match (simulates PID reuse)", () => {

--- a/packages/daemon/src/process-identity.ts
+++ b/packages/daemon/src/process-identity.ts
@@ -109,11 +109,11 @@ export function getProcessStartTimesBatch(pids: number[]): Map<number, number> {
  * @param pid - The process ID to check
  * @param storedStartTimeMs - The epoch ms start time recorded when the session was created
  * @param toleranceMs - Tolerance for start time comparison (default 2s, accounts for rounding)
- * @returns true if the PID belongs to our original process, false if recycled or dead
+ * @returns true if confirmed ours, false if confirmed recycled (start time mismatch), null if indeterminate (ps failed or process dead)
  */
-export function isOurProcess(pid: number, storedStartTimeMs: number, toleranceMs = 2_000): boolean {
+export function isOurProcess(pid: number, storedStartTimeMs: number, toleranceMs = 2_000): boolean | null {
   const currentStartTime = getProcessStartTime(pid);
-  if (currentStartTime === null) return false; // process is dead
+  if (currentStartTime === null) return null;
   return Math.abs(currentStartTime - storedStartTimeMs) <= toleranceMs;
 }
 

--- a/packages/daemon/src/process-util.ts
+++ b/packages/daemon/src/process-util.ts
@@ -73,8 +73,9 @@ export async function killPid(
 
   // Verify PID ownership before sending signals
   if (opts?.pidStartTime != null) {
-    if (!isOurProcess(pid, opts.pidStartTime)) {
-      logger.warn(`[process] PID ${pid} has been recycled — skipping kill`);
+    const ownership = isOurProcess(pid, opts.pidStartTime);
+    if (ownership === false) {
+      logger.warn(`[process] PID ${pid} has been recycled (start time mismatch) — skipping kill`);
       return;
     }
   }

--- a/packages/daemon/src/server-pool.spec.ts
+++ b/packages/daemon/src/server-pool.spec.ts
@@ -4,6 +4,7 @@ import type { HttpServerConfig, SseServerConfig, StdioServerConfig } from "@mcp-
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { getProcessStartTime } from "./process-identity";
 import {
   BASE_ENV_ALLOWLIST,
   type ConnectFn,
@@ -1741,10 +1742,21 @@ describe("disconnect kills stdio child processes (#940)", () => {
         return;
       }
 
+      // Capture the original process's start time so we can use identity-based
+      // assertions below. Bare isAlive(pid) is racy: if the OS recycles the PID
+      // between closeAll() and the assertion, a *different* process is alive at
+      // that PID and the test fails even though our process was killed correctly.
+      const originalStartTime = getProcessStartTime(pid);
+
       await pool.closeAll();
 
-      // closeAll() → disconnect() → killPid() confirms process death before returning.
-      expect(isAlive(pid)).toBe(false);
+      // Verify the *original* process is gone. If the PID was recycled, the new
+      // process will have a different start time — that still means ours was killed.
+      const postStartTime = getProcessStartTime(pid);
+      const originalProcessDead =
+        postStartTime === null || // PID no longer exists
+        (originalStartTime !== null && Math.abs(postStartTime - originalStartTime) > 2_000); // PID recycled
+      expect(originalProcessDead).toBe(true);
     } finally {
       forceKill(pid);
     }


### PR DESCRIPTION
## Summary
- `isOurProcess()` now returns `boolean | null` instead of `boolean` — `null` means "can't determine" (ps subprocess failed), distinct from `false` (confirmed PID recycled via start-time mismatch)
- `killPid` only skips the kill on `false` (confirmed recycled); on `null` it proceeds with the kill (ESRCH safely catches the already-dead case)
- `orphan-reaper` and `claude-server` fall back to bare liveness checks (`process.kill(pid, 0)` / `isProcessAlive`) when ownership is indeterminate

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — 7047 pass, 0 fail
- [x] Updated `isOurProcess` test: dead PID now expects `null` instead of `false`
- [x] Existing `closeAll kills all stdio child processes` test should no longer flake — the uncertain-ownership path now proceeds to kill instead of skipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)