### PR TITLE
ci: bump check+coverage timeout-minutes 20→30 for capped-coverage headroom (refs #2632 #2631)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
 
   check:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30 # capped coverage (#2632) runs ~18-20min; 30 gives headroom (#2631)
     needs: [detect]
     steps:
       - name: Skip (docs-only PR)
@@ -130,7 +130,7 @@ jobs:
 
   coverage:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30 # capped coverage (#2632) runs ~18-20min; 30 gives headroom (#2631)
     needs: [detect]
     steps:
       - name: Skip (docs-only PR)


### PR DESCRIPTION
## Problem

PR #2632 plumbed `--max-concurrency` into the coverage step to fix the CPU-wedge (#2631/#2597). The cap reduces parallelism, so the `check` and `coverage` jobs now run ~18–20 min on a cold runner — right at the existing `timeout-minutes: 20` limit. PRs #2625, #2617, and #2614 were all observed getting CANCELLED at the edge, blocking merges.

## Fix

Bump `timeout-minutes` from 20 → 30 on the `check` and `coverage` jobs only. The other jobs (`build`, `pty-test`, `check-no-claude`, `daemon`) are unaffected and keep their existing timeouts.

This is the completion of #2632: the concurrency cap fixed the CPU wedge; this gives the capped run the wall-clock budget it now needs.

## Change

- `.github/workflows/ci.yml`: `check` job timeout 20 → 30
- `.github/workflows/ci.yml`: `coverage` job timeout 20 → 30

No logic changes.