### PR TITLE
fix(gc): reclaim squash-merged and closed-PR worktrees via PR state (fixes #2662)

### DIFF
--- a/packages/command/src/commands/gc.spec.ts
+++ b/packages/command/src/commands/gc.spec.ts
@@ -65,6 +65,8 @@ function makeDeps(
     callTool?: GcDeps["callTool"];
     mtimes?: Map<string, number>;
     mergedPrBranches?: Set<string> | null;
+    /** Branches whose PR is MERGED or CLOSED (worktree-reclaim signal). Defaults to `mergedPrBranches`. */
+    resolvedPrBranches?: Set<string>;
   } = {},
 ): GcDeps & { logs: string[]; errors: string[]; execCalls: string[][] } {
   const logs: string[] = [];
@@ -85,7 +87,14 @@ function makeDeps(
     callTool: overrides.callTool ?? (async () => "[]"),
     exec,
     getMtime: (p) => overrides.mtimes?.get(p) ?? null,
-    queryMergedPrBranches: () => (overrides.mergedPrBranches !== undefined ? overrides.mergedPrBranches : null),
+    queryPrBranches: () => {
+      if (overrides.mergedPrBranches === undefined && overrides.resolvedPrBranches === undefined) return null;
+      if (overrides.mergedPrBranches === null) return null;
+      const merged = overrides.mergedPrBranches ?? new Set<string>();
+      // resolved is a superset of merged; default it to merged when not given.
+      const resolved = new Set<string>([...merged, ...(overrides.resolvedPrBranches ?? [])]);
+      return { merged, resolved };
+    },
     printError: (m) => errors.push(m),
     printInfo: (m) => logs.push(m),
     log: (m) => logs.push(m),
@@ -311,6 +320,38 @@ describe("runGc worktrees", () => {
 
     expect(d.logs.some((l) => l.includes("would remove 0"))).toBe(true);
     expect(d.logs.some((l) => l.includes("2 skipped (unmerged)"))).toBe(true);
+  });
+
+  test("reclaims squash-merged worktree via PR state when ancestry check misses it (#2662)", async () => {
+    const responses = makeWorktreeResponses();
+    // feat-a squash-merged (not an ancestor of main → absent from --merged);
+    // feat-b genuinely unmerged with no resolved PR.
+    responses.set("git -C /repo branch --merged main", { stdout: "* main\n" });
+
+    const d = makeDeps({
+      execResponses: responses,
+      // feat-a's PR is MERGED (squash); resolvedPrBranches carries the signal.
+      resolvedPrBranches: new Set(["feat-a"]),
+    });
+
+    await runGc({ dryRun: true, olderThanMs: 86_400_000, branchesOnly: false, worktreesOnly: true }, d);
+
+    // feat-a reclaimed via PR state; feat-b still skipped as unmerged.
+    expect(d.logs.some((l) => l.includes("would remove 1"))).toBe(true);
+    expect(d.logs.some((l) => l.includes("wt-a"))).toBe(true);
+    expect(d.logs.some((l) => l.includes("1 skipped (unmerged)"))).toBe(true);
+  });
+
+  test("warns when GitHub API is unavailable but still prunes ancestry-merged worktrees", async () => {
+    const responses = makeWorktreeResponses();
+    // wt-a/wt-b are ancestry-merged; gh is unavailable (default null).
+    const d = makeDeps({ execResponses: responses });
+
+    await runGc({ dryRun: true, olderThanMs: 86_400_000, branchesOnly: false, worktreesOnly: true }, d);
+
+    expect(d.errors.some((e) => e.includes("squash-merged/closed worktrees may not be reclaimed"))).toBe(true);
+    // Ancestry-merged worktrees are still reclaimed even offline.
+    expect(d.logs.some((l) => l.includes("would remove 2"))).toBe(true);
   });
 
   test("active-session worktree is skipped even without age filter", async () => {

--- a/packages/command/src/commands/gc.spec.ts
+++ b/packages/command/src/commands/gc.spec.ts
@@ -65,8 +65,8 @@ function makeDeps(
     callTool?: GcDeps["callTool"];
     mtimes?: Map<string, number>;
     mergedPrBranches?: Set<string> | null;
-    /** Branches whose PR is MERGED or CLOSED (worktree-reclaim signal). Defaults to `mergedPrBranches`. */
-    resolvedPrBranches?: Set<string>;
+    /** Branch → PR head SHA for MERGED/CLOSED PRs (worktree-reclaim signal). Merges with `mergedPrBranches`. */
+    resolvedPrBranches?: Map<string, string>;
   } = {},
 ): GcDeps & { logs: string[]; errors: string[]; execCalls: string[][] } {
   const logs: string[] = [];
@@ -91,8 +91,12 @@ function makeDeps(
       if (overrides.mergedPrBranches === undefined && overrides.resolvedPrBranches === undefined) return null;
       if (overrides.mergedPrBranches === null) return null;
       const merged = overrides.mergedPrBranches ?? new Set<string>();
-      // resolved is a superset of merged; default it to merged when not given.
-      const resolved = new Set<string>([...merged, ...(overrides.resolvedPrBranches ?? [])]);
+      // resolved is a superset of merged; each branch maps to its PR head SHA.
+      const resolved = new Map<string, string>();
+      for (const b of merged) resolved.set(b, overrides.resolvedPrBranches?.get(b) ?? "prheadsha");
+      if (overrides.resolvedPrBranches) {
+        for (const [b, sha] of overrides.resolvedPrBranches) resolved.set(b, sha);
+      }
       return { merged, resolved };
     },
     printError: (m) => errors.push(m),
@@ -327,11 +331,19 @@ describe("runGc worktrees", () => {
     // feat-a squash-merged (not an ancestor of main → absent from --merged);
     // feat-b genuinely unmerged with no resolved PR.
     responses.set("git -C /repo branch --merged main", { stdout: "* main\n" });
+    // Ahead-of-forge guard: feat-a's tip matches origin (0 ahead) → safe.
+    responses.set("git -C /repo/.claude/worktrees/wt-a rev-parse HEAD", { stdout: "sha-a" });
+    responses.set("git -C /repo/.claude/worktrees/wt-a rev-parse --verify --quiet refs/remotes/origin/feat-a", {
+      stdout: "sha-a",
+    });
+    responses.set("git -C /repo/.claude/worktrees/wt-a rev-list --count refs/remotes/origin/feat-a..HEAD", {
+      stdout: "0",
+    });
 
     const d = makeDeps({
       execResponses: responses,
-      // feat-a's PR is MERGED (squash); resolvedPrBranches carries the signal.
-      resolvedPrBranches: new Set(["feat-a"]),
+      // feat-a's PR is MERGED (squash); resolvedPrBranches carries the signal + head SHA.
+      resolvedPrBranches: new Map([["feat-a", "sha-a"]]),
     });
 
     await runGc({ dryRun: true, olderThanMs: 86_400_000, branchesOnly: false, worktreesOnly: true }, d);
@@ -340,6 +352,55 @@ describe("runGc worktrees", () => {
     expect(d.logs.some((l) => l.includes("would remove 1"))).toBe(true);
     expect(d.logs.some((l) => l.includes("wt-a"))).toBe(true);
     expect(d.logs.some((l) => l.includes("1 skipped (unmerged)"))).toBe(true);
+  });
+
+  test("does NOT reclaim a closed-PR worktree whose clean tip is ahead of the forge (#2662 data-loss guard)", async () => {
+    const responses = makeWorktreeResponses();
+    // feat-a not ancestry-merged; its PR is CLOSED. Author committed locally
+    // after close → clean tree, but tip is ahead of origin/feat-a.
+    responses.set("git -C /repo branch --merged main", { stdout: "* main\n" });
+    responses.set("git -C /repo/.claude/worktrees/wt-a rev-parse HEAD", { stdout: "local-ahead-sha" });
+    responses.set("git -C /repo/.claude/worktrees/wt-a rev-parse --verify --quiet refs/remotes/origin/feat-a", {
+      stdout: "origin-sha",
+    });
+    // 2 unpushed commits.
+    responses.set("git -C /repo/.claude/worktrees/wt-a rev-list --count refs/remotes/origin/feat-a..HEAD", {
+      stdout: "2",
+    });
+
+    const d = makeDeps({
+      execResponses: responses,
+      resolvedPrBranches: new Map([["feat-a", "origin-sha"]]),
+    });
+
+    await runGc({ dryRun: true, olderThanMs: 86_400_000, branchesOnly: false, worktreesOnly: true }, d);
+
+    // feat-a must NOT be reclaimed — its unpushed commits would be orphaned.
+    expect(d.logs.some((l) => l.includes("would remove 0"))).toBe(true);
+    expect(d.logs.some((l) => l.includes("1 skipped (unpushed commits)"))).toBe(true);
+    expect(d.logs.some((l) => l.includes("wt-a") && l.includes("- "))).toBe(false);
+  });
+
+  test("reclaims squash-merged worktree when origin/<branch> is pruned and tip matches PR head (#2662)", async () => {
+    const responses = makeWorktreeResponses();
+    responses.set("git -C /repo branch --merged main", { stdout: "* main\n" });
+    responses.set("git -C /repo/.claude/worktrees/wt-a rev-parse HEAD", { stdout: "pushed-head-sha" });
+    // origin/feat-a already pruned → --verify fails; fall back to PR headRefOid.
+    responses.set("git -C /repo/.claude/worktrees/wt-a rev-parse --verify --quiet refs/remotes/origin/feat-a", {
+      stdout: "",
+      exitCode: 1,
+    });
+
+    const d = makeDeps({
+      execResponses: responses,
+      // PR head SHA equals the local tip → forge has everything → safe.
+      resolvedPrBranches: new Map([["feat-a", "pushed-head-sha"]]),
+    });
+
+    await runGc({ dryRun: true, olderThanMs: 86_400_000, branchesOnly: false, worktreesOnly: true }, d);
+
+    expect(d.logs.some((l) => l.includes("would remove 1"))).toBe(true);
+    expect(d.logs.some((l) => l.includes("wt-a"))).toBe(true);
   });
 
   test("warns when GitHub API is unavailable but still prunes ancestry-merged worktrees", async () => {

--- a/packages/command/src/commands/gc.ts
+++ b/packages/command/src/commands/gc.ts
@@ -102,8 +102,14 @@ export interface GcDeps extends WorktreeShimDeps {
   callTool: (tool: string, args: Record<string, unknown>) => Promise<unknown>;
   /** Returns mtime (ms since epoch) for the given path, or null if it can't be stat'd. */
   getMtime: (path: string) => number | null;
-  /** Returns branch names that have a merged PR on GitHub, or null if the API is unavailable. */
-  queryMergedPrBranches: (cwd: string) => Set<string> | null;
+  /**
+   * Returns branch→PR-state signals from one batched `gh` call, or null if the
+   * API is unavailable. `merged` = branches with a MERGED PR (enables `-D`
+   * force-delete of squash-merged branches). `resolved` = MERGED or CLOSED
+   * (the "done" signal that lets worktree GC reclaim squash-merged and
+   * abandoned-PR worktrees `git branch --merged` can't see — #2662).
+   */
+  queryPrBranches: (cwd: string) => { merged: Set<string>; resolved: Set<string> } | null;
   log: (msg: string) => void;
   logError: (msg: string) => void;
 }
@@ -145,16 +151,26 @@ export function defaultGcDeps(): GcDeps {
         return null;
       }
     },
-    queryMergedPrBranches: (cwd) => {
+    queryPrBranches: (cwd) => {
       const result = spawnCaptureSync(
         "gh",
-        ["pr", "list", "--state", "merged", "--json", "headRefName", "--limit", "500"],
+        ["pr", "list", "--state", "all", "--json", "headRefName,state", "--limit", "1000"],
         { cwd },
       );
       if (!result.ok) return null;
       try {
-        const prs = JSON.parse(result.stdout) as Array<{ headRefName: string }>;
-        return new Set(prs.map((pr) => pr.headRefName));
+        const prs = JSON.parse(result.stdout) as Array<{ headRefName: string; state: string }>;
+        const merged = new Set<string>();
+        const resolved = new Set<string>();
+        for (const pr of prs) {
+          if (pr.state === "MERGED") {
+            merged.add(pr.headRefName);
+            resolved.add(pr.headRefName);
+          } else if (pr.state === "CLOSED") {
+            resolved.add(pr.headRefName);
+          }
+        }
+        return { merged, resolved };
       } catch {
         return null;
       }
@@ -178,6 +194,15 @@ export async function runGc(opts: GcOptions, deps: GcDeps): Promise<GcResult> {
   const { cwd } = deps;
   const prefix = opts.dryRun ? `${c.dim}[dry-run]${c.reset} ` : "";
   const gcResult: GcResult = { prunedWorktrees: [], deletedBranches: [] };
+
+  // Fetch PR-state signals at most once per run — both the worktree and branch
+  // phases consume it. `undefined` = not yet fetched; `null` = fetched but the
+  // API was unavailable.
+  let prBranchesCache: { merged: Set<string>; resolved: Set<string> } | null | undefined;
+  const getPrBranches = (): { merged: Set<string>; resolved: Set<string> } | null => {
+    if (prBranchesCache === undefined) prBranchesCache = deps.queryPrBranches(cwd);
+    return prBranchesCache;
+  };
 
   // Branches deleted during the worktree phase — skipped by the branch phase
   // to avoid "not found" false failures on the second `git branch -d`.
@@ -238,6 +263,20 @@ export async function runGc(opts: GcOptions, deps: GcDeps): Promise<GcResult> {
       if (wt.branch) checkedOutFromList.add(wt.branch);
     }
 
+    // PR-state signal: lets prune reclaim squash-merged and closed-PR worktrees
+    // that `git branch --merged` can't see (#2662). Only query when there are
+    // mcx worktrees to consider; warn (but continue with ancestry-only) if the
+    // forge is unreachable.
+    let resolvedByPr: Set<string> | undefined;
+    if (listed.worktrees.length > 0) {
+      const pr = getPrBranches();
+      if (pr) {
+        resolvedByPr = pr.resolved;
+      } else {
+        deps.logError("gc: GitHub API unavailable — squash-merged/closed worktrees may not be reclaimed");
+      }
+    }
+
     // refreshActive re-queries sessions between removals (TOCTOU mitigation).
     // Only meaningful in live mode; in dry-run we don't execute.
     //
@@ -265,6 +304,7 @@ export async function runGc(opts: GcOptions, deps: GcDeps): Promise<GcResult> {
       deps,
       dryRun: opts.dryRun,
       refreshActive,
+      resolvedByPr,
     });
 
     worktreeDeletedBranches = result.deletedBranches;
@@ -322,8 +362,9 @@ export async function runGc(opts: GcOptions, deps: GcDeps): Promise<GcResult> {
     );
 
     // Query GitHub for branches with merged PRs — enables force-delete for
-    // squash/rebase-merged branches where `git branch -d` fails.
-    const mergedPrBranches = candidates.length > 0 ? deps.queryMergedPrBranches(cwd) : null;
+    // squash/rebase-merged branches where `git branch -d` fails. Reuses the
+    // per-run PR-state cache shared with the worktree phase.
+    const mergedPrBranches = candidates.length > 0 ? (getPrBranches()?.merged ?? null) : null;
     if (candidates.length > 0 && !mergedPrBranches) {
       deps.logError("gc: GitHub API unavailable — squash-merged branches may not be cleaned");
     }

--- a/packages/command/src/commands/gc.ts
+++ b/packages/command/src/commands/gc.ts
@@ -105,11 +105,13 @@ export interface GcDeps extends WorktreeShimDeps {
   /**
    * Returns branch→PR-state signals from one batched `gh` call, or null if the
    * API is unavailable. `merged` = branches with a MERGED PR (enables `-D`
-   * force-delete of squash-merged branches). `resolved` = MERGED or CLOSED
-   * (the "done" signal that lets worktree GC reclaim squash-merged and
-   * abandoned-PR worktrees `git branch --merged` can't see — #2662).
+   * force-delete of squash-merged branches). `resolved` maps every MERGED-or-
+   * CLOSED branch to its PR head SHA (headRefOid) — the "done" signal that lets
+   * worktree GC reclaim squash-merged and abandoned-PR worktrees `git branch
+   * --merged` can't see (#2662), while the head SHA guards against orphaning
+   * unpushed commits when `origin/<branch>` has been pruned.
    */
-  queryPrBranches: (cwd: string) => { merged: Set<string>; resolved: Set<string> } | null;
+  queryPrBranches: (cwd: string) => { merged: Set<string>; resolved: Map<string, string> } | null;
   log: (msg: string) => void;
   logError: (msg: string) => void;
 }
@@ -154,20 +156,20 @@ export function defaultGcDeps(): GcDeps {
     queryPrBranches: (cwd) => {
       const result = spawnCaptureSync(
         "gh",
-        ["pr", "list", "--state", "all", "--json", "headRefName,state", "--limit", "1000"],
+        ["pr", "list", "--state", "all", "--json", "headRefName,state,headRefOid", "--limit", "1000"],
         { cwd },
       );
       if (!result.ok) return null;
       try {
-        const prs = JSON.parse(result.stdout) as Array<{ headRefName: string; state: string }>;
+        const prs = JSON.parse(result.stdout) as Array<{ headRefName: string; state: string; headRefOid: string }>;
         const merged = new Set<string>();
-        const resolved = new Set<string>();
+        const resolved = new Map<string, string>();
         for (const pr of prs) {
           if (pr.state === "MERGED") {
             merged.add(pr.headRefName);
-            resolved.add(pr.headRefName);
+            resolved.set(pr.headRefName, pr.headRefOid);
           } else if (pr.state === "CLOSED") {
-            resolved.add(pr.headRefName);
+            resolved.set(pr.headRefName, pr.headRefOid);
           }
         }
         return { merged, resolved };
@@ -198,8 +200,8 @@ export async function runGc(opts: GcOptions, deps: GcDeps): Promise<GcResult> {
   // Fetch PR-state signals at most once per run — both the worktree and branch
   // phases consume it. `undefined` = not yet fetched; `null` = fetched but the
   // API was unavailable.
-  let prBranchesCache: { merged: Set<string>; resolved: Set<string> } | null | undefined;
-  const getPrBranches = (): { merged: Set<string>; resolved: Set<string> } | null => {
+  let prBranchesCache: { merged: Set<string>; resolved: Map<string, string> } | null | undefined;
+  const getPrBranches = (): { merged: Set<string>; resolved: Map<string, string> } | null => {
     if (prBranchesCache === undefined) prBranchesCache = deps.queryPrBranches(cwd);
     return prBranchesCache;
   };
@@ -267,7 +269,7 @@ export async function runGc(opts: GcOptions, deps: GcDeps): Promise<GcResult> {
     // that `git branch --merged` can't see (#2662). Only query when there are
     // mcx worktrees to consider; warn (but continue with ancestry-only) if the
     // forge is unreachable.
-    let resolvedByPr: Set<string> | undefined;
+    let resolvedByPr: Map<string, string> | undefined;
     if (listed.worktrees.length > 0) {
       const pr = getPrBranches();
       if (pr) {
@@ -315,6 +317,9 @@ export async function runGc(opts: GcOptions, deps: GcDeps): Promise<GcResult> {
       if (result.skippedUnmerged.length > 0) {
         deps.log(`${prefix}worktrees: ${result.skippedUnmerged.length} skipped (unmerged)`);
       }
+      if (result.skippedUnpushed.length > 0) {
+        deps.log(`${prefix}worktrees: ${result.skippedUnpushed.length} skipped (unpushed commits)`);
+      }
       if (recentSkipped.length > 0) {
         deps.log(`${prefix}worktrees: ${recentSkipped.length} skipped (too recent)`);
       }
@@ -327,8 +332,9 @@ export async function runGc(opts: GcOptions, deps: GcDeps): Promise<GcResult> {
       }
     } else {
       const unmerged = result.skippedUnmerged.length > 0 ? `, skipped ${result.skippedUnmerged.length} unmerged` : "";
+      const unpushed = result.skippedUnpushed.length > 0 ? `, skipped ${result.skippedUnpushed.length} unpushed` : "";
       const tooRecent = recentSkipped.length > 0 ? `, skipped ${recentSkipped.length} too recent` : "";
-      deps.logError(`worktrees: removed ${result.pruned}${unmerged}${tooRecent}`);
+      deps.logError(`worktrees: removed ${result.pruned}${unmerged}${unpushed}${tooRecent}`);
       if (result.pruned > 0) {
         gcResult.prunedWorktrees = result.prunedNames;
         for (const b of result.deletedBranches) {

--- a/packages/core/src/worktree-shim.spec.ts
+++ b/packages/core/src/worktree-shim.spec.ts
@@ -890,7 +890,10 @@ describe("pruneWorktrees", () => {
       // `git branch -d` would fail on a non-ancestor; `-D` succeeds.
       if (cmd.includes("-D")) return { stdout: "", stderr: "", exitCode: 0 };
       if (cmd.includes("-d")) return { stdout: "", stderr: "not fully merged", exitCode: 1 };
+      // Ahead-of-forge guard: origin/<branch> pruned → --verify fails; fall back
+      // to the PR head SHA, which equals the local tip → not ahead → safe.
       if (cmd.includes("rev-parse") && cmd.includes("--verify")) return { stdout: "", stderr: "", exitCode: 1 };
+      if (cmd.includes("rev-parse")) return { stdout: "sha-squashed", stderr: "", exitCode: 0 }; // local HEAD
       return { stdout: "", stderr: "", exitCode: 0 };
     });
     const printError = mock(() => {});
@@ -900,18 +903,65 @@ describe("pruneWorktrees", () => {
       repoRoot: "/repo",
       activeWorktrees: new Set(),
       deps: { exec, printError, printInfo },
-      resolvedByPr: new Set(["claude/feat-squashed"]),
+      resolvedByPr: new Map([["claude/feat-squashed", "sha-squashed"]]),
     });
 
     expect(result.pruned).toBe(1);
     expect(result.prunedNames).toEqual(["feat-squashed"]);
     expect(result.skippedUnmerged).toEqual([]);
+    expect(result.skippedUnpushed).toEqual([]);
     expect(result.deletedBranches.has("claude/feat-squashed")).toBe(true);
     // Force-delete must be used; plain `-d` alone would leak the branch.
     expect(calls.some((c) => c.includes("-D") && c.includes("claude/feat-squashed"))).toBe(true);
   });
 
-  test("does not remove a dirty worktree even when its PR is resolved", async () => {
+  test("does not reclaim a clean resolved-PR worktree that is ahead of the forge (unpushed commits)", async () => {
+    // A CLOSED PR whose author kept committing locally: clean tree, but the tip
+    // is ahead of origin/<branch>. Reclaiming would `-D` the branch and orphan
+    // those commits (#2662 data-loss guard).
+    const porcelainOutput = [
+      "worktree /repo",
+      "HEAD abc123",
+      "branch refs/heads/main",
+      "",
+      "worktree /repo/.claude/worktrees/feat-ahead",
+      "HEAD def456",
+      "branch refs/heads/claude/feat-ahead",
+      "",
+    ].join("\n");
+
+    const calls: string[][] = [];
+    const exec = mock((cmd: string[]) => {
+      calls.push(cmd);
+      if (cmd.includes("list") && cmd.includes("--porcelain"))
+        return { stdout: porcelainOutput, stderr: "", exitCode: 0 };
+      if (cmd.includes("symbolic-ref")) return { stdout: "refs/remotes/origin/main", stderr: "", exitCode: 0 };
+      if (cmd.includes("--merged")) return { stdout: "  main\n", stderr: "", exitCode: 0 }; // NOT ancestry-merged
+      if (cmd.includes("status")) return { stdout: "", stderr: "", exitCode: 0 }; // clean
+      if (cmd.includes("rev-parse") && cmd.includes("--verify"))
+        return { stdout: "origin-sha", stderr: "", exitCode: 0 }; // origin/<branch> exists
+      if (cmd.includes("rev-parse")) return { stdout: "local-sha", stderr: "", exitCode: 0 }; // local HEAD
+      if (cmd.includes("rev-list")) return { stdout: "3\n", stderr: "", exitCode: 0 }; // 3 commits ahead
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const printError = mock(() => {});
+    const printInfo = mock(() => {});
+
+    const result = await pruneWorktrees({
+      repoRoot: "/repo",
+      activeWorktrees: new Set(),
+      deps: { exec, printError, printInfo },
+      resolvedByPr: new Map([["claude/feat-ahead", "origin-sha"]]),
+    });
+
+    expect(result.pruned).toBe(0);
+    expect(result.skippedUnpushed).toEqual(["claude/feat-ahead"]);
+    // Must never remove the worktree or force-delete the branch.
+    expect(calls.some((c) => c.includes("remove"))).toBe(false);
+    expect(calls.some((c) => c.includes("-D"))).toBe(false);
+  });
+
+  test("does not remove a worktree with unstaged changes even when its PR is resolved", async () => {
     const porcelainOutput = [
       "worktree /repo",
       "HEAD abc123",
@@ -930,7 +980,7 @@ describe("pruneWorktrees", () => {
         return { stdout: porcelainOutput, stderr: "", exitCode: 0 };
       if (cmd.includes("symbolic-ref")) return { stdout: "refs/remotes/origin/main", stderr: "", exitCode: 0 };
       if (cmd.includes("--merged")) return { stdout: "  main\n", stderr: "", exitCode: 0 };
-      if (cmd.includes("status")) return { stdout: " M file.ts\n", stderr: "", exitCode: 0 }; // DIRTY
+      if (cmd.includes("status")) return { stdout: " M file.ts\n", stderr: "", exitCode: 0 }; // unstaged modification
       return { stdout: "", stderr: "", exitCode: 0 };
     });
     const printError = mock(() => {});
@@ -940,11 +990,131 @@ describe("pruneWorktrees", () => {
       repoRoot: "/repo",
       activeWorktrees: new Set(),
       deps: { exec, printError, printInfo },
-      resolvedByPr: new Set(["claude/feat-dirty"]),
+      resolvedByPr: new Map([["claude/feat-dirty", "sha"]]),
     });
 
     expect(result.pruned).toBe(0);
-    // Never attempt removal of a dirty tree, regardless of PR state.
+    expect(calls.some((c) => c.includes("remove"))).toBe(false);
+  });
+
+  test("does not remove a worktree with STAGED changes even when its PR is resolved", async () => {
+    // Staged changes show as "M  file.ts" in --porcelain output (first col = index, second = worktree).
+    // The check is status.trim() !== "" — any non-empty output must block removal.
+    const porcelainOutput = [
+      "worktree /repo",
+      "HEAD abc123",
+      "branch refs/heads/main",
+      "",
+      "worktree /repo/.claude/worktrees/feat-staged",
+      "HEAD def456",
+      "branch refs/heads/claude/feat-staged",
+      "",
+    ].join("\n");
+
+    const calls: string[][] = [];
+    const exec = mock((cmd: string[]) => {
+      calls.push(cmd);
+      if (cmd.includes("list") && cmd.includes("--porcelain"))
+        return { stdout: porcelainOutput, stderr: "", exitCode: 0 };
+      if (cmd.includes("symbolic-ref")) return { stdout: "refs/remotes/origin/main", stderr: "", exitCode: 0 };
+      if (cmd.includes("--merged")) return { stdout: "  main\n", stderr: "", exitCode: 0 };
+      if (cmd.includes("status")) return { stdout: "M  file.ts\n", stderr: "", exitCode: 0 }; // staged modification
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const printError = mock(() => {});
+    const printInfo = mock(() => {});
+
+    const result = await pruneWorktrees({
+      repoRoot: "/repo",
+      activeWorktrees: new Set(),
+      deps: { exec, printError, printInfo },
+      resolvedByPr: new Map([["claude/feat-staged", "sha"]]),
+    });
+
+    expect(result.pruned).toBe(0);
+    expect(calls.some((c) => c.includes("remove"))).toBe(false);
+  });
+
+  test("does not remove a worktree with UNTRACKED files even when its PR is resolved", async () => {
+    // Untracked files show as "?? newfile.ts" in --porcelain output.
+    // A worktree with untracked files is not safe to reclaim — those files would vanish.
+    const porcelainOutput = [
+      "worktree /repo",
+      "HEAD abc123",
+      "branch refs/heads/main",
+      "",
+      "worktree /repo/.claude/worktrees/feat-untracked",
+      "HEAD def456",
+      "branch refs/heads/claude/feat-untracked",
+      "",
+    ].join("\n");
+
+    const calls: string[][] = [];
+    const exec = mock((cmd: string[]) => {
+      calls.push(cmd);
+      if (cmd.includes("list") && cmd.includes("--porcelain"))
+        return { stdout: porcelainOutput, stderr: "", exitCode: 0 };
+      if (cmd.includes("symbolic-ref")) return { stdout: "refs/remotes/origin/main", stderr: "", exitCode: 0 };
+      if (cmd.includes("--merged")) return { stdout: "  main\n", stderr: "", exitCode: 0 };
+      if (cmd.includes("status")) return { stdout: "?? newfile.ts\n", stderr: "", exitCode: 0 }; // untracked
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const printError = mock(() => {});
+    const printInfo = mock(() => {});
+
+    const result = await pruneWorktrees({
+      repoRoot: "/repo",
+      activeWorktrees: new Set(),
+      deps: { exec, printError, printInfo },
+      resolvedByPr: new Map([["claude/feat-untracked", "sha"]]),
+    });
+
+    expect(result.pruned).toBe(0);
+    expect(calls.some((c) => c.includes("remove"))).toBe(false);
+  });
+
+  test("does not remove a worktree whose branch has unpushed commits (not in merged or resolvedByPr)", async () => {
+    // A branch with committed-but-not-pushed work and no resolved PR must survive.
+    // The protection here is skippedUnmerged: if the branch isn't in --merged AND
+    // isn't in resolvedByPr, pruneWorktrees adds it to skippedUnmerged and skips it.
+    // The working tree can be clean (commits don't show in git status --porcelain).
+    const porcelainOutput = [
+      "worktree /repo",
+      "HEAD abc123",
+      "branch refs/heads/main",
+      "",
+      "worktree /repo/.claude/worktrees/feat-unpushed",
+      "HEAD def456",
+      "branch refs/heads/claude/feat-unpushed",
+      "",
+    ].join("\n");
+
+    const calls: string[][] = [];
+    const exec = mock((cmd: string[]) => {
+      calls.push(cmd);
+      if (cmd.includes("list") && cmd.includes("--porcelain"))
+        return { stdout: porcelainOutput, stderr: "", exitCode: 0 };
+      if (cmd.includes("symbolic-ref")) return { stdout: "refs/remotes/origin/main", stderr: "", exitCode: 0 };
+      // Branch NOT in --merged (unpushed commits make it non-ancestor)
+      if (cmd.includes("--merged")) return { stdout: "  main\n", stderr: "", exitCode: 0 };
+      // Working tree is clean — committed changes don't show in status
+      if (cmd.includes("status")) return { stdout: "", stderr: "", exitCode: 0 };
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const printError = mock(() => {});
+    const printInfo = mock(() => {});
+
+    // resolvedByPr is empty — no PR exists for this branch
+    const result = await pruneWorktrees({
+      repoRoot: "/repo",
+      activeWorktrees: new Set(),
+      deps: { exec, printError, printInfo },
+      resolvedByPr: new Map(),
+    });
+
+    expect(result.pruned).toBe(0);
+    expect(result.skippedUnmerged).toContain("claude/feat-unpushed");
+    // Must never attempt removal
     expect(calls.some((c) => c.includes("remove"))).toBe(false);
   });
 

--- a/packages/core/src/worktree-shim.spec.ts
+++ b/packages/core/src/worktree-shim.spec.ts
@@ -864,6 +864,90 @@ describe("pruneWorktrees", () => {
     expect(result.skippedUnmerged).toEqual(["claude/feat-wip"]);
   });
 
+  test("reclaims squash-merged worktree via resolvedByPr and force-deletes branch (-D)", async () => {
+    // Squash-merge: the branch tip is NOT an ancestor of main, so it never
+    // appears in `git branch --merged` — ancestry alone leaks it (#2662).
+    const porcelainOutput = [
+      "worktree /repo",
+      "HEAD abc123",
+      "branch refs/heads/main",
+      "",
+      "worktree /repo/.claude/worktrees/feat-squashed",
+      "HEAD def456",
+      "branch refs/heads/claude/feat-squashed",
+      "",
+    ].join("\n");
+
+    const calls: string[][] = [];
+    const exec = mock((cmd: string[]) => {
+      calls.push(cmd);
+      if (cmd.includes("list") && cmd.includes("--porcelain"))
+        return { stdout: porcelainOutput, stderr: "", exitCode: 0 };
+      if (cmd.includes("symbolic-ref")) return { stdout: "refs/remotes/origin/main", stderr: "", exitCode: 0 };
+      if (cmd.includes("--merged")) return { stdout: "  main\n", stderr: "", exitCode: 0 }; // NOT ancestry-merged
+      if (cmd.includes("status")) return { stdout: "", stderr: "", exitCode: 0 }; // clean
+      if (cmd.includes("remove")) return { stdout: "", stderr: "", exitCode: 0 };
+      // `git branch -d` would fail on a non-ancestor; `-D` succeeds.
+      if (cmd.includes("-D")) return { stdout: "", stderr: "", exitCode: 0 };
+      if (cmd.includes("-d")) return { stdout: "", stderr: "not fully merged", exitCode: 1 };
+      if (cmd.includes("rev-parse") && cmd.includes("--verify")) return { stdout: "", stderr: "", exitCode: 1 };
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const printError = mock(() => {});
+    const printInfo = mock(() => {});
+
+    const result = await pruneWorktrees({
+      repoRoot: "/repo",
+      activeWorktrees: new Set(),
+      deps: { exec, printError, printInfo },
+      resolvedByPr: new Set(["claude/feat-squashed"]),
+    });
+
+    expect(result.pruned).toBe(1);
+    expect(result.prunedNames).toEqual(["feat-squashed"]);
+    expect(result.skippedUnmerged).toEqual([]);
+    expect(result.deletedBranches.has("claude/feat-squashed")).toBe(true);
+    // Force-delete must be used; plain `-d` alone would leak the branch.
+    expect(calls.some((c) => c.includes("-D") && c.includes("claude/feat-squashed"))).toBe(true);
+  });
+
+  test("does not remove a dirty worktree even when its PR is resolved", async () => {
+    const porcelainOutput = [
+      "worktree /repo",
+      "HEAD abc123",
+      "branch refs/heads/main",
+      "",
+      "worktree /repo/.claude/worktrees/feat-dirty",
+      "HEAD def456",
+      "branch refs/heads/claude/feat-dirty",
+      "",
+    ].join("\n");
+
+    const calls: string[][] = [];
+    const exec = mock((cmd: string[]) => {
+      calls.push(cmd);
+      if (cmd.includes("list") && cmd.includes("--porcelain"))
+        return { stdout: porcelainOutput, stderr: "", exitCode: 0 };
+      if (cmd.includes("symbolic-ref")) return { stdout: "refs/remotes/origin/main", stderr: "", exitCode: 0 };
+      if (cmd.includes("--merged")) return { stdout: "  main\n", stderr: "", exitCode: 0 };
+      if (cmd.includes("status")) return { stdout: " M file.ts\n", stderr: "", exitCode: 0 }; // DIRTY
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const printError = mock(() => {});
+    const printInfo = mock(() => {});
+
+    const result = await pruneWorktrees({
+      repoRoot: "/repo",
+      activeWorktrees: new Set(),
+      deps: { exec, printError, printInfo },
+      resolvedByPr: new Set(["claude/feat-dirty"]),
+    });
+
+    expect(result.pruned).toBe(0);
+    // Never attempt removal of a dirty tree, regardless of PR state.
+    expect(calls.some((c) => c.includes("remove"))).toBe(false);
+  });
+
   test("batch guard: calls ensureCoreBareUnset after pruning when core.bare=true on last removal", async () => {
     // Simulate the recurrence bug: individual per-removal fix runs but a subsequent
     // removal flips core.bare back to true. The final batch guard should catch it.

--- a/packages/core/src/worktree-shim.ts
+++ b/packages/core/src/worktree-shim.ts
@@ -79,13 +79,20 @@ export interface WorktreePruneOptions {
    */
   refreshActive?: () => Promise<Set<string>>;
   /**
-   * Branch names whose PR is MERGED or CLOSED on the forge. Squash-merges leave
-   * the branch tip as a non-ancestor of the default branch, so `git branch
-   * --merged` never lists them (#2662); a resolved PR is the authoritative
-   * "done" signal for those worktrees. Branches removed via this signal are
-   * deleted with `-D` since `git branch -d` rejects a non-ancestor tip.
+   * Branches whose PR is MERGED or CLOSED on the forge, mapped to the PR's head
+   * commit SHA (headRefOid). Squash-merges leave the branch tip as a
+   * non-ancestor of the default branch, so `git branch --merged` never lists
+   * them (#2662); a resolved PR is the authoritative "done" signal for those
+   * worktrees. Branches removed via this signal are deleted with `-D` since
+   * `git branch -d` rejects a non-ancestor tip.
+   *
+   * The head SHA is a data-loss backstop: a CLOSED PR whose author kept
+   * committing locally (or never pushed a final commit) leaves a clean worktree
+   * that is *ahead* of the forge. Reclaiming it would orphan those commits, so
+   * the prune loop skips any tip ahead of `origin/<branch>`, falling back to the
+   * head SHA when the remote ref has already been pruned.
    */
-  resolvedByPr?: Set<string>;
+  resolvedByPr?: Map<string, string>;
 }
 
 /** Result of a prune operation. */
@@ -97,6 +104,11 @@ export interface WorktreePruneResult {
   /** Names of worktrees that were actually removed (empty in dry-run). */
   prunedNames: string[];
   skippedUnmerged: string[];
+  /**
+   * Branches skipped because their clean worktree is ahead of the forge —
+   * committed-but-unpushed work that reclaim-via-PR-state must not destroy.
+   */
+  skippedUnpushed: string[];
   /** Branches that were deleted (empty in dry-run). */
   deletedBranches: Set<string>;
 }
@@ -452,6 +464,49 @@ function removeWorktreeWithVerification(
 }
 
 /**
+ * Guard against orphaning committed-but-unpushed work when reclaiming a
+ * worktree via the resolved-PR path (which routes around the ancestry check and
+ * force-deletes the branch).
+ *
+ * Returns true — "do not reclaim" — when the local tip holds commits the forge
+ * does not have:
+ *  - If `origin/<branch>` exists, the tip is ahead iff `rev-list
+ *    origin/<branch>..HEAD` is non-zero.
+ *  - If the remote ref has been pruned, fall back to the PR's head SHA
+ *    (`headRefOid`): equal ⇒ forge has exactly our tip (safe); anything else ⇒
+ *    treat as ahead (a MERGED/CLOSED PR branch never advances on the forge, so
+ *    any divergence is local-only work).
+ *  - If neither signal is available, fail closed (protect).
+ *
+ * Remote-tracking refs live in the common git dir, so they are visible from the
+ * worktree checkout; all queries run with `-C worktreePath` so `HEAD` is the
+ * branch tip.
+ */
+function isAheadOfForge(
+  worktreePath: string,
+  branch: string,
+  headRefOid: string | undefined,
+  deps: WorktreeShimDeps,
+): boolean {
+  const head = deps.exec(["git", "-C", worktreePath, "rev-parse", "HEAD"]);
+  if (head.exitCode !== 0) return true; // can't determine the local tip → protect
+  const localTip = head.stdout.trim();
+
+  const originRef = `refs/remotes/origin/${branch}`;
+  const verify = deps.exec(["git", "-C", worktreePath, "rev-parse", "--verify", "--quiet", originRef]);
+  if (verify.exitCode === 0) {
+    const ahead = deps.exec(["git", "-C", worktreePath, "rev-list", "--count", `${originRef}..HEAD`]);
+    if (ahead.exitCode !== 0) return true; // can't count → protect
+    return Number(ahead.stdout.trim()) > 0;
+  }
+
+  // origin/<branch> pruned — the PR head SHA is the last thing the forge saw.
+  if (headRefOid) return localTip !== headRefOid;
+
+  return true; // no remote ref and no head SHA → protect
+}
+
+/**
  * Delete a branch after its worktree is removed.
  *
  * Default (safe) uses `git branch -d`, which only deletes ancestry-merged
@@ -584,6 +639,7 @@ export async function pruneWorktrees(opts: WorktreePruneOptions): Promise<Worktr
   const removable: string[] = [];
   const prunedNames: string[] = [];
   const skippedUnmerged: string[] = [];
+  const skippedUnpushed: string[] = [];
   const deletedBranches = new Set<string>();
   // Resolve symlinks on cwd — macOS does not resolve them in process.cwd(),
   // so a shell that cd'd through a symlink into a candidate worktree would
@@ -616,8 +672,9 @@ export async function pruneWorktrees(opts: WorktreePruneOptions): Promise<Worktr
     // A branch is "done" when git ancestry says merged OR its PR is resolved
     // (MERGED/CLOSED). The PR signal is what catches squash-merges, whose tip
     // is a non-ancestor of the default branch (#2662).
+    const ancestryMerged = wt.branch ? mergedBranches.has(wt.branch) : false;
     const prResolved = wt.branch ? (resolvedByPr?.has(wt.branch) ?? false) : false;
-    if (!skipMergeCheck && wt.branch && !mergedBranches.has(wt.branch) && !prResolved) {
+    if (!skipMergeCheck && wt.branch && !ancestryMerged && !prResolved) {
       skippedUnmerged.push(wt.branch);
       continue;
     }
@@ -625,6 +682,18 @@ export async function pruneWorktrees(opts: WorktreePruneOptions): Promise<Worktr
     // Check if clean (trim to handle trailing newline from some git versions)
     const { stdout: status, exitCode: statusExit } = deps.exec(["git", "-C", wt.path, "status", "--porcelain"]);
     if (statusExit !== 0 || status.trim() !== "") continue;
+
+    // Data-loss guard: ancestry-merged tips are fully contained in the default
+    // branch, but a PR-resolved-only tip (squash/closed) can hold committed-but-
+    // unpushed work even when the tree is clean. Reclaiming would `-D` the branch
+    // and orphan those commits. Skip when the tip is ahead of the forge.
+    if (wt.branch && prResolved && !ancestryMerged) {
+      if (isAheadOfForge(wt.path, wt.branch, resolvedByPr?.get(wt.branch), deps)) {
+        deps.printError(`Warning: worktree branch is ahead of the forge, not removing (unpushed commits): ${wt.path}`);
+        skippedUnpushed.push(wt.branch);
+        continue;
+      }
+    }
 
     // Guard: refuse to remove a worktree that contains the current CWD.
     if (cwd && (cwd === wt.path || cwd.startsWith(`${wt.path}/`))) {
@@ -688,7 +757,7 @@ export async function pruneWorktrees(opts: WorktreePruneOptions): Promise<Worktr
     }
   }
 
-  return { pruned, removable, prunedNames, skippedUnmerged, deletedBranches };
+  return { pruned, removable, prunedNames, skippedUnmerged, skippedUnpushed, deletedBranches };
 }
 
 // ── Errors ──

--- a/packages/core/src/worktree-shim.ts
+++ b/packages/core/src/worktree-shim.ts
@@ -78,6 +78,14 @@ export interface WorktreePruneOptions {
    * list and remove. Callers without a way to refresh may omit.
    */
   refreshActive?: () => Promise<Set<string>>;
+  /**
+   * Branch names whose PR is MERGED or CLOSED on the forge. Squash-merges leave
+   * the branch tip as a non-ancestor of the default branch, so `git branch
+   * --merged` never lists them (#2662); a resolved PR is the authoritative
+   * "done" signal for those worktrees. Branches removed via this signal are
+   * deleted with `-D` since `git branch -d` rejects a non-ancestor tip.
+   */
+  resolvedByPr?: Set<string>;
 }
 
 /** Result of a prune operation. */
@@ -302,7 +310,7 @@ export function cleanupWorktree(worktree: string, cwd: string, deps: WorktreeShi
       }
       if (hookExit === 0 && !existsSync(worktreePath)) {
         deps.printInfo(`Removed worktree via hook: ${worktreePath}`);
-        deleteIfSafeToDelete(branch, effectiveRoot, deps);
+        deletePrunedBranch(branch, effectiveRoot, deps);
       } else if (hookExit === 0) {
         deps.printError(`Worktree teardown hook returned success but directory still exists: ${worktreePath}`);
       } else {
@@ -310,7 +318,7 @@ export function cleanupWorktree(worktree: string, cwd: string, deps: WorktreeShi
       }
     } else {
       if (removeWorktreeWithVerification(effectiveRoot, worktreePath, deps)) {
-        deleteIfSafeToDelete(branch, effectiveRoot, deps);
+        deletePrunedBranch(branch, effectiveRoot, deps);
       }
     }
   } else {
@@ -443,14 +451,22 @@ function removeWorktreeWithVerification(
   return false;
 }
 
-/** Delete a branch if git branch -d considers it safe (merged into HEAD or upstream). */
-function deleteIfSafeToDelete(branch: string, repoRoot: string, deps: WorktreeShimDeps): boolean {
+/**
+ * Delete a branch after its worktree is removed.
+ *
+ * Default (safe) uses `git branch -d`, which only deletes ancestry-merged
+ * branches. Pass `force` when a resolved PR (MERGED/CLOSED) is the authority —
+ * a squash-merged tip is a non-ancestor, so `-d` would refuse it (#2662).
+ */
+function deletePrunedBranch(branch: string, repoRoot: string, deps: WorktreeShimDeps, force = false): boolean {
   if (!branch) return false;
   const bareBeforeDelete = isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd));
-  const { exitCode } = deps.exec(["git", "-C", repoRoot, "branch", "-d", branch]);
+  const { exitCode } = deps.exec(["git", "-C", repoRoot, "branch", force ? "-D" : "-d", branch]);
   if (exitCode === 0) {
     if (!bareBeforeDelete && isCoreBareSet(repoRoot, (cmd) => deps.exec(cmd))) {
-      deps.printError(`[shim] core.bare flipped to true by: git branch -d ${branch} (repo=${repoRoot}) — see #1330`);
+      deps.printError(
+        `[shim] core.bare flipped to true by: git branch ${force ? "-D" : "-d"} ${branch} (repo=${repoRoot}) — see #1330`,
+      );
     }
     // Verify the branch is actually gone
     const { exitCode: verifyExit } = deps.exec([
@@ -465,7 +481,7 @@ function deleteIfSafeToDelete(branch: string, repoRoot: string, deps: WorktreeSh
       deps.printInfo(`Deleted branch: ${branch} (safe)`);
       return true;
     }
-    deps.printError(`Warning: git branch -d returned success but branch still exists: ${branch}`);
+    deps.printError(`Warning: git branch ${force ? "-D" : "-d"} returned success but branch still exists: ${branch}`);
     return false;
   }
   return false;
@@ -532,7 +548,7 @@ export function getDefaultBranch(deps: WorktreeShimDeps, cwd: string): string {
  * Skips worktrees with active sessions and unmerged branches.
  */
 export async function pruneWorktrees(opts: WorktreePruneOptions): Promise<WorktreePruneResult> {
-  const { repoRoot, deps, dryRun = false, refreshActive } = opts;
+  const { repoRoot, deps, dryRun = false, refreshActive, resolvedByPr } = opts;
   let activeWorktrees = opts.activeWorktrees;
   const wtConfig = readWorktreeConfig(repoRoot);
   const { worktrees, worktreeBase } = listMcxWorktrees(repoRoot, deps);
@@ -597,7 +613,11 @@ export async function pruneWorktrees(opts: WorktreePruneOptions): Promise<Worktr
       }
     }
     if (activeWorktrees.has(wtName)) continue;
-    if (!skipMergeCheck && wt.branch && !mergedBranches.has(wt.branch)) {
+    // A branch is "done" when git ancestry says merged OR its PR is resolved
+    // (MERGED/CLOSED). The PR signal is what catches squash-merges, whose tip
+    // is a non-ancestor of the default branch (#2662).
+    const prResolved = wt.branch ? (resolvedByPr?.has(wt.branch) ?? false) : false;
+    if (!skipMergeCheck && wt.branch && !mergedBranches.has(wt.branch) && !prResolved) {
       skippedUnmerged.push(wt.branch);
       continue;
     }
@@ -635,7 +655,7 @@ export async function pruneWorktrees(opts: WorktreePruneOptions): Promise<Worktr
         deps.printInfo(`Removed worktree via hook: ${wt.path}`);
         pruned++;
         prunedNames.push(wtName);
-        if (wt.branch && deleteIfSafeToDelete(wt.branch, repoRoot, deps)) {
+        if (wt.branch && deletePrunedBranch(wt.branch, repoRoot, deps, prResolved)) {
           deletedBranches.add(wt.branch);
         }
       } else if (hookExit === 0) {
@@ -647,7 +667,7 @@ export async function pruneWorktrees(opts: WorktreePruneOptions): Promise<Worktr
       if (removeWorktreeWithVerification(repoRoot, wt.path, deps)) {
         pruned++;
         prunedNames.push(wtName);
-        if (wt.branch && deleteIfSafeToDelete(wt.branch, repoRoot, deps)) {
+        if (wt.branch && deletePrunedBranch(wt.branch, repoRoot, deps, prResolved)) {
           deletedBranches.add(wt.branch);
         }
       }


### PR DESCRIPTION
## Summary
- Worktree GC previously used only ancestry-based `git branch --merged`, which by design never lists a squash-merged branch (its tip is a non-ancestor of `main`). Those worktree dirs — plus closed-PR sandboxes — leaked forever (issue #2662 confirmed 120 accumulated dirs).
- Thread a PR-state **resolved** set (PR state MERGED or CLOSED) from a single batched `gh pr list --state all` call into `pruneWorktrees`. A worktree's branch is now "done" when git ancestry says merged **OR** its PR is resolved.
- Branches removed via the PR signal are deleted with `-D` (not `-d`), since `git branch -d` rejects a non-ancestor squash-merged tip — this closes the branch-leak half of the gap too.
- The single `gh` call is memoized and shared by the worktree and branch phases (no extra API round-trips).

### Safety (per issue must-not rules)
- Dirty worktrees are never removed (existing `git status --porcelain` gate, verified by new test) — regardless of PR state.
- Active-session and current-cwd worktrees still skipped.
- Offline / no `gh` auth: warns and degrades to ancestry-only cleanup (no PR-state removals), rather than removing blindly.
- Built on top of #2856's `removeWorktree` idempotency fix (rebased onto `origin/main`).

### Scope
Targets the canonical `mcx gc` path. `mcx worktrees --prune` and the agent cleanup path remain ancestry-only (`resolvedByPr` is optional); wiring a `gh` query into those separate dep interfaces would be scope creep.

## Test plan
- [x] `bun run am-i-done` green (pre- and post-rebase)
- [x] New shim tests: squash-merged worktree reclaimed via `resolvedByPr` + branch force-deleted with `-D`; dirty worktree with resolved PR is NOT removed
- [x] New gc tests: squash-merged worktree reclaimed when ancestry misses it; GitHub-unavailable warns but still prunes ancestry-merged worktrees
- [x] All pre-existing gc + worktree-shim tests still pass (82 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)