### PR TITLE
feat(agent-grid): capability tests batch 2 — interrupt-and-recover, fix-typescript, report-cost, permission-baseline, resume-session (fixes #2589)

### DIFF
--- a/agent-grid/src/tests/fix-typescript.ts
+++ b/agent-grid/src/tests/fix-typescript.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import type { GridTest } from "../grid-test";
 import { type CallToolFn, byeSession, promptAndWait } from "./helpers";
@@ -23,6 +23,10 @@ export function makeFixTypescriptTest(deps: { callTool: CallToolFn }): GridTest 
       ctx.onCleanup?.(() => byeSession(ctx.provider, result.sessionId, deps.callTool));
 
       try {
+        if (!existsSync(filePath)) {
+          return { status: "fail", error: "agent deleted the fixture file instead of fixing it" };
+        }
+
         const content = readFileSync(filePath, "utf-8");
 
         if (/const\s+greeting\s*:\s*number\s*=\s*"/.test(content)) {

--- a/agent-grid/src/tests/fix-typescript.ts
+++ b/agent-grid/src/tests/fix-typescript.ts
@@ -1,0 +1,45 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { GridTest } from "../grid-test";
+import { type CallToolFn, byeSession, promptAndWait } from "./helpers";
+
+const FIXTURE = "grid-fix-ts.ts";
+const BROKEN_CODE = 'const greeting: number = "hello world";\nconsole.log(greeting);\n';
+
+export function makeFixTypescriptTest(deps: { callTool: CallToolFn }): GridTest {
+  return {
+    name: "fix-typescript",
+    requires: [],
+    async run(ctx) {
+      const filePath = join(ctx.cwd, FIXTURE);
+      writeFileSync(filePath, BROKEN_CODE);
+
+      const result = await promptAndWait(ctx.provider, {
+        task: `The file ${FIXTURE} has a TypeScript type error — the type annotation does not match the assigned value. Fix it so the code type-checks. Do not remove or change the console.log line.`,
+        cwd: ctx.cwd,
+        callTool: deps.callTool,
+      });
+
+      ctx.onCleanup?.(() => byeSession(ctx.provider, result.sessionId, deps.callTool));
+
+      try {
+        const content = readFileSync(filePath, "utf-8");
+
+        if (/const\s+greeting\s*:\s*number\s*=\s*"/.test(content)) {
+          return {
+            status: "fail",
+            error: `type error not fixed, file still has number annotation with string value: ${content.slice(0, 200)}`,
+          };
+        }
+
+        if (!content.includes("console.log")) {
+          return { status: "fail", error: "console.log line was removed" };
+        }
+
+        return { status: "pass" };
+      } finally {
+        await byeSession(ctx.provider, result.sessionId, deps.callTool).catch(() => {});
+      }
+    },
+  };
+}

--- a/agent-grid/src/tests/index.ts
+++ b/agent-grid/src/tests/index.ts
@@ -3,6 +3,11 @@ export { makeReadFileTest } from "./read-file";
 export { makeEditFileTest } from "./edit-file";
 export { makeRunBashTest } from "./run-bash";
 export { makeMultiTurnTest } from "./multi-turn";
+export { makeInterruptAndRecoverTest } from "./interrupt-and-recover";
+export { makeFixTypescriptTest } from "./fix-typescript";
+export { makeReportCostTest } from "./report-cost";
+export { makePermissionBaselineTest } from "./permission-baseline";
+export { makeResumeSessionTest } from "./resume-session";
 export {
   type CallToolFn,
   type PromptResult,

--- a/agent-grid/src/tests/interrupt-and-recover.ts
+++ b/agent-grid/src/tests/interrupt-and-recover.ts
@@ -1,7 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { GridTest } from "../grid-test";
-import { type CallToolFn, byeSession, promptAndWait, promptNoWait } from "./helpers";
+import { type CallToolFn, byeSession, extractText, promptFollowUp, promptNoWait } from "./helpers";
 
 const MARKER = "GRID_INTERRUPT_RECOVER_5e7a";
 const PROOF_FILE = "grid-interrupt-proof.txt";
@@ -26,13 +26,25 @@ export function makeInterruptAndRecoverTest(deps: { callTool: CallToolFn }): Gri
           sessionId,
         });
 
-        const recovery = await promptAndWait(ctx.provider, {
+        // Wait for the interrupted turn to settle. If interrupt is a no-op the
+        // session stays active and this blocks until timeout — failing the test.
+        const waitRaw = await callTool(ctx.provider.serverName, `${ctx.provider.toolPrefix}_wait`, {
+          sessionId,
+          timeout: 30000,
+        });
+        const waitText = extractText(waitRaw);
+        if (typeof waitRaw === "object" && waitRaw !== null && (waitRaw as Record<string, unknown>).isError) {
+          return { status: "fail", error: `session did not stop after interrupt: ${waitText.slice(0, 300)}` };
+        }
+
+        // Send recovery prompt to the SAME session — proves the session is
+        // responsive after the interrupt, not just that a new session works.
+        const recovery = await promptFollowUp(ctx.provider, {
+          sessionId,
           task: `Write the exact text "${MARKER}" to a file called ${PROOF_FILE} in your current directory. Nothing else.`,
           cwd: ctx.cwd,
           callTool,
         });
-
-        ctx.onCleanup?.(() => byeSession(ctx.provider, recovery.sessionId, callTool));
 
         const proofPath = join(ctx.cwd, PROOF_FILE);
         if (!existsSync(proofPath)) {

--- a/agent-grid/src/tests/interrupt-and-recover.ts
+++ b/agent-grid/src/tests/interrupt-and-recover.ts
@@ -1,0 +1,56 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { GridTest } from "../grid-test";
+import { type CallToolFn, byeSession, promptAndWait, promptNoWait } from "./helpers";
+
+const MARKER = "GRID_INTERRUPT_RECOVER_5e7a";
+const PROOF_FILE = "grid-interrupt-proof.txt";
+
+export function makeInterruptAndRecoverTest(deps: { callTool: CallToolFn }): GridTest {
+  return {
+    name: "interrupt-and-recover",
+    requires: ["interruptAck"],
+    async run(ctx) {
+      const { callTool } = deps;
+
+      const { sessionId } = await promptNoWait(ctx.provider, {
+        task: "Count slowly from 1 to 1000000, printing each number on its own line.",
+        cwd: ctx.cwd,
+        callTool,
+      });
+
+      ctx.onCleanup?.(() => byeSession(ctx.provider, sessionId, callTool));
+
+      try {
+        await callTool(ctx.provider.serverName, `${ctx.provider.toolPrefix}_interrupt`, {
+          sessionId,
+        });
+
+        const recovery = await promptAndWait(ctx.provider, {
+          task: `Write the exact text "${MARKER}" to a file called ${PROOF_FILE} in your current directory. Nothing else.`,
+          cwd: ctx.cwd,
+          callTool,
+        });
+
+        ctx.onCleanup?.(() => byeSession(ctx.provider, recovery.sessionId, callTool));
+
+        const proofPath = join(ctx.cwd, PROOF_FILE);
+        if (!existsSync(proofPath)) {
+          return { status: "fail", error: `proof file ${PROOF_FILE} not created after interrupt recovery` };
+        }
+
+        const content = readFileSync(proofPath, "utf-8");
+        if (!content.includes(MARKER)) {
+          return {
+            status: "fail",
+            error: `proof file missing marker "${MARKER}", got: ${content.slice(0, 200)}`,
+          };
+        }
+
+        return { status: "pass" };
+      } finally {
+        await byeSession(ctx.provider, sessionId, callTool).catch(() => {});
+      }
+    },
+  };
+}

--- a/agent-grid/src/tests/permission-baseline.ts
+++ b/agent-grid/src/tests/permission-baseline.ts
@@ -1,0 +1,57 @@
+import type { GridTest } from "../grid-test";
+import { type CallToolFn, byeSession, extractText, promptNoWait } from "./helpers";
+
+export function makePermissionBaselineTest(deps: { callTool: CallToolFn }): GridTest {
+  return {
+    name: "permission-baseline",
+    requires: ["permissionRoundtrip"],
+    async run(ctx) {
+      const { callTool } = deps;
+
+      const { sessionId } = await promptNoWait(ctx.provider, {
+        task: "Delete the file named 'nonexistent-sensitive.txt' in the current directory.",
+        cwd: ctx.cwd,
+        callTool,
+      });
+
+      ctx.onCleanup?.(() => byeSession(ctx.provider, sessionId, callTool));
+
+      try {
+        const waitRaw = await callTool(ctx.provider.serverName, `${ctx.provider.toolPrefix}_wait`, { sessionId });
+        const waitText = extractText(waitRaw);
+
+        const requestId = extractRequestId(waitText);
+        if (!requestId) {
+          return {
+            status: "fail",
+            error: `no permission request received. Wait response: ${waitText.slice(0, 300)}`,
+          };
+        }
+
+        await callTool(ctx.provider.serverName, `${ctx.provider.toolPrefix}_approve`, {
+          sessionId,
+          requestId,
+        });
+
+        return { status: "pass" };
+      } finally {
+        await byeSession(ctx.provider, sessionId, callTool).catch(() => {});
+      }
+    },
+  };
+}
+
+function extractRequestId(text: string): string {
+  try {
+    const parsed = JSON.parse(text);
+    if (typeof parsed === "object" && parsed !== null) {
+      const event = parsed.event ?? parsed;
+      if (event.type === "session:permission_request" && typeof event.request?.requestId === "string") {
+        return event.request.requestId;
+      }
+      if (typeof event.requestId === "string") return event.requestId;
+    }
+  } catch {}
+  const match = text.match(/"requestId"\s*:\s*"([^"]+)"/);
+  return match?.[1] ?? "";
+}

--- a/agent-grid/src/tests/permission-baseline.ts
+++ b/agent-grid/src/tests/permission-baseline.ts
@@ -17,7 +17,10 @@ export function makePermissionBaselineTest(deps: { callTool: CallToolFn }): Grid
       ctx.onCleanup?.(() => byeSession(ctx.provider, sessionId, callTool));
 
       try {
-        const waitRaw = await callTool(ctx.provider.serverName, `${ctx.provider.toolPrefix}_wait`, { sessionId });
+        const waitRaw = await callTool(ctx.provider.serverName, `${ctx.provider.toolPrefix}_wait`, {
+          sessionId,
+          timeout: 30000,
+        });
         const waitText = extractText(waitRaw);
 
         const requestId = extractRequestId(waitText);

--- a/agent-grid/src/tests/report-cost.ts
+++ b/agent-grid/src/tests/report-cost.ts
@@ -1,0 +1,60 @@
+import type { GridTest } from "../grid-test";
+import { type CallToolFn, byeSession, extractText, promptAndWait } from "./helpers";
+
+export function makeReportCostTest(deps: { callTool: CallToolFn }): GridTest {
+  return {
+    name: "report-cost",
+    requires: ["costTracking"],
+    async run(ctx) {
+      const { callTool } = deps;
+
+      const result = await promptAndWait(ctx.provider, {
+        task: 'Reply with "hello" and nothing else.',
+        cwd: ctx.cwd,
+        callTool,
+      });
+
+      ctx.onCleanup?.(() => byeSession(ctx.provider, result.sessionId, callTool));
+
+      try {
+        const costFromResult = findCost(result.text);
+        if (costFromResult > 0) return { status: "pass" };
+
+        const listRaw = await callTool(ctx.provider.serverName, `${ctx.provider.toolPrefix}_session_list`, {});
+        const listText = extractText(listRaw);
+        const listCost = findCostForSession(listText, result.sessionId);
+        if (listCost > 0) return { status: "pass" };
+
+        return {
+          status: "fail",
+          error: `no cost > 0 reported. Result: ${result.text.slice(0, 300)}`,
+        };
+      } finally {
+        await byeSession(ctx.provider, result.sessionId, callTool).catch(() => {});
+      }
+    },
+  };
+}
+
+function findCost(text: string): number {
+  try {
+    const parsed = JSON.parse(text);
+    if (typeof parsed === "object" && parsed !== null) {
+      if (typeof parsed.cost === "number") return parsed.cost;
+      if (typeof parsed.result?.cost === "number") return parsed.result.cost;
+    }
+  } catch {}
+  const match = text.match(/"cost"\s*:\s*([\d.]+)/);
+  return match ? Number.parseFloat(match[1]) : 0;
+}
+
+function findCostForSession(listText: string, sessionId: string): number {
+  try {
+    const list = JSON.parse(listText);
+    if (Array.isArray(list)) {
+      const entry = list.find((e: Record<string, unknown>) => e.sessionId === sessionId);
+      if (entry && typeof entry.cost === "number") return entry.cost;
+    }
+  } catch {}
+  return 0;
+}

--- a/agent-grid/src/tests/resume-session.ts
+++ b/agent-grid/src/tests/resume-session.ts
@@ -1,5 +1,5 @@
 import type { GridTest } from "../grid-test";
-import { type CallToolFn, byeSession, promptAndWait, promptFollowUp } from "./helpers";
+import { type CallToolFn, byeSession, extractSessionId, extractText, promptAndWait } from "./helpers";
 
 const MARKER = "GRID_RESUME_a3f9";
 
@@ -18,28 +18,42 @@ export function makeResumeSessionTest(deps: { callTool: CallToolFn }): GridTest 
 
       const { sessionId } = turn1;
 
+      // End the daemon session — bye() deletes the session from the daemon's
+      // session map, so we cannot use promptFollowUp with the old sessionId.
       await byeSession(ctx.provider, sessionId, callTool);
 
+      // Resume via --continue: creates a NEW daemon session that restores
+      // conversation history from the most recent session in this cwd.
+      const resumeRaw = await callTool(ctx.provider.serverName, `${ctx.provider.toolPrefix}_prompt`, {
+        prompt: "What was the code I asked you to remember? Reply with just the code, nothing else.",
+        resumeSessionId: "continue",
+        cwd: ctx.cwd,
+        wait: true,
+      });
+
+      const resumeText = extractText(resumeRaw);
+      if (typeof resumeRaw === "object" && resumeRaw !== null && (resumeRaw as Record<string, unknown>).isError) {
+        return { status: "fail", error: `resume prompt failed: ${resumeText.slice(0, 300)}` };
+      }
+
+      const resumeSessionId = extractSessionId(resumeText);
+      if (resumeSessionId) {
+        ctx.onCleanup?.(() => byeSession(ctx.provider, resumeSessionId, callTool));
+      }
+
       try {
-        const resumed = await promptFollowUp(ctx.provider, {
-          sessionId,
-          task: "What was the code I asked you to remember? Reply with just the code, nothing else.",
-          cwd: ctx.cwd,
-          callTool,
-        });
-
-        ctx.onCleanup?.(() => byeSession(ctx.provider, sessionId, callTool));
-
-        if (!resumed.text.includes(MARKER)) {
+        if (!resumeText.includes(MARKER)) {
           return {
             status: "fail",
-            error: `context not retained after resume: expected "${MARKER}", got: ${resumed.text.slice(0, 200)}`,
+            error: `context not retained after resume: expected "${MARKER}", got: ${resumeText.slice(0, 200)}`,
           };
         }
 
         return { status: "pass" };
       } finally {
-        await byeSession(ctx.provider, sessionId, callTool).catch(() => {});
+        if (resumeSessionId) {
+          await byeSession(ctx.provider, resumeSessionId, callTool).catch(() => {});
+        }
       }
     },
   };

--- a/agent-grid/src/tests/resume-session.ts
+++ b/agent-grid/src/tests/resume-session.ts
@@ -1,0 +1,46 @@
+import type { GridTest } from "../grid-test";
+import { type CallToolFn, byeSession, promptAndWait, promptFollowUp } from "./helpers";
+
+const MARKER = "GRID_RESUME_a3f9";
+
+export function makeResumeSessionTest(deps: { callTool: CallToolFn }): GridTest {
+  return {
+    name: "resume-session",
+    requires: ["resume"],
+    async run(ctx) {
+      const { callTool } = deps;
+
+      const turn1 = await promptAndWait(ctx.provider, {
+        task: `Remember this code: ${MARKER}. Reply with "OK" and nothing else.`,
+        cwd: ctx.cwd,
+        callTool,
+      });
+
+      const { sessionId } = turn1;
+
+      await byeSession(ctx.provider, sessionId, callTool);
+
+      try {
+        const resumed = await promptFollowUp(ctx.provider, {
+          sessionId,
+          task: "What was the code I asked you to remember? Reply with just the code, nothing else.",
+          cwd: ctx.cwd,
+          callTool,
+        });
+
+        ctx.onCleanup?.(() => byeSession(ctx.provider, sessionId, callTool));
+
+        if (!resumed.text.includes(MARKER)) {
+          return {
+            status: "fail",
+            error: `context not retained after resume: expected "${MARKER}", got: ${resumed.text.slice(0, 200)}`,
+          };
+        }
+
+        return { status: "pass" };
+      } finally {
+        await byeSession(ctx.provider, sessionId, callTool).catch(() => {});
+      }
+    },
+  };
+}

--- a/agent-grid/src/tests/tests.spec.ts
+++ b/agent-grid/src/tests/tests.spec.ts
@@ -7,10 +7,15 @@ import { getProvider } from "@mcp-cli/core";
 import type { AgentProvider } from "@mcp-cli/core";
 import { gateTest } from "../capability-gate";
 import { makeEditFileTest } from "./edit-file";
+import { makeFixTypescriptTest } from "./fix-typescript";
 import type { CallToolFn } from "./helpers";
 import { byeSession, extractSessionId, extractText, promptAndWait, promptFollowUp, promptNoWait } from "./helpers";
+import { makeInterruptAndRecoverTest } from "./interrupt-and-recover";
 import { makeMultiTurnTest } from "./multi-turn";
+import { makePermissionBaselineTest } from "./permission-baseline";
 import { makeReadFileTest } from "./read-file";
+import { makeReportCostTest } from "./report-cost";
+import { makeResumeSessionTest } from "./resume-session";
 import { makeRunBashTest } from "./run-bash";
 import { makeSpawnInDirTest } from "./spawn-in-dir";
 
@@ -233,14 +238,19 @@ function buildAllTests(callTool: CallToolFn) {
     makeEditFileTest({ callTool }),
     makeRunBashTest({ callTool }),
     makeMultiTurnTest({ callTool }),
+    makeInterruptAndRecoverTest({ callTool }),
+    makeFixTypescriptTest({ callTool }),
+    makeReportCostTest({ callTool }),
+    makePermissionBaselineTest({ callTool }),
+    makeResumeSessionTest({ callTool }),
   ];
 }
 
 describe("test registry", () => {
   const tests = buildAllTests(stubCallTool);
 
-  test("contains exactly 5 tests", () => {
-    expect(tests).toHaveLength(5);
+  test("contains exactly 10 tests", () => {
+    expect(tests).toHaveLength(10);
   });
 
   test("test names are unique", () => {
@@ -255,6 +265,11 @@ describe("test registry", () => {
     expect(names).toContain("edit-file");
     expect(names).toContain("run-bash");
     expect(names).toContain("multi-turn");
+    expect(names).toContain("interrupt-and-recover");
+    expect(names).toContain("fix-typescript");
+    expect(names).toContain("report-cost");
+    expect(names).toContain("permission-baseline");
+    expect(names).toContain("resume-session");
   });
 });
 
@@ -599,6 +614,474 @@ describe("multi-turn", () => {
     };
 
     const t = makeMultiTurnTest({ callTool });
+    await t.run({
+      provider: requireProvider("claude"),
+      cwd,
+      onCleanup: () => {
+        cleanupRegistered = true;
+      },
+    });
+    expect(cleanupRegistered).toBe(true);
+  });
+});
+
+// ── interrupt-and-recover ────────────────────────────────────────
+
+describe("interrupt-and-recover", () => {
+  const test_ = makeInterruptAndRecoverTest({ callTool: stubCallTool });
+
+  test("has correct name and requires", () => {
+    expect(test_.name).toBe("interrupt-and-recover");
+    expect(test_.requires).toEqual(["interruptAck"]);
+  });
+
+  test("gated for providers lacking interruptAck", () => {
+    const provider = { ...requireProvider("claude"), native: {} };
+    const result = gateTest(test_, provider);
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe("n/a");
+  });
+
+  test("not gated for claude", () => {
+    expect(gateTest(test_, requireProvider("claude"))).toBeNull();
+  });
+
+  test("passes when recovery prompt creates proof file", async () => {
+    const cwd = makeTmpDir();
+    let callCount = 0;
+
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      if (tool.endsWith("_interrupt")) return mcpTextResult(JSON.stringify({ interrupted: true }));
+      callCount++;
+      if (callCount === 1) {
+        return mcpTextResult(JSON.stringify({ sessionId: "sess-int-1" }));
+      }
+      writeFileSync(join(cwd, "grid-interrupt-proof.txt"), "GRID_INTERRUPT_RECOVER_5e7a");
+      return mcpPromptResult("sess-int-2", "done");
+    };
+
+    const t = makeInterruptAndRecoverTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("pass");
+  });
+
+  test("fails when proof file not created", async () => {
+    const cwd = makeTmpDir();
+    let callCount = 0;
+
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      if (tool.endsWith("_interrupt")) return mcpTextResult(JSON.stringify({ interrupted: true }));
+      callCount++;
+      if (callCount === 1) {
+        return mcpTextResult(JSON.stringify({ sessionId: "sess-int-1" }));
+      }
+      return mcpPromptResult("sess-int-2", "done");
+    };
+
+    const t = makeInterruptAndRecoverTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("fail");
+    expect((result as { error: string }).error).toContain("not created");
+  });
+
+  test("fails when proof file has wrong content", async () => {
+    const cwd = makeTmpDir();
+    let callCount = 0;
+
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      if (tool.endsWith("_interrupt")) return mcpTextResult(JSON.stringify({ interrupted: true }));
+      callCount++;
+      if (callCount === 1) {
+        return mcpTextResult(JSON.stringify({ sessionId: "sess-int-1" }));
+      }
+      writeFileSync(join(cwd, "grid-interrupt-proof.txt"), "wrong content");
+      return mcpPromptResult("sess-int-2", "done");
+    };
+
+    const t = makeInterruptAndRecoverTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("fail");
+    expect((result as { error: string }).error).toContain("missing marker");
+  });
+
+  test("registers onCleanup", async () => {
+    const cwd = makeTmpDir();
+    let cleanupRegistered = false;
+    let callCount = 0;
+
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      if (tool.endsWith("_interrupt")) return mcpTextResult(JSON.stringify({ interrupted: true }));
+      callCount++;
+      if (callCount === 1) {
+        return mcpTextResult(JSON.stringify({ sessionId: "sess-int-1" }));
+      }
+      writeFileSync(join(cwd, "grid-interrupt-proof.txt"), "GRID_INTERRUPT_RECOVER_5e7a");
+      return mcpPromptResult("sess-int-2", "done");
+    };
+
+    const t = makeInterruptAndRecoverTest({ callTool });
+    await t.run({
+      provider: requireProvider("claude"),
+      cwd,
+      onCleanup: () => {
+        cleanupRegistered = true;
+      },
+    });
+    expect(cleanupRegistered).toBe(true);
+  });
+});
+
+// ── fix-typescript ───────────────────────────────────────────────
+
+describe("fix-typescript", () => {
+  const test_ = makeFixTypescriptTest({ callTool: stubCallTool });
+
+  test("has correct name and requires", () => {
+    expect(test_.name).toBe("fix-typescript");
+    expect(test_.requires).toEqual([]);
+  });
+
+  test("not gated for any provider", () => {
+    expect(gateTest(test_, requireProvider("claude"))).toBeNull();
+    expect(gateTest(test_, requireProvider("codex"))).toBeNull();
+  });
+
+  test("passes when callTool fixes the type error", async () => {
+    const cwd = makeTmpDir();
+
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      const filePath = join(cwd, "grid-fix-ts.ts");
+      writeFileSync(filePath, 'const greeting: string = "hello world";\nconsole.log(greeting);\n');
+      return mcpPromptResult("sess-fix", "done");
+    };
+
+    const t = makeFixTypescriptTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("pass");
+  });
+
+  test("passes when value is changed to match type", async () => {
+    const cwd = makeTmpDir();
+
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      const filePath = join(cwd, "grid-fix-ts.ts");
+      writeFileSync(filePath, "const greeting: number = 42;\nconsole.log(greeting);\n");
+      return mcpPromptResult("sess-fix", "done");
+    };
+
+    const t = makeFixTypescriptTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("pass");
+  });
+
+  test("fails when type error not fixed", async () => {
+    const cwd = makeTmpDir();
+
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      return mcpPromptResult("sess-fix", "done");
+    };
+
+    const t = makeFixTypescriptTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("fail");
+    expect((result as { error: string }).error).toContain("type error not fixed");
+  });
+
+  test("fails when console.log removed", async () => {
+    const cwd = makeTmpDir();
+
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      const filePath = join(cwd, "grid-fix-ts.ts");
+      writeFileSync(filePath, 'const greeting: string = "hello world";\n');
+      return mcpPromptResult("sess-fix", "done");
+    };
+
+    const t = makeFixTypescriptTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("fail");
+    expect((result as { error: string }).error).toContain("console.log");
+  });
+});
+
+// ── report-cost ──────────────────────────────────────────────────
+
+describe("report-cost", () => {
+  const test_ = makeReportCostTest({ callTool: stubCallTool });
+
+  test("has correct name and requires", () => {
+    expect(test_.name).toBe("report-cost");
+    expect(test_.requires).toEqual(["costTracking"]);
+  });
+
+  test("gated for providers lacking costTracking", () => {
+    const provider = { ...requireProvider("claude"), native: {} };
+    const result = gateTest(test_, provider);
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe("n/a");
+  });
+
+  test("not gated for claude", () => {
+    expect(gateTest(test_, requireProvider("claude"))).toBeNull();
+  });
+
+  test("passes when result contains cost > 0", async () => {
+    const cwd = makeTmpDir();
+
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      if (tool.endsWith("_session_list")) {
+        return mcpTextResult(JSON.stringify([]));
+      }
+      return mcpTextResult(
+        JSON.stringify({
+          sessionId: "sess-cost",
+          result: { result: "hello", cost: 0.0015, tokens: 200, numTurns: 1 },
+        }),
+      );
+    };
+
+    const t = makeReportCostTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("pass");
+  });
+
+  test("passes when session_list contains cost > 0", async () => {
+    const cwd = makeTmpDir();
+
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      if (tool.endsWith("_session_list")) {
+        return mcpTextResult(JSON.stringify([{ sessionId: "sess-cost", cost: 0.003, tokens: 400 }]));
+      }
+      return mcpPromptResult("sess-cost", "hello");
+    };
+
+    const t = makeReportCostTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("pass");
+  });
+
+  test("fails when no cost reported anywhere", async () => {
+    const cwd = makeTmpDir();
+
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      if (tool.endsWith("_session_list")) {
+        return mcpTextResult(JSON.stringify([{ sessionId: "sess-cost", cost: 0, tokens: 0 }]));
+      }
+      return mcpPromptResult("sess-cost", "hello");
+    };
+
+    const t = makeReportCostTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("fail");
+    expect((result as { error: string }).error).toContain("no cost > 0");
+  });
+});
+
+// ── permission-baseline ──────────────────────────────────────────
+
+describe("permission-baseline", () => {
+  const test_ = makePermissionBaselineTest({ callTool: stubCallTool });
+
+  test("has correct name and requires", () => {
+    expect(test_.name).toBe("permission-baseline");
+    expect(test_.requires).toEqual(["permissionRoundtrip"]);
+  });
+
+  test("gated for providers lacking permissionRoundtrip", () => {
+    const provider = { ...requireProvider("claude"), native: {} };
+    const result = gateTest(test_, provider);
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe("n/a");
+  });
+
+  test("not gated for claude", () => {
+    expect(gateTest(test_, requireProvider("claude"))).toBeNull();
+  });
+
+  test("passes when permission round-trip completes", async () => {
+    const cwd = makeTmpDir();
+
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      if (tool.endsWith("_prompt")) {
+        return mcpTextResult(JSON.stringify({ sessionId: "sess-perm" }));
+      }
+      if (tool.endsWith("_wait")) {
+        return mcpTextResult(
+          JSON.stringify({
+            type: "session:permission_request",
+            request: { requestId: "req-1", toolName: "Write", input: {} },
+            seq: 1,
+            sessionId: "sess-perm",
+          }),
+        );
+      }
+      if (tool.endsWith("_approve")) {
+        return mcpTextResult(JSON.stringify({ approved: true, requestId: "req-1" }));
+      }
+      return mcpTextResult("ok");
+    };
+
+    const t = makePermissionBaselineTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("pass");
+  });
+
+  test("fails when no permission request received", async () => {
+    const cwd = makeTmpDir();
+
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      if (tool.endsWith("_prompt")) {
+        return mcpTextResult(JSON.stringify({ sessionId: "sess-perm" }));
+      }
+      if (tool.endsWith("_wait")) {
+        return mcpTextResult(
+          JSON.stringify({
+            type: "session:result",
+            sessionId: "sess-perm",
+            result: { result: "done", cost: 0, tokens: 0, numTurns: 1 },
+          }),
+        );
+      }
+      return mcpTextResult("ok");
+    };
+
+    const t = makePermissionBaselineTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("fail");
+    expect((result as { error: string }).error).toContain("no permission request");
+  });
+
+  test("registers onCleanup", async () => {
+    const cwd = makeTmpDir();
+    let cleanupRegistered = false;
+
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      if (tool.endsWith("_prompt")) {
+        return mcpTextResult(JSON.stringify({ sessionId: "sess-perm" }));
+      }
+      if (tool.endsWith("_wait")) {
+        return mcpTextResult(
+          JSON.stringify({
+            type: "session:permission_request",
+            request: { requestId: "req-1", toolName: "Write", input: {} },
+            seq: 1,
+            sessionId: "sess-perm",
+          }),
+        );
+      }
+      if (tool.endsWith("_approve")) {
+        return mcpTextResult(JSON.stringify({ approved: true, requestId: "req-1" }));
+      }
+      return mcpTextResult("ok");
+    };
+
+    const t = makePermissionBaselineTest({ callTool });
+    await t.run({
+      provider: requireProvider("claude"),
+      cwd,
+      onCleanup: () => {
+        cleanupRegistered = true;
+      },
+    });
+    expect(cleanupRegistered).toBe(true);
+  });
+});
+
+// ── resume-session ───────────────────────────────────────────────
+
+describe("resume-session", () => {
+  const test_ = makeResumeSessionTest({ callTool: stubCallTool });
+
+  test("has correct name and requires", () => {
+    expect(test_.name).toBe("resume-session");
+    expect(test_.requires).toEqual(["resume"]);
+  });
+
+  test("gated for providers lacking resume", () => {
+    const provider = { ...requireProvider("claude"), native: { resume: false } };
+    const result = gateTest(test_, provider);
+    expect(result).not.toBeNull();
+    expect(result?.status).toBe("n/a");
+  });
+
+  test("not gated for claude", () => {
+    expect(gateTest(test_, requireProvider("claude"))).toBeNull();
+  });
+
+  test("passes when context is retained after resume", async () => {
+    const cwd = makeTmpDir();
+    let callCount = 0;
+
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      callCount++;
+      if (callCount === 1) return mcpPromptResult("sess-res", "OK");
+      if (callCount === 2) return mcpPromptResult("sess-res", "GRID_RESUME_a3f9");
+      return mcpPromptResult("sess-res", "unexpected");
+    };
+
+    const t = makeResumeSessionTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("pass");
+  });
+
+  test("fails when context not retained after resume", async () => {
+    const cwd = makeTmpDir();
+    let callCount = 0;
+
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      callCount++;
+      if (callCount === 1) return mcpPromptResult("sess-res", "OK");
+      if (callCount === 2) return mcpPromptResult("sess-res", "I don't remember");
+      return mcpPromptResult("sess-res", "unexpected");
+    };
+
+    const t = makeResumeSessionTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("fail");
+    expect((result as { error: string }).error).toContain("context not retained");
+  });
+
+  test("throws when no sessionId from initial prompt", async () => {
+    const cwd = makeTmpDir();
+
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      return mcpTextResult("plain text no session id");
+    };
+
+    const t = makeResumeSessionTest({ callTool });
+    expect(t.run({ provider: requireProvider("claude"), cwd })).rejects.toThrow("no sessionId");
+  });
+
+  test("registers onCleanup", async () => {
+    const cwd = makeTmpDir();
+    let cleanupRegistered = false;
+    let callCount = 0;
+
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      callCount++;
+      if (callCount === 1) return mcpPromptResult("sess-res", "OK");
+      if (callCount === 2) return mcpPromptResult("sess-res", "GRID_RESUME_a3f9");
+      return mcpPromptResult("sess-res", "unexpected");
+    };
+
+    const t = makeResumeSessionTest({ callTool });
     await t.run({
       provider: requireProvider("claude"),
       cwd,

--- a/agent-grid/src/tests/tests.spec.ts
+++ b/agent-grid/src/tests/tests.spec.ts
@@ -648,17 +648,19 @@ describe("interrupt-and-recover", () => {
 
   test("passes when recovery prompt creates proof file", async () => {
     const cwd = makeTmpDir();
-    let callCount = 0;
 
-    const callTool: CallToolFn = async (_server, tool) => {
+    const callTool: CallToolFn = async (_server, tool, args) => {
       if (tool.endsWith("_bye")) return mcpTextResult("ok");
       if (tool.endsWith("_interrupt")) return mcpTextResult(JSON.stringify({ interrupted: true }));
-      callCount++;
-      if (callCount === 1) {
-        return mcpTextResult(JSON.stringify({ sessionId: "sess-int-1" }));
+      if (tool.endsWith("_wait")) {
+        return mcpTextResult(JSON.stringify({ event: "session:result", sessionId: "sess-int-1", cost: 0, tokens: 0 }));
       }
-      writeFileSync(join(cwd, "grid-interrupt-proof.txt"), "GRID_INTERRUPT_RECOVER_5e7a");
-      return mcpPromptResult("sess-int-2", "done");
+      if (tool.endsWith("_prompt")) {
+        if (!args?.wait) return mcpTextResult(JSON.stringify({ sessionId: "sess-int-1" }));
+        writeFileSync(join(cwd, "grid-interrupt-proof.txt"), "GRID_INTERRUPT_RECOVER_5e7a");
+        return mcpPromptResult("sess-int-1", "done");
+      }
+      return mcpTextResult("ok");
     };
 
     const t = makeInterruptAndRecoverTest({ callTool });
@@ -668,16 +670,18 @@ describe("interrupt-and-recover", () => {
 
   test("fails when proof file not created", async () => {
     const cwd = makeTmpDir();
-    let callCount = 0;
 
-    const callTool: CallToolFn = async (_server, tool) => {
+    const callTool: CallToolFn = async (_server, tool, args) => {
       if (tool.endsWith("_bye")) return mcpTextResult("ok");
       if (tool.endsWith("_interrupt")) return mcpTextResult(JSON.stringify({ interrupted: true }));
-      callCount++;
-      if (callCount === 1) {
-        return mcpTextResult(JSON.stringify({ sessionId: "sess-int-1" }));
+      if (tool.endsWith("_wait")) {
+        return mcpTextResult(JSON.stringify({ event: "session:result", sessionId: "sess-int-1" }));
       }
-      return mcpPromptResult("sess-int-2", "done");
+      if (tool.endsWith("_prompt")) {
+        if (!args?.wait) return mcpTextResult(JSON.stringify({ sessionId: "sess-int-1" }));
+        return mcpPromptResult("sess-int-1", "done");
+      }
+      return mcpTextResult("ok");
     };
 
     const t = makeInterruptAndRecoverTest({ callTool });
@@ -688,17 +692,19 @@ describe("interrupt-and-recover", () => {
 
   test("fails when proof file has wrong content", async () => {
     const cwd = makeTmpDir();
-    let callCount = 0;
 
-    const callTool: CallToolFn = async (_server, tool) => {
+    const callTool: CallToolFn = async (_server, tool, args) => {
       if (tool.endsWith("_bye")) return mcpTextResult("ok");
       if (tool.endsWith("_interrupt")) return mcpTextResult(JSON.stringify({ interrupted: true }));
-      callCount++;
-      if (callCount === 1) {
-        return mcpTextResult(JSON.stringify({ sessionId: "sess-int-1" }));
+      if (tool.endsWith("_wait")) {
+        return mcpTextResult(JSON.stringify({ event: "session:result", sessionId: "sess-int-1" }));
       }
-      writeFileSync(join(cwd, "grid-interrupt-proof.txt"), "wrong content");
-      return mcpPromptResult("sess-int-2", "done");
+      if (tool.endsWith("_prompt")) {
+        if (!args?.wait) return mcpTextResult(JSON.stringify({ sessionId: "sess-int-1" }));
+        writeFileSync(join(cwd, "grid-interrupt-proof.txt"), "wrong content");
+        return mcpPromptResult("sess-int-1", "done");
+      }
+      return mcpTextResult("ok");
     };
 
     const t = makeInterruptAndRecoverTest({ callTool });
@@ -707,20 +713,44 @@ describe("interrupt-and-recover", () => {
     expect((result as { error: string }).error).toContain("missing marker");
   });
 
+  test("fails when wait after interrupt returns error", async () => {
+    const cwd = makeTmpDir();
+
+    const callTool: CallToolFn = async (_server, tool, args) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      if (tool.endsWith("_interrupt")) return mcpTextResult(JSON.stringify({ interrupted: true }));
+      if (tool.endsWith("_wait")) {
+        return mcpTextResult("timeout waiting for session", true);
+      }
+      if (tool.endsWith("_prompt")) {
+        if (!args?.wait) return mcpTextResult(JSON.stringify({ sessionId: "sess-int-1" }));
+        return mcpPromptResult("sess-int-1", "done");
+      }
+      return mcpTextResult("ok");
+    };
+
+    const t = makeInterruptAndRecoverTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("fail");
+    expect((result as { error: string }).error).toContain("did not stop after interrupt");
+  });
+
   test("registers onCleanup", async () => {
     const cwd = makeTmpDir();
     let cleanupRegistered = false;
-    let callCount = 0;
 
-    const callTool: CallToolFn = async (_server, tool) => {
+    const callTool: CallToolFn = async (_server, tool, args) => {
       if (tool.endsWith("_bye")) return mcpTextResult("ok");
       if (tool.endsWith("_interrupt")) return mcpTextResult(JSON.stringify({ interrupted: true }));
-      callCount++;
-      if (callCount === 1) {
-        return mcpTextResult(JSON.stringify({ sessionId: "sess-int-1" }));
+      if (tool.endsWith("_wait")) {
+        return mcpTextResult(JSON.stringify({ event: "session:result", sessionId: "sess-int-1" }));
       }
-      writeFileSync(join(cwd, "grid-interrupt-proof.txt"), "GRID_INTERRUPT_RECOVER_5e7a");
-      return mcpPromptResult("sess-int-2", "done");
+      if (tool.endsWith("_prompt")) {
+        if (!args?.wait) return mcpTextResult(JSON.stringify({ sessionId: "sess-int-1" }));
+        writeFileSync(join(cwd, "grid-interrupt-proof.txt"), "GRID_INTERRUPT_RECOVER_5e7a");
+        return mcpPromptResult("sess-int-1", "done");
+      }
+      return mcpTextResult("ok");
     };
 
     const t = makeInterruptAndRecoverTest({ callTool });
@@ -808,6 +838,22 @@ describe("fix-typescript", () => {
     const result = await t.run({ provider: requireProvider("claude"), cwd });
     expect(result.status).toBe("fail");
     expect((result as { error: string }).error).toContain("console.log");
+  });
+
+  test("fails when agent deletes the fixture file", async () => {
+    const cwd = makeTmpDir();
+    const { unlinkSync } = await import("node:fs");
+
+    const callTool: CallToolFn = async (_server, tool) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      unlinkSync(join(cwd, "grid-fix-ts.ts"));
+      return mcpPromptResult("sess-fix", "done");
+    };
+
+    const t = makeFixTypescriptTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("fail");
+    expect((result as { error: string }).error).toContain("deleted the fixture file");
   });
 });
 
@@ -1023,14 +1069,16 @@ describe("resume-session", () => {
 
   test("passes when context is retained after resume", async () => {
     const cwd = makeTmpDir();
-    let callCount = 0;
 
-    const callTool: CallToolFn = async (_server, tool) => {
+    const callTool: CallToolFn = async (_server, tool, args) => {
       if (tool.endsWith("_bye")) return mcpTextResult("ok");
-      callCount++;
-      if (callCount === 1) return mcpPromptResult("sess-res", "OK");
-      if (callCount === 2) return mcpPromptResult("sess-res", "GRID_RESUME_a3f9");
-      return mcpPromptResult("sess-res", "unexpected");
+      if (tool.endsWith("_prompt")) {
+        if (args.resumeSessionId === "continue") {
+          return mcpPromptResult("sess-res-2", "GRID_RESUME_a3f9");
+        }
+        return mcpPromptResult("sess-res", "OK");
+      }
+      return mcpTextResult("ok");
     };
 
     const t = makeResumeSessionTest({ callTool });
@@ -1040,14 +1088,16 @@ describe("resume-session", () => {
 
   test("fails when context not retained after resume", async () => {
     const cwd = makeTmpDir();
-    let callCount = 0;
 
-    const callTool: CallToolFn = async (_server, tool) => {
+    const callTool: CallToolFn = async (_server, tool, args) => {
       if (tool.endsWith("_bye")) return mcpTextResult("ok");
-      callCount++;
-      if (callCount === 1) return mcpPromptResult("sess-res", "OK");
-      if (callCount === 2) return mcpPromptResult("sess-res", "I don't remember");
-      return mcpPromptResult("sess-res", "unexpected");
+      if (tool.endsWith("_prompt")) {
+        if (args.resumeSessionId === "continue") {
+          return mcpPromptResult("sess-res-2", "I don't remember");
+        }
+        return mcpPromptResult("sess-res", "OK");
+      }
+      return mcpTextResult("ok");
     };
 
     const t = makeResumeSessionTest({ callTool });
@@ -1068,17 +1118,39 @@ describe("resume-session", () => {
     expect(t.run({ provider: requireProvider("claude"), cwd })).rejects.toThrow("no sessionId");
   });
 
+  test("fails when resume prompt returns error", async () => {
+    const cwd = makeTmpDir();
+
+    const callTool: CallToolFn = async (_server, tool, args) => {
+      if (tool.endsWith("_bye")) return mcpTextResult("ok");
+      if (tool.endsWith("_prompt")) {
+        if (args.resumeSessionId === "continue") {
+          return mcpTextResult("no session to resume", true);
+        }
+        return mcpPromptResult("sess-res", "OK");
+      }
+      return mcpTextResult("ok");
+    };
+
+    const t = makeResumeSessionTest({ callTool });
+    const result = await t.run({ provider: requireProvider("claude"), cwd });
+    expect(result.status).toBe("fail");
+    expect((result as { error: string }).error).toContain("resume prompt failed");
+  });
+
   test("registers onCleanup", async () => {
     const cwd = makeTmpDir();
     let cleanupRegistered = false;
-    let callCount = 0;
 
-    const callTool: CallToolFn = async (_server, tool) => {
+    const callTool: CallToolFn = async (_server, tool, args) => {
       if (tool.endsWith("_bye")) return mcpTextResult("ok");
-      callCount++;
-      if (callCount === 1) return mcpPromptResult("sess-res", "OK");
-      if (callCount === 2) return mcpPromptResult("sess-res", "GRID_RESUME_a3f9");
-      return mcpPromptResult("sess-res", "unexpected");
+      if (tool.endsWith("_prompt")) {
+        if (args.resumeSessionId === "continue") {
+          return mcpPromptResult("sess-res-2", "GRID_RESUME_a3f9");
+        }
+        return mcpPromptResult("sess-res", "OK");
+      }
+      return mcpTextResult("ok");
     };
 
     const t = makeResumeSessionTest({ callTool });


### PR DESCRIPTION
## Summary
- Adds 5 new capability tests for the agent-grid: `interrupt-and-recover` (requires `interruptAck`), `fix-typescript` (ungated), `report-cost` (requires `costTracking`), `permission-baseline` (requires `permissionRoundtrip`), `resume-session` (requires `resume`)
- All tests follow the batch 1 `makeXxxTest({ callTool })` factory pattern with `GridTest` interface
- Full unit test coverage in `tests.spec.ts`: pass/fail paths, gating checks, onCleanup registration

## Test plan
- [x] All 84 agent-grid tests pass (`bun test agent-grid/src/tests/tests.spec.ts`)
- [x] Full suite passes (8953 pass, 0 fail)
- [x] `bun typecheck` clean
- [x] `bun lint` clean
- [x] `bun run doing-it-wrong` clean
- [x] Pre-commit and pre-push hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)