### PR TITLE
sprint(60): tech debt — flaky/timeout tests, dead code, stale orchestration comments

### DIFF
--- a/.claude/diary/20260523.60.md
+++ b/.claude/diary/20260523.60.md
@@ -1,0 +1,59 @@
+# 2026-05-23 — Tech-debt sprint: flaky tests, dead code, blocking Bun.sleep lint (Sprint 60)
+
+## What was done
+
+11 PRs merged, v1.11.1 released. 12 issues closed + 1 pulled. ~62 min run (06:35→07:37 EDT), up to 10 parallel sessions.
+
+**Flaky / test-reliability:**
+- #2196 (#2221) — reduced `pollUntil` to 4s in server-pool disconnect tests for headroom vs Bun's 5s test timeout.
+- #2083 (#2230) — `validateFreeformTsc` flake. Nerd-snipe gate confirmed root cause: `bunx` CWD-relative resolution overhead + tsc loading 94 lib files per invocation, hitting the function's internal 10s timeout under parallel contention. Fix 1 (real): `Bun.which("tsc")` + direct spawn. Fix 2 (headroom): internal timeout 10s→30s. Adversarial review APPROVED (confirmed Fix 1 is the mechanism fix; Fix 2 is justified headroom, not symptom-masking).
+- #2211 — server-pool disconnect timeout flake. Nerd-snipe established it was the *same* root cause + fix as #2196; closed as duplicate, no impl.
+- #1248 (#2223) — `clone.spec.ts` was committing to the parent worktree HEAD during full runs; added `GIT_CEILING_DIRECTORIES` to test + prod (clone.ts/pull.ts). Copilot questioned whether the ceiling fully blocks parent discovery; impl correctly rebutted (ceiling stops discovery before reaching the ceiling dir).
+- #2100 (#2231) — extracted all 131 `Bun.sleep(numericLiteral)` violations across 35 spec files into named constants and flipped the `lint:timeouts` check from warn to **blocking**. Verified: `lint:timeouts` now reports zero violations.
+
+**Dead code / dedup / cleanup:**
+- #2204 (#2219) — removed dead `sitesOpenInBrowser` state from the browser-handlers factory.
+- #2205 (#2227) — deduped `ToolResult`/`toolOk`/`toolError` in site-worker (import from browser-handlers; −11 lines).
+
+**Bug fixes:**
+- #2217 (#2224) — `reviveSession` now propagates `state.cwd → config.cwd` before `spawnClaude` (one-line regression fix + test).
+- #2193 (#2226) — grammar: "an OpenCode" for vowel-initial labels in agent-tools.
+- #1353 (#2225) — `workItemResolver` hung-mount resilience: `Promise.race` timeout + debug logging; extracted `resolveHeadBranch` with worktree-path handling. QA round 1 returned qa:fail on one unreplied Copilot thread (docstring promised "any FS error" but only `fsStat` was caught) — impl widened the try/catch over the whole body, re-QA passed.
+
+**Tests:**
+- #1662 (#2222) — build-time validation for `seeds.ts` vs `seeds/` directory parity.
+- #1247 (#2220) — strengthened the tracing-server limit-clamping test with real seeded data.
+
+**Pulled:**
+- #2186 — modifies `.claude/phases/impl.ts` (a phase script the orchestrator reads live every tick). Halted the worker before it edited; stays open for next-plan.
+
+## What worked well
+
+- **Parallel-launch + reactive monitor loop**: 10 unblocked issues launched at once, driven entirely off the `mcx monitor` event stream. 4 PRs merged within ~14 min of pipeline start. No blind polling.
+- **Investigation gate paid off twice**: #2083 produced a measured root cause (tsc 94-lib startup, 636ms→300ms with the fix) instead of a blind timeout bump; #2211 was correctly closed as a dup of #2196 with CI evidence — zero wasted impl.
+- **Triage routing was accurate**: all low/medium PRs passed QA cleanly (only #1353 needed a one-thread micro-fix). The investigation-gate override to adversarial review (vs the triage default of qa) caught nothing wrong but is the right discipline for a flaky-fix.
+- **Copilot threads as a real gate**: QA's UNREPLIED_COUNT check correctly failed #1353 on a substantive unaddressed thread; the impl-author micro-repair (`send`, not respawn) resolved it in one round.
+
+## What didn't work
+
+- **#2186 should never have been a worker task** — it's a phase-script-only (meta) change. Caught it at the worker's first idle (before any edit) and pulled it, but it cost a spawn. **Fix:** planning must classify `.claude/phases/**`-only issues as meta (orchestrator/retro-only), never as worker picks. (Note for plan.md.)
+- **Two stale rules in the orchestrator docs** surfaced live:
+  1. `run.md`/MEMORY say sprint-`{N}` worktree commits need `SPRINT_OVERRIDE=1`. **False** — `.git-hooks/sprint-active.sh` explicitly allows worktree commits ("Worktree commits and overrides are allowed"); only the *main checkout* is guarded. The autoclassifier (correctly, per the user's "no SPRINT_OVERRIDE unless the runner requires it") blocked an override attempt; the plain commit then succeeded. Every sprint-meta + the release commit this sprint were plain commits. **Fix applied:** corrected run.md.
+  2. `run.md` documents the work-item id as `issue:<n>`; the actual tracked id is `#<n>`. `--work-item issue:2196` errors with "work item not found". **Fix applied:** corrected run.md.
+- **CI transient**: `setup-bun@v2` intermittently returned 401 "Bad credentials" on the non-required `pty-test` check (#2225, #2230), flipping PRs to UNSTABLE. Cleared on rerun. Same external-GitHub-Actions class as #2208/#2215 — not fixable in-repo.
+
+## Patterns established
+
+- **Investigation-gate impls get adversarial review, not just QA** — triage routes flaky-fix PRs to `qa` by default; the orchestrator overrides to `review` per `investigations.md`. The reviewer's job is to confirm the *mechanism* fix is load-bearing and any timeout bump is justified headroom.
+- **Author-side micro-repair for QA thread-gate failures** — when qa:fail is solely an unreplied/contained Copilot thread, `send` the impl author back (it has the worktree+context), then re-QA fresh — don't spawn an opus repair.
+
+## Stats
+
+- **PRs merged**: 11
+- **Issues closed**: 12 (11 merged + #2211 dup)
+- **Issues pulled/dropped**: 1 (#2186, meta)
+- **Investigation gates**: 2 (#2083 root-caused + fixed; #2211 closed as dup)
+- **Adversarial reviews**: 1 (#2083 — APPROVED, 0 findings requiring change)
+- **QA re-rounds**: 1 (#1353 — one unreplied-thread micro-fix)
+- **Released**: v1.11.1 (patch)
+- **Sprint cost**: ~$28 observed across sessions (heaviest: #2100 impl $9.3, #2083 review $1.1)

--- a/.claude/skills/sprint/references/run.md
+++ b/.claude/skills/sprint/references/run.md
@@ -46,8 +46,11 @@ echo "{N}" > .claude/sprints/.active
 The sentinel is gitignored. It blocks commits on main's checkout so workers
 that escape their worktree fail loudly. `/sprint retro` removes it.
 Orchestrator commits go to the `sprint-{N}` worktree opened in `plan.md`
-Step 6a (still needs `SPRINT_OVERRIDE=1` because the sentinel applies
-repo-wide).
+Step 6a. **Worktree commits do NOT need `SPRINT_OVERRIDE=1`** —
+`.git-hooks/sprint-active.sh` guards only the *main checkout* ("Worktree
+commits and overrides are allowed"). All sprint-meta and release commits
+are plain `git commit` from the worktree. (`SPRINT_OVERRIDE=1` remains the
+escape hatch for the rare case of committing in the main checkout itself.)
 
 ### Sprint-meta edits during run
 
@@ -279,7 +282,10 @@ while issues remain:
                      mcx call _work_items phase_state_set \
                        '{"workItemId":"<item.id>","repoRoot":"<abs>","key":"session_id","value":"<real-id>"}'
                      (replaces "pending:*"; tracked-item ids are
-                      "issue:<n>" or "pr:<n>"; state keys are snake_case:
+                      "#<n>" — the literal issue/PR number with a leading
+                      "#", as created by `mcx track <n>` (NOT "issue:<n>",
+                      which errors "work item not found"); state keys are
+                      snake_case:
                       session_id / qa_session_id / review_session_id /
                       repair_session_id, matching the spawning phase)
         "in-flight": session running — no action this tick

--- a/.claude/sprints/sprint-60.md
+++ b/.claude/sprints/sprint-60.md
@@ -1,6 +1,12 @@
 # Sprint 60
 
-> Planned 2026-05-23 05:35 EDT. Target: 13 PRs. Theme: **tech debt**.
+> Planned 2026-05-23 05:35 EDT. Started 2026-05-23 06:35 EDT. Target: 13 PRs. Theme: **tech debt**.
+>
+> **Run-time amendment:** #2186 pulled mid-run — it exclusively modifies
+> `.claude/phases/impl.ts` (a phase script the orchestrator reads live every
+> tick), an orchestrator/retro-only meta file. Worker was halted before
+> editing; issue stays open for next-plan. Planning bug: a phase-script-only
+> issue should not have been a worker task.
 
 ## Goal
 

--- a/.claude/sprints/sprint-60.md
+++ b/.claude/sprints/sprint-60.md
@@ -63,3 +63,20 @@ Sprint 59 wrapped clean (only open PR is the permanent #1077 bun-segfault repro)
 Deferred this sprint: #2200 (meta — needs user review per Step 1a), #2208 + #2215 (external GitHub Actions transients, not fixable in our repo), #1639 (Bun stream-cancel limitation, code is already correct), and the fast-import/clone arc bugs (#1311/#1323/etc — entangled with the unbuilt #1211 writer, too risky to mix into a debt sprint).
 
 Risk: #2100 is the heaviest pick (131 Bun.sleep violations across ~15 spec files). It's gated behind the flaky fixes and lands last; if it balloons, it's a clean candidate to split file-by-file or carry to sprint 61.
+
+## Results
+
+> Started 2026-05-23 06:35 EDT. Ended 2026-05-23 07:37 EDT (~62 min run).
+
+- **Released**: v1.11.1 (patch — all changes are fixes/refactors/tests/lint; no new commands, no breaking changes)
+- **PRs merged**: 11 (#2219 #2220 #2221 #2222 #2223 #2224 #2225 #2226 #2227 #2230 #2231)
+- **Issues closed**: 12 — #2196 #2204 #1247 #1662 #1248 #2205 #2217 #2193 #1353 #2083 #2100 (merged) + #2211 (closed as duplicate of #2196, confirmed by nerd-snipe)
+- **Issues dropped**: 1 — #2186 pulled mid-run (modifies `.claude/phases/impl.ts`, an orchestrator/retro-only meta file the orchestrator reads live; planning bug — should not have been a worker task)
+- **Investigation gates**: #2083 → confirmed root cause (bunx CWD-resolution + tsc 94-lib startup vs internal 10s timeout under contention) → Fix 1 `Bun.which("tsc")` + Fix 2 timeout 30s; adversarial review APPROVED. #2211 → resolved-by-#2196 (no impl).
+- **New issues filed**: 0 substantive (Copilot inline threads on #1248/#1353/#2193/#2083/#2100 all addressed or dismissed inline before merge).
+
+### Run notes (for retro)
+- **Stale rule**: `run.md`/MEMORY claim sprint-`{N}` worktree commits need `SPRINT_OVERRIDE=1`. False — `.git-hooks/sprint-active.sh` explicitly allows worktree commits; only the *main checkout* is guarded. All sprint-meta + release commits this sprint were plain commits. Update run.md + memory.
+- **Stale id form**: `run.md` uses `--work-item issue:<n>`; actual tracked id is `#<n>`. `issue:<n>` errors with "work item not found".
+- **CI transient**: `setup-bun@v2` intermittently 401s ("Bad credentials") on the non-required `pty-test` check (hit #2225, #2230). Same external-Actions class as #2208/#2215; cleared on rerun.
+- **Pace**: 12 issues resolved + release in ~62 min via up-to-10 parallel sessions.

--- a/.claude/sprints/sprint-60.md
+++ b/.claude/sprints/sprint-60.md
@@ -1,0 +1,59 @@
+# Sprint 60
+
+> Planned 2026-05-23 05:35 EDT. Target: 13 PRs. Theme: **tech debt**.
+
+## Goal
+
+Pay down test-reliability and code-cleanliness debt: kill the known flaky/timeout-fragile tests, remove dead code and duplicated helpers, and fix stale orchestration comments — so future sprints run on a quieter, less surprising codebase.
+
+## Issues
+
+| # | Title | Scrutiny | Batch | Model | Category |
+|---|-------|----------|-------|-------|----------|
+| 2196 | pollUntil default 5s timeout leaves no headroom vs Bun 5s test timeout | medium | 1 | opus | goal |
+| 2083 | Flaky: alias-bundle-tsc.spec.ts times out under parallel test load | high | 1 | opus | goal |
+| 2204 | refactor(sites): remove dead sitesOpenInBrowser state | low | 1 | sonnet | goal |
+| 1248 | clone.spec.ts commits to worktree HEAD during full test runs | medium | 1 | opus | goal |
+| 2186 | phase(impl): stale #1286 reference; in-handler auto-spawn never shipped | medium | 1 | opus | goal |
+| 2211 | flaky(test): server-pool disconnect tests timeout (pollUntil=test timeout) | high | 2 | opus | goal |
+| 2205 | refactor(sites): dedup ToolResult/toolOk/toolError across browser-handlers + site-worker | low | 2 | opus | goal |
+| 1353 | workItemResolver: add timeout + debug logging for hung-mount resilience | medium | 2 | opus | goal |
+| 1662 | chore(sites): codegen/build-time validation for seeds.ts vs seeds/ parity | medium | 2 | opus | goal |
+| 2217 | reviveSession does not propagate cwd from state to config before spawnClaude | low | 2 | sonnet | goal |
+| 1247 | test(tracing-server): strengthen limit-clamping test with actual data | low | 3 | sonnet | filler |
+| 2193 | fix: grammar in OpenCode tool descriptions ("a OpenCode" → "an OpenCode") | low | 3 | sonnet | filler |
+| 2100 | lint: make Bun.sleep check blocking once existing violations are cleaned up | high | 3 | opus | goal |
+
+All `claude` provider (column omitted = default).
+
+## Batch Plan
+
+### Batch 1 (immediate)
+#2196, #2083, #2204, #1248, #2186
+
+### Batch 2 (backfill)
+#2211, #2205, #1353, #1662, #2217
+
+### Batch 3 (backfill)
+#1247, #2193, #2100
+
+### Dependency edges (translate to `addBlockedBy` at run)
+- #2211 blockedBy #2196 (the pollUntil default decision must land first; #2211's server-pool fix then rebases onto it — both touch `server-pool.spec.ts`)
+- #2205 blockedBy #2204 (both touch `packages/daemon/src/site/browser-handlers.ts`; remove dead state first, then dedup the remaining helpers)
+- #2100 blockedBy #2083, #2196, #2211 (the Bun.sleep sweep touches ~15 spec files; let the targeted flaky fixes land first so the sweep rebases onto them instead of conflicting)
+
+### Hot-shared / serialization notes
+- `server-pool.spec.ts`: #2196 + #2211 (serialized via blockedBy)
+- `browser-handlers.ts` / `site-worker.ts`: #2204 + #2205 (serialized via blockedBy)
+- Spec files broadly: #2100 is the last thing to land — broadcast a "rebase + re-run lint:timeouts" directive when it starts. Scope it to exclude any files still in flight.
+
+### Investigation gate (nerd-snipe before impl — see references/investigations.md)
+- #2083 and #2211 are flaky-test issues with timing-dependent mechanisms. Both require the mandatory nerd-snipe gate (`mcx claude spawn`, persona inlined — NOT the Agent tool). Acceptable hard-fail outcome is `needs-attention` if the root cause is environmental rather than fixable. Recon suggests both are timeout-headroom issues (likely simple bumps), but confirm the mechanism before patching.
+
+## Context
+
+Sprint 59 wrapped clean (only open PR is the permanent #1077 bun-segfault repro). Plan-time verification closed **6 already-done issues** (#1400, #2209, #2212, #2213, #2214, #1234) — pr-thread refactors and cmdImport tests had already landed via recent PRs. #2193 was initially flagged done but verification found the grammar bug still live in the OpenCode snapshot, so it stays in scope.
+
+Deferred this sprint: #2200 (meta — needs user review per Step 1a), #2208 + #2215 (external GitHub Actions transients, not fixable in our repo), #1639 (Bun stream-cancel limitation, code is already correct), and the fast-import/clone arc bugs (#1311/#1323/etc — entangled with the unbuilt #1211 writer, too risky to mix into a debt sprint).
+
+Risk: #2100 is the heaviest pick (131 Bun.sleep violations across ~15 spec files). It's gated behind the flaky fixes and lands last; if it balloons, it's a clean candidate to split file-by-file or carry to sprint 61.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "bun": ">=1.3.14"
   },
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "MCP CLI — call MCP server tools from the command line with zero context overhead",
   "type": "module",
   "workspaces": ["packages/*"],


### PR DESCRIPTION
Sprint 60 container PR. Accumulates every sprint-meta commit on the `sprint-60` branch:

- plan + any mid-sprint amendments
- run-time edits (Started/Ended timestamps, Excluded section)
- Results summary
- retro diary file
- release commit (if a release is cut this sprint)

**Theme:** tech debt — kill known flaky/timeout-fragile tests, remove dead code + duplicated helpers, fix stale orchestration comments.

**13 issues:** #2196 #2083 #2204 #1248 #2186 #2211 #2205 #1353 #1662 #2217 #1247 #2193 #2100

Plan verification closed 6 already-done issues (#1400 #2209 #2212 #2213 #2214 #1234).

Marked **draft** until `/sprint retro` flips it ready and arms auto-merge.

Docs/skill-only by construction — pre-commit hooks skip the test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)