### PR TITLE
skill: /rule-author — author/refine/migrate rules + bootstrap the engine (#2348)

### DIFF
--- a/.claude/skills/rule-author/SKILL.md
+++ b/.claude/skills/rule-author/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: rule-author
+description: Author, refine, or migrate a doing-it-wrong architectural rule. Use when the user wants to "write a rule", "add a lint rule", "should we lint for this", "make a rule for X", "migrate a check-*.ts into the rule engine", or when a recurring mistake (often surfaced by harvest-rules) should be mechanized. Also covers judging whether a proposed rule is worth writing and bootstrapping the rule engine into a new repo.
+---
+
+# Rule Author
+
+## Why rules exist
+
+A rule mechanizes a recurring mistake so review rounds and CI minutes are spent on judgment, not on catching the same avoidable bug again and again. Rules are part of the project's **definition of done**: the `doing-it-wrong` sweep runs inside `am-i-done`, which is the *single* gate executed identically at pre-commit and in CI. That's the whole value — it **shifts failures left**: a violation fails in seconds on the author's machine instead of surfacing minutes later in CI (or worse, never, if the gate is incomplete). And because mcp-cli is built by autonomous agents, rules are **agentic guardrails**: an implementer that doesn't know a convention gets caught mechanically instead of shipping the mistake into main. One rule is one `scripts/rules/<id>.rule.ts` file — **not** a new `package.json` script. New rules go behind the single `doing-it-wrong` / `am-i-done` entry points.
+
+## When to use this skill
+
+- Writing a new rule from a known recurring mistake (e.g. a harvest-rules finding).
+- Refining a rule that's too broad (false positives) or too narrow (misses the shape).
+- Judging whether a proposed invariant *should* be a rule at all.
+- Migrating a legacy standalone `scripts/check-*.ts` into the engine.
+- Standing the engine up in a new repository.
+
+## References
+
+- **`references/new-rule.md`** — how to author a `.rule.ts`: the API, regex-vs-AST decision, fixtures (minimal, not elaborate), writing guidance that names the cause, and the add-rule→show-red→remediate-in-the-same-PR discipline.
+- **`references/rule-engine.md`** — a from-scratch description of the engine (every `_engine/` component, the entry scripts, and how the gate is wired). Use this when copying the engine to a new repo so you don't re-derive the layout each time.
+
+## Is this a good rule?
+
+Before writing, check all four. If any fails, refine the proposal or say so — a bad rule is worse than no rule, because every false positive teaches people to suppress reflexively and erodes trust in the whole sweep.
+
+1. **Mechanically enforceable.** The mistake must be a *shape* a regex or the TS AST can match — "raw `Bun.spawn` instead of the helper", "`expect(x.filter(...)).toHaveLength(0)`". If detecting it requires understanding intent or design quality ("is this abstraction right?"), it is a code-review concern, not a rule. Decline or narrow it to the mechanizable core.
+2. **Precise.** Aim for near-zero false positives. A noisy rule gets `// dotw-ignore`'d on sight and becomes decoration. If you can't get precision with a regex, use the AST (`references/new-rule.md`); if you still can't, the rule isn't ready.
+3. **Has a real alternative.** A rule that bans something must point at the right way to do it — ideally a shared helper that handles the corner cases, so "do it right" is easier than "do it wrong". A ban whose only escape is an unbounded `// dotw-ignore: long-running, you're on your own` is not a guardrail; it just moves the risk behind a comment. If the right answer is "use a helper that doesn't exist yet", build the helper (or file it) as part of the work.
+4. **Recurring.** One-offs don't earn a rule. The bar is roughly "a reviewer has flagged this more than twice" (see the `harvest-rules` skill). A single incident is a fix, not a rule.
+
+Borderline cases worth refining rather than rejecting: a rule that's *mostly* mechanizable but has a few legitimate exceptions (give it precise detection + a documented suppression), or one that overlaps an existing rule (resolve the overlap — don't ship two rules that fight over the same lines).

--- a/.claude/skills/rule-author/references/new-rule.md
+++ b/.claude/skills/rule-author/references/new-rule.md
@@ -1,0 +1,116 @@
+# Writing a rule
+
+## 1. The file
+
+One rule = one file: `scripts/rules/<id>.rule.ts`, default-exporting a `Rule`. The loader autoloads every `*.rule.ts` (no manual registry — `index.ts` just re-exports the loader). The `<id>` is the stable identifier used in reports and suppression comments; keep it short, kebab-case, and matching the filename prefix.
+
+```ts
+import type { CheckRule } from "./_engine/rule";
+
+const rule: CheckRule = {
+  id: "no-raw-spawn",
+  kind: "check",
+  scold: "raw Bun.spawn/spawnSync — use spawnCapture() from @mcp-cli/core",
+  guidance: [ /* see §4 */ ],
+  documentation: "#2269",       // optional: issue / PR / CLAUDE.md anchor
+  appliesToTests: false,        // optional, default true
+  check({ file, violated, ast }) { /* ... */ },
+};
+export default rule;
+```
+
+### The API (`_engine/rule.ts`)
+
+`RuleBase` fields, shared by both kinds:
+- `id: string` — stable; used in suppressions and the registry.
+- `scold: string` — one-line "what's wrong", shown once per rule in the banner.
+- `guidance: string[]` — "how to fix" bullets, shown once per rule (not per violation).
+- `documentation?: string` — pointer (issue/PR/anchor).
+- `appliesToTests?: boolean` — when `false`, `*.spec.ts`/`*.test.ts` are skipped. Default `true`.
+
+Two kinds:
+- **`PatternRule`** — `{ kind: "pattern", pattern: RegExp, except?: string[] }`. The engine runs the regex per-line (forces `/g`), reports each match as `line:column`. `except` is a list of substrings that, if present on a matched line, exempt it.
+- **`CheckRule`** — `{ kind: "check", check(ctx) }`. `ctx` is `{ file, files, violated, ast }`:
+  - `file: FileMeta` — `{ path, relPath, content, pkg, isTest }`. `pkg` is `"packages/<name>" | "scripts" | "test" | ""`.
+  - `files: Map<string, FileMeta>` — all loaded files, for cross-file checks.
+  - `violated(line, column, snippet)` — call once per violation. 1-indexed line/column.
+  - `ast: AstHelper` — lazily parsed (only on first access; nothing is paid if you don't touch it).
+
+## 2. Regex or AST?
+
+**Use a `pattern` rule** when the mistake is a single-line lexical shape with low false-positive risk: `execSync(\`...${x}...\`)`, a banned import specifier, a forbidden call on one line. Cheapest to write and read.
+
+**Use a `check` rule with `ast`** when the shape is structural, spans nodes, or a regex would be a guessing game:
+- multi-line constructs (a callback body, an `if`-guard and the assertion inside it),
+- "call to X where the receiver is `Bun`" (precise callee/receiver matching),
+- "discriminant asserted *outside* this `if`" (relationship between nodes),
+- anything where comments/strings would create false matches.
+
+`AstHelper` (`_engine/ast.ts`) gives you:
+- `sourceFile` — the `ts.SourceFile`; drop to the raw TS API when needed.
+- `find(guard)` — all descendants matching a `ts.is*` type guard.
+- `findByKind(kind)` — all nodes of a `SyntaxKind`.
+- `callsTo(name)` — `CallExpression`s whose callee is `name` (identifier or `.name`).
+- `positionOf(node)` → `{ line, column }` (1-indexed) for `violated`.
+- `stringLiterals(node)` — string/no-substitution-template text under a node.
+
+Rule of thumb: if you're writing a regex with three lookaheads to avoid false positives, stop and use the AST. The `no-raw-spawn`, `timer-callback-error-boundary`, and `test-unguarded-narrowing` rules are good `check`+`ast` references; `shell-injection` is a good `pattern` reference.
+
+### Scoping
+
+Gate inside `check` on `file.relPath` / `file.pkg` / `file.isTest` when a rule only applies to part of the tree — e.g. `if (!file.relPath.startsWith("packages/daemon/src/")) return;`, or a single-file rule with `if (file.relPath !== "…/phase.ts") return;`. The loader already skips `.d.ts`, `node_modules`, fixtures, and `*.rule.ts` files (rules don't flag themselves), and `appliesToTests:false` skips test files.
+
+## 3. Fixtures — minimal, not elaborate
+
+Every rule needs at least one fixture; the autoloaded `fixtures.spec.ts` fails CI if a registered rule has none, and asserts the violation count matches. A fixture is a real `.ts` file:
+
+`scripts/rules/fixtures/<rule-id>__<scenario>.fixture.ts`
+
+```ts
+/**
+ * @rule no-raw-spawn
+ * @expect 1
+ * @path packages/command/src/example.ts
+ */
+
+// the smallest snippet that exhibits the shape:
+const proc = Bun.spawn(["git", "status"]);
+```
+
+- `@rule` must match the filename prefix (before `__`). `@expect` is the exact count. `@path` is the synthetic path the rule sees — it controls package/test gating, so set it to a path your scope check accepts.
+- **Keep fixtures minimal.** The goal is to exercise the *shape*, not reproduce a real bug. One small clean fixture (`@expect 0`) proving the rule does NOT fire on the good pattern, and one flagged fixture (`@expect N`) proving it DOES. Add a third only for a genuine edge the rule handles specially (a near-miss that should be safe, a suppression). Don't build elaborate scenarios — they obscure what's under test and rot.
+- Both polarities are first-class: `@expect 0` fixtures catch the regression where a regex tightens and stops matching intended targets.
+- JSDoc blocks (the frontmatter and any others) are blanked to whitespace before the rule runs, with line numbers preserved — so prose in comments never triggers pattern rules, and reported lines stay aligned to the file.
+- Suppression is applied at the fixture boundary too: a fixture containing `// dotw-ignore <id>: ...` must be `@expect 0`.
+
+## 4. Guidance that names the cause
+
+This is the part most worth getting right. **Name the failure mechanism, then give non-exhaustive examples. Do not prescribe a single move.** A recipe ("just do X") leaves the reader pattern-matching instead of understanding — they can't generalize, and they can't recognize the legitimate exception. Two real failures from this codebase:
+
+- A fixing agent burned nine paragraphs deliberating between two prescribed `test-filtered-assertion` fixes because the guidance said "do A or B" with no *why*. Making it more prescriptive made it worse. The fix was to explain the cause — *"filtering is subtractive: anything you filtered out can never fail the test, so it only proves the bad thing you searched for is absent, never that the output is correct"* — from which the right move is obvious.
+- A `no-raw-spawn` agent nearly suppressed a site because the helper lacked an `env` option. The guidance now spells out what the helper handles (missing-binary throw, pipe-deadlock draining, timeout→SIGKILL, null exitCode) so the cost of reimplementing is visible, and says explicitly: *if the helper lacks an option, extend it — a missing option is not a reason to suppress.*
+
+Structure:
+- `scold` — the one-line "what's wrong".
+- `guidance[0]` — the mechanism of harm (the *why*).
+- `guidance[1..]` — "examples of doing it right (not exhaustive): …", and for ban-and-replace rules, when the escape hatch (`// dotw-ignore`) genuinely applies.
+- `documentation` — the issue/PR for the full story.
+
+## 5. Rollout: add rule → show red → remediate in the SAME PR
+
+A rule and the cleanup of its existing violations land **together**. This is non-negotiable for two reasons, both learned the hard way (#2344):
+
+- **Don't merge a rule that leaves the tree red** — the gate now blocks everyone's commits/CI on pre-existing debt that isn't their fault.
+- **Don't merge a rule that isn't swept by the gate** — sprint 62 shipped rules with green fixtures but the sweep ran nowhere, so 93 violations accumulated invisibly and the rules did nothing.
+
+Workflow:
+1. Write the rule + minimal fixtures.
+2. `bun run doing-it-wrong --rule <id> --all` — see every existing violation.
+3. Remediate each: fix it, or suppress with a reason where the construct is genuinely correct:
+   - permanent: `// dotw-ignore <id>: <reason>`
+   - temporary: `// dotw-todo <id>: <desc> — fix in #NNN` (the `#NNN` is required)
+   - The comment applies to its own line and the line below it.
+4. `bun run doing-it-wrong --rule <id>` → clean. Then the full gate: `bun run am-i-done`. **Trust the exit code, not a grep of the output** (a single violation prints "1 violation", which a plural-only grep misses).
+5. Confirm fixtures pass: `bun test scripts/rules`.
+
+When remediating a large rule across many files, partition by package and delegate the repetitive edits to per-package agents — but enumerate **all** packages (it's easy to miss one), and tell each agent to run `bun run am-i-done` before reporting, not a hand-picked subset of checks.

--- a/.claude/skills/rule-author/references/rule-engine.md
+++ b/.claude/skills/rule-author/references/rule-engine.md
@@ -1,0 +1,66 @@
+# The rule engine (for replication / bootstrapping a new repo)
+
+This describes the `doing-it-wrong` engine in enough detail to recreate it, or — faster — to copy the source files and wire them up. The engine is small, dependency-light (TypeScript + Bun's `Glob`), and deliberately flat: it suits a single-package or shallow-monorepo repo, not a deeply layered one.
+
+## Layout
+
+```
+scripts/
+  doing-it-wrong.ts        entry: runs rules, flags, exit code
+  am-i-done.ts             orchestrator: runs the rule sweep + other checks as Steps
+  rules/
+    index.ts               re-exports loadAllRules + findRule (no manual registry)
+    <id>.rule.ts           one rule per file, default export
+    fixtures/
+      <id>__<scenario>.fixture.ts
+    fixtures.spec.ts       autoloads fixtures, asserts every rule has ≥1 + counts match
+    _engine/
+      rule.ts              Rule types (pattern | check) + evaluateRule dispatch
+      rule-loader.ts       globs *.rule.ts, validates, sorts by id, dedupes ids
+      file-loader.ts       FileMeta + tree scan (what's in/out of scope)
+      ast.ts               lazy WeakMap-cached SourceFile + AstHelper
+      suppression.ts       // dotw-ignore / // dotw-todo parsing
+      fixture-loader.ts    fixture frontmatter + JSDoc blanking
+      reporter.ts          grouped, capped, grep-friendly output
+```
+
+## Components
+
+- **`rule.ts`** — defines `Rule = PatternRule | CheckRule` (see `new-rule.md` §1 for fields) and `evaluateRule(rule, file, files)`, which dispatches by kind and returns raw violations. Suppression is applied *outside* `evaluateRule` (at the runner boundary), so rule authors never deal with comments. The AST is exposed through a lazy getter — `createAstHelper(file)` is only called on first `ctx.ast` access.
+
+- **`rule-loader.ts`** — `loadAllRules(dir)` globs `*.rule.ts`, dynamically imports each, validates the default export (`id` + valid `kind` + `pattern`/`check` present), sorts by `id` (stable report order independent of glob order), and throws on duplicate ids. No hand-maintained registry — adding a file is adding a rule.
+
+- **`file-loader.ts`** — `loadFiles({ repoRoot, roots?, filter? })` scans `packages/`, `scripts/`, `test/` (override via `roots`) for `**/*.{ts,tsx}`, returning `Map<absPath, FileMeta>` where `FileMeta = { path, relPath, content, pkg, isTest }`. **Excludes** `.d.ts`, `node_modules`, anything under `rules/fixtures/` or `*.fixture.ts(x)`, and `*.rule.ts(x)` (so rules never flag themselves — engine internals under `_engine/` stay in scope as ordinary product code). `filter` is a path substring (powers `--filter`).
+
+- **`ast.ts`** — `AstHelper` over a `ts.SourceFile` cached per `FileMeta` in a `WeakMap`. Methods: `sourceFile`, `find(guard)`, `findByKind(kind)`, `callsTo(name)`, `positionOf(node)`, `stringLiterals(node)`. Pure `typescript`; no type-checker/program, so it's fast and needs no tsconfig resolution.
+
+- **`suppression.ts`** — `checkSuppression(content, lineNo, ruleId)` parses `// dotw-ignore <id>: <reason>` (permanent) and `// dotw-todo <id>: <desc> #NNN` (temporary, issue ref required). A suppression applies to its own line **and** the next non-empty line (covers comment-above and trailing-comment styles). Returns `{ suppressed, todoWithoutIssue, kind }`; a `dotw-todo` missing `#NNN` is surfaced as malformed (a future meta-rule promotes it to a hard error).
+
+- **`fixture-loader.ts`** — parses the `@rule`/`@expect`/`@path` JSDoc frontmatter, enforces filename-prefix == `@rule`, and blanks all JSDoc blocks to whitespace (line-preserving) so prose never triggers pattern rules and reported lines align. Produces a `FileMeta` shaped exactly like the production loader.
+
+- **`reporter.ts`** — `reportViolations(violations, { logger, showAll, perRuleLimit=5 })`. Groups by rule id; prints a banner (`━━━ rule: <id> ━━━`), the `scold` with a count, up to `perRuleLimit` `file:line:column` + snippet lines (grep-friendly), then the `guidance` bullets once and the `documentation` pointer. `✨ no rule violations` when clean.
+
+## Entry points
+
+- **`doing-it-wrong.ts`** — `runRules({ ruleId?, filter?, showAll? }, logger)` loads rules + files, evaluates each rule over each file (rules iterated outer so report order is registration order), applies suppression, and returns `{ violations, malformedTodos, unknownRule, ruleCount, durationMs }`. CLI flags: `--rule <id>`, `--filter <substr>`, `--all` (no per-rule cap), `--list`. **Exit code 1 on any violation or unknown rule** — the gate's source of truth. Also exported as a `ScriptFunction` (`doingItWrongStep`) so the orchestrator runs it in-process without a second Bun startup.
+
+- **`am-i-done.ts`** — the orchestrator. Declares each check as a `Step` (name, description, command — a shell string or an in-process function) and runs them with silent-first / verbose-on-failure semantics, `--from N`, `--only NAME`. Two step lists: `--pre-commit` (fast static subset: typecheck, lint, the rule sweep, any other static checks) and the comprehensive default (adds test + coverage). In an AI context (`CLAUDECODE`/`AGENT`/`MCP_CLI_AI`) it captures output to a file and surfaces only the path on failure, to protect an orchestrator's context budget.
+
+## Wiring — the load-bearing step
+
+**The engine does nothing unless the gate runs it.** This is the single most important lesson (mcp-cli #2344): sprint 62 shipped rules with green fixtures, but the sweep ran in neither pre-commit nor CI, so violations piled up invisibly and the rules were inert.
+
+Wire `am-i-done --pre-commit` into **both**:
+- the **pre-commit hook** (fast local feedback), and
+- **CI** (the unforgettable backstop — a red PR can't merge; the hook is bypassable via `--no-verify`, web edits, force-push).
+
+Run the **identical** command in both so local and CI share one definition of done — a violation then fails in seconds locally, never for the first time in CI. Keep heavyweight, environment-specific steps (test splitting, coverage with crash-retries, build/smoke) on their own CI jobs; route only the static gate through `am-i-done --pre-commit` unless/until those are folded in too.
+
+## Bootstrapping a new repo
+
+1. Copy `scripts/rules/_engine/`, `scripts/doing-it-wrong.ts`, and (recommended) `scripts/am-i-done.ts` with its `_runner/`.
+2. Adjust `file-loader.ts` `roots` to the new repo's source layout.
+3. Add `package.json` scripts: `"doing-it-wrong"` and `"am-i-done"` (one entry total — not one per rule).
+4. Wire `am-i-done --pre-commit` into the pre-commit hook and CI (see above).
+5. Write the first rule + a minimal fixture pair (`new-rule.md`), confirm `bun test scripts/rules` and `bun run doing-it-wrong` (exit 0) pass.
+6. Seed real rules from `harvest-rules` findings rather than inventing invariants speculatively.


### PR DESCRIPTION
Closes #2348. Docs-only (`.claude/skills/**`).

Adds the `/rule-author` skill, distilled from the #2344 guardrail work:

- **SKILL.md** — routing; why rules exist (am-i-done definition of done, shift-left, agentic guardrails); a four-point "is this a good rule?" test (mechanically enforceable / precise / has a real alternative / recurring); references index.
- **references/new-rule.md** — the `.rule.ts` API, regex-vs-AST decision, minimal fixtures (not elaborate reproductions), guidance that **names the cause** rather than prescribing a move, and the add-rule → show-red → remediate-in-the-same-PR discipline.
- **references/rule-engine.md** — a from-scratch description of every `_engine/` component + entry scripts + how the gate must be wired (the load-bearing lesson: a rule does nothing unless `am-i-done` runs it in both pre-commit and CI). Lets the engine be copied into a new repo without re-deriving the layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)