### PR TITLE
feat(rules): provider-drift check for session-worker vs PROVIDER_NAMES (fixes #2603)

### DIFF
--- a/scripts/rules/fixtures/provider-drift__clean.fixture.ts
+++ b/scripts/rules/fixtures/provider-drift__clean.fixture.ts
@@ -1,0 +1,10 @@
+/**
+ * @rule provider-drift
+ * @expect 0
+ * @path packages/daemon/src/claude-session-worker.ts
+ *
+ * `claude` is present in the real agent-grid/versions-schema.ts
+ * PROVIDER_NAMES array — no drift, should not fire.
+ */
+
+export const worker = "claude";

--- a/scripts/rules/fixtures/provider-drift__ignored.fixture.ts
+++ b/scripts/rules/fixtures/provider-drift__ignored.fixture.ts
@@ -1,0 +1,12 @@
+/**
+ * @rule provider-drift
+ * @expect 0
+ * @path packages/daemon/src/fakeprovider-session-worker.ts
+ *
+ * A *-session-worker.ts file that is not an agent provider is exempted by
+ * an in-file dotw-ignore annotation — should not fire even though
+ * `fakeprovider` is absent from PROVIDER_NAMES.
+ */
+
+// dotw-ignore provider-drift: fakeprovider is a test fixture, not a real agent provider
+export const worker = "fakeprovider";

--- a/scripts/rules/fixtures/provider-drift__missing.fixture.ts
+++ b/scripts/rules/fixtures/provider-drift__missing.fixture.ts
@@ -1,0 +1,10 @@
+/**
+ * @rule provider-drift
+ * @expect 1
+ * @path packages/daemon/src/fakeprovider-session-worker.ts
+ *
+ * `fakeprovider` has a session worker but is absent from the real
+ * agent-grid/versions-schema.ts PROVIDER_NAMES array — should fire once.
+ */
+
+export const worker = "fakeprovider";

--- a/scripts/rules/provider-drift.rule.ts
+++ b/scripts/rules/provider-drift.rule.ts
@@ -1,0 +1,86 @@
+/**
+ * Rule: provider-drift
+ *
+ * Every agent provider has a `packages/daemon/src/<slug>-session-worker.ts`
+ * worker. The set of those slugs must be a subset of the `PROVIDER_NAMES`
+ * array in `agent-grid/versions-schema.ts` — otherwise a newly-landed
+ * provider is silently absent from the agent-grid schema, and the
+ * `versions.yaml` CI validation passes while omitting it (detection,
+ * install, and version-pinning tooling never learn about the provider).
+ *
+ * Direction is one-way: a worker present on disk MUST be listed in
+ * PROVIDER_NAMES. PROVIDER_NAMES entries without a worker (e.g. `grok`,
+ * `copilot`, `gemini` — providers detected/installed but not hosted as a
+ * daemon session worker) are NOT flagged.
+ *
+ * agent-grid/ is outside the file-loader scan roots, so the schema is read
+ * from disk directly rather than via ctx.files/anchors (same shape as
+ * `protocol-version-spec-sync`). The anchor on claude-session-worker.ts
+ * guarantees the daemon worker set is actually in the loaded file set — a
+ * --filter or rename that hides it fails loud instead of silently passing.
+ *
+ * Escape hatch for a `*-session-worker.ts` file that is genuinely not an
+ * agent provider: add `// dotw-ignore provider-drift: <reason>` anywhere in
+ * the worker file.
+ *
+ * Source: #2603 (discovered in adversarial review of #2598, epic #2538).
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { CheckRule } from "./_engine/rule";
+
+const CLAUDE_WORKER_REL = "packages/daemon/src/claude-session-worker.ts";
+const SCHEMA_REL = "agent-grid/versions-schema.ts";
+
+// Matches packages/daemon/src/<slug>-session-worker.ts (no nested dirs, not a spec).
+const WORKER_REL = /^packages\/daemon\/src\/([a-z0-9-]+)-session-worker\.ts$/;
+const PROVIDER_NAMES_ARRAY = /\bPROVIDER_NAMES\s*=\s*\[([\s\S]*?)\]/;
+const QUOTED = /["']([\w-]+)["']/g;
+const IGNORE = /\/\/\s*dotw-ignore\s+provider-drift\s*:\s*\S/;
+
+const rule: CheckRule = {
+  id: "provider-drift",
+  kind: "check",
+  anchors: [CLAUDE_WORKER_REL],
+  scold: "a *-session-worker.ts provider is missing from PROVIDER_NAMES in agent-grid/versions-schema.ts",
+  guidance: [
+    "add the provider slug to the PROVIDER_NAMES array in agent-grid/versions-schema.ts",
+    "then add a matching entry to agent-grid/versions.yaml so the schema and CI validation cover it",
+    "if this worker is genuinely not an agent provider, annotate it: // dotw-ignore provider-drift: <reason>",
+  ],
+  documentation: "#2603",
+  appliesToTests: false,
+  check(ctx) {
+    const match = WORKER_REL.exec(ctx.file.relPath);
+    if (!match) return;
+    ctx.checked();
+
+    const slug = match[1] as string;
+    if (IGNORE.test(ctx.file.content)) return;
+
+    const repoRoot = ctx.file.path.slice(0, ctx.file.path.length - ctx.file.relPath.length);
+    let schema: string;
+    try {
+      schema = readFileSync(resolve(repoRoot, SCHEMA_REL), "utf8");
+    } catch {
+      ctx.violated(1, 1, `${SCHEMA_REL} not found on disk — cannot verify provider coverage`);
+      return;
+    }
+
+    const arrayMatch = PROVIDER_NAMES_ARRAY.exec(schema);
+    if (!arrayMatch) {
+      ctx.violated(1, 1, `PROVIDER_NAMES array not found in ${SCHEMA_REL}`);
+      return;
+    }
+
+    const providers = new Set<string>();
+    for (const m of (arrayMatch[1] as string).matchAll(QUOTED)) providers.add(m[1] as string);
+
+    if (!providers.has(slug)) {
+      ctx.violated(1, 1, `provider "${slug}" has a session worker but is absent from PROVIDER_NAMES`);
+    }
+  },
+};
+
+export default rule;


### PR DESCRIPTION
## Summary
- Adds `scripts/rules/provider-drift.rule.ts` — a `doing-it-wrong` check that fails when a `packages/daemon/src/*-session-worker.ts` provider slug is absent from the `PROVIDER_NAMES` array in `agent-grid/versions-schema.ts`. Closes the gap where a new provider lands and `versions.yaml` CI validation silently passes while omitting it (#2603).
- `agent-grid/` is outside the sweep's scan roots (adding it globally trips 17 pre-existing violations — out of scope), so the schema is read from disk with a fail-loud fallback, mirroring `protocol-version-spec-sync`. Anchored on `claude-session-worker.ts` so a `--filter`/rename that hides the daemon worker set surfaces a `MissingAnchorError` instead of silently passing.
- Direction is one-way: a worker on disk must be listed; `PROVIDER_NAMES` entries without a worker (`grok`, `copilot`, `gemini`) are not flagged. Escape hatch for a non-provider worker: `// dotw-ignore provider-drift: <reason>`.
- Three fixtures: clean (`claude` → 0), missing (`fakeprovider` → 1), ignored (annotated → 0).

## Notes
- Issue cited the schema at `packages/daemon/src/agent-grid/versions-schema.ts`; it actually landed at repo-root `agent-grid/versions-schema.ts` (PR #2598), and `PROVIDER_NAMES` is a module-`const` (not exported) — parsed from source, not imported.
- Current tree is already in sync (5 workers all listed), so this is a green preventive gate, not an active fix.

## Test plan
- [x] `bun run doing-it-wrong --rule provider-drift` — clean on current tree
- [x] E2E: stub `xai-session-worker.ts` → exactly 1 violation; removed → clean
- [x] `bun test scripts/rules/fixtures.spec.ts -t provider-drift` — 3 pass
- [x] `bun run am-i-done` — all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)