### PR TITLE
feat(track): per-work-item custom metadata via manifest-declared schema (fixes #2019)

### DIFF
--- a/.mcx.yaml
+++ b/.mcx.yaml
@@ -25,6 +25,8 @@ state:
   provider: string?
   labels: string?
   model: string?
+  scrutiny:     { type: "enum[low,medium,high]", track: true, default: medium }
+  bundled_with: { type: string, track: true, repeatable: true }
 
 phases:
   impl:

--- a/docs/phases.md
+++ b/docs/phases.md
@@ -69,6 +69,46 @@ unreachable-from-initial phases are rejected.
 State types are `string`, `number`, `boolean`, each optionally suffixed
 with `?` (e.g. `string?`). Runtime enforcement is wired in #1286.
 
+### Trackable metadata fields
+
+State fields can use an object form to declare CLI-settable metadata
+(`track: true`). These fields are exposed as `mcx track --<key>` flags
+and included in `mcx tracked --json` output under a `state` key.
+
+```yaml
+state:
+  session_id: string?          # bare type — handler-only, not CLI-settable
+  scrutiny:                    # object form — CLI-settable
+    type: enum[low,medium,high]
+    track: true
+    default: medium
+  bundled_with:
+    type: string
+    track: true
+    repeatable: true           # multiple --bundled-with flags → comma-joined
+```
+
+| Property | Type | Default | Meaning |
+|----------|------|---------|---------|
+| `type` | string | (required) | `string`, `number`, `boolean`, or `enum[val1,val2,...]`, optionally `?` |
+| `track` | boolean | `false` | Expose as `mcx track --<key>` flag |
+| `repeatable` | boolean | `false` | Allow multiple flags; values comma-joined |
+| `default` | string/number/boolean | none | Applied on track when flag is omitted |
+| `required` | boolean | `false` | Fail `mcx track` if flag is missing and no default |
+
+Usage:
+
+```bash
+mcx track 1234 --scrutiny high
+mcx track 1234 --bundled-with 1235 --bundled-with 1236
+mcx track --help                   # lists project-declared metadata fields
+mcx tracked --json                 # output includes state.scrutiny, etc.
+```
+
+Phase handlers read metadata via `ctx.state.get("scrutiny")` — same
+accessor as any other state key. The only difference is that trackable
+fields can be set at tracking time from the CLI.
+
 ## Phase source URIs
 
 Supported schemes today:

--- a/docs/phases.md
+++ b/docs/phases.md
@@ -66,8 +66,10 @@ Phase names and state keys must match `^[a-z][a-z0-9_-]{0,63}$`. The phase
 graph may contain cycles (review → repair → review is legal); only
 unreachable-from-initial phases are rejected.
 
-State types are `string`, `number`, `boolean`, each optionally suffixed
-with `?` (e.g. `string?`). Runtime enforcement is wired in #1286.
+Bare state types are `string`, `number`, `boolean`, each optionally
+suffixed with `?` (e.g. `string?`). The object form (see below) also
+accepts `enum[val1,val2,...]` with optional `?`. Runtime enforcement is
+wired in #1286.
 
 ### Trackable metadata fields
 

--- a/packages/command/src/commands/track.spec.ts
+++ b/packages/command/src/commands/track.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import type { IpcMethod, IpcMethodResult, Manifest, WorkItem } from "@mcp-cli/core";
+import type { IpcMethod, IpcMethodResult, Manifest, TrackableField, WorkItem } from "@mcp-cli/core";
 import { loadManifest } from "@mcp-cli/core";
 import type { TrackDeps } from "./track";
-import { cmdTrack, cmdTracked, cmdUntrack, formatWorkItemRow } from "./track";
+import { cmdTrack, cmdTracked, cmdUntrack, formatWorkItemRow, parseMetadataFlags } from "./track";
 
 class ExitError extends Error {
   code: number;
@@ -57,6 +57,109 @@ function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
     ...overrides,
   };
 }
+
+describe("parseMetadataFlags", () => {
+  const enumField: TrackableField = {
+    key: "scrutiny",
+    baseType: "enum",
+    optional: false,
+    enumValues: ["low", "medium", "high"],
+    repeatable: false,
+    required: false,
+    defaultValue: undefined,
+  };
+
+  const repeatableField: TrackableField = {
+    key: "bundled_with",
+    baseType: "string",
+    optional: false,
+    enumValues: null,
+    repeatable: true,
+    required: false,
+    defaultValue: undefined,
+  };
+
+  const requiredField: TrackableField = {
+    key: "priority",
+    baseType: "string",
+    optional: false,
+    enumValues: null,
+    repeatable: false,
+    required: true,
+    defaultValue: undefined,
+  };
+
+  test("parses valid enum value", () => {
+    const { metadata, errors } = parseMetadataFlags(["42", "--scrutiny", "high"], [enumField]);
+    expect(errors).toHaveLength(0);
+    expect(metadata.get("scrutiny")).toBe("high");
+  });
+
+  test("rejects invalid enum value", () => {
+    const { errors } = parseMetadataFlags(["42", "--scrutiny", "extreme"], [enumField]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("extreme");
+    expect(errors[0]).toContain("low, medium, high");
+  });
+
+  test("collects repeatable values into comma-joined string", () => {
+    const { metadata, errors } = parseMetadataFlags(
+      ["42", "--bundled-with", "100", "--bundled-with", "200"],
+      [repeatableField],
+    );
+    expect(errors).toHaveLength(0);
+    expect(metadata.get("bundled_with")).toBe("100,200");
+  });
+
+  test("rejects unknown flags when trackable fields exist", () => {
+    const { errors } = parseMetadataFlags(["42", "--bogus", "val"], [enumField]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("unknown metadata flag");
+  });
+
+  test("ignores unknown flags when no trackable fields", () => {
+    const { errors } = parseMetadataFlags(["42", "--bogus", "val"], []);
+    expect(errors).toHaveLength(0);
+  });
+
+  test("skips built-in flags", () => {
+    const { metadata, errors } = parseMetadataFlags(["42", "--branch", "feat/x", "--scrutiny", "low"], [enumField]);
+    expect(errors).toHaveLength(0);
+    expect(metadata.get("scrutiny")).toBe("low");
+    expect(metadata.has("branch")).toBe(false);
+  });
+
+  test("errors on missing required field", () => {
+    const { errors } = parseMetadataFlags(["42"], [requiredField]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("required");
+    expect(errors[0]).toContain("priority");
+  });
+
+  test("converts hyphens to underscores in flag names", () => {
+    const { metadata, errors } = parseMetadataFlags(["42", "--bundled-with", "100"], [repeatableField]);
+    expect(errors).toHaveLength(0);
+    expect(metadata.has("bundled_with")).toBe(true);
+  });
+
+  test("errors when flag has no value", () => {
+    const { errors } = parseMetadataFlags(["42", "--scrutiny"], [enumField]);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("requires a value");
+  });
+
+  test("marks consumed indices correctly", () => {
+    const { consumed } = parseMetadataFlags(
+      ["42", "--scrutiny", "high", "--bundled-with", "100"],
+      [enumField, repeatableField],
+    );
+    expect(consumed.has(0)).toBe(false);
+    expect(consumed.has(1)).toBe(true);
+    expect(consumed.has(2)).toBe(true);
+    expect(consumed.has(3)).toBe(true);
+    expect(consumed.has(4)).toBe(true);
+  });
+});
 
 describe("cmdTrack", () => {
   test("tracks a number", async () => {
@@ -448,6 +551,214 @@ describe("formatWorkItemRow", () => {
       }
       expect(captured).toEqual({ phase: "impl" });
       expect(errs.some((e) => e.includes('phase "impl" is not declared'))).toBe(true);
+    });
+
+    test("cmdTrack persists metadata via aliasStateSet", async () => {
+      const item = makeWorkItem({ id: "#42" });
+      const stateCalls: Array<{ method: string; params: unknown }> = [];
+
+      const MANIFEST_YAML = [
+        "version: 1",
+        "initial: plan",
+        "state:",
+        '  scrutiny: { type: "enum[low,medium,high]", track: true }',
+        "phases:",
+        "  plan: { source: ./p.ts, next: [build] }",
+        "  build: { source: ./b.ts }",
+      ].join("\n");
+
+      await withManifestDir(MANIFEST_YAML, (dir) => {
+        const deps: TrackDeps = {
+          ipcCall: async <M extends IpcMethod>(method: M, params?: unknown): Promise<IpcMethodResult[M]> => {
+            if (method === "trackWorkItem") return item as IpcMethodResult[M];
+            if (method === "aliasStateSet") {
+              stateCalls.push({ method, params: params as Record<string, unknown> });
+              return { ok: true } as IpcMethodResult[M];
+            }
+            throw new Error(`Unexpected IPC call: ${method}`);
+          },
+          exit: (code: number): never => {
+            throw new ExitError(code);
+          },
+          loadManifest: realManifestLoader,
+          cwd: () => dir,
+        };
+        return cmdTrack(["42", "--scrutiny", "high"], deps);
+      });
+
+      expect(stateCalls).toHaveLength(1);
+      expect(stateCalls[0].params).toEqual({
+        repoRoot: expect.any(String),
+        namespace: "workitem:#42",
+        key: "scrutiny",
+        value: "high",
+      });
+    });
+
+    test("cmdTrack rejects invalid enum value", async () => {
+      const MANIFEST_YAML = [
+        "version: 1",
+        "initial: plan",
+        "state:",
+        '  scrutiny: { type: "enum[low,medium,high]", track: true }',
+        "phases:",
+        "  plan: { source: ./p.ts, next: [build] }",
+        "  build: { source: ./b.ts }",
+      ].join("\n");
+
+      await expect(
+        withManifestDir(MANIFEST_YAML, (dir) => {
+          const deps: TrackDeps = {
+            ...makeDeps({ trackWorkItem: () => makeWorkItem() }),
+            loadManifest: realManifestLoader,
+            cwd: () => dir,
+          };
+          return cmdTrack(["42", "--scrutiny", "extreme"], deps);
+        }),
+      ).rejects.toThrow("exit(1)");
+    });
+
+    test("cmdTrack rejects unknown metadata flag when trackable fields exist", async () => {
+      const MANIFEST_YAML = [
+        "version: 1",
+        "initial: plan",
+        "state:",
+        '  scrutiny: { type: "enum[low,medium,high]", track: true }',
+        "phases:",
+        "  plan: { source: ./p.ts, next: [build] }",
+        "  build: { source: ./b.ts }",
+      ].join("\n");
+
+      await expect(
+        withManifestDir(MANIFEST_YAML, (dir) => {
+          const deps: TrackDeps = {
+            ...makeDeps({ trackWorkItem: () => makeWorkItem() }),
+            loadManifest: realManifestLoader,
+            cwd: () => dir,
+          };
+          return cmdTrack(["42", "--nonexistent", "val"], deps);
+        }),
+      ).rejects.toThrow("exit(1)");
+    });
+
+    test("cmdTrack handles repeatable fields", async () => {
+      const item = makeWorkItem({ id: "#42" });
+      const stateCalls: Array<{ key: string; value: unknown }> = [];
+
+      const MANIFEST_YAML = [
+        "version: 1",
+        "initial: plan",
+        "state:",
+        "  bundled_with: { type: string, track: true, repeatable: true }",
+        "phases:",
+        "  plan: { source: ./p.ts, next: [build] }",
+        "  build: { source: ./b.ts }",
+      ].join("\n");
+
+      await withManifestDir(MANIFEST_YAML, (dir) => {
+        const deps: TrackDeps = {
+          ipcCall: async <M extends IpcMethod>(method: M, params?: unknown): Promise<IpcMethodResult[M]> => {
+            if (method === "trackWorkItem") return item as IpcMethodResult[M];
+            if (method === "aliasStateSet") {
+              const p = params as Record<string, unknown>;
+              stateCalls.push({ key: p.key as string, value: p.value });
+              return { ok: true } as IpcMethodResult[M];
+            }
+            throw new Error(`Unexpected IPC call: ${method}`);
+          },
+          exit: (code: number): never => {
+            throw new ExitError(code);
+          },
+          loadManifest: realManifestLoader,
+          cwd: () => dir,
+        };
+        return cmdTrack(["42", "--bundled-with", "1001", "--bundled-with", "1002"], deps);
+      });
+
+      expect(stateCalls).toHaveLength(1);
+      expect(stateCalls[0].key).toBe("bundled_with");
+      expect(stateCalls[0].value).toBe("1001,1002");
+    });
+
+    test("cmdTrack persists default value when field not provided", async () => {
+      const item = makeWorkItem({ id: "#42" });
+      const stateCalls: Array<{ key: string; value: unknown }> = [];
+
+      const MANIFEST_YAML = [
+        "version: 1",
+        "initial: plan",
+        "state:",
+        '  scrutiny: { type: "enum[low,medium,high]", track: true, default: medium }',
+        "phases:",
+        "  plan: { source: ./p.ts, next: [build] }",
+        "  build: { source: ./b.ts }",
+      ].join("\n");
+
+      await withManifestDir(MANIFEST_YAML, (dir) => {
+        const deps: TrackDeps = {
+          ipcCall: async <M extends IpcMethod>(method: M, params?: unknown): Promise<IpcMethodResult[M]> => {
+            if (method === "trackWorkItem") return item as IpcMethodResult[M];
+            if (method === "aliasStateSet") {
+              const p = params as Record<string, unknown>;
+              stateCalls.push({ key: p.key as string, value: p.value });
+              return { ok: true } as IpcMethodResult[M];
+            }
+            throw new Error(`Unexpected IPC call: ${method}`);
+          },
+          exit: (code: number): never => {
+            throw new ExitError(code);
+          },
+          loadManifest: realManifestLoader,
+          cwd: () => dir,
+        };
+        return cmdTrack(["42"], deps);
+      });
+
+      expect(stateCalls).toHaveLength(1);
+      expect(stateCalls[0].key).toBe("scrutiny");
+      expect(stateCalls[0].value).toBe("medium");
+    });
+
+    test("cmdTracked --json includes state for trackable fields", async () => {
+      const items = [makeWorkItem({ id: "#42" })];
+
+      const MANIFEST_YAML = [
+        "version: 1",
+        "initial: plan",
+        "state:",
+        '  scrutiny: { type: "enum[low,medium,high]", track: true }',
+        "phases:",
+        "  plan: { source: ./p.ts, next: [build] }",
+        "  build: { source: ./b.ts }",
+      ].join("\n");
+
+      const logs: string[] = [];
+      const origLog = console.log;
+      console.log = (msg: string) => logs.push(msg);
+      try {
+        await withManifestDir(MANIFEST_YAML, (dir) => {
+          const deps: TrackDeps = {
+            ipcCall: async <M extends IpcMethod>(method: M, _params?: unknown): Promise<IpcMethodResult[M]> => {
+              if (method === "listWorkItems") return items as IpcMethodResult[M];
+              if (method === "aliasStateAll")
+                return { entries: { scrutiny: "high", session_id: "sess-1" } } as IpcMethodResult[M];
+              throw new Error(`Unexpected IPC call: ${method}`);
+            },
+            exit: (code: number): never => {
+              throw new ExitError(code);
+            },
+            loadManifest: realManifestLoader,
+            cwd: () => dir,
+          };
+          return cmdTracked(["--json"], deps);
+        });
+      } finally {
+        console.log = origLog;
+      }
+
+      const parsed = JSON.parse(logs.join(""));
+      expect(parsed[0].state).toEqual({ scrutiny: "high" });
+      expect(parsed[0].state.session_id).toBeUndefined();
     });
   });
 });

--- a/packages/command/src/commands/track.spec.ts
+++ b/packages/command/src/commands/track.spec.ts
@@ -129,6 +129,17 @@ describe("parseMetadataFlags", () => {
     expect(metadata.has("branch")).toBe(false);
   });
 
+  test("skips --phase and --json flags", () => {
+    const { metadata, errors } = parseMetadataFlags(
+      ["42", "--phase", "impl", "--json", "--scrutiny", "low"],
+      [enumField],
+    );
+    expect(errors).toHaveLength(0);
+    expect(metadata.get("scrutiny")).toBe("low");
+    expect(metadata.has("phase")).toBe(false);
+    expect(metadata.has("json")).toBe(false);
+  });
+
   test("errors on missing required field", () => {
     const { errors } = parseMetadataFlags(["42"], [requiredField]);
     expect(errors).toHaveLength(1);
@@ -571,6 +582,7 @@ describe("formatWorkItemRow", () => {
         const deps: TrackDeps = {
           ipcCall: async <M extends IpcMethod>(method: M, params?: unknown): Promise<IpcMethodResult[M]> => {
             if (method === "trackWorkItem") return item as IpcMethodResult[M];
+            if (method === "aliasStateAll") return { entries: {} } as IpcMethodResult[M];
             if (method === "aliasStateSet") {
               stateCalls.push({ method, params: params as Record<string, unknown> });
               return { ok: true } as IpcMethodResult[M];
@@ -659,6 +671,7 @@ describe("formatWorkItemRow", () => {
         const deps: TrackDeps = {
           ipcCall: async <M extends IpcMethod>(method: M, params?: unknown): Promise<IpcMethodResult[M]> => {
             if (method === "trackWorkItem") return item as IpcMethodResult[M];
+            if (method === "aliasStateAll") return { entries: {} } as IpcMethodResult[M];
             if (method === "aliasStateSet") {
               const p = params as Record<string, unknown>;
               stateCalls.push({ key: p.key as string, value: p.value });
@@ -680,7 +693,48 @@ describe("formatWorkItemRow", () => {
       expect(stateCalls[0].value).toBe("1001,1002");
     });
 
-    test("cmdTrack persists default value when field not provided", async () => {
+    test("cmdTrack re-track preserves prior metadata (does not overwrite with defaults)", async () => {
+      const item = makeWorkItem({ id: "#42" });
+      const stateCalls: Array<{ key: string; value: unknown }> = [];
+
+      const MANIFEST_YAML = [
+        "version: 1",
+        "initial: plan",
+        "state:",
+        '  scrutiny: { type: "enum[low,medium,high]", track: true, default: medium }',
+        "  bundled_with: { type: string, track: true, repeatable: true }",
+        "phases:",
+        "  plan: { source: ./p.ts, next: [build] }",
+        "  build: { source: ./b.ts }",
+      ].join("\n");
+
+      await withManifestDir(MANIFEST_YAML, (dir) => {
+        const deps: TrackDeps = {
+          ipcCall: async <M extends IpcMethod>(method: M, params?: unknown): Promise<IpcMethodResult[M]> => {
+            if (method === "trackWorkItem") return item as IpcMethodResult[M];
+            if (method === "aliasStateAll") return { entries: { scrutiny: "high" } } as IpcMethodResult[M];
+            if (method === "aliasStateSet") {
+              const p = params as Record<string, unknown>;
+              stateCalls.push({ key: p.key as string, value: p.value });
+              return { ok: true } as IpcMethodResult[M];
+            }
+            throw new Error(`Unexpected IPC call: ${method}`);
+          },
+          exit: (code: number): never => {
+            throw new ExitError(code);
+          },
+          loadManifest: realManifestLoader,
+          cwd: () => dir,
+        };
+        return cmdTrack(["42", "--bundled-with", "1001"], deps);
+      });
+
+      expect(stateCalls).toHaveLength(1);
+      expect(stateCalls[0].key).toBe("bundled_with");
+      expect(stateCalls[0].value).toBe("1001");
+    });
+
+    test("cmdTrack persists default value on first track (no existing state)", async () => {
       const item = makeWorkItem({ id: "#42" });
       const stateCalls: Array<{ key: string; value: unknown }> = [];
 
@@ -698,6 +752,7 @@ describe("formatWorkItemRow", () => {
         const deps: TrackDeps = {
           ipcCall: async <M extends IpcMethod>(method: M, params?: unknown): Promise<IpcMethodResult[M]> => {
             if (method === "trackWorkItem") return item as IpcMethodResult[M];
+            if (method === "aliasStateAll") return { entries: {} } as IpcMethodResult[M];
             if (method === "aliasStateSet") {
               const p = params as Record<string, unknown>;
               stateCalls.push({ key: p.key as string, value: p.value });

--- a/packages/command/src/commands/track.ts
+++ b/packages/command/src/commands/track.ts
@@ -43,8 +43,8 @@ const defaultDeps: TrackDeps = {
   loadManifest: tryLoadManifest,
 };
 
-/** Built-in flags that are not metadata fields. */
-const BUILTIN_FLAGS = new Set(["--branch", "--automation", "--help", "-h"]);
+/** Built-in flags that are not metadata fields (covers both cmdTrack and cmdTracked). */
+const BUILTIN_FLAGS = new Set(["--branch", "--automation", "--help", "-h", "--phase", "--json"]);
 
 /**
  * Parse metadata flags from args based on trackable fields declared in manifest.
@@ -204,12 +204,34 @@ async function persistMetadata(
   metadata: Map<string, string | number | boolean>,
   trackableFields: TrackableField[],
 ): Promise<void> {
+  if (metadata.size === 0 && !trackableFields.some((f) => f.defaultValue !== undefined)) return;
+  const ns = `workitem:${workItemId}`;
+  let existingState: Record<string, unknown> = {};
+  try {
+    const { entries } = await deps.ipcCall("aliasStateAll", { repoRoot, namespace: ns });
+    existingState = entries;
+  } catch {
+    // No existing state — all defaults are safe to apply.
+  }
   for (const field of trackableFields) {
-    const value = metadata.get(field.key) ?? field.defaultValue;
-    if (value !== undefined) {
-      const ns = `workitem:${workItemId}`;
-      await deps.ipcCall("aliasStateSet", { repoRoot, namespace: ns, key: field.key, value });
+    const explicit = metadata.get(field.key);
+    if (explicit !== undefined) {
+      await deps.ipcCall("aliasStateSet", { repoRoot, namespace: ns, key: field.key, value: explicit });
+    } else if (field.defaultValue !== undefined && !(field.key in existingState)) {
+      await deps.ipcCall("aliasStateSet", { repoRoot, namespace: ns, key: field.key, value: field.defaultValue });
     }
+  }
+}
+
+async function cleanupMetadata(deps: TrackDeps, cwd: string, workItemId: string): Promise<void> {
+  const ns = `workitem:${workItemId}`;
+  try {
+    const { entries } = await deps.ipcCall("aliasStateAll", { repoRoot: cwd, namespace: ns });
+    for (const key of Object.keys(entries)) {
+      await deps.ipcCall("aliasStateDelete", { repoRoot: cwd, namespace: ns, key });
+    }
+  } catch {
+    // Best-effort — don't fail untrack if cleanup fails.
   }
 }
 
@@ -223,6 +245,8 @@ export async function cmdUntrack(args: string[], deps: TrackDeps = defaultDeps):
     return;
   }
 
+  const cwd = (deps.cwd ?? (() => process.cwd()))();
+
   if (args[0].startsWith("branch:")) {
     const branch = args[0].slice("branch:".length);
     if (!branch) {
@@ -232,6 +256,7 @@ export async function cmdUntrack(args: string[], deps: TrackDeps = defaultDeps):
     try {
       const result = await deps.ipcCall("untrackWorkItem", { branch });
       if (result.deleted) {
+        await cleanupMetadata(deps, cwd, `branch:${branch}`);
         console.error(`Untracked branch ${branch}`);
       } else {
         console.error(`Branch ${branch} was not tracked`);
@@ -252,6 +277,7 @@ export async function cmdUntrack(args: string[], deps: TrackDeps = defaultDeps):
     try {
       const result = await deps.ipcCall("untrackWorkItem", { branch });
       if (result.deleted) {
+        await cleanupMetadata(deps, cwd, `branch:${branch}`);
         console.error(`Untracked branch ${branch}`);
       } else {
         console.error(`Branch ${branch} was not tracked`);
@@ -273,6 +299,7 @@ export async function cmdUntrack(args: string[], deps: TrackDeps = defaultDeps):
   try {
     const result = await deps.ipcCall("untrackWorkItem", { number: num });
     if (result.deleted) {
+      await cleanupMetadata(deps, cwd, `#${num}`);
       console.error(`Untracked #${num}`);
     } else {
       console.error(`#${num} was not tracked`);

--- a/packages/command/src/commands/track.ts
+++ b/packages/command/src/commands/track.ts
@@ -9,8 +9,15 @@
  *          mcx tracked --json           Machine-readable output
  */
 
-import type { IpcMethod, IpcMethodResult, Manifest, WorkItem, WorkItemPhase } from "@mcp-cli/core";
-import { WORK_ITEM_PHASES, ipcCall, loadManifest } from "@mcp-cli/core";
+import type { IpcMethod, IpcMethodResult, Manifest, TrackableField, WorkItem, WorkItemPhase } from "@mcp-cli/core";
+import {
+  WORK_ITEM_PHASES,
+  coerceTrackValue,
+  getTrackableFields,
+  ipcCall,
+  loadManifest,
+  validateTrackValue,
+} from "@mcp-cli/core";
 import { c, printError } from "../output";
 
 /** Load a manifest from the given directory, swallowing parse errors so they don't break CLI commands. */
@@ -36,16 +43,90 @@ const defaultDeps: TrackDeps = {
   loadManifest: tryLoadManifest,
 };
 
+/** Built-in flags that are not metadata fields. */
+const BUILTIN_FLAGS = new Set(["--branch", "--automation", "--help", "-h"]);
+
+/**
+ * Parse metadata flags from args based on trackable fields declared in manifest.
+ * Returns parsed metadata and the set of arg indices consumed by metadata flags.
+ */
+export function parseMetadataFlags(
+  args: string[],
+  trackableFields: TrackableField[],
+): { metadata: Map<string, string | number | boolean>; consumed: Set<number>; errors: string[] } {
+  const fieldMap = new Map(trackableFields.map((f) => [f.key, f]));
+  const metadata = new Map<string, string | number | boolean>();
+  const consumed = new Set<number>();
+  const errors: string[] = [];
+  const repeatableAccum = new Map<string, string[]>();
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg.startsWith("--") || BUILTIN_FLAGS.has(arg)) continue;
+
+    const flagName = arg.slice(2).replace(/-/g, "_");
+    const field = fieldMap.get(flagName);
+
+    if (!field) {
+      if (!fieldMap.size) continue;
+      const known = trackableFields.map((f) => `--${f.key.replace(/_/g, "-")}`);
+      errors.push(`unknown metadata flag "${arg}"; declared fields: ${known.join(", ")}`);
+      continue;
+    }
+
+    const value = args[i + 1];
+    if (value === undefined || value.startsWith("--")) {
+      errors.push(`${arg} requires a value`);
+      continue;
+    }
+
+    const validationError = validateTrackValue(field, value);
+    if (validationError) {
+      errors.push(validationError);
+      consumed.add(i);
+      consumed.add(i + 1);
+      i++;
+      continue;
+    }
+
+    consumed.add(i);
+    consumed.add(i + 1);
+
+    if (field.repeatable) {
+      const accum = repeatableAccum.get(field.key) ?? [];
+      accum.push(value);
+      repeatableAccum.set(field.key, accum);
+    } else {
+      metadata.set(field.key, coerceTrackValue(field, value));
+    }
+    i++;
+  }
+
+  for (const [key, values] of repeatableAccum) {
+    metadata.set(key, values.join(","));
+  }
+
+  for (const field of trackableFields) {
+    if (field.required && !metadata.has(field.key) && field.defaultValue === undefined) {
+      errors.push(`required metadata field --${field.key.replace(/_/g, "-")} is missing`);
+    }
+  }
+
+  return { metadata, consumed, errors };
+}
+
 // -- mcx track --
 
 export async function cmdTrack(args: string[], deps: TrackDeps = defaultDeps): Promise<void> {
+  const cwd = (deps.cwd ?? (() => process.cwd()))();
+  const manifest = (deps.loadManifest ?? tryLoadManifest)(cwd);
+  const trackableFields = getTrackableFields(manifest?.state);
+
   if (!args.length || args[0] === "--help" || args[0] === "-h") {
-    printTrackHelp();
+    printTrackHelp(trackableFields);
     return;
   }
 
-  const cwd = (deps.cwd ?? (() => process.cwd()))();
-  const manifest = (deps.loadManifest ?? tryLoadManifest)(cwd);
   const initialPhase = manifest?.initial;
 
   const automationIdx = args.indexOf("--automation");
@@ -56,6 +137,12 @@ export async function cmdTrack(args: string[], deps: TrackDeps = defaultDeps): P
       printError("--automation requires a value (e.g. merge=false,bind=true)");
       return deps.exit(1);
     }
+  }
+
+  const { metadata, consumed: metaConsumed, errors: metaErrors } = parseMetadataFlags(args, trackableFields);
+  if (metaErrors.length > 0) {
+    for (const err of metaErrors) printError(err);
+    return deps.exit(1);
   }
 
   const branchIdx = args.indexOf("--branch");
@@ -72,6 +159,7 @@ export async function cmdTrack(args: string[], deps: TrackDeps = defaultDeps): P
         ...(automationOverrides ? { automationOverrides } : {}),
         repoRoot: cwd,
       });
+      await persistMetadata(deps, cwd, item.id, metadata, trackableFields);
       console.error(`Tracking branch ${branch} (${item.id})`);
     } catch (err) {
       printError(`Failed to track branch: ${err instanceof Error ? err.message : String(err)}`);
@@ -85,6 +173,8 @@ export async function cmdTrack(args: string[], deps: TrackDeps = defaultDeps): P
     skipIndices.add(automationIdx);
     skipIndices.add(automationIdx + 1);
   }
+  for (const idx of metaConsumed) skipIndices.add(idx);
+
   const firstPositional = args.find((_, i) => !skipIndices.has(i) && !args[i].startsWith("--"));
   const num = Number(firstPositional);
   if (!firstPositional || !Number.isInteger(num) || num <= 0) {
@@ -99,10 +189,27 @@ export async function cmdTrack(args: string[], deps: TrackDeps = defaultDeps): P
       ...(automationOverrides ? { automationOverrides } : {}),
       repoRoot: cwd,
     });
+    await persistMetadata(deps, cwd, item.id, metadata, trackableFields);
     console.error(`Tracking #${num} (${item.id})`);
   } catch (err) {
     printError(`Failed to track #${num}: ${err instanceof Error ? err.message : String(err)}`);
     return deps.exit(1);
+  }
+}
+
+async function persistMetadata(
+  deps: TrackDeps,
+  repoRoot: string,
+  workItemId: string,
+  metadata: Map<string, string | number | boolean>,
+  trackableFields: TrackableField[],
+): Promise<void> {
+  for (const field of trackableFields) {
+    const value = metadata.get(field.key) ?? field.defaultValue;
+    if (value !== undefined) {
+      const ns = `workitem:${workItemId}`;
+      await deps.ipcCall("aliasStateSet", { repoRoot, namespace: ns, key: field.key, value });
+    }
   }
 }
 
@@ -213,14 +320,33 @@ export async function cmdTracked(args: string[], deps: TrackDeps = defaultDeps):
     }
   }
 
+  const trackableFields = getTrackableFields(manifest?.state);
+
   try {
     const items = await deps.ipcCall("listWorkItems", phase ? { phase } : {});
 
     if (jsonFlag) {
-      const annotated = declaredPhases
-        ? items.map((it) => ({ ...it, phaseValid: declaredPhases.includes(it.phase) }))
-        : items.map((it) => ({ ...it, phaseValid: WORK_ITEM_PHASES.includes(it.phase) }));
-      console.log(JSON.stringify(annotated, null, 2));
+      const trackableKeys = new Set(trackableFields.map((f) => f.key));
+      const annotatedItems = await Promise.all(
+        items.map(async (it) => {
+          const base = {
+            ...it,
+            phaseValid: declaredPhases ? declaredPhases.includes(it.phase) : WORK_ITEM_PHASES.includes(it.phase),
+          };
+          if (trackableKeys.size === 0) return base;
+          try {
+            const { entries } = await deps.ipcCall("aliasStateAll", { repoRoot: cwd, namespace: `workitem:${it.id}` });
+            const state: Record<string, unknown> = {};
+            for (const key of trackableKeys) {
+              if (key in entries) state[key] = entries[key];
+            }
+            return Object.keys(state).length > 0 ? { ...base, state } : base;
+          } catch {
+            return base;
+          }
+        }),
+      );
+      console.log(JSON.stringify(annotatedItems, null, 2));
       return;
     }
 
@@ -271,23 +397,58 @@ export function formatWorkItemRow(item: WorkItem): string {
   return `${c.cyan}${id}${c.reset}  ${prPad}  ${ciPad}  ${reviewPad}  ${phasePad}${branch}`;
 }
 
-function printTrackHelp(): void {
-  console.log(`mcx track — work item tracking
+function formatFieldType(field: TrackableField): string {
+  if (field.baseType === "enum" && field.enumValues) {
+    return field.enumValues.join("|");
+  }
+  return field.baseType;
+}
 
-Usage:
-  mcx track <number>                        Track an issue/PR by number
-  mcx track --branch <name>                 Track a branch (PR may not exist yet)
-  mcx track <number> --automation <csv>     Set per-item automation overrides
-  mcx untrack <number>                      Stop tracking by number
-  mcx untrack --branch <name>               Stop tracking by branch
-  mcx tracked                               List all tracked work items
-  mcx tracked --json                        Machine-readable output
-  mcx tracked --phase <phase>               Filter by phase (impl, review, repair, qa, done)
+function printTrackHelp(trackableFields: TrackableField[] = []): void {
+  const lines = [
+    "mcx track — work item tracking",
+    "",
+    "Usage:",
+    "  mcx track <number>                        Track an issue/PR by number",
+    "  mcx track --branch <name>                 Track a branch (PR may not exist yet)",
+    "  mcx track <number> --automation <csv>     Set per-item automation overrides",
+    "  mcx untrack <number>                      Stop tracking by number",
+    "  mcx untrack --branch <name>               Stop tracking by branch",
+    "  mcx tracked                               List all tracked work items",
+    "  mcx tracked --json                        Machine-readable output",
+    "  mcx tracked --phase <phase>               Filter by phase (impl, review, repair, qa, done)",
+  ];
 
-Examples:
-  mcx track 1135
-  mcx track --branch feat/new-feature
-  mcx track 1135 --automation merge=false,bind=true
-  mcx untrack 1135
-  mcx tracked --json`);
+  if (trackableFields.length > 0) {
+    lines.push("", "Metadata fields (declared in .mcx.yaml):");
+    for (const f of trackableFields) {
+      const flag = `--${f.key.replace(/_/g, "-")}`;
+      const type = formatFieldType(f);
+      const attrs: string[] = [];
+      if (f.repeatable) attrs.push("repeatable");
+      if (f.required) attrs.push("required");
+      if (f.defaultValue !== undefined) attrs.push(`default: ${f.defaultValue}`);
+      const suffix = attrs.length > 0 ? `  (${attrs.join(", ")})` : "";
+      lines.push(`  ${flag.padEnd(30)} <${type}>${suffix}`);
+    }
+  }
+
+  lines.push(
+    "",
+    "Examples:",
+    "  mcx track 1135",
+    "  mcx track --branch feat/new-feature",
+    "  mcx track 1135 --automation merge=false,bind=true",
+    "  mcx untrack 1135",
+    "  mcx tracked --json",
+  );
+
+  if (trackableFields.length > 0) {
+    const exampleField = trackableFields[0];
+    const exampleFlag = `--${exampleField.key.replace(/_/g, "-")}`;
+    const exampleValue = exampleField.enumValues?.[0] ?? "value";
+    lines.push(`  mcx track 1135 ${exampleFlag} ${exampleValue}`);
+  }
+
+  console.log(lines.join("\n"));
 }

--- a/packages/core/src/manifest.spec.ts
+++ b/packages/core/src/manifest.spec.ts
@@ -524,6 +524,46 @@ describe("state field object form (#2019)", () => {
     const field = m.state?.level;
     expect(typeof field).toBe("object");
   });
+
+  test("rejects malformed enum lists (empty values, leading/trailing commas)", () => {
+    for (const bad of ["enum[a,,b]", "enum[,a,b]", "enum[a,b,]", "enum[,]", "enum[]"]) {
+      expect(() =>
+        validateManifest(
+          {
+            initial: "a",
+            state: { level: { type: bad, track: true } },
+            phases: { a: { source: "./a.ts" } },
+          },
+          "/tmp/x",
+        ),
+      ).toThrow(ManifestError);
+    }
+  });
+
+  test("rejects trackable state key with hyphens", () => {
+    expect(() =>
+      validateManifest(
+        {
+          initial: "a",
+          state: { "my-field": { type: "string", track: true } },
+          phases: { a: { source: "./a.ts" } },
+        },
+        "/tmp/x",
+      ),
+    ).toThrow(/hyphens/);
+  });
+
+  test("allows hyphens in non-trackable state keys", () => {
+    const m = validateManifest(
+      {
+        initial: "a",
+        state: { "my-field": "string?" },
+        phases: { a: { source: "./a.ts" } },
+      },
+      "/tmp/x",
+    );
+    expect(m.state?.["my-field"]).toBe("string?");
+  });
 });
 
 describe("parseEnumValues", () => {

--- a/packages/core/src/manifest.spec.ts
+++ b/packages/core/src/manifest.spec.ts
@@ -564,6 +564,82 @@ describe("state field object form (#2019)", () => {
     );
     expect(m.state?.["my-field"]).toBe("string?");
   });
+
+  test("rejects invalid enum default at parse time", () => {
+    expect(() =>
+      validateManifest(
+        {
+          initial: "a",
+          state: { scrutiny: { type: "enum[low,medium,high]", track: true, default: "catastrophic" } },
+          phases: { a: { source: "./a.ts" } },
+        },
+        "/tmp/x",
+      ),
+    ).toThrow(ManifestError);
+  });
+
+  test("rejects non-number default for number type at parse time", () => {
+    expect(() =>
+      validateManifest(
+        {
+          initial: "a",
+          state: { count: { type: "number", track: true, default: "not-a-number" } },
+          phases: { a: { source: "./a.ts" } },
+        },
+        "/tmp/x",
+      ),
+    ).toThrow(ManifestError);
+  });
+
+  test("accepts valid enum default at parse time", () => {
+    const m = validateManifest(
+      {
+        initial: "a",
+        state: { scrutiny: { type: "enum[low,medium,high]", track: true, default: "medium" } },
+        phases: { a: { source: "./a.ts" } },
+      },
+      "/tmp/x",
+    );
+    expect(typeof m.state?.scrutiny).toBe("object");
+  });
+
+  test("rejects reserved trackable field name 'phase'", () => {
+    expect(() =>
+      validateManifest(
+        {
+          initial: "a",
+          state: { phase: { type: "string", track: true } },
+          phases: { a: { source: "./a.ts" } },
+        },
+        "/tmp/x",
+      ),
+    ).toThrow(/conflicts with built-in CLI flag/);
+  });
+
+  test("rejects reserved trackable field name 'json'", () => {
+    expect(() =>
+      validateManifest(
+        {
+          initial: "a",
+          state: { json: { type: "string", track: true } },
+          phases: { a: { source: "./a.ts" } },
+        },
+        "/tmp/x",
+      ),
+    ).toThrow(/conflicts with built-in CLI flag/);
+  });
+
+  test("allows reserved name when not trackable", () => {
+    const m = validateManifest(
+      {
+        initial: "a",
+        state: { phase: "string?" },
+        phases: { a: { source: "./a.ts" } },
+      },
+      "/tmp/x",
+    );
+    expect(m.state?.phase).toBe("string?");
+  });
 });
 
 describe("parseEnumValues", () => {
@@ -630,6 +706,12 @@ describe("validateTrackValue", () => {
     const field = getTrackableFields({ n: { type: "number", track: true } })[0];
     expect(validateTrackValue(field, "42")).toBeNull();
     expect(validateTrackValue(field, "abc")).toContain("expected a number");
+  });
+
+  test("rejects empty string for number type", () => {
+    const field = getTrackableFields({ n: { type: "number", track: true } })[0];
+    expect(validateTrackValue(field, "")).toContain("expected a number");
+    expect(validateTrackValue(field, "  ")).toContain("expected a number");
   });
 
   test("validates boolean type", () => {

--- a/packages/core/src/manifest.spec.ts
+++ b/packages/core/src/manifest.spec.ts
@@ -629,6 +629,33 @@ describe("state field object form (#2019)", () => {
     ).toThrow(/conflicts with built-in CLI flag/);
   });
 
+  test("rejects repeatable on non-string type", () => {
+    for (const type of ["number", "boolean", "enum[a,b,c]"]) {
+      expect(() =>
+        validateManifest(
+          {
+            initial: "a",
+            state: { field: { type, track: true, repeatable: true } },
+            phases: { a: { source: "./a.ts" } },
+          },
+          "/tmp/x",
+        ),
+      ).toThrow(/repeatable.*string/i);
+    }
+  });
+
+  test("allows repeatable on string type", () => {
+    const m = validateManifest(
+      {
+        initial: "a",
+        state: { tags: { type: "string", track: true, repeatable: true } },
+        phases: { a: { source: "./a.ts" } },
+      },
+      "/tmp/x",
+    );
+    expect(typeof m.state?.tags).toBe("object");
+  });
+
   test("allows reserved name when not trackable", () => {
     const m = validateManifest(
       {

--- a/packages/core/src/manifest.spec.ts
+++ b/packages/core/src/manifest.spec.ts
@@ -6,13 +6,17 @@ import {
   DEFAULT_RUNS_ON,
   MANIFEST_FILENAMES,
   ManifestError,
+  coerceTrackValue,
   detectCycles,
   findManifest,
+  getTrackableFields,
   isPhaseInCycle,
   loadManifest,
+  parseEnumValues,
   parseManifestText,
   resolveRunsOn,
   validateManifest,
+  validateTrackValue,
 } from "./manifest";
 
 let dir: string;
@@ -445,5 +449,176 @@ describe("isPhaseInCycle", () => {
     expect(isPhaseInCycle(m, "done")).toBe(false);
     expect(isPhaseInCycle(m, "review")).toBe(true);
     expect(isPhaseInCycle(m, "repair")).toBe(true);
+  });
+});
+
+describe("state field object form (#2019)", () => {
+  test("accepts object-form state with track flag", () => {
+    const m = validateManifest(
+      {
+        initial: "a",
+        state: {
+          scrutiny: { type: "enum[low,medium,high]", track: true, default: "medium" },
+          session_id: "string?",
+        },
+        phases: { a: { source: "./a.ts" } },
+      },
+      "/tmp/x",
+    );
+    expect(typeof m.state?.scrutiny).toBe("object");
+    expect(m.state?.session_id).toBe("string?");
+  });
+
+  test("accepts repeatable and required flags", () => {
+    const m = validateManifest(
+      {
+        initial: "a",
+        state: {
+          bundled_with: { type: "string", track: true, repeatable: true },
+          priority: { type: "string", track: true, required: true },
+        },
+        phases: { a: { source: "./a.ts" } },
+      },
+      "/tmp/x",
+    );
+    const field = m.state?.bundled_with;
+    expect(typeof field).toBe("object");
+    if (typeof field === "object") expect(field.repeatable).toBe(true);
+  });
+
+  test("rejects unknown keys in state field object (strict)", () => {
+    expect(() =>
+      validateManifest(
+        {
+          initial: "a",
+          state: { scrutiny: { type: "enum[low,medium,high]", track: true, bogus: true } },
+          phases: { a: { source: "./a.ts" } },
+        },
+        "/tmp/x",
+      ),
+    ).toThrow(ManifestError);
+  });
+
+  test("rejects invalid type in state field object", () => {
+    expect(() =>
+      validateManifest(
+        {
+          initial: "a",
+          state: { scrutiny: { type: "banana", track: true } },
+          phases: { a: { source: "./a.ts" } },
+        },
+        "/tmp/x",
+      ),
+    ).toThrow(ManifestError);
+  });
+
+  test("accepts enum type with optional suffix", () => {
+    const m = validateManifest(
+      {
+        initial: "a",
+        state: { level: { type: "enum[a,b,c]?", track: true } },
+        phases: { a: { source: "./a.ts" } },
+      },
+      "/tmp/x",
+    );
+    const field = m.state?.level;
+    expect(typeof field).toBe("object");
+  });
+});
+
+describe("parseEnumValues", () => {
+  test("extracts values from enum type", () => {
+    expect(parseEnumValues("enum[low,medium,high]")).toEqual(["low", "medium", "high"]);
+  });
+
+  test("extracts values from optional enum type", () => {
+    expect(parseEnumValues("enum[a,b]?")).toEqual(["a", "b"]);
+  });
+
+  test("returns null for non-enum types", () => {
+    expect(parseEnumValues("string")).toBeNull();
+    expect(parseEnumValues("number?")).toBeNull();
+  });
+});
+
+describe("getTrackableFields", () => {
+  test("extracts only fields with track: true", () => {
+    const fields = getTrackableFields({
+      scrutiny: { type: "enum[low,medium,high]", track: true, default: "medium" },
+      session_id: "string?",
+      bundled_with: { type: "string", track: true, repeatable: true },
+    });
+    expect(fields).toHaveLength(2);
+    expect(fields.map((f) => f.key)).toEqual(["scrutiny", "bundled_with"]);
+  });
+
+  test("returns empty array for undefined state", () => {
+    expect(getTrackableFields(undefined)).toEqual([]);
+  });
+
+  test("returns empty array when no fields have track: true", () => {
+    expect(getTrackableFields({ session_id: "string?" })).toEqual([]);
+  });
+
+  test("parses enum field correctly", () => {
+    const fields = getTrackableFields({
+      level: { type: "enum[low,high]", track: true },
+    });
+    expect(fields[0].baseType).toBe("enum");
+    expect(fields[0].enumValues).toEqual(["low", "high"]);
+  });
+});
+
+describe("validateTrackValue", () => {
+  test("accepts valid enum value", () => {
+    const field = getTrackableFields({ s: { type: "enum[a,b,c]", track: true } })[0];
+    expect(validateTrackValue(field, "a")).toBeNull();
+    expect(validateTrackValue(field, "b")).toBeNull();
+  });
+
+  test("rejects invalid enum value", () => {
+    const field = getTrackableFields({ s: { type: "enum[a,b,c]", track: true } })[0];
+    expect(validateTrackValue(field, "z")).toContain("invalid value");
+  });
+
+  test("accepts any string for string type", () => {
+    const field = getTrackableFields({ s: { type: "string", track: true } })[0];
+    expect(validateTrackValue(field, "anything")).toBeNull();
+  });
+
+  test("validates number type", () => {
+    const field = getTrackableFields({ n: { type: "number", track: true } })[0];
+    expect(validateTrackValue(field, "42")).toBeNull();
+    expect(validateTrackValue(field, "abc")).toContain("expected a number");
+  });
+
+  test("validates boolean type", () => {
+    const field = getTrackableFields({ b: { type: "boolean", track: true } })[0];
+    expect(validateTrackValue(field, "true")).toBeNull();
+    expect(validateTrackValue(field, "false")).toBeNull();
+    expect(validateTrackValue(field, "yes")).toContain("expected");
+  });
+});
+
+describe("coerceTrackValue", () => {
+  test("coerces number", () => {
+    const field = getTrackableFields({ n: { type: "number", track: true } })[0];
+    expect(coerceTrackValue(field, "42")).toBe(42);
+  });
+
+  test("coerces boolean", () => {
+    const field = getTrackableFields({ b: { type: "boolean", track: true } })[0];
+    expect(coerceTrackValue(field, "true")).toBe(true);
+    expect(coerceTrackValue(field, "false")).toBe(false);
+  });
+
+  test("keeps string as-is", () => {
+    const field = getTrackableFields({ s: { type: "string", track: true } })[0];
+    expect(coerceTrackValue(field, "hello")).toBe("hello");
+  });
+
+  test("keeps enum as string", () => {
+    const field = getTrackableFields({ e: { type: "enum[a,b]", track: true } })[0];
+    expect(coerceTrackValue(field, "a")).toBe("a");
   });
 });

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -33,6 +33,122 @@ const identifier = (role: string) =>
  */
 export const STATE_TYPE_RE = /^(string|number|boolean)\??$/;
 
+/**
+ * Extended type pattern that also accepts `enum[val1,val2,...]` with optional `?`.
+ * Used in the object-form state field declaration (#2019).
+ */
+export const EXTENDED_TYPE_RE = /^(string|number|boolean|enum\[[a-z0-9_,-]+\])\??$/;
+
+/**
+ * Object form for state field declarations (#2019). Fields with `track: true`
+ * are exposed as `mcx track --<key>` CLI flags.
+ */
+export const StateFieldObjectSchema = z
+  .object({
+    type: z
+      .string()
+      .regex(
+        EXTENDED_TYPE_RE,
+        'type must be "string", "number", "boolean", or "enum[val1,val2,...]", optionally suffixed with "?"',
+      ),
+    track: z.boolean().optional(),
+    repeatable: z.boolean().optional(),
+    default: z.union([z.string(), z.number(), z.boolean()]).optional(),
+    required: z.boolean().optional(),
+  })
+  .strict();
+
+export type StateFieldObject = z.infer<typeof StateFieldObjectSchema>;
+
+/** A state field is either a bare type string or an object with metadata. */
+export type StateFieldValue = string | StateFieldObject;
+
+/** Parsed trackable field metadata for CLI consumption. */
+export interface TrackableField {
+  key: string;
+  baseType: "string" | "number" | "boolean" | "enum";
+  optional: boolean;
+  enumValues: string[] | null;
+  repeatable: boolean;
+  required: boolean;
+  defaultValue: string | number | boolean | undefined;
+}
+
+/** Extract enum values from a type string like `enum[low,medium,high]`. */
+export function parseEnumValues(typeStr: string): string[] | null {
+  const m = typeStr.match(/^enum\[([^\]]+)\]\??$/);
+  return m ? m[1].split(",") : null;
+}
+
+/** Parse a state field (string or object form) into base type info. */
+function parseBaseType(field: StateFieldValue): { baseType: string; optional: boolean; typeStr: string } {
+  const typeStr = typeof field === "string" ? field : field.type;
+  const optional = typeStr.endsWith("?");
+  const raw = optional ? typeStr.slice(0, -1) : typeStr;
+  const baseType = raw.startsWith("enum[") ? "enum" : raw;
+  return { baseType, optional, typeStr };
+}
+
+/** Extract all fields with `track: true` from a manifest state section. */
+export function getTrackableFields(state: ManifestState | undefined): TrackableField[] {
+  if (!state) return [];
+  const fields: TrackableField[] = [];
+  for (const [key, field] of Object.entries(state)) {
+    if (typeof field !== "object" || !field.track) continue;
+    const { baseType, optional, typeStr } = parseBaseType(field);
+    fields.push({
+      key,
+      baseType: baseType as TrackableField["baseType"],
+      optional,
+      enumValues: parseEnumValues(typeStr),
+      repeatable: field.repeatable ?? false,
+      required: field.required ?? false,
+      defaultValue: field.default,
+    });
+  }
+  return fields;
+}
+
+/**
+ * Validate a CLI-provided value against a trackable field's type.
+ * Returns null on success, or an error message string.
+ */
+export function validateTrackValue(field: TrackableField, value: string): string | null {
+  switch (field.baseType) {
+    case "enum":
+      if (!field.enumValues?.includes(value)) {
+        return `invalid value "${value}" for ${field.key}; expected one of: ${field.enumValues?.join(", ")}`;
+      }
+      return null;
+    case "number":
+      if (Number.isNaN(Number(value))) {
+        return `invalid value "${value}" for ${field.key}; expected a number`;
+      }
+      return null;
+    case "boolean":
+      if (value !== "true" && value !== "false") {
+        return `invalid value "${value}" for ${field.key}; expected "true" or "false"`;
+      }
+      return null;
+    case "string":
+      return null;
+    default:
+      return `unknown type "${field.baseType}" for ${field.key}`;
+  }
+}
+
+/** Coerce a validated CLI string value to the appropriate JS type. */
+export function coerceTrackValue(field: TrackableField, value: string): string | number | boolean {
+  switch (field.baseType) {
+    case "number":
+      return Number(value);
+    case "boolean":
+      return value === "true";
+    default:
+      return value;
+  }
+}
+
 /** A single phase definition. */
 export const PhaseDefSchema = z
   .object({
@@ -71,13 +187,16 @@ export const ManifestWorktreeSchema = z
 export type ManifestWorktree = z.infer<typeof ManifestWorktreeSchema>;
 
 /**
- * Shared state schema declaration. Keys are identifiers; values are type
- * strings from STATE_TYPE_RE. Execution-time Zod conversion is deferred; see
- * epic #1286.
+ * Shared state schema declaration. Keys are identifiers; values are either
+ * bare type strings (string?, number, boolean?) or object declarations with
+ * extended metadata ({type, track, repeatable, default, required}).
  */
 export const ManifestStateSchema = z.record(
   identifier("state key"),
-  z.string().regex(STATE_TYPE_RE, 'state value must be "string", "number", "boolean", optionally suffixed with "?"'),
+  z.union([
+    z.string().regex(STATE_TYPE_RE, 'state value must be "string", "number", "boolean", optionally suffixed with "?"'),
+    StateFieldObjectSchema,
+  ]),
 );
 export type ManifestState = z.infer<typeof ManifestStateSchema>;
 

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -37,7 +37,7 @@ export const STATE_TYPE_RE = /^(string|number|boolean)\??$/;
  * Extended type pattern that also accepts `enum[val1,val2,...]` with optional `?`.
  * Used in the object-form state field declaration (#2019).
  */
-export const EXTENDED_TYPE_RE = /^(string|number|boolean|enum\[[a-z0-9_,-]+\])\??$/;
+export const EXTENDED_TYPE_RE = /^(string|number|boolean|enum\[[a-z0-9_]+(?:,[a-z0-9_]+)*\])\??$/;
 
 /**
  * Object form for state field declarations (#2019). Fields with `track: true`
@@ -335,6 +335,17 @@ export function validateManifest(raw: unknown, path: string): Manifest {
       `unreachable phase${unreachable.length > 1 ? "s" : ""} from initial "${manifest.initial}": ${unreachable.join(", ")}`,
       path,
     );
+  }
+
+  if (manifest.state) {
+    for (const [key, field] of Object.entries(manifest.state)) {
+      if (typeof field === "object" && field.track && key.includes("-")) {
+        throw new ManifestError(
+          `trackable state key "${key}" contains hyphens; use underscores instead (CLI flags normalize --${key} to "${key.replace(/-/g, "_")}", making this field unreachable)`,
+          path,
+        );
+      }
+    }
   }
 
   return manifest;

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -72,6 +72,14 @@ export const StateFieldObjectSchema = z
       return true;
     },
     { message: "default value does not match declared type" },
+  )
+  .refine(
+    (f) => {
+      if (!f.repeatable) return true;
+      const raw = f.type.endsWith("?") ? f.type.slice(0, -1) : f.type;
+      return raw === "string";
+    },
+    { message: "repeatable is only valid for string fields (values are stored as comma-joined strings)" },
   );
 
 export type StateFieldObject = z.infer<typeof StateFieldObjectSchema>;

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -49,14 +49,30 @@ export const StateFieldObjectSchema = z
       .string()
       .regex(
         EXTENDED_TYPE_RE,
-        'type must be "string", "number", "boolean", or "enum[val1,val2,...]", optionally suffixed with "?"',
+        'type must be "string", "number", "boolean", or "enum[val1,val2,...]" (lowercase only), optionally suffixed with "?"',
       ),
     track: z.boolean().optional(),
     repeatable: z.boolean().optional(),
     default: z.union([z.string(), z.number(), z.boolean()]).optional(),
     required: z.boolean().optional(),
   })
-  .strict();
+  .strict()
+  .refine(
+    (f) => {
+      if (f.default === undefined) return true;
+      const optional = f.type.endsWith("?");
+      const raw = optional ? f.type.slice(0, -1) : f.type;
+      if (raw.startsWith("enum[")) {
+        const values = raw.slice(5, -1).split(",");
+        return values.includes(String(f.default));
+      }
+      if (raw === "number") return typeof f.default === "number" || !Number.isNaN(Number(f.default));
+      if (raw === "boolean")
+        return f.default === true || f.default === false || f.default === "true" || f.default === "false";
+      return true;
+    },
+    { message: "default value does not match declared type" },
+  );
 
 export type StateFieldObject = z.infer<typeof StateFieldObjectSchema>;
 
@@ -121,7 +137,7 @@ export function validateTrackValue(field: TrackableField, value: string): string
       }
       return null;
     case "number":
-      if (Number.isNaN(Number(value))) {
+      if (value.trim() === "" || Number.isNaN(Number(value))) {
         return `invalid value "${value}" for ${field.key}; expected a number`;
       }
       return null;
@@ -337,13 +353,22 @@ export function validateManifest(raw: unknown, path: string): Manifest {
     );
   }
 
+  const RESERVED_TRACK_NAMES = new Set(["branch", "automation", "help", "phase", "json"]);
   if (manifest.state) {
     for (const [key, field] of Object.entries(manifest.state)) {
-      if (typeof field === "object" && field.track && key.includes("-")) {
-        throw new ManifestError(
-          `trackable state key "${key}" contains hyphens; use underscores instead (CLI flags normalize --${key} to "${key.replace(/-/g, "_")}", making this field unreachable)`,
-          path,
-        );
+      if (typeof field === "object" && field.track) {
+        if (key.includes("-")) {
+          throw new ManifestError(
+            `trackable state key "${key}" contains hyphens; use underscores instead (CLI flags normalize --${key} to "${key.replace(/-/g, "_")}", making this field unreachable)`,
+            path,
+          );
+        }
+        if (RESERVED_TRACK_NAMES.has(key)) {
+          throw new ManifestError(
+            `trackable state key "${key}" conflicts with built-in CLI flag --${key}; choose a different name`,
+            path,
+          );
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- Extends `.mcx.yaml` state declarations to accept object form (`{ type, track, repeatable, default, required }`) alongside existing bare type strings
- `mcx track <n> --<field> <value>` validates and persists custom metadata via `aliasStateSet` into the work item's state namespace
- `mcx tracked --json` includes trackable metadata in output under a `state` key, filtered to declared trackable fields only
- Dogfoods `scrutiny` (enum) and `bundled_with` (repeatable string) in mcp-cli's own manifest
- Updates `docs/phases.md` with metadata-declaration section

## Test plan
- [x] `parseMetadataFlags` unit tests: enum validation, repeatable collection, unknown-flag rejection, required-field enforcement, hyphen-to-underscore conversion, consumed-index tracking
- [x] Manifest schema tests: object-form acceptance, strict mode (rejects unknown keys), invalid type rejection, optional enum suffix
- [x] `getTrackableFields` / `validateTrackValue` / `coerceTrackValue` unit tests
- [x] Integration tests: `cmdTrack` persists metadata via `aliasStateSet`, rejects invalid enum, rejects unknown flags, handles repeatable, persists defaults
- [x] Integration test: `cmdTracked --json` includes state for trackable fields, excludes non-trackable state
- [x] Full test suite: 7190 pass, 0 fail
- [x] Typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)