### PR TITLE
feat(ci): verdict cache for --pre-push gate (closes #2396, part 1)

### DIFF
--- a/scripts/_runner/ci-steps.spec.ts
+++ b/scripts/_runner/ci-steps.spec.ts
@@ -9,7 +9,7 @@ import { createCaptureLogger } from "./logger";
 // `bun` binary whose exit code and stdout/stderr we control via env vars,
 // then assert the returned StepResult matches the documented contract.
 
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -381,6 +381,26 @@ describe("changedTestsStep", () => {
 
     const { lookupVerdict } = await import("./verdict-cache");
     expect(lookupVerdict(cacheRoot, "new-key")).toBe(true);
+  });
+
+  it("runs tests and does not store when computeKey returns null (git unavailable)", async () => {
+    const dir = makeFakeBun({ code: 0, stdout: passingSummary });
+    const cacheRoot = mkdtempSync(join(tmpdir(), "am-i-done-cache-"));
+
+    const step = changedTestsStep({
+      logName: "test_changed_null_key",
+      resolveBase: stubBase,
+      repoRoot: cacheRoot,
+      computeKey: () => null,
+    });
+    const result = await runWith(dir, () =>
+      (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
+        logger: createCaptureLogger(),
+      }),
+    );
+    expect(result).toEqual({ success: true });
+    // No verdict stored — cache file should not exist.
+    expect(existsSync(join(cacheRoot, "build/.verdict-cache.json"))).toBe(false);
   });
 
   it("does not short-circuit on a cached failure", async () => {

--- a/scripts/_runner/ci-steps.spec.ts
+++ b/scripts/_runner/ci-steps.spec.ts
@@ -257,10 +257,12 @@ describe("changedTestsStep", () => {
   // then spawns the fake `bun` (twice: safe subset + control pass), and we
   // assert the #1004 classification on the combined verdict.
   const stubBase = () => "STUB_BASE";
+  // Disable verdict cache for all legacy tests — they don't set up a repo root.
+  const noCache = () => null;
 
   it("exit 0 on both passes → success", async () => {
     const dir = makeFakeBun({ code: 0, stdout: passingSummary });
-    const step = changedTestsStep({ logName: "test_changed_x", resolveBase: stubBase });
+    const step = changedTestsStep({ logName: "test_changed_x", resolveBase: stubBase, computeKey: noCache });
     const result = await runWith(dir, () =>
       (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
         logger: createCaptureLogger(),
@@ -271,7 +273,7 @@ describe("changedTestsStep", () => {
 
   it("non-zero exit with `0 fail` summary is a #1004 pass-by-policy", async () => {
     const dir = makeFakeBun({ code: 1, stdout: passingSummary });
-    const step = changedTestsStep({ logName: "test_changed_x", resolveBase: stubBase });
+    const step = changedTestsStep({ logName: "test_changed_x", resolveBase: stubBase, computeKey: noCache });
     const result = await runWith(dir, () =>
       (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
         logger: createCaptureLogger(),
@@ -284,7 +286,7 @@ describe("changedTestsStep", () => {
     // Pass 1 (main) fails; pass 2 (control) would succeed — if the short-circuit
     // is removed, control runs and flips the verdict to success, catching the bug.
     const dir = makeTwoPassFakeBun({ code: 1, stdout: failingSummary }, { code: 0, stdout: passingSummary });
-    const step = changedTestsStep({ logName: "test_changed_sc", resolveBase: stubBase });
+    const step = changedTestsStep({ logName: "test_changed_sc", resolveBase: stubBase, computeKey: noCache });
     const result = await runWith(dir, () =>
       (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
         logger: createCaptureLogger(),
@@ -297,7 +299,7 @@ describe("changedTestsStep", () => {
     // Pass 1 (main) succeeds; pass 2 (control) fails — exercises the second
     // classifyChangedTest return and the control-fail code path.
     const dir = makeTwoPassFakeBun({ code: 0, stdout: passingSummary }, { code: 1, stdout: failingSummary });
-    const step = changedTestsStep({ logName: "test_changed_ctrl_fail", resolveBase: stubBase });
+    const step = changedTestsStep({ logName: "test_changed_ctrl_fail", resolveBase: stubBase, computeKey: noCache });
     const result = await runWith(dir, () =>
       (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
         logger: createCaptureLogger(),
@@ -310,7 +312,7 @@ describe("changedTestsStep", () => {
     // Fake bun echoes its own argv so we can prove --changed=<base> is forwarded.
     const dir = mkdtempSync(join(tmpdir(), "am-i-done-test-"));
     writeFileSync(join(dir, "bun"), '#!/usr/bin/env bash\necho "ARGV=$*"\nexit 0\n', { mode: 0o755 });
-    const step = changedTestsStep({ logName: "test_changed_argv", resolveBase: stubBase });
+    const step = changedTestsStep({ logName: "test_changed_argv", resolveBase: stubBase, computeKey: noCache });
     const result = await runWith(dir, () =>
       (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
         logger: createCaptureLogger(),
@@ -326,7 +328,7 @@ describe("changedTestsStep", () => {
     // directly as a positional arg (no ignore flag needed).
     const dir = mkdtempSync(join(tmpdir(), "am-i-done-test-"));
     writeFileSync(join(dir, "bun"), '#!/usr/bin/env bash\necho "ARGV=$*"\nexit 0\n', { mode: 0o755 });
-    const step = changedTestsStep({ logName: "test_changed_flags", resolveBase: stubBase });
+    const step = changedTestsStep({ logName: "test_changed_flags", resolveBase: stubBase, computeKey: noCache });
     await runWith(dir, () =>
       (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
         logger: createCaptureLogger(),
@@ -337,5 +339,69 @@ describe("changedTestsStep", () => {
     expect(mainLog).toContain("--path-ignore-patterns=packages/control/**");
     expect(controlLog).not.toContain("--path-ignore-patterns");
     expect(controlLog).toContain("packages/control");
+  });
+
+  it("skips tests on verdict cache hit (passing)", async () => {
+    // A fake bun that would fail — but the cache hit should prevent it from running.
+    const dir = makeFakeBun({ code: 1, stdout: "SHOULD NOT RUN\n 1 fail\n" });
+    const cacheRoot = mkdtempSync(join(tmpdir(), "am-i-done-cache-"));
+    const { storeVerdict } = await import("./verdict-cache");
+    storeVerdict(cacheRoot, "cached-key", true);
+
+    const step = changedTestsStep({
+      logName: "test_changed_cache_hit",
+      resolveBase: stubBase,
+      repoRoot: cacheRoot,
+      computeKey: () => "cached-key",
+    });
+    const result = await runWith(dir, () =>
+      (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
+        logger: createCaptureLogger(),
+      }),
+    );
+    expect(result).toEqual({ success: true });
+  });
+
+  it("runs tests on verdict cache miss and stores the result", async () => {
+    const dir = makeFakeBun({ code: 0, stdout: passingSummary });
+    const cacheRoot = mkdtempSync(join(tmpdir(), "am-i-done-cache-"));
+
+    const step = changedTestsStep({
+      logName: "test_changed_cache_miss",
+      resolveBase: stubBase,
+      repoRoot: cacheRoot,
+      computeKey: () => "new-key",
+    });
+    const result = await runWith(dir, () =>
+      (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
+        logger: createCaptureLogger(),
+      }),
+    );
+    expect(result).toEqual({ success: true });
+
+    const { lookupVerdict } = await import("./verdict-cache");
+    expect(lookupVerdict(cacheRoot, "new-key")).toBe(true);
+  });
+
+  it("does not short-circuit on a cached failure", async () => {
+    const dir = makeFakeBun({ code: 0, stdout: passingSummary });
+    const cacheRoot = mkdtempSync(join(tmpdir(), "am-i-done-cache-"));
+    const { storeVerdict, lookupVerdict } = await import("./verdict-cache");
+    storeVerdict(cacheRoot, "fail-key", false);
+
+    const step = changedTestsStep({
+      logName: "test_changed_cache_fail",
+      resolveBase: stubBase,
+      repoRoot: cacheRoot,
+      computeKey: () => "fail-key",
+    });
+    const result = await runWith(dir, () =>
+      (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
+        logger: createCaptureLogger(),
+      }),
+    );
+    // Tests ran (fake bun exits 0) and overwrite the cached failure.
+    expect(result).toEqual({ success: true });
+    expect(lookupVerdict(cacheRoot, "fail-key")).toBe(true);
   });
 });

--- a/scripts/_runner/ci-steps.ts
+++ b/scripts/_runner/ci-steps.ts
@@ -25,9 +25,11 @@
 
 import { spawn, spawnSync } from "node:child_process";
 import { writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import type { Logger, ScriptFunction, StepResult } from "./types";
+import { computeVerdictKey, lookupVerdict, storeVerdict } from "./verdict-cache";
 
 // Artefact directory matches the path the CI workflow's `Upload test/coverage
 // logs` steps glob for (`/tmp/test_*.txt`, `/tmp/coverage_*.txt`). `/tmp`
@@ -171,6 +173,10 @@ interface ChangedTestsOpts {
    * CLAUDE.md — `mock.module` pollutes Bun's global registry across files).
    */
   resolveBase?: () => string;
+  /** Override repo root for verdict cache location. DI for tests. */
+  repoRoot?: string;
+  /** Override verdict-key computation. DI for tests. */
+  computeKey?: (resolveBase: () => string) => string | null;
 }
 
 /**
@@ -189,7 +195,19 @@ interface ChangedTestsOpts {
  */
 export function changedTestsStep(opts: ChangedTestsOpts): ScriptFunction {
   const resolveBase = opts.resolveBase ?? defaultResolveBase;
+  const repoRoot = opts.repoRoot ?? resolve(fileURLToPath(import.meta.url), "../../..");
+  const getKey = opts.computeKey ?? computeVerdictKey;
   return async ({ logger, env }) => {
+    // Verdict cache: skip tests when the worktree state is unchanged (#2396).
+    const key = getKey(resolveBase);
+    if (key) {
+      const cached = lookupVerdict(repoRoot, key);
+      if (cached === true) {
+        logger.info("verdict cache hit — worktree state unchanged since last green run, skipping tests (#2396)");
+        return { success: true };
+      }
+    }
+
     const base = resolveBase();
     logger.info(`diff-aware: running tests affected by changes since ${base} (bun test --changed)`);
 
@@ -202,7 +220,10 @@ export function changedTestsStep(opts: ChangedTestsOpts): ScriptFunction {
     );
     persistLog(opts.logName, main.output);
     const mainVerdict = classifyChangedTest(main, logger);
-    if (!mainVerdict.success) return mainVerdict;
+    if (!mainVerdict.success) {
+      if (key) storeVerdict(repoRoot, key, false);
+      return mainVerdict;
+    }
 
     // control specs (sequential — yoga TDZ). Fast no-op when none changed.
     const control = await runBun(
@@ -211,7 +232,9 @@ export function changedTestsStep(opts: ChangedTestsOpts): ScriptFunction {
       env,
     );
     persistLog(`${opts.logName}_control`, control.output);
-    return classifyChangedTest(control, logger);
+    const controlVerdict = classifyChangedTest(control, logger);
+    if (key) storeVerdict(repoRoot, key, controlVerdict.success);
+    return controlVerdict;
   };
 }
 

--- a/scripts/_runner/ci-steps.ts
+++ b/scripts/_runner/ci-steps.ts
@@ -198,8 +198,10 @@ export function changedTestsStep(opts: ChangedTestsOpts): ScriptFunction {
   const repoRoot = opts.repoRoot ?? resolve(fileURLToPath(import.meta.url), "../../..");
   const getKey = opts.computeKey ?? computeVerdictKey;
   return async ({ logger, env }) => {
+    const base = resolveBase();
+
     // Verdict cache: skip tests when the worktree state is unchanged (#2396).
-    const key = getKey(resolveBase);
+    const key = getKey(() => base);
     if (key) {
       const cached = lookupVerdict(repoRoot, key);
       if (cached === true) {
@@ -208,7 +210,6 @@ export function changedTestsStep(opts: ChangedTestsOpts): ScriptFunction {
       }
     }
 
-    const base = resolveBase();
     logger.info(`diff-aware: running tests affected by changes since ${base} (bun test --changed)`);
 
     // Safe subset, parallel. control excluded (yoga-layout TDZ under --parallel, #2362).

--- a/scripts/_runner/verdict-cache.spec.ts
+++ b/scripts/_runner/verdict-cache.spec.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { lookupVerdict, storeVerdict } from "./verdict-cache";
+
+function makeTmpRepo(): string {
+  return mkdtempSync(join(tmpdir(), "verdict-cache-test-"));
+}
+
+describe("verdict-cache", () => {
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const d of dirs) rmSync(d, { recursive: true, force: true });
+    dirs.length = 0;
+  });
+
+  function tmp(): string {
+    const d = makeTmpRepo();
+    dirs.push(d);
+    return d;
+  }
+
+  it("returns null for a cache miss", () => {
+    const root = tmp();
+    expect(lookupVerdict(root, "abc:def:123")).toBeNull();
+  });
+
+  it("stores and retrieves a passing verdict", () => {
+    const root = tmp();
+    storeVerdict(root, "key1", true);
+    expect(lookupVerdict(root, "key1")).toBe(true);
+  });
+
+  it("stores and retrieves a failing verdict", () => {
+    const root = tmp();
+    storeVerdict(root, "key1", false);
+    expect(lookupVerdict(root, "key1")).toBe(false);
+  });
+
+  it("overwrites an existing entry for the same key", () => {
+    const root = tmp();
+    storeVerdict(root, "key1", false);
+    storeVerdict(root, "key1", true);
+    expect(lookupVerdict(root, "key1")).toBe(true);
+    const raw = JSON.parse(readFileSync(join(root, "build/.verdict-cache.json"), "utf8"));
+    expect(raw.entries.filter((e: { key: string }) => e.key === "key1")).toHaveLength(1);
+  });
+
+  it("evicts old entries beyond MAX_ENTRIES (16)", () => {
+    const root = tmp();
+    for (let i = 0; i < 20; i++) {
+      storeVerdict(root, `key-${i}`, true);
+    }
+    const raw = JSON.parse(readFileSync(join(root, "build/.verdict-cache.json"), "utf8"));
+    expect(raw.entries).toHaveLength(16);
+    expect(lookupVerdict(root, "key-0")).toBeNull();
+    expect(lookupVerdict(root, "key-19")).toBe(true);
+  });
+
+  it("creates build/ directory if missing", () => {
+    const root = tmp();
+    expect(existsSync(join(root, "build"))).toBe(false);
+    storeVerdict(root, "k", true);
+    expect(existsSync(join(root, "build/.verdict-cache.json"))).toBe(true);
+  });
+
+  it("handles corrupt cache file gracefully", () => {
+    const root = tmp();
+    mkdirSync(join(root, "build"), { recursive: true });
+    writeFileSync(join(root, "build/.verdict-cache.json"), "NOT JSON");
+    expect(lookupVerdict(root, "anything")).toBeNull();
+    storeVerdict(root, "after-corrupt", true);
+    expect(lookupVerdict(root, "after-corrupt")).toBe(true);
+  });
+});

--- a/scripts/_runner/verdict-cache.spec.ts
+++ b/scripts/_runner/verdict-cache.spec.ts
@@ -74,4 +74,13 @@ describe("verdict-cache", () => {
     storeVerdict(root, "after-corrupt", true);
     expect(lookupVerdict(root, "after-corrupt")).toBe(true);
   });
+
+  it("handles valid JSON with wrong shape gracefully", () => {
+    const root = tmp();
+    mkdirSync(join(root, "build"), { recursive: true });
+    writeFileSync(join(root, "build/.verdict-cache.json"), '{"entries": "not an array"}');
+    expect(lookupVerdict(root, "anything")).toBeNull();
+    storeVerdict(root, "after-bad-shape", true);
+    expect(lookupVerdict(root, "after-bad-shape")).toBe(true);
+  });
 });

--- a/scripts/_runner/verdict-cache.ts
+++ b/scripts/_runner/verdict-cache.ts
@@ -44,8 +44,14 @@ export function computeVerdictKey(resolveBase: () => string): string | null {
 
   // `git diff HEAD` captures both staged and unstaged changes in one shot.
   const diff = spawnSync("git", ["diff", "HEAD"], { encoding: "utf8" });
-  const diffContent = diff.status === 0 ? diff.stdout : "";
-  const diffHash = Bun.hash(diffContent).toString(16);
+  if (diff.status !== 0) return null;
+
+  // Untracked files (new spec files, etc.) are invisible to `git diff HEAD`.
+  // Include their names so adding/removing an untracked file flips the key.
+  const untracked = spawnSync("git", ["ls-files", "--others", "--exclude-standard"], { encoding: "utf8" });
+  const untrackedList = untracked.status === 0 ? untracked.stdout : "";
+
+  const diffHash = Bun.hash(diff.stdout + untrackedList).toString(16);
 
   return `${base}:${headSha}:${diffHash}`;
 }

--- a/scripts/_runner/verdict-cache.ts
+++ b/scripts/_runner/verdict-cache.ts
@@ -1,0 +1,89 @@
+/**
+ * Verdict cache for `--pre-push` test results.
+ *
+ * Memoizes the diff-aware test verdict keyed on a hash of the worktree
+ * state: (merge-base SHA, HEAD SHA, working-tree diff content). A re-run
+ * or re-push of the *same* state becomes a no-op — solves the
+ * commit→push double-run and repeated-push cases without owning a
+ * dependency graph. See #2396.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const CACHE_FILE = "build/.verdict-cache.json";
+
+interface VerdictEntry {
+  key: string;
+  passed: boolean;
+  /** ISO timestamp of when this verdict was recorded. */
+  ts: string;
+}
+
+interface VerdictCacheFile {
+  entries: VerdictEntry[];
+}
+
+/**
+ * Compute a cache key from the current worktree state.
+ *
+ * Components:
+ *   1. merge-base SHA (the ref tests diff against)
+ *   2. HEAD SHA (which commit we're on)
+ *   3. hash of uncommitted changes (staged + unstaged)
+ *
+ * Any code change — commit, amend, stage, edit — flips at least one of
+ * these, invalidating the cache.
+ */
+export function computeVerdictKey(resolveBase: () => string): string | null {
+  const base = resolveBase();
+  const head = spawnSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" });
+  if (head.status !== 0) return null;
+  const headSha = head.stdout.trim();
+
+  // `git diff HEAD` captures both staged and unstaged changes in one shot.
+  const diff = spawnSync("git", ["diff", "HEAD"], { encoding: "utf8" });
+  const diffContent = diff.status === 0 ? diff.stdout : "";
+  const diffHash = Bun.hash(diffContent).toString(16);
+
+  return `${base}:${headSha}:${diffHash}`;
+}
+
+function cachePath(repoRoot: string): string {
+  return join(repoRoot, CACHE_FILE);
+}
+
+function readCache(repoRoot: string): VerdictCacheFile {
+  const p = cachePath(repoRoot);
+  if (!existsSync(p)) return { entries: [] };
+  try {
+    return JSON.parse(readFileSync(p, "utf8")) as VerdictCacheFile;
+  } catch {
+    return { entries: [] };
+  }
+}
+
+function writeCache(repoRoot: string, cache: VerdictCacheFile): void {
+  const p = cachePath(repoRoot);
+  const dir = dirname(p);
+  if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  writeFileSync(p, `${JSON.stringify(cache, null, 2)}\n`);
+}
+
+const MAX_ENTRIES = 16;
+
+export function lookupVerdict(repoRoot: string, key: string): boolean | null {
+  const cache = readCache(repoRoot);
+  const entry = cache.entries.find((e) => e.key === key);
+  if (!entry) return null;
+  return entry.passed;
+}
+
+export function storeVerdict(repoRoot: string, key: string, passed: boolean): void {
+  const cache = readCache(repoRoot);
+  cache.entries = cache.entries.filter((e) => e.key !== key);
+  cache.entries.unshift({ key, passed, ts: new Date().toISOString() });
+  if (cache.entries.length > MAX_ENTRIES) cache.entries.length = MAX_ENTRIES;
+  writeCache(repoRoot, cache);
+}

--- a/scripts/_runner/verdict-cache.ts
+++ b/scripts/_runner/verdict-cache.ts
@@ -58,7 +58,9 @@ function readCache(repoRoot: string): VerdictCacheFile {
   const p = cachePath(repoRoot);
   if (!existsSync(p)) return { entries: [] };
   try {
-    return JSON.parse(readFileSync(p, "utf8")) as VerdictCacheFile;
+    const parsed = JSON.parse(readFileSync(p, "utf8"));
+    if (!Array.isArray(parsed.entries)) return { entries: [] };
+    return parsed as VerdictCacheFile;
   } catch {
     return { entries: [] };
   }
@@ -81,9 +83,13 @@ export function lookupVerdict(repoRoot: string, key: string): boolean | null {
 }
 
 export function storeVerdict(repoRoot: string, key: string, passed: boolean): void {
-  const cache = readCache(repoRoot);
-  cache.entries = cache.entries.filter((e) => e.key !== key);
-  cache.entries.unshift({ key, passed, ts: new Date().toISOString() });
-  if (cache.entries.length > MAX_ENTRIES) cache.entries.length = MAX_ENTRIES;
-  writeCache(repoRoot, cache);
+  try {
+    const cache = readCache(repoRoot);
+    cache.entries = cache.entries.filter((e) => e.key !== key);
+    cache.entries.unshift({ key, passed, ts: new Date().toISOString() });
+    if (cache.entries.length > MAX_ENTRIES) cache.entries.length = MAX_ENTRIES;
+    writeCache(repoRoot, cache);
+  } catch {
+    // Best-effort — a failed cache write must not fail the gate.
+  }
 }

--- a/scripts/rules/_engine/file-loader.ts
+++ b/scripts/rules/_engine/file-loader.ts
@@ -1,10 +1,14 @@
 /**
  * File loader for the rule engine.
  *
- * mcp-cli is a flat repo, not a layered monorepo, so the loader stays
- * simple: glob `packages/`, `scripts/`, `test/` for *.ts (excluding .d.ts
- * and node_modules), read each into memory, attach a few quick-derived
+ * mcp-cli is a layered Bun workspace — a one-line edit to
+ * `packages/core/src/model.ts` fans out through the `@mcp-cli/core`
+ * barrel to 165+ test files. The loader stays simple on purpose: glob
+ * `packages/`, `scripts/`, `test/` for *.ts (excluding .d.ts and
+ * node_modules), read each into memory, attach a few quick-derived
  * flags (`isTest`, `pkg`) and return a Map keyed by absolute path.
+ * Cross-package import edges are not tracked here; `bun test --changed`
+ * owns the authoritative module graph for diff-aware test selection.
  *
  * Rules that need richer metadata (parsed imports/exports) can attach
  * their own per-rule cache. We intentionally don't pre-parse ASTs across


### PR DESCRIPTION
## Summary
- Adds a verdict cache (`build/.verdict-cache.json`) that memoizes the `--pre-push` test result keyed on worktree state (merge-base SHA + HEAD SHA + working-tree diff hash). A re-run or re-push of the same state skips tests entirely — solves the commit→push double-run and repeated-push cases.
- Fixes the stale "flat repo, not a layered monorepo" comment in `scripts/rules/_engine/file-loader.ts` — mcp-cli is a layered workspace with deep cross-package import edges (proven: a one-line edit to `packages/core/src/model.ts` fans out to 165+ test files).
- Part 2 (AST import-graph + per-file closure-hash cache) filed as a follow-up issue.

## Test plan
- [x] `verdict-cache.spec.ts`: 7 tests covering cache miss, hit, overwrite, eviction, directory creation, corrupt file recovery
- [x] `ci-steps.spec.ts`: 3 new tests covering cache hit short-circuit, cache miss + store, and no short-circuit on cached failure
- [x] All 28 tests in `ci-steps.spec.ts` + `verdict-cache.spec.ts` pass
- [x] `bun run am-i-done --pre-commit` passes
- [x] Pre-push hook passes (including the new verdict cache itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)