### PR TITLE
feat(agent-grid): isolation framework — fresh tmpdir, git seed, cleanup on interrupt (fixes #2586)

### DIFF
--- a/agent-grid/src/index.ts
+++ b/agent-grid/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./grid-test";
 export * from "./capability-gate";
+export * from "./isolation";

--- a/agent-grid/src/isolation.spec.ts
+++ b/agent-grid/src/isolation.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { activeEnvCount, cleanGitEnv, createIsolatedEnv } from "./isolation";
 
@@ -76,7 +76,7 @@ describe("createIsolatedEnv", () => {
 
     expect(env1.dir).not.toBe(env2.dir);
 
-    Bun.write(join(env1.dir, "env1-only.txt"), "hello");
+    writeFileSync(join(env1.dir, "env1-only.txt"), "hello");
     expect(existsSync(join(env1.dir, "env1-only.txt"))).toBe(true);
     expect(existsSync(join(env2.dir, "env1-only.txt"))).toBe(false);
   });
@@ -109,5 +109,62 @@ describe("createIsolatedEnv", () => {
       env: cleanGitEnv(),
     });
     expect(r.stdout?.toString().trim()).toBe("main");
+  });
+
+  test("cleanGitEnv strips poisoned GIT_* vars and isolates from host gitconfig", () => {
+    const original = process.env.GIT_DIR;
+    const originalIdx = process.env.GIT_INDEX_FILE;
+    const originalWork = process.env.GIT_WORK_TREE;
+    try {
+      process.env.GIT_DIR = "/tmp/bogus";
+      process.env.GIT_INDEX_FILE = "/tmp/bogus-index";
+      process.env.GIT_WORK_TREE = "/tmp/bogus-tree";
+
+      const env = cleanGitEnv();
+
+      expect(env.GIT_DIR).toBeUndefined();
+      expect(env.GIT_INDEX_FILE).toBeUndefined();
+      expect(env.GIT_WORK_TREE).toBeUndefined();
+
+      expect(env.GIT_AUTHOR_NAME).toBe("agent-grid");
+      expect(env.GIT_COMMITTER_NAME).toBe("agent-grid");
+      expect(env.GIT_CONFIG_GLOBAL).toBe("/dev/null");
+      expect(env.GIT_CONFIG_SYSTEM).toBe("/dev/null");
+    } finally {
+      if (original === undefined) process.env.GIT_DIR = undefined;
+      else process.env.GIT_DIR = original;
+      if (originalIdx === undefined) process.env.GIT_INDEX_FILE = undefined;
+      else process.env.GIT_INDEX_FILE = originalIdx;
+      if (originalWork === undefined) process.env.GIT_WORK_TREE = undefined;
+      else process.env.GIT_WORK_TREE = originalWork;
+    }
+  });
+
+  test("env creation works under poisoned GIT_DIR", () => {
+    const original = process.env.GIT_DIR;
+    try {
+      process.env.GIT_DIR = "/tmp/does-not-exist";
+      using env = createIsolatedEnv();
+      dirs.push(env.dir);
+
+      expect(existsSync(join(env.dir, ".git"))).toBe(true);
+      expect(gitStatus(env.dir)).toBe("");
+    } finally {
+      if (original === undefined) process.env.GIT_DIR = undefined;
+      else process.env.GIT_DIR = original;
+    }
+  });
+
+  test("failed git init cleans up tmpdir and propagates error", () => {
+    const before = activeEnvCount();
+    const origPath = process.env.PATH ?? "";
+    try {
+      process.env.PATH = "/nonexistent-path-for-agent-grid-test";
+      expect(() => createIsolatedEnv()).toThrow();
+    } finally {
+      process.env.PATH = origPath;
+    }
+
+    expect(activeEnvCount()).toBe(before);
   });
 });

--- a/agent-grid/src/isolation.spec.ts
+++ b/agent-grid/src/isolation.spec.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { activeEnvCount, cleanGitEnv, createIsolatedEnv } from "./isolation";
+
+function gitLog(cwd: string): string {
+  const r = spawnSync("git", ["log", "--oneline"], { cwd, stdio: ["ignore", "pipe", "ignore"], env: cleanGitEnv() });
+  return r.stdout?.toString().trim() ?? "";
+}
+
+function gitStatus(cwd: string): string {
+  const r = spawnSync("git", ["status", "--porcelain"], {
+    cwd,
+    stdio: ["ignore", "pipe", "ignore"],
+    env: cleanGitEnv(),
+  });
+  return r.stdout?.toString().trim() ?? "";
+}
+
+describe("createIsolatedEnv", () => {
+  let dirs: string[] = [];
+
+  afterEach(() => {
+    for (const d of dirs) {
+      try {
+        Bun.spawnSync(["rm", "-rf", d]);
+      } catch {
+        // already cleaned
+      }
+    }
+    dirs = [];
+  });
+
+  test("creates a tmpdir with a git repo and seed commit", () => {
+    using env = createIsolatedEnv();
+    dirs.push(env.dir);
+
+    expect(existsSync(env.dir)).toBe(true);
+    expect(existsSync(join(env.dir, ".git"))).toBe(true);
+
+    const readme = readFileSync(join(env.dir, "README.md"), "utf-8");
+    expect(readme).toBe("# agent-grid test seed\n");
+
+    const log = gitLog(env.dir);
+    expect(log).toContain("seed");
+
+    expect(gitStatus(env.dir)).toBe("");
+  });
+
+  test("cleanup removes the directory", () => {
+    const env = createIsolatedEnv();
+    const { dir } = env;
+    dirs.push(dir);
+
+    expect(existsSync(dir)).toBe(true);
+    env.cleanup();
+    expect(existsSync(dir)).toBe(false);
+  });
+
+  test("Symbol.dispose removes the directory", () => {
+    let savedDir = "";
+    {
+      using env = createIsolatedEnv();
+      savedDir = env.dir;
+      dirs.push(savedDir);
+      expect(existsSync(savedDir)).toBe(true);
+    }
+    expect(existsSync(savedDir)).toBe(false);
+  });
+
+  test("environments are independent", () => {
+    using env1 = createIsolatedEnv();
+    using env2 = createIsolatedEnv();
+    dirs.push(env1.dir, env2.dir);
+
+    expect(env1.dir).not.toBe(env2.dir);
+
+    Bun.write(join(env1.dir, "env1-only.txt"), "hello");
+    expect(existsSync(join(env1.dir, "env1-only.txt"))).toBe(true);
+    expect(existsSync(join(env2.dir, "env1-only.txt"))).toBe(false);
+  });
+
+  test("activeEnvCount tracks live environments", () => {
+    const before = activeEnvCount();
+    const env = createIsolatedEnv();
+    dirs.push(env.dir);
+
+    expect(activeEnvCount()).toBe(before + 1);
+    env.cleanup();
+    expect(activeEnvCount()).toBe(before);
+  });
+
+  test("cleanup is idempotent", () => {
+    const env = createIsolatedEnv();
+    dirs.push(env.dir);
+
+    env.cleanup();
+    expect(() => env.cleanup()).not.toThrow();
+  });
+
+  test("seed commit is on main branch", () => {
+    using env = createIsolatedEnv();
+    dirs.push(env.dir);
+
+    const r = spawnSync("git", ["branch", "--show-current"], {
+      cwd: env.dir,
+      stdio: ["ignore", "pipe", "ignore"],
+      env: cleanGitEnv(),
+    });
+    expect(r.stdout?.toString().trim()).toBe("main");
+  });
+});

--- a/agent-grid/src/isolation.ts
+++ b/agent-grid/src/isolation.ts
@@ -1,0 +1,114 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const SEED_FILE = "README.md";
+const SEED_CONTENT = "# agent-grid test seed\n";
+const SEED_MESSAGE = "seed";
+
+const activeEnvs = new Set<string>();
+let handlersInstalled = false;
+
+function installInterruptHandlers(): void {
+  if (handlersInstalled) return;
+  handlersInstalled = true;
+
+  const cleanup = () => {
+    for (const dir of activeEnvs) {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // best-effort on interrupt
+      }
+    }
+    activeEnvs.clear();
+  };
+
+  process.on("SIGINT", () => {
+    cleanup();
+    process.exit(130);
+  });
+  process.on("SIGTERM", () => {
+    cleanup();
+    process.exit(143);
+  });
+}
+
+export function cleanGitEnv(): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined && !k.startsWith("GIT_")) env[k] = v;
+  }
+  env.GIT_AUTHOR_NAME = "agent-grid";
+  env.GIT_AUTHOR_EMAIL = "agent-grid@test";
+  env.GIT_COMMITTER_NAME = "agent-grid";
+  env.GIT_COMMITTER_EMAIL = "agent-grid@test";
+  return env;
+}
+
+function git(cwd: string, args: string[]): void {
+  const result = spawnSync("git", args, {
+    cwd,
+    stdio: ["ignore", "ignore", "pipe"],
+    env: cleanGitEnv(),
+  });
+  if (result.status !== 0) {
+    const stderr = result.stderr?.toString() ?? "";
+    throw new Error(`git ${args.join(" ")} failed (exit ${result.status}): ${stderr}`);
+  }
+}
+
+/** An isolated test environment with a fresh tmpdir and seeded git repo. */
+export interface IsolatedEnv {
+  /** Absolute path to the isolated directory (git work tree root). */
+  dir: string;
+  /** Remove the directory and deregister from interrupt cleanup. */
+  cleanup(): void;
+  [Symbol.dispose](): void;
+}
+
+/**
+ * Create an isolated test environment: a fresh tmpdir with `git init` and
+ * a single seed commit. The returned object supports both explicit
+ * `cleanup()` and `using` via `Symbol.dispose`.
+ *
+ * Interrupt handlers (SIGINT/SIGTERM) are installed once per process to
+ * clean up any active environments on unexpected exit.
+ */
+export function createIsolatedEnv(): IsolatedEnv {
+  installInterruptHandlers();
+
+  const dir = mkdtempSync(join(tmpdir(), "agent-grid-"));
+
+  activeEnvs.add(dir);
+
+  try {
+    git(dir, ["init", "-b", "main"]);
+    Bun.write(join(dir, SEED_FILE), SEED_CONTENT);
+    git(dir, ["add", SEED_FILE]);
+    git(dir, ["commit", "-m", SEED_MESSAGE]);
+  } catch (e) {
+    activeEnvs.delete(dir);
+    rmSync(dir, { recursive: true, force: true });
+    throw e;
+  }
+
+  const cleanup = () => {
+    activeEnvs.delete(dir);
+    rmSync(dir, { recursive: true, force: true });
+  };
+
+  return {
+    dir,
+    cleanup,
+    [Symbol.dispose]() {
+      cleanup();
+    },
+  };
+}
+
+/** Number of currently-tracked isolated environments (for testing). */
+export function activeEnvCount(): number {
+  return activeEnvs.size;
+}

--- a/agent-grid/src/isolation.ts
+++ b/agent-grid/src/isolation.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -10,29 +10,29 @@ const SEED_MESSAGE = "seed";
 const activeEnvs = new Set<string>();
 let handlersInstalled = false;
 
+function cleanupAllEnvs(): void {
+  for (const dir of activeEnvs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // best-effort on interrupt
+    }
+  }
+  activeEnvs.clear();
+}
+
 function installInterruptHandlers(): void {
   if (handlersInstalled) return;
   handlersInstalled = true;
 
-  const cleanup = () => {
-    for (const dir of activeEnvs) {
-      try {
-        rmSync(dir, { recursive: true, force: true });
-      } catch {
-        // best-effort on interrupt
-      }
-    }
-    activeEnvs.clear();
+  const onSignal = (signal: NodeJS.Signals) => {
+    cleanupAllEnvs();
+    process.removeListener(signal, onSignal);
+    process.kill(process.pid, signal);
   };
 
-  process.on("SIGINT", () => {
-    cleanup();
-    process.exit(130);
-  });
-  process.on("SIGTERM", () => {
-    cleanup();
-    process.exit(143);
-  });
+  process.on("SIGINT", () => onSignal("SIGINT"));
+  process.on("SIGTERM", () => onSignal("SIGTERM"));
 }
 
 export function cleanGitEnv(): Record<string, string> {
@@ -44,6 +44,8 @@ export function cleanGitEnv(): Record<string, string> {
   env.GIT_AUTHOR_EMAIL = "agent-grid@test";
   env.GIT_COMMITTER_NAME = "agent-grid";
   env.GIT_COMMITTER_EMAIL = "agent-grid@test";
+  env.GIT_CONFIG_GLOBAL = "/dev/null";
+  env.GIT_CONFIG_SYSTEM = "/dev/null";
   return env;
 }
 
@@ -52,6 +54,7 @@ function git(cwd: string, args: string[]): void {
     cwd,
     stdio: ["ignore", "ignore", "pipe"],
     env: cleanGitEnv(),
+    timeout: 30_000,
   });
   if (result.status !== 0) {
     const stderr = result.stderr?.toString() ?? "";
@@ -85,7 +88,7 @@ export function createIsolatedEnv(): IsolatedEnv {
 
   try {
     git(dir, ["init", "-b", "main"]);
-    Bun.write(join(dir, SEED_FILE), SEED_CONTENT);
+    writeFileSync(join(dir, SEED_FILE), SEED_CONTENT);
     git(dir, ["add", SEED_FILE]);
     git(dir, ["commit", "-m", SEED_MESSAGE]);
   } catch (e) {


### PR DESCRIPTION
## Summary
- Adds `createIsolatedEnv()` to `@mcp-cli/agent-grid` — creates a fresh tmpdir with `git init -b main` and a seed commit for each capability test
- Cleanup fires on `Symbol.dispose` (structured `using`), explicit `cleanup()`, and SIGINT/SIGTERM handlers — no leaked tmpdirs across reruns
- Strips all `GIT_*` env vars before spawning git subprocesses (`cleanGitEnv()`) so isolation works correctly inside pre-commit/pre-push hooks (#2527 compat)

## Test plan
- [x] 7 tests covering: tmpdir + git seed creation, cleanup on dispose, cleanup on explicit call, independent envs, activeEnvCount tracking, idempotent cleanup, main branch verification
- [x] Verified tests pass under poisoned GIT env (`GIT_DIR=/tmp/bogus GIT_INDEX_FILE=... bun test`)
- [x] `bun typecheck` — clean
- [x] `bun lint` — clean
- [x] `bun run am-i-done` static gate — clean
- [x] `bun test:coverage` — clean (0 failures, all thresholds met)

🤖 Generated with [Claude Code](https://claude.com/claude-code)