### PR TITLE
fix(git): distinguish git-unavailable from not-a-repo in root probes (fixes #2862)

### DIFF
--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -1271,6 +1271,50 @@ describe("cmdPhase working-tree root resolution from a worktree (#2737)", () => 
   });
 });
 
+describe("phase check treats git-unavailable as a warning, not a hard fail (#2862)", () => {
+  test("warns with the real cause and exits 0 when git is unavailable, not `no .mcx.lock`", async () => {
+    // No .mcx.lock exists at cwd — the pre-fix path would fall back to cwd,
+    // detect no lockfile, and emit a misleading `no .mcx.lock` hard failure.
+    const res = await catchExit(() =>
+      cmdPhase(["check"], {
+        cwd: () => dir,
+        resolveWorktreeRoot: (c) => c,
+        resolveRoot: (c) => c,
+        worktreeRootResult: () => ({
+          kind: "git-unavailable",
+          reason: "timeout",
+          detail: "git rev-parse timed out after 5000ms",
+        }),
+      }),
+    );
+    expect(res.code).toBeUndefined(); // non-blocking: no exit(1)
+    expect(res.err).toContain("git unavailable");
+    expect(res.err).toContain("timeout");
+    expect(res.err).not.toContain("no .mcx.lock");
+    expect(res.out).toContain("skipped");
+  });
+
+  test("still runs drift detection when git resolves the root (not-a-repo falls through)", async () => {
+    // A not-a-repo result must NOT short-circuit — it falls through to drift
+    // detection, which reports `no .mcx.lock` for a dir without one.
+    const bare = mkdtempSync(join(tmpdir(), "mcx-phase-norepo-"));
+    try {
+      const res = await catchExit(() =>
+        cmdPhase(["check"], {
+          cwd: () => bare,
+          resolveWorktreeRoot: (c) => c,
+          resolveRoot: (c) => c,
+          worktreeRootResult: () => ({ kind: "not-a-repo" }),
+        }),
+      );
+      expect(res.code).toBe(1);
+      expect(res.err).toContain("no .mcx.lock");
+    } finally {
+      rmSync(bare, { recursive: true, force: true });
+    }
+  });
+});
+
 describe("detectDrift", () => {
   async function installFixture(extraPhase?: { name: string; src: string }) {
     writeFileSync(join(dir, ".mcx.yaml"), simpleManifest);

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -54,6 +54,7 @@ import {
   extractMetadata,
   findGitRoot,
   findWorktreeRoot,
+  findWorktreeRootResult,
   hashFileSync,
   hashImportClosureSync,
   historyTargets,
@@ -77,7 +78,7 @@ import {
   wrapDryRunContext,
 } from "@mcp-cli/core";
 import type { AliasMetadata } from "@mcp-cli/core";
-import type { ExecFn, ExecResult } from "@mcp-cli/core";
+import type { ExecFn, ExecResult, GitRootResult } from "@mcp-cli/core";
 import { parseFlags } from "../flags";
 import { printError } from "../output";
 
@@ -104,6 +105,13 @@ export interface PhaseInstallDeps {
    * worktree's own copies, not the main checkout's (#2737).
    */
   resolveWorktreeRoot: (cwd: string) => string;
+  /**
+   * Probe the worktree root while distinguishing "not a repo" from "git
+   * unavailable" (timeout / spawn failure). `phase check` uses this to warn
+   * instead of hard-failing with a misleading `no .mcx.lock` when git could
+   * not answer (e.g. under host CPU starvation) — see #2862.
+   */
+  worktreeRootResult: (cwd: string) => GitRootResult;
   log: (msg: string) => void;
   logError: (msg: string) => void;
   exit: (code: number) => never;
@@ -122,6 +130,7 @@ const defaultDeps: PhaseInstallDeps = {
   cwd: () => process.cwd(),
   resolveRoot: (cwd) => findGitRoot(cwd) ?? cwd,
   resolveWorktreeRoot: (cwd) => findWorktreeRoot(cwd) ?? cwd,
+  worktreeRootResult: (cwd) => findWorktreeRootResult(cwd),
   log: (msg) => console.log(msg),
   logError: (msg) => console.error(msg),
   exit: (code) => process.exit(code),
@@ -813,6 +822,18 @@ export async function cmdPhase(
     }
 
     if (sub === "check") {
+      // If git could not resolve the worktree root (timeout / spawn failure —
+      // typically host CPU starvation), do NOT fall through to drift detection.
+      // resolveWorktreeRoot would degrade to a subdirectory cwd, where no
+      // .mcx.lock exists, and emit a misleading `no .mcx.lock` hard failure.
+      // Surface the real cause as a warning and skip the check (non-blocking).
+      // See #2862.
+      const rootResult = d.worktreeRootResult(rawCwd());
+      if (rootResult.kind === "git-unavailable") {
+        d.logError(`phase check: git unavailable (${rootResult.reason}) — ${rootResult.detail}; skipping drift check`);
+        d.log("lockfile check skipped (git unavailable)");
+        return;
+      }
       assertNoDrift(d);
       d.log("lockfile ok");
       return;

--- a/packages/core/src/git.spec.ts
+++ b/packages/core/src/git.spec.ts
@@ -4,13 +4,31 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   type ExecFn,
+  type GitSpawnFn,
   clearFindGitRootCache,
   clearFindWorktreeRootCache,
+  computeGitRootResult,
+  computeWorktreeRootResult,
   ensureCoreBareUnset,
   findGitRoot,
   findWorktreeRoot,
   fixCoreBare,
 } from "./git";
+import type { SpawnResult } from "./subprocess";
+
+/** Build a SpawnResult with sensible defaults, overriding only what a test cares about. */
+function spawnResult(overrides: Partial<SpawnResult>): SpawnResult {
+  return {
+    ok: false,
+    exitCode: null,
+    signal: null,
+    stdout: "",
+    stderr: "",
+    timedOut: false,
+    truncated: false,
+    ...overrides,
+  };
+}
 
 /** Create a temp dir with a .git file (like a worktree) */
 function makeFakeWorktree(): string {
@@ -413,6 +431,99 @@ describe("findWorktreeRoot (#2737)", () => {
       const after = findWorktreeRoot(repo);
       expect(before).toBe(after);
     } finally {
+      rmSync(repo, { recursive: true });
+    }
+  });
+});
+
+describe("git-unavailable vs not-a-repo distinction (#2862)", () => {
+  // A --show-toplevel spawn that reports a hard timeout (SIGTERM via the
+  // GIT_REV_PARSE_TIMEOUT_MS deadline).
+  const timeoutSpawn: GitSpawnFn = () => spawnResult({ timedOut: true, signal: "SIGTERM" });
+  // A spawn that failed to launch (git binary missing / ENOENT) — spawnCaptureSync
+  // catches and returns exitCode: null, timedOut: false.
+  const spawnFailed: GitSpawnFn = () => spawnResult({ exitCode: null });
+  // A genuine "outside any repo" — git answered with exit 128.
+  const notARepo: GitSpawnFn = () => spawnResult({ exitCode: 128, stderr: "fatal: not a git repository" });
+
+  describe("computeWorktreeRootResult", () => {
+    test("timeout → git-unavailable(timeout), not not-a-repo", () => {
+      const r = computeWorktreeRootResult("/anywhere", timeoutSpawn);
+      expect(r.kind).toBe("git-unavailable");
+      if (r.kind === "git-unavailable") expect(r.reason).toBe("timeout");
+    });
+
+    test("spawn failure → git-unavailable(spawn-failed)", () => {
+      const r = computeWorktreeRootResult("/anywhere", spawnFailed);
+      expect(r.kind).toBe("git-unavailable");
+      if (r.kind === "git-unavailable") expect(r.reason).toBe("spawn-failed");
+    });
+
+    test("outside a repo (exit 128) → not-a-repo", () => {
+      expect(computeWorktreeRootResult("/anywhere", notARepo).kind).toBe("not-a-repo");
+    });
+
+    test("success → root with the toplevel path", () => {
+      const ok: GitSpawnFn = () => spawnResult({ ok: true, exitCode: 0, stdout: "/repo/top\n" });
+      const r = computeWorktreeRootResult("/repo/top/sub", ok);
+      expect(r).toEqual({ kind: "root", path: "/repo/top" });
+    });
+  });
+
+  describe("computeGitRootResult", () => {
+    test("timeout on --show-toplevel → git-unavailable(timeout), no bare fallback", () => {
+      const r = computeGitRootResult("/anywhere", timeoutSpawn);
+      expect(r.kind).toBe("git-unavailable");
+      if (r.kind === "git-unavailable") expect(r.reason).toBe("timeout");
+    });
+
+    test("spawn failure → git-unavailable(spawn-failed)", () => {
+      const r = computeGitRootResult("/anywhere", spawnFailed);
+      expect(r.kind).toBe("git-unavailable");
+      if (r.kind === "git-unavailable") expect(r.reason).toBe("spawn-failed");
+    });
+
+    test("--show-toplevel exit 128 but --git-common-dir succeeds → root (bare repo)", () => {
+      // Bare-repo path: --show-toplevel errors (non-zero, not a timeout/spawn-fail),
+      // then --git-common-dir answers. Must still resolve, not collapse to unavailable.
+      const bare: GitSpawnFn = (_cmd, args) =>
+        args.includes("--show-toplevel")
+          ? spawnResult({ exitCode: 128, stderr: "fatal: this operation must be run in a work tree" })
+          : spawnResult({ ok: true, exitCode: 0, stdout: "/bare/repo.git\n" });
+      const r = computeGitRootResult("/bare/repo.git", bare);
+      expect(r.kind).toBe("root");
+    });
+
+    test("--show-toplevel exits 0 with empty stdout → not-a-repo", () => {
+      const empty: GitSpawnFn = () => spawnResult({ ok: true, exitCode: 0, stdout: "\n" });
+      expect(computeGitRootResult("/x", empty).kind).toBe("not-a-repo");
+    });
+  });
+});
+
+describe("gitDiscoverEnv strip reaches --show-toplevel (#2862 secondary gap)", () => {
+  test("findWorktreeRoot resolves the correct toplevel even with GIT_DIR/GIT_WORK_TREE injected", () => {
+    const repo = mkdtempSync(join(tmpdir(), "git-envstrip-"));
+    const priorGitDir = process.env.GIT_DIR;
+    const priorWorkTree = process.env.GIT_WORK_TREE;
+    try {
+      clearFindWorktreeRootCache();
+      Bun.spawnSync(["git", "-C", repo, "init", "-q"], { env: cleanGitEnv() });
+      const sub = join(repo, "nested");
+      mkdirSync(sub, { recursive: true });
+      // Git hooks inject these; without the strip in gitDiscoverEnv() the probe
+      // would honor GIT_DIR=/tmp and resolve the wrong (or no) tree.
+      process.env.GIT_DIR = "/tmp";
+      process.env.GIT_WORK_TREE = "/tmp";
+      const got = findWorktreeRoot(sub);
+      expect(got && (got === repo || got.endsWith(repo.replace(/^\/private/, "")))).toBeTruthy();
+    } finally {
+      // biome-ignore lint/performance/noDelete: env var must be absent, not "undefined" (the string)
+      if (priorGitDir === undefined) delete process.env.GIT_DIR;
+      else process.env.GIT_DIR = priorGitDir;
+      // biome-ignore lint/performance/noDelete: env var must be absent, not "undefined" (the string)
+      if (priorWorkTree === undefined) delete process.env.GIT_WORK_TREE;
+      else process.env.GIT_WORK_TREE = priorWorkTree;
       rmSync(repo, { recursive: true });
     }
   });

--- a/packages/core/src/git.ts
+++ b/packages/core/src/git.ts
@@ -4,7 +4,7 @@
 
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
-import { spawnCaptureSync } from "./subprocess";
+import { type SpawnResult, spawnCaptureSync } from "./subprocess";
 
 /** Timeout for `git rev-parse` plumbing probes — should complete in milliseconds on any sane repo. */
 export const GIT_REV_PARSE_TIMEOUT_MS = 5_000;
@@ -15,6 +15,58 @@ export interface ExecResult {
 }
 
 export type ExecFn = (cmd: string[]) => ExecResult;
+
+/**
+ * Discriminated outcome of a git repo-root probe. Distinguishes the three
+ * cases that {@link findGitRoot}/{@link findWorktreeRoot} historically all
+ * collapsed into a single `null` (#2862):
+ *
+ * - `root` — a working-tree/git root was resolved (`path` is absolute).
+ * - `not-a-repo` — `cwd` is genuinely outside any git repository. Falling back
+ *   to `cwd` is correct here.
+ * - `git-unavailable` — the probe could not be answered: git timed out
+ *   (`reason: "timeout"`, the orphaned-load / CPU-starvation pattern) or the
+ *   `git` process failed to spawn / was killed / exited abnormally
+ *   (`reason: "spawn-failed"`). A cwd fallback here silently degrades root
+ *   resolution and must NOT be treated as "not a repo".
+ */
+export type GitRootResult =
+  | { kind: "root"; path: string }
+  | { kind: "not-a-repo" }
+  | { kind: "git-unavailable"; reason: "timeout" | "spawn-failed"; detail: string };
+
+/** Injectable spawn seam so the *Result probes can be unit-tested without a real git. */
+export type GitSpawnFn = (
+  cmd: string,
+  args: string[],
+  opts: { timeoutMs: number; env: NodeJS.ProcessEnv },
+) => SpawnResult;
+
+/**
+ * Classify a *failed* `git rev-parse` result as `git-unavailable`, or return
+ * null when the non-zero exit is an ordinary "answered, just not here" result
+ * (e.g. exit 128 outside a repo, or the bare-repo case where `--show-toplevel`
+ * errors but `--git-common-dir` succeeds). Timeouts and spawn failures surface
+ * `exitCode: null` / `timedOut: true` from {@link spawnCaptureSync}, so the
+ * distinguishing signal is already available — it was previously discarded.
+ */
+function classifyUnavailable(r: SpawnResult): Extract<GitRootResult, { kind: "git-unavailable" }> | null {
+  if (r.timedOut) {
+    return {
+      kind: "git-unavailable",
+      reason: "timeout",
+      detail: `git rev-parse timed out after ${GIT_REV_PARSE_TIMEOUT_MS}ms`,
+    };
+  }
+  if (r.exitCode === null) {
+    return {
+      kind: "git-unavailable",
+      reason: "spawn-failed",
+      detail: r.signal ? `git killed by ${r.signal}` : "git binary not found or failed to spawn",
+    };
+  }
+  return null;
+}
 
 /**
  * @deprecated Use {@link ensureCoreBareUnset} — it removes the key regardless
@@ -112,8 +164,8 @@ function gitDiscoverEnv(): Record<string, string | undefined> {
   return rest;
 }
 
-/** Process-local cache: resolved cwd → git root (null = not a git repo). */
-const gitRootCache = new Map<string, string | null>();
+/** Process-local cache: resolved cwd → git root result. */
+const gitRootCache = new Map<string, GitRootResult>();
 
 /** Clear the findGitRoot process-local cache. Intended for tests and long-lived processes that move worktrees. */
 export function clearFindGitRootCache(): void {
@@ -121,8 +173,91 @@ export function clearFindGitRootCache(): void {
 }
 
 /**
+ * Pure core of {@link findGitRootResult} — no caching, injectable `spawn` so
+ * the timeout / spawn-failure / not-a-repo branches can be unit-tested without
+ * a real git. See {@link findGitRoot} for the resolution semantics.
+ */
+export function computeGitRootResult(cwd: string, spawn: GitSpawnFn = spawnCaptureSync): GitRootResult {
+  // gitDiscoverEnv() strips hook-injected GIT_DIR/GIT_WORK_TREE vars so that
+  // when findGitRoot runs from inside a git hook, filesystem-based discovery
+  // isn't overridden by the hook's environment.
+  const env = gitDiscoverEnv();
+  const top = spawn("git", ["-C", cwd, "rev-parse", "--show-toplevel"], {
+    timeoutMs: GIT_REV_PARSE_TIMEOUT_MS,
+    env,
+  });
+  if (top.exitCode === 0) {
+    const toplevel = top.stdout.trim();
+    if (!toplevel) return { kind: "not-a-repo" };
+    const gitDir = spawn("git", ["-C", cwd, "rev-parse", "--git-dir"], {
+      timeoutMs: GIT_REV_PARSE_TIMEOUT_MS,
+      env,
+    });
+    if (gitDir.exitCode === 0) {
+      const gitDirStr = gitDir.stdout.trim();
+      // Linked worktrees store their git-dir under .git/worktrees/<name>/,
+      // so /worktrees/ in the path is the cheapest worktree signal.
+      // Only fetch --git-common-dir when we're in a linked worktree.
+      if (gitDirStr.includes("/worktrees/")) {
+        const commonDir = spawn("git", ["-C", cwd, "rev-parse", "--git-common-dir"], {
+          timeoutMs: GIT_REV_PARSE_TIMEOUT_MS,
+          env,
+        });
+        if (commonDir.exitCode === 0) {
+          const commonDirAbs = resolve(cwd, commonDir.stdout.trim());
+          const path =
+            commonDirAbs.endsWith("/.git") || commonDirAbs.endsWith(".git") ? dirname(commonDirAbs) : commonDirAbs;
+          return { kind: "root", path };
+        }
+        return { kind: "root", path: toplevel };
+      }
+      return { kind: "root", path: toplevel };
+    }
+    return { kind: "root", path: toplevel };
+  }
+
+  // --show-toplevel failed. A timeout or spawn failure is `git-unavailable`
+  // and must NOT be confused with "not a repo" (#2862). An ordinary non-zero
+  // exit (128 outside a repo, or the bare-repo case) falls through to the
+  // --git-common-dir probe below.
+  const topUnavail = classifyUnavailable(top);
+  if (topUnavail) return topUnavail;
+
+  // Bare repo fallback — no working tree, use the common dir directly.
+  const common = spawn("git", ["-C", cwd, "rev-parse", "--git-common-dir"], {
+    timeoutMs: GIT_REV_PARSE_TIMEOUT_MS,
+    env,
+  });
+  if (common.exitCode === 0) {
+    const commonDir = common.stdout.trim();
+    if (commonDir) return { kind: "root", path: resolve(cwd, commonDir) };
+    return { kind: "not-a-repo" };
+  }
+  const commonUnavail = classifyUnavailable(common);
+  if (commonUnavail) return commonUnavail;
+  return { kind: "not-a-repo" };
+}
+
+/**
+ * Like {@link findGitRoot} but returns a {@link GitRootResult} that
+ * distinguishes "not a repo" from "git unavailable" (timeout / spawn failure).
+ * Cached process-locally by cwd. Prefer this in blocking hook paths so a
+ * degraded-git result can be surfaced as a warning rather than a misleading
+ * hard failure (#2862).
+ */
+export function findGitRootResult(cwd: string = process.cwd()): GitRootResult {
+  const cached = gitRootCache.get(cwd);
+  if (cached) return cached;
+  const result = computeGitRootResult(cwd);
+  gitRootCache.set(cwd, result);
+  return result;
+}
+
+/**
  * Resolve the git repository root from a working directory.
- * Returns an absolute path, or null if `cwd` is not inside a git repository.
+ * Returns an absolute path, or null if `cwd` is not inside a git repository
+ * OR if git was unavailable (timeout / spawn failure). Callers that need to
+ * distinguish those cases must use {@link findGitRootResult}.
  *
  * Prefers `--show-toplevel` (the working-tree root). For linked worktrees,
  * maps back to the main checkout's root via `--git-common-dir` so every
@@ -135,76 +270,48 @@ export function clearFindGitRootCache(): void {
  * Results are cached process-locally by cwd to eliminate repeated spawns.
  */
 export function findGitRoot(cwd: string = process.cwd()): string | null {
-  if (gitRootCache.has(cwd)) return gitRootCache.get(cwd) as string | null;
-
-  // gitDiscoverEnv() strips hook-injected GIT_DIR/GIT_WORK_TREE vars so that
-  // when findGitRoot runs from inside a git hook, filesystem-based discovery
-  // isn't overridden by the hook's environment.
-  const env = gitDiscoverEnv();
-  let result: string | null = null;
-  try {
-    const top = spawnCaptureSync("git", ["-C", cwd, "rev-parse", "--show-toplevel"], {
-      timeoutMs: GIT_REV_PARSE_TIMEOUT_MS,
-      env,
-    });
-    if (top.exitCode === 0) {
-      const toplevel = top.stdout.trim();
-      if (!toplevel) {
-        gitRootCache.set(cwd, null);
-        return null;
-      }
-      const gitDir = spawnCaptureSync("git", ["-C", cwd, "rev-parse", "--git-dir"], {
-        timeoutMs: GIT_REV_PARSE_TIMEOUT_MS,
-        env,
-      });
-      if (gitDir.exitCode === 0) {
-        const gitDirStr = gitDir.stdout.trim();
-        // Linked worktrees store their git-dir under .git/worktrees/<name>/,
-        // so /worktrees/ in the path is the cheapest worktree signal.
-        // Only fetch --git-common-dir when we're in a linked worktree.
-        if (gitDirStr.includes("/worktrees/")) {
-          const commonDir = spawnCaptureSync("git", ["-C", cwd, "rev-parse", "--git-common-dir"], {
-            timeoutMs: GIT_REV_PARSE_TIMEOUT_MS,
-            env,
-          });
-          if (commonDir.exitCode === 0) {
-            const commonDirAbs = resolve(cwd, commonDir.stdout.trim());
-            result =
-              commonDirAbs.endsWith("/.git") || commonDirAbs.endsWith(".git") ? dirname(commonDirAbs) : commonDirAbs;
-          } else {
-            result = toplevel;
-          }
-        } else {
-          result = toplevel;
-        }
-      } else {
-        result = toplevel;
-      }
-    } else {
-      // Bare repo fallback — no working tree, use the common dir directly.
-      const common = spawnCaptureSync("git", ["-C", cwd, "rev-parse", "--git-common-dir"], {
-        timeoutMs: GIT_REV_PARSE_TIMEOUT_MS,
-        env,
-      });
-      if (common.exitCode === 0) {
-        const commonDir = common.stdout.trim();
-        if (commonDir) result = resolve(cwd, commonDir);
-      }
-    }
-  } catch {
-    // result stays null
-  }
-
-  gitRootCache.set(cwd, result);
-  return result;
+  const r = findGitRootResult(cwd);
+  return r.kind === "root" ? r.path : null;
 }
 
-/** Process-local cache: resolved cwd → worktree root (null = not a git repo). */
-const worktreeRootCache = new Map<string, string | null>();
+/** Process-local cache: resolved cwd → worktree root result. */
+const worktreeRootCache = new Map<string, GitRootResult>();
 
 /** Clear the findWorktreeRoot process-local cache. Intended for tests and long-lived processes that move worktrees. */
 export function clearFindWorktreeRootCache(): void {
   worktreeRootCache.clear();
+}
+
+/**
+ * Pure core of {@link findWorktreeRootResult} — no caching, injectable `spawn`
+ * so the timeout / spawn-failure / not-a-repo branches can be unit-tested
+ * without a real git.
+ */
+export function computeWorktreeRootResult(cwd: string, spawn: GitSpawnFn = spawnCaptureSync): GitRootResult {
+  const env = gitDiscoverEnv();
+  const top = spawn("git", ["-C", cwd, "rev-parse", "--show-toplevel"], {
+    timeoutMs: GIT_REV_PARSE_TIMEOUT_MS,
+    env,
+  });
+  if (top.exitCode === 0) {
+    const toplevel = top.stdout.trim();
+    return toplevel ? { kind: "root", path: toplevel } : { kind: "not-a-repo" };
+  }
+  return classifyUnavailable(top) ?? { kind: "not-a-repo" };
+}
+
+/**
+ * Like {@link findWorktreeRoot} but returns a {@link GitRootResult} that
+ * distinguishes "not a repo" from "git unavailable" (timeout / spawn failure).
+ * Cached process-locally by cwd. `mcx phase check` uses this so a degraded-git
+ * result becomes a warning rather than a misleading `no .mcx.lock` (#2862).
+ */
+export function findWorktreeRootResult(cwd: string = process.cwd()): GitRootResult {
+  const cached = worktreeRootCache.get(cwd);
+  if (cached) return cached;
+  const result = computeWorktreeRootResult(cwd);
+  worktreeRootCache.set(cwd, result);
+  return result;
 }
 
 /**
@@ -219,27 +326,11 @@ export function clearFindWorktreeRootCache(): void {
  * main checkout makes `phase check`/`install` operate on the wrong tree from a
  * worktree. See #2737 (distinct from #2673, which keys runtime *state*).
  *
- * Returns null when `cwd` is not inside a git repository. Results are cached
- * process-locally by cwd.
+ * Returns null when `cwd` is not inside a git repository OR git was unavailable
+ * (timeout / spawn failure). Callers that must distinguish those cases use
+ * {@link findWorktreeRootResult}. Results are cached process-locally by cwd.
  */
 export function findWorktreeRoot(cwd: string = process.cwd()): string | null {
-  if (worktreeRootCache.has(cwd)) return worktreeRootCache.get(cwd) as string | null;
-
-  const env = gitDiscoverEnv();
-  let result: string | null = null;
-  try {
-    const top = spawnCaptureSync("git", ["-C", cwd, "rev-parse", "--show-toplevel"], {
-      timeoutMs: GIT_REV_PARSE_TIMEOUT_MS,
-      env,
-    });
-    if (top.exitCode === 0) {
-      const toplevel = top.stdout.trim();
-      if (toplevel) result = toplevel;
-    }
-  } catch {
-    // result stays null
-  }
-
-  worktreeRootCache.set(cwd, result);
-  return result;
+  const r = findWorktreeRootResult(cwd);
+  return r.kind === "root" ? r.path : null;
 }


### PR DESCRIPTION
## Summary
- `findWorktreeRoot`/`findGitRoot` collapsed three distinct outcomes — not-a-repo, git timeout (SIGTERM via `GIT_REV_PARSE_TIMEOUT_MS`), and spawn failure (missing binary) — into a single `null`. In the `mcx phase check` hook path a degraded-git result (host CPU starvation) fell back to the subdirectory cwd and surfaced a misleading `no .mcx.lock` hard failure instead of naming the real cause.
- Adds a `GitRootResult` discriminated union (`root` | `not-a-repo` | `git-unavailable{reason: "timeout" | "spawn-failed"}`) with `findWorktreeRootResult` / `findGitRootResult` and injectable `compute*` cores for testability. The existing `string | null` wrappers collapse non-root outcomes to `null`, so **no caller changes** — the bare-repo `--git-common-dir` fallback in `findGitRoot` is preserved.
- `mcx phase check` now warns (`git unavailable (<reason>) — <detail>`) and exits **0** (non-blocking) when git is unavailable, leaving the intentional `not-a-repo` → cwd fallback intact.
- Closes the secondary test gap: a test injecting `GIT_DIR=/tmp` confirms `gitDiscoverEnv()`'s env-strip reaches the `--show-toplevel` invocation and `findWorktreeRoot` still resolves the correct toplevel.

## Note on the issue's repro
The issue's repro (`GIT_REV_PARSE_TIMEOUT_MS=1` as an env var) does not actually work — the timeout is a hardcoded `const` in `git.ts:10`, never read from env. The underlying conflation is real regardless; the new unit tests exercise the timeout/spawn-fail/not-a-repo branches via an injected spawn instead. Commented on #2862.

## Test plan
- [x] `bun typecheck`
- [x] `bun lint`
- [x] Full test suite: `bun test` → 9302 pass, 0 fail
- [x] Coverage ratchet: `bun scripts/check-coverage.ts` → all thresholds met (91.57% fn / 94.73% ln)
- [x] `bun scripts/am-i-done.ts --pre-push` → all checks passed
- New tests: `git.spec.ts` (3-outcome distinction for both `compute*` fns + GIT_DIR env-strip); `phase.spec.ts` (`phase check` warns+exits 0 on git-unavailable, falls through on not-a-repo)

Note: `am-i-done`'s `test-parallel` step SIGTERM-cascaded under host CPU starvation (load 6, 12-user shared host) — zero real assertion failures, random files each run, all pass in isolation, and clean `main` crashes identically under parallel but passes serially. Documented host pattern, not this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)