### PR TITLE
fix(rules): poll-until-headroom false negative + false positive (fixes #2292, fixes #2293)

### DIFF
--- a/scripts/rules/fixtures/poll-until-headroom__clean.fixture.ts
+++ b/scripts/rules/fixtures/poll-until-headroom__clean.fixture.ts
@@ -40,3 +40,8 @@ await pollUntil(
 
 // 10s deadline under the 30s file-level setDefaultTimeout — clean (has headroom)
 await pollUntil(() => events.some((e) => e.type === "ready"), 10_000);
+
+// commented-out calls are dead code — not violations (#2293)
+// await pollUntil(condition);
+// await pollUntil(condition, 10_000); — old approach
+// pollUntil(fn) — waits for the condition

--- a/scripts/rules/fixtures/poll-until-headroom__flagged.fixture.ts
+++ b/scripts/rules/fixtures/poll-until-headroom__flagged.fixture.ts
@@ -1,6 +1,6 @@
 /**
  * @rule poll-until-headroom
- * @expect 4
+ * @expect 5
  * @path packages/daemon/src/ipc-server.spec.ts
  *
  * An explicit deadline ≥ the 5000ms watchdog can never fire its own error —
@@ -25,4 +25,10 @@ await pollUntil(() => !condition(), 10_000);
 await pollUntil(
   () => events.some((e) => e.type === "session:init"),
   6000,
+);
+
+// inline comment after timeout — still a violation (#2292)
+await pollUntil(
+  () => condition(),
+  10_000 // needs time for daemon startup
 );

--- a/scripts/rules/poll-until-headroom.rule.ts
+++ b/scripts/rules/poll-until-headroom.rule.ts
@@ -132,6 +132,11 @@ const rule: CheckRule = {
       const pollIdx = line.indexOf("pollUntil(");
       if (pollIdx === -1) continue;
 
+      // Skip commented-out calls: if "//" appears before pollUntil on the line,
+      // the call is dead code — not a live violation (#2293).
+      const commentStart = line.indexOf("//");
+      if (commentStart !== -1 && commentStart < pollIdx) continue;
+
       // parenOffset points to the '(' of the call
       const parenOffset = pollIdx + "pollUntil".length;
       const callText = collectCall(lines, i, parenOffset);
@@ -150,7 +155,9 @@ const rule: CheckRule = {
       // (intervalMs) doesn't defeat the numeric parse.
       const rest = inner.slice(commaIdx + 1);
       const nextComma = firstTopLevelComma(rest);
-      const secondArg = (nextComma === -1 ? rest : rest.slice(0, nextComma)).trim();
+      const secondArgRaw = (nextComma === -1 ? rest : rest.slice(0, nextComma)).trim();
+      // Strip inline comments so `10_000 // daemon startup` parses as 10000 (#2292).
+      const secondArg = secondArgRaw.replace(/\s*\/\/.*$/, "");
       const num = parseNumericLiteral(secondArg);
       if (num !== null && num >= watchdog) {
         violated(i + 1, pollIdx + 1, line.trim());


### PR DESCRIPTION
Closes #2292, #2293

## Summary
- **#2292 false negative**: Strip trailing `// …` inline comments from the timeout argument before numeric parsing, so `pollUntil(fn, 10_000 // reason)` is correctly flagged instead of silently dropped
- **#2293 false positive**: Skip lines where `//` precedes the `pollUntil(` match, so commented-out dead code (`// await pollUntil(condition)`) is not reported as a violation
- Added fixture cases for both scenarios (clean: 3 commented-out lines; flagged: 1 inline-comment case)

## Test plan
- [x] `bun run doing-it-wrong` — 0 violations, all 92 fixture tests pass
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun test` (non-control) — 6535 pass, 0 fail
- [x] Pre-commit hook passed (`am-i-done --pre-commit`)
- [x] Verified clean fixture: commented-out `pollUntil` calls produce `@expect 0`
- [x] Verified flagged fixture: inline-comment case produces expected violation (`@expect 5`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)