### PR TITLE
fix(phases): prEdit adapter parses --add-label and rejects unknown flags (fixes #2653)

### DIFF
--- a/.claude/phases/phase-types.spec.ts
+++ b/.claude/phases/phase-types.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { parsePrEditFlags } from "./phase-types";
+
+describe("parsePrEditFlags", () => {
+  test("parses --remove-label flags", () => {
+    const result = parsePrEditFlags(["--remove-label", "qa:fail"]);
+    expect(result).toEqual({ addLabels: [], removeLabels: ["qa:fail"] });
+  });
+
+  test("parses --add-label flags", () => {
+    const result = parsePrEditFlags(["--add-label", "qa:pass"]);
+    expect(result).toEqual({ addLabels: ["qa:pass"], removeLabels: [] });
+  });
+
+  test("parses mixed --add-label and --remove-label flags", () => {
+    const result = parsePrEditFlags(["--add-label", "review:pass", "--remove-label", "review:changes"]);
+    expect(result).toEqual({ addLabels: ["review:pass"], removeLabels: ["review:changes"] });
+  });
+
+  test("handles multiple labels of the same type", () => {
+    const result = parsePrEditFlags(["--remove-label", "a", "--remove-label", "b"]);
+    expect(result).toEqual({ addLabels: [], removeLabels: ["a", "b"] });
+  });
+
+  test("returns empty arrays for empty input", () => {
+    const result = parsePrEditFlags([]);
+    expect(result).toEqual({ addLabels: [], removeLabels: [] });
+  });
+
+  test("throws on unknown flag", () => {
+    expect(() => parsePrEditFlags(["--title", "oops"])).toThrow("prEdit: unknown flag --title");
+  });
+});

--- a/.claude/phases/phase-types.ts
+++ b/.claude/phases/phase-types.ts
@@ -6,6 +6,22 @@ export interface GhResult {
   exitCode: number;
 }
 
+export interface ParsedPrEditFlags {
+  addLabels: string[];
+  removeLabels: string[];
+}
+
+export function parsePrEditFlags(flags: string[]): ParsedPrEditFlags {
+  const addLabels: string[] = [];
+  const removeLabels: string[] = [];
+  for (let i = 0; i < flags.length; i += 2) {
+    if (flags[i] === "--add-label") addLabels.push(flags[i + 1]);
+    else if (flags[i] === "--remove-label") removeLabels.push(flags[i + 1]);
+    else throw new Error(`prEdit: unknown flag ${flags[i]}`);
+  }
+  return { addLabels, removeLabels };
+}
+
 /**
  * Typed GH operations for the gh() dependency injection point.
  * Each variant maps to a specific ctx.gh method call; adapters dispatch on op.op.

--- a/.claude/phases/qa.ts
+++ b/.claude/phases/qa.ts
@@ -15,6 +15,7 @@
  * session ID after spawn; delete it on spawn failure.
  */
 import { defineAlias, z } from "mcp-cli";
+import { parsePrEditFlags } from "./phase-types";
 import { runQa } from "./qa-fn";
 
 const ProviderSchema = z
@@ -72,11 +73,8 @@ defineAlias({
           }
         },
         async prEdit(prNumber, flags) {
-          const removeLabels: string[] = [];
-          for (let i = 0; i < flags.length; i += 2) {
-            if (flags[i] === "--remove-label") removeLabels.push(flags[i + 1]);
-          }
-          await ctx.gh.pr(prNumber).edit({ removeLabels });
+          const { addLabels, removeLabels } = parsePrEditFlags(flags);
+          await ctx.gh.pr(prNumber).edit({ addLabels, removeLabels });
         },
       },
     );

--- a/.claude/phases/review.ts
+++ b/.claude/phases/review.ts
@@ -27,6 +27,7 @@
  */
 import { NO_REPO_ROOT, findModelInSprintPlan } from "@mcp-cli/core";
 import { defineAlias, z } from "mcp-cli";
+import { parsePrEditFlags } from "./phase-types";
 import { runReview } from "./review-fn";
 
 const ProviderSchema = z
@@ -84,11 +85,8 @@ defineAlias({
           }
         },
         async prEdit(prNumber, flags) {
-          const removeLabels: string[] = [];
-          for (let i = 0; i < flags.length; i += 2) {
-            if (flags[i] === "--remove-label") removeLabels.push(flags[i + 1]);
-          }
-          await ctx.gh.pr(prNumber).edit({ removeLabels });
+          const { addLabels, removeLabels } = parsePrEditFlags(flags);
+          await ctx.gh.pr(prNumber).edit({ addLabels, removeLabels });
         },
         findModelInSprintPlan,
       },

--- a/.mcx.lock
+++ b/.mcx.lock
@@ -11,7 +11,7 @@
     {
       "name": "impl",
       "resolvedPath": ".claude/phases/impl.ts",
-      "contentHash": "df6a414333465cfa514498e77f50ec53ac97c5605e2983c8e600ef18133dc785",
+      "contentHash": "343dc4d354df4ae0bbc47b8e7ad0855c2b77d901a839829cc4c6102f8a4a841d",
       "schemaHash": "ed4e8c293093075a364653d8c077f44d68157174b7b276fbdfafb9f31fc1207d"
     },
     {
@@ -23,7 +23,7 @@
     {
       "name": "qa",
       "resolvedPath": ".claude/phases/qa.ts",
-      "contentHash": "57a2e7137e07d170a7f8e2dd6a4011732e51b36cc6ae7614f93da7796f8526c3",
+      "contentHash": "ee792e077627d19bba38938de80be83b9f19950d38fc2c177f050eadf9e5eaf8",
       "schemaHash": "2c3159b3558360d1a25caf8e7f4401da2dba237bf3799807bc8c68497290cd40"
     },
     {
@@ -35,7 +35,7 @@
     {
       "name": "review",
       "resolvedPath": ".claude/phases/review.ts",
-      "contentHash": "c8c87b106056f672ee10828cfc0a91113e2a6e0cf8fe3f88105d6a1318bcd19f",
+      "contentHash": "ba36d89927a55921dd229eac3f0056ac69bc1cc7b398e08999e32e1e05b60db2",
       "schemaHash": "dbbe21e50a1a7a002a56c511d456060166ea94c6d15b2400e7f8283c861ed83d"
     },
     {


### PR DESCRIPTION
## Summary
- Extract `parsePrEditFlags()` into `phase-types.ts` — shared flag parser for the `prEdit` adapter used in both `review.ts` and `qa.ts`
- Parse `--add-label` flags and forward them as `addLabels` to `ctx.gh.pr().edit()` (previously silently discarded)
- Throw on unrecognized flags so future callers fail loudly instead of silently no-oping
- Regenerate `.mcx.lock` — also corrects stale `impl.ts` content hash from #2570

## Test plan
- [x] New `phase-types.spec.ts` with 6 tests: `--remove-label`, `--add-label`, mixed, multiple, empty, unknown-flag-throws
- [x] Existing 43 tests in `review-fn.spec.ts` and `qa-fn.spec.ts` still pass
- [x] `mcx phase install` + `mcx phase list` confirm all phases OK
- [x] `bun typecheck` clean
- [x] `bun lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)