### PR TITLE
fix(claude): propagate state.cwd to config.cwd in reviveSession (fixes #2217)

### DIFF
--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -5110,4 +5110,28 @@ describe("reviveSession", () => {
     // spawnClaude was called (ms.lastCmd is populated)
     expect(ms.lastCmd.length).toBeGreaterThan(0);
   });
+
+  test("reviveSession propagates state.cwd to config.cwd so spawnClaude uses correct directory (#2217)", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    await server.start();
+
+    server.restoreSessions([
+      {
+        sessionId: "cwd-revive",
+        pid: null,
+        state: "idle",
+        model: null,
+        cwd: "/my/project",
+        worktree: null,
+        totalCost: 0,
+        totalTokens: 0,
+        claudeSessionId: "claude-cwd-abc",
+      },
+    ]);
+
+    server.reviveSession("cwd-revive", "continue");
+
+    expect(ms.lastOpts.cwd).toBe("/my/project");
+  });
 });

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -702,6 +702,7 @@ export class ClaudeWsServer {
     // Set up config so handleOpen delivers the prompt and resumes conversation history
     session.config.prompt = prompt;
     session.config.resumeSessionId = session.claudeSessionId;
+    session.config.cwd = session.state.cwd ?? undefined;
 
     // Clear stale process references — the old process is dead
     session.proc = null;


### PR DESCRIPTION
## Summary
- `reviveSession()` was setting `config.prompt` and `config.resumeSessionId` but not `config.cwd`
- `spawnClaude()` uses `session.config.cwd` as the process working directory, so revived sessions were spawning in an unexpected directory after daemon restart
- Fix: add `session.config.cwd = session.state.cwd ?? undefined` in `reviveSession()` before calling `spawnClaude()`

## Test plan
- Added `reviveSession propagates state.cwd to config.cwd so spawnClaude uses correct directory (#2217)` test that verifies `ms.lastOpts.cwd` equals the cwd from the restored session
- All 6 `reviveSession` tests pass; full suite passes (7616 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)