### PR TITLE
feat(command): centralized flag parser + rule banning manual args[++i] parsing (fixes #2250)

### DIFF
--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -755,7 +755,6 @@ function extractFlag(args: string[], ...flags: string[]): string | undefined {
   for (let i = 0; i < args.length; i++) {
     // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     if (flags.includes(args[i]) && args[i + 1] && !args[i + 1].startsWith("-")) {
-      // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       return args[i + 1]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     }
   }
@@ -1242,9 +1241,8 @@ export function parseAgentResumeArgs(args: string[]): AgentResumeArgs {
         model = val;
       }
     } else if (arg === "--allow") {
-      // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
+      // dotw-todo no-manual-arg-parsing: greedy multi-value consume; migration to parseFlags requires CLI change (--allow A B → --allow A --allow B) — track in #2283
       while (i + 1 < args.length && looksLikeToolName(args[i + 1])) {
-        // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
         allow.push(args[++i]); // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       }
       if (allow.length === 0) error = "--allow requires at least one tool pattern";

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -384,7 +384,7 @@ export function parseAgentSpawnArgs(
       return 0;
     }
     if (arg === "--worktree" || arg === "-w") {
-      const next = allArgs[i + 1];
+      const next = allArgs[i + 1]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (next && !next.startsWith("-")) {
         worktree = next;
         return 1;
@@ -406,7 +406,7 @@ export function parseAgentSpawnArgs(
         return 0;
       }
       if (agentOverride) return 1; // Already set by wrapper
-      const val = allArgs[i + 1];
+      const val = allArgs[i + 1]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!val || val.startsWith("-")) {
         extraError = "--agent requires a value (e.g. copilot, gemini)";
         return 0;
@@ -419,7 +419,7 @@ export function parseAgentSpawnArgs(
         extraError = `--provider is not supported by ${providerDisplayName(providerConfig)}`;
         return 0;
       }
-      const val = allArgs[i + 1];
+      const val = allArgs[i + 1]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!val || val.startsWith("-")) {
         extraError = "--provider requires a value (e.g. anthropic, openai, google)";
         return 0;
@@ -432,7 +432,7 @@ export function parseAgentSpawnArgs(
         extraError = `--resume is not supported by ${providerDisplayName(providerConfig)}`;
         return 1;
       }
-      resume = allArgs[i + 1];
+      resume = allArgs[i + 1]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!resume) {
         extraError = "--resume requires a session ID";
       }
@@ -754,7 +754,8 @@ function formatPrStatus(pr: { number: number; state: string } | null): string {
 function extractFlag(args: string[], ...flags: string[]): string | undefined {
   for (let i = 0; i < args.length; i++) {
     if (flags.includes(args[i]) && args[i + 1] && !args[i + 1].startsWith("-")) {
-      return args[i + 1];
+      // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
+      return args[i + 1]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     }
   }
   return undefined;
@@ -847,7 +848,7 @@ async function agentInterrupt(args: string[], provider: AgentProvider, d: AgentD
         d.printError(`Usage: mcx agent ${provider.name} interrupt <session-id> [--reason <text|@file>]`);
         d.exit(1);
       }
-      rawReason = args[++i];
+      rawReason = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     } else if (args[i].startsWith("--")) {
       d.printError(`Unknown flag: ${args[i]}`);
       d.exit(1);
@@ -995,7 +996,7 @@ async function agentWait(
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg === "--timeout" || arg === "-t") {
-      const val = args[++i];
+      const val = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!val) {
         error = "--timeout requires a value in ms";
       } else {
@@ -1003,7 +1004,7 @@ async function agentWait(
         if (Number.isNaN(timeout)) error = "--timeout must be a number";
       }
     } else if (arg === "--after") {
-      const val = args[++i];
+      const val = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!val) {
         error = "--after requires a sequence number";
       } else {
@@ -1015,7 +1016,7 @@ async function agentWait(
     } else if (arg === "--all" || (arg === "-a" && !hasFeature(provider, "agentSelect"))) {
       all = true;
     } else if (arg === "--mail-to") {
-      const val = args[++i];
+      const val = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!val) error = "--mail-to requires a recipient name";
       else mailTo = val;
     } else if (arg.startsWith("--mail-to=")) {
@@ -1225,7 +1226,7 @@ export function parseAgentResumeArgs(args: string[]): AgentResumeArgs {
     } else if (arg === "--wait") {
       wait = true;
     } else if (arg === "--timeout" || arg === "-t") {
-      const val = args[++i];
+      const val = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!val) {
         error = "--timeout requires a value in ms";
       } else {
@@ -1233,7 +1234,7 @@ export function parseAgentResumeArgs(args: string[]): AgentResumeArgs {
         if (Number.isNaN(timeout)) error = "--timeout must be a number";
       }
     } else if (arg === "--model" || arg === "-m") {
-      const val = args[++i];
+      const val = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!val || val.startsWith("-")) {
         error = "--model requires a value";
       } else {
@@ -1241,7 +1242,8 @@ export function parseAgentResumeArgs(args: string[]): AgentResumeArgs {
       }
     } else if (arg === "--allow") {
       while (i + 1 < args.length && looksLikeToolName(args[i + 1])) {
-        allow.push(args[++i]);
+        // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
+        allow.push(args[++i]); // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       }
       if (allow.length === 0) error = "--allow requires at least one tool pattern";
     } else if (!arg.startsWith("-")) {

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -753,6 +753,7 @@ function formatPrStatus(pr: { number: number; state: string } | null): string {
 /** Extract a flag value from args without consuming them. */
 function extractFlag(args: string[], ...flags: string[]): string | undefined {
   for (let i = 0; i < args.length; i++) {
+    // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     if (flags.includes(args[i]) && args[i + 1] && !args[i + 1].startsWith("-")) {
       // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       return args[i + 1]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
@@ -1241,6 +1242,7 @@ export function parseAgentResumeArgs(args: string[]): AgentResumeArgs {
         model = val;
       }
     } else if (arg === "--allow") {
+      // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       while (i + 1 < args.length && looksLikeToolName(args[i + 1])) {
         // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
         allow.push(args[++i]); // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283

--- a/packages/command/src/commands/alias.ts
+++ b/packages/command/src/commands/alias.ts
@@ -61,7 +61,7 @@ export function parseScopeFlag(
       if (i + 1 >= args.length) {
         throw new Error("--scope requires a value (null, legacy, global, or a path)");
       }
-      raw = args[++i];
+      raw = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       continue;
     }
     if (args[i].startsWith("--scope=")) {
@@ -428,7 +428,7 @@ export function parsePromoteArgs(args: string[]): { source: string | undefined; 
   let target: string | undefined;
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--name" && i + 1 < args.length) {
-      target = args[++i];
+      target = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     } else if (!source) {
       source = args[i];
     }

--- a/packages/command/src/commands/automation.ts
+++ b/packages/command/src/commands/automation.ts
@@ -59,6 +59,7 @@ export async function cmdAutomation(args: string[], deps?: Partial<AutomationDep
     const limitIdx = args.indexOf("--limit");
     let limit: number | undefined;
     if (limitIdx >= 0) {
+      // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       const raw = args[limitIdx + 1];
       const parsed = Number.parseInt(raw, 10);
       if (!raw || Number.isNaN(parsed) || parsed < 1) {

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -689,9 +689,8 @@ export function parseResumeArgs(args: string[]): ResumeArgs {
         model = resolveModelName(val);
       }
     } else if (arg === "--allow") {
-      // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
+      // dotw-todo no-manual-arg-parsing: greedy multi-value consume; migration to parseFlags requires CLI change (--allow A B → --allow A --allow B) — track in #2283
       while (i + 1 < args.length && !args[i + 1].startsWith("-")) {
-        // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
         allow.push(args[++i]); // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       }
       if (allow.length === 0) error = "--allow requires at least one tool pattern";

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -380,7 +380,7 @@ export function parseSpawnArgs(args: string[]): SpawnArgs {
       return 0;
     }
     if (arg === "--worktree" || arg === "-w") {
-      const next = allArgs[i + 1];
+      const next = allArgs[i + 1]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (next && !next.startsWith("-")) {
         worktree = next;
         return 1;
@@ -391,17 +391,17 @@ export function parseSpawnArgs(args: string[]): SpawnArgs {
       return 0;
     }
     if (arg === "--resume") {
-      resume = allArgs[i + 1];
+      resume = allArgs[i + 1]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!resume) extraError = "--resume requires a session ID";
       return 1;
     }
     if (arg === "--name" || arg === "-n") {
-      name = allArgs[i + 1];
+      name = allArgs[i + 1]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!name) extraError = "--name requires a value";
       return 1;
     }
     if (arg === "--work-item") {
-      const next = allArgs[i + 1];
+      const next = allArgs[i + 1]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (next && !next.startsWith("-")) {
         workItemId = next;
         return 1;
@@ -682,7 +682,7 @@ export function parseResumeArgs(args: string[]): ResumeArgs {
     } else if (arg === "--force") {
       force = true;
     } else if (arg === "--model" || arg === "-m") {
-      const val = args[++i];
+      const val = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!val) {
         error = "--model requires a value";
       } else {
@@ -690,13 +690,14 @@ export function parseResumeArgs(args: string[]): ResumeArgs {
       }
     } else if (arg === "--allow") {
       while (i + 1 < args.length && !args[i + 1].startsWith("-")) {
-        allow.push(args[++i]);
+        // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
+        allow.push(args[++i]); // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       }
       if (allow.length === 0) error = "--allow requires at least one tool pattern";
     } else if (arg === "--wait") {
       wait = true;
     } else if (arg === "--timeout") {
-      const val = args[++i];
+      const val = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!val) {
         error = "--timeout requires a value in ms";
       } else {
@@ -1393,7 +1394,7 @@ async function claudeInterrupt(args: string[], d: ClaudeDeps): Promise<void> {
         d.printError(`${args[i]} requires a value`);
         d.exit(1);
       }
-      rawReason = args[++i];
+      rawReason = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     } else if (args[i].startsWith("-")) {
       d.printError(`Unknown flag: ${args[i]}\nUsage: mcx claude interrupt <session-id> [--reason <text|@file>]`);
       d.exit(1);
@@ -1463,7 +1464,7 @@ export function parsePatchUpdateArgs(args: string[], d: Pick<ClaudeDeps, "printE
         d.printError("--source requires a value");
         d.exit(1);
       }
-      sourcePath = args[++i];
+      sourcePath = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     } else if (a.startsWith("--source=")) sourcePath = a.slice("--source=".length);
     else {
       d.printError(`Unknown argument: ${a}`);
@@ -1538,7 +1539,7 @@ export function parseApproveArgs(
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--request-id" || args[i] === "-r") {
-      const val = args[++i];
+      const val = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!val) {
         d.printError("--request-id requires a value");
         d.exit(1);
@@ -1573,14 +1574,14 @@ export function parseDenyArgs(
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--request-id" || args[i] === "-r") {
-      const val = args[++i];
+      const val = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!val) {
         d.printError("--request-id requires a value");
         d.exit(1);
       }
       requestId = val;
     } else if (args[i] === "--message" || args[i] === "-m") {
-      const val = args[++i];
+      const val = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!val) {
         d.printError("--message requires a value");
         d.exit(1);
@@ -1778,7 +1779,7 @@ export function parseWaitArgs(args: string[]): WaitArgs {
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg === "--timeout" || arg === "-t") {
-      const val = args[++i];
+      const val = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!val) {
         error = "--timeout requires a value in ms";
       } else {
@@ -1790,7 +1791,7 @@ export function parseWaitArgs(args: string[]): WaitArgs {
         }
       }
     } else if (arg === "--after") {
-      const val = args[++i];
+      const val = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!val) {
         error = "--after requires a sequence number";
       } else {
@@ -1804,7 +1805,7 @@ export function parseWaitArgs(args: string[]): WaitArgs {
     } else if (arg === "--any") {
       any = true;
     } else if (arg === "--pr") {
-      const val = args[++i];
+      const val = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!val) {
         error = "--pr requires a PR number";
       } else {
@@ -1814,7 +1815,7 @@ export function parseWaitArgs(args: string[]): WaitArgs {
     } else if (arg === "--checks") {
       checks = true;
     } else if (arg === "--mail-to") {
-      const val = args[++i];
+      const val = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!val) {
         error = "--mail-to requires a recipient name";
       } else {

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -689,6 +689,7 @@ export function parseResumeArgs(args: string[]): ResumeArgs {
         model = resolveModelName(val);
       }
     } else if (arg === "--allow") {
+      // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       while (i + 1 < args.length && !args[i + 1].startsWith("-")) {
         // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
         allow.push(args[++i]); // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283

--- a/packages/command/src/commands/export.ts
+++ b/packages/command/src/commands/export.ts
@@ -34,9 +34,9 @@ export async function cmdExport(args: string[]): Promise<void> {
     const arg = args[i];
     if (arg === "--scope" || arg === "-s") {
       if (i + 1 >= args.length) throw new Error("--scope requires a value");
-      scope = parseScope(args[++i], CONFIG_SCOPES_NO_LOCAL);
+      scope = parseScope(args[++i], CONFIG_SCOPES_NO_LOCAL); // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     } else if (arg === "--server") {
-      const val = args[++i];
+      const val = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!val) throw new Error("--server requires a name");
       serverFilter.push(val);
     } else if (arg === "--all" || arg === "-a") {

--- a/packages/command/src/commands/gc.ts
+++ b/packages/command/src/commands/gc.ts
@@ -52,7 +52,7 @@ export function parseGcArgs(args: string[]): GcOptions {
     else if (a === "--branches-only") opts.branchesOnly = true;
     else if (a === "--worktrees-only") opts.worktreesOnly = true;
     else if (a === "--older-than") {
-      const v = args[++i];
+      const v = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!v) throw new Error("--older-than requires a value (e.g. 1d, 3h)");
       opts.olderThanMs = parseDuration(v);
     } else if (a.startsWith("--older-than=")) {

--- a/packages/command/src/commands/import.ts
+++ b/packages/command/src/commands/import.ts
@@ -240,7 +240,7 @@ export async function cmdImport(args: string[]): Promise<void> {
     const arg = args[i];
     if (arg === "--scope" || arg === "-s") {
       if (i + 1 >= args.length) throw new Error("--scope requires a value");
-      scope = parseScope(args[++i], CONFIG_SCOPES_NO_LOCAL);
+      scope = parseScope(args[++i], CONFIG_SCOPES_NO_LOCAL); // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     } else if (arg === "--claude" || arg === "-c") {
       claude = true;
     } else if (arg === "--all") {
@@ -400,7 +400,7 @@ export async function cmdAddFromClaudeDesktop(
     const arg = args[i];
     if (arg === "--scope" || arg === "-s") {
       if (i + 1 >= args.length) throw new Error("--scope requires a value");
-      scope = parseScope(args[++i], CONFIG_SCOPES_NO_LOCAL);
+      scope = parseScope(args[++i], CONFIG_SCOPES_NO_LOCAL); // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     } else if (arg === "--help" || arg === "-h") {
       console.log(`mcx add-from-claude-desktop — import servers from Claude Desktop
 

--- a/packages/command/src/commands/logs.ts
+++ b/packages/command/src/commands/logs.ts
@@ -63,7 +63,7 @@ export function parseLogsArgs(args: string[]): LogsArgs {
     } else if (arg === "-f" || arg === "--follow") {
       follow = true;
     } else if (arg === "--lines" || arg === "-n") {
-      const next = args[++i];
+      const next = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!next || Number.isNaN(Number(next))) {
         error = "--lines requires a number";
         break;

--- a/packages/command/src/commands/mail.ts
+++ b/packages/command/src/commands/mail.ts
@@ -122,7 +122,7 @@ export function parseMailArgs(args: string[]): MailArgs {
       break;
     }
     if (arg === "-s") {
-      const next = args[++i];
+      const next = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!next) {
         error = "-s requires a subject";
         break;
@@ -131,14 +131,14 @@ export function parseMailArgs(args: string[]): MailArgs {
     } else if (arg === "-H") {
       headersOnly = true;
     } else if (arg === "-u") {
-      const next = args[++i];
+      const next = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!next) {
         error = "-u requires a username";
         break;
       }
       user = next;
     } else if (arg === "-r") {
-      const next = args[++i];
+      const next = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!next || Number.isNaN(Number(next))) {
         error = "-r requires a message number";
         break;
@@ -156,7 +156,7 @@ export function parseMailArgs(args: string[]): MailArgs {
       }
       timeout = val;
     } else if (arg === "--timeout") {
-      const next = args[++i];
+      const next = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!next || Number.isNaN(Number(next)) || Number(next) <= 0) {
         error = "--timeout requires a positive number";
         break;
@@ -165,14 +165,14 @@ export function parseMailArgs(args: string[]): MailArgs {
     } else if (arg.startsWith("--for=")) {
       forRecipient = arg.slice("--for=".length);
     } else if (arg === "--for") {
-      const next = args[++i];
+      const next = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!next) {
         error = "--for requires a recipient name";
         break;
       }
       forRecipient = next;
     } else if (arg === "--from") {
-      const next = args[++i];
+      const next = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!next) {
         error = "--from requires a sender name";
         break;

--- a/packages/command/src/commands/monitor.ts
+++ b/packages/command/src/commands/monitor.ts
@@ -78,26 +78,26 @@ export function parseMonitorArgs(args: string[]): MonitorArgs {
     if (arg === "--json" || arg === "-j") {
       json = true;
     } else if (arg === "--response-tail") {
-      const next = args[++i];
+      const next = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!next || next.startsWith("-")) {
         error = "--response-tail requires a session ID";
         break;
       }
       responseTail = next;
     } else if (arg === "--subscribe") {
-      subscribe = args[++i];
+      subscribe = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!subscribe) {
         error = "--subscribe requires a value";
         break;
       }
     } else if (arg === "--session") {
-      session = args[++i];
+      session = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!session) {
         error = "--session requires a value";
         break;
       }
     } else if (arg === "--pr") {
-      const next = args[++i];
+      const next = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       const n = Number(next);
       if (!next || Number.isNaN(n)) {
         error = "--pr requires a number";
@@ -105,31 +105,31 @@ export function parseMonitorArgs(args: string[]): MonitorArgs {
       }
       pr = n;
     } else if (arg === "--work-item") {
-      workItem = args[++i];
+      workItem = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!workItem) {
         error = "--work-item requires a value";
         break;
       }
     } else if (arg === "--type") {
-      type = args[++i];
+      type = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!type) {
         error = "--type requires a value";
         break;
       }
     } else if (arg === "--src") {
-      src = args[++i];
+      src = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!src) {
         error = "--src requires a value";
         break;
       }
     } else if (arg === "--phase") {
-      phase = args[++i];
+      phase = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!phase) {
         error = "--phase requires a value";
         break;
       }
     } else if (arg === "--repo") {
-      const next = args[++i];
+      const next = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!next || next.startsWith("-")) {
         error = "--repo requires a path";
         break;
@@ -138,7 +138,7 @@ export function parseMonitorArgs(args: string[]): MonitorArgs {
     } else if (arg === "--all-repos") {
       allRepos = true;
     } else if (arg === "--since") {
-      const next = args[++i];
+      const next = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       const n = Number(next);
       if (!next || Number.isNaN(n)) {
         error = "--since requires a number";
@@ -146,13 +146,13 @@ export function parseMonitorArgs(args: string[]): MonitorArgs {
       }
       since = n;
     } else if (arg === "--until") {
-      until = args[++i];
+      until = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!until) {
         error = "--until requires a pattern";
         break;
       }
     } else if (arg === "--timeout") {
-      const next = args[++i];
+      const next = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       const n = Number(next);
       if (!next || Number.isNaN(n)) {
         error = "--timeout requires seconds";
@@ -160,7 +160,7 @@ export function parseMonitorArgs(args: string[]): MonitorArgs {
       }
       timeout = n;
     } else if (arg === "--max-events") {
-      const next = args[++i];
+      const next = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       const n = Number(next);
       if (!next || Number.isNaN(n) || n < 1) {
         error = "--max-events requires a positive integer";

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -305,18 +305,18 @@ export function parsePhaseRunArgs(args: string[]): PhaseRunOptions {
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (a === "--from") {
-      from = args[++i] ?? null;
+      from = args[++i] ?? null; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (from === null) throw new Error("--from requires a phase name");
     } else if (a.startsWith("--from=")) {
       from = a.slice("--from=".length);
     } else if (a === "--work-item") {
-      workItemId = args[++i] ?? null;
+      workItemId = args[++i] ?? null; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (workItemId === null) throw new Error("--work-item requires an id");
     } else if (a.startsWith("--work-item=")) {
       workItemId = a.slice("--work-item=".length);
     } else if (a === "--force") {
       forceSeen = true;
-      const next = args[i + 1];
+      const next = args[i + 1]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (next !== undefined && !next.startsWith("--")) {
         forceMessage = next;
         i++;
@@ -355,7 +355,7 @@ export function parsePhaseLogArgs(args: string[]): PhaseLogOptions {
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (a === "--work-item") {
-      workItemId = args[++i] ?? null;
+      workItemId = args[++i] ?? null; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!workItemId) throw new Error("--work-item requires a non-empty id");
     } else if (a.startsWith("--work-item=")) {
       workItemId = a.slice("--work-item=".length);
@@ -1492,7 +1492,7 @@ export function parsePhaseAdvanceArgs(args: string[]): { workItemId: string } {
   for (let i = 0; i < args.length; i++) {
     const a = args[i];
     if (a === "--work-item") {
-      workItemId = args[++i] ?? null;
+      workItemId = args[++i] ?? null; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!workItemId) throw new Error("--work-item requires an id");
     } else if (a.startsWith("--work-item=")) {
       workItemId = a.slice("--work-item=".length);

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -930,6 +930,7 @@ async function runPhase(argv: string[], d: PhaseInstallDeps): Promise<void> {
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--arg") {
+      // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       const pair = argv[++i];
       if (!pair) {
         d.logError("--arg requires a key=val argument");
@@ -1095,6 +1096,7 @@ export function parsePhaseExecuteArgs(argv: string[]): PhaseExecuteArgs {
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--arg") {
+      // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       const pair = argv[++i];
       if (!pair) throw new Error("--arg requires a key=val argument");
       const eq = pair.indexOf("=");
@@ -1110,6 +1112,7 @@ export function parsePhaseExecuteArgs(argv: string[]): PhaseExecuteArgs {
       if (!key) throw new Error(`--arg key must be non-empty in key=val form, got: ${pair}`);
       cliArgs[key] = pair.slice(eq + 1);
     } else if (a === "--input") {
+      // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       inputJson = argv[++i] ?? null;
       if (inputJson === null) throw new Error("--input requires a JSON argument");
     } else if (a.startsWith("--input=")) {

--- a/packages/command/src/commands/pr.ts
+++ b/packages/command/src/commands/pr.ts
@@ -76,7 +76,7 @@ export function parsePrMergeArgs(args: string[]): PrMergeArgs {
     } else if (arg === "--wait") {
       wait = true;
     } else if (arg === "--timeout" || arg === "-t") {
-      const val = args[++i];
+      const val = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!val) {
         error = "--timeout requires a value in ms";
       } else {
@@ -145,7 +145,7 @@ export function parsePrWaitArgs(args: string[]): PrWaitArgs {
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg === "--max-wait") {
-      const val = args[++i];
+      const val = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!val) {
         error = "--max-wait requires a value in seconds";
       } else {

--- a/packages/command/src/commands/registry-cmd.ts
+++ b/packages/command/src/commands/registry-cmd.ts
@@ -69,9 +69,9 @@ export function extractRegistryFlags(args: string[]): {
 
   for (let i = 0; i < args.length; i++) {
     if ((args[i] === "--limit" || args[i] === "-n") && i + 1 < args.length) {
-      limit = Number.parseInt(args[i + 1], 10);
+      limit = Number.parseInt(args[i + 1], 10); // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (Number.isNaN(limit) || limit <= 0) {
-        throw new Error(`Invalid --limit "${args[i + 1]}": must be a positive integer`);
+        throw new Error(`Invalid --limit "${args[i + 1]}": must be a positive integer`); // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       }
       i++;
     } else if (args[i] === "--no-cache") {

--- a/packages/command/src/commands/remove.ts
+++ b/packages/command/src/commands/remove.ts
@@ -21,7 +21,7 @@ export function parseRemoveArgs(args: string[]): { name: string; scope: ConfigSc
     const arg = args[i];
     if (arg === "--scope" || arg === "-s") {
       if (i + 1 >= args.length) throw new Error("--scope requires a value");
-      scope = parseScope(args[++i], CONFIG_SCOPES);
+      scope = parseScope(args[++i], CONFIG_SCOPES); // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     } else if (!arg.startsWith("-")) {
       positional.push(arg);
     } else {

--- a/packages/command/src/commands/run.ts
+++ b/packages/command/src/commands/run.ts
@@ -113,7 +113,7 @@ export function parseRunArgs(args: string[]): { jsonInput: string | undefined; c
     const arg = args[i];
     if (arg.startsWith("--")) {
       if (i + 1 < args.length) {
-        cliArgs[arg.slice(2)] = args[++i];
+        cliArgs[arg.slice(2)] = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       }
       // Orphan flags (no following value) are silently ignored
     } else if (jsonInput === undefined) {

--- a/packages/command/src/commands/run.ts
+++ b/packages/command/src/commands/run.ts
@@ -113,7 +113,7 @@ export function parseRunArgs(args: string[]): { jsonInput: string | undefined; c
     const arg = args[i];
     if (arg.startsWith("--")) {
       if (i + 1 < args.length) {
-        cliArgs[arg.slice(2)] = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
+        cliArgs[arg.slice(2)] = args[++i]; // dotw-ignore no-manual-arg-parsing: pass-through — alias flag schema is dynamic, not statically known at parse time
       }
       // Orphan flags (no following value) are silently ignored
     } else if (jsonInput === undefined) {

--- a/packages/command/src/commands/site.ts
+++ b/packages/command/src/commands/site.ts
@@ -67,7 +67,7 @@ function parseKv(args: string[]): { kv: Record<string, unknown>; rest: string[] 
         kv[kebabToCamel(k)] = coerce(v);
       } else {
         const key = kebabToCamel(raw);
-        const next = args[i + 1];
+        const next = args[i + 1]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
         if (next === undefined || next.startsWith("--")) {
           kv[key] = true;
         } else {

--- a/packages/command/src/commands/spans.ts
+++ b/packages/command/src/commands/spans.ts
@@ -69,6 +69,7 @@ function printSpan(span: SpanRow): void {
 function extractNumericFlag(args: string[], flag: string): number | undefined {
   const idx = args.indexOf(flag);
   if (idx === -1 || idx + 1 >= args.length) return undefined;
+  // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
   const val = Number(args[idx + 1]);
   return Number.isFinite(val) ? val : undefined;
 }

--- a/packages/command/src/commands/spawn-args.ts
+++ b/packages/command/src/commands/spawn-args.ts
@@ -68,22 +68,23 @@ export function parseSharedSpawnArgs(
     }
 
     if (arg === "--task" || arg === "-t") {
-      task = args[++i];
+      task = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!task) error = "--task requires a value";
     } else if (arg === "--allow") {
       while (i + 1 < args.length && looksLikeToolName(args[i + 1])) {
-        allow.push(args[++i]);
+        // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
+        allow.push(args[++i]); // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       }
       if (allow.length === 0) error = "--allow requires at least one tool pattern";
     } else if (arg === "--cwd") {
-      const rawCwd = args[++i];
+      const rawCwd = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!rawCwd) {
         error = "--cwd requires a path";
       } else {
         cwd = resolve(rawCwd);
       }
     } else if (arg === "--timeout") {
-      const val = args[++i];
+      const val = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!val) {
         error = "--timeout requires a value in ms";
       } else {
@@ -91,7 +92,7 @@ export function parseSharedSpawnArgs(
         if (Number.isNaN(timeout)) error = "--timeout must be a number";
       }
     } else if (arg === "--model" || arg === "-m") {
-      const val = args[++i];
+      const val = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!val || val.startsWith("-")) {
         error = "--model requires a value";
       } else if (val.toLowerCase() === "null" || val.toLowerCase() === "none" || val.toLowerCase() === "undefined") {

--- a/packages/command/src/commands/spawn-args.ts
+++ b/packages/command/src/commands/spawn-args.ts
@@ -71,6 +71,7 @@ export function parseSharedSpawnArgs(
       task = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!task) error = "--task requires a value";
     } else if (arg === "--allow") {
+      // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       while (i + 1 < args.length && looksLikeToolName(args[i + 1])) {
         // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
         allow.push(args[++i]); // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283

--- a/packages/command/src/commands/spawn-args.ts
+++ b/packages/command/src/commands/spawn-args.ts
@@ -71,9 +71,8 @@ export function parseSharedSpawnArgs(
       task = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       if (!task) error = "--task requires a value";
     } else if (arg === "--allow") {
-      // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
+      // dotw-todo no-manual-arg-parsing: greedy multi-value consume; migration to parseFlags requires CLI change (--allow A B → --allow A --allow B) — track in #2283
       while (i + 1 < args.length && looksLikeToolName(args[i + 1])) {
-        // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
         allow.push(args[++i]); // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       }
       if (allow.length === 0) error = "--allow requires at least one tool pattern";

--- a/packages/command/src/commands/sprint-stats.ts
+++ b/packages/command/src/commands/sprint-stats.ts
@@ -465,6 +465,7 @@ Output: JSON to stdout with token counts, cost estimates, and optional phase gro
   // Parse --project
   let projectFilter: string | undefined;
   if (projectIdx !== -1) {
+    // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     projectFilter = args[projectIdx + 1];
     if (!projectFilter || projectFilter.startsWith("--")) {
       printError("sprint-stats: --project requires a project slug");
@@ -478,6 +479,7 @@ Output: JSON to stdout with token counts, cost estimates, and optional phase gro
   let sprintWarnings: string[] = [];
 
   if (sprintIdx !== -1) {
+    // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     const raw = args[sprintIdx + 1];
     const sprintN = raw ? Number.parseInt(raw, 10) : Number.NaN;
     if (Number.isNaN(sprintN)) {
@@ -500,6 +502,7 @@ Output: JSON to stdout with token counts, cost estimates, and optional phase gro
     sprintWarnings = parsed.warnings;
     window = { start: parsed.start, end: parsed.end, label: `sprint-${sprintN}` };
   } else if (sinceIdx !== -1) {
+    // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     const ref = args[sinceIdx + 1];
     if (!ref) {
       printError("sprint-stats: --since requires a tag or SHA");

--- a/packages/command/src/commands/track.ts
+++ b/packages/command/src/commands/track.ts
@@ -134,6 +134,7 @@ export async function cmdTrack(args: string[], deps: TrackDeps = defaultDeps): P
   const automationIdx = args.indexOf("--automation");
   let automationOverrides: string | undefined;
   if (automationIdx >= 0) {
+    // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     automationOverrides = args[automationIdx + 1];
     if (!automationOverrides || automationOverrides.startsWith("--")) {
       printError("--automation requires a value (e.g. merge=false,bind=true)");
@@ -149,6 +150,7 @@ export async function cmdTrack(args: string[], deps: TrackDeps = defaultDeps): P
 
   const branchIdx = args.indexOf("--branch");
   if (branchIdx >= 0) {
+    // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     const branch = args[branchIdx + 1];
     if (!branch || branch.startsWith("--")) {
       printError("Usage: mcx track --branch <name>");
@@ -329,6 +331,7 @@ export async function cmdTracked(args: string[], deps: TrackDeps = defaultDeps):
   const declaredPhases = manifest ? Object.keys(manifest.phases) : null;
 
   if (phaseIdx >= 0) {
+    // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     const raw = args[phaseIdx + 1];
     if (!raw || raw.startsWith("--")) {
       const valid = declaredPhases ?? WORK_ITEM_PHASES;

--- a/packages/command/src/commands/track.ts
+++ b/packages/command/src/commands/track.ts
@@ -76,7 +76,7 @@ export function parseMetadataFlags(
       continue;
     }
 
-    const value = args[i + 1];
+    const value = args[i + 1]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     if (value === undefined || value.startsWith("--")) {
       errors.push(`${arg} requires a value`);
       continue;

--- a/packages/command/src/commands/vfs.ts
+++ b/packages/command/src/commands/vfs.ts
@@ -150,13 +150,10 @@ async function vfsClone(args: string[], deps: VfsDeps): Promise<void> {
     const arg = args[i];
     // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     if (arg === "--cloud-id" && args[i + 1]) {
-      // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       cloudId = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     } else if (arg === "--limit" && args[i + 1]) {
-      // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       limit = Number.parseInt(args[++i], 10); // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     } else if (arg === "--depth" && args[i + 1]) {
-      // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       depth = Number.parseInt(args[++i], 10); // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     } else if (!arg.startsWith("-") && !targetDir) {
       targetDir = arg;
@@ -214,7 +211,6 @@ async function vfsPull(args: string[], deps: VfsDeps): Promise<void> {
     if (args[i] === "--full") continue;
     // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     if (args[i] === "--depth" && args[i + 1]) {
-      // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       depth = Number.parseInt(args[++i], 10); // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       continue;
     }

--- a/packages/command/src/commands/vfs.ts
+++ b/packages/command/src/commands/vfs.ts
@@ -148,6 +148,7 @@ async function vfsClone(args: string[], deps: VfsDeps): Promise<void> {
 
   for (let i = 2; i < args.length; i++) {
     const arg = args[i];
+    // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     if (arg === "--cloud-id" && args[i + 1]) {
       // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       cloudId = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
@@ -211,6 +212,7 @@ async function vfsPull(args: string[], deps: VfsDeps): Promise<void> {
   const filteredArgs: string[] = [];
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--full") continue;
+    // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     if (args[i] === "--depth" && args[i + 1]) {
       // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       depth = Number.parseInt(args[++i], 10); // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283

--- a/packages/command/src/commands/vfs.ts
+++ b/packages/command/src/commands/vfs.ts
@@ -149,11 +149,14 @@ async function vfsClone(args: string[], deps: VfsDeps): Promise<void> {
   for (let i = 2; i < args.length; i++) {
     const arg = args[i];
     if (arg === "--cloud-id" && args[i + 1]) {
-      cloudId = args[++i];
+      // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
+      cloudId = args[++i]; // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     } else if (arg === "--limit" && args[i + 1]) {
-      limit = Number.parseInt(args[++i], 10);
+      // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
+      limit = Number.parseInt(args[++i], 10); // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     } else if (arg === "--depth" && args[i + 1]) {
-      depth = Number.parseInt(args[++i], 10);
+      // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
+      depth = Number.parseInt(args[++i], 10); // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
     } else if (!arg.startsWith("-") && !targetDir) {
       targetDir = arg;
     }
@@ -209,7 +212,8 @@ async function vfsPull(args: string[], deps: VfsDeps): Promise<void> {
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--full") continue;
     if (args[i] === "--depth" && args[i + 1]) {
-      depth = Number.parseInt(args[++i], 10);
+      // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
+      depth = Number.parseInt(args[++i], 10); // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       continue;
     }
     filteredArgs.push(args[i]);

--- a/packages/command/src/flags.spec.ts
+++ b/packages/command/src/flags.spec.ts
@@ -218,6 +218,18 @@ describe("parseFlags", () => {
     expect(r.errors).toEqual([]);
   });
 
+  it("collects bare - as positional (not unknown flag)", () => {
+    const r = parseFlags(["-"], SPECS);
+    expect(r.positionals).toEqual(["-"]);
+    expect(r.errors).toEqual([]);
+  });
+
+  it("collects negative number as positional (not unknown flag)", () => {
+    const r = parseFlags(["-5"], SPECS);
+    expect(r.positionals).toEqual(["-5"]);
+    expect(r.errors).toEqual([]);
+  });
+
   it("rejects -letter as string value (short flag)", () => {
     const r = parseFlags(["--output", "-x"], SPECS);
     // -x rejected as value for --output, then processed as unknown flag

--- a/packages/command/src/flags.spec.ts
+++ b/packages/command/src/flags.spec.ts
@@ -165,4 +165,10 @@ describe("parseFlags", () => {
     const r = parseFlags([], SPECS);
     expect(r.flags.env).toEqual([]);
   });
+
+  it("throws if repeatable is set on a non-string type", () => {
+    expect(() => parseFlags([], { count: { type: "number", repeatable: true } })).toThrow(
+      'flag --count: repeatable is only supported for type "string"',
+    );
+  });
 });

--- a/packages/command/src/flags.spec.ts
+++ b/packages/command/src/flags.spec.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "bun:test";
+
+import { parseFlags } from "./flags";
+import type { FlagSpec } from "./flags";
+
+const SPECS: Record<string, FlagSpec> = {
+  output: { type: "string", alias: "o" },
+  verbose: { type: "boolean", alias: "V" },
+  count: { type: "number", alias: "n" },
+  env: { type: "string", repeatable: true },
+};
+
+describe("parseFlags", () => {
+  it("parses long boolean flags", () => {
+    const r = parseFlags(["--verbose"], SPECS);
+    expect(r.flags.verbose).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+
+  it("parses short boolean aliases", () => {
+    const r = parseFlags(["-V"], SPECS);
+    expect(r.flags.verbose).toBe(true);
+  });
+
+  it("parses long string flags", () => {
+    const r = parseFlags(["--output", "file.txt"], SPECS);
+    expect(r.flags.output).toBe("file.txt");
+    expect(r.errors).toEqual([]);
+  });
+
+  it("parses short string aliases", () => {
+    const r = parseFlags(["-o", "file.txt"], SPECS);
+    expect(r.flags.output).toBe("file.txt");
+  });
+
+  it("parses number flags", () => {
+    const r = parseFlags(["--count", "42"], SPECS);
+    expect(r.flags.count).toBe(42);
+    expect(r.errors).toEqual([]);
+  });
+
+  it("parses short number aliases", () => {
+    const r = parseFlags(["-n", "7"], SPECS);
+    expect(r.flags.count).toBe(7);
+  });
+
+  it("parses --flag=value syntax", () => {
+    const r = parseFlags(["--output=out.json"], SPECS);
+    expect(r.flags.output).toBe("out.json");
+    expect(r.errors).toEqual([]);
+  });
+
+  it("parses --flag=value for numbers", () => {
+    const r = parseFlags(["--count=99"], SPECS);
+    expect(r.flags.count).toBe(99);
+  });
+
+  it("collects repeatable flags", () => {
+    const r = parseFlags(["--env", "A=1", "--env", "B=2"], SPECS);
+    expect(r.flags.env).toEqual(["A=1", "B=2"]);
+  });
+
+  it("collects repeatable flags with = syntax", () => {
+    const r = parseFlags(["--env=A=1", "--env=B=2"], SPECS);
+    expect(r.flags.env).toEqual(["A=1", "B=2"]);
+  });
+
+  it("collects positionals", () => {
+    const r = parseFlags(["foo", "bar"], SPECS);
+    expect(r.positionals).toEqual(["foo", "bar"]);
+    expect(r.errors).toEqual([]);
+  });
+
+  it("mixes flags and positionals", () => {
+    const r = parseFlags(["--verbose", "file.txt", "--count", "3"], SPECS);
+    expect(r.flags.verbose).toBe(true);
+    expect(r.flags.count).toBe(3);
+    expect(r.positionals).toEqual(["file.txt"]);
+  });
+
+  it("stops flag parsing at --", () => {
+    const r = parseFlags(["--verbose", "--", "--output", "x"], SPECS);
+    expect(r.flags.verbose).toBe(true);
+    expect(r.flags.output).toBeUndefined();
+    expect(r.positionals).toEqual(["--output", "x"]);
+  });
+
+  it("detects --help", () => {
+    const r = parseFlags(["--help"], SPECS);
+    expect(r.help).toBe(true);
+  });
+
+  it("detects -h", () => {
+    const r = parseFlags(["-h"], SPECS);
+    expect(r.help).toBe(true);
+  });
+
+  it("errors on missing value for string flag", () => {
+    const r = parseFlags(["--output"], SPECS);
+    expect(r.errors).toEqual(["--output requires a value"]);
+  });
+
+  it("errors on missing value for number flag", () => {
+    const r = parseFlags(["--count"], SPECS);
+    expect(r.errors).toEqual(["--count requires a value"]);
+  });
+
+  it("rejects -prefixed token as a value", () => {
+    const r = parseFlags(["--output", "--verbose"], SPECS);
+    expect(r.errors).toEqual(["--output requires a value"]);
+    expect(r.flags.verbose).toBe(true);
+  });
+
+  it("rejects short-flag-looking token as a value", () => {
+    const r = parseFlags(["-o", "-V"], SPECS);
+    expect(r.errors).toEqual(["-o requires a value"]);
+    expect(r.flags.verbose).toBe(true);
+  });
+
+  it("errors on non-numeric value for number flag", () => {
+    const r = parseFlags(["--count", "abc"], SPECS);
+    expect(r.errors).toEqual(['--count requires a numeric value, got "abc"']);
+  });
+
+  it("errors on non-numeric = value for number flag", () => {
+    const r = parseFlags(["--count=abc"], SPECS);
+    expect(r.errors).toEqual(['--count requires a numeric value, got "abc"']);
+  });
+
+  it("errors on unknown flags", () => {
+    const r = parseFlags(["--unknown", "-x"], SPECS);
+    expect(r.errors).toEqual(["unknown flag: --unknown", "unknown flag: -x"]);
+  });
+
+  it("errors on = value for boolean flag", () => {
+    const r = parseFlags(["--verbose=true"], SPECS);
+    expect(r.errors).toEqual(["--verbose is a boolean flag and does not accept a value"]);
+  });
+
+  it("handles empty argv", () => {
+    const r = parseFlags([], SPECS);
+    expect(r.flags).toEqual({ env: [] });
+    expect(r.positionals).toEqual([]);
+    expect(r.errors).toEqual([]);
+    expect(r.help).toBe(false);
+  });
+
+  it("handles empty specs", () => {
+    const r = parseFlags(["foo", "--bar"], {});
+    expect(r.positionals).toEqual(["foo"]);
+    expect(r.errors).toEqual(["unknown flag: --bar"]);
+  });
+
+  it("collects multiple errors", () => {
+    const r = parseFlags(["--output", "--count", "abc"], SPECS);
+    expect(r.errors.length).toBe(2);
+  });
+
+  it("last value wins for non-repeatable flags", () => {
+    const r = parseFlags(["--output", "first", "--output", "second"], SPECS);
+    expect(r.flags.output).toBe("second");
+  });
+
+  it("initializes repeatable flags to empty array", () => {
+    const r = parseFlags([], SPECS);
+    expect(r.flags.env).toEqual([]);
+  });
+});

--- a/packages/command/src/flags.spec.ts
+++ b/packages/command/src/flags.spec.ts
@@ -171,4 +171,56 @@ describe("parseFlags", () => {
       'flag --count: repeatable is only supported for type "string"',
     );
   });
+
+  // Number coercion strictness
+  it("accepts negative number value", () => {
+    const r = parseFlags(["--count", "-5"], SPECS);
+    expect(r.flags.count).toBe(-5);
+    expect(r.errors).toEqual([]);
+  });
+
+  it("accepts negative number with = syntax", () => {
+    const r = parseFlags(["--count=-5"], SPECS);
+    expect(r.flags.count).toBe(-5);
+    expect(r.errors).toEqual([]);
+  });
+
+  it("accepts float number value", () => {
+    const r = parseFlags(["--count", "3"], SPECS);
+    expect(r.flags.count).toBe(3);
+    expect(r.errors).toEqual([]);
+  });
+
+  it("rejects empty string as number value", () => {
+    const r = parseFlags(["--count="], SPECS);
+    expect(r.errors).toEqual(['--count requires a numeric value, got ""']);
+  });
+
+  it("rejects hex as number value", () => {
+    const r = parseFlags(["--count", "0x10"], SPECS);
+    expect(r.errors).toEqual(['--count requires a numeric value, got "0x10"']);
+  });
+
+  it("rejects scientific notation as number value", () => {
+    const r = parseFlags(["--count", "1e3"], SPECS);
+    expect(r.errors).toEqual(['--count requires a numeric value, got "1e3"']);
+  });
+
+  it("rejects Infinity as number value", () => {
+    const r = parseFlags(["--count", "Infinity"], SPECS);
+    expect(r.errors).toEqual(['--count requires a numeric value, got "Infinity"']);
+  });
+
+  // Stdin sentinel and flag-value disambiguation
+  it("accepts bare - as string value (stdin sentinel)", () => {
+    const r = parseFlags(["--output", "-"], SPECS);
+    expect(r.flags.output).toBe("-");
+    expect(r.errors).toEqual([]);
+  });
+
+  it("rejects -letter as string value (short flag)", () => {
+    const r = parseFlags(["--output", "-x"], SPECS);
+    // -x rejected as value for --output, then processed as unknown flag
+    expect(r.errors).toEqual(["--output requires a value", "unknown flag: -x"]);
+  });
 });

--- a/packages/command/src/flags.ts
+++ b/packages/command/src/flags.ts
@@ -19,8 +19,9 @@ function looksLikeFlag(token: string): boolean {
   return /^-[A-Za-z]/.test(token);
 }
 
-// Validates a decimal number string (integer or float, optionally signed).
-// Rejects empty, hex ("0x…"), scientific notation ("1e3"), Infinity, and non-numeric strings.
+// Validates a decimal number string (integer or float, with optional leading minus).
+// Rejects empty, positive-sign prefix ("+5"), hex ("0x…"), scientific notation ("1e3"),
+// Infinity, and non-numeric strings.
 function parseDecimal(raw: string): number | null {
   if (!/^-?\d+(\.\d+)?$/.test(raw)) return null;
   return Number(raw);
@@ -121,7 +122,7 @@ export function parseFlags(argv: string[], specs: Record<string, FlagSpec>): Par
       continue;
     }
 
-    if (token.startsWith("-")) {
+    if (looksLikeFlag(token)) {
       errors.push(`unknown flag: ${token}`);
       continue;
     }

--- a/packages/command/src/flags.ts
+++ b/packages/command/src/flags.ts
@@ -1,0 +1,115 @@
+export interface FlagSpec {
+  type: "string" | "boolean" | "number";
+  alias?: string;
+  repeatable?: boolean;
+}
+
+export interface ParseResult {
+  flags: Record<string, string | number | boolean | string[]>;
+  positionals: string[];
+  errors: string[];
+  help: boolean;
+}
+
+export function parseFlags(argv: string[], specs: Record<string, FlagSpec>): ParseResult {
+  const flags: Record<string, string | number | boolean | string[]> = {};
+  const positionals: string[] = [];
+  const errors: string[] = [];
+  let help = false;
+
+  const byLong = new Map<string, { key: string; spec: FlagSpec }>();
+  const byShort = new Map<string, { key: string; spec: FlagSpec }>();
+
+  for (const [key, spec] of Object.entries(specs)) {
+    byLong.set(`--${key}`, { key, spec });
+    if (spec.alias) byShort.set(`-${spec.alias}`, { key, spec });
+    if (spec.repeatable && spec.type === "string") flags[key] = [];
+  }
+
+  let stopFlags = false;
+
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i];
+
+    if (stopFlags) {
+      positionals.push(token);
+      continue;
+    }
+
+    if (token === "--") {
+      stopFlags = true;
+      continue;
+    }
+
+    if (token === "--help" || token === "-h") {
+      help = true;
+      continue;
+    }
+
+    if (token.startsWith("--") && token.includes("=")) {
+      const eqIdx = token.indexOf("=");
+      const flagPart = token.slice(0, eqIdx);
+      const valuePart = token.slice(eqIdx + 1);
+      const entry = byLong.get(flagPart);
+      if (!entry) {
+        errors.push(`unknown flag: ${flagPart}`);
+        continue;
+      }
+      if (entry.spec.type === "boolean") {
+        errors.push(`${flagPart} is a boolean flag and does not accept a value`);
+        continue;
+      }
+      if (entry.spec.type === "number") {
+        const n = Number(valuePart);
+        if (Number.isNaN(n)) {
+          errors.push(`${flagPart} requires a numeric value, got "${valuePart}"`);
+          continue;
+        }
+        flags[entry.key] = n;
+      } else if (entry.spec.repeatable) {
+        (flags[entry.key] as string[]).push(valuePart);
+      } else {
+        flags[entry.key] = valuePart;
+      }
+      continue;
+    }
+
+    const entry = byLong.get(token) ?? byShort.get(token);
+    if (entry) {
+      if (entry.spec.type === "boolean") {
+        flags[entry.key] = true;
+        continue;
+      }
+
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith("-")) {
+        errors.push(`${token} requires a value`);
+        continue;
+      }
+      i++;
+
+      if (entry.spec.type === "number") {
+        const n = Number(next);
+        if (Number.isNaN(n)) {
+          errors.push(`${token} requires a numeric value, got "${next}"`);
+          continue;
+        }
+        flags[entry.key] = n;
+      } else if (entry.spec.repeatable) {
+        (flags[entry.key] as string[]).push(next);
+      } else {
+        flags[entry.key] = next;
+      }
+      continue;
+    }
+
+    if (token.startsWith("-")) {
+      errors.push(`unknown flag: ${token}`);
+      continue;
+    }
+
+    positionals.push(token);
+  }
+
+  return { flags, positionals, errors, help };
+}

--- a/packages/command/src/flags.ts
+++ b/packages/command/src/flags.ts
@@ -11,6 +11,21 @@ export interface ParseResult {
   help: boolean;
 }
 
+// Returns true when token looks like a CLI flag (--flag or -f) that cannot be a value.
+// Bare "-" (stdin sentinel) and negative numbers like "-5" are NOT flags.
+function looksLikeFlag(token: string): boolean {
+  if (token === "-") return false;
+  if (token.startsWith("--")) return true;
+  return /^-[A-Za-z]/.test(token);
+}
+
+// Validates a decimal number string (integer or float, optionally signed).
+// Rejects empty, hex ("0x…"), scientific notation ("1e3"), Infinity, and non-numeric strings.
+function parseDecimal(raw: string): number | null {
+  if (!/^-?\d+(\.\d+)?$/.test(raw)) return null;
+  return Number(raw);
+}
+
 export function parseFlags(argv: string[], specs: Record<string, FlagSpec>): ParseResult {
   const flags: Record<string, string | number | boolean | string[]> = {};
   const positionals: string[] = [];
@@ -63,8 +78,8 @@ export function parseFlags(argv: string[], specs: Record<string, FlagSpec>): Par
         continue;
       }
       if (entry.spec.type === "number") {
-        const n = Number(valuePart);
-        if (Number.isNaN(n)) {
+        const n = parseDecimal(valuePart);
+        if (n === null) {
           errors.push(`${flagPart} requires a numeric value, got "${valuePart}"`);
           continue;
         }
@@ -85,15 +100,15 @@ export function parseFlags(argv: string[], specs: Record<string, FlagSpec>): Par
       }
 
       const next = argv[i + 1];
-      if (next === undefined || next.startsWith("-")) {
+      if (next === undefined || looksLikeFlag(next)) {
         errors.push(`${token} requires a value`);
         continue;
       }
       i++;
 
       if (entry.spec.type === "number") {
-        const n = Number(next);
-        if (Number.isNaN(n)) {
+        const n = parseDecimal(next);
+        if (n === null) {
           errors.push(`${token} requires a numeric value, got "${next}"`);
           continue;
         }

--- a/packages/command/src/flags.ts
+++ b/packages/command/src/flags.ts
@@ -21,9 +21,12 @@ export function parseFlags(argv: string[], specs: Record<string, FlagSpec>): Par
   const byShort = new Map<string, { key: string; spec: FlagSpec }>();
 
   for (const [key, spec] of Object.entries(specs)) {
+    if (spec.repeatable && spec.type !== "string") {
+      throw new Error(`flag --${key}: repeatable is only supported for type "string"`);
+    }
     byLong.set(`--${key}`, { key, spec });
     if (spec.alias) byShort.set(`-${spec.alias}`, { key, spec });
-    if (spec.repeatable && spec.type === "string") flags[key] = [];
+    if (spec.repeatable) flags[key] = [];
   }
 
   let stopFlags = false;

--- a/scripts/check-args-bounds.ts
+++ b/scripts/check-args-bounds.ts
@@ -129,7 +129,7 @@ async function scanDir(dir: string): Promise<Violation[]> {
     // Skip declaration files, node_modules, and this script + its tests
     if (relPath.endsWith(".d.ts") || relPath.includes("node_modules")) continue;
     if (relPath === "check-args-bounds.ts" || relPath === "check-args-bounds.spec.ts") continue;
-    if (relPath.endsWith(".rule.ts") || relPath.endsWith(".fixture.ts")) continue;
+    if (relPath.startsWith("rules/")) continue;
 
     const absPath = `${dir}${relPath}`;
     const file = Bun.file(absPath);

--- a/scripts/check-args-bounds.ts
+++ b/scripts/check-args-bounds.ts
@@ -129,6 +129,7 @@ async function scanDir(dir: string): Promise<Violation[]> {
     // Skip declaration files, node_modules, and this script + its tests
     if (relPath.endsWith(".d.ts") || relPath.includes("node_modules")) continue;
     if (relPath === "check-args-bounds.ts" || relPath === "check-args-bounds.spec.ts") continue;
+    if (relPath.endsWith(".rule.ts") || relPath.endsWith(".fixture.ts")) continue;
 
     const absPath = `${dir}${relPath}`;
     const file = Bun.file(absPath);

--- a/scripts/rules/fixtures/no-manual-arg-parsing__clean.fixture.ts
+++ b/scripts/rules/fixtures/no-manual-arg-parsing__clean.fixture.ts
@@ -1,0 +1,30 @@
+/**
+ * @rule no-manual-arg-parsing
+ * @expect 0
+ * @path packages/command/src/commands/example-clean.ts
+ *
+ * Commands using parseFlags() and standard extract*Flag helpers
+ * should NOT be flagged.
+ */
+
+import { parseFlags } from "../flags";
+import { extractJsonFlag, extractVerboseFlag } from "../parse";
+
+export function cleanCommand(args: string[]): void {
+  const { json, rest } = extractJsonFlag(args);
+  const { verbose, rest: r2 } = extractVerboseFlag(rest);
+
+  const result = parseFlags(r2, {
+    output: { type: "string", alias: "o" },
+    count: { type: "number", alias: "n" },
+    force: { type: "boolean", alias: "f" },
+  });
+
+  console.log(json, verbose, result);
+}
+
+export function positionalOnly(args: string[]): void {
+  for (const arg of args) {
+    console.log(arg);
+  }
+}

--- a/scripts/rules/fixtures/no-manual-arg-parsing__false-positives.fixture.ts
+++ b/scripts/rules/fixtures/no-manual-arg-parsing__false-positives.fixture.ts
@@ -1,0 +1,35 @@
+/**
+ * @rule no-manual-arg-parsing
+ * @expect 0
+ * @path packages/command/src/commands/example-false-pos.ts
+ *
+ * The pattern text appearing inside comments, string literals, template
+ * literals, and object literals must NOT trigger the rule. AST-based
+ * detection skips these contexts structurally.
+ */
+
+declare const args: string[];
+
+export function helpText(): string {
+  // This comment mentions args[++i] and args[i + 1] — not real code.
+  return "manual args[++i] parsing is unsafe";
+}
+
+export function errorMessages(): string[] {
+  return [
+    "use parseFlags instead of args[++i]",
+    `the pattern args[i + 1] should not appear`,
+    "argv.shift() is also banned",
+  ];
+}
+
+export const GUIDANCE = {
+  bad: "args[++i]",
+  worse: "allArgs[i + 1]",
+  worst: "argv.shift()",
+};
+
+export function templateExample(): string {
+  const pattern = "args[i + 1]";
+  return `avoid ${pattern} in new code`;
+}

--- a/scripts/rules/fixtures/no-manual-arg-parsing__flagged.fixture.ts
+++ b/scripts/rules/fixtures/no-manual-arg-parsing__flagged.fixture.ts
@@ -1,0 +1,38 @@
+/**
+ * @rule no-manual-arg-parsing
+ * @expect 5
+ * @path packages/command/src/commands/example.ts
+ *
+ * Hand-rolled flag parsing patterns that should be detected:
+ * args[++i], args[i + 1], argv.shift(), and variants using allArgs.
+ */
+
+declare const args: string[];
+declare const argv: string[];
+declare const allArgs: string[];
+
+export function parseExample(args: string[]): void {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--output") {
+      const val = args[++i];
+      console.log(val);
+    } else if (arg === "--repo") {
+      const next = args[i + 1];
+      if (next) i++;
+    }
+  }
+}
+
+export function shiftExample(argv: string[]): void {
+  while (argv.length > 0) {
+    const flag = argv.shift();
+    if (flag === "--verbose") break;
+  }
+}
+
+export function callbackExample(allArgs: string[], i: number): void {
+  const v1 = allArgs[++i];
+  const v2 = allArgs[i + 1];
+  console.log(v1, v2);
+}

--- a/scripts/rules/fixtures/no-manual-arg-parsing__out-of-scope.fixture.ts
+++ b/scripts/rules/fixtures/no-manual-arg-parsing__out-of-scope.fixture.ts
@@ -1,0 +1,17 @@
+/**
+ * @rule no-manual-arg-parsing
+ * @expect 0
+ * @path packages/command/src/parse.ts
+ *
+ * Files outside packages/command/src/commands/ are not scoped by this rule.
+ * Helper files like parse.ts legitimately use manual arg indexing.
+ */
+
+export function extractSomeFlag(args: string[]): void {
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--some") {
+      const next = args[i + 1];
+      if (next) i++;
+    }
+  }
+}

--- a/scripts/rules/fixtures/no-manual-arg-parsing__suppressed.fixture.ts
+++ b/scripts/rules/fixtures/no-manual-arg-parsing__suppressed.fixture.ts
@@ -10,7 +10,7 @@
 export function legacyParser(args: string[]): void {
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--name") {
-      // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2250
+      // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2283
       const val = args[++i];
       console.log(val);
     }

--- a/scripts/rules/fixtures/no-manual-arg-parsing__suppressed.fixture.ts
+++ b/scripts/rules/fixtures/no-manual-arg-parsing__suppressed.fixture.ts
@@ -1,0 +1,18 @@
+/**
+ * @rule no-manual-arg-parsing
+ * @expect 0
+ * @path packages/command/src/commands/example-suppressed.ts
+ *
+ * A dotw-todo comment suppresses the violation while migration is in
+ * progress.
+ */
+
+export function legacyParser(args: string[]): void {
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--name") {
+      // dotw-todo no-manual-arg-parsing: migrate to parseFlags — fix in #2250
+      const val = args[++i];
+      console.log(val);
+    }
+  }
+}

--- a/scripts/rules/no-manual-arg-parsing.rule.ts
+++ b/scripts/rules/no-manual-arg-parsing.rule.ts
@@ -1,29 +1,29 @@
 /**
  * Rule: no-manual-arg-parsing
  *
- * Flag hand-rolled `args[++i]`, `args[i + 1]`, and `argv.shift()` patterns
- * inside command files. These are the source of the "next flag consumed as
- * value" bug class (e.g. `--repo --all` silently setting repo = "--all").
+ * Flag hand-rolled `args[++i]`, `args[i + 1]`, `allArgs[i + 1]`, and
+ * `argv.shift()` patterns inside command files. These are the source of
+ * the "next flag consumed as value" bug class (e.g. `--repo --all`
+ * silently setting repo = "--all").
  *
- * The fix is to use `parseFlags(argv, specs)` from `packages/command/src/flags.ts`,
- * which centralizes bounds checks, `-`-prefix rejection, `--flag=value`,
- * numeric coercion, and unknown-flag detection.
+ * Uses AST-based detection so comments, string literals, template
+ * literals, and type annotations are never matched.
+ *
+ * The fix is to use `parseFlags(argv, specs)` from
+ * `packages/command/src/flags.ts`, which centralizes bounds checks,
+ * `-`-prefix rejection, `--flag=value`, numeric coercion, and
+ * unknown-flag detection.
  */
 
+import ts from "typescript";
 import type { CheckRule } from "./_engine/rule";
 
-const MANUAL_PATTERNS = [
-  /args\[\+\+i\]/,
-  /args\[i\s*\+\s*1\]/,
-  /argv\.shift\(\)/,
-  /allArgs\[\+\+i\]/,
-  /allArgs\[i\s*\+\s*1\]/,
-];
+const ARG_ARRAY_NAMES = new Set(["args", "allArgs", "argv"]);
 
 const rule: CheckRule = {
   id: "no-manual-arg-parsing",
   kind: "check",
-  scold: "manual args[++i] / args[i+1] / argv.shift() flag parsing — use parseFlags() instead",
+  scold: "manual args[++i] / args[i+1] / allArgs[...] / argv.shift() flag parsing — use parseFlags() instead",
   guidance: [
     "use parseFlags(argv, specs) from packages/command/src/flags.ts",
     "parseFlags handles bounds checks, rejects -prefixed values, supports --flag=value and numeric coercion",
@@ -31,18 +31,39 @@ const rule: CheckRule = {
   ],
   documentation: "#2250",
   appliesToTests: false,
-  check({ file, violated }) {
+  check({ file, violated, ast }) {
     if (!file.relPath.startsWith("packages/command/src/commands/")) return;
 
     const lines = file.content.split("\n");
-    for (const [i, line] of lines.entries()) {
-      for (const pattern of MANUAL_PATTERNS) {
-        const m = pattern.exec(line);
-        if (m) {
-          violated(i + 1, (m.index ?? 0) + 1, line.trim());
-          break;
-        }
+
+    for (const node of ast.find(ts.isElementAccessExpression)) {
+      if (!ts.isIdentifier(node.expression)) continue;
+      if (!ARG_ARRAY_NAMES.has(node.expression.text)) continue;
+
+      const arg = node.argumentExpression;
+      if (!arg) continue;
+
+      const isPreIncrement = ts.isPrefixUnaryExpression(arg) && arg.operator === ts.SyntaxKind.PlusPlusToken;
+
+      const isIndexPlusOne =
+        ts.isBinaryExpression(arg) &&
+        arg.operatorToken.kind === ts.SyntaxKind.PlusToken &&
+        ts.isIdentifier(arg.left) &&
+        ts.isNumericLiteral(arg.right) &&
+        arg.right.text === "1";
+
+      if (isPreIncrement || isIndexPlusOne) {
+        const pos = ast.positionOf(node);
+        violated(pos.line, pos.column, lines[pos.line - 1]?.trim() ?? "");
       }
+    }
+
+    for (const node of ast.callsTo("shift")) {
+      if (!ts.isPropertyAccessExpression(node.expression)) continue;
+      if (!ts.isIdentifier(node.expression.expression)) continue;
+      if (node.expression.expression.text !== "argv") continue;
+      const pos = ast.positionOf(node);
+      violated(pos.line, pos.column, lines[pos.line - 1]?.trim() ?? "");
     }
   },
 };

--- a/scripts/rules/no-manual-arg-parsing.rule.ts
+++ b/scripts/rules/no-manual-arg-parsing.rule.ts
@@ -1,0 +1,50 @@
+/**
+ * Rule: no-manual-arg-parsing
+ *
+ * Flag hand-rolled `args[++i]`, `args[i + 1]`, and `argv.shift()` patterns
+ * inside command files. These are the source of the "next flag consumed as
+ * value" bug class (e.g. `--repo --all` silently setting repo = "--all").
+ *
+ * The fix is to use `parseFlags(argv, specs)` from `packages/command/src/flags.ts`,
+ * which centralizes bounds checks, `-`-prefix rejection, `--flag=value`,
+ * numeric coercion, and unknown-flag detection.
+ */
+
+import type { CheckRule } from "./_engine/rule";
+
+const MANUAL_PATTERNS = [
+  /args\[\+\+i\]/,
+  /args\[i\s*\+\s*1\]/,
+  /argv\.shift\(\)/,
+  /allArgs\[\+\+i\]/,
+  /allArgs\[i\s*\+\s*1\]/,
+];
+
+const rule: CheckRule = {
+  id: "no-manual-arg-parsing",
+  kind: "check",
+  scold: "manual args[++i] / args[i+1] / argv.shift() flag parsing — use parseFlags() instead",
+  guidance: [
+    "use parseFlags(argv, specs) from packages/command/src/flags.ts",
+    "parseFlags handles bounds checks, rejects -prefixed values, supports --flag=value and numeric coercion",
+    "for complex multi-value flags, consider the repeatable option in FlagSpec",
+  ],
+  documentation: "#2250",
+  appliesToTests: false,
+  check({ file, violated }) {
+    if (!file.relPath.startsWith("packages/command/src/commands/")) return;
+
+    const lines = file.content.split("\n");
+    for (const [i, line] of lines.entries()) {
+      for (const pattern of MANUAL_PATTERNS) {
+        const m = pattern.exec(line);
+        if (m) {
+          violated(i + 1, (m.index ?? 0) + 1, line.trim());
+          break;
+        }
+      }
+    }
+  },
+};
+
+export default rule;

--- a/scripts/rules/no-manual-arg-parsing.rule.ts
+++ b/scripts/rules/no-manual-arg-parsing.rule.ts
@@ -61,7 +61,7 @@ const rule: CheckRule = {
     for (const node of ast.callsTo("shift")) {
       if (!ts.isPropertyAccessExpression(node.expression)) continue;
       if (!ts.isIdentifier(node.expression.expression)) continue;
-      if (node.expression.expression.text !== "argv") continue;
+      if (!ARG_ARRAY_NAMES.has(node.expression.expression.text)) continue;
       const pos = ast.positionOf(node);
       violated(pos.line, pos.column, lines[pos.line - 1]?.trim() ?? "");
     }


### PR DESCRIPTION
## Summary

- Adds `parseFlags(argv, specs)` in `packages/command/src/flags.ts` — a typed flag parser that centralizes bounds checks, `-`-prefix value rejection, `--flag=value` syntax, numeric coercion, repeatable flags, unknown-flag detection, and `--help` handling
- Adds `no-manual-arg-parsing` doing-it-wrong rule flagging `args[++i]`, `args[i+1]`, `allArgs[i+1]`, and `argv.shift()` inside `packages/command/src/commands/`
- Suppresses 85 existing violations with `dotw-todo` referencing #2283 (migration tracking issue)
- Excludes `.rule.ts` and `.fixture.ts` from `check-args-bounds.ts` to avoid false positives on rule documentation

## Test plan

- [x] 28 unit tests for `parseFlags` covering: boolean/string/number flags, aliases, `--flag=value`, repeatable flags, positionals, `--` separator, `--help`, error cases (missing value, `-`-prefix rejection, non-numeric, unknown flags, `=` on boolean), empty input, last-value-wins
- [x] 4 rule fixtures: flagged (5 violations), clean (0), out-of-scope path (0), suppressed (0)
- [x] `bun typecheck` passes
- [x] `bun lint` passes (no fixes needed after formatting)
- [x] `bun test` — 7775 pass, 0 fail
- [x] `bun run doing-it-wrong --rule no-manual-arg-parsing` — 0 violations (all suppressed)
- [x] Pre-commit hook passes all checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)