### PR TITLE
fix(work-items): work_items_get returns queryable { found } probe, not isError (fixes #2834)

### DIFF
--- a/packages/daemon/src/work-items-server.spec.ts
+++ b/packages/daemon/src/work-items-server.spec.ts
@@ -221,12 +221,14 @@ describe("WorkItemsServer", () => {
     const parsed = JSON.parse(content[0].text);
     expect(parsed.deleted).toBe("pr:100");
 
-    // Verify it's gone
+    // Verify it's gone — a not-found probe is a non-error discriminable result (#2834)
     const getResult = await client.callTool({
       name: "work_items_get",
       arguments: { id: "pr:100" },
     });
-    expect(getResult.isError).toBe(true);
+    expect(getResult.isError).toBeFalsy();
+    const gone = JSON.parse((getResult.content as Array<{ text: string }>)[0].text);
+    expect(gone).toEqual({ found: false, id: "pr:100" });
   });
 
   test("work_items_list returns all items", async () => {
@@ -290,8 +292,9 @@ describe("WorkItemsServer", () => {
 
     expect(result.isError).toBeFalsy();
     const content = result.content as Array<{ type: string; text: string }>;
-    const item = JSON.parse(content[0].text);
-    expect(item.prNumber).toBe(42);
+    const parsed = JSON.parse(content[0].text);
+    expect(parsed.found).toBe(true);
+    expect(parsed.item.prNumber).toBe(42);
   });
 
   test("work_items_get retrieves by PR number", async () => {
@@ -310,8 +313,9 @@ describe("WorkItemsServer", () => {
 
     expect(result.isError).toBeFalsy();
     const content = result.content as Array<{ type: string; text: string }>;
-    const item = JSON.parse(content[0].text);
-    expect(item.id).toBe("pr:42");
+    const parsed = JSON.parse(content[0].text);
+    expect(parsed.found).toBe(true);
+    expect(parsed.item.id).toBe("pr:42");
   });
 
   test("work_items_get retrieves by issue number", async () => {
@@ -330,11 +334,15 @@ describe("WorkItemsServer", () => {
 
     expect(result.isError).toBeFalsy();
     const content = result.content as Array<{ type: string; text: string }>;
-    const item = JSON.parse(content[0].text);
-    expect(item.id).toBe("issue:99");
+    const parsed = JSON.parse(content[0].text);
+    expect(parsed.found).toBe(true);
+    expect(parsed.item.id).toBe("issue:99");
   });
 
-  test("work_items_get returns error when item not found", async () => {
+  // #2834: a missing row is a queryable answer, not a crash. work_items_get is an
+  // existence probe, so a not-found result must be non-error and discriminable —
+  // otherwise `mcx call` exits 1 (#2821) and a probing agent can't branch on it.
+  test("work_items_get returns a non-error { found: false } probe when item not found", async () => {
     const { db, raw } = createWorkItemDb();
     rawDb = raw;
     server = new WorkItemsServer(db);
@@ -345,9 +353,28 @@ describe("WorkItemsServer", () => {
       arguments: { id: "nonexistent" },
     });
 
-    expect(result.isError).toBe(true);
+    expect(result.isError).toBeFalsy();
     const content = result.content as Array<{ type: string; text: string }>;
-    expect(content[0].text).toContain("not found");
+    expect(JSON.parse(content[0].text)).toEqual({ found: false, id: "nonexistent" });
+  });
+
+  test("work_items_get { found: false } echoes prNumber / issueNumber lookup keys", async () => {
+    const { db, raw } = createWorkItemDb();
+    rawDb = raw;
+    server = new WorkItemsServer(db);
+
+    const { client } = await server.start();
+
+    const byPr = await client.callTool({ name: "work_items_get", arguments: { prNumber: 777 } });
+    expect(byPr.isError).toBeFalsy();
+    expect(JSON.parse((byPr.content as Array<{ text: string }>)[0].text)).toEqual({ found: false, prNumber: 777 });
+
+    const byIssue = await client.callTool({ name: "work_items_get", arguments: { issueNumber: 888 } });
+    expect(byIssue.isError).toBeFalsy();
+    expect(JSON.parse((byIssue.content as Array<{ text: string }>)[0].text)).toEqual({
+      found: false,
+      issueNumber: 888,
+    });
   });
 
   test("work_items_get returns error when no lookup key provided", async () => {

--- a/packages/daemon/src/work-items-server.ts
+++ b/packages/daemon/src/work-items-server.ts
@@ -109,7 +109,8 @@ const TOOLS = [
   },
   {
     name: "work_items_get",
-    description: "Get a single work item by ID, PR number, or issue number.",
+    description:
+      "Get a single work item by ID, PR number, or issue number. This is a queryable existence probe: a missing row is a normal answer, not an error. Returns a non-error, discriminable result — `{ found: true, item }` when present, `{ found: false, ...lookupKeys }` when absent — so callers (including `mcx call`, which exits 1 on isError) can branch on existence. isError is reserved for malformed calls (no lookup key supplied) and genuine internal failures.",
     inputSchema: {
       type: "object" as const,
       properties: {
@@ -382,10 +383,17 @@ export class WorkItemsServer {
             if (!item && prNumber) item = this.workItemDb.getWorkItemByPr(prNumber);
             if (!item && issueNumber) item = this.workItemDb.getWorkItemByIssue(issueNumber);
 
+            // Absence is a queryable answer, not a failure (#2834): return a
+            // non-error discriminable payload so `mcx call` (which exits 1 on
+            // isError, #2821) can be used as an existence probe.
             if (!item) {
-              return { content: [{ type: "text" as const, text: "Work item not found" }], isError: true };
+              const notFound: { found: false; id?: string; prNumber?: number; issueNumber?: number } = { found: false };
+              if (id !== undefined) notFound.id = id;
+              if (prNumber !== undefined) notFound.prNumber = prNumber;
+              if (issueNumber !== undefined) notFound.issueNumber = issueNumber;
+              return { content: [{ type: "text" as const, text: JSON.stringify(notFound) }] };
             }
-            return { content: [{ type: "text" as const, text: JSON.stringify(item) }] };
+            return { content: [{ type: "text" as const, text: JSON.stringify({ found: true, item }) }] };
           }
 
           case "work_items_update": {


### PR DESCRIPTION
## Summary
- `work_items_get` is documented as an existence probe shellable via `mcx call _work_items`. After #2831 wired `isError → exit 1`, a not-found probe hard-exited 1 (message on stderr) instead of giving a branchable answer. **"Not found" is an answer, not a crash.**
- Not found now returns a non-error, discriminable payload: `{ found: false, ...lookupKeys }` (echoes the provided `id`/`prNumber`/`issueNumber`). Found returns `{ found: true, item }` — symmetric `found` discriminator.
- Tool description updated to document the probe contract.

## Scope decision (narrower than the issue's loose framing)
Only the **not-found query outcome** becomes non-error. These correctly **stay `isError`** — softening them would re-open the #2821 gap:
- `"id is required"` / `"At least one of…"` — malformed calls, not query outcomes.
- **invalid phase transition** — genuine rejection of an illegal mutation; load-bearing for the phase state machine.
- `work_items_untrack` not-found — a mutation, not the documented probe.

## Consumer check
No `.ts` ctx-side or automation code parses the bare-item shape — only the server definition + spec referenced `work_items_get`. (One meta doc, `compaction-survival.md`, shows the probe; filed separately for the orchestrator-owned update since worker PRs don't touch meta files.)

## Test plan
- [x] `work_items_get` found tests assert `{ found: true, item }`
- [x] not-found probe asserts non-error `{ found: false, id }` + echoes `prNumber`/`issueNumber`
- [x] untrack "verify gone" probe asserts `{ found: false }` (was `isError`)
- [x] no-lookup-key validation still `isError` (unchanged)
- [x] `bun run am-i-done` full gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)