### PR TITLE
fix(daemon): use parseInt for semver parsing to handle pre-release suffixes (fixes #2563)

### DIFF
--- a/packages/daemon/src/claude-session/transport-resolver.spec.ts
+++ b/packages/daemon/src/claude-session/transport-resolver.spec.ts
@@ -37,4 +37,11 @@ describe("resolveTransport", () => {
     expect(resolveTransport(undefined, "2.1.123")).toBe("stdio");
     expect(resolveTransport(undefined, null)).toBe("ws");
   });
+
+  test("pre-release suffixes are parsed correctly", () => {
+    expect(resolveTransport("auto", "2.1.123-beta.1")).toBe("stdio");
+    expect(resolveTransport("auto", "2.2.0-rc.2")).toBe("stdio");
+    expect(resolveTransport("auto", "2.1.122-alpha.0")).toBe("ws");
+    expect(resolveTransport("auto", "2.1.100-dev.5")).toBe("ws");
+  });
 });

--- a/packages/daemon/src/claude-session/transport-resolver.ts
+++ b/packages/daemon/src/claude-session/transport-resolver.ts
@@ -21,8 +21,8 @@ const LAST_SDK_URL_VERSION = "2.1.122";
  * Returns negative if a < b, 0 if equal, positive if a > b.
  */
 function compareSemver(a: string, b: string): number {
-  const pa = a.split(".").map(Number);
-  const pb = b.split(".").map(Number);
+  const pa = a.split(".").map((s) => Number.parseInt(s, 10));
+  const pb = b.split(".").map((s) => Number.parseInt(s, 10));
   for (let i = 0; i < 3; i++) {
     const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
     if (diff !== 0) return diff;


### PR DESCRIPTION
## Summary
- Replace `.map(Number)` with `.map(s => Number.parseInt(s, 10))` in `compareSemver` to correctly parse pre-release version strings like `2.1.123-beta.1`
- `Number("123-beta")` returns `NaN` (breaking all comparisons); `parseInt("123-beta", 10)` correctly returns `123`
- Added test cases for pre-release version strings covering both above and below the transport gate threshold

## Test plan
- [x] Existing transport-resolver tests pass (6 tests)
- [x] New pre-release suffix test covers `beta`, `rc`, `alpha`, `dev` suffixes
- [x] Full test suite passes (8446 tests, 0 failures)
- [x] Typecheck + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)