### PR TITLE
fix(tests): strip GIT_* env vars to prevent hook-injected phantom commits (fixes #2527)

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -76,6 +76,13 @@ if $has_source; then
   echo "  am-i-done (static gate: typecheck, lint, rules)..."
   bun run am-i-done --pre-commit
 
+  # Unset git hook environment variables before running the test suite.
+  # The outer `git commit` sets GIT_DIR, GIT_INDEX_FILE, GIT_WORK_TREE, etc.
+  # Tests that spawn git commands without clearing these vars would otherwise
+  # accidentally commit into the developer's branch (#2527).
+  unset GIT_DIR GIT_INDEX_FILE GIT_WORK_TREE GIT_COMMON_DIR GIT_PREFIX \
+        GIT_AUTHOR_DATE GIT_COMMITTER_DATE
+
   echo "  test + coverage..."
   if ! bun run test:coverage; then
     echo "  (test failures logged to ~/.mcp-cli/test-failures.log)"

--- a/.git-hooks/sprint-active.spec.ts
+++ b/.git-hooks/sprint-active.spec.ts
@@ -7,6 +7,16 @@ const SPRINT_ACTIVE_SH = resolve(import.meta.dir, "sprint-active.sh");
 
 type RunResult = { code: number; stdout: string; stderr: string };
 
+/** Strip GIT_* env vars so git ops in temp repos don't inherit GIT_DIR/GIT_INDEX_FILE
+ *  from an outer `git commit` invocation and commit into the developer's branch. */
+function cleanGitEnv(extra: Record<string, string> = {}): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (!k.startsWith("GIT_") && v !== undefined) env[k] = v;
+  }
+  return { ...env, ...extra };
+}
+
 async function runCheck(cwd: string, env: Record<string, string> = {}): Promise<RunResult> {
   const script = `
     set -u
@@ -21,7 +31,7 @@ async function runCheck(cwd: string, env: Record<string, string> = {}): Promise<
   `;
   const proc = Bun.spawn(["bash", "-c", script], {
     cwd,
-    env: { ...process.env, ...env },
+    env: cleanGitEnv(env),
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -31,7 +41,7 @@ async function runCheck(cwd: string, env: Record<string, string> = {}): Promise<
 }
 
 async function sh(cwd: string, cmd: string[]): Promise<void> {
-  const proc = Bun.spawn(cmd, { cwd, stdout: "pipe", stderr: "pipe" });
+  const proc = Bun.spawn(cmd, { cwd, env: cleanGitEnv(), stdout: "pipe", stderr: "pipe" });
   const code = await proc.exited;
   if (code !== 0) {
     const err = await new Response(proc.stderr).text();

--- a/scripts/_runner/verdict-cache.spec.ts
+++ b/scripts/_runner/verdict-cache.spec.ts
@@ -3,8 +3,18 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-
 import { computeVerdictKey, lookupVerdict, storeVerdict } from "./verdict-cache";
+
+/** Strip GIT_* env vars so git operations in temp repos don't inherit GIT_DIR /
+ *  GIT_INDEX_FILE from an outer `git commit` invocation (e.g. the pre-commit hook)
+ *  and accidentally commit into the developer's working branch. */
+function cleanGitEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (!k.startsWith("GIT_") && v !== undefined) env[k] = v;
+  }
+  return env;
+}
 
 function makeTmpRepo(): string {
   return mkdtempSync(join(tmpdir(), "verdict-cache-test-"));
@@ -96,10 +106,13 @@ describe("computeVerdictKey", () => {
   function initGitRepo(): string {
     const dir = mkdtempSync(join(tmpdir(), "verdict-key-test-"));
     dirs.push(dir);
-    spawnSync("git", ["init"], { cwd: dir });
-    spawnSync("git", ["-c", "user.name=Test", "-c", "user.email=t@t", "commit", "--allow-empty", "-m", "init"], {
-      cwd: dir,
-    });
+    const gitOpts = { cwd: dir, env: cleanGitEnv() };
+    spawnSync("git", ["init"], gitOpts);
+    spawnSync(
+      "git",
+      ["-c", "user.name=Test", "-c", "user.email=t@t", "commit", "--allow-empty", "-m", "init"],
+      gitOpts,
+    );
     return dir;
   }
 
@@ -137,6 +150,7 @@ describe("computeVerdictKey", () => {
     const dir = initGitRepo();
     spawnSync("git", ["-c", "user.name=Test", "-c", "user.email=t@t", "commit", "--allow-empty", "-m", "second"], {
       cwd: dir,
+      env: cleanGitEnv(),
     });
     const key1 = computeVerdictKey(() => "HEAD~1", dir);
     const key2 = computeVerdictKey(() => "HEAD", dir);

--- a/scripts/_runner/verdict-cache.ts
+++ b/scripts/_runner/verdict-cache.ts
@@ -37,18 +37,26 @@ interface VerdictCacheFile {
  * these, invalidating the cache.
  */
 export function computeVerdictKey(resolveBase: () => string, cwd?: string): string | null {
+  // Strip GIT_* env vars so an explicit cwd is authoritative — without this,
+  // GIT_DIR set by an outer git hook invocation overrides cwd and causes git
+  // to operate on the hook's repo instead of the requested directory (#2527).
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (!k.startsWith("GIT_") && v !== undefined) env[k] = v;
+  }
+
   const base = resolveBase();
-  const head = spawnSync("git", ["rev-parse", "HEAD"], { encoding: "utf8", cwd });
+  const head = spawnSync("git", ["rev-parse", "HEAD"], { encoding: "utf8", cwd, env });
   if (head.status !== 0) return null;
   const headSha = head.stdout.trim();
 
   // `git diff HEAD` captures both staged and unstaged changes in one shot.
-  const diff = spawnSync("git", ["diff", "HEAD"], { encoding: "utf8", cwd });
+  const diff = spawnSync("git", ["diff", "HEAD"], { encoding: "utf8", cwd, env });
   if (diff.status !== 0) return null;
 
   // Untracked files (new spec files, etc.) are invisible to `git diff HEAD`.
   // Include their names so adding/removing an untracked file flips the key.
-  const untracked = spawnSync("git", ["ls-files", "--others", "--exclude-standard"], { encoding: "utf8", cwd });
+  const untracked = spawnSync("git", ["ls-files", "--others", "--exclude-standard"], { encoding: "utf8", cwd, env });
   const untrackedList = untracked.status === 0 ? untracked.stdout : "";
 
   const diffHash = Bun.hash(diff.stdout + untrackedList).toString(16);


### PR DESCRIPTION
## Summary

- **`scripts/_runner/verdict-cache.spec.ts`**: Add `cleanGitEnv()` and pass it to every `spawnSync` git call in `initGitRepo()` and the "changes when base ref changes" test. Without this, git commits in temp repos target the live worktree branch because `GIT_DIR`/`GIT_INDEX_FILE` set by the pre-commit hook are inherited.
- **`scripts/_runner/verdict-cache.ts`**: Strip `GIT_*` env vars in `computeVerdictKey` so an explicit `cwd` is always authoritative. An ambient `GIT_DIR` from a git hook previously caused all three `spawnSync` calls to operate on the hook's repo instead of the specified directory, returning `null` for every invocation.
- **`.git-hooks/sprint-active.spec.ts`**: Add `cleanGitEnv()` to `sh()` and `runCheck()` (excluded from standard test runs but had the same vulnerability).
- **`.git-hooks/pre-commit`**: Unset `GIT_DIR`, `GIT_INDEX_FILE`, `GIT_WORK_TREE`, `GIT_COMMON_DIR`, `GIT_PREFIX`, `GIT_AUTHOR_DATE`, and `GIT_COMMITTER_DATE` before invoking `bun run test:coverage` as defence-in-depth against any test fixture that still inherits hook-injected variables.

## Root cause

When `git commit` runs the pre-commit hook, it sets `GIT_DIR` (real worktree git dir), `GIT_INDEX_FILE` (real staged index), and `GIT_WORK_TREE` in the process environment. Test helpers that spawn git commands without clearing these vars inherit them — `git init` reinitialises the real git dir, and `git commit` writes to the live branch instead of the temp repo, producing phantom `init`/`second` commits with the wrong author and message.

## Test plan

- [x] `bun test scripts/_runner/verdict-cache.spec.ts` — all 12 pass
- [x] `bun run am-i-done --pre-commit` — all checks pass
- [x] `bun run am-i-done` (pre-push mode via `git push`) — all checks pass including the verdict-cache tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)