### PR TITLE
chore(skill): mechanical guard for the introspection cadence (closes #2506)

### DIFF
--- a/.claude/skills/sprint/references/retro.md
+++ b/.claude/skills/sprint/references/retro.md
@@ -224,16 +224,31 @@ git worktree remove .claude/worktrees/sprint-{N}
 git branch -D sprint-{N}   # local branch (remote was --delete-branch'd by gh pr merge)
 ```
 
-## Introspection cadence (sprints ending in 7)
+## Introspection cadence (sprints ending in 7) — MECHANICALLY GATED
 
 If the sprint number ends in 7 (17, 27, 37, 47, ~~57~~ (skipped — see #2506), 67…), queue a
 code-first introspection round to feed the *next* sprint's plan. The round
 runs as part of this retro: spawn one Explore agent with the prompt template
 at `.claude/skills/sprint/references/introspection.md`, triage findings with
 the user, and file the load-bearing ones as initiative issues. They land in
-sprint-{N+1}'s plan as Bucket-1 candidates.
+sprint-{N+1}'s plan as Bucket-1 candidates. The round's tracking issue must
+be titled like `epic: sprint-{N} introspection round — tracking` (the #2511
+convention) — that title is what the mechanical guard matches.
 
-Skip if the sprint number does not end in 7.
+**Load-bearing guard (#2506) — run for EVERY retro, before clearing the
+sprint sentinel:**
+
+```bash
+bun scripts/check-introspection-round.ts {N}
+```
+
+Exit 1 **blocks the retro** — it means the sprint ends in 7 and no
+introspection-round tracking issue exists (or GitHub was unreachable). Run
+the round and file its tracking issue, then re-run the guard. Do not clear
+the sentinel or convert the sprint PR to ready while this fails. For sprints
+not ending in 7 the guard exits 0 immediately — running it unconditionally is
+what makes the cadence skip-proof (the sprint-57 round was lost because the
+check was prose-only).
 
 The first round (sprint 47 → sprint 48) produced #1856–#1866; #1867 tracks
 the cadence. See `introspection.md` for the prompt + triage flow.

--- a/scripts/check-introspection-round.spec.ts
+++ b/scripts/check-introspection-round.spec.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import { type IssueRef, findTrackingIssue, isIntrospectionSprint, runCheck } from "./check-introspection-round";
+
+const ROUND_67: IssueRef = {
+  number: 2511,
+  title: "epic: sprint-67 introspection round (code-first + transcript) — tracking",
+};
+const CADENCE_META: IssueRef = {
+  number: 1867,
+  title: "meta: every 10 sprints, run code-first introspection + file initiatives (next: sprint 57)",
+};
+
+function capture(): { sink: (s: string) => void; text: () => string } {
+  const chunks: string[] = [];
+  return {
+    sink: (s) => {
+      chunks.push(s);
+    },
+    text: () => chunks.join(""),
+  };
+}
+
+describe("isIntrospectionSprint", () => {
+  test("true only for positive integers ending in 7", () => {
+    expect(isIntrospectionSprint(7)).toBe(true);
+    expect(isIntrospectionSprint(57)).toBe(true);
+    expect(isIntrospectionSprint(77)).toBe(true);
+    expect(isIntrospectionSprint(73)).toBe(false);
+    expect(isIntrospectionSprint(70)).toBe(false);
+    expect(isIntrospectionSprint(0)).toBe(false);
+    expect(isIntrospectionSprint(-7)).toBe(false);
+    expect(isIntrospectionSprint(7.7)).toBe(false);
+  });
+});
+
+describe("findTrackingIssue", () => {
+  test("matches the #2511 round-issue convention", () => {
+    expect(findTrackingIssue([CADENCE_META, ROUND_67], 67)).toEqual(ROUND_67);
+  });
+
+  test("accepts 'sprint 67' with a space", () => {
+    const issue: IssueRef = { number: 9, title: "sprint 67 introspection round" };
+    expect(findTrackingIssue([issue], 67)).toEqual(issue);
+  });
+
+  test("does NOT match the cadence meta-issue via its '(next: sprint 57)' suffix", () => {
+    // The sprint-57 round was skipped; #1867 mentioning "sprint 57" must not
+    // count as evidence that it ran (#2506 root cause).
+    expect(findTrackingIssue([CADENCE_META], 57)).toBeNull();
+  });
+
+  test("requires the sprint number as a whole word", () => {
+    expect(findTrackingIssue([ROUND_67], 6)).toBeNull();
+    expect(findTrackingIssue([ROUND_67], 7)).toBeNull();
+  });
+
+  test("requires 'introspection round' in the title", () => {
+    const vague: IssueRef = { number: 5, title: "sprint-77 introspection ideas" };
+    expect(findTrackingIssue([vague], 77)).toBeNull();
+  });
+});
+
+describe("runCheck", () => {
+  test("passes without listing issues when sprint does not end in 7", async () => {
+    const out = capture();
+    let listed = false;
+    const code = await runCheck(
+      73,
+      async () => {
+        listed = true;
+        return [];
+      },
+      out.sink,
+      out.sink,
+    );
+    expect(code).toBe(0);
+    expect(listed).toBe(false);
+    expect(out.text()).toContain("does not end in 7");
+  });
+
+  test("passes when a tracking issue exists", async () => {
+    const out = capture();
+    const code = await runCheck(67, async () => [CADENCE_META, ROUND_67], out.sink, out.sink);
+    expect(code).toBe(0);
+    expect(out.text()).toContain("#2511");
+  });
+
+  test("fails when sprint ends in 7 and no tracking issue exists", async () => {
+    const err = capture();
+    const code = await runCheck(77, async () => [CADENCE_META, ROUND_67], err.sink, err.sink);
+    expect(code).toBe(1);
+    expect(err.text()).toContain("BLOCKED");
+    expect(err.text()).toContain("sprint-77 introspection round");
+  });
+
+  test("fails closed when gh is unreachable", async () => {
+    const err = capture();
+    const code = await runCheck(77, async () => null, err.sink, err.sink);
+    expect(code).toBe(1);
+    expect(err.text()).toContain("do not proceed blind");
+  });
+
+  test("rejects a missing/garbage sprint argument", async () => {
+    const err = capture();
+    const code = await runCheck(Number.NaN, async () => [], err.sink, err.sink);
+    expect(code).toBe(1);
+    expect(err.text()).toContain("usage:");
+  });
+});

--- a/scripts/check-introspection-round.ts
+++ b/scripts/check-introspection-round.ts
@@ -1,0 +1,137 @@
+#!/usr/bin/env bun
+/**
+ * check-introspection-round — mechanical guard for the introspection cadence (#2506).
+ *
+ * The sprint skill requires a code-first introspection round during the retro of
+ * every sprint whose number ends in 7 (see
+ * .claude/skills/sprint/references/introspection.md). The sprint-57 round was
+ * skipped silently because the cadence was prose-only. This script makes the
+ * check load-bearing: the retro runs it before clearing the sprint sentinel and
+ * MUST NOT proceed on a non-zero exit.
+ *
+ * A round is evidenced by a tracking issue whose title contains
+ * "introspection round" and the sprint number ("sprint-67" / "sprint 67"),
+ * following the #2511 convention ("epic: sprint-67 introspection round … —
+ * tracking"). The cadence meta-issue #1867 intentionally does NOT match (its
+ * "(next: sprint 57)" suffix is what a naive matcher would have false-passed
+ * on for the exact round that was skipped).
+ *
+ * Usage:  bun scripts/check-introspection-round.ts <sprint-number>
+ *
+ * Exit 0: sprint doesn't end in 7, or a tracking issue exists.
+ * Exit 1: sprint ends in 7 and no tracking issue found (or gh unreachable).
+ */
+
+const GH_TIMEOUT_MS = 10_000;
+
+export interface IssueRef {
+  number: number;
+  title: string;
+}
+
+export type IssueLister = () => Promise<IssueRef[] | null>;
+
+/** Output sink — defaults write to the process streams; tests inject a capturing buffer. */
+export type Sink = (s: string) => void;
+
+export function isIntrospectionSprint(sprint: number): boolean {
+  return Number.isInteger(sprint) && sprint > 0 && sprint % 10 === 7;
+}
+
+export function findTrackingIssue(issues: IssueRef[], sprint: number): IssueRef | null {
+  const sprintRe = new RegExp(`sprint[-\\s]${sprint}\\b`, "i");
+  for (const issue of issues) {
+    if (!/introspection round/i.test(issue.title)) continue;
+    if (!sprintRe.test(issue.title)) continue;
+    return issue;
+  }
+  return null;
+}
+
+export async function listIntrospectionIssuesViaGh(): Promise<IssueRef[] | null> {
+  const proc = Bun.spawn(
+    [
+      "gh",
+      "issue",
+      "list",
+      "--state",
+      "all",
+      "--search",
+      "introspection in:title",
+      "--json",
+      "number,title",
+      "--limit",
+      "100",
+    ],
+    { stdout: "pipe", stderr: "pipe" },
+  );
+  const timer = setTimeout(() => proc.kill(), GH_TIMEOUT_MS);
+  try {
+    const exitCode = await proc.exited;
+    if (exitCode !== 0) return null;
+    const text = await new Response(proc.stdout).text();
+    const parsed: unknown = JSON.parse(text);
+    if (!Array.isArray(parsed)) return null;
+    const refs: IssueRef[] = [];
+    for (const entry of parsed) {
+      if (typeof entry !== "object" || entry === null) continue;
+      const num = (entry as Record<string, unknown>).number;
+      const title = (entry as Record<string, unknown>).title;
+      if (typeof num !== "number" || typeof title !== "string") continue;
+      refs.push({ number: num, title });
+    }
+    return refs;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+const defaultOut: Sink = (s) => {
+  process.stdout.write(s);
+};
+const defaultErr: Sink = (s) => {
+  process.stderr.write(s);
+};
+
+export async function runCheck(
+  sprint: number,
+  listIssues: IssueLister,
+  out: Sink = defaultOut,
+  err: Sink = defaultErr,
+): Promise<number> {
+  if (!Number.isInteger(sprint) || sprint <= 0) {
+    err("usage: bun scripts/check-introspection-round.ts <sprint-number>\n");
+    return 1;
+  }
+  if (!isIntrospectionSprint(sprint)) {
+    out(`✓ sprint ${sprint} does not end in 7 — no introspection round required\n`);
+    return 0;
+  }
+
+  const issues = await listIssues();
+  if (issues === null) {
+    err("✗ could not reach GitHub API — cannot verify the introspection round; do not proceed blind\n");
+    return 1;
+  }
+
+  const tracking = findTrackingIssue(issues, sprint);
+  if (tracking !== null) {
+    out(`✓ sprint ${sprint} introspection round tracked by #${tracking.number}: ${tracking.title}\n`);
+    return 0;
+  }
+
+  err(`✗ sprint ${sprint} ends in 7 but no introspection-round tracking issue exists.\n`);
+  err("  The retro is BLOCKED until the round runs (see .claude/skills/sprint/references/introspection.md).\n");
+  err(
+    `  Run the round, then file its tracking issue titled like: "epic: sprint-${sprint} introspection round — tracking"\n`,
+  );
+  return 1;
+}
+
+if (import.meta.main) {
+  const sprint = Number.parseInt(process.argv[2] ?? "", 10);
+  const code = await runCheck(sprint, listIntrospectionIssuesViaGh);
+  process.exit(code);
+}


### PR DESCRIPTION
Applies meta-fix #2506 (user-approved at sprint-73 plan time).

Adds `scripts/check-introspection-round.ts` + spec: exits 1 when sprint N ends in 7 and no "sprint-N introspection round" tracking issue exists (the #2511 title convention — deliberately does NOT match #1867's "(next: sprint 57)" suffix, the false-pass that let the sprint-57 round vanish undetected). `retro.md` now runs it unconditionally before clearing the sprint sentinel, making the cadence skip-proof instead of prose-only.

Verified live: sprint 73 → pass (not ending in 7), 67 → pass (finds #2511), 77 → exit 1 (blocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)