### PR TITLE
feat(am-i-done): cooperative gate lease to bound host-wide test fan-out (fixes #2690)

### DIFF
--- a/packages/core/src/alias-bundle-core.ts
+++ b/packages/core/src/alias-bundle-core.ts
@@ -46,6 +46,7 @@ export * from "./python-repr";
 export * from "./agent-tools";
 export * from "./config-file";
 export * from "./flock";
+export * from "./gate-lease";
 export * from "./scope";
 export * from "./sprint-state";
 export * from "./upgrade";

--- a/packages/core/src/gate-lease.spec.ts
+++ b/packages/core/src/gate-lease.spec.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { acquireGateLease, withGateLease } from "./gate-lease";
+
+const dirs: string[] = [];
+function freshDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "gate-lease-test-"));
+  dirs.push(d);
+  return d;
+}
+
+afterEach(() => {
+  while (dirs.length) {
+    const d = dirs.pop();
+    if (d) rmSync(d, { recursive: true, force: true });
+  }
+});
+
+const noWait = { sleep: () => Promise.resolve(), random: () => 0 };
+
+describe("acquireGateLease", () => {
+  it("acquires a slot when one is free", async () => {
+    const lockDir = freshDir();
+    const lease = await acquireGateLease({ slots: 2, lockDir, ...noWait });
+    expect(lease.held).toBe(true);
+    expect(lease.slot).toBe(0);
+    lease.release();
+  });
+
+  it("allows K concurrent holders, blocks the K+1th until a release", async () => {
+    const lockDir = freshDir();
+    const a = await acquireGateLease({ slots: 2, lockDir, ...noWait });
+    const b = await acquireGateLease({ slots: 2, lockDir, ...noWait });
+    expect(a.held).toBe(true);
+    expect(b.held).toBe(true);
+    expect(new Set([a.slot, b.slot]).size).toBe(2); // distinct slots
+
+    // Third acquisition with both slots taken must wait. Drive a manual clock
+    // so it would fail-open quickly if it never got a slot, then free a slot
+    // mid-wait and confirm it acquires instead.
+    let ticks = 0;
+    let released = false;
+    const warnings: string[] = [];
+    const c = await acquireGateLease({
+      slots: 2,
+      lockDir,
+      timeoutMs: 10_000,
+      now: () => ticks,
+      sleep: async () => {
+        ticks += 100;
+        if (!released) {
+          released = true;
+          a.release(); // free slot 0 after the first poll
+        }
+      },
+      random: () => 0,
+      logger: { warn: (m) => warnings.push(m) },
+    });
+    expect(c.held).toBe(true);
+    expect(c.slot).toBe(a.slot); // reused the freed slot
+    expect(warnings.some((w) => w.includes("queueing"))).toBe(true);
+    expect(warnings.some((w) => w.includes("acquired") && w.includes("after waiting"))).toBe(true);
+
+    b.release();
+    c.release();
+  });
+
+  it("fails open (unheld lease) when all slots stay busy past the deadline", async () => {
+    const lockDir = freshDir();
+    const a = await acquireGateLease({ slots: 1, lockDir, ...noWait });
+    expect(a.held).toBe(true);
+
+    const warnings: string[] = [];
+    let ticks = 0;
+    const b = await acquireGateLease({
+      slots: 1,
+      lockDir,
+      timeoutMs: 500,
+      now: () => ticks,
+      sleep: async () => {
+        ticks += 1000; // blow past the deadline on the first poll
+      },
+      random: () => 0,
+      logger: { warn: (m) => warnings.push(m) },
+    });
+    expect(b.held).toBe(false);
+    expect(b.slot).toBeNull();
+    expect(warnings.some((w) => w.includes("fail-open"))).toBe(true);
+
+    a.release();
+  });
+
+  it("is a no-op when slots <= 0 (disabled)", async () => {
+    const lockDir = freshDir();
+    const lease = await acquireGateLease({ slots: 0, lockDir, ...noWait });
+    expect(lease.held).toBe(false);
+    expect(lease.slot).toBeNull();
+    lease.release(); // must not throw
+  });
+
+  it("release is idempotent and frees the slot for re-acquisition", async () => {
+    const lockDir = freshDir();
+    const a = await acquireGateLease({ slots: 1, lockDir, ...noWait });
+    a.release();
+    a.release(); // idempotent
+
+    const b = await acquireGateLease({ slots: 1, lockDir, ...noWait });
+    expect(b.held).toBe(true);
+    b.release();
+  });
+});
+
+describe("withGateLease", () => {
+  it("runs fn while holding a slot and releases afterwards", async () => {
+    const lockDir = freshDir();
+    let ranWithSlotTaken = false;
+    const result = await withGateLease(
+      async () => {
+        // While inside, the only slot is taken — a non-blocking probe must wait.
+        const probe = await acquireGateLease({
+          slots: 1,
+          lockDir,
+          timeoutMs: 0,
+          now: () => 1,
+          sleep: () => Promise.resolve(),
+          random: () => 0,
+        });
+        ranWithSlotTaken = !probe.held;
+        return 42;
+      },
+      { slots: 1, lockDir, ...noWait },
+    );
+    expect(result).toBe(42);
+    expect(ranWithSlotTaken).toBe(true);
+
+    // After withGateLease returns, the slot is free again.
+    const after = await acquireGateLease({ slots: 1, lockDir, ...noWait });
+    expect(after.held).toBe(true);
+    after.release();
+  });
+
+  it("releases the slot even when fn throws", async () => {
+    const lockDir = freshDir();
+    await expect(
+      withGateLease(
+        async () => {
+          throw new Error("boom");
+        },
+        { slots: 1, lockDir, ...noWait },
+      ),
+    ).rejects.toThrow("boom");
+
+    const after = await acquireGateLease({ slots: 1, lockDir, ...noWait });
+    expect(after.held).toBe(true);
+    after.release();
+  });
+});

--- a/packages/core/src/gate-lease.ts
+++ b/packages/core/src/gate-lease.ts
@@ -1,0 +1,201 @@
+/**
+ * Cooperative gate-run lease — a host-global counting semaphore over flock(2).
+ *
+ * Problem (#2690): N `mcx claude` worker sessions each run `bun run am-i-done`
+ * concurrently. Each `bun test --parallel` fans out ~cpu-count worker threads,
+ * so N sessions × cpu-count threads oversubscribe the host and the OS starts
+ * SIGTERM-ing Bun test workers mid-run — an instant mass kill across unrelated
+ * spec files that reads like a flaky suite but is pure resource arithmetic.
+ *
+ * The fix is to QUEUE heavy test phases, never to cap/kill/reap workers (the
+ * banned sprint 69/70 pattern, #2637). This semaphore lets at most K test
+ * phases run at once across ALL worktrees on the host; a phase that can't get a
+ * slot waits cooperatively until one frees.
+ *
+ * Mechanism: K slot files in a host-shared directory, each guarded by an
+ * exclusive flock. Acquiring = winning the exclusive lock on any one slot.
+ * flock locks are kernel-managed and released automatically on process death
+ * (even SIGKILL) or fd close — so a crashed holder never strands a slot and
+ * there is no stale-lock reaper to write.
+ *
+ * Fail-open: if every slot stays busy past a generous deadline, acquire returns
+ * an un-held handle and the caller proceeds anyway. Oversubscribing slightly is
+ * strictly better than hanging the gate forever behind a wedged holder. Waits
+ * and fail-opens are logged so contention is observable.
+ */
+
+import { closeSync, mkdirSync, openSync } from "node:fs";
+import { join } from "node:path";
+
+import { options } from "./constants";
+import { flockUnlock, tryFlockExclusive } from "./flock";
+
+/** Default number of concurrent heavy test phases allowed across the host. */
+const DEFAULT_SLOTS = 2;
+/** Generous fail-open deadline — proceed unleased rather than hang the gate. */
+const DEFAULT_TIMEOUT_MS = 15 * 60 * 1000;
+/** Base poll interval; jitter is added on top to avoid lockstep retries. */
+const DEFAULT_POLL_MS = 250;
+
+/** Minimal logger surface — kept local so core doesn't depend on the runner's. */
+export interface LeaseLogger {
+  info?: (msg: string) => void;
+  warn?: (msg: string) => void;
+}
+
+export interface GateLeaseOptions {
+  /** Concurrent slots. Defaults to MCX_GATE_LEASE_SLOTS or 2. `<= 0` disables. */
+  slots?: number;
+  /** Host-shared lock directory. Defaults to ~/.mcp-cli/gate-locks. */
+  lockDir?: string;
+  /** Fail-open deadline (ms). Defaults to MCX_GATE_LEASE_TIMEOUT_MS or 15min. */
+  timeoutMs?: number;
+  /** Base poll interval (ms) while waiting for a free slot. */
+  pollIntervalMs?: number;
+  logger?: LeaseLogger;
+  /** DI seam: sleep implementation (injected in tests). */
+  sleep?: (ms: number) => Promise<void>;
+  /** DI seam: monotonic-ish clock (injected in tests). */
+  now?: () => number;
+  /** DI seam: jitter source (injected in tests). */
+  random?: () => number;
+}
+
+export interface GateLease {
+  /** True when an actual slot was held; false when disabled or fail-open. */
+  readonly held: boolean;
+  /** Index of the slot held, or null when not held. */
+  readonly slot: number | null;
+  /** Release the slot. Idempotent. */
+  release(): void;
+}
+
+const UNHELD_LEASE: GateLease = { held: false, slot: null, release: () => {} };
+
+function readSlotsFromEnv(): number {
+  const raw = process.env.MCX_GATE_LEASE_SLOTS;
+  if (raw === undefined || raw === "") return DEFAULT_SLOTS;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) ? n : DEFAULT_SLOTS;
+}
+
+function readTimeoutFromEnv(): number {
+  const raw = process.env.MCX_GATE_LEASE_TIMEOUT_MS;
+  if (raw === undefined || raw === "") return DEFAULT_TIMEOUT_MS;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_TIMEOUT_MS;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function jitteredDelay(base: number, random: () => number): number {
+  return base + Math.floor(random() * base);
+}
+
+interface HeldSlot {
+  index: number;
+  fd: number;
+}
+
+/** Try each slot file once; return the first whose exclusive flock we win. */
+function tryAcquireAnySlot(lockDir: string, slots: number): HeldSlot | null {
+  for (let i = 0; i < slots; i++) {
+    const path = join(lockDir, `slot-${i}.lock`);
+    let fd: number;
+    try {
+      fd = openSync(path, "w");
+    } catch {
+      // Slot file could not be opened (transient fs error) — skip it.
+      continue;
+    }
+    let locked = false;
+    try {
+      locked = tryFlockExclusive(fd);
+    } catch {
+      // Unexpected flock error on this fd — release it and try the next slot.
+      closeSync(fd);
+      continue;
+    }
+    if (locked) return { index: i, fd };
+    closeSync(fd);
+  }
+  return null;
+}
+
+function makeHeldLease(slot: HeldSlot): GateLease {
+  let released = false;
+  return {
+    held: true,
+    slot: slot.index,
+    release() {
+      if (released) return;
+      released = true;
+      flockUnlock(slot.fd);
+      closeSync(slot.fd);
+    },
+  };
+}
+
+/**
+ * Acquire one of K cooperative gate slots, waiting for a free slot if all are
+ * busy. Returns immediately with an unheld lease when disabled (`slots <= 0`)
+ * or when the fail-open deadline elapses. Never throws on contention.
+ */
+export async function acquireGateLease(opts: GateLeaseOptions = {}): Promise<GateLease> {
+  const slots = opts.slots ?? readSlotsFromEnv();
+  if (slots <= 0) return UNHELD_LEASE;
+
+  const lockDir = opts.lockDir ?? join(options.MCP_CLI_DIR, "gate-locks");
+  const timeoutMs = opts.timeoutMs ?? readTimeoutFromEnv();
+  const basePoll = opts.pollIntervalMs ?? DEFAULT_POLL_MS;
+  const sleep = opts.sleep ?? defaultSleep;
+  const now = opts.now ?? Date.now;
+  const random = opts.random ?? Math.random;
+  const logger = opts.logger;
+
+  mkdirSync(lockDir, { recursive: true });
+
+  const deadline = now() + timeoutMs;
+  let announcedWait = false;
+
+  const start = now();
+
+  for (;;) {
+    const slot = tryAcquireAnySlot(lockDir, slots);
+    if (slot) {
+      // warn (not info) so the message survives the am-i-done AI file logger,
+      // which mirrors only warn/error to stderr and deletes the info-only log
+      // on success — the worker context is exactly where #2690 contention needs
+      // to stay observable.
+      if (announcedWait) {
+        logger?.warn?.(`gate-lease: acquired slot ${slot.index} after waiting ${now() - start}ms (#2690)`);
+      }
+      return makeHeldLease(slot);
+    }
+    if (now() >= deadline) {
+      logger?.warn?.(
+        `gate-lease: all ${slots} slots busy past ${timeoutMs}ms — proceeding unleased (fail-open, #2690)`,
+      );
+      return UNHELD_LEASE;
+    }
+    if (!announcedWait) {
+      announcedWait = true;
+      logger?.warn?.(`gate-lease: all ${slots} slots busy — queueing for a free slot (#2690)`);
+    }
+    await sleep(jitteredDelay(basePoll, random));
+  }
+}
+
+/**
+ * Run `fn` while holding a gate slot, releasing it afterwards even on throw.
+ */
+export async function withGateLease<T>(fn: () => Promise<T>, opts: GateLeaseOptions = {}): Promise<T> {
+  const lease = await acquireGateLease(opts);
+  try {
+    return await fn();
+  } finally {
+    lease.release();
+  }
+}

--- a/scripts/_runner/runner.ts
+++ b/scripts/_runner/runner.ts
@@ -24,6 +24,8 @@
 
 import { spawn } from "node:child_process";
 
+import { withGateLease } from "@mcp-cli/core";
+
 import { createCaptureLogger } from "./logger";
 import type { Logger, ScriptFunction, Step, StepResult } from "./types";
 
@@ -74,7 +76,11 @@ export class StepRunner {
       const stepStart = Date.now();
       logger.info(`[${idx + 1}/${this.steps.length}] ${step.name} — ${step.description}`);
 
-      const result = await this.runStep(step);
+      // Heavy test phases run under a host-global gate lease so N concurrent
+      // gate runs across worktrees don't oversubscribe the host (#2690). The
+      // lease logs waits / fail-open to the real logger so contention is
+      // visible even when the step's own output is suppressed.
+      const result = step.lease ? await withGateLease(() => this.runStep(step), { logger }) : await this.runStep(step);
       const ms = Date.now() - stepStart;
 
       if (result.success) {

--- a/scripts/_runner/types.ts
+++ b/scripts/_runner/types.ts
@@ -52,6 +52,13 @@ export interface Step {
   env?: Record<string, string>;
   /** If false, a failure logs a warning but does not stop the run. */
   critical?: boolean;
+  /**
+   * If true, the step runs under a host-global gate lease (counting semaphore,
+   * #2690) so at most K such steps run at once across all worktrees. Used to
+   * bound the combined `bun test --parallel` fan-out that otherwise SIGTERM-
+   * storms the host under N concurrent gate runs.
+   */
+  lease?: boolean;
   /** Free-form hints printed after a failure. */
   onFailure?: string | string[];
 }

--- a/scripts/am-i-done.ts
+++ b/scripts/am-i-done.ts
@@ -113,22 +113,29 @@ const RULES: Step = {
   ],
 };
 
+// lease: true on the heavy test phases caps the host-wide concurrent test-
+// worker fan-out under N simultaneous gate runs across worktrees (#2690). CI
+// steps stay unleased — each CI runner is its own host, so the per-container
+// semaphore would never block and we don't want to perturb CI timing.
 const TEST_PARALLEL: Step = {
   name: "test-parallel",
   description: "bun test --parallel (excluding packages/control — yoga-layout TDZ, #2362)",
   command: "bun test --parallel --no-orphans --path-ignore-patterns=packages/control/**",
+  lease: true,
 };
 
 const TEST_CONTROL: Step = {
   name: "test-control",
   description: "bun test packages/control (sequential — yoga-layout TDZ workaround #2362)",
   command: "bun test --no-orphans packages/control",
+  lease: true,
 };
 
 const COVERAGE: Step = {
   name: "coverage",
   description: "ratchet — never lower thresholds (see scripts/check-coverage.ts)",
   command: "bun scripts/check-coverage.ts",
+  lease: true,
 };
 
 // ===== CI step list =====


### PR DESCRIPTION
## Summary
- Adds a host-global **counting semaphore** (`packages/core/src/gate-lease.ts`) over the existing `flock(2)` primitive: at most K (default 2) heavy test phases run at once across **all worktrees on the host**. Others queue cooperatively.
- Fixes #2690 — N concurrent `bun run am-i-done` runs each fan out a full `bun test --parallel` worker pool, oversubscribing the host until the OS SIGTERM-storms Bun test workers mid-run (an instant mass kill that reads like a flaky suite).
- Direction A from the issue. **Queues, never caps/kills/reaps** workers (the banned sprint 69/70 pattern, #2637). **Fails open** after a generous deadline (`MCX_GATE_LEASE_TIMEOUT_MS`, default 15min) rather than hang the gate behind a wedged holder. flock auto-releases on process death, so no stale-lock reaper.
- `scripts/_runner`: new `Step.lease` flag; the runner wraps leased steps in `withGateLease`.
- `scripts/am-i-done.ts`: leases the COMPREHENSIVE `test-parallel` / `test-control` / `coverage` steps. **CI steps stay unleased** — each CI runner is its own host, so the per-container semaphore would never block.

### Observability
Queue-waits and fail-opens log at **warn** level so they survive the `am-i-done` AI file logger (which mirrors only warn/error to stderr and deletes the info-only log on success) — the worker context is exactly where #2690 contention must stay visible.

### Tuning
- `MCX_GATE_LEASE_SLOTS` (default 2; `<= 0` disables)
- `MCX_GATE_LEASE_TIMEOUT_MS` (default 900000)

## Test plan
- [x] `packages/core/src/gate-lease.spec.ts` — K-concurrent allowed, K+1th queues until a release, fail-open after deadline, disabled no-op, idempotent release, `withGateLease` releases on throw (incl. the warn-path assertions)
- [x] `bun run am-i-done` (full) green — 128s
- [x] `bun typecheck`, `bun lint`, `bun run doing-it-wrong` clean
- [x] End-to-end: held both slots externally, ran a leased step → observed `queueing for a free slot` then `proceeding unleased (fail-open)` on stderr in an AI context, then the step ran

🤖 Generated with [Claude Code](https://claude.com/claude-code)