### PR TITLE
feat(site): log lock-contention warnings when browser operations queue (fixes #1707)

### DIFF
--- a/packages/daemon/src/site-worker.ts
+++ b/packages/daemon/src/site-worker.ts
@@ -101,7 +101,7 @@ async function snapshotBrowser(): Promise<BrowserEngine | null> {
   return withBrowserLock(async () => {
     resetIfBrowserDied();
     return browser;
-  });
+  }, "snapshotBrowser");
 }
 
 // ── Lazy browser load ──
@@ -383,7 +383,7 @@ async function tryAutoRestartBrowser(): Promise<boolean> {
     for (const s of configs) sitesOpenInBrowser.add(s.name);
 
     return { eng, configs };
-  });
+  }, "tryAutoRestartBrowser");
 
   if (locked === false) return false;
   if (locked === null) return true; // another concurrent call already restarted; skip wiggle
@@ -461,7 +461,7 @@ async function handleBrowserStart(args: Record<string, unknown>): Promise<ToolRe
     lastBrowserSession = { engine, siteNames: sites.map((s) => s.name) };
 
     return ok({ ok: true, engine, sites: eng.getSiteNames(), results: startResults });
-  });
+  }, "handleBrowserStart");
 }
 
 async function handleDisconnect(): Promise<ToolResult> {
@@ -474,7 +474,7 @@ async function handleDisconnect(): Promise<ToolResult> {
     sitesOpenInBrowser.clear();
     lastBrowserSession = null; // intentional stop — don't auto-restart on next call
     return ok({ ok: true });
-  });
+  }, "handleDisconnect");
 }
 
 function handleSniff(args: Record<string, unknown>): ToolResult {

--- a/packages/daemon/src/site/browser-lock.spec.ts
+++ b/packages/daemon/src/site/browser-lock.spec.ts
@@ -1,6 +1,117 @@
 import { describe, expect, test } from "bun:test";
 import { createBrowserLock } from "./browser-lock";
 
+describe("createBrowserLock contention warnings", () => {
+  test("no warning when there is no contention (first caller acquires immediately)", async () => {
+    const warnings: string[] = [];
+    const withLock = createBrowserLock({ warnThresholdMs: 0, warn: (msg) => warnings.push(msg) });
+
+    await withLock(async () => {}, "callerA");
+
+    // First caller never waits — no prior lock to queue behind.
+    expect(warnings).toHaveLength(0);
+  });
+
+  test("emits warning with caller label when second caller waits for lock", async () => {
+    const warnings: string[] = [];
+    const withLock = createBrowserLock({ warnThresholdMs: 0, warn: (msg) => warnings.push(msg) });
+
+    let resolveFirst!: () => void;
+    const firstDone = new Promise<void>((r) => {
+      resolveFirst = r;
+    });
+
+    const first = withLock(async () => {
+      await firstDone;
+    }, "callerFirst");
+
+    await Promise.resolve();
+
+    const second = withLock(async () => {}, "callerSecond");
+
+    resolveFirst();
+    await Promise.all([first, second]);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/^\[site-worker\] browser-lock: waiting \d+ms for lock \(caller: callerSecond\)$/);
+  });
+
+  test("emits warning without caller suffix when no label is provided", async () => {
+    const warnings: string[] = [];
+    const withLock = createBrowserLock({ warnThresholdMs: 0, warn: (msg) => warnings.push(msg) });
+
+    let resolveFirst!: () => void;
+    const firstDone = new Promise<void>((r) => {
+      resolveFirst = r;
+    });
+
+    const first = withLock(async () => {
+      await firstDone;
+    });
+
+    await Promise.resolve();
+
+    const second = withLock(async () => {});
+
+    resolveFirst();
+    await Promise.all([first, second]);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/^\[site-worker\] browser-lock: waiting \d+ms for lock$/);
+  });
+
+  test("does not warn when wait is at or below threshold", async () => {
+    const warnings: string[] = [];
+    // warnThresholdMs: 1000 — any realistic in-test wait will be < 1s
+    const withLock = createBrowserLock({ warnThresholdMs: 1000, warn: (msg) => warnings.push(msg) });
+
+    let resolveFirst!: () => void;
+    const firstDone = new Promise<void>((r) => {
+      resolveFirst = r;
+    });
+
+    const first = withLock(async () => {
+      await firstDone;
+    }, "callerFirst");
+
+    await Promise.resolve();
+
+    const second = withLock(async () => {}, "callerSecond");
+
+    resolveFirst();
+    await Promise.all([first, second]);
+
+    // Wait was sub-millisecond — should not reach 1000ms threshold.
+    expect(warnings).toHaveLength(0);
+  });
+
+  test("third queued caller warns independently", async () => {
+    const warnings: string[] = [];
+    const withLock = createBrowserLock({ warnThresholdMs: 0, warn: (msg) => warnings.push(msg) });
+
+    let resolveFirst!: () => void;
+    const firstDone = new Promise<void>((r) => {
+      resolveFirst = r;
+    });
+
+    const first = withLock(async () => {
+      await firstDone;
+    }, "callerFirst");
+
+    await Promise.resolve();
+
+    const second = withLock(async () => {}, "callerSecond");
+    const third = withLock(async () => {}, "callerThird");
+
+    resolveFirst();
+    await Promise.all([first, second, third]);
+
+    expect(warnings).toHaveLength(2);
+    expect(warnings[0]).toContain("callerSecond");
+    expect(warnings[1]).toContain("callerThird");
+  });
+});
+
 describe("createBrowserLock", () => {
   test("sequential calls execute in order", async () => {
     const withLock = createBrowserLock();

--- a/packages/daemon/src/site/browser-lock.ts
+++ b/packages/daemon/src/site/browser-lock.ts
@@ -1,5 +1,5 @@
 interface BrowserLockOptions {
-  /** Emit a warning when a caller waits longer than this for the lock. Default: 200ms. */
+  /** Emit a warning when a caller waits at least this long for the lock. Default: 200ms. Use 0 to warn on any contention. */
   warnThresholdMs?: number;
   /** Override the warning sink. Default: console.warn. Injected for testing. */
   warn?: (msg: string) => void;
@@ -10,9 +10,9 @@ interface BrowserLockOptions {
  * no two calls execute concurrently. The lock is released in `finally` so
  * throws still unblock waiting callers.
  *
- * Emits a structured warning when a caller waits longer than `warnThresholdMs`
+ * Emits a structured warning when a caller waits at least `warnThresholdMs`
  * (default 200ms) so contention is visible in the daemon log without a code
- * change to reproduce.
+ * change to reproduce. Set `warnThresholdMs: 0` to warn on any contention.
  */
 export function createBrowserLock(options: BrowserLockOptions = {}) {
   const { warnThresholdMs = 200, warn = (msg: string) => console.warn(msg) } = options;
@@ -33,7 +33,7 @@ export function createBrowserLock(options: BrowserLockOptions = {}) {
       const start = performance.now();
       await prev;
       const waited = performance.now() - start;
-      if (contended && waited > warnThresholdMs) {
+      if (contended && waited >= warnThresholdMs) {
         const callerSuffix = label ? ` (caller: ${label})` : "";
         warn(`[site-worker] browser-lock: waiting ${Math.round(waited)}ms for lock${callerSuffix}`);
       }

--- a/packages/daemon/src/site/browser-lock.ts
+++ b/packages/daemon/src/site/browser-lock.ts
@@ -1,20 +1,45 @@
+interface BrowserLockOptions {
+  /** Emit a warning when a caller waits longer than this for the lock. Default: 200ms. */
+  warnThresholdMs?: number;
+  /** Override the warning sink. Default: console.warn. Injected for testing. */
+  warn?: (msg: string) => void;
+}
+
 /**
  * Creates a serial async mutex. All callers queue behind the previous holder;
  * no two calls execute concurrently. The lock is released in `finally` so
  * throws still unblock waiting callers.
+ *
+ * Emits a structured warning when a caller waits longer than `warnThresholdMs`
+ * (default 200ms) so contention is visible in the daemon log without a code
+ * change to reproduce.
  */
-export function createBrowserLock() {
+export function createBrowserLock(options: BrowserLockOptions = {}) {
+  const { warnThresholdMs = 200, warn = (msg: string) => console.warn(msg) } = options;
   let lock: Promise<void> = Promise.resolve();
-  return async function withBrowserLock<T>(fn: () => Promise<T>): Promise<T> {
+  // Tracks callers currently inside withBrowserLock (holding or waiting). Used to
+  // distinguish genuine contention (queueSize > 0 on entry) from the initial
+  // resolved-promise await that every first caller goes through.
+  let queueSize = 0;
+  return async function withBrowserLock<T>(fn: () => Promise<T>, label?: string): Promise<T> {
+    const contended = queueSize > 0;
+    queueSize++;
     const prev = lock;
     let release!: () => void;
     lock = new Promise<void>((r) => {
       release = r;
     });
     try {
+      const start = performance.now();
       await prev;
+      const waited = performance.now() - start;
+      if (contended && waited > warnThresholdMs) {
+        const callerSuffix = label ? ` (caller: ${label})` : "";
+        warn(`[site-worker] browser-lock: waiting ${Math.round(waited)}ms for lock${callerSuffix}`);
+      }
       return await fn();
     } finally {
+      queueSize--;
       release();
     }
   };


### PR DESCRIPTION
## Summary
- Adds contention observability to `createBrowserLock`: emits `console.warn` when a caller waits longer than the threshold (default 200ms) for the lock
- Log format: `[site-worker] browser-lock: waiting <N>ms for lock (caller: handleWiggle)`
- Uses a `queueSize` counter to distinguish genuine contention from the initial resolved-promise await the first caller goes through; all four `withBrowserLock` call sites now pass caller labels
- `warnThresholdMs` and `warn` are injectable for testing (no timing-sensitive code in tests)

## Test plan
- [ ] `bun test packages/daemon/src/site/browser-lock.spec.ts` — 10 tests pass including 5 new warning tests
- [ ] `bun typecheck` passes
- [ ] `bun lint` passes
- [ ] New tests cover: no warning on first caller, warning fires with contention at threshold 0, warning includes caller label, warning omitted when below threshold, independent warnings for N queued callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)