### PR TITLE
feat(rules): add named-timeouts rule — flag inline literals in timeout/delay positions (fixes #2262)

### DIFF
--- a/packages/acp/src/fake-acp-agent.ts
+++ b/packages/acp/src/fake-acp-agent.ts
@@ -15,6 +15,19 @@
  */
 import { createInterface } from "node:readline";
 
+/** Standard "schedule the next protocol step" delay — long enough for the daemon to observe the prior frame. */
+const STEP_DELAY_MS = 30;
+/** First streamed `session/update` chunk delay — kept tiny so tests don't drag. */
+const STREAM_CHUNK_1_DELAY_MS = 10;
+/** Second streamed `session/update` chunk delay — leaves room between frames. */
+const STREAM_CHUNK_2_DELAY_MS = 20;
+/** Short tail delay before `completePrompt()` / `process.exit()` — final state transition. */
+const SHORT_COMPLETE_DELAY_MS = 50;
+/** Medium tail delay — paired with fs/read/write server-requests so the daemon round-trips before completion. */
+const MED_COMPLETE_DELAY_MS = 100;
+/** Long tail delay — paired with permission / terminal flows that require user-side decisions. */
+const LONG_COMPLETE_DELAY_MS = 200;
+
 const mode = process.argv[2] ?? "simple";
 
 const rl = createInterface({ input: process.stdin, terminal: false });
@@ -78,7 +91,7 @@ function schedulePromptEvents(): void {
   promptDone = false;
 
   if (mode === "simple") {
-    setTimeout(() => completePrompt(), 30);
+    setTimeout(() => completePrompt(), STEP_DELAY_MS);
   } else if (mode === "with-updates") {
     // Stream some session/update chunks then complete
     setTimeout(() => {
@@ -89,7 +102,7 @@ function schedulePromptEvents(): void {
           content: { type: "text", text: "Hello " },
         },
       });
-    }, 10);
+    }, STREAM_CHUNK_1_DELAY_MS);
     setTimeout(() => {
       sendNotification("session/update", {
         sessionId: acpSessionId,
@@ -98,8 +111,8 @@ function schedulePromptEvents(): void {
           content: { type: "text", text: "world!" },
         },
       });
-    }, 20);
-    setTimeout(() => completePrompt(), 50);
+    }, STREAM_CHUNK_2_DELAY_MS);
+    setTimeout(() => completePrompt(), SHORT_COMPLETE_DELAY_MS);
   } else if (mode === "permission") {
     // Send a permission request
     setTimeout(() => {
@@ -115,13 +128,13 @@ function schedulePromptEvents(): void {
         ],
       });
       // Complete after a delay (regardless of permission response)
-      setTimeout(() => completePrompt(), 200);
-    }, 30);
+      setTimeout(() => completePrompt(), LONG_COMPLETE_DELAY_MS);
+    }, STEP_DELAY_MS);
   } else if (mode === "crash-after-prompt") {
     setTimeout(() => {
       completePrompt();
-      setTimeout(() => process.exit(2), 50);
-    }, 30);
+      setTimeout(() => process.exit(2), SHORT_COMPLETE_DELAY_MS);
+    }, STEP_DELAY_MS);
   } else if (mode === "silent") {
     // No events after accepting prompt — process stays alive (for watchdog testing)
   } else if (mode === "fs-write") {
@@ -130,23 +143,23 @@ function schedulePromptEvents(): void {
         path: `${process.cwd()}/acp-test-probe.txt`,
         content: "hello from acp",
       });
-      setTimeout(() => completePrompt(), 100);
-    }, 30);
+      setTimeout(() => completePrompt(), MED_COMPLETE_DELAY_MS);
+    }, STEP_DELAY_MS);
   } else if (mode === "fs-read") {
     setTimeout(() => {
       sendServerRequest("fs-2", "fs/read_text_file", {
         path: `${process.cwd()}/package.json`,
       });
-      setTimeout(() => completePrompt(), 100);
-    }, 30);
+      setTimeout(() => completePrompt(), MED_COMPLETE_DELAY_MS);
+    }, STEP_DELAY_MS);
   } else if (mode === "fs-write-traversal") {
     setTimeout(() => {
       sendServerRequest("fs-3", "fs/write_text_file", {
         path: "/tmp/acp-traversal-probe.txt",
         content: "should be blocked",
       });
-      setTimeout(() => completePrompt(), 100);
-    }, 30);
+      setTimeout(() => completePrompt(), MED_COMPLETE_DELAY_MS);
+    }, STEP_DELAY_MS);
   } else if (mode === "terminal") {
     setTimeout(() => {
       sendServerRequest("term-1", "terminal/create", {
@@ -155,7 +168,7 @@ function schedulePromptEvents(): void {
         cwd: process.cwd(),
       });
       // After terminal/create response, request output and release
-      setTimeout(() => completePrompt(), 200);
-    }, 30);
+      setTimeout(() => completePrompt(), LONG_COMPLETE_DELAY_MS);
+    }, STEP_DELAY_MS);
   }
 }

--- a/packages/codex/src/fake-codex-server.ts
+++ b/packages/codex/src/fake-codex-server.ts
@@ -10,6 +10,13 @@
  */
 import { createInterface } from "node:readline";
 
+/** Standard "schedule the next protocol step" delay — long enough for the daemon to observe the prior frame. */
+const STEP_DELAY_MS = 30;
+/** Tail delay after a server-request (approval) before completing the turn. */
+const POST_APPROVAL_COMPLETE_DELAY_MS = 100;
+/** Tail delay before `process.exit()` in crash-after-turn mode. */
+const CRASH_EXIT_DELAY_MS = 50;
+
 const mode = process.argv[2] ?? "simple";
 
 const rl = createInterface({ input: process.stdin, terminal: false });
@@ -85,20 +92,20 @@ function scheduleEvents(): void {
         })}\n`,
       );
       // Complete the turn regardless of approval response
-      setTimeout(() => sendTurnCompleted(), 100);
-    }, 30);
+      setTimeout(() => sendTurnCompleted(), POST_APPROVAL_COMPLETE_DELAY_MS);
+    }, STEP_DELAY_MS);
   } else if (mode === "crash-after-turn") {
     setTimeout(() => {
       sendTurnCompleted();
-      setTimeout(() => process.exit(2), 50);
-    }, 30);
+      setTimeout(() => process.exit(2), CRASH_EXIT_DELAY_MS);
+    }, STEP_DELAY_MS);
   } else if (mode === "validate-input") {
     // input already validated above — complete like simple
-    setTimeout(() => sendTurnCompleted(), 30);
+    setTimeout(() => sendTurnCompleted(), STEP_DELAY_MS);
   } else if (mode === "silent") {
     // No events after turn/start — process stays alive but silent (for watchdog testing)
   } else {
     // simple
-    setTimeout(() => sendTurnCompleted(), 30);
+    setTimeout(() => sendTurnCompleted(), STEP_DELAY_MS);
   }
 }

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -17,6 +17,7 @@ import { emitMailEvent, pollMailUntil } from "./mail-wait";
 import "../help-claude";
 import {
   DEFAULT_TIMEOUT_MS,
+  GIT_REV_PARSE_TIMEOUT_MS,
   PROMPT_IPC_TIMEOUT_MS,
   WorktreeError,
   buildHookEnv,
@@ -100,7 +101,7 @@ function makeCallTool(provider: AgentProvider): (tool: string, args: Record<stri
 
 function getGitRoot(): string | null {
   try {
-    const result = spawnCaptureSync("git", ["rev-parse", "--git-common-dir"], { timeoutMs: 5000 });
+    const result = spawnCaptureSync("git", ["rev-parse", "--git-common-dir"], { timeoutMs: GIT_REV_PARSE_TIMEOUT_MS });
     if (!result.ok) return null;
     const commonDir = result.stdout.trim();
     if (!commonDir) return null;

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -11,6 +11,7 @@ import "../help-claude";
 import {
   CLAUDE_SERVER_NAME,
   DEFAULT_TIMEOUT_MS,
+  GIT_REV_PARSE_TIMEOUT_MS,
   MAX_TIMEOUT_MS,
   PROMPT_IPC_TIMEOUT_MS,
   WorktreeError,
@@ -50,6 +51,11 @@ import type { MailMessage, QuotaStatusResult, SessionInfo, WorkItem } from "@mcp
 import { emitMailEvent, pollMailUntil } from "./mail-wait";
 
 // ── Dependency injection ──
+
+/** Quick fire-and-fallback IPC probe — return fast if the daemon is slow rather than block `ls`. */
+const QUICK_IPC_PROBE_TIMEOUT_MS = 2_000;
+/** Per-worktree git probe — must finish well inside an interactive `ls` render. */
+const WORKTREE_GIT_PROBE_TIMEOUT_MS = 3_000;
 
 export interface PrStatus {
   number: number;
@@ -160,7 +166,7 @@ export async function defaultGetPrStatus(worktreePath: string): Promise<PrStatus
  */
 function getGitRoot(): string | null {
   try {
-    const result = spawnCaptureSync("git", ["rev-parse", "--git-common-dir"], { timeoutMs: 5000 });
+    const result = spawnCaptureSync("git", ["rev-parse", "--git-common-dir"], { timeoutMs: GIT_REV_PARSE_TIMEOUT_MS });
     if (!result.ok) return null;
     const commonDir = result.stdout.trim();
     if (!commonDir) return null;
@@ -992,7 +998,7 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
   // Fetch sessions and work items in parallel
   const [result, workItems] = await Promise.all([
     d.callTool("claude_session_list", toolArgs),
-    ipcCall("listWorkItems", {}, { timeoutMs: 2000 })
+    ipcCall("listWorkItems", {}, { timeoutMs: QUICK_IPC_PROBE_TIMEOUT_MS })
       .then((r) => r.items)
       .catch((): WorkItem[] => []),
   ]);
@@ -1026,7 +1032,7 @@ async function claudeList(args: string[], d: ClaudeDeps): Promise<void> {
   // Fetch quota status (non-blocking — don't fail ls if quota unavailable)
   let quotaBanner: string | null = null;
   try {
-    const quota = await ipcCall("quotaStatus", undefined, { timeoutMs: 2000 });
+    const quota = await ipcCall("quotaStatus", undefined, { timeoutMs: QUICK_IPC_PROBE_TIMEOUT_MS });
     quotaBanner = formatQuotaBanner(quota);
   } catch {
     // Quota monitoring unavailable — continue without banner
@@ -1136,7 +1142,7 @@ function formatPrStatus(pr: PrStatus | null): string {
 function getWorktreeBranch(worktreePath: string): string | null {
   try {
     const result = spawnCaptureSync("git", ["-C", worktreePath, "rev-parse", "--abbrev-ref", "HEAD"], {
-      timeoutMs: 3000,
+      timeoutMs: WORKTREE_GIT_PROBE_TIMEOUT_MS,
     });
     if (!result.ok) return null;
     const branch = result.stdout.trim();

--- a/packages/command/src/commands/mail.ts
+++ b/packages/command/src/commands/mail.ts
@@ -53,6 +53,9 @@ Options:
   -h, --help        Show this help
 `;
 
+/** Default `mcx mail --wait` timeout — seconds (parsed.timeout is multiplied by 1000 at the call site). */
+const DEFAULT_MAIL_WAIT_TIMEOUT_S = 180;
+
 export interface MailArgs {
   subject: string | undefined;
   headersOnly: boolean;
@@ -138,7 +141,7 @@ export function parseMailArgs(args: string[]): MailArgs {
       replyTo: undefined,
       suppressHeaders: false,
       wait: false,
-      timeout: 180,
+      timeout: DEFAULT_MAIL_WAIT_TIMEOUT_S,
       forRecipient: undefined,
       recipient: undefined,
       from: undefined,
@@ -154,7 +157,7 @@ export function parseMailArgs(args: string[]): MailArgs {
       replyTo: undefined,
       suppressHeaders: false,
       wait: false,
-      timeout: 180,
+      timeout: DEFAULT_MAIL_WAIT_TIMEOUT_S,
       forRecipient: undefined,
       recipient: undefined,
       from: undefined,
@@ -168,7 +171,7 @@ export function parseMailArgs(args: string[]): MailArgs {
   const replyTo = flags["reply-to"] as number | undefined;
   const suppressHeaders = (flags["suppress-headers"] as boolean | undefined) ?? false;
   const wait = (flags.wait as boolean | undefined) ?? false;
-  const timeout = (flags.timeout as number | undefined) ?? 180;
+  const timeout = (flags.timeout as number | undefined) ?? DEFAULT_MAIL_WAIT_TIMEOUT_S;
   const forRecipient = flags.for as string | undefined;
   const from = flags.from as string | undefined;
   const recipient = positionals[0] as string | undefined;
@@ -182,7 +185,7 @@ export function parseMailArgs(args: string[]): MailArgs {
       replyTo: undefined,
       suppressHeaders: false,
       wait: false,
-      timeout: 180,
+      timeout: DEFAULT_MAIL_WAIT_TIMEOUT_S,
       forRecipient: undefined,
       recipient: undefined,
       from: undefined,

--- a/packages/command/src/commands/session-display.ts
+++ b/packages/command/src/commands/session-display.ts
@@ -4,7 +4,7 @@
 
 import { dirname, resolve } from "node:path";
 import type { WorkItem } from "@mcp-cli/core";
-import { spawnCaptureSync } from "@mcp-cli/core";
+import { GIT_REV_PARSE_TIMEOUT_MS, spawnCaptureSync } from "@mcp-cli/core";
 import { c } from "../output";
 
 // ── Transcript walker ──
@@ -413,7 +413,7 @@ export function compactTranscript(entries: TranscriptEntry[], maxResultLen = 100
  */
 export function getGitRepoRoot(): string | null {
   try {
-    const result = spawnCaptureSync("git", ["rev-parse", "--git-common-dir"], { timeoutMs: 5000 });
+    const result = spawnCaptureSync("git", ["rev-parse", "--git-common-dir"], { timeoutMs: GIT_REV_PARSE_TIMEOUT_MS });
     if (!result.ok) return null;
     const commonDir = result.stdout.trim();
     if (!commonDir) return null;

--- a/packages/command/src/commands/vfs.ts
+++ b/packages/command/src/commands/vfs.ts
@@ -46,6 +46,9 @@ export function makeToolCaller(ipc: typeof ipcCall): McpToolCaller {
 const callTool = makeToolCaller(ipcCall);
 const log = (msg: string) => process.stderr.write(`${msg}\n`);
 
+/** Preflight `listTools` probe — server may need a few seconds to spin up and respond. */
+const LIST_TOOLS_PREFLIGHT_TIMEOUT_MS = 10_000;
+
 /** Map provider name → the MCP server name it requires. */
 export const PROVIDER_SERVER: Record<string, string> = {
   confluence: "atlassian",
@@ -81,7 +84,11 @@ export async function preflightCheck(providerName: string, deps: PreflightDeps =
     }
 
     // Verify the server has tools available (i.e., it's connected and responding)
-    const tools = (await ipc("listTools", { server: serverName }, { timeoutMs: 10_000 })) as unknown[];
+    const tools = (await ipc(
+      "listTools",
+      { server: serverName },
+      { timeoutMs: LIST_TOOLS_PREFLIGHT_TIMEOUT_MS },
+    )) as unknown[];
     if (!tools || (Array.isArray(tools) && tools.length === 0)) {
       printError(
         `MCP server "${serverName}" is configured but returned no tools.\n\nThis usually means:\n  - The server failed to start (check: mcx status)\n  - Authentication is needed (check: mcx auth ${serverName})\n  - The server binary is missing or misconfigured\n\nTry restarting: mcx ctl restart ${serverName}`,

--- a/packages/control/src/app.tsx
+++ b/packages/control/src/app.tsx
@@ -36,6 +36,8 @@ import { useUnreadMail } from "./hooks/use-unread-mail";
 const LOG_VIEW_HEIGHT = 20;
 const STATS_VIEW_HEIGHT = 20;
 const TRANSCRIPT_VIEW_HEIGHT = 15;
+const CONFIG_REFRESH_INTERVAL_MS = 10_000;
+const AUTH_STATUS_CLEAR_DELAY_MS = 5_000;
 
 export function App() {
   const { status, error, loading, refresh } = useDaemon({ intervalMs: 2500 });
@@ -217,7 +219,7 @@ export function App() {
         .catch(() => {});
     };
     fetchConfig();
-    const interval = setInterval(fetchConfig, 10_000);
+    const interval = setInterval(fetchConfig, CONFIG_REFRESH_INTERVAL_MS);
     return () => {
       cancelled = true;
       clearInterval(interval);
@@ -333,7 +335,7 @@ export function App() {
   useEffect(() => {
     if (authStatus && authStatus.state !== "pending") {
       if (authTimerRef.current) clearTimeout(authTimerRef.current);
-      authTimerRef.current = setTimeout(() => setAuthStatus(null), 5000);
+      authTimerRef.current = setTimeout(() => setAuthStatus(null), AUTH_STATUS_CLEAR_DELAY_MS);
     }
     return () => {
       if (authTimerRef.current) clearTimeout(authTimerRef.current);

--- a/packages/control/src/components/loading.tsx
+++ b/packages/control/src/components/loading.tsx
@@ -1,13 +1,15 @@
 import { Text } from "ink";
 import React, { useState, useEffect } from "react";
 
+const DOT_ANIMATION_INTERVAL_MS = 400;
+
 export function Loading() {
   const [dots, setDots] = useState(1);
 
   useEffect(() => {
     const id = setInterval(() => {
       setDots((d) => (d % 3) + 1);
-    }, 400);
+    }, DOT_ANIMATION_INTERVAL_MS);
     return () => clearInterval(id);
   }, []);
 

--- a/packages/control/src/hooks/use-transcript.ts
+++ b/packages/control/src/hooks/use-transcript.ts
@@ -5,6 +5,7 @@ import type { TranscriptEntry } from "../components/agent-session-detail";
 import { extractToolText, serverForProvider, toolForProvider } from "./ipc-tool-helpers";
 
 const MAX_ENTRIES = 10;
+const TRANSCRIPT_POLL_INTERVAL_MS = 3_000;
 
 export interface UseTranscriptOptions {
   /** Override ipcCall for testing (dependency injection). */
@@ -55,7 +56,7 @@ export function useTranscript(
     }
 
     poll();
-    const id = setInterval(poll, 3000);
+    const id = setInterval(poll, TRANSCRIPT_POLL_INTERVAL_MS);
     return () => {
       cancelled = true;
       clearInterval(id);

--- a/packages/core/src/claude-patch/patcher.ts
+++ b/packages/core/src/claude-patch/patcher.ts
@@ -30,6 +30,13 @@ import { options } from "../constants";
 import { sha256Hex } from "../manifest-lock";
 import { type PatchStrategy, resolveStrategy } from "./strategies";
 
+/** `<bin> --version` / `codesign -d` probe — should return well under a second; allow slack for cold disk. */
+const VERSION_PROBE_TIMEOUT_MS = 10_000;
+/** `codesign --force` (re-sign) — Mach-O signing on slow disks/CI can take a few seconds. */
+const CODESIGN_RESIGN_TIMEOUT_MS = 30_000;
+/** `which claude` PATH lookup — pure userspace, must be near-instant. */
+const WHICH_PROBE_TIMEOUT_MS = 5_000;
+
 export interface PatcherDeps {
   /** Resolve the version of a claude binary. Default: spawn `<bin> --version`. */
   versionResolver: (binPath: string) => Promise<string>;
@@ -146,7 +153,7 @@ function updateCurrentLink(linkPath: string, target: string): void {
  * Default version resolver: spawn `<binPath> --version`, expect "X.Y.Z (...)" or similar.
  */
 export async function defaultVersionResolver(binPath: string): Promise<string> {
-  const result = spawnSync(binPath, ["--version"], { encoding: "utf-8", timeout: 10_000 });
+  const result = spawnSync(binPath, ["--version"], { encoding: "utf-8", timeout: VERSION_PROBE_TIMEOUT_MS });
   if (result.status !== 0) {
     throw new Error(`${binPath} --version exited ${result.status}: ${result.stderr || result.stdout}`);
   }
@@ -164,7 +171,7 @@ export async function defaultVersionResolver(binPath: string): Promise<string> {
 export async function defaultExtractEntitlements(binPath: string): Promise<string> {
   const result = spawnSync("codesign", ["-d", "--entitlements", ":-", binPath], {
     encoding: "utf-8",
-    timeout: 10_000,
+    timeout: VERSION_PROBE_TIMEOUT_MS,
   });
   // codesign writes the plist to stdout. Empty stdout is acceptable (no entitlements).
   if (result.status !== 0) {
@@ -185,7 +192,7 @@ export async function defaultResignBinary(binPath: string, entitlementsPath: str
   const result = spawnSync(
     "codesign",
     ["--force", "--sign", "-", "--options=runtime", "--entitlements", entitlementsPath, binPath],
-    { encoding: "utf-8", timeout: 30_000 },
+    { encoding: "utf-8", timeout: CODESIGN_RESIGN_TIMEOUT_MS },
   );
   if (result.error) {
     throw new Error(`codesign --force failed: ${result.error.message}`);
@@ -201,7 +208,7 @@ export async function defaultResignBinary(binPath: string, entitlementsPath: str
  * commit the patched copy.
  */
 export async function defaultSmokeTest(binPath: string): Promise<void> {
-  const result = spawnSync(binPath, ["--version"], { encoding: "utf-8", timeout: 10_000 });
+  const result = spawnSync(binPath, ["--version"], { encoding: "utf-8", timeout: VERSION_PROBE_TIMEOUT_MS });
   if (result.status !== 0) {
     throw new Error(`smoke test failed: ${binPath} --version exited ${result.status}`);
   }
@@ -262,7 +269,7 @@ export function resolveSourceClaudePath(configPathOverride?: string): string | n
     );
   }
 
-  const r = spawnSync("which", ["claude"], { encoding: "utf-8", timeout: 5_000 });
+  const r = spawnSync("which", ["claude"], { encoding: "utf-8", timeout: WHICH_PROBE_TIMEOUT_MS });
   if (r.status !== 0) return null;
   const path = (r.stdout || "").trim();
   return path || null;

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -6,6 +6,9 @@ import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { spawnCaptureSync } from "./subprocess";
 
+/** Timeout for `git rev-parse` plumbing probes — should complete in milliseconds on any sane repo. */
+export const GIT_REV_PARSE_TIMEOUT_MS = 5_000;
+
 export interface ExecResult {
   stdout: string;
   exitCode: number;
@@ -141,7 +144,7 @@ export function findGitRoot(cwd: string = process.cwd()): string | null {
   let result: string | null = null;
   try {
     const top = spawnCaptureSync("git", ["-C", cwd, "rev-parse", "--show-toplevel"], {
-      timeoutMs: 5000,
+      timeoutMs: GIT_REV_PARSE_TIMEOUT_MS,
       env,
     });
     if (top.exitCode === 0) {
@@ -151,7 +154,7 @@ export function findGitRoot(cwd: string = process.cwd()): string | null {
         return null;
       }
       const gitDir = spawnCaptureSync("git", ["-C", cwd, "rev-parse", "--git-dir"], {
-        timeoutMs: 5000,
+        timeoutMs: GIT_REV_PARSE_TIMEOUT_MS,
         env,
       });
       if (gitDir.exitCode === 0) {
@@ -161,7 +164,7 @@ export function findGitRoot(cwd: string = process.cwd()): string | null {
         // Only fetch --git-common-dir when we're in a linked worktree.
         if (gitDirStr.includes("/worktrees/")) {
           const commonDir = spawnCaptureSync("git", ["-C", cwd, "rev-parse", "--git-common-dir"], {
-            timeoutMs: 5000,
+            timeoutMs: GIT_REV_PARSE_TIMEOUT_MS,
             env,
           });
           if (commonDir.exitCode === 0) {
@@ -180,7 +183,7 @@ export function findGitRoot(cwd: string = process.cwd()): string | null {
     } else {
       // Bare repo fallback — no working tree, use the common dir directly.
       const common = spawnCaptureSync("git", ["-C", cwd, "rev-parse", "--git-common-dir"], {
-        timeoutMs: 5000,
+        timeoutMs: GIT_REV_PARSE_TIMEOUT_MS,
         env,
       });
       if (common.exitCode === 0) {

--- a/packages/daemon/src/port-holder.ts
+++ b/packages/daemon/src/port-holder.ts
@@ -5,18 +5,26 @@
 
 import { execFile } from "node:child_process";
 
+/** `lsof` port-holder probe — diagnostic only, must not block daemon shutdown. */
+const LSOF_PROBE_TIMEOUT_MS = 2_000;
+
 export function getPortHolder(port: number): Promise<string | null> {
   return new Promise((resolve) => {
-    execFile("lsof", ["-i", `TCP:${port}`, "-sTCP:LISTEN", "-n", "-P"], { timeout: 2000 }, (err, stdout) => {
-      if (err || !stdout) return resolve(null);
-      // Skip header line, parse first result
-      const lines = stdout.trim().split("\n");
-      if (lines.length < 2) return resolve(null);
-      const parts = lines[1].split(/\s+/);
-      const command = parts[0];
-      const pid = parts[1];
-      if (command && pid) return resolve(`${command} (PID ${pid})`);
-      resolve(null);
-    });
+    execFile(
+      "lsof",
+      ["-i", `TCP:${port}`, "-sTCP:LISTEN", "-n", "-P"],
+      { timeout: LSOF_PROBE_TIMEOUT_MS },
+      (err, stdout) => {
+        if (err || !stdout) return resolve(null);
+        // Skip header line, parse first result
+        const lines = stdout.trim().split("\n");
+        if (lines.length < 2) return resolve(null);
+        const parts = lines[1].split(/\s+/);
+        const command = parts[0];
+        const pid = parts[1];
+        if (command && pid) return resolve(`${command} (PID ${pid})`);
+        resolve(null);
+      },
+    );
   });
 }

--- a/packages/daemon/src/tls/self-signed.ts
+++ b/packages/daemon/src/tls/self-signed.ts
@@ -20,6 +20,11 @@ import { chmodSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { options } from "@mcp-cli/core";
 
+/** `openssl version` / `openssl x509 -checkend` probes — pure on-disk work, should be near-instant. */
+const OPENSSL_PROBE_TIMEOUT_MS = 5_000;
+/** Key-pair + cert generation can spend noticeable CPU on RSA 2048 keygen on slow hosts. */
+const OPENSSL_REQ_TIMEOUT_MS = 30_000;
+
 /** Result of a successful certificate ensure call. */
 export interface SelfSignedMaterial {
   cert: string;
@@ -63,7 +68,7 @@ export function certPaths(dir: string): { certPath: string; keyPath: string } {
 
 /** Throws if `openssl` is not on PATH. */
 function assertOpensslAvailable(): void {
-  const r = spawnSync("openssl", ["version"], { encoding: "utf-8", timeout: 5_000 });
+  const r = spawnSync("openssl", ["version"], { encoding: "utf-8", timeout: OPENSSL_PROBE_TIMEOUT_MS });
   if (r.status !== 0) {
     throw new Error(
       "openssl is required for the local WSS listener but was not found on PATH. " +
@@ -81,7 +86,7 @@ export function isCertFresh(certPath: string, renewWithinSeconds: number): boole
   // `openssl x509 -checkend <secs>` exits 0 if cert NOT expiring within that window.
   const r = spawnSync("openssl", ["x509", "-checkend", String(renewWithinSeconds), "-noout", "-in", certPath], {
     encoding: "utf-8",
-    timeout: 5_000,
+    timeout: OPENSSL_PROBE_TIMEOUT_MS,
   });
   return r.status === 0;
 }
@@ -118,7 +123,7 @@ export function generateSelfSignedCert(
     "subjectAltName=IP:::1,IP:127.0.0.1,DNS:localhost",
   ];
 
-  const r = spawnSync("openssl", args, { encoding: "utf-8", timeout: 30_000 });
+  const r = spawnSync("openssl", args, { encoding: "utf-8", timeout: OPENSSL_REQ_TIMEOUT_MS });
   if (r.status !== 0) {
     throw new Error(`openssl req failed: ${r.stderr.trim() || `exit ${r.status}`}`);
   }

--- a/scripts/acp-spike.ts
+++ b/scripts/acp-spike.ts
@@ -24,6 +24,15 @@ import { ClientSideConnection, ndJsonStream } from "@agentclientprotocol/sdk";
 
 // ── Config ──
 
+/** Grace window for an agent process to exit cleanly after stdin closes before SIGTERM. */
+const GRACEFUL_EXIT_TIMEOUT_MS = 3_000;
+/** Second grace window after SIGTERM before falling through to SIGKILL. */
+const SIGTERM_GRACE_MS = 2_000;
+/** How long to let the agent stream tokens before sending session/cancel in the cancel-mid-generation test. */
+const PRE_CANCEL_STREAM_DELAY_MS = 3_000;
+/** Grace window for the SDK-based copilot probe to exit after we end stdin. */
+const SDK_PROBE_EXIT_GRACE_MS = 3_000;
+
 interface Config {
   agent: "copilot" | "gemini";
   tracePath: string;
@@ -243,12 +252,15 @@ class NdjsonTransport {
     }
 
     // Give it a moment to exit gracefully
-    const exited = Promise.race([this.proc.exited, new Promise<null>((r) => setTimeout(() => r(null), 3000))]);
+    const exited = Promise.race([
+      this.proc.exited,
+      new Promise<null>((r) => setTimeout(() => r(null), GRACEFUL_EXIT_TIMEOUT_MS)),
+    ]);
     const code = await exited;
     if (code === null) {
       console.error("[transport] Process did not exit, sending SIGTERM");
       this.proc.kill("SIGTERM");
-      await Promise.race([this.proc.exited, new Promise((r) => setTimeout(r, 2000))]);
+      await Promise.race([this.proc.exited, new Promise((r) => setTimeout(r, SIGTERM_GRACE_MS))]);
     }
   }
 
@@ -546,7 +558,7 @@ async function runSpike(config: Config): Promise<Findings> {
     // Wait 3s to ensure the agent is mid-generation before cancelling.
     // Note: Copilot DOES stream session/update chunks (confirmed via SDK test),
     // but they only appear for text-generation prompts, not tool-use prompts.
-    await new Promise((r) => setTimeout(r, 3000));
+    await new Promise((r) => setTimeout(r, PRE_CANCEL_STREAM_DELAY_MS));
     const cancelSentAt = Date.now();
     const cancelNotif = makeNotification("session/cancel", {
       sessionId: findings.sessionId,
@@ -683,7 +695,7 @@ async function runSpike(config: Config): Promise<Findings> {
       } catch {
         /* ignore */
       }
-      await Promise.race([sdkProc.exited, new Promise((r) => setTimeout(r, 3000))]);
+      await Promise.race([sdkProc.exited, new Promise((r) => setTimeout(r, SDK_PROBE_EXIT_GRACE_MS))]);
     }
     console.error(`[sdk] Notes: ${findings.sdkNotes.split("\n")[0]}`);
   } finally {

--- a/scripts/bun-segfault-repro/worker.ts
+++ b/scripts/bun-segfault-repro/worker.ts
@@ -10,6 +10,9 @@
 
 declare const self: Worker;
 
+/** Aggressive fetch loop — pile up deferred-work tickets so the parent's terminate() races them. */
+const FETCH_LOOP_INTERVAL_MS = 50;
+
 // Start a lightweight HTTP server — creates deferred I/O callbacks in JSC.
 const server = Bun.serve({
   port: 0,
@@ -26,7 +29,7 @@ const interval = setInterval(async () => {
   } catch {
     // Worker may be shutting down; ignore fetch errors.
   }
-}, 50);
+}, FETCH_LOOP_INTERVAL_MS);
 
 self.postMessage({ type: "ready", port: server.port });
 

--- a/scripts/rules/fixtures/named-timeouts__clean.fixture.ts
+++ b/scripts/rules/fixtures/named-timeouts__clean.fixture.ts
@@ -1,0 +1,39 @@
+/**
+ * @rule named-timeouts
+ * @expect 0
+ * @path packages/daemon/src/example-timeouts-clean.ts
+ *
+ * Safe shapes: a named *_MS constant carries the meaning at the call site,
+ * and literal 0 is an explicit "next tick" — both are allowed.
+ */
+
+declare const DEFAULT_TIMEOUT_MS: number;
+declare const DEFAULT_POLL_INTERVAL_MS: number;
+declare const ABORT_TIMEOUT_MS: number;
+declare function fn(): void;
+declare function ipc(method: string, params: unknown, opts: { timeoutMs: number }): Promise<unknown>;
+
+// Named constants — fine.
+setTimeout(fn, DEFAULT_TIMEOUT_MS);
+setInterval(fn, DEFAULT_POLL_INTERVAL_MS);
+AbortSignal.timeout(ABORT_TIMEOUT_MS);
+void ipc("listTools", {}, { timeoutMs: DEFAULT_TIMEOUT_MS });
+
+// Literal 0 — explicit next-tick scheduling, allowed.
+setTimeout(fn, 0);
+setTimeout(() => fn(), 0);
+
+// Bare numeric literals NOT in a timeout context — must not be matched.
+const port = 19275;
+const max = 100;
+const arr = [1, 2, 3];
+const obj = { retries: 3, count: 5000, intervalSeconds: 30 };
+const sliced = arr.slice(0, 2);
+console.log(port, max, sliced, obj);
+
+// `timeout` / `timeoutMs` keys with non-literal values — allowed.
+void ipc("listTools", {}, { timeoutMs: DEFAULT_TIMEOUT_MS + 1_000 });
+
+// Methods named `setTimeout` on unrelated objects, but with named constant — allowed.
+declare const conn: { setTimeout: (ms: number) => void };
+conn.setTimeout(DEFAULT_TIMEOUT_MS);

--- a/scripts/rules/fixtures/named-timeouts__clean.fixture.ts
+++ b/scripts/rules/fixtures/named-timeouts__clean.fixture.ts
@@ -23,6 +23,13 @@ void ipc("listTools", {}, { timeoutMs: DEFAULT_TIMEOUT_MS });
 setTimeout(fn, 0);
 setTimeout(() => fn(), 0);
 
+// Non-decimal zero forms still evaluate to 0 — allowed (counterpart to the
+// flagged-fixture hex/oct/bin cases, where the real value is non-zero).
+setTimeout(fn, 0x0);
+setTimeout(fn, 0o0);
+setTimeout(fn, 0b0);
+setTimeout(fn, 0_000);
+
 // Bare numeric literals NOT in a timeout context — must not be matched.
 const port = 19275;
 const max = 100;

--- a/scripts/rules/fixtures/named-timeouts__flagged.fixture.ts
+++ b/scripts/rules/fixtures/named-timeouts__flagged.fixture.ts
@@ -1,6 +1,6 @@
 /**
  * @rule named-timeouts
- * @expect 8
+ * @expect 11
  * @path packages/daemon/src/example-timeouts-bad.ts
  *
  * Each numeric literal below is a magic number sitting at a timeout/delay
@@ -28,3 +28,11 @@ exec("git status", { timeout: 10_000 });
 
 // Nested `timeoutMs` literal inside a deeper option object.
 void ipc("call", { wrapper: { timeoutMs: 2000 } as unknown }, { timeoutMs: 1_000 });
+
+// Non-decimal forms: hex / octal / binary — each is a real non-zero delay
+// (0x1F4 = 500ms, 0o7720 = 4048ms, 0b1111101000 = 1000ms). `parseFloat`
+// stops at the `x`/`o`/`b` and silently returns 0, which would wrongly
+// exempt these as "next tick". The rule must evaluate the real value.
+setTimeout(fn, 0x1f4);
+AbortSignal.timeout(0o7720);
+void ipc("listTools", {}, { timeoutMs: 0b1111101000 });

--- a/scripts/rules/fixtures/named-timeouts__flagged.fixture.ts
+++ b/scripts/rules/fixtures/named-timeouts__flagged.fixture.ts
@@ -1,0 +1,30 @@
+/**
+ * @rule named-timeouts
+ * @expect 8
+ * @path packages/daemon/src/example-timeouts-bad.ts
+ *
+ * Each numeric literal below is a magic number sitting at a timeout/delay
+ * call site where a named *_MS constant should govern it.
+ */
+
+declare function fn(): void;
+declare function ipc(method: string, params: unknown, opts: { timeoutMs: number }): Promise<unknown>;
+declare function exec(cmd: string, opts: { timeout: number }): void;
+
+// setTimeout / setInterval — numeric literal in the delay position.
+setTimeout(fn, 30000);
+setTimeout(() => fn(), 5_000);
+setInterval(fn, 3000);
+
+// AbortSignal.timeout — sole numeric-literal argument.
+const signal = AbortSignal.timeout(5000);
+void signal;
+
+// `timeoutMs` option-property — numeric literal value.
+void ipc("listTools", {}, { timeoutMs: 5000 });
+
+// `timeout` option-property — numeric literal value (e.g. spawnSync options).
+exec("git status", { timeout: 10_000 });
+
+// Nested `timeoutMs` literal inside a deeper option object.
+void ipc("call", { wrapper: { timeoutMs: 2000 } as unknown }, { timeoutMs: 1_000 });

--- a/scripts/rules/named-timeouts.rule.ts
+++ b/scripts/rules/named-timeouts.rule.ts
@@ -1,0 +1,122 @@
+/**
+ * Rule: named-timeouts
+ *
+ * Flag a numeric literal sitting in a timeout/delay position — where the
+ * magic number drifts from the constant that should govern it and carries
+ * no meaning at the call site (#1938 hardcoded 299000 vs. MAX_TIMEOUT_MS).
+ *
+ * The rule anchors strictly on the call/argument CONTEXT — never on bare
+ * numeric literals elsewhere:
+ *
+ *   - `setTimeout(fn, <literal>)` — 2nd arg
+ *   - `setInterval(fn, <literal>)` — 2nd arg
+ *   - `AbortSignal.timeout(<literal>)` — 1st arg
+ *   - `{ timeout: <literal> }` and `{ timeoutMs: <literal> }` — option-property
+ *
+ * Literal `0` is exempt (legitimate next-tick scheduling).
+ *
+ * Fix: hoist the literal to a `const FOO_MS = 30_000` near the call site,
+ * or reuse an existing `*_MS` constant (DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS,
+ * IPC_REQUEST_TIMEOUT_MS, CONNECT_TIMEOUT_MS, …) where one fits.
+ */
+
+import ts from "typescript";
+import type { CheckRule } from "./_engine/rule";
+
+const TIMER_FN_NAMES = new Set(["setTimeout", "setInterval"]);
+const TIMEOUT_OPT_KEYS = new Set(["timeout", "timeoutMs"]);
+
+/**
+ * Match a NumericLiteral, optionally wrapped in a unary `+`. Excludes `0`
+ * (the next-tick form) and any non-literal expression — variables, member
+ * accesses, arithmetic, and template literals all fall through as "named
+ * enough" because they carry an identifier the reader can chase.
+ */
+function flaggedLiteralValue(node: ts.Expression | undefined): string | undefined {
+  if (!node) return undefined;
+  let inner: ts.Expression = node;
+  if (ts.isPrefixUnaryExpression(inner) && inner.operator === ts.SyntaxKind.PlusToken) {
+    inner = inner.operand;
+  }
+  if (!ts.isNumericLiteral(inner)) return undefined;
+  // `0` and `0.0` etc. — next-tick is always allowed.
+  if (Number.parseFloat(inner.text) === 0) return undefined;
+  return inner.text;
+}
+
+/** True for `AbortSignal.timeout` — keep callee-shape matching tight. */
+function isAbortSignalTimeout(call: ts.CallExpression): boolean {
+  const expr = call.expression;
+  if (!ts.isPropertyAccessExpression(expr)) return false;
+  if (!ts.isIdentifier(expr.expression) || expr.expression.text !== "AbortSignal") return false;
+  return expr.name.text === "timeout";
+}
+
+/** True for a bare `setTimeout(...)` / `setInterval(...)` identifier call (no method form). */
+function timerFunctionName(call: ts.CallExpression): string | undefined {
+  const expr = call.expression;
+  if (!ts.isIdentifier(expr)) return undefined;
+  return TIMER_FN_NAMES.has(expr.text) ? expr.text : undefined;
+}
+
+/** Resolve a PropertyAssignment's key text (handles identifier and string-literal keys). */
+function propertyKeyName(prop: ts.PropertyAssignment): string | undefined {
+  const name = prop.name;
+  if (ts.isIdentifier(name)) return name.text;
+  if (ts.isStringLiteral(name) || ts.isNoSubstitutionTemplateLiteral(name)) return name.text;
+  return undefined;
+}
+
+const rule: CheckRule = {
+  id: "named-timeouts",
+  kind: "check",
+  appliesToTests: false,
+  scold:
+    "timeout/delay is a magic numeric literal — hoist to a named `*_MS` constant so the value carries meaning at the call site and can't drift from related constants",
+  guidance: [
+    "the failure mechanism: an inline number (`setTimeout(fn, 30000)`, `{ timeoutMs: 5000 }`) drifts from the constant that should govern it (#1938 hardcoded 299000 next to MAX_TIMEOUT_MS=299_000) and tells the reader nothing about what the duration means",
+    "fix: hoist to a `const FOO_MS = 30_000` near the call site, or reuse an existing `*_MS` constant where one fits — DEFAULT_TIMEOUT_MS / MAX_TIMEOUT_MS / IPC_REQUEST_TIMEOUT_MS / CONNECT_TIMEOUT_MS / PING_TIMEOUT_MS / DEFAULT_POLL_INTERVAL_MS …",
+    "covers (non-exhaustive): `setTimeout(fn, 30000)`, `setInterval(fn, 3000)`, `AbortSignal.timeout(5000)`, `{ timeout: 10_000 }`, `{ timeoutMs: 5000 }`",
+    "literal `0` is allowed (explicit next-tick); any non-literal (variable, expression, template) is treated as named enough",
+    "for config-driven durations: validate with `z.number()` and thread a named default — keeps the value tunable and self-documenting",
+  ],
+  documentation: "#2262",
+  check({ file, ast, violated }) {
+    const flag = (node: ts.Node): void => {
+      const pos = ast.positionOf(node);
+      const line = file.content.split("\n")[pos.line - 1] ?? "";
+      violated(pos.line, pos.column, line.trim());
+    };
+
+    // Call-site checks: setTimeout / setInterval / AbortSignal.timeout.
+    for (const call of ast.find(ts.isCallExpression)) {
+      const timerName = timerFunctionName(call);
+      if (timerName !== undefined) {
+        // 2nd arg is the delay; if absent we have nothing to flag.
+        const delay = call.arguments[1];
+        if (flaggedLiteralValue(delay) !== undefined && delay !== undefined) {
+          flag(delay);
+        }
+        continue;
+      }
+      if (isAbortSignalTimeout(call)) {
+        const ms = call.arguments[0];
+        if (flaggedLiteralValue(ms) !== undefined && ms !== undefined) {
+          flag(ms);
+        }
+      }
+    }
+
+    // Option-property checks: { timeout: N } and { timeoutMs: N } anywhere.
+    // PropertyAssignment is precise — shorthand assignments (`{ timeoutMs }`)
+    // already carry an identifier, so they're skipped naturally.
+    for (const prop of ast.find(ts.isPropertyAssignment)) {
+      const key = propertyKeyName(prop);
+      if (!key || !TIMEOUT_OPT_KEYS.has(key)) continue;
+      if (flaggedLiteralValue(prop.initializer) === undefined) continue;
+      flag(prop.initializer);
+    }
+  },
+};
+
+export default rule;

--- a/scripts/rules/named-timeouts.rule.ts
+++ b/scripts/rules/named-timeouts.rule.ts
@@ -27,6 +27,16 @@ const TIMER_FN_NAMES = new Set(["setTimeout", "setInterval"]);
 const TIMEOUT_OPT_KEYS = new Set(["timeout", "timeoutMs"]);
 
 /**
+ * Resolve the real numeric value of a `ts.NumericLiteral` text. Strips
+ * numeric separators (`1_000` → `1000`) and uses `Number()` so non-decimal
+ * forms (`0x1F4`, `0o755`, `0b111`) parse to their actual value — unlike
+ * `parseFloat`, which stops at the `x`/`o`/`b`/`_` and silently returns 0.
+ */
+function numericLiteralValue(text: string): number {
+  return Number(text.replace(/_/g, ""));
+}
+
+/**
  * Match a NumericLiteral, optionally wrapped in a unary `+`. Excludes `0`
  * (the next-tick form) and any non-literal expression — variables, member
  * accesses, arithmetic, and template literals all fall through as "named
@@ -39,8 +49,8 @@ function flaggedLiteralValue(node: ts.Expression | undefined): string | undefine
     inner = inner.operand;
   }
   if (!ts.isNumericLiteral(inner)) return undefined;
-  // `0` and `0.0` etc. — next-tick is always allowed.
-  if (Number.parseFloat(inner.text) === 0) return undefined;
+  // `0`, `0.0`, `0x0`, `0_000`, etc. — next-tick is always allowed.
+  if (numericLiteralValue(inner.text) === 0) return undefined;
   return inner.text;
 }
 

--- a/scripts/test-failure-log.ts
+++ b/scripts/test-failure-log.ts
@@ -18,6 +18,9 @@ import { dirname } from "node:path";
 /** Max entries before pruning oldest on write */
 const MAX_ENTRIES = 10_000;
 
+/** `git rev-parse` plumbing probe — diagnostic context only, must not stall test logging. */
+const GIT_REV_PARSE_TIMEOUT_MS = 5_000;
+
 export interface TestFailureEntry {
   timestamp: string;
   file: string;
@@ -97,13 +100,19 @@ export function getGitContext(): { worktree: string; branch: string; pr: number 
   let pr: number | null = null;
 
   try {
-    branch = execSync("git rev-parse --abbrev-ref HEAD", { encoding: "utf-8", timeout: 5000 }).trim();
+    branch = execSync("git rev-parse --abbrev-ref HEAD", {
+      encoding: "utf-8",
+      timeout: GIT_REV_PARSE_TIMEOUT_MS,
+    }).trim();
   } catch {
     // not in a git repo or timeout
   }
 
   try {
-    const toplevel = execSync("git rev-parse --show-toplevel", { encoding: "utf-8", timeout: 5000 }).trim();
+    const toplevel = execSync("git rev-parse --show-toplevel", {
+      encoding: "utf-8",
+      timeout: GIT_REV_PARSE_TIMEOUT_MS,
+    }).trim();
     const dirName = toplevel.split("/").pop() ?? "main";
     // Worktrees live in .claude/worktrees/<name>
     if (toplevel.includes(".claude/worktrees/")) {

--- a/test/mock-claude.ts
+++ b/test/mock-claude.ts
@@ -7,6 +7,9 @@
  * Used to exercise the full daemon dispatch path without a real claude binary.
  */
 
+/** Settle delay after sending the result message so the daemon observes the frame before close. */
+const POST_RESULT_CLOSE_DELAY_MS = 200;
+
 const args = process.argv.slice(2);
 
 // Handle --version probes from the daemon's binary-resolver (#1808/#1835).
@@ -103,7 +106,7 @@ async function run(): Promise<void> {
               session_id: sessionId,
             }),
           );
-          setTimeout(() => ws.close(), 200);
+          setTimeout(() => ws.close(), POST_RESULT_CLOSE_DELAY_MS);
         }
       }
     };


### PR DESCRIPTION
## Summary

- New architectural rule **`named-timeouts`** flags a numeric literal sitting in a timeout/delay position — where the magic number drifts from the constant that should govern it (per #1938's `299000` next to `MAX_TIMEOUT_MS = 299_000`) and carries no meaning at the call site.
- Anchors strictly on call/argument context — `setTimeout` / `setInterval` 2nd-arg, `AbortSignal.timeout` 1st-arg, and `{ timeout | timeoutMs: <literal> }` object-property — so unrelated numeric literals (ports, counts, sizes) are never matched. Literal `0` is exempt (explicit next-tick). Non-literals (variables, expressions, templates) are treated as named enough.
- Remediated all **54 sites** the rule surfaced on first sweep across `packages/{core,daemon,command,control,acp,codex}`, `scripts/`, and `test/mock-claude.ts`. Each magic number became a named `*_MS` constant near the call site, named for what the duration *governs* rather than just its numeric value.
- Hoisted the new `GIT_REV_PARSE_TIMEOUT_MS = 5_000` into `packages/core/src/git.ts` and reused it from the three `command/` sites that all run `git rev-parse --git-common-dir` with the same 5s budget. Fake-agent scaffolding (`fake-acp-agent`, `fake-codex-server`) collapsed to a small bucket of named step / completion delays instead of 22 bare literals.

Closes #2262.

## Rule shape

Fixtures (per `@rule <id> expects N violation(s)`):
- `named-timeouts__clean.fixture.ts` — `@expect 0`. Covers `setTimeout(fn, DEFAULT_TIMEOUT_MS)`, `setTimeout(fn, 0)`, `setInterval(fn, DEFAULT_POLL_INTERVAL_MS)`, `AbortSignal.timeout(ABORT_TIMEOUT_MS)`, `{ timeoutMs: DEFAULT_TIMEOUT_MS + 1_000 }`, and bare unrelated literals (ports, array slices, counts) that must NOT match.
- `named-timeouts__flagged.fixture.ts` — `@expect 11`. Covers `setTimeout(fn, 30000)`, `setInterval(fn, 3000)`, `AbortSignal.timeout(5000)`, `{ timeout: 10_000 }`, `{ timeoutMs: 5000 }`, plus nested option-objects.

Guidance text names the failure mechanism (magic number drifts from governing constant and carries no meaning at the call site) and gives non-exhaustive examples + the "literal `0` is allowed" carve-out + a config-driven default hint (`z.number()` + named default).

## Test plan

- [x] `bun test scripts/rules/fixtures.spec.ts` — all 65 fixture cases pass (clean = 0, flagged = 11).
- [x] `bun run doing-it-wrong --rule named-timeouts --all` — `✨ no rule violations`.
- [x] `bun run am-i-done` — full gate green (typecheck, lint, all rules, tests, coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
