### PR TITLE
fix(test): pass --no-orphans to all bun test invocations (fixes #2394)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
         if: needs.detect.outputs.docs_only != 'true'
         run: |
           set +e
-          unbuffer bun test packages/command/src/commands/claude.spec.ts packages/control/src/components/metrics-panel.spec.ts 2>&1 | tee /tmp/test_pty.txt
+          unbuffer bun test --no-orphans packages/command/src/commands/claude.spec.ts packages/control/src/components/metrics-panel.spec.ts 2>&1 | tee /tmp/test_pty.txt
           code=${PIPESTATUS[0]}
           if [ $code -eq 0 ]; then
             exit 0

--- a/.github/workflows/macos-matrix.yml
+++ b/.github/workflows/macos-matrix.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Test (non-daemon)
         run: |
           set +e
-          bun test packages/acp packages/clone packages/codex packages/command packages/control packages/core packages/opencode packages/permissions test/integration.spec.ts 2>&1 | tee /tmp/test_non_daemon.txt
+          bun test --no-orphans packages/acp packages/clone packages/codex packages/command packages/control packages/core packages/opencode packages/permissions test/integration.spec.ts 2>&1 | tee /tmp/test_non_daemon.txt
           code=${PIPESTATUS[0]}
           if [ $code -eq 0 ]; then
             exit 0
@@ -40,7 +40,7 @@ jobs:
       - name: Test (daemon)
         run: |
           set +e
-          bun test packages/daemon test/cli-orchestration.spec.ts test/daemon-integration.spec.ts test/stress.spec.ts test/transport-errors.spec.ts 2>&1 | tee /tmp/test_daemon.txt
+          bun test --no-orphans packages/daemon test/cli-orchestration.spec.ts test/daemon-integration.spec.ts test/stress.spec.ts test/transport-errors.spec.ts 2>&1 | tee /tmp/test_daemon.txt
           code=${PIPESTATUS[0]}
           if [ $code -eq 0 ]; then
             exit 0
@@ -49,7 +49,7 @@ jobs:
             exit 0
           elif [ $code -eq 132 ]; then
             echo "::warning::Bun segfault (exit 132) — retrying once (see #1004)"
-            bun test packages/daemon test/cli-orchestration.spec.ts test/daemon-integration.spec.ts test/stress.spec.ts test/transport-errors.spec.ts 2>&1 | tee /tmp/test_daemon_retry.txt
+            bun test --no-orphans packages/daemon test/cli-orchestration.spec.ts test/daemon-integration.spec.ts test/stress.spec.ts test/transport-errors.spec.ts 2>&1 | tee /tmp/test_daemon_retry.txt
             code2=${PIPESTATUS[0]}
             if [ $code2 -eq 0 ] || grep -q "^ 0 fail$" /tmp/test_daemon_retry.txt; then
               exit 0

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint:check": "bun install && bunx biome check .",
     "am-i-done": "bun scripts/am-i-done.ts",
     "doing-it-wrong": "bun scripts/doing-it-wrong.ts",
-    "test": "bun install && bun test --parallel --path-ignore-patterns='packages/control/**' && bun test packages/control",
+    "test": "bun install && bun test --parallel --no-orphans --path-ignore-patterns='packages/control/**' && bun test --no-orphans packages/control",
     "test:phases": "cd .claude/phases && bun test",
     "test:coverage": "bun scripts/check-coverage.ts",
     "dev:daemon": "bun packages/daemon/src/main.ts",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "am-i-done": "bun scripts/am-i-done.ts",
     "doing-it-wrong": "bun scripts/doing-it-wrong.ts",
     "test": "bun install && bun test --parallel --no-orphans --path-ignore-patterns='packages/control/**' && bun test --no-orphans packages/control",
-    "test:phases": "cd .claude/phases && bun test",
+    "test:phases": "cd .claude/phases && bun test --no-orphans",
     "test:coverage": "bun scripts/check-coverage.ts",
     "dev:daemon": "bun packages/daemon/src/main.ts",
     "dev:mcx": "bun packages/command/src/main.ts",

--- a/scripts/_runner/ci-steps.ts
+++ b/scripts/_runner/ci-steps.ts
@@ -94,7 +94,7 @@ interface TestOpts {
 
 export function bunTestWithCrashTolerance(opts: TestOpts): ScriptFunction {
   return async ({ logger, env }) => {
-    const args = ["test", ...opts.paths];
+    const args = ["test", "--no-orphans", ...opts.paths];
 
     const first = await runBun(args, logger, env);
     persistLog(opts.logName, first.output);
@@ -196,7 +196,14 @@ export function changedTestsStep(opts: ChangedTestsOpts): ScriptFunction {
     // Safe subset, parallel. control excluded (yoga-layout TDZ under --parallel, #2362).
     // --pass-with-no-tests: a diff that touches no test-reachable code is a pass, not an error.
     const main = await runBun(
-      ["test", `--changed=${base}`, "--parallel", "--path-ignore-patterns=packages/control/**", "--pass-with-no-tests"],
+      [
+        "test",
+        "--no-orphans",
+        `--changed=${base}`,
+        "--parallel",
+        "--path-ignore-patterns=packages/control/**",
+        "--pass-with-no-tests",
+      ],
       logger,
       env,
     );
@@ -206,7 +213,7 @@ export function changedTestsStep(opts: ChangedTestsOpts): ScriptFunction {
 
     // control specs (sequential — yoga TDZ). Fast no-op when none changed.
     const control = await runBun(
-      ["test", `--changed=${base}`, "packages/control", "--pass-with-no-tests"],
+      ["test", "--no-orphans", `--changed=${base}`, "packages/control", "--pass-with-no-tests"],
       logger,
       env,
     );

--- a/scripts/am-i-done.ts
+++ b/scripts/am-i-done.ts
@@ -90,13 +90,13 @@ const RULES: Step = {
 const TEST_PARALLEL: Step = {
   name: "test-parallel",
   description: "bun test --parallel (excluding packages/control — yoga-layout TDZ, #2362)",
-  command: "bun test --parallel --path-ignore-patterns=packages/control/**",
+  command: "bun test --parallel --no-orphans --path-ignore-patterns=packages/control/**",
 };
 
 const TEST_CONTROL: Step = {
   name: "test-control",
   description: "bun test packages/control (sequential — yoga-layout TDZ workaround #2362)",
-  command: "bun test packages/control",
+  command: "bun test --no-orphans packages/control",
 };
 
 const COVERAGE: Step = {

--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -131,7 +131,7 @@ import { findChangedFiles, findTestFiles, loadTimings, pruneStaleEntries, saveTi
 /** Run a single test file and return its wall-clock duration in ms */
 async function timeTestFile(file: string): Promise<{ file: string; ms: number }> {
   const start = performance.now();
-  const p = Bun.spawn(["bun", "test", file, "--timeout", "30000"], {
+  const p = Bun.spawn(["bun", "test", "--no-orphans", file, "--timeout", "30000"], {
     stdout: "ignore",
     stderr: "ignore",
   });
@@ -227,7 +227,7 @@ const testStart = Date.now();
 // 35 files falsely flagged below the 80% per-file floor. The dev `bun test`
 // command uses --parallel for speed (no --coverage there), and this script
 // stays sequential for accurate coverage aggregation.
-const proc1 = Bun.spawn(["bun", "test", "--coverage", ...nonDaemonPaths], {
+const proc1 = Bun.spawn(["bun", "test", "--no-orphans", "--coverage", ...nonDaemonPaths], {
   stdout: "pipe",
   stderr: "pipe",
 });
@@ -255,7 +255,7 @@ if (skipRun2) {
   // Run 2: daemon tests. --parallel is safe here because no --coverage flag,
   // and ws-server's port-retry tax has been reduced (see ws-server.ts).
   const proc2 = Bun.spawn(
-    ["bun", "test", "--parallel", "--timeout", "60000", "packages/daemon/src", ...daemonTestFiles],
+    ["bun", "test", "--no-orphans", "--parallel", "--timeout", "60000", "packages/daemon/src", ...daemonTestFiles],
     {
       stdout: "pipe",
       stderr: "pipe",

--- a/scripts/test-timing.ts
+++ b/scripts/test-timing.ts
@@ -108,7 +108,7 @@ async function discoverSpecFiles(): Promise<string[]> {
 
 async function timeTestFile(file: string, timeoutSec: number): Promise<RunResult> {
   const start = Bun.nanoseconds();
-  const proc = Bun.spawn(["bun", "test", file], {
+  const proc = Bun.spawn(["bun", "test", "--no-orphans", file], {
     stdout: "ignore",
     stderr: "ignore",
   });


### PR DESCRIPTION
## Summary
- Adds `--no-orphans` to every `bun test` invocation across the codebase: `package.json`, `am-i-done.ts`, `ci-steps.ts`, `check-coverage.ts`, `test-timing.ts`, and both CI workflow files (`ci.yml`, `macos-matrix.yml`)
- When the parent `bun test` process dies abnormally (killed, crash, hang), `--no-orphans` tells Bun to auto-exit and SIGKILL every descendant — preventing `--test-worker` children and spawned fixture processes (echo-server, etc.) from reparenting to PID 1 and accumulating as orphans
- No behavioral change during normal test runs — the flag only activates on abnormal parent exit

## Test plan
- [x] `bun run am-i-done` passes (typecheck, lint, rules, tests, coverage)
- [x] Pre-commit hook passes
- [x] Pre-push hook passes
- [x] Verified `--no-orphans` is a valid Bun flag (`bun test --help`)
- [x] Grep confirms zero `bun test` invocations remain without `--no-orphans`

🤖 Generated with [Claude Code](https://claude.com/claude-code)