### PR TITLE
security(containment): surface shared-temp writes as warnings (closes #2723)

### DIFF
--- a/packages/core/src/containment.spec.ts
+++ b/packages/core/src/containment.spec.ts
@@ -264,31 +264,63 @@ describe("ContainmentGuard — file writes outside worktree", () => {
     expect(r.event).toBe("session:containment_escalated");
   });
 
-  test("allows Write to /tmp (no strike)", () => {
+  // /tmp writes stay allowed (the write proceeds) but are surfaced as a
+  // warning — never a strike — so the shared-temp cross-session channel is
+  // observable on the monitor stream (#2723).
+  test("warns (no strike) on Write to /tmp", () => {
     const g = guard();
     const r = g.evaluate("Write", { file_path: "/tmp/scratch.txt" });
-    expect(r.action).toBe("allow");
+    expect(r.action).toBe("warn");
+    expect(r.event).toBe("session:containment_warning");
+    expect(r.reason).toContain("shared /tmp");
     expect(r.strikes).toBe(0);
   });
 
-  test("allows Write to /private/tmp (macOS)", () => {
+  test("warns (no strike) on Write to /private/tmp (macOS)", () => {
     const g = guard();
     const r = g.evaluate("Write", { file_path: "/private/tmp/test.json" });
-    expect(r.action).toBe("allow");
+    expect(r.action).toBe("warn");
+    expect(r.event).toBe("session:containment_warning");
     expect(r.strikes).toBe(0);
   });
 
-  test("allows Write to //private/tmp (double-slash normalized by resolve)", () => {
+  test("warns (no strike) on Write to //private/tmp (double-slash normalized by resolve)", () => {
     const g = guard();
     const r = g.evaluate("Write", { file_path: "//private/tmp/test.json" });
-    expect(r.action).toBe("allow");
+    expect(r.action).toBe("warn");
+    expect(r.event).toBe("session:containment_warning");
     expect(r.strikes).toBe(0);
   });
 
-  test("allows shell redirect to //tmp (double-slash normalized)", () => {
+  test("warns on shell redirect to //tmp (double-slash normalized)", () => {
     const g = guard();
     const r = g.evaluate("Bash", { command: 'echo "x" > //tmp/scratch.txt' });
-    expect(r.action).toBe("allow");
+    expect(r.action).toBe("warn");
+    expect(r.event).toBe("session:containment_warning");
+  });
+
+  test("warns on cp to /tmp via Bash (no strike)", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: `cp ${WORKTREE}/src/a.ts /tmp/staged.ts` });
+    expect(r.action).toBe("warn");
+    expect(r.event).toBe("session:containment_warning");
+    expect(r.strikes).toBe(0);
+  });
+
+  test("repeated /tmp writes never escalate", () => {
+    const g = guard();
+    for (let i = 0; i < 10; i++) {
+      g.evaluate("Write", { file_path: `/tmp/scratch-${i}.txt` });
+    }
+    expect(g.strikes).toBe(0);
+    expect(g.escalated).toBe(false);
+  });
+
+  test("a hard-deny target wins over a /tmp warn in the same Bash command", () => {
+    const g = guard();
+    const r = g.evaluate("Bash", { command: "cp /tmp/staged.ts /Users/test/repo/evil.ts" });
+    expect(r.action).toBe("deny");
+    expect(r.strikes).toBe(1);
   });
 });
 
@@ -411,10 +443,11 @@ describe("ContainmentGuard — bash file write detection", () => {
     expect(r.action).toBe("allow");
   });
 
-  test("allows shell redirect to /tmp", () => {
+  test("warns on shell redirect to /tmp (#2723)", () => {
     const g = guard();
     const r = g.evaluate("Bash", { command: 'echo "scratch" > /tmp/scratch.txt' });
-    expect(r.action).toBe("allow");
+    expect(r.action).toBe("warn");
+    expect(r.event).toBe("session:containment_warning");
   });
 
   test("denies cp to outside path", () => {

--- a/packages/core/src/containment.ts
+++ b/packages/core/src/containment.ts
@@ -430,16 +430,40 @@ export class ContainmentGuard {
       }
     }
 
-    // Check shell file writes (redirects, cp, mv, tee, ln, etc.)
+    // Check shell file writes (redirects, cp, mv, tee, ln, etc.). A shared-temp
+    // write is allowed-but-monitored; a hard deny (out-of-worktree, non-temp)
+    // takes precedence, so record the temp warn and keep scanning.
     const writeTargets = extractBashWriteTargets(command);
+    let tmpWarn: ContainmentResult | null = null;
     for (const target of writeTargets) {
-      if (isAllowedExternalPath(target, this.worktreeRoot, this._unresolvedRoot)) continue;
+      if (isAllowedExternalPath(target, this.worktreeRoot, this._unresolvedRoot)) {
+        tmpWarn ??= this.makeTmpWarn("Bash", target);
+        continue;
+      }
       if (isPathOutside(target, this.worktreeRoot)) {
         return this.evaluateFileAccess("Bash", target);
       }
     }
+    if (tmpWarn) return tmpWarn;
 
     return { action: "allow", reason: "", strikes: this._strikes };
+  }
+
+  /**
+   * Shared temp (/tmp, /var/tmp, /private/tmp) writes are allowed by policy but
+   * surfaced as a warning (#2723): all host worktrees share /tmp, so a silent
+   * write there is an unobservable cross-session channel. `warn` does not strike
+   * and does not deny — the write proceeds — but it now shows on the monitor
+   * stream so the activity is no longer invisible.
+   */
+  private makeTmpWarn(toolName: string, filePath: string): ContainmentResult {
+    const resolved = resolveRealpath(resolve(this.worktreeRoot, filePath));
+    return {
+      action: "warn",
+      reason: `${toolName} writes ${resolved} in shared temp outside worktree ${this.worktreeRoot}. Allowed but monitored — shared /tmp is a cross-session channel.`,
+      event: "session:containment_warning",
+      strikes: this._strikes,
+    };
   }
 
   private evaluateFileAccess(toolName: string, filePath: string): ContainmentResult {
@@ -456,9 +480,10 @@ export class ContainmentGuard {
     }
 
     // Write/Edit: strike-counted gray zone
-    // Allow /tmp writes without penalty (symlink escapes excluded via worktreeRoot guard)
+    // /tmp writes are allowed without penalty but surfaced as a warning (#2723);
+    // symlink escapes are excluded via the worktreeRoot guard in isAllowedExternalPath.
     if (isAllowedExternalPath(filePath, this.worktreeRoot, this._unresolvedRoot)) {
-      return { action: "allow", reason: "", strikes: this._strikes };
+      return this.makeTmpWarn(toolName, filePath);
     }
 
     this._strikes++;


### PR DESCRIPTION
## Summary
- Provider-mediated fs writes (ACP/codex/opencode) to `/tmp`, `/var/tmp`, `/private/tmp` were allowed with **no strike and no event** after #2720 routed them through `ContainmentGuard` — an invisible cross-session staging channel on the shared host `/tmp`.
- Changes the `/tmp` allowlist branches (`evaluateFileAccess` for Write/Edit, the `evaluateBash` loop) from a silent `allow` to a `warn` (`session:containment_warning`) via a new `makeTmpWarn` helper.
- **Policy unchanged (Option 3 from the issue)**: `warn` never denies and never strikes, so the write still proceeds and every consumer (ws-server, acp, codex, opencode — all branch only on `action === "deny"`) is unaffected. The activity now surfaces on the `mcx monitor` stream. A hard-deny target still wins over a `/tmp` warn in the same Bash command.

## Test plan
- [x] `bun run am-i-done` (full gate: typecheck, lint, rules, tests, coverage) — green
- [x] Flipped the 4 existing `/tmp → allow` containment tests to expect `warn` + `session:containment_warning` event + zero strikes
- [x] Added tests: `cp` to /tmp warns, repeated /tmp writes never escalate, and a hard-deny target wins over a /tmp warn in one Bash command
- [x] Provider specs (acp/codex/opencode session + codex permission adapter) still pass — no consumer regresses on `warn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)