### PR TITLE
feat(rules): warn-on-dead-allow-pattern + no-triplicate-allow-parsing (closes #2491)

### DIFF
--- a/scripts/rules/fixtures/no-triplicate-allow-parsing__clean.fixture.ts
+++ b/scripts/rules/fixtures/no-triplicate-allow-parsing__clean.fixture.ts
@@ -1,0 +1,15 @@
+/**
+ * @rule no-triplicate-allow-parsing
+ * @expect 0
+ * @path packages/command/src/commands/spawn-args.ts
+ *
+ * Calling validateAllowPatterns from the shared module is the correct
+ * pattern. No re-implementation of the parsing logic here.
+ */
+
+import { validateAllowPatterns } from "@mcp-cli/core";
+
+export function parseAllow(rawAllow: string[]): string[] {
+  const validation = validateAllowPatterns(rawAllow);
+  return validation.patterns;
+}

--- a/scripts/rules/fixtures/no-triplicate-allow-parsing__flagged-comma-split.fixture.ts
+++ b/scripts/rules/fixtures/no-triplicate-allow-parsing__flagged-comma-split.fixture.ts
@@ -1,0 +1,14 @@
+/**
+ * @rule no-triplicate-allow-parsing
+ * @expect 1
+ * @path packages/command/src/commands/spawn-args.ts
+ *
+ * Comma-splitting raw allow values with dead-pattern context should be
+ * flagged — exercises signal-3 (comma-split) in isolation.
+ */
+
+export function normalizeAllow(raw: string[]): string[] {
+  return raw.flatMap((v) => v.split(",").filter((p) => !isDeadPattern(p)));
+}
+
+declare function isDeadPattern(p: string): boolean;

--- a/scripts/rules/fixtures/no-triplicate-allow-parsing__flagged-phase-script.fixture.ts
+++ b/scripts/rules/fixtures/no-triplicate-allow-parsing__flagged-phase-script.fixture.ts
@@ -1,0 +1,14 @@
+/**
+ * @rule no-triplicate-allow-parsing
+ * @expect 1
+ * @path .claude/phases/impl.ts
+ *
+ * Phase scripts are in-scope for this rule — reimplementing paren-match
+ * in .claude/phases/ should be flagged.
+ */
+
+export function checkPattern(pattern: string) {
+  const m = pattern.match(/^(\w+)\((.+)\)$/);
+  if (m) return { tool: m[1], args: m[2] };
+  return null;
+}

--- a/scripts/rules/fixtures/no-triplicate-allow-parsing__flagged-regexp-ctor.fixture.ts
+++ b/scripts/rules/fixtures/no-triplicate-allow-parsing__flagged-regexp-ctor.fixture.ts
@@ -1,0 +1,12 @@
+/**
+ * @rule no-triplicate-allow-parsing
+ * @expect 1
+ * @path packages/command/src/commands/claude.ts
+ *
+ * Constructing the paren-match regex via new RegExp() should be flagged —
+ * exercises signal-2 (RegExp constructor) in isolation.
+ */
+
+export function buildParenMatcher() {
+  return new RegExp("^(\\w+)\\((.+)\\)$");
+}

--- a/scripts/rules/fixtures/no-triplicate-allow-parsing__flagged-test-style.fixture.ts
+++ b/scripts/rules/fixtures/no-triplicate-allow-parsing__flagged-test-style.fixture.ts
@@ -1,0 +1,13 @@
+/**
+ * @rule no-triplicate-allow-parsing
+ * @expect 1
+ * @path packages/command/src/commands/agent.ts
+ *
+ * Using .test() with the paren-match regex should be flagged —
+ * exercises signal-0 (standalone regex literal) independently of
+ * signal-1 (.match/.test/.exec method call).
+ */
+
+export function hasParenSyntax(pattern: string): boolean {
+  return /^(\w+)\((.+)\)$/.test(pattern);
+}

--- a/scripts/rules/fixtures/no-triplicate-allow-parsing__flagged.fixture.ts
+++ b/scripts/rules/fixtures/no-triplicate-allow-parsing__flagged.fixture.ts
@@ -1,0 +1,18 @@
+/**
+ * @rule no-triplicate-allow-parsing
+ * @expect 1
+ * @path packages/command/src/commands/spawn-args.ts
+ *
+ * Re-implementing the paren-match regex outside the canonical module
+ * should be flagged.
+ */
+
+export function parseAllow(rawAllow: string[]): string[] {
+  for (const pattern of rawAllow) {
+    const parenMatch = pattern.match(/^(\w+)\((.+)\)$/);
+    if (parenMatch) {
+      console.warn(`dead pattern: ${pattern}`);
+    }
+  }
+  return rawAllow;
+}

--- a/scripts/rules/fixtures/no-triplicate-allow-parsing__permissions-exempt.fixture.ts
+++ b/scripts/rules/fixtures/no-triplicate-allow-parsing__permissions-exempt.fixture.ts
@@ -1,0 +1,15 @@
+/**
+ * @rule no-triplicate-allow-parsing
+ * @expect 0
+ * @path packages/permissions/src/rule.ts
+ *
+ * The permissions package has its own pattern parser for permission rule
+ * evaluation (a different concern from --allow input validation). It is
+ * exempt from this rule.
+ */
+
+export function parsePattern(pattern: string) {
+  const match = pattern.match(/^(\w+)\((.+)\)$/);
+  if (match) return { tool: match[1], argPattern: match[2] };
+  return { tool: pattern, argPattern: null };
+}

--- a/scripts/rules/fixtures/warn-on-dead-allow-pattern__clean.fixture.ts
+++ b/scripts/rules/fixtures/warn-on-dead-allow-pattern__clean.fixture.ts
@@ -1,0 +1,10 @@
+/**
+ * @rule warn-on-dead-allow-pattern
+ * @expect 0
+ * @path packages/daemon/src/example.ts
+ *
+ * Valid allow patterns should not trigger the rule.
+ */
+
+const validPatterns = ["Bash", "Bash(:*)", "mcp__echo__add"];
+const withArgs = ["Bash(git:*)", "Read(src/**/*.ts)"];

--- a/scripts/rules/fixtures/warn-on-dead-allow-pattern__exempt-validator.fixture.ts
+++ b/scripts/rules/fixtures/warn-on-dead-allow-pattern__exempt-validator.fixture.ts
@@ -1,0 +1,12 @@
+/**
+ * @rule warn-on-dead-allow-pattern
+ * @expect 0
+ * @path packages/core/src/allow-patterns.ts
+ *
+ * The canonical allow-patterns module references dead patterns in comments
+ * and validation code. Lines containing validateAllowPatterns, dead-pattern,
+ * dead.pattern, or parenMatch are exempt.
+ */
+
+const result = validateAllowPatterns(["Bash(*)"]);
+if (pattern.match(/dead.pattern/)) { /* ok */ }

--- a/scripts/rules/fixtures/warn-on-dead-allow-pattern__flagged.fixture.ts
+++ b/scripts/rules/fixtures/warn-on-dead-allow-pattern__flagged.fixture.ts
@@ -1,0 +1,10 @@
+/**
+ * @rule warn-on-dead-allow-pattern
+ * @expect 2
+ * @path packages/daemon/src/example.ts
+ *
+ * String literals containing dead patterns like Bash(*) or Write(*) should
+ * be flagged. These look like wildcards but match nothing at runtime.
+ */
+
+const deadPatterns = ["Bash(*)", "Write(*)"];

--- a/scripts/rules/no-triplicate-allow-parsing.rule.ts
+++ b/scripts/rules/no-triplicate-allow-parsing.rule.ts
@@ -1,0 +1,70 @@
+/**
+ * Rule: no-triplicate-allow-parsing
+ *
+ * The canonical implementation of comma-split normalization and
+ * dead-pattern detection for --allow/--allow-only lives in
+ * `packages/core/src/allow-patterns.ts`. Consumers (spawn-args.ts,
+ * claude.ts, agent.ts) must call `validateAllowPatterns()` — not
+ * re-implement the logic inline.
+ *
+ * This rule flags files outside the canonical module that contain
+ * signature fragments of the parsing logic: the paren-match regex
+ * used for dead-pattern detection, or a comma-split loop that
+ * reimplements normalization. Importing and calling the shared
+ * function is fine; copying the internals is not.
+ */
+
+import type { CheckRule } from "./_engine/rule";
+
+const CANONICAL_PATH = "packages/core/src/allow-patterns.ts";
+
+const EXEMPT_PREFIXES = ["packages/permissions/"];
+
+const REIMPLEMENT_SIGNALS: readonly { pattern: RegExp; label: string }[] = [
+  {
+    pattern: /\(\w\+\)\\\((\.\+|\\\.)\\\)\$/,
+    label: "paren-match regex (dead-pattern detection)",
+  },
+  {
+    pattern: /\.match\(\s*\/\^\(\\w\+\)\\\(/,
+    label: "paren-match regex (dead-pattern detection)",
+  },
+  {
+    pattern: /\.split\s*\(\s*["'`,]\s*\)\s*.*(?:dead|paren|allow)/i,
+    label: "comma-split with allow-pattern handling",
+  },
+];
+
+const rule: CheckRule = {
+  id: "no-triplicate-allow-parsing",
+  kind: "check",
+  appliesToTests: false,
+  anchors: [CANONICAL_PATH],
+  scold:
+    "allow-pattern parsing logic re-implemented outside packages/core/src/allow-patterns.ts — use validateAllowPatterns() instead",
+  guidance: [
+    "comma-split normalization and dead-pattern detection must live only in packages/core/src/allow-patterns.ts",
+    "consumers should import { validateAllowPatterns } from '@mcp-cli/core' and call it with the raw --allow values",
+    "if the shared function is missing a capability you need, extend it there — do not fork the logic",
+  ],
+  documentation: "#2491",
+  check({ file, violated, checked }) {
+    if (file.relPath === CANONICAL_PATH) return;
+    if (!file.relPath.startsWith("packages/")) return;
+    if (EXEMPT_PREFIXES.some((p) => file.relPath.startsWith(p))) return;
+    if (file.relPath.endsWith(".spec.ts") || file.relPath.endsWith(".test.ts")) return;
+
+    checked();
+
+    const lines = file.content.split("\n");
+    for (const [i, line] of lines.entries()) {
+      for (const signal of REIMPLEMENT_SIGNALS) {
+        if (signal.pattern.test(line)) {
+          violated(i + 1, 1, line.trim());
+        }
+      }
+    }
+  },
+};
+
+export default rule;

--- a/scripts/rules/no-triplicate-allow-parsing.rule.ts
+++ b/scripts/rules/no-triplicate-allow-parsing.rule.ts
@@ -20,17 +20,23 @@ const CANONICAL_PATH = "packages/core/src/allow-patterns.ts";
 
 const EXEMPT_PREFIXES = ["packages/permissions/"];
 
+const IN_SCOPE_PREFIXES = ["packages/", ".claude/phases/"];
+
 const REIMPLEMENT_SIGNALS: readonly { pattern: RegExp; label: string }[] = [
   {
-    pattern: /\(\w\+\)\\\((\.\+|\\\.)\\\)\$/,
-    label: "paren-match regex (dead-pattern detection)",
+    pattern: /\/[^/]*\(\\w\+\)\\\([^/]*\//,
+    label: "paren-match regex literal (dead-pattern detection)",
   },
   {
-    pattern: /\.match\(\s*\/\^\(\\w\+\)\\\(/,
-    label: "paren-match regex (dead-pattern detection)",
+    pattern: /(?:\.match|\.test|\.exec)\(\s*\/[^/]*\(\\w\+\)\\\(/,
+    label: "paren-match regex via .match/.test/.exec (dead-pattern detection)",
   },
   {
-    pattern: /\.split\s*\(\s*["'`,]\s*\)\s*.*(?:dead|paren|allow)/i,
+    pattern: /new\s+RegExp\(\s*["'`][^"'`]*\(\\\\w\+\)\\\\\(/,
+    label: "paren-match regex via new RegExp() constructor",
+  },
+  {
+    pattern: /\.split\s*\(\s*["'`],["'`]\s*\)\s*.*(?:dead|paren|allow)/i,
     label: "comma-split with allow-pattern handling",
   },
 ];
@@ -50,7 +56,7 @@ const rule: CheckRule = {
   documentation: "#2491",
   check({ file, violated, checked }) {
     if (file.relPath === CANONICAL_PATH) return;
-    if (!file.relPath.startsWith("packages/")) return;
+    if (!IN_SCOPE_PREFIXES.some((p) => file.relPath.startsWith(p))) return;
     if (EXEMPT_PREFIXES.some((p) => file.relPath.startsWith(p))) return;
     if (file.relPath.endsWith(".spec.ts") || file.relPath.endsWith(".test.ts")) return;
 
@@ -61,6 +67,7 @@ const rule: CheckRule = {
       for (const signal of REIMPLEMENT_SIGNALS) {
         if (signal.pattern.test(line)) {
           violated(i + 1, 1, line.trim());
+          break;
         }
       }
     }

--- a/scripts/rules/warn-on-dead-allow-pattern.rule.ts
+++ b/scripts/rules/warn-on-dead-allow-pattern.rule.ts
@@ -1,0 +1,32 @@
+/**
+ * Rule: warn-on-dead-allow-pattern
+ *
+ * Catches string literals like `Bash(*)` or `Write(*)` in source files.
+ * These look like permission wildcards but are dead rules — bare `(*)`
+ * is not a valid wildcard syntax. The runtime validator in
+ * `allow-patterns.ts` catches these, but finding them at sweep time is
+ * cheaper than a runtime error in a phase script or `.mcx.yaml` config.
+ *
+ * Scope: non-test TypeScript files. Test files legitimately use these
+ * strings as fixture inputs for the validator itself.
+ */
+
+import type { PatternRule } from "./_engine/rule";
+
+const rule: PatternRule = {
+  id: "warn-on-dead-allow-pattern",
+  kind: "pattern",
+  appliesToTests: false,
+  scold:
+    'dead allow-pattern — `Tool(*)` is not a wildcard; use `"Tool"` (no parens) or `"Tool(:*)"` for prefix matching',
+  pattern: /["'`]\w+\(\*\)["'`]/,
+  except: ["validateAllowPatterns", "dead.pattern", "dead-pattern", "parenMatch"],
+  guidance: [
+    'bare `(*)` is not a permission wildcard — `"Bash(*)"`  matches nothing at runtime',
+    'to allow all calls to a tool, use just the tool name: `"Bash"`',
+    'for prefix matching, use the `:*` suffix: `"Bash(:*)"` or `"mcp__echo(:*)""`',
+  ],
+  documentation: "#2491",
+};
+
+export default rule;

--- a/scripts/rules/warn-on-dead-allow-pattern.rule.ts
+++ b/scripts/rules/warn-on-dead-allow-pattern.rule.ts
@@ -24,7 +24,7 @@ const rule: PatternRule = {
   guidance: [
     'bare `(*)` is not a permission wildcard — `"Bash(*)"`  matches nothing at runtime',
     'to allow all calls to a tool, use just the tool name: `"Bash"`',
-    'for prefix matching, use the `:*` suffix: `"Bash(:*)"` or `"mcp__echo(:*)""`',
+    'for prefix matching, use the `:*` suffix: `"Bash(:*)"` or `"mcp__echo(:*)"`',
   ],
   documentation: "#2491",
 };


### PR DESCRIPTION
## Summary
- **warn-on-dead-allow-pattern** (pattern rule): flags `Tool(*)` string literals in non-test source — these look like permission wildcards but match nothing at runtime. Exempt lines referencing `validateAllowPatterns`, `dead-pattern`, or `parenMatch` (validator internals).
- **no-triplicate-allow-parsing** (check rule): ensures comma-split + dead-pattern detection logic stays in `packages/core/src/allow-patterns.ts`. Flags re-implementation of the paren-match regex outside the canonical module. `packages/permissions/` is exempt (different concern: rule evaluation vs input validation). Uses `anchors` to hard-error if the canonical file is renamed.
- 6 fixture tests covering flagged, clean, and exemption scenarios for both rules.

## Test plan
- [x] `bun run doing-it-wrong` passes with 0 violations (rule correctly exempts permissions package)
- [x] All 99 fixture tests pass (`bun test scripts/rules/fixtures.spec.ts`)
- [x] Typecheck + lint pass
- [x] Pre-commit and pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)