### PR TITLE
fix(sprint-plan): match all numbers in paired-# cells (fixes #2735)

### DIFF
--- a/packages/core/src/sprint-plan.spec.ts
+++ b/packages/core/src/sprint-plan.spec.ts
@@ -73,6 +73,21 @@ describe("parseModelFromSprintTable", () => {
       "## Batch 1\n\n| # | Title | Model |\n|---|-------|-------|\n| 1000 | other | opus |\n\n## Batch 2\n\n| # | Title | Model |\n|---|-------|-------|\n| 1437 | impl | sonnet |\n";
     expect(parseModelFromSprintTable(twoTables, 1437)).toBe("sonnet");
   });
+
+  test("paired-# row: primary issue returns planned model", () => {
+    const paired = "| # | Title | Model |\n|---|-------|-------|\n| 2693 (+2520) | paired | opus |\n";
+    expect(parseModelFromSprintTable(paired, 2693)).toBe("opus");
+  });
+
+  test("paired-# row: secondary issue returns planned model", () => {
+    const paired = "| # | Title | Model |\n|---|-------|-------|\n| 2693 (+2520) | paired | opus |\n";
+    expect(parseModelFromSprintTable(paired, 2520)).toBe("opus");
+  });
+
+  test("paired-# row: out-of-table issue still returns null", () => {
+    const paired = "| # | Title | Model |\n|---|-------|-------|\n| 2693 (+2520) | paired | opus |\n";
+    expect(parseModelFromSprintTable(paired, 9999)).toBeNull();
+  });
 });
 
 describe("findModelInSprintPlan", () => {

--- a/packages/core/src/sprint-plan.ts
+++ b/packages/core/src/sprint-plan.ts
@@ -69,8 +69,8 @@ export function parseModelFromSprintTable(text: string, issueNumber: number): st
 
     // Data row — match the target issue number
     const issueCell = cols[issueColIdx] ?? "";
-    const numMatch = issueCell.match(/\d+/);
-    if (!numMatch || Number.parseInt(numMatch[0], 10) !== issueNumber) continue;
+    const nums = issueCell.match(/\d+/g)?.map((n) => Number.parseInt(n, 10)) ?? [];
+    if (!nums.includes(issueNumber)) continue;
 
     const modelCell = (cols[modelColIdx] ?? "").toLowerCase().trim();
     if (modelCell && isRecognizedModel(modelCell)) return modelCell;


### PR DESCRIPTION
## Summary
- `parseModelFromSprintTable` previously extracted only the first number from an issue cell, so secondary issues in `2693 (+2520)` style rows returned `null` and fell back to the label heuristic
- Now extracts all numbers from the cell via `/\d+/g` and checks membership, so both primary and secondary issue numbers resolve to the planned model
- Adds 3 new test cases to `sprint-plan.spec.ts`: primary lookup, secondary lookup, and out-of-table still returns null

## Test plan
- `bun test packages/core/src/sprint-plan.spec.ts` — 21 tests pass (18 existing + 3 new)
- `bun run am-i-done` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)