### PR TITLE
fix(daemon): self-terminating stdio drain for resultless crash + grandchild fd (fixes #2879)

### DIFF
--- a/packages/daemon/src/claude-session/ws-server-stdio.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server-stdio.spec.ts
@@ -449,6 +449,89 @@ describe("ClaudeWsServer — stdio transport", () => {
     expect(events.some((e) => e.type === "session:result")).toBe(true);
   });
 
+  test("stdio buffered result is not dropped when the child exits concurrently and a grandchild holds stdout fd (#2833 ordering / #2879 race)", async () => {
+    const mock = mockStdioSpawn();
+    server = new ClaudeWsServer({
+      spawn: mock.spawn,
+      logger: silentLogger,
+      connectTimeoutMs: 5000,
+    });
+    await server.start(0);
+
+    const sessionId = crypto.randomUUID();
+    const events: Array<{ type: string }> = [];
+    server.onSessionEvent = (_sid, event) => {
+      events.push(event);
+    };
+
+    server.prepareSession(sessionId, { prompt: "Do something", transport: "stdio" });
+    server.spawnClaude(sessionId);
+
+    // Buffer init + result AND exit in the same tick — WITHOUT first waiting for
+    // session:result. This stresses the self-terminating drain's ordering: the
+    // post-exit parked-check must let the still-queued result be read (data wins the
+    // race) rather than breaking early and dropping it. stdout never closes (grandchild
+    // holds the fd), so a premature break would strand the buffered result.
+    mock.pushStdout(`${systemInitMessage(sessionId)}\n`);
+    mock.pushStdout(`${resultMessage(sessionId)}\n`);
+    mock.exitResolve(0);
+
+    // The buffered result must still fire session:result and the completed session must
+    // auto-terminate — no dropped result, no hang.
+    await pollUntil(() => events.some((e) => e.type === "session:result"), 1000);
+    expect(events.some((e) => e.type === "session:result")).toBe(true);
+    await pollUntil(() => !server.listSessions().some((s) => s.sessionId === sessionId), 1000);
+    expect(server.listSessions().some((s) => s.sessionId === sessionId)).toBe(false);
+  });
+
+  test("stdio proc.exited handler does not hang when the child crashes without a result and a grandchild holds stdout fd (#2879)", async () => {
+    const mock = mockStdioSpawn();
+    server = new ClaudeWsServer({
+      spawn: mock.spawn,
+      logger: silentLogger,
+      connectTimeoutMs: 5000,
+    });
+    await server.start(0);
+
+    const sessionId = crypto.randomUUID();
+    const events: Array<{ type: string }> = [];
+    server.onSessionEvent = (_sid, event) => {
+      events.push(event);
+    };
+
+    server.prepareSession(sessionId, { prompt: "Do something", transport: "stdio" });
+    server.spawnClaude(sessionId);
+
+    // A caller is dead-waiting on a result — it must be rejected, not hung forever.
+    const resultWait = server.waitForResult(sessionId, 5000);
+    let resultRejected = false;
+    resultWait.catch(() => {
+      resultRejected = true;
+    });
+
+    // Child emits init + an assistant message (state → active), then CRASHES without
+    // ever emitting a result/error frame — workCompletedSignal never resolves.
+    mock.pushStdout(`${systemInitMessage(sessionId)}\n`);
+    mock.pushStdout(`${assistantMessage(sessionId)}\n`);
+    await pollUntil(() => events.some((e) => e.type === "session:response"), 1000);
+
+    // Process exits, but a grandchild inherited stdout fd 1 and keeps the pipe open:
+    // stdout NEVER closes (no closeStdout), so the drain's parked read() would await EOF
+    // forever. Pre-#2879 the proc.exited handler raced [stdioDrainDone, workCompletedSignal]
+    // — BOTH hang (no EOF, no result), so the session never disconnected. The self-
+    // terminating drain now stops on the parked read and the handler proceeds.
+    mock.exitResolve(137);
+
+    // The never-completed session transitions to disconnected (not auto-terminated —
+    // no result), and the dead-waiting resultWaiter is rejected. No hang.
+    await pollUntil(() => events.some((e) => e.type === "session:disconnected"), 1000);
+    expect(events.some((e) => e.type === "session:disconnected")).toBe(true);
+    await pollUntil(() => resultRejected, 1000);
+    expect(resultRejected).toBe(true);
+    // Crash without a result frame must NOT synthesize a session:result.
+    expect(events.some((e) => e.type === "session:result")).toBe(false);
+  });
+
   test("stdio session clears connect timeout on first stdout line", async () => {
     const mock = mockStdioSpawn();
     server = new ClaudeWsServer({

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -1060,14 +1060,16 @@ export class ClaudeWsServer {
       // branch below, flip to `disconnected`, and the #2814 handleStdioLine
       // guard drops the buffered `result` — session:result never fires (#2825).
       if (session.transport === "stdio" && session.stdioDrainDone) {
-        // Do NOT await the drain unbounded: a grandchild that inherited the child's
-        // stdout write fd holds the pipe open past exit, so the drain's parked read()
-        // never sees EOF and this handler would hang forever — no disconnect, no
-        // resultWaiter rejection, no auto-terminate (#2833). Instead race the drain
-        // against the work-completion signal. As soon as the buffered `result` is in
-        // hand (or genuine EOF arrives) we stop waiting and cancel the reader to
-        // release the parked read. This never drops a result the way a wall-clock cap
-        // would (#2825): we only stop early once completion is proven.
+        // Race the drain against the work-completion signal so a buffered trailing
+        // `result` is processed before we judge completion. The drain itself is now
+        // bounded — it self-terminates once the child is dead and its read parks on an
+        // empty queue (see the post-exit path in startStdioReader), so this await
+        // cannot hang even when a grandchild holds stdout fd 1 open past exit and the
+        // child never emitted a result (#2833/#2879). workCompletedSignal is the fast
+        // path: it resolves the instant the buffered result is in hand, before the
+        // drain finishes its post-exit quiesce. Neither drops a result the way a
+        // wall-clock cap would (#2825): the drain stops only once the queue is proven
+        // empty, never on elapsed time.
         await Promise.race([session.stdioDrainDone, session.workCompletedSignal]);
         await this.cancelStdioReader(session);
         try {
@@ -1259,6 +1261,13 @@ export class ClaudeWsServer {
     const decoder = new TextDecoder();
     let buffer = "";
 
+    // Sentinels for the post-exit read race (below). String literals are unit types so
+    // `===` narrows the read-result union cleanly, and a real read result is always an
+    // object — the two can never collide.
+    const EXITED = "stdio-child-exited" as const;
+    const PARKED = "stdio-read-parked" as const;
+    const exited = proc.exited.then(() => EXITED);
+
     const drain = async () => {
       // Genuine EOF (child closed stdout) vs an external cancel (teardown /
       // proc.exited unblocking a parked read past a grandchild-held fd) both surface
@@ -1267,12 +1276,60 @@ export class ClaudeWsServer {
       let genuineEof = false;
       try {
         for (;;) {
-          const { done, value } = await reader.read();
-          if (done) {
+          const readP = reader.read();
+          // While the child is alive, block indefinitely for the next frame — a
+          // long-idle session between turns is normal. Once the child has exited,
+          // `exited` is already resolved and wins this race immediately, handing us
+          // off to the bounded post-exit path below.
+          const raced = await Promise.race([readP, exited]);
+
+          let chunk: Awaited<ReturnType<typeof reader.read>>;
+          if (raced === EXITED) {
+            // Child is dead. Every byte it wrote is either already read or still
+            // transiting the OS-pipe→stream pump — an IO/macrotask boundary, so a
+            // bare microtask yield would be too early. Wait one full event-loop turn
+            // for the pump to flush, then decide whether this read produced data or
+            // is genuinely parked on an empty queue.
+            await new Promise<void>((resolve) => setImmediate(resolve));
+            // `Promise.resolve(PARKED)` is already settled, but Promise.race attaches
+            // reactions in argument order: if `readP` settled during the turn its
+            // reaction runs first and wins; only a still-pending (parked) read loses
+            // to PARKED. So this is a race-free "did the read produce data?" check.
+            const settled = await Promise.race([readP, Promise.resolve(PARKED)]);
+            if (settled === PARKED) {
+              // Parked read + dead child + empty queue = "no result is coming."
+              // The stream never EOFs (a grandchild inherited stdout fd 1 and holds
+              // the write end open past child exit — #2833/#2879), so awaiting EOF
+              // would hang the proc.exited handler forever. Stop draining instead.
+              //
+              // This drops nothing: the loop consumes every queued byte — resolving
+              // workCompletedSignal on any terminal `result`/`error` — before a read
+              // can park, so a parked read PROVES the queue is empty. The stop is
+              // gated on that state (child dead + parked), not on a wall-clock cap,
+              // so it does not reintroduce the #2825 drain-timeout truncation.
+              //
+              // Residual gap the code cannot show: if a never-EOF stream emits a
+              // terminal frame AND the child crashes AND the OS-pipe→stream pump has
+              // still not delivered those bytes after a full event-loop turn, the
+              // frame is dropped. This triple-conjunction does not arise for real
+              // `claude`, which closes stdout on exit — delivering EOF (the `done`
+              // branch) rather than ever reaching this parked path.
+              genuineEof = false;
+              // Cancel to resolve the outstanding parked read and free the lock; the
+              // flush below then releases cleanly (releaseLock throws on a pending read).
+              await reader.cancel().catch(() => {});
+              break;
+            }
+            chunk = settled;
+          } else {
+            chunk = raced;
+          }
+
+          if (chunk.done) {
             genuineEof = session.stdioReader === reader;
             break;
           }
-          buffer += decoder.decode(value, { stream: true });
+          buffer += decoder.decode(chunk.value, { stream: true });
 
           for (let nlIdx = buffer.indexOf("\n"); nlIdx !== -1; nlIdx = buffer.indexOf("\n")) {
             const line = buffer.slice(0, nlIdx).trim();


### PR DESCRIPTION
## Summary
- **Root cause (verified):** the `proc.exited` stdio branch raced `[stdioDrainDone, workCompletedSignal]`. When the child crashes *without* emitting a `result`/`error` frame **and** a grandchild inherited stdout fd 1 (so the stream never EOFs), neither settles — the handler hangs forever: no `session:disconnected`, no `resultWaiter` rejection, no auto-teardown. The session worker never cleans up. Reproduced deterministically (state was `active` after `session:response` — the real crash-mid-work shape; pre-fix the new test times out at 1000ms).
- **Fix:** make the drain loop **self-terminate**. Once the child has exited, each blocking `reader.read()` is raced against the exit signal; on exit we yield **one full event-loop turn** (`setImmediate`, for the OS-pipe→stream pump boundary — a bare microtask is too early) and then check whether the read produced data or is genuinely parked on an empty queue. A parked read + dead child **proves** the queue is empty (the loop drains every queued byte — resolving `workCompletedSignal` on any terminal frame — before a read can park), so stopping there drops nothing.
- **Not a #2825 regression:** the stop is gated on *state* (child dead + parked read), never on a wall-clock cap. #2825's banned pattern truncated a *slow-but-live* drain after fixed N ms; this cannot, because data-reads always win the parked-check race.
- `proc.exited`'s existing `Promise.race([stdioDrainDone, workCompletedSignal])` stays as the fast path (result-in-hand resolves before the drain's post-exit quiesce); its stale "would hang forever" comment is corrected.

## Design notes for review
- **Yield mechanics:** one full event-loop turn (`setImmediate`-equivalent), *not* a duration timer — chosen deliberately over a bare microtask so the OS-pipe→stream pump (an IO/macrotask boundary) can flush before we declare "parked". This shrinks, not eliminates, the residual gap.
- **Residual gap** (documented in a comment at the sentinel site, as it can't be shown in code): a never-EOF stream that emits a terminal frame **AND** crashes **AND** whose pump hasn't delivered those bytes after a full event-loop turn would drop the frame. This triple-conjunction does not arise for real `claude`, which closes stdout on exit — delivering EOF (the `done` branch), never reaching the parked path.
- **Race ordering:** the parked-check `Promise.race([readP, Promise.resolve(PARKED)])` is race-free — Promise.race attaches reactions in argument order, so a `readP` that settled during the turn wins; only a still-pending (parked) read loses to `PARKED`.

## Test plan
- [x] New #2879 regression test: init + assistant (state → `active`), crash without result, grandchild holds stdout (no `closeStdout`) → asserts `session:disconnected` fires, dead-waiting `resultWaiter` rejects, and **no** synthetic `session:result`. Verified it times out at 1000ms *without* the fix.
- [x] New concurrent-race test: result buffered **and** child exits in the same tick (no drain-first wait), grandchild holds fd → asserts the buffered `session:result` is **not** dropped and the session auto-terminates. Directly stresses the parked-check ordering.
- [x] Existing #2833 result-then-grandchild auto-terminate test stays green (ordering preserved).
- [x] `ws-server-stdio.spec.ts` (24), `ws-server.spec.ts` + `ws-server-stdio-load.spec.ts` (225) green.
- [x] `bun run am-i-done` full gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)