### PR TITLE
security(acp): cap fs/write_text_file content at 50MB (fixes #2732)

### DIFF
--- a/packages/acp/src/acp-session.spec.ts
+++ b/packages/acp/src/acp-session.spec.ts
@@ -335,6 +335,27 @@ describe("AcpSession server requests", () => {
     expect(existsSync("/tmp/acp-traversal-probe.txt")).toBe(false);
   });
 
+  test("fs/write_text_file rejects content over the size cap and never writes (#2732)", async () => {
+    const probePath = join(TEST_CWD, "acp-oversize-probe.txt");
+    const { existsSync, unlinkSync } = await import("node:fs");
+    try {
+      const { session } = makeSession({ agent: "fs-write-oversize" });
+      const resultPromise = session.waitForResult(10000);
+      await session.start();
+      await resultPromise;
+
+      // The oversized payload must be rejected before touching disk.
+      expect(existsSync(probePath)).toBe(false);
+    } finally {
+      try {
+        unlinkSync(probePath);
+        // dotw-ignore test-empty-catch: best-effort cleanup — probe should never exist
+      } catch {
+        // ignore cleanup errors
+      }
+    }
+  });
+
   test("terminal/create runs async command and completes", async () => {
     const { session } = makeSession({ agent: "terminal" });
     const resultPromise = session.waitForResult(10000);

--- a/packages/acp/src/acp-session.ts
+++ b/packages/acp/src/acp-session.ts
@@ -501,9 +501,26 @@ export class AcpSession {
     this.emit({ type: "session:permission_request", request: permWithId });
   }
 
+  /** Upper bound on agent-supplied fs/write_text_file content (#2732). */
+  private static readonly MAX_FS_WRITE_BYTES = 50 * 1_024 * 1_024;
+
   private async handleFsWrite(id: number | string, params: Record<string, unknown>): Promise<void> {
     const path = params.path as string;
     const content = params.content as string;
+
+    // Bound the untrusted payload before touching disk (#2732): a looping or
+    // adversarial agent could otherwise fill the shared worktree filesystem and
+    // wedge co-tenant sessions — a worktree-local DoS that needs no containment
+    // escape. The read path is already capped in command/src/file-read.ts.
+    const byteLength = Buffer.byteLength(content, "utf8");
+    if (byteLength > AcpSession.MAX_FS_WRITE_BYTES) {
+      this.rpc?.respondWithError(
+        id,
+        -1,
+        `fs/write_text_file content (${byteLength} bytes) exceeds ${AcpSession.MAX_FS_WRITE_BYTES} byte limit`,
+      );
+      return;
+    }
 
     // Resolve to an absolute path so containment/cwd checks compare like for like.
     const resolved = resolve(this.config.cwd, path);

--- a/packages/acp/src/fake-acp-agent.ts
+++ b/packages/acp/src/fake-acp-agent.ts
@@ -12,6 +12,7 @@
  *   fs-read         — handshake + session/new + sends fs/read_text_file request, then completes
  *   fs-write-traversal — sends fs/write with path traversal (../outside.txt), then completes
  *   fs-write-escape — sends fs/write to an absolute non-/tmp path the containment guard denies
+ *   fs-write-oversize — sends fs/write with content over the 50MB size cap, then completes
  *   terminal        — handshake + session/new + sends terminal/create request, then completes
  *   terminal-escape — sends terminal/create with a command targeting a path outside the worktree
  *   terminal-cwd-escape — sends terminal/create with a benign command but a cwd outside the worktree
@@ -170,6 +171,16 @@ function schedulePromptEvents(): void {
       sendServerRequest("fs-4", "fs/write_text_file", {
         path: "/etc/acp-containment-escape-probe.txt",
         content: "should be blocked",
+      });
+      setTimeout(() => completePrompt(), MED_COMPLETE_DELAY_MS);
+    }, STEP_DELAY_MS);
+  } else if (mode === "fs-write-oversize") {
+    // Content exceeds the 50MB write cap — the daemon must reject before any
+    // disk write so a looping agent can't fill the shared filesystem (#2732).
+    setTimeout(() => {
+      sendServerRequest("fs-5", "fs/write_text_file", {
+        path: `${process.cwd()}/acp-oversize-probe.txt`,
+        content: "x".repeat(50 * 1_024 * 1_024 + 1),
       });
       setTimeout(() => completePrompt(), MED_COMPLETE_DELAY_MS);
     }, STEP_DELAY_MS);


### PR DESCRIPTION
## Summary
- `handleFsWrite` in `packages/acp/src/acp-session.ts` passed untrusted, agent-supplied `content` straight to `Bun.write` with no upper bound — a looping or adversarial ACP agent could fill the shared worktree filesystem and wedge co-tenant sessions (worktree-local DoS, no containment escape needed).
- Adds a `MAX_FS_WRITE_BYTES = 50MB` guard that rejects oversized payloads with an RPC error **before** any disk write, mirroring the read-path cap in `packages/command/src/file-read.ts`.
- Checked OpenCode/Codex session fs paths (per issue note): they have no analogous daemon-mediated `Bun.write` handler, so the gap is ACP-only.

## Test plan
- [x] New test `fs/write_text_file rejects content over the size cap and never writes (#2732)` — drives a new `fs-write-oversize` fake-agent mode (content = 50MB+1) and asserts the probe file is never created.
- [x] `bun test packages/acp/` — 90 pass, 0 fail (isolated).
- [x] `bun run am-i-done --pre-commit` (static gate: typecheck + lint + rules) passes.
- [ ] Full `bun run am-i-done` shows pre-existing host-wide SIGTERM worker crashes in daemon-package test files (tracked in #2641→#2644) — non-deterministic (fail count drifted 14↔13 across runs), unrelated to this ACP-only diff. CI on a clean runner is the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)