### PR TITLE
fix(ci): split daemon tests out of check-no-claude full-suite run (#2641)

### DIFF
--- a/scripts/_runner/no-claude-test.ts
+++ b/scripts/_runner/no-claude-test.ts
@@ -1,30 +1,52 @@
 /**
  * Entry point for the `check-no-claude` CI job: run the full test suite with
- * the #1004/#1419 crash-after-pass tolerance, claude-free PATH.
+ * the #1004/#1419 crash-after-pass tolerance, on a claude-free PATH.
  *
  * The workflow strips every directory containing a `claude` binary from PATH
  * (so a test that secretly shells out to `claude` fails loudly) and then runs
- * this script. We re-use `bunTestWithCrashTolerance` — the exact junit-based
- * classifier the required `check` job uses — instead of the old raw `bun test`
- * + `grep "^ 0 fail$"` bash, which leaked Bun's post-teardown SIGTERM (exit
- * 143) as a red build: the grep needs the summary line, but a teardown crash
- * can SIGTERM the worker AFTER all tests pass but BEFORE the summary flushes.
- * The junit reporter records `failures="0"` on disk and survives that crash;
- * the `ZERO_FAIL_RE` stdout fallback covers the case where even the file is
- * lost (#2641).
+ * this script.
  *
- * This is a process-boundary shim (spawns `bun test`, then `process.exit`) and
- * is therefore excluded from the per-file coverage ratchet, like
- * `scripts/release.ts`. The behaviour it depends on lives in
- * `bunTestWithCrashTolerance` and is fully covered by `ci-steps.spec.ts`.
+ * Why two batches instead of one `bun test`: the daemon tests spawn real
+ * daemons + subprocesses and destabilise Bun 1.3.14's end-of-process teardown.
+ * Running the whole suite (daemon + non-daemon) in a single invocation tipped
+ * the CI runner into a late-run SIGTERM ~96% through — 8586/8798 tests passed,
+ * 0 failed, then the process was killed before flushing any summary, so neither
+ * the junit file nor the `0 fail` stdout line existed for the classifier to
+ * trust (#2641). The required `check` job never hit this because it already
+ * splits the daemon tests into their own invocation. We mirror that split here
+ * while still covering the *whole* suite: batch 1 is everything EXCEPT the
+ * daemon paths (via --path-ignore-patterns), batch 2 is the daemon paths.
+ *
+ * Both batches go through `bunTestWithCrashTolerance` — the same junit-based
+ * classifier `check` uses — so a clean run that crashes only at teardown is a
+ * pass. This is a process-boundary shim (spawns `bun test`, then process.exit)
+ * and is excluded from the per-file coverage ratchet, like scripts/release.ts;
+ * its behaviour lives in bunTestWithCrashTolerance, covered by ci-steps.spec.ts.
  */
+import { DAEMON_TEST_PATHS } from "../am-i-done";
 import { bunTestWithCrashTolerance } from "./ci-steps";
 import { createConsoleLogger } from "./logger";
 
-// Empty `paths` → whole suite (one invocation, matching the job's original
-// scope). retryOn132 because the suite includes the daemon tests, which
-// historically need the SIGILL retry.
-const step = bunTestWithCrashTolerance({ paths: [], logName: "test_no_claude", retryOn132: true });
-const result = await step({ args: [], env: process.env, logger: createConsoleLogger() });
-const success = typeof result === "boolean" ? result : (result?.success ?? false);
-process.exit(success ? 0 : 1);
+function ok(result: Awaited<ReturnType<ReturnType<typeof bunTestWithCrashTolerance>>>): boolean {
+  return typeof result === "boolean" ? result : (result?.success ?? false);
+}
+
+const logger = createConsoleLogger();
+const opts = { args: [] as string[], env: process.env, logger };
+
+// Daemon dirs → "<dir>/**" globs; daemon spec files stay literal.
+const daemonIgnores = DAEMON_TEST_PATHS.map((p) => (p.endsWith(".spec.ts") ? p : `${p}/**`)).map(
+  (p) => `--path-ignore-patterns=${p}`,
+);
+
+// Batch 1: the whole suite minus the daemon tests.
+const nonDaemon = bunTestWithCrashTolerance({ paths: daemonIgnores, logName: "test_no_claude", retryOn132: false });
+if (!ok(await nonDaemon(opts))) process.exit(1);
+
+// Batch 2: the daemon tests (sequential; SIGILL retry, as `check` does).
+const daemon = bunTestWithCrashTolerance({
+  paths: DAEMON_TEST_PATHS,
+  logName: "test_no_claude_daemon",
+  retryOn132: true,
+});
+process.exit(ok(await daemon(opts)) ? 0 : 1);

--- a/scripts/am-i-done.ts
+++ b/scripts/am-i-done.ts
@@ -138,7 +138,11 @@ const NON_DAEMON_TEST_PATHS = [
   "test/integration.spec.ts",
 ];
 
-const DAEMON_TEST_PATHS = [
+// Exported so the check-no-claude entry (scripts/_runner/no-claude-test.ts) can
+// split the same daemon batch out of its full-suite run — the daemon tests spawn
+// real daemons and destabilise Bun's end-of-process teardown, so they must not
+// share an invocation with the rest of the suite (#2641).
+export const DAEMON_TEST_PATHS = [
   "packages/daemon",
   "test/cli-orchestration.spec.ts",
   "test/daemon-integration.spec.ts",


### PR DESCRIPTION
## Follow-up to #2642
#2642 routed check-no-claude through `bunTestWithCrashTolerance` but the job **stayed red**. Root cause is sharper than the classifier: check-no-claude runs the *whole* suite (daemon + non-daemon) in **one** `bun test`, which tips Bun 1.3.14's end-of-process teardown into a **late-run SIGTERM at ~96%** (8586/8798 passed, **0 failed**, then the process was killed before flushing any summary — so neither the junit file nor the `0 fail` stdout line existed for the classifier to trust).

The required `check` job never hit this because it **splits the daemon tests** (they spawn real daemons + subprocesses and destabilise teardown) into their own invocation.

## Fix
Mirror `check`'s split, while still covering the whole suite:
- **batch 1**: everything *except* the daemon paths (`--path-ignore-patterns`)
- **batch 2**: the daemon paths (sequential + SIGILL retry — identical to `check`)

`DAEMON_TEST_PATHS` is now exported from `am-i-done.ts` so both jobs share one definition (no drift).

## Validation (local)
`bun scripts/_runner/no-claude-test.ts`:
- batch 1: **6103 tests / 238 files / 0 fail**
- batch 2: **2711 tests / 106 files / 0 fail**
- union = **8814 tests / 344 files** = the full suite; **exit 0**

typecheck / lint / rules: clean.

Closes the regression tracked in #2641.