### PR TITLE
fix(runner): thread explicit cwd into computeVerdictKey (fixes #2445)

### DIFF
--- a/scripts/_runner/ci-steps.ts
+++ b/scripts/_runner/ci-steps.ts
@@ -249,7 +249,7 @@ interface ChangedTestsOpts {
   /** Override repo root for verdict cache location. DI for tests. */
   repoRoot?: string;
   /** Override verdict-key computation. DI for tests. */
-  computeKey?: (resolveBase: () => string) => string | null;
+  computeKey?: (resolveBase: () => string, cwd?: string) => string | null;
   /** Override spec-file discovery. DI for tests. */
   findSpecFiles?: (repoRoot: string) => string[];
   /** Override import-graph builder. DI for tests. */
@@ -344,7 +344,7 @@ export function changedTestsStep(opts: ChangedTestsOpts): ScriptFunction {
     const base = resolveBase();
 
     // Verdict cache: skip tests when the worktree state is unchanged (#2396).
-    const key = getKey(() => base);
+    const key = getKey(() => base, repoRoot);
     if (key) {
       const cached = lookupVerdict(repoRoot, key);
       if (cached === true) {

--- a/scripts/_runner/verdict-cache.spec.ts
+++ b/scripts/_runner/verdict-cache.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -86,35 +87,61 @@ describe("verdict-cache", () => {
 });
 
 describe("computeVerdictKey", () => {
-  // Tests run inside the mcp-cli worktree — a valid git repo with a HEAD commit.
-  // computeVerdictKey runs git commands in process.cwd() so there's no need to
-  // create a temporary repo.
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const d of dirs) rmSync(d, { recursive: true, force: true });
+    dirs.length = 0;
+  });
+
+  function initGitRepo(): string {
+    const dir = mkdtempSync(join(tmpdir(), "verdict-key-test-"));
+    dirs.push(dir);
+    spawnSync("git", ["init"], { cwd: dir });
+    spawnSync("git", ["-c", "user.name=Test", "-c", "user.email=t@t", "commit", "--allow-empty", "-m", "init"], {
+      cwd: dir,
+    });
+    return dir;
+  }
 
   it("returns a non-null string with three colon-separated parts in a valid git repo", () => {
-    const key = computeVerdictKey(() => "HEAD~1");
+    const dir = initGitRepo();
+    const key = computeVerdictKey(() => "HEAD", dir);
     expect(key).not.toBeNull();
     const parts = (key as string).split(":");
-    // Format: <base>:<headSha>:<diffHash> — three non-empty segments.
     expect(parts).toHaveLength(3);
     for (const p of parts) expect(p.length).toBeGreaterThan(0);
   });
 
   it("is stable across identical invocations (same state → same key)", () => {
-    const base = "HEAD~1";
-    const key1 = computeVerdictKey(() => base);
-    const key2 = computeVerdictKey(() => base);
+    const dir = initGitRepo();
+    const key1 = computeVerdictKey(() => "HEAD", dir);
+    const key2 = computeVerdictKey(() => "HEAD", dir);
+    expect(key1).not.toBeNull();
+    expect(key2).not.toBeNull();
+    expect(key1).toEqual(key2);
+  });
+
+  it("is stable even when untracked files change in a different cwd", () => {
+    const dir = initGitRepo();
+    const probe = join(process.cwd(), `verdict-key-probe-${Date.now()}.tmp`);
+    const key1 = computeVerdictKey(() => "HEAD", dir);
+    writeFileSync(probe, "noise");
+    const key2 = computeVerdictKey(() => "HEAD", dir);
+    if (existsSync(probe)) unlinkSync(probe);
     expect(key1).not.toBeNull();
     expect(key2).not.toBeNull();
     expect(key1).toEqual(key2);
   });
 
   it("changes when the base ref changes", () => {
-    // Two different base refs produce different keys because the first
-    // key segment (the resolved base SHA) changes.
-    const key1 = computeVerdictKey(() => "HEAD~1");
-    const key2 = computeVerdictKey(() => "HEAD~2");
-    // HEAD~2 may not exist in a shallow repo — skip gracefully.
-    if (key1 === null || key2 === null) return;
+    const dir = initGitRepo();
+    spawnSync("git", ["-c", "user.name=Test", "-c", "user.email=t@t", "commit", "--allow-empty", "-m", "second"], {
+      cwd: dir,
+    });
+    const key1 = computeVerdictKey(() => "HEAD~1", dir);
+    const key2 = computeVerdictKey(() => "HEAD", dir);
+    expect(key1).not.toBeNull();
+    expect(key2).not.toBeNull();
     expect(key1).not.toEqual(key2);
   });
 });

--- a/scripts/_runner/verdict-cache.ts
+++ b/scripts/_runner/verdict-cache.ts
@@ -36,19 +36,19 @@ interface VerdictCacheFile {
  * Any code change — commit, amend, stage, edit — flips at least one of
  * these, invalidating the cache.
  */
-export function computeVerdictKey(resolveBase: () => string): string | null {
+export function computeVerdictKey(resolveBase: () => string, cwd?: string): string | null {
   const base = resolveBase();
-  const head = spawnSync("git", ["rev-parse", "HEAD"], { encoding: "utf8" });
+  const head = spawnSync("git", ["rev-parse", "HEAD"], { encoding: "utf8", cwd });
   if (head.status !== 0) return null;
   const headSha = head.stdout.trim();
 
   // `git diff HEAD` captures both staged and unstaged changes in one shot.
-  const diff = spawnSync("git", ["diff", "HEAD"], { encoding: "utf8" });
+  const diff = spawnSync("git", ["diff", "HEAD"], { encoding: "utf8", cwd });
   if (diff.status !== 0) return null;
 
   // Untracked files (new spec files, etc.) are invisible to `git diff HEAD`.
   // Include their names so adding/removing an untracked file flips the key.
-  const untracked = spawnSync("git", ["ls-files", "--others", "--exclude-standard"], { encoding: "utf8" });
+  const untracked = spawnSync("git", ["ls-files", "--others", "--exclude-standard"], { encoding: "utf8", cwd });
   const untrackedList = untracked.status === 0 ? untracked.stdout : "";
 
   const diffHash = Bun.hash(diff.stdout + untrackedList).toString(16);


### PR DESCRIPTION
## Summary
- Added optional `cwd` parameter to `computeVerdictKey` and threaded it through all three `spawnSync("git", ...)` calls (rev-parse, diff, ls-files) so git operates on an explicit directory instead of inheriting `process.cwd()`
- Updated the production call site in `changedTestsStep` (ci-steps.ts) to pass `repoRoot` as `cwd`
- Rewrote `computeVerdictKey` tests to use isolated temp git repos (`git init` + empty commit) instead of the ambient worktree, and added a determinism test that creates/removes an untracked file in `process.cwd()` while asserting the key is stable when pinned to a different `cwd`

## Test plan
- [x] `bun test scripts/_runner/verdict-cache.spec.ts` — all 12 tests pass
- [x] `bun test scripts/_runner/ci-steps.spec.ts` — all 27 tests pass (DI slot `computeKey` type updated)
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun run doing-it-wrong` — no violations
- [x] `bun run am-i-done --pre-push` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)