### PR TITLE
fix(events): poll heartbeat at 1/6 silence threshold, not 1× (fixes #1528)

### DIFF
--- a/packages/daemon/src/event-stream.ts
+++ b/packages/daemon/src/event-stream.ts
@@ -633,6 +633,10 @@ export class EventStreamServer {
           lastWriteTime = Date.now();
         }
 
+        // Poll at 1/6 the silence threshold so the worst-case gap is ~1.17× the
+        // threshold, not 2× (which happens when an event lands 1ms after a timer
+        // fire and the next check is a full interval away — see #1528).
+        const heartbeatPollMs = Math.ceil(this.heartbeatIntervalMs / 6);
         heartbeatTimer = setInterval(() => {
           if (Date.now() - lastWriteTime >= this.heartbeatIntervalMs) {
             const hb = `${JSON.stringify({ category: "heartbeat", event: "heartbeat", seq: this.eventSeq, src: "daemon", ts: new Date().toISOString() })}\n`;
@@ -643,7 +647,7 @@ export class EventStreamServer {
               cleanup();
             }
           }
-        }, this.heartbeatIntervalMs);
+        }, heartbeatPollMs);
         heartbeatTimer.unref();
       },
       cancel: cleanup,

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -3677,6 +3677,42 @@ describe("IpcServer HTTP transport", () => {
     }
   });
 
+  test("GET /events ring-buffer heartbeat poll rate is 1/6 of silence threshold (closes #1528)", () => {
+    // Verify setInterval is called with heartbeatIntervalMs/6, not heartbeatIntervalMs,
+    // so the worst-case heartbeat delay is ~1.17× the threshold, not 2×.
+    const heartbeatMs = 600;
+    const capturedIntervals: number[] = [];
+    const origSetInterval = globalThis.setInterval;
+    (globalThis as unknown as Record<string, unknown>).setInterval = (fn: (...args: unknown[]) => void, ms: number) =>
+      origSetInterval(fn, ms);
+    const patchedSetInterval = (fn: (...args: unknown[]) => void, ms: number) => {
+      capturedIntervals.push(ms);
+      return origSetInterval(fn, ms);
+    };
+    (globalThis as unknown as Record<string, unknown>).setInterval = patchedSetInterval;
+
+    try {
+      const es = new (
+        EventStreamServer as unknown as new (
+          ...args: unknown[]
+        ) => { handleEventsNDJSON(u: URL): Response }
+      )(null, mockPool(), silentLogger, heartbeatMs);
+
+      // handleEventsNDJSON creates the ReadableStream; start() runs synchronously,
+      // calling setInterval before returning. We just need to trigger stream creation.
+      const res = es.handleEventsNDJSON(new URL("http://localhost/events"));
+      // Cancel the body to release resources; we only care about the setInterval call.
+      res.body?.cancel().catch(() => {});
+
+      const pollInterval = capturedIntervals[capturedIntervals.length - 1];
+      expect(pollInterval).toBeDefined();
+      expect(pollInterval).toBe(Math.ceil(heartbeatMs / 6)); // 100ms poll, not 600ms
+      expect(pollInterval).toBeLessThan(heartbeatMs);
+    } finally {
+      (globalThis as unknown as Record<string, unknown>).setInterval = origSetInterval;
+    }
+  });
+
   test("GET /events respects subscribe filter server-side", async () => {
     startServer();
 


### PR DESCRIPTION
## Summary
- The ring-buffer fallback path's `setInterval` was using `heartbeatIntervalMs` (30s) as both the poll rate and the silence threshold. If an event arrived 1ms after a timer fire, the next heartbeat check was a full 30s away — so clients could wait up to 60s (2×) before detecting a dead connection.
- Fix: compute `heartbeatPollMs = Math.ceil(heartbeatIntervalMs / 6)` and use that as the `setInterval` interval. The silence threshold condition (`>= heartbeatIntervalMs`) is unchanged — only the check frequency improves.
- Worst-case heartbeat delay drops from `2 × threshold` to `threshold + threshold/6 ≈ 1.17 × threshold` (e.g. 35s instead of 60s for a 30s threshold).

## Test plan
- [x] New structural test verifies `setInterval` is called with `Math.ceil(heartbeatIntervalMs / 6)`, not `heartbeatIntervalMs` — catches any regression without relying on wall-clock timing
- [x] Existing `"GET /events heartbeat fires after silence"` test still passes with the shorter poll interval (200ms threshold → ~33ms poll, well within the 2s deadline)
- [x] `bun typecheck` clean
- [x] `bun lint` clean
- [x] Full test suite: 7446 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)