### PR TITLE
fix(clone): handle encoding header in fast-import commit blocks (fixes #1279)

### DIFF
--- a/packages/clone/src/engine/fast-import-parser.spec.ts
+++ b/packages/clone/src/engine/fast-import-parser.spec.ts
@@ -182,6 +182,35 @@ describe("parseFastImport", () => {
     if (c?.type === "modify") expect(asText(c.content)).toBe("A");
   });
 
+  test("encoding header in commit is ignored without desync", () => {
+    const stream =
+      "blob\nmark :1\ndata 5\nhello\n" +
+      "commit refs/heads/main\nmark :2\ncommitter A <a@a> 0 +0000\nencoding UTF-8\ndata 6\nhello\n\n" +
+      "M 100644 :1 a.md\n\n";
+
+    const [commit] = parseFastImport(stream);
+    expect(commit?.message).toBe("hello\n");
+    expect(commit?.committer).toBe("A <a@a> 0 +0000");
+    expect(commit?.changes).toHaveLength(1);
+    expect(commit?.changes[0]?.type).toBe("modify");
+  });
+
+  test("encoding header does not desync subsequent commits", () => {
+    const stream =
+      "blob\nmark :1\ndata 1\nA\n" +
+      "commit refs/heads/main\nmark :2\ncommitter C <c@c> 0 +0000\nencoding UTF-8\ndata 5\nfirst\n" +
+      "M 100644 :1 a.md\n\n" +
+      "blob\nmark :3\ndata 1\nB\n" +
+      "commit refs/heads/main\nmark :4\ncommitter C <c@c> 0 +0000\nencoding ISO-8859-1\ndata 6\nsecond\n" +
+      "from :2\nM 100644 :3 b.md\n\n";
+
+    const commits = parseFastImport(stream);
+    expect(commits).toHaveLength(2);
+    expect(commits[0]?.message).toBe("first");
+    expect(commits[1]?.message).toBe("second");
+    expect(commits[1]?.from).toBe(":2");
+  });
+
   test("tag directives are swallowed, not treated as commits", () => {
     const stream =
       "tag v1\nfrom :2\noriginal-oid deadbeef\ntagger T <t@t> 0 +0000\ndata 8\nreleased\n" +

--- a/packages/clone/src/engine/fast-import-parser.ts
+++ b/packages/clone/src/engine/fast-import-parser.ts
@@ -101,6 +101,8 @@ function parseCommit(
     } else if (p.startsWith("committer ")) {
       readLine(bytes, state);
       commit.committer = p.slice("committer ".length);
+    } else if (p.startsWith("encoding ")) {
+      readLine(bytes, state);
     } else if (p === "data" || p.startsWith("data ")) {
       commit.message = readDataString(bytes, state);
     } else if (p.startsWith("from ")) {


### PR DESCRIPTION
## Summary
- Add `encoding` branch to the commit header loop in `parseFastImport` that reads and discards the `encoding <charset>` line emitted by `git fast-export --reencode=yes`
- Without this, the parser breaks out of the header loop early, producing empty commit messages and desyncing the stream for subsequent commits

## Test plan
- [x] New test: single commit with `encoding UTF-8` header — message and changes parsed correctly
- [x] New test: two commits with different encoding headers — no stream desync, both messages and `from` ref parsed correctly
- [x] All 30 fast-import parser tests pass
- [x] Full suite: 7636 pass, 1 pre-existing flaky failure (stress.spec.ts, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)