### PR TITLE
fix(phase): hash transitive import closure for lock drift (fixes #2656)

### DIFF
--- a/.mcx.lock
+++ b/.mcx.lock
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "manifestHash": "294b0b088b52b79d08b035a3582079c07198e5f4eb36ae16b635377d3b057031",
+  "manifestHash": "7c6db54ba9992d3a66ee93eb63948f01cdcbb18a9e9ae01ac12de652e23b4f89",
   "phases": [
     {
       "name": "done",
@@ -11,8 +11,8 @@
     {
       "name": "impl",
       "resolvedPath": ".claude/phases/impl.ts",
-      "contentHash": "24e5e276c4f23e8e15be457dceb0ca6d79b4a9d23c8b00aa0d4819ea652c6f05",
-      "schemaHash": "ed4e8c293093075a364653d8c077f44d68157174b7b276fbdfafb9f31fc1207d"
+      "contentHash": "4ea18c3194c7dc7708a7f9ff55f774ebd03bf8e5c7c9dccfc8917557a11b26e1",
+      "schemaHash": "ffdce08965415cdf4bff93169087ae60b05a84fa07892fece8793b0bc06690b2"
     },
     {
       "name": "needs-attention",
@@ -23,7 +23,7 @@
     {
       "name": "qa",
       "resolvedPath": ".claude/phases/qa.ts",
-      "contentHash": "a4d7ffcb53e7e3d658d0ef110e1d206443da8331fa74caae89ea9f3249d0e677",
+      "contentHash": "3d973ec4fa0d9b47bbd609b2047498d4a2fd9af6f790765e3d9cae4c949f4ec8",
       "schemaHash": "2c3159b3558360d1a25caf8e7f4401da2dba237bf3799807bc8c68497290cd40"
     },
     {
@@ -35,8 +35,8 @@
     {
       "name": "review",
       "resolvedPath": ".claude/phases/review.ts",
-      "contentHash": "5326ed6df099c5396ad80c60c1a166f81ccc119a0e00555c76afd482b68045fd",
-      "schemaHash": "dbbe21e50a1a7a002a56c511d456060166ea94c6d15b2400e7f8283c861ed83d"
+      "contentHash": "23f5836df4aa597a1ef0b5844277c5cc135fb8a99d5491653a5969b42ffad6f1",
+      "schemaHash": "722c5636d497444124371fe5ddabf15a1ca14b0b95fed8e066b3c2cacf1e8080"
     },
     {
       "name": "triage",

--- a/.mcx.lock
+++ b/.mcx.lock
@@ -1,47 +1,47 @@
 {
   "version": 1,
-  "manifestHash": "7c6db54ba9992d3a66ee93eb63948f01cdcbb18a9e9ae01ac12de652e23b4f89",
+  "manifestHash": "294b0b088b52b79d08b035a3582079c07198e5f4eb36ae16b635377d3b057031",
   "phases": [
     {
       "name": "done",
       "resolvedPath": ".claude/phases/done.ts",
-      "contentHash": "11673a02b960efd7d4b4411639b21219fc1059d88c769f8dd266264794048892",
+      "contentHash": "c2f06149a306e11fcf86c5e6f258f9a1d254dba350a6f7db63a1b92b97cde0f7",
       "schemaHash": "65b20b69643a6f7b1250b4949e0d1dffd022aa9573aadd952a07759879ebc98f"
     },
     {
       "name": "impl",
       "resolvedPath": ".claude/phases/impl.ts",
-      "contentHash": "9d276c677aad59f8c319653d1c9553b555b0a20f13cecd001e2579a3065dfc34",
+      "contentHash": "24e5e276c4f23e8e15be457dceb0ca6d79b4a9d23c8b00aa0d4819ea652c6f05",
       "schemaHash": "ed4e8c293093075a364653d8c077f44d68157174b7b276fbdfafb9f31fc1207d"
     },
     {
       "name": "needs-attention",
       "resolvedPath": ".claude/phases/needs-attention.ts",
-      "contentHash": "83672d3dd36268fe4a2275e9056a33729dd17e642b11a5b8568e2e08548a8b77",
+      "contentHash": "30404ba095e4aa1f23d52484d46bb3008597a8fbfcc9e343914b86b4eac76a4a",
       "schemaHash": "acee09becf66bc4ce4a92a0a0533840eb0c988f0f2eb0f6eac3a77227ed5267a"
     },
     {
       "name": "qa",
       "resolvedPath": ".claude/phases/qa.ts",
-      "contentHash": "1b9b7bf979b7a9ab082d278db4743a4096d32a21d0faac0f297cd4f50e26d48d",
+      "contentHash": "a4d7ffcb53e7e3d658d0ef110e1d206443da8331fa74caae89ea9f3249d0e677",
       "schemaHash": "2c3159b3558360d1a25caf8e7f4401da2dba237bf3799807bc8c68497290cd40"
     },
     {
       "name": "repair",
       "resolvedPath": ".claude/phases/repair.ts",
-      "contentHash": "778e86326cbff5d229a4c912f452ca86f418588e10bf8b1cea2dcd1b58e5de6a",
+      "contentHash": "e905e31f1db726dee1a926b1ca93febabc6fd9841b1dc5a51e70c9101958bc95",
       "schemaHash": "46d347d6bccd711c2069e8927617eb4a921e2c97f4b7038d4b5e5cdc90897c3a"
     },
     {
       "name": "review",
       "resolvedPath": ".claude/phases/review.ts",
-      "contentHash": "3f2852d3d02e968029648b09f6122455938c0545a88489255dec993d1c518fcf",
-      "schemaHash": "722c5636d497444124371fe5ddabf15a1ca14b0b95fed8e066b3c2cacf1e8080"
+      "contentHash": "5326ed6df099c5396ad80c60c1a166f81ccc119a0e00555c76afd482b68045fd",
+      "schemaHash": "dbbe21e50a1a7a002a56c511d456060166ea94c6d15b2400e7f8283c861ed83d"
     },
     {
       "name": "triage",
       "resolvedPath": ".claude/phases/triage.ts",
-      "contentHash": "9ce2cdb651ddb5b4530d2b3171b9727e83518e9f5680fc69b5f535d4a581e41c",
+      "contentHash": "310873836d6e75965d5a4034731c5553b6f79adb4bccb9fbbe7409231f22606f",
       "schemaHash": "03a042ac366a29c9f33de68cf1b24300bc899126e4084a4fa1303247afbc772c"
     }
   ],
@@ -49,7 +49,7 @@
     {
       "name": "cleanup",
       "resolvedPath": ".claude/automation/cleanup.ts",
-      "contentHash": "605790118bd7c1465949f4c0cf9c7c125be97af1da7aa140a4a3b8829a4221c1",
+      "contentHash": "344a6baf3f8428de0d4330272f92de7cf7b6956ce1eab763aadd79508608ae96",
       "events": [
         "pr.merged"
       ],

--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -1395,6 +1395,45 @@ defineAlias(({ z }) => ({
       expect(phase?.path).toBe("impl.ts");
     }
   }, 20_000);
+
+  test("phase list/show report no drift on a clean tree, including transitive imports (#2656)", async () => {
+    // Regression: buildPhaseList/buildPhaseShow hashed the entry file only,
+    // but the lock now stores the closure hash — so every phase falsely showed
+    // "drift" on a clean tree even though `phase check` passed. Pin list==check.
+    writeFileSync(join(dir, "helper.ts"), "export const SUFFIX = 1;\n");
+    const importingAlias = `
+import { defineAlias, z } from "mcp-cli";
+import { SUFFIX } from "./helper";
+
+defineAlias(({ z }) => ({
+  name: "implement",
+  description: "Implement phase",
+  input: z.object({ issue: z.number() }),
+  output: z.object({ pr: z.number() }),
+  fn: async (input) => ({ pr: input.issue + SUFFIX }),
+}));
+`.trim();
+    writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);
+    writeFileSync(join(dir, "impl.ts"), importingAlias);
+    const { deps: installDeps } = makeDriftDeps(dir);
+    await cmdPhase(["install"], installDeps);
+
+    const loaded = loadManifest(dir);
+    if (!loaded) throw new Error("manifest failed to load");
+    const lock = parseLockfile(readFileSync(join(dir, ".mcx.lock"), "utf-8"));
+
+    // `phase check`'s view (detectDrift) is clean…
+    expect(detectDrift(makeDriftDeps(dir).deps).status).toBe("ok");
+
+    // …and so must `phase list`'s view — no phantom drift from a stale mirror.
+    const rows = buildPhaseList(loaded.manifest, lock, dir);
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) expect(row.status).toBe("ok");
+
+    // `phase show` must agree: displayed contentHash == the locked hash.
+    const show = buildPhaseShow("implement", loaded.manifest.phases.implement, loaded.manifest, lock, dir, false);
+    expect(show.contentHash).toBe(show.lockedHash);
+  }, 20_000);
 });
 
 describe("formatDriftWarning", () => {

--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -1359,6 +1359,42 @@ phases:
     const { deps: checkDeps } = makeDriftDeps(dir);
     expect(detectDrift(checkDeps).status).toBe("ok");
   }, 20_000);
+
+  test("detects drift when a transitive import changes (#2656)", async () => {
+    // Entry imports a sibling helper; editing the helper (not the entry) used
+    // to leave contentHash unchanged because only the entry file was hashed.
+    writeFileSync(join(dir, "helper.ts"), "export const SUFFIX = 1;\n");
+    const importingAlias = `
+import { defineAlias, z } from "mcp-cli";
+import { SUFFIX } from "./helper";
+
+defineAlias(({ z }) => ({
+  name: "implement",
+  description: "Implement phase",
+  input: z.object({ issue: z.number() }),
+  output: z.object({ pr: z.number() }),
+  fn: async (input) => ({ pr: input.issue + SUFFIX }),
+}));
+`.trim();
+    writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);
+    writeFileSync(join(dir, "impl.ts"), importingAlias);
+    const { deps: installDeps } = makeDriftDeps(dir);
+    await cmdPhase(["install"], installDeps);
+
+    // Clean install → no drift.
+    expect(detectDrift(makeDriftDeps(dir).deps).status).toBe("ok");
+
+    // Edit only the transitive import.
+    writeFileSync(join(dir, "helper.ts"), "export const SUFFIX = 2;\n");
+    const result = detectDrift(makeDriftDeps(dir).deps);
+    expect(result.status).toBe("drift");
+    if (result.status === "drift") {
+      const phase = result.entries.find((e) => e.kind === "phase-source");
+      expect(phase).toBeDefined();
+      // Drift is attributed to the entry phase, even though helper.ts changed.
+      expect(phase?.path).toBe("impl.ts");
+    }
+  }, 20_000);
 });
 
 describe("formatDriftWarning", () => {

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -54,6 +54,7 @@ import {
   extractMetadata,
   findGitRoot,
   hashFileSync,
+  hashImportClosureSync,
   historyTargets,
   ipcCall,
   isCommitted,
@@ -193,7 +194,7 @@ export async function installPhases(cwd: string, deps: PhaseInstallDeps): Promis
 
     let contentHash: string;
     try {
-      contentHash = deps.hashFileSync(resolvedAbs);
+      contentHash = hashImportClosureSync(resolvedAbs, cwd);
     } catch (err) {
       const e = err as NodeJS.ErrnoException;
       if (e?.code === "ENOENT") {
@@ -247,7 +248,7 @@ export async function installPhases(cwd: string, deps: PhaseInstallDeps): Promis
 
       let contentHash: string;
       try {
-        contentHash = deps.hashFileSync(resolvedAbs);
+        contentHash = hashImportClosureSync(resolvedAbs, cwd);
       } catch (err) {
         const e = err as NodeJS.ErrnoException;
         if (e?.code === "ENOENT") {
@@ -519,7 +520,7 @@ export function detectDrift(deps: DriftDeps): DriftResult {
     const abs = resolvePath(cwd, locked.resolvedPath);
     let actualHash: string;
     try {
-      actualHash = deps.hashFileSync(abs);
+      actualHash = hashImportClosureSync(abs, cwd);
     } catch {
       entries.push({
         kind: "phase-source",
@@ -570,7 +571,7 @@ export function detectDrift(deps: DriftDeps): DriftResult {
     const abs = resolvePath(cwd, locked.resolvedPath);
     let actualHash: string;
     try {
-      actualHash = deps.hashFileSync(abs);
+      actualHash = hashImportClosureSync(abs, cwd);
     } catch {
       entries.push({
         kind: "automation-source",

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -1883,7 +1883,7 @@ export function buildPhaseList(manifest: Manifest, lock: Lockfile | null, cwd: s
       status = "missing";
     } else {
       try {
-        const currentHash = hashFileSync(resolvePhaseSource(phase.source, cwd));
+        const currentHash = hashImportClosureSync(resolvePhaseSource(phase.source, cwd), cwd);
         status = currentHash === locked.contentHash ? "ok" : "drift";
       } catch {
         status = "not-found";
@@ -1940,7 +1940,7 @@ export function buildPhaseShow(
     const abs = resolvePhaseSource(phase.source, cwd);
     resolvedPath = relative(cwd, abs).split("\\").join("/") || ".";
     try {
-      contentHash = hashFileSync(abs);
+      contentHash = hashImportClosureSync(abs, cwd);
       const text = readFileSync(abs, "utf-8");
       const lines = text.split("\n");
       if (!full && lines.length > 20) {

--- a/packages/core/src/manifest-lock.spec.ts
+++ b/packages/core/src/manifest-lock.spec.ts
@@ -1,8 +1,12 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   LOCKFILE_VERSION,
   type Lockfile,
   canonicalJson,
+  hashImportClosureSync,
   parseLockfile,
   serializeLockfile,
   sha256Hex,
@@ -28,6 +32,72 @@ describe("canonicalJson", () => {
 
   test("preserves array order", () => {
     expect(canonicalJson([3, 1, 2])).toBe("[3,1,2]");
+  });
+});
+
+describe("hashImportClosureSync", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "closure-hash-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("changes when a transitive import is edited (#2656)", () => {
+    writeFileSync(join(dir, "helper.ts"), "export const N = 1;\n");
+    writeFileSync(join(dir, "entry.ts"), 'import { N } from "./helper";\nexport const X = N;\n');
+    const before = hashImportClosureSync(join(dir, "entry.ts"), dir);
+
+    // Edit the *transitive import*, not the entry — the bug was that this
+    // left the hash unchanged.
+    writeFileSync(join(dir, "helper.ts"), "export const N = 2;\n");
+    const after = hashImportClosureSync(join(dir, "entry.ts"), dir);
+    expect(after).not.toBe(before);
+  });
+
+  test("is stable when the entry and its imports are unchanged", () => {
+    writeFileSync(join(dir, "helper.ts"), "export const N = 1;\n");
+    writeFileSync(join(dir, "entry.ts"), 'import { N } from "./helper";\nexport const X = N;\n');
+    const a = hashImportClosureSync(join(dir, "entry.ts"), dir);
+    const b = hashImportClosureSync(join(dir, "entry.ts"), dir);
+    expect(a).toBe(b);
+  });
+
+  test("ignores edits to a non-imported sibling", () => {
+    writeFileSync(join(dir, "helper.ts"), "export const N = 1;\n");
+    writeFileSync(join(dir, "entry.ts"), 'import { N } from "./helper";\nexport const X = N;\n');
+    writeFileSync(join(dir, "unrelated.ts"), "export const U = 1;\n");
+    const before = hashImportClosureSync(join(dir, "entry.ts"), dir);
+    writeFileSync(join(dir, "unrelated.ts"), "export const U = 999;\n");
+    expect(hashImportClosureSync(join(dir, "entry.ts"), dir)).toBe(before);
+  });
+
+  test("does not follow bare/package specifiers", () => {
+    // "mcp-cli" and "@mcp-cli/core" are externalized by the bundler — a
+    // closure hash must not depend on package contents.
+    writeFileSync(join(dir, "entry.ts"), 'import { z } from "mcp-cli";\nimport { x } from "@scope/pkg";\n');
+    // No throw, deterministic.
+    expect(hashImportClosureSync(join(dir, "entry.ts"), dir)).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  test("is independent of repoRoot location for identical content", () => {
+    const other = mkdtempSync(join(tmpdir(), "closure-hash2-"));
+    try {
+      for (const d of [dir, other]) {
+        writeFileSync(join(d, "helper.ts"), "export const N = 1;\n");
+        writeFileSync(join(d, "entry.ts"), 'import { N } from "./helper";\nexport const X = N;\n');
+      }
+      expect(hashImportClosureSync(join(dir, "entry.ts"), dir)).toBe(
+        hashImportClosureSync(join(other, "entry.ts"), other),
+      );
+    } finally {
+      rmSync(other, { recursive: true, force: true });
+    }
+  });
+
+  test("throws ENOENT when the entry file is missing", () => {
+    expect(() => hashImportClosureSync(join(dir, "nope.ts"), dir)).toThrow();
   });
 });
 

--- a/packages/core/src/manifest-lock.ts
+++ b/packages/core/src/manifest-lock.ts
@@ -123,11 +123,21 @@ function resolveLocalImport(spec: string, fromFile: string): string | null {
  */
 export function hashImportClosureSync(entryPath: string, repoRoot: string): string {
   const contentByPath = new Map<string, string>();
-  const stack = [resolve(entryPath)];
+  const entryAbs = resolve(entryPath);
+  const stack = [entryAbs];
   while (stack.length > 0) {
     const file = stack.pop() as string;
     if (contentByPath.has(file)) continue;
-    const buf = readFileSync(file);
+    let buf: Buffer;
+    try {
+      buf = readFileSync(file);
+    } catch (err) {
+      // The entry file must exist — callers map its ENOENT to a "file missing"
+      // drift. A *sibling* that vanished between resolve-time and now is simply
+      // excluded, matching the resolve-time existence check.
+      if (file === entryAbs) throw err;
+      continue;
+    }
     contentByPath.set(file, sha256Hex(buf));
     let imports: { path: string }[];
     try {

--- a/packages/core/src/manifest-lock.ts
+++ b/packages/core/src/manifest-lock.ts
@@ -8,7 +8,8 @@
  * Format v1: JSON, keys sorted (deterministic), LF line endings.
  */
 
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { dirname, extname, isAbsolute, relative, resolve } from "node:path";
 import { z } from "zod";
 
 export const LOCKFILE_NAME = ".mcx.lock";
@@ -20,7 +21,7 @@ export const LockedPhaseSchema = z
     name: z.string(),
     /** Path relative to the repo root, forward slashes. */
     resolvedPath: z.string(),
-    /** sha256 of the source file contents (hex). */
+    /** sha256 of the transitive local-import closure (hex); see hashImportClosureSync. */
     contentHash: z.string().regex(/^[a-f0-9]{64}$/),
     /** sha256 of the extracted output-schema JSON, or empty string if none. */
     schemaHash: z.string().regex(/^([a-f0-9]{64}|)$/),
@@ -63,6 +64,87 @@ export function sha256Hex(input: string | Uint8Array | ArrayBuffer): string {
 /** Compute the sha256 of a file's contents. */
 export function hashFileSync(path: string): string {
   return sha256Hex(readFileSync(path));
+}
+
+// Extension probe order for resolving a relative import to a file. Empty string
+// first so an already-suffixed specifier (`./x.ts`, `./data.json`) wins as-is.
+const CLOSURE_RESOLVE_EXTS = ["", ".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".json"];
+const CLOSURE_INDEX_FILES = ["index.ts", "index.tsx", "index.js", "index.mjs"];
+
+function closureLoaderFor(path: string): "ts" | "tsx" | "js" | "jsx" {
+  switch (extname(path)) {
+    case ".tsx":
+      return "tsx";
+    case ".jsx":
+      return "jsx";
+    case ".js":
+    case ".mjs":
+    case ".cjs":
+      return "js";
+    default:
+      return "ts";
+  }
+}
+
+/**
+ * Resolve a single import specifier to an on-disk file, or null when it is a
+ * bare/package specifier (npm, "mcp-cli", "@mcp-cli/core") — those are
+ * externalized by the bundler and must NOT be followed into the closure.
+ */
+function resolveLocalImport(spec: string, fromFile: string): string | null {
+  if (!spec.startsWith(".") && !isAbsolute(spec)) return null;
+  const base = isAbsolute(spec) ? spec : resolve(dirname(fromFile), spec);
+  for (const ext of CLOSURE_RESOLVE_EXTS) {
+    const candidate = base + ext;
+    if (existsSync(candidate) && statSync(candidate).isFile()) return candidate;
+  }
+  for (const idx of CLOSURE_INDEX_FILES) {
+    const candidate = resolve(base, idx);
+    if (existsSync(candidate) && statSync(candidate).isFile()) return candidate;
+  }
+  return null;
+}
+
+/**
+ * Hash the transitive *local-import* closure of a phase/automation entry file.
+ *
+ * `bundleAlias` externalizes "mcp-cli" and "@mcp-cli/core", so only relative
+ * imports (siblings like `review-fn.ts`) actually land in the effective
+ * bundle. This walks that same set and returns a sha256 over the sorted map of
+ * {repo-relative path → file sha256}. Editing any sibling therefore changes
+ * the hash — closing the gap where a hash over the entry file alone missed
+ * transitive edits (#2656).
+ *
+ * Synchronous (uses Bun.Transpiler.scanImports) so the drift guard stays sync.
+ * Throws if the entry file is unreadable — callers map ENOENT to a
+ * "file missing" drift, matching the prior `hashFileSync` behavior. Resolved
+ * imports are existence-checked before queueing, so a deleted sibling is simply
+ * excluded rather than throwing.
+ */
+export function hashImportClosureSync(entryPath: string, repoRoot: string): string {
+  const contentByPath = new Map<string, string>();
+  const stack = [resolve(entryPath)];
+  while (stack.length > 0) {
+    const file = stack.pop() as string;
+    if (contentByPath.has(file)) continue;
+    const buf = readFileSync(file);
+    contentByPath.set(file, sha256Hex(buf));
+    let imports: { path: string }[];
+    try {
+      imports = new Bun.Transpiler({ loader: closureLoaderFor(file) }).scanImports(buf.toString("utf-8"));
+    } catch {
+      continue; // unparseable file — its own content hash is still captured
+    }
+    for (const imp of imports) {
+      const resolved = resolveLocalImport(imp.path, file);
+      if (resolved && !contentByPath.has(resolved)) stack.push(resolved);
+    }
+  }
+  const rel: Record<string, string> = {};
+  for (const [abs, hash] of contentByPath) {
+    rel[relative(repoRoot, abs).split("\\").join("/")] = hash;
+  }
+  return sha256Hex(canonicalJson(rel));
 }
 
 /** Deterministic JSON.stringify with sorted object keys (recursive). */

--- a/scripts/am-i-done.spec.ts
+++ b/scripts/am-i-done.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+
+import { CI, COMPREHENSIVE, PRE_COMMIT, PRE_PUSH } from "./am-i-done";
+
+const names = (steps: { name: string }[]) => steps.map((s) => s.name);
+
+describe("am-i-done step lists", () => {
+  // #2737: `mcx phase check` resolves its root to the main checkout from a
+  // linked worktree, so the local hooks must NOT run phase-lock — it would
+  // false-positive-block every clean worktree commit/push and false-negative
+  // the worktree's own lock drift. Sprints run entirely in worktrees.
+  it("does not wire phase-lock into the pre-commit hook", () => {
+    expect(names(PRE_COMMIT)).not.toContain("phase-lock");
+  });
+
+  it("does not wire phase-lock into the pre-push hook", () => {
+    expect(names(PRE_PUSH)).not.toContain("phase-lock");
+  });
+
+  // The check is sound against a real checkout (root == repo root), so CI and
+  // the default full run keep it — that is where committed lock drift is caught.
+  it("keeps phase-lock in the CI gate", () => {
+    expect(names(CI)).toContain("phase-lock");
+  });
+
+  it("keeps phase-lock in the comprehensive (default) run", () => {
+    expect(names(COMPREHENSIVE)).toContain("phase-lock");
+  });
+});

--- a/scripts/am-i-done.ts
+++ b/scripts/am-i-done.ts
@@ -86,6 +86,20 @@ const AGENT_GRID: Step = {
   onFailure: ["fix the validation errors reported above", "schema: agent-grid/versions-schema.ts"],
 };
 
+// Catches a committed .mcx.lock that has drifted from the phase/automation
+// sources — including edits to a *transitive* import (e.g. review-fn.ts), which
+// the entry-file-only hash used to miss (#2656). `phase check` hashes the full
+// local-import closure and exits non-zero on any mismatch.
+const PHASE_LOCK: Step = {
+  name: "phase-lock",
+  description: "verify .mcx.lock matches phase/automation source closure (#2656) — `mcx phase check`",
+  command: "bun packages/command/src/main.ts phase check",
+  onFailure: [
+    "a phase/automation source changed without re-install — including a transitive import like *-fn.ts",
+    "run `bun packages/command/src/main.ts phase install` and commit the updated .mcx.lock",
+  ],
+};
+
 const RULES: Step = {
   name: "doing-it-wrong",
   description: "architectural rule engine (scripts/rules/*.rule.ts)",
@@ -250,14 +264,15 @@ const STALE_TODOS_CI: Step = {
 // Default (no flag): the developer-friendly path — parallel tests for
 //   speed, `biome --write` for auto-fix, and the simpler coverage step.
 
-const PRE_COMMIT: Step[] = [INSTALL, TYPECHECK, LINT_CHECK, RULES, AGENT_GRID];
-const PRE_PUSH: Step[] = [INSTALL, TYPECHECK, LINT_CHECK, RULES, AGENT_GRID, TEST_CHANGED];
+const PRE_COMMIT: Step[] = [INSTALL, TYPECHECK, LINT_CHECK, RULES, AGENT_GRID, PHASE_LOCK];
+const PRE_PUSH: Step[] = [INSTALL, TYPECHECK, LINT_CHECK, RULES, AGENT_GRID, PHASE_LOCK, TEST_CHANGED];
 const COMPREHENSIVE: Step[] = [
   INSTALL,
   TYPECHECK,
   LINT,
   RULES,
   AGENT_GRID,
+  PHASE_LOCK,
   TEST_PARALLEL,
   TEST_CONTROL,
   TEST_PHASES_CI,
@@ -269,6 +284,7 @@ const CI: Step[] = [
   LINT_CHECK,
   RULES,
   AGENT_GRID,
+  PHASE_LOCK,
   STALE_TODOS_CI,
   TEST_NON_DAEMON_CI,
   TEST_DAEMON_CI,

--- a/scripts/am-i-done.ts
+++ b/scripts/am-i-done.ts
@@ -264,9 +264,16 @@ const STALE_TODOS_CI: Step = {
 // Default (no flag): the developer-friendly path — parallel tests for
 //   speed, `biome --write` for auto-fix, and the simpler coverage step.
 
-const PRE_COMMIT: Step[] = [INSTALL, TYPECHECK, LINT_CHECK, RULES, AGENT_GRID, PHASE_LOCK];
-const PRE_PUSH: Step[] = [INSTALL, TYPECHECK, LINT_CHECK, RULES, AGENT_GRID, PHASE_LOCK, TEST_CHANGED];
-const COMPREHENSIVE: Step[] = [
+// phase-lock is deliberately omitted from PRE_COMMIT / PRE_PUSH: `mcx phase
+// check` resolves its root to the *main* checkout from a linked worktree
+// (phase.ts → findGitRoot, #2673), so wiring it into the local hooks both
+// false-positive-blocks every clean worktree commit/push and false-negatives
+// the worktree's own lock drift (#2737). It stays in CI / COMPREHENSIVE, which
+// run against a real checkout where the root is the repo root and the check is
+// sound. Re-add to the local hooks once #2737 makes the resolver worktree-aware.
+export const PRE_COMMIT: Step[] = [INSTALL, TYPECHECK, LINT_CHECK, RULES, AGENT_GRID];
+export const PRE_PUSH: Step[] = [INSTALL, TYPECHECK, LINT_CHECK, RULES, AGENT_GRID, TEST_CHANGED];
+export const COMPREHENSIVE: Step[] = [
   INSTALL,
   TYPECHECK,
   LINT,
@@ -278,7 +285,7 @@ const COMPREHENSIVE: Step[] = [
   TEST_PHASES_CI,
   COVERAGE,
 ];
-const CI: Step[] = [
+export const CI: Step[] = [
   INSTALL,
   TYPECHECK,
   LINT_CHECK,


### PR DESCRIPTION
## Summary
- `.mcx.lock`'s per-phase/automation `contentHash` was `sha256(entry file)` only, so editing a transitive import (e.g. `review-fn.ts`) and re-running `mcx phase install` left the hash unchanged — the drift guard gave a false green and the committed lock silently drifted from the effective bundle (live evidence: #2704/#2711/#2718 edited `*-fn.ts` files; lock drifted on main undetected).
- New `hashImportClosureSync(entry, repoRoot)` in `packages/core/src/manifest-lock.ts` walks the **transitive local-import closure** — the same set the bundler keeps, since `mcp-cli` and `@mcp-cli/core` are externalized — and hashes the sorted `{repo-relative path → sha256}` map. Deterministic and Bun-version-independent (uses `Bun.Transpiler.scanImports`, not bundler output).
- Both `installPhases` and `detectDrift` now use it for phase **and** automation sources (manifest still uses the plain file hash). Root-resolution semantics left untouched (kept clear of #2673's adjacent work).
- Wired a `phase-lock` step (`mcx phase check`) into `am-i-done` for the **default full run and CI**, so committed-lock-vs-source drift now **fails loudly in CI** — previously nothing ran the drift check there, which is how the staleness persisted.
- Regenerated `.mcx.lock` under the new hashing (8 hashes updated).

### Deferred: phase-lock not in local pre-commit/pre-push (→ #2737)
`mcx phase check` resolves its root to the **main** checkout from a linked worktree (`phase.ts` → `findGitRoot`, #2673). Wiring it into the local `pre-commit`/`pre-push` hooks therefore both false-positive-blocks every clean worktree commit/push **and** false-negatives the worktree's own lock drift. Since sprints run entirely in worktrees, every worker hit the deadlock. Per the round-2 adversarial review, phase-lock is **removed from the local hook step lists** and kept only in the default run + CI, which execute against a real checkout where the root is the repo root and the check is sound. Worktree-aware root resolution is deferred to **#2737**. Pinned by `scripts/am-i-done.spec.ts`. (Fixed in `de045aff`.)

## Test plan
- [x] `bun test packages/core/src/manifest-lock.spec.ts` — 6 new cases: transitive-import edit changes the hash, stable when unchanged, ignores non-imported siblings, doesn't follow package specifiers, location-independent, throws ENOENT on missing entry.
- [x] `bun test packages/command/src/commands/phase.spec.ts` — new regression test: editing a transitive import (`helper.ts`) drifts the entry phase; 176/176 pass.
- [x] `bun test scripts/am-i-done.spec.ts` — pins phase-lock absent from pre-commit/pre-push, present in CI/comprehensive (#2737 deferral).
- [x] Manual repro: editing `review-fn.ts` now drifts the `review` phase (exit 1); clean tree passes (exit 0).
- [x] `am-i-done --pre-commit` now passes from a worktree (5 steps, no phase-lock) — the deadlock is gone.

Note: a pre-existing time-based flake (#2703, `agent-grid/src/replay.spec.ts`) trips the local `--changed` pre-push run under wide blast radius; passes in isolation and in the full gate. CI on clean runners is the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
