### PR TITLE
feat(rules): add derive-union-from-const rule (fixes #2261)

### DIFF
--- a/packages/core/src/config-file.ts
+++ b/packages/core/src/config-file.ts
@@ -10,10 +10,10 @@ import { dirname } from "node:path";
 import type { McpConfigFile, ServerConfig } from "./config";
 import { options, projectConfigPath } from "./constants";
 
-export type ConfigScope = "user" | "project" | "local";
-
 /** All valid config scopes. */
 export const CONFIG_SCOPES = ["user", "project", "local"] as const;
+
+export type ConfigScope = (typeof CONFIG_SCOPES)[number];
 
 /** Config scopes excluding "local" (for import/export which don't support it). */
 export const CONFIG_SCOPES_NO_LOCAL = ["user", "project"] as const;

--- a/scripts/rules/derive-union-from-const.rule.ts
+++ b/scripts/rules/derive-union-from-const.rule.ts
@@ -1,0 +1,91 @@
+import ts from "typescript";
+import type { CheckRule } from "./_engine/rule";
+
+const rule: CheckRule = {
+  id: "derive-union-from-const",
+  kind: "check",
+  scold: "string-literal union duplicates values from an `as const` array — derive with `(typeof X)[number]`",
+  guidance: [
+    'replace `type Foo = "a" | "b" | "c"` with `type Foo = (typeof FOO_VALUES)[number]`',
+    "this keeps the runtime array and the type in sync — adding a value to the array automatically extends the type",
+    "if the union intentionally differs from the array, suppress with `// dotw-ignore derive-union-from-const: <reason>`",
+  ],
+  documentation: "#2261",
+  appliesToTests: false,
+  check(ctx) {
+    const { ast } = ctx;
+    const constArrays = collectConstArrays(ast);
+    if (constArrays.length === 0) return;
+
+    for (const alias of ast.find(ts.isTypeAliasDeclaration)) {
+      if (!ts.isUnionTypeNode(alias.type)) continue;
+
+      const unionValues = extractStringUnionMembers(alias.type);
+      if (!unionValues || unionValues.length < 2) continue;
+
+      const unionSet = new Set(unionValues);
+      for (const arr of constArrays) {
+        if (unionSet.size > arr.values.size) continue;
+        let isSubset = true;
+        for (const v of unionValues) {
+          if (!arr.values.has(v)) {
+            isSubset = false;
+            break;
+          }
+        }
+        if (isSubset) {
+          const pos = ast.positionOf(alias);
+          const line = ctx.file.content.split("\n")[pos.line - 1] ?? "";
+          ctx.violated(pos.line, pos.column, line.trim());
+          break;
+        }
+      }
+    }
+  },
+};
+
+interface ConstArray {
+  name: string;
+  values: Set<string>;
+}
+
+function extractStringUnionMembers(union: ts.UnionTypeNode): string[] | undefined {
+  const values: string[] = [];
+  for (const member of union.types) {
+    if (ts.isLiteralTypeNode(member) && ts.isStringLiteral(member.literal)) {
+      values.push(member.literal.text);
+    } else {
+      return undefined;
+    }
+  }
+  return values;
+}
+
+function isAsConstInitializer(init: ts.Expression, sf: ts.SourceFile): ts.ArrayLiteralExpression | undefined {
+  if (
+    ts.isAsExpression(init) &&
+    init.getText(sf).endsWith("as const") &&
+    ts.isArrayLiteralExpression(init.expression)
+  ) {
+    return init.expression;
+  }
+  return undefined;
+}
+
+function collectConstArrays(ast: import("./_engine/ast").AstHelper): ConstArray[] {
+  const results: ConstArray[] = [];
+  for (const decl of ast.find(ts.isVariableDeclaration)) {
+    if (!decl.initializer) continue;
+    const arr = isAsConstInitializer(decl.initializer, ast.sourceFile);
+    if (!arr) continue;
+    const name = ts.isIdentifier(decl.name) ? decl.name.text : "";
+    const values = new Set<string>();
+    for (const el of arr.elements) {
+      if (ts.isStringLiteral(el)) values.add(el.text);
+    }
+    if (values.size > 0) results.push({ name, values });
+  }
+  return results;
+}
+
+export default rule;

--- a/scripts/rules/fixtures/derive-union-from-const__clean.fixture.ts
+++ b/scripts/rules/fixtures/derive-union-from-const__clean.fixture.ts
@@ -1,0 +1,31 @@
+/**
+ * @rule derive-union-from-const
+ * @expect 0
+ * @path packages/core/src/example-clean.ts
+ *
+ * Shapes that must NOT be flagged:
+ *   1. type derived from array via (typeof X)[number]
+ *   2. union with members not matching any as-const array
+ *   3. union with non-string members (mixed)
+ *   4. single-member union (below the 2-member threshold)
+ *   5. as-const array with no matching union at all
+ */
+
+// Shape 1: correctly derived — canonical pattern
+export const SCOPES = ["user", "project", "local"] as const;
+export type Scope = (typeof SCOPES)[number];
+
+// Shape 2: union whose members don't appear in any const array
+export const COLORS = ["red", "green", "blue"] as const;
+export type Unrelated = "alpha" | "beta" | "gamma";
+
+// Shape 3: mixed union (not all string literals) — rule bails out
+export const MODES = ["fast", "slow"] as const;
+export type MixedUnion = "fast" | "slow" | number;
+
+// Shape 4: single-member union — below threshold
+export const SINGLES = ["only"] as const;
+export type Single = "only";
+
+// Shape 5: const array with no type alias duplication
+export const STATUSES = ["pending", "active", "done"] as const;

--- a/scripts/rules/fixtures/derive-union-from-const__flagged.fixture.ts
+++ b/scripts/rules/fixtures/derive-union-from-const__flagged.fixture.ts
@@ -1,0 +1,17 @@
+/**
+ * @rule derive-union-from-const
+ * @expect 2
+ * @path packages/core/src/example-flagged.ts
+ *
+ * Two shapes that MUST be flagged:
+ *   1. hand-copied union that exactly matches the as-const array
+ *   2. union that is a strict subset of the as-const array
+ */
+
+// Shape 1: exact copy of the array values
+export const CONFIG_SCOPES = ["user", "project", "local"] as const;
+export type ConfigScope = "user" | "project" | "local";
+
+// Shape 2: strict subset — union has fewer members than the array
+export const ALL_EVENTS = ["start", "stop", "pause", "resume"] as const;
+export type CoreEvent = "start" | "stop";


### PR DESCRIPTION
## Summary
- Adds AST-based `derive-union-from-const` rule that flags string-literal union type aliases whose members are a subset of an exported `as const` array in the same file
- Remediates the one existing violation: `packages/core/src/config-file.ts` — `ConfigScope` now derives from `CONFIG_SCOPES` via `(typeof CONFIG_SCOPES)[number]`
- Includes clean and flagged fixtures (5 non-firing shapes, 2 firing shapes)

## Test plan
- [x] `bun run doing-it-wrong --rule derive-union-from-const` → 0 violations after remediation
- [x] Fixture tests pass: clean (0 violations) and flagged (2 violations) cases verified
- [x] `bun run am-i-done --pre-commit` passes (exit 0)
- [x] Full test + coverage suite passes via pre-commit hook

Closes #2261

🤖 Generated with [Claude Code](https://claude.com/claude-code)