### PR TITLE
test(daemon): add version negotiation handshake tests for MockServer and SiteServer (fixes #2569)

### DIFF
--- a/packages/daemon/src/mock-server.spec.ts
+++ b/packages/daemon/src/mock-server.spec.ts
@@ -1,8 +1,16 @@
-import { afterAll, afterEach, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { afterAll, afterEach, beforeEach, describe, expect, mock, setDefaultTimeout, test } from "bun:test";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { MOCK_SERVER_NAME, NdjsonRecorder, type RecordingEntry, silentLogger } from "@mcp-cli/core";
+import {
+  AGENT_PROTOCOL_VERSION,
+  MOCK_SERVER_NAME,
+  NdjsonRecorder,
+  ProtocolVersionMismatchError,
+  type RecordingEntry,
+  silentLogger,
+} from "@mcp-cli/core";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { pollUntil } from "../../../test/harness";
 import { testOptions } from "../../../test/test-options";
 import { StateDb } from "./db/state";
@@ -335,6 +343,92 @@ describe("MockServer", () => {
     expect(server.hasActiveSessions()).toBe(false);
     const row = db.getSession("stale-1");
     expect(row?.state).toBe("ended");
+  });
+});
+
+// ── Protocol version negotiation ──
+
+describe("MockServer protocol version negotiation", () => {
+  let server: MockServer | undefined;
+  let db: StateDb | undefined;
+
+  afterEach(async () => {
+    await server?.stop();
+    db?.close();
+    server = undefined;
+    db = undefined;
+  });
+
+  function fakeWorkerFactory(readyPayload: Record<string, unknown>) {
+    return (_scriptPath: string): Worker => {
+      const w = {
+        postMessage: mock((_msg: unknown) => {
+          queueMicrotask(() => {
+            w.onmessage?.({ data: { type: "ready", ...readyPayload } } as MessageEvent);
+          });
+        }),
+        terminate: mock(() => {}),
+        addEventListener: mock(() => {}),
+        removeEventListener: mock(() => {}),
+        onmessage: null as ((event: MessageEvent) => void) | null,
+        onerror: null as ((event: ErrorEvent | Event) => void) | null,
+      };
+      return w as unknown as Worker;
+    };
+  }
+
+  const instantClient = () =>
+    ({
+      connect: async () => {},
+      close: async () => {},
+    }) as unknown as Client;
+
+  test("accepts ready with matching supported_protocol_version", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new MockServer(
+      db,
+      undefined,
+      instantClient,
+      silentLogger,
+      2_000,
+      fakeWorkerFactory({ supported_protocol_version: AGENT_PROTOCOL_VERSION }),
+    );
+
+    await expect(server.start()).resolves.toBeDefined();
+  });
+
+  test("accepts ready without supported_protocol_version (backwards-compatible)", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    server = new MockServer(db, undefined, instantClient, silentLogger, 2_000, fakeWorkerFactory({}));
+
+    await expect(server.start()).resolves.toBeDefined();
+  });
+
+  test("rejects ready with mismatched supported_protocol_version", async () => {
+    using opts = testOptions();
+    db = new StateDb(opts.DB_PATH);
+    const mismatchedVersion = AGENT_PROTOCOL_VERSION + 1;
+    server = new MockServer(
+      db,
+      undefined,
+      instantClient,
+      silentLogger,
+      2_000,
+      fakeWorkerFactory({ supported_protocol_version: mismatchedVersion }),
+    );
+
+    try {
+      await server.start();
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProtocolVersionMismatchError);
+      const pErr = err as ProtocolVersionMismatchError;
+      expect(pErr.requested).toBe(AGENT_PROTOCOL_VERSION);
+      expect(pErr.supported).toBe(mismatchedVersion);
+      expect(pErr.message).toContain("agent-protocol.md");
+    }
   });
 });
 

--- a/packages/daemon/src/mock-server.ts
+++ b/packages/daemon/src/mock-server.ts
@@ -93,6 +93,7 @@ export function isWorkerEvent(data: unknown): data is WorkerEvent {
 // ── Server ──
 
 type ClientFactory = () => Client;
+type WorkerFactory = (scriptPath: string) => Worker;
 
 export class MockServer {
   private worker: Worker | null = null;
@@ -100,6 +101,7 @@ export class MockServer {
   private client: Client | null = null;
   private db: StateDb;
   private readonly clientFactory: ClientFactory;
+  private readonly workerFactory: WorkerFactory;
   private readonly activeSessions = new Set<string>();
   private readonly sessionAddedAt = new Map<string, number>();
   private readonly logger: Logger;
@@ -115,16 +117,18 @@ export class MockServer {
     clientFactory?: ClientFactory,
     logger?: Logger,
     private handshakeTimeoutMs = 10_000,
+    workerFactory?: WorkerFactory,
   ) {
     this.db = db;
     this.clientFactory = clientFactory ?? (() => new Client({ name: `mcp-cli/${MOCK_SERVER_NAME}`, version: "0.1.0" }));
+    this.workerFactory = workerFactory ?? ((scriptPath: string) => new Worker(scriptPath));
     this.logger = logger ?? consoleLogger;
   }
 
   /** Start the worker and connect the MCP client. */
   async start(): Promise<{ client: Client; transport: WorkerClientTransport }> {
     if (this.worker) throw new Error("start() called while worker is already running");
-    const worker = new Worker(workerPath("mock-session-worker.ts"));
+    const worker = this.workerFactory(workerPath("mock-session-worker.ts"));
     this.worker = worker;
 
     // Wait for the worker to report ready

--- a/packages/daemon/src/site-server.spec.ts
+++ b/packages/daemon/src/site-server.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { SITE_SERVER_NAME, silentLogger } from "@mcp-cli/core";
+import { AGENT_PROTOCOL_VERSION, ProtocolVersionMismatchError, SITE_SERVER_NAME, silentLogger } from "@mcp-cli/core";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { SiteServer, buildSiteToolCache, isWorkerEvent } from "./site-server";
 import { SITE_TOOLS } from "./site/tools";
@@ -128,6 +128,71 @@ describe("SiteServer", () => {
     const workerFactory = (_path: string): Worker => makeFakeWorker({ replyReady: false });
     server = new SiteServer(undefined, undefined, workerFactory, silentLogger, 250);
     await expect(server.start()).rejects.toThrow(/timeout/);
+  });
+});
+
+describe("SiteServer protocol version negotiation", () => {
+  let server: SiteServer | undefined;
+
+  afterEach(async () => {
+    await server?.stop();
+    server = undefined;
+  });
+
+  function versionWorkerFactory(readyPayload: Record<string, unknown>) {
+    return (_scriptPath: string): Worker => {
+      const w = {
+        postMessage: mock((_msg: unknown) => {
+          queueMicrotask(() => {
+            w.onmessage?.({ data: { type: "ready", ...readyPayload } } as MessageEvent);
+          });
+        }),
+        terminate: mock(() => {}),
+        addEventListener: mock(() => {}),
+        removeEventListener: mock(() => {}),
+        onmessage: null as ((event: MessageEvent) => void) | null,
+        onerror: null as ((event: ErrorEvent | Event) => void) | null,
+      };
+      return w as unknown as Worker;
+    };
+  }
+
+  test("accepts ready with matching supported_protocol_version", async () => {
+    server = new SiteServer(
+      undefined,
+      instantClient,
+      versionWorkerFactory({ supported_protocol_version: AGENT_PROTOCOL_VERSION }),
+      silentLogger,
+      2_000,
+    );
+    await expect(server.start()).resolves.toBeDefined();
+  });
+
+  test("accepts ready without supported_protocol_version (backwards-compatible)", async () => {
+    server = new SiteServer(undefined, instantClient, versionWorkerFactory({}), silentLogger, 2_000);
+    await expect(server.start()).resolves.toBeDefined();
+  });
+
+  test("rejects ready with mismatched supported_protocol_version", async () => {
+    const mismatchedVersion = AGENT_PROTOCOL_VERSION + 1;
+    server = new SiteServer(
+      undefined,
+      instantClient,
+      versionWorkerFactory({ supported_protocol_version: mismatchedVersion }),
+      silentLogger,
+      2_000,
+    );
+
+    try {
+      await server.start();
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProtocolVersionMismatchError);
+      const pErr = err as ProtocolVersionMismatchError;
+      expect(pErr.requested).toBe(AGENT_PROTOCOL_VERSION);
+      expect(pErr.supported).toBe(mismatchedVersion);
+      expect(pErr.message).toContain("agent-protocol.md");
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Add `workerFactory` injection point to `MockServer` (matches existing `SiteServer` pattern) so tests can drive the handshake without spawning a real Worker
- Add 3 protocol version negotiation tests each to `mock-server.spec.ts` and `site-server.spec.ts`: matching version (accepted), missing version (backwards-compat accepted), mismatched version (rejects with `ProtocolVersionMismatchError`)

## Test plan
- [x] `bun test packages/daemon/src/mock-server.spec.ts` — 37 tests pass (3 new)
- [x] `bun test packages/daemon/src/site-server.spec.ts` — 19 tests pass (3 new)
- [x] `bun run am-i-done` — typecheck, lint, rules, tests all pass
- [x] Pre-commit and pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)