### PR TITLE
feat(rules): add poll-until-headroom rule — flag pollUntil() with no timeout or >= 5000ms (closes #2248)

### DIFF
--- a/scripts/rules/fixtures/poll-until-headroom__clean.fixture.ts
+++ b/scripts/rules/fixtures/poll-until-headroom__clean.fixture.ts
@@ -1,0 +1,24 @@
+/**
+ * @rule poll-until-headroom
+ * @expect 0
+ * @path packages/daemon/src/server-pool.spec.ts
+ *
+ * pollUntil calls with explicit timeouts comfortably below 5000ms — no violation.
+ */
+
+import { pollUntil } from "../../../../test/harness";
+
+declare const condition: () => boolean;
+declare const events: { type: string }[];
+
+// explicit timeout well under 5000 — clean
+await pollUntil(condition, 4000);
+await pollUntil(() => true, 3_000);
+await pollUntil(async () => condition(), 2000);
+await pollUntil(() => events.some((e) => e.type === "done"), 1000);
+
+// multi-line lambda with explicit safe timeout — clean
+await pollUntil(
+  () => events.some((e) => e.type === "session:init"),
+  4000,
+);

--- a/scripts/rules/fixtures/poll-until-headroom__flagged.fixture.ts
+++ b/scripts/rules/fixtures/poll-until-headroom__flagged.fixture.ts
@@ -1,0 +1,27 @@
+/**
+ * @rule poll-until-headroom
+ * @expect 4
+ * @path packages/daemon/src/ipc-server.spec.ts
+ *
+ * pollUntil with no timeout (relying on the 5000ms default) or an explicit
+ * timeout >= 5000ms should all be flagged.
+ */
+
+import { pollUntil } from "../../../../test/harness";
+
+declare const condition: () => boolean;
+declare const events: { type: string }[];
+
+// no second argument — default 5000ms — flag
+await pollUntil(condition);
+
+// explicit timeout exactly equal to Bun's watchdog — flag
+await pollUntil(() => true, 5000);
+
+// underscore separator, still 5000 — flag
+await pollUntil(async () => condition(), 5_000);
+
+// multi-line lambda, no timeout — flag
+await pollUntil(
+  () => events.some((e) => e.type === "session:init")
+);

--- a/scripts/rules/poll-until-headroom.rule.ts
+++ b/scripts/rules/poll-until-headroom.rule.ts
@@ -1,0 +1,133 @@
+/**
+ * Rule: poll-until-headroom
+ *
+ * `pollUntil` defaults to a 5000ms timeout — exactly Bun's per-test watchdog.
+ * Under CI resource pressure, the watchdog fires before `pollUntil`'s own
+ * descriptive error, producing a flake with a useless message.
+ *
+ * Flag:
+ *   (a) `pollUntil(fn)` — no explicit timeout, relying on the 5000ms default
+ *   (b) `pollUntil(fn, N)` where N ≥ 5000 — at or above the watchdog limit
+ *
+ * A condition should resolve in milliseconds, not seconds. Give the poll a
+ * short deadline (hundreds of ms to ~1s), never one that flirts with the
+ * test timeout.
+ */
+
+import type { CheckRule } from "./_engine/rule";
+
+const BUN_DEFAULT_TIMEOUT = 5000;
+
+/**
+ * Starting from the `(` at `lines[startLine][parenOffset]`, collect the
+ * balanced call text including the outer parens. Returns null if unbalanced.
+ */
+function collectCall(lines: string[], startLine: number, parenOffset: number): string | null {
+  let text = "";
+  let depth = 0;
+
+  for (let j = startLine; j < Math.min(startLine + 30, lines.length); j++) {
+    const segment = j === startLine ? lines[j].slice(parenOffset) : lines[j];
+    for (let c = 0; c < segment.length; c++) {
+      const ch = segment[c];
+      text += ch;
+      if (ch === "(") depth++;
+      else if (ch === ")") {
+        depth--;
+        if (depth === 0) return text;
+      }
+    }
+    text += "\n";
+  }
+  return null;
+}
+
+/**
+ * Find the index of the first comma at depth 0 (top-level) within `s`,
+ * correctly skipping over nested parens, brackets, braces, and string literals.
+ * Returns -1 if none found.
+ */
+function firstTopLevelComma(s: string): number {
+  let depth = 0;
+  let inStr: '"' | "'" | "`" | null = null;
+
+  for (let i = 0; i < s.length; i++) {
+    const ch = s[i];
+    if (inStr !== null) {
+      if (ch === "\\") {
+        i++; // skip escaped char
+        continue;
+      }
+      if (ch === inStr) inStr = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      inStr = ch;
+    } else if (ch === "(" || ch === "[" || ch === "{") {
+      depth++;
+    } else if (ch === ")" || ch === "]" || ch === "}") {
+      depth--;
+    } else if (ch === "," && depth === 0) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Parse a TypeScript numeric literal (with optional `_` separators) to a
+ * JS number. Returns null if `s` is not a plain numeric literal.
+ */
+function parseNumericLiteral(s: string): number | null {
+  const cleaned = s.trim().replace(/_/g, "");
+  if (cleaned.length === 0) return null;
+  const n = Number(cleaned);
+  return Number.isFinite(n) && /^[0-9.e+\-]+$/i.test(cleaned) ? n : null;
+}
+
+const rule: CheckRule = {
+  id: "poll-until-headroom",
+  kind: "check",
+  scold:
+    "pollUntil() called with no explicit timeout or a timeout ≥ Bun's 5000ms test watchdog — flaky under CI pressure",
+  guidance: [
+    "pass a short explicit deadline: pollUntil(fn, 4000) — leave headroom so pollUntil's own error surfaces",
+    "a condition should resolve in milliseconds, not seconds; if you need 4+ seconds the test waits on time, not a condition",
+    'quote from Bun\'s own test discipline: "You are not testing the TIME PASSING, you are testing the CONDITION"',
+    "cross-reference test/CLAUDE.md flaky-prevention patterns",
+  ],
+  documentation: "#2248",
+  check({ file, violated }) {
+    if (!file.isTest) return;
+
+    const lines = file.content.split("\n");
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i];
+      const pollIdx = line.indexOf("pollUntil(");
+      if (pollIdx === -1) continue;
+
+      // parenOffset points to the '(' of the call
+      const parenOffset = pollIdx + "pollUntil".length;
+      const callText = collectCall(lines, i, parenOffset);
+      if (!callText) continue;
+
+      // inner = everything between the outer parens
+      const inner = callText.slice(1, -1);
+      const commaIdx = firstTopLevelComma(inner);
+
+      if (commaIdx === -1) {
+        // No second argument — relying on default 5000ms
+        violated(i + 1, pollIdx + 1, line.trim());
+      } else {
+        const secondArg = inner.slice(commaIdx + 1).trim();
+        const num = parseNumericLiteral(secondArg);
+        if (num !== null && num >= BUN_DEFAULT_TIMEOUT) {
+          violated(i + 1, pollIdx + 1, line.trim());
+        }
+      }
+    }
+  },
+};
+
+export default rule;


### PR DESCRIPTION
## Summary
- Adds `poll-until-headroom` check rule to the `doing-it-wrong` engine
- Flags `pollUntil(fn)` with no explicit timeout (relying on the 5000ms default = Bun's watchdog limit)
- Flags `pollUntil(fn, N)` where N ≥ 5000ms — at or above Bun's per-test deadline
- Uses parenthesis-balanced call collection to handle multi-line lambda arguments correctly

## Test plan
- `@expect 0` clean fixture: `pollUntil` calls with explicit timeouts < 5000ms (4000, 3_000, 2000, 1000, 4000 with multiline lambda) — all pass without violation
- `@expect 4` flagged fixture: no-arg call, explicit 5000, underscore `5_000`, multi-line lambda with no timeout — all flagged
- All 9 rule fixture tests pass; 7732 total tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)