### PR TITLE
feat(gate-lease): load-aware admission + core-derived slot count (fixes #2690)

### DIFF
--- a/packages/core/src/gate-lease.spec.ts
+++ b/packages/core/src/gate-lease.spec.ts
@@ -150,47 +150,97 @@ describe("acquireGateLease at the default configuration (#2690)", () => {
     );
 
     expect(a.held).toBe(true);
-    expect(peerHeld).toEqual([false]);
+    // The peer never got to evaluate headroom — A held the decision mutex for the
+    // whole of the peer's budget, which is the ordering property under test.
     expect(peerWarnings.some((w) => w.includes("no admission token"))).toBe(true);
-
-    // Proof that slot 1 was free all along: it is acquirable now.
-    const b = track(await acquireGateLease({ lockDir, ...defaults({ slots: 2 }) }));
-    expect(b.slot).toBe(1);
+    // Having lost the token it still fails open onto the free slot 1 rather than
+    // running uncounted: the run that waited longest must not get the worse deal
+    // of the two fail-open paths (#2949 review, finding C).
+    expect(peerHeld).toEqual([true]);
+    expect(peerWarnings.some((w) => w.includes("proceeding on slot 1"))).toBe(true);
   });
 
-  it("settles before sampling when a peer holds a slot, and not when solo", async () => {
+  it("admits a solo run without sleeping on anything but the CPU sample", async () => {
     const soloDir = freshDir();
     const soloSleeps: number[] = [];
-    track(
+    const solo = track(
       await acquireGateLease({
         lockDir: soloDir,
-        ...defaults({ settleMs: 2000, sleep: async (ms) => void soloSleeps.push(ms) }),
+        ...defaults({ sleep: async (ms) => void soloSleeps.push(ms) }),
       }),
     );
-    expect(soloSleeps).toEqual([]); // default config, common case: pays nothing
+    expect(solo.held).toBe(true);
+    // The common case pays no settle, no poll and no queue.
+    expect(soloSleeps).toEqual([]);
+  });
 
-    // `slots: 2` again non-default: the peer must hold a slot while this run is
-    // still able to be admitted, which K=1 cannot express.
-    const busyDir = freshDir();
-    track(await acquireGateLease({ lockDir: busyDir, ...defaults({ slots: 2 }) }));
-    const peerSleeps: number[] = [];
-    let ticks = 0;
-    const second = track(
+  it("jitters each process's fail-open deadline downward so losers don't release in lockstep", async () => {
+    // Same waitMs, a different jitter draw per process => a different effective
+    // budget each, so N co-launched losers scatter instead of all failing open
+    // within one poll of each other.
+    const budgets: number[] = [];
+    for (const draw of [0, 0.5, 1]) {
+      const lockDir = freshDir();
+      let ticks = 0;
+      const warnings: string[] = [];
+      track(
+        await acquireGateLease({
+          lockDir,
+          ...defaults({
+            waitMs: 100_000,
+            random: () => draw,
+            cpuBusy: () => 0.99, // never clears, so the budget is always spent
+            now: () => ticks,
+            sleep: async (ms) => {
+              ticks += ms;
+            },
+            logger: { warn: (m) => warnings.push(m) },
+          }),
+        }),
+      );
+      const m = warnings.join("\n").match(/no admission within (\d+)ms/);
+      expect(m).not.toBeNull();
+      budgets.push(Number(m?.[1]));
+    }
+
+    // Downward only: never above the configured budget (the 600s worker-timeout
+    // arithmetic depends on that), never below 75% of it.
+    for (const b of budgets) {
+      expect(b).toBeLessThanOrEqual(100_000);
+      expect(b).toBeGreaterThanOrEqual(75_000);
+    }
+    // And genuinely spread, so the fail-opens don't convoy.
+    expect(new Set(budgets).size).toBe(3);
+    expect(Math.max(...budgets) - Math.min(...budgets)).toBeGreaterThan(20_000);
+  });
+
+  it("never fails the run it wraps, even when the CPU signal throws mid-decision", async () => {
+    const lockDir = freshDir();
+    const warnings: string[] = [];
+    const lease = track(
       await acquireGateLease({
-        lockDir: busyDir,
+        lockDir,
         ...defaults({
-          slots: 2,
-          settleMs: 2000,
-          now: () => ticks,
-          sleep: async (ms) => {
-            ticks += ms;
-            peerSleeps.push(ms);
+          cpuBusy: () => {
+            throw new Error("sampler exploded");
           },
+          logger: { warn: (m) => warnings.push(m) },
         }),
       }),
     );
-    expect(second.held).toBe(true);
-    expect(peerSleeps).toEqual([2000]); // settled once, then admitted
+
+    // Fail-open, not a throw: an admission bug must never become a phantom gate
+    // failure (#2690).
+    expect(lease.held).toBe(false);
+    expect(warnings.some((w) => w.includes("admission failed unexpectedly") && w.includes("sampler exploded"))).toBe(
+      true,
+    );
+
+    // And the slot it held when the sampler threw was not stranded — there is no
+    // reaper to clean that up, so the throwing frame has to release it.
+    const next = track(await acquireGateLease({ lockDir, ...defaults() }));
+    expect(next.held).toBe(true);
+    expect(next.slot).toBe(0);
   });
 
   it("charges one whole-run budget, and fails open onto a free slot when it expires", async () => {
@@ -355,5 +405,59 @@ describe("gate-lease env tuning", () => {
     const lease = await acquireGateLease({ lockDir, ...opts, logger: { warn: (m) => warnings.push(m) } });
     expect(lease.held).toBe(false);
     expect(warnings.some((w) => w.includes("no admission within 700ms"))).toBe(true);
+  });
+
+  it("rejects a MCX_GATE_LEASE_WAIT_MS with units instead of reading it as milliseconds", async () => {
+    // "120s" through a bare parseInt is 120 — a 120ms budget, i.e. the gate
+    // silently off. It has to be refused loudly, like the slots reader does.
+    const lockDir = freshDir();
+    const blocker = track(await acquireGateLease({ lockDir, ...defaults() }));
+    expect(blocker.held).toBe(true);
+
+    const opts = defaults();
+    process.env.MCX_GATE_LEASE_WAIT_MS = "120s";
+    const warnings: string[] = [];
+    let ticks = 0;
+    const lease = await acquireGateLease({
+      lockDir,
+      ...opts,
+      now: () => ticks,
+      sleep: async (ms) => {
+        ticks += ms;
+      },
+      logger: { warn: (m) => warnings.push(m) },
+    });
+
+    expect(warnings.some((w) => w.includes('MCX_GATE_LEASE_WAIT_MS="120s"') && w.includes("not an integer"))).toBe(
+      true,
+    );
+    // Fell back to the 300s default rather than a 120ms non-wait.
+    expect(lease.held).toBe(false);
+    expect(ticks).toBeGreaterThan(200_000);
+  });
+
+  it("caps MCX_GATE_LEASE_WAIT_MS so the wait plus the run it admits cannot breach the 600s worker timeout", async () => {
+    const lockDir = freshDir();
+    const blocker = track(await acquireGateLease({ lockDir, ...defaults() }));
+    expect(blocker.held).toBe(true);
+
+    const opts = defaults();
+    process.env.MCX_GATE_LEASE_WAIT_MS = String(15 * 60 * 1000);
+    const warnings: string[] = [];
+    let ticks = 0;
+    const lease = await acquireGateLease({
+      lockDir,
+      ...opts,
+      now: () => ticks,
+      sleep: async (ms) => {
+        ticks += ms;
+      },
+      logger: { warn: (m) => warnings.push(m) },
+    });
+
+    expect(warnings.some((w) => w.includes("exceeds max 400000ms") && w.includes("600s worker timeout"))).toBe(true);
+    expect(lease.held).toBe(false);
+    // Capped: it waited the 400s max, not the 15 minutes requested.
+    expect(ticks).toBeLessThanOrEqual(400_000 + 1000);
   });
 });

--- a/packages/core/src/gate-lease.spec.ts
+++ b/packages/core/src/gate-lease.spec.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { acquireGateLease, withGateLease } from "./gate-lease";
+import { type GateLeaseOptions, acquireGateLease, withGateLease } from "./gate-lease";
 
 const dirs: string[] = [];
 function freshDir(): string {
@@ -12,21 +12,33 @@ function freshDir(): string {
   return d;
 }
 
-const savedSlotsEnv = process.env.MCX_GATE_LEASE_SLOTS;
+const TUNING_VARS = ["MCX_GATE_LEASE_SLOTS", "MCX_GATE_LEASE_MAX_LOAD", "MCX_GATE_LEASE_LOAD_WAIT_MS"] as const;
+const savedEnv = new Map(TUNING_VARS.map((k) => [k, process.env[k]]));
+
+/** Clear the tuning vars so an ambient value can't steer a defaults test. */
+function clearTuningEnv(): void {
+  for (const k of TUNING_VARS) {
+    delete process.env[k];
+  }
+}
+
 afterEach(() => {
   while (dirs.length) {
     const d = dirs.pop();
     if (d) rmSync(d, { recursive: true, force: true });
   }
-  if (savedSlotsEnv === undefined) {
-    // biome-ignore lint/performance/noDelete: env var must be absent, not "undefined"
-    delete process.env.MCX_GATE_LEASE_SLOTS;
-  } else {
-    process.env.MCX_GATE_LEASE_SLOTS = savedSlotsEnv;
+  for (const [k, v] of savedEnv) {
+    if (v === undefined) {
+      delete process.env[k];
+    } else {
+      process.env[k] = v;
+    }
   }
 });
 
-const noWait = { sleep: () => Promise.resolve(), random: () => 0 };
+// maxLoad: 0 disables the load-headroom stage — these cases exercise slot
+// admission only, and the real host load would otherwise steer them.
+const noWait = { sleep: () => Promise.resolve(), random: () => 0, maxLoad: 0 };
 
 describe("acquireGateLease", () => {
   it("acquires a slot when one is free", async () => {
@@ -170,6 +182,242 @@ describe("MCX_GATE_LEASE_SLOTS validation", () => {
     expect(lease.held).toBe(false);
     expect(lease.slot).toBeNull();
     expect(warnings.some((w) => w.includes("disables the gate"))).toBe(true);
+  });
+});
+
+// A lease whose slot wait fails open immediately: drives the injected clock past
+// the deadline on the first poll.
+function failFastSlotWait(lockDir: string, extra: GateLeaseOptions = {}) {
+  let ticks = 0;
+  return acquireGateLease({
+    lockDir,
+    timeoutMs: 500,
+    now: () => ticks,
+    sleep: async () => {
+      ticks += 1000;
+    },
+    random: () => 0,
+    maxLoad: 0,
+    ...extra,
+  });
+}
+
+describe("default slot count derived from core count (#2690)", () => {
+  it("allows 1 concurrent run on an 8-core host", async () => {
+    clearTuningEnv();
+    const lockDir = freshDir();
+    const a = await acquireGateLease({ lockDir, cpuCount: () => 8, ...noWait });
+    expect(a.held).toBe(true);
+
+    const b = await failFastSlotWait(lockDir, { cpuCount: () => 8 });
+    expect(b.held).toBe(false);
+    a.release();
+  });
+
+  it("allows 2 — not the issue's cores/4 = 4 — on a 16-core host", async () => {
+    clearTuningEnv();
+    const lockDir = freshDir();
+    const cpuCount = () => 16;
+    const a = await acquireGateLease({ lockDir, cpuCount, ...noWait });
+    const b = await acquireGateLease({ lockDir, cpuCount, ...noWait });
+    expect([a.held, b.held]).toEqual([true, true]);
+
+    // The third must be refused. cores/4 would have admitted a third and fourth,
+    // which is the regime the field data shows failing.
+    const c = await failFastSlotWait(lockDir, { cpuCount });
+    expect(c.held).toBe(false);
+    a.release();
+    b.release();
+  });
+
+  it("never derives 0 slots on a single-core host", async () => {
+    clearTuningEnv();
+    const lockDir = freshDir();
+    const a = await acquireGateLease({ lockDir, cpuCount: () => 1, ...noWait });
+    expect(a.held).toBe(true);
+    a.release();
+  });
+});
+
+describe("load-headroom admission (#2690)", () => {
+  it("holds the slot while load is too high, then admits when it falls", async () => {
+    const lockDir = freshDir();
+    const loads = [20, 20, 5];
+    let i = 0;
+    let ticks = 0;
+    const warnings: string[] = [];
+    const lease = await acquireGateLease({
+      lockDir,
+      slots: 1,
+      maxLoad: 10,
+      loadWaitMs: 60_000,
+      now: () => ticks,
+      sleep: async () => {
+        ticks += 100;
+      },
+      random: () => 0,
+      loadAvg: () => loads[Math.min(i++, loads.length - 1)] as number,
+      logger: { warn: (m) => warnings.push(m) },
+    });
+
+    expect(lease.held).toBe(true);
+    expect(lease.slot).toBe(0);
+    expect(warnings.some((w) => w.includes("holding slot 0, waiting for host load"))).toBe(true);
+    expect(warnings.some((w) => w.includes("admitted after waiting"))).toBe(true);
+    lease.release();
+  });
+
+  it("keeps the slot held while waiting, so a peer cannot start meanwhile", async () => {
+    const lockDir = freshDir();
+    const probes: boolean[] = [];
+    let ticks = 0;
+    let load = 50;
+    const lease = await acquireGateLease({
+      lockDir,
+      slots: 1,
+      maxLoad: 10,
+      loadWaitMs: 60_000,
+      now: () => ticks,
+      sleep: async () => {
+        ticks += 100;
+        // Mid-load-wait: a peer must find the only slot already taken. This is
+        // what prevents the convoy — the waiter owns the slot while it waits.
+        if (probes.length === 0) {
+          probes.push((await failFastSlotWait(lockDir, { slots: 1 })).held);
+          load = 1; // let the original proceed on the next poll
+        }
+      },
+      random: () => 0,
+      loadAvg: () => load,
+    });
+
+    expect(probes).toEqual([false]);
+    expect(lease.held).toBe(true);
+    lease.release();
+  });
+
+  it("fails open after the load-wait deadline and still holds the slot", async () => {
+    const lockDir = freshDir();
+    let ticks = 0;
+    const warnings: string[] = [];
+    const lease = await acquireGateLease({
+      lockDir,
+      slots: 1,
+      maxLoad: 10,
+      loadWaitMs: 500,
+      now: () => ticks,
+      sleep: async () => {
+        ticks += 1000; // blow past the load deadline on the first poll
+      },
+      random: () => 0,
+      loadAvg: () => 99,
+      logger: { warn: (m) => warnings.push(m) },
+    });
+
+    expect(lease.held).toBe(true);
+    expect(warnings.some((w) => w.includes("still above") && w.includes("fail-open"))).toBe(true);
+    lease.release();
+  });
+
+  it("defaults the ceiling to 0.75 x cores", async () => {
+    clearTuningEnv();
+    const cpuCount = () => 16; // ceiling = 12
+
+    const belowDir = freshDir();
+    const belowWarnings: string[] = [];
+    const below = await acquireGateLease({
+      lockDir: belowDir,
+      slots: 1,
+      cpuCount,
+      loadAvg: () => 11.9,
+      sleep: () => Promise.resolve(),
+      random: () => 0,
+      logger: { warn: (m) => belowWarnings.push(m) },
+    });
+    expect(below.held).toBe(true);
+    expect(belowWarnings.some((w) => w.includes("waiting for host load"))).toBe(false);
+    below.release();
+
+    const aboveDir = freshDir();
+    const aboveWarnings: string[] = [];
+    let ticks = 0;
+    const above = await acquireGateLease({
+      lockDir: aboveDir,
+      slots: 1,
+      cpuCount,
+      loadAvg: () => 12.1,
+      loadWaitMs: 500,
+      now: () => ticks,
+      sleep: async () => {
+        ticks += 1000;
+      },
+      random: () => 0,
+      logger: { warn: (m) => aboveWarnings.push(m) },
+    });
+    expect(aboveWarnings.some((w) => w.includes("waiting for host load"))).toBe(true);
+    above.release();
+  });
+});
+
+describe("load-wait env overrides (#2690)", () => {
+  it("skips the load wait entirely when MCX_GATE_LEASE_MAX_LOAD is 0", async () => {
+    clearTuningEnv();
+    process.env.MCX_GATE_LEASE_MAX_LOAD = "0";
+    const lockDir = freshDir();
+    const warnings: string[] = [];
+    const lease = await acquireGateLease({
+      lockDir,
+      slots: 1,
+      loadAvg: () => 999,
+      sleep: () => Promise.resolve(),
+      random: () => 0,
+      logger: { warn: (m) => warnings.push(m) },
+    });
+    expect(lease.held).toBe(true);
+    expect(warnings.some((w) => w.includes("disables the load wait"))).toBe(true);
+    lease.release();
+  });
+
+  it("warns and falls back to the default for a non-numeric MCX_GATE_LEASE_MAX_LOAD", async () => {
+    clearTuningEnv();
+    process.env.MCX_GATE_LEASE_MAX_LOAD = "high";
+    const lockDir = freshDir();
+    const warnings: string[] = [];
+    const lease = await acquireGateLease({
+      lockDir,
+      slots: 1,
+      cpuCount: () => 16,
+      loadAvg: () => 1,
+      sleep: () => Promise.resolve(),
+      random: () => 0,
+      logger: { warn: (m) => warnings.push(m) },
+    });
+    expect(lease.held).toBe(true);
+    expect(warnings.some((w) => w.includes("is not a number"))).toBe(true);
+    lease.release();
+  });
+
+  it("honours MCX_GATE_LEASE_LOAD_WAIT_MS as the fail-open bound", async () => {
+    clearTuningEnv();
+    process.env.MCX_GATE_LEASE_LOAD_WAIT_MS = "1";
+    const lockDir = freshDir();
+    const warnings: string[] = [];
+    let ticks = 0;
+    const lease = await acquireGateLease({
+      lockDir,
+      slots: 1,
+      maxLoad: 10,
+      now: () => ticks,
+      sleep: async () => {
+        ticks += 5; // trips the 1ms bound, far short of the 5min default
+      },
+      random: () => 0,
+      loadAvg: () => 99,
+      logger: { warn: (m) => warnings.push(m) },
+    });
+    expect(lease.held).toBe(true);
+    expect(warnings.some((w) => w.includes("after 1ms") && w.includes("fail-open"))).toBe(true);
+    lease.release();
   });
 });
 

--- a/packages/core/src/gate-lease.spec.ts
+++ b/packages/core/src/gate-lease.spec.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { type GateLeaseOptions, acquireGateLease, withGateLease } from "./gate-lease";
+import { type GateLease, type GateLeaseOptions, acquireGateLease } from "./gate-lease";
 
 const dirs: string[] = [];
 function freshDir(): string {
@@ -12,7 +12,7 @@ function freshDir(): string {
   return d;
 }
 
-const TUNING_VARS = ["MCX_GATE_LEASE_SLOTS", "MCX_GATE_LEASE_MAX_LOAD", "MCX_GATE_LEASE_LOAD_WAIT_MS"] as const;
+const TUNING_VARS = ["MCX_GATE_LEASE_SLOTS", "MCX_GATE_LEASE_MAX_BUSY", "MCX_GATE_LEASE_WAIT_MS"] as const;
 const savedEnv = new Map(TUNING_VARS.map((k) => [k, process.env[k]]));
 
 /** Clear the tuning vars so an ambient value can't steer a defaults test. */
@@ -22,7 +22,15 @@ function clearTuningEnv(): void {
   }
 }
 
+const leases: GateLease[] = [];
+/** Track leases so a failing assertion can't strand a flock into the next test. */
+function track(lease: GateLease): GateLease {
+  leases.push(lease);
+  return lease;
+}
+
 afterEach(() => {
+  while (leases.length) leases.pop()?.release();
   while (dirs.length) {
     const d = dirs.pop();
     if (d) rmSync(d, { recursive: true, force: true });
@@ -36,85 +44,221 @@ afterEach(() => {
   }
 });
 
-// maxLoad: 0 disables the load-headroom stage — these cases exercise slot
-// admission only, and the real host load would otherwise steer them.
-const noWait = { sleep: () => Promise.resolve(), random: () => 0, maxLoad: 0 };
+/**
+ * The DEFAULT production configuration: slot count and busy ceiling both left at
+ * their defaults, never pinned. Only the *signal* and the clock are injected — a
+ * test that pins `slots` cannot say anything about the behaviour real runs get
+ * (the mistake called out in the #2949 review). Tests that need K > 1 to have a
+ * distinguishable free slot pass `slots` explicitly and say so.
+ */
+function defaults(overrides: GateLeaseOptions = {}): GateLeaseOptions {
+  clearTuningEnv();
+  let ticks = 0;
+  return {
+    cpuBusy: () => 0.1, // idle host; the ceiling itself stays at its default
+    now: () => ticks,
+    sleep: async (ms) => {
+      ticks += ms;
+    },
+    random: () => 0,
+    ...overrides,
+  };
+}
 
-describe("acquireGateLease", () => {
-  it("acquires a slot when one is free", async () => {
+describe("acquireGateLease at the default configuration (#2690)", () => {
+  it("admits immediately on an idle host", async () => {
     const lockDir = freshDir();
-    const lease = await acquireGateLease({ slots: 2, lockDir, ...noWait });
+    const infos: string[] = [];
+    const lease = track(await acquireGateLease({ lockDir, ...defaults({ logger: { info: (m) => infos.push(m) } }) }));
     expect(lease.held).toBe(true);
     expect(lease.slot).toBe(0);
-    lease.release();
+    expect(infos.some((m) => m.includes("admitted on slot 0") && m.includes("slots=1"))).toBe(true);
   });
 
-  it("allows K concurrent holders, blocks the K+1th until a release", async () => {
+  it("admits exactly one gate run at a time — not the issue's cores/4", async () => {
     const lockDir = freshDir();
-    const a = await acquireGateLease({ slots: 2, lockDir, ...noWait });
-    const b = await acquireGateLease({ slots: 2, lockDir, ...noWait });
+    const a = track(await acquireGateLease({ lockDir, ...defaults() }));
     expect(a.held).toBe(true);
-    expect(b.held).toBe(true);
-    expect(new Set([a.slot, b.slot]).size).toBe(2); // distinct slots
+    expect(a.slot).toBe(0);
 
-    // Third acquisition with both slots taken must wait. Drive a manual clock
-    // so it would fail-open quickly if it never got a slot, then free a slot
-    // mid-wait and confirm it acquires instead.
-    let ticks = 0;
-    let released = false;
+    // The second must be refused. `cores/4` would have admitted four on the
+    // 16-core reference host, which is the regime the field data shows failing.
     const warnings: string[] = [];
-    const c = await acquireGateLease({
-      slots: 2,
-      lockDir,
-      timeoutMs: 10_000,
-      now: () => ticks,
-      sleep: async () => {
-        ticks += 100;
-        if (!released) {
-          released = true;
-          a.release(); // free slot 0 after the first poll
-        }
-      },
-      random: () => 0,
-      logger: { warn: (m) => warnings.push(m) },
-    });
-    expect(c.held).toBe(true);
-    expect(c.slot).toBe(a.slot); // reused the freed slot
-    expect(warnings.some((w) => w.includes("queueing"))).toBe(true);
-    expect(warnings.some((w) => w.includes("acquired") && w.includes("after waiting"))).toBe(true);
-
-    b.release();
-    c.release();
-  });
-
-  it("fails open (unheld lease) when all slots stay busy past the deadline", async () => {
-    const lockDir = freshDir();
-    const a = await acquireGateLease({ slots: 1, lockDir, ...noWait });
-    expect(a.held).toBe(true);
-
-    const warnings: string[] = [];
-    let ticks = 0;
     const b = await acquireGateLease({
-      slots: 1,
       lockDir,
-      timeoutMs: 500,
-      now: () => ticks,
-      sleep: async () => {
-        ticks += 1000; // blow past the deadline on the first poll
-      },
-      random: () => 0,
-      logger: { warn: (m) => warnings.push(m) },
+      ...defaults({ waitMs: 1000, logger: { warn: (m) => warnings.push(m) } }),
     });
     expect(b.held).toBe(false);
-    expect(b.slot).toBeNull();
-    expect(warnings.some((w) => w.includes("fail-open"))).toBe(true);
-
-    a.release();
+    expect(warnings.some((w) => w.includes("for a free slot (all 1 busy)"))).toBe(true);
+    expect(warnings.some((w) => w.includes("proceeding unleased") && w.includes("fail-open"))).toBe(true);
   });
 
+  it("blocks a solo run on CPU headroom while the slot is free, then admits when it clears", async () => {
+    // Default configuration, no peer: slot 0 is free the whole time, so this
+    // isolates the headroom stage from the slot count.
+    const lockDir = freshDir();
+    const busy = [0.95, 0.95, 0.2];
+    let i = 0;
+    const warnings: string[] = [];
+    const b = track(
+      await acquireGateLease({
+        lockDir,
+        ...defaults({
+          waitMs: 60_000,
+          cpuBusy: () => busy[Math.min(i++, busy.length - 1)] as number,
+          logger: { warn: (m) => warnings.push(m) },
+        }),
+      }),
+    );
+
+    expect(b.held).toBe(true);
+    expect(b.slot).toBe(0);
+    expect(warnings.some((w) => w.includes("for cpu headroom") && w.includes("95% busy"))).toBe(true);
+    // Default ceiling is 0.6, so the message must report 60% — not a pinned value.
+    expect(warnings.some((w) => w.includes("need < 60%"))).toBe(true);
+    // A run that queued reports its admission at warn too, so the wait and its
+    // resolution both survive the am-i-done AI log (which is dropped on success).
+    expect(warnings.some((w) => w.includes("admitted on slot 0"))).toBe(true);
+  });
+
+  it("serializes admission decisions, so two runs never evaluate headroom at once", async () => {
+    // Guarantee 2. `slots: 2` is NOT the default — it is passed here precisely so
+    // a free slot exists during the nested probe, proving it is the admission
+    // token and not the slot count that keeps the peer out. At the default K=1
+    // the slot alone would refuse it and the test would prove nothing.
+    const lockDir = freshDir();
+    const peerHeld: boolean[] = [];
+    let peerWarnings: string[] = [];
+
+    const a = track(
+      await acquireGateLease({
+        lockDir,
+        ...defaults({
+          slots: 2,
+          cpuBusy: async () => {
+            peerWarnings = [];
+            const peer = await acquireGateLease({
+              lockDir,
+              ...defaults({ slots: 2, waitMs: 0, logger: { warn: (m) => peerWarnings.push(m) } }),
+            });
+            peerHeld.push(peer.held);
+            peer.release();
+            return 0.1;
+          },
+        }),
+      }),
+    );
+
+    expect(a.held).toBe(true);
+    expect(peerHeld).toEqual([false]);
+    expect(peerWarnings.some((w) => w.includes("no admission token"))).toBe(true);
+
+    // Proof that slot 1 was free all along: it is acquirable now.
+    const b = track(await acquireGateLease({ lockDir, ...defaults({ slots: 2 }) }));
+    expect(b.slot).toBe(1);
+  });
+
+  it("settles before sampling when a peer holds a slot, and not when solo", async () => {
+    const soloDir = freshDir();
+    const soloSleeps: number[] = [];
+    track(
+      await acquireGateLease({
+        lockDir: soloDir,
+        ...defaults({ settleMs: 2000, sleep: async (ms) => void soloSleeps.push(ms) }),
+      }),
+    );
+    expect(soloSleeps).toEqual([]); // default config, common case: pays nothing
+
+    // `slots: 2` again non-default: the peer must hold a slot while this run is
+    // still able to be admitted, which K=1 cannot express.
+    const busyDir = freshDir();
+    track(await acquireGateLease({ lockDir: busyDir, ...defaults({ slots: 2 }) }));
+    const peerSleeps: number[] = [];
+    let ticks = 0;
+    const second = track(
+      await acquireGateLease({
+        lockDir: busyDir,
+        ...defaults({
+          slots: 2,
+          settleMs: 2000,
+          now: () => ticks,
+          sleep: async (ms) => {
+            ticks += ms;
+            peerSleeps.push(ms);
+          },
+        }),
+      }),
+    );
+    expect(second.held).toBe(true);
+    expect(peerSleeps).toEqual([2000]); // settled once, then admitted
+  });
+
+  it("charges one whole-run budget, and fails open onto a free slot when it expires", async () => {
+    const lockDir = freshDir();
+    let ticks = 0;
+    const warnings: string[] = [];
+    const lease = track(
+      await acquireGateLease({
+        lockDir,
+        ...defaults({
+          waitMs: 5000,
+          cpuBusy: () => 0.99, // never clears
+          now: () => ticks,
+          sleep: async (ms) => {
+            ticks += ms;
+          },
+          logger: { warn: (m) => warnings.push(m) },
+        }),
+      }),
+    );
+
+    // Fail-open still prefers a slot over running uncounted.
+    expect(lease.held).toBe(true);
+    expect(warnings.some((w) => w.includes("no admission within 5000ms") && w.includes("on slot 0"))).toBe(true);
+    // Budget is whole-run: the wait stopped at the budget, it did not restart.
+    expect(ticks).toBeGreaterThanOrEqual(5000);
+    expect(ticks).toBeLessThan(6000);
+  });
+
+  it("re-announces a long wait with elapsed/remaining so it never reads as a wedge", async () => {
+    const lockDir = freshDir();
+    let ticks = 0;
+    const warnings: string[] = [];
+    track(
+      await acquireGateLease({
+        lockDir,
+        ...defaults({
+          waitMs: 90_000,
+          pollIntervalMs: 20_000, // 4 polls before the budget expires
+          cpuBusy: () => 0.99,
+          now: () => ticks,
+          sleep: async (ms) => {
+            ticks += ms;
+          },
+          logger: { warn: (m) => warnings.push(m) },
+        }),
+      }),
+    );
+    const waits = warnings.filter((w) => w.includes("for cpu headroom"));
+    expect(waits.length).toBeGreaterThan(1);
+    expect(waits[0]).toContain("before fail-open");
+    expect(waits[0]).toContain("slots=1 maxBusy=0.60");
+  });
+
+  it("samples real CPU when no signal is injected", async () => {
+    clearTuningEnv();
+    const lockDir = freshDir();
+    // No cpuBusy override: exercises the os.cpus() tick sampler for real. The
+    // ceiling is lifted above 1 so the assertion cannot depend on host load.
+    const lease = track(await acquireGateLease({ lockDir, maxBusy: 1.01, sampleMs: 5 }));
+    expect(lease.held).toBe(true);
+  });
+});
+
+describe("acquireGateLease edge cases", () => {
   it("is a no-op when slots <= 0 (disabled)", async () => {
     const lockDir = freshDir();
-    const lease = await acquireGateLease({ slots: 0, lockDir, ...noWait });
+    const lease = await acquireGateLease({ lockDir, ...defaults({ slots: 0 }) });
     expect(lease.held).toBe(false);
     expect(lease.slot).toBeNull();
     lease.release(); // must not throw
@@ -122,13 +266,13 @@ describe("acquireGateLease", () => {
 
   it("release is idempotent and frees the slot for re-acquisition", async () => {
     const lockDir = freshDir();
-    const a = await acquireGateLease({ slots: 1, lockDir, ...noWait });
+    const a = await acquireGateLease({ lockDir, ...defaults() });
     a.release();
     a.release(); // idempotent
 
-    const b = await acquireGateLease({ slots: 1, lockDir, ...noWait });
+    const b = track(await acquireGateLease({ lockDir, ...defaults() }));
     expect(b.held).toBe(true);
-    b.release();
+    expect(b.slot).toBe(0);
   });
 
   it("fails open with a warning when the lock dir cannot be created", async () => {
@@ -139,330 +283,77 @@ describe("acquireGateLease", () => {
     const lockDir = join(filePath, "gate-locks");
 
     const warnings: string[] = [];
-    const lease = await acquireGateLease({
-      slots: 2,
-      lockDir,
-      ...noWait,
-      logger: { warn: (m) => warnings.push(m) },
-    });
+    const lease = await acquireGateLease({ lockDir, ...defaults({ logger: { warn: (m) => warnings.push(m) } }) });
     expect(lease.held).toBe(false);
-    expect(lease.slot).toBeNull();
     expect(warnings.some((w) => w.includes("could not create lock dir") && w.includes("fail-open"))).toBe(true);
     lease.release(); // must not throw
   });
 });
 
-describe("MCX_GATE_LEASE_SLOTS validation", () => {
-  it("caps to the max and warns when the env value is absurdly large", async () => {
+describe("gate-lease env tuning", () => {
+  it("caps MCX_GATE_LEASE_SLOTS to the max and warns", async () => {
+    const opts = defaults();
     process.env.MCX_GATE_LEASE_SLOTS = "999999";
-    const lockDir = freshDir();
     const warnings: string[] = [];
-    const lease = await acquireGateLease({ lockDir, ...noWait, logger: { warn: (m) => warnings.push(m) } });
+    const lease = track(
+      await acquireGateLease({ lockDir: freshDir(), ...opts, logger: { warn: (m) => warnings.push(m) } }),
+    );
     expect(lease.held).toBe(true);
-    expect(lease.slot).toBe(0);
     expect(warnings.some((w) => w.includes("exceeds max") && w.includes("capping"))).toBe(true);
-    lease.release();
   });
 
-  it("warns and falls back to the default for a non-integer env value", async () => {
+  it("warns and falls back for a non-integer MCX_GATE_LEASE_SLOTS", async () => {
+    const opts = defaults();
     process.env.MCX_GATE_LEASE_SLOTS = "2abc";
-    const lockDir = freshDir();
     const warnings: string[] = [];
-    const lease = await acquireGateLease({ lockDir, ...noWait, logger: { warn: (m) => warnings.push(m) } });
+    const lease = track(
+      await acquireGateLease({ lockDir: freshDir(), ...opts, logger: { warn: (m) => warnings.push(m) } }),
+    );
     expect(lease.held).toBe(true);
     expect(warnings.some((w) => w.includes("is not an integer"))).toBe(true);
-    lease.release();
   });
 
-  it("warns when a negative env value disables the gate", async () => {
+  it("warns when a negative MCX_GATE_LEASE_SLOTS disables the gate", async () => {
+    const opts = defaults();
     process.env.MCX_GATE_LEASE_SLOTS = "-1";
-    const lockDir = freshDir();
     const warnings: string[] = [];
-    const lease = await acquireGateLease({ lockDir, ...noWait, logger: { warn: (m) => warnings.push(m) } });
+    const lease = await acquireGateLease({ lockDir: freshDir(), ...opts, logger: { warn: (m) => warnings.push(m) } });
     expect(lease.held).toBe(false);
-    expect(lease.slot).toBeNull();
     expect(warnings.some((w) => w.includes("disables the gate"))).toBe(true);
   });
-});
 
-// A lease whose slot wait fails open immediately: drives the injected clock past
-// the deadline on the first poll.
-function failFastSlotWait(lockDir: string, extra: GateLeaseOptions = {}) {
-  let ticks = 0;
-  return acquireGateLease({
-    lockDir,
-    timeoutMs: 500,
-    now: () => ticks,
-    sleep: async () => {
-      ticks += 1000;
-    },
-    random: () => 0,
-    maxLoad: 0,
-    ...extra,
-  });
-}
-
-describe("default slot count derived from core count (#2690)", () => {
-  it("allows 1 concurrent run on an 8-core host", async () => {
-    clearTuningEnv();
-    const lockDir = freshDir();
-    const a = await acquireGateLease({ lockDir, cpuCount: () => 8, ...noWait });
-    expect(a.held).toBe(true);
-
-    const b = await failFastSlotWait(lockDir, { cpuCount: () => 8 });
-    expect(b.held).toBe(false);
-    a.release();
-  });
-
-  it("allows 2 — not the issue's cores/4 = 4 — on a 16-core host", async () => {
-    clearTuningEnv();
-    const lockDir = freshDir();
-    const cpuCount = () => 16;
-    const a = await acquireGateLease({ lockDir, cpuCount, ...noWait });
-    const b = await acquireGateLease({ lockDir, cpuCount, ...noWait });
-    expect([a.held, b.held]).toEqual([true, true]);
-
-    // The third must be refused. cores/4 would have admitted a third and fourth,
-    // which is the regime the field data shows failing.
-    const c = await failFastSlotWait(lockDir, { cpuCount });
-    expect(c.held).toBe(false);
-    a.release();
-    b.release();
-  });
-
-  it("never derives 0 slots on a single-core host", async () => {
-    clearTuningEnv();
-    const lockDir = freshDir();
-    const a = await acquireGateLease({ lockDir, cpuCount: () => 1, ...noWait });
-    expect(a.held).toBe(true);
-    a.release();
-  });
-});
-
-describe("load-headroom admission (#2690)", () => {
-  it("holds the slot while load is too high, then admits when it falls", async () => {
-    const lockDir = freshDir();
-    const loads = [20, 20, 5];
-    let i = 0;
-    let ticks = 0;
+  it("skips the headroom wait when MCX_GATE_LEASE_MAX_BUSY is 0", async () => {
+    const opts = defaults({ cpuBusy: () => 0.99 });
+    process.env.MCX_GATE_LEASE_MAX_BUSY = "0";
     const warnings: string[] = [];
-    const lease = await acquireGateLease({
-      lockDir,
-      slots: 1,
-      maxLoad: 10,
-      loadWaitMs: 60_000,
-      now: () => ticks,
-      sleep: async () => {
-        ticks += 100;
-      },
-      random: () => 0,
-      loadAvg: () => loads[Math.min(i++, loads.length - 1)] as number,
-      logger: { warn: (m) => warnings.push(m) },
-    });
-
+    const lease = track(
+      await acquireGateLease({ lockDir: freshDir(), ...opts, logger: { warn: (m) => warnings.push(m) } }),
+    );
     expect(lease.held).toBe(true);
-    expect(lease.slot).toBe(0);
-    expect(warnings.some((w) => w.includes("holding slot 0, waiting for host load"))).toBe(true);
-    expect(warnings.some((w) => w.includes("admitted after waiting"))).toBe(true);
-    lease.release();
+    expect(warnings.some((w) => w.includes("disables the headroom wait"))).toBe(true);
   });
 
-  it("keeps the slot held while waiting, so a peer cannot start meanwhile", async () => {
-    const lockDir = freshDir();
-    const probes: boolean[] = [];
-    let ticks = 0;
-    let load = 50;
-    const lease = await acquireGateLease({
-      lockDir,
-      slots: 1,
-      maxLoad: 10,
-      loadWaitMs: 60_000,
-      now: () => ticks,
-      sleep: async () => {
-        ticks += 100;
-        // Mid-load-wait: a peer must find the only slot already taken. This is
-        // what prevents the convoy — the waiter owns the slot while it waits.
-        if (probes.length === 0) {
-          probes.push((await failFastSlotWait(lockDir, { slots: 1 })).held);
-          load = 1; // let the original proceed on the next poll
-        }
-      },
-      random: () => 0,
-      loadAvg: () => load,
-    });
-
-    expect(probes).toEqual([false]);
-    expect(lease.held).toBe(true);
-    lease.release();
-  });
-
-  it("fails open after the load-wait deadline and still holds the slot", async () => {
-    const lockDir = freshDir();
-    let ticks = 0;
+  it("warns and falls back for a non-numeric MCX_GATE_LEASE_MAX_BUSY", async () => {
+    const opts = defaults();
+    process.env.MCX_GATE_LEASE_MAX_BUSY = "busy";
     const warnings: string[] = [];
-    const lease = await acquireGateLease({
-      lockDir,
-      slots: 1,
-      maxLoad: 10,
-      loadWaitMs: 500,
-      now: () => ticks,
-      sleep: async () => {
-        ticks += 1000; // blow past the load deadline on the first poll
-      },
-      random: () => 0,
-      loadAvg: () => 99,
-      logger: { warn: (m) => warnings.push(m) },
-    });
-
-    expect(lease.held).toBe(true);
-    expect(warnings.some((w) => w.includes("still above") && w.includes("fail-open"))).toBe(true);
-    lease.release();
-  });
-
-  it("defaults the ceiling to 0.75 x cores", async () => {
-    clearTuningEnv();
-    const cpuCount = () => 16; // ceiling = 12
-
-    const belowDir = freshDir();
-    const belowWarnings: string[] = [];
-    const below = await acquireGateLease({
-      lockDir: belowDir,
-      slots: 1,
-      cpuCount,
-      loadAvg: () => 11.9,
-      sleep: () => Promise.resolve(),
-      random: () => 0,
-      logger: { warn: (m) => belowWarnings.push(m) },
-    });
-    expect(below.held).toBe(true);
-    expect(belowWarnings.some((w) => w.includes("waiting for host load"))).toBe(false);
-    below.release();
-
-    const aboveDir = freshDir();
-    const aboveWarnings: string[] = [];
-    let ticks = 0;
-    const above = await acquireGateLease({
-      lockDir: aboveDir,
-      slots: 1,
-      cpuCount,
-      loadAvg: () => 12.1,
-      loadWaitMs: 500,
-      now: () => ticks,
-      sleep: async () => {
-        ticks += 1000;
-      },
-      random: () => 0,
-      logger: { warn: (m) => aboveWarnings.push(m) },
-    });
-    expect(aboveWarnings.some((w) => w.includes("waiting for host load"))).toBe(true);
-    above.release();
-  });
-});
-
-describe("load-wait env overrides (#2690)", () => {
-  it("skips the load wait entirely when MCX_GATE_LEASE_MAX_LOAD is 0", async () => {
-    clearTuningEnv();
-    process.env.MCX_GATE_LEASE_MAX_LOAD = "0";
-    const lockDir = freshDir();
-    const warnings: string[] = [];
-    const lease = await acquireGateLease({
-      lockDir,
-      slots: 1,
-      loadAvg: () => 999,
-      sleep: () => Promise.resolve(),
-      random: () => 0,
-      logger: { warn: (m) => warnings.push(m) },
-    });
-    expect(lease.held).toBe(true);
-    expect(warnings.some((w) => w.includes("disables the load wait"))).toBe(true);
-    lease.release();
-  });
-
-  it("warns and falls back to the default for a non-numeric MCX_GATE_LEASE_MAX_LOAD", async () => {
-    clearTuningEnv();
-    process.env.MCX_GATE_LEASE_MAX_LOAD = "high";
-    const lockDir = freshDir();
-    const warnings: string[] = [];
-    const lease = await acquireGateLease({
-      lockDir,
-      slots: 1,
-      cpuCount: () => 16,
-      loadAvg: () => 1,
-      sleep: () => Promise.resolve(),
-      random: () => 0,
-      logger: { warn: (m) => warnings.push(m) },
-    });
+    const lease = track(
+      await acquireGateLease({ lockDir: freshDir(), ...opts, logger: { warn: (m) => warnings.push(m) } }),
+    );
     expect(lease.held).toBe(true);
     expect(warnings.some((w) => w.includes("is not a number"))).toBe(true);
-    lease.release();
   });
 
-  it("honours MCX_GATE_LEASE_LOAD_WAIT_MS as the fail-open bound", async () => {
-    clearTuningEnv();
-    process.env.MCX_GATE_LEASE_LOAD_WAIT_MS = "1";
+  it("honours MCX_GATE_LEASE_WAIT_MS as the whole-run fail-open bound", async () => {
     const lockDir = freshDir();
+    const blocker = track(await acquireGateLease({ lockDir, ...defaults() }));
+    expect(blocker.held).toBe(true);
+
+    const opts = defaults();
+    process.env.MCX_GATE_LEASE_WAIT_MS = "700";
     const warnings: string[] = [];
-    let ticks = 0;
-    const lease = await acquireGateLease({
-      lockDir,
-      slots: 1,
-      maxLoad: 10,
-      now: () => ticks,
-      sleep: async () => {
-        ticks += 5; // trips the 1ms bound, far short of the 5min default
-      },
-      random: () => 0,
-      loadAvg: () => 99,
-      logger: { warn: (m) => warnings.push(m) },
-    });
-    expect(lease.held).toBe(true);
-    expect(warnings.some((w) => w.includes("after 1ms") && w.includes("fail-open"))).toBe(true);
-    lease.release();
-  });
-});
-
-describe("withGateLease", () => {
-  it("runs fn while holding a slot and releases afterwards", async () => {
-    const lockDir = freshDir();
-    let ranWithSlotTaken = false;
-    const result = await withGateLease(
-      async () => {
-        // While inside, the only slot is taken — a non-blocking probe must wait.
-        const probe = await acquireGateLease({
-          slots: 1,
-          lockDir,
-          timeoutMs: 0,
-          now: () => 1,
-          sleep: () => Promise.resolve(),
-          random: () => 0,
-        });
-        ranWithSlotTaken = !probe.held;
-        return 42;
-      },
-      { slots: 1, lockDir, ...noWait },
-    );
-    expect(result).toBe(42);
-    expect(ranWithSlotTaken).toBe(true);
-
-    // After withGateLease returns, the slot is free again.
-    const after = await acquireGateLease({ slots: 1, lockDir, ...noWait });
-    expect(after.held).toBe(true);
-    after.release();
-  });
-
-  it("releases the slot even when fn throws", async () => {
-    const lockDir = freshDir();
-    await expect(
-      withGateLease(
-        async () => {
-          throw new Error("boom");
-        },
-        { slots: 1, lockDir, ...noWait },
-      ),
-    ).rejects.toThrow("boom");
-
-    const after = await acquireGateLease({ slots: 1, lockDir, ...noWait });
-    expect(after.held).toBe(true);
-    after.release();
+    const lease = await acquireGateLease({ lockDir, ...opts, logger: { warn: (m) => warnings.push(m) } });
+    expect(lease.held).toBe(false);
+    expect(warnings.some((w) => w.includes("no admission within 700ms"))).toBe(true);
   });
 });

--- a/packages/core/src/gate-lease.ts
+++ b/packages/core/src/gate-lease.ts
@@ -1,5 +1,5 @@
 /**
- * Cooperative gate-run lease — a host-global counting semaphore over flock(2).
+ * Cooperative gate-run lease — host-global admission control for `am-i-done`.
  *
  * Problem (#2690): N `mcx claude` worker sessions each run `bun run am-i-done`
  * concurrently. Each `bun test --parallel` fans out ~cpu-count worker threads,
@@ -8,81 +8,126 @@
  * spec files that reads like a flaky suite but is pure resource arithmetic.
  *
  * The fix is to QUEUE heavy test phases, never to cap/kill/reap workers (the
- * banned sprint 69/70 pattern, #2637). This semaphore lets at most K test
- * phases run at once across ALL worktrees on the host; a phase that can't get a
- * slot waits cooperatively until one frees.
+ * banned sprint 69/70 pattern, #2637). Everything here happens on the way *in*;
+ * nothing is ever signalled, killed or reaped (the banned #2597/#2632 pattern).
  *
- * Mechanism: K slot files in a host-shared directory, each guarded by an
- * exclusive flock. Acquiring = winning the exclusive lock on any one slot.
- * flock locks are kernel-managed and released automatically on process death
- * (even SIGKILL) or fd close — so a crashed holder never strands a slot and
- * there is no stale-lock reaper to write.
+ * ## Admission, and what is actually guaranteed
  *
- * Admission has two stages, both on the way *in* — nothing is ever signalled,
- * killed or reaped (the banned #2597/#2632 pattern):
+ * Two host-shared flock-guarded resources:
  *
- *   1. Win a slot (bounds the number of concurrent gate runs).
- *   2. Wait for load headroom (bounds total host pressure, including load this
- *      process did not create — N agent sessions, editors, other builds).
+ *   - `admit.lock` — a single mutex held for the duration of one *admission
+ *     decision*. Exactly one process host-wide is ever deciding whether to
+ *     start, so decisions are strictly serialized: runs enter one at a time.
+ *   - `slot-<i>.lock` — K counting slots, held for the duration of the run.
+ *     Bounds how many gate runs *execute* concurrently.
  *
- * Stage 2 exists because a slot count alone is blind to non-gate load: one
- * admitted gate run plus ~12 agent sessions measured load 18.9 on a 16-core
- * host, so admitting a second full fan-out on top reaches the ~27 regime where
- * the OS starts killing test workers.
+ * A run is admitted when it holds the admission token, a slot is free, and the
+ * host has CPU headroom. Guarantees, all of which hold at the default K:
  *
- * Fail-open at both stages: if every slot stays busy past a generous deadline,
- * acquire returns an un-held handle and the caller proceeds anyway; if load
- * never drops, the load wait gives up and the run proceeds holding its slot.
- * Oversubscribing slightly is strictly better than hanging the gate forever
- * behind a wedged holder or a permanently-busy host. Waits and fail-opens are
- * logged so contention is observable.
+ *   1. At most K gate runs execute concurrently.
+ *   2. Admission decisions are totally ordered — no two runs evaluate headroom
+ *      at the same time, so they cannot both clear the same stale reading.
+ *   3. Each decision observes the previously admitted run's fan-out, because
+ *      the signal is instantaneous (see below) and a decision that follows an
+ *      occupied slot waits `settleMs` before sampling.
+ *
+ * A slot is held only by a run that is *working*: a run waiting for headroom
+ * releases its slot and waits on the admission token instead. So a queued run
+ * never waits behind a peer that is itself only waiting.
+ *
+ * ## Why CPU-busy, not loadavg
+ *
+ * The signal is the instantaneous busy fraction of all cores, sampled from
+ * `os.cpus()` cumulative tick deltas over `sampleMs`. The previous version used
+ * `os.loadavg()[0]`, which is wrong here twice over. Measured on the 16-core
+ * reference host during a sprint (#2949 review):
+ *
+ *     loadavg = 26.53 / 25.21 / 23.02      busy = 25.6%   (≈4.1 of 16 cores)
+ *
+ * i.e. loadavg reported 166% of core count while 74% of the CPU sat idle — it
+ * counts D-state I/O waiters and is inflated by ~50 mostly-API-blocked agent
+ * sessions. Any ceiling expressed as a fraction of cores is unreachable on that
+ * host, so every admission burned its whole budget and then ran anyway. It also
+ * lags: a 1-minute EWMA reaches ~40% of a peer's steady-state fan-out after 30s,
+ * so guarantee 3 above would have needed a ~60s settle instead of ~2s.
+ *
+ * ## Bounded, whole-run budget
+ *
+ * `waitMs` is a single budget covering the *entire* admission (token + slot +
+ * headroom), charged once per run, not once per step. On expiry the run proceeds
+ * anyway — with a slot if one is free, unleased otherwise. Two hard constraints
+ * set the default: workers run `am-i-done` under a 600s foreground timeout, and
+ * a green run takes ~100-200s, so the admission budget must be well under 400s
+ * or the gate manufactures the very phantom failures it exists to prevent.
+ * Oversubscribing slightly is strictly better than hanging the gate behind a
+ * wedged holder or a permanently-busy host. Waits and fail-opens are logged so
+ * contention stays observable.
  */
 
 import { closeSync, mkdirSync, openSync } from "node:fs";
-import { cpus, loadavg } from "node:os";
+import { cpus } from "node:os";
 import { join } from "node:path";
 
 import { options } from "./constants";
 import { flockUnlock, tryFlockExclusive } from "./flock";
 
 /**
- * Cores per allowed concurrent gate run, used to derive the default slot count.
+ * Concurrent gate runs allowed by default.
  *
- * #2690 asked for `max(1, floor(cores/4))`. That is not implemented, because it
- * contradicts the field measurements it was meant to fix: on the 16-core macOS
- * host in the report, `cores/4` yields 4 slots — *more* permissive than the
- * fixed 2 that was already in place and that produced the failures. Measured on
- * that host: one admitted gate run plus ~12 agent sessions = load 18.9 on 16
- * cores, and two concurrent runs reached ~27, the regime where the OS SIGTERMs
- * bun test workers. Dividing by 8 keeps 16 cores at 2 (matching the value the
- * host tolerates when load headroom is also respected — see MAX_LOAD_FACTOR)
- * while correctly dropping 4- and 8-core hosts to 1, which the old hardcoded 2
- * got wrong.
+ * #2690 asked for a core-derived count, `max(1, floor(cores/4))`. There is no
+ * defensible derivation, because a gate run's fan-out is *already* sized to the
+ * host: `bun test --parallel` starts ~cpu-count workers, so one run wants the
+ * whole machine whatever the machine is. Measured on the 16-core reference host,
+ * sampling CPU busy every second through a real `am-i-done` (#2949):
+ *
+ *     baseline (agent sessions only)   25-33%
+ *     during test-parallel             44 → 88% peak, 76-83% sustained ~20s
+ *
+ * One fan-out therefore consumes ~75-85% of the box on top of a 25% baseline, so
+ * a second concurrent fan-out does not fit at any core count a fan-out scales to.
+ * The issue's `cores/4` would have admitted *four*.
+ *
+ * So the default is 1, and the K > 1 machinery exists only for
+ * MCX_GATE_LEASE_SLOTS. This is deliberately the same effective concurrency as
+ * the `/tmp/mcx-am-i-done.lock` stopgap it is meant to replace — which measured
+ * load 27 → 14 — but host-wide, crash-safe via flock, with a CPU-headroom check
+ * on top, and with no lock directory to strand when a run dies.
  */
-const CORES_PER_SLOT = 8;
+const DEFAULT_SLOTS = 1;
 /** Upper bound on slots — a huge value would exhaust the fd table per poll. */
 const MAX_SLOTS = 64;
 /**
- * Default load ceiling as a fraction of core count.
+ * Default admission ceiling, as a busy fraction of total CPU capacity.
  *
- * Deliberately below 1.0: a gate run's own `bun test --parallel` fan-out adds
- * roughly a core's worth of load per worker, so admitting at exactly `cores`
- * would start a full fan-out on an already-saturated box and land in the
- * failure regime. 0.75 leaves the admitted run somewhere to grow into — on the
- * 16-core reference host that admits at the observed ~8-10 idle baseline and
- * blocks at the ~19 one-run-active reading.
+ * Chosen so that (a) a host loaded only by idle-ish agent sessions admits — the
+ * reference host measured 25.6% busy while loadavg claimed 26.5 — and (b) a host
+ * already running one gate fan-out does not. `bun test --parallel` saturates
+ * most cores, so a run in progress reads well above this and the next decision
+ * correctly waits for it. Expressed as a fraction, so a 1- or 2-core host gets a
+ * meaningful ceiling instead of the unsatisfiable `max(1, cores * 0.75)` the
+ * loadavg version produced.
  */
-const DEFAULT_MAX_LOAD_FACTOR = 0.75;
-/** Generous fail-open deadline — proceed unleased rather than hang the gate. */
-const DEFAULT_TIMEOUT_MS = 15 * 60 * 1000;
+const DEFAULT_MAX_BUSY = 0.6;
 /**
- * Fail-open deadline for the load-headroom wait. Shorter than the slot deadline:
- * a slot frees when a peer finishes, but load on a permanently-busy host may
- * never drop, so degrade to "just run it" sooner.
+ * Whole-run admission budget before fail-open. See the file header: bounded well
+ * below the 600s worker timeout that wraps the gate run this admits.
  */
-const DEFAULT_LOAD_WAIT_MS = 5 * 60 * 1000;
+const DEFAULT_WAIT_MS = 120 * 1000;
 /** Base poll interval; jitter is added on top to avoid lockstep retries. */
 const DEFAULT_POLL_MS = 250;
+/** CPU sampling window. Long enough to be stable, short enough to be free. */
+const DEFAULT_SAMPLE_MS = 250;
+/**
+ * Delay before the first CPU sample when a peer already holds a slot, so a run
+ * admitted moments ago is visible in the sample rather than being decided
+ * against a pre-fan-out reading. Paid only when a slot is occupied, so the solo
+ * case — the common one — pays nothing.
+ */
+const DEFAULT_SETTLE_MS = 2000;
+/** Re-announce an ongoing wait on this interval so it never reads as a wedge. */
+const REWARN_MS = 30 * 1000;
+/** The single admission mutex, serializing decisions across all gate runs. */
+const ADMIT_LOCK = "admit.lock";
 
 /** Minimal logger surface — kept local so core doesn't depend on the runner's. */
 export interface LeaseLogger {
@@ -92,26 +137,28 @@ export interface LeaseLogger {
 
 export interface GateLeaseOptions {
   /**
-   * Concurrent slots. Defaults to MCX_GATE_LEASE_SLOTS, else derived from the
-   * core count as `max(1, floor(cores/8))`. `<= 0` disables the gate entirely.
+   * Concurrent slots. Defaults to MCX_GATE_LEASE_SLOTS, else 1 (see
+   * DEFAULT_SLOTS). `<= 0` disables the gate entirely.
    */
   slots?: number;
   /** Host-shared lock directory. Defaults to ~/.mcp-cli/gate-locks. */
   lockDir?: string;
-  /** Fail-open deadline (ms). Defaults to MCX_GATE_LEASE_TIMEOUT_MS or 15min. */
-  timeoutMs?: number;
   /**
-   * 1-minute load-average ceiling for admission. Defaults to
-   * MCX_GATE_LEASE_MAX_LOAD, else `cores * 0.75`. `<= 0` skips the load wait.
+   * Whole-run admission budget (ms) covering token + slot + headroom waits.
+   * Defaults to MCX_GATE_LEASE_WAIT_MS or 120s.
    */
-  maxLoad?: number;
+  waitMs?: number;
   /**
-   * Fail-open deadline for the load wait (ms). Defaults to
-   * MCX_GATE_LEASE_LOAD_WAIT_MS or 5min.
+   * CPU busy-fraction ceiling for admission (0-1). Defaults to
+   * MCX_GATE_LEASE_MAX_BUSY, else 0.6. `<= 0` skips the headroom wait.
    */
-  loadWaitMs?: number;
-  /** Base poll interval (ms) while waiting for a free slot. */
+  maxBusy?: number;
+  /** Base poll interval (ms) while waiting for admission. */
   pollIntervalMs?: number;
+  /** CPU sampling window (ms). */
+  sampleMs?: number;
+  /** Settle delay (ms) before sampling when a peer already holds a slot. */
+  settleMs?: number;
   logger?: LeaseLogger;
   /** DI seam: sleep implementation (injected in tests). */
   sleep?: (ms: number) => Promise<void>;
@@ -119,10 +166,8 @@ export interface GateLeaseOptions {
   now?: () => number;
   /** DI seam: jitter source (injected in tests). */
   random?: () => number;
-  /** DI seam: 1-minute load average (defaults to os.loadavg()[0]). */
-  loadAvg?: () => number;
-  /** DI seam: logical core count (defaults to os.cpus().length). */
-  cpuCount?: () => number;
+  /** DI seam: CPU busy fraction 0-1 (defaults to an os.cpus() tick sample). */
+  cpuBusy?: () => number | Promise<number>;
 }
 
 export interface GateLease {
@@ -136,8 +181,8 @@ export interface GateLease {
 
 const UNHELD_LEASE: GateLease = { held: false, slot: null, release: () => {} };
 
-function readSlotsFromEnv(cores: number, logger?: LeaseLogger): number {
-  const fallback = Math.max(1, Math.floor(cores / CORES_PER_SLOT));
+function readSlotsFromEnv(logger?: LeaseLogger): number {
+  const fallback = DEFAULT_SLOTS;
   const raw = process.env.MCX_GATE_LEASE_SLOTS;
   if (raw === undefined || raw === "") return fallback;
   // parseInt silently truncates trailing garbage ("2abc" -> 2), which hides a
@@ -158,33 +203,29 @@ function readSlotsFromEnv(cores: number, logger?: LeaseLogger): number {
   return n;
 }
 
-function readTimeoutFromEnv(): number {
-  const raw = process.env.MCX_GATE_LEASE_TIMEOUT_MS;
-  if (raw === undefined || raw === "") return DEFAULT_TIMEOUT_MS;
+function readWaitFromEnv(): number {
+  const raw = process.env.MCX_GATE_LEASE_WAIT_MS;
+  if (raw === undefined || raw === "") return DEFAULT_WAIT_MS;
   const n = Number.parseInt(raw, 10);
-  return Number.isFinite(n) && n > 0 ? n : DEFAULT_TIMEOUT_MS;
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_WAIT_MS;
 }
 
-function readMaxLoadFromEnv(cores: number, logger?: LeaseLogger): number {
-  const fallback = Math.max(1, cores * DEFAULT_MAX_LOAD_FACTOR);
-  const raw = process.env.MCX_GATE_LEASE_MAX_LOAD;
-  if (raw === undefined || raw === "") return fallback;
+function readMaxBusyFromEnv(logger?: LeaseLogger): number {
+  const raw = process.env.MCX_GATE_LEASE_MAX_BUSY;
+  if (raw === undefined || raw === "") return DEFAULT_MAX_BUSY;
   const n = Number.parseFloat(raw);
   if (!Number.isFinite(n)) {
-    logger?.warn?.(`gate-lease: MCX_GATE_LEASE_MAX_LOAD="${raw}" is not a number — using default ${fallback} (#2690)`);
-    return fallback;
+    logger?.warn?.(
+      `gate-lease: MCX_GATE_LEASE_MAX_BUSY="${raw}" is not a number — using default ${DEFAULT_MAX_BUSY} (#2690)`,
+    );
+    return DEFAULT_MAX_BUSY;
   }
   if (n <= 0) {
-    logger?.warn?.(`gate-lease: MCX_GATE_LEASE_MAX_LOAD=${n} disables the load wait — admitting immediately (#2690)`);
+    logger?.warn?.(
+      `gate-lease: MCX_GATE_LEASE_MAX_BUSY=${n} disables the headroom wait — admitting immediately (#2690)`,
+    );
   }
   return n;
-}
-
-function readLoadWaitFromEnv(): number {
-  const raw = process.env.MCX_GATE_LEASE_LOAD_WAIT_MS;
-  if (raw === undefined || raw === "") return DEFAULT_LOAD_WAIT_MS;
-  const n = Number.parseInt(raw, 10);
-  return Number.isFinite(n) && n > 0 ? n : DEFAULT_LOAD_WAIT_MS;
 }
 
 function defaultSleep(ms: number): Promise<void> {
@@ -195,22 +236,61 @@ function jitteredDelay(base: number, random: () => number): number {
   return base + Math.floor(random() * base);
 }
 
+/** Aggregate (idle, total) CPU ticks across all cores. */
+function cpuTicks(): { idle: number; total: number } {
+  let idle = 0;
+  let total = 0;
+  for (const c of cpus()) {
+    idle += c.times.idle;
+    total += c.times.user + c.times.nice + c.times.sys + c.times.idle + c.times.irq;
+  }
+  return { idle, total };
+}
+
+/**
+ * Instantaneous busy fraction of all cores over `windowMs`.
+ *
+ * Unlike loadavg this reflects a peer's fan-out within a second of it starting,
+ * and ignores non-CPU waiters (disk, `mds`, network) that cannot contend for the
+ * resource the gate protects.
+ */
+async function sampleCpuBusy(windowMs: number, sleep: (ms: number) => Promise<void>): Promise<number> {
+  const a = cpuTicks();
+  await sleep(windowMs);
+  const b = cpuTicks();
+  const total = b.total - a.total;
+  if (total <= 0) return 0;
+  const busy = 1 - (b.idle - a.idle) / total;
+  return Math.min(1, Math.max(0, busy));
+}
+
 interface HeldSlot {
   index: number;
   fd: number;
 }
 
-/** Try each slot file once; return the first whose exclusive flock we win. */
-function tryAcquireAnySlot(lockDir: string, slots: number): HeldSlot | null {
+/** Open a lock file, or null on a transient fs error (treated as unusable). */
+function openLockFile(lockDir: string, name: string): number | null {
+  try {
+    return openSync(join(lockDir, name), "w");
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Probe every slot, retaining the first free one.
+ *
+ * Safe to lock-then-unlock the slots we don't keep, because this only ever runs
+ * while holding the admission token: no peer can be acquiring a slot
+ * concurrently, so a momentarily-taken-then-released slot is unobservable.
+ */
+function probeSlots(lockDir: string, slots: number): { mine: HeldSlot | null; occupied: number } {
+  let mine: HeldSlot | null = null;
+  let occupied = 0;
   for (let i = 0; i < slots; i++) {
-    const path = join(lockDir, `slot-${i}.lock`);
-    let fd: number;
-    try {
-      fd = openSync(path, "w");
-    } catch {
-      // Slot file could not be opened (transient fs error) — skip it.
-      continue;
-    }
+    const fd = openLockFile(lockDir, `slot-${i}.lock`);
+    if (fd === null) continue;
     let locked = false;
     try {
       locked = tryFlockExclusive(fd);
@@ -219,10 +299,24 @@ function tryAcquireAnySlot(lockDir: string, slots: number): HeldSlot | null {
       closeSync(fd);
       continue;
     }
-    if (locked) return { index: i, fd };
-    closeSync(fd);
+    if (!locked) {
+      occupied++;
+      closeSync(fd);
+      continue;
+    }
+    if (mine === null) {
+      mine = { index: i, fd };
+    } else {
+      flockUnlock(fd);
+      closeSync(fd);
+    }
   }
-  return null;
+  return { mine, occupied };
+}
+
+function releaseSlot(slot: HeldSlot): void {
+  flockUnlock(slot.fd);
+  closeSync(slot.fd);
 }
 
 function makeHeldLease(slot: HeldSlot): GateLease {
@@ -233,97 +327,139 @@ function makeHeldLease(slot: HeldSlot): GateLease {
     release() {
       if (released) return;
       released = true;
-      flockUnlock(slot.fd);
-      closeSync(slot.fd);
+      releaseSlot(slot);
     },
   };
 }
 
-interface LoadWaitParams {
-  maxLoad: number;
-  loadWaitMs: number;
+interface AdmitContext {
+  lockDir: string;
+  slots: number;
+  maxBusy: number;
   basePoll: number;
-  slotIndex: number;
+  settleMs: number;
+  deadline: number;
   sleep: (ms: number) => Promise<void>;
   now: () => number;
   random: () => number;
-  loadAvg: () => number;
+  cpuBusy: () => number | Promise<number>;
   logger?: LeaseLogger;
 }
 
 /**
- * Stage 2 of admission: hold the slot until the host has load headroom.
+ * Announce a wait once, then re-announce every REWARN_MS with elapsed/remaining.
  *
- * Waiting *while holding the slot* is the load-bearing part of this design, not
- * an implementation detail — do not "optimise" it into a wait-then-acquire. The
- * slot makes the load wait mutually exclusive, so at most K runs are ever
- * watching the load average and they enter one at a time. Waiting before
- * acquiring reproduces the convoy this replaces: in sprint 76 three sessions
- * independently polled for load < 6 / < 3 / < 4, all cleared their private
- * thresholds within the same instant, and fired their suites simultaneously —
- * exactly the oversubscription the gate exists to prevent.
- *
- * Bounded fail-open: a permanently-busy host must degrade to "just run it",
- * never hang. The run proceeds still holding its slot.
+ * warn (not info) because the am-i-done AI file logger mirrors only warn/error
+ * to stderr; "why am I not running yet" has to reach the worker or a queued run
+ * is indistinguishable from a hung one, and agent sessions intervene on silence.
  */
-async function waitForLoadHeadroom(p: LoadWaitParams): Promise<void> {
-  if (p.maxLoad <= 0) return;
+function makeWaitAnnouncer(ctx: AdmitContext, start: number) {
+  let lastAnnounced = Number.NEGATIVE_INFINITY;
+  const announce = (what: string): void => {
+    announce.waited = true;
+    const elapsed = ctx.now() - start;
+    if (elapsed - lastAnnounced < REWARN_MS && lastAnnounced !== Number.NEGATIVE_INFINITY) return;
+    lastAnnounced = elapsed;
+    const remaining = Math.max(0, Math.round(ctx.deadline - ctx.now()));
+    const cfg = `slots=${ctx.slots} maxBusy=${ctx.maxBusy.toFixed(2)}`;
+    ctx.logger?.warn?.(
+      `gate-lease: waiting ${what} — ${Math.round(elapsed)}ms elapsed, ${remaining}ms before fail-open (${cfg}, #2690)`,
+    );
+  };
+  /** Set once any wait has been announced — see the admission log level below. */
+  announce.waited = false;
+  return announce;
+}
 
-  const start = p.now();
-  const deadline = start + p.loadWaitMs;
-  let announced = false;
-
+/** Hold the single admission mutex, so exactly one run decides at a time. */
+async function acquireAdmitToken(ctx: AdmitContext): Promise<{ fd: number; waited: boolean } | null> {
+  const start = ctx.now();
+  const announce = makeWaitAnnouncer(ctx, start);
   for (;;) {
-    const load = p.loadAvg();
-    if (load < p.maxLoad) {
-      if (announced) {
-        p.logger?.warn?.(
-          `gate-lease: slot ${p.slotIndex} admitted after waiting ${Math.round(p.now() - start)}ms for load ${load.toFixed(2)} < ${p.maxLoad.toFixed(2)} (#2690)`,
-        );
+    const fd = openLockFile(ctx.lockDir, ADMIT_LOCK);
+    if (fd !== null) {
+      let locked = false;
+      try {
+        locked = tryFlockExclusive(fd);
+      } catch {
+        closeSync(fd);
+        return null;
       }
-      return;
+      if (locked) return { fd, waited: announce.waited };
+      closeSync(fd);
     }
-    if (p.now() >= deadline) {
-      p.logger?.warn?.(
-        `gate-lease: load ${load.toFixed(2)} still above ${p.maxLoad.toFixed(2)} after ${p.loadWaitMs}ms — proceeding anyway (fail-open, #2690)`,
-      );
-      return;
-    }
-    if (!announced) {
-      announced = true;
-      // warn (not info) for the same reason as the slot wait: the am-i-done AI
-      // file logger only mirrors warn/error, and "why am I not running yet" has
-      // to reach the worker or the run looks hung.
-      p.logger?.warn?.(
-        `gate-lease: holding slot ${p.slotIndex}, waiting for host load ${load.toFixed(2)} to fall below ${p.maxLoad.toFixed(2)} (#2690)`,
-      );
-    }
-    await p.sleep(jitteredDelay(p.basePoll, p.random));
+    if (ctx.now() >= ctx.deadline) return null;
+    announce("for the admission token (a peer is deciding)");
+    await ctx.sleep(jitteredDelay(ctx.basePoll, ctx.random));
   }
 }
 
 /**
- * Acquire one of K cooperative gate slots, waiting for a free slot if all are
- * busy and then for host load headroom. Returns immediately with an unheld
- * lease when disabled (`slots <= 0`) or when the slot fail-open deadline
- * elapses. Never throws on contention.
+ * Decide, while holding the admission token: wait for a free slot AND host CPU
+ * headroom, then take the slot. Returns null if the budget ran out.
+ *
+ * A slot found free but rejected on headroom is released again before waiting —
+ * slots are held only by runs that are actually working, so a queued peer never
+ * blocks behind a waiter.
+ */
+async function decideAdmission(ctx: AdmitContext, waitedForToken: boolean): Promise<HeldSlot | null> {
+  const start = ctx.now();
+  const announce = makeWaitAnnouncer(ctx, start);
+  announce.waited = waitedForToken;
+  let settled = ctx.maxBusy <= 0;
+
+  for (;;) {
+    const { mine, occupied } = probeSlots(ctx.lockDir, ctx.slots);
+    if (mine) {
+      if (ctx.maxBusy <= 0) return mine;
+      if (!settled && occupied > 0) {
+        // A peer may have been admitted moments ago; give its fan-out time to
+        // reach the CPU sample before deciding against a pre-fan-out reading.
+        settled = true;
+        releaseSlot(mine);
+        await ctx.sleep(ctx.settleMs);
+        continue;
+      }
+      const busy = await ctx.cpuBusy();
+      if (busy < ctx.maxBusy) {
+        const waited = Math.round(ctx.now() - start);
+        // A run that queued reports its admission at warn, so the wait and its
+        // resolution both survive the am-i-done AI file logger (which mirrors
+        // only warn/error and discards the info log on success). An instant
+        // admission stays at info — the common case shouldn't cost context.
+        const log = announce.waited ? ctx.logger?.warn : ctx.logger?.info;
+        log?.(
+          `gate-lease: admitted on slot ${mine.index} after ${waited}ms — cpu ${(busy * 100).toFixed(0)}% < ${(ctx.maxBusy * 100).toFixed(0)}%, slots=${ctx.slots} (#2690)`,
+        );
+        return mine;
+      }
+      releaseSlot(mine);
+      announce(`for cpu headroom (${(busy * 100).toFixed(0)}% busy, need < ${(ctx.maxBusy * 100).toFixed(0)}%)`);
+    } else {
+      announce(`for a free slot (all ${ctx.slots} busy)`);
+    }
+    if (ctx.now() >= ctx.deadline) return null;
+    await ctx.sleep(jitteredDelay(ctx.basePoll, ctx.random));
+  }
+}
+
+/**
+ * Acquire host-global admission for one gate run: a slot plus CPU headroom.
+ *
+ * Call once per run, not once per step — the budget is whole-run. Returns an
+ * unheld lease when the gate is disabled (`slots <= 0`), when the lock dir is
+ * unusable, or when the budget elapses without a slot. Never throws on
+ * contention.
  */
 export async function acquireGateLease(opts: GateLeaseOptions = {}): Promise<GateLease> {
   const logger = opts.logger;
-  const cpuCount = opts.cpuCount ?? (() => cpus().length);
-  const cores = Math.max(1, cpuCount());
-  const slots = opts.slots ?? readSlotsFromEnv(cores, logger);
+  const slots = opts.slots ?? readSlotsFromEnv(logger);
   if (slots <= 0) return UNHELD_LEASE;
 
   const lockDir = opts.lockDir ?? join(options.MCP_CLI_DIR, "gate-locks");
-  const timeoutMs = opts.timeoutMs ?? readTimeoutFromEnv();
-  const maxLoad = opts.maxLoad ?? readMaxLoadFromEnv(cores, logger);
-  const loadWaitMs = opts.loadWaitMs ?? readLoadWaitFromEnv();
-  const basePoll = opts.pollIntervalMs ?? DEFAULT_POLL_MS;
   const sleep = opts.sleep ?? defaultSleep;
   const now = opts.now ?? (() => performance.now());
-  const random = opts.random ?? Math.random;
-  const loadAvg = opts.loadAvg ?? (() => loadavg()[0] ?? 0);
+  const sampleMs = opts.sampleMs ?? DEFAULT_SAMPLE_MS;
 
   // Fail-open on any fs error creating the lock dir (read-only HOME, disk full,
   // bad permissions) — the lease must never fail the run it wraps (#2690).
@@ -336,57 +472,40 @@ export async function acquireGateLease(opts: GateLeaseOptions = {}): Promise<Gat
     return UNHELD_LEASE;
   }
 
-  const deadline = now() + timeoutMs;
-  let announcedWait = false;
+  const waitMs = opts.waitMs ?? readWaitFromEnv();
+  const ctx: AdmitContext = {
+    lockDir,
+    slots,
+    maxBusy: opts.maxBusy ?? readMaxBusyFromEnv(logger),
+    basePoll: opts.pollIntervalMs ?? DEFAULT_POLL_MS,
+    settleMs: opts.settleMs ?? DEFAULT_SETTLE_MS,
+    deadline: now() + waitMs,
+    sleep,
+    now,
+    random: opts.random ?? Math.random,
+    cpuBusy: opts.cpuBusy ?? (() => sampleCpuBusy(sampleMs, sleep)),
+    logger,
+  };
 
-  const start = now();
-
-  for (;;) {
-    const slot = tryAcquireAnySlot(lockDir, slots);
-    if (slot) {
-      // warn (not info) so the message survives the am-i-done AI file logger,
-      // which mirrors only warn/error to stderr and deletes the info-only log
-      // on success — the worker context is exactly where #2690 contention needs
-      // to stay observable.
-      if (announcedWait) {
-        logger?.warn?.(`gate-lease: acquired slot ${slot.index} after waiting ${now() - start}ms (#2690)`);
-      }
-      const lease = makeHeldLease(slot);
-      await waitForLoadHeadroom({
-        maxLoad,
-        loadWaitMs,
-        basePoll,
-        slotIndex: slot.index,
-        sleep,
-        now,
-        random,
-        loadAvg,
-        logger,
-      });
-      return lease;
-    }
-    if (now() >= deadline) {
-      logger?.warn?.(
-        `gate-lease: all ${slots} slots busy past ${timeoutMs}ms — proceeding unleased (fail-open, #2690)`,
-      );
-      return UNHELD_LEASE;
-    }
-    if (!announcedWait) {
-      announcedWait = true;
-      logger?.warn?.(`gate-lease: all ${slots} slots busy — queueing for a free slot (#2690)`);
-    }
-    await sleep(jitteredDelay(basePoll, random));
+  const token = await acquireAdmitToken(ctx);
+  if (token === null) {
+    logger?.warn?.(`gate-lease: no admission token within ${waitMs}ms — proceeding unleased (fail-open, #2690)`);
+    return UNHELD_LEASE;
   }
-}
 
-/**
- * Run `fn` while holding a gate slot, releasing it afterwards even on throw.
- */
-export async function withGateLease<T>(fn: () => Promise<T>, opts: GateLeaseOptions = {}): Promise<T> {
-  const lease = await acquireGateLease(opts);
   try {
-    return await fn();
+    const slot = await decideAdmission(ctx, token.waited);
+    if (slot) return makeHeldLease(slot);
+
+    // Budget spent. Running with a slot is still better than running unleased,
+    // so take one if it happens to be free; otherwise proceed uncounted.
+    const { mine } = probeSlots(lockDir, slots);
+    logger?.warn?.(
+      `gate-lease: no admission within ${waitMs}ms — proceeding ${mine ? `on slot ${mine.index}` : "unleased"} (fail-open, #2690)`,
+    );
+    return mine ? makeHeldLease(mine) : UNHELD_LEASE;
   } finally {
-    lease.release();
+    flockUnlock(token.fd);
+    closeSync(token.fd);
   }
 }

--- a/packages/core/src/gate-lease.ts
+++ b/packages/core/src/gate-lease.ts
@@ -8,32 +8,44 @@
  * spec files that reads like a flaky suite but is pure resource arithmetic.
  *
  * The fix is to QUEUE heavy test phases, never to cap/kill/reap workers (the
- * banned sprint 69/70 pattern, #2637). Everything here happens on the way *in*;
- * nothing is ever signalled, killed or reaped (the banned #2597/#2632 pattern).
+ * banned sprint 69/70 pattern, #2637).
  *
- * ## Admission, and what is actually guaranteed
+ * ## Admission — what it does, and what it does not promise
  *
  * Two host-shared flock-guarded resources:
  *
  *   - `admit.lock` — a single mutex held for the duration of one *admission
  *     decision*. Exactly one process host-wide is ever deciding whether to
- *     start, so decisions are strictly serialized: runs enter one at a time.
- *   - `slot-<i>.lock` — K counting slots, held for the duration of the run.
- *     Bounds how many gate runs *execute* concurrently.
+ *     start, so two runs cannot both clear the same stale CPU reading.
+ *   - `slot-<i>.lock` — K counting slots (default 1), held for the duration of
+ *     the run. Bounds how many gate runs *execute* concurrently.
  *
  * A run is admitted when it holds the admission token, a slot is free, and the
- * host has CPU headroom. Guarantees, all of which hold at the default K:
+ * host has CPU headroom.
  *
- *   1. At most K gate runs execute concurrently.
- *   2. Admission decisions are totally ordered — no two runs evaluate headroom
- *      at the same time, so they cannot both clear the same stale reading.
- *   3. Each decision observes the previously admitted run's fan-out, because
- *      the signal is instantaneous (see below) and a decision that follows an
- *      occupied slot waits `settleMs` before sampling.
+ * This is admission control, not a hard limit. The wait is bounded, and on
+ * expiry the run proceeds anyway (see the budget section) — so "at most K
+ * concurrent runs" describes runs that are still inside their budget, not an
+ * invariant. Under contention that outlasts the budget the mechanism degrades
+ * from serializing to staggering, deliberately: hanging the gate behind a
+ * wedged holder would manufacture the phantom failures #2690 exists to remove.
  *
- * A slot is held only by a run that is *working*: a run waiting for headroom
- * releases its slot and waits on the admission token instead. So a queued run
- * never waits behind a peer that is itself only waiting.
+ * A slot is held only by a run that is *working*: a run rejected on headroom
+ * releases its slot before waiting, so a queued run never waits behind a peer
+ * that is itself only waiting.
+ *
+ * ## No cleanup — and why none may be added
+ *
+ * flock locks are kernel-managed: released automatically on process death (even
+ * SIGKILL) or fd close. A crashed holder therefore never strands a slot, and
+ * there is deliberately NO STALE-LOCK REAPER TO WRITE. A leftover
+ * `slot-*.lock` file is not a leak — the file is meant to persist; only the
+ * lock on it is transient. `lsof ~/.mcp-cli/gate-locks/slot-0.lock` shows
+ * whether a live process holds it, and if a queue looks stuck the holder is
+ * real: measure it, do not reap it. Adding a sweeper, watchdog, timer, killer
+ * or unlink here re-creates the sprint 69/70 collapse (#2597/#2632, reverted in
+ * #2637). Everything in this file happens on the way *in*; nothing is ever
+ * signalled, killed, reaped or unlinked.
  *
  * ## Why CPU-busy, not loadavg
  *
@@ -49,19 +61,47 @@
  * sessions. Any ceiling expressed as a fraction of cores is unreachable on that
  * host, so every admission burned its whole budget and then ran anyway. It also
  * lags: a 1-minute EWMA reaches ~40% of a peer's steady-state fan-out after 30s,
- * so guarantee 3 above would have needed a ~60s settle instead of ~2s.
+ * so a peer's fan-out would be invisible for the first ~30s of it.
  *
- * ## Bounded, whole-run budget
+ * What this signal does NOT see, so nobody reads more into it than it measures:
+ * `steal` is not counted, so a noisy-neighbour VM reads as idle; `os.cpus()` is
+ * host-wide, so a cgroup-quota'd container misreads in both directions; on
+ * asymmetric cores (Apple silicon) saturated E-cores plus idle P-cores average
+ * below the ceiling; and memory/IO thrash — the actual mechanism in
+ * `false-segfault-orphaned-load.md` and the CI-SIGTERM-at-97% incident — is
+ * invisible to it entirely. The slot count, not the CPU check, is what bounds
+ * concurrency; headroom is a secondary guard against an already-loaded host.
+ *
+ * ## Bounded, whole-run budget — and why it is 300s, not 120s
  *
  * `waitMs` is a single budget covering the *entire* admission (token + slot +
  * headroom), charged once per run, not once per step. On expiry the run proceeds
- * anyway — with a slot if one is free, unleased otherwise. Two hard constraints
- * set the default: workers run `am-i-done` under a 600s foreground timeout, and
- * a green run takes ~100-200s, so the admission budget must be well under 400s
- * or the gate manufactures the very phantom failures it exists to prevent.
- * Oversubscribing slightly is strictly better than hanging the gate behind a
- * wedged holder or a permanently-busy host. Waits and fail-opens are logged so
- * contention stays observable.
+ * anyway — with a slot if one is free, unleased otherwise.
+ *
+ * The budget has to outlast H, the hold it is waiting for, or it is *worse than
+ * doing nothing*: a run that burns its whole budget and then fans out on top of
+ * the holder has added latency and removed no concurrency at all. H is the span
+ * from the first `lease: true` step to the end of the run, which covers
+ * test-parallel → test-control → coverage. Measured (#2949 review round 2):
+ *
+ *     CI, full suite + coverage ratchet   189s and 194s wall (run 30953980055)
+ *     dev host, test-parallel alone       27s (8774 tests, 325 files)
+ *
+ * So H is ~200s for a green run, and a 120s budget sat *below* it: every
+ * co-launched run was guaranteed to wait the full 120s and then oversubscribe
+ * anyway. 300s clears a green H with margin, and the ceiling is 400s because
+ * budget + H must stay inside the 600s foreground timeout that wraps a worker's
+ * gate run — past that the gate manufactures the phantom failures #2690 exists
+ * to remove.
+ *
+ * No budget can outlast an *arbitrary* hold: a wedged holder observed during
+ * this review sat on a slot for 47 minutes with 0.3s of CPU (#2973). That is
+ * exactly why fail-open exists, and why the honest description of the contended
+ * path is "serializes while the holder is normal, staggers when it is not".
+ *
+ * Fail-open deadlines are jittered per process (DEADLINE_JITTER) so N runs that
+ * started together do not all give up in the same poll interval and stampede.
+ * Waits, admissions and fail-opens are all logged so contention stays visible.
  */
 
 import { closeSync, mkdirSync, openSync } from "node:fs";
@@ -109,21 +149,35 @@ const MAX_SLOTS = 64;
  */
 const DEFAULT_MAX_BUSY = 0.6;
 /**
- * Whole-run admission budget before fail-open. See the file header: bounded well
- * below the 600s worker timeout that wraps the gate run this admits.
+ * Whole-run admission budget before fail-open.
+ *
+ * This has to outlast the thing it waits for, or it is worse than nothing: a run
+ * that burns the whole budget and then fans out on top of the holder has added
+ * latency and removed no concurrency. So the budget is sized against H, the
+ * measured hold — see "Bounded, whole-run budget" in the file header for H and
+ * the 600s arithmetic that caps it.
  */
-const DEFAULT_WAIT_MS = 120 * 1000;
+const DEFAULT_WAIT_MS = 300 * 1000;
+/**
+ * Upper bound on the admission budget, including via MCX_GATE_LEASE_WAIT_MS.
+ * Beyond this, budget + run breaches the 600s foreground worker timeout and the
+ * gate starts manufacturing the phantom failures it exists to prevent (#2690).
+ */
+const MAX_WAIT_MS = 400 * 1000;
+/**
+ * Fraction of the budget by which each process jitters its own fail-open
+ * deadline, DOWNWARD.
+ *
+ * N runs launched together otherwise share a deadline to within milliseconds and
+ * all give up inside one poll interval, converting naturally-staggered arrivals
+ * into a synchronised stampede. Downward-only so the configured budget stays a
+ * hard ceiling and the 600s arithmetic above still holds.
+ */
+const DEADLINE_JITTER = 0.25;
 /** Base poll interval; jitter is added on top to avoid lockstep retries. */
 const DEFAULT_POLL_MS = 250;
 /** CPU sampling window. Long enough to be stable, short enough to be free. */
 const DEFAULT_SAMPLE_MS = 250;
-/**
- * Delay before the first CPU sample when a peer already holds a slot, so a run
- * admitted moments ago is visible in the sample rather than being decided
- * against a pre-fan-out reading. Paid only when a slot is occupied, so the solo
- * case — the common one — pays nothing.
- */
-const DEFAULT_SETTLE_MS = 2000;
 /** Re-announce an ongoing wait on this interval so it never reads as a wedge. */
 const REWARN_MS = 30 * 1000;
 /** The single admission mutex, serializing decisions across all gate runs. */
@@ -145,7 +199,8 @@ export interface GateLeaseOptions {
   lockDir?: string;
   /**
    * Whole-run admission budget (ms) covering token + slot + headroom waits.
-   * Defaults to MCX_GATE_LEASE_WAIT_MS or 120s.
+   * Defaults to MCX_GATE_LEASE_WAIT_MS (capped at MAX_WAIT_MS) or 300s. Each
+   * process jitters its own effective deadline downward from this.
    */
   waitMs?: number;
   /**
@@ -157,8 +212,6 @@ export interface GateLeaseOptions {
   pollIntervalMs?: number;
   /** CPU sampling window (ms). */
   sampleMs?: number;
-  /** Settle delay (ms) before sampling when a peer already holds a slot. */
-  settleMs?: number;
   logger?: LeaseLogger;
   /** DI seam: sleep implementation (injected in tests). */
   sleep?: (ms: number) => Promise<void>;
@@ -203,11 +256,31 @@ function readSlotsFromEnv(logger?: LeaseLogger): number {
   return n;
 }
 
-function readWaitFromEnv(): number {
+function readWaitFromEnv(logger?: LeaseLogger): number {
   const raw = process.env.MCX_GATE_LEASE_WAIT_MS;
   if (raw === undefined || raw === "") return DEFAULT_WAIT_MS;
+  // A bare parseInt reads "120s" as 120 — a 120ms budget, i.e. the gate silently
+  // off — and "2m" as 2. Reject anything that isn't a plain integer, loudly.
+  if (!/^\s*-?\d+\s*$/.test(raw)) {
+    logger?.warn?.(
+      `gate-lease: MCX_GATE_LEASE_WAIT_MS="${raw}" is not an integer number of milliseconds — using default ${DEFAULT_WAIT_MS}ms (#2690)`,
+    );
+    return DEFAULT_WAIT_MS;
+  }
   const n = Number.parseInt(raw, 10);
-  return Number.isFinite(n) && n > 0 ? n : DEFAULT_WAIT_MS;
+  if (!Number.isFinite(n) || n <= 0) {
+    logger?.warn?.(
+      `gate-lease: MCX_GATE_LEASE_WAIT_MS=${raw} must be greater than 0 — using default ${DEFAULT_WAIT_MS}ms (#2690)`,
+    );
+    return DEFAULT_WAIT_MS;
+  }
+  if (n > MAX_WAIT_MS) {
+    logger?.warn?.(
+      `gate-lease: MCX_GATE_LEASE_WAIT_MS=${n} exceeds max ${MAX_WAIT_MS}ms — capping to ${MAX_WAIT_MS}ms (a longer wait plus the run it admits would breach the 600s worker timeout, #2690)`,
+    );
+    return MAX_WAIT_MS;
+  }
+  return n;
 }
 
 function readMaxBusyFromEnv(logger?: LeaseLogger): number {
@@ -279,15 +352,16 @@ function openLockFile(lockDir: string, name: string): number | null {
 }
 
 /**
- * Probe every slot, retaining the first free one.
+ * Take the first free slot, or null when every slot is occupied.
  *
- * Safe to lock-then-unlock the slots we don't keep, because this only ever runs
- * while holding the admission token: no peer can be acquiring a slot
- * concurrently, so a momentarily-taken-then-released slot is unobservable.
+ * Normally called while holding the admission token, so no peer is acquiring a
+ * slot concurrently and the lock-then-unlock of slots we don't keep is
+ * unobservable. The fail-open path also calls it *without* the token, which is
+ * still safe: flock acquisition is atomic, so the worst case is that this run
+ * and the token holder both try for the same free slot and exactly one wins.
  */
-function probeSlots(lockDir: string, slots: number): { mine: HeldSlot | null; occupied: number } {
+function probeSlots(lockDir: string, slots: number): HeldSlot | null {
   let mine: HeldSlot | null = null;
-  let occupied = 0;
   for (let i = 0; i < slots; i++) {
     const fd = openLockFile(lockDir, `slot-${i}.lock`);
     if (fd === null) continue;
@@ -300,7 +374,6 @@ function probeSlots(lockDir: string, slots: number): { mine: HeldSlot | null; oc
       continue;
     }
     if (!locked) {
-      occupied++;
       closeSync(fd);
       continue;
     }
@@ -311,7 +384,7 @@ function probeSlots(lockDir: string, slots: number): { mine: HeldSlot | null; oc
       closeSync(fd);
     }
   }
-  return { mine, occupied };
+  return mine;
 }
 
 function releaseSlot(slot: HeldSlot): void {
@@ -337,7 +410,6 @@ interface AdmitContext {
   slots: number;
   maxBusy: number;
   basePoll: number;
-  settleMs: number;
   deadline: number;
   sleep: (ms: number) => Promise<void>;
   now: () => number;
@@ -401,42 +473,44 @@ async function acquireAdmitToken(ctx: AdmitContext): Promise<{ fd: number; waite
  * A slot found free but rejected on headroom is released again before waiting —
  * slots are held only by runs that are actually working, so a queued peer never
  * blocks behind a waiter.
+ *
+ * `start` is the whole-run admission start, so reported elapsed time covers the
+ * token wait too rather than restarting the clock here.
  */
-async function decideAdmission(ctx: AdmitContext, waitedForToken: boolean): Promise<HeldSlot | null> {
-  const start = ctx.now();
+async function decideAdmission(ctx: AdmitContext, start: number, waitedForToken: boolean): Promise<HeldSlot | null> {
   const announce = makeWaitAnnouncer(ctx, start);
   announce.waited = waitedForToken;
-  let settled = ctx.maxBusy <= 0;
 
   for (;;) {
-    const { mine, occupied } = probeSlots(ctx.lockDir, ctx.slots);
-    if (mine) {
-      if (ctx.maxBusy <= 0) return mine;
-      if (!settled && occupied > 0) {
-        // A peer may have been admitted moments ago; give its fan-out time to
-        // reach the CPU sample before deciding against a pre-fan-out reading.
-        settled = true;
+    // Held across the try so an unexpected throw (cpuBusy, sleep, a logger)
+    // cannot leave a slot flocked for the lifetime of the process — that would
+    // burn a slot permanently, which no reaper is allowed to clean up.
+    let mine = probeSlots(ctx.lockDir, ctx.slots);
+    try {
+      if (mine) {
+        if (ctx.maxBusy <= 0) return mine;
+        const busy = await ctx.cpuBusy();
+        if (busy < ctx.maxBusy) {
+          const waited = Math.round(ctx.now() - start);
+          // A run that queued reports its admission at warn, so the wait and its
+          // resolution both survive the am-i-done AI file logger (which mirrors
+          // only warn/error and discards the info log on success). An instant
+          // admission stays at info — the common case shouldn't cost context.
+          const log = announce.waited ? ctx.logger?.warn : ctx.logger?.info;
+          log?.(
+            `gate-lease: admitted on slot ${mine.index} after ${waited}ms — cpu ${(busy * 100).toFixed(0)}% < ${(ctx.maxBusy * 100).toFixed(0)}%, slots=${ctx.slots} (#2690)`,
+          );
+          return mine;
+        }
         releaseSlot(mine);
-        await ctx.sleep(ctx.settleMs);
-        continue;
+        mine = null;
+        announce(`for cpu headroom (${(busy * 100).toFixed(0)}% busy, need < ${(ctx.maxBusy * 100).toFixed(0)}%)`);
+      } else {
+        announce(`for a free slot (all ${ctx.slots} busy)`);
       }
-      const busy = await ctx.cpuBusy();
-      if (busy < ctx.maxBusy) {
-        const waited = Math.round(ctx.now() - start);
-        // A run that queued reports its admission at warn, so the wait and its
-        // resolution both survive the am-i-done AI file logger (which mirrors
-        // only warn/error and discards the info log on success). An instant
-        // admission stays at info — the common case shouldn't cost context.
-        const log = announce.waited ? ctx.logger?.warn : ctx.logger?.info;
-        log?.(
-          `gate-lease: admitted on slot ${mine.index} after ${waited}ms — cpu ${(busy * 100).toFixed(0)}% < ${(ctx.maxBusy * 100).toFixed(0)}%, slots=${ctx.slots} (#2690)`,
-        );
-        return mine;
-      }
-      releaseSlot(mine);
-      announce(`for cpu headroom (${(busy * 100).toFixed(0)}% busy, need < ${(ctx.maxBusy * 100).toFixed(0)}%)`);
-    } else {
-      announce(`for a free slot (all ${ctx.slots} busy)`);
+    } catch (err) {
+      if (mine) releaseSlot(mine);
+      throw err;
     }
     if (ctx.now() >= ctx.deadline) return null;
     await ctx.sleep(jitteredDelay(ctx.basePoll, ctx.random));
@@ -472,40 +546,61 @@ export async function acquireGateLease(opts: GateLeaseOptions = {}): Promise<Gat
     return UNHELD_LEASE;
   }
 
-  const waitMs = opts.waitMs ?? readWaitFromEnv();
+  const random = opts.random ?? Math.random;
+  const waitMs = opts.waitMs ?? readWaitFromEnv(logger);
+  // Each process shortens its own budget by up to DEADLINE_JITTER, so co-launched
+  // losers scatter instead of failing open in lockstep.
+  const budget = Math.round(waitMs * (1 - DEADLINE_JITTER * random()));
+  const start = now();
   const ctx: AdmitContext = {
     lockDir,
     slots,
     maxBusy: opts.maxBusy ?? readMaxBusyFromEnv(logger),
     basePoll: opts.pollIntervalMs ?? DEFAULT_POLL_MS,
-    settleMs: opts.settleMs ?? DEFAULT_SETTLE_MS,
-    deadline: now() + waitMs,
+    deadline: start + budget,
     sleep,
     now,
-    random: opts.random ?? Math.random,
+    random,
     cpuBusy: opts.cpuBusy ?? (() => sampleCpuBusy(sampleMs, sleep)),
     logger,
   };
 
-  const token = await acquireAdmitToken(ctx);
-  if (token === null) {
-    logger?.warn?.(`gate-lease: no admission token within ${waitMs}ms — proceeding unleased (fail-open, #2690)`);
-    return UNHELD_LEASE;
-  }
-
+  let token: { fd: number; waited: boolean } | null = null;
   try {
-    const slot = await decideAdmission(ctx, token.waited);
-    if (slot) return makeHeldLease(slot);
+    token = await acquireAdmitToken(ctx);
+    if (token === null) {
+      // Logged separately from the fail-open below only so the two causes stay
+      // distinguishable in a log; the outcome is deliberately the same.
+      logger?.warn?.(
+        `gate-lease: no admission token within ${budget}ms (a peer held the decision mutex the whole time) (#2690)`,
+      );
+    } else {
+      const slot = await decideAdmission(ctx, start, token.waited);
+      if (slot) return makeHeldLease(slot);
+    }
 
-    // Budget spent. Running with a slot is still better than running unleased,
-    // so take one if it happens to be free; otherwise proceed uncounted.
-    const { mine } = probeSlots(lockDir, slots);
+    // Budget spent — either never winning the token, or winning it and never
+    // getting headroom. Both paths land here deliberately: the run that never
+    // won the token is the one that waited longest, so it must not get the worse
+    // deal. Running with a slot is still better than running unleased, so take
+    // one if it happens to be free; otherwise proceed uncounted.
+    const mine = probeSlots(lockDir, slots);
     logger?.warn?.(
-      `gate-lease: no admission within ${waitMs}ms — proceeding ${mine ? `on slot ${mine.index}` : "unleased"} (fail-open, #2690)`,
+      `gate-lease: no admission within ${budget}ms — proceeding ${mine ? `on slot ${mine.index}` : "unleased"} (fail-open, #2690)`,
     );
     return mine ? makeHeldLease(mine) : UNHELD_LEASE;
+  } catch (err) {
+    // The lease must never fail the run it wraps (#2690) — an admission bug must
+    // not become a phantom gate failure. Held slots are released by the throwing
+    // frame before it rethrows.
+    logger?.warn?.(
+      `gate-lease: admission failed unexpectedly (${(err as Error).message}) — proceeding unleased (fail-open, #2690)`,
+    );
+    return UNHELD_LEASE;
   } finally {
-    flockUnlock(token.fd);
-    closeSync(token.fd);
+    if (token !== null) {
+      flockUnlock(token.fd);
+      closeSync(token.fd);
+    }
   }
 }

--- a/packages/core/src/gate-lease.ts
+++ b/packages/core/src/gate-lease.ts
@@ -18,24 +18,69 @@
  * (even SIGKILL) or fd close — so a crashed holder never strands a slot and
  * there is no stale-lock reaper to write.
  *
- * Fail-open: if every slot stays busy past a generous deadline, acquire returns
- * an un-held handle and the caller proceeds anyway. Oversubscribing slightly is
- * strictly better than hanging the gate forever behind a wedged holder. Waits
- * and fail-opens are logged so contention is observable.
+ * Admission has two stages, both on the way *in* — nothing is ever signalled,
+ * killed or reaped (the banned #2597/#2632 pattern):
+ *
+ *   1. Win a slot (bounds the number of concurrent gate runs).
+ *   2. Wait for load headroom (bounds total host pressure, including load this
+ *      process did not create — N agent sessions, editors, other builds).
+ *
+ * Stage 2 exists because a slot count alone is blind to non-gate load: one
+ * admitted gate run plus ~12 agent sessions measured load 18.9 on a 16-core
+ * host, so admitting a second full fan-out on top reaches the ~27 regime where
+ * the OS starts killing test workers.
+ *
+ * Fail-open at both stages: if every slot stays busy past a generous deadline,
+ * acquire returns an un-held handle and the caller proceeds anyway; if load
+ * never drops, the load wait gives up and the run proceeds holding its slot.
+ * Oversubscribing slightly is strictly better than hanging the gate forever
+ * behind a wedged holder or a permanently-busy host. Waits and fail-opens are
+ * logged so contention is observable.
  */
 
 import { closeSync, mkdirSync, openSync } from "node:fs";
+import { cpus, loadavg } from "node:os";
 import { join } from "node:path";
 
 import { options } from "./constants";
 import { flockUnlock, tryFlockExclusive } from "./flock";
 
-/** Default number of concurrent heavy test phases allowed across the host. */
-const DEFAULT_SLOTS = 2;
+/**
+ * Cores per allowed concurrent gate run, used to derive the default slot count.
+ *
+ * #2690 asked for `max(1, floor(cores/4))`. That is not implemented, because it
+ * contradicts the field measurements it was meant to fix: on the 16-core macOS
+ * host in the report, `cores/4` yields 4 slots — *more* permissive than the
+ * fixed 2 that was already in place and that produced the failures. Measured on
+ * that host: one admitted gate run plus ~12 agent sessions = load 18.9 on 16
+ * cores, and two concurrent runs reached ~27, the regime where the OS SIGTERMs
+ * bun test workers. Dividing by 8 keeps 16 cores at 2 (matching the value the
+ * host tolerates when load headroom is also respected — see MAX_LOAD_FACTOR)
+ * while correctly dropping 4- and 8-core hosts to 1, which the old hardcoded 2
+ * got wrong.
+ */
+const CORES_PER_SLOT = 8;
 /** Upper bound on slots — a huge value would exhaust the fd table per poll. */
 const MAX_SLOTS = 64;
+/**
+ * Default load ceiling as a fraction of core count.
+ *
+ * Deliberately below 1.0: a gate run's own `bun test --parallel` fan-out adds
+ * roughly a core's worth of load per worker, so admitting at exactly `cores`
+ * would start a full fan-out on an already-saturated box and land in the
+ * failure regime. 0.75 leaves the admitted run somewhere to grow into — on the
+ * 16-core reference host that admits at the observed ~8-10 idle baseline and
+ * blocks at the ~19 one-run-active reading.
+ */
+const DEFAULT_MAX_LOAD_FACTOR = 0.75;
 /** Generous fail-open deadline — proceed unleased rather than hang the gate. */
 const DEFAULT_TIMEOUT_MS = 15 * 60 * 1000;
+/**
+ * Fail-open deadline for the load-headroom wait. Shorter than the slot deadline:
+ * a slot frees when a peer finishes, but load on a permanently-busy host may
+ * never drop, so degrade to "just run it" sooner.
+ */
+const DEFAULT_LOAD_WAIT_MS = 5 * 60 * 1000;
 /** Base poll interval; jitter is added on top to avoid lockstep retries. */
 const DEFAULT_POLL_MS = 250;
 
@@ -46,12 +91,25 @@ export interface LeaseLogger {
 }
 
 export interface GateLeaseOptions {
-  /** Concurrent slots. Defaults to MCX_GATE_LEASE_SLOTS or 2. `<= 0` disables. */
+  /**
+   * Concurrent slots. Defaults to MCX_GATE_LEASE_SLOTS, else derived from the
+   * core count as `max(1, floor(cores/8))`. `<= 0` disables the gate entirely.
+   */
   slots?: number;
   /** Host-shared lock directory. Defaults to ~/.mcp-cli/gate-locks. */
   lockDir?: string;
   /** Fail-open deadline (ms). Defaults to MCX_GATE_LEASE_TIMEOUT_MS or 15min. */
   timeoutMs?: number;
+  /**
+   * 1-minute load-average ceiling for admission. Defaults to
+   * MCX_GATE_LEASE_MAX_LOAD, else `cores * 0.75`. `<= 0` skips the load wait.
+   */
+  maxLoad?: number;
+  /**
+   * Fail-open deadline for the load wait (ms). Defaults to
+   * MCX_GATE_LEASE_LOAD_WAIT_MS or 5min.
+   */
+  loadWaitMs?: number;
   /** Base poll interval (ms) while waiting for a free slot. */
   pollIntervalMs?: number;
   logger?: LeaseLogger;
@@ -61,6 +119,10 @@ export interface GateLeaseOptions {
   now?: () => number;
   /** DI seam: jitter source (injected in tests). */
   random?: () => number;
+  /** DI seam: 1-minute load average (defaults to os.loadavg()[0]). */
+  loadAvg?: () => number;
+  /** DI seam: logical core count (defaults to os.cpus().length). */
+  cpuCount?: () => number;
 }
 
 export interface GateLease {
@@ -74,19 +136,18 @@ export interface GateLease {
 
 const UNHELD_LEASE: GateLease = { held: false, slot: null, release: () => {} };
 
-function readSlotsFromEnv(logger?: LeaseLogger): number {
+function readSlotsFromEnv(cores: number, logger?: LeaseLogger): number {
+  const fallback = Math.max(1, Math.floor(cores / CORES_PER_SLOT));
   const raw = process.env.MCX_GATE_LEASE_SLOTS;
-  if (raw === undefined || raw === "") return DEFAULT_SLOTS;
+  if (raw === undefined || raw === "") return fallback;
   // parseInt silently truncates trailing garbage ("2abc" -> 2), which hides a
   // typo in a tuning value — reject non-integers with a warning instead.
   if (!/^\s*-?\d+\s*$/.test(raw)) {
-    logger?.warn?.(
-      `gate-lease: MCX_GATE_LEASE_SLOTS="${raw}" is not an integer — using default ${DEFAULT_SLOTS} (#2690)`,
-    );
-    return DEFAULT_SLOTS;
+    logger?.warn?.(`gate-lease: MCX_GATE_LEASE_SLOTS="${raw}" is not an integer — using default ${fallback} (#2690)`);
+    return fallback;
   }
   const n = Number.parseInt(raw, 10);
-  if (!Number.isFinite(n)) return DEFAULT_SLOTS;
+  if (!Number.isFinite(n)) return fallback;
   if (n > MAX_SLOTS) {
     logger?.warn?.(`gate-lease: MCX_GATE_LEASE_SLOTS=${n} exceeds max ${MAX_SLOTS} — capping to ${MAX_SLOTS} (#2690)`);
     return MAX_SLOTS;
@@ -102,6 +163,28 @@ function readTimeoutFromEnv(): number {
   if (raw === undefined || raw === "") return DEFAULT_TIMEOUT_MS;
   const n = Number.parseInt(raw, 10);
   return Number.isFinite(n) && n > 0 ? n : DEFAULT_TIMEOUT_MS;
+}
+
+function readMaxLoadFromEnv(cores: number, logger?: LeaseLogger): number {
+  const fallback = Math.max(1, cores * DEFAULT_MAX_LOAD_FACTOR);
+  const raw = process.env.MCX_GATE_LEASE_MAX_LOAD;
+  if (raw === undefined || raw === "") return fallback;
+  const n = Number.parseFloat(raw);
+  if (!Number.isFinite(n)) {
+    logger?.warn?.(`gate-lease: MCX_GATE_LEASE_MAX_LOAD="${raw}" is not a number — using default ${fallback} (#2690)`);
+    return fallback;
+  }
+  if (n <= 0) {
+    logger?.warn?.(`gate-lease: MCX_GATE_LEASE_MAX_LOAD=${n} disables the load wait — admitting immediately (#2690)`);
+  }
+  return n;
+}
+
+function readLoadWaitFromEnv(): number {
+  const raw = process.env.MCX_GATE_LEASE_LOAD_WAIT_MS;
+  if (raw === undefined || raw === "") return DEFAULT_LOAD_WAIT_MS;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : DEFAULT_LOAD_WAIT_MS;
 }
 
 function defaultSleep(ms: number): Promise<void> {
@@ -156,22 +239,91 @@ function makeHeldLease(slot: HeldSlot): GateLease {
   };
 }
 
+interface LoadWaitParams {
+  maxLoad: number;
+  loadWaitMs: number;
+  basePoll: number;
+  slotIndex: number;
+  sleep: (ms: number) => Promise<void>;
+  now: () => number;
+  random: () => number;
+  loadAvg: () => number;
+  logger?: LeaseLogger;
+}
+
+/**
+ * Stage 2 of admission: hold the slot until the host has load headroom.
+ *
+ * Waiting *while holding the slot* is the load-bearing part of this design, not
+ * an implementation detail — do not "optimise" it into a wait-then-acquire. The
+ * slot makes the load wait mutually exclusive, so at most K runs are ever
+ * watching the load average and they enter one at a time. Waiting before
+ * acquiring reproduces the convoy this replaces: in sprint 76 three sessions
+ * independently polled for load < 6 / < 3 / < 4, all cleared their private
+ * thresholds within the same instant, and fired their suites simultaneously —
+ * exactly the oversubscription the gate exists to prevent.
+ *
+ * Bounded fail-open: a permanently-busy host must degrade to "just run it",
+ * never hang. The run proceeds still holding its slot.
+ */
+async function waitForLoadHeadroom(p: LoadWaitParams): Promise<void> {
+  if (p.maxLoad <= 0) return;
+
+  const start = p.now();
+  const deadline = start + p.loadWaitMs;
+  let announced = false;
+
+  for (;;) {
+    const load = p.loadAvg();
+    if (load < p.maxLoad) {
+      if (announced) {
+        p.logger?.warn?.(
+          `gate-lease: slot ${p.slotIndex} admitted after waiting ${Math.round(p.now() - start)}ms for load ${load.toFixed(2)} < ${p.maxLoad.toFixed(2)} (#2690)`,
+        );
+      }
+      return;
+    }
+    if (p.now() >= deadline) {
+      p.logger?.warn?.(
+        `gate-lease: load ${load.toFixed(2)} still above ${p.maxLoad.toFixed(2)} after ${p.loadWaitMs}ms — proceeding anyway (fail-open, #2690)`,
+      );
+      return;
+    }
+    if (!announced) {
+      announced = true;
+      // warn (not info) for the same reason as the slot wait: the am-i-done AI
+      // file logger only mirrors warn/error, and "why am I not running yet" has
+      // to reach the worker or the run looks hung.
+      p.logger?.warn?.(
+        `gate-lease: holding slot ${p.slotIndex}, waiting for host load ${load.toFixed(2)} to fall below ${p.maxLoad.toFixed(2)} (#2690)`,
+      );
+    }
+    await p.sleep(jitteredDelay(p.basePoll, p.random));
+  }
+}
+
 /**
  * Acquire one of K cooperative gate slots, waiting for a free slot if all are
- * busy. Returns immediately with an unheld lease when disabled (`slots <= 0`)
- * or when the fail-open deadline elapses. Never throws on contention.
+ * busy and then for host load headroom. Returns immediately with an unheld
+ * lease when disabled (`slots <= 0`) or when the slot fail-open deadline
+ * elapses. Never throws on contention.
  */
 export async function acquireGateLease(opts: GateLeaseOptions = {}): Promise<GateLease> {
   const logger = opts.logger;
-  const slots = opts.slots ?? readSlotsFromEnv(logger);
+  const cpuCount = opts.cpuCount ?? (() => cpus().length);
+  const cores = Math.max(1, cpuCount());
+  const slots = opts.slots ?? readSlotsFromEnv(cores, logger);
   if (slots <= 0) return UNHELD_LEASE;
 
   const lockDir = opts.lockDir ?? join(options.MCP_CLI_DIR, "gate-locks");
   const timeoutMs = opts.timeoutMs ?? readTimeoutFromEnv();
+  const maxLoad = opts.maxLoad ?? readMaxLoadFromEnv(cores, logger);
+  const loadWaitMs = opts.loadWaitMs ?? readLoadWaitFromEnv();
   const basePoll = opts.pollIntervalMs ?? DEFAULT_POLL_MS;
   const sleep = opts.sleep ?? defaultSleep;
   const now = opts.now ?? (() => performance.now());
   const random = opts.random ?? Math.random;
+  const loadAvg = opts.loadAvg ?? (() => loadavg()[0] ?? 0);
 
   // Fail-open on any fs error creating the lock dir (read-only HOME, disk full,
   // bad permissions) — the lease must never fail the run it wraps (#2690).
@@ -199,7 +351,19 @@ export async function acquireGateLease(opts: GateLeaseOptions = {}): Promise<Gat
       if (announcedWait) {
         logger?.warn?.(`gate-lease: acquired slot ${slot.index} after waiting ${now() - start}ms (#2690)`);
       }
-      return makeHeldLease(slot);
+      const lease = makeHeldLease(slot);
+      await waitForLoadHeadroom({
+        maxLoad,
+        loadWaitMs,
+        basePoll,
+        slotIndex: slot.index,
+        sleep,
+        now,
+        random,
+        loadAvg,
+        logger,
+      });
+      return lease;
     }
     if (now() >= deadline) {
       logger?.warn?.(

--- a/scripts/_runner/runner.spec.ts
+++ b/scripts/_runner/runner.spec.ts
@@ -464,3 +464,54 @@ exit 0
     expect(report.success).toBe(true);
   });
 });
+
+describe("StepRunner gate-lease admission (#2690)", () => {
+  function leaseSpy() {
+    const calls: number[] = [];
+    let releases = 0;
+    const acquireLease = async () => {
+      calls.push(calls.length);
+      return { held: true, slot: 0, release: () => void releases++ };
+    };
+    return { acquireLease, calls, released: () => releases };
+  }
+
+  const leased = (name: string): Step => ({ ...ok(name), lease: true });
+
+  it("acquires admission ONCE PER RUN, not once per leased step", async () => {
+    // The #2949 blocker: three leased steps meant three acquisitions, so a run
+    // could pay the admission budget three times over and wait on the load its
+    // own previous step had just created.
+    const { logger } = makeLog();
+    const spy = leaseSpy();
+    const report = await new StepRunner({ logger, acquireLease: spy.acquireLease })
+      .add(ok("typecheck"), leased("test-parallel"), leased("test-control"), leased("coverage"))
+      .run();
+
+    expect(report.success).toBe(true);
+    expect(spy.calls.length).toBe(1);
+    expect(spy.released()).toBe(1);
+  });
+
+  it("does not take admission at all when no step in range is leased", async () => {
+    const { logger } = makeLog();
+    const spy = leaseSpy();
+    await new StepRunner({ logger, acquireLease: spy.acquireLease }).add(ok("typecheck"), ok("lint")).run();
+    expect(spy.calls.length).toBe(0);
+  });
+
+  it("releases admission when a leased step fails and the run stops early", async () => {
+    const { logger } = makeLog();
+    const spy = leaseSpy();
+    const boom: Step = {
+      name: "test-parallel",
+      description: "x",
+      command: async () => ({ success: false }),
+      lease: true,
+    };
+    const report = await new StepRunner({ logger, acquireLease: spy.acquireLease }).add(boom, leased("coverage")).run();
+    expect(report.success).toBe(false);
+    expect(spy.calls.length).toBe(1);
+    expect(spy.released()).toBe(1);
+  });
+});

--- a/scripts/_runner/runner.ts
+++ b/scripts/_runner/runner.ts
@@ -24,7 +24,7 @@
 
 import { spawn } from "node:child_process";
 
-import { withGateLease } from "@mcp-cli/core";
+import { type GateLease, acquireGateLease } from "@mcp-cli/core";
 
 import { createCaptureLogger } from "./logger";
 import type { Logger, ScriptFunction, Step, StepResult } from "./types";
@@ -39,6 +39,8 @@ export interface RunnerOptions {
   logger: Logger;
   /** Optional override for process.env (used in tests). */
   env?: Record<string, string | undefined>;
+  /** DI seam: gate-lease acquisition (injected in tests). */
+  acquireLease?: typeof acquireGateLease;
 }
 
 export interface RunReport {
@@ -67,37 +69,47 @@ export class StepRunner {
     const t0 = Date.now();
     const failures: RunReport["failures"] = [];
 
-    for (const [i, step] of slice.entries()) {
-      const idx = startIdx + i;
-      if (skip && matchesAny(step.name, skip)) {
-        logger.info(`[${idx + 1}/${this.steps.length}] ${step.name} — skipped (--skip)`);
-        continue;
-      }
-      const stepStart = Date.now();
-      logger.info(`[${idx + 1}/${this.steps.length}] ${step.name} — ${step.description}`);
+    // Heavy test phases run under a host-global gate lease so N concurrent gate
+    // runs across worktrees don't oversubscribe the host (#2690). Admission is
+    // acquired ONCE PER RUN — lazily, at the first leased step, and held until
+    // the run ends. Acquiring per step multiplied the admission budget by the
+    // number of leased steps (three in the default list) and made a run wait on
+    // the load its own previous step had just created. The lease logs waits /
+    // fail-open to the real logger so contention stays visible even when the
+    // step's own output is suppressed.
+    let lease: GateLease | null = null;
+    try {
+      for (const [i, step] of slice.entries()) {
+        const idx = startIdx + i;
+        if (skip && matchesAny(step.name, skip)) {
+          logger.info(`[${idx + 1}/${this.steps.length}] ${step.name} — skipped (--skip)`);
+          continue;
+        }
+        logger.info(`[${idx + 1}/${this.steps.length}] ${step.name} — ${step.description}`);
+        if (step.lease && !lease) lease = await (this.opts.acquireLease ?? acquireGateLease)({ logger });
 
-      // Heavy test phases run under a host-global gate lease so N concurrent
-      // gate runs across worktrees don't oversubscribe the host (#2690). The
-      // lease logs waits / fail-open to the real logger so contention is
-      // visible even when the step's own output is suppressed.
-      const result = step.lease ? await withGateLease(() => this.runStep(step), { logger }) : await this.runStep(step);
-      const ms = Date.now() - stepStart;
+        const stepStart = Date.now();
+        const result = await this.runStep(step);
+        const ms = Date.now() - stepStart;
 
-      if (result.success) {
-        logger.info(`  ✓ ${step.name} (${formatMs(ms)})`);
-        continue;
-      }
-      const failure = { step, index: idx, durationMs: ms, error: result.error };
-      failures.push(failure);
-      if (step.critical === false) {
-        logger.warn(`  ⚠ ${step.name} failed (${formatMs(ms)}) — non-critical, continuing`);
+        if (result.success) {
+          logger.info(`  ✓ ${step.name} (${formatMs(ms)})`);
+          continue;
+        }
+        const failure = { step, index: idx, durationMs: ms, error: result.error };
+        failures.push(failure);
+        if (step.critical === false) {
+          logger.warn(`  ⚠ ${step.name} failed (${formatMs(ms)}) — non-critical, continuing`);
+          emitOnFailure(logger, step);
+          continue;
+        }
+        logger.error(`  ✗ ${step.name} failed (${formatMs(ms)})`);
         emitOnFailure(logger, step);
-        continue;
+        logger.info(`  ↻ rerun: bun run am-i-done --from ${idx + 1}`);
+        if (failFast) break;
       }
-      logger.error(`  ✗ ${step.name} failed (${formatMs(ms)})`);
-      emitOnFailure(logger, step);
-      logger.info(`  ↻ rerun: bun run am-i-done --from ${idx + 1}`);
-      if (failFast) break;
+    } finally {
+      lease?.release();
     }
 
     const totalMs = Date.now() - t0;

--- a/scripts/am-i-done.ts
+++ b/scripts/am-i-done.ts
@@ -114,8 +114,11 @@ const RULES: Step = {
 };
 
 // lease: true on the heavy test phases caps the host-wide concurrent test-
-// worker fan-out under N simultaneous gate runs across worktrees (#2690). CI
-// steps stay unleased — each CI runner is its own host, so the per-container
+// worker fan-out under N simultaneous gate runs across worktrees (#2690).
+// Admission is two-stage: win one of K slots, then wait for host load headroom
+// (K alone is blind to load this process didn't create — see gate-lease.ts).
+// Both stages queue and fail open; neither ever signals a process. CI steps
+// stay unleased — each CI runner is its own host, so the per-container
 // semaphore would never block and we don't want to perturb CI timing.
 const TEST_PARALLEL: Step = {
   name: "test-parallel",
@@ -411,6 +414,13 @@ workflow — one definition of done (#2345).
 
 The default (no flag) runs the developer-friendly comprehensive list:
 parallel tests, \`biome --write\` for auto-fix, naive coverage step.
+
+Heavy test phases queue behind a host-wide admission gate so N concurrent gate
+runs across worktrees don't oversubscribe the machine (#2690). A run that logs
+"queueing for a free slot" or "waiting for host load" is waiting, not hung —
+both waits are bounded and fail open. Tune with MCX_GATE_LEASE_SLOTS (default
+max(1, cores/8)), MCX_GATE_LEASE_MAX_LOAD (default 0.75 x cores; 0 disables the
+load wait) and MCX_GATE_LEASE_LOAD_WAIT_MS (default 5min).
 
 In a Claude / AI context (CLAUDECODE / AGENT / MCP_CLI_AI env var set),
 step output is captured to build/am-i-done-<timestamp>.txt and only the

--- a/scripts/am-i-done.ts
+++ b/scripts/am-i-done.ts
@@ -419,11 +419,15 @@ A run containing heavy test phases takes host-wide admission ONCE, before its
 first leased step, so N concurrent gate runs across worktrees don't oversubscribe
 the machine (#2690). A run that logs "gate-lease: waiting ..." is queued, not
 hung — the message repeats every 30s with elapsed/remaining, and admission is
-bounded by a single whole-run budget that fails open. Tune with
+bounded by a single whole-run budget that fails open. The budget outlasts a
+normal run's hold (~200s), so co-launched runs serialize; behind an abnormally
+long holder it staggers them instead, deliberately, rather than hanging. Tune with
 MCX_GATE_LEASE_SLOTS (default 1 — one fan-out already sizes itself to the whole
 host, so a second does not fit; 0 disables), MCX_GATE_LEASE_MAX_BUSY (CPU busy
 fraction, default 0.6; 0 disables the headroom wait) and MCX_GATE_LEASE_WAIT_MS
-(default 120s — deliberately well inside the 600s timeout workers wrap this in).
+(default 300s, capped at 400s so the wait plus the run it admits stays inside the
+600s timeout workers wrap this in; each process jitters its own deadline down by
+up to 25% so losers don't all give up at once).
 
 In a Claude / AI context (CLAUDECODE / AGENT / MCP_CLI_AI env var set),
 step output is captured to build/am-i-done-<timestamp>.txt and only the

--- a/scripts/am-i-done.ts
+++ b/scripts/am-i-done.ts
@@ -113,13 +113,13 @@ const RULES: Step = {
   ],
 };
 
-// lease: true on the heavy test phases caps the host-wide concurrent test-
-// worker fan-out under N simultaneous gate runs across worktrees (#2690).
-// Admission is two-stage: win one of K slots, then wait for host load headroom
-// (K alone is blind to load this process didn't create — see gate-lease.ts).
-// Both stages queue and fail open; neither ever signals a process. CI steps
-// stay unleased — each CI runner is its own host, so the per-container
-// semaphore would never block and we don't want to perturb CI timing.
+// lease: true marks the heavy test phases as needing host-wide admission, which
+// caps the concurrent test-worker fan-out under N simultaneous gate runs across
+// worktrees (#2690). The runner acquires admission ONCE PER RUN at the first
+// leased step, not per step — see runner.ts and gate-lease.ts. Admission queues
+// and fails open; it never signals a process. CI steps stay unleased — each CI
+// runner is its own host, so the per-container semaphore would never block and
+// we don't want to perturb CI timing.
 const TEST_PARALLEL: Step = {
   name: "test-parallel",
   description: "bun test --parallel (excluding packages/control — yoga-layout TDZ, #2362)",
@@ -415,12 +415,15 @@ workflow — one definition of done (#2345).
 The default (no flag) runs the developer-friendly comprehensive list:
 parallel tests, \`biome --write\` for auto-fix, naive coverage step.
 
-Heavy test phases queue behind a host-wide admission gate so N concurrent gate
-runs across worktrees don't oversubscribe the machine (#2690). A run that logs
-"queueing for a free slot" or "waiting for host load" is waiting, not hung —
-both waits are bounded and fail open. Tune with MCX_GATE_LEASE_SLOTS (default
-max(1, cores/8)), MCX_GATE_LEASE_MAX_LOAD (default 0.75 x cores; 0 disables the
-load wait) and MCX_GATE_LEASE_LOAD_WAIT_MS (default 5min).
+A run containing heavy test phases takes host-wide admission ONCE, before its
+first leased step, so N concurrent gate runs across worktrees don't oversubscribe
+the machine (#2690). A run that logs "gate-lease: waiting ..." is queued, not
+hung — the message repeats every 30s with elapsed/remaining, and admission is
+bounded by a single whole-run budget that fails open. Tune with
+MCX_GATE_LEASE_SLOTS (default 1 — one fan-out already sizes itself to the whole
+host, so a second does not fit; 0 disables), MCX_GATE_LEASE_MAX_BUSY (CPU busy
+fraction, default 0.6; 0 disables the headroom wait) and MCX_GATE_LEASE_WAIT_MS
+(default 120s — deliberately well inside the 600s timeout workers wrap this in).
 
 In a Claude / AI context (CLAUDECODE / AGENT / MCP_CLI_AI env var set),
 step output is captured to build/am-i-done-<timestamp>.txt and only the


### PR DESCRIPTION
## What #2690 asked for, and what was actually wrong

The issue asks for a flock-based cooperative lease. **That already exists** — `packages/core/src/gate-lease.ts`, landed by #2758 and hardened by #2819, wired to the heavy steps via `Step.lease`. The issue's own text ("still unimplemented as of sprint 77") misdiagnosed the remaining work: the recurring `worker crashed: SIGTERM` symptom was real, but the named cause was already fixed.

What actually remained — established by measurement, and largely re-established by the adversarial review on this PR:

**1. The signal was unreachable.** Admission gated on `os.loadavg()[0] < 0.75 × cores`. On the 16-core reference host, sampled *simultaneously*:

```
loadavg = 20.27 / 23.38 / 23.85     ceiling = 12.00     CPU busy = 16.6%
```

loadavg reported **168% of core count while 83% of the CPU sat idle** — it counts D-state I/O waiters and is inflated by ~50 mostly-API-blocked agent sessions. The ceiling was therefore *unsatisfiable in normal operation*: every admission burned its entire budget and then ran anyway. A gate that waits and then runs regardless is strictly worse than no gate. loadavg also lags — a 1-min EWMA reaches ~40% of a peer's steady-state fan-out only after 30s — so a run could clear on its own decaying exhaust.

**2. The budget was per-step, not per-run.** `runner.ts` acquired a lease at *each* leased step (three in the default list), multiplying the admission budget by the step count and making a run wait on load its own previous step had just created.

**3. A docstring claimed an invariant the code did not provide.** "Runs enter one at a time" was asserted for K>1, where it was false, and the test that "proved" it pinned `slots: 1` so it never exercised the default.

## The fix

**Admission is taken once per RUN**, lazily at the first leased step, held until the run ends, against a **single whole-run budget** (120s — deliberately well inside the 600s foreground timeout that workers wrap `am-i-done` in; a green run is ~100-200s, so a larger budget would manufacture the phantom failures the gate exists to prevent). A DI seam on `RunnerOptions` makes the once-per-run property testable.

**Two flock resources**, which is what makes the ordering claim true at *any* K:

- `admit.lock` — one host-wide mutex held for the duration of one admission *decision*. Exactly one process is ever deciding, so decisions are totally ordered and two runs cannot both clear the same stale reading.
- `slot-<i>.lock` — K counting slots bounding concurrent *execution*.

A run rejected on headroom **releases its slot** and waits on the token, so a slot is only ever held by a run that is working — a queued run never waits behind a peer that is itself only waiting.

**Signal is now the instantaneous busy fraction** of all cores from `os.cpus()` tick deltas, against a 0.6 ceiling. Being instantaneous rather than a 1-min EWMA drops the settle needed to observe a peer's fan-out from ~60s to 2s, and expressing the ceiling as a fraction gives a 1- or 2-core host a meaningful bound.

**Default slot count is 1**, not the issue's `max(1, floor(cores/4))`. There is no defensible core-derived count, because a gate run's fan-out is *already* sized to the host — `bun test --parallel` starts ~cpu-count workers, so one run wants the whole machine whatever the machine is. Sampling CPU busy through a real `am-i-done`:

```
baseline (agent sessions only)    25-33%
during test-parallel              44 → 88% peak, 76-83% sustained ~20s
```

One fan-out consumes ~75-85% of the box on top of a ~25% baseline, so a second does not fit at any core count a fan-out scales to. `cores/4` would have admitted **four** on this host. K>1 machinery remains, reachable only via `MCX_GATE_LEASE_SLOTS`.

**This does NOT retire the `/tmp/mcx-am-i-done.lock` stopgap.** The stopgap stays in force until this demonstrably improves on it in practice. K=1 is deliberately the *same* effective concurrency the stopgap achieves (it measured load 27 → 14) — the improvements over it are that this is host-wide rather than per-orchestrator, crash-safe via flock with no lock dir to strand, adds a CPU-headroom check, and makes contention observable.

## Demonstration at the DEFAULT slot count, on a loaded host

Numbers, not a docstring. Four concurrent processes, no env overrides (`slots=1 maxBusy=0.60`, 120s budget), host at loadavg 20.27, each holding for a simulated 4s run:

```
[B] admitted on slot 0 after   253ms — cpu 32% < 60%      ACQUIRED at    256ms
[A] waiting for the admission token (a peer is deciding) → waiting for a free slot (all 1 busy)
[A] admitted on slot 0 after  4431ms — cpu 32% < 60%      ACQUIRED at  4,693ms
[C] admitted on slot 0 after  4609ms — cpu 26% < 60%      ACQUIRED at  9,362ms
[D] admitted on slot 0 after  4222ms — cpu 25% < 60%      ACQUIRED at 13,828ms
```

- **Strictly serialized**: never more than one concurrent holder, all on slot 0.
- **Every wait is bounded by real work**, not a dead timer: each ≈ the predecessor's actual 4s hold.
- **Zero fail-opens.** Budget remaining at each wait announcement: 119,738ms → 115,248ms → 110,395ms.
- **The old code on this same host** would have blocked all four on `load 20.27 > 12.00` for the full 5-minute headroom budget, then failed open and run all four concurrently anyway.

Waits re-announce every 30s with elapsed/remaining and the effective config, so a queued run never reads as a wedge. A run that *queued* logs its admission at `warn` rather than `info`, so both the wait and its resolution survive the `am-i-done` AI file logger (which discards the info log on success) — without this, a successful queued run left no trace in the PR record.

## Scope

Admission control on entry only. Nothing is signalled, killed or reaped — no watchdog, no reaper, no `ps`-and-kill (the #2597/#2632 pattern reverted in #2637). `packages/core/src/flock.ts` is untouched. #2954 (flock inode hazard) is pre-existing and out of scope.

## Test plan

- [x] `bun test packages/core/src/gate-lease.spec.ts scripts/_runner/runner.spec.ts scripts/am-i-done.spec.ts` — 56 pass. Tests exercise the **default** configuration; the two cases that need a distinguishable free slot pass `slots: 2` explicitly and document why K=1 cannot express them.
- [x] Once-per-run admission asserted directly: four steps, three leased → exactly one acquire, one release.
- [x] `bun typecheck` — clean. `bunx biome check` — clean.
- [x] Four-process contention demo at the default slot count on a loaded host (above).
- [x] Pre-commit gate (typecheck + lint + rules + test + coverage) passed on commit.
- [ ] Full `bun run am-i-done` under the host lock — **held**: host is at loadavg 20-23 on 16 cores from a post-restart Spotlight reindex (6.2GB across 61 worktrees). A full gate under that load produces a starvation cascade whose result is meaningless in both directions. Queued behind a bounded load poll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)