### PR TITLE
fix(test): drop sub-default pollUntil deadlines in idle-timeout tests (fixes #2853)

### DIFF
--- a/packages/daemon/src/index.spec.ts
+++ b/packages/daemon/src/index.spec.ts
@@ -315,7 +315,7 @@ describe("daemon index.ts", () => {
       const res = await rpc(socketPath, "shutdown");
       expect(res.result).toEqual({ ok: true });
 
-      await pollUntil(() => handle?.isShuttingDown, 1_000);
+      await pollUntil(() => handle?.isShuttingDown);
       expect(handle?.isShuttingDown).toBe(true);
     });
   });
@@ -347,7 +347,7 @@ describe("daemon index.ts", () => {
       opts = testOptions();
       await withDaemonTimeout("100", async () => {
         handle = await startTestDaemonInProcess();
-        await pollUntil(() => handle?.isShuttingDown, 500);
+        await pollUntil(() => handle?.isShuttingDown);
         expect(handle?.isShuttingDown).toBe(true);
       });
     });
@@ -366,7 +366,7 @@ describe("daemon index.ts", () => {
         }
 
         // Now stop pinging and let it idle out
-        await pollUntil(() => handle?.isShuttingDown, 1_000);
+        await pollUntil(() => handle?.isShuttingDown);
         expect(handle?.isShuttingDown).toBe(true);
       });
     });
@@ -375,7 +375,7 @@ describe("daemon index.ts", () => {
       opts = testOptions();
       await withDaemonTimeout("100", async () => {
         handle = await startTestDaemonInProcess();
-        await pollUntil(() => handle?.isShuttingDown, 500);
+        await pollUntil(() => handle?.isShuttingDown);
         expect(handle?.isShuttingDown).toBe(true);
       });
     });


### PR DESCRIPTION
## Summary
- Removes four legacy per-call `pollUntil` deadline arguments (`1_000ms` and `500ms`) from idle-timeout and shutdown-via-IPC-request tests in `packages/daemon/src/index.spec.ts`
- All four calls now rely on the 1500ms harness default per the `poll-until-headroom` rule
- No product code changes; pure test hygiene fix

## Test plan
- [ ] `bun test packages/daemon/src/index.spec.ts` — 51 pass, 0 fail (verified locally)
- [ ] Pre-push gate (`am-i-done`) passed — all 6 steps green
- [ ] The four modified `pollUntil` calls no longer carry hardcoded sub-default deadlines

🤖 Generated with [Claude Code](https://claude.com/claude-code)