### PR TITLE
fix(gc): strip + prefix from git branch --merged output (fixes #2042)

### DIFF
--- a/packages/command/src/commands/gc.spec.ts
+++ b/packages/command/src/commands/gc.spec.ts
@@ -132,6 +132,30 @@ describe("runGc branches", () => {
     expect(d.errors.some((l) => l.includes("branches: deleted 1"))).toBe(true);
   });
 
+  test("strips + prefix from worktree-checked-out branches in git branch --merged output", async () => {
+    // git branch --merged uses '+ branch-name' for branches checked out in a worktree.
+    // The parser must strip the '+' or the branch name becomes '+ main' which fails deletion.
+    const responses = new Map<string, { stdout: string; stderr?: string; exitCode?: number }>();
+    // worktree-claude-abc is checked out in a secondary worktree, so git shows it with '+'
+    responses.set("git -C /repo worktree list --porcelain", {
+      stdout: "worktree /repo\nbranch refs/heads/main\n\nworktree /wt\nbranch refs/heads/worktree-claude-abc\n\n",
+    });
+    responses.set("git -C /repo symbolic-ref refs/remotes/origin/HEAD", { stdout: "refs/remotes/origin/main" });
+    responses.set("git -C /repo branch --merged main", { stdout: "+ main\n+ worktree-claude-abc\n  stale-feat\n" });
+    responses.set("git -C /repo branch --show-current", { stdout: "main" });
+    responses.set("git -C /repo fetch --prune", { stdout: "" });
+    responses.set("git -C /repo branch -d stale-feat", { stdout: "Deleted branch stale-feat", exitCode: 0 });
+
+    const d = makeDeps({ execResponses: responses });
+    await runGc({ dryRun: false, olderThanMs: 86_400_000, branchesOnly: true, worktreesOnly: false }, d);
+
+    // Should delete stale-feat, not attempt '+ main' or '+ worktree-claude-abc'
+    expect(d.execCalls.some((c) => c.join(" ") === "git -C /repo branch -d stale-feat")).toBe(true);
+    expect(d.execCalls.some((c) => c.join(" ").includes("+ "))).toBe(false);
+    expect(d.errors.some((l) => l.includes("branches: deleted 1"))).toBe(true);
+    expect(d.errors.some((l) => l.includes("failed"))).toBe(false);
+  });
+
   test("excludes default branch and current branch", async () => {
     const responses = new Map<string, { stdout: string; exitCode?: number }>();
     responses.set("git -C /repo worktree list --porcelain", { stdout: "" });

--- a/packages/command/src/commands/gc.ts
+++ b/packages/command/src/commands/gc.ts
@@ -351,7 +351,7 @@ function getMergedBranches(deps: WorktreeShimDeps, cwd: string, defaultBranch: s
   if (exitCode !== 0) return [];
   return stdout
     .split("\n")
-    .map((l) => l.replace(/^\*?\s+/, "").trim())
+    .map((l) => l.replace(/^[*+]?\s+/, "").trim())
     .filter(Boolean);
 }
 


### PR DESCRIPTION
## Summary
- `git branch --merged` prefixes branches checked out in a worktree with `+ ` (e.g., `+ main`)
- The parser in `getMergedBranches` only stripped `*`, so `+ main` was passed to `git branch -D` as a literal branch name, causing 3 spurious failures at sprint-53 wind-down
- Fix: change regex from `/^\*?\s+/` to `/^[*+]?\s+/` — one character wider

## Test plan
- [x] Added regression test covering `git branch --merged` output with `+`-prefixed branches — verifies correct branch names are passed to `git branch -d`, no `+ ` strings leak through, and deletion count is correct
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (39/39 in gc.spec.ts, full suite clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)