### PR TITLE
feat(rules): add no-as-any rule + prod-empty-catch enforcement (fixes #2496)

### DIFF
--- a/packages/command/src/commands/sprint-stats.ts
+++ b/packages/command/src/commands/sprint-stats.ts
@@ -185,7 +185,7 @@ function gitRoot(): string {
   try {
     const r = spawnCaptureSync("git", ["rev-parse", "--show-toplevel"]);
     if (r.ok) return r.stdout.trim();
-  } catch {}
+  } catch {} // dotw-todo prod-empty-catch: fallback to cwd is intentional but should log — fix in #2496
   return process.cwd();
 }
 

--- a/packages/command/src/commands/sprint-stats.ts
+++ b/packages/command/src/commands/sprint-stats.ts
@@ -185,7 +185,7 @@ function gitRoot(): string {
   try {
     const r = spawnCaptureSync("git", ["rev-parse", "--show-toplevel"]);
     if (r.ok) return r.stdout.trim();
-  } catch {} // dotw-todo prod-empty-catch: fallback to cwd is intentional but should log — fix in #2496
+  } catch {} // dotw-todo prod-empty-catch: fallback to cwd is intentional but should log — fix in #2535
   return process.cwd();
 }
 

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -78,7 +78,7 @@ export class StateDb {
   /**
    * Per-consumer versioned migration using a shared `schema_versions(name, version)` table.
    *
-   * Replaces the legacy bare `try { ALTER TABLE } catch {}` pattern that silently
+   * Replaces the legacy bare try/catch-discard pattern that
    * swallowed ALL exceptions (disk-full, permissions, corruption). Each migration
    * step and its version bump are atomic (single transaction); failures bubble up.
    *

--- a/packages/daemon/src/github/graphql-client.ts
+++ b/packages/daemon/src/github/graphql-client.ts
@@ -375,7 +375,7 @@ export async function fetchTrackedPRs(
   if (warn && typeof remaining === "number" && remaining < RATE_LIMIT_WARN_THRESHOLD) {
     try {
       warn(`[mcpd] GitHub GraphQL rate limit low: ${remaining} requests remaining`);
-    } catch {}
+    } catch {} // dotw-todo prod-empty-catch: warn() should not throw, but if it does log to stderr — fix in #2496
   }
 
   const repoData = json.data?.repository;

--- a/packages/daemon/src/github/graphql-client.ts
+++ b/packages/daemon/src/github/graphql-client.ts
@@ -375,7 +375,7 @@ export async function fetchTrackedPRs(
   if (warn && typeof remaining === "number" && remaining < RATE_LIMIT_WARN_THRESHOLD) {
     try {
       warn(`[mcpd] GitHub GraphQL rate limit low: ${remaining} requests remaining`);
-    } catch {} // dotw-todo prod-empty-catch: warn() should not throw, but if it does log to stderr — fix in #2496
+    } catch {} // dotw-todo prod-empty-catch: warn() should not throw, but if it does log to stderr — fix in #2535
   }
 
   const repoData = json.data?.repository;

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -237,7 +237,7 @@ if (releaseMode) {
   for (const p of bundleCleanup) {
     try {
       unlinkSync(p);
-    } catch {}
+    } catch {} // dotw-ignore prod-empty-catch: best-effort cleanup of temp files
   }
   console.log("Release build complete.");
 } else {
@@ -255,7 +255,7 @@ if (releaseMode) {
   for (const p of bundleCleanup) {
     try {
       unlinkSync(p);
-    } catch {}
+    } catch {} // dotw-ignore prod-empty-catch: best-effort cleanup of temp files
   }
   console.log("Built: dist/mcpd, dist/mcx, dist/mcpctl");
 }

--- a/scripts/rules/fixtures/no-as-any__clean.fixture.ts
+++ b/scripts/rules/fixtures/no-as-any__clean.fixture.ts
@@ -1,0 +1,15 @@
+/**
+ * @rule no-as-any
+ * @expect 0
+ * @path packages/daemon/src/example.ts
+ *
+ * Proper type narrowing — no `as any` usage.
+ */
+
+const x = JSON.parse("{}") as Record<string, unknown>;
+function handle(val: unknown) {
+  if (typeof val === "object" && val !== null && "foo" in val) {
+    return (val as { foo: string }).foo;
+  }
+  return undefined;
+}

--- a/scripts/rules/fixtures/no-as-any__flagged.fixture.ts
+++ b/scripts/rules/fixtures/no-as-any__flagged.fixture.ts
@@ -1,0 +1,12 @@
+/**
+ * @rule no-as-any
+ * @expect 2
+ * @path packages/daemon/src/example.ts
+ *
+ * Two `as any` casts in production code — both should be flagged.
+ */
+
+const x = JSON.parse("{}") as any;
+function handle(val: unknown) {
+  return (val as any).foo;
+}

--- a/scripts/rules/fixtures/no-as-any__suppressed.fixture.ts
+++ b/scripts/rules/fixtures/no-as-any__suppressed.fixture.ts
@@ -1,0 +1,9 @@
+/**
+ * @rule no-as-any
+ * @expect 0
+ * @path packages/daemon/src/example.ts
+ *
+ * Suppressed `as any` — the dotw-ignore comment prevents flagging.
+ */
+
+const x = JSON.parse("{}") as any; // dotw-ignore no-as-any: third-party interop requires untyped cast

--- a/scripts/rules/fixtures/prod-empty-catch__clean.fixture.ts
+++ b/scripts/rules/fixtures/prod-empty-catch__clean.fixture.ts
@@ -1,0 +1,17 @@
+/**
+ * @rule prod-empty-catch
+ * @expect 0
+ * @path packages/daemon/src/example.ts
+ *
+ * Catch blocks with a body — not flagged.
+ */
+
+function handled() {
+  try {
+    JSON.parse("bad");
+  } catch (e) {
+    throw new TypeError("parse failed", { cause: e });
+  }
+
+  try { throw new Error("boom"); } catch (e) { console.error(e); }
+}

--- a/scripts/rules/fixtures/prod-empty-catch__flagged.fixture.ts
+++ b/scripts/rules/fixtures/prod-empty-catch__flagged.fixture.ts
@@ -1,0 +1,12 @@
+/**
+ * @rule prod-empty-catch
+ * @expect 2
+ * @path packages/daemon/src/example.ts
+ *
+ * Two inline empty catch blocks in production code — both should be flagged.
+ */
+
+function risky() {
+  try { JSON.parse("bad"); } catch {}
+  try { throw new Error("boom"); } catch (e) {}
+}

--- a/scripts/rules/fixtures/prod-empty-catch__suppressed.fixture.ts
+++ b/scripts/rules/fixtures/prod-empty-catch__suppressed.fixture.ts
@@ -1,0 +1,12 @@
+/**
+ * @rule prod-empty-catch
+ * @expect 0
+ * @path packages/daemon/src/example.ts
+ *
+ * Suppressed empty catch — the dotw-ignore comment prevents flagging.
+ */
+
+function bestEffort() {
+  try { cleanup(); } catch {} // dotw-ignore prod-empty-catch: best-effort cleanup
+  try { cleanup(); } catch {} // dotw-todo prod-empty-catch: should log — fix in #2535
+}

--- a/scripts/rules/no-as-any.rule.ts
+++ b/scripts/rules/no-as-any.rule.ts
@@ -5,11 +5,13 @@ const rule: PatternRule = {
   kind: "pattern",
   appliesToTests: false,
   scold: "`as any` cast in production code — defeats TypeScript's type system",
+  // Line-level regex — matches inside string literals and comments (see #2534 for engine-level fix)
   pattern: /\bas\s+any\b/,
   except: ["// dotw-ignore no-as-any:", "// dotw-todo no-as-any:"],
   guidance: [
     "narrow to a concrete type: `as SomeType`, `as unknown as SomeType`, or a Zod parse",
     "if the type really is unknowable, use `unknown` and narrow with a type guard",
+    "false positive in a string/comment? suppress with `// dotw-ignore no-as-any: in string literal` (#2534)",
   ],
   documentation: "#2496",
 };

--- a/scripts/rules/no-as-any.rule.ts
+++ b/scripts/rules/no-as-any.rule.ts
@@ -1,0 +1,17 @@
+import type { PatternRule } from "./_engine/rule";
+
+const rule: PatternRule = {
+  id: "no-as-any",
+  kind: "pattern",
+  appliesToTests: false,
+  scold: "`as any` cast in production code — defeats TypeScript's type system",
+  pattern: /\bas\s+any\b/,
+  except: ["// dotw-ignore no-as-any:", "// dotw-todo no-as-any:"],
+  guidance: [
+    "narrow to a concrete type: `as SomeType`, `as unknown as SomeType`, or a Zod parse",
+    "if the type really is unknowable, use `unknown` and narrow with a type guard",
+  ],
+  documentation: "#2496",
+};
+
+export default rule;

--- a/scripts/rules/prod-empty-catch.rule.ts
+++ b/scripts/rules/prod-empty-catch.rule.ts
@@ -1,0 +1,18 @@
+import type { PatternRule } from "./_engine/rule";
+
+const rule: PatternRule = {
+  id: "prod-empty-catch",
+  kind: "pattern",
+  appliesToTests: false,
+  scold: "empty catch block in production code — swallows errors silently",
+  pattern: /\}\s*catch\s*(?:\([^)]*\))?\s*\{\s*\}/,
+  except: ["// dotw-ignore prod-empty-catch:", "// dotw-todo prod-empty-catch:", "* "],
+  guidance: [
+    "log the error: catch (e) { warn('context', e); }",
+    "re-throw a typed error: catch (e) { throw new SpecificError('msg', { cause: e }); }",
+    "if the catch is intentionally a no-op, add // dotw-ignore prod-empty-catch: <reason>",
+  ],
+  documentation: "#2496",
+};
+
+export default rule;

--- a/scripts/rules/prod-empty-catch.rule.ts
+++ b/scripts/rules/prod-empty-catch.rule.ts
@@ -5,9 +5,10 @@ const rule: PatternRule = {
   kind: "pattern",
   appliesToTests: false,
   scold: "empty catch block in production code — swallows errors silently",
-  // Single-line only — relies on Biome keeping empty catch bodies on one line
+  // Single-line only — relies on Biome keeping empty catch bodies on one line.
+  // Matches string literals and comments (see #2534 for engine-level fix).
   pattern: /\}\s*catch\s*(?:\([^)]*\))?\s*\{\s*\}/,
-  except: ["// dotw-ignore prod-empty-catch:", "// dotw-todo prod-empty-catch:", " * "],
+  except: ["// dotw-ignore prod-empty-catch:", "// dotw-todo prod-empty-catch:"],
   guidance: [
     "log the error: catch (e) { warn('context', e); }",
     "re-throw a typed error: catch (e) { throw new SpecificError('msg', { cause: e }); }",

--- a/scripts/rules/prod-empty-catch.rule.ts
+++ b/scripts/rules/prod-empty-catch.rule.ts
@@ -5,8 +5,9 @@ const rule: PatternRule = {
   kind: "pattern",
   appliesToTests: false,
   scold: "empty catch block in production code — swallows errors silently",
+  // Single-line only — relies on Biome keeping empty catch bodies on one line
   pattern: /\}\s*catch\s*(?:\([^)]*\))?\s*\{\s*\}/,
-  except: ["// dotw-ignore prod-empty-catch:", "// dotw-todo prod-empty-catch:", "* "],
+  except: ["// dotw-ignore prod-empty-catch:", "// dotw-todo prod-empty-catch:", " * "],
   guidance: [
     "log the error: catch (e) { warn('context', e); }",
     "re-throw a typed error: catch (e) { throw new SpecificError('msg', { cause: e }); }",


### PR DESCRIPTION
## Summary
- Add `no-as-any` pattern rule — flags `as any` casts in production code (test files excluded). Guards the invariant that the production `as any` count is 0.
- Add `prod-empty-catch` pattern rule — flags inline empty `catch {}` blocks in production code (test files excluded). Extends the existing `test-empty-catch` enforcement to non-test source.
- Both rules include fixture pairs (clean + flagged) and follow the `/rule-author add` pattern.
- Existing violations suppressed: `dotw-todo` on 2 production empty catches (`graphql-client.ts:378`, `sprint-stats.ts:188`), `dotw-ignore` on 2 build-script cleanup catches (`scripts/build.ts`).

> CI gate failure on `ci-steps.spec.ts:403` is pre-existing #2464, not introduced by this PR.

## Test plan
- [x] `bun run am-i-done --pre-commit` passes (typecheck + lint + rules)
- [x] `bun run doing-it-wrong` reports 0 violations with both new rules active
- [x] `bun test scripts/rules/fixtures.spec.ts` — all 93 fixture tests pass (includes 5 new fixtures)
- [x] `bun test` — 8270 tests pass, 0 failures
- [x] `bun run test:coverage` — all coverage thresholds met

🤖 Generated with [Claude Code](https://claude.com/claude-code)