### PR TITLE
fix(rules): convert test-filtered-assertion to AST for multi-line detection (fixes #2336)

### DIFF
--- a/scripts/rules/fixtures/test-filtered-assertion__multiline.fixture.ts
+++ b/scripts/rules/fixtures/test-filtered-assertion__multiline.fixture.ts
@@ -1,0 +1,25 @@
+/**
+ * @rule test-filtered-assertion
+ * @expect 2
+ * @path packages/core/src/example.spec.ts
+ *
+ * Prettier-wrapped multi-line chains must also be flagged.
+ */
+
+import { expect, it } from "bun:test";
+
+declare const warnings: string[];
+
+it("multi-line toHaveLength", () => {
+  expect(
+    warnings.filter((w) => w.includes("deprecated"))
+  ).toHaveLength(0);
+});
+
+it("multi-line toEqual", () => {
+  expect(
+    warnings.filter((w) =>
+      w.startsWith("warn:")
+    )
+  ).toEqual([]);
+});

--- a/scripts/rules/test-filtered-assertion.rule.ts
+++ b/scripts/rules/test-filtered-assertion.rule.ts
@@ -17,10 +17,31 @@
  * Sources: #2085, #2099.
  */
 
+import ts from "typescript";
 import type { CheckRule } from "./_engine/rule";
 
-const FILTERED_EMPTY =
-  /expect\(.+\.filter\s*\(.+\)\s*\)\s*\.\s*(?:toHaveLength\s*\(\s*0\s*\)|toEqual\s*\(\s*\[\s*\]\s*\))/;
+function containsFilterCall(node: ts.Node): boolean {
+  if (
+    ts.isCallExpression(node) &&
+    ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === "filter"
+  ) {
+    return true;
+  }
+  return ts.forEachChild(node, containsFilterCall) ?? false;
+}
+
+function isEmptyAssertion(name: string, args: ts.NodeArray<ts.Expression>): boolean {
+  if (name === "toHaveLength" && args.length === 1) {
+    const arg = args[0];
+    return arg !== undefined && ts.isNumericLiteral(arg) && arg.text === "0";
+  }
+  if (name === "toEqual" && args.length === 1) {
+    const arg = args[0];
+    return arg !== undefined && ts.isArrayLiteralExpression(arg) && arg.elements.length === 0;
+  }
+  return false;
+}
 
 const rule: CheckRule = {
   id: "test-filtered-assertion",
@@ -32,15 +53,40 @@ const rule: CheckRule = {
   ],
   documentation: "#2247",
   appliesToTests: true,
-  check({ file, violated }) {
+  check({ file, ast, violated }) {
     if (!file.isTest) return;
 
     const lines = file.content.split("\n");
-    for (const [i, line] of lines.entries()) {
-      const m = FILTERED_EMPTY.exec(line);
-      if (m) violated(i + 1, (m.index ?? 0) + 1, line.trim());
+
+    for (const call of ast.callsTo("toHaveLength").concat(ast.callsTo("toEqual"))) {
+      if (!ts.isPropertyAccessExpression(call.expression)) continue;
+      if (!isEmptyAssertion(call.expression.name.text, call.arguments)) continue;
+
+      const receiver = call.expression.expression;
+
+      const expectCall = findExpectAncestor(receiver);
+      if (!expectCall) continue;
+      if (expectCall.arguments.length !== 1) continue;
+
+      if (containsFilterCall(expectCall.arguments[0])) {
+        const pos = ast.positionOf(expectCall);
+        violated(pos.line, pos.column, lines[pos.line - 1]?.trim() ?? "");
+      }
     }
   },
 };
+
+function findExpectAncestor(node: ts.Node): ts.CallExpression | undefined {
+  if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === "expect") {
+    return node;
+  }
+  if (ts.isPropertyAccessExpression(node)) {
+    return findExpectAncestor(node.expression);
+  }
+  if (ts.isCallExpression(node)) {
+    return findExpectAncestor(node.expression);
+  }
+  return undefined;
+}
 
 export default rule;


### PR DESCRIPTION
## Summary
- Replaced the per-line regex in `test-filtered-assertion` with a TypeScript AST-based check that detects `.filter()` calls inside `expect()` arguments regardless of line-wrapping
- The AST approach walks `toHaveLength(0)` / `toEqual([])` call sites, traverses up to find the enclosing `expect()`, then checks if `.filter()` appears anywhere in its argument subtree
- Added a multi-line fixture (`test-filtered-assertion__multiline.fixture.ts`) with `@expect 2` covering Prettier-wrapped `toHaveLength` and `toEqual` forms
- No new codebase violations surfaced — the existing violations were all the two-statement pattern (`const x = arr.filter(...); expect(x)...`), which is out of scope for this rule

## Test plan
- [x] All 58 rule fixtures pass (including the new multi-line fixture)
- [x] `bun run doing-it-wrong` exits 0 (no false positives)
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` — 7941 pass, 0 fail
- [x] Pre-commit hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)