### PR TITLE
fix(npm): enumerate explicit binaries in platform package files fields (closes #2036)

### DIFF
--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -4,7 +4,7 @@
   "description": "mcp-cli native binaries for macOS ARM64",
   "os": ["darwin"],
   "cpu": ["arm64"],
-  "files": ["bin/"],
+  "files": ["bin/mcx", "bin/mcpd", "bin/mcpctl"],
   "publishConfig": {
     "access": "public"
   }

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -4,7 +4,7 @@
   "description": "mcp-cli native binaries for macOS x64",
   "os": ["darwin"],
   "cpu": ["x64"],
-  "files": ["bin/"],
+  "files": ["bin/mcx", "bin/mcpd", "bin/mcpctl"],
   "publishConfig": {
     "access": "public"
   }

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -4,7 +4,7 @@
   "description": "mcp-cli native binaries for Linux ARM64",
   "os": ["linux"],
   "cpu": ["arm64"],
-  "files": ["bin/"],
+  "files": ["bin/mcx", "bin/mcpd", "bin/mcpctl"],
   "publishConfig": {
     "access": "public"
   }

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -4,7 +4,7 @@
   "description": "mcp-cli native binaries for Linux x64",
   "os": ["linux"],
   "cpu": ["x64"],
-  "files": ["bin/"],
+  "files": ["bin/mcx", "bin/mcpd", "bin/mcpctl"],
   "publishConfig": {
     "access": "public"
   }

--- a/scripts/verify-npm-pack.spec.ts
+++ b/scripts/verify-npm-pack.spec.ts
@@ -77,7 +77,7 @@ describe("platform package npm pack structure", () => {
       };
 
       test("files field lists exact binaries (no .gitkeep)", () => {
-        expect(pkg.files).toEqual(["bin/mcx", "bin/mcpd", "bin/mcpctl"]);
+        expect(pkg.files).toEqual(BINARIES.map((b) => `bin/${b}`));
       });
 
       test("has correct os and cpu selectors", () => {

--- a/scripts/verify-npm-pack.spec.ts
+++ b/scripts/verify-npm-pack.spec.ts
@@ -76,8 +76,8 @@ describe("platform package npm pack structure", () => {
         cpu: string[];
       };
 
-      test("files field is exactly ['bin/']", () => {
-        expect(pkg.files).toEqual(["bin/"]);
+      test("files field lists exact binaries (no .gitkeep)", () => {
+        expect(pkg.files).toEqual(["bin/mcx", "bin/mcpd", "bin/mcpctl"]);
       });
 
       test("has correct os and cpu selectors", () => {


### PR DESCRIPTION
## Summary
- Change `"files": ["bin/"]` to `["bin/mcx", "bin/mcpd", "bin/mcpctl"]` in all four platform `package.json` files (`darwin-arm64`, `darwin-x64`, `linux-arm64`, `linux-x64`)
- This prevents `bin/.gitkeep` (restored by #2031) from being included in published tarballs — `files` directory entries include all contents, explicit file entries do not
- Update `verify-npm-pack.spec.ts` assertion to match the new exact files list

## Test plan
- [ ] `bun test scripts/verify-npm-pack.spec.ts` — 31 tests pass with updated assertion
- [ ] Full `bun test` — 7079 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)