### PR TITLE
test(daemon-integration): guard remaining afterAll hooks with optional chaining (fixes #2063)

### DIFF
--- a/test/daemon-integration.spec.ts
+++ b/test/daemon-integration.spec.ts
@@ -251,7 +251,7 @@ describe("P3: Stdio transport end-to-end", () => {
   });
 
   afterAll(async () => {
-    await daemon.kill();
+    await daemon?.kill();
   });
 
   test("listTools returns echo server tools", async () => {
@@ -312,7 +312,7 @@ describe("P4: Concurrent operations", () => {
   });
 
   afterAll(async () => {
-    await daemon.kill();
+    await daemon?.kill();
   });
 
   test("parallel callTool requests return correct isolated results", async () => {
@@ -423,7 +423,7 @@ describe("P5: Error scenarios", () => {
   });
 
   afterAll(async () => {
-    await daemon.kill();
+    await daemon?.kill();
   });
 
   test("callTool to non-existent server returns error", async () => {
@@ -694,7 +694,7 @@ describe("P5c: Transport connection error scenarios", () => {
   });
 
   afterAll(async () => {
-    await daemon.kill();
+    await daemon?.kill();
   });
 
   test("HTTP connection refused returns clear error", async () => {


### PR DESCRIPTION
## Summary
- Adds `?.` optional chaining to `daemon.kill()` in the `afterAll` blocks of P3 (stdio), P4 (concurrent ops), P5a (error scenarios), and P5c (dead transports)
- Prevents TypeError cascades when `beforeAll` fails mid-suite, masking the real error with a secondary failure
- Completes the pattern established in #2059 for P3b, P3c, and P5b

## Test plan
- [x] TypeScript typecheck passes
- [x] Lint passes (no changes needed)
- [x] Pre-commit suite passes (unit tests + coverage)
- [x] Verified lines 32 and 152 already use `if (daemon)` guards — not changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)