### PR TITLE
fix(ci): route check-no-claude through bunTestWithCrashTolerance (fixes #2641)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,17 +213,13 @@ jobs:
           fi
           echo "claude not on PATH — OK"
 
-          set +e
-          bun test 2>&1 | tee /tmp/test_no_claude.txt
-          code=${PIPESTATUS[0]}
-          if [ $code -eq 0 ]; then
-            exit 0
-          elif grep -q "^ 0 fail$" /tmp/test_no_claude.txt; then
-            echo "::warning::Bun crash (exit $code) after all tests passed — treating as pass (see #1004)"
-            exit 0
-          else
-            exit $code
-          fi
+          # Run the full suite through the same junit-based crash-tolerant
+          # classifier the required `check` job uses (bunTestWithCrashTolerance).
+          # The previous raw `bun test` + `grep "^ 0 fail$"` leaked Bun's
+          # post-teardown SIGTERM (exit 143) as a red build — the grep needs the
+          # summary line, which a teardown crash can pre-empt (#2641). The entry
+          # writes /tmp/test_no_claude.txt for the artefact upload below.
+          bun scripts/_runner/no-claude-test.ts
       - name: Upload no-claude test logs
         if: always() && needs.detect.outputs.docs_only != 'true'
         uses: actions/upload-artifact@v7

--- a/scripts/_runner/no-claude-test.ts
+++ b/scripts/_runner/no-claude-test.ts
@@ -1,0 +1,30 @@
+/**
+ * Entry point for the `check-no-claude` CI job: run the full test suite with
+ * the #1004/#1419 crash-after-pass tolerance, claude-free PATH.
+ *
+ * The workflow strips every directory containing a `claude` binary from PATH
+ * (so a test that secretly shells out to `claude` fails loudly) and then runs
+ * this script. We re-use `bunTestWithCrashTolerance` — the exact junit-based
+ * classifier the required `check` job uses — instead of the old raw `bun test`
+ * + `grep "^ 0 fail$"` bash, which leaked Bun's post-teardown SIGTERM (exit
+ * 143) as a red build: the grep needs the summary line, but a teardown crash
+ * can SIGTERM the worker AFTER all tests pass but BEFORE the summary flushes.
+ * The junit reporter records `failures="0"` on disk and survives that crash;
+ * the `ZERO_FAIL_RE` stdout fallback covers the case where even the file is
+ * lost (#2641).
+ *
+ * This is a process-boundary shim (spawns `bun test`, then `process.exit`) and
+ * is therefore excluded from the per-file coverage ratchet, like
+ * `scripts/release.ts`. The behaviour it depends on lives in
+ * `bunTestWithCrashTolerance` and is fully covered by `ci-steps.spec.ts`.
+ */
+import { bunTestWithCrashTolerance } from "./ci-steps";
+import { createConsoleLogger } from "./logger";
+
+// Empty `paths` → whole suite (one invocation, matching the job's original
+// scope). retryOn132 because the suite includes the daemon tests, which
+// historically need the SIGILL retry.
+const step = bunTestWithCrashTolerance({ paths: [], logName: "test_no_claude", retryOn132: true });
+const result = await step({ args: [], env: process.env, logger: createConsoleLogger() });
+const success = typeof result === "boolean" ? result : (result?.success ?? false);
+process.exit(success ? 0 : 1);

--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -116,6 +116,8 @@ const EXCLUSIONS: Record<string, string> = {
 
   // CI scripts — git-dependent, tested via pure-function unit tests + CI integration
   "scripts/release.ts": "CI-only release script, git-dependent async functions untestable in isolation",
+  "scripts/_runner/no-claude-test.ts":
+    "CI-only entry shim (spawns bun test, then process.exit); logic is bunTestWithCrashTolerance, covered by ci-steps.spec.ts (#2641)",
   // Test harness — not production code
   "test/harness.ts": "Test infrastructure, not source",
 };


### PR DESCRIPTION
## Problem
`check-no-claude` has been **red on main for two days** (bisect: green through `b68d5283`, red from `076e7ab9` = #2609). It runs raw `bun test` gated on `grep "^ 0 fail$"` of stdout. On the ubuntu runner, Bun 1.3.14 SIGTERMs a worker at post-test teardown (**exit 143**) *after* all tests pass but *before* the summary line flushes — the grep finds nothing and the 143 leaks → red.

The required `check`/`coverage` jobs were never affected: they route through `bunTestWithCrashTolerance`/`coverageWithCrashTolerance`, which key off the **junit** `failures="0"` signal (with a `ZERO_FAIL_RE` stdout fallback). check-no-claude was the only test job still on the fragile bash passthrough.

## Fix
A thin CI-only entry (`scripts/_runner/no-claude-test.ts`) runs the full suite through `bunTestWithCrashTolerance` — the exact classifier `check` uses. `ci.yml` keeps the PATH-strip prologue and the claude-absence assertion, then calls the entry. Now a clean run that crashes only at teardown is treated as a pass, identically to `check`.

## Validation (local)
- typecheck / lint / doing-it-wrong: clean
- `bun scripts/_runner/no-claude-test.ts`: **8798 pass / 0 fail / exit 0**
- `am-i-done --ci --only coverage`: **PASS** (entry shim excluded from per-file ratchet — process-boundary shim like `scripts/release.ts`; its logic is covered by `ci-steps.spec.ts`)

## Follow-up
Once green, **promote check-no-claude to required** (or add a main-branch health probe) — a non-required check rotted red for two days with no escalation because auto-merge ignores it. Tracked in #2641.

🤖 Generated with [Claude Code](https://claude.com/claude-code)