### PR TITLE
fix(lint): flag Bun.sleep with fixed numeric delays in test files (closes #1673)

### DIFF
--- a/scripts/check-test-timeouts.spec.ts
+++ b/scripts/check-test-timeouts.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { findViolations, hasFixedDelay } from "./check-test-timeouts";
+import { findBunSleepViolations, findViolations, hasBunSleep, hasFixedDelay } from "./check-test-timeouts";
 
 // Shared matrices — exercised by both hasFixedDelay (per-line) and
 // findViolations (whole-content) so the production scan path is covered.
@@ -26,7 +26,6 @@ const shouldNotMatch = [
   'expect.poll(() => value).toBe("done")',
   "someTimeout(r, 50)", // not setTimeout
   "nosetTimeout(r, 50)", // word boundary guard
-  "await Bun.sleep(50)", // Bun.sleep is the accepted form
   "setTimeout(fn, TIMEOUT, 50)", // 3-arg form: delay (2nd arg) is named constant
 ];
 
@@ -114,5 +113,93 @@ setTimeout(
     expect(vs).toHaveLength(2);
     expect(vs[0].line).toBe(2);
     expect(vs[1].line).toBe(4);
+  });
+});
+
+// --- Bun.sleep detection ---
+
+const bunSleepShouldMatch = [
+  "await Bun.sleep(50)",
+  "await Bun.sleep(100)",
+  "Bun.sleep(0)",
+  "Bun.sleep(1_000)",
+  "  Bun.sleep(200)  ",
+  "// Bun.sleep(50)", // comment lines are flagged — no comment-stripping
+];
+
+const bunSleepShouldNotMatch = [
+  "await Bun.sleep(ms)", // parameterized — acceptable
+  "await Bun.sleep(intervalMs)", // named variable
+  "await Bun.sleep(POLL_INTERVAL_MS)", // named constant
+  "await Bun.sleep(remaining)", // variable
+  "await Bun.sleep(delayMs)", // parameter name
+  "noBun.sleep(50)", // word boundary guard
+  "Promise.race([waitForMsg(), Bun.sleep(remaining).then(() => null)])", // variable arg
+];
+
+describe("check-test-timeouts hasBunSleep", () => {
+  for (const line of bunSleepShouldMatch) {
+    test(`flags: ${line.trim()}`, () => {
+      expect(hasBunSleep(line)).toBe(true);
+    });
+  }
+
+  for (const line of bunSleepShouldNotMatch) {
+    test(`allows: ${line.trim()}`, () => {
+      expect(hasBunSleep(line)).toBe(false);
+    });
+  }
+});
+
+describe("check-test-timeouts findBunSleepViolations (single-line equivalence)", () => {
+  for (const line of bunSleepShouldMatch) {
+    test(`flags: ${line.trim()}`, () => {
+      expect(findBunSleepViolations(line).length).toBeGreaterThan(0);
+    });
+  }
+
+  for (const line of bunSleepShouldNotMatch) {
+    test(`allows: ${line.trim()}`, () => {
+      expect(findBunSleepViolations(line)).toHaveLength(0);
+    });
+  }
+});
+
+describe("check-test-timeouts findBunSleepViolations (multi-line)", () => {
+  test("catches single-line Bun.sleep(50)", () => {
+    const content = "await Bun.sleep(50);";
+    const vs = findBunSleepViolations(content);
+    expect(vs).toHaveLength(1);
+    expect(vs[0].line).toBe(1);
+  });
+
+  test("catches Bun.sleep split across lines", () => {
+    const content = `await Bun.sleep(
+  100
+);`;
+    const vs = findBunSleepViolations(content);
+    expect(vs).toHaveLength(1);
+    expect(vs[0].line).toBe(1);
+  });
+
+  test("does not flag Bun.sleep with a variable argument", () => {
+    const content = "await Bun.sleep(intervalMs);";
+    expect(findBunSleepViolations(content)).toHaveLength(0);
+  });
+
+  test("reports correct line numbers for multiple Bun.sleep violations", () => {
+    const content = `// line 1
+await Bun.sleep(10);
+// line 3
+await Bun.sleep(50);`;
+    const vs = findBunSleepViolations(content);
+    expect(vs).toHaveLength(2);
+    expect(vs[0].line).toBe(2);
+    expect(vs[1].line).toBe(4);
+  });
+
+  test("does not flag Bun.sleep in Promise.race with variable arg", () => {
+    const content = "Promise.race([waitForMsg(), Bun.sleep(remaining).then(() => null)])";
+    expect(findBunSleepViolations(content)).toHaveLength(0);
   });
 });

--- a/scripts/check-test-timeouts.spec.ts
+++ b/scripts/check-test-timeouts.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { findBunSleepViolations, findViolations, hasBunSleep, hasFixedDelay } from "./check-test-timeouts";
+import { BUN_SLEEP_BASELINE, findBunSleepViolations, findViolations, hasBunSleep, hasFixedDelay } from "./check-test-timeouts";
 
 // Shared matrices — exercised by both hasFixedDelay (per-line) and
 // findViolations (whole-content) so the production scan path is covered.
@@ -116,6 +116,13 @@ setTimeout(
   });
 });
 
+describe("check-test-timeouts BUN_SLEEP_BASELINE", () => {
+  test("baseline is a positive integer", () => {
+    expect(BUN_SLEEP_BASELINE).toBeGreaterThan(0);
+    expect(Number.isInteger(BUN_SLEEP_BASELINE)).toBe(true);
+  });
+});
+
 // --- Bun.sleep detection ---
 
 const bunSleepShouldMatch = [
@@ -125,6 +132,7 @@ const bunSleepShouldMatch = [
   "Bun.sleep(1_000)",
   "  Bun.sleep(200)  ",
   "// Bun.sleep(50)", // comment lines are flagged — no comment-stripping
+  "Promise.race([p, Bun.sleep(5000).then(() => null)])", // deadline pattern — intentionally flagged (#2100 remedy: name the constant)
 ];
 
 const bunSleepShouldNotMatch = [
@@ -135,6 +143,7 @@ const bunSleepShouldNotMatch = [
   "await Bun.sleep(delayMs)", // parameter name
   "noBun.sleep(50)", // word boundary guard
   "Promise.race([waitForMsg(), Bun.sleep(remaining).then(() => null)])", // variable arg
+  "await Bun.sleep(`${delay}`)", // template literal — not a numeric literal
 ];
 
 describe("check-test-timeouts hasBunSleep", () => {

--- a/scripts/check-test-timeouts.spec.ts
+++ b/scripts/check-test-timeouts.spec.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { BUN_SLEEP_BASELINE, findBunSleepViolations, findViolations, hasBunSleep, hasFixedDelay } from "./check-test-timeouts";
+import {
+  BUN_SLEEP_BASELINE,
+  findBunSleepViolations,
+  findViolations,
+  hasBunSleep,
+  hasFixedDelay,
+} from "./check-test-timeouts";
 
 // Shared matrices — exercised by both hasFixedDelay (per-line) and
 // findViolations (whole-content) so the production scan path is covered.

--- a/scripts/check-test-timeouts.ts
+++ b/scripts/check-test-timeouts.ts
@@ -37,6 +37,11 @@ const PACKAGES_DIR = new URL("../packages/", import.meta.url).pathname;
 const SCRIPTS_DIR = new URL("../scripts/", import.meta.url).pathname;
 const TEST_DIR = new URL("../test/", import.meta.url).pathname;
 
+// Ratchet baseline: fail if NEW Bun.sleep violations are introduced.
+// Decrease this number as #2100 cleanup proceeds. Once it reaches 0,
+// replace the ratchet with a hard exit(1) like the setTimeout check.
+export const BUN_SLEEP_BASELINE = 138;
+
 /**
  * Extracts the delay (2nd positional argument) from a pre-extracted argument
  * string of a setTimeout call.  Returns the trimmed delay text, or null when
@@ -239,9 +244,10 @@ async function main(): Promise<void> {
   }
 
   if (bunSleepViolations.length > 0) {
-    // WARNING only until existing violations are cleaned up (see #2100).
-    // Once the count reaches zero this block should exit(1) like the setTimeout check.
-    process.stderr.write(`\n  [warn] Bun.sleep with fixed delay: ${bunSleepViolations.length} violation(s) found\n\n`);
+    const isRegression = bunSleepViolations.length > BUN_SLEEP_BASELINE;
+    const prefix = isRegression ? "" : "[warn] ";
+    process.stderr.write(`\n  ${prefix}Bun.sleep with fixed delay: ${bunSleepViolations.length} violation(s) found`);
+    process.stderr.write(` (baseline: ${BUN_SLEEP_BASELINE})\n\n`);
     process.stderr.write("  Bun.sleep in tests causes timing-dependent flakiness.\n");
     process.stderr.write("  Use FakeClock or dependency injection instead.\n\n");
     for (const v of bunSleepViolations) {
@@ -250,9 +256,12 @@ async function main(): Promise<void> {
     }
     process.stderr.write("  Bad:   await Bun.sleep(50) // then assert\n");
     process.stderr.write("  Good:  inject FakeClock / use configurable delay param\n\n");
+    if (isRegression) {
+      process.stderr.write(`  ❌ Regression: ${bunSleepViolations.length} > baseline ${BUN_SLEEP_BASELINE}. Fix new violations or update BUN_SLEEP_BASELINE.\n\n`);
+    }
   }
 
-  if (setTimeoutViolations.length > 0) {
+  if (setTimeoutViolations.length > 0 || bunSleepViolations.length > BUN_SLEEP_BASELINE) {
     process.exit(1);
   }
 }

--- a/scripts/check-test-timeouts.ts
+++ b/scripts/check-test-timeouts.ts
@@ -1,23 +1,28 @@
 #!/usr/bin/env bun
 /**
- * Lint rule: flag setTimeout with fixed numeric delays in *.spec.ts files.
+ * Lint rule: flag setTimeout with fixed numeric delays AND Bun.sleep with
+ * fixed numeric delays in *.spec.ts files.
  *
- * CLAUDE.md bans setTimeout for waiting in tests: "Never use setTimeout for
- * waiting, always poll with deadlines instead of fixed delays."  This script
- * enforces that rule at commit time.
+ * CLAUDE.md bans these patterns for waiting in tests: "Never use setTimeout
+ * for waiting, always poll with deadlines instead of fixed delays."
+ * Bun.sleep with a literal delay is equally problematic — use FakeClock or
+ * dependency injection for timer-dependent behavior.
  *
  * Patterns flagged:
  *   setTimeout(r, 50)
  *   setTimeout(() => r(null), 50)     ← arrow-function callback
  *   await new Promise((r) => setTimeout(r, 100))
+ *   await Bun.sleep(50)
+ *   Bun.sleep(100)
  *
- * Safe alternative: poll with a deadline helper (e.g. pollUntil / expect.poll)
- * or use Bun.sleep() for the documented exceptions (negative assertions, retry
- * backoff) described in test/CLAUDE.md.
+ * Safe alternatives:
+ *   - poll with a deadline helper (e.g. pollUntil / expect.poll)
+ *   - inject a FakeClock for timer-dependent behavior
+ *   - pass a configurable delay parameter (e.g. Bun.sleep(intervalMs))
  *
  * Detection uses parenthesis-depth tracking so nested parens in callbacks do
- * not cause false negatives, including arrow-function callbacks and setTimeout
- * calls whose arguments span multiple lines.
+ * not cause false negatives, including arrow-function callbacks and calls
+ * whose arguments span multiple lines.
  *
  * Usage:  bun scripts/check-test-timeouts.ts
  *
@@ -136,52 +141,120 @@ export function findViolations(content: string): Array<{ line: number; text: str
   return results;
 }
 
-async function scanDir(dir: string): Promise<Violation[]> {
-  const violations: Violation[] = [];
-  const glob = new Glob("**/*.spec.ts");
+/**
+ * Returns true if the line contains a Bun.sleep call whose argument is a
+ * plain numeric literal (e.g. 50, 1_000).  Named constants and variables are
+ * allowed since they can represent configurable intervals.
+ */
+export function hasBunSleep(line: string): boolean {
+  const re = /\bBun\.sleep\s*\(/g;
+  let match = re.exec(line);
+  while (match !== null) {
+    const parenOpen = match.index + match[0].length - 1;
 
-  for await (const relPath of glob.scan({ cwd: dir, absolute: false })) {
-    if (relPath.endsWith(".d.ts") || relPath.includes("node_modules")) continue;
-    if (relPath === "check-test-timeouts.spec.ts") continue;
-
-    const absPath = `${dir}${relPath}`;
-    const content = await Bun.file(absPath).text();
-
-    for (const { line, text } of findViolations(content)) {
-      violations.push({ file: absPath, line, text });
+    let depth = 1;
+    let i = parenOpen + 1;
+    while (i < line.length && depth > 0) {
+      if (line[i] === "(") depth++;
+      else if (line[i] === ")") depth--;
+      i++;
     }
+
+    if (depth === 0) {
+      const arg = line.slice(parenOpen + 1, i - 1).trim();
+      if (/^[0-9][0-9_]*$/.test(arg)) return true;
+    }
+
+    match = re.exec(line);
+  }
+  return false;
+}
+
+/**
+ * Scans a full file's content for Bun.sleep calls with fixed numeric delays,
+ * tracking parenthesis depth across newlines so multi-line calls are caught.
+ * Returns one entry per violation with a 1-based line number and the trimmed
+ * text of the line where the Bun.sleep keyword appears.
+ */
+export function findBunSleepViolations(content: string): Array<{ line: number; text: string }> {
+  const results: Array<{ line: number; text: string }> = [];
+  const lines = content.split("\n");
+  const re = /\bBun\.sleep\s*\(/g;
+
+  for (let match = re.exec(content); match !== null; match = re.exec(content)) {
+    const parenOpen = match.index + match[0].length - 1;
+
+    let depth = 1;
+    let i = parenOpen + 1;
+    while (i < content.length && depth > 0) {
+      if (content[i] === "(") depth++;
+      else if (content[i] === ")") depth--;
+      i++;
+    }
+
+    if (depth !== 0) continue;
+
+    const arg = content.slice(parenOpen + 1, i - 1).trim();
+    if (!/^[0-9][0-9_]*$/.test(arg)) continue;
+
+    const lineNum = content.slice(0, match.index).split("\n").length;
+    results.push({ line: lineNum, text: lines[lineNum - 1].trim() });
   }
 
-  return violations;
+  return results;
 }
 
 async function main(): Promise<void> {
   const dirs = [PACKAGES_DIR, SCRIPTS_DIR, TEST_DIR];
-  const allViolations: Violation[] = [];
+  const setTimeoutViolations: Violation[] = [];
+  const bunSleepViolations: Violation[] = [];
 
   for (const dir of dirs) {
-    const violations = await scanDir(dir);
-    allViolations.push(...violations);
+    const glob = new Glob("**/*.spec.ts");
+    for await (const relPath of glob.scan({ cwd: dir, absolute: false })) {
+      if (relPath.endsWith(".d.ts") || relPath.includes("node_modules")) continue;
+      if (relPath === "check-test-timeouts.spec.ts") continue;
+      const absPath = `${dir}${relPath}`;
+      const content = await Bun.file(absPath).text();
+      for (const v of findViolations(content)) setTimeoutViolations.push({ file: absPath, ...v });
+      for (const v of findBunSleepViolations(content)) bunSleepViolations.push({ file: absPath, ...v });
+    }
   }
 
-  if (allViolations.length === 0) {
-    process.stderr.write("No setTimeout violations found in test files.\n");
+  if (setTimeoutViolations.length === 0 && bunSleepViolations.length === 0) {
+    process.stderr.write("No setTimeout / Bun.sleep violations found in test files.\n");
     process.exit(0);
   }
 
-  process.stderr.write(`\n  setTimeout with fixed delay: ${allViolations.length} violation(s) found\n\n`);
-  process.stderr.write("  Fixed-delay setTimeout in tests creates flaky, environment-dependent waits.\n");
-  process.stderr.write("  Use a poll-with-deadline helper instead, or Bun.sleep() for negative assertions.\n\n");
-
-  for (const v of allViolations) {
-    process.stderr.write(`  ${v.file}:${v.line}\n`);
-    process.stderr.write(`    ${v.text}\n\n`);
+  if (setTimeoutViolations.length > 0) {
+    process.stderr.write(`\n  setTimeout with fixed delay: ${setTimeoutViolations.length} violation(s) found\n\n`);
+    process.stderr.write("  Fixed-delay setTimeout in tests creates flaky, environment-dependent waits.\n");
+    process.stderr.write("  Use a poll-with-deadline helper instead.\n\n");
+    for (const v of setTimeoutViolations) {
+      process.stderr.write(`  ${v.file}:${v.line}\n`);
+      process.stderr.write(`    ${v.text}\n\n`);
+    }
+    process.stderr.write("  Bad:   await new Promise((r) => setTimeout(r, 50))\n");
+    process.stderr.write("  Good:  await pollUntil(() => condition(), { timeout: 5000 })\n\n");
   }
 
-  process.stderr.write("  Bad:   await new Promise((r) => setTimeout(r, 50))\n");
-  process.stderr.write("  Good:  await pollUntil(() => condition(), { timeout: 5000 })\n\n");
+  if (bunSleepViolations.length > 0) {
+    // WARNING only until existing violations are cleaned up (see #2100).
+    // Once the count reaches zero this block should exit(1) like the setTimeout check.
+    process.stderr.write(`\n  [warn] Bun.sleep with fixed delay: ${bunSleepViolations.length} violation(s) found\n\n`);
+    process.stderr.write("  Bun.sleep in tests causes timing-dependent flakiness.\n");
+    process.stderr.write("  Use FakeClock or dependency injection instead.\n\n");
+    for (const v of bunSleepViolations) {
+      process.stderr.write(`  ${v.file}:${v.line}\n`);
+      process.stderr.write(`    ${v.text}\n\n`);
+    }
+    process.stderr.write("  Bad:   await Bun.sleep(50) // then assert\n");
+    process.stderr.write("  Good:  inject FakeClock / use configurable delay param\n\n");
+  }
 
-  process.exit(1);
+  if (setTimeoutViolations.length > 0) {
+    process.exit(1);
+  }
 }
 
 if (import.meta.main) {

--- a/scripts/check-test-timeouts.ts
+++ b/scripts/check-test-timeouts.ts
@@ -257,7 +257,9 @@ async function main(): Promise<void> {
     process.stderr.write("  Bad:   await Bun.sleep(50) // then assert\n");
     process.stderr.write("  Good:  inject FakeClock / use configurable delay param\n\n");
     if (isRegression) {
-      process.stderr.write(`  ❌ Regression: ${bunSleepViolations.length} > baseline ${BUN_SLEEP_BASELINE}. Fix new violations or update BUN_SLEEP_BASELINE.\n\n`);
+      process.stderr.write(
+        `  ❌ Regression: ${bunSleepViolations.length} > baseline ${BUN_SLEEP_BASELINE}. Fix new violations or update BUN_SLEEP_BASELINE.\n\n`,
+      );
     }
   }
 

--- a/scripts/check-test-timeouts.ts
+++ b/scripts/check-test-timeouts.ts
@@ -27,8 +27,8 @@
  * Usage:  bun scripts/check-test-timeouts.ts
  *
  * Exit codes:
- *   0 — no violations found
- *   1 — violations found
+ *   0 — no violations found (or Bun.sleep count at/below ratchet baseline)
+ *   1 — setTimeout violations found, or Bun.sleep count exceeds baseline
  */
 
 import { Glob } from "bun";
@@ -148,31 +148,11 @@ export function findViolations(content: string): Array<{ line: number; text: str
 
 /**
  * Returns true if the line contains a Bun.sleep call whose argument is a
- * plain numeric literal (e.g. 50, 1_000).  Named constants and variables are
- * allowed since they can represent configurable intervals.
+ * plain numeric literal (e.g. 50, 1_000).  Delegates to findBunSleepViolations
+ * to keep the detection logic in one place.
  */
 export function hasBunSleep(line: string): boolean {
-  const re = /\bBun\.sleep\s*\(/g;
-  let match = re.exec(line);
-  while (match !== null) {
-    const parenOpen = match.index + match[0].length - 1;
-
-    let depth = 1;
-    let i = parenOpen + 1;
-    while (i < line.length && depth > 0) {
-      if (line[i] === "(") depth++;
-      else if (line[i] === ")") depth--;
-      i++;
-    }
-
-    if (depth === 0) {
-      const arg = line.slice(parenOpen + 1, i - 1).trim();
-      if (/^[0-9][0-9_]*$/.test(arg)) return true;
-    }
-
-    match = re.exec(line);
-  }
-  return false;
+  return findBunSleepViolations(line).length > 0;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Extends `scripts/check-test-timeouts.ts` to detect `Bun.sleep(literal)` in `*.spec.ts` files alongside the existing `setTimeout` check
- Adds `hasBunSleep` and `findBunSleepViolations` exports following the same paren-depth-tracking pattern; named-constant and variable args (`Bun.sleep(ms)`, `Bun.sleep(INTERVAL)`) are allowed
- Uses a **ratchet baseline** (`BUN_SLEEP_BASELINE = 138`) so existing violations warn but new ones fail CI immediately. Decrease the baseline as #2100 cleanup proceeds; once it reaches 0, replace with a hard exit(1)

## Test plan

- [ ] `bun test scripts/check-test-timeouts.spec.ts` — 82 tests pass (up from 44)
- [ ] `bun run lint:timeouts` — exits 0 with `[warn]` at baseline; exits 1 if violations exceed baseline
- [ ] `bun typecheck` — clean
- [ ] `bun run lint:check` — clean
- [ ] `hasBunSleep("await Bun.sleep(50)")` → `true`; `hasBunSleep("await Bun.sleep(ms)")` → `false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)