### PR TITLE
fix(manifest): post-merge polish nits from #2086 review (fixes #2090)

### DIFF
--- a/packages/command/src/commands/track.ts
+++ b/packages/command/src/commands/track.ts
@@ -21,7 +21,7 @@ import {
 } from "@mcp-cli/core";
 import { c, printError } from "../output";
 
-/** Load a manifest from the given directory, swallowing parse errors so they don't break CLI commands. */
+/** Load a manifest from the given directory, swallowing parse errors so they don't break CLI commands. Rethrows ManifestVersionError so callers can report version mismatches explicitly. */
 function tryLoadManifest(dir: string): Manifest | null {
   try {
     return loadManifest(dir)?.manifest ?? null;

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -242,9 +242,15 @@ export type ManifestState = z.infer<typeof ManifestStateSchema>;
  */
 export const DEFAULT_RUNS_ON = "main";
 
+/**
+ * Manifest schema version this binary was compiled against. A manifest with
+ * `version > MANIFEST_SCHEMA_VERSION` requires a newer binary.
+ */
+export const MANIFEST_SCHEMA_VERSION = 1;
+
 export const ManifestSchema = z
   .object({
-    version: z.number().int().min(1).default(1),
+    version: z.number().int().min(1).default(MANIFEST_SCHEMA_VERSION),
     runsOn: z.string().min(1).optional(),
     worktree: ManifestWorktreeSchema.optional(),
     state: ManifestStateSchema.optional(),
@@ -272,13 +278,7 @@ export class ManifestError extends Error {
   }
 }
 
-/**
- * Manifest schema version this binary was compiled against. A manifest with
- * `version > MANIFEST_SCHEMA_VERSION` requires a newer binary.
- */
-export const MANIFEST_SCHEMA_VERSION = 1;
-
-/** Thrown when the manifest declares a schema version the running daemon doesn't support. */
+/** Thrown when the manifest declares a schema version the running binary doesn't support. */
 export class ManifestVersionError extends ManifestError {
   constructor(
     public readonly manifestVersion: number,
@@ -286,7 +286,7 @@ export class ManifestVersionError extends ManifestError {
     path: string,
   ) {
     super(
-      `manifest schema version ${manifestVersion} requires a newer mcx binary (this daemon supports up to version ${supportedVersion}). To update: bun run build && mcx shutdown && mcx status`,
+      `manifest schema version ${manifestVersion} requires a newer mcx binary (this binary supports up to version ${supportedVersion}). To update: bun run build && mcx shutdown && mcx status`,
       path,
     );
     this.name = "ManifestVersionError";


### PR DESCRIPTION
## Summary
- Move `MANIFEST_SCHEMA_VERSION` before `ManifestSchema` so the schema's `.default(1)` references the constant — single source of truth
- Change `ManifestVersionError` message from "this daemon supports up to version" to "this binary supports up to version" — the class lives in `@mcp-cli/core` and surfaces in non-daemon CLI contexts
- Update `tryLoadManifest` docstring in `track.ts` to accurately reflect that `ManifestVersionError` is rethrown (not swallowed with the other parse errors)

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes (no fixes applied)
- [x] `bun test packages/core/src/manifest.spec.ts packages/command/src/commands/track.spec.ts` — 208 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)