### PR TITLE
fix(daemon): persist session transport in agent_sessions DB (fixes #2602)

### DIFF
--- a/packages/daemon/src/abstract-worker-server.ts
+++ b/packages/daemon/src/abstract-worker-server.ts
@@ -30,6 +30,7 @@ export interface DbUpsertSession {
   worktree?: string;
   repoRoot?: string;
   claudeSessionId?: string;
+  transport?: string;
 }
 
 interface DbUpsert {

--- a/packages/daemon/src/abstract-worker-server.ts
+++ b/packages/daemon/src/abstract-worker-server.ts
@@ -30,7 +30,7 @@ export interface DbUpsertSession {
   worktree?: string;
   repoRoot?: string;
   claudeSessionId?: string;
-  transport?: string;
+  transport?: "ws" | "stdio";
 }
 
 interface DbUpsert {

--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -374,7 +374,7 @@ export class ClaudeServer extends AbstractWorkerServer {
         totalCost: row.totalCost,
         totalTokens: row.totalTokens,
         claudeSessionId: row.claudeSessionId,
-        transport: (row.transport as "ws" | "stdio") ?? undefined,
+        transport: row.transport === "ws" || row.transport === "stdio" ? row.transport : undefined,
       })),
     });
 

--- a/packages/daemon/src/claude-server.ts
+++ b/packages/daemon/src/claude-server.ts
@@ -374,6 +374,7 @@ export class ClaudeServer extends AbstractWorkerServer {
         totalCost: row.totalCost,
         totalTokens: row.totalTokens,
         claudeSessionId: row.claudeSessionId,
+        transport: (row.transport as "ws" | "stdio") ?? undefined,
       })),
     });
 

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -73,6 +73,7 @@ interface RestoreSessionsMessage {
     worktree: string | null;
     totalCost: number;
     totalTokens: number;
+    claudeSessionId?: string | null;
     transport?: "ws" | "stdio";
   }>;
 }

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -236,8 +236,9 @@ export async function handlePrompt(
       : undefined;
 
     let sessionName: string;
+    let sessionTransport: "ws" | "stdio";
     try {
-      sessionName = server.prepareSession(sessionId, {
+      const prepared = server.prepareSession(sessionId, {
         prompt,
         name: args.name as string | undefined,
         cwd: args.cwd as string | undefined,
@@ -249,6 +250,8 @@ export async function handlePrompt(
         resumeSessionId: args.resumeSessionId as string | undefined,
         repoRoot: args.repoRoot as string | undefined,
       });
+      sessionName = prepared.name;
+      sessionTransport = prepared.transport;
     } catch (err) {
       return {
         content: [{ type: "text", text: `Error: ${(err as Error).message}` }],
@@ -266,6 +269,7 @@ export async function handlePrompt(
         cwd: args.cwd as string | undefined,
         worktree: args.worktree as string | undefined,
         repoRoot: args.repoRoot as string | undefined,
+        transport: sessionTransport,
       },
     });
 

--- a/packages/daemon/src/claude-session/ws-server-stdio.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server-stdio.spec.ts
@@ -409,10 +409,7 @@ describe("ClaudeWsServer — stdio transport", () => {
     expect(mock.lastOpts).toMatchObject({ stdin: "pipe", stdout: "pipe" });
   });
 
-  // Production restore path: claude-server.ts does not persist or forward
-  // transport from the DB, so restored stdio sessions default to "ws" and
-  // spawn with --sdk-url instead of stdio args. Tracked in #2602.
-  test.skip("production restore path: stdio session without explicit transport revives correctly", async () => {
+  test("production restore path: stdio transport persisted in DB survives restore (fixes #2602)", async () => {
     const mock = mockStdioSpawn();
     server = new ClaudeWsServer({
       spawn: mock.spawn,
@@ -420,7 +417,7 @@ describe("ClaudeWsServer — stdio transport", () => {
     });
     await server.start(0);
 
-    const sessionId = "restored-stdio-no-transport";
+    const sessionId = "restored-stdio-from-db";
     server.restoreSessions([
       {
         sessionId,
@@ -432,15 +429,12 @@ describe("ClaudeWsServer — stdio transport", () => {
         totalCost: 0,
         totalTokens: 0,
         claudeSessionId: "claude-sess-def",
-        // No transport field — mirrors the production restore_sessions sender
+        transport: "stdio",
       },
     ]);
 
     server.reviveSession(sessionId, "follow-up prompt");
 
-    // This SHOULD use stdio args once #2602 lands a transport column in
-    // agent_sessions + forwards it in claude-server.ts restore_sessions.
-    // Currently fails: defaults to "ws" and spawns with --sdk-url.
     expect(mock.lastCmd).not.toContain("--sdk-url");
     expect(mock.lastCmd).toContain("--print");
     expect(mock.lastCmd).toContain("stream-json");

--- a/packages/daemon/src/claude-session/ws-server-stdio.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server-stdio.spec.ts
@@ -439,4 +439,33 @@ describe("ClaudeWsServer — stdio transport", () => {
     expect(mock.lastCmd).toContain("--print");
     expect(mock.lastCmd).toContain("stream-json");
   });
+
+  test("restored session without transport defaults to ws (fallback path)", async () => {
+    const mock = mockStdioSpawn();
+    server = new ClaudeWsServer({
+      spawn: mock.spawn,
+      logger: silentLogger,
+    });
+    const port = await server.start(0);
+
+    const sessionId = "restored-no-transport";
+    server.restoreSessions([
+      {
+        sessionId,
+        pid: null,
+        state: "idle",
+        model: "claude-sonnet-4-6",
+        cwd: "/test",
+        worktree: null,
+        totalCost: 0,
+        totalTokens: 0,
+        claudeSessionId: "claude-sess-fallback",
+      },
+    ]);
+
+    server.reviveSession(sessionId, "follow-up prompt");
+
+    expect(mock.lastCmd).toContain("--sdk-url");
+    expect(mock.lastCmd.some((a: string) => a.startsWith(`ws://localhost:${port}/`))).toBe(true);
+  });
 });

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -770,6 +770,7 @@ export class ClaudeWsServer {
       }
     }
     const name = config.name ?? this.generateName();
+    const resolvedTransport = config.transport ?? "ws";
 
     this.sessions.set(sessionId, {
       state,
@@ -796,10 +797,9 @@ export class ClaudeWsServer {
       pendingInterruptReason: null,
       traceparent: null,
       stuckDetector: null,
-      transport: config.transport ?? "ws",
+      transport: resolvedTransport,
       stdioWriter: null,
     });
-    const resolvedTransport = config.transport ?? "ws";
     return { name, transport: resolvedTransport };
   }
 

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -751,8 +751,8 @@ export class ClaudeWsServer {
    * Prepare a session for an incoming Claude CLI connection.
    * Call this before spawning the Claude process.
    */
-  /** Prepare a session and return the assigned name. */
-  prepareSession(sessionId: string, config: SessionConfig): string {
+  /** Prepare a session and return the assigned name and resolved transport. */
+  prepareSession(sessionId: string, config: SessionConfig): { name: string; transport: "ws" | "stdio" } {
     const state = new SessionState(sessionId);
     // Pre-populate state.cwd from config so session info shows the correct
     // cwd even if the Claude process never connects (#1836).
@@ -799,7 +799,8 @@ export class ClaudeWsServer {
       transport: config.transport ?? "ws",
       stdioWriter: null,
     });
-    return name;
+    const resolvedTransport = config.transport ?? "ws";
+    return { name, transport: resolvedTransport };
   }
 
   /**

--- a/packages/daemon/src/db/state.spec.ts
+++ b/packages/daemon/src/db/state.spec.ts
@@ -1851,13 +1851,13 @@ describe("StateDb", () => {
   });
 
   describe("migrations", () => {
-    test("fresh DB sets schema version to 6", () => {
+    test("fresh DB sets schema version to 7", () => {
       const db = createDb();
       // biome-ignore lint/complexity/useLiteralKeys: access private field for test
       const version = db["db"]
         .query<{ version: number }, [string]>("SELECT version FROM schema_versions WHERE name = ?")
         .get("state")?.version;
-      expect(version).toBe(6);
+      expect(version).toBe(7);
       db.close();
     });
 
@@ -1872,7 +1872,7 @@ describe("StateDb", () => {
       const version = db2["db"]
         .query<{ version: number }, [string]>("SELECT version FROM schema_versions WHERE name = ?")
         .get("state")?.version;
-      expect(version).toBe(6);
+      expect(version).toBe(7);
       db2.close();
     });
 
@@ -1892,7 +1892,7 @@ describe("StateDb", () => {
       const version = db["db"]
         .query<{ version: number }, [string]>("SELECT version FROM schema_versions WHERE name = ?")
         .get("state")?.version;
-      expect(version).toBe(6);
+      expect(version).toBe(7);
       db.close();
     });
 
@@ -2170,6 +2170,35 @@ describe("StateDb", () => {
       db.close();
     });
 
+    test("v7 migration adds transport to pre-existing agent_sessions table", () => {
+      const p = tmpDb();
+      paths.push(p);
+
+      const { Database } = require("bun:sqlite");
+      const raw = new Database(p, { create: true });
+      raw.exec("PRAGMA journal_mode = WAL");
+      raw.exec(`
+        CREATE TABLE schema_versions (name TEXT PRIMARY KEY, version INTEGER NOT NULL);
+        CREATE TABLE agent_sessions (
+          session_id TEXT PRIMARY KEY,
+          state TEXT NOT NULL DEFAULT 'connecting',
+          claude_session_id TEXT,
+          spawned_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        INSERT INTO schema_versions (name, version) VALUES ('state', 6);
+        INSERT INTO agent_sessions (session_id, state) VALUES ('sess-old', 'ended');
+      `);
+      raw.close();
+
+      const db = new StateDb(p);
+      // biome-ignore lint/complexity/useLiteralKeys: access private field for test
+      const cols = (db["db"].prepare("PRAGMA table_info(agent_sessions)").all() as Array<{ name: string }>).map(
+        (r) => r.name,
+      );
+      expect(cols).toContain("transport");
+      db.close();
+    });
+
     test("upsertSession with claudeSessionId persists and round-trips", () => {
       const db = createDb();
       db.upsertSession({ sessionId: "sess-csid", claudeSessionId: "claude-abc123" });
@@ -2185,6 +2214,32 @@ describe("StateDb", () => {
       const row = db.getSession("sess-csid2");
       expect(row?.claudeSessionId).toBe("claude-xyz");
       expect(row?.state).toBe("idle");
+      db.close();
+    });
+
+    test("upsertSession with transport persists and round-trips (fixes #2602)", () => {
+      const db = createDb();
+      db.upsertSession({ sessionId: "sess-transport", transport: "stdio" });
+      const row = db.getSession("sess-transport");
+      expect(row?.transport).toBe("stdio");
+      db.close();
+    });
+
+    test("upsertSession transport is preserved on partial update", () => {
+      const db = createDb();
+      db.upsertSession({ sessionId: "sess-tp2", transport: "stdio" });
+      db.upsertSession({ sessionId: "sess-tp2", state: "idle" });
+      const row = db.getSession("sess-tp2");
+      expect(row?.transport).toBe("stdio");
+      expect(row?.state).toBe("idle");
+      db.close();
+    });
+
+    test("upsertSession transport defaults to null when not provided", () => {
+      const db = createDb();
+      db.upsertSession({ sessionId: "sess-tp-null" });
+      const row = db.getSession("sess-tp-null");
+      expect(row?.transport).toBeNull();
       db.close();
     });
 

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -44,6 +44,7 @@ export interface AgentSessionRow {
   spawnedAt: string;
   endedAt: string | null;
   claudeSessionId: string | null;
+  transport: string | null;
 }
 
 /** @deprecated Use AgentSessionRow instead. */
@@ -291,6 +292,27 @@ export class StateDb {
       })();
       version = 6;
     }
+
+    if (version < 7) {
+      this.db.transaction(() => {
+        const hasAgentSessions =
+          (this.db
+            .query<{ n: number }, []>(
+              "SELECT count(*) AS n FROM sqlite_master WHERE type='table' AND name='agent_sessions'",
+            )
+            .get()?.n ?? 0) > 0;
+        if (hasAgentSessions) {
+          const hasCol = (this.db.prepare("PRAGMA table_info(agent_sessions)").all() as Array<{ name: string }>).some(
+            (r) => r.name === "transport",
+          );
+          if (!hasCol) {
+            this.db.exec("ALTER TABLE agent_sessions ADD COLUMN transport TEXT");
+          }
+        }
+        this.setSchemaVersion(CONSUMER, 7);
+      })();
+      version = 7;
+    }
   }
 
   private applyV1Schema(): void {
@@ -437,7 +459,8 @@ export class StateDb {
         total_cost   REAL NOT NULL DEFAULT 0,
         total_tokens INTEGER NOT NULL DEFAULT 0,
         spawned_at   TEXT NOT NULL DEFAULT (datetime('now')),
-        ended_at     TEXT
+        ended_at     TEXT,
+        transport    TEXT
       );
 
       CREATE TABLE IF NOT EXISTS spans (
@@ -1224,10 +1247,11 @@ export class StateDb {
     worktree?: string;
     repoRoot?: string;
     claudeSessionId?: string;
+    transport?: string;
   }): void {
     this.db.run(
-      `INSERT INTO agent_sessions (session_id, name, provider, pid, pid_start_time, state, model, cwd, worktree, repo_root, claude_session_id)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `INSERT INTO agent_sessions (session_id, name, provider, pid, pid_start_time, state, model, cwd, worktree, repo_root, claude_session_id, transport)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(session_id) DO UPDATE SET
          name = COALESCE(excluded.name, agent_sessions.name),
          provider = COALESCE(excluded.provider, agent_sessions.provider),
@@ -1238,7 +1262,8 @@ export class StateDb {
          cwd = COALESCE(excluded.cwd, agent_sessions.cwd),
          worktree = COALESCE(excluded.worktree, agent_sessions.worktree),
          repo_root = COALESCE(excluded.repo_root, agent_sessions.repo_root),
-         claude_session_id = COALESCE(excluded.claude_session_id, agent_sessions.claude_session_id)`,
+         claude_session_id = COALESCE(excluded.claude_session_id, agent_sessions.claude_session_id),
+         transport = COALESCE(excluded.transport, agent_sessions.transport)`,
       [
         session.sessionId,
         session.name ?? null,
@@ -1251,6 +1276,7 @@ export class StateDb {
         session.worktree ?? null,
         session.repoRoot ?? null,
         session.claudeSessionId ?? null,
+        session.transport ?? null,
       ],
     );
   }
@@ -1276,7 +1302,7 @@ export class StateDb {
   getSession(sessionId: string): AgentSessionRow | null {
     const row = this.db
       .query<RawSessionRow, [string]>(
-        "SELECT session_id, name, provider, pid, pid_start_time, state, model, cwd, worktree, repo_root, total_cost, total_tokens, spawned_at, ended_at, claude_session_id FROM agent_sessions WHERE session_id = ?",
+        "SELECT session_id, name, provider, pid, pid_start_time, state, model, cwd, worktree, repo_root, total_cost, total_tokens, spawned_at, ended_at, claude_session_id, transport FROM agent_sessions WHERE session_id = ?",
       )
       .get(sessionId);
     return row ? toSessionRow(row) : null;
@@ -1286,7 +1312,7 @@ export class StateDb {
     const where = active === true ? " WHERE ended_at IS NULL" : active === false ? " WHERE ended_at IS NOT NULL" : "";
     return this.db
       .query<RawSessionRow, []>(
-        `SELECT session_id, name, provider, pid, pid_start_time, state, model, cwd, worktree, repo_root, total_cost, total_tokens, spawned_at, ended_at, claude_session_id FROM agent_sessions${where} ORDER BY spawned_at DESC`,
+        `SELECT session_id, name, provider, pid, pid_start_time, state, model, cwd, worktree, repo_root, total_cost, total_tokens, spawned_at, ended_at, claude_session_id, transport FROM agent_sessions${where} ORDER BY spawned_at DESC`,
       )
       .all()
       .map(toSessionRow);
@@ -1878,6 +1904,7 @@ interface RawSessionRow {
   spawned_at: string;
   ended_at: string | null;
   claude_session_id: string | null;
+  transport: string | null;
 }
 
 function toSessionRow(row: RawSessionRow): AgentSessionRow {
@@ -1897,6 +1924,7 @@ function toSessionRow(row: RawSessionRow): AgentSessionRow {
     spawnedAt: row.spawned_at,
     endedAt: row.ended_at,
     claudeSessionId: row.claude_session_id,
+    transport: row.transport,
   };
 }
 

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -1247,7 +1247,7 @@ export class StateDb {
     worktree?: string;
     repoRoot?: string;
     claudeSessionId?: string;
-    transport?: string;
+    transport?: "ws" | "stdio";
   }): void {
     this.db.run(
       `INSERT INTO agent_sessions (session_id, name, provider, pid, pid_start_time, state, model, cwd, worktree, repo_root, claude_session_id, transport)


### PR DESCRIPTION
## Summary
- Add `transport TEXT` column to `agent_sessions` table with v7 schema migration for existing DBs
- Persist transport in `upsertSession` and forward it through the `restore_sessions` IPC message so stdio sessions survive daemon restarts
- `prepareSession` now returns `{ name, transport }` so the worker includes the resolved transport in its initial `db:upsert`

## Test plan
- [x] DB round-trip: transport persists via upsertSession and survives partial updates
- [x] DB migration: v7 migration adds `transport` column to pre-existing `agent_sessions` tables
- [x] Production restore path: unskipped test verifies stdio session restored with `transport: "stdio"` spawns with `--print`/`stream-json` instead of `--sdk-url`
- [x] All 2646 daemon tests pass
- [x] Typecheck + lint + rules clean
- [x] Pre-commit + pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)