### PR TITLE
fix(claude-session): wire resolveTransport so spawn stops using sdk-url (fixes #3003)

### DIFF
--- a/packages/command/src/commands/agent.spec.ts
+++ b/packages/command/src/commands/agent.spec.ts
@@ -292,11 +292,51 @@ describe("agent codex spawn", () => {
     expect(deps.callTool).toHaveBeenCalledWith("codex_prompt", expect.objectContaining({ worktree: "my-wt" }));
   });
 
-  test("routes non-JSON daemon errors to stderr", async () => {
+  // #3003: a spawn that never started comes back as a plain "Error: <reason>"
+  // string. It used to be printed and `return`ed — exit 0 for a session that
+  // never ran — and printError doubled the prefix the daemon text already had.
+  test("a spawn that never started exits non-zero with a single Error: prefix", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => ({
+        content: [{ type: "text", text: "Error: Claude process exited before producing a result: boom" }],
+        isError: true,
+      })),
+    });
+    await expect(cmdAgent(["codex", "spawn", "--task", "x", "--wait"], deps)).rejects.toThrow(ExitError);
+    expect(deps.printError).toHaveBeenCalledWith("Claude process exited before producing a result: boom");
+    expect(deps.log).not.toHaveBeenCalled();
+  });
+
+  test("a spawn that never started exits non-zero with --json too", async () => {
+    const deps = makeDeps({
+      callTool: mock(async () => ({
+        content: [{ type: "text", text: "Error: boom" }],
+        isError: true,
+      })),
+    });
+    await expect(cmdAgent(["codex", "spawn", "--task", "x", "--json"], deps)).rejects.toThrow(ExitError);
+    expect(deps.printError).toHaveBeenCalledWith("boom");
+    expect(deps.log).not.toHaveBeenCalled();
+  });
+
+  test("a session that ran and failed still emits its JSON payload on stdout", async () => {
+    // isError, but the payload is structured — callers parse it. Must not be
+    // rerouted to stderr just because the daemon flagged it.
+    const payload = JSON.stringify({ sessionId: "s1", success: false, errors: ["nope"] });
+    const deps = makeDeps({
+      callTool: mock(async () => ({ content: [{ type: "text", text: payload }], isError: true })),
+    });
+    await cmdAgent(["codex", "spawn", "--task", "x", "--wait"], deps);
+    expect(JSON.parse(logCalls(deps).join(""))).toEqual({ sessionId: "s1", success: false, errors: ["nope"] });
+    expect(deps.printError).not.toHaveBeenCalled();
+  });
+
+  test("routes non-JSON daemon errors to stderr and exits non-zero", async () => {
     const deps = makeDeps({
       callTool: mock(async () => ({ content: [{ type: "text", text: "connection refused" }] })),
     });
-    await cmdAgent(["codex", "spawn", "--task", "x"], deps);
+    // Exit 1 rather than 0: the spawn did not happen (#3003).
+    await expect(cmdAgent(["codex", "spawn", "--task", "x"], deps)).rejects.toThrow(ExitError);
     expect(deps.printError).toHaveBeenCalledWith("connection refused");
   });
 

--- a/packages/command/src/commands/agent.ts
+++ b/packages/command/src/commands/agent.ts
@@ -44,7 +44,13 @@ import {
 import { getStaleDaemonWarning, ipcCall } from "../daemon-lifecycle";
 import { readFileWithLimit, resolveAtPath } from "../file-read";
 import { applyJqFilter } from "../jq/index";
-import { c, printError as defaultPrintError, printInfo as defaultPrintInfo, formatToolResult } from "../output";
+import {
+  c,
+  printError as defaultPrintError,
+  printInfo as defaultPrintInfo,
+  formatToolResult,
+  stripErrorPrefix,
+} from "../output";
 import { extractFullFlag, extractJqFlag, extractJsonFlag } from "../parse";
 import {
   type SharedSessionDeps,
@@ -537,17 +543,26 @@ async function agentSpawn(
   const result = await d.callTool(`${P}_prompt`, toolArgs);
   const text = formatToolResult(result);
 
-  if (parsed.json) {
-    d.log(text);
-    return;
-  }
-
+  // A spawn that never started comes back as a plain `Error: <reason>` string
+  // rather than JSON. Route it to stderr and exit non-zero — it used to be
+  // printed and `return`ed, so `mcx claude spawn --wait` reported exit 0 for a
+  // session that never ran, with a doubled "Error: Error:" prefix (`printError`
+  // adds one and the daemon's tool text carries its own). Parse before the
+  // --json branch so that path can't emit the error string on stdout either.
+  //
+  // Deliberately keyed on parseability, not `isToolError`: a --wait spawn whose
+  // session ran and finished with `success: false` is also isError, but its
+  // payload is structured JSON that callers read from stdout (#3003).
   let parsed_data: { sessionId?: string } | undefined;
   try {
     parsed_data = JSON.parse(text) as { sessionId?: string };
   } catch {
-    // Not JSON — daemon returned an error string. Route to stderr.
-    d.printError(text);
+    d.printError(stripErrorPrefix(text));
+    d.exit(1);
+  }
+
+  if (parsed.json) {
+    d.log(text);
     return;
   }
   if (parsed_data?.sessionId) {

--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -922,10 +922,50 @@ describe("mcx claude spawn", () => {
     expect(argvs.some((a) => a.includes("worktree remove"))).toBe(false);
   });
 
-  test("a tool-level spawn failure cleans up the worktree it created (#1116)", async () => {
+  test("a tool-level spawn failure NEVER removes the worktree — the session may still be running", async () => {
+    // The daemon's waitForResult rejects at DEFAULT_TIMEOUT_MS (270s) WITHOUT
+    // killing the session, and that rejection comes back as this exact isError
+    // shape — before the 330s IPC timeout, so it is the common case. Removing
+    // the worktree here would `git worktree remove` + `git branch -d` a LIVE
+    // session's workspace whenever the tree happened to be clean. Only the
+    // IPC-throw path, where the daemon never accepted the request, may clean up.
+    const exec = mock(() => ({ stdout: "", stderr: "", exitCode: 0 }));
+    const deps = makeDeps({
+      callTool: mock(async () => ({
+        content: [{ type: "text", text: "Error: Timeout waiting for session abc12345 result after 270000ms" }],
+        isError: true,
+      })),
+      exec,
+    });
+    await expect(cmdClaude(["spawn", "--task", "x", "--worktree", "live", "--wait"], deps)).rejects.toThrow(ExitError);
+    expect(deps.printError).toHaveBeenCalledWith("Timeout waiting for session abc12345 result after 270000ms");
+    const argvs = (exec.mock.calls as unknown as Array<[string[]]>).map((c) => c[0].join(" "));
+    expect(argvs.some((a) => a.includes("worktree remove"))).toBe(false);
+    expect(argvs.some((a) => a.includes("branch -d"))).toBe(false);
+  });
+
+  test("a spawn that never started also leaves the worktree for bye/gc to reap", async () => {
+    // Same string-sniffing limitation: this text IS a never-started spawn, but
+    // the CLI cannot tell it apart from the timeout above, so it must not act.
     const exec = mock(() => ({ stdout: "", stderr: "", exitCode: 0 }));
     const deps = makeDeps({ callTool: mock(async () => FAILED_SPAWN), exec });
+    await expect(cmdClaude(["spawn", "--task", "x", "--worktree", "orphan"], deps)).rejects.toThrow(ExitError);
+    const argvs = (exec.mock.calls as unknown as Array<[string[]]>).map((c) => c[0].join(" "));
+    expect(argvs.some((a) => a.includes("worktree remove"))).toBe(false);
+  });
+
+  test("an IPC-level spawn failure still cleans up the worktree it created (#1116)", async () => {
+    // callTool REJECTED — the daemon never accepted the request, so nothing is
+    // running in the worktree and removing it is safe.
+    const exec = mock(() => ({ stdout: "", stderr: "", exitCode: 0 }));
+    const deps = makeDeps({
+      callTool: mock(async () => {
+        throw new Error("Error: daemon socket closed");
+      }),
+      exec,
+    });
     await expect(cmdClaude(["spawn", "--task", "x", "--worktree", "doomed"], deps)).rejects.toThrow(ExitError);
+    expect(deps.printError).toHaveBeenCalledWith("daemon socket closed");
     const argvs = (exec.mock.calls as unknown as Array<[string[]]>).map((c) => c[0].join(" "));
     expect(argvs.some((a) => a.includes("worktree remove"))).toBe(true);
   });

--- a/packages/command/src/commands/claude.spec.ts
+++ b/packages/command/src/commands/claude.spec.ts
@@ -870,6 +870,66 @@ describe("mcx claude spawn", () => {
     expect(deps.printError).toHaveBeenCalledWith(expect.stringContaining("Usage"));
   });
 
+  // #3003 QA / #2821: the daemon turns a failed spawn into a RESOLVED tool
+  // result with `isError: true` (claude-session-worker's catch), so `callTool`
+  // never throws for it. `mcx claude spawn` printed that text to stdout and
+  // exited 0 — a session that never ran reported success.
+  const FAILED_SPAWN = {
+    content: [{ type: "text", text: "Error: Claude process exited before producing a result: policy denied" }],
+    isError: true,
+  };
+
+  test("a spawn that never ran exits 1 with the error on stderr and nothing on stdout", async () => {
+    const deps = makeDeps({ callTool: mock(async () => FAILED_SPAWN) });
+    const stdout: string[] = [];
+    const origLog = console.log;
+    console.log = (...a: unknown[]) => {
+      stdout.push(String(a[0]));
+    };
+    try {
+      await expect(cmdClaude(["spawn", "--task", "x", "--wait"], deps)).rejects.toThrow(ExitError);
+    } finally {
+      console.log = origLog;
+    }
+    // Single "Error: " prefix — printError adds its own, so the daemon's is stripped.
+    expect(deps.printError).toHaveBeenCalledWith("Claude process exited before producing a result: policy denied");
+    expect(logCalls(deps)).toEqual([]);
+    expect(stdout).toEqual([]);
+  });
+
+  test("a successful spawn still writes its payload to stdout", async () => {
+    const deps = makeDeps({ callTool: mock(async () => toolResult({ sessionId: "abc", success: true })) });
+    await cmdClaude(["spawn", "--task", "x"], deps);
+    expect(logCalls(deps)).toEqual([JSON.stringify({ sessionId: "abc", success: true }, null, 2)]);
+    expect(deps.printError).not.toHaveBeenCalled();
+  });
+
+  test("a session that ran and failed still emits its JSON payload on stdout", async () => {
+    // isError, but structured — callers parse it, and the worktree may hold
+    // real work, so neither stderr-routing nor cleanup applies.
+    const exec = mock(() => ({ stdout: "", stderr: "", exitCode: 0 }));
+    const deps = makeDeps({
+      callTool: mock(async () => ({
+        content: [{ type: "text", text: JSON.stringify({ sessionId: "abc", success: false }, null, 2) }],
+        isError: true,
+      })),
+      exec,
+    });
+    await cmdClaude(["spawn", "--task", "x", "--worktree", "kept", "--wait"], deps);
+    expect(logCalls(deps)).toEqual([JSON.stringify({ sessionId: "abc", success: false }, null, 2)]);
+    expect(deps.printError).not.toHaveBeenCalled();
+    const argvs = (exec.mock.calls as unknown as Array<[string[]]>).map((c) => c[0].join(" "));
+    expect(argvs.some((a) => a.includes("worktree remove"))).toBe(false);
+  });
+
+  test("a tool-level spawn failure cleans up the worktree it created (#1116)", async () => {
+    const exec = mock(() => ({ stdout: "", stderr: "", exitCode: 0 }));
+    const deps = makeDeps({ callTool: mock(async () => FAILED_SPAWN), exec });
+    await expect(cmdClaude(["spawn", "--task", "x", "--worktree", "doomed"], deps)).rejects.toThrow(ExitError);
+    const argvs = (exec.mock.calls as unknown as Array<[string[]]>).map((c) => c[0].join(" "));
+    expect(argvs.some((a) => a.includes("worktree remove"))).toBe(true);
+  });
+
   test("refuses to spawn when daemon is stale (#1218)", async () => {
     const callTool = mock(async () => toolResult({ sessionId: "abc" }));
     const deps = makeDeps({

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -40,6 +40,7 @@ import {
   printError as defaultPrintError,
   printInfo as defaultPrintInfo,
   formatToolResult,
+  isToolError,
   stripErrorPrefix,
 } from "../output";
 import { extractFullFlag, extractJqFlag, extractJsonFlag } from "../parse";
@@ -580,29 +581,67 @@ async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
     }
   }
 
+  /** Best-effort worktree removal after a spawn that never produced a session (#1116). */
+  const cleanupWorktreeAfterFailure = (): void => {
+    if (!parsed.worktree || !worktreeResult) return;
+    try {
+      cleanupWorktree(parsed.worktree, worktreeResult.path, d, process.cwd());
+    } catch {
+      // Best-effort cleanup — don't mask the original error
+    }
+  };
+
+  let result: unknown;
   try {
-    const result = await d.callTool("claude_prompt", toolArgs);
-    console.log(formatToolResult(result));
+    result = await d.callTool("claude_prompt", toolArgs);
   } catch (e) {
     // IPC failed after worktree was created — clean up to avoid orphans (#1116)
-    if (parsed.worktree && worktreeResult) {
-      try {
-        cleanupWorktree(parsed.worktree, worktreeResult.path, d, process.cwd());
-      } catch {
-        // Best-effort cleanup — don't mask the original error
-      }
-    }
+    cleanupWorktreeAfterFailure();
     // `printError` already prefixes "Error: " — both `String(err)` on an Error
     // instance and the daemon's own `Error: <msg>` tool text carry it too, which
     // rendered as "Error: Error: …" for every failed spawn (#3003).
     d.printError(stripErrorPrefix(e instanceof Error ? e.message : String(e)));
     d.exit(1);
+    return;
   }
+
+  const text = formatToolResult(result);
+
+  // The daemon converts a spawn that never started into a RESOLVED tool result
+  // carrying `isError: true` and a plain `Error: <reason>` string
+  // (claude-session-worker's catch), so `callTool` never throws for it. Without
+  // this branch the error text went to stdout and the process exited 0 for a
+  // session that never ran — the exact inversion #2821 forbids. Treated like
+  // the throw above: same cleanup, same single `Error: ` prefix, same exit 1.
+  //
+  // Gated on non-parseability as well as `isError`, matching `mcx agent <p>
+  // spawn`: a --wait spawn whose session DID run and finished with
+  // `success: false` is also isError, but its payload is structured JSON that
+  // callers read from stdout — and its worktree may hold real work, so it must
+  // not be cleaned up either (#3003).
+  if (isToolError(result) && !isJsonText(text)) {
+    cleanupWorktreeAfterFailure();
+    d.printError(stripErrorPrefix(text));
+    d.exit(1);
+    return;
+  }
+
+  d.log(text);
 
   // Write null → initial transition so downstream phases can infer "from"
   // from the log rather than the Tier-3 work_items.phase fallback (#1623).
   if (parsed.workItemId) {
     tryWriteInitialTransition(parsed.workItemId, resolveGitRootOrCwd(d.getGitRoot, d.printError));
+  }
+}
+
+/** True when the tool text is a JSON document (a structured payload, not an error string). */
+function isJsonText(text: string): boolean {
+  try {
+    JSON.parse(text);
+    return true;
+  } catch {
+    return false;
   }
 }
 

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -581,22 +581,20 @@ async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
     }
   }
 
-  /** Best-effort worktree removal after a spawn that never produced a session (#1116). */
-  const cleanupWorktreeAfterFailure = (): void => {
-    if (!parsed.worktree || !worktreeResult) return;
-    try {
-      cleanupWorktree(parsed.worktree, worktreeResult.path, d, process.cwd());
-    } catch {
-      // Best-effort cleanup — don't mask the original error
-    }
-  };
-
   let result: unknown;
   try {
     result = await d.callTool("claude_prompt", toolArgs);
   } catch (e) {
-    // IPC failed after worktree was created — clean up to avoid orphans (#1116)
-    cleanupWorktreeAfterFailure();
+    // IPC failed after worktree was created — clean up to avoid orphans (#1116).
+    // Safe here and only here: a rejected callTool means the daemon never
+    // accepted the request, so no session is running in that worktree.
+    if (parsed.worktree && worktreeResult) {
+      try {
+        cleanupWorktree(parsed.worktree, worktreeResult.path, d, process.cwd());
+      } catch {
+        // Best-effort cleanup — don't mask the original error
+      }
+    }
     // `printError` already prefixes "Error: " — both `String(err)` on an Error
     // instance and the daemon's own `Error: <msg>` tool text carry it too, which
     // rendered as "Error: Error: …" for every failed spawn (#3003).
@@ -607,20 +605,28 @@ async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
 
   const text = formatToolResult(result);
 
-  // The daemon converts a spawn that never started into a RESOLVED tool result
-  // carrying `isError: true` and a plain `Error: <reason>` string
-  // (claude-session-worker's catch), so `callTool` never throws for it. Without
-  // this branch the error text went to stdout and the process exited 0 for a
-  // session that never ran — the exact inversion #2821 forbids. Treated like
-  // the throw above: same cleanup, same single `Error: ` prefix, same exit 1.
+  // The daemon converts a failed spawn into a RESOLVED tool result carrying
+  // `isError: true` and a plain `Error: <reason>` string (claude-session-worker's
+  // catch), so `callTool` never throws for it. Without this branch the error text
+  // went to stdout and the process exited 0 — the inversion #2821 forbids.
   //
   // Gated on non-parseability as well as `isError`, matching `mcx agent <p>
-  // spawn`: a --wait spawn whose session DID run and finished with
-  // `success: false` is also isError, but its payload is structured JSON that
-  // callers read from stdout — and its worktree may hold real work, so it must
-  // not be cleaned up either (#3003).
+  // spawn`: a --wait spawn whose session ran and finished with `success: false`
+  // is also isError, but its payload is structured JSON that callers read from
+  // stdout (#3003).
+  //
+  // Deliberately does NOT clean up the worktree, unlike the IPC-throw path
+  // above. `isError` text cannot distinguish "never started" from "started and
+  // is STILL RUNNING": the daemon's waitForResult rejects at DEFAULT_TIMEOUT_MS
+  // (270s) — before the 330s IPC timeout, so this is the common case — without
+  // killing the session, and returns exactly this shape. Cleaning up there would
+  // `git worktree remove` + `git branch -d` a live session's workspace out from
+  // under it whenever the tree happened to be clean (read-only task, parked on a
+  // permission prompt, rate-limit backoff). Sniffing an error string is not a
+  // sound "did this session start" oracle at any level of gating, so we accept
+  // orphaned worktrees — `mcx claude bye` and gc reap those, and an orphan is
+  // cheap where destroying live work is not.
   if (isToolError(result) && !isJsonText(text)) {
-    cleanupWorktreeAfterFailure();
     d.printError(stripErrorPrefix(text));
     d.exit(1);
     return;

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -35,7 +35,13 @@ import { getStaleDaemonWarning, ipcCall } from "../daemon-lifecycle";
 import { readFileWithLimit, resolveAtPath } from "../file-read";
 import { parseFlags } from "../flags";
 import { applyJqFilter } from "../jq/index";
-import { c, printError as defaultPrintError, printInfo as defaultPrintInfo, formatToolResult } from "../output";
+import {
+  c,
+  printError as defaultPrintError,
+  printInfo as defaultPrintInfo,
+  formatToolResult,
+  stripErrorPrefix,
+} from "../output";
 import { extractFullFlag, extractJqFlag, extractJsonFlag } from "../parse";
 import {
   colorState,
@@ -586,7 +592,10 @@ async function claudeSpawn(args: string[], d: ClaudeDeps): Promise<void> {
         // Best-effort cleanup — don't mask the original error
       }
     }
-    d.printError(String(e));
+    // `printError` already prefixes "Error: " — both `String(err)` on an Error
+    // instance and the daemon's own `Error: <msg>` tool text carry it too, which
+    // rendered as "Error: Error: …" for every failed spawn (#3003).
+    d.printError(stripErrorPrefix(e instanceof Error ? e.message : String(e)));
     d.exit(1);
   }
 

--- a/packages/command/src/commands/config.spec.ts
+++ b/packages/command/src/commands/config.spec.ts
@@ -184,6 +184,10 @@ describe("isCliOptionKey", () => {
     expect(isCliOptionKey("trust-claude")).toBe(true);
   });
 
+  it("recognizes transport, the rollback knob for the Claude transport default (#3003)", () => {
+    expect(isCliOptionKey("transport")).toBe(true);
+  });
+
   it("returns false for server names", () => {
     expect(isCliOptionKey("my-server")).toBe(false);
   });

--- a/packages/command/src/commands/config.ts
+++ b/packages/command/src/commands/config.ts
@@ -4,7 +4,14 @@
  */
 
 import type { BudgetConfig, GetConfigResult, McpConfigFile, ServerConfig } from "@mcp-cli/core";
-import { DEFAULT_CLAUDE_WS_PORT, ipcCall, isStdioConfig, readCliConfig, writeCliConfig } from "@mcp-cli/core";
+import {
+  CLAUDE_TRANSPORTS,
+  DEFAULT_CLAUDE_WS_PORT,
+  ipcCall,
+  isStdioConfig,
+  readCliConfig,
+  writeCliConfig,
+} from "@mcp-cli/core";
 import { c, printError } from "../output";
 import { readConfigFile, writeConfigFile } from "./config-file";
 
@@ -87,14 +94,15 @@ async function configSources(deps: ConfigDeps): Promise<void> {
 
 // -- CLI option keys --
 
-const VALID_KEYS = ["trust-claude", "terminal", "ws-port", "claude-binary"] as const;
+const VALID_KEYS = ["trust-claude", "terminal", "ws-port", "claude-binary", "transport"] as const;
 type ConfigKey = (typeof VALID_KEYS)[number];
 
-const KEY_MAP: Record<ConfigKey, "trustClaude" | "terminal" | "wsPort" | "claudeBinary"> = {
+const KEY_MAP: Record<ConfigKey, "trustClaude" | "terminal" | "wsPort" | "claudeBinary" | "transport"> = {
   "trust-claude": "trustClaude",
   terminal: "terminal",
   "ws-port": "wsPort",
   "claude-binary": "claudeBinary",
+  transport: "transport",
 };
 
 /** Keys whose values are stored as booleans (vs strings) */
@@ -102,6 +110,16 @@ const BOOLEAN_KEYS = new Set<ConfigKey>(["trust-claude"]);
 
 /** Keys whose values are stored as numbers */
 const NUMBER_KEYS = new Set<ConfigKey>(["ws-port"]);
+
+/**
+ * Keys restricted to a fixed set of values, with the value assumed when unset.
+ * `transport` is the rollback knob for the version-gated Claude transport
+ * default (#3003) — reachable from the CLI so recovering from a bad default
+ * doesn't require hand-editing ~/.mcp-cli/config.json.
+ */
+const ENUM_KEYS: Partial<Record<ConfigKey, { values: readonly string[]; fallback: string }>> = {
+  transport: { values: CLAUDE_TRANSPORTS, fallback: "auto" },
+};
 
 /** Check if a key is a known CLI option (vs a server name). */
 export function isCliOptionKey(key: string): boolean {
@@ -176,6 +194,11 @@ function configSetCliOption(args: string[], log?: (msg: string) => void): void {
   }
   const prop = KEY_MAP[key as ConfigKey];
   const config = readCliConfig();
+  const enumSpec = ENUM_KEYS[key as ConfigKey];
+  if (enumSpec && !enumSpec.values.includes(value)) {
+    printError(`Invalid value for ${key}: ${value}. Valid values: ${enumSpec.values.join(", ")}`);
+    process.exit(1);
+  }
   if (BOOLEAN_KEYS.has(key as ConfigKey)) {
     (config as Record<string, unknown>)[prop] = value === "true";
   } else if (NUMBER_KEYS.has(key as ConfigKey)) {
@@ -208,7 +231,7 @@ function configGetCliOption(args: string[], log?: (msg: string) => void): void {
     ? false
     : NUMBER_KEYS.has(key as ConfigKey)
       ? String(DEFAULT_CLAUDE_WS_PORT)
-      : "";
+      : (ENUM_KEYS[key as ConfigKey]?.fallback ?? "");
   (log ?? console.log)(String(config[prop] ?? defaultValue));
 }
 

--- a/packages/command/src/output.spec.ts
+++ b/packages/command/src/output.spec.ts
@@ -8,6 +8,7 @@ import {
   printAliasList,
   printServerList,
   printToolList,
+  stripErrorPrefix,
 } from "./output";
 
 describe("formatToolResult", () => {
@@ -376,5 +377,23 @@ describe("printServerList rate limit line", () => {
   test("omits the line entirely when the server is unthrottled", () => {
     const output = captureStdout(() => printServerList([base]));
     expect(output).not.toContain("rate limit");
+  });
+});
+
+describe("stripErrorPrefix", () => {
+  test("removes one leading Error: so printError does not double it (#3003)", () => {
+    expect(stripErrorPrefix("Error: boom")).toBe("boom");
+  });
+
+  test("leaves a message without the prefix untouched", () => {
+    expect(stripErrorPrefix("boom")).toBe("boom");
+  });
+
+  test("strips only the first prefix", () => {
+    expect(stripErrorPrefix("Error: Error: boom")).toBe("Error: boom");
+  });
+
+  test("does not strip a prefix that appears mid-message", () => {
+    expect(stripErrorPrefix("spawn failed: Error: boom")).toBe("spawn failed: Error: boom");
   });
 });

--- a/packages/command/src/output.ts
+++ b/packages/command/src/output.ts
@@ -56,6 +56,18 @@ export function isToolError(result: unknown): boolean {
   return typeof result === "object" && result !== null && (result as { isError?: unknown }).isError === true;
 }
 
+/**
+ * Strip one leading `"Error: "` from a message that is about to be handed to
+ * `printError`, which adds that prefix itself.
+ *
+ * Daemon tool handlers wrap failures as `{ text: "Error: <msg>", isError: true }`
+ * — the MCP text convention — so printing the text through `printError` rendered
+ * every failed spawn as `Error: Error: <msg>` (#3003).
+ */
+export function stripErrorPrefix(message: string): string {
+  return message.startsWith("Error: ") ? message.slice("Error: ".length) : message;
+}
+
 /** Format and print a tool call result to stdout */
 export function printToolResult(result: unknown): void {
   const text = formatToolResult(result);

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -83,8 +83,11 @@ export interface EphemeralAliasConfig {
   promotionThreshold?: number;
 }
 
+/** Every accepted transport value, in the order CLI help lists them. */
+export const CLAUDE_TRANSPORTS = ["auto", "stdio", "sdk-url"] as const;
+
 /** Transport mode for Claude CLI sessions. */
-export type ClaudeTransport = "auto" | "stdio" | "sdk-url";
+export type ClaudeTransport = (typeof CLAUDE_TRANSPORTS)[number];
 
 /** mcp-cli config file (~/.mcp-cli/config.json) */
 export interface CliConfig {

--- a/packages/daemon/src/claude-session-worker.ts
+++ b/packages/daemon/src/claude-session-worker.ts
@@ -21,6 +21,7 @@ import {
   type LiveSpan,
   type SessionInfo,
   type WorkItemEvent,
+  readCliConfig,
   resolveEffectiveTools,
   silentLogger,
   startSpan,
@@ -31,6 +32,7 @@ import { isResolved, resolveClaudeForSpawn } from "./claude-session/binary-resol
 import type { PermissionRule, PermissionStrategy } from "./claude-session/permission-router";
 import type { SessionEvent } from "./claude-session/session-state";
 import { CLAUDE_TOOLS } from "./claude-session/tools";
+import { resolveTransport } from "./claude-session/transport-resolver";
 import {
   ClaudeWsServer,
   type WaitResult,
@@ -752,15 +754,25 @@ async function startServer(wsPort?: number, quiet?: boolean): Promise<number> {
   // case still surfaces clearly: spawnDisabledReason makes spawnClaude
   // throw with the actionable message at first spawn attempt.
   const resolution = await resolveClaudeForSpawn();
+  // Default transport for spawns that carry no per-session `--transport`
+  // override. Version-gated (see transport-resolver.ts) and overridable via
+  // `transport` in ~/.mcp-cli/config.json. Before #3003 this was hardcoded to
+  // "ws" in prepareSession, so every spawn on a modern claude took the
+  // `--sdk-url` remote-control path — which the CLI refuses outright under
+  // API-key auth ("Remote Control is disabled by your organization's policy"),
+  // killing the child before it ever connected.
+  const defaultTransport = resolveTransport(readCliConfig().transport, resolution.version);
   const wsServerOpts: ConstructorParameters<typeof ClaudeWsServer>[0] = isResolved(resolution)
     ? {
         logger: quiet ? silentLogger : undefined,
         binaryPath: resolution.binaryPath,
         tlsConfig: resolution.tlsConfig,
+        defaultTransport,
       }
     : {
         logger: quiet ? silentLogger : undefined,
         spawnDisabledReason: resolution.error,
+        defaultTransport,
       };
 
   // Start WebSocket server

--- a/packages/daemon/src/claude-session/README.md
+++ b/packages/daemon/src/claude-session/README.md
@@ -61,7 +61,11 @@ Values:
 
 Per-session override via `SessionConfig.transport` (`"ws" | "stdio"`).
 
-Rollback is config-only; takes effect on next spawn.
+Rollback via `config.json` takes effect on the next **daemon/worker restart**,
+not the next spawn: `readCliConfig().transport` is read once in `startServer()`
+(`claude-session-worker.ts`) and handed to the long-lived `ClaudeWsServer` as
+`defaultTransport`. The per-spawn `mcx claude spawn --transport <ws|stdio>`
+override does take effect immediately.
 
 ## Behavioural divergences from the WS path
 
@@ -71,10 +75,20 @@ counters must be checked against both:
 - **`num_turns` is not cumulative over stdio.** On `sdk-url` it accumulates
   across the conversation; over `--print` the CLI restarts it at `1` for every
   turn. The #2837 result-idempotency guard keys on `num_turns`, so
-  `queuePrompt()` resets its baseline — a new prompt starts a new work cycle and
-  its result can never be a replay. Without that reset the guard suppressed
-  `session:result` on every follow-up and `mcx claude send --wait` hung forever
-  (#3003).
+  `SessionState.promptDelivered()` resets its baseline **on stdio only** — a new
+  stdio work cycle reports `num_turns=1` again and its result can never be a
+  replay. Without that reset the guard suppressed `session:result` on every
+  follow-up and `mcx claude send --wait` hung forever (#3003).
+
+  The reset is deliberately *not* applied on `ws`, where `num_turns` stays
+  cumulative and the baseline is the guard's only defence: dropping it re-opened
+  #2837 case B, where a `disconnect()` + `reconnect()` replay arriving while a
+  prompt is pending re-emitted the previous turn's result and resolved a
+  `send --wait` waiter with a stale answer. `SessionState` therefore takes the
+  resolved transport as a constructor argument, and `queuePrompt()` no longer
+  touches the baseline at all — `sendPrompt()` calls `promptDelivered()` only
+  *after* the transport write succeeds, so a failed write leaves the baseline
+  intact (no new turn started).
 - **`system/init` is re-emitted every turn** — see below.
 
 ## `system/init` dedupe

--- a/packages/daemon/src/claude-session/README.md
+++ b/packages/daemon/src/claude-session/README.md
@@ -34,7 +34,15 @@ claude binaries.
 | > 2.1.122 | `stdio` |
 
 The gate is implemented in `transport-resolver.ts` as a pure function
-`resolveTransport(configPref, version)`.
+`resolveTransport(configPref, version)`, called once at claude-session-worker
+startup and handed to `ClaudeWsServer` as `defaultTransport`. `prepareSession`
+uses it for every spawn that carries no per-session override.
+
+**Exception — contained (worktree) sessions stay on `sdk-url`.** ContainmentGuard
+rides the `can_use_tool` round-trip, which only the WS transport carries, and
+`spawnClaude` fails closed on stdio + worktree (#2688/#2791). Those sessions keep
+`ws` regardless of version. Remove the carve-out in `prepareSession` once #2805
+gives stdio `can_use_tool` parity.
 
 ## Configuration
 
@@ -54,6 +62,20 @@ Values:
 Per-session override via `SessionConfig.transport` (`"ws" | "stdio"`).
 
 Rollback is config-only; takes effect on next spawn.
+
+## Behavioural divergences from the WS path
+
+The two transports are not wire-identical. Anything that reads CLI-reported
+counters must be checked against both:
+
+- **`num_turns` is not cumulative over stdio.** On `sdk-url` it accumulates
+  across the conversation; over `--print` the CLI restarts it at `1` for every
+  turn. The #2837 result-idempotency guard keys on `num_turns`, so
+  `queuePrompt()` resets its baseline — a new prompt starts a new work cycle and
+  its result can never be a replay. Without that reset the guard suppressed
+  `session:result` on every follow-up and `mcx claude send --wait` hung forever
+  (#3003).
+- **`system/init` is re-emitted every turn** — see below.
 
 ## `system/init` dedupe
 

--- a/packages/daemon/src/claude-session/session-state.spec.ts
+++ b/packages/daemon/src/claude-session/session-state.spec.ts
@@ -100,6 +100,20 @@ function activeSession(): SessionState {
   return session;
 }
 
+/** An active session whose CLI speaks the stdio transport (num_turns restarts at 1). */
+function activeStdioSession(): SessionState {
+  const session = new SessionState("sess-1", testIdGenerator(), "stdio");
+  session.handleMessage(SYSTEM_INIT);
+  session.handleMessage(ASSISTANT_MSG);
+  return session;
+}
+
+/** Drive a follow-up prompt all the way to "delivered", as ws-server.sendPrompt does. */
+function sendPrompt(session: SessionState, message: string): void {
+  session.queuePrompt(message);
+  session.promptDelivered();
+}
+
 // ── Tests ──
 
 describe("SessionState", () => {
@@ -342,32 +356,89 @@ describe("SessionState", () => {
       expect(replay).toEqual([]);
     });
 
-    // -- #3003: a new prompt starts a new work cycle --
+    // -- #3003: a delivered prompt starts a new work cycle ON STDIO ONLY --
     //
     // num_turns is only cumulative on the sdk-url WS transport. Over stdio
     // `--print` the CLI restarts num_turns at 1 for every turn, so the #2837
     // guard read every follow-up result as a replay, never emitted
     // session:result, and `mcx claude send --wait` hung forever.
+    //
+    // The reset is scoped to stdio: on ws it would destroy the guard's only
+    // baseline and re-open #2837 case B (see the pending-prompt test below).
 
-    test("a follow-up prompt re-arms the guard so a repeated num_turns still emits", () => {
-      const session = activeSession();
+    test("stdio: a follow-up prompt re-arms the guard so a repeated num_turns still emits", () => {
+      const session = activeStdioSession();
       expect(session.handleMessage(RESULT_SUCCESS)).toHaveLength(1);
 
       // Follow-up turn. Over stdio the next result carries the SAME num_turns.
-      session.queuePrompt("second turn");
+      sendPrompt(session, "second turn");
       const second = session.handleMessage({ ...RESULT_SUCCESS, result: "TURN-2" });
       expect(second).toHaveLength(1);
       expect(second[0].type).toBe("session:result");
       expect(session.suppressedResult).toBeNull();
     });
 
-    test("the re-armed guard still suppresses a duplicate within the new work cycle", () => {
-      const session = activeSession();
+    test("stdio: three consecutive num_turns=1 results all emit", () => {
+      const session = activeStdioSession();
+      const turns = ["ONE", "TWO", "THREE"].map((result, i) => {
+        if (i > 0) sendPrompt(session, `turn ${i + 1}`);
+        return session.handleMessage({ ...RESULT_SUCCESS, num_turns: 1, result });
+      });
+      expect(turns.map((events) => events.length)).toEqual([1, 1, 1]);
+      expect(turns.map((events) => (events[0] as { result: string }).result)).toEqual(["ONE", "TWO", "THREE"]);
+    });
+
+    test("stdio: the re-armed guard still suppresses a duplicate within the new work cycle", () => {
+      const session = activeStdioSession();
       session.handleMessage(RESULT_SUCCESS);
-      session.queuePrompt("second turn");
+      sendPrompt(session, "second turn");
       expect(session.handleMessage(RESULT_SUCCESS)).toHaveLength(1);
       // No new prompt in between — this one is a genuine duplicate.
       expect(session.handleMessage(RESULT_SUCCESS)).toEqual([]);
+    });
+
+    test("stdio: a queued but UNDELIVERED prompt leaves the baseline alone", () => {
+      const session = activeStdioSession();
+      expect(session.handleMessage(RESULT_SUCCESS)).toHaveLength(1);
+      // Transport write failed, so ws-server never calls promptDelivered() —
+      // no new turn is running and the baseline must survive.
+      session.queuePrompt("second turn");
+      expect(session.handleMessage(RESULT_SUCCESS)).toEqual([]);
+    });
+
+    test("ws: a delivered prompt does NOT re-arm the guard (num_turns is cumulative)", () => {
+      const session = activeSession();
+      expect(session.handleMessage(RESULT_SUCCESS)).toHaveLength(1);
+      sendPrompt(session, "second turn");
+      // Same num_turns on ws means a replay, not a new turn.
+      expect(session.handleMessage(RESULT_SUCCESS)).toEqual([]);
+    });
+
+    test("B2: ws reconnect replay with a prompt PENDING does not re-emit the stale result", () => {
+      // #2837 case B, pending-prompt variant. Resetting the baseline in
+      // queuePrompt() made the replayed turn-1 result look like a fresh answer
+      // to turn 2, resolving a `send --wait` waiter with a stale payload while
+      // the real turn was still running (#3003 QA).
+      const session = activeSession();
+      expect(session.handleMessage(RESULT_SUCCESS)).toHaveLength(1); // num_turns=3
+
+      sendPrompt(session, "turn 2");
+
+      // WS drops mid-turn (sleep/wake, keep-alive fail) and reconnects; the CLI
+      // replays init → assistant → result for the conversation so far.
+      session.disconnect("ws dropped");
+      session.reconnect();
+      expect(session.handleMessage(SYSTEM_INIT).map((e) => e.type)).toEqual(["session:init"]);
+      session.handleMessage(ASSISTANT_MSG);
+
+      const replay = session.handleMessage({ ...RESULT_SUCCESS, result: "STALE-FROM-TURN-1" });
+      expect(replay).toEqual([]);
+      expect(session.suppressedResult).toEqual({ branch: "result", numTurns: 3, lastEmitted: 3 });
+
+      // The genuine turn-2 result (num_turns advanced) still gets through.
+      const real = session.handleMessage({ ...RESULT_SUCCESS, num_turns: 4, result: "TURN-2" });
+      expect(real).toHaveLength(1);
+      expect(real[0]).toMatchObject({ type: "session:result", result: "TURN-2" });
     });
 
     test("C: consecutive results with no turn advance emit only once", () => {

--- a/packages/daemon/src/claude-session/session-state.spec.ts
+++ b/packages/daemon/src/claude-session/session-state.spec.ts
@@ -342,6 +342,34 @@ describe("SessionState", () => {
       expect(replay).toEqual([]);
     });
 
+    // -- #3003: a new prompt starts a new work cycle --
+    //
+    // num_turns is only cumulative on the sdk-url WS transport. Over stdio
+    // `--print` the CLI restarts num_turns at 1 for every turn, so the #2837
+    // guard read every follow-up result as a replay, never emitted
+    // session:result, and `mcx claude send --wait` hung forever.
+
+    test("a follow-up prompt re-arms the guard so a repeated num_turns still emits", () => {
+      const session = activeSession();
+      expect(session.handleMessage(RESULT_SUCCESS)).toHaveLength(1);
+
+      // Follow-up turn. Over stdio the next result carries the SAME num_turns.
+      session.queuePrompt("second turn");
+      const second = session.handleMessage({ ...RESULT_SUCCESS, result: "TURN-2" });
+      expect(second).toHaveLength(1);
+      expect(second[0].type).toBe("session:result");
+      expect(session.suppressedResult).toBeNull();
+    });
+
+    test("the re-armed guard still suppresses a duplicate within the new work cycle", () => {
+      const session = activeSession();
+      session.handleMessage(RESULT_SUCCESS);
+      session.queuePrompt("second turn");
+      expect(session.handleMessage(RESULT_SUCCESS)).toHaveLength(1);
+      // No new prompt in between — this one is a genuine duplicate.
+      expect(session.handleMessage(RESULT_SUCCESS)).toEqual([]);
+    });
+
     test("C: consecutive results with no turn advance emit only once", () => {
       const session = activeSession();
       const e1 = session.handleMessage(RESULT_SUCCESS);

--- a/packages/daemon/src/claude-session/session-state.ts
+++ b/packages/daemon/src/claude-session/session-state.ts
@@ -127,12 +127,22 @@ export class SessionState {
 
   /**
    * num_turns of the last emitted `session:result`/`session:error` event.
-   * num_turns is cumulative and strictly increases per real turn, so a
-   * replayed historical `result` (WS-reconnect / revive replay) carries the
-   * old value and is suppressed. Reset in resetForClear() — a /clear respawns
-   * a fresh conversation whose num_turns restarts at 1. NOT reset in
-   * reconnect(): a reconnect is the same conversation, so a replayed result
-   * there should be suppressed (#2837).
+   * Within one work cycle a replayed historical `result` (WS-reconnect /
+   * revive replay) carries a non-increasing value and is suppressed (#2837).
+   *
+   * The baseline is reset by:
+   *   - resetForClear() — a /clear respawns a fresh conversation whose
+   *     num_turns restarts at 1.
+   *   - queuePrompt() — a follow-up prompt starts a new work cycle, so the
+   *     result that answers it is never a replay. This matters because
+   *     num_turns is only cumulative on the sdk-url WS transport; over stdio
+   *     `--print` every turn reports num_turns=1, so without the reset the
+   *     guard suppressed `session:result` on every follow-up and
+   *     `mcx claude send --wait` hung forever (#3003).
+   *
+   * NOT reset in reconnect(): a reconnect is the same conversation and skips
+   * the initial message (handleOpen sends it only on fresh connections), so a
+   * replayed result there must still be suppressed (#2837).
    *
    * Scope: this dedup is per-instance and does NOT survive a daemon restart —
    * restoreSessions() builds a fresh SessionState (lastEmittedNumTurns=-1) and
@@ -181,6 +191,11 @@ export class SessionState {
     if (this.state === "idle" || this.state === "init") {
       this.state = "active";
     }
+    // New work cycle: the next result answers THIS prompt and can never be a
+    // replay of the previous turn's, so drop the num_turns dedup baseline. Over
+    // stdio the CLI restarts num_turns at 1 for every turn, which the #2837
+    // guard would otherwise read as a duplicate (#3003).
+    this.lastEmittedNumTurns = -1;
     return userMessage(message, this.sessionId);
   }
 

--- a/packages/daemon/src/claude-session/session-state.ts
+++ b/packages/daemon/src/claude-session/session-state.ts
@@ -27,6 +27,7 @@ import {
   permissionDeny,
   userMessage,
 } from "./ndjson";
+import type { SessionTransport } from "./transport-resolver";
 
 // ── Events emitted by handleMessage ──
 
@@ -133,12 +134,17 @@ export class SessionState {
    * The baseline is reset by:
    *   - resetForClear() — a /clear respawns a fresh conversation whose
    *     num_turns restarts at 1.
-   *   - queuePrompt() — a follow-up prompt starts a new work cycle, so the
-   *     result that answers it is never a replay. This matters because
-   *     num_turns is only cumulative on the sdk-url WS transport; over stdio
-   *     `--print` every turn reports num_turns=1, so without the reset the
-   *     guard suppressed `session:result` on every follow-up and
-   *     `mcx claude send --wait` hung forever (#3003).
+   *   - promptDelivered(), on the **stdio transport only** — over stdio
+   *     `--print` every turn reports num_turns=1, so num_turns is not a
+   *     monotonic key there and without the reset the guard suppressed
+   *     `session:result` on every follow-up and `mcx claude send --wait` hung
+   *     forever (#3003).
+   *
+   * NOT reset for a new prompt on ws: num_turns IS cumulative there, so the
+   * baseline stays meaningful across turns. Dropping it would re-open #2837
+   * case B — a disconnect()+reconnect() replay while a prompt is pending would
+   * re-emit the PREVIOUS turn's result and resolve the `--wait` waiter with a
+   * stale answer while the real turn is still running.
    *
    * NOT reset in reconnect(): a reconnect is the same conversation and skips
    * the initial message (handleOpen sends it only on fresh connections), so a
@@ -151,10 +157,18 @@ export class SessionState {
    */
   private lastEmittedNumTurns = -1;
 
-  constructor(sessionId: string, genRequestId?: RequestIdGenerator) {
+  /**
+   * Transport this session's CLI process speaks. Only `stdio` restarts
+   * num_turns at 1 on every turn; `ws` keeps it cumulative. Read solely by
+   * promptDelivered() to scope the dedup-baseline reset.
+   */
+  private readonly transport: SessionTransport;
+
+  constructor(sessionId: string, genRequestId?: RequestIdGenerator, transport: SessionTransport = "ws") {
     this.sessionId = sessionId;
     this.state = "connecting";
     this.genRequestId = genRequestId ?? createDefaultIdGenerator();
+    this.transport = transport;
   }
 
   /**
@@ -191,12 +205,22 @@ export class SessionState {
     if (this.state === "idle" || this.state === "init") {
       this.state = "active";
     }
-    // New work cycle: the next result answers THIS prompt and can never be a
-    // replay of the previous turn's, so drop the num_turns dedup baseline. Over
-    // stdio the CLI restarts num_turns at 1 for every turn, which the #2837
-    // guard would otherwise read as a duplicate (#3003).
-    this.lastEmittedNumTurns = -1;
     return userMessage(message, this.sessionId);
+  }
+
+  /**
+   * Record that the message built by queuePrompt() actually reached the CLI.
+   *
+   * Called by the caller AFTER a successful transport write — never before,
+   * because a failed write leaves no new turn running and must not disturb the
+   * dedup baseline (ws-server throws on write failure, #3003).
+   *
+   * On stdio this starts a new work cycle whose result reports num_turns=1
+   * again, so the #2837 baseline has to drop. On ws num_turns stays cumulative
+   * and the baseline is left alone — see lastEmittedNumTurns.
+   */
+  promptDelivered(): void {
+    if (this.transport === "stdio") this.lastEmittedNumTurns = -1;
   }
 
   /** Build a permission response for a pending can_use_tool request. */

--- a/packages/daemon/src/claude-session/spawn-transport.spec.ts
+++ b/packages/daemon/src/claude-session/spawn-transport.spec.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "bun:test";
+import { silentLogger } from "@mcp-cli/core";
+import { resolveTransport } from "./transport-resolver";
+import { ClaudeWsServer, describeSpawnExit } from "./ws-server";
+
+// Regression coverage for #3003: `resolveTransport` was dead code and
+// `prepareSession` hardcoded `"ws"`, so every spawn on a modern claude took the
+// `--sdk-url` remote-control path — which the CLI refuses outright under
+// API-key auth, killing the child before it connected. These tests pin the
+// wiring (default transport is injectable and honoured) and the diagnostics
+// that made the failure invisible.
+
+/** A no-op spawn: these tests never start the server or launch a child. */
+function neverSpawn(): never {
+  throw new Error("spawn should not be called");
+}
+
+function makeServer(defaultTransport?: "ws" | "stdio"): ClaudeWsServer {
+  return new ClaudeWsServer({ spawn: neverSpawn, logger: silentLogger, defaultTransport });
+}
+
+describe("prepareSession transport selection (#3003)", () => {
+  test("uses the injected default transport when the spawn has no override", () => {
+    const server = makeServer("stdio");
+    expect(server.prepareSession("s1", { prompt: "hi" }).transport).toBe("stdio");
+  });
+
+  test("still defaults to ws when no default is injected", () => {
+    const server = makeServer();
+    expect(server.prepareSession("s1", { prompt: "hi" }).transport).toBe("ws");
+  });
+
+  test("a per-spawn override wins over the default", () => {
+    const server = makeServer("stdio");
+    expect(server.prepareSession("s1", { prompt: "hi", transport: "ws" }).transport).toBe("ws");
+
+    const wsDefault = makeServer("ws");
+    expect(wsDefault.prepareSession("s2", { prompt: "hi", transport: "stdio" }).transport).toBe("stdio");
+  });
+
+  test("worktree sessions keep ws even when the default is stdio", () => {
+    // ContainmentGuard rides the can_use_tool round-trip, which only ws carries;
+    // spawnClaude fails closed on stdio+worktree (#2688/#2791). Drop this once
+    // #2805 gives stdio parity.
+    const server = makeServer("stdio");
+    expect(server.prepareSession("wt", { prompt: "hi", worktree: "my-tree" }).transport).toBe("ws");
+  });
+
+  test("an explicit stdio override on a worktree session is not silently rewritten", () => {
+    // The override is honoured so spawnClaude can fail closed with its own
+    // message rather than the guard being bypassed by a quiet downgrade.
+    const server = makeServer("ws");
+    expect(server.prepareSession("wt", { prompt: "hi", worktree: "my-tree", transport: "stdio" }).transport).toBe(
+      "stdio",
+    );
+  });
+
+  test("resolveTransport picks stdio for the claude versions that ship today", () => {
+    // The wire-up point reads this; the version gate is what makes modern
+    // claude stop taking the sdk-url path.
+    expect(resolveTransport("auto", "2.1.234")).toBe("stdio");
+    expect(resolveTransport(undefined, "2.1.234")).toBe("stdio");
+    expect(resolveTransport("sdk-url", "2.1.234")).toBe("ws");
+    expect(resolveTransport("auto", "2.1.119")).toBe("ws");
+    expect(resolveTransport("auto", null)).toBe("ws");
+  });
+});
+
+describe("describeSpawnExit (#3003)", () => {
+  test("quotes the child's stderr and points at the log command", () => {
+    const msg = describeSpawnExit(
+      "abc-123",
+      "Remote Control is disabled by your organization's policy. Contact your organization admin to enable it.\n",
+    );
+    expect(msg).toContain("Remote Control is disabled by your organization's policy");
+    expect(msg).toContain("mcx logs abc-123");
+  });
+
+  test("joins multiple stderr lines into one message", () => {
+    const msg = describeSpawnExit("abc-123", "first line\n\nsecond line\n");
+    expect(msg).toContain("first line | second line");
+    expect(msg).not.toContain("\n");
+  });
+
+  test("says so explicitly when the child produced no stderr", () => {
+    const msg = describeSpawnExit("abc-123", "");
+    expect(msg).toContain("no stderr captured");
+    expect(msg).toContain("mcx logs abc-123");
+  });
+
+  test("truncates a huge stderr ring instead of inlining all of it", () => {
+    const msg = describeSpawnExit("abc-123", "x".repeat(10_000));
+    expect(msg).toContain("(truncated)");
+    expect(msg.length).toBeLessThan(600);
+  });
+});

--- a/packages/daemon/src/claude-session/spawn-transport.spec.ts
+++ b/packages/daemon/src/claude-session/spawn-transport.spec.ts
@@ -93,4 +93,13 @@ describe("describeSpawnExit (#3003)", () => {
     expect(msg).toContain("(truncated)");
     expect(msg.length).toBeLessThan(600);
   });
+
+  test("the truncation marker sits in front of the kept tail, not after it", () => {
+    // slice(-N) drops the HEAD, so a trailing "(truncated)" claimed the wrong end
+    // was cut. The fatal line is always last — keep it, and say the head is gone.
+    const msg = describeSpawnExit("abc-123", `${"x".repeat(10_000)} FATAL: policy denied`);
+    expect(msg).toContain("(truncated) ");
+    expect(msg.indexOf("(truncated)")).toBeLessThan(msg.indexOf("FATAL: policy denied"));
+    expect(msg).toContain("FATAL: policy denied");
+  });
 });

--- a/packages/daemon/src/claude-session/ws-server-stdio.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server-stdio.spec.ts
@@ -563,6 +563,46 @@ describe("ClaudeWsServer — stdio transport", () => {
     expect(session?.state).not.toBe("disconnected");
   });
 
+  // #3003: over stdio the CLI restarts num_turns at 1 on every `--print` turn,
+  // so the #2837 idempotency guard read every follow-up result as a replay and
+  // dropped session:result — `mcx claude send --wait` then hung forever. The
+  // baseline reset lives in sendPrompt()'s call to state.promptDelivered(), and
+  // nothing at the server level covered it: deleting that call left the whole
+  // claude-session suite green while reintroducing the hang.
+  test("stdio session emits a SECOND session:result for a follow-up with the same num_turns", async () => {
+    const mock = mockStdioSpawn();
+    server = new ClaudeWsServer({
+      spawn: mock.spawn,
+      logger: silentLogger,
+      connectTimeoutMs: 5000,
+    });
+    await server.start(0);
+
+    const sessionId = crypto.randomUUID();
+    const results: Array<{ type: string }> = [];
+    server.onSessionEvent = (_sid, event) => {
+      if (event.type === "session:result") results.push(event);
+    };
+
+    server.prepareSession(sessionId, { prompt: "Initial", transport: "stdio" });
+    server.spawnClaude(sessionId);
+
+    // Turn 1: init → assistant → result(num_turns=1).
+    mock.pushStdout(`${systemInitMessage(sessionId)}\n`);
+    mock.pushStdout(`${assistantMessage(sessionId)}\n`);
+    mock.pushStdout(`${resultMessage(sessionId)}\n`);
+    await pollUntil(() => results.length === 1, 1000);
+
+    // Turn 2: the CLI reports num_turns=1 again — NOT a replay over stdio.
+    server.sendPrompt(sessionId, "Follow-up question");
+    await pollUntil(() => mock.stdinWrites.length > 1, 1000);
+    mock.pushStdout(`${assistantMessage(sessionId)}\n`);
+    mock.pushStdout(`${resultMessage(sessionId)}\n`);
+    await pollUntil(() => results.length === 2, 1000);
+
+    expect(results).toHaveLength(2);
+  });
+
   test("stdio session sendPrompt writes to stdin", async () => {
     const mock = mockStdioSpawn();
     server = new ClaudeWsServer({

--- a/packages/daemon/src/claude-session/ws-server.spec.ts
+++ b/packages/daemon/src/claude-session/ws-server.spec.ts
@@ -1290,7 +1290,10 @@ describe("ClaudeWsServer", () => {
 
     const err = await resultPromise;
     expect(err).toBeInstanceOf(Error);
-    expect((err as Error).message).toContain("Process exited");
+    expect((err as Error).message).toContain("exited before producing a result");
+    // The rejection must name where the child's stderr can be read, or a spawn
+    // that dies during startup leaves the caller nothing to act on (#3003).
+    expect((err as Error).message).toContain("mcx logs test-session");
   });
 
   test("process exit resolves pending event waiters with disconnect event", async () => {

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -113,8 +113,10 @@ export function describeSpawnExit(sessionId: string, stderrTail: string): string
   if (collapsed === "") {
     return `Claude process exited before producing a result (no stderr captured; ${hint})`;
   }
+  // The tail is what matters (the fatal line is last), so the HEAD is what gets
+  // cut — the marker goes in front of the surviving text, not after it.
   const quoted =
-    collapsed.length > SPAWN_EXIT_STDERR_CHARS ? `${collapsed.slice(-SPAWN_EXIT_STDERR_CHARS)} (truncated)` : collapsed;
+    collapsed.length > SPAWN_EXIT_STDERR_CHARS ? `(truncated) ${collapsed.slice(-SPAWN_EXIT_STDERR_CHARS)}` : collapsed;
   return `Claude process exited before producing a result: ${quoted} (${hint})`;
 }
 
@@ -814,7 +816,7 @@ export class ClaudeWsServer {
       // Skip sessions already in the map (shouldn't happen, but be safe)
       if (this.sessions.has(s.sessionId)) continue;
 
-      const state = new SessionState(s.sessionId);
+      const state = new SessionState(s.sessionId, undefined, s.transport ?? "ws");
       state.state = "disconnected";
       state.model = s.model;
       state.cwd = s.cwd;
@@ -908,7 +910,18 @@ export class ClaudeWsServer {
    */
   /** Prepare a session and return the assigned name and resolved transport. */
   prepareSession(sessionId: string, config: SessionConfig): { name: string; transport: "ws" | "stdio" } {
-    const state = new SessionState(sessionId);
+    // A per-spawn `--transport` wins outright. Otherwise take the version-gated
+    // default — except for containment (worktree) sessions: ContainmentGuard
+    // rides the `can_use_tool` round-trip, which only the WS transport carries,
+    // and spawnClaude fails closed on the combination (#2688/#2791). Those keep ws
+    // rather than being silently downgraded out of the trust boundary. Drop this
+    // carve-out once #2805 gives stdio can_use_tool parity.
+    //
+    // Resolved before SessionState so the state machine knows whether num_turns
+    // is cumulative (ws) or restarts per turn (stdio) — see promptDelivered().
+    const resolvedTransport = config.transport ?? (config.worktree ? "ws" : this.defaultTransport);
+
+    const state = new SessionState(sessionId, undefined, resolvedTransport);
     // Pre-populate state.cwd from config so session info shows the correct
     // cwd even if the Claude process never connects (#1836).
     if (config.cwd) state.cwd = config.cwd;
@@ -925,13 +938,6 @@ export class ClaudeWsServer {
       }
     }
     const name = config.name ?? this.generateName();
-    // A per-spawn `--transport` wins outright. Otherwise take the version-gated
-    // default — except for containment (worktree) sessions: ContainmentGuard
-    // rides the `can_use_tool` round-trip, which only the WS transport carries,
-    // and spawnClaude fails closed on the combination (#2688/#2791). Those keep ws
-    // rather than being silently downgraded out of the trust boundary. Drop this
-    // carve-out once #2805 gives stdio can_use_tool parity.
-    const resolvedTransport = config.transport ?? (config.worktree ? "ws" : this.defaultTransport);
     const completionSignal = makeWorkCompletedSignal();
 
     this.sessions.set(sessionId, {
@@ -1226,8 +1232,12 @@ export class ClaudeWsServer {
     if (!this.sendToSession(session, outbound)) {
       // Transport write failed — sendToSession already transitioned the session
       // to disconnected. Surface the error so the prompt isn't silently lost.
+      // The dedup baseline is deliberately untouched: no new turn started (#3003).
       throw new Error(`Failed to deliver prompt to session ${sessionId}: transport write failed`);
     }
+    // The prompt is on the wire, so a new work cycle has begun. On stdio that
+    // resets the num_turns dedup baseline; on ws it is a no-op (#2837/#3003).
+    session.state.promptDelivered();
     this.addTranscript(session, "outbound", { type: "user", message: { role: "user", content: effective } });
     this.recordSessionProgress(sessionId, session);
   }
@@ -1319,7 +1329,11 @@ export class ClaudeWsServer {
     // handleOpen's ws.send(userMessage) for WS transport.
     const prompt = session.config.prompt;
     const outbound = userMessage(prompt, sessionId);
-    this.sendToSession(session, outbound);
+    if (this.sendToSession(session, outbound)) {
+      // Fresh stdio child: num_turns restarts at 1, so drop any baseline left
+      // over from the pre-respawn turns of a revived session (#3003).
+      session.state.promptDelivered();
+    }
     this.addTranscript(session, "outbound", { type: "user", message: { role: "user", content: prompt } });
 
     const reader = stdout.getReader();

--- a/packages/daemon/src/claude-session/ws-server.ts
+++ b/packages/daemon/src/claude-session/ws-server.ts
@@ -88,6 +88,36 @@ const CONNECT_TIMEOUT_MS = 30_000;
  * newline (#2769). 64 KiB matches the spawnManaged stderr ring default. */
 const MAX_STDERR_LINE_CHARS = 64 * 1024;
 
+/** Max chars of child stderr quoted inline in a spawn-failure error message.
+ * The full 64 KiB ring is persisted to `server_logs`; the error only needs
+ * enough to name the cause without turning into a wall of text. */
+const SPAWN_EXIT_STDERR_CHARS = 400;
+
+/**
+ * Build the error message handed to `--wait` callers when the Claude CLI exits
+ * before producing a result.
+ *
+ * A spawn that dies during startup (bad flags, refused auth, an org policy that
+ * blocks the requested mode) writes its reason to stderr and nothing else — no
+ * transcript, no session events. Quoting the tail here is the difference between
+ * an actionable error and `Process exited`, and the `mcx logs <session-id>`
+ * pointer is the only discoverable route to the full text (#3003).
+ */
+export function describeSpawnExit(sessionId: string, stderrTail: string): string {
+  const collapsed = stderrTail
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l !== "")
+    .join(" | ");
+  const hint = `see \`mcx logs ${sessionId}\` for full stderr`;
+  if (collapsed === "") {
+    return `Claude process exited before producing a result (no stderr captured; ${hint})`;
+  }
+  const quoted =
+    collapsed.length > SPAWN_EXIT_STDERR_CHARS ? `${collapsed.slice(-SPAWN_EXIT_STDERR_CHARS)} (truncated)` : collapsed;
+  return `Claude process exited before producing a result: ${quoted} (${hint})`;
+}
+
 /** Message types handled by the state machine's dispatch. */
 const HANDLED_MSG_TYPES: ReadonlyArray<string> = [
   "system",
@@ -134,9 +164,10 @@ export interface SessionConfig {
   /** Repo root captured at spawn time, used for worktree hook config lookup at teardown. */
   repoRoot?: string;
   /**
-   * Resolved transport for this session: `"ws"` (sdk-url WebSocket) or `"stdio"` (pipe).
-   * Resolved from CliConfig.transport + claude version at spawn time.
-   * Default: `"ws"` (preserves legacy behavior).
+   * Per-spawn transport override: `"ws"` (sdk-url WebSocket) or `"stdio"` (pipe).
+   * Set by `mcx claude spawn --transport`. When omitted, prepareSession falls
+   * back to the server's `defaultTransport`, which the worker resolves from
+   * CliConfig.transport + the claude version at startup (#3003).
    */
   transport?: "ws" | "stdio";
   /**
@@ -549,6 +580,15 @@ export class ClaudeWsServer {
    */
   private readonly spawnDisabledReason: string | null;
 
+  /**
+   * Transport used for sessions that carry no per-spawn `--transport` override.
+   * Resolved once at worker startup from `CliConfig.transport` + the detected
+   * claude version (see `transport-resolver.ts`). Defaults to `"ws"` only when
+   * the daemon could not determine a version — modern claude resolves to
+   * `"stdio"`, which needs neither `--sdk-url` nor the patched binary (#3003).
+   */
+  private readonly defaultTransport: "ws" | "stdio";
+
   constructor(deps?: {
     spawn?: SpawnFn;
     killTimeoutMs?: number;
@@ -568,6 +608,8 @@ export class ClaudeWsServer {
     binaryPath?: string;
     /** Disable spawn with this reason. Read paths still work. */
     spawnDisabledReason?: string | null;
+    /** Transport for sessions without a per-spawn override. Default: `"ws"`. */
+    defaultTransport?: "ws" | "stdio";
   }) {
     this.spawn = deps?.spawn ?? defaultSpawn;
     this.killTimeoutMs = deps?.killTimeoutMs ?? KILL_TIMEOUT_MS;
@@ -588,6 +630,7 @@ export class ClaudeWsServer {
     this.hostname = deps?.hostname ?? (this.tlsConfig ? "::1" : undefined);
     this.binaryPath = deps?.binaryPath ?? "claude";
     this.spawnDisabledReason = deps?.spawnDisabledReason ?? null;
+    this.defaultTransport = deps?.defaultTransport ?? "ws";
   }
 
   /** True when the server is running in TLS (wss://) mode. */
@@ -882,7 +925,13 @@ export class ClaudeWsServer {
       }
     }
     const name = config.name ?? this.generateName();
-    const resolvedTransport = config.transport ?? "ws";
+    // A per-spawn `--transport` wins outright. Otherwise take the version-gated
+    // default — except for containment (worktree) sessions: ContainmentGuard
+    // rides the `can_use_tool` round-trip, which only the WS transport carries,
+    // and spawnClaude fails closed on the combination (#2688/#2791). Those keep ws
+    // rather than being silently downgraded out of the trust boundary. Drop this
+    // carve-out once #2805 gives stdio can_use_tool parity.
+    const resolvedTransport = config.transport ?? (config.worktree ? "ws" : this.defaultTransport);
     const completionSignal = makeWorkCompletedSignal();
 
     this.sessions.set(sessionId, {
@@ -1122,9 +1171,14 @@ export class ClaudeWsServer {
           );
         }
       }
-      // Reject pending result waiters — they can't get results without a process
+      // Reject pending result waiters — they can't get results without a process.
+      // Carry the child's stderr in the message: a spawn that dies before it ever
+      // connects produces no transcript, so a bare "Process exited" left the
+      // caller with nothing to act on and no hint where to look. The full stderr
+      // is in `server_logs` keyed by session id, which `mcx logs <id>` prints —
+      // undiscoverable unless the error says so (#3003).
       for (const waiter of session.resultWaiters) {
-        waiter.reject(new Error("Process exited"));
+        waiter.reject(new Error(describeSpawnExit(sessionId, stderrTail)));
       }
       session.resultWaiters.length = 0;
     });


### PR DESCRIPTION
## Problem

`mcx claude spawn` died instantly on Linux hosts authenticated with `ANTHROPIC_API_KEY`, reporting only `Error: Error: Process exited`. #2982 (Linux codesign) was a real prerequisite but **not** the cause — the patched binary works fine standalone:

```
$ ~/.mcp-cli/claude-patched/current -p "Reply with exactly: PATCHED_OK" --output-format json
… "result":"PATCHED_OK"   EXIT=0
```

## Root cause — two proven facts, not inferences

**1. `resolveTransport()` was dead code.** `prepareSession` hardcoded `config.transport ?? "ws"`. `resolveTransport()` in `transport-resolver.ts` — the version gate mapping claude >2.1.122 onto stdio and honouring `CliConfig.transport` — had **zero production callers** (`grep -rn resolveTransport packages/*/src | grep -v spec` returned only the definition). `CliConfig.transport` was never read anywhere.

**2. The ws path is refused under API-key auth.** Running the daemon in the foreground against an isolated `MCP_CLI_DIR` surfaced what the IPC path swallowed:

```
[_claude] Spawn exited for session 2c5f1528… (pid 2512871, state connecting, workCompleted false):
⚠ claude.ai connectors are disabled because ANTHROPIC_API_KEY or another auth source is set…
Remote Control is disabled by your organization's policy. Contact your organization admin to enable it.
```

Confirmed against the raw binary: with the key set, `--sdk-url … --print --output-format stream-json` exits 1 on that policy line; with `env -u ANTHROPIC_API_KEY` it gets past it. Auth-shaped, not patcher-shaped.

## A second bug was hiding behind the first

Once stdio went live, `mcx claude send --wait` hung forever. `num_turns` is **cumulative on ws but restarts at 1 on every stdio `--print` turn** — verified by driving two turns into the raw binary and printing `num_turns` (`1`, then `1`). The #2837 idempotency guard (`numTurns <= lastEmittedNumTurns`) therefore read every follow-up result as a replay and suppressed `session:result`. Without this fix, flipping the default would have broken multi-turn sessions **on every platform**.

The dedup baseline is now reset when a new prompt is **delivered over stdio** — see the QA round below for why the reset is transport-scoped rather than unconditional.

## Changes

- **`claude-session-worker.ts`** — resolve `resolveTransport(readCliConfig().transport, resolution.version)` at startup, hand to `ClaudeWsServer` as `defaultTransport`.
- **`ws-server.ts`** — `prepareSession` uses it. **Worktree sessions keep `ws`**: ContainmentGuard rides the `can_use_tool` round-trip that only ws carries, and `spawnClaude` fails closed on the combination (#2688/#2791). Without that carve-out this would have been a grid-wide outage on macOS — exactly what #2791 predicted. Drop the carve-out once #2805 lands.
- **`session-state.ts`** — `SessionState` takes the resolved transport; `promptDelivered()` resets the num_turns dedup baseline **on stdio only**.
- **Diagnostics** — `describeSpawnExit()` quotes the child's stderr tail and names `mcx logs <session-id>`. The stderr was persisted all along, keyed by session UUID: reachable, but unguessable.
- **`claude.ts` / `agent.ts`** — both spawn surfaces now exit non-zero for a failed spawn, with **one** `Error:` prefix and the text on **stderr**; it previously printed to stdout and `return`ed, i.e. **exit 0 for a session that never ran** (#2821). Keyed on `isError` + JSON-parseability, so a `success: false` payload from a session that *did* run still reaches stdout for callers that parse it. Worktree cleanup is unchanged — still only on the IPC-throw path.
- **`mcx config set transport <auto|stdio|sdk-url>`** — the rollback knob for this default flip, reachable without hand-editing `config.json`. Note it is read once in `startServer()`, so it takes effect on the next **daemon/worker restart**; the per-spawn `--transport` flag takes effect immediately.

## Verified end to end (compiled daemon, claude 2.1.234, isolated `MCP_CLI_DIR`)

```
$ ./dist/mcx claude spawn -t "Reply with exactly: SPAWN_OK. Do not use any tools." --wait
Claude session started: b0045e1f
{ "sessionId": "b0045e1f-…", "success": true, "result": "SPAWN_OK", "numTurns": 1 }   EXIT=0

$ ./dist/mcx claude send --wait b0045e1f "Reply with exactly: FOLLOWUP_OK"
{ "success": true, "result": "FOLLOWUP_OK", … }                                        EXIT=0
```

A `--transport sdk-url` spawn on this host fails with the new actionable message
(`Claude process exited before producing a result: … Remote Control is disabled by your
organization's policy … (see \`mcx logs <id>\` for full stderr)`). The exit code for that
case is covered by unit tests, not by the manual run that was previously quoted here —
that block claimed `EXIT=1` from a build that still exited 0, and has been removed.

`mcx status` shows all ten virtual servers `connected` including `_claude` — the "stuck in `connecting`" observed while diagnosing was lazy startup, not the defect.

Tests: `spawn-transport.spec.ts` plus session-state, claude/agent command, output, config, and ws-server coverage. The stdio dedup wiring has a ws-server-level regression test (`ws-server-stdio.spec.ts`, "emits a SECOND session:result for a follow-up with the same num_turns") — verified to fail when `promptDelivered()` is deleted from `sendPrompt()`, which the unit-level coverage alone did not catch.

Follow-ups filed rather than fixed here: #3010 (`claudeSend` / `agentSend` still carry the #2821 inversion), #3009 (a revived ws session keeps a stale num_turns dedup baseline), #3011 (`resolve-playwright` tests hard-code bun's install layout).

## QA round — two blocking findings, both fixed

**1. The unconditional `queuePrompt()` dedup reset re-opened #2837 on ws.** The reset is
required on stdio (num_turns restarts at 1 per turn) but destructive on ws, where
num_turns is cumulative and the baseline is the guard's only defence. Reproduced: turn 1
emits `num_turns=3` → a pending prompt drops the baseline to `-1` → a
`disconnect()`+`reconnect()` replay re-emits the turn-1 result, resolving a
`send --wait` waiter with a stale answer while the real turn is still running (#2837
case B, pending-prompt variant — the existing `session-state.spec.ts` case B covered only
the no-pending-prompt variant).

Fix: `SessionState` now takes the resolved transport as a constructor argument and resets
the baseline only on stdio. The reset also moved out of `queuePrompt()` into
`promptDelivered()`, which `sendPrompt()` calls *after* a successful transport write — a
failed write throws and previously left the baseline at `-1` with no new turn running.

**2. The exit-code fix did not reach `mcx claude spawn`.** `main.ts` dispatches `claude` →
`cmdClaude` → `claudeSpawn` in `commands/claude.ts`; `agent.ts` serves
`mcx agent claude spawn`. An earlier revision of this description had that backwards. The
daemon converts a failed spawn into a **resolved** result with `isError: true`
(`claude-session-worker.ts` catch), so `callTool` never throws and nothing between
converts `isError` into a throw — the error text went to stdout with exit 0. `claudeSpawn`
now applies the same `isError` + non-JSON gate as `agent.ts`: error text to stderr with a
single `Error: ` prefix, exit 1. A structured `success: false` payload keeps its
stdout/exit-0 contract, because callers parse it.

That branch deliberately does **not** touch the worktree. A first cut cleaned it up by
analogy with the IPC-throw path (#1116), and QA caught that as destructive: an `isError`
string cannot tell "never started" from "started and is still running". The daemon's
`waitForResult` rejects at `DEFAULT_TIMEOUT_MS` (270s) *without* killing the session and
returns exactly that shape — and 270s fires before the 330s `PROMPT_IPC_TIMEOUT_MS`, so it
is the common path, not an edge case. Cleanup there would `git worktree remove` +
`git branch -d` a live session's workspace whenever the tree happened to be clean (a
read-only task, one parked on a permission prompt, one in rate-limit backoff). Orphaned
worktrees are reaped by `mcx claude bye` and gc; an orphan is cheap where destroying live
work is not. A structural never-started-vs-timed-out signal from the daemon is follow-up
work, not this PR. The IPC-throw path keeps its cleanup — a rejected `callTool` means the
daemon never accepted the request.

Non-blocking QA items also fixed: the `claude-session/README.md` rollback note (config
takes effect on daemon restart, not next spawn) and `describeSpawnExit`'s truncation
marker (`slice(-400)` cuts the head, so the marker is now a prefix).

## Known limitation — not fixed here

**`mcx claude spawn --worktree` still fails on this host.** Worktree sessions are pinned to ws for ContainmentGuard, and ws is what the org policy blocks. It now fails with the actionable message above instead of `Error: Error: Process exited`, but it fails. That gates the sprint grid on API-key-authed hosts; **#2805** (stdio `can_use_tool` parity) is the issue that unblocks it. Interim workaround: unset `ANTHROPIC_API_KEY` and use claude.ai oauth, which restores the ws path.

Fixes #3003

🤖 Generated with [Claude Code](https://claude.com/claude-code)
