### PR TITLE
fix(memory): fail non-zero on truncated audit results (fixes #2802)

### DIFF
--- a/packages/command/src/commands/memory.spec.ts
+++ b/packages/command/src/commands/memory.spec.ts
@@ -2,7 +2,15 @@ import { describe, expect, mock, test } from "bun:test";
 import { existsSync } from "node:fs";
 import { lookupFailure } from "@mcp-cli/core";
 import type { AuditResult, CmdMemoryDeps, MemoryDeps } from "./memory";
-import { buildPrompt, cmdMemory, defaultDeps, findMemoryDir, parseHaikuResponse, runMemoryAudit } from "./memory";
+import {
+  buildPrompt,
+  cmdMemory,
+  defaultDeps,
+  findMemoryDir,
+  parseHaikuResponse,
+  runMemoryAudit,
+  validateAuditResult,
+} from "./memory";
 
 // ─── findMemoryDir ────────────────────────────────────────────────────────────
 
@@ -121,6 +129,58 @@ describe("parseHaikuResponse", () => {
 
   test("returns null for empty string", () => {
     expect(parseHaikuResponse("")).toBeNull();
+  });
+});
+
+// ─── validateAuditResult ──────────────────────────────────────────────────────
+
+describe("validateAuditResult", () => {
+  const complete: AuditResult = {
+    findings: [
+      { file: "a.md", status: "load-bearing", reason: "ok", related: null },
+      { file: "b.md", status: "stale", reason: "gone", related: null },
+    ],
+    top_prune_candidates: ["b.md"],
+  };
+
+  test("ok when every expected file has a verdict", () => {
+    expect(validateAuditResult(complete, ["a.md", "b.md"])).toEqual({ ok: true, problems: [] });
+  });
+
+  test("flags incomplete audit with count and missing filenames", () => {
+    const v = validateAuditResult(complete, ["a.md", "b.md", "c.md"]);
+    expect(v.ok).toBe(false);
+    expect(v.problems.join(" ")).toContain("2/3 files evaluated");
+    expect(v.problems.join(" ")).toContain("c.md");
+  });
+
+  test("truncates the missing-file list at 5 with an ellipsis", () => {
+    const expected = ["a.md", "b.md", "c.md", "d.md", "e.md", "f.md", "g.md", "h.md"];
+    const v = validateAuditResult(complete, expected);
+    expect(v.ok).toBe(false);
+    expect(v.problems.join(" ")).toContain("…");
+  });
+
+  test("flags missing findings array", () => {
+    const v = validateAuditResult({ top_prune_candidates: [] } as unknown as AuditResult, ["a.md"]);
+    expect(v.ok).toBe(false);
+    expect(v.problems.join(" ")).toContain("no 'findings' array");
+  });
+
+  test("flags missing top_prune_candidates array", () => {
+    const v = validateAuditResult({ findings: complete.findings } as unknown as AuditResult, ["a.md", "b.md"]);
+    expect(v.ok).toBe(false);
+    expect(v.problems.join(" ")).toContain("top_prune_candidates");
+  });
+
+  test("flags a finding missing required fields", () => {
+    const bad = {
+      findings: [{ status: "load-bearing", reason: "no file field" }],
+      top_prune_candidates: [],
+    } as unknown as AuditResult;
+    const v = validateAuditResult(bad, []);
+    expect(v.ok).toBe(false);
+    expect(v.problems.join(" ")).toContain("missing required fields");
   });
 });
 
@@ -308,7 +368,10 @@ describe("runMemoryAudit", () => {
 
   test("handles malformed gh JSON gracefully", async () => {
     const result: AuditResult = {
-      findings: [{ file: "feedback_test.md", status: "load-bearing", reason: "ok", related: null }],
+      findings: [
+        { file: "feedback_test.md", status: "load-bearing", reason: "ok", related: null },
+        { file: "feedback_old.md", status: "stale", reason: "gone", related: null },
+      ],
       top_prune_candidates: [],
     };
     const deps = makeDeps({
@@ -325,7 +388,10 @@ describe("runMemoryAudit", () => {
 
   test("gh unavailable (non-zero exit) is handled gracefully", async () => {
     const result: AuditResult = {
-      findings: [{ file: "feedback_test.md", status: "load-bearing", reason: "ok", related: null }],
+      findings: [
+        { file: "feedback_test.md", status: "load-bearing", reason: "ok", related: null },
+        { file: "feedback_old.md", status: "stale", reason: "gone", related: null },
+      ],
       top_prune_candidates: [],
     };
     const deps = makeDeps({
@@ -339,9 +405,72 @@ describe("runMemoryAudit", () => {
     expect(deps.logs.join("\n")).toContain("feedback_test.md");
   });
 
+  test("exits non-zero when Haiku audits fewer files than provided (truncation)", async () => {
+    // Two files provided but Haiku returns a verdict for only one — silent truncation.
+    const partial: AuditResult = {
+      findings: [{ file: "feedback_test.md", status: "load-bearing", reason: "ok", related: null }],
+      top_prune_candidates: [],
+    };
+    const deps = makeDeps({
+      spawnCapture: (cmd) => {
+        if (cmd[0] === "gh") return { stdout: "[]", stderr: "", exitCode: 0 };
+        if (cmd.some((s) => s.includes("claude"))) return { stdout: JSON.stringify(partial), stderr: "", exitCode: 0 };
+        return { stdout: "", stderr: "", exitCode: 1 };
+      },
+    });
+    await expect(runMemoryAudit({ json: true }, deps)).rejects.toThrow("exit(1)");
+    const errLog = deps.errors.join("\n");
+    expect(errLog).toContain("failed validation");
+    expect(errLog).toContain("1/2 files evaluated");
+    expect(errLog).toContain("feedback_old.md");
+    // Must not have emitted the partial result to stdout.
+    expect(deps.logs.length).toBe(0);
+  });
+
+  test("exits non-zero when top_prune_candidates is missing", async () => {
+    const deps = makeDeps({
+      spawnCapture: (cmd) => {
+        if (cmd[0] === "gh") return { stdout: "[]", stderr: "", exitCode: 0 };
+        if (cmd.some((s) => s.includes("claude"))) {
+          // Valid JSON, both files, but no top_prune_candidates key.
+          return {
+            stdout: JSON.stringify({
+              findings: [
+                { file: "feedback_test.md", status: "load-bearing", reason: "ok", related: null },
+                { file: "feedback_old.md", status: "stale", reason: "gone", related: null },
+              ],
+            }),
+            stderr: "",
+            exitCode: 0,
+          };
+        }
+        return { stdout: "", stderr: "", exitCode: 1 };
+      },
+    });
+    await expect(runMemoryAudit({ json: true }, deps)).rejects.toThrow("exit(1)");
+    expect(deps.errors.join("\n")).toContain("top_prune_candidates");
+  });
+
+  test("exits non-zero when findings array is missing", async () => {
+    const deps = makeDeps({
+      spawnCapture: (cmd) => {
+        if (cmd[0] === "gh") return { stdout: "[]", stderr: "", exitCode: 0 };
+        if (cmd.some((s) => s.includes("claude"))) {
+          return { stdout: JSON.stringify({ top_prune_candidates: [] }), stderr: "", exitCode: 0 };
+        }
+        return { stdout: "", stderr: "", exitCode: 1 };
+      },
+    });
+    await expect(runMemoryAudit({ json: true }, deps)).rejects.toThrow("exit(1)");
+    expect(deps.errors.join("\n")).toContain("no 'findings' array");
+  });
+
   test("text mode reports 'No prune candidates' when list is empty", async () => {
     const result: AuditResult = {
-      findings: [{ file: "feedback_test.md", status: "load-bearing", reason: "Still good.", related: null }],
+      findings: [
+        { file: "feedback_test.md", status: "load-bearing", reason: "Still good.", related: null },
+        { file: "feedback_old.md", status: "load-bearing", reason: "Still good.", related: null },
+      ],
       top_prune_candidates: [],
     };
     const deps = makeDeps({

--- a/packages/command/src/commands/memory.ts
+++ b/packages/command/src/commands/memory.ts
@@ -41,6 +41,11 @@ export interface AuditResult {
   top_prune_candidates: string[];
 }
 
+export interface AuditValidation {
+  ok: boolean;
+  problems: string[];
+}
+
 export interface MemoryDeps {
   /** Resolve the git repo root. Returns null if not in a git repo, LookupFailure on error. */
   getGitRoot: () => LookupResult<string | null>;
@@ -195,6 +200,45 @@ export function parseHaikuResponse(raw: string): AuditResult | null {
   }
 }
 
+/**
+ * Validate that a parsed audit result is well-formed and complete.
+ *
+ * Haiku can truncate its output while still emitting syntactically valid JSON —
+ * e.g. a verdict for only 9 of 25 files, or an object missing `top_prune_candidates`.
+ * Such partial results must be a hard failure, not a silent exit-0 with corrupt data.
+ */
+export function validateAuditResult(result: AuditResult, expectedFiles: string[]): AuditValidation {
+  const problems: string[] = [];
+
+  if (!Array.isArray(result.findings)) {
+    problems.push("response has no 'findings' array");
+    return { ok: false, problems };
+  }
+  if (!Array.isArray(result.top_prune_candidates)) {
+    problems.push("response has no 'top_prune_candidates' array");
+  }
+
+  const audited = new Set<string>();
+  for (const f of result.findings) {
+    if (!f || typeof f.file !== "string" || typeof f.status !== "string") {
+      problems.push("a finding is missing required fields (file/status)");
+      continue;
+    }
+    audited.add(f.file);
+  }
+
+  const missing = expectedFiles.filter((f) => !audited.has(f));
+  if (missing.length > 0) {
+    const shown = missing.slice(0, 5).join(", ");
+    const suffix = missing.length > 5 ? ", …" : "";
+    problems.push(
+      `audit incomplete: ${audited.size}/${expectedFiles.length} files evaluated; ${missing.length} missing (${shown}${suffix})`,
+    );
+  }
+
+  return { ok: problems.length === 0, problems };
+}
+
 export async function runMemoryAudit(opts: { json: boolean }, deps: MemoryDeps): Promise<void> {
   const memoryDir = findMemoryDir(deps);
   if (!memoryDir) {
@@ -242,6 +286,16 @@ export async function runMemoryAudit(opts: { json: boolean }, deps: MemoryDeps):
     } catch {
       // disk full / permissions — preview above is the best we can do
     }
+    deps.exit(1);
+  }
+
+  const validation = validateAuditResult(
+    result,
+    ruleFiles.map((f) => f.name),
+  );
+  if (!validation.ok) {
+    deps.logError("memory audit: result failed validation — likely truncated or partial LLM output:");
+    for (const p of validation.problems) deps.logError(`  - ${p}`);
     deps.exit(1);
   }
 


### PR DESCRIPTION
## Summary
- `mcx memory audit` accepted any syntactically valid JSON from Haiku with **no completeness check**. A truncated-but-valid response (verdicts for 9 of 25 files, or a missing `top_prune_candidates` key) was emitted as a partial result with **exit 0** — silently corrupting the retro prune step. Text mode additionally crashed on `result.top_prune_candidates.length` when that field was absent.
- Adds `validateAuditResult(result, expectedFiles)` — verifies `findings`/`top_prune_candidates` are arrays, each finding has `file`/`status`, and **every input rule file has a verdict**. Wired into `runMemoryAudit` after parse (before formatting), so any partial/malformed result now logs specifics and exits non-zero in both json and text modes.

## On the two reported bugs
- **Bug #2 (silent truncation, exit 0):** real and fixed here.
- **Bug #1 (`--json` ignored):** does **not** reproduce in current code. `--json` dispatches correctly (`main.ts` → `cmdMemory` → `runMemoryAudit`), and json mode emits *only* JSON — proven by existing tests (`json mode prints valid JSON result`, `calls runAudit with json=true`). The human-format lines the reporter observed came from a non-`--json` invocation, not a flag-wiring defect. No code change needed for #1; see issue comment.

## Test plan
- [x] `bun run am-i-done` — full gate passes (typecheck, lint, rules, tests, coverage)
- [x] 9 new tests: truncated audit (9<25) exits non-zero without emitting partial JSON; missing `findings`; missing `top_prune_candidates`; malformed finding shape; plus `validateAuditResult` unit coverage
- [x] Existing 41 memory tests still pass (3 updated to return verdicts for all provided files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)