### PR TITLE
feat(test): pre-test orphan sweep for leaked workers and fixtures (closes #2415)

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -7,7 +7,7 @@
 
 # Pin NO_COLOR=1 before any module loads so ANSI codes never leak into
 # assertions when bun test runs under a PTY. See #2016.
-preload = ["./test/preload-no-color.ts"]
+preload = ["./test/preload-no-color.ts", "./test/orphan-sweep.ts"]
 
 # Prune directories that should not be scanned for tests
 pathIgnorePatterns = [".claude/**", "dist/**", ".git-hooks/**"]

--- a/test/orphan-sweep.spec.ts
+++ b/test/orphan-sweep.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { type PsEntry, findOrphans, parsePs } from "./orphan-sweep";
+
+describe("parsePs", () => {
+  test("parses ps -eo pid,ppid,command output", () => {
+    const output = [
+      "  PID  PPID COMMAND",
+      "    1     0 /sbin/launchd",
+      "  123     1 bun test --test-worker",
+      "  456   789 bun test/echo-server.ts",
+      "",
+    ].join("\n");
+
+    expect(parsePs(output)).toEqual([
+      { pid: 1, ppid: 0, command: "/sbin/launchd" },
+      { pid: 123, ppid: 1, command: "bun test --test-worker" },
+      { pid: 456, ppid: 789, command: "bun test/echo-server.ts" },
+    ]);
+  });
+
+  test("handles empty output", () => {
+    expect(parsePs("")).toEqual([]);
+  });
+});
+
+describe("findOrphans", () => {
+  const SELF_PID = 99999;
+
+  const entries: PsEntry[] = [
+    { pid: 1, ppid: 0, command: "/sbin/launchd" },
+    { pid: 100, ppid: 1, command: "bun test --test-worker" },
+    { pid: 101, ppid: 1, command: "bun test/echo-server.ts" },
+    { pid: 102, ppid: 1, command: "bun test/echo-http-server.ts" },
+    { pid: 103, ppid: 1, command: "bun test/echo-sse-server.ts" },
+    { pid: 104, ppid: 1, command: "bun test/slow-echo-server.ts" },
+    { pid: 105, ppid: 1, command: "bun test/http-401-server.ts" },
+    { pid: 200, ppid: 50, command: "bun test --test-worker" },
+    { pid: 300, ppid: 1, command: "/usr/bin/mcpd" },
+    { pid: 400, ppid: 1, command: "bun packages/daemon/src/main.ts" },
+    { pid: 500, ppid: 1, command: "node something-else" },
+  ];
+
+  test("selects only PPID-1 processes matching test patterns", () => {
+    const orphans = findOrphans(entries, SELF_PID);
+    const pids = orphans.map((e) => e.pid);
+    expect(pids).toEqual([100, 101, 102, 103, 104, 105]);
+  });
+
+  test("does not select processes with non-1 PPID", () => {
+    const orphans = findOrphans(entries, SELF_PID);
+    expect(orphans.find((e) => e.pid === 200)).toBeUndefined();
+  });
+
+  test("does not select non-test processes even with PPID 1", () => {
+    const orphans = findOrphans(entries, SELF_PID);
+    expect(orphans.find((e) => e.pid === 300)).toBeUndefined();
+    expect(orphans.find((e) => e.pid === 400)).toBeUndefined();
+    expect(orphans.find((e) => e.pid === 500)).toBeUndefined();
+  });
+
+  test("excludes own PID", () => {
+    const withSelf: PsEntry[] = [{ pid: SELF_PID, ppid: 1, command: "bun test --test-worker" }];
+    expect(findOrphans(withSelf, SELF_PID)).toEqual([]);
+  });
+
+  test("returns empty for no orphans", () => {
+    const clean: PsEntry[] = [
+      { pid: 1, ppid: 0, command: "/sbin/launchd" },
+      { pid: 200, ppid: 50, command: "bun test --test-worker" },
+    ];
+    expect(findOrphans(clean, SELF_PID)).toEqual([]);
+  });
+});

--- a/test/orphan-sweep.spec.ts
+++ b/test/orphan-sweep.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { type PsEntry, findOrphans, parsePs } from "./orphan-sweep";
+import { type PsEntry, findOrphans, killOrphans, parsePs } from "./orphan-sweep";
 
 describe("parsePs", () => {
   test("parses ps -eo pid,ppid,command output", () => {
@@ -69,5 +69,85 @@ describe("findOrphans", () => {
       { pid: 200, ppid: 50, command: "bun test --test-worker" },
     ];
     expect(findOrphans(clean, SELF_PID)).toEqual([]);
+  });
+
+  // Verify the top-level `bun test` command is NOT selected — it can have PPID=1
+  // in container environments and is not a worker.
+  test("does not select plain 'bun test' invocation (only --test-worker variant)", () => {
+    const plain: PsEntry[] = [{ pid: 999, ppid: 1, command: "bun test packages/core/src" }];
+    expect(findOrphans(plain, SELF_PID)).toEqual([]);
+  });
+
+  test("selects bun test --test-worker via first pattern", () => {
+    const worker: PsEntry[] = [{ pid: 42, ppid: 1, command: "bun test --test-worker --timeout 5000" }];
+    expect(findOrphans(worker, SELF_PID)).toEqual(worker);
+  });
+
+  // Each fixture-server pattern tested independently (not relying on the first pattern).
+  test.each([
+    ["bun test/echo-server.ts", "echo-server.ts"],
+    ["bun test/echo-http-server.ts", "echo-http-server.ts"],
+    ["bun test/echo-sse-server.ts", "echo-sse-server.ts"],
+    ["bun test/slow-echo-server.ts", "slow-echo-server.ts"],
+    ["bun test/http-401-server.ts", "http-401-server.ts"],
+  ])("selects orphaned fixture server: %s", (command) => {
+    const fixture: PsEntry[] = [{ pid: 77, ppid: 1, command }];
+    expect(findOrphans(fixture, SELF_PID)).toEqual(fixture);
+  });
+});
+
+describe("killOrphans", () => {
+  test("fires killFn for each orphan", () => {
+    const orphans: PsEntry[] = [
+      { pid: 10, ppid: 1, command: "bun test --test-worker" },
+      { pid: 20, ppid: 1, command: "bun test/echo-server.ts" },
+    ];
+    const killed: number[] = [];
+    killOrphans(
+      orphans,
+      (pid) => killed.push(pid),
+      () => {},
+    );
+    expect(killed).toEqual([10, 20]);
+  });
+
+  test("writes log message for each killed process", () => {
+    const orphans: PsEntry[] = [{ pid: 55, ppid: 1, command: "bun test --test-worker" }];
+    const logs: string[] = [];
+    killOrphans(
+      orphans,
+      () => {},
+      (msg) => logs.push(msg),
+    );
+    expect(logs).toEqual(["[orphan-sweep] killed pid 55: bun test --test-worker\n"]);
+  });
+
+  test("catches kill errors and continues to next orphan", () => {
+    const orphans: PsEntry[] = [
+      { pid: 10, ppid: 1, command: "bun test --test-worker" },
+      { pid: 20, ppid: 1, command: "bun test/echo-server.ts" },
+    ];
+    const killed: number[] = [];
+    killOrphans(
+      orphans,
+      (pid) => {
+        if (pid === 10) throw Object.assign(new Error("ESRCH"), { code: "ESRCH" });
+        killed.push(pid);
+      },
+      () => {},
+    );
+    expect(killed).toEqual([20]);
+  });
+
+  test("no-ops on empty list", () => {
+    let called = false;
+    killOrphans(
+      [],
+      () => {
+        called = true;
+      },
+      () => {},
+    );
+    expect(called).toBe(false);
   });
 });

--- a/test/orphan-sweep.ts
+++ b/test/orphan-sweep.ts
@@ -1,0 +1,60 @@
+/**
+ * Pre-test orphan sweep — kills leaked test workers and fixture processes
+ * that were reparented to init (PPID 1) after their spawner died.
+ *
+ * Added to bunfig.toml preload so it runs before every test suite.
+ */
+import { spawnSync } from "node:child_process";
+
+export interface PsEntry {
+  pid: number;
+  ppid: number;
+  command: string;
+}
+
+const PS_TIMEOUT_MS = 5_000;
+
+const ORPHAN_PATTERNS = [
+  /bun\s+test\b/,
+  /echo-server\.ts/,
+  /echo-http-server\.ts/,
+  /echo-sse-server\.ts/,
+  /slow-echo-server\.ts/,
+  /http-401-server\.ts/,
+];
+
+export function parsePs(stdout: string): PsEntry[] {
+  const lines = stdout.split("\n");
+  const entries: PsEntry[] = [];
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("PID")) continue;
+    const match = trimmed.match(/^(\d+)\s+(\d+)\s+(.+)$/);
+    if (!match) continue;
+    entries.push({ pid: Number(match[1]), ppid: Number(match[2]), command: match[3] });
+  }
+  return entries;
+}
+
+export function findOrphans(entries: PsEntry[], selfPid: number): PsEntry[] {
+  return entries.filter((e) => e.ppid === 1 && e.pid !== selfPid && ORPHAN_PATTERNS.some((p) => p.test(e.command)));
+}
+
+function sweep(): void {
+  const result = spawnSync("ps", ["-eo", "pid,ppid,command"], { encoding: "utf-8", timeout: PS_TIMEOUT_MS });
+  if (result.status !== 0 || !result.stdout) return;
+
+  const orphans = findOrphans(parsePs(result.stdout), process.pid);
+  if (orphans.length === 0) return;
+
+  for (const orphan of orphans) {
+    try {
+      process.kill(orphan.pid, "SIGKILL");
+      process.stderr.write(`[orphan-sweep] killed pid ${orphan.pid}: ${orphan.command}\n`);
+    } catch {
+      // Already dead or permission denied — either way, move on.
+    }
+  }
+}
+
+sweep();

--- a/test/orphan-sweep.ts
+++ b/test/orphan-sweep.ts
@@ -14,8 +14,11 @@ export interface PsEntry {
 
 const PS_TIMEOUT_MS = 5_000;
 
+// Patterns are intentionally specific to avoid matching live CI runners.
+// /bun\s+test\s+--test-worker\b/ targets only Bun's internal worker spawn,
+// not the top-level `bun test` command (which can have PPID=1 in containers).
 const ORPHAN_PATTERNS = [
-  /bun\s+test\b/,
+  /bun\s+test\s+--test-worker\b/,
   /echo-server\.ts/,
   /echo-http-server\.ts/,
   /echo-sse-server\.ts/,
@@ -40,21 +43,29 @@ export function findOrphans(entries: PsEntry[], selfPid: number): PsEntry[] {
   return entries.filter((e) => e.ppid === 1 && e.pid !== selfPid && ORPHAN_PATTERNS.some((p) => p.test(e.command)));
 }
 
-function sweep(): void {
-  const result = spawnSync("ps", ["-eo", "pid,ppid,command"], { encoding: "utf-8", timeout: PS_TIMEOUT_MS });
-  if (result.status !== 0 || !result.stdout) return;
-
-  const orphans = findOrphans(parsePs(result.stdout), process.pid);
-  if (orphans.length === 0) return;
-
+export function killOrphans(
+  orphans: PsEntry[],
+  killFn: (pid: number) => void = (pid) => process.kill(pid, "SIGKILL"),
+  log: (msg: string) => void = (msg) => process.stderr.write(msg),
+): void {
   for (const orphan of orphans) {
     try {
-      process.kill(orphan.pid, "SIGKILL");
-      process.stderr.write(`[orphan-sweep] killed pid ${orphan.pid}: ${orphan.command}\n`);
+      killFn(orphan.pid);
+      log(`[orphan-sweep] killed pid ${orphan.pid}: ${orphan.command}\n`);
     } catch {
       // Already dead or permission denied — either way, move on.
     }
   }
+}
+
+function sweep(): void {
+  // -A: all processes; -ww: unlimited command width (avoid macOS truncation at terminal width)
+  const result = spawnSync("ps", ["-A", "-ww", "-o", "pid,ppid,command"], {
+    encoding: "utf-8",
+    timeout: PS_TIMEOUT_MS,
+  });
+  if (result.status !== 0 || !result.stdout) return;
+  killOrphans(findOrphans(parsePs(result.stdout), process.pid));
 }
 
 sweep();


### PR DESCRIPTION
## Summary
- Adds `test/orphan-sweep.ts` preload that kills orphaned test workers and fixture servers (PPID 1 + test-pattern match) before each test suite run
- Conservative heuristic: only targets processes that are BOTH reparented to init AND match known test-worker/fixture command patterns — never touches mcpd, live agents, or sibling test runs
- Pure-function test coverage for the ps-output parsing and orphan selection logic

## Test plan
- [x] `bun run am-i-done` passes (typecheck, lint, rules, tests, coverage)
- [x] `test/orphan-sweep.spec.ts` covers: ps output parsing, PPID-1 filtering, pattern matching, self-PID exclusion, non-test process exclusion, empty-list no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)