### PR TITLE
test(acp): fix race in permission approve/deny waiter registration (fixes #1978)

### DIFF
--- a/packages/acp/src/acp-session.spec.ts
+++ b/packages/acp/src/acp-session.spec.ts
@@ -205,6 +205,7 @@ describe("AcpSession (with fake ACP agent)", () => {
   test("approve() responds to pending permission and resumes session", async () => {
     const { session, events } = makeSession({ agent: "permission" });
 
+    const resultPromise = session.waitForResult(10000);
     await session.start();
     await waitFor(() => events.some((e) => e.type === "session:permission_request"));
 
@@ -214,19 +215,23 @@ describe("AcpSession (with fake ACP agent)", () => {
     );
     if (!permEvent) throw new Error("Expected permission_request event");
 
-    const resultPromise = session.waitForResult(10000);
-    session.approve(permEvent.request.requestId);
+    try {
+      session.approve(permEvent.request.requestId);
 
-    expect(session.currentState).toBe("active");
-    expect(session.getInfo().pendingPermissions).toBe(0);
+      expect(session.currentState).toBe("active");
+      expect(session.getInfo().pendingPermissions).toBe(0);
 
-    const result = await resultPromise;
-    expect(result.type).toBe("session:result");
+      const result = await resultPromise;
+      expect(result.type).toBe("session:result");
+    } finally {
+      session.terminate();
+    }
   });
 
   test("deny() responds to pending permission and resumes session", async () => {
     const { session, events } = makeSession({ agent: "permission" });
 
+    const resultPromise = session.waitForResult(10000);
     await session.start();
     await waitFor(() => events.some((e) => e.type === "session:permission_request"));
 
@@ -236,13 +241,16 @@ describe("AcpSession (with fake ACP agent)", () => {
     );
     if (!permEvent) throw new Error("Expected permission_request event");
 
-    const resultPromise = session.waitForResult(10000);
-    session.deny(permEvent.request.requestId);
+    try {
+      session.deny(permEvent.request.requestId);
 
-    expect(session.currentState).toBe("active");
+      expect(session.currentState).toBe("active");
 
-    const result = await resultPromise;
-    expect(result.type).toBe("session:result");
+      const result = await resultPromise;
+      expect(result.type).toBe("session:result");
+    } finally {
+      session.terminate();
+    }
   });
 
   test("send() starts a follow-up prompt after first completes", async () => {


### PR DESCRIPTION
## Summary
- Move `waitForResult(10000)` before `session.start()` in the `approve()` and `deny()` permission tests, matching the registration pattern every other test in the file uses
- Add `try/finally` with `session.terminate()` to prevent orphan child processes on assertion failure (root cause of the 965s wallclock hang reported in the issue)
- No production code changes — test-only fix addressing a race where `session:result` fires before the waiter is registered

## Test plan
- [x] `bun test packages/acp/src/acp-session.spec.ts` — 28/28 pass
- [x] Full suite: 7076 pass, 3 pre-existing failures in `alias-bundle-tsc.spec.ts` (timeout, unrelated)
- [x] Typecheck clean
- [x] Lint clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)