### PR TITLE
perf(monitor): log rate-limit warning in repo-scoped CopilotPoller fetch path (fixes #1791)

### DIFF
--- a/packages/daemon/src/github/copilot-poller.spec.ts
+++ b/packages/daemon/src/github/copilot-poller.spec.ts
@@ -368,6 +368,33 @@ describe("CopilotPoller", () => {
       expect(poller.lastError).toBeNull();
     });
 
+    test("repo-scoped rateLimitLow logs warning with remaining count", async () => {
+      workItemDb.createWorkItem({ id: "wi:1", prNumber: 42, prState: "open" });
+      const warnMessages: string[] = [];
+      const logger = {
+        info() {},
+        warn(msg: string) {
+          warnMessages.push(msg);
+        },
+        error() {},
+        debug() {},
+      };
+      const poller = new CopilotPoller({
+        workItemDb,
+        stateDb: stateDb as unknown as CopilotPollerOptions["stateDb"] extends infer T ? T : never,
+        logger,
+        detectRepo: async () => TEST_REPO,
+        getToken: async () => "test-token",
+        fetchRepoComments: async () => ({ comments: [], rateLimitLow: true, rateLimitRemaining: 42 }),
+        fetchReviews: async () => okReviewResult([]),
+        fetchIssueComments: async () => okIssueCommentResult([]),
+      });
+
+      await poller.poll();
+
+      expect(warnMessages.some((m) => m.includes("rate limit low") && m.includes("42"))).toBe(true);
+    });
+
     test("primary rate-limit error (remaining==0) does not set lastError", async () => {
       workItemDb.createWorkItem({ id: "wi:1", prNumber: 42, prState: "open" });
       const { poller } = makePoller({

--- a/packages/daemon/src/github/copilot-poller.ts
+++ b/packages/daemon/src/github/copilot-poller.ts
@@ -274,7 +274,10 @@ export class CopilotPoller {
         try {
           const result = await this.fetchRepoCommentsFn(repo, since, token);
           inlineByPr = groupCommentsByPr(result.comments);
-          if (result.rateLimitLow) anyRateLimitLow = true;
+          if (result.rateLimitLow) {
+            anyRateLimitLow = true;
+            this.logger.warn(`[mcpd] CopilotPoller: GitHub rate limit low (${result.rateLimitRemaining} remaining)`);
+          }
           repoPollTs = preFetchTs;
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary
- The repo-scoped inline comment fetch path (`fetchRepoCommentsFn`) set `anyRateLimitLow` when rate limit was low but did not log a warning with the remaining count, unlike the per-PR review/comment paths
- Added `this.logger.warn(...)` with the remaining count parallel to the existing pattern in `pollPRReviews`/`pollPRComments`/`pollIssueComments`
- Added a test asserting the warning fires with the remaining count when `rateLimitLow: true`

## Test plan
- [ ] `bun test packages/daemon/src/github/copilot-poller.spec.ts` — 64 tests pass (new test: "repo-scoped rateLimitLow logs warning with remaining count")
- [ ] `bun typecheck` — no errors
- [ ] `bun lint` — clean
- [ ] Full suite: 7267 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)