### PR TITLE
ci: add seed embedding smoke test to catch embed regressions (closes #1682)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,3 +293,31 @@ jobs:
           else
             exit $code
           fi
+      # Verify compiled binary contains embedded seed assets (wiggle.js + config.json).
+      # Catches regressions where bun build --compile silently drops { type: "text" }
+      # or resolveJsonModule imports — the kind that passes bun test but ships broken.
+      # See #1592 (original bug), PR #1657 (fix), #1682 (this guard).
+      - name: Seed embedding smoke test
+        if: needs.detect.outputs.docs_only != 'true'
+        run: |
+          fail=0
+          check() {
+            local label="$1" pattern="$2"
+            if strings dist/mcpd | grep -q "$pattern"; then
+              echo "  PASS: $label ($pattern)"
+            else
+              echo "  FAIL: $label ($pattern) — not found in dist/mcpd"
+              fail=1
+            fi
+          }
+          echo "Checking embedded seed assets in dist/mcpd..."
+          check "teams wiggle.js"   "AUTOSUGGEST_INPUT"
+          check "teams config.json" "substrate.office.com"
+          check "owa config.json"   "outlook.cloud.microsoft"
+          if [ $fail -ne 0 ]; then
+            echo "One or more seed assets are missing from the compiled binary."
+            echo "Check that all imports in packages/daemon/src/site/seeds.ts use"
+            echo "static imports (resolveJsonModule for .json, { type: 'text' } for .js)."
+            exit 1
+          fi
+          echo "All seed assets confirmed embedded."


### PR DESCRIPTION
## Summary
- Adds a "Seed embedding smoke test" step to the `build` CI job that runs after `bun scripts/build.ts`
- Verifies `dist/mcpd` contains three sentinel strings proving all seed assets (teams/wiggle.js, teams/config.json, owa/config.json) survived `bun build --compile`
- Fails fast with a diagnostic message pointing to `seeds.ts` if any string is missing

## Test plan
- [ ] CI `build` job passes on this PR (confirming the step runs clean against current seeds)
- [ ] Manually verified sentinel strings exist in seed files: `AUTOSUGGEST_INPUT` in `seeds/teams/wiggle.js`, `substrate.office.com` in `seeds/teams/config.json`, `outlook.cloud.microsoft` in `seeds/owa/config.json`
- [ ] Step is gated on `docs_only != 'true'` (consistent with all other build steps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)