### PR TITLE
fix(clone): add GIT_CEILING_DIRECTORIES to prevent test commits leaking to worktree HEAD (fixes #1248)

### DIFF
--- a/packages/clone/src/engine/clone.spec.ts
+++ b/packages/clone/src/engine/clone.spec.ts
@@ -16,6 +16,7 @@ function cleanEnv(): Record<string, string> {
   for (const [k, v] of Object.entries(process.env)) {
     if (!k.startsWith("GIT_") && v !== undefined) env[k] = v;
   }
+  env.GIT_CEILING_DIRECTORIES = TMP;
   return env;
 }
 

--- a/packages/clone/src/engine/clone.ts
+++ b/packages/clone/src/engine/clone.ts
@@ -230,8 +230,14 @@ export async function clone(opts: CloneOptions): Promise<CloneResult> {
   for (const [k, v] of Object.entries(process.env)) {
     if (!k.startsWith("GIT_") && v !== undefined) cleanEnv[k] = v;
   }
+  cleanEnv.GIT_CEILING_DIRECTORIES = dirname(absTarget);
   const gitOpts = { cwd: absTarget, stdio: "pipe" as const, env: cleanEnv };
   execSync("git init", gitOpts);
+  if (!existsSync(join(absTarget, ".git"))) {
+    throw new Error(
+      `git init did not create .git at "${absTarget}". This usually means git resolved to a parent repository. Check GIT_DIR / GIT_WORK_TREE env vars.`,
+    );
+  }
   // Set user identity for this repo so commits work even in environments
   // without a global git config (e.g. CI runners, fresh machines).
   execSync("git config user.name mcx", gitOpts);

--- a/packages/clone/src/engine/pull.ts
+++ b/packages/clone/src/engine/pull.ts
@@ -144,6 +144,7 @@ export async function pull(opts: PullOptions): Promise<PullResult> {
       for (const [k, v] of Object.entries(process.env)) {
         if (!k.startsWith("GIT_") && v !== undefined) cleanEnv[k] = v;
       }
+      cleanEnv.GIT_CEILING_DIRECTORIES = dirname(repoDir);
       const gitOpts = { cwd: repoDir, stdio: "pipe" as const, env: cleanEnv };
       execSync("git add -A", gitOpts);
 


### PR DESCRIPTION
## Summary
- Add `GIT_CEILING_DIRECTORIES` to `clone.spec.ts`'s `cleanEnv()` (matching the pattern already used in `pull.spec.ts`) to prevent git from walking up to the ambient worktree during test runs
- Add `GIT_CEILING_DIRECTORIES` to production code in both `clone.ts` and `pull.ts` so git commands never escape the target/repo directory
- Add a post-`git init` sanity check in `clone.ts` that throws if `.git` was not created at the expected location

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — all 7615 tests pass, 0 failures
- [x] Clone-specific tests: all 345 pass in `packages/clone/`
- [x] Verified `dirname` was already imported in both production files

🤖 Generated with [Claude Code](https://claude.com/claude-code)