### PR TITLE
fix(monitor): clarify --until help text to reflect glob semantics (fixes #2137)

### DIFF
--- a/packages/command/src/commands/monitor.spec.ts
+++ b/packages/command/src/commands/monitor.spec.ts
@@ -359,6 +359,10 @@ describe("parseMonitorArgs error branches", () => {
     expect(parseMonitorArgs(["--until"]).error).toBeTruthy();
   });
 
+  test("--until without value error message reflects glob semantics", () => {
+    expect(parseMonitorArgs(["--until"]).error).toBe("--until requires a pattern");
+  });
+
   test("--timeout with non-numeric value is an error", () => {
     expect(parseMonitorArgs(["--timeout", "abc"]).error).toBeTruthy();
   });

--- a/packages/command/src/commands/monitor.ts
+++ b/packages/command/src/commands/monitor.ts
@@ -143,7 +143,7 @@ export function parseMonitorArgs(args: string[]): MonitorArgs {
     } else if (arg === "--until") {
       until = args[++i];
       if (!until) {
-        error = "--until requires an event type";
+        error = "--until requires a pattern";
         break;
       }
     } else if (arg === "--timeout") {
@@ -207,7 +207,7 @@ Filters (evaluated server-side):
   --since <seq>              Replay from cursor (reserved)
 
 Terminators:
-  --until <pattern>          Exit when this event type is seen (glob: pr.*, session.*)
+  --until <pattern>          Exit when an event matching this pattern is seen (glob: pr.*, session.*)
   --timeout <seconds>        Exit after N seconds
   --max-events <n>           Exit after N events
 


### PR DESCRIPTION
## Summary
- Changed `--until` help text from "Exit when this event type is seen" to "Exit when an event matching this pattern is seen" to accurately reflect glob matching behavior
- Also updated the error message from "requires an event type" to "requires a pattern" for consistency

## Test plan
- [ ] `bun typecheck` passes
- [ ] `bun lint` passes
- [ ] `bun test packages/command/src/commands/monitor` passes (61 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)