### PR TITLE
feat(monitor): make --until accept glob patterns like --type (fixes #1560)

### DIFF
--- a/packages/command/src/commands/monitor.spec.ts
+++ b/packages/command/src/commands/monitor.spec.ts
@@ -800,6 +800,42 @@ describe("cmdMonitor", () => {
     expect(exitCalls).toEqual([0]);
   });
 
+  test("--until glob pattern matches prefix (pr.*)", async () => {
+    const events = [
+      makeEvent(SESSION_RESULT, {}),
+      makeEvent(PR_MERGED, { category: "work_item" }),
+      makeEvent(SESSION_ENDED, {}),
+    ];
+    const stdout: string[] = [];
+    const deps = makeStreamDeps(events, { writeStdout: (l) => stdout.push(l) });
+    await cmdMonitor(["--until", "pr.*"], deps);
+    expect(stdout.length).toBe(2); // SESSION_RESULT + PR_MERGED
+  });
+
+  test("--until glob pattern does not match unrelated events", async () => {
+    const events = [makeEvent(SESSION_RESULT, {}), makeEvent(SESSION_ENDED, {})];
+    const stderr: string[] = [];
+    const exitCalls: number[] = [];
+    const deps = makeStreamDeps(events, {
+      writeStderr: (l) => stderr.push(l),
+      exit: (code) => {
+        exitCalls.push(code);
+        return undefined as never;
+      },
+    });
+    await cmdMonitor(["--until", "pr.*"], deps);
+    expect(exitCalls).toEqual([2]);
+    expect(stderr.join("")).toContain("stream ended before terminator");
+  });
+
+  test("--until wildcard * matches any event", async () => {
+    const events = [makeEvent(SESSION_RESULT, {})];
+    const stdout: string[] = [];
+    const deps = makeStreamDeps(events, { writeStdout: (l) => stdout.push(l) });
+    await cmdMonitor(["--until", "*"], deps);
+    expect(stdout.length).toBe(1);
+  });
+
   test("non-EPIPE stdout errors do not trigger finish", async () => {
     let capturedErrHandler: ((err: Error) => void) | undefined;
     const exitCalls: number[] = [];

--- a/packages/command/src/commands/monitor.ts
+++ b/packages/command/src/commands/monitor.ts
@@ -9,7 +9,7 @@
  */
 
 import type { MonitorEvent } from "@mcp-cli/core";
-import { formatMonitorEvent, openEventStream } from "@mcp-cli/core";
+import { formatMonitorEvent, globToRegex, openEventStream } from "@mcp-cli/core";
 
 export interface MonitorArgs {
   json: boolean;
@@ -194,7 +194,7 @@ Filters (evaluated server-side):
   --since <seq>              Replay from cursor (reserved)
 
 Terminators:
-  --until <type>             Exit when this event type is seen
+  --until <pattern>          Exit when this event type is seen (glob: pr.*, session.*)
   --timeout <seconds>        Exit after N seconds
   --max-events <n>           Exit after N events
 
@@ -253,6 +253,7 @@ export async function cmdMonitor(args: string[], deps?: Partial<MonitorDeps>): P
 
   let count = 0;
   let terminatorSatisfied = false;
+  const untilRegex = parsed.until !== undefined ? globToRegex(parsed.until) : undefined;
 
   try {
     for await (const event of events) {
@@ -270,7 +271,7 @@ export async function cmdMonitor(args: string[], deps?: Partial<MonitorDeps>): P
         break;
       }
 
-      if (parsed.until !== undefined && (event as MonitorEvent).event === parsed.until) {
+      if (untilRegex?.test((event as MonitorEvent).event)) {
         terminatorSatisfied = true;
         abort();
         break;


### PR DESCRIPTION
## Summary
- `--until` now accepts glob patterns (`pr.*`, `session.*`, `checks.*`) using the same `globToRegex` helper already used by `--type`
- Previously, `--until pr.*` would wait forever for a literal event named `pr.*`; now it fires on any event matching the pattern
- Regex is compiled once before the event loop — no per-event allocations

## Test plan
- [x] `--until pr.*` stops on `pr.merged` (glob prefix match)
- [x] `--until pr.*` with only `session.*` events → exits 2 with "stream ended before terminator"
- [x] `--until *` stops on the first event (wildcard)
- [x] All 57 existing monitor tests still pass
- [x] Full test suite: 7356 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)