### PR TITLE
test(harness): lower pollUntil default 5000→1500, dedupe local copies (#2273)

### DIFF
--- a/packages/command/src/commands/serve.spec.ts
+++ b/packages/command/src/commands/serve.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { ALIAS_SERVER_NAME } from "@mcp-cli/core";
 import type { IpcMethod } from "@mcp-cli/core";
+import { pollUntil } from "../../../../test/harness";
 import { _resetJqStateForTesting } from "../jq/index";
 import { SERVE_SIZE_OK, SERVE_SIZE_TRUNCATE } from "../jq/jq-support";
 import {
@@ -356,18 +357,6 @@ describe("computeToolsFingerprint", () => {
 });
 
 // -- startToolListPoller --
-
-/**
- * Poll condition until it returns true or deadline passes.
- * Never use a fixed sleep to wait for async side effects — poll instead.
- */
-async function pollUntil(condition: () => boolean | undefined | null | number, timeoutMs = 5000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (!condition() && Date.now() < deadline) {
-    await Bun.sleep(POLL_MS);
-  }
-  if (!condition()) throw new Error(`pollUntil: condition not met within ${timeoutMs}ms`);
-}
 
 describe("startToolListPoller", () => {
   test("sends notification when tool list changes", async () => {

--- a/packages/control/src/hooks/use-keyboard-plans.spec.ts
+++ b/packages/control/src/hooks/use-keyboard-plans.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { Plan, ServerStatus } from "@mcp-cli/core";
 import type { Key } from "ink";
+import { pollUntil } from "../../../../test/harness";
 import {
   type ExpandedPlanKey,
   type PlansNav,
@@ -12,8 +13,6 @@ import {
   hasCapability,
   isPlanReadOnly,
 } from "./use-keyboard-plans";
-
-const TICK_MS = 1;
 
 function makePlan(overrides: Partial<Plan> & { id: string }): Plan {
   return {
@@ -108,15 +107,6 @@ function makeNav(overrides: Partial<PlansNav> = {}): PlansNav & { state: Record<
     state,
     ...overrides,
   };
-}
-
-/** Poll for a condition with a deadline instead of fixed delay. */
-async function pollUntil(fn: () => boolean, timeoutMs = 1000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (fn()) return;
-    await Bun.sleep(TICK_MS);
-  }
 }
 
 describe("handlePlansInput", () => {

--- a/packages/daemon/src/automation-dispatcher.spec.ts
+++ b/packages/daemon/src/automation-dispatcher.spec.ts
@@ -1,21 +1,10 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import type { AutomationAction, AutomationConfig, LockedAutomation, MonitorEvent } from "@mcp-cli/core";
+import { pollUntil } from "../../../test/harness";
 import { AutomationDispatcher } from "./automation-dispatcher";
 import { EventBus } from "./event-bus";
 
-const POLL_INTERVAL_MS = 2;
-const POLL_DEADLINE_MS = 2_000;
 const SETTLE_MS = 20;
-
-async function pollUntil(predicate: () => boolean, deadline = POLL_DEADLINE_MS): Promise<void> {
-  const start = performance.now();
-  while (!predicate()) {
-    if (performance.now() - start > deadline) {
-      throw new Error(`pollUntil timed out after ${deadline}ms`);
-    }
-    await Bun.sleep(POLL_INTERVAL_MS);
-  }
-}
 
 function makeEvent(overrides: Partial<MonitorEvent> = {}): MonitorEvent {
   return {

--- a/packages/daemon/src/claude-session/ws-server-enrichment.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server-enrichment.spec.ts
@@ -146,7 +146,7 @@ describe("session.result/session.idle enrichment (integration)", () => {
       ws.send(assistantMessage(sessionId)); // accumulates 150 tokens
       ws.send(resultMessage(sessionId, "task done", 0.042, 3));
 
-      await pollUntil(() => events.idle.length >= 1, 5000);
+      await pollUntil(() => events.idle.length >= 1);
     } finally {
       ws.close();
     }
@@ -197,7 +197,7 @@ describe("session.result/session.idle enrichment (integration)", () => {
       ws.send(systemInitMessage(sessionId));
       ws.send(resultMessage(sessionId, longResult, 0.001, 1));
 
-      await pollUntil(() => events.idle.length >= 1, 5000);
+      await pollUntil(() => events.idle.length >= 1);
     } finally {
       ws.close();
     }
@@ -243,7 +243,7 @@ describe("session.result/session.idle enrichment (integration)", () => {
       ws.send(systemInitMessage(sessionId));
       ws.send(resultMessage(sessionId, "line one\nline two\nline three", 0.001, 1));
 
-      await pollUntil(() => events.idle.length >= 1, 5000);
+      await pollUntil(() => events.idle.length >= 1);
     } finally {
       ws.close();
     }

--- a/packages/daemon/src/monitor-runtime.spec.ts
+++ b/packages/daemon/src/monitor-runtime.spec.ts
@@ -3,6 +3,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { silentLogger } from "@mcp-cli/core";
 import type { MonitorEvent } from "@mcp-cli/core";
+import { pollUntil } from "../../../test/harness";
 import { testOptions } from "../../../test/test-options";
 import { EventBus } from "./event-bus";
 import { MONITOR_RESTART_POLICY, type MonitorAlias, MonitorRuntime, getMonitorBackoff } from "./monitor-runtime";
@@ -15,16 +16,6 @@ function writeMonitorScript(dir: string, name: string, source: string): string {
   const path = join(dir, `${name}.ts`);
   writeFileSync(path, source);
   return path;
-}
-
-async function pollUntil(condition: () => boolean, timeoutMs = 5_000, intervalMs = 50): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (!condition() && Date.now() < deadline) {
-    await Bun.sleep(intervalMs);
-  }
-  if (!condition()) {
-    throw new Error(`pollUntil timed out after ${timeoutMs}ms`);
-  }
 }
 
 // ── getMonitorBackoff ──

--- a/packages/daemon/src/server-pool.spec.ts
+++ b/packages/daemon/src/server-pool.spec.ts
@@ -1707,7 +1707,7 @@ describe("disconnect kills stdio child processes (#940)", () => {
 
       await pool.disconnect("sleeper");
 
-      await pollUntil(() => !isAlive(pid), 10_000);
+      await pollUntil(() => !isAlive(pid));
     } finally {
       forceKill(pid);
     }
@@ -1745,7 +1745,7 @@ describe("disconnect kills stdio child processes (#940)", () => {
 
       await pool.closeAll();
 
-      await pollUntil(() => !isAlive(pid), 10_000);
+      await pollUntil(() => !isAlive(pid));
     } finally {
       forceKill(pid);
     }
@@ -1821,7 +1821,7 @@ describe("disconnect kills stdio child processes (#940)", () => {
       // killPid would never be called, leaving the process alive.
       await pool.disconnect("sleeper");
 
-      await pollUntil(() => !isAlive(pid), 10_000);
+      await pollUntil(() => !isAlive(pid));
     } finally {
       forceKill(pid);
     }

--- a/scripts/rules/fixtures/poll-until-headroom__clean.fixture.ts
+++ b/scripts/rules/fixtures/poll-until-headroom__clean.fixture.ts
@@ -3,15 +3,30 @@
  * @expect 0
  * @path packages/daemon/src/server-pool.spec.ts
  *
- * pollUntil calls with explicit timeouts comfortably below 5000ms — no violation.
+ * No explicit timeout (relies on the safe 1500ms harness default), an explicit
+ * timeout comfortably below the watchdog, or a larger deadline that still sits
+ * under a file-level setDefaultTimeout — no violation.
  */
 
+import { setDefaultTimeout } from "bun:test";
 import { pollUntil } from "../../../../test/harness";
 
 declare const condition: () => boolean;
 declare const events: { type: string }[];
 
-// explicit timeout well under 5000 — clean
+// slow suite raises the watchdog to 30s, so a 10s poll still has headroom
+setDefaultTimeout(30_000);
+
+// no second argument — relies on the 1500ms default — clean (idiomatic form)
+await pollUntil(condition);
+await pollUntil(() => events.some((e) => e.type === "done"));
+
+// multi-line lambda, no timeout — clean
+await pollUntil(
+  () => events.some((e) => e.type === "session:init"),
+);
+
+// explicit timeout well under the watchdog — clean
 await pollUntil(condition, 4000);
 await pollUntil(() => true, 3_000);
 await pollUntil(async () => condition(), 2000);
@@ -22,3 +37,6 @@ await pollUntil(
   () => events.some((e) => e.type === "session:init"),
   4000,
 );
+
+// 10s deadline under the 30s file-level setDefaultTimeout — clean (has headroom)
+await pollUntil(() => events.some((e) => e.type === "ready"), 10_000);

--- a/scripts/rules/fixtures/poll-until-headroom__flagged.fixture.ts
+++ b/scripts/rules/fixtures/poll-until-headroom__flagged.fixture.ts
@@ -3,8 +3,8 @@
  * @expect 4
  * @path packages/daemon/src/ipc-server.spec.ts
  *
- * pollUntil with no timeout (relying on the 5000ms default) or an explicit
- * timeout >= 5000ms should all be flagged.
+ * An explicit deadline ≥ the 5000ms watchdog can never fire its own error —
+ * the watchdog kills the test first. All of these should be flagged.
  */
 
 import { pollUntil } from "../../../../test/harness";
@@ -12,16 +12,17 @@ import { pollUntil } from "../../../../test/harness";
 declare const condition: () => boolean;
 declare const events: { type: string }[];
 
-// no second argument — default 5000ms — flag
-await pollUntil(condition);
-
 // explicit timeout exactly equal to Bun's watchdog — flag
 await pollUntil(() => true, 5000);
 
 // underscore separator, still 5000 — flag
 await pollUntil(async () => condition(), 5_000);
 
-// multi-line lambda, no timeout — flag
+// well above the watchdog (the real-world server-pool case) — flag
+await pollUntil(() => !condition(), 10_000);
+
+// multi-line lambda with a deadline above the watchdog — flag
 await pollUntil(
-  () => events.some((e) => e.type === "session:init")
+  () => events.some((e) => e.type === "session:init"),
+  6000,
 );

--- a/scripts/rules/poll-until-headroom.rule.ts
+++ b/scripts/rules/poll-until-headroom.rule.ts
@@ -1,22 +1,45 @@
 /**
  * Rule: poll-until-headroom
  *
- * `pollUntil` defaults to a 5000ms timeout — exactly Bun's per-test watchdog.
- * Under CI resource pressure, the watchdog fires before `pollUntil`'s own
- * descriptive error, producing a flake with a useless message.
+ * The invariant: a `pollUntil` deadline must sit safely *below* Bun's 5000ms
+ * per-test watchdog, so pollUntil's own descriptive error wins the race over
+ * the generic "test timed out". A deadline at or above the watchdog can never
+ * fire — the watchdog kills the test first, producing a flake with a useless
+ * message under CI pressure.
  *
- * Flag:
- *   (a) `pollUntil(fn)` — no explicit timeout, relying on the 5000ms default
- *   (b) `pollUntil(fn, N)` where N ≥ 5000 — at or above the watchdog limit
+ * Flag `pollUntil(fn, N)` where N ≥ the file's effective test watchdog — a
+ * deadline at or above it can never fire its own error. The watchdog is Bun's
+ * 5000ms default, or the file's `setDefaultTimeout(N)` when larger: a slow
+ * suite that raises the test timeout to 30s may legitimately poll for 10s.
  *
- * A condition should resolve in milliseconds, not seconds. Give the poll a
- * short deadline (hundreds of ms to ~1s), never one that flirts with the
- * test timeout.
+ * Calls with *no* explicit timeout are NOT flagged: the harness default is
+ * 1500ms (#2273), well under the watchdog, so the bare call is the correct,
+ * idiomatic form. Don't sprinkle per-test timeouts — fix the default once and
+ * rely on it (Bun's own discipline: a sane default + file-level
+ * `setDefaultTimeout` for genuinely-slow suites, never per-call deadlines).
+ * If a condition genuinely needs ≥5000ms, raise the file's `setDefaultTimeout`
+ * above it and pass the matching explicit deadline — a deadline ≥ the test
+ * timeout is otherwise a no-op.
  */
 
 import type { CheckRule } from "./_engine/rule";
 
-const BUN_DEFAULT_TIMEOUT = 5000;
+const BUN_TEST_WATCHDOG_MS = 5000;
+
+/**
+ * The effective per-test watchdog for a file: Bun's 5000ms default, raised to
+ * the largest `setDefaultTimeout(N)` literal the file declares. A pollUntil
+ * deadline must stay below this to surface its own error.
+ */
+function effectiveWatchdog(content: string): number {
+  let max = BUN_TEST_WATCHDOG_MS;
+  const re = /setDefaultTimeout\(\s*([0-9_.]+)\s*\)/g;
+  for (const m of content.matchAll(re)) {
+    const n = parseNumericLiteral(m[1]);
+    if (n !== null && n > max) max = n;
+  }
+  return max;
+}
 
 /**
  * Starting from the `(` at `lines[startLine][parenOffset]`, collect the
@@ -89,10 +112,11 @@ const rule: CheckRule = {
   id: "poll-until-headroom",
   kind: "check",
   scold:
-    "pollUntil() called with no explicit timeout or a timeout ≥ Bun's 5000ms test watchdog — flaky under CI pressure",
+    "pollUntil() called with a timeout ≥ Bun's 5000ms test watchdog — the watchdog fires first, so this deadline never surfaces its own error (flaky under CI pressure)",
   guidance: [
-    "pass a short explicit deadline: pollUntil(fn, 4000) — leave headroom so pollUntil's own error surfaces",
-    "a condition should resolve in milliseconds, not seconds; if you need 4+ seconds the test waits on time, not a condition",
+    "drop the explicit timeout and rely on the 1500ms harness default — it already has ample headroom under the watchdog",
+    "a condition should resolve in milliseconds, not seconds; if you need ≥5s the test waits on time, not a condition",
+    "if a suite is genuinely slow, raise the file's setDefaultTimeout above the deadline — a deadline ≥ the test timeout is a no-op",
     'quote from Bun\'s own test discipline: "You are not testing the TIME PASSING, you are testing the CONDITION"',
     "cross-reference test/CLAUDE.md flaky-prevention patterns",
   ],
@@ -100,6 +124,7 @@ const rule: CheckRule = {
   check({ file, violated }) {
     if (!file.isTest) return;
 
+    const watchdog = effectiveWatchdog(file.content);
     const lines = file.content.split("\n");
 
     for (let i = 0; i < lines.length; i++) {
@@ -116,15 +141,19 @@ const rule: CheckRule = {
       const inner = callText.slice(1, -1);
       const commaIdx = firstTopLevelComma(inner);
 
-      if (commaIdx === -1) {
-        // No second argument — relying on default 5000ms
+      // No second argument → relies on the safe 1500ms harness default — clean.
+      if (commaIdx === -1) continue;
+
+      // Explicit numeric deadline at or above the watchdog can never fire its
+      // own error — the watchdog kills the test first. Bound the second arg at
+      // the next top-level comma so a trailing comma or a third argument
+      // (intervalMs) doesn't defeat the numeric parse.
+      const rest = inner.slice(commaIdx + 1);
+      const nextComma = firstTopLevelComma(rest);
+      const secondArg = (nextComma === -1 ? rest : rest.slice(0, nextComma)).trim();
+      const num = parseNumericLiteral(secondArg);
+      if (num !== null && num >= watchdog) {
         violated(i + 1, pollIdx + 1, line.trim());
-      } else {
-        const secondArg = inner.slice(commaIdx + 1).trim();
-        const num = parseNumericLiteral(secondArg);
-        if (num !== null && num >= BUN_DEFAULT_TIMEOUT) {
-          violated(i + 1, pollIdx + 1, line.trim());
-        }
       }
     }
   },

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -140,14 +140,22 @@ export async function startTestDaemon(
  * Poll condition until it returns truthy or deadline passes.
  * Never use a fixed sleep to wait for async side effects — poll instead.
  * Throws with a descriptive message on timeout so test failures are visible.
+ *
+ * The default deadline (1500ms) sits well under Bun's 5000ms per-test
+ * watchdog so this helper's descriptive error always wins the race over the
+ * generic "test timed out". Measured: across the full suite no condition takes
+ * longer than ~400ms to resolve (#2273), so 1500ms is an ample backstop. For a
+ * genuinely-slow condition, pass an explicit deadline AND raise the file's
+ * `setDefaultTimeout` above it — a deadline >= the test timeout is a no-op.
  */
 export async function pollUntil(
   condition: () => Promise<boolean | undefined | null | number> | boolean | undefined | null | number,
-  timeoutMs = 5000,
+  timeoutMs = 1500,
+  intervalMs = 10,
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
   while (!(await condition()) && Date.now() < deadline) {
-    await Bun.sleep(10);
+    await Bun.sleep(intervalMs);
   }
   if (!(await condition())) throw new Error(`pollUntil: condition not met within ${timeoutMs}ms`);
 }


### PR DESCRIPTION
## What

Two coupled changes that make #2273's "fix the flake at the source" approach and #2280's `poll-until-headroom` rule consistent:

1. **Lower the harness `pollUntil` default 5000 → 1500ms** (+ optional `intervalMs`). Dedupe the 4 local `pollUntil` re-implementations onto the harness helper.
2. **Reconcile the `poll-until-headroom` rule** (merged in #2280) with the lowered default, and fix the genuinely-broken sites it surfaces.

## Why

The default was pinned at exactly Bun's 5000ms per-test watchdog, so a slow condition made the watchdog fire **before** `pollUntil`'s descriptive error → opaque "test timed out", and setup-time variance under CI load became a flake.

Empirical probe (instrumented `pollUntil`, full suite, 116 invocations): `p50=12ms · p99=372ms · max=392ms`, 0 timeouts. **Zero** invocations breach 1000/1500/2000ms — the fallout list for the lower default is empty. 1500ms gives ~3.8× headroom over the worst-observed condition.

## The #2280 conflict (why the rule changed)

As merged, #2280's rule flagged `pollUntil(fn)` with **no explicit timeout** — premised on the old 5000ms default. Once this branch lowers the default to a safe 1500ms, that branch flags **136 bare calls**, mandating an explicit timeout on every one: the per-test-timeout sprawl #2273 set out to *forbid* (and the opposite of the Bun discipline the rule quotes). So the rule now mechanizes the **real invariant**:

- **Bare `pollUntil(fn)` → clean** (relies on the safe 1500ms default; idiomatic). Branch (a) dropped.
- **Flag `pollUntil(fn, N)` only where `N ≥ the file's effective watchdog`** — Bun's 5000ms, or a larger `setDefaultTimeout(N)` when declared. This removes **10 false positives** in `daemon-integration` / `monitor-alias` (both `setDefaultTimeout(30_000)` — a 10s poll there has headroom) and keeps the genuinely-broken ones.
- Hardened second-arg extraction (bounds at the next top-level comma) so a trailing comma or the new `intervalMs` 3rd arg can't defeat the numeric parse.

### Genuinely-broken sites fixed (deadline ≥ watchdog, no `setDefaultTimeout`)

- `server-pool.spec.ts` ×3 (`10_000`) — silent regression of #2221's headroom fix; dropped to default.
- `ws-server-enrichment.spec.ts` ×3 (`5000`) — dropped to default.

Both conditions resolve in <400ms (probe), so the 1500ms default is ample.

## Test plan

- [x] `bun typecheck`, `bun lint`
- [x] `bun run doing-it-wrong` → **0 violations** (was 136 with the bare-call branch)
- [x] rule fixtures: 11 pass / 0 fail (clean covers the `setDefaultTimeout` escape hatch; flagged covers `≥ watchdog`, multi-line, `10_000`)
- [x] `bun test` → full suite green (7721 pass / 0 fail pre-rule-change; affected files re-run clean)
- [ ] CI green

Closes #2273 (move #1 + the rule reconciliation of move #4). Supersedes the bare-call branch of #2280.

🤖 Generated with [Claude Code](https://claude.com/claude-code)