### PR TITLE
docs: add waitForEvent to ambient mcp-cli.d.ts template in docs/phases.md (fixes #2088)

### DIFF
--- a/docs/phases.md
+++ b/docs/phases.md
@@ -177,6 +177,28 @@ declare module "mcp-cli" {
 
   export type McpProxy = Record<string, Record<string, (args?: Record<string, unknown>) => Promise<unknown>>>;
 
+  export interface EventFilterSpec {
+    subscribe?: string[];
+    type?: string | string[];
+    session?: string;
+    pr?: number;
+    workItem?: string;
+    src?: string;
+    phase?: string;
+  }
+
+  export interface MonitorEvent {
+    seq: number;
+    ts: string;
+    src: string;
+    event: string;
+    category: string;
+    workItemId?: string;
+    sessionId?: string;
+    prNumber?: number;
+    [key: string]: unknown;
+  }
+
   export interface AliasContext {
     mcp: McpProxy;
     args: Record<string, string>;
@@ -188,6 +210,7 @@ declare module "mcp-cli" {
     workItem: AliasWorkItemInfo | null;
     repoRoot: string;
     signal: AbortSignal;
+    waitForEvent(filter: EventFilterSpec, opts?: { timeoutMs?: number; since?: number }): Promise<MonitorEvent>;
   }
 
   export interface AliasDefinition<I = unknown, O = unknown> {


### PR DESCRIPTION
## Summary
- Adds `EventFilterSpec` and `MonitorEvent` interfaces to the ambient `.d.ts` template in `docs/phases.md`
- Adds `waitForEvent` method to the `AliasContext` interface in the same template
- Phase script authors who copy-paste this template as their type scaffold will no longer get `TS2339: Property 'waitForEvent' does not exist on type 'AliasContext'`

## Test plan
- [ ] Docs-only change; typecheck and lint pass clean
- [ ] New interfaces match the authoritative definitions in `packages/core/src/alias.ts:180` and `packages/core/src/alias-bundle.ts:490-520`

🤖 Generated with [Claude Code](https://claude.com/claude-code)