### PR TITLE
test(clone): add unit test for git-init sanity-check error path (fixes #2228)

### DIFF
--- a/packages/clone/src/engine/clone.spec.ts
+++ b/packages/clone/src/engine/clone.spec.ts
@@ -121,6 +121,15 @@ describe("clone", () => {
     await expect(clone({ targetDir, provider, scope })).rejects.toThrow("partial clone");
   });
 
+  test("throws when git init does not create .git", async () => {
+    const provider = makeProvider();
+    const scope = makeScope();
+
+    await expect(clone({ targetDir, provider, scope, _gitInit: () => {} })).rejects.toThrow(
+      'git init did not create .git at "',
+    );
+  });
+
   test("clones pages into a new git repo with frontmatter", async () => {
     const entries = [
       makeEntry({ id: "p1", title: "Page One", version: 1, content: "# One\nBody one" }),

--- a/packages/clone/src/engine/clone.spec.ts
+++ b/packages/clone/src/engine/clone.spec.ts
@@ -125,7 +125,7 @@ describe("clone", () => {
     const provider = makeProvider();
     const scope = makeScope();
 
-    await expect(clone({ targetDir, provider, scope, _gitInit: () => {} })).rejects.toThrow(
+    await expect(clone({ targetDir, provider, scope, onProgress: () => {}, _gitInit: () => {} })).rejects.toThrow(
       'git init did not create .git at "',
     );
   });

--- a/packages/clone/src/engine/clone.ts
+++ b/packages/clone/src/engine/clone.ts
@@ -234,7 +234,7 @@ export async function clone(opts: CloneOptions): Promise<CloneResult> {
   }
   cleanEnv.GIT_CEILING_DIRECTORIES = dirname(absTarget);
   const gitOpts = { cwd: absTarget, stdio: "pipe" as const, env: cleanEnv };
-  const gitInitFn = opts._gitInit ?? ((cwd, env) => execSync("git init", { cwd, stdio: "pipe", env }));
+  const gitInitFn = opts._gitInit ?? ((_cwd, _env) => execSync("git init", gitOpts));
   gitInitFn(absTarget, cleanEnv);
   if (!existsSync(join(absTarget, ".git"))) {
     throw new Error(

--- a/packages/clone/src/engine/clone.ts
+++ b/packages/clone/src/engine/clone.ts
@@ -30,6 +30,8 @@ export interface CloneOptions {
   limit?: number;
   /** Maximum hierarchy depth to clone. 0 = unlimited. Depth 1 = root pages only. */
   depth?: number;
+  /** Override git init execution (for testing). */
+  _gitInit?: (cwd: string, env: Record<string, string>) => void;
 }
 
 export interface CloneResult {
@@ -232,7 +234,8 @@ export async function clone(opts: CloneOptions): Promise<CloneResult> {
   }
   cleanEnv.GIT_CEILING_DIRECTORIES = dirname(absTarget);
   const gitOpts = { cwd: absTarget, stdio: "pipe" as const, env: cleanEnv };
-  execSync("git init", gitOpts);
+  const gitInitFn = opts._gitInit ?? ((cwd, env) => execSync("git init", { cwd, stdio: "pipe", env }));
+  gitInitFn(absTarget, cleanEnv);
   if (!existsSync(join(absTarget, ".git"))) {
     throw new Error(
       `git init did not create .git at "${absTarget}". This usually means git resolved to a parent repository. Check GIT_DIR / GIT_WORK_TREE env vars.`,


### PR DESCRIPTION
## Summary
- Adds an optional `_gitInit` dependency injection hook to `CloneOptions` so tests can override the `execSync("git init", ...)` call
- Adds a test that passes a no-op `_gitInit`, causing the post-init sanity check to fire and throw the expected error (`"git init did not create .git at..."`)
- No changes to production behavior — the DI hook defaults to the real `execSync("git init", ...)` call when not provided

## Test plan
- [ ] `bun test packages/clone/src/engine/clone.spec.ts` — 20 tests pass, including the new `"throws when git init does not create .git"` test
- [ ] `bun typecheck` — clean
- [ ] `bun lint` — clean (auto-formatted the test)
- [ ] Full `bun test` — 7636 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)