### PR TITLE
fix(daemon): route compiled alias dispatch through layout-tolerant resolver; fail non-zero on tool error (fixes #2821)

### DIFF
--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -85,6 +85,7 @@ import { SIZE_HINT, SIZE_OK, applyJqFilter, generateAnalysis, jqParseErrorHints 
 import {
   extractErrorMessage,
   formatToolResult,
+  isToolError,
   printError,
   printRegistryList,
   printServerList,
@@ -599,6 +600,14 @@ async function cmdCall(args: string[]): Promise<void> {
     { server, tool, arguments: toolArgs, timeoutMs: toolTimeoutMs, cwd: process.cwd() },
     { timeoutMs: toolTimeoutMs + 5_000 },
   );
+
+  // A tool call that returned isError must exit non-zero with the message on
+  // stderr — not a silent exit 0 with the error text on stdout (#2821). This
+  // ran before Bug 1's fix masked every compiled alias failure as success.
+  if (isToolError(result)) {
+    printError(formatToolResult(result));
+    process.exit(1);
+  }
 
   // Auto-save long calls as ephemeral aliases (best-effort, non-blocking)
   maybeAutoSaveEphemeral(server, tool, toolArgs, { ipcCall });

--- a/packages/command/src/output.spec.ts
+++ b/packages/command/src/output.spec.ts
@@ -1,6 +1,13 @@
 import { describe, expect, mock, test } from "bun:test";
 import type { AliasDetail } from "@mcp-cli/core";
-import { extractErrorMessage, formatToolResult, printAliasDebug, printAliasList, printToolList } from "./output";
+import {
+  extractErrorMessage,
+  formatToolResult,
+  isToolError,
+  printAliasDebug,
+  printAliasList,
+  printToolList,
+} from "./output";
 
 describe("formatToolResult", () => {
   test("returns empty string for null", () => {
@@ -308,5 +315,25 @@ describe("extractErrorMessage", () => {
       exitCode: 1,
     });
     expect(extractErrorMessage(err)).toBe("Failed with exit code 1");
+  });
+});
+
+describe("isToolError", () => {
+  test("true for MCP result with isError: true", () => {
+    expect(isToolError({ content: [{ type: "text", text: "boom" }], isError: true })).toBe(true);
+  });
+
+  test("false for successful result", () => {
+    expect(isToolError({ content: [{ type: "text", text: "ok" }] })).toBe(false);
+  });
+
+  test("false for isError explicitly false", () => {
+    expect(isToolError({ content: [], isError: false })).toBe(false);
+  });
+
+  test("false for non-object results", () => {
+    expect(isToolError(null)).toBe(false);
+    expect(isToolError(undefined)).toBe(false);
+    expect(isToolError("isError")).toBe(false);
   });
 });

--- a/packages/command/src/output.ts
+++ b/packages/command/src/output.ts
@@ -47,6 +47,15 @@ export function formatToolResult(result: unknown): string {
   return JSON.stringify(result, null, 2);
 }
 
+/**
+ * Whether a tool call result signals an error (MCP `isError: true`).
+ * Such a result must surface as a non-zero exit with the message on stderr,
+ * not a silent exit 0 with the error text on stdout (#2821).
+ */
+export function isToolError(result: unknown): boolean {
+  return typeof result === "object" && result !== null && (result as { isError?: unknown }).isError === true;
+}
+
 /** Format and print a tool call result to stdout */
 export function printToolResult(result: unknown): void {
   const text = formatToolResult(result);

--- a/packages/daemon/src/main.spec.ts
+++ b/packages/daemon/src/main.spec.ts
@@ -2,12 +2,22 @@ import { describe, expect, test } from "bun:test";
 import { resolveWorkerEntry } from "./main";
 
 describe("resolveWorkerEntry", () => {
-  test("returns module path for ./alias-executor.ts", () => {
-    expect(resolveWorkerEntry(["/path/to/mcpd", "./alias-executor.ts"])).toBe("./alias-executor.ts");
+  test("returns canonical entry for ./alias-executor.ts", () => {
+    expect(resolveWorkerEntry(["/path/to/mcpd", "./alias-executor.ts"])).toBe("alias-executor.ts");
   });
 
-  test("returns module path for absolute path ending in alias-executor.ts", () => {
-    expect(resolveWorkerEntry(["/path/to/mcpd", "/some/dir/alias-executor.ts"])).toBe("./alias-executor.ts");
+  test("returns canonical entry for absolute path ending in alias-executor.ts (dev)", () => {
+    expect(resolveWorkerEntry(["/path/to/mcpd", "/some/dir/alias-executor.ts"])).toBe("alias-executor.ts");
+  });
+
+  test("returns canonical entry for resolved embedded .js path (compiled, #2821)", () => {
+    expect(resolveWorkerEntry(["/path/to/mcpd", "/$bunfs/root/packages/daemon/src/alias-executor.js"])).toBe(
+      "alias-executor.ts",
+    );
+  });
+
+  test("returns canonical entry for ./alias-executor.js", () => {
+    expect(resolveWorkerEntry(["/path/to/mcpd", "./alias-executor.js"])).toBe("alias-executor.ts");
   });
 
   test("returns undefined for normal daemon startup (no args)", () => {

--- a/packages/daemon/src/main.ts
+++ b/packages/daemon/src/main.ts
@@ -7,27 +7,47 @@
 
 import { assertBunVersion } from "@mcp-cli/core";
 import { startDaemon } from "./index";
+import { workerPath } from "./worker-path";
 
 assertBunVersion();
 
 /**
- * Worker entries that can be dispatched via argv in compiled binaries.
+ * Worker source filenames dispatchable via argv in compiled binaries.
  *
- * In compiled mode, Bun.spawn([process.execPath, './alias-executor.ts'])
- * re-invokes the mcpd binary with the worker path as an argument. Without
- * this dispatch, the binary unconditionally starts a second daemon (#1411).
+ * In compiled mode, Bun.spawn([process.execPath, <worker-path>]) re-invokes the
+ * mcpd binary with the worker path as an argument. Without this dispatch, the
+ * binary unconditionally starts a second daemon (#1411).
  */
-const WORKER_ENTRIES: Record<string, string> = {
-  "alias-executor.ts": "./alias-executor.ts",
-};
+const WORKER_ENTRIES = ["alias-executor.ts"];
 
-/** Check if argv indicates a worker subprocess dispatch. */
+/** Extension-less stem so a `.ts` source matches an embedded `.js`. */
+function entryStem(name: string): string {
+  return name.replace(/\.[cm]?[jt]s$/, "");
+}
+
+/**
+ * If argv indicates a worker subprocess dispatch, return the canonical worker
+ * source filename (to be resolved via the layout-tolerant resolver before
+ * import), else undefined.
+ *
+ * The daemon spawns `mcpd <resolved-worker-path>`, where that path is the
+ * embedded module resolved via `workerPath()` — `.js` in a compiled binary
+ * (`/$bunfs/…`), `.ts` in dev. Matching a literal `.ts` suffix therefore misses
+ * the compiled dispatch and starts a second daemon (#2821), so match the stem
+ * against both extensions.
+ */
 export function resolveWorkerEntry(argv: string[]): string | undefined {
   const lastArg = argv.at(-1);
   if (!lastArg) return undefined;
-  for (const [suffix, modulePath] of Object.entries(WORKER_ENTRIES)) {
-    if (lastArg === `./${suffix}` || lastArg.endsWith(`/${suffix}`)) {
-      return modulePath;
+  for (const entry of WORKER_ENTRIES) {
+    const stem = entryStem(entry);
+    if (
+      lastArg === `./${stem}.ts` ||
+      lastArg === `./${stem}.js` ||
+      lastArg.endsWith(`/${stem}.ts`) ||
+      lastArg.endsWith(`/${stem}.js`)
+    ) {
+      return entry;
     }
   }
   return undefined;
@@ -72,7 +92,11 @@ async function main(): Promise<void> {
 if (import.meta.main) {
   const workerEntry = resolveWorkerEntry(process.argv);
   if (workerEntry) {
-    import(workerEntry);
+    // Resolve through the layout-tolerant resolver rather than importing a
+    // predicted literal path: the embedded module layout is Bun-outbase
+    // dependent (#2801), and a predicted `./alias-executor.ts` fails to
+    // resolve in the compiled binary's module graph (#2821).
+    import(workerPath(workerEntry));
   } else {
     main().catch((err) => {
       console.error("[mcpd] Fatal:", err);

--- a/scripts/smoke-test.ts
+++ b/scripts/smoke-test.ts
@@ -41,7 +41,7 @@ export default defineAlias({
   description: "Smoke test alias",
   input: z.object({}),
   output: z.object({ ok: z.boolean() }),
-  handler: async () => ({ ok: true }),
+  fn: async () => ({ ok: true }),
 });
 `;
 
@@ -122,11 +122,11 @@ await run("mcx ls exits 0", async () => {
 });
 
 await run("mcx alias save/call/delete cycle", async () => {
-  // NOTE: this check currently fails on the compiled binary due to #2821
-  // (compiled daemon can't resolve ./alias-executor.ts; the error is also
-  // printed to stdout with exit 0, which is why it went unnoticed). That is
-  // the smoke doing its job — catching a real compiled-binary regression. It
-  // will pass once #2821 lands.
+  // Exercises the compiled argv-redispatch + dynamic import() executor path
+  // that regressed in #2821 (compiled daemon couldn't resolve the embedded
+  // alias-executor module, and the failure was masked as exit 0 on stdout).
+  // Both are fixed: dispatch routes through the layout-tolerant resolver, and
+  // an isError result now exits non-zero.
   // Save (source token "-" reads the script from stdin)
   const save = await $`echo ${SMOKE_SCRIPT} | ${MCX} alias save ${SMOKE_ALIAS} -`.quiet().nothrow();
   assert(save.exitCode === 0, `alias save exit code ${save.exitCode}: ${save.stderr.toString()}`);


### PR DESCRIPTION
## Summary
- **Bug 1 (P1):** `main.ts`'s argv-redispatch imported a predicted literal `./alias-executor.ts`, which doesn't resolve in the compiled binary's Bun-outbase-dependent module graph. Post-#2822 the daemon spawns `mcpd <resolved-.js-path>` (via `workerPath()`), so `resolveWorkerEntry` — which only matched a `.ts` suffix — also stopped recognizing the dispatch and booted a **second daemon** ("Another daemon is already running"). Now `resolveWorkerEntry` matches the worker stem against both `.ts`/`.js`, and the dispatch imports through `workerPath()` (the #2822 layout-tolerant resolver) instead of a predicted literal.
- **Bug 2 (masking):** `mcx call` ignored MCP `isError`, printing the error to **stdout** and exiting **0** — which is exactly why the alias smoke cycle never surfaced Bug 1. `cmdCall` now surfaces an `isError` result on stderr with a non-zero exit (`isToolError` helper in `output.ts`).
- **Smoke test:** fixed a latent `handler:`→`fn:` typo in the smoke-test alias (`defineAlias` uses `fn`); it only "passed" before because Bug 2 swallowed the failure. Updated the stale "fails until #2821 lands" comment.

## Verification note (Step 1b)
The issue's minimal repro script used `handler:` instead of the actual `defineAlias` field `fn:` (packages/core/src/alias.ts:213). With `handler:`, the alias throws `aliasDef.fn is not a function` in **both dev and compiled** — a repro-script defect, not a code bug. Once corrected to `fn:`, Bug 1's predicted mechanism reproduced exactly (second-daemon dispatch failure on the compiled binary). Root cause confirmed before fixing.

## Test plan
- [x] `bun run am-i-done` — full gate green (typecheck, lint, rules, tests, coverage)
- [x] `bun scripts/smoke-test.ts` against freshly built `dist/` — 5/5 pass incl. alias save/call/delete cycle
- [x] Compiled `dist/mcx call _aliases <alias>` on isolated `MCP_CLI_DIR`: success → `{ "ok": true }` on stdout, exit 0
- [x] Compiled `dist/mcx run <alias>`: exit 0
- [x] Failing alias: clean stdout, `Error:` on stderr, exit 1
- [x] Added unit tests: `resolveWorkerEntry` (`.js`/`.ts`/bunfs), `isToolError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)