### PR TITLE
feat(daemon): mcx daemon reload — safe restart that won't orphan sessions (fixes #2509)

### DIFF
--- a/packages/command/src/commands/version.spec.ts
+++ b/packages/command/src/commands/version.spec.ts
@@ -69,7 +69,7 @@ describe("cmdVersion", () => {
       }),
     );
     expect(stdout[2]).toContain("MISMATCH");
-    expect(stdout[2]).toContain("mcx daemon restart");
+    expect(stdout[2]).toContain("mcx daemon reload");
     expect(exitCode).toBe(2);
   });
 
@@ -193,7 +193,7 @@ describe("cmdVersion", () => {
     expect(stdout[0]).toContain("mcx 0.1.0-20260308");
     expect(stdout[1]).toContain("protocol old-proto");
     expect(stdout[2]).toContain("MISMATCH");
-    expect(stdout[2]).toContain("mcx daemon restart");
+    expect(stdout[2]).toContain("mcx daemon reload");
     expect(exitCode).toBe(2);
   });
 

--- a/packages/command/src/commands/version.ts
+++ b/packages/command/src/commands/version.ts
@@ -82,12 +82,12 @@ export async function cmdVersion(args: string[], deps?: Partial<VersionDeps>): P
     if (daemon.protocolVersion === d.protocolVersion) {
       console.log("Status:  protocol match");
     } else {
-      console.log("Status:  protocol MISMATCH — run 'mcx daemon restart'");
+      console.log("Status:  protocol MISMATCH — run 'mcx daemon reload'");
       process.exitCode = 2;
     }
   } else if (mismatch) {
     console.log(`Daemon:  protocol ${mismatch.daemonVersion} (version unknown)`);
-    console.log("Status:  protocol MISMATCH — run 'mcx daemon restart'");
+    console.log("Status:  protocol MISMATCH — run 'mcx daemon reload'");
     process.exitCode = 2;
   } else {
     console.log("Daemon:  (not running)");

--- a/packages/command/src/daemon-lifecycle.spec.ts
+++ b/packages/command/src/daemon-lifecycle.spec.ts
@@ -7,6 +7,7 @@ import { DaemonStartCooldownError } from "@mcp-cli/core";
 import { testOptions } from "../../../test/test-options";
 import {
   _buildStaleDaemonWarning,
+  _formatReloadRefusal,
   _isTransientConnectionError,
   _parseBuildEpoch,
   _resetStartCooldown,
@@ -452,33 +453,33 @@ describe("_buildStaleDaemonWarning", () => {
     const warning = _buildStaleDaemonWarning(undefined);
     expect(warning).toContain("predates build version tracking");
     expect(warning).toContain(BUILD_VERSION);
-    expect(warning).toContain("mcx shutdown");
+    expect(warning).toContain("mcx daemon reload");
   });
 
   it("recommends dist/mcx when daemon is compiled and CLI is dev", () => {
     // Compiled daemon (has epoch), dev CLI (no epoch) — daemon is the newer/authoritative side
     const warning = _buildStaleDaemonWarning("1.11.2+1779669196", "1.11.2-dev");
     expect(warning).not.toBeNull();
-    expect(warning).not.toContain("mcx shutdown");
+    expect(warning).not.toContain("mcx daemon reload");
     expect(warning).toContain("1.11.2+1779669196");
     expect(warning).toContain("1.11.2-dev");
     expect(warning).toContain("dist/mcx");
   });
 
-  it("recommends mcx shutdown when CLI is compiled and daemon is dev", () => {
+  it("recommends mcx daemon reload when CLI is compiled and daemon is dev", () => {
     // CLI compiled, daemon dev — daemon is stale
     const warning = _buildStaleDaemonWarning("1.11.2-dev", "1.11.2+1779669196");
     expect(warning).not.toBeNull();
-    expect(warning).toContain("mcx shutdown");
+    expect(warning).toContain("mcx daemon reload");
     expect(warning).toContain("1.11.2-dev");
     expect(warning).toContain("1.11.2+1779669196");
     expect(warning).not.toContain("dist/mcx");
   });
 
-  it("recommends mcx shutdown when daemon epoch is older than CLI epoch", () => {
+  it("recommends mcx daemon reload when daemon epoch is older than CLI epoch", () => {
     const warning = _buildStaleDaemonWarning("1.0.0+1000000000", "1.0.0+2000000000");
     expect(warning).not.toBeNull();
-    expect(warning).toContain("mcx shutdown");
+    expect(warning).toContain("mcx daemon reload");
     expect(warning).toContain("1.0.0+1000000000");
     expect(warning).toContain("1.0.0+2000000000");
     expect(warning).not.toContain("dist/mcx");
@@ -487,28 +488,48 @@ describe("_buildStaleDaemonWarning", () => {
   it("recommends dist/mcx when daemon epoch is newer than CLI epoch", () => {
     const warning = _buildStaleDaemonWarning("1.0.0+2000000000", "1.0.0+1000000000");
     expect(warning).not.toBeNull();
-    expect(warning).not.toContain("mcx shutdown");
+    expect(warning).not.toContain("mcx daemon reload");
     expect(warning).toContain("1.0.0+2000000000");
     expect(warning).toContain("1.0.0+1000000000");
     expect(warning).toContain("dist/mcx");
   });
 
-  it("falls back to shutdown advice when both builds are dev with different versions", () => {
-    // Both dev (no epoch): can't determine direction → fallback recommends shutdown
+  it("falls back to reload advice when both builds are dev with different versions", () => {
+    // Both dev (no epoch): can't determine direction → fallback recommends reload
     const warning = _buildStaleDaemonWarning("0.1.0-dev", "0.2.0-dev");
     expect(warning).not.toBeNull();
     expect(warning).toContain("0.1.0-dev");
     expect(warning).toContain("0.2.0-dev");
-    expect(warning).toContain("mcx shutdown");
+    expect(warning).toContain("mcx daemon reload");
   });
 
-  it("falls back to shutdown advice when neither version has an epoch", () => {
+  it("falls back to reload advice when neither version has an epoch", () => {
     // Plain semver (no +epoch, no -dev): fallback
     const warning = _buildStaleDaemonWarning("1.0.0", "1.1.0");
     expect(warning).not.toBeNull();
     expect(warning).toContain("1.0.0");
     expect(warning).toContain("1.1.0");
-    expect(warning).toContain("mcx shutdown");
+    expect(warning).toContain("mcx daemon reload");
+  });
+});
+
+// -- _formatReloadRefusal --
+
+describe("_formatReloadRefusal", () => {
+  it("names the blocking session ids when reported", () => {
+    const msg = _formatReloadRefusal(2, ["abc123", "def456"]);
+    expect(msg).toContain("2 active session(s)");
+    expect(msg).toContain("abc123");
+    expect(msg).toContain("def456");
+    expect(msg).toContain("mcx claude bye");
+    expect(msg).toContain("mcx daemon reload --force");
+  });
+
+  it("omits the id list when none are reported", () => {
+    const msg = _formatReloadRefusal(1, []);
+    expect(msg).toContain("1 active session(s)");
+    expect(msg).not.toContain(": ");
+    expect(msg).toContain("mcx daemon reload --force");
   });
 });
 

--- a/packages/command/src/daemon-lifecycle.spec.ts
+++ b/packages/command/src/daemon-lifecycle.spec.ts
@@ -528,7 +528,8 @@ describe("_formatReloadRefusal", () => {
   it("omits the id list when none are reported", () => {
     const msg = _formatReloadRefusal(1, []);
     expect(msg).toContain("1 active session(s)");
-    expect(msg).not.toContain(": ");
+    // No id-list segment: the count flows straight into the next sentence.
+    expect(msg).toContain("orphaned by a reload. Wait");
     expect(msg).toContain("mcx daemon reload --force");
   });
 });

--- a/packages/command/src/daemon-lifecycle.ts
+++ b/packages/command/src/daemon-lifecycle.ts
@@ -39,10 +39,21 @@ export class ShutdownRefusedError extends Error {
   constructor(
     message: string,
     public readonly activeSessions: number,
+    public readonly sessionIds: string[] = [],
   ) {
     super(message);
     this.name = "ShutdownRefusedError";
   }
+}
+
+/**
+ * Build the refusal message shown when `mcx daemon reload` would orphan live
+ * sessions. Names the blocking session ids when the daemon reported them so the
+ * operator can `bye` them directly instead of guessing. Exported for testing.
+ */
+export function _formatReloadRefusal(activeSessions: number, sessionIds: string[]): string {
+  const idList = sessionIds.length > 0 ? `: ${sessionIds.join(", ")}` : "";
+  return `${activeSessions} active session(s) would be orphaned by a reload${idList}. Wait for them to finish, end them (\`mcx claude bye <id>\`), then retry — or force with \`mcx daemon reload --force\`.`;
 }
 
 /** Timestamp of the last failed daemon start attempt (0 = no recent failure) */
@@ -303,9 +314,15 @@ export async function stopDaemon(opts?: { force?: boolean }): Promise<void> {
   verifiedMcpdPid = null;
   try {
     const res = await rawFetch({ id: nextId(), method: "shutdown", params: { force: opts?.force } }, PING_TIMEOUT_MS);
-    const body = (await res.json()) as { result?: { ok: boolean; activeSessions?: number; message?: string } };
+    const body = (await res.json()) as {
+      result?: { ok: boolean; activeSessions?: number; sessionIds?: string[]; message?: string };
+    };
     if (body.result && !body.result.ok) {
-      throw new ShutdownRefusedError(body.result.message ?? "Shutdown refused", body.result.activeSessions ?? 0);
+      throw new ShutdownRefusedError(
+        body.result.message ?? "Shutdown refused",
+        body.result.activeSessions ?? 0,
+        body.result.sessionIds ?? [],
+      );
     }
   } catch (err) {
     if (err instanceof ShutdownRefusedError) throw err;
@@ -492,7 +509,7 @@ export function _buildStaleDaemonWarning(
   cliBuildVersion = BUILD_VERSION,
 ): string | null {
   if (!daemonBuildVersion) {
-    return `Daemon predates build version tracking (CLI is ${cliBuildVersion}). Run \`mcx shutdown\` to pick up the new binary.`;
+    return `Daemon predates build version tracking (CLI is ${cliBuildVersion}). Run \`mcx daemon reload\` to pick up the new binary.`;
   }
   if (daemonBuildVersion === cliBuildVersion) {
     return null;
@@ -509,7 +526,7 @@ export function _buildStaleDaemonWarning(
 
   // CLI is compiled, daemon is dev — daemon is stale.
   if (cliEpoch !== null && daemonEpoch === null) {
-    return `Daemon is running a dev build (${daemonBuildVersion}) but CLI is a compiled build (${cliBuildVersion}). Run \`mcx shutdown\` to restart with the compiled daemon.`;
+    return `Daemon is running a dev build (${daemonBuildVersion}) but CLI is a compiled build (${cliBuildVersion}). Run \`mcx daemon reload\` to restart with the compiled daemon.`;
   }
 
   // Both compiled — compare epochs to determine which is stale.
@@ -517,11 +534,11 @@ export function _buildStaleDaemonWarning(
     if (daemonEpoch > cliEpoch) {
       return `Daemon is running a newer build (${daemonBuildVersion}) than CLI (${cliBuildVersion}). Use the build-matched client: \`dist/mcx\` or the installed \`mcx\` on PATH.`;
     }
-    return `Daemon is running an older build (${daemonBuildVersion}) than CLI (${cliBuildVersion}). Run \`mcx shutdown\` to pick up the new binary.`;
+    return `Daemon is running an older build (${daemonBuildVersion}) than CLI (${cliBuildVersion}). Run \`mcx daemon reload\` to pick up the new binary.`;
   }
 
   // Fallback: both dev or neither has epoch — can't determine direction.
-  return `Daemon is running a different build (${daemonBuildVersion}) than CLI (${cliBuildVersion}). Run \`mcx shutdown\` to pick up the new binary.`;
+  return `Daemon is running a different build (${daemonBuildVersion}) than CLI (${cliBuildVersion}). Run \`mcx daemon reload\` to pick up the new binary.`;
 }
 
 /**

--- a/packages/command/src/daemon-lifecycle.ts
+++ b/packages/command/src/daemon-lifecycle.ts
@@ -631,7 +631,7 @@ export function getSourceStalenessWarning(workspaceRoot?: string): string | null
   const newestAge = Math.max(...stale.map((s) => s.mtimeSec)) - buildEpoch;
   const ageStr = formatAge(newestAge);
 
-  return `dist/ binaries were built before latest source changes (${pkgList} modified ${ageStr} after build).\n  Run: bun run build && mcx daemon restart`;
+  return `dist/ binaries were built before latest source changes (${pkgList} modified ${ageStr} after build).\n  Run: bun run build && mcx daemon reload`;
 }
 
 function formatAge(seconds: number): string {

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -69,6 +69,7 @@ import { cmdVersion } from "./commands/version";
 import { cmdVfs } from "./commands/vfs";
 import {
   ShutdownRefusedError,
+  _formatReloadRefusal,
   getSourceStalenessWarning,
   getStaleDaemonWarning,
   ipcCall,
@@ -886,6 +887,24 @@ async function cmdDaemon(args: string[]): Promise<void> {
     // Next ipcCall auto-starts a fresh daemon with current code
     await ipcCall("ping");
     console.error("Daemon restarted.");
+  } else if (sub === "reload") {
+    // Safe one-shot reload: stop + auto-restart, refusing to orphan live sessions (#2509).
+    // Unlike `restart` (force:true), reload defaults force:false so the daemon's
+    // active-session guard holds — the fix for a build-mismatched (split-brain) daemon.
+    const force = args.includes("--force");
+    console.error("Reloading daemon...");
+    try {
+      await stopDaemon({ force });
+    } catch (err) {
+      if (err instanceof ShutdownRefusedError) {
+        printError(_formatReloadRefusal(err.activeSessions, err.sessionIds));
+        process.exit(1);
+      }
+      throw err;
+    }
+    // Next ipcCall auto-starts a fresh build-matched daemon.
+    await ipcCall("ping");
+    console.error("Daemon reloaded.");
   } else if (sub === "shutdown" || sub === "stop") {
     const force = args.includes("--force");
     try {
@@ -899,7 +918,7 @@ async function cmdDaemon(args: string[]): Promise<void> {
     }
     console.error("Daemon shut down.");
   } else {
-    printError("Usage: mcx daemon restart|shutdown [--force]");
+    printError("Usage: mcx daemon restart|reload|shutdown [--force]");
     process.exit(1);
   }
 }

--- a/packages/control/src/components/utils.spec.ts
+++ b/packages/control/src/components/utils.spec.ts
@@ -468,6 +468,6 @@ describe("checkProtocolVersion", () => {
     expect(msg).toContain("Protocol mismatch");
     expect(msg).toContain("old-hash-abc123");
     expect(msg).toContain(PROTOCOL_VERSION);
-    expect(msg).toContain("mcx daemon restart");
+    expect(msg).toContain("mcx daemon reload");
   });
 });

--- a/packages/core/src/ipc-client.spec.ts
+++ b/packages/core/src/ipc-client.spec.ts
@@ -22,7 +22,7 @@ describe("ProtocolMismatchError", () => {
     expect(err.cliVersion).toBe("def456");
     expect(err.message).toContain("abc123");
     expect(err.message).toContain("def456");
-    expect(err.message).toContain("mcx daemon restart");
+    expect(err.message).toContain("mcx daemon reload");
   });
 });
 

--- a/packages/core/src/ipc-client.ts
+++ b/packages/core/src/ipc-client.ts
@@ -47,14 +47,14 @@ export class IpcCallError extends Error {
 
 /**
  * Thrown when the CLI and daemon have incompatible protocol versions.
- * The user must explicitly restart the daemon to resolve this.
+ * The user must explicitly reload the daemon to resolve this.
  */
 export class ProtocolMismatchError extends Error {
   readonly daemonVersion: string;
   readonly cliVersion: string;
 
   constructor(daemonVersion: string, cliVersion: string) {
-    super(`Protocol mismatch: daemon ${daemonVersion}, CLI expects ${cliVersion}.\nRun: mcx daemon restart`);
+    super(`Protocol mismatch: daemon ${daemonVersion}, CLI expects ${cliVersion}.\nRun: mcx daemon reload`);
     this.name = "ProtocolMismatchError";
     this.daemonVersion = daemonVersion;
     this.cliVersion = cliVersion;

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -704,6 +704,8 @@ export interface ShutdownResult {
   ok: boolean;
   /** Present when ok=false — number of active sessions blocking shutdown */
   activeSessions?: number;
+  /** Present when ok=false — ids of the active sessions blocking shutdown */
+  sessionIds?: string[];
   /** Present when ok=false — human-readable refusal message */
   message?: string;
 }

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -681,6 +681,7 @@ describe("IpcServer HTTP transport", () => {
     expect(json.result).toEqual({
       ok: false,
       activeSessions: 2,
+      sessionIds: ["s1", "s2"],
       message: "2 active session(s). Use --force to shut down anyway.",
     });
   });

--- a/packages/daemon/src/ipc-server.ts
+++ b/packages/daemon/src/ipc-server.ts
@@ -520,6 +520,7 @@ export class IpcServer {
           return {
             ok: false,
             activeSessions: activeSessions.length,
+            sessionIds: activeSessions.map((s) => s.sessionId),
             message: `${activeSessions.length} active session(s). Use --force to shut down anyway.`,
           };
         }


### PR DESCRIPTION
## Summary
- Adds `mcx daemon reload`: a one-shot safe restart that stops + auto-starts a fresh, build-matched daemon. Unlike `mcx daemon restart` (`force:true`, bypasses the active-session guard), `reload` defaults `force:false`, so the daemon's existing active-session guard holds and **refuses to orphan live sessions**.
- On refusal, the message **names the blocking session ids** (now carried on the `shutdown` IPC result via `ShutdownResult.sessionIds` → `ShutdownRefusedError.sessionIds`) so the operator can `mcx claude bye <id>` directly, then retry — or `mcx daemon reload --force`.
- Stale-build warnings (`_buildStaleDaemonWarning`) now recommend `mcx daemon reload` instead of bare `mcx shutdown` for the cases where the daemon is the stale side.

## Context
This closes the remaining gap in the stale-daemon split-brain story. Spawn-refusal (#1254) and direction-aware status warnings (#2418) already landed before #2509 was filed; the missing piece was a safe-reload escape hatch that doesn't orphan live work. `bun dev:mcx`-vs-compiled cases still correctly point at the build-matched client (`dist/mcx`), unchanged.

## Test plan
- [x] `_formatReloadRefusal` unit tests: names ids when present, omits the id list when none reported, includes `mcx claude bye` + `mcx daemon reload --force` guidance
- [x] Updated `_buildStaleDaemonWarning` tests: stale-side cases now assert `mcx daemon reload`; daemon-newer cases still recommend `dist/mcx`
- [x] Daemon `shutdown` refusal test asserts `sessionIds: ["s1", "s2"]` in the IPC result
- [x] `bun run am-i-done` (full: typecheck, lint, rules, tests, coverage) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)