### PR TITLE
fix(auth): guard concurrent auth flows for the same server (fixes #1624)

### DIFF
--- a/packages/daemon/src/auth/oauth-retry.spec.ts
+++ b/packages/daemon/src/auth/oauth-retry.spec.ts
@@ -7,7 +7,7 @@ import { metrics } from "../metrics";
 import { OAuthCallbackTimeoutError } from "./callback-server";
 import type { CallbackServer } from "./callback-server";
 import type { KeychainTokens } from "./keychain";
-import { runOAuthFlowWithDcrRetry } from "./oauth-retry";
+import { AuthFlowInProgressError, _resetActiveAuthFlows, runOAuthFlowWithDcrRetry } from "./oauth-retry";
 
 function tmpDb(): string {
   return join(tmpdir(), `mcp-cli-retry-test-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
@@ -333,6 +333,134 @@ describe("runOAuthFlowWithDcrRetry", () => {
     expect(authCallCount).toBe(2);
     // Client info untouched
     expect(db.getClientInfo(SERVER)?.client_id).toBe("live-client");
+    db.close();
+  });
+});
+
+// -- Per-server concurrency guard (#1624) --
+
+describe("per-server auth concurrency guard", () => {
+  const dbPaths: string[] = [];
+
+  function createDb(): StateDb {
+    const p = tmpDb();
+    dbPaths.push(p);
+    return new StateDb(p);
+  }
+
+  afterEach(() => {
+    _resetActiveAuthFlows();
+    for (const p of dbPaths) cleanup(p);
+    dbPaths.length = 0;
+  });
+
+  test("rejects concurrent auth for the same server with AuthFlowInProgressError", async () => {
+    const db = createDb();
+    let resolveFirstFlow!: (code: string) => void;
+    const firstFlowCode = new Promise<string>((r) => {
+      resolveFirstFlow = r;
+    });
+
+    const first = runOAuthFlowWithDcrRetry(
+      SERVER,
+      SERVER_URL,
+      db,
+      {},
+      {
+        authFn: async (_provider, opts) => (opts.authorizationCode ? "AUTHORIZED" : "REDIRECT"),
+        startCallbackServer: () => makeCallback(firstFlowCode),
+      },
+    );
+
+    // Second call for the same server while first is in progress
+    await expect(
+      runOAuthFlowWithDcrRetry(
+        SERVER,
+        SERVER_URL,
+        db,
+        {},
+        {
+          authFn: async () => "AUTHORIZED",
+          startCallbackServer: () => makeCallback(Promise.resolve("code")),
+        },
+      ),
+    ).rejects.toBeInstanceOf(AuthFlowInProgressError);
+
+    // Complete the first flow
+    resolveFirstFlow("code-abc");
+    const result = await first;
+    expect(result).toBe("authenticated");
+    db.close();
+  });
+
+  test("allows concurrent auth for different servers", async () => {
+    const db = createDb();
+    let resolveA!: (code: string) => void;
+    const codeA = new Promise<string>((r) => {
+      resolveA = r;
+    });
+
+    const flowA = runOAuthFlowWithDcrRetry(
+      "server-a",
+      SERVER_URL,
+      db,
+      {},
+      {
+        authFn: async (_provider, opts) => (opts.authorizationCode ? "AUTHORIZED" : "REDIRECT"),
+        startCallbackServer: () => makeCallback(codeA),
+      },
+    );
+
+    // Different server — should not be blocked
+    const flowB = runOAuthFlowWithDcrRetry(
+      "server-b",
+      SERVER_URL,
+      db,
+      {},
+      {
+        authFn: async (_provider, opts) => (opts.authorizationCode ? "AUTHORIZED" : "REDIRECT"),
+        startCallbackServer: () => makeCallback(Promise.resolve("code-b")),
+      },
+    );
+
+    const resultB = await flowB;
+    expect(resultB).toBe("authenticated");
+
+    resolveA("code-a");
+    const resultA = await flowA;
+    expect(resultA).toBe("authenticated");
+    db.close();
+  });
+
+  test("guard is released after flow failure, allowing retry", async () => {
+    const db = createDb();
+
+    // First flow fails
+    await expect(
+      runOAuthFlowWithDcrRetry(
+        SERVER,
+        SERVER_URL,
+        db,
+        {},
+        {
+          authFn: async () => "REDIRECT",
+          startCallbackServer: () => makeCallback(Promise.reject(new Error("provider error"))),
+        },
+      ),
+    ).rejects.toThrow("provider error");
+
+    // Second flow for same server should succeed (guard released)
+    const result = await runOAuthFlowWithDcrRetry(
+      SERVER,
+      SERVER_URL,
+      db,
+      {},
+      {
+        authFn: async (_provider, opts) => (opts.authorizationCode ? "AUTHORIZED" : "REDIRECT"),
+        startCallbackServer: () => makeCallback(Promise.resolve("code-retry")),
+      },
+    );
+    expect(result).toBe("authenticated");
     db.close();
   });
 });

--- a/packages/daemon/src/auth/oauth-retry.ts
+++ b/packages/daemon/src/auth/oauth-retry.ts
@@ -15,6 +15,21 @@ import { metrics } from "../metrics";
 import { type CallbackServer, OAuthCallbackTimeoutError, startCallbackServer } from "./callback-server";
 import { DEFAULT_OAUTH_SCOPE, McpOAuthProvider, type OAuthProviderOpts } from "./oauth-provider";
 
+/** Tracks servers with an in-progress auth flow (intra-process async guard). */
+const activeAuthFlows = new Set<string>();
+
+export class AuthFlowInProgressError extends Error {
+  constructor(server: string) {
+    super(`Another auth flow is already in progress for server "${server}" — wait for it to complete or cancel it`);
+    this.name = "AuthFlowInProgressError";
+  }
+}
+
+/** @internal Reset for test isolation. */
+export function _resetActiveAuthFlows(): void {
+  activeAuthFlows.clear();
+}
+
 export interface OAuthRetryDeps {
   authFn?: (
     provider: OAuthClientProvider,
@@ -32,6 +47,24 @@ export interface OAuthRetryDeps {
  * valid, or "authenticated" after a successful code exchange.
  */
 export async function runOAuthFlowWithDcrRetry(
+  server: string,
+  serverUrl: string,
+  db: StateDb,
+  opts: Pick<OAuthProviderOpts, "clientId" | "clientSecret" | "callbackPort" | "scope" | "readKeychain">,
+  deps?: OAuthRetryDeps,
+): Promise<"already_authorized" | "authenticated"> {
+  if (activeAuthFlows.has(server)) {
+    throw new AuthFlowInProgressError(server);
+  }
+  activeAuthFlows.add(server);
+  try {
+    return await _runFlow(server, serverUrl, db, opts, deps);
+  } finally {
+    activeAuthFlows.delete(server);
+  }
+}
+
+async function _runFlow(
   server: string,
   serverUrl: string,
   db: StateDb,


### PR DESCRIPTION
## Summary
- Adds an in-memory per-server concurrency guard in `runOAuthFlowWithDcrRetry` that throws `AuthFlowInProgressError` when a second auth flow starts for the same server while one is already in progress
- Different servers can auth concurrently — the guard is per server name, not global
- File locks (`flock(2)`) are not viable here because all concurrent calls share the same daemon process — flock is per-process, not per-coroutine

## Test plan
- [x] New test: concurrent auth for same server rejects with `AuthFlowInProgressError`
- [x] New test: concurrent auth for different servers proceeds normally
- [x] New test: guard is released after flow failure, allowing retry
- [x] All 15 existing oauth-retry tests pass (no regressions)
- [x] `bun run am-i-done` passes (pre-existing ci-steps.spec.ts failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)