### PR TITLE
fix(rules): callsTo() matches element-access calls + drop fragile parseDiagnostics assertion (fixes #2300)

### DIFF
--- a/scripts/rules/_engine/ast.spec.ts
+++ b/scripts/rules/_engine/ast.spec.ts
@@ -70,6 +70,30 @@ describe("callsTo()", () => {
     expect(ast.callsTo("doElse").length).toBe(1);
   });
 
+  it('finds element-access calls like obj["name"]()', () => {
+    const ast = createAstHelper(
+      makeMeta(`
+      obj["doIt"]();
+      obj["doIt"](1, 2);
+      obj["other"]();
+      obj.doIt();
+    `),
+    );
+    expect(ast.callsTo("doIt").length).toBe(3);
+    expect(ast.callsTo("other").length).toBe(1);
+  });
+
+  it("ignores element-access with non-string-literal keys", () => {
+    const ast = createAstHelper(
+      makeMeta(`
+      const key = "foo";
+      obj[key]();
+      obj[42]();
+    `),
+    );
+    expect(ast.callsTo("foo")).toEqual([]);
+  });
+
   it("returns empty for no matches", () => {
     const ast = createAstHelper(makeMeta("const x = 1;"));
     expect(ast.callsTo("nonexistent")).toEqual([]);
@@ -126,7 +150,7 @@ describe("parent pointers", () => {
 });
 
 describe("ScriptKind selection", () => {
-  it("parses TSX content without errors when path ends in .tsx", () => {
+  it("parses TSX content as JSX when path ends in .tsx", () => {
     const ast = createAstHelper(
       makeMeta(
         `
@@ -135,11 +159,14 @@ describe("ScriptKind selection", () => {
         "/fake/component.tsx",
       ),
     );
-    expect(ast.sourceFile.parseDiagnostics.length).toBe(0);
+    const jsxElements = ast.findByKind(ts.SyntaxKind.JsxElement);
+    expect(jsxElements.length).toBeGreaterThan(0);
   });
 
   it("parses plain .ts with generics correctly", () => {
     const ast = createAstHelper(makeMeta("const fn = <T,>(x: T): T => x;"));
-    expect(ast.sourceFile.parseDiagnostics.length).toBe(0);
+    const arrowFns = ast.find(ts.isArrowFunction);
+    expect(arrowFns.length).toBe(1);
+    expect(arrowFns[0].typeParameters?.length).toBe(1);
   });
 });

--- a/scripts/rules/_engine/ast.ts
+++ b/scripts/rules/_engine/ast.ts
@@ -11,7 +11,7 @@ export interface AstHelper {
   /** Walk all descendants, collecting nodes with the given SyntaxKind. */
   findByKind(kind: ts.SyntaxKind): ts.Node[];
 
-  /** Find CallExpression nodes where the callee identifier matches `name`. */
+  /** Find CallExpression nodes where the callee matches `name` — covers `name()`, `obj.name()`, and `obj["name"]()`. */
   callsTo(name: string): ts.CallExpression[];
 
   /** Convert a node's start position to 1-indexed { line, column }. */
@@ -74,6 +74,12 @@ export function createAstHelper(file: FileMeta): AstHelper {
         if (ts.isIdentifier(expr) && expr.text === name) {
           results.push(n);
         } else if (ts.isPropertyAccessExpression(expr) && expr.name.text === name) {
+          results.push(n);
+        } else if (
+          ts.isElementAccessExpression(expr) &&
+          ts.isStringLiteral(expr.argumentExpression) &&
+          expr.argumentExpression.text === name
+        ) {
           results.push(n);
         }
       });


### PR DESCRIPTION
Closes #2300, #2301

## Summary
- `callsTo("name")` now matches `obj["name"]()` via `ElementAccessExpression` with string-literal argument, closing the false-negative gap for bracket-style method calls
- Replaced `parseDiagnostics` (internal TypeScript API) assertions in ScriptKind tests with structural AST checks — JSX element presence for .tsx, arrow function type-parameter count for .ts generics
- Updated `callsTo()` JSDoc to document all three matching patterns

## Test plan
- [x] New test: element-access calls `obj["doIt"]()` matched alongside `obj.doIt()`
- [x] New test: non-string-literal element access (`obj[key]()`, `obj[42]()`) correctly ignored
- [x] Existing `callsTo()` tests (direct calls, property access, no matches) still pass
- [x] ScriptKind tests rewritten to assert structural properties instead of internal API
- [x] `bun typecheck` clean
- [x] `bun lint` clean
- [x] `bun run doing-it-wrong` clean
- [x] `bun test scripts/rules/_engine/ast.spec.ts` — 16/16 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)