### PR TITLE
fix(gate-lease): fail-open on fs errors + validate slot env (fixes #2760)

### DIFF
--- a/packages/core/src/gate-lease.spec.ts
+++ b/packages/core/src/gate-lease.spec.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -12,10 +12,17 @@ function freshDir(): string {
   return d;
 }
 
+const savedSlotsEnv = process.env.MCX_GATE_LEASE_SLOTS;
 afterEach(() => {
   while (dirs.length) {
     const d = dirs.pop();
     if (d) rmSync(d, { recursive: true, force: true });
+  }
+  if (savedSlotsEnv === undefined) {
+    // biome-ignore lint/performance/noDelete: env var must be absent, not "undefined"
+    delete process.env.MCX_GATE_LEASE_SLOTS;
+  } else {
+    process.env.MCX_GATE_LEASE_SLOTS = savedSlotsEnv;
   }
 });
 
@@ -110,6 +117,59 @@ describe("acquireGateLease", () => {
     const b = await acquireGateLease({ slots: 1, lockDir, ...noWait });
     expect(b.held).toBe(true);
     b.release();
+  });
+
+  it("fails open with a warning when the lock dir cannot be created", async () => {
+    // Point lockDir at a path under a regular file so mkdir throws ENOTDIR.
+    const base = freshDir();
+    const filePath = join(base, "not-a-dir");
+    writeFileSync(filePath, "x");
+    const lockDir = join(filePath, "gate-locks");
+
+    const warnings: string[] = [];
+    const lease = await acquireGateLease({
+      slots: 2,
+      lockDir,
+      ...noWait,
+      logger: { warn: (m) => warnings.push(m) },
+    });
+    expect(lease.held).toBe(false);
+    expect(lease.slot).toBeNull();
+    expect(warnings.some((w) => w.includes("could not create lock dir") && w.includes("fail-open"))).toBe(true);
+    lease.release(); // must not throw
+  });
+});
+
+describe("MCX_GATE_LEASE_SLOTS validation", () => {
+  it("caps to the max and warns when the env value is absurdly large", async () => {
+    process.env.MCX_GATE_LEASE_SLOTS = "999999";
+    const lockDir = freshDir();
+    const warnings: string[] = [];
+    const lease = await acquireGateLease({ lockDir, ...noWait, logger: { warn: (m) => warnings.push(m) } });
+    expect(lease.held).toBe(true);
+    expect(lease.slot).toBe(0);
+    expect(warnings.some((w) => w.includes("exceeds max") && w.includes("capping"))).toBe(true);
+    lease.release();
+  });
+
+  it("warns and falls back to the default for a non-integer env value", async () => {
+    process.env.MCX_GATE_LEASE_SLOTS = "2abc";
+    const lockDir = freshDir();
+    const warnings: string[] = [];
+    const lease = await acquireGateLease({ lockDir, ...noWait, logger: { warn: (m) => warnings.push(m) } });
+    expect(lease.held).toBe(true);
+    expect(warnings.some((w) => w.includes("is not an integer"))).toBe(true);
+    lease.release();
+  });
+
+  it("warns when a negative env value disables the gate", async () => {
+    process.env.MCX_GATE_LEASE_SLOTS = "-1";
+    const lockDir = freshDir();
+    const warnings: string[] = [];
+    const lease = await acquireGateLease({ lockDir, ...noWait, logger: { warn: (m) => warnings.push(m) } });
+    expect(lease.held).toBe(false);
+    expect(lease.slot).toBeNull();
+    expect(warnings.some((w) => w.includes("disables the gate"))).toBe(true);
   });
 });
 

--- a/packages/core/src/gate-lease.ts
+++ b/packages/core/src/gate-lease.ts
@@ -32,6 +32,8 @@ import { flockUnlock, tryFlockExclusive } from "./flock";
 
 /** Default number of concurrent heavy test phases allowed across the host. */
 const DEFAULT_SLOTS = 2;
+/** Upper bound on slots — a huge value would exhaust the fd table per poll. */
+const MAX_SLOTS = 64;
 /** Generous fail-open deadline — proceed unleased rather than hang the gate. */
 const DEFAULT_TIMEOUT_MS = 15 * 60 * 1000;
 /** Base poll interval; jitter is added on top to avoid lockstep retries. */
@@ -55,7 +57,7 @@ export interface GateLeaseOptions {
   logger?: LeaseLogger;
   /** DI seam: sleep implementation (injected in tests). */
   sleep?: (ms: number) => Promise<void>;
-  /** DI seam: monotonic-ish clock (injected in tests). */
+  /** DI seam: monotonic clock (defaults to performance.now; injected in tests). */
   now?: () => number;
   /** DI seam: jitter source (injected in tests). */
   random?: () => number;
@@ -72,11 +74,27 @@ export interface GateLease {
 
 const UNHELD_LEASE: GateLease = { held: false, slot: null, release: () => {} };
 
-function readSlotsFromEnv(): number {
+function readSlotsFromEnv(logger?: LeaseLogger): number {
   const raw = process.env.MCX_GATE_LEASE_SLOTS;
   if (raw === undefined || raw === "") return DEFAULT_SLOTS;
+  // parseInt silently truncates trailing garbage ("2abc" -> 2), which hides a
+  // typo in a tuning value — reject non-integers with a warning instead.
+  if (!/^\s*-?\d+\s*$/.test(raw)) {
+    logger?.warn?.(
+      `gate-lease: MCX_GATE_LEASE_SLOTS="${raw}" is not an integer — using default ${DEFAULT_SLOTS} (#2690)`,
+    );
+    return DEFAULT_SLOTS;
+  }
   const n = Number.parseInt(raw, 10);
-  return Number.isFinite(n) ? n : DEFAULT_SLOTS;
+  if (!Number.isFinite(n)) return DEFAULT_SLOTS;
+  if (n > MAX_SLOTS) {
+    logger?.warn?.(`gate-lease: MCX_GATE_LEASE_SLOTS=${n} exceeds max ${MAX_SLOTS} — capping to ${MAX_SLOTS} (#2690)`);
+    return MAX_SLOTS;
+  }
+  if (n <= 0) {
+    logger?.warn?.(`gate-lease: MCX_GATE_LEASE_SLOTS=${n} disables the gate — proceeding unleased (#2690)`);
+  }
+  return n;
 }
 
 function readTimeoutFromEnv(): number {
@@ -144,18 +162,27 @@ function makeHeldLease(slot: HeldSlot): GateLease {
  * or when the fail-open deadline elapses. Never throws on contention.
  */
 export async function acquireGateLease(opts: GateLeaseOptions = {}): Promise<GateLease> {
-  const slots = opts.slots ?? readSlotsFromEnv();
+  const logger = opts.logger;
+  const slots = opts.slots ?? readSlotsFromEnv(logger);
   if (slots <= 0) return UNHELD_LEASE;
 
   const lockDir = opts.lockDir ?? join(options.MCP_CLI_DIR, "gate-locks");
   const timeoutMs = opts.timeoutMs ?? readTimeoutFromEnv();
   const basePoll = opts.pollIntervalMs ?? DEFAULT_POLL_MS;
   const sleep = opts.sleep ?? defaultSleep;
-  const now = opts.now ?? Date.now;
+  const now = opts.now ?? (() => performance.now());
   const random = opts.random ?? Math.random;
-  const logger = opts.logger;
 
-  mkdirSync(lockDir, { recursive: true });
+  // Fail-open on any fs error creating the lock dir (read-only HOME, disk full,
+  // bad permissions) — the lease must never fail the run it wraps (#2690).
+  try {
+    mkdirSync(lockDir, { recursive: true });
+  } catch (err) {
+    logger?.warn?.(
+      `gate-lease: could not create lock dir ${lockDir} (${(err as Error).message}) — proceeding unleased (fail-open, #2690)`,
+    );
+    return UNHELD_LEASE;
+  }
 
   const deadline = now() + timeoutMs;
   let announcedWait = false;


### PR DESCRIPTION
## Summary
- **Fail-open on fs errors:** `acquireGateLease` now wraps `mkdirSync` in try/catch, returning an unheld lease + `logger.warn` instead of throwing. A read-only `HOME`, disk-full, or permissions error on `~/.mcp-cli/gate-locks` can no longer crash the `am-i-done` run it wraps — honoring the module's "never throws / oversubscribe over hang" doctrine.
- **Validate `MCX_GATE_LEASE_SLOTS`:** capped at `MAX_SLOTS=64` (prevents EMFILE from opening N slot files per poll); non-integer values like `"2abc"` now warn and fall back to the default instead of silently truncating to `2`; negative values that disable the gate now log a warning so the operator knows protection is off.
- **Monotonic clock:** default `now` switched from `Date.now` to `performance.now()`, so an NTP/clock step during a wait can't cause a premature fail-open or an over-extended wait. DI seam unchanged.

## Test plan
- [x] Added spec: fails open with warning when the lock dir cannot be created (ENOTDIR via a path under a regular file)
- [x] Added specs: caps + warns on absurdly large env value; warns + falls back on non-integer; warns when a negative value disables the gate
- [x] `bun run am-i-done` — all checks pass (typecheck, lint, rules, tests, coverage)

References: #2690, #2758

🤖 Generated with [Claude Code](https://claude.com/claude-code)