### PR TITLE
meta: verify-the-hypothesis, artifact-level QA, self-repair label closure

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -80,6 +80,33 @@ in your "what I understood" report. Examples of what to call out:
 - "Plan says: hot-shared file with #NNNN — rebase before push"
 - "Plan does not list this issue — proceeding from issue body alone"
 
+### Step 1b: Verify any prescribed root cause — before implementing it
+
+If the issue body, an investigation comment, or the sprint plan prescribes a
+specific root cause or fix mechanism ("the bug is X in file Y; fix it by Z"),
+treat the prescription as a **hypothesis, not a spec**. This applies to any
+issue with a named mechanism — not just `flaky`-labeled ones.
+
+1. **Reproduce first.** Confirm the claimed mechanism empirically before
+   writing the fix: run the failing case, loop the flaky spec, trace the
+   implicated code path, or replay the documented repro. Quote the evidence
+   in your plan ("reproduced on run 6/20", "error matches at file:line").
+2. **If it reproduces** — implement the prescribed fix and state what you
+   verified.
+3. **If the evidence contradicts the prescription** — do not cargo-cult the
+   named file or fix. Find and fix the real cause, and post the discrepancy
+   as an issue comment with your evidence (commands, output, line refs) so
+   the record is corrected for the next reader. A verified disproof is a
+   valid outcome; a no-op fix shipped to match a stale diagnosis is not.
+4. **If you can neither confirm nor refute cheaply** — say so at your plan
+   checkpoint and ask before proceeding. Implementing on an unverified
+   hypothesis is how wrong fixes ship.
+
+Why: a prescribed fix encodes the investigator's context, which can be stale,
+partial, or wrong — and the implementer is the last cheap point to catch it.
+The cost of a reproduction is minutes; the cost of a plausible-but-wrong fix
+is a review/repair cycle at best and a masked bug at worst.
+
 ### Step 2: Plan the Work
 
 Explore the codebase to understand the relevant areas. Use Glob, Grep, and Read to find:

--- a/.claude/commands/qa.md
+++ b/.claude/commands/qa.md
@@ -100,7 +100,29 @@ Where possible, verify the functionality works:
 - For daemon features: check that IPC handlers are registered and route correctly
 - Run `bun typecheck` to confirm the code compiles cleanly
 
-Do NOT start the daemon or run live integration tests — focus on static verification and unit tests.
+Do NOT start the daemon or run live integration tests — focus on static verification and unit tests. **Exception — artifact-level verification (next paragraph) — which still never touches the host daemon.**
+
+**Artifact-level verification for build/infra PRs.** If the diff touches the
+build mechanism (`scripts/build.ts`, compile entrypoints, bundler flags),
+compiled output layout, or worker plumbing (`worker-path.ts`,
+`*-worker.ts` registration, `worker-plugin.ts`), unit tests + green CI are
+**not sufficient evidence** — a binary can compile green and be dead at
+runtime. Your verification must exercise the artifact:
+
+```bash
+bun run build                       # must pass, including any built-in smoke
+STATE_DIR=$(mktemp -d)              # NEVER the real ~/.mcp-cli
+MCP_CLI_DIR="$STATE_DIR" ./dist/mcpd &   # boot the compiled binary, foreground/bg
+# read its startup log: every worker-backed server must log "started",
+# zero "Failed to start" / "ModuleNotFound"; then kill the process you
+# started (only that one — it's your child, not a host process) and rm -rf
+# the temp state dir.
+```
+
+Cite the observed startup lines in your QA comment as the evidence. If the
+artifact can't be exercised in your environment, say so explicitly and mark
+the verdict's confidence accordingly — do not silently fall back to
+unit-test evidence for an artifact-shaped change.
 
 ### Step 4: Check for Tests — and Write Missing Ones
 
@@ -351,6 +373,25 @@ gh pr edit <pr-number> --add-label qa:pass --remove-label qa:fail
 # or
 gh pr edit <pr-number> --add-label qa:fail --remove-label qa:pass
 ```
+
+**Self-repaired reviews: your verification closes the review label too.**
+When the PR carries `review:changes` and the findings were fixed by the
+reviewer itself (self-repair — the reviewer leaves its label unflipped on
+purpose because it may not approve its own fix), **your fresh-eyes
+verification is the independent approval that label was waiting for**. If
+your verdict is `qa:pass` and you verified each review finding is addressed,
+swap the review label in the same breath:
+
+```bash
+gh pr edit <pr-number> --add-label qa:pass --remove-label qa:fail
+gh pr edit <pr-number> --add-label review:pass --remove-label review:changes
+```
+
+State in your QA comment that the review-label swap is backed by your
+verification of the named findings. If your verdict is `qa:fail`, or you did
+NOT verify every review finding, leave `review:changes` in place — a PR must
+never merge carrying `review:changes` (the orchestrator holds the merge until
+the label state is consistent).
 
 The `--remove-label` is a no-op if the opposite label isn't present, so the
 swap form is always safe to run regardless of prior state.

--- a/.claude/skills/sprint/references/run.md
+++ b/.claude/skills/sprint/references/run.md
@@ -470,6 +470,15 @@ SIGTERM-immortality (#2586) was written into a self-approved repair commit
 by the session that flagged the original issue, 60s apart — writing eyes
 and approving eyes were one context, and the introduced defect shipped.
 
+**Label closure after self-repair — no PR merges carrying `review:changes`.**
+The self-repairing reviewer leaves `review:changes` unflipped (correct — it
+can't approve itself), and the verifying session swaps it to `review:pass`
+when its verification covers the findings (see qa.md Step 6). The
+orchestrator enforces the invariant at the merge gate: if a PR still carries
+`review:changes` alongside `qa:pass`, do not arm or execute the merge — send
+the verifier to complete the swap (or to state which finding it could not
+verify). Post-merge label cleanup is an audit-trail repair, not a substitute.
+
 **Precondition — the reviewer must be ON the PR branch, or self-repair
 silently breaks.** It can only push if it was spawned `--cwd` the worktree
 that holds the branch. The phase scripts emit `--worktree` (they don't know


### PR DESCRIPTION
Three between-sprint skill-text promotions requested after sprint 73:

- **implement.md Step 1b** — any prescribed root cause (issue body, investigation comment, sprint plan) is a hypothesis: reproduce before implementing; on contradicting evidence, fix the real cause and document the disproof on the issue. Generalizes the discipline that paid off twice in sprint 73 (#2740's disproof, #2729's repro-first) beyond flaky-labeled issues.
- **qa.md Step 3** — artifact-level verification mandate: PRs touching build mechanism, compiled output layout, or worker plumbing must boot the built artifact with isolated state; unit tests + green CI are insufficient for artifact-shaped changes (the #2796 lesson — #2762 was QA'd green and dead at runtime).
- **qa.md Step 6 + run.md self-repair section** — label closure: the verifying session swaps review:changes→review:pass when its verification covers the self-repaired findings; the orchestrator never merges a PR still carrying review:changes (three sprint-73 PRs merged with the stale label).

🤖 Generated with [Claude Code](https://claude.com/claude-code)