### PR TITLE
feat(agent-grid): registry latest-version detection script (fixes #2584)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "dev:mcx": "bun packages/command/src/main.ts",
     "dev:mcpctl": "bun packages/control/src/main.tsx",
     "smoke-test": "bun scripts/smoke-test.ts",
+    "detect-grid": "bun scripts/agent-grid-detect.ts",
     "smoke-playwright": "bun scripts/smoke-playwright.ts",
     "prepare": "git config core.hooksPath .git-hooks"
   },

--- a/scripts/agent-grid-detect.spec.ts
+++ b/scripts/agent-grid-detect.spec.ts
@@ -3,6 +3,7 @@ import type { Provider } from "../agent-grid/versions-schema";
 import {
   type ProposedRow,
   REGISTRY,
+  compareSemVer,
   detectNewVersions,
   formatJson,
   formatYaml,
@@ -27,6 +28,42 @@ describe("parseSemVer", () => {
     expect(parseSemVer("latest")).toBeNull();
     expect(parseSemVer("")).toBeNull();
     expect(parseSemVer("abc")).toBeNull();
+  });
+
+  test("rejects garbage suffix without hyphen", () => {
+    expect(parseSemVer("1.2.3oops")).toBeNull();
+    expect(parseSemVer("1.2.3 extra")).toBeNull();
+  });
+});
+
+// ── compareSemVer ─────────────────────────────────────────────────
+
+describe("compareSemVer", () => {
+  test("returns positive when a > b", () => {
+    expect(
+      compareSemVer(
+        { major: 2, minor: 1, patch: 200, prerelease: "" },
+        { major: 2, minor: 1, patch: 119, prerelease: "" },
+      ),
+    ).toBeGreaterThan(0);
+  });
+
+  test("returns negative when a < b", () => {
+    expect(
+      compareSemVer(
+        { major: 2, minor: 1, patch: 50, prerelease: "" },
+        { major: 2, minor: 1, patch: 119, prerelease: "" },
+      ),
+    ).toBeLessThan(0);
+  });
+
+  test("returns zero when equal", () => {
+    expect(
+      compareSemVer(
+        { major: 2, minor: 1, patch: 119, prerelease: "" },
+        { major: 2, minor: 1, patch: 119, prerelease: "" },
+      ),
+    ).toBe(0);
   });
 });
 
@@ -176,6 +213,61 @@ describe("detectNewVersions", () => {
     expect(proposed).toHaveLength(0);
     expect(errors).toHaveLength(1);
     expect(errors[0]?.error).toContain("cannot parse");
+  });
+
+  test("proposes patch update in older minor line when higher minor exists", () => {
+    const providers: Provider[] = [
+      makeProvider({
+        name: "claude",
+        track: "patch",
+        versions: [
+          { version: "2.1.119", outcome: "pass" },
+          { version: "2.2.0", outcome: "pass" },
+        ],
+      }),
+    ];
+    const queryer = () => "2.1.200";
+    const { proposed } = detectNewVersions(providers, queryer);
+    expect(proposed).toHaveLength(1);
+    expect(proposed[0]?.entry.version).toBe("2.1.200");
+  });
+
+  test("rejects downgrade within same version line", () => {
+    const providers: Provider[] = [
+      makeProvider({
+        name: "claude",
+        track: "patch",
+        versions: [{ version: "2.1.119", outcome: "pass" }],
+      }),
+    ];
+    const queryer = () => "2.1.50";
+    const { proposed, skipped } = detectNewVersions(providers, queryer);
+    expect(proposed).toHaveLength(0);
+    expect(skipped.some((s) => s.reason.includes("not newer"))).toBe(true);
+  });
+
+  test("skips provider with only non-semver versions", () => {
+    const providers: Provider[] = [
+      makeProvider({
+        name: "codex",
+        versions: [{ version: "latest", outcome: "fail", failure_class: "spawn-failed" }],
+      }),
+    ];
+    const queryer = () => "0.135.0";
+    const { proposed, skipped } = detectNewVersions(providers, queryer);
+    expect(proposed).toHaveLength(0);
+    expect(skipped.some((s) => s.reason.includes("no parseable semver"))).toBe(true);
+  });
+
+  test("respects aggregate timeout", () => {
+    const providers: Provider[] = [
+      makeProvider({ name: "claude" }),
+      makeProvider({ name: "codex" }),
+      makeProvider({ name: "opencode" }),
+    ];
+    const queryer = () => "1.0.0";
+    const { errors } = detectNewVersions(providers, queryer, { aggregateTimeoutMs: -1 });
+    expect(errors.some((e) => e.error.includes("aggregate timeout"))).toBe(true);
   });
 });
 

--- a/scripts/agent-grid-detect.spec.ts
+++ b/scripts/agent-grid-detect.spec.ts
@@ -1,0 +1,252 @@
+import { describe, expect, test } from "bun:test";
+import type { Provider } from "../agent-grid/versions-schema";
+import {
+  type ProposedRow,
+  REGISTRY,
+  detectNewVersions,
+  formatJson,
+  formatYaml,
+  matchesTrack,
+  parseSemVer,
+  queryNpmVersion,
+} from "./agent-grid-detect";
+
+// ── parseSemVer ───────────────────────────────────────────────────
+
+describe("parseSemVer", () => {
+  test("parses standard semver", () => {
+    expect(parseSemVer("2.1.119")).toEqual({ major: 2, minor: 1, patch: 119, prerelease: "" });
+  });
+
+  test("parses semver with prerelease suffix", () => {
+    const result = parseSemVer("0.30.1-beta.2");
+    expect(result).toEqual({ major: 0, minor: 30, patch: 1, prerelease: "-beta.2" });
+  });
+
+  test("returns null for non-semver", () => {
+    expect(parseSemVer("latest")).toBeNull();
+    expect(parseSemVer("")).toBeNull();
+    expect(parseSemVer("abc")).toBeNull();
+  });
+});
+
+// ── matchesTrack ──────────────────────────────────────────────────
+
+describe("matchesTrack", () => {
+  const known = { major: 2, minor: 1, patch: 119, prerelease: "" };
+
+  test("patch track: same major.minor passes", () => {
+    const latest = { major: 2, minor: 1, patch: 200, prerelease: "" };
+    expect(matchesTrack(latest, known, "patch")).toBe(true);
+  });
+
+  test("patch track: different minor fails", () => {
+    const latest = { major: 2, minor: 2, patch: 0, prerelease: "" };
+    expect(matchesTrack(latest, known, "patch")).toBe(false);
+  });
+
+  test("minor track: same major passes", () => {
+    const latest = { major: 2, minor: 5, patch: 0, prerelease: "" };
+    expect(matchesTrack(latest, known, "minor")).toBe(true);
+  });
+
+  test("minor track: different major fails", () => {
+    const latest = { major: 3, minor: 0, patch: 0, prerelease: "" };
+    expect(matchesTrack(latest, known, "minor")).toBe(false);
+  });
+
+  test("major track: always passes", () => {
+    const latest = { major: 99, minor: 0, patch: 0, prerelease: "" };
+    expect(matchesTrack(latest, known, "major")).toBe(true);
+  });
+});
+
+// ── detectNewVersions ─────────────────────────────────────────────
+
+describe("detectNewVersions", () => {
+  const makeProvider = (overrides: Partial<Provider> & { name: Provider["name"] }): Provider => ({
+    track: "patch",
+    enabled: true,
+    versions: [],
+    ...overrides,
+  });
+
+  test("proposes new version when not already tracked", () => {
+    const providers: Provider[] = [
+      makeProvider({
+        name: "claude",
+        versions: [{ version: "2.1.119", outcome: "pass" }],
+      }),
+    ];
+    const queryer = () => "2.1.156";
+    const { proposed, errors } = detectNewVersions(providers, queryer);
+    expect(errors).toHaveLength(0);
+    expect(proposed).toHaveLength(1);
+    expect(proposed[0]?.provider).toBe("claude");
+    expect(proposed[0]?.entry.version).toBe("2.1.156");
+    expect(proposed[0]?.entry.outcome).toBe("untested");
+  });
+
+  test("skips when version already tracked", () => {
+    const providers: Provider[] = [
+      makeProvider({
+        name: "claude",
+        versions: [{ version: "2.1.156", outcome: "pass" }],
+      }),
+    ];
+    const queryer = () => "2.1.156";
+    const { proposed, skipped } = detectNewVersions(providers, queryer);
+    expect(proposed).toHaveLength(0);
+    expect(skipped.some((s) => s.reason.includes("already tracked"))).toBe(true);
+  });
+
+  test("skips disabled providers", () => {
+    const providers: Provider[] = [makeProvider({ name: "grok", enabled: false })];
+    const queryer = () => "1.0.0";
+    const { proposed, skipped } = detectNewVersions(providers, queryer);
+    expect(proposed).toHaveLength(0);
+    expect(skipped.some((s) => s.reason === "disabled")).toBe(true);
+  });
+
+  test("skips mock provider", () => {
+    const providers: Provider[] = [makeProvider({ name: "mock" })];
+    const queryer = () => "1.0.0";
+    const { proposed, skipped } = detectNewVersions(providers, queryer);
+    expect(proposed).toHaveLength(0);
+    expect(skipped.some((s) => s.reason.includes("mock"))).toBe(true);
+  });
+
+  test("skips providers without registry config", () => {
+    const providers: Provider[] = [makeProvider({ name: "copilot" })];
+    const queryer = () => "1.0.0";
+    const { proposed, skipped } = detectNewVersions(providers, queryer);
+    expect(proposed).toHaveLength(0);
+    expect(skipped.some((s) => s.reason.includes("no registry"))).toBe(true);
+  });
+
+  test("reports error when query fails", () => {
+    const providers: Provider[] = [makeProvider({ name: "claude" })];
+    const queryer = () => null;
+    const { proposed, errors } = detectNewVersions(providers, queryer);
+    expect(proposed).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.error).toContain("failed to query");
+  });
+
+  test("skips version outside patch track", () => {
+    const providers: Provider[] = [
+      makeProvider({
+        name: "claude",
+        track: "patch",
+        versions: [{ version: "2.1.119", outcome: "pass" }],
+      }),
+    ];
+    const queryer = () => "2.2.0";
+    const { proposed, skipped } = detectNewVersions(providers, queryer);
+    expect(proposed).toHaveLength(0);
+    expect(skipped.some((s) => s.reason.includes("outside patch track"))).toBe(true);
+  });
+
+  test("allows version within minor track", () => {
+    const providers: Provider[] = [
+      makeProvider({
+        name: "codex",
+        track: "minor",
+        versions: [{ version: "0.30.1", outcome: "fail", failure_class: "spawn-failed" }],
+      }),
+    ];
+    const queryer = () => "0.135.0";
+    const { proposed } = detectNewVersions(providers, queryer);
+    expect(proposed).toHaveLength(1);
+    expect(proposed[0]?.entry.version).toBe("0.135.0");
+  });
+
+  test("proposes for provider with no existing versions", () => {
+    const providers: Provider[] = [makeProvider({ name: "opencode", track: "minor", versions: [] })];
+    const queryer = () => "1.15.12";
+    const { proposed } = detectNewVersions(providers, queryer);
+    expect(proposed).toHaveLength(1);
+    expect(proposed[0]?.entry.version).toBe("1.15.12");
+  });
+
+  test("reports error for unparseable version", () => {
+    const providers: Provider[] = [makeProvider({ name: "claude" })];
+    const queryer = () => "not-a-version";
+    const { proposed, errors } = detectNewVersions(providers, queryer);
+    expect(proposed).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.error).toContain("cannot parse");
+  });
+});
+
+// ── queryNpmVersion ───────────────────────────────────────────────
+
+describe("queryNpmVersion", () => {
+  test("returns version from successful spawn", () => {
+    const mockSpawn = () => ({ status: 0, stdout: "2.1.156\n", stderr: "", pid: 0, signal: null, output: [] });
+    const result = queryNpmVersion("@anthropic-ai/claude-code", mockSpawn as Parameters<typeof queryNpmVersion>[1]);
+    expect(result).toBe("2.1.156");
+  });
+
+  test("returns null on spawn failure", () => {
+    const mockSpawn = () => ({ status: 1, stdout: "", stderr: "not found", pid: 0, signal: null, output: [] });
+    const result = queryNpmVersion("@nonexistent/pkg", mockSpawn as Parameters<typeof queryNpmVersion>[1]);
+    expect(result).toBeNull();
+  });
+
+  test("returns null on empty output", () => {
+    const mockSpawn = () => ({ status: 0, stdout: "", stderr: "", pid: 0, signal: null, output: [] });
+    const result = queryNpmVersion("@empty/pkg", mockSpawn as Parameters<typeof queryNpmVersion>[1]);
+    expect(result).toBeNull();
+  });
+});
+
+// ── REGISTRY ──────────────────────────────────────────────────────
+
+describe("REGISTRY", () => {
+  test("has entries for claude, codex, opencode", () => {
+    expect(REGISTRY.claude?.npm).toBe("@anthropic-ai/claude-code");
+    expect(REGISTRY.codex?.npm).toBe("@openai/codex");
+    expect(REGISTRY.opencode?.npm).toBe("opencode-ai");
+  });
+
+  test("does not have entries for stub providers", () => {
+    expect(REGISTRY.grok).toBeUndefined();
+    expect(REGISTRY.copilot).toBeUndefined();
+    expect(REGISTRY.gemini).toBeUndefined();
+    expect(REGISTRY.mock).toBeUndefined();
+  });
+});
+
+// ── Output formatters ─────────────────────────────────────────────
+
+describe("formatYaml", () => {
+  test("renders proposed rows as pasteable YAML", () => {
+    const rows: ProposedRow[] = [
+      {
+        provider: "claude",
+        track: "patch",
+        entry: { version: "2.1.156", first_seen: "2026-05-29T12:00:00Z", outcome: "untested" },
+      },
+    ];
+    const out = formatYaml(rows);
+    expect(out).toContain("claude");
+    expect(out).toContain('version: "2.1.156"');
+    expect(out).toContain("outcome: untested");
+  });
+});
+
+describe("formatJson", () => {
+  test("renders valid JSON", () => {
+    const rows: ProposedRow[] = [
+      {
+        provider: "codex",
+        track: "patch",
+        entry: { version: "0.135.0", first_seen: "2026-05-29T12:00:00Z", outcome: "untested" },
+      },
+    ];
+    const parsed = JSON.parse(formatJson(rows));
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0].provider).toBe("codex");
+  });
+});

--- a/scripts/agent-grid-detect.ts
+++ b/scripts/agent-grid-detect.ts
@@ -1,0 +1,270 @@
+#!/usr/bin/env bun
+/**
+ * Detect latest versions from provider registries and propose new
+ * `versions.yaml` rows for human review. Read-only — never writes
+ * or commits.
+ *
+ * Usage: bun scripts/agent-grid-detect.ts [--json]
+ *
+ * Exit 0: proposed rows printed (or nothing new).
+ * Exit 1: one or more registry queries failed.
+ * Exit 2: versions.yaml unreadable or invalid.
+ */
+
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import {
+  type Provider,
+  type ProviderName,
+  type VersionEntry,
+  validateVersionsGrid,
+} from "../agent-grid/versions-schema";
+
+// ── Registry map ──────────────────────────────────────────────────
+
+export interface RegistryEntry {
+  npm: string;
+}
+
+export const REGISTRY: Partial<Record<ProviderName, RegistryEntry>> = {
+  claude: { npm: "@anthropic-ai/claude-code" },
+  codex: { npm: "@openai/codex" },
+  opencode: { npm: "opencode-ai" },
+};
+
+// ── Semver helpers ────────────────────────────────────────────────
+
+export interface SemVer {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string;
+}
+
+export function parseSemVer(v: string): SemVer | null {
+  const m = v.match(/^(\d+)\.(\d+)\.(\d+)(.*)$/);
+  if (!m) return null;
+  return {
+    major: Number.parseInt(m[1] as string, 10),
+    minor: Number.parseInt(m[2] as string, 10),
+    patch: Number.parseInt(m[3] as string, 10),
+    prerelease: m[4] ?? "",
+  };
+}
+
+export function matchesTrack(latest: SemVer, known: SemVer, track: "patch" | "minor" | "major"): boolean {
+  switch (track) {
+    case "patch":
+      return latest.major === known.major && latest.minor === known.minor;
+    case "minor":
+      return latest.major === known.major;
+    case "major":
+      return true;
+  }
+}
+
+// ── Registry query ────────────────────────────────────────────────
+
+export interface QueryResult {
+  provider: string;
+  version: string;
+  ok: true;
+}
+
+export interface QueryError {
+  provider: string;
+  error: string;
+  ok: false;
+}
+
+const NPM_QUERY_TIMEOUT_MS = 15_000;
+
+export function queryNpmVersion(pkg: string, spawner = spawnSync): string | null {
+  const result = spawner("npm", ["view", pkg, "version"], {
+    encoding: "utf-8" as BufferEncoding,
+    timeout: NPM_QUERY_TIMEOUT_MS,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  if (result.status !== 0) return null;
+  const version = (result.stdout as string).trim();
+  return version || null;
+}
+
+// ── Core detection ────────────────────────────────────────────────
+
+export interface ProposedRow {
+  provider: string;
+  track: string;
+  entry: VersionEntry;
+}
+
+export function detectNewVersions(
+  providers: Provider[],
+  queryer: (pkg: string) => string | null = queryNpmVersion,
+): {
+  proposed: ProposedRow[];
+  skipped: Array<{ provider: string; reason: string }>;
+  errors: Array<{ provider: string; error: string }>;
+} {
+  const proposed: ProposedRow[] = [];
+  const skipped: Array<{ provider: string; reason: string }> = [];
+  const errors: Array<{ provider: string; error: string }> = [];
+
+  for (const provider of providers) {
+    if (provider.enabled === false) {
+      skipped.push({ provider: provider.name, reason: "disabled" });
+      continue;
+    }
+
+    if (provider.name === "mock") {
+      skipped.push({ provider: provider.name, reason: "mock provider — no registry" });
+      continue;
+    }
+
+    const reg = REGISTRY[provider.name];
+    if (!reg) {
+      skipped.push({ provider: provider.name, reason: "no registry configured" });
+      continue;
+    }
+
+    const latest = queryer(reg.npm);
+    if (!latest) {
+      errors.push({ provider: provider.name, error: `failed to query npm for ${reg.npm}` });
+      continue;
+    }
+
+    const knownVersions = new Set(provider.versions.map((v) => v.version));
+    if (knownVersions.has(latest)) {
+      skipped.push({ provider: provider.name, reason: `${latest} already tracked` });
+      continue;
+    }
+
+    const latestSemver = parseSemVer(latest);
+    if (!latestSemver) {
+      errors.push({ provider: provider.name, error: `cannot parse version "${latest}" as semver` });
+      continue;
+    }
+
+    const existingVersions = provider.versions
+      .map((v) => parseSemVer(v.version))
+      .filter((v): v is SemVer => v !== null);
+
+    const highestKnown =
+      existingVersions.length > 0
+        ? existingVersions.reduce((a, b) => {
+            if (a.major !== b.major) return a.major > b.major ? a : b;
+            if (a.minor !== b.minor) return a.minor > b.minor ? a : b;
+            return a.patch > b.patch ? a : b;
+          })
+        : null;
+
+    if (highestKnown && !matchesTrack(latestSemver, highestKnown, provider.track)) {
+      skipped.push({
+        provider: provider.name,
+        reason: `${latest} outside ${provider.track} track (highest known: ${highestKnown.major}.${highestKnown.minor}.${highestKnown.patch})`,
+      });
+      continue;
+    }
+
+    const now = new Date();
+    const isoNow = `${now.toISOString().replace(/\.\d{3}Z$/, "Z")}`;
+
+    proposed.push({
+      provider: provider.name,
+      track: provider.track,
+      entry: {
+        version: latest,
+        first_seen: isoNow,
+        outcome: "untested",
+      },
+    });
+  }
+
+  return { proposed, skipped, errors };
+}
+
+// ── Output formatting ─────────────────────────────────────────────
+
+export function formatYaml(rows: ProposedRow[]): string {
+  const lines: string[] = [];
+  lines.push("# Proposed new versions.yaml rows");
+  lines.push("# Review and merge into agent-grid/versions.yaml");
+  lines.push("");
+  for (const row of rows) {
+    lines.push(`# provider: ${row.provider} (track: ${row.track})`);
+    lines.push(`      - version: "${row.entry.version}"`);
+    if (row.entry.first_seen) lines.push(`        first_seen: "${row.entry.first_seen}"`);
+    lines.push(`        outcome: ${row.entry.outcome}`);
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+export function formatJson(rows: ProposedRow[]): string {
+  return JSON.stringify(rows, null, 2);
+}
+
+// ── Main ──────────────────────────────────────────────────────────
+
+function main(): void {
+  const jsonMode = process.argv.includes("--json");
+
+  const repoRoot = resolve(import.meta.dir, "..");
+  const versionsPath = resolve(repoRoot, "agent-grid", "versions.yaml");
+
+  let text: string;
+  try {
+    text = readFileSync(versionsPath, "utf-8");
+  } catch (err) {
+    process.stderr.write(`error: cannot read ${versionsPath}: ${(err as Error).message}\n`);
+    process.exit(2);
+  }
+
+  let raw: unknown;
+  try {
+    raw = Bun.YAML.parse(text);
+  } catch (err) {
+    process.stderr.write(`error: invalid YAML: ${(err as Error).message}\n`);
+    process.exit(2);
+  }
+
+  const validation = validateVersionsGrid(raw);
+  if (!validation.ok) {
+    process.stderr.write("error: versions.yaml is invalid:\n");
+    for (const issue of validation.issues) {
+      process.stderr.write(`  ${issue.path}: ${issue.message}\n`);
+    }
+    process.exit(2);
+  }
+
+  const { proposed, skipped, errors } = detectNewVersions(validation.grid.providers);
+
+  for (const s of skipped) {
+    process.stderr.write(`skip: ${s.provider}: ${s.reason}\n`);
+  }
+  for (const e of errors) {
+    process.stderr.write(`error: ${e.provider}: ${e.error}\n`);
+  }
+
+  if (proposed.length === 0) {
+    process.stderr.write("no new versions detected\n");
+    process.exit(errors.length > 0 ? 1 : 0);
+  }
+
+  process.stderr.write(`\n${proposed.length} new version${proposed.length === 1 ? "" : "s"} detected:\n`);
+  for (const p of proposed) {
+    process.stderr.write(`  ${p.provider} ${p.entry.version}\n`);
+  }
+  process.stderr.write("\n");
+
+  if (jsonMode) {
+    process.stdout.write(`${formatJson(proposed)}\n`);
+  } else {
+    process.stdout.write(formatYaml(proposed));
+  }
+
+  process.exit(errors.length > 0 ? 1 : 0);
+}
+
+if (import.meta.main) main();

--- a/scripts/agent-grid-detect.ts
+++ b/scripts/agent-grid-detect.ts
@@ -43,7 +43,7 @@ export interface SemVer {
 }
 
 export function parseSemVer(v: string): SemVer | null {
-  const m = v.match(/^(\d+)\.(\d+)\.(\d+)(.*)$/);
+  const m = v.match(/^(\d+)\.(\d+)\.(\d+)(-[a-zA-Z0-9.+-]+)?$/);
   if (!m) return null;
   return {
     major: Number.parseInt(m[1] as string, 10),
@@ -51,6 +51,12 @@ export function parseSemVer(v: string): SemVer | null {
     patch: Number.parseInt(m[3] as string, 10),
     prerelease: m[4] ?? "",
   };
+}
+
+export function compareSemVer(a: SemVer, b: SemVer): number {
+  if (a.major !== b.major) return a.major - b.major;
+  if (a.minor !== b.minor) return a.minor - b.minor;
+  return a.patch - b.patch;
 }
 
 export function matchesTrack(latest: SemVer, known: SemVer, track: "patch" | "minor" | "major"): boolean {
@@ -79,6 +85,7 @@ export interface QueryError {
 }
 
 const NPM_QUERY_TIMEOUT_MS = 15_000;
+const AGGREGATE_TIMEOUT_MS = 30_000;
 
 export function queryNpmVersion(pkg: string, spawner = spawnSync): string | null {
   const result = spawner("npm", ["view", pkg, "version"], {
@@ -102,6 +109,7 @@ export interface ProposedRow {
 export function detectNewVersions(
   providers: Provider[],
   queryer: (pkg: string) => string | null = queryNpmVersion,
+  opts: { aggregateTimeoutMs?: number } = {},
 ): {
   proposed: ProposedRow[];
   skipped: Array<{ provider: string; reason: string }>;
@@ -110,6 +118,8 @@ export function detectNewVersions(
   const proposed: ProposedRow[] = [];
   const skipped: Array<{ provider: string; reason: string }> = [];
   const errors: Array<{ provider: string; error: string }> = [];
+  const aggregateTimeout = opts.aggregateTimeoutMs ?? AGGREGATE_TIMEOUT_MS;
+  const startTime = Date.now();
 
   for (const provider of providers) {
     if (provider.enabled === false) {
@@ -125,6 +135,11 @@ export function detectNewVersions(
     const reg = REGISTRY[provider.name];
     if (!reg) {
       skipped.push({ provider: provider.name, reason: "no registry configured" });
+      continue;
+    }
+
+    if (Date.now() - startTime > aggregateTimeout) {
+      errors.push({ provider: provider.name, error: "aggregate timeout exceeded" });
       continue;
     }
 
@@ -150,21 +165,32 @@ export function detectNewVersions(
       .map((v) => parseSemVer(v.version))
       .filter((v): v is SemVer => v !== null);
 
-    const highestKnown =
-      existingVersions.length > 0
-        ? existingVersions.reduce((a, b) => {
-            if (a.major !== b.major) return a.major > b.major ? a : b;
-            if (a.minor !== b.minor) return a.minor > b.minor ? a : b;
-            return a.patch > b.patch ? a : b;
-          })
-        : null;
-
-    if (highestKnown && !matchesTrack(latestSemver, highestKnown, provider.track)) {
+    if (provider.versions.length > 0 && existingVersions.length === 0) {
       skipped.push({
         provider: provider.name,
-        reason: `${latest} outside ${provider.track} track (highest known: ${highestKnown.major}.${highestKnown.minor}.${highestKnown.patch})`,
+        reason: "no parseable semver versions to compare against — cannot verify track",
       });
       continue;
+    }
+
+    if (existingVersions.length > 0) {
+      const inLine = existingVersions.filter((v) => matchesTrack(latestSemver, v, provider.track));
+      if (inLine.length === 0) {
+        skipped.push({
+          provider: provider.name,
+          reason: `${latest} outside ${provider.track} track (no existing version in same line)`,
+        });
+        continue;
+      }
+
+      const highestInLine = inLine.reduce((a, b) => (compareSemVer(a, b) >= 0 ? a : b));
+      if (compareSemVer(latestSemver, highestInLine) <= 0) {
+        skipped.push({
+          provider: provider.name,
+          reason: `${latest} is not newer than ${highestInLine.major}.${highestInLine.minor}.${highestInLine.patch}`,
+        });
+        continue;
+      }
     }
 
     const now = new Date();


### PR DESCRIPTION
## Summary
- Adds `scripts/agent-grid-detect.ts` — queries npm registries (claude, codex, opencode) for each enabled provider's latest version, compares against `agent-grid/versions.yaml`, and outputs proposed new rows for human PR review
- Track-based filtering: `patch` track only proposes same major.minor versions, `minor` same major, `major` any
- Supports `--json` output mode; all status/skip/error info goes to stderr, proposed rows to stdout
- 25 tests covering semver parsing, track matching, detection logic, query DI, and output formatting

## Test plan
- [x] `bun test scripts/agent-grid-detect.spec.ts` — 25 tests pass
- [x] `bun run am-i-done --pre-commit` — all static checks pass
- [x] `bun run detect-grid` — live run detects new versions from npm and outputs proposed rows
- [x] Verified disabled providers (grok, copilot, gemini) are skipped
- [x] Verified mock provider is skipped
- [x] Verified providers without registry config (acp) are skipped with clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)