### PR TITLE
fix(resume): skip merge check for branches with zero commits ahead (fixes #2082)

### DIFF
--- a/packages/command/src/commands/agent.spec.ts
+++ b/packages/command/src/commands/agent.spec.ts
@@ -769,6 +769,17 @@ describe("parseAgentResumeArgs", () => {
     expect(result.error).toBeUndefined();
   });
 
+  test("parses --force flag", () => {
+    const result = parseAgentResumeArgs(["my-wt", "--force"]);
+    expect(result.force).toBe(true);
+    expect(result.target).toBe("my-wt");
+  });
+
+  test("defaults force to false", () => {
+    const result = parseAgentResumeArgs(["my-wt"]);
+    expect(result.force).toBe(false);
+  });
+
   test("errors on --fresh with session ID", () => {
     const result = parseAgentResumeArgs(["my-wt", "session-abc", "--fresh"]);
     expect(result.error).toContain("--fresh cannot be combined");
@@ -876,7 +887,7 @@ describe("agent codex resume", () => {
     }
   });
 
-  test("skips merged branches with exit 1 in single-target mode", async () => {
+  test("skips merged branches with commits ahead in single-target mode", async () => {
     const deps = makeResumeDeps({
       exec: mock((cmd: string[]) => {
         const cmdStr = cmd.join(" ");
@@ -885,6 +896,9 @@ describe("agent codex resume", () => {
         }
         if (cmdStr.includes("branch --merged")) {
           return { stdout: "  main\n  feat/issue-42-fix-bug\n", stderr: "", exitCode: 0 };
+        }
+        if (cmdStr.includes("rev-list") && cmdStr.includes("--count")) {
+          return { stdout: "3\n", stderr: "", exitCode: 0 };
         }
         return { stdout: "", stderr: "", exitCode: 0 };
       }),
@@ -893,7 +907,7 @@ describe("agent codex resume", () => {
     expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("already merged"));
   });
 
-  test("skips merged branches without exit in --all mode", async () => {
+  test("skips merged branches with commits ahead without exit in --all mode", async () => {
     const deps = makeResumeDeps({
       exec: mock((cmd: string[]) => {
         const cmdStr = cmd.join(" ");
@@ -902,6 +916,9 @@ describe("agent codex resume", () => {
         }
         if (cmdStr.includes("branch --merged")) {
           return { stdout: "  main\n  feat/issue-42-fix-bug\n", stderr: "", exitCode: 0 };
+        }
+        if (cmdStr.includes("rev-list") && cmdStr.includes("--count")) {
+          return { stdout: "3\n", stderr: "", exitCode: 0 };
         }
         return { stdout: "", stderr: "", exitCode: 0 };
       }),
@@ -916,6 +933,62 @@ describe("agent codex resume", () => {
         (c: unknown[]) => c[0] === "codex_prompt",
       );
       expect(promptCalls.length).toBe(0);
+    } finally {
+      mc.restore();
+    }
+  });
+
+  test("resumes merged branch with zero commits ahead (review/QA worktree)", async () => {
+    const deps = makeResumeDeps({
+      exec: mock((cmd: string[]) => {
+        const cmdStr = cmd.join(" ");
+        if (cmdStr.includes("worktree list")) {
+          return { stdout: WORKTREE_LIST_PORCELAIN, stderr: "", exitCode: 0 };
+        }
+        if (cmdStr.includes("branch --merged")) {
+          return { stdout: "  main\n  feat/issue-42-fix-bug\n", stderr: "", exitCode: 0 };
+        }
+        if (cmdStr.includes("rev-list") && cmdStr.includes("--count")) {
+          return { stdout: "0\n", stderr: "", exitCode: 0 };
+        }
+        if (cmdStr.includes("symbolic-ref")) {
+          return { stdout: "refs/heads/main\n", stderr: "", exitCode: 0 };
+        }
+        return { stdout: "", stderr: "", exitCode: 0 };
+      }),
+    });
+    const mc = mockConsole();
+    try {
+      await cmdAgent(["codex", "resume", "codex-wt1"], deps);
+      expect(deps.printError).not.toHaveBeenCalledWith(expect.stringContaining("already merged"));
+    } finally {
+      mc.restore();
+    }
+  });
+
+  test("--force bypasses merge check on truly-merged branch", async () => {
+    const deps = makeResumeDeps({
+      exec: mock((cmd: string[]) => {
+        const cmdStr = cmd.join(" ");
+        if (cmdStr.includes("worktree list")) {
+          return { stdout: WORKTREE_LIST_PORCELAIN, stderr: "", exitCode: 0 };
+        }
+        if (cmdStr.includes("branch --merged")) {
+          return { stdout: "  main\n  feat/issue-42-fix-bug\n", stderr: "", exitCode: 0 };
+        }
+        if (cmdStr.includes("rev-list") && cmdStr.includes("--count")) {
+          return { stdout: "5\n", stderr: "", exitCode: 0 };
+        }
+        if (cmdStr.includes("symbolic-ref")) {
+          return { stdout: "refs/heads/main\n", stderr: "", exitCode: 0 };
+        }
+        return { stdout: "", stderr: "", exitCode: 0 };
+      }),
+    });
+    const mc = mockConsole();
+    try {
+      await cmdAgent(["codex", "resume", "codex-wt1", "--force"], deps);
+      expect(deps.printError).not.toHaveBeenCalledWith(expect.stringContaining("already merged"));
     } finally {
       mc.restore();
     }

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -1235,7 +1235,7 @@ export function parseAgentResumeArgs(args: string[]): AgentResumeArgs {
     error = "--fresh cannot be combined with an explicit session ID";
   } else if (!all && !target) {
     error =
-      "Usage: mcx agent <provider> resume <worktree> [--fresh] [--model M] [--allow tools...]\n       mcx agent <provider> resume --all";
+      "Usage: mcx agent <provider> resume <worktree> [--fresh] [--force] [--model M] [--allow tools...] [--wait] [--timeout ms]\n       mcx agent <provider> resume --all";
   }
 
   return { target, sessionId, all, fresh, force, allow, model, wait, timeout, error };

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -1173,6 +1173,8 @@ interface AgentResumeArgs {
   sessionId: string | undefined;
   all: boolean;
   fresh: boolean;
+  /** Bypass the branch-merged pre-flight check. */
+  force: boolean;
   allow: string[];
   model: string | undefined;
   wait: boolean;
@@ -1183,6 +1185,7 @@ interface AgentResumeArgs {
 export function parseAgentResumeArgs(args: string[]): AgentResumeArgs {
   let all = false;
   let fresh = false;
+  let force = false;
   let wait = false;
   let timeout: number | undefined;
   let model: string | undefined;
@@ -1196,6 +1199,8 @@ export function parseAgentResumeArgs(args: string[]): AgentResumeArgs {
       all = true;
     } else if (arg === "--fresh") {
       fresh = true;
+    } else if (arg === "--force") {
+      force = true;
     } else if (arg === "--wait") {
       wait = true;
     } else if (arg === "--timeout" || arg === "-t") {
@@ -1233,7 +1238,7 @@ export function parseAgentResumeArgs(args: string[]): AgentResumeArgs {
       "Usage: mcx agent <provider> resume <worktree> [--fresh] [--model M] [--allow tools...]\n       mcx agent <provider> resume --all";
   }
 
-  return { target, sessionId, all, fresh, allow, model, wait, timeout, error };
+  return { target, sessionId, all, fresh, force, allow, model, wait, timeout, error };
 }
 
 async function agentResume(
@@ -1352,9 +1357,11 @@ async function resumeAgentWorktree(
     d.printError(`Warning: worktree at ${wt.path} has detached HEAD — skipping merge check`);
   }
 
-  // Check if branch is already merged into the default branch
+  // Check if branch is already merged into the default branch.
+  // Skip when --force is set or when the branch has zero commits ahead
+  // (review/QA/pre-commit worktrees that are trivially "merged").
   const defaultBranch = getDefaultBranch(d, wt.path);
-  if (branch) {
+  if (branch && !parsed.force) {
     const { stdout: mergedOutput, exitCode: mergedExit } = d.exec([
       "git",
       "-C",
@@ -1366,10 +1373,21 @@ async function resumeAgentWorktree(
     if (mergedExit === 0) {
       const mergedBranches = mergedOutput.split("\n").map((l) => l.trim().replace(/^\* /, ""));
       if (mergedBranches.includes(branch)) {
-        d.printError(
-          `Skipping "${branch}" — already merged into ${defaultBranch}. Use "mcx agent ${provider.name} worktrees --prune" to clean up.`,
-        );
-        return true;
+        const { stdout: countOutput } = d.exec([
+          "git",
+          "-C",
+          wt.path,
+          "rev-list",
+          "--count",
+          `${defaultBranch}..${branch}`,
+        ]);
+        const commitsAhead = Number.parseInt(countOutput.trim(), 10) || 0;
+        if (commitsAhead > 0) {
+          d.printError(
+            `Skipping "${branch}" — already merged into ${defaultBranch}. Use "mcx agent ${provider.name} worktrees --prune" to clean up.`,
+          );
+          return true;
+        }
       }
     }
   }

--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -4272,6 +4272,17 @@ describe("parseResumeArgs", () => {
     expect(result.target).toBe("my-wt");
   });
 
+  test("parses --force flag", () => {
+    const result = parseResumeArgs(["my-wt", "--force"]);
+    expect(result.force).toBe(true);
+    expect(result.target).toBe("my-wt");
+  });
+
+  test("defaults force to false", () => {
+    const result = parseResumeArgs(["my-wt"]);
+    expect(result.force).toBe(false);
+  });
+
   test("parses second positional as session ID", () => {
     const result = parseResumeArgs(["my-wt", "abc-session-uuid"]);
     expect(result.target).toBe("my-wt");
@@ -4455,7 +4466,7 @@ describe("cmdClaude resume", () => {
     expect(errOutput).toContain("already has an active session");
   });
 
-  test("skips already-merged branches", async () => {
+  test("skips already-merged branches with commits ahead", async () => {
     const wtPath = `${worktreeParent}/claude-merged`;
     const exec = mock((cmd: string[]) => {
       if (cmd.includes("worktree") && cmd.includes("list")) {
@@ -4468,6 +4479,9 @@ describe("cmdClaude resume", () => {
       if (cmd.includes("--merged")) {
         return { stdout: "  main\n  feat/issue-5-done\n", stderr: "", exitCode: 0 };
       }
+      if (cmd.includes("rev-list") && cmd.includes("--count")) {
+        return { stdout: "3\n", stderr: "", exitCode: 0 };
+      }
       return { stdout: "", stderr: "", exitCode: 0 };
     });
     const callTool = mock(async (tool: string) => {
@@ -4479,6 +4493,66 @@ describe("cmdClaude resume", () => {
     await cmdClaude(["resume", "claude-merged"], deps);
     const errOutput = printError.mock.calls.map((c: unknown[]) => c[0]).join("\n");
     expect(errOutput).toContain("already merged into main");
+  });
+
+  test("resumes merged branch with zero commits ahead (review/QA worktree)", async () => {
+    const wtPath = `${worktreeParent}/claude-review`;
+    const exec = mock((cmd: string[]) => {
+      if (cmd.includes("worktree") && cmd.includes("list")) {
+        return {
+          stdout: `worktree ${cwd}\nHEAD abc\nbranch refs/heads/main\n\nworktree ${wtPath}\nHEAD def\nbranch refs/heads/worktree-claude-review\n`,
+          stderr: "",
+          exitCode: 0,
+        };
+      }
+      if (cmd.includes("--merged")) {
+        return { stdout: "  main\n  worktree-claude-review\n", stderr: "", exitCode: 0 };
+      }
+      if (cmd.includes("rev-list") && cmd.includes("--count")) {
+        return { stdout: "0\n", stderr: "", exitCode: 0 };
+      }
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const callTool: ClaudeDeps["callTool"] = mock(async (tool: string, _args: Record<string, unknown>) => {
+      if (tool === "claude_session_list") return toolResult([]);
+      if (tool === "claude_prompt") return toolResult({ sessionId: "new-session-id", seq: 1 });
+      return toolResult({});
+    });
+    const deps = makeDeps({ exec, callTool });
+    await cmdClaude(["resume", "claude-review"], deps);
+    const errOutput = (deps.printError as ReturnType<typeof mock>).mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    expect(errOutput).not.toContain("already merged");
+    expect(callTool).toHaveBeenCalledWith("claude_prompt", expect.objectContaining({ resumeSessionId: "continue" }));
+  });
+
+  test("--force bypasses merge check on truly-merged branch", async () => {
+    const wtPath = `${worktreeParent}/claude-force`;
+    const exec = mock((cmd: string[]) => {
+      if (cmd.includes("worktree") && cmd.includes("list")) {
+        return {
+          stdout: `worktree ${cwd}\nHEAD abc\nbranch refs/heads/main\n\nworktree ${wtPath}\nHEAD def\nbranch refs/heads/feat/issue-99-done\n`,
+          stderr: "",
+          exitCode: 0,
+        };
+      }
+      if (cmd.includes("--merged")) {
+        return { stdout: "  main\n  feat/issue-99-done\n", stderr: "", exitCode: 0 };
+      }
+      if (cmd.includes("rev-list") && cmd.includes("--count")) {
+        return { stdout: "5\n", stderr: "", exitCode: 0 };
+      }
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const callTool: ClaudeDeps["callTool"] = mock(async (tool: string, _args: Record<string, unknown>) => {
+      if (tool === "claude_session_list") return toolResult([]);
+      if (tool === "claude_prompt") return toolResult({ sessionId: "new-session-id", seq: 1 });
+      return toolResult({});
+    });
+    const deps = makeDeps({ exec, callTool });
+    await cmdClaude(["resume", "claude-force", "--force"], deps);
+    const errOutput = (deps.printError as ReturnType<typeof mock>).mock.calls.map((c: unknown[]) => c[0]).join("\n");
+    expect(errOutput).not.toContain("already merged");
+    expect(callTool).toHaveBeenCalledWith("claude_prompt", expect.objectContaining({ resumeSessionId: "continue" }));
   });
 
   test("default resume restores conversation history via resumeSessionId", async () => {

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -653,7 +653,7 @@ export function parseResumeArgs(args: string[]): ResumeArgs {
     error = "--fresh cannot be combined with an explicit session ID";
   } else if (!all && !target) {
     error =
-      "Usage: mcx claude resume <worktree> [session-id] [--fresh] [--model M] [--allow tools...]\n       mcx claude resume --all";
+      "Usage: mcx claude resume <worktree> [session-id] [--fresh] [--force] [--model M] [--allow tools...] [--wait] [--timeout ms]\n       mcx claude resume --all";
   }
 
   return { target, sessionId, all, fresh, force, allow, model, wait, timeout, error };

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -590,6 +590,8 @@ export interface ResumeArgs {
   all: boolean;
   /** Skip conversation history restoration, use git-context prompt instead. */
   fresh: boolean;
+  /** Bypass the branch-merged pre-flight check. */
+  force: boolean;
   allow: string[];
   model: string | undefined;
   wait: boolean;
@@ -600,6 +602,7 @@ export interface ResumeArgs {
 export function parseResumeArgs(args: string[]): ResumeArgs {
   let all = false;
   let fresh = false;
+  let force = false;
   let model: string | undefined;
   let wait = false;
   let timeout: number | undefined;
@@ -613,6 +616,8 @@ export function parseResumeArgs(args: string[]): ResumeArgs {
       all = true;
     } else if (arg === "--fresh") {
       fresh = true;
+    } else if (arg === "--force") {
+      force = true;
     } else if (arg === "--model" || arg === "-m") {
       const val = args[++i];
       if (!val) {
@@ -651,7 +656,7 @@ export function parseResumeArgs(args: string[]): ResumeArgs {
       "Usage: mcx claude resume <worktree> [session-id] [--fresh] [--model M] [--allow tools...]\n       mcx claude resume --all";
   }
 
-  return { target, sessionId, all, fresh, allow, model, wait, timeout, error };
+  return { target, sessionId, all, fresh, force, allow, model, wait, timeout, error };
 }
 
 /** Extract issue number from branch name convention: feat/issue-N-slug, fix/issue-N-slug, etc. */
@@ -816,23 +821,38 @@ async function resumeWorktree(
 ): Promise<void> {
   const branch = wt.branch ?? "unknown";
 
-  // Check if branch is already merged into the default branch
-  const defaultBranch = getDefaultBranch(d, wt.path);
-  const { stdout: mergedOutput, exitCode: mergedExit } = d.exec([
-    "git",
-    "-C",
-    wt.path,
-    "branch",
-    "--merged",
-    defaultBranch,
-  ]);
-  if (mergedExit === 0) {
-    const mergedBranches = mergedOutput.split("\n").map((l) => l.trim().replace(/^\* /, ""));
-    if (mergedBranches.includes(branch)) {
-      d.printError(
-        `Skipping "${branch}" — already merged into ${defaultBranch}. Use "mcx claude worktrees --prune" to clean up.`,
-      );
-      return;
+  // Check if branch is already merged into the default branch.
+  // Skip the check entirely when --force is set or when the branch has zero
+  // commits ahead (review/QA/pre-commit worktrees that are trivially "merged").
+  if (!parsed.force) {
+    const defaultBranch = getDefaultBranch(d, wt.path);
+    const { stdout: mergedOutput, exitCode: mergedExit } = d.exec([
+      "git",
+      "-C",
+      wt.path,
+      "branch",
+      "--merged",
+      defaultBranch,
+    ]);
+    if (mergedExit === 0) {
+      const mergedBranches = mergedOutput.split("\n").map((l) => l.trim().replace(/^\* /, ""));
+      if (mergedBranches.includes(branch)) {
+        const { stdout: countOutput } = d.exec([
+          "git",
+          "-C",
+          wt.path,
+          "rev-list",
+          "--count",
+          `${defaultBranch}..${branch}`,
+        ]);
+        const commitsAhead = Number.parseInt(countOutput.trim(), 10) || 0;
+        if (commitsAhead > 0) {
+          d.printError(
+            `Skipping "${branch}" — already merged into ${defaultBranch}. Use "mcx claude worktrees --prune" to clean up.`,
+          );
+          return;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- `mcx claude resume` and `mcx agent resume` now skip the "already merged" check when the branch has zero commits ahead of the default branch — this covers review/QA scratch worktrees and impl worktrees that died before their first commit
- Branches with commits-ahead > 0 that appear in `git branch --merged` still get the prune warning (squash-merged feature branches)
- Added `--force` flag to both resume code paths to bypass the merge check entirely for rare edge cases

## Test plan
- [x] Existing "skips already-merged branches" tests updated to mock `rev-list --count` returning >0 — still pass
- [x] New test: merged branch with 0 commits ahead is NOT skipped (proceeds to resume)
- [x] New test: `--force` bypasses merge check even with commits-ahead > 0
- [x] New parser tests for `--force` flag in both `parseResumeArgs` and `parseAgentResumeArgs`
- [x] Full test suite: 7274 pass, 0 fail
- [x] Typecheck + lint + coverage all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)