### PR TITLE
fix(agent-tools): correct article for vowel-initial labels (fixes #2193)

### DIFF
--- a/packages/core/src/agent-tools.ts
+++ b/packages/core/src/agent-tools.ts
@@ -165,6 +165,7 @@ export function buildAgentTools(opts: BuildAgentToolsOptions): readonly AgentToo
   const { prefix, label, overrides = {}, extraTools = [] } = opts;
   const p = (name: string) => `${prefix}_${name}`;
   const ov = (name: AgentToolName) => overrides[name];
+  const art = /^[aeiou]/i.test(label) ? "an" : "a";
 
   const schema = (name: AgentToolName, properties: Record<string, JsonSchemaProperty>, required?: readonly string[]) =>
     applyOmit(properties, required, ov(name)?.omitProperties);
@@ -287,7 +288,7 @@ export function buildAgentTools(opts: BuildAgentToolsOptions): readonly AgentToo
     // -- transcript --
     {
       name: p("transcript"),
-      description: ov("transcript")?.description ?? `Get recent transcript entries from a ${label} session.`,
+      description: ov("transcript")?.description ?? `Get recent transcript entries from ${art} ${label} session.`,
       inputSchema: {
         type: "object" as const,
         ...schema(
@@ -324,7 +325,7 @@ export function buildAgentTools(opts: BuildAgentToolsOptions): readonly AgentToo
     // -- approve --
     {
       name: p("approve"),
-      description: ov("approve")?.description ?? `Approve a pending permission request for a ${label} session.`,
+      description: ov("approve")?.description ?? `Approve a pending permission request for ${art} ${label} session.`,
       inputSchema: {
         type: "object" as const,
         ...schema(
@@ -345,7 +346,7 @@ export function buildAgentTools(opts: BuildAgentToolsOptions): readonly AgentToo
     // -- deny --
     {
       name: p("deny"),
-      description: ov("deny")?.description ?? `Deny a pending permission request for a ${label} session.`,
+      description: ov("deny")?.description ?? `Deny a pending permission request for ${art} ${label} session.`,
       inputSchema: {
         type: "object" as const,
         ...schema(

--- a/packages/daemon/src/__snapshots__/opencode-server.spec.ts.snap
+++ b/packages/daemon/src/__snapshots__/opencode-server.spec.ts.snap
@@ -133,7 +133,7 @@ exports[`OPENCODE_TOOLS schema snapshot 1`] = `
     "name": "opencode_bye",
   },
   {
-    "description": "Get recent transcript entries from a OpenCode session.",
+    "description": "Get recent transcript entries from an OpenCode session.",
     "inputSchema": {
       "properties": {
         "limit": {
@@ -174,7 +174,7 @@ exports[`OPENCODE_TOOLS schema snapshot 1`] = `
     "name": "opencode_wait",
   },
   {
-    "description": "Approve a pending permission request for a OpenCode session.",
+    "description": "Approve a pending permission request for an OpenCode session.",
     "inputSchema": {
       "properties": {
         "requestId": {
@@ -195,7 +195,7 @@ exports[`OPENCODE_TOOLS schema snapshot 1`] = `
     "name": "opencode_approve",
   },
   {
-    "description": "Deny a pending permission request for a OpenCode session.",
+    "description": "Deny a pending permission request for an OpenCode session.",
     "inputSchema": {
       "properties": {
         "requestId": {


### PR DESCRIPTION
## Summary
- Adds an `art` helper in `buildAgentTools` that selects "a" or "an" based on whether the label starts with a vowel
- Updates the `transcript`, `approve`, and `deny` description templates to use `${art}` instead of hardcoded `"a"`
- Regenerates `opencode-server.spec.ts.snap` so the three affected descriptions now read "an OpenCode session"

## Test plan
- [ ] `bun test packages/core/src/agent-tools.spec.ts` — existing tests pass (Claude/Codex still get "a")
- [ ] `bun test packages/daemon/src/opencode-server.spec.ts` — snapshot matches updated descriptions
- [ ] `bun typecheck && bun lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)