### PR TITLE
feat(sites): catalog-driven retryOn for session-header staleness

### DIFF
--- a/packages/daemon/src/site-worker.ts
+++ b/packages/daemon/src/site-worker.ts
@@ -274,6 +274,7 @@ async function handleCall(args: Record<string, unknown>): Promise<ToolResult> {
           site: site.name,
           resolved,
           audHints: call.audHints,
+          retryOn: call.retryOn,
           onWiggle: browserSnapshot
             ? async () => {
                 const current = await snapshotBrowser();
@@ -302,6 +303,7 @@ async function handleCall(args: Record<string, unknown>): Promise<ToolResult> {
         site: site.name,
         resolved,
         audHints: call.audHints,
+        retryOn: call.retryOn,
         onWiggle: browserSnapshot
           ? async () => {
               const current = await snapshotBrowser();

--- a/packages/daemon/src/site/catalog.ts
+++ b/packages/daemon/src/site/catalog.ts
@@ -14,6 +14,16 @@ import { BUILTIN_SEEDS } from "./seeds";
 
 export type AuthMode = "bearer" | "cookie" | "auto";
 
+/**
+ * Extra response signals that mean "credentials are stale, wiggle and retry".
+ * When both fields are set, both must match — APIs that 500 for unrelated
+ * reasons shouldn't trigger a pointless refetch.
+ */
+export interface RetryOn {
+  status?: number[];
+  responseHeaderPresent?: string;
+}
+
 export interface NamedCall {
   name: string;
   url: string;
@@ -42,6 +52,12 @@ export interface NamedCall {
    * first and falls back to cookie when the vault has no credentials.
    */
   authMode?: AuthMode;
+  /**
+   * Response signals beyond 401 that should trigger wiggle + retry. Unset means
+   * 401-only. Used by APIs that validate session-scoped headers and answer with
+   * a 5xx instead of 401 (e.g. OWA's OwaSerializationException).
+   */
+  retryOn?: RetryOn;
 }
 
 export type Catalog = Record<string, NamedCall>;

--- a/packages/daemon/src/site/proxy.spec.ts
+++ b/packages/daemon/src/site/proxy.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { BrowserEngine, CapturedRequest, CookieEntry } from "./browser/engine";
 import { CredentialVault } from "./credentials";
-import { cookieProxyCall, proxyCall } from "./proxy";
+import { cookieProxyCall, proxyCall, retryReason } from "./proxy";
 import type { ResolvedCall } from "./resolver";
 
 function makeJwt(claims: Record<string, unknown>): string {
@@ -22,6 +22,34 @@ beforeEach(() => {
 
 afterEach(() => {
   globalThis.fetch = originalFetch;
+});
+
+describe("retryReason", () => {
+  test("401 is always a bearer retry, with or without retryOn", () => {
+    expect(retryReason(401, {})).toBe("bearer");
+    expect(retryReason(401, {}, { status: [500] })).toBe("bearer");
+  });
+
+  test("no retryOn means no retry beyond 401", () => {
+    expect(retryReason(500, { "x-owa-error": "1" })).toBeNull();
+    expect(retryReason(200, {})).toBeNull();
+  });
+
+  test("status + responseHeaderPresent must both match", () => {
+    const on = { status: [500], responseHeaderPresent: "x-owa-error" };
+    expect(retryReason(500, { "X-OWA-Error": "1" }, on)).toBe("session");
+    expect(retryReason(500, {}, on)).toBeNull();
+    expect(retryReason(503, { "x-owa-error": "1" }, on)).toBeNull();
+  });
+
+  test("either field alone is sufficient when it is the only one declared", () => {
+    expect(retryReason(500, {}, { status: [500] })).toBe("session");
+    expect(retryReason(418, { "x-stale": "1" }, { responseHeaderPresent: "x-stale" })).toBe("session");
+  });
+
+  test("empty retryOn never triggers a retry", () => {
+    expect(retryReason(500, { anything: "1" }, {})).toBeNull();
+  });
 });
 
 describe("proxyCall", () => {
@@ -136,6 +164,106 @@ describe("proxyCall", () => {
     expect(result.status).toBe(200);
     expect(result.usedAud).toBe("https://other.example/");
     expect(call).toBe(2);
+  });
+
+  test("retryOn 500 wiggles and retries with the same bearer once session headers are refreshed", async () => {
+    const vault = new CredentialVault();
+    const token = makeJwt({ aud: "https://owa.example/", iat: 100 });
+    // Captured from a non-service.svc request: no session headers, so the first call 500s.
+    vault.noteRequest("demo", authReq("https://owa.example/owa/", token));
+
+    let call = 0;
+    const sentSessionIds: (string | undefined)[] = [];
+    globalThis.fetch = mock(async (_url: RequestInfo | URL, init?: RequestInit) => {
+      call += 1;
+      sentSessionIds.push((init?.headers as Record<string, string>)["x-owa-sessionid"]);
+      if (call === 1) {
+        return new Response("OwaSerializationException", { status: 500, headers: { "x-owa-error": "1" } });
+      }
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as unknown as typeof fetch;
+
+    const onWiggle = async (): Promise<void> => {
+      // Same bearer, but now observed on a service.svc POST carrying session headers.
+      vault.noteRequest("demo", {
+        url: "https://owa.example/owa/service.svc",
+        method: "POST",
+        resourceType: "xhr",
+        headers: { authorization: `Bearer ${token}`, "x-owa-sessionid": "sess-1" },
+        postData: null,
+      });
+    };
+
+    const resolved: ResolvedCall = {
+      url: "https://owa.example/owa/service.svc",
+      method: "POST",
+      headers: {},
+      consumedParams: [],
+      residualParams: [],
+    };
+
+    const result = await proxyCall(vault, {
+      site: "demo",
+      resolved,
+      onWiggle,
+      retryOn: { status: [500], responseHeaderPresent: "x-owa-error" },
+    });
+
+    expect(call).toBe(2);
+    expect(result.status).toBe(200);
+    expect(sentSessionIds).toEqual([undefined, "sess-1"]);
+  });
+
+  test("500 is not retried when the call declares no retryOn", async () => {
+    const vault = new CredentialVault();
+    vault.noteRequest("demo", authReq("https://a.example/v1", makeJwt({ aud: "https://a.example/", iat: 100 })));
+
+    let call = 0;
+    globalThis.fetch = mock(async () => {
+      call += 1;
+      return new Response("boom", { status: 500, headers: { "x-owa-error": "1" } });
+    }) as unknown as typeof fetch;
+
+    const resolved: ResolvedCall = {
+      url: "https://a.example/v1/thing",
+      method: "GET",
+      headers: {},
+      consumedParams: [],
+      residualParams: [],
+    };
+
+    const result = await proxyCall(vault, { site: "demo", resolved });
+    expect(result.status).toBe(500);
+    expect(call).toBe(1);
+  });
+
+  test("session retry does not refetch when wiggle refreshed nothing", async () => {
+    const vault = new CredentialVault();
+    vault.noteRequest("demo", authReq("https://a.example/v1", makeJwt({ aud: "https://a.example/", iat: 100 })));
+
+    let call = 0;
+    globalThis.fetch = mock(async () => {
+      call += 1;
+      return new Response("stale", { status: 500, headers: { "x-owa-error": "1" } });
+    }) as unknown as typeof fetch;
+
+    const resolved: ResolvedCall = {
+      url: "https://a.example/v1/thing",
+      method: "GET",
+      headers: {},
+      consumedParams: [],
+      residualParams: [],
+    };
+
+    const result = await proxyCall(vault, {
+      site: "demo",
+      resolved,
+      onWiggle: async () => {},
+      retryOn: { status: [500] },
+    });
+
+    expect(result.status).toBe(500);
+    expect(call).toBe(1);
   });
 
   test("throws when no credentials exist", async () => {

--- a/packages/daemon/src/site/proxy.ts
+++ b/packages/daemon/src/site/proxy.ts
@@ -4,11 +4,13 @@
  *
  * 401s are retried once, optionally after running the site's wiggle script to
  * refresh tokens. If the caller doesn't pass `onWiggle`, the retry still happens
- * but without a token-refresh hook.
+ * but without a token-refresh hook. A call can declare extra retry signals via
+ * `NamedCall.retryOn` for APIs that answer stale session headers with a 5xx.
  */
 
 import type { BrowserEngine } from "./browser/engine";
-import type { CredentialVault } from "./credentials";
+import type { RetryOn } from "./catalog";
+import type { Credential, CredentialVault } from "./credentials";
 import type { ResolvedCall } from "./resolver";
 
 export interface ProxyCallOptions {
@@ -19,6 +21,33 @@ export interface ProxyCallOptions {
   aud?: string;
   /** Called once before the retry attempt; gives callers a chance to refresh tokens. */
   onWiggle?: () => Promise<void>;
+  /** Catalog-declared extra retry signals (see NamedCall.retryOn). 401 is always retried. */
+  retryOn?: RetryOn;
+}
+
+/**
+ * "bearer" — the token itself was rejected, so the failed bearer is excluded on re-pick.
+ * "session" — session-scoped headers are stale; the same bearer is usually still valid,
+ * so re-pick must be allowed to return it with refreshed headers.
+ */
+export type RetryReason = "bearer" | "session";
+
+export function retryReason(
+  status: number,
+  responseHeaders: Record<string, string>,
+  retryOn?: RetryOn,
+): RetryReason | null {
+  if (status === 401) return "bearer";
+  if (!retryOn?.status && !retryOn?.responseHeaderPresent) return null;
+
+  const wanted = retryOn.responseHeaderPresent?.toLowerCase();
+  const statusMatch = retryOn.status ? retryOn.status.includes(status) : true;
+  const headerMatch = wanted ? Object.keys(responseHeaders).some((k) => k.toLowerCase() === wanted) : true;
+  return statusMatch && headerMatch ? "session" : null;
+}
+
+function credentialChanged(before: Credential, after: Credential): boolean {
+  return before.bearer !== after.bearer || JSON.stringify(before.headers) !== JSON.stringify(after.headers);
 }
 
 export interface ProxyCallResult {
@@ -93,7 +122,7 @@ async function doFetch(
 }
 
 export async function proxyCall(vault: CredentialVault, opts: ProxyCallOptions): Promise<ProxyCallResult> {
-  const { site, resolved, audHints = [], aud, onWiggle } = opts;
+  const { site, resolved, audHints = [], aud, onWiggle, retryOn } = opts;
 
   const pick = aud
     ? (vault.getAll(site).find((c) => c.aud === aud) ?? null)
@@ -109,17 +138,20 @@ export async function proxyCall(vault: CredentialVault, opts: ProxyCallOptions):
   let merged = mergeHeaders(pick.headers, pick.bearer, resolved.headers);
   let result = await doFetch(resolved.url, resolved.method, merged, resolved.body);
 
-  if (result.status === 401) {
+  const reason = retryReason(result.status, result.headers, retryOn);
+  if (reason) {
     try {
       await onWiggle?.();
     } catch {
       // Wiggle is advisory — don't fail the retry just because wiggle failed.
     }
-    const failedBearer = pick.bearer;
+    const excludeBearers = reason === "bearer" ? [pick.bearer] : [];
     const fresh = aud
-      ? (vault.getAll(site).find((c) => c.aud === aud && c.bearer !== failedBearer) ?? null)
-      : vault.pickCredentialFor(resolved.url, resolved.method, audHints, site, { excludeBearers: [failedBearer] });
-    if (fresh) {
+      ? (vault.getAll(site).find((c) => c.aud === aud && !excludeBearers.includes(c.bearer)) ?? null)
+      : vault.pickCredentialFor(resolved.url, resolved.method, audHints, site, { excludeBearers });
+    // A session retry can legitimately re-pick the same bearer, but only if wiggle
+    // actually refreshed something — otherwise the refetch is guaranteed to fail again.
+    if (fresh && (reason === "bearer" || credentialChanged(pick, fresh))) {
       usedAud = fresh.aud;
       merged = mergeHeaders(fresh.headers, fresh.bearer, resolved.headers);
       result = await doFetch(resolved.url, resolved.method, merged, resolved.body);

--- a/packages/daemon/src/site/seeds.spec.ts
+++ b/packages/daemon/src/site/seeds.spec.ts
@@ -75,6 +75,13 @@ describe("built-in owa seed", () => {
       expect(call.jq_output).toBeTruthy();
     }
   });
+
+  test("all owa calls opt into session-staleness retry on 500 + x-owa-error", () => {
+    const catalog = loadCatalog("owa", "owa");
+    for (const call of Object.values(catalog)) {
+      expect(call.retryOn).toEqual({ status: [500], responseHeaderPresent: "x-owa-error" });
+    }
+  });
 });
 
 describe("embedded seed data (compiled-binary support)", () => {

--- a/packages/daemon/src/site/seeds/owa/catalog.json
+++ b/packages/daemon/src/site/seeds/owa/catalog.json
@@ -15,7 +15,11 @@
     "audHints": ["outlook.cloud.microsoft"],
     "fetchFilter": "owa-urlpostdata",
     "jq_input": ".params as $p | { Header: { RequestServerVersion: \"V2018_01_08\", TimeZoneContext: { TimeZoneDefinition: { Id: \"UTC\" } } }, Body: { SortOrder: [{ Order: \"Descending\", Path: { FieldURI: \"DateTimeReceived\", __type: \"PropertyUri:#Exchange\" }, __type: \"SortResults:#Exchange\" }], ParentFolderId: { BaseFolderId: { __type: \"DistinguishedFolderId:#Exchange\", Id: \"inbox\" } }, MailboxScope: \"PrimaryOnly\", ConversationShape: { BaseShape: \"IdOnly\", AdditionalProperties: [{ FieldURI: \"ConversationTopic\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"ConversationLastDeliveryTime\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"ConversationUniqueSenders\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"ConversationPreview\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"ConversationHasAttachments\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"ConversationFlagStatus\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"ConversationUnreadCount\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"ConversationMessageCount\", __type: \"PropertyUri:#Exchange\" }] }, Paging: { __type: \"IndexedPageView:#Exchange\", BasePoint: \"Beginning\", Offset: ($p.offset // 0), MaxEntriesReturned: ($p.count // 20) } } }",
-    "jq_output": "{ total: .Body.TotalConversationsInView, conversations: [.Body.Conversations[]? | { id: .ConversationId.Id, topic: .ConversationTopic, from: ([.UniqueSenders[]?] | join(\", \")), preview: .Preview, received: .LastDeliveryTime, unread: .UnreadCount, messages: .MessageCount, hasAttachments: .HasAttachments, flagged: (.FlagStatus == \"Flagged\") }] }"
+    "jq_output": "{ total: .Body.TotalConversationsInView, conversations: [.Body.Conversations[]? | { id: .ConversationId.Id, topic: .ConversationTopic, from: ([.UniqueSenders[]?] | join(\", \")), preview: .Preview, received: .LastDeliveryTime, unread: .UnreadCount, messages: .MessageCount, hasAttachments: .HasAttachments, flagged: (.FlagStatus == \"Flagged\") }] }",
+    "retryOn": {
+      "status": [500],
+      "responseHeaderPresent": "x-owa-error"
+    }
   },
   "read_mail": {
     "name": "read_mail",
@@ -32,7 +36,11 @@
     "audHints": ["outlook.cloud.microsoft"],
     "fetchFilter": "owa-urlpostdata",
     "jq_input": ".params as $p | { Header: { RequestServerVersion: \"V2018_01_08\", TimeZoneContext: { TimeZoneDefinition: { Id: \"UTC\" } } }, Body: { Conversations: [{ ConversationId: { Id: $p.conversationId } }], ItemShape: { BaseShape: \"IdOnly\", AdditionalProperties: [{ FieldURI: \"ItemBody\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"From\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"Sender\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"Subject\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"DateTimeReceived\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"DateTimeSent\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"HasAttachments\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"Importance\", __type: \"PropertyUri:#Exchange\" }, { FieldURI: \"IsRead\", __type: \"PropertyUri:#Exchange\" }], BodyType: \"Text\" }, MaxItemsToReturn: 50, SortOrder: \"DateOrderAscending\" } }",
-    "jq_output": "{ conversation: [.Body.Conversations[0]?.ConversationNodes[]?.Items[]? | { id: .ItemId.Id, subject: .Subject, from: .From.Mailbox.Name, email: .From.Mailbox.EmailAddress, sent: .DateTimeSent, body: .Body.Value, importance: .Importance, read: .IsRead, hasAttachments: .HasAttachments }] }"
+    "jq_output": "{ conversation: [.Body.Conversations[0]?.ConversationNodes[]?.Items[]? | { id: .ItemId.Id, subject: .Subject, from: .From.Mailbox.Name, email: .From.Mailbox.EmailAddress, sent: .DateTimeSent, body: .Body.Value, importance: .Importance, read: .IsRead, hasAttachments: .HasAttachments }] }",
+    "retryOn": {
+      "status": [500],
+      "responseHeaderPresent": "x-owa-error"
+    }
   },
   "react_to_mail": {
     "name": "react_to_mail",
@@ -51,7 +59,11 @@
     "audHints": ["outlook.cloud.microsoft"],
     "fetchFilter": "owa-urlpostdata",
     "jq_input": ".params as $p | { Header: { RequestServerVersion: \"V2018_01_08\" }, Body: { ItemId: { Id: $p.itemId }, ReactionType: $p.reaction, Action: ($p.action // \"add\") } }",
-    "jq_output": "{ success: (.Body.ResponseClass == \"Success\") }"
+    "jq_output": "{ success: (.Body.ResponseClass == \"Success\") }",
+    "retryOn": {
+      "status": [500],
+      "responseHeaderPresent": "x-owa-error"
+    }
   },
   "respond_meeting": {
     "name": "respond_meeting",
@@ -70,7 +82,11 @@
     "audHints": ["outlook.cloud.microsoft"],
     "fetchFilter": "owa-urlpostdata",
     "jq_input": ".params as $p | { Header: { RequestServerVersion: \"V2018_01_08\" }, Body: { EventId: { Id: $p.itemId }, Response: $p.response, SendResponse: true, Body: (if $p.message then { Value: $p.message, BodyType: \"Text\" } else null end) } }",
-    "jq_output": "{ success: (.Body.ResponseClass == \"Success\") }"
+    "jq_output": "{ success: (.Body.ResponseClass == \"Success\") }",
+    "retryOn": {
+      "status": [500],
+      "responseHeaderPresent": "x-owa-error"
+    }
   },
   "trash_conversation": {
     "name": "trash_conversation",
@@ -88,6 +104,10 @@
     "audHints": ["outlook.cloud.microsoft"],
     "fetchFilter": "owa-urlpostdata",
     "jq_input": ".params as $p | { Header: { RequestServerVersion: \"V2018_01_08\" }, Body: { ConversationActions: [{ Action: (if $p.action == \"read\" then \"AlwaysMove\" elif $p.action == \"flag\" then \"Flag\" else \"Move\" end), ConversationId: { Id: $p.conversationId }, DestinationFolderId: (if ($p.action // \"delete\") == \"delete\" then { BaseFolderId: { __type: \"DistinguishedFolderId:#Exchange\", Id: \"deleteditems\" } } else null end), IsRead: (if $p.action == \"read\" then true else null end), Flag: (if $p.action == \"flag\" then { FlagStatus: \"Flagged\", __type: \"FlagType:#Exchange\" } else null end) }] } }",
-    "jq_output": "{ success: (.Body.ResponseClass == \"Success\") }"
+    "jq_output": "{ success: (.Body.ResponseClass == \"Success\") }",
+    "retryOn": {
+      "status": [500],
+      "responseHeaderPresent": "x-owa-error"
+    }
   }
 }


### PR DESCRIPTION
Refs #1459. Blocked from reaching existing users by #2926 — see "Who this actually fixes" below.

## What this changes

- `NamedCall` gains `retryOn?: { status?: number[]; responseHeaderPresent?: string }` (`catalog.ts`). Unset preserves today's 401-only behavior. When both fields are set they are ANDed, so an API that 500s for unrelated reasons doesn't trigger a pointless refetch.
- `proxy.ts` exports a pure `retryReason(status, responseHeaders, retryOn)` → `"bearer" | "session" | null`, and `proxyCall` accepts `retryOn`.
  - **`"bearer"`** (401, always, regardless of `retryOn`) — unchanged: the failed bearer is excluded on re-pick.
  - **`"session"`** (a `retryOn` match) — deliberately does **not** exclude the failed bearer. After wiggle the token is normally still valid and only the session-scoped headers (`x-owa-sessionid`, `ms-cv`) were refreshed, so excluding it would discard the credential we need. The refetch is skipped when wiggle changed neither bearer nor headers, since it would fail identically.
- `site-worker.ts` passes `call.retryOn` at both `proxyCall` sites (bearer mode and auto-mode's bearer attempt).
- `seeds/owa/catalog.json`: all 5 service.svc calls opt in with `{ status: [500], responseHeaderPresent: "x-owa-error" }`.

Mechanism being addressed: the vault captures headers from whatever request it observed. If that wasn't a `service.svc` POST, the credential has no session headers and OWA answers 500 `OwaSerializationException` rather than 401. The OWA wiggle script navigates to `/mail/`, which issues `service.svc` POSTs and therefore repopulates exactly those headers — so wiggle-then-retry is the right recovery, and it must keep the same bearer.

## Who this actually fixes — read before assuming the 500s are gone

**This PR is inert for every existing installation.** `loadCatalog` (`catalog.ts`) copies the built-in seed into `~/.mcp-cli/sites/<site>/catalog.json` **only when that file does not exist**, and never reconciles it afterwards. So:

- **New installations** (no `~/.mcp-cli/sites/owa/catalog.json`) get the OWA opt-in and the 500 → wiggle → retry recovery.
- **Existing installations** — anyone who has ever run an OWA call — get **nothing**. Their on-disk catalog has no `retryOn`, so `site_call owa inbox` keeps 500-ing after a daemon restart exactly as it does today. The only workaround right now is deleting `~/.mcp-cli/sites/owa/catalog.json`, which is **destructive**: it discards any sniffer-captured calls and manual edits in that file.
- **#2926 (seed reconciliation) is the blocker** for this mechanism reaching existing users. It is deliberately not implemented here — merging user customization against upstream seed changes needs its own design pass, since the catalog is explicitly a user-editable, sniffer-mutated file.

## Refs, not Fixes

#1459's Scope section (proxy retry predicate, catalog type extension, OWA seed opt-in, 2–3 tests) is fully delivered. Its **Problem** section is not: the user-visible symptom it describes — "daemon restart clears the vault, `site_call owa inbox` 500s, only way to recover is poking the browser tab" — remains true for existing installations until #2926 lands. Closing #1459 on this PR would mark a user-facing problem solved while it is still reproducible, so this uses `Refs`. #1459 should close when #2926 makes the seed reachable (or earlier at maintainer discretion, if the intent was to track the mechanism only).

## Test plan

- [x] `retryReason` unit tests: 401 is `"bearer"` with and without `retryOn`; no `retryOn` never retries past 401; status+header ANDed (header match is case-insensitive); either field alone suffices when it's the only one declared; `{}` never retries.
- [x] `proxyCall` integration: 500 + `x-owa-error` wiggles and retries with the **same** bearer, and the second request carries the refreshed `x-owa-sessionid` (asserted on captured headers, `[undefined, "sess-1"]`).
- [x] 500 is **not** retried when the call declares no `retryOn` (one fetch only).
- [x] Session retry does not refetch when wiggle refreshed nothing (one fetch only).
- [x] Seed assertion: all OWA calls declare the expected `retryOn`.
- [x] `bun run am-i-done` green (all 11 steps). Note: two earlier runs died with a `worker crashed: SIGTERM` cascade at ~6s under host load 15–19; that is CPU starvation, not this change — filed as #2924 for the one genuine flake it exposed (`test/transport-errors.spec.ts`, passes 5/5 isolated).
- [ ] Not verified against live OWA — the recovery path needs a real daemon restart with a stale vault, which can't be exercised in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)