### PR TITLE
fix(phases): Array.isArray guard + typeof roundStartedAt check in review-fn/qa-fn (closes #2686, closes #2687)

### DIFF
--- a/.claude/phases/qa-fn.spec.ts
+++ b/.claude/phases/qa-fn.spec.ts
@@ -135,6 +135,21 @@ describe("readQaLabels — verdict validation (#2652)", () => {
     expect(result.rejections[0]).toMatch(/unparseable/);
   });
 
+  test("fail closed: non-array label events rejects all verdicts (#2686)", async () => {
+    const deps = makeDeps({
+      gh: async (op) => {
+        if (op.op === "pr:labels") return { stdout: "qa:pass", stderr: "", exitCode: 0 };
+        if (op.op === "pr:label-events") return { stdout: '{"foo":1}', stderr: "", exitCode: 0 };
+        if (op.op === "pr:author") return { stdout: DEFAULT_AUTHOR, stderr: "", exitCode: 0 };
+        if (op.op === "pr:head-date") return { stdout: DEFAULT_HEAD_DATE, stderr: "", exitCode: 0 };
+        return { stdout: "", stderr: "", exitCode: 1 };
+      },
+    });
+    const result = await readQaLabels(10, deps, DEFAULT_SPAWNED_AT);
+    expect(result.hasPass).toBe(false);
+    expect(result.rejections[0]).toMatch(/label-events not an array/);
+  });
+
   test("rejects stale label predating session spawn (guard b)", async () => {
     const staleEvent: GhLabelEvent = { actor: DEFAULT_AUTHOR, label: "qa:pass", created_at: "2026-06-09T09:55:00Z" };
     const deps = makeDeps({ gh: makeGh({ labels: ["qa:pass"], labelEvents: [staleEvent] }) });
@@ -230,6 +245,14 @@ describe("runQa — session exists, waiting for labels", () => {
 
   test("returns wait when qa_spawned_at is missing (fail closed)", async () => {
     const state = makeState({ qa_session_id: "abc-123" });
+    const deps = makeDeps({ gh: makeGh({ labels: ["qa:pass"] }) });
+    const result = await runQa({ provider: "claude" }, makeWork(), state, deps);
+    expect(result.action).toBe("wait");
+    if (result.action === "wait") expect(result.reason).toMatch(/fail closed/);
+  });
+
+  test("returns wait when qa_spawned_at is a string (typeof guard #2687)", async () => {
+    const state = makeState({ qa_session_id: "abc-123", qa_spawned_at: "1718000000000" as unknown as number });
     const deps = makeDeps({ gh: makeGh({ labels: ["qa:pass"] }) });
     const result = await runQa({ provider: "claude" }, makeWork(), state, deps);
     expect(result.action).toBe("wait");

--- a/.claude/phases/qa-fn.ts
+++ b/.claude/phases/qa-fn.ts
@@ -70,6 +70,9 @@ export async function readQaLabels(
   } catch {
     return { hasPass: false, hasFail: false, rejections: [`label-events JSON unparseable — fail closed`] };
   }
+  if (!Array.isArray(events)) {
+    return { hasPass: false, hasFail: false, rejections: [`label-events not an array — fail closed`] };
+  }
 
   const vctx: VerdictContext = {
     prAuthor: authorResult.stdout.trim(),
@@ -136,7 +139,7 @@ export async function runQa(
   }
 
   const roundStartedAt = (await state.get<number>("qa_spawned_at")) ?? 0;
-  if (roundStartedAt === 0 || Number.isNaN(roundStartedAt)) {
+  if (typeof roundStartedAt !== "number" || roundStartedAt === 0 || Number.isNaN(roundStartedAt)) {
     return { action: "wait", reason: "qa_spawned_at missing or invalid in state — fail closed; re-spawn to populate", model: qaModel, prompt: qaPrompt };
   }
   const { hasPass, hasFail, rejections } = await readQaLabels(work.prNumber, deps, roundStartedAt);

--- a/.claude/phases/review-fn.spec.ts
+++ b/.claude/phases/review-fn.spec.ts
@@ -173,6 +173,21 @@ describe("readReviewLabels — verdict validation (#2652)", () => {
     expect(result.rejections[0]).toMatch(/unparseable/);
   });
 
+  test("fail closed: non-array label events rejects all verdicts (#2686)", async () => {
+    const deps = makeDeps({
+      gh: async (op) => {
+        if (op.op === "pr:labels") return { stdout: "review:pass", stderr: "", exitCode: 0 };
+        if (op.op === "pr:label-events") return { stdout: '{"message":"Not Found"}', stderr: "", exitCode: 0 };
+        if (op.op === "pr:author") return { stdout: DEFAULT_AUTHOR, stderr: "", exitCode: 0 };
+        if (op.op === "pr:head-date") return { stdout: DEFAULT_HEAD_DATE, stderr: "", exitCode: 0 };
+        return { stdout: "", stderr: "", exitCode: 1 };
+      },
+    });
+    const result = await readReviewLabels(20, deps, DEFAULT_SPAWNED_AT);
+    expect(result.hasPass).toBe(false);
+    expect(result.rejections[0]).toMatch(/label-events not an array/);
+  });
+
   test("rejects stale label predating session spawn (guard b)", async () => {
     const staleEvent: GhLabelEvent = { actor: DEFAULT_AUTHOR, label: "review:pass", created_at: "2026-06-09T09:55:00Z" };
     const deps = makeDeps({ gh: makeGh({ labels: ["review:pass"], labelEvents: [staleEvent] }) });
@@ -301,6 +316,14 @@ describe("runReview — session exists", () => {
 
   test("returns wait when review_spawned_at is missing (fail closed)", async () => {
     const state = makeState({ review_session_id: "abc", review_round: 1 });
+    const deps = makeDeps({ gh: makeGh({ labels: ["review:pass"] }) });
+    const result = await runReview({ provider: "claude" }, makeWork(), state, deps, "/repo");
+    expect(result.action).toBe("wait");
+    if (result.action === "wait") expect(result.reason).toMatch(/fail closed/);
+  });
+
+  test("returns wait when review_spawned_at is a string (typeof guard #2687)", async () => {
+    const state = makeState({ review_session_id: "abc", review_round: 1, review_spawned_at: "1718000000000" as unknown as number });
     const deps = makeDeps({ gh: makeGh({ labels: ["review:pass"] }) });
     const result = await runReview({ provider: "claude" }, makeWork(), state, deps, "/repo");
     expect(result.action).toBe("wait");

--- a/.claude/phases/review-fn.ts
+++ b/.claude/phases/review-fn.ts
@@ -77,6 +77,9 @@ export async function readReviewLabels(
   } catch {
     return { hasPass: false, hasChanges: false, rejections: [`label-events JSON unparseable — fail closed`] };
   }
+  if (!Array.isArray(events)) {
+    return { hasPass: false, hasChanges: false, rejections: [`label-events not an array — fail closed`] };
+  }
 
   const vctx: VerdictContext = {
     prAuthor: authorResult.stdout.trim(),
@@ -160,7 +163,7 @@ export async function runReview(
   const storedModel = (await state.get<string>("review_model")) as "opus" | "sonnet" | null;
   const withModel = storedModel ? { model: storedModel } : {};
   const roundStartedAt = (await state.get<number>("review_spawned_at")) ?? 0;
-  if (roundStartedAt === 0 || Number.isNaN(roundStartedAt)) {
+  if (typeof roundStartedAt !== "number" || roundStartedAt === 0 || Number.isNaN(roundStartedAt)) {
     return { action: "wait", reason: "review_spawned_at missing or invalid in state — fail closed; re-spawn to populate", round, ...withModel };
   }
   const { hasPass, hasChanges, rejections } = await readReviewLabels(work.prNumber, deps, roundStartedAt);


### PR DESCRIPTION
## Summary

- **`readReviewLabels` / `readQaLabels`** (#2686): added `Array.isArray` guard immediately after `JSON.parse` in both `review-fn.ts` and `qa-fn.ts`; a non-array GitHub API response (e.g. `{"message":"Not Found"}`) now returns a clean fail-closed sentinel with a diagnostic rejection message instead of throwing `TypeError: events.filter is not a function`
- **`runReview` / `runQa` freshness guards** (#2687): added `typeof roundStartedAt !== "number"` as the first condition in the `review_spawned_at` / `qa_spawned_at` guards; a SQLite type-affinity string round-trip can no longer silently pass strict-equality and `Number.isNaN` checks, bypassing freshness validation
- Supersedes PR #2700 (same Array.isArray fix, but without the typeof check and without dropping the `.claude/commands/qa.md` hunk already merged in #2701)

## Test plan

- [ ] `fail closed: non-array label events rejects all verdicts (#2686)` added to `review-fn.spec.ts` and `qa-fn.spec.ts`
- [ ] `returns wait when review_spawned_at/qa_spawned_at is a string (typeof guard #2687)` added to both spec files
- [ ] `bun run am-i-done` passes (typecheck → lint → rules → tests → coverage)

Closes #2686
Closes #2687

🤖 Generated with [Claude Code](https://claude.com/claude-code)