### PR TITLE
fix(scripts): prepend bun install to am-i-done steps (fixes #2355)

### DIFF
--- a/scripts/am-i-done.ts
+++ b/scripts/am-i-done.ts
@@ -37,6 +37,13 @@ const REPO_ROOT = resolve(fileURLToPath(import.meta.url), "../..");
 // scripts (`bun scripts/check-*.ts`, etc.) are wrapped as string
 // commands. The rule engine runs in-process via doingItWrongStep.
 
+const INSTALL: Step = {
+  name: "install",
+  description: "bun install --frozen-lockfile (no-op when deps are current)",
+  command: "bun install --frozen-lockfile",
+  onFailure: ["lockfile may be out of date — run `bun install` manually and commit bun.lock"],
+};
+
 const TYPECHECK: Step = {
   name: "typecheck",
   description: "tsc --noEmit across all packages",
@@ -116,8 +123,19 @@ const COVERAGE: Step = {
 // Pre-push / default: comprehensive. Includes the full test suite and
 //   coverage ratchet. This is what CI also runs.
 
-const PRE_COMMIT: Step[] = [TYPECHECK, LINT_CHECK, ARGS_BOUNDS, TIMEOUTS, TEARDOWN, PHASE_DRIFT, RULES];
-const COMPREHENSIVE: Step[] = [TYPECHECK, LINT, ARGS_BOUNDS, TIMEOUTS, TEARDOWN, PHASE_DRIFT, RULES, TEST, COVERAGE];
+const PRE_COMMIT: Step[] = [INSTALL, TYPECHECK, LINT_CHECK, ARGS_BOUNDS, TIMEOUTS, TEARDOWN, PHASE_DRIFT, RULES];
+const COMPREHENSIVE: Step[] = [
+  INSTALL,
+  TYPECHECK,
+  LINT,
+  ARGS_BOUNDS,
+  TIMEOUTS,
+  TEARDOWN,
+  PHASE_DRIFT,
+  RULES,
+  TEST,
+  COVERAGE,
+];
 
 function selectSteps(): { steps: Step[]; label: string } {
   if (isPreCommit) return { steps: PRE_COMMIT, label: "pre-commit" };


### PR DESCRIPTION
Closes #2355

## Summary
- Adds a `bun install --frozen-lockfile` step as the **first step** of both `PRE_COMMIT` and `COMPREHENSIVE` step lists in `scripts/am-i-done.ts`
- Silent-first like all other steps — output is captured and only surfaced on failure
- Fast no-op (~128ms) when deps are already installed; prevents phantom failures in fresh worktrees where `node_modules` doesn't exist

## Test plan
- [x] Verified install step passes in a fresh worktree (128ms, no-op after first install)
- [x] All 8 static steps pass: install, typecheck, lint, args-bounds, test-timeouts, session-teardown, phase-drift, doing-it-wrong
- [x] Pre-commit hook passes clean
- [x] `--pre-commit` mode includes the install step (8 steps total)
- [x] `--comprehensive` mode includes the install step (10 steps total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)