### PR TITLE
test(daemon-integration): share daemons in P5b/P5c suites; add addServer/removeServer helpers (closes #2014)

### DIFF
--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -53,7 +53,7 @@ const PROFILE_CONCURRENCY = Math.max(4, Math.min(navigator.hardwareConcurrency ?
  */
 const TIMING_EXCLUSIONS: Record<string, string> = {
   "test/daemon-integration.spec.ts":
-    "Full daemon lifecycle integration tests (~12s post wsPort fix; ~22 daemon spawns)",
+    "Full daemon lifecycle integration tests (~12s; P1 idle-timeout burns 4s alone; P5b/P5c share daemons post #2014)",
   "test/stress.spec.ts": "Stress tests spawning real CLI processes",
   "test/transport-errors.spec.ts": "Live daemon transport error integration tests",
   "packages/daemon/src/index.spec.ts": "13 in-process daemon instances for startup/shutdown/idle/reload",

--- a/test/daemon-integration.spec.ts
+++ b/test/daemon-integration.spec.ts
@@ -477,49 +477,45 @@ describe("P5: Error scenarios", () => {
 
 // ---------------------------------------------------------------------------
 // P5b: Error scenario edge cases (#117)
+// Shared daemon: all server configs known at beforeAll time — pre-configure to
+// avoid hot-reload latency. Unique names guarantee test isolation.
 // ---------------------------------------------------------------------------
 describe("P5b: Error scenario edge cases", () => {
-  let daemon: TestDaemon | undefined;
+  let daemon: TestDaemon;
+  let authServer: MockServer;
 
-  afterEach(async () => {
-    if (daemon) {
-      await daemon.kill();
-      daemon = undefined;
-    }
-  });
-
-  test("HTTP 401 error suggests 'mcx auth' in the error message", async () => {
-    // Start a local HTTP server that always returns 401, using harness for proper cleanup
-    const authServer = await startMockServer("test/http-401-server.ts");
-    try {
-      daemon = await startTestDaemon({
-        authfail: { type: "http", url: `http://127.0.0.1:${authServer.port}/mcp` },
-      });
-
-      // Trigger a connection attempt — the 401 should produce an auth hint
-      const res = await rpc(daemon.socketPath, "listTools", { server: "authfail" });
-      expect(res.error).toBeDefined();
-      expect(res.error?.message).toContain("auth");
-      expect(res.error?.message).toContain("mcx auth");
-
-      // Verify lastError also contains the hint
-      const list = await rpc(daemon.socketPath, "listServers");
-      const server = (list.result as Array<{ name: string; lastError?: string }>).find((s) => s.name === "authfail");
-      expect(server?.lastError).toContain("mcx auth");
-    } finally {
-      await authServer.kill();
-    }
-  });
-
-  test("callTool with short timeout returns clear timeout error", async () => {
+  beforeAll(async () => {
+    authServer = await startMockServer("test/http-401-server.ts");
     daemon = await startTestDaemon({
+      authfail: { type: "http", url: `http://127.0.0.1:${authServer.port}/mcp` },
       slow: {
         command: "bun",
         args: [resolve("test/slow-echo-server.ts")],
         env: { SLOW_MS: "10000" },
       },
+      crasher: { command: "bun", args: [resolve("test/exit-immediately.ts")] },
     });
+  });
 
+  afterAll(async () => {
+    await daemon.kill();
+    await authServer.kill();
+  });
+
+  test("HTTP 401 error suggests 'mcx auth' in the error message", async () => {
+    // Trigger a connection attempt — the 401 should produce an auth hint
+    const res = await rpc(daemon.socketPath, "listTools", { server: "authfail" });
+    expect(res.error).toBeDefined();
+    expect(res.error?.message).toContain("auth");
+    expect(res.error?.message).toContain("mcx auth");
+
+    // Verify lastError also contains the hint
+    const list = await rpc(daemon.socketPath, "listServers");
+    const server = (list.result as Array<{ name: string; lastError?: string }>).find((s) => s.name === "authfail");
+    expect(server?.lastError).toContain("mcx auth");
+  });
+
+  test("callTool with short timeout returns clear timeout error", async () => {
     // Ensure server is connected first
     const tools = await rpc(daemon.socketPath, "listTools", { server: "slow" });
     expect(tools.error).toBeUndefined();
@@ -538,10 +534,6 @@ describe("P5b: Error scenario edge cases", () => {
   });
 
   test("server that fails to start produces actionable error via callTool", async () => {
-    daemon = await startTestDaemon({
-      crasher: { command: "bun", args: [resolve("test/exit-immediately.ts")] },
-    });
-
     // callTool against a server that crashes on startup
     const res = await rpc(daemon.socketPath, "callTool", {
       server: "crasher",
@@ -688,23 +680,24 @@ describe("P3c: SSE transport end-to-end", () => {
 
 // ---------------------------------------------------------------------------
 // P5c: HTTP/SSE transport error scenarios (#115)
+// Shared daemon: both dead-endpoint configs known at beforeAll time — pre-configure
+// to avoid hot-reload latency. Unique names guarantee test isolation.
 // ---------------------------------------------------------------------------
 describe("P5c: Transport connection error scenarios", () => {
-  let daemon: TestDaemon | undefined;
+  let daemon: TestDaemon;
 
-  afterEach(async () => {
-    if (daemon) {
-      await daemon.kill();
-      daemon = undefined;
-    }
+  beforeAll(async () => {
+    daemon = await startTestDaemon({
+      deadhttp: { type: "http", url: "http://127.0.0.1:1/mcp" },
+      deadsse: { type: "sse", url: "http://127.0.0.1:1/sse" },
+    });
+  });
+
+  afterAll(async () => {
+    await daemon.kill();
   });
 
   test("HTTP connection refused returns clear error", async () => {
-    // Point at a port with nothing listening
-    daemon = await startTestDaemon({
-      deadhttp: { type: "http", url: "http://127.0.0.1:1/mcp" },
-    });
-
     const res = await rpc(daemon.socketPath, "listTools", { server: "deadhttp" });
     expect(res.error).toBeDefined();
     // Error should mention connection or the URL
@@ -717,10 +710,6 @@ describe("P5c: Transport connection error scenarios", () => {
   });
 
   test("SSE connection refused returns clear error", async () => {
-    daemon = await startTestDaemon({
-      deadsse: { type: "sse", url: "http://127.0.0.1:1/sse" },
-    });
-
     const res = await rpc(daemon.socketPath, "listTools", { server: "deadsse" });
     expect(res.error).toBeDefined();
     const msg = res.error?.message?.toLowerCase() ?? "";

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -4,7 +4,7 @@
  * Spawns real daemon processes in isolated temp directories
  * via the MCP_CLI_DIR env var override.
  */
-import { existsSync, mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import type { IpcResponse, ServerConfig, ServerConfigMap } from "@mcp-cli/core";
@@ -212,6 +212,36 @@ export function echoSseServerConfig(port: number): ServerConfig {
     type: "sse",
     url: `http://127.0.0.1:${port}/sse`,
   };
+}
+
+/**
+ * Merge a single server into the daemon's servers.json without clobbering sibling entries.
+ * Polls listServers() until the new entry appears (or timeout throws).
+ */
+export async function addServer(d: TestDaemon, name: string, config: ServerConfig): Promise<void> {
+  const configPath = join(d.dir, "servers.json");
+  const current = JSON.parse(readFileSync(configPath, "utf-8")) as { mcpServers: ServerConfigMap };
+  current.mcpServers[name] = config;
+  writeFileSync(configPath, JSON.stringify(current));
+  await pollUntil(async () => {
+    const res = await rpc(d.socketPath, "listServers");
+    return (res.result as Array<{ name: string }>).some((s) => s.name === name);
+  }, 10_000);
+}
+
+/**
+ * Remove a single server from the daemon's servers.json.
+ * Polls listServers() until the entry disappears (or timeout throws).
+ */
+export async function removeServer(d: TestDaemon, name: string): Promise<void> {
+  const configPath = join(d.dir, "servers.json");
+  const current = JSON.parse(readFileSync(configPath, "utf-8")) as { mcpServers: ServerConfigMap };
+  delete current.mcpServers[name];
+  writeFileSync(configPath, JSON.stringify(current));
+  await pollUntil(async () => {
+    const res = await rpc(d.socketPath, "listServers");
+    return !(res.result as Array<{ name: string }>).some((s) => s.name === name);
+  }, 10_000);
 }
 
 /** Send an IPC RPC request directly to a daemon's Unix socket */


### PR DESCRIPTION
## Summary
- P5b and P5c suites converted from per-test daemon spawns to a shared `beforeAll`/`afterAll` daemon, eliminating 3 daemon spawns (~1.5s saved)
- All server configs pre-configured at daemon startup (avoids hot-reload latency that would offset the savings)
- Adds `addServer` / `removeServer` helpers to `test/harness.ts` for tests that need to inject servers into a running daemon without clobbering sibling configs
- Updates TIMING_EXCLUSIONS reason string in `scripts/check-coverage.ts` (file remains above 5s budget due to P1 idle-timeout test burning 4s)

## Test plan
- [x] `bun test test/daemon-integration.spec.ts` passes 32/32 tests (run 3×, no flakes)
- [x] `bun typecheck` clean
- [x] `bun lint` clean
- [x] `bun test` full suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)