### PR TITLE
fix(test): replace wall-clock flush with deadline-poll in use-agent-sessions (fixes #2253)

### DIFF
--- a/packages/control/src/hooks/use-agent-sessions.spec.ts
+++ b/packages/control/src/hooks/use-agent-sessions.spec.ts
@@ -7,6 +7,11 @@ import { type UseAgentSessionsOptions, useAgentSessions } from "./use-agent-sess
 
 /* ---------- helpers ---------- */
 
+/** Backoff between poll-loop retries (acceptable per test guidelines — retry sleep inside a deadline loop). */
+const RETRY_SLEEP_MS = 10;
+/** Negative-assertion window: long enough to catch a rogue timer firing (acceptable per test guidelines — negative assertion sleep). */
+const NEG_ASSERT_SLEEP_MS = 100;
+
 /** Minimal AgentSessionInfo fixture */
 function session(id: string, provider: "claude" | "codex" = "claude"): AgentSessionInfo {
   return {
@@ -157,8 +162,11 @@ describe("useAgentSessions", () => {
       ipcCallFn: ipcCallFn as UseAgentSessionsOptions["ipcCallFn"],
     });
 
-    await flush(150);
-    // Each poll calls 2 providers, so callCount should be at least 6
+    // Poll until 6 calls arrive (3 cycles × 2 providers) instead of relying on wall-clock budget.
+    const deadline = Date.now() + 5000;
+    while (callCount < 6 && Date.now() < deadline) {
+      await Bun.sleep(RETRY_SLEEP_MS);
+    }
     expect(callCount).toBeGreaterThanOrEqual(6);
   });
 
@@ -174,12 +182,18 @@ describe("useAgentSessions", () => {
       ipcCallFn: ipcCallFn as UseAgentSessionsOptions["ipcCallFn"],
     });
 
-    await flush(50);
+    // Wait for at least one poll cycle before unmounting.
+    const deadline = Date.now() + 5000;
+    while (callCount < 2 && Date.now() < deadline) {
+      await Bun.sleep(RETRY_SLEEP_MS);
+    }
+
     instance.unmount();
     instances.pop();
     const countAtUnmount = callCount;
 
-    await flush(100);
+    // Negative assertion: verify polling has stopped (standalone sleep is acceptable here).
+    await Bun.sleep(NEG_ASSERT_SLEEP_MS);
     expect(callCount).toBe(countAtUnmount);
   });
 });

--- a/packages/control/src/hooks/use-agent-sessions.spec.ts
+++ b/packages/control/src/hooks/use-agent-sessions.spec.ts
@@ -187,6 +187,9 @@ describe("useAgentSessions", () => {
     while (callCount < 2 && Date.now() < deadline) {
       await Bun.sleep(RETRY_SLEEP_MS);
     }
+    // Guard: if the deadline elapsed without reaching the target, the subsequent
+    // "count stayed the same" assertion would vacuously pass. Fail loudly instead.
+    expect(callCount).toBeGreaterThanOrEqual(2);
 
     instance.unmount();
     instances.pop();


### PR DESCRIPTION
## Summary
- Replace `await flush(150)` in the \"polls repeatedly\" test with a deadline-based poll loop that exits as soon as `callCount >= 6`; eliminates the wall-clock dependency that caused flaky failures under full-suite load
- Apply the same pattern to the \"cleanup clears interval\" test setup phase (was `flush(50)`)
- Extract magic sleep values to named constants (`RETRY_SLEEP_MS`, `NEG_ASSERT_SLEEP_MS`) to satisfy the `test-timeouts` architecture rule

## Test plan
- [x] `bun test packages/control/src/hooks/use-agent-sessions.spec.ts` — all 6 tests pass in isolation
- [x] `bun run am-i-done` — all 7 steps clean (typecheck, lint, rules, tests, coverage)
- [x] Pre-push gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)