### PR TITLE
hardening(ci-steps): gate double-panic tolerance on positive-pass evidence (fixes #2780)

### DIFF
--- a/scripts/_runner/ci-steps.spec.ts
+++ b/scripts/_runner/ci-steps.spec.ts
@@ -285,12 +285,29 @@ exit 1
     expect(result).toMatchObject({ success: false });
   });
 
-  it("exit 132 panic on both runs → pass-by-policy (#1004)", async () => {
-    // The fake bun deterministically returns the same exit code each time: a
-    // 132 panic on the first run triggers the retry, the retry panics again,
-    // and a panic-on-retry is treated as pass per #1004 (known upstream bug).
+  it("exit 132 panic on both runs with NO pass evidence → hard failure (#2780)", async () => {
+    // The fake bun deterministically returns exit 132 with no " 0 fail" line
+    // and junit failures=1 each time: the first panic triggers the retry, the
+    // retry panics again, and — since neither run recorded a clean summary —
+    // the double panic is a hard failure, not a tolerated pass. Promoting it
+    // would report the partition green with zero proof the suite passed (#2780).
     const dir = makeFakeBun({ code: 132 });
     const step = bunTestWithCrashTolerance({ paths: ["packages/daemon"], logName: "test_x" });
+    const result = await runWith(dir, () =>
+      (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
+        logger: createCaptureLogger(),
+      }),
+    );
+    expect(result).toMatchObject({ success: false });
+  });
+
+  it("exit 132 panic on first run, panic + ' 0 fail' on retry → pass-by-policy (#1004)", async () => {
+    // The genuine #1004 shape after the #2780 tightening: the first run panics
+    // with real failure evidence (no retry short-circuit), then the retry also
+    // panics BUT records zero failures. The retry's clean summary is authoritative
+    // — a panic AFTER a clean run is the tolerated upstream bug.
+    const dir = makeTwoPassFakeBun({ code: 132, stdout: failingSummary }, { code: 132, stdout: passingSummary });
+    const step = bunTestWithCrashTolerance({ paths: ["packages/daemon"], logName: "test_double_panic_evidence" });
     const result = await runWith(dir, () =>
       (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
         logger: createCaptureLogger(),
@@ -339,7 +356,11 @@ exit 139
     expect(result).toEqual({ success: true });
   });
 
-  it("SIGSEGV signal kill on both runs → pass-by-policy (#2754)", async () => {
+  it("SIGSEGV signal kill on both runs with NO pass evidence → hard failure (#2780)", async () => {
+    // A signal kill writes no junit file and emits no " 0 fail" line, so both
+    // runs carry zero pass evidence. Post-#2780 that is a hard failure — the
+    // retry fires (the #2754 regression is still covered by the "then exit 0"
+    // tests above), but a double panic without corroboration is not promoted.
     const dir = makeAlwaysSignalFakeBun("SIGSEGV");
     const step = bunTestWithCrashTolerance({ paths: ["packages/daemon"], logName: "test_sig2" });
     const result = await runWith(dir, () =>
@@ -347,16 +368,13 @@ exit 139
         logger: createCaptureLogger(),
       }),
     );
-    expect(result).toEqual({ success: true });
+    expect(result).toMatchObject({ success: false });
   });
 
-  it("non-daemon partition (no daemon-only flag) retries a SIGSEGV panic — regression for #2754 qa:fail", async () => {
-    // Before this fix the non-daemon CI partition was wired retryOn132:false and
-    // the retry gate short-circuited on that flag BEFORE the panic classifier ran,
-    // so a SIGSEGV in the non-daemon suite (e.g. acp-cost-tracking-evidence.spec.ts)
-    // hard-failed CI with no retry — the exact crash this PR set out to absorb.
-    // Panic-retry is now unconditional: a signal kill on both runs is pass-by-policy
-    // regardless of partition.
+  it("non-daemon partition: SIGSEGV panic on both runs with NO evidence → hard failure (#2780)", async () => {
+    // The #2754 retry is unconditional across partitions (no retryOn132 flag),
+    // but the #2780 tightening means a double SIGSEGV with no clean summary
+    // fails regardless of partition — it is no longer pass-by-policy.
     const dir = makeAlwaysSignalFakeBun("SIGSEGV");
     const step = bunTestWithCrashTolerance({ paths: ["packages/core"], logName: "test_sig3" });
     const result = await runWith(dir, () =>
@@ -364,7 +382,7 @@ exit 139
         logger: createCaptureLogger(),
       }),
     );
-    expect(result).toEqual({ success: true });
+    expect(result).toMatchObject({ success: false });
   });
 
   it("SIGTRAP and SIGABRT signal kills are retried as panics (#2754 owner comment)", async () => {
@@ -378,6 +396,24 @@ exit 139
       );
       expect(result).toEqual({ success: true });
     }
+  });
+
+  it("SIGTERM is NOT a panic — a SIGTERM-killed run is not retried (pins the exclusion, #2780)", async () => {
+    // SIGTERM is the runner's own timeout-kill signal; retrying it would mask a
+    // hang. It is deliberately excluded from isBunPanic. This test pins that:
+    // the fake bun is killed by SIGTERM on the first run, then would exit 0 with
+    // a clean summary on any retry. Because SIGTERM is not a panic, the retry
+    // never fires and the first-run kill falls straight through to a failure.
+    // A future edit adding SIGTERM to the panic set would let the retry succeed,
+    // flipping this assertion to success — which is exactly what must not happen.
+    const dir = makeSignalThenExitFakeBun("SIGTERM", { code: 0, stdout: passingSummary });
+    const step = bunTestWithCrashTolerance({ paths: ["packages/core"], logName: "test_sigterm" });
+    const result = await runWith(dir, () =>
+      (step as (o: { logger: ReturnType<typeof createCaptureLogger> }) => Promise<unknown>)({
+        logger: createCaptureLogger(),
+      }),
+    );
+    expect(result).toMatchObject({ success: false });
   });
 
   it("forwards StepOptions.env to the spawned subprocess (#2389 review)", async () => {

--- a/scripts/_runner/ci-steps.ts
+++ b/scripts/_runner/ci-steps.ts
@@ -263,10 +263,12 @@ export function bunTestWithCrashTolerance(opts: TestOpts): ScriptFunction {
       logger.warn(`bun crash (exit ${second.code}) on retry after all tests passed — treating as pass (#1004)`);
       return { success: true };
     }
-    if (isBunPanic(second.code, second.signal)) {
-      logger.warn("bun panic on retry too — treating as pass (known upstream bug, #1004)");
-      return { success: true };
-    }
+    // A panic on BOTH runs is only tolerated when the retry recorded zero
+    // failures — which the check above already handled. A double panic with no
+    // pass evidence (no junit, no " 0 fail" line) is a hard failure, not a
+    // pass-by-policy: promoting it would report a partition green with zero
+    // proof the suite passed, and hides the "abort instead of fail" gaming
+    // vector (SIGABRT/SIGTRAP are userspace-raisable). #2780.
     return { success: false, error: `exit ${second.code}` };
   };
 }


### PR DESCRIPTION
## Summary
- **Gap 1:** Removed the unconditional double-panic pass-by-policy in `bunTestWithCrashTolerance` (`ci-steps.ts`). A panic on both the initial run AND the retry was reported green with zero proof the suite passed. The retained `hasZeroJunitFailures(second)` gate at the prior line already covers the genuine #1004 shape (panic *after* a clean summary), so the issue's suggested `isBunPanic(second) && hasZeroJunitFailures(second)` guard is **dead relative to it** — I deleted the branch instead of adding an unreachable one. Same guarantee, no dead code.
- **Gap 3:** Added a regression test pinning SIGTERM's exclusion from the panic set — a SIGTERM-killed run must not be retried (retrying the runner's own timeout-kill would mask hangs). The test drives it through the public factory: SIGTERM-then-exit-0 must return failure (no retry fires).
- Updated the #2754/#1004 both-run-panic tests, which asserted the now-unsafe policy, to expect failure; added a positive test that a panic-then-panic-with-`0 fail`-evidence still passes (#1004 preserved).

**Gap 2** (retry-rate audit counter) is explicitly non-blocking per the issue — filed as a follow-up.

## Test plan
- [x] `bun test scripts/_runner/ci-steps.spec.ts` — 46 pass
- [x] `bun run am-i-done` — full gate green (typecheck, lint, rules, tests, coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)