### PR TITLE
fix(gh-client): address 3 deferred Copilot findings from PR #2136 (fixes #2147)

### DIFF
--- a/.claude/phases/done-fn.spec.ts
+++ b/.claude/phases/done-fn.spec.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+import { type MergePrDeps, type MergeResult, mergePr } from "./done-fn";
+
+function makeDeps(overrides: Partial<MergePrDeps> = {}): MergePrDeps {
+  return {
+    async gh(_args) {
+      return { stdout: "", stderr: "", exitCode: 0 };
+    },
+    async prMerge(_prNumber, _flags) {
+      return { stdout: "", stderr: "", exitCode: 0 };
+    },
+    async prView(_prNumber, _fields, _jqExpr?) {
+      return "MERGED";
+    },
+    async spawn(_cmd, _opts?) {
+      return { stdout: "", stderr: "", exitCode: 0 };
+    },
+    ...overrides,
+  };
+}
+
+describe("mergePr", () => {
+  test("succeeds when labels include qa:pass and CI is green", async () => {
+    const deps = makeDeps({
+      async gh(args) {
+        if (args[4] === "labels") return { stdout: "qa:pass", stderr: "", exitCode: 0 };
+        if (args[4] === "statusCheckRollup") return { stdout: "0", stderr: "", exitCode: 0 };
+        return { stdout: "", stderr: "", exitCode: 0 };
+      },
+    });
+    const result = await mergePr(42, deps);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.prNumber).toBe(42);
+  });
+
+  test("returns missing_qa_pass when qa:pass label is absent", async () => {
+    const deps = makeDeps({
+      async gh(args) {
+        if (args[4] === "labels") return { stdout: "bug", stderr: "", exitCode: 0 };
+        if (args[4] === "statusCheckRollup") return { stdout: "0", stderr: "", exitCode: 0 };
+        return { stdout: "", stderr: "", exitCode: 0 };
+      },
+    });
+    const result = await mergePr(42, deps);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("missing_qa_pass");
+  });
+
+  test("returns ci_not_green when failing checks > 0", async () => {
+    const deps = makeDeps({
+      async gh(args) {
+        if (args[4] === "labels") return { stdout: "qa:pass", stderr: "", exitCode: 0 };
+        if (args[4] === "statusCheckRollup") return { stdout: "2", stderr: "", exitCode: 0 };
+        return { stdout: "", stderr: "", exitCode: 0 };
+      },
+    });
+    const result = await mergePr(42, deps);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("ci_not_green");
+  });
+
+  test("recovers from interrupted merge when prView returns MERGED", async () => {
+    // Simulates the SIGTERM race: prMerge exits non-zero but the server
+    // actually completed the merge. prView must return "MERGED" for the
+    // done phase to treat it as ok:true (Finding 4 fix).
+    const deps = makeDeps({
+      async gh(args) {
+        if (args[4] === "labels") return { stdout: "qa:pass", stderr: "", exitCode: 0 };
+        if (args[4] === "statusCheckRollup") return { stdout: "0", stderr: "", exitCode: 0 };
+        return { stdout: "", stderr: "", exitCode: 0 };
+      },
+      async prMerge(_prNumber, _flags) {
+        return { stdout: "", stderr: "signal: interrupt", exitCode: 1 };
+      },
+      async prView(_prNumber, _fields, _jqExpr?) {
+        return "MERGED";
+      },
+    });
+    const result = await mergePr(42, deps);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.prNumber).toBe(42);
+      expect(result.localCleanup).toBeDefined();
+    }
+  });
+
+  test("returns merge_failed when interrupted merge prView returns non-MERGED", async () => {
+    // Merge genuinely failed (not just client-side SIGTERM): prView says CLOSED
+    // (not MERGED), so done phase must not treat it as success.
+    const deps = makeDeps({
+      async gh(args) {
+        if (args[4] === "labels") return { stdout: "qa:pass", stderr: "", exitCode: 0 };
+        if (args[4] === "statusCheckRollup") return { stdout: "0", stderr: "", exitCode: 0 };
+        return { stdout: "", stderr: "", exitCode: 0 };
+      },
+      async prMerge(_prNumber, _flags) {
+        return { stdout: "", stderr: "merge failed: unknown error", exitCode: 1 };
+      },
+      async prView(_prNumber, _fields, _jqExpr?) {
+        return "CLOSED";
+      },
+    });
+    const result = await mergePr(42, deps);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("merge_failed");
+  });
+
+  test("returns conflicts when merge stderr mentions conflicts", async () => {
+    const deps = makeDeps({
+      async gh(args) {
+        if (args[4] === "labels") return { stdout: "qa:pass", stderr: "", exitCode: 0 };
+        if (args[4] === "statusCheckRollup") return { stdout: "0", stderr: "", exitCode: 0 };
+        return { stdout: "", stderr: "", exitCode: 0 };
+      },
+      async prMerge(_prNumber, _flags) {
+        return { stdout: "", stderr: "Pull Request is not mergeable due to conflict", exitCode: 1 };
+      },
+    });
+    const result = await mergePr(42, deps);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("conflicts");
+  });
+});

--- a/.claude/phases/done.ts
+++ b/.claude/phases/done.ts
@@ -56,8 +56,9 @@ defineAlias({
           }
           if (jsonField === "statusCheckRollup") {
             const checks = await ctx.gh.pr(prNum).checks();
-            // Match old jq: select(.conclusion != "SUCCESS") — null (pending) counts as non-SUCCESS
-            const failing = checks.check_runs.filter((c) => c.conclusion !== "SUCCESS");
+            // Merge check-runs and legacy commit statuses; null (pending) counts as non-SUCCESS.
+            const all = [...checks.check_runs, ...checks.commit_statuses];
+            const failing = all.filter((c) => c.conclusion !== "SUCCESS");
             return { stdout: String(failing.length), stderr: "", exitCode: 0 };
           }
           return { stdout: "", stderr: `unsupported gh args: ${args.join(" ")}`, exitCode: 1 };
@@ -79,6 +80,7 @@ defineAlias({
       },
       async prView(prNumber, _fields, _jqExpr?) {
         const pr = await ctx.gh.pr(prNumber).body();
+        if (pr.merged) return "MERGED";
         return pr.state.toUpperCase();
       },
       async spawn(cmd, opts) {

--- a/packages/core/src/gh-client.spec.ts
+++ b/packages/core/src/gh-client.spec.ts
@@ -3,6 +3,7 @@ import {
   GhAuthError,
   GhClient,
   GhNotFoundError,
+  GhPageCapError,
   GhRateLimitError,
   type GhRepoInfo,
   GhServerError,
@@ -308,6 +309,102 @@ describe("PrHandle", () => {
     expect(calls[2].init.method).toBe("DELETE");
   });
 
+  test("checks() merges check-runs and commit statuses, deduplicating by context", async () => {
+    const prBody = {
+      number: 42,
+      title: "PR",
+      body: null,
+      state: "open",
+      draft: false,
+      merged: false,
+      merged_at: null,
+      labels: [],
+      mergeable: null,
+      mergeable_state: "",
+      merge_commit_sha: null,
+      head: { ref: "feat", sha: "abc123" },
+      base: { ref: "main" },
+      user: { login: "alice" },
+      created_at: "",
+      updated_at: "",
+    };
+
+    const { fn, calls } = mockFetch([
+      { status: 200, body: prBody },
+      {
+        status: 200,
+        body: {
+          total_count: 1,
+          check_runs: [{ id: 1, name: "build", status: "completed", conclusion: "SUCCESS" }],
+        },
+      },
+      {
+        status: 200,
+        body: [
+          { context: "ci/legacy", state: "success", description: null },
+          { context: "ci/legacy", state: "failure", description: null },
+          { context: "ci/other", state: "pending", description: null },
+        ],
+      },
+    ]);
+
+    const client = makeClient({ fetch: fn });
+    const result = await client.pr(42).checks();
+
+    expect(result.total_count).toBe(1);
+    expect(result.check_runs).toHaveLength(1);
+    expect(result.check_runs[0].conclusion).toBe("SUCCESS");
+
+    // 2 unique contexts (ci/legacy deduped, ci/other = pending → null conclusion)
+    expect(result.commit_statuses).toHaveLength(2);
+    const legacy = result.commit_statuses.find((s) => s.name === "ci/legacy");
+    expect(legacy?.conclusion).toBe("SUCCESS");
+    const other = result.commit_statuses.find((s) => s.name === "ci/other");
+    expect(other?.conclusion).toBeNull();
+
+    expect(calls[1].url).toContain("/commits/abc123/check-runs");
+    expect(calls[2].url).toContain("/commits/abc123/statuses");
+  });
+
+  test("checks() maps failure/error statuses to FAILURE conclusion", async () => {
+    const prBody = {
+      number: 1,
+      title: "T",
+      body: null,
+      state: "open",
+      draft: false,
+      merged: false,
+      merged_at: null,
+      labels: [],
+      mergeable: null,
+      mergeable_state: "",
+      merge_commit_sha: null,
+      head: { ref: "f", sha: "sha1" },
+      base: { ref: "main" },
+      user: { login: "u" },
+      created_at: "",
+      updated_at: "",
+    };
+
+    const { fn } = mockFetch([
+      { status: 200, body: prBody },
+      { status: 200, body: { total_count: 0, check_runs: [] } },
+      {
+        status: 200,
+        body: [
+          { context: "ctx/fail", state: "failure", description: null },
+          { context: "ctx/error", state: "error", description: null },
+        ],
+      },
+    ]);
+
+    const client = makeClient({ fetch: fn });
+    const result = await client.pr(1).checks();
+
+    expect(result.commit_statuses).toHaveLength(2);
+    expect(result.commit_statuses.every((s) => s.conclusion === "FAILURE")).toBe(true);
+  });
+
   test("allCommentSurfaces() combines all 4 surfaces", async () => {
     const { fn } = mockFetch([
       {
@@ -527,6 +624,33 @@ describe("pagination", () => {
 
     expect(comments).toHaveLength(3);
     expect(comments.map((c) => c.id)).toEqual([1, 2, 3]);
+  });
+
+  test("throws GhPageCapError when MAX_PAGES hit with next link present", async () => {
+    // Provide a fetch fn that always returns a next link, simulating an
+    // infinite paginated resource. ghPaginated should throw after MAX_PAGES.
+    let callCount = 0;
+    const alwaysNextFn = async (): Promise<Response> => {
+      callCount++;
+      return new Response(
+        JSON.stringify([{ id: callCount, body: "c", user: { login: "a" }, created_at: "", updated_at: "" }]),
+        {
+          status: 200,
+          headers: { link: `<https://api.github.com/repos/o/r/issues/42/comments?page=${callCount + 1}>; rel="next"` },
+        },
+      );
+    };
+
+    const client = makeClient({ fetch: alwaysNextFn as unknown as typeof globalThis.fetch });
+
+    try {
+      await client.pr(42).bodyComments();
+      expect.unreachable("should have thrown GhPageCapError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(GhPageCapError);
+      expect((err as GhPageCapError).itemCount).toBeGreaterThan(0);
+      expect((err as GhPageCapError).message).toContain("MAX_PAGES");
+    }
   });
 });
 

--- a/packages/core/src/gh-client.ts
+++ b/packages/core/src/gh-client.ts
@@ -53,6 +53,15 @@ export class GhServerError extends Error {
   }
 }
 
+export class GhPageCapError extends Error {
+  override name = "GhPageCapError" as const;
+  itemCount: number;
+  constructor(message: string, itemCount: number) {
+    super(message);
+    this.itemCount = itemCount;
+  }
+}
+
 // ── Response types ──
 
 export interface GhPrBody {
@@ -112,6 +121,8 @@ export interface GhCheckRun {
 export interface GhChecksResult {
   total_count: number;
   check_runs: GhCheckRun[];
+  /** Legacy commit statuses, mapped to check-run shape for uniform filtering. */
+  commit_statuses: GhCheckRun[];
 }
 
 export interface GhPrFile {
@@ -427,6 +438,12 @@ async function ghPaginated<T>(path: string, opts: RequestOptions & { page?: numb
     const items: T[] = await resp.json();
     allItems.push(...items);
     url = parseNextUrl(resp.headers.get("link"));
+    if (page === MAX_PAGES - 1 && url !== null) {
+      throw new GhPageCapError(
+        `ghPaginated: hit MAX_PAGES (${MAX_PAGES}) but more pages remain — result is truncated. Increase MAX_PAGES or use a more specific query.`,
+        allItems.length,
+      );
+    }
   }
   return allItems;
 }
@@ -478,6 +495,12 @@ interface RawReview {
   body: string;
   user: { login: string };
   submitted_at: string;
+}
+
+interface RawCommitStatus {
+  context: string;
+  state: "pending" | "success" | "failure" | "error";
+  description: string | null;
 }
 
 interface RawIssue {
@@ -601,11 +624,35 @@ export class PrHandle {
 
   async checks(): Promise<GhChecksResult> {
     const pr = await this.body();
-    const raw = await ghJson<{ total_count: number; check_runs: GhCheckRun[] }>(
-      `/repos/${this.o}/${this.r}/commits/${pr.head.sha}/check-runs`,
-      this.reqOpts(),
-    );
-    return { total_count: raw.total_count, check_runs: raw.check_runs };
+    const sha = pr.head.sha;
+    const [checkRunsRaw, statusesRaw] = await Promise.all([
+      ghJson<{ total_count: number; check_runs: GhCheckRun[] }>(
+        `/repos/${this.o}/${this.r}/commits/${sha}/check-runs`,
+        this.reqOpts(),
+      ),
+      ghPaginated<RawCommitStatus>(`/repos/${this.o}/${this.r}/commits/${sha}/statuses`, this.reqOpts()),
+    ]);
+
+    // Deduplicate by context: GitHub returns statuses in reverse-chronological
+    // order, so the first occurrence per context is the most recent.
+    const seen = new Set<string>();
+    const dedupedStatuses: GhCheckRun[] = [];
+    for (const s of statusesRaw) {
+      if (seen.has(s.context)) continue;
+      seen.add(s.context);
+      dedupedStatuses.push({
+        id: 0,
+        name: s.context,
+        status: "completed",
+        conclusion: s.state === "success" ? "SUCCESS" : s.state === "pending" ? null : "FAILURE",
+      });
+    }
+
+    return {
+      total_count: checkRunsRaw.total_count,
+      check_runs: checkRunsRaw.check_runs,
+      commit_statuses: dedupedStatuses,
+    };
   }
 
   async files(): Promise<GhPrFile[]> {


### PR DESCRIPTION
## Summary

- **Finding 3 — `ghPaginated()` silent truncation**: throws `GhPageCapError` (typed, carries `itemCount`) when `MAX_PAGES` is hit with a `next` link present; callers get an explicit error instead of silently receiving incomplete data
- **Finding 4 — `prView()` can never return `"MERGED"`**: derives state from `pr.merged === true` in the `done.ts` adapter; REST `/pulls/{n}` only returns `"open"/"closed"`, so `toUpperCase()` could never yield `"MERGED"`, breaking the SIGTERM-interrupted merge recovery path
- **Finding 5 — `statusCheckRollup` missing legacy commit statuses**: `PrHandle.checks()` now also fetches `/commits/{sha}/statuses`, deduplicates by context (first = most recent per GitHub ordering), maps `state → conclusion` (SUCCESS/FAILURE/null), and exposes results in `commit_statuses`; the `done.ts` adapter merges both arrays before counting failing checks

## Test plan

- [x] Added `GhPageCapError` import to `gh-client.spec.ts`; new test confirms it throws after MAX_PAGES (20 requests) with a next link
- [x] New `checks()` tests in `gh-client.spec.ts`: verifies PR body + check-runs + statuses fetched in parallel, deduplication by context, `failure`/`error` states map to `"FAILURE"` conclusion, `pending` maps to `null`
- [x] New `done-fn.spec.ts` (manual-runnable, excluded from CI by `pathIgnorePatterns = [".claude/**"]`): covers happy path, missing qa:pass, ci_not_green, SIGTERM-interrupted merge recovery (Finding 4 golden path), genuine merge failure, and conflict classification
- [x] Full test suite: 7426 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)