### PR TITLE
fix(phases): transition log → bun:sqlite; atomic commits, indexed reads, no advisory locking

### DIFF
--- a/docs/phases.md
+++ b/docs/phases.md
@@ -433,6 +433,29 @@ Transitions are logged to `.mcx/transitions.db` (SQLite). A pre-existing
 `.mcx/transitions.jsonl.migrated`. Disallowed or regressive transitions fail
 unless `--force "<message>"` is supplied.
 
+The import never deletes or consumes log data, and is announced on stderr —
+including where the original was parked, since that is what recovery reads from:
+
+```
+migrated 1919 entries from .mcx/transitions.jsonl → .mcx/transitions.db; original parked at .mcx/transitions.jsonl.migrated
+```
+
+Recovery affordances, all of which are safe to use more than once:
+
+- **Restoring a parked file** (`cp transitions.jsonl.migrated transitions.jsonl`)
+  re-imports it, and is idempotent: dedupe is keyed on a content hash of the
+  file plus a row-level check, so entries already in the store are skipped
+  rather than duplicated. Only genuinely new records are added — which is also
+  what makes a mixed-binary rollout safe, where an older binary regenerates a
+  jsonl the new one then imports.
+- **Records that are valid JSON but not valid entries** are reported as corrupt
+  lines and skipped. They cannot abort the import, and the original bytes remain
+  in the parked file.
+- **A claimed file that cannot be imported at all** is moved to
+  `.mcx/transitions.jsonl.unimportable.<nonce>` and reported, so one bad file
+  costs a single error instead of failing every subsequent read and write. It is
+  left on disk because it may be the only copy.
+
 ### Dry-run limitations
 
 `mcx phase run <name> --dry-run` is currently unreliable for sprint-style

--- a/docs/phases.md
+++ b/docs/phases.md
@@ -428,8 +428,10 @@ mcx phase run <target> \           # validate + log a transition
 mcx phase run <name> --dry-run     # execute the handler with a logging proxy
 ```
 
-Transitions are logged to `.mcx/transitions.jsonl`. Disallowed or regressive
-transitions fail unless `--force "<message>"` is supplied.
+Transitions are logged to `.mcx/transitions.db` (SQLite). A pre-existing
+`.mcx/transitions.jsonl` is imported on first open and parked as
+`.mcx/transitions.jsonl.migrated`. Disallowed or regressive transitions fail
+unless `--force "<message>"` is supplied.
 
 ### Dry-run limitations
 

--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -9,6 +9,7 @@ import {
   appendTransitionLog,
   historyTargets,
   parseLockfile,
+  readAllTransitions,
   readTransitionHistory,
   serializeLockfile,
 } from "@mcp-cli/core";
@@ -1586,7 +1587,7 @@ describe("formatDriftWarning", () => {
 
 describe("parsePhaseLogArgs", () => {
   test("defaults to no filters", () => {
-    expect(parsePhaseLogArgs([])).toEqual({ workItemId: null, forcedOnly: false, json: false });
+    expect(parsePhaseLogArgs([])).toEqual({ workItemId: null, forcedOnly: false, json: false, tail: null });
   });
 
   test("parses flags", () => {
@@ -1594,12 +1595,24 @@ describe("parsePhaseLogArgs", () => {
       workItemId: "#42",
       forcedOnly: true,
       json: true,
+      tail: null,
     });
     expect(parsePhaseLogArgs(["--work-item=#99"])).toEqual({
       workItemId: "#99",
       forcedOnly: false,
       json: false,
+      tail: null,
     });
+  });
+
+  test("parses --tail", () => {
+    expect(parsePhaseLogArgs(["--tail", "5"]).tail).toBe(5);
+    expect(parsePhaseLogArgs(["--tail=0"]).tail).toBe(0);
+  });
+
+  test("rejects a non-numeric --tail", () => {
+    expect(() => parsePhaseLogArgs(["--tail", "-3"])).toThrow(/--tail requires a non-negative integer/);
+    expect(() => parsePhaseLogArgs(["--tail", "abc"])).toThrow(/--tail requires a non-negative integer/);
   });
 
   test("rejects unknown flag", () => {
@@ -2153,12 +2166,7 @@ defineAlias(({ z }) => ({
     // "approved" is only logged on successful commit, never on crash.
     expect(errs.some((e) => e.includes("approved"))).toBe(false);
     // Log contains the attempted entry (audit trail) but NOT a committed one.
-    const { readFileSync: rfs } = require("node:fs");
-    const raw = rfs(join(dir, ".mcx", "transitions.jsonl"), "utf-8") as string;
-    const entries = raw
-      .split("\n")
-      .filter((l) => l.length > 0)
-      .map((l) => JSON.parse(l) as { to: string; status?: string });
+    const entries = readAllTransitions(join(dir, ".mcx", "transitions.jsonl"));
     const attempted = entries.filter((e) => e.status === "attempted");
     const committed = entries.filter((e) => e.status === "committed");
     expect(attempted.length).toBe(1);
@@ -2221,12 +2229,7 @@ defineAlias(({ z }) => ({
     expect(second.logs.join("\n")).toContain('"action": "in-flight"');
 
     // Both runs committed to the log (idempotent self-loop allowed).
-    const { readFileSync: rfs } = require("node:fs");
-    const raw = rfs(join(dir, ".mcx", "transitions.jsonl"), "utf-8") as string;
-    const entries = raw
-      .split("\n")
-      .filter((l) => l.length > 0)
-      .map((l) => JSON.parse(l) as { status?: string; to: string });
+    const entries = readAllTransitions(join(dir, ".mcx", "transitions.jsonl"));
     expect(entries.filter((e) => e.status === "committed").length).toBe(2);
     expect(entries.filter((e) => e.status === "attempted").length).toBe(2);
   }, 30_000);

--- a/packages/command/src/commands/phase.spec.ts
+++ b/packages/command/src/commands/phase.spec.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import {
   DisallowedTransitionError,
   RegressionError,
+  TransitionLockBusyError,
   UnknownPhaseError,
   appendTransitionLog,
   historyTargets,
@@ -24,12 +25,14 @@ import {
 import {
   type AdvanceChainEntry,
   type AdvanceResult,
+  COMMIT_LOCK_RETRY_DELAYS_MS,
   type PhaseInstallDeps,
   buildPhaseList,
   buildPhaseShow,
   checkStateSubset,
   cmdPhase,
   cmdPhaseAdvance,
+  commitWithLockRetry,
   detectDrift,
   executePhase,
   explainTransition,
@@ -3787,5 +3790,70 @@ phases:
     const { err: e, exitCode } = await runAdvance("#42", cycleOutputs, { workItemPhase: "impl" });
     expect(exitCode).toBe(2);
     expect(e.some((l) => l.includes("stranded"))).toBe(true);
+  });
+});
+
+describe("commitWithLockRetry (post-handler commit contention)", () => {
+  const busy = () => new TransitionLockBusyError("/x/.mcx/transitions.db", 5000);
+
+  test("retries a contended commit and returns the eventual result", async () => {
+    // The commit runs AFTER the handler, so the branch/PR/labels already exist.
+    // Throwing on the first busy error leaves db/log divergence that looks
+    // identical to a handler that never ran.
+    let calls = 0;
+    const slept: number[] = [];
+    const result = await commitWithLockRetry(
+      () => {
+        calls++;
+        if (calls < 3) throw busy();
+        return "committed";
+      },
+      { sleep: async (ms) => void slept.push(ms), random: () => 0.5 },
+    );
+
+    expect(result).toBe("committed");
+    expect(calls).toBe(3);
+    // Jittered within the lower half of each step, and increasing.
+    expect(slept).toEqual([37.5, 112.5]);
+  });
+
+  test("a commit that succeeds first time never sleeps", async () => {
+    const slept: number[] = [];
+    expect(await commitWithLockRetry(() => "ok", { sleep: async (ms) => void slept.push(ms) })).toBe("ok");
+    expect(slept).toEqual([]);
+  });
+
+  test("retries are bounded and the busy error is surfaced, not swallowed", async () => {
+    let calls = 0;
+    const slept: number[] = [];
+    await expect(
+      commitWithLockRetry(
+        () => {
+          calls++;
+          throw busy();
+        },
+        { sleep: async (ms) => void slept.push(ms), random: () => 0 },
+      ),
+    ).rejects.toThrow(TransitionLockBusyError);
+
+    expect(calls).toBe(COMMIT_LOCK_RETRY_DELAYS_MS.length + 1);
+    expect(slept).toHaveLength(COMMIT_LOCK_RETRY_DELAYS_MS.length);
+  });
+
+  test("a non-contention error is rethrown immediately without retrying", async () => {
+    let calls = 0;
+    const slept: number[] = [];
+    await expect(
+      commitWithLockRetry(
+        () => {
+          calls++;
+          throw new RegressionError("qa", "impl", "#1", ["impl", "qa"]);
+        },
+        { sleep: async (ms) => void slept.push(ms) },
+      ),
+    ).rejects.toThrow(RegressionError);
+
+    expect(calls).toBe(1);
+    expect(slept).toEqual([]);
   });
 });

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -5,7 +5,7 @@
  *   - `install` (#1291): resolves sources in the manifest, hashes them,
  *     extracts phase metadata, writes `.mcx.lock`.
  *   - `run <target>` (#1293): validates the transition against the manifest
- *     graph, appends it to `.mcx/transitions.jsonl`, prints "approved".
+ *     graph, appends it to `.mcx/transitions.db`, prints "approved".
  *   - `check` (#1292): detects drift between `.mcx.lock` and on-disk sources.
  *   - `list`: prints all declared phases from the manifest.
  *
@@ -362,6 +362,8 @@ export interface PhaseLogOptions {
   workItemId: string | null;
   forcedOnly: boolean;
   json: boolean;
+  /** Show only the newest N transitions; null = unbounded. */
+  tail: number | null;
 }
 
 export function parsePhaseLogArgs(args: string[]): PhaseLogOptions {
@@ -369,6 +371,7 @@ export function parsePhaseLogArgs(args: string[]): PhaseLogOptions {
     "work-item": { type: "string" },
     "forced-only": { type: "boolean" },
     json: { type: "boolean" },
+    tail: { type: "string" },
   });
 
   if (errors.length > 0) {
@@ -381,14 +384,28 @@ export function parsePhaseLogArgs(args: string[]): PhaseLogOptions {
   const workItemId = (flags["work-item"] as string | undefined) ?? null;
   if (workItemId !== null && workItemId === "") throw new Error("--work-item requires a non-empty id");
 
+  const rawTail = flags.tail as string | undefined;
+  let tail: number | null = null;
+  if (rawTail !== undefined) {
+    if (!/^\d+$/.test(rawTail)) throw new Error("--tail requires a non-negative integer");
+    tail = Number(rawTail);
+  }
+
   return {
     workItemId,
     forcedOnly: (flags["forced-only"] as boolean | undefined) ?? false,
     json: (flags.json as boolean | undefined) ?? false,
+    tail,
   };
 }
 
-/** Apply filters from options; return newest-first. */
+/**
+ * Present transition entries newest-first.
+ *
+ * The filters are pushed into SQL by `readAllTransitions` (#1375), so this is
+ * the display-order step; the predicates are kept here so the function is
+ * correct for any caller that hands it an unfiltered list.
+ */
 export function filterTransitionLog(
   entries: readonly TransitionLogEntry[],
   opts: { workItemId?: string | null; forcedOnly?: boolean },
@@ -429,6 +446,14 @@ export function formatTransitionLog(entries: readonly TransitionLogEntry[]): str
   return out;
 }
 
+/**
+ * Locator for a repo's transition log.
+ *
+ * Still the historical `.mcx/transitions.jsonl` path: the store is SQLite now
+ * (`.mcx/transitions.db`, see `transitionDbPath`), but every API takes the
+ * jsonl path as the key so existing callers and any leftover jsonl awaiting
+ * migration resolve to the same store.
+ */
 export function transitionLogPath(repoDir: string): string {
   return join(repoDir, ".mcx", "transitions.jsonl");
 }
@@ -912,7 +937,13 @@ export async function cmdPhase(
 
     if (sub === "log") {
       const opts = parsePhaseLogArgs(args.slice(1));
-      const entries = filterTransitionLog(readAllTransitions(transitionLogPath(stateCwd())), opts);
+      // Filters and --tail are pushed into SQL rather than read-then-filter.
+      const rows = readAllTransitions(transitionLogPath(stateCwd()), {
+        workItemId: opts.workItemId,
+        forcedOnly: opts.forcedOnly,
+        ...(opts.tail !== null ? { tail: opts.tail } : {}),
+      });
+      const entries = filterTransitionLog(rows, opts);
       if (opts.json) {
         for (const e of entries) d.log(JSON.stringify(e));
       } else if (entries.length === 0) {
@@ -1239,7 +1270,7 @@ function toAliasWorkItem(w: WorkItem): AliasWorkItemInfo {
  *      the transition log is empty (#1522). Early-exit on missing id.
  *   3. Pre-validate the transition against committed history so bogus
  *      moves fail fast before we bundle or dispatch anything.
- *   4. Append an `"attempted"` entry to `.mcx/transitions.jsonl`. This
+ *   4. Append an `"attempted"` entry to `.mcx/transitions.db`. This
  *      captures attempt evidence from ANY branch, including cases that
  *      branch-guard rejects or handlers crash. Attempted entries are
  *      ignored by graph-walk / regression checks (#1407). Note: early
@@ -1901,9 +1932,10 @@ Subcommands:
       5-step orchestrator sequence of phase run + update + spawn + state_set.
       Exits 0 on wait/in-flight/spawn; exits 2 on cycle cap (8 iterations).
 
-  mcx phase log [--work-item <id>] [--forced-only] [--json]
-      Print transitions from .mcx/transitions.jsonl, newest first.
+  mcx phase log [--work-item <id>] [--forced-only] [--tail <n>] [--json]
+      Print transitions from .mcx/transitions.db, newest first.
       --forced-only shows only entries with a --force justification.
+      --tail <n> shows only the newest n transitions after filtering.
       --json emits one JSON object per line for piping.`);
 }
 

--- a/packages/command/src/commands/phase.ts
+++ b/packages/command/src/commands/phase.ts
@@ -35,6 +35,7 @@ import {
   type ManifestState,
   NO_REPO_ROOT,
   RegressionError,
+  TransitionLockBusyError,
   type TransitionLogEntry,
   UnknownPhaseError,
   type WorkItem,
@@ -480,6 +481,42 @@ export function phaseRun(
   });
 
   return { manifest, forced: decision.forced, from: decision.from };
+}
+
+/**
+ * Backoff schedule for the post-handler commit. Bounded: the handler has
+ * already run, so waiting forever is not an option either.
+ */
+export const COMMIT_LOCK_RETRY_DELAYS_MS = [50, 150, 400, 1000] as const;
+
+/**
+ * Run the post-handler transition commit, retrying while the write lock is
+ * contended.
+ *
+ * `TransitionLockBusyError` was handled nowhere at all, and this is the one call
+ * site where losing the lock is genuinely expensive: the commit happens *after*
+ * `executeAliasBundled` returns, so the handler has already pushed the branch,
+ * opened the PR and set labels. Throwing there leaves a stuck work item whose
+ * side effects happened but whose transition was never recorded — db/log
+ * divergence, with nothing to distinguish it from a handler that never ran.
+ *
+ * Jittered so that N phase runs that collided once do not re-collide in lockstep
+ * on every subsequent attempt.
+ */
+export async function commitWithLockRetry<T>(
+  commit: () => T,
+  deps: { sleep: (ms: number) => Promise<void>; random?: () => number },
+): Promise<T> {
+  const random = deps.random ?? Math.random;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return commit();
+    } catch (err) {
+      const delay = COMMIT_LOCK_RETRY_DELAYS_MS[attempt];
+      if (delay === undefined || !(err instanceof TransitionLockBusyError)) throw err;
+      await deps.sleep(delay / 2 + random() * (delay / 2));
+    }
+  }
 }
 
 export type DriftKind =
@@ -1172,6 +1209,8 @@ export interface PhaseExecuteDeps {
   findGitRoot: (cwd: string) => string | null;
   now: () => Date;
   readCliConfig: () => CliConfig;
+  /** Backoff delay for the post-handler commit retry; injected so tests need no real time. */
+  sleep: (ms: number) => Promise<void>;
 }
 
 export function spawnExec(cmd: string[]): ExecResult {
@@ -1191,6 +1230,7 @@ const defaultExecuteDeps: PhaseExecuteDeps = {
   findGitRoot,
   now: () => new Date(),
   readCliConfig,
+  sleep: (ms) => Bun.sleep(ms),
 };
 
 export interface PhaseExecuteArgs {
@@ -1569,15 +1609,35 @@ export async function executePhase(
   // (`from === target && tail === target`) is accepted by
   // validateTransition so successive `phase run <X>` calls don't
   // trip RegressionError.
-  const txResult = phaseRun(
-    {
-      target: parsed.target,
-      from: resolvedFrom,
-      workItemId: parsed.workItemId,
-      forceMessage: parsed.forceMessage,
-    },
-    { cwd, stateCwd: stateRoot, now: ex.now },
-  );
+  let txResult: { manifest: Manifest; forced: boolean; from: string | null };
+  try {
+    txResult = await commitWithLockRetry(
+      () =>
+        phaseRun(
+          {
+            target: parsed.target,
+            from: resolvedFrom,
+            workItemId: parsed.workItemId,
+            forceMessage: parsed.forceMessage,
+          },
+          { cwd, stateCwd: stateRoot, now: ex.now },
+        ),
+      { sleep: ex.sleep },
+    );
+  } catch (err) {
+    if (!(err instanceof TransitionLockBusyError)) throw err;
+    // Never silent: the handler's side effects are already on GitHub, so this is
+    // db/log divergence, not a no-op. Say so, and say that re-running is safe.
+    d.logError(
+      [
+        `phase "${parsed.target}" COMPLETED but its transition could not be recorded: ${err.message}.`,
+        "The handler's side effects (branch, PR, labels) have already happened, so the work item's phase",
+        `and its transition log now disagree. Re-run \`mcx phase run ${parsed.target}\` once the other run`,
+        "finishes — handlers self-check and the idempotent self-loop is accepted.",
+      ].join(" "),
+    );
+    d.exit(1);
+  }
   const source = phase.source ?? "(unknown)";
   const tag = txResult.forced ? " [FORCED]" : "";
   const trail = txResult.from ?? "(initial)";

--- a/packages/core/src/phase-lock-hold-worker.ts
+++ b/packages/core/src/phase-lock-hold-worker.ts
@@ -1,0 +1,46 @@
+/**
+ * Test helper: holds a lock on the transition store for a fixed duration so
+ * phase-transition.spec.ts can observe a *contended* writer from the parent
+ * process. The 10-way fan-out worker proves the transaction boundary matters,
+ * but its transactions are sub-millisecond, so it never demonstrates that a
+ * contended writer waits rather than erroring.
+ *
+ * Two modes, both signalling `<readyFile>` once the lock is actually held so the
+ * parent can poll for readiness instead of sleeping:
+ *
+ * - `write`: holds the `BEGIN IMMEDIATE` write lock, so the parent's writer must
+ *   wait for it at `BEGIN` and then succeed (`busy_timeout` doing its job).
+ * - `read`: holds a SHARED read lock across the parent's commit point, which is
+ *   what makes the parent's `COMMIT` — not its `BEGIN` — return SQLITE_BUSY.
+ *
+ * Usage: bun run phase-lock-hold-worker.ts <write|read> <logPath> <readyFile> <holdMs>
+ */
+import { Database } from "bun:sqlite";
+import { writeFileSync } from "node:fs";
+import { transitionDbPath, withTransitionWriter } from "./phase-transition";
+
+const [mode, logPath, readyFile, holdMsRaw] = process.argv.slice(2);
+if (!mode || !logPath || !readyFile || !holdMsRaw) {
+  process.stderr.write("usage: phase-lock-hold-worker.ts <write|read> <logPath> <readyFile> <holdMs>\n");
+  process.exit(1);
+}
+const holdMs = Number(holdMsRaw);
+
+if (mode === "write") {
+  withTransitionWriter(logPath, (writer) => {
+    writer.insert({ ts: "held", workItemId: "#hold", from: null, to: "impl" });
+    writeFileSync(readyFile, "held");
+    Bun.sleepSync(holdMs);
+  });
+} else {
+  const db = new Database(transitionDbPath(logPath), { readonly: true });
+  try {
+    db.exec("BEGIN");
+    db.query("SELECT count(*) AS n FROM transitions").get();
+    writeFileSync(readyFile, "held");
+    Bun.sleepSync(holdMs);
+    db.exec("ROLLBACK");
+  } finally {
+    db.close();
+  }
+}

--- a/packages/core/src/phase-lock-test-worker.ts
+++ b/packages/core/src/phase-lock-test-worker.ts
@@ -1,11 +1,17 @@
 /**
- * Test helper: used by phase-transition.spec.ts to exercise withTransitionLock
- * under actual OS-level concurrency (subprocess fan-out). Not part of the
- * production build — import path stays local to the core package.
+ * Test helper: used by phase-transition.spec.ts to exercise
+ * `withTransitionWriter` under actual OS-level concurrency (subprocess
+ * fan-out). Not part of the production build — import path stays local to the
+ * core package.
+ *
+ * Reads the history and appends a chained entry inside one transaction, which
+ * is the same read-modify-write shape `commitTransition` uses. Without
+ * serialisation, concurrent workers observe the same tail and produce a broken
+ * `from`/`to` chain (#1328).
  *
  * Usage: bun run phase-lock-test-worker.ts <logPath> <index>
  */
-import { appendTransitionLog, readTransitionHistory, withTransitionLock } from "./phase-transition";
+import { withTransitionWriter } from "./phase-transition";
 
 const [logPath, index] = process.argv.slice(2);
 if (!logPath || index === undefined) {
@@ -13,9 +19,9 @@ if (!logPath || index === undefined) {
   process.exit(1);
 }
 
-withTransitionLock(logPath, () => {
-  const hist = readTransitionHistory(logPath, "#race");
-  appendTransitionLog(logPath, {
+withTransitionWriter(logPath, (writer) => {
+  const hist = writer.history("#race");
+  writer.insert({
     ts: `t${index}`,
     workItemId: "#race",
     from: hist.length === 0 ? null : hist[hist.length - 1].to,

--- a/packages/core/src/phase-transition.spec.ts
+++ b/packages/core/src/phase-transition.spec.ts
@@ -1,3 +1,4 @@
+import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -365,6 +366,40 @@ describe("bounded reads and filter pushdown (#1375)", () => {
   test("readTransitionHistory accepts a tail", () => {
     const tailed = readTransitionHistory(log, "#even", undefined, { tail: 2 });
     expect(tailed.map((e) => e.to)).toEqual(["step-6", "step-8"]);
+  });
+
+  test("a non-integer tail is rejected rather than reaching SQL", () => {
+    expect(() => readAllTransitions(log, { tail: Number.NaN })).toThrow(TypeError);
+    expect(() => readAllTransitions(log, { tail: Number.POSITIVE_INFINITY })).toThrow(TypeError);
+    expect(() => readAllTransitions(log, { tail: 2.5 })).toThrow(/tail must be an integer/);
+  });
+});
+
+describe("journal mode (#1372)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mcx-phase-journal-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("the store runs on the rollback journal, never WAL", () => {
+    // Load-bearing for #1372: WAL needs a `-shm` mmap that network filesystems
+    // cannot provide, so an NFS-mounted `~/` would fail to open or corrupt.
+    // Asserted on the file the store actually created, in its default
+    // configuration — if anyone "optimizes" this to WAL, this test fails.
+    const log = join(dir, "transitions.jsonl");
+    appendTransitionLog(log, { ts: "t1", workItemId: "#1", from: null, to: "impl" });
+
+    const db = new Database(transitionDbPath(log), { readonly: true });
+    try {
+      expect(db.query<{ journal_mode: string }, []>("PRAGMA journal_mode").get()?.journal_mode).toBe("delete");
+    } finally {
+      db.close();
+    }
+    // A rollback-journal store leaves no sidecar files behind once committed.
+    expect(readdirSync(dir)).toEqual(["transitions.db"]);
   });
 });
 

--- a/packages/core/src/phase-transition.spec.ts
+++ b/packages/core/src/phase-transition.spec.ts
@@ -1,24 +1,30 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Manifest } from "./manifest";
 import {
   DisallowedTransitionError,
   RegressionError,
+  TransitionLockBusyError,
   UnknownPhaseError,
+  appendAttempt,
   appendTransitionLog,
-  atomicWriteFileSync,
   commitTransition,
   historyTargets,
+  isCommitted,
   levenshtein,
   pruneStaleHistory,
   readAllTransitions,
   readTransitionHistory,
   suggestPhases,
+  transitionDbPath,
   validateTransition,
-  withTransitionLock,
+  withTransitionWriter,
 } from "./phase-transition";
+
+/** Short deadline for the deliberately-contended nested-lock test. */
+const NESTED_LOCK_TIMEOUT_MS = 50;
 
 const manifest: Manifest = {
   version: 1,
@@ -225,8 +231,10 @@ describe("transition log I/O", () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  test("read on missing file returns empty", () => {
+  test("read on missing log returns empty without creating a database", () => {
     expect(readTransitionHistory(join(dir, "nope.jsonl"), "#1")).toEqual([]);
+    // A read must not materialise storage as a side effect.
+    expect(readdirSync(dir)).toEqual([]);
   });
 
   test("append then read", () => {
@@ -240,29 +248,25 @@ describe("transition log I/O", () => {
     expect(historyTargets(entries)).toEqual(["impl", "qa"]);
   });
 
-  test("filters by workItemId", () => {
+  test("append creates the database beside the log path", () => {
+    const log = join(dir, "transitions.jsonl");
+    appendTransitionLog(log, { ts: "t1", workItemId: "#1", from: null, to: "impl" });
+    expect(transitionDbPath(log)).toBe(join(dir, "transitions.db"));
+    // No jsonl is written any more, and the rollback journal is gone post-commit.
+    expect(readdirSync(dir)).toEqual(["transitions.db"]);
+  });
+
+  test("filters by workItemId, including the null work item", () => {
     const log = join(dir, "transitions.jsonl");
     appendTransitionLog(log, { ts: "t1", workItemId: null, from: null, to: "impl" });
     appendTransitionLog(log, { ts: "t2", workItemId: "#99", from: null, to: "qa" });
     expect(readTransitionHistory(log, null).length).toBe(1);
+    expect(readTransitionHistory(log, null)[0].to).toBe("impl");
     expect(readTransitionHistory(log, "#99").length).toBe(1);
+    expect(readTransitionHistory(log, "#99")[0].to).toBe("qa");
   });
 
-  test("skips malformed lines and reports them via onCorrupt", () => {
-    const log = join(dir, "transitions.jsonl");
-    appendTransitionLog(log, { ts: "t1", workItemId: "#1", from: null, to: "impl" });
-    // Corrupt the file with a bad line
-    require("node:fs").appendFileSync(log, "not-json\n", "utf-8");
-    appendTransitionLog(log, { ts: "t2", workItemId: "#1", from: "impl", to: "qa" });
-    const corrupt: Array<{ line: number; text: string }> = [];
-    const entries = readTransitionHistory(log, "#1", (lineNumber, line) => {
-      corrupt.push({ line: lineNumber, text: line });
-    });
-    expect(historyTargets(entries)).toEqual(["impl", "qa"]);
-    expect(corrupt).toEqual([{ line: 2, text: "not-json" }]);
-  });
-
-  test("readAllTransitions returns every entry regardless of workItemId", () => {
+  test("readAllTransitions returns every entry in insertion order", () => {
     const log = join(dir, "transitions.jsonl");
     appendTransitionLog(log, { ts: "t1", workItemId: "#1", from: null, to: "impl" });
     appendTransitionLog(log, { ts: "t2", workItemId: "#2", from: null, to: "impl" });
@@ -272,11 +276,11 @@ describe("transition log I/O", () => {
     expect(all.map((e) => e.ts)).toEqual(["t1", "t2", "t3"]);
   });
 
-  test("readAllTransitions on missing file returns empty", () => {
+  test("readAllTransitions on missing log returns empty", () => {
     expect(readAllTransitions(join(dir, "nope.jsonl"))).toEqual([]);
   });
 
-  test("records force message", () => {
+  test("records force message and status", () => {
     const log = join(dir, "transitions.jsonl");
     appendTransitionLog(log, {
       ts: "t1",
@@ -284,13 +288,253 @@ describe("transition log I/O", () => {
       from: "adversarial-review",
       to: "impl",
       forceMessage: "rewriting from scratch",
+      status: "committed",
     });
+    appendTransitionLog(log, { ts: "t2", workItemId: "#1", from: "impl", to: "qa", status: "attempted" });
     const entries = readTransitionHistory(log, "#1");
     expect(entries[0].forceMessage).toBe("rewriting from scratch");
+    expect(entries[0].status).toBe("committed");
+    expect(entries[1].status).toBe("attempted");
+    // An entry written without a status stays status-less (legacy semantics).
+    expect(entries[1].forceMessage).toBeUndefined();
+    expect(isCommitted(entries[0])).toBe(true);
+    expect(isCommitted(entries[1])).toBe(false);
   });
 });
 
-describe("commitTransition / withTransitionLock (issue #1328)", () => {
+describe("bounded reads and filter pushdown (#1375)", () => {
+  let dir: string;
+  let log: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mcx-phase-tail-"));
+    log = join(dir, "transitions.jsonl");
+    for (let i = 0; i < 10; i++) {
+      appendTransitionLog(log, {
+        ts: `t${i}`,
+        workItemId: i % 2 === 0 ? "#even" : "#odd",
+        from: null,
+        to: `step-${i}`,
+        ...(i === 7 ? { forceMessage: "forced seven" } : {}),
+      });
+    }
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("tail returns the newest N entries, still oldest-first", () => {
+    const tailed = readAllTransitions(log, { tail: 3 });
+    expect(tailed.map((e) => e.to)).toEqual(["step-7", "step-8", "step-9"]);
+  });
+
+  test("tail larger than the table returns everything", () => {
+    expect(readAllTransitions(log, { tail: 500 })).toHaveLength(10);
+  });
+
+  test("tail of zero or negative returns empty", () => {
+    expect(readAllTransitions(log, { tail: 0 })).toEqual([]);
+    expect(readAllTransitions(log, { tail: -5 })).toEqual([]);
+  });
+
+  test("omitting tail preserves the unbounded default", () => {
+    expect(readAllTransitions(log)).toHaveLength(10);
+  });
+
+  test("workItemId filter is applied before the tail, not after", () => {
+    // Filtering after a tail would yield fewer than 3 rows; pushdown yields 3.
+    const tailed = readAllTransitions(log, { workItemId: "#odd", tail: 3 });
+    expect(tailed.map((e) => e.to)).toEqual(["step-5", "step-7", "step-9"]);
+  });
+
+  test("null workItemId means no filter (matches filterTransitionLog semantics)", () => {
+    expect(readAllTransitions(log, { workItemId: null })).toHaveLength(10);
+  });
+
+  test("forcedOnly filters to entries carrying a forceMessage", () => {
+    const forced = readAllTransitions(log, { forcedOnly: true });
+    expect(forced).toHaveLength(1);
+    expect(forced[0].forceMessage).toBe("forced seven");
+  });
+
+  test("forcedOnly composes with workItemId", () => {
+    expect(readAllTransitions(log, { forcedOnly: true, workItemId: "#odd" })).toHaveLength(1);
+    expect(readAllTransitions(log, { forcedOnly: true, workItemId: "#even" })).toHaveLength(0);
+  });
+
+  test("readTransitionHistory accepts a tail", () => {
+    const tailed = readTransitionHistory(log, "#even", undefined, { tail: 2 });
+    expect(tailed.map((e) => e.to)).toEqual(["step-6", "step-8"]);
+  });
+});
+
+describe("legacy jsonl migration (#1328)", () => {
+  let dir: string;
+  let log: string;
+
+  const jsonlLine = (e: Record<string, unknown>) => `${JSON.stringify(e)}\n`;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mcx-phase-migrate-"));
+    log = join(dir, "transitions.jsonl");
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("imports an existing jsonl on first open, preserving order and fields", () => {
+    writeFileSync(
+      log,
+      jsonlLine({ ts: "t1", workItemId: "#7", from: null, to: "impl", status: "committed" }) +
+        jsonlLine({ ts: "t2", workItemId: "#7", from: "impl", to: "qa", status: "attempted" }) +
+        jsonlLine({ ts: "t3", workItemId: "#8", from: null, to: "impl", forceMessage: "why not" }),
+      "utf-8",
+    );
+
+    const all = readAllTransitions(log);
+    expect(all).toHaveLength(3);
+    expect(all.map((e) => e.ts)).toEqual(["t1", "t2", "t3"]);
+    expect(all[0]).toEqual({ ts: "t1", workItemId: "#7", from: null, to: "impl", status: "committed" });
+    expect(all[1].status).toBe("attempted");
+    expect(all[2]).toEqual({ ts: "t3", workItemId: "#8", from: null, to: "impl", forceMessage: "why not" });
+  });
+
+  test("legacy entry without status round-trips as status-less, and still gates", () => {
+    writeFileSync(log, jsonlLine({ ts: "t1", workItemId: "#7", from: null, to: "impl" }), "utf-8");
+    const entries = readTransitionHistory(log, "#7");
+    expect(entries[0].status).toBeUndefined();
+    expect(isCommitted(entries[0])).toBe(true);
+  });
+
+  test("jsonl is parked as .migrated, never deleted", () => {
+    writeFileSync(log, jsonlLine({ ts: "t1", workItemId: "#7", from: null, to: "impl" }), "utf-8");
+    readAllTransitions(log);
+
+    expect(existsSync(log)).toBe(false);
+    expect(existsSync(`${log}.migrated`)).toBe(true);
+    expect(readFileSync(`${log}.migrated`, "utf-8")).toContain('"to":"impl"');
+    expect(readdirSync(dir).sort()).toEqual(["transitions.db", "transitions.jsonl.migrated"]);
+  });
+
+  test("a second migration does not overwrite an existing .migrated file", () => {
+    writeFileSync(log, jsonlLine({ ts: "first", workItemId: "#7", from: null, to: "impl" }), "utf-8");
+    readAllTransitions(log);
+    // A stale binary writes a fresh jsonl after the first migration.
+    writeFileSync(log, jsonlLine({ ts: "second", workItemId: "#7", from: "impl", to: "qa" }), "utf-8");
+    readAllTransitions(log);
+
+    expect(readFileSync(`${log}.migrated`, "utf-8")).toContain('"ts":"first"');
+    const parked = readdirSync(dir).filter((n) => n.includes(".migrated"));
+    expect(parked).toHaveLength(2);
+    // Both generations of entries are in the store.
+    expect(readAllTransitions(log).map((e) => e.ts)).toEqual(["first", "second"]);
+  });
+
+  test("reopening does not re-import (no duplicate rows)", () => {
+    writeFileSync(
+      log,
+      jsonlLine({ ts: "t1", workItemId: "#7", from: null, to: "impl" }) +
+        jsonlLine({ ts: "t2", workItemId: "#7", from: "impl", to: "qa" }),
+      "utf-8",
+    );
+
+    expect(readAllTransitions(log)).toHaveLength(2);
+    expect(readAllTransitions(log)).toHaveLength(2);
+    expect(readTransitionHistory(log, "#7")).toHaveLength(2);
+  });
+
+  test("entries appended after migration follow the imported history", () => {
+    writeFileSync(log, jsonlLine({ ts: "t1", workItemId: "#7", from: null, to: "impl" }), "utf-8");
+    appendTransitionLog(log, { ts: "t2", workItemId: "#7", from: "impl", to: "qa" });
+    expect(historyTargets(readTransitionHistory(log, "#7"))).toEqual(["impl", "qa"]);
+  });
+
+  test("corrupt lines are reported with line numbers and good lines still import", () => {
+    writeFileSync(
+      log,
+      `${jsonlLine({ ts: "t1", workItemId: "#1", from: null, to: "impl" })}not-json\n${jsonlLine({
+        ts: "t2",
+        workItemId: "#1",
+        from: "impl",
+        to: "qa",
+      })}`,
+      "utf-8",
+    );
+
+    const corrupt: Array<{ line: number; text: string }> = [];
+    const entries = readTransitionHistory(log, "#1", (lineNumber, line) => {
+      corrupt.push({ line: lineNumber, text: line });
+    });
+
+    expect(historyTargets(entries)).toEqual(["impl", "qa"]);
+    expect(corrupt).toEqual([{ line: 2, text: "not-json" }]);
+  });
+
+  test("a truncated final line does not lose the preceding entries", () => {
+    // The crash-mid-append case from #1328: last line is a partial JSON object.
+    writeFileSync(
+      log,
+      `${jsonlLine({ ts: "t1", workItemId: "#1", from: null, to: "impl" })}{"ts":"t2","workItemId":"#1","fr`,
+      "utf-8",
+    );
+    const corrupt: number[] = [];
+    const entries = readTransitionHistory(log, "#1", (lineNumber) => corrupt.push(lineNumber));
+    expect(historyTargets(entries)).toEqual(["impl"]);
+    expect(corrupt).toEqual([2]);
+  });
+
+  test("an empty jsonl migrates to an empty store", () => {
+    writeFileSync(log, "", "utf-8");
+    expect(readAllTransitions(log)).toEqual([]);
+    expect(existsSync(`${log}.migrated`)).toBe(true);
+  });
+
+  test("a staging file abandoned by a crashed import is recovered on next open", () => {
+    // Simulates a crash after the atomic rename-claim but before COMMIT: the
+    // data lives only in the staging file, and must not be stranded there.
+    writeFileSync(
+      join(dir, `transitions.jsonl.importing.${Date.now()}-abcd1234`),
+      jsonlLine({ ts: "t1", workItemId: "#7", from: null, to: "impl" }),
+      "utf-8",
+    );
+
+    expect(readAllTransitions(log).map((e) => e.ts)).toEqual(["t1"]);
+    expect(readdirSync(dir).some((n) => n.includes(".importing."))).toBe(false);
+  });
+
+  test("concurrent first-open imports the jsonl exactly once", async () => {
+    // Every worker races to migrate the same jsonl and then appends one entry.
+    // A double import would inflate the count; a lost import would deflate it.
+    const workerPath = join(import.meta.dir, "phase-lock-test-worker.ts");
+    writeFileSync(
+      log,
+      jsonlLine({ ts: "seed-1", workItemId: "#race", from: null, to: "seed-a" }) +
+        jsonlLine({ ts: "seed-2", workItemId: "#race", from: "seed-a", to: "seed-b" }),
+      "utf-8",
+    );
+
+    const procs = Array.from({ length: 8 }, (_, i) =>
+      Bun.spawn(["bun", "run", workerPath, log, String(i)], { stderr: "pipe" }),
+    );
+    const results = await Promise.all(
+      procs.map(async (p) => ({ code: await p.exited, stderr: await new Response(p.stderr).text() })),
+    );
+    const failed = results.filter((r) => r.code !== 0);
+    expect(failed.map((r) => r.stderr).join("\n")).toBe("");
+
+    // The imported history must precede every concurrently-appended entry:
+    // a worker that raced past a half-finished import would both reorder the
+    // log and validate its own transition against an empty history.
+    const entries = readTransitionHistory(log, "#race");
+    expect(entries).toHaveLength(10);
+    expect(entries.slice(0, 2).map((e) => e.ts)).toEqual(["seed-1", "seed-2"]);
+
+    // Exactly one park, and no staging file left behind.
+    expect(readdirSync(dir).sort()).toEqual(["transitions.db", "transitions.jsonl.migrated"]);
+  }, 30_000);
+});
+
+describe("commitTransition / withTransitionWriter (issue #1328)", () => {
   let dir: string;
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), "mcx-phase-commit-"));
@@ -318,22 +562,43 @@ describe("commitTransition / withTransitionLock (issue #1328)", () => {
     expect(() => commitTransition(log, { manifest, from: null, target: "done", workItemId: "#1" })).toThrow(
       DisallowedTransitionError,
     );
-    // log must not have the bad append
+    // The failed transaction must roll back, leaving no partial append.
     expect(historyTargets(readTransitionHistory(log, "#1"))).toEqual(["impl"]);
   });
 
-  test("withTransitionLock serializes concurrent writers; no history is lost", async () => {
+  test("commitTransition ignores attempted entries when inferring from", () => {
+    const log = join(dir, "transitions.jsonl");
+    commitTransition(log, { manifest, from: null, target: "impl", workItemId: "#1" });
+    appendAttempt(log, { workItemId: "#1", from: "impl", target: "needs-attention" });
+    // The attempt must not become the inferred `from`.
+    const r = commitTransition(log, { manifest, from: null, target: "qa", workItemId: "#1" });
+    expect(r.from).toBe("impl");
+  });
+
+  test("commitTransition records the force message", () => {
+    const log = join(dir, "transitions.jsonl");
+    const r = commitTransition(log, {
+      manifest,
+      from: null,
+      target: "done",
+      workItemId: "#1",
+      force: { message: "skipping ahead" },
+    });
+    expect(r.forced).toBe(true);
+    expect(readTransitionHistory(log, "#1")[0].forceMessage).toBe("skipping ahead");
+  });
+
+  test("concurrent writers are serialised; no history is lost or torn", async () => {
     const log = join(dir, "transitions.jsonl");
     const workerPath = join(import.meta.dir, "phase-lock-test-worker.ts");
 
-    // Spawn 10 concurrent child processes. Each process independently
-    // reads the tail and appends under withTransitionLock. This is actual
-    // OS-level concurrency — Promise.all of synchronous fn() cannot stress
-    // O_EXCL contention since JS is single-threaded.
+    // Spawn 10 concurrent child processes. Each independently reads the tail
+    // and appends inside one write transaction. This is actual OS-level
+    // concurrency — Promise.all of synchronous calls cannot stress it, since
+    // JS is single-threaded.
     //
-    // Without the lock, concurrent reads produce stale history snapshots:
+    // Without serialisation, concurrent reads produce stale history snapshots:
     // multiple writers see the same tail and append conflicting `from` values.
-    // With the lock, each writer commits before the next reads.
     const procs = Array.from({ length: 10 }, (_, i) => Bun.spawn(["bun", "run", workerPath, log, String(i)]));
     const exitCodes = await Promise.all(procs.map((p) => p.exited));
     expect(exitCodes.every((c) => c === 0)).toBe(true);
@@ -341,7 +606,7 @@ describe("commitTransition / withTransitionLock (issue #1328)", () => {
     const entries = readTransitionHistory(log, "#race");
     expect(entries.length).toBe(10);
     // Every entry's `from` must equal the previous entry's `to` — the
-    // invariant broken by an unlocked read/append race.
+    // invariant broken by an unserialised read/append race.
     for (let i = 0; i < entries.length; i++) {
       if (i === 0) {
         expect(entries[i].from).toBeNull();
@@ -352,47 +617,47 @@ describe("commitTransition / withTransitionLock (issue #1328)", () => {
     // Every `to` is unique — no double-write.
     const tos = entries.map((e) => e.to);
     expect(new Set(tos).size).toBe(tos.length);
-  }, 20_000); // serialized under lock; 10 subprocess spawns worst-case ~10s
+  }, 30_000);
 
-  test("withTransitionLock rejects async fn to prevent early lock release", () => {
+  test("withTransitionWriter rejects async fn to prevent an early commit", () => {
     const log = join(dir, "transitions.jsonl");
-    expect(() => withTransitionLock(log, () => Promise.resolve() as unknown as undefined)).toThrow(
-      /withTransitionLock: fn must be synchronous/,
+    expect(() => withTransitionWriter(log, () => Promise.resolve() as unknown as undefined)).toThrow(
+      /withTransitionWriter: fn must be synchronous/,
     );
   });
 
-  test("withTransitionLock times out when lock is held", () => {
+  test("withTransitionWriter rolls back when fn throws", () => {
+    const log = join(dir, "transitions.jsonl");
+    appendTransitionLog(log, { ts: "t1", workItemId: "#1", from: null, to: "impl" });
+
+    expect(() =>
+      withTransitionWriter(log, (writer) => {
+        writer.insert({ ts: "t2", workItemId: "#1", from: "impl", to: "qa" });
+        throw new Error("handler blew up");
+      }),
+    ).toThrow("handler blew up");
+
+    expect(historyTargets(readTransitionHistory(log, "#1"))).toEqual(["impl"]);
+  });
+
+  test("writer.history sees uncommitted inserts from the same transaction", () => {
+    const log = join(dir, "transitions.jsonl");
+    withTransitionWriter(log, (writer) => {
+      writer.insert({ ts: "t1", workItemId: "#1", from: null, to: "impl" });
+      expect(historyTargets(writer.history("#1"))).toEqual(["impl"]);
+    });
+    expect(historyTargets(readTransitionHistory(log, "#1"))).toEqual(["impl"]);
+  });
+
+  test("a held write lock surfaces TransitionLockBusyError, not a silent skip", () => {
     const log = join(dir, "transitions.jsonl");
     expect(() =>
-      withTransitionLock(
-        log,
-        () => {
-          // Inner attempt with short timeout should fail — lock is held.
-          withTransitionLock(log, () => undefined, { timeoutMs: 50 });
-        },
-        { timeoutMs: 1000 },
-      ),
-    ).toThrow(/could not acquire transition lock/);
-  });
-
-  test("withTransitionLock reaps stale lockfile", () => {
-    const log = join(dir, "transitions.jsonl");
-    const lockPath = `${log}.lock`;
-    require("node:fs").mkdirSync(dir, { recursive: true });
-    require("node:fs").writeFileSync(lockPath, "", "utf-8");
-    // Backdate lock mtime to be "stale"
-    const past = new Date(Date.now() - 60_000);
-    require("node:fs").utimesSync(lockPath, past, past);
-
-    let ran = false;
-    withTransitionLock(
-      log,
-      () => {
-        ran = true;
-      },
-      { staleMs: 1000, timeoutMs: 500 },
-    );
-    expect(ran).toBe(true);
+      withTransitionWriter(log, () => {
+        // Nested call is a second connection contending for the same write
+        // lock; with a short timeout it must fail loudly.
+        withTransitionWriter(log, () => undefined, { timeoutMs: NESTED_LOCK_TIMEOUT_MS });
+      }),
+    ).toThrow(TransitionLockBusyError);
   });
 });
 
@@ -449,7 +714,7 @@ describe("pruneStaleHistory (#2463)", () => {
     expect(remaining[1].ts).toBe("2026-06-01T00:00:00Z");
   });
 
-  test("returns 0 and does not rewrite when no entries match", () => {
+  test("returns 0 and changes nothing when no entries match", () => {
     const log = join(dir, "transitions.jsonl");
     appendTransitionLog(log, {
       ts: "2026-06-01T00:00:00Z",
@@ -466,16 +731,15 @@ describe("pruneStaleHistory (#2463)", () => {
     expect(readAllTransitions(log)).toHaveLength(1);
   });
 
-  test("returns 0 when log file does not exist (ENOENT)", () => {
+  test("returns 0 when no log exists", () => {
     const log = join(dir, "nonexistent", "transitions.jsonl");
     const pruned = pruneStaleHistory(log, "#42", new Date());
     expect(pruned).toBe(0);
   });
 
-  test("returns 0 when log is empty", () => {
+  test("returns 0 when the store is empty", () => {
     const log = join(dir, "transitions.jsonl");
-    require("node:fs").mkdirSync(dir, { recursive: true });
-    require("node:fs").writeFileSync(log, "", "utf-8");
+    writeFileSync(log, "", "utf-8");
 
     const pruned = pruneStaleHistory(log, "#42", new Date());
     expect(pruned).toBe(0);
@@ -503,7 +767,7 @@ describe("pruneStaleHistory (#2463)", () => {
     expect(readAllTransitions(log)).toHaveLength(0);
   });
 
-  test("preserves attempted entries older than cutoff for other work items", () => {
+  test("prunes attempted entries too, and only for the named work item", () => {
     const log = join(dir, "transitions.jsonl");
     appendTransitionLog(log, {
       ts: "2026-01-01T00:00:00Z",
@@ -527,7 +791,18 @@ describe("pruneStaleHistory (#2463)", () => {
     expect(remaining[0].workItemId).toBe("#50");
   });
 
-  test("rewrite leaves no temp files behind (#2685)", () => {
+  test("keeps entries whose ts is unparseable rather than pruning them", () => {
+    // `ts` is caller-supplied; an unparseable value must not be silently
+    // treated as "infinitely old" and deleted.
+    const log = join(dir, "transitions.jsonl");
+    appendTransitionLog(log, { ts: "not-a-date", workItemId: "#42", from: null, to: "impl", status: "committed" });
+
+    const pruned = pruneStaleHistory(log, "#42", new Date("2026-06-01T00:00:00Z"));
+    expect(pruned).toBe(0);
+    expect(readAllTransitions(log)).toHaveLength(1);
+  });
+
+  test("prune leaves no journal or temp files behind (#2685)", () => {
     const log = join(dir, "transitions.jsonl");
     appendTransitionLog(log, {
       ts: "2026-01-01T00:00:00Z",
@@ -539,64 +814,6 @@ describe("pruneStaleHistory (#2463)", () => {
 
     const pruned = pruneStaleHistory(log, "#42", new Date("2026-06-01T00:00:00Z"));
     expect(pruned).toBe(1);
-    expect(readdirSync(dir).sort()).toEqual(["transitions.jsonl"]);
-  });
-});
-
-describe("atomicWriteFileSync (#2685)", () => {
-  let dir: string;
-
-  beforeEach(() => {
-    dir = mkdtempSync(join(tmpdir(), "atomic-write-"));
-  });
-
-  afterEach(() => {
-    rmSync(dir, { recursive: true, force: true });
-  });
-
-  test("replaces target content and removes the temp file", () => {
-    const target = join(dir, "log.jsonl");
-    writeFileSync(target, "old\n", "utf-8");
-
-    atomicWriteFileSync(target, "new\n");
-
-    expect(readFileSync(target, "utf-8")).toBe("new\n");
-    expect(readdirSync(dir).sort()).toEqual(["log.jsonl"]);
-  });
-
-  test("creates parent directories when missing", () => {
-    const target = join(dir, "nested", "deep", "log.jsonl");
-    atomicWriteFileSync(target, "content\n");
-    expect(readFileSync(target, "utf-8")).toBe("content\n");
-  });
-
-  test("crash mid-write: target keeps old content, partial file never observed", () => {
-    const target = join(dir, "log.jsonl");
-    writeFileSync(target, "old-line-1\nold-line-2\n", "utf-8");
-
-    const crashingWrite = (path: string, content: string, encoding: "utf-8") => {
-      writeFileSync(path, content.slice(0, 5), encoding);
-      throw new Error("simulated crash mid-write");
-    };
-
-    expect(() => atomicWriteFileSync(target, "new-line-1\nnew-line-2\n", crashingWrite)).toThrow(
-      "simulated crash mid-write",
-    );
-
-    expect(readFileSync(target, "utf-8")).toBe("old-line-1\nold-line-2\n");
-    expect(readdirSync(dir).sort()).toEqual(["log.jsonl"]);
-  });
-
-  test("crash before any bytes written: target untouched, no temp leftovers", () => {
-    const target = join(dir, "log.jsonl");
-    writeFileSync(target, "old\n", "utf-8");
-
-    const failingWrite = () => {
-      throw new Error("ENOSPC: no space left on device");
-    };
-
-    expect(() => atomicWriteFileSync(target, "new\n", failingWrite)).toThrow("ENOSPC");
-    expect(readFileSync(target, "utf-8")).toBe("old\n");
-    expect(readdirSync(dir).sort()).toEqual(["log.jsonl"]);
+    expect(readdirSync(dir).sort()).toEqual(["transitions.db"]);
   });
 });

--- a/packages/core/src/phase-transition.spec.ts
+++ b/packages/core/src/phase-transition.spec.ts
@@ -1,10 +1,20 @@
 import { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pollUntil } from "../../../test/harness";
 import type { Manifest } from "./manifest";
+import type { MigrationReport } from "./phase-transition";
 import {
   DisallowedTransitionError,
   RegressionError,
@@ -13,6 +23,7 @@ import {
   appendAttempt,
   appendTransitionLog,
   commitTransition,
+  defaultOnMigrate,
   historyTargets,
   isCommitted,
   levenshtein,
@@ -24,6 +35,7 @@ import {
   validateTransition,
   withTransitionWriter,
 } from "./phase-transition";
+import { sanitizeBusyTimeout } from "./transition-store";
 
 /** Short deadline for the deliberately-contended nested-lock test. */
 const NESTED_LOCK_TIMEOUT_MS = 50;
@@ -601,6 +613,270 @@ describe("legacy jsonl migration (#1328)", () => {
   }, 30_000);
 });
 
+describe("import hardening: a bad record must never wedge or double the store", () => {
+  let dir: string;
+  let log: string;
+
+  const jsonlLine = (e: unknown) => `${JSON.stringify(e)}\n`;
+  const valid = (ts: string, to: string, from: string | null = null) =>
+    jsonlLine({ ts, workItemId: "#7", from, to, status: "committed" });
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mcx-phase-import-"));
+    log = join(dir, "transitions.jsonl");
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // ── 🔴1: schema-invalid records ─────────────────────────────────────
+
+  test("a schema-invalid record is quarantined as a corrupt line, not a crash", () => {
+    // `{"foo":1}` is valid JSON and a plain object, so the importer passed it
+    // through as a TransitionLogEntry; it then hit `ts TEXT NOT NULL` and threw.
+    writeFileSync(log, `${valid("t1", "impl")}${jsonlLine({ foo: 1 })}${valid("t2", "qa", "impl")}`, "utf-8");
+
+    const corrupt: number[] = [];
+    const entries = readAllTransitions(log, { onCorrupt: (lineNumber) => corrupt.push(lineNumber) });
+
+    expect(entries.map((e) => e.ts)).toEqual(["t1", "t2"]);
+    expect(corrupt).toEqual([2]);
+  });
+
+  test("a wrong-typed field is a corrupt line, not a binding TypeError", () => {
+    // `ts` as a number and `to` as an object each threw a different exception
+    // from the same unvalidated pass-through.
+    writeFileSync(
+      log,
+      `${jsonlLine({ ts: 12345, workItemId: "#7", from: null, to: "impl" })}${jsonlLine({
+        ts: "t2",
+        workItemId: "#7",
+        from: null,
+        to: { x: 1 },
+      })}${valid("t3", "impl")}`,
+      "utf-8",
+    );
+
+    const corrupt: number[] = [];
+    const entries = readAllTransitions(log, { onCorrupt: (lineNumber) => corrupt.push(lineNumber) });
+
+    expect(entries.map((e) => e.ts)).toEqual(["t3"]);
+    expect(corrupt).toEqual([1, 2]);
+  });
+
+  test("a schema-invalid record leaves the store fully usable and consumes no data", () => {
+    // The wedge: rename(2) is not transactional, so a rolled-back import left
+    // the jsonl as `.importing.<nonce>`, which findAbandonedStagingFiles
+    // replayed on every open — and openForRead drives a write transaction
+    // whenever a staging file exists, so every read AND every write threw
+    // forever, with the only copy of the log hidden under a name nobody looks
+    // for.
+    writeFileSync(log, `${valid("t1", "impl")}${jsonlLine({ foo: 1 })}`, "utf-8");
+    const noop = () => {};
+
+    expect(readAllTransitions(log, { onCorrupt: noop }).map((e) => e.ts)).toEqual(["t1"]);
+    // Reads stay usable across reopens...
+    expect(readAllTransitions(log, { onCorrupt: noop }).map((e) => e.ts)).toEqual(["t1"]);
+    expect(readTransitionHistory(log, "#7", noop)).toHaveLength(1);
+    // ...and so do writes.
+    appendTransitionLog(log, { ts: "t2", workItemId: "#7", from: "impl", to: "qa", status: "committed" });
+    expect(readAllTransitions(log, { onCorrupt: noop }).map((e) => e.ts)).toEqual(["t1", "t2"]);
+
+    // No staging file is left to replay, and the original bytes — including the
+    // rejected record — are still recoverable from the park.
+    expect(readdirSync(dir).some((n) => n.includes(".importing."))).toBe(false);
+    const parked = readdirSync(dir).filter((n) => n.includes(".migrated"));
+    expect(parked).toHaveLength(1);
+    expect(readFileSync(join(dir, parked[0]), "utf-8")).toContain('"foo":1');
+  });
+
+  test("a staging file that cannot be imported at all is quarantined, not replayed forever", () => {
+    // Belt to the validator's braces: any unexpected, non-contention import
+    // failure must cost one error and then self-heal, rather than denying
+    // service to the whole store on every subsequent open. A directory sitting
+    // at a staging path makes readFileSync throw EISDIR deterministically.
+    const staging = join(dir, `transitions.jsonl.importing.${Date.now()}-deadbeef`);
+    mkdirSync(staging);
+    const t0 = { ts: "t0", workItemId: "#7", from: null, to: "impl", status: "committed" } as const;
+
+    // One error, from whichever operation touches the store first...
+    expect(() => appendTransitionLog(log, t0)).toThrow();
+
+    // ...and then it self-heals: the unimportable staging path has been moved
+    // aside, so reads and writes both work instead of replaying the failure.
+    appendTransitionLog(log, t0);
+    expect(readAllTransitions(log).map((e) => e.ts)).toEqual(["t0"]);
+    appendTransitionLog(log, { ts: "t1", workItemId: "#7", from: "impl", to: "qa", status: "committed" });
+    expect(readAllTransitions(log)).toHaveLength(2);
+
+    // Quarantined under a name that is NOT replayed, and still on disk.
+    const quarantined = readdirSync(dir).filter((n) => n.includes(".unimportable"));
+    expect(quarantined).toHaveLength(1);
+    expect(readdirSync(dir).some((n) => n.includes(".importing."))).toBe(false);
+  });
+
+  // ── 🔴2: content-addressed dedupe ────────────────────────────────────
+
+  test("restoring the parked .migrated file does not double the history", () => {
+    // The documented recovery procedure. `imported_files` keyed on
+    // basename(staging), which embeds a fresh nonce, so it could only ever
+    // match a crash-retry of the SAME claim — it deduped nothing an operator
+    // does. Restoring the park took 3 entries to 6, destroyed chain integrity,
+    // and made the next real transition throw RegressionError.
+    writeFileSync(log, valid("t1", "impl") + valid("t2", "triage", "impl") + valid("t3", "review", "triage"), "utf-8");
+    expect(readAllTransitions(log)).toHaveLength(3);
+
+    const parked = readdirSync(dir).find((n) => n.includes(".migrated"));
+    expect(parked).toBeDefined();
+    copyFileSync(join(dir, parked as string), log);
+
+    expect(readAllTransitions(log)).toHaveLength(3);
+    expect(historyTargets(readTransitionHistory(log, "#7"))).toEqual(["impl", "triage", "review"]);
+  });
+
+  test("a mixed-binary rollout that regenerates the jsonl does not duplicate entries", () => {
+    // Guaranteed trigger: an old jsonl-era binary finds no transitions.jsonl
+    // (renamed away), validates against an EMPTY history, and writes a fresh
+    // file; the new binary then imports it under a new nonce with no dedupe.
+    writeFileSync(log, valid("t1", "impl") + valid("t2", "triage", "impl"), "utf-8");
+    expect(readAllTransitions(log)).toHaveLength(2);
+
+    // The old binary re-derives the same first transition from scratch.
+    writeFileSync(log, valid("t1", "impl"), "utf-8");
+
+    expect(historyTargets(readTransitionHistory(log, "#7"))).toEqual(["impl", "triage"]);
+  });
+
+  test("dedupe is content-addressed, so a genuinely new entry in a restored file still imports", () => {
+    // The dedupe must not degrade into "any restored file is ignored": rows
+    // that are already present are skipped, rows that are new are kept.
+    writeFileSync(log, valid("t1", "impl"), "utf-8");
+    expect(readAllTransitions(log)).toHaveLength(1);
+
+    writeFileSync(log, valid("t1", "impl") + valid("t2", "triage", "impl"), "utf-8");
+    expect(historyTargets(readTransitionHistory(log, "#7"))).toEqual(["impl", "triage"]);
+  });
+
+  // ── 🟡3: migration is announced ──────────────────────────────────────
+
+  test("a migration is announced rather than happening silently", () => {
+    // A one-way, in-place conversion of load-bearing state, now triggerable by
+    // a pure read (openForRead escalates to a write transaction), was reported
+    // nowhere at all.
+    writeFileSync(log, valid("t1", "impl") + valid("t2", "triage", "impl"), "utf-8");
+
+    const reports: MigrationReport[] = [];
+    readAllTransitions(log, { onMigrate: (r) => reports.push(r) });
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0].imported).toBe(2);
+    expect(reports[0].logPath).toBe(log);
+    expect(reports[0].parkedPath).toContain(".migrated");
+    expect(existsSync(reports[0].parkedPath)).toBe(true);
+
+    // No migration, no report.
+    readAllTransitions(log, { onMigrate: (r) => reports.push(r) });
+    expect(reports).toHaveLength(1);
+  });
+
+  test("the default migration sink writes one line to stderr", () => {
+    const written: string[] = [];
+    defaultOnMigrate({ write: (s) => written.push(s) })({
+      logPath: "/x/.mcx/transitions.jsonl",
+      dbPath: "/x/.mcx/transitions.db",
+      parkedPath: "/x/.mcx/transitions.jsonl.migrated",
+      imported: 7,
+      skipped: 2,
+      corrupt: 1,
+    });
+    expect(written).toHaveLength(1);
+    expect(written[0].endsWith("\n")).toBe(true);
+    expect(written[0]).toContain("migrated 7");
+    expect(written[0]).toContain("transitions.jsonl.migrated");
+  });
+
+  // ── 🟡6: non-object lines ────────────────────────────────────────────
+
+  test("non-object JSON lines fire the corrupt-line sink instead of vanishing", () => {
+    // `typeof parsed === "object"` discarded scalars and null without firing
+    // onCorrupt, which is the sink that exists so log rot is visible. Arrays
+    // were worse: they passed the object check and reached the wedge.
+    writeFileSync(log, `123\n"str"\nnull\n[1,2]\n${valid("t1", "impl")}`, "utf-8");
+
+    const corrupt: number[] = [];
+    const entries = readAllTransitions(log, { onCorrupt: (lineNumber) => corrupt.push(lineNumber) });
+
+    expect(entries.map((e) => e.ts)).toEqual(["t1"]);
+    expect(corrupt).toEqual([1, 2, 3, 4]);
+  });
+});
+
+describe("option sanitising reaches SQLite as a bounded integer", () => {
+  let dir: string;
+  let log: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "mcx-phase-sanitise-"));
+    log = join(dir, "transitions.jsonl");
+    appendTransitionLog(log, { ts: "t1", workItemId: "#7", from: null, to: "impl", status: "committed" });
+    appendTransitionLog(log, { ts: "t2", workItemId: "#7", from: "impl", to: "qa", status: "committed" });
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  // ── 🟡4 ──────────────────────────────────────────────────────────────
+
+  // `configure` applies the timeout to the store's own connection, and that
+  // wiring is already covered by the held-lock tests below (a 50ms timeout
+  // demonstrably expires). What was broken is the arithmetic in front of it, so
+  // that is what is asserted here — the pragma is per-connection, so it cannot
+  // be observed from a second handle.
+  test.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    "a non-finite busy_timeout of %p falls back to the default, never to a disabled wait",
+    (timeoutMs) => {
+      // `Math.max(0, Math.trunc(NaN))` is NaN — Math.max propagates it — so the
+      // pragma read `busy_timeout = NaN` and SQLite silently applied 0, which
+      // disables the wait entirely: every contended writer then fails
+      // immediately instead of serialising, and the COMMIT retry cannot help
+      // because each attempt waits zero.
+      expect(sanitizeBusyTimeout(timeoutMs)).toBe(5000);
+    },
+  );
+
+  test("a busy_timeout too large to stringify as an integer is clamped, not applied as 1ms", () => {
+    // `1e21` is an integer, but it stringifies to `1e+21`, which SQLite parsed
+    // as 1ms. Clamping is what keeps the interpolated pragma a plain decimal.
+    expect(sanitizeBusyTimeout(1e21)).toBe(2_147_483_647);
+    expect(String(sanitizeBusyTimeout(1e21))).toBe("2147483647");
+  });
+
+  test("zero and negative busy_timeouts keep their documented do-not-wait meaning", () => {
+    expect(sanitizeBusyTimeout(0)).toBe(0);
+    expect(sanitizeBusyTimeout(-1)).toBe(0);
+    expect(sanitizeBusyTimeout(250.9)).toBe(250);
+  });
+
+  test("a non-finite timeout still yields a working store end to end", () => {
+    expect(readAllTransitions(log, { timeoutMs: Number.NaN })).toHaveLength(2);
+  });
+
+  // ── 🟡5 ──────────────────────────────────────────────────────────────
+
+  test("an integer tail too large to stringify as an integer still reads", () => {
+    // `Number.isInteger(1e21)` is true, but it stringifies to `1e+21`, so an
+    // interpolated LIMIT reached SQLite as `LIMIT 1e+21` → datatype mismatch.
+    expect(readAllTransitions(log, { tail: 1e21 })).toHaveLength(2);
+    expect(readAllTransitions(log, { tail: Number.MAX_SAFE_INTEGER })).toHaveLength(2);
+    expect(readTransitionHistory(log, "#7", undefined, { tail: 1e21 })).toHaveLength(2);
+  });
+
+  test("a non-integer tail is still rejected before it reaches SQL", () => {
+    expect(() => readAllTransitions(log, { tail: 1.5 })).toThrow(TypeError);
+    expect(() => readAllTransitions(log, { tail: Number.NaN })).toThrow(TypeError);
+  });
+});
+
 describe("commitTransition / withTransitionWriter (issue #1328)", () => {
   let dir: string;
   beforeEach(() => {
@@ -796,6 +1072,37 @@ describe("commitTransition / withTransitionWriter (issue #1328)", () => {
         { timeoutMs: NESTED_LOCK_TIMEOUT_MS },
       ),
     ).toThrow(TransitionLockBusyError);
+
+    expect(await child.exited).toBe(0);
+  });
+
+  test("a read does not fail just because another process holds the import lock", async () => {
+    // The staging-file scan in `openForRead` runs unlocked, so a reader fires on
+    // a *live* peer's in-flight claim as readily as on an abandoned one. If that
+    // escalation propagated, every read-only caller (`readTransitionHistory`
+    // from `phase.ts`, `pruneStaleHistory` from `track.ts`, where it is `exit 1`)
+    // would fail for the duration of someone else's import.
+    const HOLD_MS = 400;
+    const log = join(dir, "transitions.jsonl");
+    const ready = join(dir, "import-lock-held");
+    appendTransitionLog(log, { ts: "t0", workItemId: "#read", from: null, to: "impl" });
+
+    const child = Bun.spawn(["bun", "run", holdWorkerPath, "write", log, ready, String(HOLD_MS)]);
+    await pollUntil(() => existsSync(ready));
+
+    // Planted only once the lock is held, so the reader's escalation is
+    // guaranteed to contend rather than racing the child's own migration.
+    const staging = `${log}.importing.1-deadbeef`;
+    writeFileSync(staging, `${JSON.stringify({ ts: "t1", workItemId: "#read", from: "impl", to: "qa" })}\n`);
+
+    // Pre-import history, not an error.
+    expect(historyTargets(readAllTransitions(log, { timeoutMs: NESTED_LOCK_TIMEOUT_MS }))).toEqual(["impl"]);
+    expect(
+      historyTargets(readTransitionHistory(log, "#read", undefined, { timeoutMs: NESTED_LOCK_TIMEOUT_MS })),
+    ).toEqual(["impl"]);
+    // Contention must never be mistaken for a bad file: the claim stays put for
+    // replay instead of being quarantined.
+    expect(existsSync(staging)).toBe(true);
 
     expect(await child.exited).toBe(0);
   });

--- a/packages/core/src/phase-transition.spec.ts
+++ b/packages/core/src/phase-transition.spec.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pollUntil } from "../../../test/harness";
 import type { Manifest } from "./manifest";
 import {
   DisallowedTransitionError,
@@ -26,6 +27,9 @@ import {
 
 /** Short deadline for the deliberately-contended nested-lock test. */
 const NESTED_LOCK_TIMEOUT_MS = 50;
+
+/** Helper process that holds a read or write lock so contention is observable. */
+const holdWorkerPath = join(import.meta.dir, "phase-lock-hold-worker.ts");
 
 const manifest: Manifest = {
   version: 1,
@@ -465,6 +469,34 @@ describe("legacy jsonl migration (#1328)", () => {
     expect(readAllTransitions(log).map((e) => e.ts)).toEqual(["first", "second"]);
   });
 
+  test("rapid successive parks never clobber an older parked generation", () => {
+    // Regression: the park name was `${log}.migrated.${Date.now()}`, so two
+    // parks inside one millisecond computed the same name and renameSync
+    // silently destroyed the older one. The parked jsonl is the artifact
+    // recovery reads from when the DB is what went wrong, so every generation
+    // must survive. 40 parks in a tight loop reliably collides on a ms clock.
+    const generations = 40;
+    for (let i = 0; i < generations; i++) {
+      writeFileSync(log, jsonlLine({ ts: `gen${i}`, workItemId: "#7", from: null, to: "impl" }), "utf-8");
+      readAllTransitions(log);
+    }
+
+    // Asserted over the whole directory, so a leftover staging file or an
+    // unmigrated jsonl fails here too: one park per generation and nothing else.
+    const files = readdirSync(dir).sort();
+    expect(files).toHaveLength(generations + 1);
+    expect(files[0]).toBe("transitions.db");
+    const parked = files.slice(1);
+    for (const name of parked) expect(name.startsWith("transitions.jsonl.migrated")).toBe(true);
+    // Every generation is recoverable from its own parked file.
+    const parkedContents = parked.map((n) => readFileSync(join(dir, n), "utf-8")).join("");
+    for (let i = 0; i < generations; i++) {
+      expect(parkedContents).toContain(`"ts":"gen${i}"`);
+    }
+    // The DB holds every generation too.
+    expect(readAllTransitions(log)).toHaveLength(generations);
+  });
+
   test("reopening does not re-import (no duplicate rows)", () => {
     writeFileSync(
       log,
@@ -682,6 +714,103 @@ describe("commitTransition / withTransitionWriter (issue #1328)", () => {
       expect(historyTargets(writer.history("#1"))).toEqual(["impl"]);
     });
     expect(historyTargets(readTransitionHistory(log, "#1"))).toEqual(["impl"]);
+  });
+
+  test("a contended writer waits for the lock and still commits", async () => {
+    // The 10-way fan-out above proves the transaction boundary matters, but its
+    // transactions are sub-millisecond, so it never shows a contended writer
+    // *waiting*. Here a child process holds the write lock for HOLD_MS while
+    // this writer, given a generous timeout, must block at BEGIN IMMEDIATE and
+    // then succeed rather than raising TransitionLockBusyError.
+    const HOLD_MS = 400;
+    const log = join(dir, "transitions.jsonl");
+    const ready = join(dir, "held");
+    const child = Bun.spawn(["bun", "run", holdWorkerPath, "write", log, ready, String(HOLD_MS)]);
+
+    await pollUntil(() => existsSync(ready));
+    const startedAt = Date.now();
+    appendTransitionLog(log, { ts: "contender", workItemId: "#hold", from: "impl", to: "qa" }, { timeoutMs: 30_000 });
+    const waitedMs = Date.now() - startedAt;
+
+    expect(await child.exited).toBe(0);
+    // Blocked for a meaningful fraction of the hold rather than erroring out.
+    expect(waitedMs).toBeGreaterThan(HOLD_MS / 4);
+    // Both writes are present, in lock order.
+    expect(historyTargets(readTransitionHistory(log, "#hold"))).toEqual(["impl", "qa"]);
+  });
+
+  test("a busy COMMIT retries instead of discarding the validated entry", async () => {
+    // A reader holding SHARED across the commit point blocks COMMIT's
+    // RESERVED -> EXCLUSIVE upgrade, so COMMIT itself returns SQLITE_BUSY and
+    // SQLite leaves the transaction ACTIVE. Rolling back there threw away an
+    // already-validated entry and misreported it as another run's contention.
+    //
+    // The reader has to arrive *after* BEGIN IMMEDIATE — a reader already
+    // holding SHARED beforehand blocks the schema bootstrap instead, which is
+    // the separate case covered by the next test. Hence the spawn-and-wait
+    // inside `fn`, polled synchronously because `fn` must not return a Promise.
+    // HOLD_MS > timeoutMs makes the first COMMIT attempt fail; HOLD_MS is well
+    // inside the retry budget (3 attempts x timeoutMs) so a retry succeeds.
+    const COMMIT_TIMEOUT_MS = 400;
+    const HOLD_MS = 600;
+    const log = join(dir, "transitions.jsonl");
+    const ready = join(dir, "reader-held");
+    // Materialise the store so the reader has a db file to open.
+    appendTransitionLog(log, { ts: "t0", workItemId: "#busy", from: null, to: "impl" });
+
+    let child: ReturnType<typeof Bun.spawn> | undefined;
+    withTransitionWriter(
+      log,
+      (writer) => {
+        writer.insert({ ts: "t1", workItemId: "#busy", from: "impl", to: "qa" });
+        child = Bun.spawn(["bun", "run", holdWorkerPath, "read", log, ready, String(HOLD_MS)]);
+        const deadline = Date.now() + 10_000;
+        while (!existsSync(ready) && Date.now() < deadline) Bun.sleepSync(5);
+        expect(existsSync(ready)).toBe(true);
+      },
+      { timeoutMs: COMMIT_TIMEOUT_MS },
+    );
+
+    expect(await child?.exited).toBe(0);
+    // The entry survived the busy COMMIT rather than being silently dropped.
+    expect(historyTargets(readTransitionHistory(log, "#busy"))).toEqual(["impl", "qa"]);
+  });
+
+  test("a reader blocking the schema bootstrap surfaces as lock contention", async () => {
+    // `openForWrite` -> `applySchema` writes before BEGIN IMMEDIATE, so a reader
+    // holding SHARED makes it fail. That happens outside the transaction, and
+    // used to escape as a raw unclassified SQLiteError instead of the typed
+    // error every caller of this store knows how to interpret.
+    const HOLD_MS = 400;
+    const log = join(dir, "transitions.jsonl");
+    const ready = join(dir, "bootstrap-reader-held");
+    appendTransitionLog(log, { ts: "t0", workItemId: "#boot", from: null, to: "impl" });
+
+    const child = Bun.spawn(["bun", "run", holdWorkerPath, "read", log, ready, String(HOLD_MS)]);
+    await pollUntil(() => existsSync(ready));
+
+    expect(() =>
+      appendTransitionLog(
+        log,
+        { ts: "t1", workItemId: "#boot", from: "impl", to: "qa" },
+        { timeoutMs: NESTED_LOCK_TIMEOUT_MS },
+      ),
+    ).toThrow(TransitionLockBusyError);
+
+    expect(await child.exited).toBe(0);
+  });
+
+  test("a rollback-journal locking failure is classified as lock contention", () => {
+    // SQLITE_PROTOCOL is the rollback journal's locking-protocol failure — the
+    // flaky shared-mount case the NOT-WAL decision exists to serve — so it must
+    // surface as the typed retryable error, not a raw SQLiteError. (The WAL-only
+    // SQLITE_BUSY_SNAPSHOT it replaced was unreachable in this journal mode.)
+    const log = join(dir, "transitions.jsonl");
+    expect(() =>
+      withTransitionWriter(log, () => {
+        throw Object.assign(new Error("locking protocol"), { code: "SQLITE_PROTOCOL" });
+      }),
+    ).toThrow(TransitionLockBusyError);
   });
 
   test("a held write lock surfaces TransitionLockBusyError, not a silent skip", () => {

--- a/packages/core/src/phase-transition.ts
+++ b/packages/core/src/phase-transition.ts
@@ -1,7 +1,7 @@
 /**
  * Phase transition graph enforcement (issue #1293).
  *
- * Pure validator + append-only transition log. Given a manifest and the
+ * Pure validator over an append-only transition log. Given a manifest and the
  * history of transitions for a work item, decides whether a proposed
  * `from → target` move is allowed, and classifies failures into three
  * specific errors instead of one generic "invalid transition":
@@ -13,60 +13,38 @@
  * `--force <message>` bypasses (2) and (3) but never (1). The message is
  * required (enforced by the caller) and recorded in the log entry so the
  * reasoning is preserved alongside the transition itself.
+ *
+ * Storage lives in `./transition-store` (SQLite, see #1328/#1372/#1375) and is
+ * re-exported here so callers keep a single import site.
  */
 
-import { randomBytes } from "node:crypto";
-import {
-  appendFileSync,
-  closeSync,
-  mkdirSync,
-  openSync,
-  readFileSync,
-  renameSync,
-  statSync,
-  unlinkSync,
-  writeFileSync,
-  writeSync,
-} from "node:fs";
-import { dirname, join } from "node:path";
 import type { Manifest } from "./manifest";
+import {
+  type OnCorruptLine,
+  type TransitionLogEntry,
+  appendTransitionLog,
+  isCommitted,
+  withTransitionWriter,
+} from "./transition-store";
 
-/**
- * Lifecycle status of a transition log entry.
- *
- * - `"attempted"`: intent was logged but the phase handler has not (yet)
- *   committed. Written before branch-guard / handler dispatch so attempts
- *   from feature branches or crashed handlers leave an audit trail.
- *   IGNORED by regression / graph-walk checks.
- * - `"committed"`: the phase handler ran to completion and the transition
- *   is now part of the work item's authoritative history.
- *
- * Legacy entries (written before issue #1381 re-entry fix) omit `status`;
- * readers treat missing `status` as `"committed"` for back-compat so old
- * logs continue to gate transitions the same way.
- */
-export type TransitionStatus = "attempted" | "committed";
-
-/** One record in the transition log. JSONL on disk. */
-export interface TransitionLogEntry {
-  /** ISO-8601 UTC timestamp. */
-  ts: string;
-  /** Work-item identifier, or null if transitioning outside a work item. */
-  workItemId: string | null;
-  /** Source phase; null for the very first transition (initial). */
-  from: string | null;
-  /** Target phase (guaranteed to be a declared phase). */
-  to: string;
-  /** When `--force` was used, the justification text. */
-  forceMessage?: string;
-  /** Two-phase commit status. Missing → "committed" (legacy). */
-  status?: TransitionStatus;
-}
-
-/** True when `entry` should gate future transitions (committed or legacy). */
-export function isCommitted(entry: TransitionLogEntry): boolean {
-  return entry.status !== "attempted";
-}
+export {
+  type OnCorruptLine,
+  type ReadAllOptions,
+  type ReadHistoryOptions,
+  type StoreOptions,
+  type TransitionLogEntry,
+  type TransitionStatus,
+  type TransitionWriter,
+  TransitionLockBusyError,
+  appendTransitionLog,
+  defaultOnCorruptLine,
+  isCommitted,
+  pruneStaleHistory,
+  readAllTransitions,
+  readTransitionHistory,
+  transitionDbPath,
+  withTransitionWriter,
+} from "./transition-store";
 
 export class UnknownPhaseError extends Error {
   constructor(
@@ -233,148 +211,9 @@ export function validateTransition(input: ValidateTransitionInput): {
   return { from, target, forced: false };
 }
 
-/**
- * Called once per corrupt JSONL line encountered. `lineNumber` is 1-based.
- * Default: warn to stderr so silent log rot is visible (issue #1328).
- */
-export type OnCorruptLine = (lineNumber: number, line: string, err: unknown) => void;
-
-function defaultOnCorruptLine(logPath: string): OnCorruptLine {
-  return (lineNumber, line, err) => {
-    const msg = err instanceof Error ? err.message : String(err);
-    const preview = line.length > 80 ? `${line.slice(0, 77)}...` : line;
-    process.stderr.write(`warn: corrupt transition log line ${logPath}:${lineNumber} (${msg}): ${preview}\n`);
-  };
-}
-
-/**
- * Read all transition log entries for a work item from a JSONL file.
- * Missing file → empty array. Malformed lines are passed to `onCorrupt`
- * (default: warn to stderr with line number) so corruption is visible
- * rather than silently swallowed.
- */
-export function readTransitionHistory(
-  logPath: string,
-  workItemId: string | null,
-  onCorrupt: OnCorruptLine = defaultOnCorruptLine(logPath),
-): TransitionLogEntry[] {
-  let text: string;
-  try {
-    text = readFileSync(logPath, "utf-8");
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return [];
-    throw err;
-  }
-  const out: TransitionLogEntry[] = [];
-  const lines = text.split("\n");
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (!line) continue;
-    try {
-      const entry = JSON.parse(line) as TransitionLogEntry;
-      if (entry && entry.workItemId === workItemId) out.push(entry);
-    } catch (err) {
-      onCorrupt(i + 1, line, err);
-    }
-  }
-  return out;
-}
-
-/**
- * Read every transition log entry from a JSONL file, oldest first.
- * Missing file → empty array. Malformed lines are warned to stderr and skipped.
- */
-export function readAllTransitions(logPath: string): TransitionLogEntry[] {
-  let text: string;
-  try {
-    text = readFileSync(logPath, "utf-8");
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException)?.code === "ENOENT") return [];
-    throw err;
-  }
-  const out: TransitionLogEntry[] = [];
-  const lines = text.split("\n");
-  const onCorrupt = defaultOnCorruptLine(logPath);
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (!line) continue;
-    try {
-      out.push(JSON.parse(line) as TransitionLogEntry);
-    } catch (err) {
-      onCorrupt(i + 1, line, err);
-    }
-  }
-  return out;
-}
-
-/**
- * Replace `path` with `content` atomically: write to a temp file in the
- * same directory, then `rename(2)` over the target. Readers see either the
- * old file or the new file, never a truncated/partial write (issue #2685).
- *
- * `writeFn` is injectable for crash-mid-write tests (DI, not mock.module).
- */
-export function atomicWriteFileSync(
-  path: string,
-  content: string,
-  writeFn: (path: string, content: string, encoding: "utf-8") => void = writeFileSync,
-): void {
-  mkdirSync(dirname(path), { recursive: true });
-  const tmpPath = join(dirname(path), `.tmp-${randomBytes(6).toString("hex")}`);
-  try {
-    writeFn(tmpPath, content, "utf-8");
-    renameSync(tmpPath, path);
-  } catch (err) {
-    try {
-      unlinkSync(tmpPath);
-    } catch {
-      // best effort — temp may not exist
-    }
-    throw err;
-  }
-}
-
-/**
- * Remove stale transition log entries for a work item whose incarnation
- * predates `cutoff`. Used by `mcx track` to clear history from prior
- * sprints so a re-tracked item starts with a clean slate (issue #2463).
- *
- * Returns the number of entries pruned. Acquires `withTransitionLock` so
- * concurrent phase runs can't race with the rewrite.
- */
-export function pruneStaleHistory(logPath: string, workItemId: string, cutoff: Date): number {
-  return withTransitionLock(logPath, () => {
-    const all = readAllTransitions(logPath);
-    if (all.length === 0) return 0;
-
-    const cutoffMs = cutoff.getTime();
-    const kept: TransitionLogEntry[] = [];
-    let pruned = 0;
-    for (const entry of all) {
-      if (entry.workItemId === workItemId && new Date(entry.ts).getTime() < cutoffMs) {
-        pruned++;
-      } else {
-        kept.push(entry);
-      }
-    }
-
-    if (pruned === 0) return 0;
-
-    const content = kept.map((e) => JSON.stringify(e)).join("\n") + (kept.length > 0 ? "\n" : "");
-    atomicWriteFileSync(logPath, content);
-    return pruned;
-  });
-}
-
 /** Return the `to` field of every history entry, oldest first. */
 export function historyTargets(entries: readonly TransitionLogEntry[]): string[] {
   return entries.map((e) => e.to);
-}
-
-/** Append one transition entry to the JSONL log. Creates parent dir if needed. */
-export function appendTransitionLog(logPath: string, entry: TransitionLogEntry): void {
-  mkdirSync(dirname(logPath), { recursive: true });
-  appendFileSync(logPath, `${JSON.stringify(entry)}\n`, "utf-8");
 }
 
 /**
@@ -408,96 +247,6 @@ export function appendAttempt(
   return entry;
 }
 
-/**
- * Acquire an exclusive lockfile sidecar for `logPath`, run `fn`, then release.
- *
- * Uses O_EXCL to atomically create `<logPath>.lock`. If contended, polls
- * with jittered backoff up to `timeoutMs`. Stale locks (older than
- * `staleMs`) are reaped to survive crashed holders.
- *
- * Scope: wraps the full read-validate-append cycle so concurrent
- * `mcx phase run` invocations for the same work item can't interleave
- * (issue #1328).
- */
-export function withTransitionLock<T>(
-  logPath: string,
-  fn: () => T,
-  opts: { timeoutMs?: number; staleMs?: number } = {},
-): T {
-  const timeoutMs = opts.timeoutMs ?? 5000;
-  const staleMs = opts.staleMs ?? 30_000;
-  const lockPath = `${logPath}.lock`;
-  mkdirSync(dirname(logPath), { recursive: true });
-
-  // Nonce written into the lock body so we can verify ownership before unlinking.
-  // Prevents our finally from deleting a lock acquired by another process if fn()
-  // runs longer than staleMs and our lock was reaped while we were inside fn().
-  const nonce = `${process.pid}:${Date.now()}:${Math.random().toString(36).slice(2)}`;
-
-  const deadline = Date.now() + timeoutMs;
-  let fd: number | null = null;
-  while (fd === null) {
-    try {
-      fd = openSync(lockPath, "wx");
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException)?.code !== "EEXIST") throw err;
-      try {
-        const age = Date.now() - statSync(lockPath).mtimeMs;
-        if (age > staleMs) {
-          try {
-            unlinkSync(lockPath);
-          } catch {
-            // lost the race; fall through and retry
-          }
-          continue;
-        }
-      } catch (statErr) {
-        if ((statErr as NodeJS.ErrnoException)?.code !== "ENOENT") throw statErr;
-        // lock disappeared between EEXIST and stat; retry
-        continue;
-      }
-      if (Date.now() >= deadline) {
-        throw new Error(
-          `could not acquire transition lock ${lockPath} within ${timeoutMs}ms — another phase run is in progress`,
-        );
-      }
-      const sleep = 10 + Math.floor(Math.random() * 40);
-      Bun.sleepSync(sleep);
-    }
-  }
-
-  // Write nonce so we can verify ownership in finally.
-  try {
-    writeSync(fd, nonce);
-  } catch {
-    // write failed; proceed — lock is held but we can't verify in finally
-  }
-
-  try {
-    const result = fn();
-    if (result instanceof Promise) {
-      // Lock would be released before the async work completes. Reject loudly.
-      throw new Error("withTransitionLock: fn must be synchronous (returned a Promise)");
-    }
-    return result;
-  } finally {
-    try {
-      closeSync(fd);
-    } catch {
-      // best effort
-    }
-    // Only unlink if the lock still belongs to us. If fn() took longer than
-    // staleMs another process may have reaped our lock and written their nonce.
-    try {
-      if (readFileSync(lockPath, "utf-8") === nonce) {
-        unlinkSync(lockPath);
-      }
-    } catch {
-      // best effort — stale lock will be reaped by the next waiter
-    }
-  }
-}
-
 export interface CommitTransitionInput {
   manifest: Manifest;
   /** Explicit `from`; if null, inferred from the tail of the history. */
@@ -508,11 +257,9 @@ export interface CommitTransitionInput {
   manifestPath?: string;
   /** Timestamp supplier; defaults to `new Date()`. */
   now?: () => Date;
-  /** Lock timeout passthrough. */
+  /** How long to wait for a contended write lock before failing. */
   timeoutMs?: number;
-  /** Stale-lock reaping threshold passthrough. */
-  staleMs?: number;
-  /** Corrupt-line sink, passed through to `readTransitionHistory`. */
+  /** Corrupt-line sink for the one-time legacy jsonl import. */
   onCorrupt?: OnCorruptLine;
 }
 
@@ -524,22 +271,25 @@ export interface CommitTransitionResult {
 }
 
 /**
- * Atomic read-validate-append. Holds an exclusive lock around the full
- * cycle so concurrent invocations can't observe the same history snapshot
- * and double-append (issue #1328).
+ * Atomic read-validate-append.
+ *
+ * The whole cycle runs inside one SQLite write transaction, so two concurrent
+ * invocations for the same work item cannot both validate against the same
+ * history snapshot and double-append (issue #1328). The second writer blocks on
+ * the write lock and then sees the first writer's entry.
  *
  * Callers that only need validation with no side effects should use
  * `validateTransition` directly.
  */
 export function commitTransition(logPath: string, input: CommitTransitionInput): CommitTransitionResult {
-  const { manifest, target, workItemId, force = null, manifestPath, now, timeoutMs, staleMs, onCorrupt } = input;
+  const { manifest, target, workItemId, force = null, manifestPath, now, timeoutMs, onCorrupt } = input;
 
-  return withTransitionLock(
+  return withTransitionWriter(
     logPath,
-    () => {
+    (writer) => {
       // Validation considers only committed entries; "attempted" entries
       // are audit-only and must not gate future transitions (#1407).
-      const history = readTransitionHistory(logPath, workItemId, onCorrupt).filter(isCommitted);
+      const history = writer.history(workItemId).filter(isCommitted);
       const targets = historyTargets(history);
 
       let from = input.from;
@@ -566,10 +316,10 @@ export function commitTransition(logPath: string, input: CommitTransitionInput):
         status: "committed",
         ...(force ? { forceMessage: force.message } : {}),
       };
-      appendTransitionLog(logPath, entry);
+      writer.insert(entry);
 
       return { from: decision.from, target: decision.target, forced: decision.forced, entry };
     },
-    { timeoutMs, staleMs },
+    { ...(timeoutMs !== undefined ? { timeoutMs } : {}), ...(onCorrupt !== undefined ? { onCorrupt } : {}) },
   );
 }

--- a/packages/core/src/phase-transition.ts
+++ b/packages/core/src/phase-transition.ts
@@ -28,7 +28,9 @@ import {
 } from "./transition-store";
 
 export {
+  type MigrationReport,
   type OnCorruptLine,
+  type OnMigrate,
   type ReadAllOptions,
   type ReadHistoryOptions,
   type StoreOptions,
@@ -38,6 +40,7 @@ export {
   TransitionLockBusyError,
   appendTransitionLog,
   defaultOnCorruptLine,
+  defaultOnMigrate,
   isCommitted,
   pruneStaleHistory,
   readAllTransitions,

--- a/packages/core/src/transition-store.ts
+++ b/packages/core/src/transition-store.ts
@@ -1,0 +1,617 @@
+/**
+ * SQLite-backed storage for the phase transition log (issues #1328, #1372, #1375).
+ *
+ * Replaces the append-only `.mcx/transitions.jsonl` file. The jsonl design had
+ * three distinct failure modes, all of which are structural rather than
+ * incidental:
+ *
+ *   1. #1328 — `appendFileSync` after a separate read/validate step is a
+ *      read-modify-write race. Two concurrent `mcx phase run` invocations for
+ *      the same work item both read the same history snapshot, both validate
+ *      against it, and both append. A partial write (crash or entry > PIPE_BUF)
+ *      leaves a torn line that readers then silently skip, dropping a
+ *      `committed` entry and breaking the next transition.
+ *   2. #1372 — the O_EXCL lockfile that mitigated (1) is not atomic on NFSv2
+ *      and unreliable on many NFSv3 configurations, so the mitigation does not
+ *      hold on shared mounts.
+ *   3. #1375 — every read loaded and parsed the entire file, which grows one
+ *      line per phase run forever.
+ *
+ * A single-writer SQLite transaction fixes all three at once: read-validate-
+ * insert happens inside `BEGIN IMMEDIATE` (atomic, no advisory locking), reads
+ * are indexed queries instead of full-file parses, and there is no line-level
+ * write to tear.
+ *
+ * ## Journal mode: deliberately NOT WAL
+ *
+ * This store uses SQLite's default rollback journal, not WAL. WAL requires a
+ * `-shm` shared-memory file that SQLite mmaps to coordinate readers and
+ * writers; that mmap is not available on network filesystems, so a WAL
+ * database on an NFS-mounted home directory either fails to open or corrupts.
+ * NFS-mounted `~/` is exactly the environment #1372 is about, so WAL would
+ * reintroduce the bug this store exists to fix. Rollback journal + a
+ * `busy_timeout` uses POSIX locks only, which NFS does support.
+ *
+ * DO NOT "optimize" this to `PRAGMA journal_mode = WAL`. Transactions here are
+ * single-digit-millisecond inserts; there is no throughput problem to solve,
+ * and the tradeoff is correctness on shared mounts.
+ */
+
+import { Database } from "bun:sqlite";
+import { randomBytes } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+
+/** Default wait for a contended write lock before surfacing a busy error. */
+const DEFAULT_BUSY_TIMEOUT_MS = 5000;
+
+/** Current schema revision, recorded in `meta` for future migrations. */
+const SCHEMA_VERSION = 1;
+
+/** Suffix for a legacy jsonl claimed by an in-flight import. */
+const IMPORTING_SUFFIX = ".importing.";
+
+/**
+ * Lifecycle status of a transition log entry.
+ *
+ * - `"attempted"`: intent was logged but the phase handler has not (yet)
+ *   committed. Written before branch-guard / handler dispatch so attempts
+ *   from feature branches or crashed handlers leave an audit trail.
+ *   IGNORED by regression / graph-walk checks.
+ * - `"committed"`: the phase handler ran to completion and the transition
+ *   is now part of the work item's authoritative history.
+ *
+ * Legacy entries (written before issue #1381 re-entry fix) omit `status`;
+ * readers treat missing `status` as `"committed"` for back-compat so old
+ * logs continue to gate transitions the same way.
+ */
+export type TransitionStatus = "attempted" | "committed";
+
+/** One record in the transition log. */
+export interface TransitionLogEntry {
+  /** ISO-8601 UTC timestamp. */
+  ts: string;
+  /** Work-item identifier, or null if transitioning outside a work item. */
+  workItemId: string | null;
+  /** Source phase; null for the very first transition (initial). */
+  from: string | null;
+  /** Target phase (guaranteed to be a declared phase). */
+  to: string;
+  /** When `--force` was used, the justification text. */
+  forceMessage?: string;
+  /** Two-phase commit status. Missing → "committed" (legacy). */
+  status?: TransitionStatus;
+}
+
+/** True when `entry` should gate future transitions (committed or legacy). */
+export function isCommitted(entry: TransitionLogEntry): boolean {
+  return entry.status !== "attempted";
+}
+
+/**
+ * Called once per corrupt line encountered while importing a legacy
+ * `transitions.jsonl`. `lineNumber` is 1-based.
+ *
+ * Only fires during the one-time jsonl → SQLite migration; the SQLite store
+ * itself cannot produce a partially-written record.
+ */
+export type OnCorruptLine = (lineNumber: number, line: string, err: unknown) => void;
+
+/** Default corrupt-line sink: warn to stderr so silent log rot is visible. */
+export function defaultOnCorruptLine(logPath: string): OnCorruptLine {
+  return (lineNumber, line, err) => {
+    const msg = err instanceof Error ? err.message : String(err);
+    const preview = line.length > 80 ? `${line.slice(0, 77)}...` : line;
+    process.stderr.write(`warn: corrupt transition log line ${logPath}:${lineNumber} (${msg}): ${preview}\n`);
+  };
+}
+
+/**
+ * Raised when the write lock could not be acquired. Distinguishes real
+ * contention from a programming error so callers can retry or report
+ * "another phase run is in progress".
+ */
+export class TransitionLockBusyError extends Error {
+  constructor(
+    public readonly dbPath: string,
+    public readonly timeoutMs: number,
+    options?: { cause?: unknown },
+  ) {
+    super(
+      `could not acquire the transition write lock on ${dbPath} within ${timeoutMs}ms — another phase run is in progress`,
+      options,
+    );
+    this.name = "TransitionLockBusyError";
+  }
+}
+
+/** True when `err` is a SQLite busy/locked error, by code (never by message). */
+function isBusyError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null || !("code" in err)) return false;
+  const code = (err as { code: unknown }).code;
+  return code === "SQLITE_BUSY" || code === "SQLITE_BUSY_SNAPSHOT" || code === "SQLITE_LOCKED";
+}
+
+function errnoCode(err: unknown): string | undefined {
+  if (typeof err !== "object" || err === null || !("code" in err)) return undefined;
+  const code = (err as { code: unknown }).code;
+  return typeof code === "string" ? code : undefined;
+}
+
+/**
+ * Path of the SQLite database backing `logPath`.
+ *
+ * The whole public API is keyed on the historical jsonl path so callers
+ * (`transitionLogPath()`, phase scripts, `.mcx.lock` consumers) need no
+ * change: `.mcx/transitions.jsonl` → `.mcx/transitions.db`.
+ */
+export function transitionDbPath(logPath: string): string {
+  const base = logPath.endsWith(".jsonl") ? logPath.slice(0, -".jsonl".length) : logPath;
+  return `${base}.db`;
+}
+
+// ── Row mapping ────────────────────────────────────────────────────────
+
+interface TransitionRow {
+  ts: string;
+  work_item_id: string | null;
+  from_phase: string | null;
+  to_phase: string;
+  force_message: string | null;
+  status: string | null;
+}
+
+/**
+ * Narrow a stored status string. NULL is a legacy entry (no status column
+ * value), and anything unrecognised is treated the same way — as committed —
+ * because that is how pre-#1381 logs were interpreted. Only the exact literal
+ * `"attempted"` downgrades an entry to audit-only, so a garbled value can
+ * never silently stop gating transitions.
+ */
+function toStatus(raw: string | null): TransitionStatus | undefined {
+  if (raw === "attempted") return "attempted";
+  if (raw === "committed") return "committed";
+  return undefined;
+}
+
+function rowToEntry(row: TransitionRow): TransitionLogEntry {
+  const status = toStatus(row.status);
+  return {
+    ts: row.ts,
+    workItemId: row.work_item_id,
+    from: row.from_phase,
+    to: row.to_phase,
+    ...(row.force_message !== null ? { forceMessage: row.force_message } : {}),
+    ...(status !== undefined ? { status } : {}),
+  };
+}
+
+// ── Schema ─────────────────────────────────────────────────────────────
+
+function applySchema(db: Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS transitions (
+      id            INTEGER PRIMARY KEY AUTOINCREMENT,
+      ts            TEXT NOT NULL,
+      work_item_id  TEXT,
+      from_phase    TEXT,
+      to_phase      TEXT NOT NULL,
+      force_message TEXT,
+      status        TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_transitions_work_item ON transitions(work_item_id, id);
+    CREATE TABLE IF NOT EXISTS meta (
+      key   TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS imported_files (
+      name        TEXT PRIMARY KEY,
+      imported_at TEXT NOT NULL
+    );
+  `);
+  db.run("INSERT OR IGNORE INTO meta (key, value) VALUES (?, ?)", ["schema_version", String(SCHEMA_VERSION)]);
+}
+
+// ── Legacy jsonl import ────────────────────────────────────────────────
+
+function parseJsonlEntries(text: string, onCorrupt: OnCorruptLine): TransitionLogEntry[] {
+  const out: TransitionLogEntry[] = [];
+  const lines = text.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line) continue;
+    try {
+      const parsed: unknown = JSON.parse(line);
+      if (parsed !== null && typeof parsed === "object") {
+        out.push(parsed as TransitionLogEntry);
+      }
+    } catch (err) {
+      onCorrupt(i + 1, line, err);
+    }
+  }
+  return out;
+}
+
+function insertEntries(db: Database, entries: readonly TransitionLogEntry[]): void {
+  const stmt = db.prepare(
+    "INSERT INTO transitions (ts, work_item_id, from_phase, to_phase, force_message, status) VALUES (?, ?, ?, ?, ?, ?)",
+  );
+  for (const e of entries) {
+    stmt.run(e.ts, e.workItemId, e.from, e.to, e.forceMessage ?? null, e.status ?? null);
+  }
+}
+
+/** Unique destination for a fully-imported jsonl, never overwriting an older one. */
+function migratedPath(logPath: string): string {
+  const first = `${logPath}.migrated`;
+  if (!existsSync(first)) return first;
+  return `${first}.${Date.now()}`;
+}
+
+/**
+ * Import one claimed staging file into the DB. Must run inside the caller's
+ * write transaction, and the file must be parked with `parkStagingFile` only
+ * after that transaction commits.
+ *
+ * Exactly-once is enforced by the `imported_files` row, written in the same
+ * transaction as the entries. A crash before COMMIT rolls the whole thing back
+ * and the staging file is retried on the next open; a crash after COMMIT but
+ * before the file is parked leaves the row behind, so the retry skips the
+ * insert and only parks the file. The data is never in neither place, and
+ * never in both.
+ */
+function importStagingFile(db: Database, staging: string, onCorrupt: OnCorruptLine): void {
+  const name = basename(staging);
+  const already = db.query<{ name: string }, [string]>("SELECT name FROM imported_files WHERE name = ?").get(name);
+  if (already !== null) return;
+  insertEntries(db, parseJsonlEntries(readFileSync(staging, "utf-8"), onCorrupt));
+  db.run("INSERT INTO imported_files (name, imported_at) VALUES (?, ?)", [name, new Date().toISOString()]);
+}
+
+/** Park a fully-committed staging file as `.migrated`. Never deletes it. */
+function parkStagingFile(staging: string, logPath: string): void {
+  try {
+    renameSync(staging, migratedPath(logPath));
+  } catch (err) {
+    // ENOENT: a concurrent process already parked it. Both processes agree the
+    // import committed, so there is nothing left to do.
+    if (errnoCode(err) !== "ENOENT") throw err;
+  }
+}
+
+/** Staging files left behind by a crash mid-import, oldest claim first. */
+function findAbandonedStagingFiles(logPath: string): string[] {
+  const dir = dirname(logPath);
+  const prefix = `${basename(logPath)}${IMPORTING_SUFFIX}`;
+  let names: string[];
+  try {
+    names = readdirSync(dir);
+  } catch (err) {
+    if (errnoCode(err) === "ENOENT") return [];
+    throw err;
+  }
+  // Nonces are `<Date.now()>-<random>`, so a lexical sort replays claims in
+  // the order they were made (Date.now() is a fixed 13 digits for centuries).
+  return names
+    .filter((n) => n.startsWith(prefix))
+    .sort()
+    .map((n) => join(dir, n));
+}
+
+/**
+ * Migrate a legacy `transitions.jsonl` into the DB, if one is present. Returns
+ * the staging files to park once the caller's transaction commits.
+ *
+ * Claiming is done by `rename(2)` rather than a lockfile: the first process to
+ * rename the jsonl to a private staging name owns the import, and every other
+ * process's rename fails with ENOENT. rename is atomic on POSIX and on NFS, so
+ * unlike the O_EXCL lockfile in #1372 this cannot double-claim on a shared
+ * mount — and no advisory lock is involved.
+ *
+ * This MUST be called with the write lock already held. Running it before
+ * `BEGIN IMMEDIATE` reintroduces #1328 in a new shape: a second process can
+ * observe "nothing to import" in the window between another process's
+ * directory scan and its claiming rename, then commit its own entry ahead of
+ * the imported history — leaving the log out of insertion order and the second
+ * process's transition validated against an empty history.
+ */
+function migrateLegacyJsonl(db: Database, logPath: string, onCorrupt: OnCorruptLine): string[] {
+  const staged: string[] = [];
+  for (const abandoned of findAbandonedStagingFiles(logPath)) {
+    importStagingFile(db, abandoned, onCorrupt);
+    staged.push(abandoned);
+  }
+
+  if (!existsSync(logPath)) return staged;
+
+  const staging = `${logPath}${IMPORTING_SUFFIX}${Date.now()}-${randomBytes(4).toString("hex")}`;
+  try {
+    renameSync(logPath, staging);
+  } catch (err) {
+    // ENOENT: another process claimed the jsonl first — it owns the import.
+    if (errnoCode(err) === "ENOENT") return staged;
+    throw err;
+  }
+  importStagingFile(db, staging, onCorrupt);
+  staged.push(staging);
+  return staged;
+}
+
+// ── Connection lifecycle ───────────────────────────────────────────────
+
+function configure(db: Database, busyTimeoutMs: number): void {
+  // Rollback journal (the default) is retained deliberately — see the
+  // "Journal mode: deliberately NOT WAL" note at the top of this file.
+  db.exec(`PRAGMA busy_timeout = ${Math.max(0, Math.trunc(busyTimeoutMs))}`);
+}
+
+function rollbackQuietly(db: Database): void {
+  try {
+    db.exec("ROLLBACK");
+  } catch (err) {
+    // A failed rollback means the transaction was already aborted by SQLite
+    // (the common case for a constraint violation). The original error is
+    // about to be rethrown by the caller and is the more useful one.
+    void err;
+  }
+}
+
+export interface StoreOptions {
+  /** How long to wait for a contended write lock. */
+  timeoutMs?: number;
+  /** Corrupt-line sink for the one-time legacy jsonl import. */
+  onCorrupt?: OnCorruptLine;
+}
+
+/**
+ * Open the store for writing, creating the file and schema as needed. The
+ * legacy-jsonl import deliberately does NOT happen here — it runs inside the
+ * write transaction (see `migrateLegacyJsonl`). Caller must `close()`.
+ */
+function openForWrite(logPath: string, opts: StoreOptions = {}): Database {
+  const dbPath = transitionDbPath(logPath);
+  mkdirSync(dirname(dbPath), { recursive: true });
+  const db = new Database(dbPath, { create: true });
+  try {
+    configure(db, opts.timeoutMs ?? DEFAULT_BUSY_TIMEOUT_MS);
+    applySchema(db);
+    return db;
+  } catch (err) {
+    db.close();
+    throw err;
+  }
+}
+
+/**
+ * Open the store for reading, or return null when nothing has ever been
+ * written. Reads must not materialise a database file as a side effect —
+ * `readTransitionHistory` on a fresh repo answers "no history" without
+ * touching the disk.
+ */
+function openForRead(logPath: string, opts: StoreOptions = {}): Database | null {
+  const dbPath = transitionDbPath(logPath);
+  if (existsSync(logPath) || findAbandonedStagingFiles(logPath).length > 0) {
+    // A pending import has to run under the write lock, so a read that finds
+    // one drives an otherwise-empty write transaction to completion first.
+    withDbTx(logPath, () => {}, opts);
+  }
+  if (!existsSync(dbPath)) return null;
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    configure(db, opts.timeoutMs ?? DEFAULT_BUSY_TIMEOUT_MS);
+    return db;
+  } catch (err) {
+    db.close();
+    throw err;
+  }
+}
+
+/**
+ * Run `fn` inside a single `BEGIN IMMEDIATE` write transaction.
+ *
+ * `BEGIN IMMEDIATE` takes the write lock up front, so a read-validate-insert
+ * cycle inside `fn` cannot interleave with another process's cycle: this is
+ * what makes `commitTransition` atomic without the lockfile from #1368/#1372.
+ * Concurrent writers serialise on SQLite's own lock and wait up to
+ * `busy_timeout`, after which they get a `TransitionLockBusyError`.
+ */
+function withDbTx<T>(logPath: string, fn: (db: Database) => T, opts: StoreOptions = {}): T {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_BUSY_TIMEOUT_MS;
+  const db = openForWrite(logPath, { ...opts, timeoutMs });
+  try {
+    try {
+      db.exec("BEGIN IMMEDIATE");
+    } catch (err) {
+      if (isBusyError(err)) throw new TransitionLockBusyError(transitionDbPath(logPath), timeoutMs, { cause: err });
+      throw err;
+    }
+    try {
+      // Inside the lock: the imported history is guaranteed to precede anything
+      // `fn` inserts, and `fn` validates against the full history.
+      const staged = migrateLegacyJsonl(db, logPath, opts.onCorrupt ?? defaultOnCorruptLine(logPath));
+      const result = fn(db);
+      if (result instanceof Promise) {
+        // The transaction would commit before the async work completed, so the
+        // "atomic read-validate-append" guarantee would silently not hold.
+        throw new Error("withTransitionWriter: fn must be synchronous (returned a Promise)");
+      }
+      db.exec("COMMIT");
+      for (const staging of staged) parkStagingFile(staging, logPath);
+      return result;
+    } catch (err) {
+      rollbackQuietly(db);
+      if (isBusyError(err)) throw new TransitionLockBusyError(transitionDbPath(logPath), timeoutMs, { cause: err });
+      throw err;
+    }
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Read-modify-write handle valid only for the duration of one
+ * `withTransitionWriter` call. Every method runs on the transaction's own
+ * connection, so `history()` observes exactly the rows the subsequent
+ * `insert()` is validated against — the property the jsonl implementation
+ * could not provide (#1328).
+ */
+export interface TransitionWriter {
+  /** History for one work item, oldest first, inside this transaction. */
+  history(workItemId: string | null): TransitionLogEntry[];
+  /** Append one entry inside this transaction. */
+  insert(entry: TransitionLogEntry): void;
+}
+
+/**
+ * Run `fn` as an atomic read-modify-write over the transition log.
+ *
+ * This is the concurrency primitive behind `commitTransition`: the write lock
+ * is held for the whole `fn`, so two concurrent `mcx phase run` invocations for
+ * the same work item are serialised rather than both validating against the
+ * same stale snapshot. `fn` must be synchronous — an async `fn` would let the
+ * transaction commit before its work finished, silently voiding atomicity.
+ */
+export function withTransitionWriter<T>(logPath: string, fn: (w: TransitionWriter) => T, opts: StoreOptions = {}): T {
+  return withDbTx(
+    logPath,
+    (db) => {
+      const writer: TransitionWriter = {
+        history: (workItemId) => selectEntries(db, "work_item_id IS ?", [workItemId]),
+        insert: (entry) => insertEntries(db, [entry]),
+      };
+      return fn(writer);
+    },
+    opts,
+  );
+}
+
+// ── Queries ────────────────────────────────────────────────────────────
+
+const SELECT_COLUMNS = "ts, work_item_id, from_phase, to_phase, force_message, status";
+
+/**
+ * Read the newest `tail` rows matching `where`, returned oldest-first.
+ *
+ * The tail is applied in SQL (`ORDER BY id DESC LIMIT ?`) and the page is
+ * reversed in memory, so a bounded read never materialises the full table
+ * (#1375). `id` ordering is insertion order, which is the log's contract —
+ * `ts` is supplied by callers and is not monotonic.
+ */
+function selectEntries(db: Database, where: string, params: (string | null)[], tail?: number): TransitionLogEntry[] {
+  const clause = where.length > 0 ? ` WHERE ${where}` : "";
+  if (tail === undefined) {
+    const rows = db
+      .query<TransitionRow, (string | null)[]>(`SELECT ${SELECT_COLUMNS} FROM transitions${clause} ORDER BY id ASC`)
+      .all(...params);
+    return rows.map(rowToEntry);
+  }
+  if (tail <= 0) return [];
+  const rows = db
+    .query<TransitionRow, (string | null)[]>(
+      `SELECT ${SELECT_COLUMNS} FROM transitions${clause} ORDER BY id DESC LIMIT ${Math.trunc(tail)}`,
+    )
+    .all(...params);
+  return rows.reverse().map(rowToEntry);
+}
+
+export interface ReadHistoryOptions extends StoreOptions {
+  /** Return at most the newest N entries (still ordered oldest-first). */
+  tail?: number;
+}
+
+/**
+ * Read the transition history for one work item, oldest first.
+ *
+ * `workItemId` is matched exactly, including `null` (entries recorded outside
+ * a work item) — this is an indexed lookup, not a full scan. No store yet →
+ * empty array.
+ */
+export function readTransitionHistory(
+  logPath: string,
+  workItemId: string | null,
+  onCorrupt?: OnCorruptLine,
+  opts: ReadHistoryOptions = {},
+): TransitionLogEntry[] {
+  const db = openForRead(logPath, { ...opts, ...(onCorrupt !== undefined ? { onCorrupt } : {}) });
+  if (db === null) return [];
+  try {
+    return selectEntries(db, "work_item_id IS ?", [workItemId], opts.tail);
+  } finally {
+    db.close();
+  }
+}
+
+export interface ReadAllOptions extends StoreOptions {
+  /**
+   * Restrict to one work item. `null` or omitted means "no filter" — this
+   * matches `filterTransitionLog`'s long-standing semantics, and differs from
+   * `readTransitionHistory`, where `null` selects the null work item.
+   */
+  workItemId?: string | null;
+  /** Only entries carrying a `forceMessage`. */
+  forcedOnly?: boolean;
+  /** Return at most the newest N entries (still ordered oldest-first). */
+  tail?: number;
+}
+
+/**
+ * Read transition entries, oldest first. With no options this returns every
+ * entry; `workItemId`, `forcedOnly` and `tail` are pushed down into SQL so
+ * `mcx phase log` no longer loads the whole log to filter it in memory
+ * (#1375). No store yet → empty array.
+ */
+export function readAllTransitions(logPath: string, opts: ReadAllOptions = {}): TransitionLogEntry[] {
+  const db = openForRead(logPath, opts);
+  if (db === null) return [];
+  try {
+    const clauses: string[] = [];
+    const params: (string | null)[] = [];
+    if (opts.workItemId !== undefined && opts.workItemId !== null) {
+      clauses.push("work_item_id = ?");
+      params.push(opts.workItemId);
+    }
+    if (opts.forcedOnly === true) {
+      clauses.push("force_message IS NOT NULL");
+    }
+    return selectEntries(db, clauses.join(" AND "), params, opts.tail);
+  } finally {
+    db.close();
+  }
+}
+
+/** Insert one transition entry. Creates the store if needed. */
+export function appendTransitionLog(logPath: string, entry: TransitionLogEntry, opts: StoreOptions = {}): void {
+  withDbTx(logPath, (db) => insertEntries(db, [entry]), opts);
+}
+
+/**
+ * Remove stale transition entries for a work item whose incarnation predates
+ * `cutoff`. Used by `mcx track` to clear history from prior sprints so a
+ * re-tracked item starts with a clean slate (issue #2463).
+ *
+ * Returns the number of entries deleted. Runs as a single statement inside a
+ * write transaction, so a concurrent phase run cannot observe a half-pruned
+ * history.
+ */
+export function pruneStaleHistory(logPath: string, workItemId: string, cutoff: Date, opts: StoreOptions = {}): number {
+  return withDbTx(
+    logPath,
+    (db) => {
+      // `ts` is compared as a parsed date, not lexically: it is caller-supplied
+      // and only conventionally an ISO-8601 string, so a lexical `ts < ?` in SQL
+      // would silently mis-prune any entry written in another format. An
+      // unparseable `ts` yields NaN, which fails the comparison and keeps the
+      // entry — the same conservative behaviour the jsonl implementation had.
+      const cutoffMs = cutoff.getTime();
+      const rows = db
+        .query<{ id: number; ts: string }, [string]>("SELECT id, ts FROM transitions WHERE work_item_id = ?")
+        .all(workItemId);
+      const staleIds = rows.filter((r) => new Date(r.ts).getTime() < cutoffMs).map((r) => r.id);
+      if (staleIds.length === 0) return 0;
+      const stmt = db.prepare("DELETE FROM transitions WHERE id = ?");
+      for (const id of staleIds) stmt.run(id);
+      return staleIds.length;
+    },
+    opts,
+  );
+}

--- a/packages/core/src/transition-store.ts
+++ b/packages/core/src/transition-store.ts
@@ -38,18 +38,29 @@
  */
 
 import { Database } from "bun:sqlite";
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { existsSync, linkSync, mkdirSync, readFileSync, readdirSync, renameSync, unlinkSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 
 /** Default wait for a contended write lock before surfacing a busy error. */
 const DEFAULT_BUSY_TIMEOUT_MS = 5000;
 
-/** Current schema revision, recorded in `meta` for future migrations. */
-const SCHEMA_VERSION = 1;
+/**
+ * Current schema revision, recorded in `meta` for future migrations.
+ *
+ * v2 replaced the name-keyed `imported_files` with content-hashed
+ * `imported_content` (see `applySchema`).
+ */
+const SCHEMA_VERSION = 2;
 
 /** Suffix for a legacy jsonl claimed by an in-flight import. */
 const IMPORTING_SUFFIX = ".importing.";
+
+/**
+ * Suffix for a claimed jsonl whose import failed for a non-contention reason.
+ * Must NOT start with `IMPORTING_SUFFIX`, so a quarantined file is never replayed.
+ */
+const UNIMPORTABLE_SUFFIX = ".unimportable.";
 
 /**
  * Lifecycle status of a transition log entry.
@@ -221,32 +232,98 @@ function applySchema(db: Database): void {
       key   TEXT PRIMARY KEY,
       value TEXT NOT NULL
     );
-    CREATE TABLE IF NOT EXISTS imported_files (
-      name        TEXT PRIMARY KEY,
-      imported_at TEXT NOT NULL
+    -- Keyed on a SHA-256 of the file's bytes, NOT its name. The name embeds a
+    -- fresh import nonce, so a name key could only ever match a crash-retry of
+    -- the same claim and deduped nothing an operator or a peer binary did (see
+    -- importStagingFile).
+    CREATE TABLE IF NOT EXISTS imported_content (
+      content_hash TEXT PRIMARY KEY,
+      name         TEXT NOT NULL,
+      imported_at  TEXT NOT NULL
     );
+    -- v1's name-keyed predecessor. Dropping it cannot resurrect an import:
+    -- insertImportedEntries dedupes at row level, so a staging file whose v1
+    -- marker is gone re-imports to zero new rows and is simply parked.
+    DROP TABLE IF EXISTS imported_files;
   `);
-  db.run("INSERT OR IGNORE INTO meta (key, value) VALUES (?, ?)", ["schema_version", String(SCHEMA_VERSION)]);
+  db.run("INSERT OR REPLACE INTO meta (key, value) VALUES (?, ?)", ["schema_version", String(SCHEMA_VERSION)]);
 }
 
 // ── Legacy jsonl import ────────────────────────────────────────────────
 
-function parseJsonlEntries(text: string, onCorrupt: OnCorruptLine): TransitionLogEntry[] {
-  const out: TransitionLogEntry[] = [];
+/** Optional field that must be a string when present (and not null). */
+function optionalString(value: unknown, field: string): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "string") throw new TypeError(`${field} must be a string, got ${typeof value}`);
+  return value;
+}
+
+/** Nullable field that must be a string or null. */
+function nullableString(value: unknown, field: string): string | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "string") throw new TypeError(`${field} must be a string or null, got ${typeof value}`);
+  return value;
+}
+
+/**
+ * Validate and normalise one parsed jsonl record into a `TransitionLogEntry`,
+ * throwing a descriptive `TypeError` for anything that isn't one.
+ *
+ * The importer previously passed **any** parsed JSON object straight through as
+ * a `TransitionLogEntry` with no shape check, so a record that was valid JSON
+ * but not a valid entry — `{"foo":1}` — reached the INSERT and threw from
+ * SQLite (`NOT NULL constraint failed`, or `Binding expected string...` for a
+ * wrong-typed field). Because `rename(2)` is not transactional, that throw
+ * rolled back the import but left the claimed jsonl as `.importing.<nonce>`,
+ * which was then replayed on every subsequent open — permanently wedging every
+ * read and every write, with the only copy of the log hidden under a name
+ * nobody looks for.
+ *
+ * A malformed record is log rot, exactly like a torn line, so it belongs in the
+ * `onCorrupt` sink the importer already has rather than in an exception. The
+ * design refuses to trust the file's *bytes*; it must not then trust its
+ * *schema* — least of all because the most likely producer of a schema-invalid
+ * line is a hand-recovered jsonl (#2962).
+ */
+function toEntry(parsed: unknown): TransitionLogEntry {
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new TypeError(`expected a JSON object, got ${Array.isArray(parsed) ? "array" : typeof parsed}`);
+  }
+  const raw = parsed as Record<string, unknown>;
+  if (typeof raw.ts !== "string") throw new TypeError(`ts must be a string, got ${typeof raw.ts}`);
+  if (typeof raw.to !== "string") throw new TypeError(`to must be a string, got ${typeof raw.to}`);
+
+  const forceMessage = optionalString(raw.forceMessage, "forceMessage");
+  // An unrecognised status is normalised to undefined rather than rejected, for
+  // the same reason `toStatus` does it on read: only the exact literal
+  // "attempted" may downgrade an entry to audit-only, so a garbled value can
+  // never silently stop gating transitions.
+  const status = typeof raw.status === "string" ? toStatus(raw.status) : undefined;
+  return {
+    ts: raw.ts,
+    workItemId: nullableString(raw.workItemId, "workItemId"),
+    from: nullableString(raw.from, "from"),
+    to: raw.to,
+    ...(forceMessage !== undefined ? { forceMessage } : {}),
+    ...(status !== undefined ? { status } : {}),
+  };
+}
+
+function parseJsonlEntries(text: string, onCorrupt: OnCorruptLine): { entries: TransitionLogEntry[]; corrupt: number } {
+  const entries: TransitionLogEntry[] = [];
+  let corrupt = 0;
   const lines = text.split("\n");
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     if (!line) continue;
     try {
-      const parsed: unknown = JSON.parse(line);
-      if (parsed !== null && typeof parsed === "object") {
-        out.push(parsed as TransitionLogEntry);
-      }
+      entries.push(toEntry(JSON.parse(line)));
     } catch (err) {
+      corrupt++;
       onCorrupt(i + 1, line, err);
     }
   }
-  return out;
+  return { entries, corrupt };
 }
 
 function insertEntries(db: Database, entries: readonly TransitionLogEntry[]): void {
@@ -258,6 +335,50 @@ function insertEntries(db: Database, entries: readonly TransitionLogEntry[]): vo
   }
 }
 
+/**
+ * Insert imported entries, skipping any row already present. Returns how many
+ * were inserted and how many were skipped as duplicates.
+ *
+ * Row-level dedupe is what makes re-importing the *same* history idempotent, and
+ * it is deliberately applied only on the import path — never to `appendTransitionLog`,
+ * whose job is to record whatever the caller decided.
+ *
+ * The identity tuple is `(ts, work_item_id, from_phase, to_phase, status)`.
+ * `ts` is millisecond-precision, so two rows agreeing on all five are the same
+ * transition by the log's own semantics: a work item's chain cannot legitimately
+ * contain two identical `from → to` moves at the same instant, and if it did,
+ * regression validation would reject the second anyway. `force_message` is
+ * excluded so a re-import whose justification text was reflowed still dedupes.
+ *
+ * `IS` rather than `=` for the nullable columns: `= NULL` is never true in SQL,
+ * so an initial transition (`from_phase` NULL) or a non-work-item entry
+ * (`work_item_id` NULL) would never match itself and would duplicate on every
+ * re-import — precisely the case this exists to fix.
+ */
+function insertImportedEntries(
+  db: Database,
+  entries: readonly TransitionLogEntry[],
+): { inserted: number; skipped: number } {
+  const exists = db.prepare<{ 1: number }, [string, string | null, string | null, string, string | null]>(
+    "SELECT 1 FROM transitions WHERE ts = ? AND work_item_id IS ? AND from_phase IS ? AND to_phase = ? AND status IS ? LIMIT 1",
+  );
+  const insert = db.prepare(
+    "INSERT INTO transitions (ts, work_item_id, from_phase, to_phase, force_message, status) VALUES (?, ?, ?, ?, ?, ?)",
+  );
+  let inserted = 0;
+  let skipped = 0;
+  for (const e of entries) {
+    const status = e.status ?? null;
+    if (exists.get(e.ts, e.workItemId, e.from, e.to, status) !== null) {
+      skipped++;
+      continue;
+    }
+    insert.run(e.ts, e.workItemId, e.from, e.to, e.forceMessage ?? null, status);
+    inserted++;
+  }
+  return { inserted, skipped };
+}
+
 /** Candidate park name: the plain `.migrated`, else a nonce-suffixed sibling. */
 function migratedPath(logPath: string): string {
   const first = `${logPath}.migrated`;
@@ -265,24 +386,69 @@ function migratedPath(logPath: string): string {
   return `${first}.${Date.now()}-${randomBytes(4).toString("hex")}`;
 }
 
+/** What one staging-file import contributed. */
+interface ImportResult {
+  inserted: number;
+  skipped: number;
+  corrupt: number;
+}
+
+/** A staging file imported in this transaction, awaiting its post-COMMIT park. */
+interface StagedImport {
+  path: string;
+  result: ImportResult;
+}
+
 /**
  * Import one claimed staging file into the DB. Must run inside the caller's
  * write transaction, and the file must be parked with `parkStagingFile` only
  * after that transaction commits.
  *
- * Exactly-once is enforced by the `imported_files` row, written in the same
- * transaction as the entries. A crash before COMMIT rolls the whole thing back
- * and the staging file is retried on the next open; a crash after COMMIT but
- * before the file is parked leaves the row behind, so the retry skips the
- * insert and only parks the file. The data is never in neither place, and
- * never in both.
+ * ## Idempotence is content-addressed, at two levels
+ *
+ * The dedupe key is a SHA-256 of the file's bytes, not `basename(staging)`. The
+ * name embeds a fresh `Date.now()`-plus-random import nonce, so a name key could
+ * only ever match a crash-after-COMMIT-before-park retry of the *same* claim —
+ * it deduped nothing an operator or a peer binary did, and two paths made that
+ * fatal:
+ *
+ *   - Restoring the parked `.migrated` file, which is the documented recovery
+ *     procedure, re-imported the whole history under a new nonce. Three entries
+ *     became six, chain integrity was destroyed, every visited phase appeared
+ *     twice, and the next real transition threw `RegressionError` — silently.
+ *   - The mixed-binary rollout triggers it with certainty: an old jsonl-era
+ *     binary finds no `transitions.jsonl` (renamed away), so it validates
+ *     against an *empty* history and writes a fresh file, which this binary then
+ *     imported with no dedupe.
+ *
+ * A content key makes a byte-identical restore a no-op. `insertImportedEntries`
+ * then dedupes at row level, which covers the case a content key cannot: a file
+ * that is *partly* new, such as the regenerated jsonl above. Both are needed —
+ * the hash is the cheap exact-match path, the row check is the correct one.
+ *
+ * Exactly-once across a crash still holds: the `imported_content` row is written
+ * in the same transaction as the entries, so a crash before COMMIT rolls the
+ * whole thing back and the staging file is retried on the next open; a crash
+ * after COMMIT but before the park leaves the row behind, so the retry inserts
+ * nothing and only parks the file. The data is never in neither place, and never
+ * in both.
  */
-function importStagingFile(db: Database, staging: string, onCorrupt: OnCorruptLine): void {
-  const name = basename(staging);
-  const already = db.query<{ name: string }, [string]>("SELECT name FROM imported_files WHERE name = ?").get(name);
-  if (already !== null) return;
-  insertEntries(db, parseJsonlEntries(readFileSync(staging, "utf-8"), onCorrupt));
-  db.run("INSERT INTO imported_files (name, imported_at) VALUES (?, ?)", [name, new Date().toISOString()]);
+function importStagingFile(db: Database, staging: string, onCorrupt: OnCorruptLine): ImportResult {
+  const bytes = readFileSync(staging);
+  const contentHash = createHash("sha256").update(bytes).digest("hex");
+  const already = db
+    .query<{ content_hash: string }, [string]>("SELECT content_hash FROM imported_content WHERE content_hash = ?")
+    .get(contentHash);
+  if (already !== null) return { inserted: 0, skipped: 0, corrupt: 0 };
+
+  const { entries, corrupt } = parseJsonlEntries(bytes.toString("utf-8"), onCorrupt);
+  const { inserted, skipped } = insertImportedEntries(db, entries);
+  db.run("INSERT INTO imported_content (content_hash, name, imported_at) VALUES (?, ?, ?)", [
+    contentHash,
+    basename(staging),
+    new Date().toISOString(),
+  ]);
+  return { inserted, skipped, corrupt };
 }
 
 /**
@@ -300,21 +466,68 @@ function importStagingFile(db: Database, staging: string, onCorrupt: OnCorruptLi
  * Unlinking the staging path after a successful link removes a *name*, not data:
  * the content is already reachable under the parked name at that point.
  */
-function parkStagingFile(staging: string, logPath: string): void {
+function parkStagingFile(staging: string, logPath: string): string | null {
   for (;;) {
+    const dest = migratedPath(logPath);
     try {
-      linkSync(staging, migratedPath(logPath));
+      linkSync(staging, dest);
     } catch (err) {
       const code = errnoCode(err);
       // ENOENT: a concurrent process already parked it. Both processes agree the
       // import committed, so there is nothing left to do.
-      if (code === "ENOENT") return;
+      if (code === "ENOENT") return null;
       // EEXIST: lost the race for that name; migratedPath picks a fresh nonce.
       if (code === "EEXIST") continue;
       throw err;
     }
     unlinkSync(staging);
-    return;
+    return dest;
+  }
+}
+
+/**
+ * Move a staging file that cannot be imported out of the replay set, returning
+ * its new path.
+ *
+ * Belt to `toEntry`'s braces. Validation removes the *known* way one bad record
+ * wedged the store, but any unexpected non-contention failure during import has
+ * the same shape — `rename(2)` is not transactional, so the DB rolls back while
+ * the claimed file stays on disk and is replayed on every subsequent open, and
+ * because `openForRead` escalates to a write transaction whenever a staging file
+ * exists, that denies service to every read *and* every write, permanently. One
+ * bad file must cost one error and then self-heal.
+ *
+ * `.unimportable` deliberately does not match `IMPORTING_SUFFIX`, so the file is
+ * never replayed; it is left on disk, under a reported name, because it may be
+ * the only copy of the log.
+ *
+ * `link(2)` first, for the same reason `parkStagingFile` uses it: it fails
+ * `EEXIST` atomically instead of silently replacing its destination. `link`
+ * cannot operate on anything but a regular file, so a staging *path* that is not
+ * a regular file (which is one of the ways import fails in the first place) falls
+ * back to `rename`. That fallback can only ever replace a nonce'd name minted a
+ * moment earlier, and one that by definition holds no importable log data.
+ */
+function quarantineStagingFile(staging: string, logPath: string): string {
+  for (;;) {
+    // Built from `logPath`, NOT from `staging`: appending to the staging name
+    // would leave the result still prefixed with `IMPORTING_SUFFIX`, so
+    // findAbandonedStagingFiles would keep replaying it and the quarantine would
+    // do nothing at all.
+    const dest = `${logPath}${UNIMPORTABLE_SUFFIX}${Date.now()}-${randomBytes(4).toString("hex")}`;
+    try {
+      linkSync(staging, dest);
+    } catch (err) {
+      const code = errnoCode(err);
+      if (code === "EEXIST") continue;
+      if (code === "EPERM" || code === "EISDIR" || code === "EXDEV" || code === "ENOTSUP") {
+        renameSync(staging, dest);
+        return dest;
+      }
+      throw err;
+    }
+    unlinkSync(staging);
+    return dest;
   }
 }
 
@@ -354,12 +567,24 @@ function findAbandonedStagingFiles(logPath: string): string[] {
  * the imported history — leaving the log out of insertion order and the second
  * process's transition validated against an empty history.
  */
-function migrateLegacyJsonl(db: Database, logPath: string, onCorrupt: OnCorruptLine): string[] {
-  const staged: string[] = [];
-  for (const abandoned of findAbandonedStagingFiles(logPath)) {
-    importStagingFile(db, abandoned, onCorrupt);
-    staged.push(abandoned);
-  }
+function migrateLegacyJsonl(db: Database, logPath: string, onCorrupt: OnCorruptLine): StagedImport[] {
+  const staged: StagedImport[] = [];
+
+  // Every staging file seen here is genuinely abandoned: this runs under the
+  // write lock, and a live import holds that lock for its whole duration.
+  const claim = (staging: string): void => {
+    try {
+      staged.push({ path: staging, result: importStagingFile(db, staging, onCorrupt) });
+    } catch (err) {
+      // Contention is not the file's fault — leave it in place to be replayed
+      // once the lock is free. Anything else is quarantined so it cannot deny
+      // service to the store forever.
+      if (!isBusyError(err)) quarantineStagingFile(staging, logPath);
+      throw err;
+    }
+  };
+
+  for (const abandoned of findAbandonedStagingFiles(logPath)) claim(abandoned);
 
   if (!existsSync(logPath)) return staged;
 
@@ -371,17 +596,44 @@ function migrateLegacyJsonl(db: Database, logPath: string, onCorrupt: OnCorruptL
     if (errnoCode(err) === "ENOENT") return staged;
     throw err;
   }
-  importStagingFile(db, staging, onCorrupt);
-  staged.push(staging);
+  claim(staging);
   return staged;
 }
 
 // ── Connection lifecycle ───────────────────────────────────────────────
 
+/** SQLite takes the busy timeout as a C `int`, so this is its ceiling (~24 days). */
+const MAX_BUSY_TIMEOUT_MS = 2_147_483_647;
+
+/**
+ * Coerce a caller-supplied busy timeout to an integer SQLite will actually apply.
+ *
+ * `Math.max(0, Math.trunc(ms))` looks like a guard but is NaN-transparent —
+ * `Math.max` propagates NaN — so `NaN` and `Infinity` both reached the pragma
+ * verbatim and SQLite silently applied **0**, which disables the contention wait
+ * entirely: every concurrent writer then fails immediately instead of
+ * serialising, and the COMMIT retry cannot recover it because each attempt waits
+ * zero. `1e21` was worse than useless in the other direction — it is an integer,
+ * but it stringifies to `1e+21`, which SQLite parsed as 1ms.
+ *
+ * Clamping to `MAX_BUSY_TIMEOUT_MS` is what keeps the interpolated pragma safe:
+ * the result is always a plain decimal integer in `[0, 2^31)`, so it can never
+ * reach SQL in exponential notation. A non-finite value is a caller bug, and
+ * falling back to the default is the only choice that preserves the property the
+ * store depends on; zero and negative keep their documented "do not wait"
+ * meaning.
+ */
+export function sanitizeBusyTimeout(busyTimeoutMs: number): number {
+  if (!Number.isFinite(busyTimeoutMs)) return DEFAULT_BUSY_TIMEOUT_MS;
+  const ms = Math.trunc(busyTimeoutMs);
+  if (ms <= 0) return 0;
+  return Math.min(ms, MAX_BUSY_TIMEOUT_MS);
+}
+
 function configure(db: Database, busyTimeoutMs: number): void {
   // Rollback journal (the default) is retained deliberately — see the
   // "Journal mode: deliberately NOT WAL" note at the top of this file.
-  db.exec(`PRAGMA busy_timeout = ${Math.max(0, Math.trunc(busyTimeoutMs))}`);
+  db.exec(`PRAGMA busy_timeout = ${sanitizeBusyTimeout(busyTimeoutMs)}`);
 }
 
 /**
@@ -432,11 +684,54 @@ function rollbackQuietly(db: Database): void {
   }
 }
 
+/** What one completed legacy-jsonl migration did. */
+export interface MigrationReport {
+  /** The legacy jsonl path that was migrated. */
+  logPath: string;
+  /** The SQLite store it was migrated into. */
+  dbPath: string;
+  /** Where the original bytes were parked, and can be recovered from. */
+  parkedPath: string;
+  /** Records inserted. */
+  imported: number;
+  /** Records already present in the store, skipped as duplicates. */
+  skipped: number;
+  /** Records rejected as corrupt (also reported individually via `onCorrupt`). */
+  corrupt: number;
+}
+
+/** Called once per completed legacy-jsonl migration. */
+export type OnMigrate = (report: MigrationReport) => void;
+
+/**
+ * Default migration sink: one line to stderr.
+ *
+ * A migration is a one-way, in-place conversion of load-bearing state that
+ * reported nothing anywhere. It is also now reachable from a pure *read* —
+ * `openForRead` escalates to a write transaction when there is an import
+ * pending — so a read-only-looking command mutates state, unannounced. In #2962
+ * the only reason that was recoverable is the park-not-delete decision; the
+ * operator still got no chance to notice before continuing. Naming the parked
+ * path is the point of the line: it is what recovery reads from.
+ */
+export function defaultOnMigrate(out: { write: (s: string) => void } = process.stderr): OnMigrate {
+  return ({ logPath, dbPath, parkedPath, imported, skipped, corrupt }) => {
+    const extra = [
+      ...(skipped > 0 ? [`${skipped} duplicate${skipped === 1 ? "" : "s"} skipped`] : []),
+      ...(corrupt > 0 ? [`${corrupt} corrupt record${corrupt === 1 ? "" : "s"} rejected`] : []),
+    ];
+    const suffix = extra.length > 0 ? ` (${extra.join(", ")})` : "";
+    out.write(`migrated ${imported} entries from ${logPath} → ${dbPath}${suffix}; original parked at ${parkedPath}\n`);
+  };
+}
+
 export interface StoreOptions {
   /** How long to wait for a contended write lock. */
   timeoutMs?: number;
   /** Corrupt-line sink for the one-time legacy jsonl import. */
   onCorrupt?: OnCorruptLine;
+  /** Migration announcement sink. Defaults to one stderr line per migration. */
+  onMigrate?: OnMigrate;
 }
 
 /**
@@ -469,7 +764,23 @@ function openForRead(logPath: string, opts: StoreOptions = {}): Database | null 
   if (existsSync(logPath) || findAbandonedStagingFiles(logPath).length > 0) {
     // A pending import has to run under the write lock, so a read that finds
     // one drives an otherwise-empty write transaction to completion first.
-    withDbTx(logPath, () => {}, opts);
+    try {
+      withDbTx(logPath, () => {}, opts);
+    } catch (err) {
+      // Contention here is not the reader's problem to solve. The staging-file
+      // scan above runs unlocked, so a reader also fires on another live
+      // process's in-flight claim — and making a previously-infallible read path
+      // fail on that turns read-only orchestrator polling into a stall vector
+      // (`readTransitionHistory` from `phase.ts`, `pruneStaleHistory` from
+      // `track.ts`, where it becomes `exit 1`).
+      //
+      // Falling through is safe because it cannot affect gating: the process
+      // holding the lock is completing the import, and every *writer* takes the
+      // write lock and imports before it validates. The worst case for this
+      // reader is observing the pre-import history, which is exactly what it
+      // would have seen a moment earlier.
+      if (!(err instanceof TransitionLockBusyError)) throw err;
+    }
   }
   if (!existsSync(dbPath)) return null;
   const db = new Database(dbPath, { readonly: true });
@@ -524,7 +835,21 @@ function withDbTx<T>(logPath: string, fn: (db: Database) => T, opts: StoreOption
         throw new Error("withTransitionWriter: fn must be synchronous (returned a Promise)");
       }
       commitWithRetry(db);
-      for (const staging of staged) parkStagingFile(staging, logPath);
+      // Parked, then announced: the report names the parked path, which is the
+      // artifact recovery reads from, so it must exist before it is reported.
+      const onMigrate = opts.onMigrate ?? defaultOnMigrate();
+      for (const { path, result: imported } of staged) {
+        const parkedPath = parkStagingFile(path, logPath);
+        if (parkedPath === null) continue;
+        onMigrate({
+          logPath,
+          dbPath,
+          parkedPath,
+          imported: imported.inserted,
+          skipped: imported.skipped,
+          corrupt: imported.corrupt,
+        });
+      }
       return result;
     } catch (err) {
       rollbackQuietly(db);
@@ -589,23 +914,29 @@ const SELECT_COLUMNS = "ts, work_item_id, from_phase, to_phase, force_message, s
  * (#1375). `id` ordering is insertion order, which is the log's contract —
  * `ts` is supplied by callers and is not monotonic.
  */
-function selectEntries(db: Database, where: string, params: (string | null)[], tail?: number): TransitionLogEntry[] {
+type SelectParam = string | number | null;
+
+function selectEntries(db: Database, where: string, params: SelectParam[], tail?: number): TransitionLogEntry[] {
   const clause = where.length > 0 ? ` WHERE ${where}` : "";
   if (tail === undefined) {
     const rows = db
-      .query<TransitionRow, (string | null)[]>(`SELECT ${SELECT_COLUMNS} FROM transitions${clause} ORDER BY id ASC`)
+      .query<TransitionRow, SelectParam[]>(`SELECT ${SELECT_COLUMNS} FROM transitions${clause} ORDER BY id ASC`)
       .all(...params);
     return rows.map(rowToEntry);
   }
-  // The limit is interpolated rather than bound, so a non-integer must be
-  // rejected here: NaN or Infinity would reach SQLite as `LIMIT NaN`.
+  // A non-integer tail is a caller bug and is rejected with a useful message
+  // rather than being coerced into a different query.
   if (!Number.isInteger(tail)) throw new TypeError(`tail must be an integer, got ${tail}`);
   if (tail <= 0) return [];
+  // `LIMIT ?` rather than `LIMIT ${tail}`. Interpolation left a hole the integer
+  // predicate in front of it could not close: `Number.isInteger(1e21)` is true,
+  // but it stringifies to `1e+21`, so it reached SQLite as `LIMIT 1e+21` →
+  // "datatype mismatch". Binding the parameter eliminates the class instead of
+  // patching predicates in front of it; clamping to a safe integer keeps a
+  // "larger than the table" tail meaning exactly that.
   const rows = db
-    .query<TransitionRow, (string | null)[]>(
-      `SELECT ${SELECT_COLUMNS} FROM transitions${clause} ORDER BY id DESC LIMIT ${tail}`,
-    )
-    .all(...params);
+    .query<TransitionRow, SelectParam[]>(`SELECT ${SELECT_COLUMNS} FROM transitions${clause} ORDER BY id DESC LIMIT ?`)
+    .all(...params, Math.min(tail, Number.MAX_SAFE_INTEGER));
   return rows.reverse().map(rowToEntry);
 }
 

--- a/packages/core/src/transition-store.ts
+++ b/packages/core/src/transition-store.ts
@@ -39,7 +39,7 @@
 
 import { Database } from "bun:sqlite";
 import { randomBytes } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, readdirSync, renameSync } from "node:fs";
+import { existsSync, linkSync, mkdirSync, readFileSync, readdirSync, renameSync, unlinkSync } from "node:fs";
 import { basename, dirname, join } from "node:path";
 
 /** Default wait for a contended write lock before surfacing a busy error. */
@@ -125,11 +125,28 @@ export class TransitionLockBusyError extends Error {
   }
 }
 
-/** True when `err` is a SQLite busy/locked error, by code (never by message). */
+/**
+ * True when `err` is a SQLite lock-contention error, by code (never by message).
+ *
+ * The set is calibrated for the rollback journal this store deliberately uses
+ * (see the journal-mode note above), which is why `SQLITE_PROTOCOL` is in it and
+ * `SQLITE_BUSY_SNAPSHOT` is not:
+ *
+ * - `SQLITE_PROTOCOL` is what SQLite returns when the rollback journal's
+ *   locking protocol fails to make progress — the flaky-`lockd` shared-mount
+ *   case that justifies not using WAL in the first place. Omitting it meant the
+ *   one environment the journal choice exists to serve surfaced a raw
+ *   unclassified error instead of the typed, retryable one.
+ * - `SQLITE_BUSY_SNAPSHOT` can only arise in WAL mode, so matching it here was
+ *   dead code.
+ *
+ * `SQLITE_LOCKED` is retained: it is table-level contention and is reachable
+ * under any journal mode.
+ */
 function isBusyError(err: unknown): boolean {
   if (typeof err !== "object" || err === null || !("code" in err)) return false;
   const code = (err as { code: unknown }).code;
-  return code === "SQLITE_BUSY" || code === "SQLITE_BUSY_SNAPSHOT" || code === "SQLITE_LOCKED";
+  return code === "SQLITE_BUSY" || code === "SQLITE_LOCKED" || code === "SQLITE_PROTOCOL";
 }
 
 function errnoCode(err: unknown): string | undefined {
@@ -241,11 +258,11 @@ function insertEntries(db: Database, entries: readonly TransitionLogEntry[]): vo
   }
 }
 
-/** Unique destination for a fully-imported jsonl, never overwriting an older one. */
+/** Candidate park name: the plain `.migrated`, else a nonce-suffixed sibling. */
 function migratedPath(logPath: string): string {
   const first = `${logPath}.migrated`;
   if (!existsSync(first)) return first;
-  return `${first}.${Date.now()}`;
+  return `${first}.${Date.now()}-${randomBytes(4).toString("hex")}`;
 }
 
 /**
@@ -268,14 +285,36 @@ function importStagingFile(db: Database, staging: string, onCorrupt: OnCorruptLi
   db.run("INSERT INTO imported_files (name, imported_at) VALUES (?, ?)", [name, new Date().toISOString()]);
 }
 
-/** Park a fully-committed staging file as `.migrated`. Never deletes it. */
+/**
+ * Park a fully-committed staging file beside the log, never deleting log data
+ * and never overwriting an older park.
+ *
+ * `link(2)` + `unlink(2)` rather than `rename(2)`, because rename silently
+ * replaces an existing destination: two parks landing in the same millisecond
+ * computed the same `.migrated.<Date.now()>` name and the older parked
+ * generation was destroyed. That file is precisely the artifact recovery reads
+ * from when the DB is the thing that went wrong (#2962), so a nonce alone is not
+ * enough — `link` fails `EEXIST` atomically, which closes the check-then-rename
+ * window that no amount of name entropy can.
+ *
+ * Unlinking the staging path after a successful link removes a *name*, not data:
+ * the content is already reachable under the parked name at that point.
+ */
 function parkStagingFile(staging: string, logPath: string): void {
-  try {
-    renameSync(staging, migratedPath(logPath));
-  } catch (err) {
-    // ENOENT: a concurrent process already parked it. Both processes agree the
-    // import committed, so there is nothing left to do.
-    if (errnoCode(err) !== "ENOENT") throw err;
+  for (;;) {
+    try {
+      linkSync(staging, migratedPath(logPath));
+    } catch (err) {
+      const code = errnoCode(err);
+      // ENOENT: a concurrent process already parked it. Both processes agree the
+      // import committed, so there is nothing left to do.
+      if (code === "ENOENT") return;
+      // EEXIST: lost the race for that name; migratedPath picks a fresh nonce.
+      if (code === "EEXIST") continue;
+      throw err;
+    }
+    unlinkSync(staging);
+    return;
   }
 }
 
@@ -343,6 +382,43 @@ function configure(db: Database, busyTimeoutMs: number): void {
   // Rollback journal (the default) is retained deliberately — see the
   // "Journal mode: deliberately NOT WAL" note at the top of this file.
   db.exec(`PRAGMA busy_timeout = ${Math.max(0, Math.trunc(busyTimeoutMs))}`);
+}
+
+/**
+ * Extra COMMIT attempts before a contended commit is finally given up on. Each
+ * attempt independently waits up to `busy_timeout`, so this only has to cover a
+ * reader that reappears between attempts, not the wait itself.
+ */
+const COMMIT_RETRY_ATTEMPTS = 2;
+
+/**
+ * COMMIT, retrying while SQLite reports lock contention.
+ *
+ * A busy COMMIT is **not** a failed transaction. In rollback-journal mode COMMIT
+ * must upgrade RESERVED → EXCLUSIVE, which any concurrent reader holding SHARED
+ * blocks; when that wait expires SQLite returns SQLITE_BUSY and leaves the
+ * transaction **active**. Treating it as a failure would roll back an entry that
+ * had already passed validation and then misreport it as somebody else's
+ * contention ("another phase run is in progress") — a silent lost write.
+ *
+ * Reproduced with a second process holding a read transaction open across the
+ * commit point: COMMIT raised SQLITE_BUSY after the busy_timeout, `BEGIN
+ * IMMEDIATE` then failed with "cannot start a transaction within a transaction"
+ * (proving the transaction was still live), and retrying COMMIT once the reader
+ * released committed the same entry successfully.
+ *
+ * If the retries are exhausted the entry genuinely cannot be committed, so the
+ * caller's rollback and `TransitionLockBusyError` are accurate at that point.
+ */
+function commitWithRetry(db: Database): void {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      db.exec("COMMIT");
+      return;
+    } catch (err) {
+      if (attempt >= COMMIT_RETRY_ATTEMPTS || !isBusyError(err)) throw err;
+    }
+  }
 }
 
 function rollbackQuietly(db: Database): void {
@@ -417,13 +493,25 @@ function openForRead(logPath: string, opts: StoreOptions = {}): Database | null 
  */
 function withDbTx<T>(logPath: string, fn: (db: Database) => T, opts: StoreOptions = {}): T {
   const timeoutMs = opts.timeoutMs ?? DEFAULT_BUSY_TIMEOUT_MS;
-  const db = openForWrite(logPath, { ...opts, timeoutMs });
+  const dbPath = transitionDbPath(logPath);
+  const asLockError = (err: unknown): unknown =>
+    isBusyError(err) ? new TransitionLockBusyError(dbPath, timeoutMs, { cause: err }) : err;
+
+  // `applySchema` writes (`CREATE TABLE IF NOT EXISTS` + an `INSERT OR IGNORE`
+  // into `meta`), so opening for write can itself lose the lock race to a
+  // concurrent reader or writer. Classify it here or it escapes as a raw
+  // SQLiteError that no caller knows to treat as contention.
+  let db: Database;
+  try {
+    db = openForWrite(logPath, { ...opts, timeoutMs });
+  } catch (err) {
+    throw asLockError(err);
+  }
   try {
     try {
       db.exec("BEGIN IMMEDIATE");
     } catch (err) {
-      if (isBusyError(err)) throw new TransitionLockBusyError(transitionDbPath(logPath), timeoutMs, { cause: err });
-      throw err;
+      throw asLockError(err);
     }
     try {
       // Inside the lock: the imported history is guaranteed to precede anything
@@ -435,15 +523,19 @@ function withDbTx<T>(logPath: string, fn: (db: Database) => T, opts: StoreOption
         // "atomic read-validate-append" guarantee would silently not hold.
         throw new Error("withTransitionWriter: fn must be synchronous (returned a Promise)");
       }
-      db.exec("COMMIT");
+      commitWithRetry(db);
       for (const staging of staged) parkStagingFile(staging, logPath);
       return result;
     } catch (err) {
       rollbackQuietly(db);
-      if (isBusyError(err)) throw new TransitionLockBusyError(transitionDbPath(logPath), timeoutMs, { cause: err });
-      throw err;
+      throw asLockError(err);
     }
   } finally {
+    // Load-bearing beyond releasing the fd: `bun:sqlite` closes the handle when
+    // the `Database` is garbage-collected, and closing mid-transaction rolls it
+    // back. This `finally` is what keeps `db` reachable for the whole
+    // transaction. Do not "simplify" it into a bare `using`/drop — a `db` whose
+    // last reference dies before COMMIT loses the write silently.
     db.close();
   }
 }

--- a/packages/core/src/transition-store.ts
+++ b/packages/core/src/transition-store.ts
@@ -505,10 +505,13 @@ function selectEntries(db: Database, where: string, params: (string | null)[], t
       .all(...params);
     return rows.map(rowToEntry);
   }
+  // The limit is interpolated rather than bound, so a non-integer must be
+  // rejected here: NaN or Infinity would reach SQLite as `LIMIT NaN`.
+  if (!Number.isInteger(tail)) throw new TypeError(`tail must be an integer, got ${tail}`);
   if (tail <= 0) return [];
   const rows = db
     .query<TransitionRow, (string | null)[]>(
-      `SELECT ${SELECT_COLUMNS} FROM transitions${clause} ORDER BY id DESC LIMIT ${Math.trunc(tail)}`,
+      `SELECT ${SELECT_COLUMNS} FROM transitions${clause} ORDER BY id DESC LIMIT ${tail}`,
     )
     .all(...params);
   return rows.reverse().map(rowToEntry);


### PR DESCRIPTION
## Summary

Replaces the append-only `.mcx/transitions.jsonl` phase-transition log with a
`bun:sqlite` table. Read-validate-append for a phase transition now happens
inside one `BEGIN IMMEDIATE` transaction, reads are indexed queries, and there is
no line-level write that can tear.

Closes #1328 (read-modify-write race), #1372 (O_EXCL lockfile not atomic on NFS),
#1375 (whole-file parse on every read).

- **No advisory locking left.** `withTransitionLock` and its O_EXCL lockfile,
  stale-lock reaping and nonce-ownership dance are deleted. SQLite's own write
  lock replaces all of it; contention surfaces as a typed
  `TransitionLockBusyError` instead of a silent skip.
- **Journal mode stays the default rollback journal — deliberately not WAL.**
  WAL needs a `-shm` shared-memory mmap, which network filesystems cannot
  provide; an NFS-mounted `~/` is exactly the environment #1372 is about, so WAL
  would reintroduce the bug this store exists to fix. The reasoning is a comment
  at the top of `transition-store.ts` **and** an assertion in a test, so a future
  "optimization" to WAL fails the build rather than silently regressing.
- **Migration is required and parks, never deletes.** An existing
  `transitions.jsonl` is imported on first open and renamed `.migrated`. Claiming
  is done by `rename(2)` (atomic on POSIX *and* NFS) rather than a lockfile, and
  exactly-once is enforced by an `imported_files` row written in the same
  transaction as the entries — so a crash leaves the data in exactly one place,
  never neither and never both.
- **Public API unchanged.** Every function is still keyed on the historical
  `.mcx/transitions.jsonl` path (`transitionDbPath()` maps it to
  `transitions.db`), so phase scripts and `.mcx.lock` consumers need no change.
  New params are additive and optional.
- **`#1375` deliverable:** `readAllTransitions` gained `workItemId`, `forcedOnly`
  and `tail`, all pushed into SQL. The real unbounded consumer,
  `mcx phase log`, now uses them, and `--tail <n>` is exposed on the CLI.
- `atomicWriteFileSync` is dead once the jsonl rewrite is gone — deleted along
  with its tests.

`bc73a294` in this branch is a crash-recovery preservation commit: a prior
session's uncommitted work, captured after a host restart and never gate-verified
or reviewed. It was read critically rather than trusted, which is where the two
fixes below came from.

## The concurrency test genuinely falsifies

This is the artifact worth reviewing first. `test/…phase-transition.spec.ts →
"concurrent writers are serialised; no history is lost or torn"` spawns 10 real
subprocesses (not `Promise.all` over sync calls, which cannot stress a
single-threaded runtime), each doing an independent read-modify-write, then
asserts every entry's `from` equals the previous entry's `to` and that every `to`
is unique.

I verified it can express the failure it claims to catch. Swapping the worker's
single-transaction body for the old read-then-append shape:

```ts
const hist = readTransitionHistory(logPath, "#race");   // txn 1
appendTransitionLog(logPath, { … });                    // txn 2
```

fails **3 out of 3 runs** on chain integrity:

```
614 |         expect(entries[i].from).toBe(entries[i - 1].to);
error: expect(received).toBe(expected)
Expected: "step-1"
Received: null
(fail) concurrent writers are serialised; no history is lost or torn
```

Restore the transaction and it is 3/3 green. The test is not passing because the
race is rare; it passes because the race is gone.

## Verified against the real production log, not a hand-authored fixture

Migration was exercised against a **copy of this repo's live 196 KB /
1919-entry** `transitions.jsonl`, not only the synthetic fixtures in the spec:

- 1919 jsonl lines → 1919 rows, insertion order preserved, field-for-field
  deep-equal to an independent `JSON.parse` of the same file
- import 8 ms; a subsequent `tail 5` sub-millisecond
- `.migrated` parked, `transitions.db` created, nothing else left behind
- the real log's key set is exactly `{ts, workItemId, from, to, status,
  forceMessage}` — no field the importer would have dropped

The parking behaviour also earned its keep during development: a dev-command
invocation migrated live runtime state ahead of schedule, and recovery was a
single copy from the `.migrated` file with nothing reconstructed and nothing
lost. That is the argument for keeping "park, never delete" in the final design.

## Two fixes to the inherited draft

1. **Interpolated `LIMIT`.** `tail` was string-interpolated into the SQL, so a
   `NaN` or `Infinity` from any non-CLI caller reached SQLite as `LIMIT NaN` and
   surfaced as a raw syntax error. Non-integers are now rejected with a
   `TypeError` at the boundary (test added). The CLI path was already safe;
   the library path was not.
2. **`journal_mode` had no test.** The whole NFS-safety argument rested on a
   comment. Now asserted as `delete` on the file the store actually creates, in
   its default configuration.

## Test bar

Every assertion here is against the default/production configuration — no
`journal_mode`, `busy_timeout` or timeout was chosen to make a test pass. The one
short timeout in the suite (`NESTED_LOCK_TIMEOUT_MS = 50`) exists to make a
deliberately-contended case fail *fast and loudly*, and the assertion is that it
throws `TransitionLockBusyError`.

The 10-writer test proves that the *transaction boundary* is load-bearing — split
it back into read-then-append and it fails on chain integrity — but its
transactions are sub-millisecond, so on its own it does **not** show that a
contended writer waits; all 10 exiting 0 is consistent with never having
contended at all. That property now has its own test: a child process holds the
write lock while the parent's writer blocks at `BEGIN IMMEDIATE`, and the
assertion is that the parent waits and then commits (both entries present, in
lock order) rather than raising `TransitionLockBusyError`.

Migration coverage: import fidelity and field round-trip, ordering, legacy
status-less entries still gating, corrupt-line reporting with line numbers,
truncated-final-line (the #1328 crash shape), idempotency across reopen,
exactly-once under concurrent first-open, recovery of a staging file abandoned
mid-import, and the park step including 40 rapid successive parks with every
generation still recoverable.

## Verification of record: CI

The host was saturated throughout this work (load ~25–32 on 16 cores from a
post-restart Spotlight reindex), so `bun run am-i-done` was **not** run
iteratively by hand — scoped `bun test <file>` was used instead, and **CI on
clean runners is the verification of record for this PR.** I am not claiming a
run of `am-i-done --ci`.

What did run locally, and its honest status — including one failure and why it is
not a regression:

| Check | Result |
|---|---|
| `bun typecheck` | clean |
| `bun lint` | clean, no fixes applied |
| `bun run doing-it-wrong` (42 rules) | no violations |
| `phase-transition.spec.ts` | 66 pass / 0 fail |
| `phase.spec.ts` | 183 pass / 0 fail |
| pre-commit gate (static + run-1 suite + coverage) | passed — 6237 pass / 0 fail across 228 files; coverage 94.78 % lines vs 69 % threshold; spec floor met |
| pre-push gate, 7 steps (same step list CI's `check` + `coverage` jobs run) | **failed on attempt 1, passed on retry in 41 s** |

Attempt 1 of the pre-push gate failed on `test/daemon-integration.spec.ts` →
`P5b: Error scenario edge cases`, a `beforeAll` hook timing out after 941 s
(~16 min). That file
is unrelated to this diff (daemon transport/auth integration; it never touches
the transition log — it is in the blast radius only because the diff is in
`packages/core`). Run in isolation on the same saturated host it is **32 pass / 0
fail in 14.5 s**. This is the previously-tracked load-contention signature from
\#809 and #1019, not a regression.

Rather than bypass it, the push was retried once, and the **entire 7-step gate
passed in 41 s** — the same steps that took 16 minutes and timed out while the
host was thrashing. That 23× spread is itself the evidence that the first failure
was contention. No `--no-verify`, no timeout bumps, no retry loops, nothing
skipped.

## Repair round: adversarial-review findings 10-13

**10 — park clobber (reproduced by the reviewer, 2 of 39 generations destroyed).**
The park name was `${log}.migrated.${Date.now()}`, so two parks in the same
millisecond computed the same name and `renameSync` silently replaced the older
one. Park now uses `link(2)` + `unlink(2)` with a nonce'd candidate name: `link`
fails `EEXIST` *atomically*, which closes the check-then-rename window that name
entropy alone cannot. Unlinking the staging path after a successful link removes a
name, not data. Regression test parks 40 generations in a tight loop and asserts
every one is recoverable, over the whole directory listing; it fails on the old
implementation (6 of 40 destroyed on this host).

**11 — busy COMMIT discarded a validated entry. Reproduced first, then fixed.**
The reviewer flagged this from reading and explicitly did not run it, so it was
reproduced before patching: with a second process holding a read transaction
across the commit point, `COMMIT` raised `SQLITE_BUSY` after the `busy_timeout`,
`BEGIN IMMEDIATE` then failed with *"cannot start a transaction within a
transaction"* (proving SQLite left the transaction **active**), and retrying
`COMMIT` once the reader released committed the same entry. The old path rolled
that back and reported it as another run's contention — a silent lost write.
`COMMIT` is now retried a bounded number of times before the rollback is treated
as legitimate. The test drives the real race window (reader arriving *after*
`BEGIN IMMEDIATE`) and fails without the retry.

**12 — error taxonomy was calibrated for the rejected journal mode.** `isBusyError`
matched `SQLITE_BUSY_SNAPSHOT`, which is WAL-only and therefore dead code here,
and omitted `SQLITE_PROTOCOL`, the rollback journal's locking-protocol failure —
i.e. exactly the shared-mount case the NOT-WAL decision exists to serve. The
WAL-only branch is gone and `SQLITE_PROTOCOL` is classified as contention;
`SQLITE_LOCKED` is retained since it is reachable under any journal mode.

**Additional gap found while reproducing 11:** `applySchema` writes (`CREATE TABLE
IF NOT EXISTS` plus an `INSERT OR IGNORE`) inside `openForWrite`, which runs
*before* `BEGIN IMMEDIATE` and outside the busy-classification. A concurrent
reader therefore made every writer throw a raw, unclassified `SQLITE_BUSY` that no
caller knows to read as contention. Now classified like the other two sites, with
a test.

**13 — the concurrency claim in this body is corrected above**, and a real
contention demonstration added. Also documented the previously-undocumented
invariant that `finally { db.close() }` is what keeps the `Database` reachable for
the whole transaction: `bun:sqlite` closes on GC and closing mid-transaction rolls
back, so "simplifying" that `finally` away would lose writes silently.

Deliberately unchanged, per the review: the NOT-WAL pragma and its regression
test, park-never-delete, API stability, the SQL-pushdown limit, and the `LIMIT`
integer guard. `.claude/skills/**` jsonl drift was left alone — meta files, not a
worker's to touch.

## Out of scope, filed separately

A dev command run from a worktree (`bun dev:mcx -- phase log`) resolves
`stateCwd()` to the **base repo**, so it mutates the base repo's live runtime
state rather than the worktree's. Real footgun for any worktree session, but a
separate surface — deliberately **not** worked around here.

