### PR TITLE
feat(rules): agent-protocol conformance lint rules (fixes #2553)

### DIFF
--- a/docs/agent-protocol.md
+++ b/docs/agent-protocol.md
@@ -325,7 +325,26 @@ Session unexpectedly disconnected.
 { "type": "db:disconnected", "sessionId": "ses-abc123", "reason": "process exited with code 1" }
 ```
 
-### 4.5 `db:end`
+### 4.5 `db:stderr`
+
+Forward a line of the agent subprocess's stderr for diagnostic capture. Part of `BaseWorkerEvent`; buffered per-server for `mcx logs`.
+
+```typescript
+{
+  type: "db:stderr";
+  sessionId: string;
+  line: string;
+  timestamp: number;
+}
+```
+
+**Example:**
+
+```json
+{ "type": "db:stderr", "sessionId": "ses-abc123", "line": "warning: deprecated flag", "timestamp": 1720000000000 }
+```
+
+### 4.6 `db:end`
 
 Session terminated normally.
 
@@ -342,7 +361,7 @@ Session terminated normally.
 { "type": "db:end", "sessionId": "ses-abc123" }
 ```
 
-### 4.6 `metrics:inc`
+### 4.7 `metrics:inc`
 
 Increment a counter metric.
 
@@ -361,7 +380,7 @@ Increment a counter metric.
 { "type": "metrics:inc", "name": "codex_sessions_total", "labels": { "provider": "codex" } }
 ```
 
-### 4.7 `metrics:observe`
+### 4.8 `metrics:observe`
 
 Record a histogram observation.
 
@@ -380,7 +399,7 @@ Record a histogram observation.
 { "type": "metrics:observe", "name": "codex_turn_duration_seconds", "value": 12.34 }
 ```
 
-### 4.8 `monitor:event` (Claude only)
+### 4.9 `monitor:event` (Claude only)
 
 Forward a monitor event from the Claude session's WebSocket server to the daemon's event bus. Not part of `BaseWorkerEvent`; handled by `claude-server.ts` via an extended type guard.
 
@@ -644,10 +663,11 @@ Within a major version:
 | `db:state` | all | §4.2 |
 | `db:cost` | all | §4.3 |
 | `db:disconnected` | all | §4.4 |
-| `db:end` | all | §4.5 |
-| `metrics:inc` | all | §4.6 |
-| `metrics:observe` | all | §4.7 |
-| `monitor:event` | claude | §4.8 |
+| `db:stderr` | all | §4.5 |
+| `db:end` | all | §4.6 |
+| `metrics:inc` | all | §4.7 |
+| `metrics:observe` | all | §4.8 |
+| `monitor:event` | claude | §4.9 |
 
 ### Bidirectional
 

--- a/scripts/rules/agent-protocol-appendix-sync.rule.ts
+++ b/scripts/rules/agent-protocol-appendix-sync.rule.ts
@@ -1,0 +1,159 @@
+/**
+ * Rule: agent-protocol-appendix-sync
+ *
+ * Appendix A of docs/agent-protocol.md is a "Complete Message Type Reference"
+ * — a table inventory of every message type on the daemon↔worker wire. The
+ * point of a spec is defeated if that inventory silently drifts from the real
+ * wire format, which is exactly what the #2540 adversarial review found (a
+ * type present in code but missing from the spec).
+ *
+ * This rule makes the spec self-enforcing against type-set drift. It derives
+ * the authoritative type sets from source:
+ *   - worker → daemon events: BASE_WORKER_EVENT_TYPES (abstract-worker-server.ts)
+ *     plus any per-provider extension declared in a WORKER_EVENT_TYPES set
+ *     (e.g. claude-server.ts adds "monitor:event").
+ *   - daemon → worker control messages: the union of every CONTROL_MESSAGE_TYPES
+ *     set across the worker files.
+ * ...then asserts every derived type appears in the corresponding Appendix A
+ * table. The direction is code → spec: a type in code that the spec omits or
+ * misnames fails. Spec-only rows (e.g. `error`, which is a startup-window
+ * control reply and not a BaseWorkerEvent, or the bidirectional MCP row) are
+ * allowed — the rule never forces the spec to drop documentation for things
+ * outside these Set constants.
+ *
+ * docs/ is outside the file-loader scan roots, so the spec is read from disk
+ * directly (same approach as protocol-version-spec-sync).
+ *
+ * Source: #2553 item 6, from the #2540 / PR #2546 adversarial review.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import ts from "typescript";
+import type { CheckRule, RuleContext } from "./_engine/rule";
+
+const ANCHOR = "packages/daemon/src/abstract-worker-server.ts";
+const SPEC_REL_PATH = "docs/agent-protocol.md";
+
+const WORKER_TABLE_HEADING = "Worker → Daemon"; // "Worker → Daemon"
+const CONTROL_TABLE_HEADING = "Daemon → Worker"; // "Daemon → Worker"
+
+/**
+ * Collect the string-literal members of a `const <name> = new Set(...)`
+ * declaration. Spread elements (`...OTHER_SET`) contribute no literals and are
+ * ignored — callers union the referenced set separately. Returns [] if the
+ * const is absent or is not initialized from a Set.
+ */
+export function setLiteralValues(source: string, constName: string): string[] {
+  const sf = ts.createSourceFile("x.ts", source, ts.ScriptTarget.Latest, true);
+  const out: string[] = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === constName &&
+      node.initializer &&
+      ts.isNewExpression(node.initializer) &&
+      ts.isIdentifier(node.initializer.expression) &&
+      node.initializer.expression.text === "Set"
+    ) {
+      const walkLiterals = (n: ts.Node): void => {
+        if (ts.isStringLiteralLike(n)) out.push(n.text);
+        ts.forEachChild(n, walkLiterals);
+      };
+      const arg = node.initializer.arguments?.[0];
+      if (arg) walkLiterals(arg);
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return out;
+}
+
+/**
+ * Extract the type names listed in an Appendix A table. `heading` is the `### `
+ * section title (e.g. "Worker → Daemon"); rows below it look like
+ * `| \`db:upsert\` | all | §4.1 |`. The first backtick-quoted token on each
+ * table row is the type. Parsing stops at the next `#` heading.
+ */
+export function appendixTypes(specContent: string, heading: string): Set<string> {
+  const lines = specContent.split("\n");
+  const types = new Set<string>();
+  let inSection = false;
+  for (const line of lines) {
+    if (line.startsWith("#")) {
+      inSection = line.replace(/^#+\s*/, "").trim() === heading;
+      continue;
+    }
+    if (!inSection) continue;
+    if (!line.trimStart().startsWith("|")) continue;
+    const m = /`([^`]+)`/.exec(line);
+    if (m) types.add(m[1]);
+  }
+  return types;
+}
+
+function readSpec(anchorPath: string): string | undefined {
+  const repoRoot = resolve(anchorPath, "../../../..");
+  try {
+    return readFileSync(resolve(repoRoot, SPEC_REL_PATH), "utf8");
+  } catch {
+    return undefined;
+  }
+}
+
+function check(ctx: RuleContext): void {
+  if (ctx.file.relPath !== ANCHOR) return;
+  ctx.checked();
+
+  // Worker → daemon events: BASE plus any provider WORKER_EVENT_TYPES extension.
+  const workerEvents = new Set(setLiteralValues(ctx.file.content, "BASE_WORKER_EVENT_TYPES"));
+  // Daemon → worker control messages: union across every worker file.
+  const controlTypes = new Set<string>();
+  for (const f of ctx.files.values()) {
+    if (f.pkg !== "packages/daemon") continue;
+    for (const t of setLiteralValues(f.content, "WORKER_EVENT_TYPES")) workerEvents.add(t);
+    for (const t of setLiteralValues(f.content, "CONTROL_MESSAGE_TYPES")) controlTypes.add(t);
+  }
+
+  if (workerEvents.size === 0) {
+    ctx.violated(1, 1, "BASE_WORKER_EVENT_TYPES not found or empty — cannot verify Appendix A coverage");
+    return;
+  }
+
+  const spec = readSpec(ctx.file.path);
+  if (spec === undefined) {
+    ctx.violated(1, 1, `${SPEC_REL_PATH} not found on disk — cannot verify Appendix A coverage`);
+    return;
+  }
+
+  const specWorker = appendixTypes(spec, WORKER_TABLE_HEADING);
+  const specControl = appendixTypes(spec, CONTROL_TABLE_HEADING);
+
+  for (const t of [...workerEvents].sort()) {
+    if (!specWorker.has(t)) {
+      ctx.violated(1, 1, `Appendix A (Worker → Daemon) omits worker event type \`${t}\``);
+    }
+  }
+  for (const t of [...controlTypes].sort()) {
+    if (!specControl.has(t)) {
+      ctx.violated(1, 1, `Appendix A (Daemon → Worker) omits control message type \`${t}\``);
+    }
+  }
+}
+
+const rule: CheckRule = {
+  id: "agent-protocol-appendix-sync",
+  kind: "check",
+  anchors: [ANCHOR],
+  scold: "Appendix A of docs/agent-protocol.md is missing a message type that exists in code",
+  guidance: [
+    "Appendix A must list every worker→daemon event type (BASE_WORKER_EVENT_TYPES + provider WORKER_EVENT_TYPES extensions) and every daemon→worker control type (union of CONTROL_MESSAGE_TYPES).",
+    "When you add or rename a wire message type, add/rename the matching Appendix A row (and its §-referenced body section) so the spec stays a complete reference.",
+    "Direction is code → spec: spec-only rows like `error` (a startup control reply, not a BaseWorkerEvent) are allowed and not flagged.",
+  ],
+  documentation: "docs/agent-protocol.md Appendix A; #2553 item 6",
+  check,
+};
+
+export default rule;

--- a/scripts/rules/agent-protocol-appendix-sync.spec.ts
+++ b/scripts/rules/agent-protocol-appendix-sync.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+
+import type { FileMeta } from "./_engine/file-loader";
+import { loadFiles } from "./_engine/file-loader";
+import { evaluateRule, validateAnchors } from "./_engine/rule";
+import rule, { appendixTypes, setLiteralValues } from "./agent-protocol-appendix-sync.rule";
+
+const repoRoot = process.cwd();
+
+describe("setLiteralValues", () => {
+  it("extracts string members of a typed Set literal", () => {
+    const src = `const X: ReadonlySet<string> = new Set<Foo["type"]>(["a", "b", "c"]);`;
+    expect(setLiteralValues(src, "X")).toEqual(["a", "b", "c"]);
+  });
+
+  it("ignores spread elements, keeping only literals", () => {
+    const src = `const X = new Set([...BASE, "extra"]);`;
+    expect(setLiteralValues(src, "X")).toEqual(["extra"]);
+  });
+
+  it("returns [] for an absent const", () => {
+    expect(setLiteralValues(`const Y = new Set(["a"]);`, "X")).toEqual([]);
+  });
+
+  it("returns [] when the const is not a Set", () => {
+    expect(setLiteralValues(`const X = ["a", "b"];`, "X")).toEqual([]);
+  });
+});
+
+describe("appendixTypes", () => {
+  const spec = [
+    "### Worker → Daemon",
+    "",
+    "| Type | Providers | Section |",
+    "|---|---|---|",
+    "| `ready` | all | §3.1 |",
+    "| `db:end` | all | §4.6 |",
+    "",
+    "### Bidirectional",
+    "",
+    "| `should-not-appear` | x |",
+  ].join("\n");
+
+  it("collects backtick-quoted types under the given heading only", () => {
+    expect([...appendixTypes(spec, "Worker → Daemon")].sort()).toEqual(["db:end", "ready"]);
+  });
+
+  it("stops at the next heading", () => {
+    expect(appendixTypes(spec, "Worker → Daemon").has("should-not-appear")).toBe(false);
+  });
+
+  it("returns empty for an unknown heading", () => {
+    expect(appendixTypes(spec, "Nope").size).toBe(0);
+  });
+});
+
+describe("agent-protocol-appendix-sync rule", () => {
+  it("passes on the real repo — spec Appendix A covers all code types", async () => {
+    const files = await loadFiles({ repoRoot });
+    validateAnchors(rule, files);
+    const anchor = [...files.values()].find((f) => f.relPath === "packages/daemon/src/abstract-worker-server.ts");
+    if (!anchor) throw new Error("anchor file not loaded");
+    const violations = evaluateRule(rule, anchor, files);
+    expect(violations).toEqual([]);
+  });
+
+  it("flags a code worker-event type that the spec Appendix A omits", () => {
+    // Real anchor path (so the spec resolves from disk) but content with a
+    // bogus extra type the real Appendix A cannot list.
+    const anchor: FileMeta = {
+      path: `${repoRoot}/packages/daemon/src/abstract-worker-server.ts`,
+      relPath: "packages/daemon/src/abstract-worker-server.ts",
+      content: `const BASE_WORKER_EVENT_TYPES = new Set<Foo["type"]>(["ready", "bogus:type"]);`,
+      pkg: "packages/daemon",
+      isTest: false,
+    };
+    const violations = evaluateRule(rule, anchor, new Map([[anchor.path, anchor]]));
+    expect(violations).toHaveLength(1);
+    expect(violations[0].snippet).toContain("bogus:type");
+  });
+
+  it("does not run on non-anchor files", async () => {
+    const files = await loadFiles({ repoRoot });
+    const other = [...files.values()].find((f) => f.relPath === "packages/daemon/src/claude-server.ts");
+    if (!other) throw new Error("claude-server.ts not loaded");
+    expect(evaluateRule(rule, other, files)).toEqual([]);
+  });
+});

--- a/scripts/rules/agent-protocol-forward-symmetry.rule.ts
+++ b/scripts/rules/agent-protocol-forward-symmetry.rule.ts
@@ -1,0 +1,128 @@
+/**
+ * Rule: agent-protocol-forward-symmetry
+ *
+ * Every agent-session worker maps provider session events to DB events in a
+ * `forwardSessionEvent(sessionId, event)` switch. Providers that consume the
+ * same event vocabulary must mirror the same set of session:* cases — a new
+ * provider that copy-pastes the pattern but drops a case (e.g. forgets
+ * `session:disconnected`) would silently stop persisting that transition. The
+ * #2540 review flagged this partial-mirror class as review-only-catchable;
+ * this rule catches it at lint time.
+ *
+ * Symmetry is scoped by the handler's event parameter type, not a hardcoded
+ * provider list: acp/codex/opencode/mock all take `AgentSessionEvent` and form
+ * one symmetry class; claude takes `SessionEvent` (a different, WS-sourced
+ * vocabulary with cleared/rate_limited/model_changed and no permission_request)
+ * and forms its own class. Grouping by parameter type means a future provider
+ * is auto-classified by the type it declares, and claude's legitimately
+ * different vocabulary is not forced into false symmetry.
+ *
+ * Within a class of ≥2 providers, any provider missing a case that a peer
+ * handles is flagged.
+ *
+ * Source: #2553 item 7, from the #2540 / PR #2546 adversarial review.
+ */
+
+import ts from "typescript";
+import type { CheckRule, RuleContext } from "./_engine/rule";
+
+const ANCHOR = "packages/daemon/src/abstract-worker-server.ts";
+const WORKER_SUFFIX = "-session-worker.ts";
+const HANDLER = "forwardSessionEvent";
+
+export interface ForwardHandler {
+  paramType: string;
+  cases: string[];
+}
+
+/**
+ * Parse the `forwardSessionEvent` handler out of a worker source file: the
+ * declared type of its `event` parameter and the sorted set of `session:*`
+ * case labels its switch handles. Returns undefined if the file has no such
+ * handler.
+ */
+export function extractForwardHandler(source: string): ForwardHandler | undefined {
+  const sf = ts.createSourceFile("x.ts", source, ts.ScriptTarget.Latest, true);
+  let result: ForwardHandler | undefined;
+
+  const visit = (node: ts.Node): void => {
+    if (result) return;
+    if (ts.isFunctionDeclaration(node) && node.name?.text === HANDLER) {
+      const eventParam = node.parameters.find((p) => ts.isIdentifier(p.name) && p.name.text === "event");
+      const paramType = eventParam?.type ? eventParam.type.getText(sf) : "";
+      const cases = new Set<string>();
+      const collectCases = (n: ts.Node): void => {
+        if (ts.isCaseClause(n) && ts.isStringLiteralLike(n.expression) && n.expression.text.startsWith("session:")) {
+          cases.add(n.expression.text);
+        }
+        ts.forEachChild(n, collectCases);
+      };
+      if (node.body) collectCases(node.body);
+      result = { paramType, cases: [...cases].sort() };
+      return;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return result;
+}
+
+function providerName(relPath: string): string {
+  const base = relPath.slice(relPath.lastIndexOf("/") + 1);
+  return base.slice(0, -WORKER_SUFFIX.length);
+}
+
+function check(ctx: RuleContext): void {
+  if (ctx.file.relPath !== ANCHOR) return;
+  ctx.checked();
+
+  // provider → handler, keyed within a parameter-type symmetry class.
+  const classes = new Map<string, Map<string, ForwardHandler>>();
+  for (const f of ctx.files.values()) {
+    if (!f.relPath.endsWith(WORKER_SUFFIX)) continue;
+    const handler = extractForwardHandler(f.content);
+    if (!handler) continue;
+    const key = handler.paramType || "(untyped)";
+    let group = classes.get(key);
+    if (!group) {
+      group = new Map();
+      classes.set(key, group);
+    }
+    group.set(providerName(f.relPath), handler);
+  }
+
+  for (const group of classes.values()) {
+    if (group.size < 2) continue; // a lone provider has no peer to mirror
+    const union = new Set<string>();
+    for (const h of group.values()) for (const c of h.cases) union.add(c);
+
+    for (const [provider, handler] of group) {
+      const owned = new Set(handler.cases);
+      for (const c of [...union].sort()) {
+        if (owned.has(c)) continue;
+        const peers = [...group]
+          .filter(([, h]) => h.cases.includes(c))
+          .map(([p]) => p)
+          .sort()
+          .join(", ");
+        ctx.violated(1, 1, `${provider} forwardSessionEvent omits \`${c}\` handled by peer(s): ${peers}`);
+      }
+    }
+  }
+}
+
+const rule: CheckRule = {
+  id: "agent-protocol-forward-symmetry",
+  kind: "check",
+  anchors: [ANCHOR],
+  scold: "forwardSessionEvent is asymmetric across providers that share an event vocabulary",
+  guidance: [
+    "Providers whose forwardSessionEvent takes the same event parameter type must handle the same set of session:* cases — a dropped case silently stops persisting that state transition.",
+    "Add the missing case to the flagged provider, or (if the omission is intentional and correct) document why the vocabularies legitimately differ and split the type.",
+    "Symmetry is grouped by the event parameter type: claude's SessionEvent is a separate class from AgentSessionEvent and is not compared against it.",
+  ],
+  documentation: "docs/agent-protocol.md §6; #2553 item 7",
+  check,
+};
+
+export default rule;

--- a/scripts/rules/agent-protocol-forward-symmetry.spec.ts
+++ b/scripts/rules/agent-protocol-forward-symmetry.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "bun:test";
+
+import type { FileMeta } from "./_engine/file-loader";
+import { loadFiles } from "./_engine/file-loader";
+import { evaluateRule, validateAnchors } from "./_engine/rule";
+import rule, { extractForwardHandler } from "./agent-protocol-forward-symmetry.rule";
+
+const repoRoot = process.cwd();
+const ANCHOR = "packages/daemon/src/abstract-worker-server.ts";
+
+function workerFile(provider: string, cases: string[], paramType = "AgentSessionEvent"): FileMeta {
+  const relPath = `packages/daemon/src/${provider}-session-worker.ts`;
+  const body = cases.map((c) => `    case "${c}": break;`).join("\n");
+  return {
+    path: `/x/${relPath}`,
+    relPath,
+    content: `function forwardSessionEvent(sessionId: string, event: ${paramType}): void {\n  switch (event.type) {\n${body}\n  }\n}`,
+    pkg: "packages/daemon",
+    isTest: false,
+  };
+}
+
+function anchorFile(): FileMeta {
+  return {
+    path: `/x/${ANCHOR}`,
+    relPath: ANCHOR,
+    content: "export const BASE_WORKER_EVENT_TYPES = new Set([]);",
+    pkg: "packages/daemon",
+    isTest: false,
+  };
+}
+
+describe("extractForwardHandler", () => {
+  it("extracts the event param type and session:* cases", () => {
+    const src = `function forwardSessionEvent(sessionId: string, event: AgentSessionEvent): void {
+      switch (event.type) {
+        case "session:init": break;
+        case "session:ended": break;
+        case "db:noise": break;
+      }
+    }`;
+    const h = extractForwardHandler(src);
+    expect(h?.paramType).toBe("AgentSessionEvent");
+    expect(h?.cases).toEqual(["session:ended", "session:init"]);
+  });
+
+  it("returns undefined when there is no forwardSessionEvent", () => {
+    expect(extractForwardHandler("function other() {}")).toBeUndefined();
+  });
+});
+
+describe("agent-protocol-forward-symmetry rule", () => {
+  it("passes on the real repo — providers sharing a vocabulary are symmetric", async () => {
+    const files = await loadFiles({ repoRoot });
+    validateAnchors(rule, files);
+    const anchor = [...files.values()].find((f) => f.relPath === ANCHOR);
+    if (!anchor) throw new Error("anchor file not loaded");
+    expect(evaluateRule(rule, anchor, files)).toEqual([]);
+  });
+
+  it("flags a provider missing a case its peer handles", () => {
+    const anchor = anchorFile();
+    const acp = workerFile("acp", ["session:init", "session:ended", "session:disconnected"]);
+    const codex = workerFile("codex", ["session:init", "session:ended"]); // drops disconnected
+    const files = new Map([acp, codex, anchor].map((f) => [f.path, f]));
+    const violations = evaluateRule(rule, anchor, files);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].snippet).toContain("codex");
+    expect(violations[0].snippet).toContain("session:disconnected");
+    expect(violations[0].snippet).toContain("acp");
+  });
+
+  it("does not compare across different event parameter types", () => {
+    const anchor = anchorFile();
+    const acp = workerFile("acp", ["session:init", "session:permission_request"], "AgentSessionEvent");
+    const claude = workerFile("claude", ["session:init", "session:cleared"], "SessionEvent");
+    const files = new Map([acp, claude, anchor].map((f) => [f.path, f]));
+    // acp and claude are in different symmetry classes (each a class of 1) — no violation.
+    expect(evaluateRule(rule, anchor, files)).toEqual([]);
+  });
+
+  it("does not fire when a shared-vocabulary class is fully symmetric", () => {
+    const anchor = anchorFile();
+    const acp = workerFile("acp", ["session:init", "session:ended"]);
+    const codex = workerFile("codex", ["session:ended", "session:init"]); // same set, reordered
+    const files = new Map([acp, codex, anchor].map((f) => [f.path, f]));
+    expect(evaluateRule(rule, anchor, files)).toEqual([]);
+  });
+
+  it("does not run on non-anchor files", () => {
+    const acp = workerFile("acp", ["session:init"]);
+    const files = new Map([[acp.path, acp]]);
+    expect(evaluateRule(rule, acp, files)).toEqual([]);
+  });
+});

--- a/scripts/rules/fixtures/agent-protocol-appendix-sync__clean.fixture.ts
+++ b/scripts/rules/fixtures/agent-protocol-appendix-sync__clean.fixture.ts
@@ -1,0 +1,10 @@
+/**
+ * @rule agent-protocol-appendix-sync
+ * @expect 0
+ * @path packages/daemon/src/abstract-worker-server.ts
+ *
+ * All worker event types listed here are documented in Appendix A of the
+ * real docs/agent-protocol.md (read from disk) — no violation.
+ */
+
+export const BASE_WORKER_EVENT_TYPES = new Set(["ready", "db:end"]);

--- a/scripts/rules/fixtures/agent-protocol-appendix-sync__flagged.fixture.ts
+++ b/scripts/rules/fixtures/agent-protocol-appendix-sync__flagged.fixture.ts
@@ -1,0 +1,10 @@
+/**
+ * @rule agent-protocol-appendix-sync
+ * @expect 1
+ * @path packages/daemon/src/abstract-worker-server.ts
+ *
+ * `bogus:type` is a worker event type that Appendix A cannot list — the rule
+ * fires once for the undocumented type. (`ready` is documented, so it passes.)
+ */
+
+export const BASE_WORKER_EVENT_TYPES = new Set(["ready", "bogus:type"]);

--- a/scripts/rules/fixtures/agent-protocol-forward-symmetry__clean.fixture.ts
+++ b/scripts/rules/fixtures/agent-protocol-forward-symmetry__clean.fixture.ts
@@ -1,0 +1,14 @@
+/**
+ * @rule agent-protocol-forward-symmetry
+ * @expect 0
+ * @path packages/daemon/src/abstract-worker-server.ts
+ *
+ * The rule is cross-file: it runs on the anchor and compares the
+ * forwardSessionEvent handlers of the *-session-worker.ts files in the loaded
+ * set. In fixture mode only this single anchor file is present, so no provider
+ * class forms and there is no violation. The behavioral matrix (asymmetry
+ * flagged, cross-vocabulary non-comparison) is covered in the .spec.ts, which
+ * can supply a multi-file set.
+ */
+
+export const BASE_WORKER_EVENT_TYPES = new Set(["ready"]);


### PR DESCRIPTION
## Summary
Implements items 6-7 of #2553 — two `doing-it-wrong` rules that make `docs/agent-protocol.md` self-enforcing against wire-format drift (the root cause of the #2540 adversarial-review blocking findings).

- **`agent-protocol-appendix-sync`** — derives the authoritative worker→daemon event types (`BASE_WORKER_EVENT_TYPES` + any provider `WORKER_EVENT_TYPES` extension like `monitor:event`) and daemon→worker control types (union of every `CONTROL_MESSAGE_TYPES`) from source, then asserts each appears in Appendix A. Direction is code→spec, so spec-only documentation rows (`error`, the bidirectional MCP row) are allowed and not flagged.
- **`agent-protocol-forward-symmetry`** — groups `forwardSessionEvent` handlers by their `event` parameter type and flags any provider missing a `session:*` case a peer handles. acp/codex/opencode/mock share the `AgentSessionEvent` class; claude's `SessionEvent` (cleared/rate_limited/model_changed, no permission_request) is its own class and is **not** forced into false symmetry — grouping by declared type auto-classifies future providers.
- **Spec fix (required):** documents the previously-undocumented `db:stderr` worker event in Appendix A + new §4.5 (renumbering follow-on §4.x). It was in `BASE_WORKER_EVENT_TYPES` but absent from the spec — exactly the drift the appendix-sync rule catches, so the rule could not land green without it.

Doc-polish items 1-5 of the issue are **not** addressed (stretch goal, out of scope per the sprint plan).

## Test plan
- [x] `bun test` on both new specs + `fixtures.spec.ts` (136 pass) — pure-helper unit tests, real-repo integration pass (proves spec/code are in sync now), and drift-detection (bogus type → 1 violation; asymmetric peer → flagged; cross-vocabulary → not compared).
- [x] `bun run doing-it-wrong` — 40 rules, no violations (both new rules run clean on real repo).
- [x] `bun run am-i-done` — full gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)