### PR TITLE
feat(rules): dotw-todo stale-issue check — flag suppressions referencing closed issues (fixes #2533)

### DIFF
--- a/scripts/am-i-done.ts
+++ b/scripts/am-i-done.ts
@@ -198,6 +198,17 @@ const TEST_CHANGED: Step = {
   ],
 };
 
+const STALE_TODOS_CI: Step = {
+  name: "stale-todos",
+  description: "dotw-todo stale-issue check — shells out to gh per unique issue number (CI only; fixes #2533)",
+  command: "bun scripts/check-stale-todos.ts",
+  onFailure: [
+    "a dotw-todo comment references a closed GitHub issue",
+    "fix: remove the underlying violation (and its dotw-todo suppression)",
+    "or reopen / file a successor issue and update the #NNN reference",
+  ],
+};
+
 // ===== Step lists per mode =====
 //
 // Pre-commit: fast feedback during `git commit`. Skips tests entirely
@@ -221,7 +232,16 @@ const TEST_CHANGED: Step = {
 const PRE_COMMIT: Step[] = [INSTALL, TYPECHECK, LINT_CHECK, RULES];
 const PRE_PUSH: Step[] = [INSTALL, TYPECHECK, LINT_CHECK, RULES, TEST_CHANGED];
 const COMPREHENSIVE: Step[] = [INSTALL, TYPECHECK, LINT, RULES, TEST_PARALLEL, TEST_CONTROL, COVERAGE];
-const CI: Step[] = [INSTALL, TYPECHECK, LINT_CHECK, RULES, TEST_NON_DAEMON_CI, TEST_DAEMON_CI, COVERAGE_CI];
+const CI: Step[] = [
+  INSTALL,
+  TYPECHECK,
+  LINT_CHECK,
+  RULES,
+  STALE_TODOS_CI,
+  TEST_NON_DAEMON_CI,
+  TEST_DAEMON_CI,
+  COVERAGE_CI,
+];
 
 function selectSteps(): { steps: Step[]; label: string } {
   if (isPreCommit) return { steps: PRE_COMMIT, label: "pre-commit" };

--- a/scripts/check-stale-todos.spec.ts
+++ b/scripts/check-stale-todos.spec.ts
@@ -1,6 +1,9 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { extractTodoRefs } from "./check-stale-todos";
+import { type IssueFetcher, type TodoRef, checkRefs, extractTodoRefs, scanFiles } from "./check-stale-todos";
 
 // Build dotw-todo test strings programmatically so this spec file doesn't
 // contain literal `// dotw-todo <rule>: ... #NNN` patterns. If it did,
@@ -82,11 +85,131 @@ describe("extractTodoRefs", () => {
   });
 
   it("skips identifiers like dotw-todo-needs-issue that contain dotw-todo as a substring", () => {
-    // The pattern requires whitespace after dotw-todo, so dotw-todo-<more> doesn't match.
-    // Construct the content with a template to avoid the scanner seeing a literal pattern.
     const ident = ["dotw-todo", "needs-issue"].join("-");
     const content = `// ${ident} is the rule documented in #2352`;
     const refs = extractTodoRefs(content, "packages/foo/bar.ts");
     expect(refs).toHaveLength(0);
+  });
+});
+
+describe("scanFiles", () => {
+  let tmpRoot: string;
+
+  beforeEach(async () => {
+    tmpRoot = await mkdtemp(join(tmpdir(), "stale-todos-"));
+    await mkdir(join(tmpRoot, "packages", "foo"), { recursive: true });
+    await mkdir(join(tmpRoot, "scripts"), { recursive: true });
+    await mkdir(join(tmpRoot, "test"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("finds dotw-todo refs in packages/ files", async () => {
+    await writeFile(join(tmpRoot, "packages", "foo", "bar.ts"), `${makeTodo("some-rule", "fix in #42")}\n`);
+    const refs = await scanFiles(tmpRoot);
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.issueNumbers).toEqual([42]);
+    expect(refs[0]?.file).toBe("packages/foo/bar.ts");
+  });
+
+  it("excludes .rule.ts and fixture files", async () => {
+    await mkdir(join(tmpRoot, "scripts", "rules", "fixtures"), { recursive: true });
+    await writeFile(join(tmpRoot, "scripts", "rules", "my.rule.ts"), `${makeTodo("r", "fix in #1")}\n`);
+    await writeFile(join(tmpRoot, "scripts", "rules", "fixtures", "x.ts"), `${makeTodo("r", "fix in #2")}\n`);
+    await writeFile(join(tmpRoot, "scripts", "ok.ts"), `${makeTodo("r", "fix in #3")}\n`);
+    const refs = await scanFiles(tmpRoot);
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.issueNumbers).toEqual([3]);
+  });
+
+  it("returns empty when no dotw-todo refs exist", async () => {
+    await writeFile(join(tmpRoot, "packages", "foo", "clean.ts"), "export const x = 1;\n");
+    const refs = await scanFiles(tmpRoot);
+    expect(refs).toHaveLength(0);
+  });
+});
+
+describe("checkRefs", () => {
+  const stdoutWrite = process.stdout.write.bind(process.stdout);
+  const stderrWrite = process.stderr.write.bind(process.stderr);
+  let stdoutBuf: string;
+  let stderrBuf: string;
+
+  beforeEach(() => {
+    stdoutBuf = "";
+    stderrBuf = "";
+    process.stdout.write = ((chunk: string) => {
+      stdoutBuf += chunk;
+      return true;
+    }) as typeof process.stdout.write;
+    process.stderr.write = ((chunk: string) => {
+      stderrBuf += chunk;
+      return true;
+    }) as typeof process.stderr.write;
+  });
+
+  afterEach(() => {
+    process.stdout.write = stdoutWrite;
+    process.stderr.write = stderrWrite;
+  });
+
+  const ref = (issueNumbers: number[], file = "f.ts", line = 1): TodoRef => ({
+    file,
+    line,
+    issueNumbers,
+    snippet: `snippet for ${issueNumbers.join(",")}`,
+  });
+
+  it("returns 0 with no refs", async () => {
+    const code = await checkRefs([], async () => "OPEN");
+    expect(code).toBe(0);
+    expect(stdoutBuf).toContain("no dotw-todo issue references found");
+  });
+
+  it("returns 1 when all issues are unreachable (fail-closed)", async () => {
+    const code = await checkRefs([ref([100])], async () => null);
+    expect(code).toBe(1);
+    expect(stderrBuf).toContain("could not reach GitHub API");
+    expect(stderrBuf).toContain("1 issue unreachable");
+  });
+
+  it("returns 1 when a referenced issue is CLOSED", async () => {
+    const code = await checkRefs([ref([200], "pkg/foo.ts", 5)], async (n) => (n === 200 ? "CLOSED" : "OPEN"));
+    expect(code).toBe(1);
+    expect(stderrBuf).toContain("#200 (CLOSED)");
+    expect(stderrBuf).toContain("pkg/foo.ts:5");
+  });
+
+  it("returns 0 when all referenced issues are OPEN", async () => {
+    const code = await checkRefs([ref([300])], async () => "OPEN");
+    expect(code).toBe(0);
+    expect(stdoutBuf).toContain("all referenced issues open");
+  });
+
+  it("warns but continues when some (not all) issues are unreachable", async () => {
+    const code = await checkRefs([ref([400]), ref([401])], async (n) => (n === 400 ? null : "OPEN"));
+    expect(code).toBe(0);
+    expect(stderrBuf).toContain("#400");
+    expect(stderrBuf).toContain("skipped");
+  });
+
+  it("fetches each unique issue only once", async () => {
+    const calls: number[] = [];
+    const fetcher: IssueFetcher = async (n) => {
+      calls.push(n);
+      return "OPEN";
+    };
+    await checkRefs([ref([500]), ref([500, 501])], fetcher);
+    expect(calls.sort()).toEqual([500, 501]);
+  });
+
+  it("reports multiple stale refs in one run", async () => {
+    const code = await checkRefs([ref([600], "a.ts", 10), ref([601], "b.ts", 20)], async () => "CLOSED");
+    expect(code).toBe(1);
+    expect(stderrBuf).toContain("2 dotw-todo comments reference closed issues");
+    expect(stderrBuf).toContain("a.ts:10");
+    expect(stderrBuf).toContain("b.ts:20");
   });
 });

--- a/scripts/check-stale-todos.spec.ts
+++ b/scripts/check-stale-todos.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "bun:test";
+
+import { extractTodoRefs } from "./check-stale-todos";
+
+// Build dotw-todo test strings programmatically so this spec file doesn't
+// contain literal `// dotw-todo <rule>: ... #NNN` patterns. If it did,
+// `check-stale-todos.ts`'s `scanFiles()` would pick them up and call `gh
+// issue view` on fake issue numbers — producing false positives in CI.
+function makeTodo(ruleId: string, desc: string): string {
+  return ["//", "dotw-todo", `${ruleId}:`, desc].join(" ");
+}
+
+describe("extractTodoRefs", () => {
+  it("extracts a single issue number from a standard dotw-todo comment", () => {
+    const content = [makeTodo("prod-empty-catch", "legacy path — fix in #2496"), "badCode();"].join("\n");
+    const refs = extractTodoRefs(content, "packages/foo/bar.ts");
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.file).toBe("packages/foo/bar.ts");
+    expect(refs[0]?.line).toBe(1);
+    expect(refs[0]?.issueNumbers).toEqual([2496]);
+    expect(refs[0]?.snippet).toBe(makeTodo("prod-empty-catch", "legacy path — fix in #2496"));
+  });
+
+  it("extracts multiple issue numbers from the same comment", () => {
+    const content = makeTodo("some-rule", "blocked on #1234 and #5678 landing first");
+    const refs = extractTodoRefs(content, "packages/foo/bar.ts");
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.issueNumbers).toEqual([1234, 5678]);
+  });
+
+  it("skips dotw-todo inside a string literal (double quote preceding //)", () => {
+    const content = `const msg = "${makeTodo("some-rule", "legacy path — fix in #999")}";`;
+    const refs = extractTodoRefs(content, "packages/foo/bar.ts");
+    expect(refs).toHaveLength(0);
+  });
+
+  it("skips dotw-todo inside a string literal (single quote preceding //)", () => {
+    const content = `const msg = '${makeTodo("some-rule", "legacy path — fix in #999")}';`;
+    const refs = extractTodoRefs(content, "packages/foo/bar.ts");
+    expect(refs).toHaveLength(0);
+  });
+
+  it("skips dotw-todo inside a template literal (backtick preceding //)", () => {
+    const bt = String.fromCharCode(96); // backtick — avoids a real template literal in this file
+    const content = ["const msg = ", bt, makeTodo("some-rule", "legacy path — fix in #999"), bt, ";"].join("");
+    const refs = extractTodoRefs(content, "packages/foo/bar.ts");
+    expect(refs).toHaveLength(0);
+  });
+
+  it("skips dotw-todo with no issue number", () => {
+    const content = makeTodo("some-rule", "needs cleanup eventually");
+    const refs = extractTodoRefs(content, "packages/foo/bar.ts");
+    expect(refs).toHaveLength(0);
+  });
+
+  it("handles trailing-style suppression comment (// after code)", () => {
+    const content = `doSomething(); ${makeTodo("no-raw-spawn", "migrate to spawnSync — fix in #1111")}`;
+    const refs = extractTodoRefs(content, "packages/foo/bar.ts");
+    expect(refs).toHaveLength(1);
+    expect(refs[0]?.issueNumbers).toEqual([1111]);
+    expect(refs[0]?.line).toBe(1);
+  });
+
+  it("collects refs from multiple lines", () => {
+    const content = [
+      makeTodo("rule-a", "first — fix in #101"),
+      "code();",
+      makeTodo("rule-b", "second — fix in #202"),
+    ].join("\n");
+    const refs = extractTodoRefs(content, "packages/foo/bar.ts");
+    expect(refs).toHaveLength(2);
+    expect(refs[0]?.issueNumbers).toEqual([101]);
+    expect(refs[0]?.line).toBe(1);
+    expect(refs[1]?.issueNumbers).toEqual([202]);
+    expect(refs[1]?.line).toBe(3);
+  });
+
+  it("returns empty array for a file with no dotw-todo comments", () => {
+    const content = "export const x = 1;\n// dotw-ignore some-rule: permanent exception\n";
+    const refs = extractTodoRefs(content, "packages/foo/bar.ts");
+    expect(refs).toHaveLength(0);
+  });
+
+  it("skips identifiers like dotw-todo-needs-issue that contain dotw-todo as a substring", () => {
+    // The pattern requires whitespace after dotw-todo, so dotw-todo-<more> doesn't match.
+    // Construct the content with a template to avoid the scanner seeing a literal pattern.
+    const ident = ["dotw-todo", "needs-issue"].join("-");
+    const content = `// ${ident} is the rule documented in #2352`;
+    const refs = extractTodoRefs(content, "packages/foo/bar.ts");
+    expect(refs).toHaveLength(0);
+  });
+});

--- a/scripts/check-stale-todos.ts
+++ b/scripts/check-stale-todos.ts
@@ -1,0 +1,137 @@
+#!/usr/bin/env bun
+/**
+ * check-stale-todos — flag dotw-todo comments referencing closed GitHub issues.
+ *
+ * Called by `am-i-done --ci` only: shells out to `gh` per unique issue number
+ * and is too slow for pre-commit. Reads from the same file tree as the rule
+ * engine (packages/, scripts/, test/) with the same exclusions (no fixtures,
+ * no .rule.ts, no .d.ts, no node_modules).
+ *
+ * Exit 0: all referenced issues are open (or none found).
+ * Exit 1: at least one dotw-todo references a closed issue.
+ */
+
+import { readFile } from "node:fs/promises";
+import { join, relative } from "node:path";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Glob } from "bun";
+
+export const REPO_ROOT = resolve(fileURLToPath(import.meta.url), "../..");
+
+const TODO_FULL_RE = /\/\/\s*dotw-todo\s+([\w-]+)\s*:\s*(.+)$/;
+const ISSUE_NUM_RE = /#(\d+)/g;
+const STRING_LITERAL_QUOTES = new Set(['"', "'", "`"]);
+
+export interface TodoRef {
+  file: string;
+  line: number;
+  issueNumbers: number[];
+  snippet: string;
+}
+
+/**
+ * Extract all dotw-todo issue references from a single file's content.
+ * Applies the same string-literal guard as the dotw-todo-needs-issue rule:
+ * a `//` immediately preceded by `"`, `'`, or `` ` `` is prose, not a
+ * suppression comment, and is skipped.
+ */
+export function extractTodoRefs(content: string, relPath: string): TodoRef[] {
+  const refs: TodoRef[] = [];
+  const lines = content.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === undefined) continue;
+    const m = TODO_FULL_RE.exec(line);
+    if (!m || !m[2]) continue;
+    const matchIdx = line.indexOf(m[0]);
+    const preceding = matchIdx > 0 ? line[matchIdx - 1] : undefined;
+    if (preceding !== undefined && STRING_LITERAL_QUOTES.has(preceding)) continue;
+    const desc = m[2];
+    const issueNumbers: number[] = [];
+    ISSUE_NUM_RE.lastIndex = 0;
+    for (let im = ISSUE_NUM_RE.exec(desc); im !== null; im = ISSUE_NUM_RE.exec(desc)) {
+      issueNumbers.push(Number.parseInt(im[1] as string, 10));
+    }
+    if (issueNumbers.length === 0) continue;
+    refs.push({ file: relPath, line: i + 1, issueNumbers, snippet: line.trim() });
+  }
+  return refs;
+}
+
+async function scanFiles(repoRoot: string): Promise<TodoRef[]> {
+  const roots = ["packages", "scripts", "test"];
+  const all: TodoRef[] = [];
+  for (const root of roots) {
+    const cwd = join(repoRoot, root);
+    const glob = new Glob("**/*.{ts,tsx}");
+    for await (const rel of glob.scan({ cwd, absolute: false })) {
+      if (rel.endsWith(".d.ts")) continue;
+      if (rel.includes("node_modules")) continue;
+      if (rel.includes("rules/fixtures/") || rel.endsWith(".fixture.ts") || rel.endsWith(".fixture.tsx")) continue;
+      if (rel.endsWith(".rule.ts") || rel.endsWith(".rule.tsx")) continue;
+      const abs = join(cwd, rel);
+      const content = await readFile(abs, "utf8");
+      all.push(...extractTodoRefs(content, relative(repoRoot, abs)));
+    }
+  }
+  return all;
+}
+
+function fetchIssueState(issueNumber: number): string | null {
+  const result = Bun.spawnSync(["gh", "issue", "view", String(issueNumber), "--json", "state", "--jq", ".state"]);
+  if (result.exitCode !== 0) return null;
+  return result.stdout.toString().trim();
+}
+
+async function main(): Promise<void> {
+  const refs = await scanFiles(REPO_ROOT);
+  if (refs.length === 0) {
+    process.stdout.write("✓ no dotw-todo issue references found\n");
+    return;
+  }
+
+  const uniqueNumbers = new Set<number>();
+  for (const ref of refs) {
+    for (const n of ref.issueNumbers) uniqueNumbers.add(n);
+  }
+
+  const closedIssues = new Set<number>();
+  const unreachable = new Set<number>();
+  for (const n of uniqueNumbers) {
+    const state = fetchIssueState(n);
+    if (state === null) unreachable.add(n);
+    else if (state === "CLOSED") closedIssues.add(n);
+  }
+
+  if (unreachable.size > 0) {
+    process.stderr.write(
+      `⚠ could not fetch state for issue(s): ${[...unreachable].map((n) => `#${n}`).join(", ")} — skipped\n`,
+    );
+  }
+
+  const stale = refs.filter((r) => r.issueNumbers.some((n) => closedIssues.has(n)));
+  if (stale.length === 0) {
+    process.stdout.write(
+      `✓ ${refs.length} dotw-todo ref${refs.length === 1 ? "" : "s"} checked — all referenced issues open\n`,
+    );
+    return;
+  }
+
+  process.stderr.write(
+    `\n✗ ${stale.length} dotw-todo comment${stale.length === 1 ? "" : "s"} reference closed issue${stale.length === 1 ? "" : "s"}:\n\n`,
+  );
+  for (const ref of stale) {
+    const closed = ref.issueNumbers.filter((n) => closedIssues.has(n));
+    process.stderr.write(`  ${ref.file}:${ref.line}  ${closed.map((n) => `#${n} (CLOSED)`).join(", ")}\n`);
+    process.stderr.write(`    ${ref.snippet}\n\n`);
+  }
+  process.stderr.write(
+    "fix: remove the violation (and its dotw-todo), or reopen/file a successor issue and update the reference\n",
+  );
+  process.exit(1);
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/check-stale-todos.ts
+++ b/scripts/check-stale-todos.ts
@@ -8,7 +8,7 @@
  * no .rule.ts, no .d.ts, no node_modules).
  *
  * Exit 0: all referenced issues are open (or none found).
- * Exit 1: at least one dotw-todo references a closed issue.
+ * Exit 1: at least one dotw-todo references a closed issue, or gh is unreachable.
  */
 
 import { readFile } from "node:fs/promises";
@@ -23,6 +23,8 @@ const TODO_FULL_RE = /\/\/\s*dotw-todo\s+([\w-]+)\s*:\s*(.+)$/;
 const ISSUE_NUM_RE = /#(\d+)/g;
 const STRING_LITERAL_QUOTES = new Set(['"', "'", "`"]);
 
+const GH_TIMEOUT_MS = 10_000;
+
 export interface TodoRef {
   file: string;
   line: number;
@@ -30,12 +32,8 @@ export interface TodoRef {
   snippet: string;
 }
 
-/**
- * Extract all dotw-todo issue references from a single file's content.
- * Applies the same string-literal guard as the dotw-todo-needs-issue rule:
- * a `//` immediately preceded by `"`, `'`, or `` ` `` is prose, not a
- * suppression comment, and is skipped.
- */
+export type IssueFetcher = (issueNumber: number) => Promise<string | null>;
+
 export function extractTodoRefs(content: string, relPath: string): TodoRef[] {
   const refs: TodoRef[] = [];
   const lines = content.split("\n");
@@ -59,7 +57,7 @@ export function extractTodoRefs(content: string, relPath: string): TodoRef[] {
   return refs;
 }
 
-async function scanFiles(repoRoot: string): Promise<TodoRef[]> {
+export async function scanFiles(repoRoot: string): Promise<TodoRef[]> {
   const roots = ["packages", "scripts", "test"];
   const all: TodoRef[] = [];
   for (const root of roots) {
@@ -78,17 +76,25 @@ async function scanFiles(repoRoot: string): Promise<TodoRef[]> {
   return all;
 }
 
-function fetchIssueState(issueNumber: number): string | null {
-  const result = Bun.spawnSync(["gh", "issue", "view", String(issueNumber), "--json", "state", "--jq", ".state"]);
-  if (result.exitCode !== 0) return null;
-  return result.stdout.toString().trim();
+export async function fetchIssueStateViaGh(issueNumber: number): Promise<string | null> {
+  const proc = Bun.spawn(["gh", "issue", "view", String(issueNumber), "--json", "state", "--jq", ".state"], {
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const timer = setTimeout(() => proc.kill(), GH_TIMEOUT_MS);
+  try {
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) return null;
+    return (await new Response(proc.stdout).text()).trim();
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
-async function main(): Promise<void> {
-  const refs = await scanFiles(REPO_ROOT);
+export async function checkRefs(refs: TodoRef[], fetcher: IssueFetcher): Promise<number> {
   if (refs.length === 0) {
     process.stdout.write("✓ no dotw-todo issue references found\n");
-    return;
+    return 0;
   }
 
   const uniqueNumbers = new Set<number>();
@@ -96,12 +102,20 @@ async function main(): Promise<void> {
     for (const n of ref.issueNumbers) uniqueNumbers.add(n);
   }
 
+  const results = await Promise.all([...uniqueNumbers].map(async (n) => ({ issue: n, state: await fetcher(n) })));
+
   const closedIssues = new Set<number>();
   const unreachable = new Set<number>();
-  for (const n of uniqueNumbers) {
-    const state = fetchIssueState(n);
-    if (state === null) unreachable.add(n);
-    else if (state === "CLOSED") closedIssues.add(n);
+  for (const { issue, state } of results) {
+    if (state === null) unreachable.add(issue);
+    else if (state === "CLOSED") closedIssues.add(issue);
+  }
+
+  if (unreachable.size === uniqueNumbers.size) {
+    process.stderr.write(
+      `✗ could not reach GitHub API — cannot verify issue states (${uniqueNumbers.size} issue${uniqueNumbers.size === 1 ? "" : "s"} unreachable)\n`,
+    );
+    return 1;
   }
 
   if (unreachable.size > 0) {
@@ -115,7 +129,7 @@ async function main(): Promise<void> {
     process.stdout.write(
       `✓ ${refs.length} dotw-todo ref${refs.length === 1 ? "" : "s"} checked — all referenced issues open\n`,
     );
-    return;
+    return 0;
   }
 
   process.stderr.write(
@@ -129,9 +143,11 @@ async function main(): Promise<void> {
   process.stderr.write(
     "fix: remove the violation (and its dotw-todo), or reopen/file a successor issue and update the reference\n",
   );
-  process.exit(1);
+  return 1;
 }
 
 if (import.meta.main) {
-  await main();
+  const refs = await scanFiles(REPO_ROOT);
+  const code = await checkRefs(refs, fetchIssueStateViaGh);
+  process.exit(code);
 }


### PR DESCRIPTION
## Summary
- Adds `scripts/check-stale-todos.ts`: scans source tree for `// dotw-todo ... #NNN` comments and calls `gh issue view NNN` per unique issue; exits non-zero if any referenced issue is CLOSED with file:line + snippet in the error
- Wired into `am-i-done --ci` only (too slow for pre-commit due to `gh` round-trips); not in `PRE_COMMIT`, `PRE_PUSH`, or `COMPREHENSIVE` step lists
- Spec file uses a `makeTodo()` builder so no literal `// dotw-todo ... #NNN` patterns appear in the spec source itself (prevents the scanner from picking up test data strings and calling `gh` on fake issue numbers)

## Test plan
- [x] 10 unit tests cover `extractTodoRefs`: single issue, multiple issues, string-literal exclusions (double/single/backtick), no issue number, trailing-style comments, multi-line, empty input, identifier exclusion (`dotw-todo-needs-issue`)
- [x] `bun run am-i-done --ci --only stale-todos` passes on clean main (no stale todos currently)
- [x] `bun run am-i-done --pre-commit` still 4 steps — stale-todos not included
- [x] Full pre-commit gate: typecheck + lint + rules all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)