### PR TITLE
fix(daemon): replace ?? 0 with || 0 in compareSemver to guard against NaN segments (fixes #2601)

### DIFF
--- a/packages/daemon/src/claude-session/transport-resolver.spec.ts
+++ b/packages/daemon/src/claude-session/transport-resolver.spec.ts
@@ -47,7 +47,8 @@ describe("resolveTransport", () => {
 
   test("fully non-numeric segments are treated as 0, not NaN", () => {
     // "beta" → parseInt → NaN; || 0 must coerce to 0 (NaN ?? 0 = NaN, NaN || 0 = 0)
-    // [NaN,0,0] without guard would make diff=NaN → compareSemver returns 0 (wrong)
+    // [NaN,0,0] without guard: diff=NaN, diff!==0 is true, compareSemver returns NaN;
+    // caller's NaN>0 is false → always "ws" regardless of actual version (wrong)
     // [0,0,0] with guard is correct: 0.0.0 < 2.1.122 → ws
     expect(resolveTransport("auto", "beta.0.0")).toBe("ws");
     // Empty segment from corrupt split: "2..123" → [2, NaN, 123] → [2, 0, 123]

--- a/packages/daemon/src/claude-session/transport-resolver.spec.ts
+++ b/packages/daemon/src/claude-session/transport-resolver.spec.ts
@@ -44,4 +44,14 @@ describe("resolveTransport", () => {
     expect(resolveTransport("auto", "2.1.122-alpha.0")).toBe("ws");
     expect(resolveTransport("auto", "2.1.100-dev.5")).toBe("ws");
   });
+
+  test("fully non-numeric segments are treated as 0, not NaN", () => {
+    // "beta" → parseInt → NaN; || 0 must coerce to 0 (NaN ?? 0 = NaN, NaN || 0 = 0)
+    // [NaN,0,0] without guard would make diff=NaN → compareSemver returns 0 (wrong)
+    // [0,0,0] with guard is correct: 0.0.0 < 2.1.122 → ws
+    expect(resolveTransport("auto", "beta.0.0")).toBe("ws");
+    // Empty segment from corrupt split: "2..123" → [2, NaN, 123] → [2, 0, 123]
+    // 2.0.123 < 2.1.122 → ws
+    expect(resolveTransport("auto", "2..123")).toBe("ws");
+  });
 });

--- a/packages/daemon/src/claude-session/transport-resolver.ts
+++ b/packages/daemon/src/claude-session/transport-resolver.ts
@@ -24,7 +24,7 @@ function compareSemver(a: string, b: string): number {
   const pa = a.split(".").map((s) => Number.parseInt(s, 10));
   const pb = b.split(".").map((s) => Number.parseInt(s, 10));
   for (let i = 0; i < 3; i++) {
-    const diff = (pa[i] ?? 0) - (pb[i] ?? 0);
+    const diff = (pa[i] || 0) - (pb[i] || 0);
     if (diff !== 0) return diff;
   }
   return 0;


### PR DESCRIPTION
## Summary
- Replaces `?? 0` guards in `compareSemver` with `|| 0` to properly coerce `NaN` to `0` — `NaN ?? 0` evaluates to `NaN` since nullish coalescing only catches `null`/`undefined`, not `NaN`
- Prevents silently wrong comparisons if a fully non-numeric segment (e.g. `"beta"`, empty string from corrupt split) is ever passed to the function
- Adds a test case locking in the behavior: non-numeric segments are treated as `0`, not passed through as `NaN`

## Test plan
- [x] All 8 transport-resolver tests pass, including 2 new cases for `"beta.0.0"` and `"2..123"`
- [x] `bun run am-i-done` passes (typecheck, lint, rules, tests, coverage)
- [x] Pre-push gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)