### PR TITLE
fix(test): pin NO_COLOR in preload to prevent TTY color leakage (closes #2016)

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -5,5 +5,9 @@
 # when coverage is collected on files with 0% coverage, even without a
 # configured threshold. This broke CI (see #1181).
 
+# Pin NO_COLOR=1 before any module loads so ANSI codes never leak into
+# assertions when bun test runs under a PTY. See #2016.
+preload = ["./test/preload-no-color.ts"]
+
 # Prune directories that should not be scanned for tests
 pathIgnorePatterns = [".claude/**", "dist/**", ".git-hooks/**"]

--- a/test/preload-no-color.ts
+++ b/test/preload-no-color.ts
@@ -1,0 +1,5 @@
+// Pin NO_COLOR before any module captures process.stdout.isTTY.
+// Prevents ANSI escape codes from leaking into assertions when bun test
+// runs under a PTY (interactive terminal). See #2016.
+process.env.NO_COLOR = "1";
+process.env.FORCE_COLOR = "0";


### PR DESCRIPTION
## Summary
- Adds `test/preload-no-color.ts` that sets `NO_COLOR=1` and `FORCE_COLOR=0` before any module loads
- Registers the preload in `bunfig.toml` so it runs for every `bun test` invocation
- Eliminates the entire class of TTY-vs-CI skew failures where ANSI escape codes leaked into assertions under a PTY

## Test plan
- [ ] `bun test packages/command/src/commands/claude.spec.ts -t "pads state"` passes (was broken under PTY)
- [ ] `bun test packages/control/src/components/metrics-panel.spec.ts` passes (was broken under PTY)
- [ ] Full `bun test` suite: 7079 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)