### PR TITLE
sprint(65): fix am-i-done compromise + harden test harness for parallel

### DIFF
--- a/.claude/diary/20260526.65.md
+++ b/.claude/diary/20260526.65.md
@@ -1,0 +1,53 @@
+# 2026-05-26 — am-i-done cache + test-harness parallel-safety (Sprint 65)
+
+## What was done
+
+14 PRs merged, v1.12.1 released. 14/14 planned (100%).
+
+**am-i-done cache (crown jewel):**
+- AST import-graph + per-file closure-hash test cache (#2408, PR #2446) — builds a reverse-dependency graph on the existing `scripts/rules/_engine/ast.ts` layer using `Bun.resolveSync` for specifier→path resolution (relative + `@mcp-cli/*` aliases + tsconfig paths + `export *` barrel following), hashes each spec's transitive import closure, and skips unchanged specs via `--path-ignore-patterns`. Wired into `changedTestsStep`.
+- Structured bun reporter (#2401, PR #2431) — replaced the `ZERO_FAIL_RE` stdout regex with `--reporter junit` XML parsing, with a **hybrid fallback to the stdout regex** because JUnit XML isn't flushed when bun segfaults in teardown (the #1004 case the guard exists for). Also fixed `readJunitFailures` to return `null` (not `0`) on a missing file — the coverage-masking bug.
+
+**Test-harness parallel-safety:**
+- spawnManaged for fixtures (#2413, PR #2449) — `startTestDaemon`/`startMockServer` now use spawnManaged (SIGTERM→SIGKILL + stderr drain); removed dead `Promise.race` timeout.
+- Pre-test orphan sweep (#2415, PR #2459) — `test/orphan-sweep.ts` preload SIGKILLs PPID-1 `--test-worker` processes; adversarial review caught a critical false-kill (broad `bun test` pattern would kill live CI test runs since PPID=1 is normal in containers).
+- validateFreeformTsc worktree flake (#2417, PR #2435) — root cause: `Bun.which("tsc")` searches `$PATH`, which only includes `node_modules/.bin` under `bun run`, not `bun test`. Fixed with `require.resolve("typescript/bin/tsc")` fallback.
+
+**Provider/lint quartet:**
+- provider-spec-shape rule (#2420, PR #2430), capability-flag-handler rule (#2421, PR #2440), acp-cost-tracking-evidence rule (#2419, PR #2452), agent-provider spec split (#2422, PR #2448).
+
+**DX/fixes:**
+- MCP_CLI_AI=0 opt-out (#2392, PR #2429), extractContent throws on isError (#2316, PR #2450), mcpctl Ink ErrorOverview crash → custom error boundary (#2351, PR #2433), error-sniffing suppressions (#2354, PR #2444), poll-until-headroom message (#2409, PR #2458).
+
+**Also closed:** 5 verdict-cache duplicate issues consolidated to #2427 (#2428/#2432/#2434/#2442).
+
+## What worked well
+
+- **Data beat assertion on the crown jewel.** The #2408 nerd-snipe gate returned NO-GO ("core edits are the common case → cache degenerates to `--changed`"). The user called it as an unsupported claim; the gate re-measured: **only 20% of the last 150 PRs touch core, 38.7% are single-leaf** (the cache's sweet spot). NO-GO → GO. The decisive correction was `Bun.resolveSync` (the gate had assumed a hand-rolled resolver = maintenance cost; Bun exposes its real resolver publicly).
+- **Routing risky logic to adversarial review regardless of churn paid off.** #2415 (process-killing orphan sweep) triaged low→qa on churn 60, but overriding to adversarial review caught a critical CI false-kill (PPID=1 is normal in containers; the broad `bun test` pattern would SIGKILL the live test run).
+- **Simplify-don't-patch ended the #2419 treadmill.** Evidence-detection churned 3 text-matching precision rounds (substring → regex → comment-skipping → block-comment edge case). One simplify pass to AST-based detection (`expect(state.cost)` CallExpression) collapsed the entire edge-case class.
+- **Churn-based triage auto-escalation** correctly bumped several "low"-planned rule PRs to high/adversarial-review (#2420 churn 197, #2354 IPC risk-area).
+
+## What didn't work
+
+- **Workers escaped their worktrees into the main checkout — twice.** A #2354 session rebased + committed the entire repair *in the main checkout*, switching main off `main` (commit 997c24e0 on `fix/issue-2354`), which **blocked all phase commands** ("phases only run from branch main"). Recovered by preserving the branch ref into a fresh worktree (`recover-2354`) and `git checkout main`. Separately, an empty-`--cwd` QA spawn (my locator returned blank, so `--cwd ""` defaulted to the main checkout) ran QA with no isolation. **Fix:** orchestrator must verify a spawned session's cwd is a worktree before trusting it; the empty-`--cwd` foot-gun needs a guard (filed as a follow-up consideration). Worktree-locator fragility (branch-name mismatches, `branch --show-current` returning empty) caused repeated false alarms — `git worktree list | grep -F "[branch]"` is the reliable form, not a `branch --show-current` loop.
+- **Verdict-cache pre-existing gap → 5-duplicate-issue + 3-PR sprawl.** `verdict-cache.ts` was at 66.7% line coverage on main (below the 80% floor); every fresh worktree hit it. Workers independently filed #2427/#2428/#2432/#2434/#2442 AND three PRs (#2401/#2417/#2420) each added their own fix. I let the #2417/#2420 overlap ride ("resolve at merge") instead of pinning one owner at the second hit, so it sprawled. **Fixes:** filed #2443 (meta: workers search existing issues before filing) and a bootstrap-sprint lessons.md amendment (de-bundle a shared pre-existing-main gap to one owner the moment a 2nd worktree hits it). Root cause of why it slipped to main: the per-file coverage ratchet is the *last* am-i-done step, after the daemon test step — the #1004/#2210/#2313 teardown segfault aborts am-i-done before the ratchet runs, and the coverage job's crash-tolerance passthrough can swallow the FAIL.
+- **`mcx pr comments resolve --all-addressed` is broken** (#2441) — GraphQL `pushedAt` field doesn't exist on `PullRequest`. Worked around by replying to threads directly (threads stayed unresolved-but-addressed).
+- **Orchestrator SSH push hung** during the #2354 recovery (likely a stale lock from the interrupted worker); HTTPS push failed for lack of creds. Resolved by handing the branch to a fresh worker (workers push fine).
+- **Orphaned `am-i-done` processes** from hours-old sessions (12:00PM, 4:03PM) were resident (~485MB each) adding system load — exactly what #2415's orphan sweep targets.
+
+## Patterns established
+
+- **Search-before-filing** (#2443 + bootstrap lesson): a failure reproducing on clean `main` is a *shared gap to flag*, not a per-PR fix to bundle.
+- **De-bundle on 2nd hit**: the moment a second worktree hits the same pre-existing-main gap, pin one PR as the fix owner and have the rest rebase/drop — don't let it sprawl.
+- **Route process-killing / inherently-risky logic to adversarial review** regardless of churn-based scrutiny.
+- **Verify spawned-session isolation**: confirm cwd is a worktree (not main) before trusting a spawn; never spawn with an unresolved/empty `--cwd`.
+
+## Stats
+
+- **PRs merged**: 14 / 14 (100%)
+- **Issues closed**: ~19 (14 sprint + 5 verdict-cache dups)
+- **New issues filed**: 6 (#2436, #2438, #2441, #2443, #2445, + #2408 deferred-polish follow-up)
+- **Adversarial reviews**: ~6 high-scrutiny PRs; notable catches — #2408 fatal cache-not-wired (round 1) + cycle self-inclusion (QA), #2415 CI false-kill, #2419 false-negative evidence check
+- **Repair rounds**: heaviest were #2408 (review→repair→review→QA→repair) and #2419 (3 text-matching rounds → simplify)
+- **Incident**: 1 main-checkout contamination (recovered, no work lost)

--- a/.claude/skills/bootstrap-sprint/references/lessons.md
+++ b/.claude/skills/bootstrap-sprint/references/lessons.md
@@ -396,3 +396,24 @@ in 7 of 8 siblings), not a type-layer abstraction that re-introduces
 coupling. Crucially, this constrains your lint rules: a rule must mechanize
 an invariant, never enforce DRY for its own sake. (mcp-cli writeup:
 `docs/architecture/duplication.md`.)
+
+**38. A small pre-existing gate failure on `main` becomes a duplicate
+cluster under parallel work.** When every fresh worktree runs the same
+whole-repo pre-merge gate (coverage ratchet, lint, `am-i-done`), a small
+*pre-existing* failure on `main` gets hit independently by every parallel
+session — and each one redundantly (a) files an issue for it and (b) bundles
+its own fix. Sprint 65 produced **five duplicate issues and three conflicting
+fix-PRs** for one 66.7%-coverage shortfall; the fixes then collided on the
+shared file. Two mechanizations: **workers** must search existing issues
+before filing and treat a failure that reproduces on clean `main` as a
+*shared gap to flag*, not a per-PR fix to bundle; the **orchestrator** must
+de-bundle the shared gap to a single fast-track owner the moment a *second*
+worktree hits it (one PR carries the fix, the rest rebase and drop their
+copies) instead of letting it sprawl. When bootstrapping a sprint skill,
+detect this risk by checking whether the project's pre-push gate is
+**whole-repo (vs diff-scoped)** and whether `main` is currently green under
+it — a whole-repo gate plus a near-threshold file is the setup for the
+cluster. (Related: the gate may also be *masked* — if the ratchet runs after
+a flaky-crash-prone step, a teardown segfault can abort the run before the
+gate executes, letting the under-covered file slip onto `main` in the first
+place.)

--- a/.claude/sprints/sprint-65.md
+++ b/.claude/sprints/sprint-65.md
@@ -1,6 +1,6 @@
 # Sprint 65
 
-> Planned 2026-05-26 17:55 EDT. Target: 14 work items.
+> Planned 2026-05-26 17:55 EDT. Started 2026-05-26 15:37 EDT. Target: 14 work items.
 
 ## Goal
 

--- a/.claude/sprints/sprint-65.md
+++ b/.claude/sprints/sprint-65.md
@@ -130,3 +130,14 @@ capacity without overcommitting on theme.
   but post-sprint).
 - **Defer:** #1250 (sprint wind-down rebuild concurrent cross-repo —
   cross-cutting orchestrator concern, off-theme).
+
+## Results
+
+- **Released**: v1.12.1 (patch — internal tooling/rules/test-infra + fixes; no new top-level command)
+- **PRs merged**: 14 / 14 planned (100%)
+- **Issues closed**: 14 sprint issues + 5 verdict-cache duplicates consolidated to #2427 (#2428/#2432/#2434/#2442)
+- **Issues dropped**: 0
+- **New issues filed**: #2436 (upstream Ink ErrorOverview bug), #2438 (no-import-cycles rule, builds on #2408 graph), #2441 (mcx `pr comments resolve` GraphQL bug), #2443 (meta: search-before-filing), #2445 (verdict-cache determinism flaky), + #2408 deferred-polish follow-up (LRU eviction / graph-build benchmark)
+- **Crown jewel**: #2408 AST import-graph + per-file closure-hash test cache (via `Bun.resolveSync`) — shipped after the gate's NO-GO was overturned by data (only 20% of PRs touch core; the cache wins on the ~80% leaf/narrow majority)
+- **Incident (recovered)**: a #2354 session escaped its worktree into the main checkout (rebased + committed there), switching main off `main` and blocking phase commands; recovered by preserving the branch ref into a fresh worktree and restoring main. Plus an empty-`--cwd` QA mis-spawn into main checkout. Both retro items.
+- **Convergence saves**: #2419 evidence-detection churned 3 text-matching precision rounds → simplified to AST-based detection (ended the treadmill)

--- a/.claude/sprints/sprint-65.md
+++ b/.claude/sprints/sprint-65.md
@@ -1,6 +1,6 @@
 # Sprint 65
 
-> Planned 2026-05-26 17:55 EDT. Started 2026-05-26 15:37 EDT. Target: 14 work items.
+> Planned 2026-05-26 17:55 EDT. Started 2026-05-26 15:37 EDT. Completed 2026-05-26 20:45 EDT. Target: 14 work items. Result: 14/14 merged.
 
 ## Goal
 

--- a/.claude/sprints/sprint-65.md
+++ b/.claude/sprints/sprint-65.md
@@ -1,0 +1,132 @@
+# Sprint 65
+
+> Planned 2026-05-26 17:55 EDT. Target: 14 work items.
+
+## Goal
+
+Fix the `am-i-done` compromise — ship the AST import-graph + closure-hash test
+cache (the deferred half of #2396), then harden the test harness for parallel
+safety (fixture teardown, orphan sweep), clean up the rule-engine follow-ups,
+and clear DX papercuts. Theme: flaky tests / test harness / parallel testing /
+DX.
+
+## Issues
+
+| # | Title | Scrutiny | Batch | Model | Category |
+|---|-------|----------|-------|-------|----------|
+| 2408 | AST import-graph + per-file closure-hash test cache for am-i-done | high | 1 | opus | goal |
+| 2401 | replace ZERO_FAIL_RE prose-regex with structured bun reporter output | low | 1 | sonnet | goal |
+| 2392 | detectContext: documented `MCP_CLI_AI=0` opt-out is a no-op (truthy string) | low | 1 | sonnet | filler |
+| 2354 | fix(rules): remediate 3 no-error-message-sniffing suppressions | low | 1 | sonnet | goal |
+| 2421 | feat: capability-flag lint rule — costTracking/compactLog without matching handler | med | 1 | opus | goal |
+| 2413 | test infra: route echo-server + long-lived fixtures through spawnManaged | med | 2 | opus | goal |
+| 2417 | flaky(local): validateFreeformTsc tests fail in worktree environment | med | 2 | opus | goal |
+| 2420 | rule: provider spec tests must assert capability shape, not cardinality | low | 2 | sonnet | goal |
+| 2316 | bug(core): extractContent / mcp-proxy ignores isError — alias scripts get errors as data | low | 2 | sonnet | filler |
+| 2409 | poll-until-headroom rule: setDefaultTimeout interaction not well-documented | low | 2 | sonnet | goal |
+| 2415 | test infra: pre-test orphan sweep for leaked workers and fixtures | med | 3 | opus | goal |
+| 2422 | test: provider cardinality spec vs capability-shape spec — split agent-provider.spec.ts | low | 3 | sonnet | goal |
+| 2419 | rule: costTracking: true on ACP provider requires acp-event-map test | low | 3 | sonnet | goal |
+| 2351 | mcpctl: TUI crashes (TypeError t.type) when viewing session logs with stack-trace output | med | 3 | opus | filler |
+
+## Batch Plan
+
+### Batch 1 (immediate)
+#2408, #2401, #2392, #2354, #2421
+
+### Batch 2 (backfill)
+#2413, #2417, #2420, #2316, #2409
+
+### Batch 3 (backfill)
+#2415, #2422, #2419, #2351
+
+### Dependency edges (translate to `addBlockedBy` at run time)
+- #2408 blockedBy #2401 (both touch `scripts/_runner/ci-steps.ts`; structured-bun-reporter cleanup precedes test-cache wiring)
+- #2415 blockedBy #2408 (orphan sweep integrates with the runner where the AST cache lives)
+- #2422 blockedBy #2420 (both touch `packages/acp/src/agents.spec.ts`; capability-shape assertions land before the split)
+- #2419 blockedBy #2422 (acp-event-map test added inside the now-split spec)
+- #2409 blockedBy #2401 (both touch `scripts/_runner/ci-steps.ts` test-output handling — #2409 is doc-only but anchors a comment near the reporter logic)
+
+### Hot-shared files (cross-batch broadcast targets)
+- `scripts/_runner/ci-steps.ts`: #2401, #2408, #2409, #2415 — second-and-later PRs must rebase + check for shared-region edits
+- `packages/acp/src/agents.spec.ts`: #2420, #2422, #2419 — strict serialization required
+- `packages/core/src/alias.ts` family: #2316 stands alone but watch for any worker also touching `extractContent` callers
+
+### Nerd-snipe gate (mandatory before impl spawn)
+- **#2408** (HIGH scrutiny): 200–400 LOC of new AST graph-resolver code, including specifier→path resolution (relative + `@mcp-cli/*` workspace-alias + tsconfig paths), barrel (`export *`) following, and reverse-index. Adversarial review mandatory. Investigation already documents the trade-off vs leaning entirely on `bun test --changed` — the gate should confirm we build the resolver (committing to the bonus rules upside: dead-export, find-circular-deps) rather than reverse course.
+- **#2417** (worktree-only flake): env-specific. Unclear what's different about a worktree env that breaks the spawned `tsc` binary. Gate must establish mechanism (PATH? cwd? GIT_DIR leak even after sprint 64's `gitSafeEnv` fix?) before patching. Hard-fail outcome = `needs-attention`.
+- **#2351** (TUI crash with minified stack from compiled binary): bug location is the Ink stack-frame parser. Gate must find the source-level component before any fix lands; "shotgun a try/catch" is the wrong answer.
+
+## Context
+
+**Theme genesis (user direction):** Sprint 64 closed by deferring half of #2396 —
+the verdict cache shipped (PR #2406) but the AST import-graph piece was
+explicitly scope-cut and refiled as #2408. The compromise: `am-i-done
+--pre-push` runs `bun test --changed` only, missing tests that depend
+transitively on changed source. The user's call: *"the compromise we made to
+cut out most tests from am-i-done is a real problem, we know how to fix it
+right."* So sprint 65's crown jewel is #2408 — build the real AST resolver +
+closure-hash cache on the existing rule-engine AST layer (`scripts/rules/_engine/ast.ts`).
+
+**Pre-paid investigation (don't re-pay):** #2408's body documents the feasibility
+study from 2026-05-26 — the right shape is ~200–400 LOC on the existing AST
+layer, with barrel `export *` following and tsconfig-path resolution. The
+alternative ("lean on bun's `--changed`") is also documented; the nerd-snipe
+gate should confirm direction before implementation, not redo the survey.
+
+**Test-harness arc (parallel-safety follow-through):** Sprint 64 proved the
+suite is 0-flake-across-22k-runs once leaked processes are gone. #2413
+(spawnManaged for fixtures) + #2415 (pre-test orphan sweep) + #2417
+(validateFreeformTsc worktree flake) finish what sprint 64's `--no-orphans`
+push started. Goal: make parallel test runs the *default*, not a brittle
+opt-in.
+
+**Provider/lint quartet (governance):** #2419/#2420/#2421/#2422 close the
+follow-ups filed during sprint 64's grok-provider adversarial review (PR
+#2391). #2421 ships a new rule (independent file); #2420/#2422/#2419 chain
+on `agents.spec.ts`. Together they prevent the next provider onboarding
+from re-paying for the same review findings.
+
+**DX cluster (filler):** #2392 (MCP_CLI_AI=0 truthy-string bug), #2316
+(extractContent silently treats error-result as data), #2351 (mcpctl TUI
+crashes on stack-trace logs) — three independent papercuts that round out
+capacity without overcommitting on theme.
+
+### Meta dispositions (Step 1a — APPLIED PRE-SPRINT)
+- **#2333 — applied** in PR #2425 (auto-merged): codify Bun's
+  condition-based-waiting test philosophy into `CLAUDE.md` + `test/CLAUDE.md`.
+  On-theme with sprint 64's flaky-test rules.
+- **#2398 — applied** in PR #2424 (auto-merged): retro guarantees the
+  `.active` sentinel clear + `.git-hooks/sprint-active.sh` auto-clears a
+  stale sentinel whose sprint is already squash-merged on HEAD.
+- **#2350 — deferred:** `/rule-author` consolidation. Larger lift; defer
+  to a dedicated skill-cleanup pass.
+- **#2343 — long-tail watch:** worker `.claire` mangled-path bug. Not
+  recurred since sprint 62; per user, keep open as watchpoint rather than
+  close.
+- **#2393 — epic, keep open:** Grok-harness-as-first-class-citizen.
+
+### Pending board hygiene (workers can do as side-effects, otherwise retro)
+- Close #2245, #2260, #2334, #2339 as dups of #2330 (sprint 64 PR #2404
+  consolidated them; consolidation noted in commit message). Sprint 64
+  retro already pre-classified these.
+- Close #2407 as done (`case "grok":` already in `packages/command/src/main.ts:421`).
+- Close #2416 as done (`describe("getProcessStartTime retry")` already in
+  `packages/daemon/src/process-identity.spec.ts:67`).
+
+### Excluded from candidacy (per Explore recon)
+- **Defer:** #2210, #2313 (Bun 1.3.14 segfault/bus-error — cannot fix
+  without upstream Bun patch or version bump; package.json pinned to
+  >=1.3.14).
+- **Defer:** #2215 (CI pty-test actions/checkout auth — orthogonal
+  GitHub Actions issue).
+- **Defer:** #2232, #2233, #2234 (Claude session NDJSON/stream-json
+  handling — out of theme; revisit in next session-arc sprint).
+- **Defer:** #2186 (phase impl in-handler auto-spawn — orchestrator infra,
+  off-theme).
+- **Defer:** #2423 (provider re-detect on SIGHUP — daemon refactor,
+  off-theme).
+- **Defer:** #1639 (event-bus-subscribers gauge testable — complementary
+  but post-sprint).
+- **Defer:** #1250 (sprint wind-down rebuild concurrent cross-repo —
+  cross-cutting orchestrator concern, off-theme).

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "bun": ">=1.3.14"
   },
-  "version": "1.12.0",
+  "version": "1.12.1",
   "description": "MCP CLI — call MCP server tools from the command line with zero context overhead",
   "type": "module",
   "workspaces": ["packages/*"],


### PR DESCRIPTION
Sprint 65 container PR. Accumulates every sprint-meta commit on the
`sprint-65` branch:

- plan + any mid-sprint amendments
- run-time edits (Started/Ended timestamps, Excluded section)
- Results summary
- retro diary file
- release commit (if a release is cut this sprint)

Marked **draft** until `/sprint retro` flips it ready and arms auto-merge.

## Goal

Fix the `am-i-done` compromise — ship the AST import-graph + closure-hash
test cache (the deferred half of #2396), harden the test harness for
parallel safety, clean up rule-engine follow-ups, clear DX papercuts.
Theme: flaky tests / test harness / parallel testing / DX.

## Crown jewel: #2408
200–400 LOC AST graph resolver on the existing rule-engine AST layer
(`scripts/rules/_engine/ast.ts`). Specifier→path resolution +
`export *` barrel following + reverse-index + transitive closure hash.
Adversarial review mandatory.

## 14 picks
- **Batch 1**: #2408 · #2401 · #2392 · #2354 · #2421
- **Batch 2**: #2413 · #2417 · #2420 · #2316 · #2409
- **Batch 3**: #2415 · #2422 · #2419 · #2351

See `.claude/sprints/sprint-65.md` for the full plan, dependency edges,
hot-shared file annotations, and nerd-snipe-gate dispositions.

Docs/skill-only by construction — pre-commit hooks should skip the test suite.