### PR TITLE
feat(monitor): add --all-repos flag to disable repo scoping (closes #2143)

### DIFF
--- a/packages/command/src/commands/monitor.spec.ts
+++ b/packages/command/src/commands/monitor.spec.ts
@@ -406,6 +406,11 @@ describe("parseMonitorArgs error branches", () => {
     expect(parseMonitorArgs(["--repo"]).error).toBeTruthy();
   });
 
+  test("--repo followed by a flag is an error", () => {
+    const parsed = parseMonitorArgs(["--repo", "--all-repos"]);
+    expect(parsed.error).toBeTruthy();
+  });
+
   test("--all-repos sets allRepos=true", () => {
     const parsed = parseMonitorArgs(["--all-repos"]);
     expect(parsed.allRepos).toBe(true);
@@ -930,6 +935,7 @@ describe("cmdMonitor", () => {
       },
     });
     await cmdMonitor(["--all-repos"], deps);
+    expect(capturedParams).toBeDefined();
     expect(capturedParams?.repo).toBeUndefined();
   });
 
@@ -943,6 +949,7 @@ describe("cmdMonitor", () => {
       },
     });
     await cmdMonitor(["--all-repos", "--repo", "/custom/repo"], deps);
+    expect(capturedParams).toBeDefined();
     expect(capturedParams?.repo).toBeUndefined();
   });
 });

--- a/packages/command/src/commands/monitor.spec.ts
+++ b/packages/command/src/commands/monitor.spec.ts
@@ -405,6 +405,16 @@ describe("parseMonitorArgs error branches", () => {
   test("--repo without value is an error", () => {
     expect(parseMonitorArgs(["--repo"]).error).toBeTruthy();
   });
+
+  test("--all-repos sets allRepos=true", () => {
+    const parsed = parseMonitorArgs(["--all-repos"]);
+    expect(parsed.allRepos).toBe(true);
+  });
+
+  test("allRepos defaults to false", () => {
+    const parsed = parseMonitorArgs([]);
+    expect(parsed.allRepos).toBe(false);
+  });
 });
 
 // ── cmdMonitor unit tests (dependency-injected) ──
@@ -908,5 +918,31 @@ describe("cmdMonitor", () => {
     });
     await cmdMonitor([], deps);
     expect(capturedParams?.repo).toBe("/default/repo");
+  });
+
+  test("--all-repos passes no repo to openEventStream", async () => {
+    let capturedParams: Parameters<typeof openEventStream>[0];
+    const deps = makeStreamDeps([], {
+      getCwd: () => "/some/repo",
+      openEventStream: (params) => {
+        capturedParams = params;
+        return { events: (async function* () {})(), abort: () => {} };
+      },
+    });
+    await cmdMonitor(["--all-repos"], deps);
+    expect(capturedParams?.repo).toBeUndefined();
+  });
+
+  test("--all-repos overrides --repo", async () => {
+    let capturedParams: Parameters<typeof openEventStream>[0];
+    const deps = makeStreamDeps([], {
+      getCwd: () => "/some/repo",
+      openEventStream: (params) => {
+        capturedParams = params;
+        return { events: (async function* () {})(), abort: () => {} };
+      },
+    });
+    await cmdMonitor(["--all-repos", "--repo", "/custom/repo"], deps);
+    expect(capturedParams?.repo).toBeUndefined();
   });
 });

--- a/packages/command/src/commands/monitor.ts
+++ b/packages/command/src/commands/monitor.ts
@@ -129,11 +129,12 @@ export function parseMonitorArgs(args: string[]): MonitorArgs {
         break;
       }
     } else if (arg === "--repo") {
-      repo = args[++i];
-      if (!repo) {
+      const next = args[++i];
+      if (!next || next.startsWith("-")) {
         error = "--repo requires a path";
         break;
       }
+      repo = next;
     } else if (arg === "--all-repos") {
       allRepos = true;
     } else if (arg === "--since") {

--- a/packages/command/src/commands/monitor.ts
+++ b/packages/command/src/commands/monitor.ts
@@ -23,6 +23,7 @@ export interface MonitorArgs {
   src: string | undefined;
   phase: string | undefined;
   repo: string | undefined;
+  allRepos: boolean;
   since: number | undefined;
   until: string | undefined;
   timeout: number | undefined;
@@ -64,6 +65,7 @@ export function parseMonitorArgs(args: string[]): MonitorArgs {
   let src: string | undefined;
   let phase: string | undefined;
   let repo: string | undefined;
+  let allRepos = false;
   let since: number | undefined;
   let until: string | undefined;
   let timeout: number | undefined;
@@ -132,6 +134,8 @@ export function parseMonitorArgs(args: string[]): MonitorArgs {
         error = "--repo requires a path";
         break;
       }
+    } else if (arg === "--all-repos") {
+      allRepos = true;
     } else if (arg === "--since") {
       const next = args[++i];
       const n = Number(next);
@@ -178,6 +182,7 @@ export function parseMonitorArgs(args: string[]): MonitorArgs {
     src,
     phase,
     repo,
+    allRepos,
     since,
     until,
     timeout,
@@ -204,6 +209,7 @@ Filters (evaluated server-side):
   --src <pattern>            Source attribution filter
   --phase <name>             Only items in this phase
   --repo <path>              Scope to repo root (default: current working directory)
+  --all-repos               Disable repo scoping — show events from all repos
   --since <seq>              Replay from cursor (reserved)
 
 Terminators:
@@ -230,7 +236,7 @@ export async function cmdMonitor(args: string[], deps?: Partial<MonitorDeps>): P
 
   const useJson = parsed.json || !d.isTTY;
 
-  const repo = resolveRealpath(resolve(parsed.repo ?? d.getCwd()));
+  const repo = parsed.allRepos ? undefined : resolveRealpath(resolve(parsed.repo ?? d.getCwd()));
 
   const { events, abort } = d.openEventStream({
     subscribe: parsed.subscribe,


### PR DESCRIPTION
## Summary
- Adds `--all-repos` flag to `mcx monitor` that disables the default CWD repo scoping introduced by #2139
- When `--all-repos` is set, `openEventStream` is called without a `repo` param, restoring the pre-#2139 global event stream
- `--all-repos` takes precedence over `--repo` if both are specified

## Test plan
- [x] `parseMonitorArgs(["--all-repos"])` returns `allRepos: true`
- [x] `allRepos` defaults to `false` when flag is absent
- [x] `cmdMonitor` passes `repo: undefined` to `openEventStream` when `--all-repos` is set
- [x] `--all-repos` overrides `--repo` (repo param still undefined)
- [x] All 65 monitor tests pass; full suite 7427 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)