### PR TITLE
fix(rules): harden rule-loader robustness (#2285)

### DIFF
--- a/scripts/rules/_engine/rule-loader.spec.ts
+++ b/scripts/rules/_engine/rule-loader.spec.ts
@@ -173,14 +173,20 @@ describe("loadAllRules", () => {
     }
   });
 
-  it("returns frozen rule objects", async () => {
+  it("returns deeply frozen rule objects", async () => {
     const tmp = await mkdtemp(join(tmpdir(), "rule-loader-"));
     try {
-      await writeFile(join(tmp, "frz.rule.ts"), VALID_RULE.replace('"test"', '"frz"'));
+      await writeFile(
+        join(tmp, "frz.rule.ts"),
+        `export default { id: "frz", kind: "pattern", scold: "bad", guidance: ["fix it"], pattern: /x/, except: ["ok"] };`,
+      );
       const rules = await loadAllRules(tmp);
       expect(rules.length).toBe(1);
-      expect(Object.isFrozen(rules[0])).toBe(true);
       expect(Object.isFrozen(rules)).toBe(true);
+      expect(Object.isFrozen(rules[0])).toBe(true);
+      expect(Object.isFrozen(rules[0].guidance)).toBe(true);
+      const pr = rules[0] as { except?: readonly string[] };
+      expect(Object.isFrozen(pr.except)).toBe(true);
     } finally {
       await rm(tmp, { recursive: true });
     }

--- a/scripts/rules/_engine/rule-loader.spec.ts
+++ b/scripts/rules/_engine/rule-loader.spec.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 
 import { loadAllRules } from "./rule-loader";
+
+const VALID_RULE = `export default { id: "test", kind: "pattern", scold: "bad", guidance: ["fix it"], pattern: /x/ };`;
 
 describe("loadAllRules", () => {
   it("loads rules from the default directory", async () => {
@@ -61,7 +63,7 @@ describe("loadAllRules", () => {
         join(tmp, "bad.rule.ts"),
         `export default { id: "bad", kind: "pattern", scold: "x", guidance: [] };`,
       );
-      await expect(loadAllRules(tmp)).rejects.toThrow(/missing a 'pattern' RegExp/);
+      await expect(loadAllRules(tmp)).rejects.toThrow(/failed validation/);
     } finally {
       await rm(tmp, { recursive: true });
     }
@@ -74,7 +76,7 @@ describe("loadAllRules", () => {
         join(tmp, "bad.rule.ts"),
         `export default { id: "bad", kind: "check", scold: "x", guidance: [] };`,
       );
-      await expect(loadAllRules(tmp)).rejects.toThrow(/missing a 'check' function/);
+      await expect(loadAllRules(tmp)).rejects.toThrow(/failed validation/);
     } finally {
       await rm(tmp, { recursive: true });
     }
@@ -87,7 +89,7 @@ describe("loadAllRules", () => {
         join(tmp, "bad.rule.ts"),
         `export default { id: "bad", kind: "banana", scold: "x", guidance: [] };`,
       );
-      await expect(loadAllRules(tmp)).rejects.toThrow(/unknown kind 'banana'/);
+      await expect(loadAllRules(tmp)).rejects.toThrow(/failed validation/);
     } finally {
       await rm(tmp, { recursive: true });
     }
@@ -98,6 +100,87 @@ describe("loadAllRules", () => {
     try {
       const rules = await loadAllRules(tmp);
       expect(rules).toEqual([]);
+    } finally {
+      await rm(tmp, { recursive: true });
+    }
+  });
+
+  it("loads rules from nested subdirectories", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "rule-loader-"));
+    try {
+      await writeFile(join(tmp, "top.rule.ts"), VALID_RULE.replace('"test"', '"top"'));
+      const sub = join(tmp, "subdir");
+      await mkdir(sub, { recursive: true });
+      await writeFile(join(sub, "nested.rule.ts"), VALID_RULE.replace('"test"', '"nested"'));
+      const rules = await loadAllRules(tmp);
+      const ids = rules.map((r) => r.id);
+      expect(ids).toContain("top");
+      expect(ids).toContain("nested");
+    } finally {
+      await rm(tmp, { recursive: true });
+    }
+  });
+
+  it("loads .rule.tsx files", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "rule-loader-"));
+    try {
+      await writeFile(
+        join(tmp, "tsx-rule.rule.tsx"),
+        `export default { id: "tsx-rule", kind: "pattern", scold: "bad", guidance: ["fix"], pattern: /x/ };`,
+      );
+      const rules = await loadAllRules(tmp);
+      expect(rules.map((r) => r.id)).toContain("tsx-rule");
+    } finally {
+      await rm(tmp, { recursive: true });
+    }
+  });
+
+  it("rejects a rule missing scold", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "rule-loader-"));
+    try {
+      await writeFile(
+        join(tmp, "bad.rule.ts"),
+        `export default { id: "bad", kind: "pattern", guidance: [], pattern: /x/ };`,
+      );
+      await expect(loadAllRules(tmp)).rejects.toThrow(/failed validation/);
+    } finally {
+      await rm(tmp, { recursive: true });
+    }
+  });
+
+  it("rejects a rule missing guidance", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "rule-loader-"));
+    try {
+      await writeFile(
+        join(tmp, "bad.rule.ts"),
+        `export default { id: "bad", kind: "pattern", scold: "x", pattern: /x/ };`,
+      );
+      await expect(loadAllRules(tmp)).rejects.toThrow(/failed validation/);
+    } finally {
+      await rm(tmp, { recursive: true });
+    }
+  });
+
+  it("resolves a relative rulesDir to absolute before importing", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "rule-loader-"));
+    try {
+      await writeFile(join(tmp, "rel.rule.ts"), VALID_RULE.replace('"test"', '"rel"'));
+      const relPath = relative(process.cwd(), tmp);
+      const rules = await loadAllRules(relPath);
+      expect(rules.map((r) => r.id)).toContain("rel");
+    } finally {
+      await rm(tmp, { recursive: true });
+    }
+  });
+
+  it("returns frozen rule objects", async () => {
+    const tmp = await mkdtemp(join(tmpdir(), "rule-loader-"));
+    try {
+      await writeFile(join(tmp, "frz.rule.ts"), VALID_RULE.replace('"test"', '"frz"'));
+      const rules = await loadAllRules(tmp);
+      expect(rules.length).toBe(1);
+      expect(Object.isFrozen(rules[0])).toBe(true);
+      expect(Object.isFrozen(rules)).toBe(true);
     } finally {
       await rm(tmp, { recursive: true });
     }

--- a/scripts/rules/_engine/rule-loader.ts
+++ b/scripts/rules/_engine/rule-loader.ts
@@ -2,7 +2,7 @@ import { resolve } from "node:path";
 import { Glob } from "bun";
 import { z } from "zod";
 
-import type { Rule } from "./rule";
+import type { PatternRule, Rule } from "./rule";
 
 const RULES_DIR = resolve(import.meta.dir, "..");
 
@@ -41,6 +41,14 @@ function validateRule(rel: string, rule: unknown): asserts rule is Rule {
   }
 }
 
+function deepFreezeRule(rule: Rule): Rule {
+  Object.freeze(rule.guidance);
+  if (rule.kind === "pattern" && (rule as PatternRule).except) {
+    Object.freeze((rule as PatternRule).except);
+  }
+  return Object.freeze(rule);
+}
+
 export async function loadAllRules(rulesDir: string = RULES_DIR): Promise<readonly Rule[]> {
   const absRulesDir = resolve(rulesDir);
   const glob = new Glob("**/*.rule.{ts,tsx}");
@@ -51,7 +59,7 @@ export async function loadAllRules(rulesDir: string = RULES_DIR): Promise<readon
     const mod: unknown = await import(absPath);
     const rule = (mod as { default?: unknown }).default;
     validateRule(rel, rule);
-    entries.push({ rule: Object.freeze({ ...rule } as Rule), file: rel });
+    entries.push({ rule: deepFreezeRule({ ...rule } as Rule), file: rel });
   }
 
   entries.sort((a, b) => a.rule.id.localeCompare(b.rule.id));

--- a/scripts/rules/_engine/rule-loader.ts
+++ b/scripts/rules/_engine/rule-loader.ts
@@ -1,38 +1,57 @@
-import { join } from "node:path";
+import { resolve } from "node:path";
 import { Glob } from "bun";
+import { z } from "zod";
 
 import type { Rule } from "./rule";
 
-const RULES_DIR = join(import.meta.dir, "..");
+const RULES_DIR = resolve(import.meta.dir, "..");
+
+const PatternRuleSchema = z.object({
+  id: z.string().min(1),
+  kind: z.literal("pattern"),
+  pattern: z.instanceof(RegExp),
+  scold: z.string().min(1),
+  guidance: z.array(z.string()),
+  documentation: z.string().optional(),
+  appliesToTests: z.boolean().optional(),
+  except: z.array(z.string()).optional(),
+});
+
+const CheckRuleSchema = z.object({
+  id: z.string().min(1),
+  kind: z.literal("check"),
+  check: z.custom<(ctx: unknown) => void>((v) => typeof v === "function", "expected a function"),
+  scold: z.string().min(1),
+  guidance: z.array(z.string()),
+  documentation: z.string().optional(),
+  appliesToTests: z.boolean().optional(),
+});
+
+const RuleSchema = z.discriminatedUnion("kind", [PatternRuleSchema, CheckRuleSchema]);
 
 function validateRule(rel: string, rule: unknown): asserts rule is Rule {
   if (!rule || typeof rule !== "object" || !("id" in rule) || !("kind" in rule)) {
     throw new Error(`${rel}: default export is not a Rule (missing id/kind)`);
   }
-  const r = rule as Record<string, unknown>;
-  if (r.kind === "pattern") {
-    if (!(r.pattern instanceof RegExp)) {
-      throw new Error(`${rel}: pattern rule '${r.id}' is missing a 'pattern' RegExp`);
-    }
-  } else if (r.kind === "check") {
-    if (typeof r.check !== "function") {
-      throw new Error(`${rel}: check rule '${r.id}' is missing a 'check' function`);
-    }
-  } else {
-    throw new Error(`${rel}: rule '${r.id}' has unknown kind '${r.kind}' (expected 'pattern' or 'check')`);
+  const result = RuleSchema.safeParse(rule);
+  if (!result.success) {
+    const r = rule as Record<string, unknown>;
+    const issues = result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; ");
+    throw new Error(`${rel}: rule '${r.id}' failed validation: ${issues}`);
   }
 }
 
 export async function loadAllRules(rulesDir: string = RULES_DIR): Promise<readonly Rule[]> {
-  const glob = new Glob("*.rule.ts");
+  const absRulesDir = resolve(rulesDir);
+  const glob = new Glob("**/*.rule.{ts,tsx}");
   const entries: { rule: Rule; file: string }[] = [];
 
-  for await (const rel of glob.scan({ cwd: rulesDir, absolute: false })) {
-    const absPath = join(rulesDir, rel);
+  for await (const rel of glob.scan({ cwd: absRulesDir, absolute: false })) {
+    const absPath = resolve(absRulesDir, rel);
     const mod: unknown = await import(absPath);
     const rule = (mod as { default?: unknown }).default;
     validateRule(rel, rule);
-    entries.push({ rule, file: rel });
+    entries.push({ rule: Object.freeze({ ...rule } as Rule), file: rel });
   }
 
   entries.sort((a, b) => a.rule.id.localeCompare(b.rule.id));
@@ -46,5 +65,5 @@ export async function loadAllRules(rulesDir: string = RULES_DIR): Promise<readon
     seen.set(rule.id, file);
   }
 
-  return entries.map((e) => e.rule);
+  return Object.freeze(entries.map((e) => e.rule)) as readonly Rule[];
 }


### PR DESCRIPTION
## Summary
- **Recurse glob** (`**/*.rule.{ts,tsx}`) so nested subdirectory rules and `.rule.tsx` files are discovered (#2285, #2286)
- **Full zod validation** of the Rule shape at load time — catches missing `scold`, `guidance`, bad types before runtime (#2287)
- **`resolve()` instead of `join()`** so relative `rulesDir` paths produce absolute import paths (#2288)
- **`Object.freeze`** on each rule and the returned array to prevent cross-caller mutation via import cache (#2290)

Closes #2285, #2286, #2287, #2288, #2290

## Test plan
- [x] New test: nested subdirectory rule loads correctly
- [x] New test: `.rule.tsx` file loads correctly
- [x] New test: rule missing `scold` rejected at load time
- [x] New test: rule missing `guidance` rejected at load time
- [x] New test: relative `rulesDir` path resolves correctly
- [x] New test: returned rules and array are `Object.isFrozen`
- [x] Existing tests updated for new error messages (zod validation)
- [x] `bun run doing-it-wrong` loads all 19 rules, zero violations
- [x] `bun run am-i-done --pre-commit` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)