### PR TITLE
fix(test): reduce pollUntil timeout to 4s in disconnect tests for Bun headroom (fixes #2196)

### DIFF
--- a/packages/daemon/src/server-pool.spec.ts
+++ b/packages/daemon/src/server-pool.spec.ts
@@ -1704,7 +1704,7 @@ describe("disconnect kills stdio child processes (#940)", () => {
 
       await pool.disconnect("sleeper");
 
-      await pollUntil(() => !isAlive(pid));
+      await pollUntil(() => !isAlive(pid), 4000);
     } finally {
       forceKill(pid);
     }
@@ -1742,7 +1742,7 @@ describe("disconnect kills stdio child processes (#940)", () => {
 
       await pool.closeAll();
 
-      await pollUntil(() => !isAlive(pid));
+      await pollUntil(() => !isAlive(pid), 4000);
     } finally {
       forceKill(pid);
     }
@@ -1818,7 +1818,7 @@ describe("disconnect kills stdio child processes (#940)", () => {
       // killPid would never be called, leaving the process alive.
       await pool.disconnect("sleeper");
 
-      await pollUntil(() => !isAlive(pid));
+      await pollUntil(() => !isAlive(pid), 4000);
     } finally {
       forceKill(pid);
     }


### PR DESCRIPTION
## Summary
- Pass explicit `4000`ms timeout to `pollUntil` in three disconnect tests in `server-pool.spec.ts` (lines 1707, 1745, 1821)
- Gives 1s headroom against Bun's default 5s test timeout so setup overhead doesn't cause the test to hit Bun's generic timeout before `pollUntil`'s descriptive error
- Targeted fix — does not change `pollUntil`'s global 5s default

## Test plan
- [x] All three callsites updated with `4000` timeout
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (7615 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)