### PR TITLE
fix: stop test-suite resource leaks destabilizing the shared CI run (#2641)

### DIFF
--- a/agent-grid/src/isolation.spec.ts
+++ b/agent-grid/src/isolation.spec.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { activeEnvCount, cleanGitEnv, createIsolatedEnv, onInterrupt } from "./isolation";
+import { activeEnvCount, cleanGitEnv, createIsolatedEnv } from "./isolation";
 
 function gitLog(cwd: string): string {
   const r = spawnSync("git", ["log", "--oneline"], { cwd, stdio: ["ignore", "pipe", "ignore"], env: cleanGitEnv() });
@@ -131,11 +131,14 @@ describe("createIsolatedEnv", () => {
       expect(env.GIT_CONFIG_GLOBAL).toBe("/dev/null");
       expect(env.GIT_CONFIG_SYSTEM).toBe("/dev/null");
     } finally {
-      if (original === undefined) process.env.GIT_DIR = undefined;
+      // biome-ignore lint/performance/noDelete: env var must be absent, not "undefined" (the string)
+      if (original === undefined) delete process.env.GIT_DIR;
       else process.env.GIT_DIR = original;
-      if (originalIdx === undefined) process.env.GIT_INDEX_FILE = undefined;
+      // biome-ignore lint/performance/noDelete: env var must be absent, not "undefined" (the string)
+      if (originalIdx === undefined) delete process.env.GIT_INDEX_FILE;
       else process.env.GIT_INDEX_FILE = originalIdx;
-      if (originalWork === undefined) process.env.GIT_WORK_TREE = undefined;
+      // biome-ignore lint/performance/noDelete: env var must be absent, not "undefined" (the string)
+      if (originalWork === undefined) delete process.env.GIT_WORK_TREE;
       else process.env.GIT_WORK_TREE = originalWork;
     }
   });
@@ -150,7 +153,8 @@ describe("createIsolatedEnv", () => {
       expect(existsSync(join(env.dir, ".git"))).toBe(true);
       expect(gitStatus(env.dir)).toBe("");
     } finally {
-      if (original === undefined) process.env.GIT_DIR = undefined;
+      // biome-ignore lint/performance/noDelete: env var must be absent, not "undefined" (the string)
+      if (original === undefined) delete process.env.GIT_DIR;
       else process.env.GIT_DIR = original;
     }
   });
@@ -166,58 +170,5 @@ describe("createIsolatedEnv", () => {
     }
 
     expect(activeEnvCount()).toBe(before);
-  });
-
-  // Regression for the #2586 SIGTERM-immortality bug: a process that imported
-  // createIsolatedEnv() (which installs the interrupt handlers) MUST still die
-  // on SIGTERM. The original handler re-raised the signal into a listener it
-  // failed to remove, looping forever — only SIGKILL stopped it, which is what
-  // made bun test-workers look "wedged" and hung check-no-claude for 96 min.
-  test("a process importing createIsolatedEnv still dies on SIGTERM (not immortal)", async () => {
-    const isoPath = join(import.meta.dir, "isolation.ts");
-    const proc = Bun.spawn({
-      cmd: [
-        "bun",
-        "-e",
-        `const { createIsolatedEnv } = await import(${JSON.stringify(isoPath)});createIsolatedEnv().cleanup();console.log("READY");await new Promise(() => {});`,
-      ],
-      stdout: "pipe",
-      stderr: "ignore",
-    });
-
-    // Wait for the child to confirm handlers are installed, then SIGTERM it.
-    const reader = proc.stdout.getReader();
-    await reader.read();
-    proc.kill("SIGTERM");
-
-    // A correct handler exits promptly. An immortal process never resolves
-    // `exited`; race a deadline and treat the timeout as the failure signal.
-    const DEADLINE_MS = 3_000;
-    const verdict = await Promise.race([
-      proc.exited.then(() => "exited" as const),
-      Bun.sleep(DEADLINE_MS).then(() => "immortal" as const),
-    ]);
-    if (verdict === "immortal") proc.kill("SIGKILL");
-    expect(verdict).toBe("exited");
-  });
-
-  // In-process coverage for the handler body that the subprocess test above
-  // exercises but cannot credit (coverage instruments only the parent). The
-  // injected `terminate` stands in for `process.kill(self, signal)` so the
-  // cleanup + re-raise path runs without killing the test runner — this is
-  // the exact code that was SIGTERM-immortal in #2586.
-  test("onInterrupt cleans up active envs then re-raises the signal", () => {
-    const env = createIsolatedEnv();
-    dirs.push(env.dir);
-    expect(existsSync(env.dir)).toBe(true);
-
-    let raised: NodeJS.Signals | undefined;
-    onInterrupt("SIGTERM", (s) => {
-      raised = s;
-    });
-
-    expect(activeEnvCount()).toBe(0); // cleanupAllEnvs swept the active set
-    expect(existsSync(env.dir)).toBe(false); // and removed the directory
-    expect(raised).toBe("SIGTERM"); // then re-raised with the original signal
   });
 });

--- a/agent-grid/src/isolation.ts
+++ b/agent-grid/src/isolation.ts
@@ -8,52 +8,6 @@ const SEED_CONTENT = "# agent-grid test seed\n";
 const SEED_MESSAGE = "seed";
 
 const activeEnvs = new Set<string>();
-let handlersInstalled = false;
-
-function cleanupAllEnvs(): void {
-  for (const dir of activeEnvs) {
-    try {
-      rmSync(dir, { recursive: true, force: true });
-    } catch {
-      // best-effort on interrupt
-    }
-  }
-  activeEnvs.clear();
-}
-
-/**
- * Interrupt handler body: clean up active environments, then re-raise the
- * signal so the process terminates with its default disposition. `terminate`
- * is injectable so tests can exercise the cleanup + re-raise path without the
- * real `process.kill(self, signal)` tearing down the test runner.
- *
- * Exported for testing.
- */
-export function onInterrupt(
-  signal: NodeJS.Signals,
-  terminate: (s: NodeJS.Signals) => void = (s) => process.kill(process.pid, s),
-): void {
-  cleanupAllEnvs();
-  terminate(signal);
-}
-
-function installInterruptHandlers(): void {
-  if (handlersInstalled) return;
-  handlersInstalled = true;
-
-  // Use `once`: Node removes the listener *before* invoking it, so the
-  // subsequent re-raise (in onInterrupt) hits the default disposition and the
-  // process actually terminates. The previous `on(...)` +
-  // `removeListener(signal, onSignal)` form passed the wrong reference (the
-  // registered listener was the arrow wrapper, not `onSignal`), so removal was
-  // a no-op and `process.kill(self, signal)` re-entered the still-installed
-  // handler forever — the process became immortal under SIGINT/SIGTERM (#2586
-  // regression; only SIGKILL stopped it, which is what made test workers look
-  // "wedged").
-  for (const signal of ["SIGINT", "SIGTERM"] as const) {
-    process.once(signal, () => onInterrupt(signal));
-  }
-}
 
 export function cleanGitEnv(): Record<string, string> {
   const env: Record<string, string> = {};
@@ -86,7 +40,7 @@ function git(cwd: string, args: string[]): void {
 export interface IsolatedEnv {
   /** Absolute path to the isolated directory (git work tree root). */
   dir: string;
-  /** Remove the directory and deregister from interrupt cleanup. */
+  /** Remove the directory and deregister it from the active-env set. */
   cleanup(): void;
   [Symbol.dispose](): void;
 }
@@ -96,12 +50,13 @@ export interface IsolatedEnv {
  * a single seed commit. The returned object supports both explicit
  * `cleanup()` and `using` via `Symbol.dispose`.
  *
- * Interrupt handlers (SIGINT/SIGTERM) are installed once per process to
- * clean up any active environments on unexpected exit.
+ * No process-wide signal handler is installed: tmpdir cleanup is handled by
+ * explicit `cleanup()` / `Symbol.dispose` / test `afterEach`, and the OS
+ * reclaims `/tmp` on process exit. A library used under `bun test` must never
+ * install global SIGINT/SIGTERM handlers on the shared runner (that caused the
+ * #2586 SIGTERM-immortality bug).
  */
 export function createIsolatedEnv(): IsolatedEnv {
-  installInterruptHandlers();
-
   const dir = mkdtempSync(join(tmpdir(), "agent-grid-"));
 
   activeEnvs.add(dir);

--- a/scripts/check-stale-todos.spec.ts
+++ b/scripts/check-stale-todos.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { beforeEach, describe, expect, it } from "bun:test";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -132,27 +132,21 @@ describe("scanFiles", () => {
 });
 
 describe("checkRefs", () => {
-  const stdoutWrite = process.stdout.write.bind(process.stdout);
-  const stderrWrite = process.stderr.write.bind(process.stderr);
   let stdoutBuf: string;
   let stderrBuf: string;
+  // Injected sinks — capture into local buffers instead of monkeypatching the
+  // process-global streams (which would swallow other modules' output in the
+  // shared `bun test` process and break the stream write-callback contract).
+  const out = (s: string) => {
+    stdoutBuf += s;
+  };
+  const err = (s: string) => {
+    stderrBuf += s;
+  };
 
   beforeEach(() => {
     stdoutBuf = "";
     stderrBuf = "";
-    process.stdout.write = ((chunk: string) => {
-      stdoutBuf += chunk;
-      return true;
-    }) as typeof process.stdout.write;
-    process.stderr.write = ((chunk: string) => {
-      stderrBuf += chunk;
-      return true;
-    }) as typeof process.stderr.write;
-  });
-
-  afterEach(() => {
-    process.stdout.write = stdoutWrite;
-    process.stderr.write = stderrWrite;
   });
 
   const ref = (issueNumbers: number[], file = "f.ts", line = 1): TodoRef => ({
@@ -163,33 +157,33 @@ describe("checkRefs", () => {
   });
 
   it("returns 0 with no refs", async () => {
-    const code = await checkRefs([], async () => "OPEN");
+    const code = await checkRefs([], async () => "OPEN", out, err);
     expect(code).toBe(0);
     expect(stdoutBuf).toContain("no dotw-todo issue references found");
   });
 
   it("returns 1 when all issues are unreachable (fail-closed)", async () => {
-    const code = await checkRefs([ref([100])], async () => null);
+    const code = await checkRefs([ref([100])], async () => null, out, err);
     expect(code).toBe(1);
     expect(stderrBuf).toContain("could not reach GitHub API");
     expect(stderrBuf).toContain("1 issue unreachable");
   });
 
   it("returns 1 when a referenced issue is CLOSED", async () => {
-    const code = await checkRefs([ref([200], "pkg/foo.ts", 5)], async (n) => (n === 200 ? "CLOSED" : "OPEN"));
+    const code = await checkRefs([ref([200], "pkg/foo.ts", 5)], async (n) => (n === 200 ? "CLOSED" : "OPEN"), out, err);
     expect(code).toBe(1);
     expect(stderrBuf).toContain("#200 (CLOSED)");
     expect(stderrBuf).toContain("pkg/foo.ts:5");
   });
 
   it("returns 0 when all referenced issues are OPEN", async () => {
-    const code = await checkRefs([ref([300])], async () => "OPEN");
+    const code = await checkRefs([ref([300])], async () => "OPEN", out, err);
     expect(code).toBe(0);
     expect(stdoutBuf).toContain("all referenced issues open");
   });
 
   it("warns but continues when some (not all) issues are unreachable", async () => {
-    const code = await checkRefs([ref([400]), ref([401])], async (n) => (n === 400 ? null : "OPEN"));
+    const code = await checkRefs([ref([400]), ref([401])], async (n) => (n === 400 ? null : "OPEN"), out, err);
     expect(code).toBe(0);
     expect(stderrBuf).toContain("#400");
     expect(stderrBuf).toContain("skipped");
@@ -201,12 +195,12 @@ describe("checkRefs", () => {
       calls.push(n);
       return "OPEN";
     };
-    await checkRefs([ref([500]), ref([500, 501])], fetcher);
+    await checkRefs([ref([500]), ref([500, 501])], fetcher, out, err);
     expect(calls.sort()).toEqual([500, 501]);
   });
 
   it("reports multiple stale refs in one run", async () => {
-    const code = await checkRefs([ref([600], "a.ts", 10), ref([601], "b.ts", 20)], async () => "CLOSED");
+    const code = await checkRefs([ref([600], "a.ts", 10), ref([601], "b.ts", 20)], async () => "CLOSED", out, err);
     expect(code).toBe(1);
     expect(stderrBuf).toContain("2 dotw-todo comments reference closed issues");
     expect(stderrBuf).toContain("a.ts:10");

--- a/scripts/check-stale-todos.ts
+++ b/scripts/check-stale-todos.ts
@@ -91,9 +91,24 @@ export async function fetchIssueStateViaGh(issueNumber: number): Promise<string 
   }
 }
 
-export async function checkRefs(refs: TodoRef[], fetcher: IssueFetcher): Promise<number> {
+/** Output sink — defaults write to the process streams; tests inject a capturing buffer. */
+export type Sink = (s: string) => void;
+
+const defaultOut: Sink = (s) => {
+  process.stdout.write(s);
+};
+const defaultErr: Sink = (s) => {
+  process.stderr.write(s);
+};
+
+export async function checkRefs(
+  refs: TodoRef[],
+  fetcher: IssueFetcher,
+  out: Sink = defaultOut,
+  err: Sink = defaultErr,
+): Promise<number> {
   if (refs.length === 0) {
-    process.stdout.write("✓ no dotw-todo issue references found\n");
+    out("✓ no dotw-todo issue references found\n");
     return 0;
   }
 
@@ -112,37 +127,31 @@ export async function checkRefs(refs: TodoRef[], fetcher: IssueFetcher): Promise
   }
 
   if (unreachable.size === uniqueNumbers.size) {
-    process.stderr.write(
+    err(
       `✗ could not reach GitHub API — cannot verify issue states (${uniqueNumbers.size} issue${uniqueNumbers.size === 1 ? "" : "s"} unreachable)\n`,
     );
     return 1;
   }
 
   if (unreachable.size > 0) {
-    process.stderr.write(
-      `⚠ could not fetch state for issue(s): ${[...unreachable].map((n) => `#${n}`).join(", ")} — skipped\n`,
-    );
+    err(`⚠ could not fetch state for issue(s): ${[...unreachable].map((n) => `#${n}`).join(", ")} — skipped\n`);
   }
 
   const stale = refs.filter((r) => r.issueNumbers.some((n) => closedIssues.has(n)));
   if (stale.length === 0) {
-    process.stdout.write(
-      `✓ ${refs.length} dotw-todo ref${refs.length === 1 ? "" : "s"} checked — all referenced issues open\n`,
-    );
+    out(`✓ ${refs.length} dotw-todo ref${refs.length === 1 ? "" : "s"} checked — all referenced issues open\n`);
     return 0;
   }
 
-  process.stderr.write(
+  err(
     `\n✗ ${stale.length} dotw-todo comment${stale.length === 1 ? "" : "s"} reference closed issue${stale.length === 1 ? "" : "s"}:\n\n`,
   );
   for (const ref of stale) {
     const closed = ref.issueNumbers.filter((n) => closedIssues.has(n));
-    process.stderr.write(`  ${ref.file}:${ref.line}  ${closed.map((n) => `#${n} (CLOSED)`).join(", ")}\n`);
-    process.stderr.write(`    ${ref.snippet}\n\n`);
+    err(`  ${ref.file}:${ref.line}  ${closed.map((n) => `#${n} (CLOSED)`).join(", ")}\n`);
+    err(`    ${ref.snippet}\n\n`);
   }
-  process.stderr.write(
-    "fix: remove the violation (and its dotw-todo), or reopen/file a successor issue and update the reference\n",
-  );
+  err("fix: remove the violation (and its dotw-todo), or reopen/file a successor issue and update the reference\n");
   return 1;
 }
 

--- a/scripts/install-agent.spec.ts
+++ b/scripts/install-agent.spec.ts
@@ -308,10 +308,11 @@ describe("installFromArchive", () => {
 
     const tgzPath = join(gridDir, "binaries", `${binaryName}.tgz`);
     const proc = Bun.spawn(["tar", "czf", tgzPath, "-C", tmpDir, binaryName], { stdout: "ignore", stderr: "pipe" });
+    // Drain stderr unconditionally so its fd is released on success too.
+    const tarStderr = await new Response(proc.stderr).text();
     const exitCode = await proc.exited;
     if (exitCode !== 0) {
-      const stderr = await new Response(proc.stderr).text();
-      throw new Error(`tar failed (exit ${exitCode}): ${stderr.trim()}`);
+      throw new Error(`tar failed (exit ${exitCode}): ${tarStderr.trim()}`);
     }
     if (!existsSync(tgzPath)) {
       throw new Error(`tar produced no output at ${tgzPath}`);
@@ -493,10 +494,11 @@ describe("installFromRegistry", () => {
       stdout: "ignore",
       stderr: "pipe",
     });
+    // Drain stderr unconditionally so its fd is released on success too.
+    const tarStderr = await new Response(proc.stderr).text();
     const exitCode = await proc.exited;
     if (exitCode !== 0) {
-      const stderr = await new Response(proc.stderr).text();
-      throw new Error(`tar failed (exit ${exitCode}): ${stderr.trim()}`);
+      throw new Error(`tar failed (exit ${exitCode}): ${tarStderr.trim()}`);
     }
     if (!existsSync(tgzPath)) {
       throw new Error(`tar produced no output at ${tgzPath}`);
@@ -635,10 +637,11 @@ describe("installAgent", () => {
 
     const tgzPath = join(gridDir, "binaries", `${binaryName}.tgz`);
     const proc = Bun.spawn(["tar", "czf", tgzPath, "-C", tmpDir, binaryName], { stdout: "ignore", stderr: "pipe" });
+    // Drain stderr unconditionally so its fd is released on success too.
+    const tarStderr = await new Response(proc.stderr).text();
     const exitCode = await proc.exited;
     if (exitCode !== 0) {
-      const stderr = await new Response(proc.stderr).text();
-      throw new Error(`tar failed (exit ${exitCode}): ${stderr.trim()}`);
+      throw new Error(`tar failed (exit ${exitCode}): ${tarStderr.trim()}`);
     }
     if (!existsSync(tgzPath)) {
       throw new Error(`tar produced no output at ${tgzPath}`);
@@ -703,10 +706,11 @@ providers:
 
     const tgzPath = join(gridDir, "binaries", `${binaryName}.tgz`);
     const proc = Bun.spawn(["tar", "czf", tgzPath, "-C", tmpDir, binaryName], { stdout: "ignore", stderr: "pipe" });
+    // Drain stderr unconditionally so its fd is released on success too.
+    const tarStderr = await new Response(proc.stderr).text();
     const exitCode = await proc.exited;
     if (exitCode !== 0) {
-      const stderr = await new Response(proc.stderr).text();
-      throw new Error(`tar failed (exit ${exitCode}): ${stderr.trim()}`);
+      throw new Error(`tar failed (exit ${exitCode}): ${tarStderr.trim()}`);
     }
     if (!existsSync(tgzPath)) {
       throw new Error(`tar produced no output at ${tgzPath}`);

--- a/scripts/install-agent.ts
+++ b/scripts/install-agent.ts
@@ -227,14 +227,19 @@ export async function installFromRegistry(
       stdout: "pipe",
       stderr: "pipe",
     });
+    // Drain both piped streams unconditionally so their file descriptors are
+    // released on every path — not just the error branch.
+    const [packStdout, packStderr] = await Promise.all([
+      new Response(pack.stdout).text(),
+      new Response(pack.stderr).text(),
+    ]);
     const packExit = await pack.exited;
     if (packExit !== 0) {
-      const stderr = await new Response(pack.stderr).text();
-      deps.error(`registry: npm pack failed (exit ${packExit}): ${stderr.trim()}`);
+      deps.error(`registry: npm pack failed (exit ${packExit}): ${packStderr.trim()}`);
       return null;
     }
 
-    const packOut = (await new Response(pack.stdout).text()).trim();
+    const packOut = packStdout.trim();
     const tgzName = packOut.split("\n").pop()?.trim();
     if (!tgzName) {
       deps.error("registry: npm pack produced no output");
@@ -252,10 +257,11 @@ export async function installFromRegistry(
       stdout: "ignore",
       stderr: "pipe",
     });
+    // Drain stderr unconditionally so its fd is released on success too.
+    const extractStderr = await new Response(extract.stderr).text();
     const extractExit = await extract.exited;
     if (extractExit !== 0) {
-      const stderr = await new Response(extract.stderr).text();
-      deps.error(`registry: extraction failed: ${stderr.trim()}`);
+      deps.error(`registry: extraction failed: ${extractStderr.trim()}`);
       return null;
     }
 
@@ -341,10 +347,11 @@ export async function installFromArchive(
     stdout: "ignore",
     stderr: "pipe",
   });
+  // Drain stderr unconditionally so its fd is released on success too.
+  const extractStderr = await new Response(extract.stderr).text();
   const extractExit = await extract.exited;
   if (extractExit !== 0) {
-    const stderr = await new Response(extract.stderr).text();
-    throw new Error(`Archive extraction failed (exit ${extractExit}): ${stderr.trim()}`);
+    throw new Error(`Archive extraction failed (exit ${extractExit}): ${extractStderr.trim()}`);
   }
 
   const expectedBinaryName = `${provider}-${entry.version}`;

--- a/scripts/rules/_engine/file-loader.ts
+++ b/scripts/rules/_engine/file-loader.ts
@@ -53,10 +53,39 @@ export interface LoadOptions {
   roots?: string[];
   /** Substring filter on relative path. Empty = no filter. */
   filter?: string;
+  /**
+   * Bypass the in-process memo and re-read from disk. Source files don't
+   * change within a single run, so callers (the rule sweep, the spec) hit
+   * the cache; set this only when you genuinely need a fresh read.
+   */
+  noCache?: boolean;
 }
 
-export async function loadFiles({ repoRoot, roots, filter }: LoadOptions): Promise<Map<string, FileMeta>> {
+/**
+ * Memoizes scans within a process. `doing-it-wrong.spec.ts` invokes the
+ * sweep many times over the same tree; without this each call re-reads the
+ * whole source tree, a large peak-memory contributor under shared `bun test`.
+ * Keyed on the resolved (repoRoot, roots, filter) so different queries can't
+ * collide. Reset via `resetFileCache()` if a test mutates the tree between calls.
+ */
+const cache = new Map<string, Map<string, FileMeta>>();
+
+function cacheKey(repoRoot: string, scanRoots: string[], filter: string | undefined): string {
+  return JSON.stringify({ repoRoot, roots: scanRoots, filter: filter ?? "" });
+}
+
+/** Clear the memoized scan results. For tests that change files on disk mid-run. */
+export function resetFileCache(): void {
+  cache.clear();
+}
+
+export async function loadFiles({ repoRoot, roots, filter, noCache }: LoadOptions): Promise<Map<string, FileMeta>> {
   const scanRoots = roots ?? ["packages", "scripts", "test"];
+  const key = cacheKey(repoRoot, scanRoots, filter);
+  if (!noCache) {
+    const hit = cache.get(key);
+    if (hit) return hit;
+  }
   const out = new Map<string, FileMeta>();
   for (const root of scanRoots) {
     const cwd = join(repoRoot, root);
@@ -85,5 +114,6 @@ export async function loadFiles({ repoRoot, roots, filter }: LoadOptions): Promi
       });
     }
   }
+  if (!noCache) cache.set(key, out);
   return out;
 }

--- a/scripts/test-failure-log.spec.ts
+++ b/scripts/test-failure-log.spec.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import {
   type TestFailureEntry,
   appendFailures,
-  closeDb,
+  closeAllDbs,
   getDbPath,
   getGitContext,
   logTestRun,
@@ -37,13 +37,11 @@ function makeEntry(overrides: Partial<TestFailureEntry> = {}): TestFailureEntry 
 
 describe("test-failure-log", () => {
   const tmpDirs: string[] = [];
-  const dbPaths: string[] = [];
 
   afterEach(() => {
-    for (const p of dbPaths) {
-      closeDb(p);
-    }
-    dbPaths.length = 0;
+    // Close ALL cached handles — including any opened by a test that threw
+    // before registering its path. Releases WAL/SHM sidecar file descriptors.
+    closeAllDbs();
     for (const dir of tmpDirs) {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -53,9 +51,7 @@ describe("test-failure-log", () => {
   function makeDbPath(): string {
     const dir = makeTmpDir();
     tmpDirs.push(dir);
-    const dbPath = join(dir, "test-failures.db");
-    dbPaths.push(dbPath);
-    return dbPath;
+    return join(dir, "test-failures.db");
   }
 
   describe("appendFailures + readFailures", () => {
@@ -78,7 +74,6 @@ describe("test-failure-log", () => {
       const dir = makeTmpDir();
       tmpDirs.push(dir);
       const dbPath = join(dir, "nested", "deep", "test-failures.db");
-      dbPaths.push(dbPath);
 
       appendFailures([makeEntry()], dbPath);
       const entries = readFailures(dbPath);

--- a/scripts/test-failure-log.ts
+++ b/scripts/test-failure-log.ts
@@ -84,6 +84,19 @@ export function closeDb(dbPath: string): void {
   }
 }
 
+/**
+ * Close and remove ALL cached database handles (for testing cleanup).
+ * Releases the WAL/SHM sidecar file descriptors held by every open handle.
+ * Tests should call this in `afterEach` so a handle opened by a test that
+ * throws before registering its path is still released.
+ */
+export function closeAllDbs(): void {
+  for (const db of dbCache.values()) {
+    db.close();
+  }
+  dbCache.clear();
+}
+
 /** Resolve the database path from env or default */
 export function getDbPath(): string {
   const dir = process.env.MCP_CLI_DIR;

--- a/scripts/test-failures.spec.ts
+++ b/scripts/test-failures.spec.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { type TestFailureEntry, appendFailures, closeDb, readFailures } from "./test-failure-log";
+import { type TestFailureEntry, appendFailures, closeAllDbs, readFailures } from "./test-failure-log";
 import { formatOutput, parseArgs } from "./test-failures";
 
 function makeTmpDir(): string {
@@ -29,13 +29,11 @@ function makeEntry(overrides: Partial<TestFailureEntry> = {}): TestFailureEntry 
 
 describe("test-failures CLI", () => {
   const tmpDirs: string[] = [];
-  const dbPaths: string[] = [];
 
   afterEach(() => {
-    for (const p of dbPaths) {
-      closeDb(p);
-    }
-    dbPaths.length = 0;
+    // Close ALL cached handles — including any opened by a test that threw
+    // before registering its path. Releases WAL/SHM sidecar file descriptors.
+    closeAllDbs();
     for (const dir of tmpDirs) {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -45,9 +43,7 @@ describe("test-failures CLI", () => {
   function makeDbPath(): string {
     const dir = makeTmpDir();
     tmpDirs.push(dir);
-    const dbPath = join(dir, "test-failures.db");
-    dbPaths.push(dbPath);
-    return dbPath;
+    return join(dir, "test-failures.db");
   }
 
   describe("parseArgs", () => {


### PR DESCRIPTION
## What
Adversarial review (deliberately given **no** "size threshold" theory) of the files `check-no-claude` uniquely exercises — the #2613 coverage gap — found **real defects** that accumulate across the long shared `bun test` process and trip the Linux runner's limits. The OS kills the process near the end with **zero assertion failures** (passes on macOS and in isolation). The "~97% death point" is just where the cap is crossed — not a magic number of tests.

## Fixes
- **agent-grid/src/isolation.ts** — remove the process-global SIGINT/SIGTERM handler install. It was the #2586 immortality origin **and** a shared-runner hijack, and in `main` nothing calls `createIsolatedEnv` yet (only a barrel re-export) — pure harm. tmpdir cleanup stays via `Symbol.dispose` / `cleanup()` / `afterEach`. Spec: drop the now-moot immortality + onInterrupt tests; **fix env restoration** to `delete process.env.X` instead of `= undefined` (which set the string `"undefined"` and poisoned every later git-touching test).
- **scripts/rules/_engine/file-loader.ts** — memoize `loadFiles`; it read the **whole repo source tree into memory on every call** (`doing-it-wrong.spec.ts` calls it repeatedly). Major peak-RSS contributor. Adds optional `noCache` + `resetFileCache`.
- **scripts/check-stale-todos.{ts,spec.ts}** — stop monkeypatching `process.stdout/stderr.write` (process-global mutation in a shared runner); inject `out`/`err` sinks.
- **scripts/install-agent.{ts,spec.ts}** — drain spawned `tar`/`npm` stderr/stdout pipes on the **success** path too (were drained only on error → an fd leaked per successful spawn).
- **scripts/test-failure-log.ts + specs** — `closeAllDbs()` in `afterEach` closes all WAL SQLite handles even on throw (were leaking `-wal`/`-shm` fds).

Each is an independent real bug; together the likely cause of the full-suite / check-no-claude SIGTERM-at-~97%.

## Validation
Local `am-i-done --ci` (check) + coverage gate both green. The real proof is this PR's CI: if the leaks were the cause, **check-no-claude (full suite) goes green** for the first time since #2609.

Refs #2641. Unblocks completing the `check` coverage (#2613/#2625) without the bun teardown crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)