### PR TITLE
feat(bye): keep the worktree by default, require --clean to remove it (fixes #1750)

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,8 @@ mcx claude wait [session]                      # block until session event
 mcx claude wait --any                          # race: session idle or work item event
 mcx claude log <session> [--last N]            # view session transcript
 mcx claude interrupt <session>                 # interrupt current turn
-mcx claude bye <session>                       # end session (alias: quit)
+mcx claude bye <session>                       # end session, keep worktree (alias: quit)
+mcx claude bye <session> --clean               # end session + remove worktree + delete branch
 mcx claude resume <worktree-or-branch>         # reattach to orphaned worktree session
 mcx claude resume --all                        # resume all orphaned worktree sessions
 mcx claude worktrees                           # list mcx-created worktrees (alias: wt)
@@ -353,7 +354,7 @@ mcx pr merge <pr> --auto --wait              # arm auto-merge + block until MERG
 mcx pr merge <pr> --auto --wait --timeout <ms>
 ```
 
-`mcx pr merge` never deletes local branches — use `mcx claude bye` or `mcx gc` for worktree/branch cleanup once a PR is merged.
+`mcx pr merge` never deletes local branches — use `mcx claude bye --clean` or `mcx gc` for worktree/branch cleanup once a PR is merged. A plain `mcx claude bye` ends the session only and leaves the worktree and branch in place for inspection.
 
 ### Virtual Filesystem
 

--- a/packages/command/src/commands/agent.spec.ts
+++ b/packages/command/src/commands/agent.spec.ts
@@ -1671,7 +1671,20 @@ describe("agent codex send --wait", () => {
 // ── Bye with cwd ──
 
 describe("agent bye with worktree", () => {
-  test("calls cleanupWorktree when cwd is returned", async () => {
+  test("--clean calls cleanupWorktree when cwd is returned", async () => {
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "codex_session_list") return toolResult(SESSION_LIST);
+        return toolResult({ ended: true, worktree: "my-wt", cwd: "/repo/.claude/worktrees/my-wt", repoRoot: "/repo" });
+      }),
+      exec: mock(() => ({ stdout: "", stderr: "", exitCode: 0 })),
+    });
+    await cmdAgent(["codex", "bye", "abc12345", "--clean"], deps);
+    expect(deps.callTool).toHaveBeenCalledWith("codex_bye", { sessionId: SESSION_LIST[0].sessionId });
+    expect(deps.exec).toHaveBeenCalled();
+  });
+
+  test("keeps the worktree by default", async () => {
     const deps = makeDeps({
       callTool: mock(async (tool: string) => {
         if (tool === "codex_session_list") return toolResult(SESSION_LIST);
@@ -1680,7 +1693,21 @@ describe("agent bye with worktree", () => {
       exec: mock(() => ({ stdout: "", stderr: "", exitCode: 0 })),
     });
     await cmdAgent(["codex", "bye", "abc12345"], deps);
+    expect(deps.exec).not.toHaveBeenCalled();
+    expect(deps.printInfo).toHaveBeenCalledWith(expect.stringContaining("Worktree preserved"));
+  });
+
+  test("--clean before session id is not treated as session prefix", async () => {
+    const deps = makeDeps({
+      callTool: mock(async (tool: string) => {
+        if (tool === "codex_session_list") return toolResult(SESSION_LIST);
+        return toolResult({ ended: true, worktree: "my-wt", cwd: "/repo/.claude/worktrees/my-wt", repoRoot: "/repo" });
+      }),
+      exec: mock(() => ({ stdout: "", stderr: "", exitCode: 0 })),
+    });
+    await cmdAgent(["codex", "bye", "--clean", "abc12345"], deps);
     expect(deps.callTool).toHaveBeenCalledWith("codex_bye", { sessionId: SESSION_LIST[0].sessionId });
+    expect(deps.exec).toHaveBeenCalled();
   });
 
   test("bye missing session prefix errors", async () => {
@@ -2142,7 +2169,7 @@ describe("agent claude bye with worktree and no cwd", () => {
       getCwd: mock(() => "/fake/repo"),
       exec: mock(() => ({ stdout: "", stderr: "", exitCode: 0 })),
     });
-    await cmdAgent(["claude", "bye", "abc12345"], deps);
+    await cmdAgent(["claude", "bye", "abc12345", "--clean"], deps);
     // cleanupWorktree is called (exec runs git worktree remove)
     expect(deps.callTool).toHaveBeenCalledWith("claude_bye", { sessionId: SESSION_LIST[0].sessionId });
   });

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -896,12 +896,12 @@ async function agentSend(args: string[], provider: AgentProvider, d: AgentDeps):
 
 async function agentBye(args: string[], provider: AgentProvider, d: AgentDeps): Promise<void> {
   const P = provider.toolPrefix;
-  const keepWorktree = args.includes("--keep") || args.includes("--keep-worktree");
+  const clean = args.includes("--clean");
   const positional = args.filter((a) => !a.startsWith("-"));
   const sessionPrefix = positional[0];
 
   if (!sessionPrefix) {
-    d.printError(`Usage: mcx agent ${provider.name} bye <session-id> [--keep|--keep-worktree]`);
+    d.printError(`Usage: mcx agent ${provider.name} bye <session-id> [--clean]`);
     d.exit(1);
   }
 
@@ -912,10 +912,11 @@ async function agentBye(args: string[], provider: AgentProvider, d: AgentDeps): 
   d.log(formatToolResult(result));
 
   if (byeResult.worktree) {
-    if (keepWorktree) {
+    if (!clean) {
       const wtPath =
         byeResult.cwd ?? resolveWorktreePath(d.getCwd(), byeResult.worktree, readWorktreeConfig(d.getCwd()));
       d.printInfo(`Worktree preserved: ${wtPath}`);
+      d.printInfo(`Reclaim with 'mcx agent ${provider.name} bye --clean' next time, or sweep later with 'mcx gc'.`);
     } else if (byeResult.cwd) {
       cleanupWorktree(byeResult.worktree, byeResult.cwd, d, byeResult.repoRoot);
     } else if (hasFeature(provider, "resume")) {

--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -2180,7 +2180,62 @@ describe("mcx claude bye", () => {
     await expect(cmdClaude(["bye"], deps)).rejects.toThrow(ExitError);
   });
 
-  test("--keep skips worktree cleanup and prints preserved path", async () => {
+  test("keeps the worktree by default and points at the reclaim paths", async () => {
+    const callTool: ClaudeDeps["callTool"] = mock(async (tool: string) => {
+      if (tool === "claude_session_list") return toolResult(SESSION_LIST);
+      return toolResult({ ended: true, worktree: "claude-abc123", cwd: "/repo" });
+    });
+    const exec: ClaudeDeps["exec"] = mock(() => ({ stdout: "", stderr: "", exitCode: 0 }));
+    const printInfo = mock(() => {});
+    const deps = makeDeps({ callTool, exec, printInfo });
+
+    const origLog = console.log;
+    console.log = mock(() => {});
+    try {
+      await cmdClaude(["bye", "def", "no flags"], deps);
+      expect(exec).not.toHaveBeenCalled();
+      const infoOutput = printInfo.mock.calls.map((c: unknown[]) => c[0]).join("\n");
+      expect(infoOutput).toContain("Worktree preserved:");
+      expect(infoOutput).toContain("/repo");
+      expect(infoOutput).toContain("--clean");
+      expect(infoOutput).toContain("mcx gc");
+    } finally {
+      console.log = origLog;
+    }
+  });
+
+  test("--all keeps worktrees by default and removes them with --clean", async () => {
+    const makeByeAllDeps = () => {
+      const callTool: ClaudeDeps["callTool"] = mock(async (tool: string) => {
+        if (tool === "claude_session_list") return toolResult([SESSION_LIST[0]]);
+        return toolResult({ ended: true, worktree: "claude-abc123", cwd: "/repo" });
+      });
+      const exec: ClaudeDeps["exec"] = mock(() => ({ stdout: "", stderr: "", exitCode: 0 }));
+      return { callTool, exec, deps: makeDeps({ callTool, exec }) };
+    };
+
+    const origLog = console.log;
+    const origErr = console.error;
+    console.log = mock(() => {});
+    console.error = mock(() => {});
+    try {
+      const kept = makeByeAllDeps();
+      await cmdClaude(["bye", "--all"], kept.deps);
+      expect(kept.exec).not.toHaveBeenCalled();
+
+      const cleaned = makeByeAllDeps();
+      await cmdClaude(["bye", "--all", "--clean"], cleaned.deps);
+      const removeCalls = (cleaned.exec as ReturnType<typeof mock>).mock.calls.filter((c: unknown[]) =>
+        (c[0] as string[]).includes("remove"),
+      );
+      expect(removeCalls.length).toBe(1);
+    } finally {
+      console.log = origLog;
+      console.error = origErr;
+    }
+  });
+
+  test("--keep is a no-op alias now that keeping is the default", async () => {
     const callTool: ClaudeDeps["callTool"] = mock(async (tool: string) => {
       if (tool === "claude_session_list") return toolResult(SESSION_LIST);
       return toolResult({ ended: true, worktree: "claude-abc123", cwd: "/repo" });
@@ -2209,7 +2264,7 @@ describe("mcx claude bye", () => {
     }
   });
 
-  test("--keep-worktree is an alias for --keep", async () => {
+  test("--keep-worktree is still accepted", async () => {
     const callTool: ClaudeDeps["callTool"] = mock(async (tool: string) => {
       if (tool === "claude_session_list") return toolResult(SESSION_LIST);
       return toolResult({ ended: true, worktree: "claude-abc123", cwd: "/repo" });
@@ -2235,7 +2290,7 @@ describe("mcx claude bye", () => {
     }
   });
 
-  test("removes clean worktree after bye", async () => {
+  test("--clean removes clean worktree after bye", async () => {
     const callTool: ClaudeDeps["callTool"] = mock(async (tool: string) => {
       if (tool === "claude_session_list") return toolResult(SESSION_LIST);
       return toolResult({ ended: true, worktree: "claude-abc123", cwd: "/repo" });
@@ -2251,7 +2306,7 @@ describe("mcx claude bye", () => {
     const origLog = console.log;
     console.log = mock(() => {});
     try {
-      await cmdClaude(["bye", "def"], deps);
+      await cmdClaude(["bye", "def", "--clean"], deps);
       // Should call git worktree remove
       const removeCalls = (exec as ReturnType<typeof mock>).mock.calls.filter((c: unknown[]) =>
         (c[0] as string[]).includes("remove"),
@@ -2283,7 +2338,7 @@ describe("mcx claude bye", () => {
     const origLog = console.log;
     console.log = mock(() => {});
     try {
-      await cmdClaude(["bye", "def"], deps);
+      await cmdClaude(["bye", "def", "--clean"], deps);
       // Should still attempt cleanup by resolving cwd from process.cwd()
       const removeCalls = (exec as ReturnType<typeof mock>).mock.calls.filter((c: unknown[]) =>
         (c[0] as string[]).includes("remove"),
@@ -2298,7 +2353,7 @@ describe("mcx claude bye", () => {
     }
   });
 
-  test("warns about dirty worktree after bye", async () => {
+  test("--clean refuses to remove a dirty worktree and warns", async () => {
     const callTool: ClaudeDeps["callTool"] = mock(async (tool: string) => {
       if (tool === "claude_session_list") return toolResult(SESSION_LIST);
       return toolResult({ ended: true, worktree: "claude-abc123", cwd: "/repo" });
@@ -2313,7 +2368,7 @@ describe("mcx claude bye", () => {
     const origLog = console.log;
     console.log = mock(() => {});
     try {
-      await cmdClaude(["bye", "def"], deps);
+      await cmdClaude(["bye", "def", "--clean"], deps);
       // Should NOT call git worktree remove
       const removeCalls = (exec as ReturnType<typeof mock>).mock.calls.filter((c: unknown[]) =>
         (c[0] as string[]).includes("remove"),
@@ -2359,7 +2414,7 @@ describe("mcx claude bye", () => {
     const origLog = console.log;
     console.log = mock(() => {});
     try {
-      await cmdClaude(["bye", "def", "worktree gone test"], deps);
+      await cmdClaude(["bye", "def", "worktree gone test", "--clean"], deps);
       // Should call git status but not git worktree remove
       expect(exec).toHaveBeenCalledTimes(1);
       expect((exec as ReturnType<typeof mock>).mock.calls[0][0]).toContain("status");
@@ -2389,7 +2444,7 @@ describe("mcx claude bye", () => {
     const origLog = console.log;
     console.log = mock(() => {});
     try {
-      await cmdClaude(["bye", "def"], deps);
+      await cmdClaude(["bye", "def", "--clean"], deps);
       // Directory doesn't exist on disk → verified removed regardless of exit code
       const infoOutput = printInfo.mock.calls.map((c: unknown[]) => c[0]).join("\n");
       expect(infoOutput).toContain("Removed worktree:");
@@ -2409,7 +2464,7 @@ describe("mcx claude bye", () => {
     const origLog = console.log;
     console.log = mock(() => {});
     try {
-      await cmdClaude(["bye", "def"], deps);
+      await cmdClaude(["bye", "def", "--clean"], deps);
       // exec should never be called — path traversal blocked
       expect(exec).not.toHaveBeenCalled();
     } finally {
@@ -3992,7 +4047,7 @@ describe("mcx claude bye branch cleanup", () => {
     const origLog = console.log;
     console.log = mock(() => {});
     try {
-      await cmdClaude(["bye", "def"], deps);
+      await cmdClaude(["bye", "def", "--clean"], deps);
       // Should have called branch -d
       const branchCalls = (exec as ReturnType<typeof mock>).mock.calls.filter((c: unknown[]) =>
         (c[0] as string[]).includes("-d"),
@@ -4025,7 +4080,7 @@ describe("mcx claude bye branch cleanup", () => {
     const origLog = console.log;
     console.log = mock(() => {});
     try {
-      await cmdClaude(["bye", "def"], deps);
+      await cmdClaude(["bye", "def", "--clean"], deps);
       const infoOutput = printInfo.mock.calls.map((c: unknown[]) => c[0]).join("\n");
       expect(infoOutput).toContain("Removed worktree:");
       expect(infoOutput).not.toContain("Deleted branch:");
@@ -4051,7 +4106,7 @@ describe("mcx claude bye branch cleanup", () => {
     const origLog = console.log;
     console.log = mock(() => {});
     try {
-      await cmdClaude(["bye", "def"], deps);
+      await cmdClaude(["bye", "def", "--clean"], deps);
       // Should NOT call git branch -d
       const branchCalls = (exec as ReturnType<typeof mock>).mock.calls.filter((c: unknown[]) =>
         (c[0] as string[]).includes("-d"),

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -1282,19 +1282,19 @@ async function claudeSend(args: string[], d: ClaudeDeps): Promise<void> {
 }
 
 async function claudeBye(args: string[], d: ClaudeDeps): Promise<void> {
-  const keepWorktree = args.includes("--keep") || args.includes("--keep-worktree");
+  const clean = args.includes("--clean");
   const showAll = args.includes("--all") || args.includes("-a");
   const positional = args.filter((a) => !a.startsWith("-"));
   const sessionPrefix = positional[0];
 
   // --all: end all sessions in scope (or all sessions if unscoped)
   if (showAll) {
-    await claudeByeAll(args, d, keepWorktree);
+    await claudeByeAll(args, d, clean);
     return;
   }
 
   if (!sessionPrefix) {
-    d.printError('Usage: mcx claude bye <session-id> "<message>" [--keep|--keep-worktree] [--all]');
+    d.printError('Usage: mcx claude bye <session-id> "<message>" [--clean] [--all]');
     d.exit(1);
   }
 
@@ -1313,9 +1313,10 @@ async function claudeBye(args: string[], d: ClaudeDeps): Promise<void> {
   console.log(formatToolResult(result));
 
   if (byeResult.worktree) {
-    if (keepWorktree) {
+    if (!clean) {
       const wtPath = byeResult.cwd ?? resolveKeptWorktreePath(byeResult);
       d.printInfo(`Worktree preserved: ${wtPath}`);
+      d.printInfo("Reclaim with 'mcx claude bye --clean' next time, or sweep later with 'mcx gc'.");
     } else if (byeResult.cwd) {
       cleanupWorktree(byeResult.worktree, byeResult.cwd, d, byeResult.repoRoot);
     } else {
@@ -1329,7 +1330,7 @@ async function claudeBye(args: string[], d: ClaudeDeps): Promise<void> {
 }
 
 /** End all sessions in the detected scope (or all sessions if unscoped). */
-async function claudeByeAll(args: string[], d: ClaudeDeps, keepWorktree: boolean): Promise<void> {
+async function claudeByeAll(args: string[], d: ClaudeDeps, clean: boolean): Promise<void> {
   // List sessions with scope filtering
   const toolArgs: Record<string, unknown> = {};
   const bypassScope = args.includes("--all") && !args.includes("--scoped");
@@ -1367,7 +1368,7 @@ async function claudeByeAll(args: string[], d: ClaudeDeps, keepWorktree: boolean
       const id = s.sessionId.slice(0, 8);
       console.error(`  ${id} ended`);
 
-      if (byeResult.worktree && !keepWorktree) {
+      if (byeResult.worktree && clean) {
         if (byeResult.cwd) {
           cleanupWorktree(byeResult.worktree, byeResult.cwd, d, byeResult.repoRoot);
         } else {

--- a/packages/command/src/help-claude.ts
+++ b/packages/command/src/help-claude.ts
@@ -74,10 +74,11 @@ registerHelp("claude send", {
 
 registerHelp("claude bye", {
   name: "mcx claude bye",
-  summary: "End a session and stop the process",
-  usage: ['mcx claude bye <session> "wrap up"', "mcx claude bye --all", "mcx claude bye <session> --keep-worktree"],
+  summary: "End a session and stop the process (worktree is kept by default)",
+  usage: ['mcx claude bye <session> "wrap up"', "mcx claude bye --all", "mcx claude bye <session> --clean"],
   options: [
-    ["--keep, --keep-worktree", "Preserve worktree after session ends"],
+    ["--clean", "Also remove the worktree and delete its branch"],
+    ["--keep, --keep-worktree", "No-op: keeping the worktree is the default"],
     ["--all, -a", "End all sessions in scope"],
   ],
 });


### PR DESCRIPTION
## Summary

- `mcx claude bye <id>` (and `mcx agent <provider> bye`) now **ends the session only** — the worktree and its branch stay in place. `--clean` opts into the old behavior (end + remove worktree + delete branch).
- `--keep` / `--keep-worktree` remain **accepted no-ops** (keeping is now the default), so phase scripts and orchestrator prose that still pass them do not break on merge.
- The default path prints the preserved worktree path plus the two reclaim routes (`--clean` next time, or `mcx gc`).
- `--all` honors the same default: batch bye keeps every worktree unless `--clean` is passed.

**Why:** a plain `bye` deleted the local branch, which silently broke the
impl→review→repair→QA handoff — the successor phase cannot check out a branch
bye just deleted. Keeping state makes the safe path the default one.

## Prerequisite state (re-read per the scoping note)

Both blockers landed, and their shape narrowed this change to the CLI:

- **#1748** (gc can delete squash-merged branches) plus **#2662 / PR #2873** (gc reclaims squash-merged *and* closed-PR **worktrees** via PR state) mean the "gc sweeps later" assumption now holds for worktrees, not just branches.
- **#1749** — `removeWorktreeWithVerification` in `packages/core/src/worktree-shim.ts` verifies removal, so "Removed worktree" is no longer a lie in either path.
- **#2836 / PR #2856** already made removal idempotent, so the only work left was the default flip itself.
- Worktree removal happens **entirely in the CLI** (`claudeBye` / `agentBye`); `claude_bye` on the daemon only returns `{worktree, cwd, repoRoot}`. So the `bye-and-untrack` automation action is **unaffected** by this flip.

## Constraints honored

- `--clean` keeps the existing refusal to remove a worktree with uncommitted work. No `git worktree remove --force` anywhere.
- Worktree removal and branch deletion stay separate decisions — not re-coupled.

## Accumulation / reclaim story (interaction with #2928)

This flip **accelerates** worktree accumulation: previously every bye attempted
removal, now none do unless asked. At sprint 42's peak of 17 concurrent
sessions that is ~17 worktrees held until wind-down instead of freed
incrementally, on top of the ~48 stale worktrees this repo already carries
(**#2928**). Reclaim now rests entirely on `mcx gc`, which post-#1748/#2662 can
sweep squash-merged and closed-PR worktrees by PR state. Solving the existing
backlog is #2928's job, not this PR's — stating the interaction so it is not
discovered later.

## Not touched (meta files — flagged, not edited)

Per project policy `.claude/skills/**` and `.claude/phases/**` are
orchestrator/retro-only, so two now-stale references are left for the
orchestrator rather than edited here. Neither *breaks* — both keep working, they
just describe the old default:

- `.claude/skills/sprint/references/run.md` — `bye` guidance / `--keep-worktree` usages
- `.claude/phases/repair.ts:9` ("`--worktree` if the impl worktree was auto-cleaned by `bye`") and `.claude/phases/done-fn.ts:149` ("bye impl session to prune")

## Test plan

- [x] `mcx claude bye` with a worktree: no `git` exec, prints `Worktree preserved:` + `--clean` / `mcx gc` hints
- [x] `mcx claude bye --clean`: removes worktree, deletes merged branch, refuses on dirty worktree, blocks path traversal, handles null-cwd daemon worktrees
- [x] `mcx claude bye --all` keeps by default, removes with `--clean`
- [x] `--keep` / `--keep-worktree` still accepted (no-op) in both `claude` and `agent` surfaces
- [x] `--clean` before *and* after the session id is not mistaken for a session prefix
- [x] `bun run am-i-done` full gate: **exit 0**, 11/11 steps (run under the host-wide gate lock at load 7; an earlier run at load 17 produced a 98-failure `worker panicked` cascade — the two non-cascade signals, `acp-session.spec.ts` and `close-timeout.spec.ts`, both pass in isolation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)