### PR TITLE
feat(rules): no-db-ipc-cast — ban field-level as-casts on DB/IPC reads (closes #2622)

### DIFF
--- a/packages/clone/src/engine/cache.ts
+++ b/packages/clone/src/engine/cache.ts
@@ -58,6 +58,7 @@ CREATE TABLE IF NOT EXISTS scope_meta (
 /** Normalize SQLite INTEGER to boolean for isStub. */
 function normalizeEntry(row: Record<string, unknown> | null): CachedEntry | null {
   if (!row) return null;
+  // dotw-todo no-db-ipc-cast: unguarded isStub restore cast — fix in #2742
   return { ...row, isStub: !!(row.isStub as number) } as CachedEntry;
 }
 

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -879,6 +879,7 @@ export class StateDb {
         description: row.description ?? "",
         filePath: row.file_path,
         updatedAt: row.updated_at,
+        // dotw-todo no-db-ipc-cast: unguarded alias_type restore cast — fix in #2742
         aliasType: row.alias_type as AliasType,
         ...(row.input_schema_json ? { inputSchemaJson: safeJsonParse(row.input_schema_json, {}) } : {}),
         ...(row.output_schema_json ? { outputSchemaJson: safeJsonParse(row.output_schema_json, {}) } : {}),
@@ -932,6 +933,7 @@ export class StateDb {
       name: row.name,
       description: row.description ?? "",
       filePath: row.file_path,
+      // dotw-todo no-db-ipc-cast: unguarded alias_type restore cast — fix in #2742
       aliasType: row.alias_type as AliasType,
       ...(row.bundled_js ? { bundledJs: row.bundled_js } : {}),
       ...(row.source_hash ? { sourceHash: row.source_hash } : {}),

--- a/packages/daemon/src/db/work-items.ts
+++ b/packages/daemon/src/db/work-items.ts
@@ -88,7 +88,7 @@ function rowToWorkItem(row: WorkItemRow): WorkItem {
     ciSummary: row.ci_summary,
     // dotw-todo no-db-ipc-cast: unguarded review_status restore cast — fix in #2742
     reviewStatus: row.review_status as ReviewStatus,
-    // dotw-todo no-db-ipc-cast: cast bypasses the ?? null fallback (#2602 shape) — fix in #2742
+    // dotw-todo no-db-ipc-cast: cast bypasses the ?? null fallback for non-null garbage — fix in #2742
     mergeStateStatus: (row.merge_state_status as MergeStateStatus) ?? null,
     // dotw-todo no-db-ipc-cast: unguarded phase restore cast (load-bearing for sprint pipeline) — fix in #2742
     phase: row.phase as WorkItemPhase,

--- a/packages/daemon/src/db/work-items.ts
+++ b/packages/daemon/src/db/work-items.ts
@@ -79,13 +79,18 @@ function rowToWorkItem(row: WorkItemRow): WorkItem {
     issueNumber: row.issue_number,
     branch: row.branch,
     prNumber: row.pr_number,
+    // dotw-todo no-db-ipc-cast: unguarded pr_state restore cast — fix in #2742
     prState: row.pr_state as PrState,
     prUrl: row.pr_url,
+    // dotw-todo no-db-ipc-cast: unguarded ci_status restore cast — fix in #2742
     ciStatus: row.ci_status as CiStatus,
     ciRunId: row.ci_run_id,
     ciSummary: row.ci_summary,
+    // dotw-todo no-db-ipc-cast: unguarded review_status restore cast — fix in #2742
     reviewStatus: row.review_status as ReviewStatus,
+    // dotw-todo no-db-ipc-cast: cast bypasses the ?? null fallback (#2602 shape) — fix in #2742
     mergeStateStatus: (row.merge_state_status as MergeStateStatus) ?? null,
+    // dotw-todo no-db-ipc-cast: unguarded phase restore cast (load-bearing for sprint pipeline) — fix in #2742
     phase: row.phase as WorkItemPhase,
     automationOverrides: row.automation_overrides ?? null,
     createdAt: row.created_at,

--- a/scripts/rules/fixtures/no-db-ipc-cast__clean.fixture.ts
+++ b/scripts/rules/fixtures/no-db-ipc-cast__clean.fixture.ts
@@ -1,0 +1,36 @@
+/**
+ * @rule no-db-ipc-cast
+ * @expect 0
+ * @path packages/daemon/src/db/example.ts
+ *
+ * Known-good shapes: runtime guards, `as unknown` re-narrowing flows,
+ * whole-row contract casts, and `as const`.
+ */
+
+import { Database } from "bun:sqlite";
+
+type Transport = "ws" | "stdio";
+
+interface SessionRow {
+  transport: string | null;
+}
+
+function isTransport(v: unknown): v is Transport {
+  return v === "ws" || v === "stdio";
+}
+
+const DEFAULT_TRANSPORT = "ws" as const;
+
+export function restoreSession(db: Database): Transport {
+  // whole-row cast is the row contract, not field-level narrowing — allowed
+  const row = db.query("SELECT transport FROM sessions").get() as SessionRow;
+  // runtime guard instead of a cast — the required pattern
+  return isTransport(row.transport) ? row.transport : DEFAULT_TRANSPORT;
+}
+
+export function parsePayload(raw: string): Transport {
+  const data = JSON.parse(raw) as Record<string, unknown>;
+  // `as unknown` starts an explicit re-narrowing flow — allowed
+  const candidate = data.transport as unknown;
+  return isTransport(candidate) ? candidate : DEFAULT_TRANSPORT;
+}

--- a/scripts/rules/fixtures/no-db-ipc-cast__flagged.fixture.ts
+++ b/scripts/rules/fixtures/no-db-ipc-cast__flagged.fixture.ts
@@ -1,0 +1,24 @@
+/**
+ * @rule no-db-ipc-cast
+ * @expect 3
+ * @path packages/daemon/src/db/example.ts
+ *
+ * Field-level casts on DB-row / IPC-payload reads — each one is a silent
+ * type lie that bypasses runtime fallbacks (#2602 incident shape).
+ */
+
+import { Database } from "bun:sqlite";
+
+type Transport = "ws" | "stdio";
+
+export function restoreSession(db: Database): { transport: Transport; phase: Transport } {
+  const row = db.query("SELECT transport, phase FROM sessions").get() as Record<string, unknown>;
+  const transport = row.transport as "ws" | "stdio";
+  const phase = row.phase as Transport;
+  return { transport, phase };
+}
+
+export function parsePayload(raw: string): Transport {
+  const data = JSON.parse(raw) as Record<string, unknown>;
+  return data.transport as Transport;
+}

--- a/scripts/rules/no-db-ipc-cast.rule.ts
+++ b/scripts/rules/no-db-ipc-cast.rule.ts
@@ -1,0 +1,88 @@
+/**
+ * Rule: no-db-ipc-cast
+ *
+ * Flags field-level `as` casts on values read across the DB/IPC boundary:
+ * `row.transport as "ws" | "stdio"`, `payload.kind as MessageKind`, etc.
+ * A bare cast is a silent type lie — any garbage value (empty string, NULL,
+ * unrecognised literal) passes the compiler and bypasses `?? fallback`
+ * defaults. Motivating incident: #2602's `transport` column restore path
+ * silently dropped messages on an unconstrained TEXT value.
+ *
+ * Scope (per #2622): files under a `db/` directory, the IPC protocol/client/
+ * server modules, and any file that imports `bun:sqlite` — and within those,
+ * only casts whose base identifier conventionally holds a boundary value
+ * (`row`, `result`, `data`, `payload`, …). Field-level means the cast operand
+ * is a property/element access — whole-row shapes like `stmt.get() as
+ * SessionRow` are out of scope (that's the row contract, not a per-field
+ * narrowing that dodges a runtime guard).
+ *
+ * Fix: validate at runtime — a type-guard (`isTransport(v) ? v : "ws"`), a
+ * Zod parse, or a CHECK constraint + guarded restore. `as unknown` followed
+ * by a narrowing guard is fine; `as const` is fine.
+ */
+
+import ts from "typescript";
+import type { CheckRule } from "./_engine/rule";
+
+const SCOPED_PATH_RE = /(^|\/)(db|ipc[^/]*)\.ts$|\/db\//;
+
+function isInScope(relPath: string, content: string): boolean {
+  if (relPath.includes("/db/")) return true;
+  if (SCOPED_PATH_RE.test(relPath)) return true;
+  return content.includes('"bun:sqlite"') || content.includes("'bun:sqlite'");
+}
+
+/** Casts that are part of an explicit re-narrowing flow, not a lie. */
+function isExemptTargetType(typeNode: ts.TypeNode): boolean {
+  if (typeNode.kind === ts.SyntaxKind.UnknownKeyword) return true;
+  // `as const` arrives as a TypeReference named "const"
+  return ts.isTypeReferenceNode(typeNode) && typeNode.typeName.getText() === "const";
+}
+
+/**
+ * Base identifiers that conventionally hold a DB row or a parsed IPC payload
+ * (per #2622's pattern spec). Restricting to these keeps casts on in-memory
+ * objects (event-bus payloads, config structs) out of scope.
+ */
+const BOUNDARY_BASE_RE = /^(row|rows|result|results|data|payload|parsed|json|record|records)$/;
+
+function boundaryBaseName(operand: ts.Expression): string | null {
+  let node: ts.Expression = operand;
+  while (ts.isPropertyAccessExpression(node) || ts.isElementAccessExpression(node)) {
+    node = node.expression;
+  }
+  return ts.isIdentifier(node) ? node.text : null;
+}
+
+const rule: CheckRule = {
+  id: "no-db-ipc-cast",
+  kind: "check",
+  appliesToTests: false,
+  scold:
+    "field-level `as` cast on a DB/IPC read — garbage values pass the compiler and bypass runtime fallbacks (#2602)",
+  guidance: [
+    'validate at runtime: a type guard (`isTransport(row.transport) ? row.transport : "ws"`) or a Zod parse',
+    "`as unknown` + a narrowing guard is fine; the ban is on casting straight to the target type",
+    "whole-row casts (`stmt.get() as SessionRow`) are out of scope — the rule targets per-field narrowing",
+    "legitimate exception? suppress with `// dotw-ignore no-db-ipc-cast: <reason>`",
+  ],
+  documentation: "#2622",
+  check({ file, violated, checked, ast }) {
+    if (!file.relPath.startsWith("packages/")) return;
+    if (!isInScope(file.relPath, file.content)) return;
+    checked();
+
+    for (const cast of ast.find(ts.isAsExpression)) {
+      const operand = cast.expression;
+      if (!ts.isPropertyAccessExpression(operand) && !ts.isElementAccessExpression(operand)) continue;
+      if (isExemptTargetType(cast.type)) continue;
+      const base = boundaryBaseName(operand);
+      if (base === null || !BOUNDARY_BASE_RE.test(base)) continue;
+      const { line, column } = ast.positionOf(cast);
+      const snippet = file.content.split("\n")[line - 1]?.trim() ?? "";
+      violated(line, column, snippet);
+    }
+  },
+};
+
+export default rule;

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -132,6 +132,23 @@ If a test file is too slow:
 3. **Split the file** — separate fast unit tests from slow integration tests (e.g., `foo.spec.ts` for units, `foo.integration.spec.ts` for integration)
 4. **Use `pollUntil`** instead of fixed sleeps — exits as soon as the condition is met
 
+## DB/IPC Restore Paths: test the absent-field case (required)
+
+Whenever a column is added to a session/DB restore path (or a field to an IPC
+payload parser), tests must cover **both** scenarios:
+
+- **Field present:** row contains the new column with a valid value → restore uses it
+- **Field absent/null/garbage:** row is missing the column (older DB schema),
+  stores NULL, or holds an unrecognised value → restore uses the safe default —
+  no crash, no silent wrong value
+
+Motivating incident (#2602): a `transport` TEXT column was added with no CHECK
+constraint and restored via `row.transport as "ws" | "stdio"` — the cast let
+garbage bypass the `?? "ws"` fallback and silently drop messages. Only the
+happy path was tested; the absent-field path (the one that hit production) had
+no coverage. The `no-db-ipc-cast` rule (#2622) bans the bare-cast half of this
+bug class; this test pattern is the other half.
+
 ## Summary
 
 Every `Bun.sleep` or `setTimeout` in a test is a potential flake. If you must sleep, it should be inside a retry/poll loop with a deadline — never as "wait and hope". The two acceptable standalone sleeps are: short backoff between retry attempts, and negative assertions (verifying something does NOT happen).


### PR DESCRIPTION
Applies meta-fix #2622 (user-approved at sprint-73 plan time).

1. New doing-it-wrong rule `no-db-ipc-cast` (AST-based CheckRule): flags `row.field as SomeUnion` casts in DB/IPC boundary files (db/ dirs, ipc modules, bun:sqlite importers), restricted to conventional boundary base identifiers (`row`, `result`, `data`, `payload`, …). Whole-row contract casts (`stmt.get() as SessionRow`) and `as unknown` re-narrowing flows stay legal. Clean + flagged fixtures included.
2. `test/CLAUDE.md` codifies the paired restore-with-missing-fields test pattern.
3. The 8 pre-existing violations the rule surfaced on main (all genuine instances of the #2602 bug class, including the load-bearing `row.phase as WorkItemPhase`) are suppressed with `dotw-todo` annotations tracked by #2742.

🤖 Generated with [Claude Code](https://claude.com/claude-code)