### PR TITLE
feat(rules): flag `as ReturnType<typeof import(...)>` casts in spec files (fixes #2555)

### DIFF
--- a/scripts/rules/fixtures/no-stub-import-type-cast__clean.fixture.ts
+++ b/scripts/rules/fixtures/no-stub-import-type-cast__clean.fixture.ts
@@ -1,0 +1,11 @@
+/**
+ * @rule no-stub-import-type-cast
+ * @expect 0
+ * @path scripts/_runner/example.spec.ts
+ *
+ * Direct return-type annotation — the good shape the rule steers toward.
+ */
+
+import type { ImportGraph } from "../rules/_engine/import-graph";
+
+const noGraph = (): ImportGraph => ({ forward: new Map(), reverse: new Map() });

--- a/scripts/rules/fixtures/no-stub-import-type-cast__flagged.fixture.ts
+++ b/scripts/rules/fixtures/no-stub-import-type-cast__flagged.fixture.ts
@@ -1,0 +1,10 @@
+/**
+ * @rule no-stub-import-type-cast
+ * @expect 1
+ * @path scripts/_runner/example.spec.ts
+ *
+ * Suppressive `as ReturnType<typeof import(...)>` cast in a test stub — flagged.
+ */
+
+const noGraph = (): ReturnType<typeof import("../rules/_engine/import-graph").buildImportGraph> =>
+  ({ forward: new Map() }) as ReturnType<typeof import("../rules/_engine/import-graph").buildImportGraph>;

--- a/scripts/rules/fixtures/no-stub-import-type-cast__suppressed.fixture.ts
+++ b/scripts/rules/fixtures/no-stub-import-type-cast__suppressed.fixture.ts
@@ -1,0 +1,11 @@
+/**
+ * @rule no-stub-import-type-cast
+ * @expect 0
+ * @path scripts/_runner/example.spec.ts
+ *
+ * The dotw-ignore comment suppresses the cast on that line.
+ */
+
+const noGraph = () =>
+  // dotw-ignore no-stub-import-type-cast: legacy stub, tracked for removal
+  ({ forward: new Map() }) as ReturnType<typeof import("../rules/_engine/import-graph").buildImportGraph>;

--- a/scripts/rules/no-stub-import-type-cast.rule.ts
+++ b/scripts/rules/no-stub-import-type-cast.rule.ts
@@ -1,0 +1,38 @@
+import type { PatternRule } from "./_engine/rule";
+
+/**
+ * Rule: no-stub-import-type-cast
+ *
+ * Test stubs must not be forced to a shape via `as ReturnType<typeof
+ * import("...").fn>`. This cast silently bypasses structural type checking:
+ * if the target interface gains a new required field the stub still compiles,
+ * and the mismatch is invisible at the type level. PR #2552 fixed the one
+ * confirmed instance (scripts/_runner/ci-steps.spec.ts:409); this rule stops
+ * the pattern from being reintroduced as the rules-engine test suite grows.
+ *
+ * The dynamic-import token uniquely identifies the cast, so a line-level regex
+ * is sufficient — whitespace around the `<`, `typeof`, and `(` is tolerated so
+ * a trivial reformat cannot slip past.
+ *
+ * Fix: annotate the return type directly (import the type and write
+ * `(): TheType => ({...})`) or use `satisfies` so the stub is checked
+ * structurally.
+ */
+
+const rule: PatternRule = {
+  id: "no-stub-import-type-cast",
+  kind: "pattern",
+  appliesToTests: true,
+  scold:
+    "Suppressive 'as ReturnType<typeof import(...)>' cast in test stub — use a direct return-type annotation or 'satisfies' instead",
+  pattern: /\bas\s+ReturnType\s*<\s*typeof\s+import\s*\(/,
+  except: ["// dotw-ignore no-stub-import-type-cast:", "// dotw-todo no-stub-import-type-cast:"],
+  guidance: [
+    'import the type and annotate the return directly: `import type { T } from "..."; const stub = (): T => ({...})`',
+    "or use `satisfies T` so the stub is still checked structurally",
+    "the cast compiles even when T gains a new required field — that is the blind spot this rule closes",
+  ],
+  documentation: "#2555",
+};
+
+export default rule;

--- a/scripts/rules/no-stub-import-type-cast.spec.ts
+++ b/scripts/rules/no-stub-import-type-cast.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+
+import type { FileMeta } from "./_engine/file-loader";
+import { evaluateRule } from "./_engine/rule";
+import rule from "./no-stub-import-type-cast.rule";
+
+function makeSpec(content: string): FileMeta {
+  const relPath = "scripts/_runner/example.spec.ts";
+  return { path: relPath, relPath, content, pkg: "scripts/_runner", isTest: true };
+}
+
+function evaluate(file: FileMeta) {
+  return evaluateRule(rule, file, new Map([[file.path, file]]));
+}
+
+describe("no-stub-import-type-cast", () => {
+  it("flags the confirmed ci-steps.spec.ts pattern", () => {
+    const spec = makeSpec(
+      `const noGraph = (): ReturnType<typeof import("../rules/_engine/import-graph").buildImportGraph> =>\n` +
+        `  ({ forward: new Map() } as ReturnType<typeof import("../rules/_engine/import-graph").buildImportGraph>);`, // dotw-ignore no-stub-import-type-cast: fixture string, not real code
+    );
+    const violations = evaluate(spec);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].line).toBe(2);
+  });
+
+  it("tolerates whitespace variations", () => {
+    const spec = makeSpec(`const x = ({} as  ReturnType < typeof   import ("./m").fn>);`); // dotw-ignore no-stub-import-type-cast: fixture string, not real code
+    expect(evaluate(spec)).toHaveLength(1);
+  });
+
+  it("does not flag a plain ReturnType return annotation (no `as` cast)", () => {
+    const spec = makeSpec(`const f = (): ReturnType<typeof import("./m").fn> => ({});`);
+    expect(evaluate(spec)).toHaveLength(0);
+  });
+
+  it("does not flag a direct return-type annotation with satisfies", () => {
+    const spec = makeSpec(`import type { T } from "./m";\nconst stub = { forward: new Map() } satisfies T;`);
+    expect(evaluate(spec)).toHaveLength(0);
+  });
+
+  it("does not flag an unrelated `as SomeType` cast", () => {
+    const spec = makeSpec("const x = value as SomeConcreteType;");
+    expect(evaluate(spec)).toHaveLength(0);
+  });
+
+  it("honors the dotw-ignore suppression", () => {
+    const spec = makeSpec(
+      `const x = ({} as ReturnType<typeof import("./m").fn>); // dotw-ignore no-stub-import-type-cast: legacy`,
+    );
+    expect(evaluate(spec)).toHaveLength(0);
+  });
+
+  it("does not run on non-test files (appliesToTests: true)", () => {
+    const prod: FileMeta = { ...makeSpec(`const x = ({} as ReturnType<typeof import("./m").fn>);`), isTest: false }; // dotw-ignore no-stub-import-type-cast: fixture string, not real code
+    expect(evaluate(prod)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- New `doing-it-wrong` pattern rule `no-stub-import-type-cast` (test-only) flagging the suppressive `as ReturnType<typeof import("...").fn>` cast that silently bypasses structural type checking in test stubs.
- Guidance steers to a direct return-type annotation or `satisfies`. PR #2552 fixed the one confirmed instance (`ci-steps.spec.ts:409`); this rule stops recurrence.
- Whitespace-tolerant regex; `dotw-ignore`/`dotw-todo` suppression supported. Zero existing occurrences in the repo — no day-one suppressions needed.

## Test plan
- [x] `no-stub-import-type-cast.spec.ts` — 7 cases: confirmed pattern, whitespace variants, plain `ReturnType` annotation (no fire), `satisfies` (no fire), unrelated `as` cast (no fire), suppression, prod-file skip
- [x] Fixtures: `__flagged` (@expect 1), `__clean` (@expect 0), `__suppressed` (@expect 0) — pass the autoloaded fixture harness
- [x] `bun run doing-it-wrong` clean; `bun run am-i-done` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)