### PR TITLE
fix(command): suppress spurious git diff error when worktree path is missing (fixes #2749)

### DIFF
--- a/packages/command/src/commands/session-deps.spec.ts
+++ b/packages/command/src/commands/session-deps.spec.ts
@@ -118,6 +118,11 @@ describe("defaultGetDiffStats", () => {
     const result = await defaultGetDiffStats(dir);
     expect(isLookupFailure(result)).toBe(true);
   });
+
+  test("returns null for nonexistent path (deleted worktree)", async () => {
+    const result = await defaultGetDiffStats("/tmp/mcp-nonexistent-worktree-xyzzy");
+    expect(result).toBeNull();
+  });
 });
 
 // ── defaultGetPrStatus ──
@@ -151,5 +156,10 @@ describe("defaultGetPrStatus", () => {
     dir = mkdtempSync(join(tmpdir(), "mcp-pr-test-"));
     const result = await defaultGetPrStatus(dir);
     expect(isLookupFailure(result)).toBe(true);
+  });
+
+  test("returns null for nonexistent path (deleted worktree)", async () => {
+    const result = await defaultGetPrStatus("/tmp/mcp-nonexistent-worktree-xyzzy");
+    expect(result).toBeNull();
   });
 });

--- a/packages/command/src/commands/session-deps.ts
+++ b/packages/command/src/commands/session-deps.ts
@@ -5,6 +5,7 @@
  * `claude.ts`, `agent.ts`, and `session-display.ts` share one implementation.
  */
 
+import { existsSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import type { LookupResult } from "@mcp-cli/core";
 import {
@@ -87,14 +88,20 @@ export function parseDiffShortstat(output: string): string | null {
 }
 
 export async function defaultGetDiffStats(worktreePath: string): Promise<LookupResult<string | null>> {
+  if (!existsSync(worktreePath)) return null;
   const result = await spawnCapture("git", ["diff", "--shortstat"], { cwd: worktreePath, env: cleanGitHookEnv() });
-  if (!result.ok) return lookupFailure(`git diff failed (exit ${result.exitCode}): ${result.stderr.trim()}`);
+  if (!result.ok) {
+    const exitDetail = result.exitCode !== null ? `exit ${result.exitCode}` : `signal ${result.signal ?? "unknown"}`;
+    const stderrDetail = result.stderr.trim();
+    return lookupFailure(`git diff failed (${exitDetail})${stderrDetail ? `: ${stderrDetail}` : ""}`);
+  }
   return parseDiffShortstat(result.stdout);
 }
 
 // ── PR status ──
 
 export async function defaultGetPrStatus(worktreePath: string): Promise<LookupResult<PrStatus | null>> {
+  if (!existsSync(worktreePath)) return null;
   const branchResult = await spawnCapture("git", ["branch", "--show-current"], {
     cwd: worktreePath,
     env: cleanGitHookEnv(),


### PR DESCRIPTION
## Summary
- `defaultGetDiffStats` and `defaultGetPrStatus` now return `null` (silent skip) when the worktree path no longer exists on disk, eliminating the `Error: git diff failed (exit null):` stderr noise on every `mcx claude ls` invocation
- Improved error message for process-killed failures: now reports `signal SIGTERM/SIGKILL` instead of the opaque `exit null`
- Applied the same existsSync guard to `defaultGetPrStatus` which had the identical vulnerability

## Test plan
- Added `"returns null for nonexistent path (deleted worktree)"` test to both `defaultGetDiffStats` and `defaultGetPrStatus` suites in `session-deps.spec.ts`
- Existing tests for non-git directories and valid git repos continue to pass
- `bun run am-i-done` passes (typecheck + lint + rules + tests + coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)