### PR TITLE
fix(daemon): kill orphaned stdio child on disconnect (fixes #2793)

### DIFF
--- a/packages/daemon/src/claude-session/ws-server-stdio.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server-stdio.spec.ts
@@ -790,6 +790,10 @@ describe("ClaudeWsServer — stdio transport", () => {
     const session = server.listSessions().find((s) => s.sessionId === sessionId);
     expect(session?.state).toBe("disconnected");
     expect(events.some((e) => e.type === "session:disconnected")).toBe(true);
+
+    // stdio has no reconnect path — the child must be killed, not orphaned. (#2793)
+    await pollUntil(() => mock.killed, 1000);
+    expect(mock.killed).toBe(true);
   });
 
   test("interrupt throws and disconnects when stdio write fails", async () => {

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -1191,6 +1191,11 @@ export class ClaudeWsServer {
 
   /** Parse and dispatch a single NDJSON line from stdio stdout — mirrors handleMessage for WS. */
   private handleStdioLine(sessionId: string, session: WsSession, line: string): void {
+    // Drop late emissions from a torn-down session. After disconnectSession kills
+    // the stdio proc, buffered stdout lines can still drain in; feeding them to the
+    // state machine would corrupt a disconnected/ended session. (#2793)
+    if (session.state.state === "disconnected" || session.state.state === "ended") return;
+
     let messages: NdjsonMessage[];
     try {
       messages = parseFrame(line);
@@ -1834,6 +1839,18 @@ export class ClaudeWsServer {
       waiter.reject(new Error(waiterReason));
     }
     session.resultWaiters.length = 0;
+
+    // stdio has no reconnect path (unlike WS), so a disconnected stdio session
+    // can never regain a channel to its child. Leaving the proc alive orphans it
+    // with a dead stdin until the next daemon-start reaper. Kill it now, mirroring
+    // the handleOpen WS fallback ("can't communicate without WS"). (#2793)
+    if (session.transport === "stdio" && session.proc) {
+      try {
+        session.proc.kill();
+      } catch {
+        /* already dead */
+      }
+    }
   }
 
   private handleOpen(ws: ServerWebSocket<WsData>): void {


### PR DESCRIPTION
## Summary
- stdio transport has no reconnect path, yet `disconnectSession` (invoked on an EPIPE / writer-unavailable transport write failure) left `session.proc` alive with a dead stdin — an unmanaged zombie until the next daemon-start reaper.
- Kill the proc in `disconnectSession` when `transport === "stdio"`, mirroring the existing `handleOpen` WS fallback ("can't communicate without WS").
- Guard `handleStdioLine` to drop late stdout emissions into a `disconnected`/`ended` session so residual buffered lines can't corrupt torn-down state.

## Test plan
- [x] Extended `ws-server-stdio.spec.ts` write-failure test to assert the child is killed (`mock.killed`) after a stdio disconnect.
- [x] `bun run am-i-done` (full: typecheck, lint, rules, tests, coverage) — all checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)