### PR TITLE
refactor: extract pollMailUntil/emitMailEvent to shared mail-wait.ts (closes #1395)

### DIFF
--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -1046,7 +1046,7 @@ async function agentWait(
       mailPoll.then((m) => ({ kind: "mail" as const, message: m })),
     ]);
     if (winner.kind === "mail" && winner.message) {
-      emitMailEvent(winner.message, short, d);
+      emitMailEvent(winner.message, short, d, false);
       return;
     }
     result = winner.kind === "session" ? winner.result : await waitPromise;

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -12,6 +12,7 @@ import { existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import type { AgentFeatures, AgentProvider, MailMessage } from "@mcp-cli/core";
 import { CLAUDE_SUB_ALIASES, formatHelp, getHelp, hasHelpFlag } from "../help";
+import { emitMailEvent, pollMailUntil } from "./mail-wait";
 import "../help-claude";
 import {
   DEFAULT_TIMEOUT_MS,
@@ -195,51 +196,6 @@ export function makeDefaultDeps(provider: AgentProvider): AgentDeps {
 }
 
 // ── Helpers ──
-
-/**
- * Poll for unread mail addressed to `recipient` until one arrives or the
- * deadline expires. Non-consuming — does not markRead, so the caller can
- * still read the message via `mcx mail -u <recipient>` afterward.
- *
- * `afterMs` is a `Date.now()` snapshot taken before polling begins. Only
- * mail with `createdAt` strictly after that timestamp is surfaced, so
- * pre-existing unread messages do not cause false-positive wakeups.
- *
- * Transient `pollMail` errors (IPC blips, daemon restart) are swallowed
- * and retried until the deadline; a single network hiccup will not kill
- * the entire wait.
- */
-async function pollMailUntil(
-  d: Pick<AgentDeps, "pollMail">,
-  recipient: string,
-  timeoutMs: number,
-  afterMs: number,
-  pollIntervalMs = 2000,
-): Promise<MailMessage | null> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    let msg: MailMessage | null = null;
-    try {
-      msg = await d.pollMail(recipient);
-    } catch {
-      // Transient IPC error — continue polling until deadline
-    }
-    if (msg && new Date(msg.createdAt).getTime() > afterMs) return msg;
-    const remaining = deadline - Date.now();
-    if (remaining <= 0) break;
-    await Bun.sleep(Math.min(pollIntervalMs, remaining));
-  }
-  return null;
-}
-
-function emitMailEvent(msg: MailMessage, short: boolean, d: Pick<AgentDeps, "log">): void {
-  if (short) {
-    const subj = msg.subject ?? "(no subject)";
-    d.log(`mail ${msg.id} ${msg.sender} ${subj}`);
-    return;
-  }
-  d.log(JSON.stringify({ source: "mail", mail: msg }, null, 2));
-}
 
 /** Check if an error indicates the daemon is not running (ECONNREFUSED/ENOENT). */
 function isDaemonUnavailable(err: unknown): boolean {

--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -2656,18 +2656,13 @@ describe("claudeWait --mail-to", () => {
       read: false,
       createdAt: new Date(Date.now() + 60_000).toISOString(),
     };
+    const logSpy = mock(() => {});
     const deps = makeDeps({
       callTool: mock(() => new Promise(() => {})) as unknown as ClaudeDeps["callTool"],
       pollMail: mock(async (recipient: string) => (recipient === "orchestrator" ? newMail : null)),
+      log: logSpy,
     });
-    const origLog = console.log;
-    const logSpy = mock(() => {});
-    console.log = logSpy;
-    try {
-      await cmdClaude(["wait", "--mail-to", "orchestrator", "--timeout", "5000"], deps);
-    } finally {
-      console.log = origLog;
-    }
+    await cmdClaude(["wait", "--mail-to", "orchestrator", "--timeout", "5000"], deps);
     // First call is the header line, second is the JSON payload
     const header = String((logSpy.mock.calls as unknown[][])[0][0]);
     expect(header).toContain("event=mail");
@@ -2691,6 +2686,7 @@ describe("claudeWait --mail-to", () => {
       read: false,
       createdAt: new Date(Date.now() - 60_000).toISOString(),
     };
+    const logSpy = mock(() => {});
     const deps = makeDeps({
       callTool: mock(async () =>
         toolResult({
@@ -2699,15 +2695,9 @@ describe("claudeWait --mail-to", () => {
         }),
       ),
       pollMail: mock(async () => staleMail),
+      log: logSpy,
     });
-    const origLog = console.log;
-    const logSpy = mock(() => {});
-    console.log = logSpy;
-    try {
-      await cmdClaude(["wait", "--mail-to", "orchestrator", "--timeout", "100"], deps);
-    } finally {
-      console.log = origLog;
-    }
+    await cmdClaude(["wait", "--mail-to", "orchestrator", "--timeout", "100"], deps);
     const output = (logSpy.mock.calls as unknown[][]).map((c) => String(c[0])).join("\n");
     expect(output).not.toContain('"source": "mail"');
   });
@@ -2725,21 +2715,16 @@ describe("claudeWait --mail-to", () => {
       createdAt: new Date(Date.now() + 60_000).toISOString(),
     };
     let calls = 0;
+    const logSpy = mock(() => {});
     const deps = makeDeps({
       callTool: mock(() => new Promise(() => {})) as unknown as ClaudeDeps["callTool"],
       pollMail: mock(async () => {
         if (calls++ === 0) throw new Error("ECONNREFUSED");
         return newMail;
       }),
+      log: logSpy,
     });
-    const origLog = console.log;
-    const logSpy = mock(() => {});
-    console.log = logSpy;
-    try {
-      await cmdClaude(["wait", "--mail-to", "orchestrator", "--timeout", "5000"], deps);
-    } finally {
-      console.log = origLog;
-    }
+    await cmdClaude(["wait", "--mail-to", "orchestrator", "--timeout", "5000"], deps);
     // First call is the header line, second is the JSON payload
     const header = String((logSpy.mock.calls as unknown[][])[0][0]);
     expect(header).toContain("event=mail");

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -45,6 +45,7 @@ import { parseSharedSpawnArgs } from "./spawn-args";
 import { ttyOpen } from "./tty";
 
 import type { MailMessage, QuotaStatusResult, SessionInfo, WorkItem } from "@mcp-cli/core";
+import { emitMailEvent, pollMailUntil } from "./mail-wait";
 
 // ── Dependency injection ──
 
@@ -1749,56 +1750,6 @@ export function parseWaitArgs(args: string[]): WaitArgs {
   return { sessionPrefix, timeout, afterSeq, short, all, any, pr, checks, mailTo, error };
 }
 
-/**
- * Poll for unread mail addressed to `recipient` until one arrives or the
- * deadline expires. Non-consuming — does not markRead, so the caller can
- * still read the message via `mcx mail -u <recipient>` afterward.
- *
- * `afterMs` is a `Date.now()` snapshot taken before polling begins. Only
- * mail with `createdAt` strictly after that timestamp is surfaced, so
- * pre-existing unread messages do not cause false-positive wakeups.
- *
- * Transient `pollMail` errors (IPC blips, daemon restart) are swallowed
- * and retried until the deadline; a single network hiccup will not kill
- * the entire wait.
- *
- * Returns the message, or null on timeout.
- */
-async function pollMailUntil(
-  d: Pick<ClaudeDeps, "pollMail">,
-  recipient: string,
-  timeoutMs: number,
-  afterMs: number,
-  pollIntervalMs = 2000,
-): Promise<MailMessage | null> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    let msg: MailMessage | null = null;
-    try {
-      msg = await d.pollMail(recipient);
-    } catch {
-      // Transient IPC error — continue polling until deadline
-    }
-    if (msg && new Date(msg.createdAt).getTime() > afterMs) return msg;
-    const remaining = deadline - Date.now();
-    if (remaining <= 0) break;
-    await Bun.sleep(Math.min(pollIntervalMs, remaining));
-  }
-  return null;
-}
-
-function emitMailEvent(msg: MailMessage, short: boolean): void {
-  if (short) {
-    const subj = msg.subject ?? "(no subject)";
-    console.log(`mail ${msg.id} ${msg.sender} ${subj}`);
-    return;
-  }
-  const headerParts = ["event=mail", `id=${msg.id}`];
-  if (msg.sender) headerParts.push(`sender=${msg.sender}`);
-  console.log(headerParts.join(" ").slice(0, 120));
-  console.log(JSON.stringify({ source: "mail", mail: msg }, null, 2));
-}
-
 async function claudeWait(args: string[], d: ClaudeDeps): Promise<void> {
   const parsed = parseWaitArgs(args);
 
@@ -1862,7 +1813,7 @@ async function claudeWait(args: string[], d: ClaudeDeps): Promise<void> {
       mailPoll.then((m) => ({ kind: "mail" as const, message: m })),
     ]);
     if (winner.kind === "mail" && winner.message) {
-      emitMailEvent(winner.message, parsed.short);
+      emitMailEvent(winner.message, parsed.short, d);
       return;
     }
     // Mail poll returned null (timed out) or session already won the race.

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -1813,7 +1813,7 @@ async function claudeWait(args: string[], d: ClaudeDeps): Promise<void> {
       mailPoll.then((m) => ({ kind: "mail" as const, message: m })),
     ]);
     if (winner.kind === "mail" && winner.message) {
-      emitMailEvent(winner.message, parsed.short, d);
+      emitMailEvent(winner.message, parsed.short, d, true);
       return;
     }
     // Mail poll returned null (timed out) or session already won the race.

--- a/packages/command/src/commands/mail-wait.spec.ts
+++ b/packages/command/src/commands/mail-wait.spec.ts
@@ -64,10 +64,10 @@ describe("pollMailUntil", () => {
 // ── emitMailEvent ──
 
 describe("emitMailEvent", () => {
-  test("emits header then JSON when short=false (includeHeader=true, default)", () => {
+  test("emits header then JSON when short=false and includeHeader=true", () => {
     const msg = makeMail({ id: 99, sender: "alice" });
     const logSpy = mock((..._args: unknown[]) => {});
-    emitMailEvent(msg, false, { log: logSpy });
+    emitMailEvent(msg, false, { log: logSpy }, true);
     expect(logSpy).toHaveBeenCalledTimes(2);
     const header = String((logSpy.mock.calls[0] as unknown[])[0]);
     expect(header).toContain("event=mail");
@@ -78,10 +78,10 @@ describe("emitMailEvent", () => {
     expect(parsed.mail.id).toBe(99);
   });
 
-  test("emits JSON only when short=false and includeHeader=false", () => {
+  test("emits JSON only when short=false (includeHeader=false, default)", () => {
     const msg = makeMail({ id: 99, sender: "alice" });
     const logSpy = mock((..._args: unknown[]) => {});
-    emitMailEvent(msg, false, { log: logSpy }, false);
+    emitMailEvent(msg, false, { log: logSpy });
     expect(logSpy).toHaveBeenCalledTimes(1);
     const parsed = JSON.parse(String((logSpy.mock.calls[0] as unknown[])[0]));
     expect(parsed.source).toBe("mail");
@@ -108,7 +108,7 @@ describe("emitMailEvent", () => {
   test("long format handles subject:null without crashing", () => {
     const msg = makeMail({ id: 5, sender: "dan", subject: null });
     const logSpy = mock((..._args: unknown[]) => {});
-    emitMailEvent(msg, false, { log: logSpy });
+    emitMailEvent(msg, false, { log: logSpy }, true);
     expect(logSpy).toHaveBeenCalledTimes(2);
     const parsed = JSON.parse(String((logSpy.mock.calls[1] as unknown[])[0]));
     expect(parsed.mail.id).toBe(5);

--- a/packages/command/src/commands/mail-wait.spec.ts
+++ b/packages/command/src/commands/mail-wait.spec.ts
@@ -64,7 +64,7 @@ describe("pollMailUntil", () => {
 // ── emitMailEvent ──
 
 describe("emitMailEvent", () => {
-  test("emits header then JSON when short=false", () => {
+  test("emits header then JSON when short=false (includeHeader=true, default)", () => {
     const msg = makeMail({ id: 99, sender: "alice" });
     const logSpy = mock((..._args: unknown[]) => {});
     emitMailEvent(msg, false, { log: logSpy });
@@ -74,6 +74,16 @@ describe("emitMailEvent", () => {
     expect(header).toContain("id=99");
     expect(header).toContain("sender=alice");
     const parsed = JSON.parse(String((logSpy.mock.calls[1] as unknown[])[0]));
+    expect(parsed.source).toBe("mail");
+    expect(parsed.mail.id).toBe(99);
+  });
+
+  test("emits JSON only when short=false and includeHeader=false", () => {
+    const msg = makeMail({ id: 99, sender: "alice" });
+    const logSpy = mock((..._args: unknown[]) => {});
+    emitMailEvent(msg, false, { log: logSpy }, false);
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(String((logSpy.mock.calls[0] as unknown[])[0]));
     expect(parsed.source).toBe("mail");
     expect(parsed.mail.id).toBe(99);
   });

--- a/packages/command/src/commands/mail-wait.spec.ts
+++ b/packages/command/src/commands/mail-wait.spec.ts
@@ -1,0 +1,106 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { MailMessage } from "@mcp-cli/core";
+import { emitMailEvent, pollMailUntil } from "./mail-wait";
+
+function makeMail(overrides: Partial<MailMessage> = {}): MailMessage {
+  return {
+    id: 1,
+    sender: "alice",
+    recipient: "bob",
+    subject: "hello",
+    body: "world",
+    replyTo: null,
+    read: false,
+    createdAt: new Date(Date.now() + 60_000).toISOString(),
+    ...overrides,
+  };
+}
+
+// ── pollMailUntil ──
+
+describe("pollMailUntil", () => {
+  test("returns message when createdAt is after afterMs", async () => {
+    const msg = makeMail();
+    const d = { pollMail: mock(async () => msg) };
+    const afterMs = Date.now();
+    const result = await pollMailUntil(d, "bob", 5000, afterMs, 10);
+    expect(result).toBe(msg);
+  });
+
+  test("returns null on timeout when no mail arrives", async () => {
+    const d = { pollMail: mock(async () => null) };
+    const result = await pollMailUntil(d, "bob", 50, Date.now(), 10);
+    expect(result).toBeNull();
+  });
+
+  test("filters out messages with createdAt before afterMs (HWM filter)", async () => {
+    const stale = makeMail({ createdAt: new Date(Date.now() - 60_000).toISOString() });
+    const d = { pollMail: mock(async () => stale) };
+    const result = await pollMailUntil(d, "bob", 50, Date.now(), 10);
+    expect(result).toBeNull();
+  });
+
+  test("swallows transient pollMail errors and retries", async () => {
+    const msg = makeMail();
+    let calls = 0;
+    const d = {
+      pollMail: mock(async () => {
+        if (calls++ === 0) throw new Error("ECONNREFUSED");
+        return msg;
+      }),
+    };
+    const result = await pollMailUntil(d, "bob", 5000, Date.now() - 1, 10);
+    expect(result).toBe(msg);
+    expect(calls).toBe(2);
+  });
+
+  test("passes recipient to pollMail", async () => {
+    const d = { pollMail: mock(async () => null) };
+    await pollMailUntil(d, "charlie", 50, Date.now(), 10);
+    expect(d.pollMail).toHaveBeenCalledWith("charlie");
+  });
+});
+
+// ── emitMailEvent ──
+
+describe("emitMailEvent", () => {
+  test("emits header then JSON when short=false", () => {
+    const msg = makeMail({ id: 99, sender: "alice" });
+    const logSpy = mock((..._args: unknown[]) => {});
+    emitMailEvent(msg, false, { log: logSpy });
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    const header = String((logSpy.mock.calls[0] as unknown[])[0]);
+    expect(header).toContain("event=mail");
+    expect(header).toContain("id=99");
+    expect(header).toContain("sender=alice");
+    const parsed = JSON.parse(String((logSpy.mock.calls[1] as unknown[])[0]));
+    expect(parsed.source).toBe("mail");
+    expect(parsed.mail.id).toBe(99);
+  });
+
+  test("emits short format when short=true", () => {
+    const msg = makeMail({ id: 7, sender: "bob", subject: "hi there" });
+    const logSpy = mock((..._args: unknown[]) => {});
+    emitMailEvent(msg, true, { log: logSpy });
+    expect(logSpy).toHaveBeenCalledTimes(1);
+    const output = String((logSpy.mock.calls[0] as unknown[])[0]);
+    expect(output).toBe("mail 7 bob hi there");
+  });
+
+  test("uses '(no subject)' when subject is null in short format", () => {
+    const msg = makeMail({ id: 3, sender: "carol", subject: null });
+    const logSpy = mock((..._args: unknown[]) => {});
+    emitMailEvent(msg, true, { log: logSpy });
+    const output = String((logSpy.mock.calls[0] as unknown[])[0]);
+    expect(output).toBe("mail 3 carol (no subject)");
+  });
+
+  test("long format handles subject:null without crashing", () => {
+    const msg = makeMail({ id: 5, sender: "dan", subject: null });
+    const logSpy = mock((..._args: unknown[]) => {});
+    emitMailEvent(msg, false, { log: logSpy });
+    expect(logSpy).toHaveBeenCalledTimes(2);
+    const parsed = JSON.parse(String((logSpy.mock.calls[1] as unknown[])[0]));
+    expect(parsed.mail.id).toBe(5);
+  });
+});

--- a/packages/command/src/commands/mail-wait.ts
+++ b/packages/command/src/commands/mail-wait.ts
@@ -1,0 +1,51 @@
+import type { MailMessage } from "@mcp-cli/core";
+
+/**
+ * Poll for unread mail addressed to `recipient` until one arrives or the
+ * deadline expires. Non-consuming — does not markRead, so the caller can
+ * still read the message via `mcx mail -u <recipient>` afterward.
+ *
+ * `afterMs` is a `Date.now()` snapshot taken before polling begins. Only
+ * mail with `createdAt` strictly after that timestamp is surfaced, so
+ * pre-existing unread messages do not cause false-positive wakeups.
+ *
+ * Transient `pollMail` errors (IPC blips, daemon restart) are swallowed
+ * and retried until the deadline; a single network hiccup will not kill
+ * the entire wait.
+ *
+ * Returns the message, or null on timeout.
+ */
+export async function pollMailUntil(
+  d: { pollMail: (recipient: string) => Promise<MailMessage | null> },
+  recipient: string,
+  timeoutMs: number,
+  afterMs: number,
+  pollIntervalMs = 2000,
+): Promise<MailMessage | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    let msg: MailMessage | null = null;
+    try {
+      msg = await d.pollMail(recipient);
+    } catch {
+      // Transient IPC error — continue polling until deadline
+    }
+    if (msg && new Date(msg.createdAt).getTime() > afterMs) return msg;
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await Bun.sleep(Math.min(pollIntervalMs, remaining));
+  }
+  return null;
+}
+
+export function emitMailEvent(msg: MailMessage, short: boolean, d: { log: (...args: unknown[]) => void }): void {
+  if (short) {
+    const subj = msg.subject ?? "(no subject)";
+    d.log(`mail ${msg.id} ${msg.sender} ${subj}`);
+    return;
+  }
+  const headerParts = ["event=mail", `id=${msg.id}`];
+  if (msg.sender) headerParts.push(`sender=${msg.sender}`);
+  d.log(headerParts.join(" ").slice(0, 120));
+  d.log(JSON.stringify({ source: "mail", mail: msg }, null, 2));
+}

--- a/packages/command/src/commands/mail-wait.ts
+++ b/packages/command/src/commands/mail-wait.ts
@@ -42,7 +42,7 @@ export function emitMailEvent(
   msg: MailMessage,
   short: boolean,
   d: { log: (...args: unknown[]) => void },
-  includeHeader = true,
+  includeHeader = false,
 ): void {
   if (short) {
     const subj = msg.subject ?? "(no subject)";

--- a/packages/command/src/commands/mail-wait.ts
+++ b/packages/command/src/commands/mail-wait.ts
@@ -38,14 +38,21 @@ export async function pollMailUntil(
   return null;
 }
 
-export function emitMailEvent(msg: MailMessage, short: boolean, d: { log: (...args: unknown[]) => void }): void {
+export function emitMailEvent(
+  msg: MailMessage,
+  short: boolean,
+  d: { log: (...args: unknown[]) => void },
+  includeHeader = true,
+): void {
   if (short) {
     const subj = msg.subject ?? "(no subject)";
     d.log(`mail ${msg.id} ${msg.sender} ${subj}`);
     return;
   }
-  const headerParts = ["event=mail", `id=${msg.id}`];
-  if (msg.sender) headerParts.push(`sender=${msg.sender}`);
-  d.log(headerParts.join(" ").slice(0, 120));
+  if (includeHeader) {
+    const headerParts = ["event=mail", `id=${msg.id}`];
+    if (msg.sender) headerParts.push(`sender=${msg.sender}`);
+    d.log(headerParts.join(" ").slice(0, 120));
+  }
   d.log(JSON.stringify({ source: "mail", mail: msg }, null, 2));
 }


### PR DESCRIPTION
## Summary
- Extracts duplicate `pollMailUntil` and `emitMailEvent` helpers from `claude.ts` and `agent.ts` into a new shared `packages/command/src/commands/mail-wait.ts`
- Normalises `emitMailEvent` to accept an injected `log` dep (matching `agent.ts`'s existing signature) instead of calling `console.log` directly
- Updates three `claude.spec.ts` tests to assert on `deps.log` rather than patching `console.log`, which is now correct and avoids global monkey-patching

## Test plan
- [x] New `mail-wait.spec.ts` with 9 unit tests covering `pollMailUntil` (timeout, HWM filter, transient error swallowing, recipient routing) and `emitMailEvent` (JSON/short formats, null subject)
- [x] Existing `claudeWait --mail-to` tests in `claude.spec.ts` pass with updated assertions
- [x] Full test suite: 7088 pass, 0 fail
- [x] `bun typecheck` clean
- [x] `bun lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)