### PR TITLE
perf(daemon): parallelize startup binary 'which' checks (fixes #2150)

### DIFF
--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -499,18 +499,24 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
   const wsPort = cliConfig.wsPort ?? DEFAULT_CLAUDE_WS_PORT;
   const claudeServer = new ClaudeServer(db, daemonId, undefined, logger, 10_000, wsPort);
 
+  // Run all binary 'which' checks in parallel to avoid blocking the critical path 4× sequentially.
+  const whichBinary = (bin: string) =>
+    Bun.spawn(["which", bin], { stdout: "pipe", stderr: "pipe" }).exited.then((code) => code === 0);
+  const [codexInstalled, ghInstalled, geminiInstalled, opencodeInstalled] = await Promise.all([
+    whichBinary("codex"),
+    whichBinary("gh"),
+    whichBinary("gemini"),
+    whichBinary("opencode"),
+  ]);
+
   // Codex server: only created if `codex` binary is installed
-  const codexInstalled = Bun.spawnSync(["which", "codex"], { stdout: "pipe", stderr: "pipe" }).exitCode === 0;
   const codexServer = codexInstalled ? new CodexServer(db, daemonId, undefined, logger) : null;
 
   // ACP server: created if any ACP-compatible agent binary is found on PATH
-  const acpAgentInstalled =
-    Bun.spawnSync(["which", "gh"], { stdout: "pipe", stderr: "pipe" }).exitCode === 0 ||
-    Bun.spawnSync(["which", "gemini"], { stdout: "pipe", stderr: "pipe" }).exitCode === 0;
+  const acpAgentInstalled = ghInstalled || geminiInstalled;
   const acpServer = acpAgentInstalled ? new AcpServer(db, daemonId, undefined, logger) : null;
 
   // OpenCode server: only created if `opencode` binary is installed
-  const opencodeInstalled = Bun.spawnSync(["which", "opencode"], { stdout: "pipe", stderr: "pipe" }).exitCode === 0;
   const opencodeServer = opencodeInstalled ? new OpenCodeServer(db, daemonId, undefined, logger) : null;
 
   // Mock server: always available (no external binary needed)


### PR DESCRIPTION
## Summary
- Replaces 4 sequential `Bun.spawnSync(["which", ...])` calls on the daemon startup critical path with a single `Promise.all` of async `Bun.spawn` calls
- All 4 binary checks (`codex`, `gh`, `gemini`, `opencode`) now run concurrently, cutting worst-case startup penalty from ~2s to a single parallel wait
- Behavior is identical — each server is still only created when its binary is present

## Test plan
- [x] All 7423 existing tests pass (no regressions)
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] Pre-commit hooks pass (typecheck + lint + doing-it-wrong + coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)