### PR TITLE
fix(mail-wait): abort orphan poll, narrow catch, guard NaN createdAt (fixes #2060)

### DIFF
--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -1040,11 +1040,13 @@ async function agentWait(
   if (mailTo) {
     const totalMs = timeout ?? DEFAULT_TIMEOUT_MS;
     const pollStart = Date.now();
-    const mailPoll = pollMailUntil(d, mailTo, totalMs, pollStart);
+    const ac = new AbortController();
+    const mailPoll = pollMailUntil(d, mailTo, totalMs, pollStart, 2000, ac.signal);
     const winner = await Promise.race([
       waitPromise.then((r) => ({ kind: "session" as const, result: r })),
       mailPoll.then((m) => ({ kind: "mail" as const, message: m })),
     ]);
+    ac.abort();
     if (winner.kind === "mail" && winner.message) {
       emitMailEvent(winner.message, short, d, false);
       return;

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -1807,11 +1807,13 @@ async function claudeWait(args: string[], d: ClaudeDeps): Promise<void> {
   if (parsed.mailTo) {
     const totalMs = parsed.timeout ?? DEFAULT_TIMEOUT_MS;
     const pollStart = Date.now();
-    const mailPoll = pollMailUntil(d, parsed.mailTo, totalMs, pollStart);
+    const ac = new AbortController();
+    const mailPoll = pollMailUntil(d, parsed.mailTo, totalMs, pollStart, 2000, ac.signal);
     const winner = await Promise.race([
       waitPromise.then((r) => ({ kind: "session" as const, result: r })),
       mailPoll.then((m) => ({ kind: "mail" as const, message: m })),
     ]);
+    ac.abort();
     if (winner.kind === "mail" && winner.message) {
       emitMailEvent(winner.message, parsed.short, d, true);
       return;

--- a/packages/command/src/commands/mail-wait.spec.ts
+++ b/packages/command/src/commands/mail-wait.spec.ts
@@ -1,5 +1,5 @@
-import { describe, expect, mock, test } from "bun:test";
-import type { MailMessage } from "@mcp-cli/core";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { type MailMessage, ProtocolMismatchError } from "@mcp-cli/core";
 import { emitMailEvent, pollMailUntil } from "./mail-wait";
 
 function makeMail(overrides: Partial<MailMessage> = {}): MailMessage {
@@ -58,6 +58,127 @@ describe("pollMailUntil", () => {
     const d = { pollMail: mock(async () => null) };
     await pollMailUntil(d, "charlie", 50, Date.now(), 10);
     expect(d.pollMail).toHaveBeenCalledWith("charlie");
+  });
+
+  test("returns null immediately when signal is already aborted", async () => {
+    const d = { pollMail: mock(async () => makeMail()) };
+    const ac = new AbortController();
+    ac.abort();
+    const result = await pollMailUntil(d, "bob", 5000, Date.now() - 1, 10, ac.signal);
+    expect(result).toBeNull();
+    expect(d.pollMail).not.toHaveBeenCalled();
+  });
+
+  test("stops polling after signal is aborted mid-loop", async () => {
+    const ac = new AbortController();
+    let calls = 0;
+    const d = {
+      pollMail: mock(async () => {
+        calls++;
+        // Abort after first poll so second iteration is cut short
+        if (calls === 1) ac.abort();
+        return null;
+      }),
+    };
+    const result = await pollMailUntil(d, "bob", 5000, Date.now(), 10, ac.signal);
+    expect(result).toBeNull();
+    // Should have polled exactly once before abort stopped the loop
+    expect(calls).toBe(1);
+  });
+
+  // ── error handling (#2061) ──
+
+  describe("error handling", () => {
+    let errorSpy: ReturnType<typeof mock>;
+    let originalError: typeof console.error;
+
+    beforeEach(() => {
+      originalError = console.error;
+      errorSpy = mock((..._args: unknown[]) => {});
+      console.error = errorSpy as unknown as typeof console.error;
+    });
+
+    afterEach(() => {
+      console.error = originalError;
+    });
+
+    test("re-throws ProtocolMismatchError immediately (does not spin-poll)", async () => {
+      const d = {
+        pollMail: mock(async () => {
+          throw new ProtocolMismatchError("0.9", "1.0");
+        }),
+      };
+      await expect(pollMailUntil(d, "bob", 5000, Date.now(), 10)).rejects.toBeInstanceOf(ProtocolMismatchError);
+      expect(d.pollMail).toHaveBeenCalledTimes(1);
+    });
+
+    test("re-throws unknown (non-transient) errors instead of swallowing", async () => {
+      const d = {
+        pollMail: mock(async () => {
+          throw new TypeError("response is not an object");
+        }),
+      };
+      await expect(pollMailUntil(d, "bob", 5000, Date.now(), 10)).rejects.toBeInstanceOf(TypeError);
+      expect(d.pollMail).toHaveBeenCalledTimes(1);
+    });
+
+    test("retries on transient errors with code property", async () => {
+      const msg = makeMail();
+      let calls = 0;
+      const d = {
+        pollMail: mock(async () => {
+          if (calls++ === 0) {
+            const err = new Error("connect failed") as Error & { code: string };
+            err.code = "ECONNREFUSED";
+            throw err;
+          }
+          return msg;
+        }),
+      };
+      const result = await pollMailUntil(d, "bob", 5000, Date.now() - 1, 10);
+      expect(result).toBe(msg);
+      expect(calls).toBe(2);
+    });
+
+    test("logs a warning after N consecutive transient failures", async () => {
+      const d = {
+        pollMail: mock(async () => {
+          const err = new Error("ECONNREFUSED");
+          throw err;
+        }),
+      };
+      // Short timeout — will burn through ~15 polls at 1ms interval
+      await pollMailUntil(d, "bob", 100, Date.now(), 1);
+      const warnings = errorSpy.mock.calls.filter((c) => String((c as unknown[])[0]).includes("consecutive transient"));
+      // Logs exactly once (warnedTransient latch) regardless of how many more transient errors fire
+      expect(warnings.length).toBe(1);
+    });
+  });
+
+  // ── createdAt NaN guard (#2062) ──
+
+  describe("createdAt NaN guard", () => {
+    let errorSpy: ReturnType<typeof mock>;
+    let originalError: typeof console.error;
+
+    beforeEach(() => {
+      originalError = console.error;
+      errorSpy = mock((..._args: unknown[]) => {});
+      console.error = errorSpy as unknown as typeof console.error;
+    });
+
+    afterEach(() => {
+      console.error = originalError;
+    });
+
+    test("treats messages with non-finite createdAt as a miss and logs a warning", async () => {
+      const bad = makeMail({ createdAt: "garbage" });
+      const d = { pollMail: mock(async () => bad) };
+      const result = await pollMailUntil(d, "bob", 30, Date.now(), 10);
+      expect(result).toBeNull();
+      const warnings = errorSpy.mock.calls.filter((c) => String((c as unknown[])[0]).includes("invalid createdAt"));
+      expect(warnings.length).toBe(1);
+    });
   });
 });
 

--- a/packages/command/src/commands/mail-wait.ts
+++ b/packages/command/src/commands/mail-wait.ts
@@ -1,4 +1,21 @@
-import type { MailMessage } from "@mcp-cli/core";
+import { type MailMessage, ProtocolMismatchError } from "@mcp-cli/core";
+
+/** Error codes considered transient — daemon blips, socket churn, restart races. */
+const TRANSIENT_ERROR_CODES = new Set(["ECONNREFUSED", "ECONNRESET", "EPIPE", "EAGAIN", "ENOTCONN", "ENOENT"]);
+
+/** Warn after this many consecutive transient failures (~20s at 2s interval). */
+const TRANSIENT_WARN_THRESHOLD = 10;
+
+function isTransientError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const code = (err as { code?: unknown }).code;
+  if (typeof code === "string" && TRANSIENT_ERROR_CODES.has(code)) return true;
+  // Some IPC paths surface the code only in the message string.
+  for (const c of TRANSIENT_ERROR_CODES) {
+    if (err.message.includes(c)) return true;
+  }
+  return false;
+}
 
 /**
  * Poll for unread mail addressed to `recipient` until one arrives or the
@@ -9,9 +26,10 @@ import type { MailMessage } from "@mcp-cli/core";
  * mail with `createdAt` strictly after that timestamp is surfaced, so
  * pre-existing unread messages do not cause false-positive wakeups.
  *
- * Transient `pollMail` errors (IPC blips, daemon restart) are swallowed
- * and retried until the deadline; a single network hiccup will not kill
- * the entire wait.
+ * Transient `pollMail` errors (IPC blips, daemon restart, socket churn) are
+ * swallowed and retried until the deadline. `ProtocolMismatchError` and
+ * unknown errors propagate so callers fail fast instead of spin-polling
+ * for the full timeout against an unrecoverable condition.
  *
  * Returns the message, or null on timeout.
  */
@@ -21,18 +39,45 @@ export async function pollMailUntil(
   timeoutMs: number,
   afterMs: number,
   pollIntervalMs = 2000,
+  signal?: AbortSignal,
 ): Promise<MailMessage | null> {
   const deadline = Date.now() + timeoutMs;
+  let consecutiveTransient = 0;
+  let warnedTransient = false;
+  let warnedNaN = false;
   while (Date.now() < deadline) {
+    if (signal?.aborted) return null;
     let msg: MailMessage | null = null;
     try {
       msg = await d.pollMail(recipient);
-    } catch {
-      // Transient IPC error — continue polling until deadline
+      consecutiveTransient = 0;
+    } catch (err) {
+      if (err instanceof ProtocolMismatchError) throw err;
+      if (!isTransientError(err)) throw err;
+      consecutiveTransient++;
+      if (consecutiveTransient >= TRANSIENT_WARN_THRESHOLD && !warnedTransient) {
+        warnedTransient = true;
+        console.error(
+          `[mail-wait] ${consecutiveTransient} consecutive transient IPC errors polling for ${recipient}; last: ${(err as Error).message}`,
+        );
+      }
     }
-    if (msg && new Date(msg.createdAt).getTime() > afterMs) return msg;
+    if (msg) {
+      const createdMs = new Date(msg.createdAt).getTime();
+      if (!Number.isFinite(createdMs)) {
+        if (!warnedNaN) {
+          warnedNaN = true;
+          console.error(
+            `[mail-wait] mail id=${msg.id} for ${recipient} has invalid createdAt=${JSON.stringify(msg.createdAt)}; ignoring`,
+          );
+        }
+      } else if (createdMs > afterMs) {
+        return msg;
+      }
+    }
     const remaining = deadline - Date.now();
     if (remaining <= 0) break;
+    if (signal?.aborted) return null;
     await Bun.sleep(Math.min(pollIntervalMs, remaining));
   }
   return null;


### PR DESCRIPTION
## Summary
Bundled fix for the mail-wait cluster (#2060, #2061, #2062). All three bugs share the same shared module (`packages/command/src/commands/mail-wait.ts`) extracted by #2054, so they're fixed together.

- **#2060 — orphan poll burns IPC calls**: thread an `AbortSignal` through `pollMailUntil`. `claudeWait` and `agentWait` create an `AbortController` and call `ac.abort()` once `Promise.race` resolves. A 30-min wait that resolves in 5s no longer fires ~840 unanswered `pollMail` IPC calls.
- **#2061 — bare `catch{}` swallows ProtocolMismatchError + TypeErrors**: narrow the catch to known transient codes (ECONNREFUSED, ECONNRESET, EPIPE, EAGAIN, ENOTCONN, ENOENT) checked via both `err.code` and the message string. `ProtocolMismatchError` and unknown errors propagate so the wait fails fast instead of spin-polling for the full timeout. Single warning logged after 10 consecutive transient failures so silent retry storms become visible.
- **#2062 — NaN createdAt silently drops mail**: guard `new Date(msg.createdAt).getTime()` with `Number.isFinite`. Malformed timestamps (clock bug, schema migration race, manual SQLite edit) are logged once and treated as a miss instead of being permanently invisible.

## Test plan
- [x] `bun typecheck`
- [x] `bun lint`
- [x] `bun test packages/command/src/commands/mail-wait.spec.ts` — 17/17 pass (6 new tests: abort-while-aborted, abort-mid-loop, protocol-mismatch re-throw, unknown-error re-throw, transient `code` retry, transient-warning latch, NaN guard + warning)
- [x] `bun test` — 7251 pass / 1 pre-existing unrelated failure (was already failing on origin/main pre-rebase)
- [x] Pre-commit hook (typecheck + lint + doing-it-wrong + test + coverage) passed

closes #2061
closes #2062

🤖 Generated with [Claude Code](https://claude.com/claude-code)