### PR TITLE
enhancement(coverage): spec-count floor + exclusion transparency (fixes #2815)

### DIFF
--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -127,6 +127,7 @@ const EXCLUSIONS: Record<string, string> = {
 import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { coveragePathInDiff, resolveChangedSourceFiles } from "./coverage-diff";
+import { checkSpecCountFloor, countExpectedSpecFiles, formatExclusionList } from "./coverage-report";
 // staged-files still available for --ci mode if needed in the future
 import { logTestRun } from "./test-failure-log";
 import { detectTestNoise } from "./test-noise";
@@ -456,6 +457,20 @@ if (globalLines < GLOBAL_THRESHOLDS.lines) {
   failed = true;
 }
 
+// --- Spec-count sanity floor (#2815) ---
+// Guard against a silent shrink of the coverage surface: if run-1 discovers
+// fewer spec files than exist on disk under its run paths, the per-file floor
+// above was recomputed against fewer files and would still print PASS. Fail
+// closed. Checked against run-1 output only (the coverage table we parse);
+// run-2 daemon specs have their own discovery gate in ci-steps.ts (#2719).
+const expectedSpecFiles = countExpectedSpecFiles(nonDaemonPaths, resolve(import.meta.dir, ".."));
+const specFloor = checkSpecCountFloor(coverageRun1, expectedSpecFiles);
+console.log(`Spec floor: ${specFloor.discovered ?? "?"} discovered / ${specFloor.expected} expected spec file(s)`);
+if (!specFloor.ok) {
+  console.error(`\nFAIL: ${specFloor.reason}`);
+  failed = true;
+}
+
 if (preExistingGaps.length > 0) {
   console.warn(
     `\nWARN: ${preExistingGaps.length} file(s) below ${PER_FILE_MIN_LINES}% on main (not in diff — skipped):`,
@@ -471,6 +486,13 @@ if (failures.length > 0) {
     console.error(`  ${lines.toFixed(1)}%  ${file}`);
   }
   console.error("\nEither add tests or add an exclusion with a reason in scripts/check-coverage.ts");
+  // Itemize the active exclusions so a file masked at the .endsWith() check is
+  // visible here rather than silently skipped (#2815). If the failing file is
+  // already covered by a broader suffix pattern, it shows up in this list.
+  console.error(`\n${Object.keys(EXCLUSIONS).length} active per-file exclusion(s):`);
+  for (const line of formatExclusionList(EXCLUSIONS)) {
+    console.error(line);
+  }
   failed = true;
 }
 

--- a/scripts/coverage-report.spec.ts
+++ b/scripts/coverage-report.spec.ts
@@ -1,0 +1,133 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  RAN_FILES_RE,
+  checkSpecCountFloor,
+  countExpectedSpecFiles,
+  formatExclusionList,
+  parseDiscoveredFileCount,
+} from "./coverage-report";
+
+describe("parseDiscoveredFileCount", () => {
+  test("parses the bun end-of-run summary", () => {
+    expect(parseDiscoveredFileCount("Ran 6158 tests across 225 files. [57.07s]")).toBe(225);
+  });
+
+  test("handles singular 'test' and 'file'", () => {
+    expect(parseDiscoveredFileCount("Ran 1 test across 1 file. [1.00ms]")).toBe(1);
+  });
+
+  test("finds the line embedded in larger output", () => {
+    const out = "bun test v1.3.14\n 612 pass\n 0 fail\nRan 612 tests across 26 files. [6.96s]\n";
+    expect(parseDiscoveredFileCount(out)).toBe(26);
+  });
+
+  test("returns null when the summary line is absent", () => {
+    expect(parseDiscoveredFileCount("no summary here")).toBeNull();
+  });
+
+  test("only matches at line start (not mid-line quotes)", () => {
+    expect(parseDiscoveredFileCount("logged `Ran 5 tests across 3 files` inside a string")).toBeNull();
+  });
+
+  test("RAN_FILES_RE is exported for reuse", () => {
+    expect("Ran 10 tests across 4 files.").toMatch(RAN_FILES_RE);
+  });
+});
+
+describe("countExpectedSpecFiles", () => {
+  function makeFixture(): string {
+    const root = mkdtempSync(join(tmpdir(), "cov-report-"));
+    mkdirSync(join(root, "pkg/src/nested"), { recursive: true });
+    mkdirSync(join(root, "other"), { recursive: true });
+    writeFileSync(join(root, "pkg/src/a.spec.ts"), "");
+    writeFileSync(join(root, "pkg/src/b.spec.tsx"), "");
+    writeFileSync(join(root, "pkg/src/nested/c.spec.ts"), "");
+    writeFileSync(join(root, "pkg/src/impl.ts"), ""); // non-spec, ignored
+    writeFileSync(join(root, "other/loose.spec.ts"), "");
+    writeFileSync(join(root, "other/not-a-spec.ts"), "");
+    return root;
+  }
+
+  test("recurses directories and counts spec files only", () => {
+    const root = makeFixture();
+    try {
+      expect(countExpectedSpecFiles(["pkg/src"], root)).toBe(3);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("counts an explicit spec-file path as 1, ignores non-spec file paths", () => {
+    const root = makeFixture();
+    try {
+      expect(countExpectedSpecFiles(["other/loose.spec.ts", "other/not-a-spec.ts"], root)).toBe(1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("dedupes a file already covered by a directory path", () => {
+    const root = makeFixture();
+    try {
+      // pkg/src (3 specs) + explicit a.spec.ts already inside it → still 3
+      expect(countExpectedSpecFiles(["pkg/src", "pkg/src/a.spec.ts"], root)).toBe(3);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("ignores missing paths", () => {
+    const root = makeFixture();
+    try {
+      expect(countExpectedSpecFiles(["does/not/exist"], root)).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("checkSpecCountFloor", () => {
+  test("passes when discovered equals expected", () => {
+    const r = checkSpecCountFloor("Ran 100 tests across 225 files.", 225);
+    expect(r.ok).toBe(true);
+    expect(r.discovered).toBe(225);
+  });
+
+  test("passes when discovered exceeds expected (one-sided)", () => {
+    expect(checkSpecCountFloor("Ran 100 tests across 230 files.", 225).ok).toBe(true);
+  });
+
+  test("fails closed when discovered drops below expected", () => {
+    const r = checkSpecCountFloor("Ran 100 tests across 26 files.", 225);
+    expect(r.ok).toBe(false);
+    expect(r.discovered).toBe(26);
+    expect(r.reason).toContain("expected >= 225");
+  });
+
+  test("fails closed when the summary line is unparseable", () => {
+    const r = checkSpecCountFloor("garbage output, bun changed its format", 225);
+    expect(r.ok).toBe(false);
+    expect(r.discovered).toBeNull();
+    expect(r.reason).toContain("failing closed");
+  });
+});
+
+describe("formatExclusionList", () => {
+  test("itemizes path — reason pairs", () => {
+    const lines = formatExclusionList({
+      "core/src/ipc-client.ts": "IPC transport requires running daemon",
+      "test/harness.ts": "Test infrastructure, not source",
+    });
+    expect(lines).toEqual([
+      "  core/src/ipc-client.ts — IPC transport requires running daemon",
+      "  test/harness.ts — Test infrastructure, not source",
+    ]);
+  });
+
+  test("returns an empty list for no exclusions", () => {
+    expect(formatExclusionList({})).toEqual([]);
+  });
+});

--- a/scripts/coverage-report.ts
+++ b/scripts/coverage-report.ts
@@ -1,0 +1,84 @@
+/**
+ * Pure helpers for check-coverage.ts reporting + defense-in-depth (#2815).
+ *
+ * check-coverage.ts is a top-level side-effect script (it runs the coverage
+ * pass on import), so the testable logic lives here where a spec can import it
+ * without triggering a real test run.
+ */
+
+import { existsSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import { Glob } from "bun";
+
+/** Bun's end-of-run summary line, e.g. "Ran 6158 tests across 225 files. [57.07s]". */
+export const RAN_FILES_RE = /^Ran \d+ tests? across (\d+) files?/m;
+
+/** Parse the discovered spec-file count from `bun test` stdout. null when absent. */
+export function parseDiscoveredFileCount(output: string): number | null {
+  const m = output.match(RAN_FILES_RE);
+  return m ? Number.parseInt(m[1], 10) : null;
+}
+
+/**
+ * Count *.spec.ts / *.spec.tsx files discoverable under the given run paths.
+ * Directory paths are scanned recursively; explicit spec-file paths count as 1.
+ * Non-spec file paths and missing paths are ignored. This mirrors the set of
+ * files `bun test <paths>` will discover so the floor compares files-to-files.
+ */
+export function countExpectedSpecFiles(paths: string[], rootDir: string): number {
+  const glob = new Glob("**/*.spec.{ts,tsx}");
+  const seen = new Set<string>();
+  for (const p of paths) {
+    const abs = resolve(rootDir, p);
+    if (!existsSync(abs)) continue;
+    if (statSync(abs).isDirectory()) {
+      for (const rel of glob.scanSync({ cwd: abs })) seen.add(resolve(abs, rel));
+    } else if (p.endsWith(".spec.ts") || p.endsWith(".spec.tsx")) {
+      seen.add(abs);
+    }
+  }
+  return seen.size;
+}
+
+export interface SpecFloorResult {
+  ok: boolean;
+  discovered: number | null;
+  expected: number;
+  reason?: string;
+}
+
+/**
+ * Spec-count sanity floor (#2815). The #1125 fast-path skips run-2 (daemon) and
+ * re-includes files manually, so a silent drop in discovered specs — a glob
+ * regression, bun-upgrade path-arg skew, or a spec that self-skips at import —
+ * would recompute the per-file floor against fewer source files and still print
+ * PASS. Fail closed when the run discovers fewer spec files than exist on disk.
+ * Mirrors the #2719 phases discovery floor (files vs files — exact, and the
+ * comparison is one-sided so extra discovered files never false-fail).
+ */
+export function checkSpecCountFloor(output: string, expected: number): SpecFloorResult {
+  const discovered = parseDiscoveredFileCount(output);
+  if (discovered === null) {
+    return {
+      ok: false,
+      discovered,
+      expected,
+      reason:
+        'could not parse the "Ran N tests across M files" summary from coverage output — failing closed (bun output format changed?) (#2815)',
+    };
+  }
+  if (discovered < expected) {
+    return {
+      ok: false,
+      discovered,
+      expected,
+      reason: `coverage run discovered ${discovered} spec file(s), expected >= ${expected} — a glob regression, bun path-arg skew, or a self-skipping spec silently shrank the coverage surface (#2815)`,
+    };
+  }
+  return { ok: true, discovered, expected };
+}
+
+/** Itemize active per-file exclusions (path — reason) for transparent output (#2815). */
+export function formatExclusionList(exclusions: Record<string, string>): string[] {
+  return Object.entries(exclusions).map(([path, reason]) => `  ${path} — ${reason}`);
+}


### PR DESCRIPTION
## Summary
- Adds a **spec-count sanity floor** to `check-coverage.ts`: fails closed when run-1's `Ran N tests across M files` drops below the on-disk spec count under its run paths (currently 225/225). Catches a silent coverage-surface shrink — glob regression, bun path-arg skew, or a self-skipping spec — that would otherwise recompute the per-file floor against fewer files and still print `PASS`. Mirrors the #2719 phases discovery floor; one-sided so extra discovered files never false-fail.
- Adds **exclusion transparency**: on a per-file floor failure the report now itemizes all active per-file exclusions (path — reason) so a file masked by a broader `.endsWith()` suffix pattern is visible instead of silently skipped.
- Logic extracted into a new pure module `scripts/coverage-report.ts` (`check-coverage.ts` executes on import and can't be unit-tested directly), with `scripts/coverage-report.spec.ts` covering all four helpers.

Suggested fix 2 from #2744 (unify the coverage glob with the parallel-test glob) is **declined** per the issue — the 221-vs-315 file delta is by design, not a bug.

## Test plan
- [x] `bun typecheck`, `bun lint`, `bun run doing-it-wrong` — all clean
- [x] `scripts/coverage-report.spec.ts` — 16 tests pass (parse, recurse/dedupe/missing-path counting, floor pass/fail/unparseable, exclusion formatting)
- [x] Full `bun scripts/check-coverage.ts` live: `Spec floor: 225 discovered / 225 expected spec file(s)` → `PASS` (exact match, no false-fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)