### PR TITLE
ci: add pty-test job to catch TTY color-skew regressions (closes #2051)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,6 +141,43 @@ jobs:
           if-no-files-found: ignore
           retention-days: 30
 
+  pty-test:
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+      - run: bun install --frozen-lockfile
+      - name: Install unbuffer (expect)
+        run: sudo apt-get install -y expect
+      # Run historically PTY-sensitive spec files under a real PTY via unbuffer.
+      # These tests failed in #2016 when stdout.isTTY was true and color codes
+      # leaked into assertions. The NO_COLOR preload (bunfig.toml) makes this
+      # pass today; this job catches regressions if the preload is ever removed.
+      - name: Test (PTY — TTY-sensitive files)
+        run: |
+          set +e
+          unbuffer bun test packages/command/src/commands/claude.spec.ts packages/control/src/components/metrics-panel.spec.ts 2>&1 | tee /tmp/test_pty.txt
+          code=${PIPESTATUS[0]}
+          if [ $code -eq 0 ]; then
+            exit 0
+          elif grep -q "^ 0 fail$" /tmp/test_pty.txt; then
+            echo "::warning::Bun crash (exit $code) after all tests passed — treating as pass (see #1004)"
+            exit 0
+          else
+            exit $code
+          fi
+      - name: Upload PTY test logs
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bun-pty-test-logs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: /tmp/test_pty.txt
+          if-no-files-found: ignore
+          retention-days: 30
+
   build:
     runs-on: ubuntu-latest
     needs: check


### PR DESCRIPTION
## Summary
- Adds a new `pty-test` CI job that runs the two historically PTY-sensitive spec files (`packages/command/src/commands/claude.spec.ts`, `packages/control/src/components/metrics-panel.spec.ts`) under `unbuffer` (from `expect`) to allocate a real PTY
- The job passes today because the `NO_COLOR=1` preload in `bunfig.toml` (added in PR #2046) prevents color codes from leaking into assertions — but will fail immediately if that preload is ever removed or bypassed
- Applies the same Bun crash-tolerance heuristics as other test steps (exit 0 when "0 fail" appears in output despite non-zero exit code)

## Test plan
- [ ] CI runs and `pty-test` job passes (preload is active)
- [ ] To manually verify the guard works: remove `preload-no-color.ts` from `bunfig.toml` and re-run `unbuffer bun test packages/command/src/commands/claude.spec.ts packages/control/src/components/metrics-panel.spec.ts` locally — assertions containing ANSI codes will fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)