### PR TITLE
fix(daemon): prevent socket theft when a live daemon is already listening (closes #2370)

### DIFF
--- a/packages/command/src/daemon-lifecycle.ts
+++ b/packages/command/src/daemon-lifecycle.ts
@@ -169,8 +169,10 @@ export async function ensureDaemon(): Promise<void> {
     // Flock-holder is alive. Still check protocol version — a version-mismatched
     // daemon should fail fast, not wait indefinitely for a socket that speaks wrong protocol.
     const pidData = readPidFileVersion();
-    if (pidData?.protocolVersion && pidData.protocolVersion !== PROTOCOL_VERSION) {
-      throw new ProtocolMismatchError(pidData.protocolVersion, PROTOCOL_VERSION);
+    // Absent protocolVersion (old PID file) is treated as a mismatch — consistent with
+    // isDaemonRunning(), which throws ProtocolMismatchError when the field is missing.
+    if (!pidData?.protocolVersion || pidData.protocolVersion !== PROTOCOL_VERSION) {
+      throw new ProtocolMismatchError(pidData?.protocolVersion ?? "unknown", PROTOCOL_VERSION);
     }
     verboseLog("daemon PID file flock is held — daemon is alive, waiting for socket");
     await waitForDaemon();

--- a/packages/command/src/daemon-lifecycle.ts
+++ b/packages/command/src/daemon-lifecycle.ts
@@ -161,17 +161,25 @@ export function isDaemonFlockHeld(): boolean {
  * Uses an exclusive lock file to prevent concurrent startups (race condition).
  */
 export async function ensureDaemon(): Promise<void> {
-  // isDaemonRunning() throws ProtocolMismatchError if versions don't match — fail-fast.
-  if (await isDaemonRunning()) {
-    verboseLog("daemon already running");
+  // Flock check FIRST — kernel-enforced, no side effects, no false negatives.
+  // isDaemonRunning() calls cleanStaleFiles() on failure, which unlinks the PID file.
+  // If flock runs after that, it opens a NEW inode and the original daemon's lock
+  // (held on the old inode) is invisible — defeating the guard. See #2370.
+  if (isDaemonFlockHeld()) {
+    // Flock-holder is alive. Still check protocol version — a version-mismatched
+    // daemon should fail fast, not wait indefinitely for a socket that speaks wrong protocol.
+    const pidData = readPidFileVersion();
+    if (pidData?.protocolVersion && pidData.protocolVersion !== PROTOCOL_VERSION) {
+      throw new ProtocolMismatchError(pidData.protocolVersion, PROTOCOL_VERSION);
+    }
+    verboseLog("daemon PID file flock is held — daemon is alive, waiting for socket");
+    await waitForDaemon();
     return;
   }
 
-  // Check if the daemon holds the PID file flock — definitive kernel-level liveness.
-  // This catches sleep/wake scenarios where the daemon is suspended but alive.
-  if (isDaemonFlockHeld()) {
-    verboseLog("daemon PID file flock is held — daemon is alive, waiting for socket");
-    await waitForDaemon();
+  // isDaemonRunning() throws ProtocolMismatchError if versions don't match — fail-fast.
+  if (await isDaemonRunning()) {
+    verboseLog("daemon already running");
     return;
   }
 
@@ -314,6 +322,15 @@ export async function stopDaemon(opts?: { force?: boolean }): Promise<void> {
   }
 
   cleanStaleFiles();
+}
+
+/** Read just the protocol version from the PID file. No liveness checks, no side effects. */
+function readPidFileVersion(): { protocolVersion?: string } | null {
+  try {
+    return JSON.parse(readFileSync(options.PID_PATH, "utf-8"));
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -893,7 +893,7 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
     },
     automationDispatcher: automationDispatcher ?? undefined,
   });
-  ipcServer.start();
+  await ipcServer.start();
 
   // Reset idle timer on Claude/Codex/ACP session worker events (db:upsert, db:state, db:cost)
   claudeServer.onActivity = () => resetIdleTimer();

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -4241,6 +4241,24 @@ describe("socket theft prevention (#2370)", () => {
     expect(ping2.ok).toBe(true);
   });
 
+  test("start() refuses to unlink a draining server returning 503", async () => {
+    socketPath = tmpSocket();
+    // Minimal Bun server that always returns 503 (simulates a draining daemon).
+    const draining = Bun.serve({
+      unix: socketPath,
+      fetch() {
+        return new Response("draining", { status: 503 });
+      },
+    });
+
+    try {
+      serverB = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, opts());
+      await expect(serverB.start(socketPath)).rejects.toThrow("live daemon is already listening");
+    } finally {
+      draining.stop();
+    }
+  });
+
   test("start() reclaims a stale socket from a crashed server", async () => {
     socketPath = tmpSocket();
     serverA = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, opts());

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -4193,6 +4193,80 @@ describe("IpcServer HTTP transport", () => {
   });
 });
 
+// ── Socket theft prevention (#2370) ──
+
+describe("socket theft prevention (#2370)", () => {
+  let serverA: IpcServer | undefined;
+  let serverB: IpcServer | undefined;
+  let socketPath: string;
+
+  afterEach(() => {
+    serverA?.stop();
+    serverB?.stop();
+    serverA = undefined;
+    serverB = undefined;
+    try {
+      unlinkSync(socketPath);
+      // dotw-ignore test-empty-catch: best-effort cleanup
+    } catch {
+      /* already cleaned up */
+    }
+  });
+
+  test("start() refuses to unlink a socket owned by a live server", async () => {
+    socketPath = tmpSocket();
+    serverA = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, opts());
+    await serverA.start(socketPath);
+
+    // Verify server A is alive
+    const ping = await fetch("http://localhost/rpc", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: "p1", method: "ping" }),
+      unix: socketPath,
+    } as RequestInit);
+    expect(ping.ok).toBe(true);
+
+    // Second server must refuse to steal the socket
+    serverB = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, opts());
+    await expect(serverB.start(socketPath)).rejects.toThrow("live daemon is already listening");
+
+    // Original server must still be reachable after the refused theft
+    const ping2 = await fetch("http://localhost/rpc", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: "p2", method: "ping" }),
+      unix: socketPath,
+    } as RequestInit);
+    expect(ping2.ok).toBe(true);
+  });
+
+  test("start() reclaims a stale socket from a crashed server", async () => {
+    socketPath = tmpSocket();
+    serverA = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, opts());
+    await serverA.start(socketPath);
+    // Stop server A (simulates crash) — socket file remains
+    serverA.stop();
+    serverA = undefined;
+
+    // Write a fake stale socket file (stop already cleaned it, recreate)
+    const { writeFileSync: wfs } = await import("node:fs");
+    wfs(socketPath, "");
+
+    // Second server should reclaim the stale socket
+    serverB = new IpcServer(mockPool() as never, mockConfig(), mockDb(), null, opts());
+    await serverB.start(socketPath);
+
+    const ping = await fetch("http://localhost/rpc", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: "p3", method: "ping" }),
+      unix: socketPath,
+    } as RequestInit);
+    expect(ping.ok).toBe(true);
+  });
+});
+
 // ── buildEventFilter unit tests ──
 
 import { resolve } from "node:path";

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -75,8 +75,12 @@ async function probeSocket(socketPath: string): Promise<boolean> {
       unix: socketPath,
       signal: AbortSignal.timeout(SOCKET_PROBE_TIMEOUT_MS),
     } as RequestInit);
-    return res.ok;
+    // Any established HTTP response means a live daemon accepted the connection.
+    // A draining daemon returns 503 for non-shutdown methods — that still counts as live.
+    void res;
+    return true;
   } catch {
+    // Connect error or timeout — no live daemon on this socket.
     return false;
   }
 }

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -5,7 +5,7 @@
  * Handler logic lives in per-domain modules under ./handlers/.
  */
 
-import { unlinkSync } from "node:fs";
+import { existsSync, unlinkSync } from "node:fs";
 import type {
   IpcError,
   IpcMethod,
@@ -62,6 +62,24 @@ import type { ServerPool } from "./server-pool";
 // Re-export for backward compat with existing tests and external code.
 export { buildEventFilter } from "./ipc-filter";
 export type { RequestContext } from "./handler-types";
+
+const SOCKET_PROBE_TIMEOUT_MS = 2_000;
+
+/** Probe a Unix socket to check if a live daemon is listening. */
+async function probeSocket(socketPath: string): Promise<boolean> {
+  try {
+    const res = await fetch("http://localhost/rpc", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: "probe", method: "ping" }),
+      unix: socketPath,
+      signal: AbortSignal.timeout(SOCKET_PROBE_TIMEOUT_MS),
+    } as RequestInit);
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
 
 export class IpcServer {
   private server: ReturnType<typeof Bun.serve> | null = null;
@@ -143,14 +161,22 @@ export class IpcServer {
     this.db.pruneExpiredAliases();
   }
 
-  /** Start listening on the Unix socket */
-  start(socketPath = options.SOCKET_PATH): void {
+  /** Start listening on the Unix socket. Probes for a live daemon first to prevent socket theft. */
+  async start(socketPath = options.SOCKET_PATH): Promise<void> {
     this.socketPath = socketPath;
 
-    try {
-      unlinkSync(socketPath);
-    } catch {
-      // doesn't exist, fine
+    if (existsSync(socketPath)) {
+      if (await probeSocket(socketPath)) {
+        throw new Error(
+          `[ipc] Refusing to start: a live daemon is already listening on ${socketPath}. Kill the existing daemon first or check for stale state.`,
+        );
+      }
+      // Socket file exists but no daemon is listening — stale from a crash. Safe to reclaim.
+      try {
+        unlinkSync(socketPath);
+      } catch {
+        // raced with another cleanup — fine
+      }
     }
 
     const onActivity = this.onActivity;


### PR DESCRIPTION
## Summary
- **ipc-server.ts `start()`**: Now probes the existing socket before unlinking. If a live daemon responds to a ping, `start()` throws instead of stealing the socket. Stale sockets from crashed daemons are still reclaimed.
- **daemon-lifecycle.ts `ensureDaemon()`**: Reordered to check the kernel-enforced PID flock BEFORE calling `isDaemonRunning()`. The old order let `isDaemonRunning()`'s `cleanStaleFiles()` unlink the PID file, creating a new inode — the original daemon's flock (on the old inode) became invisible to subsequent callers, defeating the singleton guard.
- **index.ts**: `ipcServer.start()` is now awaited since the socket probe is async.

## Root cause
Two bugs combined to create the split-brain:
1. `ipc-server.start()` unconditionally called `unlinkSync(socketPath)` — a second daemon could steal the socket from a healthy first daemon.
2. `ensureDaemon()` ran `isDaemonRunning()` (which calls `cleanStaleFiles()` → unlinks PID file on failure) before `isDaemonFlockHeld()`. A transient ping timeout under load would delete the PID file, and the replacement PID file would be a new inode — the original daemon's flock was invisible.

## Test plan
- [x] New test: `start()` refuses to unlink a socket owned by a live server — verifies the second server throws and the original remains reachable
- [x] New test: `start()` reclaims a stale socket from a crashed server — verifies stale socket cleanup still works
- [x] All 211 tests pass across `ipc-server.spec.ts` + `daemon-lifecycle.spec.ts`
- [x] Typecheck, lint, rules, coverage all pass (`bun run am-i-done`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)