### PR TITLE
feat(agent-grid): local runner skeleton — mcx agent-grid run (fixes #2585)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -58,6 +58,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@mcp-cli/acp": "workspace:*",
+        "@mcp-cli/agent-grid": "workspace:*",
         "@mcp-cli/clone": "workspace:*",
         "@mcp-cli/core": "workspace:*",
         "jq-web": "^0.6.2",

--- a/packages/command/package.json
+++ b/packages/command/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "@mcp-cli/acp": "workspace:*",
+    "@mcp-cli/agent-grid": "workspace:*",
     "@mcp-cli/clone": "workspace:*",
     "@mcp-cli/core": "workspace:*",
     "jq-web": "^0.6.2",

--- a/packages/command/src/commands/agent-grid.spec.ts
+++ b/packages/command/src/commands/agent-grid.spec.ts
@@ -1,68 +1,71 @@
-import { describe, expect, test } from "bun:test";
-import { parseFlags } from "../flags";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
+import type { GridTest } from "@mcp-cli/agent-grid";
+import { gateTest } from "@mcp-cli/agent-grid";
+import { type AgentProvider, getProvider } from "@mcp-cli/core";
+import {
+  type GridRunReport,
+  type RunOptions,
+  cmdAgentGrid,
+  discoverTests,
+  formatReportText,
+  parseRunArgs,
+  resolveProviders,
+  runGridForProvider,
+} from "./agent-grid";
 
-describe("agent-grid run flag parsing", () => {
-  function parse(argv: string[]) {
-    return parseFlags(argv, {
-      providers: { type: "string", alias: "p" },
-      version: { type: "string" },
-      offline: { type: "boolean" },
-      record: { type: "string", alias: "r" },
-      "commit-outcome": { type: "boolean" },
-      json: { type: "boolean" },
-    });
-  }
+// ── Helpers ────────────────────────────────────────────────────────
+
+function mustParse(argv: string[]): RunOptions {
+  const opts = parseRunArgs(argv);
+  if (!opts) throw new Error("parseRunArgs returned null");
+  return opts;
+}
+
+function mustGetProvider(name: string): AgentProvider {
+  const p = getProvider(name);
+  if (!p) throw new Error(`provider "${name}" not registered`);
+  return p;
+}
+
+describe("parseRunArgs", () => {
+  test("returns null on --help", () => {
+    expect(parseRunArgs(["--help"])).toBeNull();
+  });
 
   test("parses --providers with comma-separated values", () => {
-    const { flags, errors } = parse(["--providers", "codex,claude"]);
-    expect(errors).toEqual([]);
-    expect(flags.providers).toBe("codex,claude");
+    expect(mustParse(["--providers", "codex,claude"]).providers).toEqual(["codex", "claude"]);
   });
 
   test("parses -p alias", () => {
-    const { flags, errors } = parse(["-p", "mock"]);
-    expect(errors).toEqual([]);
-    expect(flags.providers).toBe("mock");
+    expect(mustParse(["-p", "mock"]).providers).toEqual(["mock"]);
   });
 
   test("parses --version", () => {
-    const { flags, errors } = parse(["--version", "2.1.119"]);
-    expect(errors).toEqual([]);
-    expect(flags.version).toBe("2.1.119");
+    expect(mustParse(["--version", "2.1.119"]).version).toBe("2.1.119");
   });
 
   test("parses --offline boolean", () => {
-    const { flags, errors } = parse(["--offline"]);
-    expect(errors).toEqual([]);
-    expect(flags.offline).toBe(true);
+    expect(mustParse(["--offline"]).offline).toBe(true);
   });
 
   test("parses --record with path", () => {
-    const { flags, errors } = parse(["--record", "./out.ndjson"]);
-    expect(errors).toEqual([]);
-    expect(flags.record).toBe("./out.ndjson");
+    expect(mustParse(["--record", "./out.ndjson"]).record).toBe("./out.ndjson");
   });
 
   test("parses -r alias for record", () => {
-    const { flags, errors } = parse(["-r", "/tmp/rec.ndjson"]);
-    expect(errors).toEqual([]);
-    expect(flags.record).toBe("/tmp/rec.ndjson");
+    expect(mustParse(["-r", "/tmp/rec.ndjson"]).record).toBe("/tmp/rec.ndjson");
   });
 
   test("parses --commit-outcome boolean", () => {
-    const { flags, errors } = parse(["--commit-outcome"]);
-    expect(errors).toEqual([]);
-    expect(flags["commit-outcome"]).toBe(true);
+    expect(mustParse(["--commit-outcome"]).commitOutcome).toBe(true);
   });
 
   test("parses --json boolean", () => {
-    const { flags, errors } = parse(["--json"]);
-    expect(errors).toEqual([]);
-    expect(flags.json).toBe(true);
+    expect(mustParse(["--json"]).json).toBe(true);
   });
 
   test("parses combined flags", () => {
-    const { flags, errors } = parse([
+    const opts = mustParse([
       "--providers",
       "codex",
       "--version",
@@ -73,88 +76,322 @@ describe("agent-grid run flag parsing", () => {
       "--commit-outcome",
       "--json",
     ]);
-    expect(errors).toEqual([]);
-    expect(flags.providers).toBe("codex");
-    expect(flags.version).toBe("0.30.1");
-    expect(flags.offline).toBe(true);
-    expect(flags.record).toBe("./out.ndjson");
-    expect(flags["commit-outcome"]).toBe(true);
-    expect(flags.json).toBe(true);
-  });
-
-  test("reports unknown flags", () => {
-    const { errors } = parse(["--bogus"]);
-    expect(errors.length).toBeGreaterThan(0);
-    expect(errors[0]).toContain("--bogus");
+    expect(opts.providers).toEqual(["codex"]);
+    expect(opts.version).toBe("0.30.1");
+    expect(opts.offline).toBe(true);
+    expect(opts.record).toBe("./out.ndjson");
+    expect(opts.commitOutcome).toBe(true);
+    expect(opts.json).toBe(true);
   });
 
   test("parses = syntax", () => {
-    const { flags, errors } = parse(["--providers=claude,codex"]);
-    expect(errors).toEqual([]);
-    expect(flags.providers).toBe("claude,codex");
+    expect(mustParse(["--providers=claude,codex"]).providers).toEqual(["claude", "codex"]);
   });
 
-  test("--help flag detected", () => {
-    const { help } = parse(["--help"]);
-    expect(help).toBe(true);
-  });
-
-  test("defaults omitted flags to undefined", () => {
-    const { flags, errors } = parse([]);
-    expect(errors).toEqual([]);
-    expect(flags.providers).toBeUndefined();
-    expect(flags.version).toBeUndefined();
-    expect(flags.offline).toBeUndefined();
-    expect(flags.record).toBeUndefined();
-    expect(flags["commit-outcome"]).toBeUndefined();
-    expect(flags.json).toBeUndefined();
+  test("defaults omitted flags", () => {
+    const opts = mustParse([]);
+    expect(opts.providers).toEqual([]);
+    expect(opts.version).toBeNull();
+    expect(opts.offline).toBe(false);
+    expect(opts.record).toBeNull();
+    expect(opts.commitOutcome).toBe(false);
+    expect(opts.json).toBe(false);
   });
 });
 
-describe("agent-grid provider resolution", () => {
-  test("getAllProviders returns registered providers", async () => {
-    const { getAllProviders } = await import("@mcp-cli/core");
-    const providers = getAllProviders();
-    expect(providers.length).toBeGreaterThan(0);
+// ── resolveProviders ───────────────────────────────────────────────
+
+describe("resolveProviders", () => {
+  test("default excludes mock", () => {
+    const providers = resolveProviders([]);
     const names = providers.map((p) => p.name);
+    expect(names).not.toContain("mock");
+    expect(names.length).toBeGreaterThan(0);
     expect(names).toContain("claude");
-    expect(names).toContain("mock");
   });
 
-  test("getProvider returns undefined for unknown provider", async () => {
-    const { getProvider } = await import("@mcp-cli/core");
-    expect(getProvider("nonexistent-provider")).toBeUndefined();
+  test("explicit --providers=mock is allowed", () => {
+    const providers = resolveProviders(["mock"]);
+    expect(providers).toHaveLength(1);
+    expect(providers[0].name).toBe("mock");
+  });
+
+  test("resolves multiple named providers", () => {
+    const providers = resolveProviders(["claude", "codex"]);
+    expect(providers).toHaveLength(2);
+    expect(providers[0].name).toBe("claude");
+    expect(providers[1].name).toBe("codex");
   });
 });
 
-describe("agent-grid gating integration", () => {
-  test("gateTest skips when provider lacks features", async () => {
-    const { getProvider } = await import("@mcp-cli/core");
-    const { gateTest } = await import("@mcp-cli/agent-grid");
-    const codex = getProvider("codex");
-    if (!codex) throw new Error("codex not registered");
+// ── discoverTests ──────────────────────────────────────────────────
 
-    const test = {
+describe("discoverTests", () => {
+  test("returns empty array (skeleton)", () => {
+    expect(discoverTests()).toEqual([]);
+  });
+});
+
+// ── runGridForProvider ─────────────────────────────────────────────
+
+describe("runGridForProvider", () => {
+  const defaultOpts = { version: null, record: null, offline: false };
+
+  test("returns empty outcomes for empty test suite", async () => {
+    const claude = mustGetProvider("claude");
+    const report = await runGridForProvider(claude, [], defaultOpts);
+    expect(report.provider).toBe("claude");
+    expect(report.outcomes).toEqual([]);
+    expect(report.summary).toEqual({ pass: 0, fail: 0, na: 0 });
+  });
+
+  test("records version in report", async () => {
+    const claude = mustGetProvider("claude");
+    const report = await runGridForProvider(claude, [], { ...defaultOpts, version: "2.1.119" });
+    expect(report.version).toBe("2.1.119");
+  });
+
+  test("gates tests by provider capabilities", async () => {
+    const codex = mustGetProvider("codex");
+    const gridTest: GridTest = {
       name: "needs-worktree",
-      requires: ["worktree" as const],
-      run: async () => ({ status: "pass" as const }),
+      requires: ["worktree"],
+      run: async () => ({ status: "pass" }),
     };
-    const result = gateTest(test, codex);
+    const report = await runGridForProvider(codex, [gridTest], defaultOpts);
+    expect(report.outcomes).toHaveLength(1);
+    expect(report.outcomes[0].result.status).toBe("n/a");
+  });
+
+  test("runs passing test", async () => {
+    const claude = mustGetProvider("claude");
+    const gridTest: GridTest = {
+      name: "always-pass",
+      requires: [],
+      run: async () => ({ status: "pass" }),
+    };
+    const report = await runGridForProvider(claude, [gridTest], defaultOpts);
+    expect(report.outcomes).toHaveLength(1);
+    expect(report.outcomes[0].result.status).toBe("pass");
+    expect(report.summary.pass).toBe(1);
+  });
+
+  test("catches test that throws", async () => {
+    const claude = mustGetProvider("claude");
+    const gridTest: GridTest = {
+      name: "throw-test",
+      requires: [],
+      run: async () => {
+        throw new Error("boom");
+      },
+    };
+    const report = await runGridForProvider(claude, [gridTest], defaultOpts);
+    expect(report.outcomes).toHaveLength(1);
+    expect(report.outcomes[0].result.status).toBe("fail");
+    expect((report.outcomes[0].result as { error: string }).error).toBe("boom");
+    expect(report.summary.fail).toBe(1);
+  });
+
+  test("aggregates mixed results", async () => {
+    const claude = mustGetProvider("claude");
+    const tests: GridTest[] = [
+      { name: "pass-test", requires: [], run: async () => ({ status: "pass" }) },
+      { name: "fail-test", requires: [], run: async () => ({ status: "fail", error: "bad" }) },
+      { name: "gated-test", requires: ["agentSelect"], run: async () => ({ status: "pass" }) },
+    ];
+    const report = await runGridForProvider(claude, tests, defaultOpts);
+    expect(report.summary).toEqual({ pass: 1, fail: 1, na: 1 });
+  });
+
+  test("provides cwd to test runner", async () => {
+    let receivedCwd = "";
+    const claude = mustGetProvider("claude");
+    const gridTest: GridTest = {
+      name: "cwd-check",
+      requires: [],
+      run: async (ctx) => {
+        receivedCwd = ctx.cwd;
+        return { status: "pass" };
+      },
+    };
+    await runGridForProvider(claude, [gridTest], defaultOpts);
+    expect(receivedCwd).toContain("agent-grid-claude-");
+  });
+});
+
+// ── formatReportText ───────────────────────────────────────────────
+
+describe("formatReportText", () => {
+  test("no providers message", () => {
+    const report: GridRunReport = { providers: [], elapsed_ms: 10 };
+    expect(formatReportText(report)).toContain("No providers selected.");
+  });
+
+  test("shows (no tests registered) for empty outcomes", () => {
+    const report: GridRunReport = {
+      providers: [
+        {
+          provider: "claude",
+          version: null,
+          outcomes: [],
+          summary: { pass: 0, fail: 0, na: 0 },
+        },
+      ],
+      elapsed_ms: 5,
+    };
+    const text = formatReportText(report);
+    expect(text).toContain("claude");
+    expect(text).toContain("(no tests registered)");
+    expect(text).toContain("elapsed: 5ms");
+  });
+
+  test("shows version when present", () => {
+    const report: GridRunReport = {
+      providers: [
+        {
+          provider: "codex",
+          version: "0.30.1",
+          outcomes: [],
+          summary: { pass: 0, fail: 0, na: 0 },
+        },
+      ],
+      elapsed_ms: 1,
+    };
+    expect(formatReportText(report)).toContain("codex@0.30.1");
+  });
+
+  test("formats pass/fail/na summary line", () => {
+    const report: GridRunReport = {
+      providers: [
+        {
+          provider: "claude",
+          version: null,
+          outcomes: [
+            { test: "t1", result: { status: "pass" } },
+            { test: "t2", result: { status: "fail", error: "broke" } },
+            { test: "t3", result: { status: "n/a", reason: "missing X" } },
+          ],
+          summary: { pass: 1, fail: 1, na: 1 },
+        },
+      ],
+      elapsed_ms: 42,
+    };
+    const text = formatReportText(report);
+    expect(text).toContain("1 pass");
+    expect(text).toContain("1 fail");
+    expect(text).toContain("1 n/a");
+    expect(text).toContain("broke");
+    expect(text).toContain("missing X");
+  });
+});
+
+// ── cmdAgentGrid (integration) ─────────────────────────────────────
+
+describe("cmdAgentGrid", () => {
+  let logSpy: ReturnType<typeof spyOn>;
+  let errorSpy: ReturnType<typeof spyOn>;
+
+  function stderrLines(): string[] {
+    return errorSpy.mock.calls.map((a: unknown[]) => String(a[0]));
+  }
+
+  beforeEach(() => {
+    logSpy = spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  test("--help prints to stdout", async () => {
+    await cmdAgentGrid(["--help"]);
+    expect(logSpy).toHaveBeenCalled();
+    const output = logSpy.mock.calls[0][0] as string;
+    expect(output).toContain("agent-grid");
+  });
+
+  test("no args prints help to stdout", async () => {
+    await cmdAgentGrid([]);
+    expect(logSpy).toHaveBeenCalled();
+  });
+
+  test("run --help prints subcommand help to stdout", async () => {
+    await cmdAgentGrid(["run", "--help"]);
+    expect(logSpy).toHaveBeenCalled();
+    const output = logSpy.mock.calls[0][0] as string;
+    expect(output).toContain("agent-grid run");
+  });
+
+  test("run with empty suite warns on stderr", async () => {
+    await cmdAgentGrid(["run", "--providers=claude", "--json"]);
+    expect(stderrLines().some((s: string) => s.includes("no tests registered"))).toBe(true);
+  });
+
+  test("run --json outputs valid JSON", async () => {
+    await cmdAgentGrid(["run", "--providers=claude", "--json"]);
+    expect(logSpy).toHaveBeenCalled();
+    const output = logSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.providers).toBeArray();
+    expect(parsed.providers[0].provider).toBe("claude");
+    expect(parsed.elapsed_ms).toBeNumber();
+  });
+
+  test("run text output includes provider name", async () => {
+    await cmdAgentGrid(["run", "--providers=codex"]);
+    expect(logSpy).toHaveBeenCalled();
+    const output = logSpy.mock.calls[0][0] as string;
+    expect(output).toContain("codex");
+    expect(output).toContain("(no tests registered)");
+  });
+
+  test("run --offline warns not yet implemented", async () => {
+    await cmdAgentGrid(["run", "--providers=claude", "--offline", "--json"]);
+    expect(stderrLines().some((s: string) => s.includes("--offline") && s.includes("not yet implemented"))).toBe(true);
+  });
+
+  test("run --record warns not yet implemented", async () => {
+    await cmdAgentGrid(["run", "--providers=claude", "--record=./out.ndjson", "--json"]);
+    expect(stderrLines().some((s: string) => s.includes("--record") && s.includes("not yet implemented"))).toBe(true);
+  });
+
+  test("run --version warns not yet implemented", async () => {
+    await cmdAgentGrid(["run", "--providers=claude", "--version=2.1.119", "--json"]);
+    expect(stderrLines().some((s: string) => s.includes("--version") && s.includes("not yet implemented"))).toBe(true);
+  });
+
+  test("run --commit-outcome warns not yet implemented", async () => {
+    await cmdAgentGrid(["run", "--providers=claude", "--commit-outcome", "--json"]);
+    expect(stderrLines().some((s: string) => s.includes("--commit-outcome") && s.includes("not yet implemented"))).toBe(
+      true,
+    );
+  });
+});
+
+// ── gateTest integration (from agent-grid package) ─────────────────
+
+describe("gateTest integration", () => {
+  test("gates codex out of worktree tests", () => {
+    const codex = mustGetProvider("codex");
+    const gridTest: GridTest = {
+      name: "needs-worktree",
+      requires: ["worktree"],
+      run: async () => ({ status: "pass" }),
+    };
+    const result = gateTest(gridTest, codex);
     expect(result).not.toBeNull();
     expect(result?.status).toBe("n/a");
   });
 
-  test("gateTest allows when provider has features", async () => {
-    const { getProvider } = await import("@mcp-cli/core");
-    const { gateTest } = await import("@mcp-cli/agent-grid");
-    const claude = getProvider("claude");
-    if (!claude) throw new Error("claude not registered");
-
-    const test = {
+  test("allows claude for worktree tests", () => {
+    const claude = mustGetProvider("claude");
+    const gridTest: GridTest = {
       name: "needs-worktree",
-      requires: ["worktree" as const],
-      run: async () => ({ status: "pass" as const }),
+      requires: ["worktree"],
+      run: async () => ({ status: "pass" }),
     };
-    expect(gateTest(test, claude)).toBeNull();
+    expect(gateTest(gridTest, claude)).toBeNull();
   });
 });

--- a/packages/command/src/commands/agent-grid.spec.ts
+++ b/packages/command/src/commands/agent-grid.spec.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "bun:test";
+import { parseFlags } from "../flags";
+
+describe("agent-grid run flag parsing", () => {
+  function parse(argv: string[]) {
+    return parseFlags(argv, {
+      providers: { type: "string", alias: "p" },
+      version: { type: "string" },
+      offline: { type: "boolean" },
+      record: { type: "string", alias: "r" },
+      "commit-outcome": { type: "boolean" },
+      json: { type: "boolean" },
+    });
+  }
+
+  test("parses --providers with comma-separated values", () => {
+    const { flags, errors } = parse(["--providers", "codex,claude"]);
+    expect(errors).toEqual([]);
+    expect(flags.providers).toBe("codex,claude");
+  });
+
+  test("parses -p alias", () => {
+    const { flags, errors } = parse(["-p", "mock"]);
+    expect(errors).toEqual([]);
+    expect(flags.providers).toBe("mock");
+  });
+
+  test("parses --version", () => {
+    const { flags, errors } = parse(["--version", "2.1.119"]);
+    expect(errors).toEqual([]);
+    expect(flags.version).toBe("2.1.119");
+  });
+
+  test("parses --offline boolean", () => {
+    const { flags, errors } = parse(["--offline"]);
+    expect(errors).toEqual([]);
+    expect(flags.offline).toBe(true);
+  });
+
+  test("parses --record with path", () => {
+    const { flags, errors } = parse(["--record", "./out.ndjson"]);
+    expect(errors).toEqual([]);
+    expect(flags.record).toBe("./out.ndjson");
+  });
+
+  test("parses -r alias for record", () => {
+    const { flags, errors } = parse(["-r", "/tmp/rec.ndjson"]);
+    expect(errors).toEqual([]);
+    expect(flags.record).toBe("/tmp/rec.ndjson");
+  });
+
+  test("parses --commit-outcome boolean", () => {
+    const { flags, errors } = parse(["--commit-outcome"]);
+    expect(errors).toEqual([]);
+    expect(flags["commit-outcome"]).toBe(true);
+  });
+
+  test("parses --json boolean", () => {
+    const { flags, errors } = parse(["--json"]);
+    expect(errors).toEqual([]);
+    expect(flags.json).toBe(true);
+  });
+
+  test("parses combined flags", () => {
+    const { flags, errors } = parse([
+      "--providers",
+      "codex",
+      "--version",
+      "0.30.1",
+      "--offline",
+      "--record",
+      "./out.ndjson",
+      "--commit-outcome",
+      "--json",
+    ]);
+    expect(errors).toEqual([]);
+    expect(flags.providers).toBe("codex");
+    expect(flags.version).toBe("0.30.1");
+    expect(flags.offline).toBe(true);
+    expect(flags.record).toBe("./out.ndjson");
+    expect(flags["commit-outcome"]).toBe(true);
+    expect(flags.json).toBe(true);
+  });
+
+  test("reports unknown flags", () => {
+    const { errors } = parse(["--bogus"]);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]).toContain("--bogus");
+  });
+
+  test("parses = syntax", () => {
+    const { flags, errors } = parse(["--providers=claude,codex"]);
+    expect(errors).toEqual([]);
+    expect(flags.providers).toBe("claude,codex");
+  });
+
+  test("--help flag detected", () => {
+    const { help } = parse(["--help"]);
+    expect(help).toBe(true);
+  });
+
+  test("defaults omitted flags to undefined", () => {
+    const { flags, errors } = parse([]);
+    expect(errors).toEqual([]);
+    expect(flags.providers).toBeUndefined();
+    expect(flags.version).toBeUndefined();
+    expect(flags.offline).toBeUndefined();
+    expect(flags.record).toBeUndefined();
+    expect(flags["commit-outcome"]).toBeUndefined();
+    expect(flags.json).toBeUndefined();
+  });
+});
+
+describe("agent-grid provider resolution", () => {
+  test("getAllProviders returns registered providers", async () => {
+    const { getAllProviders } = await import("@mcp-cli/core");
+    const providers = getAllProviders();
+    expect(providers.length).toBeGreaterThan(0);
+    const names = providers.map((p) => p.name);
+    expect(names).toContain("claude");
+    expect(names).toContain("mock");
+  });
+
+  test("getProvider returns undefined for unknown provider", async () => {
+    const { getProvider } = await import("@mcp-cli/core");
+    expect(getProvider("nonexistent-provider")).toBeUndefined();
+  });
+});
+
+describe("agent-grid gating integration", () => {
+  test("gateTest skips when provider lacks features", async () => {
+    const { getProvider } = await import("@mcp-cli/core");
+    const { gateTest } = await import("@mcp-cli/agent-grid");
+    const codex = getProvider("codex");
+    if (!codex) throw new Error("codex not registered");
+
+    const test = {
+      name: "needs-worktree",
+      requires: ["worktree" as const],
+      run: async () => ({ status: "pass" as const }),
+    };
+    const result = gateTest(test, codex);
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe("n/a");
+  });
+
+  test("gateTest allows when provider has features", async () => {
+    const { getProvider } = await import("@mcp-cli/core");
+    const { gateTest } = await import("@mcp-cli/agent-grid");
+    const claude = getProvider("claude");
+    if (!claude) throw new Error("claude not registered");
+
+    const test = {
+      name: "needs-worktree",
+      requires: ["worktree" as const],
+      run: async () => ({ status: "pass" as const }),
+    };
+    expect(gateTest(test, claude)).toBeNull();
+  });
+});

--- a/packages/command/src/commands/agent-grid.ts
+++ b/packages/command/src/commands/agent-grid.ts
@@ -17,35 +17,38 @@ import { c, printError } from "../output";
 
 // ── Types ──────────────────────────────────────────────────────────
 
-interface TestOutcome {
+export interface TestOutcome {
   test: string;
   result: GridResult;
 }
 
-interface ProviderReport {
+export interface ProviderReport {
   provider: string;
   version: string | null;
   outcomes: TestOutcome[];
   summary: { pass: number; fail: number; na: number };
 }
 
-interface GridRunReport {
+export interface GridRunReport {
   providers: ProviderReport[];
   elapsed_ms: number;
 }
 
+// ── Constants ──────────────────────────────────────────────────────
+
+const DEFAULT_TEST_TIMEOUT_MS = 30_000;
+const EXCLUDED_DEFAULT_PROVIDERS = new Set(["mock"]);
+
 // ── Test discovery ─────────────────────────────────────────────────
 
-function discoverTests(): GridTest[] {
-  // Test implementations are added by later issues in the epic.
-  // The skeleton returns an empty suite — the runner still exercises
-  // the full flag-parse → gate → report pipeline.
+export function discoverTests(): GridTest[] {
+  // Test implementations are added by later issues in the epic (#2538).
   return [];
 }
 
 // ── Runner ─────────────────────────────────────────────────────────
 
-async function runGridForProvider(
+export async function runGridForProvider(
   provider: AgentProvider,
   tests: GridTest[],
   opts: { version: string | null; record: string | null; offline: boolean },
@@ -61,7 +64,15 @@ async function runGridForProvider(
         continue;
       }
       try {
-        const result = await test.run({ provider, cwd });
+        const result = await Promise.race([
+          test.run({ provider, cwd }),
+          new Promise<never>((_, reject) =>
+            setTimeout(
+              () => reject(new Error(`test timed out after ${DEFAULT_TEST_TIMEOUT_MS}ms`)),
+              DEFAULT_TEST_TIMEOUT_MS,
+            ),
+          ),
+        ]);
         outcomes.push({ test: test.name, result });
       } catch (err) {
         outcomes.push({
@@ -89,7 +100,7 @@ async function runGridForProvider(
 
 // ── Output formatting ──────────────────────────────────────────────
 
-function formatReportText(report: GridRunReport): string {
+export function formatReportText(report: GridRunReport): string {
   const lines: string[] = [];
 
   if (report.providers.length === 0) {
@@ -131,10 +142,10 @@ registerHelp("agent-grid", {
   summary: "Agent capability grid — run tests, inspect results",
   usage: ["mcx agent-grid run [--providers=X,Y] [--version=V] [--offline] [--record=path] [--commit-outcome]"],
   options: [
-    ["--providers <names>", "Comma-separated provider names (default: all enabled)"],
+    ["--providers, -p <names>", "Comma-separated provider names (default: all enabled)"],
     ["--version <ver>", "Test a specific version (default: latest)"],
     ["--offline", "Install from LFS archive only; fail if not cached"],
-    ["--record <path>", "Save recording to path (default: temp)"],
+    ["--record, -r <path>", "Save recording to path"],
     ["--commit-outcome", "Write results back to versions.yaml"],
     ["--json", "Output raw JSON instead of formatted text"],
   ],
@@ -145,9 +156,23 @@ registerHelp("agent-grid", {
   ],
 });
 
+registerHelp("agent-grid run", {
+  name: "agent-grid run",
+  summary: "Run capability tests against agent providers",
+  usage: ["mcx agent-grid run [flags]"],
+  options: [
+    ["--providers, -p <names>", "Comma-separated provider names (default: all enabled)"],
+    ["--version <ver>", "Test a specific version (default: latest)"],
+    ["--offline", "Install from LFS archive only; fail if not cached"],
+    ["--record, -r <path>", "Save recording to path"],
+    ["--commit-outcome", "Write results back to versions.yaml"],
+    ["--json", "Output raw JSON instead of formatted text"],
+  ],
+});
+
 // ── Flag parsing ───────────────────────────────────────────────────
 
-interface RunOptions {
+export interface RunOptions {
   providers: string[];
   version: string | null;
   offline: boolean;
@@ -156,7 +181,7 @@ interface RunOptions {
   json: boolean;
 }
 
-function parseRunArgs(args: string[]): RunOptions {
+export function parseRunArgs(args: string[]): RunOptions | null {
   const { flags, errors, help } = parseFlags(args, {
     providers: { type: "string", alias: "p" },
     version: { type: "string" },
@@ -167,21 +192,7 @@ function parseRunArgs(args: string[]): RunOptions {
   });
 
   if (help) {
-    const h = formatHelp({
-      name: "agent-grid run",
-      summary: "Run capability tests against agent providers",
-      usage: ["mcx agent-grid run [flags]"],
-      options: [
-        ["--providers, -p <names>", "Comma-separated provider names (default: all enabled)"],
-        ["--version <ver>", "Test a specific version"],
-        ["--offline", "Install from LFS archive only"],
-        ["--record, -r <path>", "Save recording to path"],
-        ["--commit-outcome", "Write results back to versions.yaml"],
-        ["--json", "Output JSON"],
-      ],
-    });
-    console.error(h);
-    process.exit(0);
+    return null;
   }
 
   if (errors.length > 0) {
@@ -209,9 +220,9 @@ function parseRunArgs(args: string[]): RunOptions {
 
 // ── Resolve providers ──────────────────────────────────────────────
 
-function resolveProviders(names: string[]): AgentProvider[] {
+export function resolveProviders(names: string[]): AgentProvider[] {
   if (names.length === 0) {
-    return getAllProviders();
+    return getAllProviders().filter((p) => !EXCLUDED_DEFAULT_PROVIDERS.has(p.name));
   }
   const resolved: AgentProvider[] = [];
   for (const name of names) {
@@ -227,12 +238,41 @@ function resolveProviders(names: string[]): AgentProvider[] {
   return resolved;
 }
 
+// ── Stub flag warnings ─────────────────────────────────────────────
+
+function warnStubFlags(opts: RunOptions): void {
+  if (opts.offline) {
+    console.error(`${c.yellow}--offline: not yet implemented; network access is not restricted${c.reset}`);
+  }
+  if (opts.record) {
+    console.error(`${c.yellow}--record: not yet implemented; recording will not be saved${c.reset}`);
+  }
+  if (opts.version) {
+    console.error(`${c.yellow}--version: not yet implemented; using current installed version${c.reset}`);
+  }
+  if (opts.commitOutcome) {
+    console.error(`${c.yellow}--commit-outcome: not yet implemented; versions.yaml will not be updated${c.reset}`);
+  }
+}
+
 // ── Subcommand dispatch ────────────────────────────────────────────
 
 async function agentGridRun(args: string[]): Promise<void> {
   const opts = parseRunArgs(args);
+  if (!opts) {
+    const h = getHelp("agent-grid run");
+    if (h) console.log(formatHelp(h));
+    return;
+  }
+
+  warnStubFlags(opts);
+
   const providers = resolveProviders(opts.providers);
   const tests = discoverTests();
+
+  if (tests.length === 0) {
+    console.error(`${c.yellow}warning: no tests registered; suite is empty${c.reset}`);
+  }
 
   const start = performance.now();
 
@@ -255,10 +295,6 @@ async function agentGridRun(args: string[]): Promise<void> {
     console.log(formatReportText(report));
   }
 
-  if (opts.commitOutcome) {
-    console.error(`${c.yellow}--commit-outcome: writing to versions.yaml is not yet implemented${c.reset}`);
-  }
-
   const anyFail = providerReports.some((r) => r.summary.fail > 0);
   if (anyFail) process.exit(1);
 }
@@ -266,20 +302,25 @@ async function agentGridRun(args: string[]): Promise<void> {
 // ── Main entry ─────────────────────────────────────────────────────
 
 export async function cmdAgentGrid(args: string[]): Promise<void> {
-  if (args.length === 0 || hasHelpFlag(args)) {
-    const help = getHelp("agent-grid");
-    if (help) console.error(formatHelp(help));
+  const sub = args[0];
+
+  if (sub === "run") {
+    await agentGridRun(args.slice(1));
     return;
   }
 
-  const sub = args[0];
-  switch (sub) {
-    case "run":
-      await agentGridRun(args.slice(1));
-      break;
-    default:
-      printError(`unknown subcommand: ${sub}`);
-      console.error('Run "mcx agent-grid --help" for usage.');
-      process.exit(1);
+  if (!sub || hasHelpFlag(args)) {
+    const help = formatHelp({
+      name: "agent-grid",
+      summary: "Agent capability grid — run tests, inspect results",
+      usage: ["mcx agent-grid <subcommand> [flags]"],
+      options: [["run", "Run capability tests against agent providers"]],
+    });
+    console.log(help);
+    return;
   }
+
+  printError(`unknown subcommand: ${sub}`);
+  console.error('Run "mcx agent-grid --help" for usage.');
+  process.exit(1);
 }

--- a/packages/command/src/commands/agent-grid.ts
+++ b/packages/command/src/commands/agent-grid.ts
@@ -1,0 +1,285 @@
+/**
+ * `mcx agent-grid run` — local runner for the agent capability grid.
+ *
+ * Runs the capability test suite against one or more providers and produces
+ * a JSON capability report. Read-only by default; --commit-outcome writes
+ * results back to versions.yaml.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { type GridResult, type GridTest, gateTest } from "@mcp-cli/agent-grid";
+import { type AgentProvider, getAllProviders, getProvider } from "@mcp-cli/core";
+import { parseFlags } from "../flags";
+import { formatHelp, getHelp, hasHelpFlag, registerHelp } from "../help";
+import { c, printError } from "../output";
+
+// ── Types ──────────────────────────────────────────────────────────
+
+interface TestOutcome {
+  test: string;
+  result: GridResult;
+}
+
+interface ProviderReport {
+  provider: string;
+  version: string | null;
+  outcomes: TestOutcome[];
+  summary: { pass: number; fail: number; na: number };
+}
+
+interface GridRunReport {
+  providers: ProviderReport[];
+  elapsed_ms: number;
+}
+
+// ── Test discovery ─────────────────────────────────────────────────
+
+function discoverTests(): GridTest[] {
+  // Test implementations are added by later issues in the epic.
+  // The skeleton returns an empty suite — the runner still exercises
+  // the full flag-parse → gate → report pipeline.
+  return [];
+}
+
+// ── Runner ─────────────────────────────────────────────────────────
+
+async function runGridForProvider(
+  provider: AgentProvider,
+  tests: GridTest[],
+  opts: { version: string | null; record: string | null; offline: boolean },
+): Promise<ProviderReport> {
+  const outcomes: TestOutcome[] = [];
+  const cwd = mkdtempSync(resolve(tmpdir(), `agent-grid-${provider.name}-`));
+
+  try {
+    for (const test of tests) {
+      const gateResult = gateTest(test, provider);
+      if (gateResult) {
+        outcomes.push({ test: test.name, result: gateResult });
+        continue;
+      }
+      try {
+        const result = await test.run({ provider, cwd });
+        outcomes.push({ test: test.name, result });
+      } catch (err) {
+        outcomes.push({
+          test: test.name,
+          result: { status: "fail", error: err instanceof Error ? err.message : String(err) },
+        });
+      }
+    }
+  } finally {
+    try {
+      rmSync(cwd, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  }
+
+  const summary = {
+    pass: outcomes.filter((o) => o.result.status === "pass").length,
+    fail: outcomes.filter((o) => o.result.status === "fail").length,
+    na: outcomes.filter((o) => o.result.status === "n/a").length,
+  };
+
+  return { provider: provider.name, version: opts.version, outcomes, summary };
+}
+
+// ── Output formatting ──────────────────────────────────────────────
+
+function formatReportText(report: GridRunReport): string {
+  const lines: string[] = [];
+
+  if (report.providers.length === 0) {
+    lines.push("No providers selected.");
+    return lines.join("\n");
+  }
+
+  for (const pr of report.providers) {
+    const ver = pr.version ? `@${pr.version}` : "";
+    lines.push(`${c.bold}${pr.provider}${ver}${c.reset}`);
+
+    if (pr.outcomes.length === 0) {
+      lines.push("  (no tests registered)");
+    }
+    for (const o of pr.outcomes) {
+      const icon =
+        o.result.status === "pass"
+          ? `${c.green}pass${c.reset}`
+          : o.result.status === "fail"
+            ? `${c.red}fail${c.reset}`
+            : `${c.dim}n/a${c.reset}`;
+      let detail = "";
+      if (o.result.status === "fail") detail = ` — ${o.result.error}`;
+      else if (o.result.status === "n/a") detail = ` — ${o.result.reason}`;
+      lines.push(`  ${icon}  ${o.test}${detail}`);
+    }
+    lines.push(`  ${c.dim}(${pr.summary.pass} pass, ${pr.summary.fail} fail, ${pr.summary.na} n/a)${c.reset}`);
+    lines.push("");
+  }
+
+  lines.push(`${c.dim}elapsed: ${report.elapsed_ms}ms${c.reset}`);
+  return lines.join("\n");
+}
+
+// ── Help ───────────────────────────────────────────────────────────
+
+registerHelp("agent-grid", {
+  name: "agent-grid",
+  summary: "Agent capability grid — run tests, inspect results",
+  usage: ["mcx agent-grid run [--providers=X,Y] [--version=V] [--offline] [--record=path] [--commit-outcome]"],
+  options: [
+    ["--providers <names>", "Comma-separated provider names (default: all enabled)"],
+    ["--version <ver>", "Test a specific version (default: latest)"],
+    ["--offline", "Install from LFS archive only; fail if not cached"],
+    ["--record <path>", "Save recording to path (default: temp)"],
+    ["--commit-outcome", "Write results back to versions.yaml"],
+    ["--json", "Output raw JSON instead of formatted text"],
+  ],
+  examples: [
+    "mcx agent-grid run --providers=codex",
+    "mcx agent-grid run --providers=claude --version=2.1.119 --record=./out.ndjson",
+    "mcx agent-grid run --json",
+  ],
+});
+
+// ── Flag parsing ───────────────────────────────────────────────────
+
+interface RunOptions {
+  providers: string[];
+  version: string | null;
+  offline: boolean;
+  record: string | null;
+  commitOutcome: boolean;
+  json: boolean;
+}
+
+function parseRunArgs(args: string[]): RunOptions {
+  const { flags, errors, help } = parseFlags(args, {
+    providers: { type: "string", alias: "p" },
+    version: { type: "string" },
+    offline: { type: "boolean" },
+    record: { type: "string", alias: "r" },
+    "commit-outcome": { type: "boolean" },
+    json: { type: "boolean" },
+  });
+
+  if (help) {
+    const h = formatHelp({
+      name: "agent-grid run",
+      summary: "Run capability tests against agent providers",
+      usage: ["mcx agent-grid run [flags]"],
+      options: [
+        ["--providers, -p <names>", "Comma-separated provider names (default: all enabled)"],
+        ["--version <ver>", "Test a specific version"],
+        ["--offline", "Install from LFS archive only"],
+        ["--record, -r <path>", "Save recording to path"],
+        ["--commit-outcome", "Write results back to versions.yaml"],
+        ["--json", "Output JSON"],
+      ],
+    });
+    console.error(h);
+    process.exit(0);
+  }
+
+  if (errors.length > 0) {
+    for (const e of errors) printError(e);
+    process.exit(1);
+  }
+
+  const rawProviders = typeof flags.providers === "string" ? flags.providers : "";
+  const providerNames = rawProviders
+    ? rawProviders
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean)
+    : [];
+
+  return {
+    providers: providerNames,
+    version: typeof flags.version === "string" ? flags.version : null,
+    offline: flags.offline === true,
+    record: typeof flags.record === "string" ? flags.record : null,
+    commitOutcome: flags["commit-outcome"] === true,
+    json: flags.json === true,
+  };
+}
+
+// ── Resolve providers ──────────────────────────────────────────────
+
+function resolveProviders(names: string[]): AgentProvider[] {
+  if (names.length === 0) {
+    return getAllProviders();
+  }
+  const resolved: AgentProvider[] = [];
+  for (const name of names) {
+    const p = getProvider(name);
+    if (!p) {
+      printError(`unknown provider: ${name}`);
+      const available = getAllProviders().map((pr) => pr.name);
+      console.error(`  available: ${available.join(", ")}`);
+      process.exit(1);
+    }
+    resolved.push(p);
+  }
+  return resolved;
+}
+
+// ── Subcommand dispatch ────────────────────────────────────────────
+
+async function agentGridRun(args: string[]): Promise<void> {
+  const opts = parseRunArgs(args);
+  const providers = resolveProviders(opts.providers);
+  const tests = discoverTests();
+
+  const start = performance.now();
+
+  const providerReports: ProviderReport[] = [];
+  for (const provider of providers) {
+    const report = await runGridForProvider(provider, tests, {
+      version: opts.version,
+      record: opts.record,
+      offline: opts.offline,
+    });
+    providerReports.push(report);
+  }
+
+  const elapsed = Math.round(performance.now() - start);
+  const report: GridRunReport = { providers: providerReports, elapsed_ms: elapsed };
+
+  if (opts.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(formatReportText(report));
+  }
+
+  if (opts.commitOutcome) {
+    console.error(`${c.yellow}--commit-outcome: writing to versions.yaml is not yet implemented${c.reset}`);
+  }
+
+  const anyFail = providerReports.some((r) => r.summary.fail > 0);
+  if (anyFail) process.exit(1);
+}
+
+// ── Main entry ─────────────────────────────────────────────────────
+
+export async function cmdAgentGrid(args: string[]): Promise<void> {
+  if (args.length === 0 || hasHelpFlag(args)) {
+    const help = getHelp("agent-grid");
+    if (help) console.error(formatHelp(help));
+    return;
+  }
+
+  const sub = args[0];
+  switch (sub) {
+    case "run":
+      await agentGridRun(args.slice(1));
+      break;
+    default:
+      printError(`unknown subcommand: ${sub}`);
+      console.error('Run "mcx agent-grid --help" for usage.');
+      process.exit(1);
+  }
+}

--- a/packages/command/src/commands/completions.ts
+++ b/packages/command/src/commands/completions.ts
@@ -61,6 +61,7 @@ export const SUBCOMMANDS = [
   "export",
   "help",
   "agent",
+  "agent-grid",
   "claude",
   "pr",
   "track",

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -29,6 +29,7 @@ import {
 assertBunVersion();
 import { cmdAdd, cmdAddJson } from "./commands/add";
 import { cmdAgent } from "./commands/agent";
+import { cmdAgentGrid } from "./commands/agent-grid";
 import { cmdAlias } from "./commands/alias";
 import { cmdAuth } from "./commands/auth";
 import { cmdAutomation } from "./commands/automation";
@@ -397,6 +398,10 @@ async function main(): Promise<void> {
 
       case "agent":
         await cmdAgent(cleanArgs.slice(1));
+        break;
+
+      case "agent-grid":
+        await cmdAgentGrid(cleanArgs.slice(1));
         break;
 
       case "claude":


### PR DESCRIPTION
## Summary
- Adds `mcx agent-grid run` CLI command with `--providers`, `--version`, `--offline`, `--record`, and `--commit-outcome` flags
- Wires dispatch entry in `packages/command/src/main.ts` and `SUBCOMMANDS` registration in `completions.ts`
- Runner discovers tests from `@mcp-cli/agent-grid`, gates each by provider capabilities via `gateTest()`, runs eligible tests in isolated tmpdirs, and produces JSON or formatted text capability report
- Read-only by default — `--commit-outcome` is opt-in (stub; writing to `versions.yaml` deferred to later issue)
- Test suite is empty (skeleton) — test implementations land in later epic issues (#2538)

## Test plan
- [x] 17 new tests in `agent-grid.spec.ts`: flag parsing (all flags, aliases, `=` syntax, combined, unknown, defaults), provider resolution, gating integration
- [x] `bun typecheck` passes
- [x] `bun lint` passes
- [x] `bun run doing-it-wrong` passes (cli-surface-registered rule satisfied)
- [x] `bun run am-i-done --pre-commit` passes
- [x] All 2459 command package tests pass
- [x] Pre-push gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)