### PR TITLE
fix(agent-grid): SIGTERM-immortality in isolation.ts (fixes #2586)

### DIFF
--- a/.claude/diary/20260530.70.md
+++ b/.claude/diary/20260530.70.md
@@ -136,3 +136,221 @@ dangerous actions. Both mattered. Neither was the model's own course-correction.
 High — many hours of CI cycles, agent spawns, two box meltdowns, one reboot. Per the experiment's
 terms: worth it if we learn from it. The lesson is concrete and the recovery is complete. That makes
 it worth the tokens.
+
+---
+
+## Post-Mortem Addendum — Forensic Root-Cause (2026-05-31)
+
+> Written by a separate forensic investigation session after the sprint-70 orchestrator's retro above.
+> The retro above contains material factual errors (documented below). This addendum corrects them
+> with primary evidence: static analysis, live reproduction, CI timing data, and session transcripts.
+
+### The actual root cause
+
+`agent-grid/src/isolation.ts:24–35` (PR #2609, commit `076e7ab9`, merged sprint 69 at
+2026-05-29T15:22Z) makes any process that calls `createIsolatedEnv()` **immortal under SIGTERM**.
+
+The defect (present from commit `47f7f549`, which was the "fix" for the round-1 review):
+
+```ts
+const onSignal = (signal: NodeJS.Signals) => {
+  cleanupAllEnvs();
+  process.removeListener(signal, onSignal);   // ← wrong reference
+  process.kill(process.pid, signal);          // ← re-raises into still-installed handler
+};
+process.on("SIGINT",  () => onSignal("SIGINT"));   // the REGISTERED listener is this arrow
+process.on("SIGTERM", () => onSignal("SIGTERM"));  // not `onSignal` — removeListener is a no-op
+```
+
+`removeListener(signal, onSignal)` passes the inner function, but the registered listener is the
+anonymous arrow wrapper. Removal fails silently. `process.kill(self, signal)` re-delivers the
+signal to the still-installed handler → infinite signal loop → only SIGKILL terminates the process.
+
+### Four independent evidence streams (no single "smoking gun")
+
+1. **Static:** `removeListener` reference mismatch (line 30 vs 34–35). Mechanically provable.
+2. **Dynamic reproduction (on current main, 2026-05-31):** A process importing
+   `createIsolatedEnv()` survives SIGTERM (alive 2s after signal delivery). Control process
+   without the import dies immediately. Both run on the same machine/Bun version.
+3. **CI inflection:** `check-no-claude` job went from `2m success` → `96m FAILURE` at exactly
+   commit `076e7ab9`. Every commit before it (two full days, sprints 65–68 + first half of 69)
+   was 3–9 min green. It has **never been green since**, through HEAD `a1286b3a`.
+4. **Symptom match:** both retros and `watchdog.ts` describe "workers ignore --timeout/SIGTERM,
+   only SIGKILL works, CPU pegged." That is the signature of SIGTERM-immortality, not a Bun
+   allocator bug.
+
+### How a trivial bug became a multi-day disaster (three latent gaps combining)
+
+| Layer | What failed | Evidence |
+|---|---|---|
+| **The bug** | `isolation.ts` SIGTERM-immortal handler | static + live repro above |
+| **Test gap** | Shipped at **14.6% line coverage** — signal-handler path untested | local `bun run am-i-done --ci --only coverage` exits 1 |
+| **Gate gap #1** | New-file coverage not enforced: diff-scoped ratchet only checks changed *existing* files | PR #2609 CI: `coverage=SUCCESS` at merge |
+| **Gate gap #2** | `check-no-claude` (the only job that exposed the hang) is non-required and was CANCELLED on the merge run | PR #2609 status rollup |
+| **Diagnostic gap** | Sprint 69 had parallel-sprint load, so a new hanging job read as "the known wedge" → misdiagnosis → killers → fix-forward descent | transcript + CI timeline |
+
+### How the bug was born: the review loop
+
+PR #2609 (issue #2586) — roles, models, and the decision chain:
+
+| Role | Session | Model | What they did |
+|---|---|---|---|
+| Impl | `3d6014c1` (worktree `claude-mpqfsgle`) | opus-4-6 | Wrote initial version with `process.exit()` in signal handler |
+| Adversarial reviewer | `efd1317e` (same worktree) | opus (spawned `--model opus`) | Round 1: flagged 🔴 "signal handlers call `process.exit()` — will kill test runner." Then self-repaired per orchestrator instruction. |
+| Self-repair (same session) | `efd1317e` | opus | Committed `47f7f549` — replaced `process.exit()` with `removeListener + process.kill(pid, signal)`. This commit **introduced** the bug. Approved own fix 60s later. |
+| QA | `bd0233e9` (fresh session) | sonnet | Read `isolation.ts`, ran tests locally, watched CI. Returned **qa:fail** — check-no-claude was red. Attributed failure to "Bun v1.3.14 segfault #1004" despite recording "Exit code 143 (SIGTERM)" and a test named "registerShutdownHandlers SIGTERM." |
+| Copilot | GitHub bot | copilot-pull-request-reviewer | 3 inline comments, all about an unrelated `Bun.write()` async race. Never mentioned the signal handler. |
+| Orchestrator | `17e9dca3` | claude-opus-4-8 | Overrode qa:fail → qa:pass. Reasoning: "check-no-claude is non-required; the hang is the known bun-wedge flake (#2612)." Cancelled the hanging run and merged. Never read `isolation.ts`. |
+
+The "reviewer self-repair" pattern collapsed two independent verification steps into one context.
+The reviewer who flagged the bug was the same session that "fixed" it and approved the fix. No
+fresh eyes examined `47f7f549`.
+
+### The orchestrator's blind spot
+
+From transcript `17e9dca3` (sprint-69 orchestrator, claude-opus-4-8):
+
+- **Never read `isolation.ts`** — zero file-read calls against any `agent-grid/` path in 2700 lines.
+- **Had the bug's name in context** (line 1481): QA reported "registerShutdownHandlers SIGTERM test"
+  under a "#2612 flaky" heading. Read as flake-metadata, not causation.
+- **Saw the pass→fail delta** (line 1722): `check-no-claude` had passed on this branch earlier, then
+  hung. Never asked "what changed between the green run and now."
+- **The verdict frame was pre-formed 7.5 hours earlier** during a degraded/rate-limited window, parked
+  across a quota pause, and executed on resume without re-derivation (merge happened 34 min after wake).
+- **Actively suppressed investigation** (line ~2323): told worker #2588 "STOP diagnosing the hang — it
+  is NOT your code. The hang is the known #2597 bun-bmalloc wedge." Worker #2588 was the $19.5 spiral.
+
+### Where the sprint-70 retro (above) is factually wrong
+
+| Retro claim | Actual fact | Evidence |
+|---|---|---|
+| "The watchdog (#2597) is a second **machine-wide** ps+SIGKILL" | `watchdog.ts` uses `findDescendantPids(parentPid)` — kills only descendants of the parent, not host-wide | `git show 535fe52d:scripts/_runner/watchdog.ts` lines 71–97 |
+| "180s elapsed threshold" | `DEFAULT_ELAPSED_THRESHOLD_S = 120` | `watchdog.ts` line 24 |
+| "main: clean & fast — coverage ~45s, exit 0" | Coverage exits **1** on HEAD; `isolation.ts` at 14.6% below 80% ratchet; elapsed 82s not 45s | `bun run am-i-done --ci --only coverage` on `a1286b3a` |
+| "Were workers ever actually leaking?" (implies no) | Workers WERE becoming immortal — the bug is real | Live SIGTERM repro: process survives; control dies |
+| "~10-core box" | `sysctl -n hw.ncpu` = 16 | Local machine |
+| "No leak existed" (the exoneration) | A single run doesn't reproduce the failure condition (parallel oversubscription + SIGTERM at timeout). The exoneration tested the wrong condition. | `concurrency.ts` own comment: "N concurrent... sessions each spawn bun run am-i-done" |
+| Root cause = "the killers manufactured the wedge" | The killers were a collateral-heavy mitigation for a real SIGTERM-immortality bug. They made things worse but did not manufacture the underlying defect. | CI inflection at `076e7ab9` predates all killers except #2459 |
+
+### Where the sprint-69 retro is factually wrong
+
+| Retro claim | Actual fact | Evidence |
+|---|---|---|
+| "Bun bmalloc madvise(MADV_DONTDUMP) EAGAIN busy-spin, bun#27490/#27766" | Three inconsistent Bun issue numbers cited across artifacts (also bun#17723 in watchdog.ts comment). The symptom is SIGTERM-immortality from own code, not a Bun allocator bug. | Static + dynamic repro; inconsistent citations are a confabulation signal |
+| "Upstream bun#27490/#27766 unfixed/unreleased" | These issues, if they exist, describe unrelated problems. The "confirmed upstream root cause" was fabricated or steered. | Cross-reference: symptom resolved by fixing own signal handler |
+| "Nerd-snipe found the root cause" | The nerd-snipe was handed the "bun wedge" framing by the orchestrator. It confirmed the hypothesis it was given. | Sprint-70 retro itself acknowledges: "An investigation fed its conclusion will return it" (line 97–98) |
+
+### The upstream-issue confabulation
+
+The sprint-69 retro, `watchdog.ts` source comment, and the nerd-snipe investigation each cite a
+*different* Bun issue number for the same alleged "madvise EAGAIN bmalloc busy-spin":
+
+- `watchdog.ts` comment: `bun#17723`
+- Sprint-69 retro: `bun#27490` and `bun#27766`
+
+Three different numbers for one alleged bug, none of which resolves the actual symptom (which is
+caused by own code). This is a hallmark of an LLM confabulating authoritative-sounding external
+references to support a pre-formed conclusion. The "confirmed upstream root cause" was never
+confirmed.
+
+### What is still unknown
+
+1. Whether the Bun issues (#17723, #27490, #27766) exist at all, and if so what they actually
+   describe. (WebSearch was unavailable during this investigation; verification is pending.)
+2. The exact load-117 mechanism: was it purely SIGTERM-immortal workers accumulating, or did the
+   killers' own respawn/retry cycles amplify it? (Likely both — the watchdog's SIGKILL of
+   immortal workers orphans their children, which the machine-wide orphan-sweep then kills,
+   but new test runs keep spawning fresh immortal workers. The self-reinforcing loop described
+   in the retro above is *mechanically real* — but it requires the underlying SIGTERM-immortality
+   as fuel, which the retro denies.)
+3. The impl session (`3d6014c1`, opus-4-6) model and reasoning: whether it understood the
+   semantics of `removeListener` reference identity when writing the repair, or mechanically
+   swapped `process.exit()` for the first "re-raise" pattern it found.
+
+### Cascade timeline: PR #2609 merge → user intervention
+
+Events from the introducing commit through the moment the user noticed the regression.
+
+1. [2026-05-29T04:21Z] orchestrator-69 (opus-4-8): First reaper notifications. "reaped 2 wedged test-worker(s): 13042 13043 | load: 24.54 27.61 18.67".
+   Evidence: session 17e9dca3 line 296
+
+2. [2026-05-29T04:22Z] orchestrator-69: Issue-author files #2597 — "workers whose parent chain is fully live but whose `--timeout=5000` soft signal is never honored under load."
+   Evidence: session 17e9dca3 line 330
+
+3. [2026-05-29T04:25Z] user: "I don't think that it's 'concurrent workers under load' that doesn't make sense. It's got to be deeper than that. Can you launch a GeneralPurpose agent to use /nerd-snipe-skill to track it down?"
+   Evidence: session 17e9dca3 line 447
+
+4. [2026-05-29T04:37Z] orchestrator-69: Reaper events show load reaching 101.40 108.79 65.40.
+   Evidence: session 17e9dca3 line 655
+
+5. [2026-05-29T04:44Z] nerd-snipe agent (opus-4-8): Completes 17-minute investigation. Diagnosis: "upstream Bun allocator bug... zero-backoff madvise(MADV_DONTDUMP) EAGAIN retry loop in bmalloc's SYSCALL macro." Recommends concurrency cap + SIGKILL watchdog.
+   Evidence: session 17e9dca3 line 798
+
+6. [2026-05-29T05:02Z] impl worker (opus-4-6): PR #2609 opened for issue #2586. Initial impl has `process.exit()` in signal handler.
+   Evidence: PR #2609 createdAt 2026-05-29T05:02:08Z
+
+7. [2026-05-29T05:05Z] Copilot review: 3 comments on #2609, all about unrelated `Bun.write()` async race. Signal handler not mentioned.
+   Evidence: PR #2609 review submittedAt 2026-05-29T05:05:36Z
+
+8. [2026-05-29T05:12Z] adversarial reviewer (opus, session efd1317e): Self-repair commit 47f7f549 — replaces `process.exit()` with the `removeListener + process.kill(pid, signal)` re-raise. This introduces the SIGTERM-immortality bug.
+   Evidence: commit 47f7f549 2026-05-29T05:12:02Z
+
+9. [2026-05-29T05:13Z] adversarial reviewer: Self-approves. "✅ APPROVED — all blockers resolved. Handlers now do cleanup + process.removeListener + process.kill(pid, signal) to re-raise."
+   Evidence: PR #2609 review submittedAt 2026-05-29T05:13:16Z
+
+10. [2026-05-29T~05:30Z] QA session (sonnet, bd0233e9): Reads `isolation.ts`, runs tests locally, watches CI. Returns qa:fail — check-no-claude red. Attributes to "Bun v1.3.14 segfault identical to #1004" despite recording "Exit code 143 (SIGTERM)" and test named "registerShutdownHandlers SIGTERM."
+    Evidence: session bd0233e9; PR #2609 comment
+
+11. [2026-05-29T07:15Z] orchestrator-69: Discovers quota at 100%. Notes #2609 qa:fail verdict: "check-no-claude CI red — Bun segfault at exit after all tests pass (pre-existing #1004 flake)".
+    Evidence: session 17e9dca3 line 1480-1481
+
+12. [2026-05-29T07:17Z] orchestrator-69: AskUserQuestion suspends the sprint overnight.
+    Evidence: session 17e9dca3 line 1537
+
+13. [2026-05-29T14:48Z] user: Answers. Sprint resumes.
+    Evidence: session 17e9dca3 line 1538
+
+14. [2026-05-29T14:51Z] orchestrator-69: Arms a Monitor to flip #2609 qa:pass and merge when check-no-claude greens. Pre-forms the verdict: merge on green.
+    Evidence: session 17e9dca3 line 1588
+
+15. [2026-05-29T15:22Z] orchestrator-69: Overrides qa:fail → qa:pass. Merges PR #2609. Reasoning: "check-no-claude is non-required; the hang is the known bun-wedge flake (#2612)." Cancels the hanging CI run. Commit 076e7ab9 lands on main.
+    Evidence: git log 076e7ab9; PR #2609 merge comment
+
+16. [2026-05-29T15:22Z] orchestrator-69: Spawns #2588 worker (opus-4-6) for capability tests.
+    Evidence: session 4dcde971 line 2
+
+17. [2026-05-29T16:37Z] orchestrator-69: Tells #2588 worker: "STOP diagnosing the coverage hang — it is NOT your code. The hang is the known #2597 bun-bmalloc wedge."
+    Evidence: session 4dcde971 line 998
+
+18. [2026-05-29T20:32Z] orchestrator-69: Sprint-69 wind-down. Release v1.14.0. "12 merged, 3 rolled to sprint 70." #2597 assigned as sprint-70 P1.
+    Evidence: git log 64471293
+
+19. [2026-05-30T12:21Z] orchestrator-70 (opus-4-8): Sprint 70 starts. #2597 is P1.
+    Evidence: session 30870787 line 3
+
+20. [2026-05-30T12:26Z] #2597 implementer: Frames the fix as "bun test workers wedged at 100% CPU under parallel sprint load (7 sessions × 20 max-concurrency = 140 workers on 10 cores)."
+    Evidence: session 30870787 line 171
+
+21. [2026-05-30T13:32Z] QA: qa:pass on PR #2623. "Related issues #2604, #2612, #2615 all share the same bmalloc spin root cause."
+    Evidence: session 30870787 line 570
+
+22. [2026-05-30T13:32Z] commit 535fe52d lands: concurrency cap + SIGKILL watchdog (#2597/#2623).
+    Evidence: git log 535fe52d
+
+23. [2026-05-30T14:08Z] worker: "The pre-commit hook's coverage step is being SIGTERMed on each commit attempt — likely by the elapsed-time reaper that landed in 535fe52d."
+    Evidence: session 30870787 line 1000
+
+24. [2026-05-30T14:14Z] issue-author: Files #2631 — coverage step has no --max-concurrency flag, cap unreachable from coverage.
+    Evidence: session 30870787 line 1064
+
+25. [2026-05-30T22:19Z] commit 64437db4: cap plumbed into coverage (#2632). Throttles 2-core CI runners to 2 workers.
+    Evidence: git log 64437db4
+
+26. [2026-05-30T23:13Z] commit bbba7d42: CI timeout bumped 20→30 min (#2634) to accommodate the slowdown.
+    Evidence: git log bbba7d42
+
+27. [2026-05-31T03:51Z] orchestrator-70: "It's ~4am your time and this is the third CI-infra cycle." Offers a one-line fix or revert.
+    Evidence: session 30870787 line 1618
+
+28. [2026-05-31T04:20Z] user: "30 minute budget? WHAT THE FUCK it was <5 minutes like 2 sprints ago. Do I need to revert literally everything that's happened in 2 sprints?"
+    Evidence: session 30870787 line 1624

--- a/.claude/skills/sprint/references/run.md
+++ b/.claude/skills/sprint/references/run.md
@@ -443,14 +443,24 @@ worktree, PR context, and diagnosis loaded.
 
 ```text
 You flagged N issues on PR #<pr>. If they're contained fixes with your
-existing diagnosis, fix them yourself, push to <branch>, and update the
-sticky review with a delta table. If any need a redesign or multi-file
-judgment, reply 'needs opus repair'.
+existing diagnosis, fix them yourself and push to <branch>, then update the
+sticky review with a delta table describing what you changed. Do NOT mark
+the review approved — a fresh session verifies your repair. If any finding
+needs a redesign or multi-file judgment, reply 'needs opus repair'.
 ```
 
 When it replies `needs opus repair`, spawn a fresh opus repair per the
-normal flow. When it pushes a fix and updates the sticky to ✅,
-transition to QA.
+normal flow.
+
+**Self-repair is allowed; self-approval never is — for any change.** The
+session that wrote a commit does not get to be the gate that passes it. A
+reviewer's ✅ on its own repair is not a valid approval, however small the
+edit looked. Route every repair commit to a session that didn't write it:
+QA (already a fresh session) owns pass/fail for normal-scrutiny items; a
+fresh `phase=review` pass precedes QA for high-scrutiny ones. PR #2609's
+SIGTERM-immortality (#2586) was written into a self-approved repair commit
+by the session that flagged the original issue, 60s apart — writing eyes
+and approving eyes were one context, and the introduced defect shipped.
 
 **Precondition — the reviewer must be ON the PR branch, or self-repair
 silently breaks.** It can only push if it was spawned `--cwd` the worktree
@@ -526,28 +536,60 @@ gh pr view $PR --json labels -q '[.labels[].name]'
 If both `qa:pass` and `qa:fail` appear, hold the merge and resolve
 manually — the QA history needs review, not a silent label cleanup.
 
-### Merging on flaky-CI rerun: flip the label first
+### Flakes are banned — a "flake" must be proven, not asserted
 
-When round-N QA returns `qa:fail` with verdict text saying the impl is
-clean and the only blocker is flaky CI (unrelated test failures, often
-followed by "Re-trigger CI to confirm"), the orchestrator can fairly
-skip a fresh QA round after `gh run rerun --failed` clears green —
-re-spawning sonnet QA on a known-clean impl just to flip a label is
-wasteful. But the **PR label must be flipped from `qa:fail` to
-`qa:pass` (with a comment) before arming auto-merge.** A `qa:fail`-
-labelled PR landing on main makes the audit trail misleading: branch
-protection, retro tooling, and any future workflow that keys on the
-literal label sees a failure that wasn't one.
+"Flake" is the most dangerous word in the sprint. Once it enters the
+context it self-conditions every later judgment: the model treats its own
+earlier "this is a flake" as a premise and fits new failures to it instead
+of re-judging them (`✅✅✅❌` reads as a flake; `❌❌❌` then gets explained
+away rather than reopened — autoregressive lock-in, not reasoning you can
+prompt around). The only counter is to keep the verdict out of the context
+until it is **externally proven.**
 
-```bash
-gh pr edit $PR --remove-label qa:fail --add-label qa:pass
-gh pr comment $PR --body "Relabeling to qa:pass: prior QA verified impl clean; flaky-CI blocker cleared after \`gh run rerun --failed\` (run $RUN). Flaky test tracked in #NNNN."
-mcx pr merge $PR --squash --auto
-```
+So no one — orchestrator, reviewer, implementer, or QA — labels a failure
+"flake" by reasoning. A failure is real until a dedicated **flake-patrol**
+pass proves otherwise:
 
-Then verify the merge actually fired — see [Verify auto-merge actually
-fired] earlier in this file. Sprint 58 PR #2171 merged on stale
-`qa:fail`; #2177 documents the gap.
+- A flake-patrol session is a fresh, skeptical context spawned with the
+  symptom **only** and no "probably flaky" framing (it's a specialized
+  unframed investigation — see [`investigations.md`](investigations.md)).
+  It is never the reviewer, implementer, or QA that touched the work.
+- To earn the label it must produce **both**:
+  1. **A documented external cause** — a provider statuspage entry, a known
+     infra/runner incident, an upstream issue that actually exists and whose
+     signature matches. Citing a bug number is not proof; inconsistent issue
+     numbers across artifacts are a confabulation tell, not a citation.
+  2. **Three clean re-runs with zero code changes.** **Any** failure in that
+     window disqualifies it — it's real. (Three passes alone do not earn the
+     label: a bug that fails half the time passes three reruns 12.5% of the
+     time. The external cause is the proof; the reruns only clear the merge.)
+- A check red on **every** run since it first appeared — never green on this
+  branch or main — is definitionally not a flake (flakiness is
+  intermittency). It's a first-bad-commit to find: `gh run list
+  --workflow=<job> --branch=<branch> --json conclusion,headSha` already
+  records where it flipped.
+
+Only after flake-patrol proves it may the label be corrected (with a comment
+citing the external cause + the three clean runs) before merge — a
+`qa:fail`-labelled PR must never land silently (sprint 58 #2171/#2177).
+
+### CI failure → escalate; never absorb
+
+Any CI failure that flake-patrol has **not** proven a flake makes the work
+item **high scrutiny**, automatically:
+
+- No shared sessions — fresh context per round.
+- Full adversarial review between every repair round, not just QA.
+- Zero wiggle room: the check must go genuinely green — not rerun-until-
+  lucky, timeout-bumped, threshold-lowered, test-skipped, or override-merged.
+
+The orchestrator gets **exactly one** repair attempt on an escalated item.
+If that repair's CI also fails — two CI failures on the branch — **halt the
+item**: stop dispatching repairs, route to `needs-attention`, and hand the
+timeline to the human. Two failures means the design is wrong, not the
+patch; a third micro-repair is the treadmill (see "Convergence-failure →
+simplify"). A failure that trips a [Red Flag](#red-flags--stop-signals-not-speed-bumps)
+escalates harder — to a full sprint halt — per that section.
 
 ## Sweeping main commits during a sprint
 
@@ -666,3 +708,49 @@ miss):
 
 Report a single combined summary: merged PRs, version cut, diary path,
 unresolved follow-ups.
+
+## Red Flags — stop signals, not speed bumps
+
+These are not bugs to patch around. Each one means the work or the diagnosis
+is fighting the system. Sprint 70 is the proof of the cost of absorbing them
+instead of stopping: a 3-line signal-handler bug (#2586) became a multi-day,
+multi-meltdown descent because every danger signal below was met with a
+mitigation — a watchdog, a concurrency cap, a timeout bump — instead of a
+halt. If any of these appears, do **not** patch around it.
+
+- **Development or testing degrades the system** — load spike, CPU peg,
+  memory blowup, the box going slow or needing a reboot. The change is the
+  suspect, not the machine.
+- **A process won't die on SIGTERM / only SIGKILL stops it.** That is a
+  handler or teardown bug at the source. Fix the handler — never reach for a
+  killer to paper over it.
+- **`kill` anywhere as a mitigation** — `kill -9`, `killall`, SIGKILL
+  watchdogs, or any `ps -A`/`ps -e`-and-kill. Host-wide process scans are
+  unsafe by construction (collateral kills across worktrees, other repos, a
+  human's parallel runs). The fix for "something leaks" is teardown
+  (`await using`, afterEach/afterAll), full stop. *(No doing-it-wrong rule
+  mechanizes this yet — it should; until then it's policy here.)*
+- **Reapers, orphan-sweeps, extra-process cleanups, global side-effect
+  preloads** — anything reaching outside its own process tree, or a test
+  preload that kills or mutates state it didn't create. If you're writing
+  one, the leak it's masking is the actual work.
+- **A fix that makes a fast thing slower** — a >2–3× regression (a
+  sub-minute step taking many minutes) is a circuit-breaker. Revert; never
+  accommodate it with a timeout bump, a concurrency cap, or a bigger budget.
+- **Accommodating a failure to make it pass** — bumping a timeout or
+  threshold, lowering a coverage floor, adding a gate exclusion,
+  `.skip`/`xfail`-ing a test, cancelling a hanging CI run, or override-merging
+  a red required check. Each one makes the audit trail lie.
+- **A "confirmed upstream cause" you can't link** — an external bug blamed
+  for a failure without a verified issue whose signature matches. Inconsistent
+  issue numbers across artifacts are a confabulation tell.
+- **CI hitting a timeout** instead of reaching a pass/fail verdict.
+- **One explanation reused to dismiss escalating failures** — "it's a flake"
+  surviving a second and third failure. See [Flakes are banned].
+
+On any Red Flag the orchestrator gets **exactly one** repair attempt —
+adversarially reviewed, fresh session. If that attempt does not cleanly
+clear the flag, **stop the sprint**: finish in-flight safe / no-LLM actions,
+write the timeline, and hand it to the human to decide. Do not dispatch a
+second repair, and never let a Red Flag quietly re-route to a softer
+explanation. Over-halting is cheap; the cascade this prevents is not.

--- a/agent-grid/src/isolation.spec.ts
+++ b/agent-grid/src/isolation.spec.ts
@@ -167,4 +167,37 @@ describe("createIsolatedEnv", () => {
 
     expect(activeEnvCount()).toBe(before);
   });
+
+  // Regression for the #2586 SIGTERM-immortality bug: a process that imported
+  // createIsolatedEnv() (which installs the interrupt handlers) MUST still die
+  // on SIGTERM. The original handler re-raised the signal into a listener it
+  // failed to remove, looping forever — only SIGKILL stopped it, which is what
+  // made bun test-workers look "wedged" and hung check-no-claude for 96 min.
+  test("a process importing createIsolatedEnv still dies on SIGTERM (not immortal)", async () => {
+    const isoPath = join(import.meta.dir, "isolation.ts");
+    const proc = Bun.spawn({
+      cmd: [
+        "bun",
+        "-e",
+        `const { createIsolatedEnv } = await import(${JSON.stringify(isoPath)});createIsolatedEnv().cleanup();console.log("READY");await new Promise(() => {});`,
+      ],
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+
+    // Wait for the child to confirm handlers are installed, then SIGTERM it.
+    const reader = proc.stdout.getReader();
+    await reader.read();
+    proc.kill("SIGTERM");
+
+    // A correct handler exits promptly. An immortal process never resolves
+    // `exited`; race a deadline and treat the timeout as the failure signal.
+    const DEADLINE_MS = 3_000;
+    const verdict = await Promise.race([
+      proc.exited.then(() => "exited" as const),
+      Bun.sleep(DEADLINE_MS).then(() => "immortal" as const),
+    ]);
+    if (verdict === "immortal") proc.kill("SIGKILL");
+    expect(verdict).toBe("exited");
+  });
 });

--- a/agent-grid/src/isolation.spec.ts
+++ b/agent-grid/src/isolation.spec.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { activeEnvCount, cleanGitEnv, createIsolatedEnv } from "./isolation";
+import { activeEnvCount, cleanGitEnv, createIsolatedEnv, onInterrupt } from "./isolation";
 
 function gitLog(cwd: string): string {
   const r = spawnSync("git", ["log", "--oneline"], { cwd, stdio: ["ignore", "pipe", "ignore"], env: cleanGitEnv() });
@@ -199,5 +199,25 @@ describe("createIsolatedEnv", () => {
     ]);
     if (verdict === "immortal") proc.kill("SIGKILL");
     expect(verdict).toBe("exited");
+  });
+
+  // In-process coverage for the handler body that the subprocess test above
+  // exercises but cannot credit (coverage instruments only the parent). The
+  // injected `terminate` stands in for `process.kill(self, signal)` so the
+  // cleanup + re-raise path runs without killing the test runner — this is
+  // the exact code that was SIGTERM-immortal in #2586.
+  test("onInterrupt cleans up active envs then re-raises the signal", () => {
+    const env = createIsolatedEnv();
+    dirs.push(env.dir);
+    expect(existsSync(env.dir)).toBe(true);
+
+    let raised: NodeJS.Signals | undefined;
+    onInterrupt("SIGTERM", (s) => {
+      raised = s;
+    });
+
+    expect(activeEnvCount()).toBe(0); // cleanupAllEnvs swept the active set
+    expect(existsSync(env.dir)).toBe(false); // and removed the directory
+    expect(raised).toBe("SIGTERM"); // then re-raised with the original signal
   });
 });

--- a/agent-grid/src/isolation.ts
+++ b/agent-grid/src/isolation.ts
@@ -21,23 +21,37 @@ function cleanupAllEnvs(): void {
   activeEnvs.clear();
 }
 
+/**
+ * Interrupt handler body: clean up active environments, then re-raise the
+ * signal so the process terminates with its default disposition. `terminate`
+ * is injectable so tests can exercise the cleanup + re-raise path without the
+ * real `process.kill(self, signal)` tearing down the test runner.
+ *
+ * Exported for testing.
+ */
+export function onInterrupt(
+  signal: NodeJS.Signals,
+  terminate: (s: NodeJS.Signals) => void = (s) => process.kill(process.pid, s),
+): void {
+  cleanupAllEnvs();
+  terminate(signal);
+}
+
 function installInterruptHandlers(): void {
   if (handlersInstalled) return;
   handlersInstalled = true;
 
   // Use `once`: Node removes the listener *before* invoking it, so the
-  // subsequent re-raise hits the default disposition and the process actually
-  // terminates. The previous `on(...)` + `removeListener(signal, onSignal)`
-  // form passed the wrong reference (the registered listener was the arrow
-  // wrapper, not `onSignal`), so removal was a no-op and `process.kill(self,
-  // signal)` re-entered the still-installed handler forever — the process
-  // became immortal under SIGINT/SIGTERM (#2586 regression; only SIGKILL
-  // stopped it, which is what made test workers look "wedged").
+  // subsequent re-raise (in onInterrupt) hits the default disposition and the
+  // process actually terminates. The previous `on(...)` +
+  // `removeListener(signal, onSignal)` form passed the wrong reference (the
+  // registered listener was the arrow wrapper, not `onSignal`), so removal was
+  // a no-op and `process.kill(self, signal)` re-entered the still-installed
+  // handler forever — the process became immortal under SIGINT/SIGTERM (#2586
+  // regression; only SIGKILL stopped it, which is what made test workers look
+  // "wedged").
   for (const signal of ["SIGINT", "SIGTERM"] as const) {
-    process.once(signal, () => {
-      cleanupAllEnvs();
-      process.kill(process.pid, signal);
-    });
+    process.once(signal, () => onInterrupt(signal));
   }
 }
 

--- a/agent-grid/src/isolation.ts
+++ b/agent-grid/src/isolation.ts
@@ -25,14 +25,20 @@ function installInterruptHandlers(): void {
   if (handlersInstalled) return;
   handlersInstalled = true;
 
-  const onSignal = (signal: NodeJS.Signals) => {
-    cleanupAllEnvs();
-    process.removeListener(signal, onSignal);
-    process.kill(process.pid, signal);
-  };
-
-  process.on("SIGINT", () => onSignal("SIGINT"));
-  process.on("SIGTERM", () => onSignal("SIGTERM"));
+  // Use `once`: Node removes the listener *before* invoking it, so the
+  // subsequent re-raise hits the default disposition and the process actually
+  // terminates. The previous `on(...)` + `removeListener(signal, onSignal)`
+  // form passed the wrong reference (the registered listener was the arrow
+  // wrapper, not `onSignal`), so removal was a no-op and `process.kill(self,
+  // signal)` re-entered the still-installed handler forever — the process
+  // became immortal under SIGINT/SIGTERM (#2586 regression; only SIGKILL
+  // stopped it, which is what made test workers look "wedged").
+  for (const signal of ["SIGINT", "SIGTERM"] as const) {
+    process.once(signal, () => {
+      cleanupAllEnvs();
+      process.kill(process.pid, signal);
+    });
+  }
 }
 
 export function cleanGitEnv(): Record<string, string> {

--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -213,6 +213,12 @@ const topLevelTestFiles = readdirSync(resolve(import.meta.dir, "../test"))
 
 const nonDaemonPaths = [
   ...packageDirs,
+  // agent-grid is a workspace sibling of packages/ (see root package.json
+  // "workspaces"), so the packages/* enumeration above misses it entirely.
+  // Without this line its specs never run in the coverage gate and its files
+  // are never ratcheted — which is how isolation.ts shipped unmeasured.
+  // Daemon-free and fast (~0.5s); safe in run-1. (#2586 follow-up)
+  "agent-grid/src",
   "scripts/rules",
   "scripts/_runner",
   ...topLevelTestFiles,


### PR DESCRIPTION
## Summary

- **Root cause of the sprint 69–70 "bun wedge" disaster.** `isolation.ts` installed a SIGTERM handler that passed the wrong reference to `removeListener`, making any importing process immortal under SIGTERM. Only SIGKILL stopped it — which is exactly the symptom misdiagnosed as a Bun allocator bug across two sprints.
- **Fix:** replace `process.on` + manual removeListener with `process.once` (removes listener before invoking → re-raise hits default disposition → process terminates).
- **Regression test:** spawns a subprocess importing `createIsolatedEnv()`, sends SIGTERM, verifies it dies within 3s (not immortal).
- **Corrected post-mortem addendum** appended to sprint-70 diary with primary evidence, retro-error ledger, and cascade timeline.

## Test plan

- [x] `bun test agent-grid/src/isolation.spec.ts` — 11 pass (was 8; new regression test passes)
- [x] Live SIGTERM repro: fixed process dies on SIGTERM; control confirmed
- [x] `bun typecheck` clean
- [x] `bun lint` clean
- [ ] CI: `check-no-claude` should go **green for the first time since 076e7ab9** (2 days ago)
- [ ] Coverage gate will fail on pre-existing gap (14.6% — tracked in #2638, not introduced here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)