### PR TITLE
fix(manifest): version check with actionable error on schema mismatch (fixes #2075)

### DIFF
--- a/packages/command/src/commands/track.ts
+++ b/packages/command/src/commands/track.ts
@@ -11,6 +11,7 @@
 
 import type { IpcMethod, IpcMethodResult, Manifest, TrackableField, WorkItem, WorkItemPhase } from "@mcp-cli/core";
 import {
+  ManifestVersionError,
   WORK_ITEM_PHASES,
   coerceTrackValue,
   getTrackableFields,
@@ -24,7 +25,8 @@ import { c, printError } from "../output";
 function tryLoadManifest(dir: string): Manifest | null {
   try {
     return loadManifest(dir)?.manifest ?? null;
-  } catch {
+  } catch (err) {
+    if (err instanceof ManifestVersionError) throw err;
     return null;
   }
 }

--- a/packages/core/src/manifest.spec.ts
+++ b/packages/core/src/manifest.spec.ts
@@ -5,7 +5,9 @@ import { join } from "node:path";
 import {
   DEFAULT_RUNS_ON,
   MANIFEST_FILENAMES,
+  MANIFEST_SCHEMA_VERSION,
   ManifestError,
+  ManifestVersionError,
   coerceTrackValue,
   detectCycles,
   findManifest,
@@ -243,10 +245,42 @@ describe("validateManifest constraints", () => {
     }
   });
 
-  test("rejects wrong version literal", () => {
-    expect(() => validateManifest({ version: 2, initial: "a", phases: { a: { source: "./a.ts" } } }, "/tmp/x")).toThrow(
-      ManifestError,
+  test("rejects version above MANIFEST_SCHEMA_VERSION with ManifestVersionError", () => {
+    const futureVersion = MANIFEST_SCHEMA_VERSION + 1;
+    expect(() =>
+      validateManifest({ version: futureVersion, initial: "a", phases: { a: { source: "./a.ts" } } }, "/tmp/x"),
+    ).toThrow(ManifestVersionError);
+  });
+
+  test("ManifestVersionError carries version numbers and fix instructions", () => {
+    const futureVersion = MANIFEST_SCHEMA_VERSION + 1;
+    try {
+      validateManifest({ version: futureVersion, initial: "a", phases: { a: { source: "./a.ts" } } }, "/tmp/x");
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ManifestVersionError);
+      const e = err as ManifestVersionError;
+      expect(e.manifestVersion).toBe(futureVersion);
+      expect(e.supportedVersion).toBe(MANIFEST_SCHEMA_VERSION);
+      expect(e.message).toContain("bun run build");
+      expect(e.message).toContain("mcx shutdown");
+      expect(e.path).toBe("/tmp/x");
+    }
+  });
+
+  test("ManifestVersionError is a ManifestError subtype", () => {
+    const futureVersion = MANIFEST_SCHEMA_VERSION + 1;
+    expect(() =>
+      validateManifest({ version: futureVersion, initial: "a", phases: { a: { source: "./a.ts" } } }, "/tmp/x"),
+    ).toThrow(ManifestError);
+  });
+
+  test("accepts version equal to MANIFEST_SCHEMA_VERSION", () => {
+    const m = validateManifest(
+      { version: MANIFEST_SCHEMA_VERSION, initial: "a", phases: { a: { source: "./a.ts" } } },
+      "/tmp/x",
     );
+    expect(m.version).toBe(MANIFEST_SCHEMA_VERSION);
   });
 });
 

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -227,8 +227,9 @@ export type ManifestState = z.infer<typeof ManifestStateSchema>;
 /**
  * Top-level manifest shape.
  *
- * `version` is a literal discriminator so a newer manifest against an older
- * `mcx` binary fails with a clear error instead of a generic "unknown key".
+ * `version` accepts any integer ≥ 1. If `version > MANIFEST_SCHEMA_VERSION`,
+ * `validateManifest` throws `ManifestVersionError` with an actionable message
+ * instead of a generic Zod error.
  *
  * The phase graph may contain cycles (e.g. review → repair → review); cycles
  * are intentional and part of the design. Only unreachable phases are
@@ -243,7 +244,7 @@ export const DEFAULT_RUNS_ON = "main";
 
 export const ManifestSchema = z
   .object({
-    version: z.literal(1).default(1),
+    version: z.number().int().min(1).default(1),
     runsOn: z.string().min(1).optional(),
     worktree: ManifestWorktreeSchema.optional(),
     state: ManifestStateSchema.optional(),
@@ -268,6 +269,27 @@ export class ManifestError extends Error {
   ) {
     super(message);
     this.name = "ManifestError";
+  }
+}
+
+/**
+ * Manifest schema version this binary was compiled against. A manifest with
+ * `version > MANIFEST_SCHEMA_VERSION` requires a newer binary.
+ */
+export const MANIFEST_SCHEMA_VERSION = 1;
+
+/** Thrown when the manifest declares a schema version the running daemon doesn't support. */
+export class ManifestVersionError extends ManifestError {
+  constructor(
+    public readonly manifestVersion: number,
+    public readonly supportedVersion: number,
+    path: string,
+  ) {
+    super(
+      `manifest schema version ${manifestVersion} requires a newer mcx binary (this daemon supports up to version ${supportedVersion}). To update: bun run build && mcx shutdown && mcx status`,
+      path,
+    );
+    this.name = "ManifestVersionError";
   }
 }
 
@@ -323,6 +345,10 @@ export function validateManifest(raw: unknown, path: string): Manifest {
     throw new ManifestError(`manifest validation failed:\n${lines.join("\n")}`, path);
   }
   const manifest = result.data;
+
+  if (manifest.version > MANIFEST_SCHEMA_VERSION) {
+    throw new ManifestVersionError(manifest.version, MANIFEST_SCHEMA_VERSION, path);
+  }
 
   const declared = new Set(Object.keys(manifest.phases));
   if (declared.size === 0) {

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -41,6 +41,7 @@ import {
   MAIL_SERVER_NAME,
   METRICS_SERVER_NAME,
   MOCK_SERVER_NAME,
+  ManifestVersionError,
   OPENCODE_SERVER_NAME,
   PROTOCOL_VERSION,
   PR_REVIEW_COMMENT_POSTED,
@@ -667,7 +668,11 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
     try {
       manifestResult = loadManifest(process.cwd());
     } catch (err) {
-      logger.warn(`[mcpd] Failed to load manifest for automation: ${err} — skipping`);
+      if (err instanceof ManifestVersionError) {
+        logger.warn(`[mcpd] ${err.message}`);
+      } else {
+        logger.warn(`[mcpd] Failed to load manifest for automation: ${err} — skipping`);
+      }
     }
     if (manifestResult?.manifest?.automation) {
       const lockfilePath = join(process.cwd(), LOCKFILE_NAME);
@@ -1108,7 +1113,8 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
             loadManifest: (repoRoot) => {
               try {
                 return loadManifest(repoRoot)?.manifest ?? null;
-              } catch {
+              } catch (err) {
+                if (err instanceof ManifestVersionError) throw err;
                 // Malformed manifest — behave as if absent so callers don't hard-fail.
                 return null;
               }


### PR DESCRIPTION
## Summary

- Adds `MANIFEST_SCHEMA_VERSION` (= 1) and a `ManifestVersionError` thrown when a manifest's `version` exceeds the daemon's compiled-in version. Error message includes the fix command: `bun run build && mcx shutdown && mcx status`.
- Changes `ManifestSchema.version` from `z.literal(1)` to `z.number().int().min(1)` so a forward-version manifest reaches the explicit version check instead of producing a generic Zod error.
- Daemon startup (`packages/daemon/src/index.ts`) and CLI consumers (`work-items-server` `loadManifest` fn, `track.ts` `tryLoadManifest`) now distinguish `ManifestVersionError` from other parse failures — the actionable message is logged at startup and propagated (not silently swallowed) at request time.

Option 1 (manifest file watch + auto-reload) is deferred per the issue's "(1) is a nice follow-up if cheap" note.

## Test plan

- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun test packages/core/src/manifest.spec.ts` — 78 pass, includes 4 new tests covering: version mismatch throws `ManifestVersionError`, error carries `manifestVersion` + `supportedVersion` + fix command in message, `ManifestVersionError` is a `ManifestError` subtype, `version: MANIFEST_SCHEMA_VERSION` accepted.
- [x] `bun test` on touched files (`manifest.spec`, `work-items-server.spec`, `handlers/work-item.spec`, `track.spec`) — 216 pass.
- [x] Pre-commit hooks passed (typecheck + lint + doing-it-wrong + test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)