### PR TITLE
ci: pin setup-bun to 1.3.14 to avoid tags API 401s (fixes #2208)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: needs.detect.outputs.docs_only != 'true'
         with:
-          bun-version: latest
+          bun-version: "1.3.14"
       - if: needs.detect.outputs.docs_only != 'true'
         run: bun install --frozen-lockfile
       - if: needs.detect.outputs.docs_only != 'true'
@@ -150,7 +150,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: needs.detect.outputs.docs_only != 'true'
         with:
-          bun-version: latest
+          bun-version: "1.3.14"
       - if: needs.detect.outputs.docs_only != 'true'
         run: bun install --frozen-lockfile
       # Enforces per-file + global coverage thresholds from scripts/check-coverage.ts.
@@ -217,7 +217,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: needs.detect.outputs.docs_only != 'true'
         with:
-          bun-version: latest
+          bun-version: "1.3.14"
       - if: needs.detect.outputs.docs_only != 'true'
         run: bun install --frozen-lockfile
       - name: Install unbuffer (expect)
@@ -262,7 +262,7 @@ jobs:
       - uses: oven-sh/setup-bun@v2
         if: needs.detect.outputs.docs_only != 'true'
         with:
-          bun-version: latest
+          bun-version: "1.3.14"
       - if: needs.detect.outputs.docs_only != 'true'
         run: bun install --frozen-lockfile
       - if: needs.detect.outputs.docs_only != 'true'


### PR DESCRIPTION
## Summary
- `bun-version: latest` in `ci.yml` causes `setup-bun@v2` to query `https://api.github.com/repos/oven-sh/bun/git/refs/tags` on every CI run
- This intermittently 401s ("Bad credentials") due to GITHUB_TOKEN rate-limiting, blocking otherwise-green PRs with an indistinguishable failure
- Pin all 4 `setup-bun@v2` steps in `ci.yml` to `"1.3.14"` — the same version already used in `macos-matrix.yml`

## Test plan
- [ ] CI on this PR itself passes without any setup-bun 401 failure
- [ ] All 4 jobs (`check`, `coverage`, `pty-test`, `build`) use the pinned version

🤖 Generated with [Claude Code](https://claude.com/claude-code)