### PR TITLE
fix(smoke): isolate smoke-test.ts + add session-worker smoke (#2797)

### DIFF
--- a/scripts/smoke-test.ts
+++ b/scripts/smoke-test.ts
@@ -8,12 +8,26 @@
  * Run after `bun run build`:
  *   bun run smoke-test
  *
+ * Isolation: every subprocess runs against a throwaway MCP_CLI_DIR (never the
+ * user's real ~/.mcp-cli) so `mcx ls`, alias mutations, and the auto-started
+ * daemon can't touch live state. Mirrors the pattern in scripts/build.ts
+ * (smokeDaemonWorkers). The dir + daemon are torn down at exit.
+ *
  * Exits 0 if all checks pass, 1 if any fail.
  */
 
-import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 import { $ } from "bun";
+
+// Isolated runtime state — set before any subprocess spawn so the compiled
+// binaries (which read MCP_CLI_DIR from the env) never touch real user state.
+// wsPort: 0 lets the daemon pick an ephemeral WS port instead of colliding
+// with a real running daemon on the well-known port.
+const STATE_DIR = mkdtempSync(join(tmpdir(), "mcx-smoke-"));
+writeFileSync(join(STATE_DIR, "config.json"), JSON.stringify({ wsPort: 0 }));
+process.env.MCP_CLI_DIR = STATE_DIR;
 
 const MCX = resolve("dist/mcx");
 const MCPD = resolve("dist/mcpd");
@@ -84,14 +98,22 @@ await run("mcx version exits 0 and contains version string", async () => {
   assert(parsed.client.version !== "0.0.0-dev", `version not injected: ${parsed.client.version}`);
 });
 
-await run("mcpd --help exits 0", async () => {
-  const result = await $`${MCPD} --help`.quiet();
-  assert(result.exitCode === 0, `exit code ${result.exitCode}`);
-});
+// mcpd has no one-shot "print and exit" mode — any invocation boots the full
+// daemon (it ignores --help and blocks until idle-timeout). Booting the
+// compiled dist/mcpd is already covered by scripts/build.ts (smokeDaemonWorkers,
+// run on every build) and end-to-end below by "mcx agent mock spawn", so there
+// is no separate mcpd liveness check here.
 
-await run("mcpctl --version exits 0", async () => {
-  const result = await $`${MCPCTL} --version`.quiet();
-  assert(result.exitCode === 0, `exit code ${result.exitCode}`);
+await run("mcpctl boots and refuses non-TTY gracefully", async () => {
+  // mcpctl is a TUI with no one-shot flag; the only deterministic, non-hanging
+  // liveness check is that the compiled binary boots far enough to hit its
+  // no-TTY guard. `$` pipes stdout, so the child always sees isTTY === false.
+  const result = await $`${MCPCTL}`.quiet().nothrow();
+  assert(result.exitCode === 1, `expected exit 1 (no-TTY guard), got ${result.exitCode}`);
+  assert(
+    result.stderr.toString().includes("requires a terminal"),
+    `expected no-TTY guard message, got: ${result.stderr.toString()}`,
+  );
 });
 
 await run("mcx ls exits 0", async () => {
@@ -100,8 +122,13 @@ await run("mcx ls exits 0", async () => {
 });
 
 await run("mcx alias save/call/delete cycle", async () => {
-  // Save
-  const save = await $`echo ${SMOKE_SCRIPT} | ${MCX} alias save ${SMOKE_ALIAS} --stdin`.quiet().nothrow();
+  // NOTE: this check currently fails on the compiled binary due to #2821
+  // (compiled daemon can't resolve ./alias-executor.ts; the error is also
+  // printed to stdout with exit 0, which is why it went unnoticed). That is
+  // the smoke doing its job — catching a real compiled-binary regression. It
+  // will pass once #2821 lands.
+  // Save (source token "-" reads the script from stdin)
+  const save = await $`echo ${SMOKE_SCRIPT} | ${MCX} alias save ${SMOKE_ALIAS} -`.quiet().nothrow();
   assert(save.exitCode === 0, `alias save exit code ${save.exitCode}: ${save.stderr.toString()}`);
 
   try {
@@ -115,6 +142,41 @@ await run("mcx alias save/call/delete cycle", async () => {
     await $`${MCX} alias delete ${SMOKE_ALIAS}`.quiet().nothrow();
   }
 });
+
+await run("mcx agent mock spawn --wait (session worker startup)", async () => {
+  // Exercises the full compiled mcx → mcpd → mock session worker path. This is
+  // the exact runtime code path that regressed in #2762 (compiled session
+  // workers failing with ModuleNotFound while `bun build` stayed green) — a
+  // failure `bun test` on source can never catch.
+  const scriptPath = join(STATE_DIR, "mock-script.json");
+  writeFileSync(scriptPath, JSON.stringify([{ delay: 0, text: "smoke ok" }]));
+
+  const spawn = await $`${MCX} agent mock spawn --task ${scriptPath} --wait`.quiet().nothrow();
+  assert(spawn.exitCode === 0, `mock spawn exit code ${spawn.exitCode}: ${spawn.stderr.toString()}`);
+  assert(
+    spawn.stdout.toString().includes("session:result"),
+    `expected session:result in output, got: ${spawn.stdout.toString()}`,
+  );
+});
+
+// ── Teardown: stop the isolated daemon and remove the state dir ──
+
+async function teardown(): Promise<void> {
+  // The daemon auto-started by mcx runs against STATE_DIR — terminate it so it
+  // doesn't linger, then remove the throwaway state.
+  try {
+    const pidPath = join(STATE_DIR, "mcpd.pid");
+    if (existsSync(pidPath)) {
+      const { pid } = JSON.parse(readFileSync(pidPath, "utf-8")) as { pid: number };
+      if (typeof pid === "number") process.kill(pid, "SIGTERM");
+    }
+  } catch {
+    // Daemon already gone or pidfile malformed — nothing to stop.
+  }
+  rmSync(STATE_DIR, { recursive: true, force: true });
+}
+
+await teardown();
 
 // ── Summary ──
 


### PR DESCRIPTION
## Summary
- **Isolation (the P1 in #2797):** every `dist/mcx`/`dist/mcpd`/`dist/mcpctl` subprocess now runs against a throwaway `MCP_CLI_DIR` tmpdir (`wsPort: 0`), torn down at exit (daemon SIGTERM'd via pidfile). The smoke no longer reads the user's live daemon socket or mutates their real `~/.mcp-cli` alias table. Mirrors the pattern in `scripts/build.ts` (`smokeDaemonWorkers`). Verified: no `_smoke-test` alias leaks into real state.
- **Session-worker assertion (point 2):** added `mcx agent mock spawn --task … --wait`, exercising the full compiled `mcx → mcpd → mock session worker` path — the exact regression class (#2762) the smoke exists to catch. Passes.
- **Corrected checks isolation exposed as broken** (they only ever "passed" against a warm real daemon + a TTY): dropped `mcpd --help` (it boots the daemon and blocks until idle-timeout — mcpd boot is already covered by `build.ts` + the mock spawn); rewrote `mcpctl --version` as a non-TTY liveness guard (`--version` is unhandled and the TUI needs a TTY); fixed the alias source token — `--stdin` was never valid, the correct form is `-`.

## Deferred: CI wiring — blocked by #2821
Point 3 of the issue (wire `bun run smoke-test` into CI) is **not** in this PR. Once the alias check was corrected, the isolated smoke immediately caught a **pre-existing `main` bug**, filed as **#2821**: the compiled daemon can't resolve `./alias-executor.ts` (`ModuleNotFound` on the argv-redispatch `import()` path), and `mcx call _aliases` prints the error to stdout while exiting 0 (a masking bug). Turning on a blocking CI smoke gate now would paint `main` red for a bug this PR doesn't introduce. Per our rule (a failure reproducing on clean `main` is a shared gap fixed at main-level first), CI wiring is a follow-up gated on #2821's fix.

- #2821 is scheduled as a sprint amendment blocked on **#2822** (issue #2801): that PR replaces `worker-path.ts`'s predicted embed path with a layout-tolerant `Bun.resolveSync` prober; the correct #2821 fix routes `main.ts`'s `WORKER_ENTRIES` argv-redispatch through that same resolver.
- The alias check in this PR is intentionally left as a correct (currently-red locally) assertion with an inline note referencing #2821 — it is the smoke doing its job.

## Test plan
- [x] `bun run am-i-done --pre-commit` (typecheck + lint + rules) passes
- [x] `bun run build` succeeds
- [x] `bun run smoke-test`: version, mcpctl non-TTY guard, `mcx ls`, and mock session-worker spawn all pass; alias cycle correctly fails on #2821 (compiled `alias-executor.ts` ModuleNotFound)
- [x] Verified no `_smoke-test` alias leaks into real `~/.mcp-cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)