### PR TITLE
fix(site): auto-restart browser after system sleep (fixes #2071)

### DIFF
--- a/packages/daemon/src/site-worker.spec.ts
+++ b/packages/daemon/src/site-worker.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { parseSitesArg } from "./site-worker";
+import { parseSitesArg, shouldAutoRestart } from "./site-worker";
+import type { LastBrowserSession } from "./site-worker";
 
 describe("parseSitesArg", () => {
   test("returns string array for valid non-empty dense array", () => {
@@ -47,5 +48,25 @@ describe("parseSitesArg", () => {
     const msg = parseSitesArg([]) as string;
     expect(msg).toContain("non-empty");
     expect(msg).toContain("sites");
+  });
+});
+
+describe("shouldAutoRestart", () => {
+  const session: LastBrowserSession = { engine: "playwright", siteNames: ["owa"] };
+
+  test("true when session exists and vault is empty", () => {
+    expect(shouldAutoRestart(session, true)).toBe(true);
+  });
+
+  test("false when no previous session", () => {
+    expect(shouldAutoRestart(null, true)).toBe(false);
+  });
+
+  test("false when vault is not empty (browser alive or tokens cached)", () => {
+    expect(shouldAutoRestart(session, false)).toBe(false);
+  });
+
+  test("false when both null session and vault not empty", () => {
+    expect(shouldAutoRestart(null, false)).toBe(false);
   });
 });

--- a/packages/daemon/src/site-worker.ts
+++ b/packages/daemon/src/site-worker.ts
@@ -73,6 +73,23 @@ let browser: BrowserEngine | null = null;
 let browserEngineName: BrowserEngineName | null = null;
 const sitesOpenInBrowser = new Set<string>();
 
+export interface LastBrowserSession {
+  engine: BrowserEngineName;
+  /** Site names that were open in the browser. */
+  siteNames: string[];
+}
+
+let lastBrowserSession: LastBrowserSession | null = null;
+
+/**
+ * Whether an auto-restart should be attempted. Pure function for testability.
+ * Auto-restart is warranted when a previous session existed but the browser
+ * is now dead and the vault is empty (e.g. after system sleep).
+ */
+export function shouldAutoRestart(session: LastBrowserSession | null, vaultEmpty: boolean): boolean {
+  return session !== null && vaultEmpty;
+}
+
 // Serialises all operations that read-modify-write the `browser` module global,
 // preventing a concurrent observer handler from clearing the ref during start-up
 // (when browser is truthy but isRunning() is still false). See #1597.
@@ -235,8 +252,15 @@ function handleDescribe(args: Record<string, unknown>): ToolResult {
 }
 
 async function handleCall(args: Record<string, unknown>): Promise<ToolResult> {
-  const browserSnapshot = await snapshotBrowser();
+  let browserSnapshot = await snapshotBrowser();
   const site = requireSite(args.site as string);
+
+  // Auto-restart if the browser died (e.g. system sleep) and the vault is empty for this site.
+  // This avoids the confusing "No credentials available" error when the Chrome profile is intact.
+  if (shouldAutoRestart(lastBrowserSession, vault.getAll(site.name).length === 0)) {
+    const restarted = await tryAutoRestartBrowser();
+    if (restarted) browserSnapshot = await snapshotBrowser();
+  }
   const callName = args.call as string;
   const catalog = loadCatalog(site.name, site.seed ?? site.name);
   const call = catalog[callName];
@@ -310,6 +334,59 @@ function resetIfBrowserDied(): void {
   }
 }
 
+/**
+ * Silently restart the browser using the last known session config, then wiggle
+ * each site to repopulate the credential vault. Returns true if the browser
+ * started successfully (vault may still be empty if wiggle isn't configured).
+ *
+ * Called automatically from site_call when the browser has died and the vault
+ * is empty — covers the common "laptop slept, Chrome was killed" case.
+ */
+async function tryAutoRestartBrowser(): Promise<boolean> {
+  return withBrowserLock(async () => {
+    resetIfBrowserDied();
+    if (browser) return true; // another concurrent call already restarted it
+    if (!lastBrowserSession) return false;
+
+    const { engine, siteNames } = lastBrowserSession;
+    const siteConfigs: SiteConfig[] = [];
+    for (const name of siteNames) {
+      const s = getSite(name);
+      if (s) siteConfigs.push(s);
+    }
+    if (siteConfigs.length === 0) return false;
+
+    for (const s of siteConfigs) {
+      sniffer.configureSite(s.name, s.captureMode ?? "firehose", s.captureFilters);
+    }
+
+    const eng = await loadBrowser(engine);
+    const specs = siteConfigs.map(siteSpecFor);
+
+    try {
+      await withDeadline(60_000, "browser auto-restart", eng.start(specs, sniffer.asEvents()));
+    } catch {
+      await withDeadline(5_000, "browser stop on failed auto-restart", eng.stop()).catch(() => {});
+      return false;
+    }
+
+    browser = eng;
+    browserEngineName = engine;
+    for (const s of siteConfigs) sitesOpenInBrowser.add(s.name);
+
+    // Wiggle to repopulate the credential vault from fresh page requests.
+    for (const s of siteConfigs) {
+      try {
+        await withDeadline(15_000, "wiggle on auto-restart", eng.wiggle(s.name));
+      } catch {
+        // Best-effort — vault may also repopulate from background page activity.
+      }
+    }
+
+    return true;
+  });
+}
+
 const SITES_ARG_ERROR = "'sites' must be a non-empty array of site name strings";
 
 /** Validates and returns the `sites` argument as a dense, non-empty string array, or an error string. */
@@ -366,6 +443,7 @@ async function handleBrowserStart(args: Record<string, unknown>): Promise<ToolRe
     browser = eng;
     browserEngineName = engine;
     for (const s of sites) sitesOpenInBrowser.add(s.name);
+    lastBrowserSession = { engine, siteNames: sites.map((s) => s.name) };
 
     return ok({ ok: true, engine, sites: eng.getSiteNames(), results: startResults });
   });
@@ -379,6 +457,7 @@ async function handleDisconnect(): Promise<ToolResult> {
     browser = null;
     browserEngineName = null;
     sitesOpenInBrowser.clear();
+    lastBrowserSession = null; // intentional stop — don't auto-restart on next call
     return ok({ ok: true });
   });
 }
@@ -412,7 +491,13 @@ function handleSniff(args: Record<string, unknown>): ToolResult {
 
 async function handleWiggle(args: Record<string, unknown>): Promise<ToolResult> {
   const snapshot = await snapshotBrowser();
-  if (!snapshot) return error("Browser is not running. Start it with site_browser_start.");
+  if (!snapshot) {
+    return error(
+      lastBrowserSession
+        ? "Browser session was dropped (system sleep or crash). Run 'mcx site browser' to re-attach — login is usually not required as your browser profile is preserved on disk."
+        : "Browser is not running. Start it with site_browser_start.",
+    );
+  }
   const site = args.site as string | undefined;
   const touched = await snapshot.wiggle(site);
   return ok({ ok: true, touched });

--- a/packages/daemon/src/site-worker.ts
+++ b/packages/daemon/src/site-worker.ts
@@ -83,8 +83,10 @@ let lastBrowserSession: LastBrowserSession | null = null;
 
 /**
  * Whether an auto-restart should be attempted. Pure function for testability.
- * Auto-restart is warranted when a previous session existed but the browser
- * is now dead and the vault is empty (e.g. after system sleep).
+ * Returns true when a previous session exists and the vault is empty for the
+ * target site. Vault-empty is the observable proxy for "browser may have died"
+ * (e.g. after system sleep); browser liveness is not checked here.
+ * tryAutoRestartBrowser will no-op immediately if the browser is still alive.
  */
 export function shouldAutoRestart(session: LastBrowserSession | null, vaultEmpty: boolean): boolean {
   return session !== null && vaultEmpty;
@@ -341,50 +343,63 @@ function resetIfBrowserDied(): void {
  *
  * Called automatically from site_call when the browser has died and the vault
  * is empty — covers the common "laptop slept, Chrome was killed" case.
+ *
+ * Lock scope is intentionally limited to the start step. Wiggle runs outside
+ * the lock so the per-site 15s deadlines don't block unrelated browser ops
+ * (e.g. a concurrent site_disconnect or snapshotBrowser).
  */
 async function tryAutoRestartBrowser(): Promise<boolean> {
-  return withBrowserLock(async () => {
+  // Lock scope: browser global read-modify-write only. Values needed for the
+  // post-lock wiggle loop are returned from the callback so TypeScript can narrow them.
+  const locked = await withBrowserLock(async () => {
     resetIfBrowserDied();
-    if (browser) return true; // another concurrent call already restarted it
-    if (!lastBrowserSession) return false;
+    if (browser) return null; // another concurrent call already restarted it
+    if (!lastBrowserSession) return false as false;
 
     const { engine, siteNames } = lastBrowserSession;
-    const siteConfigs: SiteConfig[] = [];
+    const configs: SiteConfig[] = [];
     for (const name of siteNames) {
       const s = getSite(name);
-      if (s) siteConfigs.push(s);
+      if (s) configs.push(s);
     }
-    if (siteConfigs.length === 0) return false;
+    if (configs.length === 0) return false as false;
 
-    for (const s of siteConfigs) {
+    for (const s of configs) {
       sniffer.configureSite(s.name, s.captureMode ?? "firehose", s.captureFilters);
     }
 
     const eng = await loadBrowser(engine);
-    const specs = siteConfigs.map(siteSpecFor);
+    const specs = configs.map(siteSpecFor);
 
     try {
       await withDeadline(60_000, "browser auto-restart", eng.start(specs, sniffer.asEvents()));
     } catch {
       await withDeadline(5_000, "browser stop on failed auto-restart", eng.stop()).catch(() => {});
-      return false;
+      return false as false;
     }
 
     browser = eng;
     browserEngineName = engine;
-    for (const s of siteConfigs) sitesOpenInBrowser.add(s.name);
+    for (const s of configs) sitesOpenInBrowser.add(s.name);
 
-    // Wiggle to repopulate the credential vault from fresh page requests.
-    for (const s of siteConfigs) {
-      try {
-        await withDeadline(15_000, "wiggle on auto-restart", eng.wiggle(s.name));
-      } catch {
-        // Best-effort — vault may also repopulate from background page activity.
-      }
-    }
-
-    return true;
+    return { eng, configs };
   });
+
+  if (locked === false) return false;
+  if (locked === null) return true; // another concurrent call already restarted; skip wiggle
+
+  // Wiggle outside the lock — best-effort vault repopulation from fresh page requests.
+  // Per-site 15s deadlines don't block concurrent browser ops (snapshotBrowser, site_disconnect).
+  const { eng, configs } = locked;
+  for (const s of configs) {
+    try {
+      await withDeadline(15_000, "wiggle on auto-restart", eng.wiggle(s.name));
+    } catch {
+      // Best-effort — vault may also repopulate from background page activity.
+    }
+  }
+
+  return true;
 }
 
 const SITES_ARG_ERROR = "'sites' must be a non-empty array of site name strings";

--- a/packages/daemon/src/site/proxy.ts
+++ b/packages/daemon/src/site/proxy.ts
@@ -78,7 +78,9 @@ export async function proxyCall(vault: CredentialVault, opts: ProxyCallOptions):
     : vault.pickCredentialFor(resolved.url, resolved.method, audHints, site);
 
   if (!pick) {
-    throw new Error(`No credentials available for site '${site}'. Run 'mcx site browser ${site}' and complete login.`);
+    throw new Error(
+      `No credentials available for site '${site}'. Run 'mcx site browser ${site}' to start a browser session (if you have previously authenticated, login is usually not required — your browser profile is preserved on disk).`,
+    );
   }
 
   let usedAud = pick.aud;


### PR DESCRIPTION
## Summary

`mcx site` (playwright-engine) sessions die when the host sleeps, leaving the next call to fail with a misleading "No credentials available" error. This change:

- Tracks the last browser session (engine + site names) in the site-worker so the daemon knows what to relaunch.
- On `site_call`, if the browser is dead **and** the credential vault is empty, silently relaunches Chrome with the last-known sites and wiggles each one to repopulate the vault — then proceeds with the call. Chrome profile data persists on disk so login is usually preserved.
- Improves error messages so they no longer imply the auth cache is gone:
  - `proxyCall`: "...browser profile is preserved on disk."
  - `handleWiggle`: distinguishes "session dropped" from "never started" and tells the user to re-attach.
- `lastBrowserSession` is cleared on explicit `site_disconnect` so deliberate stops don't trigger auto-restart.

## Test plan

- [x] `bun typecheck` clean
- [x] `bun lint` clean
- [x] `bun test packages/daemon/src/site-worker.spec.ts packages/daemon/src/site/proxy.spec.ts packages/daemon/src/site-server.spec.ts` — 26 pass, 0 fail
- [x] Four new unit tests for `shouldAutoRestart` covering session/vault combinations
- [ ] Manual: laptop sleep → wake → `mcx site call owa inbox` works without manual `mcx site browser owa` re-attach
- [ ] Manual: `mcx site disconnect` followed by `mcx site call` does NOT auto-restart (intentional stop is preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)