### PR TITLE
feat(core): spawnCapture helper + rule banning raw Bun.spawn(Sync) in non-test code (fixes #2269)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,3 +54,4 @@ export * from "./bun-version";
 export * from "./sprint-plan";
 export * from "./claude-patch";
 export * from "./automation";
+export * from "./subprocess";

--- a/packages/core/src/subprocess.spec.ts
+++ b/packages/core/src/subprocess.spec.ts
@@ -9,6 +9,7 @@ describe("spawnCapture", () => {
     expect(r.stdout.trim()).toBe("hello");
     expect(r.stderr).toBe("");
     expect(r.timedOut).toBe(false);
+    expect(r.truncated).toBe(false);
     expect(r.signal).toBeNull();
   });
 
@@ -17,6 +18,7 @@ describe("spawnCapture", () => {
     expect(r.ok).toBe(false);
     expect(r.exitCode).not.toBe(0);
     expect(r.timedOut).toBe(false);
+    expect(r.truncated).toBe(false);
   });
 
   it("captures stderr from a failing command", async () => {
@@ -31,6 +33,7 @@ describe("spawnCapture", () => {
     expect(r.exitCode).toBeNull();
     expect(r.signal).toBeNull();
     expect(r.timedOut).toBe(false);
+    expect(r.truncated).toBe(false);
   });
 
   it("enforces timeout with SIGTERM escalation", async () => {
@@ -50,6 +53,13 @@ describe("spawnCapture", () => {
     expect(r.ok).toBe(true);
     expect(r.stdout.trim()).toMatch(/\/tmp/);
   });
+
+  it("truncates stdout when output exceeds maxBuffer", async () => {
+    const r = await spawnCapture("echo", ["x".repeat(200)], { maxBuffer: 50 });
+    expect(r.ok).toBe(true);
+    expect(r.truncated).toBe(true);
+    expect(r.stdout.length).toBeLessThanOrEqual(50);
+  });
 });
 
 describe("spawnCaptureSync", () => {
@@ -59,6 +69,7 @@ describe("spawnCaptureSync", () => {
     expect(r.exitCode).toBe(0);
     expect(r.stdout.trim()).toBe("hello");
     expect(r.timedOut).toBe(false);
+    expect(r.truncated).toBe(false);
   });
 
   it("reports failure with non-zero exit code", () => {
@@ -72,6 +83,7 @@ describe("spawnCaptureSync", () => {
     expect(r.ok).toBe(false);
     expect(r.exitCode).toBeNull();
     expect(r.timedOut).toBe(false);
+    expect(r.truncated).toBe(false);
   });
 
   it("enforces timeout via Bun.spawnSync", () => {
@@ -80,9 +92,24 @@ describe("spawnCaptureSync", () => {
     expect(r.timedOut).toBe(true);
   });
 
+  it("does not set timedOut when process fails without signal (timeoutMs=50 edge case)", () => {
+    // old elapsed-heuristic: elapsed≈1ms >= 50-50=0ms → incorrectly true
+    // new signalCode check: signalCode is undefined (not SIGTERM) → correctly false
+    const r = spawnCaptureSync("false", [], { timeoutMs: 50 });
+    expect(r.ok).toBe(false);
+    expect(r.timedOut).toBe(false);
+  });
+
   it("respects cwd option", () => {
     const r = spawnCaptureSync("pwd", [], { cwd: "/tmp" });
     expect(r.ok).toBe(true);
     expect(r.stdout.trim()).toMatch(/\/tmp/);
+  });
+
+  it("truncates stdout when output exceeds maxBuffer", () => {
+    const r = spawnCaptureSync("echo", ["x".repeat(200)], { maxBuffer: 50 });
+    expect(r.ok).toBe(true);
+    expect(r.truncated).toBe(true);
+    expect(r.stdout.length).toBeLessThanOrEqual(50);
   });
 });

--- a/packages/core/src/subprocess.spec.ts
+++ b/packages/core/src/subprocess.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+import { spawnCapture, spawnCaptureSync } from "./subprocess";
+
+describe("spawnCapture", () => {
+  it("captures stdout from a successful command", async () => {
+    const r = await spawnCapture("echo", ["hello"]);
+    expect(r.ok).toBe(true);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toBe("hello");
+    expect(r.stderr).toBe("");
+    expect(r.timedOut).toBe(false);
+    expect(r.signal).toBeNull();
+  });
+
+  it("reports failure with non-zero exit code", async () => {
+    const r = await spawnCapture("false", []);
+    expect(r.ok).toBe(false);
+    expect(r.exitCode).not.toBe(0);
+    expect(r.timedOut).toBe(false);
+  });
+
+  it("captures stderr from a failing command", async () => {
+    const r = await spawnCapture("ls", ["--no-such-flag-xyzzy"]);
+    expect(r.ok).toBe(false);
+    expect(r.stderr.length).toBeGreaterThan(0);
+  });
+
+  it("handles missing binary without throwing", async () => {
+    const r = await spawnCapture("nonexistent-binary-xyzzy-42", []);
+    expect(r.ok).toBe(false);
+    expect(r.exitCode).toBeNull();
+    expect(r.signal).toBeNull();
+    expect(r.timedOut).toBe(false);
+  });
+
+  it("enforces timeout with SIGTERM escalation", async () => {
+    const r = await spawnCapture("sleep", ["30"], { timeoutMs: 200 });
+    expect(r.ok).toBe(false);
+    expect(r.timedOut).toBe(true);
+  });
+
+  it("passes input to stdin", async () => {
+    const r = await spawnCapture("cat", [], { input: "piped-data" });
+    expect(r.ok).toBe(true);
+    expect(r.stdout).toBe("piped-data");
+  });
+
+  it("respects cwd option", async () => {
+    const r = await spawnCapture("pwd", [], { cwd: "/tmp" });
+    expect(r.ok).toBe(true);
+    expect(r.stdout.trim()).toMatch(/\/tmp/);
+  });
+});
+
+describe("spawnCaptureSync", () => {
+  it("captures stdout from a successful command", () => {
+    const r = spawnCaptureSync("echo", ["hello"]);
+    expect(r.ok).toBe(true);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toBe("hello");
+    expect(r.timedOut).toBe(false);
+  });
+
+  it("reports failure with non-zero exit code", () => {
+    const r = spawnCaptureSync("false", []);
+    expect(r.ok).toBe(false);
+    expect(r.exitCode).not.toBe(0);
+  });
+
+  it("handles missing binary without throwing", () => {
+    const r = spawnCaptureSync("nonexistent-binary-xyzzy-42", []);
+    expect(r.ok).toBe(false);
+    expect(r.exitCode).toBeNull();
+    expect(r.timedOut).toBe(false);
+  });
+
+  it("enforces timeout via Bun.spawnSync", () => {
+    const r = spawnCaptureSync("sleep", ["30"], { timeoutMs: 200 });
+    expect(r.ok).toBe(false);
+    expect(r.timedOut).toBe(true);
+  });
+
+  it("respects cwd option", () => {
+    const r = spawnCaptureSync("pwd", [], { cwd: "/tmp" });
+    expect(r.ok).toBe(true);
+    expect(r.stdout.trim()).toMatch(/\/tmp/);
+  });
+});

--- a/packages/core/src/subprocess.ts
+++ b/packages/core/src/subprocess.ts
@@ -5,14 +5,39 @@ export interface SpawnResult {
   stdout: string;
   stderr: string;
   timedOut: boolean;
+  truncated: boolean;
 }
 
 const SIGKILL_GRACE_MS = 5_000;
+const DEFAULT_MAX_BUFFER = 50 * 1024 * 1024; // 50 MB
+
+async function drainStream(stream: ReadableStream, maxBytes: number): Promise<{ text: string; truncated: boolean }> {
+  const reader = (stream as ReadableStream<Uint8Array>).getReader();
+  const parts: Uint8Array[] = [];
+  let total = 0;
+  let truncated = false;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (total + value.byteLength > maxBytes) {
+        parts.push(value.subarray(0, maxBytes - total));
+        truncated = true;
+        break;
+      }
+      parts.push(value);
+      total += value.byteLength;
+    }
+  } finally {
+    reader.cancel().catch(() => {});
+  }
+  return { text: Buffer.concat(parts).toString("utf8"), truncated };
+}
 
 export async function spawnCapture(
   cmd: string,
   args: string[],
-  opts?: { cwd?: string; timeoutMs?: number; input?: string },
+  opts?: { cwd?: string; timeoutMs?: number; input?: string; maxBuffer?: number },
 ): Promise<SpawnResult> {
   let proc: ReturnType<typeof Bun.spawn>;
   try {
@@ -23,13 +48,17 @@ export async function spawnCapture(
       stderr: "pipe",
     });
   } catch {
-    return { ok: false, exitCode: null, signal: null, stdout: "", stderr: "", timedOut: false };
+    return { ok: false, exitCode: null, signal: null, stdout: "", stderr: "", timedOut: false, truncated: false };
   }
 
   if (opts?.input != null && proc.stdin && typeof proc.stdin !== "number") {
-    const sink = proc.stdin as import("bun").FileSink;
-    sink.write(opts.input);
-    sink.end();
+    try {
+      const sink = proc.stdin as import("bun").FileSink;
+      sink.write(opts.input);
+      await sink.end();
+    } catch {
+      // EPIPE: child closed stdin early; continue draining output
+    }
   }
 
   let timedOut = false;
@@ -44,9 +73,10 @@ export async function spawnCapture(
     }, opts.timeoutMs);
   }
 
-  const [stdout, stderr] = await Promise.all([
-    new Response(proc.stdout as ReadableStream).text(),
-    new Response(proc.stderr as ReadableStream).text(),
+  const maxBytes = opts?.maxBuffer ?? DEFAULT_MAX_BUFFER;
+  const [out, err] = await Promise.all([
+    drainStream(proc.stdout as ReadableStream, maxBytes),
+    drainStream(proc.stderr as ReadableStream, maxBytes),
   ]);
 
   await proc.exited;
@@ -58,18 +88,18 @@ export async function spawnCapture(
     ok: proc.exitCode === 0,
     exitCode: proc.exitCode ?? null,
     signal: proc.signalCode ?? null,
-    stdout,
-    stderr,
+    stdout: out.text,
+    stderr: err.text,
     timedOut,
+    truncated: out.truncated || err.truncated,
   };
 }
 
 export function spawnCaptureSync(
   cmd: string,
   args: string[],
-  opts?: { cwd?: string; timeoutMs?: number },
+  opts?: { cwd?: string; timeoutMs?: number; maxBuffer?: number },
 ): SpawnResult {
-  const start = performance.now();
   let result: ReturnType<typeof Bun.spawnSync>;
   try {
     result = Bun.spawnSync([cmd, ...args], {
@@ -79,18 +109,25 @@ export function spawnCaptureSync(
       timeout: opts?.timeoutMs,
     });
   } catch {
-    return { ok: false, exitCode: null, signal: null, stdout: "", stderr: "", timedOut: false };
+    return { ok: false, exitCode: null, signal: null, stdout: "", stderr: "", timedOut: false, truncated: false };
   }
 
-  const elapsed = performance.now() - start;
-  const hitTimeout = opts?.timeoutMs != null && !result.success && elapsed >= opts.timeoutMs - 50;
+  // Bun sends SIGTERM when the timeout elapses; elapsed-time heuristics are unreliable
+  const hitTimeout = opts?.timeoutMs != null && result.signalCode === "SIGTERM";
+
+  const maxBytes = opts?.maxBuffer ?? DEFAULT_MAX_BUFFER;
+  const stdoutBuf = result.stdout;
+  const stderrBuf = result.stderr;
+  const stdoutTrunc = stdoutBuf != null && stdoutBuf.byteLength > maxBytes;
+  const stderrTrunc = stderrBuf != null && stderrBuf.byteLength > maxBytes;
 
   return {
     ok: result.exitCode === 0,
     exitCode: result.exitCode,
     signal: result.signalCode ?? null,
-    stdout: result.stdout?.toString() ?? "",
-    stderr: result.stderr?.toString() ?? "",
+    stdout: stdoutTrunc ? (stdoutBuf?.slice(0, maxBytes).toString() ?? "") : (stdoutBuf?.toString() ?? ""),
+    stderr: stderrTrunc ? (stderrBuf?.slice(0, maxBytes).toString() ?? "") : (stderrBuf?.toString() ?? ""),
     timedOut: hitTimeout,
+    truncated: stdoutTrunc || stderrTrunc,
   };
 }

--- a/packages/core/src/subprocess.ts
+++ b/packages/core/src/subprocess.ts
@@ -1,0 +1,96 @@
+export interface SpawnResult {
+  ok: boolean;
+  exitCode: number | null;
+  signal: string | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+}
+
+const SIGKILL_GRACE_MS = 5_000;
+
+export async function spawnCapture(
+  cmd: string,
+  args: string[],
+  opts?: { cwd?: string; timeoutMs?: number; input?: string },
+): Promise<SpawnResult> {
+  let proc: ReturnType<typeof Bun.spawn>;
+  try {
+    proc = Bun.spawn([cmd, ...args], {
+      cwd: opts?.cwd,
+      stdin: opts?.input != null ? "pipe" : "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+  } catch {
+    return { ok: false, exitCode: null, signal: null, stdout: "", stderr: "", timedOut: false };
+  }
+
+  if (opts?.input != null && proc.stdin && typeof proc.stdin !== "number") {
+    const sink = proc.stdin as import("bun").FileSink;
+    sink.write(opts.input);
+    sink.end();
+  }
+
+  let timedOut = false;
+  let killTimer: ReturnType<typeof setTimeout> | undefined;
+  let termTimer: ReturnType<typeof setTimeout> | undefined;
+
+  if (opts?.timeoutMs != null) {
+    termTimer = setTimeout(() => {
+      timedOut = true;
+      proc.kill("SIGTERM");
+      killTimer = setTimeout(() => proc.kill("SIGKILL"), SIGKILL_GRACE_MS);
+    }, opts.timeoutMs);
+  }
+
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout as ReadableStream).text(),
+    new Response(proc.stderr as ReadableStream).text(),
+  ]);
+
+  await proc.exited;
+
+  if (termTimer) clearTimeout(termTimer);
+  if (killTimer) clearTimeout(killTimer);
+
+  return {
+    ok: proc.exitCode === 0,
+    exitCode: proc.exitCode ?? null,
+    signal: proc.signalCode ?? null,
+    stdout,
+    stderr,
+    timedOut,
+  };
+}
+
+export function spawnCaptureSync(
+  cmd: string,
+  args: string[],
+  opts?: { cwd?: string; timeoutMs?: number },
+): SpawnResult {
+  const start = performance.now();
+  let result: ReturnType<typeof Bun.spawnSync>;
+  try {
+    result = Bun.spawnSync([cmd, ...args], {
+      cwd: opts?.cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: opts?.timeoutMs,
+    });
+  } catch {
+    return { ok: false, exitCode: null, signal: null, stdout: "", stderr: "", timedOut: false };
+  }
+
+  const elapsed = performance.now() - start;
+  const hitTimeout = opts?.timeoutMs != null && !result.success && elapsed >= opts.timeoutMs - 50;
+
+  return {
+    ok: result.exitCode === 0,
+    exitCode: result.exitCode,
+    signal: result.signalCode ?? null,
+    stdout: result.stdout?.toString() ?? "",
+    stderr: result.stderr?.toString() ?? "",
+    timedOut: hitTimeout,
+  };
+}

--- a/packages/core/src/subprocess.ts
+++ b/packages/core/src/subprocess.ts
@@ -20,13 +20,18 @@ async function drainStream(stream: ReadableStream, maxBytes: number): Promise<{ 
     while (true) {
       const { done, value } = await reader.read();
       if (done) break;
-      if (total + value.byteLength > maxBytes) {
-        parts.push(value.subarray(0, maxBytes - total));
-        truncated = true;
-        break;
+      if (!truncated) {
+        if (total + value.byteLength > maxBytes) {
+          parts.push(value.subarray(0, maxBytes - total));
+          total = maxBytes;
+          truncated = true;
+        } else {
+          parts.push(value);
+          total += value.byteLength;
+        }
       }
-      parts.push(value);
-      total += value.byteLength;
+      // After truncation keep reading (discarding) so the child doesn't
+      // block on a full pipe and hang; reader.cancel() cleans up on exit.
     }
   } finally {
     reader.cancel().catch(() => {});

--- a/scripts/rules/fixtures/no-raw-spawn__clean.fixture.ts
+++ b/scripts/rules/fixtures/no-raw-spawn__clean.fixture.ts
@@ -1,0 +1,28 @@
+/**
+ * @rule no-raw-spawn
+ * @expect 0
+ * @path packages/daemon/src/example.ts
+ *
+ * Uses spawnCapture — the safe subprocess wrapper — and accesses exitCode
+ * without null-coercing it.
+ */
+
+import { spawnCapture, spawnCaptureSync } from "./subprocess";
+
+async function run() {
+  const result = await spawnCapture("git", ["status"]);
+  if (!result.ok) {
+    console.error(result.stderr);
+  }
+
+  if (result.exitCode !== 0) {
+    process.exit(1);
+  }
+
+  const sync = spawnCaptureSync("git", ["rev-parse", "HEAD"]);
+  if (sync.timedOut) {
+    console.error("timed out");
+  }
+
+  return sync.stdout.trim();
+}

--- a/scripts/rules/fixtures/no-raw-spawn__clean.fixture.ts
+++ b/scripts/rules/fixtures/no-raw-spawn__clean.fixture.ts
@@ -4,10 +4,11 @@
  * @path packages/daemon/src/example.ts
  *
  * Uses spawnCapture — the safe subprocess wrapper — and accesses exitCode
- * without null-coercing it.
+ * without null-coercing it. Also demonstrates false-positive guards:
+ * process.exitCode is unrelated to subprocess exit codes.
  */
 
-import { spawnCapture, spawnCaptureSync } from "./subprocess";
+import { spawnCapture, spawnCaptureSync } from "@mcp-cli/core";
 
 async function run() {
   const result = await spawnCapture("git", ["status"]);
@@ -23,6 +24,9 @@ async function run() {
   if (sync.timedOut) {
     console.error("timed out");
   }
+
+  const code = process.exitCode ?? 0;
+  const fallback = process.exitCode || 0;
 
   return sync.stdout.trim();
 }

--- a/scripts/rules/fixtures/no-raw-spawn__flagged.fixture.ts
+++ b/scripts/rules/fixtures/no-raw-spawn__flagged.fixture.ts
@@ -1,10 +1,12 @@
 /**
  * @rule no-raw-spawn
- * @expect 2
+ * @expect 3
  * @path packages/daemon/src/example.ts
  *
- * A bare Bun.spawnSync call and an exitCode ?? 0 null-coercion.
+ * A bare Bun.spawnSync call, an exitCode ?? 0 null-coercion, and an
+ * optional-chaining exitCode coercion (result?.exitCode ?? 0).
  */
 
 const result = Bun.spawnSync(["git", "status"], { stdout: "pipe" });
 const code = result.exitCode ?? 0;
+const safe = result?.exitCode ?? 0;

--- a/scripts/rules/fixtures/no-raw-spawn__flagged.fixture.ts
+++ b/scripts/rules/fixtures/no-raw-spawn__flagged.fixture.ts
@@ -1,0 +1,10 @@
+/**
+ * @rule no-raw-spawn
+ * @expect 2
+ * @path packages/daemon/src/example.ts
+ *
+ * A bare Bun.spawnSync call and an exitCode ?? 0 null-coercion.
+ */
+
+const result = Bun.spawnSync(["git", "status"], { stdout: "pipe" });
+const code = result.exitCode ?? 0;

--- a/scripts/rules/no-raw-spawn.rule.ts
+++ b/scripts/rules/no-raw-spawn.rule.ts
@@ -6,7 +6,7 @@ const rule: CheckRule = {
   kind: "check",
   scold: "raw Bun.spawn/spawnSync or exitCode null-coercion — use spawnCapture() from @mcp-cli/core",
   guidance: [
-    "use spawnCapture(cmd, args, opts) or spawnCaptureSync(cmd, args, opts) from packages/core/src/subprocess.ts",
+    "use spawnCapture(cmd, args, opts) or spawnCaptureSync(cmd, args, opts) from @mcp-cli/core",
     "branch on result.ok / result.timedOut — never coerce exitCode with ?? 0 or || 0",
     "the helper handles: try/catch (missing binary), stderr draining, timeout+SIGKILL, honest exit codes",
   ],

--- a/scripts/rules/no-raw-spawn.rule.ts
+++ b/scripts/rules/no-raw-spawn.rule.ts
@@ -39,6 +39,9 @@ const rule: CheckRule = {
         (ts.isPropertyAccessExpression(left) && left.name.text === "exitCode");
       if (!isExitCode) continue;
 
+      if (ts.isPropertyAccessExpression(left) && ts.isIdentifier(left.expression) && left.expression.text === "process")
+        continue;
+
       const right = bin.right;
       const isZero = ts.isNumericLiteral(right) && right.text === "0";
       if (!isZero) continue;

--- a/scripts/rules/no-raw-spawn.rule.ts
+++ b/scripts/rules/no-raw-spawn.rule.ts
@@ -1,0 +1,52 @@
+import ts from "typescript";
+import type { CheckRule } from "./_engine/rule";
+
+const rule: CheckRule = {
+  id: "no-raw-spawn",
+  kind: "check",
+  scold: "raw Bun.spawn/spawnSync or exitCode null-coercion — use spawnCapture() from @mcp-cli/core",
+  guidance: [
+    "use spawnCapture(cmd, args, opts) or spawnCaptureSync(cmd, args, opts) from packages/core/src/subprocess.ts",
+    "branch on result.ok / result.timedOut — never coerce exitCode with ?? 0 or || 0",
+    "the helper handles: try/catch (missing binary), stderr draining, timeout+SIGKILL, honest exit codes",
+  ],
+  documentation: "#2269",
+  appliesToTests: false,
+
+  check({ file, violated, ast }) {
+    const inScope = file.relPath.startsWith("packages/") && file.relPath.includes("/src/");
+    if (!inScope) return;
+
+    const isSelf = file.relPath.endsWith("/subprocess.ts");
+
+    if (!isSelf) {
+      for (const call of [...ast.callsTo("spawn"), ...ast.callsTo("spawnSync")]) {
+        const expr = call.expression;
+        if (ts.isPropertyAccessExpression(expr) && ts.isIdentifier(expr.expression) && expr.expression.text === "Bun") {
+          const pos = ast.positionOf(call);
+          violated(pos.line, pos.column, call.getText(ast.sourceFile).slice(0, 80));
+        }
+      }
+    }
+
+    for (const bin of ast.find(ts.isBinaryExpression)) {
+      const op = bin.operatorToken.kind;
+      if (op !== ts.SyntaxKind.QuestionQuestionToken && op !== ts.SyntaxKind.BarBarToken) continue;
+
+      const left = bin.left;
+      const isExitCode =
+        (ts.isIdentifier(left) && left.text === "exitCode") ||
+        (ts.isPropertyAccessExpression(left) && left.name.text === "exitCode");
+      if (!isExitCode) continue;
+
+      const right = bin.right;
+      const isZero = ts.isNumericLiteral(right) && right.text === "0";
+      if (!isZero) continue;
+
+      const pos = ast.positionOf(bin);
+      violated(pos.line, pos.column, bin.getText(ast.sourceFile));
+    }
+  },
+};
+
+export default rule;


### PR DESCRIPTION
## Summary
- **Part A**: `spawnCapture` (async) and `spawnCaptureSync` in `packages/core/src/subprocess.ts` — wraps `Bun.spawn`/`spawnSync` with try/catch (missing binary → `ok:false`, not a throw), drains both stdout and stderr (bounded by `maxBuffer`, default 50 MB), enforces `timeoutMs` with SIGTERM→SIGKILL escalation, and reports `exitCode: null` as `ok:false` (never silent success)
- **Part B**: `no-raw-spawn` check rule using TS AST — flags `Bun.spawn(`/`Bun.spawnSync(` in non-test `packages/**/src` outside `subprocess.ts`, and flags `exitCode ?? 0`/`exitCode || 0` anywhere in scope
- Two test fixtures (clean + flagged) and 15 unit tests for the helper covering success, failure, missing binary, timeout, stdin input, cwd, output truncation, and the timedOut=false edge case at small timeoutMs values

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — all tests pass, 0 failures
- [x] `bun test packages/core/src/subprocess.spec.ts` — 15/15 pass (async + sync variants)
- [x] `bun test scripts/rules/fixtures.spec.ts` — 9/9 pass (clean fixture expects 0, flagged expects 3)
- [x] `bun run doing-it-wrong` correctly flags 59 existing raw-spawn call sites (migration is future work)
- [x] Pre-commit hook passes (hook gates `shell-injection` rule only; `no-raw-spawn` is not yet gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)