### PR TITLE
fix(daemon): guard reload against silent daemon downgrade (fixes #2782)

### DIFF
--- a/packages/command/src/daemon-lifecycle.spec.ts
+++ b/packages/command/src/daemon-lifecycle.spec.ts
@@ -8,6 +8,7 @@ import { testOptions } from "../../../test/test-options";
 import {
   _buildStaleDaemonWarning,
   _formatReloadRefusal,
+  _isDaemonNewerThanCli,
   _isTransientConnectionError,
   _parseBuildEpoch,
   _resetStartCooldown,
@@ -510,6 +511,40 @@ describe("_buildStaleDaemonWarning", () => {
     expect(warning).toContain("1.0.0");
     expect(warning).toContain("1.1.0");
     expect(warning).toContain("mcx daemon reload");
+  });
+});
+
+// -- _isDaemonNewerThanCli (#2782 reload downgrade guard) --
+
+describe("_isDaemonNewerThanCli", () => {
+  it("returns false when daemon has no build version (predates tracking)", () => {
+    expect(_isDaemonNewerThanCli(undefined, "1.0.0+2000")).toBe(false);
+  });
+
+  it("returns false when versions match", () => {
+    expect(_isDaemonNewerThanCli("1.0.0+1000", "1.0.0+1000")).toBe(false);
+  });
+
+  it("returns true when daemon is compiled and CLI is dev", () => {
+    // Compiled daemon vs dev CLI — daemon is authoritative; reload would downgrade
+    expect(_isDaemonNewerThanCli("1.11.2+1779669196", "1.11.2-dev")).toBe(true);
+  });
+
+  it("returns false when CLI is compiled and daemon is dev", () => {
+    // Daemon dev, CLI compiled — daemon is stale; reload is a legit upgrade
+    expect(_isDaemonNewerThanCli("1.11.2-dev", "1.11.2+1779669196")).toBe(false);
+  });
+
+  it("returns true when daemon epoch is newer than CLI epoch", () => {
+    expect(_isDaemonNewerThanCli("1.0.0+2000000000", "1.0.0+1000000000")).toBe(true);
+  });
+
+  it("returns false when daemon epoch is older than CLI epoch", () => {
+    expect(_isDaemonNewerThanCli("1.0.0+1000000000", "1.0.0+2000000000")).toBe(false);
+  });
+
+  it("returns false when both are dev builds (no direction)", () => {
+    expect(_isDaemonNewerThanCli("0.1.0-dev", "0.2.0-dev")).toBe(false);
   });
 });
 

--- a/packages/command/src/daemon-lifecycle.ts
+++ b/packages/command/src/daemon-lifecycle.ts
@@ -552,6 +552,31 @@ export function getStaleDaemonWarning(): string | null {
   return _buildStaleDaemonWarning(data.buildVersion);
 }
 
+/** Read the build version of the currently-running (live) daemon from its PID file.
+ *  Returns undefined if no live daemon or the PID file predates build-version tracking. */
+export function getRunningDaemonBuildVersion(): string | undefined {
+  return readLivePidData()?.buildVersion;
+}
+
+/**
+ * True when the running daemon is a strictly newer build than the CLI, meaning a
+ * `reload` would silently downgrade the daemon to the (older) client's build (#2782).
+ * Mirrors the "use the build-matched client" cases in `_buildStaleDaemonWarning`.
+ */
+export function _isDaemonNewerThanCli(
+  daemonBuildVersion: string | undefined,
+  cliBuildVersion = BUILD_VERSION,
+): boolean {
+  if (!daemonBuildVersion || daemonBuildVersion === cliBuildVersion) return false;
+  const daemonEpoch = _parseBuildEpoch(daemonBuildVersion);
+  const cliEpoch = _parseBuildEpoch(cliBuildVersion);
+  // Compiled daemon, dev CLI — daemon is the newer/authoritative side (#2370).
+  if (daemonEpoch !== null && cliEpoch === null) return true;
+  // Both compiled — the higher epoch is newer.
+  if (daemonEpoch !== null && cliEpoch !== null) return daemonEpoch > cliEpoch;
+  return false;
+}
+
 /**
  * Extract the build epoch (Unix seconds) from BUILD_VERSION.
  * Returns null in dev mode (no epoch suffix).

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -16,6 +16,7 @@
 
 import type { DaemonStatus, QuotaStatusResult, ServerStatus } from "@mcp-cli/core";
 import {
+  BUILD_VERSION,
   IpcCallError,
   MCP_TOOL_TIMEOUT_MS,
   PING_TIMEOUT_MS,
@@ -70,6 +71,8 @@ import { cmdVfs } from "./commands/vfs";
 import {
   ShutdownRefusedError,
   _formatReloadRefusal,
+  _isDaemonNewerThanCli,
+  getRunningDaemonBuildVersion,
   getSourceStalenessWarning,
   getStaleDaemonWarning,
   ipcCall,
@@ -901,6 +904,17 @@ async function cmdDaemon(args: string[]): Promise<void> {
     // Unlike `restart` (force:true), reload defaults force:false so the daemon's
     // active-session guard holds — the fix for a build-mismatched (split-brain) daemon.
     const force = args.includes("--force");
+    const downgrade = args.includes("--downgrade");
+    // Direction check (#2782): a stale client must not silently downgrade a newer
+    // daemon. The new daemon auto-starts from the client's binary, so if the running
+    // daemon is newer, reloading inverts the build mismatch it's meant to fix.
+    const oldBuild = getRunningDaemonBuildVersion();
+    if (!downgrade && _isDaemonNewerThanCli(oldBuild)) {
+      printError(
+        `Refusing to reload: the running daemon (${oldBuild}) is newer than this client (${BUILD_VERSION}). Reloading would downgrade the daemon to the client's older build. Run \`mcx daemon reload\` from the newer binary (\`dist/mcx\` or the installed \`mcx\` on PATH), or pass --downgrade to override.`,
+      );
+      process.exit(1);
+    }
     console.error("Reloading daemon...");
     try {
       await stopDaemon({ force });
@@ -913,7 +927,8 @@ async function cmdDaemon(args: string[]): Promise<void> {
     }
     // Next ipcCall auto-starts a fresh build-matched daemon.
     await ipcCall("ping");
-    console.error("Daemon reloaded.");
+    const newBuild = getRunningDaemonBuildVersion();
+    console.error(`Daemon reloaded: build ${oldBuild ?? "unknown"} → ${newBuild ?? "unknown"}.`);
   } else if (sub === "shutdown" || sub === "stop") {
     const force = args.includes("--force");
     try {
@@ -927,7 +942,7 @@ async function cmdDaemon(args: string[]): Promise<void> {
     }
     console.error("Daemon shut down.");
   } else {
-    printError("Usage: mcx daemon restart|reload|shutdown [--force]");
+    printError("Usage: mcx daemon restart|reload|shutdown [--force] [--downgrade]");
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Summary
- `mcx daemon reload` now performs a build-direction check before stopping the daemon: if the running daemon is a **newer** build than the invoking client, it refuses with a clear error and suggests re-running from the newer binary (or passing `--downgrade` to override). This closes the silent-downgrade footgun where a stale client on PATH would promote its older build to daemon.
- On successful reload it echoes `Daemon reloaded: build <old> → <new>.` so any version change is visible.
- New pure predicate `_isDaemonNewerThanCli` + `getRunningDaemonBuildVersion()` in `daemon-lifecycle.ts`, reusing the existing `_parseBuildEpoch` direction logic (compiled-daemon-vs-dev-CLI and higher-epoch cases).

## Test plan
- [x] `bun run am-i-done` (typecheck + lint + rules + tests + coverage) — all passed
- [x] 7 new unit tests for `_isDaemonNewerThanCli` cover: no daemon version, equal versions, compiled-daemon/dev-CLI, dev-daemon/compiled-CLI, newer/older epochs, both-dev
- [x] Usage string updated to advertise `--downgrade`

🤖 Generated with [Claude Code](https://claude.com/claude-code)