### PR TITLE
fix(core): pass model tier names through verbatim, delete resolveModelName (fixes #2659)

### DIFF
--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -27,7 +27,6 @@ import {
   parseSpawnArgs,
   parseWaitArgs,
   parseWorktreeList,
-  resolveModelName,
   resolveSessionId,
   resolveWorktree,
 } from "./claude";
@@ -277,14 +276,14 @@ describe("parseSpawnArgs", () => {
     expect(result.wait).toBe(false);
   });
 
-  test("parses --model with shortname", () => {
+  test("passes tier shortname through verbatim — no local ID resolution (#2659)", () => {
     const result = parseSpawnArgs(["--model", "sonnet", "--task", "x"]);
-    expect(result.model).toBe("claude-sonnet-4-6");
+    expect(result.model).toBe("sonnet");
   });
 
-  test("parses -m shorthand", () => {
+  test("parses -m shorthand verbatim", () => {
     const result = parseSpawnArgs(["-m", "haiku", "-t", "x"]);
-    expect(result.model).toBe("claude-haiku-4-5");
+    expect(result.model).toBe("haiku");
   });
 
   test("passes through full model ID", () => {
@@ -361,33 +360,17 @@ describe("parseSpawnArgs", () => {
   });
 });
 
-// ── resolveModelName ──
+// ── MODEL_SHORTNAMES ──
 
-describe("resolveModelName", () => {
-  test("resolves opus shortname", () => {
-    expect(resolveModelName("opus")).toBe("claude-opus-4-8");
+describe("MODEL_SHORTNAMES", () => {
+  test("is a shortname vocabulary, not a map to concrete model IDs (#2659)", () => {
+    expect([...MODEL_SHORTNAMES].sort()).toEqual(["fable", "haiku", "opus", "sonnet"]);
   });
 
-  test("resolves sonnet shortname", () => {
-    expect(resolveModelName("sonnet")).toBe("claude-sonnet-4-6");
-  });
-
-  test("resolves haiku shortname", () => {
-    expect(resolveModelName("haiku")).toBe("claude-haiku-4-5");
-  });
-
-  test("resolves fable shortname", () => {
-    expect(resolveModelName("fable")).toBe("claude-fable-5");
-  });
-
-  test("is case-insensitive", () => {
-    expect(resolveModelName("Opus")).toBe("claude-opus-4-8");
-    expect(resolveModelName("SONNET")).toBe("claude-sonnet-4-6");
-  });
-
-  test("passes through unknown model IDs", () => {
-    expect(resolveModelName("claude-opus-4-8")).toBe("claude-opus-4-8");
-    expect(resolveModelName("some-custom-model")).toBe("some-custom-model");
+  test("every --model value reaches the CLI unresolved", () => {
+    for (const tier of MODEL_SHORTNAMES) {
+      expect(parseSpawnArgs(["--model", tier, "--task", "x"]).model).toBe(tier);
+    }
   });
 });
 
@@ -873,7 +856,7 @@ describe("mcx claude spawn", () => {
       await cmdClaude(["spawn", "--task", "fix", "--model", "sonnet"], deps);
       expect(callTool).toHaveBeenCalledWith("claude_prompt", {
         prompt: "fix",
-        model: "claude-sonnet-4-6",
+        model: "sonnet",
         cwd: process.cwd(),
       });
     } finally {
@@ -1142,7 +1125,7 @@ describe("buildHeadedCommand", () => {
 
   test("includes model flag", () => {
     const result = buildHeadedCommand(parseSpawnArgs(["--task", "x", "--model", "sonnet"]));
-    expect(result).toBe("claude -p x --model claude-sonnet-4-6");
+    expect(result).toBe("claude -p x --model sonnet");
   });
 
   test("includes resolved allowedTools (additive with defaults)", () => {

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -26,7 +26,6 @@ import {
   parseWorktreeList,
   readWorktreeConfig,
   resolveEffectiveTools,
-  resolveModelName,
   resolveWorktreePath,
   spawnCaptureSync,
   updatePatchedClaude,
@@ -275,7 +274,7 @@ async function cmdClaudeInternal(args: string[], deps?: Partial<ClaudeDeps>): Pr
 // ── Subcommands ──
 
 // Re-export for tests
-export { MODEL_SHORTNAMES, resolveModelName } from "@mcp-cli/core";
+export { MODEL_SHORTNAMES } from "@mcp-cli/core";
 
 export interface SpawnArgs extends SharedSpawnArgs {
   worktree: string | undefined;
@@ -681,7 +680,7 @@ export function parseResumeArgs(args: string[]): ResumeArgs {
       if (!val) {
         modelError = "--model requires a value";
       } else {
-        model = resolveModelName(val);
+        model = val; // verbatim — the claude CLI resolves tier aliases (#2659)
       }
     } else {
       remaining.push(arg);

--- a/packages/command/src/commands/memory.ts
+++ b/packages/command/src/commands/memory.ts
@@ -18,7 +18,6 @@ import {
   isLookupFailure,
   lookupFailure,
   resolveGitRootOrCwd,
-  resolveModelName,
   resolveSourceClaudePath,
   spawnCaptureSync,
 } from "@mcp-cli/core";
@@ -75,7 +74,8 @@ export interface MemoryDeps {
   exit: (code: number) => never;
 }
 
-const HAIKU_MODEL = resolveModelName("haiku");
+/** Tier alias passed verbatim to `claude --model`; the CLI resolves it (#2659). */
+const HAIKU_MODEL = "haiku";
 
 /** Upper bound on the Haiku audit call. A hung `claude --print` must fail loud, not hang forever (#2884). */
 const HAIKU_TIMEOUT_MS = 120_000;

--- a/packages/command/src/commands/spawn-args.ts
+++ b/packages/command/src/commands/spawn-args.ts
@@ -6,7 +6,7 @@
  */
 
 import { resolve } from "node:path";
-import { looksLikeToolName, resolveModelName, validateAllowPatterns } from "@mcp-cli/core";
+import { looksLikeToolName, validateAllowPatterns } from "@mcp-cli/core";
 import { parseFlags } from "../flags";
 
 export { looksLikeToolName } from "@mcp-cli/core";
@@ -109,7 +109,7 @@ export function parseSharedSpawnArgs(
     if (Number.isNaN(timeout)) error ??= "--timeout must be a number";
   }
 
-  // Model: custom validation (startsWith("-") check + null/none/undefined guard)
+  // Model: passed through verbatim — the claude CLI resolves tier aliases (#2659)
   let model: string | undefined;
   if (flags.model !== undefined) {
     const val = flags.model as string;
@@ -118,7 +118,7 @@ export function parseSharedSpawnArgs(
     } else if (val.toLowerCase() === "null" || val.toLowerCase() === "none" || val.toLowerCase() === "undefined") {
       error ??= `--model "${val}" is not a valid model name (use: fable, opus, sonnet, haiku, or a full model ID)`;
     } else {
-      model = resolveModelName(val);
+      model = val;
     }
   }
 

--- a/packages/command/src/flags-compat.spec.ts
+++ b/packages/command/src/flags-compat.spec.ts
@@ -206,7 +206,7 @@ describe("flags-compat: parseResumeArgs --model (no flag-as-value check)", () =>
   it("accepts any non-empty value including flag-looking strings (current bug)", () => {
     // claude.ts parseResumeArgs: `if (!val)` — only checks emptiness, not startsWith("-")
     // When --model is followed by another flag like --wait, val = "--wait" which is truthy
-    // so it gets passed to resolveModelName. But ++i already consumed it.
+    // so it is stored as the model value. But ++i already consumed it.
     const r = parseResumeArgs(["wt", "--model", "sonnet"]);
     expect(r.model).toContain("sonnet");
     expect(r.error).toBeUndefined();
@@ -278,8 +278,7 @@ describe("flags-compat: parseAgentResumeArgs --model", () => {
     expect(r.error).toBe("--model requires a value");
   });
 
-  it("accepts a valid model string without resolveModelName (passes raw)", () => {
-    // agent.ts parseAgentResumeArgs does NOT call resolveModelName — stores raw
+  it("accepts a valid model string and stores it raw", () => {
     const r = parseAgentResumeArgs(["wt", "--model", "opus"]);
     expect(r.model).toBe("opus");
   });
@@ -327,14 +326,12 @@ describe("flags-compat: behavioral divergences between parsers", () => {
     expect(sharedResult.allow).toEqual(["Read"]);
   });
 
-  it("--model resolution: claude.ts calls resolveModelName, agent.ts passes raw", () => {
+  it("--model: both claude.ts and agent.ts store the raw value (#2659)", () => {
     const claudeResult = parseResumeArgs(["wt", "--model", "sonnet"]);
     const agentResult = parseAgentResumeArgs(["wt", "--model", "sonnet"]);
 
-    // claude.ts resolves shortname to full model ID
-    expect(claudeResult.model).toContain("sonnet");
-    expect(claudeResult.model?.length).toBeGreaterThan("sonnet".length);
-    // agent.ts stores raw value
+    // No local shortname→ID resolution on either path; the provider resolves the tier
+    expect(claudeResult.model).toBe("sonnet");
     expect(agentResult.model).toBe("sonnet");
   });
 
@@ -350,7 +347,6 @@ describe("flags-compat: behavioral divergences between parsers", () => {
     // But since ++i consumed "--wait", the --wait boolean is NOT set
     const claudeResult = parseResumeArgs(["wt", "--model", "--wait"]);
     // "--wait" is truthy, so no error — it's accepted as a model name
-    // resolveModelName("--wait") likely returns "--wait" as-is (unknown pass-through)
     expect(claudeResult.error).toBeUndefined();
     expect(claudeResult.wait).toBe(false); // --wait was consumed as model value
   });

--- a/packages/core/src/model.ts
+++ b/packages/core/src/model.ts
@@ -1,12 +1,11 @@
-/** Map short model names to full model IDs. */
-export const MODEL_SHORTNAMES: Record<string, string> = {
-  fable: "claude-fable-5",
-  opus: "claude-opus-4-8",
-  sonnet: "claude-sonnet-4-6",
-  haiku: "claude-haiku-4-5",
-};
-
-/** Resolve a model name: accept shortnames or pass through full IDs. */
-export function resolveModelName(input: string): string {
-  return MODEL_SHORTNAMES[input.toLowerCase()] ?? input;
-}
+/**
+ * Model tier shortnames, used only as a vocabulary for recognizing the sprint
+ * plan's Model column.
+ *
+ * mcx deliberately does NOT map these to concrete model IDs. The `claude` CLI
+ * resolves tier aliases itself — latest-in-tier on the Anthropic API, and via
+ * `ANTHROPIC_DEFAULT_{OPUS,SONNET,FABLE,HAIKU}_MODEL` on Bedrock. A local ID map
+ * went stale on every model release (silently downgrading `--model sonnet`) and
+ * broke Bedrock by pre-resolving past the tier-alias envs (#2659).
+ */
+export const MODEL_SHORTNAMES: ReadonlySet<string> = new Set(["fable", "opus", "sonnet", "haiku"]);

--- a/packages/core/src/sprint-plan.ts
+++ b/packages/core/src/sprint-plan.ts
@@ -20,7 +20,7 @@ import { MODEL_SHORTNAMES } from "./model";
  * forwarding a bad `--model` value.
  */
 function isRecognizedModel(value: string): boolean {
-  if (value in MODEL_SHORTNAMES) return true;
+  if (MODEL_SHORTNAMES.has(value)) return true;
   return /^claude-[a-z0-9.-]+$/.test(value);
 }
 

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -22,7 +22,6 @@ import {
   type SessionInfo,
   type WorkItemEvent,
   resolveEffectiveTools,
-  resolveModelName,
   silentLogger,
   startSpan,
 } from "@mcp-cli/core";
@@ -255,7 +254,7 @@ export async function handlePrompt(
         permissionRules: rules,
         allowedTools: effectiveTools,
         worktree: args.worktree as string | undefined,
-        model: args.model ? resolveModelName(args.model as string) : undefined,
+        model: (args.model as string | undefined) || undefined,
         resumeSessionId: args.resumeSessionId as string | undefined,
         repoRoot: args.repoRoot as string | undefined,
         transport: transportOverride,


### PR DESCRIPTION
## Summary

- **Deletes** `resolveModelName` and the `MODEL_SHORTNAMES` shortname→ID map. Per the issue's reopen comment and the sprint-77 scoping note, the fix is structural removal, not another value refresh — a hardcoded ID map goes stale on every model release (it had already decayed twice: `opus`→`4-6`, then `sonnet`→`4-6`).
- `--model` values now reach `claude --model` **verbatim** at all four resolution sites (`spawn-args.ts`, `claude.ts`, `claude-session-worker.ts`, `memory.ts`). Verified empirically that the `claude` CLI resolves tier aliases itself: `--model <model> … Provide an alias for the latest model (e.g. 'fable', 'opus', or 'sonnet')`. This also un-breaks Bedrock, where a bare `claude-opus-4-8` is not an inference profile and pre-resolution bypassed `ANTHROPIC_DEFAULT_*_MODEL` (unblocks #935).
- `MODEL_SHORTNAMES` survives only as a `ReadonlySet` vocabulary for `sprint-plan.ts`'s Model-column recognition, which already returned values verbatim.
- Full model IDs still pass through unchanged — deliberate pins keep working.

## Test plan

- [x] Specs assert the **absence** of local resolution, not a new ID constant: `parseSpawnArgs(["--model","sonnet"]).model === "sonnet"`, plus a loop asserting every tier in `MODEL_SHORTNAMES` survives unresolved.
- [x] Replaced the `resolveModelName` describe block with a `MODEL_SHORTNAMES` vocabulary test.
- [x] `flags-compat.spec.ts`: the claude.ts-vs-agent.ts resolution divergence is gone — both now store raw.
- [x] Updated `buildHeadedCommand` + `claude_prompt` callTool assertions to expect the tier name.
- [x] `bun run am-i-done` green (94.5s, full mode). An earlier mass-SIGTERM run was host CPU starvation (load avg 19 from concurrent sprint workers), not a code failure.

## Note for the orchestrator

`.claude/memory/project_bedrock_spawns_935.md:14` still documents the removed `resolveModelName` Bedrock caveat. Memory files are orchestrator/retro-owned, so this PR does not touch it — it needs a retro-time update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)