### PR TITLE
fix(allow-patterns): return tools:undefined on error instead of empty array (fixes #2492)

### DIFF
--- a/packages/core/src/allow-patterns.spec.ts
+++ b/packages/core/src/allow-patterns.spec.ts
@@ -165,7 +165,7 @@ describe("resolveEffectiveTools", () => {
       permissionMode: "rules",
     });
     expect(result.error).toBeDefined();
-    expect(result.tools).toEqual([]);
+    expect(result.tools).toBeUndefined();
   });
 
   test("allowOnly=true with empty allowedTools returns error", () => {
@@ -175,7 +175,7 @@ describe("resolveEffectiveTools", () => {
       permissionMode: "rules",
     });
     expect(result.error).toBeDefined();
-    expect(result.tools).toEqual([]);
+    expect(result.tools).toBeUndefined();
   });
 
   test("defaults permissionMode to rules", () => {

--- a/packages/core/src/allow-patterns.ts
+++ b/packages/core/src/allow-patterns.ts
@@ -112,7 +112,7 @@ export function resolveEffectiveTools(opts: ResolveEffectiveToolsOpts): {
   if (allowOnly) {
     if (!allowedTools || allowedTools.length === 0) {
       return {
-        tools: [],
+        tools: undefined,
         error: "allowOnly requires at least one tool in allowedTools",
       };
     }

--- a/packages/core/src/allow-patterns.ts
+++ b/packages/core/src/allow-patterns.ts
@@ -96,7 +96,7 @@ export interface ResolveEffectiveToolsOpts {
  * Compute the final resolved tool set for a session.
  *
  * - permissionMode !== "rules" → undefined (no tool restrictions)
- * - allowOnly + no allowedTools → error (empty string[] returned, caller should reject)
+ * - allowOnly + no allowedTools → {tools: undefined, error: "..."} — caller must check error
  * - allowOnly + allowedTools → exactly those tools (no defaults)
  * - allowedTools without allowOnly → union with DEFAULT_SAFE_TOOLS
  * - no allowedTools → DEFAULT_SAFE_TOOLS


### PR DESCRIPTION
## Summary
- `resolveEffectiveTools()` was returning `{tools: [], error: "..."}` on the `allowOnly=true` with no `allowedTools` error path — an empty array is truthy, so naive `if (result.tools)` callers would proceed silently with zero tools allowed
- Changed the error return to `{tools: undefined, error: "..."}`, consistent with the `permissionMode !== "rules"` path which already returns `{tools: undefined}`
- Updated two tests in `allow-patterns.spec.ts` to assert `toBeUndefined()` instead of `toEqual([])`

## Test plan
- [x] `bun test packages/core/src/allow-patterns.spec.ts` — 27 pass, 0 fail
- [x] `bun run doing-it-wrong` — no rule violations
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] Full `bun test` suite — 8265 pass, 0 fail
- [x] Pre-push gate passed (`am-i-done --pre-push`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)