### PR TITLE
feat(rules): provider-spec-shape rule — assert capability shape, not registry count (closes #2420)

### DIFF
--- a/packages/core/src/agent-provider.spec.ts
+++ b/packages/core/src/agent-provider.spec.ts
@@ -89,12 +89,6 @@ describe("agent-provider", () => {
       expect(args.agentOverride).toBe("grok");
     });
 
-    test("getAllProviders returns all 8 built-in providers (including grok via ACP)", () => {
-      const all = getAllProviders();
-      const names = all.map((p) => p.name).sort();
-      expect(names).toEqual(["acp", "claude", "codex", "copilot", "gemini", "grok", "mock", "opencode"]);
-    });
-
     test("unknown provider returns undefined", () => {
       expect(getProvider("nonexistent")).toBeUndefined();
     });

--- a/scripts/_runner/verdict-cache.spec.ts
+++ b/scripts/_runner/verdict-cache.spec.ts
@@ -103,6 +103,8 @@ describe("computeVerdictKey", () => {
     const base = "HEAD~1";
     const key1 = computeVerdictKey(() => base);
     const key2 = computeVerdictKey(() => base);
+    expect(key1).not.toBeNull();
+    expect(key2).not.toBeNull();
     expect(key1).toEqual(key2);
   });
 

--- a/scripts/rules/fixtures/provider-spec-shape__clean.fixture.ts
+++ b/scripts/rules/fixtures/provider-spec-shape__clean.fixture.ts
@@ -5,12 +5,14 @@
  *
  * Per-provider shape assertions and non-enumeration uses of getAllProviders are fine.
  * toEqual([]) (empty/reset check) and toEqual([objRef]) (full object assertion) are also fine.
+ * Shape assertions on individual elements obtained via .find are not flagged.
+ * test.skip/.only with a non-enumeration assertion is not flagged.
  */
 
 import { expect, test } from "bun:test";
 
 declare function getAllProviders(): { name: string; serverName: string; native: { worktree: boolean } }[];
-declare function getAllShims(): { feature: string }[];
+declare function getAllShims(): { feature: string; allowedPhases: string[] }[];
 declare function getProvider(name: string): { name: string; serverName: string; native: { worktree: boolean } } | undefined;
 declare function _resetRegistries(): void;
 
@@ -41,4 +43,28 @@ test("toEqual([]) is a reset/empty check — not an enumeration", () => {
 test("toEqual([objRef]) asserts full shape — legitimate", () => {
   const shim = { feature: "worktree" as const, appliesTo: () => true };
   expect(getAllShims()).toEqual([shim]);
+});
+
+// Shape assertion on an individual element obtained via .find is not a registry
+// enumeration — .find is a collection-consuming operation, not collection-preserving.
+test("getAllShims().find() then toEqual([literals]) on element property — not an enumeration", () => {
+  const shims = getAllShims();
+  const worktree = shims.find((s) => s.feature === "worktree");
+  expect(worktree?.allowedPhases).toEqual(["impl", "qa", "repair"]);
+});
+
+// test.skip with a non-enumeration assertion is fine
+test.skip("skipped shape assertion — not flagged", () => {
+  const p = getProvider("claude");
+  expect(p?.serverName).toBe("_claude");
+});
+
+// toEqual([literals]) on a value unrelated to the registry is fine even when
+// getAllProviders() appears in the same test body for an unrelated purpose
+test("registry call for iteration + unrelated toEqual([literals]) on separate value — not flagged", () => {
+  const all = getAllProviders();
+  const claudeExists = all.some((p) => p.name === "claude");
+  expect(claudeExists).toBe(true);
+  const phases = ["impl", "qa", "repair"];
+  expect(phases).toEqual(["impl", "qa", "repair"]); // not registry-derived
 });

--- a/scripts/rules/fixtures/provider-spec-shape__clean.fixture.ts
+++ b/scripts/rules/fixtures/provider-spec-shape__clean.fixture.ts
@@ -1,0 +1,44 @@
+/**
+ * @rule provider-spec-shape
+ * @expect 0
+ * @path packages/core/src/agent-provider.spec.ts
+ *
+ * Per-provider shape assertions and non-enumeration uses of getAllProviders are fine.
+ * toEqual([]) (empty/reset check) and toEqual([objRef]) (full object assertion) are also fine.
+ */
+
+import { expect, test } from "bun:test";
+
+declare function getAllProviders(): { name: string; serverName: string; native: { worktree: boolean } }[];
+declare function getAllShims(): { feature: string }[];
+declare function getProvider(name: string): { name: string; serverName: string; native: { worktree: boolean } } | undefined;
+declare function _resetRegistries(): void;
+
+test("shape assertion on individual provider — load-bearing", () => {
+  const p = getProvider("claude");
+  expect(p).toBeDefined();
+  expect(p?.serverName).toBe("_claude");
+  expect(p?.native.worktree).toBe(true);
+});
+
+test("getAllProviders used for iteration without enumeration assertion", () => {
+  for (const p of getAllProviders()) {
+    expect(p.name.length).toBeGreaterThan(0);
+  }
+});
+
+test("getAllShims for a non-enumeration check", () => {
+  const all = getAllProviders();
+  expect(all.every((p) => p.serverName.startsWith("_"))).toBe(true);
+});
+
+test("toEqual([]) is a reset/empty check — not an enumeration", () => {
+  _resetRegistries();
+  expect(getAllProviders()).toEqual([]);
+  expect(getAllShims()).toEqual([]);
+});
+
+test("toEqual([objRef]) asserts full shape — legitimate", () => {
+  const shim = { feature: "worktree" as const, appliesTo: () => true };
+  expect(getAllShims()).toEqual([shim]);
+});

--- a/scripts/rules/fixtures/provider-spec-shape__clean.fixture.ts
+++ b/scripts/rules/fixtures/provider-spec-shape__clean.fixture.ts
@@ -29,7 +29,7 @@ test("getAllProviders used for iteration without enumeration assertion", () => {
   }
 });
 
-test("getAllShims for a non-enumeration check", () => {
+test("getAllProviders for a non-enumeration check", () => {
   const all = getAllProviders();
   expect(all.every((p) => p.serverName.startsWith("_"))).toBe(true);
 });
@@ -52,6 +52,9 @@ test("getAllShims().find() then toEqual([literals]) on element property — not 
   const worktree = shims.find((s) => s.feature === "worktree");
   expect(worktree?.allowedPhases).toEqual(["impl", "qa", "repair"]);
 });
+
+// concise-arrow non-enumeration assertion — not flagged
+test("concise arrow — non-enumeration check", () => expect(getAllProviders().every((p) => p.serverName.startsWith("_"))).toBe(true));
 
 // test.skip with a non-enumeration assertion is fine
 test.skip("skipped shape assertion — not flagged", () => {

--- a/scripts/rules/fixtures/provider-spec-shape__flagged.fixture.ts
+++ b/scripts/rules/fixtures/provider-spec-shape__flagged.fixture.ts
@@ -1,0 +1,21 @@
+/**
+ * @rule provider-spec-shape
+ * @expect 2
+ * @path packages/core/src/agent-provider.spec.ts
+ *
+ * Registry enumeration assertions must be flagged.
+ */
+
+import { expect, test } from "bun:test";
+
+declare function getAllProviders(): { name: string }[];
+declare function getAllShims(): { feature: string }[];
+
+test("count assertion — pure bump on new provider", () => {
+  expect(getAllProviders()).toHaveLength(8);
+});
+
+test("name list assertion — still a count by another name", () => {
+  const names = getAllProviders().map((p) => p.name).sort();
+  expect(names).toEqual(["acp", "claude", "codex", "copilot", "gemini", "grok", "mock", "opencode"]);
+});

--- a/scripts/rules/fixtures/provider-spec-shape__flagged.fixture.ts
+++ b/scripts/rules/fixtures/provider-spec-shape__flagged.fixture.ts
@@ -1,6 +1,6 @@
 /**
  * @rule provider-spec-shape
- * @expect 2
+ * @expect 5
  * @path packages/core/src/agent-provider.spec.ts
  *
  * Registry enumeration assertions must be flagged.
@@ -18,4 +18,20 @@ test("count assertion — pure bump on new provider", () => {
 test("name list assertion — still a count by another name", () => {
   const names = getAllProviders().map((p) => p.name).sort();
   expect(names).toEqual(["acp", "claude", "codex", "copilot", "gemini", "grok", "mock", "opencode"]);
+});
+
+// test.skip does not exempt the assertion from the rule
+test.skip("skipped count assertion — still flagged", () => {
+  expect(getAllProviders()).toHaveLength(8);
+});
+
+// .length + toBe is equivalent to toHaveLength — both are count assertions
+test(".length + toBe — enumeration via property access", () => {
+  expect(getAllProviders().length).toBe(8);
+});
+
+// .length on a tracked variable + toEqual(N) is the same violation
+test(".length on a derived variable + toEqual — enumeration", () => {
+  const all = getAllProviders();
+  expect(all.length).toEqual(8);
 });

--- a/scripts/rules/fixtures/provider-spec-shape__flagged.fixture.ts
+++ b/scripts/rules/fixtures/provider-spec-shape__flagged.fixture.ts
@@ -1,6 +1,6 @@
 /**
  * @rule provider-spec-shape
- * @expect 5
+ * @expect 6
  * @path packages/core/src/agent-provider.spec.ts
  *
  * Registry enumeration assertions must be flagged.
@@ -35,3 +35,6 @@ test(".length on a derived variable + toEqual — enumeration", () => {
   const all = getAllProviders();
   expect(all.length).toEqual(8);
 });
+
+// concise-arrow expression body — still flagged
+test("concise arrow — count assertion", () => expect(getAllProviders()).toHaveLength(8));

--- a/scripts/rules/provider-spec-shape.rule.ts
+++ b/scripts/rules/provider-spec-shape.rule.ts
@@ -30,7 +30,6 @@
  *   tracked — shape assertions on individual elements are legitimate.
  *
  * Known limitations:
- *   - test.each with a concise arrow body (no curly braces) is not inspected
  *   - describe-scope registry calls are not tracked across nested test bodies
  *   - helper function indirection (const counts = () => getAllProviders().length)
  *     is not detected — it is a syntactic guard, not a semantic one
@@ -167,9 +166,8 @@ function isTestCallback(node: ts.Node): boolean {
 function findTestCallbackBody(node: ts.Node): ts.Node | undefined {
   if (isTestCallback(node)) {
     const call = node as ts.CallExpression;
-    // test("name", () => { ... }) — callback is the last argument
     const last = call.arguments[call.arguments.length - 1];
-    if (last && (ts.isArrowFunction(last) || ts.isFunctionExpression(last)) && ts.isBlock(last.body)) {
+    if (last && (ts.isArrowFunction(last) || ts.isFunctionExpression(last))) {
       return last.body;
     }
   }

--- a/scripts/rules/provider-spec-shape.rule.ts
+++ b/scripts/rules/provider-spec-shape.rule.ts
@@ -15,11 +15,25 @@
  * already prove membership implicitly (getProvider would return undefined if
  * the provider wasn't registered, and requireProvider guards on that).
  *
- * Detection strategy: within a single test/it callback, if getAllProviders() or
- * getAllShims() is called AND a toHaveLength or toEqual(array) assertion is
- * present, flag the assertion. The intermediate-variable pattern
- * (const names = getAllProviders().map(...); expect(names).toEqual([...]))
- * is covered by scope-level detection.
+ * Detection strategy:
+ *   Within a test/it/test.skip/test.only/test.each callback body, if
+ *   getAllProviders() or getAllShims() is called AND the subject of an
+ *   expect() assertion is syntactically traceable to that registry call
+ *   (direct call, collection-preserving chain, or a variable assigned from
+ *   one), flag enumeration assertions:
+ *     - toHaveLength(N>0) or toEqual([...string/number literals...])
+ *       when the subject is the collection itself
+ *     - toBe(N>0) or toEqual(N>0) when the subject is the collection's .length
+ *
+ *   The intermediate-variable pattern is handled via collectCollectionVars.
+ *   Collection-consuming operations (.find, .reduce, index access) are NOT
+ *   tracked — shape assertions on individual elements are legitimate.
+ *
+ * Known limitations:
+ *   - test.each with a concise arrow body (no curly braces) is not inspected
+ *   - describe-scope registry calls are not tracked across nested test bodies
+ *   - helper function indirection (const counts = () => getAllProviders().length)
+ *     is not detected — it is a syntactic guard, not a semantic one
  *
  * Sources: #2420, flagged in #2391 adversarial review.
  */
@@ -31,39 +45,123 @@ function isRegistryIdentifier(node: ts.Node): boolean {
   return ts.isIdentifier(node) && (node.text === "getAllProviders" || node.text === "getAllShims");
 }
 
-function containsRegistryCall(node: ts.Node): boolean {
+// Quick scan (shallow — stops at nested function bodies): does this test body
+// contain a direct getAllProviders/getAllShims call?
+function containsRegistryCallShallow(node: ts.Node): boolean {
   if (ts.isCallExpression(node) && isRegistryIdentifier(node.expression)) return true;
-  return ts.forEachChild(node, containsRegistryCall) ?? false;
+  if (ts.isArrowFunction(node) || ts.isFunctionExpression(node) || ts.isFunctionDeclaration(node)) return false;
+  return ts.forEachChild(node, containsRegistryCallShallow) ?? false;
 }
 
 function isStringOrNumberLiteral(node: ts.Node): boolean {
   return ts.isStringLiteral(node) || ts.isNumericLiteral(node);
 }
 
-function isEnumerationAssertion(methodName: string, args: ts.NodeArray<ts.Expression>): boolean {
-  // toHaveLength(N) where N > 0 — a non-zero count is a mechanical bump target.
-  // N = 0 (emptiness check) is legitimate (e.g. after _resetRegistries).
-  if (methodName === "toHaveLength" && args.length === 1) {
-    const arg = args[0];
-    return arg !== undefined && ts.isNumericLiteral(arg) && Number(arg.text) > 0;
+// Methods that preserve collection identity (result is still a collection of registry items).
+// Excludes .find, .reduce, .at, [N] — those produce single elements or scalars.
+const COLLECTION_METHODS = new Set(["map", "filter", "sort", "slice", "concat", "flatMap", "reverse"]);
+
+// Is `node` the registry collection (or a collection-preserving chain thereof)?
+// Does NOT include single-element results (.find, index access, etc.).
+function isRegistryCollection(node: ts.Node, collectionVars: Set<string>): boolean {
+  if (ts.isCallExpression(node)) {
+    if (isRegistryIdentifier(node.expression)) return true;
+    if (ts.isPropertyAccessExpression(node.expression) && COLLECTION_METHODS.has(node.expression.name.text)) {
+      return isRegistryCollection(node.expression.expression, collectionVars);
+    }
   }
-  // toEqual([s1, s2, ...]) where every element is a string/number literal —
-  // this is a name/count list, not a shape assertion.
-  // toEqual([]) and toEqual([objRef]) are legitimate and must not be flagged.
-  if (methodName === "toEqual" && args.length === 1) {
-    const arg = args[0];
-    if (!arg || !ts.isArrayLiteralExpression(arg)) return false;
-    if (arg.elements.length === 0) return false; // empty check is fine
+  if (ts.isParenthesizedExpression(node)) return isRegistryCollection(node.expression, collectionVars);
+  return ts.isIdentifier(node) && collectionVars.has(node.text);
+}
+
+// Is `node` the .length of a registry collection?
+function isRegistryLength(node: ts.Node, collectionVars: Set<string>): boolean {
+  return (
+    ts.isPropertyAccessExpression(node) &&
+    node.name.text === "length" &&
+    isRegistryCollection(node.expression, collectionVars)
+  );
+}
+
+// Walk body without descending into nested function bodies.
+function walkShallow(node: ts.Node, visit: (n: ts.Node) => void): void {
+  visit(node);
+  ts.forEachChild(node, (child) => {
+    if (ts.isArrowFunction(child) || ts.isFunctionExpression(child) || ts.isFunctionDeclaration(child)) return;
+    walkShallow(child, visit);
+  });
+}
+
+// Collect variables in the test body that are assigned from a registry collection.
+// Two passes handle one-hop derivation: const a = getAllProviders(); const b = a.map(...).
+function collectCollectionVars(body: ts.Node): Set<string> {
+  const vars = new Set<string>();
+  for (let pass = 0; pass < 2; pass++) {
+    walkShallow(body, (node) => {
+      if (
+        ts.isVariableDeclaration(node) &&
+        node.initializer &&
+        ts.isIdentifier(node.name) &&
+        !vars.has(node.name.text) &&
+        isRegistryCollection(node.initializer, vars)
+      ) {
+        vars.add(node.name.text);
+      }
+    });
+  }
+  return vars;
+}
+
+// Resolve the subject of an expect() call, walking through .not/.resolves/.rejects.
+function findExpectSubject(node: ts.Node): ts.Expression | undefined {
+  if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && node.expression.text === "expect") {
+    return node.arguments[0];
+  }
+  if (ts.isPropertyAccessExpression(node)) return findExpectSubject(node.expression);
+  return undefined;
+}
+
+// Is this an enumeration assertion on a registry collection?
+// Flags toHaveLength(N>0) and toEqual([...string/number literals...] with 1+ elements).
+function isCollectionEnumerationAssertion(methodName: string, args: ts.NodeArray<ts.Expression>): boolean {
+  if (args.length !== 1) return false;
+  const arg = args[0];
+  if (!arg) return false;
+  if (methodName === "toHaveLength") return ts.isNumericLiteral(arg) && Number(arg.text) > 0;
+  if (methodName === "toEqual" && ts.isArrayLiteralExpression(arg)) {
+    if (arg.elements.length === 0) return false; // empty check is legitimate
     return arg.elements.every(isStringOrNumberLiteral);
   }
   return false;
 }
 
+// Is this an enumeration assertion on a registry .length value?
+// Flags toBe(N>0) and toEqual(N>0).
+function isLengthEnumerationAssertion(methodName: string, args: ts.NodeArray<ts.Expression>): boolean {
+  if (args.length !== 1) return false;
+  const arg = args[0];
+  if (!arg) return false;
+  return (methodName === "toBe" || methodName === "toEqual") && ts.isNumericLiteral(arg) && Number(arg.text) > 0;
+}
+
+// Matches test/it and their modifier forms: test.skip, test.only, it.skip, it.only,
+// test.each(table)(...), it.each(table)(...).
 function isTestCallback(node: ts.Node): boolean {
   if (!ts.isCallExpression(node)) return false;
   const callee = node.expression;
-  const name = ts.isIdentifier(callee) ? callee.text : ts.isPropertyAccessExpression(callee) ? callee.name.text : "";
-  return name === "test" || name === "it";
+  // bare test(...) / it(...)
+  if (ts.isIdentifier(callee)) return callee.text === "test" || callee.text === "it";
+  // test.skip(...) / test.only(...) / it.skip(...) / it.only(...) etc.
+  if (ts.isPropertyAccessExpression(callee)) {
+    const root = callee.expression;
+    return ts.isIdentifier(root) && (root.text === "test" || root.text === "it");
+  }
+  // test.each(table)(name, fn) — outer callee is itself a call expression
+  if (ts.isCallExpression(callee) && ts.isPropertyAccessExpression(callee.expression)) {
+    const root = callee.expression.expression;
+    return ts.isIdentifier(root) && (root.text === "test" || root.text === "it");
+  }
+  return false;
 }
 
 function findTestCallbackBody(node: ts.Node): ts.Node | undefined {
@@ -97,30 +195,44 @@ const rule: CheckRule = {
     "a count or exhaustive name list forces a mechanical bump on every new provider with zero validation of its shape — adding a provider should require a new test that asserts name, serverName, toolPrefix, and relevant native.* fields, not a number change",
     "delete the enumeration assertion; the per-provider shape tests prove membership implicitly (requireProvider/getProvider fails the test if the provider is absent)",
     "example: expect(getProvider('newprovider').native.costTracking).toBe(false) is load-bearing; expect(getAllProviders().length).toBe(9) is not",
+    "only the collection itself (and collection-preserving chains: .map/.filter/.sort/etc.) is tracked — shape assertions on individual elements obtained via .find, .reduce, or index access are not flagged",
   ],
   documentation: "#2420",
   appliesToTests: true,
-  check({ file, ast, violated }) {
+  check({ file, ast, violated, checked }) {
     const lines = file.content.split("\n");
     const sf = ast.sourceFile;
 
-    // Find every test/it call, walk its body for enumeration assertions that
-    // co-occur with a registry call anywhere in the same test scope.
     const allCalls = collectAll(sf, ts.isCallExpression);
+    checked(); // signal that we performed real AST inspection on this file
 
     for (const call of allCalls) {
       const body = findTestCallbackBody(call);
       if (!body) continue;
 
-      // Does this test call getAllProviders() or getAllShims()?
-      if (!containsRegistryCall(body)) continue;
+      // Quick filter: does this test body reference getAllProviders/getAllShims at all?
+      if (!containsRegistryCallShallow(body)) continue;
 
-      // Find any enumeration assertions within this test body
+      // Collect variables in this scope that hold the registry collection (or a
+      // collection-preserving transformation of it).
+      const collectionVars = collectCollectionVars(body);
+
+      // Scan for expect(...).method(...) calls whose subject traces to the registry.
       const assertCalls = collectAll(body, ts.isCallExpression);
       for (const assertCall of assertCalls) {
         if (!ts.isPropertyAccessExpression(assertCall.expression)) continue;
         const methodName = assertCall.expression.name.text;
-        if (!isEnumerationAssertion(methodName, assertCall.arguments)) continue;
+
+        const subject = findExpectSubject(assertCall.expression.expression);
+        if (!subject) continue;
+
+        let isViolation = false;
+        if (isRegistryCollection(subject, collectionVars)) {
+          isViolation = isCollectionEnumerationAssertion(methodName, assertCall.arguments);
+        } else if (isRegistryLength(subject, collectionVars)) {
+          isViolation = isLengthEnumerationAssertion(methodName, assertCall.arguments);
+        }
+        if (!isViolation) continue;
 
         const pos = ast.positionOf(assertCall);
         violated(pos.line, pos.column, lines[pos.line - 1]?.trim() ?? "");

--- a/scripts/rules/provider-spec-shape.rule.ts
+++ b/scripts/rules/provider-spec-shape.rule.ts
@@ -1,0 +1,132 @@
+/**
+ * Rule: provider-spec-shape
+ *
+ * Flag test assertions that enumerate the provider registry (getAllProviders /
+ * getAllShims) by count or exhaustive name list instead of asserting each
+ * provider's capability shape.
+ *
+ * A registry-enumeration test (toHaveLength(N) or toEqual([...names...])) is a
+ * mechanical bump magnet: adding a new provider requires only updating a number
+ * or list with zero validation of the new provider's name, serverName,
+ * toolPrefix, or native.* fields.
+ *
+ * The fix is to add a per-provider test that asserts the fields that matter,
+ * then delete the enumeration assertion. The individual provider shape tests
+ * already prove membership implicitly (getProvider would return undefined if
+ * the provider wasn't registered, and requireProvider guards on that).
+ *
+ * Detection strategy: within a single test/it callback, if getAllProviders() or
+ * getAllShims() is called AND a toHaveLength or toEqual(array) assertion is
+ * present, flag the assertion. The intermediate-variable pattern
+ * (const names = getAllProviders().map(...); expect(names).toEqual([...]))
+ * is covered by scope-level detection.
+ *
+ * Sources: #2420, flagged in #2391 adversarial review.
+ */
+
+import ts from "typescript";
+import type { CheckRule } from "./_engine/rule";
+
+function isRegistryIdentifier(node: ts.Node): boolean {
+  return ts.isIdentifier(node) && (node.text === "getAllProviders" || node.text === "getAllShims");
+}
+
+function containsRegistryCall(node: ts.Node): boolean {
+  if (ts.isCallExpression(node) && isRegistryIdentifier(node.expression)) return true;
+  return ts.forEachChild(node, containsRegistryCall) ?? false;
+}
+
+function isStringOrNumberLiteral(node: ts.Node): boolean {
+  return ts.isStringLiteral(node) || ts.isNumericLiteral(node);
+}
+
+function isEnumerationAssertion(methodName: string, args: ts.NodeArray<ts.Expression>): boolean {
+  // toHaveLength(N) where N > 0 — a non-zero count is a mechanical bump target.
+  // N = 0 (emptiness check) is legitimate (e.g. after _resetRegistries).
+  if (methodName === "toHaveLength" && args.length === 1) {
+    const arg = args[0];
+    return arg !== undefined && ts.isNumericLiteral(arg) && Number(arg.text) > 0;
+  }
+  // toEqual([s1, s2, ...]) where every element is a string/number literal —
+  // this is a name/count list, not a shape assertion.
+  // toEqual([]) and toEqual([objRef]) are legitimate and must not be flagged.
+  if (methodName === "toEqual" && args.length === 1) {
+    const arg = args[0];
+    if (!arg || !ts.isArrayLiteralExpression(arg)) return false;
+    if (arg.elements.length === 0) return false; // empty check is fine
+    return arg.elements.every(isStringOrNumberLiteral);
+  }
+  return false;
+}
+
+function isTestCallback(node: ts.Node): boolean {
+  if (!ts.isCallExpression(node)) return false;
+  const callee = node.expression;
+  const name = ts.isIdentifier(callee) ? callee.text : ts.isPropertyAccessExpression(callee) ? callee.name.text : "";
+  return name === "test" || name === "it";
+}
+
+function findTestCallbackBody(node: ts.Node): ts.Node | undefined {
+  if (isTestCallback(node)) {
+    const call = node as ts.CallExpression;
+    // test("name", () => { ... }) — callback is the last argument
+    const last = call.arguments[call.arguments.length - 1];
+    if (last && (ts.isArrowFunction(last) || ts.isFunctionExpression(last)) && ts.isBlock(last.body)) {
+      return last.body;
+    }
+  }
+  return undefined;
+}
+
+function collectAll<T extends ts.Node>(root: ts.Node, guard: (n: ts.Node) => n is T): T[] {
+  const results: T[] = [];
+  function walk(n: ts.Node): void {
+    if (guard(n)) results.push(n);
+    ts.forEachChild(n, walk);
+  }
+  walk(root);
+  return results;
+}
+
+const rule: CheckRule = {
+  id: "provider-spec-shape",
+  kind: "check",
+  scold:
+    "getAllProviders/getAllShims enumeration assertion — assert each provider's capability shape instead of registry count or name list",
+  guidance: [
+    "a count or exhaustive name list forces a mechanical bump on every new provider with zero validation of its shape — adding a provider should require a new test that asserts name, serverName, toolPrefix, and relevant native.* fields, not a number change",
+    "delete the enumeration assertion; the per-provider shape tests prove membership implicitly (requireProvider/getProvider fails the test if the provider is absent)",
+    "example: expect(getProvider('newprovider').native.costTracking).toBe(false) is load-bearing; expect(getAllProviders().length).toBe(9) is not",
+  ],
+  documentation: "#2420",
+  appliesToTests: true,
+  check({ file, ast, violated }) {
+    const lines = file.content.split("\n");
+    const sf = ast.sourceFile;
+
+    // Find every test/it call, walk its body for enumeration assertions that
+    // co-occur with a registry call anywhere in the same test scope.
+    const allCalls = collectAll(sf, ts.isCallExpression);
+
+    for (const call of allCalls) {
+      const body = findTestCallbackBody(call);
+      if (!body) continue;
+
+      // Does this test call getAllProviders() or getAllShims()?
+      if (!containsRegistryCall(body)) continue;
+
+      // Find any enumeration assertions within this test body
+      const assertCalls = collectAll(body, ts.isCallExpression);
+      for (const assertCall of assertCalls) {
+        if (!ts.isPropertyAccessExpression(assertCall.expression)) continue;
+        const methodName = assertCall.expression.name.text;
+        if (!isEnumerationAssertion(methodName, assertCall.arguments)) continue;
+
+        const pos = ast.positionOf(assertCall);
+        violated(pos.line, pos.column, lines[pos.line - 1]?.trim() ?? "");
+      }
+    }
+  },
+};
+
+export default rule;


### PR DESCRIPTION
## Summary

- Deletes the `getAllProviders returns all 8 built-in providers` enumeration test from `agent-provider.spec.ts` — adding a new provider only required a mechanical name/count bump with zero validation of capability shape; per-provider shape tests already prove membership implicitly
- Adds `provider-spec-shape` doing-it-wrong rule: flags `toHaveLength(N>0)` and `toEqual([...string literals...])` in test/it blocks that also call `getAllProviders()` or `getAllShims()` — catches both direct and intermediate-variable patterns, including concise-arrow expression bodies
- Fixtures cover 6 violation patterns (count, name-list, test.skip count, .length+toBe, .length on derived var+toEqual, concise-arrow count) and 9 clean patterns (shape assertions, iteration, non-enumeration checks, toEqual([]), toEqual([objRef]), .find, test.skip shape, concise-arrow non-enumeration, unrelated toEqual)

## Test plan

- [ ] `bun run am-i-done` passes (typecheck, lint, rules, tests, coverage — all green)
- [ ] `bun run doing-it-wrong` reports no violations
- [ ] Fixture `provider-spec-shape__flagged.fixture.ts` triggers 6 violations (count, name-list, test.skip count, .length+toBe, .length on derived var+toEqual, concise-arrow count)
- [ ] Fixture `provider-spec-shape__clean.fixture.ts` triggers 0 violations (per-provider shape tests, `toEqual([])`, `toEqual([objRef])`, `.find`, concise-arrow non-enumeration all clean)
- [ ] All fixture tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)