### PR TITLE
sprint(54): automation modules framework + flake cluster + sprint-53 fallout

### DIFF
--- a/.claude/diary/20260518.54.md
+++ b/.claude/diary/20260518.54.md
@@ -1,0 +1,64 @@
+# 2026-05-18 — Automation framework epic + flake-cluster cleanup (Sprint 54)
+
+## What was done
+
+15 PRs merged, v1.9.0 released. 3h01m wall (planned + run window from 19:53 → 00:20 EST). Heaviest sprint to date: 1 epic, 2 flake nerd-snipe gates, 2 concrete modules proving the framework, 10 fallout/DX.
+
+**Automation arc (the epic):**
+- #2018 / PR #2056 — declarative event-triggered module framework: `automation:` manifest section, `defineAutomation` factory, `AutomationDispatcher` with audit ring buffer, IPC handlers, `mcx automation list/show/log` commands, lockfile integration, docs. **Required 2 review rounds + 2 repair rounds.** Round 1 caught 6 dead-code blockers (preset system, dispatcher never instantiated, defineAutomation not in virtual module, mcx track --automation absent, ring buffer wrap bug, docs missing). Round 2 caught 5 more (handler executor returning synthetic 'none' without loading, namespace mismatch, lockfile-hash drift). Opus spend: ~$30 across the rounds.
+- #2019 / PR #2064 — per-work-item custom metadata via manifest object-form state declarations. `mcx track --<field> <value>` for project-declared fields. 1 review self-repair round + 1 QA failure (repeatable on non-string types).
+- #2021 / PR #2066 — bind module (first concrete proof). Subscribes to `pr.opened`, matches by branch (direct OR `branchPattern` regex), patches work-item state. Reviewer found `set-state` action was dead code in the framework — self-repaired by wiring `updateWorkItem` into the dispatcher.
+- #2020 / PR #2065 — cleanup module (second concrete proof). Subscribes to `pr.merged`, verifies `mergeSha`, calls `claude_bye` for real SIGTERM (not just DB UPDATE), untracks. Reviewer found bye action was a dead audit stub — self-repaired by routing through `pool.callTool(CLAUDE_SERVER_NAME, "claude_bye")`. Plus a rebase against #2066 (conflict in dispatcher.ts).
+
+**Flake-cluster arc (3 gates, all landed):**
+- #1978 / PR #2053 — AcpSession permission-approve race. Nerd-snipe identified test-side `waitForResult` registration AFTER `session:result` could fire. 100% deterministic local repro by injecting 300ms delay. Move `waitForResult()` before `session.start()`. Closes the 47-sprint AcpSession flake leg of the cluster.
+- #2015 / PR #2059 — HTTP/SSE transport + 401 auth daemon-integration tests fail under `bun test --parallel`. **Best gate save of the sprint:** nerd-snipe theorized buffer reuse after `reader.releaseLock()`. Adversarial reviewer ran the proposed fix, **proved the theory wrong** (5 failures persisted under TTY), then identified the actual cause: ANSI color codes in `console.log(port)` under TTY. Fix: `process.stdout.write(String(port) + "\n")` in 3 mock servers + ANSI-strip in startMockServer. Reviewer self-repaired.
+- #2016 / PR #2046 — `colorState`/`MetricsPanel` TTY-color leak in tests. Direct sonnet fix: `NO_COLOR=1`/`FORCE_COLOR=0` in `bunfig.toml`-registered preload.
+- #1224 / PR #2044 — `pull.spec.ts` inheriting `core.hooksPath` from parent repo. `execFileSync` argv-form for cross-platform.
+- #2014 / PR #2057 — shared-daemon refactor for P5b/P5c (orthogonal to #2015's investigation).
+
+**Sprint-53 fallout (4 PRs):**
+- #2025 / PR #2050 — `mcx claude ls --all --short` hang. Root cause was the stale `dist/` binary at sprint start (already fixed in source; impl added regression tests).
+- #2040 / PR #2048 — orphan-reaper + claude-server null-ownership path coverage.
+- #2036 / PR #2047 — platform npm packages enumerate explicit binaries (replaced `["bin/"]` with `BINARIES.map(b => "bin/${b}")`). Copilot drove the abstraction.
+- #2017 / PR #2045 — docs/phases.md clarifies `mcp-cli` is a virtual package, with ambient `.d.ts` template.
+
+**DX:**
+- #1605 / PR #2049 — `mcx claude wait` stable `key=value` header before JSON output. Reviewer self-repaired around shape-routing bug (sessions+events both present) and mail path coverage.
+- #1395 / PR #2054 — extracted shared `mail-wait.ts` from claude.ts/agent.ts. Includes rebase round (1 Copilot caught header-default flip).
+
+## What worked well
+
+- **Reviewer self-repair saved ~4 opus repair spawns.** #1395 round 1, #2018 round 1+2, #2019, #2020 partial — all contained file:line edits with reviewer-as-fixer. Likely $10+ saved vs spawning fresh opus repair sessions.
+- **Adversarial reviewer ran the fix locally for #2015 and rejected the nerd-snipe's theory.** This is the gate working at its best — the reviewer's job is "verify mechanism matches impl," not "trust the diagnosis." Sprint 53's #1980 partially-wrong diagnosis happened because the bisect was CI-log-only. The sprint-54 lesson held: reviewer ran `script -q /dev/null sh -c 'bun test --parallel'` and reproduced 5 failures on the proposed fix, then traced the actual cause (ANSI). Lesson reinforced in `feedback_flaky_tests.md`.
+- **Both nerd-snipe gates passed.** #1978's nerd-snipe gave 100% deterministic local repro before any impl. The plan budgeted for one of {#2015, #1978} hitting `needs-attention`; neither did.
+- **Triage scrutiny calibration was accurate.** Low-scrutiny PRs (#2017, #2016, #2025, #2040, #2036, #2014, #1224) all passed QA first try. High-scrutiny PRs (#2018, #2019, #2020, #2021, #1395) all needed at least one review or QA round. No false-positive high-scrutiny calls.
+- **Module reviewer comparison surfaced the framework gap.** The plan's risk-watch — "if the second module needs to break the framework's invariants to work, that's a #2018 redesign" — paid off. Both #2020 and #2021 reviewers independently found that the framework's action types (`set-state`, `bye-and-untrack`) were declared but never executed. Both self-repaired by wiring executors in the dispatcher. This is a sprint-55 carry-forward: backfill framework executors into #2018, OR document that the framework is audit-only and modules carry their own DB-mutation code.
+- **Parallel impl spawning for the 3 #2018 dependents.** When #2018 merged, #2019 spawned alone (it builds on the manifest schema), then #2021 + #2020 spawned in parallel against `origin/main` once the schema was on main. Saved ~30 min vs strict serial.
+
+## What didn't work
+
+- **Quota hit 100% on the 5-hour budget mid-sprint** after #2018 finally merged. The orchestrator pause-default correctly fired (the plan codifies this). User explicitly approved overage to land the 3-dependent chain. Resolution: the `feedback_quota_pause_with_override.md` memory captures the surface-and-ask pattern. Net cost: ~$15-20 in extra credits to land the last 3 PRs.
+- **Multiple workers triggered per-action `Edit`/`Write`/`Bash` permission requests despite `--allow Read Glob Grep Write Edit Bash` at spawn time.** Each session asked individually for each tool call — orchestrator had to send `yes` repeatedly. The `--allow` list isn't fully propagating through to runtime, or the daemon's permission router has a per-call gate. **Action: file an issue post-sprint.** Cost: ~5-10 min of orchestrator attention answering "yes" loops.
+- **Daemon restart mid-sprint** was forced when #2019 merged (its new object-form manifest schema needed the new binary; the running daemon had the old parser, so subsequent `mcx phase run done` calls errored). Restart killed 4 idle sessions (whose work was pushed, so no data lost) but the protocol-mismatch error was surfaced via a misleading message ("Daemon is running a different build... Run `mcx shutdown`") — `mcx shutdown` then failed with a similar protocol mismatch error. The correct command was `mcx daemon restart`. **Action: file an issue for the message clarity, or auto-restart on protocol drift.**
+- **Local checkout's `.mcx.yaml` had the new object-form scrutiny/bundled_with declarations** that #2019 added — the running daemon (pre-#2019 binary) rejected them. The fix was a local rebuild + `mcx daemon restart`. This is the expected friction when a manifest-schema-changing PR lands mid-sprint; in a more careful workflow we'd have rebuilt the daemon binary at the merge boundary.
+- **Worktree GC failed on 5 entries** with `+ ` prefixes (e.g., `+ worktree-claude-mpalcbqr`). This is #2042 (mcx gc parsing bug) per memory. Not a sprint blocker, but the GC is incomplete until #2042 lands.
+
+## Patterns established
+
+- **Surface-and-ask quota override** (memory: `feedback_quota_pause_with_override.md`). At ≥95% 5-hour utilization, default to PAUSE + surface the deferred work + cost to the user. Don't silently push into `extraUsage`. User can explicitly OK the overage. This came up specifically when #2018 merged at 100% quota and the 3 dependents were ready to spawn.
+- **Action-type dead-code finding via cross-module review.** When a framework declares an action shape but provides only a stub executor, the second module's adversarial reviewer is the gate that catches it — comparing both modules' patches reveals the framework's missing executor.
+- **Reviewer-self-repair-with-framework-fix.** When a contained reviewer finding turns out to require a framework patch (not just a module patch), the reviewer can still self-repair if the framework fix is small (~5 lines). #2021's reviewer added the `set-state` executor in `automation-dispatcher.ts` during self-repair. Acceptable scope-creep when the alternative is a fresh opus repair spawn.
+
+## Stats
+
+- **PRs merged**: 15 (100% of plan)
+- **Already-closed at plan time**: 2 (#1928 already-done, #1686 duplicate)
+- **Adversarial reviews**: 5 high-scrutiny PRs reviewed (#2018, #2019, #2020, #2021, #1395) — 6+5+1+2+1 = ~15 distinct findings, all fixed
+- **Nerd-snipe gates**: 2 spawned, 2 passed (one with reviewer-discovered theory rejection — a feature of the gate)
+- **Failed/dropped**: 0
+- **Reviewer self-repair rounds**: 4 successful + 1 partial (#2018 had 2 rounds, #1395, #2019, #2020 had 1 each)
+- **Sprint cost** (rough): ~$45 opus + ~$15 sonnet = ~$60. Plus ~$15-20 overage credits to land the 3 dependents after 100% quota hit.
+- **Sessions spawned**: ~25 across 3h01m. Daemon restarted once mid-sprint.
+- **Follow-ups filed during sprint**: #2052, #2055, #2060, #2061, #2062 (titles in PR comments)
+- **Open at sprint end**: 0 of 15 sprint picks. (4 follow-ups from QA workers still open as expected.)

--- a/.claude/sprints/sprint-54.md
+++ b/.claude/sprints/sprint-54.md
@@ -1,6 +1,6 @@
 # Sprint 54
 
-> Planned 2026-05-17 19:53 EST. Target: 15 PRs.
+> Planned 2026-05-17 19:53 EST. Started 2026-05-17 21:19 EST. Target: 15 PRs.
 
 ## Goal
 

--- a/.claude/sprints/sprint-54.md
+++ b/.claude/sprints/sprint-54.md
@@ -1,6 +1,6 @@
 # Sprint 54
 
-> Planned 2026-05-17 19:53 EST. Started 2026-05-17 21:19 EST. Target: 15 PRs.
+> Planned 2026-05-17 19:53 EST. Started 2026-05-17 21:19 EST. Ended 2026-05-18 00:20 EST. Duration 3h01m. Target: 15 PRs. Merged: 15. **100% target hit.**
 
 ## Goal
 
@@ -255,3 +255,60 @@ flakes land, patch (v1.8.8). Defer the call to retro.
 11. **Use the `Monitor` harness tool, not raw Bash `mcx monitor`**.
 12. **Plan-time triage step** caught 1 already-done (#1928) + 1 dup
     (#1686) at sprint-54 plan time. The discipline is working.
+
+## Results
+
+**15/15 merged in 3h01m wall.** Heaviest sprint to date — 1 epic, 2 flake
+nerd-snipe gates, 2 concrete modules proving the framework, plus 10
+fallout/DX items.
+
+| # | PR | Phase outcome | Notes |
+|---|-----|---------------|-------|
+| 2016 | #2046 | direct (sonnet) | colorState TTY flake — fastest at ~12 min |
+| 2017 | #2045 | direct (sonnet) | docs-only |
+| 1224 | #2044 | direct (sonnet) | pull.spec hooksPath — Copilot caught the Windows-portability `execFileSync` swap |
+| 2036 | #2047 | direct (sonnet) | npm files manifest — Copilot drove the BINARIES.map(...) abstraction |
+| 2040 | #2048 | direct (sonnet) | null-ownership coverage |
+| 2025 | #2050 | direct (sonnet) | claude-ls hang — root cause was the stale binary from sprint start |
+| 1395 | #2054 | direct (sonnet) | dedupe + 1 review round (includeHeader default) + 1 Copilot round (rebase header behavior) |
+| 1605 | #2049 | direct (sonnet) | wait header — 1 Copilot round (shape routing + mail path) |
+| 2014 | #2057 | direct (sonnet) | share-daemon refactor |
+| **2015** | #2059 | **nerd-snipe gate** (opus) + **review caught wrong root cause** | nerd-snipe theory: Uint8Array buffer reuse after releaseLock. Adversarial reviewer ran the test, **proved the theory wrong**, found the actual cause: ANSI color codes in `console.log(port)` under TTY. Reviewer self-repaired (`process.stdout.write` + ANSI strip). Cost: ~$8. **Best gate save of the sprint.** |
+| **1978** | #2053 | **nerd-snipe gate** (opus) + adversarial review approve | Clean gate hit. Race in `AcpSession.spec.ts` where `waitForResult` registered AFTER `session:result` could fire. 100% deterministic local repro. Cost: ~$1.8 nerd-snipe + ~$0.6 impl. Closed the 47-sprint flake-cluster's last AcpSession leg. |
+| **2018** | #2056 | **2× review + 2× repair** (opus, $30+) | Framework epic. Round 1 review found 6 dead-code blockers (preset, dispatcher not instantiated, defineAutomation not in virtual module, mcx track --automation absent, ring-buffer wrap, docs missing). Round 2 review approved blocker fixes but found 5 new (Copilot piled on 11 more). Round 2 repair wired actual handler execution. QA verified end-to-end. **Most opus-intensive PR ever.** |
+| 2019 | #2064 | review self-repair + 1 QA fail/round-2 | Schema extension. Round 1 QA caught `repeatable: true` permitted on non-string types. Single `.refine()` fix. |
+| 2021 | #2066 | review self-repair + 1 dispatcher gap | Reviewer found `set-state` action was dead code in dispatcher. Self-repaired by wiring `updateWorkItem` callback. Framework-bug-found-via-module. |
+| 2020 | #2065 | review self-repair + 1 dispatcher gap + rebase | Same shape as #2021 but for `bye-and-untrack`. Routed through `claude_bye` for real SIGTERM. Plus rebase after #2066 merged. Final merge. |
+
+### Pipeline math
+
+- **Total opus spend** (rough): nerd-snipes $4.5 + #2018 framework $30 + #1978 impl $0.6 + #2015 impl $0.6 + reviewer self-repairs ~$8 = ~$45 opus
+- **Sonnet spend**: lots of small QA/impl runs, ~$15
+- **Quota**: 5-hour hit 100% mid-#2018-repair. User explicitly approved overage to land the chain.
+- **Sessions spawned**: ~25 across the sprint. Daemon restarted once mid-sprint to pick up post-#2019 schema (cost: 4 in-flight sessions killed, but all had pushed their work).
+
+### Gate validation
+
+- **Nerd-snipe gate (#1978)**: clean PASS. Root cause + repro + concrete fix. Adversarial review verified mechanism matches impl.
+- **Nerd-snipe gate (#2015)**: the gate caught what the gate is FOR — adversarial reviewer rejected the nerd-snipe's theory after running tests locally. New mechanism identified + fix landed. This is exactly the "verify mechanism, not just tests pass" rule paying off.
+- **Framework adversarial review (#2018)**: 2 rounds × 6 blockers + 5 blockers caught real dead code (preset, dispatcher init, docs gap, virtual-module export, track flag, ring buffer). Without the gate, all 6 would have shipped as ghost-features.
+- **Module reviewer comparison (#2020 vs #2021)**: the plan's risk-watch worked — both modules found the SAME framework gap (action executor was a stub). Both reviewers self-repaired by wiring the gap. Surface in retro: framework #2018 should have shipped these executors; we landed them via module PRs which is technically scope-creep but pragmatic given the time.
+
+## Excluded
+
+None this sprint — all 15 picks landed.
+
+## Follow-ups filed during sprint
+
+- #2052 — pre-existing `waitForEvent` gap in type stubs (filed by #2017 QA)
+- #2055 — Bun segfault when running both worker-heavy spec files together (filed by #2040 QA — user's reported segfault from earlier in the session)
+- #2060, #2061, #2062 — non-blocking follow-ups from #1395 QA (didn't capture titles inline)
+
+## Carry-forward for retro
+
+1. **The framework executor pattern** — #2018 shipped declarative action shapes (`set-state`, `bye-and-untrack`) without executors. Module PRs (#2021, #2020) had to add the executors themselves. Sprint 55 should land a framework patch ensuring all action types declared in the schema have a real executor or are removed.
+2. **Daemon restart mid-sprint** — #2019 merging required a daemon restart to pick up the new manifest schema. The restart killed 4 in-flight sessions. Acceptable here (work was pushed) but a schema-affecting PR landing mid-sprint should either pre-flight a restart window or use a more permissive parser.
+3. **Per-action tool-permission requests** — multiple workers asked for `Edit`/`Write`/`Bash` per-action despite `--allow Read Glob Grep Write Edit Bash` at spawn. The allowlist may not be propagating, or the daemon's permission router has a per-call gate. File an issue.
+4. **Quota pause + user override pattern** — see `~/.claude/.../memory/feedback_quota_pause_with_override.md`. At 100% 5-hour, the orchestrator paused; user explicitly approved overage to land the automation chain. The default (pause) is correct; the override is real cost.
+5. **Nerd-snipe theory wrong but adversarial review catches it** — #2015 was the marquee gate validation this sprint. Reviewers running tests locally against the proposed fix > trusting the diagnosis.
+6. **Reviewer self-repair worked 4× this sprint** (#1395 round 1, #2018 round 1, #2018 round 2, #2019, #2020 partial). Significant compounding savings vs spawning fresh opus repair.

--- a/.claude/sprints/sprint-54.md
+++ b/.claude/sprints/sprint-54.md
@@ -1,0 +1,257 @@
+# Sprint 54
+
+> Planned 2026-05-17 19:53 EST. Target: 15 PRs.
+
+## Goal
+
+**"Ship the automation-modules epic scaffold + first two modules so the
+orchestrator stops being a polling event-loop. Clean up the
+parallel-CI flake cluster (not just one symptom). Close sprint-53
+fallout."**
+
+Sprint 53 was 12 PRs in 72 minutes, but every minute of that wall-clock
+was an orchestrator manually triaging events, flipping labels, rerunning
+CI, byeing sessions. The Monitor stream surfaced the events but the
+*loop* was still me. That's exactly what #2018 (automation modules)
+attacks: declarative, event-triggered phase transitions defined in
+`.mcx.yaml` instead of orchestrator prose. Ship the scaffold (#2018) +
+the two simplest concrete modules (#2021 bind, #2020 cleanup), and a
+substantial fraction of sprint-53's per-tick orchestrator work becomes
+no-op'd by the framework. The compounding payoff lands sprint-55+.
+
+Side quest: attack the parallel-CI flake **cluster** instead of one
+symptom. #1980 ate 2 sprints. There are 3 more flakes on the board
+(#2015, #2016, #1978) with the same "investigation needed, fix small"
+shape. Nerd-snipe gate all three in one sprint, accept that one may
+hit `needs-attention` (that's the gate working), and stop paying the
+flake tax going forward.
+
+## Issues
+
+| #    | Title                                                                 | Scrutiny | Batch | Model  | Category                  |
+|------|-----------------------------------------------------------------------|----------|-------|--------|---------------------------|
+| 2018 | epic: automation modules — declarative, event-triggered framework     | high     | 1     | opus   | automation arc (epic)     |
+| 2019 | feat(track): per-work-item custom metadata via manifest-declared schema | medium | 1   | opus   | automation arc (substrate)|
+| 2021 | feat(automation): bind module — auto-attach PR + branch on push event | medium   | 2     | opus   | automation arc (proof)    |
+| 2020 | feat(automation): cleanup module — auto-bye + untrack on verified merge | medium | 3   | opus   | automation arc (proof)    |
+| 2015 | flaky(parallel): HTTP/SSE transport + 401 auth daemon-integration tests fail under --parallel | high | 1 | opus | flake cluster (nerd-snipe) |
+| 2016 | flaky(test): colorState + MetricsPanel fail when stdout is a TTY      | low      | 1     | sonnet | flake cluster (quick)     |
+| 1978 | flaky: AcpSession approve() waitForResult timeout in pre-commit hook  | high     | 2     | opus   | flake cluster (nerd-snipe)|
+| 1224 | bug: pull.spec.ts fails in pre-commit hook due to core.hooksPath inherit | low    | 1     | sonnet | flake cluster (quick)     |
+| 2014 | test: refactor daemon-integration.spec.ts to share daemons; drop from TIMING_EXCLUSIONS | medium | 2 | sonnet | flake hardening           |
+| 2025 | bug(claude-ls): `mcx claude ls --all --short` hangs on empty result set | low    | 1     | sonnet | sprint-53 fallout (P1)    |
+| 2040 | test: cover orphan-reaper + claude-server null-ownership paths (#1980) | low     | 2     | sonnet | sprint-53 fallout         |
+| 2036 | build: platform npm packages include bin/.gitkeep in published tarballs | low    | 2     | sonnet | sprint-53 fallout         |
+| 2017 | docs/phases.md: clarify that 'mcp-cli' is a virtual package           | low      | 3     | sonnet | docs / DX                 |
+| 1605 | mcx claude wait: stable header line before JSON for truncation safety | low      | 3     | sonnet | DX (customer-requested)   |
+| 1395 | refactor: deduplicate pollMailUntil/emitMailEvent between claude.ts and agent.ts | low | 3 | sonnet | hygiene                   |
+
+15 work items. **4 high (opus)** — 1 epic, 1 substrate, 2 flake
+nerd-snipes. **4 medium (opus or sonnet)** — 2 automation modules
+(opus, the modules are the proof-of-design and adversarial review
+needs to verify the framework's invariants), 1 daemon-test refactor,
+1 substrate. **7 low (sonnet)**. Much heavier opus profile than
+sprint 53, intentionally — the framework arc is where this sprint
+earns its keep.
+
+## Batch Plan
+
+### Batch 1 (immediate — epic scaffold + flake gates + fallout P1)
+#2018, #2019, #2015, #2016, #2025, #1224
+
+### Batch 2 (the proof modules + fallout + #1978 gate)
+#2021, #1978, #2014, #2040, #2036
+
+### Batch 3 (second proof module + remaining DX)
+#2020, #2017, #1605, #1395
+
+### Cross-issue dependencies (addBlockedBy edges)
+
+- **#2019 blockedBy #2018** — the manifest schema scaffold (#2018) defines
+  the shape of per-work-item custom metadata; #2019 plugs into that
+  shape. Land the framework first.
+- **#2021 blockedBy #2018, blockedBy #2019** — the bind module declares
+  its event subscription via the manifest schema. Needs both.
+- **#2020 blockedBy #2021** — same framework shape, but ordered so the
+  bind module's PR provides a concrete reference for the cleanup
+  module's review. Reviewer can compare the second module against
+  the first to verify the framework's invariants.
+- **#1978 blockedBy nerd-snipe verdict** — gate per
+  [`investigations.md`](../skills/sprint/references/investigations.md).
+  If verdict is `needs-attention`, drop from sprint.
+- **#2015 blockedBy nerd-snipe verdict** — same gate. May also benefit
+  from #2014 landing first (shared-daemon refactor may reduce parallel
+  contention), so #2014 is in Batch 2 ahead of #2015's impl, but
+  #2015's nerd-snipe spawns in Batch 1 alongside #2018's design work
+  (parallel investigation, no shared file).
+- **#2014 implicit ordering wrt #2015** — if #2014 lands first AND the
+  nerd-snipe says #2015's cause is per-test daemon load, #2015 impl
+  may be trivial. Re-evaluate after #2014's QA pass.
+
+5 explicit blockedBy edges (4 within the automation arc, 1 across
+flakes), 2 nerd-snipe gates that may resolve to `needs-attention`.
+This is the heaviest dependency graph this project has run; the
+automation arc is the entire point.
+
+### Flake nerd-snipe gate (per investigations.md)
+
+**Two flake nerd-snipes this sprint**: #2015 and #1978. Sprint 53's
+flake nerd-snipe (#1980) demonstrated the gate works: the diagnosis
+was incomplete but the gate caught a concrete root cause + fix plan
+before impl. QA then caught the gap. Accept that one of (#2015, #1978)
+may hit `needs-attention` — that's the gate working, not the gate
+failing. The cost of `needs-attention` is one sprint slot; the cost
+of impl-on-hope is sprint 47's coverage-CI-retry mess that ate
+months.
+
+Spawn shape (binding): `mcx claude spawn --worktree --model opus -t
+"You are nerd-snipe..."` — NOT the Agent tool. See #2009. Persona
+must be inlined; `do NOT invoke the Agent tool yourself` must appear
+verbatim in the prompt.
+
+**Per-flake context to seed the spawn:**
+
+- **#2015**: 22 daemon spawns, ~12s wall, tests P3b (HTTP) + P3c (SSE)
+  flake under `bun test --parallel`. Investigation body suggests 3
+  hypotheses (socket-readiness race, startTestDaemon polls, 401 test
+  race). Nerd-snipe should pick the verifiable one + post bisect
+  before any impl. May share root cause with #1980's PID-recycling
+  pattern (concurrent `Bun.spawn` load contention).
+- **#1978**: AcpSession `approve()` `waitForResult` times out after
+  965s under pre-commit hook load. Could be test logic (infinite
+  poll loop) or real daemon hang on resource pressure. Nerd-snipe
+  must reproduce locally — sprint 53's lesson: "reproduce locally
+  before claiming a fix."
+
+### Hot-shared file watch
+
+- `.mcx.yaml` and `.claude/phases/*.ts` — #2018, #2019, #2021, #2020
+  all touch. **Serialized via the blockedBy edges above.** The four
+  PRs land in a strict chain.
+- `packages/daemon/src/site/...` — none picked this sprint.
+- `test/daemon-integration.spec.ts` — #2014 only (impl); #2015's
+  flake fix may also land here depending on nerd-snipe verdict.
+  Watch for late conflict.
+- `packages/command/src/commands/claude.ts` — #1605 (wait header)
+  + #1395 (extract mail-wait helper). Disjoint regions. **Flagged,
+  not serialized** — second to merge rebases trivially.
+- `packages/daemon/src/work-items/` (or wherever the tracked-item
+  state lives) — #2019 only this sprint. The substrate change.
+
+### No #2042 / #2012 picks
+
+- **#2042 (mcx gc parsing)** — Explore agent flagged root cause
+  unclear; the parsing code in `getMergedBranches` looks correct.
+  Defer until either the user repros or someone explicitly traces
+  where the `+ ` prefix is fed back from.
+- **#2012 (clock-inject StuckDetector)** — sub-500ms wall savings,
+  19-test rewrite cost. Off the critical path. Defer indefinitely;
+  pick up in a "test perf" sprint if one ever materializes.
+
+## Context
+
+**Sprint-53 outcome**: 12 PRs merged + 1 already-done (#1645),
+v1.8.7 released. 47-sprint flake epic (#1980/#1987) finally closed.
+Reviewer self-repair pattern (#1944) and nerd-snipe gate (#1980)
+both proved their worth in production. User PR #2037 (am-i-done MVP)
+is open mid-sprint; user is handling.
+
+**Why the automation arc matters now**: sprint 53's orchestrator
+loop made ~50 distinct `mcx phase run` calls, ~30 `gh pr view` /
+`gh api` calls, ~15 label-flip operations, ~6 manual CI reruns. Each
+was an orchestrator decision based on a Monitor event payload.
+Roughly two-thirds of those decisions are formulaic — they're
+exactly what an event-triggered framework executes deterministically:
+"on `ci.finished` with `allGreen=true` and `state=CLEAN`: arm
+auto-merge"; "on `pr.merged`: bye the impl session if alive". #2018
+defines the manifest shape for these subscriptions, #2019 stores
+the per-work-item state the modules read, #2021 and #2020 prove the
+framework on the two simplest event types. Sprint-55's orchestrator
+loop should drop ~40% of those tick operations.
+
+**Why the flake-cluster vs one-flake-at-a-time**: sprint 53's
+post-mortem showed #1980's nerd-snipe took two passes because the
+diagnosis was partial. The fix is good but the *process* was
+expensive. Batching three flake nerd-snipes (one of which may
+already be straight-forward post-#2014) amortizes the per-flake
+context-load cost across the sprint. Two of the three may need
+multiple rounds; that's fine, the cluster is a cooldown bet that
+pays out for the test suite as a whole.
+
+**Plan-time triage** (verify-still-open, with just-in-time recheck
+because sprint 53's plan-time triage missed two already-done picks
+that merged ~12h before sprint start):
+- All 15 picks verified open at plan time (2026-05-17 19:53 EST).
+- #2018, #2019, #2020, #2021, #2022, #2023 reviewed together;
+  #2022 (auto-merge module) deferred to sprint 55 to keep the arc
+  scope to "framework + 2 modules proving 2 event types"; #2023
+  (`ctx.gh` first-class) is a separate concern (extending the
+  alias API, not the work-item lifecycle), deferred.
+- #2025: re-confirmed P1 — running the command verbatim hangs.
+  Isolated to non-JSON `--all --short` formatter.
+- #1928 (closed at plan time as already-done — fixed in PR #1918).
+- #1686 (closed at plan time as dup of #1673).
+- #1673 dropped from this sprint as Bun.sleep lint addition — pure
+  tooling improvement, no urgency, defer to a cleanup sprint.
+
+**Plan-time meta-fixes**: None this sprint. No `label:meta` issues
+open.
+
+**Risks**:
+- **#2018 scope blow-up**: epic-labeled, framework-shaped. Risk is
+  the impl session designs too much in one PR. Adversarial review
+  must enforce: only the schema + module loader + event dispatch.
+  No actual module logic in #2018's PR — that's what #2021 and #2020
+  prove. If the impl session bundles a module into #2018's PR, send
+  back to repair to extract it.
+- **#2021 / #2020 reviewer comparison**: the second module's reviewer
+  should explicitly diff against the first to verify the framework
+  abstractions hold up. If the second module needs to break the
+  framework's invariants to work, that's a #2018 redesign — surface
+  to retro, don't paper over.
+- **Flake nerd-snipe `needs-attention` budget**: budget for 1 of 2
+  nerd-snipes to hit the hard-fail outcome. If both hit
+  `needs-attention`, treat that as a signal that the flake-cluster
+  approach isn't reproducible enough yet; split each into its own
+  sprint with a user-led pre-investigation.
+- **Opus quota**: 4 opus picks this sprint vs sprint 53's 2 opus.
+  Watch the 5-hour quota during the framework batch; if utilization
+  trends toward 80% mid-sprint, finish-in-flight on the modules
+  before spawning #1978's nerd-snipe.
+- **#1605 vs #1486 epic**: same caveat as sprint 53 — keep #1605's
+  scope to the wait command's output formatter. Don't bundle in
+  monitor-epic refactoring.
+
+**Releasability**: bug fixes + framework feature + flake fixes +
+test back-fills. If the automation framework lands cleanly, this is
+a **minor** bump (v1.9.0) — `.mcx.yaml` gets a new top-level
+section (`automation:`/`modules:`), which arguably qualifies as a
+new public surface. If the framework slips and only fallout +
+flakes land, patch (v1.8.8). Defer the call to retro.
+
+## Process notes (carry-forward from sprint 53)
+
+1. **Capture phase JSON once, extract both fields** (still applies).
+2. **Verify cwd before every compound `git commit` shell command** —
+   sprint 53's direct-to-main accident. `pwd` first. Use absolute paths.
+3. **`mcx claude bye` returns multi-line JSON** — parse with
+   `jq -r '...'`, not `tail -1`.
+4. **Flip `qa:fail` → `qa:pass` label** when the QA verdict
+   explicitly diagnoses the failure as a known flake AND CI rerun
+   is green.
+5. **Reviewer self-repair beats fresh opus repair** when findings
+   are contained + diagnosed. Saved one opus spawn on #1944 in
+   sprint 53.
+6. **Nerd-snipe spawn shape** is `mcx claude spawn --worktree
+   --model opus -t "..."`, NOT the Agent tool. Persona inlined.
+   See `investigations.md`.
+7. **Sprint-53 lesson — nerd-snipe must reproduce locally** before
+   posting a fix plan. The CI-log-only bisect on #1980 was partially
+   wrong because it never ran the failing test under load.
+8. **Verify auto-merge with `state == MERGED && mergedAt != null`**.
+9. **One TaskCreate per issue** with addBlockedBy edges from the
+   dependency list. **(5 edges this sprint — the heaviest yet.)**
+10. **No `Bun.sleep` in test fixes**.
+11. **Use the `Monitor` harness tool, not raw Bash `mcx monitor`**.
+12. **Plan-time triage step** caught 1 already-done (#1928) + 1 dup
+    (#1686) at sprint-54 plan time. The discipline is working.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "bun": ">=1.2.18"
   },
-  "version": "1.8.7",
+  "version": "1.9.0",
   "description": "MCP CLI — call MCP server tools from the command line with zero context overhead",
   "type": "module",
   "workspaces": ["packages/*"],


### PR DESCRIPTION
Sprint 54 container PR. Accumulates every sprint-meta commit on the
`sprint-54` branch:

- plan + any mid-sprint amendments
- run-time edits (Started/Ended timestamps, Excluded section)
- Results summary
- retro diary file
- release commit (if a release is cut this sprint)

Marked **draft** until `/sprint retro` flips it ready and arms auto-merge.

Goal: stop the orchestrator from being a polling event-loop. Ship #2018
(automation modules framework) + #2019 (per-work-item metadata) + #2021
(bind module) + #2020 (cleanup module) — 4-PR chain that converts a
substantial fraction of sprint-53's per-tick orchestrator work into
declarative event-triggered phase transitions. Side quest: attack the
parallel-CI flake cluster (#2015, #1978, #2016, #1224) instead of one
flake at a time. Plus must-do sprint-53 fallout.

Docs/skill-only by construction — pre-commit hooks should skip the test suite.