### PR TITLE
fix(coverage): suppress misleading per-file floor output on degraded run (fixes #2759)

### DIFF
--- a/scripts/check-coverage.ts
+++ b/scripts/check-coverage.ts
@@ -127,7 +127,12 @@ const EXCLUSIONS: Record<string, string> = {
 import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { coveragePathInDiff, resolveChangedSourceFiles } from "./coverage-diff";
-import { checkSpecCountFloor, countExpectedSpecFiles, formatExclusionList } from "./coverage-report";
+import {
+  checkSpecCountFloor,
+  countExpectedSpecFiles,
+  formatDegradedRunError,
+  formatExclusionList,
+} from "./coverage-report";
 // staged-files still available for --ci mode if needed in the future
 import { logTestRun } from "./test-failure-log";
 import { detectTestNoise } from "./test-noise";
@@ -445,6 +450,27 @@ console.log(
   `Per-file:  ${PER_FILE_MIN_LINES}% lines minimum (${Object.keys(EXCLUSIONS).length} exclusions${isDiffScoped ? `, diff-scoped to ${changedFiles.size} changed file(s)` : ""})`,
 );
 
+// --- Spec-count sanity floor (#2815, #2759) — checked FIRST ---
+// Guard against a silent shrink of the coverage surface: if run-1 discovers
+// fewer spec files than exist on disk under its run paths, a worker was
+// silently SIGTERM'd (host oversubscription #2690) or a glob/path regression
+// dropped files. The per-file floor and global thresholds above were recomputed
+// against fewer files — the low-coverage files they would flag (e.g.
+// reporter.ts, opencode-client.ts) are an artifact of the missing run, not a
+// real regression. Fail closed and short-circuit BEFORE printing the misleading
+// per-file/global failures so the reader re-runs rather than chasing unrelated
+// files (#2759). Checked against run-1 output only (the coverage table we
+// parse); run-2 daemon specs have their own discovery gate in ci-steps.ts (#2719).
+const expectedSpecFiles = countExpectedSpecFiles(nonDaemonPaths, resolve(import.meta.dir, ".."));
+const specFloor = checkSpecCountFloor(coverageRun1, expectedSpecFiles);
+console.log(`Spec floor: ${specFloor.discovered ?? "?"} discovered / ${specFloor.expected} expected spec file(s)`);
+if (!specFloor.ok) {
+  for (const line of formatDegradedRunError(specFloor)) {
+    console.error(line);
+  }
+  process.exit(1);
+}
+
 let failed = false;
 
 if (globalFuncs < GLOBAL_THRESHOLDS.functions) {
@@ -454,20 +480,6 @@ if (globalFuncs < GLOBAL_THRESHOLDS.functions) {
 
 if (globalLines < GLOBAL_THRESHOLDS.lines) {
   console.error(`\nFAIL: Line coverage ${globalLines}% is below global threshold ${GLOBAL_THRESHOLDS.lines}%`);
-  failed = true;
-}
-
-// --- Spec-count sanity floor (#2815) ---
-// Guard against a silent shrink of the coverage surface: if run-1 discovers
-// fewer spec files than exist on disk under its run paths, the per-file floor
-// above was recomputed against fewer files and would still print PASS. Fail
-// closed. Checked against run-1 output only (the coverage table we parse);
-// run-2 daemon specs have their own discovery gate in ci-steps.ts (#2719).
-const expectedSpecFiles = countExpectedSpecFiles(nonDaemonPaths, resolve(import.meta.dir, ".."));
-const specFloor = checkSpecCountFloor(coverageRun1, expectedSpecFiles);
-console.log(`Spec floor: ${specFloor.discovered ?? "?"} discovered / ${specFloor.expected} expected spec file(s)`);
-if (!specFloor.ok) {
-  console.error(`\nFAIL: ${specFloor.reason}`);
   failed = true;
 }
 

--- a/scripts/coverage-report.spec.ts
+++ b/scripts/coverage-report.spec.ts
@@ -6,6 +6,7 @@ import {
   RAN_FILES_RE,
   checkSpecCountFloor,
   countExpectedSpecFiles,
+  formatDegradedRunError,
   formatExclusionList,
   parseDiscoveredFileCount,
 } from "./coverage-report";
@@ -112,6 +113,25 @@ describe("checkSpecCountFloor", () => {
     expect(r.ok).toBe(false);
     expect(r.discovered).toBeNull();
     expect(r.reason).toContain("failing closed");
+  });
+});
+
+describe("formatDegradedRunError", () => {
+  test("reports the discovered/expected mismatch and suppression + re-run guidance", () => {
+    const r = checkSpecCountFloor("Ran 100 tests across 221 files.", 315);
+    const lines = formatDegradedRunError(r);
+    const joined = lines.join("\n");
+    expect(joined).toContain("Suspected worker crash");
+    expect(joined).toContain("221 discovered < 315 expected");
+    expect(joined).toContain("unreliable and have been suppressed");
+    expect(joined).toContain("Re-run");
+    expect(joined).toContain("#2759");
+  });
+
+  test("renders '?' for an unparseable summary (null discovered)", () => {
+    const r = checkSpecCountFloor("bun changed its output format", 315);
+    const joined = formatDegradedRunError(r).join("\n");
+    expect(joined).toContain("? discovered < 315 expected");
   });
 });
 

--- a/scripts/coverage-report.ts
+++ b/scripts/coverage-report.ts
@@ -82,3 +82,21 @@ export function checkSpecCountFloor(output: string, expected: number): SpecFloor
 export function formatExclusionList(exclusions: Record<string, string>): string[] {
   return Object.entries(exclusions).map(([path, reason]) => `  ${path} — ${reason}`);
 }
+
+/**
+ * Hard-error output for a degraded coverage run (#2759). When the spec-count
+ * floor trips, the per-file and global coverage numbers were computed from a
+ * partial file set — a worker was silently SIGTERM'd under host oversubscription
+ * (#2690), or a glob/path regression shrank the surface. The low-coverage files
+ * such a run flags (e.g. reporter.ts, opencode-client.ts) are an artifact of the
+ * missing files, not a real regression, so callers must suppress the per-file
+ * failure listing and re-run rather than chase unrelated files.
+ */
+export function formatDegradedRunError(result: SpecFloorResult): string[] {
+  return [
+    `\nFAIL: ${result.reason}`,
+    `\nSuspected worker crash — spec file count mismatch (${result.discovered ?? "?"} discovered < ${result.expected} expected).`,
+    "Per-file and global coverage results are unreliable and have been suppressed.",
+    "Re-run `bun run am-i-done` (#2759).",
+  ];
+}


### PR DESCRIPTION
## Summary
- When a coverage run discovers fewer spec files than exist on disk (a Bun worker SIGTERM'd under host oversubscription #2690, or a glob/path regression), the per-file and global coverage numbers are computed from a partial set — the low-coverage files they flag (e.g. `reporter.ts`, `opencode-client.ts`) are an artifact of the missing run, not a real regression.
- The #2815 spec-count floor already *detected* this but still printed the misleading per-file failures alongside the floor FAIL, sending the reader to chase unrelated files.
- Moved the spec-count floor check before global/per-file enforcement in `check-coverage.ts` and short-circuit with a clear "Suspected worker crash — re-run `bun run am-i-done`" message, suppressing the unreliable per-file/global output. Extracted `formatDegradedRunError` as a pure, tested helper in `coverage-report.ts`.

## Test plan
- [x] `bun test scripts/coverage-report.spec.ts` — new `formatDegradedRunError` cases (count mismatch + unparseable-summary `?` rendering)
- [x] `bun run am-i-done` — full gate green (typecheck, lint, rules, tests, coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)