### PR TITLE
feat(rules): mechanical checks for vacuous/behavior-blind test assertions (fixes #2247)

### DIFF
--- a/packages/acp/src/acp-session.spec.ts
+++ b/packages/acp/src/acp-session.spec.ts
@@ -307,7 +307,7 @@ describe("AcpSession server requests", () => {
         await Bun.write(probePath, ""); // cleanup
         const { unlinkSync } = await import("node:fs");
         unlinkSync(probePath);
-      // dotw-todo test-empty-catch: cleanup — fix in #2322
+        // dotw-todo test-empty-catch: cleanup — fix in #2322
       } catch {
         // ignore cleanup errors
       }

--- a/packages/acp/src/acp-session.spec.ts
+++ b/packages/acp/src/acp-session.spec.ts
@@ -307,6 +307,7 @@ describe("AcpSession server requests", () => {
         await Bun.write(probePath, ""); // cleanup
         const { unlinkSync } = await import("node:fs");
         unlinkSync(probePath);
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
       } catch {
         // ignore cleanup errors
       }

--- a/packages/command/src/commands/config.spec.ts
+++ b/packages/command/src/commands/config.spec.ts
@@ -557,7 +557,7 @@ describe("configGetServer error handling", () => {
 
     try {
       await configGetServer(["nonexistent"], deps);
-    // dotw-todo test-empty-catch: exit-spy — fix in #2322
+      // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -591,7 +591,7 @@ describe("configSetServerEnv error handling", () => {
 
     try {
       await configSetServerEnv(["nonexistent", "env", "K:V"], deps);
-    // dotw-todo test-empty-catch: exit-spy — fix in #2322
+      // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -612,7 +612,7 @@ describe("configSetServerEnv error handling", () => {
 
     try {
       await configSetServerEnv(["srv", "env", "K:V"], deps);
-    // dotw-todo test-empty-catch: exit-spy — fix in #2322
+      // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -633,7 +633,7 @@ describe("configSetServerEnv error handling", () => {
 
     try {
       await configSetServerEnv(["srv", "env", "K:V"], deps);
-    // dotw-todo test-empty-catch: exit-spy — fix in #2322
+      // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -651,7 +651,7 @@ describe("configSetServerEnv error handling", () => {
 
     try {
       await configSetServerEnv(["srv", "env", "invalidformat"], deps);
-    // dotw-todo test-empty-catch: exit-spy — fix in #2322
+      // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -721,7 +721,7 @@ describe("configSetServerUrl", () => {
 
     try {
       await configSetServerUrl(["srv", "url", "https://example.com"], deps);
-    // dotw-todo test-empty-catch: exit-spy — fix in #2322
+      // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -739,7 +739,7 @@ describe("configSetServerUrl", () => {
 
     try {
       await configSetServerUrl(["nonexistent", "url", "https://example.com"], deps);
-    // dotw-todo test-empty-catch: exit-spy — fix in #2322
+      // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -760,7 +760,7 @@ describe("configSetServerUrl", () => {
 
     try {
       await configSetServerUrl(["srv", "url", "https://example.com"], deps);
-    // dotw-todo test-empty-catch: exit-spy — fix in #2322
+      // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -830,7 +830,7 @@ describe("configSetServerArgs", () => {
 
     try {
       await configSetServerArgs(["srv", "args", "foo"], deps);
-    // dotw-todo test-empty-catch: exit-spy — fix in #2322
+      // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -848,7 +848,7 @@ describe("configSetServerArgs", () => {
 
     try {
       await configSetServerArgs(["nonexistent", "args", "foo"], deps);
-    // dotw-todo test-empty-catch: exit-spy — fix in #2322
+      // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -866,7 +866,7 @@ describe("configSetServerArgs", () => {
 
     try {
       await configSetServerArgs(["srv", "args"], deps);
-    // dotw-todo test-empty-catch: exit-spy — fix in #2322
+      // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -999,7 +999,7 @@ function readConfigFrom(path: string): Record<string, unknown> {
   try {
     const text = readFileSync(path, "utf-8");
     return JSON.parse(text);
-  // dotw-todo test-empty-catch: parse-probe — fix in #2322
+    // dotw-todo test-empty-catch: parse-probe — fix in #2322
   } catch {
     return {};
   }
@@ -1076,7 +1076,7 @@ describe("configGetBudget", () => {
 
     try {
       await configGetBudget("budget.unknown");
-    // dotw-todo test-empty-catch: exit-spy — fix in #2322
+      // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -1141,7 +1141,7 @@ describe("configSetBudget", () => {
 
     try {
       await configSetBudget("budget.unknown", "5");
-    // dotw-todo test-empty-catch: exit-spy — fix in #2322
+      // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -1157,7 +1157,7 @@ describe("configSetBudget", () => {
 
     try {
       await configSetBudget("budget.session-cap", undefined);
-    // dotw-todo test-empty-catch: exit-spy — fix in #2322
+      // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -1173,7 +1173,7 @@ describe("configSetBudget", () => {
 
     try {
       await configSetBudget("budget.quota-thresholds", "abc,def");
-    // dotw-todo test-empty-catch: exit-spy — fix in #2322
+      // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -1189,7 +1189,7 @@ describe("configSetBudget", () => {
 
     try {
       await configSetBudget("budget.quota-thresholds", "50,150");
-    // dotw-todo test-empty-catch: exit-spy — fix in #2322
+      // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -1205,7 +1205,7 @@ describe("configSetBudget", () => {
 
     try {
       await configSetBudget("budget.sprint-window-hours", "0");
-    // dotw-todo test-empty-catch: exit-spy — fix in #2322
+      // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -1221,7 +1221,7 @@ describe("configSetBudget", () => {
 
     try {
       await configSetBudget("budget.sprint-window-hours", "abc");
-    // dotw-todo test-empty-catch: exit-spy — fix in #2322
+      // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -1237,7 +1237,7 @@ describe("configSetBudget", () => {
 
     try {
       await configSetBudget("budget.session-cap", "-5");
-    // dotw-todo test-empty-catch: exit-spy — fix in #2322
+      // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -1253,7 +1253,7 @@ describe("configSetBudget", () => {
 
     try {
       await configSetBudget("budget.session-cap", "abc");
-    // dotw-todo test-empty-catch: exit-spy — fix in #2322
+      // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }

--- a/packages/command/src/commands/config.spec.ts
+++ b/packages/command/src/commands/config.spec.ts
@@ -557,6 +557,7 @@ describe("configGetServer error handling", () => {
 
     try {
       await configGetServer(["nonexistent"], deps);
+    // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -590,6 +591,7 @@ describe("configSetServerEnv error handling", () => {
 
     try {
       await configSetServerEnv(["nonexistent", "env", "K:V"], deps);
+    // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -610,6 +612,7 @@ describe("configSetServerEnv error handling", () => {
 
     try {
       await configSetServerEnv(["srv", "env", "K:V"], deps);
+    // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -630,6 +633,7 @@ describe("configSetServerEnv error handling", () => {
 
     try {
       await configSetServerEnv(["srv", "env", "K:V"], deps);
+    // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -647,6 +651,7 @@ describe("configSetServerEnv error handling", () => {
 
     try {
       await configSetServerEnv(["srv", "env", "invalidformat"], deps);
+    // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -716,6 +721,7 @@ describe("configSetServerUrl", () => {
 
     try {
       await configSetServerUrl(["srv", "url", "https://example.com"], deps);
+    // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -733,6 +739,7 @@ describe("configSetServerUrl", () => {
 
     try {
       await configSetServerUrl(["nonexistent", "url", "https://example.com"], deps);
+    // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -753,6 +760,7 @@ describe("configSetServerUrl", () => {
 
     try {
       await configSetServerUrl(["srv", "url", "https://example.com"], deps);
+    // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -822,6 +830,7 @@ describe("configSetServerArgs", () => {
 
     try {
       await configSetServerArgs(["srv", "args", "foo"], deps);
+    // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -839,6 +848,7 @@ describe("configSetServerArgs", () => {
 
     try {
       await configSetServerArgs(["nonexistent", "args", "foo"], deps);
+    // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -856,6 +866,7 @@ describe("configSetServerArgs", () => {
 
     try {
       await configSetServerArgs(["srv", "args"], deps);
+    // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -988,6 +999,7 @@ function readConfigFrom(path: string): Record<string, unknown> {
   try {
     const text = readFileSync(path, "utf-8");
     return JSON.parse(text);
+  // dotw-todo test-empty-catch: parse-probe — fix in #2322
   } catch {
     return {};
   }
@@ -1064,6 +1076,7 @@ describe("configGetBudget", () => {
 
     try {
       await configGetBudget("budget.unknown");
+    // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -1128,6 +1141,7 @@ describe("configSetBudget", () => {
 
     try {
       await configSetBudget("budget.unknown", "5");
+    // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -1143,6 +1157,7 @@ describe("configSetBudget", () => {
 
     try {
       await configSetBudget("budget.session-cap", undefined);
+    // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -1158,6 +1173,7 @@ describe("configSetBudget", () => {
 
     try {
       await configSetBudget("budget.quota-thresholds", "abc,def");
+    // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -1173,6 +1189,7 @@ describe("configSetBudget", () => {
 
     try {
       await configSetBudget("budget.quota-thresholds", "50,150");
+    // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -1188,6 +1205,7 @@ describe("configSetBudget", () => {
 
     try {
       await configSetBudget("budget.sprint-window-hours", "0");
+    // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -1203,6 +1221,7 @@ describe("configSetBudget", () => {
 
     try {
       await configSetBudget("budget.sprint-window-hours", "abc");
+    // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -1218,6 +1237,7 @@ describe("configSetBudget", () => {
 
     try {
       await configSetBudget("budget.session-cap", "-5");
+    // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }
@@ -1233,6 +1253,7 @@ describe("configSetBudget", () => {
 
     try {
       await configSetBudget("budget.session-cap", "abc");
+    // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch {
       // expected
     }

--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -2842,6 +2842,7 @@ phases:
     const jsonLog = logs.find((l) => {
       try {
         return JSON.parse(l).repoRoot !== undefined;
+        // dotw-todo test-empty-catch: parse-probe — fix in #2322
       } catch {
         return false;
       }

--- a/packages/command/src/commands/site.spec.ts
+++ b/packages/command/src/commands/site.spec.ts
@@ -115,7 +115,7 @@ describe("cmdSite", () => {
     let caught: unknown;
     try {
       await cmdSite(["bogus"], deps);
-    // dotw-todo test-empty-catch: exit-spy — fix in #2322
+      // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch (e) {
       caught = e;
     }
@@ -236,7 +236,7 @@ describe("cmdSite", () => {
       let caught: unknown;
       try {
         await cmdSite(input, deps);
-      // dotw-todo test-empty-catch: exit-spy — fix in #2322
+        // dotw-todo test-empty-catch: exit-spy — fix in #2322
       } catch (e) {
         caught = e;
       }
@@ -296,7 +296,7 @@ describe("cmdSite", () => {
     let caught: unknown;
     try {
       await cmdSite(["list"], deps);
-    // dotw-todo test-empty-catch: exit-spy — fix in #2322
+      // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch (e) {
       caught = e;
     }

--- a/packages/command/src/commands/site.spec.ts
+++ b/packages/command/src/commands/site.spec.ts
@@ -115,6 +115,7 @@ describe("cmdSite", () => {
     let caught: unknown;
     try {
       await cmdSite(["bogus"], deps);
+    // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch (e) {
       caught = e;
     }
@@ -235,6 +236,7 @@ describe("cmdSite", () => {
       let caught: unknown;
       try {
         await cmdSite(input, deps);
+      // dotw-todo test-empty-catch: exit-spy — fix in #2322
       } catch (e) {
         caught = e;
       }
@@ -294,6 +296,7 @@ describe("cmdSite", () => {
     let caught: unknown;
     try {
       await cmdSite(["list"], deps);
+    // dotw-todo test-empty-catch: exit-spy — fix in #2322
     } catch (e) {
       caught = e;
     }

--- a/packages/command/src/commands/track.spec.ts
+++ b/packages/command/src/commands/track.spec.ts
@@ -31,7 +31,7 @@ function makeDeps(overrides: Partial<Record<IpcMethod, unknown>> = {}): TrackDep
 const realManifestLoader = (dir: string): Manifest | null => {
   try {
     return loadManifest(dir)?.manifest ?? null;
-  // dotw-todo test-empty-catch: parse-probe — fix in #2322
+    // dotw-todo test-empty-catch: parse-probe — fix in #2322
   } catch {
     return null;
   }

--- a/packages/command/src/commands/track.spec.ts
+++ b/packages/command/src/commands/track.spec.ts
@@ -31,6 +31,7 @@ function makeDeps(overrides: Partial<Record<IpcMethod, unknown>> = {}): TrackDep
 const realManifestLoader = (dir: string): Manifest | null => {
   try {
     return loadManifest(dir)?.manifest ?? null;
+  // dotw-todo test-empty-catch: parse-probe — fix in #2322
   } catch {
     return null;
   }

--- a/packages/command/src/daemon-lifecycle.spec.ts
+++ b/packages/command/src/daemon-lifecycle.spec.ts
@@ -280,6 +280,7 @@ describe("startup lock file", () => {
   afterEach(() => {
     try {
       unlinkSync(LOCK_FILE);
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* already gone */
     }
@@ -318,6 +319,7 @@ describe("startup lock file", () => {
     expect(() => {
       try {
         unlinkSync(LOCK_FILE);
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
       } catch {
         /* already gone — this is the expected path */
       }
@@ -329,6 +331,7 @@ describe("concurrent daemon startup simulation", () => {
   afterEach(() => {
     try {
       unlinkSync(LOCK_FILE);
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* already gone */
     }
@@ -344,6 +347,7 @@ describe("concurrent daemon startup simulation", () => {
           new Promise<number>((resolve, reject) => {
             try {
               resolve(openSync(LOCK_FILE, "wx"));
+            // dotw-todo test-empty-catch: exit-spy — fix in #2322
             } catch (e) {
               reject(e);
             }
@@ -495,6 +499,7 @@ describe("getSourceStalenessWarning", () => {
     // Clean up
     try {
       unlinkSync(join(srcDir, "test.ts"));
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* ignore */
     }

--- a/packages/command/src/daemon-lifecycle.spec.ts
+++ b/packages/command/src/daemon-lifecycle.spec.ts
@@ -280,7 +280,7 @@ describe("startup lock file", () => {
   afterEach(() => {
     try {
       unlinkSync(LOCK_FILE);
-    // dotw-todo test-empty-catch: cleanup — fix in #2322
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* already gone */
     }
@@ -319,7 +319,7 @@ describe("startup lock file", () => {
     expect(() => {
       try {
         unlinkSync(LOCK_FILE);
-      // dotw-todo test-empty-catch: cleanup — fix in #2322
+        // dotw-todo test-empty-catch: cleanup — fix in #2322
       } catch {
         /* already gone — this is the expected path */
       }
@@ -331,7 +331,7 @@ describe("concurrent daemon startup simulation", () => {
   afterEach(() => {
     try {
       unlinkSync(LOCK_FILE);
-    // dotw-todo test-empty-catch: cleanup — fix in #2322
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* already gone */
     }
@@ -347,7 +347,7 @@ describe("concurrent daemon startup simulation", () => {
           new Promise<number>((resolve, reject) => {
             try {
               resolve(openSync(LOCK_FILE, "wx"));
-            // dotw-todo test-empty-catch: exit-spy — fix in #2322
+              // dotw-todo test-empty-catch: exit-spy — fix in #2322
             } catch (e) {
               reject(e);
             }
@@ -499,7 +499,7 @@ describe("getSourceStalenessWarning", () => {
     // Clean up
     try {
       unlinkSync(join(srcDir, "test.ts"));
-    // dotw-todo test-empty-catch: cleanup — fix in #2322
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* ignore */
     }

--- a/packages/command/src/file-read.spec.ts
+++ b/packages/command/src/file-read.spec.ts
@@ -75,7 +75,7 @@ describe("path containment guard", () => {
     const link = join(TMP, "escape-link");
     try {
       rmSync(link);
-    // dotw-todo test-empty-catch: cleanup — fix in #2322
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* may not exist */
     }

--- a/packages/command/src/file-read.spec.ts
+++ b/packages/command/src/file-read.spec.ts
@@ -75,6 +75,7 @@ describe("path containment guard", () => {
     const link = join(TMP, "escape-link");
     try {
       rmSync(link);
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* may not exist */
     }

--- a/packages/command/src/tty/headless.spec.ts
+++ b/packages/command/src/tty/headless.spec.ts
@@ -32,7 +32,7 @@ describe("spawnHeadless with real spawn", () => {
       try {
         logContent = readFileSync(result.logFile, "utf-8");
         if (logContent.includes("headless-test-output")) break;
-      // dotw-todo test-empty-catch: parse-probe — fix in #2322
+        // dotw-todo test-empty-catch: parse-probe — fix in #2322
       } catch {
         // File may not exist yet
       }

--- a/packages/command/src/tty/headless.spec.ts
+++ b/packages/command/src/tty/headless.spec.ts
@@ -32,6 +32,7 @@ describe("spawnHeadless with real spawn", () => {
       try {
         logContent = readFileSync(result.logFile, "utf-8");
         if (logContent.includes("headless-test-output")) break;
+      // dotw-todo test-empty-catch: parse-probe — fix in #2322
       } catch {
         // File may not exist yet
       }

--- a/packages/control/src/hooks/registry-client.spec.ts
+++ b/packages/control/src/hooks/registry-client.spec.ts
@@ -179,6 +179,7 @@ describe("searchRegistry / listRegistry", () => {
     _setCacheDir(null);
     try {
       rmSync(tmpCacheDir, { recursive: true });
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {}
   });
 

--- a/packages/control/src/hooks/registry-client.spec.ts
+++ b/packages/control/src/hooks/registry-client.spec.ts
@@ -179,7 +179,7 @@ describe("searchRegistry / listRegistry", () => {
     _setCacheDir(null);
     try {
       rmSync(tmpCacheDir, { recursive: true });
-    // dotw-todo test-empty-catch: cleanup — fix in #2322
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {}
   });
 

--- a/packages/core/src/flock.spec.ts
+++ b/packages/core/src/flock.spec.ts
@@ -16,6 +16,7 @@ describe("tryFlockExclusive", () => {
     if (fd1 !== null) {
       try {
         closeSync(fd1);
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
       } catch {
         /* already closed */
       }
@@ -23,6 +24,7 @@ describe("tryFlockExclusive", () => {
     if (fd2 !== null) {
       try {
         closeSync(fd2);
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
       } catch {
         /* already closed */
       }
@@ -31,6 +33,7 @@ describe("tryFlockExclusive", () => {
     fd2 = null;
     try {
       unlinkSync(file);
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* already gone */
     }
@@ -88,6 +91,7 @@ describe("cross-process flock", () => {
   afterEach(() => {
     try {
       unlinkSync(file);
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* already gone */
     }

--- a/packages/core/src/flock.spec.ts
+++ b/packages/core/src/flock.spec.ts
@@ -16,7 +16,7 @@ describe("tryFlockExclusive", () => {
     if (fd1 !== null) {
       try {
         closeSync(fd1);
-      // dotw-todo test-empty-catch: cleanup — fix in #2322
+        // dotw-todo test-empty-catch: cleanup — fix in #2322
       } catch {
         /* already closed */
       }
@@ -24,7 +24,7 @@ describe("tryFlockExclusive", () => {
     if (fd2 !== null) {
       try {
         closeSync(fd2);
-      // dotw-todo test-empty-catch: cleanup — fix in #2322
+        // dotw-todo test-empty-catch: cleanup — fix in #2322
       } catch {
         /* already closed */
       }
@@ -33,7 +33,7 @@ describe("tryFlockExclusive", () => {
     fd2 = null;
     try {
       unlinkSync(file);
-    // dotw-todo test-empty-catch: cleanup — fix in #2322
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* already gone */
     }
@@ -91,7 +91,7 @@ describe("cross-process flock", () => {
   afterEach(() => {
     try {
       unlinkSync(file);
-    // dotw-todo test-empty-catch: cleanup — fix in #2322
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* already gone */
     }

--- a/packages/core/src/telemetry.spec.ts
+++ b/packages/core/src/telemetry.spec.ts
@@ -246,6 +246,7 @@ describe("device-id persistence", () => {
         const deviceIdPath = join(_opts.MCP_CLI_DIR, "device-id");
         try {
           return readFileSync(deviceIdPath, "utf-8").trim();
+        // dotw-todo test-empty-catch: parse-probe — fix in #2322
         } catch {
           return "fallback-id";
         }

--- a/packages/core/src/telemetry.spec.ts
+++ b/packages/core/src/telemetry.spec.ts
@@ -246,7 +246,7 @@ describe("device-id persistence", () => {
         const deviceIdPath = join(_opts.MCP_CLI_DIR, "device-id");
         try {
           return readFileSync(deviceIdPath, "utf-8").trim();
-        // dotw-todo test-empty-catch: parse-probe — fix in #2322
+          // dotw-todo test-empty-catch: parse-probe — fix in #2322
         } catch {
           return "fallback-id";
         }

--- a/packages/daemon/src/alias-state.spec.ts
+++ b/packages/daemon/src/alias-state.spec.ts
@@ -22,7 +22,7 @@ function cleanupDb(p: string): void {
   for (const suffix of ["", "-wal", "-shm"]) {
     try {
       unlinkSync(p + suffix);
-    // dotw-todo test-empty-catch: cleanup — fix in #2322
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* ignore */
     }
@@ -68,7 +68,7 @@ describe("aliasState IPC handlers — repoRoot canonicalization", () => {
     server = undefined;
     try {
       unlinkSync(socketPath);
-    // dotw-todo test-empty-catch: cleanup — fix in #2322
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* ignore */
     }

--- a/packages/daemon/src/alias-state.spec.ts
+++ b/packages/daemon/src/alias-state.spec.ts
@@ -22,6 +22,7 @@ function cleanupDb(p: string): void {
   for (const suffix of ["", "-wal", "-shm"]) {
     try {
       unlinkSync(p + suffix);
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* ignore */
     }
@@ -67,6 +68,7 @@ describe("aliasState IPC handlers — repoRoot canonicalization", () => {
     server = undefined;
     try {
       unlinkSync(socketPath);
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* ignore */
     }

--- a/packages/daemon/src/auth/callback-server.spec.ts
+++ b/packages/daemon/src/auth/callback-server.spec.ts
@@ -128,6 +128,7 @@ describe("startCallbackServer", () => {
     try {
       await fetch(`http://localhost:${port}/callback?code=again`);
       // If we get here, the server is still running (unexpected but not fatal)
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       // Expected: connection refused
     }

--- a/packages/daemon/src/auth/callback-server.spec.ts
+++ b/packages/daemon/src/auth/callback-server.spec.ts
@@ -128,7 +128,7 @@ describe("startCallbackServer", () => {
     try {
       await fetch(`http://localhost:${port}/callback?code=again`);
       // If we get here, the server is still running (unexpected but not fatal)
-    // dotw-todo test-empty-catch: cleanup — fix in #2322
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       // Expected: connection refused
     }

--- a/packages/daemon/src/auth/oauth-provider.spec.ts
+++ b/packages/daemon/src/auth/oauth-provider.spec.ts
@@ -25,6 +25,7 @@ function cleanup(path: string): void {
   for (const suffix of ["", "-wal", "-shm"]) {
     try {
       unlinkSync(`${path}${suffix}`);
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       // ignore
     }

--- a/packages/daemon/src/auth/oauth-provider.spec.ts
+++ b/packages/daemon/src/auth/oauth-provider.spec.ts
@@ -25,7 +25,7 @@ function cleanup(path: string): void {
   for (const suffix of ["", "-wal", "-shm"]) {
     try {
       unlinkSync(`${path}${suffix}`);
-    // dotw-todo test-empty-catch: cleanup — fix in #2322
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       // ignore
     }

--- a/packages/daemon/src/auth/oauth-retry.spec.ts
+++ b/packages/daemon/src/auth/oauth-retry.spec.ts
@@ -17,6 +17,7 @@ function cleanup(path: string): void {
   for (const suffix of ["", "-wal", "-shm"]) {
     try {
       unlinkSync(`${path}${suffix}`);
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       // ignore
     }

--- a/packages/daemon/src/auth/oauth-retry.spec.ts
+++ b/packages/daemon/src/auth/oauth-retry.spec.ts
@@ -17,7 +17,7 @@ function cleanup(path: string): void {
   for (const suffix of ["", "-wal", "-shm"]) {
     try {
       unlinkSync(`${path}${suffix}`);
-    // dotw-todo test-empty-catch: cleanup — fix in #2322
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       // ignore
     }

--- a/packages/daemon/src/budget-watcher.spec.ts
+++ b/packages/daemon/src/budget-watcher.spec.ts
@@ -30,7 +30,7 @@ function cleanupDbs(): void {
     for (const suffix of ["", "-wal", "-shm"]) {
       try {
         unlinkSync(`${p}${suffix}`);
-      // dotw-todo test-empty-catch: cleanup — fix in #2322
+        // dotw-todo test-empty-catch: cleanup — fix in #2322
       } catch {
         /* ignore */
       }

--- a/packages/daemon/src/budget-watcher.spec.ts
+++ b/packages/daemon/src/budget-watcher.spec.ts
@@ -30,6 +30,7 @@ function cleanupDbs(): void {
     for (const suffix of ["", "-wal", "-shm"]) {
       try {
         unlinkSync(`${p}${suffix}`);
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
       } catch {
         /* ignore */
       }

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -3161,7 +3161,7 @@ describe("readJsonlTranscript", () => {
   afterEach(() => {
     try {
       rmSync(testDir, { recursive: true });
-    // dotw-todo test-empty-catch: cleanup — fix in #2322
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       // ignore
     }
@@ -3289,7 +3289,7 @@ describe("getTranscript JSONL fallback", () => {
     server?.stop();
     try {
       rmSync(testDir, { recursive: true });
-    // dotw-todo test-empty-catch: cleanup — fix in #2322
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       // ignore
     }

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -3161,6 +3161,7 @@ describe("readJsonlTranscript", () => {
   afterEach(() => {
     try {
       rmSync(testDir, { recursive: true });
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       // ignore
     }
@@ -3288,6 +3289,7 @@ describe("getTranscript JSONL fallback", () => {
     server?.stop();
     try {
       rmSync(testDir, { recursive: true });
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       // ignore
     }

--- a/packages/daemon/src/daemon-log.spec.ts
+++ b/packages/daemon/src/daemon-log.spec.ts
@@ -93,6 +93,7 @@ describe("daemon-log file", () => {
     closeDaemonLogFile();
     try {
       rmSync(testDir, { recursive: true });
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       // already gone
     }
@@ -136,6 +137,7 @@ describe("daemon-log file", () => {
     try {
       readFileSync(backupPath);
       backupExists = true;
+    // dotw-todo test-empty-catch: parse-probe — fix in #2322
     } catch {
       // no backup
     }

--- a/packages/daemon/src/daemon-log.spec.ts
+++ b/packages/daemon/src/daemon-log.spec.ts
@@ -93,7 +93,7 @@ describe("daemon-log file", () => {
     closeDaemonLogFile();
     try {
       rmSync(testDir, { recursive: true });
-    // dotw-todo test-empty-catch: cleanup — fix in #2322
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       // already gone
     }
@@ -137,7 +137,7 @@ describe("daemon-log file", () => {
     try {
       readFileSync(backupPath);
       backupExists = true;
-    // dotw-todo test-empty-catch: parse-probe — fix in #2322
+      // dotw-todo test-empty-catch: parse-probe — fix in #2322
     } catch {
       // no backup
     }

--- a/packages/daemon/src/db/state.spec.ts
+++ b/packages/daemon/src/db/state.spec.ts
@@ -13,16 +13,19 @@ function tmpDb(): string {
 function cleanup(path: string): void {
   try {
     unlinkSync(path);
+  // dotw-todo test-empty-catch: cleanup — fix in #2322
   } catch {
     // ignore
   }
   try {
     unlinkSync(`${path}-wal`);
+  // dotw-todo test-empty-catch: cleanup — fix in #2322
   } catch {
     // ignore
   }
   try {
     unlinkSync(`${path}-shm`);
+  // dotw-todo test-empty-catch: cleanup — fix in #2322
   } catch {
     // ignore
   }
@@ -1933,6 +1936,7 @@ describe("StateDb", () => {
       } finally {
         try {
           unlinkSync(symlinkDir);
+        // dotw-todo test-empty-catch: cleanup — fix in #2322
         } catch {
           // ignore
         }
@@ -1992,6 +1996,7 @@ describe("StateDb", () => {
       } finally {
         try {
           unlinkSync(symlinkDir);
+        // dotw-todo test-empty-catch: cleanup — fix in #2322
         } catch {
           // ignore
         }

--- a/packages/daemon/src/db/state.spec.ts
+++ b/packages/daemon/src/db/state.spec.ts
@@ -13,19 +13,19 @@ function tmpDb(): string {
 function cleanup(path: string): void {
   try {
     unlinkSync(path);
-  // dotw-todo test-empty-catch: cleanup — fix in #2322
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
   } catch {
     // ignore
   }
   try {
     unlinkSync(`${path}-wal`);
-  // dotw-todo test-empty-catch: cleanup — fix in #2322
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
   } catch {
     // ignore
   }
   try {
     unlinkSync(`${path}-shm`);
-  // dotw-todo test-empty-catch: cleanup — fix in #2322
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
   } catch {
     // ignore
   }
@@ -1936,7 +1936,7 @@ describe("StateDb", () => {
       } finally {
         try {
           unlinkSync(symlinkDir);
-        // dotw-todo test-empty-catch: cleanup — fix in #2322
+          // dotw-todo test-empty-catch: cleanup — fix in #2322
         } catch {
           // ignore
         }
@@ -1996,7 +1996,7 @@ describe("StateDb", () => {
       } finally {
         try {
           unlinkSync(symlinkDir);
-        // dotw-todo test-empty-catch: cleanup — fix in #2322
+          // dotw-todo test-empty-catch: cleanup — fix in #2322
         } catch {
           // ignore
         }

--- a/packages/daemon/src/db/work-items.spec.ts
+++ b/packages/daemon/src/db/work-items.spec.ts
@@ -13,6 +13,7 @@ function cleanup(path: string): void {
   for (const suffix of ["", "-wal", "-shm"]) {
     try {
       unlinkSync(`${path}${suffix}`);
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* ignore */
     }
@@ -739,6 +740,7 @@ describe("WorkItemDb", () => {
         try {
           wi.updateWorkItem(itemId, { ciSummary: `conn-${i}` });
           results.push(true);
+        // dotw-todo test-empty-catch: parse-probe — fix in #2322
         } catch {
           results.push(false);
         } finally {

--- a/packages/daemon/src/db/work-items.spec.ts
+++ b/packages/daemon/src/db/work-items.spec.ts
@@ -13,7 +13,7 @@ function cleanup(path: string): void {
   for (const suffix of ["", "-wal", "-shm"]) {
     try {
       unlinkSync(`${path}${suffix}`);
-    // dotw-todo test-empty-catch: cleanup — fix in #2322
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* ignore */
     }
@@ -740,7 +740,7 @@ describe("WorkItemDb", () => {
         try {
           wi.updateWorkItem(itemId, { ciSummary: `conn-${i}` });
           results.push(true);
-        // dotw-todo test-empty-catch: parse-probe — fix in #2322
+          // dotw-todo test-empty-catch: parse-probe — fix in #2322
         } catch {
           results.push(false);
         } finally {

--- a/packages/daemon/src/index.spec.ts
+++ b/packages/daemon/src/index.spec.ts
@@ -420,7 +420,7 @@ describe("daemon index.ts", () => {
         try {
           const pidAfter = JSON.parse(readFileSync(pidFile, "utf-8"));
           return pidAfter.configHash !== hashBefore;
-        // dotw-todo test-empty-catch: parse-probe — fix in #2322
+          // dotw-todo test-empty-catch: parse-probe — fix in #2322
         } catch {
           return false;
         }

--- a/packages/daemon/src/index.spec.ts
+++ b/packages/daemon/src/index.spec.ts
@@ -420,6 +420,7 @@ describe("daemon index.ts", () => {
         try {
           const pidAfter = JSON.parse(readFileSync(pidFile, "utf-8"));
           return pidAfter.configHash !== hashBefore;
+        // dotw-todo test-empty-catch: parse-probe — fix in #2322
         } catch {
           return false;
         }

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -103,7 +103,7 @@ describe("IpcServer HTTP transport", () => {
     server = undefined;
     try {
       unlinkSync(socketPath);
-    // dotw-todo test-empty-catch: cleanup — fix in #2322
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* already cleaned up */
     }
@@ -161,7 +161,7 @@ describe("IpcServer HTTP transport", () => {
       sharedServer?.stop();
       try {
         unlinkSync(sharedSocket);
-      // dotw-todo test-empty-catch: cleanup — fix in #2322
+        // dotw-todo test-empty-catch: cleanup — fix in #2322
       } catch {
         /* already cleaned up */
       }
@@ -3315,7 +3315,7 @@ describe("IpcServer HTTP transport", () => {
       for (const l of buffer.split("\n").filter((s) => s.startsWith("{"))) {
         try {
           parsed.push(JSON.parse(l) as Record<string, unknown>);
-        // dotw-todo test-empty-catch: parse-probe — fix in #2322
+          // dotw-todo test-empty-catch: parse-probe — fix in #2322
         } catch {
           /* partial chunk */
         }

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -103,6 +103,7 @@ describe("IpcServer HTTP transport", () => {
     server = undefined;
     try {
       unlinkSync(socketPath);
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* already cleaned up */
     }
@@ -160,6 +161,7 @@ describe("IpcServer HTTP transport", () => {
       sharedServer?.stop();
       try {
         unlinkSync(sharedSocket);
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
       } catch {
         /* already cleaned up */
       }
@@ -3313,6 +3315,7 @@ describe("IpcServer HTTP transport", () => {
       for (const l of buffer.split("\n").filter((s) => s.startsWith("{"))) {
         try {
           parsed.push(JSON.parse(l) as Record<string, unknown>);
+        // dotw-todo test-empty-catch: parse-probe — fix in #2322
         } catch {
           /* partial chunk */
         }

--- a/packages/daemon/src/lifecycle-events.spec.ts
+++ b/packages/daemon/src/lifecycle-events.spec.ts
@@ -16,6 +16,7 @@ afterEach(() => {
   for (const db of openDbs)
     try {
       db.close();
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* already closed */
     }

--- a/packages/daemon/src/lifecycle-events.spec.ts
+++ b/packages/daemon/src/lifecycle-events.spec.ts
@@ -16,7 +16,7 @@ afterEach(() => {
   for (const db of openDbs)
     try {
       db.close();
-    // dotw-todo test-empty-catch: cleanup — fix in #2322
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* already closed */
     }

--- a/packages/daemon/src/open-event-stream.spec.ts
+++ b/packages/daemon/src/open-event-stream.spec.ts
@@ -104,7 +104,7 @@ describe("openEventStream() client integration", () => {
     _restoreOptions();
     try {
       unlinkSync(socketPath);
-    // dotw-todo test-empty-catch: cleanup — fix in #2322
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* already cleaned up */
     }
@@ -283,7 +283,7 @@ describe("openEventStream() client integration", () => {
       malformServer.stop(true);
       try {
         unlinkSync(malformSocket);
-      // dotw-todo test-empty-catch: cleanup — fix in #2322
+        // dotw-todo test-empty-catch: cleanup — fix in #2322
       } catch {
         /* already cleaned up */
       }

--- a/packages/daemon/src/open-event-stream.spec.ts
+++ b/packages/daemon/src/open-event-stream.spec.ts
@@ -104,6 +104,7 @@ describe("openEventStream() client integration", () => {
     _restoreOptions();
     try {
       unlinkSync(socketPath);
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* already cleaned up */
     }
@@ -282,6 +283,7 @@ describe("openEventStream() client integration", () => {
       malformServer.stop(true);
       try {
         unlinkSync(malformSocket);
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
       } catch {
         /* already cleaned up */
       }

--- a/packages/daemon/src/orphan-reaper.spec.ts
+++ b/packages/daemon/src/orphan-reaper.spec.ts
@@ -14,7 +14,7 @@ function cleanup(path: string): void {
   for (const suffix of ["", "-wal", "-shm"]) {
     try {
       unlinkSync(path + suffix);
-    // dotw-todo test-empty-catch: cleanup — fix in #2322
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       // ignore
     }

--- a/packages/daemon/src/orphan-reaper.spec.ts
+++ b/packages/daemon/src/orphan-reaper.spec.ts
@@ -14,6 +14,7 @@ function cleanup(path: string): void {
   for (const suffix of ["", "-wal", "-shm"]) {
     try {
       unlinkSync(path + suffix);
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       // ignore
     }

--- a/packages/daemon/src/process-util.spec.ts
+++ b/packages/daemon/src/process-util.spec.ts
@@ -9,6 +9,7 @@ function isAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
+  // dotw-todo test-empty-catch: parse-probe — fix in #2322
   } catch {
     return false;
   }
@@ -27,6 +28,7 @@ async function awaitDeath(pid: number, deadlineMs = 5_000): Promise<void> {
 function forceKill(pid: number): void {
   try {
     process.kill(pid, "SIGKILL");
+  // dotw-todo test-empty-catch: cleanup — fix in #2322
   } catch {
     // already dead
   }

--- a/packages/daemon/src/process-util.spec.ts
+++ b/packages/daemon/src/process-util.spec.ts
@@ -9,7 +9,7 @@ function isAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
     return true;
-  // dotw-todo test-empty-catch: parse-probe — fix in #2322
+    // dotw-todo test-empty-catch: parse-probe — fix in #2322
   } catch {
     return false;
   }
@@ -28,7 +28,7 @@ async function awaitDeath(pid: number, deadlineMs = 5_000): Promise<void> {
 function forceKill(pid: number): void {
   try {
     process.kill(pid, "SIGKILL");
-  // dotw-todo test-empty-catch: cleanup — fix in #2322
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
   } catch {
     // already dead
   }

--- a/packages/daemon/src/server-pool.spec.ts
+++ b/packages/daemon/src/server-pool.spec.ts
@@ -1665,7 +1665,7 @@ describe("disconnect kills stdio child processes (#940)", () => {
     try {
       process.kill(pid, 0);
       return true;
-    // dotw-todo test-empty-catch: parse-probe — fix in #2322
+      // dotw-todo test-empty-catch: parse-probe — fix in #2322
     } catch {
       return false;
     }
@@ -1675,7 +1675,7 @@ describe("disconnect kills stdio child processes (#940)", () => {
   function forceKill(pid: number): void {
     try {
       process.kill(pid, "SIGKILL");
-    // dotw-todo test-empty-catch: cleanup — fix in #2322
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       // already dead
     }

--- a/packages/daemon/src/server-pool.spec.ts
+++ b/packages/daemon/src/server-pool.spec.ts
@@ -1665,6 +1665,7 @@ describe("disconnect kills stdio child processes (#940)", () => {
     try {
       process.kill(pid, 0);
       return true;
+    // dotw-todo test-empty-catch: parse-probe — fix in #2322
     } catch {
       return false;
     }
@@ -1674,6 +1675,7 @@ describe("disconnect kills stdio child processes (#940)", () => {
   function forceKill(pid: number): void {
     try {
       process.kill(pid, "SIGKILL");
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       // already dead
     }

--- a/packages/daemon/src/work-items-server.spec.ts
+++ b/packages/daemon/src/work-items-server.spec.ts
@@ -16,6 +16,7 @@ function cleanupDb(p: string): void {
   for (const suffix of ["", "-wal", "-shm"]) {
     try {
       unlinkSync(p + suffix);
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* ignore */
     }

--- a/packages/daemon/src/work-items-server.spec.ts
+++ b/packages/daemon/src/work-items-server.spec.ts
@@ -16,7 +16,7 @@ function cleanupDb(p: string): void {
   for (const suffix of ["", "-wal", "-shm"]) {
     try {
       unlinkSync(p + suffix);
-    // dotw-todo test-empty-catch: cleanup — fix in #2322
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       /* ignore */
     }

--- a/packages/opencode/src/opencode-sse.spec.ts
+++ b/packages/opencode/src/opencode-sse.spec.ts
@@ -113,6 +113,7 @@ describe("OpenCodeSse", () => {
               try {
                 controller.enqueue('event: ping\ndata: {"n":2}\n\n');
                 controller.close();
+              // dotw-todo test-empty-catch: cleanup — fix in #2322
               } catch {
                 // Controller may be closed by abort
               }

--- a/packages/opencode/src/opencode-sse.spec.ts
+++ b/packages/opencode/src/opencode-sse.spec.ts
@@ -113,7 +113,7 @@ describe("OpenCodeSse", () => {
               try {
                 controller.enqueue('event: ping\ndata: {"n":2}\n\n');
                 controller.close();
-              // dotw-todo test-empty-catch: cleanup — fix in #2322
+                // dotw-todo test-empty-catch: cleanup — fix in #2322
               } catch {
                 // Controller may be closed by abort
               }

--- a/scripts/rules/fixtures/test-empty-catch__clean.fixture.ts
+++ b/scripts/rules/fixtures/test-empty-catch__clean.fixture.ts
@@ -1,0 +1,23 @@
+/**
+ * @rule test-empty-catch
+ * @expect 0
+ * @path packages/daemon/src/example.spec.ts
+ *
+ * Catch blocks that contain expect() calls are fine — the error is asserted.
+ */
+
+import { describe, expect, it } from "bun:test";
+
+describe("proper catch", () => {
+  it("asserts the error", () => {
+    try {
+      JSON.parse("not json");
+    } catch (e) {
+      expect(e).toBeInstanceOf(SyntaxError);
+    }
+  });
+
+  it("also uses expect().toThrow as alternative", () => {
+    expect(() => JSON.parse("not json")).toThrow(SyntaxError);
+  });
+});

--- a/scripts/rules/fixtures/test-empty-catch__flagged.fixture.ts
+++ b/scripts/rules/fixtures/test-empty-catch__flagged.fixture.ts
@@ -1,0 +1,27 @@
+/**
+ * @rule test-empty-catch
+ * @expect 2
+ * @path packages/daemon/src/example.spec.ts
+ *
+ * Two catch blocks with no expect() inside — both should be flagged.
+ */
+
+import { describe, it } from "bun:test";
+
+describe("empty catch", () => {
+  it("swallows error silently", () => {
+    try {
+      JSON.parse("not json");
+    } catch (e) {
+      // oops, forgot to assert
+    }
+  });
+
+  it("also swallows", () => {
+    try {
+      throw new Error("boom");
+    } catch {
+      console.log("caught");
+    }
+  });
+});

--- a/scripts/rules/fixtures/test-empty-catch__same-line.fixture.ts
+++ b/scripts/rules/fixtures/test-empty-catch__same-line.fixture.ts
@@ -1,0 +1,13 @@
+/**
+ * @rule test-empty-catch
+ * @expect 0
+ * @path packages/daemon/src/example.spec.ts
+ *
+ * Same-line catch with expect — should NOT be flagged.
+ */
+
+import { expect, it } from "bun:test";
+
+it("same-line catch with assertion", () => {
+  try { JSON.parse("bad"); } catch (e) { expect(e).toBeInstanceOf(SyntaxError); }
+});

--- a/scripts/rules/fixtures/test-filtered-assertion__clean.fixture.ts
+++ b/scripts/rules/fixtures/test-filtered-assertion__clean.fixture.ts
@@ -1,0 +1,19 @@
+/**
+ * @rule test-filtered-assertion
+ * @expect 0
+ * @path packages/core/src/example.spec.ts
+ *
+ * Asserting the whole collection is the correct pattern.
+ */
+
+import { expect, it } from "bun:test";
+
+declare const warnings: string[];
+
+it("asserts the whole collection", () => {
+  expect(warnings).toEqual([]);
+});
+
+it("filter with non-zero length is fine", () => {
+  expect(warnings.filter(w => w.includes("expected"))).toHaveLength(2);
+});

--- a/scripts/rules/fixtures/test-filtered-assertion__flagged.fixture.ts
+++ b/scripts/rules/fixtures/test-filtered-assertion__flagged.fixture.ts
@@ -1,0 +1,19 @@
+/**
+ * @rule test-filtered-assertion
+ * @expect 2
+ * @path packages/core/src/example.spec.ts
+ *
+ * Two filtered-then-empty assertions — both should be flagged.
+ */
+
+import { expect, it } from "bun:test";
+
+declare const warnings: string[];
+
+it("hides unexpected warnings", () => {
+  expect(warnings.filter(w => w.includes("deprecated"))).toHaveLength(0);
+});
+
+it("also hides with toEqual", () => {
+  expect(warnings.filter(w => w.startsWith("warn:"))).toEqual([]);
+});

--- a/scripts/rules/fixtures/test-trivial-bound__clean.fixture.ts
+++ b/scripts/rules/fixtures/test-trivial-bound__clean.fixture.ts
@@ -1,0 +1,24 @@
+/**
+ * @rule test-trivial-bound
+ * @expect 0
+ * @path packages/daemon/src/example.spec.ts
+ *
+ * Exact assertions, meaningful bounds, and index checks are fine.
+ */
+
+import { expect, it } from "bun:test";
+
+declare const callCount: number;
+declare const idx: number;
+
+it("exact count", () => {
+  expect(callCount).toBe(1);
+});
+
+it("meaningful upper bound", () => {
+  expect(callCount).toBeLessThanOrEqual(10);
+});
+
+it("index check — toBeGreaterThanOrEqual(0) means found", () => {
+  expect(idx).toBeGreaterThanOrEqual(0);
+});

--- a/scripts/rules/fixtures/test-trivial-bound__flagged.fixture.ts
+++ b/scripts/rules/fixtures/test-trivial-bound__flagged.fixture.ts
@@ -1,0 +1,15 @@
+/**
+ * @rule test-trivial-bound
+ * @expect 1
+ * @path packages/daemon/src/example.spec.ts
+ *
+ * toBeLessThanOrEqual(1) passes at 0 — should be flagged.
+ */
+
+import { expect, it } from "bun:test";
+
+declare const callCount: number;
+
+it("at most once — passes when never called", () => {
+  expect(callCount).toBeLessThanOrEqual(1);
+});

--- a/scripts/rules/fixtures/test-unguarded-narrowing__assert-inside-guard.fixture.ts
+++ b/scripts/rules/fixtures/test-unguarded-narrowing__assert-inside-guard.fixture.ts
@@ -1,0 +1,31 @@
+/**
+ * @rule test-unguarded-narrowing
+ * @expect 1
+ * @path packages/daemon/src/example.spec.ts
+ *
+ * Discriminant assert inside the if-guard is vacuous — the assertion is
+ * guarded by the same condition it claims to verify. If the wrong variant
+ * is returned, the whole block is skipped including the assertion.
+ */
+
+import { expect, it } from "bun:test";
+
+interface OkResult {
+  kind: "ok";
+  value: number;
+}
+interface ErrResult {
+  kind: "error";
+  message: string;
+}
+type Result = OkResult | ErrResult;
+
+declare function getResult(): Result;
+
+it("assert inside guard is still vacuous", () => {
+  const result = getResult();
+  if (result.kind === "ok") {
+    expect(result.kind).toBe("ok");
+    expect(result.value).toBe(42);
+  }
+});

--- a/scripts/rules/fixtures/test-unguarded-narrowing__clean.fixture.ts
+++ b/scripts/rules/fixtures/test-unguarded-narrowing__clean.fixture.ts
@@ -1,0 +1,29 @@
+/**
+ * @rule test-unguarded-narrowing
+ * @expect 0
+ * @path packages/daemon/src/example.spec.ts
+ *
+ * Discriminant asserted first, then narrowing — correct pattern.
+ */
+
+import { expect, it } from "bun:test";
+
+interface OkResult {
+  kind: "ok";
+  value: number;
+}
+interface ErrResult {
+  kind: "error";
+  message: string;
+}
+type Result = OkResult | ErrResult;
+
+declare function getResult(): Result;
+
+it("asserts discriminant before narrowing", () => {
+  const result = getResult();
+  expect(result.kind).toBe("ok");
+  if (result.kind === "ok") {
+    expect(result.value).toBe(42);
+  }
+});

--- a/scripts/rules/fixtures/test-unguarded-narrowing__flagged.fixture.ts
+++ b/scripts/rules/fixtures/test-unguarded-narrowing__flagged.fixture.ts
@@ -1,0 +1,30 @@
+/**
+ * @rule test-unguarded-narrowing
+ * @expect 1
+ * @path packages/daemon/src/example.spec.ts
+ *
+ * expect() inside an if-guard on a discriminant property, without first
+ * asserting the discriminant. If the variant changes, the block is
+ * silently skipped and the test passes vacuously.
+ */
+
+import { expect, it } from "bun:test";
+
+interface OkResult {
+  kind: "ok";
+  value: number;
+}
+interface ErrResult {
+  kind: "error";
+  message: string;
+}
+type Result = OkResult | ErrResult;
+
+declare function getResult(): Result;
+
+it("checks sub-field without asserting discriminant", () => {
+  const result = getResult();
+  if (result.kind === "ok") {
+    expect(result.value).toBe(42);
+  }
+});

--- a/scripts/rules/test-empty-catch.rule.ts
+++ b/scripts/rules/test-empty-catch.rule.ts
@@ -1,0 +1,57 @@
+/**
+ * Rule: test-empty-catch
+ *
+ * Flag catch blocks in test files whose body contains no `expect(` call.
+ * An empty or assertion-free catch swallows the failure the test claims
+ * to verify — the test passes vacuously when the code throws.
+ *
+ * Uses AST CatchClause nodes (#2308 parent pointers) for scope-correct
+ * detection — avoids regex scope-blindness on same-line or nested catches.
+ *
+ * Sources: #2194, #1879.
+ */
+
+import ts from "typescript";
+import type { CheckRule } from "./_engine/rule";
+
+function containsExpectCall(node: ts.Node): boolean {
+  let found = false;
+  function walk(n: ts.Node): void {
+    if (found) return;
+    if (ts.isCallExpression(n) && ts.isIdentifier(n.expression) && n.expression.text === "expect") {
+      found = true;
+      return;
+    }
+    ts.forEachChild(n, walk);
+  }
+  walk(node);
+  return found;
+}
+
+const rule: CheckRule = {
+  id: "test-empty-catch",
+  kind: "check",
+  scold: "catch block in test has no expect() — swallows the failure the test should verify",
+  guidance: [
+    "assert the caught error: expect(e).toBeInstanceOf(SomeError) or expect((e as Error).message).toContain(...)",
+    "or replace try/catch with expect(fn).toThrow(...)",
+  ],
+  documentation: "#2247",
+  appliesToTests: true,
+  check({ file, violated, ast }) {
+    if (!file.isTest) return;
+
+    const sf = ast.sourceFile;
+    const catchClauses = ast.find(ts.isCatchClause);
+
+    for (const clause of catchClauses) {
+      if (!containsExpectCall(clause.block)) {
+        const pos = ast.positionOf(clause);
+        const line = file.content.split("\n")[pos.line - 1] ?? "";
+        violated(pos.line, pos.column, line.trim());
+      }
+    }
+  },
+};
+
+export default rule;

--- a/scripts/rules/test-filtered-assertion.rule.ts
+++ b/scripts/rules/test-filtered-assertion.rule.ts
@@ -1,0 +1,40 @@
+/**
+ * Rule: test-filtered-assertion
+ *
+ * Flag `expect(arr.filter(...)).toHaveLength(0)` and `.toEqual([])` in
+ * tests. Filtering before asserting emptiness hides unexpected items in
+ * the collection — the test passes while unrelated garbage accumulates.
+ *
+ * The fix: assert the whole collection (`expect(warnings).toEqual([])`)
+ * or assert a specific element's absence with a named reason.
+ *
+ * Sources: #2085, #2099.
+ */
+
+import type { CheckRule } from "./_engine/rule";
+
+const FILTERED_EMPTY =
+  /expect\(.+\.filter\s*\(.+\)\s*\)\s*\.\s*(?:toHaveLength\s*\(\s*0\s*\)|toEqual\s*\(\s*\[\s*\]\s*\))/;
+
+const rule: CheckRule = {
+  id: "test-filtered-assertion",
+  kind: "check",
+  scold: "expect(collection.filter(...)) hides unexpected items — assert the whole collection instead",
+  guidance: [
+    "assert the whole collection: expect(warnings).toEqual([])",
+    "or assert the specific element's absence with a named reason: expect(arr).not.toContainEqual(expect.objectContaining(...))",
+  ],
+  documentation: "#2247",
+  appliesToTests: true,
+  check({ file, violated }) {
+    if (!file.isTest) return;
+
+    const lines = file.content.split("\n");
+    for (const [i, line] of lines.entries()) {
+      const m = FILTERED_EMPTY.exec(line);
+      if (m) violated(i + 1, (m.index ?? 0) + 1, line.trim());
+    }
+  },
+};
+
+export default rule;

--- a/scripts/rules/test-trivial-bound.rule.ts
+++ b/scripts/rules/test-trivial-bound.rule.ts
@@ -1,0 +1,38 @@
+/**
+ * Rule: test-trivial-bound
+ *
+ * Flag `toBeLessThanOrEqual(1)` in tests. It passes at 0, so a "fires at
+ * most once" test passes when the code never fired at all.
+ *
+ * `toBeGreaterThanOrEqual(0)` was considered but excluded: it has
+ * legitimate uses for indexOf/findIndex results where >= 0 means "found."
+ *
+ * Sources: #2197.
+ */
+
+import type { CheckRule } from "./_engine/rule";
+
+const TRIVIAL_UPPER = /\.toBeLessThanOrEqual\s*\(\s*1\s*\)/;
+
+const rule: CheckRule = {
+  id: "test-trivial-bound",
+  kind: "check",
+  scold: "toBeLessThanOrEqual(1) passes at 0 (never fired) — assert the exact count or both bounds",
+  guidance: [
+    "assert the exact expected count: expect(n).toBe(1)",
+    "or assert both bounds: expect(n).toBeGreaterThanOrEqual(1); expect(n).toBeLessThanOrEqual(3)",
+  ],
+  documentation: "#2247",
+  appliesToTests: true,
+  check({ file, violated }) {
+    if (!file.isTest) return;
+
+    const lines = file.content.split("\n");
+    for (const [i, line] of lines.entries()) {
+      const m = TRIVIAL_UPPER.exec(line);
+      if (m) violated(i + 1, (m.index ?? 0) + 1, line.trim());
+    }
+  },
+};
+
+export default rule;

--- a/scripts/rules/test-unguarded-narrowing.rule.ts
+++ b/scripts/rules/test-unguarded-narrowing.rule.ts
@@ -1,0 +1,148 @@
+/**
+ * Rule: test-unguarded-narrowing
+ *
+ * Flag tests that check a discriminated-union sub-field inside an
+ * `if (x.disc === lit)` guard without first asserting the discriminant.
+ * A regression that returns the wrong variant silently skips the block
+ * and the test passes vacuously.
+ *
+ * Uses the TS AST matcher from #2267 for reliable detection.
+ *
+ * Sources: #1990 (×3), #2049.
+ */
+
+import ts from "typescript";
+import type { CheckRule } from "./_engine/rule";
+
+function isLiteralNode(node: ts.Node): boolean {
+  return (
+    ts.isStringLiteral(node) ||
+    ts.isNumericLiteral(node) ||
+    node.kind === ts.SyntaxKind.TrueKeyword ||
+    node.kind === ts.SyntaxKind.FalseKeyword
+  );
+}
+
+function literalText(node: ts.Node): string {
+  if (ts.isStringLiteral(node)) return node.text;
+  if (ts.isNumericLiteral(node)) return node.text;
+  if (node.kind === ts.SyntaxKind.TrueKeyword) return "true";
+  if (node.kind === ts.SyntaxKind.FalseKeyword) return "false";
+  return "";
+}
+
+function collectAll<T extends ts.Node>(root: ts.Node, guard: (n: ts.Node) => n is T): T[] {
+  const results: T[] = [];
+  function walk(n: ts.Node): void {
+    if (guard(n)) results.push(n);
+    ts.forEachChild(n, walk);
+  }
+  walk(root);
+  return results;
+}
+
+function isInsideNode(inner: ts.Node, outer: ts.Node, sf: ts.SourceFile): boolean {
+  return outer.getStart(sf) <= inner.getStart(sf) && outer.getEnd() >= inner.getEnd();
+}
+
+function isDiscAssertCall(
+  call: ts.CallExpression,
+  objText: string,
+  discProp: string,
+  litVal: string,
+  sf: ts.SourceFile,
+): boolean {
+  // expect(obj.disc).toBe(lit) or .toEqual(lit)
+  if (!ts.isPropertyAccessExpression(call.expression)) return false;
+  const method = call.expression.name.text;
+  if (method !== "toBe" && method !== "toEqual") return false;
+
+  const receiver = call.expression.expression;
+  if (!ts.isCallExpression(receiver)) return false;
+  if (!ts.isIdentifier(receiver.expression) || receiver.expression.text !== "expect") return false;
+
+  const expectArg = receiver.arguments[0];
+  if (!expectArg || !ts.isPropertyAccessExpression(expectArg)) return false;
+  if (expectArg.expression.getText(sf) !== objText) return false;
+  if (expectArg.name.text !== discProp) return false;
+
+  const assertArg = call.arguments[0];
+  if (!assertArg) return false;
+  return literalText(assertArg) === litVal;
+}
+
+const rule: CheckRule = {
+  id: "test-unguarded-narrowing",
+  kind: "check",
+  scold:
+    "expect() inside if-guard without asserting the discriminant — test passes vacuously if the wrong variant is returned",
+  guidance: [
+    'assert the discriminant first: expect(result.kind).toBe("expected") before narrowing',
+    'or remove the if-guard and assert directly: expect(result).toEqual({ kind: "expected", ... })',
+  ],
+  documentation: "#2247",
+  appliesToTests: true,
+  check({ file, violated, ast }) {
+    if (!file.isTest) return;
+
+    const sf = ast.sourceFile;
+    const ifStmts = ast.find(ts.isIfStatement);
+
+    for (const ifStmt of ifStmts) {
+      const cond = ifStmt.expression;
+      if (!ts.isBinaryExpression(cond)) continue;
+      if (cond.operatorToken.kind !== ts.SyntaxKind.EqualsEqualsEqualsToken) continue;
+
+      let propAccess: ts.PropertyAccessExpression | undefined;
+      let litNode: ts.Node | undefined;
+
+      if (ts.isPropertyAccessExpression(cond.left) && isLiteralNode(cond.right)) {
+        propAccess = cond.left;
+        litNode = cond.right;
+      } else if (ts.isPropertyAccessExpression(cond.right) && isLiteralNode(cond.left)) {
+        propAccess = cond.right;
+        litNode = cond.left;
+      }
+
+      if (!propAccess || !litNode) continue;
+
+      const objText = propAccess.expression.getText(sf);
+      const discProp = propAccess.name.text;
+      const litVal = literalText(litNode);
+
+      const thenBlock = ifStmt.thenStatement;
+      const thenCalls = collectAll(thenBlock, ts.isCallExpression);
+
+      const hasSubFieldExpect = thenCalls.some((call) => {
+        if (!ts.isIdentifier(call.expression) || call.expression.text !== "expect") return false;
+        const arg = call.arguments[0];
+        if (!arg || !ts.isPropertyAccessExpression(arg)) return false;
+        return arg.expression.getText(sf) === objText;
+      });
+
+      if (!hasSubFieldExpect) continue;
+
+      const encFn = ts.findAncestor(
+        ifStmt,
+        (n) => ts.isArrowFunction(n) || ts.isFunctionExpression(n) || ts.isFunctionDeclaration(n),
+      );
+      if (!encFn) continue;
+
+      const fnCalls = collectAll(encFn, ts.isCallExpression);
+      const hasDiscAssertOutsideGuard = fnCalls.some((call) => {
+        if (!isDiscAssertCall(call, objText, discProp, litVal, sf)) return false;
+        // Assertion inside the if-guard body is vacuous — already guarded by
+        // the same condition. Only assertions outside the if count.
+        return !isInsideNode(call, ifStmt, sf);
+      });
+
+      if (!hasDiscAssertOutsideGuard) {
+        const pos = ast.positionOf(ifStmt);
+        const condText = cond.getText(sf);
+        violated(pos.line, pos.column, `if (${condText}) { expect(${objText}.…)… }`);
+      }
+    }
+  },
+};
+
+export default rule;

--- a/test/cli-orchestration.spec.ts
+++ b/test/cli-orchestration.spec.ts
@@ -289,7 +289,7 @@ describe("CLI→daemon orchestration (mock provider)", () => {
       // Clean up worktrees before removing the dir (git requires this order)
       try {
         execSync("git worktree prune", { cwd: gitDir, stdio: "pipe" });
-      // dotw-todo test-empty-catch: cleanup-exec — fix in #2322
+        // dotw-todo test-empty-catch: cleanup-exec — fix in #2322
       } catch {
         // best-effort
       }

--- a/test/cli-orchestration.spec.ts
+++ b/test/cli-orchestration.spec.ts
@@ -289,6 +289,7 @@ describe("CLI→daemon orchestration (mock provider)", () => {
       // Clean up worktrees before removing the dir (git requires this order)
       try {
         execSync("git worktree prune", { cwd: gitDir, stdio: "pipe" });
+      // dotw-todo test-empty-catch: cleanup-exec — fix in #2322
       } catch {
         // best-effort
       }

--- a/test/event-filter.integration.spec.ts
+++ b/test/event-filter.integration.spec.ts
@@ -122,7 +122,7 @@ function createOpenStream(socketPath: string) {
           if (!trimmed) continue;
           try {
             yield JSON.parse(trimmed) as MonitorEvent;
-          // dotw-todo test-empty-catch: parse-probe — fix in #2322
+            // dotw-todo test-empty-catch: parse-probe — fix in #2322
           } catch {
             // Skip malformed lines
           }
@@ -132,7 +132,7 @@ function createOpenStream(socketPath: string) {
       if (trailing.trim()) {
         try {
           yield JSON.parse(trailing.trim()) as MonitorEvent;
-        // dotw-todo test-empty-catch: parse-probe — fix in #2322
+          // dotw-todo test-empty-catch: parse-probe — fix in #2322
         } catch {
           // Ignore incomplete trailing data
         }

--- a/test/event-filter.integration.spec.ts
+++ b/test/event-filter.integration.spec.ts
@@ -122,6 +122,7 @@ function createOpenStream(socketPath: string) {
           if (!trimmed) continue;
           try {
             yield JSON.parse(trimmed) as MonitorEvent;
+          // dotw-todo test-empty-catch: parse-probe — fix in #2322
           } catch {
             // Skip malformed lines
           }
@@ -131,6 +132,7 @@ function createOpenStream(socketPath: string) {
       if (trailing.trim()) {
         try {
           yield JSON.parse(trailing.trim()) as MonitorEvent;
+        // dotw-todo test-empty-catch: parse-probe — fix in #2322
         } catch {
           // Ignore incomplete trailing data
         }

--- a/test/monitor-alias.integration.spec.ts
+++ b/test/monitor-alias.integration.spec.ts
@@ -57,6 +57,7 @@ function openEventStream(
         if (!trimmed) continue;
         try {
           yield JSON.parse(trimmed) as MonitorEvent;
+        // dotw-todo test-empty-catch: parse-probe — fix in #2322
         } catch {
           // Skip malformed lines
         }
@@ -67,6 +68,7 @@ function openEventStream(
     if (trailing.trim()) {
       try {
         yield JSON.parse(trailing.trim()) as MonitorEvent;
+      // dotw-todo test-empty-catch: parse-probe — fix in #2322
       } catch {
         // Ignore incomplete trailing data
       }

--- a/test/monitor-alias.integration.spec.ts
+++ b/test/monitor-alias.integration.spec.ts
@@ -57,7 +57,7 @@ function openEventStream(
         if (!trimmed) continue;
         try {
           yield JSON.parse(trimmed) as MonitorEvent;
-        // dotw-todo test-empty-catch: parse-probe — fix in #2322
+          // dotw-todo test-empty-catch: parse-probe — fix in #2322
         } catch {
           // Skip malformed lines
         }
@@ -68,7 +68,7 @@ function openEventStream(
     if (trailing.trim()) {
       try {
         yield JSON.parse(trailing.trim()) as MonitorEvent;
-      // dotw-todo test-empty-catch: parse-probe — fix in #2322
+        // dotw-todo test-empty-catch: parse-probe — fix in #2322
       } catch {
         // Ignore incomplete trailing data
       }

--- a/test/session-result-sse.integration.spec.ts
+++ b/test/session-result-sse.integration.spec.ts
@@ -89,6 +89,7 @@ describe("session.result via /events — cross-thread integration (#1681)", () =
           if (ev.event === "session.result" || ev.event === "session.idle") {
             received.push(ev);
           }
+        // dotw-todo test-empty-catch: parse-probe — fix in #2322
         } catch {
           // non-JSON line (heartbeat, etc.) — ignore
         }

--- a/test/session-result-sse.integration.spec.ts
+++ b/test/session-result-sse.integration.spec.ts
@@ -89,7 +89,7 @@ describe("session.result via /events — cross-thread integration (#1681)", () =
           if (ev.event === "session.result" || ev.event === "session.idle") {
             received.push(ev);
           }
-        // dotw-todo test-empty-catch: parse-probe — fix in #2322
+          // dotw-todo test-empty-catch: parse-probe — fix in #2322
         } catch {
           // non-JSON line (heartbeat, etc.) — ignore
         }

--- a/test/stress.spec.ts
+++ b/test/stress.spec.ts
@@ -64,6 +64,7 @@ describe("S1: Concurrent auto-start", () => {
       const pidFile = join(dir, "mcpd.pid");
       const data = JSON.parse(readFileSync(pidFile, "utf-8"));
       process.kill(data.pid, "SIGTERM");
+    // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       // no daemon running, fine
     }

--- a/test/stress.spec.ts
+++ b/test/stress.spec.ts
@@ -64,7 +64,7 @@ describe("S1: Concurrent auto-start", () => {
       const pidFile = join(dir, "mcpd.pid");
       const data = JSON.parse(readFileSync(pidFile, "utf-8"));
       process.kill(data.pid, "SIGTERM");
-    // dotw-todo test-empty-catch: cleanup — fix in #2322
+      // dotw-todo test-empty-catch: cleanup — fix in #2322
     } catch {
       // no daemon running, fine
     }


### PR DESCRIPTION
## Summary
- **test-unguarded-narrowing** (AST-based): flags `expect(obj.field)` inside `if (obj.disc === lit)` guards where the discriminant is never asserted — the test passes vacuously if the wrong variant is returned. Uses the #2267 AST matcher. 17 true-positive violations found in codebase.
- **test-empty-catch**: flags `catch` blocks in test files with no `expect()` — swallows the failure the test claims to verify. 79 violations found (mix of genuine bugs and defensive cleanup catches).
- **test-filtered-assertion**: flags `expect(arr.filter(...)).toHaveLength(0)` / `.toEqual([])` — hides unexpected items in the collection. 12 violations found.
- **test-trivial-bound**: flags `toBeLessThanOrEqual(1)` which passes at 0 (never fired). `toBeGreaterThanOrEqual(0)` excluded — legitimate for indexOf/findIndex checks. 0 current violations.

Each rule has ≥2 fixtures (clean + flagged). Rules are not yet wired into the pre-commit hook — they run via `bun run doing-it-wrong --rule <id>`.

## Test plan
- [x] All 19 fixture tests pass (`bun test scripts/rules/fixtures.spec.ts`)
- [x] Full test suite passes (7771 tests, 0 failures)
- [x] Typecheck clean
- [x] Lint clean
- [x] Each rule scanned against codebase — violations are true positives, no false positives observed

🤖 Generated with [Claude Code](https://claude.com/claude-code)