### PR TITLE
fix(ci): stop pulling 59MB LFS blob on every checkout (fixes #2741)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,0 @@
-# Agent-grid archived provider binaries — large blobs in Git LFS.
-# Text sidecars (*.sha256, *.md) stay regular blobs so they read without an LFS smudge.
-agent-grid/binaries/*.tgz filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,27 +68,6 @@ jobs:
         run: echo "Docs-only PR — skipping check"
       - uses: actions/checkout@v6
         if: needs.detect.outputs.docs_only != 'true'
-        with:
-          lfs: true
-      - name: Verify git-lfs objects are smudged (not pointers)
-        if: needs.detect.outputs.docs_only != 'true'
-        run: |
-          fail=0
-          for f in $(git lfs ls-files -n 2>/dev/null); do
-            if [ ! -f "$f" ]; then
-              echo "FAIL: LFS-tracked file missing: $f"
-              fail=1
-            elif head -c 100 "$f" | grep -q '^version https://git-lfs'; then
-              size=$(wc -c < "$f")
-              echo "FAIL: $f is an unresolved LFS pointer (${size} bytes)"
-              fail=1
-            fi
-          done
-          if [ $fail -ne 0 ]; then
-            echo "One or more LFS objects failed to smudge. Ensure the runner has git-lfs and checkout uses lfs: true."
-            exit 1
-          fi
-          echo "All LFS objects verified (not pointers)."
       - uses: oven-sh/setup-bun@v2
         if: needs.detect.outputs.docs_only != 'true'
         with:
@@ -142,8 +121,6 @@ jobs:
         run: echo "Docs-only PR — skipping coverage"
       - uses: actions/checkout@v6
         if: needs.detect.outputs.docs_only != 'true'
-        with:
-          lfs: true
       - uses: oven-sh/setup-bun@v2
         if: needs.detect.outputs.docs_only != 'true'
         with:
@@ -187,7 +164,6 @@ jobs:
         if: needs.detect.outputs.docs_only != 'true'
         with:
           token: ${{ github.token }}
-          lfs: true
       - uses: oven-sh/setup-bun@v2
         if: needs.detect.outputs.docs_only != 'true'
         with:
@@ -233,8 +209,6 @@ jobs:
         run: echo "Docs-only PR — skipping build"
       - uses: actions/checkout@v6
         if: needs.detect.outputs.docs_only != 'true'
-        with:
-          lfs: true
       - uses: oven-sh/setup-bun@v2
         if: needs.detect.outputs.docs_only != 'true'
         with:

--- a/agent-grid/binaries/README.md
+++ b/agent-grid/binaries/README.md
@@ -1,12 +1,27 @@
 # agent-grid/binaries
 
-Archived agent provider binaries, content-addressed and stored in **Git LFS**
-(see `.gitattributes` — only `*.tgz` is LFS-tracked; `*.sha256` sidecars stay
-regular blobs so they read without an LFS smudge).
+Archived agent provider binaries, content-addressed in **Git LFS** storage. The
+`*.tgz` blobs are **not** checked into HEAD and are **not** pulled on checkout —
+only the `*.sha256` sidecars live in the tree. This is deliberate: a 59 MB blob
+dragged on every CI checkout was burning ~13 GB/mo of LFS bandwidth and 403ing
+unrelated CI (#2741). The blobs are kept retrievable in LFS storage, referenced
+by the tag `archive/agent-grid-claude-2.1.119`.
 
 These are an offline fallback for `scripts/install-agent.ts` (#2583) when a
 registry no longer serves a pinned version. **Archives are added explicitly,
 one PR at a time — there is no automatic promotion.**
+
+## Retrieving a blob
+
+The `.tgz` is not in your working tree after a clone. Fetch it on demand
+straight from the LFS batch API (no `git lfs pull`, no LFS-on-checkout):
+
+```bash
+GITHUB_TOKEN=$(gh auth token) scripts/fetch-lfs-blob.sh
+```
+
+The script verifies the SHA-256 against the OID and is a no-op if the blob is
+already present and intact.
 
 ## Inventory
 
@@ -26,8 +41,8 @@ one PR at a time — there is no automatic promotion.**
   `claude-2.1.119` (204 MB uncompressed → 62 MB gzipped).
 - **Checksums:**
   - tgz: `5035cb068148a66444a8b8642b3d5eab926c086961101840dbe1baa62957bbc0`
-    (also the LFS oid — verifiable straight from the pointer; mirrored in
-    `claude-2.1.119.tgz.sha256`)
+    (also the LFS oid — mirrored in `claude-2.1.119.tgz.sha256` and used as the
+    fetch key in `scripts/fetch-lfs-blob.sh`)
   - inner binary: `31db3444309d5d0f8b85e8782e2dcd86f31f7e48c1a1e83d69b09268c7b4f9a2`
     (verify after extraction)
 
@@ -50,8 +65,17 @@ When adding a binary for an additional platform, use the naming convention
 2. `shasum -a 256 agent-grid/binaries/<name>.tgz > agent-grid/binaries/<name>.tgz.sha256`
 3. Add the row to `versions.yaml` with `archive`, `platform`, and optionally
    `binary_sha256`.
-4. Commit — `.gitattributes` routes the `.tgz` to LFS automatically.
+4. Upload the blob to LFS storage and keep it referenced so checkout never pulls
+   it: push it under a dedicated `lfs:` rule on a throwaway branch (or
+   `git lfs push origin <oid>`), tag the referencing commit
+   `archive/<name>`, then remove the `.tgz` pointer + the temporary LFS rule
+   from HEAD before merging. Commit only the `.sha256` sidecar and the
+   `versions.yaml` row. (See #2741 for why the blob must not stay on checkout.)
+5. Add an OID-keyed branch to `scripts/fetch-lfs-blob.sh` (or generalise it) so
+   the new archive is retrievable on demand.
 
-**LFS push note:** This repo uses `core.hooksPath=.git-hooks`, which means
-git-lfs's own `pre-push` hook is inactive. After committing LFS-tracked files,
-push objects explicitly with `git lfs push origin <branch>` before `git push`.
+**Why not LFS-on-checkout:** every `lfs: true` checkout pulls the full blob and
+bills the repo owner for LFS bandwidth — even on public repos and PRs from
+forks. At ~80–100 CI runs/month a 59 MB blob blew past the 1 GB/mo allowance and
+403'd the smudge, failing unrelated CI (#2741). Keep blobs out of HEAD; fetch on
+demand.

--- a/agent-grid/binaries/claude-2.1.119.tgz
+++ b/agent-grid/binaries/claude-2.1.119.tgz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5035cb068148a66444a8b8642b3d5eab926c086961101840dbe1baa62957bbc0
-size 61891998

--- a/scripts/fetch-lfs-blob.sh
+++ b/scripts/fetch-lfs-blob.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Fetch the archived claude-2.1.119 binary directly from the GitHub LFS batch
+# API — no `lfs: true` checkout (and no per-checkout LFS bandwidth) required.
+#
+# The blob was removed from HEAD in #2741 to stop CI dragging 59 MB on every
+# run. It still lives in LFS storage, kept referenced by the tag
+# `archive/agent-grid-claude-2.1.119`. This script is the on-demand retrieval
+# path for anyone (local dev, or a future job) that actually needs the binary.
+#
+# Caches by OID: a re-run with the blob already present and intact is a no-op.
+set -euo pipefail
+
+REPO="theshadow27/mcp-cli"
+OID="5035cb068148a66444a8b8642b3d5eab926c086961101840dbe1baa62957bbc0"
+SIZE=61891998
+REL="agent-grid/binaries/claude-2.1.119.tgz"
+: "${GITHUB_TOKEN:?set GITHUB_TOKEN (the default GITHUB_TOKEN in Actions works)}"
+
+# Resolve the output path relative to the repo root so the script works from
+# any working directory.
+ROOT="$(git rev-parse --show-toplevel)"
+OUT="${ROOT}/${REL}"
+
+sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+
+# Skip if already present and intact (cache hit).
+if [[ -f "$OUT" ]] && [[ "$(sha256 "$OUT")" == "$OID" ]]; then
+  echo "blob already present and verified: $OUT"
+  exit 0
+fi
+
+href="$(curl -sf \
+  -X POST "https://github.com/${REPO}.git/info/lfs/objects/batch" \
+  -u "x-access-token:${GITHUB_TOKEN}" \
+  -H 'Accept: application/vnd.git-lfs+json' \
+  -H 'Content-Type: application/vnd.git-lfs+json' \
+  -d "{\"operation\":\"download\",\"transfers\":[\"basic\"],\"objects\":[{\"oid\":\"${OID}\",\"size\":${SIZE}}]}" \
+  | jq -r '.objects[0].actions.download.href')"
+
+if [[ -z "$href" || "$href" == "null" ]]; then
+  echo "could not resolve LFS download href for $OID" >&2
+  exit 1
+fi
+
+mkdir -p "$(dirname "$OUT")"
+curl -sf -L "$href" -o "$OUT"
+
+actual="$(sha256 "$OUT")"
+if [[ "$actual" != "$OID" ]]; then
+  echo "checksum mismatch: $actual != $OID" >&2
+  exit 1
+fi
+echo "fetched and verified: $OUT (${SIZE} bytes)"

--- a/scripts/install-agent.ts
+++ b/scripts/install-agent.ts
@@ -325,7 +325,9 @@ export async function installFromArchive(
 
   const archivePath = resolve(deps.gridDir, entry.archive);
   if (!existsSync(archivePath)) {
-    throw new Error(`Archive not found: ${archivePath} — run 'git lfs pull' if this is a fresh clone`);
+    throw new Error(
+      `Archive not found: ${archivePath} — fetch it on demand with 'GITHUB_TOKEN=$(gh auth token) scripts/fetch-lfs-blob.sh' (blobs are no longer pulled on checkout; see #2741)`,
+    );
   }
 
   // Sidecar guards against accidental corruption (truncated LFS pull, bad disk).


### PR DESCRIPTION
## Summary
- CI checked out with `lfs: true` in all 4 jobs, dragging the 59 MB `agent-grid/binaries/claude-2.1.119.tgz` on every run — ~13.7 GB YTD (~69% of the account's LFS bandwidth), tripping the per-period LFS gate and 403ing the smudge on unrelated PRs.
- **No CI job or test reads the tgz bytes** — it is purely a runtime offline fallback for `install-agent.ts`. So this drops LFS-on-checkout entirely: removes `lfs: true` (+ the now-moot smudge-verify step) from `ci.yml`, removes the blob pointer from HEAD, and drops the `.gitattributes` LFS rule.
- The blob stays retrievable in LFS storage, kept referenced by the pushed tag `archive/agent-grid-claude-2.1.119` (cut on `origin/main` @ `cc259658`, before the removal). `scripts/fetch-lfs-blob.sh` retrieves it on demand via the LFS batch API (OID-cached, checksum-verified). README + `install-agent.ts` error hint updated to the new path.

### Divergence from the issue
The issue's step 4 ("fetch on demand in the one job that needs the binary" + `actions/cache`) is **intentionally omitted**: there is no CI job that consumes the binary, so wiring a cache+fetch step into CI would be dead code. The fetch script + README is the right replacement.

### Net effect
CI checkouts pull a 133-byte pointer instead of 59 MB → ~13 GB/mo of LFS bandwidth eliminated, clearing the budget block on CI.

## Test plan
- [x] `bun run am-i-done` — all 10 steps pass
- [x] Verified no CI job/test reads the tgz bytes (refs are path-strings in synthetic YAML)
- [x] `grep` confirms zero `lfs`/`smudge` references remain in `ci.yml`
- [x] Preservation tag `archive/agent-grid-claude-2.1.119` confirmed on remote, references pointer oid `5035cb06…`
- [x] `bash -n scripts/fetch-lfs-blob.sh` syntax-clean; executable bit set

🤖 Generated with [Claude Code](https://claude.com/claude-code)