### PR TITLE
fix(command): await ephemeral alias save before printing hint (fixes #2983)

### DIFF
--- a/packages/command/src/ephemeral.spec.ts
+++ b/packages/command/src/ephemeral.spec.ts
@@ -42,22 +42,22 @@ describe("maybeAutoSaveEphemeral", () => {
     };
   }
 
-  test("does not save when args are below threshold", () => {
+  test("does not save when args are below threshold", async () => {
     const deps = createDeps();
     options.EPHEMERAL_ALIAS_CHAR_THRESHOLD = 400;
 
-    maybeAutoSaveEphemeral("server", "tool", { short: "args" }, deps);
+    await maybeAutoSaveEphemeral("server", "tool", { short: "args" }, deps);
 
     expect(deps.ipcCall).not.toHaveBeenCalled();
     expect(deps.logError).not.toHaveBeenCalled();
   });
 
-  test("saves when args exceed threshold", () => {
+  test("saves when args exceed threshold", async () => {
     const deps = createDeps();
     options.EPHEMERAL_ALIAS_CHAR_THRESHOLD = 10;
 
     const longArgs = { query: "a".repeat(100) };
-    maybeAutoSaveEphemeral("server", "get_logs", longArgs, deps);
+    await maybeAutoSaveEphemeral("server", "get_logs", longArgs, deps);
 
     expect(deps.ipcCall).toHaveBeenCalledTimes(1);
     const callArgs = (deps.ipcCall as ReturnType<typeof mock>).mock.calls[0];
@@ -69,37 +69,37 @@ describe("maybeAutoSaveEphemeral", () => {
     expect(deps.logError).toHaveBeenCalledTimes(1);
   });
 
-  test("does not save when feature is disabled via config", () => {
+  test("does not save when feature is disabled via config", async () => {
     const deps = createDeps({
       readCliConfig: () => ({ ephemeralAliases: { enabled: false } }),
     });
     options.EPHEMERAL_ALIAS_CHAR_THRESHOLD = 10;
 
-    maybeAutoSaveEphemeral("server", "tool", { query: "a".repeat(100) }, deps);
+    await maybeAutoSaveEphemeral("server", "tool", { query: "a".repeat(100) }, deps);
 
     expect(deps.ipcCall).not.toHaveBeenCalled();
   });
 
-  test("uses config charThreshold override", () => {
+  test("uses config charThreshold override", async () => {
     const deps = createDeps({
       readCliConfig: () => ({ ephemeralAliases: { charThreshold: 5000 } }),
     });
     options.EPHEMERAL_ALIAS_CHAR_THRESHOLD = 10;
 
     // Args exceed default (10) but not config override (5000)
-    maybeAutoSaveEphemeral("server", "tool", { query: "a".repeat(100) }, deps);
+    await maybeAutoSaveEphemeral("server", "tool", { query: "a".repeat(100) }, deps);
 
     expect(deps.ipcCall).not.toHaveBeenCalled();
   });
 
-  test("uses config ttlMs override", () => {
+  test("uses config ttlMs override", async () => {
     const deps = createDeps({
       readCliConfig: () => ({ ephemeralAliases: { ttlMs: 60000 } }),
     });
     options.EPHEMERAL_ALIAS_CHAR_THRESHOLD = 10;
 
     const before = Date.now();
-    maybeAutoSaveEphemeral("server", "tool", { query: "a".repeat(100) }, deps);
+    await maybeAutoSaveEphemeral("server", "tool", { query: "a".repeat(100) }, deps);
 
     const callArgs = (deps.ipcCall as ReturnType<typeof mock>).mock.calls[0];
     const params = callArgs[1] as Record<string, unknown>;
@@ -109,11 +109,11 @@ describe("maybeAutoSaveEphemeral", () => {
     expect(expiresAt).toBeGreaterThanOrEqual(before + 60000);
   });
 
-  test("generates script with correct server/tool references", () => {
+  test("generates script with correct server/tool references", async () => {
     const deps = createDeps();
     options.EPHEMERAL_ALIAS_CHAR_THRESHOLD = 10;
 
-    maybeAutoSaveEphemeral("my-server", "my-tool", { query: "a".repeat(100) }, deps);
+    await maybeAutoSaveEphemeral("my-server", "my-tool", { query: "a".repeat(100) }, deps);
 
     const callArgs = (deps.ipcCall as ReturnType<typeof mock>).mock.calls[0];
     const params = callArgs[1] as Record<string, unknown>;
@@ -123,15 +123,71 @@ describe("maybeAutoSaveEphemeral", () => {
     expect(script).toContain("mcp[");
   });
 
-  test("hint message includes alias name", () => {
+  test("hint message includes alias name", async () => {
     const deps = createDeps();
     options.EPHEMERAL_ALIAS_CHAR_THRESHOLD = 10;
 
-    maybeAutoSaveEphemeral("server", "get_logs", { query: "a".repeat(100) }, deps);
+    await maybeAutoSaveEphemeral("server", "get_logs", { query: "a".repeat(100) }, deps);
 
     const logCall = (deps.logError as ReturnType<typeof mock>).mock.calls[0];
     const msg = logCall[0] as string;
     expect(msg).toContain("mcx run");
     expect(msg).toContain("mcx alias edit");
+  });
+
+  // #2983: the hint promises `mcx run <name>` works — it must never be printed
+  // for an alias the daemon did not persist.
+  test("does not print the run hint when saveAlias rejects", async () => {
+    const deps = createDeps({
+      ipcCall: mock(() => Promise.reject(new Error("daemon unavailable"))) as EphemeralDeps["ipcCall"],
+    });
+    options.EPHEMERAL_ALIAS_CHAR_THRESHOLD = 10;
+
+    await maybeAutoSaveEphemeral("server", "get_logs", { query: "a".repeat(100) }, deps);
+
+    const messages = (deps.logError as ReturnType<typeof mock>).mock.calls.map((c) => c[0] as string);
+    expect(messages.some((m) => m.includes("mcx run"))).toBe(false);
+    expect(messages.some((m) => m.includes("daemon unavailable"))).toBe(true);
+  });
+
+  test("does not print the run hint when saveAlias reports ok: false", async () => {
+    const deps = createDeps({
+      ipcCall: mock(() => Promise.resolve({ ok: false, reason: "permanent_alias_exists" })) as EphemeralDeps["ipcCall"],
+    });
+    options.EPHEMERAL_ALIAS_CHAR_THRESHOLD = 10;
+
+    await maybeAutoSaveEphemeral("server", "get_logs", { query: "a".repeat(100) }, deps);
+
+    const messages = (deps.logError as ReturnType<typeof mock>).mock.calls.map((c) => c[0] as string);
+    expect(messages.some((m) => m.includes("mcx run"))).toBe(false);
+    expect(messages.some((m) => m.includes("was not saved"))).toBe(true);
+  });
+
+  test("prints the run hint only after the save resolves", async () => {
+    const order: string[] = [];
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const deps = createDeps({
+      ipcCall: mock(async () => {
+        order.push("save-start");
+        await gate;
+        order.push("save-done");
+        return { ok: true, filePath: "/tmp/test.ts" };
+      }) as EphemeralDeps["ipcCall"],
+      logError: mock((msg: string) => {
+        order.push(`log:${msg.includes("mcx run") ? "hint" : "other"}`);
+      }),
+    });
+    options.EPHEMERAL_ALIAS_CHAR_THRESHOLD = 10;
+
+    const pending = maybeAutoSaveEphemeral("server", "get_logs", { query: "a".repeat(100) }, deps);
+    expect(order).toEqual(["save-start"]);
+
+    release?.();
+    await pending;
+
+    expect(order).toEqual(["save-start", "save-done", "log:hint"]);
   });
 });

--- a/packages/command/src/ephemeral.ts
+++ b/packages/command/src/ephemeral.ts
@@ -31,15 +31,24 @@ const defaultDeps: EphemeralDeps = {
 };
 
 /**
- * Auto-save a long CLI call as an ephemeral alias (fire-and-forget).
+ * Auto-save a long CLI call as an ephemeral alias.
  * Only saves if the serialized args exceed the character threshold.
+ *
+ * The `saveAlias` IPC is awaited and the "Run again" hint is printed **only**
+ * after the daemon confirms the save (#2983). The previous fire-and-forget
+ * shape printed the hint unconditionally while `process.exit()` in main.ts
+ * tore down the event loop before the socket write landed — so the alias the
+ * hint named never existed.
+ *
+ * Callers must await this **after** writing the tool payload to stdout so the
+ * extra daemon round-trip does not sit in front of `mcx call`'s output path.
  */
-export function maybeAutoSaveEphemeral(
+export async function maybeAutoSaveEphemeral(
   server: string,
   tool: string,
   toolArgs: Record<string, unknown>,
   deps?: Partial<EphemeralDeps>,
-): void {
+): Promise<void> {
   const d = { ...defaultDeps, ...deps };
   const config = d.readCliConfig();
   const ephCfg = config.ephemeralAliases;
@@ -57,10 +66,20 @@ export function maybeAutoSaveEphemeral(
   const script = `const result = await mcp[${JSON.stringify(server)}][${JSON.stringify(tool)}](${argsJson});\nconsole.log(typeof result === "string" ? result : JSON.stringify(result, null, 2));\n`;
   const description = `ephemeral: ${server}/${tool}`;
 
-  // Fire-and-forget — don't block output
-  d.ipcCall("saveAlias", { name, script, description, expiresAt }).catch(() => {
-    // Silently ignore — ephemeral save is best-effort
-  });
+  // Await the save: the hint below promises the alias is runnable, so it must
+  // not be printed unless the daemon actually persisted it.
+  try {
+    const res = await d.ipcCall("saveAlias", { name, script, description, expiresAt });
+    // The daemon refuses to shadow an existing permanent alias with an
+    // ephemeral one; it answers `{ ok: false, reason }` in that case.
+    if (res.ok !== true) {
+      d.logError(`[mcx] ephemeral alias "${name}" was not saved`);
+      return;
+    }
+  } catch (err) {
+    d.logError(`[mcx] ephemeral alias "${name}" was not saved: ${err instanceof Error ? err.message : String(err)}`);
+    return;
+  }
 
   d.logError(`\u{1F4A1} Run again: mcx run ${name} | Edit: mcx alias edit ${name}`);
 }

--- a/packages/command/src/main.ts
+++ b/packages/command/src/main.ts
@@ -612,65 +612,76 @@ async function cmdCall(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  // Auto-save long calls as ephemeral aliases (best-effort, non-blocking)
-  maybeAutoSaveEphemeral(server, tool, toolArgs, { ipcCall });
-
-  // Explicit --jq filter: apply client-side regardless of size/env
-  if (jqFilter) {
-    const formatted = formatToolResult(result);
-    let data: unknown;
-    try {
-      data = JSON.parse(formatted);
-    } catch {
-      for (const hint of jqParseErrorHints(formatted)) {
-        printError(hint);
-      }
-      process.exit(1);
-    }
-    try {
-      const filtered = await applyJqFilter(data, jqFilter);
-      console.log(JSON.stringify(filtered, null, 2));
-    } catch (err) {
-      printError(err instanceof Error ? err.message : String(err));
-      process.exit(1);
-    }
-    return;
-  }
-
-  // Size protection: only under CLAUDE=1 and without --full
-  const isClaude = process.env.CLAUDE === "1";
-  if (isClaude && !full) {
-    const formatted = formatToolResult(result);
-    const sizeBytes = Buffer.byteLength(formatted, "utf-8");
-
-    if (sizeBytes > SIZE_HINT) {
-      // Too large — replace with structural analysis
+  /** Write the tool payload to stdout using the applicable output mode. */
+  async function emitResult(): Promise<void> {
+    // Explicit --jq filter: apply client-side regardless of size/env
+    if (jqFilter) {
+      const formatted = formatToolResult(result);
+      let data: unknown;
       try {
-        const data = JSON.parse(formatted);
-        console.log(generateAnalysis(data, sizeBytes));
+        data = JSON.parse(formatted);
       } catch {
-        // Not valid JSON — just report size
-        console.log(
-          `Response too large (${(sizeBytes / 1024).toFixed(1)}KB). Use --jq '<filter>' to filter, or --full for raw output.`,
-        );
+        for (const hint of jqParseErrorHints(formatted)) {
+          printError(hint);
+        }
+        process.exit(1);
+      }
+      try {
+        const filtered = await applyJqFilter(data, jqFilter);
+        console.log(JSON.stringify(filtered, null, 2));
+      } catch (err) {
+        printError(err instanceof Error ? err.message : String(err));
+        process.exit(1);
       }
       return;
     }
 
-    if (sizeBytes > SIZE_OK) {
-      // Medium — pass through + stderr hint
+    // Size protection: only under CLAUDE=1 and without --full
+    const isClaude = process.env.CLAUDE === "1";
+    if (isClaude && !full) {
+      const formatted = formatToolResult(result);
+      const sizeBytes = Buffer.byteLength(formatted, "utf-8");
+
+      if (sizeBytes > SIZE_HINT) {
+        // Too large — replace with structural analysis
+        try {
+          const data = JSON.parse(formatted);
+          console.log(generateAnalysis(data, sizeBytes));
+        } catch {
+          // Not valid JSON — just report size
+          console.log(
+            `Response too large (${(sizeBytes / 1024).toFixed(1)}KB). Use --jq '<filter>' to filter, or --full for raw output.`,
+          );
+        }
+        return;
+      }
+
+      if (sizeBytes > SIZE_OK) {
+        // Medium — pass through + stderr hint
+        console.log(formatted);
+        console.error(`[mcx] ${(sizeBytes / 1024).toFixed(1)}KB response. Use --jq to filter.`);
+        return;
+      }
+
+      // Small — pass through unchanged
       console.log(formatted);
-      console.error(`[mcx] ${(sizeBytes / 1024).toFixed(1)}KB response. Use --jq to filter.`);
       return;
     }
 
-    // Small — pass through unchanged
-    console.log(formatted);
-    return;
+    // Default: no protection (no CLAUDE env, or --full)
+    printToolResult(result);
   }
 
-  // Default: no protection (no CLAUDE env, or --full)
-  printToolResult(result);
+  // Payload first: the ephemeral auto-save below costs an extra daemon
+  // round-trip, and `mcx call` owes its result to stdout inside the <50ms
+  // budget. The hint is stderr-only, so emitting it after stdout is harmless.
+  await emitResult();
+
+  // Auto-save long calls as ephemeral aliases. Awaited — main() resolving
+  // triggers process.exit(), which used to tear down the event loop before the
+  // fire-and-forget socket write landed, so the alias the hint advertised was
+  // never actually saved (#2983).
+  await maybeAutoSaveEphemeral(server, tool, toolArgs, { ipcCall });
 }
 
 async function cmdInfo(args: string[]): Promise<void> {

--- a/test/ephemeral-alias.integration.spec.ts
+++ b/test/ephemeral-alias.integration.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * End-to-end coverage for `mcx call`'s ephemeral auto-save (#696) and the
+ * "Run again" hint it prints (#2983).
+ *
+ * Two invariants, neither of which had a test before:
+ *   1. stdout purity — `mcx call` writes ONLY the tool payload to stdout; the
+ *      hint goes to stderr. Nothing in the suite would have caught a regression
+ *      that moved it onto stdout.
+ *   2. hint truthfulness — when the hint names an alias, `mcx run <name>` must
+ *      actually work. It did not: the save was fire-and-forget and
+ *      `process.exit()` cut the socket write short, so the alias never existed.
+ */
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { resolve } from "node:path";
+import { type TestDaemon, echoServerConfig, startTestDaemon } from "./harness";
+
+setDefaultTimeout(30_000);
+
+const MCX_SCRIPT = resolve("packages/command/src/main.ts");
+
+/** Run `mcx` as a child process against the test daemon's isolated dir. */
+async function mcx(dir: string, args: string[]): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  // CLAUDE=1 would engage size protection and rewrite stdout; this test asserts
+  // on the raw payload path, so unset it explicitly.
+  const env: Record<string, string | undefined> = { ...process.env, MCP_CLI_DIR: dir, CLAUDE: undefined };
+
+  await using proc = Bun.spawn(["bun", MCX_SCRIPT, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    env,
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { exitCode, stdout, stderr };
+}
+
+describe("mcx call — ephemeral alias auto-save", () => {
+  let daemon: TestDaemon;
+
+  beforeAll(async () => {
+    daemon = await startTestDaemon({ echo: echoServerConfig() }, { skipVirtualServers: false });
+  });
+
+  afterAll(async () => {
+    await daemon.kill();
+  });
+
+  test("hint goes to stderr and the alias it names is runnable", async () => {
+    // Echo back a JSON document so stdout is parseable, and make the serialized
+    // args exceed EPHEMERAL_ALIAS_CHAR_THRESHOLD (400) so auto-save triggers.
+    const payload = { pad: "x".repeat(600) };
+    const callArgs = JSON.stringify({ message: JSON.stringify(payload) });
+    expect(callArgs.length).toBeGreaterThan(400);
+
+    const call = await mcx(daemon.dir, ["call", "echo", "echo", callArgs]);
+
+    // (a) stdout is the payload and nothing else — no hint line in front of it
+    expect(JSON.parse(call.stdout)).toEqual(payload);
+    expect(call.stdout).not.toContain("mcx run");
+    expect(call.exitCode).toBe(0);
+
+    // (b) the hint landed on stderr
+    const match = call.stderr.match(/Run again: mcx run (\S+)/);
+    expect(match?.[1]).toBeDefined();
+    const aliasName = match?.[1] as string;
+
+    // (c) the alias the hint advertised really exists and replays the call
+    const run = await mcx(daemon.dir, ["run", aliasName]);
+    expect(run.stderr).not.toContain("not found");
+    expect(JSON.parse(run.stdout)).toEqual(payload);
+    expect(run.exitCode).toBe(0);
+  });
+
+  test("no hint and no alias when args are below the threshold", async () => {
+    const call = await mcx(daemon.dir, ["call", "echo", "echo", JSON.stringify({ message: "short" })]);
+
+    expect(call.stdout.trim()).toBe("short");
+    expect(call.stderr).not.toContain("Run again");
+    expect(call.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Problem

`mcx call` auto-saves long calls as ephemeral aliases (#696 / #800) and prints `💡 Run again: mcx run <name>` — but the alias never existed. Following the hint always wasted a call:

```
$ mcx call _metrics get_metric '<665-byte args>'
💡 Run again: mcx run get_-c6616444 | Edit: mcx alias edit get_-c6616444
$ mcx run get_-c6616444
Error: Alias "get_-c6616444" not found
```

Two causes: `maybeAutoSaveEphemeral` fired `saveAlias` fire-and-forget behind an empty `.catch(() => {})`, and `main().then(() => process.exit(...))` tore down the event loop before the Unix-socket write landed. The hint printed unconditionally either way.

## Fix

`maybeAutoSaveEphemeral` is now async, awaits the IPC, and prints the hint **only** after the daemon confirms the save. The empty catch is gone — failures print a one-line stderr diagnostic and suppress the hint. It also handles the `{ ok: false }` answer the daemon returns when an ephemeral save would shadow a permanent alias (`handlers/alias.ts:62`), where `mcx run <name>` would otherwise run a *different* alias.

`process.exit` at `main.ts:1037` is deliberately untouched — with the save awaited, `main()` no longer resolves before the write lands, so the race is closed at the source rather than patched.

## The `main.ts` change

The output block in `cmdCall` is extracted verbatim into a local `emitResult()` so the payload reaches stdout **before** the save round-trip is awaited. The four output paths each `return` early, so a statement could not simply be moved past them.

Most of the +105 is re-indentation — a dedented diff of the extracted block against `origin/main` is byte-identical — but it is **not purely cosmetic**, and one behavioral change is worth calling out explicitly:

- The two `process.exit(1)` paths inside the `--jq` block (bad filter, non-JSON payload) now short-circuit **before** the ephemeral save. On main, those paths printed the `💡 Run again:` hint and then exited 1, advertising an alias that never existed. The save now runs in strictly **fewer** cases than main, never more.
- On the `CLAUDE=1` medium-size branch, the hint now prints after the `[mcx] N KB response…` line rather than before. stderr ordering only.

QA verified the remaining 12-case output matrix (`--jq` ok/bad/non-JSON, `--full`, all three `CLAUDE=1` size branches, default, tool-`isError`) produces **identical stdout and exit codes** on both trees.

## Latency

Measured on compiled binaries from both trees against the same daemon, n=21, host load ~5 (ms):

| | TTFB median | total median | post-stdout tail |
|---|---|---|---|
| HEAD save=on | 116.2 | 128.2 | **12.0** |
| HEAD save=off | 111.5 | 114.1 | 2.6 |
| BASE save=on | 114.3 | 116.9 | 2.6 |
| BASE save=off | 108.4 | 110.7 | 2.2 |

- **Time-to-first-stdout-byte is unchanged**: 116.2 vs 114.3 (+1.9ms, within the +3.1ms binary noise on the save=off pair). The payload is not delayed.
- The awaited save adds ≈**9.4ms** to the post-stdout tail (+11.3ms total wall), all of it after stdout is written.
- **Honest caveat**: `mcx call` is ~115ms end-to-end on **both** branches on this host (bare `mcx version` ~100ms), so CLAUDE.md's <50ms budget is already blown on clean main. This PR's delta is negligible and lands entirely after output — but that should not be read as "we are inside the budget". Filed separately.
- New bounded worst case: a wedged daemon can block `mcx call` up to `IPC_REQUEST_TIMEOUT_MS` (60s) *after* stdout is delivered, where main exited immediately.

## Tests

- `ephemeral.spec.ts` — hint suppressed when `saveAlias` rejects and when it answers `ok: false`; hint emitted strictly after the save resolves. DI shape preserved, no `mock.module()`. QA confirmed non-vacuous: reverting only `ephemeral.ts` fails all three.
- New `test/ephemeral-alias.integration.spec.ts` — spawns the real CLI against a real daemon and asserts stdout is pure JSON with no hint line, the hint lands on stderr, and `mcx run <advertised-name>` replays the call. **Fails 3/3 on pre-fix code with the exact reported error**, closing the end-to-end stdout-purity gap noted in the issue. 1.34–1.44s isolated.

## Verification

Compiled binary, isolated `MCP_CLI_DIR`, 628-byte args:

```
$ ./dist/mcx call echo echo '{"message":"..."}'   # exit 0, stdout 616 bytes of pure JSON
   stderr: 💡 Run again: mcx run echo-ce3ce545 | Edit: mcx alias edit echo-ce3ce545
$ ./dist/mcx run echo-ce3ce545                     # exit 0, same 616 bytes
$ ./dist/mcx alias ls
Ephemeral (auto-expire):
  echo-ce3ce545  freeform  ephemeral: echo/echo  expires in 47h 59m
```

`bun run doing-it-wrong`: 42 rules, exit 0. Coverage clean (6342 pass / 0 fail, 91.89% functions / 94.88% lines, thresholds unchanged). No `--no-verify`, no gpgsign bypass, no coverage-threshold edits.

### Local `am-i-done` failures — pre-existing, not from this PR

4 test failures reproduce identically on clean `main` @ a5e21c24 with all changes stashed; QA verified each independently. The deterministic ones (`playwrightCandidates` BUN_INSTALL, `openEventStream()` ×2) fail in isolation on both branches; the rest are 5s-timeout flakes that swap with host load (the QA box peaked at load 27 carrying concurrent runs from unrelated repos). Per CLAUDE.md these are a shared main-level gap and are filed separately rather than bundled here. **CI on this PR is green on a clean runner.**

Fixes #2983

🤖 Generated with [Claude Code](https://claude.com/claude-code)