### PR TITLE
fix(phase-transition): make pruneStaleHistory rewrite atomic (fixes #2685)

### DIFF
--- a/packages/core/src/phase-transition.spec.ts
+++ b/packages/core/src/phase-transition.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Manifest } from "./manifest";
@@ -8,6 +8,7 @@ import {
   RegressionError,
   UnknownPhaseError,
   appendTransitionLog,
+  atomicWriteFileSync,
   commitTransition,
   historyTargets,
   levenshtein,
@@ -524,5 +525,78 @@ describe("pruneStaleHistory (#2463)", () => {
     const remaining = readAllTransitions(log);
     expect(remaining).toHaveLength(1);
     expect(remaining[0].workItemId).toBe("#50");
+  });
+
+  test("rewrite leaves no temp files behind (#2685)", () => {
+    const log = join(dir, "transitions.jsonl");
+    appendTransitionLog(log, {
+      ts: "2026-01-01T00:00:00Z",
+      workItemId: "#42",
+      from: null,
+      to: "impl",
+      status: "committed",
+    });
+
+    const pruned = pruneStaleHistory(log, "#42", new Date("2026-06-01T00:00:00Z"));
+    expect(pruned).toBe(1);
+    expect(readdirSync(dir).sort()).toEqual(["transitions.jsonl"]);
+  });
+});
+
+describe("atomicWriteFileSync (#2685)", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "atomic-write-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("replaces target content and removes the temp file", () => {
+    const target = join(dir, "log.jsonl");
+    writeFileSync(target, "old\n", "utf-8");
+
+    atomicWriteFileSync(target, "new\n");
+
+    expect(readFileSync(target, "utf-8")).toBe("new\n");
+    expect(readdirSync(dir).sort()).toEqual(["log.jsonl"]);
+  });
+
+  test("creates parent directories when missing", () => {
+    const target = join(dir, "nested", "deep", "log.jsonl");
+    atomicWriteFileSync(target, "content\n");
+    expect(readFileSync(target, "utf-8")).toBe("content\n");
+  });
+
+  test("crash mid-write: target keeps old content, partial file never observed", () => {
+    const target = join(dir, "log.jsonl");
+    writeFileSync(target, "old-line-1\nold-line-2\n", "utf-8");
+
+    const crashingWrite = (path: string, content: string, encoding: "utf-8") => {
+      writeFileSync(path, content.slice(0, 5), encoding);
+      throw new Error("simulated crash mid-write");
+    };
+
+    expect(() => atomicWriteFileSync(target, "new-line-1\nnew-line-2\n", crashingWrite)).toThrow(
+      "simulated crash mid-write",
+    );
+
+    expect(readFileSync(target, "utf-8")).toBe("old-line-1\nold-line-2\n");
+    expect(readdirSync(dir).sort()).toEqual(["log.jsonl"]);
+  });
+
+  test("crash before any bytes written: target untouched, no temp leftovers", () => {
+    const target = join(dir, "log.jsonl");
+    writeFileSync(target, "old\n", "utf-8");
+
+    const failingWrite = () => {
+      throw new Error("ENOSPC: no space left on device");
+    };
+
+    expect(() => atomicWriteFileSync(target, "new\n", failingWrite)).toThrow("ENOSPC");
+    expect(readFileSync(target, "utf-8")).toBe("old\n");
+    expect(readdirSync(dir).sort()).toEqual(["log.jsonl"]);
   });
 });

--- a/packages/core/src/phase-transition.ts
+++ b/packages/core/src/phase-transition.ts
@@ -15,18 +15,20 @@
  * reasoning is preserved alongside the transition itself.
  */
 
+import { randomBytes } from "node:crypto";
 import {
   appendFileSync,
   closeSync,
   mkdirSync,
   openSync,
   readFileSync,
+  renameSync,
   statSync,
   unlinkSync,
   writeFileSync,
   writeSync,
 } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
 import type { Manifest } from "./manifest";
 
 /**
@@ -306,6 +308,33 @@ export function readAllTransitions(logPath: string): TransitionLogEntry[] {
 }
 
 /**
+ * Replace `path` with `content` atomically: write to a temp file in the
+ * same directory, then `rename(2)` over the target. Readers see either the
+ * old file or the new file, never a truncated/partial write (issue #2685).
+ *
+ * `writeFn` is injectable for crash-mid-write tests (DI, not mock.module).
+ */
+export function atomicWriteFileSync(
+  path: string,
+  content: string,
+  writeFn: (path: string, content: string, encoding: "utf-8") => void = writeFileSync,
+): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmpPath = join(dirname(path), `.tmp-${randomBytes(6).toString("hex")}`);
+  try {
+    writeFn(tmpPath, content, "utf-8");
+    renameSync(tmpPath, path);
+  } catch (err) {
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      // best effort — temp may not exist
+    }
+    throw err;
+  }
+}
+
+/**
  * Remove stale transition log entries for a work item whose incarnation
  * predates `cutoff`. Used by `mcx track` to clear history from prior
  * sprints so a re-tracked item starts with a clean slate (issue #2463).
@@ -331,9 +360,8 @@ export function pruneStaleHistory(logPath: string, workItemId: string, cutoff: D
 
     if (pruned === 0) return 0;
 
-    mkdirSync(dirname(logPath), { recursive: true });
     const content = kept.map((e) => JSON.stringify(e)).join("\n") + (kept.length > 0 ? "\n" : "");
-    writeFileSync(logPath, content, "utf-8");
+    atomicWriteFileSync(logPath, content);
     return pruned;
   });
 }


### PR DESCRIPTION
## Summary
- `pruneStaleHistory` rewrote the transition log with truncate-then-write (`writeFileSync`), so a crash/SIGKILL/power-loss mid-rewrite could leave the log empty or partial — silently wiping a work item's entire transition history (data loss class from #2685, same failure family as #2463)
- Extracted `atomicWriteFileSync`: write to a `.tmp-<random>` file in the same directory, then `renameSync` over the target — `rename(2)` is atomic on POSIX, so readers only ever see the old or the new file; the temp file is cleaned up if the write fails
- The writer is injectable (DI, per the no-`mock.module()` rule) so the crash-mid-write path is directly testable; the `appendFileSync` risk in the same file is explicitly out of scope per the issue

## Test plan
- [x] New test: crash mid-write (writer emits partial bytes then throws) → target keeps old content byte-for-byte, no temp leftovers
- [x] New test: crash before any bytes written (ENOSPC) → target untouched, no temp leftovers
- [x] New tests: successful replace removes temp file; parent dirs created when missing; prune rewrite leaves no temp files
- [x] All 44 phase-transition tests pass
- [x] Full `bun run am-i-done` gate green (all 8 steps, 116s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)