### PR TITLE
fix(memory): bound Haiku + gh calls so audit fails fast (fixes #2884)

### DIFF
--- a/packages/command/src/commands/memory.spec.ts
+++ b/packages/command/src/commands/memory.spec.ts
@@ -284,6 +284,45 @@ describe("runMemoryAudit", () => {
     expect(deps.errors.join("\n")).toContain("code 1");
   });
 
+  test("fails fast with a clear message when the Haiku call times out", async () => {
+    const deps = makeDeps({
+      spawnCapture: (cmd) => {
+        if (cmd[0] === "gh") return { stdout: "[]", stderr: "", exitCode: 0 };
+        // Simulate a hung claude --print: SIGTERM'd by the timeout, no output.
+        return { stdout: "", stderr: "", exitCode: null as unknown as number, timedOut: true };
+      },
+    });
+    await expect(runMemoryAudit({ json: true }, deps)).rejects.toThrow("exit(1)");
+    const errLog = deps.errors.join("\n");
+    expect(errLog).toContain("timed out");
+    expect(errLog).not.toContain("exited with code");
+    // Nothing emitted to stdout — must not hang, must not print partial output.
+    expect(deps.logs.length).toBe(0);
+  });
+
+  test("passes a timeout to the Haiku spawn so it cannot hang indefinitely", async () => {
+    let haikuTimeout: number | undefined;
+    const deps = makeDeps({
+      spawnCapture: (cmd, opts) => {
+        if (cmd[0] === "gh") return { stdout: "[]", stderr: "", exitCode: 0 };
+        haikuTimeout = opts?.timeoutMs;
+        return {
+          stdout: JSON.stringify({
+            findings: [
+              { file: "feedback_test.md", status: "load-bearing", reason: "ok", related: null },
+              { file: "feedback_old.md", status: "stale", reason: "gone", related: null },
+            ],
+            top_prune_candidates: [],
+          }),
+          stderr: "",
+          exitCode: 0,
+        };
+      },
+    });
+    await runMemoryAudit({ json: true }, deps);
+    expect(haikuTimeout).toBeGreaterThan(0);
+  });
+
   test("logs diagnostic when claude returns empty stdout with exitCode 0", async () => {
     const deps = makeDeps({
       spawnCapture: (cmd) => {

--- a/packages/command/src/commands/memory.ts
+++ b/packages/command/src/commands/memory.ts
@@ -53,8 +53,15 @@ export interface MemoryDeps {
   cwd: () => string;
   /** Check whether a directory exists. */
   dirExists: (path: string) => boolean;
-  /** Spawn a process and capture stdout/stderr/exitCode. Never throws. */
-  spawnCapture: (cmd: string[], opts?: { input?: string }) => { stdout: string; stderr: string; exitCode: number };
+  /**
+   * Spawn a process and capture stdout/stderr/exitCode. Never throws.
+   * `timeoutMs` bounds the call; on expiry the child is SIGTERM'd and
+   * `timedOut` is set so callers can fail loudly instead of hanging forever.
+   */
+  spawnCapture: (
+    cmd: string[],
+    opts?: { input?: string; timeoutMs?: number },
+  ) => { stdout: string; stderr: string; exitCode: number; timedOut?: boolean };
   /** Write content to a temp file and return the path. */
   writeTempFile: (content: string) => string;
   /** Read a file. Returns null if it doesn't exist or is unreadable. */
@@ -69,6 +76,11 @@ export interface MemoryDeps {
 }
 
 const HAIKU_MODEL = resolveModelName("haiku");
+
+/** Upper bound on the Haiku audit call. A hung `claude --print` must fail loud, not hang forever (#2884). */
+const HAIKU_TIMEOUT_MS = 120_000;
+/** Upper bound on the `gh issue list` call — same class of silent-hang risk. */
+const GH_TIMEOUT_MS = 30_000;
 
 const AUDIT_PROMPT = `You are auditing a project's persistent memory rules. Rules are stored as markdown files in .claude/memory/ and indexed in MEMORY.md.
 
@@ -143,7 +155,17 @@ function callHaiku(prompt: string, deps: MemoryDeps): string | null {
     return null;
   }
 
-  const result = deps.spawnCapture([binary, "--print", "--model", HAIKU_MODEL], { input: prompt });
+  const result = deps.spawnCapture([binary, "--print", "--model", HAIKU_MODEL], {
+    input: prompt,
+    timeoutMs: HAIKU_TIMEOUT_MS,
+  });
+
+  if (result.timedOut) {
+    deps.logError(
+      `memory audit: claude --print timed out after ${HAIKU_TIMEOUT_MS / 1000}s with no response — the model call is hung. Retry, or check claude auth/connectivity.`,
+    );
+    return null;
+  }
 
   if (result.exitCode !== 0) {
     const stderrMsg = result.stderr.trim();
@@ -162,17 +184,11 @@ function callHaiku(prompt: string, deps: MemoryDeps): string | null {
  * Fetch the last N closed GitHub issues as a newline-delimited summary for prompt inclusion.
  */
 function fetchClosedIssues(deps: MemoryDeps, limit = 50): string {
-  const result = deps.spawnCapture([
-    "gh",
-    "issue",
-    "list",
-    "--state",
-    "closed",
-    "--limit",
-    String(limit),
-    "--json",
-    "number,title,closedAt",
-  ]);
+  const result = deps.spawnCapture(
+    ["gh", "issue", "list", "--state", "closed", "--limit", String(limit), "--json", "number,title,closedAt"],
+    { timeoutMs: GH_TIMEOUT_MS },
+  );
+  if (result.timedOut) return "(gh timed out)";
   if (result.exitCode !== 0) return "(gh unavailable)";
   try {
     const issues = JSON.parse(result.stdout) as Array<{ number: number; title: string; closedAt: string }>;
@@ -343,11 +359,12 @@ export function defaultDeps(): MemoryDeps {
     cwd: () => process.cwd(),
     dirExists: (path) => existsSync(path),
     spawnCapture: (cmd, opts) => {
-      const r = spawnCaptureSync(cmd[0] ?? "", cmd.slice(1), { input: opts?.input });
+      const r = spawnCaptureSync(cmd[0] ?? "", cmd.slice(1), { input: opts?.input, timeoutMs: opts?.timeoutMs });
       return {
         stdout: r.stdout,
         stderr: r.stderr,
         exitCode: r.exitCode ?? 1,
+        timedOut: r.timedOut,
       };
     },
     writeTempFile: (content) => {


### PR DESCRIPTION
## Summary
- `mcx memory audit` hung indefinitely (zero stdout, exit only on caller SIGTERM) because `callHaiku` and `fetchClosedIssues` invoked `spawnCapture` with **no timeout** — a hung `claude --print` or `gh` blocked forever.
- Threaded `timeoutMs`/`timedOut` through `MemoryDeps.spawnCapture` (already supported by the underlying `spawnCaptureSync`), bounded the Haiku call at 120s and the `gh` call at 30s, and made a timeout **fail loudly** (exit 1, clear stderr) instead of hanging silently.
- Correction to the issue's hypothesis: the audit makes a **single** `claude` call, not a per-file loop. The `#2816` `validateAuditResult()` accumulate-then-validate path was not the cause; the missing subprocess timeout was. Same fix, applied to that single call.

## Test plan
- [x] `bun typecheck` — pass
- [x] `bun lint` — pass
- [x] `bun run am-i-done` — full gate green (test failures during iteration were an upstream Bun segfault under concurrent-gate host load, not this change)
- [x] Added `memory.spec.ts` tests: timeout path fails fast with a clear message + no stdout, and the Haiku spawn is passed a positive timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)