### PR TITLE
fix(clone): accept SHA-256 hashes in parseMarksFile (fixes #1263)

### DIFF
--- a/packages/clone/src/engine/fast-import-writer.spec.ts
+++ b/packages/clone/src/engine/fast-import-writer.spec.ts
@@ -425,10 +425,39 @@ describe("marks file parsing", () => {
     expect(m.get(42)).toBe("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
   });
 
+  test("parseMarksFile reads SHA-256 (64-char) hashes", () => {
+    const sha256 = "a".repeat(64);
+    const text = `:1 ${sha256}\n`;
+    const m = parseMarksFile(text);
+    expect(m.get(1)).toBe(sha256);
+  });
+
+  test("parseMarksFile handles mixed SHA-1 and SHA-256 marks", () => {
+    const sha1 = "b".repeat(40);
+    const sha256 = "c".repeat(64);
+    const text = `:1 ${sha1}\n:2 ${sha256}\n`;
+    const m = parseMarksFile(text);
+    expect(m.size).toBe(2);
+    expect(m.get(1)).toBe(sha1);
+    expect(m.get(2)).toBe(sha256);
+  });
+
   test("parseMarksFile ignores malformed lines", () => {
     const m = parseMarksFile("garbage\n:7 short\n:9 cccccccccccccccccccccccccccccccccccccccc\n");
     expect(m.size).toBe(1);
     expect(m.get(9)).toBe("cccccccccccccccccccccccccccccccccccccccc");
+  });
+
+  test("parseMarksFile rejects hashes between 41 and 63 chars", () => {
+    const bad50 = "d".repeat(50);
+    const m = parseMarksFile(`:1 ${bad50}\n`);
+    expect(m.size).toBe(0);
+  });
+
+  test("parseMarksFile rejects hashes longer than 64 chars", () => {
+    const bad70 = "e".repeat(70);
+    const m = parseMarksFile(`:1 ${bad70}\n`);
+    expect(m.size).toBe(0);
   });
 
   test("formatMarksFile round-trips through parseMarksFile in mark order", () => {

--- a/packages/clone/src/engine/fast-import-writer.ts
+++ b/packages/clone/src/engine/fast-import-writer.ts
@@ -139,13 +139,14 @@ function concatBytes(parts: Uint8Array[]): Uint8Array {
 }
 
 /**
- * Parse a marks file (`:<mark> <sha1>` per line) into a Map.
- * Lines that don't match the format are ignored.
+ * Parse a marks file (`:<mark> <sha>` per line) into a Map.
+ * Accepts both SHA-1 (40-char) and SHA-256 (64-char) hashes.
  */
 export function parseMarksFile(text: string): Map<number, string> {
   const out = new Map<number, string>();
   for (const line of text.split("\n")) {
-    const m = line.match(/^:(\d+)\s+([0-9a-f]{40})$/);
+    const m = line.match(/^:(\d+)\s+([0-9a-f]{40}(?:[0-9a-f]{24})?)$/);
+
     if (m) out.set(Number.parseInt(m[1], 10), m[2]);
   }
   return out;


### PR DESCRIPTION
## Summary
- `parseMarksFile` regex was hardcoded to `{40}` hex chars, silently rejecting every line in SHA-256 object-format repos (64-char hashes)
- Changed regex to `([0-9a-f]{40}(?:[0-9a-f]{24})?)` — accepts exactly 40 or 64 hex chars, rejecting intermediate lengths
- Added tests for SHA-256 hashes, mixed SHA-1/SHA-256 marks files, and rejection of invalid lengths (50-char, 70-char)

## Test plan
- [x] Existing `parseMarksFile` tests still pass (SHA-1 hashes, malformed lines, round-trip)
- [x] New test: 64-char SHA-256 hash is accepted
- [x] New test: mixed SHA-1 + SHA-256 marks file parses both entries
- [x] New test: 50-char hash is rejected (not a valid git hash length)
- [x] New test: 70-char hash is rejected
- [x] `bun typecheck`, `bun lint`, `bun test` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)