### PR TITLE
chore(skill): fold harvest-rules into /rule-author (closes #2350)

### DIFF
--- a/.claude/skills/bootstrap-sprint/references/iteration.md
+++ b/.claude/skills/bootstrap-sprint/references/iteration.md
@@ -101,7 +101,7 @@ in the skill files and fix them.
 
 After several sprints, patterns emerge — coding conventions that reviewers keep
 flagging, architectural decisions that keep causing merge conflicts, test patterns
-that keep breaking. If the project has a rules extraction skill (like `/harvest-rules`
+that keep breaking. If the project has a rules extraction skill (like `/rule-author harvest`
 or `/mine-rules`), run it during the review phase. The rules it finds should flow
 back into CLAUDE.md or the project's linting configuration, preventing the same
 review comments from recurring.

--- a/.claude/skills/rule-author/SKILL.md
+++ b/.claude/skills/rule-author/SKILL.md
@@ -1,9 +1,16 @@
 ---
 name: rule-author
-description: Author, refine, or migrate a doing-it-wrong architectural rule. Use when the user wants to "write a rule", "add a lint rule", "should we lint for this", "make a rule for X", "migrate a check-*.ts into the rule engine", or when a recurring mistake (often surfaced by harvest-rules) should be mechanized. Also covers judging whether a proposed rule is worth writing and bootstrapping the rule engine into a new repo.
+description: Author, refine, or migrate a doing-it-wrong architectural rule, and harvest recurring mistakes from merged PRs. Routes on its argument — `harvest` (mine PR review comments for recurring author mistakes), `init` (bootstrap the rule engine into a repo), `add` (author a rule), or no arg (overview + "is this a good rule?" triage). Use when the user wants to "write a rule", "add a lint rule", "should we lint for this", "make a rule for X", "migrate a check-*.ts into the rule engine", "harvest rules", "what should we lint for", "reduce review churn", "mine PR comments for rules", or judging whether a proposed invariant is worth a rule.
 ---
 
 # Rule Author
+
+The rule lifecycle is **harvest → init → add**. This skill routes on its argument:
+
+- **`/rule-author harvest`** — mine merged PRs for recurring author mistakes that could become rules. See `references/harvest.md`.
+- **`/rule-author init`** — bootstrap the rule engine into a repo. See `references/rule-engine.md`.
+- **`/rule-author add <rule>`** — author a new rule. See `references/new-rule.md`.
+- **no argument** — this overview + the "is this a good rule?" triage below.
 
 ## Why rules exist
 
@@ -11,7 +18,7 @@ A rule mechanizes a recurring mistake so review rounds and CI minutes are spent 
 
 ## When to use this skill
 
-- Writing a new rule from a known recurring mistake (e.g. a harvest-rules finding).
+- Writing a new rule from a known recurring mistake (e.g. a `/rule-author harvest` finding).
 - Refining a rule that's too broad (false positives) or too narrow (misses the shape).
 - Judging whether a proposed invariant *should* be a rule at all.
 - Migrating a legacy standalone `scripts/check-*.ts` into the engine.
@@ -19,6 +26,7 @@ A rule mechanizes a recurring mistake so review rounds and CI minutes are spent 
 
 ## References
 
+- **`references/harvest.md`** — `/rule-author harvest`: the survey → cluster → decide pipeline for mining merged-PR review comments. The per-agent classifier prompt lives in `references/extract.md` and the extractor in `scripts/extract-pr.ts`.
 - **`references/new-rule.md`** — how to author a `.rule.ts`: the API, regex-vs-AST decision, fixtures (minimal, not elaborate), writing guidance that names the cause, and the add-rule→show-red→remediate-in-the-same-PR discipline.
 - **`references/rule-engine.md`** — a from-scratch description of the engine (every `_engine/` component, the entry scripts, and how the gate is wired). Use this when copying the engine to a new repo so you don't re-derive the layout each time.
 
@@ -29,6 +37,6 @@ Before writing, check all four. If any fails, refine the proposal or say so — 
 1. **Mechanically enforceable.** The mistake must be a *shape* a regex or the TS AST can match — "raw `Bun.spawn` instead of the helper", "`expect(x.filter(...)).toHaveLength(0)`". If detecting it requires understanding intent or design quality ("is this abstraction right?"), it is a code-review concern, not a rule. Decline or narrow it to the mechanizable core.
 2. **Precise.** Aim for near-zero false positives. A noisy rule gets `// dotw-ignore`'d on sight and becomes decoration. If you can't get precision with a regex, use the AST (`references/new-rule.md`); if you still can't, the rule isn't ready.
 3. **Has a real alternative.** A rule that bans something must point at the right way to do it — ideally a shared helper that handles the corner cases, so "do it right" is easier than "do it wrong". A ban whose only escape is an unbounded `// dotw-ignore: long-running, you're on your own` is not a guardrail; it just moves the risk behind a comment. If the right answer is "use a helper that doesn't exist yet", build the helper (or file it) as part of the work.
-4. **Recurring.** One-offs don't earn a rule. The bar is roughly "a reviewer has flagged this more than twice" (see the `harvest-rules` skill). A single incident is a fix, not a rule.
+4. **Recurring.** One-offs don't earn a rule. The bar is roughly "a reviewer has flagged this more than twice" (see `/rule-author harvest`). A single incident is a fix, not a rule.
 
 Borderline cases worth refining rather than rejecting: a rule that's *mostly* mechanizable but has a few legitimate exceptions (give it precise detection + a documented suppression), or one that overlaps an existing rule (resolve the overlap — don't ship two rules that fight over the same lines).

--- a/.claude/skills/rule-author/references/extract.md
+++ b/.claude/skills/rule-author/references/extract.md
@@ -3,7 +3,7 @@
 The orchestrator launches one agent per group with a short pointer instead of
 the full prompt:
 
-> Follow the instructions at `.claude/skills/harvest-rules/references/extract.md`.
+> Follow the instructions at `.claude/skills/rule-author/references/extract.md`.
 > Your group is **<group-id>**. Your PR files are:
 > `build/harvest/pr/<n>.md` (×10). Write to `build/harvest/findings/group-<id>.md`.
 

--- a/.claude/skills/rule-author/references/harvest.md
+++ b/.claude/skills/rule-author/references/harvest.md
@@ -1,13 +1,9 @@
----
-name: harvest-rules
-description: Mine merged-PR review comments for recurring author mistakes that could be caught by a doing-it-wrong rule. Use when the user wants to reduce review churn, asks "what should we lint for", "harvest rules", "mine PR comments for rules", or after a batch of PRs has merged. Surveys N PRs across parallel Sonnet agents, clusters findings, and proposes rules.
----
-
 # Harvest Rules
 
-Find mistakes that reviewers flag **more than twice** across merged PRs, then
-decide which deserve a mechanical `doing-it-wrong` rule. The goal is to spend
-review rounds on judgment, not on the same catchable mistake again and again.
+Invoked via `/rule-author harvest`. Find mistakes that reviewers flag **more than
+twice** across merged PRs, then decide which deserve a mechanical `doing-it-wrong`
+rule. The goal is to spend review rounds on judgment, not on the same catchable
+mistake again and again.
 
 ## Philosophy
 
@@ -34,7 +30,7 @@ The three stages the user cares about: **(1) survey → candidate list,
 gh pr list --state merged --limit 100 --json number --jq 'sort_by(.number) | reverse | .[].number' > build/harvest/pr-list.txt
 
 # Extract all in parallel (owner/repo auto-derived from gh context)
-xargs -P 6 -n 4 bun .claude/skills/harvest-rules/scripts/extract-pr.ts < build/harvest/pr-list.txt
+xargs -P 6 -n 4 bun .claude/skills/rule-author/scripts/extract-pr.ts < build/harvest/pr-list.txt
 ```
 
 `extract-pr.ts` writes `build/harvest/pr/<n>.md` per PR (description, changed
@@ -54,7 +50,7 @@ Launch one agent per group **in a single message** (parallel), `model:
 sonnet`, `subagent_type: general-purpose`. Keep the prompt tiny — point at the
 reference, don't inline it:
 
-> Follow the instructions at `.claude/skills/harvest-rules/references/extract.md`.
+> Follow the instructions at `.claude/skills/rule-author/references/extract.md`.
 > Your group is **aa**. Your PR files: `build/harvest/pr/2235.md` … (list the 10).
 > Write your table to `build/harvest/findings/group-aa.md`.
 

--- a/.claude/skills/rule-author/references/rule-engine.md
+++ b/.claude/skills/rule-author/references/rule-engine.md
@@ -63,4 +63,4 @@ Run the **identical** command in both so local and CI share one definition of do
 3. Add `package.json` scripts: `"doing-it-wrong"` and `"am-i-done"` (one entry total — not one per rule).
 4. Wire `am-i-done --pre-commit` into the pre-commit hook and CI (see above).
 5. Write the first rule + a minimal fixture pair (`new-rule.md`), confirm `bun test scripts/rules` and `bun run doing-it-wrong` (exit 0) pass.
-6. Seed real rules from `harvest-rules` findings rather than inventing invariants speculatively.
+6. Seed real rules from `/rule-author harvest` findings rather than inventing invariants speculatively.

--- a/.claude/skills/rule-author/scripts/extract-pr.ts
+++ b/.claude/skills/rule-author/scripts/extract-pr.ts
@@ -2,7 +2,7 @@
 /**
  * extract-pr.ts — Extract full PR context for rule harvesting.
  *
- * Usage: bun .claude/skills/harvest-rules/scripts/extract-pr.ts <pr> [<pr> ...]
+ * Usage: bun .claude/skills/rule-author/scripts/extract-pr.ts <pr> [<pr> ...]
  *
  * Writes build/harvest/pr/<pr>.md per PR with title, description, changed
  * files, and all review surfaces (issue comments, review bodies, inline

--- a/docs/architecture/duplication.md
+++ b/docs/architecture/duplication.md
@@ -54,7 +54,7 @@ history: how often does a commit touch *all* of them together vs. one at a time?
 
 - **Co-change** (commits routinely touch all siblings together) → miscategorized
   duplication. The invariant wants to live in one place; extract it. The
-  recurring-bug clusters mined by `/harvest-rules` are exactly this signal — the
+  recurring-bug clusters mined by `/rule-author harvest` are exactly this signal — the
   same fix landing in many independent PRs means the concern changes in lockstep.
 - **Independent drift** (siblings evolve separately) → *validated* duplication.
   Leave it. An abstraction here would only add coupling.
@@ -79,7 +79,7 @@ duplication's locality and regenerability, but don't fly blind on drift.
   that has known mirror-siblings, ask explicitly *"did this fix get replayed
   across all siblings?"* See the `adversarial-review` Focus Areas.
 - **Co-change / drift detector (future, not built):** a git-history miner —
-  sibling of `/harvest-rules` — that flags commits touching some-but-not-all
+  sibling of `/rule-author harvest` — that flags commits touching some-but-not-all
   siblings. That is the security-fix-not-replayed detector. Documented here as
   the intended instrument; we run the manual check until it earns building.
 - **Hand-built invariant checks (today):** where a mirror set's parallelism is


### PR DESCRIPTION
Applies meta-fix #2350 (pulled up at sprint-67 plan time per the Step-1a review). Blocker #2349 (the `/rule-author` skill) merged 2026-05-24.

Consolidates the rule lifecycle **harvest → init → add** under one skill:

- `/rule-author` SKILL.md routes on its argument (`harvest`/`init`/`add`/no-arg) and folds in the harvest-rules trigger phrases.
- `harvest-rules/SKILL.md` → `rule-author/references/harvest.md`
- `harvest-rules/references/extract.md` → `rule-author/references/extract.md` — **kept separate** (not inlined into harvest.md as the issue's literal wording suggested) to preserve the "edit the per-agent prompt in one place" design the pipeline relies on.
- `harvest-rules/scripts/extract-pr.ts` → `rule-author/scripts/extract-pr.ts`
- Rewired refs: `rule-engine.md`, `bootstrap-sprint/iteration.md`, `docs/architecture/duplication.md`, and the script usage comment.
- Removed the standalone `harvest-rules` skill. (`sprint-66.md`'s historical "deferred" note left as-is — it's an accurate record.)

Docs/skill-only by construction.