### PR TITLE
fix(work-items): allow repair → qa; warn on silent hardcoded-graph fallback (fixes #2781)

### DIFF
--- a/packages/core/src/work-item.spec.ts
+++ b/packages/core/src/work-item.spec.ts
@@ -18,6 +18,7 @@ describe("canTransition", () => {
     ["review", "qa"],
     ["review", "done"],
     ["repair", "review"],
+    ["repair", "qa"],
     ["repair", "done"],
     ["qa", "repair"],
     ["qa", "done"],
@@ -35,7 +36,6 @@ describe("canTransition", () => {
     ["review", "impl"],
     ["review", "review"],
     ["repair", "impl"],
-    ["repair", "qa"],
     ["qa", "impl"],
     ["qa", "review"],
     ["qa", "qa"],
@@ -73,6 +73,10 @@ describe("reachablePhases", () => {
 
   it("returns repair, qa, done from review", () => {
     expect([...reachablePhases("review")].sort()).toEqual(["done", "qa", "repair"]);
+  });
+
+  it("returns review, qa, done from repair", () => {
+    expect([...reachablePhases("repair")].sort()).toEqual(["done", "qa", "review"]);
   });
 
   it("returns empty array for unknown phase", () => {

--- a/packages/core/src/work-item.ts
+++ b/packages/core/src/work-item.ts
@@ -89,7 +89,7 @@ export type WorkItemEvent =
 const VALID_TRANSITIONS: Record<WorkItemPhase, ReadonlySet<WorkItemPhase>> = {
   impl: new Set(["review", "qa", "done"]),
   review: new Set(["repair", "qa", "done"]),
-  repair: new Set(["review", "done"]),
+  repair: new Set(["review", "qa", "done"]),
   qa: new Set(["repair", "done"]),
   done: new Set(), // terminal
 };

--- a/packages/daemon/src/work-items-server.spec.ts
+++ b/packages/daemon/src/work-items-server.spec.ts
@@ -476,7 +476,9 @@ describe("WorkItemsServer", () => {
   test("work_items_update rejects invalid phase transition", async () => {
     const { db, raw } = createWorkItemDb();
     rawDb = raw;
-    server = new WorkItemsServer(db);
+    server = new WorkItemsServer(db, {
+      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+    });
 
     const { client } = await server.start();
 
@@ -734,7 +736,9 @@ describe("WorkItemsServer", () => {
   test("work_items_update force=true bypasses legacy transition check and logs forced", async () => {
     const { db, raw } = createWorkItemDb();
     rawDb = raw;
-    server = new WorkItemsServer(db);
+    server = new WorkItemsServer(db, {
+      logger: { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} },
+    });
     const { client } = await server.start();
     await client.callTool({ name: "work_items_track", arguments: { prNumber: 70 } });
     await client.callTool({ name: "work_items_update", arguments: { id: "pr:70", phase: "done" } });

--- a/packages/daemon/src/work-items-server.spec.ts
+++ b/packages/daemon/src/work-items-server.spec.ts
@@ -492,6 +492,50 @@ describe("WorkItemsServer", () => {
     expect(content[0].text).toContain("Invalid phase transition");
   });
 
+  test("work_items_update allows repair → qa (matches .mcx.yaml, no repoRoot)", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    server = new WorkItemsServer(db);
+
+    const { client } = await server.start();
+
+    await client.callTool({ name: "work_items_track", arguments: { prNumber: 51, phase: "repair" } });
+
+    const result = await client.callTool({
+      name: "work_items_update",
+      arguments: { id: "pr:51", phase: "qa" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const content = result.content as Array<{ type: string; text: string }>;
+    expect(JSON.parse(content[0].text).phase).toBe("qa");
+  });
+
+  test("work_items_update warns and reports repoRoot cause when falling back to hardcoded graph", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    const warnings: string[] = [];
+    server = new WorkItemsServer(db, {
+      logger: { info: () => {}, warn: (m: string) => warnings.push(m), error: () => {}, debug: () => {} },
+    });
+
+    const { client } = await server.start();
+
+    await client.callTool({ name: "work_items_track", arguments: { prNumber: 52, phase: "done" } });
+
+    const result = await client.callTool({
+      name: "work_items_update",
+      arguments: { id: "pr:52", phase: "impl" },
+    });
+
+    expect(result.isError).toBe(true);
+    const content = result.content as Array<{ type: string; text: string }>;
+    expect(content[0].text).toContain("no repoRoot was supplied");
+    expect(content[0].text).toContain("hardcoded graph");
+    expect(warnings.some((w) => w.includes("no repoRoot was supplied"))).toBe(true);
+    expect(warnings.some((w) => w.includes(".mcx.yaml phase edges were NOT consulted"))).toBe(true);
+  });
+
   test("work_items_update allows valid phase transition", async () => {
     const { db, raw } = createWorkItemDb();
     rawDb = raw;

--- a/packages/daemon/src/work-items-server.ts
+++ b/packages/daemon/src/work-items-server.ts
@@ -455,11 +455,22 @@ export class WorkItemsServer {
                   existing.phase !== newPhase &&
                   !canTransition(existing.phase, newPhase as WorkItemPhase)
                 ) {
+                  // Fallback path: no manifest was loaded (repoRoot omitted or load
+                  // failed), so the hardcoded VALID_TRANSITIONS graph is enforced.
+                  // This graph cannot represent manifest-only phases (e.g.
+                  // "needs-attention"), so a transition legal per .mcx.yaml can be
+                  // rejected here. Warn so the divergence is not silent (#2781).
+                  const reason = repoRoot
+                    ? `manifest could not be loaded from ${repoRoot}`
+                    : "no repoRoot was supplied";
+                  this.logger.warn(
+                    `[mcpd] work_items_update ${id}: validating ${existing.phase} → ${newPhase} against the hardcoded transition graph because ${reason}; .mcx.yaml phase edges were NOT consulted.`,
+                  );
                   return {
                     content: [
                       {
                         type: "text" as const,
-                        text: `Invalid phase transition: ${existing.phase} → ${newPhase}. pass force=true with forceReason to bypass.`,
+                        text: `Invalid phase transition: ${existing.phase} → ${newPhase} (hardcoded graph; ${reason}, so .mcx.yaml edges were not consulted). Supply repoRoot to validate against the manifest, or pass force=true with forceReason to bypass.`,
                       },
                     ],
                     isError: true,


### PR DESCRIPTION
## Summary
- Add `repair → qa` to `VALID_TRANSITIONS` (`packages/core/src/work-item.ts`) so it matches `.mcx.yaml`'s declared `repair.next: [review, qa, needs-attention]`. The documented CI-failure escalation (repair → fresh adversarial review → QA round 2) no longer needs `force=true`.
- Make the hardcoded-graph fallback non-silent (`packages/daemon/src/work-items-server.ts`): when a phase update omits `repoRoot` (or the manifest fails to load), `logger.warn` that `.mcx.yaml` edges were NOT consulted, and the rejection message now states the cause (`no repoRoot was supplied` / `manifest could not be loaded`) and how to fix it.

## Notes / not in scope
- This is Option C from the issue (A + warning). The deeper liability the issue flags — the hardcoded graph can never represent manifest-only phases like `needs-attention`, so `review→needs-attention` / `qa→needs-attention` still reject on the fallback path — remains. Eliminating `VALID_TRANSITIONS` in favor of universal manifest-driven validation (Option B) requires reliable `repoRoot` propagation and is deferred.

## Test plan
- [x] `packages/core/src/work-item.spec.ts`: `repair → qa` moved allowed→forbidden list flipped; added `reachablePhases("repair")` assertion
- [x] `packages/daemon/src/work-items-server.spec.ts`: repair→qa succeeds without repoRoot; fallback path warns + reports repoRoot cause in error
- [x] `bun run am-i-done` passes (typecheck, lint, rules, tests, coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)