### PR TITLE
chore(test): convert server-pool poll loops to pollUntil (fixes #2142)

### DIFF
--- a/packages/daemon/src/server-pool.spec.ts
+++ b/packages/daemon/src/server-pool.spec.ts
@@ -4,6 +4,7 @@ import type { HttpServerConfig, SseServerConfig, StdioServerConfig } from "@mcp-
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import { pollUntil } from "../../../test/harness";
 import {
   BASE_ENV_ALLOWLIST,
   type ConnectFn,
@@ -1703,16 +1704,7 @@ describe("disconnect kills stdio child processes (#940)", () => {
 
       await pool.disconnect("sleeper");
 
-      const deadline = Date.now() + 5_000;
-      let dead = false;
-      while (Date.now() < deadline) {
-        if (!isAlive(pid)) {
-          dead = true;
-          break;
-        }
-        await Bun.sleep(100);
-      }
-      expect(dead).toBe(true);
+      await pollUntil(() => !isAlive(pid));
     } finally {
       forceKill(pid);
     }
@@ -1750,16 +1742,7 @@ describe("disconnect kills stdio child processes (#940)", () => {
 
       await pool.closeAll();
 
-      const deadline = Date.now() + 5_000;
-      let dead = false;
-      while (Date.now() < deadline) {
-        if (!isAlive(pid)) {
-          dead = true;
-          break;
-        }
-        await Bun.sleep(100);
-      }
-      expect(dead).toBe(true);
+      await pollUntil(() => !isAlive(pid));
     } finally {
       forceKill(pid);
     }

--- a/scripts/check-test-timeouts.ts
+++ b/scripts/check-test-timeouts.ts
@@ -40,7 +40,7 @@ const TEST_DIR = new URL("../test/", import.meta.url).pathname;
 // Ratchet baseline: fail if NEW Bun.sleep violations are introduced.
 // Decrease this number as #2100 cleanup proceeds. Once it reaches 0,
 // replace the ratchet with a hard exit(1) like the setTimeout check.
-export const BUN_SLEEP_BASELINE = 138;
+export const BUN_SLEEP_BASELINE = 136;
 
 /**
  * Extracts the delay (2nd positional argument) from a pre-extracted argument


### PR DESCRIPTION
## Summary
- Converts two manual `deadline`/`dead` poll loops in `server-pool.spec.ts` (disconnect and closeAll tests) to `pollUntil(() => !isAlive(pid))`
- Removes boilerplate `expect(dead).toBe(true)` — `pollUntil` throws on timeout instead
- Decreases `BUN_SLEEP_BASELINE` from 138→136 per #2100 ratchet reduction

## Test plan
- [x] `bun typecheck` — passes
- [x] `bun lint` — passes (biome reordered imports)
- [x] `bun test packages/daemon/src/server-pool.spec.ts` — 162 pass, 0 fail
- [x] `bun test` (full suite) — 7423 pass, 0 fail
- [x] Pre-commit hook passes with actual Bun.sleep count (128) under new baseline (136)

🤖 Generated with [Claude Code](https://claude.com/claude-code)