### PR TITLE
fix(claude-stdio): repair stdio transport (--verbose) + fail-closed worktree containment (#2688)

### DIFF
--- a/packages/daemon/src/claude-session/ws-server-stdio.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server-stdio.spec.ts
@@ -1,10 +1,45 @@
 import { afterEach, describe, expect, test } from "bun:test";
-import { silentLogger } from "@mcp-cli/core";
+import { type MonitorEventInput, silentLogger } from "@mcp-cli/core";
 import { serialize } from "./ndjson";
+import type { StuckDetectorClock } from "./stuck-detector";
 import type { SpawnFn } from "./ws-server";
 import { ClaudeWsServer } from "./ws-server";
 
 import { pollUntil } from "../../../../test/harness";
+
+/** Deterministic clock for StuckDetector — virtual time advances only on advance(). */
+class FakeClock implements StuckDetectorClock {
+  private _now = 0;
+  private nextId = 1;
+  private timers: { id: number; at: number; callback: () => void }[] = [];
+
+  now(): number {
+    return this._now;
+  }
+
+  setTimeout(callback: () => void, ms: number): unknown {
+    const id = this.nextId++;
+    this.timers.push({ id, at: this._now + ms, callback });
+    return id;
+  }
+
+  clearTimeout(timer: unknown): void {
+    this.timers = this.timers.filter((t) => t.id !== timer);
+  }
+
+  /** Advance virtual time by `ms`, firing expired timers in order. */
+  advance(ms: number): void {
+    const target = this._now + ms;
+    while (true) {
+      const next = this.timers.filter((t) => t.at <= target).sort((a, b) => a.at - b.at)[0];
+      if (!next) break;
+      this._now = next.at;
+      this.timers = this.timers.filter((t) => t.id !== next.id);
+      next.callback();
+    }
+    this._now = target;
+  }
+}
 
 const SETTLE_MS = 10;
 const PAST_CONNECT_TIMEOUT_MS = 300;
@@ -58,6 +93,16 @@ function resultMessage(sessionId: string): string {
     total_cost_usd: 0.01,
     usage: { input_tokens: 200, output_tokens: 100 },
     uuid: "test-uuid",
+    session_id: sessionId,
+  });
+}
+
+function streamEventMessage(sessionId: string): string {
+  return serialize({
+    type: "stream_event",
+    event: {},
+    parent_tool_use_id: null,
+    uuid: "stream-uuid",
     session_id: sessionId,
   });
 }
@@ -172,6 +217,10 @@ describe("ClaudeWsServer — stdio transport", () => {
     expect(mock.lastCmd).toContain("--print");
     expect(mock.lastCmd).toContain("--output-format");
     expect(mock.lastCmd).toContain("--input-format");
+    // stream-json print mode requires --verbose or claude exits immediately (#2688);
+    // --include-partial-messages restores the stream_event StuckDetector signal.
+    expect(mock.lastCmd).toContain("--verbose");
+    expect(mock.lastCmd).toContain("--include-partial-messages");
 
     // Spawn opts should have stdin/stdout piped
     expect(mock.lastOpts).toMatchObject({ stdin: "pipe", stdout: "pipe" });
@@ -369,6 +418,8 @@ describe("ClaudeWsServer — stdio transport", () => {
     expect(mock.lastCmd).not.toContain("--sdk-url");
     expect(mock.lastCmd).toContain("--print");
     expect(mock.lastCmd).toContain("stream-json");
+    expect(mock.lastCmd).toContain("--verbose");
+    expect(mock.lastCmd).toContain("--include-partial-messages");
   });
 
   test("restoreSessions with explicit transport:'stdio' revives with stdio args", async () => {
@@ -467,5 +518,95 @@ describe("ClaudeWsServer — stdio transport", () => {
 
     expect(mock.lastCmd).toContain("--sdk-url");
     expect(mock.lastCmd.some((a: string) => a.startsWith(`ws://localhost:${port}/`))).toBe(true);
+    // WS uses --sdk-url and must not carry the stdio-only flags.
+    expect(mock.lastCmd).not.toContain("--verbose");
+    expect(mock.lastCmd).not.toContain("--include-partial-messages");
+  });
+
+  test("contained/worktree spawn over stdio is refused fail-closed (#2688)", async () => {
+    const mock = mockStdioSpawn();
+    server = new ClaudeWsServer({
+      spawn: mock.spawn,
+      logger: silentLogger,
+    });
+    await server.start(0);
+
+    const sessionId = crypto.randomUUID();
+    server.prepareSession(sessionId, {
+      prompt: "test",
+      transport: "stdio",
+      worktree: "/tmp/wt",
+      cwd: "/tmp/wt",
+    });
+
+    expect(() => server.spawnClaude(sessionId)).toThrow("stdio transport does not support ContainmentGuard — use ws");
+    // Refusal must happen before spawn — no child process started.
+    expect(mock.lastCmd).toEqual([]);
+  });
+
+  test("non-worktree stdio spawn is allowed", async () => {
+    const mock = mockStdioSpawn();
+    server = new ClaudeWsServer({
+      spawn: mock.spawn,
+      logger: silentLogger,
+    });
+    await server.start(0);
+
+    const sessionId = crypto.randomUUID();
+    server.prepareSession(sessionId, { prompt: "test", transport: "stdio" });
+
+    expect(() => server.spawnClaude(sessionId)).not.toThrow();
+    expect(mock.lastCmd).toContain("--print");
+  });
+
+  test("stdio stream_event advances the StuckDetector liveness window (#2688)", async () => {
+    const mock = mockStdioSpawn();
+    const clock = new FakeClock();
+    const monitorEvents: MonitorEventInput[] = [];
+    server = new ClaudeWsServer({
+      spawn: mock.spawn,
+      logger: silentLogger,
+      connectTimeoutMs: 5000,
+      stuckConfig: { thresholdsMs: [100, 200, 300], repeatMs: 300 },
+      stuckClock: clock,
+    });
+    server.onMonitorEvent = (input) => monitorEvents.push(input);
+    await server.start(0);
+
+    const sessionId = crypto.randomUUID();
+    server.prepareSession(sessionId, { prompt: "test", transport: "stdio" });
+    server.spawnClaude(sessionId);
+
+    // Drive the session to "active" — records initial progress at virtual t=0,
+    // scheduling the tier-1 stuck timer for t=100.
+    mock.pushStdout(systemInitMessage(sessionId));
+    mock.pushStdout(assistantMessage(sessionId));
+    await pollUntil(() => server?.listSessions().some((s) => s.state === "active") ?? false, 1000);
+
+    const stuckCount = () => monitorEvents.filter((e) => e.event === "session.stuck").length;
+
+    // Just shy of the threshold: no stuck event yet.
+    clock.advance(99);
+    expect(stuckCount()).toBe(0);
+
+    // A stream_event arrives — its handler records progress at t=99, which must
+    // reschedule the tier-1 timer to t=199 (cancelling the original t=100 timer).
+    mock.pushStdout(streamEventMessage(sessionId));
+    await pollUntil(
+      () =>
+        server?.getTranscript(sessionId).some((e) => e.direction === "inbound" && e.message.type === "stream_event") ??
+        false,
+      1000,
+    );
+
+    // Past the ORIGINAL threshold (t=149) but before the advanced one: still no
+    // stuck — proves the window moved forward because of the stream_event.
+    clock.advance(50);
+    expect(stuckCount()).toBe(0);
+
+    // Past the advanced threshold (t=209 ≥ 199): the tier-1 stuck now fires.
+    clock.advance(60);
+    expect(stuckCount()).toBe(1);
+    expect(monitorEvents.find((e) => e.event === "session.stuck")?.tier).toBe(1);
   });
 });

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -64,7 +64,14 @@ import type { CanUseToolRequest, PermissionRule, PermissionStrategy } from "./pe
 import { PermissionRouter } from "./permission-router";
 import type { SessionEvent } from "./session-state";
 import { IGNORED_TYPES, SessionState } from "./session-state";
-import { DEFAULT_STUCK_CONFIG, StuckDetector, type StuckDetectorConfig, type StuckEvent } from "./stuck-detector";
+import {
+  DEFAULT_STUCK_CONFIG,
+  REAL_CLOCK,
+  StuckDetector,
+  type StuckDetectorClock,
+  type StuckDetectorConfig,
+  type StuckEvent,
+} from "./stuck-detector";
 
 // ── Constants ──
 
@@ -431,6 +438,7 @@ export class ClaudeWsServer {
   private readonly reclaimIntervalMs: number;
   private readonly connectTimeoutMs: number;
   private readonly stuckConfig: StuckDetectorConfig;
+  private readonly stuckClock: StuckDetectorClock;
   private eventSeq = 0;
   private readonly eventBuffer: BufferedEvent[] = [];
   private nextRequestId = 1;
@@ -476,6 +484,8 @@ export class ClaudeWsServer {
     reclaimIntervalMs?: number;
     connectTimeoutMs?: number;
     stuckConfig?: StuckDetectorConfig;
+    /** Override the StuckDetector clock (tests inject a FakeClock). */
+    stuckClock?: StuckDetectorClock;
     /** Self-signed cert + key. When provided, server runs as wss://. */
     tlsConfig?: { cert: string; key: string } | null;
     /** Override the bind hostname. Defaults to `::1` when TLS is set, otherwise unset (Bun default). */
@@ -499,6 +509,7 @@ export class ClaudeWsServer {
     this.reclaimIntervalMs = deps?.reclaimIntervalMs ?? PORT_RECLAIM_INTERVAL_MS;
     this.connectTimeoutMs = deps?.connectTimeoutMs ?? CONNECT_TIMEOUT_MS;
     this.stuckConfig = deps?.stuckConfig ?? DEFAULT_STUCK_CONFIG;
+    this.stuckClock = deps?.stuckClock ?? REAL_CLOCK;
     this.tlsConfig = deps?.tlsConfig ?? null;
     this.hostname = deps?.hostname ?? (this.tlsConfig ? "::1" : undefined);
     this.binaryPath = deps?.binaryPath ?? "claude";
@@ -831,6 +842,14 @@ export class ClaudeWsServer {
 
     const useStdio = session.transport === "stdio";
 
+    // Fail-closed: the stdio transport has no can_use_tool round-trip, so
+    // ContainmentGuard / input-rewriting / delegate-mode never fire (#2688).
+    // Refuse a contained/worktree spawn over stdio rather than silently
+    // running it outside the containment trust boundary.
+    if (useStdio && session.worktree) {
+      throw new Error("stdio transport does not support ContainmentGuard — use ws");
+    }
+
     const cmd = this.buildSpawnCmd(sessionId, session, useStdio);
 
     const envOverrides: Record<string, string | undefined> = {};
@@ -1005,6 +1024,15 @@ export class ClaudeWsServer {
       "--input-format",
       "stream-json",
     );
+
+    if (useStdio) {
+      // claude rejects `--print --output-format=stream-json` without --verbose
+      // and exits immediately (#2688). --include-partial-messages restores the
+      // stream_event liveness signal the StuckDetector consumes (absent by
+      // default on the pipe transport). The WS path uses --sdk-url and needs
+      // neither, so this is gated on useStdio.
+      cmd.push("--verbose", "--include-partial-messages");
+    }
 
     if (session.config.model) {
       cmd.push("--model", session.config.model);
@@ -2242,6 +2270,7 @@ export class ClaudeWsServer {
           hasActiveToolCall: session.state.hasActiveToolCall,
         }),
         (event) => this.handleStuckEvent(sessionId, session, event),
+        this.stuckClock,
       );
     }
     return session.stuckDetector;


### PR DESCRIPTION
## Summary

Implements parts (a) and (b) of the root-cause spec in https://github.com/theshadow27/mcp-cli/issues/2688#issuecomment-4694219686. The full mechanism, repro, and go/no-go decision are documented there — this PR is that spec made executable.

**(a) Repair the transport.** `buildSpawnCmd`'s stdio invocation emitted `--print --output-format stream-json --input-format stream-json` without `--verbose`. claude hard-rejects that combo (`When using --print, --output-format=stream-json requires --verbose`) and the child exits immediately — exactly the sprint-72 canary's `spawn exited` signature (reproduced directly against `claude 2.1.175`). Fix:
- Add `--verbose` and `--include-partial-messages` to the stdio branch only (gated on `useStdio`; the WS `--sdk-url` path is untouched and must not carry these flags — asserted).
- `--include-partial-messages` restores the `stream_event` liveness signal the StuckDetector consumes; without it stdio emits no `tool_progress`/`stream_event` at all (verified empirically — see the issue comment).

**(b) Fail-closed containment.** A contained/worktree spawn over stdio has no `can_use_tool` round-trip, so `ContainmentGuard`, input-rewriting, and delegate-mode never fire — the session would sit outside the sprint-72 trust boundary. Per the spec's NO-GO decision, `spawnClaude` now hard-refuses such spawns with `stdio transport does not support ContainmentGuard — use ws` rather than running unguarded. (Full `can_use_tool` parity is the larger follow-up, explicitly out of scope here.)

## Tests
- Updated `ws-server-stdio.spec.ts` spawn-arg assertions to require both flags; added a negative assertion on the WS path.
- Added the fail-closed refusal test (contained/worktree stdio throws, no child spawned) + a non-worktree allow test.
- Added the spec comment's **StuckDetector liveness test**: a mock stdio session emits a `stream_event`; the test asserts the detector's tier-1 window is pushed forward (no premature stuck, fires only past the advanced threshold). Made deterministic via an injectable `StuckDetectorClock` (FakeClock) threaded through the server — no wall-time waits.

Part (c) (real-binary arg-combination test) is being filed separately, per instructions.

## Test plan
- [x] `bun run am-i-done` (full gate: typecheck → lint → rules → tests → coverage) passes locally
- [x] `ws-server-stdio.spec.ts` (13 pass), `ws-server.spec.ts` + `stuck-detector.spec.ts` (240 pass)

Closes the immediate-exit half of #2688; an adversarial review will verify the impl matches the documented mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)