### PR TITLE
chore(skill): guarantee sentinel clear + stale-sentinel auto-clear (closes #2398)

### DIFF
--- a/.claude/skills/sprint/references/retro.md
+++ b/.claude/skills/sprint/references/retro.md
@@ -242,12 +242,22 @@ the cadence. See `introspection.md` for the prompt + triage flow.
 
 ```bash
 rm -f .claude/sprints/.active
+# Verify it's gone — a stuck sentinel silently turns the main checkout
+# read-only for commits until someone notices (see #2398).
+test ! -e .claude/sprints/.active || { echo "FAILED to clear sentinel"; exit 1; }
 ```
 
 This lifts the pre-commit guard (#1443) so post-sprint maintenance commits
 on main no longer need `SPRINT_OVERRIDE=1`. Do it only after the sprint PR
 merges and the worktree is removed — a stuck sentinel on a dead sprint
 still blocks commits.
+
+**Why a guaranteed terminal step**: in sprint 63 the retro ran and merged
+but the sentinel survived (mtime predated the retro commit), then blocked
+unrelated main-checkout commits days later. Defense-in-depth lives in
+`.git-hooks/sprint-active.sh` (auto-clears when the sentinel's sprint is
+already squash-merged on HEAD), but the retro must still actively clear
+to avoid relying on the safety net.
 
 ## Guidelines
 

--- a/.git-hooks/sprint-active.sh
+++ b/.git-hooks/sprint-active.sh
@@ -47,6 +47,18 @@ sprint_active_check() {
 
   local sprint_num
   sprint_num=$(tr -d '[:space:]' < "$sentinel" 2>/dev/null)
+
+  # Defense-in-depth (#2398): if the sentinel's sprint is already merged to
+  # main as a squash-merge commit, the sentinel is stale (retro failed to
+  # clear it). Auto-clear and allow the commit instead of silently blocking
+  # legitimate post-sprint work for hours/days until someone notices.
+  if [ -n "$sprint_num" ] && git log --oneline -n 100 HEAD 2>/dev/null \
+      | grep -qE "^[a-f0-9]+ sprint\(${sprint_num}\):"; then
+    echo "pre-commit: sentinel says sprint ${sprint_num} active, but its squash-merge is on HEAD — treating as stale and clearing (#2398)" >&2
+    rm -f "$sentinel"
+    return 0
+  fi
+
   echo "pre-commit: sprint ${sprint_num:-?} is active — refusing commit to main's checkout" >&2
   echo >&2
   echo "Workers must commit to their own worktree. A commit reaching main's" >&2


### PR DESCRIPTION
Applies meta-fix #2398 ahead of sprint 65.

Two fixes for the stuck-`.claude/sprints/.active`-sentinel bug observed
in sprint 63 (retro ran and merged but the sentinel survived, blocking
unrelated main-checkout commits days later until manually removed):

1. **`retro.md` Clear-sentinel step** now verifies the unlink actually
   happened (`test ! -e ...`) and explains *why* this must be a
   guaranteed terminal step.
2. **`.git-hooks/sprint-active.sh`** auto-clears the sentinel when its
   sprint number is already present as a `sprint(N):` squash-merge on
   HEAD — defense-in-depth so an interrupted retro can't silently block
   commits indefinitely.

Docs/hook only — pre-commit hooks should skip the test suite.