### PR TITLE
fix(phases): preserve per-item model assignment on impl phase-run path (fixes #2665)

### DIFF
--- a/.claude/phases/impl-fn.spec.ts
+++ b/.claude/phases/impl-fn.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { buildImplPrompt } from "./impl-fn";
+import { buildImplCommand, buildImplPrompt, resolveImplModel } from "./impl-fn";
 
 describe("buildImplPrompt", () => {
   test("includes the issue number", () => {
@@ -23,5 +23,73 @@ describe("buildImplPrompt", () => {
 
   test("resolve step references the correct pr number", () => {
     expect(buildImplPrompt(10, 99)).toContain("mcx pr comments 99 resolve --all-addressed");
+  });
+});
+
+describe("resolveImplModel", () => {
+  test("explicit input overrides everything", () => {
+    const r = resolveImplModel({ inputModel: "sonnet", stateModel: "opus", planModel: "fable", labels: [] });
+    expect(r.model).toBe("sonnet");
+    expect(r.override).toBeNull();
+  });
+
+  test("pre-set work-item state wins over the plan", () => {
+    const r = resolveImplModel({ stateModel: "claude-fable-5", planModel: "opus", labels: [] });
+    expect(r.model).toBe("claude-fable-5");
+    expect(r.override).toBeNull();
+  });
+
+  test("uses the sprint-plan model when no input/state is set", () => {
+    const r = resolveImplModel({ planModel: "claude-fable-5", labels: [] });
+    expect(r.model).toBe("claude-fable-5");
+  });
+
+  test("reports an override when the plan model differs from the heuristic", () => {
+    // #2665: a fable canary plan row must survive — not be narrowed to opus.
+    const r = resolveImplModel({ planModel: "claude-fable-5", labels: [] });
+    expect(r.override).toEqual({ planModel: "claude-fable-5", heuristic: "opus" });
+  });
+
+  test("no override when the plan model matches the heuristic", () => {
+    const r = resolveImplModel({ planModel: "opus", labels: [] });
+    expect(r.override).toBeNull();
+  });
+
+  test("falls back to the label heuristic when nothing is assigned", () => {
+    expect(resolveImplModel({ labels: [] }).model).toBe("opus");
+    expect(resolveImplModel({ labels: ["docs-only"] }).model).toBe("sonnet");
+    expect(resolveImplModel({ labels: ["flaky"] }).model).toBe("opus");
+  });
+});
+
+describe("buildImplCommand", () => {
+  test("a fable plan row yields a fable spawn command", () => {
+    // End-to-end of the #2665 fix: plan says fable → the emitted spawn command
+    // carries --model claude-fable-5, not the opus default.
+    const { model } = resolveImplModel({ planModel: "claude-fable-5", labels: [] });
+    const command = buildImplCommand({
+      provider: "claude",
+      model,
+      supportsWorktree: true,
+      prompt: "/implement 2645",
+      allowTools: ["Read", "Edit"],
+    });
+    const modelIdx = command.indexOf("--model");
+    expect(modelIdx).toBeGreaterThanOrEqual(0);
+    expect(command[modelIdx + 1]).toBe("claude-fable-5");
+    expect(command.slice(0, 2)).toEqual(["mcx", "claude"]);
+    expect(command).toContain("--worktree");
+  });
+
+  test("omits --worktree for providers that do not support it", () => {
+    const command = buildImplCommand({
+      provider: "gemini",
+      model: "opus",
+      supportsWorktree: false,
+      prompt: "/implement 1",
+      allowTools: ["Read"],
+    });
+    expect(command).not.toContain("--worktree");
+    expect(command.slice(0, 3)).toEqual(["mcx", "gemini", "spawn"]);
   });
 });

--- a/.claude/phases/impl-fn.ts
+++ b/.claude/phases/impl-fn.ts
@@ -1,9 +1,92 @@
 /** Core impl-phase logic, extracted for testability. */
 
+export type Provider = "claude" | "copilot" | "gemini" | "grok" | `acp:${string}`;
+
 export function buildImplPrompt(issueNumber: number, prNumber: number | null): string {
   const resolveStep =
     prNumber != null
       ? `\nAfter replying to each addressed thread, resolve it: mcx pr comments ${prNumber} resolve --all-addressed`
       : "";
   return `/implement ${issueNumber}${resolveStep}`;
+}
+
+export function commandForProvider(provider: Provider): string[] {
+  if (provider.startsWith("acp:")) {
+    const agent = provider.slice("acp:".length);
+    return ["mcx", "acp", "spawn", "--agent", agent];
+  }
+  return ["mcx", provider, "spawn"];
+}
+
+/**
+ * Label-based heuristic fallback when no model is assigned upstream.
+ *
+ * Flaky work always needs deep analysis (see run.md history). Orchestrator
+ * gate: a flaky issue must have a nerd-snipe root-cause comment on the issue
+ * before reaching this phase — see .claude/memory/feedback_flaky_tests.md and
+ * run.md "Flaky / CI-instability issues — nerd-snipe gate before impl".
+ * Without it, expect symptom-masking patches (sprint 47 / #1870).
+ */
+export function pickModelFromLabels(labels: string[]): string {
+  if (labels.includes("flaky")) return "opus";
+  if (labels.includes("docs-only") || labels.includes("documentation")) return "sonnet";
+  return "opus";
+}
+
+export interface ModelResolution {
+  model: string;
+  /**
+   * Set when the sprint-plan model was used and it differs from the label
+   * heuristic — i.e. the plan deliberately overrode the default. Drives the
+   * "model override" log line so a canary mismatch is never silent (#2665).
+   */
+  override: { planModel: string; heuristic: string } | null;
+}
+
+/**
+ * Resolve the model for an impl spawn (first match wins):
+ *   1. explicit input override
+ *   2. pre-set work-item state (mcx track / prior call)
+ *   3. sprint plan Model column
+ *   4. label-based heuristic
+ *
+ * Any non-empty string is accepted at each tier so per-item assignments like a
+ * `claude-fable-5` canary survive instead of being narrowed back to opus/sonnet.
+ */
+export function resolveImplModel(opts: {
+  inputModel?: string;
+  stateModel?: string | null;
+  planModel?: string | null;
+  labels: string[];
+}): ModelResolution {
+  if (opts.inputModel) return { model: opts.inputModel, override: null };
+  if (opts.stateModel) return { model: opts.stateModel, override: null };
+
+  const heuristic = pickModelFromLabels(opts.labels);
+  if (opts.planModel) {
+    return {
+      model: opts.planModel,
+      override: opts.planModel !== heuristic ? { planModel: opts.planModel, heuristic } : null,
+    };
+  }
+  return { model: heuristic, override: null };
+}
+
+export function buildImplCommand(opts: {
+  provider: Provider;
+  model: string;
+  supportsWorktree: boolean;
+  prompt: string;
+  allowTools: string[];
+}): string[] {
+  return [
+    ...commandForProvider(opts.provider),
+    ...(opts.supportsWorktree ? ["--worktree"] : []),
+    "--model",
+    opts.model,
+    "-t",
+    opts.prompt,
+    "--allow",
+    ...opts.allowTools,
+  ];
 }

--- a/.claude/phases/impl.ts
+++ b/.claude/phases/impl.ts
@@ -9,12 +9,15 @@
  * The handler is idempotent on re-entry: if `session_id` is already set in
  * state, it returns the existing session plus `action: "in-flight"`.
  *
- * Model resolution order (first match wins):
+ * Model resolution order (first match wins, see resolveImplModel):
  *   1. `input.model` — explicit override from the orchestrator
  *   2. `ctx.state.get("model")` — pre-populated by a prior call or mcx track
- *   3. Sprint plan table — reads the latest `.claude/sprints/sprint-*.md` and
- *      locates the Model column for this issue number (fixes #1437)
- *   4. `pickModel(labels)` — label-based heuristic fallback
+ *   3. Sprint plan table — the Model column for this issue, any Claude model
+ *      shortname or full ID, e.g. a `claude-fable-5` canary (fixes #1437, #2665)
+ *   4. label-based heuristic fallback
+ *
+ * When the sprint plan overrides the heuristic default, a `model override`
+ * line is logged so a per-item canary assignment is never silently dropped.
  *
  * State writes (this handler): model, provider, labels, session_id sentinel.
  * Orchestrator responsibility: replace session_id "pending:*" with the real
@@ -23,9 +26,7 @@
  */
 import { NO_REPO_ROOT, findModelInSprintPlan } from "@mcp-cli/core";
 import { defineAlias, z } from "mcp-cli";
-import { buildImplPrompt } from "./impl-fn";
-
-type Provider = "claude" | "copilot" | "gemini" | "grok" | `acp:${string}`;
+import { type Provider, buildImplCommand, buildImplPrompt, resolveImplModel } from "./impl-fn";
 
 const ProviderSchema = z
   .string()
@@ -36,41 +37,20 @@ const ProviderSchema = z
     },
   );
 
-function commandForProvider(provider: Provider): string[] {
-  if (provider.startsWith("acp:")) {
-    const agent = provider.slice("acp:".length);
-    return ["mcx", "acp", "spawn", "--agent", agent];
-  }
-  return ["mcx", provider, "spawn"];
-}
-
-function pickModel(labels: string[]): "opus" | "sonnet" {
-  // Flaky work always needs deep analysis (see run.md history).
-  // Orchestrator gate: a flaky issue must have a nerd-snipe root-cause
-  // comment on the issue before reaching this phase — see
-  // .claude/memory/feedback_flaky_tests.md and run.md "Flaky / CI-instability
-  // issues — nerd-snipe gate before impl". Without it, expect symptom-masking
-  // patches (sprint 47 / #1870).
-  if (labels.includes("flaky")) return "opus";
-  // Docs-only is cheap; everything else defaults to opus.
-  if (labels.includes("docs-only") || labels.includes("documentation")) return "sonnet";
-  return "opus";
-}
-
 defineAlias({
   name: "phase-impl",
   description: "Sprint phase: spawn implementation session for a tracked issue.",
   input: z.object({
     provider: ProviderSchema.default("claude"),
     labels: z.array(z.string()).default([]),
-    model: z.enum(["opus", "sonnet"]).optional(),
+    model: z.string().optional(),
   }),
   output: z.object({
     action: z.enum(["spawn", "in-flight"]),
     command: z.array(z.string()),
     allowTools: z.array(z.string()),
     prompt: z.string(),
-    model: z.enum(["opus", "sonnet"]),
+    model: z.string(),
     provider: ProviderSchema,
     sessionId: z.string().optional(),
     worktreePath: z.string().optional(),
@@ -88,41 +68,33 @@ defineAlias({
         command: [],
         allowTools: [],
         prompt: "",
-        model: ((await ctx.state.get<string>("model")) as "opus" | "sonnet") ?? "opus",
+        model: (await ctx.state.get<string>("model")) ?? "opus",
         provider: ((await ctx.state.get<string>("provider")) as Provider) ?? input.provider,
         sessionId: existing,
         worktreePath: (await ctx.state.get<string>("worktree_path")) ?? undefined,
       };
     }
 
-    // Resolve model: explicit input → pre-set state → sprint plan → label heuristic
-    let model: "opus" | "sonnet";
-    if (input.model) {
-      model = input.model;
-    } else {
-      const stateModel = await ctx.state.get<string>("model");
-      if (stateModel === "opus" || stateModel === "sonnet") {
-        model = stateModel;
-      } else {
-        const planModel = ctx.repoRoot !== NO_REPO_ROOT ? findModelInSprintPlan(work.issueNumber, ctx.repoRoot) : null;
-        model = planModel ?? pickModel(input.labels);
-      }
+    const stateModel = await ctx.state.get<string>("model");
+    const planModel =
+      ctx.repoRoot !== NO_REPO_ROOT ? findModelInSprintPlan(work.issueNumber, ctx.repoRoot) : null;
+    const { model, override } = resolveImplModel({
+      inputModel: input.model,
+      stateModel,
+      planModel,
+      labels: input.labels,
+    });
+    if (override) {
+      console.error(
+        `work item #${work.issueNumber} model override: ${override.planModel} (default: ${override.heuristic})`,
+      );
     }
 
     const provider = input.provider;
     const supportsWorktree = provider === "claude";
     const allowTools = ["Read", "Glob", "Grep", "Write", "Edit", "Bash", "ExitPlanMode", "EnterPlanMode"];
     const prompt = buildImplPrompt(work.issueNumber, work.prNumber ?? null);
-    const command = [
-      ...commandForProvider(provider),
-      ...(supportsWorktree ? ["--worktree"] : []),
-      "--model",
-      model,
-      "-t",
-      prompt,
-      "--allow",
-      ...allowTools,
-    ];
+    const command = buildImplCommand({ provider, model, supportsWorktree, prompt, allowTools });
 
     await ctx.state.set("provider", provider);
     await ctx.state.set("model", model);

--- a/packages/core/src/sprint-plan.spec.ts
+++ b/packages/core/src/sprint-plan.spec.ts
@@ -48,9 +48,24 @@ describe("parseModelFromSprintTable", () => {
     expect(parseModelFromSprintTable(upper, 1437)).toBe("sonnet");
   });
 
-  test("returns null for unknown model values", () => {
+  test("returns null for unknown / non-Claude model values", () => {
     const bad = "| # | Title | Model |\n|---|-------|-------|\n| 1437 | foo | gpt4 |\n";
     expect(parseModelFromSprintTable(bad, 1437)).toBeNull();
+  });
+
+  test("returns a fable shortname assignment", () => {
+    const fable = "| # | Title | Model |\n|---|-------|-------|\n| 2645 | canary | fable |\n";
+    expect(parseModelFromSprintTable(fable, 2645)).toBe("fable");
+  });
+
+  test("returns a full Claude model ID verbatim", () => {
+    const fullId = "| # | Title | Model |\n|---|-------|-------|\n| 2645 | canary | claude-fable-5 |\n";
+    expect(parseModelFromSprintTable(fullId, 2645)).toBe("claude-fable-5");
+  });
+
+  test("returns a haiku shortname assignment", () => {
+    const haiku = "| # | Title | Model |\n|---|-------|-------|\n| 2645 | filler | haiku |\n";
+    expect(parseModelFromSprintTable(haiku, 2645)).toBe("haiku");
   });
 
   test("handles multiple tables — picks correct one", () => {

--- a/packages/core/src/sprint-plan.ts
+++ b/packages/core/src/sprint-plan.ts
@@ -2,12 +2,27 @@
  * Utilities for reading the sprint plan markdown file.
  *
  * Sprint plans live at `.claude/sprints/sprint-<N>.md` and contain a markdown
- * table with a `#` column (issue number) and a `Model` column (opus/sonnet).
- * The impl phase uses these to pick the right model per issue (#1437).
+ * table with a `#` column (issue number) and a `Model` column. The impl phase
+ * uses these to pick the right model per issue (#1437). The Model column may
+ * name any Claude model — a shortname (`opus`, `sonnet`, `fable`, `haiku`) or a
+ * full ID (`claude-fable-5`) — not just opus/sonnet, so per-item canary
+ * assignments (e.g. a fable A/B run) survive the phase-run path (#2665).
  */
 
 import { readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
+import { MODEL_SHORTNAMES } from "./model";
+
+/**
+ * A Model-column cell counts as a model when it is a known shortname or a full
+ * Claude model ID. Unrecognized values (typos, non-Claude names like "gpt4")
+ * are ignored so the impl phase falls back to its label heuristic rather than
+ * forwarding a bad `--model` value.
+ */
+function isRecognizedModel(value: string): boolean {
+  if (value in MODEL_SHORTNAMES) return true;
+  return /^claude-[a-z0-9.-]+$/.test(value);
+}
 
 /**
  * Parse the Model column from a sprint plan markdown table for the given issue.
@@ -16,9 +31,9 @@ import { join } from "node:path";
  * Multiple tables per file are supported — each non-table line between
  * table blocks resets column state so the next table header is picked up.
  *
- * Returns "opus" | "sonnet" | null.
+ * Returns the recognized model name verbatim (shortname or full ID), or null.
  */
-export function parseModelFromSprintTable(text: string, issueNumber: number): "opus" | "sonnet" | null {
+export function parseModelFromSprintTable(text: string, issueNumber: number): string | null {
   let modelColIdx = -1;
   let issueColIdx = -1;
 
@@ -58,7 +73,7 @@ export function parseModelFromSprintTable(text: string, issueNumber: number): "o
     if (!numMatch || Number.parseInt(numMatch[0], 10) !== issueNumber) continue;
 
     const modelCell = (cols[modelColIdx] ?? "").toLowerCase().trim();
-    if (modelCell === "opus" || modelCell === "sonnet") return modelCell;
+    if (modelCell && isRecognizedModel(modelCell)) return modelCell;
   }
 
   return null;
@@ -68,7 +83,7 @@ export function parseModelFromSprintTable(text: string, issueNumber: number): "o
  * Scan `.claude/sprints/sprint-*.md` files (latest sprint first) and return
  * the model declared for the given issue number, or null if not found.
  */
-export function findModelInSprintPlan(issueNumber: number, repoRoot: string): "opus" | "sonnet" | null {
+export function findModelInSprintPlan(issueNumber: number, repoRoot: string): string | null {
   const sprintDir = join(repoRoot, ".claude", "sprints");
   let files: string[];
   try {


### PR DESCRIPTION
## Summary
- `mcx phase run impl` no longer drops a per-item model assignment from the sprint plan. `parseModelFromSprintTable` / `findModelInSprintPlan` previously narrowed the Model column to `opus|sonnet`, so a canary row like `claude-fable-5` was silently coerced to the `opus` default — invalidating A/B model experiments with no log or error (#2665).
- Parser now returns any recognized Claude model verbatim — shortname (`fable`, `haiku`, `opus`, `sonnet`) or full ID (`claude-fable-5`). Unrecognized / non-Claude values (e.g. `gpt4`) still fall through to the label heuristic so a typo can't forward a bad `--model`.
- Extracted `resolveImplModel` + `buildImplCommand` into `impl-fn.ts` (testable seam); `impl.ts` widens the `model` field from the `opus|sonnet` enum to a string and logs `work item #N model override: <model> (default: <heuristic>)` when the plan overrides the heuristic, so a canary mismatch is never silent.

## Test plan
- [x] `parseModelFromSprintTable` recognizes fable / haiku shortnames and full `claude-fable-5` IDs; still returns null for `gpt4`
- [x] `resolveImplModel` precedence (input → state → plan → heuristic) and override reporting
- [x] End-to-end: a `claude-fable-5` plan row yields a `--model claude-fable-5` spawn command
- [x] Full `bun run am-i-done` gate passed all 9 steps locally (167s) and the pre-push gate passed all 6 steps (45s)

> Note on host load: during this work the shared host was saturated by concurrent worktree sessions, intermittently triggering the documented Bun worker-crash cascade (#2641/#2644) plus the known-flaky `replayThroughMock` test (#2703). Those are environmental — all changed-code specs pass in isolation and a clean full gate run passed. CI on clean runners is the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)