### PR TITLE
fix(claude): reject directory paths for --claude-binary, test relative resolution (fixes #2714)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -1,7 +1,7 @@
 import { type Mock, afterEach, describe, expect, mock, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 import { DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS, isCommitted, readTransitionHistory } from "@mcp-cli/core";
 import { WORKTREE_CONFIG_FILENAME } from "@mcp-cli/core/worktree-config";
 import { _resetJqStateForTesting } from "../jq/index";
@@ -634,6 +634,33 @@ describe("cmdClaude spawn --claude-binary validation", () => {
     const call = (deps.callTool as Mock<(...a: unknown[]) => unknown>).mock.calls.find((c) => c[0] === "claude_prompt");
     expect(call).toBeDefined();
     expect((call?.[1] as { claudeBinary?: string }).claudeBinary).toBe(process.execPath);
+  });
+
+  test("resolves a relative binary path to an absolute path and plumbs it into the RPC", async () => {
+    const deps = makeDeps();
+    const origLog = console.log;
+    console.log = mock(() => {});
+    const relPath = relative(process.cwd(), process.execPath);
+    try {
+      await cmdClaude(["spawn", "--task", "x", "--claude-binary", relPath], deps);
+    } finally {
+      console.log = origLog;
+    }
+    const call = (deps.callTool as Mock<(...a: unknown[]) => unknown>).mock.calls.find((c) => c[0] === "claude_prompt");
+    expect(call).toBeDefined();
+    expect((call?.[1] as { claudeBinary?: string }).claudeBinary).toBe(process.execPath);
+  });
+
+  test("rejects a directory path with a named error before dispatch (#2714)", async () => {
+    const deps = makeDeps();
+    const tmpDir = mkdtempSync(join(tmpdir(), "mcx-test-"));
+    try {
+      await expect(cmdClaude(["spawn", "--task", "x", "--claude-binary", tmpDir], deps)).rejects.toThrow(ExitError);
+      expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("is not an executable file"));
+      expect(deps.callTool).not.toHaveBeenCalled();
+    } finally {
+      rmSync(tmpDir, { recursive: true });
+    }
   });
 });
 

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -6,7 +6,7 @@
  * No dedicated IPC methods — the same tools work from any MCP client.
  */
 
-import { constants, accessSync } from "node:fs";
+import { constants, accessSync, statSync } from "node:fs";
 import { isAbsolute, join, resolve } from "node:path";
 import { CLAUDE_SUB_ALIASES, formatHelp, getHelp, hasHelpFlag } from "../help";
 import "../help-claude";
@@ -501,6 +501,11 @@ async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
     try {
       accessSync(binPath, constants.X_OK);
     } catch {
+      d.printError(`--claude-binary: ${binPath} is not an executable file`);
+      d.exit(1);
+      return;
+    }
+    if (!statSync(binPath).isFile()) {
       d.printError(`--claude-binary: ${binPath} is not an executable file`);
       d.exit(1);
       return;


### PR DESCRIPTION
## Summary
- Add `statSync(binPath).isFile()` guard after `accessSync(X_OK)` so that a directory path (which passes the execute-bit check on POSIX) is rejected with the same named error instead of silently failing in the daemon.
- Add test covering the relative→absolute resolution branch (`resolve(process.cwd(), relPath)`) which was never hit by the existing spec since `process.execPath` is already absolute.
- Add test asserting a directory path is rejected with a named error before dispatch.

## Test plan
- [ ] `bun test packages/command/src/commands/claude.spec.ts --test-name-pattern "claude-binary"` — 6 tests pass (4 original + 2 new)
- [ ] `bun run am-i-done` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)