### PR TITLE
fix(mail): rename MAIL_RECEIVED/publishMailReceived to MAIL_SENT/publishMailSent (fixes #1725)

### DIFF
--- a/packages/command/src/commands/monitor.spec.ts
+++ b/packages/command/src/commands/monitor.spec.ts
@@ -7,7 +7,7 @@ import {
   COST_SESSION_OVER_BUDGET,
   COST_SPRINT_OVER_BUDGET,
   HEARTBEAT,
-  MAIL_RECEIVED,
+  MAIL_SENT,
   PHASE_CHANGED,
   PR_CLOSED,
   PR_MERGED,
@@ -153,7 +153,7 @@ describe("formatMonitorEvent", () => {
         from: "impl",
         to: "qa",
       }),
-      makeEvent(MAIL_RECEIVED, {
+      makeEvent(MAIL_SENT, {
         category: "mail",
         src: "daemon.mail",
         sender: "orchestrator@sessions",

--- a/packages/core/src/monitor-event.ts
+++ b/packages/core/src/monitor-event.ts
@@ -89,7 +89,7 @@ export const ISSUE_COMMENT = "issue.comment" as const;
 
 // ── Mail event names ──
 
-export const MAIL_RECEIVED = "mail.received" as const;
+export const MAIL_SENT = "mail.sent" as const;
 
 // ── Budget / cost event names (#1587) ──
 
@@ -355,7 +355,7 @@ const FORMATTERS: Partial<Record<string, Formatter>> = {
     return join(wi(e), author);
   },
 
-  [MAIL_RECEIVED]: (e) => {
+  [MAIL_SENT]: (e) => {
     const sender = typeof e.sender === "string" ? e.sender : "";
     const recipient = typeof e.recipient === "string" ? e.recipient : "";
     return join(sender, "→", recipient);

--- a/packages/daemon/src/event-bus.spec.ts
+++ b/packages/daemon/src/event-bus.spec.ts
@@ -13,7 +13,7 @@ function workItemEvent(event = "pr.merged", prNumber = 42): MonitorEventInput {
 }
 
 function mailEvent(mailId = 1): MonitorEventInput {
-  return { src: "daemon.mail", event: "mail.received", category: "mail", mailId };
+  return { src: "daemon.mail", event: "mail.sent", category: "mail", mailId };
 }
 
 describe("EventBus", () => {
@@ -47,7 +47,7 @@ describe("EventBus", () => {
     expect(received).toHaveLength(3);
     expect(received[0].event).toBe("session.result");
     expect(received[1].event).toBe("pr.merged");
-    expect(received[2].event).toBe("mail.received");
+    expect(received[2].event).toBe("mail.sent");
   });
 
   test("multiple subscribers all receive events", () => {
@@ -94,7 +94,7 @@ describe("EventBus", () => {
     bus.publish(workItemEvent());
 
     expect(received).toHaveLength(1);
-    expect(received[0].event).toBe("mail.received");
+    expect(received[0].event).toBe("mail.sent");
   });
 
   test("unsubscribe stops delivery", () => {

--- a/packages/daemon/src/handlers/mail.ts
+++ b/packages/daemon/src/handlers/mail.ts
@@ -10,7 +10,7 @@ import type { IpcMethod } from "@mcp-cli/core";
 import type { StateDb } from "../db/state";
 import type { EventBus } from "../event-bus";
 import type { RequestHandler } from "../handler-types";
-import { publishMailReceived } from "../mail-events";
+import { publishMailSent } from "../mail-events";
 
 export class MailHandlers {
   constructor(
@@ -23,7 +23,7 @@ export class MailHandlers {
     handlers.set("sendMail", async (params, _ctx) => {
       const { sender, recipient, subject, body, replyTo } = SendMailParamsSchema.parse(params);
       const id = this.db.insertMail(sender, recipient, subject, body, replyTo);
-      publishMailReceived(this.eventBus, { mailId: id, sender, recipient });
+      publishMailSent(this.eventBus, { mailId: id, sender, recipient });
       return { id };
     });
 
@@ -61,7 +61,7 @@ export class MailHandlers {
       }
       const replySubject = subject ?? (original.subject ? `Re: ${original.subject}` : undefined);
       const newId = this.db.insertMail(sender, original.sender, replySubject, body, id);
-      publishMailReceived(this.eventBus, { mailId: newId, sender, recipient: original.sender });
+      publishMailSent(this.eventBus, { mailId: newId, sender, recipient: original.sender });
       return { id: newId };
     });
 

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -2558,7 +2558,7 @@ describe("IpcServer HTTP transport", () => {
       await reader.read(); // drain initial flush — subscription is now active
 
       bus.publish({ src: "test", event: "session.response", category: "session", sessionId: "s1", chunk: "hi" });
-      bus.publish({ src: "test", event: "mail.received", category: "mail", mailId: 1, sender: "a", recipient: "b" });
+      bus.publish({ src: "test", event: "mail.sent", category: "mail", mailId: 1, sender: "a", recipient: "b" });
 
       let buffer = "";
       const deadline = Date.now() + 2_000;
@@ -2566,14 +2566,14 @@ describe("IpcServer HTTP transport", () => {
         const { value, done } = await reader.read();
         if (done) break;
         buffer += decoder.decode(value, { stream: true });
-        if (buffer.includes("mail.received")) break;
+        if (buffer.includes("mail.sent")) break;
       }
 
       controller.abort();
       reader.releaseLock();
 
       expect(buffer).not.toContain("session.response");
-      expect(buffer).toContain("mail.received");
+      expect(buffer).toContain("mail.sent");
     });
 
     test("backfill→live handoff: no gap or duplicates when since=<seq> with pre-populated log", async () => {
@@ -2749,7 +2749,7 @@ describe("IpcServer HTTP transport", () => {
       // Publish 3 live events
       bus.publish({ src: "test", event: "session.result", category: "session", sessionId: "s1" });
       bus.publish({ src: "test", event: "pr.merged", category: "work_item", prNumber: 1 });
-      bus.publish({ src: "test", event: "mail.received", category: "mail", mailId: 1, sender: "a", recipient: "b" });
+      bus.publish({ src: "test", event: "mail.sent", category: "mail", mailId: 1, sender: "a", recipient: "b" });
 
       let buffer = "";
       const deadline = Date.now() + 2_000;
@@ -2757,7 +2757,7 @@ describe("IpcServer HTTP transport", () => {
         const { value, done } = await reader.read();
         if (done) break;
         buffer += decoder.decode(value, { stream: true });
-        if (buffer.includes("mail.received")) break;
+        if (buffer.includes("mail.sent")) break;
       }
 
       controller.abort();
@@ -2867,7 +2867,7 @@ describe("IpcServer HTTP transport", () => {
       const { bus } = startServerWithBus();
 
       const controller = new AbortController();
-      const res = await fetch(`http://localhost/events?type=${encodeURIComponent("pr.*,mail.received")}`, {
+      const res = await fetch(`http://localhost/events?type=${encodeURIComponent("pr.*,mail.sent")}`, {
         method: "GET",
         unix: socketPath,
         signal: controller.signal,
@@ -2883,7 +2883,7 @@ describe("IpcServer HTTP transport", () => {
       bus.publish({ src: "test", event: "pr.merged", category: "work_item", prNumber: 42 });
       bus.publish({
         src: "test",
-        event: "mail.received",
+        event: "mail.sent",
         category: "mail",
         mailId: 1,
         sender: "a",
@@ -2896,7 +2896,7 @@ describe("IpcServer HTTP transport", () => {
         const { value, done } = await reader.read();
         if (done) break;
         buffer += decoder.decode(value, { stream: true });
-        if (buffer.includes("mail.received")) break;
+        if (buffer.includes("mail.sent")) break;
       }
 
       controller.abort();
@@ -2904,7 +2904,7 @@ describe("IpcServer HTTP transport", () => {
 
       expect(buffer).not.toContain("session.result");
       expect(buffer).toContain("pr.merged");
-      expect(buffer).toContain("mail.received");
+      expect(buffer).toContain("mail.sent");
     });
 
     test("src glob filter matches source attribution with wildcards", async () => {
@@ -3697,7 +3697,7 @@ describe("IpcServer HTTP transport", () => {
     // session event — should pass
     server.pushEvent({ event: "session.result", category: "session", t: "ev" });
     // mail event — should be filtered out
-    server.pushEvent({ event: "mail.received", category: "mail", t: "ev" });
+    server.pushEvent({ event: "mail.sent", category: "mail", t: "ev" });
     // second session event — used as terminator to know mail was skipped
     server.pushEvent({ event: "session.ended", category: "session", t: "ev" });
 
@@ -3719,7 +3719,7 @@ describe("IpcServer HTTP transport", () => {
       .map((l) => JSON.parse(l) as Record<string, unknown>);
     const events = lines.filter((l) => l.t === "ev");
     expect(events.every((e) => e.category === "session")).toBe(true);
-    expect(events.find((e) => e.event === "mail.received")).toBeUndefined();
+    expect(events.find((e) => e.event === "mail.sent")).toBeUndefined();
   });
 
   test("ring-buffer: session.response excluded from live delivery without responseTail", async () => {
@@ -4113,7 +4113,7 @@ describe("buildEventFilter", () => {
     expect(filter).not.toBeNull();
     expect(filter?.({ category: "session", event: "session.result" })).toBe(true);
     expect(filter?.({ category: "work_item", event: "pr.merged" })).toBe(true);
-    expect(filter?.({ category: "mail", event: "mail.received" })).toBe(false);
+    expect(filter?.({ category: "mail", event: "mail.sent" })).toBe(false);
   });
 
   test("session filter matches sessionId", () => {
@@ -4153,7 +4153,7 @@ describe("buildEventFilter", () => {
     const filter = buildEventFilter(params({ type: "pr.*,session.idle" }));
     expect(filter?.({ event: "pr.opened" })).toBe(true);
     expect(filter?.({ event: "session.idle" })).toBe(true);
-    expect(filter?.({ event: "mail.received" })).toBe(false);
+    expect(filter?.({ event: "mail.sent" })).toBe(false);
   });
 
   test("src glob matches src field", () => {

--- a/packages/daemon/src/mail-events.ts
+++ b/packages/daemon/src/mail-events.ts
@@ -4,22 +4,22 @@
  * Publishes mail lifecycle events to the EventBus. Kept separate from
  * ipc-server.ts to avoid merge conflicts with #1511 (GET /events endpoint).
  *
- * Usage: call publishMailReceived() from the sendMail / replyToMail handlers.
+ * Usage: call publishMailSent() from the sendMail / replyToMail handlers.
  *
  * #1512
  */
 
-import { MAIL_RECEIVED, type MonitorEventInput } from "@mcp-cli/core";
+import { MAIL_SENT, type MonitorEventInput } from "@mcp-cli/core";
 import type { EventBus } from "./event-bus";
 
-export function publishMailReceived(
+export function publishMailSent(
   eventBus: EventBus | null,
   opts: { mailId: number; sender: string; recipient: string },
 ): void {
   if (!eventBus) return;
   const input: MonitorEventInput = {
     src: "daemon.mail",
-    event: MAIL_RECEIVED,
+    event: MAIL_SENT,
     category: "mail",
     mailId: opts.mailId,
     sender: opts.sender,

--- a/packages/daemon/src/mail-server.spec.ts
+++ b/packages/daemon/src/mail-server.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { MAIL_RECEIVED, MAIL_SERVER_NAME, type MonitorEvent } from "@mcp-cli/core";
+import { MAIL_SENT, MAIL_SERVER_NAME, type MonitorEvent } from "@mcp-cli/core";
 import { testOptions } from "../../../test/test-options";
 import { StateDb } from "./db/state";
 import { EventBus } from "./event-bus";
@@ -239,7 +239,7 @@ describe("MailServer", () => {
     });
 
     expect(events).toHaveLength(1);
-    expect(events[0].event).toBe(MAIL_RECEIVED);
+    expect(events[0].event).toBe(MAIL_SENT);
     expect(events[0].sender).toBe("alice");
     expect(events[0].recipient).toBe("bob");
   });
@@ -270,7 +270,7 @@ describe("MailServer", () => {
     });
 
     expect(events).toHaveLength(1);
-    expect(events[0].event).toBe(MAIL_RECEIVED);
+    expect(events[0].event).toBe(MAIL_SENT);
     expect(events[0].sender).toBe("bob");
     expect(events[0].recipient).toBe("alice");
   });
@@ -305,6 +305,6 @@ describe("MailServer", () => {
     });
 
     expect(events).toHaveLength(1);
-    expect(events[0].event).toBe(MAIL_RECEIVED);
+    expect(events[0].event).toBe(MAIL_SENT);
   });
 });

--- a/packages/daemon/src/mail-server.ts
+++ b/packages/daemon/src/mail-server.ts
@@ -14,7 +14,7 @@ import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import type { StateDb } from "./db/state";
 import type { EventBus } from "./event-bus";
-import { publishMailReceived } from "./mail-events";
+import { publishMailSent } from "./mail-events";
 
 const TOOLS = [
   {
@@ -122,7 +122,7 @@ export class MailServer {
             const body = a.body !== undefined ? String(a.body) : undefined;
             const replyTo = a.replyTo !== undefined ? Number(a.replyTo) : undefined;
             const id = this.db.insertMail(sender, recipient, subject, body, replyTo);
-            publishMailReceived(this.eventBus, { mailId: id, sender, recipient });
+            publishMailSent(this.eventBus, { mailId: id, sender, recipient });
             return { content: [{ type: "text" as const, text: JSON.stringify({ id }) }] };
           }
 
@@ -170,7 +170,7 @@ export class MailServer {
             const subject =
               a.subject !== undefined ? String(a.subject) : original.subject ? `Re: ${original.subject}` : undefined;
             const newId = this.db.insertMail(sender, original.sender, subject, body, id);
-            publishMailReceived(this.eventBus, { mailId: newId, sender, recipient: original.sender });
+            publishMailSent(this.eventBus, { mailId: newId, sender, recipient: original.sender });
             return { content: [{ type: "text" as const, text: JSON.stringify({ id: newId }) }] };
           }
 


### PR DESCRIPTION
## Summary
- Renamed `MAIL_RECEIVED` constant (`"mail.received"`) to `MAIL_SENT` (`"mail.sent"`) in `packages/core/src/monitor-event.ts`
- Renamed `publishMailReceived()` to `publishMailSent()` in `packages/daemon/src/mail-events.ts` and all callers (`mail-server.ts`, `handlers/mail.ts`)
- Updated all test references to the old constant and string value across `mail-server.spec.ts`, `ipc-server.spec.ts`, `event-bus.spec.ts`, and `monitor.spec.ts`

**Breaking change**: consumers that hard-code `"mail.received"` as an event name string must update to `"mail.sent"`.

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes — no fixes needed
- [x] `bun test` — 7338 pass, 0 fail
- [x] Searched entire codebase for remaining `MAIL_RECEIVED`, `publishMailReceived`, and `mail.received` — none found

🤖 Generated with [Claude Code](https://claude.com/claude-code)