### PR TITLE
fix(monitor): reconcile monitor context types, eliminate double-emit risk (fixes #2497)

### DIFF
--- a/packages/command/src/commands/typegen.ts
+++ b/packages/command/src/commands/typegen.ts
@@ -125,7 +125,6 @@ export function generateDeclarations(tools: ToolInfo[]): string {
     "  }",
     "  interface MonitorAliasContext {",
     "    signal: AbortSignal;",
-    "    bus: { publish(input: AliasMonitorEventInput): void };",
     "    logger: MonitorAliasLogger;",
     "  }",
     "  interface MonitorAliasDefinition<E extends AliasMonitorEventInput = AliasMonitorEventInput> {",

--- a/packages/core/src/alias-bundle.ts
+++ b/packages/core/src/alias-bundle.ts
@@ -531,7 +531,6 @@ declare module "mcp-cli" {
   }
   export interface MonitorAliasContext {
     signal: AbortSignal;
-    bus: { publish(input: AliasMonitorEventInput): void };
     logger: MonitorAliasLogger;
   }
   export interface MonitorAliasDefinition<E extends AliasMonitorEventInput = AliasMonitorEventInput> {

--- a/packages/core/src/alias.ts
+++ b/packages/core/src/alias.ts
@@ -213,7 +213,6 @@ export interface AliasDefinition<I = unknown, O = unknown> {
   fn: (input: I, ctx: AliasContext) => O | Promise<O>;
 }
 
-
 /**
  * Unwrap MCP tool call result content for ergonomic alias authoring.
  *

--- a/packages/core/src/alias.ts
+++ b/packages/core/src/alias.ts
@@ -59,8 +59,6 @@ export interface MonitorAliasLogger {
 export interface MonitorAliasContext {
   /** Fired when the alias is disabled or the daemon is shutting down */
   signal: AbortSignal;
-  /** For fire-and-forget side events that shouldn't interrupt the generator */
-  bus: { publish(input: AliasMonitorEventInput): void };
   logger: MonitorAliasLogger;
 }
 
@@ -215,28 +213,6 @@ export interface AliasDefinition<I = unknown, O = unknown> {
   fn: (input: I, ctx: AliasContext) => O | Promise<O>;
 }
 
-/** Context passed to a defineMonitor subscribe function */
-export interface MonitorContext {
-  signal: AbortSignal;
-  mcp: McpProxy;
-}
-
-/**
- * Structured monitor definition with an async generator that yields events.
- *
- * At the defineMonitor call site:
- *   defineMonitor({
- *     name: "my-monitor",
- *     subscribe: async function*(ctx) {
- *       yield { event: "tick", category: "heartbeat" };
- *     },
- *   })
- */
-export interface MonitorDefinition {
-  name: string;
-  description?: string;
-  subscribe: (ctx: MonitorContext) => AsyncGenerator<Record<string, unknown>>;
-}
 
 /**
  * Unwrap MCP tool call result content for ergonomic alias authoring.

--- a/packages/daemon/src/monitor-executor.spec.ts
+++ b/packages/daemon/src/monitor-executor.spec.ts
@@ -1,0 +1,176 @@
+import { describe, expect, setDefaultTimeout, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { bundleAlias } from "@mcp-cli/core";
+
+setDefaultTimeout(10_000);
+
+const EXECUTOR_PATH = resolve("packages/daemon/src/monitor-executor.ts");
+
+function makeTmpDir(): string {
+  const dir = join(tmpdir(), `monitor-executor-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeScript(dir: string, name: string, source: string): string {
+  const path = join(dir, `${name}.ts`);
+  writeFileSync(path, source);
+  return path;
+}
+
+async function bundleScript(filePath: string): Promise<string> {
+  const result = await bundleAlias(filePath);
+  return result.js;
+}
+
+async function runExecutor(
+  bundledJs: string,
+  aliasName: string,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = Bun.spawn([process.execPath, EXECUTOR_PATH], {
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const payload = JSON.stringify({ bundledJs, aliasName });
+  proc.stdin.write(payload);
+  await proc.stdin.end();
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  return { stdout, stderr, exitCode: exitCode ?? 1 };
+}
+
+function parseNdjson(stdout: string): Record<string, unknown>[] {
+  return stdout
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as Record<string, unknown>);
+}
+
+describe("monitor-executor", () => {
+  test("yields 3 events produces exactly 3 NDJSON lines on stdout", async () => {
+    const dir = makeTmpDir();
+    const scriptPath = writeScript(
+      dir,
+      "ticker",
+      `import { defineMonitor } from "mcp-cli";
+defineMonitor({
+  name: "ticker",
+  subscribe: async function*(ctx) {
+    for (let i = 0; i < 3; i++) {
+      yield { event: "tick", category: "heartbeat", count: i };
+    }
+  },
+});`,
+    );
+
+    const bundledJs = await bundleScript(scriptPath);
+    const { stdout, exitCode } = await runExecutor(bundledJs, "ticker");
+
+    expect(exitCode).toBe(0);
+    const events = parseNdjson(stdout);
+    expect(events).toHaveLength(3);
+    expect(events[0]).toMatchObject({ event: "tick", count: 0 });
+    expect(events[2]).toMatchObject({ event: "tick", count: 2 });
+  });
+
+  test("no double-emit: yielded events appear exactly once", async () => {
+    const dir = makeTmpDir();
+    const scriptPath = writeScript(
+      dir,
+      "no-double",
+      `import { defineMonitor } from "mcp-cli";
+defineMonitor({
+  name: "no-double",
+  subscribe: async function*(ctx) {
+    yield { event: "yielded", n: 1 };
+    yield { event: "yielded", n: 2 };
+  },
+});`,
+    );
+
+    const bundledJs = await bundleScript(scriptPath);
+    const { stdout, exitCode } = await runExecutor(bundledJs, "no-double");
+
+    expect(exitCode).toBe(0);
+    const events = parseNdjson(stdout);
+    expect(events).toHaveLength(2);
+  });
+
+  test("logger writes go to stderr, not stdout", async () => {
+    const dir = makeTmpDir();
+    const scriptPath = writeScript(
+      dir,
+      "logger-test",
+      `import { defineMonitor } from "mcp-cli";
+defineMonitor({
+  name: "logger-test",
+  subscribe: async function*(ctx) {
+    ctx.logger.info("hello from info");
+    ctx.logger.warn("hello from warn");
+    yield { event: "done" };
+  },
+});`,
+    );
+
+    const bundledJs = await bundleScript(scriptPath);
+    const { stdout, stderr, exitCode } = await runExecutor(bundledJs, "logger-test");
+
+    expect(exitCode).toBe(0);
+    const events = parseNdjson(stdout);
+    expect(events).toHaveLength(1);
+    expect(stderr).toContain("hello from info");
+    expect(stderr).toContain("hello from warn");
+  });
+
+  test("generator error exits non-zero", async () => {
+    const dir = makeTmpDir();
+    const scriptPath = writeScript(
+      dir,
+      "crasher",
+      `import { defineMonitor } from "mcp-cli";
+defineMonitor({
+  name: "crasher",
+  subscribe: async function*(ctx) {
+    throw new Error("boom");
+  },
+});`,
+    );
+
+    const bundledJs = await bundleScript(scriptPath);
+    const { exitCode, stderr } = await runExecutor(bundledJs, "crasher");
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("boom");
+  });
+
+  test("empty generator exits cleanly with no output", async () => {
+    const dir = makeTmpDir();
+    const scriptPath = writeScript(
+      dir,
+      "empty",
+      `import { defineMonitor } from "mcp-cli";
+defineMonitor({
+  name: "empty",
+  subscribe: async function*(ctx) {
+    // yields nothing
+  },
+});`,
+    );
+
+    const bundledJs = await bundleScript(scriptPath);
+    const { stdout, exitCode } = await runExecutor(bundledJs, "empty");
+
+    expect(exitCode).toBe(0);
+    expect(stdout.trim()).toBe("");
+  });
+});

--- a/packages/daemon/src/monitor-executor.ts
+++ b/packages/daemon/src/monitor-executor.ts
@@ -41,9 +41,6 @@ async function main(): Promise<void> {
 
   const gen = monitor.subscribe({
     signal: ac.signal,
-    bus: {
-      publish: (event) => process.stdout.write(`${JSON.stringify(event)}\n`),
-    },
     logger: {
       info: (msg) => process.stderr.write(`[monitor:${aliasName}] info: ${msg}\n`),
       warn: (msg) => process.stderr.write(`[monitor:${aliasName}] warn: ${msg}\n`),


### PR DESCRIPTION
## Summary
- Delete dead `MonitorContext` and `MonitorDefinition` types from `alias.ts` — unused relics that conflicted with the live `MonitorAliasContext`
- Remove `bus.publish` from `MonitorAliasContext` and the executor context wiring — `yield` via the `for await` loop is the sole NDJSON output channel, eliminating the double-emit risk where both `bus.publish` and `for await` wrote to the same stdout pipe
- Add `monitor-executor.spec.ts` (5 tests) covering event output, no-double-emit invariant, logger→stderr routing, crash exits, and empty generators

## Test plan
- [x] New `monitor-executor.spec.ts` passes (5/5)
- [x] Existing `monitor-runtime.spec.ts` passes (14/14) — no regressions from removing `bus`
- [x] Full test suite passes (8270/8270)
- [x] `bun typecheck` clean
- [x] `bun lint` clean
- [x] `bun run doing-it-wrong` clean
- [x] Coverage ratchet passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)