### PR TITLE
refactor(core): break alias-bundle barrel-induced import cycle (fixes #2486)

### DIFF
--- a/packages/core/src/alias-bundle-core.ts
+++ b/packages/core/src/alias-bundle-core.ts
@@ -1,7 +1,11 @@
+// Re-exports all of @mcp-cli/core except alias-bundle itself.
+// Used as __mcp_core__ inside evalBundledJs so that phase scripts that write
+//   import { X } from "@mcp-cli/core"
+// can resolve X at eval time without creating the barrel-induced import cycle.
 export * from "./alias";
+export * from "./alias-bundle-types";
 export * from "./alias-dry-run";
 export * from "./alias-state";
-export * from "./alias-bundle";
 export * from "./allow-patterns";
 export * from "./cache";
 export * from "./ipc";

--- a/packages/core/src/alias-bundle-types.ts
+++ b/packages/core/src/alias-bundle-types.ts
@@ -1,0 +1,8 @@
+/** Minimal metadata captured from a single defineMonitor() call in an alias file. */
+export interface MonitorAliasMetadata {
+  name: string;
+  description?: string;
+}
+
+/** Discriminator for alias scripts: freeform side-effect, defineAlias, or defineMonitor. */
+export type AliasType = "freeform" | "defineAlias" | "defineMonitor";

--- a/packages/core/src/alias-bundle.ts
+++ b/packages/core/src/alias-bundle.ts
@@ -1,4 +1,3 @@
-// dotw-todo no-import-cycles: barrel-induced intra-package cycle via dynamic import("./index") at L193 — fix in #2486
 /**
  * Alias bundling and execution via Bun.build + AsyncFunction eval.
  *
@@ -13,6 +12,8 @@
 
 import { z } from "zod/v4";
 import type { AliasContext, AliasDefinition, AliasMonitorEventInput, McpProxy, MonitorAliasDefinition } from "./alias";
+import type { MonitorAliasMetadata } from "./alias-bundle-types";
+export type { MonitorAliasMetadata } from "./alias-bundle-types";
 import type { AutomationDefinition } from "./automation";
 import { defineAutomation } from "./automation";
 import { MONITOR_CATEGORIES } from "./monitor-event";
@@ -32,15 +33,6 @@ export const stubProxy: McpProxy = new Proxy({} as McpProxy, {
     );
   },
 });
-
-/**
- * Minimal metadata captured from a single defineMonitor() call in an alias file.
- * filePath and sourceHash are stored at the alias row level, not per-monitor.
- */
-export interface MonitorAliasMetadata {
-  name: string;
-  description?: string;
-}
 
 /** Metadata extracted from a defineAlias script at save-time. */
 export interface AliasMetadata {
@@ -187,11 +179,13 @@ async function evalBundledJs(
 ): Promise<EvalResult> {
   const stripped = stripModuleSyntax(bundledJs);
 
-  // Lazy-load the @mcp-cli/core barrel at eval time. alias-bundle.ts is part
-  // of core and re-exported from ./index, so static `import * as` would
-  // self-cycle; dynamic import defers resolution until all sibling modules
-  // are initialized.
-  const coreBarrel = await import("./index");
+  // Lazy-load the @mcp-cli/core exports at eval time so phase scripts that
+  // write `import { X } from "@mcp-cli/core"` can destructure X from the
+  // injected __mcp_core__ namespace.  We import from alias-bundle-core (not
+  // index) to avoid the barrel-induced cycle: index re-exports alias-bundle,
+  // so a static or dynamic import of index from inside alias-bundle would
+  // create alias-bundle → index → alias-bundle.
+  const coreBarrel = await import("./alias-bundle-core");
 
   let aliasDef: AliasDefinition | null = null;
   let automationDef: AutomationDefinition | null = null;

--- a/packages/core/src/alias-dry-run.ts
+++ b/packages/core/src/alias-dry-run.ts
@@ -1,4 +1,3 @@
-// dotw-todo no-import-cycles: barrel-induced intra-package cycle via core/index.ts — fix in #2486
 /**
  * Dry-run context for phases (#1296).
  *

--- a/packages/core/src/alias-state.ts
+++ b/packages/core/src/alias-state.ts
@@ -1,4 +1,3 @@
-// dotw-todo no-import-cycles: barrel-induced intra-package cycle via core/index.ts — fix in #2486
 /**
  * Factory for ctx.state / ctx.globalState accessors.
  *

--- a/packages/core/src/alias.ts
+++ b/packages/core/src/alias.ts
@@ -1,9 +1,9 @@
-// dotw-todo no-import-cycles: barrel-induced intra-package cycle via core/index.ts — fix in #2486
 /**
  * Alias definition types for structured defineAlias() aliases.
  */
 
 import type { z } from "zod/v4";
+export type { AliasType } from "./alias-bundle-types";
 import type { EventFilterSpec } from "./event-filter";
 import type { GhClient } from "./gh-client";
 import { ToolResultError } from "./mcp-result";
@@ -214,9 +214,6 @@ export interface AliasDefinition<I = unknown, O = unknown> {
   output?: z.ZodType<O>;
   fn: (input: I, ctx: AliasContext) => O | Promise<O>;
 }
-
-/** Alias type discriminant for DB and IPC */
-export type AliasType = "freeform" | "defineAlias" | "defineMonitor";
 
 /** Context passed to a defineMonitor subscribe function */
 export interface MonitorContext {

--- a/packages/core/src/automation.ts
+++ b/packages/core/src/automation.ts
@@ -1,4 +1,3 @@
-// dotw-todo no-import-cycles: barrel-induced intra-package cycle via core/index.ts — fix in #2486
 /**
  * Automation module types, schemas, and helpers.
  *

--- a/packages/core/src/branch-guard.ts
+++ b/packages/core/src/branch-guard.ts
@@ -1,4 +1,3 @@
-// dotw-todo no-import-cycles: barrel-induced intra-package cycle via core/index.ts — fix in #2486
 /**
  * Phase `runsOn` branch guard (epic #1286, issue #1294).
  *

--- a/packages/core/src/cache.ts
+++ b/packages/core/src/cache.ts
@@ -1,4 +1,3 @@
-// dotw-todo no-import-cycles: barrel-induced intra-package cycle via core/index.ts — fix in #2486
 /**
  * File-based cache for defineAlias handlers.
  *

--- a/packages/core/src/event-filter.ts
+++ b/packages/core/src/event-filter.ts
@@ -1,4 +1,3 @@
-// dotw-todo no-import-cycles: barrel-induced intra-package cycle via core/index.ts — fix in #2486
 /**
  * Shared event filter predicate for monitor events.
  *

--- a/packages/core/src/ipc-client.ts
+++ b/packages/core/src/ipc-client.ts
@@ -1,4 +1,3 @@
-// dotw-todo no-import-cycles: barrel-induced intra-package cycle via core/index.ts — fix in #2486
 /**
  * IPC client — connects to mcpd daemon via HTTP-over-Unix-socket.
  *

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -1,4 +1,3 @@
-// dotw-todo no-import-cycles: barrel-induced intra-package cycle via core/index.ts — fix in #2486
 /**
  * IPC protocol between mcx (command) and mcpd (daemon).
  *
@@ -8,8 +7,7 @@
 
 import { isAbsolute } from "node:path";
 import { z } from "zod/v4";
-import type { AliasType } from "./alias";
-import type { MonitorAliasMetadata } from "./alias-bundle";
+import type { AliasType, MonitorAliasMetadata } from "./alias-bundle-types";
 import { MONITOR_CATEGORIES } from "./monitor-event";
 import type { PlanProtocolCapability } from "./plan";
 import type { SpanEvent } from "./trace";

--- a/packages/core/src/manifest.ts
+++ b/packages/core/src/manifest.ts
@@ -1,4 +1,3 @@
-// dotw-todo no-import-cycles: barrel-induced intra-package cycle via core/index.ts — fix in #2486
 /**
  * Project-level orchestration manifest: `.mcx.{yaml,yml,json}`.
  *

--- a/packages/core/src/mcp-proxy.ts
+++ b/packages/core/src/mcp-proxy.ts
@@ -1,4 +1,3 @@
-// dotw-todo no-import-cycles: barrel-induced intra-package cycle via core/index.ts — fix in #2486
 /**
  * Shared MCP proxy factory.
  *

--- a/packages/core/src/phase-transition.ts
+++ b/packages/core/src/phase-transition.ts
@@ -1,4 +1,3 @@
-// dotw-todo no-import-cycles: barrel-induced intra-package cycle via core/index.ts — fix in #2486
 /**
  * Phase transition graph enforcement (issue #1293).
  *

--- a/packages/core/src/worktree-config.ts
+++ b/packages/core/src/worktree-config.ts
@@ -1,4 +1,3 @@
-// dotw-todo no-import-cycles: barrel-induced intra-package cycle via core/index.ts — fix in #2486
 /**
  * Per-repo worktree lifecycle hook configuration.
  *

--- a/packages/core/src/worktree-shim.ts
+++ b/packages/core/src/worktree-shim.ts
@@ -1,4 +1,3 @@
-// dotw-todo no-import-cycles: barrel-induced intra-package cycle via core/index.ts — fix in #2486
 /**
  * Worktree lifecycle shim — generic worktree management for all providers.
  *


### PR DESCRIPTION
## Summary
- Extract `MonitorAliasMetadata` and `AliasType` into `alias-bundle-types.ts` (a true leaf with no intra-package imports)
- Add `alias-bundle-core.ts` that mirrors the `@mcp-cli/core` barrel without the `alias-bundle` re-export, used as `__mcp_core__` in `evalBundledJs` so phase scripts can resolve core imports at eval time without the barrel cycle
- Change `alias-bundle.ts`'s `dynamic import("./index")` → `import("./alias-bundle-core")`, severing the `alias-bundle → index → alias-bundle` cycle; fix `ipc.ts` to import from the leaf instead of `alias.ts`, collapsing the secondary 4-node SCC (`alias → event-filter → ipc-client → ipc → alias`)
- Remove all 14 `dotw-todo no-import-cycles` suppressions across `packages/core/src/` — the underlying SCCs are gone and `bun run doing-it-wrong -- --rule no-import-cycles` passes with zero suppressions

## Test plan
- [x] `bun run doing-it-wrong -- --rule no-import-cycles` passes with no suppressions on `alias-bundle.ts` or any other core file
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] All 1101 tests pass
- [x] `bun run am-i-done` passes (full gate: typecheck → lint → rules → tests → coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)