### PR TITLE
perf(gh-client): normalize check-run conclusions, add path to GhPageCapError (fixes #2169)

### DIFF
--- a/packages/core/src/gh-client.spec.ts
+++ b/packages/core/src/gh-client.spec.ts
@@ -312,7 +312,7 @@ describe("PrHandle", () => {
     expect(calls[2].init.method).toBe("DELETE");
   });
 
-  test("checks() merges check-runs and commit statuses, deduplicating by context", async () => {
+  test("checks() returns check-runs and commit statuses as separate arrays, deduplicating statuses by context", async () => {
     const prBody = {
       number: 42,
       title: "PR",
@@ -406,6 +406,50 @@ describe("PrHandle", () => {
 
     expect(result.commit_statuses).toHaveLength(2);
     expect(result.commit_statuses.every((s) => s.conclusion === "FAILURE")).toBe(true);
+  });
+
+  test("checks() normalizes check-run conclusions to uppercase", async () => {
+    const prBody = {
+      number: 5,
+      title: "T",
+      body: null,
+      state: "open",
+      draft: false,
+      merged: false,
+      merged_at: null,
+      labels: [],
+      mergeable: null,
+      mergeable_state: "",
+      merge_commit_sha: null,
+      head: { ref: "f", sha: "sha5" },
+      base: { ref: "main" },
+      user: { login: "u" },
+      created_at: "",
+      updated_at: "",
+    };
+
+    const { fn } = mockFetch([
+      { status: 200, body: prBody },
+      {
+        status: 200,
+        body: {
+          total_count: 3,
+          check_runs: [
+            { id: 1, name: "build", status: "completed", conclusion: "success" },
+            { id: 2, name: "lint", status: "completed", conclusion: "failure" },
+            { id: 3, name: "deploy", status: "in_progress", conclusion: null },
+          ],
+        },
+      },
+      { status: 200, body: [] },
+    ]);
+
+    const client = makeClient({ fetch: fn });
+    const result = await client.pr(5).checks();
+
+    expect(result.check_runs[0].conclusion).toBe("SUCCESS");
+    expect(result.check_runs[1].conclusion).toBe("FAILURE");
+    expect(result.check_runs[2].conclusion).toBeNull();
   });
 
   test("allCommentSurfaces() combines all 4 surfaces", async () => {
@@ -653,6 +697,7 @@ describe("pagination", () => {
       expect(err).toBeInstanceOf(GhPageCapError);
       expect((err as GhPageCapError).itemCount).toBeGreaterThan(0);
       expect((err as GhPageCapError).message).toContain("MAX_PAGES");
+      expect((err as GhPageCapError).path).toContain("/issues/42/comments");
     }
   });
 });

--- a/packages/core/src/gh-client.ts
+++ b/packages/core/src/gh-client.ts
@@ -59,7 +59,7 @@ export class GhPageCapError extends Error {
   override name = "GhPageCapError" as const;
   itemCount: number;
   path: string;
-  constructor(message: string, itemCount: number, path: string) {
+  constructor(message: string, itemCount: number, path = "") {
     super(message);
     this.itemCount = itemCount;
     this.path = path;

--- a/packages/core/src/gh-client.ts
+++ b/packages/core/src/gh-client.ts
@@ -58,9 +58,11 @@ export class GhServerError extends Error {
 export class GhPageCapError extends Error {
   override name = "GhPageCapError" as const;
   itemCount: number;
-  constructor(message: string, itemCount: number) {
+  path: string;
+  constructor(message: string, itemCount: number, path: string) {
     super(message);
     this.itemCount = itemCount;
+    this.path = path;
   }
 }
 
@@ -445,8 +447,9 @@ async function ghPaginated<T>(path: string, opts: RequestOptions & { page?: numb
     url = parseNextUrl(resp.headers.get("link"));
     if (page === MAX_PAGES - 1 && url !== null) {
       throw new GhPageCapError(
-        `ghPaginated: hit MAX_PAGES (${MAX_PAGES}) but more pages remain — result is truncated. Increase MAX_PAGES or use a more specific query.`,
+        `ghPaginated: hit MAX_PAGES (${MAX_PAGES}) at ${path} but more pages remain — result is truncated. Increase MAX_PAGES or use a more specific query.`,
         allItems.length,
+        path,
       );
     }
   }
@@ -517,6 +520,12 @@ interface RawIssue {
   user: { login: string };
   created_at: string;
   updated_at: string;
+}
+
+// ── Helpers ──
+
+function normalizeConclusion(conclusion: string | null): string | null {
+  return conclusion !== null ? conclusion.toUpperCase() : null;
 }
 
 // ── Mappers ──
@@ -655,7 +664,7 @@ export class PrHandle {
 
     return {
       total_count: checkRunsRaw.total_count,
-      check_runs: checkRunsRaw.check_runs,
+      check_runs: checkRunsRaw.check_runs.map((cr) => ({ ...cr, conclusion: normalizeConclusion(cr.conclusion) })),
       commit_statuses: dedupedStatuses,
     };
   }


### PR DESCRIPTION
## Summary

- Normalize `check_runs` conclusions to uppercase in `PrHandle.checks()` so both check-run and commit-status conclusions share consistent casing (`SUCCESS`/`FAILURE`/`null`) — callers can compare with `=== "FAILURE"` without worrying which surface produced the entry
- Add `path: string` field to `GhPageCapError` and embed it in the error message, making the truncated endpoint immediately visible during production debugging
- Rename misleading spec: `checks()` returns check-runs and statuses as **separate arrays** — the merge happens in the done-phase adapter, not here

## Test plan

- [x] Renamed test: "checks() returns check-runs and commit statuses as separate arrays, deduplicating statuses by context"
- [x] Updated `GhPageCapError` test: asserts `.path` contains the endpoint path
- [x] New test: `checks() normalizes check-run conclusions to uppercase` — mocks lowercase GitHub API values (`"success"`, `"failure"`, `null`) and verifies uppercase output
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun test packages/core/src/gh-client.spec.ts` — 43 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)