### PR TITLE
fix(ci): count junit errors in crash tolerance (fixes #2669)

### DIFF
--- a/scripts/_runner/ci-steps.spec.ts
+++ b/scripts/_runner/ci-steps.spec.ts
@@ -29,12 +29,15 @@ function deriveFailures(stdout: string | undefined): number {
   return (stdout ?? "").includes(" 0 fail") ? 0 : 1;
 }
 
-function makeFakeBun(opts: { code: number; stdout?: string; stderr?: string }): string {
+function makeFakeBun(opts: { code: number; stdout?: string; stderr?: string; errors?: number }): string {
   const dir = mkdtempSync(join(tmpdir(), "am-i-done-test-"));
   const path = join(dir, "bun");
   const stdout = (opts.stdout ?? "").replace(/'/g, "'\\''");
   const stderr = (opts.stderr ?? "").replace(/'/g, "'\\''");
   const f = deriveFailures(opts.stdout);
+  // `errors` models bun's "unhandled error between tests" — written to the junit
+  // `errors` attribute, NOT `failures`. The coverage JSON has no errors concept.
+  const e = opts.errors ?? 0;
   writeFileSync(
     path,
     // Write structured output files when requested so classifiers key off
@@ -48,7 +51,7 @@ for arg in "$@"; do
   case "$arg" in
     --reporter-outfile=*)
       jpath="\${arg#--reporter-outfile=}"
-      printf '<?xml version="1.0"?><testsuites failures="${f}"></testsuites>' > "$jpath"
+      printf '<?xml version="1.0"?><testsuites failures="${f}" errors="${e}"></testsuites>' > "$jpath"
       ;;
     --junit-outfile=*)
       cpath="\${arg#--junit-outfile=}"
@@ -172,6 +175,49 @@ describe("bunTestWithCrashTolerance", () => {
   it("real test failure (non-zero exit, summary shows fail count) reports failure", async () => {
     const dir = makeFakeBun({ code: 1, stdout: failingSummary });
     const step = bunTestWithCrashTolerance({ paths: ["packages/core"], logName: "test_x" });
+    const result = await runWith(dir, () =>
+      (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
+        logger: createCaptureLogger(),
+      }),
+    );
+    expect(result).toMatchObject({ success: false });
+  });
+
+  it("unhandled error between tests (junit failures=0 errors=1) is a real failure, not a #1004 pass", async () => {
+    // The #2669 bug: bun's "unhandled error between tests" (e.g. a module-scope
+    // ReferenceError) increments junit errors="1", leaving failures="0". The
+    // " 0 fail" summary is still printed, so the crash-tolerance path used to
+    // promote this broken run to a pass. It must fail — errors count too.
+    const dir = makeFakeBun({ code: 1, stdout: passingSummary, errors: 1 });
+    const step = bunTestWithCrashTolerance({ paths: ["packages/core"], logName: "test_x" });
+    const result = await runWith(dir, () =>
+      (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
+        logger: createCaptureLogger(),
+      }),
+    );
+    expect(result).toMatchObject({ success: false });
+  });
+
+  it("unhandled error between tests with no junit file (prose fallback) is a real failure", async () => {
+    // Defense for the case where bun also crashes before flushing the junit
+    // sidecar: only the stdout survives. " 0 fail" alone must NOT pass when the
+    // output carries the "Unhandled error between tests" banner / error count.
+    const dir = mkdtempSync(join(tmpdir(), "am-i-done-test-"));
+    const ps =
+      `${passingSummary}\n# Unhandled error between tests\nReferenceError: afterEach is not defined\n 1 error\n`.replace(
+        /'/g,
+        "'\\''",
+      );
+    writeFileSync(
+      join(dir, "bun"),
+      `#!/usr/bin/env bash
+printf '%s' '${ps}'
+# Deliberately write NO --reporter-outfile — simulates a crash before flush.
+exit 1
+`,
+      { mode: 0o755 },
+    );
+    const step = bunTestWithCrashTolerance({ paths: ["packages/core"], logName: "test_unhandled_no_junit" });
     const result = await runWith(dir, () =>
       (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
         logger: createCaptureLogger(),

--- a/scripts/_runner/ci-steps.ts
+++ b/scripts/_runner/ci-steps.ts
@@ -44,19 +44,31 @@ const LOG_DIR = "/tmp";
 interface RunOutcome {
   code: number;
   output: string;
-  /** Failure count from the junit XML written by --reporter junit, or null if unavailable. */
+  /**
+   * Fault count from the junit XML written by --reporter junit (`failures` +
+   * `errors`), or null if unavailable. Bun's "unhandled error between tests"
+   * (a module-scope throw between test registrations) increments `errors`, not
+   * `failures` — both must be counted or such a run is misclassified as clean
+   * (#2669).
+   */
   junitFailures: number | null;
 }
 
 /**
- * Parse the `failures` attribute from a bun junit XML report.
- * Returns null when the file is absent or unparseable.
+ * Parse the fault count from a bun junit XML report: the `failures` attribute
+ * PLUS the `errors` attribute. Returns null when the file is absent or has
+ * neither attribute. An "unhandled error between tests" reports failures="0"
+ * errors="1", so summing is what makes the gate fail on it (#2669).
  */
 function parseJunitFailures(xmlPath: string): number | null {
   try {
     const xml = readFileSync(xmlPath, "utf8");
-    const m = xml.match(/failures="(\d+)"/);
-    return m ? Number.parseInt(m[1], 10) : null;
+    const fm = xml.match(/failures="(\d+)"/);
+    const em = xml.match(/errors="(\d+)"/);
+    if (!fm && !em) return null;
+    const failures = fm ? Number.parseInt(fm[1], 10) : 0;
+    const errors = em ? Number.parseInt(em[1], 10) : 0;
+    return failures + errors;
   } catch {
     return null;
   }
@@ -91,8 +103,21 @@ function junitTmpPath(stem: string): string {
  */
 function hasZeroJunitFailures(outcome: RunOutcome): boolean {
   if (outcome.junitFailures === 0) return true;
-  if (outcome.junitFailures === null) return ZERO_FAIL_RE.test(outcome.output);
+  if (outcome.junitFailures === null) return ZERO_FAIL_RE.test(outcome.output) && !hasUnhandledError(outcome.output);
   return false;
+}
+
+// Bun emits "# Unhandled error between tests" plus a nonzero "N errors" summary
+// line when a module-scope throw aborts test registration. Neither increments
+// the junit `failures` attribute, and a teardown crash that also drops the
+// junit sidecar (#1004) would leave only the stdout " 0 fail" line — which the
+// prose fallback would otherwise read as clean. Detect the error markers so a
+// run with an unhandled between-tests error is never promoted to a pass (#2669).
+const UNHANDLED_ERROR_RE = /Unhandled error between tests/;
+const NONZERO_ERRORS_RE = /^\s*([1-9]\d*) errors?\b/m;
+
+function hasUnhandledError(output: string): boolean {
+  return UNHANDLED_ERROR_RE.test(output) || NONZERO_ERRORS_RE.test(output);
 }
 
 async function runBun(
@@ -236,7 +261,7 @@ function classifyCoverage({ code, output, junitFailures }: RunOutcome, logger: L
   // Fallback: check-coverage.ts crashes before writing its summary file — the
   // inner bun's " 0 fail" line still reaches our stdout (#2401 hybrid).
   const cleanTests = junitFailures === 0 || (junitFailures === null && ZERO_FAIL_RE.test(output));
-  if (cleanTests && !FAIL_LINE_RE.test(output)) {
+  if (cleanTests && !FAIL_LINE_RE.test(output) && !hasUnhandledError(output)) {
     logger.warn(`bun crash (exit ${code}) after all coverage tests passed — treating as pass (#1419)`);
     return { success: true };
   }


### PR DESCRIPTION
## Summary
- `bunTestWithCrashTolerance`'s `hasZeroJunitFailures` read only the junit `failures` attribute. bun's "unhandled error between tests" (a module-scope throw between test registrations) increments `errors` instead, so `failures="0" errors="1"` was misread as clean and the #1004 crash-tolerance path promoted a broken run to a pass — breaking the "green CI ⇒ local pass" invariant (demonstrated by PR #2644).
- `parseJunitFailures` now sums `failures + errors`. The prose fallback (used when bun crashes before flushing the junit sidecar) additionally rejects output carrying the "Unhandled error between tests" banner or a nonzero error-count line.
- Genuine post-test segfault tolerance (#1004 exit 132/139 after a clean `0 fail`, #1419 coverage panic) is unchanged — those runs carry no between-tests errors.

## Test plan
- [x] New regression test: junit `failures="0" errors="1"` + exit 1 + ` 0 fail` summary → gate FAILS (would pass under old code).
- [x] New regression test: no junit file, stdout has ` 0 fail` plus the "Unhandled error between tests" banner → gate FAILS via prose fallback.
- [x] Existing #1004/#1419 crash-tolerance tests still pass (no false negatives reintroduced).
- [x] `bun run am-i-done` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)