### PR TITLE
fix(daemon): skip jittery isOurProcess check for fresh PID caches (fixes #2437)

### DIFF
--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -323,6 +323,8 @@ interface WsSession {
   pid: number | null;
   /** Process start time (epoch ms) — used to detect PID reuse before sending signals. */
   pidStartTime: number | null;
+  /** When pid was captured (epoch ms) — fresh caches skip jittery isOurProcess (#2437). */
+  pidCachedAt: number | null;
   proc: { kill: (signal?: number) => void; exited: Promise<number> } | null;
   spawnAlive: boolean;
   worktree: string | null;
@@ -665,6 +667,7 @@ export class ClaudeWsServer {
         name: s.name ?? null,
         pid: s.pid,
         pidStartTime: s.pidStartTime ?? null,
+        pidCachedAt: null,
         proc: null,
         spawnAlive: false,
         worktree: s.worktree,
@@ -718,6 +721,7 @@ export class ClaudeWsServer {
     session.spawnAlive = false;
     session.pid = null;
     session.pidStartTime = null;
+    session.pidCachedAt = null;
 
     // Transition disconnected → connecting so handleOpen treats this as a fresh spawn
     // (sends session.config.prompt) rather than a WS reconnect (which skips the initial message).
@@ -759,6 +763,7 @@ export class ClaudeWsServer {
       name,
       pid: null,
       pidStartTime: null,
+      pidCachedAt: null,
       proc: null,
       spawnAlive: false,
       worktree: config.worktree ?? null,
@@ -866,6 +871,7 @@ export class ClaudeWsServer {
     });
 
     session.pid = proc.pid;
+    session.pidCachedAt = Date.now();
     session.proc = proc;
     session.spawnAlive = true;
 
@@ -1005,10 +1011,11 @@ export class ClaudeWsServer {
    * Kill a raw PID (no proc handle) with SIGTERM → SIGKILL escalation.
    * Delegates to the shared killPid utility.
    */
-  private async killRawPid(pid: number, pidStartTime?: number | null): Promise<void> {
+  private async killRawPid(pid: number, pidStartTime?: number | null, cachedAtMs?: number | null): Promise<void> {
     await killPid(pid, this.logger, {
       pidStartTime,
       killTimeoutMs: this.killTimeoutMs,
+      cachedAtMs: cachedAtMs ?? undefined,
     });
   }
 
@@ -2419,6 +2426,7 @@ export class ClaudeWsServer {
       const dying = session.proc;
       session.proc = null;
       session.pid = null;
+      session.pidCachedAt = null;
       session.spawnAlive = false;
       await this.killAndAwaitProc(dying);
     } else if (session.pid) {
@@ -2426,8 +2434,10 @@ export class ClaudeWsServer {
       // Use killRawPid for SIGTERM → SIGKILL escalation (matches killAndAwaitProc behavior).
       // Pass pidStartTime to verify the PID hasn't been recycled by the OS.
       const pid = session.pid;
+      const cachedAt = session.pidCachedAt;
       session.pid = null;
-      await this.killRawPid(pid, session.pidStartTime);
+      session.pidCachedAt = null;
+      await this.killRawPid(pid, session.pidStartTime, cachedAt);
     }
   }
 }

--- a/packages/daemon/src/process-util.spec.ts
+++ b/packages/daemon/src/process-util.spec.ts
@@ -119,6 +119,33 @@ describe("killPid", () => {
     }
   });
 
+  test("skips ownership check when cachedAtMs is fresh (#2437)", async () => {
+    const proc = Bun.spawn(["sleep", "60"], { stdout: "ignore", stderr: "ignore" });
+    const pid = proc.pid;
+    try {
+      // pidStartTime is wrong (would trigger recycled-PID skip), but cachedAtMs is fresh
+      await killPid(pid, silentLogger, { pidStartTime: 1_000_000, cachedAtMs: Date.now() });
+      await awaitDeath(pid);
+      expect(isAlive(pid)).toBe(false);
+    } finally {
+      forceKill(pid);
+    }
+  });
+
+  test("still checks ownership when cachedAtMs is stale (#2437)", async () => {
+    const proc = Bun.spawn(["sleep", "60"], { stdout: "ignore", stderr: "ignore" });
+    const pid = proc.pid;
+    try {
+      const logger = capturingLogger();
+      // pidStartTime is wrong AND cachedAtMs is >30s ago — should skip kill
+      await killPid(pid, logger, { pidStartTime: 1_000_000, cachedAtMs: Date.now() - 60_000 });
+      expect(isAlive(pid)).toBe(true);
+      expect(logger.warns.some((w) => w.includes("recycled"))).toBe(true);
+    } finally {
+      forceKill(pid);
+    }
+  });
+
   test("proceeds without ownership check when pidStartTime is null", async () => {
     const proc = Bun.spawn(["sleep", "60"], { stdout: "ignore", stderr: "ignore" });
     const pid = proc.pid;

--- a/packages/daemon/src/process-util.ts
+++ b/packages/daemon/src/process-util.ts
@@ -14,6 +14,8 @@ const KILL_TIMEOUT_MS = 5_000;
 const KILL_SIGKILL_GRACE_MS = 2_000;
 /** Interval (ms) between liveness checks while waiting for process exit. */
 const POLL_INTERVAL_MS = 100;
+/** Cache age (ms) below which PID-recycling is near-impossible — skip jittery isOurProcess (#2437). */
+const FRESH_CACHE_MS = 30_000;
 
 /**
  * Try to send a signal to a process. Returns true if the signal was sent
@@ -59,6 +61,10 @@ async function awaitExit(pid: number, deadlineMs: number): Promise<boolean> {
  * original process before sending any signals. This prevents killing an
  * unrelated process when the PID has been recycled by the OS.
  *
+ * If `cachedAtMs` is also provided and the cache is less than `FRESH_CACHE_MS`
+ * old, the ownership check is skipped — PID recycling within that window is
+ * near-impossible, and the `ps -o etime=` parser jitters under CI load (#2437).
+ *
  * Error handling:
  * - ESRCH (no such process) is silently swallowed — process already dead.
  * - EPERM (not permitted) is logged as a warning — we don't own this PID.
@@ -71,11 +77,8 @@ export async function killPid(
 ): Promise<void> {
   const killTimeoutMs = opts?.killTimeoutMs ?? KILL_TIMEOUT_MS;
 
-  // Verify PID ownership before sending signals.
-  // Skip for recently-cached PIDs: PID recycling in <30s is near-impossible,
-  // and the etime-based check jitters by seconds under CI load (#2437).
-  const FRESH_CACHE_MS = 30_000;
-  const isFreshCache = opts?.cachedAtMs != null && Date.now() - opts.cachedAtMs < FRESH_CACHE_MS;
+  const cacheAge = opts?.cachedAtMs != null ? Date.now() - opts.cachedAtMs : null;
+  const isFreshCache = cacheAge != null && cacheAge >= 0 && cacheAge < FRESH_CACHE_MS;
   if (opts?.pidStartTime != null && !isFreshCache) {
     const ownership = isOurProcess(pid, opts.pidStartTime);
     if (ownership === false) {

--- a/packages/daemon/src/process-util.ts
+++ b/packages/daemon/src/process-util.ts
@@ -67,12 +67,16 @@ async function awaitExit(pid: number, deadlineMs: number): Promise<boolean> {
 export async function killPid(
   pid: number,
   logger: Logger,
-  opts?: { pidStartTime?: number | null; killTimeoutMs?: number },
+  opts?: { pidStartTime?: number | null; killTimeoutMs?: number; cachedAtMs?: number },
 ): Promise<void> {
   const killTimeoutMs = opts?.killTimeoutMs ?? KILL_TIMEOUT_MS;
 
-  // Verify PID ownership before sending signals
-  if (opts?.pidStartTime != null) {
+  // Verify PID ownership before sending signals.
+  // Skip for recently-cached PIDs: PID recycling in <30s is near-impossible,
+  // and the etime-based check jitters by seconds under CI load (#2437).
+  const FRESH_CACHE_MS = 30_000;
+  const isFreshCache = opts?.cachedAtMs != null && Date.now() - opts.cachedAtMs < FRESH_CACHE_MS;
+  if (opts?.pidStartTime != null && !isFreshCache) {
     const ownership = isOurProcess(pid, opts.pidStartTime);
     if (ownership === false) {
       logger.warn(`[process] PID ${pid} has been recycled (start time mismatch) — skipping kill`);

--- a/packages/daemon/src/server-pool.ts
+++ b/packages/daemon/src/server-pool.ts
@@ -64,6 +64,8 @@ interface ServerConnection {
   cachedChildPid?: number | null;
   /** Start time of cachedChildPid (epoch ms), for PID-recycling protection. */
   cachedChildPidStartTime?: number | null;
+  /** When cachedChildPid was recorded (epoch ms) — used to skip jittery isOurProcess for fresh caches. */
+  cachedChildPidAt?: number;
 }
 
 /**
@@ -369,6 +371,7 @@ export class ServerPool {
             }
             conn.cachedChildPid = pid;
             conn.cachedChildPidStartTime = pid != null ? getProcessStartTime(pid) : null;
+            conn.cachedChildPidAt = pid != null ? Date.now() : undefined;
           }
 
           // Detect server crashes / transport close to reset stale "connected" state
@@ -656,6 +659,7 @@ export class ServerPool {
         : childPid != null
           ? getProcessStartTime(childPid)
           : null;
+    const cachedAtMs = conn.cachedChildPidAt;
 
     // Flush and detach stderr listener
     if (conn.stderrCleanup) {
@@ -674,7 +678,7 @@ export class ServerPool {
     // (e.g. keepalive intervals) won't exit, causing process leaks (#940).
     // Uses SIGTERM → poll → SIGKILL escalation with PID ownership verification.
     if (childPid != null) {
-      await killPid(childPid, this.logger, { pidStartTime });
+      await killPid(childPid, this.logger, { pidStartTime, cachedAtMs });
     } else if (isStdioConfig(conn.resolved.config) && !conn.virtual) {
       this.logger.warn(`[pool] Server "${name}": no PID available — cannot verify stdio child cleanup`);
     }
@@ -683,6 +687,7 @@ export class ServerPool {
     conn.transport = null;
     conn.cachedChildPid = null;
     conn.cachedChildPidStartTime = null;
+    conn.cachedChildPidAt = undefined;
     conn.state = "disconnected";
     conn.tools.clear();
   }


### PR DESCRIPTION
## Summary
- `killPid`'s PID-recycling guard (`isOurProcess`) computes process start times from `ps -o etime=`, which jitters by seconds under CI load — exceeding the 2s tolerance and producing false negatives that skip SIGTERM entirely, leaving child processes alive
- Added `cachedAtMs` timestamp to `ServerConnection` and `killPid` opts — PIDs cached within the last 30 seconds bypass the `isOurProcess` check, since PID recycling in that window is near-impossible
- Preserves the recycling-safety property for long-lived cached PIDs (daemon servers that crashed hours ago)

## Test plan
- [x] New test: `skips ownership check when cachedAtMs is fresh` — verifies kill proceeds despite wrong pidStartTime when cache is fresh
- [x] New test: `still checks ownership when cachedAtMs is stale` — verifies the recycling guard still fires for old caches
- [x] Existing tests pass unchanged (SIGTERM, SIGKILL escalation, null pidStartTime)
- [x] `bun run am-i-done` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)