### PR TITLE
fix(phases): clear artifact_check/merge_block_labels on non-done terminal paths (fixes #2829)

### DIFF
--- a/.claude/phases/needs-attention-fn.ts
+++ b/.claude/phases/needs-attention-fn.ts
@@ -8,6 +8,7 @@ export interface NeedsAttentionWork {
 
 export interface NeedsAttentionState {
   get<T>(key: string): Promise<T | undefined>;
+  delete(key: string): Promise<void>;
 }
 
 export interface NeedsAttentionDeps {
@@ -69,6 +70,13 @@ export async function runNeedsAttention(
     commented = true;
   } catch {
     /* best-effort */
+  }
+
+  // Terminal-path parity with done (#2829): clear the artifact-check / merge-block
+  // state keys so an escalated (non-merged) work item doesn't retain stale
+  // blocking-label / artifact-check state in its work_items row.
+  for (const key of ["artifact_check", "merge_block_labels"]) {
+    await state.delete(key).catch(() => {});
   }
 
   try {

--- a/.claude/phases/triage-fn.ts
+++ b/.claude/phases/triage-fn.ts
@@ -30,6 +30,7 @@ export interface TriageDeps {
   waitForEvent(filter: TriageEventFilter, opts?: { timeoutMs?: number; since?: number }): Promise<TriageEvent>;
   stateGet<T>(key: string): Promise<T | undefined>;
   stateSet(key: string, value: unknown): Promise<void>;
+  stateDelete(key: string): Promise<void>;
   updateWorkItem(id: string, prNumber: number): Promise<void>;
   /** Changed file paths on the PR — drives the artifact-check gate (#2804). */
   listChangedFiles(prNumber: number): Promise<string[]>;
@@ -122,6 +123,10 @@ export async function runTriage(
     const changedFiles = await deps.listChangedFiles(prNumber);
     if (requiresArtifactCheck(changedFiles)) {
       await deps.stateSet("artifact_check", ARTIFACT_CHECK_REQUIRED);
+    } else {
+      // Self-correcting (#2829): a re-triage on a PR that no longer touches
+      // plumbing must clear a previously-set flag, not leave it stale.
+      await deps.stateDelete("artifact_check");
     }
   } catch {
     /* best-effort — artifact-check is advisory, never blocks triage */

--- a/.claude/phases/triage.ts
+++ b/.claude/phases/triage.ts
@@ -75,6 +75,7 @@ defineAlias({
       },
       stateGet: (key) => ctx.state.get(key),
       stateSet: (key, value) => ctx.state.set(key, value),
+      stateDelete: (key) => ctx.state.delete(key),
       async updateWorkItem(id, prNumber) {
         await ctx.mcp._work_items.work_items_update({ id, prNumber });
       },

--- a/.mcx.lock
+++ b/.mcx.lock
@@ -17,7 +17,7 @@
     {
       "name": "needs-attention",
       "resolvedPath": ".claude/phases/needs-attention.ts",
-      "contentHash": "30404ba095e4aa1f23d52484d46bb3008597a8fbfcc9e343914b86b4eac76a4a",
+      "contentHash": "4236086fff42d96e71a9a7fcdf9afac6d0256a05622dccc863a8352fa80f2d84",
       "schemaHash": "acee09becf66bc4ce4a92a0a0533840eb0c988f0f2eb0f6eac3a77227ed5267a"
     },
     {
@@ -41,7 +41,7 @@
     {
       "name": "triage",
       "resolvedPath": ".claude/phases/triage.ts",
-      "contentHash": "abb70a85a6b8478c303a20c4e501f07f98e6918191e42ee2a9aff30e77e2e904",
+      "contentHash": "4ed4abb095153be8d479e48fa455d6c528abf4b887a12cea3212f3ba544fa82d",
       "schemaHash": "03a042ac366a29c9f33de68cf1b24300bc899126e4084a4fa1303247afbc772c"
     }
   ],

--- a/test/needs-attention-phase.spec.ts
+++ b/test/needs-attention-phase.spec.ts
@@ -11,10 +11,14 @@ function makeWork(overrides: Partial<NeedsAttentionWork> = {}): NeedsAttentionWo
   return { id: "#42", prNumber: 100, issueNumber: 42, ...overrides };
 }
 
-function makeState(initial: Record<string, unknown> = {}): NeedsAttentionState {
+function makeState(initial: Record<string, unknown> = {}): NeedsAttentionState & { store: Map<string, unknown> } {
   const store = new Map<string, unknown>(Object.entries(initial));
   return {
+    store,
     get: async <T>(key: string) => store.get(key) as T | undefined,
+    delete: async (key: string) => {
+      store.delete(key);
+    },
   };
 }
 
@@ -178,5 +182,28 @@ describe("runNeedsAttention — side effects", () => {
         }),
       ),
     ).resolves.toBeDefined();
+  });
+
+  test("clears artifact_check and merge_block_labels on escalation (#2829)", async () => {
+    const state = makeState({
+      artifact_check: "required",
+      merge_block_labels: "review:changes",
+      review_round: 2,
+    });
+    await runNeedsAttention(makeWork(), state, makeDeps());
+    expect(state.store.has("artifact_check")).toBe(false);
+    expect(state.store.has("merge_block_labels")).toBe(false);
+    // Round counters are untouched — only the two blocking keys are cleared.
+    expect(state.store.get("review_round")).toBe(2);
+  });
+
+  test("a state.delete failure does not derail escalation (#2829)", async () => {
+    const brokenState: NeedsAttentionState = {
+      get: async () => undefined,
+      delete: async () => {
+        throw new Error("db down");
+      },
+    };
+    await expect(runNeedsAttention(makeWork(), brokenState, makeDeps())).resolves.toBeDefined();
   });
 });

--- a/test/triage-phase.spec.ts
+++ b/test/triage-phase.spec.ts
@@ -18,6 +18,7 @@ function makeDeps(overrides: Partial<TriageDeps> = {}): TriageDeps {
     waitForEvent: () => Promise.reject(new Error("waitForEvent not configured")),
     stateGet: () => Promise.resolve(undefined),
     stateSet: () => Promise.resolve(),
+    stateDelete: () => Promise.resolve(),
     updateWorkItem: () => Promise.resolve(),
     listChangedFiles: async () => [],
     ...overrides,
@@ -422,6 +423,21 @@ describe("runTriage — state", () => {
       }),
     );
     expect(stateWrites.artifact_check).toBe("required");
+  });
+
+  test("clears a stale artifact_check when the PR no longer touches plumbing (#2829)", async () => {
+    const deleted: string[] = [];
+    await runTriage(
+      { labels: [] },
+      makeWork({ prNumber: 100 }),
+      makeDeps({
+        listChangedFiles: async () => ["packages/core/src/config.ts"],
+        stateDelete: async (key) => {
+          deleted.push(key);
+        },
+      }),
+    );
+    expect(deleted).toContain("artifact_check");
   });
 
   test("does not set artifact_check for ordinary source changes (#2804)", async () => {


### PR DESCRIPTION
## Summary
- **needs-attention** now clears `artifact_check` and `merge_block_labels` on escalation, giving terminal-path parity with `done` (both keys were previously cleared only on the done-success path — #2826).
- **triage** now self-corrects `artifact_check`: it deletes the key when the PR no longer touches build/worker plumbing, so a re-triage is corrective rather than additive.
- Added `stateDelete` to `TriageDeps` and `delete` to `NeedsAttentionState`; regenerated `.mcx.lock`.

Out of scope (advisory-only, per issue): manually-closed/abandoned work items that never run a phase script — there is no phase hook to clear their state. The two phase-script terminal states (done, needs-attention) are the actionable surface.

## Test plan
- [x] `test/needs-attention-phase.spec.ts` — clears both keys on escalation, leaves round counters untouched, delete failure is non-fatal
- [x] `test/triage-phase.spec.ts` — clears stale `artifact_check` when plumbing no longer touched; existing set/no-set/failure cases still pass
- [x] `bun run am-i-done` — full gate green (typecheck, lint, rules, tests, coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)