### PR TITLE
test(claude-ls): regression tests for --all --short empty result set (fixes #2025)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -1548,15 +1548,18 @@ describe("mcx claude ls", () => {
     } finally {
       console.error = origErr;
     }
-  });
+  }, 2000);
 
-  test("--all --short with sessions outputs compact one-line-per-session", async () => {
+  test("--all --short with sessions bypasses repo-root filter and outputs compact lines", async () => {
     const sessions = [
       { ...SESSION_LIST[0], repoRoot: "/repo/a" },
       { ...SESSION_LIST[1], repoRoot: "/repo/b" },
     ];
     const deps = makeDeps({
       callTool: mock(async () => toolResult(sessions)),
+      // Non-null getGitRoot so the non-all path would scope by /repo/a;
+      // --all must still call with {} (no repoRoot filter).
+      getGitRoot: mock(() => "/repo/a"),
     });
 
     const logSpy = mock(() => {});
@@ -1564,7 +1567,9 @@ describe("mcx claude ls", () => {
     console.log = logSpy;
     try {
       await cmdClaude(["ls", "--all", "--short"], deps);
+      // Bypass verified: no repoRoot or scopeRoot in the call args
       expect(deps.callTool).toHaveBeenCalledWith("claude_session_list", {});
+      // Short formatter: one line per session, no header
       expect(logSpy.mock.calls.length).toBe(2);
       const line1 = (logSpy.mock.calls[0] as string[])[0];
       expect(line1).toContain("abc12345");

--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -1534,6 +1534,47 @@ describe("mcx claude ls", () => {
     }
   });
 
+  test("--all --short with empty result set exits immediately (regression #2025)", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult([])),
+    });
+
+    const errSpy = mock(() => {});
+    const origErr = console.error;
+    console.error = errSpy;
+    try {
+      await cmdClaude(["ls", "--all", "--short"], deps);
+      expect(errSpy).toHaveBeenCalledWith("No active sessions.");
+    } finally {
+      console.error = origErr;
+    }
+  });
+
+  test("--all --short with sessions outputs compact one-line-per-session", async () => {
+    const sessions = [
+      { ...SESSION_LIST[0], repoRoot: "/repo/a" },
+      { ...SESSION_LIST[1], repoRoot: "/repo/b" },
+    ];
+    const deps = makeDeps({
+      callTool: mock(async () => toolResult(sessions)),
+    });
+
+    const logSpy = mock(() => {});
+    const origLog = console.log;
+    console.log = logSpy;
+    try {
+      await cmdClaude(["ls", "--all", "--short"], deps);
+      expect(deps.callTool).toHaveBeenCalledWith("claude_session_list", {});
+      expect(logSpy.mock.calls.length).toBe(2);
+      const line1 = (logSpy.mock.calls[0] as string[])[0];
+      expect(line1).toContain("abc12345");
+      const line2 = (logSpy.mock.calls[1] as string[])[0];
+      expect(line2).toContain("def67890");
+    } finally {
+      console.log = origLog;
+    }
+  });
+
   test("shows all sessions when not in a git repo", async () => {
     const sessions = [
       { ...SESSION_LIST[0], repoRoot: "/repo/a" },


### PR DESCRIPTION
## Summary
- Adds a test proving `mcx claude ls --all --short` with 0 sessions exits immediately with "No active sessions." — the code path that was hanging in the stale-binary repro
- Adds a companion test covering `--all --short` with sessions present, confirming the short formatter is called with all sessions (not filtered by repo) and emits one line per session

## Analysis
The hang was not present in current source. The `sessions.length === 0` early-return at line 959-980 fires before the `if (short)` block at line 983, so both `--all` and `--all --short` hit the same return path for empty results. The repro was against a stale `dist/` binary built before recent changes. These tests lock in the correct behavior as a regression guard.

## Test plan
- [ ] `bun test packages/command/src/commands/claude.spec.ts` — 338 pass (2 new)
- [ ] `bun typecheck` — clean
- [ ] `bun lint` — clean
- [ ] Full `bun test` — 7081 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)