### PR TITLE
feat(rules): acp-cost-tracking-evidence rule — enforce spec coverage for ACP cost tracking (closes #2419)

### DIFF
--- a/scripts/rules/acp-cost-tracking-evidence.rule.ts
+++ b/scripts/rules/acp-cost-tracking-evidence.rule.ts
@@ -20,8 +20,9 @@
  *   two content signals:
  *     - ["']session_info_update["'] (a test exercises this event type; accepts
  *       any quote style so biome reformatting cannot trigger false failures)
- *     - expect(state.cost (an expect() call on state.cost — assignment lines
- *       like `state.cost = 0.01` in unrelated setup blocks do NOT count)
+ *     - /^\s*expect\s*\(\s*state\.cost\s*\)/ on a non-comment line — anchored
+ *       on the closing paren so state.costPerToken/costFoo don't match, and
+ *       lines starting with // or * are excluded to avoid commented-out code
  *   If either signal is absent, the costTracking: true line is flagged.
  *
  * Sources: #2419, flagged in #2391 adversarial review.
@@ -34,7 +35,13 @@ const PROVIDER_FILE = "packages/core/src/agent-provider.ts";
 const ACP_SPEC = "packages/acp/src/acp-event-map.spec.ts";
 
 function specHasCostEvidence(specContent: string): boolean {
-  return /["']session_info_update["']/.test(specContent) && specContent.includes("expect(state.cost");
+  if (!/["']session_info_update["']/.test(specContent)) return false;
+  const costAssertionRe = /^\s*expect\s*\(\s*state\.cost\s*\)/;
+  return specContent.split("\n").some((line) => {
+    const trimmed = line.trimStart();
+    if (trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*")) return false;
+    return costAssertionRe.test(trimmed);
+  });
 }
 
 function findPropertyInit(obj: ts.ObjectLiteralExpression, key: string): ts.Expression | undefined {

--- a/scripts/rules/acp-cost-tracking-evidence.rule.ts
+++ b/scripts/rules/acp-cost-tracking-evidence.rule.ts
@@ -16,31 +16,44 @@
  *   calls whose first argument is an object literal with both:
  *     - serverName: "_acp" (top-level string property)
  *     - native.costTracking: true (boolean in the nested native object)
- *   For each such provider found, checks the acp-event-map.spec.ts anchor for
- *   two content signals:
- *     - ["']session_info_update["'] (a test exercises this event type; accepts
- *       any quote style so biome reformatting cannot trigger false failures)
- *     - /^\s*expect\s*\(\s*state\.cost\s*\)/ on a non-comment line — anchored
- *       on the closing paren so state.costPerToken/costFoo don't match, and
- *       lines starting with // or * are excluded to avoid commented-out code
+ *   For each such provider found, parses acp-event-map.spec.ts via the TS AST
+ *   and checks for two structural signals:
+ *     - A StringLiteral node with text "session_info_update"
+ *     - A CallExpression `expect(state.cost)` where the callee is `expect`
+ *       and its single argument is PropertyAccessExpression `state.cost`
+ *       (exact — state.costPerToken etc. are structurally distinct)
+ *   AST-based detection makes comments, whitespace, block-comments, quote
+ *   style, and sibling-field false-positives all structurally impossible.
  *   If either signal is absent, the costTracking: true line is flagged.
  *
  * Sources: #2419, flagged in #2391 adversarial review.
  */
 
 import ts from "typescript";
+import { createAstHelper } from "./_engine/ast";
+import type { FileMeta } from "./_engine/file-loader";
 import type { CheckRule, RuleContext } from "./_engine/rule";
 
 const PROVIDER_FILE = "packages/core/src/agent-provider.ts";
 const ACP_SPEC = "packages/acp/src/acp-event-map.spec.ts";
 
-function specHasCostEvidence(specContent: string): boolean {
-  if (!/["']session_info_update["']/.test(specContent)) return false;
-  const costAssertionRe = /^\s*expect\s*\(\s*state\.cost\s*\)/;
-  return specContent.split("\n").some((line) => {
-    const trimmed = line.trimStart();
-    if (trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*")) return false;
-    return costAssertionRe.test(trimmed);
+function specHasCostEvidence(spec: FileMeta): boolean {
+  const ast = createAstHelper(spec);
+
+  const hasSessionInfoUpdate =
+    ast.find((n): n is ts.StringLiteral => ts.isStringLiteral(n) && n.text === "session_info_update").length > 0;
+  if (!hasSessionInfoUpdate) return false;
+
+  const expectCalls = ast.callsTo("expect");
+  return expectCalls.some((call) => {
+    if (call.arguments.length !== 1) return false;
+    const arg = call.arguments[0];
+    return (
+      ts.isPropertyAccessExpression(arg) &&
+      ts.isIdentifier(arg.expression) &&
+      arg.expression.text === "state" &&
+      arg.name.text === "cost"
+    );
   });
 }
 
@@ -114,15 +127,15 @@ const rule: CheckRule = {
     if (ctx.file.relPath !== PROVIDER_FILE) return;
     ctx.checked();
 
-    let specContent: string | undefined;
+    let specFile: FileMeta | undefined;
     for (const meta of ctx.files.values()) {
       if (meta.relPath === ACP_SPEC) {
-        specContent = meta.content;
+        specFile = meta;
         break;
       }
     }
 
-    const hasEvidence = specContent !== undefined && specHasCostEvidence(specContent);
+    const hasEvidence = specFile !== undefined && specHasCostEvidence(specFile);
     checkProviders(ctx, hasEvidence);
   },
 };

--- a/scripts/rules/acp-cost-tracking-evidence.rule.ts
+++ b/scripts/rules/acp-cost-tracking-evidence.rule.ts
@@ -1,0 +1,121 @@
+/**
+ * Rule: acp-cost-tracking-evidence
+ *
+ * Flag any AgentProvider registration where serverName === "_acp" and
+ * native.costTracking === true unless acp-event-map.spec.ts contains a
+ * test that exercises the session_info_update path and asserts the cost
+ * field from the accumulated state.
+ *
+ * Without this evidence, budget-watcher tracks $0.00 per turn forever for
+ * the provider (80% impl-freeze never fires for sprints using that provider)
+ * and the session display shows "—" (tracked, no data) rather than "N/A"
+ * (not supported) — actively misleading.
+ *
+ * Detection strategy:
+ *   Only runs on packages/core/src/agent-provider.ts. Finds registerProvider()
+ *   calls whose first argument is an object literal with both:
+ *     - serverName: "_acp" (top-level string property)
+ *     - native.costTracking: true (boolean in the nested native object)
+ *   For each such provider found, checks the acp-event-map.spec.ts anchor for
+ *   two content signals:
+ *     - "session_info_update" string literal (a test exercises this event type)
+ *     - state.cost (asserted after mapSessionUpdate, proving extraction works)
+ *   If either signal is absent, the costTracking: true line is flagged.
+ *
+ * Sources: #2419, flagged in #2391 adversarial review.
+ */
+
+import ts from "typescript";
+import type { CheckRule, RuleContext } from "./_engine/rule";
+
+const PROVIDER_FILE = "packages/core/src/agent-provider.ts";
+const ACP_SPEC = "packages/acp/src/acp-event-map.spec.ts";
+
+function specHasCostEvidence(specContent: string): boolean {
+  return specContent.includes('"session_info_update"') && specContent.includes("state.cost");
+}
+
+function findPropertyInit(obj: ts.ObjectLiteralExpression, key: string): ts.Expression | undefined {
+  for (const prop of obj.properties) {
+    if (ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name) && prop.name.text === key) {
+      return prop.initializer;
+    }
+  }
+  return undefined;
+}
+
+function findPropertyAssignment(obj: ts.ObjectLiteralExpression, key: string): ts.PropertyAssignment | undefined {
+  for (const prop of obj.properties) {
+    if (ts.isPropertyAssignment(prop) && ts.isIdentifier(prop.name) && prop.name.text === key) {
+      return prop;
+    }
+  }
+  return undefined;
+}
+
+function checkProviders(ctx: RuleContext, hasEvidence: boolean): void {
+  const lines = ctx.file.content.split("\n");
+  const sf = ctx.ast.sourceFile;
+
+  function walk(node: ts.Node): void {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "registerProvider" &&
+      node.arguments.length > 0
+    ) {
+      const arg = node.arguments[0];
+      if (ts.isObjectLiteralExpression(arg)) {
+        const serverNameVal = findPropertyInit(arg, "serverName");
+        if (serverNameVal && ts.isStringLiteral(serverNameVal) && serverNameVal.text === "_acp") {
+          const nativeVal = findPropertyInit(arg, "native");
+          if (nativeVal && ts.isObjectLiteralExpression(nativeVal)) {
+            const costTrackingVal = findPropertyInit(nativeVal, "costTracking");
+            if (costTrackingVal && costTrackingVal.kind === ts.SyntaxKind.TrueKeyword && !hasEvidence) {
+              const pa = findPropertyAssignment(nativeVal, "costTracking");
+              if (pa) {
+                const pos = ctx.ast.positionOf(pa);
+                ctx.violated(pos.line, pos.column, lines[pos.line - 1]?.trim() ?? "");
+              }
+            }
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, walk);
+  }
+
+  walk(sf);
+}
+
+const rule: CheckRule = {
+  id: "acp-cost-tracking-evidence",
+  kind: "check",
+  scold: "ACP provider has costTracking: true with no acp-event-map.spec.ts evidence for cost field extraction",
+  guidance: [
+    "costTracking: true on an ACP provider without a spec test is a capability claim with no evidence — budget-watcher tracks $0.00 per turn forever (80% impl-freeze never fires) and the session display shows '—' (tracked, no data) instead of 'N/A' (not supported)",
+    "add a test in acp-event-map.spec.ts that passes a session/update notification with sessionUpdate: 'session_info_update' and a cost field, then asserts expect(state.cost).toBe(<value>) — this proves the ACP event map actually extracts the cost field",
+    "the assertion must cover state.cost specifically (not just state.totalTokens) — token-count tests do not prove cost extraction works",
+    "if this ACP provider does not actually report cost, set costTracking: false instead",
+  ],
+  documentation: "#2419",
+  appliesToTests: false,
+  anchors: [ACP_SPEC],
+  check(ctx) {
+    if (ctx.file.relPath !== PROVIDER_FILE) return;
+    ctx.checked();
+
+    let specContent: string | undefined;
+    for (const meta of ctx.files.values()) {
+      if (meta.relPath === ACP_SPEC) {
+        specContent = meta.content;
+        break;
+      }
+    }
+
+    const hasEvidence = specContent !== undefined && specHasCostEvidence(specContent);
+    checkProviders(ctx, hasEvidence);
+  },
+};
+
+export default rule;

--- a/scripts/rules/acp-cost-tracking-evidence.rule.ts
+++ b/scripts/rules/acp-cost-tracking-evidence.rule.ts
@@ -18,8 +18,10 @@
  *     - native.costTracking: true (boolean in the nested native object)
  *   For each such provider found, checks the acp-event-map.spec.ts anchor for
  *   two content signals:
- *     - "session_info_update" string literal (a test exercises this event type)
- *     - state.cost (asserted after mapSessionUpdate, proving extraction works)
+ *     - ["']session_info_update["'] (a test exercises this event type; accepts
+ *       any quote style so biome reformatting cannot trigger false failures)
+ *     - expect(state.cost (an expect() call on state.cost — assignment lines
+ *       like `state.cost = 0.01` in unrelated setup blocks do NOT count)
  *   If either signal is absent, the costTracking: true line is flagged.
  *
  * Sources: #2419, flagged in #2391 adversarial review.
@@ -32,7 +34,7 @@ const PROVIDER_FILE = "packages/core/src/agent-provider.ts";
 const ACP_SPEC = "packages/acp/src/acp-event-map.spec.ts";
 
 function specHasCostEvidence(specContent: string): boolean {
-  return specContent.includes('"session_info_update"') && specContent.includes("state.cost");
+  return /["']session_info_update["']/.test(specContent) && specContent.includes("expect(state.cost");
 }
 
 function findPropertyInit(obj: ts.ObjectLiteralExpression, key: string): ts.Expression | undefined {

--- a/scripts/rules/acp-cost-tracking-evidence.spec.ts
+++ b/scripts/rules/acp-cost-tracking-evidence.spec.ts
@@ -72,6 +72,25 @@ describe("buildTurnResult", () => {
 });
 `;
 
+// expect(state.costPerToken) is a DIFFERENT field — must not count as evidence.
+const SPEC_WITH_COST_PER_TOKEN_ONLY = `
+test("session_info_update tracks cost per token", () => {
+  const state = createAcpEventMapState();
+  mapSessionUpdate({ update: { sessionUpdate: "session_info_update", costPerToken: 0.001 } }, state);
+  expect(state.costPerToken).toBe(0.001);
+});
+`;
+
+// A commented-out expect(state.cost) must not count as evidence.
+const SPEC_WITH_COMMENTED_OUT_COST = `
+test("session_info_update tracks tokens", () => {
+  const state = createAcpEventMapState();
+  mapSessionUpdate({ update: { sessionUpdate: "session_info_update" } }, state);
+  // expect(state.cost).toBe(0.005);
+  expect(state.totalTokens).toBe(0);
+});
+`;
+
 // Single-quoted variant of the session_info_update signal — biome may rewrite quotes.
 const SPEC_WITH_SINGLE_QUOTE_EVIDENCE = `
 test('session_info_update tracks cost', () => {
@@ -180,6 +199,28 @@ describe("acp-cost-tracking-evidence: cross-file evidence check", () => {
     ]);
     const violations = evaluateRule(rule, provider, files);
     expect(violations).toHaveLength(0);
+  });
+
+  it("flags when spec asserts state.costPerToken but not state.cost", () => {
+    const provider = makeFile(PROVIDER_PATH, PROVIDER_WITH_ACP_COST_TRACKING);
+    const spec = makeFile(SPEC_PATH, SPEC_WITH_COST_PER_TOKEN_ONLY);
+    const files = new Map([
+      [provider.path, provider],
+      [spec.path, spec],
+    ]);
+    const violations = evaluateRule(rule, provider, files);
+    expect(violations).toHaveLength(1);
+  });
+
+  it("flags when expect(state.cost) appears only in a comment", () => {
+    const provider = makeFile(PROVIDER_PATH, PROVIDER_WITH_ACP_COST_TRACKING);
+    const spec = makeFile(SPEC_PATH, SPEC_WITH_COMMENTED_OUT_COST);
+    const files = new Map([
+      [provider.path, provider],
+      [spec.path, spec],
+    ]);
+    const violations = evaluateRule(rule, provider, files);
+    expect(violations).toHaveLength(1);
   });
 
   it("evidence in spec clears violations for all _acp providers in the file", () => {

--- a/scripts/rules/acp-cost-tracking-evidence.spec.ts
+++ b/scripts/rules/acp-cost-tracking-evidence.spec.ts
@@ -91,6 +91,19 @@ test("session_info_update tracks tokens", () => {
 });
 `;
 
+// Block-comment around expect(state.cost) — inner line doesn't start with * so
+// the old text-matching comment filter missed it. AST excludes it structurally.
+const SPEC_WITH_BLOCK_COMMENT_COST = `
+test("session_info_update tracks tokens", () => {
+  const state = createAcpEventMapState();
+  mapSessionUpdate({ update: { sessionUpdate: "session_info_update" } }, state);
+  /*
+  expect(state.cost).toBe(0.005);
+  */
+  expect(state.totalTokens).toBe(0);
+});
+`;
+
 // Single-quoted variant of the session_info_update signal — biome may rewrite quotes.
 const SPEC_WITH_SINGLE_QUOTE_EVIDENCE = `
 test('session_info_update tracks cost', () => {
@@ -215,6 +228,17 @@ describe("acp-cost-tracking-evidence: cross-file evidence check", () => {
   it("flags when expect(state.cost) appears only in a comment", () => {
     const provider = makeFile(PROVIDER_PATH, PROVIDER_WITH_ACP_COST_TRACKING);
     const spec = makeFile(SPEC_PATH, SPEC_WITH_COMMENTED_OUT_COST);
+    const files = new Map([
+      [provider.path, provider],
+      [spec.path, spec],
+    ]);
+    const violations = evaluateRule(rule, provider, files);
+    expect(violations).toHaveLength(1);
+  });
+
+  it("flags when expect(state.cost) is inside a block comment", () => {
+    const provider = makeFile(PROVIDER_PATH, PROVIDER_WITH_ACP_COST_TRACKING);
+    const spec = makeFile(SPEC_PATH, SPEC_WITH_BLOCK_COMMENT_COST);
     const files = new Map([
       [provider.path, provider],
       [spec.path, spec],

--- a/scripts/rules/acp-cost-tracking-evidence.spec.ts
+++ b/scripts/rules/acp-cost-tracking-evidence.spec.ts
@@ -58,6 +58,29 @@ test("agent_message_chunk", () => {
 });
 `;
 
+// Spec that has state.cost as a setup *assignment* (not an expect assertion) alongside
+// a session_info_update string — the raw-includes check would pass this; the fixed
+// expect(state.cost check must flag it.
+const SPEC_WITH_COST_ASSIGNMENT_ONLY = `
+describe("buildTurnResult", () => {
+  test("maps cost", () => {
+    const state = createAcpEventMapState();
+    state.cost = 0.01;
+    mapSessionUpdate({ update: { sessionUpdate: "session_info_update" } }, state);
+    expect(state.totalTokens).toBe(0);
+  });
+});
+`;
+
+// Single-quoted variant of the session_info_update signal — biome may rewrite quotes.
+const SPEC_WITH_SINGLE_QUOTE_EVIDENCE = `
+test('session_info_update tracks cost', () => {
+  const state = createAcpEventMapState();
+  mapSessionUpdate({ update: { sessionUpdate: 'session_info_update', cost: 0.005 } }, state);
+  expect(state.cost).toBe(0.005);
+});
+`;
+
 describe("acp-cost-tracking-evidence: provider file check", () => {
   it("does not fire when costTracking: false on _acp provider", () => {
     const provider = makeFile(PROVIDER_PATH, PROVIDER_WITHOUT_ACP_COST_TRACKING);
@@ -135,6 +158,28 @@ describe("acp-cost-tracking-evidence: cross-file evidence check", () => {
     const violations = evaluateRule(rule, provider, new Map([[provider.path, provider]]));
     expect(violations).toHaveLength(1);
     expect(violations[0].snippet).toContain("costTracking: true");
+  });
+
+  it("flags costTracking: true when spec has state.cost assignment but no expect(state.cost)", () => {
+    const provider = makeFile(PROVIDER_PATH, PROVIDER_WITH_ACP_COST_TRACKING);
+    const spec = makeFile(SPEC_PATH, SPEC_WITH_COST_ASSIGNMENT_ONLY);
+    const files = new Map([
+      [provider.path, provider],
+      [spec.path, spec],
+    ]);
+    const violations = evaluateRule(rule, provider, files);
+    expect(violations).toHaveLength(1);
+  });
+
+  it("does not flag when spec uses single-quoted session_info_update with expect(state.cost)", () => {
+    const provider = makeFile(PROVIDER_PATH, PROVIDER_WITH_ACP_COST_TRACKING);
+    const spec = makeFile(SPEC_PATH, SPEC_WITH_SINGLE_QUOTE_EVIDENCE);
+    const files = new Map([
+      [provider.path, provider],
+      [spec.path, spec],
+    ]);
+    const violations = evaluateRule(rule, provider, files);
+    expect(violations).toHaveLength(0);
   });
 
   it("evidence in spec clears violations for all _acp providers in the file", () => {

--- a/scripts/rules/acp-cost-tracking-evidence.spec.ts
+++ b/scripts/rules/acp-cost-tracking-evidence.spec.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from "bun:test";
+
+import type { FileMeta } from "./_engine/file-loader";
+import { evaluateRule } from "./_engine/rule";
+import rule from "./acp-cost-tracking-evidence.rule";
+
+const PROVIDER_PATH = "packages/core/src/agent-provider.ts";
+const SPEC_PATH = "packages/acp/src/acp-event-map.spec.ts";
+
+function makeFile(relPath: string, content: string): FileMeta {
+  return { path: relPath, relPath, content, pkg: relPath.split("/").slice(0, 2).join("/"), isTest: false };
+}
+
+const PROVIDER_WITH_ACP_COST_TRACKING = `
+registerProvider({
+  name: "grok",
+  serverName: "_acp",
+  native: { costTracking: true },
+});
+`;
+
+const PROVIDER_WITHOUT_ACP_COST_TRACKING = `
+registerProvider({
+  name: "copilot",
+  serverName: "_acp",
+  native: { costTracking: false },
+});
+`;
+
+const PROVIDER_NON_ACP_COST_TRACKING = `
+registerProvider({
+  name: "opencode",
+  serverName: "_opencode",
+  native: { costTracking: true },
+});
+`;
+
+const SPEC_WITH_EVIDENCE = `
+test("session_info_update tracks tokens and cost", () => {
+  const state = createAcpEventMapState();
+  mapSessionUpdate({ update: { sessionUpdate: "session_info_update", cost: 0.005 } }, state);
+  expect(state.cost).toBe(0.005);
+});
+`;
+
+const SPEC_WITHOUT_COST_ASSERTION = `
+test("session_info_update tracks tokens", () => {
+  const state = createAcpEventMapState();
+  mapSessionUpdate({ update: { sessionUpdate: "session_info_update" } }, state);
+  expect(state.totalTokens).toBe(0);
+});
+`;
+
+const SPEC_WITHOUT_SESSION_INFO = `
+test("agent_message_chunk", () => {
+  const state = createAcpEventMapState();
+  expect(state.cost).toBeNull();
+});
+`;
+
+describe("acp-cost-tracking-evidence: provider file check", () => {
+  it("does not fire when costTracking: false on _acp provider", () => {
+    const provider = makeFile(PROVIDER_PATH, PROVIDER_WITHOUT_ACP_COST_TRACKING);
+    const violations = evaluateRule(rule, provider, new Map([[provider.path, provider]]));
+    expect(violations).toHaveLength(0);
+  });
+
+  it("does not fire when costTracking: true on non-ACP provider", () => {
+    const provider = makeFile(PROVIDER_PATH, PROVIDER_NON_ACP_COST_TRACKING);
+    const violations = evaluateRule(rule, provider, new Map([[provider.path, provider]]));
+    expect(violations).toHaveLength(0);
+  });
+
+  it("does not run on non-provider files", () => {
+    const other = makeFile("packages/command/src/commands/agent.ts", PROVIDER_WITH_ACP_COST_TRACKING);
+    const violations = evaluateRule(rule, other, new Map([[other.path, other]]));
+    expect(violations).toHaveLength(0);
+  });
+
+  it("does not run on test files (appliesToTests: false)", () => {
+    const testFile: FileMeta = { ...makeFile(PROVIDER_PATH, PROVIDER_WITH_ACP_COST_TRACKING), isTest: true };
+    const violations = evaluateRule(rule, testFile, new Map([[testFile.path, testFile]]));
+    expect(violations).toHaveLength(0);
+  });
+});
+
+describe("acp-cost-tracking-evidence: cross-file evidence check", () => {
+  it("flags costTracking: true on _acp when spec is absent from files map", () => {
+    const provider = makeFile(PROVIDER_PATH, PROVIDER_WITH_ACP_COST_TRACKING);
+    const violations = evaluateRule(rule, provider, new Map([[provider.path, provider]]));
+    expect(violations).toHaveLength(1);
+    expect(violations[0].snippet).toContain("costTracking: true");
+  });
+
+  it("flags costTracking: true on _acp when spec lacks session_info_update", () => {
+    const provider = makeFile(PROVIDER_PATH, PROVIDER_WITH_ACP_COST_TRACKING);
+    const spec = makeFile(SPEC_PATH, SPEC_WITHOUT_SESSION_INFO);
+    const files = new Map([
+      [provider.path, provider],
+      [spec.path, spec],
+    ]);
+    const violations = evaluateRule(rule, provider, files);
+    expect(violations).toHaveLength(1);
+  });
+
+  it("flags costTracking: true on _acp when spec has session_info_update but no state.cost assertion", () => {
+    const provider = makeFile(PROVIDER_PATH, PROVIDER_WITH_ACP_COST_TRACKING);
+    const spec = makeFile(SPEC_PATH, SPEC_WITHOUT_COST_ASSERTION);
+    const files = new Map([
+      [provider.path, provider],
+      [spec.path, spec],
+    ]);
+    const violations = evaluateRule(rule, provider, files);
+    expect(violations).toHaveLength(1);
+  });
+
+  it("does not flag costTracking: true on _acp when spec has full evidence", () => {
+    const provider = makeFile(PROVIDER_PATH, PROVIDER_WITH_ACP_COST_TRACKING);
+    const spec = makeFile(SPEC_PATH, SPEC_WITH_EVIDENCE);
+    const files = new Map([
+      [provider.path, provider],
+      [spec.path, spec],
+    ]);
+    const violations = evaluateRule(rule, provider, files);
+    expect(violations).toHaveLength(0);
+  });
+
+  it("flags only the _acp providers with costTracking: true, not the false ones", () => {
+    const content = `
+      registerProvider({ name: "grok",    serverName: "_acp",      native: { costTracking: true } });
+      registerProvider({ name: "gemini",  serverName: "_acp",      native: { costTracking: false } });
+      registerProvider({ name: "opencode", serverName: "_opencode", native: { costTracking: true } });
+    `;
+    const provider = makeFile(PROVIDER_PATH, content);
+    const violations = evaluateRule(rule, provider, new Map([[provider.path, provider]]));
+    expect(violations).toHaveLength(1);
+    expect(violations[0].snippet).toContain("costTracking: true");
+  });
+
+  it("evidence in spec clears violations for all _acp providers in the file", () => {
+    const content = `
+      registerProvider({ name: "grok",   serverName: "_acp", native: { costTracking: true } });
+      registerProvider({ name: "copilot", serverName: "_acp", native: { costTracking: true } });
+    `;
+    const provider = makeFile(PROVIDER_PATH, content);
+    const spec = makeFile(SPEC_PATH, SPEC_WITH_EVIDENCE);
+    const files = new Map([
+      [provider.path, provider],
+      [spec.path, spec],
+    ]);
+    const violations = evaluateRule(rule, provider, files);
+    expect(violations).toHaveLength(0);
+  });
+});

--- a/scripts/rules/fixtures/acp-cost-tracking-evidence__clean.fixture.ts
+++ b/scripts/rules/fixtures/acp-cost-tracking-evidence__clean.fixture.ts
@@ -1,0 +1,28 @@
+/**
+ * @rule acp-cost-tracking-evidence
+ * @expect 0
+ * @path packages/core/src/agent-provider.ts
+ *
+ * ACP providers with costTracking: false are not flagged.
+ * Non-ACP providers with costTracking: true are not flagged.
+ */
+
+declare function registerProvider(spec: unknown): void;
+
+registerProvider({
+  name: "copilot",
+  serverName: "_acp",
+  native: {
+    worktree: false,
+    costTracking: false,
+  },
+});
+
+registerProvider({
+  name: "opencode",
+  serverName: "_opencode",
+  native: {
+    worktree: false,
+    costTracking: true,
+  },
+});

--- a/scripts/rules/fixtures/acp-cost-tracking-evidence__flagged.fixture.ts
+++ b/scripts/rules/fixtures/acp-cost-tracking-evidence__flagged.fixture.ts
@@ -1,0 +1,37 @@
+/**
+ * @rule acp-cost-tracking-evidence
+ * @expect 2
+ * @path packages/core/src/agent-provider.ts
+ *
+ * Two ACP providers with costTracking: true and no spec in the file map.
+ * Both costTracking: true lines are flagged.
+ */
+
+declare function registerProvider(spec: unknown): void;
+
+registerProvider({
+  name: "grok",
+  serverName: "_acp",
+  native: {
+    worktree: false,
+    costTracking: true,
+  },
+});
+
+registerProvider({
+  name: "copilot",
+  serverName: "_acp",
+  native: {
+    worktree: false,
+    costTracking: true,
+  },
+});
+
+registerProvider({
+  name: "gemini",
+  serverName: "_acp",
+  native: {
+    worktree: false,
+    costTracking: false,
+  },
+});


### PR DESCRIPTION
## Summary
- Adds a `doing-it-wrong` rule (`acp-cost-tracking-evidence`) that flags any `AgentProvider` registration where `serverName === "_acp"` AND `native.costTracking: true` unless `acp-event-map.spec.ts` proves cost field extraction works
- Evidence check requires both `"session_info_update"` string and `state.cost` in the spec — the minimum proof that the event map actually extracts cost (not just tokens)
- `acp-event-map.spec.ts` already has the required test, so no ACP providers are currently blocked; the rule fires only if someone adds `costTracking: true` without spec coverage, or removes the cost assertion from the spec

## Test plan
- [x] 10 unit tests in `acp-cost-tracking-evidence.spec.ts` covering: `costTracking: false` (clean), non-ACP provider (clean), absent spec (flagged), spec without `session_info_update` (flagged), spec without `state.cost` assertion (flagged), spec with full evidence (clean), multi-provider filtering, multi-provider with evidence (all clean)
- [x] 2 fixtures: `__clean` (costTracking: false / non-ACP) and `__flagged` (2 ACP providers with costTracking: true, no spec in map → 2 violations)
- [x] `bun run am-i-done` passes (typecheck + lint + rules + tests + coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)