### PR TITLE
fix(build): restore compiled-daemon worker entrypoints (P1 regression)

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
-import { readFileSync, unlinkSync } from "node:fs";
-import { resolve } from "node:path";
+import { mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import { $ } from "bun";
 import type { BunPlugin } from "bun";
 import { daemonWorkers } from "./daemon-workers";
@@ -133,6 +134,24 @@ async function codesignIfDarwin(...paths: string[]): Promise<void> {
 
 // mcpd worker entrypoints (see scripts/daemon-workers.ts) — must be listed
 // explicitly for bun build --compile.
+//
+// `--root` pins the bundler outbase to the workers' directory. Without it,
+// Bun computes the output root from the entrypoint set and the result is
+// unstable: with ≤8 entrypoints (Bun 1.3.14) the extra entrypoints embed flat
+// at /$bunfs/root/<name>.js — next to the main module, where
+// worker-path.ts's compiled-mode `./<name>.ts` resolution finds them — but
+// with ≥9 they embed at /$bunfs/root/packages/daemon/src/<name>.js and every
+// `new Worker()` fails at runtime with `ModuleNotFound resolving "./<name>"`.
+// Growing the list from 6 to 9 entries silently broke all session workers
+// (the #2721→#2762 regression). Pinning --root makes the layout
+// deterministic; smokeDaemonWorkers() below verifies it on every build.
+const workerRoot = "packages/daemon/src";
+for (const w of [...daemonWorkers, "packages/daemon/src/main.ts"]) {
+  if (dirname(w) !== workerRoot) {
+    console.error(`daemon worker ${w} is outside ${workerRoot} — compiled-mode workerPath() requires a flat layout`);
+    process.exit(1);
+  }
+}
 
 // Packages excluded from bundling — resolved at runtime from node_modules.
 // playwright ships with a large optional-dep tree (electron, chromium-bidi, etc.)
@@ -163,6 +182,77 @@ const mcpctlConfig: BinaryBuildConfig = {
 };
 
 const bundleCleanup: string[] = [];
+
+/**
+ * Post-compile smoke: boot the freshly compiled mcpd with an isolated state
+ * dir and assert every worker-backed virtual server actually starts.
+ *
+ * This is the guard that the daemon-workers list alone cannot provide — it
+ * verifies the *embedded layout* of the binary, not just the entrypoint list.
+ * A binary where worker resolution is broken builds green but fails here with
+ * the captured daemon log.
+ *
+ * Only runs when the binary can execute on the build host (dev builds, and
+ * the native target of release builds).
+ */
+async function smokeDaemonWorkers(mcpdPath: string): Promise<void> {
+  const stateDir = mkdtempSync(join(tmpdir(), "mcpd-smoke-"));
+  // Ephemeral WS port so the smoke never collides with a real running daemon.
+  writeFileSync(join(stateDir, "config.json"), JSON.stringify({ wsPort: 0 }));
+
+  // Unconditional worker-backed servers, plus the ones gated on host binaries
+  // (mirrors the gating in packages/daemon/src/index.ts).
+  const expected = ["Claude session server started", "Mock session server started", "Site server started"];
+  if (Bun.which("codex")) expected.push("Codex session server started");
+  if (Bun.which("gh") || Bun.which("gemini") || Bun.which("grok")) expected.push("ACP session server started");
+  if (Bun.which("opencode")) expected.push("OpenCode session server started");
+
+  const proc = Bun.spawn([mcpdPath], {
+    env: { ...process.env, MCP_CLI_DIR: stateDir },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  let output = "";
+  const decoder = new TextDecoder();
+  const pump = async (stream: ReadableStream<Uint8Array>) => {
+    for await (const chunk of stream) output += decoder.decode(chunk);
+  };
+  const pumps = Promise.all([pump(proc.stdout), pump(proc.stderr)]);
+
+  const failurePattern = /ModuleNotFound|Failed to start/;
+  let failure: string | null = null;
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    if (failurePattern.test(output)) {
+      failure = "daemon reported a startup failure";
+      break;
+    }
+    if (expected.every((line) => output.includes(line))) break;
+    if (proc.exitCode !== null) {
+      failure = `daemon exited early (code ${proc.exitCode})`;
+      break;
+    }
+    await Bun.sleep(100);
+  }
+
+  proc.kill();
+  await proc.exited;
+  await pumps;
+  rmSync(stateDir, { recursive: true, force: true });
+
+  const missing = expected.filter((line) => !output.includes(line));
+  if (!failure && missing.length > 0) {
+    failure = `timed out waiting for: ${missing.join(", ")}`;
+  }
+  if (failure) {
+    console.error(`mcpd worker smoke FAILED (${mcpdPath}): ${failure}`);
+    console.error("--- daemon output ---");
+    console.error(output);
+    process.exit(1);
+  }
+  console.log(`mcpd worker smoke passed: ${expected.length} worker-backed servers started`);
+}
 
 async function buildBinary(config: BinaryBuildConfig, outfile: string, target?: string): Promise<void> {
   // Always bundle for generic "bun" target — the JS bundle is platform-agnostic.
@@ -219,12 +309,19 @@ if (releaseMode) {
     const suffix = target.replace("bun-", "");
     console.log(`Building for ${suffix}...`);
     await Promise.all([
-      $`bun build --compile --minify ${defineFlag} ${compiledFlag} ${versionFlag} ${epochFlag} ${externalFlags} --target=${target} packages/daemon/src/main.ts ${daemonWorkers} --outfile dist/mcpd-${suffix}`,
+      $`bun build --compile --minify ${defineFlag} ${compiledFlag} ${versionFlag} ${epochFlag} ${externalFlags} --root=${workerRoot} --target=${target} packages/daemon/src/main.ts ${daemonWorkers} --outfile dist/mcpd-${suffix}`,
       buildBinary(mcxConfig, `dist/mcx-${suffix}`, target),
       buildBinary(mcpctlConfig, `dist/mcpctl-${suffix}`, target),
     ]);
     if (target.includes("darwin")) {
       await codesignIfDarwin(`dist/mcpd-${suffix}`, `dist/mcx-${suffix}`, `dist/mcpctl-${suffix}`);
+    }
+    // Verify the embedded worker layout when the binary runs on this host.
+    const nativeTarget = `bun-${process.platform}-${process.arch}`;
+    if (target === nativeTarget) {
+      await smokeDaemonWorkers(resolve(`dist/mcpd-${suffix}`));
+    } else {
+      console.log(`Skipping mcpd worker smoke for ${target} (host is ${nativeTarget})`);
     }
   }
 
@@ -238,7 +335,7 @@ if (releaseMode) {
 } else {
   // Dev build: current platform, simple names
   await Promise.all([
-    $`bun build --compile --minify ${defineFlag} ${compiledFlag} ${versionFlag} ${epochFlag} ${externalFlags} packages/daemon/src/main.ts ${daemonWorkers} --outfile dist/mcpd`,
+    $`bun build --compile --minify ${defineFlag} ${compiledFlag} ${versionFlag} ${epochFlag} ${externalFlags} --root=${workerRoot} packages/daemon/src/main.ts ${daemonWorkers} --outfile dist/mcpd`,
     buildBinary(mcxConfig, "dist/mcx"),
     buildBinary(mcpctlConfig, "dist/mcpctl"),
   ]);
@@ -246,6 +343,9 @@ if (releaseMode) {
   if (process.platform === "darwin") {
     await codesignIfDarwin("dist/mcpd", "dist/mcx", "dist/mcpctl");
   }
+  // Verify the embedded worker layout — boots the compiled daemon with an
+  // isolated state dir and asserts every worker-backed server starts.
+  await smokeDaemonWorkers(resolve("dist/mcpd"));
   // Clean up intermediate bundles after all compiles finish
   for (const p of bundleCleanup) {
     try {

--- a/scripts/daemon-workers.spec.ts
+++ b/scripts/daemon-workers.spec.ts
@@ -38,4 +38,19 @@ describe("daemonWorkers bundle list", () => {
   it("has no duplicate entries", () => {
     expect(daemonWorkers.length).toBe(new Set(daemonWorkers).size);
   });
+
+  // Bun's default outbase shifts with the entrypoint count (1.3.14: ≤8 embeds
+  // workers flat at /$bunfs/root/, ≥9 nests them under packages/daemon/src/),
+  // which breaks compiled-mode `./<name>.ts` worker resolution for ALL workers
+  // at once while the build still exits 0. Every daemon compile command must
+  // pin the outbase with --root so the layout is deterministic; build.ts also
+  // smoke-boots the compiled binary to verify it (smokeDaemonWorkers).
+  it("build.ts pins --root on every compile command that embeds the workers", () => {
+    const buildSrc = readFileSync(resolve("scripts/build.ts"), "utf-8");
+    const compileLines = buildSrc.split("\n").filter((l) => l.includes("${daemonWorkers}"));
+    expect(compileLines.length).toBeGreaterThan(0);
+    for (const line of compileLines) {
+      expect(line).toContain("--root=${workerRoot}");
+    }
+  });
 });

--- a/scripts/daemon-workers.ts
+++ b/scripts/daemon-workers.ts
@@ -8,6 +8,13 @@
  * `ModuleNotFound resolving "./<name>" (entry point)` the moment its server is
  * started. `daemon-workers.spec.ts` guards against that by asserting every
  * referenced worker appears here.
+ *
+ * The compile command must also pass `--root=packages/daemon/src`: Bun's
+ * default output root is computed from the entrypoint set and silently shifts
+ * with the entrypoint COUNT (Bun 1.3.14: ≤8 flat, ≥9 nested under the cwd-
+ * relative source path), which breaks compiled-mode `./<name>.ts` resolution
+ * for every worker at once. `scripts/build.ts` pins --root and smoke-boots
+ * the compiled binary after every build to verify the embedded layout.
  */
 export const daemonWorkers = [
   "packages/daemon/src/alias-executor.ts",


### PR DESCRIPTION
Fixes #2796. P1 regression introduced by #2762 (fixes #2721): the compiled `dist/mcpd` could not start ANY session worker — every `new Worker()` failed at runtime with `ModuleNotFound resolving "./<name>-worker.ts" (entry point)` (Claude/Codex/ACP/Mock/Site all down), while `bun run build` stayed green.

## Root cause

Bun 1.3.14's `bun build --compile` computes the default output root (outbase) from the entrypoint set in a **count-dependent** way:

- **≤8 entrypoints**: additional entrypoints embed flat at `/$bunfs/root/<name>.js` — next to the main module, which is exactly where `worker-path.ts`'s compiled-mode `./<name>.ts` resolution expects them.
- **≥9 entrypoints**: they embed at `/$bunfs/root/packages/daemon/src/<name>.js`, while the main module stays at `/$bunfs/root/<outfile>` — so `./<name>.ts` resolves to nothing.

#2762 grew the worker entrypoint list from 6 to 9 (added `acp-session-worker.ts`, `opencode-session-worker.ts`, `monitor-executor.ts`), crossing the threshold. Bisection confirmed it is purely the count: replacing `monitor-executor.ts` with a trivial `console.log` file still produces the nested layout at 9 entrypoints, and any 8-entrypoint subset stays flat. Verified via `strings dist/mcpd | grep bunfs/root`. Upstream quirk tracked in #2798.

Why nothing caught it: the build exits 0 regardless of layout, and #2762's `daemon-workers.spec.ts` guard only validates **list membership** (every referenced worker is in the list) — it never inspects the compiled artifact.

## Fix

Pass `--root=packages/daemon/src` on both mcpd compile commands (dev + release) to pin the outbase. The embedded layout is now deterministically flat regardless of entrypoint count, matching the `worker-path.ts` contract. Verified for native and cross-target (`--target=bun-linux-x64`) compiles. `build.ts` also asserts every listed worker (and `main.ts`) lives in that directory, since the flat-layout contract requires it.

## Verification (the guard #2762 promised)

- **Post-compile smoke in `scripts/build.ts`** (`smokeDaemonWorkers`): boots the freshly compiled `mcpd` with an isolated `MCP_CLI_DIR` (mkdtemp) and `wsPort: 0` (never touches a real daemon's state, socket, or port), pumps stdout+stderr, and fails the build unless every worker-backed server logs `... server started` with zero `Failed to start` / `ModuleNotFound` lines (30s deadline, SIGTERM + cleanup). Runs on every dev build — i.e. in the required CI `build` job — and on the native target of release builds (cross targets log a skip).
- **`daemon-workers.spec.ts`**: new test asserting every compile command embedding `${daemonWorkers}` also pins `--root=${workerRoot}`.

Negative test: rebuilding with `--root` removed makes the smoke fail the build with the exact regression signature (`ModuleNotFound resolving "./claude-session-worker.ts" (entry point)` for all five servers).

Evidence on the fixed build (foreground `dist/mcpd`, isolated state dir):

```
[mcpd] Alias server started (0 tools)
[mcpd] Codex session server started
[mcpd] ACP session server started
[mcpd] Mock session server started
[mcpd] Site server started
[mcpd] Claude session server started (port 19275)
```

(ACP — the original #2721 failure — now also starts.) `bun run am-i-done` passes.

Related issues filed during root-cause: #2798 (upstream Bun outbase quirk), #2797 (`smoke-test.ts` isolation/CI gaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)