### PR TITLE
fix(worktree): idempotent worktree removal on 'is not a working tree' (fixes #2836)

### DIFF
--- a/packages/core/src/worktree-shim.spec.ts
+++ b/packages/core/src/worktree-shim.spec.ts
@@ -488,6 +488,72 @@ describe("cleanupWorktree", () => {
     expect(infoMsgs.some((m) => m.startsWith("Deleted branch"))).toBe(false);
   });
 
+  test("idempotent no-op when plain remove reports 'is not a working tree' (#2836)", () => {
+    // A sibling `bye` on a session sharing this worktree already removed it.
+    // The directory lingers so existsSync() is true, but git no longer tracks it.
+    tmpDir = makeTmpDir();
+    const worktreeBase = join(tmpDir, ".claude", "worktrees");
+    const worktreePath = join(worktreeBase, "shared-wt");
+    mkdirSync(worktreePath, { recursive: true });
+
+    let forceAttempted = false;
+    const exec = mock((cmd: string[]) => {
+      if (cmd.includes("status") && cmd.includes("--porcelain")) return { stdout: "", stderr: "", exitCode: 0 };
+      if (cmd.includes("--show-current")) return { stdout: "feat/branch", stderr: "", exitCode: 0 };
+      if (cmd.includes("remove") && cmd.includes("--force")) {
+        forceAttempted = true;
+        return { stdout: "", stderr: "", exitCode: 0 };
+      }
+      if (cmd.includes("remove"))
+        return { stdout: "", stderr: `fatal: '${worktreePath}' is not a working tree`, exitCode: 128 };
+      if (cmd.includes("-d")) return { stdout: "", stderr: "", exitCode: 1 };
+      if (cmd.includes("core.bare")) return { stdout: "false", stderr: "", exitCode: 0 };
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const printError = mock(() => {});
+    const printInfo = mock(() => {});
+
+    cleanupWorktree("shared-wt", worktreePath, { exec, printError, printInfo }, tmpDir);
+
+    const errorMsgs = (printError as ReturnType<typeof mock>).mock.calls.map((c: unknown[]) => c[0] as string);
+    const infoMsgs = (printInfo as ReturnType<typeof mock>).mock.calls.map((c: unknown[]) => c[0] as string);
+    // No "Failed to remove worktree" error; treated as an already-removed no-op.
+    expect(errorMsgs.some((m) => m.includes("Failed to remove worktree"))).toBe(false);
+    expect(infoMsgs.some((m) => m.includes("Worktree already removed"))).toBe(true);
+    // --force must NOT be attempted — git has already dropped the registration.
+    expect(forceAttempted).toBe(false);
+  });
+
+  test("idempotent no-op when --force remove reports 'is not a working tree' (#2836)", () => {
+    // Concurrent teardown wins between the plain remove and the --force retry.
+    tmpDir = makeTmpDir();
+    const worktreeBase = join(tmpDir, ".claude", "worktrees");
+    const worktreePath = join(worktreeBase, "race-wt");
+    mkdirSync(worktreePath, { recursive: true });
+
+    const exec = mock((cmd: string[]) => {
+      if (cmd.includes("status") && cmd.includes("--porcelain")) return { stdout: "", stderr: "", exitCode: 0 };
+      if (cmd.includes("--show-current")) return { stdout: "feat/branch", stderr: "", exitCode: 0 };
+      // Plain remove exits 0 but dir persists → triggers --force; --force then
+      // races a sibling teardown and reports the worktree is already gone.
+      if (cmd.includes("remove") && cmd.includes("--force"))
+        return { stdout: "", stderr: `fatal: '${worktreePath}' is not a working tree`, exitCode: 128 };
+      if (cmd.includes("remove")) return { stdout: "", stderr: "", exitCode: 0 };
+      if (cmd.includes("-d")) return { stdout: "", stderr: "", exitCode: 1 };
+      if (cmd.includes("core.bare")) return { stdout: "false", stderr: "", exitCode: 0 };
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const printError = mock(() => {});
+    const printInfo = mock(() => {});
+
+    cleanupWorktree("race-wt", worktreePath, { exec, printError, printInfo }, tmpDir);
+
+    const errorMsgs = (printError as ReturnType<typeof mock>).mock.calls.map((c: unknown[]) => c[0] as string);
+    const infoMsgs = (printInfo as ReturnType<typeof mock>).mock.calls.map((c: unknown[]) => c[0] as string);
+    expect(errorMsgs.some((m) => m.includes("Failed to remove worktree"))).toBe(false);
+    expect(infoMsgs.some((m) => m.includes("Worktree already removed"))).toBe(true);
+  });
+
   test("attempts removal when git status fails but directory exists (corrupted worktree)", () => {
     tmpDir = makeTmpDir();
     const worktreeBase = join(tmpDir, ".claude", "worktrees");

--- a/packages/core/src/worktree-shim.ts
+++ b/packages/core/src/worktree-shim.ts
@@ -332,6 +332,15 @@ export function cleanupWorktree(worktree: string, cwd: string, deps: WorktreeShi
 }
 
 /**
+ * Whether a `git worktree remove` stderr indicates the path is no longer a
+ * registered worktree (already removed). git's message is
+ * `fatal: '<path>' is not a working tree`.
+ */
+function isNotAWorktreeError(stderr: string): boolean {
+  return /not a working tree/i.test(stderr);
+}
+
+/**
  * Attempt `git worktree remove`, verify the directory is actually gone,
  * and retry with --force if needed. Only prints success after verification.
  * Returns true if the directory was verified removed.
@@ -351,6 +360,15 @@ function removeWorktreeWithVerification(
     "remove",
     worktreePath,
   ]);
+
+  // Idempotency: git reports "is not a working tree" when this path is no longer
+  // a registered worktree — an earlier or concurrent teardown (e.g. a sibling
+  // `bye` on a session sharing the worktree) already removed it. Treat as a
+  // no-op success rather than surfacing a spurious error (#2836).
+  if (removeExit !== 0 && isNotAWorktreeError(removeStderr)) {
+    deps.printInfo(`Worktree already removed: ${worktreePath}`);
+    return true;
+  }
 
   if (removeExit === 0 && !bareBeforeCleanup && isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd))) {
     deps.printError(
@@ -402,6 +420,14 @@ function removeWorktreeWithVerification(
 
   if (!existsSync(worktreePath)) {
     deps.printInfo(`Removed worktree (--force): ${worktreePath}`);
+    return true;
+  }
+
+  // Idempotency (concurrent teardown mid-force): if either attempt reported the
+  // path is no longer a registered worktree, git already dropped it — no-op
+  // success rather than a spurious "Failed to remove worktree" (#2836).
+  if (isNotAWorktreeError(forceStderr) || isNotAWorktreeError(removeStderr)) {
+    deps.printInfo(`Worktree already removed: ${worktreePath}`);
     return true;
   }
 

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -2100,6 +2100,25 @@ describe("ClaudeWsServer", () => {
     expect(result).toEqual({ worktree: null, cwd: null, repoRoot: null });
   });
 
+  test("bye of a --cwd session never reports a worktree for removal (#2836)", async () => {
+    // A session spawned with --cwd into a worktree it did NOT create carries a
+    // cwd but no worktree name. Its bye must not claim the worktree — only the
+    // creating (--worktree) session owns removal.
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });
+    await server.start();
+
+    server.prepareSession("cwd-session", {
+      prompt: "Hello",
+      cwd: "/repo/.claude/worktrees/claude-shared",
+      repoRoot: "/repo",
+    });
+    server.spawnClaude("cwd-session");
+
+    const result = await server.bye("cwd-session");
+    expect(result.worktree).toBeNull();
+  });
+
   test("bye suppresses worktree cleanup when another session shares the same worktree (#1837)", async () => {
     const ms = mockSpawn();
     server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });


### PR DESCRIPTION
## Summary
- `mcx claude bye` on a session sharing a worktree (creator via `--worktree`, siblings via `--cwd`) surfaced a spurious `Error: Failed to remove worktree ... (fatal: ... is not a working tree)` when an earlier or concurrent bye had already removed it.
- `removeWorktreeWithVerification` now treats git's `is not a working tree` signal — on both the plain and `--force` remove paths — as an idempotent no-op success (`Worktree already removed: <path>`), not an error. #2662 builds on this idempotency.
- The isCreator gate is already enforced structurally: `--cwd` sessions carry no worktree name, so `bye` returns `worktree: null` and never attempts removal. Locked in with an explicit ws-server test; no change to bye's default behavior (that is #1750).

## Test plan
- [x] `bun test packages/core/src/worktree-shim.spec.ts` — new idempotency tests (plain + `--force` paths) pass; genuine failures still report `Failed to remove worktree`.
- [x] `bun test packages/daemon/src/claude-session/ws-server.spec.ts` — new `--cwd` no-removal test + existing suite pass.
- [x] `bun run am-i-done` — full gate green (typecheck, lint, rules, tests, coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)