### PR TITLE
refactor(command): hoist git-root/diff-stats/PR-status into shared session-deps.ts (fixes #2505)

### DIFF
--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -11,14 +11,13 @@
 
 import { existsSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { join } from "node:path";
 import {
   type AgentFeatures,
   type AgentProvider,
   type LookupResult,
   type MailMessage,
   isLookupFailure,
-  lookupFailure,
   resolveGitRootOrCwd,
   validateAllowPatterns,
 } from "@mcp-cli/core";
@@ -28,7 +27,6 @@ import { emitMailEvent, pollMailUntil } from "./mail-wait";
 import "../help-claude";
 import {
   DEFAULT_TIMEOUT_MS,
-  GIT_REV_PARSE_TIMEOUT_MS,
   PROMPT_IPC_TIMEOUT_MS,
   WorktreeError,
   buildHookEnv,
@@ -52,8 +50,6 @@ import {
   type SharedSessionDeps,
   buildResumePrompt,
   cleanupWorktree,
-  defaultGetDiffStats,
-  defaultGetPrStatus,
   extractIssueNumber,
   parseApproveArgs,
   parseByeResult,
@@ -62,6 +58,7 @@ import {
   resolveSessionId,
   resolveWorktree,
 } from "./claude";
+import { defaultGetDiffStats, defaultGetPrStatus, getGitRoot } from "./session-deps";
 import {
   colorState,
   extractContentSummary,
@@ -110,16 +107,6 @@ function makeCallTool(provider: AgentProvider): (tool: string, args: Record<stri
     const timeoutMs = needsLongTimeout ? PROMPT_IPC_TIMEOUT_MS : undefined;
     return ipcCall("callTool", { server: provider.serverName, tool, arguments: args }, { timeoutMs });
   };
-}
-
-function getGitRoot(): LookupResult<string | null> {
-  const result = spawnCaptureSync("git", ["rev-parse", "--git-common-dir"], { timeoutMs: GIT_REV_PARSE_TIMEOUT_MS });
-  if (!result.ok)
-    return lookupFailure(`git rev-parse --git-common-dir failed (exit ${result.exitCode}): ${result.stderr.trim()}`);
-  const commonDir = result.stdout.trim();
-  if (!commonDir) return null;
-  const resolved = resolve(commonDir);
-  return resolved.endsWith(".git") ? dirname(resolved) : resolved;
 }
 
 export function makeDefaultDeps(provider: AgentProvider): AgentDeps {

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -6,13 +6,12 @@
  * No dedicated IPC methods — the same tools work from any MCP client.
  */
 
-import { dirname, join, resolve } from "node:path";
+import { join } from "node:path";
 import { CLAUDE_SUB_ALIASES, formatHelp, getHelp, hasHelpFlag } from "../help";
 import "../help-claude";
 import {
   CLAUDE_SERVER_NAME,
   DEFAULT_TIMEOUT_MS,
-  GIT_REV_PARSE_TIMEOUT_MS,
   MAX_TIMEOUT_MS,
   PROMPT_IPC_TIMEOUT_MS,
   WorktreeError,
@@ -27,7 +26,6 @@ import {
   readWorktreeConfig,
   resolveEffectiveTools,
   resolveModelName,
-  resolveRealpath,
   resolveWorktreePath,
   spawnCaptureSync,
   updatePatchedClaude,
@@ -51,8 +49,9 @@ import { parseSharedSpawnArgs } from "./spawn-args";
 import { ttyOpen } from "./tty";
 
 import type { LookupResult, MailMessage, QuotaStatusResult, SessionInfo, WorkItem } from "@mcp-cli/core";
-import { isLookupFailure, lookupFailure, resolveGitRootOrCwd, runOrLookupFailure } from "@mcp-cli/core";
+import { isLookupFailure, resolveGitRootOrCwd } from "@mcp-cli/core";
 import { emitMailEvent, pollMailUntil } from "./mail-wait";
+import { type PrStatus, defaultGetDiffStats, defaultGetPrStatus, getGitRoot, parseDiffShortstat } from "./session-deps";
 
 // ── Dependency injection ──
 
@@ -61,10 +60,7 @@ const QUICK_IPC_PROBE_TIMEOUT_MS = 2_000;
 /** Per-worktree git probe — must finish well inside an interactive `ls` render. */
 const WORKTREE_GIT_PROBE_TIMEOUT_MS = 3_000;
 
-export interface PrStatus {
-  number: number;
-  state: string;
-}
+export type { PrStatus } from "./session-deps";
 
 /** Shared dependency interface for session-based commands (claude, codex). */
 export interface SharedSessionDeps {
@@ -108,77 +104,7 @@ export interface ClaudeDeps extends SharedSessionDeps {
   } | null>;
 }
 
-/**
- * Parse `git diff --shortstat` output into a compact diff summary.
- * Returns e.g. `+142/-38 (4f)` or null if no changes / parse failure.
- */
-export function parseDiffShortstat(output: string): string | null {
-  const trimmed = output.trim();
-  if (!trimmed) return null;
-
-  const filesMatch = trimmed.match(/(\d+)\s+file/);
-  const insertMatch = trimmed.match(/(\d+)\s+insertion/);
-  const deleteMatch = trimmed.match(/(\d+)\s+deletion/);
-
-  const files = filesMatch ? Number(filesMatch[1]) : 0;
-  const insertions = insertMatch ? Number(insertMatch[1]) : 0;
-  const deletions = deleteMatch ? Number(deleteMatch[1]) : 0;
-
-  if (files === 0 && insertions === 0 && deletions === 0) return null;
-
-  return `+${insertions}/-${deletions} (${files}f)`;
-}
-
-export async function defaultGetDiffStats(worktreePath: string): Promise<LookupResult<string | null>> {
-  const stdout = await runOrLookupFailure("git", ["diff", "--shortstat"], { cwd: worktreePath });
-  if (isLookupFailure(stdout)) return stdout;
-  return parseDiffShortstat(stdout);
-}
-
-export async function defaultGetPrStatus(worktreePath: string): Promise<LookupResult<PrStatus | null>> {
-  const branchOut = await runOrLookupFailure("git", ["branch", "--show-current"], { cwd: worktreePath });
-  if (isLookupFailure(branchOut)) return branchOut;
-  const branch = branchOut.trim();
-  if (!branch) return null;
-
-  const prOut = await runOrLookupFailure("gh", [
-    "pr",
-    "list",
-    "--head",
-    branch,
-    "--json",
-    "number,state",
-    "--limit",
-    "1",
-  ]);
-  if (isLookupFailure(prOut)) return prOut;
-
-  let prs: Array<{ number: number; state: string }>;
-  try {
-    prs = JSON.parse(prOut.trim()) as Array<{ number: number; state: string }>;
-  } catch {
-    return lookupFailure(`Failed to parse gh pr list output for ${worktreePath}: ${prOut.slice(0, 100)}`);
-  }
-  if (!Array.isArray(prs) || prs.length === 0) return null;
-  const pr = prs[0];
-  return { number: pr.number, state: pr.state.toLowerCase() };
-}
-
-/**
- * Resolve the git repo root for the current working directory.
- * Uses --git-common-dir to resolve to the main repo root, not a worktree.
- * Returns null if not inside a git repo.
- */
-function getGitRoot(): LookupResult<string | null> {
-  const result = spawnCaptureSync("git", ["rev-parse", "--git-common-dir"], { timeoutMs: GIT_REV_PARSE_TIMEOUT_MS });
-  if (!result.ok)
-    return lookupFailure(`git rev-parse --git-common-dir failed (exit ${result.exitCode}): ${result.stderr.trim()}`);
-  const commonDir = result.stdout.trim();
-  if (!commonDir) return null;
-  const resolved = resolve(commonDir);
-  const root = resolved.endsWith(".git") ? dirname(resolved) : resolved;
-  return resolveRealpath(root);
-}
+export { defaultGetDiffStats, defaultGetPrStatus, getGitRoot, parseDiffShortstat } from "./session-deps";
 
 export const defaultDeps: ClaudeDeps = {
   callTool: (tool, args) => {

--- a/packages/command/src/commands/session-deps.spec.ts
+++ b/packages/command/src/commands/session-deps.spec.ts
@@ -6,7 +6,14 @@ import { join } from "node:path";
 import { isLookupFailure } from "@mcp-cli/core";
 import { defaultGetDiffStats, defaultGetPrStatus, getGitRoot, parseDiffShortstat } from "./session-deps";
 
-const GIT_ENV = { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null" };
+const GIT_ENV = {
+  ...process.env,
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_AUTHOR_NAME: "t",
+  GIT_AUTHOR_EMAIL: "t@t",
+  GIT_COMMITTER_NAME: "t",
+  GIT_COMMITTER_EMAIL: "t@t",
+};
 
 // ── parseDiffShortstat ──
 

--- a/packages/command/src/commands/session-deps.spec.ts
+++ b/packages/command/src/commands/session-deps.spec.ts
@@ -1,0 +1,139 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { isLookupFailure } from "@mcp-cli/core";
+import { defaultGetDiffStats, defaultGetPrStatus, getGitRoot, parseDiffShortstat } from "./session-deps";
+
+const GIT_ENV = { ...process.env, GIT_CONFIG_GLOBAL: "/dev/null" };
+
+// ── parseDiffShortstat ──
+
+describe("parseDiffShortstat", () => {
+  test("parses full shortstat line", () => {
+    expect(parseDiffShortstat(" 4 files changed, 142 insertions(+), 38 deletions(-)\n")).toBe("+142/-38 (4f)");
+  });
+
+  test("handles insertions only", () => {
+    expect(parseDiffShortstat(" 2 files changed, 50 insertions(+)\n")).toBe("+50/-0 (2f)");
+  });
+
+  test("handles deletions only", () => {
+    expect(parseDiffShortstat(" 1 file changed, 10 deletions(-)\n")).toBe("+0/-10 (1f)");
+  });
+
+  test("returns null for empty or whitespace", () => {
+    expect(parseDiffShortstat("")).toBeNull();
+    expect(parseDiffShortstat("  \n")).toBeNull();
+  });
+});
+
+// ── getGitRoot ──
+
+describe("getGitRoot", () => {
+  test("returns a string in a git repository", () => {
+    const root = getGitRoot();
+    expect(typeof root).toBe("string");
+  });
+
+  test("returned path is fully symlink-resolved (canonical)", () => {
+    const root = getGitRoot();
+    if (typeof root !== "string") throw new Error("expected string from getGitRoot");
+    expect(realpathSync(root)).toBe(root);
+  });
+
+  test("resolves symlinked cwd to the real repo root, not the symlink path", () => {
+    const base = mkdtempSync(join(tmpdir(), "mcp-session-deps-test-"));
+    const real = join(base, "real-dir");
+    mkdirSync(real);
+    const link = join(base, "link-dir");
+    symlinkSync(real, link);
+
+    Bun.spawnSync(["git", "init", "-q"], { cwd: real, env: GIT_ENV });
+
+    const orig = process.cwd();
+    process.chdir(link);
+    try {
+      const root = getGitRoot();
+      expect(typeof root).toBe("string");
+      if (typeof root !== "string") return;
+      expect(root).toBe(realpathSync(real));
+      expect(root).not.toContain("link-dir");
+    } finally {
+      process.chdir(orig);
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+});
+
+// ── defaultGetDiffStats ──
+
+describe("defaultGetDiffStats", () => {
+  let dir: string;
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("returns null when no changes", async () => {
+    dir = mkdtempSync(join(tmpdir(), "mcp-diff-test-"));
+    Bun.spawnSync(["git", "init", "-q"], { cwd: dir, env: GIT_ENV });
+    Bun.spawnSync(["git", "-C", dir, "commit", "--allow-empty", "-m", "init"], { env: GIT_ENV });
+    const result = await defaultGetDiffStats(dir);
+    expect(result).toBeNull();
+  });
+
+  test("returns diff summary for unstaged changes", async () => {
+    dir = mkdtempSync(join(tmpdir(), "mcp-diff-test-"));
+    Bun.spawnSync(["git", "init", "-q"], { cwd: dir, env: GIT_ENV });
+    writeFileSync(join(dir, "a.txt"), "hello\n");
+    Bun.spawnSync(["git", "-C", dir, "add", "."], { env: GIT_ENV });
+    Bun.spawnSync(["git", "-C", dir, "commit", "-m", "add a"], { env: GIT_ENV });
+    writeFileSync(join(dir, "a.txt"), "hello\nworld\n");
+    const result = await defaultGetDiffStats(dir);
+    expect(typeof result).toBe("string");
+    expect(result).toContain("+");
+    expect(result).toContain("(1f)");
+  });
+
+  test("returns LookupFailure for non-git directory", async () => {
+    dir = mkdtempSync(join(tmpdir(), "mcp-diff-test-"));
+    const result = await defaultGetDiffStats(dir);
+    expect(isLookupFailure(result)).toBe(true);
+  });
+});
+
+// ── defaultGetPrStatus ──
+
+describe("defaultGetPrStatus", () => {
+  let dir: string;
+
+  afterEach(() => {
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("returns null for detached HEAD (no branch)", async () => {
+    dir = mkdtempSync(join(tmpdir(), "mcp-pr-test-"));
+    Bun.spawnSync(["git", "init", "-q"], { cwd: dir, env: GIT_ENV });
+    Bun.spawnSync(["git", "-C", dir, "commit", "--allow-empty", "-m", "init"], { env: GIT_ENV });
+    Bun.spawnSync(["git", "-C", dir, "checkout", "--detach"], { env: GIT_ENV });
+    const result = await defaultGetPrStatus(dir);
+    expect(result).toBeNull();
+  });
+
+  test("returns LookupFailure or null for local-only branch (no remote)", async () => {
+    dir = mkdtempSync(join(tmpdir(), "mcp-pr-test-"));
+    Bun.spawnSync(["git", "init", "-q"], { cwd: dir, env: GIT_ENV });
+    Bun.spawnSync(["git", "-C", dir, "commit", "--allow-empty", "-m", "init"], { env: GIT_ENV });
+    const result = await defaultGetPrStatus(dir);
+    // gh pr list will fail (no remote) → LookupFailure, or return null/empty
+    expect(result === null || isLookupFailure(result)).toBe(true);
+  });
+
+  test("returns LookupFailure for non-git directory", async () => {
+    dir = mkdtempSync(join(tmpdir(), "mcp-pr-test-"));
+    const result = await defaultGetPrStatus(dir);
+    expect(isLookupFailure(result)).toBe(true);
+  });
+});

--- a/packages/command/src/commands/session-deps.spec.ts
+++ b/packages/command/src/commands/session-deps.spec.ts
@@ -6,8 +6,17 @@ import { join } from "node:path";
 import { isLookupFailure } from "@mcp-cli/core";
 import { defaultGetDiffStats, defaultGetPrStatus, getGitRoot, parseDiffShortstat } from "./session-deps";
 
+const {
+  GIT_DIR: _d,
+  GIT_WORK_TREE: _w,
+  GIT_COMMON_DIR: _c,
+  GIT_INDEX_FILE: _i,
+  GIT_OBJECT_DIRECTORY: _o,
+  ...baseEnv
+} = process.env;
+
 const GIT_ENV = {
-  ...process.env,
+  ...baseEnv,
   GIT_CONFIG_GLOBAL: "/dev/null",
   GIT_AUTHOR_NAME: "t",
   GIT_AUTHOR_EMAIL: "t@t",

--- a/packages/command/src/commands/session-deps.ts
+++ b/packages/command/src/commands/session-deps.ts
@@ -13,8 +13,26 @@ import {
   lookupFailure,
   resolveRealpath,
   runOrLookupFailure,
+  spawnCapture,
   spawnCaptureSync,
 } from "@mcp-cli/core";
+
+/**
+ * Strip git-hook env vars (GIT_DIR, GIT_INDEX_FILE, etc.) so that git
+ * subprocesses use cwd-based repository detection instead of the hook's
+ * injected context.  This matters when mcx is invoked from inside a git hook.
+ */
+function cleanGitHookEnv(): NodeJS.ProcessEnv {
+  const {
+    GIT_DIR: _d,
+    GIT_WORK_TREE: _w,
+    GIT_COMMON_DIR: _c,
+    GIT_INDEX_FILE: _i,
+    GIT_OBJECT_DIRECTORY: _o,
+    ...rest
+  } = process.env;
+  return rest;
+}
 
 // ── Types ──
 
@@ -32,7 +50,10 @@ export interface PrStatus {
  * Returns null if not inside a git repo.
  */
 export function getGitRoot(): LookupResult<string | null> {
-  const result = spawnCaptureSync("git", ["rev-parse", "--git-common-dir"], { timeoutMs: GIT_REV_PARSE_TIMEOUT_MS });
+  const result = spawnCaptureSync("git", ["rev-parse", "--git-common-dir"], {
+    timeoutMs: GIT_REV_PARSE_TIMEOUT_MS,
+    env: cleanGitHookEnv(),
+  });
   if (!result.ok)
     return lookupFailure(`git rev-parse --git-common-dir failed (exit ${result.exitCode}): ${result.stderr.trim()}`);
   const commonDir = result.stdout.trim();
@@ -66,17 +87,21 @@ export function parseDiffShortstat(output: string): string | null {
 }
 
 export async function defaultGetDiffStats(worktreePath: string): Promise<LookupResult<string | null>> {
-  const stdout = await runOrLookupFailure("git", ["diff", "--shortstat"], { cwd: worktreePath });
-  if (isLookupFailure(stdout)) return stdout;
-  return parseDiffShortstat(stdout);
+  const result = await spawnCapture("git", ["diff", "--shortstat"], { cwd: worktreePath, env: cleanGitHookEnv() });
+  if (!result.ok) return lookupFailure(`git diff failed (exit ${result.exitCode}): ${result.stderr.trim()}`);
+  return parseDiffShortstat(result.stdout);
 }
 
 // ── PR status ──
 
 export async function defaultGetPrStatus(worktreePath: string): Promise<LookupResult<PrStatus | null>> {
-  const branchOut = await runOrLookupFailure("git", ["branch", "--show-current"], { cwd: worktreePath });
-  if (isLookupFailure(branchOut)) return branchOut;
-  const branch = branchOut.trim();
+  const branchResult = await spawnCapture("git", ["branch", "--show-current"], {
+    cwd: worktreePath,
+    env: cleanGitHookEnv(),
+  });
+  if (!branchResult.ok)
+    return lookupFailure(`git branch failed (exit ${branchResult.exitCode}): ${branchResult.stderr.trim()}`);
+  const branch = branchResult.stdout.trim();
   if (!branch) return null;
 
   const prOut = await runOrLookupFailure("gh", [

--- a/packages/command/src/commands/session-deps.ts
+++ b/packages/command/src/commands/session-deps.ts
@@ -1,0 +1,103 @@
+/**
+ * Shared default-dependency wrappers for session-based commands (claude, agent).
+ *
+ * Houses the git-root resolver, diff-stats, and PR-status helpers so that
+ * `claude.ts`, `agent.ts`, and `session-display.ts` share one implementation.
+ */
+
+import { dirname, resolve } from "node:path";
+import type { LookupResult } from "@mcp-cli/core";
+import {
+  GIT_REV_PARSE_TIMEOUT_MS,
+  isLookupFailure,
+  lookupFailure,
+  resolveRealpath,
+  runOrLookupFailure,
+  spawnCaptureSync,
+} from "@mcp-cli/core";
+
+// ── Types ──
+
+export interface PrStatus {
+  number: number;
+  state: string;
+}
+
+// ── Git root ──
+
+/**
+ * Resolve the git repo root for the current working directory.
+ * Uses --git-common-dir to resolve to the main repo root, not a worktree.
+ * Resolves symlinks via `resolveRealpath` so callers always get a canonical path.
+ * Returns null if not inside a git repo.
+ */
+export function getGitRoot(): LookupResult<string | null> {
+  const result = spawnCaptureSync("git", ["rev-parse", "--git-common-dir"], { timeoutMs: GIT_REV_PARSE_TIMEOUT_MS });
+  if (!result.ok)
+    return lookupFailure(`git rev-parse --git-common-dir failed (exit ${result.exitCode}): ${result.stderr.trim()}`);
+  const commonDir = result.stdout.trim();
+  if (!commonDir) return null;
+  const resolved = resolve(commonDir);
+  const root = resolved.endsWith(".git") ? dirname(resolved) : resolved;
+  return resolveRealpath(root);
+}
+
+// ── Diff stats ──
+
+/**
+ * Parse `git diff --shortstat` output into a compact diff summary.
+ * Returns e.g. `+142/-38 (4f)` or null if no changes / parse failure.
+ */
+export function parseDiffShortstat(output: string): string | null {
+  const trimmed = output.trim();
+  if (!trimmed) return null;
+
+  const filesMatch = trimmed.match(/(\d+)\s+file/);
+  const insertMatch = trimmed.match(/(\d+)\s+insertion/);
+  const deleteMatch = trimmed.match(/(\d+)\s+deletion/);
+
+  const files = filesMatch ? Number(filesMatch[1]) : 0;
+  const insertions = insertMatch ? Number(insertMatch[1]) : 0;
+  const deletions = deleteMatch ? Number(deleteMatch[1]) : 0;
+
+  if (files === 0 && insertions === 0 && deletions === 0) return null;
+
+  return `+${insertions}/-${deletions} (${files}f)`;
+}
+
+export async function defaultGetDiffStats(worktreePath: string): Promise<LookupResult<string | null>> {
+  const stdout = await runOrLookupFailure("git", ["diff", "--shortstat"], { cwd: worktreePath });
+  if (isLookupFailure(stdout)) return stdout;
+  return parseDiffShortstat(stdout);
+}
+
+// ── PR status ──
+
+export async function defaultGetPrStatus(worktreePath: string): Promise<LookupResult<PrStatus | null>> {
+  const branchOut = await runOrLookupFailure("git", ["branch", "--show-current"], { cwd: worktreePath });
+  if (isLookupFailure(branchOut)) return branchOut;
+  const branch = branchOut.trim();
+  if (!branch) return null;
+
+  const prOut = await runOrLookupFailure("gh", [
+    "pr",
+    "list",
+    "--head",
+    branch,
+    "--json",
+    "number,state",
+    "--limit",
+    "1",
+  ]);
+  if (isLookupFailure(prOut)) return prOut;
+
+  let prs: Array<{ number: number; state: string }>;
+  try {
+    prs = JSON.parse(prOut.trim()) as Array<{ number: number; state: string }>;
+  } catch {
+    return lookupFailure(`Failed to parse gh pr list output for ${worktreePath}: ${prOut.slice(0, 100)}`);
+  }
+  if (!Array.isArray(prs) || prs.length === 0) return null;
+  const pr = prs[0];
+  return { number: pr.number, state: pr.state.toLowerCase() };
+}

--- a/packages/command/src/commands/session-display.ts
+++ b/packages/command/src/commands/session-display.ts
@@ -2,9 +2,8 @@
  * Shared session-display helpers used by `claude.ts` and `agent.ts`.
  */
 
-import { dirname, resolve } from "node:path";
+import { dirname } from "node:path";
 import type { WorkItem } from "@mcp-cli/core";
-import { GIT_REV_PARSE_TIMEOUT_MS, spawnCaptureSync } from "@mcp-cli/core";
 import { c } from "../output";
 
 // ── Transcript walker ──
@@ -405,23 +404,6 @@ export function compactTranscript(entries: TranscriptEntry[], maxResultLen = 100
     }
     return entry;
   });
-}
-
-/**
- * Get the git repo root for the current working directory.
- * Uses --git-common-dir to resolve to the main repo root, not a worktree.
- */
-export function getGitRepoRoot(): string | null {
-  try {
-    const result = spawnCaptureSync("git", ["rev-parse", "--git-common-dir"], { timeoutMs: GIT_REV_PARSE_TIMEOUT_MS });
-    if (!result.ok) return null;
-    const commonDir = result.stdout.trim();
-    if (!commonDir) return null;
-    const resolved = resolve(commonDir);
-    return resolved.endsWith(".git") ? dirname(resolved) : resolved;
-  } catch {
-    return null;
-  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Extracts `getGitRoot`, `defaultGetDiffStats`, `defaultGetPrStatus`, `parseDiffShortstat`, and `PrStatus` from `claude.ts` into a new `session-deps.ts` module
- Removes the duplicate `getGitRoot` from `agent.ts` and the dead `getGitRepoRoot` from `session-display.ts`
- Re-exports from `claude.ts` preserve import compatibility for all existing consumers

**Behavioral change:** `agent.ts` now calls `resolveRealpath` on the git root (matching `claude.ts`), so symlinked working directories resolve to the canonical repo path. This was a correctness gap — `claude.ts` already did this, `agent.ts` did not.

## Test plan
- [x] New `session-deps.spec.ts` with 13 tests covering:
  - `parseDiffShortstat` parsing (full, insertions-only, deletions-only, empty)
  - `getGitRoot` returns string in git repo, path is canonical/symlink-resolved
  - `getGitRoot` resolves symlinked cwd to real repo root (the behavioral change)
  - `defaultGetDiffStats` returns null for clean repo, diff summary for changes, LookupFailure for non-git dir
  - `defaultGetPrStatus` returns null for detached HEAD, handles local-only branch, LookupFailure for non-git dir
- [x] Existing `claude.spec.ts` (369 tests) passes — re-exports preserve compatibility
- [x] Existing `agent.spec.ts` (172 tests) passes
- [x] `session-deps.ts` at 94% line coverage (above 80% ratchet)
- [x] Full `bun run am-i-done` passes (typecheck, lint, rules, parallel tests, coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)