### PR TITLE
refactor(clone): migrate provider local unwrapToolResult copies to shared core helper (fixes #2317)

### DIFF
--- a/packages/clone/src/providers/asana.spec.ts
+++ b/packages/clone/src/providers/asana.spec.ts
@@ -109,12 +109,12 @@ describe("validateScopeKey (via resolveScope)", () => {
     const provider = createAsanaProvider({
       callTool: async (_server, tool, _args) => {
         if (tool === "getProject") {
-          return {
+          return wrapMcpResult({
             gid: "1234567890",
             name: "My Project",
             workspace: { gid: "ws-1", name: "My Workspace" },
             permalink_url: "https://app.asana.com/0/1234567890",
-          };
+          });
         }
         return null;
       },
@@ -130,12 +130,12 @@ describe("resolveScope", () => {
     const provider = createAsanaProvider({
       callTool: async (_server, tool, _args) => {
         if (tool === "getProject") {
-          return {
+          return wrapMcpResult({
             gid: "proj-1",
             name: "My Project",
             workspace: { gid: "ws-1", name: "My Workspace" },
             permalink_url: "https://app.asana.com/0/proj-1",
-          };
+          });
         }
         return null;
       },
@@ -151,11 +151,11 @@ describe("resolveScope", () => {
     const provider = createAsanaProvider({
       callTool: async (_server, tool, _args) => {
         if (tool === "getProject") {
-          return {
+          return wrapMcpResult({
             gid: "proj-1",
             name: "My Project",
             workspace: { gid: "ws-1", name: "My Workspace" },
-          };
+          });
         }
         return null;
       },
@@ -167,7 +167,7 @@ describe("resolveScope", () => {
 
   test("throws when project not found", async () => {
     const provider = createAsanaProvider({
-      callTool: async () => null,
+      callTool: async () => wrapMcpResult(null),
     });
     await expect(provider.resolveScope({ key: "nonexistent" })).rejects.toThrow("not found");
   });
@@ -184,7 +184,7 @@ describe("unwrapToolResult — isError handling", () => {
       },
     });
 
-    await expect(provider.resolveScope({ key: "proj-1" })).rejects.toThrow("MCP tool error: Rate limit exceeded");
+    await expect(provider.resolveScope({ key: "proj-1" })).rejects.toThrow("Rate limit exceeded");
   });
 
   test("throws on isError during list", async () => {
@@ -205,7 +205,7 @@ describe("unwrapToolResult — isError handling", () => {
       for await (const entry of provider.list(makeScope())) {
         entries.push(entry);
       }
-    }).toThrow("MCP tool error");
+    }).toThrow("403 Forbidden");
   });
 });
 
@@ -698,7 +698,7 @@ describe("create", () => {
 describe("delete", () => {
   test("calls deleteTask with correct task_gid", async () => {
     const scope = makeScope();
-    const { callTool, calls } = makeCallTool();
+    const { callTool, calls } = makeCallTool({ deleteTask: wrapMcpResult(null) });
     const provider = createAsanaProvider({ callTool });
 
     const deleteFn = provider.delete as NonNullable<typeof provider.delete>;

--- a/packages/clone/src/providers/asana.ts
+++ b/packages/clone/src/providers/asana.ts
@@ -10,6 +10,7 @@
  *         _index.md
  *         child-task.md
  */
+import { unwrapToolResultJson } from "@mcp-cli/core";
 import type {
   ChangeEvent,
   FetchResult,
@@ -20,30 +21,6 @@ import type {
   Scope,
 } from "./provider";
 import { type RetryOptions, createResilientCaller } from "./resilient-caller";
-
-/** MCP tool call result shape. */
-interface McpToolResult {
-  content: Array<{ type: string; text: string }>;
-  isError?: boolean;
-}
-
-/** Extract and parse JSON from an MCP tool call result. Throws on error responses. */
-function unwrapToolResult(result: unknown): unknown {
-  const mcpResult = result as McpToolResult;
-  if (mcpResult?.isError) {
-    const text = mcpResult.content?.[0]?.text ?? "Unknown MCP tool error";
-    throw new Error(`MCP tool error: ${text}`);
-  }
-  if (mcpResult?.content?.[0]?.type === "text") {
-    const text = mcpResult.content[0].text;
-    try {
-      return JSON.parse(text);
-    } catch {
-      return text;
-    }
-  }
-  return result;
-}
 
 /** Shape of an Asana task from the API. */
 interface AsanaTask {
@@ -139,7 +116,7 @@ export function createAsanaProvider(opts: AsanaProviderOptions): RemoteProvider 
 
   async function callAsana(tool: string, args: Record<string, unknown>): Promise<unknown> {
     const raw = await resilientCallTool(SERVER, tool, args, 30_000);
-    return unwrapToolResult(raw);
+    return unwrapToolResultJson<unknown>(raw);
   }
 
   const provider: RemoteProvider = {

--- a/packages/clone/src/providers/confluence.spec.ts
+++ b/packages/clone/src/providers/confluence.spec.ts
@@ -63,13 +63,13 @@ describe("validateScopeKey (via resolveScope)", () => {
     const provider = createConfluenceProvider({
       callTool: async (_server, tool, _args) => {
         if (tool === "getAccessibleAtlassianResources") {
-          return [{ id: "cloud-1", url: "https://example.atlassian.net", name: "Example", scopes: [] }];
+          return wrapMcpResult([{ id: "cloud-1", url: "https://example.atlassian.net", name: "Example", scopes: [] }]);
         }
         if (tool === "getConfluenceSpaces") {
-          return {
+          return wrapMcpResult({
             results: [{ id: "space-1", key: "VALID", name: "Valid Space", type: "global", status: "current" }],
             _links: { base: "https://example.atlassian.net/wiki" },
-          };
+          });
         }
         return null;
       },
@@ -538,7 +538,7 @@ describe("unwrapToolResult — isError handling", () => {
       },
     });
 
-    await expect(provider.resolveScope({ key: "TEST" })).rejects.toThrow("MCP tool error: Rate limit exceeded");
+    await expect(provider.resolveScope({ key: "TEST" })).rejects.toThrow("Rate limit exceeded");
   });
 
   test("throws on isError during list", async () => {
@@ -557,6 +557,6 @@ describe("unwrapToolResult — isError handling", () => {
       for await (const entry of provider.list(scope)) {
         entries.push(entry);
       }
-    }).toThrow("MCP tool error: 403 Forbidden");
+    }).toThrow("403 Forbidden");
   });
 });

--- a/packages/clone/src/providers/confluence.ts
+++ b/packages/clone/src/providers/confluence.ts
@@ -1,6 +1,7 @@
 /**
  * Confluence provider — maps a Confluence space to a local directory of markdown files.
  */
+import { unwrapToolResultJson } from "@mcp-cli/core";
 import type {
   ChangeEvent,
   FetchResult,
@@ -85,30 +86,6 @@ interface ResourcesResponse {
 // McpToolCaller is now defined in provider.ts and re-exported here for backwards compatibility.
 export type { McpToolCaller } from "./provider";
 
-/** MCP tool call result shape. */
-interface McpToolResult {
-  content: Array<{ type: string; text: string }>;
-  isError?: boolean;
-}
-
-/** Extract and parse JSON from an MCP tool call result. Throws on error responses. */
-function unwrapToolResult(result: unknown): unknown {
-  const mcpResult = result as McpToolResult;
-  if (mcpResult?.isError) {
-    const text = mcpResult.content?.[0]?.text ?? "Unknown MCP tool error";
-    throw new Error(`MCP tool error: ${text}`);
-  }
-  if (mcpResult?.content?.[0]?.type === "text") {
-    const text = mcpResult.content[0].text;
-    try {
-      return JSON.parse(text);
-    } catch {
-      return text;
-    }
-  }
-  return result;
-}
-
 /** Options for creating the Confluence provider. */
 export interface ConfluenceProviderOptions {
   /** Function to call an MCP tool: (server, tool, args, timeoutMs?) → result */
@@ -165,7 +142,7 @@ export function createConfluenceProvider(opts: ConfluenceProviderOptions): Remot
 
   async function callAtlassian(tool: string, args: Record<string, unknown>): Promise<unknown> {
     const raw = await resilientCallTool(SERVER, tool, args, 30_000);
-    return unwrapToolResult(raw);
+    return unwrapToolResultJson<unknown>(raw);
   }
 
   const provider: RemoteProvider = {
@@ -493,7 +470,7 @@ export async function bulkFetchPages(
     if (cursor) args.cursor = cursor;
 
     const raw = await callTool("atlassian", "getPagesInConfluenceSpace", args, 60_000);
-    const resp = unwrapToolResult(raw) as PagesResponse;
+    const resp = unwrapToolResultJson<PagesResponse>(raw);
 
     for (const page of resp.results) {
       total++;

--- a/packages/clone/src/providers/github-issues.spec.ts
+++ b/packages/clone/src/providers/github-issues.spec.ts
@@ -565,7 +565,7 @@ describe("unwrapToolResult — isError handling", () => {
     const provider = createGitHubIssuesProvider({
       callTool: async () => wrapMcpError("Not Found"),
     });
-    await expect(provider.fetch(scope, "1")).rejects.toThrow("MCP tool error: Not Found");
+    await expect(provider.fetch(scope, "1")).rejects.toThrow("Not Found");
   });
 
   test("throws on isError during list", async () => {
@@ -578,7 +578,7 @@ describe("unwrapToolResult — isError handling", () => {
       for await (const entry of provider.list(scope)) {
         entries.push(entry);
       }
-    }).toThrow("MCP tool error: Rate limit exceeded");
+    }).toThrow("Rate limit exceeded");
   });
 
   test("throws on isError during push conflict check", async () => {
@@ -590,7 +590,7 @@ describe("unwrapToolResult — isError handling", () => {
     const result = await pushFn(scope, "1", "Content", 1);
     // push catches errors and returns ok: false
     expect(result.ok).toBe(false);
-    expect(result.error).toContain("MCP tool error: Server error");
+    expect(result.error).toContain("Server error");
   });
 });
 

--- a/packages/clone/src/providers/github-issues.ts
+++ b/packages/clone/src/providers/github-issues.ts
@@ -5,6 +5,7 @@
  *   open/123-fix-auth-bug.md
  *   closed/100-initial-setup.md
  */
+import { unwrapToolResultJson } from "@mcp-cli/core";
 import type {
   ChangeEvent,
   FetchResult,
@@ -34,30 +35,6 @@ interface GitHubIssue {
 
 /** Shape of a GitHub issues list response (array of issues). */
 type GitHubIssuesResponse = GitHubIssue[];
-
-/** MCP tool call result shape. */
-interface McpToolResult {
-  content: Array<{ type: string; text: string }>;
-  isError?: boolean;
-}
-
-/** Extract and parse JSON from an MCP tool call result. Throws on error responses. */
-function unwrapToolResult(result: unknown): unknown {
-  const mcpResult = result as McpToolResult;
-  if (mcpResult?.isError) {
-    const text = mcpResult.content?.[0]?.text ?? "Unknown MCP tool error";
-    throw new Error(`MCP tool error: ${text}`);
-  }
-  if (mcpResult?.content?.[0]?.type === "text") {
-    const text = mcpResult.content[0].text;
-    try {
-      return JSON.parse(text);
-    } catch {
-      return text;
-    }
-  }
-  return result;
-}
 
 /**
  * Validate a scope key for GitHub repos. Must be `owner/repo` format.
@@ -132,7 +109,7 @@ export function createGitHubIssuesProvider(opts: GitHubIssuesProviderOptions): R
 
   async function callGitHub(tool: string, args: Record<string, unknown>): Promise<unknown> {
     const raw = await callTool(SERVER, tool, args, 30_000);
-    return unwrapToolResult(raw);
+    return unwrapToolResultJson<unknown>(raw);
   }
 
   const provider: RemoteProvider = {

--- a/packages/clone/src/providers/jira.spec.ts
+++ b/packages/clone/src/providers/jira.spec.ts
@@ -75,7 +75,7 @@ describe("validateScopeKey (via resolveScope)", () => {
     const provider = createJiraProvider({
       callTool: async (_server, tool) => {
         if (tool === "getAccessibleAtlassianResources") {
-          return [{ id: "cloud-1", url: "https://example.atlassian.net", name: "Example", scopes: [] }];
+          return wrapMcpResult([{ id: "cloud-1", url: "https://example.atlassian.net", name: "Example", scopes: [] }]);
         }
         return null;
       },
@@ -489,7 +489,7 @@ describe("resolveScope", () => {
     const provider = createJiraProvider({
       callTool: async (_server, tool) => {
         if (tool === "getAccessibleAtlassianResources") {
-          return [{ id: "cloud-1", url: "https://acme.atlassian.net", name: "Acme", scopes: [] }];
+          return wrapMcpResult([{ id: "cloud-1", url: "https://acme.atlassian.net", name: "Acme", scopes: [] }]);
         }
         return null;
       },
@@ -506,10 +506,10 @@ describe("resolveScope", () => {
       const provider = createJiraProvider({
         callTool: async (_server, tool) => {
           if (tool === "getAccessibleAtlassianResources") {
-            return [
+            return wrapMcpResult([
               { id: "cloud-1", url: "https://acme.atlassian.net", name: "Acme", scopes: [] },
               { id: "cloud-2", url: "https://corp.atlassian.net", name: "Corp", scopes: [] },
-            ];
+            ]);
           }
           return null;
         },
@@ -609,7 +609,7 @@ describe("unwrapToolResult — isError handling", () => {
       },
     });
 
-    await expect(provider.resolveScope({ key: "FOO" })).rejects.toThrow("MCP tool error: Rate limit exceeded");
+    await expect(provider.resolveScope({ key: "FOO" })).rejects.toThrow("Rate limit exceeded");
   });
 
   test("throws on isError during list", async () => {
@@ -628,6 +628,6 @@ describe("unwrapToolResult — isError handling", () => {
       for await (const entry of provider.list(scope)) {
         entries.push(entry);
       }
-    }).toThrow("MCP tool error: 403 Forbidden");
+    }).toThrow("403 Forbidden");
   });
 });

--- a/packages/clone/src/providers/jira.ts
+++ b/packages/clone/src/providers/jira.ts
@@ -1,6 +1,7 @@
 /**
  * Jira provider — maps a Jira project's issues to a local directory of markdown files.
  */
+import { unwrapToolResultJson } from "@mcp-cli/core";
 import type {
   ChangeEvent,
   FetchResult,
@@ -43,30 +44,6 @@ interface ResourcesResponse {
   url: string;
   name: string;
   scopes: string[];
-}
-
-/** MCP tool call result shape. */
-interface McpToolResult {
-  content: Array<{ type: string; text: string }>;
-  isError?: boolean;
-}
-
-/** Extract and parse JSON from an MCP tool call result. Throws on error responses. */
-function unwrapToolResult(result: unknown): unknown {
-  const mcpResult = result as McpToolResult;
-  if (mcpResult?.isError) {
-    const text = mcpResult.content?.[0]?.text ?? "Unknown MCP tool error";
-    throw new Error(`MCP tool error: ${text}`);
-  }
-  if (mcpResult?.content?.[0]?.type === "text") {
-    const text = mcpResult.content[0].text;
-    try {
-      return JSON.parse(text);
-    } catch {
-      return text;
-    }
-  }
-  return result;
 }
 
 /** Validate a scope key to prevent JQL injection. Only alphanumeric, hyphens, and underscores allowed. */
@@ -140,7 +117,7 @@ export function createJiraProvider(opts: JiraProviderOptions): RemoteProvider {
 
   async function callAtlassian(tool: string, args: Record<string, unknown>): Promise<unknown> {
     const raw = await resilientCallTool(SERVER, tool, args, 30_000);
-    return unwrapToolResult(raw);
+    return unwrapToolResultJson<unknown>(raw);
   }
 
   const provider: RemoteProvider = {


### PR DESCRIPTION
## Summary

- Removes four identical local `unwrapToolResult` / `McpToolResult` copies from `jira.ts`, `github-issues.ts`, `confluence.ts`, and `asana.ts`
- Replaces them with `unwrapToolResultJson<T>` imported from `@mcp-cli/core` — the shared helper added by PR #2307
- Updates test assertions to match the shared helper's behavior: error messages no longer include the `"MCP tool error: "` prefix, and test mocks returning raw objects are wrapped with `wrapMcpResult()` to match real MCP content format

## Test plan

- [x] All 162 provider tests pass (`bun test packages/clone/src/providers/`)
- [x] Full test suite passes (8265 pass, 0 fail)
- [x] Typecheck clean
- [x] Lint clean
- [x] `doing-it-wrong` rule sweep: no violations
- [x] Coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)