### PR TITLE
fix(test-runner): plumb concurrency cap into coverage step (fixes #2631)

### DIFF
--- a/scripts/am-i-done.ts
+++ b/scripts/am-i-done.ts
@@ -314,6 +314,7 @@ async function main(): Promise<void> {
   // Concurrency guard: detect sibling am-i-done runs and cap --max-concurrency
   // so parallel sprints can't oversubscribe cores (#2597).
   const guard = acquireConcurrencyGuard();
+  process.env.BUN_MAX_CONCURRENCY = String(guard.maxConcurrency);
   if (guard.siblingCount > 0) {
     process.stderr.write(
       `⚡ ${guard.siblingCount} sibling am-i-done run(s) detected — capping --max-concurrency=${guard.maxConcurrency} (#2597)\n`,

--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -234,7 +234,12 @@ const junit1Path = junitOutfile ? `/tmp/coverage-junit-run1-${Date.now()}.xml` :
 // 35 files falsely flagged below the 80% per-file floor. The dev `bun test`
 // command uses --parallel for speed (no --coverage there), and this script
 // stays sequential for accurate coverage aggregation.
-const run1Args = ["bun", "test", "--no-orphans", "--coverage", ...nonDaemonPaths];
+const maxConcurrency = process.env.BUN_MAX_CONCURRENCY
+  ? Number.parseInt(process.env.BUN_MAX_CONCURRENCY, 10)
+  : undefined;
+const mcFlag = maxConcurrency && Number.isFinite(maxConcurrency) ? [`--max-concurrency=${maxConcurrency}`] : [];
+
+const run1Args = ["bun", "test", "--no-orphans", "--coverage", ...mcFlag, ...nonDaemonPaths];
 if (junit1Path) run1Args.push("--reporter", "junit", `--reporter-outfile=${junit1Path}`);
 const proc1 = Bun.spawn(run1Args, {
   stdout: "pipe",
@@ -275,6 +280,7 @@ if (skipRun2) {
     "--parallel",
     "--timeout",
     "60000",
+    ...mcFlag,
     "packages/daemon/src",
     ...daemonTestFiles,
   ];


### PR DESCRIPTION
## Summary

- The concurrency cap from PR #2623 (fixes #2597) was threaded into test-parallel and test-control steps but **not** into the coverage step (`check-coverage.ts`), which spawned `bun test --coverage` with no `--max-concurrency` — defaulting to 20 workers per run
- Under parallel sprint orchestration, N sessions × 20 uncapped coverage workers = the exact oversubscription the cap was meant to prevent (load 25+, workers wedging at 100% CPU for 20-60+ minutes)
- Fix: set `BUN_MAX_CONCURRENCY` env var in `am-i-done.ts` after acquiring the concurrency guard; `check-coverage.ts` reads it and applies `--max-concurrency` to both run-1 (coverage) and run-2 (daemon tests)

## Test plan

- [x] `bun run am-i-done` passes clean (80s)
- [x] `bun typecheck` passes
- [x] Verified flag construction produces correct `--max-concurrency=N` when env var is set
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)