### PR TITLE
chore: sync .mcx.lock with done.ts hash after #2023 squash-merge

### DIFF
--- a/.mcx.lock
+++ b/.mcx.lock
@@ -5,7 +5,7 @@
     {
       "name": "done",
       "resolvedPath": ".claude/phases/done.ts",
-      "contentHash": "ea22b2775fd243d80e03224ff8c3cb1a76e5a9eca6c58f467479a0709f7f3073",
+      "contentHash": "b068c71c9cb2b38169b02349c61bc2cda4d039fc020bc4ee9c642404c7f8bae1",
       "schemaHash": "65b20b69643a6f7b1250b4949e0d1dffd022aa9573aadd952a07759879ebc98f"
     },
     {
@@ -17,31 +17,31 @@
     {
       "name": "needs-attention",
       "resolvedPath": ".claude/phases/needs-attention.ts",
-      "contentHash": "fc5b1fdec54b7ee9f2ad0af9b3ce5c78f72bf6eae395c8c3d87323df0dd0fbc1",
+      "contentHash": "cd0fdce55a4398de9e7fcacbdfe4dbafa735145ef22d4f28655b3a8d61fb2ecd",
       "schemaHash": "acee09becf66bc4ce4a92a0a0533840eb0c988f0f2eb0f6eac3a77227ed5267a"
     },
     {
       "name": "qa",
       "resolvedPath": ".claude/phases/qa.ts",
-      "contentHash": "5b9c6f948fffa4e8b39eda4a3db2e98e5488a714d62816f076b2635c555a8898",
+      "contentHash": "b481261bbd94b8e426a6653661408505c3af3ceff6ca3609dfa3578e986e1ed8",
       "schemaHash": "2c3159b3558360d1a25caf8e7f4401da2dba237bf3799807bc8c68497290cd40"
     },
     {
       "name": "repair",
       "resolvedPath": ".claude/phases/repair.ts",
-      "contentHash": "460e66f951e830f36d9d8db107dfd21ba6ce96590883fa258d5b35dc56cad1a2",
+      "contentHash": "b3427844f2e911b28de1be93c29de8238dd66ccf34f75253d527e975355c052a",
       "schemaHash": "46d347d6bccd711c2069e8927617eb4a921e2c97f4b7038d4b5e5cdc90897c3a"
     },
     {
       "name": "review",
       "resolvedPath": ".claude/phases/review.ts",
-      "contentHash": "ecc4ba4ad95601fea0f60b0fa5dfad116c431b5d8e7201be2992e5f8ce3f46e6",
+      "contentHash": "f15fa45aa731bd0d17a0ad7808fe2ea7d797732763db5b1052190bccff0e55af",
       "schemaHash": "dbbe21e50a1a7a002a56c511d456060166ea94c6d15b2400e7f8283c861ed83d"
     },
     {
       "name": "triage",
       "resolvedPath": ".claude/phases/triage.ts",
-      "contentHash": "14efba6a38d9b84f65bd4d0ff33772b3fe5eac029e8235d2cdf656602b7b2df9",
+      "contentHash": "de07b1771cb428cda5235642ae4414b6da0ce68081c56a73b0ae155d00476dd6",
       "schemaHash": "03a042ac366a29c9f33de68cf1b24300bc899126e4084a4fa1303247afbc772c"
     }
   ],


### PR DESCRIPTION
Post-sprint-57 meta fix.

The sprint-57 container PR squash-merged with the old `.mcx.lock` because `done.ts` was changed in #2023 (PR #2136, separate merge) and the lockfile commit on the sprint container predates that. Running `mcx phase install` regenerates the lockfile to the current done.ts hash; this PR commits the result so the orchestrator pre-flight invariant holds on main.

Detected during sprint-57 retro.