### PR TITLE
chore(skill): re-run hot-file overlap check on plan amendments (#2768)

### DIFF
--- a/.claude/skills/sprint/references/plan.md
+++ b/.claude/skills/sprint/references/plan.md
@@ -283,6 +283,20 @@ reviewers grepping every PR for potential duplicates across all open
 sibling branches is far higher than the (rare) cost of a single lint
 failure + rebase.
 
+**The overlap analysis is not one-shot — it must be re-run on every plan
+amendment.** When an issue is added mid-sprint (P1 discovered during QA,
+follow-up promoted to the active sprint), predict its touched files (parse
+the issue body for paths, stack traces, "modifies X" mentions) and
+cross-reference against ALL already-batched issues' predicted files before
+launching it. If it shares a file with an in-flight issue, add a
+"#amendment blockedBy #in-flight" edge (or push it to a later batch) and
+update the plan's hot-shared-files list in place so the serialization
+rationale stays current. Sprint 73 skipped this: #2754 was amended in at
+16:10, shared `scripts/_runner/ci-steps.ts` with already-batched #2719,
+launched in parallel anyway, and forced a manual merge-order intervention
+(#2768). The amendment flow in `run.md` ("Sprint-meta edits during run")
+repeats this requirement at the point of use.
+
 ## Step 5: Write the sprint plan
 
 Determine the sprint number:

--- a/.claude/skills/sprint/references/run.md
+++ b/.claude/skills/sprint/references/run.md
@@ -92,6 +92,17 @@ cp .claude/worktrees/sprint-{N}/.claude/sprints/sprint-{N}.md \
 The `sprint-{N}` PR (opened as draft in `plan.md` Step 6a) updates in place
 on every push.
 
+**Amendment gate — re-run the hot-file overlap check (#2768).** Before
+launching any issue added by a mid-sprint amendment, predict its touched
+files (issue-body paths, stack traces, "modifies X" mentions) and diff them
+against the predicted files of every already-batched AND in-flight issue.
+On overlap: add a `blockedBy` edge on the in-flight issue's Task (the
+amendment launches only after the earlier PR merges) and update the plan's
+hot-shared-files section in the same amendment commit. Never launch an
+amendment straight into the current batch without this check — sprint 73's
+#2754 amendment collided with in-flight #2719 on
+`scripts/_runner/ci-steps.ts` exactly this way.
+
 ### Task list setup — one Task per issue, NOT per batch
 
 **One `TaskCreate` per tracked issue, with `addBlockedBy` edges for every


### PR DESCRIPTION
Applies meta-fix #2768. Adds a mandatory amendment gate to the sprint skill: re-run the hot-file overlap matrix on every mid-sprint plan amendment, add blockedBy edges on collision, and update the plan's hot-shared-files section in place. Docs/skill-only — pre-commit hooks should skip the test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)