### PR TITLE
feat(mock): extend mock-script DSL to cover full protocol surface (fixes #2543)

### DIFF
--- a/packages/daemon/src/mock-server.spec.ts
+++ b/packages/daemon/src/mock-server.spec.ts
@@ -588,6 +588,39 @@ describe("Mock script DSL (extended entries)", () => {
     expect(text).toContain("req-x");
   });
 
+  test("approve resolves even if sent before wait_for executes", async () => {
+    await setup();
+    const path = writeScript("early-approve.json", [
+      { emit: "permission_request", tool: "Write", args: { path: "/tmp/x" }, request_id: "early-1" },
+      { wait_for: "approve", timeout_ms: 5000 },
+      { emit: "response", text: "continued after early approve" },
+    ]);
+
+    const result = await client.callTool({ name: "mock_prompt", arguments: { prompt: path, wait: false } });
+    const { sessionId } = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      const row = db?.getSession(sessionId);
+      if (row?.state === "waiting_permission") break;
+      await Bun.sleep(POLL_INTERVAL_MS);
+    }
+    expect(db?.getSession(sessionId)?.state).toBe("waiting_permission");
+
+    const approveResult = await client.callTool({
+      name: "mock_approve",
+      arguments: { sessionId, requestId: "early-1" },
+    });
+    expect(approveResult.isError).toBeFalsy();
+
+    await client.callTool({ name: "mock_wait", arguments: { sessionId } });
+
+    const transcript = await client.callTool({ name: "mock_transcript", arguments: { sessionId } });
+    const entries = JSON.parse((transcript.content as Array<{ type: string; text: string }>)[0].text);
+    expect(entries.some((e: { text: string }) => e.text === "continued after early approve")).toBe(true);
+    expect(entries.some((e: { text: string }) => e.text === "permission approve")).toBe(true);
+  });
+
   test("mixed legacy + emit entries in same script", async () => {
     await setup();
     const path = writeScript("mixed.json", [
@@ -601,15 +634,20 @@ describe("Mock script DSL (extended entries)", () => {
     expect(parsed.result.cost).toBeCloseTo(0.001);
   });
 
-  test("delay on emit entries works", async () => {
+  test("delay on emit entries preserves ordering", async () => {
     await setup();
     const path = writeScript("delay.json", [
-      { emit: "response", text: "fast", delay: 0 },
-      { emit: "response", text: "slow", delay: 50 },
+      { emit: "response", text: "first", delay: 0 },
+      { emit: "response", text: "second", delay: 10 },
     ]);
-    const start = Date.now();
-    await runScript(path);
-    const elapsed = Date.now() - start;
-    expect(elapsed).toBeGreaterThanOrEqual(40);
+    const result = await client.callTool({ name: "mock_prompt", arguments: { prompt: path, wait: false } });
+    const { sessionId } = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+
+    await client.callTool({ name: "mock_wait", arguments: { sessionId } });
+
+    const transcript = await client.callTool({ name: "mock_transcript", arguments: { sessionId } });
+    const entries = JSON.parse((transcript.content as Array<{ type: string; text: string }>)[0].text);
+    const texts = entries.filter((e: { role: string }) => e.role === "assistant").map((e: { text: string }) => e.text);
+    expect(texts).toEqual(["first", "second"]);
   });
 });

--- a/packages/daemon/src/mock-server.spec.ts
+++ b/packages/daemon/src/mock-server.spec.ts
@@ -1,8 +1,12 @@
-import { afterAll, afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { MOCK_SERVER_NAME, silentLogger } from "@mcp-cli/core";
 import { testOptions } from "../../../test/test-options";
 import { StateDb } from "./db/state";
 import { MockServer, buildMockToolCache, isWorkerEvent } from "./mock-server";
+
+setDefaultTimeout(10_000);
 
 // ── isWorkerEvent ──
 
@@ -329,5 +333,283 @@ describe("MockServer", () => {
     expect(server.hasActiveSessions()).toBe(false);
     const row = db.getSession("stale-1");
     expect(row?.state).toBe("ended");
+  });
+});
+
+// ── Extended mock-script DSL integration tests ──
+
+const POLL_INTERVAL_MS = 50;
+
+describe("Mock script DSL (extended entries)", () => {
+  let server: MockServer | undefined;
+  let db: StateDb | undefined;
+  let client: Awaited<ReturnType<MockServer["start"]>>["client"];
+  let opts: ReturnType<typeof testOptions>;
+  let scriptDir: string;
+
+  async function setup(): Promise<void> {
+    opts = testOptions();
+    scriptDir = join(opts.dir, "scripts");
+    mkdirSync(scriptDir, { recursive: true });
+    db = new StateDb(opts.DB_PATH);
+    server = new MockServer(db, undefined, undefined, silentLogger);
+    const { client: c } = await server.start();
+    client = c;
+  }
+
+  afterEach(async () => {
+    await server?.stop();
+    db?.close();
+    server = undefined;
+    db = undefined;
+    opts?.[Symbol.dispose]();
+  });
+
+  function writeScript(name: string, entries: unknown[]): string {
+    const path = join(scriptDir, name);
+    writeFileSync(path, JSON.stringify(entries));
+    return path;
+  }
+
+  async function runScript(path: string): Promise<string> {
+    const result = await client.callTool({ name: "mock_prompt", arguments: { prompt: path, wait: true } });
+    const content = result.content as Array<{ type: string; text: string }>;
+    return content[0].text;
+  }
+
+  test("legacy format still works", async () => {
+    await setup();
+    const path = writeScript("legacy.json", [
+      { delay: 0, text: "Hello" },
+      { delay: 0, text: "World" },
+    ]);
+    const text = await runScript(path);
+    const parsed = JSON.parse(text);
+    expect(parsed.type).toBe("session:result");
+    expect(parsed.result.tokens).toBe(2);
+  });
+
+  test("emit:init sets session_id", async () => {
+    await setup();
+    const path = writeScript("init.json", [
+      { emit: "init", session_id: "custom-id" },
+      { emit: "response", text: "after init" },
+    ]);
+    const text = await runScript(path);
+    const parsed = JSON.parse(text);
+    expect(parsed.type).toBe("session:result");
+  });
+
+  test("emit:response emits session:response event", async () => {
+    await setup();
+    const path = writeScript("response.json", [{ emit: "response", text: "Hello from DSL" }]);
+    const result = await client.callTool({ name: "mock_prompt", arguments: { prompt: path, wait: false } });
+    const content = result.content as Array<{ type: string; text: string }>;
+    const { sessionId } = JSON.parse(content[0].text);
+
+    const waitResult = await client.callTool({ name: "mock_wait", arguments: { sessionId } });
+    const waitContent = waitResult.content as Array<{ type: string; text: string }>;
+    const waitParsed = JSON.parse(waitContent[0].text);
+    expect(waitParsed.type).toBe("session:result");
+
+    const transcript = await client.callTool({ name: "mock_transcript", arguments: { sessionId } });
+    const transcriptContent = transcript.content as Array<{ type: string; text: string }>;
+    const entries = JSON.parse(transcriptContent[0].text);
+    expect(entries.some((e: { text: string }) => e.text === "Hello from DSL")).toBe(true);
+  });
+
+  test("emit:tool_call appears in transcript", async () => {
+    await setup();
+    const path = writeScript("tool_call.json", [{ emit: "tool_call", name: "Read", args: { path: "/tmp/foo" } }]);
+    const result = await client.callTool({ name: "mock_prompt", arguments: { prompt: path, wait: false } });
+    const { sessionId } = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+
+    await client.callTool({ name: "mock_wait", arguments: { sessionId } });
+
+    const transcript = await client.callTool({ name: "mock_transcript", arguments: { sessionId } });
+    const entries = JSON.parse((transcript.content as Array<{ type: string; text: string }>)[0].text);
+    expect(entries.some((e: { text: string }) => e.text?.includes("[tool_call] Read"))).toBe(true);
+  });
+
+  test("emit:cost accumulates in result", async () => {
+    await setup();
+    const path = writeScript("cost.json", [
+      { emit: "cost", usd: 0.001, tokens_in: 100, tokens_out: 50 },
+      { emit: "cost", usd: 0.002, tokens_in: 200, tokens_out: 100 },
+    ]);
+    const text = await runScript(path);
+    const parsed = JSON.parse(text);
+    expect(parsed.type).toBe("session:result");
+    expect(parsed.result.cost).toBeCloseTo(0.003);
+    expect(parsed.result.tokens).toBe(450);
+  });
+
+  test("emit:error terminates with session:error", async () => {
+    await setup();
+    const path = writeScript("error.json", [
+      { emit: "response", text: "before error" },
+      { emit: "error", message: "something broke" },
+    ]);
+    const result = await client.callTool({ name: "mock_prompt", arguments: { prompt: path, wait: false } });
+    const { sessionId } = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+
+    await client.callTool({ name: "mock_wait", arguments: { sessionId } });
+
+    const transcript = await client.callTool({ name: "mock_transcript", arguments: { sessionId } });
+    const entries = JSON.parse((transcript.content as Array<{ type: string; text: string }>)[0].text);
+    expect(entries.some((e: { text: string }) => e.text?.includes("something broke"))).toBe(true);
+  });
+
+  test("emit:disconnect emits session:disconnected", async () => {
+    await setup();
+    const path = writeScript("disconnect.json", [{ emit: "disconnect", reason: "network failure" }]);
+    const result = await client.callTool({ name: "mock_prompt", arguments: { prompt: path, wait: false } });
+    const { sessionId } = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      const row = db?.getSession(sessionId);
+      if (row?.state === "disconnected") break;
+      await Bun.sleep(POLL_INTERVAL_MS);
+    }
+    expect(db?.getSession(sessionId)?.state).toBe("disconnected");
+  });
+
+  test("emit:end terminates the session", async () => {
+    await setup();
+    const path = writeScript("end.json", [{ emit: "response", text: "bye" }, { emit: "end" }]);
+    const result = await client.callTool({ name: "mock_prompt", arguments: { prompt: path, wait: false } });
+    const { sessionId } = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+
+    await client.callTool({ name: "mock_wait", arguments: { sessionId } });
+    const status = db?.getSession(sessionId);
+    expect(status?.state).toBe("ended");
+  });
+
+  test("emit:result with custom text", async () => {
+    await setup();
+    const path = writeScript("result.json", [{ emit: "result", text: "custom done message" }]);
+    const text = await runScript(path);
+    const parsed = JSON.parse(text);
+    expect(parsed.type).toBe("session:result");
+    expect(parsed.result.result).toBe("custom done message");
+  });
+
+  test("permission_request + approve round-trip", async () => {
+    await setup();
+    const path = writeScript("perm-approve.json", [
+      { emit: "permission_request", tool: "Write", args: { path: "/tmp/x" }, request_id: "req-1" },
+      { wait_for: "approve", timeout_ms: 5000 },
+      { emit: "response", text: "approved and continuing" },
+    ]);
+
+    const result = await client.callTool({ name: "mock_prompt", arguments: { prompt: path, wait: false } });
+    const { sessionId } = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+
+    // Poll until permission request shows up as waiting_permission in DB
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      const row = db?.getSession(sessionId);
+      if (row?.state === "waiting_permission") break;
+      await Bun.sleep(POLL_INTERVAL_MS);
+    }
+    expect(db?.getSession(sessionId)?.state).toBe("waiting_permission");
+
+    // Approve the permission
+    const approveResult = await client.callTool({
+      name: "mock_approve",
+      arguments: { sessionId, requestId: "req-1" },
+    });
+    expect(approveResult.isError).toBeFalsy();
+
+    // Wait for the script to finish
+    await client.callTool({ name: "mock_wait", arguments: { sessionId } });
+
+    const transcript = await client.callTool({ name: "mock_transcript", arguments: { sessionId } });
+    const entries = JSON.parse((transcript.content as Array<{ type: string; text: string }>)[0].text);
+    expect(entries.some((e: { text: string }) => e.text === "approved and continuing")).toBe(true);
+  });
+
+  test("permission_request + deny round-trip", async () => {
+    await setup();
+    const path = writeScript("perm-deny.json", [
+      { emit: "permission_request", tool: "Bash", args: { command: "rm -rf /" }, request_id: "req-deny" },
+      { wait_for: "deny", timeout_ms: 5000 },
+      { emit: "response", text: "denied and continuing" },
+    ]);
+
+    const result = await client.callTool({ name: "mock_prompt", arguments: { prompt: path, wait: false } });
+    const { sessionId } = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      const row = db?.getSession(sessionId);
+      if (row?.state === "waiting_permission") break;
+      await Bun.sleep(POLL_INTERVAL_MS);
+    }
+
+    const denyResult = await client.callTool({
+      name: "mock_deny",
+      arguments: { sessionId, requestId: "req-deny" },
+    });
+    expect(denyResult.isError).toBeFalsy();
+
+    await client.callTool({ name: "mock_wait", arguments: { sessionId } });
+
+    const transcript = await client.callTool({ name: "mock_transcript", arguments: { sessionId } });
+    const entries = JSON.parse((transcript.content as Array<{ type: string; text: string }>)[0].text);
+    expect(entries.some((e: { text: string }) => e.text === "denied and continuing")).toBe(true);
+  });
+
+  test("approve returns error for unknown request", async () => {
+    await setup();
+    const path = writeScript("perm-unknown.json", [
+      { emit: "permission_request", tool: "Write", request_id: "req-x" },
+      { wait_for: "approve", timeout_ms: 5000 },
+    ]);
+
+    const result = await client.callTool({ name: "mock_prompt", arguments: { prompt: path, wait: false } });
+    const { sessionId } = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
+
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      const row = db?.getSession(sessionId);
+      if (row?.state === "waiting_permission") break;
+      await Bun.sleep(POLL_INTERVAL_MS);
+    }
+
+    const approveResult = await client.callTool({
+      name: "mock_approve",
+      arguments: { sessionId, requestId: "wrong-id" },
+    });
+    expect(approveResult.isError).toBe(true);
+    const text = (approveResult.content as Array<{ type: string; text: string }>)[0].text;
+    expect(text).toContain("No pending permission");
+    expect(text).toContain("req-x");
+  });
+
+  test("mixed legacy + emit entries in same script", async () => {
+    await setup();
+    const path = writeScript("mixed.json", [
+      { delay: 0, text: "legacy line" },
+      { emit: "response", text: "new line" },
+      { emit: "cost", usd: 0.001, tokens_in: 10, tokens_out: 5 },
+    ]);
+    const text = await runScript(path);
+    const parsed = JSON.parse(text);
+    expect(parsed.type).toBe("session:result");
+    expect(parsed.result.cost).toBeCloseTo(0.001);
+  });
+
+  test("delay on emit entries works", async () => {
+    await setup();
+    const path = writeScript("delay.json", [
+      { emit: "response", text: "fast", delay: 0 },
+      { emit: "response", text: "slow", delay: 50 },
+    ]);
+    const start = Date.now();
+    await runScript(path);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(40);
   });
 });

--- a/packages/daemon/src/mock-server.spec.ts
+++ b/packages/daemon/src/mock-server.spec.ts
@@ -2,6 +2,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, setDefaultTimeout, t
 import { mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { MOCK_SERVER_NAME, silentLogger } from "@mcp-cli/core";
+import { pollUntil } from "../../../test/harness";
 import { testOptions } from "../../../test/test-options";
 import { StateDb } from "./db/state";
 import { MockServer, buildMockToolCache, isWorkerEvent } from "./mock-server";
@@ -338,8 +339,6 @@ describe("MockServer", () => {
 
 // ── Extended mock-script DSL integration tests ──
 
-const POLL_INTERVAL_MS = 50;
-
 describe("Mock script DSL (extended entries)", () => {
   let server: MockServer | undefined;
   let db: StateDb | undefined;
@@ -466,12 +465,7 @@ describe("Mock script DSL (extended entries)", () => {
     const result = await client.callTool({ name: "mock_prompt", arguments: { prompt: path, wait: false } });
     const { sessionId } = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
 
-    const deadline = Date.now() + 5000;
-    while (Date.now() < deadline) {
-      const row = db?.getSession(sessionId);
-      if (row?.state === "disconnected") break;
-      await Bun.sleep(POLL_INTERVAL_MS);
-    }
+    await pollUntil(() => db?.getSession(sessionId)?.state === "disconnected", 5000);
     expect(db?.getSession(sessionId)?.state).toBe("disconnected");
   });
 
@@ -506,13 +500,7 @@ describe("Mock script DSL (extended entries)", () => {
     const result = await client.callTool({ name: "mock_prompt", arguments: { prompt: path, wait: false } });
     const { sessionId } = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
 
-    // Poll until permission request shows up as waiting_permission in DB
-    const deadline = Date.now() + 5000;
-    while (Date.now() < deadline) {
-      const row = db?.getSession(sessionId);
-      if (row?.state === "waiting_permission") break;
-      await Bun.sleep(POLL_INTERVAL_MS);
-    }
+    await pollUntil(() => db?.getSession(sessionId)?.state === "waiting_permission", 5000);
     expect(db?.getSession(sessionId)?.state).toBe("waiting_permission");
 
     // Approve the permission
@@ -541,12 +529,7 @@ describe("Mock script DSL (extended entries)", () => {
     const result = await client.callTool({ name: "mock_prompt", arguments: { prompt: path, wait: false } });
     const { sessionId } = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
 
-    const deadline = Date.now() + 5000;
-    while (Date.now() < deadline) {
-      const row = db?.getSession(sessionId);
-      if (row?.state === "waiting_permission") break;
-      await Bun.sleep(POLL_INTERVAL_MS);
-    }
+    await pollUntil(() => db?.getSession(sessionId)?.state === "waiting_permission", 5000);
 
     const denyResult = await client.callTool({
       name: "mock_deny",
@@ -571,12 +554,7 @@ describe("Mock script DSL (extended entries)", () => {
     const result = await client.callTool({ name: "mock_prompt", arguments: { prompt: path, wait: false } });
     const { sessionId } = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
 
-    const deadline = Date.now() + 5000;
-    while (Date.now() < deadline) {
-      const row = db?.getSession(sessionId);
-      if (row?.state === "waiting_permission") break;
-      await Bun.sleep(POLL_INTERVAL_MS);
-    }
+    await pollUntil(() => db?.getSession(sessionId)?.state === "waiting_permission", 5000);
 
     const approveResult = await client.callTool({
       name: "mock_approve",
@@ -599,12 +577,7 @@ describe("Mock script DSL (extended entries)", () => {
     const result = await client.callTool({ name: "mock_prompt", arguments: { prompt: path, wait: false } });
     const { sessionId } = JSON.parse((result.content as Array<{ type: string; text: string }>)[0].text);
 
-    const deadline = Date.now() + 5000;
-    while (Date.now() < deadline) {
-      const row = db?.getSession(sessionId);
-      if (row?.state === "waiting_permission") break;
-      await Bun.sleep(POLL_INTERVAL_MS);
-    }
+    await pollUntil(() => db?.getSession(sessionId)?.state === "waiting_permission", 5000);
     expect(db?.getSession(sessionId)?.state).toBe("waiting_permission");
 
     const approveResult = await client.callTool({

--- a/packages/daemon/src/mock-session-worker.ts
+++ b/packages/daemon/src/mock-session-worker.ts
@@ -426,18 +426,20 @@ async function runScript(session: MockSession): Promise<void> {
     }
   }
 
-  if (!emittedTerminal && !session.interrupted) {
+  if (!emittedTerminal) {
     session.state = "idle";
-    session.lastResultText = "Mock script completed";
-    forwardSessionEvent(session.sessionId, {
-      type: "session:result",
-      result: {
-        result: session.lastResultText,
-        cost: session.totalCost,
-        tokens: session.totalTokens > 0 ? session.totalTokens : session.entries.length,
-        numTurns: 1,
-      },
-    });
+    if (!session.interrupted) {
+      session.lastResultText = "Mock script completed";
+      forwardSessionEvent(session.sessionId, {
+        type: "session:result",
+        result: {
+          result: session.lastResultText,
+          cost: session.totalCost,
+          tokens: session.totalTokens > 0 ? session.totalTokens : session.entries.length,
+          numTurns: 1,
+        },
+      });
+    }
   }
 
   for (const waiter of session.pendingPermissions.values()) {

--- a/packages/daemon/src/mock-session-worker.ts
+++ b/packages/daemon/src/mock-session-worker.ts
@@ -5,7 +5,22 @@
  * it reads a JSON script file and emits canned responses with configurable delays.
  * No external binary, no network, fully deterministic.
  *
- * Script format: [{ "delay": 100, "text": "Hello" }, { "delay": 0, "text": "Done" }]
+ * Extended script format (discriminated union on `emit` or `wait_for`):
+ *
+ *   [
+ *     {"emit": "init", "session_id": "..."},
+ *     {"delay": 100, "emit": "response", "text": "Hello"},
+ *     {"emit": "tool_call", "name": "Read", "args": {"path": "/tmp/foo"}},
+ *     {"emit": "permission_request", "tool": "Write", "args": {}},
+ *     {"wait_for": "approve", "timeout_ms": 1000},
+ *     {"emit": "cost", "usd": 0.0012, "tokens_in": 100, "tokens_out": 50},
+ *     {"emit": "result", "text": "done"},
+ *     {"emit": "error", "message": "something broke"},
+ *     {"emit": "disconnect", "reason": "network"},
+ *     {"emit": "end"}
+ *   ]
+ *
+ * Legacy format still supported: [{"delay": 100, "text": "Hello"}]
  *
  * Protocol:
  *   1. Parent sends: { type: "init" }
@@ -15,7 +30,12 @@
  */
 
 import { resolve } from "node:path";
-import { type AgentSessionEvent, DEFAULT_TIMEOUT_MS, MOCK_SERVER_NAME } from "@mcp-cli/core";
+import {
+  type AgentPermissionRequest,
+  type AgentSessionEvent,
+  DEFAULT_TIMEOUT_MS,
+  MOCK_SERVER_NAME,
+} from "@mcp-cli/core";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { MOCK_TOOLS } from "./mock-session/tools";
@@ -46,14 +66,97 @@ declare const self: Worker;
 let mcpServer: Server | null = null;
 let transport: WorkerServerTransport | null = null;
 
-// ── Script entry type ──
+// ── Script entry types (discriminated union) ──
 
-interface ScriptEntry {
+interface EmitInit {
+  emit: "init";
+  session_id?: string;
+  delay?: number;
+}
+
+interface EmitResponse {
+  emit: "response";
+  text: string;
+  delay?: number;
+}
+
+interface EmitToolCall {
+  emit: "tool_call";
+  name: string;
+  args?: Record<string, unknown>;
+  delay?: number;
+}
+
+interface EmitPermissionRequest {
+  emit: "permission_request";
+  tool: string;
+  args?: Record<string, unknown>;
+  request_id?: string;
+  delay?: number;
+}
+
+interface EmitCost {
+  emit: "cost";
+  usd?: number;
+  tokens_in?: number;
+  tokens_out?: number;
+  delay?: number;
+}
+
+interface EmitResult {
+  emit: "result";
+  text?: string;
+  delay?: number;
+}
+
+interface EmitError {
+  emit: "error";
+  message?: string;
+  messages?: string[];
+  delay?: number;
+}
+
+interface EmitDisconnect {
+  emit: "disconnect";
+  reason?: string;
+  delay?: number;
+}
+
+interface EmitEnd {
+  emit: "end";
+  delay?: number;
+}
+
+interface WaitForEntry {
+  wait_for: "approve" | "deny";
+  timeout_ms?: number;
+}
+
+interface LegacyEntry {
   delay: number;
   text: string;
 }
 
+type ScriptEntry =
+  | EmitInit
+  | EmitResponse
+  | EmitToolCall
+  | EmitPermissionRequest
+  | EmitCost
+  | EmitResult
+  | EmitError
+  | EmitDisconnect
+  | EmitEnd
+  | WaitForEntry
+  | LegacyEntry;
+
 // ── Session type ──
+
+interface PermissionWaiter {
+  requestId: string;
+  resolve: (verdict: "approve" | "deny") => void;
+  timer: ReturnType<typeof setTimeout>;
+}
 
 interface MockSession {
   sessionId: string;
@@ -64,6 +167,10 @@ interface MockSession {
   interrupted: boolean;
   transcript: Array<{ role: string; text: string }>;
   createdAt: number;
+  pendingPermissions: Map<string, PermissionWaiter>;
+  totalCost: number;
+  totalTokens: number;
+  lastResultText: string | null;
   /** Resolves when the script finishes or is interrupted. */
   done: Promise<void>;
   resolveDone: () => void;
@@ -118,6 +225,9 @@ function forwardSessionEvent(sessionId: string, event: AgentSessionEvent): void 
         session: { sessionId, state: "init", model: event.model, cwd: event.cwd },
       });
       break;
+    case "session:permission_request":
+      self.postMessage({ type: "db:state", sessionId, state: "waiting_permission" });
+      break;
     case "session:result":
       self.postMessage({
         type: "db:cost",
@@ -142,44 +252,195 @@ function forwardSessionEvent(sessionId: string, event: AgentSessionEvent): void 
 
 // ── Script execution ──
 
-async function runScript(session: MockSession): Promise<void> {
-  session.state = "running";
-  self.postMessage({ type: "db:state", sessionId: session.sessionId, state: "active" });
+function isLegacyEntry(entry: ScriptEntry): entry is LegacyEntry {
+  return "text" in entry && "delay" in entry && !("emit" in entry) && !("wait_for" in entry);
+}
 
+function isWaitForEntry(entry: ScriptEntry): entry is WaitForEntry {
+  return "wait_for" in entry;
+}
+
+function getDelay(entry: ScriptEntry): number {
+  if ("delay" in entry && typeof entry.delay === "number") return entry.delay;
+  return 0;
+}
+
+async function applyDelay(session: MockSession, entry: ScriptEntry): Promise<boolean> {
+  const delay = getDelay(entry);
+  if (delay > 0) await Bun.sleep(delay);
+  return !session.interrupted;
+}
+
+let nextRequestId = 1;
+
+function emitInit(session: MockSession, sessionIdOverride?: string): void {
   forwardSessionEvent(session.sessionId, {
     type: "session:init",
-    sessionId: session.sessionId,
+    sessionId: sessionIdOverride ?? session.sessionId,
     provider: "mock",
     model: "mock",
     cwd: session.cwd,
   });
+}
+
+async function runScript(session: MockSession): Promise<void> {
+  session.state = "running";
+  self.postMessage({ type: "db:state", sessionId: session.sessionId, state: "active" });
+
+  let emittedTerminal = false;
+
+  // Auto-emit init unless the first entry is an explicit init
+  const firstEntry = session.entries[0];
+  const firstIsExplicitInit = firstEntry && "emit" in firstEntry && firstEntry.emit === "init";
+  if (!firstIsExplicitInit) {
+    emitInit(session);
+  }
 
   for (let i = 0; i < session.entries.length; i++) {
     if (session.interrupted) break;
 
     const entry = session.entries[i];
-    if (entry.delay > 0) {
-      await Bun.sleep(entry.delay);
-    }
-    if (session.interrupted) break;
 
-    session.transcript.push({ role: "assistant", text: entry.text });
+    if (isLegacyEntry(entry)) {
+      if (!(await applyDelay(session, entry))) break;
+      session.transcript.push({ role: "assistant", text: entry.text });
+      forwardSessionEvent(session.sessionId, { type: "session:response", text: entry.text });
+      continue;
+    }
+
+    if (isWaitForEntry(entry)) {
+      const lastPermission = [...session.pendingPermissions.values()].at(-1);
+      if (!lastPermission) continue;
+
+      const timeoutMs = entry.timeout_ms ?? 5000;
+      const verdict = await new Promise<"approve" | "deny" | "timeout">((res) => {
+        const timer = safeSetTimeout(() => res("timeout"), timeoutMs);
+        lastPermission.resolve = (v) => {
+          clearTimeout(timer);
+          res(v);
+        };
+      });
+
+      if (verdict === "timeout") {
+        session.transcript.push({ role: "system", text: `permission timeout (expected ${entry.wait_for})` });
+      } else {
+        session.transcript.push({ role: "system", text: `permission ${verdict}` });
+      }
+
+      session.pendingPermissions.delete(lastPermission.requestId);
+      self.postMessage({ type: "db:state", sessionId: session.sessionId, state: "active" });
+      continue;
+    }
+
+    if (!(await applyDelay(session, entry))) break;
+
+    switch (entry.emit) {
+      case "init": {
+        emitInit(session, entry.session_id);
+        break;
+      }
+
+      case "response": {
+        session.transcript.push({ role: "assistant", text: entry.text });
+        forwardSessionEvent(session.sessionId, { type: "session:response", text: entry.text });
+        break;
+      }
+
+      case "tool_call": {
+        const text = `[tool_call] ${entry.name}(${JSON.stringify(entry.args ?? {})})`;
+        session.transcript.push({ role: "assistant", text });
+        forwardSessionEvent(session.sessionId, { type: "session:response", text });
+        break;
+      }
+
+      case "permission_request": {
+        const requestId = entry.request_id ?? `mock-perm-${nextRequestId++}`;
+        const request: AgentPermissionRequest = {
+          requestId,
+          toolName: entry.tool,
+          input: entry.args ?? {},
+          inputSummary: `${entry.tool}(${JSON.stringify(entry.args ?? {})})`,
+        };
+
+        const waiter: PermissionWaiter = {
+          requestId,
+          resolve: () => {},
+          timer: safeSetTimeout(() => {}, 0),
+        };
+        clearTimeout(waiter.timer);
+        session.pendingPermissions.set(requestId, waiter);
+
+        forwardSessionEvent(session.sessionId, { type: "session:permission_request", request });
+        break;
+      }
+
+      case "cost": {
+        const cost = entry.usd ?? 0;
+        const tokens = (entry.tokens_in ?? 0) + (entry.tokens_out ?? 0);
+        session.totalCost += cost;
+        session.totalTokens += tokens;
+        self.postMessage({ type: "db:cost", sessionId: session.sessionId, cost, tokens });
+        break;
+      }
+
+      case "result": {
+        emittedTerminal = true;
+        session.state = "idle";
+        session.lastResultText = entry.text ?? "Mock script completed";
+        forwardSessionEvent(session.sessionId, {
+          type: "session:result",
+          result: {
+            result: session.lastResultText,
+            cost: session.totalCost,
+            tokens: session.totalTokens,
+            numTurns: 1,
+          },
+        });
+        break;
+      }
+
+      case "error": {
+        emittedTerminal = true;
+        const errors = entry.messages ?? (entry.message ? [entry.message] : ["mock error"]);
+        session.transcript.push({ role: "system", text: `error: ${errors.join("; ")}` });
+        forwardSessionEvent(session.sessionId, { type: "session:error", errors, cost: session.totalCost });
+        break;
+      }
+
+      case "disconnect": {
+        emittedTerminal = true;
+        const reason = entry.reason ?? "mock disconnect";
+        forwardSessionEvent(session.sessionId, { type: "session:disconnected", reason });
+        break;
+      }
+
+      case "end": {
+        emittedTerminal = true;
+        session.state = "ended";
+        forwardSessionEvent(session.sessionId, { type: "session:ended" });
+        break;
+      }
+    }
+  }
+
+  if (!emittedTerminal && !session.interrupted) {
+    session.state = "idle";
+    session.lastResultText = "Mock script completed";
     forwardSessionEvent(session.sessionId, {
-      type: "session:response",
-      text: entry.text,
+      type: "session:result",
+      result: {
+        result: session.lastResultText,
+        cost: session.totalCost,
+        tokens: session.totalTokens || session.entries.length,
+        numTurns: 1,
+      },
     });
   }
 
-  session.state = "idle";
-  forwardSessionEvent(session.sessionId, {
-    type: "session:result",
-    result: {
-      result: "Mock script completed",
-      cost: 0,
-      tokens: session.entries.length,
-      numTurns: 1,
-    },
-  });
+  for (const waiter of session.pendingPermissions.values()) {
+    clearTimeout(waiter.timer);
+  }
+  session.pendingPermissions.clear();
   session.resolveDone();
 }
 
@@ -205,9 +466,9 @@ async function handleToolCall(name: string, args: Record<string, unknown>): Prom
       case "mock_wait":
         return await handleWait(args);
       case "mock_approve":
-        return { content: [{ type: "text", text: "Mock sessions do not generate permission requests" }] };
+        return handleApprove(args);
       case "mock_deny":
-        return { content: [{ type: "text", text: "Mock sessions do not generate permission requests" }] };
+        return handleDeny(args);
       default:
         return { content: [{ type: "text", text: `Unknown tool: ${name}` }], isError: true };
     }
@@ -264,6 +525,10 @@ async function handlePrompt(args: Record<string, unknown>): Promise<ToolResult> 
     interrupted: false,
     transcript: [{ role: "user", text: prompt }],
     createdAt: Date.now(),
+    pendingPermissions: new Map(),
+    totalCost: 0,
+    totalTokens: 0,
+    lastResultText: null,
     done,
     resolveDone,
   };
@@ -294,7 +559,12 @@ async function handlePrompt(args: Record<string, unknown>): Promise<ToolResult> 
         text: JSON.stringify({
           type: "session:result",
           sessionId,
-          result: { cost: 0, tokens: session.entries.length, numTurns: 1 },
+          result: {
+            result: session.lastResultText ?? "Mock script completed",
+            cost: session.totalCost,
+            tokens: session.totalTokens || session.entries.length,
+            numTurns: 1,
+          },
         }),
       },
     ],
@@ -465,6 +735,35 @@ async function handleWait(args: Record<string, unknown>): Promise<ToolResult> {
   await Promise.race([...waiters, Bun.sleep(timeoutMs)]);
   const list = [...sessions.values()].map((s) => ({ sessionId: s.sessionId, state: s.state }));
   return { content: [{ type: "text", text: JSON.stringify(list, null, 2) }] };
+}
+
+function resolvePermission(args: Record<string, unknown>, verdict: "approve" | "deny"): ToolResult {
+  const sessionId = args.sessionId as string;
+  const requestId = args.requestId as string;
+  const session = sessions.get(sessionId);
+  if (!session) {
+    return { content: [{ type: "text", text: `Unknown session: ${sessionId}` }], isError: true };
+  }
+  const waiter = session.pendingPermissions.get(requestId);
+  if (!waiter) {
+    const pending = [...session.pendingPermissions.keys()];
+    return {
+      content: [{ type: "text", text: `No pending permission ${requestId}. Pending: [${pending.join(", ")}]` }],
+      isError: true,
+    };
+  }
+  clearTimeout(waiter.timer);
+  waiter.resolve(verdict);
+  session.pendingPermissions.delete(requestId);
+  return { content: [{ type: "text", text: JSON.stringify({ [`${verdict}d`]: true, requestId }) }] };
+}
+
+function handleApprove(args: Record<string, unknown>): ToolResult {
+  return resolvePermission(args, "approve");
+}
+
+function handleDeny(args: Record<string, unknown>): ToolResult {
+  return resolvePermission(args, "deny");
 }
 
 // ── Server startup ──

--- a/packages/daemon/src/mock-session-worker.ts
+++ b/packages/daemon/src/mock-session-worker.ts
@@ -164,7 +164,7 @@ interface MockSession {
   cwd: string;
   scriptPath: string;
   entries: ScriptEntry[];
-  state: "running" | "idle" | "ended";
+  state: "running" | "idle" | "ended" | "waiting_permission";
   interrupted: boolean;
   transcript: Array<{ role: string; text: string }>;
   createdAt: number;
@@ -226,9 +226,12 @@ function forwardSessionEvent(sessionId: string, event: AgentSessionEvent): void 
         session: { sessionId, state: "init", model: event.model, cwd: event.cwd },
       });
       break;
-    case "session:permission_request":
+    case "session:permission_request": {
+      const s = sessions.get(sessionId);
+      if (s) s.state = "waiting_permission";
       self.postMessage({ type: "db:state", sessionId, state: "waiting_permission" });
       break;
+    }
     case "session:result":
       self.postMessage({
         type: "db:cost",
@@ -321,12 +324,21 @@ async function runScript(session: MockSession): Promise<void> {
 
       if (verdict === "timeout") {
         session.transcript.push({ role: "system", text: `permission timeout (expected ${entry.wait_for})` });
+      } else if (verdict !== entry.wait_for) {
+        session.transcript.push({
+          role: "system",
+          text: `permission ${verdict} (expected ${entry.wait_for}) — script aborted`,
+        });
+        clearTimeout(lastPermission.timer);
+        session.pendingPermissions.delete(lastPermission.requestId);
+        break;
       } else {
         session.transcript.push({ role: "system", text: `permission ${verdict}` });
       }
 
       clearTimeout(lastPermission.timer);
       session.pendingPermissions.delete(lastPermission.requestId);
+      session.state = "running";
       self.postMessage({ type: "db:state", sessionId: session.sessionId, state: "active" });
       continue;
     }
@@ -582,8 +594,8 @@ function handleSessionList(): ToolResult {
     state: s.state,
     model: "mock",
     cwd: s.cwd,
-    cost: 0,
-    tokens: s.entries.length,
+    cost: s.totalCost,
+    tokens: s.totalTokens > 0 ? s.totalTokens : s.entries.length,
     createdAt: s.createdAt,
   }));
   return { content: [{ type: "text", text: JSON.stringify(list, null, 2) }] };
@@ -708,7 +720,11 @@ async function handleWait(args: Record<string, unknown>): Promise<ToolResult> {
             text: JSON.stringify({
               type: "session:result",
               sessionId,
-              result: { cost: 0, tokens: session.entries.length, numTurns: 1 },
+              result: {
+                cost: session.totalCost,
+                tokens: session.totalTokens > 0 ? session.totalTokens : session.entries.length,
+                numTurns: 1,
+              },
             }),
           },
         ],
@@ -724,7 +740,12 @@ async function handleWait(args: Record<string, unknown>): Promise<ToolResult> {
           text: JSON.stringify({
             type: currentState === "idle" ? "session:result" : "timeout",
             sessionId,
-            result: { result: "Mock script completed", cost: 0, tokens: session.entries.length, numTurns: 1 },
+            result: {
+              result: "Mock script completed",
+              cost: session.totalCost,
+              tokens: session.totalTokens > 0 ? session.totalTokens : session.entries.length,
+              numTurns: 1,
+            },
           }),
         },
       ],
@@ -758,7 +779,8 @@ function resolvePermission(args: Record<string, unknown>, verdict: "approve" | "
     };
   }
   waiter.resolve(verdict);
-  return { content: [{ type: "text", text: JSON.stringify({ [`${verdict}d`]: true, requestId }) }] };
+  const key = verdict === "approve" ? "approved" : "denied";
+  return { content: [{ type: "text", text: JSON.stringify({ [key]: true, requestId }) }] };
 }
 
 function handleApprove(args: Record<string, unknown>): ToolResult {

--- a/packages/daemon/src/mock-session-worker.ts
+++ b/packages/daemon/src/mock-session-worker.ts
@@ -154,6 +154,7 @@ type ScriptEntry =
 
 interface PermissionWaiter {
   requestId: string;
+  promise: Promise<"approve" | "deny" | "timeout">;
   resolve: (verdict: "approve" | "deny") => void;
   timer: ReturnType<typeof setTimeout>;
 }
@@ -297,7 +298,7 @@ async function runScript(session: MockSession): Promise<void> {
   }
 
   for (let i = 0; i < session.entries.length; i++) {
-    if (session.interrupted) break;
+    if (session.interrupted || emittedTerminal) break;
 
     const entry = session.entries[i];
 
@@ -313,13 +314,10 @@ async function runScript(session: MockSession): Promise<void> {
       if (!lastPermission) continue;
 
       const timeoutMs = entry.timeout_ms ?? 5000;
-      const verdict = await new Promise<"approve" | "deny" | "timeout">((res) => {
-        const timer = safeSetTimeout(() => res("timeout"), timeoutMs);
-        lastPermission.resolve = (v) => {
-          clearTimeout(timer);
-          res(v);
-        };
+      const timeoutPromise = new Promise<"timeout">((res) => {
+        lastPermission.timer = safeSetTimeout(() => res("timeout"), timeoutMs);
       });
+      const verdict = await Promise.race([lastPermission.promise, timeoutPromise]);
 
       if (verdict === "timeout") {
         session.transcript.push({ role: "system", text: `permission timeout (expected ${entry.wait_for})` });
@@ -327,6 +325,7 @@ async function runScript(session: MockSession): Promise<void> {
         session.transcript.push({ role: "system", text: `permission ${verdict}` });
       }
 
+      clearTimeout(lastPermission.timer);
       session.pendingPermissions.delete(lastPermission.requestId);
       self.postMessage({ type: "db:state", sessionId: session.sessionId, state: "active" });
       continue;
@@ -362,12 +361,16 @@ async function runScript(session: MockSession): Promise<void> {
           inputSummary: `${entry.tool}(${JSON.stringify(entry.args ?? {})})`,
         };
 
+        let waiterResolve: (verdict: "approve" | "deny") => void = () => {};
+        const promise = new Promise<"approve" | "deny" | "timeout">((res) => {
+          waiterResolve = (v) => res(v);
+        });
         const waiter: PermissionWaiter = {
           requestId,
-          resolve: () => {},
+          promise,
+          resolve: waiterResolve,
           timer: safeSetTimeout(() => {}, 0),
         };
-        clearTimeout(waiter.timer);
         session.pendingPermissions.set(requestId, waiter);
 
         forwardSessionEvent(session.sessionId, { type: "session:permission_request", request });
@@ -431,7 +434,7 @@ async function runScript(session: MockSession): Promise<void> {
       result: {
         result: session.lastResultText,
         cost: session.totalCost,
-        tokens: session.totalTokens || session.entries.length,
+        tokens: session.totalTokens > 0 ? session.totalTokens : session.entries.length,
         numTurns: 1,
       },
     });
@@ -562,7 +565,7 @@ async function handlePrompt(args: Record<string, unknown>): Promise<ToolResult> 
           result: {
             result: session.lastResultText ?? "Mock script completed",
             cost: session.totalCost,
-            tokens: session.totalTokens || session.entries.length,
+            tokens: session.totalTokens > 0 ? session.totalTokens : session.entries.length,
             numTurns: 1,
           },
         }),
@@ -752,9 +755,7 @@ function resolvePermission(args: Record<string, unknown>, verdict: "approve" | "
       isError: true,
     };
   }
-  clearTimeout(waiter.timer);
   waiter.resolve(verdict);
-  session.pendingPermissions.delete(requestId);
   return { content: [{ type: "text", text: JSON.stringify({ [`${verdict}d`]: true, requestId }) }] };
 }
 

--- a/packages/daemon/src/mock-session/CLAUDE.md
+++ b/packages/daemon/src/mock-session/CLAUDE.md
@@ -1,0 +1,91 @@
+# Mock Script DSL
+
+The mock provider reads a JSON script file and replays canned events with configurable delays.
+It covers the full `AgentSessionEvent` protocol surface so tests can exercise any provider behavior
+without needing a real agent binary.
+
+## Script format
+
+A script is a JSON array of entries. Each entry is one of:
+
+### Emit entries (discriminated on `emit`)
+
+All emit entries accept an optional `delay` (ms) applied before the emit.
+
+| `emit` | Required fields | Optional fields | Event emitted |
+|---|---|---|---|
+| `init` | | `session_id`, `delay` | `session:init` |
+| `response` | `text` | `delay` | `session:response` |
+| `tool_call` | `name` | `args`, `delay` | `session:response` (formatted as `[tool_call] name(args)`) |
+| `permission_request` | `tool` | `args`, `request_id`, `delay` | `session:permission_request` |
+| `cost` | | `usd`, `tokens_in`, `tokens_out`, `delay` | `db:cost` (accumulates into final result) |
+| `result` | | `text`, `delay` | `session:result` (terminal) |
+| `error` | | `message`, `messages`, `delay` | `session:error` (terminal) |
+| `disconnect` | | `reason`, `delay` | `session:disconnected` (terminal) |
+| `end` | | `delay` | `session:ended` (terminal) |
+
+### Wait entries (discriminated on `wait_for`)
+
+| Field | Type | Description |
+|---|---|---|
+| `wait_for` | `"approve" \| "deny"` | Blocks until the parent calls `mock_approve` or `mock_deny` |
+| `timeout_ms` | `number` | Max wait time (default: 5000ms) |
+
+Place a `wait_for` entry immediately after a `permission_request` to model the approval round-trip.
+
+### Legacy entries
+
+The original `{delay, text}` format still works and emits `session:response`.
+
+## Behavior
+
+- If the script does not start with `{"emit": "init"}`, the worker auto-emits `session:init` before processing.
+- If no terminal entry (`result`, `error`, `disconnect`, `end`) appears, the worker auto-emits `session:result` after the last entry.
+- Cost and token values from `cost` entries accumulate and appear in the final `session:result`.
+- `permission_request` entries register a pending permission waiter. Use `mock_approve` / `mock_deny` tools to resolve them. The `request_id` field lets you target a specific request.
+
+## Examples
+
+### Simple response script
+```json
+[
+  {"emit": "response", "text": "Hello, world!"},
+  {"emit": "result", "text": "done"}
+]
+```
+
+### Permission round-trip
+```json
+[
+  {"emit": "permission_request", "tool": "Write", "args": {"path": "/tmp/x"}, "request_id": "req-1"},
+  {"wait_for": "approve", "timeout_ms": 5000},
+  {"emit": "response", "text": "Write approved, continuing"},
+  {"emit": "result", "text": "done"}
+]
+```
+
+### Error scenario
+```json
+[
+  {"emit": "response", "text": "working..."},
+  {"emit": "error", "message": "out of tokens"}
+]
+```
+
+### Cost tracking
+```json
+[
+  {"emit": "cost", "usd": 0.001, "tokens_in": 100, "tokens_out": 50},
+  {"emit": "response", "text": "processed"},
+  {"emit": "cost", "usd": 0.002, "tokens_in": 200, "tokens_out": 100},
+  {"emit": "result", "text": "done"}
+]
+```
+
+### Legacy format (still supported)
+```json
+[
+  {"delay": 100, "text": "Hello"},
+  {"delay": 0, "text": "Done"}
+]
+```

--- a/packages/daemon/src/mock-session/tools.ts
+++ b/packages/daemon/src/mock-session/tools.ts
@@ -15,7 +15,8 @@ export const MOCK_TOOLS = buildAgentTools({
     prompt: {
       description:
         "Start a mock session with a task (JSON script file path), or send a follow-up prompt to an existing session. " +
-        "The mock reads canned responses from the JSON file and emits them with configurable delays. " +
+        "The mock reads a script of emit entries (response, tool_call, permission_request, cost, error, etc.) " +
+        "and replays them with configurable delays. See mock-session/CLAUDE.md for the DSL reference. " +
         "Returns the session ID immediately by default. Set wait=true to block until the script completes.",
       omitProperties: ["name"],
     },
@@ -41,10 +42,14 @@ export const MOCK_TOOLS = buildAgentTools({
         "If sessionId is provided, waits for that session only. Otherwise waits for any session.",
     },
     approve: {
-      description: "Approve a pending permission request (mock sessions do not generate permission requests).",
+      description:
+        "Approve a pending permission request from a mock session. " +
+        'The script must contain a {"emit": "permission_request"} entry followed by {"wait_for": "approve"}.',
     },
     deny: {
-      description: "Deny a pending permission request (mock sessions do not generate permission requests).",
+      description:
+        "Deny a pending permission request from a mock session. " +
+        'The script must contain a {"emit": "permission_request"} entry followed by {"wait_for": "deny"}.',
     },
   },
 });


### PR DESCRIPTION
## Summary
- Replaced `ScriptEntry` (`{delay, text}`) with a discriminated union covering the full `AgentSessionEvent` protocol surface: `init`, `response`, `tool_call`, `permission_request`, `cost`, `result`, `error`, `disconnect`, `end`, plus `wait_for` entries for permission approval/denial blocking
- Wired `mock_approve`/`mock_deny` tools to resolve pending permission waiters (previously no-ops)
- Added 15 integration tests covering every new entry type, permission round-trips, cost accumulation, mixed legacy+new format, and error cases
- Added authoring docs (`packages/daemon/src/mock-session/CLAUDE.md`) with DSL reference, behavior notes, and examples

## Test plan
- [x] All 37 mock-server.spec.ts tests pass (15 new + 22 existing)
- [x] Legacy `{delay, text}` format still works (backward compatible)
- [x] Permission round-trip: emit → wait_for → approve/deny → resume
- [x] Cost accumulation across multiple `emit: "cost"` entries
- [x] Terminal events (result, error, disconnect, end) stop the script
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun run doing-it-wrong` passes (0 violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)