### PR TITLE
feat(phases): dead-session backstop for review/qa verdict wait (fixes #2654)

### DIFF
--- a/.claude/phases/qa-fn.spec.ts
+++ b/.claude/phases/qa-fn.spec.ts
@@ -1,6 +1,15 @@
 import { describe, expect, test } from "bun:test";
 import type { GhLabelEvent } from "./phase-types";
-import { QA_FAIL_CAP, type QaDeps, type QaState, type QaWork, readQaLabels, runQa } from "./qa-fn";
+import {
+  QA_FAIL_CAP,
+  QA_RESPAWN_CAP,
+  QA_STUCK_TICK_CAP,
+  type QaDeps,
+  type QaState,
+  type QaWork,
+  readQaLabels,
+  runQa,
+} from "./qa-fn";
 
 const DEFAULT_SPAWNED_AT = new Date("2026-06-09T10:00:00Z").getTime();
 const DEFAULT_HEAD_DATE = "2026-06-09T09:50:00Z";
@@ -269,6 +278,54 @@ describe("runQa — session exists, waiting for labels", () => {
     const result = await runQa({ provider: "claude" }, makeWork(), state, deps);
     expect(result.action).toBe("wait");
     if (result.action === "wait") expect(result.reason).toMatch(/fail closed/);
+  });
+});
+
+// Regression for #2654: a QA session that dies before setting its verdict label
+// must not idle the gate forever — bounded respawn, then needs-attention.
+describe("runQa — dead-session backstop (#2654)", () => {
+  const stuckState = (overrides: Record<string, unknown> = {}) =>
+    makeState({ qa_session_id: "abc-123", qa_spawned_at: DEFAULT_SPAWNED_AT, ...overrides });
+  const noLabelDeps = () => makeDeps({ gh: makeGh({ labels: ["enhancement"] }) });
+
+  test("waits and increments the stuck tick while under the cap", async () => {
+    const state = stuckState();
+    const result = await runQa({ provider: "claude" }, makeWork(), state, noLabelDeps());
+    expect(result.action).toBe("wait");
+    expect(await state.get<number>("qa_stuck_ticks")).toBe(1);
+  });
+
+  test("respawns the QA session when the stuck tick cap is reached", async () => {
+    const state = stuckState({ qa_stuck_ticks: QA_STUCK_TICK_CAP - 1 });
+    const result = await runQa({ provider: "claude" }, makeWork(), state, noLabelDeps());
+    expect(result.action).toBe("spawn");
+    expect(await state.get<number>("qa_respawns")).toBe(1);
+    expect(await state.get<string>("qa_session_id")).toMatch(/^pending:/);
+    expect(await state.get<number>("qa_stuck_ticks")).toBe(0);
+  });
+
+  test("escalates to needs-attention once the respawn budget is exhausted", async () => {
+    const state = stuckState({ qa_stuck_ticks: QA_STUCK_TICK_CAP - 1, qa_respawns: QA_RESPAWN_CAP });
+    const result = await runQa({ provider: "claude" }, makeWork(), state, noLabelDeps());
+    expect(result.action).toBe("goto");
+    if (result.action === "goto") {
+      expect(result.target).toBe("needs-attention");
+      expect(result.reason).toMatch(/presumed dead/i);
+    }
+  });
+
+  test("a valid verdict still routes normally despite accumulated stuck ticks", async () => {
+    const state = stuckState({ qa_stuck_ticks: QA_STUCK_TICK_CAP - 1 });
+    const deps = makeDeps({ gh: makeGh({ labels: ["qa:pass"] }) });
+    const result = await runQa({ provider: "claude" }, makeWork(), state, deps);
+    expect(result.action).toBe("goto");
+    if (result.action === "goto") expect(result.target).toBe("done");
+  });
+
+  test("a fresh spawn resets the stuck tick counter", async () => {
+    const state = makeState({ qa_stuck_ticks: 3 });
+    await runQa({ provider: "claude" }, makeWork(), state, makeDeps());
+    expect(await state.get<number>("qa_stuck_ticks")).toBe(0);
   });
 });
 

--- a/.claude/phases/qa-fn.ts
+++ b/.claude/phases/qa-fn.ts
@@ -5,6 +5,14 @@ export type { GhOp, GhResult };
 
 export const QA_FAIL_CAP = 2;
 
+// ── dead-session backstop (#2654) ──
+// Mirror of review-fn: if the QA session dies before setting its verdict
+// label, the gate would idle forever. After this many consecutive label-less
+// ticks the session is presumed dead — do one bounded respawn, then escalate
+// to needs-attention rather than waiting indefinitely. See review-fn.ts.
+export const QA_STUCK_TICK_CAP = 5;
+export const QA_RESPAWN_CAP = 1;
+
 export interface QaWork {
   id: string;
   prNumber: number;
@@ -139,6 +147,7 @@ export async function runQa(
     const spawnedAt = Date.now();
     await state.set("qa_session_id", `pending:${spawnedAt}`);
     await state.set("qa_spawned_at", spawnedAt);
+    await state.set("qa_stuck_ticks", 0);
     return {
       action: "spawn",
       reason: "qa session starting",
@@ -161,7 +170,31 @@ export async function runQa(
   const { hasPass, hasFail, rejections } = await readQaLabels(work.prNumber, deps, roundStartedAt);
   if (!hasPass && !hasFail) {
     const suffix = rejections.length > 0 ? ` (rejected: ${rejections.join("; ")})` : "";
-    return { action: "wait", reason: `qa:pass / qa:fail label not set yet${suffix}`, model: qaModel, prompt: qaPrompt };
+    const ticks = ((await state.get<number>("qa_stuck_ticks")) ?? 0) + 1;
+    if (ticks >= QA_STUCK_TICK_CAP) {
+      const respawns = (await state.get<number>("qa_respawns")) ?? 0;
+      if (respawns >= QA_RESPAWN_CAP) {
+        return {
+          action: "goto",
+          target: "needs-attention",
+          reason: `qa stuck: no verdict after ${ticks} ticks across ${respawns} respawn(s) — QA session presumed dead, escalating${suffix}`,
+          model: qaModel,
+          prompt: qaPrompt,
+        };
+      }
+      // Presumed-dead QA session: clear the sentinel so the next entry spawns a
+      // fresh QA session, and re-enter to emit that spawn plan now.
+      await state.set("qa_respawns", respawns + 1);
+      await state.delete("qa_session_id");
+      return runQa(input, work, state, deps);
+    }
+    await state.set("qa_stuck_ticks", ticks);
+    return {
+      action: "wait",
+      reason: `qa:pass / qa:fail label not set yet${suffix} (stuck tick ${ticks}/${QA_STUCK_TICK_CAP})`,
+      model: qaModel,
+      prompt: qaPrompt,
+    };
   }
 
   if (hasPass) {

--- a/.claude/phases/review-fn.spec.ts
+++ b/.claude/phases/review-fn.spec.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import type { GhLabelEvent } from "./phase-types";
 import {
+  REVIEW_RESPAWN_CAP,
   REVIEW_ROUND_CAP,
+  REVIEW_STUCK_TICK_CAP,
   type ReviewDeps,
   type ReviewState,
   type ReviewWork,
@@ -26,6 +28,9 @@ function makeState(initial: Record<string, unknown> = {}): ReviewState {
     },
     async set(key, value) {
       store.set(key, value);
+    },
+    async delete(key) {
+      store.delete(key);
     },
   };
 }
@@ -456,6 +461,58 @@ describe("runReview — session exists", () => {
     const result = await runReview({ provider: "claude" }, makeWork(), state, deps, "/repo");
     expect(result.action).toBe("wait");
     if (result.action === "wait") expect(result.reason).toMatch(/rejected.*stale/i);
+  });
+});
+
+// Regression for #2654: a reviewer session that dies before setting its verdict
+// label must not idle the gate forever. The no-verdict-yet branch counts ticks
+// and routes to a deterministic outcome (bounded respawn, then needs-attention).
+describe("runReview — dead-session backstop (#2654)", () => {
+  const stuckState = (overrides: Record<string, unknown> = {}) =>
+    makeState({ review_session_id: "abc", review_round: 1, review_spawned_at: DEFAULT_SPAWNED_AT, ...overrides });
+  const noLabelDeps = () => makeDeps({ gh: makeGh({ labels: ["bug"] }) });
+
+  test("waits and increments the stuck tick while under the cap", async () => {
+    const state = stuckState();
+    const result = await runReview({ provider: "claude" }, makeWork(), state, noLabelDeps(), "/repo");
+    expect(result.action).toBe("wait");
+    expect(await state.get<number>("review_stuck_ticks")).toBe(1);
+  });
+
+  test("respawns the reviewer when the stuck tick cap is reached", async () => {
+    const state = stuckState({ review_stuck_ticks: REVIEW_STUCK_TICK_CAP - 1 });
+    const result = await runReview({ provider: "claude" }, makeWork(), state, noLabelDeps(), "/repo");
+    expect(result.action).toBe("spawn");
+    expect(await state.get<number>("review_respawns")).toBe(1);
+    expect(await state.get<string>("review_session_id")).toMatch(/^pending:/);
+    expect(await state.get<number>("review_stuck_ticks")).toBe(0);
+  });
+
+  test("escalates to needs-attention once the respawn budget is exhausted", async () => {
+    const state = stuckState({
+      review_stuck_ticks: REVIEW_STUCK_TICK_CAP - 1,
+      review_respawns: REVIEW_RESPAWN_CAP,
+    });
+    const result = await runReview({ provider: "claude" }, makeWork(), state, noLabelDeps(), "/repo");
+    expect(result.action).toBe("goto");
+    if (result.action === "goto") {
+      expect(result.target).toBe("needs-attention");
+      expect(result.reason).toMatch(/presumed dead/i);
+    }
+  });
+
+  test("a valid verdict still routes normally despite accumulated stuck ticks", async () => {
+    const state = stuckState({ review_stuck_ticks: REVIEW_STUCK_TICK_CAP - 1 });
+    const deps = makeDeps({ gh: makeGh({ labels: ["review:pass"] }) });
+    const result = await runReview({ provider: "claude" }, makeWork(), state, deps, "/repo");
+    expect(result.action).toBe("goto");
+    if (result.action === "goto") expect(result.target).toBe("qa");
+  });
+
+  test("a fresh spawn resets the stuck tick counter", async () => {
+    const state = makeState({ review_stuck_ticks: 3 });
+    await runReview({ provider: "claude" }, makeWork(), state, makeDeps(), "/repo");
+    expect(await state.get<number>("review_stuck_ticks")).toBe(0);
   });
 });
 

--- a/.claude/phases/review-fn.ts
+++ b/.claude/phases/review-fn.ts
@@ -5,6 +5,18 @@ export type { GhOp, GhResult };
 
 export const REVIEW_ROUND_CAP = 2;
 
+// ── dead-session backstop (#2654) ──
+// The verdict gate waits on a PR label the reviewer session sets. If that
+// session dies mid-run (quota wall, OOM, segfault, partial execution) the
+// label never lands and the gate would idle forever. After this many
+// consecutive label-less ticks the session is presumed dead and we route to
+// a deterministic outcome (one bounded respawn, then needs-attention) rather
+// than waiting indefinitely. Tick-count (not wall-clock) keeps the logic pure
+// and deterministically testable; the cap is high enough that a live-but-slow
+// reviewer clears its verdict well before tripping it.
+export const REVIEW_STUCK_TICK_CAP = 5;
+export const REVIEW_RESPAWN_CAP = 1;
+
 export interface ReviewWork {
   id: string;
   prNumber: number;
@@ -15,6 +27,7 @@ export interface ReviewWork {
 export interface ReviewState {
   get<T>(key: string): Promise<T | undefined>;
   set(key: string, value: unknown): Promise<void>;
+  delete(key: string): Promise<void>;
 }
 
 export interface ReviewDeps {
@@ -34,7 +47,13 @@ export type ReviewResult =
       model: "opus" | "sonnet";
     }
   | { action: "wait"; reason: string; round: number; model?: "opus" | "sonnet" }
-  | { action: "goto"; target: "repair" | "qa"; reason: string; round: number; model?: "opus" | "sonnet" };
+  | {
+      action: "goto";
+      target: "repair" | "qa" | "needs-attention";
+      reason: string;
+      round: number;
+      model?: "opus" | "sonnet";
+    };
 
 // ── typed verdict channel (#2575, hardened #2652) ──
 // The review verdict is read from a PR LABEL the reviewer sets transactionally
@@ -153,6 +172,7 @@ export async function runReview(
     await state.set("review_model", model);
     await state.set("review_session_id", `pending:${spawnedAt}`);
     await state.set("review_spawned_at", spawnedAt);
+    await state.set("review_stuck_ticks", 0);
     return {
       action: "spawn",
       reason: `review round ${round} starting`,
@@ -177,10 +197,36 @@ export async function runReview(
   }
   const { hasPass, hasChanges, rejections } = await readReviewLabels(work.prNumber, deps, roundStartedAt);
 
-  // No verdict label yet — the reviewer hasn't decided. Wait (never trust prose).
+  // No verdict label yet — the reviewer hasn't decided. Wait (never trust prose),
+  // but back the wait with a dead-session circuit breaker (#2654): a silently dead
+  // reviewer would otherwise idle this gate forever.
   if (!hasPass && !hasChanges) {
     const suffix = rejections.length > 0 ? ` (rejected: ${rejections.join("; ")})` : "";
-    return { action: "wait", reason: `review:pass / review:changes label not set yet${suffix}`, round, ...withModel };
+    const ticks = ((await state.get<number>("review_stuck_ticks")) ?? 0) + 1;
+    if (ticks >= REVIEW_STUCK_TICK_CAP) {
+      const respawns = (await state.get<number>("review_respawns")) ?? 0;
+      if (respawns >= REVIEW_RESPAWN_CAP) {
+        return {
+          action: "goto",
+          target: "needs-attention",
+          reason: `review stuck: no verdict after ${ticks} ticks across ${respawns} respawn(s) — reviewer session presumed dead, escalating${suffix}`,
+          round,
+          ...withModel,
+        };
+      }
+      // Presumed-dead reviewer: clear the session sentinel so the next entry
+      // spawns a fresh reviewer, and re-enter to emit that spawn plan now.
+      await state.set("review_respawns", respawns + 1);
+      await state.delete("review_session_id");
+      return runReview(input, work, state, deps, repoRoot);
+    }
+    await state.set("review_stuck_ticks", ticks);
+    return {
+      action: "wait",
+      reason: `review:pass / review:changes label not set yet${suffix} (stuck tick ${ticks}/${REVIEW_STUCK_TICK_CAP})`,
+      round,
+      ...withModel,
+    };
   }
 
   // Approved wins if both are somehow set; clear the stale changes label.

--- a/.claude/phases/review.ts
+++ b/.claude/phases/review.ts
@@ -45,7 +45,7 @@ defineAlias({
   }),
   output: z.object({
     action: z.enum(["spawn", "wait", "goto"]),
-    target: z.enum(["repair", "qa"]).optional(),
+    target: z.enum(["repair", "qa", "needs-attention"]).optional(),
     reason: z.string(),
     round: z.number(),
     command: z.array(z.string()).optional(),

--- a/.mcx.lock
+++ b/.mcx.lock
@@ -1,47 +1,47 @@
 {
   "version": 1,
-  "manifestHash": "294b0b088b52b79d08b035a3582079c07198e5f4eb36ae16b635377d3b057031",
+  "manifestHash": "7c6db54ba9992d3a66ee93eb63948f01cdcbb18a9e9ae01ac12de652e23b4f89",
   "phases": [
     {
       "name": "done",
       "resolvedPath": ".claude/phases/done.ts",
-      "contentHash": "88d7c68317a8319487d32e57eb398dfadf3aa581fe9b92de25f1acd2960c790e",
+      "contentHash": "11673a02b960efd7d4b4411639b21219fc1059d88c769f8dd266264794048892",
       "schemaHash": "65b20b69643a6f7b1250b4949e0d1dffd022aa9573aadd952a07759879ebc98f"
     },
     {
       "name": "impl",
       "resolvedPath": ".claude/phases/impl.ts",
-      "contentHash": "343dc4d354df4ae0bbc47b8e7ad0855c2b77d901a839829cc4c6102f8a4a841d",
+      "contentHash": "9d276c677aad59f8c319653d1c9553b555b0a20f13cecd001e2579a3065dfc34",
       "schemaHash": "ed4e8c293093075a364653d8c077f44d68157174b7b276fbdfafb9f31fc1207d"
     },
     {
       "name": "needs-attention",
       "resolvedPath": ".claude/phases/needs-attention.ts",
-      "contentHash": "cd0fdce55a4398de9e7fcacbdfe4dbafa735145ef22d4f28655b3a8d61fb2ecd",
+      "contentHash": "83672d3dd36268fe4a2275e9056a33729dd17e642b11a5b8568e2e08548a8b77",
       "schemaHash": "acee09becf66bc4ce4a92a0a0533840eb0c988f0f2eb0f6eac3a77227ed5267a"
     },
     {
       "name": "qa",
       "resolvedPath": ".claude/phases/qa.ts",
-      "contentHash": "6c0ee6426fd262c651ce4629e0eacaa76ce94378ac0dbe1577164769e48b4228",
+      "contentHash": "1b9b7bf979b7a9ab082d278db4743a4096d32a21d0faac0f297cd4f50e26d48d",
       "schemaHash": "2c3159b3558360d1a25caf8e7f4401da2dba237bf3799807bc8c68497290cd40"
     },
     {
       "name": "repair",
       "resolvedPath": ".claude/phases/repair.ts",
-      "contentHash": "b3427844f2e911b28de1be93c29de8238dd66ccf34f75253d527e975355c052a",
+      "contentHash": "778e86326cbff5d229a4c912f452ca86f418588e10bf8b1cea2dcd1b58e5de6a",
       "schemaHash": "46d347d6bccd711c2069e8927617eb4a921e2c97f4b7038d4b5e5cdc90897c3a"
     },
     {
       "name": "review",
       "resolvedPath": ".claude/phases/review.ts",
-      "contentHash": "381e27ec20af7440587e79ea47c078313992f8bcfb5ff573bfe8493d6441a6a9",
-      "schemaHash": "dbbe21e50a1a7a002a56c511d456060166ea94c6d15b2400e7f8283c861ed83d"
+      "contentHash": "3f2852d3d02e968029648b09f6122455938c0545a88489255dec993d1c518fcf",
+      "schemaHash": "722c5636d497444124371fe5ddabf15a1ca14b0b95fed8e066b3c2cacf1e8080"
     },
     {
       "name": "triage",
       "resolvedPath": ".claude/phases/triage.ts",
-      "contentHash": "de07b1771cb428cda5235642ae4414b6da0ce68081c56a73b0ae155d00476dd6",
+      "contentHash": "9ce2cdb651ddb5b4530d2b3171b9727e83518e9f5680fc69b5f535d4a581e41c",
       "schemaHash": "03a042ac366a29c9f33de68cf1b24300bc899126e4084a4fa1303247afbc772c"
     }
   ],

--- a/.mcx.yaml
+++ b/.mcx.yaml
@@ -21,6 +21,10 @@ state:
   review_round: number?
   repair_round: number?
   qa_fail_round: number?
+  review_stuck_ticks: number?
+  review_respawns: number?
+  qa_stuck_ticks: number?
+  qa_respawns: number?
   previous_phase: string?
   provider: string?
   labels: string?
@@ -39,7 +43,7 @@ phases:
 
   review:
     source: ./.claude/phases/review.ts
-    next: [repair, qa]
+    next: [repair, qa, needs-attention]
 
   repair:
     source: ./.claude/phases/repair.ts

--- a/test/review-phase.spec.ts
+++ b/test/review-phase.spec.ts
@@ -73,6 +73,9 @@ function makeState(initial: Record<string, unknown> = {}): ReviewState {
     set: async (key, value) => {
       store.set(key, value);
     },
+    delete: async (key) => {
+      store.delete(key);
+    },
   };
 }
 
@@ -298,6 +301,7 @@ describe("runReview — spawn path", () => {
         writes[key] = value;
         await state.set(key, value);
       },
+      delete: state.delete,
     };
     await runReview({ provider: "claude" }, makeWork(), trackingState, makeDeps(), "__none__");
     expect(writes.review_round).toBe(1);
@@ -422,6 +426,7 @@ describe("runReview — goto repair (review:changes)", () => {
         writes[key] = value;
         await state.set(key, value);
       },
+      delete: state.delete,
     };
     await runReview(
       { provider: "claude" },


### PR DESCRIPTION
## Summary
- The `no-verdict-yet → wait` branch in `review-fn.ts`/`qa-fn.ts` had no timeout, no liveness check, and no dead-session detection. A reviewer/QA session that died mid-run (quota wall, OOM, segfault, partial execution that posts a comment but never reaches `gh pr edit --add-label`) left the gate idling forever with no distress signal.
- Now the wait is backed by a deterministic circuit breaker: count consecutive label-less ticks; once `STUCK_TICK_CAP` (5) is reached the session is presumed dead → do one bounded respawn (`RESPAWN_CAP`=1) by clearing the session sentinel so the phase re-spawns a fresh session, then escalate to `needs-attention` if the respawn is also stuck. Never an infinite wait.
- Tick-count (not wall-clock) keeps the fn logic pure and deterministically testable. The cap is high enough that a live-but-slow reviewer clears its verdict well before tripping it; a valid verdict still routes normally regardless of accumulated ticks.
- Adds `review → needs-attention` to `.mcx.yaml` (qa already allowed it) and regenerates `.mcx.lock`.

## Test plan
- [x] New `runReview`/`runQa` "dead-session backstop (#2654)" describe blocks: waits under cap, respawns at cap, escalates to needs-attention once respawn budget exhausted, valid verdict still routes, fresh spawn resets the tick counter.
- [x] `bun test ./test/review-phase.spec.ts ./test/qa-phase.spec.ts` — pre-existing duplicate suites kept compiling (added `delete` to `ReviewState` stubs).
- [x] `bun run am-i-done` — full gate green (typecheck, lint, rules, tests, coverage).

Note: filed #2724 for the pre-existing `test/*-phase.spec.ts` ↔ `.claude/phases/*-fn.spec.ts` duplication discovered while touching the `ReviewState` interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)