### PR TITLE
refactor(sites): deduplicate ToolResult/toolOk/toolError in site-worker (fixes #2205)

### DIFF
--- a/packages/daemon/src/site-worker.ts
+++ b/packages/daemon/src/site-worker.ts
@@ -21,7 +21,8 @@ import { resolve as resolvePath } from "node:path";
 import { SITE_SERVER_NAME } from "@mcp-cli/core";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
-import { createBrowserHandlers, shouldAutoRestart } from "./site/browser-handlers";
+import { createBrowserHandlers, toolError as error, toolOk as ok, shouldAutoRestart } from "./site/browser-handlers";
+import type { ToolResult } from "./site/browser-handlers";
 export { shouldAutoRestart, parseSitesArg } from "./site/browser-handlers";
 export type { LastBrowserSession } from "./site/browser-handlers";
 import type { SiteSpec } from "./site/browser/engine";
@@ -134,17 +135,6 @@ const {
 } = browserHandlers;
 
 // ── Tool handlers ──
-
-type ToolResult = { content: Array<{ type: "text"; text: string }>; isError?: boolean };
-
-function ok(data: unknown): ToolResult {
-  const text = typeof data === "string" ? data : JSON.stringify(data, null, 2);
-  return { content: [{ type: "text", text }] };
-}
-
-function error(message: string): ToolResult {
-  return { content: [{ type: "text", text: `Error: ${message}` }], isError: true };
-}
 
 function handleList(): ToolResult {
   return ok(


### PR DESCRIPTION
## Summary
- Import `ToolResult` type and `toolOk`/`toolError` helpers from `./site/browser-handlers` into `site-worker.ts` (aliased as `ok`/`error` to preserve call-site readability)
- Remove the structurally identical local definitions (type + two functions, 11 lines)
- Single source of truth prevents future divergence between the two files

## Test plan
- [x] `bun typecheck` passes — all call sites in site-worker.ts resolve correctly through the imports
- [x] `bun lint` passes (biome auto-sorted import specifiers)
- [x] `bun test` — all 7615 tests pass, 0 failures
- [x] No behavioral change — imported functions are byte-for-byte identical to the removed locals

🤖 Generated with [Claude Code](https://claude.com/claude-code)