### PR TITLE
feat(protocol): NDJSON recording of daemon↔worker protocol exchange (fixes #2542)

### DIFF
--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -542,16 +542,22 @@ running without MCX_RECORD_SESSION, this command will stop it first.`);
     return;
   }
 
-  const { flags, positionals, errors } = parseFlags(args, {
-    save: { type: "string", alias: "s" },
-  });
-
-  if (errors.length > 0) {
-    d.printError(errors[0]);
-    d.exit(1);
+  // Extract --save/-s and pass everything else through to spawn.
+  // Don't use parseFlags here — it rejects unknown flags, but record
+  // accepts all spawn flags (--task, --model, --cwd, --allow, etc.).
+  let savePath: string | undefined;
+  const spawnArgs: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const tok = args[i];
+    if ((tok === "--save" || tok === "-s") && i + 1 < args.length) {
+      // dotw-ignore no-manual-arg-parsing: pass-through command — parseFlags rejects the unknown spawn flags we must forward
+      savePath = args[++i]; // dotw-ignore args-bounds: guarded by i + 1 < args.length above
+    } else if (tok.startsWith("--save=")) {
+      savePath = tok.slice("--save=".length);
+    } else {
+      spawnArgs.push(tok);
+    }
   }
-
-  let savePath = flags.save as string | undefined;
   if (!savePath) {
     const ts = new Date().toISOString().replace(/[:.]/g, "-");
     savePath = join(options.RECORDINGS_DIR, `${ts}.ndjson`);
@@ -570,8 +576,7 @@ running without MCX_RECORD_SESSION, this command will stop it first.`);
     // No daemon running — proceed
   }
 
-  // Forward remaining args to spawn, inject --wait for full capture
-  const spawnArgs = [...positionals];
+  // Inject --wait for full capture
   if (!spawnArgs.includes("--wait")) {
     spawnArgs.push("--wait");
   }

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -37,6 +37,7 @@ import {
   getProvider,
   hasWorktreeHooks,
   listMcxWorktrees,
+  options,
   pruneWorktrees,
   readWorktreeConfig,
   resolveWorktreePath,
@@ -297,9 +298,12 @@ export async function cmdAgent(args: string[], deps?: Partial<AgentDeps>): Promi
     case "status":
       await agentStatus(subArgs, provider, d);
       break;
+    case "record":
+      await agentRecord(subArgs, provider, agentOverride, d);
+      break;
     default:
       d.printError(
-        `Unknown ${providerName} subcommand: ${sub}. Use "spawn", "ls", "send", "bye", "interrupt", "log", "wait", "resume", "approve", "deny", "worktrees", or "status".`,
+        `Unknown ${providerName} subcommand: ${sub}. Use "spawn", "ls", "send", "bye", "interrupt", "log", "wait", "resume", "approve", "deny", "worktrees", "record", or "status".`,
       );
       d.exit(1);
   }
@@ -507,6 +511,74 @@ async function agentSpawn(
     d.logError(`${label} session started: ${parsed_data.sessionId.slice(0, 8)}`);
   }
   d.log(text);
+}
+
+// ── Record ──
+
+const RECORD_PING_TIMEOUT_MS = 2_000;
+const RECORD_SHUTDOWN_TIMEOUT_MS = 5_000;
+const RECORD_SHUTDOWN_SETTLE_MS = 500;
+
+async function agentRecord(
+  args: string[],
+  provider: AgentProvider,
+  agentOverride: string | undefined,
+  d: AgentDeps,
+): Promise<void> {
+  if (hasHelpFlag(args)) {
+    d.log(`mcx agent ${provider.name} record — Spawn a session with NDJSON protocol recording
+
+Usage:
+  mcx agent ${provider.name} record --task "..." [--save <path>]
+
+Options:
+  --save <path>    Output file path (default: ~/.mcp-cli/recordings/<timestamp>.ndjson)
+  --task, -t       Prompt / task for the session (required)
+
+All other spawn flags (--model, --cwd, --allow, etc.) are accepted.
+
+The daemon must be (re)started with recording enabled. If an existing daemon is
+running without MCX_RECORD_SESSION, this command will stop it first.`);
+    return;
+  }
+
+  const { flags, positionals, errors } = parseFlags(args, {
+    save: { type: "string", alias: "s" },
+  });
+
+  if (errors.length > 0) {
+    d.printError(errors[0]);
+    d.exit(1);
+  }
+
+  let savePath = flags.save as string | undefined;
+  if (!savePath) {
+    const ts = new Date().toISOString().replace(/[:.]/g, "-");
+    savePath = join(options.RECORDINGS_DIR, `${ts}.ndjson`);
+  }
+
+  // Ensure daemon is running with MCX_RECORD_SESSION set
+  process.env.MCX_RECORD_SESSION = savePath;
+
+  // Stop existing daemon if it's running (it won't have the env var)
+  try {
+    await ipcCall("ping", undefined, { timeoutMs: RECORD_PING_TIMEOUT_MS });
+    d.logError("Stopping existing daemon to enable recording...");
+    await ipcCall("shutdown", undefined, { timeoutMs: RECORD_SHUTDOWN_TIMEOUT_MS });
+    await Bun.sleep(RECORD_SHUTDOWN_SETTLE_MS);
+  } catch {
+    // No daemon running — proceed
+  }
+
+  // Forward remaining args to spawn, inject --wait for full capture
+  const spawnArgs = [...positionals];
+  if (!spawnArgs.includes("--wait")) {
+    spawnArgs.push("--wait");
+  }
+
+  d.logError(`Recording to: ${savePath}`);
+  await agentSpawn(spawnArgs, provider, agentOverride, d);
+  d.logError(`Recording saved: ${savePath}`);
 }
 
 /** Shell-quote a string (wrap in single quotes, escape internal single quotes). */
@@ -1797,6 +1869,7 @@ Usage:
   mcx agent ${name} deny <session> [req-id]     Deny pending permission request
   mcx agent ${name} worktrees [--prune]          List mcx-created worktrees
   mcx agent ${name} status <target> [--json]     One-shot session inspector
+  mcx agent ${name} record --task "..." [--save] Record NDJSON protocol trace
 
 Run "mcx agent ${name} spawn --help" for spawn options.`);
 }

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -130,6 +130,8 @@ const _originalOptions = {
   SPRINT_STATE_PATH: join(MCP_CLI_DIR, "sprint-state.json"),
   /** Directory for site configs, catalogs, and browser profiles */
   SITES_DIR: join(MCP_CLI_DIR, "sites"),
+  /** Directory for NDJSON protocol recordings (`MCX_RECORD_SESSION`) */
+  RECORDINGS_DIR: join(MCP_CLI_DIR, "recordings"),
   /** Directory for patched copies of the user's claude binary (see issue #1808) */
   CLAUDE_PATCHED_DIR: join(MCP_CLI_DIR, "claude-patched"),
   /** Directory for self-signed TLS material used by the local WSS listener (see issue #1808) */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -57,6 +57,7 @@ export * from "./bun-version";
 export * from "./sprint-plan";
 export * from "./claude-patch";
 export * from "./automation";
+export * from "./recording";
 export * from "./subprocess";
 export * from "./mcp-result";
 export * from "./lookup-result";

--- a/packages/core/src/recording.spec.ts
+++ b/packages/core/src/recording.spec.ts
@@ -1,0 +1,195 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { NdjsonRecorder, type RecordingEntry, classifyMessageKind } from "./recording";
+
+describe("classifyMessageKind", () => {
+  test("jsonrpc field → mcp", () => {
+    expect(classifyMessageKind({ jsonrpc: "2.0", id: 1, method: "tools/call" })).toBe("mcp");
+  });
+
+  test("jsonrpc notification → mcp", () => {
+    expect(classifyMessageKind({ jsonrpc: "2.0", method: "notifications/tools/list_changed" })).toBe("mcp");
+  });
+
+  test("type: init → control", () => {
+    expect(classifyMessageKind({ type: "init", daemonId: "test" })).toBe("control");
+  });
+
+  test("type: ready → control", () => {
+    expect(classifyMessageKind({ type: "ready" })).toBe("control");
+  });
+
+  test("type: error → control", () => {
+    expect(classifyMessageKind({ type: "error", message: "failed" })).toBe("control");
+  });
+
+  test("type: tools_changed → control", () => {
+    expect(classifyMessageKind({ type: "tools_changed" })).toBe("control");
+  });
+
+  test("type: restore_sessions → control", () => {
+    expect(classifyMessageKind({ type: "restore_sessions", sessions: [] })).toBe("control");
+  });
+
+  test("type: work_item_event → control", () => {
+    expect(classifyMessageKind({ type: "work_item_event", event: {} })).toBe("control");
+  });
+
+  test("type: db:upsert → db", () => {
+    expect(classifyMessageKind({ type: "db:upsert", session: { sessionId: "x" } })).toBe("db");
+  });
+
+  test("type: db:state → db", () => {
+    expect(classifyMessageKind({ type: "db:state", sessionId: "x", state: "idle" })).toBe("db");
+  });
+
+  test("type: db:cost → db", () => {
+    expect(classifyMessageKind({ type: "db:cost", sessionId: "x", cost: 0.1, tokens: 100 })).toBe("db");
+  });
+
+  test("type: db:disconnected → db", () => {
+    expect(classifyMessageKind({ type: "db:disconnected", sessionId: "x", reason: "exit" })).toBe("db");
+  });
+
+  test("type: db:end → db", () => {
+    expect(classifyMessageKind({ type: "db:end", sessionId: "x" })).toBe("db");
+  });
+
+  test("type: metrics:inc → db", () => {
+    expect(classifyMessageKind({ type: "metrics:inc", name: "counter" })).toBe("db");
+  });
+
+  test("type: metrics:observe → db", () => {
+    expect(classifyMessageKind({ type: "metrics:observe", name: "hist", value: 1.5 })).toBe("db");
+  });
+
+  test("type: monitor:event → db", () => {
+    expect(classifyMessageKind({ type: "monitor:event", input: {} })).toBe("db");
+  });
+
+  test("null → mcp (fallback)", () => {
+    expect(classifyMessageKind(null)).toBe("mcp");
+  });
+
+  test("non-object → mcp (fallback)", () => {
+    expect(classifyMessageKind("hello")).toBe("mcp");
+  });
+});
+
+describe("NdjsonRecorder", () => {
+  const dir = join(tmpdir(), `recording-test-${process.pid}`);
+  const paths: string[] = [];
+
+  afterEach(async () => {
+    for (const p of paths) {
+      rmSync(p, { force: true });
+    }
+    paths.length = 0;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function recPath(name: string): string {
+    const p = join(dir, `${name}.ndjson`);
+    paths.push(p);
+    return p;
+  }
+
+  test("writes NDJSON entries with correct format", async () => {
+    const path = recPath("basic");
+    const rec = new NdjsonRecorder(path);
+
+    rec.record("daemon->worker", "control", { type: "init", daemonId: "test" });
+    rec.record("worker->daemon", "control", { type: "ready" });
+    rec.record("daemon->worker", "mcp", { jsonrpc: "2.0", id: 1, method: "tools/list" });
+    rec.record("worker->daemon", "db", { type: "db:state", sessionId: "s1", state: "idle" });
+    await rec.close();
+
+    const lines = readFileSync(path, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(4);
+
+    const entries = lines.map((l) => JSON.parse(l) as RecordingEntry);
+
+    expect(entries[0].dir).toBe("daemon->worker");
+    expect(entries[0].kind).toBe("control");
+    expect(entries[0].payload).toEqual({ type: "init", daemonId: "test" });
+    expect(typeof entries[0].t).toBe("number");
+    expect(entries[0].t).toBeGreaterThan(0);
+
+    expect(entries[1].dir).toBe("worker->daemon");
+    expect(entries[1].kind).toBe("control");
+
+    expect(entries[2].dir).toBe("daemon->worker");
+    expect(entries[2].kind).toBe("mcp");
+
+    expect(entries[3].dir).toBe("worker->daemon");
+    expect(entries[3].kind).toBe("db");
+  });
+
+  test("recordMessage auto-classifies kind", async () => {
+    const path = recPath("auto");
+    const rec = new NdjsonRecorder(path);
+
+    rec.recordMessage("daemon->worker", { type: "init" });
+    rec.recordMessage("worker->daemon", { type: "db:cost", sessionId: "x", cost: 0, tokens: 0 });
+    rec.recordMessage("daemon->worker", { jsonrpc: "2.0", id: 1, method: "tools/call" });
+    await rec.close();
+
+    const lines = readFileSync(path, "utf-8").trim().split("\n");
+    const entries = lines.map((l) => JSON.parse(l) as RecordingEntry);
+
+    expect(entries[0].kind).toBe("control");
+    expect(entries[1].kind).toBe("db");
+    expect(entries[2].kind).toBe("mcp");
+  });
+
+  test("close() is idempotent", async () => {
+    const path = recPath("idempotent");
+    const rec = new NdjsonRecorder(path);
+    rec.record("daemon->worker", "control", { type: "init" });
+    await rec.close();
+    await rec.close();
+
+    const lines = readFileSync(path, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+  });
+
+  test("writes after close are silently dropped", async () => {
+    const path = recPath("closed");
+    const rec = new NdjsonRecorder(path);
+    rec.record("daemon->worker", "control", { type: "init" });
+    await rec.close();
+    rec.record("daemon->worker", "control", { type: "tools_changed" });
+
+    const lines = readFileSync(path, "utf-8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+  });
+
+  test("timestamps are monotonically increasing", async () => {
+    const path = recPath("monotonic");
+    const rec = new NdjsonRecorder(path);
+
+    for (let i = 0; i < 10; i++) {
+      rec.record("daemon->worker", "mcp", { jsonrpc: "2.0", id: i, method: "ping" });
+    }
+    await rec.close();
+
+    const lines = readFileSync(path, "utf-8").trim().split("\n");
+    const timestamps = lines.map((l) => (JSON.parse(l) as RecordingEntry).t);
+    for (let i = 1; i < timestamps.length; i++) {
+      expect(timestamps[i]).toBeGreaterThanOrEqual(timestamps[i - 1]);
+    }
+  });
+
+  test("creates parent directories", async () => {
+    const path = join(dir, "nested", "deep", "recording.ndjson");
+    paths.push(path);
+    const rec = new NdjsonRecorder(path);
+    rec.record("daemon->worker", "control", { type: "init" });
+    await rec.close();
+
+    const content = readFileSync(path, "utf-8").trim();
+    expect(content).not.toBe("");
+  });
+});

--- a/packages/core/src/recording.ts
+++ b/packages/core/src/recording.ts
@@ -1,0 +1,80 @@
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+
+/**
+ * Message direction on the daemon↔worker boundary.
+ */
+export type RecordingDirection = "daemon->worker" | "worker->daemon";
+
+/**
+ * Message kind — aligned with docs/agent-protocol.md §2-5:
+ *   control = §2 (daemon→worker) + §3 (worker→daemon init handshake)
+ *   db      = §4 (worker→daemon DB/metrics/monitor events)
+ *   mcp     = §5 (bidirectional JSON-RPC 2.0)
+ */
+export type RecordingKind = "control" | "db" | "mcp";
+
+export interface RecordingEntry {
+  t: number;
+  dir: RecordingDirection;
+  kind: RecordingKind;
+  payload: unknown;
+}
+
+/**
+ * Classify a postMessage payload into its protocol kind.
+ * Uses the same discrimination rules as the spec §1:
+ *   - `jsonrpc` field present → mcp
+ *   - `type` field starting with "db:" or "metrics:" or "monitor:" → db
+ *   - `type` field present (all other) → control
+ */
+export function classifyMessageKind(payload: unknown): RecordingKind {
+  if (typeof payload !== "object" || payload === null) return "mcp";
+  const obj = payload as Record<string, unknown>;
+  if ("jsonrpc" in obj) return "mcp";
+  if ("type" in obj && typeof obj.type === "string") {
+    const t = obj.type;
+    if (t.startsWith("db:") || t.startsWith("metrics:") || t === "monitor:event") return "db";
+    return "control";
+  }
+  return "mcp";
+}
+
+/**
+ * Append-only NDJSON recorder for the daemon↔worker protocol exchange.
+ *
+ * Zero overhead when not instantiated. Writes are fire-and-forget
+ * (buffered by the OS / Bun's writer). The caller is responsible for
+ * calling close() when the session ends.
+ */
+export class NdjsonRecorder {
+  private writer: ReturnType<ReturnType<typeof Bun.file>["writer"]> | null = null;
+  private closed = false;
+
+  constructor(private readonly path: string) {
+    mkdirSync(dirname(path), { recursive: true });
+    this.writer = Bun.file(path).writer();
+  }
+
+  record(dir: RecordingDirection, kind: RecordingKind, payload: unknown): void {
+    if (this.closed || !this.writer) return;
+    const entry: RecordingEntry = {
+      t: performance.timeOrigin + performance.now(),
+      dir,
+      kind,
+      payload,
+    };
+    this.writer.write(`${JSON.stringify(entry)}\n`);
+  }
+
+  recordMessage(dir: RecordingDirection, payload: unknown): void {
+    this.record(dir, classifyMessageKind(payload), payload);
+  }
+
+  async close(): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    await this.writer?.end();
+    this.writer = null;
+  }
+}

--- a/packages/core/src/recording.ts
+++ b/packages/core/src/recording.ts
@@ -25,7 +25,7 @@ export interface RecordingEntry {
  * Classify a postMessage payload into its protocol kind.
  * Uses the same discrimination rules as the spec §1:
  *   - `jsonrpc` field present → mcp
- *   - `type` field starting with "db:" or "metrics:" or "monitor:" → db
+ *   - `type` field starting with "db:" or "metrics:" or exact "monitor:event" → db
  *   - `type` field present (all other) → control
  */
 export function classifyMessageKind(payload: unknown): RecordingKind {
@@ -46,6 +46,10 @@ export function classifyMessageKind(payload: unknown): RecordingKind {
  * Zero overhead when not instantiated. Writes are fire-and-forget
  * (buffered by the OS / Bun's writer). The caller is responsible for
  * calling close() when the session ends.
+ *
+ * record() and recordMessage() never throw — a serialization or I/O
+ * failure is silently swallowed so recording can never disrupt the
+ * protocol path.
  */
 export class NdjsonRecorder {
   private writer: ReturnType<ReturnType<typeof Bun.file>["writer"]> | null = null;
@@ -58,13 +62,17 @@ export class NdjsonRecorder {
 
   record(dir: RecordingDirection, kind: RecordingKind, payload: unknown): void {
     if (this.closed || !this.writer) return;
-    const entry: RecordingEntry = {
-      t: performance.timeOrigin + performance.now(),
-      dir,
-      kind,
-      payload,
-    };
-    this.writer.write(`${JSON.stringify(entry)}\n`);
+    try {
+      const entry: RecordingEntry = {
+        t: performance.timeOrigin + performance.now(),
+        dir,
+        kind,
+        payload,
+      };
+      this.writer.write(`${JSON.stringify(entry)}\n`);
+    } catch {
+      // Recording must never disrupt the protocol path.
+    }
   }
 
   recordMessage(dir: RecordingDirection, payload: unknown): void {
@@ -74,7 +82,11 @@ export class NdjsonRecorder {
   async close(): Promise<void> {
     if (this.closed) return;
     this.closed = true;
-    await this.writer?.end();
+    try {
+      await this.writer?.end();
+    } catch {
+      // Best-effort flush.
+    }
     this.writer = null;
   }
 }

--- a/packages/daemon/src/abstract-worker-server.ts
+++ b/packages/daemon/src/abstract-worker-server.ts
@@ -1,6 +1,12 @@
 import { resolve } from "node:path";
 import type { Logger } from "@mcp-cli/core";
-import { AGENT_PROTOCOL_VERSION, ProtocolVersionMismatchError, consoleLogger, resolveRealpath } from "@mcp-cli/core";
+import {
+  AGENT_PROTOCOL_VERSION,
+  NdjsonRecorder,
+  ProtocolVersionMismatchError,
+  consoleLogger,
+  resolveRealpath,
+} from "@mcp-cli/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { closeClientWithTimeout } from "./close-timeout";
 import type { StateDb } from "./db/state";
@@ -146,6 +152,8 @@ export abstract class AbstractWorkerServer {
   protected readonly restartPolicy: RestartPolicy = DEFAULT_RESTART_POLICY;
   protected readonly handshakeTimeoutMs: number;
   protected static readonly NO_PID_SESSION_TTL_MS = 10 * 60 * 1000;
+  protected recorder: NdjsonRecorder | null = null;
+  recordingPath: string | null = null;
 
   onRestarted?: (client: Client, transport: WorkerClientTransport) => void;
   onActivity?: () => void;
@@ -179,6 +187,10 @@ export abstract class AbstractWorkerServer {
     const worker = this.workerFactory(workerPath(d.workerScript));
     this.worker = worker;
 
+    if (this.recordingPath) {
+      this.recorder = new NdjsonRecorder(this.recordingPath);
+    }
+
     await new Promise<void>((resolve, reject) => {
       let settled = false;
       const cleanup = () => {
@@ -207,9 +219,11 @@ export abstract class AbstractWorkerServer {
           }
           settled = true;
           clearTimeout(timeout);
+          this.recorder?.record("worker->daemon", "control", event.data);
           this.onWorkerReady(event.data);
           resolve();
         } else if (event.data?.type === "error") {
+          this.recorder?.record("worker->daemon", "control", event.data);
           clearTimeout(timeout);
           cleanup();
           reject(new Error(`${d.displayName} session worker init failed: ${event.data.message}`));
@@ -220,7 +234,9 @@ export abstract class AbstractWorkerServer {
         const msg = event instanceof ErrorEvent ? event.message : String(event);
         if (cleanup()) reject(new Error(`${d.displayName} session worker error: ${msg}`));
       };
-      worker.postMessage(this.buildInitMessage());
+      const initMsg = this.buildInitMessage();
+      this.recorder?.record("daemon->worker", "control", initMsg);
+      worker.postMessage(initMsg);
     });
 
     try {
@@ -247,6 +263,7 @@ export abstract class AbstractWorkerServer {
       const transportHandler = worker.onmessage;
       worker.onmessage = (event: MessageEvent) => {
         const data = event.data;
+        this.recorder?.recordMessage("worker->daemon", data);
         if (isBaseWorkerEvent(data)) {
           this.handleWorkerEvent(data);
           return;
@@ -257,6 +274,15 @@ export abstract class AbstractWorkerServer {
         }
         transportHandler?.call(worker, event);
       };
+
+      if (this.recorder) {
+        const origSend = this.transport.send.bind(this.transport);
+        const recorder = this.recorder;
+        this.transport.send = (msg, opts) => {
+          recorder.recordMessage("daemon->worker", msg);
+          return origSend(msg, opts);
+        };
+      }
 
       worker.onerror = null;
       this.attachCrashDetection(worker);
@@ -304,6 +330,8 @@ export abstract class AbstractWorkerServer {
   async stop(): Promise<void> {
     this.stopped = true;
     this.onRestarted = undefined;
+    await this.recorder?.close();
+    this.recorder = null;
     await closeClientWithTimeout(this.client);
     if (this.worker) {
       this.cleanupWorkerHandlers(this.worker);
@@ -349,6 +377,11 @@ export abstract class AbstractWorkerServer {
 
   protected buildInitMessage(): Record<string, unknown> {
     return { type: "init", daemonId: this.daemonId, protocol_version: AGENT_PROTOCOL_VERSION };
+  }
+
+  protected sendControlMessage(msg: Record<string, unknown>): void {
+    this.recorder?.record("daemon->worker", "control", msg);
+    this.worker?.postMessage(msg);
   }
 
   protected onWorkerReady(_data: unknown): void {}
@@ -480,7 +513,7 @@ export abstract class AbstractWorkerServer {
           }
           this.metrics.gauge(d.metrics.activeSessions).set(this.activeSessions.size);
 
-          (this.worker as Worker | null)?.postMessage({ type: "tools_changed" });
+          this.sendControlMessage({ type: "tools_changed" });
           this.onRestarted?.(client, transport);
           return;
         } catch (err) {

--- a/packages/daemon/src/abstract-worker-server.ts
+++ b/packages/daemon/src/abstract-worker-server.ts
@@ -1,16 +1,11 @@
 import { resolve } from "node:path";
-import type { Logger } from "@mcp-cli/core";
-import {
-  AGENT_PROTOCOL_VERSION,
-  NdjsonRecorder,
-  ProtocolVersionMismatchError,
-  consoleLogger,
-  resolveRealpath,
-} from "@mcp-cli/core";
+import type { Logger, NdjsonRecorder } from "@mcp-cli/core";
+import { AGENT_PROTOCOL_VERSION, ProtocolVersionMismatchError, consoleLogger, resolveRealpath } from "@mcp-cli/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { closeClientWithTimeout } from "./close-timeout";
 import type { StateDb } from "./db/state";
 import { type MetricsCollector, metrics as defaultMetrics } from "./metrics";
+import { setupRecording } from "./recording-hooks";
 import {
   DEFAULT_RESTART_POLICY,
   type RestartPolicy,
@@ -152,8 +147,7 @@ export abstract class AbstractWorkerServer {
   protected readonly restartPolicy: RestartPolicy = DEFAULT_RESTART_POLICY;
   protected readonly handshakeTimeoutMs: number;
   protected static readonly NO_PID_SESSION_TTL_MS = 10 * 60 * 1000;
-  protected recorder: NdjsonRecorder | null = null;
-  recordingPath: string | null = null;
+  recorder: NdjsonRecorder | null = null;
 
   onRestarted?: (client: Client, transport: WorkerClientTransport) => void;
   onActivity?: () => void;
@@ -186,10 +180,6 @@ export abstract class AbstractWorkerServer {
     this.metrics.gauge(d.metrics.crashLoopStopped).set(0);
     const worker = this.workerFactory(workerPath(d.workerScript));
     this.worker = worker;
-
-    if (this.recordingPath) {
-      this.recorder = new NdjsonRecorder(this.recordingPath);
-    }
 
     await new Promise<void>((resolve, reject) => {
       let settled = false;
@@ -243,6 +233,14 @@ export abstract class AbstractWorkerServer {
       this.transport = new WorkerClientTransport(this.worker);
       this.client = this.clientFactory();
 
+      // Install recording hooks BEFORE connect so the MCP initialize
+      // handshake is captured in both directions.
+      let rawHandler: (() => ((this: Worker, event: MessageEvent) => void) | null) | undefined;
+      if (this.recorder) {
+        const hooks = setupRecording(worker, this.transport, this.recorder);
+        rawHandler = hooks.rawTransportHandler;
+      }
+
       let handshakeTimer: ReturnType<typeof setTimeout> | undefined;
       let connectResolved = false;
       await Promise.race([
@@ -260,7 +258,10 @@ export abstract class AbstractWorkerServer {
       ]);
       clearTimeout(handshakeTimer);
 
-      const transportHandler = worker.onmessage;
+      // Post-connect: replaces the setupRecording handshake wrapper.
+      // Record ALL inbound messages here (the handshake wrapper only
+      // lived during connect and is now gone — no double-record).
+      const transportFwd = rawHandler?.() ?? worker.onmessage;
       worker.onmessage = (event: MessageEvent) => {
         const data = event.data;
         this.recorder?.recordMessage("worker->daemon", data);
@@ -272,17 +273,8 @@ export abstract class AbstractWorkerServer {
           this.handleProviderEvent(data);
           return;
         }
-        transportHandler?.call(worker, event);
+        (transportFwd as ((this: Worker, event: MessageEvent) => void) | null)?.call(worker, event);
       };
-
-      if (this.recorder) {
-        const origSend = this.transport.send.bind(this.transport);
-        const recorder = this.recorder;
-        this.transport.send = (msg, opts) => {
-          recorder.recordMessage("daemon->worker", msg);
-          return origSend(msg, opts);
-        };
-      }
 
       worker.onerror = null;
       this.attachCrashDetection(worker);
@@ -330,8 +322,6 @@ export abstract class AbstractWorkerServer {
   async stop(): Promise<void> {
     this.stopped = true;
     this.onRestarted = undefined;
-    await this.recorder?.close();
-    this.recorder = null;
     await closeClientWithTimeout(this.client);
     if (this.worker) {
       this.cleanupWorkerHandlers(this.worker);

--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -143,7 +143,7 @@ export class ClaudeServer extends AbstractWorkerServer {
       if ("cascadeHead" in event) input.cascadeHead = event.cascadeHead;
       this.onMonitorEvent(input);
     }
-    this.worker?.postMessage({ type: "work_item_event", event });
+    this.sendControlMessage({ type: "work_item_event", event });
   }
 
   // ── PID-aware session pruning ──
@@ -360,7 +360,7 @@ export class ClaudeServer extends AbstractWorkerServer {
     }
     this.metrics.gauge("mcpd_active_sessions").set(this.activeSessions.size);
 
-    this.worker?.postMessage({
+    this.sendControlMessage({
       type: "restore_sessions",
       sessions: restorable.map((row) => ({
         sessionId: row.sessionId,

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -557,6 +557,17 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
   // Mock server: always available (no external binary needed)
   const mockServer = new MockServer(db, daemonId, undefined, logger);
 
+  // NDJSON protocol recording — enabled by MCX_RECORD_SESSION env var
+  const recordingPath = process.env.MCX_RECORD_SESSION || null;
+  if (recordingPath) {
+    claudeServer.recordingPath = recordingPath;
+    if (codexServer) codexServer.recordingPath = recordingPath;
+    if (acpServer) acpServer.recordingPath = recordingPath;
+    if (opencodeServer) opencodeServer.recordingPath = recordingPath;
+    mockServer.recordingPath = recordingPath;
+    logger.info(`[daemon] NDJSON protocol recording enabled → ${recordingPath}`);
+  }
+
   // Site server: always started. The worker itself is lightweight — Playwright (and its ~200MB install)
   // is only loaded via dynamic import the first time a browser-dependent tool runs. Users with no
   // browser tool invocation pay the worker startup cost but nothing more.

--- a/packages/daemon/src/index.ts
+++ b/packages/daemon/src/index.ts
@@ -26,6 +26,7 @@ import {
 } from "node:fs";
 import { stat as fsStat } from "node:fs/promises";
 import { isAbsolute, join, resolve } from "node:path";
+import { NdjsonRecorder } from "@mcp-cli/core";
 import type { Logger } from "@mcp-cli/core";
 import {
   ACP_SERVER_NAME,
@@ -557,14 +558,18 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
   // Mock server: always available (no external binary needed)
   const mockServer = new MockServer(db, daemonId, undefined, logger);
 
-  // NDJSON protocol recording — enabled by MCX_RECORD_SESSION env var
+  // NDJSON protocol recording — enabled by MCX_RECORD_SESSION env var.
+  // A single NdjsonRecorder instance is shared across all providers so
+  // writes to the file are serialized (no interleaved partial lines).
   const recordingPath = process.env.MCX_RECORD_SESSION || null;
+  let recorder: NdjsonRecorder | null = null;
   if (recordingPath) {
-    claudeServer.recordingPath = recordingPath;
-    if (codexServer) codexServer.recordingPath = recordingPath;
-    if (acpServer) acpServer.recordingPath = recordingPath;
-    if (opencodeServer) opencodeServer.recordingPath = recordingPath;
-    mockServer.recordingPath = recordingPath;
+    recorder = new NdjsonRecorder(recordingPath);
+    claudeServer.recorder = recorder;
+    if (codexServer) codexServer.recorder = recorder;
+    if (acpServer) acpServer.recorder = recorder;
+    if (opencodeServer) opencodeServer.recorder = recorder;
+    mockServer.recorder = recorder;
     logger.info(`[daemon] NDJSON protocol recording enabled → ${recordingPath}`);
   }
 
@@ -1383,6 +1388,15 @@ export async function startDaemon(opts?: StartDaemonOptions): Promise<DaemonHand
         }
       }
       logger.info(`[mcpd] Shutdown: all virtual servers took ${Math.round(performance.now() - phase)}ms`);
+      // Close the shared NDJSON recorder AFTER all servers stop so final
+      // messages emitted during client.close() are captured.
+      if (recorder) {
+        try {
+          await recorder.close();
+        } catch (err) {
+          logger.error(`[mcpd] Error closing NDJSON recorder: ${err}`);
+        }
+      }
       phase = performance.now();
       try {
         await withPhaseTimeout(pool.closeAll(), SHUTDOWN_PHASE_TIMEOUT_MS, "pool.closeAll", logger);

--- a/packages/daemon/src/mock-server.spec.ts
+++ b/packages/daemon/src/mock-server.spec.ts
@@ -1,7 +1,8 @@
 import { afterAll, afterEach, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { MOCK_SERVER_NAME, silentLogger } from "@mcp-cli/core";
+import { MOCK_SERVER_NAME, NdjsonRecorder, type RecordingEntry, silentLogger } from "@mcp-cli/core";
 import { pollUntil } from "../../../test/harness";
 import { testOptions } from "../../../test/test-options";
 import { StateDb } from "./db/state";
@@ -622,5 +623,113 @@ describe("Mock script DSL (extended entries)", () => {
     const entries = JSON.parse((transcript.content as Array<{ type: string; text: string }>)[0].text);
     const texts = entries.filter((e: { role: string }) => e.role === "assistant").map((e: { text: string }) => e.text);
     expect(texts).toEqual(["first", "second"]);
+  });
+});
+
+// ── NDJSON recording integration ──
+
+describe("MockServer NDJSON recording", () => {
+  const recDir = join(tmpdir(), `rec-test-${process.pid}`);
+  let server: MockServer | undefined;
+  let db: StateDb | undefined;
+  let recorder: NdjsonRecorder | undefined;
+
+  afterEach(async () => {
+    await server?.stop();
+    await recorder?.close();
+    db?.close();
+    server = undefined;
+    db = undefined;
+    recorder = undefined;
+    rmSync(recDir, { recursive: true, force: true });
+  });
+
+  test("records init → ready → MCP initialize → tool call sequence", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    const recPath = join(recDir, "trace.ndjson");
+    recorder = new NdjsonRecorder(recPath);
+
+    server = new MockServer(db, "test-daemon", undefined, silentLogger);
+    server.recorder = recorder;
+
+    const { client } = await server.start();
+
+    // Exercise a tool call through the MCP client
+    await client.callTool({ name: "mock_session_list", arguments: {} });
+    await server.stop();
+    server = undefined;
+    await recorder.close();
+
+    const lines = readFileSync(recPath, "utf-8").trim().split("\n");
+    const entries = lines.map((l) => JSON.parse(l) as RecordingEntry);
+
+    // Verify we have a substantial recording
+    expect(entries.length).toBeGreaterThanOrEqual(5);
+
+    // 1. init message (daemon→worker, control)
+    const init = entries.find(
+      (e) => e.dir === "daemon->worker" && e.kind === "control" && (e.payload as { type?: string })?.type === "init",
+    );
+    expect(init).toBeDefined();
+
+    // 2. ready message (worker→daemon, control)
+    const ready = entries.find(
+      (e) => e.dir === "worker->daemon" && e.kind === "control" && (e.payload as { type?: string })?.type === "ready",
+    );
+    expect(ready).toBeDefined();
+
+    // 3. MCP initialize request (daemon→worker, mcp)
+    const initReq = entries.find(
+      (e) =>
+        e.dir === "daemon->worker" && e.kind === "mcp" && (e.payload as { method?: string })?.method === "initialize",
+    );
+    expect(initReq).toBeDefined();
+
+    // 4. MCP initialize response (worker→daemon, mcp) — this was the blocker
+    const initResp = entries.find(
+      (e) =>
+        e.dir === "worker->daemon" &&
+        e.kind === "mcp" &&
+        "result" in (e.payload as Record<string, unknown>) &&
+        (e.payload as { id?: unknown })?.id === (initReq?.payload as { id?: unknown })?.id,
+    );
+    expect(initResp).toBeDefined();
+
+    // 5. Tool call (daemon→worker, mcp)
+    const toolCall = entries.find(
+      (e) =>
+        e.dir === "daemon->worker" && e.kind === "mcp" && (e.payload as { method?: string })?.method === "tools/call",
+    );
+    expect(toolCall).toBeDefined();
+
+    // 6. Tool response (worker→daemon, mcp)
+    // The response comes through the post-connect worker.onmessage wrapper (which
+    // records DB events) and then falls through to the raw transport handler
+    // (which the setupRecording wrapper records). Look for any mcp response
+    // matching the tool call ID.
+    const toolCallId = (toolCall?.payload as { id?: unknown })?.id;
+    const toolResp = entries.find(
+      (e) =>
+        e.dir === "worker->daemon" &&
+        e.kind === "mcp" &&
+        (e.payload as { id?: unknown })?.id === toolCallId &&
+        !("method" in (e.payload as Record<string, unknown>)),
+    );
+    expect(toolResp).toBeDefined();
+
+    // Verify ordering: init before ready, ready before initialize, initialize before tool call
+    const initIdx = entries.indexOf(init as RecordingEntry);
+    const readyIdx = entries.indexOf(ready as RecordingEntry);
+    const initReqIdx = entries.indexOf(initReq as RecordingEntry);
+    const toolCallIdx = entries.indexOf(toolCall as RecordingEntry);
+    expect(initIdx).toBeLessThan(readyIdx);
+    expect(readyIdx).toBeLessThan(initReqIdx);
+    expect(initReqIdx).toBeLessThan(toolCallIdx);
+
+    // Timestamps are monotonically increasing
+    for (let i = 1; i < entries.length; i++) {
+      expect(entries[i].t).toBeGreaterThanOrEqual(entries[i - 1].t);
+    }
   });
 });

--- a/packages/daemon/src/mock-server.ts
+++ b/packages/daemon/src/mock-server.ts
@@ -10,11 +10,10 @@
  * since this is a testing-only provider.
  */
 
-import type { JsonSchema, Logger, ToolInfo } from "@mcp-cli/core";
+import type { JsonSchema, Logger, NdjsonRecorder, ToolInfo } from "@mcp-cli/core";
 import {
   AGENT_PROTOCOL_VERSION,
   MOCK_SERVER_NAME,
-  NdjsonRecorder,
   ProtocolVersionMismatchError,
   consoleLogger,
   formatToolSignature,
@@ -23,6 +22,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { closeClientWithTimeout } from "./close-timeout";
 import type { StateDb } from "./db/state";
 import { MOCK_TOOLS } from "./mock-session/tools";
+import { setupRecording } from "./recording-hooks";
 import { safeSetTimeout } from "./safe-timers";
 import { workerPath } from "./worker-path";
 import { WorkerClientTransport } from "./worker-transport";
@@ -103,12 +103,11 @@ export class MockServer {
   private readonly activeSessions = new Set<string>();
   private readonly sessionAddedAt = new Map<string, number>();
   private readonly logger: Logger;
-  private recorder: NdjsonRecorder | null = null;
   private static readonly NO_PID_SESSION_TTL_MS = 10 * 60 * 1000;
 
   /** Called on worker activity — lets the daemon reset its idle timer. */
   onActivity?: () => void;
-  recordingPath: string | null = null;
+  recorder: NdjsonRecorder | null = null;
 
   constructor(
     db: StateDb,
@@ -125,9 +124,6 @@ export class MockServer {
   /** Start the worker and connect the MCP client. */
   async start(): Promise<{ client: Client; transport: WorkerClientTransport }> {
     if (this.worker) throw new Error("start() called while worker is already running");
-    if (this.recordingPath) {
-      this.recorder = new NdjsonRecorder(this.recordingPath);
-    }
     const worker = new Worker(workerPath("mock-session-worker.ts"));
     this.worker = worker;
 
@@ -182,6 +178,14 @@ export class MockServer {
       this.transport = new WorkerClientTransport(this.worker);
       this.client = this.clientFactory();
 
+      // Install recording hooks BEFORE connect so the MCP initialize
+      // handshake is captured in both directions.
+      let rawHandler: (() => ((this: Worker, event: MessageEvent) => void) | null) | undefined;
+      if (this.recorder) {
+        const hooks = setupRecording(worker, this.transport, this.recorder);
+        rawHandler = hooks.rawTransportHandler;
+      }
+
       let handshakeTimer: ReturnType<typeof setTimeout> | undefined;
       let connectResolved = false;
       await Promise.race([
@@ -198,8 +202,10 @@ export class MockServer {
       ]);
       clearTimeout(handshakeTimer);
 
-      // Wrap worker.onmessage to intercept DB event messages
-      const transportHandler = worker.onmessage;
+      // Post-connect: replaces the setupRecording handshake wrapper.
+      // Record ALL inbound messages here (the handshake wrapper only
+      // lived during connect and is now gone — no double-record).
+      const transportFwd = rawHandler?.() ?? worker.onmessage;
       worker.onmessage = (event: MessageEvent) => {
         const data = event.data;
         this.recorder?.recordMessage("worker->daemon", data);
@@ -207,17 +213,8 @@ export class MockServer {
           this.handleWorkerEvent(data);
           return;
         }
-        transportHandler?.call(worker, event);
+        (transportFwd as ((this: Worker, event: MessageEvent) => void) | null)?.call(worker, event);
       };
-
-      if (this.recorder) {
-        const origSend = this.transport.send.bind(this.transport);
-        const recorder = this.recorder;
-        this.transport.send = (msg, opts) => {
-          recorder.recordMessage("daemon->worker", msg);
-          return origSend(msg, opts);
-        };
-      }
 
       worker.onerror = null;
     } catch (err) {
@@ -242,8 +239,6 @@ export class MockServer {
 
   /** Stop the worker and clean up. */
   async stop(): Promise<void> {
-    await this.recorder?.close();
-    this.recorder = null;
     await closeClientWithTimeout(this.client);
     if (this.worker) {
       this.worker.onmessage = null;

--- a/packages/daemon/src/mock-server.ts
+++ b/packages/daemon/src/mock-server.ts
@@ -14,6 +14,7 @@ import type { JsonSchema, Logger, ToolInfo } from "@mcp-cli/core";
 import {
   AGENT_PROTOCOL_VERSION,
   MOCK_SERVER_NAME,
+  NdjsonRecorder,
   ProtocolVersionMismatchError,
   consoleLogger,
   formatToolSignature,
@@ -102,10 +103,12 @@ export class MockServer {
   private readonly activeSessions = new Set<string>();
   private readonly sessionAddedAt = new Map<string, number>();
   private readonly logger: Logger;
+  private recorder: NdjsonRecorder | null = null;
   private static readonly NO_PID_SESSION_TTL_MS = 10 * 60 * 1000;
 
   /** Called on worker activity — lets the daemon reset its idle timer. */
   onActivity?: () => void;
+  recordingPath: string | null = null;
 
   constructor(
     db: StateDb,
@@ -122,6 +125,9 @@ export class MockServer {
   /** Start the worker and connect the MCP client. */
   async start(): Promise<{ client: Client; transport: WorkerClientTransport }> {
     if (this.worker) throw new Error("start() called while worker is already running");
+    if (this.recordingPath) {
+      this.recorder = new NdjsonRecorder(this.recordingPath);
+    }
     const worker = new Worker(workerPath("mock-session-worker.ts"));
     this.worker = worker;
 
@@ -153,8 +159,10 @@ export class MockServer {
           }
           settled = true;
           clearTimeout(timeout);
+          this.recorder?.record("worker->daemon", "control", event.data);
           resolve();
         } else if (event.data?.type === "error") {
+          this.recorder?.record("worker->daemon", "control", event.data);
           clearTimeout(timeout);
           reject(new Error(`Mock session worker init failed: ${event.data.message}`));
         }
@@ -164,7 +172,9 @@ export class MockServer {
         const msg = event instanceof ErrorEvent ? event.message : String(event);
         if (cleanup()) reject(new Error(`Mock session worker error: ${msg}`));
       };
-      worker.postMessage({ type: "init", daemonId: this.daemonId, protocol_version: AGENT_PROTOCOL_VERSION });
+      const initMsg = { type: "init" as const, daemonId: this.daemonId, protocol_version: AGENT_PROTOCOL_VERSION };
+      this.recorder?.record("daemon->worker", "control", initMsg);
+      worker.postMessage(initMsg);
     });
 
     // Set up MCP transport and connect
@@ -192,12 +202,22 @@ export class MockServer {
       const transportHandler = worker.onmessage;
       worker.onmessage = (event: MessageEvent) => {
         const data = event.data;
+        this.recorder?.recordMessage("worker->daemon", data);
         if (isWorkerEvent(data)) {
           this.handleWorkerEvent(data);
           return;
         }
         transportHandler?.call(worker, event);
       };
+
+      if (this.recorder) {
+        const origSend = this.transport.send.bind(this.transport);
+        const recorder = this.recorder;
+        this.transport.send = (msg, opts) => {
+          recorder.recordMessage("daemon->worker", msg);
+          return origSend(msg, opts);
+        };
+      }
 
       worker.onerror = null;
     } catch (err) {
@@ -222,6 +242,8 @@ export class MockServer {
 
   /** Stop the worker and clean up. */
   async stop(): Promise<void> {
+    await this.recorder?.close();
+    this.recorder = null;
     await closeClientWithTimeout(this.client);
     if (this.worker) {
       this.worker.onmessage = null;

--- a/packages/daemon/src/recording-hooks.ts
+++ b/packages/daemon/src/recording-hooks.ts
@@ -1,0 +1,47 @@
+import type { NdjsonRecorder } from "@mcp-cli/core";
+import type { WorkerClientTransport } from "./worker-transport";
+
+export interface RecordingSetup {
+  rawTransportHandler(): ((this: Worker, event: MessageEvent) => void) | null;
+}
+
+/**
+ * Wire NDJSON recording onto a worker + transport pair.
+ *
+ * Must be called AFTER the transport is constructed but BEFORE
+ * client.connect() so the MCP initialize handshake is captured.
+ *
+ * Patches:
+ *   - transport.send  → records every daemon→worker MCP message
+ *   - transport.start → wraps the worker.onmessage that start() installs,
+ *     recording every worker→daemon message during the handshake
+ *
+ * Returns a handle whose rawTransportHandler() yields the transport's
+ * original (un-wrapped) worker.onmessage — use it as the MCP fallthrough
+ * in the post-connect wrapper to avoid double-recording.
+ */
+export function setupRecording(
+  worker: Worker,
+  transport: WorkerClientTransport,
+  recorder: NdjsonRecorder,
+): RecordingSetup {
+  const origSend = transport.send.bind(transport);
+  transport.send = (msg, opts) => {
+    recorder.recordMessage("daemon->worker", msg);
+    return origSend(msg, opts);
+  };
+
+  let _rawHandler: ((this: Worker, event: MessageEvent) => void) | null = null;
+  const origStart = transport.start.bind(transport);
+  transport.start = async () => {
+    await origStart();
+    _rawHandler = worker.onmessage as typeof _rawHandler;
+    const raw = _rawHandler;
+    worker.onmessage = (event: MessageEvent) => {
+      recorder.recordMessage("worker->daemon", event.data);
+      raw?.call(worker, event);
+    };
+  };
+
+  return { rawTransportHandler: () => _rawHandler };
+}


### PR DESCRIPTION
## Summary
- Add env-gated NDJSON recording of every message crossing the daemon↔worker boundary, activated via `MCX_RECORD_SESSION=<path>` env var or `mcx agent <provider> record --save=<path>` CLI subcommand
- Each NDJSON line: `{ t, dir, kind, payload }` where `kind` aligns with `docs/agent-protocol.md` §2-5 (control | db | mcp). Zero overhead when disabled.
- Recording hooks at `AbstractWorkerServer` level (covers claude, codex, acp, opencode) and separately in `MockServer` (standalone). Worker-side untouched to minimize conflict surface with #2541.

## Files changed
- **`packages/core/src/recording.ts`** — `NdjsonRecorder` class, `classifyMessageKind()`, type definitions
- **`packages/core/src/recording.spec.ts`** — 24 tests covering classification + recorder behavior
- **`packages/core/src/constants.ts`** — `RECORDINGS_DIR` constant
- **`packages/core/src/index.ts`** — barrel export
- **`packages/daemon/src/abstract-worker-server.ts`** — recording hooks + `sendControlMessage()` helper
- **`packages/daemon/src/claude-server.ts`** — use `sendControlMessage()` for work_item_event/restore_sessions
- **`packages/daemon/src/mock-server.ts`** — standalone recording hooks (doesn't extend AbstractWorkerServer)
- **`packages/daemon/src/index.ts`** — `MCX_RECORD_SESSION` env var wiring
- **`packages/command/src/commands/agent.ts`** — `record` subcommand

## Test plan
- [x] 24 unit tests for `classifyMessageKind` (all message types) and `NdjsonRecorder` (format, auto-classify, idempotent close, dropped writes, monotonic timestamps, directory creation)
- [x] Typecheck passes
- [x] Lint passes
- [x] Architecture rules pass (`doing-it-wrong`)

> **Note:** Sibling PR #2566 (#2541 — version negotiation) touches the same dispatch layer. Whoever merges first, the other rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)