### PR TITLE
fix(rules): remediate 3 no-error-message-sniffing suppressions (fixes #2354)

### DIFF
--- a/packages/clone/src/providers/resilient-caller.spec.ts
+++ b/packages/clone/src/providers/resilient-caller.spec.ts
@@ -319,14 +319,21 @@ describe("classifyError regression tests", () => {
 });
 
 describe("friendlyMessage regression tests", () => {
-  test("not_found with alias discovery details preserves the message", () => {
+  test("not_found with diagnostic field preserves the diagnostic message", () => {
+    const detail = 'Tool "getConfluenceSpaces" not found. Tried aliases: a, b, c. Check mcx ls atlassian.';
+    const err = new VfsError("not_found", detail, undefined, detail);
+    const msg = friendlyMessage(err, "clone confluence/FOO");
+    expect(msg).toContain("Tried aliases");
+    expect(msg).toContain("mcx ls atlassian");
+  });
+
+  test("not_found without diagnostic field uses generic message", () => {
     const err = new VfsError(
       "not_found",
       'Tool "getConfluenceSpaces" not found. Tried aliases: a, b, c. Check mcx ls atlassian.',
     );
     const msg = friendlyMessage(err, "clone confluence/FOO");
-    expect(msg).toContain("Tried aliases");
-    expect(msg).toContain("mcx ls atlassian");
+    expect(msg).toContain("Resource not found");
   });
 
   test("not_found without alias details uses generic message", () => {

--- a/packages/clone/src/providers/resilient-caller.spec.ts
+++ b/packages/clone/src/providers/resilient-caller.spec.ts
@@ -319,9 +319,9 @@ describe("classifyError regression tests", () => {
 });
 
 describe("friendlyMessage regression tests", () => {
-  test("not_found with diagnostic field preserves the diagnostic message", () => {
+  test("VfsError.notFound preserves the diagnostic message verbatim", () => {
     const detail = 'Tool "getConfluenceSpaces" not found. Tried aliases: a, b, c. Check mcx ls atlassian.';
-    const err = new VfsError("not_found", detail, undefined, detail);
+    const err = VfsError.notFound(detail);
     const msg = friendlyMessage(err, "clone confluence/FOO");
     expect(msg).toContain("Tried aliases");
     expect(msg).toContain("mcx ls atlassian");

--- a/packages/clone/src/providers/resilient-caller.ts
+++ b/packages/clone/src/providers/resilient-caller.ts
@@ -18,11 +18,29 @@ export class VfsError extends Error {
     public readonly kind: VfsErrorKind,
     message: string,
     public readonly cause?: Error,
-    /** Structured diagnostic content to display verbatim (e.g. alias discovery details). */
+    /**
+     * User-facing diagnostic content for `friendlyMessage` to display verbatim.
+     * Only respected when `kind === "not_found"`. When omitted, `friendlyMessage`
+     * returns the generic fallback ("Resource not found…").
+     *
+     * Prefer `VfsError.notFound(message, cause)` over setting this directly —
+     * it enforces that `message` and `diagnostic` are consistent.
+     */
     public readonly diagnostic?: string,
   ) {
     super(message);
     this.name = "VfsError";
+  }
+
+  /**
+   * Create a `not_found` error whose full message is shown verbatim by
+   * `friendlyMessage`. Use this (not the raw constructor) whenever the
+   * message contains user-actionable diagnostic content such as alias
+   * discovery details — the factory guarantees `diagnostic === message`
+   * so future refactors can't accidentally drop the 4th positional arg.
+   */
+  static notFound(message: string, cause?: Error): VfsError {
+    return new VfsError("not_found", message, cause, message);
   }
 }
 
@@ -286,7 +304,7 @@ export function createResilientCaller(opts: ResilientCallerOptions): McpToolCall
       // All aliases failed
       const triedNames = aliases.join(", ");
       const diagnosticMsg = `Tool "${canonicalTool}" not found. Tried aliases: ${triedNames}. Your Atlassian MCP server may use different tool names — check "mcx ls atlassian".`;
-      throw new VfsError("not_found", diagnosticMsg, err.cause, diagnosticMsg);
+      throw VfsError.notFound(diagnosticMsg, err.cause);
     }
   }
 

--- a/packages/clone/src/providers/resilient-caller.ts
+++ b/packages/clone/src/providers/resilient-caller.ts
@@ -18,6 +18,8 @@ export class VfsError extends Error {
     public readonly kind: VfsErrorKind,
     message: string,
     public readonly cause?: Error,
+    /** Structured diagnostic content to display verbatim (e.g. alias discovery details). */
+    public readonly diagnostic?: string,
   ) {
     super(message);
     this.name = "VfsError";
@@ -86,9 +88,8 @@ export function friendlyMessage(err: VfsError, context?: string): string {
       return `Network error${ctx}. Check your connection and that the MCP server is running:\n  mcx status`;
     case "not_found":
       // Preserve diagnostic content (e.g. alias discovery details) when present
-      // dotw-todo no-error-message-sniffing: add typed DiagnosticError with structured content field — fix in #2354
-      if (err.message.includes("Tried aliases") || err.message.includes("mcx ls")) {
-        return err.message;
+      if (err.diagnostic != null) {
+        return err.diagnostic;
       }
       return `Resource not found${ctx}. The page or tool may have been removed.`;
     case "conflict":
@@ -284,11 +285,8 @@ export function createResilientCaller(opts: ResilientCallerOptions): McpToolCall
 
       // All aliases failed
       const triedNames = aliases.join(", ");
-      throw new VfsError(
-        "not_found",
-        `Tool "${canonicalTool}" not found. Tried aliases: ${triedNames}. Your Atlassian MCP server may use different tool names — check "mcx ls atlassian".`,
-        err.cause,
-      );
+      const diagnosticMsg = `Tool "${canonicalTool}" not found. Tried aliases: ${triedNames}. Your Atlassian MCP server may use different tool names — check "mcx ls atlassian".`;
+      throw new VfsError("not_found", diagnosticMsg, err.cause, diagnosticMsg);
     }
   }
 

--- a/packages/command/src/commands/agent.spec.ts
+++ b/packages/command/src/commands/agent.spec.ts
@@ -2119,7 +2119,7 @@ describe("agent wait flags", () => {
     const deps = makeDeps({
       callTool: mock(() => new Promise(() => {})) as unknown as AgentDeps["callTool"],
       pollMail: mock(async () => {
-        if (calls++ === 0) throw new Error("ECONNREFUSED");
+        if (calls++ === 0) throw Object.assign(new Error("connect failed"), { code: "ECONNREFUSED" });
         return newMail;
       }),
     });

--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -2886,7 +2886,7 @@ describe("claudeWait --mail-to", () => {
     const deps = makeDeps({
       callTool: mock(() => new Promise(() => {})) as unknown as ClaudeDeps["callTool"],
       pollMail: mock(async () => {
-        if (calls++ === 0) throw new Error("ECONNREFUSED");
+        if (calls++ === 0) throw Object.assign(new Error("connect failed"), { code: "ECONNREFUSED" });
         return newMail;
       }),
       log: logSpy,

--- a/packages/command/src/commands/mail-wait.spec.ts
+++ b/packages/command/src/commands/mail-wait.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import { type MailMessage, ProtocolMismatchError } from "@mcp-cli/core";
+import { IpcCallError, type IpcError, type MailMessage, ProtocolMismatchError } from "@mcp-cli/core";
 import { emitMailEvent, pollMailUntil } from "./mail-wait";
 
 function makeMail(overrides: Partial<MailMessage> = {}): MailMessage {
@@ -45,7 +45,10 @@ describe("pollMailUntil", () => {
     let calls = 0;
     const d = {
       pollMail: mock(async () => {
-        if (calls++ === 0) throw new Error("ECONNREFUSED");
+        if (calls++ === 0) {
+          const err = Object.assign(new Error("connect failed"), { code: "ECONNREFUSED" });
+          throw err;
+        }
         return msg;
       }),
     };
@@ -143,8 +146,7 @@ describe("pollMailUntil", () => {
     test("logs a warning after N consecutive transient failures", async () => {
       const d = {
         pollMail: mock(async () => {
-          const err = new Error("ECONNREFUSED");
-          throw err;
+          throw Object.assign(new Error("connect failed"), { code: "ECONNREFUSED" });
         }),
       };
       // Short timeout — will burn through ~15 polls at 1ms interval
@@ -152,6 +154,34 @@ describe("pollMailUntil", () => {
       const warnings = errorSpy.mock.calls.filter((c) => String((c as unknown[])[0]).includes("consecutive transient"));
       // Logs exactly once (warnedTransient latch) regardless of how many more transient errors fire
       expect(warnings.length).toBe(1);
+    });
+
+    test("retries on IpcCallError with systemCode matching transient code", async () => {
+      const msg = makeMail();
+      let calls = 0;
+      const d = {
+        pollMail: mock(async () => {
+          if (calls++ === 0) {
+            const ipcErr: IpcError = { code: -32603, message: "connect failed", systemCode: "ECONNRESET" };
+            throw new IpcCallError(ipcErr);
+          }
+          return msg;
+        }),
+      };
+      const result = await pollMailUntil(d, "bob", 5000, Date.now() - 1, 10);
+      expect(result).toBe(msg);
+      expect(calls).toBe(2);
+    });
+
+    test("does not retry on IpcCallError without systemCode", async () => {
+      const d = {
+        pollMail: mock(async () => {
+          const ipcErr: IpcError = { code: -32603, message: "Internal error" };
+          throw new IpcCallError(ipcErr);
+        }),
+      };
+      await expect(pollMailUntil(d, "bob", 5000, Date.now(), 10)).rejects.toBeInstanceOf(IpcCallError);
+      expect(d.pollMail).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/command/src/commands/mail-wait.ts
+++ b/packages/command/src/commands/mail-wait.ts
@@ -1,4 +1,4 @@
-import { type MailMessage, ProtocolMismatchError } from "@mcp-cli/core";
+import { IpcCallError, type MailMessage, ProtocolMismatchError } from "@mcp-cli/core";
 
 /** Error codes considered transient — daemon blips, socket churn, restart races. */
 const TRANSIENT_ERROR_CODES = new Set(["ECONNREFUSED", "ECONNRESET", "EPIPE", "EAGAIN", "ENOTCONN", "ENOENT"]);
@@ -10,14 +10,8 @@ function isTransientError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   const code = (err as { code?: unknown }).code;
   if (typeof code === "string" && TRANSIENT_ERROR_CODES.has(code)) return true;
-  // Some IPC paths surface the code only in the message string. This loop is a
-  // load-bearing fallback — the .code path above already handles structured codes,
-  // so do NOT replace this loop with getErrorCode(). The right fix is to patch the
-  // IPC transport to always emit a structured code field, then delete the loop.
-  for (const c of TRANSIENT_ERROR_CODES) {
-    // dotw-todo no-error-message-sniffing: patch IPC transport to surface structured codes on all paths — fix in #2354
-    if (err.message.includes(c)) return true;
-  }
+  if (err instanceof IpcCallError && err.systemCode !== undefined && TRANSIENT_ERROR_CODES.has(err.systemCode))
+    return true;
   return false;
 }
 

--- a/packages/control/src/hooks/use-plans.spec.ts
+++ b/packages/control/src/hooks/use-plans.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
 import type { Plan, PlanMetrics } from "@mcp-cli/core";
+import { IPC_ERROR, IpcCallError } from "@mcp-cli/core";
 import { Text } from "ink";
 import { render } from "ink-testing-library";
 import React, { type FC } from "react";
@@ -754,21 +755,29 @@ describe("usePlans — Claude plan integration", () => {
 
   it("returns only server plans when _claude server is unavailable", async () => {
     const serverPlan = makePlan("server-plan", "test-server");
-    const ipcCallFn = async (method: string, params?: unknown) => {
-      if (method === "status") return daemonStatus([{ name: "test-server", hasList: true }]);
+    const consoleErrors: unknown[][] = [];
+    const origError = console.error;
+    console.error = (...args: unknown[]) => consoleErrors.push(args);
+    try {
+      const ipcCallFn = async (method: string, params?: unknown) => {
+        if (method === "status") return daemonStatus([{ name: "test-server", hasList: true }]);
+        const p = params as { server?: string; tool?: string };
+        if (p.server === "test-server") return planToolResult([serverPlan]);
+        // Simulate _claude server not found — should be swallowed silently
+        throw new IpcCallError({ code: IPC_ERROR.SERVER_NOT_FOUND, message: 'Server "_claude" not found' });
+      };
 
-      const p = params as { server?: string; tool?: string };
-      if (p.server === "test-server") return planToolResult([serverPlan]);
-      // _claude calls throw
-      throw new Error("_claude not available");
-    };
+      const { stateRef } = mount({ ipcCallFn: ipcCallFn as UsePlansOptions["ipcCallFn"] });
+      await waitFor(() => !stateRef.current.loading);
 
-    const { stateRef } = mount({ ipcCallFn: ipcCallFn as UsePlansOptions["ipcCallFn"] });
-    await waitFor(() => !stateRef.current.loading);
-
-    expect(stateRef.current.plans).toHaveLength(1);
-    expect(stateRef.current.plans[0].id).toBe("server-plan");
-    expect(stateRef.current.error).toBeNull();
+      expect(stateRef.current.plans).toHaveLength(1);
+      expect(stateRef.current.plans[0].id).toBe("server-plan");
+      expect(stateRef.current.error).toBeNull();
+      // SERVER_NOT_FOUND is expected — must not log any errors at all
+      expect(consoleErrors).toEqual([]);
+    } finally {
+      console.error = origError;
+    }
   });
 
   it("returns empty Claude plans when claude_plans returns empty array", async () => {

--- a/packages/control/src/hooks/use-plans.ts
+++ b/packages/control/src/hooks/use-plans.ts
@@ -1,5 +1,11 @@
 import type { Plan, PlanMetrics, ServerStatus } from "@mcp-cli/core";
-import { CLAUDE_SERVER_NAME, GetPlanMetricsResultSchema, ListPlansResultSchema } from "@mcp-cli/core";
+import {
+  CLAUDE_SERVER_NAME,
+  GetPlanMetricsResultSchema,
+  IPC_ERROR,
+  IpcCallError,
+  ListPlansResultSchema,
+} from "@mcp-cli/core";
 import { ipcCall } from "@mcp-cli/core";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { extractToolText } from "./ipc-tool-helpers";
@@ -42,8 +48,7 @@ async function fetchClaudePlans(
     return JSON.parse(text) as Plan[];
   } catch (err) {
     // _claude server not available is expected — only log unexpected errors
-    // dotw-todo no-error-message-sniffing: replace with typed NotFoundError instanceof check — fix in #2354
-    if (!(err instanceof Error && err.message.includes("not found"))) {
+    if (!(err instanceof IpcCallError && err.code === IPC_ERROR.SERVER_NOT_FOUND)) {
       console.error("[use-plans] fetchClaudePlans failed:", err);
     }
     return [];

--- a/packages/core/src/ipc-client.ts
+++ b/packages/core/src/ipc-client.ts
@@ -32,6 +32,8 @@ export class IpcCallError extends Error {
   readonly code: number;
   readonly data: unknown;
   readonly remoteStack: string | undefined;
+  /** OS-level error code (e.g. "ECONNREFUSED") when the daemon wrapped a system error. */
+  readonly systemCode: string | undefined;
 
   constructor(err: IpcError) {
     super(err.message);
@@ -39,6 +41,7 @@ export class IpcCallError extends Error {
     this.code = err.code;
     this.data = err.data;
     this.remoteStack = err.stack;
+    this.systemCode = err.systemCode;
   }
 }
 

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -94,6 +94,8 @@ export interface IpcError {
   message: string;
   data?: unknown;
   stack?: string;
+  /** OS-level error code (e.g. "ECONNREFUSED") when the daemon wrapped a system error. */
+  systemCode?: string;
 }
 
 // -- Param schemas per method --

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -547,13 +547,16 @@ function toIpcError(err: unknown): IpcError {
     return { code: IPC_ERROR.INVALID_PARAMS, message: `Invalid params: ${detail}` };
   }
   if (err instanceof Error) {
-    const code = (err as unknown as { code?: number }).code;
+    const rawCode = (err as unknown as { code?: unknown }).code;
+    const code = typeof rawCode === "number" ? rawCode : IPC_ERROR.INTERNAL_ERROR;
+    const systemCode = typeof rawCode === "string" ? rawCode : undefined;
     const data = (err as unknown as { data?: unknown }).data;
     return {
-      code: typeof code === "number" ? code : IPC_ERROR.INTERNAL_ERROR,
+      code,
       message: err.message,
       ...(err.stack ? { stack: err.stack } : {}),
       ...(data !== undefined ? { data } : {}),
+      ...(systemCode !== undefined ? { systemCode } : {}),
     };
   }
   return { code: IPC_ERROR.INTERNAL_ERROR, message: String(err) };

--- a/scripts/_runner/verdict-cache.spec.ts
+++ b/scripts/_runner/verdict-cache.spec.ts
@@ -86,30 +86,35 @@ describe("verdict-cache", () => {
 });
 
 describe("computeVerdictKey", () => {
-  it("returns a non-null string when git commands succeed", () => {
-    const key = computeVerdictKey(() => "abc123");
+  // Tests run inside the mcp-cli worktree — a valid git repo with a HEAD commit.
+  // computeVerdictKey runs git commands in process.cwd() so there's no need to
+  // create a temporary repo.
+
+  it("returns a non-null string with three colon-separated parts in a valid git repo", () => {
+    const key = computeVerdictKey(() => "HEAD~1");
     expect(key).not.toBeNull();
-    expect(typeof key).toBe("string");
-    // Format: <base>:<headSha>:<diffHash>
-    expect(key).toMatch(/^[^:]+:[a-f0-9]+:[a-f0-9]+$/);
+    const parts = (key as string).split(":");
+    // Format: <base>:<headSha>:<diffHash> — three non-empty segments.
+    expect(parts).toHaveLength(3);
+    for (const p of parts) expect(p.length).toBeGreaterThan(0);
   });
 
-  it("includes the resolveBase return value as the first segment", () => {
-    const key = computeVerdictKey(() => "mybase-sha");
-    expect(key?.startsWith("mybase-sha:")).toBe(true);
+  it("is stable across identical invocations (same state → same key)", () => {
+    const base = "HEAD~1";
+    const key1 = computeVerdictKey(() => base);
+    const key2 = computeVerdictKey(() => base);
+    expect(key1).not.toBeNull();
+    expect(key2).not.toBeNull();
+    expect(key1).toEqual(key2);
   });
 
-  it("returns null when resolveBase throws", () => {
-    expect(() =>
-      computeVerdictKey(() => {
-        throw new Error("no base");
-      }),
-    ).toThrow("no base");
-  });
-
-  it("produces different keys for different bases", () => {
-    const key1 = computeVerdictKey(() => "base-a");
-    const key2 = computeVerdictKey(() => "base-b");
-    expect(key1).not.toBe(key2);
+  it("changes when the base ref changes", () => {
+    // Two different base refs produce different keys because the first
+    // key segment (the resolved base SHA) changes.
+    const key1 = computeVerdictKey(() => "HEAD~1");
+    const key2 = computeVerdictKey(() => "HEAD~2");
+    // HEAD~2 may not exist in a shallow repo — skip gracefully.
+    if (key1 === null || key2 === null) return;
+    expect(key1).not.toEqual(key2);
   });
 });

--- a/scripts/_runner/verdict-cache.spec.ts
+++ b/scripts/_runner/verdict-cache.spec.ts
@@ -86,35 +86,30 @@ describe("verdict-cache", () => {
 });
 
 describe("computeVerdictKey", () => {
-  // Tests run inside the mcp-cli worktree — a valid git repo with a HEAD commit.
-  // computeVerdictKey runs git commands in process.cwd() so there's no need to
-  // create a temporary repo.
-
-  it("returns a non-null string with three colon-separated parts in a valid git repo", () => {
-    const key = computeVerdictKey(() => "HEAD~1");
+  it("returns a non-null string when git commands succeed", () => {
+    const key = computeVerdictKey(() => "abc123");
     expect(key).not.toBeNull();
-    const parts = (key as string).split(":");
-    // Format: <base>:<headSha>:<diffHash> — three non-empty segments.
-    expect(parts).toHaveLength(3);
-    for (const p of parts) expect(p.length).toBeGreaterThan(0);
+    expect(typeof key).toBe("string");
+    // Format: <base>:<headSha>:<diffHash>
+    expect(key).toMatch(/^[^:]+:[a-f0-9]+:[a-f0-9]+$/);
   });
 
-  it("is stable across identical invocations (same state → same key)", () => {
-    const base = "HEAD~1";
-    const key1 = computeVerdictKey(() => base);
-    const key2 = computeVerdictKey(() => base);
-    expect(key1).not.toBeNull();
-    expect(key2).not.toBeNull();
-    expect(key1).toEqual(key2);
+  it("includes the resolveBase return value as the first segment", () => {
+    const key = computeVerdictKey(() => "mybase-sha");
+    expect(key?.startsWith("mybase-sha:")).toBe(true);
   });
 
-  it("changes when the base ref changes", () => {
-    // Two different base refs produce different keys because the first
-    // key segment (the resolved base SHA) changes.
-    const key1 = computeVerdictKey(() => "HEAD~1");
-    const key2 = computeVerdictKey(() => "HEAD~2");
-    // HEAD~2 may not exist in a shallow repo — skip gracefully.
-    if (key1 === null || key2 === null) return;
-    expect(key1).not.toEqual(key2);
+  it("returns null when resolveBase throws", () => {
+    expect(() =>
+      computeVerdictKey(() => {
+        throw new Error("no base");
+      }),
+    ).toThrow("no base");
+  });
+
+  it("produces different keys for different bases", () => {
+    const key1 = computeVerdictKey(() => "base-a");
+    const key2 = computeVerdictKey(() => "base-b");
+    expect(key1).not.toBe(key2);
   });
 });


### PR DESCRIPTION
## Summary

- **`use-plans.ts`**: replaces `err.message.includes("not found")` with `err instanceof IpcCallError && err.code === IPC_ERROR.SERVER_NOT_FOUND` — the `_claude` server-not-found error is always an `IpcCallError` with numeric code `-1001`
- **`resilient-caller.ts`**: adds a `diagnostic?: string` field to `VfsError`; sets it on the all-aliases-failed throw; `friendlyMessage` now branches on `err.diagnostic != null` instead of sniffing "Tried aliases" / "mcx ls" in the message
- **`mail-wait.ts`**: adds `systemCode?: string` to `IpcError` and `IpcCallError`; `toIpcError` now preserves OS-level string codes (ECONNREFUSED etc.) that were previously lost when wrapping errors through the IPC transport; `isTransientError` checks `IpcCallError.systemCode` instead of scanning the message string

All three `dotw-todo no-error-message-sniffing` suppressions removed; `bun run doing-it-wrong` passes clean.

## Test plan

- [x] `bun run doing-it-wrong` — no violations
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] Targeted spec files: `mail-wait.spec.ts`, `resilient-caller.spec.ts`, `use-plans.spec.ts`, `agent.spec.ts`, `claude.spec.ts` — all pass
- [x] Pre-push hook runs full changed-file test suite — all pass
- [x] Updated existing tests that were throwing bare `new Error("ECONNREFUSED")` (without `.code`) to use `Object.assign(new Error(...), { code: "ECONNREFUSED" })` — the old tests were exercising the now-deleted message-sniffing loop
- [x] Added `IpcCallError.systemCode` tests for the new IPC transport structured-code path

🤖 Generated with [Claude Code](https://claude.com/claude-code)