### PR TITLE
fix(work-items): ACL reserved phase-runner sentinels on phase_state_set (fixes #2682)

### DIFF
--- a/packages/core/src/work-item.spec.ts
+++ b/packages/core/src/work-item.spec.ts
@@ -4,6 +4,7 @@ import {
   type WorkItemPhase,
   canTransition,
   createWorkItem,
+  isReservedPhaseStateKey,
   isStandardPhase,
   reachablePhases,
 } from "./work-item";
@@ -95,6 +96,37 @@ describe("isStandardPhase", () => {
   it("returns false for manifest-declared phases", () => {
     expect(isStandardPhase("triage")).toBe(false);
     expect(isStandardPhase("needs-attention")).toBe(false);
+  });
+});
+
+describe("isReservedPhaseStateKey", () => {
+  it("reserves the phase-runner-owned freshness, round, and transition sentinels", () => {
+    for (const key of [
+      "review_spawned_at",
+      "qa_spawned_at",
+      "review_round",
+      "repair_round",
+      "qa_fail_round",
+      "previous_phase",
+    ]) {
+      expect(isReservedPhaseStateKey(key)).toBe(true);
+    }
+  });
+
+  it("does not reserve the orchestrator-writable session-id family or general keys", () => {
+    for (const key of [
+      "session_id",
+      "review_session_id",
+      "repair_session_id",
+      "qa_session_id",
+      "worktree_path",
+      "model",
+      "provider",
+      "labels",
+      "scrutiny",
+    ]) {
+      expect(isReservedPhaseStateKey(key)).toBe(false);
+    }
   });
 });
 

--- a/packages/core/src/work-item.ts
+++ b/packages/core/src/work-item.ts
@@ -115,6 +115,34 @@ export function isStandardPhase(phase: string): phase is WorkItemPhase {
   return WORK_ITEM_PHASE_SET.has(phase);
 }
 
+/**
+ * Phase-runner-owned state keys that drive merge-gate security and loop-bound
+ * integrity decisions. These are written exclusively by the daemon-controlled
+ * phase runner (`mcx phase run` → ctx.state → IPC aliasStateSet), never by a
+ * session or the orchestrator through the `phase_state_set` MCP tool.
+ *
+ * The session-facing `phase_state_set` / `phase_state_delete` tools MUST refuse
+ * to write or delete a reserved key (#2682): both the phase runner and the MCP
+ * tool write the same `workitem:<id>` namespace, so without this guard any
+ * session with Bash can shell out to `mcx call _work_items phase_state_set` and
+ * forge a sentinel — e.g. setting `review_spawned_at` to epoch-start makes any
+ * stale verdict label pass the #2652 freshness guard, or zeroing a `*_round`
+ * counter bypasses the "two reviews max" / QA fail-cap loop bounds.
+ *
+ * Reserved patterns:
+ *   - `*_spawned_at`   — session-spawn timestamp; load-bearing for verdict freshness
+ *   - `*_round`        — round-cap counters (review_round, repair_round, qa_fail_round)
+ *   - `previous_phase` — transition provenance
+ *
+ * NOT reserved: the `*_session_id` family (session_id, review_session_id,
+ * repair_session_id, qa_session_id). The orchestrator legitimately writes those
+ * via the MCP tool to replace the phase runner's `pending:*` sentinel with the
+ * real session id, and deletes them between rounds.
+ */
+export function isReservedPhaseStateKey(key: string): boolean {
+  return key.endsWith("_spawned_at") || key.endsWith("_round") || key === "previous_phase";
+}
+
 /** Updatable subset of WorkItem — excludes server-managed fields. */
 export type WorkItemPatch = Partial<Omit<WorkItem, "id" | "createdAt" | "updatedAt" | "version">>;
 

--- a/packages/daemon/src/work-items-server.spec.ts
+++ b/packages/daemon/src/work-items-server.spec.ts
@@ -1449,4 +1449,86 @@ describe("phase_state tools", () => {
     const text = (result.content as Array<{ text: string }>)[0].text;
     expect(text).toContain("exceeds max size");
   });
+
+  // #2682 — ACL: the session-facing MCP tool must refuse to forge phase-runner
+  // sentinels. A session with Bash can call `mcx call _work_items phase_state_set`,
+  // so without this guard it could set review_spawned_at=1 to defeat the #2652
+  // freshness guard, or zero a *_round counter to bypass loop caps.
+  test("phase_state_set rejects forging the review_spawned_at freshness sentinel", async () => {
+    const { stateDb, workItemDb, dbPath } = createRealStateDbs();
+    stateDbInst = stateDb;
+    dbPathToClean = dbPath;
+    server = new WorkItemsServer(workItemDb, { stateDb });
+    const { client } = await server.start();
+
+    await client.callTool({ name: "work_items_track", arguments: { issueNumber: 100 } });
+
+    const result = await client.callTool({
+      name: "phase_state_set",
+      arguments: { workItemId: "issue:100", repoRoot: "/repo", key: "review_spawned_at", value: 1 },
+    });
+    expect(result.isError).toBe(true);
+    expect((result.content as Array<{ text: string }>)[0].text).toContain("reserved phase-runner sentinel");
+
+    // The forged value must not have landed.
+    const got = await client.callTool({
+      name: "phase_state_get",
+      arguments: { workItemId: "issue:100", repoRoot: "/repo", key: "review_spawned_at" },
+    });
+    expect(JSON.parse((got.content as Array<{ text: string }>)[0].text).value).toBeUndefined();
+  });
+
+  test("phase_state_set rejects every reserved sentinel pattern", async () => {
+    const { stateDb, workItemDb, dbPath } = createRealStateDbs();
+    stateDbInst = stateDb;
+    dbPathToClean = dbPath;
+    server = new WorkItemsServer(workItemDb, { stateDb });
+    const { client } = await server.start();
+
+    await client.callTool({ name: "work_items_track", arguments: { issueNumber: 101 } });
+
+    for (const key of ["qa_spawned_at", "review_round", "repair_round", "qa_fail_round", "previous_phase"]) {
+      const result = await client.callTool({
+        name: "phase_state_set",
+        arguments: { workItemId: "issue:101", repoRoot: "/repo", key, value: 0 },
+      });
+      expect(result.isError).toBe(true);
+      expect((result.content as Array<{ text: string }>)[0].text).toContain("reserved phase-runner sentinel");
+    }
+  });
+
+  test("phase_state_set still allows the orchestrator's *_session_id writes", async () => {
+    const { stateDb, workItemDb, dbPath } = createRealStateDbs();
+    stateDbInst = stateDb;
+    dbPathToClean = dbPath;
+    server = new WorkItemsServer(workItemDb, { stateDb });
+    const { client } = await server.start();
+
+    await client.callTool({ name: "work_items_track", arguments: { issueNumber: 102 } });
+
+    for (const key of ["session_id", "review_session_id", "repair_session_id", "qa_session_id"]) {
+      const result = await client.callTool({
+        name: "phase_state_set",
+        arguments: { workItemId: "issue:102", repoRoot: "/repo", key, value: "real-id" },
+      });
+      expect(result.isError).toBeFalsy();
+    }
+  });
+
+  test("phase_state_delete rejects deleting a reserved sentinel", async () => {
+    const { stateDb, workItemDb, dbPath } = createRealStateDbs();
+    stateDbInst = stateDb;
+    dbPathToClean = dbPath;
+    server = new WorkItemsServer(workItemDb, { stateDb });
+    const { client } = await server.start();
+
+    await client.callTool({ name: "work_items_track", arguments: { issueNumber: 103 } });
+
+    const result = await client.callTool({
+      name: "phase_state_delete",
+      arguments: { workItemId: "issue:103", repoRoot: "/repo", key: "qa_spawned_at" },
+    });
+    expect(result.isError).toBe(true);
+    expect((result.content as Array<{ text: string }>)[0].text).toContain("reserved phase-runner sentinel");
+  });
 });

--- a/packages/daemon/src/work-items-server.ts
+++ b/packages/daemon/src/work-items-server.ts
@@ -7,7 +7,14 @@
 
 import { isAbsolute, resolve } from "node:path";
 import type { Logger, Manifest, ToolInfo, WorkItem, WorkItemPatch, WorkItemPhase } from "@mcp-cli/core";
-import { WORK_ITEMS_SERVER_NAME, canTransition, consoleLogger, isStandardPhase, resolveRealpath } from "@mcp-cli/core";
+import {
+  WORK_ITEMS_SERVER_NAME,
+  canTransition,
+  consoleLogger,
+  isReservedPhaseStateKey,
+  isStandardPhase,
+  resolveRealpath,
+} from "@mcp-cli/core";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
@@ -176,7 +183,7 @@ const TOOLS = [
   {
     name: "phase_state_set",
     description:
-      "Write a key to a work item's phase-scoped key-value store. Value must be JSON-serialisable and under 256 KB.",
+      "Write a key to a work item's phase-scoped key-value store. Value must be JSON-serialisable and under 256 KB. Reserved phase-runner sentinels (keys ending in _spawned_at or _round, and previous_phase) are rejected — they gate verdict freshness and round caps and are written only by the phase runner.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -567,6 +574,17 @@ export class WorkItemsServer {
                 isError: true,
               };
             }
+            if (isReservedPhaseStateKey(key)) {
+              return {
+                content: [
+                  {
+                    type: "text" as const,
+                    text: `Refusing to write reserved phase-runner sentinel "${key}". Keys ending in _spawned_at or _round, and previous_phase, are written exclusively by the phase runner (they gate verdict freshness and round caps). This tool is for orchestrator bookkeeping (e.g. the *_session_id family).`,
+                  },
+                ],
+                isError: true,
+              };
+            }
             const ns = `workitem:${workItemId}`;
             this.stateDb.setAliasState(repoRoot, ns, key, a.value);
             return { content: [{ type: "text" as const, text: JSON.stringify({ ok: true, key }) }] };
@@ -598,6 +616,17 @@ export class WorkItemsServer {
             if (!this.workItemDb.getWorkItem(workItemId)) {
               return {
                 content: [{ type: "text" as const, text: `Work item not found: ${workItemId}` }],
+                isError: true,
+              };
+            }
+            if (isReservedPhaseStateKey(key)) {
+              return {
+                content: [
+                  {
+                    type: "text" as const,
+                    text: `Refusing to delete reserved phase-runner sentinel "${key}". Keys ending in _spawned_at or _round, and previous_phase, are managed exclusively by the phase runner (they gate verdict freshness and round caps).`,
+                  },
+                ],
                 isError: true,
               };
             }


### PR DESCRIPTION
## Summary
- **Security fix for #2682.** `phase_state_set`/`phase_state_delete` (the `_work_items` MCP tools) had no ACL: any session with `Bash` could `mcx call _work_items phase_state_set` and forge phase-runner sentinels. The documented exploit sets `review_spawned_at=1`, defeating the #2652 verdict-freshness guard; the same hole lets a session zero a `*_round` counter to bypass the review/QA loop caps.
- **Root cause:** the phase runner writes these sentinels to the `workitem:<id>` state namespace via `ctx.state` → IPC `aliasStateSet` (a privileged in-daemon path), while the session-facing MCP tool writes the *same namespace*. Caller identity is unavailable — the orchestrator and session workers both reach the tool through the identical `mcx call` → IPC → tool path — so a caller-identity check isn't feasible here.
- **Fix:** a reserved-key ACL. `isReservedPhaseStateKey()` (core, single source of truth) flags keys the phase runner owns exclusively — `*_spawned_at`, `*_round`/`qa_fail_round`, and `previous_phase`. The `phase_state_set`/`phase_state_delete` handlers reject them. The phase runner's IPC path is untouched, and the orchestrator's legitimate `*_session_id` writes (replacing `pending:*`) still pass — those keys are deliberately **not** reserved.

## Test plan
- [x] Core unit tests for `isReservedPhaseStateKey` (reserved patterns vs. the orchestrator-writable `*_session_id` family + general keys)
- [x] Daemon tests: forged `review_spawned_at` is rejected and does not land; every reserved pattern rejects; `*_session_id` writes still succeed; `phase_state_delete` of a reserved key is rejected
- [x] `bun typecheck`, `bun lint`, pre-commit static gate all pass
- [x] All affected specs pass in isolation (`work-item`, `work-items-server`, `verdict-validation`, `review-fn`/`qa-fn`/`repair-fn`)

> Note: the full `bun run am-i-done` parallel run on this host failed with 113 whole-file worker SIGTERM/panic aborts spread across unrelated packages (acp schemas, clone, core logger/git, etc.). This is the known host resource-wedge (two day-old wedged `bun test` processes pinning cores, per #2641→#2644) — every one of those files passes cleanly in isolation, and no failure is an assertion in the changed area. Flagging rather than filing a duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)