### PR TITLE
refactor(daemon): resolve embedded workers by probing the module graph (fixes #2801)

### DIFF
--- a/packages/daemon/src/worker-path.spec.ts
+++ b/packages/daemon/src/worker-path.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { resolveEmbeddedWorker } from "./worker-path";
+
+/** Fake resolver: succeeds for the given embedded specifiers, throws otherwise. */
+function fakeResolve(embedded: Record<string, string>): (s: string) => string {
+  return (s) => {
+    const hit = embedded[s];
+    if (!hit) throw new Error(`Cannot find module '${s}'`);
+    return hit;
+  };
+}
+
+describe("resolveEmbeddedWorker", () => {
+  it("resolves a worker embedded flat (pinned --root layout)", () => {
+    const resolve = fakeResolve({ "./acp-session-worker.js": "/$bunfs/root/acp-session-worker.js" });
+    expect(resolveEmbeddedWorker("acp-session-worker.ts", resolve)).toBe("/$bunfs/root/acp-session-worker.js");
+  });
+
+  it("resolves a worker embedded nested (≥9-entrypoint layout, #2796)", () => {
+    const resolve = fakeResolve({
+      "./packages/daemon/src/site-worker.js": "/$bunfs/root/packages/daemon/src/site-worker.js",
+    });
+    expect(resolveEmbeddedWorker("site-worker.ts", resolve)).toBe("/$bunfs/root/packages/daemon/src/site-worker.js");
+  });
+
+  it("prefers the embedded module over a stray real-filesystem hit", () => {
+    // A bare candidate can resolve to a disk file; only /$bunfs/ results count.
+    const resolve = fakeResolve({
+      "./monitor-executor.js": "/home/user/monitor-executor.js",
+      "./packages/daemon/src/monitor-executor.js": "/$bunfs/root/packages/daemon/src/monitor-executor.js",
+    });
+    expect(resolveEmbeddedWorker("monitor-executor.ts", resolve)).toBe(
+      "/$bunfs/root/packages/daemon/src/monitor-executor.js",
+    );
+  });
+
+  it("throws a helpful error listing the tried candidates when unresolved", () => {
+    const resolve = fakeResolve({});
+    expect(() => resolveEmbeddedWorker("missing-worker.ts", resolve)).toThrow(
+      /Worker not embedded: missing-worker\.ts.*\.\/missing-worker\.js.*daemon-workers\.ts/s,
+    );
+  });
+
+  it("rejects a non-embedded (real-filesystem-only) resolution", () => {
+    const resolve = fakeResolve({ "./alias-executor.js": "/real/disk/alias-executor.js" });
+    expect(() => resolveEmbeddedWorker("alias-executor.ts", resolve)).toThrow(/not embedded/);
+  });
+});

--- a/packages/daemon/src/worker-path.ts
+++ b/packages/daemon/src/worker-path.ts
@@ -1,14 +1,25 @@
 /**
  * Resolve worker file paths for both dev mode and compiled binaries.
  *
- * In compiled binaries (`bun build --compile`), workers are embedded as
- * additional entrypoints and resolved via relative string paths.
  * In dev mode, workers are resolved via absolute paths using import.meta.dir.
+ *
+ * In compiled binaries (`bun build --compile`), workers are embedded as
+ * additional entrypoint modules. Reconstructing a single predicted embed path
+ * has broken worker resolution three times (#2721→#2762→#2796) because Bun's
+ * outbase layout is count-dependent (≤8 entrypoints embed flat at
+ * `/$bunfs/root/<name>.js`, ≥9 nest under `packages/daemon/src/<name>.js`).
+ *
+ * `Bun.embeddedFiles` lists embedded *assets*, not entrypoint modules (verified
+ * empty for workers), so it can't be indexed. Instead we probe the actual
+ * embedded module graph with `Bun.resolveSync` against every known layout and
+ * use whichever one the binary really has. This tolerates a layout shift at
+ * runtime instead of predicting a single one, closing the ModuleNotFound class
+ * regardless of which outbase Bun picks (#2801).
  *
  * Build injects `__COMPILED__ = true` via --define; defaults to false at runtime.
  */
 
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 declare const __COMPILED__: boolean;
 const isCompiled = typeof __COMPILED__ !== "undefined" && __COMPILED__;
@@ -16,7 +27,48 @@ const isCompiled = typeof __COMPILED__ !== "undefined" && __COMPILED__;
 /** Directory containing worker source files (dev mode only). */
 const WORKER_DIR = import.meta.dir;
 
+/** Extension-less basename, so a `.ts` reference matches an embedded `.js`. */
+function stem(name: string): string {
+  return basename(name).replace(/\.[cm]?[jt]s$/, "");
+}
+
+/** Candidate embedded specifiers for a worker, one per known Bun outbase layout. */
+function embedCandidates(name: string): string[] {
+  return [
+    `./${name}.js`, // flat layout (≤8 entrypoints / pinned --root)
+    `./packages/daemon/src/${name}.js`, // nested layout (≥9 entrypoints, #2796)
+  ];
+}
+
+/**
+ * Resolve a compiled-mode worker by probing the embedded module graph rather
+ * than reconstructing one predicted path. `resolve` is injected for tests;
+ * production passes `Bun.resolveSync`.
+ */
+export function resolveEmbeddedWorker(
+  filename: string,
+  resolve: (specifier: string) => string = (s) => Bun.resolveSync(s, WORKER_DIR),
+): string {
+  const candidates = embedCandidates(stem(filename));
+  for (const candidate of candidates) {
+    let resolved: string;
+    try {
+      resolved = resolve(candidate);
+    } catch {
+      continue; // this layout isn't present in the binary — try the next
+    }
+    // Only an embedded module counts; a bare `.js` can otherwise resolve to a
+    // stray file on the real filesystem.
+    if (resolved.startsWith("/$bunfs/")) return resolved;
+  }
+  throw new Error(
+    `Worker not embedded: ${filename}. Tried ${candidates.join(", ")}. ` +
+      `Add packages/daemon/src/${filename} to scripts/daemon-workers.ts.`,
+  );
+}
+
 /** Resolve a worker filename to a path usable with `new Worker()`. */
 export function workerPath(filename: string): string {
-  return isCompiled ? `./${filename}` : join(WORKER_DIR, filename);
+  if (!isCompiled) return join(WORKER_DIR, filename);
+  return resolveEmbeddedWorker(filename);
 }

--- a/scripts/daemon-workers.spec.ts
+++ b/scripts/daemon-workers.spec.ts
@@ -39,18 +39,12 @@ describe("daemonWorkers bundle list", () => {
     expect(daemonWorkers.length).toBe(new Set(daemonWorkers).size);
   });
 
-  // Bun's default outbase shifts with the entrypoint count (1.3.14: ≤8 embeds
-  // workers flat at /$bunfs/root/, ≥9 nests them under packages/daemon/src/),
-  // which breaks compiled-mode `./<name>.ts` worker resolution for ALL workers
-  // at once while the build still exits 0. Every daemon compile command must
-  // pin the outbase with --root so the layout is deterministic; build.ts also
-  // smoke-boots the compiled binary to verify it (smokeDaemonWorkers).
-  it("build.ts pins --root on every compile command that embeds the workers", () => {
-    const buildSrc = readFileSync(resolve("scripts/build.ts"), "utf-8");
-    const compileLines = buildSrc.split("\n").filter((l) => l.includes("${daemonWorkers}"));
-    expect(compileLines.length).toBeGreaterThan(0);
-    for (const line of compileLines) {
-      expect(line).toContain("--root=${workerRoot}");
-    }
-  });
+  // The former "build.ts pins --root" string-match assertion lived here. It
+  // tested implementation spelling, not behavior — it false-failed on harmless
+  // build.ts refactors and would green-pass if a Bun upgrade broke resolution
+  // at a different layer. Worker resolution now probes the actual embedded
+  // module graph across every known layout via Bun.resolveSync (worker-path.ts,
+  // #2801), so a single predicted layout is no longer load-bearing; the
+  // post-compile boot smoke in build.ts is the behavior-true guard that every
+  // worker actually starts.
 });


### PR DESCRIPTION
## Summary
- Replace `worker-path.ts`'s single **predicted** compiled-mode embed path (`./<name>`) with a **layout-tolerant** resolver: probe the actual embedded module graph via `Bun.resolveSync` across every known outbase layout (flat `./<name>.js` and nested `./packages/daemon/src/<name>.js`), and use whichever the binary really embedded. Only `/$bunfs/`-prefixed resolutions count, so a stray on-disk file can't shadow a worker.
- This closes the `#2721`→`#2762`→`#2796` `ModuleNotFound` regression class **regardless of which outbase Bun picks** — a runtime layout shift is tolerated instead of predicted.
- Drop the `daemon-workers.spec.ts` "build.ts pins `--root`" string-match test (implementation-spelling, not behavior) in favor of the post-compile boot smoke, per the issue's "smaller related note".

## Deviation from the issue: Option A doesn't work
The issue proposed indexing `Bun.embeddedFiles` (Option A). **Verified empirically that this cannot work**: `Bun.embeddedFiles` lists embedded *assets*, not entrypoint *modules* — it is `[]` in a compiled binary even with extra worker entrypoints (reproduced with a minimal `bun build --compile main.ts sub/wk.ts` probe). Worker entrypoints are embedded as resolvable modules, reachable only via `Bun.resolveSync` — which this PR uses. The candidate-probe approach achieves the issue's stated **intent** (stop single-point prediction; make the class structurally tolerant) using the only runtime API Bun exposes for the module graph. Option B (build-time manifest) was rejected: emitting the real `/$bunfs/…` specifier at build time still requires predicting Bun's naming, since `bun build --compile` emits no module manifest.

## Test plan
- [x] `bun typecheck`, `bun lint`, `bun run doing-it-wrong` — clean
- [x] New `worker-path.spec.ts` unit-tests the resolver (flat layout, nested layout, `/$bunfs`-only preference, unresolved error, real-fs rejection) via an injected resolver
- [x] `bun run build` — post-compile worker smoke **passes** against the real compiled `dist/mcpd`: all 6 worker-backed servers start
- [x] `bun run am-i-done` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)