### PR TITLE
security(claude): emit audit log + monitor event on spawn binary override (closes #2709)

### DIFF
--- a/packages/core/src/monitor-event.spec.ts
+++ b/packages/core/src/monitor-event.spec.ts
@@ -8,6 +8,7 @@ import {
   METRIC_SESSION_COMMAND_HIST,
   METRIC_SESSION_FOOTPRINT,
   METRIC_SESSION_QUERIES,
+  SESSION_SPAWN_OVERRIDE,
   SESSION_TOOL_USE,
   WORKER_RATELIMITED,
   formatMonitorEvent,
@@ -220,5 +221,32 @@ describe("formatMonitorEvent — lifecycle events", () => {
     );
     expect(line).toContain("0wt");
     expect(line).toContain("0br");
+  });
+
+  test("session.spawn_override shows binary path without bypassed reason when none", () => {
+    const line = formatMonitorEvent(
+      event({
+        event: SESSION_SPAWN_OVERRIDE,
+        sessionId: "abcdef1234567890",
+        binaryPath: "/custom/claude",
+      }),
+    );
+    expect(line).toContain("session.spawn_override");
+    expect(line).toContain("/custom/claude");
+    expect(line).not.toContain("bypassed");
+  });
+
+  test("session.spawn_override shows binary path and bypassed reason", () => {
+    const line = formatMonitorEvent(
+      event({
+        event: SESSION_SPAWN_OVERRIDE,
+        sessionId: "abcdef1234567890",
+        binaryPath: "/canary/claude",
+        bypassedReason: "version gate: upgrade required",
+      }),
+    );
+    expect(line).toContain("session.spawn_override");
+    expect(line).toContain("/canary/claude");
+    expect(line).toContain("bypassed: version gate: upgrade required");
   });
 });

--- a/packages/core/src/monitor-event.ts
+++ b/packages/core/src/monitor-event.ts
@@ -49,6 +49,7 @@ export const SESSION_CONTAINMENT_RESET = "session.containment_reset" as const;
 export const SESSION_IDLE = "session.idle" as const;
 export const SESSION_STUCK = "session.stuck" as const;
 export const SESSION_TOOL_USE = "session.tool_use" as const;
+export const SESSION_SPAWN_OVERRIDE = "session.spawn_override" as const;
 
 // ── Session metric event names (#1610) ──
 
@@ -257,6 +258,12 @@ const FORMATTERS: Partial<Record<string, Formatter>> = {
   },
 
   [SESSION_CONTAINMENT_ESCALATED]: (e) => join(wi(e), sid(e)),
+
+  [SESSION_SPAWN_OVERRIDE]: (e) => {
+    const binary = typeof e.binaryPath === "string" ? cap(e.binaryPath, 60) : "";
+    const bypassed = typeof e.bypassedReason === "string" ? `bypassed: ${cap(e.bypassedReason, 60)}` : "";
+    return join(wi(e), sid(e), binary, bypassed);
+  },
 
   [PR_OPENED]: (e) => {
     const branch = typeof e.branch === "string" ? e.branch : "";

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -3,7 +3,13 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { MonitorEventInput, WorkItemEvent } from "@mcp-cli/core";
-import { SESSION_PERMISSION_BLOCKED, SESSION_PERMISSION_REQUEST, silentLogger } from "@mcp-cli/core";
+import {
+  SESSION_PERMISSION_BLOCKED,
+  SESSION_PERMISSION_REQUEST,
+  SESSION_SPAWN_OVERRIDE,
+  capturingLogger,
+  silentLogger,
+} from "@mcp-cli/core";
 import { serialize } from "./ndjson";
 import type { SessionEvent } from "./session-state";
 import type { SpawnFn, WaitResult } from "./ws-server";
@@ -423,6 +429,51 @@ describe("ClaudeWsServer", () => {
     server.spawnClaude("no-model-session");
 
     expect(ms.lastCmd).not.toContain("--model");
+  });
+
+  test("spawnClaude emits warn log and SESSION_SPAWN_OVERRIDE event when binaryPath is set", async () => {
+    const ms = mockSpawn();
+    const { logger, messages } = capturingLogger();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger });
+    await server.start();
+
+    const monitorEvents: MonitorEventInput[] = [];
+    server.onMonitorEvent = (e) => monitorEvents.push(e);
+
+    server.prepareSession("bin-session", { prompt: "Hello", binaryPath: "/custom/claude" });
+    server.spawnClaude("bin-session");
+
+    const warn = messages.find((m) => m.level === "warn" && String(m.args[0]).includes("/custom/claude"));
+    expect(warn).toBeDefined();
+    expect(String(warn?.args[0])).not.toContain("bypassed");
+
+    const spawnEvent = monitorEvents.find((e) => e.event === SESSION_SPAWN_OVERRIDE);
+    expect(spawnEvent).toBeDefined();
+    expect(spawnEvent?.binaryPath).toBe("/custom/claude");
+    expect(spawnEvent?.bypassedReason).toBeUndefined();
+  });
+
+  test("spawnClaude emits warn log with bypassed reason when spawnDisabledReason is set and binaryPath overrides it", async () => {
+    const ms = mockSpawn();
+    const { logger, messages } = capturingLogger();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger, spawnDisabledReason: "version gate: upgrade required" });
+    await server.start();
+
+    const monitorEvents: MonitorEventInput[] = [];
+    server.onMonitorEvent = (e) => monitorEvents.push(e);
+
+    server.prepareSession("bypass-session", { prompt: "Hello", binaryPath: "/canary/claude" });
+    server.spawnClaude("bypass-session");
+
+    const warn = messages.find((m) => m.level === "warn" && String(m.args[0]).includes("bypassed"));
+    expect(warn).toBeDefined();
+    expect(String(warn?.args[0])).toContain("version gate: upgrade required");
+    expect(String(warn?.args[0])).toContain("/canary/claude");
+
+    const spawnEvent = monitorEvents.find((e) => e.event === SESSION_SPAWN_OVERRIDE);
+    expect(spawnEvent).toBeDefined();
+    expect(spawnEvent?.binaryPath).toBe("/canary/claude");
+    expect(spawnEvent?.bypassedReason).toBe("version gate: upgrade required");
   });
 
   test("WS connect sends user message immediately on open", async () => {

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -47,6 +47,7 @@ import {
   SESSION_PERMISSION_BLOCKED,
   SESSION_PERMISSION_REQUEST,
   SESSION_RESULT,
+  SESSION_SPAWN_OVERRIDE,
   SESSION_STUCK,
   SESSION_TOOL_USE,
   WORKER_RATELIMITED,
@@ -827,6 +828,24 @@ export class ClaudeWsServer {
     // a default binary, but the caller is canarying a known-good one) (#2681).
     if (this.spawnDisabledReason !== null && !session.config.binaryPath) {
       throw new Error(this.spawnDisabledReason);
+    }
+
+    if (session.config.binaryPath) {
+      if (this.spawnDisabledReason !== null) {
+        this.logger.warn(
+          `[_claude] session ${sessionId} spawned with custom binary "${session.config.binaryPath}"; bypassed spawnDisabledReason: "${this.spawnDisabledReason}"`,
+        );
+      } else {
+        this.logger.warn(`[_claude] session ${sessionId} spawned with custom binary "${session.config.binaryPath}"`);
+      }
+      this.onMonitorEvent?.({
+        src: "daemon.claude-server",
+        event: SESSION_SPAWN_OVERRIDE,
+        category: "session",
+        sessionId,
+        binaryPath: session.config.binaryPath,
+        ...(this.spawnDisabledReason !== null ? { bypassedReason: this.spawnDisabledReason } : {}),
+      });
     }
 
     const useStdio = session.transport === "stdio";


### PR DESCRIPTION
## Summary
- Adds `SESSION_SPAWN_OVERRIDE` (`session.spawn_override`) monitor event constant and formatter to `@mcp-cli/core`
- Emits a `daemon-log` WARN and a `session.spawn_override` monitor event whenever a session is spawned with a per-spawn `--claude-binary` override; when `spawnDisabledReason` is non-null (gate bypass), the warn includes the bypassed reason
- Keeps the bypass itself intact — only adds observability, no behavior change

## Test plan
- `monitor-event.spec.ts`: two formatter tests — binary-only and binary+bypassedReason
- `ws-server.spec.ts`: two integration tests — capturingLogger + onMonitorEvent verify warn level, message content, and event fields for both the non-bypass and bypass cases
- Full `bun run am-i-done` passed (typecheck, lint, rules, tests, coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)