### PR TITLE
feat(automation): declarative event-triggered module framework (closes #2018)

### DIFF
--- a/docs/automation.md
+++ b/docs/automation.md
@@ -25,7 +25,7 @@ automation:
 
     merge:
       source: ./.claude/automation/merge.ts
-      on: [pr.label_added, ci.finished]
+      on: [pr.merge_state_changed, ci.finished]
       enabled: false
 ```
 
@@ -42,7 +42,7 @@ Module names must match `^[a-z][a-z0-9_-]{0,63}$`.
 
 ### Valid events
 
-`pr.opened`, `pr.pushed`, `pr.merged`, `pr.closed`, `pr.label_added`,
+`pr.opened`, `pr.pushed`, `pr.merged`, `pr.closed`, `pr.merge_state_changed`,
 `pr.review_comment_posted`, `checks.started`, `checks.passed`, `checks.failed`,
 `ci.started`, `ci.running`, `ci.finished`, `review.approved`,
 `review.changes_requested`, `review.commented`, `phase.changed`,

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -1,0 +1,173 @@
+# Automation Modules
+
+Automation modules are small, event-triggered handlers declared in `.mcx.yaml`
+that perform mechanical pipeline steps without orchestrator involvement.
+Framework introduced in #2018; individual modules ship as separate issues.
+
+## Schema
+
+Add an `automation:` section to `.mcx.yaml`:
+
+```yaml
+automation:
+  preset: supervised   # supervised | semi-auto | autonomous
+
+  modules:
+    cleanup:
+      source: ./.claude/automation/cleanup.ts
+      on: [pr.merged]
+      enabled: true
+
+    bind:
+      source: ./.claude/automation/bind.ts
+      on: [pr.opened]
+      # enabled omitted — resolved from preset
+
+    merge:
+      source: ./.claude/automation/merge.ts
+      on: [pr.label_added, ci.finished]
+      enabled: false
+```
+
+### Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `preset` | `supervised \| semi-auto \| autonomous` | No (default: `supervised`) | Preset that sets default enabled state for well-known modules |
+| `modules.<name>.source` | `string` | Yes | Path to the handler script (relative to repo root) |
+| `modules.<name>.on` | `string[]` | Yes | Events to subscribe to (at least one) |
+| `modules.<name>.enabled` | `boolean` | No | Explicit enable/disable; overrides preset default |
+
+Module names must match `^[a-z][a-z0-9_-]{0,63}$`.
+
+### Valid events
+
+`pr.opened`, `pr.pushed`, `pr.merged`, `pr.closed`, `pr.label_added`,
+`pr.review_comment_posted`, `checks.started`, `checks.passed`, `checks.failed`,
+`ci.started`, `ci.running`, `ci.finished`, `review.approved`,
+`review.changes_requested`, `review.commented`, `phase.changed`,
+`session.ended`, `session.result`
+
+## Handler API
+
+Automation handlers use `defineAutomation` (imported from the `mcp-cli` virtual
+module, same pattern as `defineAlias`):
+
+```typescript
+import { defineAutomation } from "mcp-cli";
+
+export default defineAutomation({
+  name: "my-module",
+  events: ["pr.merged"],
+  fn: async (event, ctx) => {
+    // ctx provides: workItem, state, mcp, repoRoot, logger, emit, signal
+    return { action: "none", reason: "nothing to do" };
+  },
+});
+```
+
+### Context
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `ctx.workItem` | `WorkItem \| null` | The work item associated with the event |
+| `ctx.state` | `AliasStateAccessor` | Per-module persistent state |
+| `ctx.mcp` | `McpProxy` | Proxy for calling MCP server tools |
+| `ctx.repoRoot` | `string` | Repository root path |
+| `ctx.signal` | `AbortSignal` | Abort signal (30s timeout) |
+| `ctx.logger` | `{ info, warn, error }` | Structured logger |
+| `ctx.emit` | `(event) => void` | Emit a new event onto the bus |
+
+### Return actions
+
+Every handler returns a structured action:
+
+| Action | Shape | Effect |
+|--------|-------|--------|
+| `none` | `{ action: "none", reason: string }` | No-op, logged for audit |
+| `bye-and-untrack` | `{ action: "bye-and-untrack", sessionIds: string[] }` | Daemon byes sessions + untracks item |
+| `set-state` | `{ action: "set-state", patch: Record<string, unknown> }` | Daemon writes work_item fields/state |
+| `emit-event` | `{ action: "emit-event", event: {...} }` | Daemon emits a new event onto the bus |
+| `shell` | `{ action: "shell", cmd: string, args: string[] }` | Daemon executes a shell command |
+| `escalate` | `{ action: "escalate", reason: string, payload? }` | Emits `automation.escalated` event for orchestrator |
+
+> **Note:** Action execution is deferred to individual module PRs (#2020, #2021).
+> The framework records actions in the audit log but does not yet execute
+> side effects (`bye-and-untrack`, `set-state`, `shell`, etc.). The `escalate`
+> action emits its audit event immediately. The `shell` action type will
+> require an allowlist/security model before the executor ships.
+
+## Slider presets
+
+Presets set default `enabled` state for well-known module names. Explicit
+`enabled:` in the manifest always overrides the preset.
+
+| Preset | cleanup | bind | merge | Other modules |
+|--------|---------|------|-------|---------------|
+| `supervised` (default) | off | off | off | All opt-in only |
+| `semi-auto` | on | on | off | Cleanup + bind auto; merge manual |
+| `autonomous` | on | on | on | Everything on; orchestrator only on escalation |
+
+When `enabled` is omitted from a module definition, the preset fills in the
+default at `mcx phase install` time and writes the resolved value to `.mcx.lock`.
+
+## Escalation contract
+
+When a module cannot handle an event mechanically, it returns:
+
+```typescript
+return { action: "escalate", reason: "merge conflict detected", payload: { ... } };
+```
+
+This emits an `automation.escalated` event on the bus. The orchestrator
+subscribes to this event and handles it like any other monitor event — no
+special protocol, just another event in the stream.
+
+## Per-work-item overrides
+
+Modules check per-item overrides on every fire (not cached). Set overrides
+via `mcx track`:
+
+```bash
+mcx track 1234 --automation merge=false
+mcx track 1234 --automation merge=true,bind=false
+```
+
+Stored as CSV in `workItem.automationOverrides`. Parsed at dispatch time.
+Per-item overrides take precedence over module config and preset defaults.
+
+## Lifecycle
+
+1. **Install:** `mcx phase install` resolves `automation.modules[*].source`,
+   content-hashes them, and writes to `.mcx.lock`.
+2. **Daemon startup:** Daemon reads `.mcx.lock`, creates `AutomationDispatcher`,
+   registers event subscriptions on the EventBus.
+3. **Event fires:** On matching event, dispatcher invokes module handler
+   (30s timeout).
+4. **Audit:** Every dispatch records outcome in ring buffer and emits
+   `automation.{fired|skipped|errored|escalated}` event.
+5. **Introspection:** `mcx automation list/show/log` queries dispatcher state
+   via IPC.
+
+## CLI commands
+
+```bash
+mcx automation list              # show all modules, events, enabled state
+mcx automation show <name>       # details for a specific module
+mcx automation log [name]        # recent audit entries
+mcx automation log --limit 20   # limit entries
+```
+
+## Copy-adapt guide
+
+To add automation to your project:
+
+1. Add `automation:` to `.mcx.yaml` (see Schema above)
+2. Create handler script(s) using `defineAutomation`
+3. Run `mcx phase install` to resolve and lock
+4. Start daemon — modules activate automatically
+5. Use `mcx automation list` to verify
+6. Set per-item overrides with `mcx track <n> --automation <csv>`
+
+See also: [phases.md](phases.md) for the manifest and lockfile system that
+automation builds on.

--- a/packages/command/src/commands/automation.ts
+++ b/packages/command/src/commands/automation.ts
@@ -62,9 +62,10 @@ export async function cmdAutomation(args: string[], deps?: Partial<AutomationDep
     }
     await cmdShow(repoRoot, name, d);
   } else if (sub === "log") {
-    const name = args[1];
     const limitIdx = args.indexOf("--limit");
     const limit = limitIdx >= 0 ? Number.parseInt(args[limitIdx + 1], 10) : undefined;
+    const firstPositional = args[1];
+    const name = firstPositional && !firstPositional.startsWith("--") ? firstPositional : undefined;
     await cmdLog(repoRoot, name, limit, d);
   } else {
     d.logError(`Unknown subcommand: ${sub}`);

--- a/packages/command/src/commands/automation.ts
+++ b/packages/command/src/commands/automation.ts
@@ -1,0 +1,156 @@
+/**
+ * `mcx automation` — introspect automation modules declared in `.mcx.yaml`.
+ *
+ * Subcommands:
+ *   - `list`: show all declared modules, their events, and enabled state
+ *   - `show <name>`: show details for a specific module
+ *   - `log [name]`: show recent automation fires from the audit ring buffer
+ *
+ * #2018
+ */
+
+import { findGitRoot } from "@mcp-cli/core";
+import type {
+  AutomationLogEntry,
+  AutomationModuleInfo,
+  GetAutomationLogResult,
+  ListAutomationResult,
+} from "@mcp-cli/core";
+import { printError } from "../output";
+
+export interface AutomationDeps {
+  ipcCall: <T>(method: string, params?: unknown) => Promise<T>;
+  cwd: () => string;
+  log: (msg: string) => void;
+  logError: (msg: string) => void;
+  exit: (code: number) => never;
+}
+
+const defaultDeps: AutomationDeps = {
+  ipcCall: async <T>(method: string, params?: unknown): Promise<T> => {
+    const { ipcCall } = await import("../daemon-lifecycle");
+    return ipcCall(method as Parameters<typeof ipcCall>[0], params as Parameters<typeof ipcCall>[1]) as T;
+  },
+  cwd: () => process.cwd(),
+  log: (msg) => console.log(msg),
+  logError: (msg) => console.error(msg),
+  exit: (code) => process.exit(code),
+};
+
+export async function cmdAutomation(args: string[], deps?: Partial<AutomationDeps>): Promise<void> {
+  const d: AutomationDeps = { ...defaultDeps, ...deps };
+  const sub = args[0];
+
+  if (!sub || sub === "help" || sub === "--help" || sub === "-h") {
+    printAutomationHelp(d);
+    return;
+  }
+
+  const repoRoot = findGitRoot(d.cwd());
+  if (!repoRoot) {
+    d.logError("not inside a git repository");
+    d.exit(1);
+  }
+
+  if (sub === "list" || sub === "ls") {
+    await cmdList(repoRoot, d);
+  } else if (sub === "show") {
+    const name = args[1];
+    if (!name) {
+      d.logError("Usage: mcx automation show <name>");
+      d.exit(1);
+    }
+    await cmdShow(repoRoot, name, d);
+  } else if (sub === "log") {
+    const name = args[1];
+    const limitIdx = args.indexOf("--limit");
+    const limit = limitIdx >= 0 ? Number.parseInt(args[limitIdx + 1], 10) : undefined;
+    await cmdLog(repoRoot, name, limit, d);
+  } else {
+    d.logError(`Unknown subcommand: ${sub}`);
+    printAutomationHelp(d);
+    d.exit(1);
+  }
+}
+
+async function cmdList(repoRoot: string, d: AutomationDeps): Promise<void> {
+  const result = await d.ipcCall<ListAutomationResult>("listAutomation", { repoRoot });
+
+  if (result.modules.length === 0) {
+    d.log("No automation modules configured.");
+    d.log("Add an automation: section to .mcx.yaml to declare modules.");
+    return;
+  }
+
+  d.log(`Preset: ${result.preset}`);
+  d.log(`Modules (${result.modules.length}):\n`);
+
+  for (const mod of result.modules) {
+    const status = mod.enabled ? "enabled" : "disabled";
+    const fires = mod.recentFires > 0 ? `  (${mod.recentFires} recent fires)` : "";
+    d.log(`  ${mod.name}  [${status}]${fires}`);
+    d.log(`    source: ${mod.resolvedPath}`);
+    d.log(`    events: ${mod.events.join(", ")}`);
+  }
+}
+
+async function cmdShow(repoRoot: string, name: string, d: AutomationDeps): Promise<void> {
+  const result = await d.ipcCall<ListAutomationResult>("listAutomation", { repoRoot });
+  const mod = result.modules.find((m: AutomationModuleInfo) => m.name === name);
+
+  if (!mod) {
+    d.logError(`Module "${name}" not found.`);
+    if (result.modules.length > 0) {
+      d.logError(`Available: ${result.modules.map((m: AutomationModuleInfo) => m.name).join(", ")}`);
+    }
+    d.exit(1);
+  }
+
+  d.log(`Name:     ${mod.name}`);
+  d.log(`Enabled:  ${mod.enabled}`);
+  d.log(`Source:   ${mod.resolvedPath}`);
+  d.log(`Hash:     ${mod.contentHash}`);
+  d.log(`Events:   ${mod.events.join(", ")}`);
+  d.log(`Fires:    ${mod.recentFires}`);
+}
+
+async function cmdLog(
+  repoRoot: string,
+  name: string | undefined,
+  limit: number | undefined,
+  d: AutomationDeps,
+): Promise<void> {
+  const result = await d.ipcCall<GetAutomationLogResult>("getAutomationLog", {
+    repoRoot,
+    ...(name && { module: name }),
+    ...(limit && { limit }),
+  });
+
+  if (result.entries.length === 0) {
+    d.log("No automation log entries.");
+    return;
+  }
+
+  for (const entry of result.entries) {
+    const ts = new Date(entry.ts).toLocaleTimeString();
+    const wi = entry.workItemId ? ` wi:${entry.workItemId}` : "";
+    const action = entry.actionType ? ` → ${entry.actionType}` : "";
+    const err = entry.error ? ` error: ${entry.error}` : "";
+    d.log(
+      `[${ts}] ${entry.module}  ${entry.outcome}  trigger:${entry.event}${wi}${action}  ${entry.durationMs}ms${err}`,
+    );
+  }
+}
+
+function printAutomationHelp(d: AutomationDeps): void {
+  d.log(`mcx automation — introspect automation modules
+
+Subcommands:
+  list              Show all declared modules and their status
+  show <name>       Show details for a specific module
+  log [name]        Show recent automation fires (optionally filtered by module)
+    --limit <n>     Limit number of log entries (default: 50)
+
+Automation modules are declared in .mcx.yaml under the automation: section.
+Run 'mcx phase install' after editing automation sources to update .mcx.lock.`);
+}

--- a/packages/command/src/commands/automation.ts
+++ b/packages/command/src/commands/automation.ts
@@ -10,13 +10,7 @@
  */
 
 import { findGitRoot } from "@mcp-cli/core";
-import type {
-  AutomationLogEntry,
-  AutomationModuleInfo,
-  GetAutomationLogResult,
-  ListAutomationResult,
-} from "@mcp-cli/core";
-import { printError } from "../output";
+import type { AutomationModuleInfo, GetAutomationLogResult, ListAutomationResult } from "@mcp-cli/core";
 
 export interface AutomationDeps {
   ipcCall: <T>(method: string, params?: unknown) => Promise<T>;
@@ -63,7 +57,16 @@ export async function cmdAutomation(args: string[], deps?: Partial<AutomationDep
     await cmdShow(repoRoot, name, d);
   } else if (sub === "log") {
     const limitIdx = args.indexOf("--limit");
-    const limit = limitIdx >= 0 ? Number.parseInt(args[limitIdx + 1], 10) : undefined;
+    let limit: number | undefined;
+    if (limitIdx >= 0) {
+      const raw = args[limitIdx + 1];
+      const parsed = Number.parseInt(raw, 10);
+      if (!raw || Number.isNaN(parsed) || parsed < 1) {
+        d.logError(`--limit requires a positive integer, got: ${raw ?? "(missing)"}`);
+        d.exit(1);
+      }
+      limit = parsed;
+    }
     const firstPositional = args[1];
     const name = firstPositional && !firstPositional.startsWith("--") ? firstPositional : undefined;
     await cmdLog(repoRoot, name, limit, d);
@@ -137,8 +140,9 @@ async function cmdLog(
     const wi = entry.workItemId ? ` wi:${entry.workItemId}` : "";
     const action = entry.actionType ? ` → ${entry.actionType}` : "";
     const err = entry.error ? ` error: ${entry.error}` : "";
+    const skip = entry.skipReason ? ` skip: ${entry.skipReason}` : "";
     d.log(
-      `[${ts}] ${entry.module}  ${entry.outcome}  trigger:${entry.event}${wi}${action}  ${entry.durationMs}ms${err}`,
+      `[${ts}] ${entry.module}  ${entry.outcome}  trigger:${entry.event}${wi}${action}  ${entry.durationMs}ms${err}${skip}`,
     );
   }
 }

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -424,7 +424,15 @@ export function phaseRun(
   return { manifest, forced: decision.forced, from: decision.from };
 }
 
-export type DriftKind = "manifest" | "phase-source" | "phase-missing" | "phase-extra" | "corrupt-lockfile";
+export type DriftKind =
+  | "manifest"
+  | "phase-source"
+  | "phase-missing"
+  | "phase-extra"
+  | "automation-source"
+  | "automation-missing"
+  | "automation-extra"
+  | "corrupt-lockfile";
 
 export interface DriftDeps {
   loadManifest: typeof loadManifest;
@@ -539,6 +547,57 @@ export function detectDrift(deps: DriftDeps): DriftResult {
     }
   }
 
+  const lockedAutomations = lock.automations ?? [];
+  const lockedAutoByName = new Map<string, LockedAutomation>();
+  for (const a of lockedAutomations) lockedAutoByName.set(a.name, a);
+
+  const manifestAutoModules = manifest.automation?.modules ?? {};
+  const manifestAutoNames = new Set(Object.keys(manifestAutoModules));
+
+  for (const locked of lockedAutomations) {
+    if (!manifestAutoNames.has(locked.name)) {
+      entries.push({
+        kind: "automation-extra",
+        path: locked.resolvedPath,
+        expected: "(not in manifest)",
+        actual: `automation "${locked.name}" in lockfile`,
+      });
+      continue;
+    }
+    const abs = resolvePath(cwd, locked.resolvedPath);
+    let actualHash: string;
+    try {
+      actualHash = deps.hashFileSync(abs);
+    } catch {
+      entries.push({
+        kind: "automation-source",
+        path: locked.resolvedPath,
+        expected: locked.contentHash,
+        actual: "(file missing)",
+      });
+      continue;
+    }
+    if (actualHash !== locked.contentHash) {
+      entries.push({
+        kind: "automation-source",
+        path: locked.resolvedPath,
+        expected: locked.contentHash,
+        actual: actualHash,
+      });
+    }
+  }
+
+  for (const name of manifestAutoNames) {
+    if (!lockedAutoByName.has(name)) {
+      entries.push({
+        kind: "automation-missing",
+        path: manifestAutoModules[name].source,
+        expected: `"${name}"`,
+        actual: "(not installed)",
+      });
+    }
+  }
+
   if (entries.length === 0) return { status: "ok" };
   entries.sort((a, b) => a.path.localeCompare(b.path));
   return { status: "drift", entries };
@@ -554,17 +613,20 @@ export function formatDriftWarning(entries: DriftEntry[]): string {
     .map((e) => {
       switch (e.kind) {
         case "manifest":
-        case "phase-source": {
+        case "phase-source":
+        case "automation-source": {
           const exp = shortHash(e.expected);
           const act = shortHash(e.actual);
           return `  ${e.path.padEnd(width)}  locked ${exp} → ${act}`;
         }
-        case "phase-missing": {
-          const detail = e.expected || "phase in manifest";
+        case "phase-missing":
+        case "automation-missing": {
+          const detail = e.expected || "entry in manifest";
           return `  ${e.path.padEnd(width)}  [NOT INSTALLED] — ${detail} but missing from lockfile`;
         }
-        case "phase-extra": {
-          const detail = e.actual || "phase in lockfile";
+        case "phase-extra":
+        case "automation-extra": {
+          const detail = e.actual || "entry in lockfile";
           return `  ${e.path.padEnd(width)}  [STALE LOCK ENTRY] — ${detail} but removed from manifest`;
         }
         case "corrupt-lockfile": {

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -27,6 +27,7 @@ import {
   GLOBAL_STATE_NAMESPACE,
   LOCKFILE_NAME,
   LOCKFILE_VERSION,
+  type LockedAutomation,
   type LockedPhase,
   type Lockfile,
   type Manifest,
@@ -211,6 +212,43 @@ export async function installPhases(cwd: string, deps: PhaseInstallDeps): Promis
     });
   }
 
+  const automations: LockedAutomation[] = [];
+  if (manifest.automation?.modules) {
+    const moduleNames = Object.keys(manifest.automation.modules).sort();
+    for (const name of moduleNames) {
+      const mod = manifest.automation.modules[name];
+      let resolvedAbs: string;
+      try {
+        resolvedAbs = resolvePhaseSource(mod.source, cwd);
+      } catch (err) {
+        errors.push(`automation "${name}": ${err instanceof Error ? err.message : String(err)}`);
+        continue;
+      }
+
+      let contentHash: string;
+      try {
+        contentHash = deps.hashFileSync(resolvedAbs);
+      } catch (err) {
+        const e = err as NodeJS.ErrnoException;
+        if (e?.code === "ENOENT") {
+          errors.push(`automation "${name}": source ${mod.source} not found`);
+        } else {
+          errors.push(`automation "${name}": cannot read ${mod.source}: ${e?.message ?? String(err)}`);
+        }
+        continue;
+      }
+
+      const rel = relative(cwd, resolvedAbs).split("\\").join("/");
+      automations.push({
+        name,
+        resolvedPath: rel === "" ? "." : rel,
+        contentHash,
+        events: [...mod.on],
+        enabled: mod.enabled,
+      });
+    }
+  }
+
   if (errors.length > 0) {
     errors.sort();
     throw new ManifestError(errors.join("\n"), manifestPath);
@@ -220,6 +258,7 @@ export async function installPhases(cwd: string, deps: PhaseInstallDeps): Promis
     version: LOCKFILE_VERSION,
     manifestHash,
     phases,
+    ...(automations.length > 0 && { automations }),
   };
 
   return { manifest, manifestPath, lockfile, warnings };
@@ -611,6 +650,14 @@ export async function cmdPhase(
       d.log(`Installed ${count} phase${count === 1 ? "" : "s"} → ${LOCKFILE_NAME}`);
       for (const p of result.lockfile.phases) {
         d.log(`  ${p.name}  ${p.resolvedPath}  ${p.contentHash.slice(0, 12)}`);
+      }
+      if (result.lockfile.automations && result.lockfile.automations.length > 0) {
+        const aCount = result.lockfile.automations.length;
+        d.log(`Installed ${aCount} automation module${aCount === 1 ? "" : "s"}`);
+        for (const a of result.lockfile.automations) {
+          const status = a.enabled ? "on" : "off";
+          d.log(`  ${a.name}  ${a.resolvedPath}  [${status}]  events: ${a.events.join(", ")}`);
+        }
       }
       for (const w of result.warnings) {
         d.logError(`  ⚠ ${w}`);

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -49,6 +49,7 @@ import {
   createMcpProxy,
   createWaitForEvent,
   executeAliasBundled,
+  expandPreset,
   extractMetadata,
   findGitRoot,
   hashFileSync,
@@ -239,12 +240,14 @@ export async function installPhases(cwd: string, deps: PhaseInstallDeps): Promis
       }
 
       const rel = relative(cwd, resolvedAbs).split("\\").join("/");
+      const presetDefaults = expandPreset(manifest.automation?.preset ?? "supervised");
+      const resolvedEnabled = mod.enabled ?? presetDefaults[name] ?? false;
       automations.push({
         name,
         resolvedPath: rel === "" ? "." : rel,
         contentHash,
         events: [...mod.on],
-        enabled: mod.enabled,
+        enabled: resolvedEnabled,
       });
     }
   }

--- a/packages/command/src/commands/session-display.spec.ts
+++ b/packages/command/src/commands/session-display.spec.ts
@@ -241,6 +241,7 @@ function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
     reviewStatus: "none",
     mergeStateStatus: null,
     phase: "impl",
+    automationOverrides: null,
     createdAt: "2026-04-10T00:00:00Z",
     updatedAt: "2026-04-10T00:00:00Z",
     version: 1,

--- a/packages/command/src/commands/track.spec.ts
+++ b/packages/command/src/commands/track.spec.ts
@@ -50,6 +50,7 @@ function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
     reviewStatus: "none",
     mergeStateStatus: null,
     phase: "impl",
+    automationOverrides: null,
     createdAt: "2026-04-01T00:00:00Z",
     updatedAt: "2026-04-01T00:00:00Z",
     version: 1,

--- a/packages/command/src/commands/track.ts
+++ b/packages/command/src/commands/track.ts
@@ -58,9 +58,10 @@ export async function cmdTrack(args: string[], deps: TrackDeps = defaultDeps): P
     }
   }
 
-  if (args[0] === "--branch") {
-    const branch = args[1];
-    if (!branch) {
+  const branchIdx = args.indexOf("--branch");
+  if (branchIdx >= 0) {
+    const branch = args[branchIdx + 1];
+    if (!branch || branch.startsWith("--")) {
       printError("Usage: mcx track --branch <name>");
       return deps.exit(1);
     }

--- a/packages/command/src/commands/track.ts
+++ b/packages/command/src/commands/track.ts
@@ -48,6 +48,16 @@ export async function cmdTrack(args: string[], deps: TrackDeps = defaultDeps): P
   const manifest = (deps.loadManifest ?? tryLoadManifest)(cwd);
   const initialPhase = manifest?.initial;
 
+  const automationIdx = args.indexOf("--automation");
+  let automationOverrides: string | undefined;
+  if (automationIdx >= 0) {
+    automationOverrides = args[automationIdx + 1];
+    if (!automationOverrides || automationOverrides.startsWith("--")) {
+      printError("--automation requires a value (e.g. merge=false,bind=true)");
+      return deps.exit(1);
+    }
+  }
+
   if (args[0] === "--branch") {
     const branch = args[1];
     if (!branch) {
@@ -58,6 +68,7 @@ export async function cmdTrack(args: string[], deps: TrackDeps = defaultDeps): P
       const item = await deps.ipcCall("trackWorkItem", {
         branch,
         ...(initialPhase ? { initialPhase } : {}),
+        ...(automationOverrides ? { automationOverrides } : {}),
         repoRoot: cwd,
       });
       console.error(`Tracking branch ${branch} (${item.id})`);
@@ -68,9 +79,15 @@ export async function cmdTrack(args: string[], deps: TrackDeps = defaultDeps): P
     return;
   }
 
-  const num = Number(args[0]);
-  if (!Number.isInteger(num) || num <= 0) {
-    printError(`Invalid number: ${args[0]}`);
+  const skipIndices = new Set<number>();
+  if (automationIdx >= 0) {
+    skipIndices.add(automationIdx);
+    skipIndices.add(automationIdx + 1);
+  }
+  const firstPositional = args.find((_, i) => !skipIndices.has(i) && !args[i].startsWith("--"));
+  const num = Number(firstPositional);
+  if (!firstPositional || !Number.isInteger(num) || num <= 0) {
+    printError(`Invalid number: ${firstPositional ?? args[0]}`);
     return deps.exit(1);
   }
 
@@ -78,6 +95,7 @@ export async function cmdTrack(args: string[], deps: TrackDeps = defaultDeps): P
     const item = await deps.ipcCall("trackWorkItem", {
       number: num,
       ...(initialPhase ? { initialPhase } : {}),
+      ...(automationOverrides ? { automationOverrides } : {}),
       repoRoot: cwd,
     });
     console.error(`Tracking #${num} (${item.id})`);
@@ -256,19 +274,19 @@ function printTrackHelp(): void {
   console.log(`mcx track — work item tracking
 
 Usage:
-  mcx track <number>           Track an issue/PR by number
-  mcx track --branch <name>    Track a branch (PR may not exist yet)
-  mcx untrack <number>         Stop tracking by number
-  mcx untrack --branch <name>  Stop tracking by branch
-  mcx tracked                  List all tracked work items
-  mcx tracked --json           Machine-readable output
-  mcx tracked --phase <phase>  Filter by phase (impl, review, repair, qa, done)
+  mcx track <number>                        Track an issue/PR by number
+  mcx track --branch <name>                 Track a branch (PR may not exist yet)
+  mcx track <number> --automation <csv>     Set per-item automation overrides
+  mcx untrack <number>                      Stop tracking by number
+  mcx untrack --branch <name>               Stop tracking by branch
+  mcx tracked                               List all tracked work items
+  mcx tracked --json                        Machine-readable output
+  mcx tracked --phase <phase>               Filter by phase (impl, review, repair, qa, done)
 
 Examples:
   mcx track 1135
   mcx track --branch feat/new-feature
+  mcx track 1135 --automation merge=false,bind=true
   mcx untrack 1135
-  mcx untrack --branch feat/new-feature
-  mcx tracked
   mcx tracked --json`);
 }

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -31,6 +31,7 @@ import { cmdAdd, cmdAddJson } from "./commands/add";
 import { cmdAgent } from "./commands/agent";
 import { cmdAlias } from "./commands/alias";
 import { cmdAuth } from "./commands/auth";
+import { cmdAutomation } from "./commands/automation";
 import { cmdClaude } from "./commands/claude";
 import { cmdCompletions } from "./commands/completions";
 import { cmdConfig } from "./commands/config";
@@ -305,6 +306,10 @@ async function main(): Promise<void> {
         await cmdPhase(phaseArgs);
         break;
       }
+
+      case "automation":
+        await cmdAutomation(cleanArgs.slice(1));
+        break;
 
       case "auth":
         await cmdAuth(cleanArgs.slice(1));
@@ -944,6 +949,7 @@ Aliases:
 
 Utility:
   mcx search/install/update           Registry search and install
+  mcx automation <subcommand>          Introspect automation modules
   mcx gc [--dry-run]                  Prune merged branches + stale worktrees
   mcx monitor [flags]                 Stream unified daemon events (--json for NDJSON)
   mcx logs <server> [-f]              View server stderr

--- a/packages/core/src/alias-bundle.ts
+++ b/packages/core/src/alias-bundle.ts
@@ -12,6 +12,8 @@
 
 import { z } from "zod/v4";
 import type { AliasContext, AliasDefinition, AliasMonitorEventInput, McpProxy, MonitorAliasDefinition } from "./alias";
+import type { AutomationDefinition } from "./automation";
+import { defineAutomation } from "./automation";
 import { parsePythonRepr } from "./python-repr";
 
 /** Stub MCP proxy — returns undefined for any server.tool() call. */
@@ -160,6 +162,7 @@ export const stripMcpCliImport = stripModuleSyntax;
 /** Internal result from evalBundledJs — alias def plus any monitor definitions. */
 interface EvalResult {
   aliasDef: AliasDefinition | null;
+  automationDef: AutomationDefinition | null;
   monitorDefs: MonitorAliasDefinition[];
 }
 
@@ -188,6 +191,7 @@ async function evalBundledJs(
   const coreBarrel = await import("./index");
 
   let aliasDef: AliasDefinition | null = null;
+  let automationDef: AutomationDefinition | null = null;
   const monitorDefs: MonitorAliasDefinition[] = [];
 
   const injected = {
@@ -197,6 +201,10 @@ async function evalBundledJs(
       } else {
         aliasDef = defOrFactory;
       }
+    },
+    defineAutomation: (def: AutomationDefinition) => {
+      automationDef = def;
+      return def;
     },
     defineMonitor: (def: MonitorAliasDefinition<AliasMonitorEventInput>) => {
       monitorDefs.push(def);
@@ -210,7 +218,7 @@ async function evalBundledJs(
     parsePythonRepr,
   };
 
-  const code = `const { defineAlias, defineMonitor, z, mcp, args, file, json, parsePythonRepr } = __mcp_inject__;\n${stripped}`;
+  const code = `const { defineAlias, defineAutomation, defineMonitor, z, mcp, args, file, json, parsePythonRepr } = __mcp_inject__;\n${stripped}`;
   const fn = new AsyncFunction("__mcp_inject__", "__mcp_core__", code);
 
   if (timeoutMs !== undefined) {
@@ -225,7 +233,7 @@ async function evalBundledJs(
     await fn(injected, coreBarrel);
   }
 
-  return { aliasDef, monitorDefs };
+  return { aliasDef, automationDef, monitorDefs };
 }
 
 /**

--- a/packages/core/src/alias-bundle.ts
+++ b/packages/core/src/alias-bundle.ts
@@ -486,6 +486,7 @@ declare module "mcp-cli" {
   export function file(path: string): Promise<string>;
   export function json(path: string): Promise<unknown>;
   export function defineAlias(def: unknown): void;
+  export function defineAutomation(def: unknown): unknown;
   export interface AliasMonitorEventInput {
     event: string;
     category?: string;

--- a/packages/core/src/automation.spec.ts
+++ b/packages/core/src/automation.spec.ts
@@ -32,12 +32,12 @@ describe("AutomationModuleDefSchema", () => {
     expect(result.success).toBe(true);
   });
 
-  test("defaults enabled to true", () => {
+  test("enabled is undefined when omitted", () => {
     const result = AutomationModuleDefSchema.parse({
       source: "./bind.ts",
       on: ["pr.opened"],
     });
-    expect(result.enabled).toBe(true);
+    expect(result.enabled).toBeUndefined();
   });
 
   test("rejects empty source", () => {

--- a/packages/core/src/automation.spec.ts
+++ b/packages/core/src/automation.spec.ts
@@ -26,7 +26,7 @@ describe("AutomationModuleDefSchema", () => {
   test("accepts multiple events", () => {
     const result = AutomationModuleDefSchema.safeParse({
       source: "./merge.ts",
-      on: ["pr.label_added", "ci.finished"],
+      on: ["pr.merge_state_changed", "ci.finished"],
       enabled: false,
     });
     expect(result.success).toBe(true);
@@ -87,7 +87,7 @@ describe("AutomationConfigSchema", () => {
         },
         merge: {
           source: "./merge.ts",
-          on: ["ci.finished", "pr.label_added"],
+          on: ["ci.finished", "pr.merge_state_changed"],
           enabled: false,
         },
       },

--- a/packages/core/src/automation.spec.ts
+++ b/packages/core/src/automation.spec.ts
@@ -1,0 +1,263 @@
+import { describe, expect, test } from "bun:test";
+import {
+  AUTOMATION_EVENT_NAMES,
+  AUTOMATION_PRESETS,
+  type AutomationConfig,
+  AutomationConfigSchema,
+  AutomationModuleDefSchema,
+  defineAutomation,
+  expandPreset,
+  isDefineAutomation,
+  isModuleEnabledForItem,
+  isValidAutomationEvent,
+  parseAutomationOverrides,
+} from "./automation";
+
+describe("AutomationModuleDefSchema", () => {
+  test("accepts valid module definition", () => {
+    const result = AutomationModuleDefSchema.safeParse({
+      source: "./.claude/automation/cleanup.ts",
+      on: ["pr.merged"],
+      enabled: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts multiple events", () => {
+    const result = AutomationModuleDefSchema.safeParse({
+      source: "./merge.ts",
+      on: ["pr.label_added", "ci.finished"],
+      enabled: false,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("defaults enabled to true", () => {
+    const result = AutomationModuleDefSchema.parse({
+      source: "./bind.ts",
+      on: ["pr.opened"],
+    });
+    expect(result.enabled).toBe(true);
+  });
+
+  test("rejects empty source", () => {
+    const result = AutomationModuleDefSchema.safeParse({
+      source: "",
+      on: ["pr.merged"],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects empty events array", () => {
+    const result = AutomationModuleDefSchema.safeParse({
+      source: "./foo.ts",
+      on: [],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects unknown event name", () => {
+    const result = AutomationModuleDefSchema.safeParse({
+      source: "./foo.ts",
+      on: ["totally.bogus"],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects unknown keys (strict)", () => {
+    const result = AutomationModuleDefSchema.safeParse({
+      source: "./foo.ts",
+      on: ["pr.merged"],
+      enabled: true,
+      bogus: "field",
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("AutomationConfigSchema", () => {
+  test("accepts full config", () => {
+    const result = AutomationConfigSchema.safeParse({
+      preset: "semi-auto",
+      modules: {
+        cleanup: {
+          source: "./cleanup.ts",
+          on: ["pr.merged"],
+          enabled: true,
+        },
+        merge: {
+          source: "./merge.ts",
+          on: ["ci.finished", "pr.label_added"],
+          enabled: false,
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("defaults preset to supervised and modules to empty", () => {
+    const result = AutomationConfigSchema.parse({});
+    expect(result.preset).toBe("supervised");
+    expect(result.modules).toEqual({});
+  });
+
+  test("rejects invalid preset", () => {
+    const result = AutomationConfigSchema.safeParse({
+      preset: "yolo",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid module name (uppercase)", () => {
+    const result = AutomationConfigSchema.safeParse({
+      modules: {
+        BadName: {
+          source: "./x.ts",
+          on: ["pr.merged"],
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("isValidAutomationEvent", () => {
+  test("accepts all defined event names", () => {
+    for (const name of AUTOMATION_EVENT_NAMES) {
+      expect(isValidAutomationEvent(name)).toBe(true);
+    }
+  });
+
+  test("rejects unknown events", () => {
+    expect(isValidAutomationEvent("foo.bar")).toBe(false);
+    expect(isValidAutomationEvent("")).toBe(false);
+    expect(isValidAutomationEvent("heartbeat")).toBe(false);
+  });
+});
+
+describe("expandPreset", () => {
+  test("supervised returns empty defaults", () => {
+    expect(expandPreset("supervised")).toEqual({});
+  });
+
+  test("semi-auto enables cleanup and bind", () => {
+    const defaults = expandPreset("semi-auto");
+    expect(defaults.cleanup).toBe(true);
+    expect(defaults.bind).toBe(true);
+    expect(defaults.merge).toBeUndefined();
+  });
+
+  test("autonomous enables all three", () => {
+    const defaults = expandPreset("autonomous");
+    expect(defaults.cleanup).toBe(true);
+    expect(defaults.bind).toBe(true);
+    expect(defaults.merge).toBe(true);
+  });
+});
+
+describe("parseAutomationOverrides", () => {
+  test("parses valid CSV", () => {
+    const overrides = parseAutomationOverrides("merge=false,bind=true");
+    expect(overrides.get("merge")).toBe(false);
+    expect(overrides.get("bind")).toBe(true);
+  });
+
+  test("handles whitespace", () => {
+    const overrides = parseAutomationOverrides(" merge = false , bind = true ");
+    expect(overrides.get("merge")).toBe(false);
+    expect(overrides.get("bind")).toBe(true);
+  });
+
+  test("returns empty map for null/undefined/empty", () => {
+    expect(parseAutomationOverrides(null).size).toBe(0);
+    expect(parseAutomationOverrides(undefined).size).toBe(0);
+    expect(parseAutomationOverrides("").size).toBe(0);
+  });
+
+  test("skips malformed entries", () => {
+    const overrides = parseAutomationOverrides("merge=false,garbage,=bad,also=maybe");
+    expect(overrides.get("merge")).toBe(false);
+    expect(overrides.size).toBe(1);
+  });
+});
+
+describe("isModuleEnabledForItem", () => {
+  test("uses module enabled state when no override", () => {
+    expect(isModuleEnabledForItem("cleanup", true, "supervised", new Map())).toBe(true);
+    expect(isModuleEnabledForItem("cleanup", false, "supervised", new Map())).toBe(false);
+  });
+
+  test("per-item override wins over module config", () => {
+    const overrides = new Map([["cleanup", false]]);
+    expect(isModuleEnabledForItem("cleanup", true, "supervised", overrides)).toBe(false);
+  });
+
+  test("per-item override can enable a disabled module", () => {
+    const overrides = new Map([["merge", true]]);
+    expect(isModuleEnabledForItem("merge", false, "supervised", overrides)).toBe(true);
+  });
+});
+
+describe("defineAutomation", () => {
+  test("returns the definition unchanged", () => {
+    const def = defineAutomation({
+      name: "test-module",
+      events: ["pr.merged"],
+      fn: async () => ({ action: "none", reason: "test" }),
+    });
+    expect(def.name).toBe("test-module");
+    expect(def.events).toEqual(["pr.merged"]);
+  });
+});
+
+describe("isDefineAutomation", () => {
+  test("detects defineAutomation( sentinel", () => {
+    expect(isDefineAutomation('import { defineAutomation } from "mcp-cli"; defineAutomation({')).toBe(true);
+  });
+
+  test("returns false for non-matching source", () => {
+    expect(isDefineAutomation('import { defineAlias } from "mcp-cli";')).toBe(false);
+  });
+});
+
+describe("manifest automation section", () => {
+  test("manifest accepts automation section", async () => {
+    const { validateManifest } = await import("./manifest");
+    const raw = {
+      version: 1,
+      initial: "impl",
+      phases: {
+        impl: { source: "./impl.ts", next: ["done"] },
+        done: { source: "./done.ts" },
+      },
+      automation: {
+        preset: "semi-auto",
+        modules: {
+          cleanup: {
+            source: "./.claude/automation/cleanup.ts",
+            on: ["pr.merged"],
+            enabled: true,
+          },
+        },
+      },
+    };
+    const manifest = validateManifest(raw, "/test/.mcx.yaml");
+    expect(manifest.automation).toBeDefined();
+    expect(manifest.automation?.preset).toBe("semi-auto");
+    expect(Object.keys(manifest.automation?.modules ?? {})).toEqual(["cleanup"]);
+  });
+
+  test("manifest works without automation section", async () => {
+    const { validateManifest } = await import("./manifest");
+    const raw = {
+      version: 1,
+      initial: "impl",
+      phases: {
+        impl: { source: "./impl.ts", next: ["done"] },
+        done: { source: "./done.ts" },
+      },
+    };
+    const manifest = validateManifest(raw, "/test/.mcx.yaml");
+    expect(manifest.automation).toBeUndefined();
+  });
+});

--- a/packages/core/src/automation.ts
+++ b/packages/core/src/automation.ts
@@ -68,7 +68,7 @@ export const AutomationModuleDefSchema = z
   .object({
     source: z.string().min(1, "module source must be a non-empty string"),
     on: z.array(AutomationEventNameSchema).min(1, "module must subscribe to at least one event"),
-    enabled: z.boolean().default(true),
+    enabled: z.boolean().optional(),
   })
   .strict();
 
@@ -156,7 +156,7 @@ export function parseAutomationOverrides(csv: string | undefined | null): Map<st
 
 export function isModuleEnabledForItem(
   moduleName: string,
-  moduleEnabled: boolean,
+  moduleEnabled: boolean | undefined,
   preset: AutomationPreset,
   overrides: Map<string, boolean>,
 ): boolean {

--- a/packages/core/src/automation.ts
+++ b/packages/core/src/automation.ts
@@ -1,0 +1,182 @@
+/**
+ * Automation module types, schemas, and helpers.
+ *
+ * Automation modules are small event-triggered handlers declared in `.mcx.yaml`
+ * that perform mechanical pipeline steps without orchestrator involvement.
+ * Framework introduced in #2018; individual modules are separate issues.
+ */
+
+import { z } from "zod";
+import type { AliasContext } from "./alias";
+import type { MonitorEvent } from "./monitor-event";
+
+/**
+ * Valid event names that automation modules can subscribe to.
+ * Subset of monitor event names — only events with clear, mechanical triggers.
+ */
+export const AUTOMATION_EVENT_NAMES = [
+  "pr.opened",
+  "pr.pushed",
+  "pr.merged",
+  "pr.closed",
+  "pr.label_added",
+  "pr.review_comment_posted",
+  "checks.started",
+  "checks.passed",
+  "checks.failed",
+  "ci.started",
+  "ci.running",
+  "ci.finished",
+  "review.approved",
+  "review.changes_requested",
+  "review.commented",
+  "phase.changed",
+  "session.ended",
+  "session.result",
+] as const;
+
+export type AutomationEventName = (typeof AUTOMATION_EVENT_NAMES)[number];
+
+const automationEventNameSet: ReadonlySet<string> = new Set(AUTOMATION_EVENT_NAMES);
+
+export function isValidAutomationEvent(name: string): name is AutomationEventName {
+  return automationEventNameSet.has(name);
+}
+
+/** Automation presets — sugar that expands to module enable/disable defaults. */
+export const AUTOMATION_PRESETS = ["supervised", "semi-auto", "autonomous"] as const;
+export type AutomationPreset = (typeof AUTOMATION_PRESETS)[number];
+
+/** Default enabled state per preset, keyed by module name convention. */
+const PRESET_DEFAULTS: Record<AutomationPreset, Record<string, boolean>> = {
+  supervised: {},
+  "semi-auto": { cleanup: true, bind: true },
+  autonomous: { cleanup: true, bind: true, merge: true },
+};
+
+export function expandPreset(preset: AutomationPreset): Record<string, boolean> {
+  return { ...PRESET_DEFAULTS[preset] };
+}
+
+// ── Schema ──
+
+const AutomationEventNameSchema = z.string().refine(isValidAutomationEvent, {
+  message: `unknown automation event; valid events: ${AUTOMATION_EVENT_NAMES.join(", ")}`,
+});
+
+export const AutomationModuleDefSchema = z
+  .object({
+    source: z.string().min(1, "module source must be a non-empty string"),
+    on: z.array(AutomationEventNameSchema).min(1, "module must subscribe to at least one event"),
+    enabled: z.boolean().default(true),
+  })
+  .strict();
+
+export type AutomationModuleDef = z.infer<typeof AutomationModuleDefSchema>;
+
+export const AutomationConfigSchema = z
+  .object({
+    preset: z.enum(AUTOMATION_PRESETS).default("supervised"),
+    modules: z.record(z.string().regex(/^[a-z][a-z0-9_-]{0,63}$/), AutomationModuleDefSchema).default({}),
+  })
+  .strict();
+
+export type AutomationConfig = z.infer<typeof AutomationConfigSchema>;
+
+// ── Actions ──
+
+export type AutomationAction =
+  | { action: "none"; reason: string }
+  | { action: "bye-and-untrack"; sessionIds: string[] }
+  | { action: "set-state"; patch: Record<string, unknown> }
+  | { action: "emit-event"; event: { event: string; category: string; [key: string]: unknown } }
+  | { action: "shell"; cmd: string; args: string[] }
+  | { action: "escalate"; reason: string; payload?: unknown };
+
+export const AUTOMATION_ACTION_NAMES = [
+  "none",
+  "bye-and-untrack",
+  "set-state",
+  "emit-event",
+  "shell",
+  "escalate",
+] as const;
+
+export type AutomationActionName = (typeof AUTOMATION_ACTION_NAMES)[number];
+
+// ── defineAutomation ──
+
+export const DEFINE_AUTOMATION_SENTINEL = "defineAutomation(";
+
+export function isDefineAutomation(source: string): boolean {
+  return source.includes(DEFINE_AUTOMATION_SENTINEL);
+}
+
+export interface AutomationContext extends Pick<AliasContext, "mcp" | "state" | "repoRoot" | "signal"> {
+  workItem: AliasContext["workItem"];
+  logger: {
+    info(msg: string): void;
+    warn(msg: string): void;
+    error(msg: string): void;
+  };
+  emit(event: { event: string; category: string; [key: string]: unknown }): void;
+}
+
+export interface AutomationDefinition {
+  name: string;
+  events: AutomationEventName[];
+  fn: (event: MonitorEvent, ctx: AutomationContext) => AutomationAction | Promise<AutomationAction>;
+}
+
+export function defineAutomation(def: AutomationDefinition): AutomationDefinition {
+  return def;
+}
+
+// ── Per-work-item overrides ──
+
+export function parseAutomationOverrides(csv: string | undefined | null): Map<string, boolean> {
+  const result = new Map<string, boolean>();
+  if (!csv) return result;
+  for (const part of csv.split(",")) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const eqIdx = trimmed.indexOf("=");
+    if (eqIdx < 0) continue;
+    const name = trimmed.slice(0, eqIdx).trim();
+    const value = trimmed
+      .slice(eqIdx + 1)
+      .trim()
+      .toLowerCase();
+    if (name && (value === "true" || value === "false")) {
+      result.set(name, value === "true");
+    }
+  }
+  return result;
+}
+
+export function isModuleEnabledForItem(
+  moduleName: string,
+  moduleEnabled: boolean,
+  preset: AutomationPreset,
+  overrides: Map<string, boolean>,
+): boolean {
+  const presetDefaults = expandPreset(preset);
+  const baseEnabled = moduleEnabled !== undefined ? moduleEnabled : (presetDefaults[moduleName] ?? false);
+  const itemOverride = overrides.get(moduleName);
+  return itemOverride !== undefined ? itemOverride : baseEnabled;
+}
+
+// ── Audit log entry ──
+
+export type AutomationOutcome = "fired" | "skipped" | "errored" | "escalated";
+
+export interface AutomationAuditEntry {
+  module: string;
+  outcome: AutomationOutcome;
+  event: string;
+  workItemId: string | undefined;
+  action: AutomationAction | null;
+  error: string | null;
+  ts: string;
+  durationMs: number;
+}

--- a/packages/core/src/automation.ts
+++ b/packages/core/src/automation.ts
@@ -19,7 +19,7 @@ export const AUTOMATION_EVENT_NAMES = [
   "pr.pushed",
   "pr.merged",
   "pr.closed",
-  "pr.label_added",
+  "pr.merge_state_changed",
   "pr.review_comment_posted",
   "checks.started",
   "checks.passed",
@@ -177,6 +177,7 @@ export interface AutomationAuditEntry {
   workItemId: string | undefined;
   action: AutomationAction | null;
   error: string | null;
+  skipReason: string | null;
   ts: string;
   durationMs: number;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -52,3 +52,4 @@ export * from "./mcp-proxy";
 export * from "./bun-version";
 export * from "./sprint-plan";
 export * from "./claude-patch";
+export * from "./automation";

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -450,8 +450,28 @@ export const TrackWorkItemParamsSchema = z
     initialPhase: z.string().optional(),
     /** Absolute path to the repo root; used server-side to locate a .mcx manifest for initialPhase validation. */
     repoRoot: z.string().optional(),
-    /** CSV of per-item automation overrides (e.g. "merge=false,bind=true"). */
-    automationOverrides: z.string().optional(),
+    /** CSV of per-item automation overrides (e.g. "merge=false,bind=true"). Each entry must be name=true or name=false. */
+    automationOverrides: z
+      .string()
+      .refine(
+        (csv) => {
+          if (!csv) return true;
+          for (const part of csv.split(",")) {
+            const trimmed = part.trim();
+            if (!trimmed) continue;
+            const eqIdx = trimmed.indexOf("=");
+            if (eqIdx < 0) return false;
+            const value = trimmed
+              .slice(eqIdx + 1)
+              .trim()
+              .toLowerCase();
+            if (value !== "true" && value !== "false") return false;
+          }
+          return true;
+        },
+        { message: "automationOverrides must be CSV of name=true|false pairs (e.g. 'cleanup=false,bind=true')" },
+      )
+      .optional(),
   })
   .refine((p) => p.number != null || p.branch != null, {
     message: "Either number or branch is required",
@@ -555,7 +575,7 @@ export interface ListAutomationResult {
 export const GetAutomationLogParamsSchema = z.object({
   repoRoot: z.string().min(1),
   module: z.string().optional(),
-  limit: z.number().optional(),
+  limit: z.number().int().min(1).max(200).optional(),
 });
 
 export interface AutomationLogEntry {
@@ -565,6 +585,7 @@ export interface AutomationLogEntry {
   workItemId: string | undefined;
   actionType: string | null;
   error: string | null;
+  skipReason: string | null;
   ts: string;
   durationMs: number;
 }

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -450,6 +450,8 @@ export const TrackWorkItemParamsSchema = z
     initialPhase: z.string().optional(),
     /** Absolute path to the repo root; used server-side to locate a .mcx manifest for initialPhase validation. */
     repoRoot: z.string().optional(),
+    /** CSV of per-item automation overrides (e.g. "merge=false,bind=true"). */
+    automationOverrides: z.string().optional(),
   })
   .refine((p) => p.number != null || p.branch != null, {
     message: "Either number or branch is required",

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -67,7 +67,9 @@ export type IpcMethod =
   | "aliasStateAll"
   | "getBudgetConfig"
   | "setBudgetConfig"
-  | "publishEvent";
+  | "publishEvent"
+  | "listAutomation"
+  | "getAutomationLog";
 
 // -- Request/Response --
 
@@ -528,6 +530,47 @@ export interface PublishEventResult {
   seq: number;
 }
 
+// -- Automation schemas (#2018) --
+
+export const ListAutomationParamsSchema = z.object({
+  repoRoot: z.string().min(1),
+});
+
+export interface AutomationModuleInfo {
+  name: string;
+  resolvedPath: string;
+  contentHash: string;
+  events: string[];
+  enabled: boolean;
+  recentFires: number;
+}
+
+export interface ListAutomationResult {
+  modules: AutomationModuleInfo[];
+  preset: string;
+}
+
+export const GetAutomationLogParamsSchema = z.object({
+  repoRoot: z.string().min(1),
+  module: z.string().optional(),
+  limit: z.number().optional(),
+});
+
+export interface AutomationLogEntry {
+  module: string;
+  outcome: string;
+  event: string;
+  workItemId: string | undefined;
+  actionType: string | null;
+  error: string | null;
+  ts: string;
+  durationMs: number;
+}
+
+export interface GetAutomationLogResult {
+  entries: AutomationLogEntry[];
+}
+
 // -- Result types for methods without a named interface --
 
 export interface PingResult {
@@ -744,6 +787,8 @@ export interface IpcMethodResult {
   getBudgetConfig: BudgetConfig;
   setBudgetConfig: { ok: true };
   publishEvent: PublishEventResult;
+  listAutomation: ListAutomationResult;
+  getAutomationLog: GetAutomationLogResult;
 }
 
 // -- Error codes --

--- a/packages/core/src/manifest-lock.ts
+++ b/packages/core/src/manifest-lock.ts
@@ -28,6 +28,17 @@ export const LockedPhaseSchema = z
   .strict();
 export type LockedPhase = z.infer<typeof LockedPhaseSchema>;
 
+export const LockedAutomationSchema = z
+  .object({
+    name: z.string(),
+    resolvedPath: z.string(),
+    contentHash: z.string().regex(/^[a-f0-9]{64}$/),
+    events: z.array(z.string()),
+    enabled: z.boolean(),
+  })
+  .strict();
+export type LockedAutomation = z.infer<typeof LockedAutomationSchema>;
+
 export const LockfileSchema = z
   .object({
     version: z.literal(LOCKFILE_VERSION),
@@ -35,6 +46,8 @@ export const LockfileSchema = z
     manifestHash: z.string().regex(/^[a-f0-9]{64}$/),
     /** Phases, sorted alphabetically by name. */
     phases: z.array(LockedPhaseSchema),
+    /** Automation modules, sorted alphabetically by name. Optional for backward compat. */
+    automations: z.array(LockedAutomationSchema).optional(),
   })
   .strict();
 export type Lockfile = z.infer<typeof LockfileSchema>;
@@ -69,6 +82,9 @@ export function serializeLockfile(lock: Lockfile): string {
   const sorted: Lockfile = {
     ...lock,
     phases: [...lock.phases].sort((a, b) => a.name.localeCompare(b.name)),
+    ...(lock.automations && {
+      automations: [...lock.automations].sort((a, b) => a.name.localeCompare(b.name)),
+    }),
   };
   return `${JSON.stringify(sorted, null, 2)}\n`;
 }

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -8,6 +8,7 @@
 import { lstatSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { z } from "zod";
+import { AutomationConfigSchema } from "./automation";
 
 /** Recognized manifest filenames, in load-preference order. */
 export const MANIFEST_FILENAMES = [".mcx.yaml", ".mcx.yml", ".mcx.json"] as const;
@@ -105,6 +106,7 @@ export const ManifestSchema = z
     state: ManifestStateSchema.optional(),
     initial: identifier("initial"),
     phases: z.record(identifier("phase name"), PhaseDefSchema),
+    automation: AutomationConfigSchema.optional(),
   })
   .strict();
 

--- a/packages/core/src/monitor-event.ts
+++ b/packages/core/src/monitor-event.ts
@@ -25,6 +25,7 @@ export const MONITOR_CATEGORIES = [
   "gc",
   "cost",
   "quota",
+  "automation",
 ] as const;
 
 export type MonitorCategory = (typeof MONITOR_CATEGORIES)[number];
@@ -111,6 +112,13 @@ export const DAEMON_CONFIG_RELOADED = "daemon.config_reloaded" as const;
 // ── GC event names (#1586) ──
 
 export const GC_PRUNED = "gc.pruned" as const;
+
+// ── Automation event names (#2018) ──
+
+export const AUTOMATION_FIRED = "automation.fired" as const;
+export const AUTOMATION_SKIPPED = "automation.skipped" as const;
+export const AUTOMATION_ERRORED = "automation.errored" as const;
+export const AUTOMATION_ESCALATED = "automation.escalated" as const;
 
 // ── Heartbeat ──
 
@@ -419,6 +427,31 @@ const FORMATTERS: Partial<Record<string, Formatter>> = {
     const br = Array.isArray(e.branches) ? `${(e.branches as string[]).length}br` : "";
     const reason = typeof e.reason === "string" ? e.reason : "";
     return join(wt, br, reason);
+  },
+
+  [AUTOMATION_FIRED]: (e) => {
+    const mod = typeof e.module === "string" ? e.module : "";
+    const act = typeof e.actionType === "string" ? e.actionType : "";
+    const dur = typeof e.durationMs === "number" ? `${e.durationMs}ms` : "";
+    return join(wi(e), mod, act, dur);
+  },
+
+  [AUTOMATION_SKIPPED]: (e) => {
+    const mod = typeof e.module === "string" ? e.module : "";
+    const reason = typeof e.reason === "string" ? cap(e.reason, 60) : "";
+    return join(wi(e), mod, reason);
+  },
+
+  [AUTOMATION_ERRORED]: (e) => {
+    const mod = typeof e.module === "string" ? e.module : "";
+    const err = typeof e.error === "string" ? cap(e.error, 60) : "";
+    return join(wi(e), mod, err);
+  },
+
+  [AUTOMATION_ESCALATED]: (e) => {
+    const mod = typeof e.module === "string" ? e.module : "";
+    const reason = typeof e.reason === "string" ? cap(e.reason, 60) : "";
+    return join(wi(e), mod, reason);
   },
 
   [HEARTBEAT]: (e) => `seq:${e.seq}`,

--- a/packages/core/src/work-item.ts
+++ b/packages/core/src/work-item.ts
@@ -38,6 +38,7 @@ export interface WorkItem {
   reviewStatus: ReviewStatus;
   mergeStateStatus: MergeStateStatus | null;
   phase: WorkItemPhase;
+  automationOverrides: string | null;
   createdAt: string;
   updatedAt: string;
   version: number;
@@ -133,6 +134,7 @@ export function createWorkItem(id: string, phase?: WorkItemPhase): WorkItem {
     reviewStatus: "none",
     mergeStateStatus: null,
     phase: phase ?? "impl",
+    automationOverrides: null,
     createdAt: now,
     updatedAt: now,
     version: 1,

--- a/packages/daemon/src/automation-dispatcher.spec.ts
+++ b/packages/daemon/src/automation-dispatcher.spec.ts
@@ -340,4 +340,150 @@ describe("AutomationDispatcher", () => {
     expect(executedModules).toHaveLength(0);
     expect(published.some((e) => e.event === "automation.skipped")).toBe(true);
   });
+
+  test("skipped audit entries use skipReason instead of error", async () => {
+    dispatcher.load(makeConfig(), [makeLocked({ enabled: false })]);
+    dispatcher.start();
+
+    const published: MonitorEvent[] = [];
+    bus.subscribe((event) => {
+      if (event.event.startsWith("automation.")) published.push(event);
+    });
+
+    bus.publish(makeEvent());
+    await pollUntil(() => published.some((e) => e.event === "automation.skipped"));
+
+    const log = dispatcher.getAuditLog();
+    expect(log).toHaveLength(1);
+    expect(log[0].outcome).toBe("skipped");
+    expect(log[0].skipReason).toBe("disabled by config or override");
+    expect(log[0].error).toBeNull();
+  });
+
+  test("resolves workItemId from prNumber via resolveWorkItemId", async () => {
+    dispatcher = new AutomationDispatcher({
+      eventBus: bus,
+      repoRoot: "/test/repo",
+      getWorkItemOverrides: (workItemId) => {
+        if (workItemId === "#42") return "cleanup=false";
+        return undefined;
+      },
+      resolveWorkItemId: (prNumber) => {
+        if (prNumber === 42) return "#42";
+        return undefined;
+      },
+      executeModule: async (mod, event) => {
+        executedModules.push({ name: mod.name, event: event.event });
+        return executeResult;
+      },
+    });
+
+    const published: MonitorEvent[] = [];
+    bus.subscribe((event) => {
+      if (event.event.startsWith("automation.")) published.push(event);
+    });
+
+    dispatcher.load(makeConfig(), [makeLocked()]);
+    dispatcher.start();
+
+    bus.publish(makeEvent({ prNumber: 42 }));
+    await pollUntil(() => published.some((e) => e.event === "automation.skipped"));
+
+    expect(executedModules).toHaveLength(0);
+    const skipped = published.find((e) => e.event === "automation.skipped");
+    expect(skipped).toBeDefined();
+  });
+
+  test("default executor loads and calls module from resolvedPath", async () => {
+    const fixtureDir = import.meta.dir;
+    const defaultDispatcher = new AutomationDispatcher({
+      eventBus: bus,
+      repoRoot: fixtureDir,
+    });
+
+    const published: MonitorEvent[] = [];
+    bus.subscribe((event) => {
+      if (event.event.startsWith("automation.")) published.push(event);
+    });
+
+    defaultDispatcher.load(makeConfig(), [
+      makeLocked({
+        resolvedPath: "test-fixtures/echo-automation.ts",
+        events: ["pr.merged"],
+      }),
+    ]);
+    defaultDispatcher.start();
+
+    bus.publish(makeEvent());
+    await pollUntil(() => published.some((e) => e.event === "automation.fired"));
+
+    const fired = published.find((e) => e.event === "automation.fired");
+    expect(fired).toBeDefined();
+    expect(fired?.actionType).toBe("none");
+
+    const log = defaultDispatcher.getAuditLog();
+    expect(log).toHaveLength(1);
+    expect(log[0].outcome).toBe("fired");
+
+    defaultDispatcher.stop();
+  });
+
+  test("default executor emits errored when module has no fn export", async () => {
+    const fixtureDir = import.meta.dir;
+    const defaultDispatcher = new AutomationDispatcher({
+      eventBus: bus,
+      repoRoot: fixtureDir,
+    });
+
+    const published: MonitorEvent[] = [];
+    bus.subscribe((event) => {
+      if (event.event.startsWith("automation.")) published.push(event);
+    });
+
+    defaultDispatcher.load(makeConfig(), [
+      makeLocked({
+        resolvedPath: "test-fixtures/bad-automation.ts",
+        events: ["pr.merged"],
+      }),
+    ]);
+    defaultDispatcher.start();
+
+    bus.publish(makeEvent());
+    await pollUntil(() => published.some((e) => e.event === "automation.errored"));
+
+    const errored = published.find((e) => e.event === "automation.errored");
+    expect(errored).toBeDefined();
+    expect(errored?.error).toContain("no default export with an fn()");
+
+    defaultDispatcher.stop();
+  });
+
+  test("default executor emits errored when module file is missing", async () => {
+    const defaultDispatcher = new AutomationDispatcher({
+      eventBus: bus,
+      repoRoot: "/nonexistent/path",
+    });
+
+    const published: MonitorEvent[] = [];
+    bus.subscribe((event) => {
+      if (event.event.startsWith("automation.")) published.push(event);
+    });
+
+    defaultDispatcher.load(makeConfig(), [
+      makeLocked({
+        resolvedPath: "does-not-exist.ts",
+        events: ["pr.merged"],
+      }),
+    ]);
+    defaultDispatcher.start();
+
+    bus.publish(makeEvent());
+    await pollUntil(() => published.some((e) => e.event === "automation.errored"));
+
+    const errored = published.find((e) => e.event === "automation.errored");
+    expect(errored).toBeDefined();
+    expect(errored?.error).toContain("failed to load");
+
+    defaultDispatcher.stop();
+  });
 });

--- a/packages/daemon/src/automation-dispatcher.spec.ts
+++ b/packages/daemon/src/automation-dispatcher.spec.ts
@@ -1,0 +1,274 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { AutomationAction, AutomationConfig, LockedAutomation, MonitorEvent } from "@mcp-cli/core";
+import { AutomationDispatcher } from "./automation-dispatcher";
+import { EventBus } from "./event-bus";
+
+function makeEvent(overrides: Partial<MonitorEvent> = {}): MonitorEvent {
+  return {
+    seq: 1,
+    ts: new Date().toISOString(),
+    src: "test",
+    event: "pr.merged",
+    category: "work_item",
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<AutomationConfig> = {}): AutomationConfig {
+  return {
+    preset: "supervised",
+    modules: {},
+    ...overrides,
+  };
+}
+
+function makeLocked(overrides: Partial<LockedAutomation> = {}): LockedAutomation {
+  return {
+    name: "cleanup",
+    resolvedPath: ".claude/automation/cleanup.ts",
+    contentHash: "a".repeat(64),
+    events: ["pr.merged"],
+    enabled: true,
+    ...overrides,
+  };
+}
+
+describe("AutomationDispatcher", () => {
+  let bus: EventBus;
+  let dispatcher: AutomationDispatcher;
+  let executedModules: Array<{ name: string; event: string }>;
+  let executeResult: AutomationAction;
+
+  beforeEach(() => {
+    bus = new EventBus();
+    executedModules = [];
+    executeResult = { action: "none", reason: "test" };
+
+    dispatcher = new AutomationDispatcher({
+      eventBus: bus,
+      repoRoot: "/test/repo",
+      executeModule: async (mod, event) => {
+        executedModules.push({ name: mod.name, event: event.event });
+        return executeResult;
+      },
+    });
+  });
+
+  afterEach(() => {
+    dispatcher.stop();
+  });
+
+  test("subscribes to event bus and dispatches on matching event", async () => {
+    dispatcher.load(makeConfig(), [makeLocked()]);
+    dispatcher.start();
+
+    bus.publish(makeEvent());
+    await Bun.sleep(10);
+
+    expect(executedModules).toHaveLength(1);
+    expect(executedModules[0].name).toBe("cleanup");
+    expect(executedModules[0].event).toBe("pr.merged");
+  });
+
+  test("does not dispatch on non-matching event", async () => {
+    dispatcher.load(makeConfig(), [makeLocked()]);
+    dispatcher.start();
+
+    bus.publish(makeEvent({ event: "pr.opened" }));
+    await Bun.sleep(10);
+
+    expect(executedModules).toHaveLength(0);
+  });
+
+  test("skips disabled module", async () => {
+    dispatcher.load(makeConfig(), [makeLocked({ enabled: false })]);
+    dispatcher.start();
+
+    bus.publish(makeEvent());
+    await Bun.sleep(10);
+
+    expect(executedModules).toHaveLength(0);
+  });
+
+  test("emits automation.fired audit event", async () => {
+    const published: MonitorEvent[] = [];
+    bus.subscribe((event) => {
+      if (event.event.startsWith("automation.")) {
+        published.push(event);
+      }
+    });
+
+    dispatcher.load(makeConfig(), [makeLocked()]);
+    dispatcher.start();
+
+    bus.publish(makeEvent());
+    await Bun.sleep(10);
+
+    const fired = published.find((e) => e.event === "automation.fired");
+    expect(fired).toBeDefined();
+    expect(fired?.module).toBe("cleanup");
+    expect(fired?.category).toBe("automation");
+    expect(fired?.src).toBe("automation:cleanup");
+  });
+
+  test("emits automation.skipped when disabled by override", async () => {
+    const published: MonitorEvent[] = [];
+    bus.subscribe((event) => {
+      if (event.event.startsWith("automation.")) {
+        published.push(event);
+      }
+    });
+
+    dispatcher = new AutomationDispatcher({
+      eventBus: bus,
+      repoRoot: "/test/repo",
+      getWorkItemOverrides: () => "cleanup=false",
+      executeModule: async (mod, event) => {
+        executedModules.push({ name: mod.name, event: event.event });
+        return executeResult;
+      },
+    });
+
+    dispatcher.load(makeConfig(), [makeLocked()]);
+    dispatcher.start();
+
+    bus.publish(makeEvent({ workItemId: "wi-1" }));
+    await Bun.sleep(10);
+
+    expect(executedModules).toHaveLength(0);
+    const skipped = published.find((e) => e.event === "automation.skipped");
+    expect(skipped).toBeDefined();
+    expect(skipped?.module).toBe("cleanup");
+  });
+
+  test("emits automation.escalated when handler returns escalate", async () => {
+    executeResult = { action: "escalate", reason: "needs human review" };
+
+    const published: MonitorEvent[] = [];
+    bus.subscribe((event) => {
+      if (event.event.startsWith("automation.")) {
+        published.push(event);
+      }
+    });
+
+    dispatcher.load(makeConfig(), [makeLocked()]);
+    dispatcher.start();
+
+    bus.publish(makeEvent());
+    await Bun.sleep(10);
+
+    const escalated = published.find((e) => e.event === "automation.escalated");
+    expect(escalated).toBeDefined();
+    expect(escalated?.reason).toBe("needs human review");
+  });
+
+  test("emits automation.errored when handler throws", async () => {
+    dispatcher = new AutomationDispatcher({
+      eventBus: bus,
+      repoRoot: "/test/repo",
+      executeModule: async () => {
+        throw new Error("handler crashed");
+      },
+    });
+
+    const published: MonitorEvent[] = [];
+    bus.subscribe((event) => {
+      if (event.event.startsWith("automation.")) {
+        published.push(event);
+      }
+    });
+
+    dispatcher.load(makeConfig(), [makeLocked()]);
+    dispatcher.start();
+
+    bus.publish(makeEvent());
+    await Bun.sleep(10);
+
+    const errored = published.find((e) => e.event === "automation.errored");
+    expect(errored).toBeDefined();
+    expect(errored?.error).toBe("handler crashed");
+  });
+
+  test("per-item override can enable a disabled module", async () => {
+    dispatcher = new AutomationDispatcher({
+      eventBus: bus,
+      repoRoot: "/test/repo",
+      getWorkItemOverrides: () => "cleanup=true",
+      executeModule: async (mod, event) => {
+        executedModules.push({ name: mod.name, event: event.event });
+        return { action: "none", reason: "test" };
+      },
+    });
+
+    dispatcher.load(makeConfig(), [makeLocked({ enabled: false })]);
+    dispatcher.start();
+
+    bus.publish(makeEvent({ workItemId: "wi-1" }));
+    await Bun.sleep(10);
+
+    expect(executedModules).toHaveLength(1);
+  });
+
+  test("listModules returns registered modules", () => {
+    dispatcher.load(makeConfig({ preset: "semi-auto" }), [
+      makeLocked(),
+      makeLocked({ name: "bind", events: ["pr.opened"], resolvedPath: "./bind.ts" }),
+    ]);
+
+    const modules = dispatcher.listModules();
+    expect(modules).toHaveLength(2);
+    expect(modules[0].name).toBe("bind");
+    expect(modules[1].name).toBe("cleanup");
+  });
+
+  test("getAuditLog returns entries after fires", async () => {
+    dispatcher.load(makeConfig(), [makeLocked()]);
+    dispatcher.start();
+
+    bus.publish(makeEvent());
+    await Bun.sleep(10);
+
+    const log = dispatcher.getAuditLog();
+    expect(log).toHaveLength(1);
+    expect(log[0].module).toBe("cleanup");
+    expect(log[0].outcome).toBe("fired");
+    expect(log[0].event).toBe("pr.merged");
+    expect(log[0].actionType).toBe("none");
+  });
+
+  test("getAuditLog filters by module name", async () => {
+    dispatcher.load(makeConfig(), [
+      makeLocked(),
+      makeLocked({ name: "bind", events: ["pr.merged"], resolvedPath: "./bind.ts" }),
+    ]);
+    dispatcher.start();
+
+    bus.publish(makeEvent());
+    await Bun.sleep(10);
+
+    const cleanupLog = dispatcher.getAuditLog("cleanup");
+    expect(cleanupLog).toHaveLength(1);
+    expect(cleanupLog[0].module).toBe("cleanup");
+
+    const bindLog = dispatcher.getAuditLog("bind");
+    expect(bindLog).toHaveLength(1);
+    expect(bindLog[0].module).toBe("bind");
+  });
+
+  test("stop unsubscribes from event bus", async () => {
+    dispatcher.load(makeConfig(), [makeLocked()]);
+    dispatcher.start();
+    dispatcher.stop();
+
+    bus.publish(makeEvent());
+    await Bun.sleep(10);
+
+    expect(executedModules).toHaveLength(0);
+  });
+
+  test("moduleCount reflects loaded modules", () => {
+    expect(dispatcher.moduleCount).toBe(0);
+    dispatcher.load(makeConfig(), [makeLocked()]);
+    expect(dispatcher.moduleCount).toBe(1);
+  });
+});

--- a/packages/daemon/src/automation-dispatcher.spec.ts
+++ b/packages/daemon/src/automation-dispatcher.spec.ts
@@ -3,6 +3,19 @@ import type { AutomationAction, AutomationConfig, LockedAutomation, MonitorEvent
 import { AutomationDispatcher } from "./automation-dispatcher";
 import { EventBus } from "./event-bus";
 
+const POLL_INTERVAL_MS = 2;
+const POLL_DEADLINE_MS = 2_000;
+
+async function pollUntil(predicate: () => boolean, deadline = POLL_DEADLINE_MS): Promise<void> {
+  const start = performance.now();
+  while (!predicate()) {
+    if (performance.now() - start > deadline) {
+      throw new Error(`pollUntil timed out after ${deadline}ms`);
+    }
+    await Bun.sleep(POLL_INTERVAL_MS);
+  }
+}
+
 function makeEvent(overrides: Partial<MonitorEvent> = {}): MonitorEvent {
   return {
     seq: 1,
@@ -63,7 +76,7 @@ describe("AutomationDispatcher", () => {
     dispatcher.start();
 
     bus.publish(makeEvent());
-    await Bun.sleep(10);
+    await pollUntil(() => executedModules.length >= 1);
 
     expect(executedModules).toHaveLength(1);
     expect(executedModules[0].name).toBe("cleanup");
@@ -75,17 +88,25 @@ describe("AutomationDispatcher", () => {
     dispatcher.start();
 
     bus.publish(makeEvent({ event: "pr.opened" }));
-    await Bun.sleep(10);
+    // Publish a matching event after to confirm the first was skipped
+    bus.publish(makeEvent());
+    await pollUntil(() => executedModules.length >= 1);
 
-    expect(executedModules).toHaveLength(0);
+    expect(executedModules).toHaveLength(1);
+    expect(executedModules[0].event).toBe("pr.merged");
   });
 
   test("skips disabled module", async () => {
+    const published: MonitorEvent[] = [];
+    bus.subscribe((event) => {
+      if (event.event.startsWith("automation.")) published.push(event);
+    });
+
     dispatcher.load(makeConfig(), [makeLocked({ enabled: false })]);
     dispatcher.start();
 
     bus.publish(makeEvent());
-    await Bun.sleep(10);
+    await pollUntil(() => published.length >= 1);
 
     expect(executedModules).toHaveLength(0);
   });
@@ -102,7 +123,7 @@ describe("AutomationDispatcher", () => {
     dispatcher.start();
 
     bus.publish(makeEvent());
-    await Bun.sleep(10);
+    await pollUntil(() => published.some((e) => e.event === "automation.fired"));
 
     const fired = published.find((e) => e.event === "automation.fired");
     expect(fired).toBeDefined();
@@ -133,7 +154,7 @@ describe("AutomationDispatcher", () => {
     dispatcher.start();
 
     bus.publish(makeEvent({ workItemId: "wi-1" }));
-    await Bun.sleep(10);
+    await pollUntil(() => published.some((e) => e.event === "automation.skipped"));
 
     expect(executedModules).toHaveLength(0);
     const skipped = published.find((e) => e.event === "automation.skipped");
@@ -155,7 +176,7 @@ describe("AutomationDispatcher", () => {
     dispatcher.start();
 
     bus.publish(makeEvent());
-    await Bun.sleep(10);
+    await pollUntil(() => published.some((e) => e.event === "automation.escalated"));
 
     const escalated = published.find((e) => e.event === "automation.escalated");
     expect(escalated).toBeDefined();
@@ -182,7 +203,7 @@ describe("AutomationDispatcher", () => {
     dispatcher.start();
 
     bus.publish(makeEvent());
-    await Bun.sleep(10);
+    await pollUntil(() => published.some((e) => e.event === "automation.errored"));
 
     const errored = published.find((e) => e.event === "automation.errored");
     expect(errored).toBeDefined();
@@ -204,7 +225,7 @@ describe("AutomationDispatcher", () => {
     dispatcher.start();
 
     bus.publish(makeEvent({ workItemId: "wi-1" }));
-    await Bun.sleep(10);
+    await pollUntil(() => executedModules.length >= 1);
 
     expect(executedModules).toHaveLength(1);
   });
@@ -226,7 +247,7 @@ describe("AutomationDispatcher", () => {
     dispatcher.start();
 
     bus.publish(makeEvent());
-    await Bun.sleep(10);
+    await pollUntil(() => dispatcher.getAuditLog().length >= 1);
 
     const log = dispatcher.getAuditLog();
     expect(log).toHaveLength(1);
@@ -244,7 +265,7 @@ describe("AutomationDispatcher", () => {
     dispatcher.start();
 
     bus.publish(makeEvent());
-    await Bun.sleep(10);
+    await pollUntil(() => dispatcher.getAuditLog().length >= 2);
 
     const cleanupLog = dispatcher.getAuditLog("cleanup");
     expect(cleanupLog).toHaveLength(1);
@@ -256,19 +277,67 @@ describe("AutomationDispatcher", () => {
   });
 
   test("stop unsubscribes from event bus", async () => {
+    const published: MonitorEvent[] = [];
+    bus.subscribe((event) => {
+      if (event.event.startsWith("automation.")) published.push(event);
+    });
+
     dispatcher.load(makeConfig(), [makeLocked()]);
     dispatcher.start();
     dispatcher.stop();
 
     bus.publish(makeEvent());
-    await Bun.sleep(10);
+    // Give enough time — no audit events should appear
+    await Bun.sleep(20);
 
     expect(executedModules).toHaveLength(0);
+    expect(published.filter((e) => e.event === "automation.fired")).toHaveLength(0);
   });
 
   test("moduleCount reflects loaded modules", () => {
     expect(dispatcher.moduleCount).toBe(0);
     dispatcher.load(makeConfig(), [makeLocked()]);
     expect(dispatcher.moduleCount).toBe(1);
+  });
+
+  test("ring buffer returns newest entries in chronological order after wrapping", async () => {
+    dispatcher.load(makeConfig(), [makeLocked()]);
+    dispatcher.start();
+
+    const totalEvents = 220;
+    for (let i = 0; i < totalEvents; i++) {
+      bus.publish(makeEvent({ seq: i }));
+    }
+    await pollUntil(() => dispatcher.getAuditLog(undefined, 300).length >= 200);
+
+    const log = dispatcher.getAuditLog(undefined, 50);
+    expect(log).toHaveLength(50);
+    // Newest 50 entries should be the last 50 events published (seq 170-219).
+    // They should be in chronological order (oldest first within the slice).
+    for (let i = 1; i < log.length; i++) {
+      expect(log[i].ts >= log[i - 1].ts).toBe(true);
+    }
+
+    const fullLog = dispatcher.getAuditLog(undefined, 300);
+    expect(fullLog).toHaveLength(200);
+  });
+
+  test("preset defaults apply when module enabled is undefined in lockfile", async () => {
+    const published: MonitorEvent[] = [];
+    bus.subscribe((event) => {
+      if (event.event.startsWith("automation.")) published.push(event);
+    });
+
+    // Module with enabled=false should be skipped under any preset
+    // (lockfile resolves enabled at install time; this tests the dispatcher
+    // respects the resolved value)
+    dispatcher.load(makeConfig({ preset: "supervised" }), [makeLocked({ enabled: false })]);
+    dispatcher.start();
+
+    bus.publish(makeEvent());
+    await pollUntil(() => published.some((e) => e.event === "automation.skipped"));
+
+    expect(executedModules).toHaveLength(0);
+    expect(published.some((e) => e.event === "automation.skipped")).toBe(true);
   });
 });

--- a/packages/daemon/src/automation-dispatcher.ts
+++ b/packages/daemon/src/automation-dispatcher.ts
@@ -121,15 +121,16 @@ export class AutomationDispatcher {
       let error: string | null = null;
 
       try {
+        let timer: ReturnType<typeof setTimeout> | undefined;
         action = await Promise.race([
           this.executeModule(mod, event),
-          new Promise<never>((_, reject) =>
-            setTimeout(
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(
               () => reject(new Error(`module "${mod.name}" timed out after ${MODULE_TIMEOUT_MS}ms`)),
               MODULE_TIMEOUT_MS,
-            ),
-          ),
-        ]);
+            );
+          }),
+        ]).finally(() => clearTimeout(timer));
 
         if (action.action === "escalate") {
           outcome = "escalated";

--- a/packages/daemon/src/automation-dispatcher.ts
+++ b/packages/daemon/src/automation-dispatcher.ts
@@ -1,0 +1,257 @@
+/**
+ * Automation module dispatcher.
+ *
+ * Subscribes to the daemon EventBus, matches incoming events against
+ * registered automation modules, executes handlers in subprocess workers,
+ * and emits audit events for every dispatch outcome.
+ *
+ * Module handlers run in isolated Bun subprocesses (same model as alias
+ * execution) so a crash cannot take down the daemon.
+ *
+ * #2018
+ */
+
+import type {
+  AutomationAction,
+  AutomationAuditEntry,
+  AutomationConfig,
+  AutomationLogEntry,
+  AutomationModuleInfo,
+  AutomationOutcome,
+  AutomationPreset,
+  LockedAutomation,
+  MonitorEvent,
+} from "@mcp-cli/core";
+import { isModuleEnabledForItem, parseAutomationOverrides } from "@mcp-cli/core";
+import type { EventBus } from "./event-bus";
+
+const AUDIT_RING_CAPACITY = 200;
+const MODULE_TIMEOUT_MS = 30_000;
+
+interface RegisteredModule {
+  name: string;
+  resolvedPath: string;
+  contentHash: string;
+  events: Set<string>;
+  enabled: boolean;
+}
+
+export class AutomationDispatcher {
+  private modules = new Map<string, RegisteredModule>();
+  private preset: AutomationPreset = "supervised";
+  private subscriptionId: number | null = null;
+  private auditRing: AutomationAuditEntry[] = [];
+  private auditHead = 0;
+  private auditCount = 0;
+  private repoRoot: string;
+  private eventBus: EventBus;
+  private getWorkItemOverrides: (workItemId: string) => string | undefined;
+  private executeModule: (module: RegisteredModule, event: MonitorEvent) => Promise<AutomationAction>;
+
+  constructor(opts: {
+    eventBus: EventBus;
+    repoRoot: string;
+    getWorkItemOverrides?: (workItemId: string) => string | undefined;
+    executeModule?: (module: RegisteredModule, event: MonitorEvent) => Promise<AutomationAction>;
+  }) {
+    this.eventBus = opts.eventBus;
+    this.repoRoot = opts.repoRoot;
+    this.getWorkItemOverrides = opts.getWorkItemOverrides ?? (() => undefined);
+    this.executeModule = opts.executeModule ?? defaultExecuteModule;
+  }
+
+  load(config: AutomationConfig, locked: LockedAutomation[]): void {
+    this.modules.clear();
+    this.preset = config.preset ?? "supervised";
+
+    for (const entry of locked) {
+      this.modules.set(entry.name, {
+        name: entry.name,
+        resolvedPath: entry.resolvedPath,
+        contentHash: entry.contentHash,
+        events: new Set(entry.events),
+        enabled: entry.enabled,
+      });
+    }
+  }
+
+  start(): void {
+    if (this.subscriptionId !== null) return;
+    if (this.modules.size === 0) return;
+
+    const allEvents = new Set<string>();
+    for (const mod of this.modules.values()) {
+      for (const e of mod.events) allEvents.add(e);
+    }
+
+    this.subscriptionId = this.eventBus.subscribe(
+      (event) => {
+        this.onEvent(event).catch((err) => {
+          console.error("[AutomationDispatcher] unhandled error in onEvent:", err);
+        });
+      },
+      (event) => allEvents.has(event.event),
+    );
+  }
+
+  stop(): void {
+    if (this.subscriptionId !== null) {
+      this.eventBus.unsubscribe(this.subscriptionId);
+      this.subscriptionId = null;
+    }
+  }
+
+  private async onEvent(event: MonitorEvent): Promise<void> {
+    for (const mod of this.modules.values()) {
+      if (!mod.events.has(event.event)) continue;
+
+      const workItemId = typeof event.workItemId === "string" ? event.workItemId : undefined;
+      const overrides = parseAutomationOverrides(workItemId ? this.getWorkItemOverrides(workItemId) : undefined);
+
+      if (!isModuleEnabledForItem(mod.name, mod.enabled, this.preset, overrides)) {
+        this.recordAudit(mod.name, "skipped", event.event, workItemId, null, "disabled by config or override", 0);
+        this.emitAuditEvent(mod.name, "skipped", event, { reason: "disabled by config or override" });
+        continue;
+      }
+
+      const start = performance.now();
+      let action: AutomationAction;
+      let outcome: AutomationOutcome;
+      let error: string | null = null;
+
+      try {
+        action = await Promise.race([
+          this.executeModule(mod, event),
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () => reject(new Error(`module "${mod.name}" timed out after ${MODULE_TIMEOUT_MS}ms`)),
+              MODULE_TIMEOUT_MS,
+            ),
+          ),
+        ]);
+
+        if (action.action === "escalate") {
+          outcome = "escalated";
+        } else {
+          outcome = "fired";
+        }
+      } catch (err) {
+        outcome = "errored";
+        error = err instanceof Error ? err.message : String(err);
+        action = { action: "none", reason: `error: ${error}` };
+      }
+
+      const durationMs = Math.round(performance.now() - start);
+      this.recordAudit(mod.name, outcome, event.event, workItemId, action, error, durationMs);
+      this.emitAuditEvent(mod.name, outcome, event, {
+        actionType: action.action,
+        error,
+        durationMs,
+        ...(action.action === "escalate" && { reason: action.reason }),
+      });
+    }
+  }
+
+  private emitAuditEvent(
+    moduleName: string,
+    outcome: AutomationOutcome,
+    triggerEvent: MonitorEvent,
+    extra: Record<string, unknown>,
+  ): void {
+    const eventName = `automation.${outcome}` as const;
+    this.eventBus.publish({
+      src: `automation:${moduleName}`,
+      event: eventName,
+      category: "automation",
+      module: moduleName,
+      triggerEvent: triggerEvent.event,
+      triggerSeq: triggerEvent.seq,
+      ...(triggerEvent.workItemId && { workItemId: triggerEvent.workItemId }),
+      ...(triggerEvent.prNumber && { prNumber: triggerEvent.prNumber }),
+      ...extra,
+    });
+  }
+
+  private recordAudit(
+    module: string,
+    outcome: AutomationOutcome,
+    event: string,
+    workItemId: string | undefined,
+    action: AutomationAction | null,
+    error: string | null,
+    durationMs: number,
+  ): void {
+    const entry: AutomationAuditEntry = {
+      module,
+      outcome,
+      event,
+      workItemId,
+      action,
+      error,
+      ts: new Date().toISOString(),
+      durationMs,
+    };
+
+    if (this.auditCount < AUDIT_RING_CAPACITY) {
+      this.auditRing.push(entry);
+      this.auditCount++;
+    } else {
+      this.auditRing[this.auditHead] = entry;
+      this.auditHead = (this.auditHead + 1) % AUDIT_RING_CAPACITY;
+    }
+  }
+
+  listModules(): AutomationModuleInfo[] {
+    const result: AutomationModuleInfo[] = [];
+    for (const mod of this.modules.values()) {
+      const fires = this.getAuditLog(mod.name).filter((e) => e.outcome === "fired").length;
+      result.push({
+        name: mod.name,
+        resolvedPath: mod.resolvedPath,
+        contentHash: mod.contentHash,
+        events: [...mod.events],
+        enabled: mod.enabled,
+        recentFires: fires,
+      });
+    }
+    return result.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  getAuditLog(moduleName?: string, limit = 50): AutomationLogEntry[] {
+    const entries: AutomationAuditEntry[] = [];
+    const n = Math.min(this.auditCount, AUDIT_RING_CAPACITY);
+
+    for (let i = 0; i < n; i++) {
+      const idx = this.auditCount <= AUDIT_RING_CAPACITY ? i : (this.auditHead + i) % AUDIT_RING_CAPACITY;
+      const entry = this.auditRing[idx];
+      if (moduleName && entry.module !== moduleName) continue;
+      entries.push(entry);
+    }
+
+    return entries.slice(-limit).map((e) => ({
+      module: e.module,
+      outcome: e.outcome,
+      event: e.event,
+      workItemId: e.workItemId,
+      actionType: e.action?.action ?? null,
+      error: e.error,
+      ts: e.ts,
+      durationMs: e.durationMs,
+    }));
+  }
+
+  get moduleCount(): number {
+    return this.modules.size;
+  }
+
+  get currentPreset(): AutomationPreset {
+    return this.preset;
+  }
+}
+
+async function defaultExecuteModule(module: RegisteredModule, _event: MonitorEvent): Promise<AutomationAction> {
+  return {
+    action: "none",
+    reason: `module "${module.name}" loaded but no concrete handler registered (framework-only)`,
+  };
+}

--- a/packages/daemon/src/automation-dispatcher.ts
+++ b/packages/daemon/src/automation-dispatcher.ts
@@ -11,10 +11,13 @@
  * #2018
  */
 
+import { resolve } from "node:path";
 import type {
   AutomationAction,
   AutomationAuditEntry,
   AutomationConfig,
+  AutomationContext,
+  AutomationDefinition,
   AutomationLogEntry,
   AutomationModuleInfo,
   AutomationOutcome,
@@ -47,18 +50,21 @@ export class AutomationDispatcher {
   private repoRoot: string;
   private eventBus: EventBus;
   private getWorkItemOverrides: (workItemId: string) => string | undefined;
+  private resolveWorkItemId: (prNumber: number) => string | undefined;
   private executeModule: (module: RegisteredModule, event: MonitorEvent) => Promise<AutomationAction>;
 
   constructor(opts: {
     eventBus: EventBus;
     repoRoot: string;
     getWorkItemOverrides?: (workItemId: string) => string | undefined;
+    resolveWorkItemId?: (prNumber: number) => string | undefined;
     executeModule?: (module: RegisteredModule, event: MonitorEvent) => Promise<AutomationAction>;
   }) {
     this.eventBus = opts.eventBus;
     this.repoRoot = opts.repoRoot;
     this.getWorkItemOverrides = opts.getWorkItemOverrides ?? (() => undefined);
-    this.executeModule = opts.executeModule ?? defaultExecuteModule;
+    this.resolveWorkItemId = opts.resolveWorkItemId ?? (() => undefined);
+    this.executeModule = opts.executeModule ?? this.defaultExecuteModule.bind(this);
   }
 
   load(config: AutomationConfig, locked: LockedAutomation[]): void {
@@ -102,16 +108,23 @@ export class AutomationDispatcher {
     }
   }
 
+  private resolveWorkItemIdFromEvent(event: MonitorEvent): string | undefined {
+    if (typeof event.workItemId === "string") return event.workItemId;
+    if (typeof event.prNumber === "number") return this.resolveWorkItemId(event.prNumber);
+    return undefined;
+  }
+
   private async onEvent(event: MonitorEvent): Promise<void> {
     for (const mod of this.modules.values()) {
       if (!mod.events.has(event.event)) continue;
 
-      const workItemId = typeof event.workItemId === "string" ? event.workItemId : undefined;
+      const workItemId = this.resolveWorkItemIdFromEvent(event);
       const overrides = parseAutomationOverrides(workItemId ? this.getWorkItemOverrides(workItemId) : undefined);
 
       if (!isModuleEnabledForItem(mod.name, mod.enabled, this.preset, overrides)) {
-        this.recordAudit(mod.name, "skipped", event.event, workItemId, null, "disabled by config or override", 0);
-        this.emitAuditEvent(mod.name, "skipped", event, { reason: "disabled by config or override" });
+        const skipReason = "disabled by config or override";
+        this.recordAudit(mod.name, "skipped", event.event, workItemId, null, null, skipReason, 0);
+        this.emitAuditEvent(mod.name, "skipped", event, { skipReason });
         continue;
       }
 
@@ -144,7 +157,7 @@ export class AutomationDispatcher {
       }
 
       const durationMs = Math.round(performance.now() - start);
-      this.recordAudit(mod.name, outcome, event.event, workItemId, action, error, durationMs);
+      this.recordAudit(mod.name, outcome, event.event, workItemId, action, error, null, durationMs);
       this.emitAuditEvent(mod.name, outcome, event, {
         actionType: action.action,
         error,
@@ -181,6 +194,7 @@ export class AutomationDispatcher {
     workItemId: string | undefined,
     action: AutomationAction | null,
     error: string | null,
+    skipReason: string | null,
     durationMs: number,
   ): void {
     const entry: AutomationAuditEntry = {
@@ -190,6 +204,7 @@ export class AutomationDispatcher {
       workItemId,
       action,
       error,
+      skipReason,
       ts: new Date().toISOString(),
       durationMs,
     };
@@ -239,6 +254,7 @@ export class AutomationDispatcher {
       workItemId: e.workItemId,
       actionType: e.action?.action ?? null,
       error: e.error,
+      skipReason: e.skipReason,
       ts: e.ts,
       durationMs: e.durationMs,
     }));
@@ -251,11 +267,53 @@ export class AutomationDispatcher {
   get currentPreset(): AutomationPreset {
     return this.preset;
   }
-}
 
-async function defaultExecuteModule(module: RegisteredModule, _event: MonitorEvent): Promise<AutomationAction> {
-  return {
-    action: "none",
-    reason: `module "${module.name}" loaded but no concrete handler registered (framework-only)`,
-  };
+  private async defaultExecuteModule(mod: RegisteredModule, event: MonitorEvent): Promise<AutomationAction> {
+    const absPath = resolve(this.repoRoot, mod.resolvedPath);
+    let exported: Record<string, unknown>;
+    try {
+      exported = await import(absPath);
+    } catch (err) {
+      throw new Error(
+        `failed to load "${mod.name}" from ${mod.resolvedPath}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    const def = exported.default as AutomationDefinition | undefined;
+    if (!def || typeof def.fn !== "function") {
+      throw new Error(`module "${mod.name}" has no default export with an fn() handler`);
+    }
+
+    const ctx: AutomationContext = {
+      mcp: new Proxy({} as AutomationContext["mcp"], {
+        get: (_, prop) => {
+          throw new Error(`mcp.${String(prop)} is not available in automation context`);
+        },
+      }),
+      state: new Proxy({} as AutomationContext["state"], {
+        get: (_, prop) => {
+          throw new Error(`state.${String(prop)} is not available in automation context`);
+        },
+      }),
+      repoRoot: this.repoRoot,
+      signal: AbortSignal.timeout(MODULE_TIMEOUT_MS),
+      workItem: null,
+      logger: {
+        info: (msg: string) => console.log(`[automation:${mod.name}] ${msg}`),
+        warn: (msg: string) => console.warn(`[automation:${mod.name}] ${msg}`),
+        error: (msg: string) => console.error(`[automation:${mod.name}] ${msg}`),
+      },
+      emit: (evt) => {
+        const { event: evtName, category: evtCategory, ...rest } = evt;
+        this.eventBus.publish({
+          src: `automation:${mod.name}`,
+          event: evtName,
+          category: evtCategory as "automation",
+          ...rest,
+        });
+      },
+    };
+
+    return def.fn(event, ctx);
+  }
 }

--- a/packages/daemon/src/automation-dispatcher.ts
+++ b/packages/daemon/src/automation-dispatcher.ts
@@ -43,6 +43,7 @@ export class AutomationDispatcher {
   private auditRing: AutomationAuditEntry[] = [];
   private auditHead = 0;
   private auditCount = 0;
+  private auditTotal = 0;
   private repoRoot: string;
   private eventBus: EventBus;
   private getWorkItemOverrides: (workItemId: string) => string | undefined;
@@ -192,6 +193,7 @@ export class AutomationDispatcher {
       durationMs,
     };
 
+    this.auditTotal++;
     if (this.auditCount < AUDIT_RING_CAPACITY) {
       this.auditRing.push(entry);
       this.auditCount++;
@@ -220,9 +222,10 @@ export class AutomationDispatcher {
   getAuditLog(moduleName?: string, limit = 50): AutomationLogEntry[] {
     const entries: AutomationAuditEntry[] = [];
     const n = Math.min(this.auditCount, AUDIT_RING_CAPACITY);
+    const wrapped = this.auditTotal > AUDIT_RING_CAPACITY;
 
     for (let i = 0; i < n; i++) {
-      const idx = this.auditCount <= AUDIT_RING_CAPACITY ? i : (this.auditHead + i) % AUDIT_RING_CAPACITY;
+      const idx = wrapped ? (this.auditHead + i) % AUDIT_RING_CAPACITY : i;
       const entry = this.auditRing[idx];
       if (moduleName && entry.module !== moduleName) continue;
       entries.push(entry);

--- a/packages/daemon/src/db/work-items.spec.ts
+++ b/packages/daemon/src/db/work-items.spec.ts
@@ -352,7 +352,7 @@ describe("WorkItemDb", () => {
       const row = raw
         .query<{ version: number }, [string]>("SELECT version FROM schema_versions WHERE name = ?")
         .get("work_items");
-      expect(row?.version).toBe(6);
+      expect(row?.version).toBe(7);
     });
 
     test("does not touch PRAGMA user_version (leaves it free for other consumers)", () => {
@@ -376,7 +376,7 @@ describe("WorkItemDb", () => {
       const row = raw
         .query<{ version: number }, [string]>("SELECT version FROM schema_versions WHERE name = ?")
         .get("work_items");
-      expect(row?.version).toBe(6);
+      expect(row?.version).toBe(7);
     });
 
     test("legacy v1 DB (work_items table, no transitions table) seeds at 1 then upgrades to 2", () => {
@@ -410,7 +410,7 @@ describe("WorkItemDb", () => {
       const seeded = raw
         .query<{ version: number }, [string]>("SELECT version FROM schema_versions WHERE name = ?")
         .get("work_items");
-      expect(seeded?.version).toBe(6);
+      expect(seeded?.version).toBe(7);
 
       // v2 transitions table now exists
       const hasTransitions = raw
@@ -444,7 +444,7 @@ describe("WorkItemDb", () => {
       const row = raw
         .query<{ version: number }, [string]>("SELECT version FROM schema_versions WHERE name = ?")
         .get("work_items");
-      expect(row?.version).toBe(6);
+      expect(row?.version).toBe(7);
 
       // And the tables actually got created (regression for the PRAGMA-fallback bug)
       const item = db.createWorkItem({ issueNumber: 1, phase: "impl" });
@@ -783,7 +783,7 @@ describe("WorkItemDb", () => {
       const seed = new Database(p, { create: true });
       seed.exec("PRAGMA journal_mode = WAL");
       seed.exec("CREATE TABLE IF NOT EXISTS schema_versions (name TEXT PRIMARY KEY, version INTEGER NOT NULL)");
-      seed.exec("INSERT INTO schema_versions (name, version) VALUES ('work_items', 6)");
+      seed.exec("INSERT INTO schema_versions (name, version) VALUES ('work_items', 7)");
       seed.close();
       // The second process (this WorkItemDb call) must not throw a UNIQUE constraint error.
       const db2 = new Database(p, { create: true });

--- a/packages/daemon/src/db/work-items.ts
+++ b/packages/daemon/src/db/work-items.ts
@@ -65,6 +65,7 @@ interface WorkItemRow {
   ci_summary: string | null;
   review_status: string;
   merge_state_status: string | null;
+  automation_overrides: string | null;
   phase: string;
   created_at: string;
   updated_at: string;
@@ -86,6 +87,7 @@ function rowToWorkItem(row: WorkItemRow): WorkItem {
     reviewStatus: row.review_status as ReviewStatus,
     mergeStateStatus: (row.merge_state_status as MergeStateStatus) ?? null,
     phase: row.phase as WorkItemPhase,
+    automationOverrides: row.automation_overrides ?? null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
     version: row.version,
@@ -244,6 +246,11 @@ export class WorkItemDb {
       })();
       version = 6;
     }
+    if (version < 7) {
+      this.db.exec("ALTER TABLE work_items ADD COLUMN automation_overrides TEXT");
+      this.setSchemaVersion(CONSUMER, 7);
+      version = 7;
+    }
   }
 
   private setSchemaVersion(name: string, version: number): void {
@@ -335,6 +342,7 @@ export class WorkItemDb {
           ["ciSummary", "ci_summary"],
           ["reviewStatus", "review_status"],
           ["mergeStateStatus", "merge_state_status"],
+          ["automationOverrides", "automation_overrides"],
           ["phase", "phase"],
         ];
 

--- a/packages/daemon/src/db/work-items.ts
+++ b/packages/daemon/src/db/work-items.ts
@@ -265,8 +265,8 @@ export class WorkItemDb {
     const id = item.id ?? randomUUIDv7();
     this.db
       .query(
-        `INSERT INTO work_items (id, issue_number, branch, pr_number, pr_state, pr_url, ci_status, ci_run_id, ci_summary, review_status, merge_state_status, phase)
-         VALUES ($id, $issue_number, $branch, $pr_number, $pr_state, $pr_url, $ci_status, $ci_run_id, $ci_summary, $review_status, $merge_state_status, $phase)`,
+        `INSERT INTO work_items (id, issue_number, branch, pr_number, pr_state, pr_url, ci_status, ci_run_id, ci_summary, review_status, merge_state_status, automation_overrides, phase)
+         VALUES ($id, $issue_number, $branch, $pr_number, $pr_state, $pr_url, $ci_status, $ci_run_id, $ci_summary, $review_status, $merge_state_status, $automation_overrides, $phase)`,
       )
       .run({
         $id: id,
@@ -280,6 +280,7 @@ export class WorkItemDb {
         $ci_summary: item.ciSummary ?? null,
         $review_status: item.reviewStatus ?? "none",
         $merge_state_status: item.mergeStateStatus ?? null,
+        $automation_overrides: item.automationOverrides ?? null,
         $phase: item.phase ?? "impl",
       });
 

--- a/packages/daemon/src/handlers/automation.ts
+++ b/packages/daemon/src/handlers/automation.ts
@@ -1,0 +1,36 @@
+/**
+ * IPC handlers for automation module introspection.
+ *
+ * #2018
+ */
+
+import { GetAutomationLogParamsSchema, type IpcMethod, ListAutomationParamsSchema } from "@mcp-cli/core";
+import type { AutomationDispatcher } from "../automation-dispatcher";
+import type { RequestHandler } from "../handler-types";
+
+export class AutomationHandlers {
+  constructor(private dispatcher: AutomationDispatcher | null) {}
+
+  register(handlers: Map<IpcMethod, RequestHandler>): void {
+    handlers.set("listAutomation", async (params) => {
+      const _parsed = ListAutomationParamsSchema.parse(params);
+      if (!this.dispatcher) {
+        return { modules: [], preset: "supervised" };
+      }
+      return {
+        modules: this.dispatcher.listModules(),
+        preset: this.dispatcher.currentPreset,
+      };
+    });
+
+    handlers.set("getAutomationLog", async (params) => {
+      const parsed = GetAutomationLogParamsSchema.parse(params);
+      if (!this.dispatcher) {
+        return { entries: [] };
+      }
+      return {
+        entries: this.dispatcher.getAuditLog(parsed.module, parsed.limit),
+      };
+    });
+  }
+}

--- a/packages/daemon/src/handlers/automation.ts
+++ b/packages/daemon/src/handlers/automation.ts
@@ -1,6 +1,11 @@
 /**
  * IPC handlers for automation module introspection.
  *
+ * Limitation: the daemon currently manages a single AutomationDispatcher
+ * bound to the repo root it was started from. The repoRoot parameter is
+ * parsed but not yet used for per-repo dispatcher resolution — callers
+ * from a different repo will see the startup-directory dispatcher's data.
+ *
  * #2018
  */
 
@@ -13,7 +18,7 @@ export class AutomationHandlers {
 
   register(handlers: Map<IpcMethod, RequestHandler>): void {
     handlers.set("listAutomation", async (params) => {
-      const _parsed = ListAutomationParamsSchema.parse(params);
+      ListAutomationParamsSchema.parse(params);
       if (!this.dispatcher) {
         return { modules: [], preset: "supervised" };
       }

--- a/packages/daemon/src/handlers/work-item.ts
+++ b/packages/daemon/src/handlers/work-item.ts
@@ -57,7 +57,7 @@ export class WorkItemHandlers {
 
   register(handlers: Map<IpcMethod, RequestHandler>): void {
     handlers.set("trackWorkItem", async (params, _ctx) => {
-      const { number, branch, initialPhase, repoRoot } = TrackWorkItemParamsSchema.parse(params);
+      const { number, branch, initialPhase, repoRoot, automationOverrides } = TrackWorkItemParamsSchema.parse(params);
 
       // Validate initialPhase server-side when a manifest is available (#1351).
       // When no manifest is present (repoRoot absent or manifest missing), accept any string.
@@ -78,15 +78,22 @@ export class WorkItemHandlers {
       if (number) {
         const existing = this.workItemDb.getWorkItemByIssue(number) ?? this.workItemDb.getWorkItem(`#${number}`);
         if (existing) {
-          // Backfill: if prNumber is null, kick off background re-resolution
           if (existing.prNumber === null && this.resolveIssuePr) {
             this.resolveAndUpdateWorkItem(existing.id, number);
+          }
+          if (automationOverrides !== undefined) {
+            return this.workItemDb.updateWorkItem(existing.id, { automationOverrides });
           }
           return existing;
         }
       } else if (branch) {
         const existing = this.workItemDb.getWorkItemByBranch(branch);
-        if (existing) return existing;
+        if (existing) {
+          if (automationOverrides !== undefined) {
+            return this.workItemDb.updateWorkItem(existing.id, { automationOverrides });
+          }
+          return existing;
+        }
       }
 
       // Create the item immediately (non-blocking) so the caller isn't waiting on GitHub
@@ -97,6 +104,7 @@ export class WorkItemHandlers {
         prNumber: null,
         branch: branch ?? null,
         ...(initialPhase ? { phase: initialPhase as WorkItemPhase } : {}),
+        ...(automationOverrides ? { automationOverrides } : {}),
       });
 
       // Fire-and-forget: resolve PR number in the background

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -60,6 +60,7 @@ import {
   readCliConfig,
   readWorktreeConfig,
   resolveWorktreePath,
+  sha256Hex,
   tryFlockExclusive,
 } from "@mcp-cli/core";
 import { AcpServer, buildAcpToolCache } from "./acp-server";
@@ -673,9 +674,22 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
       try {
         const lockText = readFileSync(lockfilePath, "utf-8");
         const lock = parseLockfile(lockText);
+        const currentManifestHash = sha256Hex(readFileSync(manifestResult.path, "utf-8"));
+        if (lock.manifestHash !== currentManifestHash) {
+          logger.warn(
+            `[mcpd] Lockfile manifest hash mismatch (locked: ${lock.manifestHash.slice(0, 8)}… vs current: ${currentManifestHash.slice(0, 8)}…) — run \`mcx phase install\``,
+          );
+        }
         automations = lock.automations ?? [];
-      } catch {
-        logger.warn("[mcpd] Automation configured but no lockfile found — run `mcx phase install`");
+      } catch (err) {
+        const isEnoent = err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code === "ENOENT";
+        if (isEnoent) {
+          logger.warn("[mcpd] Automation configured but no lockfile found — run `mcx phase install`");
+        } else {
+          logger.warn(
+            `[mcpd] Automation configured but lockfile is corrupt: ${err instanceof Error ? err.message : String(err)} — run \`mcx phase install\``,
+          );
+        }
       }
       if (automations.length > 0) {
         automationDispatcher = new AutomationDispatcher({
@@ -684,6 +698,10 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
           getWorkItemOverrides: (workItemId) => {
             const item = workItemDb.getWorkItem(workItemId);
             return item?.automationOverrides ?? undefined;
+          },
+          resolveWorkItemId: (prNumber) => {
+            const item = workItemDb.getWorkItemByPr(prNumber);
+            return item?.id ?? undefined;
           },
         });
         automationDispatcher.load(manifestResult.manifest.automation, automations);

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -37,6 +37,7 @@ import {
   DAEMON_READY_SIGNAL,
   DAEMON_RESTARTED,
   DEFAULT_CLAUDE_WS_PORT,
+  LOCKFILE_NAME,
   MAIL_SERVER_NAME,
   METRICS_SERVER_NAME,
   MOCK_SERVER_NAME,
@@ -54,6 +55,7 @@ import {
   isCoreBareSet,
   loadManifest,
   options,
+  parseLockfile,
   pruneExpiredCache,
   readCliConfig,
   readWorktreeConfig,
@@ -62,6 +64,7 @@ import {
 } from "@mcp-cli/core";
 import { AcpServer, buildAcpToolCache } from "./acp-server";
 import { AliasServer, buildAliasToolCache } from "./alias-server";
+import { AutomationDispatcher } from "./automation-dispatcher";
 import { BudgetWatcher } from "./budget-watcher";
 import { ClaudeServer, buildClaudeToolCache } from "./claude-server";
 import { CodexServer, buildCodexToolCache } from "./codex-server";
@@ -654,6 +657,39 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
     logger.info("[mcpd] Session metrics aggregator started");
   }
 
+  // Start automation dispatcher (#2018) — reads lockfile, subscribes to event bus
+  let automationDispatcher: AutomationDispatcher | null = null;
+  {
+    const workItemDb = new WorkItemDb(db.getDatabase());
+    const manifestResult = loadManifest(process.cwd());
+    if (manifestResult?.manifest?.automation) {
+      const lockfilePath = join(process.cwd(), LOCKFILE_NAME);
+      let automations: import("@mcp-cli/core").LockedAutomation[] = [];
+      try {
+        const lockText = readFileSync(lockfilePath, "utf-8");
+        const lock = parseLockfile(lockText);
+        automations = lock.automations ?? [];
+      } catch {
+        logger.warn("[mcpd] Automation configured but no lockfile found — run `mcx phase install`");
+      }
+      if (automations.length > 0) {
+        automationDispatcher = new AutomationDispatcher({
+          eventBus: mailEventBus,
+          repoRoot: process.cwd(),
+          getWorkItemOverrides: (workItemId) => {
+            const item = workItemDb.getWorkItem(workItemId);
+            return item?.automationOverrides ?? undefined;
+          },
+        });
+        automationDispatcher.load(manifestResult.manifest.automation, automations);
+        automationDispatcher.start();
+        logger.info(
+          `[mcpd] Automation dispatcher started (${automations.length} module(s), preset: ${manifestResult.manifest.automation.preset ?? "supervised"})`,
+        );
+      }
+    }
+  }
+
   // Start IPC server
   const ipcServer = new IpcServer(pool, config, db, aliasServer, {
     daemonId,
@@ -697,6 +733,7 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
         logger.error(`[mcpd] Monitor restart for "${name}" failed: ${err}`);
       });
     },
+    automationDispatcher: automationDispatcher ?? undefined,
   });
   ipcServer.start();
 

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -661,7 +661,12 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
   let automationDispatcher: AutomationDispatcher | null = null;
   {
     const workItemDb = new WorkItemDb(db.getDatabase());
-    const manifestResult = loadManifest(process.cwd());
+    let manifestResult: ReturnType<typeof loadManifest> | null = null;
+    try {
+      manifestResult = loadManifest(process.cwd());
+    } catch (err) {
+      logger.warn(`[mcpd] Failed to load manifest for automation: ${err} — skipping`);
+    }
     if (manifestResult?.manifest?.automation) {
       const lockfilePath = join(process.cwd(), LOCKFILE_NAME);
       let automations: import("@mcp-cli/core").LockedAutomation[] = [];
@@ -1155,6 +1160,7 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
       if (idleTimer) clearTimeout(idleTimer);
       clearInterval(pruneInterval);
       clearInterval(metricsInterval);
+      automationDispatcher?.stop();
       eventLog.stopPruning();
       quotaPoller.stop();
       budgetWatcher.dispose();

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -32,6 +32,7 @@ import {
 } from "@mcp-cli/core";
 import { z } from "zod/v4";
 import type { AliasServer } from "./alias-server";
+import type { AutomationDispatcher } from "./automation-dispatcher";
 import { getDaemonLogLines } from "./daemon-log";
 import type { StateDb } from "./db/state";
 import { WorkItemDb } from "./db/work-items";
@@ -41,6 +42,7 @@ import { EventStreamServer } from "./event-stream";
 import type { RequestContext, RequestHandler } from "./handler-types";
 import { AliasHandlers } from "./handlers/alias";
 import { AuthHandlers } from "./handlers/auth";
+import { AutomationHandlers } from "./handlers/automation";
 import { BudgetHandlers } from "./handlers/budget";
 import { ConfigHandlers } from "./handlers/config";
 import { EventHandlers } from "./handlers/event";
@@ -100,6 +102,7 @@ export class IpcServer {
       eventBus?: EventBus;
       eventLog?: EventLog;
       onAliasChanged?: (name: string) => void;
+      automationDispatcher?: AutomationDispatcher;
     },
   ) {
     this.daemonId = opts.daemonId;
@@ -132,6 +135,7 @@ export class IpcServer {
       resolveIssuePr: opts.resolveIssuePr ?? null,
       loadManifestFn: opts.loadManifest ?? ((r) => loadManifest(r)?.manifest ?? null),
       onAliasChanged: opts.onAliasChanged ?? null,
+      automationDispatcher: opts.automationDispatcher ?? null,
     });
     this.db.pruneExpiredAliases();
   }
@@ -374,6 +378,7 @@ export class IpcServer {
     resolveIssuePr: ((n: number) => Promise<{ prNumber: number | null }>) | null;
     loadManifestFn: ((repoRoot: string) => Manifest | null) | null;
     onAliasChanged: ((name: string) => void) | null;
+    automationDispatcher: AutomationDispatcher | null;
   }): void {
     const serveHandlers = new ServeHandlers(this.serveInstances, this.logger);
     new AuthHandlers(this.pool).register(this.handlers);
@@ -384,6 +389,7 @@ export class IpcServer {
     serveHandlers.register(this.handlers);
     new BudgetHandlers(this.db).register(this.handlers);
     new EventHandlers(deps.eventBus).register(this.handlers);
+    new AutomationHandlers(deps.automationDispatcher).register(this.handlers);
     new TelemetryHandlers(this.db).register(this.handlers);
     new ConfigHandlers(this.pool, this.config, this.onReloadConfig).register(this.handlers);
     new MailHandlers(this.db, deps.eventBus, () => this.draining).register(this.handlers);

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -476,7 +476,7 @@ export class IpcServer {
     });
 
     // Catch duplicate registrations (silently-overwritten handlers are invisible bugs).
-    const EXPECTED = 51;
+    const EXPECTED = 53;
     if (this.handlers.size !== EXPECTED) {
       throw new Error(
         `Handler count mismatch after registration: expected ${EXPECTED}, got ${this.handlers.size}. A handler was duplicated or omitted.`,

--- a/packages/daemon/src/test-fixtures/bad-automation.ts
+++ b/packages/daemon/src/test-fixtures/bad-automation.ts
@@ -1,0 +1,1 @@
+export default { notAnAutomation: true };

--- a/packages/daemon/src/test-fixtures/echo-automation.ts
+++ b/packages/daemon/src/test-fixtures/echo-automation.ts
@@ -1,0 +1,10 @@
+import { defineAutomation } from "@mcp-cli/core";
+
+export default defineAutomation({
+  name: "echo",
+  events: ["pr.merged"],
+  fn: async (event, ctx) => {
+    ctx.logger.info(`echo: ${event.event}`);
+    return { action: "none", reason: `echoed ${event.event}` };
+  },
+});


### PR DESCRIPTION
## Summary

Adds the foundation for manifest-declared automation modules (#2018), including core schemas/types, lockfile entries, daemon-side dispatcher/IPC introspection, monitor formatting, and CLI commands.

**Second commit addresses all 6 blockers and 3 should-fixes from the adversarial review.**

### Blockers fixed

1. **Ring buffer bug** — `auditTotal` tracked separately from `auditCount` so `getAuditLog` reads in chronological order after the ring wraps past capacity (200).
2. **Preset system dead code** — `enabled` field changed from `.default(true)` to `.optional()` in Zod schema. Preset defaults are now resolved at `mcx phase install` time via `expandPreset()` and written to the lockfile.
3. **docs/automation.md** — Added covering: schema, handler API, slider presets, escalation contract, per-item overrides, lifecycle, CLI commands, copy-adapt guide.
4. **`defineAutomation` not in virtual module** — Added to `alias-bundle.ts` injected context alongside `defineAlias`/`defineMonitor`. Module authors can now `import { defineAutomation } from "mcp-cli"`.
5. **`mcx track --automation` not implemented** — Added `--automation <csv>` flag, `automationOverrides` IPC param, DB column (migration v7), handler wiring for both new and existing items.
6. **Dispatcher never instantiated** — Daemon startup now reads `.mcx.lock`, creates `AutomationDispatcher`, loads config, and calls `.start()` when automation modules are configured.

### Should-fixes addressed

- **`Bun.sleep(10)` in tests** — All 12+ dispatcher tests rewritten to use `pollUntil()` with deadline-based polling.
- **Ring buffer wrapping test** — New test writes >200 entries and verifies `getAuditLog` returns the newest N in chronological order.
- **Action executor documented as deferred** — `docs/automation.md` explicitly notes that action execution (bye-and-untrack, set-state, shell, etc.) is deferred to module PRs (#2020, #2021). The framework records actions in audit but does not execute side effects.

### Additional fixes

- Fixed `mcx automation log --limit 10` parsing `--limit` as a module name (Copilot review comment).
- Added preset integration test verifying disabled modules emit `automation.skipped`.

### Scope

- ✅ Framework only — no concrete modules shipped
- ✅ No `.claude/automation/cleanup.ts` or `bind.ts` — those are #2020/#2021

## Test plan

- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun run build` produces binaries
- [x] 43 automation tests pass (core + dispatcher)
- [x] 168 phase tests pass (install path with `expandPreset`)
- [x] 34 track tests pass (including manifest integration)
- [x] 65 work-items DB tests pass (migration v7)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)