### PR TITLE
fix(daemon): migrate 25 setTimeout/setInterval callbacks to safe-timers (fixes #2323)

### DIFF
--- a/packages/daemon/src/abstract-worker-server.ts
+++ b/packages/daemon/src/abstract-worker-server.ts
@@ -12,6 +12,7 @@ import {
   maxAttempts,
   shouldRestart,
 } from "./restart-policy";
+import { safeSetTimeout } from "./safe-timers";
 import { workerPath } from "./worker-path";
 import { WorkerClientTransport } from "./worker-transport";
 
@@ -191,8 +192,7 @@ export abstract class AbstractWorkerServer {
         this.worker = null;
         return true;
       };
-      // dotw-todo timer-callback-error-boundary: block-body in Promise constructor; cleanup()/reject may throw — fix in #2323
-      const timeout = setTimeout(() => {
+      const timeout = safeSetTimeout(() => {
         if (cleanup()) reject(new Error(`${d.displayName} session worker startup timeout`));
       }, 10_000);
       worker.onmessage = (event: MessageEvent) => {
@@ -227,8 +227,7 @@ export abstract class AbstractWorkerServer {
           return r;
         }),
         new Promise<never>((_, reject) => {
-          // dotw-todo timer-callback-error-boundary: block-body in Promise constructor; metrics.counter/reject may throw — fix in #2323
-          handshakeTimer = setTimeout(() => {
+          handshakeTimer = safeSetTimeout(() => {
             if (connectResolved) return;
             this.metrics.counter("mcpd_connect_timeouts_total").inc();
             reject(new Error(`MCP handshake timeout (${this.handshakeTimeoutMs / 1000}s)`));

--- a/packages/daemon/src/acp-session-worker.ts
+++ b/packages/daemon/src/acp-session-worker.ts
@@ -18,6 +18,7 @@ import { ACP_SERVER_NAME, type AgentSessionEvent, DEFAULT_TIMEOUT_MS } from "@mc
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { ACP_TOOLS } from "./acp-session/tools";
+import { safeSetTimeout } from "./safe-timers";
 import { createIsControlMessage } from "./worker-control-message";
 import { WorkerServerTransport } from "./worker-transport";
 
@@ -383,8 +384,7 @@ async function handleWait(args: Record<string, unknown>): Promise<{
     }
 
     const entry = await new Promise<BufferedEvent>((resolve, reject) => {
-      // dotw-todo timer-callback-error-boundary: block-body in Promise constructor; findIndex/splice/map may throw — fix in #2323
-      const timer = setTimeout(() => {
+      const timer = safeSetTimeout(() => {
         const idx = afterSeqWaiters.findIndex((w) => w.resolve === resolve);
         if (idx !== -1) afterSeqWaiters.splice(idx, 1);
         const list = [...sessions.values()].map((s) => s.getInfo());

--- a/packages/daemon/src/auth/callback-server.ts
+++ b/packages/daemon/src/auth/callback-server.ts
@@ -5,6 +5,8 @@
  * from the OAuth redirect, then auto-stops.
  */
 
+import { safeSetTimeout } from "../safe-timers";
+
 export interface CallbackServer {
   /** The full callback URL (http://localhost:{port}/callback) */
   url: string;
@@ -69,8 +71,7 @@ export function startCallbackServer(preferredPort?: number): CallbackServer {
         if (code) {
           resolveCode(code);
           // Auto-stop after brief delay to ensure response is sent
-          // dotw-todo timer-callback-error-boundary: block-body with if-guard; server.stop may throw — fix in #2323
-          setTimeout(() => {
+          safeSetTimeout(() => {
             if (!stopped) {
               stopped = true;
               server.stop(true);
@@ -95,8 +96,7 @@ export function startCallbackServer(preferredPort?: number): CallbackServer {
   const url = `http://localhost:${port}/callback`;
 
   // Timeout: reject if no callback within 2 minutes
-  // dotw-todo timer-callback-error-boundary: block-body with if-guard; server.stop/rejectCode may throw — fix in #2323
-  const timeout = setTimeout(() => {
+  const timeout = safeSetTimeout(() => {
     if (!stopped) {
       stopped = true;
       server.stop(true);

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -54,7 +54,7 @@ import {
 } from "@mcp-cli/core";
 import type { ServerWebSocket } from "bun";
 import { killPid } from "../process-util";
-import { safeSetTimeout } from "../safe-timers";
+import { safeSetInterval, safeSetTimeout } from "../safe-timers";
 import { ContainmentGuard } from "./containment";
 import type { NdjsonMessage } from "./ndjson";
 import { keepAlive, parseFrame, permissionAllow, permissionDeny, setModelRequest, userMessage } from "./ndjson";
@@ -866,8 +866,7 @@ export class ClaudeWsServer {
     // from being stuck in "connecting" forever when the Claude CLI fails to establish
     // a WebSocket connection (e.g., race after daemon auto-start, #837).
     if (session.connectTimer) clearTimeout(session.connectTimer);
-    // dotw-todo timer-callback-error-boundary: multi-statement connect-timeout callback with state transitions — fix in #2323
-    session.connectTimer = setTimeout(() => {
+    session.connectTimer = safeSetTimeout(() => {
       session.connectTimer = null;
       // Only act if still in connecting state with no WS
       if (session.ws !== null || session.state.state !== "connecting") return;
@@ -1621,8 +1620,7 @@ export class ClaudeWsServer {
     }
 
     // Start keep-alive
-    // dotw-todo timer-callback-error-boundary: if-guard wrapping try, not a single-try block — fix in #2323
-    session.keepAliveTimer = setInterval(() => {
+    session.keepAliveTimer = safeSetInterval(() => {
       if (session.ws?.readyState === WS_OPEN) {
         try {
           session.ws.send(keepAlive());

--- a/packages/daemon/src/codex-session-worker.ts
+++ b/packages/daemon/src/codex-session-worker.ts
@@ -23,6 +23,7 @@ import { type AgentSessionEvent, CODEX_SERVER_NAME, DEFAULT_TIMEOUT_MS } from "@
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { CODEX_TOOLS } from "./codex-session/tools";
+import { safeSetTimeout } from "./safe-timers";
 import { createIsControlMessage } from "./worker-control-message";
 import { WorkerServerTransport } from "./worker-transport";
 
@@ -394,8 +395,7 @@ async function handleWait(args: Record<string, unknown>): Promise<{
 
     // No buffered events — block until one arrives
     const entry = await new Promise<BufferedEvent>((resolve, reject) => {
-      // dotw-todo timer-callback-error-boundary: block-body in Promise constructor; findIndex/splice/map may throw — fix in #2323
-      const timer = setTimeout(() => {
+      const timer = safeSetTimeout(() => {
         const idx = afterSeqWaiters.findIndex((w) => w.resolve === resolve);
         if (idx !== -1) afterSeqWaiters.splice(idx, 1);
         // On timeout, return current session list as fallback

--- a/packages/daemon/src/config/watcher.ts
+++ b/packages/daemon/src/config/watcher.ts
@@ -9,7 +9,7 @@ import { type FSWatcher, existsSync, statSync, watch } from "node:fs";
 import { basename, dirname } from "node:path";
 import type { Logger, ResolvedConfig, ResolvedServer } from "@mcp-cli/core";
 import { consoleLogger, options, projectConfigPath } from "@mcp-cli/core";
-import { safeSetInterval } from "../safe-timers";
+import { safeSetInterval, safeSetTimeout } from "../safe-timers";
 import { configHash, loadConfig as defaultLoadConfig } from "./loader";
 
 const DEBOUNCE_MS = 300;
@@ -210,8 +210,7 @@ export class ConfigWatcher {
       clearTimeout(this.debounceTimer);
       this.debounceTimer = null;
     }
-    // dotw-todo timer-callback-error-boundary: multi-statement debounce; reload() is async-without-await — fix in #2323
-    this.debounceTimer = setTimeout(() => {
+    this.debounceTimer = safeSetTimeout(() => {
       this.debounceTimer = null;
       if (this.stopped) return;
       this.reload();

--- a/packages/daemon/src/derived-events.ts
+++ b/packages/daemon/src/derived-events.ts
@@ -6,6 +6,7 @@ import type { DerivedRule } from "./derived-rules";
 import type { EventBus } from "./event-bus";
 import type { EventLog } from "./event-log";
 import { metrics } from "./metrics";
+import { safeSetTimeout } from "./safe-timers";
 
 // Causal chain length beyond which derived events are dropped to prevent infinite loops.
 const MAX_DERIVED_DEPTH = 4;
@@ -140,8 +141,7 @@ export class DerivedEventPublisher {
     }
 
     const delay = this._retryBaseMs * 2 ** attempt;
-    // dotw-todo timer-callback-error-boundary: setup statements before try/catch; pendingTimers.delete may throw — fix in #2323
-    const timer = setTimeout(() => {
+    const timer = safeSetTimeout(() => {
       this.pendingTimers.delete(timer);
       if (this.disposed) return;
 

--- a/packages/daemon/src/event-stream.ts
+++ b/packages/daemon/src/event-stream.ts
@@ -13,6 +13,7 @@ import type { EventBus } from "./event-bus";
 import type { EventLog } from "./event-log";
 import { buildEventFilter } from "./ipc-filter";
 import { metrics } from "./metrics";
+import { safeSetInterval } from "./safe-timers";
 import type { ServerPool } from "./server-pool";
 
 export class EventStreamServer {
@@ -472,8 +473,7 @@ export class EventStreamServer {
               }
             }
 
-            // dotw-todo timer-callback-error-boundary: try+2 extra statements outside try; bus.touch/pruneStale may throw — fix in #2323
-            heartbeatTimer = setInterval(() => {
+            heartbeatTimer = safeSetInterval(() => {
               try {
                 controller.enqueue(encoder.encode("\n"));
               } catch {
@@ -638,8 +638,7 @@ export class EventStreamServer {
         // threshold, not 2× (which happens when an event lands 1ms after a timer
         // fire and the next check is a full interval away — see #1528).
         const heartbeatPollMs = Math.ceil(this.heartbeatIntervalMs / 6);
-        // dotw-todo timer-callback-error-boundary: if-guard wrapping try is not a single top-level try — fix in #2323
-        heartbeatTimer = setInterval(() => {
+        heartbeatTimer = safeSetInterval(() => {
           if (Date.now() - lastWriteTime >= this.heartbeatIntervalMs) {
             const hb = `${JSON.stringify({ category: "heartbeat", event: "heartbeat", seq: this.eventSeq, src: "daemon", ts: new Date().toISOString() })}\n`;
             try {

--- a/packages/daemon/src/github/copilot-poller.ts
+++ b/packages/daemon/src/github/copilot-poller.ts
@@ -24,6 +24,7 @@ import type { WorkItem } from "@mcp-cli/core";
 import type { MonitorEventInput } from "@mcp-cli/core";
 import type { StateDb } from "../db/state";
 import type { WorkItemDb } from "../db/work-items";
+import { safeSetTimeout } from "../safe-timers";
 import type { RepoInfo } from "./graphql-client";
 import { clearTokenCache, detectRepo, getGhToken } from "./graphql-client";
 
@@ -184,8 +185,7 @@ export class CopilotPoller {
 
   private scheduleNext(delayMs: number): void {
     if (this.stopped) return;
-    // dotw-todo timer-callback-error-boundary: async poll chain, poll() rejection propagates unhandled — fix in #2323
-    this.timer = setTimeout(async () => {
+    this.timer = safeSetTimeout(async () => {
       await this.poll();
       this.scheduleNext(this.currentIntervalMs);
     }, delayMs);

--- a/packages/daemon/src/github/work-item-poller.ts
+++ b/packages/daemon/src/github/work-item-poller.ts
@@ -13,6 +13,7 @@ import type { Logger, WorkItemEvent } from "@mcp-cli/core";
 import { computeSrcChurn, consoleLogger } from "@mcp-cli/core";
 import type { CiStatus, PrState, ReviewStatus, WorkItem, WorkItemPatch } from "@mcp-cli/core";
 import type { WorkItemDb } from "../db/work-items";
+import { safeSetTimeout } from "../safe-timers";
 import { type MergeStatePR, computeCascadeHead } from "./cascade-head";
 import { type CiEvent, type CiRunState, computeCiTransitions } from "./ci-events";
 import { type FetchPRsOptions, type PRStatus, type RepoInfo, detectRepo, fetchTrackedPRs } from "./graphql-client";
@@ -114,8 +115,7 @@ export class WorkItemPoller {
 
   private scheduleNext(delayMs: number): void {
     if (this.stopped) return;
-    // dotw-todo timer-callback-error-boundary: async poll chain, poll() rejection propagates unhandled — fix in #2323
-    this.timer = setTimeout(async () => {
+    this.timer = safeSetTimeout(async () => {
       await this.poll();
       this.scheduleNext(this.currentIntervalMs);
     }, delayMs);

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -96,6 +96,7 @@ import { MonitorRuntime } from "./monitor-runtime";
 import { OpenCodeServer, buildOpenCodeToolCache } from "./opencode-server";
 import { reapOrphanedSessions } from "./orphan-reaper";
 import { QuotaPoller } from "./quota";
+import { safeSetInterval, safeSetTimeout } from "./safe-timers";
 import { ServerPool } from "./server-pool";
 import { SessionMetricsAggregator } from "./session-metrics";
 import { SiteServer, buildSiteToolCache } from "./site-server";
@@ -584,8 +585,7 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
   // This ensures dead sessions are cleaned up promptly, not just at idle-timeout boundary.
   // Also sweep core.bare so external flips (e.g. from `gh pr merge`) self-heal
   // within 30s regardless of origin. See #1330.
-  // dotw-todo timer-callback-error-boundary: multi-call block, any pruneDeadSessions/sweepCoreBare may throw — fix in #2323
-  const pruneInterval = setInterval(() => {
+  const pruneInterval = safeSetInterval(() => {
     claudeServer.pruneDeadSessions();
     codexServer?.pruneDeadSessions();
     acpServer?.pruneDeadSessions();
@@ -595,8 +595,7 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
   }, 30_000);
 
   // Update uptime and server gauges periodically
-  // dotw-todo timer-callback-error-boundary: multi-statement metrics block — fix in #2323
-  const metricsInterval = setInterval(() => {
+  const metricsInterval = safeSetInterval(() => {
     uptimeGauge.set(Math.round(process.uptime()));
     const servers = pool.listServers();
     serversTotal.set(servers.length);
@@ -617,8 +616,7 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
     if (idleTimer) clearTimeout(idleTimer);
     idleTimerScheduledAt = performance.now();
     const scheduledAt = idleTimerScheduledAt;
-    // dotw-todo timer-callback-error-boundary: complex idle-timer block with many calls — fix in #2323
-    idleTimer = setTimeout(() => {
+    idleTimer = safeSetTimeout(() => {
       const firedAt = performance.now();
       const actualDelayMs = Math.round(firedAt - scheduledAt);
       const driftMs = actualDelayMs - idleTimeoutMs;

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -361,8 +361,7 @@ export class IpcServer {
   }
 
   private startDrainTimeout(): void {
-    // dotw-todo timer-callback-error-boundary: multi-statement block with logger+onShutdown calls — fix in #2323
-    this.drainTimer = setTimeout(() => {
+    this.drainTimer = safeSetTimeout(() => {
       if (!this.shutdownScheduled) {
         this.logger.warn(
           `[ipc] Drain timeout (${this.drainTimeoutMs}ms) — forcing shutdown with ${this.inflightCount} request(s) still in-flight`,

--- a/packages/daemon/src/mock-server.ts
+++ b/packages/daemon/src/mock-server.ts
@@ -16,6 +16,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { closeClientWithTimeout } from "./close-timeout";
 import type { StateDb } from "./db/state";
 import { MOCK_TOOLS } from "./mock-session/tools";
+import { safeSetTimeout } from "./safe-timers";
 import { workerPath } from "./worker-path";
 import { WorkerClientTransport } from "./worker-transport";
 
@@ -132,8 +133,7 @@ export class MockServer {
         this.worker = null;
         return true;
       };
-      // dotw-todo timer-callback-error-boundary: block-body in Promise constructor; cleanup()/reject may throw — fix in #2323
-      const timeout = setTimeout(() => {
+      const timeout = safeSetTimeout(() => {
         if (cleanup()) reject(new Error("Mock session worker startup timeout"));
       }, 10_000);
       worker.onmessage = (event: MessageEvent) => {
@@ -167,8 +167,7 @@ export class MockServer {
           return r;
         }),
         new Promise<never>((_, reject) => {
-          // dotw-todo timer-callback-error-boundary: block-body in Promise constructor; reject may be stale — fix in #2323
-          handshakeTimer = setTimeout(() => {
+          handshakeTimer = safeSetTimeout(() => {
             if (connectResolved) return;
             reject(new Error("MCP handshake timeout (10s)"));
           }, this.handshakeTimeoutMs);

--- a/packages/daemon/src/mock-session-worker.ts
+++ b/packages/daemon/src/mock-session-worker.ts
@@ -19,6 +19,7 @@ import { type AgentSessionEvent, DEFAULT_TIMEOUT_MS, MOCK_SERVER_NAME } from "@m
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { MOCK_TOOLS } from "./mock-session/tools";
+import { safeSetTimeout } from "./safe-timers";
 import { createIsControlMessage } from "./worker-control-message";
 import { WorkerServerTransport } from "./worker-transport";
 
@@ -393,8 +394,7 @@ async function handleWait(args: Record<string, unknown>): Promise<ToolResult> {
     }
 
     const entry = await new Promise<BufferedEvent>((res, reject) => {
-      // dotw-todo timer-callback-error-boundary: block-body in Promise constructor; findIndex/splice/map may throw — fix in #2323
-      const timer = setTimeout(() => {
+      const timer = safeSetTimeout(() => {
         const idx = afterSeqWaiters.findIndex((w) => w.resolve === res);
         if (idx !== -1) afterSeqWaiters.splice(idx, 1);
         const list = [...sessions.values()].map((s) => ({ sessionId: s.sessionId, state: s.state }));

--- a/packages/daemon/src/monitor-runtime.ts
+++ b/packages/daemon/src/monitor-runtime.ts
@@ -14,6 +14,7 @@ import type { AliasType, Logger, MonitorCategory, MonitorEventInput } from "@mcp
 import { bundleAlias } from "@mcp-cli/core";
 import type { Subprocess } from "bun";
 import type { EventBus } from "./event-bus";
+import { safeSetTimeout } from "./safe-timers";
 import { workerPath } from "./worker-path";
 
 export const MONITOR_RESTART_POLICY = {
@@ -339,8 +340,7 @@ export class MonitorRuntime {
         `[monitor-runtime] "${mon.name}" crashed (exit ${code}), restarting in ${delay}ms (attempt ${mon.attempt})`,
       );
 
-      // dotw-todo timer-callback-error-boundary: complex async restart callback, spawnMonitor may throw — fix in #2323
-      mon.restartTimer = setTimeout(async () => {
+      mon.restartTimer = safeSetTimeout(async () => {
         if (mon.stopped || this.stopped) return;
 
         const preservedAttempt = mon.attempt;

--- a/packages/daemon/src/opencode-session-worker.ts
+++ b/packages/daemon/src/opencode-session-worker.ts
@@ -18,6 +18,7 @@ import { OpenCodeSession, type OpenCodeSessionConfig } from "@mcp-cli/opencode";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { OPENCODE_TOOLS } from "./opencode-session/tools";
+import { safeSetTimeout } from "./safe-timers";
 import { createIsControlMessage } from "./worker-control-message";
 import { WorkerServerTransport } from "./worker-transport";
 
@@ -386,8 +387,7 @@ async function handleWait(args: Record<string, unknown>): Promise<{
     }
 
     const entry = await new Promise<BufferedEvent>((resolve, reject) => {
-      // dotw-todo timer-callback-error-boundary: block-body in Promise constructor; findIndex/splice/map may throw — fix in #2323
-      const timer = setTimeout(() => {
+      const timer = safeSetTimeout(() => {
         const idx = afterSeqWaiters.findIndex((w) => w.resolve === resolve);
         if (idx !== -1) afterSeqWaiters.splice(idx, 1);
         const list = [...sessions.values()].map((s) => s.getInfo());

--- a/packages/daemon/src/site-server.ts
+++ b/packages/daemon/src/site-server.ts
@@ -18,6 +18,7 @@ import {
   maxAttempts,
   shouldRestart,
 } from "./restart-policy";
+import { safeSetTimeout } from "./safe-timers";
 import { SITE_TOOLS } from "./site/tools";
 import { workerPath } from "./worker-path";
 import { WorkerClientTransport } from "./worker-transport";
@@ -103,8 +104,7 @@ export class SiteServer {
         this.worker = null;
         return true;
       };
-      // dotw-todo timer-callback-error-boundary: block-body in Promise constructor; cleanup()/reject may throw — fix in #2323
-      const timeout = setTimeout(() => {
+      const timeout = safeSetTimeout(() => {
         if (cleanup()) reject(new Error(`Site worker startup timeout (${this.handshakeTimeoutMs}ms)`));
       }, this.handshakeTimeoutMs);
 
@@ -138,8 +138,7 @@ export class SiteServer {
           return r;
         }),
         new Promise<never>((_, reject) => {
-          // dotw-todo timer-callback-error-boundary: block-body in Promise constructor; reject may be stale — fix in #2323
-          handshakeTimer = setTimeout(() => {
+          handshakeTimer = safeSetTimeout(() => {
             if (connectResolved) return;
             reject(new Error(`Site MCP handshake timeout (${this.handshakeTimeoutMs}ms)`));
           }, this.handshakeTimeoutMs);


### PR DESCRIPTION
## Summary
- Migrate all 25 remaining `setTimeout`/`setInterval` callsites in `packages/daemon/src/` to `safeSetTimeout`/`safeSetInterval`, routing unhandled timer callback errors to `console.error` instead of crashing the daemon process
- Remove all 25 `// dotw-todo timer-callback-error-boundary` markers across 17 files
- Add/update `safe-timers` imports in all affected files

## Test plan
- [x] Zero `dotw-todo timer-callback-error-boundary` markers remain (`grep` returns 0 matches)
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun run doing-it-wrong` passes (all arch rules clean)
- [x] `bun test` passes (7956 tests, 0 failures)
- [x] Pre-commit hook passes all gates
- [x] `am-i-done --pre-commit` passes (static + coverage)
- [ ] `am-i-done` full: blocked by known Yoga parallel-runner flaky (#2362) — 172 failures all `Cannot access 'Yoga' before initialization`, unrelated to this change

Closes #2323

🤖 Generated with [Claude Code](https://claude.com/claude-code)