### PR TITLE
feat(monitor): add --repo flag to scope events to a repo root (closes #1563)

### DIFF
--- a/packages/command/src/commands/monitor.spec.ts
+++ b/packages/command/src/commands/monitor.spec.ts
@@ -28,6 +28,7 @@ import {
   SESSION_RESPONSE,
   SESSION_RESULT,
   formatMonitorEvent,
+  type openEventStream,
 } from "@mcp-cli/core";
 import type { MonitorDeps } from "./monitor";
 import { cmdMonitor, parseMonitorArgs } from "./monitor";
@@ -395,6 +396,15 @@ describe("parseMonitorArgs error branches", () => {
     const parsed = parseMonitorArgs(["--since", "42"]);
     expect(parsed.since).toBe(42);
   });
+
+  test("--repo parsed correctly", () => {
+    const parsed = parseMonitorArgs(["--repo", "/home/user/myrepo"]);
+    expect(parsed.repo).toBe("/home/user/myrepo");
+  });
+
+  test("--repo without value is an error", () => {
+    expect(parseMonitorArgs(["--repo"]).error).toBeTruthy();
+  });
 });
 
 // ── cmdMonitor unit tests (dependency-injected) ──
@@ -407,6 +417,7 @@ function makeStreamDeps(events: MonitorEvent[], overrides: Partial<MonitorDeps> 
   return {
     openEventStream: () => ({ events: gen(), abort: () => {} }),
     isTTY: true,
+    getCwd: () => "/test/repo",
     writeStdout: () => {},
     writeStderr: () => {},
     exit: (code) => {
@@ -498,6 +509,7 @@ describe("cmdMonitor", () => {
     const deps: MonitorDeps = {
       openEventStream: () => ({ events: abortStream, abort: () => {} }),
       isTTY: true,
+      getCwd: () => "/test/repo",
       writeStdout: () => {},
       writeStderr: () => {},
       exit: (code) => {
@@ -522,6 +534,7 @@ describe("cmdMonitor", () => {
     const deps: MonitorDeps = {
       openEventStream: () => ({ events: errorStream, abort: () => {} }),
       isTTY: true,
+      getCwd: () => "/test/repo",
       writeStdout: () => {},
       writeStderr: (l) => stderr.push(l),
       exit: (code) => {
@@ -547,6 +560,7 @@ describe("cmdMonitor", () => {
         },
       }),
       isTTY: true,
+      getCwd: () => "/test/repo",
       writeStdout: () => {},
       writeStderr: () => {},
       exit: (code) => {
@@ -569,6 +583,7 @@ describe("cmdMonitor", () => {
     const deps: MonitorDeps = {
       openEventStream: () => ({ events: emptyGen(), abort: () => {} }),
       isTTY: true,
+      getCwd: () => "/test/repo",
       writeStdout: () => {},
       writeStderr: () => {},
       exit: (code) => {
@@ -611,6 +626,7 @@ describe("cmdMonitor", () => {
         },
       }),
       isTTY: true,
+      getCwd: () => "/test/repo",
       writeStdout: () => {},
       writeStderr: () => {},
       exit: (code) => {
@@ -647,6 +663,7 @@ describe("cmdMonitor", () => {
         },
       }),
       isTTY: true,
+      getCwd: () => "/test/repo",
       writeStdout: () => {},
       writeStderr: () => {},
       exit: (code) => {
@@ -673,6 +690,7 @@ describe("cmdMonitor", () => {
         },
       }),
       isTTY: true,
+      getCwd: () => "/test/repo",
       writeStdout: () => {},
       writeStderr: () => {},
       exit: (code) => {
@@ -778,6 +796,7 @@ describe("cmdMonitor", () => {
         },
       }),
       isTTY: true,
+      getCwd: () => "/test/repo",
       writeStdout: () => {},
       writeStderr: () => {},
       exit: (code) => {
@@ -845,6 +864,7 @@ describe("cmdMonitor", () => {
     const deps: MonitorDeps = {
       openEventStream: () => ({ events: emptyGen(), abort: () => {} }),
       isTTY: true,
+      getCwd: () => "/test/repo",
       writeStdout: () => {},
       writeStderr: () => {},
       exit: (code) => {
@@ -863,5 +883,30 @@ describe("cmdMonitor", () => {
     const otherErr = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
     capturedErrHandler?.(otherErr);
     expect(exitCalls).toHaveLength(0);
+  });
+
+  test("--repo is passed to openEventStream", async () => {
+    let capturedParams: Parameters<typeof openEventStream>[0];
+    const deps = makeStreamDeps([], {
+      openEventStream: (params) => {
+        capturedParams = params;
+        return { events: (async function* () {})(), abort: () => {} };
+      },
+    });
+    await cmdMonitor(["--repo", "/custom/repo"], deps);
+    expect(capturedParams?.repo).toBe("/custom/repo");
+  });
+
+  test("repo defaults to getCwd() when --repo is not specified", async () => {
+    let capturedParams: Parameters<typeof openEventStream>[0];
+    const deps = makeStreamDeps([], {
+      getCwd: () => "/default/repo",
+      openEventStream: (params) => {
+        capturedParams = params;
+        return { events: (async function* () {})(), abort: () => {} };
+      },
+    });
+    await cmdMonitor([], deps);
+    expect(capturedParams?.repo).toBe("/default/repo");
   });
 });

--- a/packages/command/src/commands/monitor.ts
+++ b/packages/command/src/commands/monitor.ts
@@ -8,8 +8,9 @@
  * Part of #1486 (monitor epic), #1515 (projection layer).
  */
 
+import { resolve } from "node:path";
 import type { MonitorEvent } from "@mcp-cli/core";
-import { formatMonitorEvent, globToRegex, openEventStream } from "@mcp-cli/core";
+import { formatMonitorEvent, globToRegex, openEventStream, resolveRealpath } from "@mcp-cli/core";
 
 export interface MonitorArgs {
   json: boolean;
@@ -229,7 +230,7 @@ export async function cmdMonitor(args: string[], deps?: Partial<MonitorDeps>): P
 
   const useJson = parsed.json || !d.isTTY;
 
-  const repo = parsed.repo ?? d.getCwd();
+  const repo = resolveRealpath(resolve(parsed.repo ?? d.getCwd()));
 
   const { events, abort } = d.openEventStream({
     subscribe: parsed.subscribe,

--- a/packages/command/src/commands/monitor.ts
+++ b/packages/command/src/commands/monitor.ts
@@ -21,6 +21,7 @@ export interface MonitorArgs {
   type: string | undefined;
   src: string | undefined;
   phase: string | undefined;
+  repo: string | undefined;
   since: number | undefined;
   until: string | undefined;
   timeout: number | undefined;
@@ -31,6 +32,7 @@ export interface MonitorArgs {
 export interface MonitorDeps {
   openEventStream: typeof openEventStream;
   isTTY: boolean;
+  getCwd: () => string;
   writeStdout: (line: string) => void;
   writeStderr: (line: string) => void;
   exit: (code: number) => never;
@@ -42,6 +44,7 @@ export interface MonitorDeps {
 const defaultDeps: MonitorDeps = {
   openEventStream,
   isTTY: Boolean(process.stdout.isTTY),
+  getCwd: () => process.cwd(),
   writeStdout: (line) => process.stdout.write(line),
   writeStderr: (line) => process.stderr.write(line),
   exit: (code) => process.exit(code),
@@ -59,6 +62,7 @@ export function parseMonitorArgs(args: string[]): MonitorArgs {
   let type: string | undefined;
   let src: string | undefined;
   let phase: string | undefined;
+  let repo: string | undefined;
   let since: number | undefined;
   let until: string | undefined;
   let timeout: number | undefined;
@@ -121,6 +125,12 @@ export function parseMonitorArgs(args: string[]): MonitorArgs {
         error = "--phase requires a value";
         break;
       }
+    } else if (arg === "--repo") {
+      repo = args[++i];
+      if (!repo) {
+        error = "--repo requires a path";
+        break;
+      }
     } else if (arg === "--since") {
       const next = args[++i];
       const n = Number(next);
@@ -166,6 +176,7 @@ export function parseMonitorArgs(args: string[]): MonitorArgs {
     type,
     src,
     phase,
+    repo,
     since,
     until,
     timeout,
@@ -191,6 +202,7 @@ Filters (evaluated server-side):
   --type <name>              Event type filter (e.g. session.result)
   --src <pattern>            Source attribution filter
   --phase <name>             Only items in this phase
+  --repo <path>              Scope to repo root (default: current working directory)
   --since <seq>              Replay from cursor (reserved)
 
 Terminators:
@@ -217,6 +229,8 @@ export async function cmdMonitor(args: string[], deps?: Partial<MonitorDeps>): P
 
   const useJson = parsed.json || !d.isTTY;
 
+  const repo = parsed.repo ?? d.getCwd();
+
   const { events, abort } = d.openEventStream({
     subscribe: parsed.subscribe,
     session: parsed.session,
@@ -225,6 +239,7 @@ export async function cmdMonitor(args: string[], deps?: Partial<MonitorDeps>): P
     type: parsed.type,
     src: parsed.src,
     phase: parsed.phase,
+    repo,
     since: parsed.since,
     responseTail: parsed.responseTail,
   });

--- a/packages/core/src/event-filter.spec.ts
+++ b/packages/core/src/event-filter.spec.ts
@@ -104,6 +104,17 @@ describe("matchFilter", () => {
     expect(matchFilter(makeEvent({ phase: "impl" }), spec)).toBe(false);
   });
 
+  test("repo filter matches repoRoot field", () => {
+    const spec: EventFilterSpec = { repo: "/home/user/myrepo" };
+    expect(matchFilter(makeEvent({ repoRoot: "/home/user/myrepo" }), spec)).toBe(true);
+    expect(matchFilter(makeEvent({ repoRoot: "/home/user/other" }), spec)).toBe(false);
+  });
+
+  test("repo filter passes through events with no repoRoot (unscoped events)", () => {
+    const spec: EventFilterSpec = { repo: "/home/user/myrepo" };
+    expect(matchFilter(makeEvent({}), spec)).toBe(true);
+  });
+
   test("multiple filter axes — all must match (AND)", () => {
     const spec: EventFilterSpec = { pr: 10, type: "ci.*" };
     expect(matchFilter(makeEvent({ prNumber: 10, event: "ci.finished" }), spec)).toBe(true);
@@ -158,12 +169,20 @@ describe("filterSpecToStreamParams", () => {
   });
 
   test("passes through scalar fields", () => {
-    const p = filterSpecToStreamParams({ pr: 42, session: "s1", workItem: "w1", src: "x", phase: "impl" });
+    const p = filterSpecToStreamParams({
+      pr: 42,
+      session: "s1",
+      workItem: "w1",
+      src: "x",
+      phase: "impl",
+      repo: "/repo",
+    });
     expect(p.pr).toBe(42);
     expect(p.session).toBe("s1");
     expect(p.workItem).toBe("w1");
     expect(p.src).toBe("x");
     expect(p.phase).toBe("impl");
+    expect(p.repo).toBe("/repo");
   });
 
   test("undefined fields stay undefined", () => {

--- a/packages/core/src/event-filter.ts
+++ b/packages/core/src/event-filter.ts
@@ -21,6 +21,8 @@ export interface EventFilterSpec {
   workItem?: string;
   src?: string;
   phase?: string;
+  /** Filter to events scoped to this repo root. Events with no repoRoot pass through. */
+  repo?: string;
 }
 
 export class WaitTimeoutError extends Error {
@@ -67,6 +69,7 @@ export function createEventMatcher(spec: EventFilterSpec): (event: MonitorEvent)
       if (!srcPattern.test(event.src)) return false;
     }
     if (spec.phase !== undefined && event.phase !== spec.phase) return false;
+    if (spec.repo !== undefined && event.repoRoot !== undefined && event.repoRoot !== spec.repo) return false;
     return true;
   };
 }
@@ -97,6 +100,7 @@ export function filterSpecToStreamParams(spec: EventFilterSpec): {
   type?: string;
   src?: string;
   phase?: string;
+  repo?: string;
 } {
   return {
     subscribe: spec.subscribe?.join(","),
@@ -106,6 +110,7 @@ export function filterSpecToStreamParams(spec: EventFilterSpec): {
     type: Array.isArray(spec.type) ? spec.type.join(",") : spec.type,
     src: spec.src,
     phase: spec.phase,
+    repo: spec.repo,
   };
 }
 

--- a/packages/core/src/ipc-client.ts
+++ b/packages/core/src/ipc-client.ts
@@ -220,6 +220,8 @@ export function openEventStream(params?: {
   src?: string;
   /** Filter to a specific phase */
   phase?: string;
+  /** Scope to events from sessions in this repo root path. Events with no repoRoot pass through. */
+  repo?: string;
   /** Include session.response chunks for this session ID only */
   responseTail?: string;
 }): { events: AsyncIterable<import("./monitor-event").MonitorEvent>; abort: () => void } {
@@ -232,6 +234,7 @@ export function openEventStream(params?: {
   if (params?.type) qs.set("type", params.type);
   if (params?.src) qs.set("src", params.src);
   if (params?.phase) qs.set("phase", params.phase);
+  if (params?.repo) qs.set("repo", params.repo);
   if (params?.responseTail) qs.set("responseTail", params.responseTail);
 
   const controller = new AbortController();

--- a/packages/core/src/monitor-event.ts
+++ b/packages/core/src/monitor-event.ts
@@ -134,7 +134,7 @@ export interface MonitorEventBase {
   workItemId?: string;
   sessionId?: string;
   prNumber?: number;
-  /** Repo root path this event is scoped to. Present on session events; absent on global events (mail, quota, heartbeats). */
+  /** Repo root path this event is scoped to. Present when known / when session is repo-scoped; absent on global events (mail, quota, heartbeats) and sessions started without a configured or discoverable repo root. */
   repoRoot?: string;
   /** Causal chain of seq IDs — present on events from DerivedEventPublisher (src:"daemon.derived"). Depth is capped at 4. */
   causedBy?: number[];

--- a/packages/core/src/monitor-event.ts
+++ b/packages/core/src/monitor-event.ts
@@ -134,6 +134,8 @@ export interface MonitorEventBase {
   workItemId?: string;
   sessionId?: string;
   prNumber?: number;
+  /** Repo root path this event is scoped to. Present on session events; absent on global events (mail, quota, heartbeats). */
+  repoRoot?: string;
   /** Causal chain of seq IDs — present on events from DerivedEventPublisher (src:"daemon.derived"). Depth is capped at 4. */
   causedBy?: number[];
   [key: string]: unknown;

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -49,6 +49,7 @@ import {
   SESSION_TOOL_USE,
   WORKER_RATELIMITED,
   consoleLogger,
+  findGitRoot,
   generateSessionName,
 } from "@mcp-cli/core";
 import type { ServerWebSocket } from "bun";
@@ -1875,7 +1876,9 @@ export class ClaudeWsServer {
     const mapped = ClaudeWsServer.SESSION_EVENT_MAP[event.type];
     if (!mapped) return;
 
-    const sessionRepoRoot = this.sessions.get(sessionId)?.config?.repoRoot;
+    const sessionConfig = this.sessions.get(sessionId)?.config;
+    const sessionRepoRoot =
+      sessionConfig?.repoRoot ?? (sessionConfig?.cwd ? (findGitRoot(sessionConfig.cwd) ?? undefined) : undefined);
     const input: MonitorEventInput = {
       src: "daemon.claude-server",
       event: mapped,

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -1875,11 +1875,13 @@ export class ClaudeWsServer {
     const mapped = ClaudeWsServer.SESSION_EVENT_MAP[event.type];
     if (!mapped) return;
 
+    const sessionRepoRoot = this.sessions.get(sessionId)?.config?.repoRoot;
     const input: MonitorEventInput = {
       src: "daemon.claude-server",
       event: mapped,
       category: "session",
       sessionId,
+      ...(sessionRepoRoot ? { repoRoot: sessionRepoRoot } : {}),
     };
 
     if ("cost" in event) input.cost = event.cost;

--- a/packages/daemon/src/event-stream.ts
+++ b/packages/daemon/src/event-stream.ts
@@ -234,6 +234,7 @@ export class EventStreamServer {
    *   type=<glob>              Event name glob filter (comma-separated OR)
    *   src=<pattern>            Source attribution glob filter
    *   phase=<name>             Phase filter on work item phase
+   *   repo=<path>              Scope to repo root (pass-through for events with no repoRoot)
    *   since=<seq>              Replay events after this cursor from the durable log (#1513)
    *   responseTail=<sessionId> Include session.response chunks for this session only
    */

--- a/packages/daemon/src/ipc-filter.ts
+++ b/packages/daemon/src/ipc-filter.ts
@@ -20,8 +20,9 @@ export function buildEventFilter(params: URLSearchParams): ((event: Record<strin
   const typeRaw = params.get("type");
   const srcRaw = params.get("src");
   const phase = params.get("phase");
+  const repo = params.get("repo");
 
-  if (!subscribeRaw && !session && prRaw === null && !workItem && !typeRaw && !srcRaw && !phase) {
+  if (!subscribeRaw && !session && prRaw === null && !workItem && !typeRaw && !srcRaw && !phase && !repo) {
     return null;
   }
 
@@ -52,6 +53,7 @@ export function buildEventFilter(params: URLSearchParams): ((event: Record<strin
       : {}),
     ...(srcRaw ? { src: srcRaw } : {}),
     ...(phase ? { phase } : {}),
+    ...(repo ? { repo } : {}),
   };
 
   const matcher = createEventMatcher(spec);

--- a/packages/daemon/src/ipc-filter.ts
+++ b/packages/daemon/src/ipc-filter.ts
@@ -3,7 +3,8 @@
  * Extracted from ipc-server.ts to break the event-stream ↔ ipc-server circular dependency.
  */
 
-import { type EventFilterSpec, type MonitorEvent, createEventMatcher } from "@mcp-cli/core";
+import { resolve } from "node:path";
+import { type EventFilterSpec, type MonitorEvent, createEventMatcher, resolveRealpath } from "@mcp-cli/core";
 
 /**
  * Build a server-side predicate from GET /events query params.
@@ -20,7 +21,8 @@ export function buildEventFilter(params: URLSearchParams): ((event: Record<strin
   const typeRaw = params.get("type");
   const srcRaw = params.get("src");
   const phase = params.get("phase");
-  const repo = params.get("repo");
+  const repoRaw = params.get("repo");
+  const repo = repoRaw ? resolveRealpath(resolve(repoRaw)) : null;
 
   if (!subscribeRaw && !session && prRaw === null && !workItem && !typeRaw && !srcRaw && !phase && !repo) {
     return null;

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -4194,4 +4194,17 @@ describe("buildEventFilter", () => {
     expect(filter?.({ category: "heartbeat", event: "heartbeat" })).toBe(true);
     expect(filter?.({ category: "heartbeat", event: "heartbeat", src: "daemon" })).toBe(true);
   });
+
+  test("repo filter matches repoRoot field", () => {
+    const filter = buildEventFilter(params({ repo: "/home/user/myrepo" }));
+    expect(filter).not.toBeNull();
+    expect(filter?.({ repoRoot: "/home/user/myrepo", event: "session.result" })).toBe(true);
+    expect(filter?.({ repoRoot: "/home/user/other", event: "session.result" })).toBe(false);
+  });
+
+  test("repo filter passes through events with no repoRoot", () => {
+    const filter = buildEventFilter(params({ repo: "/home/user/myrepo" }));
+    expect(filter?.({ event: "mail.sent", category: "mail" })).toBe(true);
+    expect(filter?.({ event: "quota.threshold", category: "quota" })).toBe(true);
+  });
 });

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -4097,6 +4097,8 @@ describe("IpcServer HTTP transport", () => {
 
 // ── buildEventFilter unit tests ──
 
+import { resolve } from "node:path";
+import { resolveRealpath } from "@mcp-cli/core";
 import { buildEventFilter } from "./ipc-server";
 
 describe("buildEventFilter", () => {
@@ -4196,10 +4198,13 @@ describe("buildEventFilter", () => {
   });
 
   test("repo filter matches repoRoot field", () => {
-    const filter = buildEventFilter(params({ repo: "/home/user/myrepo" }));
+    // Use canonical paths — /home on macOS is a symlink; resolveRealpath matches daemon normalisation
+    const REPO = resolveRealpath(resolve("/home/user/myrepo"));
+    const OTHER = resolveRealpath(resolve("/home/user/other"));
+    const filter = buildEventFilter(params({ repo: REPO }));
     expect(filter).not.toBeNull();
-    expect(filter?.({ repoRoot: "/home/user/myrepo", event: "session.result" })).toBe(true);
-    expect(filter?.({ repoRoot: "/home/user/other", event: "session.result" })).toBe(false);
+    expect(filter?.({ repoRoot: REPO, event: "session.result" })).toBe(true);
+    expect(filter?.({ repoRoot: OTHER, event: "session.result" })).toBe(false);
   });
 
   test("repo filter passes through events with no repoRoot", () => {


### PR DESCRIPTION
## Summary
- Add `--repo <path>` flag to `mcx monitor` that scopes events to a specific repo root; defaults to `process.cwd()` when omitted
- Server-side: `repo` param flows through `openEventStream()` → `GET /events?repo=` → `buildEventFilter()` → `createEventMatcher()`, which passes events with no `repoRoot` through (heartbeats, mail, quota) and filters session events that have a non-matching `repoRoot`
- Session events now include `repoRoot` in their payload, sourced from `session.config.repoRoot` in `publishSessionMonitorEvent()`

## Test plan
- [x] `parseMonitorArgs(["--repo", "/path"])` returns correct `repo` field
- [x] `parseMonitorArgs(["--repo"])` with missing value sets error
- [x] `cmdMonitor` passes `--repo` value to `openEventStream`
- [x] `cmdMonitor` defaults `repo` to `getCwd()` when `--repo` is omitted
- [x] `buildEventFilter` with `repo=X` passes events with matching `repoRoot`, rejects events with different `repoRoot`, passes through events with no `repoRoot`
- [x] `createEventMatcher` with `repo` spec: same pass-through/match/reject semantics
- [x] `filterSpecToStreamParams` includes `repo` field
- [x] `bun typecheck` ✓ `bun lint` ✓ `bun test` (7361 pass, 0 fail) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)