### PR TITLE
fix(agent-tools): apply art helper to interrupt/bye/wait default descriptions (fixes #2229)

### DIFF
--- a/packages/core/src/agent-tools.spec.ts
+++ b/packages/core/src/agent-tools.spec.ts
@@ -91,6 +91,24 @@ describe("buildAgentTools", () => {
     expect(prompt.description).toContain("Test Agent");
   });
 
+  test("art helper uses 'an' for vowel-initial labels in all default descriptions", () => {
+    const tools = buildAgentTools({ prefix: "test", label: "Agentic Provider" });
+    for (const basename of ["interrupt", "bye", "wait", "transcript", "approve", "deny"] as const) {
+      const tool = findTool(tools, `test_${basename}`);
+      expect(tool.description).toContain("an Agentic Provider");
+      expect(tool.description).not.toContain("a Agentic Provider");
+    }
+  });
+
+  test("art helper uses 'a' for consonant-initial labels in all default descriptions", () => {
+    const tools = buildAgentTools(minimal); // label: "Test Agent"
+    for (const basename of ["interrupt", "bye", "wait", "transcript", "approve", "deny"] as const) {
+      const tool = findTool(tools, `test_${basename}`);
+      expect(tool.description).toContain("a Test Agent");
+      expect(tool.description).not.toContain("an Test Agent");
+    }
+  });
+
   test("overrides replace description", () => {
     const tools = buildAgentTools({
       ...minimal,

--- a/packages/core/src/agent-tools.ts
+++ b/packages/core/src/agent-tools.ts
@@ -242,7 +242,7 @@ export function buildAgentTools(opts: BuildAgentToolsOptions): readonly AgentToo
     // -- interrupt --
     {
       name: p("interrupt"),
-      description: ov("interrupt")?.description ?? `Interrupt the current turn of a ${label} session.`,
+      description: ov("interrupt")?.description ?? `Interrupt the current turn of ${art} ${label} session.`,
       inputSchema: {
         type: "object" as const,
         ...schema(
@@ -266,7 +266,7 @@ export function buildAgentTools(opts: BuildAgentToolsOptions): readonly AgentToo
       name: p("bye"),
       description:
         ov("bye")?.description ??
-        `Gracefully end a ${label} session: close the connection, stop the process, clean up.`,
+        `Gracefully end ${art} ${label} session: close the connection, stop the process, clean up.`,
       inputSchema: {
         type: "object" as const,
         ...schema(
@@ -308,7 +308,7 @@ export function buildAgentTools(opts: BuildAgentToolsOptions): readonly AgentToo
       name: p("wait"),
       description:
         ov("wait")?.description ??
-        `Block until a ${label} session event occurs (result, error, or permission request). If sessionId is provided, waits for that session only. Otherwise waits for any session.`,
+        `Block until ${art} ${label} session event occurs (result, error, or permission request). If sessionId is provided, waits for that session only. Otherwise waits for any session.`,
       inputSchema: {
         type: "object" as const,
         ...schema("wait", {


### PR DESCRIPTION
## Summary
- Three default descriptions in `buildAgentTools` (`interrupt`, `bye`, `wait`) still hardcoded `a ${label}` instead of using the `art` helper added in #2193
- Updated all three to use `${art} ${label}` so any future vowel-initial provider gets correct grammar ("an OpenCode session" not "a OpenCode session")
- Added two regression tests verifying `art` is applied correctly for both vowel-initial and consonant-initial labels across all six affected tool descriptions

## Test plan
- [x] New tests confirm vowel-initial label (`"Agentic Provider"`) produces `"an Agentic Provider"` for `interrupt`, `bye`, `wait`, `transcript`, `approve`, `deny`
- [x] New tests confirm consonant-initial label (`"Test Agent"`) produces `"a Test Agent"` for the same tools
- [x] Full test suite passes (7634 tests, 0 failures)
- [x] `bun typecheck` and `bun lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)