### PR TITLE
fix(phase): resolve working-tree files against worktree root, not main checkout (fixes #2737)

### DIFF
--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -1200,37 +1200,71 @@ function makeDriftDeps(cwd: string) {
   return { deps, logs, errs, getExitCode: () => exitCode };
 }
 
-describe("cmdPhase root resolution from a worktree (#2673)", () => {
-  test("phase check resolves .mcx.lock from the main checkout root, not the worktree CWD", async () => {
-    // Main checkout: manifest + source + a freshly installed (in-sync) lock.
+describe("cmdPhase working-tree root resolution from a worktree (#2737)", () => {
+  test("phase check reads the worktree's OWN .mcx.lock, not the main checkout's", async () => {
+    // Main checkout: manifest + source + a STALE lock (main lags the branch —
+    // the normal state for any in-progress worktree, per #2737).
     writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);
     writeFileSync(join(dir, "impl.ts"), simpleAlias);
     const { deps } = makeDriftDeps(dir);
     await cmdPhase(["install"], deps);
+    const staleMain = parseLockfile(readFileSync(join(dir, ".mcx.lock"), "utf-8"));
+    staleMain.phases[0].contentHash = "0".repeat(64);
+    writeFileSync(join(dir, ".mcx.lock"), serializeLockfile(staleMain));
 
-    // Worktree checkout: identical sources but a STALE committed lock — this is
-    // the #2570 scenario where the lock at HEAD lagged the source.
+    // Worktree checkout: identical sources with a FRESH, in-sync lock.
     const worktree = mkdtempSync(join(tmpdir(), "mcx-phase-wt-"));
     try {
       writeFileSync(join(worktree, ".mcx.yaml"), simpleManifest);
       writeFileSync(join(worktree, "impl.ts"), simpleAlias);
-      const stale = parseLockfile(readFileSync(join(dir, ".mcx.lock"), "utf-8"));
-      stale.phases[0].contentHash = "0".repeat(64);
-      writeFileSync(join(worktree, ".mcx.lock"), serializeLockfile(stale));
+      await cmdPhase(["install"], { ...makeDriftDeps(worktree).deps, resolveWorktreeRoot: (c) => c });
 
-      // Control: with no root mapping, checking from the worktree reads the
-      // worktree's stale lock and falsely reports drift.
-      const control = await catchExit(() => cmdPhase(["check"], { cwd: () => worktree, resolveRoot: (c) => c }));
-      expect(control.code).toBe(1);
-      expect(control.err).toContain("out of date");
-
-      // Fix: mapping the worktree CWD back to the main checkout root reads the
-      // in-sync lock and reports ok.
-      const mapped = await catchExit(() =>
-        cmdPhase(["check"], { cwd: () => worktree, resolveRoot: (c) => (c === worktree ? dir : c) }),
+      // Bug (#2673 over-correction): mapping the worktree CWD to the main
+      // checkout reads main's STALE lock and false-fails.
+      const mappedToMain = await catchExit(() =>
+        cmdPhase(["check"], {
+          cwd: () => worktree,
+          resolveWorktreeRoot: (c) => (c === worktree ? dir : c),
+          resolveRoot: (c) => c,
+        }),
       );
-      expect(mapped.code).toBeUndefined();
-      expect(mapped.out).toContain("lockfile ok");
+      expect(mappedToMain.code).toBe(1);
+      expect(mappedToMain.err).toContain("out of date");
+
+      // Fix (#2737): resolving working-tree files against the worktree's own
+      // root reads the worktree's in-sync lock and reports ok — even though
+      // main's lock is stale.
+      const worktreeLocal = await catchExit(() =>
+        cmdPhase(["check"], { cwd: () => worktree, resolveWorktreeRoot: (c) => c, resolveRoot: (c) => dir }),
+      );
+      expect(worktreeLocal.code).toBeUndefined();
+      expect(worktreeLocal.out).toContain("lockfile ok");
+    } finally {
+      rmSync(worktree, { recursive: true, force: true });
+    }
+  });
+
+  test("phase install writes .mcx.lock into the worktree, not the main checkout", async () => {
+    // Main checkout: manifest + source, no lock yet.
+    writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);
+    writeFileSync(join(dir, "impl.ts"), simpleAlias);
+
+    const worktree = mkdtempSync(join(tmpdir(), "mcx-phase-wt-install-"));
+    try {
+      writeFileSync(join(worktree, ".mcx.yaml"), simpleManifest);
+      writeFileSync(join(worktree, "impl.ts"), simpleAlias);
+
+      // Install from the worktree, with the worktree resolving to itself and
+      // the (distinct) state root pointing at main.
+      await cmdPhase(["install"], {
+        ...makeDriftDeps(worktree).deps,
+        resolveWorktreeRoot: (c) => c,
+        resolveRoot: (c) => dir,
+      });
+
+      // The lock landed in the worktree; the main checkout was untouched.
+      expect(existsSync(join(worktree, ".mcx.lock"))).toBe(true);
+      expect(existsSync(join(dir, ".mcx.lock"))).toBe(false);
     } finally {
       rmSync(worktree, { recursive: true, force: true });
     }

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -53,6 +53,7 @@ import {
   expandPreset,
   extractMetadata,
   findGitRoot,
+  findWorktreeRoot,
   hashFileSync,
   hashImportClosureSync,
   historyTargets,
@@ -91,7 +92,18 @@ export interface PhaseInstallDeps {
   readFile: (path: string) => Promise<string>;
   executeAliasBundled: typeof executeAliasBundled;
   cwd: () => string;
+  /**
+   * Resolve runtime *state* root (transition log, daemon DB). For a linked
+   * worktree this maps back to the main checkout so state is shared (#2673).
+   */
   resolveRoot: (cwd: string) => string;
+  /**
+   * Resolve the *working-tree* root (`.mcx.lock`, `.mcx.yaml`, phase sources).
+   * Unlike {@link resolveRoot}, this stays inside the worktree — those files
+   * are per-checkout, so `phase check`/`install`/`list` must operate on the
+   * worktree's own copies, not the main checkout's (#2737).
+   */
+  resolveWorktreeRoot: (cwd: string) => string;
   log: (msg: string) => void;
   logError: (msg: string) => void;
   exit: (code: number) => never;
@@ -109,6 +121,7 @@ const defaultDeps: PhaseInstallDeps = {
   executeAliasBundled,
   cwd: () => process.cwd(),
   resolveRoot: (cwd) => findGitRoot(cwd) ?? cwd,
+  resolveWorktreeRoot: (cwd) => findWorktreeRoot(cwd) ?? cwd,
   log: (msg) => console.log(msg),
   logError: (msg) => console.error(msg),
   exit: (code) => process.exit(code),
@@ -296,7 +309,14 @@ export interface PhaseRunOptions {
 }
 
 export interface PhaseRunDeps {
+  /** Working-tree root — where the manifest and phase sources live (#2737). */
   cwd: string;
+  /**
+   * Runtime-state root for the transition log. Defaults to `cwd`. From a
+   * linked worktree, pass the main-checkout root so transitions are shared
+   * across worktrees (#2673); `cwd` stays worktree-local for the manifest.
+   */
+  stateCwd?: string;
   now?: () => Date;
 }
 
@@ -414,7 +434,7 @@ export function phaseRun(
   }
   const { path: manifestPath, manifest } = loaded;
 
-  const logPath = transitionLogPath(deps.cwd);
+  const logPath = transitionLogPath(deps.stateCwd ?? deps.cwd);
   const decision = commitTransition(logPath, {
     manifest,
     from: options.from,
@@ -728,14 +748,21 @@ export async function cmdPhase(
   execDeps?: Partial<PhaseExecuteDeps>,
 ): Promise<void> {
   const d: PhaseInstallDeps = { ...defaultDeps, ...deps };
-  // Resolve manifest / .mcx.lock / transition-log lookups from the main
-  // checkout root, not the raw CWD. From a linked worktree, process.cwd() is
-  // the worktree checkout whose committed .mcx.lock can be stale, while phase
-  // *state* is keyed by findGitRoot's main-checkout root — so a lock that is in
-  // sync at the root falsely reports "out of date" from a worktree. Mapping the
-  // lookup root through the same resolver keeps both consistent (#2673).
+  // Two distinct roots (#2737, correcting #2673's over-unification):
+  //   d.cwd()    → the *working-tree* root (this checkout's own toplevel).
+  //                .mcx.lock, .mcx.yaml, and phase sources are per-checkout, so
+  //                install/check/list/show/why must read the worktree's copies.
+  //                From a linked worktree, resolving these to the main checkout
+  //                either false-fails (main's lock lags the branch) or silently
+  //                writes into main's tree.
+  //   stateCwd() → the runtime-*state* root (main checkout for linked
+  //                worktrees). The transition log (.mcx/) is shared across
+  //                worktrees, keyed to one repo (#2673).
   const rawCwd = d.cwd;
-  d.cwd = () => d.resolveRoot(rawCwd());
+  d.cwd = () => d.resolveWorktreeRoot(rawCwd());
+  // findGitRoot (via resolveRoot) maps the worktree back to the main checkout;
+  // for a normal checkout it is a no-op, so this is correct in both cases.
+  const stateCwd = () => d.resolveRoot(d.cwd());
   const sub = args[0];
 
   if (!sub || sub === "help" || sub === "--help" || sub === "-h") {
@@ -864,7 +891,7 @@ export async function cmdPhase(
 
     if (sub === "log") {
       const opts = parsePhaseLogArgs(args.slice(1));
-      const entries = filterTransitionLog(readAllTransitions(transitionLogPath(d.cwd())), opts);
+      const entries = filterTransitionLog(readAllTransitions(transitionLogPath(stateCwd())), opts);
       if (opts.json) {
         for (const e of entries) d.log(JSON.stringify(e));
       } else if (entries.length === 0) {
@@ -895,12 +922,13 @@ export async function cmdPhase(
         const filtered = argv.filter((a) => a !== "--no-execute");
         const opts = parsePhaseRunArgs(filtered);
         const cwd = d.cwd();
+        const stateRoot = stateCwd();
         // Mirror pickResolvedFrom from executePhase (#1802, #1824).
         let resolvedFrom: string | null = opts.from;
         if (resolvedFrom === null) {
           const manifestForFrom = d.loadManifest(cwd);
           const priorTargets = manifestForFrom
-            ? historyTargets(readTransitionHistory(transitionLogPath(cwd), opts.workItemId).filter(isCommitted))
+            ? historyTargets(readTransitionHistory(transitionLogPath(stateRoot), opts.workItemId).filter(isCommitted))
             : [];
           let dbCandidate: string | null = null;
           if (opts.workItemId !== null && manifestForFrom) {
@@ -930,7 +958,7 @@ export async function cmdPhase(
               )
             : (dbCandidate ?? logCandidate);
         }
-        const result = phaseRun({ ...opts, from: resolvedFrom }, { cwd });
+        const result = phaseRun({ ...opts, from: resolvedFrom }, { cwd, stateCwd: stateRoot });
         const source = result.manifest.phases[opts.target]?.source ?? "(unknown)";
         const tag = result.forced ? " [FORCED]" : "";
         const trail = result.from ?? "(initial)";
@@ -1256,7 +1284,12 @@ export async function executePhase(
 ): Promise<void> {
   const d: PhaseInstallDeps = { ...defaultDeps, ...deps };
   const ex: PhaseExecuteDeps = { ...defaultExecuteDeps, ...execDeps };
+  // Working-tree root (manifest, phase sources, branch guard) vs. runtime-state
+  // root (transition log). For a linked worktree, resolveRoot maps back to the
+  // main checkout so the transition log is shared; for a normal checkout it is
+  // a no-op. See #2737 / #2673.
   const cwd = d.cwd();
+  const stateRoot = d.resolveRoot(cwd);
 
   let parsed: PhaseExecuteArgs;
   try {
@@ -1309,7 +1342,7 @@ export async function executePhase(
   // we spend cycles running the handler. The final commit below repeats
   // this under the transition lock; pre-check is a fail-fast guard, not
   // the source of truth.
-  const logPath = transitionLogPath(cwd);
+  const logPath = transitionLogPath(stateRoot);
   const prior = readTransitionHistory(logPath, parsed.workItemId).filter(isCommitted);
   const priorTargets = historyTargets(prior);
   // Resolve "from" phase (#1802, #1824):
@@ -1491,7 +1524,7 @@ export async function executePhase(
       workItemId: parsed.workItemId,
       forceMessage: parsed.forceMessage,
     },
-    { cwd, now: ex.now },
+    { cwd, stateCwd: stateRoot, now: ex.now },
   );
   const source = phase.source ?? "(unknown)";
   const tag = txResult.forced ? " [FORCED]" : "";

--- a/packages/core/src/git.spec.ts
+++ b/packages/core/src/git.spec.ts
@@ -2,7 +2,15 @@ import { describe, expect, mock, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { type ExecFn, clearFindGitRootCache, ensureCoreBareUnset, findGitRoot, fixCoreBare } from "./git";
+import {
+  type ExecFn,
+  clearFindGitRootCache,
+  clearFindWorktreeRootCache,
+  ensureCoreBareUnset,
+  findGitRoot,
+  findWorktreeRoot,
+  fixCoreBare,
+} from "./git";
 
 /** Create a temp dir with a .git file (like a worktree) */
 function makeFakeWorktree(): string {
@@ -334,6 +342,76 @@ describe("findGitRoot", () => {
       clearFindGitRootCache();
       const after = findGitRoot(repo);
       expect(before).toBe(after); // same result after cache clear
+    } finally {
+      rmSync(repo, { recursive: true });
+    }
+  });
+});
+
+describe("findWorktreeRoot (#2737)", () => {
+  const cleanEnv = cleanGitEnv();
+  const gitOpts = { env: cleanEnv, stdout: "ignore" as const, stderr: "ignore" as const };
+  const commitEnv = {
+    ...cleanEnv,
+    GIT_AUTHOR_NAME: "t",
+    GIT_AUTHOR_EMAIL: "t@t",
+    GIT_COMMITTER_NAME: "t",
+    GIT_COMMITTER_EMAIL: "t@t",
+  };
+
+  test("returns the worktree's OWN toplevel, not the main checkout, from a linked worktree", () => {
+    const repo = mkdtempSync(join(tmpdir(), "git-wt-local-"));
+    const wt = join(repo, "linked-wt");
+    try {
+      clearFindWorktreeRootCache();
+      Bun.spawnSync(["git", "-C", repo, "init", "-q"], gitOpts);
+      Bun.spawnSync(["git", "-C", repo, "commit", "--allow-empty", "-m", "init", "-q"], { ...gitOpts, env: commitEnv });
+      Bun.spawnSync(["git", "-C", repo, "worktree", "add", wt, "-b", "wt-branch", "-q"], gitOpts);
+
+      const wtRoot = findWorktreeRoot(wt);
+      const mainRoot = findGitRoot(wt);
+      // findGitRoot maps the worktree back to main; findWorktreeRoot does NOT.
+      expect(wtRoot).not.toBeNull();
+      expect(wtRoot && (wtRoot === wt || wtRoot.endsWith(wt.replace(/^\/private/, "")))).toBeTruthy();
+      expect(wtRoot).not.toBe(mainRoot);
+    } finally {
+      rmSync(repo, { recursive: true, force: true });
+    }
+  });
+
+  test("returns the repo root from a subdirectory of a normal checkout", () => {
+    const repo = mkdtempSync(join(tmpdir(), "git-wt-sub-"));
+    try {
+      clearFindWorktreeRootCache();
+      Bun.spawnSync(["git", "-C", repo, "init", "-q"], { env: cleanGitEnv() });
+      const sub = join(repo, "nested", "deeper");
+      mkdirSync(sub, { recursive: true });
+      const got = findWorktreeRoot(sub);
+      expect(got && (got === repo || got.endsWith(repo.replace(/^\/private/, "")))).toBeTruthy();
+    } finally {
+      rmSync(repo, { recursive: true });
+    }
+  });
+
+  test("returns null outside any git repository", () => {
+    const dir = mkdtempSync(join(tmpdir(), "git-wt-none-"));
+    try {
+      clearFindWorktreeRootCache();
+      expect(findWorktreeRoot(dir)).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  test("clearFindWorktreeRootCache resets the cache", () => {
+    const repo = mkdtempSync(join(tmpdir(), "git-wt-cache-"));
+    try {
+      clearFindWorktreeRootCache();
+      Bun.spawnSync(["git", "-C", repo, "init", "-q"], { env: cleanGitEnv() });
+      const before = findWorktreeRoot(repo);
+      clearFindWorktreeRootCache();
+      const after = findWorktreeRoot(repo);
+      expect(before).toBe(after);
     } finally {
       rmSync(repo, { recursive: true });
     }

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -198,3 +198,48 @@ export function findGitRoot(cwd: string = process.cwd()): string | null {
   gitRootCache.set(cwd, result);
   return result;
 }
+
+/** Process-local cache: resolved cwd → worktree root (null = not a git repo). */
+const worktreeRootCache = new Map<string, string | null>();
+
+/** Clear the findWorktreeRoot process-local cache. Intended for tests and long-lived processes that move worktrees. */
+export function clearFindWorktreeRootCache(): void {
+  worktreeRootCache.clear();
+}
+
+/**
+ * Resolve the working-tree root of `cwd` — the toplevel of *this* checkout,
+ * NOT remapped to the main checkout for linked worktrees.
+ *
+ * Unlike {@link findGitRoot} (which maps linked worktrees back to the main
+ * checkout via `--git-common-dir` so every worktree shares one key for daemon
+ * state), this returns the worktree's own `--show-toplevel`. Use it for
+ * per-checkout working-tree files — `.mcx.lock`, `.mcx.yaml`, phase sources —
+ * that each linked worktree owns its own copy of. Resolving those from the
+ * main checkout makes `phase check`/`install` operate on the wrong tree from a
+ * worktree. See #2737 (distinct from #2673, which keys runtime *state*).
+ *
+ * Returns null when `cwd` is not inside a git repository. Results are cached
+ * process-locally by cwd.
+ */
+export function findWorktreeRoot(cwd: string = process.cwd()): string | null {
+  if (worktreeRootCache.has(cwd)) return worktreeRootCache.get(cwd) as string | null;
+
+  const env = gitDiscoverEnv();
+  let result: string | null = null;
+  try {
+    const top = spawnCaptureSync("git", ["-C", cwd, "rev-parse", "--show-toplevel"], {
+      timeoutMs: GIT_REV_PARSE_TIMEOUT_MS,
+      env,
+    });
+    if (top.exitCode === 0) {
+      const toplevel = top.stdout.trim();
+      if (toplevel) result = toplevel;
+    }
+  } catch {
+    // result stays null
+  }
+
+  worktreeRootCache.set(cwd, result);
+  return result;
+}

--- a/scripts/am-i-done.spec.ts
+++ b/scripts/am-i-done.spec.ts
@@ -7,16 +7,17 @@ const names = (steps: { name: string }[]) => steps.map((s) => s.name);
 const leased = (steps: Step[]) => steps.filter((s) => s.lease).map((s) => s.name);
 
 describe("am-i-done step lists", () => {
-  // #2737: `mcx phase check` resolves its root to the main checkout from a
-  // linked worktree, so the local hooks must NOT run phase-lock — it would
-  // false-positive-block every clean worktree commit/push and false-negative
-  // the worktree's own lock drift. Sprints run entirely in worktrees.
-  it("does not wire phase-lock into the pre-commit hook", () => {
-    expect(names(PRE_COMMIT)).not.toContain("phase-lock");
+  // #2737: `mcx phase check` now resolves its working-tree files (.mcx.lock,
+  // phase sources) against the worktree's own root (findWorktreeRoot), not the
+  // main checkout — so it is sound from a linked worktree and the local hooks
+  // run it. This is what closed the false-positive/false-negative that had
+  // kept it out of the local gates. Sprints run entirely in worktrees.
+  it("wires phase-lock into the pre-commit hook", () => {
+    expect(names(PRE_COMMIT)).toContain("phase-lock");
   });
 
-  it("does not wire phase-lock into the pre-push hook", () => {
-    expect(names(PRE_PUSH)).not.toContain("phase-lock");
+  it("wires phase-lock into the pre-push hook", () => {
+    expect(names(PRE_PUSH)).toContain("phase-lock");
   });
 
   // The check is sound against a real checkout (root == repo root), so CI and

--- a/scripts/am-i-done.ts
+++ b/scripts/am-i-done.ts
@@ -286,15 +286,14 @@ const STALE_TODOS_CI: Step = {
 // Default (no flag): the developer-friendly path — parallel tests for
 //   speed, `biome --write` for auto-fix, and the simpler coverage step.
 
-// phase-lock is deliberately omitted from PRE_COMMIT / PRE_PUSH: `mcx phase
-// check` resolves its root to the *main* checkout from a linked worktree
-// (phase.ts → findGitRoot, #2673), so wiring it into the local hooks both
-// false-positive-blocks every clean worktree commit/push and false-negatives
-// the worktree's own lock drift (#2737). It stays in CI / COMPREHENSIVE, which
-// run against a real checkout where the root is the repo root and the check is
-// sound. Re-add to the local hooks once #2737 makes the resolver worktree-aware.
-export const PRE_COMMIT: Step[] = [INSTALL, TYPECHECK, LINT_CHECK, RULES, AGENT_GRID];
-export const PRE_PUSH: Step[] = [INSTALL, TYPECHECK, LINT_CHECK, RULES, AGENT_GRID, TEST_CHANGED];
+// phase-lock now runs in the local hooks too. #2737 made `mcx phase check`
+// resolve its working-tree files (.mcx.lock, phase sources) against the
+// worktree's own root (findWorktreeRoot) instead of the main checkout
+// (findGitRoot) — so from a linked worktree it checks the worktree's own lock,
+// not main's. That removes the false-positive/false-negative that previously
+// forced it out of PRE_COMMIT / PRE_PUSH.
+export const PRE_COMMIT: Step[] = [INSTALL, TYPECHECK, LINT_CHECK, RULES, AGENT_GRID, PHASE_LOCK];
+export const PRE_PUSH: Step[] = [INSTALL, TYPECHECK, LINT_CHECK, RULES, AGENT_GRID, PHASE_LOCK, TEST_CHANGED];
 export const COMPREHENSIVE: Step[] = [
   INSTALL,
   TYPECHECK,


### PR DESCRIPTION
## Summary
- `mcx phase check/install/list` resolved `.mcx.lock` and phase sources through `findGitRoot`, which maps a linked worktree back to the **main** checkout. From a worktree this false-failed every commit/push (main's lock lags the branch) and made `phase install` silently write into main's working tree — cost a QA round on sprint-74 PR #2826 and blocked PR #2728.
- Adds `findWorktreeRoot` (worktree's own `--show-toplevel`, no common-dir remap) and splits the two roots in `cmdPhase`/`executePhase`: **working-tree files** (`.mcx.lock`, `.mcx.yaml`, phase sources) resolve against the worktree; **runtime state** (transition log, daemon DB) stays keyed to the main checkout via `findGitRoot` (#2673's concern, preserved).
- Re-arms the `phase-lock` step in `PRE_COMMIT`/`PRE_PUSH` in `scripts/am-i-done.ts` now that `mcx phase check` is worktree-sound (the explicit follow-on in the issue comments), and flips the `am-i-done.spec.ts` assertions that pinned its absence.

## Test plan
- [x] `bun typecheck` / `bun lint` clean
- [x] New `findWorktreeRoot` tests (git.spec.ts): returns the worktree's own toplevel from a linked worktree (≠ `findGitRoot`), repo root from a subdir, null outside a repo, cache clear.
- [x] Rewrote the `#2673` phase.spec.ts test → asserts `phase check` reads the worktree's own lock (ok even when main's is stale) and `phase install` writes into the worktree, not main.
- [x] Flipped am-i-done.spec.ts: phase-lock now wired into pre-commit/pre-push.
- [x] Live: `bun dev:mcx -- phase check` from this linked worktree → `lockfile ok` (reads the worktree's lock).
- [x] Full `bun run am-i-done` (11 steps, incl. re-armed phase-lock) green; pre-commit hook passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)