### PR TITLE
feat(tls): defense-in-depth validation for cached cert/key material (fixes #1831)

### DIFF
--- a/packages/daemon/src/claude-session/ws-server-tls.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server-tls.spec.ts
@@ -97,6 +97,33 @@ describe("ClaudeWsServer (TLS mode, #1808)", () => {
     expect(env.NODE_TLS_REJECT_UNAUTHORIZED).toBe("0");
   });
 
+  test("sdk-url follows an overridden hostname instead of the hardcoded default", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger, hostname: "127.0.0.1" });
+    const port = await server.start();
+    server.prepareSession("host-session", { prompt: "hi" });
+    server.spawnClaude("host-session");
+    expect(ms.lastCmd).toContain(`ws://127.0.0.1:${port}/session/host-session`);
+  });
+
+  test("sdk-url brackets an IPv6 hostname override", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger, hostname: "::1" });
+    const port = await server.start();
+    server.prepareSession("v6-session", { prompt: "hi" });
+    server.spawnClaude("v6-session");
+    expect(ms.lastCmd).toContain(`ws://[::1]:${port}/session/v6-session`);
+  });
+
+  test("sdk-url maps wildcard binds to the matching loopback address", async () => {
+    const ms = mockSpawn();
+    server = new ClaudeWsServer({ spawn: ms.spawn, logger: silentLogger, hostname: "0.0.0.0" });
+    const port = await server.start();
+    server.prepareSession("wild-session", { prompt: "hi" });
+    server.spawnClaude("wild-session");
+    expect(ms.lastCmd).toContain(`ws://127.0.0.1:${port}/session/wild-session`);
+  });
+
   test("TLS mode binds on [::1] and accepts a wss:// upgrade", async () => {
     const dir = mkdtempSync(join(tmpdir(), "ws-tls-"));
     const { cert, key } = ensureSelfSignedCert({ dir, validityDays: 7 });

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -595,6 +595,19 @@ export class ClaudeWsServer {
     return this.tlsConfig !== null;
   }
 
+  /**
+   * Host portion of the `--sdk-url` handed to claude, derived from the actual
+   * bind hostname so an overridden `hostname` can't diverge from the URL.
+   * IPv6 literals are bracketed; wildcard binds map to the matching loopback
+   * address because a wildcard is not a connectable target.
+   */
+  private get sdkUrlHost(): string {
+    const host = this.hostname ?? "localhost";
+    if (host === "0.0.0.0") return "127.0.0.1";
+    if (host === "::") return "[::1]";
+    return host.includes(":") ? `[${host}]` : host;
+  }
+
   /** Current event sequence number (monotonically increasing). */
   get currentSeq(): number {
     return this.eventSeq;
@@ -1178,9 +1191,8 @@ export class ClaudeWsServer {
     if (!useStdio) {
       const port = this.port;
       if (!port) throw new Error("WS server not started");
-      const sdkUrl = this.tlsConfig
-        ? `wss://[::1]:${port}/session/${sessionId}`
-        : `ws://localhost:${port}/session/${sessionId}`;
+      const scheme = this.tlsConfig ? "wss" : "ws";
+      const sdkUrl = `${scheme}://${this.sdkUrlHost}:${port}/session/${sessionId}`;
       cmd.push("--sdk-url", sdkUrl);
       // WS transport needs an empty prompt placeholder; the real prompt
       // is delivered via the first WS message in handleOpen.

--- a/packages/daemon/src/tls/self-signed.spec.ts
+++ b/packages/daemon/src/tls/self-signed.spec.ts
@@ -3,7 +3,15 @@ import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { certPaths, ensureSelfSignedCert, generateSelfSignedCert, isCertFresh, readCachedCert } from "./self-signed";
+import {
+  certPaths,
+  ensureSelfSignedCert,
+  generateSelfSignedCert,
+  isCertFresh,
+  isCertParseable,
+  isKeyParseable,
+  readCachedCert,
+} from "./self-signed";
 
 const POLL_MS = 20;
 
@@ -77,6 +85,35 @@ describe("isCertFresh", () => {
   });
 });
 
+describe("isCertParseable / isKeyParseable", () => {
+  test("both true for freshly generated material", () => {
+    const dir = freshDir();
+    const { certPath, keyPath } = generateSelfSignedCert(dir, { commonName: "localhost", validityDays: 30 });
+    expect(isCertParseable(certPath)).toBe(true);
+    expect(isKeyParseable(keyPath)).toBe(true);
+  });
+
+  test("false for missing files", () => {
+    expect(isCertParseable("/nonexistent/cert.pem")).toBe(false);
+    expect(isKeyParseable("/nonexistent/key.pem")).toBe(false);
+  });
+
+  test("false for garbage contents", () => {
+    const dir = freshDir();
+    const { certPath, keyPath } = certPaths(dir);
+    writeFileSync(certPath, "not a cert", { mode: 0o644 });
+    writeFileSync(keyPath, "not a key", { mode: 0o600 });
+    expect(isCertParseable(certPath)).toBe(false);
+    expect(isKeyParseable(keyPath)).toBe(false);
+  });
+
+  test("cert is not accepted as a private key", () => {
+    const dir = freshDir();
+    const { certPath } = generateSelfSignedCert(dir, { commonName: "localhost", validityDays: 30 });
+    expect(isKeyParseable(certPath)).toBe(false);
+  });
+});
+
 describe("ensureSelfSignedCert", () => {
   test("generates on first call when dir is empty", () => {
     const dir = freshDir();
@@ -122,6 +159,16 @@ describe("ensureSelfSignedCert", () => {
     expect(m.cert).toContain("-----BEGIN CERTIFICATE-----");
   });
 
+  test("regenerates when the cached key is corrupted but the cert is valid", () => {
+    const dir = freshDir();
+    const first = ensureSelfSignedCert({ dir, validityDays: 30 });
+    writeFileSync(first.keyPath, "corrupted", { mode: 0o600 });
+    const second = ensureSelfSignedCert({ dir, validityDays: 30 });
+    expect(second.key).toMatch(/-----BEGIN (RSA )?PRIVATE KEY-----/);
+    expect(second.cert).not.toBe(first.cert);
+    expect(isKeyParseable(second.keyPath)).toBe(true);
+  });
+
   test("rejects renewWithinSeconds <= 0", () => {
     const dir = freshDir();
     expect(() => ensureSelfSignedCert({ dir, renewWithinSeconds: 0 })).toThrow();
@@ -140,6 +187,22 @@ describe("readCachedCert", () => {
     const { certPath } = certPaths(dir);
     mkdirSync(dir, { recursive: true });
     writeFileSync(certPath, "stub", { mode: 0o644 });
+    expect(readCachedCert(dir)).toBeNull();
+  });
+
+  test("returns null when the cached cert is unparseable", () => {
+    const dir = freshDir();
+    const { certPath, keyPath } = certPaths(dir);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(certPath, "garbage", { mode: 0o644 });
+    writeFileSync(keyPath, "garbage", { mode: 0o600 });
+    expect(readCachedCert(dir)).toBeNull();
+  });
+
+  test("returns null when the cached key is unparseable", () => {
+    const dir = freshDir();
+    const generated = ensureSelfSignedCert({ dir, validityDays: 30 });
+    writeFileSync(generated.keyPath, "garbage", { mode: 0o600 });
     expect(readCachedCert(dir)).toBeNull();
   });
 

--- a/packages/daemon/src/tls/self-signed.ts
+++ b/packages/daemon/src/tls/self-signed.ts
@@ -91,6 +91,26 @@ export function isCertFresh(certPath: string, renewWithinSeconds: number): boole
   return r.status === 0;
 }
 
+/** True when `openssl x509` can parse the file at `certPath`. */
+export function isCertParseable(certPath: string): boolean {
+  if (!existsSync(certPath)) return false;
+  const r = spawnSync("openssl", ["x509", "-noout", "-in", certPath], {
+    encoding: "utf-8",
+    timeout: OPENSSL_PROBE_TIMEOUT_MS,
+  });
+  return r.status === 0;
+}
+
+/** True when `openssl pkey` can parse the private key at `keyPath`. */
+export function isKeyParseable(keyPath: string): boolean {
+  if (!existsSync(keyPath)) return false;
+  const r = spawnSync("openssl", ["pkey", "-noout", "-in", keyPath], {
+    encoding: "utf-8",
+    timeout: OPENSSL_PROBE_TIMEOUT_MS,
+  });
+  return r.status === 0;
+}
+
 /**
  * Generate a fresh self-signed cert + key into `dir`. Overwrites existing
  * files. Returns the on-disk PEM contents alongside their paths.
@@ -162,7 +182,9 @@ export function ensureSelfSignedCert(opts: EnsureOptions = {}): SelfSignedMateri
   mkdirSync(dir, { recursive: true });
   const { certPath, keyPath } = certPaths(dir);
 
-  if (!opts.force && existsSync(keyPath) && isCertFresh(certPath, renewWithinSeconds)) {
+  // A corrupted key next to a valid cert would otherwise be handed to
+  // Bun.serve as unusable TLS material, so the key is parse-checked too.
+  if (!opts.force && isKeyParseable(keyPath) && isCertFresh(certPath, renewWithinSeconds)) {
     return {
       cert: readFileSync(certPath, "utf-8"),
       key: readFileSync(keyPath, "utf-8"),
@@ -184,6 +206,7 @@ export function readCachedCert(dir?: string): SelfSignedMaterial | null {
   const resolved = dir ?? options.TLS_DIR;
   const { certPath, keyPath } = certPaths(resolved);
   if (!existsSync(certPath) || !existsSync(keyPath)) return null;
+  if (!isCertParseable(certPath) || !isKeyParseable(keyPath)) return null;
   try {
     return {
       cert: readFileSync(certPath, "utf-8"),


### PR DESCRIPTION
## Summary
- `readCachedCert()` now openssl-parses both PEMs (`x509 -noout` / `pkey -noout`) before returning, honoring its documented "returns null when missing or unparseable" contract instead of handing back garbage file contents.
- `ensureSelfSignedCert()` parse-checks the cached private key in its reuse decision, so a corrupted `key.pem` next to a valid `cert.pem` triggers regeneration rather than unusable TLS material reaching `Bun.serve`.
- `--sdk-url` host is derived from the server's actual bind hostname (IPv6 bracketed, wildcard binds mapped to the matching loopback) instead of hardcoding `[::1]`/`localhost`, closing the divergence the `hostname` constructor option allowed.

New exported predicates `isCertParseable` / `isKeyParseable` back the checks above.

## Test plan
- [x] `self-signed.spec.ts`: parseability predicates (valid material, missing files, garbage, cert-rejected-as-key); `ensureSelfSignedCert` regenerates on corrupted cached key; `readCachedCert` returns null for unparseable cert and for unparseable key.
- [x] `ws-server-tls.spec.ts`: sdk-url follows an overridden hostname, brackets an IPv6 override, and maps `0.0.0.0` to `127.0.0.1`. Existing default-path assertions (`ws://localhost`, `wss://[::1]`) unchanged and still pass.
- [x] `bun run am-i-done` — all 11 steps pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)