### PR TITLE
fix(acp,security): route fs/read_text_file through ContainmentGuard (fixes #2722)

### DIFF
--- a/packages/acp/src/acp-session.spec.ts
+++ b/packages/acp/src/acp-session.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { AgentSessionEvent } from "@mcp-cli/core";
@@ -381,6 +381,30 @@ describe("AcpSession worktree containment (#2519)", () => {
     } finally {
       session.terminate();
       rmSync(worktree, { recursive: true, force: true });
+    }
+  });
+
+  test("fs/read of an in-cwd symlink escaping the worktree emits a containment_warning (#2722)", async () => {
+    const { session, events, worktree } = makeWorktreeSession("fs-read-symlink");
+    // An out-of-worktree target the symlink points at (warn-only read).
+    const target = mkdtempSync(join(tmpdir(), "acp-symlink-target-"));
+    const secret = join(target, "secret.txt");
+    try {
+      await Bun.write(secret, "out-of-scope secret");
+      symlinkSync(secret, join(worktree, "secret_link"));
+
+      const resultPromise = session.waitForResult(10000);
+      await session.start();
+      await resultPromise;
+
+      // Read is warn-only by policy: allowed, but the symlink target escaping the
+      // worktree must surface a warning rather than slip past unmonitored.
+      expect(events.some((e) => e.type === "session:containment_warning")).toBe(true);
+      expect(events.some((e) => e.type === "session:containment_denied")).toBe(false);
+    } finally {
+      session.terminate();
+      rmSync(worktree, { recursive: true, force: true });
+      rmSync(target, { recursive: true, force: true });
     }
   });
 

--- a/packages/acp/src/acp-session.ts
+++ b/packages/acp/src/acp-session.ts
@@ -533,9 +533,18 @@ export class AcpSession {
   private async handleFsRead(id: number | string, params: Record<string, unknown>): Promise<void> {
     const path = params.path as string;
 
-    // Validate path is under session cwd
+    // Resolve to an absolute path so containment/cwd checks compare like for like.
     const resolved = resolve(this.config.cwd, path);
-    if (!resolved.startsWith(`${this.config.cwd}/`) && resolved !== this.config.cwd) {
+
+    // Worktree containment (#2519, #2722): route reads through the guard so an
+    // in-cwd symlink whose target escapes the worktree is realpath-resolved and
+    // emits a session:containment_warning. Reads are warn-only by policy, so the
+    // guard never denies here — it restores the monitoring contract that the raw
+    // startsWith check silently bypassed. Falls back to the cwd traversal check
+    // for non-worktree sessions.
+    if (this.containment) {
+      gateContainment(this.containment, "Read", { file_path: resolved }, (e) => this.emit(e));
+    } else if (!resolved.startsWith(`${this.config.cwd}/`) && resolved !== this.config.cwd) {
       this.rpc?.respondWithError(id, -1, `Path traversal denied: ${path} is outside session cwd`);
       return;
     }

--- a/packages/acp/src/fake-acp-agent.ts
+++ b/packages/acp/src/fake-acp-agent.ts
@@ -10,6 +10,7 @@
  *   silent          — handshake + session/new + prompt accepted, then no events (for watchdog testing)
  *   fs-write        — handshake + session/new + sends fs/write_text_file request, then completes
  *   fs-read         — handshake + session/new + sends fs/read_text_file request, then completes
+ *   fs-read-symlink — sends fs/read for an in-cwd symlink whose target escapes the worktree
  *   fs-write-traversal — sends fs/write with path traversal (../outside.txt), then completes
  *   fs-write-escape — sends fs/write to an absolute non-/tmp path the containment guard denies
  *   terminal        — handshake + session/new + sends terminal/create request, then completes
@@ -152,6 +153,15 @@ function schedulePromptEvents(): void {
     setTimeout(() => {
       sendServerRequest("fs-2", "fs/read_text_file", {
         path: `${process.cwd()}/package.json`,
+      });
+      setTimeout(() => completePrompt(), MED_COMPLETE_DELAY_MS);
+    }, STEP_DELAY_MS);
+  } else if (mode === "fs-read-symlink") {
+    // The symlink itself is in-cwd, so the legacy startsWith check passes; only
+    // realpath resolution catches the out-of-worktree target (#2722).
+    setTimeout(() => {
+      sendServerRequest("fs-5", "fs/read_text_file", {
+        path: `${process.cwd()}/secret_link`,
       });
       setTimeout(() => completePrompt(), MED_COMPLETE_DELAY_MS);
     }, STEP_DELAY_MS);


### PR DESCRIPTION
## Summary
- The ACP `fs/read_text_file` handler used a raw `resolved.startsWith(cwd)` check, which passes for an in-cwd symlink even when its realpath target escapes the worktree — skipping symlink resolution and never emitting `session:containment_warning`. This was a symlink info-disclosure + monitoring gap left behind when #2720 wired the write/terminal/exec paths through the guard.
- Route the resolved read path through `gateContainment("Read", { file_path })` so symlinks are realpath-resolved and out-of-scope reads surface a `session:containment_warning`. Reads stay warn-only (never denied), restoring the guard's "reads are allowed but monitored" contract. Non-worktree sessions keep the cwd traversal check as a fallback.

## Test plan
- [x] New spec: an in-cwd symlink pointing outside the worktree emits `session:containment_warning` and is **not** denied (`packages/acp/src/acp-session.spec.ts`), backed by a new `fs-read-symlink` fake-agent mode.
- [x] `bun test packages/acp/src/acp-session.spec.ts` — 32 pass.
- [x] `bun run am-i-done` — all checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)