### PR TITLE
refactor(test): route test fixtures through spawnManaged for proper teardown (closes #2413)

### DIFF
--- a/test/daemon-integration.spec.ts
+++ b/test/daemon-integration.spec.ts
@@ -51,7 +51,7 @@ describe("P1: Daemon lifecycle", () => {
     expect(res.result).toEqual({ ok: true });
 
     const exitCode = await Promise.race([
-      daemon.proc.exited,
+      daemon.exitCode,
       Bun.sleep(SHUTDOWN_TIMEOUT_MS).then(() => "timeout" as const),
     ]);
     expect(exitCode).toBe(0);
@@ -66,12 +66,12 @@ describe("P1: Daemon lifecycle", () => {
     daemon = await startTestDaemon({});
     await rpc(daemon.socketPath, "shutdown");
     const exitCode = await Promise.race([
-      daemon.proc.exited,
+      daemon.exitCode,
       Bun.sleep(SHUTDOWN_TIMEOUT_MS).then(() => "timeout" as const),
     ]);
     expect(exitCode).not.toBe("timeout");
 
-    const stderr = await new Response(daemon.proc.stderr as ReadableStream).text();
+    const stderr = daemon.stderrTail();
     expect(stderr).toContain("Shutting down (IPC shutdown request)");
     expect(stderr).toContain("Shutdown complete in ");
     // Per-phase instrumentation should be visible at info level (#1103)
@@ -82,14 +82,14 @@ describe("P1: Daemon lifecycle", () => {
 
   test("shutdown via SIGTERM logs reason in stderr", async () => {
     daemon = await startTestDaemon({});
-    daemon.proc.kill("SIGTERM");
+    await daemon.handle.kill();
     const exitCode = await Promise.race([
-      daemon.proc.exited,
+      daemon.exitCode,
       Bun.sleep(SHUTDOWN_TIMEOUT_MS).then(() => "timeout" as const),
     ]);
     expect(exitCode).not.toBe("timeout");
 
-    const stderr = await new Response(daemon.proc.stderr as ReadableStream).text();
+    const stderr = daemon.stderrTail();
     expect(stderr).toContain("Shutting down (SIGTERM)");
     daemon = undefined;
   });
@@ -103,15 +103,13 @@ describe("P1: Daemon lifecycle", () => {
     // Under CPU contention setTimeout can fire late — see #842 for root cause investigation.
     const t0 = Date.now();
     const exitCode = await Promise.race([
-      daemon.proc.exited,
+      daemon.exitCode,
       Bun.sleep(SHUTDOWN_TIMEOUT_MS).then(() => "timeout" as const),
     ]);
     const elapsed = Date.now() - t0;
 
     if (exitCode === "timeout") {
-      console.error(
-        `[idle-timeout-test] timed out after ${elapsed}ms, pid ${daemon.proc.pid} killed=${daemon.proc.killed}`,
-      );
+      console.error(`[idle-timeout-test] timed out after ${elapsed}ms, pid ${daemon.handle.pid}`);
     }
     expect(exitCode).toBe(0);
 
@@ -119,7 +117,7 @@ describe("P1: Daemon lifecycle", () => {
     if (exitCode === 0) expect(elapsed).toBeLessThan(8_000);
 
     // Verify timing instrumentation is present in stderr (#842)
-    const stderr = await new Response(daemon.proc.stderr as ReadableStream).text();
+    const stderr = daemon.stderrTail();
     expect(stderr).toContain("Idle timer fired: expected=4000ms actual=");
     expect(stderr).toContain("drift=");
     expect(stderr).toContain("Shutdown complete in ");
@@ -139,8 +137,8 @@ describe("P1: Daemon lifecycle", () => {
     expect(existsSync(pidPath)).toBe(true);
 
     // Force kill (no clean shutdown → PID file remains)
-    daemon.proc.kill("SIGKILL");
-    await daemon.proc.exited;
+    daemon.handle.killNow();
+    await daemon.exitCode;
     expect(existsSync(pidPath)).toBe(true);
 
     // Start a new daemon in the same directory — it should overwrite the stale PID

--- a/test/daemon-integration.spec.ts
+++ b/test/daemon-integration.spec.ts
@@ -82,12 +82,8 @@ describe("P1: Daemon lifecycle", () => {
 
   test("shutdown via SIGTERM logs reason in stderr", async () => {
     daemon = await startTestDaemon({});
-    await daemon.handle.kill();
-    const exitCode = await Promise.race([
-      daemon.exitCode,
-      Bun.sleep(SHUTDOWN_TIMEOUT_MS).then(() => "timeout" as const),
-    ]);
-    expect(exitCode).not.toBe("timeout");
+    const status = await daemon.handle.kill();
+    expect(status.exitCode).not.toBeNull();
 
     const stderr = daemon.stderrTail();
     expect(stderr).toContain("Shutting down (SIGTERM)");

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -7,19 +7,22 @@
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import type { IpcResponse, ServerConfig, ServerConfigMap } from "@mcp-cli/core";
+import type { IpcResponse, ManagedHandle, ServerConfig, ServerConfigMap } from "@mcp-cli/core";
+import { spawnManaged } from "@mcp-cli/core";
 
 export interface MockServer {
-  proc: ReturnType<typeof Bun.spawn>;
+  handle: ManagedHandle;
   port: number;
   kill: () => Promise<void>;
 }
 
 export interface TestDaemon {
-  proc: ReturnType<typeof Bun.spawn>;
+  handle: ManagedHandle;
+  exitCode: Promise<number | null>;
   dir: string;
   socketPath: string;
   kill: () => Promise<void>;
+  stderrTail: () => string;
 }
 
 /** Create an isolated temp directory for a test daemon */
@@ -66,7 +69,7 @@ export async function startTestDaemon(
   // Production keeps the well-known port; only test daemons opt in to wsPort: 0.
   writeFileSync(join(dir, "config.json"), JSON.stringify({ wsPort: 0 }));
 
-  const proc = Bun.spawn(["bun", resolve("packages/daemon/src/main.ts")], {
+  const result = spawnManaged("bun", [resolve("packages/daemon/src/main.ts")], {
     stdout: "ignore",
     stderr: "pipe",
     env: {
@@ -78,6 +81,13 @@ export async function startTestDaemon(
     },
   });
 
+  if (!result.ok) {
+    rmSync(dir, { recursive: true, force: true });
+    throw new Error("Failed to spawn daemon process");
+  }
+
+  const { handle } = result;
+
   // Wait for daemon to be ready by polling the socket file + ping.
   // This is more reliable than reading stdout (which has pipe buffering
   // issues on Linux CI runners).
@@ -86,7 +96,7 @@ export async function startTestDaemon(
 
   while (Date.now() < deadline) {
     // Check if process died
-    const exited = await Promise.race([proc.exited.then(() => true), Bun.sleep(50).then(() => false)]);
+    const exited = await Promise.race([handle.exited.then(() => true), Bun.sleep(50).then(() => false)]);
     if (exited) break;
 
     if (!existsSync(socketPath)) continue;
@@ -105,34 +115,24 @@ export async function startTestDaemon(
   }
 
   if (!ready) {
-    proc.kill();
-    const stderr = await new Response(proc.stderr).text();
+    await handle.kill();
+    const stderr = handle.stderrTail();
     rmSync(dir, { recursive: true, force: true });
     throw new Error(`Daemon failed to start within ${options?.timeout ?? 15_000}ms.\nstderr: ${stderr}`);
   }
 
+  const exitCode = handle.exited.then((s) => s.exitCode);
+
   return {
-    proc,
+    handle,
+    exitCode,
     dir,
     socketPath,
     kill: async () => {
-      try {
-        proc.kill("SIGTERM");
-      } catch {
-        // already exited
-      }
-      // Bounded wait: if SIGTERM doesn't work within 5s, escalate to SIGKILL
-      const exited = await Promise.race([proc.exited.then(() => true), Bun.sleep(5_000).then(() => false)]);
-      if (!exited) {
-        try {
-          proc.kill("SIGKILL");
-        } catch {
-          // already exited
-        }
-        await Promise.race([proc.exited, Bun.sleep(2_000)]);
-      }
+      await handle.kill();
       rmSync(dir, { recursive: true, force: true });
     },
+    stderrTail: () => handle.stderrTail(),
   };
 }
 
@@ -165,13 +165,23 @@ export async function pollUntil(
  * The server script must print the listening port as the first line of stdout.
  */
 export async function startMockServer(scriptPath: string): Promise<MockServer> {
-  const proc = Bun.spawn(["bun", resolve(scriptPath)], {
+  const result = spawnManaged("bun", [resolve(scriptPath)], {
     stdout: "pipe",
     stderr: "pipe",
   });
 
+  if (!result.ok) {
+    throw new Error(`Failed to spawn mock server: ${scriptPath}`);
+  }
+
+  const { handle } = result;
+
   // Read the port from the first line of stdout (bounded to 10s to prevent hangs under contention)
-  const reader = proc.stdout.getReader();
+  if (!handle.stdout) {
+    await handle.kill();
+    throw new Error("Mock server stdout stream unavailable");
+  }
+  const reader = handle.stdout.getReader();
   const readResult = await Promise.race([
     reader.read(),
     Bun.sleep(10_000).then(() => ({ value: undefined, done: true as const, timeout: true as const })),
@@ -188,28 +198,23 @@ export async function startMockServer(scriptPath: string): Promise<MockServer> {
   reader.releaseLock();
 
   if (!portLine) {
-    proc.kill();
-    const stderr = await new Response(proc.stderr).text();
+    await handle.kill();
+    const stderr = handle.stderrTail();
     const reason = "timeout" in readResult ? "timed out waiting for port" : "no output";
     throw new Error(`Mock server failed to start (${reason}): ${stderr}`);
   }
 
   const port = Number(portLine);
   if (!port || Number.isNaN(port)) {
-    proc.kill();
+    await handle.kill();
     throw new Error(`Mock server printed invalid port: ${JSON.stringify(portLine)}`);
   }
 
   return {
-    proc,
+    handle,
     port,
     kill: async () => {
-      try {
-        proc.kill("SIGTERM");
-      } catch {
-        // already exited
-      }
-      await Promise.race([proc.exited, Bun.sleep(3_000)]);
+      await handle.kill();
     },
   };
 }


### PR DESCRIPTION
## Summary
- Migrate `startTestDaemon` and `startMockServer` in `test/harness.ts` from bare `Bun.spawn` to `spawnManaged`, which guarantees SIGTERM→SIGKILL escalation and stderr auto-drain via ring buffer
- Update `TestDaemon` and `MockServer` interfaces: replace raw `proc` with `ManagedHandle`, add convenience `exitCode` promise and `stderrTail()` accessor
- Update all `daemon.proc.*` call sites in `test/daemon-integration.spec.ts` to use the new interface (`daemon.exitCode`, `daemon.stderrTail()`, `daemon.handle.kill()`, `daemon.handle.killNow()`)

## Test plan
- [x] All 32 daemon-integration tests pass (lifecycle, config reload, transport, concurrency, error paths)
- [x] All 33 tests across harness-dependent files pass (stress, transport-errors, monitor-alias, session-result-sse, cli-orchestration)
- [x] `bun typecheck` clean
- [x] `bun lint` clean
- [x] Pre-commit + pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)