### PR TITLE
feat(agent-grid): package scaffold + capability gating (fixes #2581)

### DIFF
--- a/agent-grid/package.json
+++ b/agent-grid/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@mcp-cli/agent-grid",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "dependencies": {
+    "@mcp-cli/core": "workspace:*"
+  }
+}

--- a/agent-grid/src/capability-gate.spec.ts
+++ b/agent-grid/src/capability-gate.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { getProvider } from "@mcp-cli/core";
+import type { AgentProvider } from "@mcp-cli/core";
+import { gateTest, missingFeatures } from "./capability-gate.js";
+import type { GridResult, GridTest } from "./grid-test.js";
+
+function requireProvider(name: string): AgentProvider {
+  const p = getProvider(name);
+  if (!p) throw new Error(`provider "${name}" not registered`);
+  return p;
+}
+
+function stubTest(requires: GridTest["requires"]): GridTest {
+  return {
+    name: "stub",
+    requires,
+    run: async () => ({ status: "pass" }),
+  };
+}
+
+describe("missingFeatures", () => {
+  test("returns empty for provider with all required features", () => {
+    const claude = requireProvider("claude");
+    expect(missingFeatures(claude, ["worktree", "resume", "costTracking"])).toEqual([]);
+  });
+
+  test("returns missing features for provider lacking them", () => {
+    const codex = requireProvider("codex");
+    expect(missingFeatures(codex, ["worktree", "resume"])).toEqual(["worktree", "resume"]);
+  });
+
+  test("returns empty when requires is empty", () => {
+    const codex = requireProvider("codex");
+    expect(missingFeatures(codex, [])).toEqual([]);
+  });
+
+  test("partial overlap returns only missing", () => {
+    const codex = requireProvider("codex");
+    expect(missingFeatures(codex, ["costTracking", "worktree"])).toEqual(["worktree"]);
+  });
+
+  test("treats absent keys as missing", () => {
+    const mock = requireProvider("mock");
+    expect(missingFeatures(mock, ["worktree"])).toEqual(["worktree"]);
+  });
+});
+
+describe("gateTest", () => {
+  test("returns null when test has no requirements", () => {
+    const claude = requireProvider("claude");
+    expect(gateTest(stubTest([]), claude)).toBeNull();
+  });
+
+  test("returns null when provider satisfies all requirements", () => {
+    const claude = requireProvider("claude");
+    expect(gateTest(stubTest(["worktree", "resume"]), claude)).toBeNull();
+  });
+
+  test("returns n/a with reason when provider lacks a feature", () => {
+    const codex = requireProvider("codex");
+    const result = gateTest(stubTest(["worktree"]), codex);
+    expect(result).not.toBeNull();
+    const r = result as GridResult & { status: "n/a" };
+    expect(r.status).toBe("n/a");
+    expect(r.reason).toContain("codex");
+    expect(r.reason).toContain("worktree");
+  });
+
+  test("lists all missing features in reason", () => {
+    const codex = requireProvider("codex");
+    const result = gateTest(stubTest(["worktree", "resume", "compactLog"]), codex);
+    expect(result).not.toBeNull();
+    const r = result as GridResult & { status: "n/a" };
+    expect(r.reason).toContain("worktree");
+    expect(r.reason).toContain("resume");
+    expect(r.reason).toContain("compactLog");
+  });
+
+  test("skips for mock provider with minimal features", () => {
+    const mock = requireProvider("mock");
+    const result = gateTest(stubTest(["costTracking"]), mock);
+    expect(result).not.toBeNull();
+    expect((result as GridResult & { status: "n/a" }).status).toBe("n/a");
+  });
+});

--- a/agent-grid/src/capability-gate.spec.ts
+++ b/agent-grid/src/capability-gate.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import { getProvider } from "@mcp-cli/core";
 import type { AgentProvider } from "@mcp-cli/core";
-import { gateTest, missingFeatures } from "./capability-gate.js";
-import type { GridResult, GridTest } from "./grid-test.js";
+import { gateTest, missingFeatures } from "./capability-gate";
+import type { GridResult, GridTest } from "./grid-test";
 
 function requireProvider(name: string): AgentProvider {
   const p = getProvider(name);

--- a/agent-grid/src/capability-gate.ts
+++ b/agent-grid/src/capability-gate.ts
@@ -1,5 +1,5 @@
 import type { AgentFeatures, AgentProvider } from "@mcp-cli/core";
-import type { GridResult, GridTest } from "./grid-test.js";
+import type { GridResult, GridTest } from "./grid-test";
 
 /** Check which required features a provider lacks. */
 export function missingFeatures(provider: AgentProvider, requires: (keyof AgentFeatures)[]): (keyof AgentFeatures)[] {

--- a/agent-grid/src/capability-gate.ts
+++ b/agent-grid/src/capability-gate.ts
@@ -1,0 +1,24 @@
+import type { AgentFeatures, AgentProvider } from "@mcp-cli/core";
+import type { GridResult, GridTest } from "./grid-test.js";
+
+/** Check which required features a provider lacks. */
+export function missingFeatures(provider: AgentProvider, requires: (keyof AgentFeatures)[]): (keyof AgentFeatures)[] {
+  return requires.filter((f) => provider.native[f] !== true);
+}
+
+/**
+ * Gate a test against a provider's capabilities.
+ * Returns a skip result if the provider lacks any required feature,
+ * or null if the test should proceed.
+ */
+export function gateTest(test: GridTest, provider: AgentProvider): GridResult | null {
+  if (test.requires.length === 0) return null;
+
+  const missing = missingFeatures(provider, test.requires);
+  if (missing.length === 0) return null;
+
+  return {
+    status: "n/a",
+    reason: `provider "${provider.name}" lacks: ${missing.join(", ")}`,
+  };
+}

--- a/agent-grid/src/grid-test.ts
+++ b/agent-grid/src/grid-test.ts
@@ -1,0 +1,17 @@
+import type { AgentFeatures, AgentProvider } from "@mcp-cli/core";
+
+/** Outcome of a single grid test execution. */
+export type GridResult = { status: "pass" } | { status: "fail"; error: string } | { status: "n/a"; reason: string };
+
+/** Context provided to each grid test's run function. */
+export interface GridTestContext {
+  provider: AgentProvider;
+  cwd: string;
+}
+
+/** A single capability test in the agent grid. */
+export interface GridTest {
+  name: string;
+  requires: (keyof AgentFeatures)[];
+  run(ctx: GridTestContext): Promise<GridResult>;
+}

--- a/agent-grid/src/index.ts
+++ b/agent-grid/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./grid-test.js";
+export * from "./capability-gate.js";

--- a/agent-grid/src/index.ts
+++ b/agent-grid/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./grid-test.js";
-export * from "./capability-gate.js";
+export * from "./grid-test";
+export * from "./capability-gate";

--- a/agent-grid/tsconfig.json
+++ b/agent-grid/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,13 @@
         "playwright": "^1.58.0",
       },
     },
+    "agent-grid": {
+      "name": "@mcp-cli/agent-grid",
+      "version": "0.1.0",
+      "dependencies": {
+        "@mcp-cli/core": "workspace:*",
+      },
+    },
     "packages/acp": {
       "name": "@mcp-cli/acp",
       "version": "0.1.0",
@@ -127,6 +134,8 @@
     "@hono/node-server": ["@hono/node-server@1.19.11", "", { "peerDependencies": { "hono": "^4" } }, "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g=="],
 
     "@mcp-cli/acp": ["@mcp-cli/acp@workspace:packages/acp"],
+
+    "@mcp-cli/agent-grid": ["@mcp-cli/agent-grid@workspace:agent-grid"],
 
     "@mcp-cli/clone": ["@mcp-cli/clone@workspace:packages/clone"],
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "version": "1.13.0",
   "description": "MCP CLI — call MCP server tools from the command line with zero context overhead",
   "type": "module",
-  "workspaces": ["packages/*"],
+  "workspaces": ["packages/*", "agent-grid"],
   "bin": {
     "mcx": "bin/mcx.js",
     "mcpd": "bin/mcpd.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,9 +32,11 @@
       "@mcp-cli/control": ["./packages/control/src/main.tsx"],
       "@mcp-cli/control/*": ["./packages/control/src/*"],
       "@mcp-cli/clone": ["./packages/clone/src/index.ts"],
-      "@mcp-cli/clone/*": ["./packages/clone/src/*"]
+      "@mcp-cli/clone/*": ["./packages/clone/src/*"],
+      "@mcp-cli/agent-grid": ["./agent-grid/src/index.ts"],
+      "@mcp-cli/agent-grid/*": ["./agent-grid/src/*"]
     }
   },
-  "include": ["packages/*/src/**/*.ts", "packages/*/src/**/*.tsx", "test/**/*.ts"],
+  "include": ["packages/*/src/**/*.ts", "packages/*/src/**/*.tsx", "agent-grid/src/**/*.ts", "test/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- Scaffolds `agent-grid/` as a Bun workspace package (`@mcp-cli/agent-grid`) with package.json, tsconfig, and barrel exports
- Implements capability gating: `GridTest` interface with `requires: (keyof AgentFeatures)[]` and `gateTest()` that returns `n/a` with reason when a provider lacks required features
- Wires into root workspace config (`package.json` workspaces, `tsconfig.json` paths + include)

## Test plan
- [x] `capability-gate.spec.ts` — 10 tests covering: full-feature provider passes, missing features skip with reason, empty requires passes, partial overlap, absent keys treated as missing, mock provider gating
- [x] `bun typecheck` passes
- [x] `bun lint:check` passes (biome formatted)
- [x] `bun run doing-it-wrong` — 0 violations
- [x] Pre-commit + pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)