### PR TITLE
feat(core): PII/secret sanitizer library + pre-commit hook (fixes #2580)

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -56,8 +56,15 @@ if [ -n "$recording_files" ]; then
   # binaries. These can't be text-scanned so they must be blocked outright
   # (raw binaries should go through LFS; only LFS pointer files are text).
   # shellcheck disable=SC2086
-  binary_files=$(git diff --cached --numstat -- $recording_files \
-    | awk '$1 == "-" && $2 == "-" { print $3 }' || true)
+  binary_numstat=$(git diff --cached --numstat -- $recording_files) || {
+    echo "pre-commit: git diff --numstat failed (fail-closed)" >&2
+    exit 1
+  }
+  binary_files=$(printf '%s\n' "$binary_numstat" \
+    | awk '$1 == "-" && $2 == "-" { print $3 }') || {
+    echo "pre-commit: binary detection failed (fail-closed)" >&2
+    exit 1
+  }
   if [ -n "$binary_files" ]; then
     echo "pre-commit: staged binary files in recordings/ or binaries/ cannot be scanned for secrets" >&2
     printf '%s\n' "$binary_files" | head -10 >&2
@@ -68,8 +75,18 @@ if [ -n "$recording_files" ]; then
   # Extract added text lines from diff. Filter out only the "+++ b/..."
   # file-header lines (3 plusses), keeping real content that starts with "+".
   # shellcheck disable=SC2086
-  added_content=$(git diff --cached -U0 --no-color -- $recording_files \
-    | grep -E '^\+' | grep -v '^\+\+\+' | sed 's/^\+//' || true)
+  diff_output=$(git diff --cached -U0 --no-color -- $recording_files) || {
+    echo "pre-commit: git diff failed (fail-closed)" >&2
+    exit 1
+  }
+  added_content=$(printf '%s\n' "$diff_output" \
+    | grep -E '^\+' | grep -v '^\+\+\+' | sed 's/^\+//') || {
+    rc=$?
+    if [ "$rc" -gt 1 ]; then
+      echo "pre-commit: content extraction failed (fail-closed)" >&2
+      exit 1
+    fi
+  }
   if [ -n "$added_content" ]; then
     HOOK_DIR_ABS="$(cd "$HOOK_DIR/.." && pwd)"
     if ! printf '%s\n' "$added_content" | bun run "$HOOK_DIR_ABS/scripts/scan-secrets.ts"; then

--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -52,11 +52,12 @@ fi
 # any scanner error is treated as a match (safe default).
 recording_files=$(echo "$staged_files" | grep -E '^(recordings/|agent-grid/binaries/)' || true)
 if [ -n "$recording_files" ]; then
+  # shellcheck disable=SC2086 — $recording_files is newline-delimited paths from git; quoting would pass as single arg
   added_content=$(git diff --cached -U0 --no-color -- $recording_files \
     | grep -E '^\+[^+]' | sed 's/^\+//' || true)
   if [ -n "$added_content" ]; then
     HOOK_DIR_ABS="$(cd "$HOOK_DIR/.." && pwd)"
-    if ! echo "$added_content" | bun run "$HOOK_DIR_ABS/scripts/scan-secrets.ts" 2>/dev/null; then
+    if ! printf '%s\n' "$added_content" | bun run "$HOOK_DIR_ABS/scripts/scan-secrets.ts"; then
       echo "pre-commit: refusing to stage files with unsanitized secrets in recordings/ or binaries/" >&2
       echo "Run the sanitizer on the files before committing, or bypass with:" >&2
       echo "  SKIP_PRIVACY_CHECK=1 git commit ..." >&2

--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -52,9 +52,24 @@ fi
 # any scanner error is treated as a match (safe default).
 recording_files=$(echo "$staged_files" | grep -E '^(recordings/|agent-grid/binaries/)' || true)
 if [ -n "$recording_files" ]; then
-  # shellcheck disable=SC2086 — $recording_files is newline-delimited paths from git; quoting would pass as single arg
+  # Fail-closed on binary files: git diff --numstat shows "-\t-\t<path>" for
+  # binaries. These can't be text-scanned so they must be blocked outright
+  # (raw binaries should go through LFS; only LFS pointer files are text).
+  # shellcheck disable=SC2086
+  binary_files=$(git diff --cached --numstat -- $recording_files \
+    | awk '$1 == "-" && $2 == "-" { print $3 }' || true)
+  if [ -n "$binary_files" ]; then
+    echo "pre-commit: staged binary files in recordings/ or binaries/ cannot be scanned for secrets" >&2
+    printf '%s\n' "$binary_files" | head -10 >&2
+    echo "Use LFS for binary content, or run the sanitizer on text equivalents." >&2
+    exit 1
+  fi
+
+  # Extract added text lines from diff. Filter out only the "+++ b/..."
+  # file-header lines (3 plusses), keeping real content that starts with "+".
+  # shellcheck disable=SC2086
   added_content=$(git diff --cached -U0 --no-color -- $recording_files \
-    | grep -E '^\+[^+]' | sed 's/^\+//' || true)
+    | grep -E '^\+' | grep -v '^\+\+\+' | sed 's/^\+//' || true)
   if [ -n "$added_content" ]; then
     HOOK_DIR_ABS="$(cd "$HOOK_DIR/.." && pwd)"
     if ! printf '%s\n' "$added_content" | bun run "$HOOK_DIR_ABS/scripts/scan-secrets.ts"; then

--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -59,8 +59,7 @@ if [ -n "$recording_files" ]; then
     HOOK_DIR_ABS="$(cd "$HOOK_DIR/.." && pwd)"
     if ! printf '%s\n' "$added_content" | bun run "$HOOK_DIR_ABS/scripts/scan-secrets.ts"; then
       echo "pre-commit: refusing to stage files with unsanitized secrets in recordings/ or binaries/" >&2
-      echo "Run the sanitizer on the files before committing, or bypass with:" >&2
-      echo "  SKIP_PRIVACY_CHECK=1 git commit ..." >&2
+      echo "Run the sanitizer on the files before committing." >&2
       exit 1
     fi
   fi

--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -47,6 +47,24 @@ if [ -z "${SKIP_PRIVACY_CHECK:-}" ]; then
   fi
 fi
 
+# Secret/PII sanitizer gate: reject staged additions to recordings/ or
+# agent-grid/binaries/ that contain secret-shaped content. Fail-closed:
+# any scanner error is treated as a match (safe default).
+recording_files=$(echo "$staged_files" | grep -E '^(recordings/|agent-grid/binaries/)' || true)
+if [ -n "$recording_files" ]; then
+  added_content=$(git diff --cached -U0 --no-color -- $recording_files \
+    | grep -E '^\+[^+]' | sed 's/^\+//' || true)
+  if [ -n "$added_content" ]; then
+    HOOK_DIR_ABS="$(cd "$HOOK_DIR/.." && pwd)"
+    if ! echo "$added_content" | bun run "$HOOK_DIR_ABS/scripts/scan-secrets.ts" 2>/dev/null; then
+      echo "pre-commit: refusing to stage files with unsanitized secrets in recordings/ or binaries/" >&2
+      echo "Run the sanitizer on the files before committing, or bypass with:" >&2
+      echo "  SKIP_PRIVACY_CHECK=1 git commit ..." >&2
+      exit 1
+    fi
+  fi
+fi
+
 # Classify staged files into tiers
 # shellcheck source=classify.sh
 source "$HOOK_DIR/classify.sh"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -58,6 +58,7 @@ export * from "./sprint-plan";
 export * from "./claude-patch";
 export * from "./automation";
 export * from "./recording";
+export * from "./sanitizer";
 export * from "./subprocess";
 export * from "./mcp-result";
 export * from "./lookup-result";

--- a/packages/core/src/recording.ts
+++ b/packages/core/src/recording.ts
@@ -1,5 +1,6 @@
 import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
+import { sanitizeJsonPayload } from "./sanitizer";
 
 /**
  * Message direction on the daemon↔worker boundary.
@@ -69,7 +70,8 @@ export class NdjsonRecorder {
         kind,
         payload,
       };
-      this.writer.write(`${JSON.stringify(entry)}\n`);
+      const { sanitized } = sanitizeJsonPayload(entry);
+      this.writer.write(`${JSON.stringify(sanitized)}\n`);
     } catch {
       // Recording must never disrupt the protocol path.
     }

--- a/packages/core/src/sanitizer.spec.ts
+++ b/packages/core/src/sanitizer.spec.ts
@@ -20,6 +20,16 @@ describe("scanSecrets", () => {
       const result = scanSecrets("AKIA_SHORT");
       expect(result.matches.some((m) => m.pattern === "aws-access-key")).toBe(false);
     });
+
+    test("ignores git SHA-1 hashes (40 hex chars)", () => {
+      const result = scanSecrets("commit e2b5eb6721f62f7b6da14bbab9ab9380cadc080c");
+      expect(result.matches.some((m) => m.pattern === "aws-secret-key")).toBe(false);
+    });
+
+    test("ignores SHA-1 of empty string (all hex)", () => {
+      const result = scanSecrets("da39a3ee5e6b4b0d3255bfef95601890afd80709");
+      expect(result.matches.some((m) => m.pattern === "aws-secret-key")).toBe(false);
+    });
   });
 
   describe("JWTs", () => {
@@ -88,6 +98,26 @@ describe("scanSecrets", () => {
     test("detects ANTHROPIC_API_KEY", () => {
       const result = scanSecrets("ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxxxxxxxxxx");
       expect(result.clean).toBe(false);
+    });
+
+    test("preserves key name when sanitizing env-key-value", () => {
+      const result = sanitizeText('"API_KEY": "super-secret-key-value-1234"');
+      expect(result.text).toContain("API_KEY");
+      expect(result.text).toContain("[REDACTED:");
+      expect(result.text).not.toContain("super-secret");
+    });
+
+    test("preserves key name when sanitizing well-known-env", () => {
+      const result = sanitizeText("GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1234");
+      expect(result.text).toContain("GITHUB_TOKEN=");
+      expect(result.text).toContain("[REDACTED:");
+      expect(result.text).not.toContain("ghp_");
+    });
+
+    test("preserves separator when sanitizing well-known-env with JSON", () => {
+      const result = sanitizeText('"ANTHROPIC_API_KEY": "sk-ant-xxxxxxxxxxxxxxxxxxxx"');
+      expect(result.text).toContain("ANTHROPIC_API_KEY");
+      expect(result.text).toContain("[REDACTED:");
     });
   });
 
@@ -467,6 +497,7 @@ describe("negative tests: non-secrets pass through unchanged", () => {
     "password: ********",
     "[REDACTED:aws-access-key] already sanitized",
     "10.0.0.1",
+    "e2b5eb6721f62f7b6da14bbab9ab9380cadc080c",
   ];
 
   for (const input of SAFE_INPUTS) {

--- a/packages/core/src/sanitizer.spec.ts
+++ b/packages/core/src/sanitizer.spec.ts
@@ -1,390 +1,442 @@
 import { describe, expect, test } from "bun:test";
-import {
-  ResidualSecretError,
-  type SanitizeResult,
-  assertClean,
-  sanitizeJsonPayload,
-  sanitizeText,
-  scanSecrets,
-} from "./sanitizer";
+import { ResidualSecretError, assertClean, sanitizeJsonPayload, sanitizeText, scanSecrets } from "./sanitizer";
 
-describe("scanSecrets", () => {
-  describe("AWS keys", () => {
-    test("detects AWS access key IDs", () => {
-      const result = scanSecrets("key = AKIAIOSFODNN7EXAMPLE");
-      expect(result.clean).toBe(false);
-      expect(result.matches.some((m) => m.pattern === "aws-access-key")).toBe(true);
-    });
+// ── AWS ────────────────────────────────────────────────────────────
 
-    test("ignores partial AKIA prefix without full length", () => {
-      const result = scanSecrets("AKIA_SHORT");
-      expect(result.matches.some((m) => m.pattern === "aws-access-key")).toBe(false);
-    });
-
-    test("ignores git SHA-1 hashes (40 hex chars)", () => {
-      const result = scanSecrets("commit e2b5eb6721f62f7b6da14bbab9ab9380cadc080c");
-      expect(result.matches.some((m) => m.pattern === "aws-secret-key")).toBe(false);
-    });
-
-    test("ignores SHA-1 of empty string (all hex)", () => {
-      const result = scanSecrets("da39a3ee5e6b4b0d3255bfef95601890afd80709");
-      expect(result.matches.some((m) => m.pattern === "aws-secret-key")).toBe(false);
-    });
+describe("scanSecrets / AWS", () => {
+  test("detects AKIA long-lived access key", () => {
+    const r = scanSecrets("key = AKIAIOSFODNN7EXAMPLE");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "aws-access-key")).toBe(true);
   });
 
-  describe("JWTs", () => {
-    test("detects JWT tokens", () => {
-      const jwt =
-        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U";
-      const result = scanSecrets(`token: ${jwt}`);
-      expect(result.clean).toBe(false);
-      expect(result.matches.some((m) => m.pattern === "jwt")).toBe(true);
-    });
-
-    test("ignores strings that look JWT-ish but have only two segments", () => {
-      const result = scanSecrets("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0");
-      expect(result.matches.some((m) => m.pattern === "jwt")).toBe(false);
-    });
+  test("detects ASIA STS temporary access key", () => {
+    const r = scanSecrets("key = ASIAJEXAMPLEXEG456NY");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "aws-access-key")).toBe(true);
   });
 
-  describe("Authorization headers", () => {
-    test("detects Bearer token in header", () => {
-      const result = scanSecrets('"Authorization": "Bearer sk-1234567890abcdefghijk"');
-      expect(result.clean).toBe(false);
-      expect(result.matches.some((m) => m.pattern === "authorization-header")).toBe(true);
-    });
-
-    test("detects Basic auth in header", () => {
-      const result = scanSecrets('"Authorization": "Basic dXNlcjpwYXNzd29yZDEyMzQ1"');
-      expect(result.clean).toBe(false);
-      expect(result.matches.some((m) => m.pattern === "authorization-header")).toBe(true);
-    });
-
-    test("does not flag the word Authorization in prose", () => {
-      const result = scanSecrets("The Authorization flow requires a redirect");
-      expect(result.matches.some((m) => m.pattern === "authorization-header")).toBe(false);
-    });
+  test("ignores partial AKIA prefix without full length", () => {
+    const r = scanSecrets("AKIA_SHORT");
+    expect(r.matches.some((m) => m.pattern === "aws-access-key")).toBe(false);
   });
 
-  describe("API key headers", () => {
-    test("detects X-API-Key header value", () => {
-      const result = scanSecrets('"X-API-Key": "abcdef1234567890abcdef"');
-      expect(result.clean).toBe(false);
-      expect(result.matches.some((m) => m.pattern === "generic-api-key-header")).toBe(true);
-    });
+  test("ignores git SHA-1 hashes (40 hex chars)", () => {
+    const r = scanSecrets("commit e2b5eb6721f62f7b6da14bbab9ab9380cadc080c");
+    expect(r.matches.some((m) => m.pattern === "aws-secret-key")).toBe(false);
   });
 
-  describe("environment variable secrets", () => {
-    test("detects GITHUB_TOKEN assignment", () => {
-      const result = scanSecrets("GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1234");
-      expect(result.clean).toBe(false);
-    });
-
-    test("detects API_KEY in JSON", () => {
-      const result = scanSecrets('{"API_KEY": "super-secret-key-value-1234"}');
-      expect(result.clean).toBe(false);
-    });
-
-    test("detects DATABASE_URL with credentials", () => {
-      const result = scanSecrets("DATABASE_URL=postgres://user:password123@host:5432/db");
-      expect(result.clean).toBe(false);
-    });
-
-    test("detects CLIENT_SECRET", () => {
-      const result = scanSecrets('"CLIENT_SECRET": "a1b2c3d4e5f6g7h8i9j0klmn"');
-      expect(result.clean).toBe(false);
-    });
-
-    test("detects ANTHROPIC_API_KEY", () => {
-      const result = scanSecrets("ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxxxxxxxxxx");
-      expect(result.clean).toBe(false);
-    });
-
-    test("preserves key name when sanitizing env-key-value", () => {
-      const result = sanitizeText('"API_KEY": "super-secret-key-value-1234"');
-      expect(result.text).toContain("API_KEY");
-      expect(result.text).toContain("[REDACTED:");
-      expect(result.text).not.toContain("super-secret");
-    });
-
-    test("preserves key name when sanitizing well-known-env", () => {
-      const result = sanitizeText("GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1234");
-      expect(result.text).toContain("GITHUB_TOKEN=");
-      expect(result.text).toContain("[REDACTED:");
-      expect(result.text).not.toContain("ghp_");
-    });
-
-    test("preserves separator when sanitizing well-known-env with JSON", () => {
-      const result = sanitizeText('"ANTHROPIC_API_KEY": "sk-ant-xxxxxxxxxxxxxxxxxxxx"');
-      expect(result.text).toContain("ANTHROPIC_API_KEY");
-      expect(result.text).toContain("[REDACTED:");
-    });
-  });
-
-  describe("GitHub tokens", () => {
-    test("detects ghp_ personal access token", () => {
-      const result = scanSecrets("token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij");
-      expect(result.clean).toBe(false);
-      expect(result.matches.some((m) => m.pattern === "github-token")).toBe(true);
-    });
-
-    test("detects gho_ OAuth token", () => {
-      const result = scanSecrets("gho_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij");
-      expect(result.clean).toBe(false);
-    });
-
-    test("detects ghs_ server-to-server token", () => {
-      const result = scanSecrets("ghs_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij");
-      expect(result.clean).toBe(false);
-    });
-  });
-
-  describe("npm tokens", () => {
-    test("detects npm_ token", () => {
-      const result = scanSecrets("npm_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij12");
-      expect(result.clean).toBe(false);
-      expect(result.matches.some((m) => m.pattern === "npm-token")).toBe(true);
-    });
-  });
-
-  describe("Slack tokens", () => {
-    test("detects xoxb- bot token", () => {
-      const result = scanSecrets("xoxb-1234567890-abcdefghij");
-      expect(result.clean).toBe(false);
-      expect(result.matches.some((m) => m.pattern === "slack-token")).toBe(true);
-    });
-
-    test("detects xoxp- user token", () => {
-      const result = scanSecrets("xoxp-1234567890-abcdefghij");
-      expect(result.clean).toBe(false);
-    });
-  });
-
-  describe("Stripe keys", () => {
-    test("detects sk_live_ secret key", () => {
-      const result = scanSecrets("sk_live_TESTONLY00000000000000x");
-      expect(result.clean).toBe(false);
-      expect(result.matches.some((m) => m.pattern === "stripe-key")).toBe(true);
-    });
-
-    test("detects sk_test_ test key", () => {
-      const result = scanSecrets("sk_test_TESTONLY00000000000000x");
-      expect(result.clean).toBe(false);
-    });
-  });
-
-  describe("private key blocks", () => {
-    test("detects RSA private key", () => {
-      const key = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA...\n-----END RSA PRIVATE KEY-----";
-      const result = scanSecrets(key);
-      expect(result.clean).toBe(false);
-      expect(result.matches.some((m) => m.pattern === "private-key-block")).toBe(true);
-    });
-
-    test("detects generic private key block", () => {
-      const key = "-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----";
-      const result = scanSecrets(key);
-      expect(result.clean).toBe(false);
-    });
-  });
-
-  describe("emails", () => {
-    test("detects email addresses", () => {
-      const result = scanSecrets("contact: alice.smith@acmecorp.com");
-      expect(result.clean).toBe(false);
-      expect(result.matches.some((m) => m.pattern === "email")).toBe(true);
-    });
-
-    test("allows example.com emails (false positive)", () => {
-      const result = scanSecrets("test@example.com");
-      expect(result.matches.some((m) => m.pattern === "email")).toBe(false);
-    });
-
-    test("allows noreply@anthropic.com", () => {
-      const result = scanSecrets("Co-Authored-By: Claude <noreply@anthropic.com>");
-      expect(result.matches.some((m) => m.pattern === "email")).toBe(false);
-    });
-
-    test("allows GitHub noreply addresses", () => {
-      const result = scanSecrets("user@users.noreply.github.com");
-      expect(result.matches.some((m) => m.pattern === "email")).toBe(false);
-    });
-  });
-
-  describe("IP addresses", () => {
-    test("detects IPv4 addresses", () => {
-      const result = scanSecrets("server: 172.16.254.1");
-      expect(result.clean).toBe(false);
-      expect(result.matches.some((m) => m.pattern === "ipv4")).toBe(true);
-    });
-
-    test("detects IPv6 addresses", () => {
-      const result = scanSecrets("addr: 2001:0db8:85a3:0000:0000:8a2e:0370:7334");
-      expect(result.clean).toBe(false);
-      expect(result.matches.some((m) => m.pattern === "ipv6")).toBe(true);
-    });
-
-    test("allows localhost 127.0.0.1", () => {
-      const result = scanSecrets("bind: 127.0.0.1");
-      expect(result.matches.some((m) => m.pattern === "ipv4")).toBe(false);
-    });
-
-    test("allows 0.0.0.0", () => {
-      const result = scanSecrets("listen: 0.0.0.0");
-      expect(result.matches.some((m) => m.pattern === "ipv4")).toBe(false);
-    });
-
-    test("allows 10.0.0.x range", () => {
-      const result = scanSecrets("bind: 10.0.0.1");
-      expect(result.matches.some((m) => m.pattern === "ipv4")).toBe(false);
-    });
-
-    test("allows subnet masks", () => {
-      const result = scanSecrets("mask: 255.255.255.0");
-      expect(result.matches.some((m) => m.pattern === "ipv4")).toBe(false);
-    });
-
-    test("allows RFC 5737 documentation IPs", () => {
-      const result = scanSecrets("example: 192.0.2.1 and 198.51.100.1 and 203.0.113.1");
-      expect(result.matches.some((m) => m.pattern === "ipv4")).toBe(false);
-    });
-  });
-
-  describe("home paths", () => {
-    test("detects /Users/<name>/ paths", () => {
-      const result = scanSecrets("path: /Users/johndoe/projects/secret");
-      expect(result.clean).toBe(false);
-      expect(result.matches.some((m) => m.pattern === "home-path")).toBe(true);
-    });
-
-    test("detects /home/<name>/ paths", () => {
-      const result = scanSecrets("path: /home/ubuntu/.ssh/id_rsa");
-      expect(result.clean).toBe(false);
-    });
-
-    test("detects Claude-style slug paths (macOS)", () => {
-      const result = scanSecrets("dir: -Users-johndoe-projects");
-      expect(result.clean).toBe(false);
-      expect(result.matches.some((m) => m.pattern === "home-path-slug")).toBe(true);
-    });
-
-    test("detects Linux home slug paths (-home-alice-)", () => {
-      const result = scanSecrets("dir: -home-alice-project-foo");
-      expect(result.clean).toBe(false);
-      expect(result.matches.some((m) => m.pattern === "home-path-slug")).toBe(true);
-    });
-
-    test("allows /Users/Shared/", () => {
-      const result = scanSecrets("/Users/Shared/data");
-      expect(result.matches.some((m) => m.pattern === "home-path")).toBe(false);
-    });
-
-    test("allows /home/runner/ (CI)", () => {
-      const result = scanSecrets("/home/runner/work/project");
-      expect(result.matches.some((m) => m.pattern === "home-path")).toBe(false);
-    });
-  });
-
-  describe("connection strings", () => {
-    test("detects MongoDB URI", () => {
-      const result = scanSecrets("mongodb://admin:password@host:27017/db");
-      expect(result.clean).toBe(false);
-      expect(result.matches.some((m) => m.pattern === "connection-string")).toBe(true);
-    });
-
-    test("detects PostgreSQL URI", () => {
-      const result = scanSecrets("postgres://user:pass@host:5432/mydb");
-      expect(result.clean).toBe(false);
-    });
-
-    test("detects Redis URI", () => {
-      const result = scanSecrets("redis://default:secretpass@redis.example.com:6379");
-      expect(result.clean).toBe(false);
-    });
-  });
-
-  describe("generic secret assignments", () => {
-    test("detects password assignment", () => {
-      const result = scanSecrets('"password": "hunter2-extended-edition"');
-      expect(result.clean).toBe(false);
-    });
-
-    test("detects secret assignment", () => {
-      const result = scanSecrets('"secret": "my-super-secret-value-123"');
-      expect(result.clean).toBe(false);
-    });
-
-    test("does not flag masked passwords (****)", () => {
-      const result = scanSecrets('"password": "********"');
-      expect(result.matches.some((m) => m.pattern === "generic-secret-assignment")).toBe(false);
-    });
+  test("ignores SHA-1 of empty string (all hex)", () => {
+    const r = scanSecrets("da39a3ee5e6b4b0d3255bfef95601890afd80709");
+    expect(r.matches.some((m) => m.pattern === "aws-secret-key")).toBe(false);
   });
 });
 
+// ── GitHub ─────────────────────────────────────────────────────────
+
+describe("scanSecrets / GitHub tokens", () => {
+  test("detects ghp_ personal access token", () => {
+    const r = scanSecrets("token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "github-token")).toBe(true);
+  });
+
+  test("detects gho_ OAuth token", () => {
+    const r = scanSecrets("gho_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "github-token")).toBe(true);
+  });
+
+  test("detects ghs_ server-to-server token", () => {
+    const r = scanSecrets("ghs_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "github-token")).toBe(true);
+  });
+
+  test("detects github_pat_ fine-grained PAT", () => {
+    const token = "github_pat_11ABCDEF0GHIJKLMNOPQRS_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345678";
+    const r = scanSecrets(`token: ${token}`);
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "github-fine-grained-token")).toBe(true);
+  });
+});
+
+// ── JWTs ───────────────────────────────────────────────────────────
+
+describe("scanSecrets / JWTs", () => {
+  test("detects JWT tokens", () => {
+    const jwt =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U";
+    const r = scanSecrets(`token: ${jwt}`);
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "jwt")).toBe(true);
+  });
+
+  test("ignores two-segment eyJ strings", () => {
+    const r = scanSecrets("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0");
+    expect(r.matches.some((m) => m.pattern === "jwt")).toBe(false);
+  });
+});
+
+// ── Authorization headers ──────────────────────────────────────────
+
+describe("scanSecrets / Authorization headers", () => {
+  test("detects Bearer token in header", () => {
+    const r = scanSecrets('"Authorization": "Bearer sk-1234567890abcdefghijk"');
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "authorization-header")).toBe(true);
+  });
+
+  test("detects Basic auth in header", () => {
+    const r = scanSecrets('"Authorization": "Basic dXNlcjpwYXNzd29yZDEyMzQ1"');
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "authorization-header")).toBe(true);
+  });
+
+  test("does not flag the word Authorization in prose", () => {
+    const r = scanSecrets("The Authorization flow requires a redirect");
+    expect(r.matches.some((m) => m.pattern === "authorization-header")).toBe(false);
+  });
+});
+
+// ── API key headers ────────────────────────────────────────────────
+
+describe("scanSecrets / API key headers", () => {
+  test("detects X-API-Key header value", () => {
+    const r = scanSecrets('"X-API-Key": "abcdef1234567890abcdef"');
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "generic-api-key-header")).toBe(true);
+  });
+});
+
+// ── Environment variable secrets ───────────────────────────────────
+
+describe("scanSecrets / env vars", () => {
+  test("detects GITHUB_TOKEN assignment", () => {
+    const r = scanSecrets("GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1234");
+    expect(r.clean).toBe(false);
+  });
+
+  test("detects API_KEY in JSON", () => {
+    const r = scanSecrets('{"API_KEY": "super-secret-key-value-1234"}');
+    expect(r.clean).toBe(false);
+  });
+
+  test("detects DATABASE_URL with credentials", () => {
+    const r = scanSecrets("DATABASE_URL=postgres://user:password123@host:5432/db");
+    expect(r.clean).toBe(false);
+  });
+
+  test("detects CLIENT_SECRET", () => {
+    const r = scanSecrets('"CLIENT_SECRET": "a1b2c3d4e5f6g7h8i9j0klmn"');
+    expect(r.clean).toBe(false);
+  });
+
+  test("detects ANTHROPIC_API_KEY", () => {
+    const r = scanSecrets("ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxxxxxxxxxx");
+    expect(r.clean).toBe(false);
+  });
+
+  test("preserves key name when sanitizing env-key-value", () => {
+    const r = sanitizeText('"API_KEY": "super-secret-key-value-1234"');
+    expect(r.text).toContain("API_KEY");
+    expect(r.text).toContain("[REDACTED:");
+    expect(r.text).not.toContain("super-secret");
+  });
+
+  test("preserves key name when sanitizing well-known-env", () => {
+    const r = sanitizeText("GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1234");
+    expect(r.text).toContain("GITHUB_TOKEN=");
+    expect(r.text).toContain("[REDACTED:");
+    expect(r.text).not.toContain("ghp_");
+  });
+
+  test("preserves separator when sanitizing well-known-env with JSON", () => {
+    const r = sanitizeText('"ANTHROPIC_API_KEY": "sk-ant-xxxxxxxxxxxxxxxxxxxx"');
+    expect(r.text).toContain("ANTHROPIC_API_KEY");
+    expect(r.text).toContain("[REDACTED:");
+  });
+});
+
+// ── Platform tokens ────────────────────────────────────────────────
+
+describe("scanSecrets / platform tokens", () => {
+  test("detects npm_ token", () => {
+    const r = scanSecrets("npm_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij12");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "npm-token")).toBe(true);
+  });
+
+  test("detects xoxb- Slack bot token", () => {
+    const r = scanSecrets("xoxb-1234567890-abcdefghij");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "slack-token")).toBe(true);
+  });
+
+  test("detects xoxp- Slack user token", () => {
+    const r = scanSecrets("xoxp-1234567890-abcdefghij");
+    expect(r.clean).toBe(false);
+  });
+
+  test("detects sk_live_ Stripe secret key", () => {
+    const r = scanSecrets("sk_live_TESTONLY00000000000000x");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "stripe-key")).toBe(true);
+  });
+
+  test("detects sk_test_ Stripe test key", () => {
+    const r = scanSecrets("sk_test_TESTONLY00000000000000x");
+    expect(r.clean).toBe(false);
+  });
+
+  test("detects pypi- token", () => {
+    const r = scanSecrets("pypi-AgEIcHlwaS5vcmcABCDEFGH12345");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "pypi-token")).toBe(true);
+  });
+
+  test("detects sk-ant- Anthropic key literal", () => {
+    const r = scanSecrets("sk-ant-api03-abcdefghijklmnopqrstuv");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "anthropic-api-key")).toBe(true);
+  });
+});
+
+// ── Private key blocks ─────────────────────────────────────────────
+
+describe("scanSecrets / private keys", () => {
+  test("detects RSA private key", () => {
+    const key = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA...\n-----END RSA PRIVATE KEY-----";
+    const r = scanSecrets(key);
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "private-key-block")).toBe(true);
+  });
+
+  test("detects generic private key block", () => {
+    const key = "-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----";
+    const r = scanSecrets(key);
+    expect(r.clean).toBe(false);
+  });
+
+  test("detects encrypted private key block", () => {
+    const key = "-----BEGIN ENCRYPTED PRIVATE KEY-----\nMIIE...\n-----END ENCRYPTED PRIVATE KEY-----";
+    const r = scanSecrets(key);
+    expect(r.clean).toBe(false);
+  });
+});
+
+// ── Emails ─────────────────────────────────────────────────────────
+
+describe("scanSecrets / emails", () => {
+  test("detects email addresses", () => {
+    const r = scanSecrets("contact: alice.smith@acmecorp.com");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "email")).toBe(true);
+  });
+
+  test("allows example.com emails", () => {
+    const r = scanSecrets("test@example.com");
+    expect(r.matches.some((m) => m.pattern === "email")).toBe(false);
+  });
+
+  test("allows noreply@anthropic.com", () => {
+    const r = scanSecrets("Co-Authored-By: Claude <noreply@anthropic.com>");
+    expect(r.matches.some((m) => m.pattern === "email")).toBe(false);
+  });
+
+  test("allows GitHub noreply addresses", () => {
+    const r = scanSecrets("user@users.noreply.github.com");
+    expect(r.matches.some((m) => m.pattern === "email")).toBe(false);
+  });
+
+  test("does not match TLD containing pipe character (regression: [A-Z|a-z] bug)", () => {
+    const r = scanSecrets("user@example.c|m");
+    expect(r.matches.some((m) => m.pattern === "email")).toBe(false);
+  });
+
+  test("matches emails with valid 2+ letter TLDs only", () => {
+    const r = scanSecrets("user@corp.io and admin@test.engineering");
+    expect(r.matches.filter((m) => m.pattern === "email").length).toBe(2);
+  });
+});
+
+// ── IP addresses ───────────────────────────────────────────────────
+
+describe("scanSecrets / IPs", () => {
+  test("detects IPv4 addresses", () => {
+    const r = scanSecrets("server: 172.16.254.1");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "ipv4")).toBe(true);
+  });
+
+  test("detects IPv6 addresses", () => {
+    const r = scanSecrets("addr: 2001:0db8:85a3:0000:0000:8a2e:0370:7334");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "ipv6")).toBe(true);
+  });
+
+  test("allows localhost 127.0.0.1", () => {
+    expect(scanSecrets("bind: 127.0.0.1").matches.some((m) => m.pattern === "ipv4")).toBe(false);
+  });
+
+  test("allows 0.0.0.0", () => {
+    expect(scanSecrets("listen: 0.0.0.0").matches.some((m) => m.pattern === "ipv4")).toBe(false);
+  });
+
+  test("allows 10.0.0.x range", () => {
+    expect(scanSecrets("bind: 10.0.0.1").matches.some((m) => m.pattern === "ipv4")).toBe(false);
+  });
+
+  test("allows subnet masks", () => {
+    expect(scanSecrets("mask: 255.255.255.0").matches.some((m) => m.pattern === "ipv4")).toBe(false);
+  });
+
+  test("allows RFC 5737 documentation IPs", () => {
+    expect(
+      scanSecrets("example: 192.0.2.1 and 198.51.100.1 and 203.0.113.1").matches.some((m) => m.pattern === "ipv4"),
+    ).toBe(false);
+  });
+});
+
+// ── Home paths ─────────────────────────────────────────────────────
+
+describe("scanSecrets / home paths", () => {
+  test("detects /Users/<name>/ paths", () => {
+    const r = scanSecrets("path: /Users/johndoe/projects/secret");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "home-path")).toBe(true);
+  });
+
+  test("detects /home/<name>/ paths", () => {
+    const r = scanSecrets("path: /home/ubuntu/.ssh/id_rsa");
+    expect(r.clean).toBe(false);
+  });
+
+  test("detects macOS Claude slug paths", () => {
+    const r = scanSecrets("dir: -Users-johndoe-projects");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "home-path-slug")).toBe(true);
+  });
+
+  test("detects Linux Claude slug paths (-home-alice-)", () => {
+    const r = scanSecrets("dir: -home-alice-project-foo");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "home-path-slug")).toBe(true);
+  });
+
+  test("allows /Users/Shared/", () => {
+    expect(scanSecrets("/Users/Shared/data").matches.some((m) => m.pattern === "home-path")).toBe(false);
+  });
+
+  test("allows /home/runner/ (CI)", () => {
+    expect(scanSecrets("/home/runner/work/project").matches.some((m) => m.pattern === "home-path")).toBe(false);
+  });
+});
+
+// ── Connection strings ─────────────────────────────────────────────
+
+describe("scanSecrets / connection strings", () => {
+  test("detects MongoDB URI", () => {
+    const r = scanSecrets("mongodb://admin:password@host:27017/db");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "connection-string")).toBe(true);
+  });
+
+  test("detects PostgreSQL URI", () => {
+    const r = scanSecrets("postgres://user:pass@host:5432/mydb");
+    expect(r.clean).toBe(false);
+  });
+
+  test("detects Redis URI", () => {
+    const r = scanSecrets("redis://default:secretpass@redis.example.com:6379");
+    expect(r.clean).toBe(false);
+  });
+});
+
+// ── Generic secret assignments ─────────────────────────────────────
+
+describe("scanSecrets / generic secrets", () => {
+  test("detects password assignment", () => {
+    const r = scanSecrets('"password": "hunter2-extended-edition"');
+    expect(r.clean).toBe(false);
+  });
+
+  test("detects secret assignment", () => {
+    const r = scanSecrets('"secret": "my-super-secret-value-123"');
+    expect(r.clean).toBe(false);
+  });
+
+  test("does not flag masked passwords (****)", () => {
+    expect(scanSecrets('"password": "********"').matches.some((m) => m.pattern === "generic-secret-assignment")).toBe(
+      false,
+    );
+  });
+});
+
+// ── sanitizeText ───────────────────────────────────────────────────
+
 describe("sanitizeText", () => {
   test("replaces secrets with redaction placeholders", () => {
-    const input = "key = AKIAIOSFODNN7EXAMPLE and done";
-    const result = sanitizeText(input);
-    expect(result.text).toContain("[REDACTED:aws-access-key]");
-    expect(result.text).not.toContain("AKIAIOSFODNN7EXAMPLE");
-    expect(result.replacements).toBeGreaterThan(0);
+    const r = sanitizeText("key = AKIAIOSFODNN7EXAMPLE and done");
+    expect(r.text).toContain("[REDACTED:aws-access-key]");
+    expect(r.text).not.toContain("AKIAIOSFODNN7EXAMPLE");
+    expect(r.replacements).toBeGreaterThan(0);
   });
 
   test("replaces JWT tokens", () => {
     const jwt =
       "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U";
-    const result = sanitizeText(`Authorization: Bearer ${jwt}`);
-    expect(result.text).toContain("[REDACTED:");
-    expect(result.text).not.toContain("eyJhbGci");
+    const r = sanitizeText(`Authorization: Bearer ${jwt}`);
+    expect(r.text).toContain("[REDACTED:");
+    expect(r.text).not.toContain("eyJhbGci");
   });
 
   test("replaces home paths", () => {
-    const result = sanitizeText("working in /Users/johndoe/code/project");
-    expect(result.text).toContain("[REDACTED:home-path]");
-    expect(result.text).not.toContain("johndoe");
+    const r = sanitizeText("working in /Users/johndoe/code/project");
+    expect(r.text).toContain("[REDACTED:home-path]");
+    expect(r.text).not.toContain("johndoe");
   });
 
   test("replaces emails", () => {
-    const result = sanitizeText("from alice.smith@acmecorp.com");
-    expect(result.text).toContain("[REDACTED:email]");
-    expect(result.text).not.toContain("alice.smith@acmecorp.com");
+    const r = sanitizeText("from alice.smith@acmecorp.com");
+    expect(r.text).toContain("[REDACTED:email]");
+    expect(r.text).not.toContain("alice.smith@acmecorp.com");
   });
 
   test("replaces multiple different secret types", () => {
     const input = ["key = AKIAIOSFODNN7EXAMPLE", "email: alice@acmecorp.com", "server: 172.16.254.1"].join("\n");
-    const result = sanitizeText(input);
-    expect(result.text).not.toContain("AKIAIOSFODNN7EXAMPLE");
-    expect(result.text).not.toContain("alice@acmecorp.com");
-    expect(result.text).not.toContain("172.16.254.1");
+    const r = sanitizeText(input);
+    expect(r.text).not.toContain("AKIAIOSFODNN7EXAMPLE");
+    expect(r.text).not.toContain("alice@acmecorp.com");
+    expect(r.text).not.toContain("172.16.254.1");
   });
 
   test("preserves non-secret content", () => {
     const input = "hello world, version 1.2.3, port 8080";
-    const result = sanitizeText(input);
-    expect(result.text).toBe(input);
-    expect(result.replacements).toBe(0);
-    expect(result.clean).toBe(true);
+    const r = sanitizeText(input);
+    expect(r.text).toBe(input);
+    expect(r.replacements).toBe(0);
+    expect(r.clean).toBe(true);
   });
 
   test("counts individual occurrences, not pattern classes", () => {
-    const input = "alice@acmecorp.com and bob@acmecorp.com";
-    const result = sanitizeText(input);
-    expect(result.replacements).toBe(2);
+    const r = sanitizeText("alice@acmecorp.com and bob@acmecorp.com");
+    expect(r.replacements).toBe(2);
   });
 
   test("passes through already-redacted text", () => {
     const input = "key = [REDACTED:aws-access-key]";
-    const result = sanitizeText(input);
-    expect(result.text).toBe(input);
+    const r = sanitizeText(input);
+    expect(r.text).toBe(input);
   });
 });
+
+// ── sanitizeJsonPayload ────────────────────────────────────────────
 
 describe("sanitizeJsonPayload", () => {
   test("sanitizes string values in objects", () => {
     const obj = {
-      tokens: {
-        github: "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
-      },
+      tokens: { github: "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij" },
       data: "safe content",
     };
     const { sanitized, replacements } = sanitizeJsonPayload(obj);
@@ -403,15 +455,7 @@ describe("sanitizeJsonPayload", () => {
   });
 
   test("handles deeply nested structures", () => {
-    const obj = {
-      level1: {
-        level2: {
-          level3: {
-            secret: "AKIAIOSFODNN7EXAMPLE",
-          },
-        },
-      },
-    };
+    const obj = { level1: { level2: { level3: { secret: "AKIAIOSFODNN7EXAMPLE" } } } };
     const { sanitized } = sanitizeJsonPayload(obj);
     const s = sanitized as { level1: { level2: { level3: { secret: string } } } };
     expect(s.level1.level2.level3.secret).toContain("[REDACTED:");
@@ -436,6 +480,8 @@ describe("sanitizeJsonPayload", () => {
   });
 });
 
+// ── assertClean ────────────────────────────────────────────────────
+
 describe("assertClean", () => {
   test("does not throw for clean text", () => {
     expect(() => assertClean("hello world, port 8080")).not.toThrow();
@@ -458,12 +504,16 @@ describe("assertClean", () => {
   });
 });
 
+// ── Defence in depth: sanitize → re-scan ───────────────────────────
+
 describe("defence in depth: sanitize then re-scan", () => {
   const DIRTY_INPUTS = [
     'Authorization: "Bearer sk-1234567890abcdefghijklmnop"',
     "AKIAIOSFODNN7EXAMPLE",
+    "ASIAJEXAMPLEXEG456NY",
     "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U",
     "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
+    "github_pat_11ABCDEF0GHIJKLMNOPQRS_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345678",
     "xoxb-1234567890-abcdefghij",
     "sk_live_TESTONLY00000000000000x",
     "alice@acmecorp.com",
@@ -474,23 +524,27 @@ describe("defence in depth: sanitize then re-scan", () => {
     '"password": "hunter2-extended-edition"',
     "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA...\n-----END RSA PRIVATE KEY-----",
     "npm_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij12",
+    "pypi-AgEIcHlwaS5vcmcABCDEFGH12345",
+    "sk-ant-api03-abcdefghijklmnopqrstuv",
   ];
 
   for (const input of DIRTY_INPUTS) {
     test(`sanitize→re-scan is clean: ${input.slice(0, 50)}...`, () => {
-      const result = sanitizeText(input);
-      expect(result.clean).toBe(true);
-      expect(() => assertClean(result.text)).not.toThrow();
+      const r = sanitizeText(input);
+      expect(r.clean).toBe(true);
+      expect(() => assertClean(r.text)).not.toThrow();
     });
   }
 
   test("combined payload: all secrets in one blob", () => {
     const combined = DIRTY_INPUTS.join("\n");
-    const result = sanitizeText(combined);
-    expect(result.clean).toBe(true);
-    expect(() => assertClean(result.text)).not.toThrow();
+    const r = sanitizeText(combined);
+    expect(r.clean).toBe(true);
+    expect(() => assertClean(r.text)).not.toThrow();
   });
 });
+
+// ── Negative tests: non-secrets pass through unchanged ─────────────
 
 describe("negative tests: non-secrets pass through unchanged", () => {
   const SAFE_INPUTS = [
@@ -517,15 +571,18 @@ describe("negative tests: non-secrets pass through unchanged", () => {
     "[REDACTED:aws-access-key] already sanitized",
     "10.0.0.1",
     "e2b5eb6721f62f7b6da14bbab9ab9380cadc080c",
+    "user@example.c|m is not a real email",
   ];
 
   for (const input of SAFE_INPUTS) {
     test(`passes through unchanged: ${input.slice(0, 60)}`, () => {
-      const result = sanitizeText(input);
-      expect(result.text).toBe(input);
+      const r = sanitizeText(input);
+      expect(r.text).toBe(input);
     });
   }
 });
+
+// ── NDJSON recording line sanitization ─────────────────────────────
 
 describe("NDJSON recording line sanitization", () => {
   test("sanitizes a realistic recording entry with secrets", () => {
@@ -541,11 +598,11 @@ describe("NDJSON recording line sanitization", () => {
         },
       },
     });
-    const result = sanitizeText(entry);
-    expect(result.text).not.toContain("ghp_ABCDEF");
-    expect(result.text).not.toContain("johndoe");
-    expect(result.text).toContain("[REDACTED:");
-    expect(result.clean).toBe(true);
+    const r = sanitizeText(entry);
+    expect(r.text).not.toContain("ghp_ABCDEF");
+    expect(r.text).not.toContain("johndoe");
+    expect(r.text).toContain("[REDACTED:");
+    expect(r.clean).toBe(true);
   });
 
   test("preserves structure of clean recording entries", () => {
@@ -555,8 +612,8 @@ describe("NDJSON recording line sanitization", () => {
       kind: "mcp",
       payload: { jsonrpc: "2.0", id: 1, method: "tools/list" },
     });
-    const result = sanitizeText(entry);
-    expect(result.text).toBe(entry);
-    expect(result.clean).toBe(true);
+    const r = sanitizeText(entry);
+    expect(r.text).toBe(entry);
+    expect(r.clean).toBe(true);
   });
 });

--- a/packages/core/src/sanitizer.spec.ts
+++ b/packages/core/src/sanitizer.spec.ts
@@ -262,8 +262,14 @@ describe("scanSecrets", () => {
       expect(result.clean).toBe(false);
     });
 
-    test("detects Claude-style slug paths", () => {
+    test("detects Claude-style slug paths (macOS)", () => {
       const result = scanSecrets("dir: -Users-johndoe-projects");
+      expect(result.clean).toBe(false);
+      expect(result.matches.some((m) => m.pattern === "home-path-slug")).toBe(true);
+    });
+
+    test("detects Linux home slug paths (-home-alice-)", () => {
+      const result = scanSecrets("dir: -home-alice-project-foo");
       expect(result.clean).toBe(false);
       expect(result.matches.some((m) => m.pattern === "home-path-slug")).toBe(true);
     });
@@ -360,6 +366,12 @@ describe("sanitizeText", () => {
     expect(result.clean).toBe(true);
   });
 
+  test("counts individual occurrences, not pattern classes", () => {
+    const input = "alice@acmecorp.com and bob@acmecorp.com";
+    const result = sanitizeText(input);
+    expect(result.replacements).toBe(2);
+  });
+
   test("passes through already-redacted text", () => {
     const input = "key = [REDACTED:aws-access-key]";
     const result = sanitizeText(input);
@@ -416,6 +428,12 @@ describe("sanitizeJsonPayload", () => {
     expect(sanitizeJsonPayload({}).sanitized).toEqual({});
     expect(sanitizeJsonPayload([]).sanitized).toEqual([]);
   });
+
+  test("counts key replacements in the total", () => {
+    const obj = { "alice@acmecorp.com": "safe-value" };
+    const { replacements } = sanitizeJsonPayload(obj);
+    expect(replacements).toBeGreaterThanOrEqual(1);
+  });
 });
 
 describe("assertClean", () => {
@@ -451,6 +469,7 @@ describe("defence in depth: sanitize then re-scan", () => {
     "alice@acmecorp.com",
     "172.16.254.1",
     "/Users/johndoe/secret/file",
+    "-home-alice-project-foo",
     "mongodb://admin:pass123@mongo.internal:27017/prod",
     '"password": "hunter2-extended-edition"',
     "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA...\n-----END RSA PRIVATE KEY-----",

--- a/packages/core/src/sanitizer.spec.ts
+++ b/packages/core/src/sanitizer.spec.ts
@@ -1,0 +1,512 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ResidualSecretError,
+  type SanitizeResult,
+  assertClean,
+  sanitizeJsonPayload,
+  sanitizeText,
+  scanSecrets,
+} from "./sanitizer";
+
+describe("scanSecrets", () => {
+  describe("AWS keys", () => {
+    test("detects AWS access key IDs", () => {
+      const result = scanSecrets("key = AKIAIOSFODNN7EXAMPLE");
+      expect(result.clean).toBe(false);
+      expect(result.matches.some((m) => m.pattern === "aws-access-key")).toBe(true);
+    });
+
+    test("ignores partial AKIA prefix without full length", () => {
+      const result = scanSecrets("AKIA_SHORT");
+      expect(result.matches.some((m) => m.pattern === "aws-access-key")).toBe(false);
+    });
+  });
+
+  describe("JWTs", () => {
+    test("detects JWT tokens", () => {
+      const jwt =
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U";
+      const result = scanSecrets(`token: ${jwt}`);
+      expect(result.clean).toBe(false);
+      expect(result.matches.some((m) => m.pattern === "jwt")).toBe(true);
+    });
+
+    test("ignores strings that look JWT-ish but have only two segments", () => {
+      const result = scanSecrets("eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0");
+      expect(result.matches.some((m) => m.pattern === "jwt")).toBe(false);
+    });
+  });
+
+  describe("Authorization headers", () => {
+    test("detects Bearer token in header", () => {
+      const result = scanSecrets('"Authorization": "Bearer sk-1234567890abcdefghijk"');
+      expect(result.clean).toBe(false);
+      expect(result.matches.some((m) => m.pattern === "authorization-header")).toBe(true);
+    });
+
+    test("detects Basic auth in header", () => {
+      const result = scanSecrets('"Authorization": "Basic dXNlcjpwYXNzd29yZDEyMzQ1"');
+      expect(result.clean).toBe(false);
+      expect(result.matches.some((m) => m.pattern === "authorization-header")).toBe(true);
+    });
+
+    test("does not flag the word Authorization in prose", () => {
+      const result = scanSecrets("The Authorization flow requires a redirect");
+      expect(result.matches.some((m) => m.pattern === "authorization-header")).toBe(false);
+    });
+  });
+
+  describe("API key headers", () => {
+    test("detects X-API-Key header value", () => {
+      const result = scanSecrets('"X-API-Key": "abcdef1234567890abcdef"');
+      expect(result.clean).toBe(false);
+      expect(result.matches.some((m) => m.pattern === "generic-api-key-header")).toBe(true);
+    });
+  });
+
+  describe("environment variable secrets", () => {
+    test("detects GITHUB_TOKEN assignment", () => {
+      const result = scanSecrets("GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx1234");
+      expect(result.clean).toBe(false);
+    });
+
+    test("detects API_KEY in JSON", () => {
+      const result = scanSecrets('{"API_KEY": "super-secret-key-value-1234"}');
+      expect(result.clean).toBe(false);
+    });
+
+    test("detects DATABASE_URL with credentials", () => {
+      const result = scanSecrets("DATABASE_URL=postgres://user:password123@host:5432/db");
+      expect(result.clean).toBe(false);
+    });
+
+    test("detects CLIENT_SECRET", () => {
+      const result = scanSecrets('"CLIENT_SECRET": "a1b2c3d4e5f6g7h8i9j0klmn"');
+      expect(result.clean).toBe(false);
+    });
+
+    test("detects ANTHROPIC_API_KEY", () => {
+      const result = scanSecrets("ANTHROPIC_API_KEY=sk-ant-xxxxxxxxxxxxxxxxxxxx");
+      expect(result.clean).toBe(false);
+    });
+  });
+
+  describe("GitHub tokens", () => {
+    test("detects ghp_ personal access token", () => {
+      const result = scanSecrets("token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij");
+      expect(result.clean).toBe(false);
+      expect(result.matches.some((m) => m.pattern === "github-token")).toBe(true);
+    });
+
+    test("detects gho_ OAuth token", () => {
+      const result = scanSecrets("gho_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij");
+      expect(result.clean).toBe(false);
+    });
+
+    test("detects ghs_ server-to-server token", () => {
+      const result = scanSecrets("ghs_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij");
+      expect(result.clean).toBe(false);
+    });
+  });
+
+  describe("npm tokens", () => {
+    test("detects npm_ token", () => {
+      const result = scanSecrets("npm_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij12");
+      expect(result.clean).toBe(false);
+      expect(result.matches.some((m) => m.pattern === "npm-token")).toBe(true);
+    });
+  });
+
+  describe("Slack tokens", () => {
+    test("detects xoxb- bot token", () => {
+      const result = scanSecrets("xoxb-1234567890-abcdefghij");
+      expect(result.clean).toBe(false);
+      expect(result.matches.some((m) => m.pattern === "slack-token")).toBe(true);
+    });
+
+    test("detects xoxp- user token", () => {
+      const result = scanSecrets("xoxp-1234567890-abcdefghij");
+      expect(result.clean).toBe(false);
+    });
+  });
+
+  describe("Stripe keys", () => {
+    test("detects sk_live_ secret key", () => {
+      const result = scanSecrets("sk_live_TESTONLY00000000000000x");
+      expect(result.clean).toBe(false);
+      expect(result.matches.some((m) => m.pattern === "stripe-key")).toBe(true);
+    });
+
+    test("detects sk_test_ test key", () => {
+      const result = scanSecrets("sk_test_TESTONLY00000000000000x");
+      expect(result.clean).toBe(false);
+    });
+  });
+
+  describe("private key blocks", () => {
+    test("detects RSA private key", () => {
+      const key = "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA...\n-----END RSA PRIVATE KEY-----";
+      const result = scanSecrets(key);
+      expect(result.clean).toBe(false);
+      expect(result.matches.some((m) => m.pattern === "private-key-block")).toBe(true);
+    });
+
+    test("detects generic private key block", () => {
+      const key = "-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----";
+      const result = scanSecrets(key);
+      expect(result.clean).toBe(false);
+    });
+  });
+
+  describe("emails", () => {
+    test("detects email addresses", () => {
+      const result = scanSecrets("contact: alice.smith@acmecorp.com");
+      expect(result.clean).toBe(false);
+      expect(result.matches.some((m) => m.pattern === "email")).toBe(true);
+    });
+
+    test("allows example.com emails (false positive)", () => {
+      const result = scanSecrets("test@example.com");
+      expect(result.matches.some((m) => m.pattern === "email")).toBe(false);
+    });
+
+    test("allows noreply@anthropic.com", () => {
+      const result = scanSecrets("Co-Authored-By: Claude <noreply@anthropic.com>");
+      expect(result.matches.some((m) => m.pattern === "email")).toBe(false);
+    });
+
+    test("allows GitHub noreply addresses", () => {
+      const result = scanSecrets("user@users.noreply.github.com");
+      expect(result.matches.some((m) => m.pattern === "email")).toBe(false);
+    });
+  });
+
+  describe("IP addresses", () => {
+    test("detects IPv4 addresses", () => {
+      const result = scanSecrets("server: 172.16.254.1");
+      expect(result.clean).toBe(false);
+      expect(result.matches.some((m) => m.pattern === "ipv4")).toBe(true);
+    });
+
+    test("detects IPv6 addresses", () => {
+      const result = scanSecrets("addr: 2001:0db8:85a3:0000:0000:8a2e:0370:7334");
+      expect(result.clean).toBe(false);
+      expect(result.matches.some((m) => m.pattern === "ipv6")).toBe(true);
+    });
+
+    test("allows localhost 127.0.0.1", () => {
+      const result = scanSecrets("bind: 127.0.0.1");
+      expect(result.matches.some((m) => m.pattern === "ipv4")).toBe(false);
+    });
+
+    test("allows 0.0.0.0", () => {
+      const result = scanSecrets("listen: 0.0.0.0");
+      expect(result.matches.some((m) => m.pattern === "ipv4")).toBe(false);
+    });
+
+    test("allows 10.0.0.x range", () => {
+      const result = scanSecrets("bind: 10.0.0.1");
+      expect(result.matches.some((m) => m.pattern === "ipv4")).toBe(false);
+    });
+
+    test("allows subnet masks", () => {
+      const result = scanSecrets("mask: 255.255.255.0");
+      expect(result.matches.some((m) => m.pattern === "ipv4")).toBe(false);
+    });
+
+    test("allows RFC 5737 documentation IPs", () => {
+      const result = scanSecrets("example: 192.0.2.1 and 198.51.100.1 and 203.0.113.1");
+      expect(result.matches.some((m) => m.pattern === "ipv4")).toBe(false);
+    });
+  });
+
+  describe("home paths", () => {
+    test("detects /Users/<name>/ paths", () => {
+      const result = scanSecrets("path: /Users/johndoe/projects/secret");
+      expect(result.clean).toBe(false);
+      expect(result.matches.some((m) => m.pattern === "home-path")).toBe(true);
+    });
+
+    test("detects /home/<name>/ paths", () => {
+      const result = scanSecrets("path: /home/ubuntu/.ssh/id_rsa");
+      expect(result.clean).toBe(false);
+    });
+
+    test("detects Claude-style slug paths", () => {
+      const result = scanSecrets("dir: -Users-johndoe-projects");
+      expect(result.clean).toBe(false);
+      expect(result.matches.some((m) => m.pattern === "home-path-slug")).toBe(true);
+    });
+
+    test("allows /Users/Shared/", () => {
+      const result = scanSecrets("/Users/Shared/data");
+      expect(result.matches.some((m) => m.pattern === "home-path")).toBe(false);
+    });
+
+    test("allows /home/runner/ (CI)", () => {
+      const result = scanSecrets("/home/runner/work/project");
+      expect(result.matches.some((m) => m.pattern === "home-path")).toBe(false);
+    });
+  });
+
+  describe("connection strings", () => {
+    test("detects MongoDB URI", () => {
+      const result = scanSecrets("mongodb://admin:password@host:27017/db");
+      expect(result.clean).toBe(false);
+      expect(result.matches.some((m) => m.pattern === "connection-string")).toBe(true);
+    });
+
+    test("detects PostgreSQL URI", () => {
+      const result = scanSecrets("postgres://user:pass@host:5432/mydb");
+      expect(result.clean).toBe(false);
+    });
+
+    test("detects Redis URI", () => {
+      const result = scanSecrets("redis://default:secretpass@redis.example.com:6379");
+      expect(result.clean).toBe(false);
+    });
+  });
+
+  describe("generic secret assignments", () => {
+    test("detects password assignment", () => {
+      const result = scanSecrets('"password": "hunter2-extended-edition"');
+      expect(result.clean).toBe(false);
+    });
+
+    test("detects secret assignment", () => {
+      const result = scanSecrets('"secret": "my-super-secret-value-123"');
+      expect(result.clean).toBe(false);
+    });
+
+    test("does not flag masked passwords (****)", () => {
+      const result = scanSecrets('"password": "********"');
+      expect(result.matches.some((m) => m.pattern === "generic-secret-assignment")).toBe(false);
+    });
+  });
+});
+
+describe("sanitizeText", () => {
+  test("replaces secrets with redaction placeholders", () => {
+    const input = "key = AKIAIOSFODNN7EXAMPLE and done";
+    const result = sanitizeText(input);
+    expect(result.text).toContain("[REDACTED:aws-access-key]");
+    expect(result.text).not.toContain("AKIAIOSFODNN7EXAMPLE");
+    expect(result.replacements).toBeGreaterThan(0);
+  });
+
+  test("replaces JWT tokens", () => {
+    const jwt =
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U";
+    const result = sanitizeText(`Authorization: Bearer ${jwt}`);
+    expect(result.text).toContain("[REDACTED:");
+    expect(result.text).not.toContain("eyJhbGci");
+  });
+
+  test("replaces home paths", () => {
+    const result = sanitizeText("working in /Users/johndoe/code/project");
+    expect(result.text).toContain("[REDACTED:home-path]");
+    expect(result.text).not.toContain("johndoe");
+  });
+
+  test("replaces emails", () => {
+    const result = sanitizeText("from alice.smith@acmecorp.com");
+    expect(result.text).toContain("[REDACTED:email]");
+    expect(result.text).not.toContain("alice.smith@acmecorp.com");
+  });
+
+  test("replaces multiple different secret types", () => {
+    const input = ["key = AKIAIOSFODNN7EXAMPLE", "email: alice@acmecorp.com", "server: 172.16.254.1"].join("\n");
+    const result = sanitizeText(input);
+    expect(result.text).not.toContain("AKIAIOSFODNN7EXAMPLE");
+    expect(result.text).not.toContain("alice@acmecorp.com");
+    expect(result.text).not.toContain("172.16.254.1");
+  });
+
+  test("preserves non-secret content", () => {
+    const input = "hello world, version 1.2.3, port 8080";
+    const result = sanitizeText(input);
+    expect(result.text).toBe(input);
+    expect(result.replacements).toBe(0);
+    expect(result.clean).toBe(true);
+  });
+
+  test("passes through already-redacted text", () => {
+    const input = "key = [REDACTED:aws-access-key]";
+    const result = sanitizeText(input);
+    expect(result.text).toBe(input);
+  });
+});
+
+describe("sanitizeJsonPayload", () => {
+  test("sanitizes string values in objects", () => {
+    const obj = {
+      tokens: {
+        github: "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
+      },
+      data: "safe content",
+    };
+    const { sanitized, replacements } = sanitizeJsonPayload(obj);
+    expect(replacements).toBeGreaterThan(0);
+    const s = sanitized as { tokens: { github: string }; data: string };
+    expect(s.tokens.github).toContain("[REDACTED:");
+    expect(s.data).toBe("safe content");
+  });
+
+  test("sanitizes nested arrays", () => {
+    const obj = { tokens: ["ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij", "safe-value"] };
+    const { sanitized } = sanitizeJsonPayload(obj);
+    const s = sanitized as Record<string, string[]>;
+    expect(s.tokens[0]).toContain("[REDACTED:");
+    expect(s.tokens[1]).toBe("safe-value");
+  });
+
+  test("handles deeply nested structures", () => {
+    const obj = {
+      level1: {
+        level2: {
+          level3: {
+            secret: "AKIAIOSFODNN7EXAMPLE",
+          },
+        },
+      },
+    };
+    const { sanitized } = sanitizeJsonPayload(obj);
+    const s = sanitized as { level1: { level2: { level3: { secret: string } } } };
+    expect(s.level1.level2.level3.secret).toContain("[REDACTED:");
+  });
+
+  test("preserves non-string primitives", () => {
+    const obj = { count: 42, active: true, empty: null };
+    const { sanitized, replacements } = sanitizeJsonPayload(obj);
+    expect(sanitized).toEqual(obj);
+    expect(replacements).toBe(0);
+  });
+
+  test("handles empty objects and arrays", () => {
+    expect(sanitizeJsonPayload({}).sanitized).toEqual({});
+    expect(sanitizeJsonPayload([]).sanitized).toEqual([]);
+  });
+});
+
+describe("assertClean", () => {
+  test("does not throw for clean text", () => {
+    expect(() => assertClean("hello world, port 8080")).not.toThrow();
+  });
+
+  test("throws ResidualSecretError for dirty text", () => {
+    expect(() => assertClean("key = AKIAIOSFODNN7EXAMPLE")).toThrow(ResidualSecretError);
+  });
+
+  test("error includes match details", () => {
+    try {
+      assertClean("AKIAIOSFODNN7EXAMPLE");
+      expect.unreachable("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ResidualSecretError);
+      const rse = err as ResidualSecretError;
+      expect(rse.matches.length).toBeGreaterThan(0);
+      expect(rse.matches[0].pattern).toBe("aws-access-key");
+    }
+  });
+});
+
+describe("defence in depth: sanitize then re-scan", () => {
+  const DIRTY_INPUTS = [
+    'Authorization: "Bearer sk-1234567890abcdefghijklmnop"',
+    "AKIAIOSFODNN7EXAMPLE",
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U",
+    "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
+    "xoxb-1234567890-abcdefghij",
+    "sk_live_TESTONLY00000000000000x",
+    "alice@acmecorp.com",
+    "172.16.254.1",
+    "/Users/johndoe/secret/file",
+    "mongodb://admin:pass123@mongo.internal:27017/prod",
+    '"password": "hunter2-extended-edition"',
+    "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA...\n-----END RSA PRIVATE KEY-----",
+    "npm_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij12",
+  ];
+
+  for (const input of DIRTY_INPUTS) {
+    test(`sanitize→re-scan is clean: ${input.slice(0, 50)}...`, () => {
+      const result = sanitizeText(input);
+      expect(result.clean).toBe(true);
+      expect(() => assertClean(result.text)).not.toThrow();
+    });
+  }
+
+  test("combined payload: all secrets in one blob", () => {
+    const combined = DIRTY_INPUTS.join("\n");
+    const result = sanitizeText(combined);
+    expect(result.clean).toBe(true);
+    expect(() => assertClean(result.text)).not.toThrow();
+  });
+});
+
+describe("negative tests: non-secrets pass through unchanged", () => {
+  const SAFE_INPUTS = [
+    "normal log message with no secrets",
+    "version 2.1.119",
+    "port 8080",
+    "127.0.0.1:3000",
+    "http://localhost:8080/api",
+    "0.0.0.0:443",
+    "test@example.com",
+    "noreply@anthropic.com",
+    "user@users.noreply.github.com",
+    "/Users/Shared/data",
+    "/home/runner/work/project",
+    "255.255.255.0",
+    "192.0.2.1",
+    '{ "type": "init", "daemonId": "test-123" }',
+    '{ "jsonrpc": "2.0", "id": 1, "method": "tools/list" }',
+    "the Authorization flow requires a redirect",
+    "AKIA followed by nothing special",
+    "abc.def.ghi is not an IP",
+    "Co-Authored-By: Claude <noreply@anthropic.com>",
+    "password: ********",
+    "[REDACTED:aws-access-key] already sanitized",
+    "10.0.0.1",
+  ];
+
+  for (const input of SAFE_INPUTS) {
+    test(`passes through unchanged: ${input.slice(0, 60)}`, () => {
+      const result = sanitizeText(input);
+      expect(result.text).toBe(input);
+    });
+  }
+});
+
+describe("NDJSON recording line sanitization", () => {
+  test("sanitizes a realistic recording entry with secrets", () => {
+    const entry = JSON.stringify({
+      t: 1234567890,
+      dir: "worker->daemon",
+      kind: "control",
+      payload: {
+        type: "init",
+        env: {
+          GITHUB_TOKEN: "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",
+          HOME: "/Users/johndoe/",
+        },
+      },
+    });
+    const result = sanitizeText(entry);
+    expect(result.text).not.toContain("ghp_ABCDEF");
+    expect(result.text).not.toContain("johndoe");
+    expect(result.text).toContain("[REDACTED:");
+    expect(result.clean).toBe(true);
+  });
+
+  test("preserves structure of clean recording entries", () => {
+    const entry = JSON.stringify({
+      t: 1234567890,
+      dir: "daemon->worker",
+      kind: "mcp",
+      payload: { jsonrpc: "2.0", id: 1, method: "tools/list" },
+    });
+    const result = sanitizeText(entry);
+    expect(result.text).toBe(entry);
+    expect(result.clean).toBe(true);
+  });
+});

--- a/packages/core/src/sanitizer.spec.ts
+++ b/packages/core/src/sanitizer.spec.ts
@@ -367,6 +367,27 @@ describe("scanSecrets / IPs", () => {
     expect(scanSecrets("bind: 10.0.0.1").matches.some((m) => m.pattern === "ipv4")).toBe(false);
   });
 
+  test("detects compressed IPv6 ::1 loopback (but false-positive filtered)", () => {
+    const r = scanSecrets("addr: ::1");
+    expect(r.matches.some((m) => m.pattern === "ipv6-compressed")).toBe(false);
+  });
+
+  test("detects compressed IPv6 fe80:: link-local", () => {
+    const r = scanSecrets("addr: fe80::");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "ipv6-compressed")).toBe(true);
+  });
+
+  test("detects compressed IPv6 2001:db8::1", () => {
+    const r = scanSecrets("addr: 2001:db8::1");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "ipv6-compressed")).toBe(true);
+  });
+
+  test("allows :: unspecified address (false-positive filtered)", () => {
+    expect(scanSecrets("bind: ::").matches.some((m) => m.pattern === "ipv6-compressed")).toBe(false);
+  });
+
   test("allows subnet masks", () => {
     expect(scanSecrets("mask: 255.255.255.0").matches.some((m) => m.pattern === "ipv4")).toBe(false);
   });
@@ -553,6 +574,16 @@ describe("sanitizeJsonPayload", () => {
     expect(sanitizeJsonPayload([]).sanitized).toEqual([]);
   });
 
+  test("deduplicates colliding sanitized keys instead of dropping values", () => {
+    const obj = { "alice@acmecorp.com": 1, "bob@acmecorp.com": 2 };
+    const { sanitized } = sanitizeJsonPayload(obj);
+    const keys = Object.keys(sanitized as Record<string, unknown>);
+    expect(keys.length).toBe(2);
+    const values = Object.values(sanitized as Record<string, unknown>);
+    expect(values).toContain(1);
+    expect(values).toContain(2);
+  });
+
   test("counts key replacements in the total", () => {
     const obj = { "alice@acmecorp.com": "safe-value" };
     const { replacements } = sanitizeJsonPayload(obj);
@@ -610,6 +641,8 @@ describe("defence in depth: sanitize then re-scan", () => {
     "AIzaSyA1234567890abcdefghijklmnopqrstuv",
     "hvs.ABCDEFghijklmnopqrstuv1234",
     "ATBB1234567890abcdefghijklmnopqrstuvwxyz",
+    "fe80::",
+    "2001:db8::1",
   ];
 
   for (const input of DIRTY_INPUTS) {
@@ -659,6 +692,8 @@ describe("negative tests: non-secrets pass through unchanged", () => {
     "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
     "glpat- followed by nothing special",
     "AIza short",
+    "::1",
+    "::",
   ];
 
   for (const input of SAFE_INPUTS) {

--- a/packages/core/src/sanitizer.spec.ts
+++ b/packages/core/src/sanitizer.spec.ts
@@ -21,13 +21,25 @@ describe("scanSecrets / AWS", () => {
     expect(r.matches.some((m) => m.pattern === "aws-access-key")).toBe(false);
   });
 
-  test("ignores git SHA-1 hashes (40 hex chars)", () => {
-    const r = scanSecrets("commit e2b5eb6721f62f7b6da14bbab9ab9380cadc080c");
+  test("detects AWS secret key with context keyword", () => {
+    const r = scanSecrets("aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "aws-secret-key")).toBe(true);
+  });
+
+  test("detects SecretAccessKey context", () => {
+    const r = scanSecrets('SecretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"');
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "aws-secret-key")).toBe(true);
+  });
+
+  test("ignores bare 40-char base64 strings without context", () => {
+    const r = scanSecrets("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
     expect(r.matches.some((m) => m.pattern === "aws-secret-key")).toBe(false);
   });
 
-  test("ignores SHA-1 of empty string (all hex)", () => {
-    const r = scanSecrets("da39a3ee5e6b4b0d3255bfef95601890afd80709");
+  test("ignores git SHA-1 hashes (40 hex chars)", () => {
+    const r = scanSecrets("commit e2b5eb6721f62f7b6da14bbab9ab9380cadc080c");
     expect(r.matches.some((m) => m.pattern === "aws-secret-key")).toBe(false);
   });
 });
@@ -199,6 +211,74 @@ describe("scanSecrets / platform tokens", () => {
     const r = scanSecrets("sk-ant-api03-abcdefghijklmnopqrstuv");
     expect(r.clean).toBe(false);
     expect(r.matches.some((m) => m.pattern === "anthropic-api-key")).toBe(true);
+  });
+});
+
+// ── GitLab / Google / Vault / Bitbucket ─────────────────────────────
+
+describe("scanSecrets / additional providers", () => {
+  test("detects glpat- GitLab token", () => {
+    const r = scanSecrets("token: glpat-ABCDEFghijklmnopqrstuv12");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "gitlab-token")).toBe(true);
+  });
+
+  test("detects GR1348941 GitLab runner token", () => {
+    const r = scanSecrets("GR1348941ABCDEFghijklmnopqrstuv12");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "gitlab-runner-token")).toBe(true);
+  });
+
+  test("detects AIza Google API key", () => {
+    const r = scanSecrets("key: AIzaSyA1234567890abcdefghijklmnopqrstuv");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "google-api-key")).toBe(true);
+  });
+
+  test("detects hvs. Vault service token", () => {
+    const r = scanSecrets("token: hvs.ABCDEFghijklmnopqrstuv1234");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "vault-token")).toBe(true);
+  });
+
+  test("detects hvb. Vault batch token", () => {
+    const r = scanSecrets("hvb.ABCDEFghijklmnopqrstuv1234");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "vault-token")).toBe(true);
+  });
+
+  test("detects ATBB Bitbucket token", () => {
+    const r = scanSecrets("ATBB1234567890abcdefghijklmnopqrstuvwxyz");
+    expect(r.clean).toBe(false);
+    expect(r.matches.some((m) => m.pattern === "bitbucket-token")).toBe(true);
+  });
+});
+
+// ── Preview field (blocker fix) ─────────────────────────────────────
+
+describe("scanSecrets / preview field safety", () => {
+  test("preview does not contain the full secret", () => {
+    const secret = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij";
+    const r = scanSecrets(secret);
+    expect(r.matches.length).toBeGreaterThan(0);
+    const match = r.matches[0];
+    expect(match.preview).not.toBe(secret);
+    expect(match.preview.length).toBeLessThan(secret.length);
+    expect(match.preview).toContain("***");
+  });
+
+  test("preview shows first 4 + last 2 chars for long secrets", () => {
+    const r = scanSecrets("AKIAIOSFODNN7EXAMPLE");
+    const match = r.matches.find((m) => m.pattern === "aws-access-key");
+    expect(match).toBeDefined();
+    expect(match?.preview).toBe("AKIA***LE");
+  });
+
+  test("preview shows first 2 chars for short matches", () => {
+    const r = scanSecrets('"password": "hunter2x"');
+    const match = r.matches.find((m) => m.pattern === "generic-secret-assignment");
+    expect(match).toBeDefined();
+    expect(match?.preview).toBe("hu***");
   });
 });
 
@@ -526,6 +606,10 @@ describe("defence in depth: sanitize then re-scan", () => {
     "npm_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij12",
     "pypi-AgEIcHlwaS5vcmcABCDEFGH12345",
     "sk-ant-api03-abcdefghijklmnopqrstuv",
+    "glpat-ABCDEFghijklmnopqrstuv12",
+    "AIzaSyA1234567890abcdefghijklmnopqrstuv",
+    "hvs.ABCDEFghijklmnopqrstuv1234",
+    "ATBB1234567890abcdefghijklmnopqrstuvwxyz",
   ];
 
   for (const input of DIRTY_INPUTS) {
@@ -572,6 +656,9 @@ describe("negative tests: non-secrets pass through unchanged", () => {
     "10.0.0.1",
     "e2b5eb6721f62f7b6da14bbab9ab9380cadc080c",
     "user@example.c|m is not a real email",
+    "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+    "glpat- followed by nothing special",
+    "AIza short",
   ];
 
   for (const input of SAFE_INPUTS) {

--- a/packages/core/src/sanitizer.ts
+++ b/packages/core/src/sanitizer.ts
@@ -22,7 +22,49 @@ interface PatternDef {
   re: RegExp;
 }
 
-const ENV_KEY_NAMES = [
+// ── Pattern taxonomy ───────────────────────────────────────────────
+//
+// Organized by provider/family so coverage is by-construction:
+// every known prefix/format for a provider is grouped together.
+// When a new provider is added, add a block — don't sprinkle into
+// an unstructured list.
+
+// ── AWS ────────────────────────────────────────────────────────────
+// AKIA = long-lived IAM keys, ASIA = STS temporary credentials.
+// Both are 20-char uppercase alphanumeric after the 4-char prefix.
+const AWS_ACCESS_KEY = /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g;
+// 40-char base64-ish secret key (appears after access key ID in configs).
+const AWS_SECRET_KEY = /\b[A-Za-z0-9/+=]{40}(?=\s|"|'|$)/gm;
+
+// ── GitHub ─────────────────────────────────────────────────────────
+// Classic PATs (ghp_), OAuth (gho_), user-to-server (ghu_),
+// server-to-server (ghs_), refresh (ghr_) — 36+ alphanumeric.
+const GITHUB_CLASSIC_TOKEN = /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}\b/g;
+// Fine-grained PATs: github_pat_ prefix + base62 segments separated by underscore.
+const GITHUB_FINE_GRAINED_TOKEN = /\bgithub_pat_[A-Za-z0-9]{22}_[A-Za-z0-9]{50,}\b/g;
+
+// ── JWTs ───────────────────────────────────────────────────────────
+const JWT = /\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g;
+
+// ── Private key blocks (PEM) ───────────────────────────────────────
+const PRIVATE_KEY_BLOCK =
+  /-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP |ENCRYPTED )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |DSA |OPENSSH |PGP |ENCRYPTED )?PRIVATE KEY-----/g;
+
+// ── Platform tokens ────────────────────────────────────────────────
+const NPM_TOKEN = /\bnpm_[A-Za-z0-9]{36,}\b/g;
+const SLACK_TOKEN = /\bxox[bpars]-[A-Za-z0-9\-]{10,}\b/g;
+const STRIPE_KEY = /\b(?:sk|pk|rk)_(?:live|test)_[A-Za-z0-9]{20,}\b/g;
+const PYPI_TOKEN = /\bpypi-[A-Za-z0-9_-]{16,}\b/g;
+const ANTHROPIC_API_KEY_LITERAL = /\bsk-ant-[A-Za-z0-9_-]{20,}\b/g;
+
+// ── Header-based secrets ───────────────────────────────────────────
+const AUTHORIZATION_HEADER =
+  /(?<=["']?(?:Authorization|authorization|Proxy-Authorization|proxy-authorization)["']?\s*[:=]\s*["']?)(?:Bearer |Basic |Token |token )?[A-Za-z0-9_/+\-.=]{20,}/g;
+const GENERIC_API_KEY_HEADER =
+  /(?<=["']?(?:X-API-Key|x-api-key|X-Api-Key|api[_-]?key)["']?\s*[:=]\s*["']?)[A-Za-z0-9_/+\-.=]{16,}/g;
+
+// ── Environment variable secrets ───────────────────────────────────
+const ENV_KEY_SUFFIXES = [
   "API_KEY",
   "API_SECRET",
   "SECRET_KEY",
@@ -76,31 +118,31 @@ const WELL_KNOWN_ENVS = [
   "SSH_PRIVATE_KEY",
 ];
 
+// ── PII patterns ───────────────────────────────────────────────────
+const EMAIL = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g;
+const IPV4 = /\b(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\b/g;
+const IPV6_FULL = /\b(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}\b/g;
+const IPV6_COMPRESSED = /\b(?:[0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}\b/g;
+const HOME_PATH = /(?:\/Users\/|\/home\/)[A-Za-z0-9._-]+\//g;
+const HOME_PATH_SLUG = /-(?:Users|home)-[A-Za-z0-9._-]+-/g;
+
+// ── Connection strings ─────────────────────────────────────────────
+const CONNECTION_STRING = /\b(?:mongodb|postgres|postgresql|mysql|redis|amqp|amqps):\/\/[^\s"'`,;)}\]]+/gi;
+
+// ── Generic secret assignment ──────────────────────────────────────
+const GENERIC_SECRET_ASSIGNMENT =
+  /(?<=["']?(?:password|passwd|secret|credential|token)["']?\s*[:=]\s*["']?)[A-Za-z0-9_/+\-.=!@#$%^&*]{8,}/gi;
+
 function buildPatterns(): PatternDef[] {
-  const suffixPattern = ENV_KEY_NAMES.map((k) => k.replace(/_/g, "[_-]")).join("|");
+  const suffixPattern = ENV_KEY_SUFFIXES.map((k) => k.replace(/_/g, "[_-]")).join("|");
   const wellKnownPattern = WELL_KNOWN_ENVS.map((k) => k.replace(/_/g, "[_-]")).join("|");
 
   return [
-    {
-      name: "aws-access-key",
-      re: /\bAKIA[0-9A-Z]{16}\b/g,
-    },
-    {
-      name: "aws-secret-key",
-      re: /\b[A-Za-z0-9/+=]{40}(?=\s|"|'|$)/gm,
-    },
-    {
-      name: "jwt",
-      re: /\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g,
-    },
-    {
-      name: "authorization-header",
-      re: /(?<=["']?(?:Authorization|authorization|Proxy-Authorization|proxy-authorization)["']?\s*[:=]\s*["']?)(?:Bearer |Basic |Token |token )?[A-Za-z0-9_/+\-.=]{20,}/g,
-    },
-    {
-      name: "generic-api-key-header",
-      re: /(?<=["']?(?:X-API-Key|x-api-key|X-Api-Key|api[_-]?key)["']?\s*[:=]\s*["']?)[A-Za-z0-9_/+\-.=]{16,}/g,
-    },
+    { name: "aws-access-key", re: AWS_ACCESS_KEY },
+    { name: "aws-secret-key", re: AWS_SECRET_KEY },
+    { name: "jwt", re: JWT },
+    { name: "authorization-header", re: AUTHORIZATION_HEADER },
+    { name: "generic-api-key-header", re: GENERIC_API_KEY_HEADER },
     {
       name: "well-known-env",
       re: new RegExp(`(?<=(?:${wellKnownPattern})["']?\\s*[:=]\\s*["']?)[A-Za-z0-9_/+\\-.=]{8,}`, "gi"),
@@ -109,58 +151,22 @@ function buildPatterns(): PatternDef[] {
       name: "env-key-value",
       re: new RegExp(`(?<=[A-Z_]*(?:${suffixPattern})["']?\\s*[:=]\\s*["']?)[A-Za-z0-9_/+\\-.=]{8,}`, "gi"),
     },
-    {
-      name: "private-key-block",
-      re: /-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----/g,
-    },
-    {
-      name: "github-token",
-      re: /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}\b/g,
-    },
-    {
-      name: "npm-token",
-      re: /\bnpm_[A-Za-z0-9]{36,}\b/g,
-    },
-    {
-      name: "slack-token",
-      re: /\bxox[bpars]-[A-Za-z0-9\-]{10,}\b/g,
-    },
-    {
-      name: "stripe-key",
-      re: /\b(?:sk|pk|rk)_(?:live|test)_[A-Za-z0-9]{20,}\b/g,
-    },
-    {
-      name: "email",
-      re: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/g,
-    },
-    {
-      name: "ipv4",
-      re: /\b(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\b/g,
-    },
-    {
-      name: "ipv6",
-      re: /\b(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}\b/g,
-    },
-    {
-      name: "ipv6-compressed",
-      re: /\b(?:[0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}\b/g,
-    },
-    {
-      name: "home-path",
-      re: /(?:\/Users\/|\/home\/)[A-Za-z0-9._-]+\//g,
-    },
-    {
-      name: "home-path-slug",
-      re: /-(?:Users|home)-[A-Za-z0-9._-]+-/g,
-    },
-    {
-      name: "connection-string",
-      re: /\b(?:mongodb|postgres|postgresql|mysql|redis|amqp|amqps):\/\/[^\s"'`,;)}\]]+/gi,
-    },
-    {
-      name: "generic-secret-assignment",
-      re: /(?<=["']?(?:password|passwd|secret|credential|token)["']?\s*[:=]\s*["']?)[A-Za-z0-9_/+\-.=!@#$%^&*]{8,}/gi,
-    },
+    { name: "private-key-block", re: PRIVATE_KEY_BLOCK },
+    { name: "github-token", re: GITHUB_CLASSIC_TOKEN },
+    { name: "github-fine-grained-token", re: GITHUB_FINE_GRAINED_TOKEN },
+    { name: "anthropic-api-key", re: ANTHROPIC_API_KEY_LITERAL },
+    { name: "npm-token", re: NPM_TOKEN },
+    { name: "slack-token", re: SLACK_TOKEN },
+    { name: "stripe-key", re: STRIPE_KEY },
+    { name: "pypi-token", re: PYPI_TOKEN },
+    { name: "email", re: EMAIL },
+    { name: "ipv4", re: IPV4 },
+    { name: "ipv6", re: IPV6_FULL },
+    { name: "ipv6-compressed", re: IPV6_COMPRESSED },
+    { name: "home-path", re: HOME_PATH },
+    { name: "home-path-slug", re: HOME_PATH_SLUG },
+    { name: "connection-string", re: CONNECTION_STRING },
+    { name: "generic-secret-assignment", re: GENERIC_SECRET_ASSIGNMENT },
   ];
 }
 

--- a/packages/core/src/sanitizer.ts
+++ b/packages/core/src/sanitizer.ts
@@ -1,5 +1,3 @@
-import { homedir } from "node:os";
-
 export interface SecretMatch {
   pattern: string;
   offset: number;
@@ -105,11 +103,11 @@ function buildPatterns(): PatternDef[] {
     },
     {
       name: "well-known-env",
-      re: new RegExp(`(?<=${wellKnownPattern})["']?\\s*[:=]\\s*["']?([A-Za-z0-9_/+\\-.=]{8,})`, "gi"),
+      re: new RegExp(`(?<=(?:${wellKnownPattern})["']?\\s*[:=]\\s*["']?)[A-Za-z0-9_/+\\-.=]{8,}`, "gi"),
     },
     {
       name: "env-key-value",
-      re: new RegExp(`(?:[A-Z_]*(?:${suffixPattern}))["']?\\s*[:=]\\s*["']?([A-Za-z0-9_/+\\-.=]{8,})`, "gi"),
+      re: new RegExp(`(?<=[A-Z_]*(?:${suffixPattern})["']?\\s*[:=]\\s*["']?)[A-Za-z0-9_/+\\-.=]{8,}`, "gi"),
     },
     {
       name: "private-key-block",
@@ -293,6 +291,7 @@ function isKnownFalsePositive(patternName: string, matched: string): boolean {
   if (patternName === "aws-secret-key") {
     if (/^[A-Za-z]+$/.test(matched)) return true;
     if (/^[0-9]+$/.test(matched)) return true;
+    if (/^[0-9a-fA-F]+$/.test(matched)) return true;
     if (matched.length < 40) return true;
   }
 
@@ -306,8 +305,4 @@ function isKnownFalsePositive(patternName: string, matched: string): boolean {
 
 export function sanitizeForRecording(ndjsonLine: string): SanitizeResult {
   return sanitizeText(ndjsonLine);
-}
-
-export function buildHomePath(): string {
-  return homedir();
 }

--- a/packages/core/src/sanitizer.ts
+++ b/packages/core/src/sanitizer.ts
@@ -151,7 +151,7 @@ function buildPatterns(): PatternDef[] {
     },
     {
       name: "home-path-slug",
-      re: /-Users-[A-Za-z0-9._-]+-/g,
+      re: /-(?:Users|home)-[A-Za-z0-9._-]+-/g,
     },
     {
       name: "connection-string",
@@ -203,13 +203,11 @@ export function sanitizeText(text: string): SanitizeResult {
   for (const { name, re } of getPatterns()) {
     const pattern = new RegExp(re.source, re.flags);
     const placeholder = redactionPlaceholder(name);
-    let replaced = false;
     result = result.replace(pattern, (match) => {
       if (isKnownFalsePositive(name, match)) return match;
-      replaced = true;
+      replacements++;
       return placeholder;
     });
-    if (replaced) replacements++;
   }
 
   const residual = scanSecrets(result);
@@ -236,8 +234,9 @@ export function sanitizeJsonPayload(obj: unknown): { sanitized: unknown; replace
     if (val !== null && typeof val === "object") {
       const out: Record<string, unknown> = {};
       for (const [k, v] of Object.entries(val as Record<string, unknown>)) {
-        const sanitizedKey = sanitizeText(k).text;
-        out[sanitizedKey] = walk(v);
+        const keyResult = sanitizeText(k);
+        total += keyResult.replacements;
+        out[keyResult.text] = walk(v);
       }
       return out;
     }

--- a/packages/core/src/sanitizer.ts
+++ b/packages/core/src/sanitizer.ts
@@ -1,0 +1,313 @@
+import { homedir } from "node:os";
+
+export interface SecretMatch {
+  pattern: string;
+  offset: number;
+  length: number;
+  matched: string;
+}
+
+export interface ScanResult {
+  matches: SecretMatch[];
+  clean: boolean;
+}
+
+export interface SanitizeResult {
+  text: string;
+  replacements: number;
+  residualMatches: SecretMatch[];
+  clean: boolean;
+}
+
+interface PatternDef {
+  name: string;
+  re: RegExp;
+}
+
+const ENV_KEY_NAMES = [
+  "API_KEY",
+  "API_SECRET",
+  "SECRET_KEY",
+  "ACCESS_KEY",
+  "PRIVATE_KEY",
+  "AUTH_TOKEN",
+  "BEARER_TOKEN",
+  "SESSION_TOKEN",
+  "REFRESH_TOKEN",
+  "CLIENT_SECRET",
+  "ENCRYPTION_KEY",
+  "SIGNING_KEY",
+  "MASTER_KEY",
+  "DATABASE_URL",
+  "DATABASE_PASSWORD",
+  "DB_PASSWORD",
+  "REDIS_PASSWORD",
+  "REDIS_URL",
+  "MONGO_URI",
+  "MONGODB_URI",
+  "POSTGRES_PASSWORD",
+  "MYSQL_PASSWORD",
+];
+
+const WELL_KNOWN_ENVS = [
+  "GH_TOKEN",
+  "GITHUB_TOKEN",
+  "OPENAI_API_KEY",
+  "ANTHROPIC_API_KEY",
+  "AWS_SECRET_ACCESS_KEY",
+  "AWS_SESSION_TOKEN",
+  "AZURE_CLIENT_SECRET",
+  "SLACK_TOKEN",
+  "SLACK_BOT_TOKEN",
+  "STRIPE_SECRET_KEY",
+  "SENDGRID_API_KEY",
+  "TWILIO_AUTH_TOKEN",
+  "NPM_TOKEN",
+  "SENTRY_DSN",
+  "DATADOG_API_KEY",
+  "NEWRELIC_LICENSE_KEY",
+  "CLOUDFLARE_API_KEY",
+  "HEROKU_API_KEY",
+  "GITLAB_TOKEN",
+  "BITBUCKET_TOKEN",
+  "CODECOV_TOKEN",
+  "SONAR_TOKEN",
+  "DOCKER_PASSWORD",
+  "PYPI_TOKEN",
+  "NUGET_API_KEY",
+  "SSH_PRIVATE_KEY",
+];
+
+function buildPatterns(): PatternDef[] {
+  const suffixPattern = ENV_KEY_NAMES.map((k) => k.replace(/_/g, "[_-]")).join("|");
+  const wellKnownPattern = WELL_KNOWN_ENVS.map((k) => k.replace(/_/g, "[_-]")).join("|");
+
+  return [
+    {
+      name: "aws-access-key",
+      re: /\bAKIA[0-9A-Z]{16}\b/g,
+    },
+    {
+      name: "aws-secret-key",
+      re: /\b[A-Za-z0-9/+=]{40}(?=\s|"|'|$)/gm,
+    },
+    {
+      name: "jwt",
+      re: /\beyJ[A-Za-z0-9_-]{10,}\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g,
+    },
+    {
+      name: "authorization-header",
+      re: /(?<=["']?(?:Authorization|authorization|Proxy-Authorization|proxy-authorization)["']?\s*[:=]\s*["']?)(?:Bearer |Basic |Token |token )?[A-Za-z0-9_/+\-.=]{20,}/g,
+    },
+    {
+      name: "generic-api-key-header",
+      re: /(?<=["']?(?:X-API-Key|x-api-key|X-Api-Key|api[_-]?key)["']?\s*[:=]\s*["']?)[A-Za-z0-9_/+\-.=]{16,}/g,
+    },
+    {
+      name: "well-known-env",
+      re: new RegExp(`(?<=${wellKnownPattern})["']?\\s*[:=]\\s*["']?([A-Za-z0-9_/+\\-.=]{8,})`, "gi"),
+    },
+    {
+      name: "env-key-value",
+      re: new RegExp(`(?:[A-Z_]*(?:${suffixPattern}))["']?\\s*[:=]\\s*["']?([A-Za-z0-9_/+\\-.=]{8,})`, "gi"),
+    },
+    {
+      name: "private-key-block",
+      re: /-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----/g,
+    },
+    {
+      name: "github-token",
+      re: /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}\b/g,
+    },
+    {
+      name: "npm-token",
+      re: /\bnpm_[A-Za-z0-9]{36,}\b/g,
+    },
+    {
+      name: "slack-token",
+      re: /\bxox[bpars]-[A-Za-z0-9\-]{10,}\b/g,
+    },
+    {
+      name: "stripe-key",
+      re: /\b(?:sk|pk|rk)_(?:live|test)_[A-Za-z0-9]{20,}\b/g,
+    },
+    {
+      name: "email",
+      re: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/g,
+    },
+    {
+      name: "ipv4",
+      re: /\b(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\b/g,
+    },
+    {
+      name: "ipv6",
+      re: /\b(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}\b/g,
+    },
+    {
+      name: "ipv6-compressed",
+      re: /\b(?:[0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}\b/g,
+    },
+    {
+      name: "home-path",
+      re: /(?:\/Users\/|\/home\/)[A-Za-z0-9._-]+\//g,
+    },
+    {
+      name: "home-path-slug",
+      re: /-Users-[A-Za-z0-9._-]+-/g,
+    },
+    {
+      name: "connection-string",
+      re: /\b(?:mongodb|postgres|postgresql|mysql|redis|amqp|amqps):\/\/[^\s"'`,;)}\]]+/gi,
+    },
+    {
+      name: "generic-secret-assignment",
+      re: /(?<=["']?(?:password|passwd|secret|credential|token)["']?\s*[:=]\s*["']?)[A-Za-z0-9_/+\-.=!@#$%^&*]{8,}/gi,
+    },
+  ];
+}
+
+let _patterns: PatternDef[] | null = null;
+function getPatterns(): PatternDef[] {
+  if (!_patterns) _patterns = buildPatterns();
+  return _patterns;
+}
+
+export function scanSecrets(text: string): ScanResult {
+  const matches: SecretMatch[] = [];
+
+  for (const { name, re } of getPatterns()) {
+    const pattern = new RegExp(re.source, re.flags);
+    for (let m = pattern.exec(text); m !== null; m = pattern.exec(text)) {
+      if (isKnownFalsePositive(name, m[0])) continue;
+      matches.push({
+        pattern: name,
+        offset: m.index,
+        length: m[0].length,
+        matched: m[0],
+      });
+    }
+  }
+
+  return { matches, clean: matches.length === 0 };
+}
+
+const PLACEHOLDER_PREFIX = "[REDACTED";
+const PLACEHOLDER_SUFFIX = "]";
+
+function redactionPlaceholder(patternName: string): string {
+  return `${PLACEHOLDER_PREFIX}:${patternName}${PLACEHOLDER_SUFFIX}`;
+}
+
+export function sanitizeText(text: string): SanitizeResult {
+  let result = text;
+  let replacements = 0;
+
+  for (const { name, re } of getPatterns()) {
+    const pattern = new RegExp(re.source, re.flags);
+    const placeholder = redactionPlaceholder(name);
+    let replaced = false;
+    result = result.replace(pattern, (match) => {
+      if (isKnownFalsePositive(name, match)) return match;
+      replaced = true;
+      return placeholder;
+    });
+    if (replaced) replacements++;
+  }
+
+  const residual = scanSecrets(result);
+  return {
+    text: result,
+    replacements,
+    residualMatches: residual.matches,
+    clean: residual.clean,
+  };
+}
+
+export function sanitizeJsonPayload(obj: unknown): { sanitized: unknown; replacements: number } {
+  let total = 0;
+
+  function walk(val: unknown): unknown {
+    if (typeof val === "string") {
+      const { text, replacements } = sanitizeText(val);
+      total += replacements;
+      return text;
+    }
+    if (Array.isArray(val)) {
+      return val.map(walk);
+    }
+    if (val !== null && typeof val === "object") {
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(val as Record<string, unknown>)) {
+        const sanitizedKey = sanitizeText(k).text;
+        out[sanitizedKey] = walk(v);
+      }
+      return out;
+    }
+    return val;
+  }
+
+  const sanitized = walk(obj);
+  return { sanitized, replacements: total };
+}
+
+export class ResidualSecretError extends Error {
+  constructor(public readonly matches: SecretMatch[]) {
+    const summary = matches
+      .slice(0, 5)
+      .map((m) => `  ${m.pattern} at offset ${m.offset}`)
+      .join("\n");
+    super(`Residual secrets detected after sanitization:\n${summary}`);
+    this.name = "ResidualSecretError";
+  }
+}
+
+export function assertClean(text: string): void {
+  const { matches, clean } = scanSecrets(text);
+  if (!clean) {
+    throw new ResidualSecretError(matches);
+  }
+}
+
+const LOCALHOST_PATTERNS = /^(?:127\.0\.0\.\d+|0\.0\.0\.0|10\.0\.0\.\d+)$/;
+const DOCUMENTATION_IPS = /^(?:192\.0\.2\.\d+|198\.51\.100\.\d+|203\.0\.113\.\d+)$/;
+const EXAMPLE_DOMAINS = /^[^@]+@(?:example\.com|example\.org|test\.com|localhost)$/;
+
+function isKnownFalsePositive(patternName: string, matched: string): boolean {
+  if (patternName === "ipv4") {
+    if (LOCALHOST_PATTERNS.test(matched)) return true;
+    if (DOCUMENTATION_IPS.test(matched)) return true;
+    if (matched === "255.255.255.0" || matched === "255.255.255.255") return true;
+    if (/^\d+\.\d+\.\d+$/.test(matched)) return true;
+  }
+
+  if (patternName === "email") {
+    if (EXAMPLE_DOMAINS.test(matched)) return true;
+    if (matched.endsWith("@users.noreply.github.com")) return true;
+    if (matched === "noreply@anthropic.com") return true;
+  }
+
+  if (patternName === "home-path") {
+    if (matched === "/Users/Shared/" || matched === "/home/runner/") return true;
+  }
+
+  if (patternName === "aws-secret-key") {
+    if (/^[A-Za-z]+$/.test(matched)) return true;
+    if (/^[0-9]+$/.test(matched)) return true;
+    if (matched.length < 40) return true;
+  }
+
+  if (patternName === "generic-secret-assignment") {
+    if (/^\*+$/.test(matched)) return true;
+    if (/^\[REDACTED/.test(matched)) return true;
+  }
+
+  return false;
+}
+
+export function sanitizeForRecording(ndjsonLine: string): SanitizeResult {
+  return sanitizeText(ndjsonLine);
+}
+
+export function buildHomePath(): string {
+  return homedir();
+}

--- a/packages/core/src/sanitizer.ts
+++ b/packages/core/src/sanitizer.ts
@@ -140,7 +140,8 @@ const WELL_KNOWN_ENVS = [
 const EMAIL = /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g;
 const IPV4 = /\b(?:(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\.){3}(?:25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)\b/g;
 const IPV6_FULL = /\b(?:[0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}\b/g;
-const IPV6_COMPRESSED = /\b(?:[0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}\b/g;
+const IPV6_COMPRESSED =
+  /(?:\b[0-9a-fA-F]{1,4}(?::[0-9a-fA-F]{1,4}){0,5})?::(?:[0-9a-fA-F]{1,4}(?::[0-9a-fA-F]{1,4}){0,5}\b)?/g;
 const HOME_PATH = /(?:\/Users\/|\/home\/)[A-Za-z0-9._-]+\//g;
 const HOME_PATH_SLUG = /-(?:Users|home)-[A-Za-z0-9._-]+-/g;
 
@@ -270,7 +271,13 @@ export function sanitizeJsonPayload(obj: unknown): { sanitized: unknown; replace
       for (const [k, v] of Object.entries(val as Record<string, unknown>)) {
         const keyResult = sanitizeText(k);
         total += keyResult.replacements;
-        out[keyResult.text] = walk(v);
+        let sanitizedKey = keyResult.text;
+        if (sanitizedKey in out) {
+          let n = 2;
+          while (`${sanitizedKey}_${n}` in out) n++;
+          sanitizedKey = `${sanitizedKey}_${n}`;
+        }
+        out[sanitizedKey] = walk(v);
       }
       return out;
     }
@@ -319,6 +326,10 @@ function isKnownFalsePositive(patternName: string, matched: string): boolean {
 
   if (patternName === "home-path") {
     if (matched === "/Users/Shared/" || matched === "/home/runner/") return true;
+  }
+
+  if (patternName === "ipv6-compressed") {
+    if (matched === "::" || matched === "::1") return true;
   }
 
   if (patternName === "aws-secret-key") {

--- a/packages/core/src/sanitizer.ts
+++ b/packages/core/src/sanitizer.ts
@@ -2,7 +2,7 @@ export interface SecretMatch {
   pattern: string;
   offset: number;
   length: number;
-  matched: string;
+  preview: string;
 }
 
 export interface ScanResult {
@@ -33,8 +33,9 @@ interface PatternDef {
 // AKIA = long-lived IAM keys, ASIA = STS temporary credentials.
 // Both are 20-char uppercase alphanumeric after the 4-char prefix.
 const AWS_ACCESS_KEY = /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g;
-// 40-char base64-ish secret key (appears after access key ID in configs).
-const AWS_SECRET_KEY = /\b[A-Za-z0-9/+=]{40}(?=\s|"|'|$)/gm;
+// 40-char base64-ish secret key, only when preceded by an AWS-context keyword.
+const AWS_SECRET_KEY =
+  /(?<=(?:aws_secret_access_key|AWS_SECRET_ACCESS_KEY|SecretAccessKey|secret_access_key|aws_secret)\s*[:=]\s*["']?)[A-Za-z0-9/+=]{40}(?=\s|"|'|$)/gm;
 
 // ── GitHub ─────────────────────────────────────────────────────────
 // Classic PATs (ghp_), OAuth (gho_), user-to-server (ghu_),
@@ -56,6 +57,23 @@ const SLACK_TOKEN = /\bxox[bpars]-[A-Za-z0-9\-]{10,}\b/g;
 const STRIPE_KEY = /\b(?:sk|pk|rk)_(?:live|test)_[A-Za-z0-9]{20,}\b/g;
 const PYPI_TOKEN = /\bpypi-[A-Za-z0-9_-]{16,}\b/g;
 const ANTHROPIC_API_KEY_LITERAL = /\bsk-ant-[A-Za-z0-9_-]{20,}\b/g;
+
+// ── GitLab ──────────────────────────────────────────────────────────
+// Project/personal/group access tokens + pipeline triggers.
+const GITLAB_TOKEN = /\bglpat-[A-Za-z0-9_-]{20,}\b/g;
+const GITLAB_RUNNER_TOKEN = /\bGR1348941[A-Za-z0-9_-]{20,}\b/g;
+
+// ── Google Cloud ────────────────────────────────────────────────────
+// API keys (AIza prefix), OAuth client secrets, service account key IDs.
+const GOOGLE_API_KEY = /\bAIza[A-Za-z0-9_-]{35}\b/g;
+
+// ── HashiCorp Vault ─────────────────────────────────────────────────
+// Service (hvs.), batch (hvb.), recovery (hvp.) tokens.
+const VAULT_TOKEN = /\b(?:hvs|hvb|hvp)\.[A-Za-z0-9_-]{24,}\b/g;
+
+// ── Bitbucket ───────────────────────────────────────────────────────
+// App passwords / repository access tokens.
+const BITBUCKET_TOKEN = /\bATBB[A-Za-z0-9]{32,}\b/g;
 
 // ── Header-based secrets ───────────────────────────────────────────
 const AUTHORIZATION_HEADER =
@@ -159,6 +177,11 @@ function buildPatterns(): PatternDef[] {
     { name: "slack-token", re: SLACK_TOKEN },
     { name: "stripe-key", re: STRIPE_KEY },
     { name: "pypi-token", re: PYPI_TOKEN },
+    { name: "gitlab-token", re: GITLAB_TOKEN },
+    { name: "gitlab-runner-token", re: GITLAB_RUNNER_TOKEN },
+    { name: "google-api-key", re: GOOGLE_API_KEY },
+    { name: "vault-token", re: VAULT_TOKEN },
+    { name: "bitbucket-token", re: BITBUCKET_TOKEN },
     { name: "email", re: EMAIL },
     { name: "ipv4", re: IPV4 },
     { name: "ipv6", re: IPV6_FULL },
@@ -176,6 +199,11 @@ function getPatterns(): PatternDef[] {
   return _patterns;
 }
 
+function redactPreview(raw: string): string {
+  if (raw.length <= 8) return `${raw.slice(0, 2)}***`;
+  return `${raw.slice(0, 4)}***${raw.slice(-2)}`;
+}
+
 export function scanSecrets(text: string): ScanResult {
   const matches: SecretMatch[] = [];
 
@@ -187,7 +215,7 @@ export function scanSecrets(text: string): ScanResult {
         pattern: name,
         offset: m.index,
         length: m[0].length,
-        matched: m[0],
+        preview: redactPreview(m[0]),
       });
     }
   }
@@ -294,9 +322,6 @@ function isKnownFalsePositive(patternName: string, matched: string): boolean {
   }
 
   if (patternName === "aws-secret-key") {
-    if (/^[A-Za-z]+$/.test(matched)) return true;
-    if (/^[0-9]+$/.test(matched)) return true;
-    if (/^[0-9a-fA-F]+$/.test(matched)) return true;
     if (matched.length < 40) return true;
   }
 

--- a/scripts/scan-secrets.ts
+++ b/scripts/scan-secrets.ts
@@ -1,0 +1,45 @@
+/**
+ * Reads stdin line-by-line and scans for PII / secret patterns.
+ * Exit 0 = clean, exit 1 = secrets found, exit 2 = scanner error (fail-closed).
+ *
+ * Used by the pre-commit hook to gate recordings/ and binaries/ additions.
+ */
+import { scanSecrets } from "../packages/core/src/sanitizer";
+
+async function main(): Promise<void> {
+  const chunks: string[] = [];
+  const reader = Bun.stdin.stream().getReader();
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(new TextDecoder().decode(value));
+  }
+
+  const text = chunks.join("");
+  if (!text.trim()) {
+    process.exit(0);
+  }
+
+  const { matches, clean } = scanSecrets(text);
+  if (clean) {
+    process.exit(0);
+  }
+
+  const grouped = new Map<string, number>();
+  for (const m of matches) {
+    grouped.set(m.pattern, (grouped.get(m.pattern) ?? 0) + 1);
+  }
+
+  console.error(`scan-secrets: ${matches.length} secret(s) detected:`);
+  for (const [pattern, count] of grouped) {
+    console.error(`  ${pattern}: ${count} match(es)`);
+  }
+
+  process.exit(1);
+}
+
+main().catch(() => {
+  console.error("scan-secrets: scanner error (fail-closed)");
+  process.exit(2);
+});


### PR DESCRIPTION
## Summary
- Add `packages/core/src/sanitizer.ts` — PII/secret sanitizer library with 20 pattern classes: AWS keys, JWTs, Authorization headers, GitHub/npm/Slack/Stripe tokens, private key blocks, emails, IPv4/IPv6 addresses, home paths (raw + Claude slug), connection strings, env var secrets (`*_KEY`, `*_TOKEN`, well-known names), generic secret assignments
- Defence-in-depth: `sanitizeText()` re-scans after replacement and reports residual matches; `assertClean()` throws `ResidualSecretError` on any remaining match
- Pre-commit hook (`.git-hooks/pre-commit`) gates all staged additions to `recordings/` and `agent-grid/binaries/` through `scripts/scan-secrets.ts`, fail-closed on scanner error
- False-positive allowlist: localhost/documentation IPs, example.com/anthropic.com/noreply emails, CI paths (`/home/runner/`), subnet masks, already-redacted text

## Test plan
- [x] 98 unit tests in `sanitizer.spec.ts` covering:
  - Every pattern class (positive detection)
  - Adversarial near-misses proving non-secrets pass through unchanged (22 safe inputs)
  - Defence-in-depth: sanitize→re-scan round-trip for 13 dirty inputs + combined blob
  - `sanitizeJsonPayload` deep object/array walk
  - `assertClean` throws with match details
  - Realistic NDJSON recording line sanitization
- [x] `bun typecheck` clean
- [x] `bun lint` clean
- [x] `bun run doing-it-wrong` — 0 violations across 36 rules
- [x] Pre-commit hook passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)