### PR TITLE
fix(build): anchor worker-smoke failure pattern to worker servers (fixes #2800)

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -5,6 +5,7 @@ import { dirname, join, resolve } from "node:path";
 import { $ } from "bun";
 import type { BunPlugin } from "bun";
 import { daemonWorkers } from "./daemon-workers";
+import { WORKER_SMOKE_FAILURE_PATTERN } from "./smoke-failure-pattern";
 
 // Ensure deps are installed (fast no-op when already present)
 await $`bun install`.quiet();
@@ -183,6 +184,11 @@ const mcpctlConfig: BinaryBuildConfig = {
 
 const bundleCleanup: string[] = [];
 
+// Grace period after SIGTERM before escalating the smoke daemon to SIGKILL.
+const SMOKE_KILL_GRACE_MS = 5000;
+// Deadline for all worker-backed servers to boot (generous for loaded CI runners).
+const SMOKE_DEADLINE_MS = 60_000;
+
 /**
  * Post-compile smoke: boot the freshly compiled mcpd with an isolated state
  * dir and assert every worker-backed virtual server actually starts.
@@ -214,37 +220,46 @@ async function smokeDaemonWorkers(mcpdPath: string): Promise<void> {
   });
 
   let output = "";
-  const decoder = new TextDecoder();
-  const pump = async (stream: ReadableStream<Uint8Array>) => {
-    for await (const chunk of stream) output += decoder.decode(chunk);
-  };
-  const pumps = Promise.all([pump(proc.stdout), pump(proc.stderr)]);
-
-  const failurePattern = /ModuleNotFound|Failed to start/;
   let failure: string | null = null;
-  const deadline = Date.now() + 30_000;
-  while (Date.now() < deadline) {
-    if (failurePattern.test(output)) {
-      failure = "daemon reported a startup failure";
-      break;
+  try {
+    const decoder = new TextDecoder();
+    const pump = async (stream: ReadableStream<Uint8Array>) => {
+      for await (const chunk of stream) output += decoder.decode(chunk);
+    };
+    const pumps = Promise.all([pump(proc.stdout), pump(proc.stderr)]);
+
+    const deadline = Date.now() + SMOKE_DEADLINE_MS;
+    while (Date.now() < deadline) {
+      if (WORKER_SMOKE_FAILURE_PATTERN.test(output)) {
+        failure = "daemon reported a worker startup failure";
+        break;
+      }
+      if (expected.every((line) => output.includes(line))) break;
+      if (proc.exitCode !== null) {
+        failure = `daemon exited early (code ${proc.exitCode})`;
+        break;
+      }
+      await Bun.sleep(100);
     }
-    if (expected.every((line) => output.includes(line))) break;
-    if (proc.exitCode !== null) {
-      failure = `daemon exited early (code ${proc.exitCode})`;
-      break;
+
+    proc.kill();
+    // Bounded grace period: a wedged worker thread must not hang the required
+    // `build` job indefinitely on an un-timed `await proc.exited`.
+    const killTimer = setTimeout(() => proc.kill(9), SMOKE_KILL_GRACE_MS);
+    await proc.exited;
+    clearTimeout(killTimer);
+    await pumps;
+
+    const missing = expected.filter((line) => !output.includes(line));
+    if (!failure && missing.length > 0) {
+      failure = `timed out waiting for: ${missing.join(", ")}`;
     }
-    await Bun.sleep(100);
+  } finally {
+    // Guard against a throw between spawn and kill leaking the daemon + tmpdir.
+    if (proc.exitCode === null) proc.kill(9);
+    rmSync(stateDir, { recursive: true, force: true });
   }
 
-  proc.kill();
-  await proc.exited;
-  await pumps;
-  rmSync(stateDir, { recursive: true, force: true });
-
-  const missing = expected.filter((line) => !output.includes(line));
-  if (!failure && missing.length > 0) {
-    failure = `timed out waiting for: ${missing.join(", ")}`;
-  }
   if (failure) {
     console.error(`mcpd worker smoke FAILED (${mcpdPath}): ${failure}`);
     console.error("--- daemon output ---");

--- a/scripts/smoke-failure-pattern.spec.ts
+++ b/scripts/smoke-failure-pattern.spec.ts
@@ -1,0 +1,52 @@
+// Guards the build.ts worker-smoke failure detector (#2800): it must fire on a
+// worker-backed server failure or a ModuleNotFound worker-resolution regression,
+// and must NOT fire on the non-worker servers (metrics/tracing/mail/work-items)
+// that log the identical "Failed to start ... server" phrase — those would
+// false-fail the required `build` gate on a transient init hiccup.
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { WORKER_SMOKE_FAILURE_PATTERN } from "./smoke-failure-pattern";
+
+// Worker-backed servers this smoke asserts (see build.ts `expected` list).
+const WORKER_SERVERS = ["Claude session", "Codex session", "ACP session", "OpenCode session", "mock", "site"];
+// Non-worker servers that log the same phrase but must not trip the detector.
+const NON_WORKER_SERVERS = ["metrics", "tracing", "mail", "work items"];
+
+describe("WORKER_SMOKE_FAILURE_PATTERN", () => {
+  it("matches ModuleNotFound (the direct worker-resolution regression signal)", () => {
+    expect(WORKER_SMOKE_FAILURE_PATTERN.test('ModuleNotFound resolving "./acp-session-worker" (entry point)')).toBe(
+      true,
+    );
+  });
+
+  it("matches a startup failure of every worker-backed server", () => {
+    for (const name of WORKER_SERVERS) {
+      const line = `[mcpd] Failed to start ${name} server: Error: boom`;
+      expect(WORKER_SMOKE_FAILURE_PATTERN.test(line)).toBe(true);
+    }
+  });
+
+  it("does NOT match a startup failure of a non-worker server", () => {
+    for (const name of NON_WORKER_SERVERS) {
+      const line = `[mcpd] Failed to start ${name} server: Error: sqlite blip`;
+      expect(WORKER_SMOKE_FAILURE_PATTERN.test(line)).toBe(false);
+    }
+  });
+
+  it("does not match a clean daemon startup log", () => {
+    expect(WORKER_SMOKE_FAILURE_PATTERN.test("[mcpd] Claude session server started")).toBe(false);
+  });
+
+  // Drift guard: the servers the daemon actually logs "Failed to start ... server"
+  // for must stay partitioned by the pattern exactly as classified above. If a
+  // new server is added, this fails until it's classified in one bucket.
+  it("classifies every daemon 'Failed to start' log site", () => {
+    const src = readFileSync(resolve("packages/daemon/src/index.ts"), "utf-8");
+    const names = [...src.matchAll(/Failed to start (.+?) server:/g)].map((m) => m[1]);
+    expect(names.length).toBeGreaterThan(0);
+    const known = new Set([...WORKER_SERVERS, ...NON_WORKER_SERVERS, "alias"]);
+    const unknown = names.filter((n) => !known.has(n));
+    expect(unknown).toEqual([]);
+  });
+});

--- a/scripts/smoke-failure-pattern.ts
+++ b/scripts/smoke-failure-pattern.ts
@@ -1,0 +1,14 @@
+/**
+ * Failure signal for the post-compile daemon-worker smoke (build.ts).
+ *
+ * Anchored to the worker-backed server names the smoke asserts. A bare
+ * /Failed to start/ over-matches: the daemon logs that same phrase for
+ * metrics/tracing/mail/work-items servers, which are NOT worker-backed and are
+ * unrelated to the `new Worker("./<name>")` entrypoint-resolution regression
+ * this smoke guards. Matching them would false-fail the required `build` gate
+ * on a transient init hiccup (e.g. a SQLite/FS blip in the isolated tmpdir) and
+ * misdiagnose it as a worker startup failure. `ModuleNotFound` is the direct
+ * worker-resolution signal. See #2800.
+ */
+export const WORKER_SMOKE_FAILURE_PATTERN =
+  /ModuleNotFound|Failed to start (Claude session|Codex session|ACP session|OpenCode session|mock|site) server/;


### PR DESCRIPTION
## Summary
- The post-compile daemon-worker smoke (`scripts/build.ts`) used a bare `/Failed to start/` detector on the **required** `build` gate. `metrics`, `tracing`, `mail`, and `work-items` log that identical phrase but are **not** worker-backed — a transient init hiccup in any of them (SQLite/FS blip in the isolated tmpdir) would false-fail the gate and misdiagnose it as a worker startup failure.
- Anchored the detector to the worker-backed server names + `ModuleNotFound` (the direct worker-resolution signal), extracted into an importable, unit-tested module `scripts/smoke-failure-pattern.ts`.
- Companion hardening in the same function: bounded SIGTERM→SIGKILL grace period (`await proc.exited` was un-timed), `try/finally` so an unexpected throw can't leak the daemon proc + tmpdir, and bumped the boot deadline 30s→60s for loaded 2-core CI runners.

## Test plan
- [x] New `scripts/smoke-failure-pattern.spec.ts`: pattern matches every worker-backed server failure + `ModuleNotFound`, does **not** match metrics/tracing/mail/work-items, and a drift-guard classifies every `Failed to start ... server` log site in `packages/daemon/src/index.ts`.
- [x] `bun run build` — real dev build: `mcpd worker smoke passed: 6 worker-backed servers started`.
- [x] `bun typecheck`, `bun lint`, static `am-i-done` gate pass.

Note: the full `am-i-done` test suite shows the pre-existing near-end SIGTERM resource-leak flake in daemon integration specs (documented, unrelated to this build-tooling change — those specs pass 194/194 in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)