### PR TITLE
feat(agent-grid): replay recordings through actual mock worker (fixes #2616)

### DIFF
--- a/agent-grid/src/replay.spec.ts
+++ b/agent-grid/src/replay.spec.ts
@@ -667,10 +667,43 @@ describe("replayThroughMock", () => {
 
     const report = await replayThroughMock(entries, "extra.ndjson", {
       workerPath: MOCK_WORKER_PATH,
+      timeoutMs: 500, // short timeout — testing count detection, not timeout duration
     });
 
     expect(report.pass).toBe(false);
     expect(report.violations.some((v) => v.rule === "mock-replay-count")).toBe(true);
+  });
+
+  test("Phase-2 worker crash produces mock-worker-crash violation, not silent count mismatch", async () => {
+    // Worker that sends ready on init but crashes on the next message
+    const crashWorkerPath = tmpFile("crash-worker.ts");
+    writeFileSync(
+      crashWorkerPath,
+      `self.onmessage = (ev) => {
+  if (ev.data?.type === "init") {
+    self.postMessage({ type: "ready", supported_protocol_version: 1 });
+    self.onmessage = () => { throw new Error("intentional phase-2 crash"); };
+  }
+};`,
+    );
+
+    const entries: RecordingEntry[] = [
+      entry({ dir: "daemon->worker", kind: "control", payload: { type: "init", protocol_version: 1 } }),
+      entry({ dir: "worker->daemon", kind: "control", payload: { type: "ready", supported_protocol_version: 1 } }),
+      // Extra expected message that won't arrive because the worker crashes
+      db("db:end", { sessionId: "test" }),
+      // Trigger message that causes the crash
+      entry({ dir: "daemon->worker", kind: "control", payload: { type: "shutdown" } }),
+    ];
+
+    const report = await replayThroughMock(entries, "crash.ndjson", {
+      workerPath: crashWorkerPath,
+      timeoutMs: 3000,
+    });
+
+    expect(report.pass).toBe(false);
+    // Crash must surface as mock-worker-crash, not silently as count mismatch alone
+    expect(report.violations.some((v) => v.rule === "mock-worker-crash")).toBe(true);
   });
 });
 

--- a/agent-grid/src/replay.spec.ts
+++ b/agent-grid/src/replay.spec.ts
@@ -1,9 +1,11 @@
-import { afterAll, describe, expect, test } from "bun:test";
-import { rmSync, writeFileSync } from "node:fs";
+import { afterAll, afterEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { RecordingEntry } from "@mcp-cli/core";
-import { parseRecording, validateRecording } from "./replay";
+import { parseRecording, replayThroughMock, validateRecording } from "./replay";
+
+setDefaultTimeout(15_000);
 
 const tmpFiles: string[] = [];
 function tmpFile(suffix: string): string {
@@ -14,7 +16,7 @@ function tmpFile(suffix: string): string {
 afterAll(() => {
   for (const f of tmpFiles) {
     try {
-      rmSync(f);
+      rmSync(f, { recursive: true });
     } catch {}
   }
 });
@@ -46,6 +48,8 @@ function mcp(dir: RecordingEntry["dir"], payload: Record<string, unknown>): Reco
 function db(type: string, fields: Record<string, unknown> = {}): RecordingEntry {
   return entry({ dir: "worker->daemon", kind: "db", payload: { type, ...fields } });
 }
+
+// ── Static validation ─────────────────────────────────────────────
 
 describe("validateRecording", () => {
   test("valid minimal handshake passes", () => {
@@ -269,96 +273,140 @@ describe("validateRecording", () => {
   });
 });
 
-// ── Session lifecycle replay ──────────────────────────────────────
+// ── Deeper validation from #2614 findings ─────────────────────────
 
-describe("session lifecycle replay", () => {
-  test("valid mock lifecycle passes", () => {
-    const entries: RecordingEntry[] = [
+describe("deeper validation (#2614 findings)", () => {
+  test("restore_sessions: element must be object with sessionId and provider", () => {
+    const entries = [
       INIT,
       READY,
-      mcp("daemon->worker", { id: 1, method: "tools/list" }),
-      mcp("worker->daemon", { id: 1, result: { tools: [] } }),
-      db("db:upsert", { session: { sessionId: "s1", state: "connecting" } }),
-      db("db:state", { sessionId: "s1", state: "active" }),
-      db("db:upsert", { session: { sessionId: "s1", state: "init", model: "mock", cwd: "/tmp" } }),
-      db("db:cost", { sessionId: "s1", cost: 0.01, tokens: 100 }),
-      db("db:state", { sessionId: "s1", state: "idle" }),
-      db("db:end", { sessionId: "s1" }),
+      entry({
+        dir: "daemon->worker",
+        kind: "control",
+        payload: { type: "restore_sessions", sessions: ["not-an-object"] },
+      }),
+    ];
+    const report = validateRecording(entries, "bad.ndjson");
+    expect(report.pass).toBe(false);
+    expect(report.violations.some((v) => v.rule === "required-field" && v.message.includes("sessions[0]"))).toBe(true);
+  });
+
+  test("restore_sessions: element missing sessionId", () => {
+    const entries = [
+      INIT,
+      READY,
+      entry({
+        dir: "daemon->worker",
+        kind: "control",
+        payload: { type: "restore_sessions", sessions: [{ provider: "mock" }] },
+      }),
+    ];
+    const report = validateRecording(entries, "bad.ndjson");
+    expect(report.pass).toBe(false);
+    expect(
+      report.violations.some(
+        (v) => v.rule === "required-field" && v.message.includes("sessions[0]") && v.message.includes("sessionId"),
+      ),
+    ).toBe(true);
+  });
+
+  test("restore_sessions: element missing provider", () => {
+    const entries = [
+      INIT,
+      READY,
+      entry({
+        dir: "daemon->worker",
+        kind: "control",
+        payload: { type: "restore_sessions", sessions: [{ sessionId: "s1" }] },
+      }),
+    ];
+    const report = validateRecording(entries, "bad.ndjson");
+    expect(report.pass).toBe(false);
+    expect(
+      report.violations.some(
+        (v) => v.rule === "required-field" && v.message.includes("sessions[0]") && v.message.includes("provider"),
+      ),
+    ).toBe(true);
+  });
+
+  test("restore_sessions: valid element passes", () => {
+    const entries = [
+      INIT,
+      READY,
+      entry({
+        dir: "daemon->worker",
+        kind: "control",
+        payload: { type: "restore_sessions", sessions: [{ sessionId: "s1", provider: "mock" }] },
+      }),
     ];
     const report = validateRecording(entries, "test.ndjson");
-    expect(report.pass).toBe(true);
+    expect(report.violations.filter((v) => v.rule === "required-field")).toHaveLength(0);
   });
 
-  test("permission round-trip lifecycle passes", () => {
-    const entries: RecordingEntry[] = [
+  test("work_item_event: event must be object not primitive", () => {
+    const entries = [
       INIT,
       READY,
-      mcp("daemon->worker", { id: 1, method: "tools/list" }),
-      mcp("worker->daemon", { id: 1, result: { tools: [] } }),
-      db("db:upsert", { session: { sessionId: "s1", state: "connecting" } }),
-      db("db:state", { sessionId: "s1", state: "active" }),
-      db("db:upsert", { session: { sessionId: "s1", state: "init", model: "mock", cwd: "/tmp" } }),
-      db("db:state", { sessionId: "s1", state: "waiting_permission" }),
-      db("db:state", { sessionId: "s1", state: "active" }),
-      db("db:state", { sessionId: "s1", state: "idle" }),
-      db("db:end", { sessionId: "s1" }),
-    ];
-    const report = validateRecording(entries, "test.ndjson");
-    expect(report.pass).toBe(true);
-  });
-
-  test("db event before upsert fails", () => {
-    const entries: RecordingEntry[] = [INIT, READY, db("db:state", { sessionId: "s1", state: "active" })];
-    const report = validateRecording(entries, "bad.ndjson");
-    expect(report.pass).toBe(false);
-    expect(report.violations.some((v) => v.rule === "lifecycle" && v.message.includes("before db:upsert"))).toBe(true);
-  });
-
-  test("event after db:end fails", () => {
-    const entries: RecordingEntry[] = [
-      INIT,
-      READY,
-      db("db:upsert", { session: { sessionId: "s1", state: "connecting" } }),
-      db("db:state", { sessionId: "s1", state: "active" }),
-      db("db:upsert", { session: { sessionId: "s1", state: "init" } }),
-      db("db:state", { sessionId: "s1", state: "idle" }),
-      db("db:end", { sessionId: "s1" }),
-      db("db:state", { sessionId: "s1", state: "active" }),
+      entry({
+        dir: "daemon->worker",
+        kind: "control",
+        payload: { type: "work_item_event", event: "not-an-object" },
+      }),
     ];
     const report = validateRecording(entries, "bad.ndjson");
     expect(report.pass).toBe(false);
-    expect(report.violations.some((v) => v.rule === "lifecycle" && v.message.includes("after db:end"))).toBe(true);
-  });
-
-  test("invalid state transition detected", () => {
-    const entries: RecordingEntry[] = [
-      INIT,
-      READY,
-      db("db:upsert", { session: { sessionId: "s1", state: "connecting" } }),
-      db("db:state", { sessionId: "s1", state: "idle" }),
-    ];
-    const report = validateRecording(entries, "bad.ndjson");
-    expect(report.pass).toBe(false);
-    expect(report.violations.some((v) => v.rule === "lifecycle" && v.message.includes('"connecting" → "idle"'))).toBe(
+    expect(report.violations.some((v) => v.rule === "required-field" && v.message.includes("must be an object"))).toBe(
       true,
     );
   });
 
-  test("multiple independent sessions tracked correctly", () => {
-    const entries: RecordingEntry[] = [
+  test("monitor:event: input must be object not primitive", () => {
+    const entries = [INIT, READY, db("monitor:event", { input: 42 })];
+    const report = validateRecording(entries, "bad.ndjson");
+    expect(report.pass).toBe(false);
+    expect(report.violations.some((v) => v.rule === "required-field" && v.message.includes("must be an object"))).toBe(
+      true,
+    );
+  });
+
+  test("MCP response: result and error mutual exclusion", () => {
+    const entries = [INIT, READY, mcp("worker->daemon", { id: 1, result: {}, error: { code: -1, message: "x" } })];
+    const report = validateRecording(entries, "bad.ndjson");
+    expect(report.pass).toBe(false);
+    expect(report.violations.some((v) => v.rule === "mcp-format" && v.message.includes("mutual exclusion"))).toBe(true);
+  });
+
+  test("MCP response: must have id", () => {
+    const entries = [
       INIT,
       READY,
-      db("db:upsert", { session: { sessionId: "s1", state: "connecting" } }),
-      db("db:upsert", { session: { sessionId: "s2", state: "connecting" } }),
-      db("db:state", { sessionId: "s1", state: "active" }),
-      db("db:state", { sessionId: "s2", state: "active" }),
-      db("db:upsert", { session: { sessionId: "s1", state: "init" } }),
-      db("db:upsert", { session: { sessionId: "s2", state: "init" } }),
-      db("db:state", { sessionId: "s1", state: "idle" }),
-      db("db:state", { sessionId: "s2", state: "idle" }),
-      db("db:end", { sessionId: "s1" }),
-      db("db:end", { sessionId: "s2" }),
+      entry({ dir: "worker->daemon", kind: "mcp", payload: { jsonrpc: "2.0", result: {} } }),
     ];
+    const report = validateRecording(entries, "bad.ndjson");
+    expect(report.pass).toBe(false);
+    expect(report.violations.some((v) => v.rule === "mcp-format" && v.message.includes("id field"))).toBe(true);
+  });
+
+  test("MCP response: must not have method field", () => {
+    const entries = [INIT, READY, mcp("worker->daemon", { id: 1, result: {}, method: "tools/list" })];
+    const report = validateRecording(entries, "bad.ndjson");
+    expect(report.pass).toBe(false);
+    expect(report.violations.some((v) => v.rule === "mcp-format" && v.message.includes("must not have a method"))).toBe(
+      true,
+    );
+  });
+
+  test("MCP request: method must be string", () => {
+    const entries = [INIT, READY, mcp("daemon->worker", { id: 1, method: 42 })];
+    const report = validateRecording(entries, "bad.ndjson");
+    expect(report.pass).toBe(false);
+    expect(
+      report.violations.some((v) => v.rule === "mcp-format" && v.message.includes("method must be a string")),
+    ).toBe(true);
+  });
+
+  test("MCP notification: no id, has method — passes", () => {
+    const entries = [INIT, READY, mcp("worker->daemon", { method: "notifications/tools/list_changed" })];
     const report = validateRecording(entries, "test.ndjson");
     expect(report.pass).toBe(true);
   });
@@ -405,6 +453,224 @@ describe("MCP request/response correlation", () => {
     ];
     const report = validateRecording(entries, "test.ndjson");
     expect(report.pass).toBe(true);
+  });
+});
+
+// ── Mock-driver replay ────────────────────────────────────────────
+
+const MOCK_WORKER_PATH = join(import.meta.dir, "../../packages/daemon/src/mock-session-worker.ts");
+
+describe("replayThroughMock", () => {
+  const activeWorkers: Worker[] = [];
+
+  afterEach(() => {
+    for (const w of activeWorkers) {
+      try {
+        w.onmessage = null;
+        w.onerror = null;
+        w.terminate();
+      } catch {}
+    }
+    activeWorkers.length = 0;
+  });
+
+  test("init-only recording replays through mock worker", async () => {
+    // Record phase: spawn mock worker, capture actual output
+    const recorded: RecordingEntry[] = [];
+    const worker = new Worker(MOCK_WORKER_PATH);
+    activeWorkers.push(worker);
+
+    try {
+      const initPayload = { type: "init", protocol_version: 1 };
+      recorded.push(entry({ dir: "daemon->worker", kind: "control", payload: initPayload }));
+
+      const readyPayload = await new Promise<Record<string, unknown>>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error("timeout")), 5000);
+        worker.onmessage = (event: MessageEvent) => {
+          clearTimeout(timer);
+          resolve(event.data);
+        };
+        worker.onerror = (event: ErrorEvent | Event) => {
+          clearTimeout(timer);
+          reject(new Error(event instanceof ErrorEvent ? event.message : String(event)));
+        };
+        worker.postMessage(initPayload);
+      });
+
+      recorded.push(entry({ dir: "worker->daemon", kind: "control", payload: readyPayload }));
+    } finally {
+      worker.onmessage = null;
+      worker.onerror = null;
+      worker.terminate();
+      activeWorkers.length = 0;
+    }
+
+    // Replay phase
+    const report = await replayThroughMock(recorded, "init-only.ndjson", {
+      workerPath: MOCK_WORKER_PATH,
+    });
+
+    expect(report.pass).toBe(true);
+    expect(report.violations).toHaveLength(0);
+    expect(report.expectedWorkerMessages).toBe(1);
+    expect(report.actualWorkerMessages).toBe(1);
+  });
+
+  test("full mock_prompt recording replays correctly", async () => {
+    // Create a temp script for the mock worker
+    const scriptDir = tmpFile("scripts");
+    mkdirSync(scriptDir, { recursive: true });
+    const scriptPath = join(scriptDir, "test-script.json");
+    writeFileSync(
+      scriptPath,
+      JSON.stringify([
+        { emit: "response", text: "hello from mock" },
+        { emit: "result", text: "done" },
+      ]),
+    );
+
+    // Record phase: spawn worker, do full MCP exchange, collect output
+    const recorded: RecordingEntry[] = [];
+    const workerMessages: unknown[] = [];
+    const worker = new Worker(MOCK_WORKER_PATH);
+    activeWorkers.push(worker);
+
+    try {
+      const initPayload = { type: "init", protocol_version: 1 };
+      recorded.push(entry({ dir: "daemon->worker", kind: "control", payload: initPayload }));
+
+      // Wait for ready
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error("timeout")), 5000);
+        worker.onmessage = (event: MessageEvent) => {
+          clearTimeout(timer);
+          workerMessages.push(event.data);
+          recorded.push(entry({ dir: "worker->daemon", kind: "control", payload: event.data }));
+          resolve();
+        };
+        worker.onerror = (ev: ErrorEvent | Event) => {
+          clearTimeout(timer);
+          reject(new Error(ev instanceof ErrorEvent ? ev.message : String(ev)));
+        };
+        worker.postMessage(initPayload);
+      });
+
+      // Send MCP initialize
+      const initializeMsg = {
+        jsonrpc: "2.0",
+        id: 0,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "replay-test", version: "0.1.0" },
+        },
+      };
+      recorded.push(entry({ dir: "daemon->worker", kind: "mcp", payload: initializeMsg }));
+
+      // Collect MCP initialize response
+      const initResponse = await new Promise<unknown>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error("mcp init timeout")), 5000);
+        worker.onmessage = (event: MessageEvent) => {
+          clearTimeout(timer);
+          workerMessages.push(event.data);
+          recorded.push(entry({ dir: "worker->daemon", kind: "mcp", payload: event.data }));
+          resolve(event.data);
+        };
+        worker.postMessage(initializeMsg);
+      });
+
+      // Send initialized notification
+      const initializedMsg = { jsonrpc: "2.0", method: "notifications/initialized" };
+      recorded.push(entry({ dir: "daemon->worker", kind: "mcp", payload: initializedMsg }));
+      worker.postMessage(initializedMsg);
+
+      // Send tools/call with mock_prompt
+      const toolCallMsg = {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "mock_prompt",
+          arguments: { prompt: scriptPath, cwd: scriptDir, wait: true },
+        },
+      };
+      recorded.push(entry({ dir: "daemon->worker", kind: "mcp", payload: toolCallMsg }));
+
+      // Collect all worker→daemon messages until we get the tool call response
+      await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error("tool call timeout")), 10000);
+        worker.onmessage = (event: MessageEvent) => {
+          const data = event.data;
+          workerMessages.push(data);
+          const kind = classifyForRecording(data);
+          recorded.push(entry({ dir: "worker->daemon", kind, payload: data }));
+
+          // The tool call response has the matching id
+          if (
+            typeof data === "object" &&
+            data !== null &&
+            "jsonrpc" in data &&
+            "id" in data &&
+            (data as Record<string, unknown>).id === 1
+          ) {
+            clearTimeout(timer);
+            resolve();
+          }
+        };
+        worker.postMessage(toolCallMsg);
+      });
+    } finally {
+      worker.onmessage = null;
+      worker.onerror = null;
+      worker.terminate();
+      activeWorkers.length = 0;
+    }
+
+    // Replay phase
+    const report = await replayThroughMock(recorded, "full.ndjson", {
+      workerPath: MOCK_WORKER_PATH,
+    });
+
+    expect(report.violations).toEqual([]);
+    expect(report.pass).toBe(true);
+    expect(report.actualWorkerMessages).toBe(report.expectedWorkerMessages);
+  });
+
+  test("rejects recording with no daemon→worker messages", async () => {
+    const report = await replayThroughMock([], "empty.ndjson", {
+      workerPath: MOCK_WORKER_PATH,
+    });
+
+    expect(report.pass).toBe(false);
+    expect(report.violations.some((v) => v.rule === "mock-replay")).toBe(true);
+  });
+
+  test("rejects recording without init as first message", async () => {
+    const entries = [mcp("daemon->worker", { id: 1, method: "tools/list" })];
+    const report = await replayThroughMock(entries, "no-init.ndjson", {
+      workerPath: MOCK_WORKER_PATH,
+    });
+
+    expect(report.pass).toBe(false);
+    expect(report.violations.some((v) => v.rule === "mock-replay" && v.message.includes("init"))).toBe(true);
+  });
+
+  test("detects count mismatch when recording has extra expected messages", async () => {
+    // A recording that claims the worker sent more messages than it actually will
+    const entries: RecordingEntry[] = [
+      entry({ dir: "daemon->worker", kind: "control", payload: { type: "init", protocol_version: 1 } }),
+      entry({ dir: "worker->daemon", kind: "control", payload: { type: "ready", supported_protocol_version: 1 } }),
+      // Fake extra message the worker won't produce
+      db("db:end", { sessionId: "phantom" }),
+    ];
+
+    const report = await replayThroughMock(entries, "extra.ndjson", {
+      workerPath: MOCK_WORKER_PATH,
+    });
+
+    expect(report.pass).toBe(false);
+    expect(report.violations.some((v) => v.rule === "mock-replay-count")).toBe(true);
   });
 });
 
@@ -458,3 +724,17 @@ describe("parseRecording", () => {
     expect(entries).toHaveLength(1);
   });
 });
+
+// ── Helper ────────────────────────────────────────────────────────
+
+function classifyForRecording(data: unknown): "control" | "db" | "mcp" {
+  if (typeof data !== "object" || data === null) return "mcp";
+  const obj = data as Record<string, unknown>;
+  if ("jsonrpc" in obj) return "mcp";
+  if ("type" in obj && typeof obj.type === "string") {
+    const t = obj.type;
+    if (t.startsWith("db:") || t.startsWith("metrics:") || t === "monitor:event") return "db";
+    return "control";
+  }
+  return "mcp";
+}

--- a/agent-grid/src/replay.ts
+++ b/agent-grid/src/replay.ts
@@ -454,7 +454,9 @@ function structurallyEqual(a: unknown, b: unknown): boolean {
   return JSON.stringify(normalizeForComparison(a)) === JSON.stringify(normalizeForComparison(b));
 }
 
-const MOCK_WORKER_PATH = join(import.meta.dir, "../../packages/daemon/src/mock-session-worker.ts");
+function defaultMockWorkerPath(): string {
+  return join(import.meta.dir, "../../packages/daemon/src/mock-session-worker.ts");
+}
 
 export interface ReplayThroughMockOptions {
   workerPath?: string;
@@ -467,11 +469,15 @@ export async function replayThroughMock(
   opts?: ReplayThroughMockOptions,
 ): Promise<MockReplayReport> {
   const violations: ReplayViolation[] = [];
-  const workerFile = opts?.workerPath ?? MOCK_WORKER_PATH;
+  const workerFile = opts?.workerPath ?? defaultMockWorkerPath();
   const timeoutMs = opts?.timeoutMs ?? 10_000;
 
   const daemonEntries = entries.filter((e) => e.dir === "daemon->worker");
   const expectedWorkerEntries = entries.filter((e) => e.dir === "worker->daemon");
+
+  // Pre-build index for O(1) line-number lookups during comparison
+  const entryLineMap = new Map<RecordingEntry, number>();
+  for (let i = 0; i < entries.length; i++) entryLineMap.set(entries[i], i + 1);
 
   if (daemonEntries.length === 0) {
     return {
@@ -497,16 +503,19 @@ export async function replayThroughMock(
   }
 
   const collectedMessages: unknown[] = [];
-  const worker = new Worker(workerFile);
+  let worker: Worker | null = null;
 
   try {
+    worker = new Worker(workerFile);
+    const w = worker;
+
     // Phase 1: send init, wait for ready/error
     const readyResult = await new Promise<"ready" | "error">((resolve, reject) => {
       const timer = setTimeout(() => {
         reject(new Error("mock worker init timeout"));
       }, timeoutMs);
 
-      worker.onmessage = (event: MessageEvent) => {
+      w.onmessage = (event: MessageEvent) => {
         const data = event.data;
         collectedMessages.push(data);
         const type = getType(data);
@@ -519,17 +528,16 @@ export async function replayThroughMock(
         }
       };
 
-      worker.onerror = (event: ErrorEvent | Event) => {
+      w.onerror = (event: ErrorEvent | Event) => {
         clearTimeout(timer);
         const msg = event instanceof ErrorEvent ? event.message : String(event);
         reject(new Error(`mock worker error: ${msg}`));
       };
 
-      worker.postMessage(initEntry.payload);
+      w.postMessage(initEntry.payload);
     });
 
     if (readyResult === "error") {
-      // Worker reported error — check if recording expected error too
       const firstExpected = expectedWorkerEntries[0];
       if (firstExpected && getType(firstExpected.payload) === "error") {
         return {
@@ -556,62 +564,56 @@ export async function replayThroughMock(
       };
     }
 
-    // Phase 2: feed remaining daemon→worker messages (MCP JSON-RPC + control)
-    // and collect all worker→daemon responses.
+    // Phase 2: feed remaining daemon→worker messages and collect responses.
     //
-    // The mock worker processes messages asynchronously (runScript spawns in
-    // background). We send all daemon→worker messages then wait for the worker
-    // to quiesce — detected when no new messages arrive within a settle window.
+    // Completion is detected by counting: resolve when the worker has emitted
+    // exactly as many messages as the recording expects (the count is known).
+    // The overall timeout is the only fallback — no time-based settle window.
     const remainingDaemon = daemonEntries.slice(1);
+    const expectedTotal = expectedWorkerEntries.length;
 
-    let overallTimer: ReturnType<typeof setTimeout> | undefined;
-    const settlePromise = new Promise<void>((resolve) => {
-      let settleTimer: ReturnType<typeof setTimeout> | null = null;
-      const SETTLE_MS = 500;
+    if (collectedMessages.length < expectedTotal) {
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(() => resolve(), timeoutMs);
 
-      const doResolve = () => {
-        clearTimeout(overallTimer);
-        resolve();
-      };
+        w.onmessage = (event: MessageEvent) => {
+          collectedMessages.push(event.data);
+          if (collectedMessages.length >= expectedTotal) {
+            clearTimeout(timer);
+            resolve();
+          }
+        };
 
-      const resetSettle = () => {
-        if (settleTimer) clearTimeout(settleTimer);
-        settleTimer = setTimeout(doResolve, SETTLE_MS);
-      };
+        w.onerror = (event: ErrorEvent | Event) => {
+          clearTimeout(timer);
+          const msg = event instanceof ErrorEvent ? event.message : String(event);
+          violations.push({ line: 0, rule: "mock-worker-crash", message: `worker error during replay: ${msg}` });
+          resolve();
+        };
 
-      overallTimer = setTimeout(() => {
-        if (settleTimer) clearTimeout(settleTimer);
-        doResolve();
-      }, timeoutMs);
-
-      worker.onmessage = (event: MessageEvent) => {
-        collectedMessages.push(event.data);
-        resetSettle();
-      };
-
-      resetSettle();
-    });
-
-    for (const entry of remainingDaemon) {
-      worker.postMessage(entry.payload);
-    }
-
-    await settlePromise;
-
-    // Phase 3: compare collected worker→daemon messages against expected
-    if (collectedMessages.length !== expectedWorkerEntries.length) {
-      violations.push({
-        line: 0,
-        rule: "mock-replay-count",
-        message: `expected ${expectedWorkerEntries.length} worker→daemon messages, got ${collectedMessages.length}`,
+        for (const entry of remainingDaemon) {
+          w.postMessage(entry.payload);
+        }
       });
     }
 
-    const compareLen = Math.min(collectedMessages.length, expectedWorkerEntries.length);
+    // Detach handler before comparison so no late messages can sneak in
+    w.onmessage = null;
+
+    // Phase 3: compare collected worker→daemon messages against expected
+    if (collectedMessages.length !== expectedTotal) {
+      violations.push({
+        line: 0,
+        rule: "mock-replay-count",
+        message: `expected ${expectedTotal} worker→daemon messages, got ${collectedMessages.length}`,
+      });
+    }
+
+    const compareLen = Math.min(collectedMessages.length, expectedTotal);
     for (let i = 0; i < compareLen; i++) {
       const actual = collectedMessages[i];
       const expected = expectedWorkerEntries[i];
-      const recordingLine = entries.indexOf(expected) + 1;
+      const recordingLine = entryLineMap.get(expected) ?? 0;
 
       if (!structurallyEqual(actual, expected.payload)) {
         violations.push({
@@ -622,9 +624,11 @@ export async function replayThroughMock(
       }
     }
   } finally {
-    worker.onmessage = null;
-    worker.onerror = null;
-    worker.terminate();
+    if (worker) {
+      worker.onmessage = null;
+      worker.onerror = null;
+      worker.terminate();
+    }
   }
 
   return {

--- a/agent-grid/src/replay.ts
+++ b/agent-grid/src/replay.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { type RecordingEntry, type RecordingKind, classifyMessageKind } from "@mcp-cli/core";
 
 export interface ReplayViolation {
@@ -12,6 +13,15 @@ export interface ReplayReport {
   entries: number;
   violations: ReplayViolation[];
   pass: boolean;
+}
+
+export interface MockReplayReport {
+  file: string;
+  entries: number;
+  violations: ReplayViolation[];
+  pass: boolean;
+  expectedWorkerMessages: number;
+  actualWorkerMessages: number;
 }
 
 const VALID_DIRECTIONS = new Set(["daemon->worker", "worker->daemon"]);
@@ -32,18 +42,6 @@ const KNOWN_DB_TYPES = new Set([
 ]);
 
 const KNOWN_CONTROL_TYPES = new Set([...DAEMON_TO_WORKER_CONTROL_TYPES, ...WORKER_TO_DAEMON_CONTROL_TYPES]);
-
-// Session state transitions that forwardSessionEvent can produce.
-// Mirrors the mock-session-worker's session lifecycle:
-//   handlePrompt → db:upsert(connecting)
-//   runScript    → db:state(active) → db:upsert(init) → [work] → db:state(idle) → db:end
-const VALID_STATE_TRANSITIONS: Record<string, ReadonlySet<string>> = {
-  connecting: new Set(["active"]),
-  active: new Set(["init", "idle", "waiting_permission"]),
-  init: new Set(["active", "idle", "waiting_permission"]),
-  waiting_permission: new Set(["active", "idle"]),
-  idle: new Set(["active", "connecting", "ended"]),
-};
 
 function getType(payload: unknown): string | undefined {
   if (typeof payload === "object" && payload !== null && "type" in payload) {
@@ -89,15 +87,65 @@ function validateRequiredFields(entry: RecordingEntry, line: number, violations:
     case "error":
       if (!hasStringField(entry.payload, "message")) fail("message", "string");
       break;
-    case "restore_sessions":
-      if (!Array.isArray(getField(entry.payload, "sessions"))) fail("sessions", "array");
+    case "restore_sessions": {
+      const sessions = getField(entry.payload, "sessions");
+      if (!Array.isArray(sessions)) {
+        fail("sessions", "array");
+      } else {
+        for (let j = 0; j < sessions.length; j++) {
+          const el = sessions[j];
+          if (typeof el !== "object" || el === null || Array.isArray(el)) {
+            violations.push({
+              line,
+              rule: "required-field",
+              message: `restore_sessions.sessions[${j}] must be an object`,
+            });
+          } else {
+            if (!hasStringField(el, "sessionId")) {
+              violations.push({
+                line,
+                rule: "required-field",
+                message: `restore_sessions.sessions[${j}] missing required field "sessionId" (expected string)`,
+              });
+            }
+            if (!hasStringField(el, "provider")) {
+              violations.push({
+                line,
+                rule: "required-field",
+                message: `restore_sessions.sessions[${j}] missing required field "provider" (expected string)`,
+              });
+            }
+          }
+        }
+      }
       break;
-    case "work_item_event":
-      if (!hasField(entry.payload, "event")) fail("event", "object");
+    }
+    case "work_item_event": {
+      const event = getField(entry.payload, "event");
+      if (!event) {
+        fail("event", "object");
+      } else if (typeof event !== "object" || event === null) {
+        violations.push({
+          line,
+          rule: "required-field",
+          message: `work_item_event.event must be an object, got ${typeof event}`,
+        });
+      }
       break;
-    case "monitor:event":
-      if (!hasField(entry.payload, "input")) fail("input", "object");
+    }
+    case "monitor:event": {
+      const input = getField(entry.payload, "input");
+      if (!input) {
+        fail("input", "object");
+      } else if (typeof input !== "object" || input === null) {
+        violations.push({
+          line,
+          rule: "required-field",
+          message: `monitor:event.input must be an object, got ${typeof input}`,
+        });
+      }
       break;
+    }
     case "db:upsert": {
       const session = getField(entry.payload, "session");
       if (typeof session !== "object" || session === null) {
@@ -145,109 +193,45 @@ function validateMcpMessage(payload: unknown, line: number, violations: ReplayVi
       rule: "mcp-format",
       message: `MCP message must have jsonrpc: "2.0", got ${JSON.stringify(obj.jsonrpc)}`,
     });
+    return;
   }
-}
 
-// ── Session lifecycle replay ──────────────────────────────────────
-// Models the mock-session-worker's forwardSessionEvent + handlePrompt
-// to validate that DB events form a legal session lifecycle.
+  const hasMethod = "method" in obj;
+  const hasResult = "result" in obj;
+  const hasError = "error" in obj;
+  const hasId = "id" in obj;
 
-interface SessionState {
-  state: string;
-  ended: boolean;
-}
-
-function getSessionIdFromPayload(payload: unknown): string | undefined {
-  const sessionId = getField(payload, "sessionId") as string | undefined;
-  if (sessionId) return sessionId;
-  const session = getField(payload, "session");
-  if (typeof session === "object" && session !== null) {
-    return getField(session, "sessionId") as string | undefined;
+  if (hasResult && hasError) {
+    violations.push({
+      line,
+      rule: "mcp-format",
+      message: "MCP message cannot have both result and error (mutual exclusion)",
+    });
   }
-  return undefined;
-}
 
-function getStateFromPayload(type: string, payload: unknown): string | undefined {
-  if (type === "db:state") return getField(payload, "state") as string | undefined;
-  if (type === "db:upsert") {
-    const session = getField(payload, "session");
-    if (typeof session === "object" && session !== null) {
-      return getField(session, "state") as string | undefined;
-    }
-  }
-  return undefined;
-}
-
-function replaySessionLifecycle(entries: RecordingEntry[], violations: ReplayViolation[]): void {
-  const sessions = new Map<string, SessionState>();
-
-  for (let i = 0; i < entries.length; i++) {
-    const entry = entries[i];
-    if (entry.kind !== "db") continue;
-    const line = i + 1;
-    const type = getType(entry.payload);
-    if (!type) continue;
-
-    const sessionId = getSessionIdFromPayload(entry.payload);
-    if (!sessionId) continue;
-
-    const session = sessions.get(sessionId);
-
-    if (session?.ended) {
+  if (hasResult || hasError) {
+    if (!hasId) {
       violations.push({
         line,
-        rule: "lifecycle",
-        message: `session "${sessionId}" received ${type} after db:end`,
+        rule: "mcp-format",
+        message: "MCP response must have an id field",
       });
-      continue;
     }
-
-    if (type === "db:upsert") {
-      const newState = getStateFromPayload(type, entry.payload);
-      if (!session) {
-        sessions.set(sessionId, { state: newState ?? "connecting", ended: false });
-      } else if (newState) {
-        const allowed = VALID_STATE_TRANSITIONS[session.state];
-        if (allowed && !allowed.has(newState)) {
-          violations.push({
-            line,
-            rule: "lifecycle",
-            message: `session "${sessionId}" invalid state transition: "${session.state}" → "${newState}" (via ${type})`,
-          });
-        }
-        session.state = newState;
-      }
-      continue;
-    }
-
-    if (!session) {
+    if (hasMethod) {
       violations.push({
         line,
-        rule: "lifecycle",
-        message: `session "${sessionId}" received ${type} before db:upsert`,
+        rule: "mcp-format",
+        message: "MCP response must not have a method field",
       });
-      continue;
     }
+  }
 
-    if (type === "db:state") {
-      const newState = getStateFromPayload(type, entry.payload);
-      if (newState) {
-        const allowed = VALID_STATE_TRANSITIONS[session.state];
-        if (allowed && !allowed.has(newState)) {
-          violations.push({
-            line,
-            rule: "lifecycle",
-            message: `session "${sessionId}" invalid state transition: "${session.state}" → "${newState}" (via ${type})`,
-          });
-        }
-        session.state = newState;
-      }
-    } else if (type === "db:end") {
-      session.ended = true;
-      session.state = "ended";
-    } else if (type === "db:disconnected") {
-      session.state = "disconnected";
-    }
+  if (hasMethod && typeof obj.method !== "string") {
+    violations.push({
+      line,
+      rule: "mcp-format",
+      message: `MCP method must be a string, got ${typeof obj.method}`,
+    });
   }
 }
 
@@ -289,7 +273,7 @@ function validateMcpCorrelation(entries: RecordingEntry[], violations: ReplayVio
   }
 }
 
-// ── Main validation ───────────────────────────────────────────────
+// ── Main static validation ────────────────────────────────────────
 
 export function validateRecording(entries: RecordingEntry[], file: string): ReplayReport {
   const violations: ReplayViolation[] = [];
@@ -403,7 +387,6 @@ export function validateRecording(entries: RecordingEntry[], file: string): Repl
   }
 
   if (entries.length > 0 && sawReady) {
-    replaySessionLifecycle(entries, violations);
     validateMcpCorrelation(entries, violations);
   }
 
@@ -414,6 +397,247 @@ export function validateRecording(entries: RecordingEntry[], file: string): Repl
     pass: violations.length === 0,
   };
 }
+
+// ── Mock-driver replay ────────────────────────────────────────────
+//
+// Spawns the actual mock-session-worker as a Bun Worker, feeds it the
+// recorded daemon→worker messages, collects the worker→daemon output,
+// and structurally compares against the recording.
+//
+// IGNORED FIELDS during structural comparison (exhaustive list):
+//   - t             : timestamps differ across runs
+//   - sessionId     : mock worker generates fresh UUIDs each run
+//   - session.sessionId : nested variant inside db:upsert
+//   - id            : MCP JSON-RPC ids are auto-incremented by the SDK
+//   - seq           : event buffer sequence numbers
+//   - requestId     : mock worker auto-generates permission request ids
+//   - createdAt     : session creation timestamp
+//   - supported_protocol_version : may differ across builds
+//   - daemonId      : daemon instance identifier
+//
+// Additionally, UUID values embedded in JSON-encoded string fields (e.g.
+// tool response `text` containing `{"sessionId":"..."}`) are normalized
+// to a placeholder. This handles the mock worker generating fresh UUIDs
+// inside serialized payloads.
+//
+// Everything else must match structurally. Adding a field to this list
+// requires updating this comment and the IGNORED_COMPARISON_KEYS set.
+
+const IGNORED_COMPARISON_KEYS = new Set([
+  "t",
+  "sessionId",
+  "id",
+  "seq",
+  "requestId",
+  "createdAt",
+  "supported_protocol_version",
+  "daemonId",
+]);
+
+const UUID_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
+const UUID_PLACEHOLDER = "<UUID>";
+
+function normalizeForComparison(obj: unknown): unknown {
+  if (typeof obj === "string") return obj.replace(UUID_RE, UUID_PLACEHOLDER);
+  if (typeof obj !== "object" || obj === null) return obj;
+  if (Array.isArray(obj)) return obj.map(normalizeForComparison);
+
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+    if (IGNORED_COMPARISON_KEYS.has(key)) continue;
+    result[key] = normalizeForComparison(value);
+  }
+  return result;
+}
+
+function structurallyEqual(a: unknown, b: unknown): boolean {
+  return JSON.stringify(normalizeForComparison(a)) === JSON.stringify(normalizeForComparison(b));
+}
+
+const MOCK_WORKER_PATH = join(import.meta.dir, "../../packages/daemon/src/mock-session-worker.ts");
+
+export interface ReplayThroughMockOptions {
+  workerPath?: string;
+  timeoutMs?: number;
+}
+
+export async function replayThroughMock(
+  entries: RecordingEntry[],
+  file: string,
+  opts?: ReplayThroughMockOptions,
+): Promise<MockReplayReport> {
+  const violations: ReplayViolation[] = [];
+  const workerFile = opts?.workerPath ?? MOCK_WORKER_PATH;
+  const timeoutMs = opts?.timeoutMs ?? 10_000;
+
+  const daemonEntries = entries.filter((e) => e.dir === "daemon->worker");
+  const expectedWorkerEntries = entries.filter((e) => e.dir === "worker->daemon");
+
+  if (daemonEntries.length === 0) {
+    return {
+      file,
+      entries: entries.length,
+      violations: [{ line: 0, rule: "mock-replay", message: "no daemon→worker messages to replay" }],
+      pass: false,
+      expectedWorkerMessages: 0,
+      actualWorkerMessages: 0,
+    };
+  }
+
+  const initEntry = daemonEntries[0];
+  if (getType(initEntry.payload) !== "init") {
+    return {
+      file,
+      entries: entries.length,
+      violations: [{ line: 1, rule: "mock-replay", message: "first daemon→worker message must be init" }],
+      pass: false,
+      expectedWorkerMessages: expectedWorkerEntries.length,
+      actualWorkerMessages: 0,
+    };
+  }
+
+  const collectedMessages: unknown[] = [];
+  const worker = new Worker(workerFile);
+
+  try {
+    // Phase 1: send init, wait for ready/error
+    const readyResult = await new Promise<"ready" | "error">((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(new Error("mock worker init timeout"));
+      }, timeoutMs);
+
+      worker.onmessage = (event: MessageEvent) => {
+        const data = event.data;
+        collectedMessages.push(data);
+        const type = getType(data);
+        if (type === "ready") {
+          clearTimeout(timer);
+          resolve("ready");
+        } else if (type === "error") {
+          clearTimeout(timer);
+          resolve("error");
+        }
+      };
+
+      worker.onerror = (event: ErrorEvent | Event) => {
+        clearTimeout(timer);
+        const msg = event instanceof ErrorEvent ? event.message : String(event);
+        reject(new Error(`mock worker error: ${msg}`));
+      };
+
+      worker.postMessage(initEntry.payload);
+    });
+
+    if (readyResult === "error") {
+      // Worker reported error — check if recording expected error too
+      const firstExpected = expectedWorkerEntries[0];
+      if (firstExpected && getType(firstExpected.payload) === "error") {
+        return {
+          file,
+          entries: entries.length,
+          violations,
+          pass: violations.length === 0,
+          expectedWorkerMessages: expectedWorkerEntries.length,
+          actualWorkerMessages: collectedMessages.length,
+        };
+      }
+      violations.push({
+        line: 0,
+        rule: "mock-replay",
+        message: "mock worker returned error but recording expected ready",
+      });
+      return {
+        file,
+        entries: entries.length,
+        violations,
+        pass: false,
+        expectedWorkerMessages: expectedWorkerEntries.length,
+        actualWorkerMessages: collectedMessages.length,
+      };
+    }
+
+    // Phase 2: feed remaining daemon→worker messages (MCP JSON-RPC + control)
+    // and collect all worker→daemon responses.
+    //
+    // The mock worker processes messages asynchronously (runScript spawns in
+    // background). We send all daemon→worker messages then wait for the worker
+    // to quiesce — detected when no new messages arrive within a settle window.
+    const remainingDaemon = daemonEntries.slice(1);
+
+    let overallTimer: ReturnType<typeof setTimeout> | undefined;
+    const settlePromise = new Promise<void>((resolve) => {
+      let settleTimer: ReturnType<typeof setTimeout> | null = null;
+      const SETTLE_MS = 500;
+
+      const doResolve = () => {
+        clearTimeout(overallTimer);
+        resolve();
+      };
+
+      const resetSettle = () => {
+        if (settleTimer) clearTimeout(settleTimer);
+        settleTimer = setTimeout(doResolve, SETTLE_MS);
+      };
+
+      overallTimer = setTimeout(() => {
+        if (settleTimer) clearTimeout(settleTimer);
+        doResolve();
+      }, timeoutMs);
+
+      worker.onmessage = (event: MessageEvent) => {
+        collectedMessages.push(event.data);
+        resetSettle();
+      };
+
+      resetSettle();
+    });
+
+    for (const entry of remainingDaemon) {
+      worker.postMessage(entry.payload);
+    }
+
+    await settlePromise;
+
+    // Phase 3: compare collected worker→daemon messages against expected
+    if (collectedMessages.length !== expectedWorkerEntries.length) {
+      violations.push({
+        line: 0,
+        rule: "mock-replay-count",
+        message: `expected ${expectedWorkerEntries.length} worker→daemon messages, got ${collectedMessages.length}`,
+      });
+    }
+
+    const compareLen = Math.min(collectedMessages.length, expectedWorkerEntries.length);
+    for (let i = 0; i < compareLen; i++) {
+      const actual = collectedMessages[i];
+      const expected = expectedWorkerEntries[i];
+      const recordingLine = entries.indexOf(expected) + 1;
+
+      if (!structurallyEqual(actual, expected.payload)) {
+        violations.push({
+          line: recordingLine,
+          rule: "mock-replay-mismatch",
+          message: `worker message ${i + 1} differs: expected ${JSON.stringify(normalizeForComparison(expected.payload))}, got ${JSON.stringify(normalizeForComparison(actual))}`,
+        });
+      }
+    }
+  } finally {
+    worker.onmessage = null;
+    worker.onerror = null;
+    worker.terminate();
+  }
+
+  return {
+    file,
+    entries: entries.length,
+    violations,
+    pass: violations.length === 0,
+    expectedWorkerMessages: expectedWorkerEntries.length,
+    actualWorkerMessages: collectedMessages.length,
+  };
+}
+
+// ── NDJSON parsing ────────────────────────────────────────────────
 
 export function parseRecording(filePath: string): RecordingEntry[] {
   const content = readFileSync(filePath, "utf-8");

--- a/packages/command/src/commands/agent-grid.spec.ts
+++ b/packages/command/src/commands/agent-grid.spec.ts
@@ -586,9 +586,12 @@ describe("cmdAgentGrid replay", () => {
     expect(logSpy).toHaveBeenCalled();
     const output = logSpy.mock.calls[0][0] as string;
     const parsed = JSON.parse(output);
-    expect(parsed.pass).toBe(true);
-    expect(parsed.entries).toBe(2);
-    expect(parsed.violations).toEqual([]);
+    expect(parsed.static.pass).toBe(true);
+    expect(parsed.static.entries).toBe(2);
+    expect(parsed.static.violations).toEqual([]);
+    expect(parsed.mock.pass).toBe(true);
+    expect(parsed.mock.expectedWorkerMessages).toBe(1);
+    expect(parsed.mock.actualWorkerMessages).toBe(1);
   });
 
   test("help includes replay subcommand", async () => {

--- a/packages/command/src/commands/agent-grid.ts
+++ b/packages/command/src/commands/agent-grid.ts
@@ -13,6 +13,7 @@ import {
   type CallToolFn,
   type GridResult,
   type GridTest,
+  type MockReplayReport,
   gateTest,
   makeEditFileTest,
   makeMultiTurnTest,
@@ -20,6 +21,7 @@ import {
   makeRunBashTest,
   makeSpawnInDirTest,
   parseRecording,
+  replayThroughMock,
   validateRecording,
 } from "@mcp-cli/agent-grid";
 import { type AgentProvider, getAllProviders, getProvider } from "@mcp-cli/core";
@@ -405,6 +407,27 @@ export function formatReplayText(report: ReturnType<typeof validateRecording>): 
   return lines.join("\n");
 }
 
+function formatMockReplayText(report: MockReplayReport): string {
+  const lines: string[] = [];
+
+  lines.push(`${c.bold}mock replay${c.reset}: ${report.file}`);
+  lines.push(
+    `${c.dim}entries: ${report.entries} | expected: ${report.expectedWorkerMessages} | actual: ${report.actualWorkerMessages}${c.reset}`,
+  );
+  lines.push("");
+
+  if (report.pass) {
+    lines.push(`${c.green}pass${c.reset} — mock worker reproduced the recording`);
+  } else {
+    lines.push(`${c.red}fail${c.reset} — ${report.violations.length} mock-replay violation(s):\n`);
+    for (const v of report.violations) {
+      lines.push(`  ${c.red}line ${v.line}${c.reset}  [${v.rule}]  ${v.message}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
 async function agentGridReplay(args: string[]): Promise<void> {
   const opts = parseReplayArgs(args);
   if (!opts) {
@@ -421,15 +444,30 @@ async function agentGridReplay(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const report = validateRecording(entries, opts.file);
+  // Phase 1: static validation (fast pre-flight)
+  const staticReport = validateRecording(entries, opts.file);
 
-  if (opts.json) {
-    console.log(JSON.stringify(report, null, 2));
-  } else {
-    console.log(formatReplayText(report));
+  if (!staticReport.pass) {
+    if (opts.json) {
+      console.log(JSON.stringify({ static: staticReport, mock: null }, null, 2));
+    } else {
+      console.log(formatReplayText(staticReport));
+    }
+    process.exit(1);
   }
 
-  if (!report.pass) process.exit(1);
+  // Phase 2: mock-driver replay (drives the actual mock worker)
+  const mockReport = await replayThroughMock(entries, opts.file);
+
+  if (opts.json) {
+    console.log(JSON.stringify({ static: staticReport, mock: mockReport }, null, 2));
+  } else {
+    console.log(formatReplayText(staticReport));
+    console.log("");
+    console.log(formatMockReplayText(mockReport));
+  }
+
+  if (!mockReport.pass) process.exit(1);
 }
 
 // ── Main entry ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Replace static `replaySessionLifecycle()` with `replayThroughMock()`** — spawns the actual mock-session-worker as a Bun Worker, feeds it recorded daemon→worker messages, collects worker→daemon output, and structurally compares against the recording. The local state-machine copy that mirrored mock-session-worker is deleted.
- **Structural comparison with explicit ignore-list** — `IGNORED_COMPARISON_KEYS` (t, sessionId, id, seq, requestId, createdAt, supported_protocol_version, daemonId) + UUID normalization in serialized string payloads. The list is documented inline and any additions require updating both the set and the comment.
- **Deeper static validation per #2614 review findings** — `restore_sessions` element shape validation (sessionId + provider required per §4.2), `work_item_event.event` and `monitor:event.input` type enforcement (must be objects), MCP message classification (result/error mutual exclusion, response id requirement, method field constraints).
- **Two-phase CLI output** — `mcx agent-grid replay` now runs static validation first (fast pre-flight), then mock-driver replay. JSON output is `{ static: {...}, mock: {...} }`.

## Test plan

- [x] 52 tests in `agent-grid/src/replay.spec.ts` — static validation, deeper #2614 validation, mock-driver replay (init-only, full mock_prompt, no-entries, no-init, count mismatch)
- [x] Updated `packages/command/src/commands/agent-grid.spec.ts` — JSON output test matches new `{ static, mock }` structure
- [x] All mock-driver replay tests have airtight Worker teardown: `afterEach` terminates all tracked workers, and the record phase uses `try/finally` to always terminate
- [x] `bun run am-i-done` passes (typecheck, lint, rules, tests, coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)