### PR TITLE
fix(docs): add MonitorCategory alias and waitForEvent row to phases.md (fixes #2116)

### DIFF
--- a/docs/phases.md
+++ b/docs/phases.md
@@ -177,8 +177,10 @@ declare module "mcp-cli" {
 
   export type McpProxy = Record<string, Record<string, (args?: Record<string, unknown>) => Promise<unknown>>>;
 
+  export type MonitorCategory = string;
+
   export interface EventFilterSpec {
-    subscribe?: string[];
+    subscribe?: MonitorCategory[];
     type?: string | string[];
     session?: string;
     pr?: number;
@@ -192,7 +194,7 @@ declare module "mcp-cli" {
     ts: string;
     src: string;
     event: string;
-    category: string;
+    category: MonitorCategory;
     workItemId?: string;
     sessionId?: string;
     prNumber?: number;
@@ -263,6 +265,7 @@ exactly like normal aliases. The handler receives a scoped `ctx`:
 | `ctx.args` | CLI `--key value` pairs |
 | `ctx.file`, `ctx.json` | Read utility helpers |
 | `ctx.cache` | TTL-bounded cached producer |
+| `ctx.waitForEvent` | Await a matching daemon event (`EventFilterSpec`); optional `timeoutMs` and `since` seq |
 
 Bun globals (`Bun.spawnSync`, `fetch`) are available — phases typically shell
 out to `gh`, `git`, or project tooling.

--- a/docs/phases.md
+++ b/docs/phases.md
@@ -177,7 +177,21 @@ declare module "mcp-cli" {
 
   export type McpProxy = Record<string, Record<string, (args?: Record<string, unknown>) => Promise<unknown>>>;
 
-  export type MonitorCategory = string;
+  export type MonitorCategory =
+    | "session"
+    | "work_item"
+    | "ci"
+    | "copilot"
+    | "review"
+    | "issue"
+    | "mail"
+    | "heartbeat"
+    | "worker"
+    | "daemon"
+    | "gc"
+    | "cost"
+    | "quota"
+    | "automation";
 
   export interface EventFilterSpec {
     subscribe?: MonitorCategory[];
@@ -266,6 +280,7 @@ exactly like normal aliases. The handler receives a scoped `ctx`:
 | `ctx.file`, `ctx.json` | Read utility helpers |
 | `ctx.cache` | TTL-bounded cached producer |
 | `ctx.waitForEvent` | Await a matching daemon event (`EventFilterSpec`); optional `timeoutMs` and `since` seq |
+| `ctx.signal` | `AbortSignal` fired when the phase runner is cancelled or times out |
 
 Bun globals (`Bun.spawnSync`, `fetch`) are available — phases typically shell
 out to `gh`, `git`, or project tooling.


### PR DESCRIPTION
## Summary
- Add `export type MonitorCategory = string;` to the ambient `mcp-cli.d.ts` template in `docs/phases.md`, so `EventFilterSpec.subscribe` and `MonitorEvent.category` use the named type instead of bare `string`
- Update `EventFilterSpec.subscribe?: string[]` → `MonitorCategory[]` and `MonitorEvent.category: string` → `MonitorCategory` to match the core types in `packages/core/src/event-filter.ts` and `packages/core/src/monitor-event.ts`
- Add missing `ctx.waitForEvent` row to the Phase handler API table

## Test plan
- [ ] `bun typecheck` passes
- [ ] `bun lint` passes
- [ ] Ambient template now matches core types (`MonitorCategory` used consistently)
- [ ] Phase handler API table has a complete row for `ctx.waitForEvent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)