### PR TITLE
fix(ci): stop classifying .claude/phases/*.ts as docs-only in detect (fixes #2717)

### DIFF
--- a/.git-hooks/classify.sh
+++ b/.git-hooks/classify.sh
@@ -18,8 +18,13 @@ classify_files() {
   while IFS= read -r file; do
     [ -z "$file" ] && continue
     case "$file" in
-      # Docs: markdown files, .claude/ directory contents
-      *.md | .claude/*)
+      # Docs: markdown files plus the enumerated docs-only .claude/ subdirs.
+      # Other .claude/ paths are NOT docs — .claude/phases/*.ts are executable
+      # phase scripts with specs run by am-i-done (test:phases, #2648), and
+      # automation/workflows/skills also carry runnable code (#2717). They
+      # fall through to config (*.json) or source below.
+      # Keep in sync with the detect job in .github/workflows/ci.yml.
+      *.md | .claude/diary/* | .claude/sprints/* | .claude/memory/*)
         ;;
       # Config: JSON files, scripts/, build tooling, git hooks, CI workflows
       *.json | scripts/* | .git-hooks/* | .github/*)

--- a/.git-hooks/classify.spec.ts
+++ b/.git-hooks/classify.spec.ts
@@ -43,8 +43,43 @@ describe("pre-commit classify_files", () => {
     expect(result.has_config).toBe(false);
   });
 
-  test("docs-only: .claude/ non-markdown files", async () => {
-    const result = await classify([".claude/diary/20260318.md", ".claude/arcs.md"]);
+  test("docs-only: enumerated .claude/ docs subdirs", async () => {
+    const result = await classify([
+      ".claude/diary/20260318.md",
+      ".claude/sprints/sprint-72.md",
+      ".claude/memory/notes.md",
+      ".claude/arcs.md",
+    ]);
+    expect(result.has_source).toBe(false);
+    expect(result.has_config).toBe(false);
+  });
+
+  // .claude/phases/*.ts are executable phase scripts with specs run by
+  // am-i-done (test:phases, #2648) — never docs-only (#2717).
+  test("source: .claude/phases/ phase scripts and specs", async () => {
+    const result = await classify([".claude/phases/done-fn.ts", ".claude/phases/done-fn.spec.ts"]);
+    expect(result.has_source).toBe(true);
+    expect(result.has_config).toBe(false);
+  });
+
+  test("source: other runnable .claude/ code (automation, workflows, skills)", async () => {
+    const result = await classify([
+      ".claude/automation/bind.ts",
+      ".claude/workflows/sprint-lessons.js",
+      ".claude/skills/release/release.ts",
+    ]);
+    expect(result.has_source).toBe(true);
+    expect(result.has_config).toBe(false);
+  });
+
+  test("config: .claude/ JSON files", async () => {
+    const result = await classify([".claude/settings.local.json"]);
+    expect(result.has_source).toBe(false);
+    expect(result.has_config).toBe(true);
+  });
+
+  test("docs-only: .claude/ markdown outside enumerated subdirs", async () => {
+    const result = await classify([".claude/agents/issue-author.md", ".claude/commands/qa.md"]);
     expect(result.has_source).toBe(false);
     expect(result.has_config).toBe(false);
   });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,15 @@ concurrency:
   cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 jobs:
-  # Detect whether this PR touches only docs (*.md, .claude/*).
-  # Config files (*.json, .github/**, scripts/**, .git-hooks/**) and all source
-  # code are NOT docs-only. push-to-main and workflow_dispatch events are never
-  # docs-only. Sets output docs_only=true to let check/coverage/build skip work.
+  # Detect whether this PR touches only docs: *.md anywhere, plus the
+  # enumerated docs-only .claude/ subdirs (diary, sprints, memory). Other
+  # .claude/ paths are NOT docs — .claude/phases/*.ts are executable phase
+  # scripts tested by `am-i-done --ci` (test:phases, #2648), and automation/
+  # workflows/skills also carry runnable code (#2717). Config files (*.json,
+  # .github/**, scripts/**, .git-hooks/**) and all source code are NOT
+  # docs-only. push-to-main and workflow_dispatch events are never docs-only.
+  # Sets output docs_only=true to let check/coverage/build skip work.
+  # Keep the docs pattern in sync with .git-hooks/classify.sh.
   #
   # Security: the file list is read from the GitHub API (origin's view), not from
   # the PR's checkout. The classification logic is inlined here so a malicious PR
@@ -47,7 +52,7 @@ jobs:
           while IFS= read -r file; do
             [ -z "$file" ] && continue
             case "$file" in
-              *.md | .claude/*) ;;
+              *.md | .claude/diary/* | .claude/sprints/* | .claude/memory/*) ;;
               *) docs_only=false; break ;;
             esac
           done <<< "$changed"


### PR DESCRIPTION
## Summary
- The `detect` job in `ci.yml` (and its local mirror `.git-hooks/classify.sh`) blanket-matched `.claude/*` as docs-only, so a PR touching only `.claude/phases/*.ts` skipped check/coverage/build — the phase specs wired into `am-i-done --ci` (#2648) never ran for exactly the PRs that change them.
- Docs-only is now an allowlist: `*.md` anywhere plus `.claude/{diary,sprints,memory}/`. Everything else under `.claude/` (phases, automation, workflows, skills scripts, JSON) fails safe into full CI / the config-or-source tier. Both copies carry keep-in-sync comments pointing at each other.
- Added classify.spec.ts coverage: phases → source, automation/workflows/skills scripts → source, `.claude` JSON → config, diary/sprints/memory + non-enumerated `.claude` markdown → docs.

## Test plan
- [x] `cd .git-hooks && bun test --no-orphans` — 20 pass (incl. 5 new tests)
- [x] Shell simulation of the ci.yml inline case block: phase-only / phase-spec-only / skills-script PRs → `docs_only=false`; diary+sprint+md and agents-md PRs → `docs_only=true`
- [x] `bun run am-i-done` — full gate green
- [ ] Observe `detect` on this PR: it touches `.github/**` so `docs_only=false` and full CI runs

Note: the classify.spec.ts tests are inert in CI until #2771 lands (bunfig `pathIgnorePatterns` excludes `.git-hooks/**`; no `test:hooks` runner exists — filed while implementing this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)