### PR TITLE
fix(done-fn): check prView state before classifying merge errors (fixes #2155)

### DIFF
--- a/.claude/phases/done-fn.spec.ts
+++ b/.claude/phases/done-fn.spec.ts
@@ -115,6 +115,52 @@ describe("mergePr", () => {
       async prMerge(_prNumber, _flags) {
         return { stdout: "", stderr: "Pull Request is not mergeable due to conflict", exitCode: 1 };
       },
+      async prView(_prNumber, _fields, _jqExpr?) {
+        return "OPEN";
+      },
+    });
+    const result = await mergePr(42, deps);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("conflicts");
+  });
+
+  test("returns ok:true when concurrent rerun sees 'not mergeable' but PR is already MERGED", async () => {
+    // Concurrent rerun scenario: a previous done invocation already merged the PR
+    // server-side. The second call gets "Pull Request is not mergeable" from GitHub,
+    // which must NOT be classified as conflicts — prView confirms MERGED, so ok:true.
+    const deps = makeDeps({
+      async gh(args) {
+        if (args[4] === "labels") return { stdout: "qa:pass", stderr: "", exitCode: 0 };
+        if (args[4] === "statusCheckRollup") return { stdout: "0", stderr: "", exitCode: 0 };
+        return { stdout: "", stderr: "", exitCode: 0 };
+      },
+      async prMerge(_prNumber, _flags) {
+        return { stdout: "", stderr: "Pull Request is not mergeable", exitCode: 1 };
+      },
+      async prView(_prNumber, _fields, _jqExpr?) {
+        return "MERGED";
+      },
+    });
+    const result = await mergePr(42, deps);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.prNumber).toBe(42);
+  });
+
+  test("falls back to conflicts classification when prView fails and stderr matches", async () => {
+    // prView is unreachable (network error), so we fall back to deterministic
+    // stderr pattern matching — "not mergeable" is classified as conflicts.
+    const deps = makeDeps({
+      async gh(args) {
+        if (args[4] === "labels") return { stdout: "qa:pass", stderr: "", exitCode: 0 };
+        if (args[4] === "statusCheckRollup") return { stdout: "0", stderr: "", exitCode: 0 };
+        return { stdout: "", stderr: "", exitCode: 0 };
+      },
+      async prMerge(_prNumber, _flags) {
+        return { stdout: "", stderr: "Pull Request is not mergeable due to conflict", exitCode: 1 };
+      },
+      async prView(_prNumber, _fields, _jqExpr?) {
+        throw new Error("network unreachable");
+      },
     });
     const result = await mergePr(42, deps);
     expect(result.ok).toBe(false);

--- a/.claude/phases/done-fn.ts
+++ b/.claude/phases/done-fn.ts
@@ -83,7 +83,28 @@ export async function mergePr(prNumber: number, deps: MergePrDeps): Promise<Merg
   const mergeResult = await deps.prMerge(prNumber, ["--squash", "--delete-branch"]);
   if (mergeResult.exitCode !== 0) {
     const stderr = mergeResult.stderr;
-    // Classify deterministic failures first — no API round-trip needed.
+    // Check server state first — prMerge can fail client-side (SIGTERM, network)
+    // while the server-side merge already completed. Also guards against concurrent
+    // reruns: a second done invocation sees "not mergeable" from GitHub (PR already
+    // merged) which would otherwise match the conflicts pattern below and incorrectly
+    // spawn a rebase worker. prView is authoritative; pattern matching is only a
+    // fallback when the PR is confirmed to not be merged.
+    try {
+      const stateOut = await deps.prView(prNumber, "state", ".state");
+      if (stateOut === "MERGED") {
+        const worktreeHeld = /used by worktree|cannot delete branch.*checked out/i.test(stderr);
+        return {
+          ok: true,
+          prNumber,
+          localCleanup: worktreeHeld
+            ? "skipped: worktree holds branch (bye impl session to prune)"
+            : "branch delete incomplete: gh interrupted before client-side cleanup; prune impl branch manually",
+        };
+      }
+    } catch {
+      /* prView failed — fall through to deterministic error classification */
+    }
+    // Classify deterministic failures — only after confirming PR is not yet merged.
     if (/not mergeable|conflict/i.test(stderr)) {
       return {
         ok: false,
@@ -99,25 +120,6 @@ export async function mergePr(prNumber: number, deps: MergePrDeps): Promise<Merg
         nextAction: "inspect branch-protection required checks; re-run the missing check",
         detail: stderr,
       };
-    }
-    // Outcome unknown — poll state. gh (Go binary) may exit 1 after SIGTERM
-    // when the HTTP request already completed server-side. In all interrupt
-    // cases --delete-branch never finishes client-side, so always signal that
-    // cleanup is incomplete regardless of the specific error.
-    try {
-      const stateOut = await deps.prView(prNumber, "state", ".state");
-      if (stateOut === "MERGED") {
-        const worktreeHeld = /used by worktree|cannot delete branch.*checked out/i.test(stderr);
-        return {
-          ok: true,
-          prNumber,
-          localCleanup: worktreeHeld
-            ? "skipped: worktree holds branch (bye impl session to prune)"
-            : "branch delete incomplete: gh interrupted before client-side cleanup; prune impl branch manually",
-        };
-      }
-    } catch {
-      /* prView failed — fall through to merge_failed */
     }
     return {
       ok: false,

--- a/test/done-phase.spec.ts
+++ b/test/done-phase.spec.ts
@@ -155,69 +155,63 @@ describe("mergePr — success", () => {
 // ── Merge failure classification ──
 
 describe("mergePr — merge failure paths", () => {
-  test("conflict error → conflicts (no prView call)", async () => {
-    let prViewCalled = false;
+  test("conflict error → conflicts (prView confirms not merged)", async () => {
     const result = await mergePr(
       100,
       makeDeps({
         prMerge: async () => fail("Pull Request is not mergeable"),
-        prView: async () => {
-          prViewCalled = true;
-          return "MERGED";
-        },
+        prView: async () => "OPEN",
       }),
     );
     expect(result).toMatchObject({ ok: false, reason: "conflicts" });
     if (!result.ok) expect(result.detail).toContain("not mergeable");
-    expect(prViewCalled).toBe(false);
   });
 
-  test("'conflict' keyword → conflicts (no prView call)", async () => {
-    let prViewCalled = false;
+  test("'conflict' keyword → conflicts (prView confirms not merged)", async () => {
     const result = await mergePr(
       100,
       makeDeps({
         prMerge: async () => fail("merge conflict detected"),
-        prView: async () => {
-          prViewCalled = true;
-          return "MERGED";
-        },
+        prView: async () => "OPEN",
       }),
     );
     expect(result).toMatchObject({ ok: false, reason: "conflicts" });
-    expect(prViewCalled).toBe(false);
   });
 
-  test("required check error → missing_required_check (no prView call)", async () => {
-    let prViewCalled = false;
+  test("required check error → missing_required_check (prView confirms not merged)", async () => {
     const result = await mergePr(
       100,
       makeDeps({
         prMerge: async () => fail("required check 'CI' has not passed"),
-        prView: async () => {
-          prViewCalled = true;
-          return "MERGED";
-        },
+        prView: async () => "OPEN",
       }),
     );
     expect(result).toMatchObject({ ok: false, reason: "missing_required_check" });
-    expect(prViewCalled).toBe(false);
   });
 
-  test("required status error → missing_required_check (no prView call)", async () => {
-    let prViewCalled = false;
+  test("required status error → missing_required_check (prView confirms not merged)", async () => {
     const result = await mergePr(
       100,
       makeDeps({
         prMerge: async () => fail("Required status check not passing"),
-        prView: async () => {
-          prViewCalled = true;
-          return "MERGED";
-        },
+        prView: async () => "OPEN",
       }),
     );
     expect(result).toMatchObject({ ok: false, reason: "missing_required_check" });
-    expect(prViewCalled).toBe(false);
+  });
+
+  test("'not mergeable' error but PR is already MERGED → ok:true (concurrent rerun guard)", async () => {
+    // A second done invocation finds the PR already merged server-side.
+    // GitHub returns "not mergeable" but prView confirms MERGED → must not
+    // misclassify as conflicts and spawn a rebase worker.
+    const result = await mergePr(
+      100,
+      makeDeps({
+        prMerge: async () => fail("Pull Request is not mergeable"),
+        prView: async () => "MERGED",
+      }),
+    );
+    expect(result).toMatchObject({ ok: true, prNumber: 100 });
   });
 
   test("generic failure → merge_failed", async () => {


### PR DESCRIPTION
## Summary

- Reorder merge error handling in `done-fn.ts` so `prView` state is checked **before** stderr pattern matching, not after
- Concurrent done reruns that hit "Pull Request is not mergeable" (because a prior invocation already merged it) now correctly return `ok: true` instead of misclassifying as `conflicts` and spawning a spurious rebase worker
- Pattern matching (`conflicts`, `missing_required_check`) is now only reached after `prView` confirms the PR is not yet merged; if `prView` itself throws, the original fallback behavior is preserved

## Test plan

- [x] Updated 4 existing tests in `test/done-phase.spec.ts` that previously asserted `prView` was not called for conflict/required-check errors — now they supply `prView: async () => "OPEN"` so the pattern-match path is still exercised
- [x] Added new test: `'not mergeable' error but PR is MERGED → ok:true` (concurrent rerun guard)
- [x] Added 3 new tests in `.claude/phases/done-fn.spec.ts`: concurrent rerun scenario, prView-fails fallback, and "not mergeable" with OPEN state
- [x] `bun typecheck` — pass
- [x] `bun lint` — pass
- [x] `bun test` — 7429 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)