### PR TITLE
fix(build): bundle ACP/OpenCode/monitor workers into compiled mcpd (fixes #2721)

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -3,6 +3,7 @@ import { readFileSync, unlinkSync } from "node:fs";
 import { resolve } from "node:path";
 import { $ } from "bun";
 import type { BunPlugin } from "bun";
+import { daemonWorkers } from "./daemon-workers";
 
 // Ensure deps are installed (fast no-op when already present)
 await $`bun install`.quiet();
@@ -130,14 +131,8 @@ async function codesignIfDarwin(...paths: string[]): Promise<void> {
   }
 }
 
-// mcpd worker entrypoints — must be listed explicitly for bun build --compile
-const daemonWorkers = [
-  "packages/daemon/src/alias-executor.ts",
-  "packages/daemon/src/claude-session-worker.ts",
-  "packages/daemon/src/codex-session-worker.ts",
-  "packages/daemon/src/mock-session-worker.ts",
-  "packages/daemon/src/site-worker.ts",
-];
+// mcpd worker entrypoints (see scripts/daemon-workers.ts) — must be listed
+// explicitly for bun build --compile.
 
 // Packages excluded from bundling — resolved at runtime from node_modules.
 // playwright ships with a large optional-dep tree (electron, chromium-bidi, etc.)

--- a/scripts/daemon-workers.spec.ts
+++ b/scripts/daemon-workers.spec.ts
@@ -1,0 +1,41 @@
+// Guards the compiled-binary worker bundle: every worker the daemon loads via
+// `workerPath("...")` / `workerScript: "..."` must be an explicit entrypoint in
+// `daemonWorkers`, or the compiled `dist/mcpd` fails at runtime with
+// `ModuleNotFound resolving "./<name>" (entry point)` (issue #2721 — ACP).
+import { describe, expect, it } from "bun:test";
+import { existsSync, readFileSync } from "node:fs";
+import { basename, resolve } from "node:path";
+import { Glob } from "bun";
+import { daemonWorkers } from "./daemon-workers";
+
+const DAEMON_SRC = resolve("packages/daemon/src");
+
+/** Worker filenames (e.g. "acp-session-worker.ts") referenced from daemon source. */
+function referencedWorkers(): Set<string> {
+  const refs = new Set<string>();
+  const literal = /(?:workerPath\(\s*|workerScript:\s*)"([^"]+\.ts)"/g;
+  for (const file of new Glob("**/*.ts").scanSync({ cwd: DAEMON_SRC, absolute: true })) {
+    if (file.endsWith(".spec.ts")) continue;
+    const src = readFileSync(file, "utf-8");
+    for (const m of src.matchAll(literal)) refs.add(m[1]);
+  }
+  return refs;
+}
+
+const bundledNames = new Set(daemonWorkers.map((p) => basename(p)));
+
+describe("daemonWorkers bundle list", () => {
+  it("includes every worker referenced from daemon source", () => {
+    const missing = [...referencedWorkers()].filter((w) => !bundledNames.has(w)).sort();
+    expect(missing).toEqual([]);
+  });
+
+  it("lists only files that exist", () => {
+    const absent = daemonWorkers.filter((p) => !existsSync(resolve(p)));
+    expect(absent).toEqual([]);
+  });
+
+  it("has no duplicate entries", () => {
+    expect(daemonWorkers.length).toBe(new Set(daemonWorkers).size);
+  });
+});

--- a/scripts/daemon-workers.ts
+++ b/scripts/daemon-workers.ts
@@ -1,0 +1,21 @@
+/**
+ * mcpd worker entrypoints — must be listed explicitly so `bun build --compile`
+ * embeds them. Each name here corresponds to a `workerPath(...)` /
+ * `workerScript: ...` reference in `packages/daemon/src`; the daemon resolves
+ * them via `./<name>` at runtime in compiled mode (see `worker-path.ts`).
+ *
+ * A worker missing from this list builds fine but fails at runtime with
+ * `ModuleNotFound resolving "./<name>" (entry point)` the moment its server is
+ * started. `daemon-workers.spec.ts` guards against that by asserting every
+ * referenced worker appears here.
+ */
+export const daemonWorkers = [
+  "packages/daemon/src/alias-executor.ts",
+  "packages/daemon/src/claude-session-worker.ts",
+  "packages/daemon/src/codex-session-worker.ts",
+  "packages/daemon/src/acp-session-worker.ts",
+  "packages/daemon/src/opencode-session-worker.ts",
+  "packages/daemon/src/mock-session-worker.ts",
+  "packages/daemon/src/monitor-executor.ts",
+  "packages/daemon/src/site-worker.ts",
+];


### PR DESCRIPTION
## Summary
- Compiled `dist/mcpd` failed to start the ACP session server with `ModuleNotFound resolving "./acp-session-worker.ts" (entry point)` — the worker was never listed as a `bun build --compile` entrypoint in `scripts/build.ts`.
- Same class of bug affected `opencode-session-worker.ts` (eagerly started via the same `AbstractWorkerServer`) and `monitor-executor.ts` (lazily spawned via `workerPath`) — both also added.
- Extracted the entrypoint list into `scripts/daemon-workers.ts` and added a guard test that scans `packages/daemon/src` for every `workerPath(...)` / `workerScript:` reference and asserts it is bundled, so a new worker can't silently miss the compiled binary again.

## Test plan
- [x] `scripts/daemon-workers.spec.ts` — 3 passing; verified it fails if a referenced worker is removed from the list (sanity-checked by removing `acp-session-worker.ts`).
- [x] `bun run am-i-done` (full: typecheck → lint → rules → tests → coverage) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)