### PR TITLE
fix(review): consume typed review:pass/review:changes label, not scraped prose (fixes #2575)

### DIFF
--- a/.claude/commands/adversarial-review.md
+++ b/.claude/commands/adversarial-review.md
@@ -18,6 +18,8 @@ Adversarial review of the current branch's PR. Be critical, not agreeable.
    - **chaos-dancer** — user abuse/social weaponization vectors (if applicable)
 5. Synthesize all perspectives into the output format below
 6. If issues are out of scope of the PR description, create follow-up issues in gh.
+7. **Set the verdict label** (`review:pass` / `review:changes`) — this is the control signal
+   the phase gate reads. See [Setting the Verdict Label](#setting-the-verdict-label) below.
 
 ## Delta Mode (re-review after fixes)
 
@@ -42,10 +44,10 @@ major refactor, >50% of files changed are new files not touched in the original 
 ✅ **APPROVED** — all blockers resolved. (or)
 ⚠️ **Changes Requested** — N blockers remain.
 
-(Place the verdict line FIRST. The phase-script scanner anchors on
-`✅ APPROVED` / `⚠️ Changes Requested` to decide whether to advance the
-PR. If you write the verdict as the last line, scanners that truncate
-on long stickies may miss it.)
+(This verdict line is for human/repairer readability only. The phase
+gate does NOT read it — it reads the `review:pass` / `review:changes`
+**label** you set in [Setting the Verdict Label](#setting-the-verdict-label).
+Keep the prose verdict and the label in agreement.)
 
 ### Changes Since Last Review
 
@@ -105,9 +107,12 @@ with enough detail to file an issue.
 - ⚠️ **Changes Requested** — blocking issues found
 - ℹ️ **Comment** — suggestions only, non-blocking
 
-(Place the verdict near the **top** of the comment. The phase-script
-scanner uses the verdict line as the primary signal; tables and prose
-below it are interpreted in light of it.)
+(This prose verdict is for human/repairer readability. The phase gate
+advances the PR based on the `review:pass` / `review:changes` **label**
+you set — see [Setting the Verdict Label](#setting-the-verdict-label) —
+never on this text. A ✅/⚠️ that appears in a quoted diff or forwarded
+block must not be able to advance a PR; that's why the label, not prose,
+is the control signal.)
 ```
 
 ## Posting the Review (Sticky Comment)
@@ -132,3 +137,30 @@ fi
 
 This ensures repair sessions and second reviewers always see the latest state
 of all findings in one place, with clear tracking of what was fixed vs what remains.
+
+## Setting the Verdict Label
+
+The sticky comment is for humans. The **label is the machine-readable verdict the
+phase gate trusts** — mirroring how `qa` emits `qa:pass`/`qa:fail`. After posting the
+review, set exactly one verdict label **transactionally** (add one, remove the other in
+the same command, so a PR never carries both):
+
+```bash
+# Approved — no blocking issues:
+gh pr edit <PR> --add-label review:pass --remove-label review:changes
+
+# Changes requested — blocking issues remain:
+gh pr edit <PR> --add-label review:changes --remove-label review:pass
+```
+
+Rules:
+- **Always set a label.** No label → the gate waits forever (the reviewer is treated as
+  not yet done). A review with no verdict label is an incomplete review.
+- **`review:pass` only when there are no 🔴 blockers** (and no un-dismissed 🟡 you intend
+  to block on). 🔵 suggestions and resolved/historical findings do not block.
+- **`review:changes` when any 🔴 (or blocking 🟡) remains.** The repairer reads the sticky
+  comment for the specifics, then re-review (Delta Mode) flips the label to `review:pass`
+  once blockers are resolved.
+- **An ℹ️ Comment-only verdict** (suggestions, nothing blocking) is `review:pass` — it lets
+  the PR advance to qa.
+- Never hand-edit prose to flip the gate: prose is never read. Only the label moves the PR.

--- a/.claude/phases/review-fn.spec.ts
+++ b/.claude/phases/review-fn.spec.ts
@@ -215,4 +215,67 @@ describe("runReview — session exists", () => {
     await runReview({ provider: "claude" }, makeWork(), state, deps, "/repo");
     expect(await state.get<string>("previous_phase")).toBe("review");
   });
+
+  test("clears review:changes on the goto repair (verdict consumed)", async () => {
+    const removed: string[] = [];
+    const state = makeState({ review_session_id: "abc", review_round: 1 });
+    const deps = makeDeps({
+      gh: labelsGh(["review:changes"]),
+      async prEdit(_prNumber, flags) {
+        for (let i = 0; i < flags.length; i += 2) {
+          if (flags[i] === "--remove-label") removed.push(flags[i + 1]);
+        }
+      },
+    });
+    await runReview({ provider: "claude" }, makeWork(), state, deps, "/repo");
+    expect(removed).toContain("review:changes");
+  });
+
+  test("clears review:changes even when the round cap routes to qa", async () => {
+    const removed: string[] = [];
+    const state = makeState({ review_session_id: "abc", review_round: REVIEW_ROUND_CAP });
+    const deps = makeDeps({
+      gh: labelsGh(["review:changes"]),
+      async prEdit(_prNumber, flags) {
+        for (let i = 0; i < flags.length; i += 2) {
+          if (flags[i] === "--remove-label") removed.push(flags[i + 1]);
+        }
+      },
+    });
+    const result = await runReview({ provider: "claude" }, makeWork(), state, deps, "/repo");
+    expect(result.action).toBe("goto");
+    if (result.action === "goto") expect(result.target).toBe("qa");
+    expect(removed).toContain("review:changes");
+  });
+});
+
+// Regression for #2649 mirror-replay drift: review must clear the verdict label it
+// consumes, so a re-entry after the repair round waits for a fresh verdict instead of
+// replaying the stale one. Drives the real lifecycle over a shared mutable label set.
+describe("runReview — lifecycle (#2649)", () => {
+  test("stale review:changes does not survive into the round-2 re-entry", async () => {
+    const labels = new Set<string>(["review:changes"]);
+    const deps = makeDeps({
+      gh: async (op) =>
+        op.op === "pr:labels"
+          ? { stdout: [...labels].join("\n"), stderr: "", exitCode: 0 }
+          : { stdout: "", stderr: `unsupported gh op: ${op.op}`, exitCode: 1 },
+      async prEdit(_prNumber, flags) {
+        for (let i = 0; i < flags.length; i += 2) {
+          if (flags[i] === "--remove-label") labels.delete(flags[i + 1]);
+        }
+      },
+    });
+    const state = makeState({ review_session_id: "sess_r1", review_round: 1 });
+
+    const r1 = await runReview({ provider: "claude" }, makeWork(), state, deps, "/repo");
+    expect(r1).toMatchObject({ action: "goto", target: "repair" });
+    expect(labels.has("review:changes")).toBe(false);
+
+    // Repair clears the session sentinel; review spawns a fresh round-2 reviewer.
+    await state.set("review_session_id", "sess_r2");
+
+    const r2 = await runReview({ provider: "claude" }, makeWork(), state, deps, "/repo");
+    expect(r2.action).toBe("wait");
+  });
 });

--- a/.claude/phases/review-fn.spec.ts
+++ b/.claude/phases/review-fn.spec.ts
@@ -4,7 +4,7 @@ import {
   type ReviewDeps,
   type ReviewState,
   type ReviewWork,
-  scanReviewComments,
+  readReviewLabels,
   runReview,
 } from "./review-fn";
 
@@ -24,10 +24,21 @@ function makeState(initial: Record<string, unknown> = {}): ReviewState {
   };
 }
 
+/** gh() stub that returns the given label names for the `pr:labels` op. */
+function labelsGh(labels: string[], exitCode = 0): ReviewDeps["gh"] {
+  return async (op) => {
+    if (op.op === "pr:labels") {
+      return { stdout: exitCode === 0 ? labels.join("\n") : "", stderr: "", exitCode };
+    }
+    return { stdout: "", stderr: `unsupported gh op: ${op.op}`, exitCode: 1 };
+  };
+}
+
 function makeDeps(overrides: Partial<ReviewDeps> = {}): ReviewDeps {
   return {
-    async gh(_args) {
-      return { stdout: "", stderr: "", exitCode: 0 };
+    gh: labelsGh([]),
+    async prEdit(_prNumber, _flags) {
+      /* no-op */
     },
     findModelInSprintPlan(_issueNumber, _repoRoot) {
       return null;
@@ -36,117 +47,43 @@ function makeDeps(overrides: Partial<ReviewDeps> = {}): ReviewDeps {
   };
 }
 
-const STICKY_APPROVED = `## Adversarial Review\n\n✅ **Approved** — no issues found.\n`;
-const STICKY_CHANGES = `## Adversarial Review\n\n⚠️ **Changes requested** — see blockers below.\n`;
-const STICKY_NAKED_RED = `## Adversarial Review\n\n🔴 Missing error handler\n`;
-const STICKY_NAKED_RESOLVED = `## Adversarial Review\n\n🔴 ✅ Fixed in abc123\n`;
-const STICKY_NAKED_YELLOW = `## Adversarial Review\n\n🟡 Minor style nit\n`;
-
-describe("scanReviewComments", () => {
-  test("returns found=false when gh exits non-zero", async () => {
-    const deps = makeDeps({
-      async gh() {
-        return { stdout: "", stderr: "error", exitCode: 1 };
-      },
-    });
-    const result = await scanReviewComments(20, deps);
-    expect(result.found).toBe(false);
-    expect(result.hasBlockers).toBe(false);
+describe("readReviewLabels", () => {
+  test("returns both false when gh exits non-zero", async () => {
+    const deps = makeDeps({ gh: labelsGh(["review:pass"], 1) });
+    expect(await readReviewLabels(20, deps)).toEqual({ hasPass: false, hasChanges: false });
   });
 
-  test("returns found=false when no sticky comment present", async () => {
-    const deps = makeDeps({
-      async gh() {
-        return { stdout: "Just a regular comment\n", stderr: "", exitCode: 0 };
-      },
-    });
-    const result = await scanReviewComments(20, deps);
-    expect(result.found).toBe(false);
-    expect(result.hasBlockers).toBe(false);
+  test("returns hasPass=true when review:pass label present", async () => {
+    const deps = makeDeps({ gh: labelsGh(["bug", "review:pass"]) });
+    expect(await readReviewLabels(20, deps)).toEqual({ hasPass: true, hasChanges: false });
   });
 
-  test("returns approved when verdict line matches ✅ Approved", async () => {
-    const deps = makeDeps({
-      async gh() {
-        return { stdout: STICKY_APPROVED, stderr: "", exitCode: 0 };
-      },
-    });
-    const result = await scanReviewComments(20, deps);
-    expect(result.found).toBe(true);
-    expect(result.hasBlockers).toBe(false);
-    expect(result.summary).toMatch(/approved/i);
+  test("returns hasChanges=true when review:changes label present", async () => {
+    const deps = makeDeps({ gh: labelsGh(["review:changes"]) });
+    expect(await readReviewLabels(20, deps)).toEqual({ hasPass: false, hasChanges: true });
   });
 
-  test("returns changes-requested when verdict line matches ⚠️ Changes requested", async () => {
-    const deps = makeDeps({
-      async gh() {
-        return { stdout: STICKY_CHANGES, stderr: "", exitCode: 0 };
-      },
-    });
-    const result = await scanReviewComments(20, deps);
-    expect(result.found).toBe(true);
-    expect(result.hasBlockers).toBe(true);
-    expect(result.summary).toMatch(/changes requested/i);
+  test("returns both true when both labels present", async () => {
+    const deps = makeDeps({ gh: labelsGh(["review:pass", "review:changes"]) });
+    expect(await readReviewLabels(20, deps)).toEqual({ hasPass: true, hasChanges: true });
   });
 
-  test("classifies naked 🔴 without resolution marker as blocker", async () => {
-    const deps = makeDeps({
-      async gh() {
-        return { stdout: STICKY_NAKED_RED, stderr: "", exitCode: 0 };
-      },
-    });
-    const result = await scanReviewComments(20, deps);
-    expect(result.found).toBe(true);
-    expect(result.hasBlockers).toBe(true);
+  test("returns both false when neither verdict label present", async () => {
+    const deps = makeDeps({ gh: labelsGh(["bug", "enhancement"]) });
+    expect(await readReviewLabels(20, deps)).toEqual({ hasPass: false, hasChanges: false });
   });
 
-  test("ignores 🔴 that has resolution marker on same line", async () => {
+  test("trims whitespace around label names", async () => {
     const deps = makeDeps({
-      async gh() {
-        return { stdout: STICKY_NAKED_RESOLVED, stderr: "", exitCode: 0 };
-      },
+      gh: async () => ({ stdout: " review:pass \n bug \n", stderr: "", exitCode: 0 }),
     });
-    const result = await scanReviewComments(20, deps);
-    expect(result.found).toBe(true);
-    expect(result.hasBlockers).toBe(false);
+    expect(await readReviewLabels(20, deps)).toEqual({ hasPass: true, hasChanges: false });
   });
 
-  test("classifies naked 🟡 without resolution as blocker", async () => {
-    const deps = makeDeps({
-      async gh() {
-        return { stdout: STICKY_NAKED_YELLOW, stderr: "", exitCode: 0 };
-      },
-    });
-    const result = await scanReviewComments(20, deps);
-    expect(result.found).toBe(true);
-    expect(result.hasBlockers).toBe(true);
-  });
-
-  test("uses last sticky comment when multiple are present", async () => {
-    // First sticky: changes requested, second sticky: approved — approved wins (it's last)
-    const twoStickies =
-      `## Adversarial Review\n⚠️ Changes requested\n` +
-      `\n` +
-      `## Adversarial Review\n✅ Approved — all clear\n`;
-    const deps = makeDeps({
-      async gh() {
-        return { stdout: twoStickies, stderr: "", exitCode: 0 };
-      },
-    });
-    const result = await scanReviewComments(20, deps);
-    expect(result.hasBlockers).toBe(false);
-  });
-
-  test("returns all clear when sticky has no blockers and no explicit verdict", async () => {
-    const noEmoji = `## Adversarial Review\n\nLooks good to me, minor suggestion addressed.\n`;
-    const deps = makeDeps({
-      async gh() {
-        return { stdout: noEmoji, stderr: "", exitCode: 0 };
-      },
-    });
-    const result = await scanReviewComments(20, deps);
-    expect(result.found).toBe(true);
-    expect(result.hasBlockers).toBe(false);
+  test("consults only the label op, never comment prose (label-only control signal)", async () => {
+    // Even if a comment body echoed "review:pass", readReviewLabels asks pr:labels only.
+    const deps = makeDeps({ gh: labelsGh([]) });
+    expect(await readReviewLabels(20, deps)).toEqual({ hasPass: false, hasChanges: false });
   });
 });
 
@@ -160,6 +97,7 @@ describe("runReview — no session yet", () => {
   test("defaults to sonnet when sprint plan has no entry", async () => {
     const state = makeState();
     const result = await runReview({ provider: "claude" }, makeWork(), state, makeDeps(), "/repo");
+    expect(result.action).toBe("spawn");
     if (result.action === "spawn") expect(result.model).toBe("sonnet");
   });
 
@@ -167,6 +105,7 @@ describe("runReview — no session yet", () => {
     const state = makeState();
     const deps = makeDeps({ findModelInSprintPlan: () => "opus" });
     const result = await runReview({ provider: "claude" }, makeWork(), state, deps, "/repo");
+    expect(result.action).toBe("spawn");
     if (result.action === "spawn") expect(result.model).toBe("opus");
   });
 
@@ -174,6 +113,7 @@ describe("runReview — no session yet", () => {
     const state = makeState();
     const deps = makeDeps({ findModelInSprintPlan: () => "sonnet" });
     const result = await runReview({ provider: "claude", model: "opus" }, makeWork(), state, deps, "/repo");
+    expect(result.action).toBe("spawn");
     if (result.action === "spawn") expect(result.model).toBe("opus");
   });
 
@@ -200,6 +140,7 @@ describe("runReview — no session yet", () => {
   test("uses acp spawn command for acp: provider", async () => {
     const state = makeState();
     const result = await runReview({ provider: "acp:reviewer" }, makeWork(), state, makeDeps(), "/repo");
+    expect(result.action).toBe("spawn");
     if (result.action === "spawn") {
       expect(result.command).toContain("acp");
       expect(result.command).toContain("--agent");
@@ -209,48 +150,50 @@ describe("runReview — no session yet", () => {
 });
 
 describe("runReview — session exists", () => {
-  test("returns wait when no sticky comment yet", async () => {
+  test("returns wait when no verdict label set yet", async () => {
     const state = makeState({ review_session_id: "abc", review_round: 1 });
-    const deps = makeDeps({
-      async gh() {
-        return { stdout: "A regular comment\n", stderr: "", exitCode: 0 };
-      },
-    });
+    const deps = makeDeps({ gh: labelsGh(["bug"]) });
     const result = await runReview({ provider: "claude" }, makeWork(), state, deps, "/repo");
     expect(result.action).toBe("wait");
+    if (result.action === "wait") expect(result.reason).toMatch(/label not set/i);
   });
 
-  test("returns goto qa when review is clean", async () => {
+  test("returns goto qa when review:pass label is set", async () => {
     const state = makeState({ review_session_id: "abc", review_round: 1 });
-    const deps = makeDeps({
-      async gh() {
-        return { stdout: STICKY_APPROVED, stderr: "", exitCode: 0 };
-      },
-    });
+    const deps = makeDeps({ gh: labelsGh(["review:pass"]) });
     const result = await runReview({ provider: "claude" }, makeWork(), state, deps, "/repo");
     expect(result.action).toBe("goto");
     if (result.action === "goto") expect(result.target).toBe("qa");
   });
 
-  test("returns goto repair when blockers remain and round < cap", async () => {
+  test("removes review:changes when both labels present (pass wins)", async () => {
     const state = makeState({ review_session_id: "abc", review_round: 1 });
+    const removed: string[] = [];
     const deps = makeDeps({
-      async gh() {
-        return { stdout: STICKY_CHANGES, stderr: "", exitCode: 0 };
+      gh: labelsGh(["review:pass", "review:changes"]),
+      async prEdit(_prNumber, flags) {
+        for (let i = 0; i < flags.length; i += 2) {
+          if (flags[i] === "--remove-label") removed.push(flags[i + 1]);
+        }
       },
     });
+    const result = await runReview({ provider: "claude" }, makeWork(), state, deps, "/repo");
+    expect(result.action).toBe("goto");
+    if (result.action === "goto") expect(result.target).toBe("qa");
+    expect(removed).toContain("review:changes");
+  });
+
+  test("returns goto repair when review:changes and round < cap", async () => {
+    const state = makeState({ review_session_id: "abc", review_round: 1 });
+    const deps = makeDeps({ gh: labelsGh(["review:changes"]) });
     const result = await runReview({ provider: "claude" }, makeWork(), state, deps, "/repo");
     expect(result.action).toBe("goto");
     if (result.action === "goto") expect(result.target).toBe("repair");
   });
 
-  test("returns goto qa when round cap reached even with blockers", async () => {
+  test("returns goto qa when round cap reached even with review:changes", async () => {
     const state = makeState({ review_session_id: "abc", review_round: REVIEW_ROUND_CAP });
-    const deps = makeDeps({
-      async gh() {
-        return { stdout: STICKY_CHANGES, stderr: "", exitCode: 0 };
-      },
-    });
+    const deps = makeDeps({ gh: labelsGh(["review:changes"]) });
     const result = await runReview({ provider: "claude" }, makeWork(), state, deps, "/repo");
     expect(result.action).toBe("goto");
     if (result.action === "goto") {
@@ -261,12 +204,15 @@ describe("runReview — session exists", () => {
 
   test("increments review_round in state when going to repair", async () => {
     const state = makeState({ review_session_id: "abc", review_round: 1 });
-    const deps = makeDeps({
-      async gh() {
-        return { stdout: STICKY_CHANGES, stderr: "", exitCode: 0 };
-      },
-    });
+    const deps = makeDeps({ gh: labelsGh(["review:changes"]) });
     await runReview({ provider: "claude" }, makeWork(), state, deps, "/repo");
     expect(await state.get<number>("review_round")).toBe(2);
+  });
+
+  test("sets previous_phase to review when going to repair", async () => {
+    const state = makeState({ review_session_id: "abc", review_round: 1 });
+    const deps = makeDeps({ gh: labelsGh(["review:changes"]) });
+    await runReview({ provider: "claude" }, makeWork(), state, deps, "/repo");
+    expect(await state.get<string>("previous_phase")).toBe("review");
   });
 });

--- a/.claude/phases/review-fn.ts
+++ b/.claude/phases/review-fn.ts
@@ -120,7 +120,16 @@ export async function runReview(
     return { action: "goto", target: "qa", reason: "review:pass → qa", round, ...withModel };
   }
 
-  // review:changes — blockers remain.
+  // review:changes — blockers remain. Consume (clear) the verdict label co-located
+  // with the decision to trust it: the phase that *reads* a verdict invalidates it,
+  // so a re-entry after the repair round waits for the next reviewer's fresh verdict
+  // instead of replaying this stale one. Without this, the round-2 reviewer is
+  // spawned but its verdict is never consumed — `review_round` is already at the cap,
+  // so the next tick reads the stale `review:changes` and misroutes to qa, silently
+  // defeating the two-review guarantee (mirror-replay drift, #2649). qa is safe by a
+  // different seam — `repair-fn` clears `qa:fail` on every repair spawn.
+  await removeLabel(work.prNumber, "review:changes", deps);
+
   if (round >= REVIEW_ROUND_CAP) {
     return {
       action: "goto",

--- a/.claude/phases/review-fn.ts
+++ b/.claude/phases/review-fn.ts
@@ -19,6 +19,7 @@ export interface ReviewState {
 
 export interface ReviewDeps {
   gh(op: GhOp): Promise<GhResult>;
+  prEdit(prNumber: number, flags: string[]): Promise<void>;
   findModelInSprintPlan(issueNumber: number, repoRoot: string): "opus" | "sonnet" | null;
 }
 
@@ -35,51 +36,30 @@ export type ReviewResult =
   | { action: "wait"; reason: string; round: number; model?: "opus" | "sonnet" }
   | { action: "goto"; target: "repair" | "qa"; reason: string; round: number; model?: "opus" | "sonnet" };
 
-// ── verdict heuristic (#2007) ──
-// Layered match: explicit verdict line wins; if absent, fall back to
-// "naked" 🔴/🟡 — emoji on a line that does NOT also carry a resolution
-// marker (✅ / fixed / resolved / addressed / reverted / n/a). Surveyed
-// across 200 merged PRs (49 with stickies, 38 approved): the prior
-// `/🔴|🟡/.test()` regex flagged 38 of 38 approved PRs as blocked
-// because reviewers reference past 🔴/🟡 in delta tables alongside
-// ✅ Fixed in <sha>. The verdict-line check eliminates that whole
-// false-positive class; the same-line-resolution fallback handles
-// stickies the reviewer wrote without an explicit verdict header.
-const VERDICT_APPROVED_RE = /✅\s*\*?\*?\s*(approved|approve)\b/i;
-const VERDICT_CHANGES_RE = /(⚠️|🟡|🔴)\s*\*?\*?\s*changes\s*requested/i;
-const RESOLVED_TOKEN_RE = /(✅|☑|\bfixed\b|\bresolved\b|\baddressed\b|\breverted\b|\bn\/a\b|\bnot applicable\b|\bwon[''']t fix\b)/i;
-
-export async function scanReviewComments(
+// ── typed verdict channel (#2575) ──
+// The review verdict is read from a PR LABEL the reviewer sets transactionally
+// (`review:pass` / `review:changes`), mirroring qa's `qa:pass`/`qa:fail`. We do
+// NOT scrape the sticky comment body: prose is attacker-influenced free text in
+// a multi-agent environment, so a quoted/forwarded `✅ APPROVED` could advance a
+// PR no reviewer approved (the merge-gate prompt-injection vector). A label is a
+// structured signal the agent must deliberately apply — the only control signal
+// the gate trusts. The prior prose-scraping heuristic (#2007) is removed.
+export async function readReviewLabels(
   prNumber: number,
   deps: Pick<ReviewDeps, "gh">,
-): Promise<{ found: boolean; hasBlockers: boolean; summary: string }> {
-  const result = await deps.gh({ op: "pr:comments", prNumber });
-  if (result.exitCode !== 0) return { found: false, hasBlockers: false, summary: "gh pr view failed" };
-  const lastIdx = result.stdout.lastIndexOf("## Adversarial Review");
-  if (lastIdx === -1) return { found: false, hasBlockers: false, summary: "no sticky comment yet" };
-  const sticky = result.stdout.slice(lastIdx);
-  const lines = sticky.split("\n");
-  for (const line of lines) {
-    if (VERDICT_APPROVED_RE.test(line)) {
-      return { found: true, hasBlockers: false, summary: "verdict: approved" };
-    }
-    if (VERDICT_CHANGES_RE.test(line)) {
-      return { found: true, hasBlockers: true, summary: "verdict: changes requested" };
-    }
+): Promise<{ hasPass: boolean; hasChanges: boolean }> {
+  const result = await deps.gh({ op: "pr:labels", prNumber });
+  if (result.exitCode !== 0) return { hasPass: false, hasChanges: false };
+  const names = new Set(result.stdout.split(/\r?\n/).map((l) => l.trim()));
+  return { hasPass: names.has("review:pass"), hasChanges: names.has("review:changes") };
+}
+
+async function removeLabel(prNumber: number, label: string, deps: Pick<ReviewDeps, "prEdit">): Promise<void> {
+  try {
+    await deps.prEdit(prNumber, ["--remove-label", label]);
+  } catch {
+    /* best-effort */
   }
-  // No explicit verdict line — fall back to naked-emoji scan.
-  let nakedRed = 0;
-  let nakedYellow = 0;
-  for (const line of lines) {
-    if (!/🔴|🟡/.test(line)) continue;
-    if (RESOLVED_TOKEN_RE.test(line)) continue; // same-line resolution marker
-    nakedRed += (line.match(/🔴/g) ?? []).length;
-    nakedYellow += (line.match(/🟡/g) ?? []).length;
-  }
-  if (nakedRed + nakedYellow > 0) {
-    return { found: true, hasBlockers: true, summary: `blockers remain (🔴×${nakedRed}, 🟡×${nakedYellow}, no verdict line)` };
-  }
-  return { found: true, hasBlockers: false, summary: "all clear" };
 }
 
 export async function runReview(
@@ -126,26 +106,32 @@ export async function runReview(
   }
 
   const storedModel = (await state.get<string>("review_model")) as "opus" | "sonnet" | null;
-  const scan = await scanReviewComments(work.prNumber, deps);
-  if (!scan.found) {
-    return { action: "wait", reason: scan.summary, round, ...(storedModel ? { model: storedModel } : {}) };
+  const withModel = storedModel ? { model: storedModel } : {};
+  const { hasPass, hasChanges } = await readReviewLabels(work.prNumber, deps);
+
+  // No verdict label yet — the reviewer hasn't decided. Wait (never trust prose).
+  if (!hasPass && !hasChanges) {
+    return { action: "wait", reason: "review:pass / review:changes label not set yet", round, ...withModel };
   }
 
-  if (!scan.hasBlockers) {
-    return { action: "goto", target: "qa", reason: "review clean → qa", round, ...(storedModel ? { model: storedModel } : {}) };
+  // Approved wins if both are somehow set; clear the stale changes label.
+  if (hasPass) {
+    if (hasChanges) await removeLabel(work.prNumber, "review:changes", deps);
+    return { action: "goto", target: "qa", reason: "review:pass → qa", round, ...withModel };
   }
 
+  // review:changes — blockers remain.
   if (round >= REVIEW_ROUND_CAP) {
     return {
       action: "goto",
       target: "qa",
       reason: `review round cap (${REVIEW_ROUND_CAP}) reached; deferring remaining items to qa`,
       round,
-      ...(storedModel ? { model: storedModel } : {}),
+      ...withModel,
     };
   }
 
   await state.set("review_round", round + 1);
   await state.set("previous_phase", "review");
-  return { action: "goto", target: "repair", reason: "blockers remain → repair", round, ...(storedModel ? { model: storedModel } : {}) };
+  return { action: "goto", target: "repair", reason: "review:changes → repair", round, ...withModel };
 }

--- a/.claude/phases/review.ts
+++ b/.claude/phases/review.ts
@@ -2,11 +2,14 @@
  * Phase: review — adversarial review for high-scrutiny PRs.
  *
  * On first entry: emits the spawn plan for the reviewer.
- * On re-entry (review_session_id already set): scans the PR for the sticky
- *   `## Adversarial Review` comment and decides the transition.
- *     - no comment yet         → { action: "wait" }
- *     - 🔴 or 🟡 present       → { action: "goto", target: "repair" } (with round cap)
- *     - all ✅ / no blockers    → { action: "goto", target: "qa" }
+ * On re-entry (review_session_id already set): reads the typed verdict LABEL
+ *   the reviewer set (`review:pass` / `review:changes`) and decides the
+ *   transition. The sticky comment body is NEVER scraped for the verdict —
+ *   prose is attacker-influenced free text, so trusting it is a merge-gate
+ *   prompt-injection vector (#2575). The label is the only control signal.
+ *     - no verdict label yet   → { action: "wait" }
+ *     - review:changes         → { action: "goto", target: "repair" } (with round cap)
+ *     - review:pass            → { action: "goto", target: "qa" }
  *
  * Round cap: review_round >= 2 and issues remain → prefer qa (matches
  * run.md's "two reviews max" rule).
@@ -20,7 +23,7 @@
  * Orchestrator responsibility: replace review_session_id "pending:*" with real
  * session ID after spawn; delete review_session_id before re-entering review
  * for a new round (so the handler spawns a fresh reviewer rather than reading
- * the previous reviewer's comment).
+ * the previous reviewer's verdict label).
  */
 import { NO_REPO_ROOT, findModelInSprintPlan } from "@mcp-cli/core";
 import { defineAlias, z } from "mcp-cli";
@@ -35,7 +38,7 @@ const ProviderSchema = z
 
 defineAlias({
   name: "phase-review",
-  description: "Sprint phase: spawn adversarial reviewer or act on its sticky comment.",
+  description: "Sprint phase: spawn adversarial reviewer or act on its review:pass/review:changes verdict label.",
   input: z.object({
     provider: ProviderSchema.default("claude"),
     model: z.enum(["opus", "sonnet"]).optional(),
@@ -71,15 +74,21 @@ defineAlias({
       {
         async gh(op) {
           try {
-            if (op.op === "pr:comments") {
-              const comments = await ctx.gh.pr(op.prNumber).bodyComments();
-              const stdout = comments.map((c) => c.body).join("\n");
-              return { stdout, stderr: "", exitCode: 0 };
+            if (op.op === "pr:labels") {
+              const pr = await ctx.gh.pr(op.prNumber).body();
+              return { stdout: pr.labels.join("\n"), stderr: "", exitCode: 0 };
             }
             return { stdout: "", stderr: `unsupported gh op: ${op.op}`, exitCode: 1 };
           } catch (err) {
             return { stdout: "", stderr: err instanceof Error ? err.message : String(err), exitCode: 1 };
           }
+        },
+        async prEdit(prNumber, flags) {
+          const removeLabels: string[] = [];
+          for (let i = 0; i < flags.length; i += 2) {
+            if (flags[i] === "--remove-label") removeLabels.push(flags[i + 1]);
+          }
+          await ctx.gh.pr(prNumber).edit({ removeLabels });
         },
         findModelInSprintPlan,
       },

--- a/.mcx.lock
+++ b/.mcx.lock
@@ -11,7 +11,7 @@
     {
       "name": "impl",
       "resolvedPath": ".claude/phases/impl.ts",
-      "contentHash": "3d0267ea72f28afe5161fa137bd1a6fd85baa603e13cb2f8324c2c0310520e6d",
+      "contentHash": "df6a414333465cfa514498e77f50ec53ac97c5605e2983c8e600ef18133dc785",
       "schemaHash": "ed4e8c293093075a364653d8c077f44d68157174b7b276fbdfafb9f31fc1207d"
     },
     {
@@ -35,7 +35,7 @@
     {
       "name": "review",
       "resolvedPath": ".claude/phases/review.ts",
-      "contentHash": "e61f3c3ae1ef3cd483922242722fef1417b86b1e4014c816afe4326d2fe7058b",
+      "contentHash": "c8c87b106056f672ee10828cfc0a91113e2a6e0cf8fe3f88105d6a1318bcd19f",
       "schemaHash": "dbbe21e50a1a7a002a56c511d456060166ea94c6d15b2400e7f8283c861ed83d"
     },
     {

--- a/test/review-phase.spec.ts
+++ b/test/review-phase.spec.ts
@@ -5,12 +5,22 @@ import {
   type ReviewDeps,
   type ReviewState,
   type ReviewWork,
+  readReviewLabels,
   runReview,
-  scanReviewComments,
 } from "../.claude/phases/review-fn";
 
 function ok(stdout = ""): GhResult {
   return { stdout, stderr: "", exitCode: 0 };
+}
+
+/** gh() stub returning the given label names for the `pr:labels` op. */
+function labelsGh(labels: string[], exitCode = 0): ReviewDeps["gh"] {
+  return async (op: GhOp) => {
+    if (op.op === "pr:labels") {
+      return { stdout: exitCode === 0 ? labels.join("\n") : "", stderr: "", exitCode };
+    }
+    return { stdout: "", stderr: `unsupported gh op: ${op.op}`, exitCode: 1 };
+  };
 }
 
 function makeWork(overrides: Partial<ReviewWork> = {}): ReviewWork {
@@ -35,161 +45,60 @@ function makeState(initial: Record<string, unknown> = {}): ReviewState {
 
 function makeDeps(overrides: Partial<ReviewDeps> = {}): ReviewDeps {
   return {
-    gh: async () => ok(""),
+    gh: labelsGh([]),
+    prEdit: async () => {},
     findModelInSprintPlan: () => null,
     ...overrides,
   };
 }
 
-// ── scanReviewComments ──
+// ── readReviewLabels: the typed verdict channel (#2575) ──
 
-describe("scanReviewComments — parsing", () => {
-  test("no sticky comment → found: false", async () => {
-    const result = await scanReviewComments(100, {
-      gh: async () => ok("some other comment\n\nanother comment"),
+describe("readReviewLabels — typed verdict channel", () => {
+  test("gh failure → both false", async () => {
+    expect(await readReviewLabels(100, { gh: labelsGh(["review:pass"], 1) })).toEqual({
+      hasPass: false,
+      hasChanges: false,
     });
-    expect(result).toEqual({ found: false, hasBlockers: false, summary: "no sticky comment yet" });
   });
 
-  test("sticky comment with no blockers → found: true, hasBlockers: false", async () => {
-    // Realistic format: blank line between header and body (as gh pr view --comments produces)
-    const comment = "## Adversarial Review\n\n✅ All good\n✅ Looks clean";
-    const result = await scanReviewComments(100, {
-      gh: async () => ok(comment),
+  test("review:pass present → hasPass", async () => {
+    expect(await readReviewLabels(100, { gh: labelsGh(["bug", "review:pass"]) })).toEqual({
+      hasPass: true,
+      hasChanges: false,
     });
-    expect(result).toEqual({ found: true, hasBlockers: false, summary: "all clear" });
   });
 
-  test("sticky comment with 🔴 → hasBlockers: true", async () => {
-    // Realistic format: blank line between header and emoji (real gh output format)
-    const comment = "## Adversarial Review\n\n🔴 Critical issue found";
-    const result = await scanReviewComments(100, {
-      gh: async () => ok(comment),
+  test("review:changes present → hasChanges", async () => {
+    expect(await readReviewLabels(100, { gh: labelsGh(["review:changes"]) })).toEqual({
+      hasPass: false,
+      hasChanges: true,
     });
-    expect(result).toMatchObject({ found: true, hasBlockers: true });
   });
 
-  test("sticky comment with 🟡 → hasBlockers: true", async () => {
-    // Realistic format: blank line between header and emoji
-    const comment = "## Adversarial Review\n\n🟡 Warning: edge case missed";
-    const result = await scanReviewComments(100, {
-      gh: async () => ok(comment),
+  test("both present → both true", async () => {
+    expect(await readReviewLabels(100, { gh: labelsGh(["review:pass", "review:changes"]) })).toEqual({
+      hasPass: true,
+      hasChanges: true,
     });
-    expect(result).toMatchObject({ found: true, hasBlockers: true });
   });
 
-  test("realistic gh output: blank-line-separated header and emoji content", async () => {
-    // Mirrors real 'gh pr view --json comments -q .comments[].body' output where
-    // paragraphs within a comment are separated by blank lines. The header block
-    // and the 🔴 items are in different split-chunks, so a naive split(/\n{2,}/)
-    // approach (the old code) would return hasBlockers: false — this test documents
-    // that the fix (lastIndexOf) handles it correctly.
-    const body = "## Adversarial Review\n\n🔴 Missing null check in foo.ts line 42\n\n🟡 Consider extracting helper";
-    const result = await scanReviewComments(100, {
-      gh: async () => ok(body),
+  test("neither present → both false (no verdict yet)", async () => {
+    expect(await readReviewLabels(100, { gh: labelsGh(["bug", "enhancement"]) })).toEqual({
+      hasPass: false,
+      hasChanges: false,
     });
-    expect(result).toMatchObject({ found: true, hasBlockers: true });
   });
 
-  test("gh call fails → found: false with error summary", async () => {
-    const result = await scanReviewComments(100, {
-      gh: async () => ({ stdout: "", stderr: "not found", exitCode: 1 }),
-    });
-    expect(result).toEqual({ found: false, hasBlockers: false, summary: "gh pr view failed" });
-  });
-
-  test("picks most recent sticky comment (lastIndexOf)", async () => {
-    // Two adversarial review comments in output; the last one (most recent) is clean.
-    // Realistic format with blank lines between header and body paragraphs.
-    const body = "## Adversarial Review\n\n🔴 Old blocker\n\n## Adversarial Review\n\n✅ All resolved";
-    const result = await scanReviewComments(100, {
-      gh: async () => ok(body),
-    });
-    expect(result).toMatchObject({ found: true, hasBlockers: false });
-  });
-
-  // ── verdict-line heuristic (#2007 fix) ──
-
-  test("✅ APPROVED verdict + 🔴 in delta-table rows → no blockers", async () => {
-    // Real-world false positive from PR #1998 / #2006: reviewer writes
-    // `✅ **APPROVED**` near the top, then a delta table where each row
-    // references its prior 🔴/🟡 alongside ✅ Fixed. Old regex flagged
-    // every approved sticky as blocked.
-    const body = [
-      "## Adversarial Review",
-      "",
-      "### Verdict",
-      "✅ **APPROVED** — all blockers resolved.",
-      "",
-      "| # | Previous Issue | Status |",
-      "|---|----------------|--------|",
-      "| 1 | 🔴 Read-side regression | ✅ Fixed in ad84422 |",
-      "| 2 | 🟡 Migration TOCTOU | ✅ Fixed in ad84422 |",
-    ].join("\n");
-    const result = await scanReviewComments(100, { gh: async () => ok(body) });
-    expect(result).toMatchObject({ found: true, hasBlockers: false });
-    expect(result.summary).toContain("approved");
-  });
-
-  test("⚠️ Changes Requested verdict → blockers regardless of delta table", async () => {
-    const body = [
-      "## Adversarial Review",
-      "",
-      "### Verdict",
-      "⚠️ **Changes Requested** — 1 new finding.",
-      "",
-      "| # | Previous Issue | Status |",
-      "|---|----------------|--------|",
-      "| 1 | 🔴 Old issue | ✅ Fixed |",
-      "",
-      "🔴 New finding: missing null check in foo.ts:42",
-    ].join("\n");
-    const result = await scanReviewComments(100, { gh: async () => ok(body) });
-    expect(result).toMatchObject({ found: true, hasBlockers: true });
-  });
-
-  test("no verdict line + naked 🔴 → blockers", async () => {
-    const body = "## Adversarial Review\n\n🔴 Critical issue, unresolved";
-    const result = await scanReviewComments(100, { gh: async () => ok(body) });
-    expect(result).toMatchObject({ found: true, hasBlockers: true });
-  });
-
-  test("no verdict line + 🔴 paired with same-line ✅ Fixed → no blockers", async () => {
-    // Reviewer omitted explicit verdict line but every emoji is paired
-    // with a resolution marker on the same line.
-    const body =
-      "## Adversarial Review\n\n- 🔴 Read-side regression: ✅ Fixed in abc123\n- 🟡 Test gap: ✅ Resolved by adding spec";
-    const result = await scanReviewComments(100, { gh: async () => ok(body) });
-    expect(result).toMatchObject({ found: true, hasBlockers: false });
-  });
-
-  test("no verdict line + 🔴 with same-line 'fixed' word → no blockers", async () => {
-    const body = "## Adversarial Review\n\nThe original 🔴 finding was fixed in commit deadbeef.";
-    const result = await scanReviewComments(100, { gh: async () => ok(body) });
-    expect(result).toMatchObject({ found: true, hasBlockers: false });
-  });
-
-  test("no verdict line + 🔴 same-line 'fixed' AND naked 🔴 elsewhere → blockers", async () => {
-    const body = [
-      "## Adversarial Review",
-      "",
-      "Prior 🔴 issue was fixed in abc123.",
-      "",
-      "🔴 But a new finding: missing test coverage.",
-    ].join("\n");
-    const result = await scanReviewComments(100, { gh: async () => ok(body) });
-    expect(result).toMatchObject({ found: true, hasBlockers: true });
-  });
-
-  test("passes correct op to gh", async () => {
+  test("passes the pr:labels op (never pr:comments — prose is not consulted)", async () => {
     let captured: GhOp | undefined;
-    await scanReviewComments(99, {
+    await readReviewLabels(99, {
       gh: async (op) => {
         captured = op;
         return ok("");
       },
     });
-    expect(captured).toEqual({ op: "pr:comments", prNumber: 99 });
+    expect(captured).toEqual({ op: "pr:labels", prNumber: 99 });
   });
 });
 
@@ -204,9 +113,7 @@ describe("runReview — spawn path", () => {
   test("default model is sonnet when no plan entry", async () => {
     const result = await runReview({ provider: "claude" }, makeWork(), makeState(), makeDeps(), "__none__");
     expect(result.action).toBe("spawn");
-    if (result.action === "spawn") {
-      expect(result.model).toBe("sonnet");
-    }
+    if (result.action === "spawn") expect(result.model).toBe("sonnet");
   });
 
   test("explicit model input overrides plan", async () => {
@@ -218,9 +125,7 @@ describe("runReview — spawn path", () => {
       "/some/root",
     );
     expect(result.action).toBe("spawn");
-    if (result.action === "spawn") {
-      expect(result.model).toBe("opus");
-    }
+    if (result.action === "spawn") expect(result.model).toBe("opus");
   });
 
   test("sprint plan model used when no explicit input", async () => {
@@ -232,9 +137,7 @@ describe("runReview — spawn path", () => {
       "/some/root",
     );
     expect(result.action).toBe("spawn");
-    if (result.action === "spawn") {
-      expect(result.model).toBe("opus");
-    }
+    if (result.action === "spawn") expect(result.model).toBe("opus");
   });
 
   test("NO_REPO_ROOT skips sprint plan lookup", async () => {
@@ -253,9 +156,7 @@ describe("runReview — spawn path", () => {
     );
     expect(planCalled).toBe(false);
     expect(result.action).toBe("spawn");
-    if (result.action === "spawn") {
-      expect(result.model).toBe("sonnet");
-    }
+    if (result.action === "spawn") expect(result.model).toBe("sonnet");
   });
 
   test("command includes correct provider", async () => {
@@ -305,20 +206,19 @@ describe("runReview — spawn path", () => {
     await runReview({ provider: "claude" }, makeWork(), trackingState, makeDeps(), "__none__");
     expect(writes.review_round).toBe(1);
     expect(writes.review_model).toBe("sonnet");
-    expect(typeof writes.review_session_id).toBe("string");
     expect(String(writes.review_session_id)).toMatch(/^pending:/);
   });
 });
 
-// ── runReview — re-entry (session set) ──
+// ── runReview — re-entry (session set), driven by verdict label ──
 
 describe("runReview — wait path", () => {
-  test("session set, no sticky comment → wait", async () => {
+  test("session set, no verdict label → wait", async () => {
     const result = await runReview(
       { provider: "claude" },
       makeWork(),
       makeState({ review_session_id: "sess_123", review_round: 1 }),
-      makeDeps({ gh: async () => ok("just some comment") }),
+      makeDeps({ gh: labelsGh(["bug"]) }),
       "__none__",
     );
     expect(result.action).toBe("wait");
@@ -329,58 +229,73 @@ describe("runReview — wait path", () => {
       { provider: "claude" },
       makeWork(),
       makeState({ review_session_id: "sess_123", review_round: 1, review_model: "opus" }),
-      makeDeps({ gh: async () => ok("comment without adversarial review") }),
+      makeDeps({ gh: labelsGh([]) }),
       "__none__",
     );
     expect(result.action).toBe("wait");
-    if (result.action === "wait") {
-      expect(result.model).toBe("opus");
-    }
+    if (result.action === "wait") expect(result.model).toBe("opus");
   });
 });
 
-describe("runReview — goto qa (clean review)", () => {
-  test("sticky comment with no blockers → goto qa", async () => {
+describe("runReview — goto qa (review:pass)", () => {
+  test("review:pass label → goto qa", async () => {
     const result = await runReview(
       { provider: "claude" },
       makeWork(),
       makeState({ review_session_id: "sess_123", review_round: 1 }),
-      makeDeps({ gh: async () => ok("## Adversarial Review\n\n✅ All good") }),
+      makeDeps({ gh: labelsGh(["review:pass"]) }),
       "__none__",
     );
     expect(result).toMatchObject({ action: "goto", target: "qa" });
   });
-});
 
-describe("runReview — goto repair (blockers present)", () => {
-  test("blockers below cap → goto repair", async () => {
-    const state = makeState({ review_session_id: "sess_123", review_round: 1 });
+  test("both labels set → pass wins and stale review:changes is removed", async () => {
+    const removed: string[] = [];
     const result = await runReview(
       { provider: "claude" },
       makeWork(),
-      state,
-      makeDeps({ gh: async () => ok("## Adversarial Review\n\n🔴 Critical issue") }),
+      makeState({ review_session_id: "sess_123", review_round: 1 }),
+      makeDeps({
+        gh: labelsGh(["review:pass", "review:changes"]),
+        prEdit: async (_pr, flags) => {
+          for (let i = 0; i < flags.length; i += 2) {
+            if (flags[i] === "--remove-label") removed.push(flags[i + 1]);
+          }
+        },
+      }),
+      "__none__",
+    );
+    expect(result).toMatchObject({ action: "goto", target: "qa" });
+    expect(removed).toContain("review:changes");
+  });
+});
+
+describe("runReview — goto repair (review:changes)", () => {
+  test("review:changes below cap → goto repair", async () => {
+    const result = await runReview(
+      { provider: "claude" },
+      makeWork(),
+      makeState({ review_session_id: "sess_123", review_round: 1 }),
+      makeDeps({ gh: labelsGh(["review:changes"]) }),
       "__none__",
     );
     expect(result).toMatchObject({ action: "goto", target: "repair" });
   });
 
-  test("round cap reached with blockers → goto qa instead of repair", async () => {
+  test("round cap reached with review:changes → goto qa instead of repair", async () => {
     const result = await runReview(
       { provider: "claude" },
       makeWork(),
       makeState({ review_session_id: "sess_123", review_round: REVIEW_ROUND_CAP }),
-      makeDeps({ gh: async () => ok("## Adversarial Review\n\n🔴 Still failing") }),
+      makeDeps({ gh: labelsGh(["review:changes"]) }),
       "__none__",
     );
     expect(result).toMatchObject({ action: "goto", target: "qa" });
     expect(result.action).toBe("goto");
-    if (result.action === "goto") {
-      expect(result.reason).toContain("round cap");
-    }
+    if (result.action === "goto") expect(result.reason).toContain("cap");
   });
 
-  test("blockers below cap increments review_round in state", async () => {
+  test("review:changes below cap increments review_round and sets previous_phase", async () => {
     const writes: Record<string, unknown> = {};
     const state = makeState({ review_session_id: "sess_123", review_round: 1 });
     const trackingState: ReviewState = {
@@ -394,7 +309,7 @@ describe("runReview — goto repair (blockers present)", () => {
       { provider: "claude" },
       makeWork(),
       trackingState,
-      makeDeps({ gh: async () => ok("## Adversarial Review\n\n🔴 Issue") }),
+      makeDeps({ gh: labelsGh(["review:changes"]) }),
       "__none__",
     );
     expect(writes.review_round).toBe(2);

--- a/test/review-phase.spec.ts
+++ b/test/review-phase.spec.ts
@@ -315,4 +315,87 @@ describe("runReview — goto repair (review:changes)", () => {
     expect(writes.review_round).toBe(2);
     expect(writes.previous_phase).toBe("review");
   });
+
+  test("review:changes is cleared on the goto repair (verdict consumed)", async () => {
+    const removed: string[] = [];
+    const result = await runReview(
+      { provider: "claude" },
+      makeWork(),
+      makeState({ review_session_id: "sess_123", review_round: 1 }),
+      makeDeps({
+        gh: labelsGh(["review:changes"]),
+        prEdit: async (_pr, flags) => {
+          for (let i = 0; i < flags.length; i += 2) {
+            if (flags[i] === "--remove-label") removed.push(flags[i + 1]);
+          }
+        },
+      }),
+      "__none__",
+    );
+    expect(result).toMatchObject({ action: "goto", target: "repair" });
+    expect(removed).toContain("review:changes");
+  });
+
+  test("review:changes is cleared even when the round cap routes to qa", async () => {
+    const removed: string[] = [];
+    const result = await runReview(
+      { provider: "claude" },
+      makeWork(),
+      makeState({ review_session_id: "sess_123", review_round: REVIEW_ROUND_CAP }),
+      makeDeps({
+        gh: labelsGh(["review:changes"]),
+        prEdit: async (_pr, flags) => {
+          for (let i = 0; i < flags.length; i += 2) {
+            if (flags[i] === "--remove-label") removed.push(flags[i + 1]);
+          }
+        },
+      }),
+      "__none__",
+    );
+    expect(result).toMatchObject({ action: "goto", target: "qa" });
+    expect(removed).toContain("review:changes");
+  });
+});
+
+// ── Multi-tick lifecycle: stale verdict must not survive the repair round (#2649) ──
+//
+// Regression for the mirror-replay drift caught in adversarial review: the read side
+// (`readReviewLabels`) mirrored qa, but the *clear* did not. The qa loop is safe only
+// because `repair-fn` clears `qa:fail` on every repair spawn; review left
+// `review:changes` on the PR, so on re-entry — with `review_round` already at the cap —
+// the gate replayed the stale label and misrouted the round-2 reviewer to qa.
+// This drives the real lifecycle over a SHARED, MUTABLE label set + state map, the only
+// shape that exercises the cross-tick invariant (every other test pre-seeds its label).
+describe("runReview — lifecycle (#2649)", () => {
+  test("stale review:changes does not survive into the round-2 re-entry", async () => {
+    // Shared label set: prEdit --remove-label mutates it; pr:labels reads it back.
+    const labels = new Set<string>(["review:changes"]);
+    const deps = makeDeps({
+      gh: async (op: GhOp) =>
+        op.op === "pr:labels"
+          ? { stdout: [...labels].join("\n"), stderr: "", exitCode: 0 }
+          : { stdout: "", stderr: `unsupported gh op: ${op.op}`, exitCode: 1 },
+      prEdit: async (_pr, flags) => {
+        for (let i = 0; i < flags.length; i += 2) {
+          if (flags[i] === "--remove-label") labels.delete(flags[i + 1]);
+        }
+      },
+    });
+    const state = makeState({ review_session_id: "sess_r1", review_round: 1 });
+
+    // Round 1: review:changes → repair, and the verdict label is consumed.
+    const r1 = await runReview({ provider: "claude" }, makeWork(), state, deps, "__none__");
+    expect(r1).toMatchObject({ action: "goto", target: "repair" });
+    expect(labels.has("review:changes")).toBe(false);
+    expect(await state.get<number>("review_round")).toBe(REVIEW_ROUND_CAP); // 1 → 2
+
+    // Repair clears the session sentinel and spawns a fresh round-2 reviewer.
+    await state.set("review_session_id", "sess_r2");
+
+    // Round-2 re-entry BEFORE the new reviewer renders a verdict: with the stale label
+    // gone the gate WAITS, rather than reading round >= cap + a phantom review:changes
+    // and misrouting to qa (the orphaned-reviewer bug).
+    const r2 = await runReview({ provider: "claude" }, makeWork(), state, deps, "__none__");
+    expect(r2.action).toBe("wait");
+  });
 });


### PR DESCRIPTION
## Summary

Closes the **merge-gate prompt-injection vector** in #2575. The `review` phase
decided whether to advance/merge a PR by **regex-scraping the free-text body** of
the `## Adversarial Review` sticky comment for `✅ APPROVED`. In a multi-agent,
agent-authored-diff environment that body is **attacker-influenced free text** — a
quoted diff hunk, a forwarded block, or a crafted PR description containing
`✅ APPROVED` on its own line advanced a PR no reviewer approved. No human in the loop.

The fix mirrors the proven `qa` pattern: the verdict becomes a **typed PR label** the
reviewer sets transactionally, and the gate reads **only the label** — never prose.

## Changes

**Consumer** — `.claude/phases/review-fn.ts`, `review.ts`
- Replace `scanReviewComments` (prose scrape + 🔴/🟡 heuristic, #2007) with
  `readReviewLabels()` reading `review:pass` / `review:changes` via the `pr:labels` op.
- `runReview` now mirrors `runQa`: no label → `wait`; `review:pass` → `qa` (clears any
  stale `review:changes`); `review:changes` → `repair` (round-capped → `qa`).
- Wire `pr:labels` + `prEdit` in `review.ts`; drop the `pr:comments` adapter.

**Producer** — `.claude/commands/adversarial-review.md`
- Add **Setting the Verdict Label**: transactional `gh pr edit --add-label review:pass
  --remove-label review:changes` (and inverse), mirroring `qa`.
- Correct the now-false notes claiming the gate anchors on the prose verdict line. The
  prose verdict is human/repairer-readable only; **the label is the sole control signal.**

**Repo** — created `review:pass` / `review:changes` labels (mirroring `qa:pass`/`qa:fail`).

**Tests** — rewrote both review specs (co-located `.claude/phases/review-fn.spec.ts` and
the CI-run `test/review-phase.spec.ts`) to the label model; removed the prose-scrape cases.

> [!NOTE]
> The two spec files are **not** redundant: `bunfig.toml` ignores `.claude/**`, so
> `test/review-phase.spec.ts` is the only one the CI suite runs. I nearly deleted it as a
> dup — restored it. Filed **#2648** for that dotdir spec-mirror smell.

## Why this is the right fix (not the stopgap)

#2575 offered a stopgap (anchor on a magic-string sentinel, skip fenced regions). That
still parses prose. A label is a structured signal the reviewer must *deliberately apply*
— a `✅` appearing in quoted/forwarded text can never move the gate. Producer **and**
consumer are updated together, as the issue required.

## Test plan
- `bun run am-i-done` — ✅ all checks pass (typecheck, lint, rules, tests, coverage).
- Unit coverage: `readReviewLabels` (all label combinations, gh-failure); `runReview`
  re-entry (no label → wait, pass → qa, both → pass-wins+clear, changes → repair,
  round-cap → qa, round/previous_phase writes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)