### PR TITLE
fix(daemon): diagnose worker-dispatch async rejection + gate argv provenance (fixes #2835)

### DIFF
--- a/packages/daemon/src/alias-server.ts
+++ b/packages/daemon/src/alias-server.ts
@@ -339,6 +339,10 @@ export class AliasServer {
       const result = await spawnCapture(process.execPath, [this.executorPath], {
         input: stdinPayload,
         timeoutMs,
+        // Corroborate the worker dispatch in main.ts's resolveWorkerEntry: only a
+        // daemon-spawned executor carries this sentinel (#2835). env is
+        // pass-through (replaces, not merges), so spread the parent env.
+        env: { ...process.env, MCPD_WORKER: "1" },
       });
 
       if (result.ok && result.stderr.trim()) {

--- a/packages/daemon/src/main.spec.ts
+++ b/packages/daemon/src/main.spec.ts
@@ -1,34 +1,41 @@
 import { describe, expect, test } from "bun:test";
 import { resolveWorkerEntry } from "./main";
 
+const WORKER_ENV = { MCPD_WORKER: "1" };
+
 describe("resolveWorkerEntry", () => {
   test("returns canonical entry for ./alias-executor.ts", () => {
-    expect(resolveWorkerEntry(["/path/to/mcpd", "./alias-executor.ts"])).toBe("alias-executor.ts");
+    expect(resolveWorkerEntry(["/path/to/mcpd", "./alias-executor.ts"], WORKER_ENV)).toBe("alias-executor.ts");
   });
 
   test("returns canonical entry for absolute path ending in alias-executor.ts (dev)", () => {
-    expect(resolveWorkerEntry(["/path/to/mcpd", "/some/dir/alias-executor.ts"])).toBe("alias-executor.ts");
+    expect(resolveWorkerEntry(["/path/to/mcpd", "/some/dir/alias-executor.ts"], WORKER_ENV)).toBe("alias-executor.ts");
   });
 
   test("returns canonical entry for resolved embedded .js path (compiled, #2821)", () => {
-    expect(resolveWorkerEntry(["/path/to/mcpd", "/$bunfs/root/packages/daemon/src/alias-executor.js"])).toBe(
-      "alias-executor.ts",
-    );
+    expect(
+      resolveWorkerEntry(["/path/to/mcpd", "/$bunfs/root/packages/daemon/src/alias-executor.js"], WORKER_ENV),
+    ).toBe("alias-executor.ts");
   });
 
   test("returns canonical entry for ./alias-executor.js", () => {
-    expect(resolveWorkerEntry(["/path/to/mcpd", "./alias-executor.js"])).toBe("alias-executor.ts");
+    expect(resolveWorkerEntry(["/path/to/mcpd", "./alias-executor.js"], WORKER_ENV)).toBe("alias-executor.ts");
   });
 
   test("returns undefined for normal daemon startup (no args)", () => {
-    expect(resolveWorkerEntry(["/path/to/mcpd"])).toBeUndefined();
+    expect(resolveWorkerEntry(["/path/to/mcpd"], WORKER_ENV)).toBeUndefined();
   });
 
   test("returns undefined for empty argv", () => {
-    expect(resolveWorkerEntry([])).toBeUndefined();
+    expect(resolveWorkerEntry([], WORKER_ENV)).toBeUndefined();
   });
 
   test("returns undefined for unrecognized worker path", () => {
-    expect(resolveWorkerEntry(["/path/to/mcpd", "./not-a-worker.ts"])).toBeUndefined();
+    expect(resolveWorkerEntry(["/path/to/mcpd", "./not-a-worker.ts"], WORKER_ENV)).toBeUndefined();
+  });
+
+  test("returns undefined for matching argv without the MCPD_WORKER sentinel (#2835)", () => {
+    expect(resolveWorkerEntry(["/path/to/mcpd", "/any/path/alias-executor.js"], {})).toBeUndefined();
+    expect(resolveWorkerEntry(["/path/to/mcpd", "./alias-executor.ts"], {})).toBeUndefined();
   });
 });

--- a/packages/daemon/src/main.ts
+++ b/packages/daemon/src/main.ts
@@ -35,8 +35,15 @@ function entryStem(name: string): string {
  * (`/$bunfs/…`), `.ts` in dev. Matching a literal `.ts` suffix therefore misses
  * the compiled dispatch and starts a second daemon (#2821), so match the stem
  * against both extensions.
+ *
+ * The raw positional argv is attacker-controllable, so the match alone is not
+ * proof of a genuine worker dispatch: a `mcpd <path-ending-in-alias-executor.js>`
+ * call from outside the daemon would otherwise route into the executor. Gate on
+ * the `MCPD_WORKER` sentinel that the spawner sets (`alias-server.ts`) so only a
+ * daemon-spawned subprocess is routed (#2835).
  */
-export function resolveWorkerEntry(argv: string[]): string | undefined {
+export function resolveWorkerEntry(argv: string[], env: NodeJS.ProcessEnv = process.env): string | undefined {
+  if (!env.MCPD_WORKER) return undefined;
   const lastArg = argv.at(-1);
   if (!lastArg) return undefined;
   for (const entry of WORKER_ENTRIES) {
@@ -96,7 +103,16 @@ if (import.meta.main) {
     // predicted literal path: the embedded module layout is Bun-outbase
     // dependent (#2801), and a predicted `./alias-executor.ts` fails to
     // resolve in the compiled binary's module graph (#2821).
-    import(workerPath(workerEntry));
+    //
+    // The dynamic import is awaited inside an IIFE so a rejecting embedded
+    // module init surfaces a loud `[mcpd]` diagnostic and a non-zero exit,
+    // rather than a bare Bun unhandledRejection with no guaranteed exit (#2835).
+    (async () => {
+      await import(workerPath(workerEntry));
+    })().catch((err) => {
+      console.error("[mcpd] worker dispatch failed:", err);
+      process.exit(1);
+    });
   } else {
     main().catch((err) => {
       console.error("[mcpd] Fatal:", err);


### PR DESCRIPTION
## Summary
- Wrap the compiled-mode worker `import()` in an awaited async IIFE with a `.catch` so a rejecting embedded-module init surfaces a loud `[mcpd] worker dispatch failed:` diagnostic and a guaranteed non-zero exit, instead of a silent Bun `unhandledRejection` (Gap 1, main.ts).
- Gate `resolveWorkerEntry` on an `MCPD_WORKER` env sentinel set by the spawner in `alias-server.ts`, so a crafted argv ending in `alias-executor.js|.ts` from outside a genuine daemon spawn no longer routes into the executor (Gap 2). Chose the env-sentinel approach over the `/$bunfs/` prefix check because it corroborates in both dev and compiled mode.
- `env` in `spawnCapture` is pass-through (replaces, not merges), so the spawner spreads `process.env` alongside the sentinel.

## Test plan
- [x] `bun run am-i-done` (typecheck, lint, rules, tests, coverage) — all green
- [x] Updated `main.spec.ts` to pass the sentinel env in the existing dispatch cases
- [x] Added a test asserting a matching argv **without** `MCPD_WORKER` returns `undefined`
- [x] Rebased onto origin/main (includes #2851) — no drift in the touched `alias-server.ts` region

🤖 Generated with [Claude Code](https://claude.com/claude-code)