### PR TITLE
test(core): split agent-provider spec into cardinality and capability-shape tests (fixes #2422)

### DIFF
--- a/packages/core/src/agent-provider.spec.ts
+++ b/packages/core/src/agent-provider.spec.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
+  type AgentFeatures,
   type AgentProvider,
   type AgentShim,
+  type BuiltInProviderName,
   _resetRegistries,
   getAllProviders,
   getAllShims,
@@ -18,186 +20,293 @@ function requireProvider(name: string): AgentProvider {
   return p as AgentProvider;
 }
 
-describe("agent-provider", () => {
-  describe("built-in providers", () => {
-    test("claude provider is registered with full native features", () => {
-      const claude = requireProvider("claude");
-      expect(claude.name).toBe("claude");
-      expect(claude.serverName).toBe("_claude");
-      expect(claude.toolPrefix).toBe("claude");
-      expect(claude.native.worktree).toBe(true);
-      expect(claude.native.resume).toBe(true);
-      expect(claude.native.repoScoped).toBe(true);
-      expect(claude.native.costTracking).toBe(true);
-      expect(claude.native.compactLog).toBe(true);
-      expect(claude.native.afterSeq).toBe(true);
-      expect(claude.native.headed).toBe(true);
-      expect(claude.native.agentSelect).toBe(false);
-    });
+// ── Capability shape table ─────────────────────────────────────────────────
+//
+// Record<BuiltInProviderName, ...> is exhaustive by construction: TypeScript
+// will fail to compile if a BuiltInProviderName member is missing from the
+// table or if the type is widened. Adding a new built-in provider requires:
+//   1. Extending BuiltInProviderName in agent-provider.ts
+//   2. Adding an entry here — compile error enforces it.
+//
+// `agentOverride` is present for ACP variants that inject it into spawn args.
 
-    test("codex provider is registered", () => {
-      const codex = requireProvider("codex");
-      expect(codex.serverName).toBe("_codex");
-      expect(codex.toolPrefix).toBe("codex");
-      expect(codex.native.worktree).toBe(false);
-      expect(codex.native.costTracking).toBe(true);
-    });
+interface ProviderShapeExpectation {
+  serverName: string;
+  toolPrefix: string;
+  native: Partial<AgentFeatures>;
+  agentOverride?: string;
+}
 
-    test("opencode provider is registered", () => {
-      const oc = requireProvider("opencode");
-      expect(oc.serverName).toBe("_opencode");
-      expect(oc.toolPrefix).toBe("opencode");
-      expect(oc.native.headed).toBe(false);
-    });
+const PROVIDER_SHAPES: Record<BuiltInProviderName, ProviderShapeExpectation> = {
+  claude: {
+    serverName: "_claude",
+    toolPrefix: "claude",
+    native: {
+      worktree: true,
+      resume: true,
+      repoScoped: true,
+      costTracking: true,
+      compactLog: true,
+      afterSeq: true,
+      headed: true,
+      agentSelect: false,
+    },
+  },
+  codex: {
+    serverName: "_codex",
+    toolPrefix: "codex",
+    native: {
+      worktree: false,
+      resume: false,
+      repoScoped: false,
+      costTracking: true,
+      compactLog: false,
+      afterSeq: false,
+      headed: true,
+      agentSelect: false,
+    },
+  },
+  opencode: {
+    serverName: "_opencode",
+    toolPrefix: "opencode",
+    native: {
+      worktree: false,
+      resume: false,
+      repoScoped: false,
+      costTracking: true,
+      compactLog: false,
+      afterSeq: false,
+      headed: false,
+      agentSelect: false,
+    },
+  },
+  acp: {
+    serverName: "_acp",
+    toolPrefix: "acp",
+    native: {
+      worktree: false,
+      resume: false,
+      repoScoped: false,
+      costTracking: false,
+      compactLog: false,
+      afterSeq: false,
+      headed: false,
+      agentSelect: true,
+    },
+  },
+  copilot: {
+    serverName: "_acp",
+    toolPrefix: "acp",
+    agentOverride: "copilot",
+    native: {
+      worktree: false,
+      resume: false,
+      repoScoped: false,
+      costTracking: false,
+      compactLog: false,
+      afterSeq: false,
+      headed: false,
+      agentSelect: true,
+    },
+  },
+  gemini: {
+    serverName: "_acp",
+    toolPrefix: "acp",
+    agentOverride: "gemini",
+    native: {
+      worktree: false,
+      resume: false,
+      repoScoped: false,
+      costTracking: false,
+      compactLog: false,
+      afterSeq: false,
+      headed: false,
+      agentSelect: true,
+    },
+  },
+  grok: {
+    serverName: "_acp",
+    toolPrefix: "acp",
+    agentOverride: "grok",
+    native: {
+      worktree: false,
+      resume: false,
+      repoScoped: false,
+      costTracking: false,
+      compactLog: false,
+      afterSeq: false,
+      headed: false,
+      agentSelect: true,
+    },
+  },
+  mock: {
+    serverName: "_mock",
+    toolPrefix: "mock",
+    native: {
+      resume: false,
+    },
+  },
+};
 
-    test("acp provider is registered", () => {
-      const acp = requireProvider("acp");
-      expect(acp.serverName).toBe("_acp");
-      expect(acp.toolPrefix).toBe("acp");
-      expect(acp.native.agentSelect).toBe(true);
-    });
+// ── Cardinality ────────────────────────────────────────────────────────────
 
-    test("mock provider is registered with minimal features", () => {
-      const mock = requireProvider("mock");
-      expect(mock.serverName).toBe("_mock");
-      expect(mock.toolPrefix).toBe("mock");
-      expect(mock.native.resume).toBe(false);
-      const args = mock.buildSpawnArgs({ task: "/path/to/script.json" });
-      expect(args.task).toBe("/path/to/script.json");
+describe("built-in provider cardinality", () => {
+  // Iterating PROVIDER_SHAPES keys keeps the cardinality assertion in sync
+  // with the shape table automatically. No getAllProviders() enumeration needed.
+  for (const name of Object.keys(PROVIDER_SHAPES) as BuiltInProviderName[]) {
+    test(`${name} is registered`, () => {
+      expect(getProvider(name)).toBeDefined();
     });
+  }
 
-    test("copilot is an ACP variant with agentOverride", () => {
-      const copilot = requireProvider("copilot");
-      expect(copilot.serverName).toBe("_acp");
-      expect(copilot.toolPrefix).toBe("acp");
-      const args = copilot.buildSpawnArgs({ task: "test" });
-      expect(args.agentOverride).toBe("copilot");
-    });
-
-    test("gemini is an ACP variant with agentOverride", () => {
-      const gemini = requireProvider("gemini");
-      expect(gemini.serverName).toBe("_acp");
-      const args = gemini.buildSpawnArgs({ task: "test" });
-      expect(args.agentOverride).toBe("gemini");
-    });
-
-    test("grok is an ACP variant (first-class harness target) with agentOverride", () => {
-      const grok = requireProvider("grok");
-      expect(grok.serverName).toBe("_acp");
-      expect(grok.toolPrefix).toBe("acp");
-      const args = grok.buildSpawnArgs({ task: "test" });
-      expect(args.agentOverride).toBe("grok");
-    });
-
-    test("unknown provider returns undefined", () => {
-      expect(getProvider("nonexistent")).toBeUndefined();
-    });
+  test("unknown provider returns undefined", () => {
+    expect(getProvider("nonexistent")).toBeUndefined();
   });
+});
 
-  describe("buildSpawnArgs", () => {
-    test("claude passes through all common options", () => {
-      const claude = requireProvider("claude");
-      const args = claude.buildSpawnArgs({
-        task: "implement feature",
-        model: "opus",
-        cwd: "/tmp",
-        allowedTools: ["read"],
-        disallowedTools: ["write"],
-        wait: true,
-        timeout: 5000,
-        extras: { custom: "value" },
+// ── Capability shapes ──────────────────────────────────────────────────────
+
+describe("built-in provider capability shapes", () => {
+  for (const [name, shape] of Object.entries(PROVIDER_SHAPES) as [BuiltInProviderName, ProviderShapeExpectation][]) {
+    test(`${name}: serverName and toolPrefix`, () => {
+      const p = requireProvider(name);
+      expect(p.serverName).toBe(shape.serverName);
+      expect(p.toolPrefix).toBe(shape.toolPrefix);
+    });
+
+    test(`${name}: native feature flags`, () => {
+      const p = requireProvider(name);
+      for (const [flag, expected] of Object.entries(shape.native) as [keyof AgentFeatures, boolean][]) {
+        expect(p.native[flag]).toBe(expected);
+      }
+    });
+
+    if (shape.agentOverride !== undefined) {
+      const expectedOverride = shape.agentOverride;
+      test(`${name}: buildSpawnArgs injects agentOverride="${expectedOverride}"`, () => {
+        const p = requireProvider(name);
+        const args = p.buildSpawnArgs({ task: "test" });
+        expect(args.agentOverride).toBe(expectedOverride);
       });
-      expect(args.task).toBe("implement feature");
-      expect(args.model).toBe("opus");
-      expect(args.cwd).toBe("/tmp");
-      expect(args.allowedTools).toEqual(["read"]);
-      expect(args.wait).toBe(true);
-      expect(args.custom).toBe("value");
-    });
+    }
+  }
+});
 
-    test("copilot injects agentOverride into spawn args", () => {
-      const copilot = requireProvider("copilot");
-      const args = copilot.buildSpawnArgs({ task: "test", extras: { foo: 1 } });
-      expect(args.agentOverride).toBe("copilot");
-      expect(args.foo).toBe(1);
-    });
+// ── buildSpawnArgs: shared behavior ───────────────────────────────────────
 
-    test("extras cannot overwrite explicit fields", () => {
-      const claude = requireProvider("claude");
-      const args = claude.buildSpawnArgs({
-        task: "real task",
-        model: "opus",
-        cwd: "/safe",
-        extras: { task: "", model: "haiku", cwd: "/evil" },
-      });
-      expect(args.task).toBe("real task");
-      expect(args.model).toBe("opus");
-      expect(args.cwd).toBe("/safe");
+describe("buildSpawnArgs", () => {
+  test("claude passes through all common options", () => {
+    const claude = requireProvider("claude");
+    const args = claude.buildSpawnArgs({
+      task: "implement feature",
+      model: "opus",
+      cwd: "/tmp",
+      allowedTools: ["read"],
+      disallowedTools: ["write"],
+      wait: true,
+      timeout: 5000,
+      extras: { custom: "value" },
     });
+    expect(args.task).toBe("implement feature");
+    expect(args.model).toBe("opus");
+    expect(args.cwd).toBe("/tmp");
+    expect(args.allowedTools).toEqual(["read"]);
+    expect(args.wait).toBe(true);
+    expect(args.custom).toBe("value");
   });
 
-  describe("shim registry", () => {
-    afterEach(() => {
-      const builtInProviders = getAllProviders();
-      _resetRegistries();
-      for (const p of builtInProviders) registerProvider(p);
-    });
-
-    test("getShims returns empty array when no shims registered", () => {
-      const claude = requireProvider("claude");
-      expect(getShims(claude)).toEqual([]);
-    });
-
-    test("shim applies to providers lacking the feature", () => {
-      const worktreeShim: AgentShim = {
-        feature: "worktree",
-        appliesTo: (p: AgentProvider) => !p.native.worktree,
-      };
-      registerShim(worktreeShim);
-
-      const claude = requireProvider("claude");
-      const codex = requireProvider("codex");
-
-      // Claude has native worktree — shim should NOT apply
-      expect(getShims(claude)).toEqual([]);
-      // Codex lacks native worktree — shim SHOULD apply
-      expect(getShims(codex)).toEqual([worktreeShim]);
-    });
-
-    test("multiple shims can apply to the same provider", () => {
-      const shimA: AgentShim = {
-        feature: "worktree",
-        appliesTo: (p: AgentProvider) => !p.native.worktree,
-      };
-      const shimB: AgentShim = {
-        feature: "resume",
-        appliesTo: (p: AgentProvider) => !p.native.resume,
-      };
-      registerShim(shimA);
-      registerShim(shimB);
-
-      const codex = requireProvider("codex");
-      expect(getShims(codex)).toEqual([shimA, shimB]);
-    });
-
-    test("getAllShims returns all registered shims", () => {
-      const shim: AgentShim = {
-        feature: "worktree",
-        appliesTo: () => true,
-      };
-      registerShim(shim);
-      expect(getAllShims()).toEqual([shim]);
-    });
+  test("mock passes through task", () => {
+    const mock = requireProvider("mock");
+    const args = mock.buildSpawnArgs({ task: "/path/to/script.json" });
+    expect(args.task).toBe("/path/to/script.json");
   });
 
-  describe("_resetRegistries", () => {
-    test("clears all providers and shims then restores", () => {
-      const saved = getAllProviders();
-      _resetRegistries();
-      expect(getAllProviders()).toEqual([]);
-      expect(getAllShims()).toEqual([]);
-      // Restore so subsequent tests in the same worker aren't poisoned
-      for (const p of saved) registerProvider(p);
+  test("copilot injects agentOverride into spawn args alongside extras", () => {
+    const copilot = requireProvider("copilot");
+    const args = copilot.buildSpawnArgs({ task: "test", extras: { foo: 1 } });
+    expect(args.agentOverride).toBe("copilot");
+    expect(args.foo).toBe(1);
+  });
+
+  test("extras cannot overwrite explicit fields", () => {
+    const claude = requireProvider("claude");
+    const args = claude.buildSpawnArgs({
+      task: "real task",
+      model: "opus",
+      cwd: "/safe",
+      extras: { task: "", model: "haiku", cwd: "/evil" },
     });
+    expect(args.task).toBe("real task");
+    expect(args.model).toBe("opus");
+    expect(args.cwd).toBe("/safe");
+  });
+});
+
+// ── Shim registry ──────────────────────────────────────────────────────────
+
+describe("shim registry", () => {
+  afterEach(() => {
+    const builtInProviders = getAllProviders();
+    _resetRegistries();
+    for (const p of builtInProviders) registerProvider(p);
+  });
+
+  test("getShims returns empty array when no shims registered", () => {
+    const claude = requireProvider("claude");
+    expect(getShims(claude)).toEqual([]);
+  });
+
+  test("shim applies to providers lacking the feature", () => {
+    const worktreeShim: AgentShim = {
+      feature: "worktree",
+      appliesTo: (p: AgentProvider) => !p.native.worktree,
+    };
+    registerShim(worktreeShim);
+
+    const claude = requireProvider("claude");
+    const codex = requireProvider("codex");
+
+    // Claude has native worktree — shim should NOT apply
+    expect(getShims(claude)).toEqual([]);
+    // Codex lacks native worktree — shim SHOULD apply
+    expect(getShims(codex)).toEqual([worktreeShim]);
+  });
+
+  test("multiple shims can apply to the same provider", () => {
+    const shimA: AgentShim = {
+      feature: "worktree",
+      appliesTo: (p: AgentProvider) => !p.native.worktree,
+    };
+    const shimB: AgentShim = {
+      feature: "resume",
+      appliesTo: (p: AgentProvider) => !p.native.resume,
+    };
+    registerShim(shimA);
+    registerShim(shimB);
+
+    const codex = requireProvider("codex");
+    expect(getShims(codex)).toEqual([shimA, shimB]);
+  });
+
+  test("getAllShims returns all registered shims", () => {
+    const shim: AgentShim = {
+      feature: "worktree",
+      appliesTo: () => true,
+    };
+    registerShim(shim);
+    expect(getAllShims()).toEqual([shim]);
+  });
+});
+
+// ── _resetRegistries ───────────────────────────────────────────────────────
+
+describe("_resetRegistries", () => {
+  test("clears all providers and shims then restores", () => {
+    const saved = getAllProviders();
+    _resetRegistries();
+    expect(getAllProviders()).toEqual([]);
+    expect(getAllShims()).toEqual([]);
+    // Restore so subsequent tests in the same worker aren't poisoned
+    for (const p of saved) registerProvider(p);
   });
 });

--- a/packages/core/src/agent-provider.ts
+++ b/packages/core/src/agent-provider.ts
@@ -40,6 +40,8 @@ export interface CommonSpawnOpts {
   extras?: Record<string, unknown>;
 }
 
+export type BuiltInProviderName = "claude" | "codex" | "opencode" | "acp" | "copilot" | "gemini" | "grok" | "mock";
+
 export interface AgentProvider {
   /** Provider identifier: "claude", "codex", "acp", "opencode", "copilot", "gemini" */
   name: string;


### PR DESCRIPTION
## Summary
- Exports `BuiltInProviderName` union type from `agent-provider.ts`; using `Record<BuiltInProviderName, ...>` in the spec table means TypeScript enforces at compile time that every built-in provider has a shape entry — adding a new provider name to the union without a table row is a build error
- Splits the spec into two distinct concerns: **cardinality** (each built-in name resolves via `getProvider()`) and **capability shape** (table-driven checks of `serverName`, `toolPrefix`, all declared `native.*` flags, and `agentOverride` injection for ACP variants)
- Cardinality section iterates the static `PROVIDER_SHAPES` table keys rather than calling `getAllProviders()`, so it is compliant with the `provider-spec-shape` rule added in #2420

## Test plan
- [ ] `bun test packages/core/src/agent-provider.spec.ts` passes with all 8 providers covered
- [ ] `bun run doing-it-wrong` — no `provider-spec-shape` violations in the spec
- [ ] `bun typecheck` — removing an entry from `PROVIDER_SHAPES` produces a TypeScript error (exhaustiveness enforced)
- [ ] `bun run am-i-done` passes (pre-push gate confirmed clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)