### PR TITLE
refactor(sites): remove sitesOpenInBrowser dead state from browser-handlers factory (closes #2204)

### DIFF
--- a/packages/daemon/src/site/browser-handlers.ts
+++ b/packages/daemon/src/site/browser-handlers.ts
@@ -84,14 +84,12 @@ export function createBrowserHandlers<S extends SiteConfigLike = SiteConfigLike>
   const withBrowserLock = createBrowserLock();
   let browser: BrowserEngine | null = null;
   let browserEngineName: BrowserEngineName | null = null;
-  const sitesOpenInBrowser = new Set<string>();
   let lastBrowserSession: LastBrowserSession | null = null;
 
   function resetIfBrowserDied(): void {
     if (browser && !browser.isRunning()) {
       browser = null;
       browserEngineName = null;
-      sitesOpenInBrowser.clear();
     }
   }
 
@@ -158,7 +156,6 @@ export function createBrowserHandlers<S extends SiteConfigLike = SiteConfigLike>
 
       browser = eng;
       browserEngineName = engine;
-      for (const s of configs) sitesOpenInBrowser.add(s.name);
 
       return { eng, configs };
     }, "tryAutoRestartBrowser");
@@ -218,7 +215,6 @@ export function createBrowserHandlers<S extends SiteConfigLike = SiteConfigLike>
       }
       browser = eng;
       browserEngineName = engine;
-      for (const s of sites) sitesOpenInBrowser.add(s.name);
       lastBrowserSession = { engine, siteNames: sites.map((s) => s.name) };
 
       return toolOk({ ok: true, engine, sites: eng.getSiteNames(), results: startResults });
@@ -232,7 +228,6 @@ export function createBrowserHandlers<S extends SiteConfigLike = SiteConfigLike>
       await withDeadline(30_000, "browser stop", browser.stop());
       browser = null;
       browserEngineName = null;
-      sitesOpenInBrowser.clear();
       lastBrowserSession = null;
       return toolOk({ ok: true });
     }, "handleDisconnect");


### PR DESCRIPTION
## Summary
- Removes `sitesOpenInBrowser` (`Set<string>`) from `createBrowserHandlers` — it was written in 4 places but never read (no `.has()`, `.size`, or iteration)
- `lastBrowserSession.siteNames` already tracks the same data and is the only field consulted by `tryAutoRestartBrowser`
- Pure dead-code removal: no behavior change

## Test plan
- [x] Existing `browser-handlers.spec.ts` tests (5 tests) pass unchanged
- [x] `bun typecheck` passes
- [x] `bun lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)