### PR TITLE
fix(rules): narrow no-hardcoded-test-port — drop connect, guard missing parents (fixes #2319)

### DIFF
--- a/scripts/rules/fixtures/no-hardcoded-test-port__clean.fixture.ts
+++ b/scripts/rules/fixtures/no-hardcoded-test-port__clean.fixture.ts
@@ -7,6 +7,7 @@
  *   - port: 0  (dynamic — the correct pattern)
  *   - port: N  inside expect()/assertion — not a server bind
  *   - port: N  in a mock struct returned by a helper — not a server bind
+ *   - connect({ port: N }) — client dial, not a server bind
  *   - transport-named variable with numeric literal — "transport" ≠ "port" word
  *   - unrelated numeric literals (timeouts, counts)
  */
@@ -45,6 +46,13 @@ describe("dynamic-port server", () => {
     }
     const cb = makeCallback();
     expect(cb.port).toBe(9999);
+  });
+
+  it("connect() is a client dial — fixed port is correct", () => {
+    // Client connections dial a known port by definition; port: 0 is meaningless.
+    const connect = (_opts: { port: number }) => {};
+    connect({ port: 6379 });
+    connect({ port: 5432 });
   });
 
   it("transport-named variable with a numeric literal is not a port", () => {

--- a/scripts/rules/no-hardcoded-test-port.rule.ts
+++ b/scripts/rules/no-hardcoded-test-port.rule.ts
@@ -10,7 +10,7 @@
  * Two patterns are flagged (test files only):
  *
  *   1. A `port:` property in an ObjectLiteralExpression that is a **direct
- *      argument** to a known server-construction call (serve/listen/connect/
+ *      argument** to a known server-construction call (serve/listen/
  *      createServer). Plain data objects, mock structs, and assertion arguments
  *      are excluded.
  *
@@ -30,7 +30,7 @@ import ts from "typescript";
 import type { CheckRule } from "./_engine/rule";
 
 // Call/constructor names whose first object-literal argument is a server config.
-const SERVER_CALL_NAMES = new Set(["serve", "listen", "connect", "createServer"]);
+const SERVER_CALL_NAMES = new Set(["serve", "listen", "createServer"]);
 
 const rule: CheckRule = {
   id: "no-hardcoded-test-port",
@@ -38,7 +38,7 @@ const rule: CheckRule = {
   appliesToTests: true,
   scold: "hardcoded port number in test — use port: 0 and read the OS-assigned port from the server handle",
   guidance: [
-    "pass port: 0 to serve()/listen()/connect() — the OS picks a free ephemeral port",
+    "pass port: 0 to serve()/listen() — the OS picks a free ephemeral port",
     "read the assigned port back: `server.port` (Bun), `server.address().port` (net.Server)",
     "never invent a random-port helper — they reintroduce collision risk (Bun's guide bans them)",
     "if a fixed port is truly required (e.g. OAuth redirect-URI), add: // dotw-ignore no-hardcoded-test-port: <reason>",
@@ -83,6 +83,9 @@ function isPortPropertyName(name: ts.PropertyName): boolean {
  * Requires parent nodes (setParentNodes=true, enabled since #2308).
  */
 function isDirectServerCallArg(node: ts.PropertyAssignment): boolean {
+  if (node.parent === undefined) {
+    throw new Error("no-hardcoded-test-port: parent nodes not set — ensure setParentNodes=true in createAstHelper");
+  }
   if (!ts.isObjectLiteralExpression(node.parent)) return false;
   const callOrNew = node.parent.parent;
   if (!ts.isCallExpression(callOrNew) && !ts.isNewExpression(callOrNew)) return false;


### PR DESCRIPTION
Closes #2319, #2320

## Summary
- Remove `"connect"` from `SERVER_CALL_NAMES` — client dials (`redis.connect`, `pg.connect`, `net.connect`) are not server binds; `port: 0` is meaningless for clients, so flagging them produces false positives
- Add defensive `throw` in `isDirectServerCallArg` when `node.parent` is undefined — if a future refactor drops `setParentNodes=true`, Pattern 1 now crashes loudly instead of silently passing everything
- Add clean fixture proving `connect({ port: N })` is no longer flagged
- Update JSDoc and guidance strings to remove stale `connect()` references

## Test plan
- [x] `bun run am-i-done --pre-commit` passes (all 7 static checks)
- [x] `bun test scripts/rules/fixtures.spec.ts` — all 57 fixture tests pass, including new `connect()` clean fixture
- [x] Verified `no-hardcoded-test-port__clean.fixture.ts` expects 0 violations with `connect({ port: 6379 })`
- [x] Verified `no-hardcoded-test-port__flagged.fixture.ts` still expects 2 violations (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)