### PR TITLE
fix(rules): extend no-raw-path-handling to catch variable-bound and Map-key process.cwd() (fixes #2321)

### DIFF
--- a/scripts/rules/fixtures/no-raw-path-handling__clean.fixture.ts
+++ b/scripts/rules/fixtures/no-raw-path-handling__clean.fixture.ts
@@ -31,3 +31,18 @@ if (p.startsWith(`${root}/`)) doSomething();
 // must NOT be flagged (thread #3 false-positive shape)
 if (pathEq(process.cwd(), root) === true) doSomething();
 const same = canonicalCwd() === storedRoot;
+
+// Map lookup with canonicalCwd — correct, not flagged
+cache.get(canonicalCwd());
+cache.set(canonicalCwd(), value);
+
+// Variable bound to canonicalCwd used in comparison — not flagged
+const normalizedDir = canonicalCwd();
+if (normalizedDir === storedRoot) doSomething();
+
+// process.cwd() as fallback default (not a direct const binding) — not flagged
+const cwd = (args.cwd as string) ?? process.cwd();
+
+// const bound to process.cwd() but never compared — not flagged
+const myDir = process.cwd();
+console.log(myDir);

--- a/scripts/rules/fixtures/no-raw-path-handling__flagged.fixture.ts
+++ b/scripts/rules/fixtures/no-raw-path-handling__flagged.fixture.ts
@@ -1,6 +1,6 @@
 /**
  * @rule no-raw-path-handling
- * @expect 3
+ * @expect 6
  * @path packages/daemon/src/example-flagged.ts
  *
  * Raw path handling patterns that should be flagged.
@@ -14,3 +14,11 @@ if (target.startsWith("\\\\")) doSomething();
 
 // process.cwd() in === comparison (daemon scope)
 if (repoRoot === process.cwd()) doSomething();
+
+// Map-like method with raw process.cwd() argument (daemon scope)
+cache.get(process.cwd());
+cache.set(process.cwd(), value);
+
+// Variable-bound process.cwd() in comparison (daemon scope)
+const dir = process.cwd();
+if (dir === repoRoot) doSomething();

--- a/scripts/rules/no-raw-path-handling.rule.ts
+++ b/scripts/rules/no-raw-path-handling.rule.ts
@@ -11,6 +11,14 @@
  * 2. (daemon only) `process.cwd()` compared with `===`/`!==` without
  *    going through `resolveRealpath`/`canonicalCwd` — symlinked CWDs
  *    silently fail the comparison.
+ *
+ * 3. (daemon only) `process.cwd()` passed to Map-like methods (`.get`,
+ *    `.set`, `.has`, `.delete`) — raw CWD as a lookup key silently
+ *    misses under symlinks.
+ *
+ * 4. (daemon only) `const` variable bound to `process.cwd()` then used
+ *    in `===`/`!==` comparison — same bug class as Detection 2 but one
+ *    step removed.
  */
 
 import ts from "typescript";
@@ -18,6 +26,7 @@ import type { CheckRule } from "./_engine/rule";
 
 const SLASH = "/";
 const UNC_PREFIX = "\\\\";
+const MAP_METHODS = new Set(["get", "set", "has", "delete"]);
 
 const rule: CheckRule = {
   id: "no-raw-path-handling",
@@ -27,6 +36,8 @@ const rule: CheckRule = {
     'replace `s.startsWith("/")` with `path.isAbsolute(s)` (handles both Unix and Windows paths)',
     "replace `a === process.cwd()` with `pathEq(a, canonicalCwd())`",
     'import { pathEq, canonicalCwd } from "@mcp-cli/core" for realpath-normalized comparisons',
+    "variable-bound form (`const dir = process.cwd(); dir === x`) is caught — use `canonicalCwd()` at the assignment site",
+    "Map lookups with raw CWD (`cache.get(process.cwd())`) are caught — normalize with `canonicalCwd()` first",
   ],
   documentation: "#2251",
   appliesToTests: false,
@@ -49,15 +60,47 @@ const rule: CheckRule = {
       violated(pos.line, pos.column, (lines[pos.line - 1] ?? "").trim());
     }
 
-    // Detection 2: process.cwd() as direct operand of === / !== (daemon scope only)
+    // Detections 2–4 are daemon-scoped only.
     if (!file.relPath.startsWith("packages/daemon/src/")) return;
 
+    // Detection 2: process.cwd() as direct operand of === / !==
     for (const bin of ast.findByKind(ts.SyntaxKind.BinaryExpression) as ts.BinaryExpression[]) {
       const op = bin.operatorToken.kind;
       if (op !== ts.SyntaxKind.EqualsEqualsEqualsToken && op !== ts.SyntaxKind.ExclamationEqualsEqualsToken) continue;
       if (!isProcessCwd(bin.left) && !isProcessCwd(bin.right)) continue;
       const pos = ast.positionOf(bin);
       violated(pos.line, pos.column, (lines[pos.line - 1] ?? "").trim());
+    }
+
+    // Detection 3: process.cwd() as argument to Map-like method calls
+    for (const call of ast.findByKind(ts.SyntaxKind.CallExpression) as ts.CallExpression[]) {
+      if (!ts.isPropertyAccessExpression(call.expression)) continue;
+      if (!MAP_METHODS.has(call.expression.name.text)) continue;
+      if (!call.arguments.some((arg) => isProcessCwd(arg))) continue;
+      const pos = ast.positionOf(call);
+      violated(pos.line, pos.column, (lines[pos.line - 1] ?? "").trim());
+    }
+
+    // Detection 4: const variable bound to process.cwd(), then used in === / !==
+    const cwdVarNames = new Set<string>();
+    for (const decl of ast.findByKind(ts.SyntaxKind.VariableDeclaration) as ts.VariableDeclaration[]) {
+      if (!decl.initializer || !isProcessCwd(decl.initializer)) continue;
+      if (!ts.isIdentifier(decl.name)) continue;
+      const declList = decl.parent;
+      if (ts.isVariableDeclarationList(declList) && declList.flags & ts.NodeFlags.Const) {
+        cwdVarNames.add(decl.name.text);
+      }
+    }
+    if (cwdVarNames.size > 0) {
+      for (const bin of ast.findByKind(ts.SyntaxKind.BinaryExpression) as ts.BinaryExpression[]) {
+        const op = bin.operatorToken.kind;
+        if (op !== ts.SyntaxKind.EqualsEqualsEqualsToken && op !== ts.SyntaxKind.ExclamationEqualsEqualsToken) continue;
+        const leftMatch = ts.isIdentifier(bin.left) && cwdVarNames.has(bin.left.text);
+        const rightMatch = ts.isIdentifier(bin.right) && cwdVarNames.has(bin.right.text);
+        if (!leftMatch && !rightMatch) continue;
+        const pos = ast.positionOf(bin);
+        violated(pos.line, pos.column, (lines[pos.line - 1] ?? "").trim());
+      }
     }
   },
 };


### PR DESCRIPTION
## Summary
- Adds Detection 3: flags `process.cwd()` passed as argument to Map-like methods (`.get`, `.set`, `.has`, `.delete`) in daemon code — raw CWD as a lookup key silently misses under symlinks
- Adds Detection 4: flags `const` variable bound to `process.cwd()` then used in `===`/`!==` comparison — same bug class as Detection 2 but one step removed (only tracks `const` bindings to avoid reassignment false positives)
- Extends guidance array with notes on both new detections
- No existing violations in daemon code — both detections are future-proofing

Closes #2321

## Test plan
- [x] Extended `__flagged` fixture: 3 new violations (2 Map ops, 1 variable-bound comparison), `@expect` bumped from 3 to 6
- [x] Extended `__clean` fixture: canonicalCwd Map ops, canonicalCwd variable comparison, `??` fallback default, const-without-comparison — all non-triggering
- [x] `bun test scripts/rules/fixtures.spec.ts` — 60 tests pass
- [x] `bun run am-i-done --pre-commit` — all checks pass (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)