### PR TITLE
fix(claude-patch): skip Mach-O codesign off-darwin (fixes #2982)

### DIFF
--- a/packages/core/src/claude-patch/patcher.spec.ts
+++ b/packages/core/src/claude-patch/patcher.spec.ts
@@ -1,10 +1,20 @@
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
-import { copyFileSync, existsSync, mkdtempSync, readFileSync, readdirSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { sha256Hex } from "../manifest-lock";
 import {
+  DEFAULT_DEPS,
   defaultExtractEntitlements,
   defaultResignBinary,
   defaultSmokeTest,
@@ -31,7 +41,13 @@ const enc = new TextEncoder();
 function makeFakeDeps(overrides: Partial<PatcherDeps> = {}): PatcherDeps {
   // Default fake deps that simulate a successful sign+smoke flow without
   // touching real codesign or spawning claude.
+  //
+  // `platform` is pinned to "darwin" so the signing path stays under test on
+  // every runner (the injected extract/resign doubles never shell out). The
+  // off-darwin skip branch is covered explicitly in the platform-gate block
+  // below — see #2982.
   return {
+    platform: "darwin",
     versionResolver: async () => "2.1.121",
     extractEntitlements: async () => "<plist><dict/></plist>",
     resignBinary: async () => {},
@@ -245,6 +261,144 @@ describe("updatePatchedClaude", () => {
     await expect(updatePatchedClaude({ sourcePath, storeDir }, deps)).rejects.toThrow(/entitlements/);
     const stagingFiles = readdirSync(storeDir).filter((f) => f.includes(".staging."));
     expect(stagingFiles).toHaveLength(0);
+  });
+});
+
+// Mach-O signing is macOS-only; off-darwin `codesign` doesn't exist and the
+// ELF copy needs no signature. Before #2982 the patcher ran it unconditionally,
+// so every `mcx claude patch-update` on Linux died with
+// "codesign -d failed: exit undefined" and spawn was unusable on the box.
+// `deps.platform` is injected here so BOTH branches run on ANY host.
+describe("Mach-O signing platform gate (#2982)", () => {
+  let tmpDir: string;
+  let storeDir: string;
+  /** Empty dir pointed at by TMPDIR during the patch, so the temp entitlements plist is observable. */
+  let plistScratch: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "patcher-platform-"));
+    storeDir = join(tmpDir, "store");
+    plistScratch = join(tmpDir, "tmp");
+    mkdirSync(plistScratch);
+  });
+
+  /** Run `fn` with os.tmpdir() redirected at the (empty) scratch dir. */
+  async function withScratchTmpdir<T>(fn: () => Promise<T>): Promise<T> {
+    const prev = process.env.TMPDIR;
+    process.env.TMPDIR = plistScratch;
+    try {
+      return await fn();
+    } finally {
+      restoreEnv("TMPDIR", prev);
+    }
+  }
+
+  test("darwin: extracts entitlements, re-signs the staging copy, then smoke tests", async () => {
+    const sourcePath = makeFakeClaudeBinary(tmpDir, "2.1.121");
+    const calls: string[] = [];
+    const seen: { binPath?: string; entPath?: string; entContent?: string; tmpDuringSign?: string[] } = {};
+    const deps = makeFakeDeps({
+      platform: "darwin",
+      extractEntitlements: async (p) => {
+        calls.push(`extract:${p}`);
+        return "<plist><dict/></plist>";
+      },
+      resignBinary: async (binPath, entPath) => {
+        calls.push("resign");
+        seen.binPath = binPath;
+        seen.entPath = entPath;
+        seen.entContent = readFileSync(entPath, "utf-8");
+        seen.tmpDuringSign = readdirSync(plistScratch);
+      },
+      smokeTest: async (binPath) => {
+        calls.push(`smoke:${binPath.includes(".staging.")}`);
+      },
+    });
+
+    const result = await withScratchTmpdir(() => updatePatchedClaude({ sourcePath, storeDir }, deps));
+
+    expect(calls).toEqual([`extract:${sourcePath}`, "resign", "smoke:true"]);
+    // codesign runs against the staging copy — never the source, never the published path.
+    expect(seen.binPath).toContain("2.1.121.patched.staging.");
+    // The plist really existed on disk while codesign ran, holding the extracted entitlements.
+    expect(seen.entContent).toBe("<plist><dict/></plist>");
+    expect(seen.tmpDuringSign).toEqual([basename(seen.entPath ?? "")]);
+    // ...and is removed afterwards.
+    expect(readdirSync(plistScratch)).toEqual([]);
+    expect(result.status).toBe("patched");
+    expect(readdirSync(storeDir).sort()).toEqual(["2.1.121.meta.json", "2.1.121.patched", "current"]);
+  });
+
+  test("darwin: a real signing failure still aborts the patch and cleans up", async () => {
+    const sourcePath = makeFakeClaudeBinary(tmpDir, "2.1.121");
+    let smokeCalls = 0;
+    const deps = makeFakeDeps({
+      platform: "darwin",
+      resignBinary: async () => {
+        throw new Error("codesign --force failed: exit 1");
+      },
+      smokeTest: async () => {
+        smokeCalls++;
+      },
+    });
+
+    await expect(withScratchTmpdir(() => updatePatchedClaude({ sourcePath, storeDir }, deps))).rejects.toThrow(
+      /codesign --force failed/,
+    );
+    expect(smokeCalls).toBe(0);
+    // Nothing published, no staging leftovers, no orphaned entitlements plist.
+    expect(readdirSync(storeDir)).toEqual([]);
+    expect(readdirSync(plistScratch)).toEqual([]);
+  });
+
+  for (const platform of ["linux", "win32"] as const) {
+    test(`${platform}: skips entitlements + re-sign entirely, still smoke tests and promotes`, async () => {
+      const sourcePath = makeFakeClaudeBinary(tmpDir, "2.1.121");
+      const calls: string[] = [];
+      const deps = makeFakeDeps({
+        platform,
+        extractEntitlements: async () => {
+          calls.push("extract");
+          return "<plist><dict/></plist>";
+        },
+        resignBinary: async () => {
+          calls.push("resign");
+        },
+        smokeTest: async (binPath) => {
+          calls.push(`smoke:${binPath.includes(".staging.")}`);
+        },
+      });
+
+      const result = await withScratchTmpdir(() => updatePatchedClaude({ sourcePath, storeDir }, deps));
+
+      // No codesign shell-outs at all — and no temp plist was ever written.
+      expect(calls).toEqual(["smoke:true"]);
+      expect(readdirSync(plistScratch)).toEqual([]);
+
+      expect(result.status).toBe("patched");
+      if (result.status !== "patched") throw new Error("typeguard");
+      expect(existsSync(result.patchedPath)).toBe(true);
+      expect(existsSync(result.currentLink)).toBe(true);
+      expect(readdirSync(storeDir).sort()).toEqual(["2.1.121.meta.json", "2.1.121.patched", "current"]);
+      // The promoted binary is the patched bytes, not the untouched source.
+      expect(new TextDecoder().decode(readFileSync(result.patchedPath))).not.toContain("claude-staging.fedstart.com");
+    });
+  }
+
+  test("off-darwin: a smoke-test failure still aborts (the gate skips signing, not verification)", async () => {
+    const sourcePath = makeFakeClaudeBinary(tmpDir, "2.1.121");
+    const deps = makeFakeDeps({
+      platform: "linux",
+      smokeTest: async () => {
+        throw new Error("simulated smoke test failure");
+      },
+    });
+    await expect(updatePatchedClaude({ sourcePath, storeDir }, deps)).rejects.toThrow(/smoke/);
+    expect(readdirSync(storeDir)).toEqual([]);
+  });
+
+  test("DEFAULT_DEPS wires the real host platform", () => {
+    expect(DEFAULT_DEPS.platform).toBe(process.platform);
   });
 });
 

--- a/packages/core/src/claude-patch/patcher.ts
+++ b/packages/core/src/claude-patch/patcher.ts
@@ -38,6 +38,15 @@ const CODESIGN_RESIGN_TIMEOUT_MS = 30_000;
 const WHICH_PROBE_TIMEOUT_MS = 5_000;
 
 export interface PatcherDeps {
+  /**
+   * Host platform, in `process.platform` terms. Defaults to `process.platform`.
+   *
+   * Only `"darwin"` gets the Mach-O code-signing pass (entitlements extraction,
+   * temp plist, ad-hoc re-sign) — see #2982. Injectable so both branches are
+   * testable from a single runner instead of being skipped on whichever OS CI
+   * happens to run.
+   */
+  platform: typeof process.platform;
   /** Resolve the version of a claude binary. Default: spawn `<bin> --version`. */
   versionResolver: (binPath: string) => Promise<string>;
   /** Extract entitlements from a signed Mach-O binary. macOS only. */
@@ -215,6 +224,7 @@ export async function defaultSmokeTest(binPath: string): Promise<void> {
 }
 
 export const DEFAULT_DEPS: PatcherDeps = {
+  platform: process.platform,
   versionResolver: defaultVersionResolver,
   extractEntitlements: defaultExtractEntitlements,
   resignBinary: defaultResignBinary,
@@ -290,6 +300,29 @@ function readConfigClaudeBinary(configPath: string): string | null {
     return typeof parsed.claudeBinary === "string" ? parsed.claudeBinary : null;
   } catch {
     return null;
+  }
+}
+
+/**
+ * Copy the source binary's entitlements onto the staged patched copy and
+ * re-sign it ad-hoc. **macOS only** — the caller gates on platform.
+ *
+ * The entitlements plist is written to a temp file because `codesign
+ * --entitlements` takes a path, not stdin. It is removed whether or not the
+ * re-sign succeeds; the staging binary is the caller's to clean up.
+ */
+async function resignStagedBinary(deps: PatcherDeps, sourcePath: string, stagingPath: string): Promise<void> {
+  const entitlements = await deps.extractEntitlements(sourcePath);
+  const entPath = join(tmpdir(), `mcx-entitlements-${process.pid}-${Date.now()}.plist`);
+  writeFileSync(entPath, entitlements, { mode: 0o600 });
+  try {
+    await deps.resignBinary(stagingPath, entPath);
+  } finally {
+    try {
+      rmSync(entPath, { force: true });
+    } catch {
+      // ignore
+    }
   }
 }
 
@@ -388,17 +421,14 @@ export async function updatePatchedClaude(
   deps.writeBytesAtomic(stagingPath, patched);
   chmodSync(stagingPath, 0o755);
   try {
-    const entitlements = await deps.extractEntitlements(sourcePath);
-    const entPath = join(tmpdir(), `mcx-entitlements-${process.pid}-${Date.now()}.plist`);
-    writeFileSync(entPath, entitlements, { mode: 0o600 });
-    try {
-      await deps.resignBinary(stagingPath, entPath);
-    } finally {
-      try {
-        rmSync(entPath, { force: true });
-      } catch {
-        // ignore
-      }
+    // Code signing is a Mach-O concept and `codesign` ships only with the
+    // macOS developer tools. Elsewhere the binary is an ELF/PE image that
+    // carries no signature to preserve, so the entitlements probe, the temp
+    // plist, and the ad-hoc re-sign are all skipped outright — running them
+    // off-darwin made patch-update (and therefore every mcx spawn on Linux)
+    // fail with "codesign -d failed: exit undefined". See #2982.
+    if (deps.platform === "darwin") {
+      await resignStagedBinary(deps, sourcePath, stagingPath);
     }
 
     await deps.smokeTest(stagingPath);


### PR DESCRIPTION
## Problem

`updatePatchedClaude` ran `codesign -d --entitlements` and `codesign --force` unconditionally after staging the patched binary. On Linux `codesign` does not exist, so every `mcx claude patch-update` died:

```
$ mcx claude patch-update
Error: patch-update failed: codesign -d failed: exit undefined
```

Since claude 2.1.120+ requires a patched copy (#1808), this meant `mcx claude spawn` was **completely dead on Linux** — the reporting box had fallen back to raw `tmux new-session` for orchestrator sessions, losing all `mcx claude ls/send/approve` tooling.

## Fix

Gate the entire signing pass — entitlements probe, temp plist, ad-hoc re-sign — on `platform === "darwin"`, extracted into `resignStagedBinary`. Off-darwin the binary is an ELF/PE image with no signature to preserve, so none of it happens at all (not even the temp plist write); the flow goes staging → smoke test → promote. On darwin behavior is unchanged, including the `catch { rmSync(stagingPath) }` abort path on a genuine signing failure.

**Seam choice.** The gate lives in the `update()` flow rather than inside `DEFAULT_DEPS`, because gating the defaults would still run the temp-plist dance off-darwin (writing an empty plist to `tmpdir()` for nothing). The cost of a flow-level gate is that it would skip the injected codesign doubles on a Linux runner and make the existing signing tests vacuous — so `platform` became an injected `PatcherDeps` member (defaulting to `process.platform`) instead of a direct read. `makeFakeDeps()` pins `platform: "darwin"`, keeping every pre-existing test meaningful on any host, and the new tests drive `"linux"`/`"win32"` explicitly. No `mock.module()`.

## Tests

`patcher.spec.ts` (~80ms isolated): darwin asserts call order `extract → resign → smoke`, that codesign runs against the `.staging.` copy, and that the plist exists with the extracted content *during* the re-sign and is gone after; darwin signing failure aborts before smoke test and leaves an empty store dir; `linux`/`win32` assert `["smoke:true"]` only, an **empty TMPDIR scratch** (proving no plist was ever written), promotion, and patched bytes; off-darwin smoke failure still aborts; `DEFAULT_DEPS.platform === process.platform`. Mutation-checked — replacing the gate with an always-true condition fails exactly the two skip tests.

## Verified end-to-end on Linux (the platform that was broken)

```
$ ./dist/mcx claude patch-update
Patched claude 2.1.234 → /home/ubuntu/.mcp-cli/claude-patched/2.1.234.patched
Strategy: host-check-ipv6-loopback-v1
EXIT=0

$ ./dist/mcx claude patch-update          # idempotent
claude 2.1.234 already patched (host-check-ipv6-loopback-v1). Use --force to re-patch.

$ ~/.mcp-cli/claude-patched/current --version
2.1.234 (Claude Code)      # patched ELF runs
```

Pre-fix control, unmodified `main` patcher against a temp store: `PRE-FIX ERROR: codesign -d failed: exit undefined` — the exact #2982 signature.

**Scope check:** grep for `codesign|xcrun|otool|spctl|plutil|security|hdiutil|SetFile|xattr` across `packages/` hits only `patcher.ts`. `claudePatchUpdate` and `resolveClaudeForSpawn` are pure JS/fs. Nothing else needed a platform gate.

## Gate

`bun run am-i-done --ci` → **exit 0** (`✅ all checks passed`, 12/12 steps). Pre-push gate passed under bun `1.3.14+0d9b296af`: `✅ all checks passed (83078ms)`. No `--no-verify`, no gpgsign bypass, no threshold or exclusion edits.

Based on `a5e21c24` rather than current `main`; touches only `packages/core/src/claude-patch/*`, no overlap with merged work. Branch protection here is `strict_required_status_checks_policy: false`, so no rebase needed.

Fixes #2982

🤖 Generated with [Claude Code](https://claude.com/claude-code)