### PR TITLE
feat(agent-grid): scripts/install-agent.ts (registry-first, LFS-fallback, sha256-verified) (fixes #2583)

### DIFF
--- a/agent-grid/versions-schema.ts
+++ b/agent-grid/versions-schema.ts
@@ -31,6 +31,10 @@ export const VersionEntrySchema = z
     outcome: z.enum(OUTCOME_VALUES),
     recording: z.string().optional(),
     archive: z.string().optional(),
+    binary_sha256: z
+      .string()
+      .regex(/^[0-9a-f]{64}$/, "must be a 64-char hex sha256 hash")
+      .optional(),
     failure_class: z.enum(FAILURE_CLASSES).optional(),
     reason: z.string().optional(),
     issue: z.number().int().positive().optional(),

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -132,6 +132,8 @@ const _originalOptions = {
   SITES_DIR: join(MCP_CLI_DIR, "sites"),
   /** Directory for NDJSON protocol recordings (`MCX_RECORD_SESSION`) */
   RECORDINGS_DIR: join(MCP_CLI_DIR, "recordings"),
+  /** Directory for agent provider binaries installed by `scripts/install-agent.ts` */
+  AGENTS_DIR: join(MCP_CLI_DIR, "agents"),
   /** Directory for patched copies of the user's claude binary (see issue #1808) */
   CLAUDE_PATCHED_DIR: join(MCP_CLI_DIR, "claude-patched"),
   /** Directory for self-signed TLS material used by the local WSS listener (see issue #1808) */

--- a/scripts/install-agent.spec.ts
+++ b/scripts/install-agent.spec.ts
@@ -1,12 +1,14 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   type InstallDeps,
+  Sha256MismatchError,
   findVersionEntry,
   installAgent,
   installFromArchive,
+  installFromRegistry,
   loadGrid,
   parseInstallAgentArgs,
   readSidecarChecksum,
@@ -286,6 +288,222 @@ describe("installFromArchive", () => {
 
     await expect(installFromArchive(entry, "testprov", destDir, makeDeps())).rejects.toThrow("No archive path");
   });
+
+  test("rejects symlinks in extracted archive", async () => {
+    await createTestArchive("testprov", "1.0.0");
+
+    const entry = {
+      version: "1.0.0",
+      outcome: "pass" as const,
+      archive: "binaries/testprov-1.0.0.tgz",
+    };
+
+    // Pre-place a symlink at the expected binary path before extraction
+    // to simulate a malicious archive that extracts symlinks
+    const symlinkPath = join(destDir, "testprov-1.0.0");
+    writeFileSync(join(destDir, "legit-target"), "real file");
+    rmSync(symlinkPath, { force: true });
+
+    // Extract the real archive, then replace the binary with a symlink
+    const result = await installFromArchive(entry, "testprov", destDir, makeDeps());
+    expect(result.binaryPath).toContain("testprov-1.0.0");
+
+    // Verify that the function would reject if the file were a symlink
+    // by calling with a rigged destDir containing a symlink
+    const symlinkDestDir = join(tmpDir, "symlink-dest");
+    mkdirSync(symlinkDestDir, { recursive: true });
+
+    // Create a new archive that we'll extract, then swap the binary for a symlink
+    await createTestArchive("linkprov", "1.0.0");
+    const linkEntry = {
+      version: "1.0.0",
+      outcome: "pass" as const,
+      archive: "binaries/linkprov-1.0.0.tgz",
+    };
+
+    // Create a mock deps.spawn that extracts normally but then we swap the result
+    const realDeps = makeDeps({ agentsDir: symlinkDestDir });
+    const origSpawn = realDeps.spawn;
+    let tarCalled = false;
+    realDeps.spawn = ((cmd: string[], opts: Record<string, unknown>) => {
+      const proc = origSpawn(cmd, opts);
+      if (cmd[0] === "tar" && !tarCalled) {
+        tarCalled = true;
+        // After tar finishes, replace the binary with a symlink
+        return {
+          ...proc,
+          exited: (proc as { exited: Promise<number> }).exited.then((code: number) => {
+            if (code === 0) {
+              const extracted = join(symlinkDestDir, "linkprov-1.0.0");
+              rmSync(extracted, { force: true });
+              symlinkSync("/tmp/evil-target", extracted);
+            }
+            return code;
+          }),
+          stderr: (proc as { stderr: ReadableStream }).stderr,
+        };
+      }
+      return proc;
+    }) as typeof Bun.spawn;
+
+    await expect(installFromArchive(linkEntry, "linkprov", symlinkDestDir, realDeps)).rejects.toThrow("symlink");
+  });
+
+  test("fails on binary_sha256 mismatch", async () => {
+    await createTestArchive("testprov", "1.0.0");
+
+    const entry = {
+      version: "1.0.0",
+      outcome: "pass" as const,
+      archive: "binaries/testprov-1.0.0.tgz",
+      binary_sha256: "0".repeat(64),
+    };
+
+    await expect(installFromArchive(entry, "testprov", destDir, makeDeps())).rejects.toThrow(
+      "SHA256 mismatch for extracted binary",
+    );
+  });
+});
+
+// ── Registry install (with mocked npm spawn) ───────────────────────
+
+describe("installFromRegistry", () => {
+  let tmpDir: string;
+  let gridDir: string;
+  let destDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `registry-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    gridDir = join(tmpDir, "agent-grid");
+    destDir = join(tmpDir, "dest");
+    mkdirSync(join(gridDir, "binaries"), { recursive: true });
+    mkdirSync(destDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeDeps(overrides?: Partial<InstallDeps>): InstallDeps {
+    return {
+      agentsDir: destDir,
+      gridDir,
+      versionsPath: join(gridDir, "versions.yaml"),
+      spawn: Bun.spawn,
+      log: () => {},
+      error: () => {},
+      ...overrides,
+    };
+  }
+
+  async function createNpmPackageTgz(binaryContent: string): Promise<string> {
+    const pkgDir = join(tmpDir, "pkg-build", "package");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(join(pkgDir, "cli.mjs"), binaryContent, { mode: 0o755 });
+    writeFileSync(join(pkgDir, "package.json"), JSON.stringify({ name: "test", version: "1.0.0" }));
+
+    const tgzName = "test-pkg-1.0.0.tgz";
+    const tgzPath = join(tmpDir, "pkg-build", tgzName);
+    const proc = Bun.spawn(["tar", "czf", tgzPath, "--no-same-owner", "-C", join(tmpDir, "pkg-build"), "package"], {
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    await proc.exited;
+    rmSync(pkgDir, { recursive: true });
+    return tgzName;
+  }
+
+  function mockNpmSpawn(tgzDir: string, tgzName: string): typeof Bun.spawn {
+    return ((cmd: string[], opts: Record<string, unknown>) => {
+      if (cmd[0] === "npm") {
+        const packDest = cmd[cmd.indexOf("--pack-destination") + 1] as string;
+        copyFileSync(join(tgzDir, tgzName), join(packDest, tgzName));
+
+        const stdout = new ReadableStream({
+          start(c) {
+            c.enqueue(new TextEncoder().encode(`${tgzName}\n`));
+            c.close();
+          },
+        });
+        const stderr = new ReadableStream({
+          start(c) {
+            c.close();
+          },
+        });
+        return { exited: Promise.resolve(0), stdout, stderr };
+      }
+      return Bun.spawn(cmd, opts);
+    }) as typeof Bun.spawn;
+  }
+
+  function mockFailedNpmSpawn(): typeof Bun.spawn {
+    return ((cmd: string[], opts: Record<string, unknown>) => {
+      if (cmd[0] === "npm") {
+        const stdout = new ReadableStream({
+          start(c) {
+            c.close();
+          },
+        });
+        const stderr = new ReadableStream({
+          start(c) {
+            c.enqueue(new TextEncoder().encode("npm ERR! 404 Not Found\n"));
+            c.close();
+          },
+        });
+        return { exited: Promise.resolve(1), stdout, stderr };
+      }
+      return Bun.spawn(cmd, opts);
+    }) as typeof Bun.spawn;
+  }
+
+  test("returns null for provider without npm mapping", async () => {
+    const entry = { version: "1.0.0", outcome: "pass" as const };
+    const result = await installFromRegistry(entry, "mock", "1.0.0", destDir, makeDeps());
+    expect(result).toBeNull();
+  });
+
+  test("installs binary from npm pack output", async () => {
+    const binaryContent = '#!/usr/bin/env node\nconsole.log("claude");';
+    const tgzName = await createNpmPackageTgz(binaryContent);
+    const tgzDir = join(tmpDir, "pkg-build");
+
+    const entry = { version: "2.1.119", outcome: "pass" as const };
+    const deps = makeDeps({ spawn: mockNpmSpawn(tgzDir, tgzName) });
+
+    const result = await installFromRegistry(entry, "claude", "2.1.119", destDir, deps);
+
+    expect(result).not.toBeNull();
+    expect(result?.binaryPath).toContain("claude");
+    expect(result?.sha256).toMatch(/^[0-9a-f]{64}$/);
+
+    const content = readFileSync(result?.binaryPath ?? "", "utf-8");
+    expect(content).toContain("claude");
+  });
+
+  test("returns null on npm pack failure", async () => {
+    const entry = { version: "2.1.119", outcome: "pass" as const };
+    const deps = makeDeps({ spawn: mockFailedNpmSpawn() });
+
+    const result = await installFromRegistry(entry, "claude", "2.1.119", destDir, deps);
+    expect(result).toBeNull();
+  });
+
+  test("throws on binary_sha256 mismatch", async () => {
+    const binaryContent = '#!/usr/bin/env node\nconsole.log("claude");';
+    const tgzName = await createNpmPackageTgz(binaryContent);
+    const tgzDir = join(tmpDir, "pkg-build");
+
+    const entry = {
+      version: "2.1.119",
+      outcome: "pass" as const,
+      binary_sha256: "0".repeat(64),
+    };
+    const deps = makeDeps({ spawn: mockNpmSpawn(tgzDir, tgzName) });
+
+    await expect(installFromRegistry(entry, "claude", "2.1.119", destDir, deps)).rejects.toThrow(
+      "SHA256 mismatch for registry-installed binary",
+    );
+  });
 });
 
 // ── Full installAgent flow ─────────────────────────────────────────
@@ -379,5 +597,82 @@ providers:
     const result = await installAgent({ provider: "mock", version: "1.0.0", offline: false }, makeDeps());
 
     expect(result.source).toBe("archive");
+  });
+
+  test("falls back to archive when npm pack fails", async () => {
+    // Set up a grid with a claude provider (which has an npm mapping)
+    const binaryName = "claude-3.0.0";
+    const binaryPath = join(tmpDir, binaryName);
+    writeFileSync(binaryPath, "#!/bin/sh\necho ok", { mode: 0o755 });
+
+    const tgzPath = join(gridDir, "binaries", `${binaryName}.tgz`);
+    const proc = Bun.spawn(
+      ["tar", "czf", tgzPath, "--uid", "0", "--gid", "0", "--numeric-owner", "-C", tmpDir, binaryName],
+      { stdout: "ignore", stderr: "ignore" },
+    );
+    await proc.exited;
+    const hash = await sha256File(tgzPath);
+    writeFileSync(`${tgzPath}.sha256`, `${hash}  ${binaryName}.tgz\n`);
+    rmSync(binaryPath);
+
+    const yaml = `
+providers:
+  - name: claude
+    track: patch
+    versions:
+      - version: "3.0.0"
+        outcome: pass
+        archive: binaries/claude-3.0.0.tgz
+`;
+    writeFileSync(join(gridDir, "versions.yaml"), yaml);
+
+    // Mock npm to fail, so it falls back to archive
+    const failSpawn = ((cmd: string[], opts: Record<string, unknown>) => {
+      if (cmd[0] === "npm") {
+        const stdout = new ReadableStream({
+          start(c) {
+            c.close();
+          },
+        });
+        const stderr = new ReadableStream({
+          start(c) {
+            c.enqueue(new TextEncoder().encode("npm ERR!\n"));
+            c.close();
+          },
+        });
+        return { exited: Promise.resolve(1), stdout, stderr };
+      }
+      return Bun.spawn(cmd, opts);
+    }) as typeof Bun.spawn;
+
+    const deps = { ...makeDeps(), spawn: failSpawn };
+    const result = await installAgent({ provider: "claude", version: "3.0.0", offline: false }, deps);
+
+    expect(result.source).toBe("archive");
+    expect(result.provider).toBe("claude");
+  });
+
+  test("cleans up destDir on total failure", async () => {
+    await setupGrid();
+
+    // Use a version that doesn't have an archive to force archive failure
+    const yaml = `
+providers:
+  - name: mock
+    track: patch
+    versions:
+      - version: "2.0.0"
+        outcome: pass
+        archive: binaries/nonexistent.tgz
+`;
+    writeFileSync(join(gridDir, "versions.yaml"), yaml);
+
+    const destDir = join(agentsDir, "mock", "2.0.0");
+
+    await expect(installAgent({ provider: "mock", version: "2.0.0", offline: true }, makeDeps())).rejects.toThrow(
+      "Archive not found",
+    );
+
+    expect(existsSync(destDir)).toBe(false);
   });
 });

--- a/scripts/install-agent.spec.ts
+++ b/scripts/install-agent.spec.ts
@@ -4,7 +4,6 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   type InstallDeps,
-  Sha256MismatchError,
   findVersionEntry,
   installAgent,
   installFromArchive,
@@ -231,11 +230,17 @@ describe("installFromArchive", () => {
     const tgzPath = join(gridDir, "binaries", `${binaryName}.tgz`);
     const proc = Bun.spawn(
       ["tar", "czf", tgzPath, "--uid", "0", "--gid", "0", "--numeric-owner", "-C", tmpDir, binaryName],
-      { stdout: "ignore", stderr: "ignore" },
+      { stdout: "ignore", stderr: "pipe" },
     );
-    await proc.exited;
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text();
+      throw new Error(`tar failed (exit ${exitCode}): ${stderr.trim()}`);
+    }
+    if (!existsSync(tgzPath)) {
+      throw new Error(`tar produced no output at ${tgzPath}`);
+    }
 
-    // Write sha256 sidecar
     const hash = await sha256File(tgzPath);
     writeFileSync(`${tgzPath}.sha256`, `${hash}  ${binaryName}.tgz\n`);
 
@@ -410,9 +415,16 @@ describe("installFromRegistry", () => {
     const tgzPath = join(tmpDir, "pkg-build", tgzName);
     const proc = Bun.spawn(["tar", "czf", tgzPath, "--no-same-owner", "-C", join(tmpDir, "pkg-build"), "package"], {
       stdout: "ignore",
-      stderr: "ignore",
+      stderr: "pipe",
     });
-    await proc.exited;
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text();
+      throw new Error(`tar failed (exit ${exitCode}): ${stderr.trim()}`);
+    }
+    if (!existsSync(tgzPath)) {
+      throw new Error(`tar produced no output at ${tgzPath}`);
+    }
     rmSync(pkgDir, { recursive: true });
     return tgzName;
   }
@@ -548,9 +560,16 @@ describe("installAgent", () => {
     const tgzPath = join(gridDir, "binaries", `${binaryName}.tgz`);
     const proc = Bun.spawn(
       ["tar", "czf", tgzPath, "--uid", "0", "--gid", "0", "--numeric-owner", "-C", tmpDir, binaryName],
-      { stdout: "ignore", stderr: "ignore" },
+      { stdout: "ignore", stderr: "pipe" },
     );
-    await proc.exited;
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text();
+      throw new Error(`tar failed (exit ${exitCode}): ${stderr.trim()}`);
+    }
+    if (!existsSync(tgzPath)) {
+      throw new Error(`tar produced no output at ${tgzPath}`);
+    }
 
     const hash = await sha256File(tgzPath);
     writeFileSync(`${tgzPath}.sha256`, `${hash}  ${binaryName}.tgz\n`);
@@ -612,9 +631,16 @@ providers:
     const tgzPath = join(gridDir, "binaries", `${binaryName}.tgz`);
     const proc = Bun.spawn(
       ["tar", "czf", tgzPath, "--uid", "0", "--gid", "0", "--numeric-owner", "-C", tmpDir, binaryName],
-      { stdout: "ignore", stderr: "ignore" },
+      { stdout: "ignore", stderr: "pipe" },
     );
-    await proc.exited;
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text();
+      throw new Error(`tar failed (exit ${exitCode}): ${stderr.trim()}`);
+    }
+    if (!existsSync(tgzPath)) {
+      throw new Error(`tar produced no output at ${tgzPath}`);
+    }
     const hash = await sha256File(tgzPath);
     writeFileSync(`${tgzPath}.sha256`, `${hash}  ${binaryName}.tgz\n`);
     rmSync(binaryPath);

--- a/scripts/install-agent.spec.ts
+++ b/scripts/install-agent.spec.ts
@@ -1,0 +1,383 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type InstallDeps,
+  findVersionEntry,
+  installAgent,
+  installFromArchive,
+  loadGrid,
+  parseInstallAgentArgs,
+  readSidecarChecksum,
+  sha256File,
+} from "./install-agent";
+
+// ── Arg parsing ────────────────────────────────────────────────────
+
+describe("parseInstallAgentArgs", () => {
+  test("parses provider@version", () => {
+    const args = parseInstallAgentArgs(["claude@2.1.119"]);
+    expect(args).toEqual({ provider: "claude", version: "2.1.119", offline: false });
+  });
+
+  test("parses --offline flag", () => {
+    const args = parseInstallAgentArgs(["--offline", "claude@2.1.119"]);
+    expect(args).toEqual({ provider: "claude", version: "2.1.119", offline: true });
+  });
+
+  test("--offline can follow the spec", () => {
+    const args = parseInstallAgentArgs(["codex@0.30.1", "--offline"]);
+    expect(args).toEqual({ provider: "codex", version: "0.30.1", offline: true });
+  });
+
+  test("rejects missing spec", () => {
+    expect(() => parseInstallAgentArgs([])).toThrow("Usage:");
+  });
+
+  test("rejects spec without @", () => {
+    expect(() => parseInstallAgentArgs(["claude"])).toThrow("expected provider@version");
+  });
+
+  test("rejects spec with @ at position 0", () => {
+    expect(() => parseInstallAgentArgs(["@2.1.119"])).toThrow("expected provider@version");
+  });
+
+  test("rejects unknown flags", () => {
+    expect(() => parseInstallAgentArgs(["--foo", "claude@2.1.119"])).toThrow("Unknown flag");
+  });
+});
+
+// ── Grid loading ───────────────────────────────────────────────────
+
+describe("loadGrid", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `install-agent-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("loads a valid versions.yaml", () => {
+    const yaml = `
+providers:
+  - name: claude
+    track: patch
+    versions:
+      - version: "2.1.119"
+        outcome: pass
+        archive: binaries/claude-2.1.119.tgz
+`;
+    writeFileSync(join(tmpDir, "versions.yaml"), yaml);
+    const grid = loadGrid(join(tmpDir, "versions.yaml"));
+    expect(grid.providers).toHaveLength(1);
+    expect(grid.providers[0]?.name).toBe("claude");
+  });
+
+  test("throws on missing file", () => {
+    expect(() => loadGrid(join(tmpDir, "missing.yaml"))).toThrow("Cannot read");
+  });
+
+  test("throws on invalid YAML content", () => {
+    writeFileSync(join(tmpDir, "bad.yaml"), "providers: [{ invalid");
+    expect(() => loadGrid(join(tmpDir, "bad.yaml"))).toThrow();
+  });
+
+  test("throws on schema validation failure", () => {
+    writeFileSync(join(tmpDir, "empty.yaml"), "providers: []");
+    expect(() => loadGrid(join(tmpDir, "empty.yaml"))).toThrow("validation failed");
+  });
+});
+
+// ── findVersionEntry ───────────────────────────────────────────────
+
+describe("findVersionEntry", () => {
+  const grid = {
+    providers: [
+      {
+        name: "claude" as const,
+        track: "patch" as const,
+        enabled: true,
+        versions: [
+          { version: "2.1.119", outcome: "pass" as const, archive: "binaries/claude-2.1.119.tgz" },
+          { version: "latest", outcome: "untested" as const },
+        ],
+      },
+    ],
+  };
+
+  test("finds existing version", () => {
+    const entry = findVersionEntry(grid, "claude", "2.1.119");
+    expect(entry).not.toBeNull();
+    expect(entry?.archive).toBe("binaries/claude-2.1.119.tgz");
+  });
+
+  test("returns null for unknown provider", () => {
+    expect(findVersionEntry(grid, "unknown", "1.0.0")).toBeNull();
+  });
+
+  test("returns null for unknown version", () => {
+    expect(findVersionEntry(grid, "claude", "9.9.9")).toBeNull();
+  });
+});
+
+// ── SHA256 helpers ─────────────────────────────────────────────────
+
+describe("sha256File", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `sha256-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("computes correct sha256", async () => {
+    const path = join(tmpDir, "test.txt");
+    writeFileSync(path, "hello world\n");
+    const hash = await sha256File(path);
+    expect(hash).toBe("a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447");
+  });
+});
+
+describe("readSidecarChecksum", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `sidecar-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("reads hash-only format", () => {
+    const tgzPath = join(tmpDir, "test.tgz");
+    writeFileSync(tgzPath, "dummy");
+    writeFileSync(`${tgzPath}.sha256`, "abcd".repeat(16));
+    expect(readSidecarChecksum(tgzPath)).toBe("abcd".repeat(16));
+  });
+
+  test("reads hash-with-filename format", () => {
+    const tgzPath = join(tmpDir, "test.tgz");
+    writeFileSync(tgzPath, "dummy");
+    writeFileSync(`${tgzPath}.sha256`, `${"abcd".repeat(16)}  test.tgz\n`);
+    expect(readSidecarChecksum(tgzPath)).toBe("abcd".repeat(16));
+  });
+
+  test("throws on missing sidecar", () => {
+    expect(() => readSidecarChecksum(join(tmpDir, "missing.tgz"))).toThrow("sidecar not found");
+  });
+
+  test("throws on invalid hash", () => {
+    const tgzPath = join(tmpDir, "test.tgz");
+    writeFileSync(tgzPath, "dummy");
+    writeFileSync(`${tgzPath}.sha256`, "not-a-hash");
+    expect(() => readSidecarChecksum(tgzPath)).toThrow("Invalid sha256");
+  });
+});
+
+// ── Archive install (integration-style with real tgz) ──────────────
+
+describe("installFromArchive", () => {
+  let tmpDir: string;
+  let gridDir: string;
+  let destDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `archive-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    gridDir = join(tmpDir, "agent-grid");
+    destDir = join(tmpDir, "dest");
+    mkdirSync(join(gridDir, "binaries"), { recursive: true });
+    mkdirSync(destDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeDeps(overrides?: Partial<InstallDeps>): InstallDeps {
+    return {
+      agentsDir: destDir,
+      gridDir,
+      versionsPath: join(gridDir, "versions.yaml"),
+      spawn: Bun.spawn,
+      log: () => {},
+      error: () => {},
+      ...overrides,
+    };
+  }
+
+  async function createTestArchive(provider: string, version: string): Promise<string> {
+    const binaryName = `${provider}-${version}`;
+    const binaryContent = `#!/bin/sh\necho "${provider} ${version}"`;
+    const binaryPath = join(tmpDir, binaryName);
+    writeFileSync(binaryPath, binaryContent, { mode: 0o755 });
+
+    const tgzPath = join(gridDir, "binaries", `${binaryName}.tgz`);
+    const proc = Bun.spawn(
+      ["tar", "czf", tgzPath, "--uid", "0", "--gid", "0", "--numeric-owner", "-C", tmpDir, binaryName],
+      { stdout: "ignore", stderr: "ignore" },
+    );
+    await proc.exited;
+
+    // Write sha256 sidecar
+    const hash = await sha256File(tgzPath);
+    writeFileSync(`${tgzPath}.sha256`, `${hash}  ${binaryName}.tgz\n`);
+
+    // Clean up the loose binary
+    rmSync(binaryPath);
+
+    return tgzPath;
+  }
+
+  test("extracts archive and verifies sha256", async () => {
+    await createTestArchive("testprov", "1.0.0");
+
+    const entry = {
+      version: "1.0.0",
+      outcome: "pass" as const,
+      archive: "binaries/testprov-1.0.0.tgz",
+    };
+
+    const result = await installFromArchive(entry, "testprov", destDir, makeDeps());
+    expect(result.binaryPath).toContain("testprov-1.0.0");
+    expect(result.sha256).toMatch(/^[0-9a-f]{64}$/);
+
+    const content = readFileSync(result.binaryPath, "utf-8");
+    expect(content).toContain("testprov 1.0.0");
+  });
+
+  test("fails on sha256 mismatch", async () => {
+    await createTestArchive("testprov", "1.0.0");
+    // Corrupt the sidecar
+    const sidecarPath = join(gridDir, "binaries", "testprov-1.0.0.tgz.sha256");
+    writeFileSync(sidecarPath, `${"0".repeat(64)}  testprov-1.0.0.tgz\n`);
+
+    const entry = {
+      version: "1.0.0",
+      outcome: "pass" as const,
+      archive: "binaries/testprov-1.0.0.tgz",
+    };
+
+    await expect(installFromArchive(entry, "testprov", destDir, makeDeps())).rejects.toThrow("SHA256 mismatch");
+  });
+
+  test("fails when archive file is missing", async () => {
+    const entry = {
+      version: "1.0.0",
+      outcome: "pass" as const,
+      archive: "binaries/nonexistent.tgz",
+    };
+
+    await expect(installFromArchive(entry, "testprov", destDir, makeDeps())).rejects.toThrow("Archive not found");
+  });
+
+  test("fails when entry has no archive path", async () => {
+    const entry = { version: "1.0.0", outcome: "untested" as const };
+
+    await expect(installFromArchive(entry, "testprov", destDir, makeDeps())).rejects.toThrow("No archive path");
+  });
+});
+
+// ── Full installAgent flow ─────────────────────────────────────────
+
+describe("installAgent", () => {
+  let tmpDir: string;
+  let gridDir: string;
+  let agentsDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `install-full-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    gridDir = join(tmpDir, "agent-grid");
+    agentsDir = join(tmpDir, "agents");
+    mkdirSync(join(gridDir, "binaries"), { recursive: true });
+    mkdirSync(agentsDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function makeDeps(): InstallDeps {
+    return {
+      agentsDir,
+      gridDir,
+      versionsPath: join(gridDir, "versions.yaml"),
+      spawn: Bun.spawn,
+      log: () => {},
+      error: () => {},
+    };
+  }
+
+  async function setupGrid(): Promise<void> {
+    const binaryName = "mock-1.0.0";
+    const binaryPath = join(tmpDir, binaryName);
+    writeFileSync(binaryPath, "#!/bin/sh\necho ok", { mode: 0o755 });
+
+    const tgzPath = join(gridDir, "binaries", `${binaryName}.tgz`);
+    const proc = Bun.spawn(
+      ["tar", "czf", tgzPath, "--uid", "0", "--gid", "0", "--numeric-owner", "-C", tmpDir, binaryName],
+      { stdout: "ignore", stderr: "ignore" },
+    );
+    await proc.exited;
+
+    const hash = await sha256File(tgzPath);
+    writeFileSync(`${tgzPath}.sha256`, `${hash}  ${binaryName}.tgz\n`);
+    rmSync(binaryPath);
+
+    const yaml = `
+providers:
+  - name: mock
+    track: patch
+    versions:
+      - version: "1.0.0"
+        outcome: pass
+        archive: binaries/mock-1.0.0.tgz
+`;
+    writeFileSync(join(gridDir, "versions.yaml"), yaml);
+  }
+
+  test("installs from archive in offline mode", async () => {
+    await setupGrid();
+
+    const result = await installAgent({ provider: "mock", version: "1.0.0", offline: true }, makeDeps());
+
+    expect(result.source).toBe("archive");
+    expect(result.provider).toBe("mock");
+    expect(result.version).toBe("1.0.0");
+    expect(result.sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test("throws on unknown provider", async () => {
+    await setupGrid();
+
+    await expect(
+      installAgent({ provider: "nonexistent", version: "1.0.0", offline: true }, makeDeps()),
+    ).rejects.toThrow("Unknown provider");
+  });
+
+  test("throws on unknown version", async () => {
+    await setupGrid();
+
+    await expect(installAgent({ provider: "mock", version: "9.9.9", offline: true }, makeDeps())).rejects.toThrow(
+      "not found for mock",
+    );
+  });
+
+  test("falls back to archive when registry has no npm mapping", async () => {
+    await setupGrid();
+
+    const result = await installAgent({ provider: "mock", version: "1.0.0", offline: false }, makeDeps());
+
+    expect(result.source).toBe("archive");
+  });
+});

--- a/scripts/install-agent.spec.ts
+++ b/scripts/install-agent.spec.ts
@@ -48,6 +48,10 @@ describe("parseInstallAgentArgs", () => {
   test("rejects unknown flags", () => {
     expect(() => parseInstallAgentArgs(["--foo", "claude@2.1.119"])).toThrow("Unknown flag");
   });
+
+  test("rejects multiple positional specs", () => {
+    expect(() => parseInstallAgentArgs(["claude@2.1.119", "codex@0.30.1"])).toThrow("Too many arguments");
+  });
 });
 
 // ── Grid loading ───────────────────────────────────────────────────

--- a/scripts/install-agent.spec.ts
+++ b/scripts/install-agent.spec.ts
@@ -1,5 +1,14 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { copyFileSync, existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -673,10 +682,9 @@ providers:
     expect(result.provider).toBe("claude");
   });
 
-  test("cleans up destDir on total failure", async () => {
+  test("cleans up staging dir on failure, keeps destDir shell", async () => {
     await setupGrid();
 
-    // Use a version that doesn't have an archive to force archive failure
     const yaml = `
 providers:
   - name: mock
@@ -694,6 +702,42 @@ providers:
       "Archive not found",
     );
 
-    expect(existsSync(destDir)).toBe(false);
+    // destDir still exists (created for the lock file) but staging was cleaned up
+    expect(existsSync(destDir)).toBe(true);
+    // No leftover staging dirs
+    const parent = join(agentsDir, "mock");
+    const siblings = readdirSync(parent);
+    for (const s of siblings) {
+      expect(s).not.toContain(".staging-");
+    }
+  });
+
+  test("preserves existing install when reinstall fails", async () => {
+    await setupGrid();
+
+    // First install succeeds
+    const result = await installAgent({ provider: "mock", version: "1.0.0", offline: true }, makeDeps());
+    expect(existsSync(result.binaryPath)).toBe(true);
+    const originalContent = readFileSync(result.binaryPath, "utf-8");
+
+    // Now break the archive so reinstall fails
+    const yaml = `
+providers:
+  - name: mock
+    track: patch
+    versions:
+      - version: "1.0.0"
+        outcome: pass
+        archive: binaries/nonexistent.tgz
+`;
+    writeFileSync(join(gridDir, "versions.yaml"), yaml);
+
+    await expect(installAgent({ provider: "mock", version: "1.0.0", offline: true }, makeDeps())).rejects.toThrow(
+      "Archive not found",
+    );
+
+    // Original install is untouched
+    expect(existsSync(result.binaryPath)).toBe(true);
+    expect(readFileSync(result.binaryPath, "utf-8")).toBe(originalContent);
   });
 });

--- a/scripts/install-agent.spec.ts
+++ b/scripts/install-agent.spec.ts
@@ -228,10 +228,7 @@ describe("installFromArchive", () => {
     writeFileSync(binaryPath, binaryContent, { mode: 0o755 });
 
     const tgzPath = join(gridDir, "binaries", `${binaryName}.tgz`);
-    const proc = Bun.spawn(
-      ["tar", "czf", tgzPath, "--uid", "0", "--gid", "0", "--numeric-owner", "-C", tmpDir, binaryName],
-      { stdout: "ignore", stderr: "pipe" },
-    );
+    const proc = Bun.spawn(["tar", "czf", tgzPath, "-C", tmpDir, binaryName], { stdout: "ignore", stderr: "pipe" });
     const exitCode = await proc.exited;
     if (exitCode !== 0) {
       const stderr = await new Response(proc.stderr).text();
@@ -558,10 +555,7 @@ describe("installAgent", () => {
     writeFileSync(binaryPath, "#!/bin/sh\necho ok", { mode: 0o755 });
 
     const tgzPath = join(gridDir, "binaries", `${binaryName}.tgz`);
-    const proc = Bun.spawn(
-      ["tar", "czf", tgzPath, "--uid", "0", "--gid", "0", "--numeric-owner", "-C", tmpDir, binaryName],
-      { stdout: "ignore", stderr: "pipe" },
-    );
+    const proc = Bun.spawn(["tar", "czf", tgzPath, "-C", tmpDir, binaryName], { stdout: "ignore", stderr: "pipe" });
     const exitCode = await proc.exited;
     if (exitCode !== 0) {
       const stderr = await new Response(proc.stderr).text();
@@ -629,10 +623,7 @@ providers:
     writeFileSync(binaryPath, "#!/bin/sh\necho ok", { mode: 0o755 });
 
     const tgzPath = join(gridDir, "binaries", `${binaryName}.tgz`);
-    const proc = Bun.spawn(
-      ["tar", "czf", tgzPath, "--uid", "0", "--gid", "0", "--numeric-owner", "-C", tmpDir, binaryName],
-      { stdout: "ignore", stderr: "pipe" },
-    );
+    const proc = Bun.spawn(["tar", "czf", tgzPath, "-C", tmpDir, binaryName], { stdout: "ignore", stderr: "pipe" });
     const exitCode = await proc.exited;
     if (exitCode !== 0) {
       const stderr = await new Response(proc.stderr).text();

--- a/scripts/install-agent.ts
+++ b/scripts/install-agent.ts
@@ -21,6 +21,7 @@ import {
   openSync,
   readFileSync,
   readdirSync,
+  renameSync,
   rmSync,
 } from "node:fs";
 import { join, resolve } from "node:path";
@@ -372,6 +373,8 @@ export async function installAgent(args: InstallArgs, deps: InstallDeps = defaul
   }
 
   const destDir = join(deps.agentsDir, args.provider, args.version);
+  const stagingDir = join(deps.agentsDir, args.provider, `${args.version}.staging-${Date.now()}`);
+
   mkdirSync(destDir, { recursive: true });
 
   const lockPath = join(destDir, ".install.lock");
@@ -381,16 +384,20 @@ export async function installAgent(args: InstallArgs, deps: InstallDeps = defaul
     throw new Error(`Another install of ${args.provider}@${args.version} is already in progress`);
   }
 
+  mkdirSync(stagingDir, { recursive: true });
+
   try {
     // Registry-first (skip if --offline)
     if (!args.offline) {
       deps.error(`Trying registry for ${args.provider}@${args.version}...`);
-      const registryResult = await installFromRegistry(entry, args.provider, args.version, destDir, deps);
+      const registryResult = await installFromRegistry(entry, args.provider, args.version, stagingDir, deps);
       if (registryResult) {
+        const finalBinaryPath = join(destDir, registryResult.binaryPath.slice(stagingDir.length + 1));
+        swapStagingToFinal(stagingDir, destDir);
         return {
           provider: args.provider,
           version: args.version,
-          binaryPath: registryResult.binaryPath,
+          binaryPath: finalBinaryPath,
           source: "registry",
           sha256: registryResult.sha256,
         };
@@ -400,22 +407,29 @@ export async function installAgent(args: InstallArgs, deps: InstallDeps = defaul
 
     // Archive fallback
     deps.error(`Installing ${args.provider}@${args.version} from archive...`);
-    const archiveResult = await installFromArchive(entry, args.provider, destDir, deps);
+    const archiveResult = await installFromArchive(entry, args.provider, stagingDir, deps);
+    const finalBinaryPath = join(destDir, archiveResult.binaryPath.slice(stagingDir.length + 1));
+    swapStagingToFinal(stagingDir, destDir);
 
     return {
       provider: args.provider,
       version: args.version,
-      binaryPath: archiveResult.binaryPath,
+      binaryPath: finalBinaryPath,
       source: "archive",
       sha256: archiveResult.sha256,
     };
   } catch (err) {
-    rmSync(destDir, { recursive: true, force: true });
+    rmSync(stagingDir, { recursive: true, force: true });
     throw err;
   } finally {
     flockUnlock(lockFd);
     closeSync(lockFd);
   }
+}
+
+function swapStagingToFinal(stagingDir: string, destDir: string): void {
+  rmSync(destDir, { recursive: true, force: true });
+  renameSync(stagingDir, destDir);
 }
 
 async function main(): Promise<void> {

--- a/scripts/install-agent.ts
+++ b/scripts/install-agent.ts
@@ -1,0 +1,380 @@
+#!/usr/bin/env bun
+/**
+ * Install an agent provider binary at a specific version.
+ *
+ * Resolution order: npm registry first, LFS archive fallback.
+ * All installs are sha256-verified against the sidecar checksum.
+ *
+ * Usage:
+ *   bun scripts/install-agent.ts claude@2.1.119
+ *   bun scripts/install-agent.ts --offline claude@2.1.119
+ */
+
+import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { options } from "@mcp-cli/core";
+import { type VersionEntry, type VersionsGrid, validateVersionsGrid } from "../agent-grid/versions-schema";
+
+const REPO_ROOT = resolve(import.meta.dir, "..");
+const GRID_DIR = resolve(REPO_ROOT, "agent-grid");
+const VERSIONS_PATH = resolve(GRID_DIR, "versions.yaml");
+
+// ── Provider → npm package mapping ─────────────────────────────────
+
+const NPM_PACKAGES: Record<string, string> = {
+  claude: "@anthropic-ai/claude-code",
+};
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export interface InstallResult {
+  provider: string;
+  version: string;
+  binaryPath: string;
+  source: "registry" | "archive";
+  sha256: string;
+}
+
+export interface InstallArgs {
+  provider: string;
+  version: string;
+  offline: boolean;
+}
+
+export interface InstallDeps {
+  agentsDir: string;
+  gridDir: string;
+  versionsPath: string;
+  spawn: typeof Bun.spawn;
+  log: (msg: string) => void;
+  error: (msg: string) => void;
+}
+
+const defaultDeps: InstallDeps = {
+  agentsDir: options.AGENTS_DIR,
+  gridDir: GRID_DIR,
+  versionsPath: VERSIONS_PATH,
+  spawn: Bun.spawn,
+  log: (msg) => console.log(msg),
+  error: (msg) => console.error(msg),
+};
+
+// ── Argument parsing ───────────────────────────────────────────────
+
+export function parseInstallAgentArgs(argv: string[]): InstallArgs {
+  let offline = false;
+  const positional: string[] = [];
+
+  for (const arg of argv) {
+    if (arg === "--offline") {
+      offline = true;
+    } else if (arg.startsWith("-")) {
+      throw new Error(`Unknown flag: ${arg}`);
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  if (positional.length === 0) {
+    throw new Error("Usage: install-agent [--offline] <provider@version>");
+  }
+
+  const spec = positional[0] as string;
+  const atIdx = spec.indexOf("@");
+  if (atIdx < 1) {
+    throw new Error(`Invalid spec "${spec}" — expected provider@version (e.g. claude@2.1.119)`);
+  }
+
+  const provider = spec.slice(0, atIdx);
+  const version = spec.slice(atIdx + 1);
+  if (!version) {
+    throw new Error(`Missing version in "${spec}" — expected provider@version`);
+  }
+
+  return { provider, version, offline };
+}
+
+// ── Grid loading ───────────────────────────────────────────────────
+
+export function loadGrid(versionsPath: string): VersionsGrid {
+  let text: string;
+  try {
+    text = readFileSync(versionsPath, "utf-8");
+  } catch (err) {
+    throw new Error(`Cannot read ${versionsPath}: ${(err as Error).message}`);
+  }
+
+  let raw: unknown;
+  try {
+    raw = Bun.YAML.parse(text);
+  } catch (err) {
+    throw new Error(`Invalid YAML: ${(err as Error).message}`);
+  }
+
+  const result = validateVersionsGrid(raw);
+  if (!result.ok) {
+    const msgs = result.issues.map((i) => `${i.path}: ${i.message}`).join("; ");
+    throw new Error(`versions.yaml validation failed: ${msgs}`);
+  }
+
+  return result.grid;
+}
+
+export function findVersionEntry(grid: VersionsGrid, provider: string, version: string): VersionEntry | null {
+  const prov = grid.providers.find((p) => p.name === provider);
+  if (!prov) return null;
+  return prov.versions.find((v) => v.version === version) ?? null;
+}
+
+// ── SHA256 helpers ─────────────────────────────────────────────────
+
+export async function sha256File(path: string): Promise<string> {
+  const file = Bun.file(path);
+  const hasher = new Bun.CryptoHasher("sha256");
+  const bytes = await file.arrayBuffer();
+  hasher.update(new Uint8Array(bytes));
+  return hasher.digest("hex");
+}
+
+export function readSidecarChecksum(tgzPath: string): string {
+  const sidecarPath = `${tgzPath}.sha256`;
+  let text: string;
+  try {
+    text = readFileSync(sidecarPath, "utf-8").trim();
+  } catch {
+    throw new Error(`Checksum sidecar not found: ${sidecarPath}`);
+  }
+
+  // Format: "<hash>  <filename>" or just "<hash>"
+  const hash = text.split(/\s+/)[0] as string;
+  if (!/^[0-9a-f]{64}$/.test(hash)) {
+    throw new Error(`Invalid sha256 in sidecar ${sidecarPath}: "${hash}"`);
+  }
+  return hash;
+}
+
+// ── Registry install (npm pack) ────────────────────────────────────
+
+export async function installFromRegistry(
+  provider: string,
+  version: string,
+  destDir: string,
+  deps: InstallDeps,
+): Promise<{ binaryPath: string; sha256: string } | null> {
+  const npmPkg = NPM_PACKAGES[provider];
+  if (!npmPkg) return null;
+
+  const tmpDir = join(destDir, ".tmp-registry");
+  mkdirSync(tmpDir, { recursive: true });
+
+  try {
+    deps.error(`registry: npm pack ${npmPkg}@${version}...`);
+    const pack = deps.spawn(["npm", "pack", `${npmPkg}@${version}`, "--pack-destination", tmpDir], {
+      cwd: tmpDir,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const packExit = await pack.exited;
+    if (packExit !== 0) {
+      const stderr = await new Response(pack.stderr).text();
+      deps.error(`registry: npm pack failed (exit ${packExit}): ${stderr.trim()}`);
+      return null;
+    }
+
+    const packOut = (await new Response(pack.stdout).text()).trim();
+    const tgzName = packOut.split("\n").pop()?.trim();
+    if (!tgzName) {
+      deps.error("registry: npm pack produced no output");
+      return null;
+    }
+
+    const tgzPath = join(tmpDir, tgzName);
+    if (!existsSync(tgzPath)) {
+      deps.error(`registry: expected tarball not found: ${tgzPath}`);
+      return null;
+    }
+
+    deps.error("registry: extracting package...");
+    const extract = deps.spawn(["tar", "xzf", tgzPath, "-C", tmpDir], {
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const extractExit = await extract.exited;
+    if (extractExit !== 0) {
+      const stderr = await new Response(extract.stderr).text();
+      deps.error(`registry: extraction failed: ${stderr.trim()}`);
+      return null;
+    }
+
+    const packageDir = join(tmpDir, "package");
+    const binaryName = provider;
+    const candidates = [join(packageDir, "cli.mjs"), join(packageDir, "bin", binaryName), join(packageDir, binaryName)];
+
+    let sourceBinary: string | null = null;
+    for (const c of candidates) {
+      if (existsSync(c)) {
+        sourceBinary = c;
+        break;
+      }
+    }
+
+    if (!sourceBinary) {
+      deps.error(`registry: no binary found in package (checked: ${candidates.join(", ")})`);
+      return null;
+    }
+
+    const binaryDest = join(destDir, binaryName);
+    const file = Bun.file(sourceBinary);
+    await Bun.write(binaryDest, file);
+
+    chmodSync(binaryDest, 0o755);
+
+    const hash = await sha256File(binaryDest);
+    deps.error(`registry: installed ${binaryDest} (sha256: ${hash})`);
+
+    return { binaryPath: binaryDest, sha256: hash };
+  } catch (err) {
+    deps.error(`registry: failed: ${(err as Error).message}`);
+    return null;
+  } finally {
+    rmSync(tmpDir, { recursive: true, force: true });
+  }
+}
+
+// ── Archive install (LFS) ──────────────────────────────────────────
+
+export async function installFromArchive(
+  entry: VersionEntry,
+  provider: string,
+  destDir: string,
+  deps: InstallDeps,
+): Promise<{ binaryPath: string; sha256: string }> {
+  if (!entry.archive) {
+    throw new Error(`No archive path in versions.yaml for ${provider}@${entry.version}`);
+  }
+
+  const archivePath = resolve(deps.gridDir, entry.archive);
+  if (!existsSync(archivePath)) {
+    throw new Error(`Archive not found: ${archivePath} — run 'git lfs pull' if this is a fresh clone`);
+  }
+
+  const expectedHash = readSidecarChecksum(archivePath);
+  const actualHash = await sha256File(archivePath);
+
+  if (actualHash !== expectedHash) {
+    throw new Error(
+      `SHA256 mismatch for ${archivePath}\n  expected: ${expectedHash}\n  actual:   ${actualHash}\nArchive may be corrupted or tampered with.`,
+    );
+  }
+
+  deps.error(`archive: checksum verified (${expectedHash})`);
+
+  mkdirSync(destDir, { recursive: true });
+  const extract = deps.spawn(["tar", "xzf", archivePath, "-C", destDir], {
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+  const extractExit = await extract.exited;
+  if (extractExit !== 0) {
+    const stderr = await new Response(extract.stderr).text();
+    throw new Error(`Archive extraction failed (exit ${extractExit}): ${stderr.trim()}`);
+  }
+
+  const files = readdirSync(destDir);
+  const binaryName =
+    files.find((f) => f === `${provider}-${entry.version}`) ??
+    files.find((f) => f === provider) ??
+    files.find((f) => f.startsWith(provider) && !f.endsWith(".sha256"));
+
+  if (!binaryName) {
+    throw new Error(`No binary found after extracting archive (files: ${files.join(", ")})`);
+  }
+
+  const binaryPath = join(destDir, binaryName);
+
+  chmodSync(binaryPath, 0o755);
+
+  const binaryHash = await sha256File(binaryPath);
+  deps.error(`archive: installed ${binaryPath} (binary sha256: ${binaryHash})`);
+
+  return { binaryPath, sha256: binaryHash };
+}
+
+// ── Main ───────────────────────────────────────────────────────────
+
+export async function installAgent(args: InstallArgs, deps: InstallDeps = defaultDeps): Promise<InstallResult> {
+  const grid = loadGrid(deps.versionsPath);
+  const entry = findVersionEntry(grid, args.provider, args.version);
+
+  if (!entry) {
+    const prov = grid.providers.find((p) => p.name === args.provider);
+    if (!prov) {
+      const known = grid.providers.map((p) => p.name).join(", ");
+      throw new Error(`Unknown provider "${args.provider}" — known: ${known}`);
+    }
+    const versions = prov.versions.map((v) => v.version).join(", ");
+    throw new Error(`Version "${args.version}" not found for ${args.provider} — known: ${versions || "(none)"}`);
+  }
+
+  const destDir = join(deps.agentsDir, args.provider, args.version);
+  mkdirSync(destDir, { recursive: true });
+
+  // Registry-first (skip if --offline)
+  if (!args.offline) {
+    deps.error(`Trying registry for ${args.provider}@${args.version}...`);
+    const registryResult = await installFromRegistry(args.provider, args.version, destDir, deps);
+    if (registryResult) {
+      return {
+        provider: args.provider,
+        version: args.version,
+        binaryPath: registryResult.binaryPath,
+        source: "registry",
+        sha256: registryResult.sha256,
+      };
+    }
+    deps.error("Registry install failed — falling back to archive...");
+  }
+
+  // Archive fallback
+  deps.error(`Installing ${args.provider}@${args.version} from archive...`);
+  const archiveResult = await installFromArchive(entry, args.provider, destDir, deps);
+
+  return {
+    provider: args.provider,
+    version: args.version,
+    binaryPath: archiveResult.binaryPath,
+    source: "archive",
+    sha256: archiveResult.sha256,
+  };
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+
+  if (argv.length === 0 || argv.includes("--help") || argv.includes("-h")) {
+    console.error("Usage: install-agent [--offline] <provider@version>");
+    console.error("");
+    console.error("Install an agent provider binary, verified by sha256 checksum.");
+    console.error("");
+    console.error("Options:");
+    console.error("  --offline    Install from LFS archive only (no network)");
+    console.error("");
+    console.error("Examples:");
+    console.error("  install-agent claude@2.1.119");
+    console.error("  install-agent --offline claude@2.1.119");
+    process.exit(argv.length === 0 ? 1 : 0);
+  }
+
+  try {
+    const args = parseInstallAgentArgs(argv);
+    const result = await installAgent(args);
+    console.log(JSON.stringify(result, null, 2));
+  } catch (err) {
+    console.error(`error: ${(err as Error).message}`);
+    process.exit(1);
+  }
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/scripts/install-agent.ts
+++ b/scripts/install-agent.ts
@@ -10,7 +10,7 @@
  *   bun scripts/install-agent.ts --offline claude@2.1.119
  */
 
-import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { options } from "@mcp-cli/core";
 import { type VersionEntry, type VersionsGrid, validateVersionsGrid } from "../agent-grid/versions-schema";
@@ -26,6 +26,13 @@ const NPM_PACKAGES: Record<string, string> = {
 };
 
 // ── Types ──────────────────────────────────────────────────────────
+
+export class Sha256MismatchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "Sha256MismatchError";
+  }
+}
 
 export interface InstallResult {
   provider: string;
@@ -156,6 +163,7 @@ export function readSidecarChecksum(tgzPath: string): string {
 // ── Registry install (npm pack) ────────────────────────────────────
 
 export async function installFromRegistry(
+  entry: VersionEntry,
   provider: string,
   version: string,
   destDir: string,
@@ -195,7 +203,7 @@ export async function installFromRegistry(
     }
 
     deps.error("registry: extracting package...");
-    const extract = deps.spawn(["tar", "xzf", tgzPath, "-C", tmpDir], {
+    const extract = deps.spawn(["tar", "xzf", tgzPath, "--no-same-owner", "-C", tmpDir], {
       stdout: "ignore",
       stderr: "pipe",
     });
@@ -230,10 +238,18 @@ export async function installFromRegistry(
     chmodSync(binaryDest, 0o755);
 
     const hash = await sha256File(binaryDest);
+
+    if (entry.binary_sha256 && hash !== entry.binary_sha256) {
+      throw new Sha256MismatchError(
+        `SHA256 mismatch for registry-installed binary\n  expected: ${entry.binary_sha256}\n  actual:   ${hash}\nRegistry may have served a tampered package.`,
+      );
+    }
+
     deps.error(`registry: installed ${binaryDest} (sha256: ${hash})`);
 
     return { binaryPath: binaryDest, sha256: hash };
   } catch (err) {
+    if (err instanceof Sha256MismatchError) throw err;
     deps.error(`registry: failed: ${(err as Error).message}`);
     return null;
   } finally {
@@ -258,11 +274,14 @@ export async function installFromArchive(
     throw new Error(`Archive not found: ${archivePath} — run 'git lfs pull' if this is a fresh clone`);
   }
 
+  // Sidecar guards against accidental corruption (truncated LFS pull, bad disk).
+  // Not a supply-chain boundary — the sidecar lives next to the archive in the
+  // same LFS-tracked tree. The real trust anchor is git LFS object integrity.
   const expectedHash = readSidecarChecksum(archivePath);
   const actualHash = await sha256File(archivePath);
 
   if (actualHash !== expectedHash) {
-    throw new Error(
+    throw new Sha256MismatchError(
       `SHA256 mismatch for ${archivePath}\n  expected: ${expectedHash}\n  actual:   ${actualHash}\nArchive may be corrupted or tampered with.`,
     );
   }
@@ -270,7 +289,7 @@ export async function installFromArchive(
   deps.error(`archive: checksum verified (${expectedHash})`);
 
   mkdirSync(destDir, { recursive: true });
-  const extract = deps.spawn(["tar", "xzf", archivePath, "-C", destDir], {
+  const extract = deps.spawn(["tar", "xzf", archivePath, "--no-same-owner", "-C", destDir], {
     stdout: "ignore",
     stderr: "pipe",
   });
@@ -280,21 +299,33 @@ export async function installFromArchive(
     throw new Error(`Archive extraction failed (exit ${extractExit}): ${stderr.trim()}`);
   }
 
+  const expectedBinaryName = `${provider}-${entry.version}`;
   const files = readdirSync(destDir);
-  const binaryName =
-    files.find((f) => f === `${provider}-${entry.version}`) ??
-    files.find((f) => f === provider) ??
-    files.find((f) => f.startsWith(provider) && !f.endsWith(".sha256"));
+  const binaryName = files.find((f) => f === expectedBinaryName) ?? files.find((f) => f === provider);
 
   if (!binaryName) {
-    throw new Error(`No binary found after extracting archive (files: ${files.join(", ")})`);
+    throw new Error(
+      `No binary found after extracting archive (expected "${expectedBinaryName}" or "${provider}", got: ${files.join(", ")})`,
+    );
   }
 
   const binaryPath = join(destDir, binaryName);
 
+  const stat = lstatSync(binaryPath);
+  if (stat.isSymbolicLink()) {
+    throw new Error(`Extracted file is a symlink — refusing to install: ${binaryPath}`);
+  }
+
   chmodSync(binaryPath, 0o755);
 
   const binaryHash = await sha256File(binaryPath);
+
+  if (entry.binary_sha256 && binaryHash !== entry.binary_sha256) {
+    throw new Sha256MismatchError(
+      `SHA256 mismatch for extracted binary\n  expected: ${entry.binary_sha256}\n  actual:   ${binaryHash}\nArchive may contain a tampered binary.`,
+    );
+  }
+
   deps.error(`archive: installed ${binaryPath} (binary sha256: ${binaryHash})`);
 
   return { binaryPath, sha256: binaryHash };
@@ -319,33 +350,38 @@ export async function installAgent(args: InstallArgs, deps: InstallDeps = defaul
   const destDir = join(deps.agentsDir, args.provider, args.version);
   mkdirSync(destDir, { recursive: true });
 
-  // Registry-first (skip if --offline)
-  if (!args.offline) {
-    deps.error(`Trying registry for ${args.provider}@${args.version}...`);
-    const registryResult = await installFromRegistry(args.provider, args.version, destDir, deps);
-    if (registryResult) {
-      return {
-        provider: args.provider,
-        version: args.version,
-        binaryPath: registryResult.binaryPath,
-        source: "registry",
-        sha256: registryResult.sha256,
-      };
+  try {
+    // Registry-first (skip if --offline)
+    if (!args.offline) {
+      deps.error(`Trying registry for ${args.provider}@${args.version}...`);
+      const registryResult = await installFromRegistry(entry, args.provider, args.version, destDir, deps);
+      if (registryResult) {
+        return {
+          provider: args.provider,
+          version: args.version,
+          binaryPath: registryResult.binaryPath,
+          source: "registry",
+          sha256: registryResult.sha256,
+        };
+      }
+      deps.error("Registry install failed — falling back to archive...");
     }
-    deps.error("Registry install failed — falling back to archive...");
+
+    // Archive fallback
+    deps.error(`Installing ${args.provider}@${args.version} from archive...`);
+    const archiveResult = await installFromArchive(entry, args.provider, destDir, deps);
+
+    return {
+      provider: args.provider,
+      version: args.version,
+      binaryPath: archiveResult.binaryPath,
+      source: "archive",
+      sha256: archiveResult.sha256,
+    };
+  } catch (err) {
+    rmSync(destDir, { recursive: true, force: true });
+    throw err;
   }
-
-  // Archive fallback
-  deps.error(`Installing ${args.provider}@${args.version} from archive...`);
-  const archiveResult = await installFromArchive(entry, args.provider, destDir, deps);
-
-  return {
-    provider: args.provider,
-    version: args.version,
-    binaryPath: archiveResult.binaryPath,
-    source: "archive",
-    sha256: archiveResult.sha256,
-  };
 }
 
 async function main(): Promise<void> {

--- a/scripts/install-agent.ts
+++ b/scripts/install-agent.ts
@@ -154,8 +154,10 @@ export function findVersionEntry(grid: VersionsGrid, provider: string, version: 
 export async function sha256File(path: string): Promise<string> {
   const file = Bun.file(path);
   const hasher = new Bun.CryptoHasher("sha256");
-  const bytes = await file.arrayBuffer();
-  hasher.update(new Uint8Array(bytes));
+  const stream = file.stream();
+  for await (const chunk of stream) {
+    hasher.update(chunk);
+  }
   return hasher.digest("hex");
 }
 
@@ -248,6 +250,9 @@ export async function installFromRegistry(
     }
 
     const binaryDest = join(destDir, binaryName);
+    if (existsSync(binaryDest) && lstatSync(binaryDest).isSymbolicLink()) {
+      throw new Error(`Refusing to overwrite symlink at ${binaryDest}`);
+    }
     const file = Bun.file(sourceBinary);
     await Bun.write(binaryDest, file);
 
@@ -330,6 +335,9 @@ export async function installFromArchive(
   const stat = lstatSync(binaryPath);
   if (stat.isSymbolicLink()) {
     throw new Error(`Extracted file is a symlink — refusing to install: ${binaryPath}`);
+  }
+  if (!stat.isFile()) {
+    throw new Error(`Extracted path is not a regular file — refusing to install: ${binaryPath}`);
   }
 
   chmodSync(binaryPath, 0o755);

--- a/scripts/install-agent.ts
+++ b/scripts/install-agent.ts
@@ -3,16 +3,28 @@
  * Install an agent provider binary at a specific version.
  *
  * Resolution order: npm registry first, LFS archive fallback.
- * All installs are sha256-verified against the sidecar checksum.
+ * Registry installs are verified against `binary_sha256` from versions.yaml
+ * when present. Archive installs are verified against the `.sha256` sidecar
+ * (corruption guard — the real trust anchor is git LFS object integrity).
  *
  * Usage:
  *   bun scripts/install-agent.ts claude@2.1.119
  *   bun scripts/install-agent.ts --offline claude@2.1.119
  */
 
-import { chmodSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+} from "node:fs";
 import { join, resolve } from "node:path";
-import { options } from "@mcp-cli/core";
+import { flockUnlock, options, tryFlockExclusive } from "@mcp-cli/core";
 import { type VersionEntry, type VersionsGrid, validateVersionsGrid } from "../agent-grid/versions-schema";
 
 const REPO_ROOT = resolve(import.meta.dir, "..");
@@ -84,6 +96,10 @@ export function parseInstallAgentArgs(argv: string[]): InstallArgs {
 
   if (positional.length === 0) {
     throw new Error("Usage: install-agent [--offline] <provider@version>");
+  }
+
+  if (positional.length > 1) {
+    throw new Error("Too many arguments — expected a single provider@version spec");
   }
 
   const spec = positional[0] as string;
@@ -350,6 +366,13 @@ export async function installAgent(args: InstallArgs, deps: InstallDeps = defaul
   const destDir = join(deps.agentsDir, args.provider, args.version);
   mkdirSync(destDir, { recursive: true });
 
+  const lockPath = join(destDir, ".install.lock");
+  const lockFd = openSync(lockPath, "w");
+  if (!tryFlockExclusive(lockFd)) {
+    closeSync(lockFd);
+    throw new Error(`Another install of ${args.provider}@${args.version} is already in progress`);
+  }
+
   try {
     // Registry-first (skip if --offline)
     if (!args.offline) {
@@ -381,6 +404,9 @@ export async function installAgent(args: InstallArgs, deps: InstallDeps = defaul
   } catch (err) {
     rmSync(destDir, { recursive: true, force: true });
     throw err;
+  } finally {
+    flockUnlock(lockFd);
+    closeSync(lockFd);
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `scripts/install-agent.ts` — resolves `provider@version` to a runnable binary via npm registry (for claude → `@anthropic-ai/claude-code`), falling back to the LFS archive in `agent-grid/binaries/`, with sha256 verification against `.sha256` sidecar files
- `--offline` flag forces archive-only installation (no network)
- Checksum mismatch is a hard failure with a clear diagnostic message
- Add `AGENTS_DIR` (`~/.mcp-cli/agents/`) to core constants for binary install location
- 27 tests covering arg parsing, grid loading, sha256 verification, archive extraction, checksum mismatch detection, offline mode, and full install flow

## Test plan
- [x] `bun test scripts/install-agent.spec.ts` — 27 tests pass
- [x] Arg parsing: `provider@version`, `--offline`, invalid specs, unknown flags
- [x] Grid loading: valid YAML, missing file, invalid YAML, schema validation failure
- [x] SHA256: correct hash computation, sidecar reading (hash-only and hash+filename formats), missing sidecar, invalid hash
- [x] Archive install: extraction + sha256 verification, checksum mismatch hard failure, missing archive, missing archive path
- [x] Full flow: offline install, unknown provider/version errors, registry-to-archive fallback
- [x] `bun run am-i-done` passes (pre-existing SIGKILL flake in `compactify.spec.ts` under parallel load — unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)