### PR TITLE
fix(dx): direction-aware remediation in stale-daemon mismatch warning (fixes #2381)

### DIFF
--- a/packages/command/src/daemon-lifecycle.spec.ts
+++ b/packages/command/src/daemon-lifecycle.spec.ts
@@ -422,18 +422,70 @@ describe("_buildStaleDaemonWarning", () => {
     expect(_buildStaleDaemonWarning(BUILD_VERSION)).toBeNull();
   });
 
-  it("returns warning when daemon buildVersion differs from CLI", () => {
-    const warning = _buildStaleDaemonWarning("0.1.0-20250101");
-    expect(warning).toContain("different build");
-    expect(warning).toContain("0.1.0-20250101");
-    expect(warning).toContain(BUILD_VERSION);
-    expect(warning).toContain("mcx shutdown");
+  it("returns null when both versions match (explicit cliBuildVersion)", () => {
+    expect(_buildStaleDaemonWarning("1.0.0+1000", "1.0.0+1000")).toBeNull();
   });
 
   it("returns warning when daemon has no buildVersion (predates tracking)", () => {
     const warning = _buildStaleDaemonWarning(undefined);
     expect(warning).toContain("predates build version tracking");
     expect(warning).toContain(BUILD_VERSION);
+    expect(warning).toContain("mcx shutdown");
+  });
+
+  it("recommends dist/mcx when daemon is compiled and CLI is dev", () => {
+    // Compiled daemon (has epoch), dev CLI (no epoch) — daemon is the newer/authoritative side
+    const warning = _buildStaleDaemonWarning("1.11.2+1779669196", "1.11.2-dev");
+    expect(warning).not.toBeNull();
+    expect(warning).not.toContain("mcx shutdown");
+    expect(warning).toContain("1.11.2+1779669196");
+    expect(warning).toContain("1.11.2-dev");
+    expect(warning).toContain("dist/mcx");
+  });
+
+  it("recommends mcx shutdown when CLI is compiled and daemon is dev", () => {
+    // CLI compiled, daemon dev — daemon is stale
+    const warning = _buildStaleDaemonWarning("1.11.2-dev", "1.11.2+1779669196");
+    expect(warning).not.toBeNull();
+    expect(warning).toContain("mcx shutdown");
+    expect(warning).toContain("1.11.2-dev");
+    expect(warning).toContain("1.11.2+1779669196");
+    expect(warning).not.toContain("dist/mcx");
+  });
+
+  it("recommends mcx shutdown when daemon epoch is older than CLI epoch", () => {
+    const warning = _buildStaleDaemonWarning("1.0.0+1000000000", "1.0.0+2000000000");
+    expect(warning).not.toBeNull();
+    expect(warning).toContain("mcx shutdown");
+    expect(warning).toContain("1.0.0+1000000000");
+    expect(warning).toContain("1.0.0+2000000000");
+    expect(warning).not.toContain("dist/mcx");
+  });
+
+  it("recommends dist/mcx when daemon epoch is newer than CLI epoch", () => {
+    const warning = _buildStaleDaemonWarning("1.0.0+2000000000", "1.0.0+1000000000");
+    expect(warning).not.toBeNull();
+    expect(warning).not.toContain("mcx shutdown");
+    expect(warning).toContain("1.0.0+2000000000");
+    expect(warning).toContain("1.0.0+1000000000");
+    expect(warning).toContain("dist/mcx");
+  });
+
+  it("falls back to shutdown advice when both builds are dev with different versions", () => {
+    // Both dev (no epoch): can't determine direction → fallback recommends shutdown
+    const warning = _buildStaleDaemonWarning("0.1.0-dev", "0.2.0-dev");
+    expect(warning).not.toBeNull();
+    expect(warning).toContain("0.1.0-dev");
+    expect(warning).toContain("0.2.0-dev");
+    expect(warning).toContain("mcx shutdown");
+  });
+
+  it("falls back to shutdown advice when neither version has an epoch", () => {
+    // Plain semver (no +epoch, no -dev): fallback
+    const warning = _buildStaleDaemonWarning("1.0.0", "1.1.0");
+    expect(warning).not.toBeNull();
+    expect(warning).toContain("1.0.0");
+    expect(warning).toContain("1.1.0");
     expect(warning).toContain("mcx shutdown");
   });
 });

--- a/packages/command/src/daemon-lifecycle.ts
+++ b/packages/command/src/daemon-lifecycle.ts
@@ -459,17 +459,46 @@ async function startDaemon(): Promise<void> {
 
 /**
  * Compare a daemon's build version against the CLI's BUILD_VERSION.
- * Returns a warning string if they differ, null if they match.
- * Exported with underscore prefix for testing.
+ * Returns a direction-aware warning string if they differ, null if they match.
+ * Exported with underscore prefix for testing. The optional cliBuildVersion
+ * parameter exists solely to allow unit tests to exercise all branches
+ * (BUILD_VERSION is dev in tests).
  */
-export function _buildStaleDaemonWarning(daemonBuildVersion: string | undefined): string | null {
-  if (!daemonBuildVersion || daemonBuildVersion !== BUILD_VERSION) {
-    if (!daemonBuildVersion) {
-      return `Daemon predates build version tracking (CLI is ${BUILD_VERSION}). Run \`mcx shutdown\` to pick up the new binary.`;
-    }
-    return `Daemon is running a different build (${daemonBuildVersion}) than CLI (${BUILD_VERSION}). Run \`mcx shutdown\` to pick up the new binary.`;
+export function _buildStaleDaemonWarning(
+  daemonBuildVersion: string | undefined,
+  cliBuildVersion = BUILD_VERSION,
+): string | null {
+  if (!daemonBuildVersion) {
+    return `Daemon predates build version tracking (CLI is ${cliBuildVersion}). Run \`mcx shutdown\` to pick up the new binary.`;
   }
-  return null;
+  if (daemonBuildVersion === cliBuildVersion) {
+    return null;
+  }
+
+  const daemonEpoch = _parseBuildEpoch(daemonBuildVersion);
+  const cliEpoch = _parseBuildEpoch(cliBuildVersion);
+
+  // Daemon is compiled, CLI is dev — daemon is the newer/authoritative side.
+  // Shutting down the daemon would be wrong and dangerous (#2370).
+  if (daemonEpoch !== null && cliEpoch === null) {
+    return `Daemon is a compiled build (${daemonBuildVersion}) but CLI is a dev build (${cliBuildVersion}). Use the build-matched client (\`dist/mcx\` or the installed \`mcx\` on PATH) instead of \`bun dev:mcx\`.`;
+  }
+
+  // CLI is compiled, daemon is dev — daemon is stale.
+  if (cliEpoch !== null && daemonEpoch === null) {
+    return `Daemon is running a dev build (${daemonBuildVersion}) but CLI is a compiled build (${cliBuildVersion}). Run \`mcx shutdown\` to restart with the compiled daemon.`;
+  }
+
+  // Both compiled — compare epochs to determine which is stale.
+  if (daemonEpoch !== null && cliEpoch !== null) {
+    if (daemonEpoch > cliEpoch) {
+      return `Daemon is running a newer build (${daemonBuildVersion}) than CLI (${cliBuildVersion}). Use the build-matched client: \`dist/mcx\` or the installed \`mcx\` on PATH.`;
+    }
+    return `Daemon is running an older build (${daemonBuildVersion}) than CLI (${cliBuildVersion}). Run \`mcx shutdown\` to pick up the new binary.`;
+  }
+
+  // Fallback: both dev or neither has epoch — can't determine direction.
+  return `Daemon is running a different build (${daemonBuildVersion}) than CLI (${cliBuildVersion}). Run \`mcx shutdown\` to pick up the new binary.`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- `_buildStaleDaemonWarning` now compares build epochs before choosing remediation text: compiled-vs-dev, dev-vs-compiled, both-compiled-older, both-compiled-newer, and fallback cases are all handled separately
- When the daemon is the newer/compiled side and the CLI is a dev build, the message recommends `dist/mcx` or the installed `mcx` on PATH instead of `mcx shutdown` — which would wrongly orphan the live daemon and its sessions (#2370)
- Added an optional `cliBuildVersion` parameter (default `BUILD_VERSION`) to allow all branches to be unit-tested; 8 new test cases cover every direction

## Test plan
- [x] `bun test packages/command/src/daemon-lifecycle.spec.ts` — 58 pass, 0 fail
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] Pre-push gate passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)