### PR TITLE
fix(test): widen mock-session poll budgets in interrupt test (fixes #2877)

### DIFF
--- a/test/cli-orchestration.spec.ts
+++ b/test/cli-orchestration.spec.ts
@@ -542,7 +542,10 @@ describe("CLI→daemon orchestration (mock provider)", () => {
       const spawnResult = JSON.parse((spawnRes.result as { content: Array<{ text: string }> }).content[0].text);
       const sessionId: string = spawnResult.sessionId;
 
-      // Wait for the session to enter running state before interrupting
+      // Wait for the session to enter running state before interrupting.
+      // 15s budget (file watchdog is setDefaultTimeout(30_000)): the mock reaches
+      // "running" in <1s at idle, but under CI coverage contention the daemon can be
+      // starved past 5s — a too-tight poll deadline fires its own error (#2877).
       await pollUntil(async () => {
         const statusRes = await rpc(daemon.socketPath, "callTool", {
           server: "_mock",
@@ -551,7 +554,7 @@ describe("CLI→daemon orchestration (mock provider)", () => {
         });
         const status = JSON.parse((statusRes.result as { content: Array<{ text: string }> }).content[0].text);
         return status.state === "running";
-      }, 5000);
+      }, 15_000);
 
       const intRes = await rpc(daemon.socketPath, "callTool", {
         server: "_mock",
@@ -561,7 +564,9 @@ describe("CLI→daemon orchestration (mock provider)", () => {
       const intResult = JSON.parse((intRes.result as { content: Array<{ text: string }> }).content[0].text);
       expect(intResult.interrupted).toBe(true);
 
-      // Wait for script to finish (should be fast since interrupted)
+      // Wait for script to finish (should be fast since interrupted).
+      // Same 15s budget as the running-state poll above — the post-interrupt drain
+      // is subject to the same CI-contention starvation (#2877).
       await pollUntil(async () => {
         const statusRes = await rpc(daemon.socketPath, "callTool", {
           server: "_mock",
@@ -570,7 +575,7 @@ describe("CLI→daemon orchestration (mock provider)", () => {
         });
         const status = JSON.parse((statusRes.result as { content: Array<{ text: string }> }).content[0].text);
         return status.state === "idle";
-      }, 5000);
+      }, 15_000);
 
       // Transcript should NOT have all entries
       const transcriptRes = await rpc(daemon.socketPath, "callTool", {


### PR DESCRIPTION
## Summary
- `interrupt stops a running script` (`test/cli-orchestration.spec.ts`) flaked in CI at 5143.58ms.
- **The issue's root-cause analysis is disproven.** It attributes the flake to `pollUntil(..., 5000)` having zero headroom against Bun's 5s per-test watchdog. But this file sets `setDefaultTimeout(30_000)` at module scope — Bun's watchdog for this test is **30s, not 5s**. The failure was `pollUntil`'s *own* 5000ms deadline throwing (`~143ms setup + 5000ms poll = 5143.58ms`) because the mock session did not reach `running` within 5000ms under CI coverage contention.
- The issue's suggested fix (drop to the 1500ms default, or reduce to 4000) is **backwards** — a shorter budget would flake *more* often. The condition resolves in <1s at idle, so the fix is to **widen** the budget: `5000 → 15_000`, well under the 30s watchdog. Applied to both 5000ms callsites in the test (running-state wait and post-interrupt idle-drain), which share the same contention exposure.
- The `poll-until-headroom` rule correctly did **not** flag line 554: `5000 < 30000` (the file's effective watchdog), so there was no headroom violation to catch.

## Test plan
- [x] `bun test test/cli-orchestration.spec.ts -t "interrupt stops a running script"` passes (320ms at idle)
- [x] `bun run am-i-done` full gate green (typecheck, lint, rules, tests, coverage)
- [x] Discrepancy documented as an issue comment on #2877 for the record

🤖 Generated with [Claude Code](https://claude.com/claude-code)