### PR TITLE
fix(rules): recognize toStrictEqual in test-unguarded-narrowing (fixes #2335)

### DIFF
--- a/scripts/rules/fixtures/test-unguarded-narrowing__strict-equal.fixture.ts
+++ b/scripts/rules/fixtures/test-unguarded-narrowing__strict-equal.fixture.ts
@@ -1,0 +1,29 @@
+/**
+ * @rule test-unguarded-narrowing
+ * @expect 0
+ * @path packages/daemon/src/example.spec.ts
+ *
+ * Discriminant asserted with toStrictEqual before narrowing — correct pattern.
+ */
+
+import { expect, it } from "bun:test";
+
+interface OkResult {
+  kind: "ok";
+  value: number;
+}
+interface ErrResult {
+  kind: "error";
+  message: string;
+}
+type Result = OkResult | ErrResult;
+
+declare function getResult(): Result;
+
+it("asserts discriminant with toStrictEqual before narrowing", () => {
+  const result = getResult();
+  expect(result.kind).toStrictEqual("ok");
+  if (result.kind === "ok") {
+    expect(result.value).toBe(42);
+  }
+});

--- a/scripts/rules/test-unguarded-narrowing.rule.ts
+++ b/scripts/rules/test-unguarded-narrowing.rule.ts
@@ -55,7 +55,7 @@ function isDiscAssertCall(
   // expect(obj.disc).toBe(lit) or .toEqual(lit)
   if (!ts.isPropertyAccessExpression(call.expression)) return false;
   const method = call.expression.name.text;
-  if (method !== "toBe" && method !== "toEqual") return false;
+  if (method !== "toBe" && method !== "toEqual" && method !== "toStrictEqual") return false;
 
   const receiver = call.expression.expression;
   if (!ts.isCallExpression(receiver)) return false;

--- a/scripts/rules/test-unguarded-narrowing.rule.ts
+++ b/scripts/rules/test-unguarded-narrowing.rule.ts
@@ -52,7 +52,7 @@ function isDiscAssertCall(
   litVal: string,
   sf: ts.SourceFile,
 ): boolean {
-  // expect(obj.disc).toBe(lit) or .toEqual(lit)
+  // expect(obj.disc).toBe(lit), .toEqual(lit), or .toStrictEqual(lit)
   if (!ts.isPropertyAccessExpression(call.expression)) return false;
   const method = call.expression.name.text;
   if (method !== "toBe" && method !== "toEqual" && method !== "toStrictEqual") return false;


### PR DESCRIPTION
## Summary
- Add `toStrictEqual` to the `isDiscAssertCall` method whitelist in `test-unguarded-narrowing.rule.ts`, alongside `toBe` and `toEqual`
- Add fixture `test-unguarded-narrowing__strict-equal.fixture.ts` (`@expect 0`) confirming `toStrictEqual` discriminant assertions are recognized as valid
- No newly-surfaced violations found (no existing `toStrictEqual` usage in test files)

## Test plan
- [x] `bun run doing-it-wrong` passes (19 rules, 0 violations)
- [x] New fixture validates `toStrictEqual` is accepted as a discriminant assertion
- [x] Pre-commit hook ran full static gate (typecheck, lint, rules, phase-drift) — all passed
- [x] `bun test scripts/` — 392 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)