### PR TITLE
chore(skill): add --allow Bash to investigations.md spawn template (#2121)

### DIFF
--- a/.claude/skills/sprint/references/investigations.md
+++ b/.claude/skills/sprint/references/investigations.md
@@ -60,7 +60,7 @@ The gate is for issues where the wrong fix is worse than no fix.
 **Use `mcx claude spawn`, NOT the Agent tool / `subagent_type: "nerd-snipe"`.**
 
 ```bash
-mcx claude spawn --worktree --model opus -t "$(cat <<'PROMPT'
+mcx claude spawn --worktree --model opus --allow Read Glob Grep Write Edit Bash -t "$(cat <<'PROMPT'
 You are nerd-snipe (read .claude/agents/nerd-snipe.md directly first to
 ground in the persona — do NOT invoke the Agent tool yourself).
 


### PR DESCRIPTION
Applies meta-fix #2121. Adds `--allow Read Glob Grep Write Edit Bash` to the canonical nerd-snipe investigation spawn template so investigation workers don't hit permission_request walls on `bun test` / `git bisect` (witnessed sprint 57, #2103 — ~\$0.50 wasted).

Docs/skill-only — pre-commit hooks skip the test suite. Lands before sprint 59 finalizes so the flake investigation (#2112) spawns from the corrected template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)