### PR TITLE
fix(rules): rewrite spawn-mock-kill-resolves-exited as AST rule to eliminate cross-object FPs (fixes #2284)

### DIFF
--- a/packages/daemon/src/claude-session-worker.spec.ts
+++ b/packages/daemon/src/claude-session-worker.spec.ts
@@ -196,12 +196,10 @@ describe("handlePrompt: auto-revive disconnected session (#1765)", () => {
   });
 
   test("returns error when disconnected session has no claudeSessionId", async () => {
-    const noopSpawn: SpawnFn = (_cmd) => ({
-      pid: 1,
-      exited: new Promise<number>(() => {}),
-      kill: () => {},
-      stderr: null,
-    });
+    const noopSpawn: SpawnFn = (_cmd) => {
+      const { promise: exited, resolve } = Promise.withResolvers<number>();
+      return { pid: 1, exited, kill: () => resolve(0), stderr: null };
+    };
     server = new ClaudeWsServer({ spawn: noopSpawn, logger: silentLogger });
     await server.start();
 

--- a/scripts/rules/fixtures/spawn-mock-kill-resolves-exited__cross-object-clean.fixture.ts
+++ b/scripts/rules/fixtures/spawn-mock-kill-resolves-exited__cross-object-clean.fixture.ts
@@ -1,0 +1,30 @@
+/**
+ * @rule spawn-mock-kill-resolves-exited
+ * @expect 0
+ * @path packages/daemon/src/multi-object.spec.ts
+ *
+ * Two separate objects within proximity — one has a never-resolving exited,
+ * the other has a no-op kill. Because they are distinct object literals the
+ * rule must NOT fire (fixes #2284).
+ */
+
+import { describe, it } from "bun:test";
+
+describe("cross-object — no false positive", () => {
+  it("separate objects are fine", () => {
+    // Object A — intentional, unrelated to proc lifecycle
+    const testTimer = {
+      exited: new Promise(() => {}),
+      label: "timer",
+    };
+
+    // Object B — completely separate
+    const mockHandler = {
+      kill: () => {},
+      name: "handler",
+    };
+
+    void testTimer;
+    void mockHandler;
+  });
+});

--- a/scripts/rules/spawn-mock-kill-resolves-exited.rule.ts
+++ b/scripts/rules/spawn-mock-kill-resolves-exited.rule.ts
@@ -9,22 +9,48 @@
  * `exited`, teardown blocks for the full SIGTERM→SIGKILL escalation window
  * (~5–7 s) or until the Bun hook timeout — every test in the suite pays it.
  *
- * The `new Promise(() => {})` + no-op `kill` co-occurrence is unambiguous and
- * only meaningful in test files, so this rule is scoped to *.spec.ts / *.test.ts.
+ * Uses the TypeScript AST so that only object literals containing BOTH
+ * properties are flagged — two separate objects within proximity don't
+ * false-positive (see #2284).
  */
+
+import ts from "typescript";
 
 import type { CheckRule } from "./_engine/rule";
 
-// Matches: exited: new Promise(() => {}) or exited: new Promise(() => undefined)
-const NEVER_RESOLVING_EXITED = /exited\s*:\s*new\s+Promise\s*\(\s*\(\s*\)\s*=>\s*(?:\{\s*\}|undefined)\s*\)/;
+/**
+ * True when a PropertyAssignment's initializer is `new Promise(() => {})` or
+ * `new Promise(() => undefined)` — i.e. a promise that never resolves.
+ */
+function isNeverResolvingPromise(init: ts.Expression): boolean {
+  if (!ts.isNewExpression(init)) return false;
+  if (!ts.isIdentifier(init.expression) || init.expression.text !== "Promise") return false;
+  const args = init.arguments;
+  if (!args || args.length !== 1) return false;
+  const arg = args[0];
+  if (!ts.isArrowFunction(arg)) return false;
+  if (arg.parameters.length !== 0) return false;
+  const body = arg.body;
+  if (ts.isBlock(body)) {
+    return body.statements.length === 0;
+  }
+  // () => undefined
+  return ts.isIdentifier(body) && body.text === "undefined";
+}
 
-// Matches: kill: () => {} or kill: () => undefined (no-op variants)
-const NOOP_KILL = /kill\s*:\s*\(\s*\)\s*=>\s*(?:\{\s*\}|undefined)/;
-
-// Number of lines either side to search for the kill co-occurrence.
-// Large enough for any realistic object literal, small enough to avoid
-// cross-object false positives.
-const WINDOW = 20;
+/**
+ * True when a PropertyAssignment's initializer is `() => {}` or
+ * `() => undefined` — i.e. a no-op arrow function.
+ */
+function isNoopArrow(init: ts.Expression): boolean {
+  if (!ts.isArrowFunction(init)) return false;
+  if (init.parameters.length !== 0) return false;
+  const body = init.body;
+  if (ts.isBlock(body)) {
+    return body.statements.length === 0;
+  }
+  return ts.isIdentifier(body) && body.text === "undefined";
+}
 
 const rule: CheckRule = {
   id: "spawn-mock-kill-resolves-exited",
@@ -37,19 +63,31 @@ const rule: CheckRule = {
   ],
   documentation: "#2249",
   appliesToTests: true,
-  check({ file, violated }) {
+  check({ file, ast, violated }) {
     if (!file.isTest) return;
 
-    const lines = file.content.split("\n");
-    for (const [i, line] of lines.entries()) {
-      if (!NEVER_RESOLVING_EXITED.test(line)) continue;
-      const start = Math.max(0, i - WINDOW);
-      const end = Math.min(lines.length - 1, i + WINDOW);
-      for (let j = start; j <= end; j++) {
-        if (NOOP_KILL.test(lines[j] ?? "")) {
-          violated(i + 1, 1, line.trim());
-          break;
+    const { sourceFile } = ast;
+    const lines = sourceFile.text.split("\n");
+
+    for (const obj of ast.find(ts.isObjectLiteralExpression)) {
+      let exitedProp: ts.PropertyAssignment | undefined;
+      let hasNoopKill = false;
+
+      for (const prop of obj.properties) {
+        if (!ts.isPropertyAssignment(prop)) continue;
+        const name = prop.name;
+        if (!ts.isIdentifier(name)) continue;
+
+        if (name.text === "exited" && isNeverResolvingPromise(prop.initializer)) {
+          exitedProp = prop;
+        } else if (name.text === "kill" && isNoopArrow(prop.initializer)) {
+          hasNoopKill = true;
         }
+      }
+
+      if (exitedProp && hasNoopKill) {
+        const { line, column } = ast.positionOf(exitedProp);
+        violated(line, column, (lines[line - 1] ?? "").trim());
       }
     }
   },


### PR DESCRIPTION
## Summary
- Rewrites `spawn-mock-kill-resolves-exited` from a ±20-line regex window to a TypeScript AST check that only flags when both `exited: new Promise(() => {})` and `kill: () => {}` properties belong to the **same** `ObjectLiteralExpression` node
- Adds a `__cross-object-clean` fixture proving two separate objects within proximity don't false-positive
- Fixes a previously-undetected true positive in `claude-session-worker.spec.ts` (the typed `new Promise<number>(() => {})` variant the old regex missed)

## Test plan
- [x] Existing `__flagged` fixture still fires (1 violation)
- [x] Existing `__clean` fixture stays clean (0 violations)
- [x] New `__cross-object-clean` fixture passes (0 violations — the FP case from #2284)
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun run doing-it-wrong` — 0 violations
- [x] `bun test` — 7941 pass, 0 fail
- [x] Pre-commit hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)