### PR TITLE
fix(ci): add scripts/ to CI test invocation (fixes #2305)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
         if: needs.detect.outputs.docs_only != 'true'
         run: |
           set +e
-          bun test packages/acp packages/clone packages/codex packages/command packages/control packages/core packages/opencode packages/permissions test/integration.spec.ts 2>&1 | tee /tmp/test_non_daemon.txt
+          bun test packages/acp packages/clone packages/codex packages/command packages/control packages/core packages/opencode packages/permissions scripts/rules test/integration.spec.ts 2>&1 | tee /tmp/test_non_daemon.txt
           code=${PIPESTATUS[0]}
           if [ $code -eq 0 ]; then
             exit 0

--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -209,7 +209,7 @@ const topLevelTestFiles = readdirSync(resolve(import.meta.dir, "../test"))
   .filter((f) => f.endsWith(".spec.ts") && RUN1_TEST_FILES.has(`test/${f}`))
   .map((f) => `test/${f}`);
 
-const nonDaemonPaths = [...packageDirs, ...topLevelTestFiles, ...RUN1_DAEMON_UNIT_TESTS];
+const nonDaemonPaths = [...packageDirs, "scripts/rules", ...topLevelTestFiles, ...RUN1_DAEMON_UNIT_TESTS];
 
 const testStart = Date.now();
 


### PR DESCRIPTION
## Summary
- Add `scripts/` to the non-daemon test step in `.github/workflows/ci.yml` — 18 spec files (339 tests, ~840ms) including all rule-engine fixture tests were silently excluded from CI
- Add `scripts/` to `check-coverage.ts` non-daemon paths so the coverage job also runs them
- The 4 fixture failures mentioned in #2305 were already fixed by subsequent commits (#2299/PR #2308); verified all 40 rule tests and 339 total scripts tests pass on current main

## Test plan
- [x] `bun test scripts/` — 339 pass, 0 fail (840ms)
- [x] `bun test` — 7764 pass, 0 fail (full suite)
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Correction (post-review):** scoped to `scripts/rules` only (the rule-engine fixture + `_engine` specs). `scripts/_runner` excluded — its sources are under the 80% coverage ratchet (tracked in #2311); `scripts/bun-segfault-repro` excluded (the 60-worker segfault repro). Earlier "all scripts/ / 339 tests" claim was from the first revision.