### PR TITLE
fix(test): eliminate double condition evaluation in pollUntil (fixes #2630)

### DIFF
--- a/test/harness.spec.ts
+++ b/test/harness.spec.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { pollUntil } from "./harness";
+
+describe("pollUntil", () => {
+  test("resolves when condition is immediately true", async () => {
+    let callCount = 0;
+    await pollUntil(() => {
+      callCount++;
+      return true;
+    });
+    expect(callCount).toBe(1);
+  });
+
+  test("does not evaluate condition extra time on success", async () => {
+    let callCount = 0;
+    await pollUntil(() => {
+      callCount++;
+      return callCount >= 3;
+    });
+    expect(callCount).toBe(3);
+  });
+
+  test("throws on timeout", async () => {
+    await expect(pollUntil(() => false, 50, 10)).rejects.toThrow("pollUntil: condition not met within 50ms");
+  });
+
+  test("works with async conditions", async () => {
+    let callCount = 0;
+    await pollUntil(async () => {
+      callCount++;
+      return callCount >= 2;
+    });
+    expect(callCount).toBe(2);
+  });
+
+  test("accepts truthy non-boolean returns", async () => {
+    await pollUntil(() => 1);
+    await pollUntil(() => 42);
+  });
+});

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -154,10 +154,15 @@ export async function pollUntil(
   intervalMs = 10,
 ): Promise<void> {
   const deadline = Date.now() + timeoutMs;
-  while (!(await condition()) && Date.now() < deadline) {
+  let met = false;
+  while (Date.now() < deadline) {
+    if (await condition()) {
+      met = true;
+      break;
+    }
     await Bun.sleep(intervalMs);
   }
-  if (!(await condition())) throw new Error(`pollUntil: condition not met within ${timeoutMs}ms`);
+  if (!met) throw new Error(`pollUntil: condition not met within ${timeoutMs}ms`);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Restructured `pollUntil` in `test/harness.ts` to track success in a `met` flag instead of re-evaluating the condition after the loop exits
- Eliminates one extra condition evaluation (IPC round-trip) on every successful poll
- Checks deadline *before* condition evaluation (correct order — avoids one post-deadline evaluation on expiry)

## Test plan
- [x] Added `test/harness.spec.ts` with 5 tests covering:
  - Immediate success (condition called exactly once)
  - Delayed success (no extra evaluation — exact call count)
  - Timeout behavior (throws with descriptive message)
  - Async conditions
  - Truthy non-boolean returns
- [x] Ran 206 tests in files that use `pollUntil` — all pass
- [x] Full suite: 8814 tests, 0 failures
- [x] `bun typecheck` — pass
- [x] `bun lint` — pass
- [x] `bun run doing-it-wrong` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)