### PR TITLE
fix(test): clean up leaked tmpdirs + missing afterEach import (fixes #2645, #2667)

### DIFF
--- a/scripts/check-stale-todos.spec.ts
+++ b/scripts/check-stale-todos.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "bun:test";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";

--- a/scripts/test-timings.spec.ts
+++ b/scripts/test-timings.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -32,6 +32,10 @@ describe("loadTimings / saveTimings", () => {
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "test-timings-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
   });
 
   it("returns empty object when file does not exist", () => {
@@ -114,6 +118,10 @@ describe("findChangedFiles", () => {
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "test-timings-changed-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
   });
 
   it("marks all files as changed when cache is empty", async () => {


### PR DESCRIPTION
## Summary
- `scripts/test-timings.spec.ts`: add `afterEach` cleanup (`rmSync(dir, { recursive: true, force: true })`) to both `mkdtempSync` describe blocks — stops ~15 leaked tmpdirs per run (fixes #2645). ~3300 leaked dirs were present in local `$TMPDIR` confirming the issue.
- `scripts/check-stale-todos.spec.ts`: add missing `afterEach` import (fixes #2667). Pre-existing #2644 regression on main — `ReferenceError: afterEach is not defined` as an unhandled error between tests, which fails the local `am-i-done` gate on every branch. Bundled here because it blocked this PR's gate; no other fix PR exists. CI didn't catch it because the JUnit parser ignores the `errors` attribute — tracked separately in #2669.

## Test plan
- [x] `bun test scripts/test-timings.spec.ts` — 18 pass; tmpdir count before/after run identical (zero new leaks)
- [x] `bun test scripts/check-stale-todos.spec.ts` — 20 pass, 0 errors (was 17 pass + 1 load error; 3 tests were blocked)
- [x] `bun run am-i-done` — all 8 steps green

🤖 Generated with [Claude Code](https://claude.com/claude-code)