### PR TITLE
feat(resume): accept ended sessions in spawn --resume (fixes #2114)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -60,6 +60,7 @@ function makeDeps(overrides?: Partial<ClaudeDeps>): ClaudeDeps {
       reason: "no patch needed",
     })),
     readFileWithLimit: mock(() => "file content"),
+    getAgentSession: mock(async () => null),
     ...overrides,
   };
 }
@@ -922,6 +923,107 @@ describe("mcx claude spawn", () => {
     });
     await expect(cmdClaude(["spawn", "--task", "@/tmp/missing.md"], deps)).rejects.toThrow(ExitError);
     expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("does not exist"));
+  });
+
+  test("--resume with ended session uses resumeSessionId instead of sessionId", async () => {
+    const callTool = mock(async () => toolResult({ sessionId: "new-session", seq: 1 }));
+    const getAgentSession = mock(async () => ({
+      sessionId: "daemon-ended",
+      state: "ended",
+      cwd: "/tmp/worktree",
+      claudeSessionId: "claude-abc123",
+    }));
+    const deps = makeDeps({ callTool, getAgentSession });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["spawn", "--resume", "daemon-ended", "--task", "continue"], deps);
+      expect(callTool).toHaveBeenCalledWith("claude_prompt", {
+        prompt: "continue",
+        resumeSessionId: "claude-abc123",
+        cwd: "/tmp/worktree",
+      });
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("--resume with ended session inherits cwd from DB when caller has no explicit cwd", async () => {
+    const callTool = mock(async () => toolResult({ sessionId: "new", seq: 1 }));
+    const getAgentSession = mock(async () => ({
+      sessionId: "daemon-ended",
+      state: "ended",
+      cwd: "/projects/myrepo/.claude/worktrees/feat",
+      claudeSessionId: "claude-xyz789",
+    }));
+    const deps = makeDeps({ callTool, getAgentSession });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["spawn", "--resume", "daemon-ended"], deps);
+      const callArgs = (callTool.mock.calls[0] as unknown as [string, Record<string, unknown>])[1];
+      expect(callArgs.resumeSessionId).toBe("claude-xyz789");
+      expect(callArgs.cwd).toBe("/projects/myrepo/.claude/worktrees/feat");
+      expect(callArgs.sessionId).toBeUndefined();
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("--resume with ended session with no claudeSessionId exits with error", async () => {
+    const callTool = mock(async () => toolResult({ sessionId: "new", seq: 1 }));
+    const getAgentSession = mock(async () => ({
+      sessionId: "daemon-ended",
+      state: "ended",
+      cwd: "/tmp/worktree",
+      claudeSessionId: null,
+    }));
+    const deps = makeDeps({ callTool, getAgentSession });
+
+    await expect(cmdClaude(["spawn", "--resume", "daemon-ended"], deps)).rejects.toThrow(ExitError);
+    expect(callTool).not.toHaveBeenCalled();
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("has no recorded Claude session ID"));
+  });
+
+  test("--resume with active session still uses sessionId", async () => {
+    const callTool = mock(async () => toolResult({ sessionId: "existing", seq: 5 }));
+    const getAgentSession = mock(async () => ({
+      sessionId: "daemon-active",
+      state: "idle",
+      cwd: "/tmp/worktree",
+      claudeSessionId: "claude-abc",
+    }));
+    const deps = makeDeps({ callTool, getAgentSession });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["spawn", "--resume", "daemon-active", "--task", "keep going"], deps);
+      const callArgs = (callTool.mock.calls[0] as unknown as [string, Record<string, unknown>])[1];
+      expect(callArgs.sessionId).toBe("daemon-active");
+      expect(callArgs.resumeSessionId).toBeUndefined();
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("--resume when session not in DB still uses sessionId (in-memory active session)", async () => {
+    const callTool = mock(async () => toolResult({ sessionId: "abc", seq: 1 }));
+    const getAgentSession = mock(async () => null);
+    const deps = makeDeps({ callTool, getAgentSession });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["spawn", "--resume", "in-memory-id", "--task", "continue"], deps);
+      const callArgs = (callTool.mock.calls[0] as unknown as [string, Record<string, unknown>])[1];
+      expect(callArgs.sessionId).toBe("in-memory-id");
+      expect(callArgs.resumeSessionId).toBeUndefined();
+    } finally {
+      console.log = origLog;
+    }
   });
 });
 

--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -987,6 +987,25 @@ describe("mcx claude spawn", () => {
     expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("has no recorded Claude session ID"));
   });
 
+  test("--resume (ended session) + --worktree exits with clear error before creating worktree", async () => {
+    const callTool = mock(async () => toolResult({ sessionId: "new", seq: 1 }));
+    const getAgentSession = mock(async () => ({
+      sessionId: "daemon-ended",
+      state: "ended",
+      cwd: "/tmp/worktree",
+      claudeSessionId: "claude-abc123",
+    }));
+    const deps = makeDeps({ callTool, getAgentSession });
+
+    await expect(cmdClaude(["spawn", "--resume", "daemon-ended", "--worktree", "my-branch"], deps)).rejects.toThrow(
+      ExitError,
+    );
+    expect(callTool).not.toHaveBeenCalled();
+    // exec should not have been called — worktree must not be created before the error
+    expect(deps.exec).not.toHaveBeenCalled();
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("--worktree and --resume"));
+  });
+
   test("--resume with active session still uses sessionId", async () => {
     const callTool = mock(async () => toolResult({ sessionId: "existing", seq: 5 }));
     const getAgentSession = mock(async () => ({

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -87,6 +87,13 @@ export interface ClaudeDeps extends SharedSessionDeps {
   runPatchUpdate: typeof updatePatchedClaude;
   /** Read a file by path, enforcing size limits. Injected for testability. */
   readFileWithLimit: (path: string) => string;
+  /** Look up a session from the DB (including ended sessions). Injected for testability. */
+  getAgentSession: (sessionId: string) => Promise<{
+    sessionId: string;
+    state: string;
+    cwd: string | null;
+    claudeSessionId: string | null;
+  } | null>;
 }
 
 /**
@@ -213,6 +220,21 @@ export const defaultDeps: ClaudeDeps = {
   },
   runPatchUpdate: updatePatchedClaude,
   readFileWithLimit,
+  getAgentSession: async (sessionId) => {
+    try {
+      const result = (await ipcCall("getAgentSession", { sessionId })) as {
+        session: {
+          sessionId: string;
+          state: string;
+          cwd: string | null;
+          claudeSessionId: string | null;
+        } | null;
+      };
+      return result.session;
+    } catch {
+      return null;
+    }
+  },
 };
 
 // ── Entry point ──
@@ -449,6 +471,26 @@ function tryWriteInitialTransition(workItemId: string, gitRoot: string): void {
   }
 }
 
+/**
+ * If daemonSessionId refers to an ended session with a known claudeSessionId,
+ * return the info needed to spawn a fresh session restoring its JSONL history.
+ * Returns null for active/in-memory sessions (caller should use sessionId as-is).
+ */
+async function resolveEndedSessionForResume(
+  daemonSessionId: string,
+  d: ClaudeDeps,
+): Promise<{ claudeSessionId: string; cwd: string | null } | null> {
+  const session = await d.getAgentSession(daemonSessionId);
+  if (!session || session.state !== "ended") return null;
+  if (!session.claudeSessionId) {
+    d.printError(
+      `Session ${daemonSessionId} is ended but has no recorded Claude session ID — cannot resume transcript. The session may have ended before its first response was received.`,
+    );
+    d.exit(1);
+  }
+  return { claudeSessionId: session.claudeSessionId, cwd: session.cwd };
+}
+
 async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
   if (hasHelpFlag(args)) {
     const spawnHelp = getHelp("claude spawn");
@@ -496,11 +538,26 @@ async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
   }
 
   const toolArgs: Record<string, unknown> = { prompt: task };
-  if (parsed.resume) toolArgs.sessionId = parsed.resume;
+  if (parsed.resume) {
+    // Check if the target session is ended — if so, use resumeSessionId on a fresh spawn
+    // rather than sessionId (which would try to send a follow-up to a dead session).
+    const endedSession = await resolveEndedSessionForResume(parsed.resume, d);
+    if (endedSession) {
+      // Spawn a new session restoring history from the ended session's JSONL transcript.
+      toolArgs.resumeSessionId = endedSession.claudeSessionId;
+      // Inherit the original session's cwd when the caller hasn't set one explicitly.
+      if (!parsed.cwd && !parsed.worktree && endedSession.cwd) {
+        toolArgs.cwd = endedSession.cwd;
+      }
+    } else {
+      // Session is active (or not in DB) — send as follow-up prompt to existing session.
+      toolArgs.sessionId = parsed.resume;
+    }
+  }
   if (parsed.allow.length > 0) toolArgs.allowedTools = parsed.allow;
   // Without this, sessions inherit daemon cwd instead of caller's shell (#1331).
   if (parsed.cwd) toolArgs.cwd = parsed.cwd;
-  else if (!parsed.worktree) toolArgs.cwd = process.cwd();
+  else if (!parsed.worktree && !toolArgs.cwd) toolArgs.cwd = process.cwd();
   if (parsed.timeout) toolArgs.timeout = parsed.timeout;
   if (parsed.model) toolArgs.model = parsed.model;
   if (parsed.name) toolArgs.name = parsed.name;

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -543,10 +543,16 @@ async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
     // rather than sessionId (which would try to send a follow-up to a dead session).
     const endedSession = await resolveEndedSessionForResume(parsed.resume, d);
     if (endedSession) {
+      if (parsed.worktree) {
+        d.printError(
+          "--worktree and --resume (ended session) cannot be combined: restoring conversation history requires the original session's working directory, not a new worktree. Drop --worktree to resume, or omit --resume to start fresh in the new worktree.",
+        );
+        d.exit(1);
+      }
       // Spawn a new session restoring history from the ended session's JSONL transcript.
       toolArgs.resumeSessionId = endedSession.claudeSessionId;
       // Inherit the original session's cwd when the caller hasn't set one explicitly.
-      if (!parsed.cwd && !parsed.worktree && endedSession.cwd) {
+      if (!parsed.cwd && endedSession.cwd) {
         toolArgs.cwd = endedSession.cwd;
       }
     } else {

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -69,7 +69,8 @@ export type IpcMethod =
   | "setBudgetConfig"
   | "publishEvent"
   | "listAutomation"
-  | "getAutomationLog";
+  | "getAutomationLog"
+  | "getAgentSession";
 
 // -- Request/Response --
 
@@ -599,6 +600,25 @@ export interface GetAutomationLogResult {
   entries: AutomationLogEntry[];
 }
 
+export const GetAgentSessionParamsSchema = z.object({
+  sessionId: z.string(),
+});
+
+export interface GetAgentSessionResult {
+  session: {
+    sessionId: string;
+    name: string | null;
+    provider: string;
+    state: string;
+    cwd: string | null;
+    worktree: string | null;
+    repoRoot: string | null;
+    claudeSessionId: string | null;
+    spawnedAt: string;
+    endedAt: string | null;
+  } | null;
+}
+
 // -- Result types for methods without a named interface --
 
 export interface PingResult {
@@ -817,6 +837,7 @@ export interface IpcMethodResult {
   publishEvent: PublishEventResult;
   listAutomation: ListAutomationResult;
   getAutomationLog: GetAutomationLogResult;
+  getAgentSession: GetAgentSessionResult;
 }
 
 // -- Error codes --

--- a/packages/daemon/src/abstract-worker-server.ts
+++ b/packages/daemon/src/abstract-worker-server.ts
@@ -27,6 +27,7 @@ export interface DbUpsertSession {
   cwd?: string;
   worktree?: string;
   repoRoot?: string;
+  claudeSessionId?: string;
 }
 
 interface DbUpsert {

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -649,6 +649,7 @@ function forwardSessionEvent(sessionId: string, event: SessionEvent): void {
           state: event.state,
           model: event.model,
           cwd: event.cwd,
+          claudeSessionId: event.sessionId,
         },
       });
       break;

--- a/packages/daemon/src/db/state.spec.ts
+++ b/packages/daemon/src/db/state.spec.ts
@@ -1848,13 +1848,13 @@ describe("StateDb", () => {
   });
 
   describe("migrations", () => {
-    test("fresh DB sets schema version to 5", () => {
+    test("fresh DB sets schema version to 6", () => {
       const db = createDb();
       // biome-ignore lint/complexity/useLiteralKeys: access private field for test
       const version = db["db"]
         .query<{ version: number }, [string]>("SELECT version FROM schema_versions WHERE name = ?")
         .get("state")?.version;
-      expect(version).toBe(5);
+      expect(version).toBe(6);
       db.close();
     });
 
@@ -1869,7 +1869,7 @@ describe("StateDb", () => {
       const version = db2["db"]
         .query<{ version: number }, [string]>("SELECT version FROM schema_versions WHERE name = ?")
         .get("state")?.version;
-      expect(version).toBe(5);
+      expect(version).toBe(6);
       db2.close();
     });
 
@@ -1889,7 +1889,7 @@ describe("StateDb", () => {
       const version = db["db"]
         .query<{ version: number }, [string]>("SELECT version FROM schema_versions WHERE name = ?")
         .get("state")?.version;
-      expect(version).toBe(5);
+      expect(version).toBe(6);
       db.close();
     });
 
@@ -2133,6 +2133,53 @@ describe("StateDb", () => {
       expect(cols).toContain("repo_root");
       expect(cols).toContain("pid_start_time");
       expect(cols).toContain("name");
+      expect(cols).toContain("claude_session_id");
+      db.close();
+    });
+
+    test("v6 migration adds claude_session_id to pre-existing agent_sessions table", () => {
+      const p = tmpDb();
+      paths.push(p);
+
+      const { Database } = require("bun:sqlite");
+      const raw = new Database(p, { create: true });
+      raw.exec("PRAGMA journal_mode = WAL");
+      raw.exec(`
+        CREATE TABLE schema_versions (name TEXT PRIMARY KEY, version INTEGER NOT NULL);
+        CREATE TABLE agent_sessions (
+          session_id TEXT PRIMARY KEY,
+          state TEXT NOT NULL DEFAULT 'connecting',
+          spawned_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        INSERT INTO schema_versions (name, version) VALUES ('state', 5);
+        INSERT INTO agent_sessions (session_id, state) VALUES ('sess-old', 'ended');
+      `);
+      raw.close();
+
+      const db = new StateDb(p);
+      // biome-ignore lint/complexity/useLiteralKeys: access private field for test
+      const cols = (db["db"].prepare("PRAGMA table_info(agent_sessions)").all() as Array<{ name: string }>).map(
+        (r) => r.name,
+      );
+      expect(cols).toContain("claude_session_id");
+      db.close();
+    });
+
+    test("upsertSession with claudeSessionId persists and round-trips", () => {
+      const db = createDb();
+      db.upsertSession({ sessionId: "sess-csid", claudeSessionId: "claude-abc123" });
+      const row = db.getSession("sess-csid");
+      expect(row?.claudeSessionId).toBe("claude-abc123");
+      db.close();
+    });
+
+    test("upsertSession claudeSessionId is preserved on partial update", () => {
+      const db = createDb();
+      db.upsertSession({ sessionId: "sess-csid2", claudeSessionId: "claude-xyz" });
+      db.upsertSession({ sessionId: "sess-csid2", state: "idle" });
+      const row = db.getSession("sess-csid2");
+      expect(row?.claudeSessionId).toBe("claude-xyz");
+      expect(row?.state).toBe("idle");
       db.close();
     });
 

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -280,9 +280,9 @@ export class StateDb {
             )
             .get()?.n ?? 0) > 0;
         if (hasAgentSessions) {
-          const hasCol = (
-            this.db.prepare("PRAGMA table_info(agent_sessions)").all() as Array<{ name: string }>
-          ).some((r) => r.name === "claude_session_id");
+          const hasCol = (this.db.prepare("PRAGMA table_info(agent_sessions)").all() as Array<{ name: string }>).some(
+            (r) => r.name === "claude_session_id",
+          );
           if (!hasCol) {
             this.db.exec("ALTER TABLE agent_sessions ADD COLUMN claude_session_id TEXT");
           }

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -43,6 +43,7 @@ export interface AgentSessionRow {
   totalTokens: number;
   spawnedAt: string;
   endedAt: string | null;
+  claudeSessionId: string | null;
 }
 
 /** @deprecated Use AgentSessionRow instead. */
@@ -268,6 +269,27 @@ export class StateDb {
         this.setSchemaVersion(CONSUMER, 5);
       })();
       version = 5;
+    }
+
+    if (version < 6) {
+      this.db.transaction(() => {
+        const hasAgentSessions =
+          (this.db
+            .query<{ n: number }, []>(
+              "SELECT count(*) AS n FROM sqlite_master WHERE type='table' AND name='agent_sessions'",
+            )
+            .get()?.n ?? 0) > 0;
+        if (hasAgentSessions) {
+          const hasCol = (
+            this.db.prepare("PRAGMA table_info(agent_sessions)").all() as Array<{ name: string }>
+          ).some((r) => r.name === "claude_session_id");
+          if (!hasCol) {
+            this.db.exec("ALTER TABLE agent_sessions ADD COLUMN claude_session_id TEXT");
+          }
+        }
+        this.setSchemaVersion(CONSUMER, 6);
+      })();
+      version = 6;
     }
   }
 
@@ -1201,10 +1223,11 @@ export class StateDb {
     cwd?: string;
     worktree?: string;
     repoRoot?: string;
+    claudeSessionId?: string;
   }): void {
     this.db.run(
-      `INSERT INTO agent_sessions (session_id, name, provider, pid, pid_start_time, state, model, cwd, worktree, repo_root)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `INSERT INTO agent_sessions (session_id, name, provider, pid, pid_start_time, state, model, cwd, worktree, repo_root, claude_session_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(session_id) DO UPDATE SET
          name = COALESCE(excluded.name, agent_sessions.name),
          provider = COALESCE(excluded.provider, agent_sessions.provider),
@@ -1214,7 +1237,8 @@ export class StateDb {
          model = COALESCE(excluded.model, agent_sessions.model),
          cwd = COALESCE(excluded.cwd, agent_sessions.cwd),
          worktree = COALESCE(excluded.worktree, agent_sessions.worktree),
-         repo_root = COALESCE(excluded.repo_root, agent_sessions.repo_root)`,
+         repo_root = COALESCE(excluded.repo_root, agent_sessions.repo_root),
+         claude_session_id = COALESCE(excluded.claude_session_id, agent_sessions.claude_session_id)`,
       [
         session.sessionId,
         session.name ?? null,
@@ -1226,6 +1250,7 @@ export class StateDb {
         session.cwd ?? null,
         session.worktree ?? null,
         session.repoRoot ?? null,
+        session.claudeSessionId ?? null,
       ],
     );
   }
@@ -1251,7 +1276,7 @@ export class StateDb {
   getSession(sessionId: string): AgentSessionRow | null {
     const row = this.db
       .query<RawSessionRow, [string]>(
-        "SELECT session_id, name, provider, pid, pid_start_time, state, model, cwd, worktree, repo_root, total_cost, total_tokens, spawned_at, ended_at FROM agent_sessions WHERE session_id = ?",
+        "SELECT session_id, name, provider, pid, pid_start_time, state, model, cwd, worktree, repo_root, total_cost, total_tokens, spawned_at, ended_at, claude_session_id FROM agent_sessions WHERE session_id = ?",
       )
       .get(sessionId);
     return row ? toSessionRow(row) : null;
@@ -1261,7 +1286,7 @@ export class StateDb {
     const where = active === true ? " WHERE ended_at IS NULL" : active === false ? " WHERE ended_at IS NOT NULL" : "";
     return this.db
       .query<RawSessionRow, []>(
-        `SELECT session_id, name, provider, pid, pid_start_time, state, model, cwd, worktree, repo_root, total_cost, total_tokens, spawned_at, ended_at FROM agent_sessions${where} ORDER BY spawned_at DESC`,
+        `SELECT session_id, name, provider, pid, pid_start_time, state, model, cwd, worktree, repo_root, total_cost, total_tokens, spawned_at, ended_at, claude_session_id FROM agent_sessions${where} ORDER BY spawned_at DESC`,
       )
       .all()
       .map(toSessionRow);
@@ -1852,6 +1877,7 @@ interface RawSessionRow {
   total_tokens: number;
   spawned_at: string;
   ended_at: string | null;
+  claude_session_id: string | null;
 }
 
 function toSessionRow(row: RawSessionRow): AgentSessionRow {
@@ -1870,6 +1896,7 @@ function toSessionRow(row: RawSessionRow): AgentSessionRow {
     totalTokens: row.total_tokens,
     spawnedAt: row.spawned_at,
     endedAt: row.ended_at,
+    claudeSessionId: row.claude_session_id,
   };
 }
 

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -19,6 +19,7 @@ import type {
   ServeInstanceInfo,
 } from "@mcp-cli/core";
 import {
+  GetAgentSessionParamsSchema,
   GetDaemonLogsParamsSchema,
   GetLogsParamsSchema,
   IPC_ERROR,
@@ -458,6 +459,26 @@ export class IpcServer {
       return this.getQuotaStatus();
     });
 
+    this.handlers.set("getAgentSession", async (params, _ctx) => {
+      const { sessionId } = GetAgentSessionParamsSchema.parse(params);
+      const row = this.db.getSession(sessionId);
+      if (!row) return { session: null };
+      return {
+        session: {
+          sessionId: row.sessionId,
+          name: row.name,
+          provider: row.provider,
+          state: row.state,
+          cwd: row.cwd,
+          worktree: row.worktree,
+          repoRoot: row.repoRoot,
+          claudeSessionId: row.claudeSessionId,
+          spawnedAt: row.spawnedAt,
+          endedAt: row.endedAt,
+        },
+      };
+    });
+
     this.handlers.set("shutdown", async (params, _ctx) => {
       const { force } = ShutdownParamsSchema.parse(params ?? {});
       if (!force) {
@@ -476,7 +497,7 @@ export class IpcServer {
     });
 
     // Catch duplicate registrations (silently-overwritten handlers are invisible bugs).
-    const EXPECTED = 53;
+    const EXPECTED = 54;
     if (this.handlers.size !== EXPECTED) {
       throw new Error(
         `Handler count mismatch after registration: expected ${EXPECTED}, got ${this.handlers.size}. A handler was duplicated or omitted.`,


### PR DESCRIPTION
## Summary

- Persists the Claude CLI session ID (`claudeSessionId`) from the `session:init` event to the `agent_sessions` DB row via a new `claude_session_id` column (migration v6), so ended sessions can be resurrected by their daemon session ID
- `spawn --resume <daemon-session-id>` now checks the DB: if the session is `ended`, rewrites to `resumeSessionId` (which restores JSONL history via `claude --resume`) instead of `sessionId` (which fails with "Unknown session" against the in-memory session map); also inherits `cwd` from the DB row when no explicit `cwd` was given
- Adds `getAgentSession` IPC method to query any session (including ended) from the DB by daemon session ID

## Test plan

- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun test` — 7345 pass, 0 fail
- [x] New unit tests in `claude.spec.ts` cover: ended session → `resumeSessionId`, `cwd` inheritance, null `claudeSessionId` error, active session → `sessionId` unchanged, not-in-DB → `sessionId` unchanged
- [x] New DB tests cover: v6 migration on legacy tables, `claudeSessionId` round-trip, partial-update preservation

🤖 Generated with [Claude Code](https://claude.com/claude-code)