### PR TITLE
fix(clone): clear core.hooksPath in initGitRepo to prevent pre-commit hook inheritance (fixes #1224)

### DIFF
--- a/packages/clone/src/engine/pull.spec.ts
+++ b/packages/clone/src/engine/pull.spec.ts
@@ -64,6 +64,9 @@ function initGitRepo(): void {
   const env = cleanEnv();
   const gitOpts = { cwd: repoDir, stdio: "pipe" as const, env };
   execSync("git init", gitOpts);
+  // Prevent inheriting core.hooksPath from the parent repo's config; temp repos
+  // have no hook structure and would trigger the parent pre-commit hook otherwise.
+  execSync("git config core.hooksPath ''", gitOpts);
   execSync("git config user.name Test", gitOpts);
   execSync("git config user.email test@test.com", gitOpts);
   writeFileSync(join(repoDir, ".gitignore"), ".clone/\n");

--- a/packages/clone/src/engine/pull.spec.ts
+++ b/packages/clone/src/engine/pull.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { execSync } from "node:child_process";
+import { execFileSync, execSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -64,9 +64,10 @@ function initGitRepo(): void {
   const env = cleanEnv();
   const gitOpts = { cwd: repoDir, stdio: "pipe" as const, env };
   execSync("git init", gitOpts);
-  // Prevent inheriting core.hooksPath from the parent repo's config; temp repos
-  // have no hook structure and would trigger the parent pre-commit hook otherwise.
-  execSync("git config core.hooksPath ''", gitOpts);
+  // Guard against a global/system core.hooksPath (e.g. set by the prepare script
+  // in a CI or developer environment) triggering hooks in temp repos that have no
+  // hook structure. argv form avoids shell quoting so the empty string is portable.
+  execFileSync("git", ["config", "core.hooksPath", ""], gitOpts);
   execSync("git config user.name Test", gitOpts);
   execSync("git config user.email test@test.com", gitOpts);
   writeFileSync(join(repoDir, ".gitignore"), ".clone/\n");


### PR DESCRIPTION
## Summary
- `pull.spec.ts` runs `git commit` in temp repos; those repos inherited `core.hooksPath = .git-hooks` from the parent repo (set by the `prepare` script), causing git to invoke the parent's pre-commit hook inside temp dirs that have no hook structure
- Added `git config core.hooksPath ''` immediately after `git init` in `initGitRepo()` to disable hook execution in temp repos
- `cleanEnv()` already strips `GIT_*` env vars, but `core.hooksPath` is a git config key (not an env var), so this separate config step is required

## Test plan
- [x] `bun test packages/clone/src/engine/pull.spec.ts` — all 20 tests pass
- [x] `bun typecheck` — clean
- [x] `bun lint:check` — clean
- [x] Pre-commit hook ran full suite and committed cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)