### PR TITLE
fix(phase): resolve lock/manifest from main checkout root (fixes #2673)

### DIFF
--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -10,6 +10,7 @@ import {
   historyTargets,
   parseLockfile,
   readTransitionHistory,
+  serializeLockfile,
 } from "@mcp-cli/core";
 import {
   bundleAlias,
@@ -1198,6 +1199,43 @@ function makeDriftDeps(cwd: string) {
   };
   return { deps, logs, errs, getExitCode: () => exitCode };
 }
+
+describe("cmdPhase root resolution from a worktree (#2673)", () => {
+  test("phase check resolves .mcx.lock from the main checkout root, not the worktree CWD", async () => {
+    // Main checkout: manifest + source + a freshly installed (in-sync) lock.
+    writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);
+    writeFileSync(join(dir, "impl.ts"), simpleAlias);
+    const { deps } = makeDriftDeps(dir);
+    await cmdPhase(["install"], deps);
+
+    // Worktree checkout: identical sources but a STALE committed lock — this is
+    // the #2570 scenario where the lock at HEAD lagged the source.
+    const worktree = mkdtempSync(join(tmpdir(), "mcx-phase-wt-"));
+    try {
+      writeFileSync(join(worktree, ".mcx.yaml"), simpleManifest);
+      writeFileSync(join(worktree, "impl.ts"), simpleAlias);
+      const stale = parseLockfile(readFileSync(join(dir, ".mcx.lock"), "utf-8"));
+      stale.phases[0].contentHash = "0".repeat(64);
+      writeFileSync(join(worktree, ".mcx.lock"), serializeLockfile(stale));
+
+      // Control: with no root mapping, checking from the worktree reads the
+      // worktree's stale lock and falsely reports drift.
+      const control = await catchExit(() => cmdPhase(["check"], { cwd: () => worktree, resolveRoot: (c) => c }));
+      expect(control.code).toBe(1);
+      expect(control.err).toContain("out of date");
+
+      // Fix: mapping the worktree CWD back to the main checkout root reads the
+      // in-sync lock and reports ok.
+      const mapped = await catchExit(() =>
+        cmdPhase(["check"], { cwd: () => worktree, resolveRoot: (c) => (c === worktree ? dir : c) }),
+      );
+      expect(mapped.code).toBeUndefined();
+      expect(mapped.out).toContain("lockfile ok");
+    } finally {
+      rmSync(worktree, { recursive: true, force: true });
+    }
+  });
+});
 
 describe("detectDrift", () => {
   async function installFixture(extraPhase?: { name: string; src: string }) {

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -90,6 +90,7 @@ export interface PhaseInstallDeps {
   readFile: (path: string) => Promise<string>;
   executeAliasBundled: typeof executeAliasBundled;
   cwd: () => string;
+  resolveRoot: (cwd: string) => string;
   log: (msg: string) => void;
   logError: (msg: string) => void;
   exit: (code: number) => never;
@@ -106,6 +107,7 @@ const defaultDeps: PhaseInstallDeps = {
   readFile: (path) => Bun.file(path).text(),
   executeAliasBundled,
   cwd: () => process.cwd(),
+  resolveRoot: (cwd) => findGitRoot(cwd) ?? cwd,
   log: (msg) => console.log(msg),
   logError: (msg) => console.error(msg),
   exit: (code) => process.exit(code),
@@ -725,6 +727,14 @@ export async function cmdPhase(
   execDeps?: Partial<PhaseExecuteDeps>,
 ): Promise<void> {
   const d: PhaseInstallDeps = { ...defaultDeps, ...deps };
+  // Resolve manifest / .mcx.lock / transition-log lookups from the main
+  // checkout root, not the raw CWD. From a linked worktree, process.cwd() is
+  // the worktree checkout whose committed .mcx.lock can be stale, while phase
+  // *state* is keyed by findGitRoot's main-checkout root — so a lock that is in
+  // sync at the root falsely reports "out of date" from a worktree. Mapping the
+  // lookup root through the same resolver keeps both consistent (#2673).
+  const rawCwd = d.cwd;
+  d.cwd = () => d.resolveRoot(rawCwd());
   const sub = args[0];
 
   if (!sub || sub === "help" || sub === "--help" || sub === "-h") {


### PR DESCRIPTION
## Summary
- `mcx phase` read `.mcx.lock` and phase sources from the worktree's raw CWD while phase *state* was keyed by `findGitRoot`'s main-checkout root. From a linked worktree, an in-sync lock therefore falsely reported `.mcx.lock is out of date` (#2673).
- Map the lookup root through the same resolver (`findGitRoot`) once at the `cmdPhase` boundary, so every subcommand (run/check/install/list/show/log/advance) resolves manifest, lock, and transition-log from one consistent root.
- Resolver is injectable (`resolveRoot` dep) for testing; default is `findGitRoot(cwd) ?? cwd`, which already maps a linked worktree back to the main checkout.

## Test plan
- [x] New regression test reproduces the bug: from a worktree CWD with a stale committed lock, `phase check` falsely reports drift without root mapping, and reports `lockfile ok` with it.
- [x] `bun test packages/command/src/commands/phase.spec.ts` — 176 pass
- [x] `bun run am-i-done --pre-commit` (typecheck + lint + rules) passes
- [x] Full sequential `bun test` on this change's base passes (9070 pass, 0 fail)

## Hot-shared note
#2656 is concurrently changing drift-hash computation in adjacent files. This diff is scoped strictly to root resolution (no hash-logic changes). Whichever PR merges second must rebase and re-check root-resolution assumptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)