### PR TITLE
fix(test): convert last manual poll loop to pollUntil in disconnect test (fixes #2112)

### DIFF
--- a/packages/daemon/src/server-pool.spec.ts
+++ b/packages/daemon/src/server-pool.spec.ts
@@ -1818,16 +1818,7 @@ describe("disconnect kills stdio child processes (#940)", () => {
       // killPid would never be called, leaving the process alive.
       await pool.disconnect("sleeper");
 
-      const deadline = Date.now() + 5_000;
-      let dead = false;
-      while (Date.now() < deadline) {
-        if (!isAlive(pid)) {
-          dead = true;
-          break;
-        }
-        await Bun.sleep(100);
-      }
-      expect(dead).toBe(true);
+      await pollUntil(() => !isAlive(pid));
     } finally {
       forceKill(pid);
     }


### PR DESCRIPTION
## Summary
- Replace the manual deadline/poll loop in the `disconnect kills child process using connectFn-supplied childPid` test (#2135 regression test) with `pollUntil(() => !isAlive(pid))`
- This is the same conversion PR #2163 applied to the other two disconnect tests — the #2135 test was added by PR #2165 concurrently and missed the pattern change
- Eliminates the bun test timeout race (manual 100ms polling + 5s deadline vs bun's 5s test timeout)

## Test plan
- [x] `bun test packages/daemon/src/server-pool.spec.ts` — 163/163 pass (4.61s)
- [x] `bun test` — 7445/7445 pass, 0 failures
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `Bun.sleep` ratchet check passes (128 violations, baseline 136)

🤖 Generated with [Claude Code](https://claude.com/claude-code)