### PR TITLE
fix(ci): fail closed when phase test run discovers 0 specs (closes #2719)

### DIFF
--- a/scripts/_runner/ci-steps.spec.ts
+++ b/scripts/_runner/ci-steps.spec.ts
@@ -34,7 +34,13 @@ function deriveFailures(stdout: string | undefined): number {
   return (stdout ?? "").includes(" 0 fail") ? 0 : 1;
 }
 
-function makeFakeBun(opts: { code: number; stdout?: string; stderr?: string; errors?: number }): string {
+function makeFakeBun(opts: {
+  code: number;
+  stdout?: string;
+  stderr?: string;
+  errors?: number;
+  junitTests?: number;
+}): string {
   const dir = mkdtempSync(join(tmpdir(), "am-i-done-test-"));
   const path = join(dir, "bun");
   const stdout = (opts.stdout ?? "").replace(/'/g, "'\\''");
@@ -43,6 +49,10 @@ function makeFakeBun(opts: { code: number; stdout?: string; stderr?: string; err
   // `errors` models bun's "unhandled error between tests" — written to the junit
   // `errors` attribute, NOT `failures`. The coverage JSON has no errors concept.
   const e = opts.errors ?? 0;
+  // `junitTests` models the root `tests="N"` attribute — the discovered-test
+  // floor signal for phasesTestWithCrashTolerance (#2719). 12 matches the
+  // pass+fail totals in passingSummary/failingSummary.
+  const t = opts.junitTests ?? 12;
   writeFileSync(
     path,
     // Write structured output files when requested so classifiers key off
@@ -56,7 +66,7 @@ for arg in "$@"; do
   case "$arg" in
     --reporter-outfile=*)
       jpath="\${arg#--reporter-outfile=}"
-      printf '<?xml version="1.0"?><testsuites failures="${f}" errors="${e}"></testsuites>' > "$jpath"
+      printf '<?xml version="1.0"?><testsuites tests="${t}" failures="${f}" errors="${e}"></testsuites>' > "$jpath"
       ;;
     --junit-outfile=*)
       cpath="\${arg#--junit-outfile=}"
@@ -983,10 +993,19 @@ describe("changedTestsStep", () => {
   });
 });
 
+// Temp dir with n dummy `*-fn.spec.ts` files — models `.claude/phases/` for
+// the discovered-spec floor (#2719). The files are never executed (the fake
+// bun ignores its cwd); only their on-disk count matters.
+function makePhasesDir(n: number): string {
+  const dir = mkdtempSync(join(tmpdir(), "fake-phases-"));
+  for (let i = 0; i < n; i++) writeFileSync(join(dir, `x${i}-fn.spec.ts`), "");
+  return dir;
+}
+
 describe("phasesTestWithCrashTolerance", () => {
   it("exit 0 is success", async () => {
     const dir = makeFakeBun({ code: 0, stdout: passingSummary });
-    const step = phasesTestWithCrashTolerance({ phasesDir: dir, logName: "test_phases_x" });
+    const step = phasesTestWithCrashTolerance({ phasesDir: makePhasesDir(2), logName: "test_phases_x" });
     const result = await runWith(dir, () =>
       (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
         logger: createCaptureLogger(),
@@ -995,9 +1014,9 @@ describe("phasesTestWithCrashTolerance", () => {
     expect(result).toEqual({ success: true });
   });
 
-  it("non-zero exit with `0 fail` summary is a #1004 pass-by-policy", async () => {
+  it("non-zero exit with `0 fail` summary is a #1004 pass-by-policy (floor satisfied via junit tests attr)", async () => {
     const dir = makeFakeBun({ code: 1, stdout: passingSummary });
-    const step = phasesTestWithCrashTolerance({ phasesDir: dir, logName: "test_phases_x" });
+    const step = phasesTestWithCrashTolerance({ phasesDir: makePhasesDir(2), logName: "test_phases_x" });
     const result = await runWith(dir, () =>
       (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
         logger: createCaptureLogger(),
@@ -1008,7 +1027,7 @@ describe("phasesTestWithCrashTolerance", () => {
 
   it("real test failure (non-zero exit, summary shows fail count) reports failure", async () => {
     const dir = makeFakeBun({ code: 1, stdout: failingSummary });
-    const step = phasesTestWithCrashTolerance({ phasesDir: dir, logName: "test_phases_x" });
+    const step = phasesTestWithCrashTolerance({ phasesDir: makePhasesDir(2), logName: "test_phases_x" });
     const result = await runWith(dir, () =>
       (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
         logger: createCaptureLogger(),
@@ -1019,8 +1038,12 @@ describe("phasesTestWithCrashTolerance", () => {
 
   it("passes phasesDir as the cwd to bun — args logged reflect the directory context", async () => {
     const dir = mkdtempSync(join(tmpdir(), "am-i-done-test-"));
-    writeFileSync(join(dir, "bun"), '#!/usr/bin/env bash\necho "ARGV=$*"\nexit 0\n', { mode: 0o755 });
-    const phasesDir = mkdtempSync(join(tmpdir(), "fake-phases-"));
+    writeFileSync(
+      join(dir, "bun"),
+      '#!/usr/bin/env bash\necho "ARGV=$*"\necho "Ran 1 tests across 1 files."\nexit 0\n',
+      { mode: 0o755 },
+    );
+    const phasesDir = makePhasesDir(1);
     const step = phasesTestWithCrashTolerance({ phasesDir, logName: "test_phases_cwd" });
     const result = await runWith(dir, () =>
       (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
@@ -1030,5 +1053,69 @@ describe("phasesTestWithCrashTolerance", () => {
     expect(result).toEqual({ success: true });
     const log = readFileSync("/tmp/test_phases_cwd.txt", "utf8");
     expect(log).toContain("--no-orphans");
+  });
+
+  // --- discovered-spec floor (#2719): bun exits 0 on 0 discovered files, so
+  // exit code alone must never be sufficient for a pass.
+
+  it("fails when phasesDir contains 0 spec files, even on exit 0", async () => {
+    const dir = makeFakeBun({ code: 0, stdout: passingSummary });
+    const step = phasesTestWithCrashTolerance({ phasesDir: makePhasesDir(0), logName: "test_phases_x" });
+    const result = await runWith(dir, () =>
+      (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
+        logger: createCaptureLogger(),
+      }),
+    );
+    expect(result).toMatchObject({ success: false, error: expect.stringContaining("0 phase spec files") });
+  });
+
+  it('fails when the run reports 0 discovered tests (junit tests="0") despite exit 0', async () => {
+    // The literal fail-open scenario from #2719: bun exits 0 having run nothing.
+    const dir = makeFakeBun({ code: 0, stdout: " 0 pass\n 0 fail\n", junitTests: 0 });
+    const step = phasesTestWithCrashTolerance({ phasesDir: makePhasesDir(2), logName: "test_phases_x" });
+    const result = await runWith(dir, () =>
+      (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
+        logger: createCaptureLogger(),
+      }),
+    );
+    expect(result).toMatchObject({ success: false, error: expect.stringContaining("pathIgnorePatterns") });
+  });
+
+  it("fails when fewer files ran than spec files exist on disk (partial discovery)", async () => {
+    const dir = makeFakeBun({ code: 0, stdout: " 5 pass\n 0 fail\nRan 5 tests across 1 files.\n" });
+    const step = phasesTestWithCrashTolerance({ phasesDir: makePhasesDir(3), logName: "test_phases_x" });
+    const result = await runWith(dir, () =>
+      (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
+        logger: createCaptureLogger(),
+      }),
+    );
+    expect(result).toMatchObject({ success: false, error: expect.stringContaining("discovered 1 files") });
+  });
+
+  it("fails closed when neither junit tests attribute nor summary line is available", async () => {
+    // Fake bun that emits no output and writes no junit file: exit 0 carries
+    // no evidence anything ran — must not pass.
+    const dir = mkdtempSync(join(tmpdir(), "am-i-done-test-"));
+    writeFileSync(join(dir, "bun"), "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+    const step = phasesTestWithCrashTolerance({ phasesDir: makePhasesDir(1), logName: "test_phases_x" });
+    const result = await runWith(dir, () =>
+      (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
+        logger: createCaptureLogger(),
+      }),
+    );
+    expect(result).toMatchObject({ success: false, error: expect.stringContaining("failing closed") });
+  });
+
+  it("prefers the stdout file count over the junit tests attribute", async () => {
+    // junit says 12 tests, but the summary line says only 1 file ran — with 3
+    // spec files on disk the file count (exact signal) must win and fail.
+    const dir = makeFakeBun({ code: 0, stdout: `${passingSummary}Ran 12 tests across 1 files.\n` });
+    const step = phasesTestWithCrashTolerance({ phasesDir: makePhasesDir(3), logName: "test_phases_x" });
+    const result = await runWith(dir, () =>
+      (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
+        logger: createCaptureLogger(),
+      }),
+    );
+    expect(result).toMatchObject({ success: false, error: expect.stringContaining("discovered 1 files") });
   });
 });

--- a/scripts/_runner/ci-steps.ts
+++ b/scripts/_runner/ci-steps.ts
@@ -104,6 +104,23 @@ function parseJunitFailures(xmlPath: string): number | null {
 }
 
 /**
+ * Parse the total test count from a bun junit XML report: the `tests` attribute
+ * on the root `<testsuites>` element (first match in document order — nested
+ * `<testsuite>` elements carry per-file counts). Returns null when the file is
+ * absent or has no `tests` attribute. Used by the phases step to fail closed
+ * when `bun test` exits 0 having discovered nothing (#2719).
+ */
+function parseJunitTests(xmlPath: string): number | null {
+  try {
+    const xml = readFileSync(xmlPath, "utf8");
+    const m = xml.match(/tests="(\d+)"/);
+    return m ? Number.parseInt(m[1], 10) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Parse the `{ failures: N }` JSON summary written by check-coverage.ts via --junit-outfile.
  * Returns null when the file is absent or unparseable.
  */
@@ -210,6 +227,11 @@ const ZERO_FAIL_RE = /^ 0 fail$/m;
 // FAILURE as a #1419 crash-after-pass and let CI swallow it (#2744).
 const COVERAGE_PASS_RE = /^PASS: All coverage thresholds met/m;
 const FAIL_LINE_RE = /^FAIL:/m;
+// Bun's end-of-run summary: "Ran 129 tests across 6 files. [20.00ms]". Like
+// ZERO_FAIL_RE it is written to stdout incrementally, so it survives a #1004
+// teardown crash that drops the junit sidecar. The file count is the durable
+// fallback for the phases discovered-spec floor (#2719).
+const RAN_FILES_RE = /^Ran \d+ tests? across (\d+) files?/m;
 
 interface TestOpts {
   /** `bun test` positional arguments — directories and/or spec files. */
@@ -256,22 +278,67 @@ interface PhasesTestOpts {
   phasesDir: string;
 }
 
+/** Count `*.spec.ts` files under a directory (recursive). */
+function countSpecFiles(dir: string): number {
+  let count = 0;
+  for (const _ of new Glob("**/*.spec.ts").scanSync({ cwd: dir })) count++;
+  return count;
+}
+
+/**
+ * Verify the run actually discovered at least as many spec files as exist on
+ * disk. `bun test` exits 0 when it discovers ZERO spec files, so without this
+ * floor the step is fail-open: a rename, a bad phasesDir, or a bun upgrade
+ * that changes `pathIgnorePatterns` anchoring would silently revert phase
+ * specs to the pre-#2648 dark state (#2719). Primary signal: the stdout
+ * "Ran N tests across M files" line (files vs files — exact, and survives a
+ * #1004 teardown crash). Fallback: the junit `tests` attribute (each spec
+ * file contributes ≥1 test, so tests ≥ files). Neither parseable → fail closed.
+ */
+function checkDiscoveryFloor(outcome: RunOutcome, junitPath: string, specCount: number): StepResult {
+  const filesMatch = outcome.output.match(RAN_FILES_RE);
+  const discovered = filesMatch ? Number.parseInt(filesMatch[1], 10) : parseJunitTests(junitPath);
+  if (discovered === null) {
+    return {
+      success: false,
+      error:
+        "could not determine discovered phase spec count (no junit tests attribute, no summary line) — failing closed (#2719)",
+    };
+  }
+  if (discovered < specCount) {
+    return {
+      success: false,
+      error: `phase test run discovered ${discovered} ${filesMatch ? "files" : "tests"}, expected >= ${specCount} spec files — check pathIgnorePatterns anchoring and phasesDir (#2719)`,
+    };
+  }
+  return { success: true };
+}
+
 /**
  * Run `bun test --no-orphans` from within `.claude/phases/` so the files
  * are discovered relative to that CWD — bypassing the root bunfig.toml
  * `pathIgnorePatterns = [".claude/**"]` exclusion that silences them when
  * run from the repo root (#2648). Carries the same #1004 crash-after-pass
- * tolerance as `bunTestWithCrashTolerance`.
+ * tolerance as `bunTestWithCrashTolerance`, but fails closed when the run
+ * discovers fewer spec files than exist on disk (#2719).
  */
 export function phasesTestWithCrashTolerance(opts: PhasesTestOpts): ScriptFunction {
   return async ({ logger, env }) => {
+    const specCount = countSpecFiles(opts.phasesDir);
+    if (specCount === 0) {
+      return {
+        success: false,
+        error: `0 phase spec files found in ${opts.phasesDir} — specs renamed/moved, or bad phasesDir? (#2719)`,
+      };
+    }
     const args = ["test", "--no-orphans"];
-    const first = await runBun(args, logger, env, junitTmpPath(opts.logName), opts.phasesDir);
+    const junitPath = junitTmpPath(opts.logName);
+    const first = await runBun(args, logger, env, junitPath, opts.phasesDir);
     persistLog(opts.logName, first.output);
-    if (first.code === 0) return { success: true };
+    if (first.code === 0) return checkDiscoveryFloor(first, junitPath, specCount);
     if (hasZeroJunitFailures(first)) {
       logger.warn(`bun crash (exit ${first.code}) after phase tests passed — treating as pass (#1004)`);
-      return { success: true };
+      return checkDiscoveryFloor(first, junitPath, specCount);
     }
     return { success: false, error: `exit ${first.code}` };
   };

--- a/scripts/_runner/phases-discovery.spec.ts
+++ b/scripts/_runner/phases-discovery.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, setDefaultTimeout } from "bun:test";
+
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { Glob } from "bun";
+
+// Nested bun cold start can stretch under CI parallel load; the phase suite
+// itself runs in ~20ms.
+setDefaultTimeout(15_000);
+
+// Real-bun smoke test for the pathIgnorePatterns bypass (#2719).
+//
+// The phases CI step relies on a fragile, otherwise-untested invariant: the
+// root bunfig.toml sets `pathIgnorePatterns = [".claude/**"]`, which bun
+// anchors to the bunfig's directory — so specs discovered relative to a
+// `.claude/phases/` cwd happen NOT to match the root-anchored glob and run.
+// If a bun upgrade changes that anchoring, `bun test` from that cwd discovers
+// 0 files and exits 0, silently reverting phase specs to the pre-#2648 dark
+// state. This test spawns the REAL bun (no fake-bun stub) from that cwd and
+// asserts the discovered count covers every spec file on disk.
+
+const repoRoot = resolve(import.meta.dir, "../..");
+const phasesDir = join(repoRoot, ".claude", "phases");
+
+describe("phases spec discovery (real bun, #2719)", () => {
+  it("bun test from .claude/phases discovers every on-disk spec file", () => {
+    let specCount = 0;
+    for (const _ of new Glob("**/*.spec.ts").scanSync({ cwd: phasesDir })) specCount++;
+    expect(specCount).toBeGreaterThanOrEqual(1);
+
+    const junitPath = join(mkdtempSync(join(tmpdir(), "phases-discovery-")), "junit.xml");
+    const run = spawnSync(
+      process.execPath,
+      ["test", "--no-orphans", "--reporter", "junit", `--reporter-outfile=${junitPath}`],
+      { cwd: phasesDir, encoding: "utf8" },
+    );
+    expect(run.status).toBe(0);
+
+    const xml = readFileSync(junitPath, "utf8");
+    const m = xml.match(/tests="(\d+)"/);
+    expect(m).not.toBeNull();
+    const discoveredTests = Number.parseInt((m as RegExpMatchArray)[1], 10);
+    // Each spec file contributes at least one test, so tests >= files. A
+    // 0-discovery regression reports tests="0" (or no junit at all) here
+    // instead of exiting 0 unnoticed.
+    expect(discoveredTests).toBeGreaterThanOrEqual(specCount);
+
+    const summary = `${run.stdout}${run.stderr}`;
+    const files = summary.match(/^Ran \d+ tests? across (\d+) files?/m);
+    expect(files).not.toBeNull();
+    expect(Number.parseInt((files as RegExpMatchArray)[1], 10)).toBeGreaterThanOrEqual(specCount);
+  });
+});


### PR DESCRIPTION
## Summary
- `bun test` exits 0 when it discovers zero spec files, so `phasesTestWithCrashTolerance` was fail-open: a spec rename/move, a bad `phasesDir`, or a bun upgrade changing `pathIgnorePatterns` anchoring would silently revert phase specs to the pre-#2648 dark state while CI stayed green.
- **Part 1 — discovered-spec floor**: the step now fails before running if `phasesDir` has 0 `*.spec.ts` files, and after a passing run requires the discovered count (stdout `Ran N tests across M files` primary — survives a #1004 teardown crash like `ZERO_FAIL_RE`; junit `tests="N"` fallback) to cover every on-disk spec file. Neither signal parseable → fail closed.
- **Part 2 — real-bun smoke test**: `scripts/_runner/phases-discovery.spec.ts` spawns the real bun (no fake-bun stub) from `.claude/phases/` and asserts full discovery, so a bun upgrade that breaks the root-anchored `pathIgnorePatterns = [".claude/**"]` bypass trips a test instead of going dark. Runs in ~73ms.

## Test plan
- [x] New unit tests: 0 spec files on disk → fail; junit `tests="0"` despite exit 0 (the literal #2719 scenario) → fail; partial discovery (fewer files ran than specs exist) → fail; no junit + no summary line → fail closed; stdout file count preferred over junit test count
- [x] Existing #1004 crash-after-pass tolerance still passes when the floor is satisfied
- [x] Real-bun smoke test discovers all 6 phase spec files (129 tests)
- [x] `bun run am-i-done` green (typecheck, lint, rules, full tests, coverage ratchet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)