### PR TITLE
feat(agent-grid): capability tests batch 1 — spawn-in-dir, read-file, edit-file, run-bash, multi-turn (fixes #2588)

### DIFF
--- a/agent-grid/src/grid-test.ts
+++ b/agent-grid/src/grid-test.ts
@@ -7,6 +7,7 @@ export type GridResult = { status: "pass" } | { status: "fail"; error: string } 
 export interface GridTestContext {
   provider: AgentProvider;
   cwd: string;
+  onCleanup?: (fn: () => Promise<void>) => void;
 }
 
 /** A single capability test in the agent grid. */

--- a/agent-grid/src/index.ts
+++ b/agent-grid/src/index.ts
@@ -2,3 +2,4 @@ export * from "./grid-test";
 export * from "./capability-gate";
 export * from "./isolation";
 export * from "./replay";
+export * from "./tests";

--- a/agent-grid/src/tests/edit-file.ts
+++ b/agent-grid/src/tests/edit-file.ts
@@ -21,6 +21,8 @@ export function makeEditFileTest(deps: { callTool: CallToolFn }): GridTest {
         callTool: deps.callTool,
       });
 
+      ctx.onCleanup?.(() => byeSession(ctx.provider, result.sessionId, deps.callTool));
+
       try {
         const content = readFileSync(filePath, "utf-8");
         if (!content.includes(MODIFIED)) {
@@ -34,9 +36,7 @@ export function makeEditFileTest(deps: { callTool: CallToolFn }): GridTest {
         }
         return { status: "pass" };
       } finally {
-        if (result.sessionId) {
-          await byeSession(ctx.provider, result.sessionId, deps.callTool).catch(() => {});
-        }
+        await byeSession(ctx.provider, result.sessionId, deps.callTool).catch(() => {});
       }
     },
   };

--- a/agent-grid/src/tests/edit-file.ts
+++ b/agent-grid/src/tests/edit-file.ts
@@ -1,0 +1,43 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { GridTest } from "../grid-test";
+import { type CallToolFn, byeSession, promptAndWait } from "./helpers";
+
+const FIXTURE = "grid-test-edit.txt";
+const ORIGINAL = "GRID_EDIT_ORIGINAL_4d9e";
+const MODIFIED = "GRID_EDIT_MODIFIED_4d9e";
+
+export function makeEditFileTest(deps: { callTool: CallToolFn }): GridTest {
+  return {
+    name: "edit-file",
+    requires: [],
+    async run(ctx) {
+      const filePath = join(ctx.cwd, FIXTURE);
+      writeFileSync(filePath, `line1\n${ORIGINAL}\nline3\n`);
+
+      const result = await promptAndWait(ctx.provider, {
+        task: `Edit the file ${FIXTURE} in your current directory: replace the text "${ORIGINAL}" with "${MODIFIED}". Do not change anything else. Do not explain.`,
+        cwd: ctx.cwd,
+        callTool: deps.callTool,
+      });
+
+      try {
+        const content = readFileSync(filePath, "utf-8");
+        if (!content.includes(MODIFIED)) {
+          return {
+            status: "fail",
+            error: `file does not contain "${MODIFIED}" after edit. Content: ${content.slice(0, 200)}`,
+          };
+        }
+        if (content.includes(ORIGINAL)) {
+          return { status: "fail", error: `file still contains "${ORIGINAL}" — replacement incomplete` };
+        }
+        return { status: "pass" };
+      } finally {
+        if (result.sessionId) {
+          await byeSession(ctx.provider, result.sessionId, deps.callTool).catch(() => {});
+        }
+      }
+    },
+  };
+}

--- a/agent-grid/src/tests/helpers.ts
+++ b/agent-grid/src/tests/helpers.ts
@@ -1,0 +1,100 @@
+import type { AgentProvider } from "@mcp-cli/core";
+
+export type CallToolFn = (server: string, tool: string, args: Record<string, unknown>) => Promise<unknown>;
+
+export interface PromptResult {
+  sessionId: string;
+  text: string;
+  raw: unknown;
+}
+
+export function extractText(raw: unknown): string {
+  if (typeof raw !== "object" || raw === null) return String(raw);
+  const obj = raw as Record<string, unknown>;
+  if (!Array.isArray(obj.content)) return JSON.stringify(raw);
+
+  const parts: string[] = [];
+  for (const item of obj.content) {
+    if (typeof item === "object" && item !== null && "text" in item) {
+      parts.push(String((item as { text: unknown }).text));
+    }
+  }
+  return parts.join("\n");
+}
+
+export function extractSessionId(text: string): string {
+  try {
+    const parsed = JSON.parse(text) as Record<string, unknown>;
+    if (typeof parsed.sessionId === "string") return parsed.sessionId;
+  } catch {
+    // not JSON — try regex fallback
+  }
+  const match = text.match(/"sessionId"\s*:\s*"([^"]+)"/);
+  return match?.[1] ?? "";
+}
+
+function isErrorResult(raw: unknown): boolean {
+  if (typeof raw !== "object" || raw === null) return false;
+  return (raw as Record<string, unknown>).isError === true;
+}
+
+export async function promptAndWait(
+  provider: AgentProvider,
+  opts: { task: string; cwd: string; callTool: CallToolFn },
+): Promise<PromptResult> {
+  const raw = await opts.callTool(provider.serverName, `${provider.toolPrefix}_prompt`, {
+    prompt: opts.task,
+    cwd: opts.cwd,
+    wait: true,
+  });
+
+  const text = extractText(raw);
+  if (isErrorResult(raw)) {
+    throw new Error(`prompt failed: ${text}`);
+  }
+
+  const sessionId = extractSessionId(text);
+  return { sessionId, text, raw };
+}
+
+export async function promptNoWait(
+  provider: AgentProvider,
+  opts: { task: string; cwd: string; callTool: CallToolFn },
+): Promise<{ sessionId: string }> {
+  const raw = await opts.callTool(provider.serverName, `${provider.toolPrefix}_prompt`, {
+    prompt: opts.task,
+    cwd: opts.cwd,
+  });
+
+  const text = extractText(raw);
+  if (isErrorResult(raw)) {
+    throw new Error(`prompt failed: ${text}`);
+  }
+
+  const sessionId = extractSessionId(text);
+  if (!sessionId) throw new Error("no sessionId in prompt response");
+  return { sessionId };
+}
+
+export async function promptFollowUp(
+  provider: AgentProvider,
+  opts: { sessionId: string; task: string; cwd: string; callTool: CallToolFn },
+): Promise<PromptResult> {
+  const raw = await opts.callTool(provider.serverName, `${provider.toolPrefix}_prompt`, {
+    prompt: opts.task,
+    sessionId: opts.sessionId,
+    cwd: opts.cwd,
+    wait: true,
+  });
+
+  const text = extractText(raw);
+  if (isErrorResult(raw)) {
+    throw new Error(`follow-up prompt failed: ${text}`);
+  }
+
+  return { sessionId: opts.sessionId, text, raw };
+}
+
+export async function byeSession(provider: AgentProvider, sessionId: string, callTool: CallToolFn): Promise<void> {
+  await callTool(provider.serverName, `${provider.toolPrefix}_bye`, { sessionId });
+}

--- a/agent-grid/src/tests/helpers.ts
+++ b/agent-grid/src/tests/helpers.ts
@@ -54,6 +54,7 @@ export async function promptAndWait(
   }
 
   const sessionId = extractSessionId(text);
+  if (!sessionId) throw new Error("no sessionId in prompt response");
   return { sessionId, text, raw };
 }
 

--- a/agent-grid/src/tests/helpers.ts
+++ b/agent-grid/src/tests/helpers.ts
@@ -1,4 +1,5 @@
 import type { AgentProvider } from "@mcp-cli/core";
+import { parsePythonRepr } from "@mcp-cli/core";
 
 export type CallToolFn = (server: string, tool: string, args: Record<string, unknown>) => Promise<unknown>;
 
@@ -23,13 +24,12 @@ export function extractText(raw: unknown): string {
 }
 
 export function extractSessionId(text: string): string {
-  try {
-    const parsed = JSON.parse(text) as Record<string, unknown>;
-    if (typeof parsed.sessionId === "string") return parsed.sessionId;
-  } catch {
-    // not JSON — try regex fallback
+  const normalized = parsePythonRepr(text);
+  if (typeof normalized === "object" && normalized !== null) {
+    const obj = normalized as Record<string, unknown>;
+    if (typeof obj.sessionId === "string") return obj.sessionId;
   }
-  const match = text.match(/"sessionId"\s*:\s*"([^"]+)"/);
+  const match = text.match(/['"]sessionId['"]\s*:\s*['"]([^'"]+)['"]/);
   return match?.[1] ?? "";
 }
 

--- a/agent-grid/src/tests/index.ts
+++ b/agent-grid/src/tests/index.ts
@@ -1,0 +1,15 @@
+export { makeSpawnInDirTest } from "./spawn-in-dir";
+export { makeReadFileTest } from "./read-file";
+export { makeEditFileTest } from "./edit-file";
+export { makeRunBashTest } from "./run-bash";
+export { makeMultiTurnTest } from "./multi-turn";
+export {
+  type CallToolFn,
+  type PromptResult,
+  extractText,
+  extractSessionId,
+  promptAndWait,
+  promptFollowUp,
+  promptNoWait,
+  byeSession,
+} from "./helpers";

--- a/agent-grid/src/tests/multi-turn.ts
+++ b/agent-grid/src/tests/multi-turn.ts
@@ -1,0 +1,68 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { GridTest } from "../grid-test";
+import { type CallToolFn, byeSession, promptAndWait, promptFollowUp } from "./helpers";
+
+const MARKER = "GRID_MULTI_8b2c";
+const PROOF_FILE = "multi-turn-proof.txt";
+
+export function makeMultiTurnTest(deps: { callTool: CallToolFn }): GridTest {
+  return {
+    name: "multi-turn",
+    requires: ["multiTurn"],
+    async run(ctx) {
+      const { callTool } = deps;
+
+      const turn1 = await promptAndWait(ctx.provider, {
+        task: `Remember this code: ${MARKER}. Reply with "OK" and nothing else.`,
+        cwd: ctx.cwd,
+        callTool,
+      });
+
+      const { sessionId } = turn1;
+      if (!sessionId) {
+        return { status: "fail", error: "no sessionId returned from turn 1" };
+      }
+
+      try {
+        const turn2 = await promptFollowUp(ctx.provider, {
+          sessionId,
+          task: "What was the code I asked you to remember? Reply with just the code, nothing else.",
+          cwd: ctx.cwd,
+          callTool,
+        });
+
+        if (!turn2.text.includes(MARKER)) {
+          return {
+            status: "fail",
+            error: `context not retained: expected "${MARKER}" in turn 2 response, got: ${turn2.text.slice(0, 200)}`,
+          };
+        }
+
+        await promptFollowUp(ctx.provider, {
+          sessionId,
+          task: `Write the code ${MARKER} to a file called ${PROOF_FILE} in the current directory.`,
+          cwd: ctx.cwd,
+          callTool,
+        });
+
+        const proofPath = join(ctx.cwd, PROOF_FILE);
+        if (!existsSync(proofPath)) {
+          return { status: "fail", error: `proof file ${PROOF_FILE} was not created` };
+        }
+
+        const content = readFileSync(proofPath, "utf-8");
+        if (!content.includes(MARKER)) {
+          return {
+            status: "fail",
+            error: `proof file does not contain "${MARKER}", got: ${content.slice(0, 200)}`,
+          };
+        }
+
+        return { status: "pass" };
+      } finally {
+        await byeSession(ctx.provider, sessionId, callTool).catch(() => {});
+      }
+    },
+  };
+}

--- a/agent-grid/src/tests/multi-turn.ts
+++ b/agent-grid/src/tests/multi-turn.ts
@@ -20,9 +20,7 @@ export function makeMultiTurnTest(deps: { callTool: CallToolFn }): GridTest {
       });
 
       const { sessionId } = turn1;
-      if (!sessionId) {
-        return { status: "fail", error: "no sessionId returned from turn 1" };
-      }
+      ctx.onCleanup?.(() => byeSession(ctx.provider, sessionId, callTool));
 
       try {
         const turn2 = await promptFollowUp(ctx.provider, {

--- a/agent-grid/src/tests/read-file.ts
+++ b/agent-grid/src/tests/read-file.ts
@@ -19,6 +19,8 @@ export function makeReadFileTest(deps: { callTool: CallToolFn }): GridTest {
         callTool: deps.callTool,
       });
 
+      ctx.onCleanup?.(() => byeSession(ctx.provider, result.sessionId, deps.callTool));
+
       try {
         if (!result.text.includes(MARKER)) {
           return {
@@ -28,9 +30,7 @@ export function makeReadFileTest(deps: { callTool: CallToolFn }): GridTest {
         }
         return { status: "pass" };
       } finally {
-        if (result.sessionId) {
-          await byeSession(ctx.provider, result.sessionId, deps.callTool).catch(() => {});
-        }
+        await byeSession(ctx.provider, result.sessionId, deps.callTool).catch(() => {});
       }
     },
   };

--- a/agent-grid/src/tests/read-file.ts
+++ b/agent-grid/src/tests/read-file.ts
@@ -1,0 +1,37 @@
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { GridTest } from "../grid-test";
+import { type CallToolFn, byeSession, promptAndWait } from "./helpers";
+
+const MARKER = "GRID_READ_MARKER_7f3a";
+const FIXTURE = "grid-test-read.txt";
+
+export function makeReadFileTest(deps: { callTool: CallToolFn }): GridTest {
+  return {
+    name: "read-file",
+    requires: [],
+    async run(ctx) {
+      writeFileSync(join(ctx.cwd, FIXTURE), MARKER);
+
+      const result = await promptAndWait(ctx.provider, {
+        task: `Read the file ${FIXTURE} in your current directory and reply with its exact contents. Nothing else.`,
+        cwd: ctx.cwd,
+        callTool: deps.callTool,
+      });
+
+      try {
+        if (!result.text.includes(MARKER)) {
+          return {
+            status: "fail",
+            error: `expected marker "${MARKER}" in response, got: ${result.text.slice(0, 200)}`,
+          };
+        }
+        return { status: "pass" };
+      } finally {
+        if (result.sessionId) {
+          await byeSession(ctx.provider, result.sessionId, deps.callTool).catch(() => {});
+        }
+      }
+    },
+  };
+}

--- a/agent-grid/src/tests/run-bash.ts
+++ b/agent-grid/src/tests/run-bash.ts
@@ -1,0 +1,32 @@
+import { realpathSync } from "node:fs";
+import type { GridTest } from "../grid-test";
+import { type CallToolFn, byeSession, promptAndWait } from "./helpers";
+
+export function makeRunBashTest(deps: { callTool: CallToolFn }): GridTest {
+  return {
+    name: "run-bash",
+    requires: [],
+    async run(ctx) {
+      const expected = realpathSync(ctx.cwd);
+      const result = await promptAndWait(ctx.provider, {
+        task: "Run the bash command `pwd` and reply with the output. Nothing else.",
+        cwd: ctx.cwd,
+        callTool: deps.callTool,
+      });
+
+      try {
+        if (!result.text.includes(expected)) {
+          return {
+            status: "fail",
+            error: `expected pwd output "${expected}" in response, got: ${result.text.slice(0, 200)}`,
+          };
+        }
+        return { status: "pass" };
+      } finally {
+        if (result.sessionId) {
+          await byeSession(ctx.provider, result.sessionId, deps.callTool).catch(() => {});
+        }
+      }
+    },
+  };
+}

--- a/agent-grid/src/tests/run-bash.ts
+++ b/agent-grid/src/tests/run-bash.ts
@@ -1,31 +1,36 @@
-import { realpathSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import type { GridTest } from "../grid-test";
 import { type CallToolFn, byeSession, promptAndWait } from "./helpers";
+
+const MARKER = "GRID_BASH_PROOF_9c4f";
+const PROOF_FILE = "grid-bash-proof.txt";
 
 export function makeRunBashTest(deps: { callTool: CallToolFn }): GridTest {
   return {
     name: "run-bash",
     requires: [],
     async run(ctx) {
-      const expected = realpathSync(ctx.cwd);
       const result = await promptAndWait(ctx.provider, {
-        task: "Run the bash command `pwd` and reply with the output. Nothing else.",
+        task: `Run this exact bash command: echo '${MARKER}' > ${PROOF_FILE}\nDo not explain, just run it.`,
         cwd: ctx.cwd,
         callTool: deps.callTool,
       });
 
+      ctx.onCleanup?.(() => byeSession(ctx.provider, result.sessionId, deps.callTool));
+
       try {
-        if (!result.text.includes(expected)) {
-          return {
-            status: "fail",
-            error: `expected pwd output "${expected}" in response, got: ${result.text.slice(0, 200)}`,
-          };
+        const proofPath = join(ctx.cwd, PROOF_FILE);
+        if (!existsSync(proofPath)) {
+          return { status: "fail", error: `proof file ${PROOF_FILE} was not created by bash` };
+        }
+        const content = readFileSync(proofPath, "utf-8");
+        if (!content.includes(MARKER)) {
+          return { status: "fail", error: `proof file missing marker "${MARKER}", got: ${content.slice(0, 200)}` };
         }
         return { status: "pass" };
       } finally {
-        if (result.sessionId) {
-          await byeSession(ctx.provider, result.sessionId, deps.callTool).catch(() => {});
-        }
+        await byeSession(ctx.provider, result.sessionId, deps.callTool).catch(() => {});
       }
     },
   };

--- a/agent-grid/src/tests/spawn-in-dir.ts
+++ b/agent-grid/src/tests/spawn-in-dir.ts
@@ -7,22 +7,22 @@ export function makeSpawnInDirTest(deps: { callTool: CallToolFn }): GridTest {
     name: "spawn-in-dir",
     requires: [],
     async run(ctx) {
-      const expected = realpathSync(ctx.cwd);
+      const resolved = realpathSync(ctx.cwd);
       const result = await promptAndWait(ctx.provider, {
         task: "Print your current working directory path and nothing else. Do not add any explanation.",
         cwd: ctx.cwd,
         callTool: deps.callTool,
       });
 
+      ctx.onCleanup?.(() => byeSession(ctx.provider, result.sessionId, deps.callTool));
+
       try {
-        if (!result.text.includes(expected)) {
-          return { status: "fail", error: `expected cwd "${expected}" in response, got: ${result.text.slice(0, 200)}` };
+        if (!result.text.includes(resolved) && !result.text.includes(ctx.cwd)) {
+          return { status: "fail", error: `expected cwd "${resolved}" in response, got: ${result.text.slice(0, 200)}` };
         }
         return { status: "pass" };
       } finally {
-        if (result.sessionId) {
-          await byeSession(ctx.provider, result.sessionId, deps.callTool).catch(() => {});
-        }
+        await byeSession(ctx.provider, result.sessionId, deps.callTool).catch(() => {});
       }
     },
   };

--- a/agent-grid/src/tests/spawn-in-dir.ts
+++ b/agent-grid/src/tests/spawn-in-dir.ts
@@ -1,0 +1,29 @@
+import { realpathSync } from "node:fs";
+import type { GridTest } from "../grid-test";
+import { type CallToolFn, byeSession, promptAndWait } from "./helpers";
+
+export function makeSpawnInDirTest(deps: { callTool: CallToolFn }): GridTest {
+  return {
+    name: "spawn-in-dir",
+    requires: [],
+    async run(ctx) {
+      const expected = realpathSync(ctx.cwd);
+      const result = await promptAndWait(ctx.provider, {
+        task: "Print your current working directory path and nothing else. Do not add any explanation.",
+        cwd: ctx.cwd,
+        callTool: deps.callTool,
+      });
+
+      try {
+        if (!result.text.includes(expected)) {
+          return { status: "fail", error: `expected cwd "${expected}" in response, got: ${result.text.slice(0, 200)}` };
+        }
+        return { status: "pass" };
+      } finally {
+        if (result.sessionId) {
+          await byeSession(ctx.provider, result.sessionId, deps.callTool).catch(() => {});
+        }
+      }
+    },
+  };
+}

--- a/agent-grid/src/tests/tests.spec.ts
+++ b/agent-grid/src/tests/tests.spec.ts
@@ -1,0 +1,456 @@
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { getProvider } from "@mcp-cli/core";
+import type { AgentProvider } from "@mcp-cli/core";
+import { gateTest } from "../capability-gate";
+import { makeEditFileTest } from "./edit-file";
+import type { CallToolFn } from "./helpers";
+import { byeSession, extractText, promptAndWait, promptFollowUp, promptNoWait } from "./helpers";
+import { makeMultiTurnTest } from "./multi-turn";
+import { makeReadFileTest } from "./read-file";
+import { makeRunBashTest } from "./run-bash";
+import { makeSpawnInDirTest } from "./spawn-in-dir";
+
+function requireProvider(name: string): AgentProvider {
+  const p = getProvider(name);
+  if (!p) throw new Error(`provider "${name}" not registered`);
+  return p;
+}
+
+function makeTmpDir(): string {
+  return mkdtempSync(join(tmpdir(), "grid-test-spec-"));
+}
+
+function mcpTextResult(text: string, isError = false): unknown {
+  return { content: [{ type: "text", text }], ...(isError ? { isError: true } : {}) };
+}
+
+function mcpPromptResult(sessionId: string, resultText: string): unknown {
+  return mcpTextResult(JSON.stringify({ sessionId, success: true, text: resultText }));
+}
+
+const stubCallTool: CallToolFn = async () => mcpTextResult("stub");
+
+// ── extractText ───────────────────────────────────────────────────
+
+describe("extractText", () => {
+  test("extracts text from MCP content array", () => {
+    const raw = { content: [{ type: "text", text: "hello world" }] };
+    expect(extractText(raw)).toBe("hello world");
+  });
+
+  test("joins multiple content items", () => {
+    const raw = {
+      content: [
+        { type: "text", text: "a" },
+        { type: "text", text: "b" },
+      ],
+    };
+    expect(extractText(raw)).toBe("a\nb");
+  });
+
+  test("returns JSON for non-content shape", () => {
+    expect(extractText({ foo: "bar" })).toBe('{"foo":"bar"}');
+  });
+
+  test("returns string for primitive", () => {
+    expect(extractText(null)).toBe("null");
+    expect(extractText(42)).toBe("42");
+  });
+});
+
+// ── promptAndWait ─────────────────────────────────────────────────
+
+describe("promptAndWait", () => {
+  const claude = requireProvider("claude");
+
+  test("extracts sessionId from JSON response", async () => {
+    const callTool: CallToolFn = async () => mcpPromptResult("abc-123", "hello");
+    const result = await promptAndWait(claude, { task: "test", cwd: "/tmp", callTool });
+    expect(result.sessionId).toBe("abc-123");
+    expect(result.text).toContain("abc-123");
+  });
+
+  test("throws on error result", async () => {
+    const callTool: CallToolFn = async () => mcpTextResult("something broke", true);
+    expect(promptAndWait(claude, { task: "test", cwd: "/tmp", callTool })).rejects.toThrow("prompt failed");
+  });
+
+  test("extracts sessionId from regex fallback", async () => {
+    const callTool: CallToolFn = async () => mcpTextResult('some preamble "sessionId": "fallback-id" and more');
+    const result = await promptAndWait(claude, { task: "test", cwd: "/tmp", callTool });
+    expect(result.sessionId).toBe("fallback-id");
+  });
+
+  test("returns empty sessionId when not found", async () => {
+    const callTool: CallToolFn = async () => mcpTextResult("no session info here");
+    const result = await promptAndWait(claude, { task: "test", cwd: "/tmp", callTool });
+    expect(result.sessionId).toBe("");
+  });
+
+  test("calls correct tool with correct args", async () => {
+    let capturedServer = "";
+    let capturedTool = "";
+    let capturedArgs: Record<string, unknown> = {};
+    const callTool: CallToolFn = async (server, tool, args) => {
+      capturedServer = server;
+      capturedTool = tool;
+      capturedArgs = args;
+      return mcpPromptResult("s1", "ok");
+    };
+    await promptAndWait(claude, { task: "do stuff", cwd: "/my/dir", callTool });
+    expect(capturedServer).toBe("_claude");
+    expect(capturedTool).toBe("claude_prompt");
+    expect(capturedArgs.prompt).toBe("do stuff");
+    expect(capturedArgs.cwd).toBe("/my/dir");
+    expect(capturedArgs.wait).toBe(true);
+  });
+});
+
+// ── promptNoWait ──────────────────────────────────────────────────
+
+describe("promptNoWait", () => {
+  const claude = requireProvider("claude");
+
+  test("extracts sessionId", async () => {
+    const callTool: CallToolFn = async () => mcpTextResult(JSON.stringify({ sessionId: "nw-1", seq: 0 }));
+    const result = await promptNoWait(claude, { task: "test", cwd: "/tmp", callTool });
+    expect(result.sessionId).toBe("nw-1");
+  });
+
+  test("throws on error result", async () => {
+    const callTool: CallToolFn = async () => mcpTextResult("error", true);
+    expect(promptNoWait(claude, { task: "test", cwd: "/tmp", callTool })).rejects.toThrow("prompt failed");
+  });
+
+  test("throws when no sessionId returned", async () => {
+    const callTool: CallToolFn = async () => mcpTextResult("plain text no session");
+    expect(promptNoWait(claude, { task: "test", cwd: "/tmp", callTool })).rejects.toThrow("no sessionId");
+  });
+
+  test("does not send wait flag", async () => {
+    let capturedArgs: Record<string, unknown> = {};
+    const callTool: CallToolFn = async (_s, _t, args) => {
+      capturedArgs = args;
+      return mcpTextResult(JSON.stringify({ sessionId: "nw-2", seq: 0 }));
+    };
+    await promptNoWait(claude, { task: "test", cwd: "/tmp", callTool });
+    expect(capturedArgs.wait).toBeUndefined();
+  });
+});
+
+// ── promptFollowUp ────────────────────────────────────────────────
+
+describe("promptFollowUp", () => {
+  const claude = requireProvider("claude");
+
+  test("sends sessionId in args", async () => {
+    let capturedArgs: Record<string, unknown> = {};
+    const callTool: CallToolFn = async (_s, _t, args) => {
+      capturedArgs = args;
+      return mcpPromptResult("fu-1", "response");
+    };
+    const result = await promptFollowUp(claude, { sessionId: "fu-1", task: "follow", cwd: "/tmp", callTool });
+    expect(result.sessionId).toBe("fu-1");
+    expect(capturedArgs.sessionId).toBe("fu-1");
+    expect(capturedArgs.wait).toBe(true);
+  });
+
+  test("throws on error result", async () => {
+    const callTool: CallToolFn = async () => mcpTextResult("bad", true);
+    expect(promptFollowUp(claude, { sessionId: "fu-1", task: "test", cwd: "/tmp", callTool })).rejects.toThrow(
+      "follow-up prompt failed",
+    );
+  });
+});
+
+// ── byeSession ────────────────────────────────────────────────────
+
+describe("byeSession", () => {
+  test("calls bye tool with correct args", async () => {
+    let capturedTool = "";
+    let capturedArgs: Record<string, unknown> = {};
+    const callTool: CallToolFn = async (_s, tool, args) => {
+      capturedTool = tool;
+      capturedArgs = args;
+      return mcpTextResult("ok");
+    };
+    await byeSession(requireProvider("claude"), "sess-bye", callTool);
+    expect(capturedTool).toBe("claude_bye");
+    expect(capturedArgs.sessionId).toBe("sess-bye");
+  });
+});
+
+// ── test registry ─────────────────────────────────────────────────
+
+function buildAllTests(callTool: CallToolFn) {
+  return [
+    makeSpawnInDirTest({ callTool }),
+    makeReadFileTest({ callTool }),
+    makeEditFileTest({ callTool }),
+    makeRunBashTest({ callTool }),
+    makeMultiTurnTest({ callTool }),
+  ];
+}
+
+describe("test registry", () => {
+  const tests = buildAllTests(stubCallTool);
+
+  test("contains exactly 5 tests", () => {
+    expect(tests).toHaveLength(5);
+  });
+
+  test("test names are unique", () => {
+    const names = tests.map((t) => t.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  test("expected test names are present", () => {
+    const names = tests.map((t) => t.name);
+    expect(names).toContain("spawn-in-dir");
+    expect(names).toContain("read-file");
+    expect(names).toContain("edit-file");
+    expect(names).toContain("run-bash");
+    expect(names).toContain("multi-turn");
+  });
+});
+
+// ── Test structure and gating ─────────────────────────────────────
+
+describe("spawn-in-dir", () => {
+  const test_ = makeSpawnInDirTest({ callTool: stubCallTool });
+
+  test("has correct name and requires", () => {
+    expect(test_.name).toBe("spawn-in-dir");
+    expect(test_.requires).toEqual([]);
+  });
+
+  test("not gated for claude", () => {
+    expect(gateTest(test_, requireProvider("claude"))).toBeNull();
+  });
+
+  test("not gated for codex", () => {
+    expect(gateTest(test_, requireProvider("codex"))).toBeNull();
+  });
+
+  test("passes when response includes cwd", async () => {
+    const cwd = makeTmpDir();
+    const expected = Bun.spawnSync(["realpath", cwd]).stdout.toString().trim();
+
+    const callTool: CallToolFn = async () => mcpPromptResult("sess-1", expected);
+    const t = makeSpawnInDirTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("pass");
+  });
+
+  test("fails when response does not include cwd", async () => {
+    const cwd = makeTmpDir();
+    const callTool: CallToolFn = async () => mcpPromptResult("sess-1", "/some/other/path");
+    const t = makeSpawnInDirTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("fail");
+  });
+});
+
+describe("read-file", () => {
+  const test_ = makeReadFileTest({ callTool: stubCallTool });
+
+  test("has correct name and requires", () => {
+    expect(test_.name).toBe("read-file");
+    expect(test_.requires).toEqual([]);
+  });
+
+  test("passes when response includes marker", async () => {
+    const cwd = makeTmpDir();
+    const callTool: CallToolFn = async () => mcpPromptResult("sess-1", "GRID_READ_MARKER_7f3a");
+    const t = makeReadFileTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("pass");
+    expect(existsSync(join(cwd, "grid-test-read.txt"))).toBe(true);
+  });
+
+  test("fails when response lacks marker", async () => {
+    const cwd = makeTmpDir();
+    const callTool: CallToolFn = async () => mcpPromptResult("sess-1", "some other text");
+    const t = makeReadFileTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("fail");
+  });
+});
+
+describe("edit-file", () => {
+  const test_ = makeEditFileTest({ callTool: stubCallTool });
+
+  test("has correct name and requires", () => {
+    expect(test_.name).toBe("edit-file");
+    expect(test_.requires).toEqual([]);
+  });
+
+  test("passes when callTool simulates a successful edit", async () => {
+    const cwd = makeTmpDir();
+    const filePath = join(cwd, "grid-test-edit.txt");
+
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_prompt")) {
+        const content = readFileSync(filePath, "utf-8");
+        writeFileSync(filePath, content.replace("GRID_EDIT_ORIGINAL_4d9e", "GRID_EDIT_MODIFIED_4d9e"));
+        return mcpPromptResult("sess-1", "done");
+      }
+      return mcpTextResult("ok");
+    };
+
+    const t = makeEditFileTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("pass");
+  });
+
+  test("fails when file not modified", async () => {
+    const cwd = makeTmpDir();
+    const callTool: CallToolFn = async () => mcpPromptResult("sess-1", "done");
+    const t = makeEditFileTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("fail");
+  });
+});
+
+describe("run-bash", () => {
+  const test_ = makeRunBashTest({ callTool: stubCallTool });
+
+  test("has correct name and requires", () => {
+    expect(test_.name).toBe("run-bash");
+    expect(test_.requires).toEqual([]);
+  });
+
+  test("passes when response includes cwd", async () => {
+    const cwd = makeTmpDir();
+    const expected = Bun.spawnSync(["realpath", cwd]).stdout.toString().trim();
+    const callTool: CallToolFn = async () => mcpPromptResult("sess-1", expected);
+    const t = makeRunBashTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("pass");
+  });
+
+  test("fails when response does not include cwd", async () => {
+    const cwd = makeTmpDir();
+    const callTool: CallToolFn = async () => mcpPromptResult("sess-1", "/wrong/path");
+    const t = makeRunBashTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("fail");
+  });
+});
+
+describe("multi-turn", () => {
+  const test_ = makeMultiTurnTest({ callTool: stubCallTool });
+
+  test("has correct name and requires", () => {
+    expect(test_.name).toBe("multi-turn");
+    expect(test_.requires).toEqual(["multiTurn"]);
+  });
+
+  test("gated for providers lacking multiTurn", () => {
+    const provider = { ...requireProvider("claude"), native: {} };
+    const result = gateTest(test_, provider);
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe("n/a");
+  });
+
+  test("not gated for claude", () => {
+    expect(gateTest(test_, requireProvider("claude"))).toBeNull();
+  });
+
+  test("passes with simulated multi-turn conversation", async () => {
+    const cwd = makeTmpDir();
+    let callCount = 0;
+
+    const callTool: CallToolFn = async (_server, tool, args) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      callCount++;
+      if (callCount === 1) {
+        return mcpPromptResult("sess-mt", "OK");
+      }
+      if (callCount === 2) {
+        return mcpPromptResult("sess-mt", "GRID_MULTI_8b2c");
+      }
+      if (callCount === 3) {
+        writeFileSync(join(cwd, "multi-turn-proof.txt"), "GRID_MULTI_8b2c");
+        return mcpPromptResult("sess-mt", "done");
+      }
+      return mcpPromptResult("sess-mt", "unexpected");
+    };
+
+    const t = makeMultiTurnTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("pass");
+  });
+
+  test("fails when no sessionId from turn 1", async () => {
+    const cwd = makeTmpDir();
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      return mcpTextResult("plain text no session id");
+    };
+    const t = makeMultiTurnTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("fail");
+    expect((result as { error: string }).error).toContain("no sessionId");
+  });
+
+  test("fails when proof file not created", async () => {
+    const cwd = makeTmpDir();
+    let callCount = 0;
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      callCount++;
+      if (callCount === 1) return mcpPromptResult("sess-mt", "OK");
+      if (callCount === 2) return mcpPromptResult("sess-mt", "GRID_MULTI_8b2c");
+      return mcpPromptResult("sess-mt", "done");
+    };
+    const t = makeMultiTurnTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("fail");
+    expect((result as { error: string }).error).toContain("was not created");
+  });
+
+  test("fails when proof file has wrong content", async () => {
+    const cwd = makeTmpDir();
+    let callCount = 0;
+
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      callCount++;
+      if (callCount === 1) return mcpPromptResult("sess-mt", "OK");
+      if (callCount === 2) return mcpPromptResult("sess-mt", "GRID_MULTI_8b2c");
+      if (callCount === 3) {
+        writeFileSync(join(cwd, "multi-turn-proof.txt"), "wrong content");
+        return mcpPromptResult("sess-mt", "done");
+      }
+      return mcpPromptResult("sess-mt", "unexpected");
+    };
+
+    const t = makeMultiTurnTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("fail");
+    expect((result as { error: string }).error).toContain("does not contain");
+  });
+
+  test("fails when context not retained in turn 2", async () => {
+    const cwd = makeTmpDir();
+    let callCount = 0;
+
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      callCount++;
+      if (callCount === 1) return mcpPromptResult("sess-mt", "OK");
+      if (callCount === 2) return mcpPromptResult("sess-mt", "I don't remember");
+      return mcpPromptResult("sess-mt", "done");
+    };
+
+    const t = makeMultiTurnTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("fail");
+    expect((result as { error: string }).error).toContain("context not retained");
+  });
+});

--- a/agent-grid/src/tests/tests.spec.ts
+++ b/agent-grid/src/tests/tests.spec.ts
@@ -8,7 +8,7 @@ import type { AgentProvider } from "@mcp-cli/core";
 import { gateTest } from "../capability-gate";
 import { makeEditFileTest } from "./edit-file";
 import type { CallToolFn } from "./helpers";
-import { byeSession, extractText, promptAndWait, promptFollowUp, promptNoWait } from "./helpers";
+import { byeSession, extractSessionId, extractText, promptAndWait, promptFollowUp, promptNoWait } from "./helpers";
 import { makeMultiTurnTest } from "./multi-turn";
 import { makeReadFileTest } from "./read-file";
 import { makeRunBashTest } from "./run-bash";
@@ -73,6 +73,30 @@ describe("extractText", () => {
   });
 });
 
+// ── extractSessionId ─────────────────────────────────────────────
+
+describe("extractSessionId", () => {
+  test("extracts from JSON", () => {
+    expect(extractSessionId('{"sessionId": "abc-123", "ok": true}')).toBe("abc-123");
+  });
+
+  test("extracts from Python repr (single-quoted)", () => {
+    expect(extractSessionId("{'sessionId': 'py-456', 'ok': True}")).toBe("py-456");
+  });
+
+  test("extracts via regex fallback for embedded JSON", () => {
+    expect(extractSessionId('some preamble "sessionId": "fallback-id" and more')).toBe("fallback-id");
+  });
+
+  test("extracts via regex fallback for embedded Python repr", () => {
+    expect(extractSessionId("some preamble 'sessionId': 'py-fallback' and more")).toBe("py-fallback");
+  });
+
+  test("returns empty string when no sessionId", () => {
+    expect(extractSessionId("no session info here")).toBe("");
+  });
+});
+
 // ── promptAndWait ─────────────────────────────────────────────────
 
 describe("promptAndWait", () => {
@@ -94,6 +118,12 @@ describe("promptAndWait", () => {
     const callTool: CallToolFn = async () => mcpTextResult('some preamble "sessionId": "fallback-id" and more');
     const result = await promptAndWait(claude, { task: "test", cwd: "/tmp", callTool });
     expect(result.sessionId).toBe("fallback-id");
+  });
+
+  test("extracts sessionId from Python repr response", async () => {
+    const callTool: CallToolFn = async () => mcpTextResult("{'sessionId': 'py-sess-1', 'success': True}");
+    const result = await promptAndWait(claude, { task: "test", cwd: "/tmp", callTool });
+    expect(result.sessionId).toBe("py-sess-1");
   });
 
   test("throws when no sessionId found", async () => {

--- a/agent-grid/src/tests/tests.spec.ts
+++ b/agent-grid/src/tests/tests.spec.ts
@@ -1,5 +1,5 @@
-import { describe, expect, test } from "bun:test";
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { afterAll, describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
@@ -20,9 +20,20 @@ function requireProvider(name: string): AgentProvider {
   return p;
 }
 
+const tmpDirs: string[] = [];
 function makeTmpDir(): string {
-  return mkdtempSync(join(tmpdir(), "grid-test-spec-"));
+  const dir = mkdtempSync(join(tmpdir(), "grid-test-spec-"));
+  tmpDirs.push(dir);
+  return dir;
 }
+
+afterAll(() => {
+  for (const dir of tmpDirs) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {}
+  }
+});
 
 function mcpTextResult(text: string, isError = false): unknown {
   return { content: [{ type: "text", text }], ...(isError ? { isError: true } : {}) };
@@ -32,7 +43,7 @@ function mcpPromptResult(sessionId: string, resultText: string): unknown {
   return mcpTextResult(JSON.stringify({ sessionId, success: true, text: resultText }));
 }
 
-const stubCallTool: CallToolFn = async () => mcpTextResult("stub");
+const stubCallTool: CallToolFn = async () => mcpPromptResult("stub-session", "stub");
 
 // ── extractText ───────────────────────────────────────────────────
 
@@ -85,10 +96,9 @@ describe("promptAndWait", () => {
     expect(result.sessionId).toBe("fallback-id");
   });
 
-  test("returns empty sessionId when not found", async () => {
+  test("throws when no sessionId found", async () => {
     const callTool: CallToolFn = async () => mcpTextResult("no session info here");
-    const result = await promptAndWait(claude, { task: "test", cwd: "/tmp", callTool });
-    expect(result.sessionId).toBe("");
+    expect(promptAndWait(claude, { task: "test", cwd: "/tmp", callTool })).rejects.toThrow("no sessionId");
   });
 
   test("calls correct tool with correct args", async () => {
@@ -236,11 +246,25 @@ describe("spawn-in-dir", () => {
     expect(gateTest(test_, requireProvider("codex"))).toBeNull();
   });
 
-  test("passes when response includes cwd", async () => {
+  test("passes when response includes resolved cwd", async () => {
     const cwd = makeTmpDir();
     const expected = Bun.spawnSync(["realpath", cwd]).stdout.toString().trim();
 
-    const callTool: CallToolFn = async () => mcpPromptResult("sess-1", expected);
+    const callTool: CallToolFn = async (_s, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      return mcpPromptResult("sess-1", expected);
+    };
+    const t = makeSpawnInDirTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("pass");
+  });
+
+  test("passes when response includes unresolved cwd", async () => {
+    const cwd = makeTmpDir();
+    const callTool: CallToolFn = async (_s, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      return mcpPromptResult("sess-1", cwd);
+    };
     const t = makeSpawnInDirTest({ callTool });
     const result = await t.run({ provider: requireProvider("claude"), cwd });
     expect(result.status).toBe("pass");
@@ -248,10 +272,31 @@ describe("spawn-in-dir", () => {
 
   test("fails when response does not include cwd", async () => {
     const cwd = makeTmpDir();
-    const callTool: CallToolFn = async () => mcpPromptResult("sess-1", "/some/other/path");
+    const callTool: CallToolFn = async (_s, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      return mcpPromptResult("sess-1", "/some/other/path");
+    };
     const t = makeSpawnInDirTest({ callTool });
     const result = await t.run({ provider: requireProvider("claude"), cwd });
     expect(result.status).toBe("fail");
+  });
+
+  test("registers onCleanup", async () => {
+    const cwd = makeTmpDir();
+    let cleanupRegistered = false;
+    const callTool: CallToolFn = async (_s, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      return mcpPromptResult("sess-1", cwd);
+    };
+    const t = makeSpawnInDirTest({ callTool });
+    await t.run({
+      provider: requireProvider("claude"),
+      cwd,
+      onCleanup: () => {
+        cleanupRegistered = true;
+      },
+    });
+    expect(cleanupRegistered).toBe(true);
   });
 });
 
@@ -265,7 +310,10 @@ describe("read-file", () => {
 
   test("passes when response includes marker", async () => {
     const cwd = makeTmpDir();
-    const callTool: CallToolFn = async () => mcpPromptResult("sess-1", "GRID_READ_MARKER_7f3a");
+    const callTool: CallToolFn = async (_s, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      return mcpPromptResult("sess-1", "GRID_READ_MARKER_7f3a");
+    };
     const t = makeReadFileTest({ callTool });
     const result = await t.run({ provider: requireProvider("claude"), cwd });
     expect(result.status).toBe("pass");
@@ -274,7 +322,10 @@ describe("read-file", () => {
 
   test("fails when response lacks marker", async () => {
     const cwd = makeTmpDir();
-    const callTool: CallToolFn = async () => mcpPromptResult("sess-1", "some other text");
+    const callTool: CallToolFn = async (_s, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      return mcpPromptResult("sess-1", "some other text");
+    };
     const t = makeReadFileTest({ callTool });
     const result = await t.run({ provider: requireProvider("claude"), cwd });
     expect(result.status).toBe("fail");
@@ -309,7 +360,10 @@ describe("edit-file", () => {
 
   test("fails when file not modified", async () => {
     const cwd = makeTmpDir();
-    const callTool: CallToolFn = async () => mcpPromptResult("sess-1", "done");
+    const callTool: CallToolFn = async (_s, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      return mcpPromptResult("sess-1", "done");
+    };
     const t = makeEditFileTest({ callTool });
     const result = await t.run({ provider: requireProvider("claude"), cwd });
     expect(result.status).toBe("fail");
@@ -324,21 +378,66 @@ describe("run-bash", () => {
     expect(test_.requires).toEqual([]);
   });
 
-  test("passes when response includes cwd", async () => {
+  test("passes when bash creates proof file with marker", async () => {
     const cwd = makeTmpDir();
-    const expected = Bun.spawnSync(["realpath", cwd]).stdout.toString().trim();
-    const callTool: CallToolFn = async () => mcpPromptResult("sess-1", expected);
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_prompt")) {
+        writeFileSync(join(cwd, "grid-bash-proof.txt"), "GRID_BASH_PROOF_9c4f\n");
+        return mcpPromptResult("sess-1", "done");
+      }
+      return mcpTextResult("ok");
+    };
     const t = makeRunBashTest({ callTool });
     const result = await t.run({ provider: requireProvider("claude"), cwd });
     expect(result.status).toBe("pass");
   });
 
-  test("fails when response does not include cwd", async () => {
+  test("fails when proof file not created", async () => {
     const cwd = makeTmpDir();
-    const callTool: CallToolFn = async () => mcpPromptResult("sess-1", "/wrong/path");
+    const callTool: CallToolFn = async (_s, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      return mcpPromptResult("sess-1", "done");
+    };
     const t = makeRunBashTest({ callTool });
     const result = await t.run({ provider: requireProvider("claude"), cwd });
     expect(result.status).toBe("fail");
+    expect((result as { error: string }).error).toContain("was not created");
+  });
+
+  test("fails when proof file has wrong content", async () => {
+    const cwd = makeTmpDir();
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_prompt")) {
+        writeFileSync(join(cwd, "grid-bash-proof.txt"), "wrong content");
+        return mcpPromptResult("sess-1", "done");
+      }
+      return mcpTextResult("ok");
+    };
+    const t = makeRunBashTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("fail");
+    expect((result as { error: string }).error).toContain("missing marker");
+  });
+
+  test("registers onCleanup", async () => {
+    const cwd = makeTmpDir();
+    let cleanupRegistered = false;
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_prompt")) {
+        writeFileSync(join(cwd, "grid-bash-proof.txt"), "GRID_BASH_PROOF_9c4f\n");
+        return mcpPromptResult("sess-1", "done");
+      }
+      return mcpTextResult("ok");
+    };
+    const t = makeRunBashTest({ callTool });
+    await t.run({
+      provider: requireProvider("claude"),
+      cwd,
+      onCleanup: () => {
+        cleanupRegistered = true;
+      },
+    });
+    expect(cleanupRegistered).toBe(true);
   });
 });
 
@@ -386,16 +485,14 @@ describe("multi-turn", () => {
     expect(result.status).toBe("pass");
   });
 
-  test("fails when no sessionId from turn 1", async () => {
+  test("throws when no sessionId from turn 1", async () => {
     const cwd = makeTmpDir();
     const callTool: CallToolFn = async (_server, tool) => {
       if (tool.endsWith("_bye")) return mcpTextResult("ok");
       return mcpTextResult("plain text no session id");
     };
     const t = makeMultiTurnTest({ callTool });
-    const result = await t.run({ provider: requireProvider("claude"), cwd });
-    expect(result.status).toBe("fail");
-    expect((result as { error: string }).error).toContain("no sessionId");
+    expect(t.run({ provider: requireProvider("claude"), cwd })).rejects.toThrow("no sessionId");
   });
 
   test("fails when proof file not created", async () => {
@@ -452,5 +549,33 @@ describe("multi-turn", () => {
     const result = await t.run({ provider: requireProvider("claude"), cwd });
     expect(result.status).toBe("fail");
     expect((result as { error: string }).error).toContain("context not retained");
+  });
+
+  test("registers onCleanup after turn 1", async () => {
+    const cwd = makeTmpDir();
+    let cleanupRegistered = false;
+    let callCount = 0;
+
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      callCount++;
+      if (callCount === 1) return mcpPromptResult("sess-mt", "OK");
+      if (callCount === 2) return mcpPromptResult("sess-mt", "GRID_MULTI_8b2c");
+      if (callCount === 3) {
+        writeFileSync(join(cwd, "multi-turn-proof.txt"), "GRID_MULTI_8b2c");
+        return mcpPromptResult("sess-mt", "done");
+      }
+      return mcpPromptResult("sess-mt", "unexpected");
+    };
+
+    const t = makeMultiTurnTest({ callTool });
+    await t.run({
+      provider: requireProvider("claude"),
+      cwd,
+      onCleanup: () => {
+        cleanupRegistered = true;
+      },
+    });
+    expect(cleanupRegistered).toBe(true);
   });
 });

--- a/packages/command/src/commands/agent-grid.spec.ts
+++ b/packages/command/src/commands/agent-grid.spec.ts
@@ -264,6 +264,31 @@ describe("runGridForProvider", () => {
     expect(cleanupCalled).toBe(true);
   });
 
+  test("accumulates multiple onCleanup fns and runs LIFO on timeout", async () => {
+    const order: number[] = [];
+    const claude = mustGetProvider("claude");
+    const LONGER_THAN_TIMEOUT = 60_000;
+    const gridTest: GridTest = {
+      name: "multi-cleanup",
+      requires: [],
+      run: async (ctx) => {
+        ctx.onCleanup?.(async () => {
+          order.push(1);
+        });
+        ctx.onCleanup?.(async () => {
+          order.push(2);
+        });
+        ctx.onCleanup?.(async () => {
+          order.push(3);
+        });
+        await new Promise((resolve) => setTimeout(resolve, LONGER_THAN_TIMEOUT));
+        return { status: "pass" };
+      },
+    };
+    await runGridForProvider(claude, [gridTest], { ...defaultOpts, timeoutMs: 100 });
+    expect(order).toEqual([3, 2, 1]);
+  });
+
   test("provides onCleanup in test context", async () => {
     let hasOnCleanup = false;
     const claude = mustGetProvider("claude");

--- a/packages/command/src/commands/agent-grid.spec.ts
+++ b/packages/command/src/commands/agent-grid.spec.ts
@@ -241,6 +241,43 @@ describe("runGridForProvider", () => {
     await runGridForProvider(claude, [gridTest], defaultOpts);
     expect(receivedCwd).toContain("agent-grid-claude-");
   });
+
+  test("calls onCleanup on timeout", async () => {
+    let cleanupCalled = false;
+    const claude = mustGetProvider("claude");
+    const LONGER_THAN_TIMEOUT = 60_000;
+    const gridTest: GridTest = {
+      name: "slow-test",
+      requires: [],
+      run: async (ctx) => {
+        ctx.onCleanup?.(async () => {
+          cleanupCalled = true;
+        });
+        await new Promise((resolve) => setTimeout(resolve, LONGER_THAN_TIMEOUT));
+        return { status: "pass" };
+      },
+    };
+    const report = await runGridForProvider(claude, [gridTest], { ...defaultOpts, timeoutMs: 100 });
+    expect(report.outcomes).toHaveLength(1);
+    expect(report.outcomes[0].result.status).toBe("fail");
+    expect((report.outcomes[0].result as { error: string }).error).toContain("timed out");
+    expect(cleanupCalled).toBe(true);
+  });
+
+  test("provides onCleanup in test context", async () => {
+    let hasOnCleanup = false;
+    const claude = mustGetProvider("claude");
+    const gridTest: GridTest = {
+      name: "cleanup-check",
+      requires: [],
+      run: async (ctx) => {
+        hasOnCleanup = typeof ctx.onCleanup === "function";
+        return { status: "pass" };
+      },
+    };
+    await runGridForProvider(claude, [gridTest], defaultOpts);
+    expect(hasOnCleanup).toBe(true);
+  });
 });
 
 // ── formatReportText ───────────────────────────────────────────────

--- a/packages/command/src/commands/agent-grid.spec.ts
+++ b/packages/command/src/commands/agent-grid.spec.ts
@@ -16,6 +16,7 @@ import {
   parseRunArgs,
   resolveProviders,
   runGridForProvider,
+  warnStubFlags,
 } from "./agent-grid";
 
 // ── Helpers ────────────────────────────────────────────────────────
@@ -127,13 +128,31 @@ describe("resolveProviders", () => {
     expect(providers[0].name).toBe("claude");
     expect(providers[1].name).toBe("codex");
   });
+
+  test("exits on unknown provider", () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("EXIT");
+    });
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    expect(() => resolveProviders(["nonexistent-provider-xyz"])).toThrow("EXIT");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    exitSpy.mockRestore();
+    errSpy.mockRestore();
+  });
 });
 
 // ── discoverTests ──────────────────────────────────────────────────
 
 describe("discoverTests", () => {
-  test("returns empty array (skeleton)", () => {
-    expect(discoverTests()).toEqual([]);
+  test("returns batch 1 tests", () => {
+    const tests = discoverTests();
+    expect(tests.length).toBeGreaterThanOrEqual(5);
+    const names = tests.map((t) => t.name);
+    expect(names).toContain("spawn-in-dir");
+    expect(names).toContain("read-file");
+    expect(names).toContain("edit-file");
+    expect(names).toContain("run-bash");
+    expect(names).toContain("multi-turn");
   });
 });
 
@@ -329,49 +348,73 @@ describe("cmdAgentGrid", () => {
     expect(output).toContain("agent-grid run");
   });
 
-  test("run with empty suite warns on stderr", async () => {
-    await cmdAgentGrid(["run", "--providers=claude", "--json"]);
-    expect(stderrLines().some((s: string) => s.includes("no tests registered"))).toBe(true);
+  test("unknown subcommand exits with error", async () => {
+    const exitSpy = spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("EXIT");
+    });
+    await expect(cmdAgentGrid(["bogus"])).rejects.toThrow("EXIT");
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalled();
+    const msg = stderrLines().join(" ");
+    expect(msg).toContain("unknown subcommand");
+    exitSpy.mockRestore();
+  });
+});
+
+// ── warnStubFlags ─────────────────────────────────────────────────
+
+describe("warnStubFlags", () => {
+  const base: RunOptions = {
+    providers: [],
+    version: null,
+    offline: false,
+    record: null,
+    commitOutcome: false,
+    json: false,
+  };
+
+  let errorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    errorSpy = spyOn(console, "error").mockImplementation(() => {});
   });
 
-  test("run --json outputs valid JSON", async () => {
-    await cmdAgentGrid(["run", "--providers=claude", "--json"]);
-    expect(logSpy).toHaveBeenCalled();
-    const output = logSpy.mock.calls[0][0] as string;
-    const parsed = JSON.parse(output);
-    expect(parsed.providers).toBeArray();
-    expect(parsed.providers[0].provider).toBe("claude");
-    expect(parsed.elapsed_ms).toBeNumber();
+  afterEach(() => {
+    errorSpy.mockRestore();
   });
 
-  test("run text output includes provider name", async () => {
-    await cmdAgentGrid(["run", "--providers=codex"]);
-    expect(logSpy).toHaveBeenCalled();
-    const output = logSpy.mock.calls[0][0] as string;
-    expect(output).toContain("codex");
-    expect(output).toContain("(no tests registered)");
+  test("no warnings when no stub flags set", () => {
+    warnStubFlags(base);
+    expect(errorSpy).not.toHaveBeenCalled();
   });
 
-  test("run --offline warns not yet implemented", async () => {
-    await cmdAgentGrid(["run", "--providers=claude", "--offline", "--json"]);
-    expect(stderrLines().some((s: string) => s.includes("--offline") && s.includes("not yet implemented"))).toBe(true);
+  test("warns on --offline", () => {
+    warnStubFlags({ ...base, offline: true });
+    expect(errorSpy).toHaveBeenCalled();
+    expect(String(errorSpy.mock.calls[0][0])).toContain("--offline");
   });
 
-  test("run --record warns not yet implemented", async () => {
-    await cmdAgentGrid(["run", "--providers=claude", "--record=./out.ndjson", "--json"]);
-    expect(stderrLines().some((s: string) => s.includes("--record") && s.includes("not yet implemented"))).toBe(true);
+  test("warns on --record", () => {
+    warnStubFlags({ ...base, record: "/tmp/rec" });
+    expect(errorSpy).toHaveBeenCalled();
+    expect(String(errorSpy.mock.calls[0][0])).toContain("--record");
   });
 
-  test("run --version warns not yet implemented", async () => {
-    await cmdAgentGrid(["run", "--providers=claude", "--version=2.1.119", "--json"]);
-    expect(stderrLines().some((s: string) => s.includes("--version") && s.includes("not yet implemented"))).toBe(true);
+  test("warns on --version", () => {
+    warnStubFlags({ ...base, version: "1.0.0" });
+    expect(errorSpy).toHaveBeenCalled();
+    expect(String(errorSpy.mock.calls[0][0])).toContain("--version");
   });
 
-  test("run --commit-outcome warns not yet implemented", async () => {
-    await cmdAgentGrid(["run", "--providers=claude", "--commit-outcome", "--json"]);
-    expect(stderrLines().some((s: string) => s.includes("--commit-outcome") && s.includes("not yet implemented"))).toBe(
-      true,
-    );
+  test("warns on --commit-outcome", () => {
+    warnStubFlags({ ...base, commitOutcome: true });
+    expect(errorSpy).toHaveBeenCalled();
+    expect(String(errorSpy.mock.calls[0][0])).toContain("--commit-outcome");
+  });
+
+  test("warns on all stub flags combined", () => {
+    warnStubFlags({ ...base, offline: true, record: "/tmp/x", version: "1.0", commitOutcome: true });
+    expect(errorSpy.mock.calls.length).toBe(4);
   });
 });
 

--- a/packages/command/src/commands/agent-grid.ts
+++ b/packages/command/src/commands/agent-grid.ts
@@ -98,14 +98,16 @@ export async function runGridForProvider(
       let timer: ReturnType<typeof setTimeout> | undefined;
       const timeoutMs = opts.timeoutMs ?? DEFAULT_TEST_TIMEOUT_MS;
       try {
+        const testPromise = test.run({
+          provider,
+          cwd,
+          onCleanup: (fn) => {
+            cleanupFns.push(fn);
+          },
+        });
+        testPromise.catch(() => {});
         const result = await Promise.race([
-          test.run({
-            provider,
-            cwd,
-            onCleanup: (fn) => {
-              cleanupFns.push(fn);
-            },
-          }),
+          testPromise,
           new Promise<never>((_, reject) => {
             timer = setTimeout(() => reject(new Error(`test timed out after ${timeoutMs}ms`)), timeoutMs);
           }),

--- a/packages/command/src/commands/agent-grid.ts
+++ b/packages/command/src/commands/agent-grid.ts
@@ -53,9 +53,16 @@ const EXCLUDED_DEFAULT_PROVIDERS = new Set(["mock"]);
 
 // ── Test discovery ─────────────────────────────────────────────────
 
-function ipcCallTool(server: string, tool: string, args: Record<string, unknown>): Promise<unknown> {
+let _coreModule: typeof import("@mcp-cli/core") | undefined;
+async function getCoreModule() {
+  _coreModule ??= await import("@mcp-cli/core");
+  return _coreModule;
+}
+
+async function ipcCallTool(server: string, tool: string, args: Record<string, unknown>): Promise<unknown> {
   const timeoutMs = tool.endsWith("_prompt") || tool.endsWith("_wait") ? 120_000 : undefined;
-  return import("@mcp-cli/core").then((m) => m.ipcCall("callTool", { server, tool, arguments: args }, { timeoutMs }));
+  const m = await getCoreModule();
+  return m.ipcCall("callTool", { server, tool, arguments: args }, { timeoutMs });
 }
 
 export function discoverTests(): GridTest[] {
@@ -74,7 +81,7 @@ export function discoverTests(): GridTest[] {
 export async function runGridForProvider(
   provider: AgentProvider,
   tests: GridTest[],
-  opts: { version: string | null; record: string | null; offline: boolean },
+  opts: { version: string | null; record: string | null; offline: boolean; timeoutMs?: number },
 ): Promise<ProviderReport> {
   const outcomes: TestOutcome[] = [];
   const cwd = mkdtempSync(resolve(tmpdir(), `agent-grid-${provider.name}-`));
@@ -86,18 +93,28 @@ export async function runGridForProvider(
         outcomes.push({ test: test.name, result: gateResult });
         continue;
       }
+
+      let cleanupFn: (() => Promise<void>) | undefined;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timeoutMs = opts.timeoutMs ?? DEFAULT_TEST_TIMEOUT_MS;
       try {
         const result = await Promise.race([
-          test.run({ provider, cwd }),
-          new Promise<never>((_, reject) =>
-            setTimeout(
-              () => reject(new Error(`test timed out after ${DEFAULT_TEST_TIMEOUT_MS}ms`)),
-              DEFAULT_TEST_TIMEOUT_MS,
-            ),
-          ),
+          test.run({
+            provider,
+            cwd,
+            onCleanup: (fn) => {
+              cleanupFn = fn;
+            },
+          }),
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(() => reject(new Error(`test timed out after ${timeoutMs}ms`)), timeoutMs);
+          }),
         ]);
+        clearTimeout(timer);
         outcomes.push({ test: test.name, result });
       } catch (err) {
+        clearTimeout(timer);
+        if (cleanupFn) await cleanupFn().catch(() => {});
         outcomes.push({
           test: test.name,
           result: { status: "fail", error: err instanceof Error ? err.message : String(err) },

--- a/packages/command/src/commands/agent-grid.ts
+++ b/packages/command/src/commands/agent-grid.ts
@@ -48,7 +48,7 @@ export interface GridRunReport {
 
 // ── Constants ──────────────────────────────────────────────────────
 
-const DEFAULT_TEST_TIMEOUT_MS = 30_000;
+const DEFAULT_TEST_TIMEOUT_MS = 130_000;
 const EXCLUDED_DEFAULT_PROVIDERS = new Set(["mock"]);
 
 // ── Test discovery ─────────────────────────────────────────────────
@@ -94,7 +94,7 @@ export async function runGridForProvider(
         continue;
       }
 
-      let cleanupFn: (() => Promise<void>) | undefined;
+      const cleanupFns: (() => Promise<void>)[] = [];
       let timer: ReturnType<typeof setTimeout> | undefined;
       const timeoutMs = opts.timeoutMs ?? DEFAULT_TEST_TIMEOUT_MS;
       try {
@@ -103,7 +103,7 @@ export async function runGridForProvider(
             provider,
             cwd,
             onCleanup: (fn) => {
-              cleanupFn = fn;
+              cleanupFns.push(fn);
             },
           }),
           new Promise<never>((_, reject) => {
@@ -114,7 +114,9 @@ export async function runGridForProvider(
         outcomes.push({ test: test.name, result });
       } catch (err) {
         clearTimeout(timer);
-        if (cleanupFn) await cleanupFn().catch(() => {});
+        for (let i = cleanupFns.length - 1; i >= 0; i--) {
+          await cleanupFns[i]().catch(() => {});
+        }
         outcomes.push({
           test: test.name,
           result: { status: "fail", error: err instanceof Error ? err.message : String(err) },

--- a/packages/command/src/commands/agent-grid.ts
+++ b/packages/command/src/commands/agent-grid.ts
@@ -9,7 +9,19 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
-import { type GridResult, type GridTest, gateTest, parseRecording, validateRecording } from "@mcp-cli/agent-grid";
+import {
+  type CallToolFn,
+  type GridResult,
+  type GridTest,
+  gateTest,
+  makeEditFileTest,
+  makeMultiTurnTest,
+  makeReadFileTest,
+  makeRunBashTest,
+  makeSpawnInDirTest,
+  parseRecording,
+  validateRecording,
+} from "@mcp-cli/agent-grid";
 import { type AgentProvider, getAllProviders, getProvider } from "@mcp-cli/core";
 import { parseFlags } from "../flags";
 import { formatHelp, getHelp, hasHelpFlag, registerHelp } from "../help";
@@ -41,9 +53,20 @@ const EXCLUDED_DEFAULT_PROVIDERS = new Set(["mock"]);
 
 // ── Test discovery ─────────────────────────────────────────────────
 
+function ipcCallTool(server: string, tool: string, args: Record<string, unknown>): Promise<unknown> {
+  const timeoutMs = tool.endsWith("_prompt") || tool.endsWith("_wait") ? 120_000 : undefined;
+  return import("@mcp-cli/core").then((m) => m.ipcCall("callTool", { server, tool, arguments: args }, { timeoutMs }));
+}
+
 export function discoverTests(): GridTest[] {
-  // Test implementations are added by later issues in the epic (#2538).
-  return [];
+  const deps = { callTool: ipcCallTool satisfies CallToolFn };
+  return [
+    makeSpawnInDirTest(deps),
+    makeReadFileTest(deps),
+    makeEditFileTest(deps),
+    makeRunBashTest(deps),
+    makeMultiTurnTest(deps),
+  ];
 }
 
 // ── Runner ─────────────────────────────────────────────────────────
@@ -244,7 +267,7 @@ export function resolveProviders(names: string[]): AgentProvider[] {
 
 // ── Stub flag warnings ─────────────────────────────────────────────
 
-function warnStubFlags(opts: RunOptions): void {
+export function warnStubFlags(opts: RunOptions): void {
   if (opts.offline) {
     console.error(`${c.yellow}--offline: not yet implemented; network access is not restricted${c.reset}`);
   }


### PR DESCRIPTION
## Summary
- Adds 5 capability tests for the agent-grid: `spawn-in-dir`, `read-file`, `edit-file`, `run-bash`, `multi-turn`
- Each test is a factory function accepting injected `callTool` for DI-based testability (no `mock.module()`)
- Shared helpers (`promptAndWait`, `promptFollowUp`, `byeSession`, `extractText`) in `helpers.ts`
- `discoverTests()` in the command package wires tests to IPC via `ipcCallTool` with appropriate timeouts
- 42 unit tests across `tests.spec.ts` + updated `agent-grid.spec.ts` (coverage: helpers 100%, all test files 97-100%)
- Added `agent-grid/src` to coverage run paths in `check-coverage.ts`

## Test plan
- [x] `bun typecheck` passes
- [x] `bun lint` passes (835 files, no fixes)
- [x] `bun run doing-it-wrong` passes (0 violations)
- [x] 101 tests pass across agent-grid + command agent-grid specs
- [x] Per-file coverage: helpers.ts 100%, all test files 97-100%, agent-grid.ts 88%
- [x] `discoverTests()` returns 5 named tests
- [x] `gateTest()` correctly gates `multi-turn` for providers lacking `multiTurn` feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)