### PR TITLE
fix(daemon): suppress false-positive permission_request monitor events for auto/rules strategies (fixes #2129)

### DIFF
--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -1641,7 +1641,7 @@ describe("ClaudeWsServer", () => {
     }
   });
 
-  test("session.permission_blocked does not fire when strategy=auto", async () => {
+  test("session.permission_blocked and session.permission_request do not fire when strategy=auto", async () => {
     const ms = mockSpawn();
     const monitorEvents: MonitorEventInput[] = [];
     server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
@@ -1655,17 +1655,20 @@ describe("ClaudeWsServer", () => {
     try {
       await waitForMessage(ws);
       ws.send(systemInitMessage("perm-auto-1"));
+      // Wait for the auto-approval response before checking monitor events
+      const responsePromise = waitForMessage(ws);
       ws.send(canUseToolMessage("req-auto-1"));
-      // Wait for permission_request monitor event (auto-approved)
-      await pollUntil(() => monitorEvents.some((e) => e.event === SESSION_PERMISSION_REQUEST));
+      await responsePromise;
 
+      // Neither permission_request nor permission_blocked should appear for auto strategy
+      expect(monitorEvents.some((e) => e.event === SESSION_PERMISSION_REQUEST)).toBe(false);
       expect(monitorEvents.some((e) => e.event === SESSION_PERMISSION_BLOCKED)).toBe(false);
     } finally {
       ws.close();
     }
   });
 
-  test("session.permission_request still fires for all strategies (informational)", async () => {
+  test("session.permission_request fires only for delegate strategy", async () => {
     const ms = mockSpawn();
     const monitorEvents: MonitorEventInput[] = [];
     server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -1681,6 +1681,12 @@ export class ClaudeWsServer {
         `[_claude] ${label} for session ${sessionId}, event ${event.type}: ${err instanceof Error ? err.stack : err}`,
       );
 
+    // For permission_request events that will be auto-resolved (non-delegate strategies),
+    // suppress the monitor event and wait-notification. Only delegate strategy requires
+    // orchestrator intervention; emitting for auto/rules floods the monitor stream with
+    // noise that orchestrators cannot act on (fixes #2129).
+    let suppressMonitorEvent = false;
+
     switch (event.type) {
       case "session:init":
         // Capture Claude Code's own session ID for JSONL file lookup
@@ -1692,17 +1698,21 @@ export class ClaudeWsServer {
         this.emitToolUseEvents(sessionId, event.message);
         break;
       case "session:permission_request":
-        session.pendingImmediate = true;
         this.recordSessionProgress(sessionId, session);
-        try {
-          this.resolveEventWaiters(sessionId, {
-            sessionId,
-            event: "session:permission_request",
-            requestId: event.requestId,
-            toolName: event.request.tool_name,
-          });
-        } catch (err) {
-          logErr("resolveEventWaiters failed", err);
+        if (session.router.strategy === "delegate") {
+          session.pendingImmediate = true;
+          try {
+            this.resolveEventWaiters(sessionId, {
+              sessionId,
+              event: "session:permission_request",
+              requestId: event.requestId,
+              toolName: event.request.tool_name,
+            });
+          } catch (err) {
+            logErr("resolveEventWaiters failed", err);
+          }
+        } else {
+          suppressMonitorEvent = true;
         }
         this.handlePermissionRequest(sessionId, session, event.requestId, event.request).catch((err) => {
           this.logger.error(
@@ -1837,7 +1847,9 @@ export class ClaudeWsServer {
         break;
     }
 
-    this.publishSessionMonitorEvent(sessionId, event);
+    if (!suppressMonitorEvent) {
+      this.publishSessionMonitorEvent(sessionId, event);
+    }
   }
 
   private static readonly SESSION_EVENT_MAP: Record<string, string> = {


### PR DESCRIPTION
## Summary
- For `auto` and `rules` permission strategies, `can_use_tool` requests are auto-resolved internally — the orchestrator cannot and need not act on them. Previously, a `session.permission_request` monitor event fired synchronously before the router evaluated the request, flooding the monitor stream with events that `mcx claude approve` immediately rejected with "No pending permission requests."
- Fix: only emit `session.permission_request` monitor events and wake `wait`-listeners when `strategy === "delegate"`. Auto/rules strategies suppress both; the permission is still evaluated and responded to the Claude process as before.
- Also suppresses the spurious `pendingImmediate` flag-set for non-delegate permission requests, preventing a race where `mcx claude wait` could return a stale permission event that was already auto-resolved.

## Test plan
- [x] Updated `"session.permission_blocked and session.permission_request do not fire when strategy=auto"`: waits for the auto-approval response, then asserts neither monitor event fired
- [x] Renamed/updated `"session.permission_request fires only for delegate strategy"`: verifies delegate strategy still emits the event
- [x] All 7423 tests pass, 0 failures
- [x] `bun typecheck` clean, `bun lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)