### PR TITLE
fix: env-unset anti-pattern + self-abort leak, both exposed by bun 1.4 (fixes #2984, fixes #2985)

### DIFF
--- a/packages/command/src/commands/mail.spec.ts
+++ b/packages/command/src/commands/mail.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { IpcMethod, MailMessage } from "@mcp-cli/core";
+import { restoreEnv, unsetEnv } from "../../../../test/env";
 import type { MailDeps } from "./mail";
 import { cmdMail, defaultSenderName, parseMailArgs } from "./mail";
 
@@ -317,15 +318,13 @@ describe("defaultSenderName", () => {
   test("returns USER env var when not CLAUDE", () => {
     const origClaude = process.env.CLAUDE;
     const origUser = process.env.USER;
-    process.env.CLAUDE = undefined;
+    unsetEnv("CLAUDE");
     process.env.USER = "jacob";
     try {
       expect(defaultSenderName()).toBe("jacob");
     } finally {
-      if (origClaude !== undefined) process.env.CLAUDE = origClaude;
-      else process.env.CLAUDE = undefined;
-      if (origUser !== undefined) process.env.USER = origUser;
-      else process.env.USER = undefined;
+      restoreEnv("CLAUDE", origClaude);
+      restoreEnv("USER", origUser);
     }
   });
 
@@ -337,8 +336,7 @@ describe("defaultSenderName", () => {
       const base = cwd.split("/").pop() ?? "claude";
       expect(defaultSenderName()).toBe(`claude-${base}`);
     } finally {
-      if (origClaude !== undefined) process.env.CLAUDE = origClaude;
-      else process.env.CLAUDE = undefined;
+      restoreEnv("CLAUDE", origClaude);
     }
   });
 });

--- a/packages/command/src/commands/serve.spec.ts
+++ b/packages/command/src/commands/serve.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { ALIAS_SERVER_NAME } from "@mcp-cli/core";
 import type { IpcMethod } from "@mcp-cli/core";
+import { restoreEnv, unsetEnv } from "../../../../test/env";
 import { pollUntil } from "../../../../test/harness";
 import { _resetJqStateForTesting } from "../jq/index";
 import { SERVE_SIZE_OK, SERVE_SIZE_TRUNCATE } from "../jq/jq-support";
@@ -126,15 +127,11 @@ describe("checkRecursionGuard", () => {
   });
 
   afterEach(() => {
-    if (savedEnv === undefined) {
-      process.env.MCX_SERVE = undefined;
-    } else {
-      process.env.MCX_SERVE = savedEnv;
-    }
+    restoreEnv("MCX_SERVE", savedEnv);
   });
 
   test("returns false when MCX_SERVE is not set", () => {
-    process.env.MCX_SERVE = undefined;
+    unsetEnv("MCX_SERVE");
     expect(checkRecursionGuard()).toBe(false);
   });
 

--- a/packages/command/src/daemon-lifecycle.spec.ts
+++ b/packages/command/src/daemon-lifecycle.spec.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { BUILD_VERSION, PID_MAX_AGE_MS, PROTOCOL_VERSION } from "@mcp-cli/core";
 import { DaemonStartCooldownError } from "@mcp-cli/core";
+import { unsetEnv } from "../../../test/env";
 import { testOptions } from "../../../test/test-options";
 import {
   _buildStaleDaemonWarning,
@@ -46,7 +47,7 @@ describe("verboseLog", () => {
   });
 
   test("does nothing when MCX_VERBOSE is not set", () => {
-    process.env.MCX_VERBOSE = undefined;
+    unsetEnv("MCX_VERBOSE");
     const lines: string[] = [];
     const origError = console.error;
     console.error = (...args: unknown[]) => lines.push(String(args[0]));

--- a/packages/core/src/ipc-client.ts
+++ b/packages/core/src/ipc-client.ts
@@ -24,6 +24,27 @@ function getProcessSpan(): LiveSpan {
   return _processSpan;
 }
 
+/** True for the `DOMException` an `AbortController` raises on `abort()`. */
+function isAbortError(err: unknown): boolean {
+  return err instanceof DOMException && err.name === "AbortError";
+}
+
+/**
+ * True when `err` is the abort we ourselves triggered via the stream's own
+ * `abort()` function, and therefore a clean end-of-stream rather than a failure.
+ *
+ * Tearing down a streaming `fetch()` mid-flight rejects the in-flight read with
+ * `AbortError`. Bun >= 1.4 surfaces that rejection through the async iterator's
+ * close path, so a consumer doing `stream.abort(); break;` gets the AbortError
+ * thrown out of its `for await` — and, when the loop is already unwinding, as an
+ * unhandled rejection. `abort()` means "stop iterating", so the generator must
+ * absorb it. Every other error (and any abort from a caller-supplied signal we
+ * did not raise) still propagates.
+ */
+function isSelfAbort(controller: AbortController, err: unknown): boolean {
+  return controller.signal.aborted && isAbortError(err);
+}
+
 /**
  * Structured error thrown by ipcCall() when the daemon returns an error response.
  * Preserves the error code, data, and remote stack trace from the daemon.
@@ -163,36 +184,41 @@ export function openLogStream(params: {
   const url = `http://localhost/logs?${qs.toString()}`;
 
   async function* iterate(): AsyncGenerator<{ timestamp: number; line: string }> {
-    const res = await fetch(url, {
-      method: "GET",
-      unix: options.SOCKET_PATH,
-      signal: controller.signal,
-    } as RequestInit);
+    try {
+      const res = await fetch(url, {
+        method: "GET",
+        unix: options.SOCKET_PATH,
+        signal: controller.signal,
+      } as RequestInit);
 
-    if (!res.ok) {
-      throw new Error(`SSE stream error: ${res.status} ${await res.text()}`);
-    }
+      if (!res.ok) {
+        throw new Error(`SSE stream error: ${res.status} ${await res.text()}`);
+      }
 
-    const body = res.body;
-    if (!body) throw new Error("No response body");
+      const body = res.body;
+      if (!body) throw new Error("No response body");
 
-    const decoder = new TextDecoder();
-    let buffer = "";
+      const decoder = new TextDecoder();
+      let buffer = "";
 
-    for await (const chunk of body) {
-      buffer += decoder.decode(chunk as Uint8Array, { stream: true });
-      const parts = buffer.split("\n\n");
-      buffer = parts.pop() ?? "";
+      for await (const chunk of body) {
+        buffer += decoder.decode(chunk as Uint8Array, { stream: true });
+        const parts = buffer.split("\n\n");
+        buffer = parts.pop() ?? "";
 
-      for (const part of parts) {
-        const line = part.replace(/^data: /, "");
-        if (!line) continue;
-        try {
-          yield JSON.parse(line) as { timestamp: number; line: string };
-        } catch {
-          // Skip malformed SSE events
+        for (const part of parts) {
+          const line = part.replace(/^data: /, "");
+          if (!line) continue;
+          try {
+            yield JSON.parse(line) as { timestamp: number; line: string };
+          } catch {
+            // Skip malformed SSE events
+          }
         }
       }
+    } catch (err) {
+      if (!isSelfAbort(controller, err)) throw err;
+      // abort() was called — end iteration cleanly.
     }
   }
 
@@ -245,45 +271,50 @@ export function openEventStream(params?: {
   const url = `http://localhost/events${qsStr ? `?${qsStr}` : ""}`;
 
   async function* iterate(): AsyncGenerator<import("./monitor-event").MonitorEvent> {
-    const res = await fetch(url, {
-      method: "GET",
-      unix: options.SOCKET_PATH,
-      signal: controller.signal,
-    } as RequestInit);
+    try {
+      const res = await fetch(url, {
+        method: "GET",
+        unix: options.SOCKET_PATH,
+        signal: controller.signal,
+      } as RequestInit);
 
-    if (!res.ok) {
-      throw new Error(`Event stream error: ${res.status} ${await res.text()}`);
-    }
+      if (!res.ok) {
+        throw new Error(`Event stream error: ${res.status} ${await res.text()}`);
+      }
 
-    const body = res.body;
-    if (!body) throw new Error("No response body");
+      const body = res.body;
+      if (!body) throw new Error("No response body");
 
-    const decoder = new TextDecoder();
-    let buffer = "";
+      const decoder = new TextDecoder();
+      let buffer = "";
 
-    for await (const chunk of body) {
-      buffer += decoder.decode(chunk as Uint8Array, { stream: true });
-      const lines = buffer.split("\n");
-      buffer = lines.pop() ?? "";
+      for await (const chunk of body) {
+        buffer += decoder.decode(chunk as Uint8Array, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
 
-      for (const line of lines) {
-        const trimmed = line.trim();
-        if (!trimmed) continue;
-        try {
-          yield JSON.parse(trimmed) as import("./monitor-event").MonitorEvent;
-        } catch {
-          // Skip malformed lines
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed) continue;
+          try {
+            yield JSON.parse(trimmed) as import("./monitor-event").MonitorEvent;
+          } catch {
+            // Skip malformed lines
+          }
         }
       }
-    }
-    // Flush any trailing bytes buffered by the streaming decoder
-    const trailing = decoder.decode();
-    if (trailing.trim()) {
-      try {
-        yield JSON.parse(trailing.trim()) as import("./monitor-event").MonitorEvent;
-      } catch {
-        // Ignore incomplete trailing data
+      // Flush any trailing bytes buffered by the streaming decoder
+      const trailing = decoder.decode();
+      if (trailing.trim()) {
+        try {
+          yield JSON.parse(trailing.trim()) as import("./monitor-event").MonitorEvent;
+        } catch {
+          // Ignore incomplete trailing data
+        }
       }
+    } catch (err) {
+      if (!isSelfAbort(controller, err)) throw err;
+      // abort() was called — end iteration cleanly.
     }
   }
 

--- a/packages/daemon/src/index.spec.ts
+++ b/packages/daemon/src/index.spec.ts
@@ -14,6 +14,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { ALIAS_SERVER_NAME, CLAUDE_SERVER_NAME, PROTOCOL_VERSION, silentLogger } from "@mcp-cli/core";
 import { _restoreOptions } from "@mcp-cli/core";
+import { restoreEnv } from "../../../test/env";
 import { pollUntil, rpc } from "../../../test/harness";
 import { testOptions } from "../../../test/test-options";
 import { StateDb } from "./db/state";
@@ -33,11 +34,7 @@ async function withDaemonTimeout<T>(timeoutMs: string, fn: () => Promise<T>): Pr
   try {
     return await fn();
   } finally {
-    if (orig === undefined) {
-      process.env.MCP_DAEMON_TIMEOUT = undefined;
-    } else {
-      process.env.MCP_DAEMON_TIMEOUT = orig;
-    }
+    restoreEnv("MCP_DAEMON_TIMEOUT", orig);
   }
 }
 

--- a/packages/daemon/src/open-event-stream.spec.ts
+++ b/packages/daemon/src/open-event-stream.spec.ts
@@ -161,26 +161,54 @@ describe("openEventStream() client integration", () => {
     startServerWithBus();
 
     const stream = openEventStream();
-    // Abort before any iteration begins — the signal is already set when fetch() is called,
-    // so the generator should throw AbortError immediately on the first .next() call.
+    // Abort before any iteration begins — the signal is already set when fetch() is
+    // called, so the generator must end iteration immediately *and cleanly*: an abort
+    // we initiated ourselves is an end-of-stream, not an error the consumer has to
+    // catch (#2985).
     stream.abort();
 
-    let iterationEnded = false;
-
-    void (async () => {
-      try {
-        for await (const _event of stream.events) {
-          // Should never reach here — abort was called before iteration
-        }
-      } catch (err: unknown) {
-        expect(err).toBeInstanceOf(DOMException);
-        expect((err as DOMException).name).toBe("AbortError");
-      } finally {
-        iterationEnded = true;
+    let eventCount = 0;
+    const consumed = (async () => {
+      for await (const _event of stream.events) {
+        // Should never reach here — abort was called before iteration
+        eventCount++;
       }
+      return "iteration-ended";
     })();
 
-    await pollUntil(() => iterationEnded);
+    // Must *resolve*, not reject: the consumer never has to catch its own abort,
+    // and the iterator must not be left dangling.
+    await expect(consumed).resolves.toBe("iteration-ended");
+    expect(eventCount).toBe(0);
+  });
+
+  test("a non-abort stream error still propagates to the consumer", async () => {
+    // The abort-absorbing catch in openEventStream() must not swallow real failures.
+    // Point the client at a server that answers /events with a 500.
+    const errSocket = tmpSocket();
+    const errServer = Bun.serve({
+      unix: errSocket,
+      fetch: () => new Response("boom", { status: 500 }),
+    });
+    options.SOCKET_PATH = errSocket;
+
+    try {
+      const stream = openEventStream();
+      const consume = (async () => {
+        for await (const _event of stream.events) {
+          /* no events expected */
+        }
+      })();
+      await expect(consume).rejects.toThrow(/Event stream error: 500/);
+    } finally {
+      errServer.stop(true);
+      try {
+        unlinkSync(errSocket);
+        // dotw-ignore test-empty-catch: best-effort cleanup — file may already be gone
+      } catch {
+        /* already cleaned up */
+      }
+    }
   });
 
   test("?since=N query param is forwarded correctly in the request URL", async () => {

--- a/packages/daemon/src/site/browser/resolve-playwright.spec.ts
+++ b/packages/daemon/src/site/browser/resolve-playwright.spec.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
+import { restoreEnv, unsetEnv } from "../../../../../test/env";
 import {
   _defaultInstall,
   _resetCache,
@@ -32,19 +33,20 @@ describe("playwrightCandidates", () => {
       const candidates = playwrightCandidates();
       expect(candidates).toContain(join("/fake/bun", "install", "global", "node_modules", "playwright"));
     } finally {
-      if (prev === undefined) process.env.BUN_INSTALL = undefined;
-      else process.env.BUN_INSTALL = prev;
+      restoreEnv("BUN_INSTALL", prev);
     }
   });
 
   test("omits BUN_INSTALL path when env var is unset", () => {
     const prev = process.env.BUN_INSTALL;
     try {
-      process.env.BUN_INSTALL = undefined;
+      // Must be a real removal: assigning `undefined` leaves the string
+      // "undefined" behind, which still reads as a set BUN_INSTALL (#2984).
+      unsetEnv("BUN_INSTALL");
       const candidates = playwrightCandidates();
       expect(candidates.some((c) => c.includes("install/global"))).toBe(false);
     } finally {
-      if (prev !== undefined) process.env.BUN_INSTALL = prev;
+      restoreEnv("BUN_INSTALL", prev);
     }
   });
 });

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -37,6 +37,10 @@ profiler then surfaces the file as a candidate for splitting.
 Before writing new helpers, check what already exists:
 - `test/harness.ts` — `startTestDaemon`, `rpc`, `createTestDir`, `echoServerConfig` for integration tests
 - `test/test-options.ts` — `testOptions` with temp dir setup and `Symbol.dispose` cleanup
+- `test/env.ts` — `unsetEnv` / `restoreEnv` for save-mutate-restore around `process.env`.
+  **Never write `process.env.FOO = undefined`** — it stringifies to the literal
+  `"undefined"` (truthy) instead of removing the key, and leaks into every later test
+  in the file (#2984)
 - `packages/daemon/src/test-helpers.ts` — `makeConfig`, `makeMockTransport`, `makeMockClient`
 
 ## Core Rules

--- a/test/env.ts
+++ b/test/env.ts
@@ -1,0 +1,28 @@
+/**
+ * Environment-variable helpers for tests.
+ *
+ * `process.env.FOO = undefined` does **not** remove `FOO` — the assignment
+ * stringifies, leaving the literal string `"undefined"` behind, which is truthy
+ * and leaks into every later test in the file. Bun 1.3.x happened to read the
+ * key back as `undefined`, which hid the bug; Bun >= 1.4 matches Node and
+ * returns `"undefined"`, which exposed it (#2984). Removal is the only correct
+ * operation, on every runtime.
+ *
+ * `Reflect.deleteProperty` rather than the `delete` operator: biome's
+ * `performance/noDelete` rule flags `delete`, and its suggested fix is
+ * `= undefined` — i.e. the exact bug this module exists to prevent.
+ */
+
+/** Remove an environment variable (the correct way to "unset" it). */
+export function unsetEnv(name: string): void {
+  Reflect.deleteProperty(process.env, name);
+}
+
+/**
+ * Restore an environment variable to a value captured before a test mutated it.
+ * A captured value of `undefined` means "was not set", so the key is removed.
+ */
+export function restoreEnv(name: string, prev: string | undefined): void {
+  if (prev === undefined) unsetEnv(name);
+  else process.env[name] = prev;
+}


### PR DESCRIPTION
Two deterministic failures on clean `main` under this host's bun (`1.4.0-canary.1+827475e21`). **Neither is a canary artifact** — both are real defects that stable 1.3.14 was masking.

## #2984 — `process.env.X = undefined` does not unset

Assignment stringifies, leaving the literal `"undefined"` (truthy) behind. In `resolve-playwright.spec.ts` the *preceding* test's `finally` leaked `BUN_INSTALL="undefined"` into the next test, so the "omits BUN_INSTALL path when env var is unset" assertion failed.

**Version-dependent, contrary to the issue's original diagnosis.** Bun 1.3.14 reads such a key back as `undefined` (masking it); bun ≥1.4 matches Node and returns `"undefined"` (exposing it). Proven both ways rather than assumed:

- `env -u BUN_INSTALL bun test …` on canary → **still fails** (ambient env irrelevant)
- `BUN_INSTALL=… <1.3.14>/bun test …` → **passes** (ambient var exported, still green)

Adds `test/env.ts` (`unsetEnv` / `restoreEnv`) and routes every occurrence through it — `resolve-playwright.spec.ts` plus four latent ones in `index`/`serve`/`daemon-lifecycle`/`mail` specs that pass today only because the callee compares against an exact value rather than testing truthiness. #2984 asks for exactly this repo-wide sweep.

`Reflect.deleteProperty` rather than `delete`: biome's `performance/noDelete` flags the operator and its autofix is `= undefined` — the exact bug. Verified that fix only applies under `--unsafe`, which `bun lint` does not pass, so the standard gate cannot reintroduce it. Filed as #2994.

## #2985 — self-initiated abort escapes as an unhandled rejection

`stream.abort()` tears down the in-flight streaming `fetch()`, rejecting the pending body read with `AbortError`. Bun ≥1.4 surfaces that through the async iterator's close path, so a consumer doing `stream.abort(); break;` gets it thrown out of its own `for await` — and, with the loop already unwinding, it leaks as "Unhandled error between tests", destabilising unrelated tests in the same file.

**Our code was unsafe on both versions.** An abort we initiate is an end-of-stream, not an error the caller must catch. `mcx monitor` and `mcx logs` already carried private `AbortError` catches papering over it; the contract now holds at the source in `ipc-client.ts`.

Both generators wrap their body and swallow **only** when `controller.signal.aborted` *and* the error is an `AbortError` — every other failure still propagates, covered by a new 500-response test. An abort from a caller-supplied signal we did not raise still propagates. The pre-iteration-abort test now asserts the fixed contract (resolves, zero events) instead of the old throw. The large line count in `ipc-client.ts` is mostly re-indentation from the `try` wrapper.

## Verification

- Both fixes verified passing under **canary** and under **stable 1.3.14**.
- Clean-`main` control @ 78120d33 produced 4 failures + 1 unhandled error; this branch reduces that to 1 (`stress.spec.ts` S1 = #619, unrelated and pre-existing) and removes the leaked rejection.
- Pre-push gate passed under bun `1.3.14+0d9b296af`: `✅ all checks passed (116158ms)`.
- No `--no-verify`, no gpgsign bypass, no coverage-threshold or exclusion edits, no `mock.module()`.

Fixes #2984
Fixes #2985

🤖 Generated with [Claude Code](https://claude.com/claude-code)