### PR TITLE
test(tracing-server): strengthen limit-clamping test with actual data (closes #1247)

### DIFF
--- a/packages/daemon/src/tracing-server.spec.ts
+++ b/packages/daemon/src/tracing-server.spec.ts
@@ -241,15 +241,19 @@ describe("TracingServer", () => {
     test("clamps limit to valid range", async () => {
       using opts = testOptions();
       db = new StateDb(opts.DB_PATH);
+      for (let i = 0; i < 5; i++) {
+        insertSpan(db, { spanId: `s${i}`.padEnd(16, "0"), startTimeMs: 1000 + i });
+      }
       server = new TracingServer(db);
       const { client } = await server.start();
 
-      // Should not error with oversized or zero limit
+      // 9999 clamps to 1000, which is > 5 — all spans returned
       const over = parseResult(await client.callTool({ name: "query_traces", arguments: { limit: 9999 } }));
-      expect(over.spans).toEqual([]);
+      expect((over.spans as unknown[]).length).toBe(5);
 
+      // 0 clamps to 1 — exactly one span returned
       const zero = parseResult(await client.callTool({ name: "query_traces", arguments: { limit: 0 } }));
-      expect(zero.spans).toEqual([]);
+      expect((zero.spans as unknown[]).length).toBe(1);
     });
 
     test("filters by server name substring", async () => {


### PR DESCRIPTION
## Summary
- Replaces the vacuous "clamps limit to valid range" test that inserted no spans (always returned `[]` regardless of limit)
- Inserts 5 spans, then asserts `limit: 9999` returns all 5 (capped at 1000 > 5) and `limit: 0` returns 1 (clamps from 0 to 1)
- No implementation changes — test-only fix

## Test plan
- [ ] `bun test packages/daemon/src/tracing-server.spec.ts` — all 28 tests pass
- [ ] `bun typecheck` — clean
- [ ] `bun lint` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)