### PR TITLE
fix(rules): address Copilot review findings on 4 unreviewed rule merges

### DIFF
--- a/scripts/rules/cli-surface-registered.rule.ts
+++ b/scripts/rules/cli-surface-registered.rule.ts
@@ -2,6 +2,7 @@ import ts from "typescript";
 
 import type { AstHelper } from "./_engine/ast";
 import { createAstHelper } from "./_engine/ast";
+import type { FileMeta } from "./_engine/file-loader";
 import type { CheckRule, RuleContext } from "./_engine/rule";
 
 const MAIN_REL = "packages/command/src/main.ts";
@@ -144,7 +145,11 @@ function collectParsedFlags(ast: AstHelper): Map<string, { line: number; col: nu
   const result = new Map<string, { line: number; col: number }>();
 
   function addFlag(text: string, node: ts.Node) {
-    if (!text.startsWith("--")) return;
+    // Accept both long (`--foo`) and short (`-h`) flag literals so the two
+    // directions of the check are symmetric — the reverse direction iterates
+    // every KNOWN_FLAGS entry, and excluding short flags here would mean a
+    // KNOWN_FLAGS entry like `-h` could never be matched as "parsed".
+    if (!text.startsWith("-")) return;
     if (HELP_FLAGS.has(text)) return;
     if (result.has(text)) return;
     const pos = ast.positionOf(node);
@@ -219,7 +224,7 @@ function checkSubcommandsToDispatch(ctx: RuleContext): void {
   const entries = extractSubcommandsWithPositions(ctx.ast);
   if (!entries) return;
 
-  let mainMeta: import("./_engine/file-loader").FileMeta | undefined;
+  let mainMeta: FileMeta | undefined;
   for (const meta of ctx.files.values()) {
     if (meta.relPath === MAIN_REL) {
       mainMeta = meta;
@@ -251,6 +256,10 @@ function checkFlagKnownFlags(ctx: RuleContext): void {
   }
 
   for (const { name, line, col } of known.entries) {
+    // Skip help flags in the reverse direction too — they're handled centrally
+    // (not per-command parse) and would otherwise be unmatchable when listed
+    // in a per-command KNOWN_FLAGS for documentation/completion purposes.
+    if (HELP_FLAGS.has(name)) continue;
     if (!parsed.has(name)) {
       ctx.violated(line, col, `KNOWN_FLAGS entry "${name}" not parsed anywhere`);
     }

--- a/scripts/rules/cli-surface-registered.spec.ts
+++ b/scripts/rules/cli-surface-registered.spec.ts
@@ -281,6 +281,42 @@ describe("cli-surface-registered: flag ↔ KNOWN_FLAGS", () => {
     expect(violations).toHaveLength(0);
   });
 
+  it("does not flag -h in KNOWN_FLAGS as unparsed (help-flag symmetry)", () => {
+    const file = makeFile(
+      "packages/command/src/commands/example.ts",
+      `const KNOWN_FLAGS = new Set(["--verbose", "-h"]);
+      if (args[i] === "--verbose") {}
+      if (args[i] === "-h") return;`,
+    );
+    const files = new Map([[file.path, file]]);
+    const violations = evaluateRule(rule, file, files);
+    expect(violations).toHaveLength(0);
+  });
+
+  it("does not flag --help in KNOWN_FLAGS as unparsed (help-flag symmetry)", () => {
+    const file = makeFile(
+      "packages/command/src/commands/example.ts",
+      `const KNOWN_FLAGS = new Set(["--verbose", "--help"]);
+      if (args[i] === "--verbose") {}`,
+    );
+    const files = new Map([[file.path, file]]);
+    const violations = evaluateRule(rule, file, files);
+    expect(violations).toHaveLength(0);
+  });
+
+  it("detects parsed short flags not in KNOWN_FLAGS", () => {
+    const file = makeFile(
+      "packages/command/src/commands/example.ts",
+      `const KNOWN_FLAGS = new Set(["--verbose"]);
+      if (args[i] === "--verbose") {}
+      if (args[i] === "-q") {}`,
+    );
+    const files = new Map([[file.path, file]]);
+    const violations = evaluateRule(rule, file, files);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].snippet).toBe('flag "-q" parsed but not in KNOWN_FLAGS');
+  });
+
   it("does not fire when file has no KNOWN_FLAGS", () => {
     const file = makeFile(
       "packages/command/src/commands/gc.ts",

--- a/scripts/rules/derive-union-from-const.rule.ts
+++ b/scripts/rules/derive-union-from-const.rule.ts
@@ -1,5 +1,8 @@
 import ts from "typescript";
+import type { AstHelper } from "./_engine/ast";
 import type { CheckRule } from "./_engine/rule";
+
+const PACKAGE_SRC_RE = /^packages\/[^/]+\/src\//;
 
 const rule: CheckRule = {
   id: "derive-union-from-const",
@@ -8,14 +11,19 @@ const rule: CheckRule = {
   guidance: [
     'replace `type Foo = "a" | "b" | "c"` with `type Foo = (typeof FOO_VALUES)[number]`',
     "this keeps the runtime array and the type in sync — adding a value to the array automatically extends the type",
+    "only *exported* `as const` arrays are considered the source of truth — non-exported arrays are local helpers",
     "if the union intentionally differs from the array, suppress with `// dotw-ignore derive-union-from-const: <reason>`",
   ],
   documentation: "#2261",
   appliesToTests: false,
   check(ctx) {
+    if (!PACKAGE_SRC_RE.test(ctx.file.relPath)) return;
+
     const { ast } = ctx;
     const constArrays = collectConstArrays(ast);
     if (constArrays.length === 0) return;
+
+    const lines = ctx.file.content.split("\n");
 
     for (const alias of ast.find(ts.isTypeAliasDeclaration)) {
       if (!ts.isUnionTypeNode(alias.type)) continue;
@@ -35,7 +43,7 @@ const rule: CheckRule = {
         }
         if (isSubset) {
           const pos = ast.positionOf(alias);
-          const line = ctx.file.content.split("\n")[pos.line - 1] ?? "";
+          const line = lines[pos.line - 1] ?? "";
           ctx.violated(pos.line, pos.column, line.trim());
           break;
         }
@@ -72,10 +80,21 @@ function isAsConstInitializer(init: ts.Expression, sf: ts.SourceFile): ts.ArrayL
   return undefined;
 }
 
-function collectConstArrays(ast: import("./_engine/ast").AstHelper): ConstArray[] {
+/**
+ * Collect *exported* `const FOO = [...] as const` arrays. Non-exported arrays
+ * are local helpers, not the canonical surface a type alias should derive
+ * from, so they're ignored — matching the rule's documented intent.
+ */
+function collectConstArrays(ast: AstHelper): ConstArray[] {
   const results: ConstArray[] = [];
   for (const decl of ast.find(ts.isVariableDeclaration)) {
     if (!decl.initializer) continue;
+    const declList = decl.parent;
+    if (!ts.isVariableDeclarationList(declList)) continue;
+    const stmt = declList.parent;
+    if (!ts.isVariableStatement(stmt)) continue;
+    const isExported = stmt.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword) ?? false;
+    if (!isExported) continue;
     const arr = isAsConstInitializer(decl.initializer, ast.sourceFile);
     if (!arr) continue;
     const name = ts.isIdentifier(decl.name) ? decl.name.text : "";

--- a/scripts/rules/fixtures/derive-union-from-const__clean.fixture.ts
+++ b/scripts/rules/fixtures/derive-union-from-const__clean.fixture.ts
@@ -9,6 +9,8 @@
  *   3. union with non-string members (mixed)
  *   4. single-member union (below the 2-member threshold)
  *   5. as-const array with no matching union at all
+ *   6. union duplicates a NON-EXPORTED const array — non-exported arrays are
+ *      local helpers, not the canonical source the rule guards
  */
 
 // Shape 1: correctly derived — canonical pattern
@@ -29,3 +31,9 @@ export type Single = "only";
 
 // Shape 5: const array with no type alias duplication
 export const STATUSES = ["pending", "active", "done"] as const;
+
+// Shape 6: NON-EXPORTED const array — must NOT be considered the source.
+// Local helpers are intentionally allowed to coexist with hand-written types
+// without triggering the "derive from array" guidance.
+const internalKinds = ["a", "b", "c"] as const;
+export type LocalKind = "a" | "b" | "c";

--- a/scripts/rules/fixtures/derive-union-from-const__out-of-scope.fixture.ts
+++ b/scripts/rules/fixtures/derive-union-from-const__out-of-scope.fixture.ts
@@ -1,0 +1,12 @@
+/**
+ * @rule derive-union-from-const
+ * @expect 0
+ * @path scripts/example-script.ts
+ *
+ * Files outside `packages/*\/src/` are out of scope. A duplicated union
+ * exactly matching an exported `as const` array would be flagged inside
+ * packages/<name>/src — here it must NOT be, proving the path scope guard.
+ */
+
+export const SCRIPT_MODES = ["dry", "real", "diff"] as const;
+export type ScriptMode = "dry" | "real" | "diff";

--- a/scripts/rules/fixtures/no-raw-path-handling__clean.fixture.ts
+++ b/scripts/rules/fixtures/no-raw-path-handling__clean.fixture.ts
@@ -41,8 +41,29 @@ const normalizedDir = canonicalCwd();
 if (normalizedDir === storedRoot) doSomething();
 
 // process.cwd() as fallback default (not a direct const binding) — not flagged
-const cwd = (args.cwd as string) ?? process.cwd();
+const effectiveCwd = (args.cwd as string) ?? process.cwd();
 
 // const bound to process.cwd() but never compared — not flagged
 const myDir = process.cwd();
 console.log(myDir);
+
+// Detection 3 FP guard: process.cwd() in VALUE position of .set must NOT flag.
+// Only argument 0 (the key) is checked.
+cache.set("some-key", process.cwd());
+indexByName.set(name, process.cwd());
+
+// Detection 4 FP guard: a parameter named `cwd` that shadows the outer
+// `const cwd = canonicalCwd()` (line 21 above) must NOT be flagged when
+// compared. Scope-aware lookup resolves to the parameter, not the outer
+// binding, so the result of the resolution is "not bound to process.cwd()".
+function compareCwd(cwd: string, other: string): boolean {
+  return cwd === other;
+}
+
+// Detection 4 FP guard: a local `const dir` bound to something else, even
+// when the SAME file also has `const dir = process.cwd()` in another scope,
+// must resolve to the local in the inner scope.
+function localShadow(other: string): boolean {
+  const dir = canonicalCwd();
+  return dir === other;
+}

--- a/scripts/rules/fixtures/no-raw-path-handling__clean.fixture.ts
+++ b/scripts/rules/fixtures/no-raw-path-handling__clean.fixture.ts
@@ -67,3 +67,18 @@ function localShadow(other: string): boolean {
   const dir = canonicalCwd();
   return dir === other;
 }
+
+// Detection 4 FP guard: a `const x = process.cwd()` declared inside a nested
+// `if`/`for` block must NOT leak out to outer-scope name lookups. A naive
+// descendant walk of the outer block would find the inner const and falsely
+// flag the outer `dir === other` (the outer `dir` doesn't actually refer to
+// that inner binding by JS lexical scope rules).
+function nestedBlockScopeLeak(other: string): boolean {
+  if (other) {
+    const dir = process.cwd();
+    void dir;
+  }
+  // @ts-expect-error fixture is excluded from typecheck — `dir` is intentionally
+  // a free identifier here to exercise scope-resolution correctness.
+  return dir === other;
+}

--- a/scripts/rules/no-raw-path-handling.rule.ts
+++ b/scripts/rules/no-raw-path-handling.rule.ts
@@ -150,6 +150,18 @@ function lookupName(name: string, from: ts.Node): ts.Declaration | undefined {
       }
     }
 
+    // for-loop bindings (`for (const x = ...; ...)`, `for (const x of ...)`) are
+    // block-scoped to the loop including its body, so check them when ascending
+    // out of the body but before the enclosing function/block scope.
+    if (ts.isForStatement(parent) || ts.isForInStatement(parent) || ts.isForOfStatement(parent)) {
+      const init = parent.initializer;
+      if (init && ts.isVariableDeclarationList(init)) {
+        for (const decl of init.declarations) {
+          if (ts.isIdentifier(decl.name) && decl.name.text === name) return decl;
+        }
+      }
+    }
+
     if (ts.isBlock(parent) || ts.isSourceFile(parent) || ts.isModuleBlock(parent)) {
       const found = findConstDeclInScope(parent, name);
       if (found) return found;
@@ -160,27 +172,23 @@ function lookupName(name: string, from: ts.Node): ts.Declaration | undefined {
   return undefined;
 }
 
-function findConstDeclInScope(scope: ts.Node, name: string): ts.VariableDeclaration | undefined {
-  let found: ts.VariableDeclaration | undefined;
-  function visit(child: ts.Node): void {
-    if (found) return;
-    if (ts.isVariableDeclaration(child) && ts.isIdentifier(child.name) && child.name.text === name) {
-      found = child;
-      return;
+/**
+ * Look up a `const`/`let`/`var` declaration of `name` in the *direct* statement
+ * list of `scope`. Walking all descendants would leak nested-block bindings
+ * (e.g. `if (cond) { const x = ... }`) into outer scopes, violating JS lexical
+ * scope and producing both false positives and false negatives.
+ */
+function findConstDeclInScope(
+  scope: ts.Block | ts.SourceFile | ts.ModuleBlock,
+  name: string,
+): ts.VariableDeclaration | undefined {
+  for (const stmt of scope.statements) {
+    if (!ts.isVariableStatement(stmt)) continue;
+    for (const decl of stmt.declarationList.declarations) {
+      if (ts.isIdentifier(decl.name) && decl.name.text === name) return decl;
     }
-    if (
-      ts.isFunctionDeclaration(child) ||
-      ts.isFunctionExpression(child) ||
-      ts.isArrowFunction(child) ||
-      ts.isMethodDeclaration(child) ||
-      ts.isConstructorDeclaration(child)
-    ) {
-      return;
-    }
-    ts.forEachChild(child, visit);
   }
-  ts.forEachChild(scope, visit);
-  return found;
+  return undefined;
 }
 
 export default rule;

--- a/scripts/rules/no-raw-path-handling.rule.ts
+++ b/scripts/rules/no-raw-path-handling.rule.ts
@@ -12,13 +12,16 @@
  *    going through `resolveRealpath`/`canonicalCwd` — symlinked CWDs
  *    silently fail the comparison.
  *
- * 3. (daemon only) `process.cwd()` passed to Map-like methods (`.get`,
- *    `.set`, `.has`, `.delete`) — raw CWD as a lookup key silently
- *    misses under symlinks.
+ * 3. (daemon only) `process.cwd()` passed as the *key* (first argument)
+ *    to Map-like methods (`.get`, `.set`, `.has`, `.delete`) — raw CWD
+ *    as a lookup key silently misses under symlinks. Only argument 0
+ *    is checked; `.set(key, process.cwd())` (value position) is fine.
  *
  * 4. (daemon only) `const` variable bound to `process.cwd()` then used
  *    in `===`/`!==` comparison — same bug class as Detection 2 but one
- *    step removed.
+ *    step removed. Resolution uses scope-aware name lookup, not raw
+ *    identifier text matching, so parameters/locals that shadow an
+ *    outer const are not falsely flagged.
  */
 
 import ts from "typescript";
@@ -37,7 +40,7 @@ const rule: CheckRule = {
     "replace `a === process.cwd()` with `pathEq(a, canonicalCwd())`",
     'import { pathEq, canonicalCwd } from "@mcp-cli/core" for realpath-normalized comparisons',
     "variable-bound form (`const dir = process.cwd(); dir === x`) is caught — use `canonicalCwd()` at the assignment site",
-    "Map lookups with raw CWD (`cache.get(process.cwd())`) are caught — normalize with `canonicalCwd()` first",
+    "Map lookups with raw CWD as key (`cache.get(process.cwd())`) are caught — normalize with `canonicalCwd()` first",
   ],
   documentation: "#2251",
   appliesToTests: false,
@@ -72,35 +75,30 @@ const rule: CheckRule = {
       violated(pos.line, pos.column, (lines[pos.line - 1] ?? "").trim());
     }
 
-    // Detection 3: process.cwd() as argument to Map-like method calls
+    // Detection 3: process.cwd() as the *key* argument (position 0) to Map-like
+    // method calls. Only position 0 matters — `.set(key, process.cwd())` puts
+    // the cwd in the value position and is not a lookup-key normalization bug.
     for (const call of ast.findByKind(ts.SyntaxKind.CallExpression) as ts.CallExpression[]) {
       if (!ts.isPropertyAccessExpression(call.expression)) continue;
       if (!MAP_METHODS.has(call.expression.name.text)) continue;
-      if (!call.arguments.some((arg) => isProcessCwd(arg))) continue;
+      if (call.arguments.length === 0) continue;
+      if (!isProcessCwd(call.arguments[0])) continue;
       const pos = ast.positionOf(call);
       violated(pos.line, pos.column, (lines[pos.line - 1] ?? "").trim());
     }
 
-    // Detection 4: const variable bound to process.cwd(), then used in === / !==
-    const cwdVarNames = new Set<string>();
-    for (const decl of ast.findByKind(ts.SyntaxKind.VariableDeclaration) as ts.VariableDeclaration[]) {
-      if (!decl.initializer || !isProcessCwd(decl.initializer)) continue;
-      if (!ts.isIdentifier(decl.name)) continue;
-      const declList = decl.parent;
-      if (ts.isVariableDeclarationList(declList) && declList.flags & ts.NodeFlags.Const) {
-        cwdVarNames.add(decl.name.text);
-      }
-    }
-    if (cwdVarNames.size > 0) {
-      for (const bin of ast.findByKind(ts.SyntaxKind.BinaryExpression) as ts.BinaryExpression[]) {
-        const op = bin.operatorToken.kind;
-        if (op !== ts.SyntaxKind.EqualsEqualsEqualsToken && op !== ts.SyntaxKind.ExclamationEqualsEqualsToken) continue;
-        const leftMatch = ts.isIdentifier(bin.left) && cwdVarNames.has(bin.left.text);
-        const rightMatch = ts.isIdentifier(bin.right) && cwdVarNames.has(bin.right.text);
-        if (!leftMatch && !rightMatch) continue;
-        const pos = ast.positionOf(bin);
-        violated(pos.line, pos.column, (lines[pos.line - 1] ?? "").trim());
-      }
+    // Detection 4: identifier compared with === / !== that resolves (by JS
+    // scope rules) to a `const` declaration bound to `process.cwd()`. Walks
+    // up from each comparison identifier through enclosing scopes so a
+    // shadowing parameter or local of the same name is *not* falsely flagged.
+    for (const bin of ast.findByKind(ts.SyntaxKind.BinaryExpression) as ts.BinaryExpression[]) {
+      const op = bin.operatorToken.kind;
+      if (op !== ts.SyntaxKind.EqualsEqualsEqualsToken && op !== ts.SyntaxKind.ExclamationEqualsEqualsToken) continue;
+      const leftHit = ts.isIdentifier(bin.left) && resolvesToCwdConst(bin.left);
+      const rightHit = ts.isIdentifier(bin.right) && resolvesToCwdConst(bin.right);
+      if (!leftHit && !rightHit) continue;
+      const pos = ast.positionOf(bin);
+      violated(pos.line, pos.column, (lines[pos.line - 1] ?? "").trim());
     }
   },
 };
@@ -117,6 +115,72 @@ function isProcessCwd(node: ts.Node): boolean {
     n.expression.expression.text === "process" &&
     n.expression.name.text === "cwd"
   );
+}
+
+/**
+ * Resolve an identifier to the nearest enclosing declaration (parameter or
+ * const variable) using JS scope rules, then report whether it's a `const`
+ * bound to `process.cwd()`. Parameters and shadowing inner locals correctly
+ * short-circuit the walk — they're the binding the identifier refers to, so
+ * the outer `const cwd = process.cwd()` is not consulted.
+ */
+function resolvesToCwdConst(id: ts.Identifier): boolean {
+  const decl = lookupName(id.text, id);
+  if (!decl || !ts.isVariableDeclaration(decl)) return false;
+  const declList = decl.parent;
+  if (!ts.isVariableDeclarationList(declList)) return false;
+  if (!(declList.flags & ts.NodeFlags.Const)) return false;
+  return !!decl.initializer && isProcessCwd(decl.initializer);
+}
+
+function lookupName(name: string, from: ts.Node): ts.Declaration | undefined {
+  let current: ts.Node = from;
+  while (current.parent) {
+    const parent: ts.Node = current.parent;
+
+    if (
+      ts.isFunctionDeclaration(parent) ||
+      ts.isFunctionExpression(parent) ||
+      ts.isArrowFunction(parent) ||
+      ts.isMethodDeclaration(parent) ||
+      ts.isConstructorDeclaration(parent)
+    ) {
+      for (const p of parent.parameters) {
+        if (ts.isIdentifier(p.name) && p.name.text === name) return p;
+      }
+    }
+
+    if (ts.isBlock(parent) || ts.isSourceFile(parent) || ts.isModuleBlock(parent)) {
+      const found = findConstDeclInScope(parent, name);
+      if (found) return found;
+    }
+
+    current = parent;
+  }
+  return undefined;
+}
+
+function findConstDeclInScope(scope: ts.Node, name: string): ts.VariableDeclaration | undefined {
+  let found: ts.VariableDeclaration | undefined;
+  function visit(child: ts.Node): void {
+    if (found) return;
+    if (ts.isVariableDeclaration(child) && ts.isIdentifier(child.name) && child.name.text === name) {
+      found = child;
+      return;
+    }
+    if (
+      ts.isFunctionDeclaration(child) ||
+      ts.isFunctionExpression(child) ||
+      ts.isArrowFunction(child) ||
+      ts.isMethodDeclaration(child) ||
+      ts.isConstructorDeclaration(child)
+    ) {
+      return;
+    }
+    ts.forEachChild(child, visit);
+  }
+  ts.forEachChild(scope, visit);
+  return found;
 }
 
 export default rule;


### PR DESCRIPTION
Closes #2380

Fix-forward for the 4 sprint-63 rule PRs (#2373, #2374, #2376, #2377) that bulk-merged on green CI alone with no review/QA cycle. Copilot flagged substantive latent false-positive risks in each — the gate stayed clean only because the affected patterns hadn't yet appeared in the codebase.

## Per-rule fixes

### `no-raw-path-handling` (was #2374)
- **Detection 3 narrowed to argument position 0.** Was: `process.cwd()` in ANY argument of `.get/.set/.has/.delete` → false-positive on `.set(key, process.cwd())` (value position). Now: only the lookup-key position (argument 0) is checked.
- **Detection 4 uses scope-aware name resolution.** Was: matched comparison identifiers by raw text only → a parameter named `cwd` that shadows an outer `const cwd = process.cwd()` would be falsely flagged. Now: walks up enclosing scopes (parameters → block → function → source file) to find the actual binding the identifier refers to, then checks if THAT binding is a `const` bound to `process.cwd()`.
- **Clean fixture fixed.** Was: declared `const cwd` twice at top-level (invalid TS). Renamed the second one and added FP-fix shape coverage (value-position `process.cwd()` in `.set`, parameter-shadow case, inner-const-shadow case).

### `cli-surface-registered` (was #2377)
- **`collectParsedFlags` now records short flags too.** Was: filtered out non-`--` literals, so `-h` could never appear in the parsed set, but `HELP_FLAGS` includes `-h` AND the reverse direction iterates every `KNOWN_FLAGS` entry → `-h` in `KNOWN_FLAGS` would always fire "not parsed anywhere". Now both `-h` and `--help` are recorded.
- **Reverse check skips `HELP_FLAGS`.** Help flags are handled centrally, not per-command, so they're excluded from BOTH directions for symmetry.
- **Replaced inline `import("./_engine/file-loader").FileMeta`** with a proper top-of-file import.
- Three new spec tests lock in: `-h` in `KNOWN_FLAGS` doesn't false-fire, `--help` in `KNOWN_FLAGS` doesn't false-fire, and parsed short flags missing from `KNOWN_FLAGS` STILL flag.

### `derive-union-from-const` (was #2376)
- **Scope guard.** Was: `check()` ran on every scanned file (scripts/, test/, ...). Now: only fires on `packages/*/src/` files, matching the documented intent. New `__out-of-scope.fixture.ts` proves it.
- **Exported `as const` only.** Was: `collectConstArrays()` collected non-exported arrays too, contradicting the doc comment "exported as-const array". Now: requires the `export` modifier. Non-exported arrays are local helpers, not the canonical source. Clean fixture extended with a non-exported case that must not flag.
- **Perf: hoisted `ctx.file.content.split("\n")`** out of the inner subset-match loop (was being called once per matching alias).

### `check-tool-result-iserror` (was #2373)
Careful review pass — no real defect. Existing fixtures cover the relevant edge cases (wrapper exprs, destructuring, inline access, late guard, optional chain). Known limitations (alias rebinding through a fresh `const`, element-access `result["content"]`, captures into nested closures) are acceptable tradeoffs, not FP risks worth complicating the rule for.

## Test plan
- [x] `bun run am-i-done` green (after re-run; one pre-existing process-identity flake — filed as #2383, unrelated to rules)
- [x] All 63 rule fixtures pass
- [x] 28 cli-surface-registered spec tests pass (3 new)
- [x] Crafted FP cases (in updated clean fixtures) confirm the rule no longer false-fires
- [x] Existing flagged fixtures still hit expected counts (true positives preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)