### PR TITLE
fix(ci): provide GH_TOKEN to the check job so stale-todos can call gh (refs #2752)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,12 @@ jobs:
       # per check run for zero behaviour change (#2389 review).
       - name: am-i-done --ci (typecheck, lint, rules, non-daemon + daemon tests)
         if: needs.detect.outputs.docs_only != 'true'
+        env:
+          # stale-todos shells out to `gh issue view`; without a token gh
+          # exits instantly and the step fails closed on the first branch
+          # that carries a real dotw-todo (see #2752 — masked until then
+          # because main had zero production dotw-todos).
+          GH_TOKEN: ${{ github.token }}
         run: bun run am-i-done --ci --skip install --skip coverage --verbose
       # ci-steps.ts persists captured stdout+stderr to /tmp/test_*.txt for
       # this artefact upload (test_non_daemon.txt, test_daemon.txt,


### PR DESCRIPTION
One-line workflow fix: the `check` job's `am-i-done --ci` step had no `GH_TOKEN`, so the stale-todos step's `gh issue view` calls exit instantly and fail closed. Masked since #2533 because main carried zero production dotw-todo comments — PR #2751 (first branch with real ones) failed identically on its original run and a rerun (2/2, <300ms per step — too fast for the 10s lookup timeouts, ruling out transient blips).

Diagnosis trail + correction on #2752 (originally misfiled as a transient-blip retry ask; the retry/backoff hardening there remains valid follow-up).

Unblocks #2751.

🤖 Generated with [Claude Code](https://claude.com/claude-code)