### PR TITLE
feat(rules): add bidirectional SUBCOMMANDS + flag↔KNOWN_FLAGS checks (fixes #2314, fixes #2327)

### DIFF
--- a/scripts/rules/cli-surface-registered.rule.ts
+++ b/scripts/rules/cli-surface-registered.rule.ts
@@ -6,15 +6,21 @@ import type { CheckRule, RuleContext } from "./_engine/rule";
 
 const MAIN_REL = "packages/command/src/main.ts";
 const COMPLETIONS_REL = "packages/command/src/commands/completions.ts";
+const COMMANDS_DIR = "packages/command/src/commands/";
 
-function collectSwitchCases(ctx: RuleContext): Array<{ name: string; line: number; col: number }> {
-  const results: Array<{ name: string; line: number; col: number }> = [];
+interface NamedLocation {
+  name: string;
+  line: number;
+  col: number;
+}
+
+// ── SUBCOMMANDS helpers ──────────────────────────────────────────────────
+
+function collectSwitchCases(ctx: RuleContext): NamedLocation[] {
+  const results: NamedLocation[] = [];
   const switches = ctx.ast.find(ts.isSwitchStatement);
   for (const sw of switches) {
-    // Only the top-level `switch (command)` dispatch — skip helper-function switches
-    // that happen to use a different variable (e.g. `switch (transport)`).
     if (!ts.isIdentifier(sw.expression) || sw.expression.text !== "command") continue;
-    // Defense-in-depth: also skip any switch nested inside another switch.
     const isNested = ts.findAncestor(sw.parent, ts.isSwitchStatement) !== undefined;
     if (isNested) continue;
     for (const clause of sw.caseBlock.clauses) {
@@ -27,28 +33,33 @@ function collectSwitchCases(ctx: RuleContext): Array<{ name: string; line: numbe
   return results;
 }
 
-function extractSubcommandsFromAst(ast: AstHelper): Set<string> | null {
+function extractSubcommandsWithPositions(ast: AstHelper): NamedLocation[] | null {
   const decls = ast.find(ts.isVariableDeclaration);
   for (const decl of decls) {
     if (!ts.isIdentifier(decl.name) || decl.name.text !== "SUBCOMMANDS") continue;
     if (!decl.initializer) continue;
-    // Unwrap `as const` — the initializer is an AsExpression wrapping the real array.
     const init = ts.isAsExpression(decl.initializer) ? decl.initializer.expression : decl.initializer;
     if (!ts.isArrayLiteralExpression(init)) continue;
-    const result = new Set<string>();
+    const result: NamedLocation[] = [];
     for (const elem of init.elements) {
-      if (ts.isStringLiteral(elem)) result.add(elem.text);
+      if (ts.isStringLiteral(elem)) {
+        const pos = ast.positionOf(elem);
+        result.push({ name: elem.text, line: pos.line, col: pos.column });
+      }
     }
     return result;
   }
   return null;
 }
 
+function extractSubcommandsFromAst(ast: AstHelper): Set<string> | null {
+  const entries = extractSubcommandsWithPositions(ast);
+  return entries ? new Set(entries.map((e) => e.name)) : null;
+}
+
 function findSubcommands(ctx: RuleContext): Set<string> | null {
-  // Fixtures inline SUBCOMMANDS in the same file — check the local AST first.
   const local = extractSubcommandsFromAst(ctx.ast);
   if (local !== null) return local;
-  // Cross-file: exact path match to avoid colliding with test fixtures.
   for (const meta of ctx.files.values()) {
     if (meta.relPath === COMPLETIONS_REL) {
       return extractSubcommandsFromAst(createAstHelper(meta));
@@ -57,37 +68,193 @@ function findSubcommands(ctx: RuleContext): Set<string> | null {
   return null;
 }
 
+/** Collect all command names dispatched by main.ts — switch cases + pre-switch args[0] checks. */
+function collectDispatchedCommands(ast: AstHelper): Set<string> {
+  const result = new Set<string>();
+
+  const switches = ast.find(ts.isSwitchStatement);
+  for (const sw of switches) {
+    if (!ts.isIdentifier(sw.expression) || sw.expression.text !== "command") continue;
+    const isNested = ts.findAncestor(sw.parent, ts.isSwitchStatement) !== undefined;
+    if (isNested) continue;
+    for (const clause of sw.caseBlock.clauses) {
+      if (!ts.isCaseClause(clause)) continue;
+      if (!ts.isStringLiteral(clause.expression)) continue;
+      result.add(clause.expression.text);
+    }
+  }
+
+  for (const bin of ast.find(ts.isBinaryExpression)) {
+    if (bin.operatorToken.kind !== ts.SyntaxKind.EqualsEqualsEqualsToken) continue;
+    const strSide = ts.isStringLiteral(bin.left) ? bin.left : ts.isStringLiteral(bin.right) ? bin.right : undefined;
+    if (!strSide || strSide.text.startsWith("-")) continue;
+    const other = strSide === bin.left ? bin.right : bin.left;
+    if (
+      ts.isElementAccessExpression(other) &&
+      ts.isIdentifier(other.expression) &&
+      other.expression.text === "args" &&
+      ts.isNumericLiteral(other.argumentExpression) &&
+      other.argumentExpression.text === "0"
+    ) {
+      result.add(strSide.text);
+    }
+  }
+
+  return result;
+}
+
+// ── KNOWN_FLAGS helpers ──────────────────────────────────────────────────
+
+function extractKnownFlags(ast: AstHelper): { flags: Set<string>; entries: NamedLocation[] } | null {
+  const decls = ast.find(ts.isVariableDeclaration);
+  for (const decl of decls) {
+    if (!ts.isIdentifier(decl.name) || decl.name.text !== "KNOWN_FLAGS") continue;
+    if (!decl.initializer) continue;
+
+    let arrayExpr: ts.ArrayLiteralExpression | undefined;
+
+    if (ts.isNewExpression(decl.initializer)) {
+      const arg = decl.initializer.arguments?.[0];
+      if (arg && ts.isArrayLiteralExpression(arg)) arrayExpr = arg;
+    } else if (ts.isArrayLiteralExpression(decl.initializer)) {
+      arrayExpr = decl.initializer;
+    } else if (ts.isAsExpression(decl.initializer) && ts.isArrayLiteralExpression(decl.initializer.expression)) {
+      arrayExpr = decl.initializer.expression;
+    }
+
+    if (!arrayExpr) continue;
+
+    const flags = new Set<string>();
+    const entries: NamedLocation[] = [];
+    for (const elem of arrayExpr.elements) {
+      if (ts.isStringLiteral(elem)) {
+        flags.add(elem.text);
+        const pos = ast.positionOf(elem);
+        entries.push({ name: elem.text, line: pos.line, col: pos.column });
+      }
+    }
+    return { flags, entries };
+  }
+  return null;
+}
+
+const HELP_FLAGS = new Set(["--help", "-h"]);
+
+function collectParsedFlags(ast: AstHelper): Map<string, { line: number; col: number }> {
+  const result = new Map<string, { line: number; col: number }>();
+
+  function addFlag(text: string, node: ts.Node) {
+    if (!text.startsWith("--")) return;
+    if (HELP_FLAGS.has(text)) return;
+    if (result.has(text)) return;
+    const pos = ast.positionOf(node);
+    result.set(text, { line: pos.line, col: pos.column });
+  }
+
+  for (const clause of ast.find(ts.isCaseClause)) {
+    if (ts.isStringLiteral(clause.expression)) addFlag(clause.expression.text, clause.expression);
+  }
+
+  for (const bin of ast.find(ts.isBinaryExpression)) {
+    if (bin.operatorToken.kind !== ts.SyntaxKind.EqualsEqualsEqualsToken) continue;
+    if (ts.isStringLiteral(bin.left)) addFlag(bin.left.text, bin.left);
+    if (ts.isStringLiteral(bin.right)) addFlag(bin.right.text, bin.right);
+  }
+
+  for (const call of [...ast.callsTo("indexOf"), ...ast.callsTo("includes")]) {
+    const arg = call.arguments[0];
+    if (arg && ts.isStringLiteral(arg)) addFlag(arg.text, arg);
+  }
+
+  return result;
+}
+
+// ── Rule ─────────────────────────────────────────────────────────────────
+
 const rule: CheckRule = {
   id: "cli-surface-registered",
   kind: "check",
-  scold: "CLI subcommand in dispatch but not registered in SUBCOMMANDS (completions.ts)",
+  scold: "CLI surface registration mismatch — command or flag set out of sync with its anchor",
   guidance: [
-    "Add the command to the SUBCOMMANDS array in packages/command/src/commands/completions.ts",
-    "Also add it to printUsage() in packages/command/src/main.ts if user-facing",
-    "Until a centralized COMMANDS registry exists, every dispatch case must appear in SUBCOMMANDS",
+    "dispatch case without SUBCOMMANDS entry → add to SUBCOMMANDS in completions.ts",
+    "SUBCOMMANDS entry without dispatch case → remove from SUBCOMMANDS or add case in main.ts",
+    "parsed --flag missing from KNOWN_FLAGS → add to the KNOWN_FLAGS set in the same file",
+    "KNOWN_FLAGS entry not parsed anywhere → remove from KNOWN_FLAGS or add code that handles it",
   ],
-  documentation: "#2246",
+  documentation: "#2246, #2314, #2327",
   appliesToTests: false,
   check(ctx) {
-    if (ctx.file.relPath !== MAIN_REL) return;
-
-    const cases = collectSwitchCases(ctx);
-    if (cases.length === 0) return;
-
-    const subcommands = findSubcommands(ctx);
-    if (!subcommands) {
-      // Hard-error: completions.ts is missing from the file set (renamed? moved?).
-      // Silently skipping here would give false confidence that the invariant is enforced.
-      ctx.violated(1, 1, `SUBCOMMANDS anchor not found — is ${COMPLETIONS_REL} missing or renamed?`);
-      return;
+    if (ctx.file.relPath === MAIN_REL) {
+      checkDispatchToSubcommands(ctx);
     }
 
-    for (const { name, line, col } of cases) {
-      if (!subcommands.has(name)) {
-        ctx.violated(line, col, `case "${name}"`);
-      }
+    if (ctx.file.relPath === COMPLETIONS_REL) {
+      checkSubcommandsToDispatch(ctx);
+    }
+
+    if (ctx.file.relPath.startsWith(COMMANDS_DIR)) {
+      checkFlagKnownFlags(ctx);
     }
   },
 };
+
+function checkDispatchToSubcommands(ctx: RuleContext): void {
+  const cases = collectSwitchCases(ctx);
+  if (cases.length === 0) return;
+
+  const subcommands = findSubcommands(ctx);
+  if (!subcommands) {
+    ctx.violated(1, 1, `SUBCOMMANDS anchor not found — is ${COMPLETIONS_REL} missing or renamed?`);
+    return;
+  }
+
+  for (const { name, line, col } of cases) {
+    if (!subcommands.has(name)) {
+      ctx.violated(line, col, `case "${name}"`);
+    }
+  }
+}
+
+function checkSubcommandsToDispatch(ctx: RuleContext): void {
+  const entries = extractSubcommandsWithPositions(ctx.ast);
+  if (!entries) return;
+
+  let mainMeta: import("./_engine/file-loader").FileMeta | undefined;
+  for (const meta of ctx.files.values()) {
+    if (meta.relPath === MAIN_REL) {
+      mainMeta = meta;
+      break;
+    }
+  }
+  if (!mainMeta) return;
+
+  const mainAst = createAstHelper(mainMeta);
+  const dispatched = collectDispatchedCommands(mainAst);
+
+  for (const { name, line, col } of entries) {
+    if (!dispatched.has(name)) {
+      ctx.violated(line, col, `SUBCOMMANDS entry "${name}" has no dispatch case`);
+    }
+  }
+}
+
+function checkFlagKnownFlags(ctx: RuleContext): void {
+  const known = extractKnownFlags(ctx.ast);
+  if (!known) return;
+
+  const parsed = collectParsedFlags(ctx.ast);
+
+  for (const [flag, { line, col }] of parsed) {
+    if (!known.flags.has(flag)) {
+      ctx.violated(line, col, `flag "${flag}" parsed but not in KNOWN_FLAGS`);
+    }
+  }
+
+  for (const { name, line, col } of known.entries) {
+    if (!parsed.has(name)) {
+      ctx.violated(line, col, `KNOWN_FLAGS entry "${name}" not parsed anywhere`);
+    }
+  }
+}
 
 export default rule;

--- a/scripts/rules/cli-surface-registered.spec.ts
+++ b/scripts/rules/cli-surface-registered.spec.ts
@@ -14,7 +14,7 @@ function makeFile(relPath: string, content: string): FileMeta {
   };
 }
 
-describe("cli-surface-registered cross-file", () => {
+describe("cli-surface-registered: dispatch → SUBCOMMANDS", () => {
   it("finds SUBCOMMANDS in a separate completions.ts file", () => {
     const main = makeFile(
       "packages/command/src/main.ts",
@@ -52,9 +52,6 @@ describe("cli-surface-registered cross-file", () => {
   });
 
   it("skips nested switches (only outer dispatch checked)", () => {
-    // Inner switch uses the SAME discriminant (`command`) so the isNested
-    // guard — not just the expression filter — is what prevents "kill" from
-    // being checked against SUBCOMMANDS.
     const main = makeFile(
       "packages/command/src/main.ts",
       `const SUBCOMMANDS = ["serve"] as const;
@@ -79,8 +76,6 @@ describe("cli-surface-registered cross-file", () => {
   });
 
   it("hard-errors when SUBCOMMANDS anchor is not found in any loaded file", () => {
-    // No inline SUBCOMMANDS, no completions.ts in the file set.
-    // The rule must fail loudly rather than silently pass.
     const main = makeFile(
       "packages/command/src/main.ts",
       `switch (command) {
@@ -94,7 +89,6 @@ describe("cli-surface-registered cross-file", () => {
   });
 
   it("does not flag switch inside a helper function (only switch (command) is the dispatch)", () => {
-    // A helper function with its own switch must not produce false positives.
     const main = makeFile(
       "packages/command/src/main.ts",
       `const SUBCOMMANDS = ["ls"] as const;
@@ -110,6 +104,267 @@ describe("cli-surface-registered cross-file", () => {
     );
     const files = new Map([[main.path, main]]);
     const violations = evaluateRule(rule, main, files);
+    expect(violations).toHaveLength(0);
+  });
+});
+
+describe("cli-surface-registered: SUBCOMMANDS → dispatch", () => {
+  it("flags orphaned SUBCOMMANDS entries with no dispatch case", () => {
+    const main = makeFile(
+      "packages/command/src/main.ts",
+      `switch (command) {
+        case "ls": break;
+      }`,
+    );
+    const completions = makeFile(
+      "packages/command/src/commands/completions.ts",
+      `export const SUBCOMMANDS = ["ls", "orphaned"] as const;`,
+    );
+    const files = new Map([
+      [main.path, main],
+      [completions.path, completions],
+    ]);
+    const violations = evaluateRule(rule, completions, files);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].snippet).toBe('SUBCOMMANDS entry "orphaned" has no dispatch case');
+  });
+
+  it("does not flag entries that are dispatched via pre-switch args[0] check", () => {
+    const main = makeFile(
+      "packages/command/src/main.ts",
+      `if (args[0] === "help") { printUsage(); return; }
+      switch (command) {
+        case "ls": break;
+      }`,
+    );
+    const completions = makeFile(
+      "packages/command/src/commands/completions.ts",
+      `export const SUBCOMMANDS = ["ls", "help"] as const;`,
+    );
+    const files = new Map([
+      [main.path, main],
+      [completions.path, completions],
+    ]);
+    const violations = evaluateRule(rule, completions, files);
+    expect(violations).toHaveLength(0);
+  });
+
+  it("reports nothing when all SUBCOMMANDS have dispatch cases", () => {
+    const main = makeFile(
+      "packages/command/src/main.ts",
+      `switch (command) {
+        case "ls": break;
+        case "call": break;
+      }`,
+    );
+    const completions = makeFile(
+      "packages/command/src/commands/completions.ts",
+      `export const SUBCOMMANDS = ["ls", "call"] as const;`,
+    );
+    const files = new Map([
+      [main.path, main],
+      [completions.path, completions],
+    ]);
+    const violations = evaluateRule(rule, completions, files);
+    expect(violations).toHaveLength(0);
+  });
+
+  it("skips when main.ts is not in the file set", () => {
+    const completions = makeFile(
+      "packages/command/src/commands/completions.ts",
+      `export const SUBCOMMANDS = ["ls", "orphaned"] as const;`,
+    );
+    const files = new Map([[completions.path, completions]]);
+    const violations = evaluateRule(rule, completions, files);
+    expect(violations).toHaveLength(0);
+  });
+
+  it("flags multiple orphaned entries", () => {
+    const main = makeFile(
+      "packages/command/src/main.ts",
+      `switch (command) {
+        case "ls": break;
+      }`,
+    );
+    const completions = makeFile(
+      "packages/command/src/commands/completions.ts",
+      `export const SUBCOMMANDS = ["ls", "dead1", "dead2"] as const;`,
+    );
+    const files = new Map([
+      [main.path, main],
+      [completions.path, completions],
+    ]);
+    const violations = evaluateRule(rule, completions, files);
+    expect(violations).toHaveLength(2);
+    expect(violations.map((v) => v.snippet)).toEqual([
+      'SUBCOMMANDS entry "dead1" has no dispatch case',
+      'SUBCOMMANDS entry "dead2" has no dispatch case',
+    ]);
+  });
+
+  it("does not flag pre-switch args[0] flag comparisons as dispatched commands", () => {
+    const main = makeFile(
+      "packages/command/src/main.ts",
+      `if (args[0] === "--help") { printUsage(); return; }
+      switch (command) {
+        case "ls": break;
+      }`,
+    );
+    const completions = makeFile(
+      "packages/command/src/commands/completions.ts",
+      `export const SUBCOMMANDS = ["ls"] as const;`,
+    );
+    const files = new Map([
+      [main.path, main],
+      [completions.path, completions],
+    ]);
+    const violations = evaluateRule(rule, completions, files);
+    expect(violations).toHaveLength(0);
+  });
+});
+
+describe("cli-surface-registered: flag ↔ KNOWN_FLAGS", () => {
+  it("flags a parsed --flag missing from KNOWN_FLAGS", () => {
+    const file = makeFile(
+      "packages/command/src/commands/example.ts",
+      `const KNOWN_FLAGS = new Set(["--verbose"]);
+      function parseExampleArgs(args: string[]) {
+        for (let i = 0; i < args.length; i++) {
+          if (args[i] === "--verbose") {}
+          else if (args[i] === "--quiet") {}
+        }
+      }`,
+    );
+    const files = new Map([[file.path, file]]);
+    const violations = evaluateRule(rule, file, files);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].snippet).toBe('flag "--quiet" parsed but not in KNOWN_FLAGS');
+  });
+
+  it("flags a KNOWN_FLAGS entry not parsed anywhere", () => {
+    const file = makeFile(
+      "packages/command/src/commands/example.ts",
+      `const KNOWN_FLAGS = new Set(["--verbose", "--dead-flag"]);
+      function parseExampleArgs(args: string[]) {
+        for (let i = 0; i < args.length; i++) {
+          if (args[i] === "--verbose") {}
+        }
+      }`,
+    );
+    const files = new Map([[file.path, file]]);
+    const violations = evaluateRule(rule, file, files);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].snippet).toBe('KNOWN_FLAGS entry "--dead-flag" not parsed anywhere');
+  });
+
+  it("reports nothing when flags and KNOWN_FLAGS are in sync", () => {
+    const file = makeFile(
+      "packages/command/src/commands/example.ts",
+      `const KNOWN_FLAGS = new Set(["--sprint", "--since"]);
+      const sprintIdx = args.indexOf("--sprint");
+      const sinceIdx = args.indexOf("--since");`,
+    );
+    const files = new Map([[file.path, file]]);
+    const violations = evaluateRule(rule, file, files);
+    expect(violations).toHaveLength(0);
+  });
+
+  it("excludes --help from the flag set-difference", () => {
+    const file = makeFile(
+      "packages/command/src/commands/example.ts",
+      `const KNOWN_FLAGS = new Set(["--verbose"]);
+      if (args.includes("--help")) return;
+      if (args[i] === "--verbose") {}`,
+    );
+    const files = new Map([[file.path, file]]);
+    const violations = evaluateRule(rule, file, files);
+    expect(violations).toHaveLength(0);
+  });
+
+  it("does not fire when file has no KNOWN_FLAGS", () => {
+    const file = makeFile(
+      "packages/command/src/commands/gc.ts",
+      `function parseGcArgs(args: string[]) {
+        if (args[i] === "--dry-run") {}
+        else if (args[i] === "--branches-only") {}
+      }`,
+    );
+    const files = new Map([[file.path, file]]);
+    const violations = evaluateRule(rule, file, files);
+    expect(violations).toHaveLength(0);
+  });
+
+  it("does not fire on files outside commands/", () => {
+    const file = makeFile(
+      "packages/command/src/main.ts",
+      `const KNOWN_FLAGS = new Set(["--verbose"]);
+      if (args[i] === "--quiet") {}`,
+    );
+    const completions = makeFile(
+      "packages/command/src/commands/completions.ts",
+      "export const SUBCOMMANDS = [] as const;",
+    );
+    const files = new Map([
+      [file.path, file],
+      [completions.path, completions],
+    ]);
+    const violations = evaluateRule(rule, file, files);
+    // Only the dispatch→SUBCOMMANDS check fires on main.ts, not the flag check
+    // (no switch cases → no violations from sub-check 1 either)
+    expect(violations).toHaveLength(0);
+  });
+
+  it("detects flags via indexOf and includes calls", () => {
+    const file = makeFile(
+      "packages/command/src/commands/example.ts",
+      `const KNOWN_FLAGS = new Set(["--sprint"]);
+      const idx = args.indexOf("--sprint");
+      if (args.includes("--since")) {}`,
+    );
+    const files = new Map([[file.path, file]]);
+    const violations = evaluateRule(rule, file, files);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].snippet).toBe('flag "--since" parsed but not in KNOWN_FLAGS');
+  });
+
+  it("detects both directions simultaneously", () => {
+    const file = makeFile(
+      "packages/command/src/commands/example.ts",
+      `const KNOWN_FLAGS = new Set(["--keep", "--dead"]);
+      if (args[i] === "--keep") {}
+      if (args[i] === "--new") {}`,
+    );
+    const files = new Map([[file.path, file]]);
+    const violations = evaluateRule(rule, file, files);
+    expect(violations).toHaveLength(2);
+    const snippets = violations.map((v) => v.snippet).sort();
+    expect(snippets).toEqual([
+      'KNOWN_FLAGS entry "--dead" not parsed anywhere',
+      'flag "--new" parsed but not in KNOWN_FLAGS',
+    ]);
+  });
+
+  it("handles KNOWN_FLAGS as plain array", () => {
+    const file = makeFile(
+      "packages/command/src/commands/example.ts",
+      `const KNOWN_FLAGS = ["--verbose"];
+      if (args[i] === "--verbose") {}
+      if (args[i] === "--missing") {}`,
+    );
+    const files = new Map([[file.path, file]]);
+    const violations = evaluateRule(rule, file, files);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].snippet).toBe('flag "--missing" parsed but not in KNOWN_FLAGS');
+  });
+
+  it("handles KNOWN_FLAGS as const array", () => {
+    const file = makeFile(
+      "packages/command/src/commands/example.ts",
+      `const KNOWN_FLAGS = ["--verbose"] as const;
+      if (args[i] === "--verbose") {}`,
+    );
+    const files = new Map([[file.path, file]]);
+    const violations = evaluateRule(rule, file, files);
     expect(violations).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Closes #2314, #2327

## Summary
- **Sub-check 2 (SUBCOMMANDS → dispatch)**: Detects dead SUBCOMMANDS entries — commands registered for shell completion but with no corresponding dispatch case in main.ts. Accounts for pre-switch `args[0]` handling (e.g., `"help"`).
- **Sub-check 3 (flag ↔ KNOWN_FLAGS)**: Bidirectional set-difference between parsed `--flag` literals and the `KNOWN_FLAGS` set in command files. Detects both unregistered flags and dead KNOWN_FLAGS entries. Excludes `--help`/`-h` (universally early-return).
- Updated scold/guidance/documentation to cover all three sub-checks.
- 22 test cases covering both new sub-checks, existing behavior, and edge cases.

## Test plan
- [x] 22 tests pass (`bun test scripts/rules/cli-surface-registered.spec.ts`)
- [x] Rule sweep clean against live codebase (`bun run doing-it-wrong --filter cli-surface-registered`)
- [x] Full static gate passes (`bun run am-i-done --pre-commit`)
- [x] Pre-commit hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)