### PR TITLE
fix(auth): interactive `mcx auth` never borrows the keychain token (follow-up to #2840)

### DIFF
--- a/packages/daemon/src/handlers/auth.spec.ts
+++ b/packages/daemon/src/handlers/auth.spec.ts
@@ -83,6 +83,51 @@ describe("AuthHandlers – triggerAuth", () => {
     expect(err).toBeInstanceOf(Error);
     expect((err as { code?: number }).code).toBe(IPC_ERROR.INTERNAL_ERROR);
   });
+
+  // Regression: the interactive `mcx auth` flow must NEVER borrow the read-only
+  // Claude Code keychain token. Borrowing it meant a revoked keychain
+  // refresh_token drove the SDK into a failed refresh (invalid_grant) whose
+  // recovery opened a SECOND browser window (and an abandoned callback timed out
+  // into a DCR-retry THIRD). The handler must always pass skipKeychainTokens:true
+  // so exactly one browser opens — independent of --force.
+  describe("always skips the keychain token in the interactive flow", () => {
+    function remotePool() {
+      return mockPool({
+        getServerUrl: () => "https://mcp.example.com/v1/mcp",
+        getDb: () => ({
+          getTokens: () => null,
+          deleteTokens: () => {},
+        }),
+        getServerConfig: () => null,
+        restart: async () => {},
+      });
+    }
+
+    for (const force of [false, true]) {
+      test(`skipKeychainTokens=true when force=${force}`, async () => {
+        let capturedOpts: { skipKeychainTokens?: boolean } | undefined;
+        const spyFlow = (async (
+          _server: string,
+          _url: string,
+          _db: unknown,
+          opts: { skipKeychainTokens?: boolean },
+        ) => {
+          capturedOpts = opts;
+          return "authenticated" as const;
+        }) as unknown as typeof import("../auth/oauth-retry").runOAuthFlowWithDcrRetry;
+
+        const map = new Map<IpcMethod, RequestHandler>();
+        const { AuthHandlers } = await import("./auth");
+        new AuthHandlers(remotePool(), spyFlow).register(map);
+
+        const result = (await invoke(map, "triggerAuth")({ server: "myserver", force }, {} as never)) as {
+          ok: boolean;
+        };
+        expect(result.ok).toBe(true);
+        expect(capturedOpts?.skipKeychainTokens).toBe(true);
+      });
+    }
+  });
 });
 
 describe("AuthHandlers – authStatus", () => {

--- a/packages/daemon/src/handlers/auth.ts
+++ b/packages/daemon/src/handlers/auth.ts
@@ -12,7 +12,11 @@ import type { RequestHandler } from "../handler-types";
 import type { ServerPool } from "../server-pool";
 
 export class AuthHandlers {
-  constructor(private pool: ServerPool) {}
+  constructor(
+    private pool: ServerPool,
+    // Injectable for tests (the repo forbids mock.module). Defaults to the real flow.
+    private runOAuthFlow: typeof runOAuthFlowWithDcrRetry = runOAuthFlowWithDcrRetry,
+  ) {}
 
   register(handlers: Map<IpcMethod, RequestHandler>): void {
     handlers.set("triggerAuth", async (params, _ctx) => {
@@ -59,24 +63,31 @@ export class AuthHandlers {
       // the SQLite row below, so the failure message names the real source.
       const store = poolDb.getTokens(server) ? "mcx (SQLite)" : "the macOS Keychain (Claude Code)";
 
-      // --force: drop the stored credential up front so a stale/revoked token is
-      // not reused, forcing a clean interactive flow without waiting for the
-      // token endpoint to reject it. Deleting the SQLite row alone is not enough:
-      // the keychain is read-only to mcx, so we also pass skipKeychainTokens to
-      // bypass the keychain fallback — otherwise a keychain-stored token (the
-      // #2840 scenario) would still be served and --force would be a no-op.
+      // --force: also drop mcx's own SQLite token up front, so a stale/revoked
+      // mcx-owned token is not silently refreshed — forcing a clean browser flow
+      // instead of the already_authorized fast path.
       if (force) {
         new McpOAuthProvider(server, serverUrl, poolDb).invalidateCredentials("tokens");
       }
 
       let flowResult: Awaited<ReturnType<typeof runOAuthFlowWithDcrRetry>>;
       try {
-        flowResult = await runOAuthFlowWithDcrRetry(server, serverUrl, poolDb, {
+        flowResult = await this.runOAuthFlow(server, serverUrl, poolDb, {
           clientId,
           clientSecret,
           callbackPort,
           scope,
-          skipKeychainTokens: force,
+          // The interactive `mcx auth` flow always mints a fresh mcx-owned token
+          // and NEVER borrows the read-only Claude Code keychain token. Borrowing
+          // it here was the bug (#2840 follow-up): a revoked keychain refresh_token
+          // makes the SDK attempt a refresh that fails invalid_grant, and the
+          // recovery path then opens a SECOND browser window (and the abandoned
+          // callback times out into a DCR-retry THIRD window). Skipping the
+          // keychain collapses this to exactly one browser. The passive connect
+          // path still adopts a valid keychain token silently — only the explicit
+          // interactive mint opts out. `--force` no longer gates this; it only
+          // controls whether the mcx-owned SQLite token above is dropped first.
+          skipKeychainTokens: true,
         });
       } catch (err) {
         // Name the server + credential store + recovery path. The bare SDK


### PR DESCRIPTION
## Symptom

`mcx auth <oauth-server>` (without `--force`) opens **two or three browser windows**. Completing the first one fails with:

```
Authentication for "<server>" failed: Invalid PKCE code_verifier
```

Re-running just reproduces it — every attempt spawns competing flows.

## Root cause

The interactive auth flow borrowed Claude Code's **read-only keychain token** — `skipKeychainTokens` was gated on `--force` (`handlers/auth.ts`):

```ts
skipKeychainTokens: force,   // false for plain `mcx auth`
```

When the borrowed keychain token carries a **revoked** `refresh_token`, the sequence is:

1. Flow opens **browser A** (PKCE verifier `V_A`).
2. In parallel the SDK tries to refresh the borrowed token → `invalid_grant`.
3. The #2840 / #2869 recovery path (`clearing stored tokens and retrying via browser…`) opens **browser B** with a new verifier `V_B`.
4. The abandoned callback for A times out after 120s → DCR-retry opens **browser C**.

Because the PKCE verifier is persisted keyed by `server_name` (one row in `oauth_verifiers`), each new flow's `INSERT OR REPLACE` **overwrites** the previous verifier. The user completes browser A, but the daemon exchanges A's authorization code against `V_B`/`V_C` → **`Invalid PKCE code_verifier`**.

`--force` already worked, because it set `skipKeychainTokens: true`. Only the plain path was broken — and that's the common path.

This is a follow-up to #2840 (fixed in #2869): the interactive-re-auth fallback works, but it fires *on top of* an already-open browser instead of *instead of* one.

## Fix

The interactive `mcx auth` flow now **always** mints a fresh mcx-owned token and never borrows the keychain token:

```ts
skipKeychainTokens: true,   // unconditional
```

- Exactly **one** browser window opens (or a silent refresh of mcx's *own* SQLite token → `already_authorized`, no browser).
- The **passive connect path is unchanged** — it still adopts a valid keychain token silently (no browser), which is the intended keychain-reuse behavior.
- `--force` no longer gates keychain-skipping; it now only controls whether mcx's own SQLite token is dropped up front (skipping the silent-refresh fast path).

A revoked keychain token is simply ignored → straight to one browser, which is the #2840 outcome, minus the extra windows.

## Tests

- `AuthHandlers` gains an injectable flow fn (DI — the repo forbids `mock.module`).
- New regression tests assert `skipKeychainTokens === true` is passed for **both** `force=false` and `force=true`.
- `bun run am-i-done` green (the `SIGTERM` worker crashes seen under heavy local parallelism do not reproduce on a quiet run or in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)