### PR TITLE
fix(sites): auto-mode falls back to cookie on 403 as well as 401 (fixes #2478)

### DIFF
--- a/packages/daemon/src/site-worker.spec.ts
+++ b/packages/daemon/src/site-worker.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseSitesArg, shouldAutoRestart } from "./site-worker";
+import { parseSitesArg, shouldAutoRestart, shouldFallbackToCookie } from "./site-worker";
 import type { LastBrowserSession } from "./site-worker";
 
 describe("parseSitesArg", () => {
@@ -68,5 +68,25 @@ describe("shouldAutoRestart", () => {
 
   test("false when both null session and vault not empty", () => {
     expect(shouldAutoRestart(null, false)).toBe(false);
+  });
+});
+
+describe("shouldFallbackToCookie", () => {
+  test("true on 401 (unauthorized)", () => {
+    expect(shouldFallbackToCookie(401)).toBe(true);
+  });
+
+  test("true on 403 (Microsoft expired/insufficient token)", () => {
+    expect(shouldFallbackToCookie(403)).toBe(true);
+  });
+
+  test("false on 200 success", () => {
+    expect(shouldFallbackToCookie(200)).toBe(false);
+  });
+
+  test("false on other 4xx/5xx (404, 429, 500)", () => {
+    expect(shouldFallbackToCookie(404)).toBe(false);
+    expect(shouldFallbackToCookie(429)).toBe(false);
+    expect(shouldFallbackToCookie(500)).toBe(false);
   });
 });

--- a/packages/daemon/src/site-worker.ts
+++ b/packages/daemon/src/site-worker.ts
@@ -21,9 +21,15 @@ import { resolve as resolvePath } from "node:path";
 import { AGENT_PROTOCOL_VERSION, SITE_SERVER_NAME } from "@mcp-cli/core";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
-import { createBrowserHandlers, toolError as error, toolOk as ok, shouldAutoRestart } from "./site/browser-handlers";
+import {
+  createBrowserHandlers,
+  toolError as error,
+  toolOk as ok,
+  shouldAutoRestart,
+  shouldFallbackToCookie,
+} from "./site/browser-handlers";
 import type { ToolResult } from "./site/browser-handlers";
-export { shouldAutoRestart, parseSitesArg } from "./site/browser-handlers";
+export { shouldAutoRestart, shouldFallbackToCookie, parseSitesArg } from "./site/browser-handlers";
 export type { LastBrowserSession } from "./site/browser-handlers";
 import type { SiteSpec } from "./site/browser/engine";
 import {
@@ -275,9 +281,9 @@ async function handleCall(args: Record<string, unknown>): Promise<ToolResult> {
               }
             : undefined,
         });
-        if (result.status === 401 && browserSnapshot) {
+        if (shouldFallbackToCookie(result.status) && browserSnapshot) {
           console.error(
-            `[site] call=${callName} site=${site.name} authMode=auto bearer returned 401, falling back to cookie`,
+            `[site] call=${callName} site=${site.name} authMode=auto bearer returned ${result.status}, falling back to cookie`,
           );
           result = await cookieProxyCall({ site: site.name, resolved, browser: browserSnapshot });
         }

--- a/packages/daemon/src/site/browser-handlers.ts
+++ b/packages/daemon/src/site/browser-handlers.ts
@@ -34,6 +34,11 @@ export function shouldAutoRestart(session: LastBrowserSession | null, vaultEmpty
   return session !== null && vaultEmpty;
 }
 
+// Microsoft APIs (and some others) return 403 for expired/insufficient tokens, not 401.
+export function shouldFallbackToCookie(status: number): boolean {
+  return status === 401 || status === 403;
+}
+
 // ── parseSitesArg ──
 
 const SITES_ARG_ERROR = "'sites' must be a non-empty array of site name strings";


### PR DESCRIPTION
## Summary
- Extend auto-mode bearer→cookie fallback to fire on `403` as well as `401`. Microsoft APIs (and some others) return `403` for expired/insufficient tokens, so the fallback previously never fired for them and the user got a confusing `403` from an auto-routing call.
- Extract a pure `shouldFallbackToCookie(status)` predicate in `site/browser-handlers.ts` (matching the `shouldAutoRestart` pattern) so the condition is unit-testable.
- Log line now reports the actual status (`returned ${status}`) instead of a hardcoded `401`.

## Test plan
- [x] New `shouldFallbackToCookie` unit tests: true on 401/403, false on 200/404/429/500
- [x] `bun run am-i-done` (typecheck, lint, rules, tests, coverage) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)