### PR TITLE
fix(shim): add core.bare probes around hook-based teardown paths (fixes #1365)

### DIFF
--- a/packages/core/src/worktree-shim.spec.ts
+++ b/packages/core/src/worktree-shim.spec.ts
@@ -508,6 +508,49 @@ describe("cleanupWorktree", () => {
     expect(infoMsgs.some((m) => m.startsWith("Deleted branch"))).toBe(false);
     expect(errorMsgs.some((m) => m.includes("branch still exists"))).toBe(true);
   });
+
+  test("hook teardown: probes core.bare before/after and heals on flip", () => {
+    tmpDir = makeTmpDir();
+    writeFileSync(
+      join(tmpDir, WORKTREE_CONFIG_FILENAME),
+      JSON.stringify({ worktree: { setup: "true", teardown: "rm -rf $MCX_PATH" } }),
+    );
+    mkdirSync(join(tmpDir, ".git"), { recursive: true });
+
+    const execCalls: string[][] = [];
+    const exec = mock((cmd: string[]) => {
+      execCalls.push(cmd);
+      if (cmd.includes("status") && cmd.includes("--porcelain")) return { stdout: "", stderr: "", exitCode: 0 };
+      if (cmd.includes("--show-current")) return { stdout: "feat/branch", stderr: "", exitCode: 0 };
+      // Teardown hook succeeds (worktree path won't exist on disk → existsSync false)
+      if (cmd[0] === "sh") return { stdout: "", stderr: "", exitCode: 0 };
+      // Simulate core.bare flipped to true by the hook
+      if (cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset")) {
+        const hookIdx = execCalls.findIndex((c) => c[0] === "sh");
+        if (hookIdx >= 0 && execCalls.indexOf(cmd) > hookIdx) {
+          return { stdout: "true", stderr: "", exitCode: 0 };
+        }
+        return { stdout: "", stderr: "", exitCode: 1 };
+      }
+      if (cmd.includes("--unset") && cmd.includes("core.bare")) return { stdout: "", stderr: "", exitCode: 0 };
+      if (cmd.includes("-d")) return { stdout: "", stderr: "", exitCode: 0 };
+      if (cmd.includes("rev-parse") && cmd.includes("--verify")) return { stdout: "", stderr: "", exitCode: 1 };
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const printErrors: string[] = [];
+    const printError = mock((msg: string) => printErrors.push(msg));
+    const printInfos: string[] = [];
+    const printInfo = mock((msg: string) => printInfos.push(msg));
+
+    cleanupWorktree("my-wt", join(tmpDir, ".claude", "worktrees", "my-wt"), { exec, printError, printInfo }, tmpDir);
+
+    expect(printErrors.some((m) => m.includes("[shim] core.bare flipped to true by: teardown hook"))).toBe(true);
+    expect(printInfos.some((m) => m.includes("Removed core.bare key after teardown hook"))).toBe(true);
+    // Verify probe ran before the hook
+    const hookIdx = execCalls.findIndex((c) => c[0] === "sh");
+    const isCoreBareRead = (c: string[]) => c.includes("config") && c.includes("core.bare") && !c.includes("--unset");
+    expect(execCalls.slice(0, hookIdx).some(isCoreBareRead)).toBe(true);
+  });
 });
 
 // ── getDefaultBranch ──
@@ -748,6 +791,73 @@ describe("pruneWorktrees", () => {
       expect(unsetCalls.length).toBeGreaterThanOrEqual(1);
       // Verify the batch guard printed the fix (via printInfo, not printError)
       expect(printInfos.some((m) => m.includes("batch worktree prune"))).toBe(true);
+    } finally {
+      rmSync(repoRoot, { recursive: true });
+    }
+  });
+
+  test("hook teardown: probes core.bare before/after and heals on flip", async () => {
+    const repoRoot = makeTmpDir();
+    try {
+      writeFileSync(join(repoRoot, ".git"), "gitdir: /some/repo\n");
+      writeFileSync(
+        join(repoRoot, WORKTREE_CONFIG_FILENAME),
+        JSON.stringify({ worktree: { setup: "true", teardown: "rm -rf $MCX_PATH" } }),
+      );
+      const wt1 = join(repoRoot, ".claude", "worktrees", "feat-hook");
+
+      const porcelainOutput = [
+        `worktree ${repoRoot}`,
+        "HEAD abc123",
+        "branch refs/heads/main",
+        "",
+        `worktree ${wt1}`,
+        "HEAD def456",
+        "branch refs/heads/claude/feat-hook",
+        "",
+      ].join("\n");
+
+      const execCalls: string[][] = [];
+      const exec = mock((cmd: string[]) => {
+        execCalls.push(cmd);
+        if (cmd.includes("list") && cmd.includes("--porcelain"))
+          return { stdout: porcelainOutput, stderr: "", exitCode: 0 };
+        if (cmd.includes("symbolic-ref")) return { stdout: "refs/remotes/origin/main", stderr: "", exitCode: 0 };
+        if (cmd.includes("--merged")) return { stdout: "  main\n  claude/feat-hook\n", stderr: "", exitCode: 0 };
+        if (cmd.includes("status")) return { stdout: "", stderr: "", exitCode: 0 };
+        // Hook succeeds (path won't exist on disk → existsSync false)
+        if (cmd[0] === "sh") return { stdout: "", stderr: "", exitCode: 0 };
+        if (cmd.includes("branch") && cmd.includes("-d")) return { stdout: "", stderr: "", exitCode: 0 };
+        if (cmd.includes("rev-parse") && cmd.includes("--verify")) return { stdout: "", stderr: "", exitCode: 1 };
+        // Simulate core.bare flipped to true by the hook
+        if (cmd.includes("config") && cmd.includes("core.bare") && !cmd.includes("--unset")) {
+          const hookIdx = execCalls.findIndex((c) => c[0] === "sh");
+          if (hookIdx >= 0 && execCalls.indexOf(cmd) > hookIdx) {
+            return { stdout: "true", stderr: "", exitCode: 0 };
+          }
+          return { stdout: "", stderr: "", exitCode: 1 };
+        }
+        if (cmd.includes("--unset") && cmd.includes("core.bare")) return { stdout: "", stderr: "", exitCode: 0 };
+        return { stdout: "", stderr: "", exitCode: 0 };
+      });
+      const printErrors: string[] = [];
+      const printError = mock((msg: string) => printErrors.push(msg));
+      const printInfos: string[] = [];
+      const printInfo = mock((msg: string) => printInfos.push(msg));
+
+      const result = await pruneWorktrees({
+        repoRoot,
+        activeWorktrees: new Set(),
+        deps: { exec, printError, printInfo },
+      });
+
+      expect(result.pruned).toBe(1);
+      expect(printErrors.some((m) => m.includes("[shim] core.bare flipped to true by: teardown hook"))).toBe(true);
+      expect(printInfos.some((m) => m.includes("Removed core.bare key after teardown hook"))).toBe(true);
+      // Verify probe ran before the hook
+      const hookIdx = execCalls.findIndex((c) => c[0] === "sh");
+      const isCoreBareRead = (c: string[]) => c.includes("config") && c.includes("core.bare") && !c.includes("--unset");
+      expect(execCalls.slice(0, hookIdx).some(isCoreBareRead)).toBe(true);
     } finally {
       rmSync(repoRoot, { recursive: true });
     }

--- a/packages/core/src/worktree-shim.ts
+++ b/packages/core/src/worktree-shim.ts
@@ -230,7 +230,19 @@ export function cleanupWorktree(worktree: string, cwd: string, deps: WorktreeShi
 
     if (hasWorktreeHooks(wtConfig) && wtConfig.teardown) {
       const hookEnv = buildHookEnv({ branch: worktree, path: worktreePath, cwd: effectiveRoot });
+      const bareBeforeHook = isCoreBareSet(effectiveRoot, (cmd) => deps.exec(cmd));
       const { exitCode: hookExit, stderr: hookStderr } = deps.exec(["sh", "-c", wtConfig.teardown], { env: hookEnv });
+      if (!bareBeforeHook && isCoreBareSet(effectiveRoot, (cmd) => deps.exec(cmd))) {
+        deps.printError(
+          `[shim] core.bare flipped to true by: teardown hook for ${worktreePath} (repo=${effectiveRoot}) — see #1330`,
+        );
+      }
+      const hookBareResult = ensureCoreBareUnset(effectiveRoot, (cmd) => deps.exec(cmd));
+      if (hookBareResult === "removed") {
+        deps.printInfo("Removed core.bare key after teardown hook");
+      } else if (hookBareResult === "fallback") {
+        deps.printError("[shim] core.bare key could not be removed after teardown hook — set to false as fallback");
+      }
       if (hookExit === 0 && !existsSync(worktreePath)) {
         deps.printInfo(`Removed worktree via hook: ${worktreePath}`);
         deleteIfSafeToDelete(branch, effectiveRoot, deps);
@@ -523,7 +535,19 @@ export async function pruneWorktrees(opts: WorktreePruneOptions): Promise<Worktr
     // Remove worktree
     if (hasWorktreeHooks(wtConfig) && wtConfig.teardown) {
       const hookEnv = buildHookEnv({ branch: wtName, path: wt.path, cwd: repoRoot });
+      const bareBeforePruneHook = isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd));
       const { exitCode: hookExit, stderr: hookStderr } = deps.exec(["sh", "-c", wtConfig.teardown], { env: hookEnv });
+      if (!bareBeforePruneHook && isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd))) {
+        deps.printError(
+          `[shim] core.bare flipped to true by: teardown hook for ${wt.path} (repo=${repoRoot}) — see #1330`,
+        );
+      }
+      const pruneHookBareResult = ensureCoreBareUnset(repoRoot, (cmd) => deps.exec(cmd));
+      if (pruneHookBareResult === "removed") {
+        deps.printInfo("Removed core.bare key after teardown hook");
+      } else if (pruneHookBareResult === "fallback") {
+        deps.printError("[shim] core.bare key could not be removed after teardown hook — set to false as fallback");
+      }
       if (hookExit === 0 && !existsSync(wt.path)) {
         deps.printInfo(`Removed worktree via hook: ${wt.path}`);
         pruned++;


### PR DESCRIPTION
## Summary
- PR #1363 added `isCoreBareSet()` before/after probes to the shim's direct git operations (worktree add/remove, branch -d) but missed the **hook-based teardown paths** in `cleanupWorktree` and `pruneWorktrees`.
- Adds `isCoreBareSet()` probes + `ensureCoreBareUnset()` around hook execution in both paths, matching the pattern used by `removeWorktreeWithVerification`. If a teardown hook internally runs `git worktree remove` and flips `core.bare`, the flip is now detected, attributed, and healed.
- Adds two tests covering the hook-teardown probe path for both `cleanupWorktree` and `pruneWorktrees`.

## Test plan
- [x] New test: `cleanupWorktree` hook teardown probes `core.bare` before/after and heals on flip
- [x] New test: `pruneWorktrees` hook teardown probes `core.bare` before/after and heals on flip
- [x] All existing tests pass (34/34 in worktree-shim.spec.ts, 7637/7637 full suite)
- [x] Typecheck, lint, coverage all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)