### PR TITLE
fix(manifest): correct findManifest JSDoc (fixes #1361)

### DIFF
--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -295,7 +295,8 @@ export class ManifestVersionError extends ManifestError {
 
 /**
  * Find the first matching manifest in `dir`, in preference order.
- * Returns absolute path or null. Does not stat — callers handle ENOENT.
+ * Returns absolute path or null.
+ * Throws on non-absence errors (EACCES, EPERM, ESTALE, etc.).
  */
 export function findManifest(dir: string): string | null {
   for (const name of MANIFEST_FILENAMES) {


### PR DESCRIPTION
## Summary
- Corrects the `findManifest` JSDoc which falsely claimed "Does not stat — callers handle ENOENT"
- The function has always used `lstatSync`; since PR #1360 it also propagates non-absence errors instead of swallowing them
- Updated comment now reads: "Throws on non-absence errors (EACCES, EPERM, ESTALE, etc.)"

## Test plan
- [ ] `bun typecheck` passes
- [ ] `bun lint` passes
- [ ] `bun test` passes (no logic changed, doc-only fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)