### PR TITLE
test: guard daemon integration cleanup hooks

### DIFF
--- a/test/daemon-integration.spec.ts
+++ b/test/daemon-integration.spec.ts
@@ -251,7 +251,7 @@ describe("P3: Stdio transport end-to-end", () => {
   });
 
   afterAll(async () => {
-    await daemon.kill();
+    await daemon?.kill();
   });
 
   test("listTools returns echo server tools", async () => {
@@ -312,7 +312,7 @@ describe("P4: Concurrent operations", () => {
   });
 
   afterAll(async () => {
-    await daemon.kill();
+    await daemon?.kill();
   });
 
   test("parallel callTool requests return correct isolated results", async () => {
@@ -423,7 +423,7 @@ describe("P5: Error scenarios", () => {
   });
 
   afterAll(async () => {
-    await daemon.kill();
+    await daemon?.kill();
   });
 
   test("callTool to non-existent server returns error", async () => {
@@ -694,7 +694,7 @@ describe("P5c: Transport connection error scenarios", () => {
   });
 
   afterAll(async () => {
-    await daemon.kill();
+    await daemon?.kill();
   });
 
   test("HTTP connection refused returns clear error", async () => {


### PR DESCRIPTION
## Summary

- Guard the four remaining daemon integration `afterAll` cleanups with optional chaining.
- This keeps a failed `beforeAll` daemon start from adding secondary teardown `TypeError` failures.

Fixes #2063.

## Validation

- `bun test test/daemon-integration.spec.ts` still fails locally because daemon startup hits `SQLiteError: no such function: unixepoch` in `packages/daemon/src/session-metrics.ts`.
- After this change, the captured focused run had no matches for `TypeError`, `undefined is not an object`, or `daemon.kill` in the test output.
- `bunx biome check test/daemon-integration.spec.ts`
- `bun --bun tsc -b`
- `git diff --check HEAD~1 HEAD`
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact --timeout 30`

## Not run

- Full green daemon integration run. The local daemon cannot start on this host due the SQLite `unixepoch` failure above.
- Full pre-commit coverage hook. The hook passed typecheck, full Biome, shell-injection, args-bounds, timeout, teardown, and phase-drift checks, then `bun scripts/check-coverage.ts` stayed CPU-bound locally for more than seven minutes with no new output. I stopped that hook run and used the explicit checks listed above.
