### PR TITLE
test(phases): regression test for validateVerdictLabel NaN guard (closes #2683)

### DIFF
--- a/.claude/phases/phase-types.spec.ts
+++ b/.claude/phases/phase-types.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parsePrEditFlags } from "./phase-types";
+import { type GhLabelEvent, type VerdictContext, parsePrEditFlags, validateVerdictLabel } from "./phase-types";
 
 describe("parsePrEditFlags", () => {
   test("parses --remove-label flags", () => {
@@ -29,5 +29,63 @@ describe("parsePrEditFlags", () => {
 
   test("throws on unknown flag", () => {
     expect(() => parsePrEditFlags(["--title", "oops"])).toThrow("prEdit: unknown flag --title");
+  });
+});
+
+describe("validateVerdictLabel", () => {
+  const HEAD_DATE = "2026-05-31T00:00:00Z";
+  const ROUND_STARTED_AT = Date.parse("2026-06-01T00:00:00Z");
+  const FRESH = "2026-06-02T00:00:00Z"; // postdates round + head → passes (b) and (c)
+  const STALE = "2026-05-30T00:00:00Z"; // predates round start → would fail guard (b)
+
+  const ctx = (over: Partial<VerdictContext> = {}): VerdictContext => ({
+    prAuthor: "author-login",
+    roundStartedAt: ROUND_STARTED_AT,
+    headCommitDate: HEAD_DATE,
+    ...over,
+  });
+
+  const labelEvent = (created_at: string, over: Partial<GhLabelEvent> = {}): GhLabelEvent => ({
+    actor: "author-login",
+    label: "review:pass",
+    created_at,
+    ...over,
+  });
+
+  test("accepts a fresh verdict that postdates round start and head commit", () => {
+    const result = validateVerdictLabel("review:pass", [labelEvent(FRESH)], ctx());
+    expect(result.valid).toBe(true);
+  });
+
+  // Regression for #2683: a NaN roundStartedAt must fail closed BEFORE reaching the
+  // freshness comparison. Without the early guard, `eventTime < NaN` is `false`, so a
+  // STALE event would silently slip past guard (b) and advance a stale verdict.
+  test("fails closed when roundStartedAt is NaN (does not silently bypass freshness)", () => {
+    const result = validateVerdictLabel("review:pass", [labelEvent(STALE)], ctx({ roundStartedAt: NaN }));
+    expect(result.valid).toBe(false);
+    expect(result.valid === false && result.rejection).toContain("NaN");
+  });
+
+  test("NaN guard rejects even an otherwise-fresh event (guard precedes all comparisons)", () => {
+    const result = validateVerdictLabel("review:pass", [labelEvent(FRESH)], ctx({ roundStartedAt: NaN }));
+    expect(result.valid).toBe(false);
+  });
+
+  // Proves the freshness comparison IS live for a real (non-NaN) roundStartedAt — the
+  // behavior the NaN guard protects.
+  test("rejects a stale verdict that predates round start", () => {
+    const result = validateVerdictLabel("review:pass", [labelEvent(STALE)], ctx());
+    expect(result.valid).toBe(false);
+    expect(result.valid === false && result.rejection).toContain("stale verdict");
+  });
+
+  test("fails closed when no matching label event exists", () => {
+    const result = validateVerdictLabel("review:pass", [labelEvent(FRESH, { label: "qa:pass" })], ctx());
+    expect(result.valid).toBe(false);
+  });
+
+  test("fails closed on an unparseable event timestamp", () => {
+    const result = validateVerdictLabel("review:pass", [labelEvent("not-a-date")], ctx());
+    expect(result.valid).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- **#2683 is already fixed on main** — this PR adds the missing regression test, it does **not** add a redundant fix.
- The NaN fail-closed guard for `ctx.roundStartedAt` already exists at `phase-types.ts:77` (landed via #2678; `review-fn.ts:163` and `qa-fn.ts:139` are also NaN-aware via `=== 0 || Number.isNaN(...)`). #2683 was filed against the pre-merge PR branch; the guard shipped with the merge.
- `validateVerdictLabel` previously had **zero direct unit coverage** (`phase-types.spec.ts` only tested `parsePrEditFlags`). This adds 6 tests locking in fail-closed semantics, including the exact #2683 case.

## Verification of PR #2700's claim
PR #2700's body asserts `validateVerdictLabel` "already guards against NaN (see phase-types.ts)". Independently verified against `main` (`f4c4a5e1`): the claim is **accurate** — the early guard returns `{ valid: false, rejection: "roundStartedAt is NaN — fail closed" }` before any timestamp comparison.

## Why this test genuinely protects the guard (mutation-verified)
Removing the `Number.isNaN(ctx.roundStartedAt)` early guard makes the "NaN + stale event" test return `valid: true` — the precise #2683 bug (`eventTime < NaN` is `false`, so a stale verdict slips past guard (b)). With the guard present, all 6 tests pass.

## Test plan
- [x] `bun run test:phases` — `phase-types.spec.ts`: 12 pass (6 existing + 6 new)
- [x] Mutation check: deleting the guard fails exactly the 2 NaN regression tests, then reverted
- [x] `bun run am-i-done` static gate (typecheck / lint / doing-it-wrong / agent-grid) green with change present
- [x] Change is confined to `.claude/phases/phase-types.spec.ts` (test-only)

## Discovered while working (filed separately)
- The `.claude/phases/*.spec.ts` suite (`test:phases`) is **not wired into any gate** (CI / pre-commit / am-i-done) — tracked in #2648. As a result, `done-fn.spec.ts` has **7 failing `mergePr` tests on clean main** (a regression of the closed #2571). Data-point comment added to #2648; out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)