### PR TITLE
fix(rules): enable parent pointers in AST helper — setParentNodes=true (fixes #2299)

### DIFF
--- a/scripts/rules/_engine/ast.spec.ts
+++ b/scripts/rules/_engine/ast.spec.ts
@@ -112,6 +112,19 @@ describe("stringLiterals()", () => {
   });
 });
 
+describe("parent pointers", () => {
+  it("sets node.parent so findAncestor works", () => {
+    const ast = createAstHelper(makeMeta("function f() { const x = 1; }"));
+    const decls = ast.find(ts.isVariableDeclaration);
+    expect(decls.length).toBe(1);
+    const decl = decls[0];
+    expect(decl.parent).toBeDefined();
+    const fn = ts.findAncestor(decl, ts.isFunctionDeclaration);
+    expect(fn).toBeDefined();
+    expect((fn as ts.FunctionDeclaration).name?.text).toBe("f");
+  });
+});
+
 describe("ScriptKind selection", () => {
   it("parses TSX content without errors when path ends in .tsx", () => {
     const ast = createAstHelper(

--- a/scripts/rules/_engine/ast.ts
+++ b/scripts/rules/_engine/ast.ts
@@ -31,7 +31,7 @@ function scriptKindFor(path: string): ts.ScriptKind {
 function getSourceFile(file: FileMeta): ts.SourceFile {
   let sf = sourceFileCache.get(file);
   if (!sf) {
-    sf = ts.createSourceFile(file.path, file.content, ts.ScriptTarget.Latest, false, scriptKindFor(file.path));
+    sf = ts.createSourceFile(file.path, file.content, ts.ScriptTarget.Latest, true, scriptKindFor(file.path));
     sourceFileCache.set(file, sf);
   }
   return sf;


### PR DESCRIPTION
## Summary
- Changed `setParentNodes` from `false` to `true` in `ts.createSourceFile` call in `scripts/rules/_engine/ast.ts`
- This enables `node.parent` traversal and `ts.findAncestor()` for rule authors using the exposed `sourceFile`
- Added test verifying parent pointers are set and `findAncestor` returns correct ancestors

## Test plan
- [x] New test: `parent pointers > sets node.parent so findAncestor works` — verifies `VariableDeclaration` inside a function has a parent chain leading back to the `FunctionDeclaration`
- [x] All existing AST helper tests still pass (14 total)
- [x] Full test suite passes (7748 tests)
- [x] Typecheck and lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)