### PR TITLE
fix(watcher): eliminate scheduleReload debounce-count flake (fixes #2729)

### DIFF
--- a/packages/daemon/src/config/watcher.spec.ts
+++ b/packages/daemon/src/config/watcher.spec.ts
@@ -12,7 +12,6 @@ const POLL_MS = 50;
 const SETTLE_MS = 200;
 const DEBOUNCE_POLL_MS = 20;
 const DEBOUNCE_SETTLE_MS = 100;
-const DEBOUNCE_WAIT_MS = 300;
 
 /** Build an McpConfigFile from server entries */
 function mcpConfig(servers: Record<string, ServerConfig>): McpConfigFile {
@@ -414,7 +413,9 @@ describe("ConfigWatcher error paths", () => {
       },
       logger: silentLogger,
     });
-    watcher.start();
+    // Do NOT call watcher.start() — the poll timer would independently detect the
+    // file write and call scheduleReload() again, racing with the debounce under load.
+    // This test is about debounce deduplication, not polling/watching behavior.
 
     // Write a change then call scheduleReload twice in quick succession
     writeJson(opts.USER_SERVERS_PATH, mcpConfig({ beta: { command: "cat" } }));
@@ -422,10 +423,10 @@ describe("ConfigWatcher error paths", () => {
     scheduleReload();
     scheduleReload();
 
-    // Wait for debounce to settle
-    await Bun.sleep(DEBOUNCE_WAIT_MS);
+    // Wait for the debounce to fire (condition-based, not time-based — test/CLAUDE.md)
+    await waitForCalls(cb, 1);
 
-    // Should have loaded at most once despite double schedule
+    // Should have loaded exactly once despite double schedule
     expect(loadCount).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary
- Remove `watcher.start()` from the debounce-deduplication test: the poll timer (50ms interval) was independently detecting the file write during the fixed 300ms sleep and calling `scheduleReload()` again, racing with the debounce under load → `loadCount = 2`
- Replace `await Bun.sleep(DEBOUNCE_WAIT_MS)` with `await waitForCalls(cb, 1)` — condition-based wait per `test/CLAUDE.md` (test the CONDITION, not time passing)
- Remove now-unused `DEBOUNCE_WAIT_MS` constant

## Test plan
- [x] Reproduced flake: `Expected: 1, Received: 2` on run 6 of 20 before fix
- [x] Verified fix: 30/30 passes after fix (`for i in {1..30}; do bun test ... || break; done`)
- [x] `bun run am-i-done` passes (typecheck → lint → rules → tests → coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)