### PR TITLE
fix(memory): spawnCapture returns stdout/stderr/exitCode; truncate parse-failure output (fixes #2151)

### DIFF
--- a/packages/command/src/commands/memory.spec.ts
+++ b/packages/command/src/commands/memory.spec.ts
@@ -130,13 +130,18 @@ function makeDeps(overrides: Partial<MemoryDeps> = {}): MemoryDeps & { logs: str
     dirExists: () => true,
     spawnCapture: (cmd) => {
       if (cmd[0] === "gh") {
-        return JSON.stringify([{ number: 99, title: "Fix old rule", closedAt: "2026-01-01T00:00:00Z" }]);
+        return {
+          stdout: JSON.stringify([{ number: 99, title: "Fix old rule", closedAt: "2026-01-01T00:00:00Z" }]),
+          stderr: "",
+          exitCode: 0,
+        };
       }
       if (cmd.some((s) => s.includes("claude"))) {
-        return JSON.stringify(auditResult);
+        return { stdout: JSON.stringify(auditResult), stderr: "", exitCode: 0 };
       }
-      return null;
+      return { stdout: "", stderr: "unknown command", exitCode: 1 };
     },
+    writeTempFile: (_content) => "/tmp/memory-audit-response-test.txt",
     readFile: (path) => {
       if (path.endsWith("MEMORY.md")) return "# Memory\n- [feedback_test](feedback_test.md)";
       if (path.endsWith("feedback_test.md")) return "---\nname: test\n---\nrule content";
@@ -191,24 +196,69 @@ describe("runMemoryAudit", () => {
     await expect(runMemoryAudit({ json: false }, deps)).rejects.toThrow("exit(1)");
   });
 
-  test("exits when Haiku returns null", async () => {
+  test("exits when Haiku returns non-zero exit code", async () => {
     const deps = makeDeps({
       spawnCapture: (cmd) => {
-        if (cmd[0] === "gh") return "[]";
-        return null; // claude returns null
+        if (cmd[0] === "gh") return { stdout: "[]", stderr: "", exitCode: 0 };
+        return { stdout: "", stderr: "authentication failed", exitCode: 1 };
       },
     });
     await expect(runMemoryAudit({ json: false }, deps)).rejects.toThrow("exit(1)");
+    expect(deps.errors.join("\n")).toContain("authentication failed");
+    expect(deps.errors.join("\n")).toContain("code 1");
+  });
+
+  test("logs stderr from failed claude subprocess without conflating with parse failure", async () => {
+    const deps = makeDeps({
+      spawnCapture: (cmd) => {
+        if (cmd[0] === "gh") return { stdout: "[]", stderr: "", exitCode: 0 };
+        return { stdout: "", stderr: "model not found", exitCode: 2 };
+      },
+    });
+    await expect(runMemoryAudit({ json: false }, deps)).rejects.toThrow("exit(1)");
+    const errLog = deps.errors.join("\n");
+    expect(errLog).toContain("model not found");
+    expect(errLog).not.toContain("no response from Haiku");
+    expect(errLog).not.toContain("failed to parse");
   });
 
   test("exits when Haiku returns unparseable response", async () => {
     const deps = makeDeps({
       spawnCapture: (cmd) => {
-        if (cmd[0] === "gh") return "[]";
-        return "I cannot help with that."; // not JSON
+        if (cmd[0] === "gh") return { stdout: "[]", stderr: "", exitCode: 0 };
+        return { stdout: "I cannot help with that.", stderr: "", exitCode: 0 };
       },
     });
     await expect(runMemoryAudit({ json: false }, deps)).rejects.toThrow("exit(1)");
+  });
+
+  test("parse failure shows truncated preview and temp file path", async () => {
+    const deps = makeDeps({
+      spawnCapture: (cmd) => {
+        if (cmd[0] === "gh") return { stdout: "[]", stderr: "", exitCode: 0 };
+        return { stdout: "I cannot help with that.", stderr: "", exitCode: 0 };
+      },
+    });
+    await expect(runMemoryAudit({ json: false }, deps)).rejects.toThrow("exit(1)");
+    const errLog = deps.errors.join("\n");
+    expect(errLog).toContain("failed to parse Haiku response");
+    expect(errLog).toContain("preview:");
+    expect(errLog).toContain("full response saved to:");
+    expect(errLog).toContain("/tmp/memory-audit-response-test.txt");
+  });
+
+  test("parse failure does not dump full response to stderr", async () => {
+    const longResponse = "x".repeat(10000);
+    const deps = makeDeps({
+      spawnCapture: (cmd) => {
+        if (cmd[0] === "gh") return { stdout: "[]", stderr: "", exitCode: 0 };
+        return { stdout: longResponse, stderr: "", exitCode: 0 };
+      },
+    });
+    await expect(runMemoryAudit({ json: false }, deps)).rejects.toThrow("exit(1)");
+    const totalErrLen = deps.errors.join("\n").length;
+    // Full 10KB response must not appear in stderr
+    expect(totalErrLen).toBeLessThan(500);
   });
 
   test("handles malformed gh JSON gracefully", async () => {
@@ -218,13 +268,29 @@ describe("runMemoryAudit", () => {
     };
     const deps = makeDeps({
       spawnCapture: (cmd) => {
-        if (cmd[0] === "gh") return "{malformed json}"; // parse error in fetchClosedIssues
-        if (cmd.some((s) => s.includes("claude"))) return JSON.stringify(result);
-        return null;
+        if (cmd[0] === "gh") return { stdout: "{malformed json}", stderr: "", exitCode: 0 };
+        if (cmd.some((s) => s.includes("claude"))) return { stdout: JSON.stringify(result), stderr: "", exitCode: 0 };
+        return { stdout: "", stderr: "", exitCode: 1 };
       },
     });
     await runMemoryAudit({ json: false }, deps);
     // Should still complete even with broken gh output
+    expect(deps.logs.join("\n")).toContain("feedback_test.md");
+  });
+
+  test("gh unavailable (non-zero exit) is handled gracefully", async () => {
+    const result: AuditResult = {
+      findings: [{ file: "feedback_test.md", status: "load-bearing", reason: "ok", related: null }],
+      top_prune_candidates: [],
+    };
+    const deps = makeDeps({
+      spawnCapture: (cmd) => {
+        if (cmd[0] === "gh") return { stdout: "", stderr: "gh: not found", exitCode: 127 };
+        if (cmd.some((s) => s.includes("claude"))) return { stdout: JSON.stringify(result), stderr: "", exitCode: 0 };
+        return { stdout: "", stderr: "", exitCode: 1 };
+      },
+    });
+    await runMemoryAudit({ json: false }, deps);
     expect(deps.logs.join("\n")).toContain("feedback_test.md");
   });
 
@@ -235,9 +301,9 @@ describe("runMemoryAudit", () => {
     };
     const deps = makeDeps({
       spawnCapture: (cmd) => {
-        if (cmd[0] === "gh") return "[]";
-        if (cmd.some((s) => s.includes("claude"))) return JSON.stringify(result);
-        return null;
+        if (cmd[0] === "gh") return { stdout: "[]", stderr: "", exitCode: 0 };
+        if (cmd.some((s) => s.includes("claude"))) return { stdout: JSON.stringify(result), stderr: "", exitCode: 0 };
+        return { stdout: "", stderr: "", exitCode: 1 };
       },
     });
     await runMemoryAudit({ json: false }, deps);

--- a/packages/command/src/commands/memory.spec.ts
+++ b/packages/command/src/commands/memory.spec.ts
@@ -208,6 +208,35 @@ describe("runMemoryAudit", () => {
     expect(deps.errors.join("\n")).toContain("code 1");
   });
 
+  test("logs diagnostic when claude returns empty stdout with exitCode 0", async () => {
+    const deps = makeDeps({
+      spawnCapture: (cmd) => {
+        if (cmd[0] === "gh") return { stdout: "[]", stderr: "", exitCode: 0 };
+        return { stdout: "", stderr: "", exitCode: 0 };
+      },
+    });
+    await expect(runMemoryAudit({ json: false }, deps)).rejects.toThrow("exit(1)");
+    const errLog = deps.errors.join("\n");
+    expect(errLog).toContain("claude returned empty response");
+  });
+
+  test("parse failure survives writeTempFile throwing", async () => {
+    const deps = makeDeps({
+      spawnCapture: (cmd) => {
+        if (cmd[0] === "gh") return { stdout: "[]", stderr: "", exitCode: 0 };
+        return { stdout: "not json at all", stderr: "", exitCode: 0 };
+      },
+      writeTempFile: () => {
+        throw new Error("disk full");
+      },
+    });
+    await expect(runMemoryAudit({ json: false }, deps)).rejects.toThrow("exit(1)");
+    const errLog = deps.errors.join("\n");
+    expect(errLog).toContain("failed to parse Haiku response");
+    expect(errLog).toContain("preview:");
+    expect(errLog).not.toContain("disk full");
+  });
+
   test("logs stderr from failed claude subprocess without conflating with parse failure", async () => {
     const deps = makeDeps({
       spawnCapture: (cmd) => {

--- a/packages/command/src/commands/memory.ts
+++ b/packages/command/src/commands/memory.ts
@@ -217,6 +217,7 @@ export async function runMemoryAudit(opts: { json: boolean }, deps: MemoryDeps):
   const rawResponse = callHaiku(prompt, deps);
 
   if (!rawResponse) {
+    deps.logError("memory audit: claude returned empty response");
     deps.exit(1);
   }
 
@@ -225,10 +226,14 @@ export async function runMemoryAudit(opts: { json: boolean }, deps: MemoryDeps):
     const head = rawResponse.slice(0, 50);
     const tail = rawResponse.length > 100 ? rawResponse.slice(-50) : "";
     const preview = tail ? `${head}…${tail}` : head;
-    const tmpPath = deps.writeTempFile(rawResponse);
     deps.logError(`memory audit: failed to parse Haiku response (${rawResponse.length} chars)`);
     deps.logError(`  preview: ${preview}`);
-    deps.logError(`  full response saved to: ${tmpPath}`);
+    try {
+      const tmpPath = deps.writeTempFile(rawResponse);
+      deps.logError(`  full response saved to: ${tmpPath}`);
+    } catch {
+      // disk full / permissions — preview above is the best we can do
+    }
     deps.exit(1);
   }
 

--- a/packages/command/src/commands/memory.ts
+++ b/packages/command/src/commands/memory.ts
@@ -10,7 +10,8 @@
  *   mcx memory audit --json       Machine-readable JSON (for retro-skill)
  */
 
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { resolveModelName, resolveSourceClaudePath } from "@mcp-cli/core";
 import { printError } from "../output";
@@ -39,8 +40,10 @@ export interface MemoryDeps {
   cwd: () => string;
   /** Check whether a directory exists. */
   dirExists: (path: string) => boolean;
-  /** Spawn a process and capture stdout. Returns null on non-zero exit. */
-  spawnCapture: (cmd: string[], opts?: { input?: string; onStderr?: (s: string) => void }) => string | null;
+  /** Spawn a process and capture stdout/stderr/exitCode. Never throws. */
+  spawnCapture: (cmd: string[], opts?: { input?: string }) => { stdout: string; stderr: string; exitCode: number };
+  /** Write content to a temp file and return the path. */
+  writeTempFile: (content: string) => string;
   /** Read a file. Returns null if it doesn't exist or is unreadable. */
   readFile: (path: string) => string | null;
   /** List files in a directory matching an extension. Returns [] if dir missing. */
@@ -118,7 +121,7 @@ export function buildPrompt(
 }
 
 /**
- * Call claude --print with the given prompt and model, return stdout.
+ * Call claude --print with the given prompt and model, return stdout or null on failure.
  */
 function callHaiku(prompt: string, deps: MemoryDeps): string | null {
   const binary = deps.findClaudeBinary();
@@ -127,19 +130,26 @@ function callHaiku(prompt: string, deps: MemoryDeps): string | null {
     return null;
   }
 
-  return deps.spawnCapture([binary, "--print", "--model", HAIKU_MODEL], {
-    input: prompt,
-    onStderr: (s) => {
-      if (s.trim()) deps.logError(`memory audit: claude stderr: ${s.trim()}`);
-    },
-  });
+  const result = deps.spawnCapture([binary, "--print", "--model", HAIKU_MODEL], { input: prompt });
+
+  if (result.exitCode !== 0) {
+    const stderrMsg = result.stderr.trim();
+    deps.logError(`memory audit: claude exited with code ${result.exitCode}${stderrMsg ? `: ${stderrMsg}` : ""}`);
+    return null;
+  }
+
+  if (result.stderr.trim()) {
+    deps.logError(`memory audit: claude stderr: ${result.stderr.trim()}`);
+  }
+
+  return result.stdout;
 }
 
 /**
  * Fetch the last N closed GitHub issues as a newline-delimited summary for prompt inclusion.
  */
 function fetchClosedIssues(deps: MemoryDeps, limit = 50): string {
-  const raw = deps.spawnCapture([
+  const result = deps.spawnCapture([
     "gh",
     "issue",
     "list",
@@ -150,9 +160,9 @@ function fetchClosedIssues(deps: MemoryDeps, limit = 50): string {
     "--json",
     "number,title,closedAt",
   ]);
-  if (!raw) return "(gh unavailable)";
+  if (result.exitCode !== 0) return "(gh unavailable)";
   try {
-    const issues = JSON.parse(raw) as Array<{ number: number; title: string; closedAt: string }>;
+    const issues = JSON.parse(result.stdout) as Array<{ number: number; title: string; closedAt: string }>;
     return issues.map((i) => `#${i.number}: ${i.title} (closed ${i.closedAt.slice(0, 10)})`).join("\n");
   } catch {
     return "(parse error)";
@@ -207,15 +217,18 @@ export async function runMemoryAudit(opts: { json: boolean }, deps: MemoryDeps):
   const rawResponse = callHaiku(prompt, deps);
 
   if (!rawResponse) {
-    deps.logError("memory audit: no response from Haiku");
     deps.exit(1);
   }
 
   const result = parseHaikuResponse(rawResponse);
   if (!result) {
-    deps.logError("memory audit: failed to parse Haiku response");
-    deps.logError("--- raw response ---");
-    deps.logError(rawResponse);
+    const head = rawResponse.slice(0, 50);
+    const tail = rawResponse.length > 100 ? rawResponse.slice(-50) : "";
+    const preview = tail ? `${head}…${tail}` : head;
+    const tmpPath = deps.writeTempFile(rawResponse);
+    deps.logError(`memory audit: failed to parse Haiku response (${rawResponse.length} chars)`);
+    deps.logError(`  preview: ${preview}`);
+    deps.logError(`  full response saved to: ${tmpPath}`);
     deps.exit(1);
   }
 
@@ -271,11 +284,16 @@ export function defaultDeps(): MemoryDeps {
         stderr: "pipe",
         stdin: opts?.input ? Buffer.from(opts.input) : undefined,
       });
-      if (r.exitCode !== 0) {
-        opts?.onStderr?.(r.stderr.toString());
-        return null;
-      }
-      return r.stdout.toString();
+      return {
+        stdout: r.stdout.toString(),
+        stderr: r.stderr.toString(),
+        exitCode: r.exitCode ?? 1,
+      };
+    },
+    writeTempFile: (content) => {
+      const path = join(tmpdir(), `memory-audit-response-${Date.now()}.txt`);
+      writeFileSync(path, content, "utf-8");
+      return path;
     },
     readFile: (path) => {
       try {


### PR DESCRIPTION
## Summary
- `spawnCapture` now returns `{ stdout, stderr, exitCode }` instead of `string | null`, so `callHaiku` can distinguish subprocess failures (bad model, auth error, timeout) from parse failures — logs the actual exit code and stderr instead of a generic message
- Parse failures now show only first/last 50 chars of the response plus a path to a temp file with the full content, preventing 50KB+ stderr dumps on large repos
- Added `writeTempFile` to `MemoryDeps` for testability; `fetchClosedIssues` updated to use the new return type

## Test plan
- [x] New tests: exitCode-based failure logging with correct error message, no conflation of subprocess failures with parse failures, stderr output stays under 500 chars for 10KB bad response, gh non-zero exit handled gracefully, gh unavailable path covered
- [x] All 7449 existing tests pass
- [x] `bun typecheck` passes
- [x] `bun lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)