### PR TITLE
fix(context): treat MCP_CLI_AI=0/false as explicit ai opt-out (fixes #2392)

### DIFF
--- a/scripts/_runner/context.spec.ts
+++ b/scripts/_runner/context.spec.ts
@@ -15,11 +15,14 @@ describe("detectContext", () => {
     expect(detectContext({ MCP_CLI_AI: "1" })).toBe("ai");
   });
 
-  it("MCP_CLI_AI=0 opts out of ai even when CLAUDECODE/AGENT are set", () => {
-    // The documented escape hatch: explicit "0" or "false" forces streaming
-    // output even in an AI-var environment (e.g. grok running inside Claude).
+  it("MCP_CLI_AI=0 or MCP_CLI_AI=false opts out of ai", () => {
     expect(detectContext({ MCP_CLI_AI: "0" })).not.toBe("ai");
     expect(detectContext({ MCP_CLI_AI: "false" })).not.toBe("ai");
+  });
+
+  it("MCP_CLI_AI=0 opt-out overrides CLAUDECODE and AGENT", () => {
+    // The documented escape hatch: explicit opt-out wins even when other AI
+    // vars are set (e.g. a non-Claude agent running inside a Claude session).
     expect(detectContext({ MCP_CLI_AI: "0", CLAUDECODE: "1" })).not.toBe("ai");
     expect(detectContext({ MCP_CLI_AI: "0", AGENT: "grok" })).not.toBe("ai");
     expect(detectContext({ MCP_CLI_AI: "false", CLAUDECODE: "1", AGENT: "x" })).not.toBe("ai");

--- a/scripts/_runner/context.spec.ts
+++ b/scripts/_runner/context.spec.ts
@@ -15,6 +15,16 @@ describe("detectContext", () => {
     expect(detectContext({ MCP_CLI_AI: "1" })).toBe("ai");
   });
 
+  it("MCP_CLI_AI=0 opts out of ai even when CLAUDECODE/AGENT are set", () => {
+    // The documented escape hatch: explicit "0" or "false" forces streaming
+    // output even in an AI-var environment (e.g. grok running inside Claude).
+    expect(detectContext({ MCP_CLI_AI: "0" })).not.toBe("ai");
+    expect(detectContext({ MCP_CLI_AI: "false" })).not.toBe("ai");
+    expect(detectContext({ MCP_CLI_AI: "0", CLAUDECODE: "1" })).not.toBe("ai");
+    expect(detectContext({ MCP_CLI_AI: "0", AGENT: "grok" })).not.toBe("ai");
+    expect(detectContext({ MCP_CLI_AI: "false", CLAUDECODE: "1", AGENT: "x" })).not.toBe("ai");
+  });
+
   it("returns 'ai' when both CI and CLAUDECODE are set (agent-driven CI)", () => {
     // Without this precedence, an agent-driven CI run streams to the
     // workflow log instead of capturing to file — defeating the whole

--- a/scripts/_runner/context.ts
+++ b/scripts/_runner/context.ts
@@ -23,12 +23,20 @@
 
 import type { ExecutionContext } from "./types";
 
+// "0" and "false" are explicit opt-outs; anything else (including absent) is
+// neither an explicit opt-in nor an explicit opt-out.
+function isFalsyEnv(val: string | undefined): boolean {
+  return val === "0" || val === "false";
+}
+
 export function detectContext(env: Record<string, string | undefined> = process.env): ExecutionContext {
   // AI vars take priority over CI: an agent-driven workflow (e.g. Claude
   // Action) sets both, and the file-logger context-preservation behaviour
-  // is the whole reason this project tracks audience. Set MCP_CLI_AI=0
-  // (or leave AI vars unset) to opt back into the CI streaming path.
-  if (env.CLAUDECODE || env.AGENT || env.MCP_CLI_AI) return "ai";
+  // is the whole reason this project tracks audience. Set MCP_CLI_AI=0 or
+  // MCP_CLI_AI=false to force-opt back into the streaming path — this
+  // override wins even when CLAUDECODE/AGENT are set (e.g. a non-Claude
+  // agent running inside a Claude session).
+  if (!isFalsyEnv(env.MCP_CLI_AI) && (env.CLAUDECODE || env.AGENT || env.MCP_CLI_AI)) return "ai";
   if (env.GITHUB_ACTIONS || env.CI) return "ci";
   const shell = env.SHELL?.split("/").pop() ?? "";
   if (["sh", "bash", "zsh"].includes(shell)) return "sh";

--- a/scripts/_runner/context.ts
+++ b/scripts/_runner/context.ts
@@ -23,9 +23,9 @@
 
 import type { ExecutionContext } from "./types";
 
-// "0" and "false" are explicit opt-outs; anything else (including absent) is
-// neither an explicit opt-in nor an explicit opt-out.
-function isFalsyEnv(val: string | undefined): boolean {
+// Returns true only when MCP_CLI_AI is explicitly set to "0" or "false" —
+// the two values that signal an intentional opt-out of the ai context.
+function isExplicitAiOptOut(val: string | undefined): boolean {
   return val === "0" || val === "false";
 }
 
@@ -36,7 +36,7 @@ export function detectContext(env: Record<string, string | undefined> = process.
   // MCP_CLI_AI=false to force-opt back into the streaming path — this
   // override wins even when CLAUDECODE/AGENT are set (e.g. a non-Claude
   // agent running inside a Claude session).
-  if (!isFalsyEnv(env.MCP_CLI_AI) && (env.CLAUDECODE || env.AGENT || env.MCP_CLI_AI)) return "ai";
+  if (!isExplicitAiOptOut(env.MCP_CLI_AI) && (env.CLAUDECODE || env.AGENT || env.MCP_CLI_AI)) return "ai";
   if (env.GITHUB_ACTIONS || env.CI) return "ci";
   const shell = env.SHELL?.split("/").pop() ?? "";
   if (["sh", "bash", "zsh"].includes(shell)) return "sh";


### PR DESCRIPTION
## Summary

- `MCP_CLI_AI=0` was a no-op because the string `"0"` is truthy in JS — any assignment, including `=0`, forced `"ai"` context
- Add `isFalsyEnv` helper that treats `"0"` and `"false"` as explicit opt-outs
- An explicit `MCP_CLI_AI=0` now overrides `CLAUDECODE`/`AGENT` — giving non-Claude agents (e.g. grok) a clean way to get streaming output without needing `--verbose` or `unset`

## Test plan

- [x] Existing 7 tests still pass unchanged
- [x] New test: `MCP_CLI_AI: "0"` returns non-ai
- [x] New test: `MCP_CLI_AI: "false"` returns non-ai
- [x] New test: `MCP_CLI_AI: "0"` + `CLAUDECODE: "1"` returns non-ai (override wins)
- [x] New test: `MCP_CLI_AI: "0"` + `AGENT: "grok"` returns non-ai
- [x] Pre-commit static gate passes (`bun run am-i-done --pre-commit`)
- [x] Pre-existing `verdict-cache.ts` coverage failure filed as #2428 (not introduced by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)