### PR TITLE
test: cover orphan-reaper and claude-server null-ownership paths (closes #2040)

### DIFF
--- a/packages/daemon/src/claude-server.spec.ts
+++ b/packages/daemon/src/claude-server.spec.ts
@@ -502,6 +502,58 @@ describe("ClaudeServer", () => {
     server = undefined; // prevent double stop
   });
 
+  // ── restoreActiveSessions — null ownership paths ──
+
+  test("restoreActiveSessions: null ownership + dead PID → session ended", () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new ClaudeServer(
+      db,
+      undefined,
+      undefined,
+      silentLogger,
+      10_000,
+      undefined,
+      undefined,
+      undefined,
+      () => null,
+    );
+
+    db.upsertSession({ sessionId: "restore-null-dead", state: "running", pid: 88888, pidStartTime: 1000000 });
+
+    const restore = (server as unknown as { restoreActiveSessions: () => void }).restoreActiveSessions.bind(server);
+    restore();
+
+    const row = db.getSession("restore-null-dead");
+    expect(row?.state).toBe("ended");
+    expect(row?.endedAt).not.toBeNull();
+  });
+
+  test("restoreActiveSessions: null ownership + alive PID → session preserved", () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new ClaudeServer(
+      db,
+      undefined,
+      undefined,
+      silentLogger,
+      10_000,
+      undefined,
+      undefined,
+      undefined,
+      () => null,
+    );
+
+    db.upsertSession({ sessionId: "restore-null-alive", state: "running", pid: process.pid, pidStartTime: 1000000 });
+
+    const restore = (server as unknown as { restoreActiveSessions: () => void }).restoreActiveSessions.bind(server);
+    restore();
+
+    const row = db.getSession("restore-null-alive");
+    expect(row?.state).not.toBe("ended");
+    expect(row?.endedAt).toBeNull();
+  });
+
   // ── Crash recovery ──
 
   test("handleWorkerCrash ends orphaned sessions after successful restart", async () => {

--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -76,6 +76,7 @@ export class ClaudeServer extends AbstractWorkerServer {
   private wsPort: number | null = null;
   private readonly configuredWsPort?: number;
   private readonly getProcessStartTimeFn: (pid: number) => number | null;
+  private readonly isOurProcessFn: (pid: number, storedStartTimeMs: number) => boolean | null;
   private readonly sessionPids = new Map<string, number>();
   private readonly sessionPidStartTimes = new Map<string, number>();
   private readonly sessionLastCost = new Map<string, number>();
@@ -96,10 +97,12 @@ export class ClaudeServer extends AbstractWorkerServer {
     configuredWsPort?: number,
     getProcessStartTimeFn: (pid: number) => number | null = defaultGetProcessStartTime,
     metricsCollector?: MetricsCollector,
+    isOurProcessFn: (pid: number, storedStartTimeMs: number) => boolean | null = isOurProcess,
   ) {
     super(db, daemonId, clientFactory, logger, handshakeTimeoutMs, metricsCollector);
     this.configuredWsPort = configuredWsPort;
     this.getProcessStartTimeFn = getProcessStartTimeFn;
+    this.isOurProcessFn = isOurProcessFn;
     this.daemonSpan = startSpan("mcpd");
   }
 
@@ -313,7 +316,7 @@ export class ClaudeServer extends AbstractWorkerServer {
       if (row.state === "ended") return false;
       if (row.pid != null) {
         if (row.pidStartTime != null) {
-          const ownership = isOurProcess(row.pid, row.pidStartTime);
+          const ownership = this.isOurProcessFn(row.pid, row.pidStartTime);
           if (ownership === false) {
             this.logger.warn(
               `[claude-server] Skipping restore of session ${row.sessionId} — pid ${row.pid} has been recycled`,

--- a/packages/daemon/src/orphan-reaper.spec.ts
+++ b/packages/daemon/src/orphan-reaper.spec.ts
@@ -161,4 +161,28 @@ describe("reapOrphanedSessions", () => {
 
     expect(result).toBe(0);
   });
+
+  test("null ownership + alive PID → session preserved (ownership uncertain)", () => {
+    const db = createDb();
+    db.upsertSession({ sessionId: "sess-null-alive", state: "running", pid: process.pid, pidStartTime: 1000000 });
+
+    const { logger, messages } = capturingLogger();
+    const result = reapOrphanedSessions(db, logger, { isOurProcess: () => null });
+
+    expect(result).toBe(0);
+    expect(db.listSessions(true)).toHaveLength(1);
+    expect(messages.some((m) => m.level === "info" && String(m.args[0]).includes("ownership uncertain"))).toBe(true);
+  });
+
+  test("null ownership + dead PID → session cleaned up", () => {
+    const db = createDb();
+    db.upsertSession({ sessionId: "sess-null-dead", state: "running", pid: 88888, pidStartTime: 1000000 });
+
+    const { logger, messages } = capturingLogger();
+    const result = reapOrphanedSessions(db, logger, { isOurProcess: () => null });
+
+    expect(result).toBe(1);
+    expect(db.listSessions(true)).toHaveLength(0);
+    expect(messages.some((m) => m.level === "warn" && String(m.args[0]).includes("no longer alive"))).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `isOurProcessFn` as an injectable constructor param on `ClaudeServer` (defaults to `isOurProcess`) so the null-ownership path in `restoreActiveSessions` is testable without module mocking
- Adds 2 tests to `orphan-reaper.spec.ts`: null-ownership + alive PID → session preserved; null-ownership + dead PID → session cleaned up
- Adds 2 tests to `claude-server.spec.ts`: calls `restoreActiveSessions` directly with `() => null` for both dead and alive PID cases

## Test plan
- [ ] `bun test packages/daemon/src/orphan-reaper.spec.ts` — 2 new tests pass, covering both null-path branches
- [ ] `bun test packages/daemon/src/claude-server.spec.ts` — 2 new tests pass, covering null ownership in restoreActiveSessions
- [ ] Full `bun test` — 7083 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)