### PR TITLE
chore(rules): extend no-js-extension rule to .claude/phases/**

### DIFF
--- a/.claude/phases/done-fn.ts
+++ b/.claude/phases/done-fn.ts
@@ -1,6 +1,6 @@
 /** Core done-phase logic, extracted for testability via dependency injection. */
 
-import type { GhOp, GhResult } from "./phase-types.js";
+import type { GhOp, GhResult } from "./phase-types";
 export type { GhOp, GhResult };
 
 export interface ProcessHandle {

--- a/.claude/phases/qa-fn.ts
+++ b/.claude/phases/qa-fn.ts
@@ -1,6 +1,6 @@
 /** Core qa-phase logic, extracted for testability via dependency injection. */
 
-import type { GhOp, GhResult } from "./phase-types.js";
+import type { GhOp, GhResult } from "./phase-types";
 export type { GhOp, GhResult };
 
 export const QA_FAIL_CAP = 2;

--- a/.claude/phases/review-fn.ts
+++ b/.claude/phases/review-fn.ts
@@ -1,6 +1,6 @@
 /** Core review-phase logic, extracted for testability via dependency injection. */
 
-import type { GhOp, GhResult } from "./phase-types.js";
+import type { GhOp, GhResult } from "./phase-types";
 export type { GhOp, GhResult };
 
 export const REVIEW_ROUND_CAP = 2;

--- a/.mcx.lock
+++ b/.mcx.lock
@@ -5,7 +5,7 @@
     {
       "name": "done",
       "resolvedPath": ".claude/phases/done.ts",
-      "contentHash": "b068c71c9cb2b38169b02349c61bc2cda4d039fc020bc4ee9c642404c7f8bae1",
+      "contentHash": "88d7c68317a8319487d32e57eb398dfadf3aa581fe9b92de25f1acd2960c790e",
       "schemaHash": "65b20b69643a6f7b1250b4949e0d1dffd022aa9573aadd952a07759879ebc98f"
     },
     {
@@ -23,7 +23,7 @@
     {
       "name": "qa",
       "resolvedPath": ".claude/phases/qa.ts",
-      "contentHash": "b481261bbd94b8e426a6653661408505c3af3ceff6ca3609dfa3578e986e1ed8",
+      "contentHash": "57a2e7137e07d170a7f8e2dd6a4011732e51b36cc6ae7614f93da7796f8526c3",
       "schemaHash": "2c3159b3558360d1a25caf8e7f4401da2dba237bf3799807bc8c68497290cd40"
     },
     {
@@ -35,7 +35,7 @@
     {
       "name": "review",
       "resolvedPath": ".claude/phases/review.ts",
-      "contentHash": "f15fa45aa731bd0d17a0ad7808fe2ea7d797732763db5b1052190bccff0e55af",
+      "contentHash": "e61f3c3ae1ef3cd483922242722fef1417b86b1e4014c816afe4326d2fe7058b",
       "schemaHash": "dbbe21e50a1a7a002a56c511d456060166ea94c6d15b2400e7f8283c861ed83d"
     },
     {

--- a/scripts/rules/no-js-extension-local-import.rule.ts
+++ b/scripts/rules/no-js-extension-local-import.rule.ts
@@ -1,7 +1,7 @@
 /**
  * Rule: no-js-extension-local-import
  *
- * Relative imports within packages/ must use
+ * Relative imports within packages/ and .claude/phases/ must use
  * extensionless specifiers (e.g. `./phase-types`, not `./phase-types.js`).
  * TypeScript resolves .ts source files without extensions at compile time,
  * and the .js suffix becomes a footgun when the import is later refactored
@@ -28,7 +28,7 @@ const rule: CheckRule = {
   documentation: "#2173",
   appliesToTests: true,
   check({ file, violated }) {
-    const inScope = file.relPath.startsWith("packages/");
+    const inScope = file.relPath.startsWith("packages/") || file.relPath.startsWith(".claude/phases/");
     if (!inScope) return;
 
     const lines = file.content.split("\n");


### PR DESCRIPTION
Applies meta-fix #2200. Extends the `no-js-extension-local-import` dotw rule (from #2173) to cover `.claude/phases/**` and strips `.js` from the three `phase-types` type imports in `done-fn.ts`/`qa-fn.ts`/`review-fn.ts`.

Verified: `mcx phase install` (lock regenerated), typecheck, `doing-it-wrong`, full test suite (4610 pass).

Closes #2200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)