### PR TITLE
fix(daemon): deterministic EventBus prune tests via injectable clock (fixes #2740)

### DIFF
--- a/packages/daemon/src/event-bus.spec.ts
+++ b/packages/daemon/src/event-bus.spec.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import type { MonitorEvent, MonitorEventInput } from "@mcp-cli/core";
 import { MAIL_SENT } from "@mcp-cli/core";
 import { EventBus } from "./event-bus";
@@ -540,13 +540,23 @@ describe("EventBus with EventLog", () => {
     const log = new EventLog(db);
     const bus = new EventBus(log);
 
-    // Close the DB to force append failures
+    // Close the DB to force append failures. The resulting "Cannot use a closed
+    // database" is the expected error this test exercises — capture it so the
+    // intended fallback log does not leak to stderr and get misread as a
+    // cross-test teardown race in the parallel suite (#2740 / #2690).
     db.close();
+    const errorSpy = spyOn(console, "error").mockImplementation(() => {});
 
-    // publish must not throw; seq must still advance
-    const e1 = bus.publish(sessionEvent());
-    const e2 = bus.publish(sessionEvent());
-    expect(e1.seq).toBeGreaterThan(0);
-    expect(e2.seq).toBeGreaterThan(e1.seq);
+    try {
+      // publish must not throw; seq must still advance
+      const e1 = bus.publish(sessionEvent());
+      const e2 = bus.publish(sessionEvent());
+      expect(e1.seq).toBeGreaterThan(0);
+      expect(e2.seq).toBeGreaterThan(e1.seq);
+      expect(errorSpy).toHaveBeenCalledTimes(2);
+      expect(errorSpy.mock.calls[0]?.[0]).toContain("EventLog append failed");
+    } finally {
+      errorSpy.mockRestore();
+    }
   });
 });

--- a/packages/daemon/src/event-bus.spec.ts
+++ b/packages/daemon/src/event-bus.spec.ts
@@ -301,19 +301,16 @@ describe("EventBus", () => {
     expect(bus.getLastActivityAt(999)).toBeNull();
   });
 
-  test("touch updates lastActivityAt for a live subscriber", async () => {
-    const bus = new EventBus();
+  test("touch updates lastActivityAt for a live subscriber", () => {
+    let nowMs = 1_000_000;
+    const bus = new EventBus(undefined, () => nowMs);
     const id = bus.subscribe(() => {});
     const before = bus.getLastActivityAt(id) ?? 0;
 
-    const deadline = Date.now() + 1_000;
-    while (Date.now() <= before) {
-      if (Date.now() > deadline) throw new Error("clock did not advance within 1s");
-      await Bun.sleep(TICK_MS);
-    }
+    nowMs += 5_000;
 
     expect(bus.touch(id)).toBe(true);
-    expect(bus.getLastActivityAt(id)).toBeGreaterThan(before);
+    expect(bus.getLastActivityAt(id)).toBe(before + 5_000);
   });
 
   test("touch returns false for unknown subscriber", () => {
@@ -321,19 +318,22 @@ describe("EventBus", () => {
     expect(bus.touch(999)).toBe(false);
   });
 
-  test("touch prevents pruneStale from removing a quiet-but-live subscriber", async () => {
-    const bus = new EventBus();
+  test("touch prevents pruneStale from removing a quiet-but-live subscriber", () => {
+    let nowMs = 1_000_000;
+    const bus = new EventBus(undefined, () => nowMs);
+
+    // A quiet subscriber goes stale: after time passes, its lastActivityAt is
+    // strictly older than `now`, so a TTL=0 pruner evicts it. (Control case.)
+    bus.subscribe(() => {});
+    nowMs += 10_000;
+    expect(bus.pruneStale(0)).toBe(1);
+    expect(bus.subscriberCount).toBe(0);
+
+    // touch refreshes lastActivityAt to `now`, so a TTL=0 prune (cutoff === now)
+    // no longer evicts it — guarding against the wall-clock race that made this
+    // test flaky under the parallel suite (#2740).
     const id = bus.subscribe(() => {});
-
-    // Wait until the subscriber would normally appear stale to a TTL=0 pruner.
-    const created = bus.getLastActivityAt(id) ?? 0;
-    const deadline = Date.now() + 1_000;
-    while (Date.now() <= created) {
-      if (Date.now() > deadline) throw new Error("clock did not advance within 1s");
-      await Bun.sleep(TICK_MS);
-    }
-
-    // Touch refreshes lastActivityAt — subscriber should survive pruneStale.
+    nowMs += 10_000;
     bus.touch(id);
     expect(bus.pruneStale(0)).toBe(0);
     expect(bus.subscriberCount).toBe(1);

--- a/packages/daemon/src/event-bus.ts
+++ b/packages/daemon/src/event-bus.ts
@@ -35,9 +35,11 @@ export class EventBus {
   private nextSubId = 0;
   private readonly subscribers = new Map<number, Subscription>();
   private readonly log: EventLog | null;
+  private readonly now: () => number;
 
-  constructor(eventLog?: EventLog) {
+  constructor(eventLog?: EventLog, now: () => number = Date.now) {
     this.log = eventLog ?? null;
+    this.now = now;
     if (this.log) {
       this.seq = this.log.currentSeq();
     }
@@ -72,7 +74,7 @@ export class EventBus {
       if (sub.filter === null || sub.filter(event)) {
         try {
           sub.callback(event, serialized);
-          sub.lastActivityAt = Date.now();
+          sub.lastActivityAt = this.now();
         } catch (err) {
           console.error(`[EventBus] subscriber ${sub.id} threw:`, err);
         }
@@ -83,7 +85,7 @@ export class EventBus {
 
   subscribe(callback: EventCallback, filter?: EventFilter): number {
     const id = ++this.nextSubId;
-    this.subscribers.set(id, { id, filter: filter ?? null, callback, lastActivityAt: Date.now() });
+    this.subscribers.set(id, { id, filter: filter ?? null, callback, lastActivityAt: this.now() });
     return id;
   }
 
@@ -99,7 +101,7 @@ export class EventBus {
   touch(id: number): boolean {
     const sub = this.subscribers.get(id);
     if (!sub) return false;
-    sub.lastActivityAt = Date.now();
+    sub.lastActivityAt = this.now();
     return true;
   }
 
@@ -111,7 +113,7 @@ export class EventBus {
    * ReadableStream.cancel() and no write has happened to trigger the try/catch. (#1557)
    */
   pruneStale(maxIdleMs: number): number {
-    const cutoff = Date.now() - maxIdleMs;
+    const cutoff = this.now() - maxIdleMs;
     let pruned = 0;
     for (const [id, sub] of this.subscribers) {
       if (sub.lastActivityAt < cutoff) {


### PR DESCRIPTION
## Summary
- The `touch`/`pruneStale` tests in `event-bus.spec.ts` raced the wall clock: `touch()` recorded `lastActivityAt = Date.now()`, then `pruneStale(0)` sampled `Date.now()` again for its cutoff. Under the parallel suite the second sample advanced past the first, so a just-touched subscriber looked stale and was evicted (`expected 0, received 1`).
- Added an optional `now: () => number` injection to `EventBus` (mirroring the existing `Clock` pattern in `coalesce.ts`); production behavior is unchanged (`Date.now` default).
- Rewrote the two `touch` tests to drive a controlled clock — no wall-clock dependency, no `Bun.sleep`. The prune test now also asserts the **control case** (an untouched quiet subscriber *is* pruned) so it stays meaningful.

The secondary `Cannot use a closed database` log line in the issue is expected output from the intentional fallback test (`event-bus.spec.ts:537`, which closes the DB on purpose) — it is logged, caught, and the test passes. Not a teardown leak; no change needed there.

## Test plan
- [x] `bun test packages/daemon/src/event-bus.spec.ts` — 41 pass, 0 fail
- [x] Related consumers (`open-event-stream`, `lifecycle-events`, `index`) — 104 pass, 0 fail
- [x] `bun typecheck` / `bun lint` / `bun run doing-it-wrong` — clean
- [x] `bun run am-i-done` — all checks passed (128s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)