### PR TITLE
fix(rules): clarify poll-until-headroom scold — setDefaultTimeout raises effective watchdog (fixes #2409)

### DIFF
--- a/scripts/rules/poll-until-headroom.rule.ts
+++ b/scripts/rules/poll-until-headroom.rule.ts
@@ -112,11 +112,12 @@ const rule: CheckRule = {
   id: "poll-until-headroom",
   kind: "check",
   scold:
-    "pollUntil() called with a timeout ≥ Bun's 5000ms test watchdog — the watchdog fires first, so this deadline never surfaces its own error (flaky under CI pressure)",
+    "pollUntil() called with a timeout ≥ the file's effective test watchdog (Bun's 5000ms default, or setDefaultTimeout(N) when the file raises it) — the watchdog fires first, so this deadline never surfaces its own error (flaky under CI pressure)",
   guidance: [
     "drop the explicit timeout and rely on the 1500ms harness default — it already has ample headroom under the watchdog",
     "a condition should resolve in milliseconds, not seconds; if you need ≥5s the test waits on time, not a condition",
     "if a suite is genuinely slow, raise the file's setDefaultTimeout above the deadline — a deadline ≥ the test timeout is a no-op",
+    "if the file already sets setDefaultTimeout(N), explicit pollUntil timeouts below N are valid — the effective watchdog is N, not 5000ms; the rule only flags timeouts ≥ the effective watchdog",
     'quote from Bun\'s own test discipline: "You are not testing the TIME PASSING, you are testing the CONDITION"',
     "cross-reference test/CLAUDE.md flaky-prevention patterns",
   ],

--- a/scripts/rules/poll-until-headroom.rule.ts
+++ b/scripts/rules/poll-until-headroom.rule.ts
@@ -117,7 +117,7 @@ const rule: CheckRule = {
     "drop the explicit timeout and rely on the 1500ms harness default — it already has ample headroom under the watchdog",
     "a condition should resolve in milliseconds, not seconds; if you need ≥5s the test waits on time, not a condition",
     "if a suite is genuinely slow, raise the file's setDefaultTimeout above the deadline — a deadline ≥ the test timeout is a no-op",
-    "if the file already sets setDefaultTimeout(N), explicit pollUntil timeouts below N are valid — the effective watchdog is N, not 5000ms; the rule only flags timeouts ≥ the effective watchdog",
+    "if the file sets setDefaultTimeout(N) where N > 5000ms, the effective watchdog is N (not 5000ms) — explicit pollUntil timeouts below N are valid; the rule only flags timeouts ≥ the effective watchdog",
     'quote from Bun\'s own test discipline: "You are not testing the TIME PASSING, you are testing the CONDITION"',
     "cross-reference test/CLAUDE.md flaky-prevention patterns",
   ],


### PR DESCRIPTION
## Summary
- Updated the `poll-until-headroom` rule's `scold` message to state that the effective watchdog is Bun's 5000ms default **or** `setDefaultTimeout(N)` when the file raises it — not always 5000ms
- Added an explicit guidance bullet: "if the file already sets `setDefaultTimeout(N)`, explicit `pollUntil` timeouts below N are valid — the effective watchdog is N, not 5000ms"
- No logic changes — `effectiveWatchdog()` already computed this correctly; the messaging just didn't say so

## Test plan
- [x] `bun run am-i-done` passes (typecheck, lint, rule sweep, tests, coverage)
- [x] Rule logic unchanged — only `scold` string and `guidance` array modified
- [x] Reproducing scenario: `server-pool.spec.ts` with `setDefaultTimeout(30_000)` and `pollUntil(fn, 10_000)` would now show a scold that correctly explains why 10_000 is not a violation

🤖 Generated with [Claude Code](https://claude.com/claude-code)