### PR TITLE
feat(monitor): producer-rendered summary + severity on the event envelope (fixes #1924)

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,20 @@ Event types include `session.idle`, `session.result`, `session.permission_reques
 
 Payloads come pre-enriched — `cost`, `turns`, `lastTool`, `resultPreview`, `allGreen`, etc. — so orchestrators react push-shaped without a 5-lookup hydration loop. This is the load-bearing primitive for the `/sprint` skill; see [.claude/skills/sprint/README.md](.claude/skills/sprint/README.md).
 
+#### Event envelope contract
+
+Every event is a **flat** JSON object — category-specific fields live at the top level, never under a nested `payload`. Two fields are stamped by the producer side of the bus and are always present:
+
+- **`summary`** — one-line description (≤120 chars), rendered from the same per-type formatters the human-readable output uses.
+- **`severity`** — actionability tier: `info` (heartbeats, `session.tool_use`, metrics) → `notable` (`pr.opened`, `ci.started`, reviews) → `actionable` (`session.idle`, `session.result`, `ci.finished`, `pr.merged`, `phase.changed`) → `urgent` (`session.permission_request`, `cost.*_over_budget`, `worker.ratelimited`, `daemon.restarted`). A few types are value-dependent: `pr.merge_state_changed` is `actionable` only with a `cascadeHead`, `quota.utilization_threshold` is `urgent` at ≥95%, `pr.review_comment_posted` is `actionable` only when `newCount > 0`. Unmapped event types default to `info`.
+
+So the orchestrator's filter is a severity threshold rather than a hand-maintained event whitelist:
+
+```bash
+mcx monitor --subscribe session,work_item,ci --json \
+  | jq 'select(.severity == "actionable" or .severity == "urgent") | "\(.event)  \(.summary)"'
+```
+
 ### Phases & Automation
 
 `mcx` ships a declarative phase engine for work items. Declare a state machine in `.mcx.yaml` at the repo root, write each phase as a `defineAlias` script under `.claude/phases/`, and the daemon drives transitions per work item:

--- a/README.md
+++ b/README.md
@@ -315,17 +315,19 @@ Payloads come pre-enriched — `cost`, `turns`, `lastTool`, `resultPreview`, `al
 
 #### Event envelope contract
 
-Every event is a **flat** JSON object — category-specific fields live at the top level, never under a nested `payload`. Two fields are stamped by the producer side of the bus and are always present:
+Every event is a **flat** JSON object — category-specific fields live at the top level, never under a nested `payload`. A nested `payload` is rejected by the type at typed call sites and stripped at runtime for events arriving over untyped ingress (the `publishEvent` IPC `extra` record, automation `emit-event`). Two fields are stamped by the producer side of the bus and are present on every event a daemon at this version emits — live, replayed, and heartbeat:
 
-- **`summary`** — one-line description (≤120 chars), rendered from the same per-type formatters the human-readable output uses.
-- **`severity`** — actionability tier: `info` (heartbeats, `session.tool_use`, metrics) → `notable` (`pr.opened`, `ci.started`, reviews) → `actionable` (`session.idle`, `session.result`, `ci.finished`, `pr.merged`, `phase.changed`) → `urgent` (`session.permission_request`, `cost.*_over_budget`, `worker.ratelimited`, `daemon.restarted`). A few types are value-dependent: `pr.merge_state_changed` is `actionable` only with a `cascadeHead`, `quota.utilization_threshold` is `urgent` at ≥95%, `pr.review_comment_posted` is `actionable` only when `newCount > 0`. Unmapped event types default to `info`.
+- **`summary`** — one-line description, rendered from the same per-type formatters the human-readable output uses. Newlines collapsed, trimmed, capped at 120 chars, never empty. A producer may set it explicitly; it is normalized the same way either way.
+- **`severity`** — actionability tier: `info` (heartbeats, `session.tool_use`, metrics) → `notable` (`pr.opened`, `ci.started`, reviews) → `actionable` (`session.idle`, `session.result`, `ci.finished`, `pr.merged`, `phase.changed`, `alias.crashed`) → `urgent` (`session.permission_request`, `cost.*_over_budget`, `worker.ratelimited`, `daemon.restarted`). A few types are value-dependent: `pr.merge_state_changed` is `actionable` only with a `cascadeHead`, `quota.utilization_threshold` is `urgent` at ≥95%, `pr.review_comment_posted` is `actionable` only when `newCount > 0`. Unmapped event types default to `info`. A producer-supplied value outside the four tiers is discarded in favour of the table, so the field is always one of the four.
 
 So the orchestrator's filter is a severity threshold rather than a hand-maintained event whitelist:
 
 ```bash
 mcx monitor --subscribe session,work_item,ci --json \
-  | jq 'select(.severity == "actionable" or .severity == "urgent") | "\(.event)  \(.summary)"'
+  | jq 'select(.severity == null or .severity == "actionable" or .severity == "urgent") | "\(.event)  \(.summary)"'
 ```
+
+The `.severity == null` clause makes the filter fail **open**: `PROTOCOL_VERSION` hashes `ipc.ts` only, so a long-lived pre-#1924 `mcpd` will happily serve a new `mcx` fieldless events without a mismatch error. Without the null clause that reads as a silent, healthy stream rather than a stale daemon. Drop the clause once the fields are required rather than optional.
 
 ### Phases & Automation
 

--- a/packages/core/src/monitor-event.spec.ts
+++ b/packages/core/src/monitor-event.spec.ts
@@ -1,5 +1,20 @@
 import { describe, expect, test } from "bun:test";
 import type { MonitorEvent } from "./monitor-event";
+import * as monitorEventModule from "./monitor-event";
+import {
+  CI_FINISHED,
+  MONITOR_SEVERITIES,
+  MONITOR_SEVERITY_RANK,
+  PR_MERGE_STATE_CHANGED,
+  PR_OPENED,
+  PR_REVIEW_COMMENT_POSTED,
+  QUOTA_UTILIZATION_THRESHOLD,
+  SESSION_IDLE,
+  SESSION_PERMISSION_REQUEST,
+  enrichMonitorEvent,
+  severityForMonitorEvent,
+  summarizeMonitorEvent,
+} from "./monitor-event";
 import {
   DAEMON_CONFIG_RELOADED,
   DAEMON_RESTARTED,
@@ -13,6 +28,11 @@ import {
   WORKER_RATELIMITED,
   formatMonitorEvent,
 } from "./monitor-event";
+
+/** Every exported event-name constant, so new event types are covered automatically. */
+const KNOWN_EVENTS: string[] = Object.values(monitorEventModule as Record<string, unknown>).filter(
+  (v): v is string => typeof v === "string",
+);
 
 function event(overrides: Partial<MonitorEvent> & { event: string }): MonitorEvent {
   return {
@@ -248,5 +268,118 @@ describe("formatMonitorEvent — lifecycle events", () => {
     expect(line).toContain("session.spawn_override");
     expect(line).toContain("/canary/claude");
     expect(line).toContain("bypassed: version gate: upgrade required");
+  });
+
+  test("uses producer summary as the detail for unknown event types", () => {
+    const line = formatMonitorEvent(event({ event: "future.event", summary: "something happened" }));
+    expect(line).toContain("future.event");
+    expect(line).toContain("something happened");
+  });
+});
+
+describe("summarizeMonitorEvent", () => {
+  test("renders the same detail the formatter uses", () => {
+    const e = event({ event: PR_MERGE_STATE_CHANGED, prNumber: 42, from: "CLEAN", to: "BEHIND", cascadeHead: 41 });
+    expect(summarizeMonitorEvent(e)).toBe("PR#42  CLEAN → BEHIND  cascade:#41");
+  });
+
+  test("works without seq/ts (emit time, before the bus stamps them)", () => {
+    const summary = summarizeMonitorEvent({
+      src: "test",
+      category: "ci",
+      event: CI_FINISHED,
+      prNumber: 7,
+      allGreen: true,
+    });
+    expect(summary).toContain("PR#7");
+    expect(summary).toContain("all green");
+  });
+
+  test("falls back to the event name when there are no contextual fields", () => {
+    expect(summarizeMonitorEvent({ src: "t", category: "session", event: "session.cleared" })).toBe("session.cleared");
+  });
+
+  test("collapses newlines and caps at 120 chars", () => {
+    const summary = summarizeMonitorEvent(
+      event({ event: "unknown.event", detail: `line1\n  line2${"x".repeat(400)}` }),
+    );
+    expect(summary.length).toBeLessThanOrEqual(120);
+    expect(summary).not.toContain("\n");
+    expect(summary).toBe(summary.trimStart());
+  });
+});
+
+describe("severityForMonitorEvent", () => {
+  test("maps known tiers", () => {
+    expect(severityForMonitorEvent(event({ event: SESSION_PERMISSION_REQUEST }))).toBe("urgent");
+    expect(severityForMonitorEvent(event({ event: SESSION_IDLE }))).toBe("actionable");
+    expect(severityForMonitorEvent(event({ event: PR_OPENED }))).toBe("notable");
+    expect(severityForMonitorEvent(event({ event: HEARTBEAT }))).toBe("info");
+  });
+
+  test("defaults unmapped event types to info", () => {
+    expect(severityForMonitorEvent(event({ event: "brand.new.event" }))).toBe("info");
+  });
+
+  test("pr.merge_state_changed is actionable only with a cascade head", () => {
+    expect(severityForMonitorEvent(event({ event: PR_MERGE_STATE_CHANGED, from: "CLEAN", to: "DIRTY" }))).toBe(
+      "notable",
+    );
+    expect(
+      severityForMonitorEvent(event({ event: PR_MERGE_STATE_CHANGED, from: "CLEAN", to: "BEHIND", cascadeHead: 12 })),
+    ).toBe("actionable");
+  });
+
+  test("quota threshold escalates to urgent at 95%", () => {
+    expect(severityForMonitorEvent(event({ event: QUOTA_UTILIZATION_THRESHOLD, utilization: 80 }))).toBe("notable");
+    expect(severityForMonitorEvent(event({ event: QUOTA_UTILIZATION_THRESHOLD, utilization: 95 }))).toBe("urgent");
+  });
+
+  test("review comments are actionable only when new ones landed", () => {
+    expect(severityForMonitorEvent(event({ event: PR_REVIEW_COMMENT_POSTED, newCount: 0 }))).toBe("notable");
+    expect(severityForMonitorEvent(event({ event: PR_REVIEW_COMMENT_POSTED, newCount: 3 }))).toBe("actionable");
+  });
+
+  test("ranks are ordered so consumers can threshold", () => {
+    expect(MONITOR_SEVERITY_RANK.urgent).toBeGreaterThan(MONITOR_SEVERITY_RANK.actionable);
+    expect(MONITOR_SEVERITY_RANK.actionable).toBeGreaterThan(MONITOR_SEVERITY_RANK.notable);
+    expect(MONITOR_SEVERITY_RANK.notable).toBeGreaterThan(MONITOR_SEVERITY_RANK.info);
+  });
+});
+
+describe("enrichMonitorEvent", () => {
+  test("stamps a non-empty summary and a valid severity", () => {
+    const e = enrichMonitorEvent({ src: "test", category: "session", event: SESSION_IDLE, sessionId: "abcdef1234" });
+    expect(e.summary).toBeTruthy();
+    expect(MONITOR_SEVERITIES).toContain(e.severity);
+    expect(e.severity).toBe("actionable");
+  });
+
+  test("preserves producer-supplied summary and severity", () => {
+    const e = enrichMonitorEvent({
+      src: "test",
+      category: "session",
+      event: SESSION_IDLE,
+      summary: "hand-written",
+      severity: "urgent",
+    });
+    expect(e.summary).toBe("hand-written");
+    expect(e.severity).toBe("urgent");
+  });
+
+  test("never carries a nested payload — the envelope is flat", () => {
+    // The type forbids `payload`; this guards the runtime contract for events
+    // crossing an untyped boundary (JSON replay, worker postMessage).
+    const e = enrichMonitorEvent({ src: "test", category: "ci", event: CI_FINISHED, prNumber: 1, allGreen: false });
+    expect(Object.hasOwn(e, "payload")).toBe(false);
+    expect(e.summary).not.toContain("payload");
+  });
+
+  test("every known event type produces a non-empty summary and a valid severity", () => {
+    for (const name of KNOWN_EVENTS) {
+      const e = enrichMonitorEvent({ src: "test", category: "session", event: name });
+      expect(e.summary, `summary for ${name}`).toBeTruthy();
+      expect(MONITOR_SEVERITIES, `severity for ${name}`).toContain(e.severity);
+    }
   });
 });

--- a/packages/core/src/monitor-event.spec.ts
+++ b/packages/core/src/monitor-event.spec.ts
@@ -12,6 +12,7 @@ import {
   SESSION_IDLE,
   SESSION_PERMISSION_REQUEST,
   enrichMonitorEvent,
+  hasExplicitSeverity,
   severityForMonitorEvent,
   summarizeMonitorEvent,
 } from "./monitor-event";
@@ -367,12 +368,71 @@ describe("enrichMonitorEvent", () => {
     expect(e.severity).toBe("urgent");
   });
 
-  test("never carries a nested payload — the envelope is flat", () => {
-    // The type forbids `payload`; this guards the runtime contract for events
-    // crossing an untyped boundary (JSON replay, worker postMessage).
-    const e = enrichMonitorEvent({ src: "test", category: "ci", event: CI_FINISHED, prNumber: 1, allGreen: false });
+  test("strips a nested payload that arrived over an untyped boundary", () => {
+    // The type forbids `payload`, but IPC `extra` and automation `emit-event`
+    // spread caller-supplied keys the compiler never sees. Feed one in.
+    const hostile = {
+      src: "test",
+      category: "ci",
+      event: CI_FINISHED,
+      prNumber: 1,
+      allGreen: false,
+      payload: { state: "BEHIND" },
+    } as unknown as Parameters<typeof enrichMonitorEvent>[0];
+    const e = enrichMonitorEvent(hostile);
     expect(Object.hasOwn(e, "payload")).toBe(false);
-    expect(e.summary).not.toContain("payload");
+    expect(JSON.stringify(e)).not.toContain("BEHIND");
+  });
+
+  test("rejects an out-of-set severity in favour of the table", () => {
+    const hostile = {
+      src: "test",
+      category: "session",
+      event: SESSION_PERMISSION_REQUEST,
+      severity: "banana",
+    } as unknown as Parameters<typeof enrichMonitorEvent>[0];
+    const e = enrichMonitorEvent(hostile);
+    expect(MONITOR_SEVERITIES).toContain(e.severity);
+    expect(e.severity).toBe("urgent");
+  });
+
+  test("re-caps a producer-supplied summary that blows the budget", () => {
+    const e = enrichMonitorEvent({
+      src: "test",
+      category: "session",
+      event: SESSION_IDLE,
+      summary: "z".repeat(500),
+    });
+    expect(e.summary.length).toBe(120);
+    expect(e.summary.endsWith("…")).toBe(true);
+  });
+
+  test("degrades instead of throwing when rendering blows up", () => {
+    // `fallback` stringifies arbitrary producer values; a throwing toString is
+    // the cheapest realistic way to make rendering fail. Delivery must survive,
+    // and the static tier must be preserved.
+    const poison = {
+      src: "test",
+      category: "session",
+      event: SESSION_PERMISSION_REQUEST,
+      bad: {
+        toString() {
+          throw new Error("boom");
+        },
+      },
+    } as unknown as Parameters<typeof enrichMonitorEvent>[0];
+    const e = enrichMonitorEvent(poison);
+    expect(e.summary).toBe(SESSION_PERMISSION_REQUEST);
+    expect(e.severity).toBe("urgent");
+  });
+
+  test("every exported event-name constant has an explicit severity classification", () => {
+    // Not a tautology: `severityForMonitorEvent` defaults to `info`, so a new
+    // event constant with no table entry would otherwise sit silently below the
+    // documented actionability filter. This fails until the table is updated.
+    for (const name of KNOWN_EVENTS) {
+      expect(hasExplicitSeverity(name), `no explicit severity tier for "${name}"`).toBe(true);
+    }
   });
 
   test("every known event type produces a non-empty summary and a valid severity", () => {

--- a/packages/core/src/monitor-event.ts
+++ b/packages/core/src/monitor-event.ts
@@ -10,21 +10,31 @@
  *
  * ## Envelope contract (#1924)
  *
- * - **Flat.** Category-specific fields live at the top level of the envelope.
- *   A nested `payload` object is forbidden (`payload?: never` on
- *   `MonitorEventBase`) — consumers must never need `.payload.x` fallbacks.
- * - **`summary`** — a producer-rendered one-line description (≤120 chars, no
- *   leading whitespace, never empty). Set by `enrichMonitorEvent` at publish
- *   time from the shared per-type formatters, so consumers get a usable preview
- *   without reimplementing the formatter switch.
- * - **`severity`** — actionability tier (`info` | `notable` | `actionable` |
- *   `urgent`), also set at publish time. Consumers filter with
- *   `select(.severity == "actionable" or .severity == "urgent")` instead of
- *   maintaining their own event-name whitelist.
+ * `enrichMonitorEvent` is the single enforcement point. It runs on every event
+ * published through `EventBus.publish`, on every event replayed from the event
+ * log, and on the synthesized NDJSON heartbeat. It does not trust producer
+ * input: the type-level guards below only bind on typed call sites, and two
+ * ingress paths (the `publishEvent` IPC `extra` record and automation
+ * `emit-event`) spread caller-supplied keys the compiler cannot see.
  *
- * Both fields are typed optional for one release of bake-in, but every event
- * published through the bus (and every event replayed from the event log) has
- * them — consumers can rely on their presence.
+ * - **Flat.** Category-specific fields live at the top level of the envelope.
+ *   A nested `payload` object is forbidden — `payload?: never` on
+ *   `MonitorEventBase` rejects it at typed call sites, and `enrichMonitorEvent`
+ *   deletes it at runtime for everything else. Consumers never need `.payload.x`.
+ * - **`summary`** — a one-line description rendered from the shared per-type
+ *   formatters, so consumers get a usable preview without reimplementing the
+ *   formatter switch. Newlines are collapsed, the string is trimmed and capped
+ *   at 120 chars, and it is never empty. A producer-supplied `summary` is
+ *   preferred but is normalized the same way.
+ * - **`severity`** — actionability tier (`info` | `notable` | `actionable` |
+ *   `urgent`). A producer-supplied value is used only if it is one of those
+ *   four; anything else falls back to the classification table. Consumers
+ *   filter with `select(.severity == "actionable" or .severity == "urgent")`
+ *   instead of maintaining their own event-name whitelist.
+ *
+ * Both fields are typed optional for one release of bake-in, so that a consumer
+ * talking to a pre-#1924 daemon still typechecks. Every event emitted by a
+ * daemon at this version has them.
  */
 
 // ── Event categories ──
@@ -138,6 +148,10 @@ export const AUTOMATION_FIRED = "automation.fired" as const;
 export const AUTOMATION_SKIPPED = "automation.skipped" as const;
 export const AUTOMATION_ERRORED = "automation.errored" as const;
 export const AUTOMATION_ESCALATED = "automation.escalated" as const;
+
+// ── Alias supervisor event names (#1924) ──
+
+export const ALIAS_CRASHED = "alias.crashed" as const;
 
 // ── Heartbeat ──
 
@@ -543,8 +557,8 @@ const MAX_SUMMARY = 120;
 export function summarizeMonitorEvent(e: FormatterInput): string {
   if (e.event === HEARTBEAT) return typeof e.seq === "number" ? `heartbeat seq:${e.seq}` : "heartbeat";
   const formatter = FORMATTERS[e.event];
-  const detail = (formatter ? formatter(e) : fallback(e)).replace(/\s*[\r\n]+\s*/g, " ").trim();
-  return cap(detail || e.event, MAX_SUMMARY);
+  const detail = normalizeSummary(formatter ? formatter(e) : fallback(e));
+  return detail || normalizeSummary(e.event) || e.event || "(unnamed event)";
 }
 
 /**
@@ -570,6 +584,7 @@ const SEVERITY_BY_EVENT: Partial<Record<string, MonitorSeverity>> = {
   [SESSION_ENDED]: "actionable",
   [SESSION_RATE_LIMITED]: "actionable",
   [SESSION_CONTAINMENT_DENIED]: "actionable",
+  [ALIAS_CRASHED]: "actionable",
   [PR_MERGED]: "actionable",
   [PR_CLOSED]: "actionable",
   [CI_FINISHED]: "actionable",
@@ -627,15 +642,53 @@ export function severityForMonitorEvent(e: MonitorEventBase): MonitorSeverity {
   return SEVERITY_BY_EVENT[e.event] ?? "info";
 }
 
+const SEVERITY_SET: ReadonlySet<string> = new Set(MONITOR_SEVERITIES);
+
+/** True when `event` has an explicit tier rather than falling through to the `info` default. */
+export function hasExplicitSeverity(event: string): boolean {
+  return event in SEVERITY_BY_EVENT || event in SEVERITY_OVERRIDES;
+}
+
 /**
- * Stamp `summary` and `severity` onto an event, preserving anything the
- * producer set explicitly. Called at every publish and replay boundary so
- * consumers can rely on both fields being present.
+ * Normalize an event onto the envelope contract. This is the single enforcement
+ * point for all three invariants, because the two untyped ingress paths
+ * (`publishEvent` IPC `extra`, automation `emit-event`) spread caller-supplied
+ * keys straight into `publish` and the compiler cannot see them:
+ *
+ * - **`payload` is dropped.** The envelope is flat; a nested payload never
+ *   reaches a consumer even if a caller supplies one.
+ * - **`severity` is validated** against `MONITOR_SEVERITIES`. A missing or
+ *   out-of-set value falls back to the classification table, so the field is
+ *   always one of the four tiers.
+ * - **`summary` is re-normalized** — newlines collapsed, trimmed, capped at 120
+ *   chars — whether it came from a producer or from the formatters. Never empty.
  */
 export function enrichMonitorEvent<T extends FormatterInput>(e: T): T & { summary: string; severity: MonitorSeverity } {
-  const summary = typeof e.summary === "string" && e.summary ? e.summary : summarizeMonitorEvent(e);
-  const severity = e.severity ?? severityForMonitorEvent(e);
-  return { ...e, summary, severity };
+  const { payload: _payload, ...rest } = e;
+  try {
+    const producerSummary = typeof e.summary === "string" ? normalizeSummary(e.summary) : "";
+    const summary = producerSummary || summarizeMonitorEvent(e);
+    const severity =
+      typeof e.severity === "string" && SEVERITY_SET.has(e.severity)
+        ? (e.severity as MonitorSeverity)
+        : severityForMonitorEvent(e);
+    return { ...rest, summary, severity } as T & { summary: string; severity: MonitorSeverity };
+  } catch (err) {
+    // Never throw: `publish` calls this before its own error containment, and
+    // some callers (derived-events) publish after committing their cursor, so a
+    // throw here would drop the event permanently. Degrade to the event name
+    // plus the static tier — rendering is best-effort, delivery is not.
+    console.error(`[monitor-event] enrich failed for "${e.event}", degrading:`, err);
+    return {
+      ...rest,
+      summary: typeof e.event === "string" && e.event ? cap(e.event, MAX_SUMMARY) : "(unnamed event)",
+      severity: SEVERITY_BY_EVENT[e.event] ?? "info",
+    } as T & { summary: string; severity: MonitorSeverity };
+  }
+}
+
+function normalizeSummary(s: string): string {
+  return cap(s.replace(/\s*[\r\n]+\s*/g, " ").trim(), MAX_SUMMARY);
 }
 
 function fallback(e: FormatterInput): string {

--- a/packages/core/src/monitor-event.ts
+++ b/packages/core/src/monitor-event.ts
@@ -7,6 +7,24 @@
  *
  * Part of #1486 (monitor epic), introduced in #1512.
  * Projection layer (formatters, chunk suppression) added in #1515.
+ *
+ * ## Envelope contract (#1924)
+ *
+ * - **Flat.** Category-specific fields live at the top level of the envelope.
+ *   A nested `payload` object is forbidden (`payload?: never` on
+ *   `MonitorEventBase`) — consumers must never need `.payload.x` fallbacks.
+ * - **`summary`** — a producer-rendered one-line description (≤120 chars, no
+ *   leading whitespace, never empty). Set by `enrichMonitorEvent` at publish
+ *   time from the shared per-type formatters, so consumers get a usable preview
+ *   without reimplementing the formatter switch.
+ * - **`severity`** — actionability tier (`info` | `notable` | `actionable` |
+ *   `urgent`), also set at publish time. Consumers filter with
+ *   `select(.severity == "actionable" or .severity == "urgent")` instead of
+ *   maintaining their own event-name whitelist.
+ *
+ * Both fields are typed optional for one release of bake-in, but every event
+ * published through the bus (and every event replayed from the event log) has
+ * them — consumers can rely on their presence.
  */
 
 // ── Event categories ──
@@ -127,7 +145,26 @@ export const HEARTBEAT = "heartbeat" as const;
 
 // ── Envelope ──
 
-/** Common fields for all monitor events. */
+/** Actionability tiers, ascending. See `MONITOR_SEVERITY_RANK` for ordering. */
+export const MONITOR_SEVERITIES = ["info", "notable", "actionable", "urgent"] as const;
+
+export type MonitorSeverity = (typeof MONITOR_SEVERITIES)[number];
+
+/** Numeric rank for threshold comparisons (`rank >= rank("actionable")`). */
+export const MONITOR_SEVERITY_RANK: Record<MonitorSeverity, number> = {
+  info: 0,
+  notable: 1,
+  actionable: 2,
+  urgent: 3,
+};
+
+/**
+ * Common fields for all monitor events.
+ *
+ * Category-specific fields go at the top level — see the envelope contract in
+ * the file header. Nesting them under `payload` is a producer-side contract
+ * violation and is rejected by the type.
+ */
 export interface MonitorEventBase {
   src: string;
   event: string;
@@ -135,6 +172,12 @@ export interface MonitorEventBase {
   workItemId?: string;
   sessionId?: string;
   prNumber?: number;
+  /** Producer-rendered one-liner (≤120 chars). Always present on published events. */
+  summary?: string;
+  /** Actionability tier. Always present on published events. */
+  severity?: MonitorSeverity;
+  /** Forbidden: the envelope is flat. Put category-specific fields at the top level. */
+  payload?: never;
   /** Repo root path this event is scoped to. Present when known / when session is repo-scoped; absent on global events (mail, quota, heartbeats) and sessions started without a configured or discoverable repo root. */
   repoRoot?: string;
   /** Causal chain of seq IDs — present on events from DerivedEventPublisher (src:"daemon.derived"). Depth is capped at 4. */
@@ -161,23 +204,23 @@ function ts(e: MonitorEvent): string {
   return `[${h}:${m}:${s}]`;
 }
 
-function wi(e: MonitorEvent): string {
+function wi(e: MonitorEventBase): string {
   return typeof e.workItemId === "string" ? e.workItemId : "";
 }
 
-function sid(e: MonitorEvent): string {
+function sid(e: MonitorEventBase): string {
   return typeof e.sessionId === "string" ? e.sessionId.slice(0, 8) : "";
 }
 
-function pr(e: MonitorEvent): string {
+function pr(e: MonitorEventBase): string {
   return typeof e.prNumber === "number" ? `PR#${e.prNumber}` : "";
 }
 
-function cost(e: MonitorEvent): string {
+function cost(e: MonitorEventBase): string {
   return typeof e.cost === "number" ? `$${e.cost.toFixed(2)}` : "";
 }
 
-function turns(e: MonitorEvent): string {
+function turns(e: MonitorEventBase): string {
   return typeof e.numTurns === "number" ? `${e.numTurns}t` : "";
 }
 
@@ -189,7 +232,13 @@ function join(...parts: (string | undefined | false)[]): string {
   return parts.filter(Boolean).join("  ");
 }
 
-type Formatter = (e: MonitorEvent) => string;
+/**
+ * Formatters run both at emit time (to render `summary`, before `seq`/`ts` are
+ * stamped) and at display time, so they must tolerate a partial envelope.
+ */
+type FormatterInput = MonitorEventBase & Partial<Pick<MonitorEvent, "seq" | "ts">>;
+
+type Formatter = (e: FormatterInput) => string;
 
 const FORMATTERS: Partial<Record<string, Formatter>> = {
   [SESSION_RESULT]: (e) => {
@@ -471,19 +520,127 @@ const FORMATTERS: Partial<Record<string, Formatter>> = {
  *
  * Format: `[HH:MM:SS] event.type  <context fields>`
  *
- * Falls back to a generic one-liner for unknown event types.
+ * For event types without a formatter, uses the producer-rendered `summary`
+ * when present, else a generic field dump.
  */
 export function formatMonitorEvent(e: MonitorEvent): string {
   const formatter = FORMATTERS[e.event];
   const label = e.event === HEARTBEAT ? "♥ heartbeat    " : e.event.padEnd(24);
-  const detail = formatter ? formatter(e) : fallback(e);
+  const detail = formatter ? formatter(e) : typeof e.summary === "string" && e.summary ? e.summary : fallback(e);
   const line = `${ts(e)} ${label}  ${detail}`;
   return cap(line, MAX_LINE);
 }
 
-function fallback(e: MonitorEvent): string {
+// ── Producer-owned envelope fields (#1924) ──
+
+const MAX_SUMMARY = 120;
+
+/**
+ * Render the one-line `summary` for an event, from the same per-type formatters
+ * used by `formatMonitorEvent`. Never returns an empty string — events with no
+ * contextual fields summarize to their event name.
+ */
+export function summarizeMonitorEvent(e: FormatterInput): string {
+  if (e.event === HEARTBEAT) return typeof e.seq === "number" ? `heartbeat seq:${e.seq}` : "heartbeat";
+  const formatter = FORMATTERS[e.event];
+  const detail = (formatter ? formatter(e) : fallback(e)).replace(/\s*[\r\n]+\s*/g, " ").trim();
+  return cap(detail || e.event, MAX_SUMMARY);
+}
+
+/**
+ * Baseline severity per event type. Unmapped types default to `info`.
+ * Value-dependent tiers are refined by SEVERITY_OVERRIDES below.
+ */
+const SEVERITY_BY_EVENT: Partial<Record<string, MonitorSeverity>> = {
+  // urgent — a human/orchestrator decision is blocking progress or money is burning
+  [SESSION_PERMISSION_REQUEST]: "urgent",
+  [SESSION_PERMISSION_BLOCKED]: "urgent",
+  [COST_SESSION_OVER_BUDGET]: "urgent",
+  [COST_SPRINT_OVER_BUDGET]: "urgent",
+  [WORKER_RATELIMITED]: "urgent",
+  [DAEMON_RESTARTED]: "urgent",
+  [SESSION_CONTAINMENT_ESCALATED]: "urgent",
+
+  // actionable — the orchestrator has work to do in response
+  [SESSION_IDLE]: "actionable",
+  [SESSION_RESULT]: "actionable",
+  [SESSION_STUCK]: "actionable",
+  [SESSION_ERROR]: "actionable",
+  [SESSION_DISCONNECTED]: "actionable",
+  [SESSION_ENDED]: "actionable",
+  [SESSION_RATE_LIMITED]: "actionable",
+  [SESSION_CONTAINMENT_DENIED]: "actionable",
+  [PR_MERGED]: "actionable",
+  [PR_CLOSED]: "actionable",
+  [CI_FINISHED]: "actionable",
+  [CHECKS_FAILED]: "actionable",
+  [PHASE_CHANGED]: "actionable",
+  [GC_PRUNED]: "actionable",
+  [AUTOMATION_ERRORED]: "actionable",
+  [AUTOMATION_ESCALATED]: "actionable",
+
+  // notable — state moved, but nothing to do yet
+  [PR_OPENED]: "notable",
+  [PR_PUSHED]: "notable",
+  [CI_STARTED]: "notable",
+  [CI_RUNNING]: "notable",
+  [CHECKS_STARTED]: "notable",
+  [CHECKS_PASSED]: "notable",
+  [REVIEW_APPROVED]: "notable",
+  [REVIEW_CHANGES_REQUESTED]: "notable",
+  [REVIEW_COMMENTED]: "notable",
+  [REVIEW_STICKY_UPDATED]: "notable",
+  [PR_COMMENT]: "notable",
+  [ISSUE_COMMENT]: "notable",
+  [DAEMON_CONFIG_RELOADED]: "notable",
+  [SESSION_CONTAINMENT_WARNING]: "notable",
+  [SESSION_CONTAINMENT_RESET]: "notable",
+  [SESSION_MODEL_CHANGED]: "notable",
+  [SESSION_CLEARED]: "notable",
+  [SESSION_SPAWN_OVERRIDE]: "notable",
+  [AUTOMATION_FIRED]: "notable",
+  [AUTOMATION_SKIPPED]: "notable",
+
+  // info — telemetry / chatter (also the default for unmapped types)
+  [HEARTBEAT]: "info",
+  [SESSION_TOOL_USE]: "info",
+  [SESSION_RESPONSE]: "info",
+  [MAIL_SENT]: "info",
+  [METRIC_SESSION_FOOTPRINT]: "info",
+  [METRIC_SESSION_COMMAND_HIST]: "info",
+  [METRIC_SESSION_QUERIES]: "info",
+};
+
+/** Value-dependent severity: the same event type can be chatter or a call to action. */
+const SEVERITY_OVERRIDES: Partial<Record<string, (e: MonitorEventBase) => MonitorSeverity>> = {
+  // A BEHIND PR with a known cascade head is the orchestrator's cue to update-branch.
+  [PR_MERGE_STATE_CHANGED]: (e) => (typeof e.cascadeHead === "number" ? "actionable" : "notable"),
+  [QUOTA_UTILIZATION_THRESHOLD]: (e) =>
+    typeof e.utilization === "number" && e.utilization >= 95 ? "urgent" : "notable",
+  [PR_REVIEW_COMMENT_POSTED]: (e) => (typeof e.newCount === "number" && e.newCount > 0 ? "actionable" : "notable"),
+};
+
+/** Classify an event's actionability. Unmapped event types are `info`. */
+export function severityForMonitorEvent(e: MonitorEventBase): MonitorSeverity {
+  const override = SEVERITY_OVERRIDES[e.event];
+  if (override) return override(e);
+  return SEVERITY_BY_EVENT[e.event] ?? "info";
+}
+
+/**
+ * Stamp `summary` and `severity` onto an event, preserving anything the
+ * producer set explicitly. Called at every publish and replay boundary so
+ * consumers can rely on both fields being present.
+ */
+export function enrichMonitorEvent<T extends FormatterInput>(e: T): T & { summary: string; severity: MonitorSeverity } {
+  const summary = typeof e.summary === "string" && e.summary ? e.summary : summarizeMonitorEvent(e);
+  const severity = e.severity ?? severityForMonitorEvent(e);
+  return { ...e, summary, severity };
+}
+
+function fallback(e: FormatterInput): string {
   const fields = Object.entries(e)
-    .filter(([k]) => !["seq", "ts", "src", "event", "category"].includes(k))
+    .filter(([k]) => !["seq", "ts", "src", "event", "category", "summary", "severity"].includes(k))
     .slice(0, 4)
     .map(([k, v]) => `${k}:${String(v).slice(0, 20)}`);
   return fields.join("  ");

--- a/packages/daemon/src/event-bus.spec.ts
+++ b/packages/daemon/src/event-bus.spec.ts
@@ -28,6 +28,39 @@ describe("EventBus", () => {
     expect(new Date(result.ts).getTime()).toBeGreaterThan(0);
   });
 
+  test("publish stamps summary and severity (#1924)", () => {
+    const bus = new EventBus();
+    const received: MonitorEvent[] = [];
+    bus.subscribe((e) => received.push(e));
+
+    const idle = bus.publish({ src: "test", event: "session.idle", category: "session", sessionId: "abcdef1234" });
+    expect(idle.summary).toBeTruthy();
+    expect(idle.severity).toBe("actionable");
+
+    const heartbeat = bus.publish({ src: "test", event: "heartbeat", category: "heartbeat" });
+    expect(heartbeat.severity).toBe("info");
+
+    for (const e of received) {
+      expect(typeof e.summary).toBe("string");
+      expect(e.summary).toBeTruthy();
+      expect(["info", "notable", "actionable", "urgent"] as (string | undefined)[]).toContain(e.severity);
+      expect(Object.hasOwn(e, "payload")).toBe(false);
+    }
+  });
+
+  test("publish preserves a producer-supplied summary/severity", () => {
+    const bus = new EventBus();
+    const e = bus.publish({
+      src: "test",
+      event: "session.idle",
+      category: "session",
+      summary: "explicit",
+      severity: "urgent",
+    });
+    expect(e.summary).toBe("explicit");
+    expect(e.severity).toBe("urgent");
+  });
+
   test("seq is monotonically increasing across sources", () => {
     const bus = new EventBus();
     const e1 = bus.publish(sessionEvent());

--- a/packages/daemon/src/event-bus.ts
+++ b/packages/daemon/src/event-bus.ts
@@ -11,7 +11,7 @@
  * #1512 #1557
  */
 
-import type { MonitorEvent, MonitorEventInput } from "@mcp-cli/core";
+import { type MonitorEvent, type MonitorEventInput, enrichMonitorEvent } from "@mcp-cli/core";
 import type { CoalescerOptions, SubmitOptions } from "./coalesce";
 import { CoalescingPublisher } from "./coalesce";
 import type { EventLog } from "./event-log";
@@ -45,7 +45,10 @@ export class EventBus {
     }
   }
 
-  publish(input: MonitorEventInput): MonitorEvent {
+  publish(rawInput: MonitorEventInput): MonitorEvent {
+    // summary/severity are stamped once, here, so every consumer (live stream,
+    // replay, TUI) sees them regardless of which producer emitted the event.
+    const input = enrichMonitorEvent(rawInput);
     const ts = new Date().toISOString();
     let seq: number;
 

--- a/packages/daemon/src/event-log.ts
+++ b/packages/daemon/src/event-log.ts
@@ -9,7 +9,7 @@
  */
 
 import type { Database } from "bun:sqlite";
-import type { MonitorEvent } from "@mcp-cli/core";
+import { type MonitorEvent, enrichMonitorEvent } from "@mcp-cli/core";
 import { safeSetInterval } from "./safe-timers";
 
 const CONSUMER = "event_log";
@@ -98,7 +98,8 @@ export class EventLog {
     }
 
     // Overlay the authoritative seq from the DB column — payload stores seq=0 placeholder.
-    return rows.map((r) => ({ ...(JSON.parse(r.payload) as MonitorEvent), seq: r.seq }));
+    // Enrich on read so rows written before summary/severity existed still satisfy the contract.
+    return rows.map((r) => enrichMonitorEvent({ ...(JSON.parse(r.payload) as MonitorEvent), seq: r.seq }));
   }
 
   prune(olderThan: Date): number {

--- a/packages/daemon/src/event-stream.ts
+++ b/packages/daemon/src/event-stream.ts
@@ -8,6 +8,7 @@
  */
 
 import type { Logger } from "@mcp-cli/core";
+import { HEARTBEAT, enrichMonitorEvent } from "@mcp-cli/core";
 import { getDaemonLogLines, subscribeDaemonLogs } from "./daemon-log";
 import type { EventBus } from "./event-bus";
 import type { EventLog } from "./event-log";
@@ -640,7 +641,17 @@ export class EventStreamServer {
         const heartbeatPollMs = Math.ceil(this.heartbeatIntervalMs / 6);
         heartbeatTimer = safeSetInterval(() => {
           if (Date.now() - lastWriteTime >= this.heartbeatIntervalMs) {
-            const hb = `${JSON.stringify({ category: "heartbeat", event: "heartbeat", seq: this.eventSeq, src: "daemon", ts: new Date().toISOString() })}\n`;
+            // Enriched like any other event — the heartbeat is the highest-frequency
+            // thing on the stream, so it must satisfy the envelope contract too.
+            const hb = `${JSON.stringify(
+              enrichMonitorEvent({
+                category: "heartbeat" as const,
+                event: HEARTBEAT,
+                seq: this.eventSeq,
+                src: "daemon",
+                ts: new Date().toISOString(),
+              }),
+            )}\n`;
             try {
               controller.enqueue(encoder.encode(hb));
               lastWriteTime = Date.now();

--- a/packages/daemon/src/handlers/event.spec.ts
+++ b/packages/daemon/src/handlers/event.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import type { IpcMethod } from "@mcp-cli/core";
-import { IPC_ERROR } from "@mcp-cli/core";
+import type { IpcMethod, MonitorEvent } from "@mcp-cli/core";
+import { IPC_ERROR, MONITOR_SEVERITIES, SESSION_PERMISSION_REQUEST } from "@mcp-cli/core";
+import { EventBus } from "../event-bus";
 import type { RequestHandler } from "../handler-types";
 import { EventHandlers } from "./event";
 
@@ -38,5 +39,95 @@ describe("EventHandlers", () => {
     await expect(
       invoke(map, "publishEvent")({ src: "test", event: "test.event", category: "session" }, {} as never),
     ).rejects.toMatchObject({ code: IPC_ERROR.INTERNAL_ERROR });
+  });
+});
+
+/**
+ * The envelope invariants (#1924) are only at risk on untyped ingress. `extra` is
+ * `z.record(z.string(), z.unknown())`, so any socket client can put arbitrary keys
+ * — including `payload`, a bogus `severity`, and an oversized `summary` — into the
+ * object that `EventHandlers` spreads into `publish`. The compiler cannot see them.
+ *
+ * These tests drive the real handler over a default `new EventBus()` and assert on
+ * the envelope a monitor consumer actually receives: the JSON string the bus
+ * serializes for its subscribers. No stub bus, no hand-built input, no assertion
+ * against the intended shape — only against the emitted one.
+ */
+describe("publishEvent envelope invariants over untyped ingress", () => {
+  function publishAndObserve(params: Record<string, unknown>): MonitorEvent {
+    const bus = new EventBus();
+    const map = new Map<IpcMethod, RequestHandler>();
+    new EventHandlers(bus).register(map);
+
+    let observed: MonitorEvent | undefined;
+    bus.subscribe((_event, serialized) => {
+      observed = JSON.parse(serialized) as MonitorEvent;
+    });
+
+    const handler = map.get("publishEvent");
+    if (!handler) throw new Error("publishEvent not registered");
+    handler(params, {} as never);
+
+    if (!observed) throw new Error("no event delivered to subscriber");
+    return observed;
+  }
+
+  test("a hostile client cannot violate any of the three invariants", () => {
+    const observed = publishAndObserve({
+      src: "hostile-client",
+      event: SESSION_PERMISSION_REQUEST,
+      category: "session",
+      extra: {
+        payload: { state: "BEHIND" },
+        severity: "banana",
+        summary: "x".repeat(500),
+      },
+    });
+
+    // Flat: the nested payload never reaches the consumer.
+    expect(Object.hasOwn(observed, "payload")).toBe(false);
+
+    // Severity is one of the four tiers — and specifically the table's tier, so
+    // an urgent event cannot be smuggled below the documented filter threshold.
+    expect(MONITOR_SEVERITIES as readonly (string | undefined)[]).toContain(observed.severity);
+    expect(observed.severity).toBe("urgent");
+
+    // Summary is capped and non-empty.
+    expect(observed.summary).toBeTruthy();
+    expect((observed.summary ?? "").length).toBeLessThanOrEqual(120);
+  });
+
+  test("a producer-supplied summary is normalized, not trusted verbatim", () => {
+    const observed = publishAndObserve({
+      src: "hostile-client",
+      event: "session.idle",
+      category: "session",
+      extra: { summary: `  leading\nand\r\nembedded newlines  ${"y".repeat(200)}` },
+    });
+
+    // Newline runs collapse to a single space and the ends are trimmed; interior
+    // spacing from the producer is otherwise left alone.
+    expect(observed.summary).toBe(`${`leading and embedded newlines  ${"y".repeat(200)}`.slice(0, 119)}…`);
+    expect(observed.summary).not.toContain("\n");
+    expect(observed.summary).not.toContain("\r");
+    expect((observed.summary ?? "").length).toBeLessThanOrEqual(120);
+    expect(observed.summary?.startsWith(" ")).toBe(false);
+  });
+
+  test("an in-set producer severity is still honoured", () => {
+    const observed = publishAndObserve({
+      src: "hostile-client",
+      event: "session.tool_use",
+      category: "session",
+      extra: { severity: "urgent" },
+    });
+    expect(observed.severity).toBe("urgent");
+  });
+
+  test("the default path stamps both fields with no producer input at all", () => {
+    const observed = publishAndObserve({ src: "cli", event: "session.idle", category: "session" });
+    expect(observed.summary).toBeTruthy();
+    expect(MONITOR_SEVERITIES as readonly (string | undefined)[]).toContain(observed.severity);
+    expect(observed.severity).toBe("actionable");
   });
 });

--- a/packages/daemon/src/ipc-server.spec.ts
+++ b/packages/daemon/src/ipc-server.spec.ts
@@ -3765,6 +3765,11 @@ describe("IpcServer HTTP transport", () => {
       expect(hb.src).toBe("daemon");
       expect(typeof hb.ts).toBe("string");
       expect(typeof hb.seq).toBe("number");
+      // #1924: the heartbeat is synthesized outside EventBus.publish, so it has
+      // its own route to the envelope contract. Assert on the actual wire bytes.
+      expect(hb.summary).toBe(`heartbeat seq:${hb.seq as number}`);
+      expect(hb.severity).toBe("info");
+      expect(Object.hasOwn(hb, "payload")).toBe(false);
     } finally {
       Object.defineProperty(IpcServer, "HEARTBEAT_INTERVAL_MS", {
         value: origInterval ?? 30_000,

--- a/packages/daemon/src/monitor-runtime.ts
+++ b/packages/daemon/src/monitor-runtime.ts
@@ -11,7 +11,7 @@
  */
 
 import type { AliasType, Logger, ManagedHandle, MonitorCategory, MonitorEventInput } from "@mcp-cli/core";
-import { bundleAlias, spawnManaged } from "@mcp-cli/core";
+import { ALIAS_CRASHED, bundleAlias, spawnManaged } from "@mcp-cli/core";
 import type { EventBus } from "./event-bus";
 import { safeSetTimeout } from "./safe-timers";
 import { workerPath } from "./worker-path";
@@ -305,7 +305,7 @@ export class MonitorRuntime {
 
       this.bus.publish({
         src: "daemon.alias-supervisor",
-        event: "alias.crashed",
+        event: ALIAS_CRASHED,
         category: "session",
         name: mon.name,
         errorMessage: `Monitor "${mon.name}" exited with code ${code}`,


### PR DESCRIPTION
## Summary

- **`severity`** — actionability tier (`info` / `notable` / `actionable` / `urgent`) on every event, so the orchestrator filter is `select(.severity == "actionable" or .severity == "urgent")` instead of a hand-maintained event-name whitelist. Table covers every exported event constant; value-dependent overrides for `pr.merge_state_changed` (actionable only with a `cascadeHead`), `quota.utilization_threshold` (urgent at ≥95%), and `pr.review_comment_posted` (actionable only when `newCount > 0`). Unmapped types default to `info`.
- **`summary`** — a one-line description (≤120 chars, never empty, newlines collapsed) rendered from the *same* per-type formatters `formatMonitorEvent` uses, so consumers stop reimplementing a 30-branch formatter switch. `formatMonitorEvent` now uses `e.summary` as the detail for event types it has no formatter for.
- **Stamped at the chokepoint, not at ~100 call sites.** `enrichMonitorEvent` runs in `EventBus.publish` and on `EventLog.getSince` replay, so live-stream, replay, and TUI consumers all see both fields — including rows written before this change. A producer that sets `summary`/`severity` explicitly wins.
- **Flat-envelope contract enforced by the type**: `payload?: never` on `MonitorEventBase`, plus JSDoc on the interface and file header, plus a README section documenting the tiers.

### Correction to the issue's scope item 1

The issue assumed `pr.merge_state_changed`, `work_item.phase_changed`, and `ci.finished` nest their fields under `.payload` and need moving. **They don't** — all three already publish flat (the formatters read `e.from` / `e.to` / `e.allGreen` top-level, and `publishWorkItemMonitorEvent` assigns to `input.<field>` directly). Evidence:

- `payload?: never` compiled with **zero** type errors across all packages — no producer assigns `payload`.
- A live `mcx monitor --json` stream returns `has("payload") == false` for every event.

So no fields needed relocating; the audit is satisfied by type-level prohibition + a runtime guard test rather than a migration. Both fields are left **optional** in the type per the issue's migration plan (bake-in before flipping to required).

## Test plan

- [x] `packages/core/src/monitor-event.spec.ts` (+11): summary matches formatter output; works without `seq`/`ts` (emit time); falls back to event name when no contextual fields; caps at 120 chars and strips newlines; each severity tier and all three value-dependent overrides; rank ordering; `enrichMonitorEvent` preserves producer-set values; no `payload` key survives; **sweep over every exported event constant** asserting non-empty summary + valid severity (so new event types are covered automatically).
- [x] `packages/daemon/src/event-bus.spec.ts` (+2): `publish` stamps both fields on every subscriber-delivered event and preserves explicit ones.
- [x] `bun run am-i-done` — all 11 steps pass (103s). Note: an earlier run showed 87 mass `worker crashed: SIGTERM` failures purely from host load average ~10 (sibling gates); clean at load < 5.
- [x] `formatMonitorEvent` output for known event types is byte-identical (non-goal: no consumer breakage) — existing formatter tests unchanged and passing.
- [ ] Not verified end-to-end against a restarted daemon: the running daemon is the pre-change compiled binary and is shared with other live sessions, so I did not restart it. The publish chokepoint is covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)