### PR TITLE
refactor(phases): extract GhResult to shared phase-types.ts (closes #2144)

### DIFF
--- a/.claude/phases/done-fn.ts
+++ b/.claude/phases/done-fn.ts
@@ -1,10 +1,7 @@
 /** Core done-phase logic, extracted for testability via dependency injection. */
 
-export interface GhResult {
-  stdout: string;
-  stderr: string;
-  exitCode: number;
-}
+import type { GhResult } from "./phase-types.js";
+export type { GhResult };
 
 export type MergeResult =
   | { ok: true; prNumber: number; localCleanup?: string }

--- a/.claude/phases/phase-types.ts
+++ b/.claude/phases/phase-types.ts
@@ -1,0 +1,7 @@
+/** Shared types used across phase fn files. */
+
+export interface GhResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}

--- a/.claude/phases/qa-fn.ts
+++ b/.claude/phases/qa-fn.ts
@@ -1,10 +1,7 @@
 /** Core qa-phase logic, extracted for testability via dependency injection. */
 
-export interface GhResult {
-  stdout: string;
-  stderr: string;
-  exitCode: number;
-}
+import type { GhResult } from "./phase-types.js";
+export type { GhResult };
 
 export const QA_FAIL_CAP = 2;
 

--- a/.claude/phases/review-fn.ts
+++ b/.claude/phases/review-fn.ts
@@ -1,10 +1,7 @@
 /** Core review-phase logic, extracted for testability via dependency injection. */
 
-export interface GhResult {
-  stdout: string;
-  stderr: string;
-  exitCode: number;
-}
+import type { GhResult } from "./phase-types.js";
+export type { GhResult };
 
 export const REVIEW_ROUND_CAP = 2;
 


### PR DESCRIPTION
## Summary
- Extracts the duplicate `GhResult` interface (`{ stdout, stderr, exitCode }`) from `done-fn.ts`, `qa-fn.ts`, and `review-fn.ts` into a new `.claude/phases/phase-types.ts`
- All three fn files now `import type { GhResult }` from the shared source and re-export it for their consumers (test files, phase scripts)
- No behavioral changes — pure type deduplication

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes (no fixes needed)
- [x] `bun test test/done-phase.spec.ts test/qa-phase.spec.ts test/review-phase.spec.ts` — 71 tests pass
- [x] Existing test files that import `GhResult` from the fn files continue to work via re-export

🤖 Generated with [Claude Code](https://claude.com/claude-code)