### PR TITLE
fix(core): update MODEL_SHORTNAMES — opus→4-8, add fable, fix haiku ID (fixes #2659)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -256,7 +256,7 @@ describe("parseSpawnArgs", () => {
 
   test("parses -m shorthand", () => {
     const result = parseSpawnArgs(["-m", "haiku", "-t", "x"]);
-    expect(result.model).toBe("claude-haiku-4-5-20251001");
+    expect(result.model).toBe("claude-haiku-4-5");
   });
 
   test("passes through full model ID", () => {
@@ -337,7 +337,7 @@ describe("parseSpawnArgs", () => {
 
 describe("resolveModelName", () => {
   test("resolves opus shortname", () => {
-    expect(resolveModelName("opus")).toBe("claude-opus-4-6");
+    expect(resolveModelName("opus")).toBe("claude-opus-4-8");
   });
 
   test("resolves sonnet shortname", () => {
@@ -345,16 +345,20 @@ describe("resolveModelName", () => {
   });
 
   test("resolves haiku shortname", () => {
-    expect(resolveModelName("haiku")).toBe("claude-haiku-4-5-20251001");
+    expect(resolveModelName("haiku")).toBe("claude-haiku-4-5");
+  });
+
+  test("resolves fable shortname", () => {
+    expect(resolveModelName("fable")).toBe("claude-fable-5");
   });
 
   test("is case-insensitive", () => {
-    expect(resolveModelName("Opus")).toBe("claude-opus-4-6");
+    expect(resolveModelName("Opus")).toBe("claude-opus-4-8");
     expect(resolveModelName("SONNET")).toBe("claude-sonnet-4-6");
   });
 
   test("passes through unknown model IDs", () => {
-    expect(resolveModelName("claude-opus-4-6")).toBe("claude-opus-4-6");
+    expect(resolveModelName("claude-opus-4-8")).toBe("claude-opus-4-8");
     expect(resolveModelName("some-custom-model")).toBe("some-custom-model");
   });
 });

--- a/packages/command/src/commands/spawn-args.spec.ts
+++ b/packages/command/src/commands/spawn-args.spec.ts
@@ -134,8 +134,8 @@ describe("parseSharedSpawnArgs", () => {
   });
 
   it("passes full model ID through unchanged", () => {
-    const result = parseSharedSpawnArgs(["--model", "claude-opus-4-6", "--task", "x"]);
-    expect(result.model).toBe("claude-opus-4-6");
+    const result = parseSharedSpawnArgs(["--model", "claude-opus-4-8", "--task", "x"]);
+    expect(result.model).toBe("claude-opus-4-8");
   });
 
   it("--allow stops consuming at lowercase positional (worktree name)", () => {

--- a/packages/command/src/commands/spawn-args.ts
+++ b/packages/command/src/commands/spawn-args.ts
@@ -116,7 +116,7 @@ export function parseSharedSpawnArgs(
     if (val.startsWith("-")) {
       error ??= "--model requires a value";
     } else if (val.toLowerCase() === "null" || val.toLowerCase() === "none" || val.toLowerCase() === "undefined") {
-      error ??= `--model "${val}" is not a valid model name (use: opus, sonnet, haiku, or a full model ID)`;
+      error ??= `--model "${val}" is not a valid model name (use: fable, opus, sonnet, haiku, or a full model ID)`;
     } else {
       model = resolveModelName(val);
     }

--- a/packages/core/src/model.ts
+++ b/packages/core/src/model.ts
@@ -1,8 +1,9 @@
 /** Map short model names to full model IDs. */
 export const MODEL_SHORTNAMES: Record<string, string> = {
-  opus: "claude-opus-4-6",
+  fable: "claude-fable-5",
+  opus: "claude-opus-4-8",
   sonnet: "claude-sonnet-4-6",
-  haiku: "claude-haiku-4-5-20251001",
+  haiku: "claude-haiku-4-5",
 };
 
 /** Resolve a model name: accept shortnames or pass through full IDs. */


### PR DESCRIPTION
## Summary
- Update `opus` shortname from `claude-opus-4-6` to `claude-opus-4-8` (current model)
- Add `fable` shortname mapping to `claude-fable-5`
- Fix `haiku` from dated `claude-haiku-4-5-20251001` to bare `claude-haiku-4-5`
- Update error message in `spawn-args.ts` to include `fable` in valid shortname list
- Add `resolves fable shortname` test, update existing assertions for new IDs

## Test plan
- [x] `resolveModelName("opus")` returns `claude-opus-4-8`
- [x] `resolveModelName("fable")` returns `claude-fable-5`
- [x] `resolveModelName("haiku")` returns `claude-haiku-4-5`
- [x] `resolveModelName("sonnet")` unchanged at `claude-sonnet-4-6`
- [x] Case-insensitive resolution still works
- [x] Full model IDs still pass through unchanged
- [x] All 416 tests in affected files pass
- [x] `bun run am-i-done` passes (pre-existing `check-stale-todos.spec.ts` failure filed as #2664)

🤖 Generated with [Claude Code](https://claude.com/claude-code)