### PR TITLE
fix(clone): don't write done to fast-import on import error path (fixes #1311)

### DIFF
--- a/packages/clone/src/engine/remote-protocol.spec.ts
+++ b/packages/clone/src/engine/remote-protocol.spec.ts
@@ -224,7 +224,7 @@ describe("remote-protocol", () => {
     expect(errors[0]).toContain("provider unreachable");
   });
 
-  test("import error: calls onError with message and writes done terminator", async () => {
+  test("import error: calls onError with message and writes blank terminator (no done)", async () => {
     const errors: string[] = [];
     const handlers = makeHandlers({
       handleImport: async () => {
@@ -234,7 +234,7 @@ describe("remote-protocol", () => {
     const stdin = streamFrom("import refs/heads/main\n\n");
     const { stream, result } = collectStream();
     await runProtocol(stdin, stream, handlers, { marksDir: MARKS_DIR, onError: (msg) => errors.push(msg) });
-    expect(result()).toBe("done\n");
+    expect(result()).toBe("\n");
     expect(errors).toHaveLength(1);
     expect(errors[0]).toContain("import failed");
     expect(errors[0]).toContain("import broken");

--- a/packages/clone/src/engine/remote-protocol.ts
+++ b/packages/clone/src/engine/remote-protocol.ts
@@ -124,7 +124,7 @@ export async function runProtocol(
           await writeLine(writer, response);
         } catch (err) {
           logError(`git-remote-mcx: import failed: ${errorMessage(err)}\n`);
-          await writeLine(writer, "done\n");
+          await writeLine(writer, "\n");
           return;
         }
       } else if (line === "export") {


### PR DESCRIPTION
## Summary
- Remove `done\n` from the import error path in `remote-protocol.ts`, replacing it with a blank terminator (`\n`)
- In git fast-import protocol, `done` tells git to commit all pending objects — writing it after a failed import could cause partial/corrupt refs to be committed
- Error path now matches `list` and `export` error paths, which already write blank terminators

## Test plan
- [x] Updated existing test to verify blank terminator (not `done`) on import error
- [x] All 7632 tests pass (0 failures)
- [x] Typecheck clean
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)