### PR TITLE
fix(claude): handle rate_limit_event NDJSON type — emit session:rate_limited (fixes #2232)

### DIFF
--- a/packages/daemon/src/claude-session/session-state.spec.ts
+++ b/packages/daemon/src/claude-session/session-state.spec.ts
@@ -967,6 +967,45 @@ describe("SessionState", () => {
         retryAfterMs: 30000,
       });
     });
+
+    describe("rate_limit_event top-level message", () => {
+      test("emits session:rate_limited and sets rateLimited flag", () => {
+        const session = initSession();
+        const events = session.handleMessage({ type: "rate_limit_event" });
+
+        expect(events).toHaveLength(1);
+        expect(events[0]).toMatchObject({ type: "session:rate_limited", sessionId: "sess-1" });
+        expect(session.rateLimited).toBe(true);
+      });
+
+      test("extracts retryAfterMs from retry_after_ms field", () => {
+        const session = initSession();
+        const events = session.handleMessage({ type: "rate_limit_event", retry_after_ms: 60000 });
+
+        expect(events[0]).toMatchObject({
+          type: "session:rate_limited",
+          sessionId: "sess-1",
+          retryAfterMs: 60000,
+        });
+      });
+
+      test("converts retry_after seconds to ms", () => {
+        const session = initSession();
+        const events = session.handleMessage({ type: "rate_limit_event", retry_after: 30 });
+
+        expect(events[0]).toMatchObject({
+          type: "session:rate_limited",
+          sessionId: "sess-1",
+          retryAfterMs: 30000,
+        });
+      });
+
+      test("does not set parseMismatch", () => {
+        const session = initSession();
+        session.handleMessage({ type: "rate_limit_event" });
+        expect(session.parseMismatch).toBe(false);
+      });
+    });
   });
 
   describe("parseMismatch lifecycle", () => {

--- a/packages/daemon/src/claude-session/session-state.ts
+++ b/packages/daemon/src/claude-session/session-state.ts
@@ -111,6 +111,7 @@ export class SessionState {
     if (msg.type === "assistant") return this.handleAssistant(msg);
     if (msg.type === "result") return this.handleResult(msg);
     if (msg.type === "control_request") return this.handleControlRequest(msg);
+    if (msg.type === "rate_limit_event") return this.handleRateLimitEvent(msg);
 
     return [];
   }
@@ -405,6 +406,12 @@ export class SessionState {
         request,
       },
     ];
+  }
+
+  private handleRateLimitEvent(msg: NdjsonMessage): SessionEvent[] {
+    this.rateLimited = true;
+    const retryAfterMs = extractRetryAfterMs(msg);
+    return [{ type: "session:rate_limited", sessionId: this.sessionId, retryAfterMs }];
   }
 }
 

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -75,7 +75,13 @@ const KILL_SIGKILL_GRACE_MS = 2_000;
 const CONNECT_TIMEOUT_MS = 30_000;
 
 /** Message types handled by the state machine's dispatch. */
-const HANDLED_MSG_TYPES: ReadonlyArray<string> = ["system", "assistant", "result", "control_request"];
+const HANDLED_MSG_TYPES: ReadonlyArray<string> = [
+  "system",
+  "assistant",
+  "result",
+  "control_request",
+  "rate_limit_event",
+];
 
 /**
  * Message types that the daemon knows about (handled or intentionally ignored).


### PR DESCRIPTION
## Summary

- `rate_limit_event` is a top-level NDJSON message type emitted by Claude CLI ≥ 2.1.150 that was missing from `KNOWN_MSG_TYPES`, triggering a spurious "Unrecognized message type" error log on every turn
- Added a dedicated handler in `SessionState.handleRateLimitEvent()` that extracts retry info and emits `session:rate_limited` — wiring into the existing rate-limit machinery in ws-server.ts (which sets `pendingImmediate`, resolves event waiters, and emits the `WORKER_RATELIMITED` monitor event)
- Added `rate_limit_event` to `HANDLED_MSG_TYPES` in ws-server.ts so `KNOWN_MSG_TYPES` stays accurate

## Test plan

- [x] 4 new tests in `session-state.spec.ts` covering: emits `session:rate_limited`, sets `rateLimited` flag, extracts `retry_after_ms`, converts `retry_after` seconds → ms, does not set `parseMismatch`
- [x] All 74 session-state tests pass
- [x] All 210 ws-server tests pass
- [x] `bun run am-i-done` passes (1 pre-existing flaky failure in ci-steps.spec.ts under parallel — filed #2464)

🤖 Generated with [Claude Code](https://claude.com/claude-code)