### PR TITLE
fix(phase): add resolve-threads step to impl and review worker prompts (fixes #2331)

### DIFF
--- a/.claude/phases/impl-fn.spec.ts
+++ b/.claude/phases/impl-fn.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { buildImplPrompt } from "./impl-fn";
+
+describe("buildImplPrompt", () => {
+  test("includes the issue number", () => {
+    const prompt = buildImplPrompt(42, null);
+    expect(prompt).toContain("42");
+  });
+
+  test("contains /implement skill invocation", () => {
+    expect(buildImplPrompt(42, null)).toMatch(/^\/implement 42/);
+  });
+
+  test("omits resolve step when prNumber is null", () => {
+    const prompt = buildImplPrompt(42, null);
+    expect(prompt).not.toContain("resolve");
+  });
+
+  test("includes resolve step when prNumber is provided", () => {
+    const prompt = buildImplPrompt(42, 30);
+    expect(prompt).toContain("mcx pr comments 30 resolve --all-addressed");
+  });
+
+  test("resolve step references the correct pr number", () => {
+    expect(buildImplPrompt(10, 99)).toContain("mcx pr comments 99 resolve --all-addressed");
+  });
+});

--- a/.claude/phases/impl-fn.ts
+++ b/.claude/phases/impl-fn.ts
@@ -1,0 +1,9 @@
+/** Core impl-phase logic, extracted for testability. */
+
+export function buildImplPrompt(issueNumber: number, prNumber: number | null): string {
+  const resolveStep =
+    prNumber != null
+      ? `\nAfter replying to each addressed thread, resolve it: mcx pr comments ${prNumber} resolve --all-addressed`
+      : "";
+  return `/implement ${issueNumber}${resolveStep}`;
+}

--- a/.claude/phases/impl.ts
+++ b/.claude/phases/impl.ts
@@ -23,6 +23,7 @@
  */
 import { NO_REPO_ROOT, findModelInSprintPlan } from "@mcp-cli/core";
 import { defineAlias, z } from "mcp-cli";
+import { buildImplPrompt } from "./impl-fn";
 
 type Provider = "claude" | "copilot" | "gemini" | "grok" | `acp:${string}`;
 
@@ -109,7 +110,7 @@ defineAlias({
     const provider = input.provider;
     const supportsWorktree = provider === "claude";
     const allowTools = ["Read", "Glob", "Grep", "Write", "Edit", "Bash", "ExitPlanMode", "EnterPlanMode"];
-    const prompt = `/implement ${work.issueNumber}`;
+    const prompt = buildImplPrompt(work.issueNumber, work.prNumber ?? null);
     const command = [
       ...commandForProvider(provider),
       ...(supportsWorktree ? ["--worktree"] : []),

--- a/.claude/phases/review-fn.spec.ts
+++ b/.claude/phases/review-fn.spec.ts
@@ -150,6 +150,24 @@ describe("scanReviewComments", () => {
   });
 });
 
+describe("runReview — spawn prompt", () => {
+  test("includes resolve step with correct pr number", async () => {
+    const state = makeState();
+    const result = await runReview({ provider: "claude" }, makeWork({ prNumber: 55 }), state, makeDeps(), "/repo");
+    if (result.action === "spawn") {
+      expect(result.prompt).toContain("mcx pr comments 55 resolve --all-addressed");
+    }
+  });
+
+  test("resolve step names the pr number from the work item", async () => {
+    const state = makeState();
+    const result = await runReview({ provider: "claude" }, makeWork({ prNumber: 99 }), state, makeDeps(), "/repo");
+    if (result.action === "spawn") {
+      expect(result.prompt).toContain("mcx pr comments 99 resolve --all-addressed");
+    }
+  });
+});
+
 describe("runReview — no session yet", () => {
   test("returns spawn action", async () => {
     const state = makeState();

--- a/.claude/phases/review-fn.ts
+++ b/.claude/phases/review-fn.ts
@@ -105,7 +105,8 @@ export async function runReview(
     }
 
     const allowTools = ["Read", "Glob", "Grep", "Write", "Edit", "Bash"];
-    const prompt = `/adversarial-review (PR ${work.prNumber}, branch ${work.branch}, round ${round})`;
+    const resolveStep = `After replying to each addressed thread, resolve it: mcx pr comments ${work.prNumber} resolve --all-addressed`;
+    const prompt = `/adversarial-review (PR ${work.prNumber}, branch ${work.branch}, round ${round})\n${resolveStep}`;
     const cmdBase = input.provider.startsWith("acp:")
       ? ["mcx", "acp", "spawn", "--agent", input.provider.slice(4)]
       : ["mcx", input.provider, "spawn"];


### PR DESCRIPTION
## Summary
- `impl.ts`: when a PR exists on the work item, the spawned worker's prompt now appends `mcx pr comments <pr> resolve --all-addressed` after any addressed thread
- `review-fn.ts`: the adversarial reviewer's spawn prompt now includes the same resolve instruction (PR number is always known in review phase)
- Extract `buildImplPrompt` to `impl-fn.ts` for testability, mirroring the existing `buildRepairPrompt` pattern in `repair-fn.ts`

## Test plan
- [ ] `bun test impl-fn.spec.ts` — 5 new tests: prompt shape, resolve step present/absent based on prNumber
- [ ] `bun test review-fn.spec.ts` — 2 new tests: spawn prompt contains resolve step with correct PR number
- [ ] `bun test --no-orphans` (packages) — 7775 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)