### PR TITLE
fix(containment): strip Write/Edit from CLI --allowedTools for worktree sessions (fixes #2343)

### DIFF
--- a/packages/daemon/src/claude-session/containment.spec.ts
+++ b/packages/daemon/src/claude-session/containment.spec.ts
@@ -38,6 +38,12 @@ describe("ContainmentGuard — in-worktree operations", () => {
     expect(r.action).toBe("allow");
   });
 
+  test("allows MultiEdit inside worktree", () => {
+    const g = guard();
+    const r = g.evaluate("MultiEdit", { file_path: `${WORKTREE}/src/main.ts`, edits: [] });
+    expect(r.action).toBe("allow");
+  });
+
   test("allows Read inside worktree", () => {
     const g = guard();
     const r = g.evaluate("Read", { file_path: `${WORKTREE}/README.md` });
@@ -124,6 +130,14 @@ describe("ContainmentGuard — file writes outside worktree", () => {
     const r = g.evaluate("Edit", { file_path: "/Users/test/repo/b.ts" });
     expect(r.action).toBe("deny");
     expect(r.strikes).toBe(2);
+  });
+
+  test("denies MultiEdit outside worktree with strike", () => {
+    const g = guard();
+    const r = g.evaluate("MultiEdit", { file_path: "/Users/test/repo/src/main.ts", edits: [] });
+    expect(r.action).toBe("deny");
+    expect(r.event).toBe("session:containment_denied");
+    expect(r.strikes).toBe(1);
   });
 
   test("escalates on 3rd strike", () => {

--- a/packages/daemon/src/claude-session/containment.ts
+++ b/packages/daemon/src/claude-session/containment.ts
@@ -240,10 +240,14 @@ function extractBashWriteTargets(command: string): string[] {
   return targets;
 }
 
+// ── Containment-gated tool sets ──
+
+export const CONTAINMENT_WRITE_TOOLS: ReadonlySet<string> = new Set(["Write", "Edit", "NotebookEdit"]);
+
 // ── File path extraction ──
 
 function extractFilePath(toolName: string, input: Record<string, unknown>): string | null {
-  if (toolName === "Write" || toolName === "Edit" || toolName === "Read") {
+  if (toolName === "Write" || toolName === "Edit" || toolName === "Read" || toolName === "NotebookEdit") {
     const fp = input.file_path;
     return typeof fp === "string" ? fp : null;
   }

--- a/packages/daemon/src/claude-session/containment.ts
+++ b/packages/daemon/src/claude-session/containment.ts
@@ -242,12 +242,18 @@ function extractBashWriteTargets(command: string): string[] {
 
 // ── Containment-gated tool sets ──
 
-export const CONTAINMENT_WRITE_TOOLS: ReadonlySet<string> = new Set(["Write", "Edit", "NotebookEdit"]);
+export const CONTAINMENT_WRITE_TOOLS: ReadonlySet<string> = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
 
 // ── File path extraction ──
 
 function extractFilePath(toolName: string, input: Record<string, unknown>): string | null {
-  if (toolName === "Write" || toolName === "Edit" || toolName === "Read" || toolName === "NotebookEdit") {
+  if (
+    toolName === "Write" ||
+    toolName === "Edit" ||
+    toolName === "MultiEdit" ||
+    toolName === "Read" ||
+    toolName === "NotebookEdit"
+  ) {
     const fp = input.file_path;
     return typeof fp === "string" ? fp : null;
   }

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -321,6 +321,43 @@ describe("ClaudeWsServer", () => {
     expect(ms.lastCmd).toContain("my-tree");
   });
 
+  test("spawnClaude strips Write/Edit from --allowedTools for worktree sessions", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    await server.start();
+
+    server.prepareSession("wt-session", {
+      prompt: "Hello",
+      allowedTools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash(git:*)"],
+      worktree: "my-tree",
+    });
+    server.spawnClaude("wt-session");
+
+    expect(ms.lastCmd).toContain("--allowedTools");
+    expect(ms.lastCmd).toContain("Read");
+    expect(ms.lastCmd).toContain("Glob");
+    expect(ms.lastCmd).toContain("Grep");
+    expect(ms.lastCmd).toContain("Bash(git:*)");
+    expect(ms.lastCmd).not.toContain("Write");
+    expect(ms.lastCmd).not.toContain("Edit");
+  });
+
+  test("spawnClaude keeps Write/Edit in --allowedTools for non-worktree sessions", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    await server.start();
+
+    server.prepareSession("no-wt-session", {
+      prompt: "Hello",
+      allowedTools: ["Read", "Write", "Edit", "Glob"],
+    });
+    server.spawnClaude("no-wt-session");
+
+    expect(ms.lastCmd).toContain("--allowedTools");
+    expect(ms.lastCmd).toContain("Write");
+    expect(ms.lastCmd).toContain("Edit");
+  });
+
   test("spawnClaude passes --model flag when model is set in config", async () => {
     const ms = mockSpawn();
     server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
@@ -485,6 +522,87 @@ describe("ClaudeWsServer", () => {
       const parsed = JSON.parse(response.trim());
       expect(parsed.type).toBe("control_response");
       expect(parsed.response.response.behavior).toBe("deny");
+    } finally {
+      ws.close();
+    }
+  });
+
+  test("containment guard denies Write outside worktree via can_use_tool", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    const port = await server.start();
+
+    const worktreeCwd = "/Users/test/repo/.claude/worktrees/my-tree";
+    server.prepareSession("wt-session", {
+      prompt: "Hello",
+      worktree: "my-tree",
+      cwd: worktreeCwd,
+    });
+    server.spawnClaude("wt-session");
+
+    const ws = await connectMockClaude(port, "wt-session");
+    try {
+      await waitForMessage(ws);
+      ws.send(systemInitMessage("wt-session"));
+      const responsePromise = waitForMessage(ws);
+      ws.send(
+        serialize({
+          type: "control_request",
+          request_id: "req-escape",
+          request: {
+            subtype: "can_use_tool",
+            tool_name: "Write",
+            input: { file_path: "/Users/test/repo/.claire/worktrees/my-tree/src/bad.ts", content: "escape" },
+            tool_use_id: "tool-escape",
+          },
+        }),
+      );
+
+      const response = await responsePromise;
+      const parsed = JSON.parse(response.trim());
+      expect(parsed.type).toBe("control_response");
+      expect(parsed.response.response.behavior).toBe("deny");
+    } finally {
+      ws.close();
+    }
+  });
+
+  test("containment guard allows Write inside worktree via can_use_tool", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    const port = await server.start();
+
+    const worktreeCwd = "/Users/test/repo/.claude/worktrees/my-tree";
+    server.prepareSession("wt-session-ok", {
+      prompt: "Hello",
+      worktree: "my-tree",
+      cwd: worktreeCwd,
+      permissionStrategy: "auto",
+    });
+    server.spawnClaude("wt-session-ok");
+
+    const ws = await connectMockClaude(port, "wt-session-ok");
+    try {
+      await waitForMessage(ws);
+      ws.send(systemInitMessage("wt-session-ok"));
+      const responsePromise = waitForMessage(ws);
+      ws.send(
+        serialize({
+          type: "control_request",
+          request_id: "req-ok",
+          request: {
+            subtype: "can_use_tool",
+            tool_name: "Write",
+            input: { file_path: `${worktreeCwd}/src/good.ts`, content: "safe" },
+            tool_use_id: "tool-ok",
+          },
+        }),
+      );
+
+      const response = await responsePromise;
+      const parsed = JSON.parse(response.trim());
+      expect(parsed.type).toBe("control_response");
+      expect(parsed.response.response.behavior).toBe("allow");
     } finally {
       ws.close();
     }

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -321,14 +321,14 @@ describe("ClaudeWsServer", () => {
     expect(ms.lastCmd).toContain("my-tree");
   });
 
-  test("spawnClaude strips Write/Edit from --allowedTools for worktree sessions", async () => {
+  test("spawnClaude strips Write/Edit/NotebookEdit from --allowedTools for worktree sessions", async () => {
     const ms = mockSpawn();
     server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
     await server.start();
 
     server.prepareSession("wt-session", {
       prompt: "Hello",
-      allowedTools: ["Read", "Write", "Edit", "Glob", "Grep", "Bash(git:*)"],
+      allowedTools: ["Read", "Write", "Edit", "NotebookEdit", "Glob", "Grep", "Bash(git:*)"],
       worktree: "my-tree",
     });
     server.spawnClaude("wt-session");
@@ -340,6 +340,7 @@ describe("ClaudeWsServer", () => {
     expect(ms.lastCmd).toContain("Bash(git:*)");
     expect(ms.lastCmd).not.toContain("Write");
     expect(ms.lastCmd).not.toContain("Edit");
+    expect(ms.lastCmd).not.toContain("NotebookEdit");
   });
 
   test("spawnClaude keeps Write/Edit in --allowedTools for non-worktree sessions", async () => {
@@ -356,6 +357,23 @@ describe("ClaudeWsServer", () => {
     expect(ms.lastCmd).toContain("--allowedTools");
     expect(ms.lastCmd).toContain("Write");
     expect(ms.lastCmd).toContain("Edit");
+  });
+
+  test("spawnClaude omits --allowedTools when all tools are containment-gated in worktree session", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    await server.start();
+
+    server.prepareSession("wt-only-write", {
+      prompt: "Hello",
+      allowedTools: ["Write", "Edit"],
+      worktree: "my-tree",
+    });
+    server.spawnClaude("wt-only-write");
+
+    expect(ms.lastCmd).not.toContain("--allowedTools");
+    expect(ms.lastCmd).not.toContain("Write");
+    expect(ms.lastCmd).not.toContain("Edit");
   });
 
   test("spawnClaude passes --model flag when model is set in config", async () => {

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -321,14 +321,14 @@ describe("ClaudeWsServer", () => {
     expect(ms.lastCmd).toContain("my-tree");
   });
 
-  test("spawnClaude strips Write/Edit/NotebookEdit from --allowedTools for worktree sessions", async () => {
+  test("spawnClaude strips Write/Edit/MultiEdit/NotebookEdit from --allowedTools for worktree sessions", async () => {
     const ms = mockSpawn();
     server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
     await server.start();
 
     server.prepareSession("wt-session", {
       prompt: "Hello",
-      allowedTools: ["Read", "Write", "Edit", "NotebookEdit", "Glob", "Grep", "Bash(git:*)"],
+      allowedTools: ["Read", "Write", "Edit", "MultiEdit", "NotebookEdit", "Glob", "Grep", "Bash(git:*)"],
       worktree: "my-tree",
     });
     server.spawnClaude("wt-session");
@@ -340,7 +340,28 @@ describe("ClaudeWsServer", () => {
     expect(ms.lastCmd).toContain("Bash(git:*)");
     expect(ms.lastCmd).not.toContain("Write");
     expect(ms.lastCmd).not.toContain("Edit");
+    expect(ms.lastCmd).not.toContain("MultiEdit");
     expect(ms.lastCmd).not.toContain("NotebookEdit");
+  });
+
+  test("spawnClaude strips argument-scoped write tool patterns from --allowedTools for worktree sessions", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    await server.start();
+
+    server.prepareSession("wt-arg-session", {
+      prompt: "Hello",
+      allowedTools: ["Read", "Write(/tmp/file)", "Edit(src/**)", "Glob", "Bash(git:*)"],
+      worktree: "my-tree",
+    });
+    server.spawnClaude("wt-arg-session");
+
+    expect(ms.lastCmd).toContain("--allowedTools");
+    expect(ms.lastCmd).toContain("Read");
+    expect(ms.lastCmd).toContain("Glob");
+    expect(ms.lastCmd).toContain("Bash(git:*)");
+    expect(ms.lastCmd).not.toContain("Write(/tmp/file)");
+    expect(ms.lastCmd).not.toContain("Edit(src/**)");
   });
 
   test("spawnClaude keeps Write/Edit in --allowedTools for non-worktree sessions", async () => {

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -626,6 +626,60 @@ describe("ClaudeWsServer", () => {
     }
   });
 
+  test("containment guard initializes from session:init cwd when config.cwd is absent (worktree mode)", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    const port = await server.start();
+
+    const worktreeCwd = "/Users/test/repo/.claude/worktrees/wt-init";
+    server.prepareSession("wt-no-cwd", {
+      prompt: "Hello",
+      worktree: "wt-init",
+    });
+    server.spawnClaude("wt-no-cwd");
+
+    const ws = await connectMockClaude(port, "wt-no-cwd");
+    try {
+      await waitForMessage(ws);
+      ws.send(
+        serialize({
+          type: "system",
+          subtype: "init",
+          cwd: worktreeCwd,
+          session_id: "wt-no-cwd",
+          tools: ["Read", "Write"],
+          mcp_servers: [],
+          model: "claude-sonnet-4-6",
+          permissionMode: "default",
+          apiKeySource: "test",
+          claude_code_version: "2.1.70",
+          uuid: "test-uuid",
+        }),
+      );
+
+      const responsePromise = waitForMessage(ws);
+      ws.send(
+        serialize({
+          type: "control_request",
+          request_id: "req-escape-init",
+          request: {
+            subtype: "can_use_tool",
+            tool_name: "Write",
+            input: { file_path: "/Users/test/repo/src/escaped.ts", content: "bad" },
+            tool_use_id: "tool-escape-init",
+          },
+        }),
+      );
+
+      const response = await responsePromise;
+      const parsed = JSON.parse(response.trim());
+      expect(parsed.type).toBe("control_response");
+      expect(parsed.response.response.behavior).toBe("deny");
+    } finally {
+      ws.close();
+    }
+  });
+
   test("listSessions returns session info", async () => {
     const ms = mockSpawn();
     server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -826,7 +826,10 @@ export class ClaudeWsServer {
     }
     let cliAllowedTools = session.config.allowedTools;
     if (session.config.worktree && cliAllowedTools?.length) {
-      cliAllowedTools = cliAllowedTools.filter((t) => !CONTAINMENT_WRITE_TOOLS.has(t));
+      cliAllowedTools = cliAllowedTools.filter((t) => {
+        const baseName = t.split("(")[0] ?? t;
+        return !CONTAINMENT_WRITE_TOOLS.has(baseName);
+      });
     }
     if (cliAllowedTools?.length) {
       cmd.push("--allowedTools", ...cliAllowedTools);

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -56,7 +56,7 @@ import {
 import type { ServerWebSocket } from "bun";
 import { killPid } from "../process-util";
 import { safeSetInterval, safeSetTimeout } from "../safe-timers";
-import { ContainmentGuard } from "./containment";
+import { CONTAINMENT_WRITE_TOOLS, ContainmentGuard } from "./containment";
 import type { NdjsonMessage } from "./ndjson";
 import { keepAlive, parseFrame, permissionAllow, permissionDeny, setModelRequest, userMessage } from "./ndjson";
 import type { CanUseToolRequest, PermissionRule, PermissionStrategy } from "./permission-router";
@@ -826,8 +826,7 @@ export class ClaudeWsServer {
     }
     let cliAllowedTools = session.config.allowedTools;
     if (session.config.worktree && cliAllowedTools?.length) {
-      const CONTAINMENT_GATED = new Set(["Write", "Edit"]);
-      cliAllowedTools = cliAllowedTools.filter((t) => !CONTAINMENT_GATED.has(t));
+      cliAllowedTools = cliAllowedTools.filter((t) => !CONTAINMENT_WRITE_TOOLS.has(t));
     }
     if (cliAllowedTools?.length) {
       cmd.push("--allowedTools", ...cliAllowedTools);

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -824,8 +824,13 @@ export class ClaudeWsServer {
     if (session.config.model) {
       cmd.push("--model", session.config.model);
     }
-    if (session.config.allowedTools?.length) {
-      cmd.push("--allowedTools", ...session.config.allowedTools);
+    let cliAllowedTools = session.config.allowedTools;
+    if (session.config.worktree && cliAllowedTools?.length) {
+      const CONTAINMENT_GATED = new Set(["Write", "Edit"]);
+      cliAllowedTools = cliAllowedTools.filter((t) => !CONTAINMENT_GATED.has(t));
+    }
+    if (cliAllowedTools?.length) {
+      cmd.push("--allowedTools", ...cliAllowedTools);
     }
     if (session.config.worktree && !session.config.cwd) {
       // Only pass --worktree when cwd is not set. When both are present,

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -1734,6 +1734,9 @@ export class ClaudeWsServer {
       case "session:init":
         // Capture Claude Code's own session ID for JSONL file lookup
         session.claudeSessionId = event.sessionId;
+        if (session.worktree && !session.containment && event.cwd) {
+          session.containment = new ContainmentGuard(event.cwd);
+        }
         this.recordSessionProgress(sessionId, session);
         break;
       case "session:response":


### PR DESCRIPTION
## Summary
- Strip `Write`, `Edit`, `MultiEdit`, and `NotebookEdit` from `--allowedTools` passed to Claude Code CLI when spawning worktree sessions, so these tools are no longer auto-approved by the CLI
- The strip logic parses the base tool name from argument-scoped patterns (e.g. `Write(/tmp)`, `Edit(src/**)`) before comparing against the gated set
- The daemon's permission router and containment guard handle all write-capable tools — they see every `can_use_tool` request and can deny paths outside the worktree
- Non-worktree sessions are unaffected; write tools remain in their `--allowedTools`

## Root cause
Claude Code CLI auto-approves tools listed in `--allowedTools` internally without emitting `can_use_tool` control requests. The daemon's `ContainmentGuard` only intercepts incoming `can_use_tool` requests, so it was completely bypassed for write calls — allowing LLM-hallucinated paths (e.g. `.claire` typo) to write outside the worktree.

## What's gated
`CONTAINMENT_WRITE_TOOLS` in `containment.ts` is the single source of truth: `Write`, `Edit`, `MultiEdit`, `NotebookEdit`. The `extractFilePath` function handles all of these (all use `file_path` input). The strip filter in `ws-server.ts` splits on `(` to handle argument-scoped patterns before checking the set.

## Test plan
- [x] `spawnClaude` strips Write/Edit/MultiEdit/NotebookEdit from `--allowedTools` for worktree sessions
- [x] `spawnClaude` strips argument-scoped patterns like `Write(/tmp/file)` and `Edit(src/**)`
- [x] `spawnClaude` keeps Write/Edit in `--allowedTools` for non-worktree sessions
- [x] Containment guard denies Write outside worktree via `can_use_tool` WS protocol
- [x] Containment guard allows Write inside worktree via `can_use_tool` WS protocol
- [x] Containment guard denies MultiEdit outside worktree, allows inside
- [x] Containment guard initializes from `session:init` cwd when `config.cwd` is absent
- [x] `bun run am-i-done` passes (typecheck, lint, rules, tests, coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)