### PR TITLE
fix(test): enumerate partition specs via git ls-files (fixes #2850)

### DIFF
--- a/scripts/_runner/test-partition.spec.ts
+++ b/scripts/_runner/test-partition.spec.ts
@@ -1,16 +1,24 @@
 import { describe, expect, it } from "bun:test";
-import { globSync } from "node:fs";
+import { spawnSync } from "node:child_process";
 import { resolve } from "node:path";
 
 import { DAEMON_TEST_PATHS, NON_DAEMON_TEST_PATHS, parseFlag, parseRepeatableFlag } from "../am-i-done";
 
 const REPO_ROOT = resolve(import.meta.dirname, "../..");
 
+// Enumerate tracked spec files via `git ls-files` rather than a filesystem glob so
+// untracked/gitignored scratch specs (e.g. under build/) never enter the partition check (#2850).
+// Dot-directory specs (.claude/**, .git-hooks/**) are excluded to match the prior glob semantics:
+// they are run by dedicated CI steps (test:phases, test:hooks), not the two partitions checked here.
 function allSpecFiles(): string[] {
-  return globSync("**/*.spec.ts", {
-    cwd: REPO_ROOT,
-    ignore: ["node_modules/**", "**/node_modules/**"],
-  });
+  const result = spawnSync("git", ["ls-files", "*.spec.ts"], { cwd: REPO_ROOT, encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(`git ls-files failed: ${result.stderr}`);
+  }
+  return result.stdout
+    .split("\n")
+    .filter((line) => line.length > 0)
+    .filter((f) => !f.split("/").some((seg) => seg.startsWith(".")));
 }
 
 function matchesPath(file: string, paths: string[]): boolean {


### PR DESCRIPTION
## Summary
- `test-partition.spec.ts`'s `allSpecFiles()` used node's `globSync`, which enumerated the filesystem irrespective of `.gitignore` — so leftover scratch `*.spec.ts` under the gitignored `build/` dir caused spurious local partition-coverage failures (#2850). CI was unaffected (clean checkout has no scratch files).
- Switched to `git ls-files '*.spec.ts'` so only tracked files enter the check.
- Preserved the prior dot-directory skipping (`.claude/**`, `.git-hooks/**`), which `globSync` did implicitly — those specs are run by dedicated CI steps (`test:phases`, `test:hooks`), not the two partitions this test guards.

## Discovery (filed separately)
The `git ls-files` switch surfaced that `.claude/skills/*.spec.ts` (two files) are run by no test step at all — a pre-existing coverage gap the old glob hid. Filed as #2903; out of scope here.

## Test plan
- [x] `build/junk.spec.ts` repro from the issue now passes instead of failing
- [x] `bun test scripts/_runner/test-partition.spec.ts` — 10 pass
- [x] `bun run am-i-done` — all 11 steps green

🤖 Generated with [Claude Code](https://claude.com/claude-code)