### PR TITLE
fix(agent-grid): separate Phase-1 init budget from Phase-2 wait in replayThroughMock (fixes #2703)

### DIFF
--- a/agent-grid/src/replay.spec.ts
+++ b/agent-grid/src/replay.spec.ts
@@ -707,9 +707,12 @@ describe("replayThroughMock", () => {
   });
 
   test("short Phase-2 timeoutMs does not starve the Phase-1 init handshake (#2703)", async () => {
-    // Worker whose ready arrives well after the Phase-2 budget — stands in for
-    // spawn/transpile latency under parallel suite load. Init must be governed
-    // by initTimeoutMs (default 10s), not the short Phase-2 timeoutMs.
+    // Worker whose ready arrives 250ms after init — a stand-in for
+    // spawn/transpile latency under parallel suite load. The recording's only
+    // expected message (ready) is collected during Phase 1, so Phase 2 is
+    // never entered: timeoutMs: 50 exists solely to prove the Phase-1 init
+    // deadline no longer reads it. On pre-fix code this fails in ~50ms with
+    // "mock worker init timeout"; with initTimeoutMs (default 10s) it passes.
     const slowInitWorkerPath = tmpFile("slow-init-worker.ts");
     writeFileSync(
       slowInitWorkerPath,
@@ -728,7 +731,7 @@ describe("replayThroughMock", () => {
 
     const report = await replayThroughMock(entries, "slow-init.ndjson", {
       workerPath: slowInitWorkerPath,
-      timeoutMs: 50, // far below the worker's init latency — must only bound Phase 2
+      timeoutMs: 50, // far below the worker's init latency — must not cap Phase 1
     });
 
     expect(report.pass).toBe(true);

--- a/agent-grid/src/replay.spec.ts
+++ b/agent-grid/src/replay.spec.ts
@@ -705,6 +705,35 @@ describe("replayThroughMock", () => {
     // Crash must surface as mock-worker-crash, not silently as count mismatch alone
     expect(report.violations.some((v) => v.rule === "mock-worker-crash")).toBe(true);
   });
+
+  test("short Phase-2 timeoutMs does not starve the Phase-1 init handshake (#2703)", async () => {
+    // Worker whose ready arrives well after the Phase-2 budget — stands in for
+    // spawn/transpile latency under parallel suite load. Init must be governed
+    // by initTimeoutMs (default 10s), not the short Phase-2 timeoutMs.
+    const slowInitWorkerPath = tmpFile("slow-init-worker.ts");
+    writeFileSync(
+      slowInitWorkerPath,
+      `self.onmessage = async (ev) => {
+  if (ev.data?.type === "init") {
+    await new Promise((r) => setTimeout(r, 250));
+    self.postMessage({ type: "ready", supported_protocol_version: 1 });
+  }
+};`,
+    );
+
+    const entries: RecordingEntry[] = [
+      entry({ dir: "daemon->worker", kind: "control", payload: { type: "init", protocol_version: 1 } }),
+      entry({ dir: "worker->daemon", kind: "control", payload: { type: "ready", supported_protocol_version: 1 } }),
+    ];
+
+    const report = await replayThroughMock(entries, "slow-init.ndjson", {
+      workerPath: slowInitWorkerPath,
+      timeoutMs: 50, // far below the worker's init latency — must only bound Phase 2
+    });
+
+    expect(report.pass).toBe(true);
+    expect(report.violations).toEqual([]);
+  });
 });
 
 // ── parseRecording ────────────────────────────────────────────────

--- a/agent-grid/src/replay.ts
+++ b/agent-grid/src/replay.ts
@@ -460,7 +460,20 @@ function defaultMockWorkerPath(): string {
 
 export interface ReplayThroughMockOptions {
   workerPath?: string;
+  /**
+   * Budget for the Phase-2 message wait — how long to wait for the worker to
+   * emit the expected number of messages before concluding it went silent.
+   * Tests exercising crash/count-mismatch paths set this low to bound the
+   * worst-case wait; it must NOT cap worker startup (see initTimeoutMs).
+   */
   timeoutMs?: number;
+  /**
+   * Budget for the Phase-1 init/ready handshake, which includes spawning and
+   * transpiling the worker file — load-sensitive under a parallel test suite
+   * (#2703). Kept separate from timeoutMs so a short Phase-2 budget never
+   * starves worker startup.
+   */
+  initTimeoutMs?: number;
 }
 
 export async function replayThroughMock(
@@ -471,6 +484,7 @@ export async function replayThroughMock(
   const violations: ReplayViolation[] = [];
   const workerFile = opts?.workerPath ?? defaultMockWorkerPath();
   const timeoutMs = opts?.timeoutMs ?? 10_000;
+  const initTimeoutMs = opts?.initTimeoutMs ?? 10_000;
 
   const daemonEntries = entries.filter((e) => e.dir === "daemon->worker");
   const expectedWorkerEntries = entries.filter((e) => e.dir === "worker->daemon");
@@ -513,7 +527,7 @@ export async function replayThroughMock(
     const readyResult = await new Promise<"ready" | "error">((resolve, reject) => {
       const timer = setTimeout(() => {
         reject(new Error("mock worker init timeout"));
-      }, timeoutMs);
+      }, initTimeoutMs);
 
       w.onmessage = (event: MessageEvent) => {
         const data = event.data;


### PR DESCRIPTION
## Problem

`replayThroughMock` used a single `timeoutMs` for two unrelated waits:
- **Phase 1**: deadline on the worker init/ready handshake (includes spawning + transpiling the worker file — load-sensitive)
- **Phase 2**: fallback wait for the worker to emit the expected message count (the "went silent" detector)

Tests bounding the Phase-2 worst case (`timeoutMs: 3000` in the crash test, `500` in the count-mismatch test) therefore also capped worker startup at 3s/500ms. Under the suite's `--max-concurrency=20`, Phase-1 reliably exceeds 3s → the `mock worker init timeout` flake (#2703), which fired 7+ times across 5 branches on 2026-06-11 and hard-blocked pushes from core-touching branches.

## Fix

New `initTimeoutMs` option (default 10s) owns the Phase-1 deadline. `timeoutMs` now bounds only the Phase-2 message wait. No caller changes needed — existing short budgets keep bounding exactly what they meant to bound.

The init wait was already event-driven (resolve-on-ready), so the issue's `pollUntil` prescription didn't apply — the bug was budget-sharing, not time-based waiting.

## Verification

- New regression test: worker delays `ready` past the Phase-2 budget (`timeoutMs: 50`); init must survive on the default `initTimeoutMs`. Fails in 83ms on the old code, passes with the fix.
- `bun run am-i-done` green (134s, 10/10 steps), pre-push gate green on push.

Fixes #2703

🤖 Generated with [Claude Code](https://claude.com/claude-code)