### PR TITLE
fix(test): exclude control package from --parallel to prevent yoga-layout TDZ (fixes #2362)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint:check": "bun install && bunx biome check .",
     "am-i-done": "bun scripts/am-i-done.ts",
     "doing-it-wrong": "bun scripts/doing-it-wrong.ts",
-    "test": "bun install && bun test --parallel",
+    "test": "bun install && bun test --parallel --path-ignore-patterns='packages/control/**' && bun test packages/control",
     "test:phases": "cd .claude/phases && bun test",
     "test:coverage": "bun scripts/check-coverage.ts",
     "dev:daemon": "bun packages/daemon/src/main.ts",

--- a/scripts/am-i-done.ts
+++ b/scripts/am-i-done.ts
@@ -102,10 +102,16 @@ const RULES: Step = {
   ],
 };
 
-const TEST: Step = {
-  name: "test",
-  description: "bun test --parallel",
-  command: "bun test --parallel",
+const TEST_PARALLEL: Step = {
+  name: "test-parallel",
+  description: "bun test --parallel (excluding packages/control — yoga-layout TDZ, #2362)",
+  command: "bun test --parallel --path-ignore-patterns=packages/control/**",
+};
+
+const TEST_CONTROL: Step = {
+  name: "test-control",
+  description: "bun test packages/control (sequential — yoga-layout TDZ workaround #2362)",
+  command: "bun test packages/control",
 };
 
 const COVERAGE: Step = {
@@ -133,7 +139,8 @@ const COMPREHENSIVE: Step[] = [
   TEARDOWN,
   PHASE_DRIFT,
   RULES,
-  TEST,
+  TEST_PARALLEL,
+  TEST_CONTROL,
   COVERAGE,
 ];
 


### PR DESCRIPTION
## Summary
- Bun 1.3.x `--parallel` test mode breaks ESM top-level await module evaluation for yoga-layout's WASM init, causing deterministic "Cannot access 'Yoga' before initialization" ReferenceError in all ink-dependent tests (packages/control)
- Split the `bun test --parallel` step into two phases: parallel for all non-ink packages (~29s) + sequential for packages/control (~9s) — total ~38s vs previous ~28s
- Updated both `package.json` `test` script and `am-i-done.ts` TEST step to use `--path-ignore-patterns=packages/control/**`

## Root cause
yoga-layout@3.2.1 uses `const Yoga = wrapAssembly(await loadYoga())` — a top-level await that loads WASM. Bun's `--parallel` flag changes module evaluation strategy such that the TDZ on `const Yoga` is hit even for a single test file. Preloads don't share module registries with test files in parallel mode, making the "deterministic preload" approach ineffective.

## Test plan
- [x] `bun test --parallel --path-ignore-patterns='packages/control/**'` passes (7408 tests, 0 fail)
- [x] `bun test packages/control` passes (618 tests, 0 fail)
- [x] `bun run test` passes (both phases)
- [x] `bun run am-i-done` passes all 11 steps
- [x] Verified across 4+ consecutive runs with zero Yoga TDZ errors

Closes #2362

🤖 Generated with [Claude Code](https://claude.com/claude-code)