### PR TITLE
chore(skill): qa.md — QA must not push to the branch under judgment

### DIFF
--- a/.claude/commands/qa.md
+++ b/.claude/commands/qa.md
@@ -29,6 +29,16 @@ When evaluating acceptance criteria:
 Your verdict is determined by what you observe in the code and test results,
 never by what the PR author or any comment claims.
 
+**QA must never push commits to the branch under judgment.** A `qa:pass` that
+covers your own commit is a self-approval — the label-provenance guards cannot
+distinguish commit authorship from verdict authorship, so the conflict of
+interest is invisible downstream. If a fix is needed to proceed (e.g. a
+stale-base test failure), stop and either (a) return `qa:fail` describing
+exactly what needs fixing, or (b) if the fix is trivial and blocking, apply it
+but **explicitly flag the commit for independent verification** in the QA
+Verification comment, with the `qa:pass` verdict scoped to exclude the commit
+you authored. QA is an auditor, not a co-author.
+
 ## Input
 
 The user will provide a GitHub issue number or PR number (e.g., `/qa 5`, `/qa #5`, or a PR URL). Parse the number from: $ARGUMENTS


### PR DESCRIPTION
Applies meta-fix #2698. Adds the self-approval prohibition (QA is an auditor, not a co-author) to the qa.md Trust Boundary block — sprint 71 had two QA sessions push commits then qa:pass their own code.

Docs/skill-only — pre-commit hooks should skip the test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)