### PR TITLE
feat(ci): wire .claude/phases/*-fn.spec.ts into am-i-done and CI (fixes #2648)

### DIFF
--- a/.claude/phases/done-fn.ts
+++ b/.claude/phases/done-fn.ts
@@ -22,8 +22,7 @@ export async function spawnWithTimeout(
   opts?: { timeoutMs?: number },
   _testDeps: SpawnTimeoutTestDeps = {},
 ): Promise<GhResult> {
-  const spawner: Spawner =
-    _testDeps.spawner ?? ((c, o) => Bun.spawn(c, o) as unknown as ProcessHandle);
+  const spawner: Spawner = _testDeps.spawner ?? ((c, o) => Bun.spawn(c, o) as unknown as ProcessHandle);
   const sigkillDelayMs = _testDeps.sigkillDelayMs ?? 5_000;
   const proc = spawner(cmd, { stdout: "pipe", stderr: "pipe" });
   let sigkillTimer: ReturnType<typeof setTimeout> | undefined;
@@ -53,12 +52,7 @@ export type MergeResult =
   | { ok: true; prNumber: number; localCleanup?: string }
   | {
       ok: false;
-      reason:
-        | "ci_not_green"
-        | "missing_qa_pass"
-        | "conflicts"
-        | "missing_required_check"
-        | "merge_failed";
+      reason: "ci_not_green" | "missing_qa_pass" | "conflicts" | "missing_required_check" | "merge_failed";
       nextAction: string;
       detail?: string;
     };

--- a/.claude/phases/done.ts
+++ b/.claude/phases/done.ts
@@ -50,7 +50,11 @@ defineAlias({
       const prHandle = ctx.gh.pr(work.prNumber);
       const threads = await prHandle.reviewThreads();
       for (const t of threads.filter((t) => !t.isResolved)) {
-        try { await prHandle.resolveReviewThread(t.id); } catch { /* best-effort */ }
+        try {
+          await prHandle.resolveReviewThread(t.id);
+        } catch {
+          /* best-effort */
+        }
       }
     } catch {
       /* non-fatal — thread resolution is cosmetic; merge proceeds regardless */
@@ -77,9 +81,11 @@ defineAlias({
       },
       async prMerge(prNumber, flags) {
         try {
-          const method = flags.includes("--squash") ? "squash" as const
-            : flags.includes("--rebase") ? "rebase" as const
-            : "merge" as const;
+          const method = flags.includes("--squash")
+            ? ("squash" as const)
+            : flags.includes("--rebase")
+              ? ("rebase" as const)
+              : ("merge" as const);
           const deleteBranch = flags.includes("--delete-branch");
           await ctx.gh.pr(prNumber).merge({ method, deleteBranch });
           return { stdout: "", stderr: "", exitCode: 0 };
@@ -134,7 +140,11 @@ defineAlias({
     }
 
     const pullProc = Bun.spawn(["git", "pull"], { stdout: "pipe", stderr: "pipe" });
-    const pullTimer = setTimeout(() => { try { pullProc.kill(); } catch {} }, 60_000);
+    const pullTimer = setTimeout(() => {
+      try {
+        pullProc.kill();
+      } catch {}
+    }, 60_000);
     const [_pullOut, pullStderr, pullExitCode] = await Promise.all([
       new Response(pullProc.stdout).text(),
       new Response(pullProc.stderr).text(),

--- a/.claude/phases/impl.ts
+++ b/.claude/phases/impl.ts
@@ -29,9 +29,12 @@ type Provider = "claude" | "copilot" | "gemini" | "grok" | `acp:${string}`;
 
 const ProviderSchema = z
   .string()
-  .refine((v): v is Provider => v === "claude" || v === "copilot" || v === "gemini" || v === "grok" || v.startsWith("acp:"), {
-    message: 'provider must be "claude", "copilot", "gemini", "grok", or "acp:<agent>"',
-  });
+  .refine(
+    (v): v is Provider => v === "claude" || v === "copilot" || v === "gemini" || v === "grok" || v.startsWith("acp:"),
+    {
+      message: 'provider must be "claude", "copilot", "gemini", "grok", or "acp:<agent>"',
+    },
+  );
 
 function commandForProvider(provider: Provider): string[] {
   if (provider.startsWith("acp:")) {
@@ -101,8 +104,7 @@ defineAlias({
       if (stateModel === "opus" || stateModel === "sonnet") {
         model = stateModel;
       } else {
-        const planModel =
-          ctx.repoRoot !== NO_REPO_ROOT ? findModelInSprintPlan(work.issueNumber, ctx.repoRoot) : null;
+        const planModel = ctx.repoRoot !== NO_REPO_ROOT ? findModelInSprintPlan(work.issueNumber, ctx.repoRoot) : null;
         model = planModel ?? pickModel(input.labels);
       }
     }

--- a/.claude/phases/needs-attention.ts
+++ b/.claude/phases/needs-attention.ts
@@ -36,23 +36,18 @@ defineAlias({
       );
     }
 
-    return runNeedsAttention(
-      { id: work.id, prNumber: work.prNumber, issueNumber: work.issueNumber },
-      ctx.state,
-      {
-        async prEdit(prNumber, flags) {
-          const removeLabels: string[] = [];
-          for (let i = 0; i < flags.length; i += 2) {
-            if (flags[i] === "--remove-label") removeLabels.push(flags[i + 1]);
-          }
-          await ctx.gh.pr(prNumber).edit({ removeLabels });
-        },
-        async prComment(prNumber, body) {
-          await ctx.gh.pr(prNumber).comment(body);
-        },
-        updateWorkItemPhase: (id, phase) =>
-          ctx.mcp._work_items.work_items_update({ id, phase }),
+    return runNeedsAttention({ id: work.id, prNumber: work.prNumber, issueNumber: work.issueNumber }, ctx.state, {
+      async prEdit(prNumber, flags) {
+        const removeLabels: string[] = [];
+        for (let i = 0; i < flags.length; i += 2) {
+          if (flags[i] === "--remove-label") removeLabels.push(flags[i + 1]);
+        }
+        await ctx.gh.pr(prNumber).edit({ removeLabels });
       },
-    );
+      async prComment(prNumber, body) {
+        await ctx.gh.pr(prNumber).comment(body);
+      },
+      updateWorkItemPhase: (id, phase) => ctx.mcp._work_items.work_items_update({ id, phase }),
+    });
   },
 });

--- a/.claude/phases/qa-fn.spec.ts
+++ b/.claude/phases/qa-fn.spec.ts
@@ -48,18 +48,25 @@ function makeGh(opts: GhStubOpts = {}): QaDeps["gh"] {
   const events = opts.labelEvents ?? validEventsFor(labels);
   return async (op) => {
     if (op.op === "pr:labels") {
-      return { stdout: (opts.labelsExitCode ?? 0) === 0 ? labels.join("\n") : "", stderr: "", exitCode: opts.labelsExitCode ?? 0 };
+      return {
+        stdout: (opts.labelsExitCode ?? 0) === 0 ? labels.join("\n") : "",
+        stderr: "",
+        exitCode: opts.labelsExitCode ?? 0,
+      };
     }
     if (op.op === "pr:label-events") {
-      if ((opts.eventsExitCode ?? 0) !== 0) return { stdout: "", stderr: "events fetch error", exitCode: opts.eventsExitCode ?? 1 };
+      if ((opts.eventsExitCode ?? 0) !== 0)
+        return { stdout: "", stderr: "events fetch error", exitCode: opts.eventsExitCode ?? 1 };
       return { stdout: JSON.stringify(events), stderr: "", exitCode: 0 };
     }
     if (op.op === "pr:author") {
-      if ((opts.authorExitCode ?? 0) !== 0) return { stdout: "", stderr: "author fetch error", exitCode: opts.authorExitCode ?? 1 };
+      if ((opts.authorExitCode ?? 0) !== 0)
+        return { stdout: "", stderr: "author fetch error", exitCode: opts.authorExitCode ?? 1 };
       return { stdout: opts.author ?? DEFAULT_AUTHOR, stderr: "", exitCode: 0 };
     }
     if (op.op === "pr:head-date") {
-      if ((opts.headDateExitCode ?? 0) !== 0) return { stdout: "", stderr: "head-date fetch error", exitCode: opts.headDateExitCode ?? 1 };
+      if ((opts.headDateExitCode ?? 0) !== 0)
+        return { stdout: "", stderr: "head-date fetch error", exitCode: opts.headDateExitCode ?? 1 };
       return { stdout: opts.headDate ?? DEFAULT_HEAD_DATE, stderr: "", exitCode: 0 };
     }
     return { stdout: "", stderr: `unsupported gh op: ${op.op}`, exitCode: 1 };
@@ -160,7 +167,9 @@ describe("readQaLabels — verdict validation (#2652)", () => {
 
   test("rejects label predating head commit (guard c)", async () => {
     const event: GhLabelEvent = { actor: DEFAULT_AUTHOR, label: "qa:pass", created_at: "2026-06-09T10:05:00Z" };
-    const deps = makeDeps({ gh: makeGh({ labels: ["qa:pass"], labelEvents: [event], headDate: "2026-06-09T10:10:00Z" }) });
+    const deps = makeDeps({
+      gh: makeGh({ labels: ["qa:pass"], labelEvents: [event], headDate: "2026-06-09T10:10:00Z" }),
+    });
     const result = await readQaLabels(10, deps, DEFAULT_SPAWNED_AT);
     expect(result.hasPass).toBe(false);
     expect(result.rejections[0]).toMatch(/verdict on stale code/);
@@ -171,7 +180,10 @@ describe("readQaLabels — verdict validation (#2652)", () => {
     const deps = makeDeps({
       gh: async (op) => {
         if (op.op === "pr:labels") return { stdout: "bug\nenhancement", stderr: "", exitCode: 0 };
-        if (op.op === "pr:label-events") { eventsFetched = true; return { stdout: "[]", stderr: "", exitCode: 0 }; }
+        if (op.op === "pr:label-events") {
+          eventsFetched = true;
+          return { stdout: "[]", stderr: "", exitCode: 0 };
+        }
         return { stdout: "", stderr: "", exitCode: 1 };
       },
     });
@@ -322,7 +334,11 @@ describe("runQa — session exists, qa:fail", () => {
   });
 
   test("returns goto needs-attention when fail cap exceeded", async () => {
-    const state = makeState({ qa_session_id: "abc-123", qa_fail_round: QA_FAIL_CAP, qa_spawned_at: DEFAULT_SPAWNED_AT });
+    const state = makeState({
+      qa_session_id: "abc-123",
+      qa_fail_round: QA_FAIL_CAP,
+      qa_spawned_at: DEFAULT_SPAWNED_AT,
+    });
     const deps = makeDeps({ gh: makeGh({ labels: ["qa:fail"] }) });
     const result = await runQa({ provider: "claude" }, makeWork(), state, deps);
     expect(result.action).toBe("goto");

--- a/.claude/phases/qa-fn.ts
+++ b/.claude/phases/qa-fn.ts
@@ -33,7 +33,14 @@ export type QaResult =
       allowTools: string[];
     }
   | { action: "wait"; reason: string; model: "sonnet"; prompt: string }
-  | { action: "goto"; target: "done" | "repair" | "needs-attention"; reason: string; model: "sonnet"; prompt: string; round?: number };
+  | {
+      action: "goto";
+      target: "done" | "repair" | "needs-attention";
+      reason: string;
+      model: "sonnet";
+      prompt: string;
+      round?: number;
+    };
 
 // ── verdict validation (#2652) ──
 // Same hardened validation as review-fn: labels are validated against the
@@ -58,7 +65,11 @@ export async function readQaLabels(
   ]);
 
   if (eventsResult.exitCode !== 0) {
-    return { hasPass: false, hasFail: false, rejections: [`label-events fetch failed (${eventsResult.stderr}) — fail closed`] };
+    return {
+      hasPass: false,
+      hasFail: false,
+      rejections: [`label-events fetch failed (${eventsResult.stderr}) — fail closed`],
+    };
   }
   if (authorResult.exitCode !== 0 || headDateResult.exitCode !== 0) {
     return { hasPass: false, hasFail: false, rejections: [`verdict context fetch failed — fail closed`] };
@@ -140,7 +151,12 @@ export async function runQa(
 
   const roundStartedAt = (await state.get<number>("qa_spawned_at")) ?? 0;
   if (typeof roundStartedAt !== "number" || roundStartedAt === 0 || Number.isNaN(roundStartedAt)) {
-    return { action: "wait", reason: "qa_spawned_at missing or invalid in state — fail closed; re-spawn to populate", model: qaModel, prompt: qaPrompt };
+    return {
+      action: "wait",
+      reason: "qa_spawned_at missing or invalid in state — fail closed; re-spawn to populate",
+      model: qaModel,
+      prompt: qaPrompt,
+    };
   }
   const { hasPass, hasFail, rejections } = await readQaLabels(work.prNumber, deps, roundStartedAt);
   if (!hasPass && !hasFail) {

--- a/.claude/phases/qa.ts
+++ b/.claude/phases/qa.ts
@@ -20,10 +20,9 @@ import { runQa } from "./qa-fn";
 
 const ProviderSchema = z
   .string()
-  .refine(
-    (v) => v === "claude" || v === "copilot" || v === "gemini" || v.startsWith("acp:"),
-    { message: 'provider must be "claude", "copilot", "gemini", or "acp:<agent>"' },
-  );
+  .refine((v) => v === "claude" || v === "copilot" || v === "gemini" || v.startsWith("acp:"), {
+    message: 'provider must be "claude", "copilot", "gemini", or "acp:<agent>"',
+  });
 
 defineAlias({
   name: "phase-qa",

--- a/.claude/phases/repair-fn.spec.ts
+++ b/.claude/phases/repair-fn.spec.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { REPAIR_ROUND_CAP, type RepairDeps, type RepairState, type RepairWork, buildRepairPrompt, runRepair } from "./repair-fn";
+import {
+  REPAIR_ROUND_CAP,
+  type RepairDeps,
+  type RepairState,
+  type RepairWork,
+  buildRepairPrompt,
+  runRepair,
+} from "./repair-fn";
 
 function makeWork(overrides: Partial<RepairWork> = {}): RepairWork {
   return { id: "wi-1", prNumber: 30, ...overrides };

--- a/.claude/phases/repair.ts
+++ b/.claude/phases/repair.ts
@@ -19,10 +19,9 @@ import { runRepair } from "./repair-fn";
 
 const ProviderSchema = z
   .string()
-  .refine(
-    (v) => v === "claude" || v === "copilot" || v === "gemini" || v.startsWith("acp:"),
-    { message: 'provider must be "claude", "copilot", "gemini", or "acp:<agent>"' },
-  );
+  .refine((v) => v === "claude" || v === "copilot" || v === "gemini" || v.startsWith("acp:"), {
+    message: 'provider must be "claude", "copilot", "gemini", or "acp:<agent>"',
+  });
 
 defineAlias({
   name: "phase-repair",
@@ -53,30 +52,25 @@ defineAlias({
       );
     }
 
-    return runRepair(
-      input,
-      { id: work.id, prNumber: work.prNumber },
-      ctx.state,
-      {
-        async prEdit(prNumber, flags) {
-          const opts: Record<string, string[]> = {};
-          for (let i = 0; i < flags.length; i += 2) {
-            const flag = flags[i];
-            const value = flags[i + 1];
-            if (flag === "--remove-label") {
-              if (!opts.removeLabels) opts.removeLabels = [];
-              (opts.removeLabels as string[]).push(value);
-            } else if (flag === "--add-label") {
-              if (!opts.addLabels) opts.addLabels = [];
-              (opts.addLabels as string[]).push(value);
-            }
+    return runRepair(input, { id: work.id, prNumber: work.prNumber }, ctx.state, {
+      async prEdit(prNumber, flags) {
+        const opts: Record<string, string[]> = {};
+        for (let i = 0; i < flags.length; i += 2) {
+          const flag = flags[i];
+          const value = flags[i + 1];
+          if (flag === "--remove-label") {
+            if (!opts.removeLabels) opts.removeLabels = [];
+            (opts.removeLabels as string[]).push(value);
+          } else if (flag === "--add-label") {
+            if (!opts.addLabels) opts.addLabels = [];
+            (opts.addLabels as string[]).push(value);
           }
-          await ctx.gh.pr(prNumber).edit({
-            removeLabels: opts.removeLabels,
-            addLabels: opts.addLabels,
-          });
-        },
+        }
+        await ctx.gh.pr(prNumber).edit({
+          removeLabels: opts.removeLabels,
+          addLabels: opts.addLabels,
+        });
       },
-    );
+    });
   },
 });

--- a/.claude/phases/review-fn.spec.ts
+++ b/.claude/phases/review-fn.spec.ts
@@ -52,18 +52,25 @@ function makeGh(opts: GhStubOpts = {}): ReviewDeps["gh"] {
   const events = opts.labelEvents ?? validEventsFor(labels);
   return async (op) => {
     if (op.op === "pr:labels") {
-      return { stdout: (opts.labelsExitCode ?? 0) === 0 ? labels.join("\n") : "", stderr: "", exitCode: opts.labelsExitCode ?? 0 };
+      return {
+        stdout: (opts.labelsExitCode ?? 0) === 0 ? labels.join("\n") : "",
+        stderr: "",
+        exitCode: opts.labelsExitCode ?? 0,
+      };
     }
     if (op.op === "pr:label-events") {
-      if ((opts.eventsExitCode ?? 0) !== 0) return { stdout: "", stderr: "events fetch error", exitCode: opts.eventsExitCode ?? 1 };
+      if ((opts.eventsExitCode ?? 0) !== 0)
+        return { stdout: "", stderr: "events fetch error", exitCode: opts.eventsExitCode ?? 1 };
       return { stdout: JSON.stringify(events), stderr: "", exitCode: 0 };
     }
     if (op.op === "pr:author") {
-      if ((opts.authorExitCode ?? 0) !== 0) return { stdout: "", stderr: "author fetch error", exitCode: opts.authorExitCode ?? 1 };
+      if ((opts.authorExitCode ?? 0) !== 0)
+        return { stdout: "", stderr: "author fetch error", exitCode: opts.authorExitCode ?? 1 };
       return { stdout: opts.author ?? DEFAULT_AUTHOR, stderr: "", exitCode: 0 };
     }
     if (op.op === "pr:head-date") {
-      if ((opts.headDateExitCode ?? 0) !== 0) return { stdout: "", stderr: "head-date fetch error", exitCode: opts.headDateExitCode ?? 1 };
+      if ((opts.headDateExitCode ?? 0) !== 0)
+        return { stdout: "", stderr: "head-date fetch error", exitCode: opts.headDateExitCode ?? 1 };
       return { stdout: opts.headDate ?? DEFAULT_HEAD_DATE, stderr: "", exitCode: 0 };
     }
     return { stdout: "", stderr: `unsupported gh op: ${op.op}`, exitCode: 1 };
@@ -118,7 +125,8 @@ describe("readReviewLabels", () => {
     const deps = makeDeps({
       gh: async (op) => {
         if (op.op === "pr:labels") return { stdout: " review:pass \n bug \n", stderr: "", exitCode: 0 };
-        if (op.op === "pr:label-events") return { stdout: JSON.stringify(validEventsFor(["review:pass"])), stderr: "", exitCode: 0 };
+        if (op.op === "pr:label-events")
+          return { stdout: JSON.stringify(validEventsFor(["review:pass"])), stderr: "", exitCode: 0 };
         if (op.op === "pr:author") return { stdout: DEFAULT_AUTHOR, stderr: "", exitCode: 0 };
         if (op.op === "pr:head-date") return { stdout: DEFAULT_HEAD_DATE, stderr: "", exitCode: 0 };
         return { stdout: "", stderr: "", exitCode: 1 };
@@ -189,7 +197,11 @@ describe("readReviewLabels — verdict validation (#2652)", () => {
   });
 
   test("rejects stale label predating session spawn (guard b)", async () => {
-    const staleEvent: GhLabelEvent = { actor: DEFAULT_AUTHOR, label: "review:pass", created_at: "2026-06-09T09:55:00Z" };
+    const staleEvent: GhLabelEvent = {
+      actor: DEFAULT_AUTHOR,
+      label: "review:pass",
+      created_at: "2026-06-09T09:55:00Z",
+    };
     const deps = makeDeps({ gh: makeGh({ labels: ["review:pass"], labelEvents: [staleEvent] }) });
     const result = await readReviewLabels(20, deps, DEFAULT_SPAWNED_AT);
     expect(result.hasPass).toBe(false);
@@ -198,7 +210,9 @@ describe("readReviewLabels — verdict validation (#2652)", () => {
 
   test("rejects label predating head commit (guard c)", async () => {
     const event: GhLabelEvent = { actor: DEFAULT_AUTHOR, label: "review:pass", created_at: "2026-06-09T10:05:00Z" };
-    const deps = makeDeps({ gh: makeGh({ labels: ["review:pass"], labelEvents: [event], headDate: "2026-06-09T10:10:00Z" }) });
+    const deps = makeDeps({
+      gh: makeGh({ labels: ["review:pass"], labelEvents: [event], headDate: "2026-06-09T10:10:00Z" }),
+    });
     const result = await readReviewLabels(20, deps, DEFAULT_SPAWNED_AT);
     expect(result.hasPass).toBe(false);
     expect(result.rejections[0]).toMatch(/verdict on stale code/);
@@ -209,7 +223,10 @@ describe("readReviewLabels — verdict validation (#2652)", () => {
     const deps = makeDeps({
       gh: async (op) => {
         if (op.op === "pr:labels") return { stdout: "bug\nenhancement", stderr: "", exitCode: 0 };
-        if (op.op === "pr:label-events") { eventsFetched = true; return { stdout: "[]", stderr: "", exitCode: 0 }; }
+        if (op.op === "pr:label-events") {
+          eventsFetched = true;
+          return { stdout: "[]", stderr: "", exitCode: 0 };
+        }
         return { stdout: "", stderr: "", exitCode: 1 };
       },
     });
@@ -364,7 +381,11 @@ describe("runReview — session exists", () => {
   });
 
   test("returns goto qa when round cap reached even with review:changes", async () => {
-    const state = makeState({ review_session_id: "abc", review_round: REVIEW_ROUND_CAP, review_spawned_at: DEFAULT_SPAWNED_AT });
+    const state = makeState({
+      review_session_id: "abc",
+      review_round: REVIEW_ROUND_CAP,
+      review_spawned_at: DEFAULT_SPAWNED_AT,
+    });
     const deps = makeDeps({ gh: makeGh({ labels: ["review:changes"] }) });
     const result = await runReview({ provider: "claude" }, makeWork(), state, deps, "/repo");
     expect(result.action).toBe("goto");
@@ -405,7 +426,11 @@ describe("runReview — session exists", () => {
 
   test("clears review:changes even when the round cap routes to qa", async () => {
     const removed: string[] = [];
-    const state = makeState({ review_session_id: "abc", review_round: REVIEW_ROUND_CAP, review_spawned_at: DEFAULT_SPAWNED_AT });
+    const state = makeState({
+      review_session_id: "abc",
+      review_round: REVIEW_ROUND_CAP,
+      review_spawned_at: DEFAULT_SPAWNED_AT,
+    });
     const deps = makeDeps({
       gh: makeGh({ labels: ["review:changes"] }),
       async prEdit(_prNumber, flags) {
@@ -421,7 +446,11 @@ describe("runReview — session exists", () => {
   });
 
   test("rejects stale review:pass and returns wait with rejection reason", async () => {
-    const staleEvent: GhLabelEvent = { actor: DEFAULT_AUTHOR, label: "review:pass", created_at: "2026-06-09T09:55:00Z" };
+    const staleEvent: GhLabelEvent = {
+      actor: DEFAULT_AUTHOR,
+      label: "review:pass",
+      created_at: "2026-06-09T09:55:00Z",
+    };
     const state = makeState({ review_session_id: "abc", review_round: 1, review_spawned_at: DEFAULT_SPAWNED_AT });
     const deps = makeDeps({ gh: makeGh({ labels: ["review:pass"], labelEvents: [staleEvent] }) });
     const result = await runReview({ provider: "claude" }, makeWork(), state, deps, "/repo");

--- a/.claude/phases/review-fn.ts
+++ b/.claude/phases/review-fn.ts
@@ -65,7 +65,11 @@ export async function readReviewLabels(
   ]);
 
   if (eventsResult.exitCode !== 0) {
-    return { hasPass: false, hasChanges: false, rejections: [`label-events fetch failed (${eventsResult.stderr}) — fail closed`] };
+    return {
+      hasPass: false,
+      hasChanges: false,
+      rejections: [`label-events fetch failed (${eventsResult.stderr}) — fail closed`],
+    };
   }
   if (authorResult.exitCode !== 0 || headDateResult.exitCode !== 0) {
     return { hasPass: false, hasChanges: false, rejections: [`verdict context fetch failed — fail closed`] };
@@ -164,7 +168,12 @@ export async function runReview(
   const withModel = storedModel ? { model: storedModel } : {};
   const roundStartedAt = (await state.get<number>("review_spawned_at")) ?? 0;
   if (typeof roundStartedAt !== "number" || roundStartedAt === 0 || Number.isNaN(roundStartedAt)) {
-    return { action: "wait", reason: "review_spawned_at missing or invalid in state — fail closed; re-spawn to populate", round, ...withModel };
+    return {
+      action: "wait",
+      reason: "review_spawned_at missing or invalid in state — fail closed; re-spawn to populate",
+      round,
+      ...withModel,
+    };
   }
   const { hasPass, hasChanges, rejections } = await readReviewLabels(work.prNumber, deps, roundStartedAt);
 

--- a/.claude/phases/review.ts
+++ b/.claude/phases/review.ts
@@ -32,10 +32,9 @@ import { runReview } from "./review-fn";
 
 const ProviderSchema = z
   .string()
-  .refine(
-    (v) => v === "claude" || v === "copilot" || v === "gemini" || v.startsWith("acp:"),
-    { message: 'provider must be "claude", "copilot", "gemini", or "acp:<agent>"' },
-  );
+  .refine((v) => v === "claude" || v === "copilot" || v === "gemini" || v.startsWith("acp:"), {
+    message: 'provider must be "claude", "copilot", "gemini", or "acp:<agent>"',
+  });
 
 defineAlias({
   name: "phase-review",

--- a/.claude/phases/triage-fn.ts
+++ b/.claude/phases/triage-fn.ts
@@ -25,10 +25,7 @@ export interface TriageDeps {
     reasons: string[];
     metrics?: Record<string, unknown>;
   }>;
-  waitForEvent(
-    filter: TriageEventFilter,
-    opts?: { timeoutMs?: number; since?: number },
-  ): Promise<TriageEvent>;
+  waitForEvent(filter: TriageEventFilter, opts?: { timeoutMs?: number; since?: number }): Promise<TriageEvent>;
   stateGet<T>(key: string): Promise<T | undefined>;
   stateSet(key: string, value: unknown): Promise<void>;
   updateWorkItem(id: string, prNumber: number): Promise<void>;
@@ -107,9 +104,7 @@ export async function runTriage(
   const isFlaky = labels.includes("flaky");
   const scrutiny = isFlaky ? "high" : raw.scrutiny;
   const reasons =
-    isFlaky && raw.scrutiny !== "high"
-      ? [...raw.reasons, "label:flaky forces high scrutiny"]
-      : raw.reasons;
+    isFlaky && raw.scrutiny !== "high" ? [...raw.reasons, "label:flaky forces high scrutiny"] : raw.reasons;
   const decision = scrutiny === "high" ? "review" : "qa";
 
   await deps.stateSet("triage_scrutiny", scrutiny);

--- a/.claude/phases/triage.ts
+++ b/.claude/phases/triage.ts
@@ -46,11 +46,15 @@ defineAlias({
         }
       },
       async runEstimate(prNumber: number) {
-        const proc = Bun.spawn(
-          ["bun", ".claude/skills/estimate/triage.ts", "--pr", String(prNumber), "--json"],
-          { stdout: "pipe", stderr: "pipe" },
-        );
-        const timer = setTimeout(() => { try { proc.kill(); } catch {} }, 30_000);
+        const proc = Bun.spawn(["bun", ".claude/skills/estimate/triage.ts", "--pr", String(prNumber), "--json"], {
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const timer = setTimeout(() => {
+          try {
+            proc.kill();
+          } catch {}
+        }, 30_000);
         const [stdout, stderr, exitCode] = await Promise.all([
           new Response(proc.stdout).text(),
           new Response(proc.stderr).text(),

--- a/scripts/_runner/ci-steps.spec.ts
+++ b/scripts/_runner/ci-steps.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, setDefaultTimeout } from "bun:test";
 
-import { bunTestWithCrashTolerance, changedTestsStep, coverageWithCrashTolerance } from "./ci-steps";
+import {
+  bunTestWithCrashTolerance,
+  changedTestsStep,
+  coverageWithCrashTolerance,
+  phasesTestWithCrashTolerance,
+} from "./ci-steps";
 import { createCaptureLogger } from "./logger";
 
 // Tests spawn real child processes (fake bun scripts) and some build the full
@@ -849,5 +854,55 @@ describe("changedTestsStep", () => {
     // Control pass gets only the packages/control/ skip pattern — not the root-level one.
     expect(controlLog).toContain(`--path-ignore-patterns=${relControl}`);
     expect(controlLog).not.toContain(`--path-ignore-patterns=${relOther}`);
+  });
+});
+
+describe("phasesTestWithCrashTolerance", () => {
+  it("exit 0 is success", async () => {
+    const dir = makeFakeBun({ code: 0, stdout: passingSummary });
+    const step = phasesTestWithCrashTolerance({ phasesDir: dir, logName: "test_phases_x" });
+    const result = await runWith(dir, () =>
+      (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
+        logger: createCaptureLogger(),
+      }),
+    );
+    expect(result).toEqual({ success: true });
+  });
+
+  it("non-zero exit with `0 fail` summary is a #1004 pass-by-policy", async () => {
+    const dir = makeFakeBun({ code: 1, stdout: passingSummary });
+    const step = phasesTestWithCrashTolerance({ phasesDir: dir, logName: "test_phases_x" });
+    const result = await runWith(dir, () =>
+      (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
+        logger: createCaptureLogger(),
+      }),
+    );
+    expect(result).toEqual({ success: true });
+  });
+
+  it("real test failure (non-zero exit, summary shows fail count) reports failure", async () => {
+    const dir = makeFakeBun({ code: 1, stdout: failingSummary });
+    const step = phasesTestWithCrashTolerance({ phasesDir: dir, logName: "test_phases_x" });
+    const result = await runWith(dir, () =>
+      (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
+        logger: createCaptureLogger(),
+      }),
+    );
+    expect(result).toMatchObject({ success: false });
+  });
+
+  it("passes phasesDir as the cwd to bun — args logged reflect the directory context", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "am-i-done-test-"));
+    writeFileSync(join(dir, "bun"), '#!/usr/bin/env bash\necho "ARGV=$*"\nexit 0\n', { mode: 0o755 });
+    const phasesDir = mkdtempSync(join(tmpdir(), "fake-phases-"));
+    const step = phasesTestWithCrashTolerance({ phasesDir, logName: "test_phases_cwd" });
+    const result = await runWith(dir, () =>
+      (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
+        logger: createCaptureLogger(),
+      }),
+    );
+    expect(result).toEqual({ success: true });
+    const log = readFileSync("/tmp/test_phases_cwd.txt", "utf8");
+    expect(log).toContain("--no-orphans");
   });
 });

--- a/scripts/_runner/ci-steps.ts
+++ b/scripts/_runner/ci-steps.ts
@@ -125,6 +125,7 @@ async function runBun(
   logger: Logger,
   env: Record<string, string | undefined> = process.env,
   junitPath?: string,
+  cwd?: string,
 ): Promise<RunOutcome> {
   // spawn() rejects undefined env values — drop them so explicit `unset`
   // semantics aren't required upstream. Matches runShell() in runner.ts.
@@ -135,7 +136,7 @@ async function runBun(
   const fullArgs =
     junitPath && args[0] === "test" ? [...args, "--reporter", "junit", `--reporter-outfile=${junitPath}`] : args;
   const buf: string[] = [];
-  const child = spawn("bun", fullArgs, { env: cleanEnv, stdio: ["ignore", "pipe", "pipe"] });
+  const child = spawn("bun", fullArgs, { env: cleanEnv, stdio: ["ignore", "pipe", "pipe"], ...(cwd ? { cwd } : {}) });
   child.stdout.setEncoding("utf8");
   child.stderr.setEncoding("utf8");
   child.stdout.on("data", (d: string) => {
@@ -213,6 +214,34 @@ export function bunTestWithCrashTolerance(opts: TestOpts): ScriptFunction {
       return { success: true };
     }
     return { success: false, error: `exit ${second.code}` };
+  };
+}
+
+interface PhasesTestOpts {
+  /** Stem used for `<TMP>/<logName>.txt` artefact preservation. */
+  logName: string;
+  /** Absolute path to the `.claude/phases` directory. */
+  phasesDir: string;
+}
+
+/**
+ * Run `bun test --no-orphans` from within `.claude/phases/` so the files
+ * are discovered relative to that CWD — bypassing the root bunfig.toml
+ * `pathIgnorePatterns = [".claude/**"]` exclusion that silences them when
+ * run from the repo root (#2648). Carries the same #1004 crash-after-pass
+ * tolerance as `bunTestWithCrashTolerance`.
+ */
+export function phasesTestWithCrashTolerance(opts: PhasesTestOpts): ScriptFunction {
+  return async ({ logger, env }) => {
+    const args = ["test", "--no-orphans"];
+    const first = await runBun(args, logger, env, junitTmpPath(opts.logName), opts.phasesDir);
+    persistLog(opts.logName, first.output);
+    if (first.code === 0) return { success: true };
+    if (hasZeroJunitFailures(first)) {
+      logger.warn(`bun crash (exit ${first.code}) after phase tests passed — treating as pass (#1004)`);
+      return { success: true };
+    }
+    return { success: false, error: `exit ${first.code}` };
   };
 }
 

--- a/scripts/_runner/test-partition.spec.ts
+++ b/scripts/_runner/test-partition.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { globSync } from "node:fs";
 import { resolve } from "node:path";
 
-import { DAEMON_TEST_PATHS, NON_DAEMON_TEST_PATHS } from "../am-i-done";
+import { DAEMON_TEST_PATHS, NON_DAEMON_TEST_PATHS, parseFlag, parseRepeatableFlag } from "../am-i-done";
 
 const REPO_ROOT = resolve(import.meta.dirname, "../..");
 
@@ -45,5 +45,33 @@ describe("CI test path partition", () => {
   it("a hypothetical scripts/newdir/foo.spec.ts would be matched", () => {
     const hypothetical = "scripts/newdir/foo.spec.ts";
     expect(matchesPath(hypothetical, ALL_CI_PATHS)).toBe(true);
+  });
+});
+
+describe("parseFlag", () => {
+  it("returns the value after a matching flag", () => {
+    expect(parseFlag(["--from", "3", "--verbose"], "--from")).toBe("3");
+  });
+
+  it("returns undefined when flag is absent", () => {
+    expect(parseFlag(["--verbose"], "--from")).toBeUndefined();
+  });
+
+  it("returns undefined when flag is last with no value", () => {
+    expect(parseFlag(["--from"], "--from")).toBeUndefined();
+  });
+});
+
+describe("parseRepeatableFlag", () => {
+  it("collects all values for a repeated flag", () => {
+    expect(parseRepeatableFlag(["--skip", "lint", "--skip", "coverage"], "--skip")).toEqual(["lint", "coverage"]);
+  });
+
+  it("returns empty array when flag is absent", () => {
+    expect(parseRepeatableFlag(["--verbose"], "--skip")).toEqual([]);
+  });
+
+  it("skips a trailing flag with no value", () => {
+    expect(parseRepeatableFlag(["--skip", "lint", "--skip"], "--skip")).toEqual(["lint"]);
   });
 });

--- a/scripts/am-i-done.ts
+++ b/scripts/am-i-done.ts
@@ -31,7 +31,12 @@
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { bunTestWithCrashTolerance, changedTestsStep, coverageWithCrashTolerance } from "./_runner/ci-steps";
+import {
+  bunTestWithCrashTolerance,
+  changedTestsStep,
+  coverageWithCrashTolerance,
+  phasesTestWithCrashTolerance,
+} from "./_runner/ci-steps";
 import { detectContext, isCi, isPreCommit, isPrePush } from "./_runner/context";
 import { createAiFileLogger, createConsoleLogger } from "./_runner/logger";
 import { StepRunner } from "./_runner/runner";
@@ -171,6 +176,22 @@ const TEST_DAEMON_CI: Step = {
   ],
 };
 
+const TEST_PHASES_CI: Step = {
+  name: "test-phases",
+  description:
+    "phase fn-specs (.claude/phases/*-fn.spec.ts) — co-located specs excluded from bunfig pathIgnorePatterns (#2648)",
+  command: phasesTestWithCrashTolerance({
+    phasesDir: resolve(REPO_ROOT, ".claude/phases"),
+    logName: "test_phases",
+  }),
+  source: "scripts/_runner/ci-steps.ts",
+  onFailure: [
+    "run `bun run test:phases` locally to reproduce",
+    "specs live in .claude/phases/*-fn.spec.ts — co-located next to each phase module",
+    "log artefact: /tmp/test_phases.txt",
+  ],
+};
+
 const COVERAGE_CI: Step = {
   name: "coverage",
   description: "coverage --ci (ratchet + #1419/#1004 retry handling)",
@@ -231,7 +252,17 @@ const STALE_TODOS_CI: Step = {
 
 const PRE_COMMIT: Step[] = [INSTALL, TYPECHECK, LINT_CHECK, RULES, AGENT_GRID];
 const PRE_PUSH: Step[] = [INSTALL, TYPECHECK, LINT_CHECK, RULES, AGENT_GRID, TEST_CHANGED];
-const COMPREHENSIVE: Step[] = [INSTALL, TYPECHECK, LINT, RULES, AGENT_GRID, TEST_PARALLEL, TEST_CONTROL, COVERAGE];
+const COMPREHENSIVE: Step[] = [
+  INSTALL,
+  TYPECHECK,
+  LINT,
+  RULES,
+  AGENT_GRID,
+  TEST_PARALLEL,
+  TEST_CONTROL,
+  TEST_PHASES_CI,
+  COVERAGE,
+];
 const CI: Step[] = [
   INSTALL,
   TYPECHECK,
@@ -241,6 +272,7 @@ const CI: Step[] = [
   STALE_TODOS_CI,
   TEST_NON_DAEMON_CI,
   TEST_DAEMON_CI,
+  TEST_PHASES_CI,
   COVERAGE_CI,
 ];
 
@@ -251,12 +283,12 @@ function selectSteps(): { steps: Step[]; label: string } {
   return { steps: COMPREHENSIVE, label: "default" };
 }
 
-function parseFlag(argv: string[], flag: string): string | undefined {
+export function parseFlag(argv: string[], flag: string): string | undefined {
   const i = argv.indexOf(flag);
   return i >= 0 && i + 1 < argv.length ? argv[i + 1] : undefined;
 }
 
-function parseRepeatableFlag(argv: string[], flag: string): string[] {
+export function parseRepeatableFlag(argv: string[], flag: string): string[] {
   const out: string[] = [];
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === flag && i + 1 < argv.length) out.push(argv[i + 1] as string);


### PR DESCRIPTION
## Summary

- **Core fix**: Add `phasesTestWithCrashTolerance` to `scripts/_runner/ci-steps.ts` — runs `bun test --no-orphans` from `.claude/phases/` cwd, bypassing the root `bunfig.toml` `pathIgnorePatterns = [".claude/**"]` exclusion that silenced co-located phase specs from every `am-i-done` run and CI job (#2648)
- **Wiring**: Add `TEST_PHASES_CI` step to `scripts/am-i-done.ts` in both the `CI` and `COMPREHENSIVE` step lists (after `test-daemon` in CI, after `test-control` in comprehensive). Same #1004 crash tolerance as other test steps; logs to `/tmp/test_phases.txt` for CI artifact upload
- **Coverage fix**: Export `parseFlag`/`parseRepeatableFlag` from `am-i-done.ts` and add tests so the file meets the 80% ratchet now that it is in the diff (was 76.9% on main)
- **Tests**: Add `phasesTestWithCrashTolerance` tests to `ci-steps.spec.ts` covering exit-0 pass, #1004 crash-after-pass, real-failure, and cwd-usage paths
- **Biome**: Auto-format sweep of `.claude/phases/*.ts` (safe formatting only, no logic changes)

## Test plan

- [x] `bun test .claude/phases/` was confirmed to fail before (pathIgnorePatterns blocks it)
- [x] `bun run am-i-done --only test-phases --verbose` runs all 101 phase specs, 0 failures
- [x] `bun run am-i-done --ci --skip install --skip coverage` — all 10 steps pass
- [x] `bun run am-i-done --ci --only coverage` — coverage ratchet passes (am-i-done.ts now ≥ 80%)
- [x] New `phasesTestWithCrashTolerance` tests pass in `ci-steps.spec.ts`
- [x] New `parseFlag`/`parseRepeatableFlag` tests pass in `test-partition.spec.ts`
- [x] Pre-commit and pre-push hooks passed on commit and push
- [ ] Note: a follow-up issue has been filed for the CI `detect` job's docs-only classifier incorrectly treating `.claude/phases/*.ts` as docs — phase-only PRs would still skip CI until that is fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)