### PR TITLE
fix(test): replace identity-based assertion with poll-with-deadline in disconnect/closeAll tests (fixes #2103)

### DIFF
--- a/packages/daemon/src/server-pool.spec.ts
+++ b/packages/daemon/src/server-pool.spec.ts
@@ -4,7 +4,6 @@ import type { HttpServerConfig, SseServerConfig, StdioServerConfig } from "@mcp-
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
-import { getProcessStartTime } from "./process-identity";
 import {
   BASE_ENV_ALLOWLIST,
   type ConnectFn,
@@ -1702,14 +1701,18 @@ describe("disconnect kills stdio child processes (#940)", () => {
         return;
       }
 
-      const originalStartTime = getProcessStartTime(pid);
-
       await pool.disconnect("sleeper");
 
-      const postStartTime = getProcessStartTime(pid);
-      const originalProcessDead =
-        postStartTime === null || (originalStartTime !== null && Math.abs(postStartTime - originalStartTime) > 2_000);
-      expect(originalProcessDead).toBe(true);
+      const deadline = Date.now() + 5_000;
+      let dead = false;
+      while (Date.now() < deadline) {
+        if (!isAlive(pid)) {
+          dead = true;
+          break;
+        }
+        await Bun.sleep(100);
+      }
+      expect(dead).toBe(true);
     } finally {
       forceKill(pid);
     }
@@ -1745,21 +1748,18 @@ describe("disconnect kills stdio child processes (#940)", () => {
         return;
       }
 
-      // Capture the original process's start time so we can use identity-based
-      // assertions below. Bare isAlive(pid) is racy: if the OS recycles the PID
-      // between closeAll() and the assertion, a *different* process is alive at
-      // that PID and the test fails even though our process was killed correctly.
-      const originalStartTime = getProcessStartTime(pid);
-
       await pool.closeAll();
 
-      // Verify the *original* process is gone. If the PID was recycled, the new
-      // process will have a different start time — that still means ours was killed.
-      const postStartTime = getProcessStartTime(pid);
-      const originalProcessDead =
-        postStartTime === null || // PID no longer exists
-        (originalStartTime !== null && Math.abs(postStartTime - originalStartTime) > 2_000); // PID recycled
-      expect(originalProcessDead).toBe(true);
+      const deadline = Date.now() + 5_000;
+      let dead = false;
+      while (Date.now() < deadline) {
+        if (!isAlive(pid)) {
+          dead = true;
+          break;
+        }
+        await Bun.sleep(100);
+      }
+      expect(dead).toBe(true);
     } finally {
       forceKill(pid);
     }


### PR DESCRIPTION
## Summary

- Replace the single-shot `getProcessStartTime` identity-based assertion in the `disconnect` and `closeAll` tests with a poll-with-deadline loop using `isAlive(pid)`, per `test/CLAUDE.md` flaky test patterns
- The old assertion had a null-handling blind spot (`originalStartTime === null` caused both conditions to be false) and didn't account for `killPid` not having executed yet on slow CI runners (30ms test completion vs 110ms minimum for killPid)
- Remove unused `getProcessStartTime` import

## Production race (separate issue)

The underlying production race — `connectFn` → PID cache race in `ensureConnected` where `cachedChildPid` can be cached as `null` if the child exits during the `await` between connect resolution and PID read — is tracked in #2135. This PR only fixes the test flake.

## Test plan

- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test packages/daemon/src/server-pool.spec.ts` — 162 tests pass (including both modified tests)
- [x] `bun test` — full suite passes (7353 pass, 0 fail)
- [x] Both `disconnect sends SIGTERM` and `closeAll kills all` tests now use poll-with-deadline (5s deadline, 100ms poll interval) instead of point-in-time assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)