### PR TITLE
fix(acp): skip non-JSON preamble before ACP handshake (fixes #2848)

### DIFF
--- a/packages/acp/src/acp-process.spec.ts
+++ b/packages/acp/src/acp-process.spec.ts
@@ -37,15 +37,17 @@ describe("AcpProcess", () => {
     expect(proc.alive).toBe(false);
   });
 
-  test("handles malformed NDJSON lines via onError", async () => {
+  test("malformed lines after the first JSON frame go to onError", async () => {
     const errors: string[] = [];
+    const preamble: string[] = [];
 
     const proc = new AcpProcess({
       cwd: process.cwd(),
-      command: ["bash", "-c", "echo 'not json'; echo '{\"valid\":true}'"],
+      command: ["bash", "-c", "echo '{\"valid\":true}'; echo 'not json'"],
       onMessage: () => {},
       onExit: () => {},
       onError: (_err, rawLine) => errors.push(rawLine),
+      onPreamble: (rawLine) => preamble.push(rawLine),
     });
 
     proc.spawn();
@@ -55,8 +57,57 @@ describe("AcpProcess", () => {
       await Bun.sleep(POLL_MS);
     }
 
-    expect(errors).toHaveLength(1);
-    expect(errors[0]).toBe("not json");
+    expect(errors).toEqual(["not json"]);
+    expect(preamble).toHaveLength(0);
+  });
+
+  test("skips a non-JSON preamble banner before the first JSON frame", async () => {
+    const messages: Record<string, unknown>[] = [];
+    const errors: string[] = [];
+    const preamble: string[] = [];
+
+    const proc = new AcpProcess({
+      cwd: process.cwd(),
+      command: [
+        "bash",
+        "-c",
+        'echo \'A new version of Grok Build is available: 0.2.91 -> 0.2.93 [stable]\'; echo \'{"jsonrpc":"2.0","id":1,"result":"ok"}\'',
+      ],
+      onMessage: (msg) => messages.push(msg),
+      onExit: () => {},
+      onError: (_err, rawLine) => errors.push(rawLine),
+      onPreamble: (rawLine) => preamble.push(rawLine),
+    });
+
+    proc.spawn();
+
+    const deadline = Date.now() + 5000;
+    while (!proc.exited && Date.now() < deadline) {
+      await Bun.sleep(POLL_MS);
+    }
+
+    expect(errors).toHaveLength(0);
+    expect(preamble).toEqual(["A new version of Grok Build is available: 0.2.91 -> 0.2.93 [stable]"]);
+    expect(messages).toEqual([{ jsonrpc: "2.0", id: 1, result: "ok" }]);
+    expect(proc.preambleText).toContain("A new version of Grok Build");
+  });
+
+  test("preambleText is empty when stdout leads with a JSON frame", async () => {
+    const proc = new AcpProcess({
+      cwd: process.cwd(),
+      command: ["bash", "-c", 'echo \'{"jsonrpc":"2.0","id":1,"result":"ok"}\''],
+      onMessage: () => {},
+      onExit: () => {},
+    });
+
+    proc.spawn();
+
+    const deadline = Date.now() + 5000;
+    while (!proc.exited && Date.now() < deadline) {
+      await Bun.sleep(POLL_MS);
+    }
+
+    expect(proc.preambleText).toBe("");
   });
 
   test("write sends NDJSON to stdin", async () => {

--- a/packages/acp/src/acp-process.ts
+++ b/packages/acp/src/acp-process.ts
@@ -21,16 +21,28 @@ export interface AcpProcessOptions {
   onMessage: (msg: Record<string, unknown>) => void;
   /** Called when the process exits. */
   onExit: (code: number | null, signal: string | null) => void;
-  /** Called on parse errors (malformed NDJSON lines). */
+  /** Called on parse errors (malformed NDJSON lines) after the first valid JSON-RPC frame. */
   onError?: (error: Error, rawLine: string) => void;
+  /**
+   * Called for each non-JSON line seen *before* the first parseable JSON-RPC frame.
+   * These are banner / MOTD / update-notice lines that some agents (grok, gemini, …)
+   * print on stdout before ACP framing begins. They are skipped, not treated as errors.
+   */
+  onPreamble?: (rawLine: string) => void;
   /** Called with stderr chunks. */
   onStderr?: (chunk: string) => void;
 }
+
+/** Cap on how many preamble lines / characters we retain for diagnostics. */
+const MAX_PREAMBLE_LINES = 20;
+const MAX_PREAMBLE_CHARS = 2000;
 
 export class AcpProcess {
   private handle: ManagedHandle | null = null;
   private readonly opts: AcpProcessOptions;
   private _exited = false;
+  private _sawFirstFrame = false;
+  private readonly _preamble: string[] = [];
 
   constructor(opts: AcpProcessOptions) {
     this.opts = opts;
@@ -97,6 +109,38 @@ export class AcpProcess {
     return this._exited;
   }
 
+  /**
+   * Non-JSON lines emitted on stdout before the first JSON-RPC frame, joined.
+   * Empty once a frame has been parsed with no preceding noise. Used to surface
+   * the real cause when a handshake fails ("expected JSON-RPC, got: <banner>").
+   */
+  get preambleText(): string {
+    return this._preamble.join("\n");
+  }
+
+  /** Parse a single stdout line: route to onMessage, preamble, or onError. */
+  private handleLine(trimmed: string): void {
+    if (!trimmed) return;
+    try {
+      const parsed = JSON.parse(trimmed) as Record<string, unknown>;
+      this._sawFirstFrame = true;
+      this.opts.onMessage(parsed);
+    } catch (err) {
+      if (!this._sawFirstFrame) {
+        this.recordPreamble(trimmed);
+        this.opts.onPreamble?.(trimmed);
+      } else {
+        this.opts.onError?.(err instanceof Error ? err : new Error(String(err)), trimmed);
+      }
+    }
+  }
+
+  private recordPreamble(line: string): void {
+    if (this._preamble.length >= MAX_PREAMBLE_LINES) return;
+    if (this.preambleText.length + line.length > MAX_PREAMBLE_CHARS) return;
+    this._preamble.push(line);
+  }
+
   /** Read stdout line by line and parse as JSON. */
   private async readLines(): Promise<void> {
     const stdout = this.handle?.stdout;
@@ -116,25 +160,11 @@ export class AcpProcess {
         buffer = lines.pop() ?? "";
 
         for (const line of lines) {
-          const trimmed = line.trim();
-          if (!trimmed) continue;
-          try {
-            const parsed = JSON.parse(trimmed) as Record<string, unknown>;
-            this.opts.onMessage(parsed);
-          } catch (err) {
-            this.opts.onError?.(err instanceof Error ? err : new Error(String(err)), trimmed);
-          }
+          this.handleLine(line.trim());
         }
       }
 
-      if (buffer.trim()) {
-        try {
-          const parsed = JSON.parse(buffer.trim()) as Record<string, unknown>;
-          this.opts.onMessage(parsed);
-        } catch (err) {
-          this.opts.onError?.(err instanceof Error ? err : new Error(String(err)), buffer.trim());
-        }
-      }
+      this.handleLine(buffer.trim());
     } catch (err) {
       if (!this._exited) {
         this.opts.onError?.(err instanceof Error ? err : new Error(String(err)), "");

--- a/packages/acp/src/acp-session.spec.ts
+++ b/packages/acp/src/acp-session.spec.ts
@@ -174,6 +174,25 @@ describe("AcpSession (with fake ACP agent)", () => {
     expect(errEvent?.errors[0]).toMatch(/exited with code 2/);
   });
 
+  test("start() succeeds when the agent prints a non-JSON update banner first", async () => {
+    const { session, events } = makeSession({ agent: "banner-then-handshake" });
+
+    const resultPromise = session.waitForResult(10000);
+    await session.start();
+    const result = await resultPromise;
+
+    expect(result.type).toBe("session:result");
+    expect(session.currentState).toBe("idle");
+    expect(events.some((e) => e.type === "session:init")).toBe(true);
+  });
+
+  test("start() surfaces the banner bytes when handshake fails after a preamble", async () => {
+    const { session } = makeSession({ agent: "banner-then-exit" });
+
+    await expect(session.start()).rejects.toThrow(/non-JSON-RPC output before the handshake/);
+    await expect(session.start()).rejects.toThrow(/A new version of Grok Build is available/);
+  });
+
   test("permission request with allow rule auto-approves", async () => {
     const { session, events } = makeSession({
       agent: "permission",

--- a/packages/acp/src/acp-session.ts
+++ b/packages/acp/src/acp-session.ts
@@ -117,6 +117,9 @@ export class AcpSession {
       onError: (err, line) => {
         console.error(`[acp-session:${this.sessionId}] Parse error: ${err.message} (line: ${line})`);
       },
+      onPreamble: (line) => {
+        console.error(`[acp-session:${this.sessionId}] Skipping non-JSON preamble before handshake: ${line}`);
+      },
     });
 
     this.proc.spawn();
@@ -159,7 +162,15 @@ export class AcpSession {
       this.transcript.push(userEntry(this.config.prompt));
       await this.startPrompt(this.config.prompt);
     } catch (err) {
+      const preamble = this.proc.preambleText;
       this.proc.kill();
+      if (preamble) {
+        const orig = err instanceof Error ? err.message : String(err);
+        const shown = preamble.length > 500 ? `${preamble.slice(0, 500)}…` : preamble;
+        throw new Error(
+          `${orig} — agent "${this.agentDisplayName}" emitted non-JSON-RPC output before the handshake (expected JSON-RPC, got: ${JSON.stringify(shown)}). This is often a self-update or MOTD banner; re-run to let the agent consume it.`,
+        );
+      }
       throw err;
     }
   }

--- a/packages/acp/src/fake-acp-agent.ts
+++ b/packages/acp/src/fake-acp-agent.ts
@@ -8,6 +8,8 @@
  *   permission      — handshake + session/new + sends session/request_permission, completes after response
  *   crash-after-prompt — handshake + session/new + prompt completes + exit code 2
  *   silent          — handshake + session/new + prompt accepted, then no events (for watchdog testing)
+ *   banner-then-handshake — prints a non-JSON update banner on stdout, then behaves like `simple`
+ *   banner-then-exit — prints a non-JSON update banner on stdout, then exits 1 without handshaking
  *   fs-write        — handshake + session/new + sends fs/write_text_file request, then completes
  *   fs-read         — handshake + session/new + sends fs/read_text_file request, then completes
  *   fs-read-symlink — sends fs/read for an in-cwd symlink whose target escapes the worktree
@@ -33,7 +35,19 @@ const MED_COMPLETE_DELAY_MS = 100;
 /** Long tail delay — paired with permission / terminal flows that require user-side decisions. */
 const LONG_COMPLETE_DELAY_MS = 200;
 
-const mode = process.argv[2] ?? "simple";
+const rawMode = process.argv[2] ?? "simple";
+
+const UPDATE_BANNER = "A new version of Grok Build is available: 0.2.91 -> 0.2.93 [stable]";
+
+if (rawMode === "banner-then-handshake" || rawMode === "banner-then-exit") {
+  // Emit a non-JSON banner on stdout before any JSON-RPC framing — mimics an agent
+  // with a pending self-update (see #2848).
+  process.stdout.write(`${UPDATE_BANNER}\n`);
+  if (rawMode === "banner-then-exit") process.exit(1);
+}
+
+// banner-then-handshake behaves like `simple` for the rest of the flow.
+const mode = rawMode === "banner-then-handshake" ? "simple" : rawMode;
 
 const rl = createInterface({ input: process.stdin, terminal: false });
 


### PR DESCRIPTION
## Summary
- ACP stdio reader now **skips non-JSON preamble lines** until the first parseable JSON-RPC frame, routing them to a new `onPreamble` callback instead of `onError`. This hardens mcx against *any* agent that prints a banner/MOTD/update notice on stdout before ACP framing begins (grok's self-update banner was the trigger — #2848 — but gemini/copilot are equally capable).
- On handshake failure where a preamble was captured, `AcpSession.start()` now **surfaces the actual bytes read** (`expected JSON-RPC, got: "<banner>"`) instead of the opaque `Process exited`, turning a 30-minute diagnosis into a 30-second one.
- Implements suggested fixes (1) + (3) from the issue. Fix (2) (suppressing the update check via spawn env) was intentionally not taken — `agents.ts` is untouched.

Out of scope (per pre-start amendment): the trailing `mcx agent codex log/status` bug in the issue is being split into its own issue.

## Test plan
- [x] `AcpProcess`: skips a banner line before the first JSON frame (→ `onPreamble`, not `onError`); malformed lines *after* the first frame still go to `onError`; `preambleText` empty when stdout leads with JSON.
- [x] `AcpSession`: `start()` succeeds when the agent prints a banner first (`banner-then-handshake` fake mode); `start()` rejects with the banner bytes when the agent exits after a preamble (`banner-then-exit` fake mode).
- [x] `bun run am-i-done` green (typecheck, lint, rules, tests, coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)