### PR TITLE
fix(ci): am-i-done --ci covers all scripts/*.spec.ts and test/*.spec.ts (fixes #2613)

### DIFF
--- a/scripts/_runner/test-partition.spec.ts
+++ b/scripts/_runner/test-partition.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "bun:test";
+import { globSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { DAEMON_TEST_PATHS, NON_DAEMON_TEST_PATHS } from "../am-i-done";
+
+const REPO_ROOT = resolve(import.meta.dirname, "../..");
+
+function allSpecFiles(): string[] {
+  return globSync("**/*.spec.ts", {
+    cwd: REPO_ROOT,
+    ignore: ["node_modules/**", "**/node_modules/**"],
+  });
+}
+
+function matchesPath(file: string, paths: string[]): boolean {
+  return paths.some((p) => file === p || file.startsWith(p.endsWith("/") ? p : `${p}/`));
+}
+
+describe("CI test path partition", () => {
+  const ALL_CI_PATHS = [...NON_DAEMON_TEST_PATHS, ...DAEMON_TEST_PATHS];
+
+  it("non-daemon and daemon paths are mutually exclusive", () => {
+    const overlap = NON_DAEMON_TEST_PATHS.filter((p) =>
+      DAEMON_TEST_PATHS.some((d) => p.startsWith(d) || d.startsWith(p)),
+    );
+    expect(overlap).toEqual([]);
+  });
+
+  it("every *.spec.ts in the repo is covered by exactly one partition", () => {
+    const specs = allSpecFiles();
+    const uncovered = specs.filter((f) => !matchesPath(f, ALL_CI_PATHS));
+    expect(uncovered).toEqual([]);
+  });
+
+  it("scripts/ root-level spec files are covered (regression guard for #2613)", () => {
+    const scriptsRootSpecs = allSpecFiles().filter(
+      (f) => f.startsWith("scripts/") && !f.startsWith("scripts/_runner/") && !f.startsWith("scripts/rules/"),
+    );
+    expect(scriptsRootSpecs.length).toBeGreaterThan(0);
+    const uncovered = scriptsRootSpecs.filter((f) => !matchesPath(f, ALL_CI_PATHS));
+    expect(uncovered).toEqual([]);
+  });
+
+  it("a hypothetical scripts/newdir/foo.spec.ts would be matched", () => {
+    const hypothetical = "scripts/newdir/foo.spec.ts";
+    expect(matchesPath(hypothetical, ALL_CI_PATHS)).toBe(true);
+  });
+});

--- a/scripts/am-i-done.ts
+++ b/scripts/am-i-done.ts
@@ -124,7 +124,7 @@ const COVERAGE: Step = {
 // Test paths mirror .github/workflows/ci.yml; adding a new package directory
 // means updating both lists (and matching the workflow's artifact upload glob).
 
-const NON_DAEMON_TEST_PATHS = [
+export const NON_DAEMON_TEST_PATHS = [
   "packages/acp",
   "packages/clone",
   "packages/codex",
@@ -133,18 +133,11 @@ const NON_DAEMON_TEST_PATHS = [
   "packages/core",
   "packages/opencode",
   "packages/permissions",
-  "scripts/rules",
-  "scripts/_runner",
-  "test/integration.spec.ts",
+  "scripts/",
+  "agent-grid/",
 ];
 
-const DAEMON_TEST_PATHS = [
-  "packages/daemon",
-  "test/cli-orchestration.spec.ts",
-  "test/daemon-integration.spec.ts",
-  "test/stress.spec.ts",
-  "test/transport-errors.spec.ts",
-];
+export const DAEMON_TEST_PATHS = ["packages/daemon", "test/"];
 
 const TEST_NON_DAEMON_CI: Step = {
   name: "test-non-daemon",


### PR DESCRIPTION
## Summary
- Broadened `NON_DAEMON_TEST_PATHS` from `scripts/rules` + `scripts/_runner` to `scripts/` (catches 13 previously invisible root-level script specs) and added `agent-grid/`
- Consolidated `DAEMON_TEST_PATHS` from 5 individual `test/*.spec.ts` entries to `test/` (catches 9 previously invisible phase/integration specs)
- Added `scripts/_runner/test-partition.spec.ts` — asserts the two CI test partitions are mutually exclusive, collectively exhaustive, and specifically guards against the #2613 regression (hypothetical `scripts/newdir/foo.spec.ts` must match)

## Test plan
- [x] `bun test scripts/_runner/test-partition.spec.ts` — 4/4 pass (partition completeness, mutual exclusivity, #2613 regression guard, hypothetical new-dir coverage)
- [x] `bun test scripts/` — 652 tests across 32 files pass (confirms the broadened path doesn't break existing script tests)
- [x] Typecheck clean, lint clean
- [x] Pre-commit and pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)