### PR TITLE
fix(hook): use BRE grep in pre-commit to fix macOS BSD portability (fixes #2628)

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -34,7 +34,7 @@ if [ -z "${SKIP_PRIVACY_CHECK:-}" ]; then
   # Grep added lines only (not context, not removed). -U disables newline
   # normalization so we can reliably match within single diff lines.
   privacy_hits=$(git diff --cached -U0 --no-color -- $staged_files \
-    | grep -E "^\+" | grep -E "$privacy_pattern" || true)
+    | grep '^+' | grep -E "$privacy_pattern" || true)
   if [ -n "$privacy_hits" ]; then
     echo "pre-commit: refusing to stage lines containing local home paths" >&2
     echo "pattern: $privacy_pattern" >&2
@@ -80,7 +80,7 @@ if [ -n "$recording_files" ]; then
     exit 1
   }
   added_content=$(printf '%s\n' "$diff_output" \
-    | grep -E '^\+' | grep -v '^\+\+\+' | sed 's/^\+//') || {
+    | grep '^+' | grep -v '^+++' | sed 's/^+//') || {
     rc=$?
     if [ "$rc" -gt 1 ]; then
       echo "pre-commit: content extraction failed (fail-closed)" >&2


### PR DESCRIPTION
## Summary
- Replace `grep -E '^\+'` with `grep '^+'` (BRE mode) in two locations in `.git-hooks/pre-commit` — the privacy-check pipeline (line 37) and the secret-scanner content extraction (line 83)
- In POSIX ERE, `\+` is not a valid escape; BSD grep on macOS rejects it with "repetition-operator operand invalid" (exit 2), which triggers the fail-closed guard and blocks all commits staging files under `agent-grid/binaries/`
- BRE treats `+` as a literal character without escaping, making the pattern portable across GNU and BSD grep

## Test plan
- [x] Verified `grep '^+'` correctly extracts added diff lines and `grep -v '^+++'` excludes file headers
- [x] `bun run am-i-done --pre-commit` passes
- [x] Manual pattern test: `printf '+line\n context\n+++ b/file\n+add\n' | grep '^+' | grep -v '^+++'` outputs only content lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)