### PR TITLE
fix(rules): FP-guard string-literal // in poll-until-headroom (fixes #2371)

### DIFF
--- a/scripts/rules/fixtures/poll-until-headroom__clean.fixture.ts
+++ b/scripts/rules/fixtures/poll-until-headroom__clean.fixture.ts
@@ -5,7 +5,8 @@
  *
  * No explicit timeout (relies on the safe 1500ms harness default), an explicit
  * timeout comfortably below the watchdog, or a larger deadline that still sits
- * under a file-level setDefaultTimeout — no violation.
+ * under a file-level setDefaultTimeout — no violation. Also covers the case
+ * where "//" appears inside a string literal earlier on the same line (#2371).
  */
 
 import { setDefaultTimeout } from "bun:test";
@@ -45,3 +46,9 @@ await pollUntil(() => events.some((e) => e.type === "ready"), 10_000);
 // await pollUntil(condition);
 // await pollUntil(condition, 10_000); — old approach
 // pollUntil(fn) — waits for the condition
+
+// "//" inside a string literal earlier on the line must not be treated as a
+// line comment — the call is live and this explicit timeout is below the
+// watchdog, so it should not be flagged (#2371).
+const url = "http://localhost"; await pollUntil(condition, 4000);
+const endpoint = "https://api.example.com"; await pollUntil(() => true, 3_000);

--- a/scripts/rules/fixtures/poll-until-headroom__flagged.fixture.ts
+++ b/scripts/rules/fixtures/poll-until-headroom__flagged.fixture.ts
@@ -1,6 +1,6 @@
 /**
  * @rule poll-until-headroom
- * @expect 5
+ * @expect 6
  * @path packages/daemon/src/ipc-server.spec.ts
  *
  * An explicit deadline ≥ the 5000ms watchdog can never fire its own error —
@@ -32,3 +32,7 @@ await pollUntil(
   () => condition(),
   10_000 // needs time for daemon startup
 );
+
+// URL string earlier on the same line — "//" is inside a string, not a comment;
+// the call is live and the deadline ≥ watchdog — must still be flagged (#2371)
+const url = "http://localhost"; await pollUntil(condition, 10_000);

--- a/scripts/rules/poll-until-headroom.rule.ts
+++ b/scripts/rules/poll-until-headroom.rule.ts
@@ -66,6 +66,31 @@ function collectCall(lines: string[], startLine: number, parenOffset: number): s
 }
 
 /**
+ * Find the start of a real line-comment `//` on a line, ignoring `//` that
+ * appears inside a string literal. Returns -1 if there is no line comment.
+ */
+function realCommentStart(line: string): number {
+  let inStr: '"' | "'" | "`" | null = null;
+  for (let i = 0; i < line.length - 1; i++) {
+    const ch = line[i];
+    if (inStr !== null) {
+      if (ch === "\\") {
+        i++;
+        continue;
+      }
+      if (ch === inStr) inStr = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      inStr = ch;
+    } else if (ch === "/" && line[i + 1] === "/") {
+      return i;
+    }
+  }
+  return -1;
+}
+
+/**
  * Find the index of the first comma at depth 0 (top-level) within `s`,
  * correctly skipping over nested parens, brackets, braces, and string literals.
  * Returns -1 if none found.
@@ -132,9 +157,9 @@ const rule: CheckRule = {
       const pollIdx = line.indexOf("pollUntil(");
       if (pollIdx === -1) continue;
 
-      // Skip commented-out calls: if "//" appears before pollUntil on the line,
-      // the call is dead code — not a live violation (#2293).
-      const commentStart = line.indexOf("//");
+      // Skip commented-out calls: if a real "//" (not inside a string literal)
+      // appears before pollUntil on the line, the call is dead code (#2293, #2371).
+      const commentStart = realCommentStart(line);
       if (commentStart !== -1 && commentStart < pollIdx) continue;
 
       // parenOffset points to the '(' of the call


### PR DESCRIPTION
## Summary
- `poll-until-headroom.rule.ts:137` used `line.indexOf("//")` which matched `//` inside string literals (e.g. `"http://localhost"`), causing a false negative: a live `pollUntil` call preceded by a URL string was wrongly skipped as dead code
- Adds `realCommentStart(line)` which walks the line respecting single/double/template-quote string boundaries and backslash escapes, returning the first genuine `//` comment index or -1
- Fixture: clean fixture adds the URL-preceding-call cases (must not fire); flagged fixture adds the same URL scenario with deadline ≥ watchdog (must still fire, count bumped 5→6)

## Test plan
- [x] `bun test scripts/rules/fixtures.spec.ts` — 109 pass, 0 fail
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun run doing-it-wrong` — clean
- [x] Pre-commit hook passed (static gate: typecheck + lint + rules)
- [x] Rebased onto main post-#2549

🤖 Generated with [Claude Code](https://claude.com/claude-code)