### PR TITLE
fix(phase): prune stale transition log entries on re-track (fixes #2463)

### DIFF
--- a/packages/command/src/commands/track.spec.ts
+++ b/packages/command/src/commands/track.spec.ts
@@ -1,6 +1,9 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { IpcMethod, IpcMethodResult, Manifest, TrackableField, WorkItem } from "@mcp-cli/core";
-import { loadManifest } from "@mcp-cli/core";
+import { appendTransitionLog, loadManifest, readAllTransitions } from "@mcp-cli/core";
 import type { TrackDeps } from "./track";
 import { cmdTrack, cmdTracked, cmdUntrack, formatWorkItemRow, parseMetadataFlags } from "./track";
 
@@ -898,5 +901,157 @@ describe("formatWorkItemRow", () => {
       expect(parsed[0].state).toEqual({ scrutiny: "high" });
       expect(parsed[0].state.session_id).toBeUndefined();
     });
+  });
+});
+
+describe("pruneStaleHistory integration (#2463)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "track-prune-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("re-tracking an issue prunes stale transition log entries", async () => {
+    const logPath = join(dir, ".mcx", "transitions.jsonl");
+
+    appendTransitionLog(logPath, {
+      ts: "2026-05-01T00:00:00Z",
+      workItemId: "#2135",
+      from: null,
+      to: "impl",
+      status: "committed",
+    });
+    appendTransitionLog(logPath, {
+      ts: "2026-05-01T01:00:00Z",
+      workItemId: "#2135",
+      from: "impl",
+      to: "triage",
+      status: "committed",
+    });
+    appendTransitionLog(logPath, {
+      ts: "2026-05-01T00:30:00Z",
+      workItemId: "#99",
+      from: null,
+      to: "impl",
+      status: "committed",
+    });
+
+    const freshCreatedAt = "2026-05-27 14:49:10";
+    const item = makeWorkItem({
+      id: "#2135",
+      issueNumber: 2135,
+      createdAt: freshCreatedAt,
+      version: 1,
+    });
+
+    const deps: TrackDeps = {
+      ipcCall: async <M extends IpcMethod>(method: M): Promise<IpcMethodResult[M]> => {
+        if (method === "trackWorkItem") return item as IpcMethodResult[M];
+        throw new Error(`Unexpected IPC call: ${method}`);
+      },
+      exit: (code: number): never => {
+        throw new ExitError(code);
+      },
+      cwd: () => dir,
+    };
+
+    await cmdTrack(["2135"], deps);
+
+    const remaining = readAllTransitions(logPath);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].workItemId).toBe("#99");
+  });
+
+  test("re-tracking a branch prunes stale transition log entries", async () => {
+    const logPath = join(dir, ".mcx", "transitions.jsonl");
+
+    appendTransitionLog(logPath, {
+      ts: "2026-04-01T00:00:00Z",
+      workItemId: "branch:feat/test",
+      from: null,
+      to: "impl",
+      status: "committed",
+    });
+
+    const freshCreatedAt = "2026-05-01T00:00:00Z";
+    const item = makeWorkItem({
+      id: "branch:feat/test",
+      branch: "feat/test",
+      createdAt: freshCreatedAt,
+      version: 1,
+    });
+
+    const deps: TrackDeps = {
+      ipcCall: async <M extends IpcMethod>(method: M): Promise<IpcMethodResult[M]> => {
+        if (method === "trackWorkItem") return item as IpcMethodResult[M];
+        throw new Error(`Unexpected IPC call: ${method}`);
+      },
+      exit: (code: number): never => {
+        throw new ExitError(code);
+      },
+      cwd: () => dir,
+    };
+
+    await cmdTrack(["--branch", "feat/test"], deps);
+
+    const remaining = readAllTransitions(logPath);
+    expect(remaining).toHaveLength(0);
+  });
+
+  test("preserves current-incarnation entries when re-tracking existing item", async () => {
+    const logPath = join(dir, ".mcx", "transitions.jsonl");
+
+    const createdAt = "2026-05-01T00:00:00Z";
+    appendTransitionLog(logPath, {
+      ts: "2026-05-01T00:01:00Z",
+      workItemId: "#42",
+      from: null,
+      to: "impl",
+      status: "committed",
+    });
+
+    const item = makeWorkItem({
+      id: "#42",
+      issueNumber: 42,
+      createdAt,
+      version: 2,
+    });
+
+    const deps: TrackDeps = {
+      ipcCall: async <M extends IpcMethod>(method: M): Promise<IpcMethodResult[M]> => {
+        if (method === "trackWorkItem") return item as IpcMethodResult[M];
+        throw new Error(`Unexpected IPC call: ${method}`);
+      },
+      exit: (code: number): never => {
+        throw new ExitError(code);
+      },
+      cwd: () => dir,
+    };
+
+    await cmdTrack(["42"], deps);
+
+    const remaining = readAllTransitions(logPath);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].workItemId).toBe("#42");
+  });
+
+  test("no-op when log file does not exist", async () => {
+    const item = makeWorkItem();
+    const deps: TrackDeps = {
+      ipcCall: async <M extends IpcMethod>(method: M): Promise<IpcMethodResult[M]> => {
+        if (method === "trackWorkItem") return item as IpcMethodResult[M];
+        throw new Error(`Unexpected IPC call: ${method}`);
+      },
+      exit: (code: number): never => {
+        throw new ExitError(code);
+      },
+      cwd: () => dir,
+    };
+
+    await cmdTrack(["1135"], deps);
   });
 });

--- a/packages/command/src/commands/track.spec.ts
+++ b/packages/command/src/commands/track.spec.ts
@@ -1054,4 +1054,53 @@ describe("pruneStaleHistory integration (#2463)", () => {
 
     await cmdTrack(["1135"], deps);
   });
+
+  test("createdAt in SQLite format (no TZ) is parsed as UTC, not local time", async () => {
+    const logPath = join(dir, ".mcx", "transitions.jsonl");
+
+    // Entry 30 minutes AFTER createdAt — must be preserved (current incarnation).
+    // If createdAt were parsed as local time on a UTC-4 machine, the cutoff
+    // would shift +4h and this entry would be incorrectly pruned.
+    const createdAt = "2026-06-01 12:00:00";
+    appendTransitionLog(logPath, {
+      ts: "2026-06-01T12:30:00Z",
+      workItemId: "#77",
+      from: null,
+      to: "impl",
+      status: "committed",
+    });
+
+    // Stale entry from prior sprint — must be pruned.
+    appendTransitionLog(logPath, {
+      ts: "2026-05-01T00:00:00Z",
+      workItemId: "#77",
+      from: null,
+      to: "impl",
+      status: "committed",
+    });
+
+    const item = makeWorkItem({
+      id: "#77",
+      issueNumber: 77,
+      createdAt,
+      version: 1,
+    });
+
+    const deps: TrackDeps = {
+      ipcCall: async <M extends IpcMethod>(method: M): Promise<IpcMethodResult[M]> => {
+        if (method === "trackWorkItem") return item as IpcMethodResult[M];
+        throw new Error(`Unexpected IPC call: ${method}`);
+      },
+      exit: (code: number): never => {
+        throw new ExitError(code);
+      },
+      cwd: () => dir,
+    };
+
+    await cmdTrack(["77"], deps);
+
+    const remaining = readAllTransitions(logPath);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].ts).toBe("2026-06-01T12:30:00Z");
+  });
 });

--- a/packages/command/src/commands/track.ts
+++ b/packages/command/src/commands/track.ts
@@ -9,6 +9,7 @@
  *          mcx tracked --json           Machine-readable output
  */
 
+import { join } from "node:path";
 import type { IpcMethod, IpcMethodResult, Manifest, TrackableField, WorkItem, WorkItemPhase } from "@mcp-cli/core";
 import {
   ManifestVersionError,
@@ -17,6 +18,7 @@ import {
   getTrackableFields,
   ipcCall,
   loadManifest,
+  pruneStaleHistory,
   validateTrackValue,
 } from "@mcp-cli/core";
 import { parseFlags } from "../flags";
@@ -178,6 +180,7 @@ export async function cmdTrack(args: string[], deps: TrackDeps = defaultDeps): P
         ...(automationOverrides ? { automationOverrides } : {}),
         repoRoot: cwd,
       });
+      pruneStaleHistory(join(cwd, ".mcx", "transitions.jsonl"), item.id, new Date(item.createdAt));
       await persistMetadata(deps, cwd, item.id, metadata, trackableFields);
       console.error(`Tracking branch ${branch} (${item.id})`);
     } catch (err) {
@@ -201,6 +204,7 @@ export async function cmdTrack(args: string[], deps: TrackDeps = defaultDeps): P
       ...(automationOverrides ? { automationOverrides } : {}),
       repoRoot: cwd,
     });
+    pruneStaleHistory(join(cwd, ".mcx", "transitions.jsonl"), item.id, new Date(item.createdAt));
     await persistMetadata(deps, cwd, item.id, metadata, trackableFields);
     console.error(`Tracking #${num} (${item.id})`);
   } catch (err) {

--- a/packages/command/src/commands/track.ts
+++ b/packages/command/src/commands/track.ts
@@ -24,6 +24,12 @@ import {
 import { parseFlags } from "../flags";
 import { c, printError } from "../output";
 
+/** Parse SQLite `datetime('now')` format ("YYYY-MM-DD HH:MM:SS", UTC without timezone indicator) as UTC. `new Date()` would parse it as local time. */
+function parseSqliteUtc(s: string): Date {
+  if (/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(s)) return new Date(`${s.replace(" ", "T")}Z`);
+  return new Date(s);
+}
+
 /** Load a manifest from the given directory, swallowing parse errors so they don't break CLI commands. Rethrows ManifestVersionError so callers can report version mismatches explicitly. */
 function tryLoadManifest(dir: string): Manifest | null {
   try {
@@ -180,7 +186,7 @@ export async function cmdTrack(args: string[], deps: TrackDeps = defaultDeps): P
         ...(automationOverrides ? { automationOverrides } : {}),
         repoRoot: cwd,
       });
-      pruneStaleHistory(join(cwd, ".mcx", "transitions.jsonl"), item.id, new Date(item.createdAt));
+      pruneStaleHistory(join(cwd, ".mcx", "transitions.jsonl"), item.id, parseSqliteUtc(item.createdAt));
       await persistMetadata(deps, cwd, item.id, metadata, trackableFields);
       console.error(`Tracking branch ${branch} (${item.id})`);
     } catch (err) {
@@ -204,7 +210,7 @@ export async function cmdTrack(args: string[], deps: TrackDeps = defaultDeps): P
       ...(automationOverrides ? { automationOverrides } : {}),
       repoRoot: cwd,
     });
-    pruneStaleHistory(join(cwd, ".mcx", "transitions.jsonl"), item.id, new Date(item.createdAt));
+    pruneStaleHistory(join(cwd, ".mcx", "transitions.jsonl"), item.id, parseSqliteUtc(item.createdAt));
     await persistMetadata(deps, cwd, item.id, metadata, trackableFields);
     console.error(`Tracking #${num} (${item.id})`);
   } catch (err) {

--- a/packages/core/src/phase-transition.spec.ts
+++ b/packages/core/src/phase-transition.spec.ts
@@ -11,6 +11,7 @@ import {
   commitTransition,
   historyTargets,
   levenshtein,
+  pruneStaleHistory,
   readAllTransitions,
   readTransitionHistory,
   suggestPhases,
@@ -391,5 +392,137 @@ describe("commitTransition / withTransitionLock (issue #1328)", () => {
       { staleMs: 1000, timeoutMs: 500 },
     );
     expect(ran).toBe(true);
+  });
+});
+
+describe("pruneStaleHistory (#2463)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "prune-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("removes entries for the work item older than cutoff, preserves others", () => {
+    const log = join(dir, "transitions.jsonl");
+    appendTransitionLog(log, {
+      ts: "2026-05-01T00:00:00Z",
+      workItemId: "#42",
+      from: null,
+      to: "impl",
+      status: "committed",
+    });
+    appendTransitionLog(log, {
+      ts: "2026-05-01T01:00:00Z",
+      workItemId: "#42",
+      from: "impl",
+      to: "triage",
+      status: "committed",
+    });
+    appendTransitionLog(log, {
+      ts: "2026-05-01T00:30:00Z",
+      workItemId: "#99",
+      from: null,
+      to: "impl",
+      status: "committed",
+    });
+    appendTransitionLog(log, {
+      ts: "2026-06-01T00:00:00Z",
+      workItemId: "#42",
+      from: null,
+      to: "impl",
+      status: "committed",
+    });
+
+    const cutoff = new Date("2026-05-27T14:49:10Z");
+    const pruned = pruneStaleHistory(log, "#42", cutoff);
+
+    expect(pruned).toBe(2);
+    const remaining = readAllTransitions(log);
+    expect(remaining).toHaveLength(2);
+    expect(remaining[0].workItemId).toBe("#99");
+    expect(remaining[1].workItemId).toBe("#42");
+    expect(remaining[1].ts).toBe("2026-06-01T00:00:00Z");
+  });
+
+  test("returns 0 and does not rewrite when no entries match", () => {
+    const log = join(dir, "transitions.jsonl");
+    appendTransitionLog(log, {
+      ts: "2026-06-01T00:00:00Z",
+      workItemId: "#42",
+      from: null,
+      to: "impl",
+      status: "committed",
+    });
+
+    const cutoff = new Date("2026-05-01T00:00:00Z");
+    const pruned = pruneStaleHistory(log, "#42", cutoff);
+
+    expect(pruned).toBe(0);
+    expect(readAllTransitions(log)).toHaveLength(1);
+  });
+
+  test("returns 0 when log file does not exist (ENOENT)", () => {
+    const log = join(dir, "nonexistent", "transitions.jsonl");
+    const pruned = pruneStaleHistory(log, "#42", new Date());
+    expect(pruned).toBe(0);
+  });
+
+  test("returns 0 when log is empty", () => {
+    const log = join(dir, "transitions.jsonl");
+    require("node:fs").mkdirSync(dir, { recursive: true });
+    require("node:fs").writeFileSync(log, "", "utf-8");
+
+    const pruned = pruneStaleHistory(log, "#42", new Date());
+    expect(pruned).toBe(0);
+  });
+
+  test("removes all stale entries when every entry for the item is stale", () => {
+    const log = join(dir, "transitions.jsonl");
+    appendTransitionLog(log, {
+      ts: "2026-01-01T00:00:00Z",
+      workItemId: "#10",
+      from: null,
+      to: "impl",
+      status: "committed",
+    });
+    appendTransitionLog(log, {
+      ts: "2026-01-02T00:00:00Z",
+      workItemId: "#10",
+      from: "impl",
+      to: "triage",
+      status: "committed",
+    });
+
+    const pruned = pruneStaleHistory(log, "#10", new Date("2026-06-01T00:00:00Z"));
+    expect(pruned).toBe(2);
+    expect(readAllTransitions(log)).toHaveLength(0);
+  });
+
+  test("preserves attempted entries older than cutoff for other work items", () => {
+    const log = join(dir, "transitions.jsonl");
+    appendTransitionLog(log, {
+      ts: "2026-01-01T00:00:00Z",
+      workItemId: "#50",
+      from: null,
+      to: "impl",
+      status: "attempted",
+    });
+    appendTransitionLog(log, {
+      ts: "2026-01-01T00:00:00Z",
+      workItemId: "#42",
+      from: null,
+      to: "impl",
+      status: "attempted",
+    });
+
+    const pruned = pruneStaleHistory(log, "#42", new Date("2026-06-01T00:00:00Z"));
+    expect(pruned).toBe(1);
+    const remaining = readAllTransitions(log);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].workItemId).toBe("#50");
   });
 });

--- a/packages/core/src/phase-transition.ts
+++ b/packages/core/src/phase-transition.ts
@@ -15,7 +15,17 @@
  * reasoning is preserved alongside the transition itself.
  */
 
-import { appendFileSync, closeSync, mkdirSync, openSync, readFileSync, statSync, unlinkSync, writeSync } from "node:fs";
+import {
+  appendFileSync,
+  closeSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+  writeSync,
+} from "node:fs";
 import { dirname } from "node:path";
 import type { Manifest } from "./manifest";
 
@@ -293,6 +303,39 @@ export function readAllTransitions(logPath: string): TransitionLogEntry[] {
     }
   }
   return out;
+}
+
+/**
+ * Remove stale transition log entries for a work item whose incarnation
+ * predates `cutoff`. Used by `mcx track` to clear history from prior
+ * sprints so a re-tracked item starts with a clean slate (issue #2463).
+ *
+ * Returns the number of entries pruned. Acquires `withTransitionLock` so
+ * concurrent phase runs can't race with the rewrite.
+ */
+export function pruneStaleHistory(logPath: string, workItemId: string, cutoff: Date): number {
+  return withTransitionLock(logPath, () => {
+    const all = readAllTransitions(logPath);
+    if (all.length === 0) return 0;
+
+    const cutoffMs = cutoff.getTime();
+    const kept: TransitionLogEntry[] = [];
+    let pruned = 0;
+    for (const entry of all) {
+      if (entry.workItemId === workItemId && new Date(entry.ts).getTime() < cutoffMs) {
+        pruned++;
+      } else {
+        kept.push(entry);
+      }
+    }
+
+    if (pruned === 0) return 0;
+
+    mkdirSync(dirname(logPath), { recursive: true });
+    const content = kept.map((e) => JSON.stringify(e)).join("\n") + (kept.length > 0 ? "\n" : "");
+    writeFileSync(logPath, content, "utf-8");
+    return pruned;
+  });
 }
 
 /** Return the `to` field of every history entry, oldest first. */


### PR DESCRIPTION
## Summary
- Add `pruneStaleHistory(logPath, workItemId, cutoff)` to `core/phase-transition.ts` — removes transition log entries for a work item that predate its `createdAt`, under `withTransitionLock` for concurrency safety
- Call it from `track.ts` after `trackWorkItem` returns (both number-track and branch-track paths), using `item.createdAt` as the cutoff
- Fixes both failure modes: stale `logCandidate` poisoning `from` resolution (DisallowedTransitionError) and stale history triggering false regression detection (RegressionError)

## Test plan
- [x] 6 unit tests in `phase-transition.spec.ts`: mixed entries (prune matching + preserve others), no-match no-op, ENOENT, empty log, all-stale, attempted entries for other work items
- [x] 4 integration tests in `track.spec.ts`: re-track issue prunes stale entries, re-track branch prunes, preserves current-incarnation entries, no-op when log missing
- [x] #1802 regression guard: all 175 phase.spec.ts tests pass (stale-db-vs-log precedence unaffected — pruning happens at track time, not phase-run time)
- [x] typecheck, lint, doing-it-wrong rules all clean
- [x] Pre-commit and pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)