### PR TITLE
fix(pool): capture stdio child PID inside connectFn to close ensureConnected race (fixes #2135)

### DIFF
--- a/packages/daemon/src/server-pool.spec.ts
+++ b/packages/daemon/src/server-pool.spec.ts
@@ -1783,4 +1783,70 @@ describe("disconnect kills stdio child processes (#940)", () => {
     // Should not throw
     await pool.disconnect("remote");
   });
+
+  // Regression: connectFn PID race (#2135)
+  // The SDK's close handler clears transport._process (→ transport.pid = null) as soon
+  // as the child exits. If the child exits between connectFn resolving and the caller
+  // reading transport.pid, cachedChildPid is stored as null and disconnect() skips
+  // killPid entirely. The fix: connectFn captures the PID synchronously before returning
+  // and includes it as result.childPid. ensureConnected prefers result.childPid over
+  // transport.pid, so the correct PID reaches cachedChildPid regardless of timing.
+  test("disconnect kills child process using connectFn-supplied childPid when transport.pid is null (#2135)", async () => {
+    const transport = new StdioClientTransport({ command: "sleep", args: ["60"], stderr: "pipe" });
+    await transport.start();
+    const pid = transport.pid;
+    if (pid == null) throw new Error("expected pid after start()");
+
+    try {
+      // Simulate the race: connectFn captures PID before returning, but by the
+      // time the pool reads it, transport.pid is null (process already exited).
+      // We model this by wrapping the real transport so that .pid always returns
+      // null — but the connectFn still reports the correct PID via result.childPid.
+      const racyTransport = new Proxy(transport, {
+        get(target, prop, receiver) {
+          if (prop === "pid") return null; // simulates close-handler having already fired
+          const val = Reflect.get(target, prop, receiver);
+          return typeof val === "function" ? val.bind(target) : val;
+        },
+      });
+
+      const connectFn: ConnectFn = mock(() =>
+        Promise.resolve({
+          client: makeMockClient() as unknown as Client,
+          transport: racyTransport as unknown as Transport,
+          childPid: pid, // captured synchronously inside connectFn — the fix for #2135
+        }),
+      );
+      const pool = new ServerPool(
+        makeConfig({ sleeper: { command: "sleep", args: ["60"] } }),
+        undefined,
+        connectFn,
+        silentLogger,
+      );
+      await pool.listTools("sleeper");
+
+      if (!isAlive(pid)) {
+        console.warn(`[test] sleep process ${pid} died during setup — skipping #2135 assertion`);
+        return;
+      }
+
+      // disconnect() must kill the child despite transport.pid returning null.
+      // Before the fix, cachedChildPid would be null (from transport.pid) and
+      // killPid would never be called, leaving the process alive.
+      await pool.disconnect("sleeper");
+
+      const deadline = Date.now() + 5_000;
+      let dead = false;
+      while (Date.now() < deadline) {
+        if (!isAlive(pid)) {
+          dead = true;
+          break;
+        }
+        await Bun.sleep(100);
+      }
+      expect(dead).toBe(true);
+    } finally {
+      forceKill(pid);
+    }
+  });
 });

--- a/packages/daemon/src/server-pool.ts
+++ b/packages/daemon/src/server-pool.ts
@@ -74,7 +74,17 @@ export type ConnectFn = (
   config: ServerConfig,
   authProvider?: OAuthClientProvider,
   signal?: AbortSignal,
-) => Promise<{ client: Client; transport: Transport }>;
+) => Promise<{
+  client: Client;
+  transport: Transport;
+  /**
+   * Stdio child PID captured synchronously after transport.start() resolves,
+   * before any further event-loop yields. Consumers should prefer this over
+   * reading transport.pid later — the close handler may have already cleared
+   * _process by then (see #2135).
+   */
+  childPid?: number | null;
+}>;
 
 export class ServerPool {
   private connections = new Map<string, ServerConnection>();
@@ -318,7 +328,7 @@ export class ServerPool {
               reject(new Error(`Connection to "${name}" timed out after ${timeoutMs}ms`)),
             );
           });
-          let result!: { client: Client; transport: Transport };
+          let result!: Awaited<ReturnType<ConnectFn>>;
           const connectPromise = this.connectFn(name, config, authProvider, ac.signal);
           try {
             result = await Promise.race([connectPromise, timeoutPromise]);
@@ -330,7 +340,7 @@ export class ServerPool {
             // Without this, each timed-out attempt leaks a promise + unhandled rejection.
             connectPromise.catch(() => {});
           }
-          const { client, transport } = result;
+          const { client, transport, childPid: connectFnPid } = result;
 
           // Attach stderr capture (Node streams buffer in paused mode, so no data is lost)
           this.attachStderrCapture(name, transport, conn);
@@ -341,10 +351,16 @@ export class ServerPool {
           conn.lastUsed = Date.now();
           conn.lastError = undefined;
 
-          // Cache stdio child PID at connect time so disconnect() can kill it
-          // even if the transport's _process is cleared by a close event first.
+          // Cache stdio child PID so disconnect() can kill it even if the transport's
+          // _process is cleared by a close event first.
+          //
+          // Prefer connectFnPid (captured synchronously inside connectFn before any
+          // further await) over reading transport.pid here. By the time this line
+          // executes there has been at least one event-loop yield (the Promise.race
+          // resolution), during which the child may have exited and the SDK's close
+          // handler may have cleared _process → pid becomes null (#2135).
           if (transport instanceof StdioClientTransport) {
-            const pid = transport.pid;
+            const pid = connectFnPid !== undefined ? connectFnPid : transport.pid;
             if (pid == null) {
               this.logger.warn(
                 `[pool] Server "${name}": stdio child PID unavailable at connect time — process cleanup may be incomplete`,
@@ -907,7 +923,7 @@ async function defaultConnect(
   config: ServerConfig,
   authProvider?: OAuthClientProvider,
   signal?: AbortSignal,
-): Promise<{ client: Client; transport: Transport }> {
+): ReturnType<ConnectFn> {
   const transport = createTransport(config, authProvider);
   const client = new Client({ name: `mcp-cli/${name}`, version: "0.1.0" });
 
@@ -919,7 +935,12 @@ async function defaultConnect(
   }
 
   await client.connect(transport);
-  return { client, transport };
+  // Capture PID synchronously here — before returning — so the caller receives
+  // it without an intervening event-loop yield. The SDK's close handler clears
+  // _process (and thus transport.pid) as soon as the child exits, so reading
+  // transport.pid after any await in the caller can race with that handler (#2135).
+  const childPid = transport instanceof StdioClientTransport ? transport.pid : undefined;
+  return { client, transport, childPid };
 }
 
 function createTransport(config: ServerConfig, authProvider?: OAuthClientProvider): Transport {


### PR DESCRIPTION
## Summary

- Extends `ConnectFn` return type with optional `childPid?: number | null` so the PID can be propagated from the factory to the caller without a second read.
- `defaultConnect` captures `transport.pid` synchronously before returning — before any further event-loop yields where the SDK close handler could clear `_process` and null out the PID.
- `ensureConnected` prefers `result.childPid` (set by `connectFn`) over reading `transport.pid` directly, which races against the close handler in CI conditions where processes can exit immediately after starting.

## Test plan

- [x] Added regression test: `disconnect kills child process using connectFn-supplied childPid when transport.pid is null (#2135)` — wraps a real `StdioClientTransport` in a Proxy that always returns `null` for `.pid`, verifies `disconnect()` still kills the process using the PID bundled in `result.childPid`
- [x] All 163 `server-pool.spec.ts` tests pass
- [x] Full suite: 7424 pass, 0 fail
- [x] `bun typecheck` clean
- [x] `bun lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)