### PR TITLE
ci: smoke step verifying tests pass with claude pruned from PATH (fixes #2544)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,67 @@ jobs:
           if-no-files-found: ignore
           retention-days: 30
 
+  check-no-claude:
+    runs-on: ubuntu-latest
+    needs: [detect]
+    steps:
+      - name: Skip (docs-only PR)
+        if: needs.detect.outputs.docs_only == 'true'
+        run: echo "Docs-only PR — skipping check-no-claude"
+      - uses: actions/checkout@v6
+        if: needs.detect.outputs.docs_only != 'true'
+      - uses: oven-sh/setup-bun@v2
+        if: needs.detect.outputs.docs_only != 'true'
+        with:
+          bun-version: "1.3.14"
+      - if: needs.detect.outputs.docs_only != 'true'
+        run: bun install --frozen-lockfile
+      # Verify the test suite passes with claude absent from PATH and MCX_CLAUDE_BINARY
+      # unset. Catches specs that accidentally call the real claude binary — which would
+      # break local dev for anyone without claude installed and would not be caught by
+      # the normal check job (claude IS on PATH there). See #2544.
+      - name: bun test (claude-free PATH)
+        if: needs.detect.outputs.docs_only != 'true'
+        run: |
+          # Strip any directory containing a 'claude' binary from PATH.
+          new_path=""
+          IFS=: read -ra dirs <<< "$PATH"
+          for dir in "${dirs[@]}"; do
+            if [ -f "$dir/claude" ]; then
+              echo "Removed $dir from PATH (contains claude binary)"
+            else
+              new_path="${new_path}${dir}:"
+            fi
+          done
+          export PATH="${new_path%:}"
+          unset MCX_CLAUDE_BINARY
+
+          if command -v claude &>/dev/null; then
+            echo "claude is still on PATH after filtering — setup failed"
+            exit 1
+          fi
+          echo "claude not on PATH — OK"
+
+          set +e
+          bun test 2>&1 | tee /tmp/test_no_claude.txt
+          code=${PIPESTATUS[0]}
+          if [ $code -eq 0 ]; then
+            exit 0
+          elif grep -q "^ 0 fail$" /tmp/test_no_claude.txt; then
+            echo "::warning::Bun crash (exit $code) after all tests passed — treating as pass (see #1004)"
+            exit 0
+          else
+            exit $code
+          fi
+      - name: Upload no-claude test logs
+        if: always() && needs.detect.outputs.docs_only != 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: bun-no-claude-test-logs-${{ github.run_id }}-${{ github.run_attempt }}
+          path: /tmp/test_no_claude.txt
+          if-no-files-found: ignore
+          retention-days: 30
+
   pty-test:
     runs-on: ubuntu-latest
     needs: [check, detect]

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -44,6 +44,7 @@ Before writing new helpers, check what already exists:
 1. **Never use `setTimeout` for waiting** — await the condition directly
 2. **Never hardcode ports** — use `port: 0` for OS-assigned ports
 3. **Prefer Bun's default test timeout** — only override when a test genuinely needs longer (e.g., integration tests with polling)
+4. **Tests must pass without claude on PATH** — the `check-no-claude` CI job runs `bun test` with claude stripped from PATH and `MCX_CLAUDE_BINARY` unset. Tests that exercise claude-session behavior must inject a synthetic claude binary via `startTestDaemon`'s `pathPrefix` option (see `test/harness.ts`) pointing to `test/mock-claude.ts`. Never rely on the real `claude` binary being available.
 
 ## Subprocess Spawning
 


### PR DESCRIPTION
## Summary
- Adds `check-no-claude` CI job that strips any directory containing a `claude` binary from PATH, unsets `MCX_CLAUDE_BINARY`, and runs `bun test`
- Job catches specs that accidentally require the real `claude` binary, which would break local dev for anyone without Claude Code installed
- Documents the constraint as rule 4 in `test/CLAUDE.md`

## Test plan
- [ ] `bun run am-i-done --pre-commit` passes locally
- [ ] New job runs in parallel with `check` and `coverage` (both need `[detect]`)
- [ ] Job uses same Bun crash passthrough heuristic as other test jobs (`grep "^ 0 fail$"`) for #1004 resilience
- [ ] Smoke verification: removing `mock-claude.ts`'s `--version` spoof handler in a separate PR should turn this job red

🤖 Generated with [Claude Code](https://claude.com/claude-code)