### PR TITLE
feat(daemon): observe result-suppression by num_turns idempotency guard (fixes #2859)

### DIFF
--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -770,6 +770,7 @@ async function startServer(wsPort?: number, quiet?: boolean): Promise<number> {
   wsServer.onMonitorEvent = (input) => self.postMessage({ type: "monitor:event", input });
   wsServer.onStderrLine = (sessionId, line, timestamp) =>
     self.postMessage({ type: "db:stderr", sessionId, line, timestamp });
+  wsServer.onMetric = (name, labels) => self.postMessage({ type: "metrics:inc", name, labels });
   const port = await wsServer.start(wsPort);
 
   // Start MCP Server

--- a/packages/daemon/src/claude-session/session-state.spec.ts
+++ b/packages/daemon/src/claude-session/session-state.spec.ts
@@ -393,6 +393,52 @@ describe("SessionState", () => {
       expect(events[0].type).toBe("session:result");
     });
 
+    // -- #2859: suppression observability --
+    //
+    // When the guard fires it must record `suppressedResult` so the caller
+    // (ws-server) can emit a debug log + metric. Without this, an over-firing
+    // guard drops a completion invisibly — no event, no log, no metric.
+
+    test("records suppressedResult (branch=result) when a success replay is dropped", () => {
+      const session = activeSession();
+      session.handleMessage(RESULT_SUCCESS); // num_turns=3, emits
+      const replay = session.handleMessage(RESULT_SUCCESS);
+      expect(replay).toEqual([]);
+      expect(session.suppressedResult).toEqual({ branch: "result", numTurns: 3, lastEmitted: 3 });
+    });
+
+    test("records suppressedResult (branch=error) when an error replay is dropped", () => {
+      const session = activeSession();
+      const first = session.handleMessage(RESULT_ERROR); // num_turns=1
+      expect(first[0].type).toBe("session:error");
+      const replay = session.handleMessage(RESULT_ERROR);
+      expect(replay).toEqual([]);
+      expect(session.suppressedResult).toEqual({ branch: "error", numTurns: 1, lastEmitted: 1 });
+    });
+
+    test("records suppressedResult (branch=fallback) when a fallback replay carrying num_turns is dropped", () => {
+      const session = activeSession();
+      session.handleMessage(RESULT_SUCCESS); // num_turns=3, emits
+      // Fallback path (missing subtype so strict schemas fail) but num_turns present == replay.
+      const { subtype: _s, ...fallbackReplay } = RESULT_SUCCESS;
+      const replay = session.handleMessage(fallbackReplay);
+      expect(replay).toEqual([]);
+      expect(session.suppressedResult).toEqual({ branch: "fallback", numTurns: 3, lastEmitted: 3 });
+    });
+
+    test("suppressedResult is null on a genuine emit and cleared on the next message", () => {
+      const session = activeSession();
+      session.handleMessage(RESULT_SUCCESS); // genuine emit
+      expect(session.suppressedResult).toBeNull();
+
+      session.handleMessage(RESULT_SUCCESS); // replay — sets it
+      expect(session.suppressedResult).not.toBeNull();
+
+      // A subsequent non-result message clears the flag.
+      session.handleMessage(ASSISTANT_MSG);
+      expect(session.suppressedResult).toBeNull();
+    });
+
     test("suppression targets only a true replay, never a genuine advancing turn", () => {
       const session = activeSession();
       // Genuine turn — emits (a waiter here would resolve).

--- a/packages/daemon/src/claude-session/session-state.ts
+++ b/packages/daemon/src/claude-session/session-state.ts
@@ -46,6 +46,22 @@ export type SessionEvent =
   | { type: "session:containment_escalated"; toolName: string; reason: string; strikes: number }
   | { type: "session:containment_reset"; toolName: string; reason: string; strikes: number };
 
+// ── Result-suppression diagnostics (#2859) ──
+
+/** Which branch of handleResult() suppressed a replayed result. */
+export type SuppressedResultBranch = "result" | "error" | "fallback";
+
+/**
+ * Recorded when handleResult()'s idempotency guard drops a replayed
+ * result/error. Read by the caller to emit a debug log + metric so an
+ * over-firing guard is diagnosable instead of a silent hang.
+ */
+export interface SuppressedResultInfo {
+  branch: SuppressedResultBranch;
+  numTurns: number;
+  lastEmitted: number;
+}
+
 // ── Outbound message (string ready to send over WS) ──
 
 export type OutboundMessage = string;
@@ -93,6 +109,16 @@ export class SessionState {
   parseMismatch = false;
 
   /**
+   * Set when handleResult()'s num_turns idempotency guard (#2837) suppressed a
+   * replayed result/error at one of its `return []` points. Cleared on every
+   * handleMessage call, like parseMismatch. The caller (ws-server) reads it to
+   * emit a debug log + increment `mcpd_session_result_suppressed_total` so an
+   * over-firing guard is not invisible in production — a swallowed completion
+   * would otherwise be indistinguishable from a hung session (#2859).
+   */
+  suppressedResult: SuppressedResultInfo | null = null;
+
+  /**
    * True after the first `session:init` event has been emitted. Subsequent
    * `system/init` messages (stdio re-emits one every turn) still update
    * model/cwd but suppress the event to avoid downstream noise.
@@ -127,6 +153,7 @@ export class SessionState {
    */
   handleMessage(msg: NdjsonMessage): SessionEvent[] {
     this.parseMismatch = false;
+    this.suppressedResult = null;
     if (IGNORED_TYPES.has(msg.type)) return [];
     if (msg.type === "system" && msg.subtype === "status") return [];
 
@@ -343,7 +370,14 @@ export class SessionState {
       // per-message usage throughout the turn. Result usage would double-count.
       this.state = "idle";
       this.rateLimited = false;
-      if (this.numTurns <= this.lastEmittedNumTurns) return [];
+      if (this.numTurns <= this.lastEmittedNumTurns) {
+        this.suppressedResult = {
+          branch: "result",
+          numTurns: this.numTurns,
+          lastEmitted: this.lastEmittedNumTurns,
+        };
+        return [];
+      }
       this.lastEmittedNumTurns = this.numTurns;
       return [
         {
@@ -362,7 +396,14 @@ export class SessionState {
       this.cost = r.total_cost_usd;
       this.numTurns = r.num_turns;
       this.state = "idle";
-      if (this.numTurns <= this.lastEmittedNumTurns) return [];
+      if (this.numTurns <= this.lastEmittedNumTurns) {
+        this.suppressedResult = {
+          branch: "error",
+          numTurns: this.numTurns,
+          lastEmitted: this.lastEmittedNumTurns,
+        };
+        return [];
+      }
       this.lastEmittedNumTurns = this.numTurns;
       return [{ type: "session:error", errors: r.errors ?? [], cost: this.cost }];
     }
@@ -387,7 +428,14 @@ export class SessionState {
       // suppress a genuine completion — a silent hang, since session:result is
       // the sole driver of workCompleted / waiter resolution. Fail open (#2837).
       if (r.num_turns != null) {
-        if (this.numTurns <= this.lastEmittedNumTurns) return [];
+        if (this.numTurns <= this.lastEmittedNumTurns) {
+          this.suppressedResult = {
+            branch: "fallback",
+            numTurns: this.numTurns,
+            lastEmitted: this.lastEmittedNumTurns,
+          };
+          return [];
+        }
         this.lastEmittedNumTurns = this.numTurns;
       }
 

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -559,6 +559,45 @@ describe("ClaudeWsServer", () => {
     }
   });
 
+  test("suppressed replay increments onMetric + debug-logs, and is not misreported as stuck (#2859)", async () => {
+    const ms = mockSpawn();
+    const { logger, texts } = capturingLogger();
+    const metricCalls: { name: string; labels?: Record<string, string> }[] = [];
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger });
+    server.onMetric = (name, labels) => metricCalls.push({ name, labels });
+    const port = await server.start();
+
+    server.prepareSession("suppress-1", { prompt: "Hello" });
+    server.spawnClaude("suppress-1");
+
+    const ws = await connectMockClaude(port, "suppress-1");
+    try {
+      await waitForMessage(ws);
+
+      const resultPromise = server.waitForResult("suppress-1", 5000);
+      ws.send(systemInitMessage("suppress-1"));
+      ws.send(assistantMessage("suppress-1"));
+      ws.send(resultMessage("suppress-1", 3)); // genuine completion, num_turns=3
+      await resultPromise;
+
+      // Replay the same result (same num_turns) — the guard must suppress it.
+      ws.send(resultMessage("suppress-1", 3));
+      await pollUntil(() => metricCalls.some((c) => c.name === "mcpd_session_result_suppressed_total"));
+
+      const suppressed = metricCalls.find((c) => c.name === "mcpd_session_result_suppressed_total");
+      expect(suppressed?.labels).toEqual({ branch: "result" });
+
+      const joined = texts.join("\n");
+      expect(joined).toContain("suppressed replayed result");
+      expect(joined).toContain("num_turns=3");
+      expect(joined).toContain("branch=result");
+      // The misleading "session stuck" error must NOT fire for a legitimate replay.
+      expect(joined).not.toContain("produced no events even after fallback");
+    } finally {
+      ws.close();
+    }
+  });
+
   test("can_use_tool with auto router is auto-approved", async () => {
     const ms = mockSpawn();
     server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger });

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -507,6 +507,14 @@ export class ClaudeWsServer {
   onStderrLine: ((sessionId: string, line: string, timestamp: number) => void) | null = null;
 
   /**
+   * Called to increment a worker-side metric counter on the main thread's
+   * collector (the worker's own `metrics` singleton is a separate instance).
+   * Wired by the worker to `metrics:inc`. Used to surface result-suppression
+   * over-firing (#2859).
+   */
+  onMetric: ((name: string, labels?: Record<string, string>) => void) | null = null;
+
+  /**
    * Optional TLS material. When set, `Bun.serve` runs in HTTPS mode and binds
    * on `[::1]` instead of the default. Patched-claude (#1808) requires
    * `wss://` and an IPv6 hostname that maps onto an entry in its allowlist.
@@ -1326,6 +1334,22 @@ export class ClaudeWsServer {
     }
   }
 
+  /**
+   * Surface a result-suppression by the num_turns idempotency guard (#2837):
+   * emit a debug log + increment a metric so an over-firing guard is
+   * diagnosable rather than a silent dropped completion (#2859). No-op when
+   * the last message wasn't suppressed. Shared by the WS and stdio loops.
+   */
+  private emitSuppressionDiagnostics(sessionId: string, state: SessionState): void {
+    const s = state.suppressedResult;
+    if (!s) return;
+    this.logger.debug(
+      `[_claude] suppressed replayed result num_turns=${s.numTurns} ` +
+        `lastEmitted=${s.lastEmitted} sessionId=${sessionId} branch=${s.branch}`,
+    );
+    this.onMetric?.("mcpd_session_result_suppressed_total", { branch: s.branch });
+  }
+
   /** Parse and dispatch a single NDJSON line from stdio stdout — mirrors handleMessage for WS. */
   private handleStdioLine(sessionId: string, session: WsSession, line: string): void {
     let messages: NdjsonMessage[];
@@ -1365,6 +1389,7 @@ export class ClaudeWsServer {
     for (const msg of messages) {
       this.addTranscript(session, "inbound", msg);
       const events = session.state.handleMessage(msg);
+      this.emitSuppressionDiagnostics(sessionId, session.state);
 
       if (session.state.parseMismatch) {
         this.logger.error(
@@ -1385,7 +1410,9 @@ export class ClaudeWsServer {
         );
       }
 
-      if (msg.type === "result" && events.length === 0) {
+      // A suppressed replay legitimately produces no events (#2859) — don't
+      // misreport it as a stuck session; emitSuppressionDiagnostics already logged it.
+      if (msg.type === "result" && events.length === 0 && !session.state.suppressedResult) {
         this.logger.error(
           `[_claude] Result message for session ${sessionId} produced no events even after fallback — ` +
             `session stuck in "${session.state.state}" state. Keys: ${Object.keys(msg).join(", ")}`,
@@ -2093,6 +2120,7 @@ export class ClaudeWsServer {
     for (const msg of messages) {
       this.addTranscript(session, "inbound", msg);
       const events = session.state.handleMessage(msg);
+      this.emitSuppressionDiagnostics(sessionId, session.state);
 
       // Log when a fallback schema was used — the strict schema didn't match
       // but we still extracted what we could and kept working.
@@ -2121,7 +2149,9 @@ export class ClaudeWsServer {
       }
 
       // Warn if a result message produced no events — even the fallback failed.
-      if (msg.type === "result" && events.length === 0) {
+      // A suppressed replay legitimately produces no events (#2859) — don't
+      // misreport it as a stuck session; emitSuppressionDiagnostics already logged it.
+      if (msg.type === "result" && events.length === 0 && !session.state.suppressedResult) {
         this.logger.error(
           `[_claude] Result message for session ${sessionId} produced no events even after fallback — ` +
             `session stuck in "${session.state.state}" state. Keys: ${Object.keys(msg).join(", ")}`,


### PR DESCRIPTION
## Summary
- The #2837 `num_turns` idempotency guard in `SessionState.handleResult()` does `return []` at three points, dropping a replayed `session:result`/`session:error` with **no log, event, or metric** — an over-firing guard would be indistinguishable from a hung session.
- `SessionState` now records `suppressedResult` (`branch`/`numTurns`/`lastEmitted`) at each suppression point, mirroring the logger-free `parseMismatch` pattern (state machine sets a field; caller observes it).
- `ws-server` reads it in **both** message loops (WS + stdio): emits a debug log `suppressed replayed result num_turns=N lastEmitted=M sessionId=... branch=...` and increments `mcpd_session_result_suppressed_total{branch}` via a new `onMetric` callback wired to the worker's existing `metrics:inc` bridge.
- Also stops the pre-existing "Result message … produced no events … session stuck" error from misfiring on legitimate suppressed replays.

## Test plan
- [x] `session-state.spec.ts`: `suppressedResult` set with correct `branch`/`numTurns`/`lastEmitted` for all three branches (result/error/fallback); null on genuine emit and cleared on next message.
- [x] `ws-server.spec.ts`: end-to-end replay increments `onMetric` with `{branch:"result"}`, emits the debug log, and does **not** log the misleading "stuck" error.
- [x] `bun run am-i-done` green on a clean host (87s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)