### PR TITLE
chore(skill): record 57=skipped, 67=done in introspection cadence

### DIFF
--- a/.claude/skills/sprint/references/introspection.md
+++ b/.claude/skills/sprint/references/introspection.md
@@ -17,7 +17,7 @@ for the kind of finding this round is meant to surface.
 ## Cadence
 
 **Run during the retro of sprints whose number ends in 7**: 17, 27, 37,
-47-done, **57**, 67, 77… The round's findings feed the *next* sprint's
+47-done, 57-**skipped** (never ran — see #2506), 67-done, 77… The round's findings feed the *next* sprint's
 plan (Bucket-1 candidates for sprint 58, 68, …). See `retro.md`
 "Introspection cadence" section for the trigger.
 
@@ -121,4 +121,5 @@ A round is "done" when:
 | Sprint | Date | Findings filed | Tracking issue |
 |--------|------|----------------|----------------|
 | 47 (pre-48 plan) | 2026-04-28 | #1856–#1866 | #1867 (this template) |
-| 57 | TBD | TBD | TBD |
+| 57 | — | **skipped** — round never ran, undetected (root cause: #2506) | — |
+| 67 (at sprint-67 plan) | 2026-05-27 | #2495–#2510 (code + transcript) | #2511 |

--- a/.claude/skills/sprint/references/retro.md
+++ b/.claude/skills/sprint/references/retro.md
@@ -226,7 +226,7 @@ git branch -D sprint-{N}   # local branch (remote was --delete-branch'd by gh pr
 
 ## Introspection cadence (sprints ending in 7)
 
-If the sprint number ends in 7 (17, 27, 37, 47, **57**, 67…), queue a
+If the sprint number ends in 7 (17, 27, 37, 47, ~~57~~ (skipped — see #2506), 67…), queue a
 code-first introspection round to feed the *next* sprint's plan. The round
 runs as part of this retro: spawn one Explore agent with the prompt template
 at `.claude/skills/sprint/references/introspection.md`, triage findings with


### PR DESCRIPTION
Updates the introspection round-history (introspection.md + retro.md) to mark sprint-57 as **skipped** (the round never ran and wasn't detected — mechanical-guard fix tracked in #2506) and log the sprint-67 round (#2495–#2510, tracking #2511). Docs/skill-only.