### PR TITLE
sprint(66): bugfix sweep — daemon races, session-NDJSON, flaky root-causes, cookie auth

### DIFF
--- a/.claude/agents/issue-author.md
+++ b/.claude/agents/issue-author.md
@@ -1,0 +1,37 @@
+---
+name: issue-author
+description: Use this agent to file a GitHub issue from a short problem report — it validates labels, searches open AND closed issues for duplicates, enhances an existing issue (comment/reopen-as-regression) instead of filing a duplicate, and writes a well-formed issue with actionable repro data. Invoke it (ideally with run_in_background) whenever you notice a bug, test gap, flake, DX papercut, edge case, or improvement and want it tracked without breaking your flow. Note: the #2009 Agent-tool observability objection (no progress visibility) does NOT apply here — filing is fire-and-forget; you don't need to watch it.\n\n<example>\nContext: A worker mid-implementation notices an unrelated bug in adjacent code.\nuser: "While fixing the parser I noticed extractContent throws on a null content array in alias.ts — file that."\nassistant: "I'll hand this to the issue-author agent in the background so I can keep working."\n<commentary>\nThe report is tangential to the current task; issue-author absorbs the dedup-search and label work off the caller's context.\n</commentary>\n</example>\n\n<example>\nContext: A flaky test failed once during QA.\nuser: "daemon-integration.spec.ts timed out once, passed on rerun — track it."\nassistant: "Launching issue-author to search for an existing flaky issue for that file and either add a data point or file a new one."\n<commentary>\nIssue-author searches all states first, so a recurring flake gets a new data point on the existing issue rather than a duplicate.\n</commentary>\n</example>
+model: sonnet
+---
+
+You are issue-author. Your job: turn a one-line problem report into a correctly-filed, de-duplicated GitHub issue, so the caller can fire-and-forget and keep working. Be **fast and shallow** — 2–3 targeted searches, not a deep investigation. The whole point is to take the dedup/label cost off the caller's context budget; if you turn into a 20-call investigation you've just moved the bloat.
+
+## Protocol
+
+1. **Match house style.** Skim the repo's filing conventions (the "Every problem gets an issue" section of CLAUDE.md) so the issue reads like the others.
+
+2. **Validate labels first.** Run `gh label list` and only use labels that exist. **Never invent a label** — a single unknown label makes `gh issue create` abort entirely. Map the report to the closest existing labels (e.g. `bug`, `enhancement`, `flaky`, `meta`).
+
+3. **Search for duplicates across ALL states** (open *and* closed):
+   `gh issue list --state all --search "<specific symptom tokens>"` — search the failing test name, file path, or error string, not generic words.
+
+4. **Decide:**
+   - **Exact open duplicate** → add a one-line data-point comment (new repro / new occurrence) to it. Don't file. Return that issue's URL.
+   - **Closed issue, same symptom** → this is a **regression**: reopen it (or file new and link "regression of #N") with the new evidence. Return the URL.
+   - **Existing open issue that more detail would improve** → comment to enhance it.
+   - **No match** → file a new issue.
+
+5. **Write it well** (new issue or comment): actionable repro data — exact commands, logs, `file:line`, timestamps, version. A bare "this happened" is useless. Title = the specific symptom. Body = **Problem / Impact / Repro / (suggested fix, if known)**.
+
+6. **Return one line**: the issue URL (or `commented on #N` / `reopened #N`). The caller does not wait for anything else.
+
+## Scope boundary
+
+You own the **historical** dedup layer (existing + closed issues). **Batch-collapse** of multiple simultaneous reports of the same symptom is the orchestrator's job (it has the real-time global view), not yours — don't try to coordinate with other in-flight reports.
+
+## Do not
+
+- Invent labels, or file with a label you didn't confirm exists.
+- File without searching closed issues (regressions hide there).
+- Write a report with no repro data.
+- Escalate into a deep investigation. If the report needs root-cause work, say so in the issue and let a nerd-snipe handle it — don't do it yourself.

--- a/.claude/diary/20260527.66.md
+++ b/.claude/diary/20260527.66.md
@@ -1,0 +1,52 @@
+# 2026-05-27 — Bugfix sweep: daemon races, session-NDJSON, flaky root-causes, cookie auth (Sprint 66)
+
+## What was done
+
+13 PRs merged, v1.12.2 released. 15/15 planned issues resolved.
+
+**Silent-cleanup audit (headline):**
+- #2153 (#2467) — 11 silent `.catch(() => {})` → `console.warn` / `this.logger.warn` across 5 daemon files; 5 intentional suppressions left documented. Review caught 2 over-conversions (CLI-side `run.ts` would spam the user terminal; `subprocess.ts` `reader.cancel()` rejection is expected exit noise) → reverted.
+
+**Daemon-race trio:**
+- #2135 — closed as already-fixed-on-main (sprint 58, PR #2165). Planner picked up a stale-open issue; its leftover transition-log poisoned from-detect (see #2463 below).
+- #2437 (#2470) — flaky SIGTERM-to-stdio-child timeout. Gate **refuted** the planted #2135 hypothesis (that fix is already on main) and found the independent cause: `isOurProcess` derives start-time from `ps -o etime=` (whole-second truncation + ps overhead), which under CI load can exceed the 2000ms ownership tolerance → `killPid` no-ops → test times out. Fix: cache-age guard (skip the jittery check for PIDs cached <30s). 500-iteration repro in the gate comment.
+- #2411 (#2481) — `cleanStaleFiles` flock guard (don't unlink a live daemon's PID file).
+- #1624 (#2480) — concurrent-auth DCR guard (`try/finally` releases the in-flight Set on every exit path).
+
+**Session-NDJSON pair:** #2232 (#2466) `rate_limit_event` handler; #2233 (#2472) `error_during_execution` (is_error, no `errors[]`) routed to `session:error`.
+
+**Cookie auth (heavy):** #1595 (#2469) — cookie-based `mcx site` auth + `site_credentials` tool + per-call/site `authMode`. Review found a CORS blocker (`page.evaluate(fetch)` is CORS-bound, breaks the common cross-origin case); holistic repair switched to `browserContext.cookies(url)` + daemon-side fetch.
+
+**Permission semantics (heavy):** #2074 (#2476) — `--allow` was *replacing* the default safe tools (`??`), not extending them. Review then found the union wasn't propagated to the Claude CLI `--allowedTools` layer + the logic was triplicated. Codex was requested for a holistic pass but is broken (#2482) → opus refactored everything into `packages/core/src/allow-patterns.ts` (single source of truth). `--allow-only` added; dead patterns now error.
+
+**Rule + fillers:** #2438 (#2484) no-import-cycles rule (Tarjan SCC, grandfathers 5 existing cycles); #2445 (#2475) verdict-cache cwd flake; #2441 (#2465) `pr comments` `pushedAt`→`updatedAt`; #2451 (#2462) `extractContent` empty-block; #2215 (#2483) pty-test CI checkout auth; #2436 upstream Ink bug filed (vadimdemedes/ink#963), local boundary already covered by closed #2351.
+
+## What worked well
+
+- **All 3 nerd-snipe gates passed with concrete root causes — zero needs-attention.** #2437's gate doing real refutation (ruling out the plan's own hypothesis) is the gate working as intended.
+- **Forced adversarial review for gated fixes regardless of triage churn** caught real gaps a sonnet QA would miss: the #2074 dual-layer propagation miss, the #2437 `ws-server.ts` mirror-sibling call site.
+- **Reactive monitor-stream orchestration** — every transition driven off events, no polling.
+- **Risk-tiered final gate**: genuine QA for high-blast-radius #2074 (permissions); CI-as-validator + qa:pass-by-judgment for #2215 (CI-config) and #2438 (dev-time rule) where a local `am-i-done` QA adds machine load without signal.
+
+## What didn't work
+
+- **Reviewer-self-repair is incompatible with kept impl worktrees** (#2153, #2437 — the big lesson). I kept impl worktrees (`--keep-worktree`, which *locks the branch*) AND used reviewer-self-repair, but reviewers ran in fresh `--worktree` scratch branches that can't `git checkout` the locked branch. They edited the impl worktree via `git -C` but ran `am-i-done` in their own scratch worktree (= main, validation meaningless) and hung. Recovery: spawn finalizers `--cwd` the kept worktree. **Fix applied to run.md**: every post-impl phase (review/repair/QA) reuses the impl worktree via `--cwd`; reserve fresh `--worktree` only for nerd-snipe gates. Structural fix is `--track`/#1286 (have the spawn auto-write `worktree_path` so phases emit `--cwd` automatically instead of relying on the orchestrator to remember).
+- **#2135 stranded on a stale transition-log (#2463)**: re-tracking a prior-sprint issue inherited a stale transition-log tail; `mcx phase run impl` from-detect resolved to the old phase, the batch spawn loop silently swallowed the failure, leaving `session_id=""`. Worked around with direct-spawn + explicit `--from`.
+- **Codex fully broken (#2482)**: every `mcx agent codex spawn` fails `RPC -32600 Invalid request` (even minimal); `_codex` server connects but session-start is rejected. Regression of the closed #845/#851/#666. Fell back to opus.
+- **Load-induced Bun segfaults**: concurrent `am-i-done` suites pushed the machine to ~112 bun procs, segfaulting Bun workers in *unrelated* test files (#2210/#2313 class). Workers couldn't pass a full local `am-i-done`. Mitigation: push via the #1125 pre-commit fast path + rely on CI for the full suite in a clean env. Worth considering a concurrency cap on local full-suite runs during a sprint.
+- **Filing friction, demonstrated twice**: #2471 aborted on a nonexistent `tech-debt` label; #2482 filed before checking closed predecessors. Both motivated **epic #2485** (`mcx issue` mail funnel + `issue-author` agent). The `issue-author` agent doc + a CLAUDE.md interim rule swap ("delegate to issue-author, don't hand-search") shipped on this sprint's branch.
+
+## Patterns established
+
+- **One worktree per issue, `--cwd` through all phases** (impl→review→repair→QA); fresh `--worktree` only for off-branch investigations. → run.md.
+- **Report-don't-hand-file**: delegate issue filing to a dedicated agent/funnel so dedup-search happens off the caller's context; the orchestrator's global view does batch-collapse (N reports = one main-level gap = priority signal). → epic #2485.
+- **CI-as-validator** for CI-config and adversarial-approved low-blast-radius PRs; genuine QA reserved for high-blast-radius surfaces.
+
+## Stats
+
+- **PRs merged**: 13
+- **Issues closed**: 15/15 (incl. #2135 already-done, #2436 upstream-filed)
+- **Adversarial reviews**: 4 high-scrutiny (#2153, #1595, #2074, #2438) — all Changes-Requested round 1, all converged (#1595 + #2074 needed holistic-refactor repairs)
+- **Nerd-snipe gates**: 3/3 passed (#2074, #2437, #2445)
+- **New issues filed**: #2463, #2471, #2482, #2485 + 1 alias-bundle follow-up + ink#963 (upstream)
+- **Failed/dropped**: 0

--- a/.claude/skills/sprint/references/run.md
+++ b/.claude/skills/sprint/references/run.md
@@ -452,6 +452,22 @@ When it replies `needs opus repair`, spawn a fresh opus repair per the
 normal flow. When it pushes a fix and updates the sticky to ✅,
 transition to QA.
 
+**Precondition — the reviewer must be ON the PR branch, or self-repair
+silently breaks.** It can only push if it was spawned `--cwd` the worktree
+that holds the branch. The phase scripts emit `--worktree` (they don't know
+the impl worktree's path), so the orchestrator **must override review /
+repair / QA spawns with `--cwd <kept-impl-worktree>`** — never let a
+post-impl phase spawn a fresh `--worktree`. A reviewer in a fresh
+`--worktree` lands on a scratch branch and **cannot** check out the PR
+branch (it's locked in the kept impl worktree); it will then either edit
+the wrong tree via `git -C` while validating in the scratch tree (= main,
+meaningless) or hang. Sprint 66 lost two cycles (#2153, #2437) to exactly
+this. **Rule: one worktree per issue, `--cwd` through
+impl→review→repair→QA; fresh `--worktree` only for off-branch nerd-snipe
+gates.** Structural fix: `--track` / #1286 — have the spawn auto-persist
+`worktree_path` to the work item so phases emit `--cwd` without the
+orchestrator having to remember.
+
 ### Auto-merge re-arm after force-push
 
 The orchestrator drives merges directly. Force-push rebases silently

--- a/.claude/sprints/sprint-66.md
+++ b/.claude/sprints/sprint-66.md
@@ -1,0 +1,113 @@
+# Sprint 66
+
+> Planned 2026-05-26 21:00 EDT. Target: 15 work items.
+
+## Goal
+
+Bugfix sweep — fix the daemon/connection races, Claude session-NDJSON parsing
+gaps, and flaky-test root-causes that accumulated through sprints 64–65; follow
+through on the #2408 import-graph (no-import-cycles rule); and close the
+cookie-auth gap that limits many site use cases. Headlined by the silent
+`.catch(() => {})` cleanup audit (#2153). Theme: correctness / reliability /
+daemon hardening.
+
+## Issues
+
+| # | Title | Scrutiny | Batch | Model | Category |
+|---|-------|----------|-------|-------|----------|
+| 2153 | silent `.catch(() => {})` audit across daemon session workers + cleanup paths | high | 1 | opus | goal |
+| 2451 | extractContent returns `[undefined]` when single text block has no text | low | 1 | sonnet | goal |
+| 2441 | `mcx pr comments resolve` fails — GraphQL `pushedAt` field doesn't exist | low | 1 | sonnet | goal |
+| 2232 | claude `rate_limit_event` NDJSON type unhandled → log noise every turn | low | 1 | sonnet | goal |
+| 2135 | connectFn→PID race: childPid cached null when process exits during connect | med | 1 | opus | goal |
+| 1595 | sites: cookie-based session auth unsupported — bearer-only captures miss many cases | high | 2 | opus | goal |
+| 2233 | claude `result/error_during_execution` lacks `errors[]`, mis-parsed as empty success | med | 2 | sonnet | goal |
+| 2411 | cleanStaleFiles unlinks PID file when flock is held on existing inode | low | 2 | sonnet | goal |
+| 2437 | flaky: disconnect SIGTERM to stdio child times out intermittently | med | 2 | opus | goal |
+| 2074 | per-action tool permission prompts despite `--allow` on spawn | med | 2 | opus | goal |
+| 2438 | rule: categorically ban import cycles (no-import-cycles), built on #2408 graph | med | 3 | opus | goal |
+| 2445 | flaky: computeVerdictKey determinism test shares process.cwd() with acp-session | med | 3 | opus | goal |
+| 1624 | race: concurrent `mcx auth` on same server stages conflicting DCR clients | med | 3 | opus | filler |
+| 2215 | ci: pty-test job fails with actions/checkout auth error on PR runs | low | 3 | sonnet | filler |
+| 2436 | upstream: file Ink bug for ErrorOverview duplicate-key + incomplete parseLine guard | low | 3 | sonnet | filler |
+
+## Batch Plan
+
+### Batch 1 (immediate)
+#2153, #2451, #2441, #2232, #2135
+
+### Batch 2 (backfill)
+#1595, #2233, #2411, #2437, #2074
+
+### Batch 3 (backfill)
+#2438, #2445, #1624, #2215, #2436
+
+### Dependency edges (translate to `addBlockedBy` at run time)
+- #2411 blockedBy #2135 (both touch daemon-lifecycle/server-pool sync; the PID-race fix is the foundation for the flock guard to be meaningful)
+- #2437 blockedBy #2135 (the connectFn→PID race is the likely root of the SIGTERM-to-stdio-child flake; the nerd-snipe gate should confirm #2135 resolves it before patching the test)
+- #2233 blockedBy #2232 (both touch the claude-session NDJSON/session-state parsing path; serialize to avoid a logical conflict on the message-type handling)
+
+### Hot-shared files (cross-batch broadcast targets)
+- `packages/daemon/src/server-pool.ts` + `packages/command/src/daemon-lifecycle.ts`: #2135, #2411, #2437 — serialized via edges; #2135 lands first.
+- `packages/daemon/src/claude-session/` (ndjson / session-state): #2232, #2233 — serialized.
+- `packages/daemon/src/*-session-worker.ts` (all 5 providers): #2153 rewrites the cleanup `.catch` across every worker — strictly serialize any other session-worker-touching PR behind it (none planned this sprint, but broadcast if one appears).
+
+### Nerd-snipe gate (mandatory before impl spawn)
+- **#2437** (flaky SIGTERM-to-stdio-child timeout): establish the mechanism before patching. Prime hypothesis: the #2135 connectFn→PID race leaves childPid null so the kill targets nothing. Gate must confirm whether #2135's fix resolves it, or whether there's an independent SIGTERM-propagation bug. Hard-fail = `needs-attention`. (#2454 was closed as a dup — same flake.)
+- **#2445** (flaky verdict-cache determinism): the test shares `process.cwd()` with acp-session-worker tests that create/remove untracked files; gate must confirm the race window + the right isolation (cwd param to `computeVerdictKey`) before patching. This is a CONDITION-not-TIME-PASSING violation per `test/CLAUDE.md`.
+- **#2074** (per-action permission prompts despite `--allow`): unclear mechanism — does the allow-list reach the SDK and get ignored, or is it a doc gap (which tool families don't honor `--allow`)? Gate must reproduce + trace the allow-list through to the SDK before any fix. Hard-fail = `needs-attention`.
+
+## Context
+
+**Theme genesis:** Sprint 65 (14/14 merged, v1.12.1) shipped the #2408 AST
+import-graph cache and a test-harness parallel-safety arc, but its reviews/QA
+surfaced a cluster of latent daemon/session bugs and flakies. Sprint 66 drains
+that cluster plus the longest-standing daemon races (#2135, #1624, #2411).
+
+**Headline #2153** (silent `.catch(() => {})` audit): 5 cleanup sites across
+`claude/opencode/codex/acp/mock-session-worker.ts` swallow promise rejections,
+so cleanup failures vanish as untraceable resource leaks. Recon confirmed it's
+one uniform PR (~10–20 LOC): route the silent catches through a
+`logCleanupError` helper. High scrutiny + adversarial review because it touches
+every session worker's teardown path.
+
+**#1595** (cookie-based site auth): the second heavy. Today `mcx site` captures
+are bearer-token-only; cookie-session sites (a large class the user has hit
+repeatedly) can't be driven. Feature-sized (~100–200 LOC across
+`packages/daemon/src/site/`), auth-sensitive → high scrutiny + adversarial
+review. Placed in batch 2 (not batch 1) so it doesn't share a batch with the
+other heavy (#2153).
+
+**Daemon-race trio** (#2135 → #2411 → #2437): the connectFn→PID race (#2135) is
+the root — childPid cached null when the child exits during connect. The flock
+guard (#2411, follow-on to sprint 64's #2410) and the SIGTERM-flake (#2437) both
+depend on it landing first. Serialized.
+
+**Session-NDJSON pair** (#2232 → #2233): both are wire-format gaps in the claude
+session stream — `rate_limit_event` logs an error every turn; `error_during_execution`
+mis-parses as empty success (corrupts interrupt handling). Serialized on the
+shared parsing file.
+
+**#2438** (no-import-cycles rule): follow-through on #2408's now-merged import
+graph (`scripts/rules/_engine/import-graph.ts` exposes closureOf/dependentsOf
+for SCC/DFS cycle detection). Free invariant — no cycles on main today, so the
+rule lands clean and guards against regression. The `find-circular-deps` payoff
+the #2408 gate named.
+
+### Meta dispositions (Step 1a — APPLIED PRE-SPRINT)
+- **#2443 — applied** in PR #2460 (merged): "search existing issues before
+  filing" rule added to CLAUDE.md's filing contract (captures the sprint-65
+  verdict-cache 6-dup sprawl).
+- **#2343 — deferred** (per user): worker `.claire` mangled-path / worktree-escape
+  bug. Same class as sprint 65's worker-escaped-to-main incident; revisit.
+- **#2350 — deferred** (per user): `/rule-author` + harvest-rules consolidation.
+- **#2393 — deferred** (per user): Grok-first-class-citizen epic.
+
+### Excluded from candidacy
+- **#2186** (phase impl auto-spawn + stale comment): touches `.claude/phases/impl.ts`
+  (orchestration meta) — handle via the meta flow, not a sprint issue.
+- **#1250** (wind-down rebuild breaks cross-repo sprints): touches `run.md` (meta).
+- **#2210 / #2313** (Bun 1.3.14 segfault/bus-error): un-fixable without an
+  upstream Bun patch or version bump. Still parked.
+- **#2439** (closed-done — fixed by #2417/#2435), **#2454** (closed-dup of #2437),
+  **#2447** (closed — 6th verdict-cache dup, fixed by #2401).

--- a/.claude/sprints/sprint-66.md
+++ b/.claude/sprints/sprint-66.md
@@ -1,6 +1,6 @@
 # Sprint 66
 
-> Planned 2026-05-26 21:00 EDT. Started 2026-05-27 10:48 EDT. Target: 15 work items.
+> Planned 2026-05-26 21:00 EDT. Started 2026-05-27 10:48 EDT. Ended 2026-05-27 12:47 EDT. Target: 15 work items.
 
 ## Goal
 
@@ -111,3 +111,14 @@ the #2408 gate named.
   upstream Bun patch or version bump. Still parked.
 - **#2439** (closed-done — fixed by #2417/#2435), **#2454** (closed-dup of #2437),
   **#2447** (closed — 6th verdict-cache dup, fixed by #2401).
+
+## Results
+
+- **Released**: v1.12.2 (patch — features/fixes, no new top-level command or package)
+- **PRs merged**: 13 (#2462 #2465 #2466 #2467 #2469 #2470 #2472 #2475 #2476 #2480 #2481 #2483 #2484)
+- **Issues closed**: 15/15 — all planned. 13 via PR; **#2135** closed as already-fixed-on-main (sprint 58 PR #2165 — planner picked up a stale-open issue); **#2436** resolved by filing upstream (vadimdemedes/ink#963) — ErrorOverview bug is Ink's code, local boundary already handled by closed #2351.
+- **Issues dropped**: 0
+- **Nerd-snipe gates**: 3/3 passed (#2074 `--allow`-replaces-defaults, #2437 `isOurProcess` etime jitter, #2445 verdict-cache cwd race) — all produced concrete root causes + fix plans; zero needs-attention.
+- **Adversarial reviews**: 4 high-scrutiny (#2153, #1595, #2074, #2438) — all Changes-Requested round 1, all converged. #1595 (CORS redesign) and #2074 (permission-resolution unification into `allow-patterns.ts`) needed holistic-refactor repairs.
+- **New issues filed**: #2463 (stale transition-log poisons `mcx phase` from-detect), #2471 (`/proc` jitter-free etime source), #2482 (codex spawn RPC -32600 regression), #2485 (epic: `mcx issue` mail funnel + issue-author agent), the alias-bundle import-cycle follow-up, + ink#963 (upstream).
+- **Shipped to sprint branch (lands on merge)**: `.claude/agents/issue-author.md` + the CLAUDE.md filing-rule swap (interim of #2485).

--- a/.claude/sprints/sprint-66.md
+++ b/.claude/sprints/sprint-66.md
@@ -1,6 +1,6 @@
 # Sprint 66
 
-> Planned 2026-05-26 21:00 EDT. Target: 15 work items.
+> Planned 2026-05-26 21:00 EDT. Started 2026-05-27 10:48 EDT. Target: 15 work items.
 
 ## Goal
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -226,6 +226,15 @@ Examples of things that must be filed:
 - Bugs in adjacent code discovered while reading
 - Missing documentation or misleading help text
 
-**Search before filing.** Before opening an issue — especially for an `am-i-done` / coverage / lint / test failure — search existing issues first (`gh issue list --state all --search "<symptom keywords>"`, e.g. the failing file or test name). If a match exists, add a one-line data-point comment instead of filing a duplicate. If the failure reproduces on a clean `main` (or you can tell other sessions are hitting the same thing), it is a **pre-existing shared gap**: flag it rather than bundling a redundant fix into your PR — one PR owns the fix, the rest rebase. Blindly re-filing destroys the regression signal (N independent reports of one symptom = one main-level gap to fix once, not N issues) and the parallel re-fixes collide on the shared file. (Sprint 65 produced six duplicate issues and three conflicting fix-PRs for a single coverage gap by skipping this.)
+**Filing — delegate to `issue-author`, don't hand-search.** When you hit a problem (bug, test gap, flake, `am-i-done` / coverage / lint failure, DX papercut, edge case, missing docs), do **not** stop to search-and-file by hand. Launch the **`issue-author`** agent in the background and keep working:
+
+```
+Agent(subagent_type: "issue-author", run_in_background: true,
+      prompt: "<what you saw + any repro: commands, file:line, error>")
+```
+
+It validates labels, searches open **and** closed issues, adds a data-point comment or reopens a regression instead of filing a duplicate, and writes a repro-backed issue — all in its own context, off your budget. The URL arrives as a notification; you don't wait. *(Once the `mcx issue` mail funnel lands — epic #2485 — this becomes "fire `mcx issue`", same syntax as `gh issue`, which also works outside Agent-tool contexts. Until then, a context without the Agent tool falls back to `gh issue create` — but you still never owe a manual dedup-search.)*
+
+**Still true however you file:** if a failure reproduces on clean `main`, or you can see other sessions hitting the same thing, it's a **pre-existing shared gap** — flag it and rebase onto the one PR that owns the fix; don't bundle a redundant fix into your PR. N independent reports of one symptom = one main-level gap fixed once, not N issues, and parallel re-fixes collide on the shared file. (Sprint 65: six duplicate issues + three conflicting fix-PRs from skipping this.)
 
 Usability issues (daemon bugs, connection, etc) are P1 and take priority over all other work.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "bun": ">=1.3.14"
   },
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "MCP CLI — call MCP server tools from the command line with zero context overhead",
   "type": "module",
   "workspaces": ["packages/*"],


### PR DESCRIPTION
Sprint 66 container PR. Accumulates every sprint-meta commit on the `sprint-66` branch:

- plan + any mid-sprint amendments
- run-time edits (Started/Completed timestamps, Excluded section)
- Results summary
- retro diary file
- release commit (if a release is cut this sprint)

**Goal:** Bugfix sweep — daemon/connection races (#2135→#2411→#2437), Claude session-NDJSON gaps (#2232/#2233), flaky-test root-causes (#2437/#2445), #2408-graph follow-through (#2438 no-import-cycles), and the cookie-auth gap (#1595). Headlined by the silent `.catch(() => {})` cleanup audit (#2153). 15 issues.

Marked **draft** until `/sprint retro` flips it ready and arms auto-merge.

Docs/skill-only by construction — pre-commit hooks should skip the test suite.