### PR TITLE
test(monitor): ring-buffer backfill coverage for session.response/responseTail gate (closes #1759)

### DIFF
--- a/packages/daemon/src/event-stream.ts
+++ b/packages/daemon/src/event-stream.ts
@@ -10,6 +10,7 @@
 import type { Logger } from "@mcp-cli/core";
 import { getDaemonLogLines, subscribeDaemonLogs } from "./daemon-log";
 import type { EventBus } from "./event-bus";
+import type { EventLog } from "./event-log";
 import { buildEventFilter } from "./ipc-filter";
 import { metrics } from "./metrics";
 import type { ServerPool } from "./server-pool";
@@ -51,6 +52,7 @@ export class EventStreamServer {
     private readonly pool: ServerPool,
     private readonly logger: Logger,
     private readonly heartbeatIntervalMs = 30_000,
+    private readonly explicitEventLog: EventLog | null = null,
   ) {
     if (eventBus) {
       this.eventSeq = eventBus.currentSeq;
@@ -249,7 +251,7 @@ export class EventStreamServer {
       }
       sinceSeq = parsed;
     }
-    const eventLog = this.eventBus?.eventLog ?? null;
+    const eventLog = this.eventBus?.eventLog ?? this.explicitEventLog ?? null;
 
     const prRaw = url.searchParams.get("pr");
     if (prRaw !== null && !(Number.isInteger(Number(prRaw)) && Number(prRaw) >= 1)) {

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -3825,6 +3825,133 @@ describe("IpcServer HTTP transport", () => {
     expect(buffer).toContain("session.result");
   });
 
+  test("ring-buffer: backfill session.response excluded by default (no responseTail) (#1759)", async () => {
+    const db = new Database(":memory:");
+    const eventLog = new EventLog(db);
+    socketPath = tmpSocket();
+    server = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, {
+      ...opts(),
+      eventLog,
+    });
+    server.start(socketPath);
+
+    // Pre-populate the log directly — no EventBus, so ring-buffer path is used
+    const tempBus = new EventBus(eventLog);
+    tempBus.publish({ src: "test", event: "session.response", category: "session", sessionId: "s1", chunk: "secret" });
+    tempBus.publish({ src: "test", event: "session.result", category: "session", sessionId: "s1" });
+
+    const controller = new AbortController();
+    const res = await fetch("http://localhost/events?since=0", {
+      method: "GET",
+      unix: socketPath,
+      signal: controller.signal,
+    } as RequestInit);
+
+    expect(res.status).toBe(200);
+    if (!res.body) throw new Error("Expected response body");
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+
+    let buffer = "";
+    const deadline = Date.now() + 2_000;
+    while (Date.now() < deadline) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      if (buffer.includes("session.result")) break;
+    }
+
+    controller.abort();
+    reader.releaseLock();
+
+    expect(buffer).not.toContain("session.response");
+    expect(buffer).toContain("session.result");
+  });
+
+  test("ring-buffer: backfill session.response included when responseTail matches (#1759)", async () => {
+    const db = new Database(":memory:");
+    const eventLog = new EventLog(db);
+    socketPath = tmpSocket();
+    server = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, {
+      ...opts(),
+      eventLog,
+    });
+    server.start(socketPath);
+
+    const tempBus = new EventBus(eventLog);
+    tempBus.publish({ src: "test", event: "session.response", category: "session", sessionId: "s1", chunk: "hello" });
+    tempBus.publish({ src: "test", event: "session.result", category: "session", sessionId: "s1" });
+
+    const controller = new AbortController();
+    const res = await fetch("http://localhost/events?since=0&responseTail=s1", {
+      method: "GET",
+      unix: socketPath,
+      signal: controller.signal,
+    } as RequestInit);
+
+    expect(res.status).toBe(200);
+    if (!res.body) throw new Error("Expected response body");
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+
+    let buffer = "";
+    const deadline = Date.now() + 2_000;
+    while (Date.now() < deadline) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      if (buffer.includes("session.result")) break;
+    }
+
+    controller.abort();
+    reader.releaseLock();
+
+    expect(buffer).toContain("session.response");
+    expect(buffer).toContain("session.result");
+  });
+
+  test("ring-buffer: backfill session.response excluded when responseTail is different session (#1759)", async () => {
+    const db = new Database(":memory:");
+    const eventLog = new EventLog(db);
+    socketPath = tmpSocket();
+    server = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, {
+      ...opts(),
+      eventLog,
+    });
+    server.start(socketPath);
+
+    const tempBus = new EventBus(eventLog);
+    tempBus.publish({ src: "test", event: "session.response", category: "session", sessionId: "s1", chunk: "secret" });
+    tempBus.publish({ src: "test", event: "session.result", category: "session", sessionId: "s1" });
+
+    const controller = new AbortController();
+    const res = await fetch("http://localhost/events?since=0&responseTail=other-session", {
+      method: "GET",
+      unix: socketPath,
+      signal: controller.signal,
+    } as RequestInit);
+
+    expect(res.status).toBe(200);
+    if (!res.body) throw new Error("Expected response body");
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+
+    let buffer = "";
+    const deadline = Date.now() + 2_000;
+    while (Date.now() < deadline) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      if (buffer.includes("session.result")) break;
+    }
+
+    controller.abort();
+    reader.releaseLock();
+
+    expect(buffer).not.toContain("session.response");
+    expect(buffer).toContain("session.result");
+  });
+
   test("ring-buffer: rejects connection when subscriber cap is reached (#1961)", async () => {
     startServer();
     if (!server) throw new Error("server not started");

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -36,6 +36,7 @@ import { getDaemonLogLines } from "./daemon-log";
 import type { StateDb } from "./db/state";
 import { WorkItemDb } from "./db/work-items";
 import type { EventBus } from "./event-bus";
+import type { EventLog } from "./event-log";
 import { EventStreamServer } from "./event-stream";
 import type { RequestContext, RequestHandler } from "./handler-types";
 import { AliasHandlers } from "./handlers/alias";
@@ -97,6 +98,7 @@ export class IpcServer {
       resolveIssuePr?: (number: number) => Promise<{ prNumber: number | null }>;
       loadManifest?: (repoRoot: string) => Manifest | null;
       eventBus?: EventBus;
+      eventLog?: EventLog;
       onAliasChanged?: (name: string) => void;
     },
   ) {
@@ -113,8 +115,15 @@ export class IpcServer {
 
     const workItemDb = new WorkItemDb(this.db.getDatabase());
     const eventBus = opts.eventBus ?? null;
+    const eventLog = opts.eventLog ?? null;
 
-    this.eventStream = new EventStreamServer(eventBus, this.pool, this.logger, IpcServer.HEARTBEAT_INTERVAL_MS);
+    this.eventStream = new EventStreamServer(
+      eventBus,
+      this.pool,
+      this.logger,
+      IpcServer.HEARTBEAT_INTERVAL_MS,
+      eventLog,
+    );
 
     this.registerHandlers({
       aliasServer,


### PR DESCRIPTION
## Summary
- The ring-buffer fallback backfill loop (`shouldDeliverFallback` in `event-stream.ts`) was unreachable because `eventLog` was derived solely from `eventBus`, which is `null` in the ring-buffer path — so `since=` always returned 400 before reaching the backfill code
- Add an optional `eventLog` parameter to `EventStreamServer` and `IpcServer` opts, falling back to `eventBus.eventLog` as before; this makes the ring-buffer backfill code path reachable independently of `eventBus`
- Add 3 integration tests mirroring the EventBus backfill suite: `session.response` excluded without `responseTail`, included when `responseTail` matches, excluded when `responseTail` is a different session

## Test plan
- [x] 3 new ring-buffer path backfill tests all pass
- [x] Full test suite: 7043 pass, 0 fail
- [x] `bun typecheck` passes
- [x] `bun lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)