### PR TITLE
feat(protocol): version negotiation in init handshake + typed mismatch error (fixes #2541)

### DIFF
--- a/docs/agent-protocol.md
+++ b/docs/agent-protocol.md
@@ -1,6 +1,6 @@
 # Agent Protocol Specification
 
-**Version:** 1 (pre-negotiation — `protocol_version` field lands with version negotiation story)
+**Version:** 1
 
 **Status:** Normative. This document is the single source of truth for every message type that crosses the mcpd daemon ↔ agent worker boundary.
 
@@ -60,16 +60,18 @@ Sent once at worker startup. Worker must reply with `ready` (§3.1) or `error` (
 ```typescript
 {
   type: "init";
-  daemonId?: string;   // daemon instance identifier
+  daemonId?: string;            // daemon instance identifier
+  protocol_version?: number;    // version of this protocol the daemon speaks (see §7)
 }
 ```
 
-**Claude-only extensions** (`claude-session-worker.ts:48-56`):
+**Claude-only extensions** (`claude-session-worker.ts:48-57`):
 
 ```typescript
 {
   type: "init";
   daemonId?: string;
+  protocol_version?: number;
   wsPort?: number;       // port hint for WebSocket server
   quiet?: boolean;       // suppress worker-side console logging (tests)
   traceparent?: string;  // W3C Trace Context — worker span becomes child
@@ -81,6 +83,7 @@ Sent once at worker startup. Worker must reply with `ready` (§3.1) or `error` (
 | Field | claude | codex | acp | opencode | mock |
 |---|---|---|---|---|---|
 | `daemonId` | optional | optional | optional | optional | optional |
+| `protocol_version` | optional | optional | optional | optional | optional |
 | `wsPort` | optional | — | — | — | — |
 | `quiet` | optional | — | — | — | — |
 | `traceparent` | optional | — | — | — | — |
@@ -88,7 +91,7 @@ Sent once at worker startup. Worker must reply with `ready` (§3.1) or `error` (
 **Example:**
 
 ```json
-{ "type": "init", "daemonId": "mcpd-a1b2c3", "wsPort": 0, "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01" }
+{ "type": "init", "daemonId": "mcpd-a1b2c3", "protocol_version": 1, "wsPort": 0, "traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01" }
 ```
 
 ### 2.2 `tools_changed`
@@ -180,24 +183,25 @@ Signals the worker is initialized and ready to accept MCP JSON-RPC messages.
 ```typescript
 {
   type: "ready";
-  [key: string]: unknown;  // provider-specific extensions allowed
+  supported_protocol_version?: number;  // version of this protocol the worker speaks (see §7)
+  [key: string]: unknown;               // provider-specific extensions allowed
 }
 ```
 
 **Claude extension:** includes `port: number` — the actual WebSocket server port.
 
-**Semantics:** The daemon awaits `ready` before wiring up the MCP `Client` transport. If `ready` is not received within the startup timeout, the daemon treats it as a spawn failure.
+**Semantics:** The daemon awaits `ready` before wiring up the MCP `Client` transport. If `ready` is not received within the startup timeout, the daemon treats it as a spawn failure. If `supported_protocol_version` is present and does not match `protocol_version` from init, the daemon rejects the worker with a `ProtocolVersionMismatchError`.
 
 **Example (Claude):**
 
 ```json
-{ "type": "ready", "port": 49152 }
+{ "type": "ready", "port": 49152, "supported_protocol_version": 1 }
 ```
 
 **Example (all others):**
 
 ```json
-{ "type": "ready" }
+{ "type": "ready", "supported_protocol_version": 1 }
 ```
 
 ### 3.2 `error`
@@ -582,14 +586,21 @@ If a future version aligns more closely with either protocol (e.g., adopting ACP
 
 ### Scheme
 
-Semver for the protocol version number (`protocol_version` field, added by the version-negotiation story):
+Semver for the protocol version number (`protocol_version` field in `init`, `supported_protocol_version` field in `ready`):
 
 - **Major:** breaking changes (removing fields, renaming message types, changing semantics)
 - **Minor:** additive changes (new optional fields, new message types)
 
 ### Current version
 
-**v1** — documents today's behavior. The `protocol_version` field does not yet exist in messages; it will be added by the version-negotiation story. Until then, absence of the field implies v1.
+**v1** — `AGENT_PROTOCOL_VERSION` is exported from `@mcp-cli/core` and used as the canonical source of truth for both daemon and workers.
+
+### Version negotiation
+
+1. Daemon sends `protocol_version: AGENT_PROTOCOL_VERSION` in the `init` message (§2.1).
+2. Worker echoes `supported_protocol_version: AGENT_PROTOCOL_VERSION` in the `ready` message (§3.1).
+3. If `supported_protocol_version` is present and does not match the daemon's `protocol_version`, the daemon rejects the worker with a `ProtocolVersionMismatchError` containing `{requested, supported, doc_url}`.
+4. If `supported_protocol_version` is absent (pre-negotiation worker), the daemon accepts the worker (backwards-compatible).
 
 ### Back-compat rules
 
@@ -604,7 +615,7 @@ Within a major version:
 
 | Version | Date | Changes |
 |---|---|---|
-| 1 | 2026-05-28 | Initial formal specification of existing protocol. |
+| 1 | 2026-05-28 | Initial formal specification of existing protocol. Version negotiation via `protocol_version`/`supported_protocol_version` fields + `ProtocolVersionMismatchError`. |
 
 ---
 

--- a/docs/agent-protocol.md
+++ b/docs/agent-protocol.md
@@ -61,7 +61,7 @@ Sent once at worker startup. Worker must reply with `ready` (§3.1) or `error` (
 {
   type: "init";
   daemonId?: string;            // daemon instance identifier
-  protocol_version?: number;    // version of this protocol the daemon speaks (see §7)
+  protocol_version?: number;    // version of this protocol the daemon speaks (see §8)
 }
 ```
 
@@ -183,7 +183,7 @@ Signals the worker is initialized and ready to accept MCP JSON-RPC messages.
 ```typescript
 {
   type: "ready";
-  supported_protocol_version?: number;  // version of this protocol the worker speaks (see §7)
+  supported_protocol_version?: number;  // version of this protocol the worker speaks (see §8)
   [key: string]: unknown;               // provider-specific extensions allowed
 }
 ```
@@ -586,21 +586,25 @@ If a future version aligns more closely with either protocol (e.g., adopting ACP
 
 ### Scheme
 
-Semver for the protocol version number (`protocol_version` field in `init`, `supported_protocol_version` field in `ready`):
+The protocol version is an integer. Bump semantics:
 
-- **Major:** breaking changes (removing fields, renaming message types, changing semantics)
-- **Minor:** additive changes (new optional fields, new message types)
+- **Major bump (N → N+1):** breaking changes (removing fields, renaming message types, changing semantics). All workers must be rebuilt before the daemon is upgraded.
+- Within a major version, additive changes (new optional fields, new message types) do not require a version bump.
 
 ### Current version
 
 **v1** — `AGENT_PROTOCOL_VERSION` is exported from `@mcp-cli/core` and used as the canonical source of truth for both daemon and workers.
 
-### Version negotiation
+### Version assertion
+
+This is a hard gate, not a downgrade negotiation. There is no "accept N and N-1" grace window.
 
 1. Daemon sends `protocol_version: AGENT_PROTOCOL_VERSION` in the `init` message (§2.1).
 2. Worker echoes `supported_protocol_version: AGENT_PROTOCOL_VERSION` in the `ready` message (§3.1).
-3. If `supported_protocol_version` is present and does not match the daemon's `protocol_version`, the daemon rejects the worker with a `ProtocolVersionMismatchError` containing `{requested, supported, doc_url}`.
-4. If `supported_protocol_version` is absent (pre-negotiation worker), the daemon accepts the worker (backwards-compatible).
+3. If `supported_protocol_version` is present and does not match the daemon's `protocol_version`, the daemon rejects the worker with a `ProtocolVersionMismatchError` containing `{requested, supported, docUrl}`.
+4. If `supported_protocol_version` is absent (pre-negotiation worker), the daemon accepts the worker (backwards-compatible). A future major version may remove this fallback.
+
+**Upgrade procedure:** rebuild all worker binaries (`bun build`) before bumping `AGENT_PROTOCOL_VERSION` in the daemon. A stale worker binary will be rejected on its first spawn attempt.
 
 ### Back-compat rules
 

--- a/packages/core/src/agent-protocol.spec.ts
+++ b/packages/core/src/agent-protocol.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { AGENT_PROTOCOL_SPEC_URL, AGENT_PROTOCOL_VERSION, ProtocolVersionMismatchError } from "./agent-protocol";
+
+describe("AGENT_PROTOCOL_VERSION", () => {
+  test("is a positive integer", () => {
+    expect(AGENT_PROTOCOL_VERSION).toBeGreaterThan(0);
+    expect(Number.isInteger(AGENT_PROTOCOL_VERSION)).toBe(true);
+  });
+});
+
+describe("ProtocolVersionMismatchError", () => {
+  test("captures requested and supported versions", () => {
+    const err = new ProtocolVersionMismatchError(2, 1);
+    expect(err.requested).toBe(2);
+    expect(err.supported).toBe(1);
+    expect(err.name).toBe("ProtocolVersionMismatchError");
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  test("message references the spec doc URL", () => {
+    const err = new ProtocolVersionMismatchError(2, 1);
+    expect(err.message).toContain(AGENT_PROTOCOL_SPEC_URL);
+    expect(err.message).toContain("v2");
+    expect(err.message).toContain("v1");
+  });
+
+  test("docUrl field matches the constant", () => {
+    const err = new ProtocolVersionMismatchError(3, 1);
+    expect(err.docUrl).toBe(AGENT_PROTOCOL_SPEC_URL);
+  });
+});

--- a/packages/core/src/agent-protocol.ts
+++ b/packages/core/src/agent-protocol.ts
@@ -1,0 +1,19 @@
+export const AGENT_PROTOCOL_VERSION = 1;
+
+export const AGENT_PROTOCOL_SPEC_URL = "docs/agent-protocol.md";
+
+export class ProtocolVersionMismatchError extends Error {
+  readonly requested: number;
+  readonly supported: number;
+  readonly docUrl: string;
+
+  constructor(requested: number, supported: number) {
+    super(
+      `Protocol version mismatch: daemon requested v${requested}, worker supports v${supported}. See ${AGENT_PROTOCOL_SPEC_URL}`,
+    );
+    this.name = "ProtocolVersionMismatchError";
+    this.requested = requested;
+    this.supported = supported;
+    this.docUrl = AGENT_PROTOCOL_SPEC_URL;
+  }
+}

--- a/packages/core/src/agent-protocol.ts
+++ b/packages/core/src/agent-protocol.ts
@@ -1,5 +1,7 @@
 export const AGENT_PROTOCOL_VERSION = 1;
 
+// Repo-relative path — not a URL. Consumers outside this repo should refer to
+// the agent-protocol.md file in the mcp-cli repository.
 export const AGENT_PROTOCOL_SPEC_URL = "docs/agent-protocol.md";
 
 export class ProtocolVersionMismatchError extends Error {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,6 +48,7 @@ export * from "./pr-churn";
 export * from "./monitor-event";
 export * from "./event-filter";
 export * from "./gh-client";
+export * from "./agent-protocol";
 export * from "./errors";
 export * from "./telemetry";
 export * from "./phase-source";

--- a/packages/daemon/src/abstract-worker-server.spec.ts
+++ b/packages/daemon/src/abstract-worker-server.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { silentLogger } from "@mcp-cli/core";
+import { AGENT_PROTOCOL_VERSION, ProtocolVersionMismatchError, silentLogger } from "@mcp-cli/core";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { testOptions } from "../../../test/test-options";
 import {
@@ -365,6 +365,96 @@ describe("AbstractWorkerServer", () => {
       expect(() => {
         internals(s).handleWorkerEvent({ type: "unknown:future:type" } as never);
       }).not.toThrow();
+    });
+  });
+
+  // ── Protocol version negotiation ──
+
+  describe("protocol version negotiation", () => {
+    test("buildInitMessage includes protocol_version", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      server = makeServer(StubWorkerServer, db);
+
+      await server.start();
+
+      const worker = internals(server).worker;
+      expect(worker).not.toBeNull();
+      const postMessage = (worker as unknown as { postMessage: ReturnType<typeof mock> }).postMessage;
+      const initCall = postMessage.mock.calls[0];
+      expect(initCall[0]).toMatchObject({
+        type: "init",
+        protocol_version: AGENT_PROTOCOL_VERSION,
+      });
+    });
+
+    test("accepts ready with matching supported_protocol_version", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      const factory = () => {
+        const w = {
+          postMessage: mock((_msg: unknown) => {
+            queueMicrotask(() => {
+              w.onmessage?.({
+                data: { type: "ready", supported_protocol_version: AGENT_PROTOCOL_VERSION },
+              } as MessageEvent);
+            });
+          }),
+          terminate: mock(() => {}),
+          addEventListener: mock(() => {}),
+          removeEventListener: mock(() => {}),
+          onmessage: null as ((event: MessageEvent) => void) | null,
+          onerror: null as ((event: ErrorEvent | Event) => void) | null,
+        };
+        return w as unknown as Worker;
+      };
+      server = makeServer(StubWorkerServer, db, { workerFactory: factory });
+
+      await expect(server.start()).resolves.toBeDefined();
+    });
+
+    test("accepts ready without supported_protocol_version (backwards-compatible)", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      // Default mockWorkerFactory sends { type: "ready" } with no version — must still work
+      server = makeServer(StubWorkerServer, db);
+
+      await expect(server.start()).resolves.toBeDefined();
+    });
+
+    test("rejects ready with mismatched supported_protocol_version", async () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      const mismatchedVersion = AGENT_PROTOCOL_VERSION + 1;
+      const factory = () => {
+        const w = {
+          postMessage: mock((_msg: unknown) => {
+            queueMicrotask(() => {
+              w.onmessage?.({
+                data: { type: "ready", supported_protocol_version: mismatchedVersion },
+              } as MessageEvent);
+            });
+          }),
+          terminate: mock(() => {}),
+          addEventListener: mock(() => {}),
+          removeEventListener: mock(() => {}),
+          onmessage: null as ((event: MessageEvent) => void) | null,
+          onerror: null as ((event: ErrorEvent | Event) => void) | null,
+        };
+        return w as unknown as Worker;
+      };
+      server = makeServer(StubWorkerServer, db, { workerFactory: factory });
+
+      try {
+        await server.start();
+        expect.unreachable("should have thrown");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ProtocolVersionMismatchError);
+        const pErr = err as ProtocolVersionMismatchError;
+        expect(pErr.requested).toBe(AGENT_PROTOCOL_VERSION);
+        expect(pErr.supported).toBe(mismatchedVersion);
+        expect(pErr.message).toContain("agent-protocol.md");
+      }
     });
   });
 });

--- a/packages/daemon/src/abstract-worker-server.ts
+++ b/packages/daemon/src/abstract-worker-server.ts
@@ -1,12 +1,6 @@
 import { resolve } from "node:path";
 import type { Logger } from "@mcp-cli/core";
-import {
-  AGENT_PROTOCOL_SPEC_URL,
-  AGENT_PROTOCOL_VERSION,
-  ProtocolVersionMismatchError,
-  consoleLogger,
-  resolveRealpath,
-} from "@mcp-cli/core";
+import { AGENT_PROTOCOL_VERSION, ProtocolVersionMismatchError, consoleLogger, resolveRealpath } from "@mcp-cli/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { closeClientWithTimeout } from "./close-timeout";
 import type { StateDb } from "./db/state";
@@ -203,7 +197,8 @@ export abstract class AbstractWorkerServer {
       }, 10_000);
       worker.onmessage = (event: MessageEvent) => {
         if (event.data?.type === "ready") {
-          const supported = event.data.supported_protocol_version as number | undefined;
+          const raw = event.data.supported_protocol_version;
+          const supported = typeof raw === "number" ? raw : undefined;
           if (supported !== undefined && supported !== AGENT_PROTOCOL_VERSION) {
             clearTimeout(timeout);
             cleanup();

--- a/packages/daemon/src/abstract-worker-server.ts
+++ b/packages/daemon/src/abstract-worker-server.ts
@@ -1,6 +1,12 @@
 import { resolve } from "node:path";
 import type { Logger } from "@mcp-cli/core";
-import { consoleLogger, resolveRealpath } from "@mcp-cli/core";
+import {
+  AGENT_PROTOCOL_SPEC_URL,
+  AGENT_PROTOCOL_VERSION,
+  ProtocolVersionMismatchError,
+  consoleLogger,
+  resolveRealpath,
+} from "@mcp-cli/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { closeClientWithTimeout } from "./close-timeout";
 import type { StateDb } from "./db/state";
@@ -197,6 +203,13 @@ export abstract class AbstractWorkerServer {
       }, 10_000);
       worker.onmessage = (event: MessageEvent) => {
         if (event.data?.type === "ready") {
+          const supported = event.data.supported_protocol_version as number | undefined;
+          if (supported !== undefined && supported !== AGENT_PROTOCOL_VERSION) {
+            clearTimeout(timeout);
+            cleanup();
+            reject(new ProtocolVersionMismatchError(AGENT_PROTOCOL_VERSION, supported));
+            return;
+          }
           settled = true;
           clearTimeout(timeout);
           this.onWorkerReady(event.data);
@@ -340,7 +353,7 @@ export abstract class AbstractWorkerServer {
   // ── Protected hooks (override in subclasses) ──
 
   protected buildInitMessage(): Record<string, unknown> {
-    return { type: "init", daemonId: this.daemonId };
+    return { type: "init", daemonId: this.daemonId, protocol_version: AGENT_PROTOCOL_VERSION };
   }
 
   protected onWorkerReady(_data: unknown): void {}

--- a/packages/daemon/src/acp-session-worker.ts
+++ b/packages/daemon/src/acp-session-worker.ts
@@ -14,7 +14,7 @@
  */
 
 import { AcpSession, type AcpSessionConfig } from "@mcp-cli/acp";
-import { ACP_SERVER_NAME, type AgentSessionEvent, DEFAULT_TIMEOUT_MS } from "@mcp-cli/core";
+import { ACP_SERVER_NAME, AGENT_PROTOCOL_VERSION, type AgentSessionEvent, DEFAULT_TIMEOUT_MS } from "@mcp-cli/core";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { ACP_TOOLS } from "./acp-session/tools";
@@ -27,6 +27,7 @@ import { WorkerServerTransport } from "./worker-transport";
 interface InitMessage {
   type: "init";
   daemonId?: string;
+  protocol_version?: number;
 }
 
 interface ToolsChangedMessage {
@@ -519,7 +520,7 @@ self.onmessage = async (event: MessageEvent) => {
   if (isControlMessage(data) && data.type === "init") {
     try {
       await startServer();
-      self.postMessage({ type: "ready" });
+      self.postMessage({ type: "ready", supported_protocol_version: AGENT_PROTOCOL_VERSION });
     } catch (err) {
       mcpServer = null;
       transport = null;

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -15,6 +15,7 @@
  */
 
 import {
+  AGENT_PROTOCOL_VERSION,
   CLAUDE_SERVER_NAME,
   DEFAULT_TIMEOUT_MS,
   type LiveSpan,
@@ -48,6 +49,7 @@ import { WorkerServerTransport } from "./worker-transport";
 interface InitMessage {
   type: "init";
   daemonId?: string;
+  protocol_version?: number;
   wsPort?: number;
   /** Suppress worker-side console logging (used in tests). */
   quiet?: boolean;
@@ -803,7 +805,7 @@ self.onmessage = async (event: MessageEvent) => {
     });
     try {
       const port = await startServer(data.wsPort, data.quiet);
-      self.postMessage({ type: "ready", port });
+      self.postMessage({ type: "ready", port, supported_protocol_version: AGENT_PROTOCOL_VERSION });
     } catch (err) {
       // Clean up partially-initialized resources
       await wsServer

--- a/packages/daemon/src/codex-session-worker.ts
+++ b/packages/daemon/src/codex-session-worker.ts
@@ -19,7 +19,7 @@
  */
 
 import { CodexSession, type CodexSessionConfig } from "@mcp-cli/codex";
-import { type AgentSessionEvent, CODEX_SERVER_NAME, DEFAULT_TIMEOUT_MS } from "@mcp-cli/core";
+import { AGENT_PROTOCOL_VERSION, type AgentSessionEvent, CODEX_SERVER_NAME, DEFAULT_TIMEOUT_MS } from "@mcp-cli/core";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { CODEX_TOOLS } from "./codex-session/tools";
@@ -32,6 +32,7 @@ import { WorkerServerTransport } from "./worker-transport";
 interface InitMessage {
   type: "init";
   daemonId?: string;
+  protocol_version?: number;
 }
 
 interface ToolsChangedMessage {
@@ -529,7 +530,7 @@ self.onmessage = async (event: MessageEvent) => {
   if (isControlMessage(data) && data.type === "init") {
     try {
       await startServer();
-      self.postMessage({ type: "ready" });
+      self.postMessage({ type: "ready", supported_protocol_version: AGENT_PROTOCOL_VERSION });
     } catch (err) {
       mcpServer = null;
       transport = null;

--- a/packages/daemon/src/mock-server.ts
+++ b/packages/daemon/src/mock-server.ts
@@ -11,7 +11,13 @@
  */
 
 import type { JsonSchema, Logger, ToolInfo } from "@mcp-cli/core";
-import { MOCK_SERVER_NAME, consoleLogger, formatToolSignature } from "@mcp-cli/core";
+import {
+  AGENT_PROTOCOL_VERSION,
+  MOCK_SERVER_NAME,
+  ProtocolVersionMismatchError,
+  consoleLogger,
+  formatToolSignature,
+} from "@mcp-cli/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { closeClientWithTimeout } from "./close-timeout";
 import type { StateDb } from "./db/state";
@@ -138,6 +144,13 @@ export class MockServer {
       }, 10_000);
       worker.onmessage = (event: MessageEvent) => {
         if (event.data?.type === "ready") {
+          const raw = event.data.supported_protocol_version;
+          const supported = typeof raw === "number" ? raw : undefined;
+          if (supported !== undefined && supported !== AGENT_PROTOCOL_VERSION) {
+            clearTimeout(timeout);
+            if (cleanup()) reject(new ProtocolVersionMismatchError(AGENT_PROTOCOL_VERSION, supported));
+            return;
+          }
           settled = true;
           clearTimeout(timeout);
           resolve();
@@ -151,7 +164,7 @@ export class MockServer {
         const msg = event instanceof ErrorEvent ? event.message : String(event);
         if (cleanup()) reject(new Error(`Mock session worker error: ${msg}`));
       };
-      worker.postMessage({ type: "init", daemonId: this.daemonId });
+      worker.postMessage({ type: "init", daemonId: this.daemonId, protocol_version: AGENT_PROTOCOL_VERSION });
     });
 
     // Set up MCP transport and connect

--- a/packages/daemon/src/mock-session-worker.ts
+++ b/packages/daemon/src/mock-session-worker.ts
@@ -31,6 +31,7 @@
 
 import { resolve } from "node:path";
 import {
+  AGENT_PROTOCOL_VERSION,
   type AgentPermissionRequest,
   type AgentSessionEvent,
   DEFAULT_TIMEOUT_MS,
@@ -48,6 +49,7 @@ import { WorkerServerTransport } from "./worker-transport";
 interface InitMessage {
   type: "init";
   daemonId?: string;
+  protocol_version?: number;
 }
 
 interface ToolsChangedMessage {
@@ -832,7 +834,7 @@ self.onmessage = async (event: MessageEvent) => {
   if (isControlMessage(data) && data.type === "init") {
     try {
       await startServer();
-      self.postMessage({ type: "ready" });
+      self.postMessage({ type: "ready", supported_protocol_version: AGENT_PROTOCOL_VERSION });
     } catch (err) {
       mcpServer = null;
       transport = null;

--- a/packages/daemon/src/opencode-session-worker.ts
+++ b/packages/daemon/src/opencode-session-worker.ts
@@ -13,7 +13,12 @@
  *   4. Worker sends MCP JSON-RPC responses + DB event messages back
  */
 
-import { type AgentSessionEvent, DEFAULT_TIMEOUT_MS, OPENCODE_SERVER_NAME } from "@mcp-cli/core";
+import {
+  AGENT_PROTOCOL_VERSION,
+  type AgentSessionEvent,
+  DEFAULT_TIMEOUT_MS,
+  OPENCODE_SERVER_NAME,
+} from "@mcp-cli/core";
 import { OpenCodeSession, type OpenCodeSessionConfig } from "@mcp-cli/opencode";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
@@ -27,6 +32,7 @@ import { WorkerServerTransport } from "./worker-transport";
 interface InitMessage {
   type: "init";
   daemonId?: string;
+  protocol_version?: number;
 }
 
 interface ToolsChangedMessage {
@@ -522,7 +528,7 @@ self.onmessage = async (event: MessageEvent) => {
   if (isControlMessage(data) && data.type === "init") {
     try {
       await startServer();
-      self.postMessage({ type: "ready" });
+      self.postMessage({ type: "ready", supported_protocol_version: AGENT_PROTOCOL_VERSION });
     } catch (err) {
       mcpServer = null;
       transport = null;

--- a/packages/daemon/src/site-server.ts
+++ b/packages/daemon/src/site-server.ts
@@ -8,7 +8,13 @@
  */
 
 import type { JsonSchema, Logger, ToolInfo } from "@mcp-cli/core";
-import { SITE_SERVER_NAME, consoleLogger, formatToolSignature } from "@mcp-cli/core";
+import {
+  AGENT_PROTOCOL_VERSION,
+  ProtocolVersionMismatchError,
+  SITE_SERVER_NAME,
+  consoleLogger,
+  formatToolSignature,
+} from "@mcp-cli/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { closeClientWithTimeout } from "./close-timeout";
 import {
@@ -110,6 +116,13 @@ export class SiteServer {
 
       worker.onmessage = (event: MessageEvent) => {
         if (event.data?.type === "ready") {
+          const raw = event.data.supported_protocol_version;
+          const supported = typeof raw === "number" ? raw : undefined;
+          if (supported !== undefined && supported !== AGENT_PROTOCOL_VERSION) {
+            clearTimeout(timeout);
+            if (cleanup()) reject(new ProtocolVersionMismatchError(AGENT_PROTOCOL_VERSION, supported));
+            return;
+          }
           settled = true;
           clearTimeout(timeout);
           resolve();
@@ -123,7 +136,7 @@ export class SiteServer {
         const msg = event instanceof ErrorEvent ? event.message : String(event);
         if (cleanup()) reject(new Error(`Site worker error: ${msg}`));
       };
-      worker.postMessage({ type: "init", daemonId: this.daemonId });
+      worker.postMessage({ type: "init", daemonId: this.daemonId, protocol_version: AGENT_PROTOCOL_VERSION });
     });
 
     try {

--- a/packages/daemon/src/site-worker.ts
+++ b/packages/daemon/src/site-worker.ts
@@ -18,7 +18,7 @@
 import { existsSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
 import { resolve as resolvePath } from "node:path";
-import { SITE_SERVER_NAME } from "@mcp-cli/core";
+import { AGENT_PROTOCOL_VERSION, SITE_SERVER_NAME } from "@mcp-cli/core";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { createBrowserHandlers, toolError as error, toolOk as ok, shouldAutoRestart } from "./site/browser-handlers";
@@ -60,6 +60,7 @@ void shouldAutoRestart; // re-exported above; suppress unused warning
 interface InitMessage {
   type: "init";
   daemonId?: string;
+  protocol_version?: number;
 }
 
 interface ToolsChangedMessage {
@@ -460,7 +461,7 @@ self.onmessage = async (event: MessageEvent): Promise<void> => {
   if (isControlMessage(data) && data.type === "init") {
     try {
       await startServer();
-      self.postMessage({ type: "ready" });
+      self.postMessage({ type: "ready", supported_protocol_version: AGENT_PROTOCOL_VERSION });
     } catch (err) {
       mcpServer = null;
       transport = null;

--- a/scripts/rules/fixtures/protocol-version-spec-sync__clean.fixture.ts
+++ b/scripts/rules/fixtures/protocol-version-spec-sync__clean.fixture.ts
@@ -1,0 +1,9 @@
+/**
+ * @rule protocol-version-spec-sync
+ * @expect 0
+ * @path packages/core/src/agent-protocol.ts
+ *
+ * Version matches the spec — no violation.
+ */
+
+export const AGENT_PROTOCOL_VERSION = 1;

--- a/scripts/rules/fixtures/protocol-version-spec-sync__flagged.fixture.ts
+++ b/scripts/rules/fixtures/protocol-version-spec-sync__flagged.fixture.ts
@@ -1,0 +1,9 @@
+/**
+ * @rule protocol-version-spec-sync
+ * @expect 1
+ * @path packages/core/src/agent-protocol.ts
+ *
+ * Version doesn't match the spec (999 vs 1) — should fire.
+ */
+
+export const AGENT_PROTOCOL_VERSION = 999;

--- a/scripts/rules/protocol-version-spec-sync.rule.ts
+++ b/scripts/rules/protocol-version-spec-sync.rule.ts
@@ -1,0 +1,69 @@
+/**
+ * Rule: protocol-version-spec-sync
+ *
+ * The AGENT_PROTOCOL_VERSION constant in packages/core/src/agent-protocol.ts
+ * and the "Version:" line in docs/agent-protocol.md must agree. If they
+ * diverge, one was bumped without the other — a spec/code mismatch that
+ * defeats the point of having a spec.
+ *
+ * docs/ is outside the file-loader scan roots, so the spec is read from
+ * disk directly rather than via ctx.files/anchors.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { CheckRule } from "./_engine/rule";
+
+const CORE_REL_PATH = "packages/core/src/agent-protocol.ts";
+const SPEC_REL_PATH = "docs/agent-protocol.md";
+
+const VERSION_CONST = /\bAGENT_PROTOCOL_VERSION\s*=\s*(\d+)/;
+const SPEC_VERSION = /^\*\*Version:\*\*\s*(\d+)/m;
+
+const rule: CheckRule = {
+  id: "protocol-version-spec-sync",
+  kind: "check",
+  scold: "AGENT_PROTOCOL_VERSION and docs/agent-protocol.md version line are out of sync",
+  guidance: [
+    "The version number in AGENT_PROTOCOL_VERSION (packages/core/src/agent-protocol.ts)",
+    "must match the **Version:** line in docs/agent-protocol.md.",
+    "When bumping the protocol version, update both files and add a changelog entry.",
+  ],
+  documentation: "docs/agent-protocol.md §8 Versioning",
+
+  check(ctx) {
+    if (ctx.file.relPath !== CORE_REL_PATH) return;
+    ctx.checked();
+
+    const coreMatch = VERSION_CONST.exec(ctx.file.content);
+    if (!coreMatch) {
+      ctx.violated(1, 1, "AGENT_PROTOCOL_VERSION constant not found in agent-protocol.ts");
+      return;
+    }
+
+    const repoRoot = resolve(ctx.file.path, "../../../..");
+    let specContent: string;
+    try {
+      specContent = readFileSync(resolve(repoRoot, SPEC_REL_PATH), "utf8");
+    } catch {
+      ctx.violated(1, 1, `${SPEC_REL_PATH} not found on disk — cannot verify version sync`);
+      return;
+    }
+
+    const specMatch = SPEC_VERSION.exec(specContent);
+    if (!specMatch) {
+      ctx.violated(1, 1, "**Version:** line not found in docs/agent-protocol.md");
+      return;
+    }
+
+    const codeVersion = coreMatch[1];
+    const specVersion = specMatch[1];
+
+    if (codeVersion !== specVersion) {
+      const line = ctx.file.content.substring(0, coreMatch.index).split("\n").length;
+      ctx.violated(line, 1, `AGENT_PROTOCOL_VERSION = ${codeVersion} but spec says Version: ${specVersion}`);
+    }
+  },
+};
+
+export default rule;

--- a/scripts/rules/protocol-version-spec-sync.rule.ts
+++ b/scripts/rules/protocol-version-spec-sync.rule.ts
@@ -23,6 +23,7 @@ const SPEC_VERSION = /^\*\*Version:\*\*\s*(\d+)/m;
 const rule: CheckRule = {
   id: "protocol-version-spec-sync",
   kind: "check",
+  anchors: [CORE_REL_PATH],
   scold: "AGENT_PROTOCOL_VERSION and docs/agent-protocol.md version line are out of sync",
   guidance: [
     "The version number in AGENT_PROTOCOL_VERSION (packages/core/src/agent-protocol.ts)",


### PR DESCRIPTION
## Summary
- Add `AGENT_PROTOCOL_VERSION` constant and `ProtocolVersionMismatchError` typed error in `@mcp-cli/core`
- Daemon sends `protocol_version` in init message; all 5 workers (claude, codex, acp, opencode, mock) echo `supported_protocol_version` in ready
- On mismatch, daemon rejects with `ProtocolVersionMismatchError` containing `{requested, supported, doc_url}` — observable in daemon log and surfaced to IPC client
- Backwards-compatible: workers that omit `supported_protocol_version` are accepted (pre-negotiation workers)
- `protocol-version-spec-sync` architectural rule enforces that `AGENT_PROTOCOL_VERSION` and the spec `**Version:**` line stay in sync
- Spec (`docs/agent-protocol.md`) updated: §2.1 init, §3.1 ready, §8 Versioning

## Test plan
- [x] Unit tests for `ProtocolVersionMismatchError` (captures versions, references spec URL)
- [x] `buildInitMessage` includes `protocol_version` field
- [x] Matching `supported_protocol_version` accepted
- [x] Missing `supported_protocol_version` accepted (backwards-compat)
- [x] Mismatched `supported_protocol_version` rejected with `ProtocolVersionMismatchError`
- [x] `protocol-version-spec-sync` rule passes (versions in sync)
- [x] `bun typecheck` clean
- [x] `bun lint` clean
- [x] `bun run doing-it-wrong` clean
- [x] All 18 new+existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)