### PR TITLE
refactor(codex): align waiter cleanup with opencode/acp siblings (fixes #2473, fixes #2468)

### DIFF
--- a/packages/codex/src/codex-session.spec.ts
+++ b/packages/codex/src/codex-session.spec.ts
@@ -84,6 +84,14 @@ describe("CodexSession (no process)", () => {
     await expect(session.waitForEvent(10)).rejects.toThrow("waitForEvent timeout");
   });
 
+  test("waitForEvent() cancel rejects and cleans up timer", async () => {
+    const { session } = makeSession();
+    const p = session.waitForEvent(5000);
+    expect(typeof p.cancel).toBe("function");
+    p.cancel?.();
+    await expect(p).rejects.toThrow("waitForEvent cancelled");
+  });
+
   test("terminate() resolves pending waitForResult with session:ended", async () => {
     const { session } = makeSession();
     const p = session.waitForResult(5000);

--- a/packages/codex/src/codex-session.ts
+++ b/packages/codex/src/codex-session.ts
@@ -232,12 +232,15 @@ export class CodexSession {
     });
   }
 
-  /** Wait for any actionable event. */
-  waitForEvent(timeoutMs: number): Promise<AgentSessionEvent> {
+  /** Wait for any actionable event. Returns a cancellable promise. */
+  waitForEvent(timeoutMs: number): Promise<AgentSessionEvent> & { cancel?: () => void } {
     if (this.state === "ended") {
       return Promise.reject(new Error("Session already ended"));
     }
-    return new Promise<AgentSessionEvent>((resolve, reject) => {
+
+    let cancelFn: (() => void) | undefined;
+
+    const promise = new Promise<AgentSessionEvent>((resolve, reject) => {
       const timer = setTimeout(() => {
         this.eventWaiters = this.eventWaiters.filter((w) => w !== waiter);
         reject(new Error(`waitForEvent timeout (${timeoutMs}ms)`));
@@ -248,8 +251,24 @@ export class CodexSession {
         this.eventWaiters = this.eventWaiters.filter((w) => w !== waiter);
         resolve(event);
       };
+
+      cancelFn = () => {
+        clearTimeout(timer);
+        this.eventWaiters = this.eventWaiters.filter((w) => w !== waiter);
+        reject(new Error("waitForEvent cancelled"));
+      };
+
       this.eventWaiters.push(waiter);
-    });
+
+      if (this.state === "ended") {
+        clearTimeout(timer);
+        this.eventWaiters = this.eventWaiters.filter((w) => w !== waiter);
+        resolve({ type: "session:ended" });
+      }
+    }) as Promise<AgentSessionEvent> & { cancel?: () => void };
+
+    promise.cancel = cancelFn;
+    return promise;
   }
 
   /** Get current session info. */

--- a/packages/daemon/src/codex-session-worker.ts
+++ b/packages/daemon/src/codex-session-worker.ts
@@ -434,19 +434,22 @@ async function handleWait(args: Record<string, unknown>): Promise<{
     return { content: [{ type: "text", text: JSON.stringify(event, null, 2) }] };
   }
 
-  // Wait for any session — race all waiters and suppress timeout rejections
-  // from the losers to prevent unhandled promise rejections from leaked timers.
+  // Wait for any session
   if (sessions.size === 0) {
     return { content: [{ type: "text", text: JSON.stringify([]) }] };
   }
 
   const waiters = [...sessions.values()].map((s) => s.waitForEvent(timeoutMs));
-  const event = await Promise.race(waiters);
-  // Swallow timeout rejections from losing waiters
-  for (const p of waiters) {
-    p.catch(() => {});
+  try {
+    const event = await Promise.race(waiters);
+    return { content: [{ type: "text", text: JSON.stringify(event, null, 2) }] };
+  } finally {
+    // Cancel losing waiters to prevent timer/reference leaks
+    for (const p of waiters) {
+      if (typeof p.cancel === "function") p.cancel();
+      p.catch(() => {});
+    }
   }
-  return { content: [{ type: "text", text: JSON.stringify(event, null, 2) }] };
 }
 
 function handleApprove(args: Record<string, unknown>): {


### PR DESCRIPTION
## Summary
- Adds cancellable promise pattern (`.cancel()`) to `CodexSession.waitForEvent()`, matching the existing `OpenCodeSession` and `AcpSession` implementations
- Wraps the `Promise.race` in `codex-session-worker.ts` with `try/finally` + `.cancel()` calls on losing waiters, preventing timer/reference leaks
- Adds test for the new cancel behavior

## Test plan
- [x] Existing 35 codex-session tests pass
- [x] New `waitForEvent() cancel rejects and cleans up timer` test passes
- [x] Typecheck clean
- [x] Lint clean
- [x] Full `am-i-done` passes (1 pre-existing flaky timeout in monitor event bridge, unrelated)

Fixes #2473, Fixes #2468

🤖 Generated with [Claude Code](https://claude.com/claude-code)