### PR TITLE
fix(rules): report honest ruleCount/durationMs for unknown --rule id (fixes #2289)

### DIFF
--- a/scripts/doing-it-wrong.spec.ts
+++ b/scripts/doing-it-wrong.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+
+import { runRules } from "./doing-it-wrong";
+
+function makeLogger() {
+  const messages: { level: string; msg: string }[] = [];
+  return {
+    logger: {
+      info: (msg: string) => messages.push({ level: "info", msg }),
+      warn: (msg: string) => messages.push({ level: "warn", msg }),
+      error: (msg: string) => messages.push({ level: "error", msg }),
+    },
+    messages,
+  };
+}
+
+describe("runRules", () => {
+  it("returns unknownRule=true with honest ruleCount for an unknown rule id", async () => {
+    const { logger, messages } = makeLogger();
+    const result = await runRules({ ruleId: "no-such-rule-xyz" }, logger);
+
+    expect(result.unknownRule).toBe(true);
+    expect(result.violations).toEqual([]);
+    expect(result.ruleCount).toBeGreaterThan(0);
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+
+    const errorMsg = messages.find((m) => m.level === "error")?.msg;
+    expect(errorMsg).toContain("no-such-rule-xyz");
+    expect(errorMsg).toContain("not registered");
+  });
+
+  it("returns unknownRule=false for a valid rule run", async () => {
+    const { logger } = makeLogger();
+    const result = await runRules({}, logger);
+
+    expect(result.unknownRule).toBe(false);
+    expect(result.ruleCount).toBeGreaterThan(0);
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/scripts/doing-it-wrong.spec.ts
+++ b/scripts/doing-it-wrong.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import { runRules } from "./doing-it-wrong";
+import { loadAllRules } from "./rules/index";
 
 function makeLogger() {
   const messages: { level: string; msg: string }[] = [];
@@ -17,11 +18,12 @@ function makeLogger() {
 describe("runRules", () => {
   it("returns unknownRule=true with honest ruleCount for an unknown rule id", async () => {
     const { logger, messages } = makeLogger();
+    const allRules = await loadAllRules();
     const result = await runRules({ ruleId: "no-such-rule-xyz" }, logger);
 
     expect(result.unknownRule).toBe(true);
     expect(result.violations).toEqual([]);
-    expect(result.ruleCount).toBeGreaterThan(0);
+    expect(result.ruleCount).toBe(allRules.length);
     expect(result.durationMs).toBeGreaterThanOrEqual(0);
 
     const errorMsg = messages.find((m) => m.level === "error")?.msg;
@@ -31,7 +33,7 @@ describe("runRules", () => {
 
   it("returns unknownRule=false for a valid rule run", async () => {
     const { logger } = makeLogger();
-    const result = await runRules({}, logger);
+    const result = await runRules({ ruleId: "shell-injection", filter: "scripts/doing-it-wrong.ts" }, logger);
 
     expect(result.unknownRule).toBe(false);
     expect(result.ruleCount).toBeGreaterThan(0);

--- a/scripts/doing-it-wrong.ts
+++ b/scripts/doing-it-wrong.ts
@@ -54,7 +54,13 @@ export async function runRules(
   const rules = opts.ruleId ? allRules.filter((r) => r.id === opts.ruleId) : allRules;
   if (opts.ruleId && rules.length === 0) {
     logger.error(`rule '${opts.ruleId}' not registered. known: ${allRules.map((r) => r.id).join(", ")}`);
-    return { violations: [], malformedTodos: [], unknownRule: true, ruleCount: 0, durationMs: 0 };
+    return {
+      violations: [],
+      malformedTodos: [],
+      unknownRule: true,
+      ruleCount: allRules.length,
+      durationMs: Date.now() - t0,
+    };
   }
 
   const files = await loadFiles({ repoRoot: REPO_ROOT, filter: opts.filter });


### PR DESCRIPTION
## Summary
- When `doing-it-wrong --rule <unknown-id>` is passed, the early-return path now reports the actual `ruleCount` (number of rules loaded) and `durationMs` (real wall time) instead of the misleading `0` / `0ms`
- The error message and exit code 1 were already in place — this fixes only the dishonest summary line ("checked 0 rules in 0ms" → "checked 19 rules in 38ms")
- Added `scripts/doing-it-wrong.spec.ts` covering both the unknown-rule and valid-rule paths

## Test plan
- [x] `bun test scripts/doing-it-wrong.spec.ts` — 2 tests pass
- [x] `bun scripts/doing-it-wrong.ts --rule bogus-rule-id` — now prints honest "checked 19 rules in 38ms" with the error message
- [x] `bun run am-i-done --pre-commit` — all static checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)