### PR TITLE
fix(daemon): silence SQLiteError stderr in session-metrics.spec.ts (fixes #2607)

### DIFF
--- a/packages/daemon/src/session-metrics.spec.ts
+++ b/packages/daemon/src/session-metrics.spec.ts
@@ -517,15 +517,18 @@ describe("SessionMetricsAggregator", () => {
       const localAgg = new SessionMetricsAggregator({ bus: localBus, db: localDb, coalesceWindowMs: 500 });
       const errorSpy = spyOn(console, "error").mockImplementation(() => {});
 
-      localBus.publish(toolUse("s1", "Read", { filePath: "/f", dirPath: "/", linesHint: 1 }));
-      localDb.exec("DROP TABLE session_metrics");
-      localBus.publish(sessionEnd("s1"));
+      try {
+        localBus.publish(toolUse("s1", "Read", { filePath: "/f", dirPath: "/", linesHint: 1 }));
+        localDb.exec("DROP TABLE session_metrics");
+        localBus.publish(sessionEnd("s1"));
 
-      expect(localAgg.sessionCount).toBe(1);
-      expect(localAgg.getState("s1")?.hasToolCalls).toBe(true);
-
-      errorSpy.mockRestore();
-      localDb.close();
+        expect(localAgg.sessionCount).toBe(1);
+        expect(localAgg.getState("s1")?.hasToolCalls).toBe(true);
+      } finally {
+        localAgg.dispose();
+        errorSpy.mockRestore();
+        localDb.close();
+      }
     });
   });
 

--- a/packages/daemon/src/session-metrics.spec.ts
+++ b/packages/daemon/src/session-metrics.spec.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, spyOn, test } from "bun:test";
 import type { MonitorEvent, MonitorEventInput } from "@mcp-cli/core";
 import {
   METRIC_SESSION_COMMAND_HIST,
@@ -512,14 +512,20 @@ describe("SessionMetricsAggregator", () => {
 
   describe("persist failure retention", () => {
     test("retains in-memory state when DB write fails", () => {
-      bus.publish(toolUse("s1", "Read", { filePath: "/f", dirPath: "/", linesHint: 1 }));
+      const localDb = freshDb();
+      const localBus = new EventBus();
+      const localAgg = new SessionMetricsAggregator({ bus: localBus, db: localDb, coalesceWindowMs: 500 });
+      const errorSpy = spyOn(console, "error").mockImplementation(() => {});
 
-      db.exec("DROP TABLE session_metrics");
+      localBus.publish(toolUse("s1", "Read", { filePath: "/f", dirPath: "/", linesHint: 1 }));
+      localDb.exec("DROP TABLE session_metrics");
+      localBus.publish(sessionEnd("s1"));
 
-      bus.publish(sessionEnd("s1"));
+      expect(localAgg.sessionCount).toBe(1);
+      expect(localAgg.getState("s1")?.hasToolCalls).toBe(true);
 
-      expect(agg.sessionCount).toBe(1);
-      expect(agg.getState("s1")?.hasToolCalls).toBe(true);
+      errorSpy.mockRestore();
+      localDb.close();
     });
   });
 


### PR DESCRIPTION
## Summary
- The "persist failure retention" test deliberately drops `session_metrics` to verify error-path behavior, but the shared `afterEach` then calls `agg.dispose()` on the same db, emitting `SQLiteError` to stderr and causing `am-i-done` to exit 1
- Isolated the test to its own local `db`/`bus`/`agg` so the DROP never touches shared resources
- Suppressed the expected `console.error` during the test using `spyOn` so the intentional failure doesn't pollute stderr

## Test plan
- [x] `bun test packages/daemon/src/session-metrics.spec.ts` — 41 pass, 0 fail, zero stderr noise
- [x] `bun run am-i-done` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)