### PR TITLE
chore: bump engines.bun to >=1.3.14 (closes #2072)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@theshadow27/mcp-cli",
   "engines": {
-    "bun": ">=1.2.18"
+    "bun": ">=1.3.14"
   },
   "version": "1.9.0",
   "description": "MCP CLI — call MCP server tools from the command line with zero context overhead",

--- a/packages/core/src/bun-version.spec.ts
+++ b/packages/core/src/bun-version.spec.ts
@@ -2,8 +2,8 @@ import { describe, expect, it, spyOn } from "bun:test";
 import { MIN_BUN_VERSION, assertBunVersion } from "./bun-version";
 
 describe("assertBunVersion", () => {
-  it("MIN_BUN_VERSION is 1.2.18", () => {
-    expect(MIN_BUN_VERSION).toBe("1.2.18");
+  it("MIN_BUN_VERSION is 1.3.14", () => {
+    expect(MIN_BUN_VERSION).toBe("1.3.14");
   });
 
   it("does not exit when current Bun version meets the minimum", () => {
@@ -49,7 +49,7 @@ describe("assertBunVersion", () => {
     const stderrSpy = spyOn(process.stderr, "write").mockImplementation(() => true);
 
     try {
-      // Any currently-shipping Bun (>=1.2.18) should satisfy a >=1.2.0 requirement
+      // Any currently-shipping Bun (>=1.3.14) should satisfy a >=1.2.0 requirement
       expect(() => assertBunVersion("1.2.0")).not.toThrow();
       expect(stderrSpy).not.toHaveBeenCalled();
     } finally {
@@ -66,7 +66,7 @@ describe("assertBunVersion", () => {
     const stderrSpy = spyOn(process.stderr, "write").mockImplementation(() => true);
 
     try {
-      expect(() => assertBunVersion("1.2.18", "1.2.17")).toThrow("process.exit called");
+      expect(() => assertBunVersion("1.3.14", "1.3.13")).toThrow("process.exit called");
       expect(exitSpy).toHaveBeenCalledWith(1);
     } finally {
       exitSpy.mockRestore();
@@ -81,7 +81,7 @@ describe("assertBunVersion", () => {
     const stderrSpy = spyOn(process.stderr, "write").mockImplementation(() => true);
 
     try {
-      expect(() => assertBunVersion("1.2.18", "1.2.18")).not.toThrow();
+      expect(() => assertBunVersion("1.3.14", "1.3.14")).not.toThrow();
       expect(stderrSpy).not.toHaveBeenCalled();
     } finally {
       exitSpy.mockRestore();
@@ -96,7 +96,7 @@ describe("assertBunVersion", () => {
     const stderrSpy = spyOn(process.stderr, "write").mockImplementation(() => true);
 
     try {
-      expect(() => assertBunVersion("1.2.18", "1.2.18-canary.20250401")).not.toThrow();
+      expect(() => assertBunVersion("1.3.14", "1.3.14-canary.20250401")).not.toThrow();
       expect(stderrSpy).not.toHaveBeenCalled();
     } finally {
       exitSpy.mockRestore();
@@ -111,7 +111,7 @@ describe("assertBunVersion", () => {
     const stderrSpy = spyOn(process.stderr, "write").mockImplementation(() => true);
 
     try {
-      expect(() => assertBunVersion("1.2.18", "1.2.17-canary.20250401")).toThrow("process.exit called");
+      expect(() => assertBunVersion("1.3.14", "1.3.13-canary.20250401")).toThrow("process.exit called");
       expect(exitSpy).toHaveBeenCalledWith(1);
     } finally {
       exitSpy.mockRestore();

--- a/packages/core/src/bun-version.ts
+++ b/packages/core/src/bun-version.ts
@@ -1,6 +1,6 @@
 import { compareVersions } from "./upgrade";
 
-export const MIN_BUN_VERSION = "1.2.18";
+export const MIN_BUN_VERSION = "1.3.14";
 
 /**
  * Exits with a clear error if the running Bun version is older than minVersion.


### PR DESCRIPTION
## Summary
- Bumps `engines.bun` in root `package.json` from `>=1.2.18` to `>=1.3.14` — the current stable Bun release
- No per-package `package.json` files declare `engines`; no pre-commit hook bun-version assertion exists
- Verified segfault issues #2055 and #2068 (both reported on 1.3.13) pass cleanly under 1.3.14 — upstream fixed

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] Pre-commit hooks pass
- [x] `bun test packages/daemon/src/orphan-reaper.spec.ts packages/daemon/src/claude-server.spec.ts` — 102 tests pass, no segfault (was crashing on 1.3.13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)