### PR TITLE
feat(phases): mechanize sprint-73 meta rules into phase scripts (fixes #2804)

### DIFF
--- a/.claude/phases/done-fn.spec.ts
+++ b/.claude/phases/done-fn.spec.ts
@@ -46,6 +46,38 @@ describe("mergePr", () => {
     if (!result.ok) expect(result.reason).toBe("missing_qa_pass");
   });
 
+  test("blocks merge when the PR still carries review:changes (#2804)", async () => {
+    const deps = makeDeps({
+      async gh(op) {
+        if (op.op === "pr:labels") return { stdout: "qa:pass\nreview:pass\nreview:changes", stderr: "", exitCode: 0 };
+        if (op.op === "pr:checks") return { stdout: "0", stderr: "", exitCode: 0 };
+        return { stdout: "", stderr: "", exitCode: 0 };
+      },
+    });
+    const result = await mergePr(42, deps);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("inconsistent_labels");
+      expect(result.blockingLabels).toContain("review:changes");
+    }
+  });
+
+  test("blocks merge when qa:pass and qa:fail are both present (#2804)", async () => {
+    const deps = makeDeps({
+      async gh(op) {
+        if (op.op === "pr:labels") return { stdout: "qa:pass\nqa:fail", stderr: "", exitCode: 0 };
+        if (op.op === "pr:checks") return { stdout: "0", stderr: "", exitCode: 0 };
+        return { stdout: "", stderr: "", exitCode: 0 };
+      },
+    });
+    const result = await mergePr(42, deps);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("inconsistent_labels");
+      expect(result.blockingLabels).toEqual(expect.arrayContaining(["qa:pass", "qa:fail"]));
+    }
+  });
+
   test("returns ci_not_green when failing checks > 0", async () => {
     const deps = makeDeps({
       async gh(op) {

--- a/.claude/phases/done-fn.ts
+++ b/.claude/phases/done-fn.ts
@@ -1,6 +1,6 @@
 /** Core done-phase logic, extracted for testability via dependency injection. */
 
-import type { GhOp, GhResult } from "./phase-types";
+import { type GhOp, type GhResult, labelsConsistent } from "./phase-types";
 export type { GhOp, GhResult };
 
 export interface ProcessHandle {
@@ -52,9 +52,17 @@ export type MergeResult =
   | { ok: true; prNumber: number; localCleanup?: string }
   | {
       ok: false;
-      reason: "ci_not_green" | "missing_qa_pass" | "conflicts" | "missing_required_check" | "merge_failed";
+      reason:
+        | "ci_not_green"
+        | "missing_qa_pass"
+        | "inconsistent_labels"
+        | "conflicts"
+        | "missing_required_check"
+        | "merge_failed";
       nextAction: string;
       detail?: string;
+      /** Labels blocking the merge, set only for reason === "inconsistent_labels" (#2804). */
+      blockingLabels?: string[];
     };
 
 export interface MergePrDeps {
@@ -89,18 +97,26 @@ export async function mergePr(prNumber: number, deps: MergePrDeps): Promise<Merg
   }
 
   const labels = labelOut.stdout.split(/\r?\n/).map((l) => l.trim());
+
+  // Label-closure gate (#2804): refuse merge on inconsistent verdict labels —
+  // a lingering `review:changes` after self-repair, or contradictory qa:pass +
+  // qa:fail. Surfaces the blocking labels so the orchestrator sees them without
+  // re-reading the PR.
+  const consistency = labelsConsistent(labels);
+  if (!consistency.ok) {
+    return {
+      ok: false,
+      reason: "inconsistent_labels",
+      nextAction: `PR #${prNumber} carries inconsistent verdict labels (${consistency.blocking.join(", ")}); send the verifier to close them before merge`,
+      blockingLabels: consistency.blocking,
+    };
+  }
+
   if (!labels.includes("qa:pass")) {
     return {
       ok: false,
       reason: "missing_qa_pass",
       nextAction: `spawn qa for PR #${prNumber}; do not transition to done until qa:pass is set`,
-    };
-  }
-  if (labels.includes("qa:fail")) {
-    return {
-      ok: false,
-      reason: "missing_qa_pass",
-      nextAction: `PR #${prNumber} has both qa:pass and qa:fail; remove the stale label before merge`,
     };
   }
 

--- a/.claude/phases/done.ts
+++ b/.claude/phases/done.ts
@@ -28,6 +28,7 @@ defineAlias({
         reason: z.string(),
         nextAction: z.string(),
         detail: z.string().optional(),
+        blockingLabels: z.array(z.string()).optional(),
       })
       .optional(),
   }),
@@ -103,11 +104,27 @@ defineAlias({
       },
     });
     if (!result.ok) {
+      // Surface blocking verdict labels to work-item state so the orchestrator
+      // sees them without re-reading the PR (#2804).
+      if (result.reason === "inconsistent_labels" && result.blockingLabels) {
+        try {
+          await ctx.state.set("merge_block_labels", result.blockingLabels.join(","));
+        } catch {
+          /* non-fatal — the error payload also carries the labels */
+        }
+      }
       return {
         merged: false,
         prNumber: work.prNumber,
         issueNumber: work.issueNumber,
-        error: { reason: result.reason, nextAction: result.nextAction, detail: result.detail },
+        error: {
+          reason: result.reason,
+          nextAction: result.nextAction,
+          detail: result.detail,
+          ...(result.reason === "inconsistent_labels" && result.blockingLabels
+            ? { blockingLabels: result.blockingLabels }
+            : {}),
+        },
       };
     }
 
@@ -135,6 +152,8 @@ defineAlias({
       "labels",
       "model",
       "review_model",
+      "artifact_check",
+      "merge_block_labels",
     ]) {
       await ctx.state.delete(key);
     }

--- a/.claude/phases/impl-fn.spec.ts
+++ b/.claude/phases/impl-fn.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { buildImplCommand, buildImplPrompt, resolveImplModel } from "./impl-fn";
+import { buildImplCommand, buildImplPrompt, detectPrescribedRootCause, resolveImplModel } from "./impl-fn";
 
 describe("buildImplPrompt", () => {
   test("includes the issue number", () => {
@@ -23,6 +23,38 @@ describe("buildImplPrompt", () => {
 
   test("resolve step references the correct pr number", () => {
     expect(buildImplPrompt(10, 99)).toContain("mcx pr comments 99 resolve --all-addressed");
+  });
+
+  test("omits the verify-hypothesis mandate by default", () => {
+    expect(buildImplPrompt(42, null)).not.toContain("VERIFY-THE-HYPOTHESIS");
+  });
+
+  test("appends the verify-hypothesis mandate when flagged", () => {
+    const prompt = buildImplPrompt(42, null, { verifyHypothesis: true });
+    expect(prompt).toContain("VERIFY-THE-HYPOTHESIS");
+    expect(prompt).toContain("Reproduction evidence:");
+  });
+});
+
+describe("detectPrescribedRootCause", () => {
+  test("true when the issue carries the flaky label", () => {
+    expect(detectPrescribedRootCause({ labels: ["flaky"], commentBodies: [] })).toBe(true);
+  });
+
+  test("true when the issue carries needs-attention", () => {
+    expect(detectPrescribedRootCause({ labels: ["needs-attention"], commentBodies: [] })).toBe(true);
+  });
+
+  test("true when a comment reads like an investigation writeup", () => {
+    expect(detectPrescribedRootCause({ labels: [], commentBodies: ["Investigation: the race is in X"] })).toBe(true);
+  });
+
+  test("true on a Root cause: comment (case-insensitive)", () => {
+    expect(detectPrescribedRootCause({ labels: [], commentBodies: ["root cause: null deref at foo.ts:12"] })).toBe(true);
+  });
+
+  test("false for an ordinary issue with plain comments", () => {
+    expect(detectPrescribedRootCause({ labels: ["enhancement"], commentBodies: ["+1", "any update?"] })).toBe(false);
   });
 });
 

--- a/.claude/phases/impl-fn.ts
+++ b/.claude/phases/impl-fn.ts
@@ -2,12 +2,44 @@
 
 export type Provider = "claude" | "copilot" | "gemini" | "grok" | `acp:${string}`;
 
-export function buildImplPrompt(issueNumber: number, prNumber: number | null): string {
+// ── verify-hypothesis injection (#2804) ──
+// A prescribed root cause is a hypothesis, not a spec (implement.md Step 1b).
+// #2740's disproof and #2729's repro-first discipline paid off in sprint 73 but
+// were never prompted. When the issue carries a prescribed root cause, require a
+// "Reproduction evidence:" section at the plan checkpoint before any impl code.
+const VERIFY_HYPOTHESIS_MANDATE = `
+
+VERIFY-THE-HYPOTHESIS MANDATE (this issue prescribes a root cause / carries an investigation):
+Treat the prescribed root cause as a HYPOTHESIS, not a spec (implement.md Step 1b).
+Before writing any implementation code, reproduce the claimed mechanism and add a
+"Reproduction evidence:" section to your plan checkpoint quoting what you observed
+(commands, output, file:line). If the evidence contradicts the prescription, do NOT
+cargo-cult the named file — fix the real cause and post the discrepancy as an issue
+comment. A verified disproof is a valid outcome; a no-op fix on a stale diagnosis is not.`;
+
+/**
+ * Detect a prescribed-root-cause signal on the issue. Any of:
+ *   - the issue carries the `flaky` or `needs-attention` label, or
+ *   - an issue comment reads like an investigation / root-cause writeup
+ *     ("Investigation:", "Root cause:", "Reproduction:", "Repro:").
+ */
+export function detectPrescribedRootCause(opts: { labels: string[]; commentBodies: string[] }): boolean {
+  if (opts.labels.includes("flaky") || opts.labels.includes("needs-attention")) return true;
+  const signal = /\b(investigation|root cause|reproduction|repro)\s*:/i;
+  return opts.commentBodies.some((body) => signal.test(body));
+}
+
+export function buildImplPrompt(
+  issueNumber: number,
+  prNumber: number | null,
+  opts: { verifyHypothesis?: boolean } = {},
+): string {
   const resolveStep =
     prNumber != null
       ? `\nAfter replying to each addressed thread, resolve it: mcx pr comments ${prNumber} resolve --all-addressed`
       : "";
-  return `/implement ${issueNumber}${resolveStep}`;
+  const verifyStep = opts.verifyHypothesis ? VERIFY_HYPOTHESIS_MANDATE : "";
+  return `/implement ${issueNumber}${resolveStep}${verifyStep}`;
 }
 
 export function commandForProvider(provider: Provider): string[] {

--- a/.claude/phases/impl.ts
+++ b/.claude/phases/impl.ts
@@ -26,7 +26,13 @@
  */
 import { NO_REPO_ROOT, findModelInSprintPlan } from "@mcp-cli/core";
 import { defineAlias, z } from "mcp-cli";
-import { type Provider, buildImplCommand, buildImplPrompt, resolveImplModel } from "./impl-fn";
+import {
+  type Provider,
+  buildImplCommand,
+  buildImplPrompt,
+  detectPrescribedRootCause,
+  resolveImplModel,
+} from "./impl-fn";
 
 const ProviderSchema = z
   .string()
@@ -93,7 +99,25 @@ defineAlias({
     const provider = input.provider;
     const supportsWorktree = provider === "claude";
     const allowTools = ["Read", "Glob", "Grep", "Write", "Edit", "Bash", "ExitPlanMode", "EnterPlanMode"];
-    const prompt = buildImplPrompt(work.issueNumber, work.prNumber ?? null);
+
+    // Verify-hypothesis injection (#2804): if the issue prescribes a root cause
+    // (flaky/needs-attention label or an investigation comment), require repro
+    // evidence at the plan checkpoint. Best-effort — a fetch failure must not
+    // block the spawn.
+    let verifyHypothesis = input.labels.includes("flaky") || input.labels.includes("needs-attention");
+    if (!verifyHypothesis) {
+      try {
+        const comments = await ctx.gh.issue(work.issueNumber).comments();
+        verifyHypothesis = detectPrescribedRootCause({
+          labels: input.labels,
+          commentBodies: comments.map((c) => c.body),
+        });
+      } catch {
+        /* best-effort — verify-hypothesis prompt is advisory */
+      }
+    }
+
+    const prompt = buildImplPrompt(work.issueNumber, work.prNumber ?? null, { verifyHypothesis });
     const command = buildImplCommand({ provider, model, supportsWorktree, prompt, allowTools });
 
     await ctx.state.set("provider", provider);

--- a/.claude/phases/phase-types.spec.ts
+++ b/.claude/phases/phase-types.spec.ts
@@ -1,5 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import { type GhLabelEvent, type VerdictContext, parsePrEditFlags, validateVerdictLabel } from "./phase-types";
+import {
+  type GhLabelEvent,
+  type VerdictContext,
+  labelsConsistent,
+  parsePrEditFlags,
+  requiresArtifactCheck,
+  validateVerdictLabel,
+} from "./phase-types";
 
 describe("parsePrEditFlags", () => {
   test("parses --remove-label flags", () => {
@@ -87,5 +94,69 @@ describe("validateVerdictLabel", () => {
   test("fails closed on an unparseable event timestamp", () => {
     const result = validateVerdictLabel("review:pass", [labelEvent("not-a-date")], ctx());
     expect(result.valid).toBe(false);
+  });
+});
+
+describe("requiresArtifactCheck", () => {
+  test("matches scripts/build.ts", () => {
+    expect(requiresArtifactCheck(["scripts/build.ts"])).toBe(true);
+  });
+
+  test("matches scripts/daemon-workers.ts", () => {
+    expect(requiresArtifactCheck(["scripts/daemon-workers.ts"])).toBe(true);
+  });
+
+  test("matches the worker-path resolver", () => {
+    expect(requiresArtifactCheck(["packages/daemon/src/worker-path.ts"])).toBe(true);
+  });
+
+  test("matches any *-worker.ts entrypoint", () => {
+    expect(requiresArtifactCheck(["packages/daemon/src/mail-session-worker.ts"])).toBe(true);
+  });
+
+  test("matches worker-plugin.ts in any directory", () => {
+    expect(requiresArtifactCheck(["packages/daemon/src/worker-plugin.ts"])).toBe(true);
+  });
+
+  test("does not match ordinary source files", () => {
+    expect(requiresArtifactCheck(["packages/command/src/main.ts", "packages/core/src/config.ts"])).toBe(false);
+  });
+
+  test("does not match a spec for a worker (endsWith guard is on -worker.ts, not worker*.spec)", () => {
+    expect(requiresArtifactCheck(["packages/daemon/src/mock-server.ts"])).toBe(false);
+  });
+
+  test("ignores blank entries", () => {
+    expect(requiresArtifactCheck(["", "  "])).toBe(false);
+  });
+
+  test("returns true if ANY file in the set matches", () => {
+    expect(requiresArtifactCheck(["docs/x.md", "scripts/build.ts"])).toBe(true);
+  });
+});
+
+describe("labelsConsistent", () => {
+  test("ok when no verdict labels present", () => {
+    expect(labelsConsistent(["bug", "enhancement"])).toEqual({ ok: true, blocking: [] });
+  });
+
+  test("ok with qa:pass + review:pass", () => {
+    expect(labelsConsistent(["qa:pass", "review:pass"])).toEqual({ ok: true, blocking: [] });
+  });
+
+  test("blocks a lingering review:changes even with review:pass present", () => {
+    const r = labelsConsistent(["qa:pass", "review:pass", "review:changes"]);
+    expect(r.ok).toBe(false);
+    expect(r.blocking).toContain("review:changes");
+  });
+
+  test("blocks contradictory qa:pass + qa:fail", () => {
+    const r = labelsConsistent(["qa:pass", "qa:fail"]);
+    expect(r.ok).toBe(false);
+    expect(r.blocking).toEqual(expect.arrayContaining(["qa:pass", "qa:fail"]));
+  });
+
+  test("trims whitespace before matching", () => {
+    expect(labelsConsistent([" review:changes "]).ok).toBe(false);
   });
 });

--- a/.claude/phases/phase-types.ts
+++ b/.claude/phases/phase-types.ts
@@ -6,6 +6,79 @@ export interface GhResult {
   exitCode: number;
 }
 
+// ── artifact-check gate (#2804) ──
+// A binary can compile green, pass unit tests, and be dead at runtime because
+// no phase booted the compiled artifact (#2796/#2799: #2762 shipped runtime-dead).
+// When a PR touches the build mechanism, compiled-output layout, or worker
+// plumbing, triage sets `artifact_check=required` and qa/review append the
+// mandate below to their spawn prompts so the verifier exercises the artifact.
+export const ARTIFACT_CHECK_REQUIRED = "required" as const;
+
+/**
+ * True when any changed file touches build/worker plumbing — the class of change
+ * that unit tests + green CI cannot vouch for. Matches:
+ *   - scripts/build.ts, scripts/daemon-workers.ts (build mechanism)
+ *   - packages/daemon/src/worker-path.ts (compiled-output path resolution)
+ *   - any file whose basename ends with "-worker.ts" (worker entrypoints)
+ *   - worker-plugin.ts (worker boilerplate)
+ */
+export function requiresArtifactCheck(changedFiles: string[]): boolean {
+  return changedFiles.some((raw) => {
+    const f = raw.trim();
+    if (f.length === 0) return false;
+    const base = f.split("/").pop() ?? f;
+    if (f === "scripts/build.ts" || f === "scripts/daemon-workers.ts") return true;
+    if (f === "packages/daemon/src/worker-path.ts") return true;
+    if (base === "worker-plugin.ts") return true;
+    if (base.endsWith("-worker.ts")) return true;
+    return false;
+  });
+}
+
+/**
+ * Spawn-prompt mandate appended for artifact-shaped PRs. Boots the compiled
+ * binary with isolated state and asserts every worker-backed server starts —
+ * never touching the host daemon or ~/.mcp-cli.
+ */
+export const ARTIFACT_CHECK_MANDATE = `
+
+ARTIFACT-BOOT MANDATE (this PR changed build/worker plumbing — unit tests + CI are NOT sufficient):
+Boot \`dist/mcpd\` with an isolated state dir and assert all 5 worker-backed servers
+start (daemon, alias, mail, metrics, tracing). Never touch host state (~/.mcp-cli).
+
+  bun run build
+  STATE_DIR=$(mktemp -d)
+  MCP_CLI_DIR="$STATE_DIR" ./dist/mcpd &   # boot compiled binary, isolated state
+  # assert every worker-backed server logs "started"; zero "Failed to start" /
+  # "ModuleNotFound"; then kill ONLY the process you started and rm -rf "$STATE_DIR".
+
+Cite the observed startup lines as evidence. If the artifact cannot be exercised
+in your environment, say so explicitly and lower the verdict confidence — do NOT
+fall back to unit-test evidence for an artifact-shaped change.`;
+
+// ── label-closure merge gate (#2804) ──
+// #2769, #2779, #2790 merged carrying stale `review:changes` after self-repair.
+// The done phase must refuse the merge transition when labels are inconsistent.
+export interface LabelConsistency {
+  ok: boolean;
+  /** Labels blocking the merge (empty when ok). */
+  blocking: string[];
+}
+
+/**
+ * Merge-readiness label check. A PR is NOT mergeable when it carries:
+ *   - `review:changes` (regardless of whether `review:pass` is also present —
+ *     a self-repaired review must be closed by the verifier before merge), or
+ *   - both `qa:pass` and `qa:fail` simultaneously (contradictory verdict).
+ */
+export function labelsConsistent(labels: string[]): LabelConsistency {
+  const set = new Set(labels.map((l) => l.trim()).filter((l) => l.length > 0));
+  const blocking: string[] = [];
+  if (set.has("review:changes")) blocking.push("review:changes");
+  if (set.has("qa:pass") && set.has("qa:fail")) blocking.push("qa:pass", "qa:fail");
+  return { ok: blocking.length === 0, blocking };
+}
+
 export interface ParsedPrEditFlags {
   addLabels: string[];
   removeLabels: string[];

--- a/.claude/phases/qa-fn.spec.ts
+++ b/.claude/phases/qa-fn.spec.ts
@@ -278,6 +278,24 @@ describe("runQa — no session yet", () => {
       expect(result.prompt).toContain("PR 200");
     }
   });
+
+  test("omits the artifact-boot mandate by default (#2804)", async () => {
+    const state = makeState();
+    const result = await runQa({ provider: "claude" }, makeWork(), state, makeDeps());
+    if (result.action === "spawn") {
+      expect(result.prompt).not.toContain("ARTIFACT-BOOT MANDATE");
+    }
+  });
+
+  test("appends the artifact-boot mandate when artifact_check=required (#2804)", async () => {
+    const state = makeState({ artifact_check: "required" });
+    const result = await runQa({ provider: "claude" }, makeWork(), state, makeDeps());
+    expect(result.action).toBe("spawn");
+    if (result.action === "spawn") {
+      expect(result.prompt).toContain("ARTIFACT-BOOT MANDATE");
+      expect(result.command).toContain(result.prompt);
+    }
+  });
 });
 
 describe("runQa — session exists, waiting for labels", () => {

--- a/.claude/phases/qa-fn.ts
+++ b/.claude/phases/qa-fn.ts
@@ -1,6 +1,14 @@
 /** Core qa-phase logic, extracted for testability via dependency injection. */
 
-import { type GhLabelEvent, type GhOp, type GhResult, type VerdictContext, validateVerdictLabel } from "./phase-types";
+import {
+  ARTIFACT_CHECK_MANDATE,
+  ARTIFACT_CHECK_REQUIRED,
+  type GhLabelEvent,
+  type GhOp,
+  type GhResult,
+  type VerdictContext,
+  validateVerdictLabel,
+} from "./phase-types";
 export type { GhOp, GhResult };
 
 export const QA_FAIL_CAP = 2;
@@ -137,13 +145,17 @@ export async function runQa(
   const qaPrompt = `/qa ${work.issueNumber} (PR ${work.prNumber}, branch ${work.branch})`;
 
   if (!sessionId) {
+    // Artifact-boot mandate (#2804) is appended only to the spawn command — not
+    // to the wait/goto prompt fields, which are informational.
+    const artifactCheck = (await state.get<string>("artifact_check")) === ARTIFACT_CHECK_REQUIRED;
+    const spawnPrompt = artifactCheck ? qaPrompt + ARTIFACT_CHECK_MANDATE : qaPrompt;
     const worktreePath = await state.get<string>("worktree_path");
     const allowTools = ["Read", "Glob", "Grep", "Write", "Edit", "Bash"];
     const cmdBase = input.provider.startsWith("acp:")
       ? ["mcx", "acp", "spawn", "--agent", input.provider.slice(4)]
       : ["mcx", input.provider, "spawn"];
     const worktreeFlags = worktreePath ? ["--cwd", worktreePath] : ["--worktree"];
-    const command = [...cmdBase, ...worktreeFlags, "--model", qaModel, "-t", qaPrompt, "--allow", ...allowTools];
+    const command = [...cmdBase, ...worktreeFlags, "--model", qaModel, "-t", spawnPrompt, "--allow", ...allowTools];
     const spawnedAt = Date.now();
     await state.set("qa_session_id", `pending:${spawnedAt}`);
     await state.set("qa_spawned_at", spawnedAt);
@@ -153,7 +165,7 @@ export async function runQa(
       reason: "qa session starting",
       model: qaModel,
       command,
-      prompt: qaPrompt,
+      prompt: spawnPrompt,
       allowTools,
     };
   }

--- a/.claude/phases/review-fn.spec.ts
+++ b/.claude/phases/review-fn.spec.ts
@@ -256,6 +256,24 @@ describe("runReview — spawn prompt", () => {
       expect(result.prompt).toContain("mcx pr comments 99 resolve --all-addressed");
     }
   });
+
+  test("omits the artifact-boot mandate by default (#2804)", async () => {
+    const state = makeState();
+    const result = await runReview({ provider: "claude" }, makeWork(), state, makeDeps(), "/repo");
+    if (result.action === "spawn") {
+      expect(result.prompt).not.toContain("ARTIFACT-BOOT MANDATE");
+    }
+  });
+
+  test("appends the artifact-boot mandate when artifact_check=required (#2804)", async () => {
+    const state = makeState({ artifact_check: "required" });
+    const result = await runReview({ provider: "claude" }, makeWork(), state, makeDeps(), "/repo");
+    expect(result.action).toBe("spawn");
+    if (result.action === "spawn") {
+      expect(result.prompt).toContain("ARTIFACT-BOOT MANDATE");
+      expect(result.command).toContain(result.prompt);
+    }
+  });
 });
 
 describe("runReview — no session yet", () => {

--- a/.claude/phases/review-fn.ts
+++ b/.claude/phases/review-fn.ts
@@ -1,6 +1,14 @@
 /** Core review-phase logic, extracted for testability via dependency injection. */
 
-import { type GhLabelEvent, type GhOp, type GhResult, type VerdictContext, validateVerdictLabel } from "./phase-types";
+import {
+  ARTIFACT_CHECK_MANDATE,
+  ARTIFACT_CHECK_REQUIRED,
+  type GhLabelEvent,
+  type GhOp,
+  type GhResult,
+  type VerdictContext,
+  validateVerdictLabel,
+} from "./phase-types";
 export type { GhOp, GhResult };
 
 export const REVIEW_ROUND_CAP = 2;
@@ -161,7 +169,10 @@ export async function runReview(
 
     const allowTools = ["Read", "Glob", "Grep", "Write", "Edit", "Bash"];
     const resolveStep = `After replying to each addressed thread, resolve it: mcx pr comments ${work.prNumber} resolve --all-addressed`;
-    const prompt = `/adversarial-review (PR ${work.prNumber}, branch ${work.branch}, round ${round})\n${resolveStep}`;
+    const artifactCheck = (await state.get<string>("artifact_check")) === ARTIFACT_CHECK_REQUIRED;
+    const prompt = `/adversarial-review (PR ${work.prNumber}, branch ${work.branch}, round ${round})\n${resolveStep}${
+      artifactCheck ? ARTIFACT_CHECK_MANDATE : ""
+    }`;
     const cmdBase = input.provider.startsWith("acp:")
       ? ["mcx", "acp", "spawn", "--agent", input.provider.slice(4)]
       : ["mcx", input.provider, "spawn"];

--- a/.claude/phases/triage-fn.ts
+++ b/.claude/phases/triage-fn.ts
@@ -1,5 +1,7 @@
 /** Core triage logic, extracted for testability via dependency injection. */
 
+import { ARTIFACT_CHECK_REQUIRED, requiresArtifactCheck } from "./phase-types";
+
 export interface TriageEventFilter {
   type?: string | string[];
   workItem?: string;
@@ -29,6 +31,8 @@ export interface TriageDeps {
   stateGet<T>(key: string): Promise<T | undefined>;
   stateSet(key: string, value: unknown): Promise<void>;
   updateWorkItem(id: string, prNumber: number): Promise<void>;
+  /** Changed file paths on the PR — drives the artifact-check gate (#2804). */
+  listChangedFiles(prNumber: number): Promise<string[]>;
 }
 
 export type TriageResult =
@@ -109,6 +113,19 @@ export async function runTriage(
 
   await deps.stateSet("triage_scrutiny", scrutiny);
   await deps.stateSet("triage_reasons", reasons.join("; "));
+
+  // Artifact-check gate (#2804): build/worker-plumbing changes can compile
+  // green and be dead at runtime, so flag them for the qa/review verifier to
+  // exercise the compiled binary. Best-effort: a file-list fetch failure must
+  // not derail triage's primary scrutiny decision.
+  try {
+    const changedFiles = await deps.listChangedFiles(prNumber);
+    if (requiresArtifactCheck(changedFiles)) {
+      await deps.stateSet("artifact_check", ARTIFACT_CHECK_REQUIRED);
+    }
+  } catch {
+    /* best-effort — artifact-check is advisory, never blocks triage */
+  }
 
   try {
     await deps.updateWorkItem(work.id, prNumber);

--- a/.claude/phases/triage.ts
+++ b/.claude/phases/triage.ts
@@ -78,6 +78,10 @@ defineAlias({
       async updateWorkItem(id, prNumber) {
         await ctx.mcp._work_items.work_items_update({ id, prNumber });
       },
+      async listChangedFiles(prNumber) {
+        const files = await ctx.gh.pr(prNumber).files();
+        return files.map((f) => f.filename);
+      },
     });
   },
 });

--- a/.mcx.lock
+++ b/.mcx.lock
@@ -1,17 +1,17 @@
 {
   "version": 1,
-  "manifestHash": "7c6db54ba9992d3a66ee93eb63948f01cdcbb18a9e9ae01ac12de652e23b4f89",
+  "manifestHash": "1fadf9890088056a9bfb5f8c05bcb68601bca6bf23ead33788f5972a29e594d9",
   "phases": [
     {
       "name": "done",
       "resolvedPath": ".claude/phases/done.ts",
-      "contentHash": "c2f06149a306e11fcf86c5e6f258f9a1d254dba350a6f7db63a1b92b97cde0f7",
-      "schemaHash": "65b20b69643a6f7b1250b4949e0d1dffd022aa9573aadd952a07759879ebc98f"
+      "contentHash": "8c7a1604f4738ee4a79f3dc9a50c88acd233b3562c60107e8d5fc8dd75393390",
+      "schemaHash": "93813ec021f8ee0b78803977856232e324280005e21974deaf7d6662fc638144"
     },
     {
       "name": "impl",
       "resolvedPath": ".claude/phases/impl.ts",
-      "contentHash": "4ea18c3194c7dc7708a7f9ff55f774ebd03bf8e5c7c9dccfc8917557a11b26e1",
+      "contentHash": "521f7473b0268497fc2f019116052a159a3746c423c5d4d32ae8bdd50bf6ddd6",
       "schemaHash": "ffdce08965415cdf4bff93169087ae60b05a84fa07892fece8793b0bc06690b2"
     },
     {
@@ -23,7 +23,7 @@
     {
       "name": "qa",
       "resolvedPath": ".claude/phases/qa.ts",
-      "contentHash": "3d973ec4fa0d9b47bbd609b2047498d4a2fd9af6f790765e3d9cae4c949f4ec8",
+      "contentHash": "daa1715e657cd5ebec371a6682f432cbf648089b6a420faf4fc8cc539b21703e",
       "schemaHash": "2c3159b3558360d1a25caf8e7f4401da2dba237bf3799807bc8c68497290cd40"
     },
     {
@@ -35,13 +35,13 @@
     {
       "name": "review",
       "resolvedPath": ".claude/phases/review.ts",
-      "contentHash": "23f5836df4aa597a1ef0b5844277c5cc135fb8a99d5491653a5969b42ffad6f1",
+      "contentHash": "8dba2280a06f9c9d61ad80c8015c4404d6078301c934a8c708d87ef411eb7e81",
       "schemaHash": "722c5636d497444124371fe5ddabf15a1ca14b0b95fed8e066b3c2cacf1e8080"
     },
     {
       "name": "triage",
       "resolvedPath": ".claude/phases/triage.ts",
-      "contentHash": "310873836d6e75965d5a4034731c5553b6f79adb4bccb9fbbe7409231f22606f",
+      "contentHash": "abb70a85a6b8478c303a20c4e501f07f98e6918191e42ee2a9aff30e77e2e904",
       "schemaHash": "03a042ac366a29c9f33de68cf1b24300bc899126e4084a4fa1303247afbc772c"
     }
   ],

--- a/.mcx.yaml
+++ b/.mcx.yaml
@@ -29,6 +29,8 @@ state:
   provider: string?
   labels: string?
   model: string?
+  artifact_check: string?
+  merge_block_labels: string?
   scrutiny:     { type: "enum[low,medium,high]", track: true, default: medium }
   bundled_with: { type: string, track: true, repeatable: true }
 

--- a/test/done-phase.spec.ts
+++ b/test/done-phase.spec.ts
@@ -42,7 +42,7 @@ describe("mergePr — label guard", () => {
     if (!result.ok) expect(result.nextAction).toContain("spawn qa");
   });
 
-  test("both qa:pass and qa:fail → missing_qa_pass (stale label)", async () => {
+  test("both qa:pass and qa:fail → inconsistent_labels (#2804)", async () => {
     const result = await mergePr(
       100,
       makeDeps({
@@ -52,8 +52,22 @@ describe("mergePr — label guard", () => {
         },
       }),
     );
-    expect(result).toMatchObject({ ok: false, reason: "missing_qa_pass" });
-    if (!result.ok) expect(result.nextAction).toContain("stale label");
+    expect(result).toMatchObject({ ok: false, reason: "inconsistent_labels" });
+    if (!result.ok) expect(result.blockingLabels).toEqual(expect.arrayContaining(["qa:pass", "qa:fail"]));
+  });
+
+  test("lingering review:changes blocks merge → inconsistent_labels (#2804)", async () => {
+    const result = await mergePr(
+      100,
+      makeDeps({
+        gh: async (op) => {
+          if (op.op === "pr:labels") return ok("qa:pass\nreview:pass\nreview:changes");
+          return ok("0");
+        },
+      }),
+    );
+    expect(result).toMatchObject({ ok: false, reason: "inconsistent_labels" });
+    if (!result.ok) expect(result.blockingLabels).toContain("review:changes");
   });
 
   test("gh labels call fails → merge_failed", async () => {

--- a/test/triage-phase.spec.ts
+++ b/test/triage-phase.spec.ts
@@ -19,6 +19,7 @@ function makeDeps(overrides: Partial<TriageDeps> = {}): TriageDeps {
     stateGet: () => Promise.resolve(undefined),
     stateSet: () => Promise.resolve(),
     updateWorkItem: () => Promise.resolve(),
+    listChangedFiles: async () => [],
     ...overrides,
   };
 }
@@ -406,6 +407,49 @@ describe("runTriage — state", () => {
     );
     expect(stateWrites.triage_scrutiny).toBe("low");
     expect(stateWrites.triage_reasons).toBe("small; clean");
+  });
+
+  test("sets artifact_check=required when a worker file changed (#2804)", async () => {
+    const stateWrites: Record<string, unknown> = {};
+    await runTriage(
+      { labels: [] },
+      makeWork({ prNumber: 100 }),
+      makeDeps({
+        listChangedFiles: async () => ["packages/daemon/src/mail-session-worker.ts"],
+        stateSet: async (key, value) => {
+          stateWrites[key] = value;
+        },
+      }),
+    );
+    expect(stateWrites.artifact_check).toBe("required");
+  });
+
+  test("does not set artifact_check for ordinary source changes (#2804)", async () => {
+    const stateWrites: Record<string, unknown> = {};
+    await runTriage(
+      { labels: [] },
+      makeWork({ prNumber: 100 }),
+      makeDeps({
+        listChangedFiles: async () => ["packages/core/src/config.ts"],
+        stateSet: async (key, value) => {
+          stateWrites[key] = value;
+        },
+      }),
+    );
+    expect("artifact_check" in stateWrites).toBe(false);
+  });
+
+  test("a listChangedFiles failure does not derail triage (#2804)", async () => {
+    const result = await runTriage(
+      { labels: [] },
+      makeWork({ prNumber: 100 }),
+      makeDeps({
+        listChangedFiles: async () => {
+          throw new Error("gh files fetch failed");
+        },
+      }),
+    );
+    expect(result.action).toBe("goto");
   });
 
   test("updateWorkItem connectivity failure is swallowed", async () => {


### PR DESCRIPTION
## Summary
Promotes the three sprint-73 prose rules from PR #2803 into phase machinery so workers can't skip them:

- **Artifact-check injection** — `triage` computes changed files (`ctx.gh.pr(n).files()`), and when any touch build/worker plumbing (`scripts/build.ts`, `scripts/daemon-workers.ts`, `worker-path.ts`, `*-worker.ts`, `worker-plugin.ts`) writes `artifact_check=required`. `qa` and `review` read that key and append an artifact-boot mandate (boot `dist/mcpd` with isolated `MCP_CLI_DIR`, assert all 5 worker-backed servers start) to their **spawn** prompts only.
- **Label-closure merge gate** — `mergePr` refuses the merge via a shared `labelsConsistent()` when the PR carries `review:changes` (even alongside `review:pass`), or both `qa:pass` and `qa:fail`. New `inconsistent_labels` reason; blocking labels surface to work-item state (`merge_block_labels`) and the error payload.
- **Verify-hypothesis injection** — `impl` detects a prescribed root cause (`flaky`/`needs-attention` label or an "Investigation:"/"Root cause:"/"Repro:" comment) and appends the Step-1b reproduction-evidence mandate to the spawn prompt.

New shared pure logic lives in `phase-types.ts` (`requiresArtifactCheck`, `labelsConsistent`, mandate constants); new state keys `artifact_check` / `merge_block_labels` added to `.mcx.yaml`.

**Note:** the issue claimed `triage.ts` "already computes changedFiles" — it does not. Triage runs the estimate (which returns metrics, not raw paths), so this adds a `listChangedFiles` dep wired to the gh client.

## Test plan
- [x] `bun run am-i-done` (typecheck, lint, rules, full test suite, coverage) — green
- [x] `requiresArtifactCheck` / `labelsConsistent` unit tests (`phase-types.spec.ts`)
- [x] `detectPrescribedRootCause` + prompt-injection tests (`impl-fn.spec.ts`)
- [x] artifact-mandate spawn-prompt tests (`qa-fn.spec.ts`, `review-fn.spec.ts`)
- [x] `inconsistent_labels` gate tests for review:changes and dual-qa (`done-fn.spec.ts`, `test/done-phase.spec.ts`)
- [x] triage artifact-check state-write tests incl. fetch-failure fallback (`test/triage-phase.spec.ts`)
- [x] `mcx phase install` — lock in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)