### PR TITLE
docs(allow): document DEFAULT_SAFE_TOOLS asymmetry in session workers (closes #2490)

### DIFF
--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -211,6 +211,11 @@ export async function handlePrompt(
     const allowedTools = (args.allowedTools as string[]) ?? undefined;
     const allowOnly = (args.allowOnly as boolean) ?? false;
 
+    // Claude-specific: resolveEffectiveTools() unions allowedTools with DEFAULT_SAFE_TOOLS
+    // (or returns DEFAULT_SAFE_TOOLS alone when no tools are supplied). This is intentional —
+    // Claude's permission-router enforces these baselines. Other session workers
+    // (codex, acp, opencode) pass allowedTools raw; DEFAULT_SAFE_TOOLS is a no-op for
+    // them because those providers have no equivalent permission-router machinery.
     const resolved = resolveEffectiveTools({
       allowedTools,
       allowOnly,


### PR DESCRIPTION
## Summary
- Adds a 5-line comment in `claude-session-worker.ts` near the `resolveEffectiveTools()` call explaining that the union with `DEFAULT_SAFE_TOOLS` is Claude-specific
- Documents that Codex/ACP/OpenCode workers pass `allowedTools` raw because they lack Claude's permission-router machinery
- Prevents future readers from "fixing" the intentional asymmetry by accident

## Test plan
- No behavioral changes — documentation only
- `bun run am-i-done` passes (typecheck, lint, rules, tests, coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)