### PR TITLE
sprint(67): rules + tech-debt mop-up

### DIFF
--- a/.claude/diary/20260528.67.md
+++ b/.claude/diary/20260528.67.md
@@ -1,0 +1,73 @@
+# 2026-05-28 — Rules + tech-debt mop-up (Sprint 67)
+
+## What was done
+
+14 PRs merged, v1.12.3 released. 16 of 16 planned issues resolved (14 PR-merged, 2 closed-as-already-fixed).
+
+**Sprint anchor — diff-scope coverage ratchet (#2495, PR #2515):**
+- `scripts/coverage-diff.ts` resolves changed source files from merge-base via committed + uncommitted git diff; `scripts/check-coverage.ts` enforces per-file 80% floor only on diff-scoped files on feature branches, full enforcement on main / indeterminate git state
+- Adversarial review (round 1) caught: zero unit tests for `resolveChangedSourceFiles`, detached-HEAD not handled, suffix-match too broad — all three fixed via reviewer self-repair before QA
+- This is the structural fix that ends sprints 64–66's "shared-gap fails my unrelated PR" failure mode
+
+**New doing-it-wrong rules (4 new):**
+- `no-cli-catch-warn` (#2474, PR #2517) — ban unguarded `console.warn` in `.catch()` in `packages/command/`, AST-aware per-warn guard detection (round-1 review caught substring-on-source false-negatives and per-callback granularity bug; self-repaired)
+- `warn-on-dead-allow-pattern` + `no-triplicate-allow-parsing` (#2491, PR #2531) — enforce that allow-pattern parsing logic stays in `packages/core/src/allow-patterns.ts`; rule scope extended to `.claude/phases/**/*.ts` after pessimist-prime flagged it
+- `no-as-any` + `prod-empty-catch` (#2496, PR #2530) — flag `as any` casts and inline empty catch blocks in production
+- `no-cli-catch-warn` has both per-warn and per-callback semantics — needed an AST walk to dominating IfStatement/ConditionalExpression, not a substring includes()
+
+**Worker filesystem-escape containment fix (#2343, PR #2518):**
+- Nerd-snipe gate confirmed root cause: Claude Code CLI auto-approves tools in `--allowedTools` *without emitting `can_use_tool`* to the daemon, bypassing the ContainmentGuard entirely (the `.claire`/`.claude` typo from sprint 62 was an LLM hallucination, not a code bug)
+- Fix: strip Write/Edit/MultiEdit/NotebookEdit from `--allowedTools` for worktree sessions so all writes traverse `can_use_tool` → ContainmentGuard. Centralized `CONTAINMENT_WRITE_TOOLS` in `containment.ts` as the single source of truth; ws-server imports it
+- Convergence-failure: round-1 review only flagged NotebookEdit; round-2 QA found MultiEdit + argument-form patterns (`Write(/tmp)`) bypass exact-name strip. Simplify pass enumerated the full tool set and parsed `Tool(arg)` patterns by splitting on `(`. Pre-commit hook broken in worktrees by #2527 forced `--no-verify` with manual gate verification
+
+**Silent catch elimination (#2498, PR #2526):**
+- Replaced silent `catch {}` blocks with typed `LookupFailure` sentinel (`{ _tag: "lookup-failure", message }`); call sites distinguish "no data" from "lookup failed" and log to stderr
+- Convergence-failure (round-1 + round-2): each repair pass missed adjacent dead-catch-around-spawnCaptureSync sites. Simplify pass centralized the pattern in `core/spawn-lookup.ts` as `runOrLookupFailure` / `runSyncOrLookupFailure` — caller sites consume the helper instead of mirroring the result.ok check
+
+**Event-bus / cycles / migration:**
+- #2497 (PR #2523) — removed dead `MonitorContext`/`MonitorDefinition` types + dead `bus.publish` channel in monitor-executor; rebased twice as #2486 alias-bundle landed
+- #2486 (PR #2521) — broke alias-bundle barrel import cycle by extracting `alias-bundle-core.ts` for `__mcp_core__` consumers (followup #2522 filed for the duplicated-export-list drift hazard — invert via re-export from core)
+- #2317 (PR #2524) — migrated 4 clone-provider local `unwrapToolResult` copies to shared `@mcp-cli/core` helper
+- #2492 (PR #2525) — `resolveEffectiveTools` returns `tools: undefined` (not `[]`) on error path; caller must check `error`
+
+**Tests + diagnostics:**
+- #2457 (PR #2514) — added missing happy-path test for `controlSkipPatterns` closure-cache filter
+- #2464 (PR #2532) — nerd-snipe confirmed flake root cause: 10 `changedTestsStep` tests each scan ~200 spec files (~2000ms) → parallel I/O contention pushes past 5s timeout → Bun SIGTERM → `exit -1`. Fix: dep-inject `noSpecFiles`/`noGraph` stubs; `setDefaultTimeout(10_000)` for headroom; instrumented `runBun` error handler. Test file runtime 14–23s → 2.75s (8x improvement)
+- #2488 (PR #2516) — `no-import-cycles` rule edge-drop diagnostic + cache hardening; followup-fixed Copilot's "test asserts nothing" findings via QA test improvement
+- #2490 (PR #2528) — 5-line comment in `claude-session-worker.ts` documenting `DEFAULT_SAFE_TOOLS` union asymmetry
+
+**Also closed (already-fixed):**
+- #2455 acp-cost-tracking-evidence block-comment FP — superseded by PR #2452 AST detection
+- #2489 file-loader.ts coverage — already brought to 100% by PR #2484 no-import-cycles work
+
+## What worked well
+
+- **Reviewer self-repair was the dominant repair mode.** Of 7 PRs that went through adversarial review (#2495, #2474, #2343, #2497, #2498, #2491, #2496, #2464), 6 used self-repair successfully — the reviewer already had worktree + diagnosis loaded; sending it back to fix 1–3 contained findings was 5–10× cheaper than spawning a fresh opus repair
+- **Simplify pass beats whack-a-mole.** When #2343 and #2498 both showed convergence-failure (new findings each round, not the same finding recurring), launching an opus simplify pass — "step back, enumerate the full class of cases, write a canonical helper, don't patch the flagged lines" — collapsed both to one more round. Each had been heading toward the round-cap → needs-attention path
+- **Nerd-snipe gate produced excellent specs.** #2343 and #2464 both had concrete root cause + fix plan in the issue comment before impl spawned; opus implemented directly from comment with zero replanning. #2464 worker even validated the fix (8x runtime drop) in the gate session before re-purposing as the impl PR — saved a full impl cycle
+- **`-c` worktree handoff across phases.** Once impl pushed, every subsequent phase (review, QA, repair) used `--cwd <kept-impl-worktree>` instead of `--worktree`, so the reviewer always landed on the right branch. Sprint 66's #2153/#2437 cycle losses from fresh-worktree reviewers did not recur
+- **Quota recovery via sliding window.** When 5h utilization hit 100% with #2343/#2498 simplify still in flight, the workers throttled to 0-cost but the session stayed alive — by the time the window slid forward enough, both worker sessions resumed and completed without intervention. Did not need to wait for the full reset
+
+## What didn't work
+
+- **Opus over-planning loop on Batch 2 spawns.** Four opus impl sessions (#2491, #2496, #2497, #2498) all idled after ~15-30 turns with "Here's my understanding of the issue:" preview text — entering plan mode and stopping, waiting for approval. Required four manual "Continue — implement, run am-i-done, commit, PR" nudges. Burned ~5 minutes of orchestrator time across the batch. *Fix: include "implement directly, do not stop after planning" in the spawn prompt for opus impl* — TODO file follow-up.
+- **#2343 first round missed MultiEdit; #2498 first round missed adjacent dead-catch sites.** Both reviewers found 1-2 instances of a bug class then stopped; QA round 2 found more instances. Adversarial review didn't enumerate the full class. *Fix: when a review identifies a bug pattern (not a one-off), the spawn prompt for that review should require enumerating ALL instances of the class, not just the first 1-3 lines.*
+- **Pre-commit hook test-commit pollution (#2527) broke `git commit` in worktrees.** #2343 repair session hit it: when tests run during pre-commit, subprocess git operations create junk commits inside the worktree. Required `--no-verify` with manual gate verification to push. *Fix: tracked in #2527 — orthogonal to this sprint's scope; the workers worked around it correctly once authorized.*
+- **`mcx phase run impl` returns "opus" for #2490 despite plan saying sonnet.** The phase script's sprint-plan model lookup didn't apply for the docs-only issue. Resulted in an opus session for a 5-line comment. Low cost impact, but the heuristic disagreed with the plan. *Fix: file follow-up for the plan-lookup parser.*
+- **Two convergence-failure simplify passes burned ~$8 in opus repair cost.** #2343 had 1 review + 2 QA + 1 simplify (round 3) = 4 rounds total; #2498 had 1 review + 2 QA + 1 simplify = 4 rounds. Both could have been one-and-done if round-1 review had enumerated the bug class. See above fix.
+
+## Patterns established
+
+- **"Simplify pass after 2 convergence-failure rounds" is now load-bearing.** Both #2343 and #2498 followed the same shape — round 1 finds 1-2 instances, repair fixes those, round 2 finds adjacent instances, repair fixes those, round 3 finds still more. Stopping at round 2 and launching a simplify pass collapsed both to one more round each. The pattern is already in `run.md` "Convergence-failure → simplify, don't keep patching" — this sprint adds two more data points (sprint 62 #2271 was the previous canonical case)
+- **Reviewer self-repair message template works.** Standard "You flagged N issues on PR #X. Self-repair: (a) <fix1>; (b) <fix2>; (c) <fix3>. Push to <branch>, update sticky review. If any need redesign instead, reply 'needs opus repair'." consistently produced clean fixes — none escalated to needs-opus-repair this sprint
+- **Nerd-snipe worker can dual-role as impl when fix is already validated in the gate.** #2464 had the fix in the worktree + 8x runtime validation by the time the comment posted; pushing the gate's worktree as the impl PR (instead of discarding + spawning fresh opus) saved a full cycle. Conditions: (1) gate worker had the worktree, (2) fix was validated locally before posting the issue comment, (3) the comment is still the durable spec for adversarial review.
+
+## Stats
+
+- **PRs merged**: 14
+- **Issues closed**: 16 of 16 planned (14 PR-merged + 2 already-fixed)
+- **Adversarial reviews**: 7 (all 7 had findings, 6 self-repaired, 0 escalated to opus repair as 'needs opus repair')
+- **Convergence-failure / simplify passes**: 2 (#2343, #2498)
+- **Failed/dropped**: 0
+- **New issues filed**: 8 (#2519, #2520, #2522, #2527, #2533, #2534, #2536, plus a comment on #2210 for Bun crash telemetry)
+- **Sprint cost**: ~$80 (rough estimate from session costs across 16+ workers)

--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -9,6 +9,7 @@
 
 ## Feedback (general — sprint-specific guidance lives in `.claude/skills/sprint/`)
 - [Codex retro learnings](feedback_codex_retro.md) — stale binaries, partial branches, protocol drift
+- [Codex broken (#2482)](codex_broken_2482.md) — codex spawn fully broken (RPC -32600) as of sprint 66; don't route to codex, use opus
 - [Git HTTPS push](feedback_git_https_push.md) — when agents get stuck pushing, tell them to use HTTPS
 - [Review context in PRs](feedback_review_pr_comments.md) — reviewers post to PR, repairers read PR comments first
 - [Open bun.report links](feedback_bun_report.md) — always `open` bun.report URLs to submit crash telemetry

--- a/.claude/memory/codex_broken_2482.md
+++ b/.claude/memory/codex_broken_2482.md
@@ -1,0 +1,14 @@
+---
+name: codex-broken-2482
+description: "codex spawn is fully broken (RPC -32600) as of sprint 66 — don't route work to codex until"
+metadata: 
+  node_type: memory
+  type: reference
+  originSessionId: a70cb538-7ecc-4124-af37-fb5c697c46ed
+---
+
+As of sprint 66 (2026-05-27), **`mcx agent codex spawn` fails immediately for any prompt** with `RPC error -32600: Invalid request` — no codex session can be created. The `_codex` virtual server shows connected (9 tools) in `mcx status`, so it's the session-start RPC that's rejected, not the server. Reproduced with both a long `--cwd` prompt and a bare minimal one.
+
+This is a **regression** of the same protocol-drift class as the now-closed #845/#851 (`missing field threadId`) and #666 (`invalid type: map`). Tracked in **#2482**.
+
+**How to apply:** Don't route sprint/repair/refactor work to codex until #2482 is resolved — fall back to opus. In sprint 66 the #2074 holistic refactor was sent to codex first, errored twice, and had to be redone on opus. See [[feedback_codex_retro]] for the broader codex pitfalls (stale binaries, partial branches, schema drift).

--- a/.claude/sprints/sprint-67.md
+++ b/.claude/sprints/sprint-67.md
@@ -1,6 +1,6 @@
 # Sprint 67
 
-> Planned 2026-05-27. Started 2026-05-27. Target: ~16 PRs. Theme: **Rules + tech-debt mop-up** (introspection sprint, ends in 7).
+> Planned 2026-05-27. Started 2026-05-27. Ended 2026-05-28. Target: ~16 PRs. Theme: **Rules + tech-debt mop-up** (introspection sprint, ends in 7).
 
 ## Goal
 
@@ -49,6 +49,16 @@ All Provider = `claude` (codex spawn is broken — #2482; never route codex this
 - Rule-adds (#2488/#2455/#2474/#2491/#2496) each create their own `scripts/rules/*.rule.ts`; the engine discovers by glob (no central registry), so no dispatch-table collision.
 - #2495 supersedes the *urgency* of #2489 — once the ratchet is diff-scoped, a pre-existing file-loader gap no longer fails unrelated worktrees. #2489 stays as a quick coverage backfill, not a blocker.
 - #2343 and #2464 hit the **nerd-snipe investigation gate** (`references/investigations.md`) before impl — `mcx claude spawn` with persona inlined, NOT the Agent tool (#2009). Hard-fail outcome = `needs-attention`; accept it as a possible result.
+
+## Results
+
+- **Released**: v1.12.3 (patch)
+- **PRs merged**: 14 (#2514, #2515, #2516, #2517, #2518, #2521, #2523, #2524, #2525, #2526, #2528, #2530, #2531, #2532)
+- **Issues closed**: 16 of 16 (14 PR-merged + 2 closed-as-already-fixed: #2455 by #2452, #2489 by #2484)
+- **Issues dropped**: 0
+- **New issues filed**: 8 (#2519 containment for non-Claude providers, #2520 ContainmentGuard fail-open for unknown tools, #2522 alias-bundle drift hazard inversion, #2527 pre-commit hook test-commit pollution, #2533 dotw-todo-stale-issue rule, #2534 string-literal-aware pattern matching, #2536 noGraph stub `as` cast → `satisfies`, plus a comment on #2210 for Bun crash telemetry)
+- **Convergence-failure / simplify passes**: 2 (#2343 worktree-containment hit twice — round 1 missed NotebookEdit, round 2 missed MultiEdit + arg-form patterns; #2498 silent-catch hit once — round 1 fix exposed adjacent dead-catch sites). Both resolved by stepping back and writing a canonical helper + enumerating the full tool set, not by patching the flagged lines.
+- **Sprint anchor**: #2495 diff-scope coverage ratchet landed first batch, eliminated the "shared gap fails my unrelated PR" failure mode that drove sprints 64–66's duplicate-issue storms.
 
 ## Context
 

--- a/.claude/sprints/sprint-67.md
+++ b/.claude/sprints/sprint-67.md
@@ -1,6 +1,6 @@
 # Sprint 67
 
-> Planned 2026-05-27. Target: ~16 PRs. Theme: **Rules + tech-debt mop-up** (introspection sprint, ends in 7).
+> Planned 2026-05-27. Started 2026-05-27. Target: ~16 PRs. Theme: **Rules + tech-debt mop-up** (introspection sprint, ends in 7).
 
 ## Goal
 

--- a/.claude/sprints/sprint-67.md
+++ b/.claude/sprints/sprint-67.md
@@ -1,0 +1,55 @@
+# Sprint 67
+
+> Planned 2026-05-27. Target: ~16 PRs. Theme: **Rules + tech-debt mop-up** (introspection sprint, ends in 7).
+
+## Goal
+
+Finish the doing-it-wrong rules system (#2352) and clear high-leverage tech-debt — anchored on the structural fix that ends the duplicate-issue storms: diff-scoping the coverage ratchet (#2495).
+
+## Issues
+
+| # | Title | Scrutiny | Batch | Model | Category |
+|---|-------|----------|-------|-------|----------|
+| 2495 | diff-scope am-i-done coverage ratchet (anchor) | high (adversarial) | 1 | opus | goal |
+| 2343 | worker filesystem-escape into main checkout | high (nerd-snipe gate) | 1 | opus | goal |
+| 2492 | allow-patterns resolveEffectiveTools empty-array footgun | low | 1 | sonnet | goal |
+| 2457 | ci-steps happy-path closure-cache tests | low | 1 | sonnet | goal |
+| 2488 | import-graph edge-drop diagnostic + cache hardening | low | 1 | sonnet | goal |
+| 2491 | doing-it-wrong rules for allow-pattern regressions | medium | 2 | opus | goal |
+| 2497 | monitor-executor dead bus.publish channel (double-emit) | high (adversarial) | 2 | opus | goal |
+| 2496 | no-as-any rule + extend empty-catch to production | medium | 2 | opus | goal |
+| 2486 | break alias-bundle.ts barrel-induced import cycle | medium | 2 | sonnet | goal |
+| 2455 | acp-cost-tracking-evidence block-comment FP | low | 2 | sonnet | goal |
+| 2464 | flaky ci-steps.spec.ts:403 under parallel run | high (nerd-snipe gate) | 3 | opus | goal |
+| 2498 | production catch {} swallowing auth/git/parse failures | medium | 3 | opus | goal |
+| 2317 | migrate clone-provider unwrapToolResult copies to core | low | 3 | sonnet | filler |
+| 2474 | rule: no console.warn in .catch() without verbosity gate | low | 3 | sonnet | filler |
+| 2489 | file-loader.ts coverage (14.3% → 80%) | low | 3 | sonnet | filler |
+| 2490 | docs: DEFAULT_SAFE_TOOLS union Claude-specific comment | low | 3 | sonnet | filler |
+
+All Provider = `claude` (codex spawn is broken — #2482; never route codex this sprint).
+
+## Batch Plan
+
+### Batch 1 (immediate)
+#2495, #2343, #2492, #2457, #2488
+
+### Batch 2 (backfill)
+#2491, #2497, #2496, #2486, #2455
+
+### Batch 3 (backfill)
+#2464, #2498, #2317, #2474, #2489, #2490
+
+### Dependency edges (blockedBy)
+- #2491 blockedBy #2492 (shared `packages/core/src/allow-patterns.ts`; #2492 changes the return contract first)
+- #2490 blockedBy #2492 (shared `allow-patterns.ts`)
+- #2464 blockedBy #2457 (shared `scripts/_runner/ci-steps.spec.ts`; land the clean happy-path tests, then rebase the flaky fix)
+
+### Notes
+- Rule-adds (#2488/#2455/#2474/#2491/#2496) each create their own `scripts/rules/*.rule.ts`; the engine discovers by glob (no central registry), so no dispatch-table collision.
+- #2495 supersedes the *urgency* of #2489 — once the ratchet is diff-scoped, a pre-existing file-loader gap no longer fails unrelated worktrees. #2489 stays as a quick coverage backfill, not a blocker.
+- #2343 and #2464 hit the **nerd-snipe investigation gate** (`references/investigations.md`) before impl — `mcx claude spawn` with persona inlined, NOT the Agent tool (#2009). Hard-fail outcome = `needs-attention`; accept it as a possible result.
+
+## Context
+
+Theme C chosen over the #2485 mail/issue funnel (deferred to a feature sprint) and an agent-session-reliability sprint (#2482 codex is routed around, not blocking). This is the first code-first **introspection** round since sprint-47 (sprint-57 was skipped); it produced #2495–#2498 (pulled in here) plus a tracking epic and a backlog of structural findings (StateDb/ws-server god-objects as epics, perf wins, the cadence-guard #11) for sprint 68. Meta-fix #2350 (fold harvest-rules → /rule-author) lands pre-sprint via PR #2494; the introspection.md/retro.md 57=skipped record update is a pending orchestrator meta-edit. Risk: 4 high-scrutiny issues (2 nerd-snipe gates) is a heavier-than-usual top end — the gates may consume slots and one could land in needs-attention.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "bun": ">=1.3.14"
   },
-  "version": "1.12.2",
+  "version": "1.12.3",
   "description": "MCP CLI — call MCP server tools from the command line with zero context overhead",
   "type": "module",
   "workspaces": ["packages/*"],


### PR DESCRIPTION
Sprint 67 container PR. Accumulates every sprint-meta commit on the `sprint-67` branch:

- plan + any mid-sprint amendments
- run-time edits (Started/Ended timestamps, Excluded section)
- Results summary
- retro diary file
- release commit (if a release is cut this sprint)

**Theme:** Rules + tech-debt mop-up (introspection sprint). Anchor: #2495 (diff-scope the coverage ratchet — ends the duplicate-issue storms). 16 issues; see `.claude/sprints/sprint-67.md`.

Marked **draft** until `/sprint retro` flips it ready and arms auto-merge.

Docs/skill-only by construction — pre-commit hooks should skip the test suite.