### PR TITLE
fix(mcpctl): add error boundary to prevent Ink ErrorOverview crash (fixes #2351)

### DIFF
--- a/packages/control/src/components/error-boundary.spec.tsx
+++ b/packages/control/src/components/error-boundary.spec.tsx
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "bun:test";
+import { Text } from "ink";
+import { render } from "ink-testing-library";
+import React from "react";
+import { ErrorBoundary } from "./error-boundary";
+
+function Thrower({ error }: { error: Error }): never {
+  throw error;
+}
+
+function makeError(message: string, stack: string): Error {
+  const err = new Error(message);
+  err.stack = stack;
+  return err;
+}
+
+describe("ErrorBoundary", () => {
+  it("renders children when no error", () => {
+    const { lastFrame } = render(
+      <ErrorBoundary>
+        <Text>hello</Text>
+      </ErrorBoundary>,
+    );
+    expect(lastFrame()).toContain("hello");
+  });
+
+  it("catches errors and displays the message", () => {
+    const err = makeError("boom", "Error: boom\n    at Foo (foo.ts:1:2)");
+    const { lastFrame } = render(
+      <ErrorBoundary>
+        <Thrower error={err} />
+      </ErrorBoundary>,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("mcpctl crashed: boom");
+    expect(frame).toContain("at Foo (foo.ts:1:2)");
+    expect(frame).toContain("Ctrl+C");
+  });
+
+  it("handles native-only stack frames without crashing", () => {
+    const stack = ["TypeError: undefined is not an object", "    at native", "    at Object.run (/app.js:10:5)"].join(
+      "\n",
+    );
+    const err = makeError("undefined is not an object", stack);
+    const { lastFrame } = render(
+      <ErrorBoundary>
+        <Thrower error={err} />
+      </ErrorBoundary>,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("mcpctl crashed");
+    expect(frame).toContain("at native");
+    expect(frame).toContain("Object.run");
+  });
+
+  it("handles Bun compiled-binary style frames", () => {
+    const stack = [
+      "TypeError: t.type is undefined",
+      "- ep (/$bunfs/root/mcpctl:208:5860)",
+      "- Np (/$bunfs/root/mcpctl:231:2203)",
+    ].join("\n");
+    const err = makeError("t.type is undefined", stack);
+    const { lastFrame } = render(
+      <ErrorBoundary>
+        <Thrower error={err} />
+      </ErrorBoundary>,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("mcpctl crashed: t.type is undefined");
+    expect(frame).toContain("ep");
+  });
+
+  it("handles empty/trailing newlines in stack without duplicate keys", () => {
+    const stack = "Error: fail\n    at A (a.ts:1:1)\n\n\n    at B (b.ts:2:2)\n";
+    const err = makeError("fail", stack);
+    const { lastFrame } = render(
+      <ErrorBoundary>
+        <Thrower error={err} />
+      </ErrorBoundary>,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("mcpctl crashed: fail");
+    expect(frame).toContain("at A");
+    expect(frame).toContain("at B");
+  });
+
+  it("handles error with no stack", () => {
+    const err = new Error("no stack");
+    err.stack = undefined;
+    const { lastFrame } = render(
+      <ErrorBoundary>
+        <Thrower error={err} />
+      </ErrorBoundary>,
+    );
+    const frame = lastFrame() ?? "";
+    expect(frame).toContain("mcpctl crashed: no stack");
+  });
+});

--- a/packages/control/src/components/error-boundary.tsx
+++ b/packages/control/src/components/error-boundary.tsx
@@ -1,0 +1,41 @@
+import { Box, Text } from "ink";
+import React, { type ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends React.PureComponent<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  render(): ReactNode {
+    const { error } = this.state;
+    if (error) {
+      const lines = error.stack?.split("\n").slice(1) ?? [];
+      return (
+        <Box flexDirection="column" padding={1}>
+          <Text color="red" bold>
+            mcpctl crashed: {error.message}
+          </Text>
+          <Text dimColor> </Text>
+          {lines.map((line, i) => (
+            <Text key={`${i}:${line}`} dimColor>
+              {line}
+            </Text>
+          ))}
+          <Text dimColor> </Text>
+          <Text>Press Ctrl+C to exit.</Text>
+        </Box>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/packages/control/src/main.tsx
+++ b/packages/control/src/main.tsx
@@ -11,6 +11,7 @@ import { render } from "ink";
 assertBunVersion();
 import React from "react";
 import { App } from "./app";
+import { ErrorBoundary } from "./components/error-boundary";
 
 if (import.meta.main) {
   if (!process.stdout.isTTY) {
@@ -18,9 +19,14 @@ if (import.meta.main) {
     process.exit(1);
   }
 
-  const { waitUntilExit } = render(<App />, {
-    exitOnCtrlC: true,
-  });
+  const { waitUntilExit } = render(
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>,
+    {
+      exitOnCtrlC: true,
+    },
+  );
 
   await waitUntilExit();
 }


### PR DESCRIPTION
## Summary
- Added a custom `ErrorBoundary` React class component that catches rendering errors before Ink's broken built-in `ErrorOverview` can process them
- Wraps `<App />` in `main.tsx` with the boundary, which renders a safe fallback showing the error message and raw stack trace using only `<Box>` and `<Text>`
- Fixes the two-stage crash: primary render error → Ink's ErrorOverview crashes on truthy-but-incomplete `parseLine` results (e.g. `{native: true}`) and duplicate `key={line}` values

## Test plan
- [x] 6 test cases in `error-boundary.spec.tsx` covering:
  - Normal rendering (no error, children pass through)
  - Error catch + message display
  - Native-only stack frames (`at native` → `{native: true}`, no function/file/line)
  - Bun compiled-binary style frames (`- ep (/$bunfs/root/mcpctl:208:5860)`)
  - Empty/trailing newlines in stack (duplicate key prevention via `${i}:${line}`)
  - Error with no stack trace (`stack = undefined`)
- [x] `bun typecheck` passes
- [x] `bun lint` passes  
- [x] All 5132 tests pass, 0 failures
- [x] Filed #2432 for pre-existing `verdict-cache.ts` coverage gap on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)