### PR TITLE
fix(security): fail closed for unrecognized tools in worktree containment (fixes #2693)

### DIFF
--- a/packages/daemon/src/claude-session/containment.spec.ts
+++ b/packages/daemon/src/claude-session/containment.spec.ts
@@ -56,11 +56,93 @@ describe("ContainmentGuard — in-worktree operations", () => {
     expect(r.action).toBe("allow");
   });
 
-  test("allows unknown tools (no file_path)", () => {
+  test("allows known non-filesystem tools (Agent, TodoWrite, WebFetch)", () => {
     const g = guard();
-    const r = g.evaluate("Agent", { prompt: "do something" });
-    expect(r.action).toBe("allow");
+    expect(g.evaluate("Agent", { prompt: "do something" }).action).toBe("allow");
+    expect(g.evaluate("TodoWrite", { todos: [] }).action).toBe("allow");
+    expect(g.evaluate("WebFetch", { url: "https://example.com" }).action).toBe("allow");
+    expect(g.evaluate("ExitPlanMode", { plan: "x" }).action).toBe("allow");
   });
+
+  test("allows MCP tools by prefix", () => {
+    const g = guard();
+    const r = g.evaluate("mcp__atlassian__search", { query: "test" });
+    expect(r.action).toBe("allow");
+    expect(r.event).toBeUndefined();
+  });
+});
+
+// ── Fail-closed for unrecognized tools (#2520) ──
+
+describe("ContainmentGuard — fail closed for unrecognized tools", () => {
+  test("denies an unrecognized tool by default", () => {
+    const g = guard();
+    const r = g.evaluate("FutureWriteTool", { file_path: `${WORKTREE}/src/main.ts` });
+    expect(r.action).toBe("deny");
+    expect(r.event).toBe("session:containment_denied");
+  });
+
+  test("denies an unrecognized tool even with no path argument", () => {
+    const g = guard();
+    const r = g.evaluate("SomeBrandNewTool", { foo: "bar" });
+    expect(r.action).toBe("deny");
+    expect(r.event).toBe("session:containment_denied");
+  });
+
+  test("denying an unrecognized tool does not consume a strike (no full lockout)", () => {
+    const g = guard();
+    for (let i = 0; i < 5; i++) {
+      const r = g.evaluate("SomeBrandNewTool", { foo: "bar" });
+      expect(r.action).toBe("deny");
+    }
+    expect(g.strikes).toBe(0);
+    expect(g.escalated).toBe(false);
+    // A legitimate in-worktree write still works afterwards.
+    expect(g.evaluate("Write", { file_path: `${WORKTREE}/src/main.ts` }).action).toBe("allow");
+  });
+
+  test("denies a write tool whose path argument is missing (fail closed)", () => {
+    const g = guard();
+    const r = g.evaluate("Write", { content: "data" });
+    expect(r.action).toBe("deny");
+    expect(r.event).toBe("session:containment_denied");
+  });
+});
+
+// ── Absolute-path escape into the parent main checkout (#2693) ──
+// A worktree lives at <main>/.claude/worktrees/<id>; the orchestrator's main
+// checkout is its parent. Absolute paths quoted from issue investigation
+// comments resolve into main, not the worktree, and must be denied.
+describe("ContainmentGuard — absolute path into parent main checkout", () => {
+  // WORKTREE = /Users/test/repo/.claude/worktrees/my-worktree → main = /Users/test/repo
+  const MAIN = "/Users/test/repo";
+  const strayFiles = [
+    `${MAIN}/packages/command/src/commands/track.ts`,
+    `${MAIN}/packages/command/src/commands/track.spec.ts`,
+    `${MAIN}/packages/core/src/phase-transition.ts`,
+    `${MAIN}/packages/core/src/phase-transition.spec.ts`,
+  ];
+
+  for (const file of strayFiles) {
+    test(`denies Write to main-checkout path ${file}`, () => {
+      const g = guard();
+      const r = g.evaluate("Write", { file_path: file });
+      expect(r.action).toBe("deny");
+      expect(r.strikes).toBe(1);
+    });
+
+    test(`denies Edit to main-checkout path ${file}`, () => {
+      const g = guard();
+      const r = g.evaluate("Edit", { file_path: file, old_string: "a", new_string: "b" });
+      expect(r.action).toBe("deny");
+    });
+
+    test(`denies MultiEdit to main-checkout path ${file}`, () => {
+      const g = guard();
+      const r = g.evaluate("MultiEdit", { file_path: file, edits: [] });
+      expect(r.action).toBe("deny");
+    });
+  }
 });
 
 // ── Git write commands outside worktree ──
@@ -261,10 +343,11 @@ describe("ContainmentGuard — edge cases", () => {
     expect(r.action).toBe("allow");
   });
 
-  test("handles missing file_path in Write", () => {
+  test("denies Write with missing file_path (fail closed, #2520)", () => {
     const g = guard();
     const r = g.evaluate("Write", {});
-    expect(r.action).toBe("allow");
+    expect(r.action).toBe("deny");
+    expect(r.event).toBe("session:containment_denied");
   });
 
   test("git commands with flags before subcommand", () => {

--- a/packages/daemon/src/claude-session/containment.spec.ts
+++ b/packages/daemon/src/claude-session/containment.spec.ts
@@ -56,12 +56,24 @@ describe("ContainmentGuard — in-worktree operations", () => {
     expect(r.action).toBe("allow");
   });
 
+  test("allows NotebookEdit inside worktree (notebook_path param)", () => {
+    const g = guard();
+    const r = g.evaluate("NotebookEdit", { notebook_path: `${WORKTREE}/nb.ipynb`, new_source: "x" });
+    expect(r.action).toBe("allow");
+  });
+
   test("allows known non-filesystem tools (Agent, TodoWrite, WebFetch)", () => {
     const g = guard();
     expect(g.evaluate("Agent", { prompt: "do something" }).action).toBe("allow");
     expect(g.evaluate("TodoWrite", { todos: [] }).action).toBe("allow");
     expect(g.evaluate("WebFetch", { url: "https://example.com" }).action).toBe("allow");
     expect(g.evaluate("ExitPlanMode", { plan: "x" }).action).toBe("allow");
+  });
+
+  test("allows read-only MCP discovery built-ins (no mcp__ prefix)", () => {
+    const g = guard();
+    expect(g.evaluate("ListMcpResourcesTool", {}).action).toBe("allow");
+    expect(g.evaluate("ReadMcpResourceTool", { server: "s", uri: "u" }).action).toBe("allow");
   });
 
   test("allows MCP tools by prefix", () => {
@@ -106,6 +118,13 @@ describe("ContainmentGuard — fail closed for unrecognized tools", () => {
     const r = g.evaluate("Write", { content: "data" });
     expect(r.action).toBe("deny");
     expect(r.event).toBe("session:containment_denied");
+  });
+
+  test("denies NotebookEdit escaping the worktree (path-check is functional)", () => {
+    const g = guard();
+    const r = g.evaluate("NotebookEdit", { notebook_path: "/Users/test/repo/nb.ipynb", new_source: "x" });
+    expect(r.action).toBe("deny");
+    expect(r.strikes).toBe(1);
   });
 });
 

--- a/packages/daemon/src/claude-session/containment.ts
+++ b/packages/daemon/src/claude-session/containment.ts
@@ -267,6 +267,10 @@ const CONTAINMENT_SAFE_TOOLS: ReadonlySet<string> = new Set([
   "KillBash",
   "SlashCommand",
   "Skill",
+  // Read-only MCP discovery built-ins (no `mcp__` prefix — they're built-ins,
+  // not server-namespaced tool calls).
+  "ListMcpResourcesTool",
+  "ReadMcpResourceTool",
 ]);
 
 // MCP tools execute in the daemon / external servers, not the worktree's
@@ -276,13 +280,13 @@ const MCP_TOOL_PREFIX = "mcp__";
 // ── File path extraction ──
 
 function extractFilePath(toolName: string, input: Record<string, unknown>): string | null {
-  if (
-    toolName === "Write" ||
-    toolName === "Edit" ||
-    toolName === "MultiEdit" ||
-    toolName === "Read" ||
-    toolName === "NotebookEdit"
-  ) {
+  if (toolName === "NotebookEdit") {
+    // The live NotebookEdit tool's path parameter is `notebook_path`; fall back
+    // to `file_path` for older/aliased shapes.
+    const np = input.notebook_path ?? input.file_path;
+    return typeof np === "string" ? np : null;
+  }
+  if (toolName === "Write" || toolName === "Edit" || toolName === "MultiEdit" || toolName === "Read") {
     const fp = input.file_path;
     return typeof fp === "string" ? fp : null;
   }

--- a/packages/daemon/src/claude-session/containment.ts
+++ b/packages/daemon/src/claude-session/containment.ts
@@ -242,7 +242,36 @@ function extractBashWriteTargets(command: string): string[] {
 
 // ── Containment-gated tool sets ──
 
+// Write-capable file tools. Their path argument is resolved and must stay
+// inside the worktree; a call whose path can't be extracted fails closed.
 export const CONTAINMENT_WRITE_TOOLS: ReadonlySet<string> = new Set(["Write", "Edit", "MultiEdit", "NotebookEdit"]);
+
+// Read-class file tools. Out-of-worktree access is warned, never denied.
+const CONTAINMENT_READ_TOOLS: ReadonlySet<string> = new Set(["Read", "Glob", "Grep"]);
+
+// Built-in tools that cannot write to an arbitrary filesystem path via a tool
+// argument. Bash is handled separately (command parsing). Everything not in any
+// known set — including a future write-capable tool the guard doesn't yet
+// recognize — fails closed (#2520) so containment can't be silently bypassed.
+const CONTAINMENT_SAFE_TOOLS: ReadonlySet<string> = new Set([
+  "NotebookRead",
+  "WebFetch",
+  "WebSearch",
+  "Task",
+  "Agent",
+  "TodoWrite",
+  "TodoRead",
+  "ExitPlanMode",
+  "BashOutput",
+  "KillShell",
+  "KillBash",
+  "SlashCommand",
+  "Skill",
+]);
+
+// MCP tools execute in the daemon / external servers, not the worktree's
+// filesystem surface, and are the core purpose of mcp-cli — allow by prefix.
+const MCP_TOOL_PREFIX = "mcp__";
 
 // ── File path extraction ──
 
@@ -336,13 +365,47 @@ export class ContainmentGuard {
       return this.evaluateBash(input);
     }
 
-    // File-path tools
-    const filePath = extractFilePath(toolName, input);
-    if (filePath && isPathOutside(filePath, this.worktreeRoot)) {
-      return this.evaluateFileAccess(toolName, filePath);
+    // Write-capable file tools — resolve the path and deny if it escapes the
+    // worktree. A write call whose path can't be extracted fails closed (#2520):
+    // a malformed or unrecognized-shape write must never be silently allowed.
+    if (CONTAINMENT_WRITE_TOOLS.has(toolName)) {
+      const filePath = extractFilePath(toolName, input);
+      if (filePath === null) {
+        return {
+          action: "deny",
+          reason: `${toolName} call has no resolvable file path; containment cannot verify it stays inside ${this.worktreeRoot}. Denied.`,
+          event: "session:containment_denied",
+          strikes: this._strikes,
+        };
+      }
+      if (isPathOutside(filePath, this.worktreeRoot)) {
+        return this.evaluateFileAccess(toolName, filePath);
+      }
+      return { action: "allow", reason: "", strikes: this._strikes };
     }
 
-    return { action: "allow", reason: "", strikes: this._strikes };
+    // Read-class file tools — out-of-worktree access is warned, not denied.
+    if (CONTAINMENT_READ_TOOLS.has(toolName)) {
+      const filePath = extractFilePath(toolName, input);
+      if (filePath && isPathOutside(filePath, this.worktreeRoot)) {
+        return this.evaluateFileAccess(toolName, filePath);
+      }
+      return { action: "allow", reason: "", strikes: this._strikes };
+    }
+
+    // Known non-filesystem tools and daemon-hosted MCP tools are allowed.
+    if (CONTAINMENT_SAFE_TOOLS.has(toolName) || toolName.startsWith(MCP_TOOL_PREFIX)) {
+      return { action: "allow", reason: "", strikes: this._strikes };
+    }
+
+    // Unrecognized tool — fail closed (#2520). A write-capable tool the guard
+    // doesn't yet know about must not silently bypass worktree containment.
+    return {
+      action: "deny",
+      reason: `Tool "${toolName}" is not recognized by the worktree containment guard and is denied by default. If this tool is safe, add it to the containment allowlist.`,
+      event: "session:containment_denied",
+      strikes: this._strikes,
+    };
   }
 
   private evaluateBash(input: Record<string, unknown>): ContainmentResult {

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -2746,7 +2746,7 @@ export function extractToolFields(toolName: string, input: Record<string, unknow
       break;
     }
     case "NotebookEdit": {
-      const fp = input.file_path;
+      const fp = input.notebook_path ?? input.file_path;
       if (typeof fp === "string") {
         fields.filePath = fp;
         fields.dirPath = dirname(fp);


### PR DESCRIPTION
Closes #2693
Closes #2520

## Summary
- `ContainmentGuard.evaluate()` returned `{action: "allow"}` for any tool whose path it couldn't extract, so a write-capable tool the guard didn't recognize silently bypassed worktree containment (no event, no operator signal). It now **fails closed**.
- `evaluate()` is restructured around explicit tool categories:
  - **Write tools** (`Write`/`Edit`/`MultiEdit`/`NotebookEdit`) — path-checked; deny when the path escapes the worktree **and** deny when the path can't be extracted.
  - **Read tools** (`Read`/`Glob`/`Grep`) — warn on out-of-worktree access, never deny.
  - **Safe non-fs built-ins** (`Task`/`Agent`/`TodoWrite`/`WebFetch`/`WebSearch`/`ExitPlanMode`/`BashOutput`/`KillShell`/`SlashCommand`/`Skill`/…) and the `mcp__` prefix — allowed.
  - **Everything else (unrecognized) — denied by default**, emitting `session:containment_denied`.
- Unrecognized-tool denials **do not consume a strike**, so a benign unknown tool can't escalate the session to full lockout — the specific call is blocked, the rest of the session proceeds.

The #2693 Edit/Write absolute-path-into-main-checkout case was already covered by the existing path resolution (an absolute path into the parent main checkout resolves as outside the worktree → deny). This PR locks that in with explicit regression tests over the exact four files from the sprint-71 incident, and closes the broader fail-open class that #2693 and #2520 share.

## Test plan
- [x] New regression tests: `Write`/`Edit`/`MultiEdit` to a parent main-checkout absolute path are denied (#2693).
- [x] New fail-closed tests: unrecognized tool denied (with/without a path arg), repeated unknown-tool denials don't consume strikes, write tool with missing `file_path` denied (#2520).
- [x] Known-safe tools (`Agent`, `TodoWrite`, `WebFetch`, `ExitPlanMode`) and `mcp__*` tools still allowed.
- [x] Updated the prior `handles missing file_path in Write` test (was asserting the old fail-open `allow`).
- [x] Full `bun run am-i-done` passes (typecheck, lint, rules, tests, coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)