### PR TITLE
feat(memory): add mcx memory audit command (fixes #1945)

### DIFF
--- a/packages/command/src/commands/memory.spec.ts
+++ b/packages/command/src/commands/memory.spec.ts
@@ -1,0 +1,357 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync } from "node:fs";
+import type { AuditResult, CmdMemoryDeps, MemoryDeps } from "./memory";
+import { buildPrompt, cmdMemory, defaultDeps, findMemoryDir, parseHaikuResponse, runMemoryAudit } from "./memory";
+
+// ─── findMemoryDir ────────────────────────────────────────────────────────────
+
+describe("findMemoryDir", () => {
+  test("returns path when .claude/memory exists at git root", () => {
+    const deps = {
+      getGitRoot: () => "/repo",
+      cwd: () => "/repo/sub",
+      dirExists: () => true,
+    };
+    expect(findMemoryDir(deps)).toBe("/repo/.claude/memory");
+  });
+
+  test("returns null when directory does not exist", () => {
+    const deps = {
+      getGitRoot: () => "/repo",
+      cwd: () => "/repo",
+      dirExists: () => false,
+    };
+    expect(findMemoryDir(deps)).toBeNull();
+  });
+
+  test("uses cwd when git root is null", () => {
+    const deps = {
+      getGitRoot: () => null,
+      cwd: () => "/myproject",
+      dirExists: (path: string) => path === "/myproject/.claude/memory",
+    };
+    expect(findMemoryDir(deps)).toBe("/myproject/.claude/memory");
+  });
+});
+
+// ─── buildPrompt ──────────────────────────────────────────────────────────────
+
+describe("buildPrompt", () => {
+  test("includes memory index in prompt", () => {
+    const prompt = buildPrompt(
+      "/repo/.claude/memory",
+      "# Memory Index\n- [foo](foo.md) — bar",
+      [{ name: "foo.md", content: "rule content" }],
+      "closed issues list",
+    );
+    expect(prompt).toContain("# Memory Index");
+    expect(prompt).toContain("foo.md");
+    expect(prompt).toContain("rule content");
+    expect(prompt).toContain("closed issues list");
+  });
+
+  test("uses placeholder when no rule files", () => {
+    const prompt = buildPrompt("/repo/.claude/memory", "index", [], "issues");
+    expect(prompt).toContain("(no rule files found)");
+  });
+});
+
+// ─── parseHaikuResponse ───────────────────────────────────────────────────────
+
+describe("parseHaikuResponse", () => {
+  const validResult: AuditResult = {
+    findings: [
+      {
+        file: "feedback_foo.md",
+        status: "load-bearing",
+        reason: "Still needed.",
+        related: null,
+      },
+      {
+        file: "feedback_bar.md",
+        status: "stale",
+        reason: "Issue #42 shipped.",
+        related: null,
+      },
+    ],
+    top_prune_candidates: ["feedback_bar.md"],
+  };
+
+  test("parses bare JSON", () => {
+    expect(parseHaikuResponse(JSON.stringify(validResult))).toEqual(validResult);
+  });
+
+  test("parses JSON wrapped in markdown code fences", () => {
+    const fenced = `\`\`\`json\n${JSON.stringify(validResult)}\n\`\`\``;
+    expect(parseHaikuResponse(fenced)).toEqual(validResult);
+  });
+
+  test("parses JSON with unlabeled code fences", () => {
+    const fenced = `\`\`\`\n${JSON.stringify(validResult)}\n\`\`\``;
+    expect(parseHaikuResponse(fenced)).toEqual(validResult);
+  });
+
+  test("skips leading prose before first {", () => {
+    const withProse = `Here is the result:\n${JSON.stringify(validResult)}`;
+    expect(parseHaikuResponse(withProse)).toEqual(validResult);
+  });
+
+  test("returns null for invalid JSON", () => {
+    expect(parseHaikuResponse("not json at all")).toBeNull();
+  });
+
+  test("returns null for JSON that starts with { but is malformed", () => {
+    expect(parseHaikuResponse("{not valid json}")).toBeNull();
+  });
+
+  test("returns null for empty string", () => {
+    expect(parseHaikuResponse("")).toBeNull();
+  });
+});
+
+// ─── runMemoryAudit ───────────────────────────────────────────────────────────
+
+function makeDeps(overrides: Partial<MemoryDeps> = {}): MemoryDeps & { logs: string[]; errors: string[] } {
+  const logs: string[] = [];
+  const errors: string[] = [];
+
+  const auditResult: AuditResult = {
+    findings: [
+      { file: "feedback_test.md", status: "load-bearing", reason: "Still needed.", related: null },
+      { file: "feedback_old.md", status: "stale", reason: "Fixed in #99.", related: null },
+    ],
+    top_prune_candidates: ["feedback_old.md"],
+  };
+
+  return {
+    logs,
+    errors,
+    getGitRoot: () => "/repo",
+    cwd: () => "/repo",
+    dirExists: () => true,
+    spawnCapture: (cmd) => {
+      if (cmd[0] === "gh") {
+        return JSON.stringify([{ number: 99, title: "Fix old rule", closedAt: "2026-01-01T00:00:00Z" }]);
+      }
+      if (cmd.some((s) => s.includes("claude"))) {
+        return JSON.stringify(auditResult);
+      }
+      return null;
+    },
+    readFile: (path) => {
+      if (path.endsWith("MEMORY.md")) return "# Memory\n- [feedback_test](feedback_test.md)";
+      if (path.endsWith("feedback_test.md")) return "---\nname: test\n---\nrule content";
+      if (path.endsWith("feedback_old.md")) return "---\nname: old\n---\nold content";
+      return null;
+    },
+    listFiles: (_, ext) => {
+      if (ext === ".md") return ["feedback_test.md", "feedback_old.md", "MEMORY.md"];
+      return [];
+    },
+    findClaudeBinary: () => "/usr/bin/claude",
+    log: (msg) => logs.push(msg),
+    logError: (msg) => errors.push(msg),
+    exit: (code) => {
+      throw new Error(`exit(${code})`);
+    },
+    ...overrides,
+  };
+}
+
+describe("runMemoryAudit", () => {
+  test("text mode prints findings and prune candidates", async () => {
+    const deps = makeDeps();
+    await runMemoryAudit({ json: false }, deps);
+    const output = deps.logs.join("\n");
+    expect(output).toContain("feedback_test.md");
+    expect(output).toContain("feedback_old.md");
+    expect(output).toContain("Top prune candidates");
+    expect(output).toContain("feedback_old.md");
+  });
+
+  test("json mode prints valid JSON result", async () => {
+    const deps = makeDeps();
+    await runMemoryAudit({ json: true }, deps);
+    expect(deps.logs.length).toBe(1);
+    const parsed = JSON.parse(deps.logs[0]) as AuditResult;
+    expect(parsed.findings).toBeArray();
+    expect(parsed.top_prune_candidates).toBeArray();
+  });
+
+  test("exits with error when no memory directory found", async () => {
+    const deps = makeDeps({
+      getGitRoot: () => null,
+      cwd: () => "/nonexistent",
+      dirExists: () => false,
+    });
+    await expect(runMemoryAudit({ json: false }, deps)).rejects.toThrow("exit(1)");
+  });
+
+  test("exits when claude binary not found", async () => {
+    const deps = makeDeps({ findClaudeBinary: () => null });
+    await expect(runMemoryAudit({ json: false }, deps)).rejects.toThrow("exit(1)");
+  });
+
+  test("exits when Haiku returns null", async () => {
+    const deps = makeDeps({
+      spawnCapture: (cmd) => {
+        if (cmd[0] === "gh") return "[]";
+        return null; // claude returns null
+      },
+    });
+    await expect(runMemoryAudit({ json: false }, deps)).rejects.toThrow("exit(1)");
+  });
+
+  test("exits when Haiku returns unparseable response", async () => {
+    const deps = makeDeps({
+      spawnCapture: (cmd) => {
+        if (cmd[0] === "gh") return "[]";
+        return "I cannot help with that."; // not JSON
+      },
+    });
+    await expect(runMemoryAudit({ json: false }, deps)).rejects.toThrow("exit(1)");
+  });
+
+  test("handles malformed gh JSON gracefully", async () => {
+    const result: AuditResult = {
+      findings: [{ file: "feedback_test.md", status: "load-bearing", reason: "ok", related: null }],
+      top_prune_candidates: [],
+    };
+    const deps = makeDeps({
+      spawnCapture: (cmd) => {
+        if (cmd[0] === "gh") return "{malformed json}"; // parse error in fetchClosedIssues
+        if (cmd.some((s) => s.includes("claude"))) return JSON.stringify(result);
+        return null;
+      },
+    });
+    await runMemoryAudit({ json: false }, deps);
+    // Should still complete even with broken gh output
+    expect(deps.logs.join("\n")).toContain("feedback_test.md");
+  });
+
+  test("text mode reports 'No prune candidates' when list is empty", async () => {
+    const result: AuditResult = {
+      findings: [{ file: "feedback_test.md", status: "load-bearing", reason: "Still good.", related: null }],
+      top_prune_candidates: [],
+    };
+    const deps = makeDeps({
+      spawnCapture: (cmd) => {
+        if (cmd[0] === "gh") return "[]";
+        if (cmd.some((s) => s.includes("claude"))) return JSON.stringify(result);
+        return null;
+      },
+    });
+    await runMemoryAudit({ json: false }, deps);
+    expect(deps.logs.join("\n")).toContain("No prune candidates");
+  });
+});
+
+// ─── cmdMemory ────────────────────────────────────────────────────────────────
+
+describe("cmdMemory", () => {
+  function makeCmdDeps(overrides: Partial<CmdMemoryDeps> = {}): CmdMemoryDeps & { logs: string[] } {
+    const logs: string[] = [];
+    return {
+      logs,
+      exit: (code) => {
+        throw new Error(`exit(${code})`);
+      },
+      log: (msg) => logs.push(msg),
+      runAudit: async () => {},
+      makeDeps: () => makeDeps(),
+      ...overrides,
+    };
+  }
+
+  test("prints help when no subcommand", async () => {
+    const d = makeCmdDeps();
+    await cmdMemory([], d);
+    expect(d.logs.join("\n")).toContain("mcx memory audit");
+  });
+
+  test("prints help with --help flag", async () => {
+    const d = makeCmdDeps();
+    await cmdMemory(["--help"], d);
+    expect(d.logs.join("\n")).toContain("mcx memory audit");
+  });
+
+  test("prints help with -h flag", async () => {
+    const d = makeCmdDeps();
+    await cmdMemory(["-h"], d);
+    expect(d.logs.join("\n")).toContain("mcx memory audit");
+  });
+
+  test("exits with error for unknown subcommand", async () => {
+    const d = makeCmdDeps();
+    await expect(cmdMemory(["unknown"], d)).rejects.toThrow("exit(1)");
+  });
+
+  test("calls runAudit with json=false for audit", async () => {
+    const calls: Array<{ json: boolean }> = [];
+    const d = makeCmdDeps({
+      runAudit: async (opts) => {
+        calls.push(opts);
+      },
+    });
+    await cmdMemory(["audit"], d);
+    expect(calls).toEqual([{ json: false }]);
+  });
+
+  test("calls runAudit with json=true for audit --json", async () => {
+    const calls: Array<{ json: boolean }> = [];
+    const d = makeCmdDeps({
+      runAudit: async (opts) => {
+        calls.push(opts);
+      },
+    });
+    await cmdMemory(["audit", "--json"], d);
+    expect(calls).toEqual([{ json: true }]);
+  });
+
+  test("exits with error for unknown flags", async () => {
+    const d = makeCmdDeps();
+    await expect(cmdMemory(["audit", "--unknown-flag"], d)).rejects.toThrow("exit(1)");
+  });
+});
+
+// ─── defaultDeps (safe I/O methods) ───────────────────────────────────────────
+
+describe("defaultDeps", () => {
+  const deps = defaultDeps();
+
+  test("cwd() returns a non-empty string", () => {
+    expect(typeof deps.cwd()).toBe("string");
+    expect(deps.cwd().length).toBeGreaterThan(0);
+  });
+
+  test("dirExists() returns true for existing path and false for missing", () => {
+    expect(deps.dirExists(import.meta.dir)).toBe(true);
+    expect(deps.dirExists("/this/path/does/not/exist/ever")).toBe(false);
+  });
+
+  test("readFile() reads a real file", () => {
+    const content = deps.readFile(import.meta.path);
+    expect(content).not.toBeNull();
+    expect(content).toContain("defaultDeps");
+  });
+
+  test("readFile() returns null for missing file", () => {
+    expect(deps.readFile("/no/such/file.md")).toBeNull();
+  });
+
+  test("listFiles() returns .ts files in this directory", () => {
+    const files = deps.listFiles(import.meta.dir, ".ts");
+    expect(files).toContain("memory.spec.ts");
+    expect(files).toContain("memory.ts");
+  });
+
+  test("listFiles() returns [] for missing directory", () => {
+    expect(deps.listFiles("/no/such/dir", ".md")).toEqual([]);
+  });
+
+  test("getGitRoot() returns the repo root (we are in a git repo)", () => {
+    const root = deps.getGitRoot();
+    expect(root).not.toBeNull();
+    expect(existsSync(`${root}/.git`) || existsSync(`${root}/../.git`)).toBe(true);
+  });
+});

--- a/packages/command/src/commands/memory.spec.ts
+++ b/packages/command/src/commands/memory.spec.ts
@@ -39,7 +39,6 @@ describe("findMemoryDir", () => {
 describe("buildPrompt", () => {
   test("includes memory index in prompt", () => {
     const prompt = buildPrompt(
-      "/repo/.claude/memory",
       "# Memory Index\n- [foo](foo.md) — bar",
       [{ name: "foo.md", content: "rule content" }],
       "closed issues list",
@@ -51,7 +50,7 @@ describe("buildPrompt", () => {
   });
 
   test("uses placeholder when no rule files", () => {
-    const prompt = buildPrompt("/repo/.claude/memory", "index", [], "issues");
+    const prompt = buildPrompt("index", [], "issues");
     expect(prompt).toContain("(no rule files found)");
   });
 });
@@ -352,6 +351,7 @@ describe("defaultDeps", () => {
   test("getGitRoot() returns the repo root (we are in a git repo)", () => {
     const root = deps.getGitRoot();
     expect(root).not.toBeNull();
-    expect(existsSync(`${root}/.git`) || existsSync(`${root}/../.git`)).toBe(true);
+    // .git may be a directory (main checkout) or a file (worktree)
+    expect(existsSync(`${root}/.git`)).toBe(true);
   });
 });

--- a/packages/command/src/commands/memory.ts
+++ b/packages/command/src/commands/memory.ts
@@ -1,0 +1,358 @@
+/**
+ * `mcx memory audit` — Haiku-driven contradiction + staleness check.
+ *
+ * Reads .claude/memory/ files + MEMORY.md index, passes them along with
+ * recently-closed GitHub issues to Haiku, and reports rules that look
+ * stale, contradictory, or superseded.
+ *
+ * Usage:
+ *   mcx memory audit              Print human-readable report
+ *   mcx memory audit --json       Machine-readable JSON (for retro-skill)
+ */
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { resolveModelName } from "@mcp-cli/core";
+import { printError } from "../output";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type AuditStatus = "load-bearing" | "stale" | "contradicts" | "superseded-by";
+
+export interface AuditFinding {
+  file: string;
+  status: AuditStatus;
+  reason: string;
+  /** The other rule's file ID when status is "contradicts" or "superseded-by". */
+  related: string | null;
+}
+
+export interface AuditResult {
+  findings: AuditFinding[];
+  top_prune_candidates: string[];
+}
+
+export interface MemoryDeps {
+  /** Resolve the git repo root. Returns null if not in a git repo. */
+  getGitRoot: () => string | null;
+  /** Current working directory. */
+  cwd: () => string;
+  /** Check whether a directory exists. */
+  dirExists: (path: string) => boolean;
+  /** Spawn a process and capture stdout. Returns null on non-zero exit. */
+  spawnCapture: (cmd: string[], opts?: { input?: string }) => string | null;
+  /** Read a file. Returns null if it doesn't exist or is unreadable. */
+  readFile: (path: string) => string | null;
+  /** List files in a directory matching an extension. Returns [] if dir missing. */
+  listFiles: (dir: string, ext: string) => string[];
+  /** Resolve the claude binary path. Returns null if not found. */
+  findClaudeBinary: () => string | null;
+  log: (msg: string) => void;
+  logError: (msg: string) => void;
+  exit: (code: number) => never;
+}
+
+const HAIKU_MODEL = resolveModelName("haiku");
+
+const AUDIT_PROMPT = `You are auditing a project's persistent memory rules. Rules are stored as markdown files in .claude/memory/ and indexed in MEMORY.md.
+
+For each rule file listed in the findings, classify it as one of:
+- load-bearing: still actively needed, accurate, no issues
+- stale: the issue it references has been closed and the fix shipped, or the behavior it describes no longer applies
+- contradicts: conflicts with another rule in a meaningful way (set "related" to the conflicting file name)
+- superseded-by: another rule already covers the same ground more accurately (set "related" to the superseding file name)
+
+## MEMORY.md index:
+
+{MEMORY_MD}
+
+## Rule file contents:
+
+{RULE_FILES}
+
+## Recently closed GitHub issues (last 50):
+
+{CLOSED_ISSUES}
+
+## Response format
+
+Respond with ONLY valid JSON — no prose before or after:
+{
+  "findings": [
+    {
+      "file": "<filename.md>",
+      "status": "load-bearing" | "stale" | "contradicts" | "superseded-by",
+      "reason": "<1-2 sentence explanation>",
+      "related": "<other-file.md or null>"
+    }
+  ],
+  "top_prune_candidates": ["<file1.md>", "<file2.md>"]
+}
+
+The top_prune_candidates list should contain 3-5 files most worth pruning (stale or superseded). If none are worth pruning, return an empty array.`;
+
+// ─── Core logic ───────────────────────────────────────────────────────────────
+
+/**
+ * Find the .claude/memory directory by walking up from cwd or using git root.
+ */
+export function findMemoryDir(deps: Pick<MemoryDeps, "getGitRoot" | "cwd" | "dirExists">): string | null {
+  const root = deps.getGitRoot() ?? deps.cwd();
+  const candidate = join(root, ".claude", "memory");
+  return deps.dirExists(candidate) ? candidate : null;
+}
+
+/**
+ * Build the prompt for Haiku by assembling all memory file contents.
+ */
+export function buildPrompt(
+  memoryDir: string,
+  memoryIndex: string,
+  ruleFiles: Array<{ name: string; content: string }>,
+  closedIssues: string,
+): string {
+  const rulesBlock = ruleFiles.map((f) => `### ${f.name}\n\n${f.content}`).join("\n\n---\n\n");
+
+  return AUDIT_PROMPT.replace("{MEMORY_MD}", memoryIndex)
+    .replace("{RULE_FILES}", rulesBlock || "(no rule files found)")
+    .replace("{CLOSED_ISSUES}", closedIssues || "(unavailable)");
+}
+
+/**
+ * Call claude --print with the given prompt and model, return stdout.
+ */
+function callHaiku(prompt: string, deps: MemoryDeps): string | null {
+  const binary = deps.findClaudeBinary();
+  if (!binary) {
+    deps.logError("memory audit: claude binary not found — install claude or set MCX_CLAUDE_BINARY");
+    return null;
+  }
+
+  const result = deps.spawnCapture([binary, "--print", "--model", HAIKU_MODEL], { input: prompt });
+  return result;
+}
+
+/**
+ * Fetch the last N closed GitHub issues as a compact JSON string.
+ */
+function fetchClosedIssues(deps: MemoryDeps, limit = 50): string {
+  const raw = deps.spawnCapture([
+    "gh",
+    "issue",
+    "list",
+    "--state",
+    "closed",
+    "--limit",
+    String(limit),
+    "--json",
+    "number,title,closedAt",
+  ]);
+  if (!raw) return "(gh unavailable)";
+  try {
+    const issues = JSON.parse(raw) as Array<{ number: number; title: string; closedAt: string }>;
+    return issues.map((i) => `#${i.number}: ${i.title} (closed ${i.closedAt.slice(0, 10)})`).join("\n");
+  } catch {
+    return "(parse error)";
+  }
+}
+
+/**
+ * Parse Haiku's response, stripping markdown fences if present.
+ */
+export function parseHaikuResponse(raw: string): AuditResult | null {
+  const trimmed = raw.trim();
+  // Strip ```json ... ``` fences if present
+  const fenced = trimmed.match(/^```(?:json)?\s*([\s\S]*?)```\s*$/);
+  const jsonStr = fenced ? fenced[1].trim() : trimmed;
+  // Find the first { to skip any leading prose
+  const start = jsonStr.indexOf("{");
+  if (start === -1) return null;
+  try {
+    return JSON.parse(jsonStr.slice(start)) as AuditResult;
+  } catch {
+    return null;
+  }
+}
+
+export async function runMemoryAudit(opts: { json: boolean }, deps: MemoryDeps): Promise<void> {
+  const memoryDir = findMemoryDir(deps);
+  if (!memoryDir) {
+    deps.logError("memory audit: .claude/memory/ directory not found. Run from a project with Claude Code memory.");
+    deps.exit(1);
+  }
+
+  deps.logError("memory audit: reading memory files…");
+
+  // Read MEMORY.md index
+  const gitRoot = deps.getGitRoot() ?? deps.cwd();
+  const memoryIndexPath = join(gitRoot, ".claude", "memory", "MEMORY.md");
+  const memoryIndex = deps.readFile(memoryIndexPath) ?? "(MEMORY.md not found)";
+
+  // Read all *.md files in the memory dir (excluding MEMORY.md itself)
+  const mdFiles = deps.listFiles(memoryDir, ".md").filter((f) => f !== "MEMORY.md");
+  const ruleFiles: Array<{ name: string; content: string }> = [];
+  for (const name of mdFiles) {
+    const content = deps.readFile(join(memoryDir, name));
+    if (content !== null) ruleFiles.push({ name, content });
+  }
+
+  deps.logError(`memory audit: ${ruleFiles.length} rule files, fetching closed issues…`);
+  const closedIssues = fetchClosedIssues(deps);
+
+  deps.logError("memory audit: calling Haiku…");
+  const prompt = buildPrompt(memoryDir, memoryIndex, ruleFiles, closedIssues);
+  const rawResponse = callHaiku(prompt, deps);
+
+  if (!rawResponse) {
+    deps.logError("memory audit: no response from Haiku");
+    deps.exit(1);
+  }
+
+  const result = parseHaikuResponse(rawResponse);
+  if (!result) {
+    deps.logError("memory audit: failed to parse Haiku response");
+    deps.logError("--- raw response ---");
+    deps.logError(rawResponse);
+    deps.exit(1);
+  }
+
+  if (opts.json) {
+    deps.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  // Human-readable output
+  const statusSymbol: Record<AuditStatus, string> = {
+    "load-bearing": "✓",
+    stale: "✗",
+    contradicts: "≠",
+    "superseded-by": "→",
+  };
+
+  for (const finding of result.findings) {
+    const sym = statusSymbol[finding.status] ?? "?";
+    const rel = finding.related ? ` (see ${finding.related})` : "";
+    deps.log(`${sym} ${finding.file}: ${finding.status}${rel}`);
+    deps.log(`  ${finding.reason}`);
+  }
+
+  if (result.top_prune_candidates.length > 0) {
+    deps.log("");
+    deps.log("Top prune candidates:");
+    for (const f of result.top_prune_candidates) {
+      deps.log(`  - ${f}`);
+    }
+  } else {
+    deps.log("");
+    deps.log("No prune candidates identified.");
+  }
+}
+
+// ─── Default deps ─────────────────────────────────────────────────────────────
+
+export function defaultDeps(): MemoryDeps {
+  return {
+    getGitRoot: () => {
+      const r = Bun.spawnSync(["git", "rev-parse", "--show-toplevel"], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      if (r.exitCode !== 0) return null;
+      return r.stdout.toString().trim() || null;
+    },
+    cwd: () => process.cwd(),
+    dirExists: (path) => existsSync(path),
+    spawnCapture: (cmd, opts) => {
+      const r = Bun.spawnSync(cmd, {
+        stdout: "pipe",
+        stderr: "pipe",
+        stdin: opts?.input ? Buffer.from(opts.input) : undefined,
+      });
+      if (r.exitCode !== 0) return null;
+      return r.stdout.toString();
+    },
+    readFile: (path) => {
+      try {
+        return readFileSync(path, "utf-8");
+      } catch {
+        return null;
+      }
+    },
+    listFiles: (dir, ext) => {
+      try {
+        return readdirSync(dir)
+          .filter((f) => f.endsWith(ext))
+          .sort();
+      } catch {
+        return [];
+      }
+    },
+    findClaudeBinary: () => {
+      // Honor MCX_CLAUDE_BINARY first
+      const env = process.env.MCX_CLAUDE_BINARY?.trim();
+      if (env && existsSync(env)) return env;
+      // Fall back to PATH
+      const r = Bun.spawnSync(["which", "claude"], { stdout: "pipe", stderr: "pipe" });
+      if (r.exitCode !== 0) return null;
+      return r.stdout.toString().trim() || null;
+    },
+    log: (msg) => console.log(msg),
+    logError: (msg) => console.error(msg),
+    exit: (code) => process.exit(code),
+  };
+}
+
+// ─── Entry point ─────────────────────────────────────────────────────────────
+
+export interface CmdMemoryDeps {
+  exit: (code: number) => never;
+  log: (msg: string) => void;
+  runAudit: (opts: { json: boolean }, deps: MemoryDeps) => Promise<void>;
+  makeDeps: () => MemoryDeps;
+}
+
+function defaultCmdDeps(): CmdMemoryDeps {
+  return {
+    exit: (code) => process.exit(code),
+    log: (msg) => console.log(msg),
+    runAudit: runMemoryAudit,
+    makeDeps: defaultDeps,
+  };
+}
+
+export async function cmdMemory(args: string[], d: CmdMemoryDeps = defaultCmdDeps()): Promise<void> {
+  const sub = args[0];
+
+  if (!sub || sub === "--help" || sub === "-h") {
+    d.log(HELP_TEXT);
+    return;
+  }
+
+  if (sub !== "audit") {
+    printError(`Unknown memory subcommand: ${sub}`);
+    d.log(HELP_TEXT);
+    d.exit(1);
+  }
+
+  const rest = args.slice(1);
+  const json = rest.includes("--json");
+  const unknownFlags = rest.filter((a) => a.startsWith("--") && a !== "--json");
+  if (unknownFlags.length > 0) {
+    printError(`Unknown flag(s): ${unknownFlags.join(", ")}`);
+    d.exit(1);
+  }
+
+  await d.runAudit({ json }, d.makeDeps());
+}
+
+const HELP_TEXT = `mcx memory — Claude Code memory management
+
+Usage:
+  mcx memory audit [--json]    Haiku-driven staleness + contradiction check
+
+Options:
+  --json    Output machine-readable JSON (for retro-skill consumption)
+
+Examples:
+  mcx memory audit
+  mcx memory audit --json`;

--- a/packages/command/src/commands/memory.ts
+++ b/packages/command/src/commands/memory.ts
@@ -11,8 +11,8 @@
  */
 
 import { existsSync, readFileSync, readdirSync } from "node:fs";
-import { join, resolve } from "node:path";
-import { resolveModelName } from "@mcp-cli/core";
+import { join } from "node:path";
+import { resolveModelName, resolveSourceClaudePath } from "@mcp-cli/core";
 import { printError } from "../output";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -40,7 +40,7 @@ export interface MemoryDeps {
   /** Check whether a directory exists. */
   dirExists: (path: string) => boolean;
   /** Spawn a process and capture stdout. Returns null on non-zero exit. */
-  spawnCapture: (cmd: string[], opts?: { input?: string }) => string | null;
+  spawnCapture: (cmd: string[], opts?: { input?: string; onStderr?: (s: string) => void }) => string | null;
   /** Read a file. Returns null if it doesn't exist or is unreadable. */
   readFile: (path: string) => string | null;
   /** List files in a directory matching an extension. Returns [] if dir missing. */
@@ -56,7 +56,7 @@ const HAIKU_MODEL = resolveModelName("haiku");
 
 const AUDIT_PROMPT = `You are auditing a project's persistent memory rules. Rules are stored as markdown files in .claude/memory/ and indexed in MEMORY.md.
 
-For each rule file listed in the findings, classify it as one of:
+For each rule file provided in the input below, classify it as one of:
 - load-bearing: still actively needed, accurate, no issues
 - stale: the issue it references has been closed and the fix shipped, or the behavior it describes no longer applies
 - contradicts: conflicts with another rule in a meaningful way (set "related" to the conflicting file name)
@@ -94,7 +94,7 @@ The top_prune_candidates list should contain 3-5 files most worth pruning (stale
 // ─── Core logic ───────────────────────────────────────────────────────────────
 
 /**
- * Find the .claude/memory directory by walking up from cwd or using git root.
+ * Find the .claude/memory directory relative to the git root (or cwd if not in a repo).
  */
 export function findMemoryDir(deps: Pick<MemoryDeps, "getGitRoot" | "cwd" | "dirExists">): string | null {
   const root = deps.getGitRoot() ?? deps.cwd();
@@ -106,7 +106,6 @@ export function findMemoryDir(deps: Pick<MemoryDeps, "getGitRoot" | "cwd" | "dir
  * Build the prompt for Haiku by assembling all memory file contents.
  */
 export function buildPrompt(
-  memoryDir: string,
   memoryIndex: string,
   ruleFiles: Array<{ name: string; content: string }>,
   closedIssues: string,
@@ -128,12 +127,16 @@ function callHaiku(prompt: string, deps: MemoryDeps): string | null {
     return null;
   }
 
-  const result = deps.spawnCapture([binary, "--print", "--model", HAIKU_MODEL], { input: prompt });
-  return result;
+  return deps.spawnCapture([binary, "--print", "--model", HAIKU_MODEL], {
+    input: prompt,
+    onStderr: (s) => {
+      if (s.trim()) deps.logError(`memory audit: claude stderr: ${s.trim()}`);
+    },
+  });
 }
 
 /**
- * Fetch the last N closed GitHub issues as a compact JSON string.
+ * Fetch the last N closed GitHub issues as a newline-delimited summary for prompt inclusion.
  */
 function fetchClosedIssues(deps: MemoryDeps, limit = 50): string {
   const raw = deps.spawnCapture([
@@ -200,7 +203,7 @@ export async function runMemoryAudit(opts: { json: boolean }, deps: MemoryDeps):
   const closedIssues = fetchClosedIssues(deps);
 
   deps.logError("memory audit: calling Haiku…");
-  const prompt = buildPrompt(memoryDir, memoryIndex, ruleFiles, closedIssues);
+  const prompt = buildPrompt(memoryIndex, ruleFiles, closedIssues);
   const rawResponse = callHaiku(prompt, deps);
 
   if (!rawResponse) {
@@ -268,7 +271,10 @@ export function defaultDeps(): MemoryDeps {
         stderr: "pipe",
         stdin: opts?.input ? Buffer.from(opts.input) : undefined,
       });
-      if (r.exitCode !== 0) return null;
+      if (r.exitCode !== 0) {
+        opts?.onStderr?.(r.stderr.toString());
+        return null;
+      }
       return r.stdout.toString();
     },
     readFile: (path) => {
@@ -288,13 +294,11 @@ export function defaultDeps(): MemoryDeps {
       }
     },
     findClaudeBinary: () => {
-      // Honor MCX_CLAUDE_BINARY first
-      const env = process.env.MCX_CLAUDE_BINARY?.trim();
-      if (env && existsSync(env)) return env;
-      // Fall back to PATH
-      const r = Bun.spawnSync(["which", "claude"], { stdout: "pipe", stderr: "pipe" });
-      if (r.exitCode !== 0) return null;
-      return r.stdout.toString().trim() || null;
+      try {
+        return resolveSourceClaudePath();
+      } catch {
+        return null;
+      }
     },
     log: (msg) => console.log(msg),
     logError: (msg) => console.error(msg),

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -959,6 +959,7 @@ Utility:
   mcx monitor [flags]                 Stream unified daemon events (--json for NDJSON)
   mcx logs <server> [-f]              View server stderr
   mcx mail <subcommand>               Inter-session messaging
+  mcx memory audit [--json]           Haiku-driven memory staleness + contradiction check
   mcx note <subcommand>               Tool annotations
   mcx serve                           Run as stdio MCP server
   mcx scope <subcommand>              Directory scope management

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -44,6 +44,7 @@ import { cmdAddFromClaudeDesktop, cmdImport } from "./commands/import";
 import { cmdInstall } from "./commands/install";
 import { cmdLogs } from "./commands/logs";
 import { cmdMail } from "./commands/mail";
+import { cmdMemory } from "./commands/memory";
 import { cmdMonitor } from "./commands/monitor";
 import { cmdNote } from "./commands/note";
 import { cmdPhase } from "./commands/phase";
@@ -359,6 +360,10 @@ async function main(): Promise<void> {
 
       case "note":
         await cmdNote(cleanArgs.slice(1));
+        break;
+
+      case "memory":
+        await cmdMemory(cleanArgs.slice(1));
         break;
 
       case "track":


### PR DESCRIPTION
## Summary

- New `mcx memory audit [--json]` command: reads `.claude/memory/*.md` + `MEMORY.md` index, fetches last 50 closed GitHub issues, calls Haiku via `claude --print`, and classifies each rule as `load-bearing`, `stale`, `contradicts`, or `superseded-by`
- Outputs top 3-5 prune candidates; `--json` mode for retro-skill consumption
- Wired into `main.ts` dispatch under `case "memory"`
- retro.md wire-up deferred to #2131 (meta-file invariant — cannot touch `.claude/skills/**` during a sprint)

## Test plan

- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun test` — 7372 pass, 0 fail (34 new tests in `memory.spec.ts`)
- [x] Coverage: `memory.ts` at 89% lines (above 80% threshold)
- [x] Covers: `findMemoryDir`, `buildPrompt`, `parseHaikuResponse` (including fence-stripping and catch paths), `runMemoryAudit` (text + JSON modes, all error paths), `cmdMemory` (help, unknown subcommand, --json flag, unknown flag), `defaultDeps` safe I/O methods

🤖 Generated with [Claude Code](https://claude.com/claude-code)