### PR TITLE
fix(monitor): exit 2 when stream ends before --until / --max-events terminator fires (fixes #1561)

### DIFF
--- a/packages/command/src/commands/monitor.spec.ts
+++ b/packages/command/src/commands/monitor.spec.ts
@@ -366,6 +366,14 @@ describe("parseMonitorArgs error branches", () => {
     expect(parseMonitorArgs(["--max-events", "abc"]).error).toBeTruthy();
   });
 
+  test("--max-events 0 is an error", () => {
+    expect(parseMonitorArgs(["--max-events", "0"]).error).toBeTruthy();
+  });
+
+  test("--max-events negative is an error", () => {
+    expect(parseMonitorArgs(["--max-events", "-1"]).error).toBeTruthy();
+  });
+
   test("--help sets error to 'help'", () => {
     expect(parseMonitorArgs(["--help"]).error).toBe("help");
     expect(parseMonitorArgs(["-h"]).error).toBe("help");
@@ -623,6 +631,58 @@ describe("cmdMonitor", () => {
 
     expect(abortCalled).toBe(true);
     expect(exitCalls).toEqual([0]);
+  });
+
+  test("--until satisfied calls abort() on the stream", async () => {
+    let abortCalled = false;
+    const events = [makeEvent(SESSION_RESULT, {}), makeEvent(PR_MERGED, { category: "work_item" })];
+    async function* gen(): AsyncGenerator<MonitorEvent> {
+      for (const e of events) yield e;
+    }
+    const deps: MonitorDeps = {
+      openEventStream: () => ({
+        events: gen(),
+        abort: () => {
+          abortCalled = true;
+        },
+      }),
+      isTTY: true,
+      writeStdout: () => {},
+      writeStderr: () => {},
+      exit: (code) => {
+        throw new Error(`exit:${code}`);
+      },
+      onSigint: () => {},
+      onStdoutError: () => {},
+    };
+    await cmdMonitor(["--until", PR_MERGED], deps);
+    expect(abortCalled).toBe(true);
+  });
+
+  test("--max-events satisfied calls abort() on the stream", async () => {
+    let abortCalled = false;
+    const events = [makeEvent(SESSION_RESULT, {}), makeEvent(SESSION_ENDED, {}), makeEvent(SESSION_CLEARED, {})];
+    async function* gen(): AsyncGenerator<MonitorEvent> {
+      for (const e of events) yield e;
+    }
+    const deps: MonitorDeps = {
+      openEventStream: () => ({
+        events: gen(),
+        abort: () => {
+          abortCalled = true;
+        },
+      }),
+      isTTY: true,
+      writeStdout: () => {},
+      writeStderr: () => {},
+      exit: (code) => {
+        throw new Error(`exit:${code}`);
+      },
+      onSigint: () => {},
+      onStdoutError: () => {},
+    };
+    await cmdMonitor(["--max-events", "2"], deps);
+    expect(abortCalled).toBe(true);
   });
 
   test("--until set but stream ends before event → exit 2 with message", async () => {

--- a/packages/command/src/commands/monitor.spec.ts
+++ b/packages/command/src/commands/monitor.spec.ts
@@ -625,6 +625,121 @@ describe("cmdMonitor", () => {
     expect(exitCalls).toEqual([0]);
   });
 
+  test("--until set but stream ends before event → exit 2 with message", async () => {
+    const events = [makeEvent(SESSION_RESULT, {}), makeEvent(SESSION_ENDED, {})];
+    const stderr: string[] = [];
+    const exitCalls: number[] = [];
+    const deps = makeStreamDeps(events, {
+      writeStderr: (l) => stderr.push(l),
+      exit: (code) => {
+        exitCalls.push(code);
+        return undefined as never;
+      },
+    });
+    await cmdMonitor(["--until", PR_MERGED], deps);
+    expect(exitCalls).toEqual([2]);
+    expect(stderr.join("")).toContain("stream ended before terminator");
+  });
+
+  test("--max-events set but stream ends with fewer events → exit 2 with message", async () => {
+    const events = [makeEvent(SESSION_RESULT, {}), makeEvent(SESSION_ENDED, {})];
+    const stderr: string[] = [];
+    const exitCalls: number[] = [];
+    const deps = makeStreamDeps(events, {
+      writeStderr: (l) => stderr.push(l),
+      exit: (code) => {
+        exitCalls.push(code);
+        return undefined as never;
+      },
+    });
+    await cmdMonitor(["--max-events", "5"], deps);
+    expect(exitCalls).toEqual([2]);
+    expect(stderr.join("")).toContain("stream ended before terminator");
+  });
+
+  test("--until satisfied → no exit(2)", async () => {
+    const events = [makeEvent(SESSION_RESULT, {}), makeEvent(PR_MERGED, { category: "work_item" })];
+    const exitCalls: number[] = [];
+    const deps = makeStreamDeps(events, {
+      exit: (code) => {
+        exitCalls.push(code);
+        return undefined as never;
+      },
+    });
+    await cmdMonitor(["--until", PR_MERGED], deps);
+    expect(exitCalls).toHaveLength(0);
+  });
+
+  test("--max-events satisfied → no exit(2)", async () => {
+    const events = [makeEvent(SESSION_RESULT, {}), makeEvent(SESSION_ENDED, {}), makeEvent(SESSION_CLEARED, {})];
+    const exitCalls: number[] = [];
+    const deps = makeStreamDeps(events, {
+      exit: (code) => {
+        exitCalls.push(code);
+        return undefined as never;
+      },
+    });
+    await cmdMonitor(["--max-events", "2"], deps);
+    expect(exitCalls).toHaveLength(0);
+  });
+
+  test("no terminator set, stream exhausts → no exit(2)", async () => {
+    const events = [makeEvent(SESSION_RESULT, {}), makeEvent(SESSION_ENDED, {})];
+    const exitCalls: number[] = [];
+    const deps = makeStreamDeps(events, {
+      exit: (code) => {
+        exitCalls.push(code);
+        return undefined as never;
+      },
+    });
+    await cmdMonitor([], deps);
+    expect(exitCalls).toHaveLength(0);
+  });
+
+  test("--timeout fires before --until event → exit 0, not exit 2", async () => {
+    let abortCalled = false;
+    let resolveStream: (() => void) | undefined;
+
+    async function* hangingStream(): AsyncGenerator<MonitorEvent> {
+      await new Promise<void>((resolve) => {
+        resolveStream = resolve;
+      });
+    }
+
+    const exitCalls: number[] = [];
+    let capturedTimerFn: (() => void) | undefined;
+
+    const deps: MonitorDeps = {
+      openEventStream: () => ({
+        events: hangingStream(),
+        abort: () => {
+          abortCalled = true;
+          resolveStream?.();
+        },
+      }),
+      isTTY: true,
+      writeStdout: () => {},
+      writeStderr: () => {},
+      exit: (code) => {
+        exitCalls.push(code);
+        return undefined as never;
+      },
+      onSigint: () => {},
+      onStdoutError: () => {},
+      createTimeout: (fn, _ms) => {
+        capturedTimerFn = fn;
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      },
+    };
+
+    const promise = cmdMonitor(["--timeout", "1", "--until", PR_MERGED], deps);
+    capturedTimerFn?.();
+    await promise;
+
+    expect(abortCalled).toBe(true);
+    expect(exitCalls).toEqual([0]);
+  });
+
   test("non-EPIPE stdout errors do not trigger finish", async () => {
     let capturedErrHandler: ((err: Error) => void) | undefined;
     const exitCalls: number[] = [];

--- a/packages/command/src/commands/monitor.ts
+++ b/packages/command/src/commands/monitor.ts
@@ -252,6 +252,7 @@ export async function cmdMonitor(args: string[], deps?: Partial<MonitorDeps>): P
   });
 
   let count = 0;
+  let terminatorSatisfied = false;
 
   try {
     for await (const event of events) {
@@ -264,10 +265,12 @@ export async function cmdMonitor(args: string[], deps?: Partial<MonitorDeps>): P
       count++;
 
       if (parsed.maxEvents !== undefined && count >= parsed.maxEvents) {
+        terminatorSatisfied = true;
         break;
       }
 
       if (parsed.until !== undefined && (event as MonitorEvent).event === parsed.until) {
+        terminatorSatisfied = true;
         break;
       }
     }
@@ -282,5 +285,13 @@ export async function cmdMonitor(args: string[], deps?: Partial<MonitorDeps>): P
     }
   } finally {
     if (timeoutId !== undefined) clearTimeout(timeoutId);
+  }
+
+  if (!done && !terminatorSatisfied) {
+    const hasTerminator = parsed.until !== undefined || parsed.maxEvents !== undefined;
+    if (hasTerminator) {
+      d.writeStderr("monitor: stream ended before terminator\n");
+      d.exit(2);
+    }
   }
 }

--- a/packages/command/src/commands/monitor.ts
+++ b/packages/command/src/commands/monitor.ts
@@ -146,8 +146,8 @@ export function parseMonitorArgs(args: string[]): MonitorArgs {
     } else if (arg === "--max-events") {
       const next = args[++i];
       const n = Number(next);
-      if (!next || Number.isNaN(n)) {
-        error = "--max-events requires a number";
+      if (!next || Number.isNaN(n) || n < 1) {
+        error = "--max-events requires a positive integer";
         break;
       }
       maxEvents = n;
@@ -266,11 +266,13 @@ export async function cmdMonitor(args: string[], deps?: Partial<MonitorDeps>): P
 
       if (parsed.maxEvents !== undefined && count >= parsed.maxEvents) {
         terminatorSatisfied = true;
+        abort();
         break;
       }
 
       if (parsed.until !== undefined && (event as MonitorEvent).event === parsed.until) {
         terminatorSatisfied = true;
+        abort();
         break;
       }
     }
@@ -290,6 +292,7 @@ export async function cmdMonitor(args: string[], deps?: Partial<MonitorDeps>): P
   if (!done && !terminatorSatisfied) {
     const hasTerminator = parsed.until !== undefined || parsed.maxEvents !== undefined;
     if (hasTerminator) {
+      done = true;
       d.writeStderr("monitor: stream ended before terminator\n");
       d.exit(2);
     }


### PR DESCRIPTION
## Summary
- Track whether a terminator (`--until` or `--max-events`) was satisfied before the event stream ended
- If the stream ends naturally (daemon disconnect/restart) without satisfying the terminator, exit with code 2 and write `monitor: stream ended before terminator` to stderr
- SIGINT, timeout, and EPIPE exits remain exit 0 — only unintended stream endings produce exit 2

## Test plan
- [ ] `--until <type>` set, stream ends without seeing the event → exits 2, stderr message
- [ ] `--max-events N` set, stream ends with fewer than N events → exits 2, stderr message
- [ ] `--until <type>` satisfied (event seen) → no exit(2)
- [ ] `--max-events N` satisfied (N events counted) → no exit(2)
- [ ] No terminator set, stream exhausts → exit 0 (unchanged)
- [ ] `--timeout` fires before `--until` event → exit 0 (timeout is an intentional exit)
- [ ] All 7344 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)