### PR TITLE
fix(command): pass cwd to gh in defaultGetPrStatus (fixes #2788)

### DIFF
--- a/packages/command/src/commands/session-deps.spec.ts
+++ b/packages/command/src/commands/session-deps.spec.ts
@@ -148,7 +148,12 @@ describe("defaultGetPrStatus", () => {
     Bun.spawnSync(["git", "init", "-q"], { cwd: dir, env: GIT_ENV });
     Bun.spawnSync(["git", "-C", dir, "commit", "--allow-empty", "-m", "init"], { env: GIT_ENV });
     const result = await defaultGetPrStatus(dir);
-    // gh pr list will fail (no remote) → LookupFailure, or return null/empty
+    // A remote-less cwd makes `gh pr list` resolve to no repo → LookupFailure
+    // (or null/empty). This stays permissive: asserting LookupFailure *only*
+    // couples the test to `gh`'s live repo-resolution, which is not
+    // deterministic across environments — the very network-flake this fix
+    // (missing `cwd: worktreePath`, #2788) removes. The real regression guard
+    // is the `cwd` argument itself and the comment on it in session-deps.ts.
     expect(result === null || isLookupFailure(result)).toBe(true);
   });
 

--- a/packages/command/src/commands/session-deps.ts
+++ b/packages/command/src/commands/session-deps.ts
@@ -111,16 +111,17 @@ export async function defaultGetPrStatus(worktreePath: string): Promise<LookupRe
   const branch = branchResult.stdout.trim();
   if (!branch) return null;
 
-  const prOut = await runOrLookupFailure("gh", [
-    "pr",
-    "list",
-    "--head",
-    branch,
-    "--json",
-    "number,state",
-    "--limit",
-    "1",
-  ]);
+  // `cwd: worktreePath` is load-bearing: without it `gh` resolves the base repo
+  // from the process's cwd, not the worktree — querying the wrong remote in
+  // production, and in tests making a live network call against whatever repo
+  // the runner happens to sit in (that non-deterministically blew the 5s test
+  // timeout and surfaced as a phantom coverage failure, #2788). A local-only
+  // repo has no remote, so `gh` fails fast here instead of hitting the network.
+  const prOut = await runOrLookupFailure(
+    "gh",
+    ["pr", "list", "--head", branch, "--json", "number,state", "--limit", "1"],
+    { cwd: worktreePath },
+  );
   if (isLookupFailure(prOut)) return prOut;
 
   let prs: Array<{ number: number; state: string }>;


### PR DESCRIPTION
## Summary
- **Root cause (corrected):** The `gh pr list` call in `defaultGetPrStatus` omitted `cwd: worktreePath`, so `gh` resolved the base repo from the process cwd instead of the target worktree. In production this queries the wrong remote; in CI it made a live network call against whatever repo the runner sat in, which non-deterministically blew the 5s test timeout and surfaced as the phantom coverage failure that motivated #2788.
- **The issue's hypothesis was wrong.** #2788 claimed a passthrough bug in `scripts/_runner/ci-steps.ts` `coverageWithCrashTolerance` ("all tests passed, no verdict"). The run-1 artifact (CI run 27435497363) actually shows ` 1 fail` — a genuine 5001ms timeout of `defaultGetPrStatus > local-only branch`, not a missing verdict. `ci-steps.ts` behaved correctly and is **not** touched. See the discrepancy comment on #2788 for evidence.
- **Coordination note:** because the fix lands in `session-deps.ts` (not `ci-steps.ts`), the #2815 defense-in-depth work does **not** stack on this change — the two no longer overlap.
- Test kept **permissive** (`null || LookupFailure`): asserting `LookupFailure` only would couple the unit test to `gh`'s live repo-resolution, which is non-deterministic across environments — the very network-flake this fix removes. The real regression guard is the `cwd` argument and its comment.

## Test plan
- [x] `bun run am-i-done` (full gate) passes locally
- [x] `session-deps.spec.ts` passes 15/15 in isolation and in the bundled `test-changed` run
- [x] Verified `spawnCapture` forwards `cwd` to `Bun.spawn` (packages/core/src/subprocess.ts:250)
- [x] Confirmed remote-less repo makes `gh pr list` fail fast (`no git remotes found`, exit 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)