### PR TITLE
fix(monitor): fail fast when bound daemon dies under a passive wait (fixes #2508)

### DIFF
--- a/packages/command/src/commands/monitor.spec.ts
+++ b/packages/command/src/commands/monitor.spec.ts
@@ -444,6 +444,8 @@ function makeStreamDeps(events: MonitorEvent[], overrides: Partial<MonitorDeps> 
     },
     onSigint: () => {},
     onStdoutError: () => {},
+    checkDaemonLiveness: () => true,
+    livenessTimeoutMs: 0,
     ...overrides,
   };
 }
@@ -529,6 +531,8 @@ describe("cmdMonitor", () => {
       openEventStream: () => ({ events: abortStream, abort: () => {} }),
       isTTY: true,
       getCwd: () => "/test/repo",
+      checkDaemonLiveness: () => true,
+      livenessTimeoutMs: 0,
       writeStdout: () => {},
       writeStderr: () => {},
       exit: (code) => {
@@ -554,6 +558,8 @@ describe("cmdMonitor", () => {
       openEventStream: () => ({ events: errorStream, abort: () => {} }),
       isTTY: true,
       getCwd: () => "/test/repo",
+      checkDaemonLiveness: () => true,
+      livenessTimeoutMs: 0,
       writeStdout: () => {},
       writeStderr: (l) => stderr.push(l),
       exit: (code) => {
@@ -580,6 +586,8 @@ describe("cmdMonitor", () => {
       }),
       isTTY: true,
       getCwd: () => "/test/repo",
+      checkDaemonLiveness: () => true,
+      livenessTimeoutMs: 0,
       writeStdout: () => {},
       writeStderr: () => {},
       exit: (code) => {
@@ -603,6 +611,8 @@ describe("cmdMonitor", () => {
       openEventStream: () => ({ events: emptyGen(), abort: () => {} }),
       isTTY: true,
       getCwd: () => "/test/repo",
+      checkDaemonLiveness: () => true,
+      livenessTimeoutMs: 0,
       writeStdout: () => {},
       writeStderr: () => {},
       exit: (code) => {
@@ -646,6 +656,8 @@ describe("cmdMonitor", () => {
       }),
       isTTY: true,
       getCwd: () => "/test/repo",
+      checkDaemonLiveness: () => true,
+      livenessTimeoutMs: 0,
       writeStdout: () => {},
       writeStderr: () => {},
       exit: (code) => {
@@ -683,6 +695,8 @@ describe("cmdMonitor", () => {
       }),
       isTTY: true,
       getCwd: () => "/test/repo",
+      checkDaemonLiveness: () => true,
+      livenessTimeoutMs: 0,
       writeStdout: () => {},
       writeStderr: () => {},
       exit: (code) => {
@@ -710,6 +724,8 @@ describe("cmdMonitor", () => {
       }),
       isTTY: true,
       getCwd: () => "/test/repo",
+      checkDaemonLiveness: () => true,
+      livenessTimeoutMs: 0,
       writeStdout: () => {},
       writeStderr: () => {},
       exit: (code) => {
@@ -816,6 +832,8 @@ describe("cmdMonitor", () => {
       }),
       isTTY: true,
       getCwd: () => "/test/repo",
+      checkDaemonLiveness: () => true,
+      livenessTimeoutMs: 0,
       writeStdout: () => {},
       writeStderr: () => {},
       exit: (code) => {
@@ -884,6 +902,8 @@ describe("cmdMonitor", () => {
       openEventStream: () => ({ events: emptyGen(), abort: () => {} }),
       isTTY: true,
       getCwd: () => "/test/repo",
+      checkDaemonLiveness: () => true,
+      livenessTimeoutMs: 0,
       writeStdout: () => {},
       writeStderr: () => {},
       exit: (code) => {
@@ -901,6 +921,135 @@ describe("cmdMonitor", () => {
     expect(capturedErrHandler).toBeDefined();
     const otherErr = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
     capturedErrHandler?.(otherErr);
+    expect(exitCalls).toHaveLength(0);
+  });
+
+  // ── Liveness watchdog (#2508): passive monitor must never outlive its daemon ──
+
+  test("watchdog exits 3 loudly when the bound daemon dies mid-stream", async () => {
+    let resolveStream: (() => void) | undefined;
+    async function* hangingStream(): AsyncGenerator<MonitorEvent> {
+      await new Promise<void>((resolve) => {
+        resolveStream = resolve;
+      });
+    }
+    const stderr: string[] = [];
+    const exitCalls: number[] = [];
+    let watchdogFn: (() => void) | undefined;
+    const deps: MonitorDeps = {
+      openEventStream: () => ({
+        events: hangingStream(),
+        abort: () => {
+          resolveStream?.();
+        },
+      }),
+      isTTY: true,
+      getCwd: () => "/test/repo",
+      checkDaemonLiveness: () => false, // daemon is a corpse
+      livenessTimeoutMs: 90_000,
+      writeStdout: () => {},
+      writeStderr: (l) => stderr.push(l),
+      exit: (code) => {
+        exitCalls.push(code);
+        return undefined as never;
+      },
+      onSigint: () => {},
+      onStdoutError: () => {},
+      createTimeout: (fn) => {
+        watchdogFn = fn;
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      },
+    };
+
+    const promise = cmdMonitor([], deps);
+    await Promise.resolve();
+    // Simulate the silence window elapsing.
+    watchdogFn?.();
+    await promise;
+
+    expect(exitCalls).toEqual([3]);
+    expect(stderr.join("")).toContain("bound daemon is not responding");
+  });
+
+  test("watchdog warns and keeps watching when daemon PID is still alive", async () => {
+    let resolveStream: (() => void) | undefined;
+    async function* hangingStream(): AsyncGenerator<MonitorEvent> {
+      await new Promise<void>((resolve) => {
+        resolveStream = resolve;
+      });
+    }
+    const stderr: string[] = [];
+    const exitCalls: number[] = [];
+    const timerFns: Array<() => void> = [];
+    let sigintFn: (() => void) | undefined;
+    const deps: MonitorDeps = {
+      openEventStream: () => ({
+        events: hangingStream(),
+        abort: () => {
+          resolveStream?.();
+        },
+      }),
+      isTTY: true,
+      getCwd: () => "/test/repo",
+      checkDaemonLiveness: () => true, // alive but silent
+      livenessTimeoutMs: 90_000,
+      writeStdout: () => {},
+      writeStderr: (l) => stderr.push(l),
+      exit: (code) => {
+        exitCalls.push(code);
+        return undefined as never;
+      },
+      onSigint: (fn) => {
+        sigintFn = fn;
+      },
+      onStdoutError: () => {},
+      createTimeout: (fn) => {
+        timerFns.push(fn);
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      },
+    };
+
+    const promise = cmdMonitor([], deps);
+    await Promise.resolve();
+    timerFns[0]?.(); // fire watchdog once
+
+    expect(exitCalls).toHaveLength(0);
+    expect(stderr.join("")).toContain("no daemon heartbeat");
+    expect(timerFns.length).toBeGreaterThanOrEqual(2); // re-armed
+
+    sigintFn?.(); // clean shutdown
+    await promise;
+    expect(exitCalls).toEqual([0]);
+  });
+
+  test("stream end with dead daemon and no terminator exits 3, not a blind 0", async () => {
+    const events = [makeEvent(SESSION_RESULT, {})];
+    const stderr: string[] = [];
+    const exitCalls: number[] = [];
+    const deps = makeStreamDeps(events, {
+      checkDaemonLiveness: () => false,
+      writeStderr: (l) => stderr.push(l),
+      exit: (code) => {
+        exitCalls.push(code);
+        return undefined as never;
+      },
+    });
+    await cmdMonitor([], deps);
+    expect(exitCalls).toEqual([3]);
+    expect(stderr.join("")).toContain("bound daemon vanished");
+  });
+
+  test("stream end with live daemon and no terminator still exits cleanly", async () => {
+    const events = [makeEvent(SESSION_RESULT, {})];
+    const exitCalls: number[] = [];
+    const deps = makeStreamDeps(events, {
+      checkDaemonLiveness: () => true,
+      exit: (code) => {
+        exitCalls.push(code);
+        return undefined as never;
+      },
+    });
+    await cmdMonitor([], deps);
     expect(exitCalls).toHaveLength(0);
   });
 

--- a/packages/command/src/commands/monitor.ts
+++ b/packages/command/src/commands/monitor.ts
@@ -11,7 +11,14 @@
 import { resolve } from "node:path";
 import type { MonitorEvent } from "@mcp-cli/core";
 import { formatMonitorEvent, globToRegex, openEventStream, resolveRealpath } from "@mcp-cli/core";
+import { isDaemonPidAlive } from "../daemon-lifecycle";
 import { parseFlags } from "../flags";
+
+// The daemon emits a heartbeat after 30s of event-bus silence (see
+// EventStreamServer.EVENTBUS_HEARTBEAT_MS). A passive monitor should therefore
+// see *something* at least every 30s from a live daemon. Wait for 3 missed
+// heartbeats before declaring the channel dead, to tolerate GC / IO pauses.
+const DEFAULT_LIVENESS_TIMEOUT_MS = 90_000;
 
 export interface MonitorArgs {
   json: boolean;
@@ -42,6 +49,10 @@ export interface MonitorDeps {
   onSigint: (fn: () => void) => void;
   onStdoutError: (fn: (err: Error) => void) => void;
   createTimeout?: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  /** Non-destructive probe: is the bound daemon's process + socket still alive? (#2508) */
+  checkDaemonLiveness: () => boolean;
+  /** Silence window before the liveness watchdog fires. `<= 0` disables it. */
+  livenessTimeoutMs: number;
 }
 
 const defaultDeps: MonitorDeps = {
@@ -53,6 +64,8 @@ const defaultDeps: MonitorDeps = {
   exit: (code) => process.exit(code),
   onSigint: (fn) => process.once("SIGINT", fn),
   onStdoutError: (fn) => process.stdout.on("error", fn),
+  checkDaemonLiveness: isDaemonPidAlive,
+  livenessTimeoutMs: DEFAULT_LIVENESS_TIMEOUT_MS,
 };
 
 export function parseMonitorArgs(args: string[]): MonitorArgs {
@@ -187,13 +200,49 @@ export async function cmdMonitor(args: string[], deps?: Partial<MonitorDeps>): P
 
   let done = false;
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let watchdogId: ReturnType<typeof setTimeout> | undefined;
+
+  const clearWatchdog = () => {
+    if (watchdogId !== undefined) {
+      clearTimeout(watchdogId);
+      watchdogId = undefined;
+    }
+  };
 
   const finish = (code: number) => {
     if (done) return;
     done = true;
     if (timeoutId !== undefined) clearTimeout(timeoutId);
+    clearWatchdog();
     abort();
     d.exit(code);
+  };
+
+  const silenceSecs = () => Math.round(d.livenessTimeoutMs / 1000);
+
+  // Liveness watchdog (#2508): a passive monitor must never silently outlive the
+  // daemon it is bound to. Re-armed on every received event; if it fires, the
+  // channel has been silent past the heartbeat window. Probe the daemon: if its
+  // PID/socket are gone, the daemon is a corpse — exit loudly instead of hanging
+  // blind. If the process is somehow still alive, warn and keep watching.
+  const armWatchdog = () => {
+    if (d.livenessTimeoutMs <= 0) return;
+    clearWatchdog();
+    watchdogId = (d.createTimeout ?? setTimeout)(() => {
+      if (done) return;
+      if (!d.checkDaemonLiveness()) {
+        d.writeStderr(
+          `monitor: bound daemon is not responding — no events or heartbeat for ${silenceSecs()}s and its PID/socket are gone. The daemon has died; exiting so you are not left blind.\n`,
+        );
+        finish(3);
+      } else {
+        d.writeStderr(
+          `monitor: warning — no daemon heartbeat for ${silenceSecs()}s, but the daemon PID is alive. Still watching.\n`,
+        );
+        armWatchdog();
+      }
+    }, d.livenessTimeoutMs) as ReturnType<typeof setTimeout>;
+    watchdogId.unref?.();
   };
 
   if (parsed.timeout !== undefined) {
@@ -211,8 +260,12 @@ export async function cmdMonitor(args: string[], deps?: Partial<MonitorDeps>): P
   let terminatorSatisfied = false;
   const untilRegex = parsed.until !== undefined ? globToRegex(parsed.until) : undefined;
 
+  // Arm before the first event so a daemon that dies immediately after bind is caught.
+  armWatchdog();
+
   try {
     for await (const event of events) {
+      armWatchdog();
       if (useJson) {
         d.writeStdout(`${JSON.stringify(event)}\n`);
       } else {
@@ -244,6 +297,7 @@ export async function cmdMonitor(args: string[], deps?: Partial<MonitorDeps>): P
     }
   } finally {
     if (timeoutId !== undefined) clearTimeout(timeoutId);
+    clearWatchdog();
   }
 
   if (!done && !terminatorSatisfied) {
@@ -252,6 +306,16 @@ export async function cmdMonitor(args: string[], deps?: Partial<MonitorDeps>): P
       done = true;
       d.writeStderr("monitor: stream ended before terminator\n");
       d.exit(2);
+    } else if (!d.checkDaemonLiveness()) {
+      // Passive monitor with no terminator: the stream ended on its own. In
+      // production openEventStream only ends when the socket closes, so a dead
+      // daemon here means the channel died under us (#2508). Never return 0
+      // blind — surface it loudly and exit non-zero.
+      done = true;
+      d.writeStderr(
+        "monitor: bound daemon vanished — the event stream closed and its PID/socket are gone. Exiting non-zero instead of silently returning.\n",
+      );
+      d.exit(3);
     }
   }
 }

--- a/packages/command/src/daemon-lifecycle.ts
+++ b/packages/command/src/daemon-lifecycle.ts
@@ -404,6 +404,19 @@ export function isDaemonInitializing(): boolean {
 }
 
 /**
+ * Non-destructive liveness probe for a bound daemon (#2508).
+ *
+ * True when the PID file is fresh, the process is alive and is actually mcpd,
+ * and the socket file still exists. Unlike isDaemonRunning() this never cleans
+ * stale files and never pings — safe to call repeatedly from a passive
+ * `mcx monitor` silence watchdog without racing the auto-start file dance.
+ */
+export function isDaemonPidAlive(): boolean {
+  if (readLivePidData() === null) return false;
+  return existsSync(options.SOCKET_PATH);
+}
+
+/**
  * Non-destructive daemon reachability check for polling during startup.
  *
  * Unlike isDaemonRunning(), this never calls cleanStaleFiles(). During the


### PR DESCRIPTION
## Summary
- `mcx monitor` could stay silently bound to a dead/orphaned daemon — no error, no timeout — leaving the orchestrator blind for hours (memorialized across 5 sprint-67 sessions). This is a liveness/failure-detection gap, distinct from the event-shape monitor epics (#1486/#1924/#1939).
- Add a **liveness watchdog** to `cmdMonitor`: re-armed on every received event, it fires after 3 missed daemon heartbeat windows (90s of total silence). On fire it probes the bound daemon — if its PID/socket are gone it exits **non-zero (3)** with a loud stderr message; if the process is somehow still alive it warns and keeps watching.
- Also close the quieter variant: an unexpected **stream-end with no terminator** now probes liveness and exits 3 (with a "bound daemon vanished" message) instead of silently returning 0.
- Add `isDaemonPidAlive()` — a non-destructive PID/socket probe (no stale-file cleanup, no ping) safe to poll from a passive monitor.

`mcx claude wait` is unaffected: it uses a blocking `claude_wait` RPC with a daemon-side timeout, so a dead socket already errors that path. The silent-corpse gap is specific to the streaming `monitor` channel.

Per the coordination note, changes to `packages/core/src/monitor-event.ts` were **not** required — the fix lives entirely in `packages/command`.

## Test plan
- [x] 4 new tests in `monitor.spec.ts`: watchdog exits 3 on dead daemon; watchdog warns + re-arms when PID alive; stream-end + dead daemon → exit 3; stream-end + live daemon → clean exit
- [x] `bun test packages/command/src/commands/monitor.spec.ts` — 71 pass
- [x] `bun test packages/command/src/daemon-lifecycle.spec.ts` — 61 pass
- [x] `bun run am-i-done` — full gate green (typecheck, lint, rules, tests, coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)