### PR TITLE
test(sites): add build-time validation for seeds.ts vs seeds/ directory parity (fixes #1662)

### DIFF
--- a/packages/daemon/src/site/seeds.spec.ts
+++ b/packages/daemon/src/site/seeds.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { _restoreOptions, options } from "@mcp-cli/core";
@@ -141,4 +141,47 @@ describe("embedded seed data (compiled-binary support)", () => {
       void seedName; // referenced in test name only
     }
   });
+});
+
+describe("seeds/ directory ↔ seeds.ts parity", () => {
+  const seedsDir = join(import.meta.dir, "seeds");
+
+  const diskSeeds = readdirSync(seedsDir, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name)
+    .sort();
+
+  const registeredSeeds = Object.keys(BUILTIN_SEEDS).sort();
+
+  test("every directory under seeds/ has an entry in BUILTIN_SEEDS", () => {
+    const missing = diskSeeds.filter((d) => !registeredSeeds.includes(d));
+    expect(missing).toEqual([]);
+  });
+
+  test("every BUILTIN_SEEDS entry has a directory under seeds/", () => {
+    const orphaned = registeredSeeds.filter((s) => !diskSeeds.includes(s));
+    expect(orphaned).toEqual([]);
+  });
+
+  for (const seed of diskSeeds) {
+    describe(`seed "${seed}" file parity`, () => {
+      const seedDir = join(seedsDir, seed);
+
+      test("catalog.json exists on disk and is imported", () => {
+        expect(existsSync(join(seedDir, "catalog.json"))).toBe(true);
+        expect(BUILTIN_SEEDS[seed]?.catalog).toBeTruthy();
+      });
+
+      test("config.json exists on disk and is imported", () => {
+        expect(existsSync(join(seedDir, "config.json"))).toBe(true);
+        expect(BUILTIN_SEEDS[seed]?.config).toBeTruthy();
+      });
+
+      test("wiggle.js parity — if on disk then imported, and vice versa", () => {
+        const onDisk = existsSync(join(seedDir, "wiggle.js"));
+        const imported = typeof BUILTIN_SEEDS[seed]?.wiggleSrc === "string";
+        expect(imported).toBe(onDisk);
+      });
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- Adds parity validation tests to `seeds.spec.ts` that assert every directory under `seeds/` has a corresponding `BUILTIN_SEEDS` entry and vice versa
- For each seed directory, validates that `catalog.json`, `config.json`, and `wiggle.js` are present on disk if and only if they are imported in `seeds.ts`
- Catches silent mismatches (new seed dir without import, or stale import after dir removal) in CI/pre-commit

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (7623 tests, 0 failures)
- [x] New parity tests (5 added) all pass against current seeds/ layout
- [x] Verified test would catch a missing BUILTIN_SEEDS entry by inspecting the assertion logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)