### PR TITLE
feat(ctx.gh): add validate() for eager auth/repo resolution (closes #2154)

### DIFF
--- a/packages/core/src/alias.ts
+++ b/packages/core/src/alias.ts
@@ -168,6 +168,12 @@ export interface AliasContext {
    * operations via `ctx.gh.pr(123).body()`, `ctx.gh.issue(456).comments()`,
    * etc. Also exposes `ctx.gh.graphql()` and `ctx.gh.rest()` escape hatches.
    * Auth resolves from GH_TOKEN → GITHUB_TOKEN → `gh auth token`.
+   *
+   * **Lazy contract**: `pr()`, `issue()`, and `repo()` return handles that
+   * defer auth and repo detection until the first method call. Auth failures
+   * therefore surface at call time, not at handle creation. Phase scripts that
+   * build multiple handles should call `await ctx.gh.validate()` at setup time
+   * to fail fast before any handle is used.
    */
   gh: GhClient;
   /**

--- a/packages/core/src/gh-client.spec.ts
+++ b/packages/core/src/gh-client.spec.ts
@@ -916,3 +916,34 @@ describe("rateLimit", () => {
     expect(info.reset).toBeInstanceOf(Date);
   });
 });
+
+// ── validate ──
+
+describe("validate", () => {
+  test("resolves without error when token and repo are valid", async () => {
+    const { fn } = mockFetch([]);
+    const client = makeClient({ fetch: fn });
+    await expect(client.validate()).resolves.toBeUndefined();
+  });
+
+  test("throws GhAuthError eagerly when token resolution fails", async () => {
+    const { fn } = mockFetch([]);
+    const client = new GhClient({
+      repoRoot: "/tmp/test",
+      owner: "o",
+      repo: "r",
+      getToken: async () => {
+        throw new GhAuthError("no token");
+      },
+      fetch: fn,
+    });
+    await expect(client.validate()).rejects.toBeInstanceOf(GhAuthError);
+  });
+
+  test("is safe to call multiple times", async () => {
+    const { fn } = mockFetch([]);
+    const client = makeClient({ fetch: fn });
+    await expect(client.validate()).resolves.toBeUndefined();
+    await expect(client.validate()).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/gh-client.spec.ts
+++ b/packages/core/src/gh-client.spec.ts
@@ -940,10 +940,29 @@ describe("validate", () => {
     await expect(client.validate()).rejects.toBeInstanceOf(GhAuthError);
   });
 
-  test("is safe to call multiple times", async () => {
+  test("is safe to call multiple times (env-var path)", async () => {
     const { fn } = mockFetch([]);
     const client = makeClient({ fetch: fn });
     await expect(client.validate()).resolves.toBeUndefined();
     await expect(client.validate()).resolves.toBeUndefined();
+  });
+
+  test("caches token resolution for getToken clients", async () => {
+    let callCount = 0;
+    const { fn } = mockFetch([]);
+    const client = new GhClient({
+      repoRoot: "/tmp/test",
+      owner: "o",
+      repo: "r",
+      getToken: async () => {
+        callCount++;
+        return "gho_custom";
+      },
+      fetch: fn,
+    });
+    await client.validate();
+    await client.validate();
+    await client.validate();
+    expect(callCount).toBe(1);
   });
 });

--- a/packages/core/src/gh-client.ts
+++ b/packages/core/src/gh-client.ts
@@ -921,6 +921,7 @@ export class GhClient {
   private readonly getTokenFn: (() => Promise<string>) | undefined;
   private readonly fetchFn: FetchFn;
   private resolvedRepo: GhRepoInfo | null;
+  private cachedReqOpts: RequestOptions | null = null;
 
   constructor(opts: GhClientOptions) {
     this.repoRoot = opts.repoRoot;
@@ -937,8 +938,10 @@ export class GhClient {
   }
 
   private async makeReqOpts(): Promise<RequestOptions> {
+    if (this.cachedReqOpts) return this.cachedReqOpts;
     const token = await resolveToken({ getToken: this.getTokenFn });
-    return { token, fetchFn: this.fetchFn, getToken: this.getTokenFn };
+    this.cachedReqOpts = { token, fetchFn: this.fetchFn, getToken: this.getTokenFn };
+    return this.cachedReqOpts;
   }
 
   /**

--- a/packages/core/src/gh-client.ts
+++ b/packages/core/src/gh-client.ts
@@ -941,6 +941,19 @@ export class GhClient {
     return { token, fetchFn: this.fetchFn, getToken: this.getTokenFn };
   }
 
+  /**
+   * Eagerly resolve the GitHub token and repo, throwing immediately if either
+   * fails. Call this at phase-script setup time to surface auth/repo errors
+   * before building handles — useful when a phase script constructs multiple
+   * handles and would otherwise only fail on the third `.body()` call.
+   *
+   * Safe to call multiple times; resolution is cached after the first call.
+   */
+  async validate(): Promise<void> {
+    await this.ensureRepo();
+    await this.makeReqOpts();
+  }
+
   pr(prNumber: number): PrHandle {
     const self = this;
     let cachedOpts: RequestOptions | null = null;


### PR DESCRIPTION
## Summary
- Adds `GhClient.validate()` — an async method that eagerly resolves the GitHub token and git remote repo before any handle method is called
- Updates `AliasContext.gh` JSDoc to document the lazy Proxy contract and direct phase authors to `validate()` for fail-fast setup
- Adds 3 tests covering: successful validation, `GhAuthError` thrown eagerly, and repeated safe invocations

## Test plan
- [x] `validate` test suite (3 tests) in `gh-client.spec.ts` — all pass
- [x] Full test suite: 40 pass in `gh-client.spec.ts`, 7426 total (no regressions)
- [x] Typecheck and lint clean
- [x] Rebased onto `origin/main` after #2147 landed; checked for duplicate methods — none

🤖 Generated with [Claude Code](https://claude.com/claude-code)