### PR TITLE
chore(rules): update rule docs, fix fixture comment, repoint orphaned suppressions (fixes #2340, fixes #2341)

### DIFF
--- a/packages/clone/src/providers/resilient-caller.ts
+++ b/packages/clone/src/providers/resilient-caller.ts
@@ -86,7 +86,7 @@ export function friendlyMessage(err: VfsError, context?: string): string {
       return `Network error${ctx}. Check your connection and that the MCP server is running:\n  mcx status`;
     case "not_found":
       // Preserve diagnostic content (e.g. alias discovery details) when present
-      // dotw-todo no-error-message-sniffing: add typed DiagnosticError with structured content field — fix in #2264
+      // dotw-todo no-error-message-sniffing: add typed DiagnosticError with structured content field — fix in #2354
       if (err.message.includes("Tried aliases") || err.message.includes("mcx ls")) {
         return err.message;
       }

--- a/packages/command/src/commands/mail-wait.ts
+++ b/packages/command/src/commands/mail-wait.ts
@@ -15,7 +15,7 @@ function isTransientError(err: unknown): boolean {
   // so do NOT replace this loop with getErrorCode(). The right fix is to patch the
   // IPC transport to always emit a structured code field, then delete the loop.
   for (const c of TRANSIENT_ERROR_CODES) {
-    // dotw-todo no-error-message-sniffing: patch IPC transport to surface structured codes on all paths — fix in #2264
+    // dotw-todo no-error-message-sniffing: patch IPC transport to surface structured codes on all paths — fix in #2354
     if (err.message.includes(c)) return true;
   }
   return false;

--- a/packages/control/src/hooks/use-plans.ts
+++ b/packages/control/src/hooks/use-plans.ts
@@ -42,7 +42,7 @@ async function fetchClaudePlans(
     return JSON.parse(text) as Plan[];
   } catch (err) {
     // _claude server not available is expected — only log unexpected errors
-    // dotw-todo no-error-message-sniffing: replace with typed NotFoundError instanceof check — fix in #2264
+    // dotw-todo no-error-message-sniffing: replace with typed NotFoundError instanceof check — fix in #2354
     if (!(err instanceof Error && err.message.includes("not found"))) {
       console.error("[use-plans] fetchClaudePlans failed:", err);
     }

--- a/packages/core/src/subprocess.spec.ts
+++ b/packages/core/src/subprocess.spec.ts
@@ -100,6 +100,12 @@ describe("spawnCaptureSync", () => {
     expect(r.timedOut).toBe(false);
   });
 
+  it("passes input to stdin", () => {
+    const r = spawnCaptureSync("cat", [], { input: "piped-sync-data" });
+    expect(r.ok).toBe(true);
+    expect(r.stdout).toBe("piped-sync-data");
+  });
+
   it("respects cwd option", () => {
     const r = spawnCaptureSync("pwd", [], { cwd: "/tmp" });
     expect(r.ok).toBe(true);

--- a/packages/daemon/src/github/graphql-client.ts
+++ b/packages/daemon/src/github/graphql-client.ts
@@ -254,7 +254,13 @@ export function clearTokenCache(): void {
 async function execGhAuthToken(): Promise<string> {
   const result = await spawnCapture("gh", ["auth", "token"]);
   if (!result.ok) {
-    const exitInfo = result.exitCode === null ? "binary not found" : `exit ${result.exitCode}`;
+    const exitInfo = result.timedOut
+      ? "timed out"
+      : result.signal
+        ? `signal ${result.signal}`
+        : result.exitCode === null
+          ? "binary not found"
+          : `exit ${result.exitCode}`;
     throw new Error(`gh auth token failed (${exitInfo}): ${result.stderr.trim()}`);
   }
   return result.stdout.trim();

--- a/packages/daemon/src/github/graphql-client.ts
+++ b/packages/daemon/src/github/graphql-client.ts
@@ -254,7 +254,8 @@ export function clearTokenCache(): void {
 async function execGhAuthToken(): Promise<string> {
   const result = await spawnCapture("gh", ["auth", "token"]);
   if (!result.ok) {
-    throw new Error(`gh auth token failed (exit ${result.exitCode}): ${result.stderr.trim()}`);
+    const exitInfo = result.exitCode === null ? "binary not found" : `exit ${result.exitCode}`;
+    throw new Error(`gh auth token failed (${exitInfo}): ${result.stderr.trim()}`);
   }
   return result.stdout.trim();
 }

--- a/scripts/rules/fixtures/no-error-message-sniffing__clean.fixture.ts
+++ b/scripts/rules/fixtures/no-error-message-sniffing__clean.fixture.ts
@@ -55,8 +55,6 @@ export function valueNotCondition(err: unknown): void {
 }
 
 export function assignedInArrow(errors: Error[]): string[] {
-  // .message.includes inside an arrow function body used as a filter predicate.
-  // The predicate is an arrow function argument, not a bare control-flow condition.
-  // This fires in practice and is flagged — but pure "store then use" is clean.
+  // .message access inside a .map() callback — read for display, not a control-flow condition.
   return errors.filter((e) => e instanceof TimeoutError).map((e) => e.message);
 }

--- a/scripts/rules/no-error-message-sniffing.rule.ts
+++ b/scripts/rules/no-error-message-sniffing.rule.ts
@@ -2,8 +2,9 @@
  * Rule: no-error-message-sniffing
  *
  * Flags `.message.startsWith(...)` / `.message.includes(...)` /
- * `.message.match(...)` when the call result directly drives control flow
- * (used as the condition of an `if`, `while`, `? :`, or `switch`).
+ * `.message.match(...)` / `.message.matchAll(...)` when the call result
+ * directly drives control flow (used as the condition of an `if`, `for`,
+ * `while`, `? :`, or `switch`).
  *
  * Why: error message text is prose, not a stable contract. The moment a
  * message is reworded the branch silently stops firing. The alternative is


### PR DESCRIPTION
## Summary
- Update `no-error-message-sniffing` rule header comment to mention `matchAll` and `for`-condition scanning
- Fix misleading `assignedInArrow` clean fixture comment (described `.message.includes` but code uses `.map`)
- Repoint 3 orphaned `dotw-todo` suppressions from closed #2264 → fresh #2354
- Improve `graphql-client.ts` `execGhAuthToken` error message when `exitCode === null` (binary not found)
- Add `spawnCaptureSync` stdin input test

Closes #2340, #2341

## Test plan
- [x] `bun run am-i-done` passes (exit code 0 for static gate; 2 pre-existing failures in full suite unrelated to this PR: Ink Yoga init, core.bare worktree timeout)
- [x] `bun run doing-it-wrong` clean (0 violations)
- [x] `subprocess.spec.ts` — 16/16 pass (new input test included)
- [x] `graphql-client.spec.ts` — 50/50 pass
- [x] All 3 `dotw-todo` comments now reference open #2354

🤖 Generated with [Claude Code](https://claude.com/claude-code)