### PR TITLE
fix(gate): extend cooperative gate lease to TEST_CHANGED in pre-push (fixes #2761)

### DIFF
--- a/scripts/am-i-done.spec.ts
+++ b/scripts/am-i-done.spec.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "bun:test";
 
+import type { Step } from "./_runner/types";
 import { CI, COMPREHENSIVE, PRE_COMMIT, PRE_PUSH } from "./am-i-done";
 
 const names = (steps: { name: string }[]) => steps.map((s) => s.name);
+const leased = (steps: Step[]) => steps.filter((s) => s.lease).map((s) => s.name);
 
 describe("am-i-done step lists", () => {
   // #2737: `mcx phase check` resolves its root to the main checkout from a
@@ -25,5 +27,17 @@ describe("am-i-done step lists", () => {
 
   it("keeps phase-lock in the comprehensive (default) run", () => {
     expect(names(COMPREHENSIVE)).toContain("phase-lock");
+  });
+
+  // #2761: test-changed in the pre-push gate runs a near-full parallel spec
+  // set on a packages/core diff, which stacks on top of leased COMPREHENSIVE
+  // runs from other worktrees and re-creates the oversubscription #2690 fixed.
+  // CI steps stay unleased — each CI runner is its own host.
+  it("leases test-changed in the pre-push gate (#2761)", () => {
+    expect(leased(PRE_PUSH)).toContain("test-changed");
+  });
+
+  it("does not lease test-changed in CI (each runner is its own host)", () => {
+    expect(leased(CI)).not.toContain("test-changed");
   });
 });

--- a/scripts/am-i-done.ts
+++ b/scripts/am-i-done.ts
@@ -229,6 +229,7 @@ const TEST_CHANGED: Step = {
     "diff-aware tests — only files affected by the diff (bun test --changed; parallel, control sequential #2362)",
   command: changedTestsStep({ logName: "test_changed" }),
   source: "scripts/_runner/ci-steps.ts",
+  lease: true,
   onFailure: [
     "real failure: see the captured output above",
     "this runs only tests in your diff's blast radius — CI (`--ci`) runs the full suite + coverage",


### PR DESCRIPTION
## Summary
- Adds `lease: true` to the `TEST_CHANGED` step so the pre-push hook participates in the host-global counting semaphore introduced by #2690
- A `packages/core` diff triggers a near-full parallel spec set via `bun test --changed`, which could stack on top of leased COMPREHENSIVE runs from other worktrees and re-create the oversubscription that #2690 was designed to bound
- CI steps remain unleased — each CI runner is its own container/host, so the semaphore would never block there

## Test plan
- Added two assertions to `scripts/am-i-done.spec.ts`: `test-changed` in `PRE_PUSH` is leased; `test-changed` in `CI` is not leased
- All 6 tests pass
- Pre-commit and pre-push gates both pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)