### PR TITLE
fix(rules): make appliesToTests:true skip non-test files in engine (fixes #2337)

### DIFF
--- a/scripts/rules/_engine/rule.spec.ts
+++ b/scripts/rules/_engine/rule.spec.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "bun:test";
+
+import type { FileMeta } from "./file-loader";
+import type { CheckRule, PatternRule } from "./rule";
+import { evaluateRule } from "./rule";
+
+function makeFile(overrides: Partial<FileMeta> = {}): FileMeta {
+  return {
+    path: "/fake/example.ts",
+    relPath: "packages/daemon/src/example.ts",
+    content: "const x = 1;\n",
+    pkg: "packages/daemon",
+    isTest: false,
+    ...overrides,
+  };
+}
+
+const emptyFiles = new Map<string, FileMeta>();
+
+describe("evaluateRule appliesToTests filtering", () => {
+  const checkRule: CheckRule = {
+    id: "test-rule",
+    kind: "check",
+    scold: "test",
+    guidance: [],
+    check({ file, violated }) {
+      violated(1, 1, file.content.split("\n")[0]);
+    },
+  };
+
+  const patternRule: PatternRule = {
+    id: "test-pattern",
+    kind: "pattern",
+    scold: "test",
+    guidance: [],
+    pattern: /const/,
+  };
+
+  describe("appliesToTests omitted (default — runs on all files)", () => {
+    it("runs on production files", () => {
+      const v = evaluateRule(checkRule, makeFile({ isTest: false }), emptyFiles);
+      expect(v).toHaveLength(1);
+    });
+
+    it("runs on test files", () => {
+      const v = evaluateRule(checkRule, makeFile({ isTest: true }), emptyFiles);
+      expect(v).toHaveLength(1);
+    });
+  });
+
+  describe("appliesToTests: false (production-only)", () => {
+    const prodOnly: CheckRule = { ...checkRule, appliesToTests: false };
+
+    it("runs on production files", () => {
+      const v = evaluateRule(prodOnly, makeFile({ isTest: false }), emptyFiles);
+      expect(v).toHaveLength(1);
+    });
+
+    it("skips test files", () => {
+      const v = evaluateRule(prodOnly, makeFile({ isTest: true }), emptyFiles);
+      expect(v).toHaveLength(0);
+    });
+  });
+
+  describe("appliesToTests: true (test-only)", () => {
+    const testOnly: CheckRule = { ...checkRule, appliesToTests: true };
+    const testOnlyPattern: PatternRule = { ...patternRule, appliesToTests: true };
+
+    it("skips production files (check rule)", () => {
+      const v = evaluateRule(testOnly, makeFile({ isTest: false }), emptyFiles);
+      expect(v).toHaveLength(0);
+    });
+
+    it("runs on test files (check rule)", () => {
+      const v = evaluateRule(testOnly, makeFile({ isTest: true }), emptyFiles);
+      expect(v).toHaveLength(1);
+    });
+
+    it("skips production files (pattern rule)", () => {
+      const v = evaluateRule(testOnlyPattern, makeFile({ isTest: false }), emptyFiles);
+      expect(v).toHaveLength(0);
+    });
+
+    it("runs on test files (pattern rule)", () => {
+      const v = evaluateRule(testOnlyPattern, makeFile({ isTest: true }), emptyFiles);
+      expect(v).toHaveLength(1);
+    });
+  });
+});

--- a/scripts/rules/_engine/rule.ts
+++ b/scripts/rules/_engine/rule.ts
@@ -45,7 +45,12 @@ interface RuleBase {
   guidance: string[];
   /** Optional pointer to CLAUDE.md anchor, issue, or PR. */
   documentation?: string;
-  /** When false, .spec.ts / .test.ts files are skipped for this rule. Default true. */
+  /**
+   * Controls whether the engine runs this rule against test files.
+   * - `false` → skip .spec.ts / .test.ts files (rule only runs on production code).
+   * - `true`  → skip non-test files (rule only runs on test code).
+   * - omitted → run on all files (default).
+   */
   appliesToTests?: boolean;
 }
 
@@ -78,6 +83,7 @@ export interface Violation {
  */
 export function evaluateRule(rule: Rule, file: FileMeta, files: Map<string, FileMeta>): Omit<Violation, "rule">[] {
   if (rule.appliesToTests === false && file.isTest) return [];
+  if (rule.appliesToTests === true && !file.isTest) return [];
 
   const collected: Omit<Violation, "rule">[] = [];
   const violated: Violated = (line, column, snippet) => {

--- a/scripts/rules/no-hardcoded-test-port.rule.ts
+++ b/scripts/rules/no-hardcoded-test-port.rule.ts
@@ -45,8 +45,6 @@ const rule: CheckRule = {
   ],
   documentation: "#2272",
   check({ file, violated, ast }) {
-    if (!file.isTest) return;
-
     // Pattern 1: `port: <nonzero>` as a direct property of an object literal
     // passed to a known server-construction call/constructor.
     // Excludes: mock structs, return objects, assertion arguments.

--- a/scripts/rules/no-js-extension-local-import.rule.ts
+++ b/scripts/rules/no-js-extension-local-import.rule.ts
@@ -26,7 +26,6 @@ const rule: CheckRule = {
     "exception: imports with 'with { type: ... }' (asset/text imports) are intentionally exempt",
   ],
   documentation: "#2173",
-  appliesToTests: true,
   check({ file, violated }) {
     const inScope = file.relPath.startsWith("packages/") || file.relPath.startsWith(".claude/phases/");
     if (!inScope) return;

--- a/scripts/rules/poll-until-headroom.rule.ts
+++ b/scripts/rules/poll-until-headroom.rule.ts
@@ -121,9 +121,8 @@ const rule: CheckRule = {
     "cross-reference test/CLAUDE.md flaky-prevention patterns",
   ],
   documentation: "#2248",
+  appliesToTests: true,
   check({ file, violated }) {
-    if (!file.isTest) return;
-
     const watchdog = effectiveWatchdog(file.content);
     const lines = file.content.split("\n");
 

--- a/scripts/rules/spawn-mock-kill-resolves-exited.rule.ts
+++ b/scripts/rules/spawn-mock-kill-resolves-exited.rule.ts
@@ -64,8 +64,6 @@ const rule: CheckRule = {
   documentation: "#2249",
   appliesToTests: true,
   check({ file, ast, violated }) {
-    if (!file.isTest) return;
-
     const { sourceFile } = ast;
     const lines = sourceFile.text.split("\n");
 

--- a/scripts/rules/test-empty-catch.rule.ts
+++ b/scripts/rules/test-empty-catch.rule.ts
@@ -39,8 +39,6 @@ const rule: CheckRule = {
   documentation: "#2247",
   appliesToTests: true,
   check({ file, violated, ast }) {
-    if (!file.isTest) return;
-
     const sf = ast.sourceFile;
     const catchClauses = ast.find(ts.isCatchClause);
 

--- a/scripts/rules/test-filtered-assertion.rule.ts
+++ b/scripts/rules/test-filtered-assertion.rule.ts
@@ -54,8 +54,6 @@ const rule: CheckRule = {
   documentation: "#2247",
   appliesToTests: true,
   check({ file, ast, violated }) {
-    if (!file.isTest) return;
-
     const lines = file.content.split("\n");
 
     for (const call of ast.callsTo("toHaveLength").concat(ast.callsTo("toEqual"))) {

--- a/scripts/rules/test-trivial-bound.rule.ts
+++ b/scripts/rules/test-trivial-bound.rule.ts
@@ -25,8 +25,6 @@ const rule: CheckRule = {
   documentation: "#2247",
   appliesToTests: true,
   check({ file, violated }) {
-    if (!file.isTest) return;
-
     const lines = file.content.split("\n");
     for (const [i, line] of lines.entries()) {
       const m = TRIVIAL_UPPER.exec(line);

--- a/scripts/rules/test-unguarded-narrowing.rule.ts
+++ b/scripts/rules/test-unguarded-narrowing.rule.ts
@@ -83,8 +83,6 @@ const rule: CheckRule = {
   documentation: "#2247",
   appliesToTests: true,
   check({ file, violated, ast }) {
-    if (!file.isTest) return;
-
     const sf = ast.sourceFile;
     const ifStmts = ast.find(ts.isIfStatement);
 


### PR DESCRIPTION
## Summary
- Engine now handles `appliesToTests: true` symmetrically with `false`: when set to `true`, non-test files are skipped before `check()` is called, making test-only rules declarative instead of requiring a per-rule `if (!file.isTest) return` guard.
- Removed the redundant `if (!file.isTest) return` guard from 7 test-only rules: `test-trivial-bound`, `test-filtered-assertion`, `test-empty-catch`, `test-unguarded-narrowing`, `no-hardcoded-test-port`, `spawn-mock-kill-resolves-exited`, `poll-until-headroom`.
- Removed incorrect `appliesToTests: true` from `no-js-extension-local-import` (it runs on all files, not just tests). Added missing `appliesToTests: true` to `poll-until-headroom`.

## Test plan
- [x] New `rule.spec.ts` with 8 tests covering all three `appliesToTests` states (omitted/true/false) for both check and pattern rules
- [x] All 57 fixture tests pass (validates no behavioral regression in rule scoping)
- [x] `bun typecheck` clean
- [x] `bun lint` clean
- [x] `bun run doing-it-wrong` clean (0 violations)
- [x] Pre-commit hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)