### PR TITLE
sprint(76): stdio/daemon session-result reliability + CI-gate false-fails

### DIFF
--- a/.claude/diary/20260713.76.md
+++ b/.claude/diary/20260713.76.md
@@ -1,0 +1,64 @@
+# 2026-07-13 — Session-result reliability drain, run through a double quota exhaustion (Sprint 76)
+
+## What was done
+
+18 PRs merged (17 planned + 1 amendment), v1.14.6 released. 100% of plan, zero drops.
+
+**stdio/daemon session-result reliability (the sprint goal):**
+- waitForResult trusts sticky workCompleted flag over transient disconnected state (#2858 / PR #2894) — spawn --wait no longer misses buffered results
+- Self-terminating stdio drain: reader.read() raced against a child-exited sentinel (proc.exited + event-loop-turn yield), state-gated per the #2825 ban on wall-clock drain timeouts (#2879 / PR #2910) — a grandchild holding stdout can no longer hang proc.exited on a resultless crash
+- Result-suppression observability for the num_turns idempotency guard (#2859 / PR #2899)
+- work_items_get returns a queryable `{found: false}` probe instead of isError hard-exit (#2834 / PR #2891)
+- mcx memory audit bounded: callHaiku 120s / fetchClosedIssues 30s, loud failure instead of infinite hang (#2884 / PR #2898, was P1 — this retro's memory-audit step is the first consumer of the fix)
+
+**CI/coverage-gate false-fail kills:**
+- Double-panic pass-by-policy now requires positive-pass evidence; SIGTERM exclusion pinned by spec (#2780 / PR #2889) — validated in production the same day when it correctly hard-failed the #2915 SIGSEGV cluster instead of green-washing it
+- Per-file coverage floor suppressed on degraded runs (#2759 / PR #2888)
+- Partition specs enumerated via git ls-files, not filesystem glob (#2850 / PR #2905)
+- RAN_FILES_RE single-sourced via const-only bun-summary.ts after the first attempt (importing coverage-report.ts from ci-steps.ts) tanked coverage to 16.7% (#2883 / PR #2902, one repair round)
+- pollUntil headroom in the interrupt test — issue's prescribed root cause was disproven by the worker; real cause fixed and documented (#2877 / PR #2912)
+
+**Rules/conformance:**
+- no-stub-import-type-cast rule (#2555 / PR #2906), provider-drift rule (#2603 / PR #2909), agent-protocol Appendix-A sync + forwardSessionEvent symmetry rules (#2553 items 6-7 / PR #2914)
+
+**Worktree/gc:**
+- git-level squash-merge (patch-equivalence) as a third worktree-reclaim signal, plumbing confined to worktree-shim.ts, #2662 skip buckets preserved (#2887 / PR #2911, high scrutiny — data-loss case verified safe by construction in review)
+- findGitRoot/findWorktreeRoot discriminated union replaces the conflated null (#2862 / PR #2896)
+
+**Also:**
+- sites auto-mode falls back on 403 as well as 401 (#2478 / PR #2907)
+- phase state-key leak on non-done terminal paths (#2829 / PR #2908)
+- opencode-server.spec.ts metrics isolation (#2892 / PR #2897, amendment — flake-patrol verdict on the #2889 CI red, orchestrator personally verified the mechanism at opencode-server.spec.ts:574-596 before the qa:fail override)
+
+## What worked well
+
+- **Send-first recovery from the quota double-exhaustion.** All 6 rate-limited sessions revived with a single `mcx claude send` nudge — zero restarts, zero lost work. Two sessions had actually finished before the limit hit; their only gap was work-item bookkeeping (branch/prNumber never recorded), backfilled in one command each.
+- **#2780 paid for itself within hours of merging.** The positive-pass evidence gate hard-failed 4 SIGSEGV runs that the old pass-by-policy would have silently greened. The failure signature it printed (💡 hints + artifact paths) made the #2915 diagnosis a 10-minute job.
+- **Plan-pinned scrutiny overrode triage's churn heuristic correctly.** Triage scored #2879 and #2887 "low" on churn (~80 lines each); the plan pinned both high. Both adversarial reviews approved round 1, but the review of #2887 is what verified the data-loss worst case is safe by construction — exactly what the high pin was for.
+- **Verify-before-implementing discipline held.** #2877's worker disproved the issue's prescribed root cause and fixed the real one instead of cargo-culting.
+- **One-issue-per-shared-gap held under pressure.** The SIGSEGV cluster hit two PRs simultaneously; it produced exactly one issue (#2915) with both data points plus the rerun outcome, not two per-PR "fixes".
+
+## What didn't work
+
+- **~5h monitor blind spot (16:33–21:53Z).** session.result events for three sessions (0314e15b, fc282d64, 05ce3440) that fired at 16:33–16:35Z were never delivered as task notifications — they landed while the orchestrator was mid-turn processing other events. The pipeline sat idle ~5h until an unrelated cross-repo session event woke it. Recovery was cheap (log-read every idle session) but the stall was pure wall-clock loss. Needs an issue on notification delivery during active turns + an orchestrator-side "idle too long → resurvey" habit.
+- **Double 5h-quota exhaustion mid-run.** Extra-usage credits were already at 100% (50,258/50,000), so the second window exhaustion was a hard stop until reset. The mid-run adaptation (impl-freeze at 80%, prompt bye of finished sessions) kept the damage to a pause rather than lost work.
+- **#2883's first implementation tanked coverage to 16.7%** by importing coverage-report.ts (which drags the world in) from ci-steps.ts. Real PR-caused failure, correctly escalated, one repair round produced the right structure (const-only shared module). The lesson is already generalized in docs/architecture/duplication.md — abstract the noun (the regex), not the module.
+- **CI SIGSEGV flake cluster (#2915):** 4/4 crashes across two branches at the same site (right after scripts/bun-segfault-repro/repro.test.ts, inside the next spec file), then 2/2 clean on rerun. The deliberate #28415 repro living inside the CI partition is a standing crash bomb; #2915 carries the quarantine proposal.
+- **QA sessions' final result frame is the follow-up note, not the verdict.** Twice (52a971ed, 2b842293) the session.result payload was "follow-up issue already filed" because the verdict message and the issue-author handoff raced; the verdict was one frame earlier in the log. Cosmetic but cost a log-read each time to confirm the pass.
+
+## Patterns established
+
+- **Rate-limited session recovery: send first, restart never.** A rate-limit result frame ends the turn but preserves the session; a resume message continues from full context. Restarting by session id would have re-paid ~$3-7 of context per worker.
+- **Backfill-then-triage for sessions that die after PR-push but before bookkeeping**: set branch+prNumber via work_items_update, then run the normal triage→qa chain; no special-casing needed.
+- **Plan-pinned scrutiny is authoritative over triage churn heuristics** — write the override into phase state immediately after triage runs.
+
+## Stats
+
+- **PRs merged**: 18 (+ sprint container #2886)
+- **Issues closed**: 18
+- **Adversarial reviews**: 3 (#2879, #2887, #2603) — 0 blocking findings, all round-1 approvals
+- **Repair rounds**: 1 (#2883 coverage collapse)
+- **qa:fail overrides**: 1 (#2889 CI red → flake-patrol → pre-existing main defect #2892, amended into sprint and fixed)
+- **Failed/dropped**: 0
+- **New issues filed**: 9 (#2890, #2892, #2893, #2895, #2904, #2913, #2915, #2916, #2917) + data points on #2690 and #2915
+- **Sprint cost**: ~$45 observed across post-recovery sessions (impl $1.5–7, QA $0.3–0.7, reviews $2.1–2.3 each); day-1 session costs not fully captured across the context compaction

--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -30,6 +30,7 @@
 - [Never bypass gates (--no-verify banned)](feedback_never_bypass_gate.md) — push blocked by a flake → retry (never --no-verify); same tracked signature → wait + retry once more; NEW signature → stop and report. CI on clean runners is the arbiter
 
 ## Infra / Known Issues
+- [Bedrock for spawns (#935)](project_bedrock_spawns_935.md) — quota-stall escape hatch: restart daemon from Bedrock-env shell; model-ID caveat with `--model opus`
 - [CPU wedge: bun test-workers](cpu-wedge-test-workers.md) — ⚠️ CORRECTED: the band-aid killers (orphan-sweep preload + watchdog #2597 + cap #2632) WERE the disease, reverted in #2637. No real leak: clean main runs coverage in ~45s. Rule: never fix a leak with a process killer / host-wide `ps`+kill. See retro `.claude/diary/20260530.70.md`
 - [Early segfault = check host load first](false-segfault-orphaned-load.md) — am-i-done aborting ~25-30s with a Bun segfault + mass `worker panicked` cascade is usually host CPU starvation (orphaned `bun build/burn.ts` from investigations), not a code bug; check `uptime` + PPID=1 bun procs before treating as real
 - [CI suite SIGTERM at ~97%](ci-suite-sigterm-resource-leak.md) — large `bun test` killed near end with 0 failures, Linux-only, passes isolated = resource leak in test files, NOT a size threshold. A hang / near-end SIGTERM is a STOP-and-fix-root-cause signal — never a killer/reaper/timeout-bump (those caused the 69/70 collapse). Diagnose with bias-free adversarial review. #2641→#2644.

--- a/.claude/memory/project_bedrock_spawns_935.md
+++ b/.claude/memory/project_bedrock_spawns_935.md
@@ -1,0 +1,14 @@
+---
+name: project-bedrock-spawns-935
+description: Bedrock for mcx claude spawns — issue
+metadata: 
+  node_type: memory
+  type: project
+  originSessionId: edbafd85-70a1-4903-a1b0-46b69a5a179b
+---
+
+Routing `mcx claude` / `mcx agent claude` spawns to Bedrock (unmetered, vs company-capped Anthropic extra usage) is tracked in **#935** (profiles / `--profile` + `~/.mcp-cli/profiles/`); fresh data point added 2026-07-13 after sprint 76 stalled 3× on quota.
+
+**Workaround today (daemon-global):** spawned claude processes inherit the daemon's env (`ws-server.ts` spawnClaude merges `process.env`). So: `mcx serve-kill`, then in a shell run `source <(grep '^export' ~/github/claude_bedrock.sh)` and any `mcx` command — the auto-started daemon carries the Bedrock vars and every subsequent spawn uses Bedrock. Fragile: a later daemon auto-start from a non-Bedrock shell silently reverts.
+
+**Caveat:** `resolveModelName` (`packages/core/src/model.ts`) turns `--model opus` into `claude-opus-4-8` — not a Bedrock inference profile. Under Bedrock, either omit `--model` (env `ANTHROPIC_MODEL` applies) or pass full `us.anthropic.*` IDs; explicit resolved IDs also defeat `ANTHROPIC_DEFAULT_*_MODEL` tier aliases.

--- a/.claude/sprints/sprint-76.md
+++ b/.claude/sprints/sprint-76.md
@@ -4,6 +4,7 @@
 > Amended 2026-07-12 12:54 EDT — added #2887 (git-level squash-merge gc signal) to Batch 3 as filler.
 > Started 2026-07-12 12:55 EDT.
 > Amended 2026-07-12 13:15 EDT — added #2892 (opencode-server.spec.ts global-metrics test-isolation defect; flake-patrol verdict on the #2889 CI red). Hot-file check: touches only packages/daemon/src/opencode-server.spec.ts — no overlap with any batched or in-flight pick.
+> Completed 2026-07-13 18:09 EDT — 18/18 merged. Run spanned a double 5h-quota exhaustion (extra-usage credits at 100%, hard pause to window reset) and a ~5h monitor blind spot (session.result events missed 16:33–21:53Z; recovered by log-reading each idle session). CI SIGSEGV flake cluster filed as #2915.
 
 ## Goal
 

--- a/.claude/sprints/sprint-76.md
+++ b/.claude/sprints/sprint-76.md
@@ -3,6 +3,7 @@
 > Planned 2026-07-12 09:55 EDT. Target: 17 PRs.
 > Amended 2026-07-12 12:54 EDT — added #2887 (git-level squash-merge gc signal) to Batch 3 as filler.
 > Started 2026-07-12 12:55 EDT.
+> Amended 2026-07-12 13:15 EDT — added #2892 (opencode-server.spec.ts global-metrics test-isolation defect; flake-patrol verdict on the #2889 CI red). Hot-file check: touches only packages/daemon/src/opencode-server.spec.ts — no overlap with any batched or in-flight pick.
 
 ## Goal
 
@@ -29,6 +30,7 @@ Close the stdio/daemon session-result reliability class opened by sprint 75, and
 | 2877 | cli-orchestration.spec.ts:554 pollUntil(5000) has zero headroom against Bun's 5s timeout | low | 3 | opus | claude | filler |
 | 2553 | agent-protocol conformance rules — items 6-7 ONLY (Appendix A type-set + mirror-replay checks) | medium | 3 | opus | claude | filler |
 | 2887 | git-level squash-merge detection (patch-equivalence) as a 3rd worktree-reclaim signal | high | 3 | opus | claude | filler |
+| 2892 | opencode-server.spec.ts asserts on global metrics singleton — port #956/#975 isolation fix (amendment) | low | 2 | opus | claude | goal |
 
 ## Batch Plan
 

--- a/.claude/sprints/sprint-76.md
+++ b/.claude/sprints/sprint-76.md
@@ -1,0 +1,59 @@
+# Sprint 76
+
+> Planned 2026-07-12 09:55 EDT. Target: 16 PRs.
+
+## Goal
+
+Close the stdio/daemon session-result reliability class opened by sprint 75, and kill the CI/coverage-gate false-fail bugs that block the sprint pipeline itself.
+
+## Issues
+
+| # | Title | Scrutiny | Batch | Model | Provider | Category |
+|---|-------|----------|-------|-------|----------|----------|
+| 2858 | waitForResult rejects disconnected before workCompleted fast-path → spawn --wait misses buffered result | medium | 1 | opus | claude | goal |
+| 2780 | double-panic pass-by-policy has no positive-pass evidence gate; SIGTERM exclusion unpinned | medium | 1 | opus | claude | goal |
+| 2884 | mcx memory audit --json hangs indefinitely (P1 — blocks retro memory-prune) | medium | 1 | opus | claude | goal |
+| 2834 | _work_items server isError:true for queryable not-found hard-exits mcx call after #2821 | medium | 1 | opus | claude | goal |
+| 2759 | check-coverage per-file floor misleads when a parallel worker is silently killed (spec-count drop) | medium | 1 | opus | claude | goal |
+| 2879 | proc.exited handler hangs on crash-without-frame + grandchild holding stdout fd | high | 2 | opus | claude | goal |
+| 2859 | idempotency guard in handleResult() suppresses silently — add debug log + metric | low | 2 | opus | claude | goal |
+| 2862 | findWorktreeRoot/findGitRoot conflate not-a-repo / missing-git / timeout into one null | medium | 2 | opus | claude | filler |
+| 2555 | doing-it-wrong rule: flag `as ReturnType<typeof import(...)>` casts in *.spec.ts | low | 2 | opus | claude | filler |
+| 2850 | test-partition allSpecFiles() picks up gitignored scratch specs under build/ | low | 2 | opus | claude | filler |
+| 2883 | dedup RAN_FILES_RE regex (ci-steps.ts imports from coverage-report.ts) | low | 3 | opus | claude | filler |
+| 2829 | artifact_check / merge_block_labels state keys leak on non-done-success terminal paths | low | 3 | opus | claude | filler |
+| 2478 | sites auto-mode fallback should also trigger on 403, not just 401 | low | 3 | opus | claude | filler |
+| 2603 | doing-it-wrong rule: PROVIDER_NAMES drift vs *-session-worker.ts files | low | 3 | opus | claude | filler |
+| 2877 | cli-orchestration.spec.ts:554 pollUntil(5000) has zero headroom against Bun's 5s timeout | low | 3 | opus | claude | filler |
+| 2553 | agent-protocol conformance rules — items 6-7 ONLY (Appendix A type-set + mirror-replay checks) | medium | 3 | opus | claude | filler |
+
+## Batch Plan
+
+### Batch 1 (immediate)
+#2858, #2780, #2884, #2834, #2759
+
+### Batch 2 (backfill)
+#2879, #2859, #2862, #2555, #2850
+
+### Batch 3 (backfill)
+#2883, #2829, #2478, #2603, #2877, #2553
+
+### Dependency edges (translate to `addBlockedBy` at run time)
+- #2879 blockedBy #2858 (both edit `packages/daemon/src/claude-session/ws-server.ts` — 2858 at waitForResult ~1710, 2879 at proc.exited ~1030; serialize to avoid a shared-file rebase)
+- #2883 blockedBy #2780 (both edit `scripts/_runner/ci-steps.ts` — 2780 gates the panic branch, 2883 removes the dup RAN_FILES_RE; 2883 rebases onto 2780)
+
+### Hot-shared file watch
+- `packages/daemon/src/claude-session/ws-server.ts` — #2858, #2879 (serialized via edge above). No other picks touch it (#2860/#2868 deferred).
+- `scripts/_runner/ci-steps.ts` — #2780, #2883 (serialized). #2883 also reads the already-exported `RAN_FILES_RE` from `coverage-report.ts` — no edit there, no collision.
+- `packages/daemon/src/claude-session/session-state.ts` — only #2859 now (#2860/#2868 deferred), no collision.
+- New `scripts/rules/*.rule.ts` files (#2555, #2603) are distinct filenames — no collision with each other or #2553's conformance rules.
+- No dispatch-table (main.ts / router / registry) collisions among these picks.
+
+### Pre-session clarifications required
+- **#2879**: design-sensitive. The bounded `reader.cancel()` guard for the abnormal-exit sub-case must NOT reintroduce a wall-clock delay — #2825 banned that pattern (the ws-server-stdio-load drain-timeout regression). Gate the cancel on "no result expected", not on a timer. High scrutiny → adversarial + QA.
+- **#2860 rescope note (deferred, not picked)**: its Option B docstring already landed; only Option A (actual lastEmittedNumTurns persistence) remained, and that needs design — deferred.
+- **#2553**: scope is **items 6-7 only** (the two conformance lint rules: Appendix A event/message inventory validated against `BASE_WORKER_EVENT_TYPES` + per-provider `CONTROL_MESSAGE_TYPES`; and `forwardSessionEvent` symmetry across providers). Doc-polish items 1-5 are a stretch goal, not required for QA pass.
+
+## Context
+
+Sprint 75 shipped "orchestrator reliability — stdio drop/hang class, monitor blind spots, phase-lock". This sprint drains the residual session-result reliability follow-ons it spawned (#2858, #2859, #2879) plus the CI/coverage-gate false-fail bugs that directly cost every worker diagnostic time (#2780, #2759, #2883, #2850, #2877). Recon closed #2881 (fix already on main) and deferred #2860/#2868 (partial/unreachable), which dissolved the ws-server/session-state serialization pinch — the session cluster is now cleanly parallelizable except the two documented edges. #2884 is P1: the memory-audit hang blocks the retro's memory-prune step, so it lands in Batch 1.

--- a/.claude/sprints/sprint-76.md
+++ b/.claude/sprints/sprint-76.md
@@ -2,6 +2,7 @@
 
 > Planned 2026-07-12 09:55 EDT. Target: 17 PRs.
 > Amended 2026-07-12 12:54 EDT — added #2887 (git-level squash-merge gc signal) to Batch 3 as filler.
+> Started 2026-07-12 12:55 EDT.
 
 ## Goal
 

--- a/.claude/sprints/sprint-76.md
+++ b/.claude/sprints/sprint-76.md
@@ -65,3 +65,12 @@ Close the stdio/daemon session-result reliability class opened by sprint 75, and
 ## Context
 
 Sprint 75 shipped "orchestrator reliability — stdio drop/hang class, monitor blind spots, phase-lock". This sprint drains the residual session-result reliability follow-ons it spawned (#2858, #2859, #2879) plus the CI/coverage-gate false-fail bugs that directly cost every worker diagnostic time (#2780, #2759, #2883, #2850, #2877). Recon closed #2881 (fix already on main) and deferred #2860/#2868 (partial/unreachable), which dissolved the ws-server/session-state serialization pinch — the session cluster is now cleanly parallelizable except the two documented edges. #2884 is P1: the memory-audit hang blocks the retro's memory-prune step, so it lands in Batch 1.
+
+## Results
+
+- **Released**: v1.14.6 (tag at retro, after the sprint container PR merges)
+- **PRs merged**: 18/18 (17 planned + amendment #2892) — 100% of plan, including both high-scrutiny items (#2879, #2887)
+- **Issues closed**: 18
+- **Issues dropped**: 0
+- **New issues filed**: 9 — #2890 (retry-rate observability), #2892 (amended into sprint, closed), #2893 (work-items meta-doc drift), #2895 (handshakeTimer clearTimeout leak), #2904 (verdict-key-probe tmp leak), #2913 (rule-pattern gap: provider-drift + protocol-version-spec-sync), #2915 (CI SIGSEGV flake cluster, 4/4 then 2/2-clean rerun data), #2916, #2917 (follow-ups from QA); plus data points on #2690 (host-load convoy) and #2915
+- **Notable run events**: double 5h-quota exhaustion mid-run (extra-usage at 100%, hard pause to reset; all 6 rate-limited sessions revived via send, zero restarts); ~5h monitor blind spot (session.result events 16:33–21:53Z never delivered — recovered by log-reading idle sessions); #2915 SIGSEGV cluster blocked 2 PRs, cleared by rerun (flake confirmed)

--- a/.claude/sprints/sprint-76.md
+++ b/.claude/sprints/sprint-76.md
@@ -1,6 +1,7 @@
 # Sprint 76
 
-> Planned 2026-07-12 09:55 EDT. Target: 16 PRs.
+> Planned 2026-07-12 09:55 EDT. Target: 17 PRs.
+> Amended 2026-07-12 12:54 EDT — added #2887 (git-level squash-merge gc signal) to Batch 3 as filler.
 
 ## Goal
 
@@ -26,6 +27,7 @@ Close the stdio/daemon session-result reliability class opened by sprint 75, and
 | 2603 | doing-it-wrong rule: PROVIDER_NAMES drift vs *-session-worker.ts files | low | 3 | opus | claude | filler |
 | 2877 | cli-orchestration.spec.ts:554 pollUntil(5000) has zero headroom against Bun's 5s timeout | low | 3 | opus | claude | filler |
 | 2553 | agent-protocol conformance rules — items 6-7 ONLY (Appendix A type-set + mirror-replay checks) | medium | 3 | opus | claude | filler |
+| 2887 | git-level squash-merge detection (patch-equivalence) as a 3rd worktree-reclaim signal | high | 3 | opus | claude | filler |
 
 ## Batch Plan
 
@@ -36,7 +38,7 @@ Close the stdio/daemon session-result reliability class opened by sprint 75, and
 #2879, #2859, #2862, #2555, #2850
 
 ### Batch 3 (backfill)
-#2883, #2829, #2478, #2603, #2877, #2553
+#2883, #2829, #2478, #2603, #2877, #2553, #2887
 
 ### Dependency edges (translate to `addBlockedBy` at run time)
 - #2879 blockedBy #2858 (both edit `packages/daemon/src/claude-session/ws-server.ts` — 2858 at waitForResult ~1710, 2879 at proc.exited ~1030; serialize to avoid a shared-file rebase)
@@ -47,12 +49,14 @@ Close the stdio/daemon session-result reliability class opened by sprint 75, and
 - `scripts/_runner/ci-steps.ts` — #2780, #2883 (serialized). #2883 also reads the already-exported `RAN_FILES_RE` from `coverage-report.ts` — no edit there, no collision.
 - `packages/daemon/src/claude-session/session-state.ts` — only #2859 now (#2860/#2868 deferred), no collision.
 - New `scripts/rules/*.rule.ts` files (#2555, #2603) are distinct filenames — no collision with each other or #2553's conformance rules.
+- `packages/core/src/worktree-shim.ts` + `packages/command/src/commands/gc.ts` — only #2887. No other pick touches either. **#2887 must keep its git primitive in `worktree-shim.ts`, NOT `packages/core/src/git.ts`** — #2862 edits git.ts (findGitRoot/findWorktreeRoot) this sprint; an additive export there is a same-file collision risk. Constraint pinned in the #2887 body.
 - No dispatch-table (main.ts / router / registry) collisions among these picks.
 
 ### Pre-session clarifications required
 - **#2879**: design-sensitive. The bounded `reader.cancel()` guard for the abnormal-exit sub-case must NOT reintroduce a wall-clock delay — #2825 banned that pattern (the ws-server-stdio-load drain-timeout regression). Gate the cancel on "no result expected", not on a timer. High scrutiny → adversarial + QA.
 - **#2860 rescope note (deferred, not picked)**: its Option B docstring already landed; only Option A (actual lastEmittedNumTurns persistence) remained, and that needs design — deferred.
 - **#2553**: scope is **items 6-7 only** (the two conformance lint rules: Appendix A event/message inventory validated against `BASE_WORKER_EVENT_TYPES` + per-provider `CONTROL_MESSAGE_TYPES`; and `forwardSessionEvent` symmetry across providers). Doc-polish items 1-5 are a stretch goal, not required for QA pass.
+- **#2887** (high scrutiny — data-loss risk): the new git-level squash signal deletes non-ancestor branch tips with `git branch -D`. A false-positive patch-equivalence match that force-deletes committed-but-unpushed work is the worst-case regression. MUST preserve the #2662 skip buckets (dirty / active-session / `isAheadOfForge`-unpushed → `skippedUnpushed`) and ship a spec for the ahead-of-forge and genuinely-unmerged-lookalike cases. Port theshadow27's existing validated script (source pending in the #2887 comment) rather than re-deriving. Keep git plumbing in `worktree-shim.ts` (see hot-shared note).
 
 ## Context
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "bun": ">=1.3.14"
   },
-  "version": "1.14.5",
+  "version": "1.14.6",
   "description": "MCP CLI — call MCP server tools from the command line with zero context overhead",
   "type": "module",
   "workspaces": ["packages/*", "agent-grid"],


### PR DESCRIPTION
Sprint 76 container PR. Accumulates every sprint-meta commit on the `sprint-76` branch:

- plan + any mid-sprint amendments
- run-time edits (Started/Ended timestamps, Excluded section)
- Results summary
- retro diary file
- release commit (if a release is cut this sprint)

**Goal:** Close the stdio/daemon session-result reliability class opened by sprint 75, and kill the CI/coverage-gate false-fail bugs that block the sprint pipeline.

16 issues across 3 batches. Two serialization edges: #2879→#2858 (ws-server.ts), #2883→#2780 (ci-steps.ts).

Marked **draft** until `/sprint retro` flips it ready and arms auto-merge.

Docs/skill-only by construction — pre-commit hooks should skip the test suite.