### PR TITLE
feat(mcx): add `mcx pr comments` and `mcx pr wait-for-copilot` commands (fixes #1912)

### DIFF
--- a/packages/command/src/commands/pr.spec.ts
+++ b/packages/command/src/commands/pr.spec.ts
@@ -25,7 +25,18 @@ const emptySnapshot: PrThreadSnapshot = {
   reviews: [],
   topLevelComments: [],
   fetchedAt: "2026-05-23T00:00:00.000Z",
+  pushedAt: null,
+  truncated: false,
 };
+
+function neverStream() {
+  return {
+    events: (async function* () {
+      // Never yields — simulates no events arriving
+    })(),
+    abort: () => {},
+  };
+}
 
 function makeDeps(overrides: Partial<PrDeps> = {}): PrDeps {
   return {
@@ -37,6 +48,7 @@ function makeDeps(overrides: Partial<PrDeps> = {}): PrDeps {
     sleep: () => Promise.resolve(),
     ipcCall: (() => Promise.resolve(emptySnapshot)) as PrDeps["ipcCall"],
     repoRoot: () => "/tmp/test-repo",
+    openStream: neverStream,
     ...overrides,
   };
 }
@@ -428,6 +440,7 @@ describe("prWaitForCopilot", () => {
   test("exits 0 immediately when Copilot has posted and push is old", async () => {
     const copilotSnapshot: PrThreadSnapshot = {
       ...emptySnapshot,
+      pushedAt: new Date(Date.now() - 120_000).toISOString(),
       threads: [
         {
           threadId: "T1",
@@ -444,17 +457,9 @@ describe("prWaitForCopilot", () => {
 
     const deps = makeDeps({
       ipcCall: (() => Promise.resolve(copilotSnapshot)) as PrDeps["ipcCall"],
-      exec: (cmd: string[]) => {
-        if (cmd.some((c: string) => c.includes("pulls/"))) {
-          // Return a push time >90s ago
-          return { stdout: new Date(Date.now() - 120_000).toISOString(), stderr: "", exitCode: 0 };
-        }
-        return { stdout: "", stderr: "", exitCode: 0 };
-      },
     });
 
     await prWaitForCopilot(["42"], deps);
-    // If we get here without ExitError, it exited 0
   });
 
   test("exits 1 on parse error", async () => {
@@ -462,6 +467,137 @@ describe("prWaitForCopilot", () => {
     const deps = makeDeps({ printError: (m: string) => errors.push(m) });
     await expect(prWaitForCopilot([], deps)).rejects.toBeInstanceOf(ExitError);
     expect(errors[0]).toMatch(/Usage/);
+  });
+
+  test("exits 1 when event stream dies and Copilot not ready", async () => {
+    const errors: string[] = [];
+    const deps = makeDeps({
+      ipcCall: (() => Promise.resolve(emptySnapshot)) as PrDeps["ipcCall"],
+      printError: (m: string) => errors.push(m),
+      openStream: () => ({
+        events: (async function* () {
+          // Stream ends immediately (simulates daemon restart)
+        })(),
+        abort: () => {},
+      }),
+    });
+
+    const err = await prWaitForCopilot(["42", "--max-wait", "60"], deps).catch((e) => e);
+    expect(err).toBeInstanceOf(ExitError);
+    expect((err as ExitError).code).toBe(1);
+    expect(errors.some((e: string) => e.includes("Timed out"))).toBe(true);
+  });
+
+  test("exits 0 when event stream dies but final check finds Copilot ready", async () => {
+    const copilotSnapshot: PrThreadSnapshot = {
+      ...emptySnapshot,
+      pushedAt: new Date(Date.now() - 120_000).toISOString(),
+      reviews: [{ id: 1, user: "Copilot", state: "COMMENTED", body: "LGTM" }],
+    };
+
+    let callCount = 0;
+    const deps = makeDeps({
+      ipcCall: (() => {
+        callCount++;
+        if (callCount === 1) return Promise.resolve(emptySnapshot);
+        return Promise.resolve(copilotSnapshot);
+      }) as PrDeps["ipcCall"],
+      openStream: () => ({
+        events: (async function* () {
+          // Stream dies immediately
+        })(),
+        abort: () => {},
+      }),
+    });
+
+    await prWaitForCopilot(["42"], deps);
+    expect(callCount).toBe(2);
+  });
+
+  test("exits 1 on timeout when Copilot never posts", async () => {
+    const errors: string[] = [];
+    const deps = makeDeps({
+      ipcCall: (() => Promise.resolve(emptySnapshot)) as PrDeps["ipcCall"],
+      printError: (m: string) => errors.push(m),
+      openStream: () => ({
+        events: (async function* () {
+          // Yield one event to exercise the loop
+          yield { type: "pr.review_comment_posted", ts: Date.now() } as never;
+        })(),
+        abort: () => {},
+      }),
+    });
+
+    const err = await prWaitForCopilot(["42", "--max-wait", "0"], deps).catch((e) => e);
+    expect(err).toBeInstanceOf(ExitError);
+    expect((err as ExitError).code).toBe(1);
+    expect(errors.some((e: string) => e.includes("Timed out"))).toBe(true);
+  });
+
+  test("returns false when Copilot posted but pushedAt is null", async () => {
+    const snapshot: PrThreadSnapshot = {
+      ...emptySnapshot,
+      pushedAt: null,
+      threads: [
+        {
+          threadId: "T1",
+          rootCommentId: 100,
+          user: "Copilot",
+          location: "src/main.ts:10",
+          body: "Suggestion",
+          resolved: false,
+          outdated: false,
+          replies: [],
+        },
+      ],
+    };
+
+    const errors: string[] = [];
+    const deps = makeDeps({
+      ipcCall: (() => Promise.resolve(snapshot)) as PrDeps["ipcCall"],
+      printError: (m: string) => errors.push(m),
+      openStream: () => ({
+        events: (async function* () {})(),
+        abort: () => {},
+      }),
+    });
+
+    const err = await prWaitForCopilot(["42", "--max-wait", "0"], deps).catch((e) => e);
+    expect(err).toBeInstanceOf(ExitError);
+    expect((err as ExitError).code).toBe(1);
+  });
+
+  test("returns false when Copilot posted but push is too recent", async () => {
+    const snapshot: PrThreadSnapshot = {
+      ...emptySnapshot,
+      pushedAt: new Date(Date.now() - 10_000).toISOString(),
+      threads: [
+        {
+          threadId: "T1",
+          rootCommentId: 100,
+          user: "Copilot",
+          location: "src/main.ts:10",
+          body: "Suggestion",
+          resolved: false,
+          outdated: false,
+          replies: [],
+        },
+      ],
+    };
+
+    const errors: string[] = [];
+    const deps = makeDeps({
+      ipcCall: (() => Promise.resolve(snapshot)) as PrDeps["ipcCall"],
+      printError: (m: string) => errors.push(m),
+      openStream: () => ({
+        events: (async function* () {})(),
+        abort: () => {},
+      }),
+    });
+
+    const err = await prWaitForCopilot(["42", "--max-wait", "0"], deps).catch((e) => e);
+    expect(err).toBeInstanceOf(ExitError);
+    expect((err as ExitError).code).toBe(1);
   });
 });
 

--- a/packages/command/src/commands/pr.spec.ts
+++ b/packages/command/src/commands/pr.spec.ts
@@ -1,6 +1,16 @@
 import { describe, expect, test } from "bun:test";
+import type { PrThreadSnapshot } from "@mcp-cli/core";
 import type { PrDeps } from "./pr";
-import { cmdPr, parsePrMergeArgs, prMerge } from "./pr";
+import {
+  cmdPr,
+  formatSnapshotXml,
+  parsePrCommentsArgs,
+  parsePrMergeArgs,
+  parsePrWaitArgs,
+  prComments,
+  prMerge,
+  prWaitForCopilot,
+} from "./pr";
 
 class ExitError extends Error {
   code: number;
@@ -10,6 +20,13 @@ class ExitError extends Error {
   }
 }
 
+const emptySnapshot: PrThreadSnapshot = {
+  threads: [],
+  reviews: [],
+  topLevelComments: [],
+  fetchedAt: "2026-05-23T00:00:00.000Z",
+};
+
 function makeDeps(overrides: Partial<PrDeps> = {}): PrDeps {
   return {
     exec: () => ({ stdout: "", stderr: "", exitCode: 0 }),
@@ -18,6 +35,8 @@ function makeDeps(overrides: Partial<PrDeps> = {}): PrDeps {
       throw new ExitError(code);
     },
     sleep: () => Promise.resolve(),
+    ipcCall: (() => Promise.resolve(emptySnapshot)) as PrDeps["ipcCall"],
+    repoRoot: () => "/tmp/test-repo",
     ...overrides,
   };
 }
@@ -79,13 +98,88 @@ describe("parsePrMergeArgs", () => {
   });
 });
 
+// ── parsePrCommentsArgs ──
+
+describe("parsePrCommentsArgs", () => {
+  test("parses PR number", () => {
+    const r = parsePrCommentsArgs(["42"]);
+    expect(r.prNumber).toBe(42);
+    expect(r.json).toBe(false);
+    expect(r.includeResolved).toBe(false);
+    expect(r.error).toBeUndefined();
+  });
+
+  test("parses --json", () => {
+    const r = parsePrCommentsArgs(["1", "--json"]);
+    expect(r.json).toBe(true);
+  });
+
+  test("parses --include-resolved", () => {
+    const r = parsePrCommentsArgs(["1", "--include-resolved"]);
+    expect(r.includeResolved).toBe(true);
+  });
+
+  test("parses all flags together", () => {
+    const r = parsePrCommentsArgs(["99", "--json", "--include-resolved"]);
+    expect(r.prNumber).toBe(99);
+    expect(r.json).toBe(true);
+    expect(r.includeResolved).toBe(true);
+  });
+
+  test("errors when no PR number", () => {
+    const r = parsePrCommentsArgs([]);
+    expect(r.error).toMatch(/Usage/);
+  });
+
+  test("errors on unknown flag", () => {
+    const r = parsePrCommentsArgs(["1", "--unknown"]);
+    expect(r.error).toMatch(/Unknown flag/);
+  });
+
+  test("errors on invalid PR number", () => {
+    const r = parsePrCommentsArgs(["abc"]);
+    expect(r.error).toMatch(/Invalid PR number/);
+  });
+});
+
+// ── parsePrWaitArgs ──
+
+describe("parsePrWaitArgs", () => {
+  test("parses PR number with defaults", () => {
+    const r = parsePrWaitArgs(["42"]);
+    expect(r.prNumber).toBe(42);
+    expect(r.maxWaitMs).toBe(600_000);
+    expect(r.error).toBeUndefined();
+  });
+
+  test("parses --max-wait", () => {
+    const r = parsePrWaitArgs(["1", "--max-wait", "300"]);
+    expect(r.maxWaitMs).toBe(300_000);
+  });
+
+  test("errors when no PR number", () => {
+    const r = parsePrWaitArgs([]);
+    expect(r.error).toMatch(/Usage/);
+  });
+
+  test("errors on invalid --max-wait", () => {
+    const r = parsePrWaitArgs(["1", "--max-wait", "abc"]);
+    expect(r.error).toMatch(/number/);
+  });
+
+  test("errors on missing --max-wait value", () => {
+    const r = parsePrWaitArgs(["1", "--max-wait"]);
+    expect(r.error).toMatch(/requires a value/);
+  });
+});
+
 // ── prMerge ──
 
 describe("prMerge", () => {
   test("calls gh pr merge with --squash, no --delete-branch", async () => {
     const calls: string[][] = [];
     const deps = makeDeps({
-      exec: (cmd) => {
+      exec: (cmd: string[]) => {
         calls.push(cmd);
         return { stdout: "✓ Merged", stderr: "", exitCode: 0 };
       },
@@ -103,7 +197,7 @@ describe("prMerge", () => {
   test("passes --auto when requested", async () => {
     const calls: string[][] = [];
     const deps = makeDeps({
-      exec: (cmd) => {
+      exec: (cmd: string[]) => {
         calls.push(cmd);
         return { stdout: "", stderr: "", exitCode: 0 };
       },
@@ -115,7 +209,7 @@ describe("prMerge", () => {
   test("never passes --delete-branch even with --auto", async () => {
     const calls: string[][] = [];
     const deps = makeDeps({
-      exec: (cmd) => {
+      exec: (cmd: string[]) => {
         calls.push(cmd);
         return { stdout: "", stderr: "", exitCode: 0 };
       },
@@ -128,7 +222,7 @@ describe("prMerge", () => {
     const errors: string[] = [];
     const deps = makeDeps({
       exec: () => ({ stdout: "", stderr: "PR already merged", exitCode: 1 }),
-      printError: (m) => errors.push(m),
+      printError: (m: string) => errors.push(m),
     });
     await expect(prMerge(["1"], deps)).rejects.toBeInstanceOf(ExitError);
     expect(errors[0]).toContain("PR already merged");
@@ -136,7 +230,7 @@ describe("prMerge", () => {
 
   test("exits with usage error when no PR number given", async () => {
     const errors: string[] = [];
-    const deps = makeDeps({ printError: (m) => errors.push(m) });
+    const deps = makeDeps({ printError: (m: string) => errors.push(m) });
     await expect(prMerge([], deps)).rejects.toBeInstanceOf(ExitError);
     expect(errors[0]).toMatch(/Usage/);
   });
@@ -144,7 +238,7 @@ describe("prMerge", () => {
   test("--wait polls until MERGED", async () => {
     let calls = 0;
     const deps = makeDeps({
-      exec: (cmd) => {
+      exec: (cmd: string[]) => {
         calls++;
         if (cmd.includes("view")) {
           // Return MERGED on second poll
@@ -161,61 +255,299 @@ describe("prMerge", () => {
   test("--wait times out with exit 124", async () => {
     const errors: string[] = [];
     const deps = makeDeps({
-      exec: (cmd) => {
+      exec: (cmd: string[]) => {
         if (cmd.includes("view")) return { stdout: "OPEN", stderr: "", exitCode: 0 };
         return { stdout: "", stderr: "", exitCode: 0 };
       },
-      printError: (m) => errors.push(m),
+      printError: (m: string) => errors.push(m),
     });
     const err = await prMerge(["9", "--wait", "--timeout", "100"], deps).catch((e) => e);
     expect(err).toBeInstanceOf(ExitError);
     expect((err as ExitError).code).toBe(124);
-    expect(errors.some((e) => e.includes("timed out"))).toBe(true);
+    expect(errors.some((e: string) => e.includes("timed out"))).toBe(true);
   });
 
   test("--wait exits immediately on gh pr view failure", async () => {
     const errors: string[] = [];
     const deps = makeDeps({
-      exec: (cmd) => {
+      exec: (cmd: string[]) => {
         if (cmd.includes("view")) return { stdout: "", stderr: "auth failure", exitCode: 1 };
         return { stdout: "", stderr: "", exitCode: 0 };
       },
-      printError: (m) => errors.push(m),
+      printError: (m: string) => errors.push(m),
     });
     const err = await prMerge(["1", "--wait"], deps).catch((e) => e);
     expect(err).toBeInstanceOf(ExitError);
     expect((err as ExitError).code).toBe(1);
-    expect(errors.some((e) => e.includes("auth failure"))).toBe(true);
+    expect(errors.some((e: string) => e.includes("auth failure"))).toBe(true);
   });
 
   test("--wait exits immediately on gh pr view failure (no stderr)", async () => {
     const errors: string[] = [];
     const deps = makeDeps({
-      exec: (cmd) => {
+      exec: (cmd: string[]) => {
         if (cmd.includes("view")) return { stdout: "", stderr: "", exitCode: 2 };
         return { stdout: "", stderr: "", exitCode: 0 };
       },
-      printError: (m) => errors.push(m),
+      printError: (m: string) => errors.push(m),
     });
     const err = await prMerge(["1", "--wait"], deps).catch((e) => e);
     expect(err).toBeInstanceOf(ExitError);
     expect((err as ExitError).code).toBe(2);
-    expect(errors.some((e) => e.includes("exited with code 2"))).toBe(true);
+    expect(errors.some((e: string) => e.includes("exited with code 2"))).toBe(true);
   });
 
   test("--wait exits nonzero when PR is closed", async () => {
     const errors: string[] = [];
     const deps = makeDeps({
-      exec: (cmd) => {
+      exec: (cmd: string[]) => {
         if (cmd.includes("view")) return { stdout: "CLOSED", stderr: "", exitCode: 0 };
         return { stdout: "", stderr: "", exitCode: 0 };
       },
-      printError: (m) => errors.push(m),
+      printError: (m: string) => errors.push(m),
     });
     const err = await prMerge(["11", "--wait", "--timeout", "30000"], deps).catch((e) => e);
     expect(err).toBeInstanceOf(ExitError);
     expect((err as ExitError).code).toBe(1);
-    expect(errors.some((e) => e.includes("closed"))).toBe(true);
+    expect(errors.some((e: string) => e.includes("closed"))).toBe(true);
+  });
+});
+
+// ── prComments ──
+
+describe("prComments", () => {
+  test("calls IPC with correct params", async () => {
+    const ipcCalls: Array<{ method: string; params: unknown }> = [];
+    const deps = makeDeps({
+      ipcCall: ((method: string, params: unknown) => {
+        ipcCalls.push({ method, params });
+        return Promise.resolve(emptySnapshot);
+      }) as PrDeps["ipcCall"],
+    });
+
+    const origLog = console.log;
+    console.log = (() => {}) as typeof console.log;
+    try {
+      await prComments(["42"], deps);
+    } finally {
+      console.log = origLog;
+    }
+
+    expect(ipcCalls).toHaveLength(1);
+    expect(ipcCalls[0].method).toBe("getPrThreadSnapshot");
+    expect(ipcCalls[0].params).toEqual({
+      prNumber: 42,
+      repoRoot: "/tmp/test-repo",
+      includeResolved: false,
+    });
+  });
+
+  test("passes --include-resolved to IPC", async () => {
+    const ipcCalls: Array<{ method: string; params: unknown }> = [];
+    const deps = makeDeps({
+      ipcCall: ((method: string, params: unknown) => {
+        ipcCalls.push({ method, params });
+        return Promise.resolve(emptySnapshot);
+      }) as PrDeps["ipcCall"],
+    });
+
+    const origLog = console.log;
+    console.log = (() => {}) as typeof console.log;
+    try {
+      await prComments(["42", "--include-resolved"], deps);
+    } finally {
+      console.log = origLog;
+    }
+
+    expect((ipcCalls[0].params as Record<string, unknown>).includeResolved).toBe(true);
+  });
+
+  test("outputs JSON when --json flag is set", async () => {
+    const snapshot: PrThreadSnapshot = {
+      ...emptySnapshot,
+      threads: [
+        {
+          threadId: "T1",
+          rootCommentId: 100,
+          user: "Copilot",
+          location: "src/main.ts:10",
+          body: "Suggestion",
+          resolved: false,
+          outdated: false,
+          replies: [],
+        },
+      ],
+    };
+
+    const deps = makeDeps({
+      ipcCall: (() => Promise.resolve(snapshot)) as PrDeps["ipcCall"],
+    });
+
+    const output: string[] = [];
+    const origLog = console.log;
+    console.log = ((m: string) => output.push(m)) as typeof console.log;
+    try {
+      await prComments(["1", "--json"], deps);
+    } finally {
+      console.log = origLog;
+    }
+
+    const parsed = JSON.parse(output.join(""));
+    expect(parsed.threads).toHaveLength(1);
+    expect(parsed.threads[0].user).toBe("Copilot");
+  });
+
+  test("outputs XML by default", async () => {
+    const deps = makeDeps({
+      ipcCall: (() => Promise.resolve(emptySnapshot)) as PrDeps["ipcCall"],
+    });
+
+    const output: string[] = [];
+    const origLog = console.log;
+    console.log = ((m: string) => output.push(m)) as typeof console.log;
+    try {
+      await prComments(["1"], deps);
+    } finally {
+      console.log = origLog;
+    }
+
+    expect(output.join("")).toContain("<pr-threads");
+  });
+
+  test("exits on error", async () => {
+    const errors: string[] = [];
+    const deps = makeDeps({ printError: (m: string) => errors.push(m) });
+    await expect(prComments([], deps)).rejects.toBeInstanceOf(ExitError);
+    expect(errors[0]).toMatch(/Usage/);
+  });
+});
+
+// ── prWaitForCopilot ──
+
+describe("prWaitForCopilot", () => {
+  test("exits 0 immediately when Copilot has posted and push is old", async () => {
+    const copilotSnapshot: PrThreadSnapshot = {
+      ...emptySnapshot,
+      threads: [
+        {
+          threadId: "T1",
+          rootCommentId: 100,
+          user: "Copilot",
+          location: "src/main.ts:10",
+          body: "Suggestion",
+          resolved: false,
+          outdated: false,
+          replies: [],
+        },
+      ],
+    };
+
+    const deps = makeDeps({
+      ipcCall: (() => Promise.resolve(copilotSnapshot)) as PrDeps["ipcCall"],
+      exec: (cmd: string[]) => {
+        if (cmd.some((c: string) => c.includes("pulls/"))) {
+          // Return a push time >90s ago
+          return { stdout: new Date(Date.now() - 120_000).toISOString(), stderr: "", exitCode: 0 };
+        }
+        return { stdout: "", stderr: "", exitCode: 0 };
+      },
+    });
+
+    await prWaitForCopilot(["42"], deps);
+    // If we get here without ExitError, it exited 0
+  });
+
+  test("exits 1 on parse error", async () => {
+    const errors: string[] = [];
+    const deps = makeDeps({ printError: (m: string) => errors.push(m) });
+    await expect(prWaitForCopilot([], deps)).rejects.toBeInstanceOf(ExitError);
+    expect(errors[0]).toMatch(/Usage/);
+  });
+});
+
+// ── formatSnapshotXml ──
+
+describe("formatSnapshotXml", () => {
+  test("renders empty snapshot", () => {
+    const xml = formatSnapshotXml(emptySnapshot);
+    expect(xml).toContain("<pr-threads");
+    expect(xml).toContain("</pr-threads>");
+    expect(xml).not.toContain("<thread");
+  });
+
+  test("renders threads with replies", () => {
+    const snapshot: PrThreadSnapshot = {
+      ...emptySnapshot,
+      threads: [
+        {
+          threadId: "T_abc",
+          rootCommentId: 1,
+          user: "Copilot",
+          location: "src/index.ts:42",
+          body: "Consider using const",
+          resolved: false,
+          outdated: false,
+          replies: [{ user: "dev", body: "Fixed", commentId: 2 }],
+        },
+      ],
+    };
+
+    const xml = formatSnapshotXml(snapshot);
+    expect(xml).toContain('id="T_abc"');
+    expect(xml).toContain('location="src/index.ts:42"');
+    expect(xml).toContain('user="Copilot"');
+    expect(xml).toContain("Consider using const");
+    expect(xml).toContain('user="dev"');
+    expect(xml).toContain("Fixed");
+  });
+
+  test("renders reviews section", () => {
+    const snapshot: PrThreadSnapshot = {
+      ...emptySnapshot,
+      reviews: [{ id: 10, user: "reviewer", state: "CHANGES_REQUESTED", body: "Please fix" }],
+    };
+
+    const xml = formatSnapshotXml(snapshot);
+    expect(xml).toContain("<reviews>");
+    expect(xml).toContain('state="CHANGES_REQUESTED"');
+    expect(xml).toContain("Please fix");
+  });
+
+  test("renders top-level comments section", () => {
+    const snapshot: PrThreadSnapshot = {
+      ...emptySnapshot,
+      topLevelComments: [{ id: 20, user: "commenter", body: "Nice work" }],
+    };
+
+    const xml = formatSnapshotXml(snapshot);
+    expect(xml).toContain("<comments>");
+    expect(xml).toContain('user="commenter"');
+    expect(xml).toContain("Nice work");
+  });
+
+  test("escapes XML entities", () => {
+    const snapshot: PrThreadSnapshot = {
+      ...emptySnapshot,
+      threads: [
+        {
+          threadId: "T1",
+          rootCommentId: 1,
+          user: "bot",
+          location: "a.ts:1",
+          body: 'x < 5 && y > 3 & "z"',
+          resolved: false,
+          outdated: false,
+          replies: [],
+        },
+      ],
+    };
+
+    const xml = formatSnapshotXml(snapshot);
+    expect(xml).toContain("&lt;");
+    expect(xml).toContain("&gt;");
+    expect(xml).toContain("&amp;");
+    expect(xml).toContain("&quot;");
+    expect(xml).not.toContain("< 5");
   });
 });
 
@@ -225,7 +557,7 @@ describe("cmdPr", () => {
   test("prints usage with no args", async () => {
     const logs: string[] = [];
     const origLog = console.log;
-    console.log = (m: string) => logs.push(m);
+    console.log = ((m: string) => logs.push(m)) as typeof console.log;
     try {
       await cmdPr([]);
       expect(logs.join("")).toContain("mcx pr");
@@ -237,7 +569,7 @@ describe("cmdPr", () => {
   test("routes to prMerge on 'merge' subcommand", async () => {
     const calls: string[][] = [];
     const deps = makeDeps({
-      exec: (cmd) => {
+      exec: (cmd: string[]) => {
         calls.push(cmd);
         return { stdout: "", stderr: "", exitCode: 0 };
       },
@@ -246,10 +578,44 @@ describe("cmdPr", () => {
     expect(calls[0]).toContain("42");
   });
 
+  test("routes to prComments on 'comments' subcommand", async () => {
+    const ipcCalls: Array<{ method: string }> = [];
+    const deps = makeDeps({
+      ipcCall: ((method: string, params: unknown) => {
+        ipcCalls.push({ method });
+        return Promise.resolve(emptySnapshot);
+      }) as PrDeps["ipcCall"],
+    });
+
+    const origLog = console.log;
+    console.log = (() => {}) as typeof console.log;
+    try {
+      await cmdPr(["comments", "10"], deps);
+    } finally {
+      console.log = origLog;
+    }
+
+    expect(ipcCalls[0].method).toBe("getPrThreadSnapshot");
+  });
+
   test("exits on unknown subcommand", async () => {
     const errors: string[] = [];
-    const deps = makeDeps({ printError: (m) => errors.push(m) });
+    const deps = makeDeps({ printError: (m: string) => errors.push(m) });
     await expect(cmdPr(["frobnicate"], deps)).rejects.toBeInstanceOf(ExitError);
     expect(errors[0]).toContain("Unknown pr subcommand");
+  });
+
+  test("usage includes new subcommands", async () => {
+    const logs: string[] = [];
+    const origLog = console.log;
+    console.log = ((m: string) => logs.push(m)) as typeof console.log;
+    try {
+      await cmdPr(["--help"]);
+      const output = logs.join("");
+      expect(output).toContain("comments");
+      expect(output).toContain("wait-for-copilot");
+    } finally {
+      console.log = origLog;
+    }
   });
 });

--- a/packages/command/src/commands/pr.ts
+++ b/packages/command/src/commands/pr.ts
@@ -6,8 +6,8 @@
  * (#1800). Local cleanup is left to `mcx claude bye` → cleanupWorktree.
  */
 
-import type { IpcMethod, IpcMethodResult, PrThreadSnapshot } from "@mcp-cli/core";
-import { DEFAULT_TIMEOUT_MS, findGitRoot, openEventStream } from "@mcp-cli/core";
+import type { IpcMethod, IpcMethodResult, MonitorEvent, PrThreadSnapshot } from "@mcp-cli/core";
+import { COPILOT_USERS, DEFAULT_TIMEOUT_MS, findGitRoot, openEventStream } from "@mcp-cli/core";
 import { ipcCall as defaultIpcCall } from "../daemon-lifecycle";
 import { printError as defaultPrintError } from "../output";
 
@@ -20,6 +20,7 @@ export interface PrDeps {
   sleep: (ms: number) => Promise<void>;
   ipcCall: <M extends IpcMethod>(method: M, params?: unknown) => Promise<IpcMethodResult[M]>;
   repoRoot: () => string;
+  openStream: (params: Record<string, unknown>) => { events: AsyncIterable<MonitorEvent>; abort: () => void };
 }
 
 export const defaultPrDeps: PrDeps = {
@@ -36,11 +37,8 @@ export const defaultPrDeps: PrDeps = {
   sleep: (ms) => Bun.sleep(ms),
   ipcCall: defaultIpcCall,
   repoRoot: () => findGitRoot(process.cwd()) ?? process.cwd(),
+  openStream: openEventStream,
 };
-
-// ── Copilot user detection ──
-
-const COPILOT_USERS = new Set(["Copilot", "copilot-pull-request-reviewer[bot]"]);
 
 // ── Arg parsing ──
 
@@ -285,9 +283,9 @@ export async function prWaitForCopilot(args: string[], deps: Partial<PrDeps> = {
   const ready = await checkCopilotReady(prNumber, repoRoot, d);
   if (ready) return;
 
-  const { events, abort } = openEventStream({
+  const { events, abort } = d.openStream({
     pr: prNumber,
-    type: "pr.review_comment_posted",
+    type: "pr.review_comment_posted,review.approved,review.changes_requested,review.commented",
     repo: repoRoot,
   });
 
@@ -301,10 +299,15 @@ export async function prWaitForCopilot(args: string[], deps: Partial<PrDeps> = {
     abort();
   }
 
-  if (Date.now() >= deadline) {
-    d.printError(`Timed out waiting for Copilot on PR #${prNumber} (${parsed.maxWaitMs / 1000}s).`);
-    d.exit(1);
+  // Stream ended without returning (daemon restart, connection drop).
+  // Do a final check before giving up.
+  if (Date.now() < deadline) {
+    const lastCheck = await checkCopilotReady(prNumber, repoRoot, d);
+    if (lastCheck) return;
   }
+
+  d.printError(`Timed out waiting for Copilot on PR #${prNumber} (${parsed.maxWaitMs / 1000}s).`);
+  d.exit(1);
 }
 
 async function checkCopilotReady(prNumber: number, repoRoot: string, d: PrDeps): Promise<boolean> {
@@ -319,21 +322,10 @@ async function checkCopilotReady(prNumber: number, repoRoot: string, d: PrDeps):
 
   if (!hasCopilot) return false;
 
-  // Push-age check: fetchedAt - pushedAt must be ≥ 90s.
-  // The pushedAt is not in the snapshot (would need separate API call).
-  // Use the head commit date from gh api as a proxy.
-  const { stdout, exitCode } = d.exec([
-    "gh",
-    "api",
-    `repos/{owner}/{repo}/pulls/${prNumber}`,
-    "--jq",
-    ".pushed_at // .updated_at",
-  ]);
+  if (!snapshot.pushedAt) return false;
 
-  if (exitCode !== 0 || !stdout) return hasCopilot;
-
-  const pushedAt = new Date(stdout).getTime();
-  if (Number.isNaN(pushedAt)) return hasCopilot;
+  const pushedAt = new Date(snapshot.pushedAt).getTime();
+  if (Number.isNaN(pushedAt)) return false;
 
   return Date.now() - pushedAt >= 90_000;
 }

--- a/packages/command/src/commands/pr.ts
+++ b/packages/command/src/commands/pr.ts
@@ -6,7 +6,9 @@
  * (#1800). Local cleanup is left to `mcx claude bye` → cleanupWorktree.
  */
 
-import { DEFAULT_TIMEOUT_MS } from "@mcp-cli/core";
+import type { IpcMethod, IpcMethodResult, PrThreadSnapshot } from "@mcp-cli/core";
+import { DEFAULT_TIMEOUT_MS, findGitRoot, openEventStream } from "@mcp-cli/core";
+import { ipcCall as defaultIpcCall } from "../daemon-lifecycle";
 import { printError as defaultPrintError } from "../output";
 
 // ── Deps ──
@@ -16,6 +18,8 @@ export interface PrDeps {
   printError: (msg: string) => void;
   exit: (code: number) => never;
   sleep: (ms: number) => Promise<void>;
+  ipcCall: <M extends IpcMethod>(method: M, params?: unknown) => Promise<IpcMethodResult[M]>;
+  repoRoot: () => string;
 }
 
 export const defaultPrDeps: PrDeps = {
@@ -30,7 +34,13 @@ export const defaultPrDeps: PrDeps = {
   printError: defaultPrintError,
   exit: (code) => process.exit(code),
   sleep: (ms) => Bun.sleep(ms),
+  ipcCall: defaultIpcCall,
+  repoRoot: () => findGitRoot(process.cwd()) ?? process.cwd(),
 };
+
+// ── Copilot user detection ──
+
+const COPILOT_USERS = new Set(["Copilot", "copilot-pull-request-reviewer[bot]"]);
 
 // ── Arg parsing ──
 
@@ -88,6 +98,79 @@ export function parsePrMergeArgs(args: string[]): PrMergeArgs {
   if (!squash && !rebase && !mergeCommit) squash = true;
 
   return { prNumber, squash, rebase, mergeCommit, auto, wait, timeout, error };
+}
+
+export interface PrCommentsArgs {
+  prNumber: number | undefined;
+  json: boolean;
+  includeResolved: boolean;
+  error: string | undefined;
+}
+
+export function parsePrCommentsArgs(args: string[]): PrCommentsArgs {
+  let prNumber: number | undefined;
+  let json = false;
+  let includeResolved = false;
+  let error: string | undefined;
+
+  for (const arg of args) {
+    if (arg === "--json") {
+      json = true;
+    } else if (arg === "--include-resolved") {
+      includeResolved = true;
+    } else if (!arg.startsWith("-")) {
+      prNumber = Number(arg);
+      if (Number.isNaN(prNumber)) error = `Invalid PR number: ${arg}`;
+    } else {
+      error = `Unknown flag: ${arg}`;
+    }
+  }
+
+  if (prNumber === undefined && !error) {
+    error = "Usage: mcx pr comments <pr-number> [--json] [--include-resolved]";
+  }
+
+  return { prNumber, json, includeResolved, error };
+}
+
+export interface PrWaitArgs {
+  prNumber: number | undefined;
+  maxWaitMs: number;
+  error: string | undefined;
+}
+
+export function parsePrWaitArgs(args: string[]): PrWaitArgs {
+  let prNumber: number | undefined;
+  let maxWaitMs = 600_000;
+  let error: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--max-wait") {
+      const val = args[++i];
+      if (!val) {
+        error = "--max-wait requires a value in seconds";
+      } else {
+        const secs = Number(val);
+        if (Number.isNaN(secs)) {
+          error = "--max-wait must be a number";
+        } else {
+          maxWaitMs = secs * 1000;
+        }
+      }
+    } else if (!arg.startsWith("-")) {
+      prNumber = Number(arg);
+      if (Number.isNaN(prNumber)) error = `Invalid PR number: ${arg}`;
+    } else {
+      error = `Unknown flag: ${arg}`;
+    }
+  }
+
+  if (prNumber === undefined && !error) {
+    error = "Usage: mcx pr wait-for-copilot <pr-number> [--max-wait <seconds>]";
+  }
+
+  return { prNumber, maxWaitMs, error };
 }
 
 // ── Subcommands ──
@@ -164,6 +247,148 @@ export async function prMerge(args: string[], deps: Partial<PrDeps> = {}): Promi
   d.exit(124);
 }
 
+export async function prComments(args: string[], deps: Partial<PrDeps> = {}): Promise<void> {
+  const d: PrDeps = { ...defaultPrDeps, ...deps };
+  const parsed = parsePrCommentsArgs(args);
+
+  if (parsed.error || parsed.prNumber === undefined) {
+    d.printError(parsed.error ?? "Usage: mcx pr comments <pr-number> [--json] [--include-resolved]");
+    d.exit(1);
+  }
+
+  const snapshot = await d.ipcCall("getPrThreadSnapshot", {
+    prNumber: parsed.prNumber,
+    repoRoot: d.repoRoot(),
+    includeResolved: parsed.includeResolved,
+  });
+
+  if (parsed.json) {
+    console.log(JSON.stringify(snapshot, null, 2));
+  } else {
+    console.log(formatSnapshotXml(snapshot));
+  }
+}
+
+export async function prWaitForCopilot(args: string[], deps: Partial<PrDeps> = {}): Promise<void> {
+  const d: PrDeps = { ...defaultPrDeps, ...deps };
+  const parsed = parsePrWaitArgs(args);
+
+  if (parsed.error || parsed.prNumber === undefined) {
+    d.printError(parsed.error ?? "Usage: mcx pr wait-for-copilot <pr-number> [--max-wait <seconds>]");
+    d.exit(1);
+  }
+
+  const prNumber = parsed.prNumber;
+  const deadline = Date.now() + parsed.maxWaitMs;
+  const repoRoot = d.repoRoot();
+
+  const ready = await checkCopilotReady(prNumber, repoRoot, d);
+  if (ready) return;
+
+  const { events, abort } = openEventStream({
+    pr: prNumber,
+    type: "pr.review_comment_posted",
+    repo: repoRoot,
+  });
+
+  try {
+    for await (const _event of events) {
+      if (Date.now() >= deadline) break;
+      const nowReady = await checkCopilotReady(prNumber, repoRoot, d);
+      if (nowReady) return;
+    }
+  } finally {
+    abort();
+  }
+
+  if (Date.now() >= deadline) {
+    d.printError(`Timed out waiting for Copilot on PR #${prNumber} (${parsed.maxWaitMs / 1000}s).`);
+    d.exit(1);
+  }
+}
+
+async function checkCopilotReady(prNumber: number, repoRoot: string, d: PrDeps): Promise<boolean> {
+  const snapshot = await d.ipcCall("getPrThreadSnapshot", {
+    prNumber,
+    repoRoot,
+    includeResolved: true,
+  });
+
+  const hasCopilot =
+    snapshot.threads.some((t) => COPILOT_USERS.has(t.user)) || snapshot.reviews.some((r) => COPILOT_USERS.has(r.user));
+
+  if (!hasCopilot) return false;
+
+  // Push-age check: fetchedAt - pushedAt must be ≥ 90s.
+  // The pushedAt is not in the snapshot (would need separate API call).
+  // Use the head commit date from gh api as a proxy.
+  const { stdout, exitCode } = d.exec([
+    "gh",
+    "api",
+    `repos/{owner}/{repo}/pulls/${prNumber}`,
+    "--jq",
+    ".pushed_at // .updated_at",
+  ]);
+
+  if (exitCode !== 0 || !stdout) return hasCopilot;
+
+  const pushedAt = new Date(stdout).getTime();
+  if (Number.isNaN(pushedAt)) return hasCopilot;
+
+  return Date.now() - pushedAt >= 90_000;
+}
+
+// ── XML formatter ──
+
+function escapeXml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+export function formatSnapshotXml(snapshot: PrThreadSnapshot): string {
+  const lines: string[] = [];
+  lines.push(`<pr-threads fetchedAt="${escapeXml(snapshot.fetchedAt)}">`);
+
+  for (const thread of snapshot.threads) {
+    lines.push(
+      `  <thread id="${escapeXml(thread.threadId)}" location="${escapeXml(thread.location)}" resolved="${thread.resolved}" outdated="${thread.outdated}">`,
+    );
+    lines.push(`    <comment user="${escapeXml(thread.user)}">`);
+    lines.push(`      ${escapeXml(thread.body)}`);
+    lines.push("    </comment>");
+    for (const reply of thread.replies) {
+      lines.push(`    <reply user="${escapeXml(reply.user)}">`);
+      lines.push(`      ${escapeXml(reply.body)}`);
+      lines.push("    </reply>");
+    }
+    lines.push("  </thread>");
+  }
+
+  if (snapshot.reviews.length > 0) {
+    lines.push("  <reviews>");
+    for (const review of snapshot.reviews) {
+      lines.push(`    <review id="${review.id}" user="${escapeXml(review.user)}" state="${escapeXml(review.state)}">`);
+      if (review.body) {
+        lines.push(`      ${escapeXml(review.body)}`);
+      }
+      lines.push("    </review>");
+    }
+    lines.push("  </reviews>");
+  }
+
+  if (snapshot.topLevelComments.length > 0) {
+    lines.push("  <comments>");
+    for (const comment of snapshot.topLevelComments) {
+      lines.push(`    <comment id="${comment.id}" user="${escapeXml(comment.user)}">`);
+      lines.push(`      ${escapeXml(comment.body)}`);
+      lines.push("    </comment>");
+    }
+    lines.push("  </comments>");
+  }
+
+  lines.push("</pr-threads>");
+  return lines.join("\n");
+}
+
 // ── Entry point ──
 
 export async function cmdPr(args: string[], deps: Partial<PrDeps> = {}): Promise<void> {
@@ -180,9 +405,15 @@ export async function cmdPr(args: string[], deps: Partial<PrDeps> = {}): Promise
     case "merge":
       await prMerge(subArgs, deps);
       break;
+    case "comments":
+      await prComments(subArgs, deps);
+      break;
+    case "wait-for-copilot":
+      await prWaitForCopilot(subArgs, deps);
+      break;
     default: {
       const d: Pick<PrDeps, "printError" | "exit"> = { ...defaultPrDeps, ...deps };
-      d.printError(`Unknown pr subcommand: ${sub}. Use "merge".`);
+      d.printError(`Unknown pr subcommand: ${sub}. Run "mcx pr --help" for usage.`);
       d.exit(1);
     }
   }
@@ -192,19 +423,24 @@ function printPrUsage(): void {
   console.log(`mcx pr — worktree-aware GitHub PR helpers
 
 Usage:
-  mcx pr merge <pr>                    Merge PR without local-branch cleanup errors
-  mcx pr merge <pr> --auto             Enable auto-merge (merges when CI passes)
-  mcx pr merge <pr> --auto --wait      Enable auto-merge + block until merged
+  mcx pr merge <pr>                       Merge PR without local-branch cleanup errors
+  mcx pr merge <pr> --auto                Enable auto-merge (merges when CI passes)
+  mcx pr merge <pr> --auto --wait         Enable auto-merge + block until merged
+  mcx pr comments <pr>                    Show PR threads (XML for LLM consumption)
+  mcx pr comments <pr> --json             Show PR threads as JSON
+  mcx pr comments <pr> --include-resolved Include resolved threads
+  mcx pr wait-for-copilot <pr>            Block until Copilot review is ready
+  mcx pr wait-for-copilot <pr> --max-wait 300  Custom timeout in seconds (default: 600)
 
 Merge strategy (default: --squash):
-  --squash                             Squash and merge
-  --rebase                             Rebase and merge
-  --merge                              Create a merge commit
+  --squash                                Squash and merge
+  --rebase                                Rebase and merge
+  --merge                                 Create a merge commit
 
 Options:
-  --auto                               Enable auto-merge (requires branch protection)
-  --wait                               Block until the PR reaches MERGED state
-  --timeout, -t <ms>                   Max wait time (default: ${DEFAULT_TIMEOUT_MS})
+  --auto                                  Enable auto-merge (requires branch protection)
+  --wait                                  Block until the PR reaches MERGED state
+  --timeout, -t <ms>                      Max wait time (default: ${DEFAULT_TIMEOUT_MS})
 
 Unlike 'gh pr merge --delete-branch', 'mcx pr merge' never attempts local branch
 deletion. Use 'mcx claude bye' to clean up the worktree and local branch once

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -70,7 +70,8 @@ export type IpcMethod =
   | "publishEvent"
   | "listAutomation"
   | "getAutomationLog"
-  | "getAgentSession";
+  | "getAgentSession"
+  | "getPrThreadSnapshot";
 
 // -- Request/Response --
 
@@ -781,6 +782,51 @@ export const SetBudgetConfigParamsSchema = z.object({
   quotaDeadband: z.number().nonnegative().optional(),
 });
 
+// -- PR thread snapshot types --
+
+export const GetPrThreadSnapshotParamsSchema = z.object({
+  prNumber: z.number().int().positive(),
+  repoRoot: z.string().refine((s) => isAbsolute(s), "repoRoot must be absolute"),
+  includeResolved: z.boolean().optional(),
+});
+
+export interface PrThread {
+  threadId: string;
+  rootCommentId: number;
+  user: string;
+  location: string;
+  body: string;
+  resolved: boolean;
+  outdated: boolean;
+  replies: PrThreadReply[];
+}
+
+export interface PrThreadReply {
+  user: string;
+  body: string;
+  commentId: number;
+}
+
+export interface PrReviewEntry {
+  id: number;
+  user: string;
+  state: string;
+  body: string;
+}
+
+export interface PrCommentEntry {
+  id: number;
+  user: string;
+  body: string;
+}
+
+export interface PrThreadSnapshot {
+  threads: PrThread[];
+  reviews: PrReviewEntry[];
+  topLevelComments: PrCommentEntry[];
+  fetchedAt: string;
+}
+
 // -- Method → Result type map --
 
 export interface IpcMethodResult {
@@ -838,6 +884,7 @@ export interface IpcMethodResult {
   listAutomation: ListAutomationResult;
   getAutomationLog: GetAutomationLogResult;
   getAgentSession: GetAgentSessionResult;
+  getPrThreadSnapshot: PrThreadSnapshot;
 }
 
 // -- Error codes --

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -782,6 +782,10 @@ export const SetBudgetConfigParamsSchema = z.object({
   quotaDeadband: z.number().nonnegative().optional(),
 });
 
+// -- Copilot user detection --
+
+export const COPILOT_USERS = new Set(["Copilot", "copilot-pull-request-reviewer[bot]"]);
+
 // -- PR thread snapshot types --
 
 export const GetPrThreadSnapshotParamsSchema = z.object({
@@ -825,6 +829,8 @@ export interface PrThreadSnapshot {
   reviews: PrReviewEntry[];
   topLevelComments: PrCommentEntry[];
   fetchedAt: string;
+  pushedAt: string | null;
+  truncated: boolean;
 }
 
 // -- Method → Result type map --

--- a/packages/daemon/src/handlers/pr-thread.spec.ts
+++ b/packages/daemon/src/handlers/pr-thread.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { COPILOT_USERS, isBotNoise } from "./pr-thread";
+
+describe("isBotNoise", () => {
+  test("flags coderabbitai[bot] as noise", () => {
+    expect(isBotNoise({ user: "coderabbitai[bot]", body: "some review" })).toBe(true);
+  });
+
+  test("flags robobun watermark comments as noise", () => {
+    expect(isBotNoise({ user: "robobun", body: "<!-- generated-comment abc123 -->\nSome text" })).toBe(true);
+  });
+
+  test("passes Copilot through", () => {
+    expect(isBotNoise({ user: "Copilot", body: "suggestion here" })).toBe(false);
+  });
+
+  test("passes copilot-pull-request-reviewer[bot] through", () => {
+    expect(isBotNoise({ user: "copilot-pull-request-reviewer[bot]", body: "review" })).toBe(false);
+  });
+
+  test("passes human users through", () => {
+    expect(isBotNoise({ user: "octocat", body: "LGTM" })).toBe(false);
+  });
+
+  test("passes github-actions[bot] through (not in filter)", () => {
+    expect(isBotNoise({ user: "github-actions[bot]", body: "CI passed" })).toBe(false);
+  });
+
+  test("detects watermark mid-body", () => {
+    expect(isBotNoise({ user: "somebot", body: "prefix <!-- generated-comment xyz --> suffix" })).toBe(true);
+  });
+});
+
+describe("COPILOT_USERS", () => {
+  test("includes Copilot", () => {
+    expect(COPILOT_USERS.has("Copilot")).toBe(true);
+  });
+
+  test("includes copilot-pull-request-reviewer[bot]", () => {
+    expect(COPILOT_USERS.has("copilot-pull-request-reviewer[bot]")).toBe(true);
+  });
+
+  test("excludes random users", () => {
+    expect(COPILOT_USERS.has("octocat")).toBe(false);
+  });
+});

--- a/packages/daemon/src/handlers/pr-thread.ts
+++ b/packages/daemon/src/handlers/pr-thread.ts
@@ -1,0 +1,212 @@
+import type { IpcMethod, PrCommentEntry, PrReviewEntry, PrThread, PrThreadSnapshot } from "@mcp-cli/core";
+import { GetPrThreadSnapshotParamsSchema, createGhClient } from "@mcp-cli/core";
+import type { RequestHandler } from "../handler-types";
+
+// ── Bot-noise filter ──
+
+const CODERABBIT_USER = "coderabbitai[bot]";
+const ROBOBUN_WATERMARK = /<!-- generated-comment/;
+
+export const COPILOT_USERS = new Set(["Copilot", "copilot-pull-request-reviewer[bot]"]);
+
+export function isBotNoise(entry: { user: string; body: string }): boolean {
+  if (entry.user === CODERABBIT_USER) return true;
+  if (ROBOBUN_WATERMARK.test(entry.body)) return true;
+  return false;
+}
+
+// ── GraphQL query ──
+
+const REVIEW_THREADS_QUERY = `
+query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          isOutdated
+          comments(first: 50) {
+            nodes {
+              databaseId
+              body
+              author { login }
+              path
+              line
+            }
+          }
+        }
+      }
+      reviews(first: 50) {
+        nodes {
+          databaseId
+          body
+          state
+          author { login }
+        }
+      }
+      comments(first: 100) {
+        nodes {
+          databaseId
+          body
+          author { login }
+        }
+      }
+      headRefOid
+      pushedAt
+    }
+  }
+}
+`;
+
+// ── GraphQL response types ──
+
+interface GqlThreadComment {
+  databaseId: number;
+  body: string;
+  author: { login: string } | null;
+  path: string | null;
+  line: number | null;
+}
+
+interface GqlThread {
+  id: string;
+  isResolved: boolean;
+  isOutdated: boolean;
+  comments: { nodes: GqlThreadComment[] };
+}
+
+interface GqlReview {
+  databaseId: number;
+  body: string;
+  state: string;
+  author: { login: string } | null;
+}
+
+interface GqlComment {
+  databaseId: number;
+  body: string;
+  author: { login: string } | null;
+}
+
+interface GqlResponse {
+  repository: {
+    pullRequest: {
+      reviewThreads: { nodes: GqlThread[] };
+      reviews: { nodes: GqlReview[] };
+      comments: { nodes: GqlComment[] };
+      headRefOid: string;
+      pushedAt: string | null;
+    };
+  };
+}
+
+// ── Mapping ──
+
+function mapThread(gql: GqlThread): PrThread | null {
+  const comments = gql.comments.nodes;
+  if (comments.length === 0) return null;
+
+  const root = comments[0];
+  const user = root.author?.login ?? "unknown";
+  const location = root.path ? `${root.path}:${root.line ?? 0}` : "unknown";
+
+  return {
+    threadId: gql.id,
+    rootCommentId: root.databaseId,
+    user,
+    location,
+    body: root.body,
+    resolved: gql.isResolved,
+    outdated: gql.isOutdated,
+    replies: comments.slice(1).map((c) => ({
+      user: c.author?.login ?? "unknown",
+      body: c.body,
+      commentId: c.databaseId,
+    })),
+  };
+}
+
+function mapReview(gql: GqlReview): PrReviewEntry {
+  return {
+    id: gql.databaseId,
+    user: gql.author?.login ?? "unknown",
+    state: gql.state,
+    body: gql.body,
+  };
+}
+
+function mapComment(gql: GqlComment): PrCommentEntry {
+  return {
+    id: gql.databaseId,
+    user: gql.author?.login ?? "unknown",
+    body: gql.body,
+  };
+}
+
+// ── Handler ──
+
+export class PrThreadHandlers {
+  private inflight = new Map<string, Promise<PrThreadSnapshot>>();
+
+  register(handlers: Map<IpcMethod, RequestHandler>): void {
+    handlers.set("getPrThreadSnapshot", async (params) => {
+      const { prNumber, repoRoot, includeResolved } = GetPrThreadSnapshotParamsSchema.parse(params);
+      const key = `${repoRoot}:${prNumber}:${includeResolved ?? false}`;
+
+      const existing = this.inflight.get(key);
+      if (existing) return existing;
+
+      const promise = this.fetchSnapshot(prNumber, repoRoot, includeResolved ?? false);
+      this.inflight.set(key, promise);
+      try {
+        return await promise;
+      } finally {
+        this.inflight.delete(key);
+      }
+    });
+  }
+
+  private async fetchSnapshot(prNumber: number, repoRoot: string, includeResolved: boolean): Promise<PrThreadSnapshot> {
+    const client = createGhClient({ repoRoot });
+
+    const data = await client.graphql<GqlResponse>(REVIEW_THREADS_QUERY, {
+      ...(await this.resolveOwnerRepo(repoRoot)),
+      number: prNumber,
+    });
+
+    const pr = data.repository.pullRequest;
+
+    const threads: PrThread[] = [];
+    for (const gqlThread of pr.reviewThreads.nodes) {
+      const thread = mapThread(gqlThread);
+      if (!thread) continue;
+      if (!includeResolved && thread.resolved) continue;
+      if (isBotNoise(thread)) continue;
+      threads.push(thread);
+    }
+
+    const reviews = pr.reviews.nodes.map(mapReview).filter((r) => !isBotNoise(r));
+
+    const topLevelComments = pr.comments.nodes.map(mapComment).filter((c) => !isBotNoise(c));
+
+    return {
+      threads,
+      reviews,
+      topLevelComments,
+      fetchedAt: new Date().toISOString(),
+    };
+  }
+
+  private async resolveOwnerRepo(repoRoot: string): Promise<{ owner: string; repo: string }> {
+    const result = Bun.spawnSync(["git", "remote", "get-url", "origin"], {
+      cwd: repoRoot,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const url = result.stdout.toString().trim();
+    const match = url.match(/[/:]([\w.-]+)\/([\w.-]+?)(?:\.git)?$/);
+    if (!match) throw new Error(`Cannot parse GitHub owner/repo from remote: ${url}`);
+    return { owner: match[1], repo: match[2] };
+  }
+}

--- a/packages/daemon/src/handlers/pr-thread.ts
+++ b/packages/daemon/src/handlers/pr-thread.ts
@@ -1,5 +1,5 @@
 import type { IpcMethod, PrCommentEntry, PrReviewEntry, PrThread, PrThreadSnapshot } from "@mcp-cli/core";
-import { GetPrThreadSnapshotParamsSchema, createGhClient } from "@mcp-cli/core";
+import { GetPrThreadSnapshotParamsSchema, createGhClient, parseGitRemoteUrl } from "@mcp-cli/core";
 import type { RequestHandler } from "../handler-types";
 
 // ── Bot-noise filter ──
@@ -7,7 +7,7 @@ import type { RequestHandler } from "../handler-types";
 const CODERABBIT_USER = "coderabbitai[bot]";
 const ROBOBUN_WATERMARK = /<!-- generated-comment/;
 
-export const COPILOT_USERS = new Set(["Copilot", "copilot-pull-request-reviewer[bot]"]);
+export { COPILOT_USERS } from "@mcp-cli/core";
 
 export function isBotNoise(entry: { user: string; body: string }): boolean {
   if (entry.user === CODERABBIT_USER) return true;
@@ -22,6 +22,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $number) {
       reviewThreads(first: 100) {
+        pageInfo { hasNextPage }
         nodes {
           id
           isResolved
@@ -38,6 +39,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
         }
       }
       reviews(first: 50) {
+        pageInfo { hasNextPage }
         nodes {
           databaseId
           body
@@ -46,6 +48,7 @@ query($owner: String!, $repo: String!, $number: Int!) {
         }
       }
       comments(first: 100) {
+        pageInfo { hasNextPage }
         nodes {
           databaseId
           body
@@ -89,12 +92,16 @@ interface GqlComment {
   author: { login: string } | null;
 }
 
+interface GqlPageInfo {
+  hasNextPage: boolean;
+}
+
 interface GqlResponse {
   repository: {
     pullRequest: {
-      reviewThreads: { nodes: GqlThread[] };
-      reviews: { nodes: GqlReview[] };
-      comments: { nodes: GqlComment[] };
+      reviewThreads: { pageInfo: GqlPageInfo; nodes: GqlThread[] };
+      reviews: { pageInfo: GqlPageInfo; nodes: GqlReview[] };
+      comments: { pageInfo: GqlPageInfo; nodes: GqlComment[] };
       headRefOid: string;
       pushedAt: string | null;
     };
@@ -190,23 +197,30 @@ export class PrThreadHandlers {
 
     const topLevelComments = pr.comments.nodes.map(mapComment).filter((c) => !isBotNoise(c));
 
+    const truncated =
+      pr.reviewThreads.pageInfo.hasNextPage || pr.reviews.pageInfo.hasNextPage || pr.comments.pageInfo.hasNextPage;
+
     return {
       threads,
       reviews,
       topLevelComments,
       fetchedAt: new Date().toISOString(),
+      pushedAt: pr.pushedAt,
+      truncated,
     };
   }
 
   private async resolveOwnerRepo(repoRoot: string): Promise<{ owner: string; repo: string }> {
-    const result = Bun.spawnSync(["git", "remote", "get-url", "origin"], {
+    const proc = Bun.spawn(["git", "remote", "get-url", "origin"], {
       cwd: repoRoot,
       stdout: "pipe",
       stderr: "pipe",
     });
-    const url = result.stdout.toString().trim();
-    const match = url.match(/[/:]([\w.-]+)\/([\w.-]+?)(?:\.git)?$/);
-    if (!match) throw new Error(`Cannot parse GitHub owner/repo from remote: ${url}`);
-    return { owner: match[1], repo: match[2] };
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      throw new Error(`Failed to detect GitHub repo from git remote in ${repoRoot}`);
+    }
+    const url = (await new Response(proc.stdout).text()).trim();
+    return parseGitRemoteUrl(url);
   }
 }

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -49,6 +49,7 @@ import { ConfigHandlers } from "./handlers/config";
 import { EventHandlers } from "./handlers/event";
 import { MailHandlers } from "./handlers/mail";
 import { NoteHandlers } from "./handlers/note";
+import { PrThreadHandlers } from "./handlers/pr-thread";
 import { ServeHandlers } from "./handlers/serve";
 import { StatusHandler } from "./handlers/status";
 import { TelemetryHandlers } from "./handlers/telemetry";
@@ -395,6 +396,7 @@ export class IpcServer {
     new ConfigHandlers(this.pool, this.config, this.onReloadConfig).register(this.handlers);
     new MailHandlers(this.db, deps.eventBus, () => this.draining).register(this.handlers);
     new NoteHandlers(this.db).register(this.handlers);
+    new PrThreadHandlers().register(this.handlers);
     new ToolHandlers(this.pool, this.db, deps.aliasServer, this.daemonId).register(this.handlers);
     new StatusHandler(this.pool, this.db, serveHandlers, this.serveInstances, this.getWsPortInfo).register(
       this.handlers,
@@ -497,7 +499,7 @@ export class IpcServer {
     });
 
     // Catch duplicate registrations (silently-overwritten handlers are invisible bugs).
-    const EXPECTED = 54;
+    const EXPECTED = 55;
     if (this.handlers.size !== EXPECTED) {
       throw new Error(
         `Handler count mismatch after registration: expected ${EXPECTED}, got ${this.handlers.size}. A handler was duplicated or omitted.`,


### PR DESCRIPTION
## Summary

PR #1 of #1912 — read-side `mcx pr` subcommands only (`--reply`/`--resolve` deferred to follow-up).

- **`mcx pr comments <pr>`** — fetches all PR review threads, reviews, and top-level comments via a new `getPrThreadSnapshot` daemon IPC method backed by a single GraphQL query. XML output by default (for LLM consumption), `--json` for machine-readable, `--include-resolved` to show resolved threads. Bot-noise filter drops CodeRabbit + robobun watermark comments.
- **`mcx pr wait-for-copilot <pr>`** — blocks until Copilot has posted ≥1 review artifact AND ≥90s since last push. Checks via the snapshot IPC, falls back to event stream. `--max-wait <seconds>` (default: 600).
- **Daemon handler** deduplicates concurrent `getPrThreadSnapshot` calls for the same PR via in-flight Promise sharing.

## Test plan

- [x] Bot-noise filter unit tests (CodeRabbit, robobun watermark, Copilot passthrough, human passthrough)
- [x] CLI arg parsing tests for `comments` and `wait-for-copilot` subcommands
- [x] `prComments` IPC integration test (correct params, JSON/XML output modes)
- [x] `prWaitForCopilot` immediate-exit test (Copilot posted + push old enough)
- [x] XML formatter tests (threads, replies, reviews, top-level comments, entity escaping)
- [x] Existing `prMerge` + `cmdPr` tests pass unchanged
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun test` — 7481 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)