### PR TITLE
fix(spawn): make --allow additive with DEFAULT_SAFE_TOOLS, detect dead patterns (fixes #2074)

### DIFF
--- a/packages/command/src/commands/agent.spec.ts
+++ b/packages/command/src/commands/agent.spec.ts
@@ -820,6 +820,52 @@ describe("parseAgentResumeArgs", () => {
     expect(result.allow).toEqual(["Read", "Write"]);
     expect(result.target).toBe("my-worktree");
   });
+
+  // ── Comma-split via shared validateAllowPatterns (#2074) ──
+
+  test("splits comma-separated --allow patterns", () => {
+    const result = parseAgentResumeArgs(["my-wt", "--allow", "Bash,Write,Read"]);
+    expect(result.allow).toEqual(["Bash", "Write", "Read"]);
+  });
+
+  test("warns on comma-separated patterns", () => {
+    const result = parseAgentResumeArgs(["my-wt", "--allow", "Bash,Write"]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("Comma-separated");
+  });
+
+  // ── Dead pattern detection via shared validateAllowPatterns (#2074) ──
+
+  test("errors on Bash(*) dead pattern", () => {
+    const result = parseAgentResumeArgs(["my-wt", "--allow", "Bash(*)"]);
+    expect(result.error).toContain("dead rule");
+  });
+
+  test("warns on Bash(git*) missing colon wildcard", () => {
+    const result = parseAgentResumeArgs(["my-wt", "--allow", "Bash(git*)"]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("may not match");
+  });
+
+  // ── --allow-only (#2074) ──
+
+  test("sets allowOnly=true with --allow-only flag", () => {
+    const result = parseAgentResumeArgs(["my-wt", "--allow-only", "Bash"]);
+    expect(result.allowOnly).toBe(true);
+    expect(result.allow).toEqual(["Bash"]);
+  });
+
+  test("errors on empty --allow-only", () => {
+    const result = parseAgentResumeArgs(["my-wt", "--allow-only"]);
+    expect(result.error).toBe("--allow-only requires at least one tool pattern");
+  });
+
+  // ── Mutual exclusivity (#2074) ──
+
+  test("errors when --allow and --allow-only both present", () => {
+    const result = parseAgentResumeArgs(["my-wt", "--allow", "Read", "--allow-only", "Bash"]);
+    expect(result.error).toBe("--allow and --allow-only are mutually exclusive");
+  });
 });
 
 // ── Resume (shimmed provider — codex) ──

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -11,7 +11,7 @@
 import { existsSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
-import type { AgentFeatures, AgentProvider, MailMessage } from "@mcp-cli/core";
+import { type AgentFeatures, type AgentProvider, type MailMessage, validateAllowPatterns } from "@mcp-cli/core";
 import { parseFlags } from "../flags";
 import { CLAUDE_SUB_ALIASES, formatHelp, getHelp, hasHelpFlag } from "../help";
 import { emitMailEvent, pollMailUntil } from "./mail-wait";
@@ -1228,53 +1228,42 @@ interface AgentResumeArgs {
 }
 
 export function parseAgentResumeArgs(args: string[]): AgentResumeArgs {
-  const allow: string[] = [];
+  const rawAllow: string[] = [];
   let allowOnly = false;
+  let sawAllow = false;
+  let sawAllowOnly = false;
   let allowError: string | undefined;
-  const warnings: string[] = [];
   const remaining: string[] = [];
 
   // Phase 1: extract --allow/--allow-only with greedy looksLikeToolName heuristic
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--allow" || args[i] === "--allow-only") {
-      if (args[i] === "--allow-only") allowOnly = true;
+      if (args[i] === "--allow") sawAllow = true;
+      if (args[i] === "--allow-only") {
+        sawAllowOnly = true;
+        allowOnly = true;
+      }
       // dotw-ignore no-manual-arg-parsing: greedy multi-value --allow must run before parseFlags; parseFlags has no multi-value-with-heuristic mode
       while (i + 1 < args.length && looksLikeToolName(args[i + 1])) {
-        const raw = args[++i]; // dotw-ignore no-manual-arg-parsing: see above — greedy consume in pre-processing phase
-        if (raw.includes(",")) {
-          warnings.push(
-            `Comma-separated --allow pattern "${raw}" was split into ${raw.split(",").length} patterns — use spaces instead`,
-          );
-          for (const part of raw.split(",")) {
-            const trimmed = part.trim();
-            if (trimmed) allow.push(trimmed);
-          }
-        } else {
-          allow.push(raw);
-        }
+        rawAllow.push(args[++i]); // dotw-ignore no-manual-arg-parsing: see above — greedy consume in pre-processing phase
       }
-      if (allow.length === 0) allowError = `${args[i]} requires at least one tool pattern`;
+      if (rawAllow.length === 0) allowError = `${args[i]} requires at least one tool pattern`;
     } else {
       remaining.push(args[i]);
     }
   }
 
-  // Mechanism B: detect dead patterns
-  for (const pattern of allow) {
-    const parenMatch = pattern.match(/^(\w+)\((.+)\)$/);
-    if (parenMatch) {
-      const toolName = parenMatch[1];
-      const inner = parenMatch[2];
-      if (inner === "*") {
-        warnings.push(
-          `"${pattern}" is a dead rule — bare (*) is not a wildcard. Use "${toolName}" (no parens) to allow all ${toolName} calls, or "${toolName}(:*)" for prefix matching`,
-        );
-      } else if (inner.endsWith("*") && !inner.endsWith(":*")) {
-        warnings.push(
-          `"${pattern}" may not match as expected — use ":*" suffix for prefix wildcards (e.g. "${toolName}(${inner.slice(0, -1)}:*)")`,
-        );
-      }
-    }
+  // Mutual exclusivity
+  if (sawAllow && sawAllowOnly) {
+    allowError ??= "--allow and --allow-only are mutually exclusive";
+  }
+
+  // Validate: comma-split + dead-pattern detection via shared module
+  const validation = validateAllowPatterns(rawAllow);
+  const allow = validation.patterns;
+  const warnings = [...validation.warnings];
+  if (validation.errors.length > 0) {
+    allowError ??= validation.errors[0];
   }
 
   // Phase 2: parseFlags for standard flags
@@ -1302,7 +1291,7 @@ export function parseAgentResumeArgs(args: string[]): AgentResumeArgs {
     if (val.startsWith("-")) {
       error ??= "--model requires a value";
     } else {
-      model = val; // RAW, no resolveModelName
+      model = val;
     }
   }
 
@@ -1329,7 +1318,7 @@ export function parseAgentResumeArgs(args: string[]): AgentResumeArgs {
     error = "--fresh cannot be combined with an explicit session ID";
   } else if (!all && !target) {
     error =
-      "Usage: mcx agent <provider> resume <worktree> [--fresh] [--force] [--model M] [--allow tools...] [--wait] [--timeout ms]\n       mcx agent <provider> resume --all";
+      "Usage: mcx agent <provider> resume <worktree> [--fresh] [--force] [--model M] [--allow tools...] [--allow-only tools...] [--wait] [--timeout ms]\n       mcx agent <provider> resume --all";
   }
 
   return { target, sessionId, all, fresh, force, allow, allowOnly, model, wait, timeout, error, warnings };

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -344,6 +344,7 @@ export async function cmdAgent(args: string[], deps?: Partial<AgentDeps>): Promi
 interface AgentSpawnArgs {
   task: string | undefined;
   allow: string[];
+  allowOnly: boolean;
   cwd: string | undefined;
   timeout: number | undefined;
   model: string | undefined;
@@ -355,6 +356,7 @@ interface AgentSpawnArgs {
   provider: string | undefined;
   resume: string | undefined;
   error: string | undefined;
+  warnings: string[];
 }
 
 export function parseAgentSpawnArgs(
@@ -462,6 +464,8 @@ async function agentSpawn(
     d.exit(1);
   }
 
+  for (const w of parsed.warnings) d.printError(`warning: ${w}`);
+
   // ACP requires --agent
   if (hasFeature(provider, "agentSelect") && !parsed.agent) {
     d.printError("--agent is required for ACP. Specify which agent to spawn (e.g. copilot, gemini, grok).");
@@ -503,6 +507,7 @@ async function agentSpawn(
   const toolArgs: Record<string, unknown> = { prompt: task };
   if (parsed.resume) toolArgs.sessionId = parsed.resume;
   if (parsed.allow.length > 0) toolArgs.allowedTools = parsed.allow;
+  if (parsed.allowOnly) toolArgs.allowOnly = true;
   if (parsed.cwd) toolArgs.cwd = parsed.cwd;
   if (parsed.timeout) toolArgs.timeout = parsed.timeout;
   if (parsed.model) toolArgs.model = parsed.model;
@@ -1214,27 +1219,61 @@ interface AgentResumeArgs {
   /** Bypass the branch-merged pre-flight check. */
   force: boolean;
   allow: string[];
+  allowOnly: boolean;
   model: string | undefined;
   wait: boolean;
   timeout: number | undefined;
   error: string | undefined;
+  warnings: string[];
 }
 
 export function parseAgentResumeArgs(args: string[]): AgentResumeArgs {
   const allow: string[] = [];
+  let allowOnly = false;
   let allowError: string | undefined;
+  const warnings: string[] = [];
   const remaining: string[] = [];
 
-  // Phase 1: extract --allow with greedy looksLikeToolName heuristic
+  // Phase 1: extract --allow/--allow-only with greedy looksLikeToolName heuristic
   for (let i = 0; i < args.length; i++) {
-    if (args[i] === "--allow") {
+    if (args[i] === "--allow" || args[i] === "--allow-only") {
+      if (args[i] === "--allow-only") allowOnly = true;
       // dotw-ignore no-manual-arg-parsing: greedy multi-value --allow must run before parseFlags; parseFlags has no multi-value-with-heuristic mode
       while (i + 1 < args.length && looksLikeToolName(args[i + 1])) {
-        allow.push(args[++i]); // dotw-ignore no-manual-arg-parsing: see above — greedy consume in pre-processing phase
+        const raw = args[++i]; // dotw-ignore no-manual-arg-parsing: see above — greedy consume in pre-processing phase
+        if (raw.includes(",")) {
+          warnings.push(
+            `Comma-separated --allow pattern "${raw}" was split into ${raw.split(",").length} patterns — use spaces instead`,
+          );
+          for (const part of raw.split(",")) {
+            const trimmed = part.trim();
+            if (trimmed) allow.push(trimmed);
+          }
+        } else {
+          allow.push(raw);
+        }
       }
-      if (allow.length === 0) allowError = "--allow requires at least one tool pattern";
+      if (allow.length === 0) allowError = `${args[i]} requires at least one tool pattern`;
     } else {
       remaining.push(args[i]);
+    }
+  }
+
+  // Mechanism B: detect dead patterns
+  for (const pattern of allow) {
+    const parenMatch = pattern.match(/^(\w+)\((.+)\)$/);
+    if (parenMatch) {
+      const toolName = parenMatch[1];
+      const inner = parenMatch[2];
+      if (inner === "*") {
+        warnings.push(
+          `"${pattern}" is a dead rule — bare (*) is not a wildcard. Use "${toolName}" (no parens) to allow all ${toolName} calls, or "${toolName}(:*)" for prefix matching`,
+        );
+      } else if (inner.endsWith("*") && !inner.endsWith(":*")) {
+        warnings.push(
+          `"${pattern}" may not match as expected — use ":*" suffix for prefix wildcards (e.g. "${toolName}(${inner.slice(0, -1)}:*)")`,
+        );
+      }
     }
   }
 
@@ -1293,7 +1332,7 @@ export function parseAgentResumeArgs(args: string[]): AgentResumeArgs {
       "Usage: mcx agent <provider> resume <worktree> [--fresh] [--force] [--model M] [--allow tools...] [--wait] [--timeout ms]\n       mcx agent <provider> resume --all";
   }
 
-  return { target, sessionId, all, fresh, force, allow, model, wait, timeout, error };
+  return { target, sessionId, all, fresh, force, allow, allowOnly, model, wait, timeout, error, warnings };
 }
 
 async function agentResume(
@@ -1308,6 +1347,8 @@ async function agentResume(
     d.printError(parsed.error);
     d.exit(1);
   }
+
+  for (const w of parsed.warnings) d.printError(`warning: ${w}`);
 
   const P = provider.toolPrefix;
   const cwd = d.getCwd();
@@ -1456,6 +1497,7 @@ async function resumeAgentWorktree(
 
   const toolArgs: Record<string, unknown> = { cwd: wt.path };
   if (parsed.allow.length > 0) toolArgs.allowedTools = parsed.allow;
+  if (parsed.allowOnly) toolArgs.allowOnly = true;
   if (parsed.model) toolArgs.model = parsed.model;
   if (parsed.timeout) toolArgs.timeout = parsed.timeout;
 

--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -1059,9 +1059,17 @@ describe("buildHeadedCommand", () => {
     expect(result).toBe("claude -p x --model claude-sonnet-4-6");
   });
 
-  test("includes allowedTools", () => {
-    const result = buildHeadedCommand(parseSpawnArgs(["--task", "x", "--allow", "Read", "Glob"]));
-    expect(result).toBe("claude -p x --allowedTools Read Glob");
+  test("includes resolved allowedTools (additive with defaults)", () => {
+    const result = buildHeadedCommand(parseSpawnArgs(["--task", "x", "--allow", "Bash"]));
+    expect(result).toContain("--allowedTools");
+    expect(result).toContain("Bash");
+    expect(result).toContain("Read");
+    expect(result).toContain("Write");
+  });
+
+  test("--allow-only passes exact tools without defaults", () => {
+    const result = buildHeadedCommand(parseSpawnArgs(["--task", "x", "--allow-only", "Bash"]));
+    expect(result).toBe("claude -p x --allowedTools Bash");
   });
 
   test("handles task with special characters", () => {
@@ -4439,6 +4447,52 @@ describe("parseResumeArgs", () => {
   test("errors when --fresh and explicit session ID are both set", () => {
     const result = parseResumeArgs(["my-wt", "abc-session-uuid", "--fresh"]);
     expect(result.error).toBe("--fresh cannot be combined with an explicit session ID");
+  });
+
+  // ── Comma-split via shared validateAllowPatterns (#2074) ──
+
+  test("splits comma-separated --allow patterns", () => {
+    const result = parseResumeArgs(["my-wt", "--allow", "Bash,Write,Read"]);
+    expect(result.allow).toEqual(["Bash", "Write", "Read"]);
+  });
+
+  test("warns on comma-separated patterns", () => {
+    const result = parseResumeArgs(["my-wt", "--allow", "Bash,Write"]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("Comma-separated");
+  });
+
+  // ── Dead pattern detection via shared validateAllowPatterns (#2074) ──
+
+  test("errors on Bash(*) dead pattern", () => {
+    const result = parseResumeArgs(["my-wt", "--allow", "Bash(*)"]);
+    expect(result.error).toContain("dead rule");
+  });
+
+  test("warns on Bash(git*) missing colon wildcard", () => {
+    const result = parseResumeArgs(["my-wt", "--allow", "Bash(git*)"]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("may not match");
+  });
+
+  // ── --allow-only (#2074) ──
+
+  test("sets allowOnly=true with --allow-only flag", () => {
+    const result = parseResumeArgs(["my-wt", "--allow-only", "Bash"]);
+    expect(result.allowOnly).toBe(true);
+    expect(result.allow).toEqual(["Bash"]);
+  });
+
+  test("errors on empty --allow-only", () => {
+    const result = parseResumeArgs(["my-wt", "--allow-only"]);
+    expect(result.error).toBe("--allow-only requires at least one tool pattern");
+  });
+
+  // ── Mutual exclusivity (#2074) ──
+
+  test("errors when --allow and --allow-only both present", () => {
+    const result = parseResumeArgs(["my-wt", "--allow", "Read", "--allow-only", "Bash"]);
+    expect(result.error).toBe("--allow and --allow-only are mutually exclusive");
   });
 });
 

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -24,12 +24,14 @@ import {
   loadManifest,
   parseWorktreeList,
   readWorktreeConfig,
+  resolveEffectiveTools,
   resolveModelName,
   resolveRealpath,
   resolveWorktreePath,
   spawnCapture,
   spawnCaptureSync,
   updatePatchedClaude,
+  validateAllowPatterns,
 } from "@mcp-cli/core";
 import { getStaleDaemonWarning, ipcCall } from "../daemon-lifecycle";
 import { readFileWithLimit, resolveAtPath } from "../file-read";
@@ -431,7 +433,12 @@ export function buildHeadedCommand(parsed: SpawnArgs): string {
     parts.push("--model", shellQuote(parsed.model));
   }
   if (parsed.allow.length > 0) {
-    parts.push("--allowedTools", ...parsed.allow.map(shellQuote));
+    if (parsed.allowOnly) {
+      parts.push("--allowedTools", ...parsed.allow.map(shellQuote));
+    } else {
+      const { tools } = resolveEffectiveTools({ allowedTools: parsed.allow });
+      if (tools) parts.push("--allowedTools", ...tools.map(shellQuote));
+    }
   }
 
   return parts.join(" ");
@@ -664,35 +671,29 @@ export interface ResumeArgs {
 }
 
 export function parseResumeArgs(args: string[]): ResumeArgs {
-  const allow: string[] = [];
+  const rawAllow: string[] = [];
   let allowOnly = false;
+  let sawAllow = false;
+  let sawAllowOnly = false;
   let allowError: string | undefined;
-  const warnings: string[] = [];
   let model: string | undefined;
   let modelError: string | undefined;
   const remaining: string[] = [];
 
-  // Phase 1: extract --allow/--allow-only (greedy, no heuristic) and --model (unconditional consume)
+  // Phase 1: extract --allow/--allow-only (greedy, no heuristic — resume consumes all non-flags) and --model
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg === "--allow" || arg === "--allow-only") {
-      if (arg === "--allow-only") allowOnly = true;
+      if (arg === "--allow") sawAllow = true;
+      if (arg === "--allow-only") {
+        sawAllowOnly = true;
+        allowOnly = true;
+      }
       // dotw-ignore no-manual-arg-parsing: greedy multi-value consume (no heuristic) cannot be expressed in parseFlags
       while (i + 1 < args.length && !args[i + 1].startsWith("-")) {
-        const raw = args[++i]; // dotw-ignore no-manual-arg-parsing: greedy multi-value loop
-        if (raw.includes(",")) {
-          warnings.push(
-            `Comma-separated --allow pattern "${raw}" was split into ${raw.split(",").length} patterns — use spaces instead`,
-          );
-          for (const part of raw.split(",")) {
-            const trimmed = part.trim();
-            if (trimmed) allow.push(trimmed);
-          }
-        } else {
-          allow.push(raw);
-        }
+        rawAllow.push(args[++i]); // dotw-ignore no-manual-arg-parsing: greedy multi-value loop
       }
-      if (allow.length === 0) allowError = `${arg} requires at least one tool pattern`;
+      if (rawAllow.length === 0) allowError = `${arg} requires at least one tool pattern`;
     } else if (arg === "--model" || arg === "-m") {
       const val = args[++i]; // dotw-ignore no-manual-arg-parsing: unconditional consume required for compat — parseFlags rejects flag-looking values
       if (!val) {
@@ -703,6 +704,19 @@ export function parseResumeArgs(args: string[]): ResumeArgs {
     } else {
       remaining.push(arg);
     }
+  }
+
+  // Mutual exclusivity
+  if (sawAllow && sawAllowOnly) {
+    allowError ??= "--allow and --allow-only are mutually exclusive";
+  }
+
+  // Validate: comma-split + dead-pattern detection via shared module
+  const validation = validateAllowPatterns(rawAllow);
+  const allow = validation.patterns;
+  const warnings = [...validation.warnings];
+  if (validation.errors.length > 0) {
+    allowError ??= validation.errors[0];
   }
 
   // Phase 2: parseFlags for other flags
@@ -740,25 +754,7 @@ export function parseResumeArgs(args: string[]): ResumeArgs {
     error ??= "--fresh cannot be combined with an explicit session ID";
   } else if (!all && !target) {
     error ??=
-      "Usage: mcx claude resume <worktree> [session-id] [--fresh] [--force] [--model M] [--allow tools...] [--wait] [--timeout ms]\n       mcx claude resume --all";
-  }
-
-  // Mechanism B: detect dead patterns
-  for (const pattern of allow) {
-    const parenMatch = pattern.match(/^(\w+)\((.+)\)$/);
-    if (parenMatch) {
-      const toolName = parenMatch[1];
-      const inner = parenMatch[2];
-      if (inner === "*") {
-        warnings.push(
-          `"${pattern}" is a dead rule — bare (*) is not a wildcard. Use "${toolName}" (no parens) to allow all ${toolName} calls, or "${toolName}(:*)" for prefix matching`,
-        );
-      } else if (inner.endsWith("*") && !inner.endsWith(":*")) {
-        warnings.push(
-          `"${pattern}" may not match as expected — use ":*" suffix for prefix wildcards (e.g. "${toolName}(${inner.slice(0, -1)}:*)")`,
-        );
-      }
-    }
+      "Usage: mcx claude resume <worktree> [session-id] [--fresh] [--force] [--model M] [--allow tools...] [--allow-only tools...] [--wait] [--timeout ms]\n       mcx claude resume --all";
   }
 
   return { target, sessionId, all, fresh, force, allow, allowOnly, model, wait, timeout, error, warnings };

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -506,6 +506,8 @@ async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
     d.exit(1);
   }
 
+  for (const w of parsed.warnings) d.printError(`warning: ${w}`);
+
   if (!parsed.task && !parsed.resume) {
     d.printError('Usage: mcx claude spawn --task "description" [--worktree [name]] [--allow tools...]');
     d.printError('Run "mcx claude spawn --help" for details.');
@@ -557,6 +559,7 @@ async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
     }
   }
   if (parsed.allow.length > 0) toolArgs.allowedTools = parsed.allow;
+  if (parsed.allowOnly) toolArgs.allowOnly = true;
   // Without this, sessions inherit daemon cwd instead of caller's shell (#1331).
   if (parsed.cwd) toolArgs.cwd = parsed.cwd;
   else if (!parsed.worktree && !toolArgs.cwd) toolArgs.cwd = process.cwd();
@@ -652,28 +655,44 @@ export interface ResumeArgs {
   /** Bypass the branch-merged pre-flight check. */
   force: boolean;
   allow: string[];
+  allowOnly: boolean;
   model: string | undefined;
   wait: boolean;
   timeout: number | undefined;
   error: string | undefined;
+  warnings: string[];
 }
 
 export function parseResumeArgs(args: string[]): ResumeArgs {
   const allow: string[] = [];
+  let allowOnly = false;
   let allowError: string | undefined;
+  const warnings: string[] = [];
   let model: string | undefined;
   let modelError: string | undefined;
   const remaining: string[] = [];
 
-  // Phase 1: extract --allow (greedy, no heuristic) and --model (unconditional consume)
+  // Phase 1: extract --allow/--allow-only (greedy, no heuristic) and --model (unconditional consume)
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
-    if (arg === "--allow") {
+    if (arg === "--allow" || arg === "--allow-only") {
+      if (arg === "--allow-only") allowOnly = true;
       // dotw-ignore no-manual-arg-parsing: greedy multi-value consume (no heuristic) cannot be expressed in parseFlags
       while (i + 1 < args.length && !args[i + 1].startsWith("-")) {
-        allow.push(args[++i]); // dotw-ignore no-manual-arg-parsing: greedy multi-value loop
+        const raw = args[++i]; // dotw-ignore no-manual-arg-parsing: greedy multi-value loop
+        if (raw.includes(",")) {
+          warnings.push(
+            `Comma-separated --allow pattern "${raw}" was split into ${raw.split(",").length} patterns — use spaces instead`,
+          );
+          for (const part of raw.split(",")) {
+            const trimmed = part.trim();
+            if (trimmed) allow.push(trimmed);
+          }
+        } else {
+          allow.push(raw);
+        }
       }
-      if (allow.length === 0) allowError = "--allow requires at least one tool pattern";
+      if (allow.length === 0) allowError = `${arg} requires at least one tool pattern`;
     } else if (arg === "--model" || arg === "-m") {
       const val = args[++i]; // dotw-ignore no-manual-arg-parsing: unconditional consume required for compat — parseFlags rejects flag-looking values
       if (!val) {
@@ -724,7 +743,25 @@ export function parseResumeArgs(args: string[]): ResumeArgs {
       "Usage: mcx claude resume <worktree> [session-id] [--fresh] [--force] [--model M] [--allow tools...] [--wait] [--timeout ms]\n       mcx claude resume --all";
   }
 
-  return { target, sessionId, all, fresh, force, allow, model, wait, timeout, error };
+  // Mechanism B: detect dead patterns
+  for (const pattern of allow) {
+    const parenMatch = pattern.match(/^(\w+)\((.+)\)$/);
+    if (parenMatch) {
+      const toolName = parenMatch[1];
+      const inner = parenMatch[2];
+      if (inner === "*") {
+        warnings.push(
+          `"${pattern}" is a dead rule — bare (*) is not a wildcard. Use "${toolName}" (no parens) to allow all ${toolName} calls, or "${toolName}(:*)" for prefix matching`,
+        );
+      } else if (inner.endsWith("*") && !inner.endsWith(":*")) {
+        warnings.push(
+          `"${pattern}" may not match as expected — use ":*" suffix for prefix wildcards (e.g. "${toolName}(${inner.slice(0, -1)}:*)")`,
+        );
+      }
+    }
+  }
+
+  return { target, sessionId, all, fresh, force, allow, allowOnly, model, wait, timeout, error, warnings };
 }
 
 /** Extract issue number from branch name convention: feat/issue-N-slug, fix/issue-N-slug, etc. */
@@ -809,6 +846,8 @@ export async function claudeResume(args: string[], d: ClaudeDeps): Promise<void>
     d.printError(parsed.error);
     d.exit(1);
   }
+
+  for (const w of parsed.warnings) d.printError(`warning: ${w}`);
 
   const cwd = process.cwd();
 
@@ -926,6 +965,7 @@ async function resumeWorktree(
 
   const toolArgs: Record<string, unknown> = { cwd: wt.path };
   if (parsed.allow.length > 0) toolArgs.allowedTools = parsed.allow;
+  if (parsed.allowOnly) toolArgs.allowOnly = true;
   if (parsed.model) toolArgs.model = parsed.model;
   if (parsed.timeout) toolArgs.timeout = parsed.timeout;
   if (parsed.wait) toolArgs.wait = true;

--- a/packages/command/src/commands/spawn-args.spec.ts
+++ b/packages/command/src/commands/spawn-args.spec.ts
@@ -179,19 +179,17 @@ describe("parseSharedSpawnArgs", () => {
     expect(result.allow).toEqual(["Bash", "Write"]);
   });
 
-  // ── Mechanism B: dead pattern detection (#2074) ──
+  // ── Mechanism B: dead pattern detection (#2074) — dead patterns are errors ──
 
-  it("warns on Bash(*) dead pattern", () => {
+  it("errors on Bash(*) dead pattern", () => {
     const result = parseSharedSpawnArgs(["--allow", "Bash(*)", "--task", "x"]);
-    expect(result.warnings.length).toBe(1);
-    expect(result.warnings[0]).toContain("dead rule");
-    expect(result.warnings[0]).toContain('Use "Bash"');
+    expect(result.error).toContain("dead rule");
+    expect(result.error).toContain('Use "Bash"');
   });
 
-  it("warns on Write(*) dead pattern", () => {
+  it("errors on Write(*) dead pattern", () => {
     const result = parseSharedSpawnArgs(["--allow", "Write(*)", "--task", "x"]);
-    expect(result.warnings.length).toBe(1);
-    expect(result.warnings[0]).toContain("dead rule");
+    expect(result.error).toContain("dead rule");
   });
 
   it("warns on Bash(git*) missing colon wildcard", () => {
@@ -232,6 +230,18 @@ describe("parseSharedSpawnArgs", () => {
   it("errors on empty --allow-only", () => {
     const result = parseSharedSpawnArgs(["--allow-only", "--task", "x"]);
     expect(result.error).toBe("--allow-only requires at least one tool pattern");
+  });
+
+  // ── Mutual exclusivity (#2074) ──
+
+  it("errors when --allow and --allow-only both present", () => {
+    const result = parseSharedSpawnArgs(["--allow", "Read", "--allow-only", "Bash", "--task", "x"]);
+    expect(result.error).toBe("--allow and --allow-only are mutually exclusive");
+  });
+
+  it("errors when --allow-only then --allow both present", () => {
+    const result = parseSharedSpawnArgs(["--allow-only", "Bash", "--allow", "Read", "--task", "x"]);
+    expect(result.error).toBe("--allow and --allow-only are mutually exclusive");
   });
 });
 

--- a/packages/command/src/commands/spawn-args.spec.ts
+++ b/packages/command/src/commands/spawn-args.spec.ts
@@ -154,6 +154,85 @@ describe("parseSharedSpawnArgs", () => {
     const result = parseSharedSpawnArgs(["--allow", "mcp__echo__add", "Read", "--task", "x"]);
     expect(result.allow).toEqual(["mcp__echo__add", "Read"]);
   });
+
+  // ── Mechanism C: comma-separated patterns (#2074) ──
+
+  it("splits comma-separated --allow patterns into individual entries", () => {
+    const result = parseSharedSpawnArgs(["--allow", "Bash,Write,Read", "--task", "x"]);
+    expect(result.allow).toEqual(["Bash", "Write", "Read"]);
+  });
+
+  it("warns when comma-separated patterns are detected", () => {
+    const result = parseSharedSpawnArgs(["--allow", "Bash,Write", "--task", "x"]);
+    expect(result.warnings.length).toBe(1);
+    expect(result.warnings[0]).toContain("Comma-separated");
+    expect(result.warnings[0]).toContain("Bash,Write");
+  });
+
+  it("handles mixed comma and space-separated patterns", () => {
+    const result = parseSharedSpawnArgs(["--allow", "Read", "Bash,Write", "--task", "x"]);
+    expect(result.allow).toEqual(["Read", "Bash", "Write"]);
+  });
+
+  it("ignores empty segments in comma-separated patterns", () => {
+    const result = parseSharedSpawnArgs(["--allow", "Bash,,Write,", "--task", "x"]);
+    expect(result.allow).toEqual(["Bash", "Write"]);
+  });
+
+  // ── Mechanism B: dead pattern detection (#2074) ──
+
+  it("warns on Bash(*) dead pattern", () => {
+    const result = parseSharedSpawnArgs(["--allow", "Bash(*)", "--task", "x"]);
+    expect(result.warnings.length).toBe(1);
+    expect(result.warnings[0]).toContain("dead rule");
+    expect(result.warnings[0]).toContain('Use "Bash"');
+  });
+
+  it("warns on Write(*) dead pattern", () => {
+    const result = parseSharedSpawnArgs(["--allow", "Write(*)", "--task", "x"]);
+    expect(result.warnings.length).toBe(1);
+    expect(result.warnings[0]).toContain("dead rule");
+  });
+
+  it("warns on Bash(git*) missing colon wildcard", () => {
+    const result = parseSharedSpawnArgs(["--allow", "Bash(git*)", "--task", "x"]);
+    expect(result.warnings.length).toBe(1);
+    expect(result.warnings[0]).toContain("may not match");
+    expect(result.warnings[0]).toContain(":*");
+  });
+
+  it("does not warn on valid Bash(git:*) pattern", () => {
+    const result = parseSharedSpawnArgs(["--allow", "Bash(git:*)", "--task", "x"]);
+    expect(result.warnings.length).toBe(0);
+  });
+
+  it("does not warn on bare tool name", () => {
+    const result = parseSharedSpawnArgs(["--allow", "Bash", "--task", "x"]);
+    expect(result.warnings.length).toBe(0);
+  });
+
+  it("does not warn on exact command pattern", () => {
+    const result = parseSharedSpawnArgs(["--allow", "Bash(bun test)", "--task", "x"]);
+    expect(result.warnings.length).toBe(0);
+  });
+
+  // ── --allow-only (#2074) ──
+
+  it("sets allowOnly=false by default", () => {
+    const result = parseSharedSpawnArgs(["--allow", "Bash", "--task", "x"]);
+    expect(result.allowOnly).toBe(false);
+  });
+
+  it("sets allowOnly=true with --allow-only flag", () => {
+    const result = parseSharedSpawnArgs(["--allow-only", "Bash", "--task", "x"]);
+    expect(result.allowOnly).toBe(true);
+    expect(result.allow).toEqual(["Bash"]);
+  });
+
+  it("errors on empty --allow-only", () => {
+    const result = parseSharedSpawnArgs(["--allow-only", "--task", "x"]);
+    expect(result.error).toBe("--allow-only requires at least one tool pattern");
+  });
 });
 
 describe("looksLikeToolName", () => {

--- a/packages/command/src/commands/spawn-args.ts
+++ b/packages/command/src/commands/spawn-args.ts
@@ -29,11 +29,15 @@ export function looksLikeToolName(s: string): boolean {
 export interface SharedSpawnArgs {
   task: string | undefined;
   allow: string[];
+  /** When true, --allow replaces DEFAULT_SAFE_TOOLS instead of extending them. */
+  allowOnly: boolean;
   cwd: string | undefined;
   timeout: number | undefined;
   model: string | undefined;
   wait: boolean;
   error: string | undefined;
+  /** Non-fatal warnings (footgun patterns detected in --allow). */
+  warnings: string[];
 }
 
 /**
@@ -49,10 +53,12 @@ export function parseSharedSpawnArgs(
   extra?: (arg: string, allArgs: string[], index: number) => number | undefined,
 ): SharedSpawnArgs {
   const allow: string[] = [];
+  let allowOnly = false;
   let allowError: string | undefined;
+  const warnings: string[] = [];
   const remaining: string[] = [];
 
-  // Phase 1: extract --allow (greedy looksLikeToolName) and handle extra callback
+  // Phase 1: extract --allow/--allow-only (greedy looksLikeToolName) and handle extra callback
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
 
@@ -65,14 +71,45 @@ export function parseSharedSpawnArgs(
       }
     }
 
-    if (arg === "--allow") {
+    if (arg === "--allow" || arg === "--allow-only") {
+      if (arg === "--allow-only") allowOnly = true;
       // dotw-ignore no-manual-arg-parsing: greedy multi-value consume with looksLikeToolName heuristic cannot be expressed in parseFlags
       while (i + 1 < args.length && looksLikeToolName(args[i + 1])) {
-        allow.push(args[++i]); // dotw-ignore no-manual-arg-parsing: greedy multi-value loop
+        const raw = args[++i]; // dotw-ignore no-manual-arg-parsing: greedy multi-value loop
+        // Mechanism C: split comma-separated patterns (e.g. "Bash,Write" → ["Bash", "Write"])
+        if (raw.includes(",")) {
+          warnings.push(
+            `Comma-separated --allow pattern "${raw}" was split into ${raw.split(",").length} patterns — use spaces instead`,
+          );
+          for (const part of raw.split(",")) {
+            const trimmed = part.trim();
+            if (trimmed) allow.push(trimmed);
+          }
+        } else {
+          allow.push(raw);
+        }
       }
-      if (allow.length === 0) allowError = "--allow requires at least one tool pattern";
+      if (allow.length === 0) allowError = `${arg} requires at least one tool pattern`;
     } else {
       remaining.push(arg);
+    }
+  }
+
+  // Mechanism B: detect Tool(*) dead patterns — bare * inside parens is never a wildcard
+  for (const pattern of allow) {
+    const parenMatch = pattern.match(/^(\w+)\((.+)\)$/);
+    if (parenMatch) {
+      const argPattern = parenMatch[1];
+      const inner = parenMatch[2];
+      if (inner === "*") {
+        warnings.push(
+          `"${pattern}" is a dead rule — bare (*) is not a wildcard. Use "${argPattern}" (no parens) to allow all ${argPattern} calls, or "${argPattern}(:*)" for prefix matching`,
+        );
+      } else if (inner.endsWith("*") && !inner.endsWith(":*")) {
+        warnings.push(
+          `"${pattern}" may not match as expected — use ":*" suffix for prefix wildcards (e.g. "${argPattern}(${inner.slice(0, -1)}:*)")`,
+        );
+      }
     }
   }
 
@@ -139,5 +176,5 @@ export function parseSharedSpawnArgs(
   const task = (flags.task as string | undefined) ?? positionals.find((p) => p !== "-") ?? undefined;
   const wait = (flags.wait as boolean | undefined) ?? false;
 
-  return { task, allow, cwd, timeout, model, wait, error };
+  return { task, allow, allowOnly, cwd, timeout, model, wait, error, warnings };
 }

--- a/packages/command/src/commands/spawn-args.ts
+++ b/packages/command/src/commands/spawn-args.ts
@@ -1,30 +1,15 @@
 /**
  * Shared spawn argument parsing for `mcx claude spawn` and `mcx codex spawn`.
  *
- * Common flags: --task/-t, --allow, --cwd, --timeout, --model/-m, --wait
+ * Common flags: --task/-t, --allow, --allow-only, --cwd, --timeout, --model/-m, --wait
  * Provider-specific flags are handled by callers via the `extra` hook.
  */
 
 import { resolve } from "node:path";
-import { resolveModelName } from "@mcp-cli/core";
+import { looksLikeToolName, resolveModelName, validateAllowPatterns } from "@mcp-cli/core";
 import { parseFlags } from "../flags";
 
-/**
- * Heuristic: does a string look like a tool name / pattern for --allow?
- * Tool names are PascalCase (Read, WebSearch), MCP-style (mcp__echo__add),
- * or contain wildcards (*). Worktree names and session IDs are typically
- * lowercase-kebab or hex strings.
- */
-export function looksLikeToolName(s: string): boolean {
-  if (s.startsWith("-")) return false;
-  // Wildcards are always tool patterns
-  if (s.includes("*")) return true;
-  // MCP-style tool names
-  if (s.startsWith("mcp_")) return true;
-  // PascalCase: starts with uppercase letter
-  if (/^[A-Z]/.test(s)) return true;
-  return false;
-}
+export { looksLikeToolName } from "@mcp-cli/core";
 
 export interface SharedSpawnArgs {
   task: string | undefined;
@@ -52,10 +37,11 @@ export function parseSharedSpawnArgs(
   args: string[],
   extra?: (arg: string, allArgs: string[], index: number) => number | undefined,
 ): SharedSpawnArgs {
-  const allow: string[] = [];
+  const rawAllow: string[] = [];
   let allowOnly = false;
+  let sawAllow = false;
+  let sawAllowOnly = false;
   let allowError: string | undefined;
-  const warnings: string[] = [];
   const remaining: string[] = [];
 
   // Phase 1: extract --allow/--allow-only (greedy looksLikeToolName) and handle extra callback
@@ -72,45 +58,34 @@ export function parseSharedSpawnArgs(
     }
 
     if (arg === "--allow" || arg === "--allow-only") {
-      if (arg === "--allow-only") allowOnly = true;
+      if (arg === "--allow") sawAllow = true;
+      if (arg === "--allow-only") {
+        sawAllowOnly = true;
+        allowOnly = true;
+      }
       // dotw-ignore no-manual-arg-parsing: greedy multi-value consume with looksLikeToolName heuristic cannot be expressed in parseFlags
       while (i + 1 < args.length && looksLikeToolName(args[i + 1])) {
-        const raw = args[++i]; // dotw-ignore no-manual-arg-parsing: greedy multi-value loop
-        // Mechanism C: split comma-separated patterns (e.g. "Bash,Write" → ["Bash", "Write"])
-        if (raw.includes(",")) {
-          warnings.push(
-            `Comma-separated --allow pattern "${raw}" was split into ${raw.split(",").length} patterns — use spaces instead`,
-          );
-          for (const part of raw.split(",")) {
-            const trimmed = part.trim();
-            if (trimmed) allow.push(trimmed);
-          }
-        } else {
-          allow.push(raw);
-        }
+        rawAllow.push(args[++i]); // dotw-ignore no-manual-arg-parsing: greedy multi-value loop
       }
-      if (allow.length === 0) allowError = `${arg} requires at least one tool pattern`;
+      if (rawAllow.length === 0) allowError = `${arg} requires at least one tool pattern`;
     } else {
       remaining.push(arg);
     }
   }
 
-  // Mechanism B: detect Tool(*) dead patterns — bare * inside parens is never a wildcard
-  for (const pattern of allow) {
-    const parenMatch = pattern.match(/^(\w+)\((.+)\)$/);
-    if (parenMatch) {
-      const argPattern = parenMatch[1];
-      const inner = parenMatch[2];
-      if (inner === "*") {
-        warnings.push(
-          `"${pattern}" is a dead rule — bare (*) is not a wildcard. Use "${argPattern}" (no parens) to allow all ${argPattern} calls, or "${argPattern}(:*)" for prefix matching`,
-        );
-      } else if (inner.endsWith("*") && !inner.endsWith(":*")) {
-        warnings.push(
-          `"${pattern}" may not match as expected — use ":*" suffix for prefix wildcards (e.g. "${argPattern}(${inner.slice(0, -1)}:*)")`,
-        );
-      }
-    }
+  // Mutual exclusivity
+  if (sawAllow && sawAllowOnly) {
+    allowError ??= "--allow and --allow-only are mutually exclusive";
+  }
+
+  // Validate: comma-split + dead-pattern detection via shared module
+  const validation = validateAllowPatterns(rawAllow);
+  const allow = validation.patterns;
+  const warnings = [...validation.warnings];
+
+  // Dead patterns are errors
+  if (validation.errors.length > 0) {
+    allowError ??= validation.errors[0];
   }
 
   // Phase 2: parseFlags for standard flags

--- a/packages/core/src/agent-tools.ts
+++ b/packages/core/src/agent-tools.ts
@@ -192,7 +192,15 @@ export function buildAgentTools(opts: BuildAgentToolsOptions): readonly AgentToo
             allowedTools: {
               type: "array",
               items: { type: "string" },
-              description: "Tool patterns to auto-approve (e.g. 'Bash(git *)', 'Read')",
+              description:
+                "Tool patterns to auto-approve (e.g. 'Bash(git:*)', 'Read'). " +
+                "Added to DEFAULT_SAFE_TOOLS by default; set allowOnly=true to replace them instead.",
+            },
+            allowOnly: {
+              type: "boolean",
+              description:
+                "When true, allowedTools replaces DEFAULT_SAFE_TOOLS instead of extending them. " +
+                "Use for locked-down sessions that should only have the explicitly listed tools.",
             },
             worktree: { type: "string", description: "Git worktree name for isolation" },
             name: {

--- a/packages/core/src/allow-patterns.spec.ts
+++ b/packages/core/src/allow-patterns.spec.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_SAFE_TOOLS, looksLikeToolName, resolveEffectiveTools, validateAllowPatterns } from "./allow-patterns";
+
+// ── DEFAULT_SAFE_TOOLS ──
+
+describe("DEFAULT_SAFE_TOOLS", () => {
+  test("contains the expected safe tools", () => {
+    expect(DEFAULT_SAFE_TOOLS).toEqual(["Read", "Glob", "Grep", "Write", "Edit"]);
+  });
+
+  test("is frozen", () => {
+    expect(Object.isFrozen(DEFAULT_SAFE_TOOLS)).toBe(true);
+  });
+});
+
+// ── looksLikeToolName ──
+
+describe("looksLikeToolName", () => {
+  test("accepts PascalCase names", () => {
+    expect(looksLikeToolName("Read")).toBe(true);
+    expect(looksLikeToolName("WebSearch")).toBe(true);
+  });
+
+  test("accepts wildcards", () => {
+    expect(looksLikeToolName("*")).toBe(true);
+    expect(looksLikeToolName("Bash*")).toBe(true);
+  });
+
+  test("accepts mcp-style names", () => {
+    expect(looksLikeToolName("mcp__echo__add")).toBe(true);
+  });
+
+  test("rejects lowercase identifiers", () => {
+    expect(looksLikeToolName("my-worktree")).toBe(false);
+    expect(looksLikeToolName("codex-wt1")).toBe(false);
+  });
+
+  test("rejects flags", () => {
+    expect(looksLikeToolName("--task")).toBe(false);
+    expect(looksLikeToolName("-t")).toBe(false);
+  });
+});
+
+// ── validateAllowPatterns ──
+
+describe("validateAllowPatterns", () => {
+  test("passes through simple patterns", () => {
+    const result = validateAllowPatterns(["Read", "Bash"]);
+    expect(result.patterns).toEqual(["Read", "Bash"]);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("splits comma-separated patterns", () => {
+    const result = validateAllowPatterns(["Bash,Write,Read"]);
+    expect(result.patterns).toEqual(["Bash", "Write", "Read"]);
+  });
+
+  test("warns on comma-separated patterns", () => {
+    const result = validateAllowPatterns(["Bash,Write"]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("Comma-separated");
+  });
+
+  test("handles mixed comma and individual patterns", () => {
+    const result = validateAllowPatterns(["Read", "Bash,Write"]);
+    expect(result.patterns).toEqual(["Read", "Bash", "Write"]);
+  });
+
+  test("ignores empty segments in comma-separated patterns", () => {
+    const result = validateAllowPatterns(["Bash,,Write,"]);
+    expect(result.patterns).toEqual(["Bash", "Write"]);
+  });
+
+  test("errors on Bash(*) dead pattern", () => {
+    const result = validateAllowPatterns(["Bash(*)"]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("dead rule");
+    expect(result.errors[0]).toContain('Use "Bash"');
+  });
+
+  test("errors on Write(*) dead pattern", () => {
+    const result = validateAllowPatterns(["Write(*)"]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain("dead rule");
+  });
+
+  test("warns on Bash(git*) missing colon wildcard", () => {
+    const result = validateAllowPatterns(["Bash(git*)"]);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("may not match");
+    expect(result.warnings[0]).toContain(":*");
+  });
+
+  test("no warning on valid Bash(git:*) pattern", () => {
+    const result = validateAllowPatterns(["Bash(git:*)"]);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("no warning on bare tool name", () => {
+    const result = validateAllowPatterns(["Bash"]);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("no warning on exact command pattern", () => {
+    const result = validateAllowPatterns(["Bash(bun test)"]);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("detects multiple dead patterns", () => {
+    const result = validateAllowPatterns(["Bash(*)", "Write(*)"]);
+    expect(result.errors).toHaveLength(2);
+  });
+});
+
+// ── resolveEffectiveTools ──
+
+describe("resolveEffectiveTools", () => {
+  test("returns undefined when permissionMode is not rules", () => {
+    const result = resolveEffectiveTools({ permissionMode: "auto" });
+    expect(result.tools).toBeUndefined();
+    expect(result.error).toBeUndefined();
+  });
+
+  test("returns DEFAULT_SAFE_TOOLS when no allowedTools", () => {
+    const result = resolveEffectiveTools({ permissionMode: "rules" });
+    expect(result.tools).toEqual([...DEFAULT_SAFE_TOOLS]);
+  });
+
+  test("unions allowedTools with DEFAULT_SAFE_TOOLS by default", () => {
+    const result = resolveEffectiveTools({
+      allowedTools: ["Bash"],
+      permissionMode: "rules",
+    });
+    expect(result.tools).toContain("Bash");
+    expect(result.tools).toContain("Read");
+    expect(result.tools).toContain("Write");
+  });
+
+  test("deduplicates when allowedTools overlaps defaults", () => {
+    const result = resolveEffectiveTools({
+      allowedTools: ["Read", "Bash"],
+      permissionMode: "rules",
+    });
+    const readCount = result.tools?.filter((t) => t === "Read").length;
+    expect(readCount).toBe(1);
+  });
+
+  test("allowOnly=true uses exactly the provided tools", () => {
+    const result = resolveEffectiveTools({
+      allowedTools: ["Bash"],
+      allowOnly: true,
+      permissionMode: "rules",
+    });
+    expect(result.tools).toEqual(["Bash"]);
+    expect(result.error).toBeUndefined();
+  });
+
+  test("allowOnly=true with no allowedTools returns error", () => {
+    const result = resolveEffectiveTools({
+      allowOnly: true,
+      permissionMode: "rules",
+    });
+    expect(result.error).toBeDefined();
+    expect(result.tools).toEqual([]);
+  });
+
+  test("allowOnly=true with empty allowedTools returns error", () => {
+    const result = resolveEffectiveTools({
+      allowedTools: [],
+      allowOnly: true,
+      permissionMode: "rules",
+    });
+    expect(result.error).toBeDefined();
+    expect(result.tools).toEqual([]);
+  });
+
+  test("defaults permissionMode to rules", () => {
+    const result = resolveEffectiveTools({});
+    expect(result.tools).toEqual([...DEFAULT_SAFE_TOOLS]);
+  });
+});

--- a/packages/core/src/allow-patterns.ts
+++ b/packages/core/src/allow-patterns.ts
@@ -1,0 +1,127 @@
+/**
+ * Unified permission-pattern resolution for --allow / --allow-only.
+ *
+ * Single source of truth consumed by CLI parsers (spawn, claude resume,
+ * agent resume) and the session worker. Covers:
+ *   1. Comma-split normalization
+ *   2. Dead-pattern detection (errors, not warnings)
+ *   3. DEFAULT_SAFE_TOOLS union / allow-only semantics
+ *   4. Mutual-exclusivity of --allow vs --allow-only
+ */
+
+// ── Defaults ──
+
+export const DEFAULT_SAFE_TOOLS: readonly string[] = Object.freeze(["Read", "Glob", "Grep", "Write", "Edit"]);
+
+// ── Heuristic ──
+
+/**
+ * Does a string look like a tool name / pattern for --allow?
+ * Tool names are PascalCase (Read, WebSearch), MCP-style (mcp__echo__add),
+ * or contain wildcards (*). Worktree names and session IDs are typically
+ * lowercase-kebab or hex strings.
+ */
+export function looksLikeToolName(s: string): boolean {
+  if (s.startsWith("-")) return false;
+  if (s.includes("*")) return true;
+  if (s.startsWith("mcp_")) return true;
+  if (/^[A-Z]/.test(s)) return true;
+  return false;
+}
+
+// ── Validation ──
+
+export interface AllowValidation {
+  patterns: string[];
+  errors: string[];
+  warnings: string[];
+}
+
+/**
+ * Normalize and validate raw --allow values.
+ *
+ * - Splits comma-separated entries ("Bash,Write" → ["Bash", "Write"]) with a warning
+ * - Detects dead patterns like Bash(*) — these are ERRORS because a permission
+ *   rule that matches nothing is a misconfiguration, not a footgun to warn about
+ * - Detects missing :* suffix in prefix wildcards
+ */
+export function validateAllowPatterns(rawValues: string[]): AllowValidation {
+  const patterns: string[] = [];
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  for (const raw of rawValues) {
+    if (raw.includes(",")) {
+      warnings.push(
+        `Comma-separated --allow pattern "${raw}" was split into ${raw.split(",").length} patterns — use spaces instead`,
+      );
+      for (const part of raw.split(",")) {
+        const trimmed = part.trim();
+        if (trimmed) patterns.push(trimmed);
+      }
+    } else {
+      patterns.push(raw);
+    }
+  }
+
+  for (const pattern of patterns) {
+    const parenMatch = pattern.match(/^(\w+)\((.+)\)$/);
+    if (parenMatch) {
+      const toolName = parenMatch[1];
+      const inner = parenMatch[2];
+      if (inner === "*") {
+        errors.push(
+          `"${pattern}" is a dead rule — bare (*) is not a wildcard. Use "${toolName}" (no parens) to allow all ${toolName} calls, or "${toolName}(:*)" for prefix matching`,
+        );
+      } else if (inner.endsWith("*") && !inner.endsWith(":*")) {
+        warnings.push(
+          `"${pattern}" may not match as expected — use ":*" suffix for prefix wildcards (e.g. "${toolName}(${inner.slice(0, -1)}:*)")`,
+        );
+      }
+    }
+  }
+
+  return { patterns, errors, warnings };
+}
+
+// ── Resolution ──
+
+export interface ResolveEffectiveToolsOpts {
+  allowedTools?: string[];
+  allowOnly?: boolean;
+  permissionMode?: string;
+}
+
+/**
+ * Compute the final resolved tool set for a session.
+ *
+ * - permissionMode !== "rules" → undefined (no tool restrictions)
+ * - allowOnly + no allowedTools → error (empty string[] returned, caller should reject)
+ * - allowOnly + allowedTools → exactly those tools (no defaults)
+ * - allowedTools without allowOnly → union with DEFAULT_SAFE_TOOLS
+ * - no allowedTools → DEFAULT_SAFE_TOOLS
+ */
+export function resolveEffectiveTools(opts: ResolveEffectiveToolsOpts): {
+  tools: string[] | undefined;
+  error?: string;
+} {
+  const { allowedTools, allowOnly = false, permissionMode = "rules" } = opts;
+
+  if (permissionMode !== "rules") return { tools: undefined };
+
+  if (allowOnly) {
+    if (!allowedTools || allowedTools.length === 0) {
+      return {
+        tools: [],
+        error: "allowOnly requires at least one tool in allowedTools",
+      };
+    }
+    return { tools: [...allowedTools] };
+  }
+
+  if (allowedTools && allowedTools.length > 0) {
+    return { tools: [...new Set([...DEFAULT_SAFE_TOOLS, ...allowedTools])] };
+  }
+
+  return { tools: [...DEFAULT_SAFE_TOOLS] };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export * from "./alias";
 export * from "./alias-dry-run";
 export * from "./alias-state";
 export * from "./alias-bundle";
+export * from "./allow-patterns";
 export * from "./cache";
 export * from "./ipc";
 export * from "./ipc-client";

--- a/packages/daemon/src/__snapshots__/opencode-server.spec.ts.snap
+++ b/packages/daemon/src/__snapshots__/opencode-server.spec.ts.snap
@@ -6,8 +6,12 @@ exports[`OPENCODE_TOOLS schema snapshot 1`] = `
     "description": "Start a new OpenCode agent session with a prompt, or send a follow-up prompt to an existing session. OpenCode is provider-agnostic: it wraps any LLM (Grok, Gemini, Bedrock, open-source) in a coding agent harness. Returns the session ID immediately by default. Set wait=true to block until the next actionable event (result, error, permission request, or ended).",
     "inputSchema": {
       "properties": {
+        "allowOnly": {
+          "description": "When true, allowedTools replaces DEFAULT_SAFE_TOOLS instead of extending them. Use for locked-down sessions that should only have the explicitly listed tools.",
+          "type": "boolean",
+        },
         "allowedTools": {
-          "description": "Tool patterns to auto-approve (e.g. 'Bash(git *)', 'Read')",
+          "description": "Tool patterns to auto-approve (e.g. 'Bash(git:*)', 'Read'). Added to DEFAULT_SAFE_TOOLS by default; set allowOnly=true to replace them instead.",
           "items": {
             "type": "string",
           },

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -20,6 +20,7 @@ import {
   type LiveSpan,
   type SessionInfo,
   type WorkItemEvent,
+  resolveEffectiveTools,
   resolveModelName,
   silentLogger,
   startSpan,
@@ -27,7 +28,7 @@ import {
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { isResolved, resolveClaudeForSpawn } from "./claude-session/binary-resolver";
-import { DEFAULT_SAFE_TOOLS, type PermissionRule, type PermissionStrategy } from "./claude-session/permission-router";
+import type { PermissionRule, PermissionStrategy } from "./claude-session/permission-router";
 import type { SessionEvent } from "./claude-session/session-state";
 import { CLAUDE_TOOLS } from "./claude-session/tools";
 import {
@@ -209,14 +210,19 @@ export async function handlePrompt(
     const permissionMode = (args.permissionMode as PermissionStrategy) ?? "rules";
     const allowedTools = (args.allowedTools as string[]) ?? undefined;
     const allowOnly = (args.allowOnly as boolean) ?? false;
-    const effectiveTools =
-      permissionMode === "rules"
-        ? allowedTools
-          ? allowOnly
-            ? allowedTools
-            : [...new Set([...DEFAULT_SAFE_TOOLS, ...allowedTools])]
-          : [...DEFAULT_SAFE_TOOLS]
-        : undefined;
+
+    const resolved = resolveEffectiveTools({
+      allowedTools,
+      allowOnly,
+      permissionMode,
+    });
+    if (resolved.error) {
+      return {
+        content: [{ type: "text", text: `Error: ${resolved.error}` }],
+        isError: true,
+      };
+    }
+    const effectiveTools = resolved.tools;
     const rules: PermissionRule[] | undefined = effectiveTools
       ? effectiveTools.map((tool) => ({ tool, action: "allow" as const }))
       : undefined;
@@ -229,7 +235,7 @@ export async function handlePrompt(
         cwd: args.cwd as string | undefined,
         permissionStrategy: permissionMode,
         permissionRules: rules,
-        allowedTools,
+        allowedTools: effectiveTools,
         worktree: args.worktree as string | undefined,
         model: args.model ? resolveModelName(args.model as string) : undefined,
         resumeSessionId: args.resumeSessionId as string | undefined,

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -208,7 +208,15 @@ export async function handlePrompt(
     sessionId = crypto.randomUUID();
     const permissionMode = (args.permissionMode as PermissionStrategy) ?? "rules";
     const allowedTools = (args.allowedTools as string[]) ?? undefined;
-    const effectiveTools = permissionMode === "rules" ? (allowedTools ?? DEFAULT_SAFE_TOOLS) : undefined;
+    const allowOnly = (args.allowOnly as boolean) ?? false;
+    const effectiveTools =
+      permissionMode === "rules"
+        ? allowedTools
+          ? allowOnly
+            ? allowedTools
+            : [...new Set([...DEFAULT_SAFE_TOOLS, ...allowedTools])]
+          : [...DEFAULT_SAFE_TOOLS]
+        : undefined;
     const rules: PermissionRule[] | undefined = effectiveTools
       ? effectiveTools.map((tool) => ({ tool, action: "allow" as const }))
       : undefined;

--- a/packages/daemon/src/claude-session/permission-router.ts
+++ b/packages/daemon/src/claude-session/permission-router.ts
@@ -29,11 +29,7 @@ export type DelegateCallback = (request: CanUseToolRequest) => Promise<RouterDec
 
 // ── Defaults ──
 
-/**
- * Safe tools allowed by default when no explicit --allow is provided.
- * Permits file read/write but blocks shell execution and network access.
- */
-export const DEFAULT_SAFE_TOOLS: readonly string[] = Object.freeze(["Read", "Glob", "Grep", "Write", "Edit"]);
+export { DEFAULT_SAFE_TOOLS } from "@mcp-cli/core";
 
 // ── Router ──
 


### PR DESCRIPTION
## Summary

Holistic refactoring of `--allow` permission logic per adversarial review feedback. Replaces the fragmented implementation (triplicated across spawn-args, claude resume, agent resume with drifting heuristics) with a **single shared module** (`packages/core/src/allow-patterns.ts`).

### What changed
- **Unified module**: `validateAllowPatterns()` handles comma-split + dead-pattern detection; `resolveEffectiveTools()` handles DEFAULT_SAFE_TOOLS union + allow-only semantics
- **Dead patterns are errors**: `Bash(*)` etc. now produce parse errors, not warnings — a permission rule that matches nothing is a misconfiguration
- **Mutual exclusivity**: `--allow` and `--allow-only` in the same invocation produce an error
- **API-level validation**: `allowOnly=true` with no/empty `allowedTools` is rejected by the worker (was silently falling through to DEFAULT_SAFE_TOOLS)
- **SessionConfig stores resolved tools**: CLI subprocess `--allowedTools` now matches the WS permission router (eliminates permission round-trip regression)
- **buildHeadedCommand fixed**: Headed sessions now resolve tools correctly for both additive and allow-only modes
- **permission-router.ts**: `DEFAULT_SAFE_TOOLS` canonical definition moved to core; daemon re-exports for backward compat

### Files changed
| File | Change |
|------|--------|
| `packages/core/src/allow-patterns.ts` | **NEW** — shared module (looksLikeToolName, validateAllowPatterns, resolveEffectiveTools, DEFAULT_SAFE_TOOLS) |
| `packages/core/src/allow-patterns.spec.ts` | **NEW** — 27 tests for shared module |
| `packages/command/src/commands/spawn-args.ts` | Delegates to shared module, adds mutual exclusivity |
| `packages/command/src/commands/claude.ts` | Resume parser + buildHeadedCommand use shared module |
| `packages/command/src/commands/agent.ts` | Resume parser uses shared module |
| `packages/daemon/src/claude-session-worker.ts` | Uses `resolveEffectiveTools()`, stores resolved set in config |
| `packages/daemon/src/claude-session/permission-router.ts` | Re-exports DEFAULT_SAFE_TOOLS from core |
| `*.spec.ts` | Tests updated: dead patterns = errors, new resume/mutual-exclusivity/headed tests |

## Test plan
- [x] `allow-patterns.spec.ts`: 27 tests (DEFAULT_SAFE_TOOLS, looksLikeToolName, validateAllowPatterns, resolveEffectiveTools)
- [x] `spawn-args.spec.ts`: dead patterns now error, mutual exclusivity tests
- [x] `claude.spec.ts`: resume comma-split, dead patterns, --allow-only, mutual exclusivity, buildHeadedCommand additive/allow-only
- [x] `agent.spec.ts`: resume comma-split, dead patterns, --allow-only, mutual exclusivity
- [x] `bun run am-i-done` passes (7243 tests, worker crashes are pre-existing Bun infra)

Fixes #2074

🤖 Generated with [Claude Code](https://claude.com/claude-code)