### PR TITLE
fix(coverage): diff-scope per-file coverage ratchet (fixes #2495)

### DIFF
--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -123,6 +123,7 @@ const EXCLUSIONS: Record<string, string> = {
 
 import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { coveragePathInDiff, resolveChangedSourceFiles } from "./coverage-diff";
 // staged-files still available for --ci mode if needed in the future
 import { logTestRun } from "./test-failure-log";
 import { detectTestNoise } from "./test-noise";
@@ -395,16 +396,30 @@ for (const source of [coverageRun1, stdout2 + stderr2]) {
   }
 }
 
+// --- Diff-scoping: only fail on files the current branch touches (#2495) ---
+// On a feature branch, pre-existing gaps in untouched files warn but don't fail.
+// On main (or when git state is indeterminate), full enforcement applies.
+const changedFiles = resolveChangedSourceFiles();
+const isDiffScoped = changedFiles !== null;
+
+function isFileInDiff(coveragePath: string): boolean {
+  return coveragePathInDiff(coveragePath, changedFiles);
+}
+
 const failures: { file: string; lines: number }[] = [];
+const preExistingGaps: { file: string; lines: number }[] = [];
 
 for (const [file, { lines }] of bestCoverage) {
   if (lines >= PER_FILE_MIN_LINES) continue;
 
-  // Check exclusions (suffix match)
   const excluded = Object.keys(EXCLUSIONS).some((pattern) => file.endsWith(pattern));
   if (excluded) continue;
 
-  failures.push({ file, lines });
+  if (isDiffScoped && !isFileInDiff(file)) {
+    preExistingGaps.push({ file, lines });
+  } else {
+    failures.push({ file, lines });
+  }
 }
 
 // --- Check test output noise ---
@@ -416,7 +431,9 @@ const noiseLines = detectTestNoise(output);
 console.log("\n--- Coverage Report ---");
 console.log(`Global:    ${globalFuncs}% functions, ${globalLines}% lines`);
 console.log(`Threshold: ${GLOBAL_THRESHOLDS.functions}% functions, ${GLOBAL_THRESHOLDS.lines}% lines`);
-console.log(`Per-file:  ${PER_FILE_MIN_LINES}% lines minimum (${Object.keys(EXCLUSIONS).length} exclusions)`);
+console.log(
+  `Per-file:  ${PER_FILE_MIN_LINES}% lines minimum (${Object.keys(EXCLUSIONS).length} exclusions${isDiffScoped ? `, diff-scoped to ${changedFiles.size} changed file(s)` : ""})`,
+);
 
 let failed = false;
 
@@ -428,6 +445,15 @@ if (globalFuncs < GLOBAL_THRESHOLDS.functions) {
 if (globalLines < GLOBAL_THRESHOLDS.lines) {
   console.error(`\nFAIL: Line coverage ${globalLines}% is below global threshold ${GLOBAL_THRESHOLDS.lines}%`);
   failed = true;
+}
+
+if (preExistingGaps.length > 0) {
+  console.warn(
+    `\nWARN: ${preExistingGaps.length} file(s) below ${PER_FILE_MIN_LINES}% on main (not in diff — skipped):`,
+  );
+  for (const { file, lines } of preExistingGaps.sort((a, b) => a.lines - b.lines)) {
+    console.warn(`  ${lines.toFixed(1)}%  ${file}`);
+  }
 }
 
 if (failures.length > 0) {

--- a/scripts/coverage-diff.spec.ts
+++ b/scripts/coverage-diff.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { coveragePathInDiff } from "./coverage-diff";
+import { type GitRunner, coveragePathInDiff, resolveChangedSourceFiles } from "./coverage-diff";
 
 describe("coveragePathInDiff", () => {
   test("returns true when changed is null (full enforcement)", () => {
@@ -21,7 +21,7 @@ describe("coveragePathInDiff", () => {
     expect(coveragePathInDiff("core/src/config.ts", changed)).toBe(true);
   });
 
-  test("suffix match — changed path is shorter", () => {
+  test("suffix match — changed path is shorter (requires / separator)", () => {
     const changed = new Set(["src/config.ts"]);
     expect(coveragePathInDiff("packages/core/src/config.ts", changed)).toBe(true);
   });
@@ -40,5 +40,113 @@ describe("coveragePathInDiff", () => {
   test("does not false-positive on partial filename overlap", () => {
     const changed = new Set(["packages/core/src/config.ts"]);
     expect(coveragePathInDiff("packages/core/src/config-display.ts", changed)).toBe(false);
+  });
+
+  test("slash guard prevents bare suffix collision without path separator", () => {
+    const changed = new Set(["ig.ts"]);
+    expect(coveragePathInDiff("packages/core/src/config.ts", changed)).toBe(false);
+    expect(coveragePathInDiff("ig.ts", changed)).toBe(true);
+  });
+});
+
+function makeGit(responses: Record<string, { status: number; stdout: string }>): GitRunner {
+  return (_cmd: string, args: string[]) => {
+    const key = args.join(" ");
+    return responses[key] ?? { status: 1, stdout: "" };
+  };
+}
+
+describe("resolveChangedSourceFiles", () => {
+  test("returns null when rev-parse fails", () => {
+    const git = makeGit({});
+    expect(resolveChangedSourceFiles(git)).toBeNull();
+  });
+
+  test("returns null on main branch", () => {
+    const git = makeGit({ "rev-parse --abbrev-ref HEAD": { status: 0, stdout: "main\n" } });
+    expect(resolveChangedSourceFiles(git)).toBeNull();
+  });
+
+  test("returns null on master branch", () => {
+    const git = makeGit({ "rev-parse --abbrev-ref HEAD": { status: 0, stdout: "master\n" } });
+    expect(resolveChangedSourceFiles(git)).toBeNull();
+  });
+
+  test("returns null on detached HEAD", () => {
+    const git = makeGit({ "rev-parse --abbrev-ref HEAD": { status: 0, stdout: "HEAD\n" } });
+    expect(resolveChangedSourceFiles(git)).toBeNull();
+  });
+
+  test("returns changed files on feature branch via origin/main", () => {
+    const git = makeGit({
+      "rev-parse --abbrev-ref HEAD": { status: 0, stdout: "fix/my-branch\n" },
+      "merge-base origin/main HEAD": { status: 0, stdout: "abc123\n" },
+      "diff --name-only abc123 HEAD": {
+        status: 0,
+        stdout: "packages/core/src/config.ts\npackages/daemon/src/main.ts\n",
+      },
+      "diff --name-only HEAD": { status: 0, stdout: "packages/core/src/env.ts\n" },
+    });
+    const result = resolveChangedSourceFiles(git);
+    expect(result).toEqual(
+      new Set(["packages/core/src/config.ts", "packages/daemon/src/main.ts", "packages/core/src/env.ts"]),
+    );
+  });
+
+  test("falls back to local main when origin/main is unavailable", () => {
+    const git = makeGit({
+      "rev-parse --abbrev-ref HEAD": { status: 0, stdout: "fix/my-branch\n" },
+      "merge-base origin/main HEAD": { status: 1, stdout: "" },
+      "merge-base main HEAD": { status: 0, stdout: "def456\n" },
+      "diff --name-only def456 HEAD": { status: 0, stdout: "scripts/check-coverage.ts\n" },
+      "diff --name-only HEAD": { status: 0, stdout: "" },
+    });
+    const result = resolveChangedSourceFiles(git);
+    expect(result).toEqual(new Set(["scripts/check-coverage.ts"]));
+  });
+
+  test("returns null when both origin/main and main merge-base fail", () => {
+    const git = makeGit({
+      "rev-parse --abbrev-ref HEAD": { status: 0, stdout: "fix/my-branch\n" },
+      "merge-base origin/main HEAD": { status: 1, stdout: "" },
+      "merge-base main HEAD": { status: 1, stdout: "" },
+    });
+    expect(resolveChangedSourceFiles(git)).toBeNull();
+  });
+
+  test("skips ref when committed diff fails", () => {
+    const git = makeGit({
+      "rev-parse --abbrev-ref HEAD": { status: 0, stdout: "fix/my-branch\n" },
+      "merge-base origin/main HEAD": { status: 0, stdout: "abc123\n" },
+      "diff --name-only abc123 HEAD": { status: 1, stdout: "" },
+      "merge-base main HEAD": { status: 0, stdout: "def456\n" },
+      "diff --name-only def456 HEAD": { status: 0, stdout: "src/foo.ts\n" },
+      "diff --name-only HEAD": { status: 0, stdout: "" },
+    });
+    const result = resolveChangedSourceFiles(git);
+    expect(result).toEqual(new Set(["src/foo.ts"]));
+  });
+
+  test("handles uncommitted diff failure gracefully", () => {
+    const git = makeGit({
+      "rev-parse --abbrev-ref HEAD": { status: 0, stdout: "fix/my-branch\n" },
+      "merge-base origin/main HEAD": { status: 0, stdout: "abc123\n" },
+      "diff --name-only abc123 HEAD": { status: 0, stdout: "src/bar.ts\n" },
+      "diff --name-only HEAD": { status: 1, stdout: "" },
+    });
+    const result = resolveChangedSourceFiles(git);
+    expect(result).toEqual(new Set(["src/bar.ts"]));
+  });
+
+  test("deduplicates files appearing in both committed and uncommitted", () => {
+    const git = makeGit({
+      "rev-parse --abbrev-ref HEAD": { status: 0, stdout: "fix/my-branch\n" },
+      "merge-base origin/main HEAD": { status: 0, stdout: "abc123\n" },
+      "diff --name-only abc123 HEAD": { status: 0, stdout: "src/shared.ts\nsrc/other.ts\n" },
+      "diff --name-only HEAD": { status: 0, stdout: "src/shared.ts\n" },
+    });
+    const result = resolveChangedSourceFiles(git);
+    expect(result).toEqual(new Set(["src/shared.ts", "src/other.ts"]));
+    expect(result?.size).toBe(2);
   });
 });

--- a/scripts/coverage-diff.spec.ts
+++ b/scripts/coverage-diff.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { coveragePathInDiff } from "./coverage-diff";
+
+describe("coveragePathInDiff", () => {
+  test("returns true when changed is null (full enforcement)", () => {
+    expect(coveragePathInDiff("packages/core/src/config.ts", null)).toBe(true);
+  });
+
+  test("exact match", () => {
+    const changed = new Set(["packages/core/src/config.ts"]);
+    expect(coveragePathInDiff("packages/core/src/config.ts", changed)).toBe(true);
+  });
+
+  test("no match for unrelated file", () => {
+    const changed = new Set(["packages/core/src/config.ts"]);
+    expect(coveragePathInDiff("packages/daemon/src/server-pool.ts", changed)).toBe(false);
+  });
+
+  test("suffix match — coverage path is shorter", () => {
+    const changed = new Set(["packages/core/src/config.ts"]);
+    expect(coveragePathInDiff("core/src/config.ts", changed)).toBe(true);
+  });
+
+  test("suffix match — changed path is shorter", () => {
+    const changed = new Set(["src/config.ts"]);
+    expect(coveragePathInDiff("packages/core/src/config.ts", changed)).toBe(true);
+  });
+
+  test("empty changed set means nothing is in diff", () => {
+    const changed = new Set<string>();
+    expect(coveragePathInDiff("packages/core/src/config.ts", changed)).toBe(false);
+  });
+
+  test("multiple changed files — match on second", () => {
+    const changed = new Set(["scripts/am-i-done.ts", "packages/core/src/env.ts"]);
+    expect(coveragePathInDiff("packages/core/src/env.ts", changed)).toBe(true);
+    expect(coveragePathInDiff("packages/core/src/config.ts", changed)).toBe(false);
+  });
+
+  test("does not false-positive on partial filename overlap", () => {
+    const changed = new Set(["packages/core/src/config.ts"]);
+    expect(coveragePathInDiff("packages/core/src/config-display.ts", changed)).toBe(false);
+  });
+});

--- a/scripts/coverage-diff.ts
+++ b/scripts/coverage-diff.ts
@@ -1,0 +1,47 @@
+import { spawnSync } from "node:child_process";
+
+/**
+ * Coverage paths from Bun's table use relative paths (e.g. "packages/core/src/config.ts")
+ * while git diff returns repo-root-relative paths. They usually match exactly, but
+ * we also handle suffix matches for resilience.
+ */
+export function coveragePathInDiff(coveragePath: string, changed: Set<string> | null): boolean {
+  if (!changed) return true;
+  for (const f of changed) {
+    if (f === coveragePath || f.endsWith(`/${coveragePath}`) || coveragePath.endsWith(f)) return true;
+  }
+  return false;
+}
+
+/**
+ * Resolve files changed in the current branch vs main.
+ * Returns null when on main or when git state can't be determined (full enforcement).
+ * Returns a Set of relative paths when diff-scoping is possible.
+ */
+export function resolveChangedSourceFiles(): Set<string> | null {
+  const branch = spawnSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { encoding: "utf8" });
+  if (branch.status !== 0) return null;
+  const branchName = branch.stdout.trim();
+  if (branchName === "main" || branchName === "master") return null;
+
+  for (const ref of ["origin/main", "main"]) {
+    const mb = spawnSync("git", ["merge-base", ref, "HEAD"], { encoding: "utf8" });
+    if (mb.status !== 0 || !mb.stdout.trim()) continue;
+
+    const base = mb.stdout.trim();
+    const committed = spawnSync("git", ["diff", "--name-only", base, "HEAD"], { encoding: "utf8" });
+    if (committed.status !== 0) continue;
+
+    const uncommitted = spawnSync("git", ["diff", "--name-only", "HEAD"], { encoding: "utf8" });
+
+    const files = new Set(
+      [committed.stdout, uncommitted.status === 0 ? uncommitted.stdout : ""]
+        .join("\n")
+        .trim()
+        .split("\n")
+        .filter((f) => f.length > 0),
+    );
+    return files;
+  }
+  return null;
+}

--- a/scripts/coverage-diff.ts
+++ b/scripts/coverage-diff.ts
@@ -1,4 +1,8 @@
-import { spawnSync } from "node:child_process";
+import { type SpawnSyncReturns, spawnSync } from "node:child_process";
+
+export type GitRunner = (cmd: string, args: string[]) => Pick<SpawnSyncReturns<string>, "status" | "stdout">;
+
+const defaultGit: GitRunner = (cmd, args) => spawnSync(cmd, args, { encoding: "utf8" });
 
 /**
  * Coverage paths from Bun's table use relative paths (e.g. "packages/core/src/config.ts")
@@ -8,7 +12,7 @@ import { spawnSync } from "node:child_process";
 export function coveragePathInDiff(coveragePath: string, changed: Set<string> | null): boolean {
   if (!changed) return true;
   for (const f of changed) {
-    if (f === coveragePath || f.endsWith(`/${coveragePath}`) || coveragePath.endsWith(f)) return true;
+    if (f === coveragePath || f.endsWith(`/${coveragePath}`) || coveragePath.endsWith(`/${f}`)) return true;
   }
   return false;
 }
@@ -18,21 +22,21 @@ export function coveragePathInDiff(coveragePath: string, changed: Set<string> | 
  * Returns null when on main or when git state can't be determined (full enforcement).
  * Returns a Set of relative paths when diff-scoping is possible.
  */
-export function resolveChangedSourceFiles(): Set<string> | null {
-  const branch = spawnSync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { encoding: "utf8" });
+export function resolveChangedSourceFiles(git: GitRunner = defaultGit): Set<string> | null {
+  const branch = git("git", ["rev-parse", "--abbrev-ref", "HEAD"]);
   if (branch.status !== 0) return null;
   const branchName = branch.stdout.trim();
-  if (branchName === "main" || branchName === "master") return null;
+  if (branchName === "main" || branchName === "master" || branchName === "HEAD") return null;
 
   for (const ref of ["origin/main", "main"]) {
-    const mb = spawnSync("git", ["merge-base", ref, "HEAD"], { encoding: "utf8" });
+    const mb = git("git", ["merge-base", ref, "HEAD"]);
     if (mb.status !== 0 || !mb.stdout.trim()) continue;
 
     const base = mb.stdout.trim();
-    const committed = spawnSync("git", ["diff", "--name-only", base, "HEAD"], { encoding: "utf8" });
+    const committed = git("git", ["diff", "--name-only", base, "HEAD"]);
     if (committed.status !== 0) continue;
 
-    const uncommitted = spawnSync("git", ["diff", "--name-only", "HEAD"], { encoding: "utf8" });
+    const uncommitted = git("git", ["diff", "--name-only", "HEAD"]);
 
     const files = new Set(
       [committed.stdout, uncommitted.status === 0 ? uncommitted.stdout : ""]


### PR DESCRIPTION
## Summary
- Per-file coverage ratchet is now **diff-scoped** on feature branches: only files changed in the branch (committed + uncommitted vs merge-base) are enforced against the 80% floor
- Pre-existing gaps in untouched files emit `WARN` instead of `FAIL`, eliminating the dominant workflow pain (10 sessions hit this in sprints 64–66, spawning 5 duplicate issues + 3 independent fix PRs for `verdict-cache.ts` alone)
- On `main` (or when git state is indeterminate), full enforcement applies unchanged — the ratchet rule is intact

## Implementation
- New `scripts/coverage-diff.ts`: exports `resolveChangedSourceFiles()` (git merge-base + diff) and `coveragePathInDiff()` (path matching with suffix resilience)
- `scripts/check-coverage.ts`: imports the utility, splits below-threshold files into `failures` (in diff → FAIL) vs `preExistingGaps` (not in diff → WARN)
- `scripts/coverage-diff.spec.ts`: 8 unit tests covering exact match, suffix match, null passthrough, empty set, partial-name false-positive guard

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun test` passes (7647 + 626 = 8273 tests, 0 failures)
- [x] New `coverage-diff.spec.ts` — 8 tests, all pass
- [x] Pre-commit hook passes
- [x] Pre-push hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)