### PR TITLE
fix(rules): detect destructuring and inline-chain blind spots in check-tool-result-iserror (fixes #2342)

### DIFF
--- a/scripts/rules/check-tool-result-iserror.rule.ts
+++ b/scripts/rules/check-tool-result-iserror.rule.ts
@@ -56,22 +56,63 @@ function walkSkippingNestedFunctions(node: ts.Node, visit: (n: ts.Node) => void)
   });
 }
 
+function isExpressionWrapper(node: ts.Node): boolean {
+  return (
+    ts.isAwaitExpression(node) ||
+    ts.isParenthesizedExpression(node) ||
+    ts.isAsExpression(node) ||
+    ts.isNonNullExpression(node) ||
+    ts.isTypeAssertionExpression(node) ||
+    ts.isSatisfiesExpression(node)
+  );
+}
+
 function getBindingName(node: ts.Node): string | undefined {
   let current = node.parent;
   while (current) {
     if (ts.isVariableDeclaration(current) && ts.isIdentifier(current.name)) {
       return current.name.text;
     }
-    if (
-      ts.isAwaitExpression(current) ||
-      ts.isParenthesizedExpression(current) ||
-      ts.isAsExpression(current) ||
-      ts.isNonNullExpression(current) ||
-      ts.isTypeAssertionExpression(current) ||
-      ts.isSatisfiesExpression(current)
-    ) {
+    if (isExpressionWrapper(current)) {
       current = current.parent;
       continue;
+    }
+    break;
+  }
+  return undefined;
+}
+
+function getDestructuredContentElement(node: ts.Node): ts.BindingElement | undefined {
+  let current = node.parent;
+  while (current) {
+    if (ts.isVariableDeclaration(current) && ts.isObjectBindingPattern(current.name)) {
+      for (const el of current.name.elements) {
+        const name = el.propertyName ?? el.name;
+        if (ts.isIdentifier(name) && name.text === "content") {
+          return el;
+        }
+      }
+      return undefined;
+    }
+    if (isExpressionWrapper(current)) {
+      current = current.parent;
+      continue;
+    }
+    break;
+  }
+  return undefined;
+}
+
+function getInlineContentAccess(node: ts.Node): ts.PropertyAccessExpression | undefined {
+  let current: ts.Node = node;
+  while (current.parent) {
+    const parent = current.parent;
+    if (isExpressionWrapper(parent)) {
+      current = parent;
+      continue;
+    }
+    if (ts.isPropertyAccessExpression(parent) && parent.name.text === "content" && parent.expression === current) {
+      return parent;
     }
     break;
   }
@@ -151,7 +192,22 @@ const rule: CheckRule = {
 
     for (const call of callToolCalls) {
       const bindingName = getBindingName(call);
-      if (!bindingName) continue;
+      if (!bindingName) {
+        const destructuredEl = getDestructuredContentElement(call);
+        if (destructuredEl) {
+          const pos = ast.positionOf(destructuredEl);
+          const line = lines[pos.line - 1] ?? "";
+          violated(pos.line, pos.column, line.trim());
+          continue;
+        }
+        const inlineAccess = getInlineContentAccess(call);
+        if (inlineAccess) {
+          const pos = ast.positionOf(inlineAccess);
+          const line = lines[pos.line - 1] ?? "";
+          violated(pos.line, pos.column, line.trim());
+        }
+        continue;
+      }
 
       const scope = getEnclosingBlock(call);
       const contentAccesses = findContentAccesses(scope, bindingName);

--- a/scripts/rules/fixtures/check-tool-result-iserror__no-binding.fixture.ts
+++ b/scripts/rules/fixtures/check-tool-result-iserror__no-binding.fixture.ts
@@ -1,32 +1,24 @@
 /**
  * @rule check-tool-result-iserror
- * @expect 0
+ * @expect 2
  * @path packages/daemon/src/example.ts
  *
- * Known blind spots: the rule does NOT flag these patterns because
- * getBindingName() cannot resolve a named Identifier binding:
- *   1. ObjectBindingPattern destructuring — VariableDeclaration.name is not an Identifier
- *   2. Inline property-access chain — PropertyAccessExpression breaks the traversal
- *
- * These patterns ARE unsafe. Always use unwrapToolResult() or
- * unwrapToolResultJson() instead. This fixture pins the boundary so
- * future rule extensions know what gaps remain.
+ * Both patterns are unsafe: .content accessed from a callTool() result
+ * without an isError guard or unwrapToolResult wrapper.
  */
 
-// Blind spot 1: destructuring — getBindingName walks up to VariableDeclaration
-// but the name is ObjectBindingPattern, not Identifier → returns undefined → skipped.
+// Destructuring: content extracted via ObjectBindingPattern without isError check.
 async function destructurePattern(mcp: { callTool: Function }) {
   const { content } = (await mcp.callTool("s", "t", {})) as {
     content: Array<{ type: string; text: string }>;
     isError?: boolean;
   };
-  return content[0].text; // unsafe — not flagged due to destructuring
+  return content[0].text;
 }
 
-// Blind spot 2: inline property-access — callTool result is never bound to
-// a named variable, so there is no binding name to scan for.
+// Inline chain: .content accessed directly on the callTool() result expression.
 async function inlinePattern(mcp: { callTool: Function }) {
   return (
     (await mcp.callTool("s", "t", {})) as { content: Array<{ type: string; text: string }> }
-  ).content[0].text; // unsafe — not flagged due to no binding
+  ).content[0].text;
 }


### PR DESCRIPTION
## Summary
- Adds detection for two blind spots in `check-tool-result-iserror`: destructured `content` from `callTool()` results (ObjectBindingPattern) and inline `.content` property-access chains with no intermediate binding.
- Extracts `isExpressionWrapper()` helper to share the await/as/parens/non-null wrapper walk logic across `getBindingName`, `getDestructuredContentElement`, and `getInlineContentAccess`.
- Updates fixture from `@expect 0` to `@expect 2` — both patterns now flagged.
- No codebase violations surfaced (all `callTool` usage in non-test code already uses `unwrapToolResult`).

Closes #2342

## Test plan
- [x] `bun run doing-it-wrong` passes — fixture expectations match (2 violations detected)
- [x] `bun run am-i-done --pre-commit` passes (typecheck, lint, rules)
- [x] Pre-commit hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)