### PR TITLE
fix(rules): no-import-cycles edge-drop diagnostic + cache hardening (fixes #2488)

### DIFF
--- a/scripts/rules/_engine/import-graph.spec.ts
+++ b/scripts/rules/_engine/import-graph.spec.ts
@@ -89,6 +89,55 @@ describe("extractEdges", () => {
     expect(edges).toHaveLength(0);
   });
 
+  test("droppedEdges counts unresolvable specifiers in buildImportGraph", () => {
+    const resolve: SpecifierResolver = (spec) => {
+      if (spec === "./good") return "/test/good.ts";
+      throw new Error("not found");
+    };
+    const graph = buildImportGraph(["/test/root.ts"], {
+      readFile: (p) => {
+        if (p === "/test/root.ts") return `import "./good"; import "./missing";`;
+        return "";
+      },
+      resolve,
+    });
+    expect(graph.droppedEdges).toBe(1);
+  });
+
+  test("droppedEdges is zero when all specifiers resolve", () => {
+    const resolve: SpecifierResolver = (spec, _dir) => {
+      const target = spec.replace("./", "/test/").concat(".ts");
+      return target;
+    };
+    const graph = buildImportGraph(["/test/a.ts"], {
+      readFile: (p) => {
+        if (p === "/test/a.ts") return `import "./b";`;
+        return "";
+      },
+      resolve,
+    });
+    expect(graph.droppedEdges).toBe(0);
+  });
+
+  test("onUnresolvable callback is called for each dropped edge", () => {
+    const dropped: { specifier: string; fromFile: string }[] = [];
+    const resolve: SpecifierResolver = (spec) => {
+      if (spec === "./good") return "/test/good.ts";
+      throw new Error("not found");
+    };
+    buildImportGraph(["/test/root.ts"], {
+      readFile: (p) => {
+        if (p === "/test/root.ts") return `import "./good"; import "./bad1"; import "./bad2";`;
+        return "";
+      },
+      resolve,
+      onUnresolvable: (specifier, fromFile) => dropped.push({ specifier, fromFile }),
+    });
+    expect(dropped).toHaveLength(2);
+    expect(dropped[0]).toEqual({ specifier: "./bad1", fromFile: "/test/root.ts" });
+    expect(dropped[1]).toEqual({ specifier: "./bad2", fromFile: "/test/root.ts" });
+  });
+
   test("works with real Bun.resolveSync on actual files", () => {
     const repoRoot = process.cwd();
     const src = `import { IpcMethod } from "./ipc";`;

--- a/scripts/rules/_engine/import-graph.ts
+++ b/scripts/rules/_engine/import-graph.ts
@@ -16,6 +16,12 @@ export interface ImportGraph {
   reverse: ReadonlyMap<string, ReadonlySet<string>>;
   /** All files in the graph. */
   files: ReadonlySet<string>;
+  /**
+   * Number of import specifiers that could not be resolved during graph construction.
+   * A non-zero value means the graph is incomplete — cycles involving unresolvable
+   * specifiers are invisible. Check this when assessing rule completeness.
+   */
+  droppedEdges: number;
   /** Compute the transitive import closure of a file (all files it depends on, transitively). */
   closureOf(file: string): ReadonlySet<string>;
   /** Compute the reverse closure (all files that transitively depend on a given file). */
@@ -107,6 +113,8 @@ function scriptKindFor(path: string): ts.ScriptKind {
 export interface BuildGraphOptions {
   readFile?: (path: string) => string;
   resolve?: SpecifierResolver;
+  /** Called for each specifier that could not be resolved. Use to collect diagnostics. */
+  onUnresolvable?: (specifier: string, fromFile: string) => void;
 }
 
 /**
@@ -124,6 +132,7 @@ export function buildImportGraph(
 ): ImportGraph {
   const readFile = typeof opts === "function" ? opts : (opts?.readFile ?? ((p: string) => readFileSync(p, "utf8")));
   const resolve = (typeof opts === "object" && opts !== null ? opts?.resolve : undefined) ?? defaultResolve;
+  const onUnresolvable = typeof opts === "object" && opts !== null ? opts?.onUnresolvable : undefined;
   const edges: MutableEdges = {
     forward: new Map(),
     reverse: new Map(),
@@ -131,6 +140,7 @@ export function buildImportGraph(
   const allFiles = new Set<string>();
   const queue = [...rootFiles];
   const visited = new Set<string>();
+  let droppedEdges = 0;
 
   while (queue.length > 0) {
     const file = queue.pop();
@@ -145,7 +155,20 @@ export function buildImportGraph(
       continue;
     }
 
-    const fileEdges = extractEdges(content, file, resolve);
+    const raw = parseSpecifiers(content, file);
+    const fileEdges: ImportEdge[] = [];
+    const dir = dirname(file);
+    for (const { specifier, isBarrelReExport } of raw) {
+      try {
+        const resolved = resolve(specifier, dir);
+        if (!isTerminal(resolved)) {
+          fileEdges.push({ target: resolved, isBarrelReExport });
+        }
+      } catch {
+        droppedEdges++;
+        onUnresolvable?.(specifier, file);
+      }
+    }
     edges.forward.set(file, fileEdges);
 
     for (const edge of fileEdges) {
@@ -172,10 +195,10 @@ export function buildImportGraph(
   // The `isBarrelReExport` flag is preserved for rule consumers that
   // want to distinguish barrel re-exports from direct imports.
 
-  return createGraph(edges, allFiles);
+  return createGraph(edges, allFiles, droppedEdges);
 }
 
-function createGraph(edges: MutableEdges, allFiles: Set<string>): ImportGraph {
+function createGraph(edges: MutableEdges, allFiles: Set<string>, droppedEdges: number): ImportGraph {
   const closureCache = new Map<string, ReadonlySet<string>>();
   const reverseClosureCache = new Map<string, ReadonlySet<string>>();
 
@@ -231,6 +254,7 @@ function createGraph(edges: MutableEdges, allFiles: Set<string>): ImportGraph {
     forward: edges.forward,
     reverse: edges.reverse,
     files: allFiles,
+    droppedEdges,
     closureOf,
     dependentsOf,
   };

--- a/scripts/rules/no-import-cycles.rule.spec.ts
+++ b/scripts/rules/no-import-cycles.rule.spec.ts
@@ -148,6 +148,29 @@ describe("rule integration", () => {
     expect(violations).toHaveLength(0);
   });
 
+  test("cache is isolated per files Map — distinct maps produce independent results", () => {
+    const file1 = makeFile({ path: "/fake/packages/core/src/a.ts", relPath: "packages/core/src/a.ts" });
+    const files1 = new Map([[file1.path, file1]]);
+    const file2 = makeFile({ path: "/fake/packages/core/src/b.ts", relPath: "packages/core/src/b.ts" });
+    const files2 = new Map([[file2.path, file2]]);
+
+    // Running against two distinct Map objects must not cross-contaminate.
+    const v1 = evaluateRule(rule, file1, files1);
+    const v2 = evaluateRule(rule, file2, files2);
+    expect(v1).toHaveLength(0);
+    expect(v2).toHaveLength(0);
+  });
+
+  test("same files Map reuses the cached result on second invocation", () => {
+    const file = makeFile();
+    const files = new Map([[file.path, file]]);
+    // Two evaluations with the same Map should both return the same result
+    // (the second call hits the WeakMap cache).
+    const v1 = evaluateRule(rule, file, files);
+    const v2 = evaluateRule(rule, file, files);
+    expect(v1).toEqual(v2);
+  });
+
   test("real codebase SCCs are intra-package (no cross-package cycles)", () => {
     const repoRoot = process.cwd();
     const coreIndex = `${repoRoot}/packages/core/src/index.ts`;

--- a/scripts/rules/no-import-cycles.rule.spec.ts
+++ b/scripts/rules/no-import-cycles.rule.spec.ts
@@ -6,7 +6,8 @@ import { buildImportGraph } from "./_engine/import-graph";
 import type { SpecifierResolver } from "./_engine/import-graph";
 import { evaluateRule } from "./_engine/rule";
 import { checkSuppression } from "./_engine/suppression";
-import rule, { findSCCs, findSelfImports, traceCycle } from "./no-import-cycles.rule";
+import rule, { _cycleCache, findSCCs, findSelfImports, traceCycle } from "./no-import-cycles.rule";
+import type { CycleInfo } from "./no-import-cycles.rule";
 
 // ── Helpers ────────────────────────────────────────────────────────────
 
@@ -154,21 +155,33 @@ describe("rule integration", () => {
     const file2 = makeFile({ path: "/fake/packages/core/src/b.ts", relPath: "packages/core/src/b.ts" });
     const files2 = new Map([[file2.path, file2]]);
 
-    // Running against two distinct Map objects must not cross-contaminate.
-    const v1 = evaluateRule(rule, file1, files1);
+    // Populate the cache for files1.
+    evaluateRule(rule, file1, files1);
+
+    // Poison files1's cache entry so it reports a self-import for file2's path.
+    // If the cache is not isolated, evaluating file2 against the distinct files2
+    // Map would incorrectly return this poisoned result.
+    const cache1 = _cycleCache.get(files1);
+    expect(cache1).toBeDefined();
+    const poison: CycleInfo = { cyclePath: [file2.path], isCrossPackage: false };
+    cache1?.set(file2.path, poison);
+
+    // Evaluating file2 against files2 (a distinct Map) must NOT see the poisoned
+    // entry from files1 — it must compute a fresh, clean result.
     const v2 = evaluateRule(rule, file2, files2);
-    expect(v1).toHaveLength(0);
     expect(v2).toHaveLength(0);
   });
 
   test("same files Map reuses the cached result on second invocation", () => {
     const file = makeFile();
     const files = new Map([[file.path, file]]);
-    // Two evaluations with the same Map should both return the same result
-    // (the second call hits the WeakMap cache).
-    const v1 = evaluateRule(rule, file, files);
-    const v2 = evaluateRule(rule, file, files);
-    expect(v1).toEqual(v2);
+
+    evaluateRule(rule, file, files);
+    const firstCacheMap = _cycleCache.get(files);
+
+    // Second call must return the same Map object — not recompute and replace it.
+    evaluateRule(rule, file, files);
+    expect(_cycleCache.get(files)).toBe(firstCacheMap);
   });
 
   test("real codebase SCCs are intra-package (no cross-package cycles)", () => {

--- a/scripts/rules/no-import-cycles.rule.ts
+++ b/scripts/rules/no-import-cycles.rule.ts
@@ -9,7 +9,7 @@ import type { CheckRule } from "./_engine/rule";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
-interface CycleInfo {
+export interface CycleInfo {
   cyclePath: string[];
   isCrossPackage: boolean;
 }
@@ -121,6 +121,9 @@ export function traceCycle(
 // Keyed by the files Map identity so the cache is scoped to the rule-engine
 // run. WeakMap means the entry is collected when the run's Map is GC'd.
 const cycleCache = new WeakMap<Map<string, FileMeta>, Map<string, CycleInfo>>();
+
+/** @internal — test-only visibility for cache isolation and reuse assertions */
+export const _cycleCache = cycleCache;
 
 function deriveRepoRoot(files: Map<string, FileMeta>): string {
   for (const meta of files.values()) {

--- a/scripts/rules/no-import-cycles.rule.ts
+++ b/scripts/rules/no-import-cycles.rule.ts
@@ -118,8 +118,9 @@ export function traceCycle(
 
 // ── Graph + cycle detection (cached per run) ───────────────────────────
 
-let cachedFilesRef: Map<string, FileMeta> | null = null;
-let cachedCycleMap: Map<string, CycleInfo> | null = null;
+// Keyed by the files Map identity so the cache is scoped to the rule-engine
+// run. WeakMap means the entry is collected when the run's Map is GC'd.
+const cycleCache = new WeakMap<Map<string, FileMeta>, Map<string, CycleInfo>>();
 
 function deriveRepoRoot(files: Map<string, FileMeta>): string {
   for (const meta of files.values()) {
@@ -131,7 +132,8 @@ function deriveRepoRoot(files: Map<string, FileMeta>): string {
 }
 
 function computeCycles(files: Map<string, FileMeta>): Map<string, CycleInfo> {
-  if (cachedFilesRef === files && cachedCycleMap) return cachedCycleMap;
+  const cached = cycleCache.get(files);
+  if (cached) return cached;
 
   const repoRoot = deriveRepoRoot(files);
   const contentMap = new Map<string, string>();
@@ -145,6 +147,12 @@ function computeCycles(files: Map<string, FileMeta>): Map<string, CycleInfo> {
   const graph = buildImportGraph(roots, {
     readFile: (p) => contentMap.get(p) ?? readFileSync(p, "utf8"),
   });
+
+  if (graph.droppedEdges > 0 && process.env.DEBUG) {
+    process.stderr.write(
+      `[no-import-cycles] ${graph.droppedEdges} unresolvable import specifier(s) dropped — graph may be incomplete\n`,
+    );
+  }
 
   const result = new Map<string, CycleInfo>();
 
@@ -167,8 +175,7 @@ function computeCycles(files: Map<string, FileMeta>): Map<string, CycleInfo> {
     });
   }
 
-  cachedFilesRef = files;
-  cachedCycleMap = result;
+  cycleCache.set(files, result);
   return result;
 }
 


### PR DESCRIPTION
## Summary

- **Edge-drop diagnostic**: `buildImportGraph` now counts unresolvable import specifiers and surfaces the total as `graph.droppedEdges`. A non-zero value means the graph is incomplete and cycles through unresolvable imports are invisible. `no-import-cycles` logs the count to stderr when `DEBUG` is set. An `onUnresolvable` callback on `BuildGraphOptions` lets callers collect per-specifier detail.
- **Cache hardening**: Replaced the two module-level `cachedFilesRef`/`cachedCycleMap` variables in `no-import-cycles.rule.ts` with a `WeakMap<Map<string, FileMeta>, Map<string, CycleInfo>>`. The cache is now scoped to the rule-engine run by Map identity — immune to a refactor constructing a new Map per rule (which would have silently busted the old reference-equality check every call).
- `extractEdges` public API is unchanged; `buildImportGraph` inlines the resolution loop to accumulate the count without touching the exported utility.

## Test plan

- [x] `droppedEdges` is 1 when exactly one specifier fails to resolve
- [x] `droppedEdges` is 0 when all specifiers resolve
- [x] `onUnresolvable` callback receives specifier + source file for each drop
- [x] Cache isolation: two distinct `files` Maps produce independent results (no cross-contamination)
- [x] Same `files` Map reuses cached result on second invocation
- [x] `bun run am-i-done --pre-commit` passes (typecheck + lint + rules)
- [x] Full test suite: 43/43 tests in modified files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)