### PR TITLE
feat(daemon): capture claude stdio child stderr for spawn postmortems (closes #2738)

### DIFF
--- a/packages/core/src/subprocess.spec.ts
+++ b/packages/core/src/subprocess.spec.ts
@@ -179,6 +179,26 @@ describe("spawnManaged", () => {
     expect(chunks.join("")).toContain("callback-test");
   });
 
+  it("calls onStderrEnd once after the stderr stream drains, following the final chunk", async () => {
+    const order: string[] = [];
+    const r = spawnManaged("sh", ["-c", "printf 'no-newline-tail' >&2"], {
+      onStderr: () => order.push("chunk"),
+      onStderrEnd: () => order.push("end"),
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+
+    await r.handle.exited;
+    const deadline = Date.now() + 2000;
+    while (!order.includes("end") && Date.now() < deadline) {
+      await Bun.sleep(POLL_INTERVAL_MS);
+    }
+    // The trailing chunk (which had no newline) is delivered before EOF is signalled.
+    expect(order).toContain("chunk");
+    expect(order[order.length - 1]).toBe("end");
+    expect(order.filter((o) => o === "end")).toHaveLength(1);
+  });
+
   it("truncates stderr ring buffer to stderrMaxBytes", async () => {
     const r = spawnManaged("sh", ["-c", "dd if=/dev/zero bs=1024 count=128 2>/dev/null | tr '\\0' 'A' >&2"], {
       stderrMaxBytes: 1024,

--- a/packages/core/src/subprocess.ts
+++ b/packages/core/src/subprocess.ts
@@ -20,6 +20,9 @@ export interface ManagedSpawnOptions {
   stderr?: "pipe" | "inherit" | "ignore";
   /** Real-time tap on decoded stderr chunks (only when stderr is "pipe"). */
   onStderr?: (chunk: string) => void;
+  /** Called once after the stderr stream fully drains (EOF). Lets line-buffered
+   * consumers flush a trailing partial line that had no final newline. */
+  onStderrEnd?: () => void;
   /** Maximum bytes retained in the stderr ring buffer (default 64 KB). */
   stderrMaxBytes?: number;
   /** SIGTERM → SIGKILL grace window in ms (default 5 000). */
@@ -85,6 +88,7 @@ export function spawnManaged(cmd: string, args: string[], opts?: ManagedSpawnOpt
     const reader = (proc.stderr as ReadableStream<Uint8Array>).getReader();
     const decoder = new TextDecoder();
     const onChunk = opts?.onStderr;
+    const onEnd = opts?.onStderrEnd;
     const append = (chunk: Uint8Array) => {
       if (chunk.byteLength === 0) return;
       stderrChunks.push(chunk);
@@ -117,6 +121,8 @@ export function spawnManaged(cmd: string, args: string[], opts?: ManagedSpawnOpt
         if (tail) onChunk?.(tail);
       } catch {
         // stream closed — expected on kill
+      } finally {
+        onEnd?.();
       }
     })();
   }

--- a/packages/daemon/src/abstract-worker-server.spec.ts
+++ b/packages/daemon/src/abstract-worker-server.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { AGENT_PROTOCOL_VERSION, ProtocolVersionMismatchError, silentLogger } from "@mcp-cli/core";
+import { AGENT_PROTOCOL_VERSION, ProtocolVersionMismatchError, capturingLogger, silentLogger } from "@mcp-cli/core";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { testOptions } from "../../../test/test-options";
 import {
@@ -344,6 +344,7 @@ describe("AbstractWorkerServer", () => {
         "db:state",
         "db:cost",
         "db:disconnected",
+        "db:stderr",
         "db:end",
         "metrics:inc",
         "metrics:observe",
@@ -365,6 +366,53 @@ describe("AbstractWorkerServer", () => {
       expect(() => {
         internals(s).handleWorkerEvent({ type: "unknown:future:type" } as never);
       }).not.toThrow();
+    });
+  });
+
+  // ── db:stderr capture (#2738) ──
+
+  describe("db:stderr capture", () => {
+    test("persists child stderr lines keyed by session id", () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      server = makeServer(StubWorkerServer, db);
+
+      internals(server).handleWorkerEvent({
+        type: "db:stderr",
+        sessionId: "sess-1",
+        line: "auth error: token expired",
+        timestamp: 1000,
+      });
+      internals(server).handleWorkerEvent({
+        type: "db:stderr",
+        sessionId: "sess-1",
+        line: "fatal: exiting 1",
+        timestamp: 1001,
+      });
+
+      const logs = db.getServerLogs("sess-1");
+      expect(logs.map((l) => l.line)).toEqual(["auth error: token expired", "fatal: exiting 1"]);
+    });
+
+    test("db:disconnected log line surfaces the captured stderr tail", () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      const { logger, texts } = capturingLogger();
+      const s = new StubWorkerServer(db, undefined, instantClient, logger, undefined, new MetricsCollector());
+      server = s;
+
+      internals(s).handleWorkerEvent({
+        type: "db:stderr",
+        sessionId: "sess-2",
+        line: "spawn failed: ENOENT",
+        timestamp: 2000,
+      });
+      internals(s).handleWorkerEvent({ type: "db:disconnected", sessionId: "sess-2", reason: "spawn exited" });
+
+      const line = texts.find((t) => t.includes("disconnected"));
+      expect(line).toBeDefined();
+      expect(line).toContain("spawn exited");
+      expect(line).toContain("spawn failed: ENOENT");
     });
   });
 

--- a/packages/daemon/src/abstract-worker-server.spec.ts
+++ b/packages/daemon/src/abstract-worker-server.spec.ts
@@ -414,6 +414,32 @@ describe("AbstractWorkerServer", () => {
       expect(line).toContain("spawn exited");
       expect(line).toContain("spawn failed: ENOENT");
     });
+
+    test("db:disconnected surfaces the newest 5 stderr lines (tail, not head), in order (#2769)", () => {
+      using opts = testOptions();
+      db = new StateDb(opts.DB_PATH);
+      const { logger, texts } = capturingLogger();
+      const s = new StubWorkerServer(db, undefined, instantClient, logger, undefined, new MetricsCollector());
+      server = s;
+
+      // 8 lines — a session that ran a while then died. The disconnect summary
+      // must show the death cause (newest), not the startup banner (oldest).
+      for (let i = 0; i < 8; i++) {
+        internals(s).handleWorkerEvent({
+          type: "db:stderr",
+          sessionId: "sess-tail",
+          line: `line-${i}`,
+          timestamp: 3000 + i,
+        });
+      }
+      internals(s).handleWorkerEvent({ type: "db:disconnected", sessionId: "sess-tail", reason: "spawn exited" });
+
+      const line = texts.find((t) => t.includes("disconnected"));
+      expect(line).toBeDefined();
+      // Newest 5 (line-3..line-7), oldest→newest; banners line-0..line-2 dropped.
+      expect(line).toContain("line-3 | line-4 | line-5 | line-6 | line-7");
+      expect(line).not.toContain("line-0");
+    });
   });
 
   // ── Protocol version negotiation ──

--- a/packages/daemon/src/abstract-worker-server.ts
+++ b/packages/daemon/src/abstract-worker-server.ts
@@ -581,7 +581,7 @@ export abstract class AbstractWorkerServer {
         // Surface the captured stderr tail inline so the disconnect line is a
         // self-contained postmortem rather than a bare "spawn exited" (#2738).
         const tail = this.db
-          .getServerLogs(event.sessionId, 5)
+          .getRecentServerLogs(event.sessionId, 5)
           .map((l) => l.line)
           .join(" | ");
         const suffix = tail ? ` — stderr: ${tail}` : "";

--- a/packages/daemon/src/abstract-worker-server.ts
+++ b/packages/daemon/src/abstract-worker-server.ts
@@ -57,6 +57,13 @@ interface DbDisconnected {
   reason: string;
 }
 
+interface DbStderr {
+  type: "db:stderr";
+  sessionId: string;
+  line: string;
+  timestamp: number;
+}
+
 interface DbEnd {
   type: "db:end";
   sessionId: string;
@@ -86,6 +93,7 @@ export type BaseWorkerEvent =
   | DbState
   | DbCost
   | DbDisconnected
+  | DbStderr
   | DbEnd
   | DbMetric
   | DbHistogram
@@ -97,6 +105,7 @@ export const BASE_WORKER_EVENT_TYPES: ReadonlySet<string> = new Set<BaseWorkerEv
   "db:state",
   "db:cost",
   "db:disconnected",
+  "db:stderr",
   "db:end",
   "metrics:inc",
   "metrics:observe",
@@ -562,10 +571,26 @@ export abstract class AbstractWorkerServer {
         this.onSessionCost(event);
         this.onActivity?.();
         break;
-      case "db:disconnected":
-        this.logger.warn(`[${d.providerName}-server] Session ${event.sessionId} disconnected: ${event.reason}`);
+      case "db:stderr":
+        // Persist child-process stderr keyed by session ID so spawn-failure
+        // postmortems survive the session's death (#2738). `mcx logs <session-id>`
+        // reads these back via the getLogs DB fallback.
+        this.db.insertServerLog(event.sessionId, event.line, event.timestamp);
+        break;
+      case "db:disconnected": {
+        // Surface the captured stderr tail inline so the disconnect line is a
+        // self-contained postmortem rather than a bare "spawn exited" (#2738).
+        const tail = this.db
+          .getServerLogs(event.sessionId, 5)
+          .map((l) => l.line)
+          .join(" | ");
+        const suffix = tail ? ` — stderr: ${tail}` : "";
+        this.logger.warn(
+          `[${d.providerName}-server] Session ${event.sessionId} disconnected: ${event.reason}${suffix}`,
+        );
         this.db.updateSessionState(event.sessionId, "disconnected");
         break;
+      }
       case "db:end":
         this.activeSessions.delete(event.sessionId);
         this.sessionAddedAt.delete(event.sessionId);

--- a/packages/daemon/src/claude-server.spec.ts
+++ b/packages/daemon/src/claude-server.spec.ts
@@ -25,6 +25,7 @@ describe("WORKER_EVENT_TYPES", () => {
       "db:state",
       "db:cost",
       "db:disconnected",
+      "db:stderr",
       "db:end",
       "metrics:inc",
       "metrics:observe",
@@ -45,6 +46,7 @@ describe("isWorkerEvent", () => {
     expect(isWorkerEvent({ type: "db:state", sessionId: "s1", state: "active" })).toBe(true);
     expect(isWorkerEvent({ type: "db:cost", sessionId: "s1", cost: 0, tokens: 0 })).toBe(true);
     expect(isWorkerEvent({ type: "db:disconnected", sessionId: "s1", reason: "x" })).toBe(true);
+    expect(isWorkerEvent({ type: "db:stderr", sessionId: "s1", line: "boom", timestamp: 1 })).toBe(true);
     expect(isWorkerEvent({ type: "db:end", sessionId: "s1" })).toBe(true);
   });
 

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -768,6 +768,8 @@ async function startServer(wsPort?: number, quiet?: boolean): Promise<number> {
   wsServer = new ClaudeWsServer(wsServerOpts);
   wsServer.onSessionEvent = forwardSessionEvent;
   wsServer.onMonitorEvent = (input) => self.postMessage({ type: "monitor:event", input });
+  wsServer.onStderrLine = (sessionId, line, timestamp) =>
+    self.postMessage({ type: "db:stderr", sessionId, line, timestamp });
   const port = await wsServer.start(wsPort);
 
   // Start MCP Server

--- a/packages/daemon/src/claude-session/ws-server-stdio.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server-stdio.spec.ts
@@ -440,6 +440,87 @@ describe("ClaudeWsServer — stdio transport", () => {
     expect(mock.lastCmd).toContain("stream-json");
   });
 
+  test("forwards line-buffered child stderr keyed by session, flushing trailing partial on exit (#2738)", async () => {
+    let onStderr: ((chunk: string) => void) | undefined;
+    let onStderrEnd: (() => void) | undefined;
+    let exitResolve: (code: number) => void = () => {};
+    const spawn: SpawnFn = (_cmd, opts) => {
+      onStderr = opts.onStderr;
+      onStderrEnd = opts.onStderrEnd;
+      return {
+        pid: 6001,
+        exited: new Promise<number>((r) => {
+          exitResolve = r;
+        }),
+        kill: () => exitResolve(143),
+        stdout: new ReadableStream<Uint8Array>({ start() {} }),
+        stdin: { write: () => 0, flush: () => 0 },
+        stderrTail: () => "",
+      };
+    };
+    server = new ClaudeWsServer({ spawn, logger: silentLogger, connectTimeoutMs: 5000 });
+    await server.start(0);
+
+    const captured: Array<{ sessionId: string; line: string }> = [];
+    server.onStderrLine = (sessionId, line) => captured.push({ sessionId, line });
+
+    const sessionId = crypto.randomUUID();
+    server.prepareSession(sessionId, { prompt: "hi", transport: "stdio" });
+    server.spawnClaude(sessionId);
+
+    expect(onStderr).toBeDefined();
+    // Chunk boundaries split mid-line — the buffer must reassemble across chunks.
+    onStderr?.("auth error: token ");
+    onStderr?.("expired\nversion mis");
+    onStderr?.("match\n");
+    // A final line with NO trailing newline — must NOT be emitted until EOF.
+    onStderr?.("fatal: no trailing newline");
+    expect(captured.map((c) => c.line)).toEqual(["auth error: token expired", "version mismatch"]);
+
+    // Stream EOF flushes the trailing partial — the canary's first/only bytes.
+    onStderrEnd?.();
+    expect(captured.map((c) => c.line)).toEqual([
+      "auth error: token expired",
+      "version mismatch",
+      "fatal: no trailing newline",
+    ]);
+    expect(captured.every((c) => c.sessionId === sessionId)).toBe(true);
+  });
+
+  test("a single partial stderr line with no newline is flushed on exit, not dropped (#2738)", async () => {
+    let onStderr: ((chunk: string) => void) | undefined;
+    let onStderrEnd: (() => void) | undefined;
+    let exitResolve: (code: number) => void = () => {};
+    const spawn: SpawnFn = (_cmd, opts) => {
+      onStderr = opts.onStderr;
+      onStderrEnd = opts.onStderrEnd;
+      return {
+        pid: 6002,
+        exited: new Promise<number>((r) => {
+          exitResolve = r;
+        }),
+        kill: () => exitResolve(143),
+        stdout: new ReadableStream<Uint8Array>({ start() {} }),
+        stdin: { write: () => 0, flush: () => 0 },
+        stderrTail: () => "",
+      };
+    };
+    server = new ClaudeWsServer({ spawn, logger: silentLogger, connectTimeoutMs: 5000 });
+    await server.start(0);
+
+    const captured: string[] = [];
+    server.onStderrLine = (_sid, line) => captured.push(line);
+
+    const sessionId = crypto.randomUUID();
+    server.prepareSession(sessionId, { prompt: "hi", transport: "stdio" });
+    server.spawnClaude(sessionId);
+
+    onStderr?.("spawn failed: ENOENT claude");
+    expect(captured).toEqual([]);
+    onStderrEnd?.();
+    expect(captured).toEqual(["spawn failed: ENOENT claude"]);
+  });
+
   test("restored session without transport defaults to ws (fallback path)", async () => {
     const mock = mockStdioSpawn();
     server = new ClaudeWsServer({

--- a/packages/daemon/src/claude-session/ws-server-stdio.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server-stdio.spec.ts
@@ -521,6 +521,47 @@ describe("ClaudeWsServer — stdio transport", () => {
     expect(captured).toEqual(["spawn failed: ENOENT claude"]);
   });
 
+  test("a child spewing bytes with no newline is force-flushed in capped slices, bounding the buffer (#2769)", async () => {
+    let onStderr: ((chunk: string) => void) | undefined;
+    let onStderrEnd: (() => void) | undefined;
+    let exitResolve: (code: number) => void = () => {};
+    const spawn: SpawnFn = (_cmd, opts) => {
+      onStderr = opts.onStderr;
+      onStderrEnd = opts.onStderrEnd;
+      return {
+        pid: 6003,
+        exited: new Promise<number>((r) => {
+          exitResolve = r;
+        }),
+        kill: () => exitResolve(143),
+        stdout: new ReadableStream<Uint8Array>({ start() {} }),
+        stdin: { write: () => 0, flush: () => 0 },
+        stderrTail: () => "",
+      };
+    };
+    server = new ClaudeWsServer({ spawn, logger: silentLogger, connectTimeoutMs: 5000 });
+    await server.start(0);
+
+    const captured: string[] = [];
+    server.onStderrLine = (_sid, line) => captured.push(line);
+
+    const sessionId = crypto.randomUUID();
+    server.prepareSession(sessionId, { prompt: "hi", transport: "stdio" });
+    server.spawnClaude(sessionId);
+
+    const CAP = 64 * 1024;
+    // 200 KiB with no newline — must NOT accumulate unbounded; it is force-split.
+    onStderr?.("X".repeat(CAP * 3 + 100));
+    // Slices emitted while over the cap; a sub-cap remainder waits for EOF.
+    expect(captured.length).toBe(3);
+    expect(captured.every((l) => l.length === CAP)).toBe(true);
+    onStderrEnd?.();
+    // The trailing remainder is flushed on exit; no bytes are dropped.
+    expect(captured.length).toBe(4);
+    expect(captured[3]?.length).toBe(100);
+    expect(captured.reduce((n, l) => n + l.length, 0)).toBe(CAP * 3 + 100);
+  });
+
   test("restored session without transport defaults to ws (fallback path)", async () => {
     const mock = mockStdioSpawn();
     server = new ClaudeWsServer({

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -252,6 +252,10 @@ export type SpawnFn = (
     stderr?: "ignore" | "pipe";
     stdin?: "ignore" | "pipe";
     env?: Record<string, string | undefined>;
+    /** Real-time tap on decoded child stderr chunks (only when stderr === "pipe"). */
+    onStderr?: (chunk: string) => void;
+    /** Called once after the child stderr stream drains — flush trailing partial line. */
+    onStderrEnd?: () => void;
   },
 ) => {
   pid: number;
@@ -441,6 +445,13 @@ export class ClaudeWsServer {
 
   /** Called to forward monitor events to the main thread's EventBus (#1567). */
   onMonitorEvent: ((input: MonitorEventInput) => void) | null = null;
+
+  /**
+   * Called for each complete stderr line from a spawned child process, keyed by
+   * session ID. Forwarded to the main thread for persistence so spawn-failure
+   * postmortems are recoverable via `mcx logs <session-id>` (#2738).
+   */
+  onStderrLine: ((sessionId: string, line: string, timestamp: number) => void) | null = null;
 
   /**
    * Optional TLS material. When set, `Bun.serve` runs in HTTPS mode and binds
@@ -843,12 +854,34 @@ export class ClaudeWsServer {
     if (!useStdio && this.tlsConfig) {
       envOverrides.NODE_TLS_REJECT_UNAUTHORIZED = "0";
     }
+    // Line-buffer child stderr and forward each complete line keyed by session
+    // ID (#2738). Short-lived spawn failures may emit only a partial first line,
+    // so the tail is flushed on exit below — never dropped.
+    const stderrState = { partial: "" };
+    const emitStderr = (line: string) => {
+      if (line === "") return;
+      this.onStderrLine?.(sessionId, line, Date.now());
+    };
+
     const proc = this.spawn(cmd, {
       cwd: session.config.cwd,
       stdout: useStdio ? "pipe" : "ignore",
       stderr: "pipe",
       stdin: useStdio ? "pipe" : "ignore",
       env: Object.keys(envOverrides).length > 0 ? envOverrides : undefined,
+      onStderr: (chunk) => {
+        const text = stderrState.partial + chunk;
+        const lines = text.split("\n");
+        stderrState.partial = lines.pop() ?? "";
+        for (const line of lines) emitStderr(line);
+      },
+      onStderrEnd: () => {
+        // Flush the trailing partial line (stderr without a final newline) so a
+        // short-lived spawn's only output is never dropped (#2738).
+        const last = stderrState.partial;
+        stderrState.partial = "";
+        emitStderr(last);
+      },
     });
 
     session.pid = proc.pid;
@@ -2782,6 +2815,8 @@ function defaultSpawn(
     stderr?: "ignore" | "pipe";
     stdin?: "ignore" | "pipe";
     env?: Record<string, string | undefined>;
+    onStderr?: (chunk: string) => void;
+    onStderrEnd?: () => void;
   },
 ): ReturnType<SpawnFn> {
   // Strip CLAUDECODE env var so the spawned claude process doesn't think
@@ -2802,6 +2837,8 @@ function defaultSpawn(
     stdout: opts.stdout ?? "pipe",
     stderr: opts.stderr ?? "pipe",
     stdin: opts.stdin ?? "pipe",
+    onStderr: opts.onStderr,
+    onStderrEnd: opts.onStderrEnd,
   });
   if (!r.ok) throw new Error(`Failed to spawn ${bin}`);
   return {

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -75,6 +75,11 @@ const KILL_SIGKILL_GRACE_MS = 2_000;
 /** Time (ms) to wait for a WebSocket connection after spawning a Claude CLI process. */
 const CONNECT_TIMEOUT_MS = 30_000;
 
+/** Max chars retained in the unterminated child-stderr line buffer before it is
+ * force-flushed in slices, bounding memory for a child that never emits a
+ * newline (#2769). 64 KiB matches the spawnManaged stderr ring default. */
+const MAX_STDERR_LINE_CHARS = 64 * 1024;
+
 /** Message types handled by the state machine's dispatch. */
 const HANDLED_MSG_TYPES: ReadonlyArray<string> = [
   "system",
@@ -874,6 +879,14 @@ export class ClaudeWsServer {
         const lines = text.split("\n");
         stderrState.partial = lines.pop() ?? "";
         for (const line of lines) emitStderr(line);
+        // Cap the unterminated partial: a child spewing bytes with no newline
+        // (a JSON/base64 blob, a \r-only progress bar) would otherwise grow this
+        // buffer — and the single line eventually forwarded across the worker
+        // boundary — without bound (#2769). Force-emit in capped slices instead.
+        while (stderrState.partial.length > MAX_STDERR_LINE_CHARS) {
+          emitStderr(stderrState.partial.slice(0, MAX_STDERR_LINE_CHARS));
+          stderrState.partial = stderrState.partial.slice(MAX_STDERR_LINE_CHARS);
+        }
       },
       onStderrEnd: () => {
         // Flush the trailing partial line (stderr without a final newline) so a

--- a/packages/daemon/src/db/state.spec.ts
+++ b/packages/daemon/src/db/state.spec.ts
@@ -311,6 +311,45 @@ describe("StateDb", () => {
       db.close();
     });
 
+    test("getRecentServerLogs returns the newest N (tail), in chronological order (#2769)", () => {
+      const db = createDb();
+      const now = Date.now();
+      db.insertServerLog("srv", "a", now);
+      db.insertServerLog("srv", "b", now + 1);
+      db.insertServerLog("srv", "c", now + 2);
+      db.insertServerLog("srv", "d", now + 3);
+
+      // getServerLogs (head) takes the OLDEST 2; getRecentServerLogs takes the
+      // newest 2 — the opposite end — and returns them oldest→newest.
+      expect(db.getServerLogs("srv", 2).map((l) => l.line)).toEqual(["a", "b"]);
+      expect(db.getRecentServerLogs("srv", 2).map((l) => l.line)).toEqual(["c", "d"]);
+      db.close();
+    });
+
+    test("getRecentServerLogs without a limit returns all, oldest→newest", () => {
+      const db = createDb();
+      const now = Date.now();
+      db.insertServerLog("srv", "a", now);
+      db.insertServerLog("srv", "b", now + 1);
+      expect(db.getRecentServerLogs("srv").map((l) => l.line)).toEqual(["a", "b"]);
+      expect(db.getRecentServerLogs("nope")).toEqual([]);
+      db.close();
+    });
+
+    test("getRecentServerLogs breaks timestamp ties by insertion order (id tiebreaker, #2769)", () => {
+      const db = createDb();
+      const ts = Date.now();
+      // Three lines sharing one Date.now() ms — as happens when one stderr chunk
+      // splits into multiple lines. Insertion order must be preserved.
+      db.insertServerLog("srv", "first", ts);
+      db.insertServerLog("srv", "second", ts);
+      db.insertServerLog("srv", "third", ts);
+
+      expect(db.getRecentServerLogs("srv", 2).map((l) => l.line)).toEqual(["second", "third"]);
+      expect(db.getServerLogs("srv").map((l) => l.line)).toEqual(["first", "second", "third"]);
+      db.close();
+    });
+
     test("clearServerLogs by server", () => {
       const db = createDb();
       const now = Date.now();

--- a/packages/daemon/src/db/state.ts
+++ b/packages/daemon/src/db/state.ts
@@ -1099,12 +1099,35 @@ export class StateDb {
     const limitClause = limit ? " LIMIT ?" : "";
     if (limit) params.push(limit);
 
+    // `id` tiebreaker: lines from one stderr chunk share a Date.now() ms, so
+    // ordering on timestamp_ms alone is nondeterministic within a chunk (#2769).
     return this.db
       .query<{ line: string; timestamp_ms: number }, (string | number)[]>(
-        `SELECT line, timestamp_ms FROM server_logs WHERE ${where} ORDER BY timestamp_ms ASC${limitClause}`,
+        `SELECT line, timestamp_ms FROM server_logs WHERE ${where} ORDER BY timestamp_ms ASC, id ASC${limitClause}`,
       )
       .all(...params)
       .map((row) => ({ line: row.line, timestampMs: row.timestamp_ms }));
+  }
+
+  /**
+   * Most recent `limit` log lines for a server, returned in chronological
+   * (oldest→newest) order. Unlike {@link getServerLogs} — which takes the
+   * OLDEST N — this returns the TAIL, i.e. the lines a spawn-failure postmortem
+   * actually wants (#2769). Mirrors the in-memory ring's newest-N semantics so
+   * `mcx logs <id>` reads the same end whether the session is live or dead.
+   */
+  getRecentServerLogs(serverName: string, limit?: number): Array<{ line: string; timestampMs: number }> {
+    const limitClause = limit ? " LIMIT ?" : "";
+    const params: (string | number)[] = [serverName];
+    if (limit) params.push(limit);
+
+    const rows = this.db
+      .query<{ line: string; timestamp_ms: number }, (string | number)[]>(
+        `SELECT line, timestamp_ms FROM server_logs WHERE server_name = ? ORDER BY timestamp_ms DESC, id DESC${limitClause}`,
+      )
+      .all(...params)
+      .map((row) => ({ line: row.line, timestampMs: row.timestamp_ms }));
+    return rows.reverse();
   }
 
   clearServerLogs(serverName?: string): void {

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -57,6 +57,7 @@ function mockDb(overrides?: Partial<Record<string, unknown>>) {
     touchAliasExpiry: () => {},
     pruneExpiredAliases: () => 0,
     getServerLogs: () => [],
+    getRecentServerLogs: () => [],
     getCachedTools: () => [],
     listSessions: () => [],
     getDatabase: () => new Database(":memory:"),
@@ -2100,11 +2101,18 @@ describe("IpcServer HTTP transport", () => {
     expect(buffer).toContain("pool-line");
   });
 
-  test("getLogs falls back to persistent DB when the pool ring is empty (#2738)", async () => {
+  test("getLogs falls back to the newest-N persistent tail when the pool ring is empty (#2738, #2769)", async () => {
     socketPath = tmpSocket();
+    // The fallback must read the TAIL (getRecentServerLogs), not the head — a
+    // postmortem wants the death cause, not the startup banner (#2769).
+    const recentCalls: Array<{ server: string; limit?: number }> = [];
     const db = mockDb({
-      getServerLogs: (serverName: string) =>
-        serverName === "sess-dead" ? [{ line: "spawn failed: ENOENT", timestampMs: 4242 }] : [],
+      // Head reader — if the fallback wrongly calls this, the test sees banners.
+      getServerLogs: () => [{ line: "startup banner", timestampMs: 1 }],
+      getRecentServerLogs: (serverName: string, limit?: number) => {
+        recentCalls.push({ server: serverName, limit });
+        return serverName === "sess-dead" ? [{ line: "spawn failed: ENOENT", timestampMs: 4242 }] : [];
+      },
     });
     // Pool ring is empty (default mockPool getStderrLines) → a dead session is
     // no longer in the pool, so getLogs must read its persisted stderr from DB.
@@ -2122,6 +2130,8 @@ describe("IpcServer HTTP transport", () => {
       server: "sess-dead",
       lines: [{ timestamp: 4242, line: "spawn failed: ENOENT" }],
     });
+    // Proves the tail reader was used (with the caller's limit), not the head.
+    expect(recentCalls).toEqual([{ server: "sess-dead", limit: 10 }]);
   });
 
   // Bug #1 regression: callTool → _aliases must forward the caller's cwd so

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -2100,6 +2100,30 @@ describe("IpcServer HTTP transport", () => {
     expect(buffer).toContain("pool-line");
   });
 
+  test("getLogs falls back to persistent DB when the pool ring is empty (#2738)", async () => {
+    socketPath = tmpSocket();
+    const db = mockDb({
+      getServerLogs: (serverName: string) =>
+        serverName === "sess-dead" ? [{ line: "spawn failed: ENOENT", timestampMs: 4242 }] : [],
+    });
+    // Pool ring is empty (default mockPool getStderrLines) → a dead session is
+    // no longer in the pool, so getLogs must read its persisted stderr from DB.
+    server = new IpcServer(mockPool() as never, mockConfig(), db, null, opts());
+    server.start(socketPath);
+
+    const res = await rpc("/rpc", {
+      id: "logs-fallback",
+      method: "getLogs",
+      params: { server: "sess-dead", limit: 10 },
+    });
+    const json = (await res.json()) as IpcResponse;
+    expect(json.error).toBeUndefined();
+    expect(json.result).toEqual({
+      server: "sess-dead",
+      lines: [{ timestamp: 4242, line: "spawn failed: ENOENT" }],
+    });
+  });
+
   // Bug #1 regression: callTool → _aliases must forward the caller's cwd so
   // the executor subprocess can resolve repo root from the caller, not from
   // the daemon's cwd. See PR #1307 adversarial review.

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -448,6 +448,16 @@ export class IpcServer {
 
       if (since === undefined) {
         const lines = this.pool.getStderrLines(server, limit);
+        // Fall back to the persistent log when the in-memory ring is empty — a
+        // dead claude/agent session (or stopped MCP server) is no longer in the
+        // pool, but its stderr was persisted keyed by session ID (#2738).
+        if (lines.length === 0) {
+          const dbLogs = this.db.getServerLogs(server, limit);
+          return {
+            server,
+            lines: dbLogs.map((l) => ({ timestamp: l.timestampMs, line: l.line })),
+          };
+        }
         return {
           server,
           lines: lines.map((l) => ({ timestamp: l.timestamp, line: l.line })),

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -451,8 +451,10 @@ export class IpcServer {
         // Fall back to the persistent log when the in-memory ring is empty — a
         // dead claude/agent session (or stopped MCP server) is no longer in the
         // pool, but its stderr was persisted keyed by session ID (#2738).
+        // Use the newest-N tail so the DB read matches the ring's semantics —
+        // a postmortem wants the death cause, not the startup banner (#2769).
         if (lines.length === 0) {
-          const dbLogs = this.db.getServerLogs(server, limit);
+          const dbLogs = this.db.getRecentServerLogs(server, limit);
           return {
             server,
             lines: dbLogs.map((l) => ({ timestamp: l.timestampMs, line: l.line })),


### PR DESCRIPTION
## Summary
- stdio-transport claude sessions spawn a child process in a worker thread; its stderr was drained by `spawnManaged` but never surfaced to the daemon, so a session dying within seconds (both sprint-72 canaries) left no recoverable record of *why*.
- Line-buffer the child's stderr keyed by **session ID** (`ClaudeWsServer.onStderrLine` → worker `db:stderr` message → `insertServerLog`), surface the captured tail inline on the `disconnected` daemon-log line, and make `getLogs` fall back to the persistent DB when the in-memory ring is empty so **`mcx logs <session-id>` returns postmortem stderr for an already-exited session**.
- Added a `spawnManaged` `onStderrEnd` hook so a trailing partial line (stderr with **no final newline**) is flushed on stream EOF — both canaries died in ~3s, so the very first bytes may be a partial line and must not be dropped.

## What changed
- `core/subprocess.ts` — new `onStderrEnd?()` option, called once after the stderr stream drains (after the final chunk).
- `ws-server.ts` — `SpawnFn`/`defaultSpawn` thread `onStderr`/`onStderrEnd`; new `onStderrLine` callback; `spawnClaude` line-buffers stderr and flushes the trailing partial on EOF.
- `claude-session-worker.ts` — forwards `db:stderr` to the parent.
- `abstract-worker-server.ts` — new `db:stderr` worker event persists via `insertServerLog`; `db:disconnected` log line now appends the recent stderr tail.
- `ipc-server.ts` — `getLogs` falls back to `db.getServerLogs` when the pool ring is empty.

## Test plan
- [x] `ws-server-stdio.spec.ts` — line-buffering reassembles across chunk boundaries; trailing partial flushed on exit; single no-newline line not dropped; lines keyed by session ID
- [x] `subprocess.spec.ts` — `onStderrEnd` fires once, after the final chunk
- [x] `abstract-worker-server.spec.ts` — `db:stderr` persists keyed by session ID; `db:disconnected` log surfaces the stderr tail; exhaustiveness lists updated
- [x] `ipc-server.spec.ts` — `getLogs` DB fallback returns persisted stderr for a dead session
- [x] `bun run am-i-done` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)