### PR TITLE
refactor(test): replace as-cast with typed annotation on noGraph stub (fixes #2536)

### DIFF
--- a/scripts/_runner/ci-steps.spec.ts
+++ b/scripts/_runner/ci-steps.spec.ts
@@ -19,6 +19,8 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import type { ImportGraph } from "../rules/_engine/import-graph";
+
 /**
  * Derive the junit/coverage failures count from the stdout content.
  * A stdout containing " 0 fail" is a clean-run signal → 0 failures.
@@ -404,15 +406,14 @@ describe("changedTestsStep", () => {
   // test; under parallel load this pushes the file past Bun's default
   // timeout and triggers SIGTERM of the child process → exit -1 (#2464).
   const noSpecFiles = () => [] as string[];
-  const noGraph = () =>
-    ({
-      forward: new Map(),
-      reverse: new Map(),
-      files: new Set(),
-      droppedEdges: 0,
-      closureOf: () => new Set(),
-      dependentsOf: () => new Set(),
-    }) as ReturnType<typeof import("../rules/_engine/import-graph").buildImportGraph>;
+  const noGraph = (): ImportGraph => ({
+    forward: new Map(),
+    reverse: new Map(),
+    files: new Set(),
+    droppedEdges: 0,
+    closureOf: () => new Set(),
+    dependentsOf: () => new Set(),
+  });
 
   it("exit 0 on both passes → success", async () => {
     const dir = makeFakeBun({ code: 0, stdout: passingSummary });


### PR DESCRIPTION
## Summary
- Imports `ImportGraph` type directly from `scripts/rules/_engine/import-graph.ts` instead of using `ReturnType<typeof import(...)>`
- Annotates `noGraph()` return type as `: ImportGraph` — TypeScript now enforces structural completeness; any new required field becomes a compile error at the stub call site
- No runtime change; all 28 `ci-steps.spec.ts` tests continue to pass

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes (no changes applied — code was already formatted correctly)
- [x] `bun test scripts/_runner/ci-steps.spec.ts` — 28/28 pass
- [x] Pre-commit and pre-push `am-i-done` gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)