### PR TITLE
feat(rules): capability-flag lint rule — costTracking/compactLog without handler (fixes #2421)

### DIFF
--- a/scripts/rules/capability-flag-handler.rule.spec.ts
+++ b/scripts/rules/capability-flag-handler.rule.spec.ts
@@ -112,6 +112,8 @@ registerProvider({
     expect(violations).toHaveLength(1);
     expect(violations[0].snippet).toContain("bad");
     expect(violations[0].snippet).toContain("costTracking");
+    expect(violations[0].line).toBeGreaterThan(0);
+    expect(violations[0].column).toBeGreaterThan(0);
   });
 
   it("flagged — compactLog true but no compact code in session", () => {
@@ -184,6 +186,28 @@ registerProvider({
     expect(violations).toHaveLength(0);
   });
 
+  it("spec files do not satisfy evidence — isTest:true files are ignored", () => {
+    const pf = providerFile(`
+registerProvider({
+	name: "bad",
+	serverName: "_bad",
+	toolPrefix: "bad",
+	buildSpawnArgs: () => ({}),
+	native: { costTracking: true },
+});
+`);
+    const specFile: FileMeta = {
+      path: "packages/daemon/src/bad-session/state.spec.ts",
+      relPath: "packages/daemon/src/bad-session/state.spec.ts",
+      content: "total_cost_usd: 0.05",
+      pkg: "packages/daemon",
+      isTest: true,
+    };
+    const violations = evaluateRule(rule, pf, buildFiles(pf, specFile));
+    expect(violations).toHaveLength(1);
+    expect(violations[0].snippet).toContain("costTracking");
+  });
+
   it("ignores flags not in the evidence map", () => {
     const pf = providerFile(`
 registerProvider({
@@ -212,8 +236,14 @@ registerProvider({
     const glob = new Bun.Glob("packages/daemon/src/**/*.ts");
     const files = buildFiles(pf);
     for await (const path of glob.scan({ cwd: ".", absolute: false })) {
-      if (path.includes(".spec.") || path.includes(".test.")) continue;
-      const meta = makeFile(path, await Bun.file(path).text());
+      const content = await Bun.file(path).text();
+      const meta: FileMeta = {
+        path,
+        relPath: path,
+        content,
+        pkg: path.split("/").slice(0, 2).join("/"),
+        isTest: /\.(spec|test)\.tsx?$/.test(path),
+      };
       files.set(meta.path, meta);
     }
 

--- a/scripts/rules/capability-flag-handler.rule.spec.ts
+++ b/scripts/rules/capability-flag-handler.rule.spec.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "bun:test";
+
+import type { FileMeta } from "./_engine/file-loader";
+import { evaluateRule } from "./_engine/rule";
+import rule from "./capability-flag-handler.rule";
+
+function makeFile(relPath: string, content: string): FileMeta {
+  return {
+    path: relPath,
+    relPath,
+    content,
+    pkg: relPath.split("/").slice(0, 2).join("/"),
+    isTest: false,
+  };
+}
+
+const PROVIDER_PATH = "packages/core/src/agent-provider.ts";
+
+function providerFile(registrations: string): FileMeta {
+  return makeFile(PROVIDER_PATH, `function registerProvider(_p: unknown): void {}\n${registrations}`);
+}
+
+function sessionFile(prefix: string, name: string, content: string): FileMeta {
+  return makeFile(`packages/daemon/src/${prefix}-session/${name}`, content);
+}
+
+function workerFile(prefix: string, content: string): FileMeta {
+  return makeFile(`packages/daemon/src/${prefix}-session-worker.ts`, content);
+}
+
+function buildFiles(...metas: FileMeta[]): Map<string, FileMeta> {
+  return new Map(metas.map((m) => [m.path, m]));
+}
+
+describe("capability-flag-handler", () => {
+  it("skips non-provider files", () => {
+    const file = makeFile("packages/core/src/other.ts", "costTracking: true");
+    const violations = evaluateRule(rule, file, buildFiles(file));
+    expect(violations).toHaveLength(0);
+  });
+
+  it("clean — false flags produce no violations", () => {
+    const pf = providerFile(`
+registerProvider({
+	name: "safe",
+	serverName: "_safe",
+	toolPrefix: "safe",
+	buildSpawnArgs: () => ({}),
+	native: { costTracking: false, compactLog: false },
+});
+`);
+    const violations = evaluateRule(rule, pf, buildFiles(pf));
+    expect(violations).toHaveLength(0);
+  });
+
+  it("clean — costTracking with cost evidence in session dir", () => {
+    const pf = providerFile(`
+registerProvider({
+	name: "good",
+	serverName: "_good",
+	toolPrefix: "good",
+	buildSpawnArgs: () => ({}),
+	native: { costTracking: true },
+});
+`);
+    const sf = sessionFile("good", "state.ts", "this.cost = result.total_cost_usd;");
+    const violations = evaluateRule(rule, pf, buildFiles(pf, sf));
+    expect(violations).toHaveLength(0);
+  });
+
+  it("clean — compactLog with compact evidence in session dir", () => {
+    const pf = providerFile(`
+registerProvider({
+	name: "good",
+	serverName: "_good",
+	toolPrefix: "good",
+	buildSpawnArgs: () => ({}),
+	native: { compactLog: true },
+});
+`);
+    const sf = sessionFile("good", "ws-server.ts", "export function compactifyEntry(entry) {}");
+    const violations = evaluateRule(rule, pf, buildFiles(pf, sf));
+    expect(violations).toHaveLength(0);
+  });
+
+  it("clean — evidence in worker file counts", () => {
+    const pf = providerFile(`
+registerProvider({
+	name: "good",
+	serverName: "_good",
+	toolPrefix: "good",
+	buildSpawnArgs: () => ({}),
+	native: { compactLog: true },
+});
+`);
+    const wf = workerFile("good", "if (args.compact) { return compactifyEntry(e); }");
+    const violations = evaluateRule(rule, pf, buildFiles(pf, wf));
+    expect(violations).toHaveLength(0);
+  });
+
+  it("flagged — costTracking true but no session files", () => {
+    const pf = providerFile(`
+registerProvider({
+	name: "bad",
+	serverName: "_bad",
+	toolPrefix: "bad",
+	buildSpawnArgs: () => ({}),
+	native: { costTracking: true },
+});
+`);
+    const violations = evaluateRule(rule, pf, buildFiles(pf));
+    expect(violations).toHaveLength(1);
+    expect(violations[0].snippet).toContain("bad");
+    expect(violations[0].snippet).toContain("costTracking");
+  });
+
+  it("flagged — compactLog true but no compact code in session", () => {
+    const pf = providerFile(`
+registerProvider({
+	name: "bad",
+	serverName: "_bad",
+	toolPrefix: "bad",
+	buildSpawnArgs: () => ({}),
+	native: { compactLog: true },
+});
+`);
+    const sf = sessionFile("bad", "state.ts", "export class SessionState {}");
+    const violations = evaluateRule(rule, pf, buildFiles(pf, sf));
+    expect(violations).toHaveLength(1);
+    expect(violations[0].snippet).toContain("compactLog");
+  });
+
+  it("flagged — session files exist but with wrong evidence", () => {
+    const pf = providerFile(`
+registerProvider({
+	name: "wrong",
+	serverName: "_wrong",
+	toolPrefix: "wrong",
+	buildSpawnArgs: () => ({}),
+	native: { costTracking: true },
+});
+`);
+    const sf = sessionFile("wrong", "state.ts", "export function handleCompact() {}");
+    const violations = evaluateRule(rule, pf, buildFiles(pf, sf));
+    expect(violations).toHaveLength(1);
+    expect(violations[0].snippet).toContain("costTracking");
+  });
+
+  it("multiple providers — only flags the one missing evidence", () => {
+    const pf = providerFile(`
+registerProvider({
+	name: "has-cost",
+	serverName: "_has",
+	toolPrefix: "has",
+	buildSpawnArgs: () => ({}),
+	native: { costTracking: true },
+});
+registerProvider({
+	name: "no-cost",
+	serverName: "_no",
+	toolPrefix: "no",
+	buildSpawnArgs: () => ({}),
+	native: { costTracking: true },
+});
+`);
+    const sf = sessionFile("has", "state.ts", "this.cost = msg.total_cost_usd;");
+    const violations = evaluateRule(rule, pf, buildFiles(pf, sf));
+    expect(violations).toHaveLength(1);
+    expect(violations[0].snippet).toContain("no-cost");
+  });
+
+  it("ACP variants share session dir via serverName", () => {
+    const pf = providerFile(`
+registerProvider({
+	name: "grok",
+	serverName: "_acp",
+	toolPrefix: "acp",
+	buildSpawnArgs: () => ({}),
+	native: { costTracking: true },
+});
+`);
+    const sf = sessionFile("acp", "event-map.ts", "state.cost = update.cost;");
+    const violations = evaluateRule(rule, pf, buildFiles(pf, sf));
+    expect(violations).toHaveLength(0);
+  });
+
+  it("ignores flags not in the evidence map", () => {
+    const pf = providerFile(`
+registerProvider({
+	name: "headless",
+	serverName: "_headless",
+	toolPrefix: "headless",
+	buildSpawnArgs: () => ({}),
+	native: { headed: true, worktree: true, resume: true },
+});
+`);
+    const violations = evaluateRule(rule, pf, buildFiles(pf));
+    expect(violations).toHaveLength(0);
+  });
+
+  it("does not false-positive on the real provider file", async () => {
+    const realProvider = Bun.file("packages/core/src/agent-provider.ts");
+    const content = await realProvider.text();
+    const pf: FileMeta = {
+      path: PROVIDER_PATH,
+      relPath: PROVIDER_PATH,
+      content,
+      pkg: "packages/core",
+      isTest: false,
+    };
+
+    const glob = new Bun.Glob("packages/daemon/src/**/*.ts");
+    const files = buildFiles(pf);
+    for await (const path of glob.scan({ cwd: ".", absolute: false })) {
+      if (path.includes(".spec.") || path.includes(".test.")) continue;
+      const meta = makeFile(path, await Bun.file(path).text());
+      files.set(meta.path, meta);
+    }
+
+    const violations = evaluateRule(rule, pf, files);
+    expect(violations).toHaveLength(0);
+  });
+});

--- a/scripts/rules/capability-flag-handler.rule.ts
+++ b/scripts/rules/capability-flag-handler.rule.ts
@@ -1,0 +1,136 @@
+import ts from "typescript";
+
+import type { AstHelper } from "./_engine/ast";
+import { createAstHelper } from "./_engine/ast";
+import type { FileMeta } from "./_engine/file-loader";
+import type { CheckRule, RuleContext } from "./_engine/rule";
+
+const PROVIDER_REL = "packages/core/src/agent-provider.ts";
+const SESSION_DIR = "packages/daemon/src/";
+
+interface FlagEntry {
+  flag: string;
+  line: number;
+  col: number;
+}
+
+interface ProviderInfo {
+  name: string;
+  serverName: string;
+  flags: FlagEntry[];
+  nameLine: number;
+  nameCol: number;
+}
+
+const EVIDENCE: Record<string, RegExp> = {
+  costTracking: /\b(cost|total_cost_usd)\b/,
+  compactLog: /\bcompact/,
+};
+
+function sessionPrefix(serverName: string): string {
+  return serverName.replace(/^_/, "");
+}
+
+function isSessionFile(relPath: string, prefix: string): boolean {
+  const tail = relPath.slice(SESSION_DIR.length);
+  return (
+    tail.startsWith(`${prefix}-session/`) ||
+    tail.startsWith(`${prefix}-session-worker`) ||
+    tail.startsWith(`${prefix}-server`)
+  );
+}
+
+function extractProviders(ast: AstHelper): ProviderInfo[] {
+  const results: ProviderInfo[] = [];
+
+  for (const call of ast.callsTo("registerProvider")) {
+    const arg = call.arguments[0];
+    if (!arg || !ts.isObjectLiteralExpression(arg)) continue;
+
+    let name: string | undefined;
+    let serverName: string | undefined;
+    let nameLine = 0;
+    let nameCol = 0;
+    const flags: FlagEntry[] = [];
+
+    for (const prop of arg.properties) {
+      if (!ts.isPropertyAssignment(prop) || !ts.isIdentifier(prop.name)) continue;
+
+      if (prop.name.text === "name" && ts.isStringLiteral(prop.initializer)) {
+        name = prop.initializer.text;
+        const pos = ast.positionOf(prop.initializer);
+        nameLine = pos.line;
+        nameCol = pos.column;
+      }
+
+      if (prop.name.text === "serverName" && ts.isStringLiteral(prop.initializer)) {
+        serverName = prop.initializer.text;
+      }
+
+      if (prop.name.text === "native" && ts.isObjectLiteralExpression(prop.initializer)) {
+        for (const flagProp of prop.initializer.properties) {
+          if (!ts.isPropertyAssignment(flagProp) || !ts.isIdentifier(flagProp.name)) continue;
+          if (flagProp.initializer.kind === ts.SyntaxKind.TrueKeyword) {
+            const flagName = flagProp.name.text;
+            if (flagName in EVIDENCE) {
+              const pos = ast.positionOf(flagProp);
+              flags.push({ flag: flagName, line: pos.line, col: pos.col });
+            }
+          }
+        }
+      }
+    }
+
+    if (name && serverName) {
+      results.push({ name, serverName, flags, nameLine, nameCol });
+    }
+  }
+
+  return results;
+}
+
+function sessionFilesHaveEvidence(files: Map<string, FileMeta>, prefix: string, pattern: RegExp): boolean {
+  for (const meta of files.values()) {
+    if (!meta.relPath.startsWith(SESSION_DIR)) continue;
+    if (!isSessionFile(meta.relPath, prefix)) continue;
+    if (pattern.test(meta.content)) return true;
+  }
+  return false;
+}
+
+const rule: CheckRule = {
+  id: "capability-flag-handler",
+  kind: "check",
+  scold: "Provider advertises a capability flag but no session handler exercises it",
+  guidance: [
+    "A provider's `native` flags (costTracking, compactLog, …) gate CLI behavior — setting one to `true` without a corresponding handler means the feature silently no-ops or displays misleading data.",
+    "`costTracking: true` → the provider's session code must reference cost / total_cost_usd fields.",
+    "`compactLog: true` → the provider's session code must contain a compact-log code path.",
+    "Fix: add the missing handler in packages/daemon/src/<provider>-session/, or set the flag to `false`.",
+  ],
+  documentation: "#2421, #2391",
+  appliesToTests: false,
+  anchors: [PROVIDER_REL],
+  check(ctx: RuleContext) {
+    if (ctx.file.relPath !== PROVIDER_REL) return;
+    ctx.checked();
+
+    const providers = extractProviders(ctx.ast);
+    for (const provider of providers) {
+      const prefix = sessionPrefix(provider.serverName);
+      for (const { flag, line, col } of provider.flags) {
+        const pattern = EVIDENCE[flag];
+        if (!pattern) continue;
+        if (!sessionFilesHaveEvidence(ctx.files, prefix, pattern)) {
+          ctx.violated(
+            line,
+            col,
+            `${provider.name}: native.${flag} is true but no handler found in ${prefix}-session/`,
+          );
+        }
+      }
+    }
+  },
+};
+
+export default rule;

--- a/scripts/rules/capability-flag-handler.rule.ts
+++ b/scripts/rules/capability-flag-handler.rule.ts
@@ -11,7 +11,7 @@ const SESSION_DIR = "packages/daemon/src/";
 interface FlagEntry {
   flag: string;
   line: number;
-  col: number;
+  column: number;
 }
 
 interface ProviderInfo {
@@ -74,7 +74,7 @@ function extractProviders(ast: AstHelper): ProviderInfo[] {
             const flagName = flagProp.name.text;
             if (flagName in EVIDENCE) {
               const pos = ast.positionOf(flagProp);
-              flags.push({ flag: flagName, line: pos.line, col: pos.col });
+              flags.push({ flag: flagName, line: pos.line, column: pos.column });
             }
           }
         }
@@ -91,6 +91,7 @@ function extractProviders(ast: AstHelper): ProviderInfo[] {
 
 function sessionFilesHaveEvidence(files: Map<string, FileMeta>, prefix: string, pattern: RegExp): boolean {
   for (const meta of files.values()) {
+    if (meta.isTest) continue;
     if (!meta.relPath.startsWith(SESSION_DIR)) continue;
     if (!isSessionFile(meta.relPath, prefix)) continue;
     if (pattern.test(meta.content)) return true;
@@ -118,13 +119,13 @@ const rule: CheckRule = {
     const providers = extractProviders(ctx.ast);
     for (const provider of providers) {
       const prefix = sessionPrefix(provider.serverName);
-      for (const { flag, line, col } of provider.flags) {
+      for (const { flag, line, column } of provider.flags) {
         const pattern = EVIDENCE[flag];
         if (!pattern) continue;
         if (!sessionFilesHaveEvidence(ctx.files, prefix, pattern)) {
           ctx.violated(
             line,
-            col,
+            column,
             `${provider.name}: native.${flag} is true but no handler found in ${prefix}-session/`,
           );
         }

--- a/scripts/rules/fixtures/capability-flag-handler__clean.fixture.ts
+++ b/scripts/rules/fixtures/capability-flag-handler__clean.fixture.ts
@@ -1,0 +1,20 @@
+/**
+ * @rule capability-flag-handler
+ * @expect 0
+ * @path packages/core/src/agent-provider.ts
+ *
+ * Provider declares costTracking: false — no handler needed, no violation.
+ */
+
+function registerProvider(_p: unknown): void {}
+
+registerProvider({
+	name: "safe-provider",
+	serverName: "_safe",
+	toolPrefix: "safe",
+	buildSpawnArgs: () => ({}),
+	native: {
+		costTracking: false,
+		compactLog: false,
+	},
+});

--- a/scripts/rules/fixtures/capability-flag-handler__flagged.fixture.ts
+++ b/scripts/rules/fixtures/capability-flag-handler__flagged.fixture.ts
@@ -1,0 +1,21 @@
+/**
+ * @rule capability-flag-handler
+ * @expect 2
+ * @path packages/core/src/agent-provider.ts
+ *
+ * Provider claims costTracking and compactLog but the fixture file set
+ * contains no session files — both flags are unexercised.
+ */
+
+function registerProvider(_p: unknown): void {}
+
+registerProvider({
+	name: "broken-provider",
+	serverName: "_broken",
+	toolPrefix: "broken",
+	buildSpawnArgs: () => ({}),
+	native: {
+		costTracking: true,
+		compactLog: true,
+	},
+});


### PR DESCRIPTION
## Summary
- Adds `capability-flag-handler` doing-it-wrong check rule that cross-references provider `native` capability flags with session handler code
- When a provider sets `costTracking: true` or `compactLog: true`, the rule verifies the provider's session directory (derived from `serverName`) contains evidence of a handler exercising that capability
- Uses AST to parse `registerProvider()` calls and regex evidence patterns against session files via `ctx.files` cross-file map
- Prevents silent flag drift like the Grok `costTracking` incident caught manually during #2391 review

## Test plan
- [x] 12 unit tests covering: early return on non-provider files, false flags, evidence in session dir, evidence in worker files, missing evidence, wrong evidence, multiple providers, ACP variant serverName sharing, non-tracked flags, real provider file integration test
- [x] 2 fixtures: clean (false flags → 0 violations) and flagged (true flags with no session files → 2 violations)
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun run doing-it-wrong` passes (27 rules, 0 violations)
- [x] Fixture test suite passes (83 fixtures including new ones)
- [x] Integration test verifies no false positives against the real `agent-provider.ts` + daemon session files

🤖 Generated with [Claude Code](https://claude.com/claude-code)