### PR TITLE
fix(ci): correct detect job comment from .claude/** to .claude/* (fixes #2127)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 jobs:
-  # Detect whether this PR touches only docs (*.md, .claude/**).
+  # Detect whether this PR touches only docs (*.md, .claude/*).
   # Config files (*.json, .github/**, scripts/**, .git-hooks/**) and all source
   # code are NOT docs-only. push-to-main and workflow_dispatch events are never
   # docs-only. Sets output docs_only=true to let check/coverage/build skip work.


### PR DESCRIPTION
## Summary
- The `detect` job comment on line 18 of `ci.yml` said `.claude/**` (recursive glob) but the actual `case` pattern on line 50 uses `.claude/*` (non-recursive, matches only direct children of `.claude/`)
- Updated the comment to match the actual behavior, eliminating a misleading discrepancy that would confuse anyone reading the file

## Test plan
- [x] Diff verified: only the comment changes, no behavior change
- [x] Pre-commit hooks passed (typecheck, lint, doing-it-wrong)

🤖 Generated with [Claude Code](https://claude.com/claude-code)