### PR TITLE
feat(pr): add 'mcx pr comments <pr> resolve' to resolve review threads (closes #2312)

### DIFF
--- a/.claude/phases/repair-fn.spec.ts
+++ b/.claude/phases/repair-fn.spec.ts
@@ -44,6 +44,11 @@ describe("buildRepairPrompt", () => {
     expect(buildRepairPrompt(30, "qa")).toMatch(/push/i);
     expect(buildRepairPrompt(30, "review")).toMatch(/push/i);
   });
+
+  test("includes resolve instruction for both phases", () => {
+    expect(buildRepairPrompt(30, "qa")).toContain("mcx pr comments 30 resolve --all-addressed");
+    expect(buildRepairPrompt(30, "review")).toContain("mcx pr comments 30 resolve --all-addressed");
+  });
 });
 
 describe("runRepair — session already in flight", () => {

--- a/.claude/phases/repair-fn.ts
+++ b/.claude/phases/repair-fn.ts
@@ -31,9 +31,10 @@ export type RepairResult =
     };
 
 export function buildRepairPrompt(prNumber: number, previousPhase: "review" | "qa"): string {
+  const resolveStep = `After replying to each addressed thread, resolve it: mcx pr comments ${prNumber} resolve --all-addressed`;
   return previousPhase === "qa"
-    ? `Repair PR #${prNumber}. Read the qa:fail comment: gh pr view ${prNumber} --comments. Address every blocker. Push to existing branch.`
-    : `Repair PR #${prNumber}. Read the adversarial review sticky comment: gh pr view ${prNumber} --comments. Fix all 🔴 and 🟡. Push to existing branch.`;
+    ? `Repair PR #${prNumber}. Read the qa:fail comment: gh pr view ${prNumber} --comments. Address every blocker. ${resolveStep}. Push to existing branch.`
+    : `Repair PR #${prNumber}. Read the adversarial review sticky comment: gh pr view ${prNumber} --comments. Fix all 🔴 and 🟡. ${resolveStep}. Push to existing branch.`;
 }
 
 export async function runRepair(

--- a/packages/command/src/commands/pr.spec.ts
+++ b/packages/command/src/commands/pr.spec.ts
@@ -6,8 +6,10 @@ import {
   formatSnapshotXml,
   parsePrCommentsArgs,
   parsePrMergeArgs,
+  parsePrResolveArgs,
   parsePrWaitArgs,
   prComments,
+  prCommentsResolve,
   prMerge,
   prWaitForCopilot,
 } from "./pr";
@@ -687,6 +689,243 @@ describe("formatSnapshotXml", () => {
   });
 });
 
+// ── parsePrResolveArgs ──
+
+describe("parsePrResolveArgs", () => {
+  test("parses single-thread resolve", () => {
+    const r = parsePrResolveArgs(["42", "resolve", "PRRT_abc"]);
+    expect(r.prNumber).toBe(42);
+    expect(r.threadId).toBe("PRRT_abc");
+    expect(r.allAddressed).toBe(false);
+    expect(r.replyText).toBeUndefined();
+    expect(r.error).toBeUndefined();
+  });
+
+  test("parses single-thread resolve with reply text", () => {
+    const r = parsePrResolveArgs(["42", "resolve", "PRRT_abc", "Done, fixed now"]);
+    expect(r.threadId).toBe("PRRT_abc");
+    expect(r.replyText).toBe("Done, fixed now");
+    expect(r.error).toBeUndefined();
+  });
+
+  test("joins multi-word reply text", () => {
+    const r = parsePrResolveArgs(["1", "resolve", "T1", "Fixed", "in", "latest", "commit"]);
+    expect(r.replyText).toBe("Fixed in latest commit");
+  });
+
+  test("parses --all-addressed", () => {
+    const r = parsePrResolveArgs(["42", "resolve", "--all-addressed"]);
+    expect(r.prNumber).toBe(42);
+    expect(r.allAddressed).toBe(true);
+    expect(r.threadId).toBeUndefined();
+    expect(r.error).toBeUndefined();
+  });
+
+  test("errors when no PR number", () => {
+    const r = parsePrResolveArgs([]);
+    expect(r.error).toMatch(/Usage/);
+  });
+
+  test("errors on invalid PR number", () => {
+    const r = parsePrResolveArgs(["abc", "resolve", "T1"]);
+    expect(r.error).toMatch(/Invalid PR number/);
+  });
+
+  test("errors when target missing after resolve", () => {
+    const r = parsePrResolveArgs(["42", "resolve"]);
+    expect(r.error).toMatch(/Usage/);
+  });
+
+  test("errors on unknown flag as target", () => {
+    const r = parsePrResolveArgs(["42", "resolve", "--bogus"]);
+    expect(r.error).toMatch(/Unknown flag/);
+  });
+});
+
+// ── prCommentsResolve ──
+
+const threadWithReply = {
+  threadId: "PRRT_abc",
+  rootCommentId: 100,
+  user: "reviewer",
+  location: "src/index.ts:10",
+  body: "Please fix this",
+  resolved: false,
+  outdated: false,
+  replies: [{ user: "dev", body: "Fixed", commentId: 101 }],
+};
+
+const threadWithoutReply = {
+  threadId: "PRRT_xyz",
+  rootCommentId: 200,
+  user: "reviewer",
+  location: "src/other.ts:5",
+  body: "Another comment",
+  resolved: false,
+  outdated: false,
+  replies: [],
+};
+
+const resolvedThread = {
+  ...threadWithReply,
+  threadId: "PRRT_done",
+  rootCommentId: 300,
+  resolved: true,
+};
+
+function makeResolveSnapshot(threads = [threadWithReply, threadWithoutReply]): PrThreadSnapshot {
+  return { ...emptySnapshot, threads };
+}
+
+describe("prCommentsResolve", () => {
+  test("resolves a single thread via gh api graphql", async () => {
+    const execCalls: string[][] = [];
+    const deps = makeDeps({
+      exec: (cmd: string[]) => {
+        execCalls.push(cmd);
+        return { stdout: '{"data":{}}', stderr: "", exitCode: 0 };
+      },
+      ipcCall: (() => Promise.resolve(makeResolveSnapshot())) as PrDeps["ipcCall"],
+    });
+    await prCommentsResolve(["42", "resolve", "PRRT_abc"], deps);
+    expect(execCalls).toHaveLength(1);
+    const [cmd] = execCalls;
+    expect(cmd[0]).toBe("gh");
+    expect(cmd[1]).toBe("api");
+    expect(cmd[2]).toBe("graphql");
+    expect(cmd.join(" ")).toContain("resolveReviewThread");
+    expect(cmd.join(" ")).toContain("PRRT_abc");
+  });
+
+  test("posts reply then resolves when reply text given", async () => {
+    const execCalls: string[][] = [];
+    const snapshot = makeResolveSnapshot([threadWithReply]);
+    const deps = makeDeps({
+      exec: (cmd: string[]) => {
+        execCalls.push(cmd);
+        return { stdout: "{}", stderr: "", exitCode: 0 };
+      },
+      ipcCall: (() => Promise.resolve(snapshot)) as PrDeps["ipcCall"],
+    });
+    await prCommentsResolve(["42", "resolve", "PRRT_abc", "Done, see latest commit"], deps);
+    expect(execCalls).toHaveLength(2);
+    // First call: reply
+    expect(execCalls[0].join(" ")).toContain("/pulls/42/comments");
+    expect(execCalls[0].join(" ")).toContain("Done, see latest commit");
+    expect(execCalls[0].join(" ")).toContain("in_reply_to=100");
+    // Second call: resolve
+    expect(execCalls[1].join(" ")).toContain("resolveReviewThread");
+  });
+
+  test("exits with error when thread not found for reply", async () => {
+    const errors: string[] = [];
+    const deps = makeDeps({
+      ipcCall: (() => Promise.resolve(makeResolveSnapshot())) as PrDeps["ipcCall"],
+      printError: (m: string) => errors.push(m),
+    });
+    await expect(prCommentsResolve(["42", "resolve", "PRRT_nonexistent", "reply text"], deps)).rejects.toBeInstanceOf(
+      ExitError,
+    );
+    expect(errors[0]).toContain("PRRT_nonexistent");
+  });
+
+  test("exits when gh api graphql fails", async () => {
+    const errors: string[] = [];
+    const deps = makeDeps({
+      exec: () => ({ stdout: "", stderr: "auth error", exitCode: 1 }),
+      ipcCall: (() => Promise.resolve(makeResolveSnapshot())) as PrDeps["ipcCall"],
+      printError: (m: string) => errors.push(m),
+    });
+    await expect(prCommentsResolve(["42", "resolve", "PRRT_abc"], deps)).rejects.toBeInstanceOf(ExitError);
+    expect(errors[0]).toContain("auth error");
+  });
+
+  test("--all-addressed resolves threads with replies", async () => {
+    const execCalls: string[][] = [];
+    const snapshot = makeResolveSnapshot([threadWithReply, threadWithoutReply, resolvedThread]);
+    const deps = makeDeps({
+      exec: (cmd: string[]) => {
+        execCalls.push(cmd);
+        return { stdout: "{}", stderr: "", exitCode: 0 };
+      },
+      ipcCall: (() => Promise.resolve(snapshot)) as PrDeps["ipcCall"],
+    });
+    await prCommentsResolve(["42", "resolve", "--all-addressed"], deps);
+    // Only threadWithReply is unresolved with a reply
+    expect(execCalls).toHaveLength(1);
+    expect(execCalls[0].join(" ")).toContain("PRRT_abc");
+  });
+
+  test("--all-addressed skips threads without replies", async () => {
+    const execCalls: string[][] = [];
+    const snapshot = makeResolveSnapshot([threadWithoutReply]);
+    const deps = makeDeps({
+      exec: (cmd: string[]) => {
+        execCalls.push(cmd);
+        return { stdout: "{}", stderr: "", exitCode: 0 };
+      },
+      ipcCall: (() => Promise.resolve(snapshot)) as PrDeps["ipcCall"],
+    });
+    await prCommentsResolve(["42", "resolve", "--all-addressed"], deps);
+    expect(execCalls).toHaveLength(0);
+  });
+
+  test("--all-addressed skips already-resolved threads", async () => {
+    const execCalls: string[][] = [];
+    const snapshot = makeResolveSnapshot([resolvedThread]);
+    const deps = makeDeps({
+      exec: (cmd: string[]) => {
+        execCalls.push(cmd);
+        return { stdout: "{}", stderr: "", exitCode: 0 };
+      },
+      ipcCall: (() => Promise.resolve(snapshot)) as PrDeps["ipcCall"],
+    });
+    await prCommentsResolve(["42", "resolve", "--all-addressed"], deps);
+    expect(execCalls).toHaveLength(0);
+  });
+
+  test("--all-addressed continues resolving after a failure", async () => {
+    const errors: string[] = [];
+    const failThread = { ...threadWithReply, threadId: "PRRT_fail", rootCommentId: 999 };
+    const snapshot = makeResolveSnapshot([failThread, threadWithReply]);
+    let call = 0;
+    const deps = makeDeps({
+      exec: () => {
+        call++;
+        if (call === 1) return { stdout: "", stderr: "fail", exitCode: 1 };
+        return { stdout: "{}", stderr: "", exitCode: 0 };
+      },
+      ipcCall: (() => Promise.resolve(snapshot)) as PrDeps["ipcCall"],
+      printError: (m: string) => errors.push(m),
+    });
+    await prCommentsResolve(["42", "resolve", "--all-addressed"], deps);
+    expect(errors.some((e) => e.includes("PRRT_fail"))).toBe(true);
+    expect(call).toBe(2);
+  });
+
+  test("exits with usage error when args missing", async () => {
+    const errors: string[] = [];
+    const deps = makeDeps({ printError: (m: string) => errors.push(m) });
+    await expect(prCommentsResolve([], deps)).rejects.toBeInstanceOf(ExitError);
+    expect(errors[0]).toMatch(/Usage/);
+  });
+
+  test("prComments routes to resolve when second arg is 'resolve'", async () => {
+    const execCalls: string[][] = [];
+    const snapshot = makeResolveSnapshot([threadWithReply]);
+    const deps = makeDeps({
+      exec: (cmd: string[]) => {
+        execCalls.push(cmd);
+        return { stdout: "{}", stderr: "", exitCode: 0 };
+      },
+      ipcCall: (() => Promise.resolve(snapshot)) as PrDeps["ipcCall"],
+    });
+    await prComments(["42", "resolve", "PRRT_abc"], deps);
+    expect(execCalls).toHaveLength(1);
+    expect(execCalls[0].join(" ")).toContain("resolveReviewThread");
+  });
+});
+
 // ── cmdPr ──
 
 describe("cmdPr", () => {
@@ -750,6 +989,8 @@ describe("cmdPr", () => {
       const output = logs.join("");
       expect(output).toContain("comments");
       expect(output).toContain("wait-for-copilot");
+      expect(output).toContain("resolve");
+      expect(output).toContain("--all-addressed");
     } finally {
       console.log = origLog;
     }

--- a/packages/command/src/commands/pr.spec.ts
+++ b/packages/command/src/commands/pr.spec.ts
@@ -794,7 +794,8 @@ describe("prCommentsResolve", () => {
     expect(cmd[1]).toBe("api");
     expect(cmd[2]).toBe("graphql");
     expect(cmd.join(" ")).toContain("resolveReviewThread");
-    expect(cmd.join(" ")).toContain("PRRT_abc");
+    expect(cmd.join(" ")).toContain("$threadId");
+    expect(cmd.join(" ")).toContain("threadId=PRRT_abc");
   });
 
   test("posts reply then resolves when reply text given", async () => {
@@ -809,10 +810,11 @@ describe("prCommentsResolve", () => {
     });
     await prCommentsResolve(["42", "resolve", "PRRT_abc", "Done, see latest commit"], deps);
     expect(execCalls).toHaveLength(2);
-    // First call: reply
+    // First call: reply — must use -F (raw-field) to prevent @-file expansion
     expect(execCalls[0].join(" ")).toContain("/pulls/42/comments");
     expect(execCalls[0].join(" ")).toContain("Done, see latest commit");
     expect(execCalls[0].join(" ")).toContain("in_reply_to=100");
+    expect(execCalls[0]).toContain("-F");
     // Second call: resolve
     expect(execCalls[1].join(" ")).toContain("resolveReviewThread");
   });
@@ -898,7 +900,7 @@ describe("prCommentsResolve", () => {
       ipcCall: (() => Promise.resolve(snapshot)) as PrDeps["ipcCall"],
       printError: (m: string) => errors.push(m),
     });
-    await prCommentsResolve(["42", "resolve", "--all-addressed"], deps);
+    await expect(prCommentsResolve(["42", "resolve", "--all-addressed"], deps)).rejects.toBeInstanceOf(ExitError);
     expect(errors.some((e) => e.includes("PRRT_fail"))).toBe(true);
     expect(call).toBe(2);
   });

--- a/packages/command/src/commands/pr.ts
+++ b/packages/command/src/commands/pr.ts
@@ -131,6 +131,54 @@ export function parsePrCommentsArgs(args: string[]): PrCommentsArgs {
   return { prNumber, json, includeResolved, error };
 }
 
+export interface PrResolveArgs {
+  prNumber: number | undefined;
+  threadId: string | undefined;
+  allAddressed: boolean;
+  replyText: string | undefined;
+  error: string | undefined;
+}
+
+const RESOLVE_USAGE =
+  "Usage: mcx pr comments <pr> resolve <thread-id> [reply text]\n       mcx pr comments <pr> resolve --all-addressed";
+
+export function parsePrResolveArgs(args: string[]): PrResolveArgs {
+  // args = [prNumber, "resolve", <thread-id | --all-addressed>, ...replyParts]
+  let prNumber: number | undefined;
+  let threadId: string | undefined;
+  let allAddressed = false;
+  let replyText: string | undefined;
+  let error: string | undefined;
+
+  if (!args[0]) {
+    return { prNumber, threadId, allAddressed, replyText, error: RESOLVE_USAGE };
+  }
+
+  prNumber = Number(args[0]);
+  if (Number.isNaN(prNumber)) {
+    return { prNumber: undefined, threadId, allAddressed, replyText, error: `Invalid PR number: ${args[0]}` };
+  }
+
+  // args[1] is "resolve" (the subcommand marker, already validated by caller)
+  const target = args[2];
+  if (!target) {
+    return { prNumber, threadId, allAddressed, replyText, error: RESOLVE_USAGE };
+  }
+
+  if (target === "--all-addressed") {
+    allAddressed = true;
+  } else if (target.startsWith("-")) {
+    return { prNumber, threadId, allAddressed, replyText, error: `Unknown flag: ${target}` };
+  } else {
+    threadId = target;
+    if (args.length > 3) {
+      replyText = args.slice(3).join(" ");
+    }
+  }
+
+  return { prNumber, threadId, allAddressed, replyText, error };
+}
+
 export interface PrWaitArgs {
   prNumber: number | undefined;
   maxWaitMs: number;
@@ -247,6 +295,11 @@ export async function prMerge(args: string[], deps: Partial<PrDeps> = {}): Promi
 
 export async function prComments(args: string[], deps: Partial<PrDeps> = {}): Promise<void> {
   const d: PrDeps = { ...defaultPrDeps, ...deps };
+
+  if (args[1] === "resolve") {
+    return prCommentsResolve(args, d);
+  }
+
   const parsed = parsePrCommentsArgs(args);
 
   if (parsed.error || parsed.prNumber === undefined) {
@@ -265,6 +318,94 @@ export async function prComments(args: string[], deps: Partial<PrDeps> = {}): Pr
   } else {
     console.log(formatSnapshotXml(snapshot));
   }
+}
+
+export async function prCommentsResolve(args: string[], deps: Partial<PrDeps> = {}): Promise<void> {
+  const d: PrDeps = { ...defaultPrDeps, ...deps };
+  const parsed = parsePrResolveArgs(args);
+
+  if (parsed.error || parsed.prNumber === undefined) {
+    d.printError(parsed.error ?? RESOLVE_USAGE);
+    d.exit(1);
+  }
+
+  const prNumber = parsed.prNumber as number;
+
+  if (parsed.allAddressed) {
+    const snapshot = await d.ipcCall("getPrThreadSnapshot", {
+      prNumber,
+      repoRoot: d.repoRoot(),
+      includeResolved: false,
+    });
+
+    const toResolve = snapshot.threads.filter((t) => !t.resolved && t.replies.length > 0);
+    if (toResolve.length === 0) {
+      console.error("No addressed threads to resolve.");
+      return;
+    }
+
+    let resolved = 0;
+    for (const thread of toResolve) {
+      const { exitCode, stderr } = d.exec(buildResolveCmd(thread.threadId));
+      if (exitCode !== 0) {
+        d.printError(`Failed to resolve thread ${thread.threadId}: ${stderr || `exit ${exitCode}`}`);
+      } else {
+        resolved++;
+      }
+    }
+    console.error(`Resolved ${resolved}/${toResolve.length} addressed thread(s).`);
+    return;
+  }
+
+  // Single-thread resolve
+  const threadId = parsed.threadId as string;
+
+  if (parsed.replyText) {
+    const snapshot = await d.ipcCall("getPrThreadSnapshot", {
+      prNumber,
+      repoRoot: d.repoRoot(),
+      includeResolved: true,
+    });
+
+    const thread = snapshot.threads.find((t) => t.threadId === threadId);
+    if (!thread) {
+      d.printError(`Thread ${threadId} not found in PR #${prNumber}`);
+      d.exit(1);
+    }
+
+    const { exitCode: replyExit, stderr: replyStderr } = d.exec([
+      "gh",
+      "api",
+      `/repos/{owner}/{repo}/pulls/${prNumber}/comments`,
+      "-X",
+      "POST",
+      "-f",
+      `body=${parsed.replyText}`,
+      "-F",
+      `in_reply_to=${thread.rootCommentId}`,
+    ]);
+    if (replyExit !== 0) {
+      d.printError(replyStderr || `Failed to post reply (exit ${replyExit})`);
+      d.exit(replyExit);
+    }
+  }
+
+  const { exitCode, stderr } = d.exec(buildResolveCmd(threadId));
+  if (exitCode !== 0) {
+    d.printError(stderr || `Failed to resolve thread (exit ${exitCode})`);
+    d.exit(exitCode);
+  }
+  console.error(`Resolved thread ${threadId}.`);
+}
+
+function buildResolveCmd(threadId: string): string[] {
+  return [
+    "gh",
+    "api",
+    "graphql",
+    "-f",
+    `query=mutation{resolveReviewThread(input:{threadId:"${threadId}"}){thread{isResolved}}}`,
+  ];
 }
 
 export async function prWaitForCopilot(args: string[], deps: Partial<PrDeps> = {}): Promise<void> {
@@ -415,24 +556,27 @@ function printPrUsage(): void {
   console.log(`mcx pr — worktree-aware GitHub PR helpers
 
 Usage:
-  mcx pr merge <pr>                       Merge PR without local-branch cleanup errors
-  mcx pr merge <pr> --auto                Enable auto-merge (merges when CI passes)
-  mcx pr merge <pr> --auto --wait         Enable auto-merge + block until merged
-  mcx pr comments <pr>                    Show PR threads (XML for LLM consumption)
-  mcx pr comments <pr> --json             Show PR threads as JSON
-  mcx pr comments <pr> --include-resolved Include resolved threads
-  mcx pr wait-for-copilot <pr>            Block until Copilot review is ready
-  mcx pr wait-for-copilot <pr> --max-wait 300  Custom timeout in seconds (default: 600)
+  mcx pr merge <pr>                               Merge PR without local-branch cleanup errors
+  mcx pr merge <pr> --auto                        Enable auto-merge (merges when CI passes)
+  mcx pr merge <pr> --auto --wait                 Enable auto-merge + block until merged
+  mcx pr comments <pr>                            Show PR threads (XML for LLM consumption)
+  mcx pr comments <pr> --json                     Show PR threads as JSON
+  mcx pr comments <pr> --include-resolved         Include resolved threads
+  mcx pr comments <pr> resolve <thread-id>        Resolve a single review thread
+  mcx pr comments <pr> resolve <thread-id> <text> Reply with text, then resolve
+  mcx pr comments <pr> resolve --all-addressed    Resolve all threads that have a reply
+  mcx pr wait-for-copilot <pr>                    Block until Copilot review is ready
+  mcx pr wait-for-copilot <pr> --max-wait 300     Custom timeout in seconds (default: 600)
 
 Merge strategy (default: --squash):
-  --squash                                Squash and merge
-  --rebase                                Rebase and merge
-  --merge                                 Create a merge commit
+  --squash                                        Squash and merge
+  --rebase                                        Rebase and merge
+  --merge                                         Create a merge commit
 
 Options:
-  --auto                                  Enable auto-merge (requires branch protection)
-  --wait                                  Block until the PR reaches MERGED state
-  --timeout, -t <ms>                      Max wait time (default: ${DEFAULT_TIMEOUT_MS})
+  --auto                                          Enable auto-merge (requires branch protection)
+  --wait                                          Block until the PR reaches MERGED state
+  --timeout, -t <ms>                              Max wait time (default: ${DEFAULT_TIMEOUT_MS})
 
 Unlike 'gh pr merge --delete-branch', 'mcx pr merge' never attempts local branch
 deletion. Use 'mcx claude bye' to clean up the worktree and local branch once

--- a/packages/command/src/commands/pr.ts
+++ b/packages/command/src/commands/pr.ts
@@ -354,6 +354,10 @@ export async function prCommentsResolve(args: string[], deps: Partial<PrDeps> = 
       }
     }
     console.error(`Resolved ${resolved}/${toResolve.length} addressed thread(s).`);
+    if (resolved < toResolve.length) {
+      d.exit(1);
+      return;
+    }
     return;
   }
 
@@ -379,7 +383,7 @@ export async function prCommentsResolve(args: string[], deps: Partial<PrDeps> = 
       `/repos/{owner}/{repo}/pulls/${prNumber}/comments`,
       "-X",
       "POST",
-      "-f",
+      "-F",
       `body=${parsed.replyText}`,
       "-F",
       `in_reply_to=${thread.rootCommentId}`,
@@ -404,7 +408,9 @@ function buildResolveCmd(threadId: string): string[] {
     "api",
     "graphql",
     "-f",
-    `query=mutation{resolveReviewThread(input:{threadId:"${threadId}"}){thread{isResolved}}}`,
+    "query=mutation($threadId: ID!) { resolveReviewThread(input: { threadId: $threadId }) { thread { isResolved } } }",
+    "-f",
+    `threadId=${threadId}`,
   ];
 }
 


### PR DESCRIPTION
## Summary
- Extends `mcx pr comments <pr>` with a `resolve` subcommand: `mcx pr comments <pr> resolve <thread-id> [reply text]` to resolve a single thread (optionally posting a reply first), and `mcx pr comments <pr> resolve --all-addressed` to bulk-resolve all unresolved threads that already have a reply
- Implements resolution via `gh api graphql` (the `resolveReviewThread` mutation) and reply-posting via `gh api /repos/{owner}/{repo}/pulls/{n}/comments`, using the existing `deps.exec` injection pattern — no new deps, no daemon changes
- `done.ts` merge-time auto-resolve remains as the backstop; this new verb lets workers resolve threads explicitly after replying, before the PR reaches merge

## Test plan
- [x] `parsePrResolveArgs`: covers single-thread, reply text, `--all-addressed`, empty args, invalid PR number, missing target, unknown flag
- [x] `prCommentsResolve`: covers graphql exec call, reply+resolve sequence, thread-not-found error, gh failure, `--all-addressed` filtering (with/without replies, already resolved, partial failure continues)
- [x] `prComments` routes to resolve when `args[1] === "resolve"`
- [x] `cmdPr` usage includes `resolve` and `--all-addressed`
- [x] Full test suite: 7766 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)