### PR TITLE
feat(gc): git-level squash-merge detection as a third worktree-reclaim signal (fixes #2887)

### DIFF
--- a/packages/core/src/worktree-shim.spec.ts
+++ b/packages/core/src/worktree-shim.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -9,6 +10,7 @@ import {
   cleanupWorktree,
   createWorktree,
   getDefaultBranch,
+  isSquashMerged,
   listMcxWorktrees,
   parseWorktreeList,
   pruneWorktrees,
@@ -761,6 +763,90 @@ describe("listMcxWorktrees", () => {
 
 // ── pruneWorktrees ──
 
+describe("isSquashMerged (real git)", () => {
+  // Runs real git plumbing (merge-base, commit-tree, cherry) against a
+  // throwaway repo — the only way to prove the patch-equivalence algorithm
+  // actually detects a squash-merge and does not false-positive (#2887).
+  // git honors an inherited GIT_DIR/GIT_WORK_TREE over `-C`, so when this spec
+  // runs under a git hook (e.g. pre-push, which exports GIT_DIR), a bare
+  // `git commit` would land in the REAL repo instead of the temp fixture. Strip
+  // all GIT_* vars so every command is confined to the throwaway repo.
+  const cleanGitEnv: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (!k.startsWith("GIT_") && v !== undefined) cleanGitEnv[k] = v;
+  }
+
+  const realExec: WorktreeShimDeps["exec"] = (cmd) => {
+    const r = spawnSync(cmd[0], cmd.slice(1), { encoding: "utf8", env: cleanGitEnv });
+    return { stdout: r.stdout ?? "", stderr: r.stderr ?? "", exitCode: r.status ?? 1 };
+  };
+  const deps: WorktreeShimDeps = { exec: realExec, printError: () => {}, printInfo: () => {} };
+
+  function git(repo: string, ...args: string[]): void {
+    const r = spawnSync("git", ["-C", repo, ...args], { encoding: "utf8", env: cleanGitEnv });
+    if ((r.status ?? 1) !== 0) throw new Error(`git ${args.join(" ")} failed: ${r.stderr}`);
+  }
+
+  function initRepo(): string {
+    const repo = makeTmpDir();
+    git(repo, "init", "-q", "-b", "main");
+    git(repo, "config", "user.email", "t@t.t");
+    git(repo, "config", "user.name", "t");
+    git(repo, "commit", "--allow-empty", "-q", "-m", "base");
+    return repo;
+  }
+
+  test("detects a squash-merged branch (cumulative diff already in main)", () => {
+    const repo = initRepo();
+    try {
+      // feat: two commits that together produce feature.txt="hello\nworld"
+      git(repo, "checkout", "-q", "-b", "feat");
+      writeFileSync(join(repo, "feature.txt"), "hello\n");
+      git(repo, "add", "-A");
+      git(repo, "commit", "-q", "-m", "feat 1");
+      writeFileSync(join(repo, "feature.txt"), "hello\nworld\n");
+      git(repo, "add", "-A");
+      git(repo, "commit", "-q", "-m", "feat 2");
+
+      // Simulate a squash-merge into main: one commit with the same net tree.
+      git(repo, "checkout", "-q", "main");
+      writeFileSync(join(repo, "feature.txt"), "hello\nworld\n");
+      git(repo, "add", "-A");
+      git(repo, "commit", "-q", "-m", "squash: feat (#123)");
+
+      expect(isSquashMerged(repo, "feat", "main", deps)).toBe(true);
+    } finally {
+      rmSync(repo, { recursive: true });
+    }
+  });
+
+  test("does not false-positive on a genuinely-unmerged branch with a unique diff", () => {
+    const repo = initRepo();
+    try {
+      git(repo, "checkout", "-q", "-b", "feat");
+      writeFileSync(join(repo, "feature.txt"), "unique feature work\n");
+      git(repo, "add", "-A");
+      git(repo, "commit", "-q", "-m", "feat unique");
+
+      // main advances with unrelated work — feat's diff is NOT present in main.
+      git(repo, "checkout", "-q", "main");
+      writeFileSync(join(repo, "other.txt"), "unrelated\n");
+      git(repo, "add", "-A");
+      git(repo, "commit", "-q", "-m", "unrelated");
+
+      expect(isSquashMerged(repo, "feat", "main", deps)).toBe(false);
+    } finally {
+      rmSync(repo, { recursive: true });
+    }
+  });
+
+  test("returns false (fail-closed) when git plumbing fails", () => {
+    // Nonexistent repo path → merge-base fails → no reclaim on uncertainty.
+    const missing = join(tmpdir(), `no-such-repo-${Date.now()}`);
+    expect(isSquashMerged(missing, "feat", "main", deps)).toBe(false);
+  });
+});
+
 describe("pruneWorktrees", () => {
   test("prunes clean merged worktrees", async () => {
     const porcelainOutput = [
@@ -913,6 +999,161 @@ describe("pruneWorktrees", () => {
     expect(result.deletedBranches.has("claude/feat-squashed")).toBe(true);
     // Force-delete must be used; plain `-d` alone would leak the branch.
     expect(calls.some((c) => c.includes("-D") && c.includes("claude/feat-squashed"))).toBe(true);
+  });
+
+  test("reclaims a squash-merged branch detected offline via patch-equivalence and force-deletes (-D)", async () => {
+    // #2887: neither ancestry (--merged) nor resolvedByPr fires. isSquashMerged
+    // reports the branch diff is already in main; the branch tip equals its
+    // origin ref (not ahead) so it is safe to reclaim with -D.
+    const porcelainOutput = [
+      "worktree /repo",
+      "HEAD abc123",
+      "branch refs/heads/main",
+      "",
+      "worktree /repo/.claude/worktrees/feat-squashed-offline",
+      "HEAD def456",
+      "branch refs/heads/claude/feat-squashed-offline",
+      "",
+    ].join("\n");
+
+    const calls: string[][] = [];
+    const exec = mock((cmd: string[]) => {
+      calls.push(cmd);
+      if (cmd.includes("list") && cmd.includes("--porcelain"))
+        return { stdout: porcelainOutput, stderr: "", exitCode: 0 };
+      if (cmd.includes("symbolic-ref")) return { stdout: "refs/remotes/origin/main", stderr: "", exitCode: 0 };
+      if (cmd.includes("--merged")) return { stdout: "  main\n", stderr: "", exitCode: 0 }; // NOT ancestry-merged
+      // squash detection plumbing
+      if (cmd.includes("merge-base")) return { stdout: "base-sha", stderr: "", exitCode: 0 };
+      if (cmd.includes("commit-tree")) return { stdout: "dangling-sha", stderr: "", exitCode: 0 };
+      if (cmd.includes("cherry")) return { stdout: "- dangling-sha\n", stderr: "", exitCode: 0 }; // equivalent
+      if (cmd.includes("status")) return { stdout: "", stderr: "", exitCode: 0 }; // clean
+      if (cmd.includes("remove")) return { stdout: "", stderr: "", exitCode: 0 };
+      if (cmd.includes("-D")) return { stdout: "", stderr: "", exitCode: 0 };
+      if (cmd.includes("-d")) return { stdout: "", stderr: "not fully merged", exitCode: 1 };
+      // ahead-of-forge: origin/<branch> exists and equals the tip → not ahead
+      if (cmd.includes("rev-parse") && cmd.some((a) => a.includes("refs/remotes/origin/")))
+        return { stdout: "tip-sha", stderr: "", exitCode: 0 };
+      // post-delete verification: refs/heads/<branch> is gone
+      if (cmd.includes("rev-parse") && cmd.some((a) => a.includes("refs/heads/")))
+        return { stdout: "", stderr: "", exitCode: 1 };
+      if (cmd.includes("rev-list")) return { stdout: "0\n", stderr: "", exitCode: 0 }; // 0 ahead
+      if (cmd.includes("rev-parse")) return { stdout: "tip-sha", stderr: "", exitCode: 0 }; // local HEAD
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const printError = mock(() => {});
+    const printInfo = mock(() => {});
+
+    const result = await pruneWorktrees({
+      repoRoot: "/repo",
+      activeWorktrees: new Set(),
+      deps: { exec, printError, printInfo },
+      // No PR entry — the squash signal is what makes this reclaimable.
+      resolvedByPr: new Map(),
+    });
+
+    expect(result.pruned).toBe(1);
+    expect(result.prunedNames).toEqual(["feat-squashed-offline"]);
+    expect(result.skippedUnmerged).toEqual([]);
+    expect(result.skippedUnpushed).toEqual([]);
+    expect(result.deletedBranches.has("claude/feat-squashed-offline")).toBe(true);
+    expect(calls.some((c) => c.includes("-D") && c.includes("claude/feat-squashed-offline"))).toBe(true);
+  });
+
+  test("skips a squash-detected branch that is ahead of the forge (unpushed commits) → skippedUnpushed", async () => {
+    // #2887 data-loss guard: the branch diff is patch-equivalent to main, but
+    // the local tip carries commits the forge has not seen. Deleting would
+    // orphan them, so the squash path must honor the ahead-of-forge guard
+    // exactly as the PR path does.
+    const porcelainOutput = [
+      "worktree /repo",
+      "HEAD abc123",
+      "branch refs/heads/main",
+      "",
+      "worktree /repo/.claude/worktrees/feat-squashed-ahead",
+      "HEAD def456",
+      "branch refs/heads/claude/feat-squashed-ahead",
+      "",
+    ].join("\n");
+
+    const calls: string[][] = [];
+    const exec = mock((cmd: string[]) => {
+      calls.push(cmd);
+      if (cmd.includes("list") && cmd.includes("--porcelain"))
+        return { stdout: porcelainOutput, stderr: "", exitCode: 0 };
+      if (cmd.includes("symbolic-ref")) return { stdout: "refs/remotes/origin/main", stderr: "", exitCode: 0 };
+      if (cmd.includes("--merged")) return { stdout: "  main\n", stderr: "", exitCode: 0 };
+      if (cmd.includes("merge-base")) return { stdout: "base-sha", stderr: "", exitCode: 0 };
+      if (cmd.includes("commit-tree")) return { stdout: "dangling-sha", stderr: "", exitCode: 0 };
+      if (cmd.includes("cherry")) return { stdout: "- dangling-sha\n", stderr: "", exitCode: 0 }; // patch-equivalent
+      if (cmd.includes("status")) return { stdout: "", stderr: "", exitCode: 0 }; // clean tree
+      // origin/<branch> exists but the local tip is ahead → protect
+      if (cmd.includes("rev-parse") && cmd.includes("--verify"))
+        return { stdout: "origin-sha", stderr: "", exitCode: 0 };
+      if (cmd.includes("rev-list")) return { stdout: "2\n", stderr: "", exitCode: 0 }; // 2 commits ahead
+      if (cmd.includes("rev-parse")) return { stdout: "local-sha", stderr: "", exitCode: 0 };
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const printError = mock(() => {});
+    const printInfo = mock(() => {});
+
+    const result = await pruneWorktrees({
+      repoRoot: "/repo",
+      activeWorktrees: new Set(),
+      deps: { exec, printError, printInfo },
+      resolvedByPr: new Map(),
+    });
+
+    expect(result.pruned).toBe(0);
+    expect(result.skippedUnpushed).toEqual(["claude/feat-squashed-ahead"]);
+    // Must never remove the worktree or force-delete the branch.
+    expect(calls.some((c) => c.includes("remove"))).toBe(false);
+    expect(calls.some((c) => c.includes("-D"))).toBe(false);
+  });
+
+  test("does NOT reclaim a genuinely-unmerged branch whose diff merely resembles main", async () => {
+    // #2887 false-positive guard: patch-equivalence must not fire on a branch
+    // with a unique diff. `git cherry` reports '+' (not in default branch), so
+    // isSquashMerged is false and the branch is protected via skippedUnmerged.
+    const porcelainOutput = [
+      "worktree /repo",
+      "HEAD abc123",
+      "branch refs/heads/main",
+      "",
+      "worktree /repo/.claude/worktrees/feat-lookalike",
+      "HEAD def456",
+      "branch refs/heads/claude/feat-lookalike",
+      "",
+    ].join("\n");
+
+    const calls: string[][] = [];
+    const exec = mock((cmd: string[]) => {
+      calls.push(cmd);
+      if (cmd.includes("list") && cmd.includes("--porcelain"))
+        return { stdout: porcelainOutput, stderr: "", exitCode: 0 };
+      if (cmd.includes("symbolic-ref")) return { stdout: "refs/remotes/origin/main", stderr: "", exitCode: 0 };
+      if (cmd.includes("--merged")) return { stdout: "  main\n", stderr: "", exitCode: 0 };
+      if (cmd.includes("merge-base")) return { stdout: "base-sha", stderr: "", exitCode: 0 };
+      if (cmd.includes("commit-tree")) return { stdout: "dangling-sha", stderr: "", exitCode: 0 };
+      if (cmd.includes("cherry")) return { stdout: "+ dangling-sha\n", stderr: "", exitCode: 0 }; // unique diff
+      if (cmd.includes("status")) return { stdout: "", stderr: "", exitCode: 0 };
+      return { stdout: "", stderr: "", exitCode: 0 };
+    });
+    const printError = mock(() => {});
+    const printInfo = mock(() => {});
+
+    const result = await pruneWorktrees({
+      repoRoot: "/repo",
+      activeWorktrees: new Set(),
+      deps: { exec, printError, printInfo },
+      resolvedByPr: new Map(),
+    });
+
+    expect(result.pruned).toBe(0);
+    expect(result.skippedUnmerged).toEqual(["claude/feat-lookalike"]);
+    // Never removed, never force-deleted.
+    expect(calls.some((c) => c.includes("remove"))).toBe(false);
+    expect(calls.some((c) => c.includes("-D"))).toBe(false);
   });
 
   test("does not reclaim a clean resolved-PR worktree that is ahead of the forge (unpushed commits)", async () => {

--- a/packages/core/src/worktree-shim.ts
+++ b/packages/core/src/worktree-shim.ts
@@ -507,6 +507,57 @@ function isAheadOfForge(
 }
 
 /**
+ * Detect a squash-merge at the git layer via patch-equivalence (#2887).
+ *
+ * `git branch --merged` never lists a squash-merged branch because its tip is a
+ * non-ancestor of the default branch, and a resolved PR is only visible while
+ * `gh pr list` still returns it. This third signal is offline and
+ * PR-independent: it synthesizes a single squash commit of the branch's
+ * cumulative diff and asks whether that diff is already present in the default
+ * branch.
+ *
+ *   mergeBase = git merge-base <defaultBranch> <branch>
+ *   tree      = git rev-parse <branch>^{tree}
+ *   dangling  = git commit-tree <tree> -p <mergeBase> -m _   # synthetic squash
+ *   git cherry <defaultBranch> <dangling>   # '-' prefix ⇒ diff already in default
+ *
+ * `git cherry` compares by patch-id, so it only reports equivalence when the
+ * branch's cumulative diff genuinely matches something already merged — a
+ * branch that merely resembles main (unique diff) yields '+' and is NOT a
+ * match. Any git failure returns false (fail-closed: never reclaim on
+ * uncertainty). Branches matched here are non-ancestor tips, so callers must
+ * delete with `-D` and must still honor the ahead-of-forge unpushed guard.
+ */
+export function isSquashMerged(
+  repoRoot: string,
+  branch: string,
+  defaultBranch: string,
+  deps: WorktreeShimDeps,
+): boolean {
+  const mergeBase = deps.exec(["git", "-C", repoRoot, "merge-base", defaultBranch, branch]);
+  if (mergeBase.exitCode !== 0) return false;
+  const base = mergeBase.stdout.trim();
+  if (!base) return false;
+
+  const tree = deps.exec(["git", "-C", repoRoot, "rev-parse", `${branch}^{tree}`]);
+  if (tree.exitCode !== 0) return false;
+  const treeSha = tree.stdout.trim();
+  if (!treeSha) return false;
+
+  const dangling = deps.exec(["git", "-C", repoRoot, "commit-tree", treeSha, "-p", base, "-m", "_"]);
+  if (dangling.exitCode !== 0) return false;
+  const danglingSha = dangling.stdout.trim();
+  if (!danglingSha) return false;
+
+  const cherry = deps.exec(["git", "-C", repoRoot, "cherry", defaultBranch, danglingSha]);
+  if (cherry.exitCode !== 0) return false;
+  // `git cherry` prints "- <sha>" when the change is already in defaultBranch
+  // (patch-equivalent) and "+ <sha>" when it is unique. Empty output ⇒ nothing
+  // to compare ⇒ not a match.
+  return cherry.stdout.trim().startsWith("-");
+}
+
+/**
  * Delete a branch after its worktree is removed.
  *
  * Default (safe) uses `git branch -d`, which only deletes ancestry-merged
@@ -670,24 +721,38 @@ export async function pruneWorktrees(opts: WorktreePruneOptions): Promise<Worktr
     }
     if (activeWorktrees.has(wtName)) continue;
     // A branch is "done" when git ancestry says merged OR its PR is resolved
-    // (MERGED/CLOSED). The PR signal is what catches squash-merges, whose tip
-    // is a non-ancestor of the default branch (#2662).
+    // (MERGED/CLOSED) OR its cumulative diff is patch-equivalent to something
+    // already in the default branch. The PR signal catches squash-merges whose
+    // tip is a non-ancestor (#2662); the patch-equivalence signal catches the
+    // same class offline when the PR has aged out of `gh pr list` or was never
+    // opened (#2887). Only compute the (more expensive) git-level squash check
+    // when the two cheaper signals miss.
     const ancestryMerged = wt.branch ? mergedBranches.has(wt.branch) : false;
     const prResolved = wt.branch ? (resolvedByPr?.has(wt.branch) ?? false) : false;
-    if (!skipMergeCheck && wt.branch && !ancestryMerged && !prResolved) {
+    const squashMerged =
+      wt.branch && !ancestryMerged && !prResolved ? isSquashMerged(repoRoot, wt.branch, defaultBranch, deps) : false;
+    if (!skipMergeCheck && wt.branch && !ancestryMerged && !prResolved && !squashMerged) {
       skippedUnmerged.push(wt.branch);
       continue;
     }
+
+    // Both the PR-resolved and the squash-detected signals reclaim non-ancestor
+    // tips, so both delete with `-D` and both must clear the ahead-of-forge
+    // guard below.
+    const nonAncestorReclaim = (prResolved || squashMerged) && !ancestryMerged;
 
     // Check if clean (trim to handle trailing newline from some git versions)
     const { stdout: status, exitCode: statusExit } = deps.exec(["git", "-C", wt.path, "status", "--porcelain"]);
     if (statusExit !== 0 || status.trim() !== "") continue;
 
     // Data-loss guard: ancestry-merged tips are fully contained in the default
-    // branch, but a PR-resolved-only tip (squash/closed) can hold committed-but-
-    // unpushed work even when the tree is clean. Reclaiming would `-D` the branch
-    // and orphan those commits. Skip when the tip is ahead of the forge.
-    if (wt.branch && prResolved && !ancestryMerged) {
+    // branch, but a non-ancestor tip reclaimed via PR-state (squash/closed) or
+    // via git-level patch-equivalence can hold committed-but-unpushed work even
+    // when the tree is clean. Reclaiming would `-D` the branch and orphan those
+    // commits. Skip when the tip is ahead of the forge. A squash-detected branch
+    // has no PR head SHA backstop, so isAheadOfForge falls back to the
+    // origin/<branch> ref (protecting when it is absent) — see #2887.
+    if (wt.branch && nonAncestorReclaim) {
       if (isAheadOfForge(wt.path, wt.branch, resolvedByPr?.get(wt.branch), deps)) {
         deps.printError(`Warning: worktree branch is ahead of the forge, not removing (unpushed commits): ${wt.path}`);
         skippedUnpushed.push(wt.branch);
@@ -724,7 +789,7 @@ export async function pruneWorktrees(opts: WorktreePruneOptions): Promise<Worktr
         deps.printInfo(`Removed worktree via hook: ${wt.path}`);
         pruned++;
         prunedNames.push(wtName);
-        if (wt.branch && deletePrunedBranch(wt.branch, repoRoot, deps, prResolved)) {
+        if (wt.branch && deletePrunedBranch(wt.branch, repoRoot, deps, nonAncestorReclaim)) {
           deletedBranches.add(wt.branch);
         }
       } else if (hookExit === 0) {
@@ -736,7 +801,7 @@ export async function pruneWorktrees(opts: WorktreePruneOptions): Promise<Worktr
       if (removeWorktreeWithVerification(repoRoot, wt.path, deps)) {
         pruned++;
         prunedNames.push(wtName);
-        if (wt.branch && deletePrunedBranch(wt.branch, repoRoot, deps, prResolved)) {
+        if (wt.branch && deletePrunedBranch(wt.branch, repoRoot, deps, nonAncestorReclaim)) {
           deletedBranches.add(wt.branch);
         }
       }


### PR DESCRIPTION
## Summary
- Adds an offline, PR-independent third "done" signal to `pruneWorktrees` (#2887): detect a squash-merge via **patch-equivalence** (`git merge-base` → `commit-tree` → `git cherry`) instead of ancestry. Catches standing scratch worktrees whose PRs have aged out of `gh pr list` or were never opened — the leaking population that neither `git branch --merged` nor the #2662 resolved-PR signal can see.
- A branch is reclaimable when ancestry-merged **OR** PR-resolved **OR** patch-equivalent to the default branch. Squash-detected tips are non-ancestors, so they force-delete with `-D`.
- **All new git plumbing stays in `packages/core/src/worktree-shim.ts`** (not `git.ts`, per the #2896 conflict-surface constraint). `isSquashMerged` fails closed on any git error (never reclaim on uncertainty).

## Safety (binding data-loss guardrails)
- The #2662 skip buckets are preserved untouched: **dirty**, **active-session**, and **ahead-of-forge** → the last routes to `skippedUnpushed`. The squash path reuses `isAheadOfForge` exactly as the PR path does (no PR head-SHA backstop, so it protects when `origin/<branch>` is absent).
- The (more expensive) squash check only runs when the two cheaper signals miss.

## Test plan
- [x] `isSquashMerged` real-git tests: (1) detects an actual squash-merge, (2) does NOT false-positive on a genuinely-unmerged branch with a unique diff, (3) fails closed on git error.
- [x] prune-loop buckets: (a) offline squash reclaim + `-D`, (b) squash-detected but ahead-of-forge → `skippedUnpushed`, (c) genuinely-unmerged lookalike → not reclaimed.
- [x] Fixed a test-isolation bug: the real-git tests now strip `GIT_*` env vars so they can't commit into the real repo when run under a git hook (pre-push exports `GIT_DIR`, which git honors over `-C`).
- [x] `bun run am-i-done` full gate green (pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)