### PR TITLE
ci(build): wire bun run smoke-test into the build job post-compile (fixes #2797)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,7 +232,12 @@ jobs:
       # `bun test` on source can never catch). Lives here rather than in the
       # am-i-done runner because it needs the freshly compiled dist/ binaries,
       # which only the build job produces — same placement rationale as the
-      # Playwright resolver smoke below. Same #1004 crash-retry wrapper.
+      # Playwright resolver smoke below. Crash policy: retry once on a Bun
+      # crash (exit 132/139) as flake insurance, then FAIL. This deliberately
+      # does NOT mirror the pass-on-double-crash wrapper of the older smoke
+      # steps: #1004 is CLOSED (fixed upstream 2026-04-11), and a
+      # deterministic segfault in the compiled binaries is exactly the
+      # regression class this gate exists to block.
       - name: Compiled binary smoke test
         if: needs.detect.outputs.docs_only != 'true'
         timeout-minutes: 5
@@ -243,14 +248,14 @@ jobs:
           if [ $code -eq 0 ]; then
             exit 0
           elif [ $code -eq 132 ] || [ $code -eq 139 ]; then
-            echo "::warning::Bun crash (exit $code) during binary smoke test — retrying once (see #1004)"
+            echo "::warning::Bun crash (exit $code) during binary smoke test — retrying once"
             bun run smoke-test 2>&1 | tee /tmp/smoke_test_retry.txt
             code2=${PIPESTATUS[0]}
             if [ $code2 -eq 0 ]; then
               exit 0
             elif [ $code2 -eq 132 ] || [ $code2 -eq 139 ]; then
-              echo "::warning::Bun crash on retry too — treating as pass (known upstream bug, see #1004)"
-              exit 0
+              echo "::error::Bun crashed twice consecutively (exit $code2) during the binary smoke test. #1004 is CLOSED (fixed upstream) — do NOT file under it. Open the bun.report URL from the crash output so Bun gets the telemetry, then file a NEW issue with the bun.report URL, crash address, Bun version, and this commit SHA (per CLAUDE.md)."
+              exit $code2
             else
               exit $code2
             fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,39 @@ jobs:
         run: bun scripts/build.ts
       - if: needs.detect.outputs.docs_only != 'true'
         run: ls -lh dist/
+      # Compiled-binary smoke (#2797): exercises dist/mcx, dist/mcpd, and
+      # dist/mcpctl end-to-end against an isolated throwaway MCP_CLI_DIR —
+      # version injection, mcpctl no-TTY guard, `mcx ls`, the alias
+      # save/call/delete cycle (the #2821 compiled alias-dispatch class), and
+      # a full mcx → mcpd → mock session-worker spawn (the #2762 class that
+      # `bun test` on source can never catch). Lives here rather than in the
+      # am-i-done runner because it needs the freshly compiled dist/ binaries,
+      # which only the build job produces — same placement rationale as the
+      # Playwright resolver smoke below. Same #1004 crash-retry wrapper.
+      - name: Compiled binary smoke test
+        if: needs.detect.outputs.docs_only != 'true'
+        timeout-minutes: 5
+        run: |
+          set +e
+          bun run smoke-test 2>&1 | tee /tmp/smoke_test.txt
+          code=${PIPESTATUS[0]}
+          if [ $code -eq 0 ]; then
+            exit 0
+          elif [ $code -eq 132 ] || [ $code -eq 139 ]; then
+            echo "::warning::Bun crash (exit $code) during binary smoke test — retrying once (see #1004)"
+            bun run smoke-test 2>&1 | tee /tmp/smoke_test_retry.txt
+            code2=${PIPESTATUS[0]}
+            if [ $code2 -eq 0 ]; then
+              exit 0
+            elif [ $code2 -eq 132 ] || [ $code2 -eq 139 ]; then
+              echo "::warning::Bun crash on retry too — treating as pass (known upstream bug, see #1004)"
+              exit 0
+            else
+              exit $code2
+            fi
+          else
+            exit $code
+          fi
       - name: Playwright resolver binary smoke test
         if: needs.detect.outputs.docs_only != 'true'
         timeout-minutes: 5


### PR DESCRIPTION
## Summary

Completes point 3 of #2797 (points 1–2 — `MCP_CLI_DIR` isolation and the mock session-worker assertion — merged in #2824). Adds a **Compiled binary smoke test** step to the required `build` check in `ci.yml`, running `bun run smoke-test` immediately after `bun scripts/build.ts` produces `dist/`.

## Placement decision

The `build` job, as a raw post-compile step — **not** the am-i-done runner (`scripts/_runner/ci-steps.ts`):

- The smoke exercises the **compiled `dist/` binaries**, which only the `build` job produces. `am-i-done` (the `check` job, the pre-commit/pre-push hooks) never compiles binaries — routing it through the runner would force a full `bun build --compile` into every local gate run for a check whose whole point is the build artifact.
- This is the established convention for binary smokes in this workflow: the **Playwright resolver binary smoke test** (`scripts/smoke-playwright.ts`) and the **seed-embedding check** already live as post-build steps in the same job. The step mirrors the Playwright smoke's shape: `timeout-minutes: 5`, output tee'd to `/tmp/smoke_test.txt`.
- The #2818 pattern (test:hooks through `dirScopedTestWithCrashTolerance`) applies to `bun test` spec directories hidden by `pathIgnorePatterns` — a different problem; `smoke-test.ts` is not a bun test suite.

## Crash policy: retry-once, then FAIL

Unlike the older PTY/Playwright wrappers, a **second consecutive Bun crash (exit 132/139) fails the step**. The pass-on-double-crash branch those wrappers carry is stale policy — #1004 closed 2026-04-11 as fixed upstream, and a deterministic segfault in the compiled binaries is exactly the regression class this gate exists to block. On double crash the step emits an `::error::` directing the operator to open the bun.report URL and file a **new** issue (not under #1004, per CLAUDE.md). Retry-once is kept as flake insurance. The two pre-existing pass-by-policy wrappers are intentionally untouched here; their cleanup is tracked separately.

No duplication with #2818 or #2824: nothing in CI previously invoked `smoke-test.ts` (verified by grep across `.github/` and `scripts/_runner/`).

## What the gate now catches pre-merge

- `mcx version` injection, `mcpctl` no-TTY guard, `mcx ls`
- alias save/call/delete through the compiled argv-redispatch executor (the #2821 class, fixed by #2831)
- full `mcx → mcpd → mock session worker` spawn (the #2762 ModuleNotFound class that `bun test` on source can never catch)

## Test plan

- [x] `bun run build && bun run smoke-test` — all 5 checks pass locally (2.0s)
- [x] Full `bun run am-i-done` — all 11 steps pass (both commits)
- [ ] CI `build` job green on this PR (the new step exercising itself)

Fixes #2797

🤖 Generated with [Claude Code](https://claude.com/claude-code)