### PR TITLE
fix(auth): recover from revoked keychain refresh_token via interactive re-auth (fixes #2840)

### DIFF
--- a/packages/command/src/commands/auth.spec.ts
+++ b/packages/command/src/commands/auth.spec.ts
@@ -58,6 +58,14 @@ describe("extractAuthFlags", () => {
     expect(result.rest).toEqual(["server-name", "--unknown"]);
     expect(result.status).toBe(false);
     expect(result.help).toBe(false);
+    expect(result.force).toBe(false);
+  });
+
+  test("extracts --force and --reset flags", () => {
+    expect(extractAuthFlags(["srv", "--force"]).force).toBe(true);
+    const reset = extractAuthFlags(["srv", "--reset"]);
+    expect(reset.force).toBe(true);
+    expect(reset.rest).toEqual(["srv"]);
   });
 });
 
@@ -205,9 +213,28 @@ describe("cmdAuth <server>", () => {
 
     await cmdAuth(["notion"], deps);
 
-    expect(deps.ipcCall).toHaveBeenCalledWith("triggerAuth", { server: "notion" });
+    expect(deps.ipcCall).toHaveBeenCalledWith("triggerAuth", { server: "notion", force: false });
     expect(deps.errors[0]).toBe("Authenticating with notion...");
     expect(deps.errors[1]).toBe("Authenticated successfully");
+  });
+
+  test("--force passes force:true and notes it in the status line", async () => {
+    const result: TriggerAuthResult = { ok: true, message: "Authenticated successfully" };
+    const deps = makeDeps({ ipcCall: mock(() => Promise.resolve(result as never)) });
+
+    await cmdAuth(["notion", "--force"], deps);
+
+    expect(deps.ipcCall).toHaveBeenCalledWith("triggerAuth", { server: "notion", force: true });
+    expect(deps.errors[0]).toBe("Authenticating with notion (forcing clean re-auth)...");
+  });
+
+  test("--reset is an alias for --force", async () => {
+    const result: TriggerAuthResult = { ok: true, message: "Done" };
+    const deps = makeDeps({ ipcCall: mock(() => Promise.resolve(result as never)) });
+
+    await cmdAuth(["notion", "--reset"], deps);
+
+    expect(deps.ipcCall).toHaveBeenCalledWith("triggerAuth", { server: "notion", force: true });
   });
 
   test("outputs JSON with --json flag", async () => {

--- a/packages/command/src/commands/auth.ts
+++ b/packages/command/src/commands/auth.ts
@@ -33,9 +33,10 @@ Usage:
   mcx auth <server> --status    Check auth status without triggering login
 
 Flags:
-  --json, -j     Output as JSON
-  --status       Check status only (don't trigger auth flow)
-  --help, -h     Show this help`);
+  --json, -j       Output as JSON
+  --status         Check status only (don't trigger auth flow)
+  --force, --reset Drop the stored credential first, forcing a fresh browser flow
+  --help, -h       Show this help`);
 }
 
 export function statusLabel(s: ServerAuthStatus): string {
@@ -62,14 +63,22 @@ export function authSupportLabel(s: ServerAuthStatus): string {
   }
 }
 
-export function extractAuthFlags(args: string[]): { status: boolean; help: boolean; rest: string[] } {
+export function extractAuthFlags(args: string[]): {
+  status: boolean;
+  help: boolean;
+  force: boolean;
+  rest: string[];
+} {
   const rest: string[] = [];
   let status = false;
   let help = false;
+  let force = false;
 
   for (const arg of args) {
     if (arg === "--status") {
       status = true;
+    } else if (arg === "--force" || arg === "--reset") {
+      force = true;
     } else if (arg === "--help" || arg === "-h") {
       help = true;
     } else {
@@ -77,7 +86,7 @@ export function extractAuthFlags(args: string[]): { status: boolean; help: boole
     }
   }
 
-  return { status, help, rest };
+  return { status, help, force, rest };
 }
 
 export function stripAnsi(s: string): string {
@@ -91,7 +100,7 @@ export async function cmdAuth(args: string[], deps?: Partial<AuthDeps>): Promise
 
   // Extract flags
   const { json, rest: r1 } = extractJsonFlag(args);
-  const { status: statusOnly, help, rest } = extractAuthFlags(r1);
+  const { status: statusOnly, help, force, rest } = extractAuthFlags(r1);
 
   if (help) {
     printHelp(d.log);
@@ -148,8 +157,8 @@ export async function cmdAuth(args: string[], deps?: Partial<AuthDeps>): Promise
   }
 
   // Server specified without --status: trigger auth
-  d.logError(`Authenticating with ${server}...`);
-  const result = await d.ipcCall("triggerAuth", { server });
+  d.logError(`Authenticating with ${server}${force ? " (forcing clean re-auth)" : ""}...`);
+  const result = await d.ipcCall("triggerAuth", { server, force });
 
   if (json) {
     d.log(JSON.stringify({ ok: result.ok, message: result.message, server }, null, 2));

--- a/packages/core/src/ipc.ts
+++ b/packages/core/src/ipc.ts
@@ -130,6 +130,9 @@ export const GrepToolsParamsSchema = z.object({
 
 export const TriggerAuthParamsSchema = z.object({
   server: z.string(),
+  /** Force a clean re-auth: invalidate stored tokens before the flow so a
+   *  stale/revoked credential is not reused (skips waiting for API rejection). */
+  force: z.boolean().optional(),
 });
 
 export const AuthStatusParamsSchema = z.object({

--- a/packages/daemon/src/auth/oauth-provider.spec.ts
+++ b/packages/daemon/src/auth/oauth-provider.spec.ts
@@ -133,6 +133,40 @@ describe("McpOAuthProvider", () => {
       expect(tokens?.expires_in).toBeUndefined();
       db.close();
     });
+
+    test("skipKeychainTokens bypasses keychain fallback, returning undefined (refresh-retry path)", async () => {
+      const db = createDb();
+      // Keychain holds a (revoked) token — must NOT be served on the retry path.
+      mockReadKeychain.mockImplementation(() =>
+        Promise.resolve({ accessToken: "kc-revoked", refreshToken: "kc-revoked-refresh", clientId: "kc-client" }),
+      );
+
+      const provider = new McpOAuthProvider("srv", "https://api.example.com", db, {
+        skipKeychainTokens: true,
+        readKeychain: mockReadKeychain,
+      });
+      const tokens = await provider.tokens();
+
+      expect(tokens).toBeUndefined();
+      // Short-circuits before loadKeychain() is reached
+      expect(mockReadKeychain).not.toHaveBeenCalled();
+      db.close();
+    });
+
+    test("skipKeychainTokens does not affect SQLite tokens (SQLite still wins)", async () => {
+      const db = createDb();
+      db.saveTokens("srv", { access_token: "sqlite-tok", token_type: "Bearer" });
+      mockReadKeychain.mockImplementation(() => Promise.resolve({ accessToken: "kc", clientId: "kc-client" }));
+
+      const provider = new McpOAuthProvider("srv", "https://api.example.com", db, {
+        skipKeychainTokens: true,
+        readKeychain: mockReadKeychain,
+      });
+      const tokens = await provider.tokens();
+
+      expect(tokens?.access_token).toBe("sqlite-tok");
+      db.close();
+    });
   });
 
   // -- clientInformation() --

--- a/packages/daemon/src/auth/oauth-provider.ts
+++ b/packages/daemon/src/auth/oauth-provider.ts
@@ -50,6 +50,13 @@ export interface OAuthProviderOpts {
    * restored after deleteClientInfo() clears the SQLite row.
    */
   skipKeychainClientId?: boolean;
+  /**
+   * When true, skip the macOS Keychain fallback in tokens().
+   * Used by the refresh-retry path so a revoked keychain refresh_token is
+   * not re-served after invalidateCredentials("tokens") clears the SQLite
+   * row — otherwise the retry would loop on the same invalid_grant.
+   */
+  skipKeychainTokens?: boolean;
 }
 
 export class McpOAuthProvider implements OAuthClientProvider {
@@ -165,6 +172,9 @@ export class McpOAuthProvider implements OAuthClientProvider {
     if (dbTokens) return dbTokens;
 
     // 2. Check Keychain (Claude Code tokens)
+    //    Skipped when skipKeychainTokens is set (refresh-retry path — the
+    //    keychain entry may hold a revoked refresh_token we just invalidated).
+    if (this.opts.skipKeychainTokens) return undefined;
     const kc = await this.loadKeychain();
     if (kc) {
       const tokens: OAuthTokens = {

--- a/packages/daemon/src/auth/oauth-retry.spec.ts
+++ b/packages/daemon/src/auth/oauth-retry.spec.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { unlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { InvalidGrantError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
 import { StateDb } from "../db/state";
 import { metrics } from "../metrics";
 import { OAuthCallbackTimeoutError } from "./callback-server";
@@ -305,6 +306,131 @@ describe("runOAuthFlowWithDcrRetry", () => {
 
     // Only one attempt — access_denied is not a timeout, no retry
     expect(callbackNum).toBe(1);
+    db.close();
+  });
+
+  // -- invalid_grant (revoked/rotated refresh token) recovery (#2840) --
+
+  test("recovers from invalid_grant by retrying via browser (fresh authorization_code flow)", async () => {
+    const db = createDb();
+    const seenRefreshTokens: Array<string | undefined> = [];
+    let redirectCalls = 0;
+
+    const result = await runOAuthFlowWithDcrRetry(
+      SERVER,
+      SERVER_URL,
+      db,
+      {
+        // Keychain holds a refresh token that the server has revoked.
+        readKeychain: async (): Promise<KeychainTokens> =>
+          Promise.resolve({ accessToken: "kc-tok", refreshToken: "kc-revoked-refresh", clientId: "kc-client" }),
+      },
+      {
+        authFn: async (provider, authOpts) => {
+          if (authOpts.authorizationCode) return "AUTHORIZED";
+          redirectCalls++;
+          const toks = await (provider as { tokens(): Promise<{ refresh_token?: string } | undefined> }).tokens();
+          seenRefreshTokens.push(toks?.refresh_token);
+          // First attempt: SDK refresh throws invalid_grant. Retry: no token.
+          if (redirectCalls === 1) {
+            throw new InvalidGrantError("The refresh_token provided was invalid.");
+          }
+          return "REDIRECT";
+        },
+        startCallbackServer: () => makeCallback(Promise.resolve("code-fresh")),
+      },
+    );
+
+    expect(result).toBe("authenticated");
+    // First attempt sees the revoked keychain refresh token; retry skips the
+    // keychain fallback so no stale token is re-served (would loop otherwise).
+    expect(seenRefreshTokens).toEqual(["kc-revoked-refresh", undefined]);
+    db.close();
+  });
+
+  test("invalid_grant retry deletes SQLite tokens before the fresh flow", async () => {
+    const db = createDb();
+    db.saveTokens(SERVER, { access_token: "stale", token_type: "Bearer", refresh_token: "stale-refresh" });
+
+    let redirectCalls = 0;
+    await runOAuthFlowWithDcrRetry(
+      SERVER,
+      SERVER_URL,
+      db,
+      {},
+      {
+        authFn: async (_provider, authOpts) => {
+          if (authOpts.authorizationCode) return "AUTHORIZED";
+          redirectCalls++;
+          if (redirectCalls === 1) throw new InvalidGrantError("invalid refresh");
+          return "REDIRECT";
+        },
+        startCallbackServer: () => makeCallback(Promise.resolve("code-fresh")),
+      },
+    );
+
+    // Stale SQLite token was invalidated on the retry path
+    expect(db.getTokens(SERVER)).toBeUndefined();
+    db.close();
+  });
+
+  test("does not loop forever on repeated invalid_grant — rethrows after one retry", async () => {
+    const db = createDb();
+    let callbackNum = 0;
+
+    await expect(
+      runOAuthFlowWithDcrRetry(
+        SERVER,
+        SERVER_URL,
+        db,
+        {},
+        {
+          authFn: async (_provider, authOpts) => {
+            if (authOpts.authorizationCode) return "AUTHORIZED";
+            throw new InvalidGrantError("still invalid");
+          },
+          startCallbackServer: () => {
+            callbackNum++;
+            return makeCallback(Promise.resolve("code"));
+          },
+        },
+      ),
+    ).rejects.toThrow("still invalid");
+
+    // Exactly two attempts: initial + one retry
+    expect(callbackNum).toBe(2);
+    db.close();
+  });
+
+  test("increments oauth_refresh_retry_total{triggered,success} on invalid_grant recovery", async () => {
+    const db = createDb();
+    let redirectCalls = 0;
+
+    const snap = (outcome: string): number =>
+      metrics.toJSON().counters.find((c) => c.name === "oauth_refresh_retry_total" && c.labels?.outcome === outcome)
+        ?.value ?? 0;
+
+    const triggeredBefore = snap("triggered");
+    const successBefore = snap("success");
+
+    await runOAuthFlowWithDcrRetry(
+      SERVER,
+      SERVER_URL,
+      db,
+      {},
+      {
+        authFn: async (_provider, authOpts) => {
+          if (authOpts.authorizationCode) return "AUTHORIZED";
+          redirectCalls++;
+          if (redirectCalls === 1) throw new InvalidGrantError("invalid");
+          return "REDIRECT";
+        },
+        startCallbackServer: () => makeCallback(Promise.resolve("code-x")),
+      },
+    );
+
+    expect(snap("triggered") - triggeredBefore).toBe(1);
+    expect(snap("success") - successBefore).toBe(1);
     db.close();
   });
 

--- a/packages/daemon/src/auth/oauth-retry.spec.ts
+++ b/packages/daemon/src/auth/oauth-retry.spec.ts
@@ -434,6 +434,79 @@ describe("runOAuthFlowWithDcrRetry", () => {
     db.close();
   });
 
+  test("skipKeychainTokens opt bypasses the keychain token on the first attempt (--force plumbing)", async () => {
+    const db = createDb();
+    const seenRefreshTokens: Array<string | undefined> = [];
+    let redirectCalls = 0;
+
+    // --force threads skipKeychainTokens:true. A keychain token is present but
+    // must NEVER be served — the flow goes straight to a fresh browser auth with
+    // no invalid_grant round-trip (that round-trip is what --force must avoid).
+    const result = await runOAuthFlowWithDcrRetry(
+      SERVER,
+      SERVER_URL,
+      db,
+      {
+        skipKeychainTokens: true,
+        readKeychain: async (): Promise<KeychainTokens> =>
+          Promise.resolve({ accessToken: "kc-tok", refreshToken: "kc-revoked-refresh", clientId: "kc-client" }),
+      },
+      {
+        authFn: async (provider, authOpts) => {
+          if (authOpts.authorizationCode) return "AUTHORIZED";
+          redirectCalls++;
+          const toks = await (provider as { tokens(): Promise<{ refresh_token?: string } | undefined> }).tokens();
+          seenRefreshTokens.push(toks?.refresh_token);
+          return "REDIRECT";
+        },
+        startCallbackServer: () => makeCallback(Promise.resolve("code-fresh")),
+      },
+    );
+
+    expect(result).toBe("authenticated");
+    // Exactly one redirect (no invalid_grant retry) and the keychain refresh
+    // token was never surfaced — skipped from the very first attempt.
+    expect(redirectCalls).toBe(1);
+    expect(seenRefreshTokens).toEqual([undefined]);
+    db.close();
+  });
+
+  test("recovers from a DCR timeout AND a subsequent invalid_grant in one flow (independent budgets)", async () => {
+    const db = createDb();
+    let callbackNum = 0;
+    let redirectCalls = 0;
+
+    // Server burns client_ids (DCR timeout) and holds a revoked refresh token.
+    // Both recoveries must fire in a single flow — a shared retry budget would
+    // let the DCR retry starve the invalid_grant retry (or vice versa).
+    const result = await runOAuthFlowWithDcrRetry(
+      SERVER,
+      SERVER_URL,
+      db,
+      {},
+      {
+        authFn: async (_provider, authOpts) => {
+          if (authOpts.authorizationCode) return "AUTHORIZED";
+          redirectCalls++;
+          // After the DCR retry, the second attempt hits the revoked token.
+          if (redirectCalls === 2) throw new InvalidGrantError("revoked");
+          return "REDIRECT";
+        },
+        startCallbackServer: () => {
+          callbackNum++;
+          // First attempt times out → burns client_id → DCR retry.
+          if (callbackNum === 1) return makeCallback(Promise.reject(new OAuthCallbackTimeoutError()));
+          return makeCallback(Promise.resolve("code-fresh"));
+        },
+      },
+    );
+
+    expect(result).toBe("authenticated");
+    // initial (timeout) + DCR retry (invalid_grant) + invalid_grant retry = 3
+    expect(callbackNum).toBe(3);
+    db.close();
+  });
+
   test("regression: happy path makes exactly two auth calls, no client info deleted", async () => {
     const db = createDb();
     db.saveClientInfo(SERVER, { client_id: "live-client" });

--- a/packages/daemon/src/auth/oauth-retry.ts
+++ b/packages/daemon/src/auth/oauth-retry.ts
@@ -62,7 +62,10 @@ export async function runOAuthFlowWithDcrRetry(
   server: string,
   serverUrl: string,
   db: StateDb,
-  opts: Pick<OAuthProviderOpts, "clientId" | "clientSecret" | "callbackPort" | "scope" | "readKeychain">,
+  opts: Pick<
+    OAuthProviderOpts,
+    "clientId" | "clientSecret" | "callbackPort" | "scope" | "readKeychain" | "skipKeychainTokens"
+  >,
   deps?: OAuthRetryDeps,
 ): Promise<"already_authorized" | "authenticated"> {
   if (activeAuthFlows.has(server)) {
@@ -80,7 +83,10 @@ async function _runFlow(
   server: string,
   serverUrl: string,
   db: StateDb,
-  opts: Pick<OAuthProviderOpts, "clientId" | "clientSecret" | "callbackPort" | "scope" | "readKeychain">,
+  opts: Pick<
+    OAuthProviderOpts,
+    "clientId" | "clientSecret" | "callbackPort" | "scope" | "readKeychain" | "skipKeychainTokens"
+  >,
   deps?: OAuthRetryDeps,
 ): Promise<"already_authorized" | "authenticated"> {
   const doAuth =
@@ -88,15 +94,19 @@ async function _runFlow(
     ((provider: OAuthClientProvider, authOpts: { serverUrl: string; scope?: string; authorizationCode?: string }) =>
       auth(provider, authOpts));
   const makeCallback = deps?.startCallbackServer ?? startCallbackServer;
-  const MAX_RETRIES = 1;
 
-  // Recovery flags carried into the retry attempt. Independent: a DCR timeout
-  // burns the keychain client_id; an invalid_grant burns the keychain tokens.
+  // Two independent one-shot recoveries: a DCR timeout burns the keychain
+  // client_id; an invalid_grant burns the keychain tokens. Each gets its own
+  // budget (a shared counter would let one starve the other), so a server that
+  // needs both can recover from both. Total attempts are still bounded to
+  // initial + one retry per cause.
   let skipKeychainClientId = false;
-  let skipKeychainTokens = false;
-  let retriedForInvalidGrant = false;
+  let skipKeychainTokens = opts.skipKeychainTokens ?? false;
+  let dcrRetried = false;
+  let invalidGrantRetried = false;
+  const MAX_ATTEMPTS = 3;
 
-  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
     const callback = makeCallback(opts.callbackPort);
     try {
       const provider = new McpOAuthProvider(server, serverUrl, db, {
@@ -115,19 +125,20 @@ async function _runFlow(
       // result === "REDIRECT" — browser opened; wait for the authorization code
       const code = await callback.waitForCode;
       await doAuth(provider, { serverUrl, authorizationCode: code });
-      if (skipKeychainClientId) {
+      if (dcrRetried) {
         metrics.counter("oauth_dcr_retry_total", { server, outcome: "success" }).inc();
       }
-      if (retriedForInvalidGrant) {
+      if (invalidGrantRetried) {
         metrics.counter("oauth_refresh_retry_total", { server, outcome: "success" }).inc();
       }
       return "authenticated";
     } catch (err) {
       const isTimeout = err instanceof OAuthCallbackTimeoutError;
-      if (isTimeout && attempt < MAX_RETRIES) {
+      if (isTimeout && !dcrRetried) {
         console.error(
           "[auth] OAuth callback timed out (possibly 5xx on authorize) — deleting cached client registration and retrying...",
         );
+        dcrRetried = true;
         skipKeychainClientId = true;
         db.deleteClientInfo(server);
         continue;
@@ -139,15 +150,15 @@ async function _runFlow(
           { cause: err },
         );
       }
-      if (isInvalidGrantError(err) && attempt < MAX_RETRIES) {
+      if (isInvalidGrantError(err) && !invalidGrantRetried) {
         console.error(
           `[auth] refresh token for "${server}" was rejected (invalid_grant) — clearing stored tokens and retrying via browser...`,
         );
         // Delete SQLite tokens; the retry provider skips the keychain fallback
         // so the revoked refresh_token is not re-served (would loop otherwise).
         new McpOAuthProvider(server, serverUrl, db).invalidateCredentials("tokens");
+        invalidGrantRetried = true;
         skipKeychainTokens = true;
-        retriedForInvalidGrant = true;
         metrics.counter("oauth_refresh_retry_total", { server, outcome: "triggered" }).inc();
         continue;
       }

--- a/packages/daemon/src/auth/oauth-retry.ts
+++ b/packages/daemon/src/auth/oauth-retry.ts
@@ -10,6 +10,7 @@
 
 import { auth } from "@modelcontextprotocol/sdk/client/auth.js";
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import { InvalidGrantError, OAuthError } from "@modelcontextprotocol/sdk/server/auth/errors.js";
 import type { StateDb } from "../db/state";
 import { metrics } from "../metrics";
 import { type CallbackServer, OAuthCallbackTimeoutError, startCallbackServer } from "./callback-server";
@@ -28,6 +29,17 @@ export class AuthFlowInProgressError extends Error {
 /** @internal Reset for test isolation. */
 export function _resetActiveAuthFlows(): void {
   activeAuthFlows.clear();
+}
+
+/**
+ * True when the error is an OAuth `invalid_grant` — i.e. the refresh_token
+ * was rejected (revoked/rotated/expired). The SDK constructs an
+ * `InvalidGrantError` for the `invalid_grant` code; the `errorCode` check is a
+ * belt-and-suspenders guard against instanceof gaps (duplicate SDK copies).
+ */
+function isInvalidGrantError(err: unknown): boolean {
+  if (err instanceof InvalidGrantError) return true;
+  return err instanceof OAuthError && err.errorCode === "invalid_grant";
 }
 
 export interface OAuthRetryDeps {
@@ -78,13 +90,19 @@ async function _runFlow(
   const makeCallback = deps?.startCallbackServer ?? startCallbackServer;
   const MAX_RETRIES = 1;
 
+  // Recovery flags carried into the retry attempt. Independent: a DCR timeout
+  // burns the keychain client_id; an invalid_grant burns the keychain tokens.
+  let skipKeychainClientId = false;
+  let skipKeychainTokens = false;
+  let retriedForInvalidGrant = false;
+
   for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
-    const skipKeychainClientId = attempt > 0;
     const callback = makeCallback(opts.callbackPort);
     try {
       const provider = new McpOAuthProvider(server, serverUrl, db, {
         ...opts,
         skipKeychainClientId,
+        skipKeychainTokens,
       });
       provider.setRedirectUrl(callback.url);
       const authScope = provider.getEffectiveScope() ?? DEFAULT_OAUTH_SCOPE;
@@ -100,6 +118,9 @@ async function _runFlow(
       if (skipKeychainClientId) {
         metrics.counter("oauth_dcr_retry_total", { server, outcome: "success" }).inc();
       }
+      if (retriedForInvalidGrant) {
+        metrics.counter("oauth_refresh_retry_total", { server, outcome: "success" }).inc();
+      }
       return "authenticated";
     } catch (err) {
       const isTimeout = err instanceof OAuthCallbackTimeoutError;
@@ -107,6 +128,7 @@ async function _runFlow(
         console.error(
           "[auth] OAuth callback timed out (possibly 5xx on authorize) — deleting cached client registration and retrying...",
         );
+        skipKeychainClientId = true;
         db.deleteClientInfo(server);
         continue;
       }
@@ -116,6 +138,18 @@ async function _runFlow(
           "OAuth callback timed out twice; no recovery available — authorization failed after DCR retry",
           { cause: err },
         );
+      }
+      if (isInvalidGrantError(err) && attempt < MAX_RETRIES) {
+        console.error(
+          `[auth] refresh token for "${server}" was rejected (invalid_grant) — clearing stored tokens and retrying via browser...`,
+        );
+        // Delete SQLite tokens; the retry provider skips the keychain fallback
+        // so the revoked refresh_token is not re-served (would loop otherwise).
+        new McpOAuthProvider(server, serverUrl, db).invalidateCredentials("tokens");
+        skipKeychainTokens = true;
+        retriedForInvalidGrant = true;
+        metrics.counter("oauth_refresh_retry_total", { server, outcome: "triggered" }).inc();
+        continue;
       }
       throw err;
     } finally {

--- a/packages/daemon/src/handlers/auth.ts
+++ b/packages/daemon/src/handlers/auth.ts
@@ -55,9 +55,16 @@ export class AuthHandlers {
       const serverConfig = this.pool.getServerConfig(server);
       const { clientId, clientSecret, callbackPort, scope } = serverConfig ?? {};
 
-      // --force: drop stored tokens up front so a stale/revoked credential is
+      // Which store the credential came from — captured BEFORE --force deletes
+      // the SQLite row below, so the failure message names the real source.
+      const store = poolDb.getTokens(server) ? "mcx (SQLite)" : "the macOS Keychain (Claude Code)";
+
+      // --force: drop the stored credential up front so a stale/revoked token is
       // not reused, forcing a clean interactive flow without waiting for the
-      // token endpoint to reject it.
+      // token endpoint to reject it. Deleting the SQLite row alone is not enough:
+      // the keychain is read-only to mcx, so we also pass skipKeychainTokens to
+      // bypass the keychain fallback — otherwise a keychain-stored token (the
+      // #2840 scenario) would still be served and --force would be a no-op.
       if (force) {
         new McpOAuthProvider(server, serverUrl, poolDb).invalidateCredentials("tokens");
       }
@@ -69,11 +76,11 @@ export class AuthHandlers {
           clientSecret,
           callbackPort,
           scope,
+          skipKeychainTokens: force,
         });
       } catch (err) {
         // Name the server + credential store + recovery path. The bare SDK
         // message ("The refresh_token provided was invalid.") gave no context.
-        const store = poolDb.getTokens(server) ? "mcx (SQLite)" : "the macOS Keychain (Claude Code)";
         const detail = err instanceof Error ? err.message : String(err);
         throw Object.assign(
           new Error(

--- a/packages/daemon/src/handlers/auth.ts
+++ b/packages/daemon/src/handlers/auth.ts
@@ -16,7 +16,7 @@ export class AuthHandlers {
 
   register(handlers: Map<IpcMethod, RequestHandler>): void {
     handlers.set("triggerAuth", async (params, _ctx) => {
-      const { server } = TriggerAuthParamsSchema.parse(params);
+      const { server, force } = TriggerAuthParamsSchema.parse(params);
       const serverUrl = this.pool.getServerUrl(server);
 
       // Non-remote server — check for `auth` tool convention
@@ -55,12 +55,35 @@ export class AuthHandlers {
       const serverConfig = this.pool.getServerConfig(server);
       const { clientId, clientSecret, callbackPort, scope } = serverConfig ?? {};
 
-      const flowResult = await runOAuthFlowWithDcrRetry(server, serverUrl, poolDb, {
-        clientId,
-        clientSecret,
-        callbackPort,
-        scope,
-      });
+      // --force: drop stored tokens up front so a stale/revoked credential is
+      // not reused, forcing a clean interactive flow without waiting for the
+      // token endpoint to reject it.
+      if (force) {
+        new McpOAuthProvider(server, serverUrl, poolDb).invalidateCredentials("tokens");
+      }
+
+      let flowResult: Awaited<ReturnType<typeof runOAuthFlowWithDcrRetry>>;
+      try {
+        flowResult = await runOAuthFlowWithDcrRetry(server, serverUrl, poolDb, {
+          clientId,
+          clientSecret,
+          callbackPort,
+          scope,
+        });
+      } catch (err) {
+        // Name the server + credential store + recovery path. The bare SDK
+        // message ("The refresh_token provided was invalid.") gave no context.
+        const store = poolDb.getTokens(server) ? "mcx (SQLite)" : "the macOS Keychain (Claude Code)";
+        const detail = err instanceof Error ? err.message : String(err);
+        throw Object.assign(
+          new Error(
+            `Authentication for "${server}" failed: ${detail}\n` +
+              `The stored credential (from ${store}) could not be used and automatic browser re-auth did not complete.\n` +
+              `Retry with: mcx auth ${server} --force  (drops the stored credential and forces a fresh browser flow).`,
+          ),
+          { code: IPC_ERROR.INTERNAL_ERROR },
+        );
+      }
 
       await this.pool.restart(server);
 


### PR DESCRIPTION
## Summary
- `mcx auth <server>` no longer hard-fails on a stale/revoked keychain `refresh_token`. The OAuth retry loop now catches `InvalidGrantError`, invalidates stored tokens, and retries once via a fresh interactive (browser) authorization_code flow.
- New `skipKeychainTokens` provider bypass (mirrors the `skipKeychainClientId` DCR fix from #1546) so the retry does not re-serve the revoked keychain token and loop forever.
- New `mcx auth <server> --force` / `--reset` flag to drop the stored credential up front and force a clean flow without waiting for API rejection.
- Terminal auth failures now name the server, the credential store (Keychain vs SQLite), and the recovery command, replacing the bare `Error: The refresh_token provided was invalid.`
- Added `oauth_refresh_retry_total{outcome}` metric for observability.

## Root cause (verified against @modelcontextprotocol/sdk 1.29.0)
- SDK `client/auth.js:290` re-throws `InvalidGrantError` (an `OAuthError`, not a `ServerError`) instead of falling through to a new authorization flow.
- `oauth-retry.ts` `_runFlow` only caught `OAuthCallbackTimeoutError`; everything else propagated as a hard failure.
- `tokens()` fell back to the Keychain, so a naive retry re-served the same revoked token.

## Test plan
- [x] `bun run am-i-done` (exit 0: typecheck, lint, rules, tests, coverage)
- [x] `oauth-retry.spec.ts`: invalid_grant → single browser retry; SQLite tokens invalidated; no infinite loop on repeated invalid_grant; `oauth_refresh_retry_total` triggered+success metrics
- [x] `oauth-provider.spec.ts`: `tokens()` skips keychain when `skipKeychainTokens` set; SQLite still wins
- [x] `auth.spec.ts`: `--force`/`--reset` parse; `force` threaded through `triggerAuth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)