### PR TITLE
feat(core): path helpers (pathEq/canonicalCwd) + no-raw-path-handling rule (fixes #2251)

### DIFF
--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -117,7 +117,7 @@ const defaultDeps: PhaseInstallDeps = {
 export function resolvePhaseSource(source: string, repoRoot: string): string {
   if (source.startsWith("file://")) {
     const rest = source.slice("file://".length);
-    const path = rest.startsWith("/") ? rest : `/${rest}`;
+    const path = isAbsolute(rest) ? rest : `/${rest}`;
     return resolvePath(path);
   }
   if (/^[a-z][a-z0-9+.-]*:\/\//i.test(source)) {

--- a/packages/command/src/commands/run.ts
+++ b/packages/command/src/commands/run.ts
@@ -6,7 +6,7 @@
  * --key value pairs are passed as CLI args (available in ctx.args).
  */
 
-import { relative, resolve } from "node:path";
+import { isAbsolute, relative, resolve } from "node:path";
 import { type IpcMethod, type IpcMethodResult, options as coreOptions, ipcCall, readCliConfig } from "@mcp-cli/core";
 import { runAlias } from "../alias-runner";
 import { printError } from "../output";
@@ -41,14 +41,14 @@ export function isScopeAllowed(scope: string | null | undefined, cwd: string): b
   if (scope == null || scope === "global") return true;
   // Anything that isn't `null`, `"global"`, or an absolute path is malformed —
   // fail closed so a misconfigured scope can't accidentally grant global access.
-  if (!scope.startsWith("/")) return false;
+  if (!isAbsolute(scope)) return false;
   const normalizedScope = resolve(scope);
   const normalizedCwd = resolve(cwd);
   if (normalizedCwd === normalizedScope) return true;
   const rel = relative(normalizedScope, normalizedCwd);
   // `relative` returns "" for same path, a non-".." path for inside,
   // and a path starting with ".." (or an absolute path on Windows) for outside.
-  return rel !== "" && !rel.startsWith("..") && !rel.startsWith("/");
+  return rel !== "" && !rel.startsWith("..") && !isAbsolute(rel);
 }
 
 export async function cmdRun(args: string[], deps?: Partial<CmdRunDeps>): Promise<{ _recordPromise: Promise<void> }> {

--- a/packages/core/src/claude-patch/patcher.ts
+++ b/packages/core/src/claude-patch/patcher.ts
@@ -25,7 +25,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { dirname, isAbsolute, join } from "node:path";
 import { options } from "../constants";
 import { sha256Hex } from "../manifest-lock";
 import { type PatchStrategy, resolveStrategy } from "./strategies";
@@ -440,7 +440,7 @@ export function readCurrentPatchedMeta(storeDir?: string): PatchedMeta | null {
     const stat = lstatSync(link);
     if (stat.isSymbolicLink()) {
       target = readlinkSync(link);
-      if (!target.startsWith("/")) target = join(dirname(link), target);
+      if (!isAbsolute(target)) target = join(dirname(link), target);
     } else {
       // Pointer file fallback (see updateCurrentLink).
       target = readFileSync(link, "utf-8").trim();

--- a/packages/core/src/fs.spec.ts
+++ b/packages/core/src/fs.spec.ts
@@ -4,7 +4,15 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { testOptions } from "../../../test/test-options";
 import { options } from "./constants";
-import { auditRuntimePermissions, ensureStateDir, hardenFile, isPathContained, resolveRealpath } from "./fs";
+import {
+  auditRuntimePermissions,
+  canonicalCwd,
+  ensureStateDir,
+  hardenFile,
+  isPathContained,
+  pathEq,
+  resolveRealpath,
+} from "./fs";
 import { capturingLogger } from "./logger";
 
 describe("isPathContained", () => {
@@ -82,6 +90,54 @@ describe("resolveRealpath", () => {
     } finally {
       rmSync(base, { recursive: true, force: true });
     }
+  });
+});
+
+describe("pathEq", () => {
+  test("returns true for identical paths", () => {
+    const base = mkdtempSync(join(tmpdir(), "mcp-fs-test-"));
+    try {
+      const file = join(base, "a.txt");
+      writeFileSync(file, "x");
+      expect(pathEq(file, file)).toBe(true);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  test("returns true when one path goes through a symlink", () => {
+    const base = mkdtempSync(join(tmpdir(), "mcp-fs-test-"));
+    try {
+      const real = join(base, "real-dir");
+      mkdirSync(real);
+      const link = join(base, "link-dir");
+      symlinkSync(real, link);
+      expect(pathEq(real, link)).toBe(true);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  test("returns false for different paths", () => {
+    const base = mkdtempSync(join(tmpdir(), "mcp-fs-test-"));
+    try {
+      const a = join(base, "a");
+      const b = join(base, "b");
+      mkdirSync(a);
+      mkdirSync(b);
+      expect(pathEq(a, b)).toBe(false);
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("canonicalCwd", () => {
+  test("returns a string matching resolveRealpath of cwd", () => {
+    const result = canonicalCwd();
+    expect(typeof result).toBe("string");
+    expect(result.length).toBeGreaterThan(0);
+    expect(result).toBe(realpathSync(process.cwd()));
   });
 });
 

--- a/packages/core/src/fs.spec.ts
+++ b/packages/core/src/fs.spec.ts
@@ -133,11 +133,27 @@ describe("pathEq", () => {
 });
 
 describe("canonicalCwd", () => {
-  test("returns a string matching resolveRealpath of cwd", () => {
+  test("output is idempotent under realpathSync — not a raw symlink alias", () => {
+    // If canonicalCwd() returned an unresolved symlink path, a second
+    // realpathSync would differ. Idempotency proves the path is fully resolved.
     const result = canonicalCwd();
-    expect(typeof result).toBe("string");
-    expect(result.length).toBeGreaterThan(0);
-    expect(result).toBe(realpathSync(process.cwd()));
+    expect(realpathSync(result)).toBe(result);
+  });
+
+  test("resolves symlinked cwd to the real directory, not the symlink path", () => {
+    const base = mkdtempSync(join(tmpdir(), "mcp-fs-test-"));
+    const real = join(base, "real-dir");
+    mkdirSync(real);
+    const link = join(base, "link-dir");
+    symlinkSync(real, link);
+    const orig = process.cwd();
+    process.chdir(link);
+    try {
+      expect(canonicalCwd()).toBe(realpathSync(real));
+    } finally {
+      process.chdir(orig);
+      rmSync(base, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/core/src/fs.ts
+++ b/packages/core/src/fs.ts
@@ -74,7 +74,12 @@ export function auditRuntimePermissions(logger: Logger = consoleLogger): void {
   }
 }
 
-/** Realpath-normalized equality: both paths are resolved + symlink-followed before comparison. */
+/**
+ * Realpath-normalized equality: both paths are resolved + symlink-followed before comparison.
+ * Assumes both paths exist. For non-existent paths, the comparison is best-effort: the
+ * missing tail is re-joined from basename segments without case normalization, so results
+ * may be inconsistent on case-insensitive filesystems when paths don't exist yet.
+ */
 export function pathEq(a: string, b: string): boolean {
   return resolveRealpath(resolve(a)) === resolveRealpath(resolve(b));
 }

--- a/packages/core/src/fs.ts
+++ b/packages/core/src/fs.ts
@@ -74,6 +74,16 @@ export function auditRuntimePermissions(logger: Logger = consoleLogger): void {
   }
 }
 
+/** Realpath-normalized equality: both paths are resolved + symlink-followed before comparison. */
+export function pathEq(a: string, b: string): boolean {
+  return resolveRealpath(resolve(a)) === resolveRealpath(resolve(b));
+}
+
+/** Canonical working directory: `resolve(process.cwd())` with symlinks followed. */
+export function canonicalCwd(): string {
+  return resolveRealpath(resolve(process.cwd()));
+}
+
 /**
  * Resolve the command to launch the daemon.
  *

--- a/packages/daemon/src/claude-session/containment.ts
+++ b/packages/daemon/src/claude-session/containment.ts
@@ -1,6 +1,6 @@
 // Worktree containment enforcement — see #1441 for design.
 
-import { resolve } from "node:path";
+import { isAbsolute, resolve } from "node:path";
 import { isPathContained, resolveRealpath } from "@mcp-cli/core";
 
 // ── Types ──
@@ -197,7 +197,7 @@ function extractBashWriteTargets(command: string): string[] {
           for (let k = fileArgStart; k < tokens.length; k++) {
             const raw = tokens[k] ?? "";
             const t = unquote(raw);
-            if (t.startsWith("/")) {
+            if (isAbsolute(t)) {
               targets.push(t);
               break;
             }
@@ -214,12 +214,12 @@ function extractBashWriteTargets(command: string): string[] {
         for (const flag of outputFlags) {
           if (raw.startsWith(`${flag}=`)) {
             const val = unquote(raw.slice(flag.length + 1));
-            if (val.startsWith("/")) targets.push(val);
+            if (isAbsolute(val)) targets.push(val);
           }
         }
         if (outputFlags.includes(raw) && k + 1 < tokens.length) {
           const val = unquote(tokens[k + 1] ?? "");
-          if (val.startsWith("/")) targets.push(val);
+          if (isAbsolute(val)) targets.push(val);
           k++;
         }
       }
@@ -233,7 +233,7 @@ function extractBashWriteTargets(command: string): string[] {
       const raw = tokens[k] ?? "";
       if (raw.startsWith("-")) continue;
       const t = unquote(raw);
-      if (t.startsWith("/")) targets.push(t);
+      if (isAbsolute(t)) targets.push(t);
     }
   }
 

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -25,7 +25,7 @@ import {
   writeSync,
 } from "node:fs";
 import { stat as fsStat } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { isAbsolute, join, resolve } from "node:path";
 import type { Logger } from "@mcp-cli/core";
 import {
   ACP_SERVER_NAME,
@@ -415,7 +415,7 @@ export async function resolveHeadBranch(cwd: string): Promise<string | null> {
       const match = gitdirLine.match(/^gitdir:\s*(.+)$/);
       const target = match?.[1]?.trim();
       if (!target) return null;
-      gitDir = target.startsWith("/") ? target : `${cwd}/${target}`;
+      gitDir = isAbsolute(target) ? target : `${cwd}/${target}`;
     } else {
       gitDir = dotGitPath;
     }

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -415,7 +415,7 @@ export async function resolveHeadBranch(cwd: string): Promise<string | null> {
       const match = gitdirLine.match(/^gitdir:\s*(.+)$/);
       const target = match?.[1]?.trim();
       if (!target) return null;
-      gitDir = isAbsolute(target) ? target : `${cwd}/${target}`;
+      gitDir = isAbsolute(target) ? target : join(cwd, target);
     } else {
       gitDir = dotGitPath;
     }

--- a/scripts/rules/fixtures/no-raw-path-handling__clean.fixture.ts
+++ b/scripts/rules/fixtures/no-raw-path-handling__clean.fixture.ts
@@ -1,0 +1,26 @@
+/**
+ * @rule no-raw-path-handling
+ * @expect 0
+ * @path packages/daemon/src/example-clean.ts
+ *
+ * Correct patterns: path.isAbsolute, pathEq, canonicalCwd.
+ */
+
+import { isAbsolute } from "node:path";
+import { canonicalCwd, pathEq } from "@mcp-cli/core";
+
+// isAbsolute — correct way to check
+if (isAbsolute(somePath)) doSomething();
+
+// pathEq — correct way to compare paths
+if (pathEq(a, b)) doSomething();
+
+// canonicalCwd — correct way to capture cwd
+const cwd = canonicalCwd();
+
+// startsWith with a non-"/" string — not flagged
+if (name.startsWith("packages/")) doSomething();
+if (name.startsWith("-")) doSomething();
+
+// Template-literal arg to startsWith — not flagged
+if (p.startsWith(`${root}/`)) doSomething();

--- a/scripts/rules/fixtures/no-raw-path-handling__clean.fixture.ts
+++ b/scripts/rules/fixtures/no-raw-path-handling__clean.fixture.ts
@@ -4,6 +4,8 @@
  * @path packages/daemon/src/example-clean.ts
  *
  * Correct patterns: path.isAbsolute, pathEq, canonicalCwd.
+ * Also validates that process.cwd() nested inside helper calls
+ * (not a direct === operand) does NOT trigger false positives.
  */
 
 import { isAbsolute } from "node:path";
@@ -24,3 +26,8 @@ if (name.startsWith("-")) doSomething();
 
 // Template-literal arg to startsWith — not flagged
 if (p.startsWith(`${root}/`)) doSomething();
+
+// process.cwd() nested inside a helper call, not a direct === operand —
+// must NOT be flagged (thread #3 false-positive shape)
+if (pathEq(process.cwd(), root) === true) doSomething();
+const same = canonicalCwd() === storedRoot;

--- a/scripts/rules/fixtures/no-raw-path-handling__flagged.fixture.ts
+++ b/scripts/rules/fixtures/no-raw-path-handling__flagged.fixture.ts
@@ -1,0 +1,16 @@
+/**
+ * @rule no-raw-path-handling
+ * @expect 3
+ * @path packages/daemon/src/example-flagged.ts
+ *
+ * Raw path handling patterns that should be flagged.
+ */
+
+// startsWith("/") — use path.isAbsolute instead
+if (target.startsWith("/")) doSomething();
+
+// startsWith("\\\\") — UNC path check, use path.isAbsolute instead
+if (target.startsWith("\\\\")) doSomething();
+
+// process.cwd() in === comparison (daemon scope)
+if (repoRoot === process.cwd()) doSomething();

--- a/scripts/rules/no-raw-path-handling.rule.ts
+++ b/scripts/rules/no-raw-path-handling.rule.ts
@@ -1,0 +1,78 @@
+/**
+ * Rule: no-raw-path-handling
+ *
+ * Catches two patterns of ad-hoc path handling that produce silent
+ * zero-match / cross-repo bugs when symlinks or subdir invocations
+ * are involved:
+ *
+ * 1. `s.startsWith("/")` (or `"\\\\")` used as an absolute-path test
+ *    instead of `path.isAbsolute(s)`.
+ *
+ * 2. (daemon only) `process.cwd()` compared with `===`/`!==` without
+ *    going through `resolveRealpath`/`canonicalCwd` — symlinked CWDs
+ *    silently fail the comparison.
+ */
+
+import ts from "typescript";
+import type { CheckRule } from "./_engine/rule";
+
+const SLASH = "/";
+const UNC_PREFIX = "\\\\";
+
+const rule: CheckRule = {
+  id: "no-raw-path-handling",
+  kind: "check",
+  scold: "raw path handling — use path.isAbsolute / pathEq / canonicalCwd instead",
+  guidance: [
+    'replace `s.startsWith("/")` with `path.isAbsolute(s)` (handles both Unix and Windows paths)',
+    "replace `a === process.cwd()` with `pathEq(a, b)` or compare against `canonicalCwd()`",
+    'import { pathEq, canonicalCwd } from "@mcp-cli/core" for realpath-normalized comparisons',
+  ],
+  documentation: "#2251",
+  appliesToTests: false,
+  check({ file, violated, ast }) {
+    if (!file.relPath.startsWith("packages/")) return;
+
+    const lines = file.content.split("\n");
+
+    // Detection 1: .startsWith("/") or .startsWith("\\\\") as abs-path check
+    for (const call of ast.callsTo("startsWith")) {
+      if (call.arguments.length < 1) continue;
+      const arg = call.arguments[0];
+      if (!ts.isStringLiteral(arg)) continue;
+      if (arg.text !== SLASH && arg.text !== UNC_PREFIX) continue;
+      const pos = ast.positionOf(call);
+      violated(pos.line, pos.column, (lines[pos.line - 1] ?? "").trim());
+    }
+
+    // Detection 2: process.cwd() in === / !== (daemon scope only)
+    if (!file.relPath.startsWith("packages/daemon/src/")) return;
+
+    for (const bin of ast.findByKind(ts.SyntaxKind.BinaryExpression) as ts.BinaryExpression[]) {
+      const op = bin.operatorToken.kind;
+      if (op !== ts.SyntaxKind.EqualsEqualsEqualsToken && op !== ts.SyntaxKind.ExclamationEqualsEqualsToken) continue;
+      if (!containsProcessCwd(bin.left) && !containsProcessCwd(bin.right)) continue;
+      const pos = ast.positionOf(bin);
+      violated(pos.line, pos.column, (lines[pos.line - 1] ?? "").trim());
+    }
+  },
+};
+
+function containsProcessCwd(node: ts.Node): boolean {
+  if (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    ts.isIdentifier(node.expression.expression) &&
+    node.expression.expression.text === "process" &&
+    node.expression.name.text === "cwd"
+  ) {
+    return true;
+  }
+  let found = false;
+  ts.forEachChild(node, (child) => {
+    if (containsProcessCwd(child)) found = true;
+  });
+  return found;
+}
+
+export default rule;

--- a/scripts/rules/no-raw-path-handling.rule.ts
+++ b/scripts/rules/no-raw-path-handling.rule.ts
@@ -35,7 +35,11 @@ const rule: CheckRule = {
 
     const lines = file.content.split("\n");
 
-    // Detection 1: .startsWith("/") or .startsWith("\\\\") as abs-path check
+    // Detection 1: .startsWith("/") or .startsWith("\\\\") as abs-path check.
+    // callsTo("startsWith") matches by method name only, not receiver type — any
+    // object method named startsWith with a "/" arg will be flagged. In practice
+    // all such calls in this codebase are string operations, but use dotw-ignore
+    // with a reason if you have a legitimate non-path startsWith("/") call.
     for (const call of ast.callsTo("startsWith")) {
       if (call.arguments.length < 1) continue;
       const arg = call.arguments[0];

--- a/scripts/rules/no-raw-path-handling.rule.ts
+++ b/scripts/rules/no-raw-path-handling.rule.ts
@@ -5,8 +5,8 @@
  * zero-match / cross-repo bugs when symlinks or subdir invocations
  * are involved:
  *
- * 1. `s.startsWith("/")` (or `"\\\\")` used as an absolute-path test
- *    instead of `path.isAbsolute(s)`.
+ * 1. `s.startsWith("/")` or `s.startsWith("\\\\")` used as an
+ *    absolute-path test instead of `path.isAbsolute(s)`.
  *
  * 2. (daemon only) `process.cwd()` compared with `===`/`!==` without
  *    going through `resolveRealpath`/`canonicalCwd` — symlinked CWDs
@@ -25,7 +25,7 @@ const rule: CheckRule = {
   scold: "raw path handling — use path.isAbsolute / pathEq / canonicalCwd instead",
   guidance: [
     'replace `s.startsWith("/")` with `path.isAbsolute(s)` (handles both Unix and Windows paths)',
-    "replace `a === process.cwd()` with `pathEq(a, b)` or compare against `canonicalCwd()`",
+    "replace `a === process.cwd()` with `pathEq(a, canonicalCwd())`",
     'import { pathEq, canonicalCwd } from "@mcp-cli/core" for realpath-normalized comparisons',
   ],
   documentation: "#2251",
@@ -45,34 +45,31 @@ const rule: CheckRule = {
       violated(pos.line, pos.column, (lines[pos.line - 1] ?? "").trim());
     }
 
-    // Detection 2: process.cwd() in === / !== (daemon scope only)
+    // Detection 2: process.cwd() as direct operand of === / !== (daemon scope only)
     if (!file.relPath.startsWith("packages/daemon/src/")) return;
 
     for (const bin of ast.findByKind(ts.SyntaxKind.BinaryExpression) as ts.BinaryExpression[]) {
       const op = bin.operatorToken.kind;
       if (op !== ts.SyntaxKind.EqualsEqualsEqualsToken && op !== ts.SyntaxKind.ExclamationEqualsEqualsToken) continue;
-      if (!containsProcessCwd(bin.left) && !containsProcessCwd(bin.right)) continue;
+      if (!isProcessCwd(bin.left) && !isProcessCwd(bin.right)) continue;
       const pos = ast.positionOf(bin);
       violated(pos.line, pos.column, (lines[pos.line - 1] ?? "").trim());
     }
   },
 };
 
-function containsProcessCwd(node: ts.Node): boolean {
-  if (
-    ts.isCallExpression(node) &&
-    ts.isPropertyAccessExpression(node.expression) &&
-    ts.isIdentifier(node.expression.expression) &&
-    node.expression.expression.text === "process" &&
-    node.expression.name.text === "cwd"
-  ) {
-    return true;
-  }
-  let found = false;
-  ts.forEachChild(node, (child) => {
-    if (containsProcessCwd(child)) found = true;
-  });
-  return found;
+/** Match `process.cwd()` optionally wrapped in parentheses — no recursive descent. */
+function isProcessCwd(node: ts.Node): boolean {
+  let n = node;
+  while (ts.isParenthesizedExpression(n)) n = n.expression;
+  return (
+    ts.isCallExpression(n) &&
+    n.arguments.length === 0 &&
+    ts.isPropertyAccessExpression(n.expression) &&
+    ts.isIdentifier(n.expression.expression) &&
+    n.expression.expression.text === "process" &&
+    n.expression.name.text === "cwd"
+  );
 }
 
 export default rule;


### PR DESCRIPTION
## Summary
- Add `pathEq(a, b)` and `canonicalCwd()` helpers to `packages/core/src/fs.ts` for realpath-normalized path comparison, eliminating symlink-related mismatches
- Add `no-raw-path-handling` AST-based doing-it-wrong rule that flags `startsWith("/")` / `startsWith("\\")` as absolute-path checks (use `path.isAbsolute`) and raw `process.cwd()` in `===`/`!==` comparisons within daemon code (use `pathEq`/`canonicalCwd`)
- Migrate all 8 existing violations across 5 files (containment.ts, phase.ts, run.ts, daemon/index.ts, patcher.ts) to use `path.isAbsolute`

## Test plan
- [x] `pathEq` tests: identical paths, symlink-resolved equality, different paths
- [x] `canonicalCwd` test: returns realpath of cwd
- [x] Rule fixtures: clean fixture (0 violations), flagged fixture (3 violations — startsWith("/"), startsWith("\\\\"), process.cwd() ===)
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun run doing-it-wrong` — 0 violations across 3 rules
- [x] Full test suite: 7749 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)