### PR TITLE
feat(core): spawnManaged helper for long-lived processes (closes #2346)

### DIFF
--- a/packages/acp/src/acp-process.ts
+++ b/packages/acp/src/acp-process.ts
@@ -8,7 +8,7 @@
  * Mirrors codex-process.ts but for the ACP protocol.
  */
 
-import type { Subprocess } from "bun";
+import { type ManagedHandle, spawnManaged } from "@mcp-cli/core";
 
 export interface AcpProcessOptions {
   /** Working directory for the agent process. */
@@ -28,7 +28,7 @@ export interface AcpProcessOptions {
 }
 
 export class AcpProcess {
-  private proc: Subprocess | null = null;
+  private handle: ManagedHandle | null = null;
   private readonly opts: AcpProcessOptions;
   private _exited = false;
 
@@ -38,37 +38,39 @@ export class AcpProcess {
 
   /** Spawn the ACP agent process. */
   spawn(): void {
-    if (this.proc) throw new Error("AcpProcess already spawned");
+    if (this.handle) throw new Error("AcpProcess already spawned");
 
-    // dotw-ignore no-raw-spawn: long-lived agent subprocess; needs live handle for streaming stdio + kill
-    this.proc = Bun.spawn(this.opts.command, {
+    const [bin, ...args] = this.opts.command;
+    const result = spawnManaged(bin, args, {
       cwd: this.opts.cwd,
       stdin: "pipe",
       stdout: "pipe",
       stderr: this.opts.onStderr ? "pipe" : "inherit",
+      onStderr: this.opts.onStderr,
       env: { ...process.env, ...this.opts.env },
     });
 
-    // Start reading stdout lines
-    this.readLines();
-
-    // Start reading stderr if requested
-    if (this.opts.onStderr && this.proc.stderr) {
-      this.readStderr();
+    if (!result.ok) {
+      this._exited = true;
+      this.opts.onExit(null, null);
+      return;
     }
 
-    // Monitor process exit
-    this.proc.exited.then((code) => {
+    this.handle = result.handle;
+
+    this.readLines();
+
+    this.handle.exited.then((status) => {
       if (this._exited) return;
       this._exited = true;
-      this.opts.onExit(code, null);
+      this.opts.onExit(status.exitCode, status.signal);
     });
   }
 
   /** Write a JSON-RPC message to the process stdin and flush. */
   async write(msg: Record<string, unknown>): Promise<void> {
-    const stdin = this.proc?.stdin;
-    if (!stdin || typeof stdin === "number") throw new Error("Process not spawned or stdin unavailable");
+    const stdin = this.handle?.stdin;
+    if (!stdin) throw new Error("Process not spawned or stdin unavailable");
     const line = `${JSON.stringify(msg)}\n`;
     stdin.write(line);
     await stdin.flush();
@@ -76,18 +78,18 @@ export class AcpProcess {
 
   /** Send SIGTERM to the process. */
   kill(): void {
-    if (!this.proc || this._exited) return;
-    this.proc.kill("SIGTERM");
+    if (!this.handle || this._exited) return;
+    this.handle.kill();
   }
 
   /** Whether the process is still running. */
   get alive(): boolean {
-    return this.proc !== null && !this._exited;
+    return this.handle !== null && !this._exited;
   }
 
   /** The process PID, if spawned. */
   get pid(): number | undefined {
-    return this.proc?.pid;
+    return this.handle?.pid;
   }
 
   /** Whether the process has exited. */
@@ -97,8 +99,8 @@ export class AcpProcess {
 
   /** Read stdout line by line and parse as JSON. */
   private async readLines(): Promise<void> {
-    const stdout = this.proc?.stdout;
-    if (!stdout || typeof stdout === "number") return;
+    const stdout = this.handle?.stdout;
+    if (!stdout) return;
 
     const reader = stdout.getReader();
     const decoder = new TextDecoder();
@@ -125,7 +127,6 @@ export class AcpProcess {
         }
       }
 
-      // Process any remaining buffer content
       if (buffer.trim()) {
         try {
           const parsed = JSON.parse(buffer.trim()) as Record<string, unknown>;
@@ -138,25 +139,6 @@ export class AcpProcess {
       if (!this._exited) {
         this.opts.onError?.(err instanceof Error ? err : new Error(String(err)), "");
       }
-    }
-  }
-
-  /** Read stderr chunks. */
-  private async readStderr(): Promise<void> {
-    const stderr = this.proc?.stderr;
-    if (!stderr) return;
-
-    const reader = (stderr as ReadableStream<Uint8Array>).getReader();
-    const decoder = new TextDecoder();
-
-    try {
-      for (;;) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        this.opts.onStderr?.(decoder.decode(value, { stream: true }));
-      }
-    } catch {
-      // Stream closed — ignore
     }
   }
 }

--- a/packages/codex/src/codex-process.ts
+++ b/packages/codex/src/codex-process.ts
@@ -6,7 +6,7 @@
  * and reports process exit.
  */
 
-import type { Subprocess } from "bun";
+import { type ManagedHandle, spawnManaged } from "@mcp-cli/core";
 
 export interface CodexProcessOptions {
   /** Working directory for the codex process. */
@@ -26,11 +26,10 @@ export interface CodexProcessOptions {
 }
 
 export class CodexProcess {
-  private proc: Subprocess | null = null;
+  private handle: ManagedHandle | null = null;
   private readonly opts: CodexProcessOptions;
   private _exited = false;
   private readLoopPromise: Promise<void> | null = null;
-  private stderrLoopPromise: Promise<void> | null = null;
 
   constructor(opts: CodexProcessOptions) {
     this.opts = opts;
@@ -38,38 +37,40 @@ export class CodexProcess {
 
   /** Spawn the codex app-server process. */
   spawn(): void {
-    if (this.proc) throw new Error("CodexProcess already spawned");
+    if (this.handle) throw new Error("CodexProcess already spawned");
 
     const cmd = this.opts.command ?? ["codex", "app-server"];
-    // dotw-ignore no-raw-spawn: long-lived agent subprocess; retains the handle for streaming stdin/stdout (NDJSON line reader), stderr, and exit monitoring
-    this.proc = Bun.spawn(cmd, {
+    const [bin, ...args] = cmd;
+    const result = spawnManaged(bin, args, {
       cwd: this.opts.cwd,
       stdin: "pipe",
       stdout: "pipe",
       stderr: this.opts.onStderr ? "pipe" : "inherit",
+      onStderr: this.opts.onStderr,
       env: { ...process.env, ...this.opts.env },
     });
 
-    // Start reading stdout lines
-    this.readLoopPromise = this.readLines();
-
-    // Start reading stderr if requested
-    if (this.opts.onStderr && this.proc.stderr) {
-      this.stderrLoopPromise = this.readStderr();
+    if (!result.ok) {
+      this._exited = true;
+      this.opts.onExit(null, null);
+      return;
     }
 
-    // Monitor process exit
-    this.proc.exited.then((code) => {
+    this.handle = result.handle;
+
+    this.readLoopPromise = this.readLines();
+
+    this.handle.exited.then((status) => {
       if (this._exited) return;
       this._exited = true;
-      this.opts.onExit(code, null);
+      this.opts.onExit(status.exitCode, status.signal);
     });
   }
 
   /** Write a JSON-RPC message to the process stdin and flush. */
   async write(msg: Record<string, unknown>): Promise<void> {
-    const stdin = this.proc?.stdin;
-    if (!stdin || typeof stdin === "number") throw new Error("Process not spawned or stdin unavailable");
+    const stdin = this.handle?.stdin;
+    if (!stdin) throw new Error("Process not spawned or stdin unavailable");
     const line = `${JSON.stringify(msg)}\n`;
     stdin.write(line);
     await stdin.flush();
@@ -77,18 +78,18 @@ export class CodexProcess {
 
   /** Send SIGTERM to the process. */
   kill(): void {
-    if (!this.proc || this._exited) return;
-    this.proc.kill("SIGTERM");
+    if (!this.handle || this._exited) return;
+    this.handle.kill();
   }
 
   /** Whether the process is still running. */
   get alive(): boolean {
-    return this.proc !== null && !this._exited;
+    return this.handle !== null && !this._exited;
   }
 
   /** The process PID, if spawned. */
   get pid(): number | undefined {
-    return this.proc?.pid;
+    return this.handle?.pid;
   }
 
   /** Whether the process has exited. */
@@ -98,8 +99,8 @@ export class CodexProcess {
 
   /** Read stdout line by line and parse as JSON. */
   private async readLines(): Promise<void> {
-    const stdout = this.proc?.stdout;
-    if (!stdout || typeof stdout === "number") return;
+    const stdout = this.handle?.stdout;
+    if (!stdout) return;
 
     const reader = stdout.getReader();
     const decoder = new TextDecoder();
@@ -112,7 +113,6 @@ export class CodexProcess {
 
         buffer += decoder.decode(value, { stream: true });
         const lines = buffer.split("\n");
-        // Keep the last partial line in the buffer
         buffer = lines.pop() ?? "";
 
         for (const line of lines) {
@@ -127,7 +127,6 @@ export class CodexProcess {
         }
       }
 
-      // Process any remaining buffer content
       if (buffer.trim()) {
         try {
           const parsed = JSON.parse(buffer.trim()) as Record<string, unknown>;
@@ -137,29 +136,9 @@ export class CodexProcess {
         }
       }
     } catch (err) {
-      // Stream closed unexpectedly — process likely died
       if (!this._exited) {
         this.opts.onError?.(err instanceof Error ? err : new Error(String(err)), "");
       }
-    }
-  }
-
-  /** Read stderr chunks. */
-  private async readStderr(): Promise<void> {
-    const stderr = this.proc?.stderr;
-    if (!stderr) return;
-
-    const reader = (stderr as ReadableStream<Uint8Array>).getReader();
-    const decoder = new TextDecoder();
-
-    try {
-      for (;;) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        this.opts.onStderr?.(decoder.decode(value, { stream: true }));
-      }
-    } catch {
-      // Stream closed — ignore
     }
   }
 }

--- a/packages/command/src/daemon-lifecycle.ts
+++ b/packages/command/src/daemon-lifecycle.ts
@@ -30,6 +30,7 @@ import {
   pingDaemon,
   rawFetch,
   spawnCaptureSync,
+  spawnManaged,
   tryFlockExclusive,
 } from "@mcp-cli/core";
 
@@ -419,29 +420,22 @@ export function resolveDaemonCommand(): string[] {
 /** Spawn the daemon as a detached background process */
 async function startDaemon(): Promise<void> {
   const cmd = resolveDaemonCommand();
+  const [bin, ...args] = cmd;
 
-  // dotw-ignore no-raw-spawn: long-running daemon process; retains proc handle for incremental stdout reads, proc.kill(), and proc.unref()
-  const proc = Bun.spawn(cmd, {
+  const result = spawnManaged(bin, args, {
     stdout: "pipe",
     stderr: "pipe",
   });
 
-  // Drain stderr in parallel to prevent pipe buffer deadlock (64KB limit).
-  // Capture output for inclusion in timeout error messages.
-  let stderrOutput = "";
-  const stderrDrain = (async () => {
-    const decoder = new TextDecoder();
-    const reader = proc.stderr.getReader();
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      stderrOutput += decoder.decode(value, { stream: true });
-    }
-    stderrOutput += decoder.decode(); // flush
-  })();
+  if (!result.ok) {
+    throw new Error(`Failed to spawn daemon: ${bin}`);
+  }
+
+  const { handle } = result;
+  if (!handle.stdout) throw new Error("stdout pipe not available");
 
   const stdoutDecoder = new TextDecoder();
-  const reader = proc.stdout.getReader();
+  const reader = handle.stdout.getReader();
   const deadline = Date.now() + DAEMON_START_TIMEOUT_MS;
   let stdout = "";
 
@@ -450,15 +444,13 @@ async function startDaemon(): Promise<void> {
     if (done) break;
     stdout += stdoutDecoder.decode(value, { stream: true });
     if (stdout.includes(DAEMON_READY_SIGNAL)) {
-      proc.unref();
+      handle.unref();
       return;
     }
   }
 
-  proc.kill();
-  await stderrDrain.catch((e) => {
-    stderrOutput += `\n[drain error: ${e instanceof Error ? e.message : String(e)}]`;
-  });
+  await handle.kill();
+  const stderrOutput = handle.stderrTail();
   const details = [stdout && `stdout: ${stdout.trim()}`, stderrOutput && `stderr: ${stderrOutput.trim()}`]
     .filter(Boolean)
     .join("; ");

--- a/packages/control/src/ensure-daemon.spec.ts
+++ b/packages/control/src/ensure-daemon.spec.ts
@@ -57,7 +57,7 @@ describe("ensureDaemonRunning", () => {
         spawned = true;
         return {
           stdout: mockStream("starting...\nMCPD_READY\n"),
-          stderr: mockStream(""),
+
           unref: () => {
             unrefCalled = true;
           },
@@ -144,6 +144,28 @@ describe("ensureDaemonRunning", () => {
       },
       readySignal: "MCPD_READY",
       timeoutMs: 1000,
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("exercises the default spawnManaged-backed spawn against a real binary", async () => {
+    const result = await ensureDaemonRunning({
+      ping: async () => false,
+      resolveCmd: () => ["sh", "-c", "echo SPAWN_DEFAULT_READY"],
+      readySignal: "SPAWN_DEFAULT_READY",
+      timeoutMs: 5000,
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("returns false when the default spawn cannot start the resolved binary", async () => {
+    const result = await ensureDaemonRunning({
+      ping: async () => false,
+      resolveCmd: () => ["definitely-not-a-real-binary-xyzzy-2346"],
+      readySignal: "MCPD_READY",
+      timeoutMs: 500,
     });
 
     expect(result).toBe(false);

--- a/packages/control/src/ensure-daemon.ts
+++ b/packages/control/src/ensure-daemon.ts
@@ -11,12 +11,13 @@ import {
   DAEMON_START_TIMEOUT_MS,
   resolveDaemonCommand as coreResolveDaemonCommand,
   pingDaemon,
+  spawnManaged,
 } from "@mcp-cli/core";
 
 /** Dependencies injectable for testing */
 export interface EnsureDaemonDeps {
   ping: () => Promise<boolean>;
-  spawn: (cmd: string[]) => { stdout: ReadableStream; stderr: ReadableStream; unref: () => void; kill: () => void };
+  spawn: (cmd: string[]) => { stdout: ReadableStream; unref: () => void; kill: () => void };
   resolveCmd: () => string[];
   readySignal: string;
   timeoutMs: number;
@@ -24,8 +25,20 @@ export interface EnsureDaemonDeps {
 
 const defaultDeps: EnsureDaemonDeps = {
   ping: pingDaemon,
-  // dotw-ignore no-raw-spawn: launches the long-lived daemon and retains live handle for unref, kill, and streaming stdout/stderr
-  spawn: (cmd) => Bun.spawn(cmd, { stdout: "pipe", stderr: "pipe" }),
+  spawn: (cmd) => {
+    const [bin, ...args] = cmd;
+    const r = spawnManaged(bin, args, { stdout: "pipe", stderr: "pipe" });
+    if (!r.ok) throw new Error(`Failed to spawn ${bin}`);
+    const stdout = r.handle.stdout;
+    if (!stdout) throw new Error("stdout pipe not available");
+    return {
+      stdout,
+      unref: () => r.handle.unref(),
+      kill: () => {
+        r.handle.kill();
+      },
+    };
+  },
   resolveCmd: () => coreResolveDaemonCommand(import.meta.dir),
   readySignal: DAEMON_READY_SIGNAL,
   timeoutMs: DAEMON_START_TIMEOUT_MS,
@@ -46,30 +59,12 @@ export async function ensureDaemonRunning(deps: Partial<EnsureDaemonDeps> = {}):
     const cmd = resolveCmd();
     const proc = spawn(cmd);
 
-    // Abort controller bounds all reads to the timeout window.
-    // This prevents reader.read() from blocking indefinitely if the
-    // daemon emits partial output then hangs.
     const ac = new AbortController();
     const timer = setTimeout(() => ac.abort(), timeoutMs);
 
-    // Wait for MCPD_READY signal on stdout
     const decoder = new TextDecoder();
     const reader = proc.stdout.getReader();
     let stdout = "";
-
-    // Drain stderr to prevent pipe buffer deadlock.
-    // Attach .catch() so cancellation doesn't produce an unhandled rejection.
-    const stderrReader = proc.stderr.getReader();
-    const drainStderr = (async () => {
-      try {
-        for (;;) {
-          const { done } = await stderrReader.read();
-          if (done) break;
-        }
-      } catch {
-        // Cancelled or aborted — expected on success/timeout paths
-      }
-    })();
 
     try {
       while (!ac.signal.aborted) {
@@ -84,12 +79,9 @@ export async function ensureDaemonRunning(deps: Partial<EnsureDaemonDeps> = {}):
         if (readResult.done) break;
         stdout += decoder.decode(readResult.value, { stream: true });
         if (stdout.includes(readySignal)) {
-          // Detach — let daemon run independently
           clearTimeout(timer);
           proc.unref();
           reader.releaseLock();
-          stderrReader.cancel().catch(() => {});
-          await drainStderr;
           return true;
         }
       }
@@ -97,12 +89,9 @@ export async function ensureDaemonRunning(deps: Partial<EnsureDaemonDeps> = {}):
       // AbortError from timeout — fall through to cleanup
     }
 
-    // Timed out or process exited without ready signal — kill to avoid orphans
     clearTimeout(timer);
     proc.kill();
     reader.releaseLock();
-    stderrReader.cancel().catch(() => {});
-    await drainStderr;
     return await ping();
   } catch {
     return false;

--- a/packages/core/src/subprocess.spec.ts
+++ b/packages/core/src/subprocess.spec.ts
@@ -204,6 +204,20 @@ describe("spawnManaged", () => {
     expect(status.signal).toBeTruthy();
   });
 
+  it("killNow() bypasses grace and SIGKILLs immediately", async () => {
+    const r = spawnManaged("sleep", ["30"]);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+
+    const start = Date.now();
+    r.handle.killNow();
+    const status = await r.handle.exited;
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeLessThan(1_000);
+    expect(status.signal).toBe("SIGKILL");
+  });
+
   it("kill() does not leak the SIGKILL timer into the event loop after exit", async () => {
     // Spawn a bun child that itself calls spawnManaged + kill + await exited,
     // then exits promptly. If the SIGKILL timer is not cleared, the child's

--- a/packages/core/src/subprocess.spec.ts
+++ b/packages/core/src/subprocess.spec.ts
@@ -204,6 +204,27 @@ describe("spawnManaged", () => {
     expect(status.signal).toBeTruthy();
   });
 
+  it("kill() does not leak the SIGKILL timer into the event loop after exit", async () => {
+    // Spawn a bun child that itself calls spawnManaged + kill + await exited,
+    // then exits promptly. If the SIGKILL timer is not cleared, the child's
+    // event loop is held alive for graceMs (5s default) — observable as wall
+    // time of the parent's await.
+    const child = process.execPath;
+    const script = `
+      import { spawnManaged } from "${import.meta.dir.replace(/\\\\/g, "/")}/subprocess";
+      const r = spawnManaged("sleep", ["30"]);
+      if (!r.ok) process.exit(2);
+      // SIGKILL grace 10s — if the timer leaks, this process hangs ~10s after exit.
+      await r.handle.kill(10_000);
+    `;
+    const start = Date.now();
+    const result = await spawnCapture(child, ["-e", script], { timeoutMs: 8_000 });
+    const elapsed = Date.now() - start;
+    expect(result.ok).toBe(true);
+    expect(result.timedOut).toBe(false);
+    expect(elapsed).toBeLessThan(5_000);
+  });
+
   it("reports non-zero exit code honestly", async () => {
     const r = spawnManaged("false", []);
     expect(r.ok).toBe(true);

--- a/packages/core/src/subprocess.spec.ts
+++ b/packages/core/src/subprocess.spec.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "bun:test";
-import { spawnCapture, spawnCaptureSync } from "./subprocess";
+import { spawnCapture, spawnCaptureSync, spawnManaged } from "./subprocess";
+
+const POLL_INTERVAL_MS = 10;
 
 describe("spawnCapture", () => {
   it("captures stdout from a successful command", async () => {
@@ -117,5 +119,140 @@ describe("spawnCaptureSync", () => {
     expect(r.ok).toBe(true);
     expect(r.truncated).toBe(true);
     expect(r.stdout.length).toBeLessThanOrEqual(50);
+  });
+});
+
+describe("spawnManaged", () => {
+  it("spawns a process and reports exit status", async () => {
+    const r = spawnManaged("echo", ["managed"]);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+
+    expect(r.handle.pid).toBeGreaterThan(0);
+    const status = await r.handle.exited;
+    expect(status.exitCode).toBe(0);
+    expect(status.signal).toBeNull();
+  });
+
+  it("returns ok:false for missing binary without throwing", () => {
+    const r = spawnManaged("nonexistent-binary-xyzzy-42", []);
+    expect(r.ok).toBe(false);
+  });
+
+  it("captures stdout as a readable stream", async () => {
+    const r = spawnManaged("echo", ["stream-test"]);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+
+    expect(r.handle.stdout).not.toBeNull();
+    const text = await new Response(r.handle.stdout as ReadableStream).text();
+    expect(text.trim()).toBe("stream-test");
+    await r.handle.exited;
+  });
+
+  it("auto-drains stderr into ring buffer", async () => {
+    const r = spawnManaged("sh", ["-c", "echo err-output >&2"]);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+
+    await r.handle.exited;
+    const deadline = Date.now() + 2000;
+    while (!r.handle.stderrTail().includes("err-output") && Date.now() < deadline) {
+      await Bun.sleep(POLL_INTERVAL_MS);
+    }
+    expect(r.handle.stderrTail()).toContain("err-output");
+  });
+
+  it("calls onStderr callback with chunks", async () => {
+    const chunks: string[] = [];
+    const r = spawnManaged("sh", ["-c", "echo callback-test >&2"], {
+      onStderr: (chunk) => chunks.push(chunk),
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+
+    await r.handle.exited;
+    const deadline = Date.now() + 2000;
+    while (!chunks.join("").includes("callback-test") && Date.now() < deadline) {
+      await Bun.sleep(POLL_INTERVAL_MS);
+    }
+    expect(chunks.join("")).toContain("callback-test");
+  });
+
+  it("truncates stderr ring buffer to stderrMaxBytes", async () => {
+    const r = spawnManaged("sh", ["-c", "dd if=/dev/zero bs=1024 count=128 2>/dev/null | tr '\\0' 'A' >&2"], {
+      stderrMaxBytes: 1024,
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+
+    await r.handle.exited;
+    const deadline = Date.now() + 2000;
+    while (r.handle.stderrTail().length === 0 && Date.now() < deadline) {
+      await Bun.sleep(POLL_INTERVAL_MS);
+    }
+    expect(r.handle.stderrTail().length).toBeLessThanOrEqual(1024);
+  });
+
+  it("kill() sends SIGTERM then SIGKILL after grace period", async () => {
+    const r = spawnManaged("sleep", ["30"]);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+
+    const status = await r.handle.kill(100);
+    expect(status.exitCode).not.toBe(0);
+    expect(status.signal).toBeTruthy();
+  });
+
+  it("reports non-zero exit code honestly", async () => {
+    const r = spawnManaged("false", []);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+
+    const status = await r.handle.exited;
+    expect(status.exitCode).not.toBe(0);
+  });
+
+  it("exposes stdin as a writable sink", async () => {
+    const r = spawnManaged("cat", []);
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+
+    expect(r.handle.stdin).not.toBeNull();
+    const stdin = r.handle.stdin as import("bun").FileSink;
+    stdin.write("hello-stdin\n");
+    await stdin.end();
+
+    const text = await new Response(r.handle.stdout as ReadableStream).text();
+    expect(text.trim()).toBe("hello-stdin");
+    await r.handle.exited;
+  });
+
+  it("respects cwd option", async () => {
+    const r = spawnManaged("pwd", [], { cwd: "/tmp" });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+
+    const text = await new Response(r.handle.stdout as ReadableStream).text();
+    expect(text.trim()).toMatch(/\/tmp/);
+    await r.handle.exited;
+  });
+
+  it("returns null stdin/stdout when configured as ignore", () => {
+    const r = spawnManaged("true", [], { stdin: "ignore", stdout: "ignore" });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+
+    expect(r.handle.stdin).toBeNull();
+    expect(r.handle.stdout).toBeNull();
+  });
+
+  it("stderrTail returns empty string when stderr is inherit", async () => {
+    const r = spawnManaged("true", [], { stderr: "inherit" });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+
+    await r.handle.exited;
+    expect(r.handle.stderrTail()).toBe("");
   });
 });

--- a/packages/core/src/subprocess.ts
+++ b/packages/core/src/subprocess.ts
@@ -39,9 +39,14 @@ export interface ManagedHandle {
   readonly exited: Promise<ManagedExitStatus>;
   /** SIGTERM immediately; SIGKILL after graceMs (default from spawn opts). Returns exit status. */
   kill(graceMs?: number): Promise<ManagedExitStatus>;
+  /**
+   * Force SIGKILL immediately, bypassing SIGTERM and the grace window.
+   * Use for callers that ran their own SIGTERM timeout and need an escape hatch.
+   */
+  killNow(): void;
   /** Detach the child so the parent can exit without waiting. */
   unref(): void;
-  /** Return the last N bytes captured from the auto-drained stderr ring buffer. */
+  /** Return up to stderrMaxBytes captured from the auto-drained stderr ring buffer. */
   stderrTail(): string;
 }
 
@@ -70,24 +75,46 @@ export function spawnManaged(cmd: string, args: string[], opts?: ManagedSpawnOpt
   }
 
   // --- stderr auto-drain ring buffer ---
-  let stderrBuf = "";
+  // Bytes-accurate ring: store raw Uint8Array chunks and trim by total byte
+  // length (not UTF-16 code units). Decode lazily in stderrTail() so the
+  // truncation boundary never silently splits a multibyte char in storage —
+  // any partial codepoint at the front becomes U+FFFD on decode (honest).
+  const stderrChunks: Uint8Array[] = [];
+  let stderrTotalBytes = 0;
   if (stderrMode === "pipe" && proc.stderr && typeof proc.stderr !== "number") {
     const reader = (proc.stderr as ReadableStream<Uint8Array>).getReader();
     const decoder = new TextDecoder();
     const onChunk = opts?.onStderr;
+    const append = (chunk: Uint8Array) => {
+      if (chunk.byteLength === 0) return;
+      stderrChunks.push(chunk);
+      stderrTotalBytes += chunk.byteLength;
+      while (stderrTotalBytes > maxStderr && stderrChunks.length > 0) {
+        const first = stderrChunks[0] as Uint8Array;
+        const excess = stderrTotalBytes - maxStderr;
+        if (excess >= first.byteLength) {
+          stderrChunks.shift();
+          stderrTotalBytes -= first.byteLength;
+        } else {
+          stderrChunks[0] = first.subarray(excess);
+          stderrTotalBytes -= excess;
+        }
+      }
+    };
     (async () => {
       try {
         for (;;) {
           const { done, value } = await reader.read();
           if (done) break;
           const text = decoder.decode(value, { stream: true });
-          onChunk?.(text);
-          stderrBuf += text;
-          if (stderrBuf.length > maxStderr) {
-            stderrBuf = stderrBuf.slice(-maxStderr);
-          }
+          if (text) onChunk?.(text);
+          append(value);
         }
-        stderrBuf += decoder.decode(); // flush
+        // Flush any partial codepoint the streaming decoder was buffering.
+        // Pass it through onStderr too (was previously dropped from the tap),
+        // and the raw bytes are already in `stderrChunks` from the last read.
+        const tail = decoder.decode();
+        if (tail) onChunk?.(tail);
       } catch {
         // stream closed — expected on kill
       }
@@ -136,14 +163,32 @@ export function spawnManaged(cmd: string, args: string[], opts?: ManagedSpawnOpt
       ? (proc.stdout as ReadableStream<Uint8Array>)
       : null;
 
+  const killNow = (): void => {
+    try {
+      proc.kill("SIGKILL");
+    } catch {
+      // already dead
+    }
+  };
+
   const handle: ManagedHandle = {
     pid: proc.pid,
     stdin: stdinSink,
     stdout: stdoutStream,
     exited: exitedPromise,
     kill,
+    killNow,
     unref: () => proc.unref(),
-    stderrTail: () => stderrBuf,
+    stderrTail: () => {
+      if (stderrChunks.length === 0) return "";
+      const total = new Uint8Array(stderrTotalBytes);
+      let off = 0;
+      for (const c of stderrChunks) {
+        total.set(c, off);
+        off += c.byteLength;
+      }
+      return new TextDecoder("utf-8").decode(total);
+    },
   };
 
   return { ok: true, handle };

--- a/packages/core/src/subprocess.ts
+++ b/packages/core/src/subprocess.ts
@@ -101,24 +101,28 @@ export function spawnManaged(cmd: string, args: string[], opts?: ManagedSpawnOpt
   }));
 
   // --- kill with SIGTERM→SIGKILL escalation ---
+  // Clear the SIGKILL timer on exit so a SIGTERM-cooperator doesn't leak a
+  // graceMs-pending timer into the event loop AND doesn't fire SIGKILL at a
+  // recycled PID. exitedPromise.finally is a microtask, so even if exited
+  // already resolved before kill() set the timer, the cleanup wins the race.
   let killed = false;
   const kill = (overrideGraceMs?: number): Promise<ManagedExitStatus> => {
-    if (!killed) {
-      killed = true;
+    if (killed) return exitedPromise;
+    killed = true;
+    try {
+      proc.kill("SIGTERM");
+    } catch {
+      // already dead
+    }
+    const g = overrideGraceMs ?? graceMs;
+    const timer = setTimeout(() => {
       try {
-        proc.kill("SIGTERM");
+        proc.kill("SIGKILL");
       } catch {
         // already dead
       }
-      const g = overrideGraceMs ?? graceMs;
-      setTimeout(() => {
-        try {
-          proc.kill("SIGKILL");
-        } catch {
-          // already dead
-        }
-      }, g);
-    }
+    }, g);
+    exitedPromise.finally(() => clearTimeout(timer));
     return exitedPromise;
   };
 

--- a/packages/core/src/subprocess.ts
+++ b/packages/core/src/subprocess.ts
@@ -8,6 +8,143 @@ export interface SpawnResult {
   truncated: boolean;
 }
 
+// ---------------------------------------------------------------------------
+// spawnManaged — long-lived process helper
+// ---------------------------------------------------------------------------
+
+export interface ManagedSpawnOptions {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  stdin?: "pipe" | "ignore";
+  stdout?: "pipe" | "inherit" | "ignore";
+  stderr?: "pipe" | "inherit" | "ignore";
+  /** Real-time tap on decoded stderr chunks (only when stderr is "pipe"). */
+  onStderr?: (chunk: string) => void;
+  /** Maximum bytes retained in the stderr ring buffer (default 64 KB). */
+  stderrMaxBytes?: number;
+  /** SIGTERM → SIGKILL grace window in ms (default 5 000). */
+  killGraceMs?: number;
+}
+
+export interface ManagedExitStatus {
+  exitCode: number | null;
+  signal: string | null;
+}
+
+export interface ManagedHandle {
+  readonly pid: number;
+  readonly stdin: import("bun").FileSink | null;
+  readonly stdout: ReadableStream<Uint8Array> | null;
+  /** Resolves when the process exits. */
+  readonly exited: Promise<ManagedExitStatus>;
+  /** SIGTERM immediately; SIGKILL after graceMs (default from spawn opts). Returns exit status. */
+  kill(graceMs?: number): Promise<ManagedExitStatus>;
+  /** Detach the child so the parent can exit without waiting. */
+  unref(): void;
+  /** Return the last N bytes captured from the auto-drained stderr ring buffer. */
+  stderrTail(): string;
+}
+
+export type ManagedSpawnResult = { ok: true; handle: ManagedHandle } | { ok: false };
+
+const DEFAULT_STDERR_MAX_BYTES = 64 * 1024; // 64 KB
+
+export function spawnManaged(cmd: string, args: string[], opts?: ManagedSpawnOptions): ManagedSpawnResult {
+  const stderrMode = opts?.stderr ?? "pipe";
+  const stdoutMode = opts?.stdout ?? "pipe";
+  const stdinMode = opts?.stdin ?? "pipe";
+  const graceMs = opts?.killGraceMs ?? SIGKILL_GRACE_MS;
+  const maxStderr = opts?.stderrMaxBytes ?? DEFAULT_STDERR_MAX_BYTES;
+
+  let proc: ReturnType<typeof Bun.spawn>;
+  try {
+    proc = Bun.spawn([cmd, ...args], {
+      cwd: opts?.cwd,
+      env: opts?.env,
+      stdin: stdinMode,
+      stdout: stdoutMode === "ignore" ? "ignore" : stdoutMode === "inherit" ? "inherit" : "pipe",
+      stderr: stderrMode === "ignore" ? "ignore" : stderrMode === "inherit" ? "inherit" : "pipe",
+    });
+  } catch {
+    return { ok: false };
+  }
+
+  // --- stderr auto-drain ring buffer ---
+  let stderrBuf = "";
+  if (stderrMode === "pipe" && proc.stderr && typeof proc.stderr !== "number") {
+    const reader = (proc.stderr as ReadableStream<Uint8Array>).getReader();
+    const decoder = new TextDecoder();
+    const onChunk = opts?.onStderr;
+    (async () => {
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          const text = decoder.decode(value, { stream: true });
+          onChunk?.(text);
+          stderrBuf += text;
+          if (stderrBuf.length > maxStderr) {
+            stderrBuf = stderrBuf.slice(-maxStderr);
+          }
+        }
+        stderrBuf += decoder.decode(); // flush
+      } catch {
+        // stream closed — expected on kill
+      }
+    })();
+  }
+
+  // --- exited promise with honest reporting ---
+  const exitedPromise: Promise<ManagedExitStatus> = proc.exited.then(() => ({
+    exitCode: proc.exitCode ?? null,
+    signal: proc.signalCode ?? null,
+  }));
+
+  // --- kill with SIGTERM→SIGKILL escalation ---
+  let killed = false;
+  const kill = (overrideGraceMs?: number): Promise<ManagedExitStatus> => {
+    if (!killed) {
+      killed = true;
+      try {
+        proc.kill("SIGTERM");
+      } catch {
+        // already dead
+      }
+      const g = overrideGraceMs ?? graceMs;
+      setTimeout(() => {
+        try {
+          proc.kill("SIGKILL");
+        } catch {
+          // already dead
+        }
+      }, g);
+    }
+    return exitedPromise;
+  };
+
+  const stdinSink: import("bun").FileSink | null =
+    stdinMode === "pipe" && proc.stdin && typeof proc.stdin !== "number"
+      ? (proc.stdin as import("bun").FileSink)
+      : null;
+
+  const stdoutStream: ReadableStream<Uint8Array> | null =
+    stdoutMode === "pipe" && proc.stdout && typeof proc.stdout !== "number"
+      ? (proc.stdout as ReadableStream<Uint8Array>)
+      : null;
+
+  const handle: ManagedHandle = {
+    pid: proc.pid,
+    stdin: stdinSink,
+    stdout: stdoutStream,
+    exited: exitedPromise,
+    kill,
+    unref: () => proc.unref(),
+    stderrTail: () => stderrBuf,
+  };
+
+  return { ok: true, handle };
+}
+
 const SIGKILL_GRACE_MS = 5_000;
 const DEFAULT_MAX_BUFFER = 50 * 1024 * 1024; // 50 MB
 

--- a/packages/daemon/src/alias-server.ts
+++ b/packages/daemon/src/alias-server.ts
@@ -12,14 +12,14 @@ import type {
   MonitorAliasMetadata,
   ToolInfo,
 } from "@mcp-cli/core";
-import { ALIAS_SERVER_NAME, bundleAlias, computeSourceHash, formatToolSignature } from "@mcp-cli/core";
+import { ALIAS_SERVER_NAME, bundleAlias, computeSourceHash, formatToolSignature, spawnCapture } from "@mcp-cli/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import type { StateDb } from "./db/state";
-import { safeSetTimeout } from "./safe-timers";
+
 import { workerPath } from "./worker-path";
 
 /** Max concurrent subprocess executions to prevent fork-bomb scenarios. */
@@ -336,46 +336,28 @@ export class AliasServer {
   private async spawnExecutor(stdinPayload: string, timeoutMs: number): Promise<unknown> {
     await this.semaphore.acquire();
     try {
-      // dotw-ignore no-raw-spawn: retains live proc handle — uses proc.stdin.write, proc.kill via killTimeout, and proc.exited
-      const proc = Bun.spawn([process.execPath, this.executorPath], {
-        stdin: "pipe",
-        stdout: "pipe",
-        stderr: "pipe",
+      const result = await spawnCapture(process.execPath, [this.executorPath], {
+        input: stdinPayload,
+        timeoutMs,
       });
 
-      proc.stdin.write(stdinPayload);
-      proc.stdin.end();
-
-      const killTimeout = safeSetTimeout(() => {
-        proc.kill("SIGKILL");
-      }, timeoutMs);
-
-      const [stdout, stderr, exitCode] = await Promise.all([
-        new Response(proc.stdout).text(),
-        new Response(proc.stderr).text(),
-        proc.exited,
-      ]);
-
-      clearTimeout(killTimeout);
-
-      // Surface subprocess warnings (e.g. output validation) even on success
-      if (exitCode === 0 && stderr.trim()) {
-        console.warn(`[alias] executor stderr: ${stderr.trim()}`);
+      if (result.ok && result.stderr.trim()) {
+        console.warn(`[alias] executor stderr: ${result.stderr.trim()}`);
       }
 
-      if (exitCode !== 0) {
-        if (stdout) {
+      if (!result.ok) {
+        if (result.stdout) {
           try {
-            const parsed = JSON.parse(stdout) as { error?: string };
+            const parsed = JSON.parse(result.stdout) as { error?: string };
             if (parsed.error) throw new Error(parsed.error);
           } catch (e) {
             if (!(e instanceof SyntaxError)) throw e;
           }
         }
-        throw new Error(stderr || `Alias executor exited with code ${exitCode}`);
+        throw new Error(result.stderr || `Alias executor exited with code ${result.exitCode}`);
       }
 
-      const parsed = JSON.parse(stdout) as { result: unknown; error?: string };
+      const parsed = JSON.parse(result.stdout) as { result: unknown; error?: string };
       if (parsed.error) throw new Error(parsed.error);
       return parsed.result;
     } finally {

--- a/packages/daemon/src/alias-server.ts
+++ b/packages/daemon/src/alias-server.ts
@@ -354,7 +354,12 @@ export class AliasServer {
             if (!(e instanceof SyntaxError)) throw e;
           }
         }
-        throw new Error(result.stderr || `Alias executor exited with code ${result.exitCode}`);
+        const reason = result.timedOut
+          ? `timed out after ${timeoutMs}ms`
+          : result.signal
+            ? `killed by signal ${result.signal}`
+            : `exit code ${result.exitCode ?? "null"}`;
+        throw new Error(result.stderr || `Alias executor failed: ${reason}`);
       }
 
       const parsed = JSON.parse(result.stdout) as { result: unknown; error?: string };

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -3406,17 +3406,12 @@ describe("stderr drain", () => {
     lastOpts: { cwd?: string };
   } {
     let exitResolve: (code: number) => void = () => {};
-    let stderrController: ReadableStreamDefaultController<Uint8Array> | null = null;
-    const encoder = new TextEncoder();
+    let stderrAccum = "";
     const state = {
       spawn: ((cmd: string[], opts: { cwd?: string }) => {
         state.lastCmd = cmd;
         state.lastOpts = { cwd: opts.cwd };
-        const stderrStream = new ReadableStream<Uint8Array>({
-          start(controller) {
-            stderrController = controller;
-          },
-        });
+        stderrAccum = "";
         return {
           pid: 99999,
           exited: new Promise<number>((r) => {
@@ -3426,12 +3421,14 @@ describe("stderr drain", () => {
             state.killed = true;
             exitResolve(143);
           },
-          stderr: stderrStream,
+          stderrTail: () => stderrAccum,
         };
       }) as SpawnFn,
       exitResolve: (code: number) => exitResolve(code),
-      writeStderr: (text: string) => stderrController?.enqueue(encoder.encode(text)),
-      closeStderr: () => stderrController?.close(),
+      writeStderr: (text: string) => {
+        stderrAccum += text;
+      },
+      closeStderr: () => {},
       killed: false,
       lastCmd: [] as string[],
       lastOpts: {} as { cwd?: string },
@@ -3488,7 +3485,7 @@ describe("stderr drain", () => {
     await pollUntil(() => server?.listSessions().some((s: { state: string }) => s.state === "disconnected"));
   });
 
-  test("stderrLines ring buffer limits to 50 lines", async () => {
+  test("stderrTail content appears in exit log", async () => {
     const errors: string[] = [];
     const capturingLogger = { ...silentLogger, error: (...args: unknown[]) => errors.push(args.join(" ")) };
     const ms = mockSpawnWithStderr();
@@ -3498,8 +3495,7 @@ describe("stderr drain", () => {
     server.prepareSession("ring-buffer-test", { prompt: "Hello" });
     server.spawnClaude("ring-buffer-test");
 
-    // Write 80 lines — only last 50 should be kept
-    for (let i = 0; i < 80; i++) {
+    for (let i = 0; i < 10; i++) {
       ms.writeStderr(`line ${i}\n`);
     }
 
@@ -3507,19 +3503,10 @@ describe("stderr drain", () => {
     ms.exitResolve(1);
     await pollUntil(() => server?.listSessions().some((s: { state: string }) => s.state === "disconnected"));
 
-    // The exit handler logs all buffered stderr lines — verify ring buffer behavior
     const exitLog = errors.find((e) => e.includes("Spawn exited"));
     expect(exitLog).toBeDefined();
-    // Should NOT contain early lines (0-29) — they were evicted
-    expect(exitLog).not.toContain("line 0\n");
-    expect(exitLog).not.toContain("line 29\n");
-    // Should contain the last 50 lines (30-79)
-    expect(exitLog).toContain("line 30");
-    expect(exitLog).toContain("line 79");
-    // Count the lines in the logged suffix (after ": ")
-    const suffix = exitLog?.split(": ").slice(1).join(": ") ?? "";
-    const lineCount = suffix.split("\n").filter((l: string) => l.startsWith("line ")).length;
-    expect(lineCount).toBe(50);
+    expect(exitLog).toContain("line 0");
+    expect(exitLog).toContain("line 9");
   });
 
   test("spawnClaude passes cwd to spawn for hook-created worktrees", async () => {

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -51,6 +51,7 @@ import {
   consoleLogger,
   findGitRoot,
   generateSessionName,
+  spawnManaged,
 } from "@mcp-cli/core";
 import type { ServerWebSocket } from "bun";
 import { killPid } from "../process-util";
@@ -236,6 +237,7 @@ export type SpawnFn = (
   exited: Promise<number>;
   kill: (signal?: number) => void;
   stderr?: ReadableStream<Uint8Array> | null;
+  stderrTail?: () => string;
 };
 
 interface ResultWaiter {
@@ -895,34 +897,17 @@ export class ClaudeWsServer {
       }
     }, this.connectTimeoutMs);
 
-    // Drain stderr immediately to prevent pipe buffer deadlock.
-    // On macOS the pipe buffer is 64KB — if the child writes more than that
-    // without the parent reading, the child blocks on the write syscall.
-    // This is the root cause of #546: hook-created worktrees in complex repos
-    // (git-crypt, large projects) produce enough stderr during Claude startup
-    // to fill the buffer, blocking Claude before it connects via WebSocket.
-    //
-    // Per-process buffer: captured by closure so old drain coroutines can't
-    // contaminate a new process's buffer after clearSession respawns.
-    const procStderrLines: string[] = [];
-    const drainDone = proc.stderr
-      ? drainStderr(proc.stderr, procStderrLines).catch(() => {
-          /* stream closed — expected on process exit */
-        })
-      : Promise.resolve();
+    // stderr is auto-drained by spawnManaged to prevent pipe buffer deadlock
+    // (#546). Use proc.stderrTail() for diagnostics.
 
     // Watch for process exit
     proc.exited.then(async () => {
-      // If a new process has been spawned (e.g. via clearSession), ignore the old one
       if (session.proc !== proc) return;
       session.spawnAlive = false;
       if (session.state.state === "ended") return;
-      // Wait for drain to finish — proc.exited fires when the kernel reaps
-      // the process, but the pipe may still have buffered data.
-      await drainDone;
-      // Re-check after async drain — a clearSession or bye may have run
       if (session.proc !== proc || (session.state.state as string) === "ended") return;
-      const suffix = procStderrLines.length > 0 ? `: ${procStderrLines.join("\n")}` : "";
+      const stderrTail = proc.stderrTail?.() ?? "";
+      const suffix = stderrTail ? `: ${stderrTail}` : "";
       this.logger.error(
         `[_claude] Spawn exited for session ${sessionId} (pid ${proc.pid}, state ${session.state.state}, workCompleted ${session.workCompleted})${suffix}`,
       );
@@ -2498,44 +2483,6 @@ export function readJsonlTranscript(
   }
 }
 
-// ── Stderr drain ──
-
-const MAX_STDERR_LINES = 50;
-
-/**
- * Actively consume a stderr ReadableStream into a ring buffer of lines.
- *
- * CRITICAL: Without this, piped stderr fills the OS pipe buffer (64KB on macOS)
- * and the child process blocks on the next write — deadlocking before it can
- * connect via WebSocket. This is the fix for #546.
- */
-async function drainStderr(stream: ReadableStream<Uint8Array>, lines: string[]): Promise<void> {
-  const reader = stream.getReader();
-  const decoder = new TextDecoder();
-  let partial = "";
-  try {
-    for (;;) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      partial += decoder.decode(value, { stream: true });
-      const parts = partial.split("\n");
-      partial = parts.pop() ?? "";
-      for (const line of parts) {
-        if (line.length === 0) continue;
-        lines.push(line);
-        if (lines.length > MAX_STDERR_LINES) lines.shift();
-      }
-    }
-    // Flush any remaining partial line
-    if (partial.length > 0) {
-      lines.push(partial);
-      if (lines.length > MAX_STDERR_LINES) lines.shift();
-    }
-  } finally {
-    reader.releaseLock();
-  }
-}
-
 // ── Helpers ──
 
 function isAddrInUse(err: unknown): boolean {
@@ -2634,6 +2581,7 @@ function defaultSpawn(
   exited: Promise<number>;
   kill: (signal?: number) => void;
   stderr?: ReadableStream<Uint8Array> | null;
+  stderrTail?: () => string;
 } {
   // Strip CLAUDECODE env var so the spawned claude process doesn't think
   // it's a nested session and refuse to start.
@@ -2646,18 +2594,21 @@ function defaultSpawn(
     env.PWD = opts.cwd;
   }
 
-  // dotw-ignore no-raw-spawn: retains live proc handle — exposes pid, kill, exited, and stderr stream to caller
-  const proc = Bun.spawn(cmd, {
+  const [bin, ...args] = cmd;
+  const r = spawnManaged(bin, args, {
     cwd: opts.cwd,
     env,
-    stdout: opts.stdout === "ignore" ? null : "pipe",
-    stderr: opts.stderr === "ignore" ? null : "pipe",
-    stdin: opts.stdin === "ignore" ? null : "pipe",
+    stdout: opts.stdout ?? "pipe",
+    stderr: opts.stderr ?? "pipe",
+    stdin: opts.stdin ?? "pipe",
   });
+  if (!r.ok) throw new Error(`Failed to spawn ${bin}`);
   return {
-    pid: proc.pid,
-    exited: proc.exited,
-    kill: (signal?: number) => proc.kill(signal),
-    stderr: proc.stderr,
+    pid: r.handle.pid,
+    exited: r.handle.exited.then((s) => (s.exitCode === null ? 1 : s.exitCode)),
+    kill: () => {
+      r.handle.kill();
+    },
+    stderrTail: () => r.handle.stderrTail(),
   };
 }

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -2606,8 +2606,12 @@ function defaultSpawn(
   return {
     pid: r.handle.pid,
     exited: r.handle.exited.then((s) => (s.exitCode === null ? 1 : s.exitCode)),
-    kill: () => {
-      r.handle.kill();
+    kill: (signal?: number) => {
+      // Route signal=9 (SIGKILL) through killNow so callers running their own
+      // SIGTERM-then-SIGKILL timeout (killAndAwaitProc) actually escalate. The
+      // grace-based kill() is one-shot and would silently no-op the SIGKILL.
+      if (signal === 9) r.handle.killNow();
+      else r.handle.kill();
     },
     stderrTail: () => r.handle.stderrTail(),
   };

--- a/packages/daemon/src/monitor-runtime.ts
+++ b/packages/daemon/src/monitor-runtime.ts
@@ -10,9 +10,8 @@
  * #1583
  */
 
-import type { AliasType, Logger, MonitorCategory, MonitorEventInput } from "@mcp-cli/core";
-import { bundleAlias } from "@mcp-cli/core";
-import type { Subprocess } from "bun";
+import type { AliasType, Logger, ManagedHandle, MonitorCategory, MonitorEventInput } from "@mcp-cli/core";
+import { bundleAlias, spawnManaged } from "@mcp-cli/core";
 import type { EventBus } from "./event-bus";
 import { safeSetTimeout } from "./safe-timers";
 import { workerPath } from "./worker-path";
@@ -44,7 +43,7 @@ const VALID_CATEGORIES: ReadonlySet<string> = new Set<MonitorCategory>([
 
 interface RunningMonitor {
   name: string;
-  proc: Subprocess;
+  handle: ManagedHandle;
   crashTimestamps: number[];
   attempt: number;
   restartTimer: ReturnType<typeof setTimeout> | null;
@@ -107,7 +106,7 @@ export class MonitorRuntime {
     if (existing) {
       existing.stopped = true;
       if (existing.restartTimer) clearTimeout(existing.restartTimer);
-      await this.killProc(existing.proc, 5_000);
+      await existing.handle.kill(5_000);
       this.monitors.delete(name);
     }
     const alias = this.getAlias(name);
@@ -126,7 +125,7 @@ export class MonitorRuntime {
     for (const [, mon] of this.monitors) {
       mon.stopped = true;
       if (mon.restartTimer) clearTimeout(mon.restartTimer);
-      stopPromises.push(this.killProc(mon.proc, 5_000));
+      stopPromises.push(mon.handle.kill(5_000).then(() => {}));
     }
     await Promise.allSettled(stopPromises);
     this.monitors.clear();
@@ -149,37 +148,60 @@ export class MonitorRuntime {
     }
 
     const payload = JSON.stringify({ bundledJs, aliasName: alias.name });
-    // dotw-ignore no-raw-spawn: retains live proc handle for streaming stdout/stderr NDJSON and crash detection via watchExit
-    const proc = Bun.spawn([process.execPath, this.executorPath], {
+    const stderrRing: string[] = [];
+    let stderrLineBuf = "";
+    const logger = this.logger;
+    const aliasName = alias.name;
+
+    const result = spawnManaged(process.execPath, [this.executorPath], {
       stdin: "pipe",
       stdout: "pipe",
       stderr: "pipe",
+      onStderr: (chunk) => {
+        stderrLineBuf += chunk;
+        for (let idx = stderrLineBuf.indexOf("\n"); idx !== -1; idx = stderrLineBuf.indexOf("\n")) {
+          const line = stderrLineBuf.slice(0, idx).trim();
+          stderrLineBuf = stderrLineBuf.slice(idx + 1);
+          if (line) {
+            logger.warn(`[monitor:${aliasName}] ${line}`);
+            stderrRing.push(line);
+            if (stderrRing.length > STDERR_RING_SIZE) stderrRing.shift();
+          }
+        }
+      },
     });
 
-    proc.stdin.write(payload);
-    proc.stdin.end();
+    if (!result.ok) {
+      this.logger.error(`[monitor-runtime] Failed to spawn executor for "${alias.name}"`);
+      return false;
+    }
+
+    const { handle } = result;
+    if (handle.stdin) {
+      handle.stdin.write(payload);
+      await handle.stdin.end();
+    }
 
     const mon: RunningMonitor = {
       name: alias.name,
-      proc,
+      handle,
       crashTimestamps: [],
       attempt: 0,
       restartTimer: null,
       stopped: false,
-      stderrRing: [],
+      stderrRing,
       startedAt: Date.now(),
     };
     this.monitors.set(alias.name, mon);
 
     this.readStdout(mon);
-    this.readStderr(mon);
     this.watchExit(mon);
     return true;
   }
 
   private readStdout(mon: RunningMonitor): void {
-    const stdout = mon.proc.stdout;
-    if (!stdout || typeof stdout === "number") return;
+    const stdout = mon.handle.stdout;
+    if (!stdout) return;
     const reader = stdout.getReader();
     const decoder = new TextDecoder();
     let buffer = "";
@@ -246,56 +268,9 @@ export class MonitorRuntime {
     pump();
   }
 
-  private readStderr(mon: RunningMonitor): void {
-    const stderr = mon.proc.stderr;
-    if (!stderr || typeof stderr === "number") return;
-    const reader = stderr.getReader();
-    const decoder = new TextDecoder();
-    let buffer = "";
-
-    const pump = async () => {
-      try {
-        // eslint-disable-next-line no-constant-condition
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          buffer += decoder.decode(value, { stream: true });
-          if (buffer.length > MAX_LINE_BUFFER) {
-            buffer = buffer.slice(-MAX_LINE_BUFFER);
-          }
-
-          for (let newlineIdx = buffer.indexOf("\n"); newlineIdx !== -1; newlineIdx = buffer.indexOf("\n")) {
-            const line = buffer.slice(0, newlineIdx).trim();
-            buffer = buffer.slice(newlineIdx + 1);
-            if (line) {
-              this.logger.warn(`[monitor:${mon.name}] ${line}`);
-              mon.stderrRing.push(line);
-              if (mon.stderrRing.length > STDERR_RING_SIZE) {
-                mon.stderrRing.shift();
-              }
-            }
-          }
-        }
-
-        buffer += decoder.decode();
-        const remaining = buffer.trim();
-        if (remaining) {
-          this.logger.warn(`[monitor:${mon.name}] ${remaining}`);
-          mon.stderrRing.push(remaining);
-          if (mon.stderrRing.length > STDERR_RING_SIZE) {
-            mon.stderrRing.shift();
-          }
-        }
-      } catch {
-        // Reader closed
-      }
-    };
-
-    pump();
-  }
-
   private watchExit(mon: RunningMonitor): void {
-    mon.proc.exited.then((code) => {
+    mon.handle.exited.then((status) => {
+      const code = status.exitCode;
       if (mon.stopped || this.stopped) return;
 
       // Clean exit (code 0) means the generator completed — not a crash.
@@ -361,24 +336,6 @@ export class MonitorRuntime {
         }
       }, delay);
     });
-  }
-
-  private async killProc(proc: Subprocess, timeoutMs: number): Promise<void> {
-    try {
-      proc.kill("SIGTERM");
-    } catch {
-      return;
-    }
-
-    const exited = Promise.race([proc.exited, Bun.sleep(timeoutMs).then(() => "timeout" as const)]);
-    const result = await exited;
-    if (result === "timeout") {
-      try {
-        proc.kill("SIGKILL");
-      } catch {
-        // already dead
-      }
-    }
   }
 }
 

--- a/packages/daemon/src/monitor-runtime.ts
+++ b/packages/daemon/src/monitor-runtime.ts
@@ -49,6 +49,7 @@ interface RunningMonitor {
   restartTimer: ReturnType<typeof setTimeout> | null;
   stopped: boolean;
   stderrRing: string[];
+  flushStderrLine: () => void;
   startedAt: number;
 }
 
@@ -149,24 +150,33 @@ export class MonitorRuntime {
 
     const payload = JSON.stringify({ bundledJs, aliasName: alias.name });
     const stderrRing: string[] = [];
-    let stderrLineBuf = "";
+    const stderrLine = { buf: "" };
     const logger = this.logger;
     const aliasName = alias.name;
+    const emitLine = (line: string): void => {
+      const trimmed = line.trim();
+      if (!trimmed) return;
+      logger.warn(`[monitor:${aliasName}] ${trimmed}`);
+      stderrRing.push(trimmed);
+      if (stderrRing.length > STDERR_RING_SIZE) stderrRing.shift();
+    };
+    const flushStderrLine = (): void => {
+      if (stderrLine.buf) {
+        emitLine(stderrLine.buf);
+        stderrLine.buf = "";
+      }
+    };
 
     const result = spawnManaged(process.execPath, [this.executorPath], {
       stdin: "pipe",
       stdout: "pipe",
       stderr: "pipe",
       onStderr: (chunk) => {
-        stderrLineBuf += chunk;
-        for (let idx = stderrLineBuf.indexOf("\n"); idx !== -1; idx = stderrLineBuf.indexOf("\n")) {
-          const line = stderrLineBuf.slice(0, idx).trim();
-          stderrLineBuf = stderrLineBuf.slice(idx + 1);
-          if (line) {
-            logger.warn(`[monitor:${aliasName}] ${line}`);
-            stderrRing.push(line);
-            if (stderrRing.length > STDERR_RING_SIZE) stderrRing.shift();
-          }
+        stderrLine.buf += chunk;
+        for (let idx = stderrLine.buf.indexOf("\n"); idx !== -1; idx = stderrLine.buf.indexOf("\n")) {
+          const line = stderrLine.buf.slice(0, idx);
+          stderrLine.buf = stderrLine.buf.slice(idx + 1);
+          emitLine(line);
         }
       },
     });
@@ -190,6 +200,7 @@ export class MonitorRuntime {
       restartTimer: null,
       stopped: false,
       stderrRing,
+      flushStderrLine,
       startedAt: Date.now(),
     };
     this.monitors.set(alias.name, mon);
@@ -270,6 +281,9 @@ export class MonitorRuntime {
 
   private watchExit(mon: RunningMonitor): void {
     mon.handle.exited.then((status) => {
+      // Flush any trailing stderr line the child wrote without a newline so
+      // diagnostics aren't silently dropped on a no-EOL crash message.
+      mon.flushStderrLine();
       const code = status.exitCode;
       if (mon.stopped || this.stopped) return;
 

--- a/packages/opencode/src/opencode-process.ts
+++ b/packages/opencode/src/opencode-process.ts
@@ -9,6 +9,8 @@
  * need stdout for URL discovery, then communication moves to HTTP.
  */
 
+import { spawnManaged } from "@mcp-cli/core";
+
 /** Default timeout for URL discovery from stdout (30s). */
 export const URL_DISCOVERY_TIMEOUT_MS = 30_000;
 
@@ -28,6 +30,25 @@ export type SpawnFn = (
   cmd: string[],
   opts: { cwd: string; stdout: "pipe"; stderr: "inherit"; env: Record<string, string | undefined> },
 ) => SpawnResult;
+
+const defaultSpawnFn: SpawnFn = (cmd, o) => {
+  const [bin, ...args] = cmd;
+  const r = spawnManaged(bin, args, {
+    cwd: o.cwd,
+    stdout: o.stdout,
+    stderr: o.stderr,
+    env: o.env,
+  });
+  if (!r.ok) throw new Error(`Failed to spawn ${bin}`);
+  return {
+    pid: r.handle.pid,
+    stdout: r.handle.stdout,
+    exited: r.handle.exited.then((s) => (s.exitCode === null ? undefined : s.exitCode)),
+    kill: () => {
+      r.handle.kill();
+    },
+  };
+};
 
 export interface OpenCodeProcessOptions {
   /** Working directory for the agent process. */
@@ -51,8 +72,7 @@ export class OpenCodeProcess {
 
   constructor(opts: OpenCodeProcessOptions) {
     this.opts = opts;
-    // dotw-ignore no-raw-spawn: long-lived agent subprocess; needs live handle for streaming stdout URL discovery + kill
-    this.spawnFn = opts.spawnFn ?? ((cmd, o) => Bun.spawn(cmd, o));
+    this.spawnFn = opts.spawnFn ?? defaultSpawnFn;
   }
 
   /**

--- a/scripts/rules/no-raw-spawn.rule.ts
+++ b/scripts/rules/no-raw-spawn.rule.ts
@@ -4,11 +4,11 @@ import type { CheckRule } from "./_engine/rule";
 const rule: CheckRule = {
   id: "no-raw-spawn",
   kind: "check",
-  scold: "raw Bun.spawn/spawnSync or exitCode null-coercion — use spawnCapture() from @mcp-cli/core",
+  scold: "raw Bun.spawn/spawnSync or exitCode null-coercion — use spawnCapture/spawnManaged from @mcp-cli/core",
   guidance: [
-    "use spawnCapture / spawnCaptureSync from @mcp-cli/core. The point is to NOT relitigate the spawn corner cases at every call site: raw Bun.spawn THROWS on a missing binary instead of returning, a full stderr pipe can deadlock the child unless drained, a hung child needs timeout → SIGTERM → SIGKILL escalation, output needs a maxBuffer cap, and exitCode is null when the process never ran (so ?? 0 / || 0 silently reports failure as success). The helper solves all of these once; branch on result.ok / result.timedOut.",
-    "if the helper lacks an option you need (env, stdin, cwd, …), EXTEND THE HELPER — adding it once fixes every call site. Re-implementing raw spawn to get one missing option means re-owning every corner case above, for everyone. A missing option is NOT a reason to suppress.",
-    'suppress with // dotw-ignore no-raw-spawn: <reason> ONLY when the spawn is fundamentally not capture-and-wait: a long-lived process whose handle you retain (pid / kill / streaming stdin / incremental stdout), interactive stdio:"inherit" (pager/editor), or fire-and-forget. Capture-and-wait that just needs another option does not qualify.',
+    "use spawnCapture / spawnCaptureSync from @mcp-cli/core for capture-and-wait (run a command, collect output, check result). Use spawnManaged for long-lived processes whose handle you retain (streaming stdin/stdout, kill, exit monitoring). The point is to NOT relitigate the spawn corner cases at every call site: raw Bun.spawn THROWS on a missing binary instead of returning, a full stderr pipe can deadlock the child unless drained, a hung child needs timeout → SIGTERM → SIGKILL escalation, and exitCode is null when the process never ran (so ?? 0 / || 0 silently reports failure as success). Both helpers solve all of these once.",
+    "if either helper lacks an option you need, EXTEND THE HELPER — adding it once fixes every call site. Re-implementing raw spawn to get one missing option means re-owning every corner case above, for everyone. A missing option is NOT a reason to suppress.",
+    'suppress with // dotw-ignore no-raw-spawn: <reason> ONLY when the spawn is fundamentally not capture-and-wait AND not a managed long-lived process: interactive stdio:"inherit" (pager/editor), fire-and-forget (no handle retained), or file-redirect stdout/stderr (Bun.file). If you retain a handle for streaming, kill, or exit monitoring, use spawnManaged instead of suppressing.',
   ],
   documentation: "#2269",
   appliesToTests: false,


### PR DESCRIPTION
## Summary

- Adds `spawnManaged()` to `@mcp-cli/core` — the managed long-lived-process counterpart to `spawnCapture`, finally giving the `no-raw-spawn` rule a real escape hatch instead of an unguarded `// dotw-ignore` GLWT comment.
- Migrates every existing `dotw-ignore no-raw-spawn` long-lived spawn site to the new helper (daemon auto-start, mcpctl daemon recovery, monitor runtime, alias executor, claude/codex/acp/opencode session workers).
- Updates the `no-raw-spawn` rule guidance so future authors know to reach for `spawnManaged` rather than suppress.

### The helper

`spawnManaged(cmd, args, opts)` returns `{ ok: false }` instead of throwing on a missing binary, and on success hands back a `ManagedHandle` that:

- exposes typed `pid`, `stdin` (FileSink | null), `stdout` (ReadableStream | null), `exited` (Promise<ManagedExitStatus>)
- auto-drains stderr into a ring buffer (default 64 KB, configurable) with an optional `onStderr` chunk tap — fixes the deadlock class that bit #546
- offers `kill(graceMs?)` with SIGTERM → SIGKILL escalation
- reports an honest `ManagedExitStatus { exitCode, signal }` so callers can't silently `?? 0` a `null` exit code into "success"
- supports `unref()` for the detach-the-daemon pattern
- exposes `stderrTail()` for post-mortem diagnostics

### Why each consumer benefits

Each migrated site previously re-implemented stderr drain, exit translation, and SIGTERM/SIGKILL escalation independently — between 30 and 60 lines per file. The helper collapses that to a handful of lines against a typed handle and fixes per-site bug classes (forgotten stderr drain, lost null exit code, no SIGKILL fallback) structurally.

### Rule update

`scripts/rules/no-raw-spawn.rule.ts` now documents both helpers and narrows the suppression contract: a retained handle for streaming / kill / exit monitoring means use `spawnManaged`, not a `dotw-ignore`. Suppression is reserved for `stdio: \"inherit\"`, fire-and-forget (no retained handle), and file-redirect spawns.

Closes #2346.

## Test plan

- [x] `bun run am-i-done` green locally (typecheck → lint → rules → tests → coverage)
- [x] New `spawnManaged` test suite in `packages/core/src/subprocess.spec.ts` covers happy path, missing binary, stderr ring/tap/truncation, stdin sink, cwd, ignore stdio, SIGTERM/SIGKILL escalation, and honest non-zero exit reporting
- [x] `ensure-daemon.spec.ts` adds coverage for the default `spawnManaged`-backed `spawn` factory (both ok and `!ok` branches)
- [x] Existing ws-server stderr-drain spec migrated to the new `stderrTail()` surface and still passes