### PR TITLE
fix(worktree): fork new worktrees from origin/main, not stale local HEAD (fixes #2679)

### DIFF
--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -72,7 +72,7 @@ export interface SharedSessionDeps {
   /** Run a command and return stdout + stderr + exit code. Used for git operations in `bye`. */
   exec: (
     cmd: string[],
-    opts?: { env?: Record<string, string> },
+    opts?: { env?: Record<string, string>; timeoutMs?: number },
   ) => { stdout: string; stderr: string; exitCode: number };
 }
 
@@ -123,7 +123,7 @@ export const defaultDeps: ClaudeDeps = {
     // spawnCaptureSync replaces the env when provided; merge with process.env
     // here so callers that pass a few extra vars still inherit PATH etc.
     const env = opts?.env ? { ...process.env, ...opts.env } : undefined;
-    const result = spawnCaptureSync(cmd[0] ?? "", cmd.slice(1), { env });
+    const result = spawnCaptureSync(cmd[0] ?? "", cmd.slice(1), { env, timeoutMs: opts?.timeoutMs });
     return {
       stdout: result.stdout.trim(),
       stderr: result.stderr.trim(),

--- a/packages/core/src/worktree-shim.spec.ts
+++ b/packages/core/src/worktree-shim.spec.ts
@@ -12,6 +12,7 @@ import {
   listMcxWorktrees,
   parseWorktreeList,
   pruneWorktrees,
+  resolveWorktreeStartPoint,
 } from "./worktree-shim";
 
 // ── Helpers ──
@@ -83,7 +84,7 @@ describe("createWorktree", () => {
     expect(deps.exec).not.toHaveBeenCalled();
   });
 
-  test("shimmed worktree: creates with branch prefix", () => {
+  test("shimmed worktree: creates with branch prefix from origin default branch", () => {
     const deps = makeDeps();
     const result = createWorktree({ name: "my-feat", repoRoot: "/repo", branchPrefix: "codex/" }, deps);
     expect(result.shimmed).toBe(true);
@@ -93,15 +94,16 @@ describe("createWorktree", () => {
       worktree: "my-feat",
       repoRoot: "/repo",
     });
-    // Should call git worktree add with prefixed branch
+    // Should fork from origin/main (mock exec reports an origin remote + successful fetch)
     expect(deps.exec).toHaveBeenCalledWith([
       "git",
       "worktree",
       "add",
+      "--no-track",
       "/repo/.claude/worktrees/my-feat",
       "-b",
       "codex/my-feat",
-      "HEAD",
+      "origin/main",
     ]);
   });
 
@@ -114,10 +116,11 @@ describe("createWorktree", () => {
       "git",
       "worktree",
       "add",
+      "--no-track",
       "/repo/.claude/worktrees/my-feat",
       "-b",
       "my-feat",
-      "HEAD",
+      "origin/main",
     ]);
   });
 
@@ -226,11 +229,77 @@ describe("createWorktree", () => {
       "git",
       "worktree",
       "add",
+      "--no-track",
       join(tmpDir, ".claude", "worktrees", "my-feat"),
       "-b",
       "my-feat",
-      "HEAD",
+      "origin/main",
     ]);
+  });
+});
+
+// ── resolveWorktreeStartPoint (#2679) ──
+
+describe("resolveWorktreeStartPoint", () => {
+  /** exec mock that routes by git subcommand; everything else succeeds with empty output. */
+  function routingExec(routes: {
+    remoteExit?: number;
+    symbolicRefStdout?: string;
+    fetchExit?: number;
+    fetchStderr?: string;
+    verifyExit?: number;
+  }) {
+    return mock((cmd: string[]) => {
+      if (cmd.includes("remote")) return { stdout: "", stderr: "", exitCode: routes.remoteExit ?? 0 };
+      if (cmd.includes("symbolic-ref")) return { stdout: routes.symbolicRefStdout ?? "", stderr: "", exitCode: 0 };
+      if (cmd.includes("fetch"))
+        return { stdout: "", stderr: routes.fetchStderr ?? "", exitCode: routes.fetchExit ?? 0 };
+      if (cmd.includes("rev-parse")) return { stdout: "", stderr: "", exitCode: routes.verifyExit ?? 0 };
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+  }
+
+  test("fetches origin default branch and returns origin/<branch>", () => {
+    const exec = routingExec({ symbolicRefStdout: "refs/remotes/origin/main" });
+    const deps = makeDeps({ exec });
+    expect(resolveWorktreeStartPoint("/repo", deps)).toBe("origin/main");
+    // Fetch must be bounded by a timeout so an unreachable remote can't hang spawn
+    expect(exec).toHaveBeenCalledWith(
+      ["git", "-C", "/repo", "fetch", "origin", "main"],
+      expect.objectContaining({ timeoutMs: expect.any(Number) }),
+    );
+    expect(deps.printError).not.toHaveBeenCalled();
+  });
+
+  test("respects non-main default branch from origin/HEAD", () => {
+    const exec = routingExec({ symbolicRefStdout: "refs/remotes/origin/master" });
+    const deps = makeDeps({ exec });
+    expect(resolveWorktreeStartPoint("/repo", deps)).toBe("origin/master");
+    expect(exec).toHaveBeenCalledWith(["git", "-C", "/repo", "fetch", "origin", "master"], expect.anything());
+  });
+
+  test("no origin remote: falls back to HEAD silently without fetching", () => {
+    const exec = routingExec({ remoteExit: 2 });
+    const deps = makeDeps({ exec });
+    expect(resolveWorktreeStartPoint("/repo", deps)).toBe("HEAD");
+    const fetchCalls = exec.mock.calls.filter((c) => (c[0] as string[]).includes("fetch"));
+    expect(fetchCalls).toHaveLength(0);
+    expect(deps.printError).not.toHaveBeenCalled();
+  });
+
+  test("fetch failure (offline): falls back to HEAD with a stale-base warning", () => {
+    const exec = routingExec({ fetchExit: 128, fetchStderr: "fatal: unable to access remote" });
+    const deps = makeDeps({ exec });
+    expect(resolveWorktreeStartPoint("/repo", deps)).toBe("HEAD");
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("may be stale"));
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("fatal: unable to access remote"));
+  });
+
+  test("origin ref missing after fetch: falls back to HEAD with a warning", () => {
+    const exec = routingExec({ verifyExit: 1 });
+    const deps = makeDeps({ exec });
+    expect(resolveWorktreeStartPoint("/repo", deps)).toBe("HEAD");
+    expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("may be stale"));
   });
 });
 

--- a/packages/core/src/worktree-shim.ts
+++ b/packages/core/src/worktree-shim.ts
@@ -22,11 +22,14 @@ import {
 
 // ── Types ──
 
+/** Bound the pre-fork `git fetch` so an unreachable remote can't hang spawn. */
+const WORKTREE_FETCH_TIMEOUT_MS = 15_000;
+
 /** Minimal dependency interface for worktree operations. */
 export interface WorktreeShimDeps {
   exec: (
     cmd: string[],
-    opts?: { env?: Record<string, string> },
+    opts?: { env?: Record<string, string>; timeoutMs?: number },
   ) => { stdout: string; stderr: string; exitCode: number };
   printError: (msg: string) => void;
   /** Print an informational status message (no "Error:" prefix). Used for successful operations. */
@@ -93,6 +96,40 @@ export interface WorktreePruneResult {
 // ── Create ──
 
 /**
+ * Resolve the start point for a new worktree branch.
+ *
+ * During an active merge train the local default branch lags origin, so forking
+ * from local HEAD produces stale bases (#2679). Fetch origin's default branch
+ * and fork from `origin/<branch>` instead. Falls back to HEAD silently when the
+ * repo has no origin remote, and with a loud warning when the fetch fails
+ * (offline, auth, unreachable).
+ */
+export function resolveWorktreeStartPoint(repoRoot: string, deps: WorktreeShimDeps): string {
+  const remote = deps.exec(["git", "-C", repoRoot, "remote", "get-url", "origin"]);
+  if (remote.exitCode !== 0) return "HEAD";
+
+  const defaultBranch = getDefaultBranch(deps, repoRoot);
+  const fetch = deps.exec(["git", "-C", repoRoot, "fetch", "origin", defaultBranch], {
+    timeoutMs: WORKTREE_FETCH_TIMEOUT_MS,
+  });
+  if (fetch.exitCode !== 0) {
+    deps.printError(
+      `Warning: git fetch origin ${defaultBranch} failed — forking worktree from local HEAD, which may be stale (#2679): ${fetch.stderr.trim().slice(0, 200)}`,
+    );
+    return "HEAD";
+  }
+
+  const verify = deps.exec(["git", "-C", repoRoot, "rev-parse", "--verify", `refs/remotes/origin/${defaultBranch}`]);
+  if (verify.exitCode !== 0) {
+    deps.printError(
+      `Warning: origin/${defaultBranch} not found after fetch — forking worktree from local HEAD, which may be stale (#2679)`,
+    );
+    return "HEAD";
+  }
+  return `origin/${defaultBranch}`;
+}
+
+/**
  * Create a worktree for a provider session.
  *
  * Handles three cases:
@@ -136,8 +173,18 @@ export function createWorktree(opts: WorktreeCreateOptions, deps: WorktreeShimDe
   // Case 2: branchPrefix: false — create with raw branch name
   if (wtConfig?.branchPrefix === false) {
     const worktreePath = resolveWorktreePath(repoRoot, name, wtConfig);
+    const startPoint2 = resolveWorktreeStartPoint(repoRoot, deps);
     const bareBeforeAdd2 = isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd));
-    const { exitCode, stderr } = deps.exec(["git", "worktree", "add", worktreePath, "-b", name, "HEAD"]);
+    const { exitCode, stderr } = deps.exec([
+      "git",
+      "worktree",
+      "add",
+      "--no-track",
+      worktreePath,
+      "-b",
+      name,
+      startPoint2,
+    ]);
     if (exitCode !== 0) {
       throw new WorktreeError(`Failed to create worktree: ${stderr}`);
     }
@@ -172,8 +219,18 @@ export function createWorktree(opts: WorktreeCreateOptions, deps: WorktreeShimDe
   // Case 4: Shim creates worktree with prefixed branch name
   const worktreePath = resolveWorktreePath(repoRoot, name, wtConfig);
   const gitBranch = branchPrefix ? `${branchPrefix}${name}` : name;
+  const startPoint4 = resolveWorktreeStartPoint(repoRoot, deps);
   const bareBeforeAdd4 = isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd));
-  const { exitCode, stderr } = deps.exec(["git", "worktree", "add", worktreePath, "-b", gitBranch, "HEAD"]);
+  const { exitCode, stderr } = deps.exec([
+    "git",
+    "worktree",
+    "add",
+    "--no-track",
+    worktreePath,
+    "-b",
+    gitBranch,
+    startPoint4,
+  ]);
   if (exitCode !== 0) {
     throw new WorktreeError(`Failed to create worktree: ${stderr}`);
   }


### PR DESCRIPTION
## Summary
- `createWorktree` now resolves the fork point via a new `resolveWorktreeStartPoint`: it runs `git fetch origin <default-branch>` (bounded by a 15s timeout) and forks the new worktree branch from `origin/<branch>` with `--no-track`, instead of stale local `HEAD`.
- Fallbacks: silent `HEAD` when the repo has no `origin` remote; loud stderr warning + `HEAD` when the fetch fails (offline/unreachable) or the origin ref is missing after fetch.
- `WorktreeShimDeps.exec` / `SharedSessionDeps.exec` gain an optional `timeoutMs`, passed through to `spawnCaptureSync` so the fetch can't hang spawn.

Fixes the sprint-71 stale-base incidents (#2679): workers forked pre-merge bases during active merge trains, causing file resurrection on rebase and duplicate fix commits.

## Test plan
- [x] New `resolveWorktreeStartPoint` specs: origin happy path (asserts bounded fetch), non-main default branch (origin/master), no-remote silent fallback, fetch-failure warning fallback, missing-ref-after-fetch fallback
- [x] Updated `createWorktree` exact-arg assertions to `--no-track` + `origin/main`
- [x] Full `bun run am-i-done` gate passed 9/9 on this commit (140s run)
- [x] Pre-push gate note: three earlier gate runs failed only on the tracked load-induced flake #2703 (agent-grid replay 3s mock-worker init timeout, unrelated to this diff) while the host was pinned at load 10–16 by wedged Jun-9 bun-test workers (#2597). Push went through clean once load eased; data points filed on both issues. CI on clean runners is the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)