### PR TITLE
feat(automation): bind module — auto-attach PR + branch on pr.opened event (fixes #2021)

### DIFF
--- a/.claude/automation/bind.ts
+++ b/.claude/automation/bind.ts
@@ -16,12 +16,16 @@ export default defineAutomation({
     if (!item) {
       const pattern = ctx.config.branchPattern;
       if (typeof pattern === "string") {
-        const match = new RegExp(pattern).exec(branch);
-        if (match?.groups?.issue) {
-          const issueNumber = Number.parseInt(match.groups.issue, 10);
-          if (!Number.isNaN(issueNumber)) {
-            item = ctx.findWorkItemByIssue(issueNumber);
+        try {
+          const match = new RegExp(pattern).exec(branch);
+          if (match?.groups?.issue) {
+            const issueNumber = Number.parseInt(match.groups.issue, 10);
+            if (!Number.isNaN(issueNumber)) {
+              item = ctx.findWorkItemByIssue(issueNumber);
+            }
           }
+        } catch {
+          ctx.logger.warn(`invalid branchPattern regex: ${pattern}`);
         }
       }
     }
@@ -38,6 +42,7 @@ export default defineAutomation({
 
     return {
       action: "set-state",
+      workItemId: item.id,
       patch: { prNumber, branch },
     };
   },

--- a/.claude/automation/bind.ts
+++ b/.claude/automation/bind.ts
@@ -1,0 +1,44 @@
+import { defineAutomation } from "@mcp-cli/core";
+
+export default defineAutomation({
+  name: "bind",
+  events: ["pr.opened"],
+  fn: async (event, ctx) => {
+    const prNumber = event.prNumber;
+    const branch = event.branch;
+
+    if (typeof prNumber !== "number" || typeof branch !== "string") {
+      return { action: "none", reason: "event missing prNumber or branch" };
+    }
+
+    let item = ctx.findWorkItemByBranch(branch);
+
+    if (!item) {
+      const pattern = ctx.config.branchPattern;
+      if (typeof pattern === "string") {
+        const match = new RegExp(pattern).exec(branch);
+        if (match?.groups?.issue) {
+          const issueNumber = Number.parseInt(match.groups.issue, 10);
+          if (!Number.isNaN(issueNumber)) {
+            item = ctx.findWorkItemByIssue(issueNumber);
+          }
+        }
+      }
+    }
+
+    if (!item) {
+      return { action: "none", reason: `no tracked item with branch ${branch}` };
+    }
+
+    if (item.prNumber != null) {
+      return { action: "none", reason: `item already bound to PR #${item.prNumber}` };
+    }
+
+    ctx.logger.info(`binding PR #${prNumber} to ${item.id} via branch ${branch}`);
+
+    return {
+      action: "set-state",
+      patch: { prNumber, branch },
+    };
+  },
+});

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -171,3 +171,55 @@ To add automation to your project:
 
 See also: [phases.md](phases.md) for the manifest and lockfile system that
 automation builds on.
+
+## Worked example: bind module
+
+The **bind** module auto-attaches a PR number and branch to a tracked work
+item when a `pr.opened` event fires. It is the second reference module
+(after cleanup) and ships as #2021.
+
+### How it works
+
+1. A `pr.opened` event arrives with `prNumber` and `branch`.
+2. The module looks up work items by branch (direct match).
+3. If no direct match and `branchPattern` is configured, it extracts an
+   issue number from the branch name via a named capture group `(?<issue>\d+)`
+   and looks up by issue number.
+4. If a matching unbound item is found, it returns `set-state` with
+   `{ prNumber, branch }`.
+5. If the item already has a `prNumber`, the module no-ops (idempotent).
+
+### Manifest
+
+```yaml
+automation:
+  preset: semi-auto   # bind on by default
+
+  modules:
+    bind:
+      source: ./.claude/automation/bind.ts
+      on: [pr.opened]
+      # Optional: extract issue number from branch naming convention
+      config:
+        branchPattern: '^(?:feat|fix)/issue-(?<issue>\d+)-'
+```
+
+### Per-item override
+
+```bash
+mcx track 1234 --automation bind=false   # skip auto-bind for this item
+```
+
+### Context methods used
+
+The bind module uses two context methods introduced alongside the module:
+
+- `ctx.findWorkItemByBranch(branch)` — look up a work item by its branch field
+- `ctx.findWorkItemByIssue(issueNumber)` — look up a work item by issue number
+- `ctx.config` — module-specific config from the manifest (e.g., `branchPattern`)
+
+### Module config
+
+Modules can declare a `config:` bag in the manifest. The config is
+passed through the lockfile and available as `ctx.config` at runtime.
+Config is a flat `Record<string, unknown>` — keep it simple.

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -248,6 +248,7 @@ export async function installPhases(cwd: string, deps: PhaseInstallDeps): Promis
         contentHash,
         events: [...mod.on],
         enabled: resolvedEnabled,
+        ...(mod.config && Object.keys(mod.config).length > 0 ? { config: mod.config } : {}),
       });
     }
   }

--- a/packages/core/src/automation.ts
+++ b/packages/core/src/automation.ts
@@ -90,7 +90,7 @@ export type AutomationConfig = z.infer<typeof AutomationConfigSchema>;
 export type AutomationAction =
   | { action: "none"; reason: string }
   | { action: "bye-and-untrack"; sessionIds: string[] }
-  | { action: "set-state"; patch: Record<string, unknown> }
+  | { action: "set-state"; workItemId: string; patch: Record<string, unknown> }
   | { action: "emit-event"; event: { event: string; category: string; [key: string]: unknown } }
   | { action: "shell"; cmd: string; args: string[] }
   | { action: "escalate"; reason: string; payload?: unknown };

--- a/packages/core/src/automation.ts
+++ b/packages/core/src/automation.ts
@@ -9,6 +9,7 @@
 import { z } from "zod";
 import type { AliasContext } from "./alias";
 import type { MonitorEvent } from "./monitor-event";
+import type { WorkItem } from "./work-item";
 
 /**
  * Valid event names that automation modules can subscribe to.
@@ -69,6 +70,7 @@ export const AutomationModuleDefSchema = z
     source: z.string().min(1, "module source must be a non-empty string"),
     on: z.array(AutomationEventNameSchema).min(1, "module must subscribe to at least one event"),
     enabled: z.boolean().optional(),
+    config: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 
@@ -120,6 +122,9 @@ export interface AutomationContext extends Pick<AliasContext, "mcp" | "state" | 
     error(msg: string): void;
   };
   emit(event: { event: string; category: string; [key: string]: unknown }): void;
+  findWorkItemByBranch(branch: string): WorkItem | null;
+  findWorkItemByIssue(issueNumber: number): WorkItem | null;
+  config: Record<string, unknown>;
 }
 
 export interface AutomationDefinition {

--- a/packages/core/src/manifest-lock.ts
+++ b/packages/core/src/manifest-lock.ts
@@ -35,6 +35,7 @@ export const LockedAutomationSchema = z
     contentHash: z.string().regex(/^[a-f0-9]{64}$/),
     events: z.array(z.string()),
     enabled: z.boolean(),
+    config: z.record(z.string(), z.unknown()).optional(),
   })
   .strict();
 export type LockedAutomation = z.infer<typeof LockedAutomationSchema>;

--- a/packages/daemon/src/automation-bind.spec.ts
+++ b/packages/daemon/src/automation-bind.spec.ts
@@ -1,0 +1,261 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+import type { AutomationAction, AutomationContext, MonitorEvent, WorkItem } from "@mcp-cli/core";
+import { createWorkItem } from "@mcp-cli/core";
+
+import bindModule from "../../../.claude/automation/bind";
+
+function makeEvent(overrides: Partial<MonitorEvent> = {}): MonitorEvent {
+  return {
+    seq: 1,
+    ts: new Date().toISOString(),
+    src: "daemon.work-item-poller",
+    event: "pr.opened",
+    category: "work_item",
+    prNumber: 42,
+    branch: "feat/issue-100-foo",
+    ...overrides,
+  };
+}
+
+function makeWorkItem(overrides: Partial<WorkItem> = {}): WorkItem {
+  return {
+    ...createWorkItem("#100"),
+    issueNumber: 100,
+    branch: "feat/issue-100-foo",
+    ...overrides,
+  };
+}
+
+function makeCtx(overrides: Partial<AutomationContext> = {}): AutomationContext {
+  return {
+    mcp: new Proxy({} as AutomationContext["mcp"], {
+      get: (_, prop) => {
+        throw new Error(`mcp.${String(prop)} not available`);
+      },
+    }),
+    state: new Proxy({} as AutomationContext["state"], {
+      get: (_, prop) => {
+        throw new Error(`state.${String(prop)} not available`);
+      },
+    }),
+    repoRoot: "/test/repo",
+    signal: AbortSignal.timeout(5_000),
+    workItem: null,
+    config: {},
+    findWorkItemByBranch: () => null,
+    findWorkItemByIssue: () => null,
+    logger: { info: () => {}, warn: () => {}, error: () => {} },
+    emit: () => {},
+    ...overrides,
+  };
+}
+
+describe("bind automation module", () => {
+  test("binds PR to tracked item matched by branch", async () => {
+    const item = makeWorkItem({ prNumber: null });
+    const ctx = makeCtx({
+      findWorkItemByBranch: (branch) => (branch === "feat/issue-100-foo" ? item : null),
+    });
+
+    const result = await bindModule.fn(makeEvent(), ctx);
+
+    expect(result.action).toBe("set-state");
+    expect((result as { patch: Record<string, unknown> }).patch).toEqual({
+      prNumber: 42,
+      branch: "feat/issue-100-foo",
+    });
+  });
+
+  test("no-op when item already has prNumber", async () => {
+    const item = makeWorkItem({ prNumber: 99 });
+    const ctx = makeCtx({
+      findWorkItemByBranch: () => item,
+    });
+
+    const result = await bindModule.fn(makeEvent(), ctx);
+
+    expect(result.action).toBe("none");
+    expect((result as { reason: string }).reason).toContain("already bound to PR #99");
+  });
+
+  test("no-op when no tracked item matches branch", async () => {
+    const ctx = makeCtx({
+      findWorkItemByBranch: () => null,
+      findWorkItemByIssue: () => null,
+    });
+
+    const result = await bindModule.fn(makeEvent(), ctx);
+
+    expect(result.action).toBe("none");
+    expect((result as { reason: string }).reason).toContain("no tracked item");
+  });
+
+  test("no-op when event missing prNumber", async () => {
+    const event = makeEvent({ prNumber: undefined });
+    const ctx = makeCtx();
+
+    const result = await bindModule.fn(event, ctx);
+
+    expect(result.action).toBe("none");
+    expect((result as { reason: string }).reason).toBe("event missing prNumber or branch");
+  });
+
+  test("no-op when event missing branch", async () => {
+    const event = makeEvent();
+    (event as Record<string, unknown>).branch = undefined;
+    const ctx = makeCtx();
+
+    const result = await bindModule.fn(event, ctx);
+
+    expect(result.action).toBe("none");
+    expect((result as { reason: string }).reason).toBe("event missing prNumber or branch");
+  });
+
+  test("branchPattern extracts issue number and matches by issue", async () => {
+    const item = makeWorkItem({ prNumber: null, branch: null });
+    const ctx = makeCtx({
+      config: { branchPattern: "^(?:feat|fix)/issue-(?<issue>\\d+)-" },
+      findWorkItemByBranch: () => null,
+      findWorkItemByIssue: (n) => (n === 100 ? item : null),
+    });
+
+    const result = await bindModule.fn(makeEvent({ branch: "feat/issue-100-widget" }), ctx);
+
+    expect(result.action).toBe("set-state");
+    expect((result as { patch: Record<string, unknown> }).patch).toEqual({
+      prNumber: 42,
+      branch: "feat/issue-100-widget",
+    });
+  });
+
+  test("branchPattern no-op when pattern does not match branch", async () => {
+    const ctx = makeCtx({
+      config: { branchPattern: "^(?:feat|fix)/issue-(?<issue>\\d+)-" },
+      findWorkItemByBranch: () => null,
+      findWorkItemByIssue: () => null,
+    });
+
+    const result = await bindModule.fn(makeEvent({ branch: "chore/cleanup" }), ctx);
+
+    expect(result.action).toBe("none");
+    expect((result as { reason: string }).reason).toContain("no tracked item");
+  });
+
+  test("direct branch match takes priority over branchPattern", async () => {
+    const branchItem = makeWorkItem({ id: "#200", prNumber: null, branch: "feat/issue-100-foo" });
+    const issueItem = makeWorkItem({ id: "#100", prNumber: null });
+    const ctx = makeCtx({
+      config: { branchPattern: "^feat/issue-(?<issue>\\d+)-" },
+      findWorkItemByBranch: (b) => (b === "feat/issue-100-foo" ? branchItem : null),
+      findWorkItemByIssue: (n) => (n === 100 ? issueItem : null),
+    });
+
+    const result = (await bindModule.fn(makeEvent(), ctx)) as { action: string; patch: Record<string, unknown> };
+
+    expect(result.action).toBe("set-state");
+    expect(result.patch.prNumber).toBe(42);
+  });
+
+  describe("integration with dispatcher", () => {
+    let bus: import("./event-bus").EventBus;
+
+    beforeEach(async () => {
+      const { EventBus } = await import("./event-bus");
+      bus = new EventBus();
+    });
+
+    test("dispatcher fires bind module and records audit", async () => {
+      const { AutomationDispatcher } = await import("./automation-dispatcher");
+      const item = makeWorkItem({ prNumber: null });
+
+      const dispatcher = new AutomationDispatcher({
+        eventBus: bus,
+        repoRoot: import.meta.dir,
+        getWorkItemByBranch: (branch) => (branch === "feat/issue-100-foo" ? item : null),
+        getWorkItemByIssue: () => null,
+        executeModule: async (_mod, event) => {
+          const ctx = makeCtx({
+            findWorkItemByBranch: (b) => (b === "feat/issue-100-foo" ? item : null),
+          });
+          return bindModule.fn(event, ctx);
+        },
+      });
+
+      const published: MonitorEvent[] = [];
+      bus.subscribe((event) => {
+        if (event.event.startsWith("automation.")) published.push(event);
+      });
+
+      dispatcher.load({ preset: "semi-auto", modules: {} }, [
+        {
+          name: "bind",
+          resolvedPath: ".claude/automation/bind.ts",
+          contentHash: "a".repeat(64),
+          events: ["pr.opened"],
+          enabled: true,
+        },
+      ]);
+      dispatcher.start();
+
+      bus.publish(makeEvent());
+
+      const start = performance.now();
+      while (!published.some((e) => e.event === "automation.fired") && performance.now() - start < 2_000) {
+        await Bun.sleep(2);
+      }
+
+      const fired = published.find((e) => e.event === "automation.fired");
+      expect(fired).toBeDefined();
+      expect(fired?.module).toBe("bind");
+      expect(fired?.actionType).toBe("set-state");
+
+      dispatcher.stop();
+    });
+
+    test("per-item override blocks bind module", async () => {
+      const { AutomationDispatcher } = await import("./automation-dispatcher");
+      const executedModules: string[] = [];
+
+      const dispatcher = new AutomationDispatcher({
+        eventBus: bus,
+        repoRoot: import.meta.dir,
+        getWorkItemOverrides: () => "bind=false",
+        resolveWorkItemId: () => "#100",
+        executeModule: async (mod) => {
+          executedModules.push(mod.name);
+          return { action: "none", reason: "test" };
+        },
+      });
+
+      const published: MonitorEvent[] = [];
+      bus.subscribe((event) => {
+        if (event.event.startsWith("automation.")) published.push(event);
+      });
+
+      dispatcher.load({ preset: "semi-auto", modules: {} }, [
+        {
+          name: "bind",
+          resolvedPath: ".claude/automation/bind.ts",
+          contentHash: "a".repeat(64),
+          events: ["pr.opened"],
+          enabled: true,
+        },
+      ]);
+      dispatcher.start();
+
+      bus.publish(makeEvent({ workItemId: "#100" }));
+
+      const start = performance.now();
+      while (!published.some((e) => e.event === "automation.skipped") && performance.now() - start < 2_000) {
+        await Bun.sleep(2);
+      }
+
+      expect(executedModules).toHaveLength(0);
+      const skipped = published.find((e) => e.event === "automation.skipped");
+      expect(skipped).toBeDefined();
+      expect(skipped?.module).toBe("bind");
+
+      dispatcher.stop();
+    });
+  });
+});

--- a/packages/daemon/src/automation-bind.spec.ts
+++ b/packages/daemon/src/automation-bind.spec.ts
@@ -142,18 +142,23 @@ describe("bind automation module", () => {
   });
 
   test("direct branch match takes priority over branchPattern", async () => {
-    const branchItem = makeWorkItem({ id: "#200", prNumber: null, branch: "feat/issue-100-foo" });
+    const branchItem = makeWorkItem({ id: "#200", prNumber: 999, branch: "feat/issue-100-foo" });
     const issueItem = makeWorkItem({ id: "#100", prNumber: null });
+    let issueQueryCalled = false;
     const ctx = makeCtx({
       config: { branchPattern: "^feat/issue-(?<issue>\\d+)-" },
       findWorkItemByBranch: (b) => (b === "feat/issue-100-foo" ? branchItem : null),
-      findWorkItemByIssue: (n) => (n === 100 ? issueItem : null),
+      findWorkItemByIssue: (n) => {
+        issueQueryCalled = true;
+        return n === 100 ? issueItem : null;
+      },
     });
 
-    const result = (await bindModule.fn(makeEvent(), ctx)) as { action: string; patch: Record<string, unknown> };
+    const result = await bindModule.fn(makeEvent(), ctx);
 
-    expect(result.action).toBe("set-state");
-    expect(result.patch.prNumber).toBe(42);
+    expect(result.action).toBe("none");
+    expect((result as { reason: string }).reason).toContain("already bound to PR #999");
+    expect(issueQueryCalled).toBe(false);
   });
 
   describe("integration with dispatcher", () => {

--- a/packages/daemon/src/automation-bind.spec.ts
+++ b/packages/daemon/src/automation-bind.spec.ts
@@ -60,7 +60,9 @@ describe("bind automation module", () => {
     const result = await bindModule.fn(makeEvent(), ctx);
 
     expect(result.action).toBe("set-state");
-    expect((result as { patch: Record<string, unknown> }).patch).toEqual({
+    const setState = result as { workItemId: string; patch: Record<string, unknown> };
+    expect(setState.workItemId).toBe("#100");
+    expect(setState.patch).toEqual({
       prNumber: 42,
       branch: "feat/issue-100-foo",
     });
@@ -122,7 +124,9 @@ describe("bind automation module", () => {
     const result = await bindModule.fn(makeEvent({ branch: "feat/issue-100-widget" }), ctx);
 
     expect(result.action).toBe("set-state");
-    expect((result as { patch: Record<string, unknown> }).patch).toEqual({
+    const setState = result as { workItemId: string; patch: Record<string, unknown> };
+    expect(setState.workItemId).toBe("#100");
+    expect(setState.patch).toEqual({
       prNumber: 42,
       branch: "feat/issue-100-widget",
     });
@@ -139,6 +143,22 @@ describe("bind automation module", () => {
 
     expect(result.action).toBe("none");
     expect((result as { reason: string }).reason).toContain("no tracked item");
+  });
+
+  test("invalid branchPattern regex logs warning and falls through", async () => {
+    const warnings: string[] = [];
+    const ctx = makeCtx({
+      config: { branchPattern: "[invalid(" },
+      findWorkItemByBranch: () => null,
+      findWorkItemByIssue: () => null,
+      logger: { info: () => {}, warn: (msg) => warnings.push(msg), error: () => {} },
+    });
+
+    const result = await bindModule.fn(makeEvent(), ctx);
+
+    expect(result.action).toBe("none");
+    expect((result as { reason: string }).reason).toContain("no tracked item");
+    expect(warnings.some((w) => w.includes("invalid branchPattern regex"))).toBe(true);
   });
 
   test("direct branch match takes priority over branchPattern", async () => {
@@ -213,6 +233,57 @@ describe("bind automation module", () => {
       expect(fired).toBeDefined();
       expect(fired?.module).toBe("bind");
       expect(fired?.actionType).toBe("set-state");
+
+      dispatcher.stop();
+    });
+
+    test("dispatcher applies set-state patch via updateWorkItem", async () => {
+      const { AutomationDispatcher } = await import("./automation-dispatcher");
+      const item = makeWorkItem({ prNumber: null });
+      const updates: Array<{ id: string; patch: Record<string, unknown> }> = [];
+
+      const dispatcher = new AutomationDispatcher({
+        eventBus: bus,
+        repoRoot: import.meta.dir,
+        getWorkItemByBranch: (branch) => (branch === "feat/issue-100-foo" ? item : null),
+        getWorkItemByIssue: () => null,
+        updateWorkItem: (id, patch) => {
+          updates.push({ id, patch });
+        },
+        executeModule: async (_mod, event) => {
+          const ctx = makeCtx({
+            findWorkItemByBranch: (b) => (b === "feat/issue-100-foo" ? item : null),
+          });
+          return bindModule.fn(event, ctx);
+        },
+      });
+
+      const published: MonitorEvent[] = [];
+      bus.subscribe((event) => {
+        if (event.event.startsWith("automation.")) published.push(event);
+      });
+
+      dispatcher.load({ preset: "semi-auto", modules: {} }, [
+        {
+          name: "bind",
+          resolvedPath: ".claude/automation/bind.ts",
+          contentHash: "a".repeat(64),
+          events: ["pr.opened"],
+          enabled: true,
+        },
+      ]);
+      dispatcher.start();
+
+      bus.publish(makeEvent());
+
+      const start = performance.now();
+      while (!published.some((e) => e.event === "automation.fired") && performance.now() - start < 2_000) {
+        await Bun.sleep(2);
+      }
+
+      expect(updates).toHaveLength(1);
+      expect(updates[0].id).toBe("#100");
+      expect(updates[0].patch).toEqual({ prNumber: 42, branch: "feat/issue-100-foo" });
 
       dispatcher.stop();
     });

--- a/packages/daemon/src/automation-dispatcher.ts
+++ b/packages/daemon/src/automation-dispatcher.ts
@@ -24,6 +24,7 @@ import type {
   AutomationPreset,
   LockedAutomation,
   MonitorEvent,
+  WorkItem,
 } from "@mcp-cli/core";
 import { isModuleEnabledForItem, parseAutomationOverrides } from "@mcp-cli/core";
 import type { EventBus } from "./event-bus";
@@ -37,6 +38,7 @@ interface RegisteredModule {
   contentHash: string;
   events: Set<string>;
   enabled: boolean;
+  config: Record<string, unknown>;
 }
 
 export class AutomationDispatcher {
@@ -51,6 +53,8 @@ export class AutomationDispatcher {
   private eventBus: EventBus;
   private getWorkItemOverrides: (workItemId: string) => string | undefined;
   private resolveWorkItemId: (prNumber: number) => string | undefined;
+  private getWorkItemByBranch: (branch: string) => WorkItem | null;
+  private getWorkItemByIssue: (issueNumber: number) => WorkItem | null;
   private executeModule: (module: RegisteredModule, event: MonitorEvent) => Promise<AutomationAction>;
 
   constructor(opts: {
@@ -58,12 +62,16 @@ export class AutomationDispatcher {
     repoRoot: string;
     getWorkItemOverrides?: (workItemId: string) => string | undefined;
     resolveWorkItemId?: (prNumber: number) => string | undefined;
+    getWorkItemByBranch?: (branch: string) => WorkItem | null;
+    getWorkItemByIssue?: (issueNumber: number) => WorkItem | null;
     executeModule?: (module: RegisteredModule, event: MonitorEvent) => Promise<AutomationAction>;
   }) {
     this.eventBus = opts.eventBus;
     this.repoRoot = opts.repoRoot;
     this.getWorkItemOverrides = opts.getWorkItemOverrides ?? (() => undefined);
     this.resolveWorkItemId = opts.resolveWorkItemId ?? (() => undefined);
+    this.getWorkItemByBranch = opts.getWorkItemByBranch ?? (() => null);
+    this.getWorkItemByIssue = opts.getWorkItemByIssue ?? (() => null);
     this.executeModule = opts.executeModule ?? this.defaultExecuteModule.bind(this);
   }
 
@@ -78,6 +86,7 @@ export class AutomationDispatcher {
         contentHash: entry.contentHash,
         events: new Set(entry.events),
         enabled: entry.enabled,
+        config: entry.config ?? {},
       });
     }
   }
@@ -298,6 +307,9 @@ export class AutomationDispatcher {
       repoRoot: this.repoRoot,
       signal: AbortSignal.timeout(MODULE_TIMEOUT_MS),
       workItem: null,
+      config: mod.config,
+      findWorkItemByBranch: (branch: string) => this.getWorkItemByBranch(branch),
+      findWorkItemByIssue: (issueNumber: number) => this.getWorkItemByIssue(issueNumber),
       logger: {
         info: (msg: string) => console.log(`[automation:${mod.name}] ${msg}`),
         warn: (msg: string) => console.warn(`[automation:${mod.name}] ${msg}`),

--- a/packages/daemon/src/automation-dispatcher.ts
+++ b/packages/daemon/src/automation-dispatcher.ts
@@ -55,6 +55,7 @@ export class AutomationDispatcher {
   private resolveWorkItemId: (prNumber: number) => string | undefined;
   private getWorkItemByBranch: (branch: string) => WorkItem | null;
   private getWorkItemByIssue: (issueNumber: number) => WorkItem | null;
+  private updateWorkItem: (workItemId: string, patch: Record<string, unknown>) => void;
   private executeModule: (module: RegisteredModule, event: MonitorEvent) => Promise<AutomationAction>;
 
   constructor(opts: {
@@ -64,6 +65,7 @@ export class AutomationDispatcher {
     resolveWorkItemId?: (prNumber: number) => string | undefined;
     getWorkItemByBranch?: (branch: string) => WorkItem | null;
     getWorkItemByIssue?: (issueNumber: number) => WorkItem | null;
+    updateWorkItem?: (workItemId: string, patch: Record<string, unknown>) => void;
     executeModule?: (module: RegisteredModule, event: MonitorEvent) => Promise<AutomationAction>;
   }) {
     this.eventBus = opts.eventBus;
@@ -72,6 +74,7 @@ export class AutomationDispatcher {
     this.resolveWorkItemId = opts.resolveWorkItemId ?? (() => undefined);
     this.getWorkItemByBranch = opts.getWorkItemByBranch ?? (() => null);
     this.getWorkItemByIssue = opts.getWorkItemByIssue ?? (() => null);
+    this.updateWorkItem = opts.updateWorkItem ?? (() => {});
     this.executeModule = opts.executeModule ?? this.defaultExecuteModule.bind(this);
   }
 
@@ -158,6 +161,10 @@ export class AutomationDispatcher {
           outcome = "escalated";
         } else {
           outcome = "fired";
+        }
+
+        if (action.action === "set-state") {
+          this.updateWorkItem(action.workItemId, action.patch);
         }
       } catch (err) {
         outcome = "errored";

--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -132,6 +132,8 @@ export class ClaudeServer extends AbstractWorkerServer {
         category: "work_item",
       };
       if ("prNumber" in event) input.prNumber = event.prNumber;
+      if ("branch" in event) input.branch = event.branch;
+      if ("base" in event) input.base = event.base;
       if ("failedJob" in event) input.failedJob = event.failedJob;
       if ("reviewer" in event) input.reviewer = event.reviewer;
       if ("itemId" in event) input.workItemId = event.itemId;

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -705,6 +705,9 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
           },
           getWorkItemByBranch: (branch) => workItemDb.getWorkItemByBranch(branch),
           getWorkItemByIssue: (issueNumber) => workItemDb.getWorkItemByIssue(issueNumber),
+          updateWorkItem: (id, patch) => {
+            workItemDb.updateWorkItem(id, patch as import("@mcp-cli/core").WorkItemPatch);
+          },
         });
         automationDispatcher.load(manifestResult.manifest.automation, automations);
         automationDispatcher.start();

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -703,6 +703,8 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
             const item = workItemDb.getWorkItemByPr(prNumber);
             return item?.id ?? undefined;
           },
+          getWorkItemByBranch: (branch) => workItemDb.getWorkItemByBranch(branch),
+          getWorkItemByIssue: (issueNumber) => workItemDb.getWorkItemByIssue(issueNumber),
         });
         automationDispatcher.load(manifestResult.manifest.automation, automations);
         automationDispatcher.start();


### PR DESCRIPTION
## Summary
- Add `bind` automation module (`.claude/automation/bind.ts`) — subscribes to `pr.opened`, matches branch to tracked work items, returns `set-state` with `{ prNumber, branch }`
- Extend `AutomationContext` with `findWorkItemByBranch`/`findWorkItemByIssue` query methods and per-module `config` bag
- Forward `branch`/`base` fields from `WorkItemEvent` through to `MonitorEvent` on the event bus
- Wire dispatcher and daemon startup with DB query callbacks; add optional `config` to module schema and lockfile

## Test plan
- [x] Bind fires on matching `pr.opened` event when branch matches tracked-but-unbound item
- [x] No-op when item already has `prNumber` set
- [x] No-op when no tracked item matches branch
- [x] No-op when event missing `prNumber` or `branch`
- [x] `branchPattern` config extracts issue number via named capture group and matches by issue
- [x] `branchPattern` no-op when pattern doesn't match branch
- [x] Direct branch match takes priority over `branchPattern`
- [x] Integration: dispatcher fires bind module and records `automation.fired` audit event
- [x] Integration: per-item override (`bind=false`) blocks module execution
- [x] Full suite: 7163 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)