### PR TITLE
refactor(phases): replace position-based gh() arg parsing with typed GhOp operations (closes #2145)

### DIFF
--- a/.claude/phases/done-fn.ts
+++ b/.claude/phases/done-fn.ts
@@ -1,7 +1,7 @@
 /** Core done-phase logic, extracted for testability via dependency injection. */
 
-import type { GhResult } from "./phase-types.js";
-export type { GhResult };
+import type { GhOp, GhResult } from "./phase-types.js";
+export type { GhOp, GhResult };
 
 export type MergeResult =
   | { ok: true; prNumber: number; localCleanup?: string }
@@ -18,7 +18,7 @@ export type MergeResult =
     };
 
 export interface MergePrDeps {
-  gh(args: string[]): Promise<GhResult>;
+  gh(op: GhOp): Promise<GhResult>;
   prMerge(prNumber: number, flags: string[]): Promise<GhResult>;
   prView(prNumber: number, fields: string, jqExpr?: string): Promise<string>;
   spawn(cmd: string[], opts?: { timeoutMs?: number }): Promise<GhResult>;
@@ -27,12 +27,8 @@ export interface MergePrDeps {
 export async function mergePr(prNumber: number, deps: MergePrDeps): Promise<MergeResult> {
   // Guard 1 + Guard 2 in parallel: fetch labels and CI status concurrently.
   const [labelOut, ciOut] = await Promise.all([
-    deps.gh(["pr", "view", String(prNumber), "--json", "labels", "-q", ".labels[].name"]),
-    deps.gh([
-      "pr", "view", String(prNumber),
-      "--json", "statusCheckRollup",
-      "-q", '[.statusCheckRollup[] | select(.conclusion != "SUCCESS")] | length',
-    ]),
+    deps.gh({ op: "pr:labels", prNumber }),
+    deps.gh({ op: "pr:checks", prNumber }),
   ]);
 
   if (labelOut.exitCode !== 0) {

--- a/.claude/phases/done.ts
+++ b/.claude/phases/done.ts
@@ -46,22 +46,20 @@ defineAlias({
     }
 
     const result = await mergePr(work.prNumber, {
-      async gh(args) {
+      async gh(op) {
         try {
-          const prNum = Number(args[2]);
-          const jsonField = args[4];
-          if (jsonField === "labels") {
-            const pr = await ctx.gh.pr(prNum).body();
+          if (op.op === "pr:labels") {
+            const pr = await ctx.gh.pr(op.prNumber).body();
             return { stdout: pr.labels.join("\n"), stderr: "", exitCode: 0 };
           }
-          if (jsonField === "statusCheckRollup") {
-            const checks = await ctx.gh.pr(prNum).checks();
+          if (op.op === "pr:checks") {
+            const checks = await ctx.gh.pr(op.prNumber).checks();
             // Merge check-runs and legacy commit statuses; null (pending) counts as non-SUCCESS.
             const all = [...checks.check_runs, ...checks.commit_statuses];
             const failing = all.filter((c) => c.conclusion !== "SUCCESS");
             return { stdout: String(failing.length), stderr: "", exitCode: 0 };
           }
-          return { stdout: "", stderr: `unsupported gh args: ${args.join(" ")}`, exitCode: 1 };
+          return { stdout: "", stderr: `unsupported gh op: ${op.op}`, exitCode: 1 };
         } catch (err) {
           return { stdout: "", stderr: err instanceof Error ? err.message : String(err), exitCode: 1 };
         }

--- a/.claude/phases/phase-types.ts
+++ b/.claude/phases/phase-types.ts
@@ -5,3 +5,16 @@ export interface GhResult {
   stderr: string;
   exitCode: number;
 }
+
+/**
+ * Typed GH operations for the gh() dependency injection point.
+ * Each variant maps to a specific ctx.gh method call; adapters dispatch on op.op.
+ * stdout format per op:
+ *   pr:labels   — newline-separated label names
+ *   pr:checks   — decimal count of non-SUCCESS checks
+ *   pr:comments — concatenated comment bodies (newline-joined)
+ */
+export type GhOp =
+  | { op: "pr:labels"; prNumber: number }
+  | { op: "pr:checks"; prNumber: number }
+  | { op: "pr:comments"; prNumber: number };

--- a/.claude/phases/qa-fn.ts
+++ b/.claude/phases/qa-fn.ts
@@ -1,7 +1,7 @@
 /** Core qa-phase logic, extracted for testability via dependency injection. */
 
-import type { GhResult } from "./phase-types.js";
-export type { GhResult };
+import type { GhOp, GhResult } from "./phase-types.js";
+export type { GhOp, GhResult };
 
 export const QA_FAIL_CAP = 2;
 
@@ -19,7 +19,7 @@ export interface QaState {
 }
 
 export interface QaDeps {
-  gh(args: string[]): Promise<GhResult>;
+  gh(op: GhOp): Promise<GhResult>;
   prEdit(prNumber: number, flags: string[]): Promise<void>;
 }
 
@@ -39,7 +39,7 @@ export async function readQaLabels(
   prNumber: number,
   deps: Pick<QaDeps, "gh">,
 ): Promise<{ hasPass: boolean; hasFail: boolean }> {
-  const result = await deps.gh(["pr", "view", String(prNumber), "--json", "labels", "-q", ".labels[].name"]);
+  const result = await deps.gh({ op: "pr:labels", prNumber });
   if (result.exitCode !== 0) return { hasPass: false, hasFail: false };
   const names = new Set(result.stdout.split(/\r?\n/).map((l) => l.trim()));
   return { hasPass: names.has("qa:pass"), hasFail: names.has("qa:fail") };

--- a/.claude/phases/qa.ts
+++ b/.claude/phases/qa.ts
@@ -60,10 +60,9 @@ defineAlias({
       { id: work.id, prNumber: work.prNumber, branch: work.branch, issueNumber: work.issueNumber },
       ctx.state,
       {
-        async gh(args) {
+        async gh(op) {
           try {
-            const prNum = Number(args[2]);
-            const pr = await ctx.gh.pr(prNum).body();
+            const pr = await ctx.gh.pr(op.prNumber).body();
             const stdout = pr.labels.join("\n");
             return { stdout, stderr: "", exitCode: 0 };
           } catch (err) {

--- a/.claude/phases/qa.ts
+++ b/.claude/phases/qa.ts
@@ -62,9 +62,11 @@ defineAlias({
       {
         async gh(op) {
           try {
-            const pr = await ctx.gh.pr(op.prNumber).body();
-            const stdout = pr.labels.join("\n");
-            return { stdout, stderr: "", exitCode: 0 };
+            if (op.op === "pr:labels") {
+              const pr = await ctx.gh.pr(op.prNumber).body();
+              return { stdout: pr.labels.join("\n"), stderr: "", exitCode: 0 };
+            }
+            return { stdout: "", stderr: `unsupported gh op: ${op.op}`, exitCode: 1 };
           } catch (err) {
             return { stdout: "", stderr: err instanceof Error ? err.message : String(err), exitCode: 1 };
           }

--- a/.claude/phases/review-fn.ts
+++ b/.claude/phases/review-fn.ts
@@ -1,7 +1,7 @@
 /** Core review-phase logic, extracted for testability via dependency injection. */
 
-import type { GhResult } from "./phase-types.js";
-export type { GhResult };
+import type { GhOp, GhResult } from "./phase-types.js";
+export type { GhOp, GhResult };
 
 export const REVIEW_ROUND_CAP = 2;
 
@@ -18,7 +18,7 @@ export interface ReviewState {
 }
 
 export interface ReviewDeps {
-  gh(args: string[]): Promise<GhResult>;
+  gh(op: GhOp): Promise<GhResult>;
   findModelInSprintPlan(issueNumber: number, repoRoot: string): "opus" | "sonnet" | null;
 }
 
@@ -53,7 +53,7 @@ export async function scanReviewComments(
   prNumber: number,
   deps: Pick<ReviewDeps, "gh">,
 ): Promise<{ found: boolean; hasBlockers: boolean; summary: string }> {
-  const result = await deps.gh(["pr", "view", String(prNumber), "--json", "comments", "-q", ".comments[].body"]);
+  const result = await deps.gh({ op: "pr:comments", prNumber });
   if (result.exitCode !== 0) return { found: false, hasBlockers: false, summary: "gh pr view failed" };
   const lastIdx = result.stdout.lastIndexOf("## Adversarial Review");
   if (lastIdx === -1) return { found: false, hasBlockers: false, summary: "no sticky comment yet" };

--- a/.claude/phases/review.ts
+++ b/.claude/phases/review.ts
@@ -69,11 +69,9 @@ defineAlias({
       { id: work.id, prNumber: work.prNumber, branch: work.branch, issueNumber: work.issueNumber ?? null },
       ctx.state,
       {
-        async gh(args) {
+        async gh(op) {
           try {
-            const prNumStr = args[2];
-            const prNum = Number(prNumStr);
-            const comments = await ctx.gh.pr(prNum).bodyComments();
+            const comments = await ctx.gh.pr(op.prNumber).bodyComments();
             const stdout = comments.map((c) => c.body).join("\n");
             return { stdout, stderr: "", exitCode: 0 };
           } catch (err) {

--- a/.claude/phases/review.ts
+++ b/.claude/phases/review.ts
@@ -71,9 +71,12 @@ defineAlias({
       {
         async gh(op) {
           try {
-            const comments = await ctx.gh.pr(op.prNumber).bodyComments();
-            const stdout = comments.map((c) => c.body).join("\n");
-            return { stdout, stderr: "", exitCode: 0 };
+            if (op.op === "pr:comments") {
+              const comments = await ctx.gh.pr(op.prNumber).bodyComments();
+              const stdout = comments.map((c) => c.body).join("\n");
+              return { stdout, stderr: "", exitCode: 0 };
+            }
+            return { stdout: "", stderr: `unsupported gh op: ${op.op}`, exitCode: 1 };
           } catch (err) {
             return { stdout: "", stderr: err instanceof Error ? err.message : String(err), exitCode: 1 };
           }

--- a/test/done-phase.spec.ts
+++ b/test/done-phase.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { type MergePrDeps, mergePr } from "../.claude/phases/done-fn";
-import type { GhResult } from "../.claude/phases/done-fn";
+import type { GhOp, GhResult } from "../.claude/phases/done-fn";
 
 function ok(stdout = ""): GhResult {
   return { stdout, stderr: "", exitCode: 0 };
@@ -12,10 +12,10 @@ function fail(stderr = "oops", exitCode = 1): GhResult {
 
 function makeDeps(overrides: Partial<MergePrDeps> = {}): MergePrDeps {
   return {
-    gh: async (args) => {
+    gh: async (op) => {
       // Default: labels returns qa:pass, CI returns 0 ungreen checks
-      if (args.includes("labels")) return ok("qa:pass");
-      if (args.includes("statusCheckRollup")) return ok("0");
+      if (op.op === "pr:labels") return ok("qa:pass");
+      if (op.op === "pr:checks") return ok("0");
       return ok();
     },
     prMerge: async () => ok(),
@@ -32,8 +32,8 @@ describe("mergePr — label guard", () => {
     const result = await mergePr(
       100,
       makeDeps({
-        gh: async (args) => {
-          if (args.includes("labels")) return ok("needs-review");
+        gh: async (op) => {
+          if (op.op === "pr:labels") return ok("needs-review");
           return ok("0");
         },
       }),
@@ -46,8 +46,8 @@ describe("mergePr — label guard", () => {
     const result = await mergePr(
       100,
       makeDeps({
-        gh: async (args) => {
-          if (args.includes("labels")) return ok("qa:pass\nqa:fail");
+        gh: async (op) => {
+          if (op.op === "pr:labels") return ok("qa:pass\nqa:fail");
           return ok("0");
         },
       }),
@@ -60,8 +60,8 @@ describe("mergePr — label guard", () => {
     const result = await mergePr(
       100,
       makeDeps({
-        gh: async (args) => {
-          if (args.includes("labels")) return fail("auth required");
+        gh: async (op) => {
+          if (op.op === "pr:labels") return fail("auth required");
           return ok("0");
         },
       }),
@@ -74,8 +74,8 @@ describe("mergePr — label guard", () => {
     const result = await mergePr(
       100,
       makeDeps({
-        gh: async (args) => {
-          if (args.includes("labels")) return ok("qa:pass");
+        gh: async (op) => {
+          if (op.op === "pr:labels") return ok("qa:pass");
           return fail("rate limited");
         },
       }),
@@ -88,8 +88,8 @@ describe("mergePr — label guard", () => {
     const result = await mergePr(
       100,
       makeDeps({
-        gh: async (args) => {
-          if (args.includes("labels")) return ok("qa:pass");
+        gh: async (op) => {
+          if (op.op === "pr:labels") return ok("qa:pass");
           return ok("3");
         },
       }),
@@ -101,8 +101,8 @@ describe("mergePr — label guard", () => {
     const result = await mergePr(
       100,
       makeDeps({
-        gh: async (args) => {
-          if (args.includes("labels")) return ok("qa:pass");
+        gh: async (op) => {
+          if (op.op === "pr:labels") return ok("qa:pass");
           return ok("null");
         },
       }),
@@ -308,22 +308,20 @@ describe("mergePr — merge failure paths", () => {
 // ── Guard order ──
 
 describe("mergePr — guard ordering", () => {
-  test("gh calls happen in parallel (both args captured)", async () => {
-    const capturedArgs: string[][] = [];
+  test("gh calls happen in parallel (both ops captured)", async () => {
+    const capturedOps: GhOp[] = [];
     await mergePr(
       100,
       makeDeps({
-        gh: async (args) => {
-          capturedArgs.push(args);
-          if (args.includes("labels")) return ok("qa:pass");
+        gh: async (op) => {
+          capturedOps.push(op);
+          if (op.op === "pr:labels") return ok("qa:pass");
           return ok("0");
         },
       }),
     );
     // Both calls should have occurred
-    const hasLabels = capturedArgs.some((a) => a.includes("labels"));
-    const hasCi = capturedArgs.some((a) => a.includes("statusCheckRollup"));
-    expect(hasLabels).toBe(true);
-    expect(hasCi).toBe(true);
+    expect(capturedOps.some((o) => o.op === "pr:labels")).toBe(true);
+    expect(capturedOps.some((o) => o.op === "pr:checks")).toBe(true);
   });
 });

--- a/test/qa-phase.spec.ts
+++ b/test/qa-phase.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { GhResult } from "../.claude/phases/qa-fn";
+import type { GhOp, GhResult } from "../.claude/phases/qa-fn";
 import { QA_FAIL_CAP, type QaDeps, type QaState, type QaWork, readQaLabels, runQa } from "../.claude/phases/qa-fn";
 
 function ok(stdout = ""): GhResult {
@@ -72,15 +72,15 @@ describe("readQaLabels — parsing", () => {
     expect(result).toEqual({ hasPass: true, hasFail: true });
   });
 
-  test("passes correct args to gh", async () => {
-    let captured: string[] | undefined;
+  test("passes correct op to gh", async () => {
+    let captured: GhOp | undefined;
     await readQaLabels(99, {
-      gh: async (args) => {
-        captured = args;
+      gh: async (op) => {
+        captured = op;
         return ok("");
       },
     });
-    expect(captured).toEqual(["pr", "view", "99", "--json", "labels", "-q", ".labels[].name"]);
+    expect(captured).toEqual({ op: "pr:labels", prNumber: 99 });
   });
 });
 

--- a/test/review-phase.spec.ts
+++ b/test/review-phase.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { GhResult } from "../.claude/phases/review-fn";
+import type { GhOp, GhResult } from "../.claude/phases/review-fn";
 import {
   REVIEW_ROUND_CAP,
   type ReviewDeps,
@@ -179,6 +179,17 @@ describe("scanReviewComments — parsing", () => {
     ].join("\n");
     const result = await scanReviewComments(100, { gh: async () => ok(body) });
     expect(result).toMatchObject({ found: true, hasBlockers: true });
+  });
+
+  test("passes correct op to gh", async () => {
+    let captured: GhOp | undefined;
+    await scanReviewComments(99, {
+      gh: async (op) => {
+        captured = op;
+        return ok("");
+      },
+    });
+    expect(captured).toEqual({ op: "pr:comments", prNumber: 99 });
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds `GhOp` discriminated union (`pr:labels | pr:checks | pr:comments`) to `phase-types.ts` — one canonical type for all gh dependency injection points across phase fn files
- Updates `done-fn.ts`, `qa-fn.ts`, `review-fn.ts` to accept `gh(op: GhOp)` instead of `gh(args: string[])`, and updates each call site to pass a typed op object
- Adapters in `done.ts`, `qa.ts`, `review.ts` now dispatch on `op.op` rather than parsing positional string args — mismatched call patterns are now compile errors instead of silent misroutes

## Test plan
- [x] `bun typecheck` — clean (no errors)
- [x] `bun lint` — clean (no fixes applied)
- [x] `bun test test/done-phase.spec.ts test/qa-phase.spec.ts test/review-phase.spec.ts` — 72/72 pass
- [x] `bun test` (full suite) — 7445/7445 pass across 303 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)