### PR TITLE
fix(daemon): strip redundant Error: prefix from alias error content (fixes #2832)

### DIFF
--- a/packages/daemon/src/alias-server.spec.ts
+++ b/packages/daemon/src/alias-server.spec.ts
@@ -280,6 +280,61 @@ describe("AliasServer", () => {
     expect(content[0].text).toContain("not found");
   });
 
+  function setupThrowingAlias(opts: ReturnType<typeof testOptions>) {
+    db = new StateDb(opts.DB_PATH);
+    mkdirSync(opts.ALIASES_DIR, { recursive: true });
+    const scriptPath = join(opts.ALIASES_DIR, "boom.ts");
+    writeFileSync(
+      scriptPath,
+      [
+        'import { defineAlias, z } from "mcp-cli";',
+        "defineAlias({",
+        '  name: "boom",',
+        '  description: "Always throws",',
+        "  input: z.object({}),",
+        "  output: z.object({}),",
+        '  fn: () => { throw new Error("kaboom"); },',
+        "});",
+      ].join("\n"),
+    );
+    db.saveAlias(
+      "boom",
+      scriptPath,
+      "Always throws",
+      "defineAlias",
+      JSON.stringify({ type: "object", properties: {} }),
+      JSON.stringify({ type: "object", properties: {} }),
+    );
+    return { db, scriptPath };
+  }
+
+  test("callTool error text has no doubled 'Error:' prefix", async () => {
+    using opts = testOptions();
+    const { db: testDb } = setupThrowingAlias(opts);
+    server = new AliasServer(testDb);
+
+    const { client } = await server.start();
+    const result = await client.callTool({ name: "boom", arguments: {} });
+    const content = result.content as Array<{ type: string; text: string }>;
+
+    expect(result.isError).toBe(true);
+    expect(content[0].text).toBe("kaboom");
+    expect(content[0].text).not.toMatch(/^Error:/);
+  });
+
+  test("callToolWithChain error text has no doubled 'Error:' prefix", async () => {
+    using opts = testOptions();
+    const { db: testDb } = setupThrowingAlias(opts);
+    server = new AliasServer(testDb);
+    await server.start();
+
+    const result = await server.callToolWithChain("boom", {}, []);
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe("kaboom");
+    expect(result.content[0].text).not.toMatch(/^Error:/);
+  });
+
   test("start() with no aliases returns empty tool list", async () => {
     using opts = testOptions();
     db = new StateDb(opts.DB_PATH);

--- a/packages/daemon/src/alias-server.ts
+++ b/packages/daemon/src/alias-server.ts
@@ -157,7 +157,7 @@ export class AliasServer {
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         return {
-          content: [{ type: "text" as const, text: `Error: ${message}` }],
+          content: [{ type: "text" as const, text: message }],
           isError: true,
         };
       }
@@ -223,7 +223,7 @@ export class AliasServer {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       return {
-        content: [{ type: "text" as const, text: `Error: ${message}` }],
+        content: [{ type: "text" as const, text: message }],
         isError: true,
       };
     }


### PR DESCRIPTION
## Summary
- `alias-server.ts` was prepending `Error: ` to thrown error messages in two catch blocks (`CallToolRequest` handler and `callToolWithChain`)
- `cmdCall` in `main.ts` then passed that text through `printError()`, which adds its own `Error: ` prefix — producing `Error: Error: <msg>`
- Fix: return bare `message` (no prefix) from both catch blocks in `alias-server.ts`, letting `printError()` own the single label

## Test plan
- Added `setupThrowingAlias` helper in `alias-server.spec.ts` that defines a `defineAlias` fn which throws `new Error("kaboom")`
- New test `callTool error text has no doubled 'Error:' prefix` — verifies content text equals `"kaboom"` and does not match `/^Error:/`
- New test `callToolWithChain error text has no doubled 'Error:' prefix` — same assertion via the chain path
- `bun run am-i-done` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)