### PR TITLE
fix(claude-session): surface transport write failures instead of stuck session (fixes #2562)

### DIFF
--- a/packages/daemon/src/claude-session/ws-server-stdio.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server-stdio.spec.ts
@@ -121,11 +121,13 @@ function mockStdioSpawn(): {
   pushStdout: (data: string) => void;
   closeStdout: () => void;
   stdinWrites: string[];
+  failWrites: (err: Error) => void;
 } {
   let exitResolve: (code: number) => void = () => {};
   let stdoutController: ReadableStreamDefaultController<Uint8Array> | null = null;
   const encoder = new TextEncoder();
   const stdinWrites: string[] = [];
+  let writeError: Error | null = null;
 
   const stdoutStream = new ReadableStream<Uint8Array>({
     start(controller) {
@@ -135,6 +137,7 @@ function mockStdioSpawn(): {
 
   const mockStdin = {
     write(data: string | Uint8Array): number {
+      if (writeError) throw writeError;
       const str = typeof data === "string" ? data : new TextDecoder().decode(data);
       stdinWrites.push(str);
       return typeof data === "string" ? data.length : data.byteLength;
@@ -183,6 +186,9 @@ function mockStdioSpawn(): {
       }
     },
     stdinWrites,
+    failWrites: (err: Error) => {
+      writeError = err;
+    },
   };
   return state;
 }
@@ -730,5 +736,69 @@ describe("ClaudeWsServer — stdio transport", () => {
     clock.advance(60);
     expect(stuckCount()).toBe(1);
     expect(monitorEvents.find((e) => e.event === "session.stuck")?.tier).toBe(1);
+  });
+
+  // ── Transport write-failure handling (#2562) ──
+  // A failed stdio write (SIGPIPE / broken pipe on child crash) must not leave
+  // the state machine believing a prompt is being processed. The session is
+  // transitioned to disconnected and the error is surfaced to the caller.
+
+  async function driveToIdle(
+    mock: ReturnType<typeof mockStdioSpawn>,
+    server: ClaudeWsServer,
+    sessionId: string,
+    events: Array<{ type: string }>,
+  ): Promise<void> {
+    mock.pushStdout(`${systemInitMessage(sessionId)}\n`);
+    await pollUntil(() => events.some((e) => e.type === "session:init"), 1000);
+    mock.pushStdout(`${resultMessage(sessionId)}\n`);
+    await pollUntil(() => events.some((e) => e.type === "session:result"), 1000);
+  }
+
+  test("sendPrompt throws and disconnects when stdio write fails", async () => {
+    const mock = mockStdioSpawn();
+    server = new ClaudeWsServer({ spawn: mock.spawn, logger: silentLogger, connectTimeoutMs: 5000 });
+    await server.start(0);
+
+    const sessionId = crypto.randomUUID();
+    const events: Array<{ type: string }> = [];
+    server.onSessionEvent = (_sid, event) => events.push(event);
+
+    server.prepareSession(sessionId, { prompt: "first", transport: "stdio" });
+    server.spawnClaude(sessionId);
+    await driveToIdle(mock, server, sessionId, events);
+
+    // Pipe breaks before the follow-up prompt is written.
+    mock.failWrites(new Error("EPIPE: broken pipe"));
+
+    expect(() => server.sendPrompt(sessionId, "second")).toThrow(/transport write failed/);
+
+    // State machine must not be left in active/processing — it is disconnected.
+    const session = server.listSessions().find((s) => s.sessionId === sessionId);
+    expect(session?.state).toBe("disconnected");
+    expect(events.some((e) => e.type === "session:disconnected")).toBe(true);
+  });
+
+  test("interrupt throws and disconnects when stdio write fails", async () => {
+    const mock = mockStdioSpawn();
+    server = new ClaudeWsServer({ spawn: mock.spawn, logger: silentLogger, connectTimeoutMs: 5000 });
+    await server.start(0);
+
+    const sessionId = crypto.randomUUID();
+    const events: Array<{ type: string }> = [];
+    server.onSessionEvent = (_sid, event) => events.push(event);
+
+    server.prepareSession(sessionId, { prompt: "first", transport: "stdio" });
+    server.spawnClaude(sessionId);
+    await driveToIdle(mock, server, sessionId, events);
+
+    mock.failWrites(new Error("EPIPE: broken pipe"));
+
+    expect(() => server.interrupt(sessionId, "stop")).toThrow(/transport write failed/);
+
+    const session = server.listSessions().find((s) => s.sessionId === sessionId);
+    expect(session?.state).toBe("disconnected");
+    // A failed interrupt must not stash a pending reason on a dead session.
+    expect(events.some((e) => e.type === "session:disconnected")).toBe(true);
   });
 });

--- a/packages/daemon/src/claude-session/ws-server-stdio.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server-stdio.spec.ts
@@ -107,6 +107,19 @@ function streamEventMessage(sessionId: string): string {
   });
 }
 
+function canUseToolMessage(requestId: string): string {
+  return serialize({
+    type: "control_request",
+    request_id: requestId,
+    request: {
+      subtype: "can_use_tool",
+      tool_name: "Bash",
+      input: { command: "echo hello" },
+      tool_use_id: "tool-1",
+    },
+  });
+}
+
 /**
  * Mock spawn that exposes stdin/stdout streams for stdio transport testing.
  * The mock stdout is a ReadableStream that the test can push NDJSON lines into.
@@ -799,6 +812,36 @@ describe("ClaudeWsServer — stdio transport", () => {
     const session = server.listSessions().find((s) => s.sessionId === sessionId);
     expect(session?.state).toBe("disconnected");
     // A failed interrupt must not stash a pending reason on a dead session.
+    expect(events.some((e) => e.type === "session:disconnected")).toBe(true);
+  });
+
+  test("respondToPermission throws and disconnects when stdio write fails", async () => {
+    const mock = mockStdioSpawn();
+    server = new ClaudeWsServer({ spawn: mock.spawn, logger: silentLogger, connectTimeoutMs: 5000 });
+    await server.start(0);
+
+    const sessionId = crypto.randomUUID();
+    const events: Array<{ type: string }> = [];
+    server.onSessionEvent = (_sid, event) => events.push(event);
+
+    // `delegate` strategy leaves the can_use_tool request pending for an external
+    // responder instead of auto-answering it, so the public respondToPermission
+    // path is the one exercised below.
+    server.prepareSession(sessionId, { prompt: "first", transport: "stdio", permissionStrategy: "delegate" });
+    server.spawnClaude(sessionId);
+
+    mock.pushStdout(`${systemInitMessage(sessionId)}\n`);
+    await pollUntil(() => events.some((e) => e.type === "session:init"), 1000);
+    mock.pushStdout(`${canUseToolMessage("req-1")}\n`);
+    await pollUntil(() => events.some((e) => e.type === "session:permission_request"), 1000);
+
+    // Pipe breaks before the permission response is written.
+    mock.failWrites(new Error("EPIPE: broken pipe"));
+
+    expect(() => server.respondToPermission(sessionId, "req-1", true)).toThrow(/transport write failed/);
+
+    const session = server.listSessions().find((s) => s.sessionId === sessionId);
+    expect(session?.state).toBe("disconnected");
     expect(events.some((e) => e.type === "session:disconnected")).toBe(true);
   });
 });

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -1395,7 +1395,13 @@ export class ClaudeWsServer {
     const session = this.getSession(sessionId);
     const requestId = `mcpd-model-${this.nextRequestId++}`;
     const outbound = setModelRequest(requestId, model);
-    this.sendToSession(session, outbound);
+    if (!this.sendToSession(session, outbound)) {
+      // Transport write failed — sendToSession already transitioned the session
+      // to disconnected. Surface the error before mutating tracked-model state so
+      // we don't emit a phantom session:model_changed for a change the child never
+      // received nor report success on a dead session (#2562).
+      throw new Error(`Failed to deliver set_model to session ${sessionId}: transport write failed`);
+    }
 
     // Update tracked model in state
     const events = session.state.setModel(model);
@@ -2300,10 +2306,16 @@ export class ClaudeWsServer {
       }
       if (result.action === "deny") {
         session.state.respondToPermission(requestId, false, result.reason);
-        this.sendToSession(
-          session,
-          permissionDeny(requestId, result.reason, result.event === "session:containment_escalated"),
-        );
+        if (
+          !this.sendToSession(
+            session,
+            permissionDeny(requestId, result.reason, result.event === "session:containment_escalated"),
+          )
+        ) {
+          // Write failed — sendToSession disconnected the session. Surface it via
+          // the caller's .catch logger rather than swallowing the false (#2562).
+          throw new Error(`Failed to deliver permission denial to session ${sessionId}: transport write failed`);
+        }
         return;
       }
     }
@@ -2326,7 +2338,11 @@ export class ClaudeWsServer {
       : permissionDeny(requestId, decision.message ?? "Denied");
 
     session.state.respondToPermission(requestId, decision.allow, decision.message);
-    this.sendToSession(session, outbound);
+    if (!this.sendToSession(session, outbound)) {
+      // Write failed — sendToSession disconnected the session. Surface it via the
+      // caller's .catch logger rather than swallowing the false (#2562).
+      throw new Error(`Failed to deliver permission response to session ${sessionId}: transport write failed`);
+    }
   }
 
   // ── Stuck detection (#1585) ──

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -1053,7 +1053,11 @@ export class ClaudeWsServer {
     const effective = pendingReason ? `[Interrupt context: ${pendingReason}]\n\n${message}` : message;
     const outbound = session.state.queuePrompt(effective);
     session.pendingInterruptReason = null;
-    this.sendToSession(session, outbound);
+    if (!this.sendToSession(session, outbound)) {
+      // Transport write failed — sendToSession already transitioned the session
+      // to disconnected. Surface the error so the prompt isn't silently lost.
+      throw new Error(`Failed to deliver prompt to session ${sessionId}: transport write failed`);
+    }
     this.addTranscript(session, "outbound", { type: "user", message: { role: "user", content: effective } });
     this.recordSessionProgress(sessionId, session);
   }
@@ -1248,7 +1252,9 @@ export class ClaudeWsServer {
   respondToPermission(sessionId: string, requestId: string, allow: boolean, message?: string): void {
     const session = this.getSession(sessionId);
     const outbound = session.state.respondToPermission(requestId, allow, message);
-    this.sendToSession(session, outbound);
+    if (!this.sendToSession(session, outbound)) {
+      throw new Error(`Failed to deliver permission response to session ${sessionId}: transport write failed`);
+    }
     this.recordSessionProgress(sessionId, session);
   }
 
@@ -1256,7 +1262,9 @@ export class ClaudeWsServer {
   interrupt(sessionId: string, reason?: string): void {
     const session = this.getSession(sessionId);
     const outbound = session.state.interrupt();
-    this.sendToSession(session, outbound);
+    if (!this.sendToSession(session, outbound)) {
+      throw new Error(`Failed to deliver interrupt to session ${sessionId}: transport write failed`);
+    }
     session.pendingInterruptReason = reason ?? null;
   }
 
@@ -1783,7 +1791,7 @@ export class ClaudeWsServer {
    * Full WebSocket disconnection cleanup. Must be called from every error path
    * that detects a broken WS — not just handleClose.
    */
-  private disconnectSessionWs(sessionId: string, session: WsSession, reason: string): void {
+  private disconnectSession(sessionId: string, session: WsSession, reason: string): void {
     const prevState = session.state.state;
     session.ws = null;
 
@@ -1814,9 +1822,10 @@ export class ClaudeWsServer {
       }
     }
 
-    // Reject pending result waiters — they can't get results without WS
+    // Reject pending result waiters — they can't get results without a transport
+    const waiterReason = session.transport === "stdio" ? "stdio transport disconnected" : "WebSocket disconnected";
     for (const waiter of session.resultWaiters) {
-      waiter.reject(new Error("WebSocket disconnected"));
+      waiter.reject(new Error(waiterReason));
     }
     session.resultWaiters.length = 0;
   }
@@ -1857,7 +1866,7 @@ export class ClaudeWsServer {
         ws.send(outbound);
       } catch (err) {
         this.logger.error(`[_claude] WebSocket send failed on open for session ${sessionId}: ${err}`);
-        this.disconnectSessionWs(sessionId, session, "WebSocket send failed on open");
+        this.disconnectSession(sessionId, session, "WebSocket send failed on open");
         // Kill the spawned process — it can't communicate without WS
         if (session.proc) {
           try {
@@ -1878,7 +1887,7 @@ export class ClaudeWsServer {
           session.ws.send(keepAlive());
         } catch (err) {
           this.logger.error(`[_claude] WebSocket keep-alive send failed for session ${sessionId}: ${err}`);
-          this.disconnectSessionWs(sessionId, session, "WebSocket keep-alive send failed");
+          this.disconnectSession(sessionId, session, "WebSocket keep-alive send failed");
         }
       }
     }, KEEP_ALIVE_MS);
@@ -1963,7 +1972,7 @@ export class ClaudeWsServer {
       `[_claude] WebSocket disconnected for session ${sessionId} (spawn ${session.spawnAlive ? "alive" : "dead"})`,
     );
 
-    this.disconnectSessionWs(sessionId, session, "WebSocket closed");
+    this.disconnectSession(sessionId, session, "WebSocket closed");
   }
 
   // ── Event handling ──
@@ -2550,30 +2559,53 @@ export class ClaudeWsServer {
     return generateSessionName(usedNames);
   }
 
-  private sendToSession(session: WsSession, message: string): void {
+  /**
+   * Write an outbound message to the session's transport.
+   *
+   * Returns true if the write was issued, false if it could not be delivered.
+   * On failure the session is transitioned to `disconnected` (#2562) so that a
+   * dead transport cannot leave the state machine believing a prompt is being
+   * processed when the child never received it. Callers that mutated session
+   * state before calling (queuePrompt / respondToPermission / interrupt) MUST
+   * propagate a false return rather than continue silently.
+   */
+  private sendToSession(session: WsSession, message: string): boolean {
     if (session.transport === "stdio") {
-      if (session.stdioWriter) {
-        try {
-          session.stdioWriter.write(`${message}\n`);
-          session.stdioWriter.flush();
-        } catch (err) {
-          this.logger.error(`[_claude] stdio write failed: ${err}`);
-        }
+      if (!session.stdioWriter) {
+        this.failSend(session, "stdio writer unavailable");
+        return false;
       }
-      return;
+      try {
+        session.stdioWriter.write(`${message}\n`);
+        session.stdioWriter.flush();
+        return true;
+      } catch (err) {
+        this.logger.error(`[_claude] stdio write failed: ${err}`);
+        this.failSend(session, `stdio write failed: ${err}`);
+        return false;
+      }
     }
     // WS transport
     if (session.ws?.readyState === WS_OPEN) {
       try {
         session.ws.send(message);
+        return true;
       } catch (err) {
         this.logger.error(`[_claude] WebSocket send failed: ${err}`);
-        for (const [sid, s] of this.sessions) {
-          if (s === session) {
-            this.disconnectSessionWs(sid, session, "WebSocket send failed");
-            break;
-          }
-        }
+        this.failSend(session, "WebSocket send failed");
+        return false;
+      }
+    }
+    this.failSend(session, "WebSocket not open");
+    return false;
+  }
+
+  /** Transition a session to disconnected after a transport write failed. */
+  private failSend(session: WsSession, reason: string): void {
+    for (const [sid, s] of this.sessions) {
+      if (s === session) {
+        this.disconnectSession(sid, session, reason);
+        return;
       }
     }
   }


### PR DESCRIPTION
## Summary
- `sendToSession` swallowed write errors, so a failed stdio write (SIGPIPE / broken pipe on child crash) left the state machine in `processing` while the child never received the prompt — silent loss until the stuck detector fired minutes later. This became load-bearing with the stdio transport (#2551) where pipe failures are common.
- `sendToSession` now returns whether the write was delivered and transitions the session to `disconnected` on any failure (missing/closed transport or write exception, both stdio and WS), via the generalized `disconnectSession` (was `disconnectSessionWs`).
- `sendPrompt` / `respondToPermission` / `interrupt` propagate the failure as a thrown error (surfaced cleanly through the worker's `handleToolCall` try/catch as an `isError` response) so callers see it instead of continuing against a dead transport.

This implements option (b) from the issue: a dead transport can no longer leave the state machine believing a prompt is being processed.

## Test plan
- [x] `bun run am-i-done` (full gate: typecheck, lint, rules, tests, coverage) passes
- [x] New regression tests in `ws-server-stdio.spec.ts`: `sendPrompt` and `interrupt` throw and disconnect the session (state=`disconnected`, `session:disconnected` emitted) when the stdio write fails
- [x] Existing 232 ws-server / stdio tests still pass (WS-path disconnect message preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)