### PR TITLE
fix(claude): interrupt result (is_error:true, no errors[]) routed to session:error (closes #2233)

### DIFF
--- a/packages/daemon/src/claude-session/ndjson.spec.ts
+++ b/packages/daemon/src/claude-session/ndjson.spec.ts
@@ -222,6 +222,21 @@ describe("Result schemas", () => {
       expect(result.subtype).toBe(subtype);
     }
   });
+
+  test("parses interrupt result — is_error:true with no errors[]", () => {
+    // Claude 2.1.150+: control_request/interrupt produces this shape — no errors array.
+    const interruptResult = {
+      type: "result",
+      subtype: "error_during_execution",
+      is_error: true,
+      num_turns: 1,
+      total_cost_usd: 0.01,
+      session_id: "abc-123",
+    };
+    const result = ResultError.parse(interruptResult);
+    expect(result.is_error).toBe(true);
+    expect(result.errors).toBeUndefined();
+  });
 });
 
 describe("CanUseTool schema", () => {

--- a/packages/daemon/src/claude-session/ndjson.ts
+++ b/packages/daemon/src/claude-session/ndjson.ts
@@ -118,8 +118,8 @@ export const ResultError = z
   .object({
     type: z.literal("result"),
     subtype: z.string(),
-    is_error: z.literal(true).optional(),
-    errors: z.array(z.string()),
+    is_error: z.literal(true),
+    errors: z.array(z.string()).optional(),
     duration_ms: z.number().optional(),
     num_turns: z.number(),
     total_cost_usd: z.number(),
@@ -137,6 +137,7 @@ export const ResultFallback = z
   .object({
     type: z.literal("result"),
     subtype: z.string().optional(),
+    is_error: z.boolean().optional(),
     result: z.string().optional(),
     errors: z.array(z.string()).optional(),
     num_turns: z.number().optional(),

--- a/packages/daemon/src/claude-session/session-state.spec.ts
+++ b/packages/daemon/src/claude-session/session-state.spec.ts
@@ -243,6 +243,29 @@ describe("SessionState", () => {
       ]);
     });
 
+    test("interrupt result (is_error:true, no errors[]) emits session:error not session:result", () => {
+      // Regression for #2233: Claude 2.1.150+ interrupt produces result with
+      // is_error:true but no errors[] — must route to session:error, not session:result.
+      const session = activeSession();
+      const interruptResult = {
+        type: "result",
+        subtype: "error_during_execution",
+        is_error: true,
+        num_turns: 1,
+        total_cost_usd: 0.01,
+        session_id: "sess-1",
+      };
+      const events = session.handleMessage(interruptResult);
+
+      expect(session.state).toBe("idle");
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe("session:error");
+      if (events[0].type === "session:error") {
+        expect(events[0].errors).toEqual([]);
+        expect(events[0].cost).toBe(0.01);
+      }
+    });
+
     test("sets cumulative cost from SDK (not additive)", () => {
       const session = activeSession();
       session.handleMessage(RESULT_SUCCESS); // total_cost_usd=0.05, num_turns=3

--- a/packages/daemon/src/claude-session/session-state.ts
+++ b/packages/daemon/src/claude-session/session-state.ts
@@ -325,7 +325,7 @@ export class SessionState {
       this.cost = r.total_cost_usd;
       this.numTurns = r.num_turns;
       this.state = "idle";
-      return [{ type: "session:error", errors: r.errors, cost: this.cost }];
+      return [{ type: "session:error", errors: r.errors ?? [], cost: this.cost }];
     }
 
     // Fallback: transition to idle for any result message, even if neither
@@ -342,8 +342,8 @@ export class SessionState {
       if (r.num_turns != null) this.numTurns = r.num_turns;
       this.state = "idle";
 
-      const errors = r.errors;
-      if (r.subtype !== "success" && Array.isArray(errors) && errors.length > 0) {
+      const errors = r.errors ?? [];
+      if (r.subtype !== "success" && (r.is_error === true || errors.length > 0)) {
         return [{ type: "session:error", errors, cost: this.cost }];
       }
       return [


### PR DESCRIPTION
## Summary
- `error_during_execution` interrupt results have `is_error: true` but no `errors[]` array; `ResultError` required `errors`, so the message fell through to `ResultFallback` and emitted an empty `session:result` instead of `session:error`
- Made `errors` optional in `ResultError` (discriminant is now `is_error: z.literal(true)`) and added `is_error` to `ResultFallback` for typed access in the fallback path
- Updated both `handleResult` paths: strict branch uses `r.errors ?? []`; fallback branch checks `r.is_error === true` in addition to `errors.length > 0`

## Test plan
- [x] New `ndjson.spec.ts` test: interrupt shape (`is_error: true`, no `errors[]`) parses as `ResultError`
- [x] New `session-state.spec.ts` regression test: interrupt result emits `session:error` (not `session:result`) with empty errors array
- [x] Existing error tests still pass (122 tests across both files)
- [x] Full gate: typecheck + lint + rules + tests + coverage all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)