### PR TITLE
feat(clone): add ExportTransaction for transactional export semantics (fixes #1312)

### DIFF
--- a/packages/clone/src/engine/export-transaction.spec.ts
+++ b/packages/clone/src/engine/export-transaction.spec.ts
@@ -246,7 +246,7 @@ describe("ExportTransaction", () => {
         entries: { "a.md": { content: "old", version: 1 } },
       });
       let receivedFrontmatter: Record<string, unknown> | undefined;
-      const originalPush = provider.push?.bind(provider);
+      const originalPush = (provider.push as NonNullable<typeof provider.push>).bind(provider);
       (provider as unknown as Record<string, unknown>).push = async (
         scope: unknown,
         id: string,
@@ -342,7 +342,7 @@ describe("ExportTransaction", () => {
       });
 
       let pushCount = 0;
-      const originalPush = provider.push?.bind(provider);
+      const originalPush = (provider.push as NonNullable<typeof provider.push>).bind(provider);
       (provider as unknown as Record<string, unknown>).push = async (
         scope: unknown,
         id: string,

--- a/packages/clone/src/engine/export-transaction.spec.ts
+++ b/packages/clone/src/engine/export-transaction.spec.ts
@@ -1,0 +1,384 @@
+import { describe, expect, test } from "bun:test";
+import { createMockProvider } from "./__tests__/mock-provider";
+import { ExportTransaction, type ExportTransactionOptions, type PathResolver } from "./export-transaction";
+import type { ParsedCommit } from "./fast-import-parser";
+
+function makeOpts(
+  overrides: Partial<ExportTransactionOptions> & {
+    entries?: Record<string, { content: string; version: number }>;
+  } = {},
+): ExportTransactionOptions {
+  const entries: Record<string, { content: string; version: number }> = overrides.entries ?? {
+    "README.md": { content: "# Hello", version: 1 },
+    "docs/guide.md": { content: "# Guide", version: 2 },
+  };
+
+  const provider = overrides.provider ?? createMockProvider({ entries });
+  const scope = { key: "test", cloudId: "mock-cloud", resolved: {} };
+
+  const pathMap = new Map<string, { id: string; version: number }>();
+  for (const [id, entry] of Object.entries(entries)) {
+    pathMap.set(id, { id, version: entry.version });
+  }
+
+  const resolvePath: PathResolver = overrides.resolvePath ?? ((path) => pathMap.get(path));
+
+  return { provider, scope, resolvePath };
+}
+
+function commit(ref: string, changes: ParsedCommit["changes"]): ParsedCommit {
+  return { ref, message: "test", changes };
+}
+
+describe("ExportTransaction", () => {
+  describe("staging", () => {
+    test("stages modify operations for known paths", () => {
+      const tx = new ExportTransaction(makeOpts());
+      const errors = tx.stage([
+        commit("refs/heads/main", [
+          { type: "modify", path: "README.md", content: new TextEncoder().encode("# Updated") },
+        ]),
+      ]);
+      expect(errors).toHaveLength(0);
+      expect(tx.size).toBe(1);
+      expect(tx.refs).toEqual(["refs/heads/main"]);
+    });
+
+    test("stages create operations for unknown paths", () => {
+      const tx = new ExportTransaction(makeOpts());
+      const errors = tx.stage([
+        commit("refs/heads/main", [
+          { type: "modify", path: "new-file.md", content: new TextEncoder().encode("# New") },
+        ]),
+      ]);
+      expect(errors).toHaveLength(0);
+      expect(tx.size).toBe(1);
+    });
+
+    test("stages delete operations for known paths", () => {
+      const tx = new ExportTransaction(makeOpts());
+      const errors = tx.stage([commit("refs/heads/main", [{ type: "delete", path: "README.md" }])]);
+      expect(errors).toHaveLength(0);
+      expect(tx.size).toBe(1);
+    });
+
+    test("returns error for delete of unknown path", () => {
+      const tx = new ExportTransaction(makeOpts());
+      const errors = tx.stage([commit("refs/heads/main", [{ type: "delete", path: "nonexistent.md" }])]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].ok).toBe(false);
+      expect(errors[0].error).toContain("cannot delete unknown path");
+    });
+
+    test("returns error for modify without content", () => {
+      const tx = new ExportTransaction(makeOpts());
+      const errors = tx.stage([commit("refs/heads/main", [{ type: "modify", path: "README.md" }])]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].ok).toBe(false);
+      expect(errors[0].error).toContain("no content");
+    });
+
+    test("returns error for deleteall", () => {
+      const tx = new ExportTransaction(makeOpts());
+      const errors = tx.stage([commit("refs/heads/main", [{ type: "deleteall" }])]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].error).toContain("deleteall not supported");
+    });
+
+    test("stages multiple commits across refs", () => {
+      const tx = new ExportTransaction(makeOpts());
+      const errors = tx.stage([
+        commit("refs/heads/main", [{ type: "modify", path: "README.md", content: new TextEncoder().encode("v2") }]),
+        commit("refs/heads/feature", [
+          { type: "modify", path: "docs/guide.md", content: new TextEncoder().encode("v3") },
+        ]),
+      ]);
+      expect(errors).toHaveLength(0);
+      expect(tx.size).toBe(2);
+      expect(tx.refs).toContain("refs/heads/main");
+      expect(tx.refs).toContain("refs/heads/feature");
+    });
+  });
+
+  describe("commit — success", () => {
+    test("applies all staged modifications atomically", async () => {
+      const provider = createMockProvider({
+        entries: { "README.md": { content: "# Hello", version: 1 } },
+      });
+      const opts = makeOpts({ provider, entries: { "README.md": { content: "# Hello", version: 1 } } });
+      const tx = new ExportTransaction(opts);
+
+      tx.stage([
+        commit("refs/heads/main", [
+          { type: "modify", path: "README.md", content: new TextEncoder().encode("# Updated") },
+        ]),
+      ]);
+
+      const result = await tx.commit();
+      expect(result.refs).toHaveLength(1);
+      expect(result.refs[0].ok).toBe(true);
+      expect(result.refs[0].ref).toBe("refs/heads/main");
+      expect(result.response).toBe("ok refs/heads/main\n\n");
+      expect(provider.state.get("README.md")?.content).toBe("# Updated");
+    });
+
+    test("applies create operations", async () => {
+      const provider = createMockProvider({ entries: {} });
+      const opts = makeOpts({ provider, entries: {} });
+      const tx = new ExportTransaction(opts);
+
+      tx.stage([
+        commit("refs/heads/main", [
+          { type: "modify", path: "new-page.md", content: new TextEncoder().encode("# New") },
+        ]),
+      ]);
+
+      const result = await tx.commit();
+      expect(result.refs[0].ok).toBe(true);
+      expect(provider.calls.create).toBe(1);
+    });
+
+    test("applies delete operations", async () => {
+      const provider = createMockProvider({
+        entries: { "page.md": { content: "x", version: 1 } },
+      });
+      const opts = makeOpts({ provider, entries: { "page.md": { content: "x", version: 1 } } });
+      const tx = new ExportTransaction(opts);
+
+      tx.stage([commit("refs/heads/main", [{ type: "delete", path: "page.md" }])]);
+
+      const result = await tx.commit();
+      expect(result.refs[0].ok).toBe(true);
+      expect(provider.calls.delete).toBe(1);
+    });
+
+    test("empty transaction commits successfully", async () => {
+      const tx = new ExportTransaction(makeOpts());
+      tx.stage([commit("refs/heads/main", [])]);
+      const result = await tx.commit();
+      expect(result.refs[0].ok).toBe(true);
+      expect(result.response).toBe("ok refs/heads/main\n\n");
+    });
+  });
+
+  describe("commit — partial failure", () => {
+    test("version conflict fails entire transaction", async () => {
+      const provider = createMockProvider({
+        entries: { "README.md": { content: "# Hello", version: 2 } },
+      });
+      // resolvePath thinks version is 1, but provider has version 2
+      const opts: ExportTransactionOptions = {
+        provider,
+        scope: { key: "test", cloudId: "mock-cloud", resolved: {} },
+        resolvePath: (path) => (path === "README.md" ? { id: "README.md", version: 1 } : undefined),
+      };
+      const tx = new ExportTransaction(opts);
+
+      tx.stage([
+        commit("refs/heads/main", [
+          { type: "modify", path: "README.md", content: new TextEncoder().encode("# Conflict") },
+        ]),
+      ]);
+
+      const result = await tx.commit();
+      expect(result.refs[0].ok).toBe(false);
+      expect(result.refs[0].error).toContain("version conflict");
+      expect(result.response).toContain("error refs/heads/main");
+    });
+
+    test("mid-stream failure aborts remaining operations", async () => {
+      const provider = createMockProvider({
+        entries: {
+          "a.md": { content: "a", version: 1 },
+          "b.md": { content: "b", version: 1 },
+        },
+      });
+
+      // Arm push failure after first successful push
+      let pushCount = 0;
+      const originalPush = provider.push?.bind(provider);
+      if (!originalPush) throw new Error("provider.push is undefined");
+      (provider as unknown as { push: typeof originalPush }).push = async (scope, id, content, baseVersion, fm) => {
+        pushCount++;
+        if (pushCount === 2) throw new Error("network timeout");
+        return originalPush(scope, id, content, baseVersion, fm);
+      };
+
+      const opts: ExportTransactionOptions = {
+        provider,
+        scope: { key: "test", cloudId: "mock-cloud", resolved: {} },
+        resolvePath: (path) => {
+          if (path === "a.md") return { id: "a.md", version: 1 };
+          if (path === "b.md") return { id: "b.md", version: 1 };
+          return undefined;
+        },
+      };
+
+      const tx = new ExportTransaction(opts);
+      tx.stage([
+        commit("refs/heads/main", [
+          { type: "modify", path: "a.md", content: new TextEncoder().encode("a-updated") },
+          { type: "modify", path: "b.md", content: new TextEncoder().encode("b-updated") },
+        ]),
+      ]);
+
+      const result = await tx.commit();
+      expect(result.refs[0].ok).toBe(false);
+      expect(result.refs[0].error).toContain("network timeout");
+      expect(result.response).toContain("error refs/heads/main");
+    });
+
+    test("multi-ref failure reports per-ref errors", async () => {
+      const provider = createMockProvider({
+        entries: { "a.md": { content: "a", version: 1 } },
+      });
+      provider.armPushFailure(new Error("provider down"));
+
+      const opts: ExportTransactionOptions = {
+        provider,
+        scope: { key: "test", cloudId: "mock-cloud", resolved: {} },
+        resolvePath: (path) => (path === "a.md" ? { id: "a.md", version: 1 } : undefined),
+      };
+
+      const tx = new ExportTransaction(opts);
+      tx.stage([
+        commit("refs/heads/main", [{ type: "modify", path: "a.md", content: new TextEncoder().encode("updated") }]),
+        commit("refs/heads/feature", [{ type: "modify", path: "new.md", content: new TextEncoder().encode("new") }]),
+      ]);
+
+      const result = await tx.commit();
+      // First ref fails
+      const mainRef = result.refs.find((r) => r.ref === "refs/heads/main");
+      expect(mainRef?.ok).toBe(false);
+      expect(mainRef?.error).toContain("provider down");
+      // Second ref is aborted
+      const featureRef = result.refs.find((r) => r.ref === "refs/heads/feature");
+      expect(featureRef?.ok).toBe(false);
+      expect(featureRef?.error).toContain("aborted");
+      // Response contains both error lines
+      expect(result.response).toContain("error refs/heads/main");
+      expect(result.response).toContain("error refs/heads/feature");
+    });
+
+    test("validation failure prevents any mutations", async () => {
+      const provider = createMockProvider({
+        entries: { "a.md": { content: "a", version: 1 } },
+      });
+      // Override validate to reject content
+      (
+        provider as unknown as { validate: (c: string) => { valid: boolean; errors: string[]; warnings: string[] } }
+      ).validate = (content: string) => ({
+        valid: content !== "bad",
+        errors: content === "bad" ? ["content is bad"] : [],
+        warnings: [],
+      });
+
+      const opts: ExportTransactionOptions = {
+        provider,
+        scope: { key: "test", cloudId: "mock-cloud", resolved: {} },
+        resolvePath: (path) => (path === "a.md" ? { id: "a.md", version: 1 } : undefined),
+      };
+
+      const tx = new ExportTransaction(opts);
+      tx.stage([
+        commit("refs/heads/main", [{ type: "modify", path: "a.md", content: new TextEncoder().encode("bad") }]),
+      ]);
+
+      const result = await tx.commit();
+      expect(result.refs[0].ok).toBe(false);
+      expect(result.refs[0].error).toContain("validation failed");
+      // Provider was never called
+      expect(provider.calls.push).toBe(0);
+    });
+  });
+
+  describe("rollback", () => {
+    test("rollback discards staged operations", () => {
+      const tx = new ExportTransaction(makeOpts());
+      tx.stage([
+        commit("refs/heads/main", [{ type: "modify", path: "README.md", content: new TextEncoder().encode("v2") }]),
+      ]);
+      expect(tx.size).toBe(1);
+      tx.rollback();
+      expect(tx.size).toBe(0);
+    });
+
+    test("cannot commit after rollback", async () => {
+      const tx = new ExportTransaction(makeOpts());
+      tx.rollback();
+      await expect(tx.commit()).rejects.toThrow("already rolled back");
+    });
+
+    test("cannot rollback after commit", async () => {
+      const tx = new ExportTransaction(makeOpts());
+      tx.stage([commit("refs/heads/main", [])]);
+      await tx.commit();
+      expect(() => tx.rollback()).toThrow("already committed");
+    });
+
+    test("cannot commit twice", async () => {
+      const tx = new ExportTransaction(makeOpts());
+      tx.stage([commit("refs/heads/main", [])]);
+      await tx.commit();
+      await expect(tx.commit()).rejects.toThrow("already committed");
+    });
+  });
+
+  describe("response formatting", () => {
+    test("successful single-ref response", async () => {
+      const provider = createMockProvider({
+        entries: { "a.md": { content: "a", version: 1 } },
+      });
+      const opts = makeOpts({ provider, entries: { "a.md": { content: "a", version: 1 } } });
+      const tx = new ExportTransaction(opts);
+
+      tx.stage([
+        commit("refs/heads/main", [{ type: "modify", path: "a.md", content: new TextEncoder().encode("updated") }]),
+      ]);
+
+      const result = await tx.commit();
+      expect(result.response).toBe("ok refs/heads/main\n\n");
+    });
+
+    test("successful multi-ref response", async () => {
+      const provider = createMockProvider({
+        entries: { "a.md": { content: "a", version: 1 } },
+      });
+      const opts: ExportTransactionOptions = {
+        provider,
+        scope: { key: "test", cloudId: "mock-cloud", resolved: {} },
+        resolvePath: (path) => (path === "a.md" ? { id: "a.md", version: 1 } : undefined),
+      };
+      const tx = new ExportTransaction(opts);
+
+      tx.stage([
+        commit("refs/heads/main", [{ type: "modify", path: "a.md", content: new TextEncoder().encode("v2") }]),
+        commit("refs/heads/feature", [{ type: "modify", path: "new.md", content: new TextEncoder().encode("new") }]),
+      ]);
+
+      const result = await tx.commit();
+      expect(result.response).toContain("ok refs/heads/main");
+      expect(result.response).toContain("ok refs/heads/feature");
+      expect(result.response).toEndWith("\n\n");
+    });
+
+    test("error response includes reason", async () => {
+      const provider = createMockProvider({
+        entries: { "a.md": { content: "a", version: 2 } },
+      });
+      const opts: ExportTransactionOptions = {
+        provider,
+        scope: { key: "test", cloudId: "mock-cloud", resolved: {} },
+        resolvePath: (path) => (path === "a.md" ? { id: "a.md", version: 1 } : undefined),
+      };
+      const tx = new ExportTransaction(opts);
+
+      tx.stage([
+        commit("refs/heads/main", [{ type: "modify", path: "a.md", content: new TextEncoder().encode("conflict") }]),
+      ]);
+
+      const result = await tx.commit();
+      expect(result.response).toMatch(/^error refs\/heads\/main .+\n\n$/);
+    });
+  });
+});

--- a/packages/clone/src/engine/export-transaction.spec.ts
+++ b/packages/clone/src/engine/export-transaction.spec.ts
@@ -159,6 +159,40 @@ describe("ExportTransaction", () => {
       expect(errors).toHaveLength(1);
       expect(errors[0].error).toContain("provider does not support delete");
     });
+
+    test("coalesces create then modify of same path into single create", () => {
+      const tx = new ExportTransaction(makeOpts());
+      const errors = tx.stage([
+        commit("refs/heads/main", [{ type: "modify", path: "new.md", content: new TextEncoder().encode("v1") }]),
+        commit("refs/heads/main", [{ type: "modify", path: "new.md", content: new TextEncoder().encode("v2") }]),
+      ]);
+      expect(errors).toHaveLength(0);
+      expect(tx.size).toBe(1);
+    });
+
+    test("coalesces create then delete of same path into zero ops", () => {
+      const tx = new ExportTransaction(makeOpts());
+      const errors = tx.stage([
+        commit("refs/heads/main", [{ type: "modify", path: "new.md", content: new TextEncoder().encode("temp") }]),
+        commit("refs/heads/main", [{ type: "delete", path: "new.md" }]),
+      ]);
+      expect(errors).toHaveLength(0);
+      expect(tx.size).toBe(0);
+    });
+
+    test("strips frontmatter from create content", () => {
+      const provider = createMockProvider({ entries: {} });
+      const opts = makeOpts({ provider, entries: {} });
+      const tx = new ExportTransaction(opts);
+      const contentWithFm = "---\ntitle: My Page\nid: abc\n---\n\n# Hello";
+      const errors = tx.stage([
+        commit("refs/heads/main", [
+          { type: "modify", path: "new.md", content: new TextEncoder().encode(contentWithFm) },
+        ]),
+      ]);
+      expect(errors).toHaveLength(0);
+      expect(tx.size).toBe(1);
+    });
   });
 
   describe("commit — success", () => {
@@ -306,6 +340,61 @@ describe("ExportTransaction", () => {
       expect(provider.state.get("a.md")?.content).toBe("v4");
       expect(provider.state.get("a.md")?.version).toBe(4);
       expect(provider.calls.push).toBe(3);
+    });
+
+    test("create then modify same new path coalesces to single create with final content", async () => {
+      const provider = createMockProvider({ entries: {} });
+      const opts = makeOpts({ provider, entries: {} });
+      const tx = new ExportTransaction(opts);
+
+      tx.stage([
+        commit("refs/heads/main", [
+          { type: "modify", path: "new.md", content: new TextEncoder().encode("first draft") },
+        ]),
+        commit("refs/heads/main", [
+          { type: "modify", path: "new.md", content: new TextEncoder().encode("final draft") },
+        ]),
+      ]);
+
+      const result = await tx.commit();
+      expect(result.refs[0].ok).toBe(true);
+      expect(provider.calls.create).toBe(1);
+      // Find the created entry and verify it has the final content
+      const created = [...provider.state.values()].find((e) => e.content === "final draft");
+      expect(created).toBeDefined();
+    });
+
+    test("create path strips frontmatter before sending to provider", async () => {
+      const provider = createMockProvider({ entries: {} });
+      const opts = makeOpts({ provider, entries: {} });
+      const tx = new ExportTransaction(opts);
+
+      const contentWithFm = "---\ntitle: My Page\nid: abc\n---\n\n# Hello World";
+      tx.stage([
+        commit("refs/heads/main", [
+          { type: "modify", path: "new.md", content: new TextEncoder().encode(contentWithFm) },
+        ]),
+      ]);
+
+      const result = await tx.commit();
+      expect(result.refs[0].ok).toBe(true);
+      const created = [...provider.state.values()].find((e) => e.content === "# Hello World");
+      expect(created).toBeDefined();
+      expect(created?.content).not.toContain("---");
+    });
+
+    test("empty content (zero-byte) commits successfully", async () => {
+      const provider = createMockProvider({
+        entries: { "a.md": { content: "old", version: 1 } },
+      });
+      const opts = makeOpts({ provider, entries: { "a.md": { content: "old", version: 1 } } });
+      const tx = new ExportTransaction(opts);
+
+      tx.stage([commit("refs/heads/main", [{ type: "modify", path: "a.md", content: new Uint8Array(0) }])]);
+
+      const result = await tx.commit();
+      expect(result.refs[0].ok).toBe(true);
+      expect(provider.state.get("a.md")?.content).toBe("");
     });
   });
 
@@ -589,6 +678,24 @@ done
       const response = await handler(stdin);
       expect(response).toContain("ok refs/heads/main");
       expect(provider.state.get("README.md")?.content).toBe("# Updated");
+    });
+
+    test("deduplicates staging errors per ref (one error line per ref)", () => {
+      const tx = new ExportTransaction(makeOpts());
+      const errors = tx.stage([commit("refs/heads/main", [{ type: "deleteall" }, { type: "deleteall" }])]);
+      expect(errors).toHaveLength(2);
+      tx.rollback();
+
+      // Simulate what createExportHandler does: deduplicate per ref
+      const seen = new Set<string>();
+      const lines: string[] = [];
+      for (const s of errors) {
+        if (seen.has(s.ref)) continue;
+        seen.add(s.ref);
+        lines.push(`error ${s.ref} ${s.error}`);
+      }
+      expect(lines).toHaveLength(1);
+      expect(lines[0]).toContain("refs/heads/main");
     });
   });
 });

--- a/packages/clone/src/engine/export-transaction.spec.ts
+++ b/packages/clone/src/engine/export-transaction.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import { createMockProvider } from "./__tests__/mock-provider";
-import { ExportTransaction, type ExportTransactionOptions, type PathResolver } from "./export-transaction";
+import {
+  ExportTransaction,
+  type ExportTransactionOptions,
+  type PathResolver,
+  createExportHandler,
+} from "./export-transaction";
 import type { ParsedCommit } from "./fast-import-parser";
 
 function makeOpts(
@@ -98,10 +103,66 @@ describe("ExportTransaction", () => {
       expect(tx.refs).toContain("refs/heads/main");
       expect(tx.refs).toContain("refs/heads/feature");
     });
+
+    test("accepts empty content (zero-byte file)", () => {
+      const tx = new ExportTransaction(makeOpts());
+      const errors = tx.stage([
+        commit("refs/heads/main", [{ type: "modify", path: "README.md", content: new Uint8Array(0) }]),
+      ]);
+      expect(errors).toHaveLength(0);
+      expect(tx.size).toBe(1);
+    });
+
+    test("throws if stage() called after commit()", async () => {
+      const tx = new ExportTransaction(makeOpts());
+      tx.stage([commit("refs/heads/main", [])]);
+      await tx.commit();
+      expect(() => tx.stage([commit("refs/heads/main", [])])).toThrow("already committed");
+    });
+
+    test("throws if stage() called after rollback()", () => {
+      const tx = new ExportTransaction(makeOpts());
+      tx.rollback();
+      expect(() => tx.stage([commit("refs/heads/main", [])])).toThrow("already rolled back");
+    });
+
+    test("returns error when provider lacks push capability", () => {
+      const provider = createMockProvider({ entries: { "a.md": { content: "a", version: 1 } } });
+      (provider as unknown as Record<string, unknown>).push = undefined;
+      const opts = makeOpts({ provider, entries: { "a.md": { content: "a", version: 1 } } });
+      const tx = new ExportTransaction(opts);
+      const errors = tx.stage([
+        commit("refs/heads/main", [{ type: "modify", path: "a.md", content: new TextEncoder().encode("updated") }]),
+      ]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].error).toContain("provider does not support push");
+    });
+
+    test("returns error when provider lacks create capability", () => {
+      const provider = createMockProvider({ entries: {} });
+      (provider as unknown as Record<string, unknown>).create = undefined;
+      const opts = makeOpts({ provider, entries: {} });
+      const tx = new ExportTransaction(opts);
+      const errors = tx.stage([
+        commit("refs/heads/main", [{ type: "modify", path: "new.md", content: new TextEncoder().encode("new") }]),
+      ]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].error).toContain("provider does not support create");
+    });
+
+    test("returns error when provider lacks delete capability", () => {
+      const provider = createMockProvider({ entries: { "a.md": { content: "a", version: 1 } } });
+      (provider as unknown as Record<string, unknown>).delete = undefined;
+      const opts = makeOpts({ provider, entries: { "a.md": { content: "a", version: 1 } } });
+      const tx = new ExportTransaction(opts);
+      const errors = tx.stage([commit("refs/heads/main", [{ type: "delete", path: "a.md" }])]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0].error).toContain("provider does not support delete");
+    });
   });
 
   describe("commit — success", () => {
-    test("applies all staged modifications atomically", async () => {
+    test("applies all staged modifications", async () => {
       const provider = createMockProvider({
         entries: { "README.md": { content: "# Hello", version: 1 } },
       });
@@ -159,14 +220,100 @@ describe("ExportTransaction", () => {
       expect(result.refs[0].ok).toBe(true);
       expect(result.response).toBe("ok refs/heads/main\n\n");
     });
+
+    test("calls toRemote() to convert content before push", async () => {
+      const provider = createMockProvider({
+        entries: { "a.md": { content: "old", version: 1 } },
+      });
+      let convertedContent: string | undefined;
+      (provider as unknown as Record<string, unknown>).toRemote = (md: string) => {
+        convertedContent = `<html>${md}</html>`;
+        return convertedContent;
+      };
+      const opts = makeOpts({ provider, entries: { "a.md": { content: "old", version: 1 } } });
+      const tx = new ExportTransaction(opts);
+
+      tx.stage([
+        commit("refs/heads/main", [{ type: "modify", path: "a.md", content: new TextEncoder().encode("# Hello") }]),
+      ]);
+
+      await tx.commit();
+      expect(provider.state.get("a.md")?.content).toBe("<html># Hello</html>");
+    });
+
+    test("passes frontmatter to provider.push()", async () => {
+      const provider = createMockProvider({
+        entries: { "a.md": { content: "old", version: 1 } },
+      });
+      let receivedFrontmatter: Record<string, unknown> | undefined;
+      const originalPush = provider.push?.bind(provider);
+      (provider as unknown as Record<string, unknown>).push = async (
+        scope: unknown,
+        id: string,
+        content: string,
+        baseVersion: number,
+        frontmatter?: Record<string, unknown>,
+      ) => {
+        receivedFrontmatter = frontmatter;
+        return originalPush(scope as never, id, content, baseVersion, frontmatter);
+      };
+
+      const opts = makeOpts({ provider, entries: { "a.md": { content: "old", version: 1 } } });
+      const tx = new ExportTransaction(opts);
+
+      const contentWithFm = "---\ntitle: My Page\nid: a.md\n---\n\n# Hello";
+      tx.stage([
+        commit("refs/heads/main", [{ type: "modify", path: "a.md", content: new TextEncoder().encode(contentWithFm) }]),
+      ]);
+
+      await tx.commit();
+      expect(receivedFrontmatter).toEqual({ title: "My Page", id: "a.md" });
+    });
+
+    test("same-path across multiple commits tracks version updates", async () => {
+      const provider = createMockProvider({
+        entries: { "a.md": { content: "v1", version: 1 } },
+      });
+      const opts = makeOpts({ provider, entries: { "a.md": { content: "v1", version: 1 } } });
+      const tx = new ExportTransaction(opts);
+
+      tx.stage([
+        commit("refs/heads/main", [{ type: "modify", path: "a.md", content: new TextEncoder().encode("v2") }]),
+        commit("refs/heads/main", [{ type: "modify", path: "a.md", content: new TextEncoder().encode("v3") }]),
+      ]);
+
+      const result = await tx.commit();
+      expect(result.refs[0].ok).toBe(true);
+      expect(provider.state.get("a.md")?.content).toBe("v3");
+      expect(provider.state.get("a.md")?.version).toBe(3);
+    });
+
+    test("same-path modified across three commits tracks versions", async () => {
+      const provider = createMockProvider({
+        entries: { "a.md": { content: "v1", version: 1 } },
+      });
+      const opts = makeOpts({ provider, entries: { "a.md": { content: "v1", version: 1 } } });
+      const tx = new ExportTransaction(opts);
+
+      tx.stage([
+        commit("refs/heads/main", [{ type: "modify", path: "a.md", content: new TextEncoder().encode("v2") }]),
+        commit("refs/heads/main", [{ type: "modify", path: "a.md", content: new TextEncoder().encode("v3") }]),
+        commit("refs/heads/main", [{ type: "modify", path: "a.md", content: new TextEncoder().encode("v4") }]),
+      ]);
+
+      const result = await tx.commit();
+      expect(result.refs[0].ok).toBe(true);
+      expect(provider.state.get("a.md")?.content).toBe("v4");
+      expect(provider.state.get("a.md")?.version).toBe(4);
+      expect(provider.calls.push).toBe(3);
+    });
   });
 
   describe("commit — partial failure", () => {
-    test("version conflict fails entire transaction", async () => {
+    test("version conflict fails the ref", async () => {
       const provider = createMockProvider({
         entries: { "README.md": { content: "# Hello", version: 2 } },
       });
-      // resolvePath thinks version is 1, but provider has version 2
       const opts: ExportTransactionOptions = {
         provider,
         scope: { key: "test", cloudId: "mock-cloud", resolved: {} },
@@ -186,7 +333,7 @@ describe("ExportTransaction", () => {
       expect(result.response).toContain("error refs/heads/main");
     });
 
-    test("mid-stream failure aborts remaining operations", async () => {
+    test("mid-stream failure: succeeded refs reported ok, failed ref gets error", async () => {
       const provider = createMockProvider({
         entries: {
           "a.md": { content: "a", version: 1 },
@@ -194,14 +341,18 @@ describe("ExportTransaction", () => {
         },
       });
 
-      // Arm push failure after first successful push
       let pushCount = 0;
       const originalPush = provider.push?.bind(provider);
-      if (!originalPush) throw new Error("provider.push is undefined");
-      (provider as unknown as { push: typeof originalPush }).push = async (scope, id, content, baseVersion, fm) => {
+      (provider as unknown as Record<string, unknown>).push = async (
+        scope: unknown,
+        id: string,
+        content: string,
+        baseVersion: number,
+        fm?: Record<string, unknown>,
+      ) => {
         pushCount++;
         if (pushCount === 2) throw new Error("network timeout");
-        return originalPush(scope, id, content, baseVersion, fm);
+        return originalPush(scope as never, id, content, baseVersion, fm);
       };
 
       const opts: ExportTransactionOptions = {
@@ -216,19 +367,23 @@ describe("ExportTransaction", () => {
 
       const tx = new ExportTransaction(opts);
       tx.stage([
-        commit("refs/heads/main", [
+        commit("refs/heads/feature", [
           { type: "modify", path: "a.md", content: new TextEncoder().encode("a-updated") },
-          { type: "modify", path: "b.md", content: new TextEncoder().encode("b-updated") },
         ]),
+        commit("refs/heads/main", [{ type: "modify", path: "b.md", content: new TextEncoder().encode("b-updated") }]),
       ]);
 
       const result = await tx.commit();
-      expect(result.refs[0].ok).toBe(false);
-      expect(result.refs[0].error).toContain("network timeout");
-      expect(result.response).toContain("error refs/heads/main");
+      // First ref (feature) succeeded — all its ops were applied
+      const featureRef = result.refs.find((r) => r.ref === "refs/heads/feature");
+      expect(featureRef?.ok).toBe(true);
+      // Second ref (main) failed
+      const mainRef = result.refs.find((r) => r.ref === "refs/heads/main");
+      expect(mainRef?.ok).toBe(false);
+      expect(mainRef?.error).toContain("network timeout");
     });
 
-    test("multi-ref failure reports per-ref errors", async () => {
+    test("multi-ref failure reports per-ref errors with aborted for unattempted", async () => {
       const provider = createMockProvider({
         entries: { "a.md": { content: "a", version: 1 } },
       });
@@ -247,15 +402,12 @@ describe("ExportTransaction", () => {
       ]);
 
       const result = await tx.commit();
-      // First ref fails
       const mainRef = result.refs.find((r) => r.ref === "refs/heads/main");
       expect(mainRef?.ok).toBe(false);
       expect(mainRef?.error).toContain("provider down");
-      // Second ref is aborted
       const featureRef = result.refs.find((r) => r.ref === "refs/heads/feature");
       expect(featureRef?.ok).toBe(false);
       expect(featureRef?.error).toContain("aborted");
-      // Response contains both error lines
       expect(result.response).toContain("error refs/heads/main");
       expect(result.response).toContain("error refs/heads/feature");
     });
@@ -264,7 +416,6 @@ describe("ExportTransaction", () => {
       const provider = createMockProvider({
         entries: { "a.md": { content: "a", version: 1 } },
       });
-      // Override validate to reject content
       (
         provider as unknown as { validate: (c: string) => { valid: boolean; errors: string[]; warnings: string[] } }
       ).validate = (content: string) => ({
@@ -287,8 +438,13 @@ describe("ExportTransaction", () => {
       const result = await tx.commit();
       expect(result.refs[0].ok).toBe(false);
       expect(result.refs[0].error).toContain("validation failed");
-      // Provider was never called
       expect(provider.calls.push).toBe(0);
+    });
+
+    test("commit throws if stage had unresolved errors", async () => {
+      const tx = new ExportTransaction(makeOpts());
+      tx.stage([commit("refs/heads/main", [{ type: "deleteall" }])]);
+      await expect(tx.commit()).rejects.toThrow("unresolved stage errors");
     });
   });
 
@@ -379,6 +535,60 @@ describe("ExportTransaction", () => {
 
       const result = await tx.commit();
       expect(result.response).toMatch(/^error refs\/heads\/main .+\n\n$/);
+    });
+
+    test("error messages with newlines are sanitized", async () => {
+      const provider = createMockProvider({
+        entries: { "a.md": { content: "a", version: 1 } },
+      });
+      provider.armPushFailure(new Error("line1\nline2\rline3"));
+
+      const opts = makeOpts({ provider, entries: { "a.md": { content: "a", version: 1 } } });
+      const tx = new ExportTransaction(opts);
+
+      tx.stage([
+        commit("refs/heads/main", [{ type: "modify", path: "a.md", content: new TextEncoder().encode("updated") }]),
+      ]);
+
+      const result = await tx.commit();
+      const lines = result.response.split("\n");
+      // First line is the error, should be a single protocol line with no embedded newlines
+      expect(lines[0]).toMatch(/^error refs\/heads\/main line1 line2 line3$/);
+    });
+  });
+
+  describe("createExportHandler", () => {
+    test("parses fast-import stream and applies via transaction", async () => {
+      const provider = createMockProvider({
+        entries: { "README.md": { content: "old", version: 1 } },
+      });
+
+      const handler = createExportHandler({
+        provider,
+        scope: { key: "test", cloudId: "mock-cloud", resolved: {} },
+        resolvePath: (path) => (path === "README.md" ? { id: "README.md", version: 1 } : undefined),
+      });
+
+      // Minimal fast-import stream
+      const stream = `commit refs/heads/main
+committer Test <test@test.com> 1700000000 +0000
+data 11
+test commit
+M 100644 inline README.md
+data 9
+# Updated
+done
+`;
+      const stdin = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(stream));
+          controller.close();
+        },
+      });
+
+      const response = await handler(stdin);
+      expect(response).toContain("ok refs/heads/main");
+      expect(provider.state.get("README.md")?.content).toBe("# Updated");
     });
   });
 });

--- a/packages/clone/src/engine/export-transaction.ts
+++ b/packages/clone/src/engine/export-transaction.ts
@@ -80,6 +80,10 @@ export class ExportTransaction {
   private readonly refSet = new Set<string>();
   /** Tracks version updates from successful pushes/creates within this tx. */
   private readonly versionOverrides = new Map<string, { id: string; version: number }>();
+  /** Tracks paths staged as creates (index into this.staged) so later ops coalesce. */
+  private readonly pendingCreates = new Map<string, number>();
+  /** Indices of staged ops that were coalesced away (create+delete same path). */
+  private readonly removedIndices = new Set<number>();
   private committed = false;
   private rolledBack = false;
   private hasStageErrors = false;
@@ -122,6 +126,12 @@ export class ExportTransaction {
     }
 
     if (change.type === "delete") {
+      const pendingIdx = this.pendingCreates.get(change.path);
+      if (pendingIdx != null) {
+        this.removedIndices.add(pendingIdx);
+        this.pendingCreates.delete(change.path);
+        return undefined;
+      }
       if (!provider.delete) {
         return { ref, ok: false, error: "provider does not support delete" };
       }
@@ -139,12 +149,21 @@ export class ExportTransaction {
     }
 
     const decoded = new TextDecoder().decode(change.content);
+    const { content: body, fields } = stripFrontmatter(decoded);
+
+    // Coalesce with a pending create for the same path
+    const pendingIdx = this.pendingCreates.get(change.path);
+    if (pendingIdx != null) {
+      const pending = this.staged[pendingIdx] as StagedOp & { type: "create" };
+      pending.content = body;
+      return undefined;
+    }
+
     const entry = this.resolvePath(change.path);
     if (entry) {
       if (!provider.push) {
         return { ref, ok: false, error: "provider does not support push" };
       }
-      const { content: body, fields } = stripFrontmatter(decoded);
       this.staged.push({
         type: "modify",
         path: change.path,
@@ -159,15 +178,16 @@ export class ExportTransaction {
         return { ref, ok: false, error: "provider does not support create" };
       }
       const title = titleFromPath(change.path);
-      this.staged.push({ type: "create", path: change.path, title, content: decoded, ref });
+      this.pendingCreates.set(change.path, this.staged.length);
+      this.staged.push({ type: "create", path: change.path, title, content: body, ref });
     }
 
     return undefined;
   }
 
-  /** Number of staged operations. */
+  /** Number of staged operations (excludes coalesced-away ops). */
   get size(): number {
-    return this.staged.length;
+    return this.staged.length - this.removedIndices.size;
   }
 
   /** All refs touched by staged commits. */
@@ -189,21 +209,23 @@ export class ExportTransaction {
     if (this.hasStageErrors) throw new Error("ExportTransaction has unresolved stage errors");
     this.committed = true;
 
-    if (this.staged.length === 0) {
+    const ops = this.staged.filter((_, i) => !this.removedIndices.has(i));
+
+    if (ops.length === 0) {
       const ok = this.buildAllOk();
       return { refs: ok, response: this.formatResponse(ok) };
     }
 
-    const preErrors = this.preValidate();
+    const preErrors = this.preValidate(ops);
     if (preErrors.length > 0) {
-      const refs = this.buildRefStatuses(preErrors, 0);
+      const refs = this.buildRefStatuses(preErrors, 0, ops);
       return { refs, response: this.formatResponse(refs) };
     }
 
     let appliedCount = 0;
     const errors: Array<{ ref: string; error: string }> = [];
 
-    for (const op of this.staged) {
+    for (const op of ops) {
       const result = await this.applyOp(op);
       if (result) {
         errors.push({ ref: op.ref, error: result });
@@ -213,7 +235,7 @@ export class ExportTransaction {
     }
 
     if (errors.length > 0) {
-      const refs = this.buildRefStatuses(errors, appliedCount);
+      const refs = this.buildRefStatuses(errors, appliedCount, ops);
       return { refs, response: this.formatResponse(refs) };
     }
 
@@ -228,13 +250,13 @@ export class ExportTransaction {
     this.staged.length = 0;
   }
 
-  private preValidate(): Array<{ ref: string; error: string }> {
+  private preValidate(ops: StagedOp[]): Array<{ ref: string; error: string }> {
     const errors: Array<{ ref: string; error: string }> = [];
     const { provider } = this.opts;
 
     if (!provider.validate) return errors;
 
-    for (const op of this.staged) {
+    for (const op of ops) {
       if (op.type === "delete") continue;
       const result = provider.validate(op.content);
       if (!result.valid) {
@@ -289,16 +311,19 @@ export class ExportTransaction {
     return [...this.refSet].map((ref) => ({ ref, ok: true }));
   }
 
-  private buildRefStatuses(errors: Array<{ ref: string; error: string }>, appliedCount: number): RefStatus[] {
+  private buildRefStatuses(
+    errors: Array<{ ref: string; error: string }>,
+    appliedCount: number,
+    ops: StagedOp[],
+  ): RefStatus[] {
     const errorsByRef = new Map<string, string>();
     for (const { ref, error } of errors) {
       if (!errorsByRef.has(ref)) errorsByRef.set(ref, error);
     }
 
-    // Determine which refs had ALL their ops applied successfully
     const refOpIndices = new Map<string, number[]>();
-    for (let i = 0; i < this.staged.length; i++) {
-      const ref = this.staged[i].ref;
+    for (let i = 0; i < ops.length; i++) {
+      const ref = ops[i].ref;
       const existing = refOpIndices.get(ref);
       if (existing) {
         existing.push(i);
@@ -366,7 +391,13 @@ export function createExportHandler(
     const stageErrors = tx.stage(commits);
     if (stageErrors.length > 0) {
       tx.rollback();
-      const lines = stageErrors.map((s) => `error ${s.ref} ${sanitizeProtocolError(s.error ?? "staging failed")}`);
+      const seen = new Set<string>();
+      const lines: string[] = [];
+      for (const s of stageErrors) {
+        if (seen.has(s.ref)) continue;
+        seen.add(s.ref);
+        lines.push(`error ${s.ref} ${sanitizeProtocolError(s.error ?? "staging failed")}`);
+      }
       return `${lines.join("\n")}\n\n`;
     }
 

--- a/packages/clone/src/engine/export-transaction.ts
+++ b/packages/clone/src/engine/export-transaction.ts
@@ -1,17 +1,22 @@
 /**
- * Transactional export — stages parsed commits and applies them atomically.
+ * Export transaction — stages parsed fast-import commits, applies them
+ * sequentially to a RemoteProvider, and returns per-ref ok/error status.
  *
- * Solves #1312: if handleExport throws mid-stream after writing N commits,
- * the provider has N mutations applied but git's local refs show none advanced.
+ * Solves #1312: on partial failure, git refs are only advanced for
+ * operations that succeeded. Refs whose operations failed (or were never
+ * attempted) get error lines, so `git push` reports accurate per-ref
+ * status and the next push re-attempts only what failed.
  *
- * Strategy: parse all commits from the fast-import stream first, validate
- * them against the provider, then apply all-or-nothing. On partial failure,
- * no mutations are visible to the provider and per-ref error lines are
- * returned so git can report accurate status.
+ * NOT atomic: providers are remote REST APIs that don't support
+ * multi-mutation rollback. Successful mutations persist even when later
+ * operations fail. The invariant is ref-consistency: a ref is reported
+ * "ok" only if ALL its provider mutations succeeded.
  */
 
 import type { PushResult, RemoteProvider, ResolvedScope } from "../providers/provider";
 import type { ParsedChange, ParsedCommit } from "./fast-import-parser";
+import { parseFastImport } from "./fast-import-parser";
+import { stripFrontmatter } from "./frontmatter";
 
 export interface ExportOp {
   type: "modify" | "create" | "delete";
@@ -47,33 +52,47 @@ export interface ExportTransactionOptions {
 }
 
 type StagedOp =
-  | { type: "modify"; path: string; id: string; content: string; baseVersion: number; ref: string }
+  | {
+      type: "modify";
+      path: string;
+      id: string;
+      content: string;
+      baseVersion: number;
+      ref: string;
+      frontmatter: Record<string, unknown> | null;
+    }
   | { type: "create"; path: string; title: string; content: string; parentId?: string; ref: string }
   | { type: "delete"; path: string; id: string; ref: string };
 
 /**
- * ExportTransaction stages commits parsed from a fast-import stream
- * and applies them atomically to a RemoteProvider.
+ * Stages commits parsed from a fast-import stream and applies them
+ * sequentially to a RemoteProvider, returning per-ref ok/error status.
  *
  * Usage:
  *   const tx = new ExportTransaction(opts);
- *   tx.stage(commits);          // parse + validate
- *   const result = await tx.commit();  // apply all-or-nothing
- *   // or: tx.rollback();       // discard without side effects
+ *   tx.stage(commits);
+ *   const result = await tx.commit();
+ *   // or: tx.rollback();
  */
 export class ExportTransaction {
   private readonly opts: ExportTransactionOptions;
   private readonly staged: StagedOp[] = [];
   private readonly refSet = new Set<string>();
+  /** Tracks version updates from successful pushes/creates within this tx. */
+  private readonly versionOverrides = new Map<string, { id: string; version: number }>();
   private committed = false;
   private rolledBack = false;
+  private hasStageErrors = false;
 
   constructor(opts: ExportTransactionOptions) {
     this.opts = opts;
   }
 
-  /** Stage parsed commits for atomic application. Returns validation errors (if any). */
+  /** Stage parsed commits. Returns validation errors (if any). */
   stage(commits: ParsedCommit[]): RefStatus[] {
+    if (this.committed) throw new Error("ExportTransaction already committed");
+    if (this.rolledBack) throw new Error("ExportTransaction already rolled back");
+
     const errors: RefStatus[] = [];
 
     for (const commit of commits) {
@@ -81,20 +100,32 @@ export class ExportTransaction {
 
       for (const change of commit.changes) {
         const result = this.stageChange(change, commit.ref);
-        if (result) errors.push(result);
+        if (result) {
+          errors.push(result);
+          this.hasStageErrors = true;
+        }
       }
     }
 
     return errors;
   }
 
+  private resolvePath(path: string): { id: string; version: number } | undefined {
+    return this.versionOverrides.get(path) ?? this.opts.resolvePath(path);
+  }
+
   private stageChange(change: ParsedChange, ref: string): RefStatus | undefined {
+    const { provider } = this.opts;
+
     if (change.type === "deleteall") {
       return { ref, ok: false, error: "deleteall not supported in export transactions" };
     }
 
     if (change.type === "delete") {
-      const entry = this.opts.resolvePath(change.path);
+      if (!provider.delete) {
+        return { ref, ok: false, error: "provider does not support delete" };
+      }
+      const entry = this.resolvePath(change.path);
       if (!entry) {
         return { ref, ok: false, error: `cannot delete unknown path: ${change.path}` };
       }
@@ -103,24 +134,32 @@ export class ExportTransaction {
     }
 
     // type === "modify"
-    const content = change.content ? new TextDecoder().decode(change.content) : undefined;
-    if (!content) {
+    if (change.content === undefined) {
       return { ref, ok: false, error: `no content for path: ${change.path}` };
     }
 
-    const entry = this.opts.resolvePath(change.path);
+    const decoded = new TextDecoder().decode(change.content);
+    const entry = this.resolvePath(change.path);
     if (entry) {
+      if (!provider.push) {
+        return { ref, ok: false, error: "provider does not support push" };
+      }
+      const { content: body, fields } = stripFrontmatter(decoded);
       this.staged.push({
         type: "modify",
         path: change.path,
         id: entry.id,
-        content,
+        content: body,
         baseVersion: entry.version,
         ref,
+        frontmatter: fields,
       });
     } else {
+      if (!provider.create) {
+        return { ref, ok: false, error: "provider does not support create" };
+      }
       const title = titleFromPath(change.path);
-      this.staged.push({ type: "create", path: change.path, title, content, ref });
+      this.staged.push({ type: "create", path: change.path, title, content: decoded, ref });
     }
 
     return undefined;
@@ -137,31 +176,31 @@ export class ExportTransaction {
   }
 
   /**
-   * Apply all staged operations atomically.
+   * Apply all staged operations sequentially.
    *
-   * Validates all operations against the provider first. If any validation
-   * fails, none are applied. On success, all are applied in order. If an
-   * apply-time error occurs (network, conflict), the transaction halts and
-   * returns per-ref errors for the failed ref and "aborted" for remaining refs.
+   * Pre-validates content against the provider. If any validation fails,
+   * no operations are applied. On an apply-time error, the transaction
+   * halts: refs whose operations all succeeded are reported "ok", the
+   * failed ref gets the error, and remaining refs are "aborted".
    */
   async commit(): Promise<ExportTransactionResult> {
     if (this.committed) throw new Error("ExportTransaction already committed");
     if (this.rolledBack) throw new Error("ExportTransaction already rolled back");
+    if (this.hasStageErrors) throw new Error("ExportTransaction has unresolved stage errors");
     this.committed = true;
 
     if (this.staged.length === 0) {
-      return { refs: this.buildAllOk(), response: this.formatResponse(this.buildAllOk()) };
+      const ok = this.buildAllOk();
+      return { refs: ok, response: this.formatResponse(ok) };
     }
 
-    // Phase 1: pre-validate (provider.validate if available)
     const preErrors = this.preValidate();
     if (preErrors.length > 0) {
-      const refs = this.buildRefStatuses(preErrors);
+      const refs = this.buildRefStatuses(preErrors, 0);
       return { refs, response: this.formatResponse(refs) };
     }
 
-    // Phase 2: apply all operations
-    const applied: StagedOp[] = [];
+    let appliedCount = 0;
     const errors: Array<{ ref: string; error: string }> = [];
 
     for (const op of this.staged) {
@@ -170,17 +209,16 @@ export class ExportTransaction {
         errors.push({ ref: op.ref, error: result });
         break;
       }
-      applied.push(op);
+      appliedCount++;
     }
 
     if (errors.length > 0) {
-      // Rollback applied operations
-      await this.rollbackApplied(applied);
-      const refs = this.buildRefStatuses(errors);
+      const refs = this.buildRefStatuses(errors, appliedCount);
       return { refs, response: this.formatResponse(refs) };
     }
 
-    return { refs: this.buildAllOk(), response: this.formatResponse(this.buildAllOk()) };
+    const ok = this.buildAllOk();
+    return { refs: ok, response: this.formatResponse(ok) };
   }
 
   /** Discard all staged operations without applying. */
@@ -214,13 +252,26 @@ export class ExportTransaction {
       switch (op.type) {
         case "modify": {
           if (!provider.push) return "provider does not support push";
-          const result: PushResult = await provider.push(scope, op.id, op.content, op.baseVersion);
+          const content = provider.toRemote?.(op.content) ?? op.content;
+          const currentVersion = this.versionOverrides.get(op.path)?.version ?? op.baseVersion;
+          const result: PushResult = await provider.push(
+            scope,
+            op.id,
+            content,
+            currentVersion,
+            op.frontmatter ?? undefined,
+          );
           if (!result.ok) return result.error ?? "push failed";
+          if (result.newVersion != null) {
+            this.versionOverrides.set(op.path, { id: op.id, version: result.newVersion });
+          }
           return undefined;
         }
         case "create": {
           if (!provider.create) return "provider does not support create";
-          await provider.create(scope, op.parentId, op.title, op.content);
+          const content = provider.toRemote?.(op.content) ?? op.content;
+          const entry = await provider.create(scope, op.parentId, op.title, content);
+          this.versionOverrides.set(op.path, { id: entry.id, version: entry.version });
           return undefined;
         }
         case "delete": {
@@ -234,38 +285,39 @@ export class ExportTransaction {
     }
   }
 
-  /**
-   * Best-effort rollback of already-applied operations.
-   *
-   * This is a compensating transaction — it cannot guarantee atomicity at the
-   * provider level (the provider may not support undo). The caller should log
-   * rollback failures but not throw, since the primary error is more important.
-   */
-  private async rollbackApplied(_applied: StagedOp[]): Promise<void> {
-    // Rollback is best-effort. For providers that support versioning,
-    // a future enhancement could restore the previous version. For now,
-    // the key invariant is that we DON'T advance git refs on failure —
-    // the next push will re-attempt the same operations, which either
-    // succeed (idempotent) or surface the conflict for manual resolution.
-    //
-    // This satisfies the #1312 requirement: git refs are consistent with
-    // what the provider acknowledges, even if the provider has partial state.
-  }
-
   private buildAllOk(): RefStatus[] {
     return [...this.refSet].map((ref) => ({ ref, ok: true }));
   }
 
-  private buildRefStatuses(errors: Array<{ ref: string; error: string }>): RefStatus[] {
+  private buildRefStatuses(errors: Array<{ ref: string; error: string }>, appliedCount: number): RefStatus[] {
     const errorsByRef = new Map<string, string>();
     for (const { ref, error } of errors) {
       if (!errorsByRef.has(ref)) errorsByRef.set(ref, error);
     }
 
+    // Determine which refs had ALL their ops applied successfully
+    const refOpIndices = new Map<string, number[]>();
+    for (let i = 0; i < this.staged.length; i++) {
+      const ref = this.staged[i].ref;
+      const existing = refOpIndices.get(ref);
+      if (existing) {
+        existing.push(i);
+      } else {
+        refOpIndices.set(ref, [i]);
+      }
+    }
+
+    const completedRefs = new Set<string>();
+    for (const [ref, indices] of refOpIndices) {
+      if (!errorsByRef.has(ref) && indices.every((i) => i < appliedCount)) {
+        completedRefs.add(ref);
+      }
+    }
+
     return [...this.refSet].map((ref) => {
+      if (completedRefs.has(ref)) return { ref, ok: true };
       const error = errorsByRef.get(ref);
       if (error) return { ref, ok: false, error };
-      // Refs not yet processed when the error occurred are "aborted"
       return { ref, ok: false, error: "aborted: earlier operation failed" };
     });
   }
@@ -273,12 +325,64 @@ export class ExportTransaction {
   /** Format per-ref status into the git remote helper protocol response. */
   private formatResponse(refs: RefStatus[]): string {
     if (refs.length === 0) return "\n";
-    const lines = refs.map((r) => (r.ok ? `ok ${r.ref}` : `error ${r.ref} ${r.error ?? "unknown"}`));
+    const lines = refs.map((r) =>
+      r.ok ? `ok ${r.ref}` : `error ${r.ref} ${sanitizeProtocolError(r.error ?? "unknown")}`,
+    );
     return `${lines.join("\n")}\n\n`;
   }
+}
+
+function sanitizeProtocolError(msg: string): string {
+  return msg.replace(/[\r\n]+/g, " ").trim();
 }
 
 function titleFromPath(path: string): string {
   const base = path.split("/").pop() ?? path;
   return base.replace(/\.md$/, "");
+}
+
+/**
+ * Create a handleExport function suitable for RemoteHelperHandlers.
+ *
+ * Reads the full fast-import stream, parses it, stages all commits into
+ * an ExportTransaction, and applies them to the provider.
+ */
+export function createExportHandler(
+  opts: ExportTransactionOptions,
+): (stdin: ReadableStream<Uint8Array>) => Promise<string> {
+  return async (stdin: ReadableStream<Uint8Array>): Promise<string> => {
+    const chunks: Uint8Array[] = [];
+    const reader = stdin.getReader();
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+
+    const raw = concatUint8Arrays(chunks);
+    const commits = parseFastImport(raw);
+
+    const tx = new ExportTransaction(opts);
+    const stageErrors = tx.stage(commits);
+    if (stageErrors.length > 0) {
+      tx.rollback();
+      const lines = stageErrors.map((s) => `error ${s.ref} ${sanitizeProtocolError(s.error ?? "staging failed")}`);
+      return `${lines.join("\n")}\n\n`;
+    }
+
+    const result = await tx.commit();
+    return result.response;
+  };
+}
+
+function concatUint8Arrays(arrays: Uint8Array[]): Uint8Array {
+  if (arrays.length === 1) return arrays[0];
+  const total = arrays.reduce((sum, a) => sum + a.length, 0);
+  const result = new Uint8Array(total);
+  let offset = 0;
+  for (const a of arrays) {
+    result.set(a, offset);
+    offset += a.length;
+  }
+  return result;
 }

--- a/packages/clone/src/engine/export-transaction.ts
+++ b/packages/clone/src/engine/export-transaction.ts
@@ -1,0 +1,284 @@
+/**
+ * Transactional export — stages parsed commits and applies them atomically.
+ *
+ * Solves #1312: if handleExport throws mid-stream after writing N commits,
+ * the provider has N mutations applied but git's local refs show none advanced.
+ *
+ * Strategy: parse all commits from the fast-import stream first, validate
+ * them against the provider, then apply all-or-nothing. On partial failure,
+ * no mutations are visible to the provider and per-ref error lines are
+ * returned so git can report accurate status.
+ */
+
+import type { PushResult, RemoteProvider, ResolvedScope } from "../providers/provider";
+import type { ParsedChange, ParsedCommit } from "./fast-import-parser";
+
+export interface ExportOp {
+  type: "modify" | "create" | "delete";
+  ref: string;
+  path: string;
+  content?: string;
+  /** Provider entry ID (for modify/delete). */
+  id?: string;
+  /** Base version for optimistic concurrency (modify). */
+  baseVersion?: number;
+}
+
+export interface RefStatus {
+  ref: string;
+  ok: boolean;
+  error?: string;
+}
+
+export interface ExportTransactionResult {
+  /** Per-ref status (ok or error with reason). */
+  refs: RefStatus[];
+  /** Protocol response string (ok/error lines + blank terminator). */
+  response: string;
+}
+
+export type PathResolver = (path: string) => { id: string; version: number } | undefined;
+
+export interface ExportTransactionOptions {
+  provider: RemoteProvider;
+  scope: ResolvedScope;
+  /** Resolve a file path to a cached entry ID + version (for modify/delete). */
+  resolvePath: PathResolver;
+}
+
+type StagedOp =
+  | { type: "modify"; path: string; id: string; content: string; baseVersion: number; ref: string }
+  | { type: "create"; path: string; title: string; content: string; parentId?: string; ref: string }
+  | { type: "delete"; path: string; id: string; ref: string };
+
+/**
+ * ExportTransaction stages commits parsed from a fast-import stream
+ * and applies them atomically to a RemoteProvider.
+ *
+ * Usage:
+ *   const tx = new ExportTransaction(opts);
+ *   tx.stage(commits);          // parse + validate
+ *   const result = await tx.commit();  // apply all-or-nothing
+ *   // or: tx.rollback();       // discard without side effects
+ */
+export class ExportTransaction {
+  private readonly opts: ExportTransactionOptions;
+  private readonly staged: StagedOp[] = [];
+  private readonly refSet = new Set<string>();
+  private committed = false;
+  private rolledBack = false;
+
+  constructor(opts: ExportTransactionOptions) {
+    this.opts = opts;
+  }
+
+  /** Stage parsed commits for atomic application. Returns validation errors (if any). */
+  stage(commits: ParsedCommit[]): RefStatus[] {
+    const errors: RefStatus[] = [];
+
+    for (const commit of commits) {
+      this.refSet.add(commit.ref);
+
+      for (const change of commit.changes) {
+        const result = this.stageChange(change, commit.ref);
+        if (result) errors.push(result);
+      }
+    }
+
+    return errors;
+  }
+
+  private stageChange(change: ParsedChange, ref: string): RefStatus | undefined {
+    if (change.type === "deleteall") {
+      return { ref, ok: false, error: "deleteall not supported in export transactions" };
+    }
+
+    if (change.type === "delete") {
+      const entry = this.opts.resolvePath(change.path);
+      if (!entry) {
+        return { ref, ok: false, error: `cannot delete unknown path: ${change.path}` };
+      }
+      this.staged.push({ type: "delete", path: change.path, id: entry.id, ref });
+      return undefined;
+    }
+
+    // type === "modify"
+    const content = change.content ? new TextDecoder().decode(change.content) : undefined;
+    if (!content) {
+      return { ref, ok: false, error: `no content for path: ${change.path}` };
+    }
+
+    const entry = this.opts.resolvePath(change.path);
+    if (entry) {
+      this.staged.push({
+        type: "modify",
+        path: change.path,
+        id: entry.id,
+        content,
+        baseVersion: entry.version,
+        ref,
+      });
+    } else {
+      const title = titleFromPath(change.path);
+      this.staged.push({ type: "create", path: change.path, title, content, ref });
+    }
+
+    return undefined;
+  }
+
+  /** Number of staged operations. */
+  get size(): number {
+    return this.staged.length;
+  }
+
+  /** All refs touched by staged commits. */
+  get refs(): string[] {
+    return [...this.refSet];
+  }
+
+  /**
+   * Apply all staged operations atomically.
+   *
+   * Validates all operations against the provider first. If any validation
+   * fails, none are applied. On success, all are applied in order. If an
+   * apply-time error occurs (network, conflict), the transaction halts and
+   * returns per-ref errors for the failed ref and "aborted" for remaining refs.
+   */
+  async commit(): Promise<ExportTransactionResult> {
+    if (this.committed) throw new Error("ExportTransaction already committed");
+    if (this.rolledBack) throw new Error("ExportTransaction already rolled back");
+    this.committed = true;
+
+    if (this.staged.length === 0) {
+      return { refs: this.buildAllOk(), response: this.formatResponse(this.buildAllOk()) };
+    }
+
+    // Phase 1: pre-validate (provider.validate if available)
+    const preErrors = this.preValidate();
+    if (preErrors.length > 0) {
+      const refs = this.buildRefStatuses(preErrors);
+      return { refs, response: this.formatResponse(refs) };
+    }
+
+    // Phase 2: apply all operations
+    const applied: StagedOp[] = [];
+    const errors: Array<{ ref: string; error: string }> = [];
+
+    for (const op of this.staged) {
+      const result = await this.applyOp(op);
+      if (result) {
+        errors.push({ ref: op.ref, error: result });
+        break;
+      }
+      applied.push(op);
+    }
+
+    if (errors.length > 0) {
+      // Rollback applied operations
+      await this.rollbackApplied(applied);
+      const refs = this.buildRefStatuses(errors);
+      return { refs, response: this.formatResponse(refs) };
+    }
+
+    return { refs: this.buildAllOk(), response: this.formatResponse(this.buildAllOk()) };
+  }
+
+  /** Discard all staged operations without applying. */
+  rollback(): void {
+    if (this.committed) throw new Error("ExportTransaction already committed");
+    this.rolledBack = true;
+    this.staged.length = 0;
+  }
+
+  private preValidate(): Array<{ ref: string; error: string }> {
+    const errors: Array<{ ref: string; error: string }> = [];
+    const { provider } = this.opts;
+
+    if (!provider.validate) return errors;
+
+    for (const op of this.staged) {
+      if (op.type === "delete") continue;
+      const result = provider.validate(op.content);
+      if (!result.valid) {
+        errors.push({ ref: op.ref, error: `validation failed: ${result.errors.join("; ")}` });
+      }
+    }
+
+    return errors;
+  }
+
+  private async applyOp(op: StagedOp): Promise<string | undefined> {
+    const { provider, scope } = this.opts;
+
+    try {
+      switch (op.type) {
+        case "modify": {
+          if (!provider.push) return "provider does not support push";
+          const result: PushResult = await provider.push(scope, op.id, op.content, op.baseVersion);
+          if (!result.ok) return result.error ?? "push failed";
+          return undefined;
+        }
+        case "create": {
+          if (!provider.create) return "provider does not support create";
+          await provider.create(scope, op.parentId, op.title, op.content);
+          return undefined;
+        }
+        case "delete": {
+          if (!provider.delete) return "provider does not support delete";
+          await provider.delete(scope, op.id);
+          return undefined;
+        }
+      }
+    } catch (err) {
+      return err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  /**
+   * Best-effort rollback of already-applied operations.
+   *
+   * This is a compensating transaction — it cannot guarantee atomicity at the
+   * provider level (the provider may not support undo). The caller should log
+   * rollback failures but not throw, since the primary error is more important.
+   */
+  private async rollbackApplied(_applied: StagedOp[]): Promise<void> {
+    // Rollback is best-effort. For providers that support versioning,
+    // a future enhancement could restore the previous version. For now,
+    // the key invariant is that we DON'T advance git refs on failure —
+    // the next push will re-attempt the same operations, which either
+    // succeed (idempotent) or surface the conflict for manual resolution.
+    //
+    // This satisfies the #1312 requirement: git refs are consistent with
+    // what the provider acknowledges, even if the provider has partial state.
+  }
+
+  private buildAllOk(): RefStatus[] {
+    return [...this.refSet].map((ref) => ({ ref, ok: true }));
+  }
+
+  private buildRefStatuses(errors: Array<{ ref: string; error: string }>): RefStatus[] {
+    const errorsByRef = new Map<string, string>();
+    for (const { ref, error } of errors) {
+      if (!errorsByRef.has(ref)) errorsByRef.set(ref, error);
+    }
+
+    return [...this.refSet].map((ref) => {
+      const error = errorsByRef.get(ref);
+      if (error) return { ref, ok: false, error };
+      // Refs not yet processed when the error occurred are "aborted"
+      return { ref, ok: false, error: "aborted: earlier operation failed" };
+    });
+  }
+
+  /** Format per-ref status into the git remote helper protocol response. */
+  private formatResponse(refs: RefStatus[]): string {
+    if (refs.length === 0) return "\n";
+    const lines = refs.map((r) => (r.ok ? `ok ${r.ref}` : `error ${r.ref} ${r.error ?? "unknown"}`));
+    return `${lines.join("\n")}\n\n`;
+  }
+}
+
+function titleFromPath(path: string): string {
+  const base = path.split("/").pop() ?? path;
+  return base.replace(/\.md$/, "");
+}

--- a/packages/clone/src/index.ts
+++ b/packages/clone/src/index.ts
@@ -10,3 +10,4 @@ export * from "./engine/frontmatter";
 export * from "./engine/pull";
 export * from "./engine/push";
 export * from "./engine/remote-protocol";
+export * from "./engine/export-transaction";


### PR DESCRIPTION
## Summary
- Adds `ExportTransaction` class (`packages/clone/src/engine/export-transaction.ts`) that stages parsed fast-import commits and applies them to a `RemoteProvider` with per-ref error reporting
- NOT atomic: providers are remote REST APIs without multi-mutation rollback. The invariant is **ref-consistency** — a ref is reported "ok" only if ALL its provider mutations succeeded; refs whose operations failed get `error <ref> <reason>` protocol lines
- Solves #1312: on partial failure, `git push` reports accurate per-ref status and the next push re-attempts only what failed
- Pre-validates content via `provider.validate()` before any mutations; halts-and-reports on first apply-time error
- Tracks transaction-local version state (`versionOverrides`) so the same path can be modified across multiple commits within one fast-import stream without version conflicts
- Coalesces path lifecycle within a stream: create→modify becomes single create with final content; create→delete cancels out
- Strips YAML frontmatter from both modify and create paths before sending to provider
- Deduplicates staging errors per ref so git remote-helper gets exactly one status line per ref

## Test plan
- [x] 42 tests covering staging (modify/create/delete/deleteall/multi-ref/coalescing/frontmatter), commit success (version tracking, empty content, create+modify coalescing), partial-failure (version conflict, mid-stream network error, multi-ref abort), validation gating, rollback semantics, protocol response formatting, and `createExportHandler` integration
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun test` — full suite pass (1 pre-existing flaky in control/use-daemon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)