### PR TITLE
feat(claude): scriptable auth-profile switching (fixes #3006)

### DIFF
--- a/packages/command/src/claude-auth-store.spec.ts
+++ b/packages/command/src/claude-auth-store.spec.ts
@@ -1,0 +1,646 @@
+import { describe, expect, test } from "bun:test";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { testOptions } from "../../../test/test-options";
+import {
+  type AuthPaths,
+  AuthProfileError,
+  type ClaudeAuthProfile,
+  assertPlatformSupported,
+  defaultAuthPaths,
+  listProfiles,
+  loadProfile,
+  patchClaudeConfigIdentity,
+  readActiveProfileName,
+  readProfile,
+  saveProfile,
+  summarizeProfile,
+  writeFileAtomic,
+} from "./claude-auth-store";
+
+// ── Fixtures ──
+
+const ACCESS_TOKEN = "sk-ant-oat01-FAKE-ACCESS-TOKEN-DO-NOT-LOG";
+const REFRESH_TOKEN = "sk-ant-ort01-FAKE-REFRESH-TOKEN-DO-NOT-LOG";
+const EXPIRES_AT = Date.UTC(2026, 7, 19, 3, 14, 0);
+const NOW = new Date(Date.UTC(2026, 7, 18, 12, 0, 0));
+
+function credentials(overrides?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    claudeAiOauth: {
+      accessToken: ACCESS_TOKEN,
+      refreshToken: REFRESH_TOKEN,
+      expiresAt: EXPIRES_AT,
+      refreshTokenExpiresAt: EXPIRES_AT + 86_400_000,
+      scopes: ["user:inference"],
+      subscriptionType: "max",
+      rateLimitTier: "default_claude_max_20x",
+      ...overrides,
+    },
+  };
+}
+
+function oauthAccount(email: string): Record<string, unknown> {
+  return { accountUuid: `uuid-${email}`, emailAddress: email, organizationName: "Acme" };
+}
+
+interface Sandbox extends AuthPaths {
+  root: string;
+  [Symbol.dispose](): void;
+}
+
+/** Temp filesystem standing in for `~/.claude` + `~/.mcp-cli`. Never touches the real home. */
+function sandbox(opts?: {
+  credentials?: Record<string, unknown> | null;
+  claudeConfig?: Record<string, unknown> | null;
+  policy?: Record<string, unknown> | null;
+}): Sandbox {
+  const root = mkdtempSync(join(tmpdir(), "mcx-auth-"));
+  const claudeHome = join(root, ".claude");
+  mkdirSync(claudeHome, { recursive: true });
+
+  const paths: AuthPaths = {
+    profilesDir: join(root, ".mcp-cli", "auth-profiles"),
+    credentialsPath: join(claudeHome, ".credentials.json"),
+    claudeConfigPath: join(root, ".claude.json"),
+    policyLimitsPath: join(claudeHome, "policy-limits.json"),
+  };
+
+  const creds = opts?.credentials === undefined ? credentials() : opts.credentials;
+  if (creds) writeFileSync(paths.credentialsPath, JSON.stringify(creds, null, 2), { mode: 0o600 });
+
+  const config =
+    opts?.claudeConfig === undefined
+      ? { userID: "user-a", oauthAccount: oauthAccount("a@example.com"), projects: { "/repo": { allowedTools: [] } } }
+      : opts.claudeConfig;
+  if (config) writeFileSync(paths.claudeConfigPath, JSON.stringify(config, null, 2), { mode: 0o600 });
+
+  const policy =
+    opts?.policy === undefined ? { restrictions: { allow_remote_control: { allowed: false } } } : opts.policy;
+  if (policy) writeFileSync(paths.policyLimitsPath, JSON.stringify(policy, null, 2), { mode: 0o600 });
+
+  return {
+    ...paths,
+    root,
+    [Symbol.dispose]() {
+      rmSync(root, { recursive: true, force: true });
+    },
+  };
+}
+
+function save(paths: AuthPaths, name: string, env: Record<string, string | undefined> = {}, apiKeyEnvVar?: string) {
+  return saveProfile({ paths, name, env, now: NOW, platform: "linux", apiKeyEnvVar });
+}
+
+function load(paths: AuthPaths, name: string, env: Record<string, string | undefined> = {}) {
+  return loadProfile({ paths, name, env, now: NOW, platform: "linux" });
+}
+
+function mode(path: string): number {
+  return statSync(path).mode & 0o777;
+}
+
+// ── save ──
+
+describe("saveProfile", () => {
+  test("captures credentials and identity, creates 0700 dir with 0600 files", () => {
+    using fs = sandbox();
+    const result = save(fs, "work");
+
+    expect(result.profile.kind).toBe("oauth");
+    expect(result.replaced).toBe(false);
+    expect(result.becameActive).toBe(true);
+    expect(result.profile.credentials).toEqual(credentials());
+    expect(result.profile.identity?.userID).toBe("user-a");
+    expect(mode(fs.profilesDir)).toBe(0o700);
+    expect(mode(join(fs.profilesDir, "work.json"))).toBe(0o600);
+    expect(readActiveProfileName(fs)).toBe("work");
+  });
+
+  test("records the org-policy remote-control flag", () => {
+    using fs = sandbox();
+    expect(save(fs, "work").profile.policy?.allowRemoteControl).toBe(false);
+  });
+
+  test("second save of the same name updates in place and keeps createdAt", () => {
+    using fs = sandbox();
+    const first = save(fs, "work");
+    const later = new Date(NOW.getTime() + 60_000);
+    const second = saveProfile({ paths: fs, name: "work", env: {}, now: later, platform: "linux" });
+
+    expect(second.replaced).toBe(true);
+    expect(second.profile.createdAt).toBe(first.profile.createdAt);
+    expect(second.profile.updatedAt).toBe(later.toISOString());
+  });
+
+  test("throws no-credentials when nothing is logged in", () => {
+    using fs = sandbox({ credentials: null });
+    expect(() => save(fs, "work")).toThrow(AuthProfileError);
+    try {
+      save(fs, "work");
+    } catch (err) {
+      expect((err as AuthProfileError).code).toBe("no-credentials");
+    }
+  });
+
+  test("ANTHROPIC_API_KEY in env stores the var NAME and never the value", () => {
+    using fs = sandbox();
+    const secret = "sk-ant-api03-SUPER-SECRET-VALUE";
+    const result = save(fs, "ci", { ANTHROPIC_API_KEY: secret });
+
+    expect(result.profile.kind).toBe("api-key");
+    expect(result.profile.apiKeyEnvVar).toBe("ANTHROPIC_API_KEY");
+    expect(result.profile.credentials).toBeUndefined();
+    const onDisk = readFileSync(join(fs.profilesDir, "ci.json"), "utf-8");
+    expect(onDisk).not.toContain(secret);
+    expect(onDisk).not.toContain(ACCESS_TOKEN);
+    expect(onDisk).not.toContain(REFRESH_TOKEN);
+  });
+
+  test("api-key save does not claim the live oauth credentials or the active pointer", () => {
+    using fs = sandbox();
+    const result = save(fs, "ci", { ANTHROPIC_API_KEY: "x" });
+
+    expect(result.becameActive).toBe(false);
+    expect(readActiveProfileName(fs)).toBeNull();
+    expect(result.warnings.join(" ")).toContain("NOT captured");
+  });
+
+  test("--api-key-env forces an api-key profile even when the var is unset", () => {
+    using fs = sandbox();
+    const result = save(fs, "ci", {}, "MY_KEY");
+
+    expect(result.profile.kind).toBe("api-key");
+    expect(result.profile.apiKeyEnvVar).toBe("MY_KEY");
+    expect(result.warnings.join(" ")).toContain("MY_KEY is not set");
+  });
+
+  test("rejects path-traversal and empty profile names", () => {
+    using fs = sandbox();
+    for (const bad of ["../escape", "a/b", "", ".hidden"]) {
+      expect(() => save(fs, bad)).toThrow(AuthProfileError);
+    }
+  });
+});
+
+// ── load ──
+
+describe("loadProfile", () => {
+  test("swaps credentials and identity, preserving unrelated ~/.claude.json keys and mode", () => {
+    using fs = sandbox();
+    save(fs, "work");
+
+    // Simulate logging in as someone else, then capture that identity too.
+    writeFileSync(fs.credentialsPath, JSON.stringify(credentials({ accessToken: "second-token" })), { mode: 0o600 });
+    writeFileSync(
+      fs.claudeConfigPath,
+      JSON.stringify({ userID: "user-b", oauthAccount: oauthAccount("b@example.com"), projects: { "/repo": {} } }),
+      { mode: 0o600 },
+    );
+    save(fs, "personal");
+
+    const result = load(fs, "work");
+
+    expect(result.credentialsWritten).toBe(true);
+    expect(result.identityWritten).toBe(true);
+    const liveCreds = JSON.parse(readFileSync(fs.credentialsPath, "utf-8"));
+    expect(liveCreds).toEqual(credentials());
+    const liveConfig = JSON.parse(readFileSync(fs.claudeConfigPath, "utf-8"));
+    expect(liveConfig.userID).toBe("user-a");
+    expect(liveConfig.projects).toEqual({ "/repo": {} }); // unrelated keys survive
+    expect(mode(fs.credentialsPath)).toBe(0o600);
+    expect(readActiveProfileName(fs)).toBe("work");
+  });
+
+  test("writes refreshed live credentials back to the previously active profile", () => {
+    using fs = sandbox();
+    save(fs, "work"); // work is active
+    writeFileSync(fs.claudeConfigPath, JSON.stringify({ userID: "user-b", oauthAccount: oauthAccount("b@x.com") }));
+    writeFileSync(fs.credentialsPath, JSON.stringify(credentials({ accessToken: "rotated" })));
+    save(fs, "personal"); // personal becomes active
+
+    // Claude refreshes the token in place while "personal" is active.
+    const refreshed = credentials({ accessToken: "refreshed-token", expiresAt: EXPIRES_AT + 3_600_000 });
+    writeFileSync(fs.credentialsPath, JSON.stringify(refreshed));
+
+    const result = load(fs, "work");
+
+    expect(result.wroteBack).toBe("personal");
+    expect(result.wroteBackChanged).toBe(true);
+    const stored = readProfile(fs, "personal");
+    expect(stored?.credentials).toEqual(refreshed);
+  });
+
+  test("reports no change when the active profile's credentials are untouched", () => {
+    using fs = sandbox();
+    save(fs, "work");
+    writeFileSync(fs.credentialsPath, JSON.stringify(credentials({ accessToken: "other" })));
+    save(fs, "personal");
+
+    const result = load(fs, "work");
+    expect(result.wroteBack).toBe("personal");
+    expect(result.wroteBackChanged).toBe(false);
+  });
+
+  test("invalidates the cached org policy", () => {
+    using fs = sandbox();
+    save(fs, "work");
+    const result = load(fs, "work");
+
+    expect(result.policyInvalidated).toBe(true);
+    expect(existsSync(fs.policyLimitsPath)).toBe(false);
+  });
+
+  test("backs up the pre-existing files once, and never overwrites that backup", () => {
+    using fs = sandbox();
+    save(fs, "work");
+    const first = load(fs, "work");
+
+    expect(first.backupDir).not.toBeNull();
+    const backupCreds = JSON.parse(readFileSync(join(first.backupDir as string, "credentials.json"), "utf-8"));
+    expect(backupCreds).toEqual(credentials());
+    expect(mode(first.backupDir as string)).toBe(0o700);
+    expect(mode(join(first.backupDir as string, "credentials.json"))).toBe(0o600);
+
+    writeFileSync(fs.credentialsPath, JSON.stringify(credentials({ accessToken: "newer" })));
+    const second = load(fs, "work");
+    expect(second.backupDir).toBeNull();
+    const stillOriginal = JSON.parse(readFileSync(join(first.backupDir as string, "credentials.json"), "utf-8"));
+    expect(stillOriginal).toEqual(credentials());
+  });
+
+  test("re-loading the active profile absorbs a refreshed token instead of reverting it", () => {
+    using fs = sandbox();
+    save(fs, "work");
+    const refreshed = credentials({ accessToken: "refreshed-in-place" });
+    writeFileSync(fs.credentialsPath, JSON.stringify(refreshed));
+
+    const result = load(fs, "work");
+
+    expect(result.wroteBack).toBe("work");
+    expect(readProfile(fs, "work")?.credentials).toEqual(refreshed);
+    expect(JSON.parse(readFileSync(fs.credentialsPath, "utf-8"))).toEqual(refreshed);
+  });
+
+  test("unknown active profile: backs up live credentials and warns, destroying nothing", () => {
+    using fs = sandbox();
+    // Profile saved from a different machine state — active pointer never written.
+    const profile: ClaudeAuthProfile = {
+      version: 1,
+      name: "imported",
+      kind: "oauth",
+      createdAt: NOW.toISOString(),
+      updatedAt: NOW.toISOString(),
+      credentials: credentials({ accessToken: "imported-token" }),
+      identity: { userID: "user-c" },
+    };
+    mkdirSync(fs.profilesDir, { recursive: true, mode: 0o700 });
+    writeFileSync(join(fs.profilesDir, "imported.json"), JSON.stringify(profile), { mode: 0o600 });
+
+    const result = load(fs, "imported");
+
+    expect(result.previousActive).toBeNull();
+    expect(result.backupDir).not.toBeNull();
+    expect(result.warnings.join(" ")).toContain("no active profile was recorded");
+    const rescued = JSON.parse(readFileSync(join(result.backupDir as string, "credentials.json"), "utf-8"));
+    expect(rescued).toEqual(credentials()); // the pre-switch identity is recoverable
+  });
+
+  test("dangling active pointer: warns and keeps an orphan backup", () => {
+    using fs = sandbox();
+    save(fs, "work");
+    save(fs, "other");
+    load(fs, "work"); // consumes the one-time "original" backup, active = work
+    rmSync(join(fs.profilesDir, "work.json"));
+
+    const result = load(fs, "other");
+
+    expect(result.wroteBack).toBeNull();
+    expect(result.orphanBackupDir).not.toBeNull();
+    expect(result.warnings.join(" ")).toContain("no longer exists");
+    expect(existsSync(join(result.orphanBackupDir as string, "credentials.json"))).toBe(true);
+  });
+
+  test("api-key profile leaves credentials untouched and warns about the env var", () => {
+    using fs = sandbox();
+    save(fs, "ci", {}, "MY_KEY");
+    const before = readFileSync(fs.credentialsPath, "utf-8");
+
+    const result = load(fs, "ci");
+
+    expect(result.credentialsWritten).toBe(false);
+    expect(readFileSync(fs.credentialsPath, "utf-8")).toBe(before);
+    expect(result.warnings.join(" ")).toContain("export MY_KEY");
+    expect(result.warnings.join(" ")).toContain("MY_KEY is not set");
+  });
+
+  test("api-key profile with the env var set does not warn about it being unset", () => {
+    using fs = sandbox();
+    save(fs, "ci", {}, "MY_KEY");
+    const result = load(fs, "ci", { MY_KEY: "value" });
+    expect(result.warnings.join(" ")).not.toContain("MY_KEY is not set");
+  });
+
+  test("switching away from an api-key profile does not fabricate a write-back", () => {
+    using fs = sandbox();
+    save(fs, "work");
+    save(fs, "ci", { ANTHROPIC_API_KEY: "x" });
+    load(fs, "ci");
+
+    const result = load(fs, "work");
+    expect(result.previousActive).toBe("ci");
+    expect(result.wroteBack).toBeNull();
+  });
+
+  test("throws not-found for an unknown profile", () => {
+    using fs = sandbox();
+    try {
+      load(fs, "nope");
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(AuthProfileError);
+      expect((err as AuthProfileError).code).toBe("not-found");
+    }
+  });
+
+  test("profile without identity keys skips the ~/.claude.json patch", () => {
+    using fs = sandbox({ claudeConfig: null });
+    save(fs, "work");
+    const result = load(fs, "work");
+
+    expect(result.identityWritten).toBe(false);
+    expect(result.credentialsWritten).toBe(true);
+  });
+});
+
+// ── ~/.claude.json surgery ──
+
+describe("patchClaudeConfigIdentity", () => {
+  test("rewrites only the identity keys and preserves the file mode", () => {
+    using fs = sandbox();
+    chmodSync(fs.claudeConfigPath, 0o644);
+
+    patchClaudeConfigIdentity(fs.claudeConfigPath, { userID: "user-z", oauthAccount: oauthAccount("z@x.com") });
+
+    const config = JSON.parse(readFileSync(fs.claudeConfigPath, "utf-8"));
+    expect(config.userID).toBe("user-z");
+    expect(config.oauthAccount.emailAddress).toBe("z@x.com");
+    expect(config.projects).toEqual({ "/repo": { allowedTools: [] } });
+    expect(mode(fs.claudeConfigPath)).toBe(0o644);
+  });
+
+  test("removes identity keys when the profile carries none", () => {
+    using fs = sandbox();
+    patchClaudeConfigIdentity(fs.claudeConfigPath, {});
+    const config = JSON.parse(readFileSync(fs.claudeConfigPath, "utf-8"));
+    expect("userID" in config).toBe(false);
+    expect("oauthAccount" in config).toBe(false);
+    expect(config.projects).toBeDefined();
+  });
+
+  test("creates the file when it is missing", () => {
+    using fs = sandbox({ claudeConfig: null });
+    patchClaudeConfigIdentity(fs.claudeConfigPath, { userID: "fresh" });
+    expect(JSON.parse(readFileSync(fs.claudeConfigPath, "utf-8")).userID).toBe("fresh");
+  });
+
+  test("refuses to touch a config that is not valid JSON", () => {
+    using fs = sandbox();
+    writeFileSync(fs.claudeConfigPath, "{ not json");
+    try {
+      patchClaudeConfigIdentity(fs.claudeConfigPath, { userID: "x" });
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(AuthProfileError);
+      expect((err as AuthProfileError).code).toBe("config-unreadable");
+    }
+    expect(readFileSync(fs.claudeConfigPath, "utf-8")).toBe("{ not json");
+  });
+});
+
+// ── Atomic write ──
+
+describe("writeFileAtomic", () => {
+  test("writes 0600 and leaves no temp file behind", () => {
+    using fs = sandbox();
+    const target = join(fs.root, "out.json");
+    writeFileAtomic(target, '{"a":1}\n');
+
+    expect(readFileSync(target, "utf-8")).toBe('{"a":1}\n');
+    expect(mode(target)).toBe(0o600);
+    expect(readdirSync(fs.root).sort()).toEqual([".claude", ".claude.json", "out.json"]);
+  });
+});
+
+// ── Platform split ──
+
+describe("assertPlatformSupported", () => {
+  test("linux is supported", () => {
+    expect(() => assertPlatformSupported("linux")).not.toThrow();
+  });
+
+  test("darwin fails with a keychain-specific unsupported-platform error", () => {
+    try {
+      assertPlatformSupported("darwin");
+      throw new Error("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(AuthProfileError);
+      expect((err as AuthProfileError).code).toBe("unsupported-platform");
+      expect((err as AuthProfileError).message).toContain("Keychain");
+    }
+  });
+
+  test("other platforms fail too", () => {
+    expect(() => assertPlatformSupported("win32")).toThrow(AuthProfileError);
+  });
+
+  test("save and load refuse to run on darwin", () => {
+    using fs = sandbox();
+    expect(() => saveProfile({ paths: fs, name: "work", env: {}, now: NOW, platform: "darwin" })).toThrow(
+      AuthProfileError,
+    );
+    expect(() => loadProfile({ paths: fs, name: "work", env: {}, now: NOW, platform: "darwin" })).toThrow(
+      AuthProfileError,
+    );
+    expect(existsSync(fs.profilesDir)).toBe(false);
+  });
+});
+
+// ── Summaries ──
+
+describe("summarizeProfile / listProfiles", () => {
+  test("summary carries account + expiry but no token material", () => {
+    using fs = sandbox();
+    const { profile } = save(fs, "work");
+    const summary = summarizeProfile(profile, "work", NOW);
+
+    expect(summary).toMatchObject({
+      name: "work",
+      kind: "oauth",
+      active: true,
+      account: "a@example.com",
+      organization: "Acme",
+      subscriptionType: "max",
+      allowRemoteControl: false,
+      hasCredentials: true,
+    });
+    expect(summary.expiresAt).toBe(new Date(EXPIRES_AT).toISOString());
+    expect(summary.expired).toBe(false);
+    const serialized = JSON.stringify(summary);
+    expect(serialized).not.toContain(ACCESS_TOKEN);
+    expect(serialized).not.toContain(REFRESH_TOKEN);
+  });
+
+  test("marks an expired access token", () => {
+    using fs = sandbox();
+    const { profile } = save(fs, "work");
+    const later = new Date(EXPIRES_AT + 1000);
+    expect(summarizeProfile(profile, null, later).expired).toBe(true);
+  });
+
+  test("api-key summary exposes the env var name and no credentials", () => {
+    using fs = sandbox();
+    const { profile } = save(fs, "ci", {}, "MY_KEY");
+    const summary = summarizeProfile(profile, null, NOW);
+
+    expect(summary.apiKeyEnvVar).toBe("MY_KEY");
+    expect(summary.hasCredentials).toBe(false);
+    expect(summary.account).toBeNull();
+  });
+
+  test("lists profiles sorted with the active one flagged", () => {
+    using fs = sandbox();
+    save(fs, "zeta");
+    save(fs, "alpha");
+
+    const summaries = listProfiles(fs, NOW);
+    expect(summaries.map((s) => s.name)).toEqual(["alpha", "zeta"]);
+    expect(summaries.filter((s) => s.active).map((s) => s.name)).toEqual(["alpha"]);
+  });
+
+  test("returns an empty list when nothing has been saved", () => {
+    using fs = sandbox();
+    expect(listProfiles(fs, NOW)).toEqual([]);
+  });
+});
+
+// ── Path resolution (CLAUDE_CONFIG_DIR) ──
+
+describe("defaultAuthPaths", () => {
+  test("falls back to the home-relative layout when CLAUDE_CONFIG_DIR is unset", () => {
+    using opts = testOptions();
+    const paths = defaultAuthPaths({});
+
+    expect(paths.credentialsPath).toBe(opts.CLAUDE_CREDENTIALS_PATH);
+    expect(paths.claudeConfigPath).toBe(opts.CLAUDE_CONFIG_PATH);
+    expect(paths.policyLimitsPath).toBe(opts.CLAUDE_POLICY_LIMITS_PATH);
+    expect(paths.profilesDir).toBe(opts.AUTH_PROFILES_DIR);
+  });
+
+  test("CLAUDE_CONFIG_DIR relocates all three files into that directory", () => {
+    using opts = testOptions();
+    const cfg = join(opts.dir, "cfgdir");
+    const paths = defaultAuthPaths({ CLAUDE_CONFIG_DIR: cfg });
+
+    // Under a redirected config dir .claude.json sits INSIDE it, unlike the default layout.
+    expect(paths.credentialsPath).toBe(join(cfg, ".credentials.json"));
+    expect(paths.claudeConfigPath).toBe(join(cfg, ".claude.json"));
+    expect(paths.policyLimitsPath).toBe(join(cfg, "policy-limits.json"));
+  });
+
+  test("an empty CLAUDE_CONFIG_DIR is ignored", () => {
+    using opts = testOptions();
+    expect(defaultAuthPaths({ CLAUDE_CONFIG_DIR: "  " }).credentialsPath).toBe(opts.CLAUDE_CREDENTIALS_PATH);
+  });
+
+  test("CLAUDE_SECURESTORAGE_CONFIG_DIR overrides only the credentials location", () => {
+    using opts = testOptions();
+    const cfg = join(opts.dir, "cfgdir");
+    const secure = join(opts.dir, "securedir");
+    const paths = defaultAuthPaths({ CLAUDE_CONFIG_DIR: cfg, CLAUDE_SECURESTORAGE_CONFIG_DIR: secure });
+
+    expect(paths.credentialsPath).toBe(join(secure, ".credentials.json"));
+    expect(paths.claudeConfigPath).toBe(join(cfg, ".claude.json"));
+  });
+
+  test("an existing .config.json in the config dir supersedes .claude.json", () => {
+    using opts = testOptions();
+    const cfg = join(opts.dir, "cfgdir");
+    mkdirSync(cfg, { recursive: true });
+    writeFileSync(join(cfg, ".config.json"), "{}");
+
+    expect(defaultAuthPaths({ CLAUDE_CONFIG_DIR: cfg }).claudeConfigPath).toBe(join(cfg, ".config.json"));
+  });
+
+  test("an active pointer from another config dir does not trigger a bogus write-back", () => {
+    using opts = testOptions();
+    const cfgA = join(opts.dir, "cfgA");
+    const cfgB = join(opts.dir, "cfgB");
+    mkdirSync(cfgA, { recursive: true });
+    mkdirSync(cfgB, { recursive: true });
+    const pathsA = defaultAuthPaths({ CLAUDE_CONFIG_DIR: cfgA });
+    const pathsB = defaultAuthPaths({ CLAUDE_CONFIG_DIR: cfgB });
+
+    writeFileSync(pathsA.credentialsPath, JSON.stringify(credentials()), { mode: 0o600 });
+    save(pathsA, "alpha"); // active pointer now describes cfgA
+
+    // A different identity lives in cfgB; loading alpha there must not claim it for alpha.
+    writeFileSync(pathsB.credentialsPath, JSON.stringify(credentials({ accessToken: "cfgB-token" })), { mode: 0o600 });
+    const result = load(pathsB, "alpha");
+
+    expect(result.previousActive).toBeNull();
+    expect(result.wroteBack).toBeNull();
+    expect(result.warnings.join(" ")).toContain("was recorded for");
+    expect(readProfile(pathsA, "alpha")?.credentials).toEqual(credentials());
+  });
+
+  test("save/load round-trip works against a CLAUDE_CONFIG_DIR layout", () => {
+    using opts = testOptions();
+    const cfg = join(opts.dir, "cfgdir");
+    mkdirSync(cfg, { recursive: true });
+    const paths = defaultAuthPaths({ CLAUDE_CONFIG_DIR: cfg });
+    writeFileSync(paths.credentialsPath, JSON.stringify(credentials()), { mode: 0o600 });
+    writeFileSync(paths.claudeConfigPath, JSON.stringify({ userID: "cfg-user", keep: true }));
+
+    save(paths, "cfg");
+    writeFileSync(paths.credentialsPath, JSON.stringify(credentials({ accessToken: "elsewhere" })));
+    save(paths, "other"); // "other" owns the second identity and becomes active
+    const result = load(paths, "cfg");
+
+    expect(result.credentialsWritten).toBe(true);
+    expect(result.wroteBack).toBe("other");
+    expect(JSON.parse(readFileSync(paths.credentialsPath, "utf-8"))).toEqual(credentials());
+    expect(JSON.parse(readFileSync(paths.claudeConfigPath, "utf-8")).keep).toBe(true);
+  });
+});
+
+// ── --oauth override ──
+
+describe("saveProfile forceOauth", () => {
+  test("captures the oauth identity even when ANTHROPIC_API_KEY is exported", () => {
+    using fs = sandbox();
+    const result = saveProfile({
+      paths: fs,
+      name: "work",
+      env: { ANTHROPIC_API_KEY: "sk-ant-api03-SECRET" },
+      now: NOW,
+      platform: "linux",
+      forceOauth: true,
+    });
+
+    expect(result.profile.kind).toBe("oauth");
+    expect(result.profile.credentials).toEqual(credentials());
+    expect(readFileSync(join(fs.profilesDir, "work.json"), "utf-8")).not.toContain("sk-ant-api03-SECRET");
+  });
+});

--- a/packages/command/src/claude-auth-store.ts
+++ b/packages/command/src/claude-auth-store.ts
@@ -1,0 +1,757 @@
+/**
+ * Claude auth-profile store — scriptable identity switching for Claude Code (#3006).
+ *
+ * Claude Code keeps its identity in three places (Linux):
+ *   - `~/.claude/.credentials.json`  — the live OAuth tokens (mode 0600, plain JSON)
+ *   - `~/.claude.json`               — a large shared config that also carries
+ *                                      `userID` / `oauthAccount`
+ *   - `~/.claude/policy-limits.json` — a cache of the org policy for the current identity
+ *
+ * A *profile* is a single JSON file under `~/.mcp-cli/auth-profiles/<name>.json`
+ * holding a verbatim copy of the credentials plus the two identity keys. One file
+ * per profile means a profile swap is a single `rename()` — there is no window in
+ * which credentials have been updated but identity has not.
+ *
+ * Security invariants (enforced by tests):
+ *   - API key **values** are never stored. An `api-key` profile records only the
+ *     NAME of the env var that is expected to carry the key.
+ *   - Token values are never returned by any summary/list/format function.
+ *   - The profile directory is 0700, every file 0600.
+ *   - Every write is atomic (temp file + `rename`), so a crash can never leave a
+ *     truncated `.credentials.json` behind.
+ *
+ * macOS is not supported yet: credentials live in the Keychain there, not in a
+ * file (see `assertPlatformSupported`).
+ */
+
+import {
+  chmodSync,
+  closeSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import { flockUnlock, options, tryFlockExclusive } from "@mcp-cli/core";
+
+// ── Types ──
+
+export const PROFILE_KINDS = ["oauth", "api-key"] as const;
+export type ProfileKind = (typeof PROFILE_KINDS)[number];
+
+/** Current on-disk profile schema version. */
+export const PROFILE_VERSION = 1;
+
+/** Identity keys lifted out of `~/.claude.json`. Never contains tokens. */
+export interface StoredIdentity {
+  userID?: string;
+  oauthAccount?: Record<string, unknown>;
+}
+
+/** Org-policy snapshot taken at save time (advisory — the policy is refetched by Claude). */
+export interface StoredPolicy {
+  /** `restrictions.allow_remote_control.allowed`, or null when unknown. */
+  allowRemoteControl: boolean | null;
+  /** When the snapshot was taken (ISO). */
+  capturedAt: string;
+}
+
+export interface ClaudeAuthProfile {
+  version: number;
+  name: string;
+  kind: ProfileKind;
+  createdAt: string;
+  updatedAt: string;
+  /** api-key profiles only: the NAME of the env var expected to hold the key. Never the value. */
+  apiKeyEnvVar?: string;
+  /** oauth profiles only: verbatim `~/.claude/.credentials.json` contents. */
+  credentials?: Record<string, unknown>;
+  /** oauth profiles only: `userID` / `oauthAccount` from `~/.claude.json`. */
+  identity?: StoredIdentity;
+  policy?: StoredPolicy;
+}
+
+/** Non-secret projection of a profile, safe to print. */
+export interface ProfileSummary {
+  name: string;
+  kind: ProfileKind;
+  active: boolean;
+  /** Email address, falling back to the account UUID, or null. */
+  account: string | null;
+  organization: string | null;
+  subscriptionType: string | null;
+  /** Access-token expiry as ISO, or null when unknown. */
+  expiresAt: string | null;
+  expired: boolean | null;
+  /** api-key profiles: the env var name the profile expects. */
+  apiKeyEnvVar: string | null;
+  allowRemoteControl: boolean | null;
+  hasCredentials: boolean;
+  updatedAt: string;
+}
+
+/** Filesystem locations the store reads and writes. Injected so tests never touch a real `~/.claude`. */
+export interface AuthPaths {
+  profilesDir: string;
+  credentialsPath: string;
+  claudeConfigPath: string;
+  policyLimitsPath: string;
+}
+
+/**
+ * Resolve where Claude Code keeps its identity, honouring `CLAUDE_CONFIG_DIR`.
+ *
+ * Verified against the claude 2.1.235 bundle and by running the binary:
+ *   - credentials: `(CLAUDE_SECURESTORAGE_CONFIG_DIR ?? CLAUDE_CONFIG_DIR ?? ~/.claude)/.credentials.json`
+ *   - policy cache: `(CLAUDE_CONFIG_DIR ?? ~/.claude)/policy-limits.json`
+ *   - global config: `(CLAUDE_CONFIG_DIR ?? ~)/.claude.json` — note the *different* base:
+ *     with a redirected config dir the file sits directly inside it, but by default it
+ *     sits beside `~/.claude`, not in it.
+ *   - if `<configDir>/.config.json` exists it supersedes `.claude.json` (the binary
+ *     prefers it), so we patch that file instead of creating a second source of truth.
+ *
+ * With `CLAUDE_CONFIG_DIR` unset the paths come from `options`, which tests override.
+ */
+export function defaultAuthPaths(env: Record<string, string | undefined> = process.env): AuthPaths {
+  const configDir = env.CLAUDE_CONFIG_DIR?.trim() ? env.CLAUDE_CONFIG_DIR : undefined;
+  const secureDir = env.CLAUDE_SECURESTORAGE_CONFIG_DIR?.trim() ? env.CLAUDE_SECURESTORAGE_CONFIG_DIR : undefined;
+
+  const credentialsRoot = secureDir ?? configDir;
+  const credentialsPath = credentialsRoot
+    ? join(credentialsRoot, ".credentials.json")
+    : options.CLAUDE_CREDENTIALS_PATH;
+  const policyLimitsPath = configDir ? join(configDir, "policy-limits.json") : options.CLAUDE_POLICY_LIMITS_PATH;
+
+  const globalConfigDefault = configDir ? join(configDir, ".claude.json") : options.CLAUDE_CONFIG_PATH;
+  const dotConfig = configDir
+    ? join(configDir, ".config.json")
+    : join(dirname(options.CLAUDE_CREDENTIALS_PATH), ".config.json");
+  const claudeConfigPath = existsSync(dotConfig) ? dotConfig : globalConfigDefault;
+
+  return {
+    profilesDir: options.AUTH_PROFILES_DIR,
+    credentialsPath,
+    claudeConfigPath,
+    policyLimitsPath,
+  };
+}
+
+/** Raised for every expected failure so the CLI can map it to an exit code without message sniffing. */
+export class AuthProfileError extends Error {
+  constructor(
+    message: string,
+    /** Stable, machine-readable failure code. */
+    readonly code:
+      | "unsupported-platform"
+      | "invalid-name"
+      | "not-found"
+      | "no-credentials"
+      | "config-locked"
+      | "config-unreadable",
+    errorOptions?: ErrorOptions,
+  ) {
+    super(message, errorOptions);
+    this.name = "AuthProfileError";
+  }
+}
+
+// ── Paths and naming ──
+
+const PROFILE_NAME_RE = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/;
+const DIR_MODE = 0o700;
+const FILE_MODE = 0o600;
+const ACTIVE_FILE = "active.json";
+const BACKUPS_DIR = "backups";
+const ORIGINAL_BACKUP = "original";
+
+export function validateProfileName(name: string): void {
+  if (!PROFILE_NAME_RE.test(name)) {
+    throw new AuthProfileError(
+      `Invalid profile name "${name}": use letters, digits, hyphens or underscores (max 64 chars)`,
+      "invalid-name",
+    );
+  }
+}
+
+export function profilePath(paths: AuthPaths, name: string): string {
+  validateProfileName(name);
+  return join(paths.profilesDir, `${name}.json`);
+}
+
+export function ensureProfilesDir(paths: AuthPaths): void {
+  mkdirSync(paths.profilesDir, { recursive: true, mode: DIR_MODE });
+  // mkdir's mode argument is masked by umask; force the bits for a pre-existing dir too.
+  chmodSync(paths.profilesDir, DIR_MODE);
+}
+
+// ── Low-level IO ──
+
+/** Write `content` to `path` via temp file + rename. A crash can never leave a truncated target. */
+export function writeFileAtomic(path: string, content: string, mode: number = FILE_MODE): void {
+  const tmp = `${path}.tmp-${process.pid}-${Math.random().toString(36).slice(2, 10)}`;
+  writeFileSync(tmp, content, { mode });
+  chmodSync(tmp, mode); // umask-proof
+  renameSync(tmp, path);
+}
+
+function readJsonObject(path: string, what: string): Record<string, unknown> {
+  const raw = readFileSync(path, "utf-8");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new AuthProfileError(`${what} at ${path} is not valid JSON — refusing to touch it`, "config-unreadable", {
+      cause: err,
+    });
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new AuthProfileError(`${what} at ${path} is not a JSON object — refusing to touch it`, "config-unreadable");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+/** File mode bits (permission bits only), or `fallback` when the file is absent. */
+function modeOf(path: string, fallback: number): number {
+  if (!existsSync(path)) return fallback;
+  return statSync(path).mode & 0o777;
+}
+
+const LOCK_DEADLINE_MS = 2_000;
+const LOCK_RETRY_MS = 25;
+
+/**
+ * Run `fn` while holding an exclusive advisory lock on `path`.
+ *
+ * Claude Code rewrites `~/.claude.json` in place while it runs, so the lock plus
+ * the mtime re-check in `patchClaudeConfigIdentity` is our concurrency defence.
+ * The lock is kernel-managed and released on process death.
+ */
+export function withExclusiveLock<T>(path: string, fn: () => T, deadlineMs = LOCK_DEADLINE_MS): T {
+  // "a+" creates the file if absent and never truncates an existing one.
+  const fd = openSync(path, "a+");
+  const deadline = Date.now() + deadlineMs;
+  let held = false;
+  try {
+    while (!held) {
+      held = tryFlockExclusive(fd);
+      if (held) break;
+      if (Date.now() >= deadline) {
+        throw new AuthProfileError(
+          `${path} is locked by another process (is Claude Code running?) — retry in a moment`,
+          "config-locked",
+        );
+      }
+      Bun.sleepSync(LOCK_RETRY_MS);
+    }
+    return fn();
+  } finally {
+    if (held) flockUnlock(fd);
+    closeSync(fd);
+  }
+}
+
+// ── Profile records ──
+
+export function listProfileNames(paths: AuthPaths): string[] {
+  if (!existsSync(paths.profilesDir)) return [];
+  return readdirSync(paths.profilesDir)
+    .filter((f) => f.endsWith(".json") && f !== ACTIVE_FILE)
+    .map((f) => f.slice(0, -".json".length))
+    .filter((name) => PROFILE_NAME_RE.test(name))
+    .sort();
+}
+
+export function readProfile(paths: AuthPaths, name: string): ClaudeAuthProfile | null {
+  const path = profilePath(paths, name);
+  if (!existsSync(path)) return null;
+  const raw = readJsonObject(path, `Profile "${name}"`);
+  return raw as unknown as ClaudeAuthProfile;
+}
+
+export function writeProfile(paths: AuthPaths, profile: ClaudeAuthProfile): void {
+  ensureProfilesDir(paths);
+  writeFileAtomic(profilePath(paths, profile.name), `${JSON.stringify(profile, null, 2)}\n`);
+}
+
+/** Which profile the live credential file currently holds, and where that file was. */
+export interface ActivePointer {
+  name: string;
+  /** Credential path the pointer was written for. Null for pointers written before this field existed. */
+  credentialsPath: string | null;
+}
+
+export function readActivePointer(paths: AuthPaths): ActivePointer | null {
+  const path = join(paths.profilesDir, ACTIVE_FILE);
+  if (!existsSync(path)) return null;
+  const raw = readJsonObject(path, "Active-profile pointer");
+  const name = raw.profile;
+  if (typeof name !== "string" || !PROFILE_NAME_RE.test(name)) return null;
+  return { name, credentialsPath: typeof raw.credentialsPath === "string" ? raw.credentialsPath : null };
+}
+
+export function readActiveProfileName(paths: AuthPaths): string | null {
+  return readActivePointer(paths)?.name ?? null;
+}
+
+export function writeActiveProfileName(paths: AuthPaths, name: string, now: Date): void {
+  ensureProfilesDir(paths);
+  writeFileAtomic(
+    join(paths.profilesDir, ACTIVE_FILE),
+    `${JSON.stringify({ profile: name, since: now.toISOString(), credentialsPath: paths.credentialsPath }, null, 2)}\n`,
+  );
+}
+
+// ── Live state ──
+
+export interface LiveState {
+  credentials: Record<string, unknown> | null;
+  identity: StoredIdentity;
+  policy: StoredPolicy | null;
+}
+
+function readPolicySnapshot(paths: AuthPaths, now: Date): StoredPolicy | null {
+  if (!existsSync(paths.policyLimitsPath)) return null;
+  const raw = readJsonObject(paths.policyLimitsPath, "policy-limits.json");
+  const restrictions = raw.restrictions;
+  let allowed: boolean | null = null;
+  if (typeof restrictions === "object" && restrictions !== null) {
+    const entry = (restrictions as Record<string, unknown>).allow_remote_control;
+    if (typeof entry === "object" && entry !== null) {
+      const value = (entry as Record<string, unknown>).allowed;
+      if (typeof value === "boolean") allowed = value;
+    }
+  }
+  return { allowRemoteControl: allowed, capturedAt: now.toISOString() };
+}
+
+/** Read the currently-active identity off disk. Never mutates anything. */
+export function readLiveState(paths: AuthPaths, now: Date): LiveState {
+  const credentials = existsSync(paths.credentialsPath)
+    ? readJsonObject(paths.credentialsPath, "Claude credentials")
+    : null;
+
+  const identity: StoredIdentity = {};
+  if (existsSync(paths.claudeConfigPath)) {
+    const config = readJsonObject(paths.claudeConfigPath, "~/.claude.json");
+    if (typeof config.userID === "string") identity.userID = config.userID;
+    const account = config.oauthAccount;
+    if (typeof account === "object" && account !== null && !Array.isArray(account)) {
+      identity.oauthAccount = account as Record<string, unknown>;
+    }
+  }
+
+  return { credentials, identity, policy: readPolicySnapshot(paths, now) };
+}
+
+/**
+ * Return a copy of `config` with only the identity keys replaced (or dropped when the
+ * profile has none). Key order is preserved so the rewritten `~/.claude.json` stays as
+ * close to the original as possible.
+ */
+function applyIdentity(config: Record<string, unknown>, identity: StoredIdentity): Record<string, unknown> {
+  const next: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(config)) {
+    if (key === "userID") {
+      if (identity.userID !== undefined) next.userID = identity.userID;
+      continue;
+    }
+    if (key === "oauthAccount") {
+      if (identity.oauthAccount !== undefined) next.oauthAccount = identity.oauthAccount;
+      continue;
+    }
+    next[key] = value;
+  }
+  if (identity.userID !== undefined && !("userID" in config)) next.userID = identity.userID;
+  if (identity.oauthAccount !== undefined && !("oauthAccount" in config)) next.oauthAccount = identity.oauthAccount;
+  return next;
+}
+
+/**
+ * Patch only `userID` / `oauthAccount` in `~/.claude.json`, preserving every other
+ * key and the file's existing permissions.
+ *
+ * Concurrency: the read-modify-write runs under an exclusive advisory lock, and the
+ * file's mtime+size are re-checked immediately before the rename. If Claude Code
+ * rewrote the file underneath us we retry rather than clobber its changes.
+ */
+export function patchClaudeConfigIdentity(path: string, identity: StoredIdentity, attempts = 3): void {
+  withExclusiveLock(path, () => {
+    for (let attempt = 0; attempt < attempts; attempt++) {
+      const before = existsSync(path) ? statSync(path) : null;
+      const config = before && before.size > 0 ? readJsonObject(path, "~/.claude.json") : {};
+
+      const next = applyIdentity(config, identity);
+
+      const after = existsSync(path) ? statSync(path) : null;
+      const changedUnderUs =
+        (before === null) !== (after === null) ||
+        (before !== null && after !== null && (before.mtimeMs !== after.mtimeMs || before.size !== after.size));
+      if (changedUnderUs) continue; // another writer won the race — re-read and retry
+
+      writeFileAtomic(path, `${JSON.stringify(next, null, 2)}\n`, modeOf(path, FILE_MODE));
+      return;
+    }
+    throw new AuthProfileError(
+      `${path} kept changing while writing identity keys (is Claude Code running?) — retry in a moment`,
+      "config-locked",
+    );
+  });
+}
+
+// ── Backups ──
+
+/** Copy the live identity files into `dir`. Missing files are skipped. */
+function backupLiveFiles(paths: AuthPaths, dir: string): string {
+  mkdirSync(dir, { recursive: true, mode: DIR_MODE });
+  chmodSync(dir, DIR_MODE);
+  for (const [src, name] of [
+    [paths.credentialsPath, "credentials.json"],
+    [paths.claudeConfigPath, "claude.json"],
+    [paths.policyLimitsPath, "policy-limits.json"],
+  ] as const) {
+    if (!existsSync(src)) continue;
+    const dest = join(dir, name);
+    copyFileSync(src, dest);
+    chmodSync(dest, FILE_MODE);
+  }
+  return dir;
+}
+
+/**
+ * Snapshot the live files before the first overwrite of anything we did not create.
+ * The `original` backup is written once and never replaced.
+ */
+export function backupOriginals(paths: AuthPaths): string | null {
+  const dir = join(paths.profilesDir, BACKUPS_DIR, ORIGINAL_BACKUP);
+  if (existsSync(dir)) return null;
+  ensureProfilesDir(paths);
+  return backupLiveFiles(paths, dir);
+}
+
+/** Snapshot live credentials that belong to no known profile, so a switch can never lose them. */
+export function backupOrphan(paths: AuthPaths, now: Date): string {
+  const stamp = now.toISOString().replace(/[:.]/g, "-");
+  ensureProfilesDir(paths);
+  return backupLiveFiles(paths, join(paths.profilesDir, BACKUPS_DIR, `orphan-${stamp}`));
+}
+
+// ── Platform support ──
+
+/** Throws unless the current platform stores Claude credentials in a file we can swap. */
+export function assertPlatformSupported(platform: string): void {
+  if (platform === "linux") return;
+  const detail =
+    platform === "darwin"
+      ? "Claude Code stores its credentials in the macOS Keychain, not in ~/.claude/.credentials.json"
+      : `unsupported platform "${platform}"`;
+  throw new AuthProfileError(
+    `mcx claude auth is Linux-only for now: ${detail}. Nothing was read or written.`,
+    "unsupported-platform",
+  );
+}
+
+// ── save ──
+
+export interface SaveOptions {
+  paths: AuthPaths;
+  name: string;
+  env: Record<string, string | undefined>;
+  now: Date;
+  platform: string;
+  /** Force an api-key profile bound to this env var name (implies kind "api-key"). */
+  apiKeyEnvVar?: string;
+  /**
+   * Capture the OAuth credentials even when an API key is present in `env`.
+   * Needed because a shell with `ANTHROPIC_API_KEY` exported would otherwise
+   * never be able to snapshot the logged-in claude.ai identity.
+   */
+  forceOauth?: boolean;
+}
+
+export interface SaveResult {
+  profile: ClaudeAuthProfile;
+  replaced: boolean;
+  /** True when the active pointer now names this profile. */
+  becameActive: boolean;
+  warnings: string[];
+}
+
+const DEFAULT_API_KEY_ENV = "ANTHROPIC_API_KEY";
+
+export function saveProfile(opts: SaveOptions): SaveResult {
+  const { paths, name, env, now, platform } = opts;
+  assertPlatformSupported(platform);
+  validateProfileName(name);
+
+  const warnings: string[] = [];
+  const existing = readProfile(paths, name);
+  const apiKeyEnvVar = opts.forceOauth
+    ? undefined
+    : (opts.apiKeyEnvVar ?? (env[DEFAULT_API_KEY_ENV] ? DEFAULT_API_KEY_ENV : undefined));
+  const kind: ProfileKind = apiKeyEnvVar ? "api-key" : "oauth";
+  const live = readLiveState(paths, now);
+
+  const profile: ClaudeAuthProfile = {
+    version: PROFILE_VERSION,
+    name,
+    kind,
+    createdAt: existing?.createdAt ?? now.toISOString(),
+    updatedAt: now.toISOString(),
+  };
+  if (live.policy) profile.policy = live.policy;
+
+  if (kind === "api-key") {
+    // Record the env var NAME only — never the key value, and never someone
+    // else's OAuth tokens that merely happen to be on disk right now.
+    profile.apiKeyEnvVar = apiKeyEnvVar;
+    if (!env[apiKeyEnvVar as string]) {
+      warnings.push(`${apiKeyEnvVar} is not set in this environment — the profile records the variable name only`);
+    }
+    if (live.credentials) {
+      warnings.push(
+        `live OAuth credentials in ${paths.credentialsPath} were NOT captured (api-key profiles store no tokens)`,
+      );
+    }
+  } else {
+    if (!live.credentials) {
+      throw new AuthProfileError(
+        `No Claude credentials found at ${paths.credentialsPath} — log in with claude first, or set ${DEFAULT_API_KEY_ENV} to save an api-key profile`,
+        "no-credentials",
+      );
+    }
+    profile.credentials = live.credentials;
+    profile.identity = live.identity;
+    if (live.identity.userID === undefined && live.identity.oauthAccount === undefined) {
+      warnings.push(`no userID/oauthAccount found in ${paths.claudeConfigPath} — only credentials were captured`);
+    }
+  }
+
+  writeProfile(paths, profile);
+
+  // An oauth save establishes provenance for the live credentials: the next
+  // `load` knows where to write a refreshed token back to.
+  let becameActive = false;
+  if (kind === "oauth") {
+    writeActiveProfileName(paths, name, now);
+    becameActive = true;
+  }
+
+  return { profile, replaced: existing !== null, becameActive, warnings };
+}
+
+// ── load ──
+
+export interface LoadOptions {
+  paths: AuthPaths;
+  name: string;
+  env: Record<string, string | undefined>;
+  now: Date;
+  platform: string;
+}
+
+export interface LoadResult {
+  name: string;
+  kind: ProfileKind;
+  previousActive: string | null;
+  /** Profile that received the live credentials before the switch, if any. */
+  wroteBack: string | null;
+  wroteBackChanged: boolean;
+  backupDir: string | null;
+  orphanBackupDir: string | null;
+  credentialsWritten: boolean;
+  identityWritten: boolean;
+  policyInvalidated: boolean;
+  apiKeyEnvVar: string | null;
+  warnings: string[];
+}
+
+/** Deep value equality for plain JSON values (used to detect a refreshed token). */
+function jsonEquals(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+export function loadProfile(opts: LoadOptions): LoadResult {
+  const { paths, name, env, now, platform } = opts;
+  assertPlatformSupported(platform);
+
+  const target = readProfile(paths, name);
+  if (!target) {
+    throw new AuthProfileError(
+      `No such auth profile: "${name}". Run "mcx claude auth ls" to see saved ones.`,
+      "not-found",
+    );
+  }
+
+  const warnings: string[] = [];
+  // The pointer records which credential file it described. A different
+  // CLAUDE_CONFIG_DIR means those live credentials are not the ones the pointer
+  // names, so we must not write them back into that profile.
+  const pointer = readActivePointer(paths);
+  const pointerApplies =
+    pointer !== null && (pointer.credentialsPath ?? paths.credentialsPath) === paths.credentialsPath;
+  if (pointer && !pointerApplies) {
+    warnings.push(
+      `active profile "${pointer.name}" was recorded for ${pointer.credentialsPath} — nothing was written back for this config dir`,
+    );
+  }
+  const previousActive = pointerApplies && pointer ? pointer.name : null;
+  const live = readLiveState(paths, now);
+
+  // (6) Back up anything we did not create, once, before the first overwrite.
+  const backupDir = backupOriginals(paths);
+
+  // (4) Write-back: Claude rewrites .credentials.json in place on refresh, so the
+  // live tokens must land back in their origin profile before we replace them.
+  let wroteBack: string | null = null;
+  let wroteBackChanged = false;
+  let orphanBackupDir: string | null = null;
+
+  if (previousActive === name) {
+    // Re-loading the active profile: refresh the stored copy, then continue
+    // (cheap idempotent path — also repairs a profile whose token has rotated).
+    if (live.credentials && !jsonEquals(live.credentials, target.credentials)) {
+      const refreshed: ClaudeAuthProfile = {
+        ...target,
+        credentials: live.credentials,
+        identity: live.identity,
+        updatedAt: now.toISOString(),
+      };
+      writeProfile(paths, refreshed);
+      target.credentials = refreshed.credentials;
+      target.identity = refreshed.identity;
+      wroteBack = name;
+      wroteBackChanged = true;
+    }
+  } else if (previousActive) {
+    const origin = readProfile(paths, previousActive);
+    if (!origin) {
+      warnings.push(
+        `active profile "${previousActive}" no longer exists — the live credentials were backed up instead of written back`,
+      );
+      if (live.credentials) orphanBackupDir = backupOrphan(paths, now);
+    } else if (origin.kind === "api-key") {
+      // api-key profiles intentionally hold no tokens; nothing to write back.
+      wroteBack = null;
+    } else if (live.credentials) {
+      const changed = !jsonEquals(live.credentials, origin.credentials) || !jsonEquals(live.identity, origin.identity);
+      if (changed) {
+        writeProfile(paths, {
+          ...origin,
+          credentials: live.credentials,
+          identity: live.identity,
+          updatedAt: now.toISOString(),
+        });
+      }
+      wroteBack = previousActive;
+      wroteBackChanged = changed;
+    }
+  } else if (live.credentials) {
+    // First ever use, or the pointer was lost: do not guess an owner — keep a copy.
+    if (backupDir === null) orphanBackupDir = backupOrphan(paths, now);
+    warnings.push(
+      `no active profile was recorded — the live credentials were backed up to ${orphanBackupDir ?? backupDir}. Run "mcx claude auth save <name>" first to keep them as a profile.`,
+    );
+  }
+
+  // Apply the target profile.
+  let credentialsWritten = false;
+  if (target.credentials) {
+    writeFileAtomic(paths.credentialsPath, `${JSON.stringify(target.credentials, null, 2)}\n`);
+    credentialsWritten = true;
+  } else if (target.kind === "api-key") {
+    warnings.push(
+      `profile "${name}" is an api-key profile: export ${target.apiKeyEnvVar ?? DEFAULT_API_KEY_ENV} before running claude`,
+    );
+    if (target.apiKeyEnvVar && !env[target.apiKeyEnvVar]) {
+      warnings.push(`${target.apiKeyEnvVar} is not set in this environment`);
+    }
+  } else {
+    warnings.push(`profile "${name}" has no stored credentials — ${paths.credentialsPath} was left untouched`);
+  }
+
+  let identityWritten = false;
+  if (target.identity && (target.identity.userID !== undefined || target.identity.oauthAccount !== undefined)) {
+    patchClaudeConfigIdentity(paths.claudeConfigPath, target.identity);
+    identityWritten = true;
+  }
+
+  // (8) The org policy is cached per identity — drop it so Claude refetches.
+  let policyInvalidated = false;
+  if (existsSync(paths.policyLimitsPath)) {
+    unlinkSync(paths.policyLimitsPath);
+    policyInvalidated = true;
+  }
+
+  writeActiveProfileName(paths, name, now);
+
+  return {
+    name,
+    kind: target.kind,
+    previousActive,
+    wroteBack,
+    wroteBackChanged,
+    backupDir,
+    orphanBackupDir,
+    credentialsWritten,
+    identityWritten,
+    policyInvalidated,
+    apiKeyEnvVar: target.apiKeyEnvVar ?? null,
+    warnings,
+  };
+}
+
+// ── ls ──
+
+function oauthField(profile: ClaudeAuthProfile, key: string): string | null {
+  const value = profile.identity?.oauthAccount?.[key];
+  return typeof value === "string" ? value : null;
+}
+
+function credentialsRoot(profile: ClaudeAuthProfile): Record<string, unknown> | null {
+  const root = profile.credentials?.claudeAiOauth;
+  if (typeof root === "object" && root !== null && !Array.isArray(root)) return root as Record<string, unknown>;
+  return null;
+}
+
+/**
+ * Non-secret projection of a profile. Never reads or returns token material —
+ * only expiry, account, and policy metadata.
+ */
+export function summarizeProfile(profile: ClaudeAuthProfile, activeName: string | null, now: Date): ProfileSummary {
+  const root = credentialsRoot(profile);
+  const expiresAtMs = typeof root?.expiresAt === "number" ? root.expiresAt : null;
+  const subscription = typeof root?.subscriptionType === "string" ? root.subscriptionType : null;
+
+  return {
+    name: profile.name,
+    kind: profile.kind,
+    active: profile.name === activeName,
+    account: oauthField(profile, "emailAddress") ?? oauthField(profile, "accountUuid"),
+    organization: oauthField(profile, "organizationName"),
+    subscriptionType: subscription,
+    expiresAt: expiresAtMs === null ? null : new Date(expiresAtMs).toISOString(),
+    expired: expiresAtMs === null ? null : expiresAtMs <= now.getTime(),
+    apiKeyEnvVar: profile.apiKeyEnvVar ?? null,
+    allowRemoteControl: profile.policy?.allowRemoteControl ?? null,
+    hasCredentials: profile.credentials !== undefined,
+    updatedAt: profile.updatedAt,
+  };
+}
+
+export function listProfiles(paths: AuthPaths, now: Date): ProfileSummary[] {
+  const active = readActiveProfileName(paths);
+  const summaries: ProfileSummary[] = [];
+  for (const name of listProfileNames(paths)) {
+    const profile = readProfile(paths, name);
+    if (!profile) continue;
+    summaries.push(summarizeProfile({ ...profile, name }, active, now));
+  }
+  return summaries;
+}

--- a/packages/command/src/commands/claude-auth.spec.ts
+++ b/packages/command/src/commands/claude-auth.spec.ts
@@ -1,0 +1,343 @@
+import { describe, expect, mock, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { AuthPaths } from "../claude-auth-store";
+import { ExitError } from "../test-helpers";
+import { type AuthCliDeps, type AuthEnvDeps, claudeAuth, formatProfileTable } from "./claude-auth";
+
+const ACCESS_TOKEN = "sk-ant-oat01-FAKE-CLI-TOKEN";
+const EXPIRES_AT = Date.UTC(2026, 7, 19, 3, 14, 0);
+const NOW = new Date(Date.UTC(2026, 7, 18, 12, 0, 0));
+
+const CREDENTIALS = {
+  claudeAiOauth: {
+    accessToken: ACCESS_TOKEN,
+    refreshToken: "sk-ant-ort01-FAKE-CLI-REFRESH",
+    expiresAt: EXPIRES_AT,
+    scopes: ["user:inference"],
+    subscriptionType: "max",
+  },
+};
+
+interface Harness {
+  paths: AuthPaths;
+  root: string;
+  out: string[];
+  err: string[];
+  info: string[];
+  deps: AuthCliDeps;
+  envDeps: Partial<AuthEnvDeps>;
+  [Symbol.dispose](): void;
+}
+
+function harness(opts?: { env?: Record<string, string | undefined>; platform?: string }): Harness {
+  const root = mkdtempSync(join(tmpdir(), "mcx-authcli-"));
+  mkdirSync(join(root, ".claude"), { recursive: true });
+  const paths: AuthPaths = {
+    profilesDir: join(root, ".mcp-cli", "auth-profiles"),
+    credentialsPath: join(root, ".claude", ".credentials.json"),
+    claudeConfigPath: join(root, ".claude.json"),
+    policyLimitsPath: join(root, ".claude", "policy-limits.json"),
+  };
+  writeFileSync(paths.credentialsPath, JSON.stringify(CREDENTIALS), { mode: 0o600 });
+  writeFileSync(
+    paths.claudeConfigPath,
+    JSON.stringify({ userID: "user-a", oauthAccount: { emailAddress: "a@example.com", accountUuid: "uuid-a" } }),
+    { mode: 0o600 },
+  );
+  writeFileSync(paths.policyLimitsPath, JSON.stringify({ restrictions: { allow_remote_control: { allowed: true } } }), {
+    mode: 0o600,
+  });
+
+  const out: string[] = [];
+  const err: string[] = [];
+  const info: string[] = [];
+  const deps = {
+    log: (...args: unknown[]) => out.push(args.map(String).join(" ")),
+    printError: (msg: string) => err.push(msg),
+    printInfo: (msg: string) => info.push(msg),
+    exit: mock((code: number) => {
+      throw new ExitError(code);
+    }),
+  } as unknown as AuthCliDeps;
+
+  return {
+    paths,
+    root,
+    out,
+    err,
+    info,
+    deps,
+    envDeps: { paths, env: opts?.env ?? {}, platform: opts?.platform ?? "linux", now: () => NOW },
+    [Symbol.dispose]() {
+      rmSync(root, { recursive: true, force: true });
+    },
+  };
+}
+
+async function expectExit(fn: () => Promise<void>, code: number): Promise<void> {
+  try {
+    await fn();
+    throw new Error(`expected exit(${code})`);
+  } catch (err) {
+    expect(err).toBeInstanceOf(ExitError);
+    expect((err as ExitError).code).toBe(code);
+  }
+}
+
+describe("mcx claude auth — dispatch", () => {
+  test("unknown subcommand exits 1 with guidance on stderr", async () => {
+    using h = harness();
+    await expectExit(() => claudeAuth(["frobnicate"], h.deps, h.envDeps), 1);
+    expect(h.err.join(" ")).toContain("Unknown claude auth subcommand");
+    expect(h.out).toEqual([]);
+  });
+
+  test("missing subcommand exits 1", async () => {
+    using h = harness();
+    await expectExit(() => claudeAuth([], h.deps, h.envDeps), 1);
+  });
+
+  test("unknown flag exits 1", async () => {
+    using h = harness();
+    await expectExit(() => claudeAuth(["ls", "--bogus"], h.deps, h.envDeps), 1);
+    expect(h.err.join(" ")).toContain("unknown flag");
+  });
+
+  test("save without a name exits 1", async () => {
+    using h = harness();
+    await expectExit(() => claudeAuth(["save"], h.deps, h.envDeps), 1);
+    expect(h.err.join(" ")).toContain("Missing profile name");
+  });
+
+  test("darwin exits 2 with an unsupported-platform message and writes nothing", async () => {
+    using h = harness({ platform: "darwin" });
+    await expectExit(() => claudeAuth(["save", "work"], h.deps, h.envDeps), 2);
+    expect(h.err.join(" ")).toContain("Linux-only");
+    expect(existsSync(h.paths.profilesDir)).toBe(false);
+  });
+
+  test("loading an unknown profile exits 1", async () => {
+    using h = harness();
+    await expectExit(() => claudeAuth(["load", "nope"], h.deps, h.envDeps), 1);
+    expect(h.err.join(" ")).toContain("No such auth profile");
+  });
+
+  test("an invalid profile name exits 1 without creating anything", async () => {
+    using h = harness();
+    await expectExit(() => claudeAuth(["save", "../escape"], h.deps, h.envDeps), 1);
+    expect(h.err.join(" ")).toContain("Invalid profile name");
+  });
+});
+
+describe("mcx claude auth save", () => {
+  test("human output confirms the save and the new active profile", async () => {
+    using h = harness();
+    await claudeAuth(["save", "work"], h.deps, h.envDeps);
+
+    expect(h.out.join("\n")).toContain('Saved auth profile "work" (oauth)');
+    expect(h.out.join("\n")).toContain('active profile is now "work"');
+    expect(existsSync(join(h.paths.profilesDir, "work.json"))).toBe(true);
+  });
+
+  test("--json emits a machine-readable record with no token material", async () => {
+    using h = harness();
+    await claudeAuth(["save", "work", "--json"], h.deps, h.envDeps);
+
+    const payload = JSON.parse(h.out.join("\n"));
+    expect(payload).toMatchObject({ ok: true, action: "save", name: "work", kind: "oauth", active: true });
+    expect(h.out.join("\n")).not.toContain(ACCESS_TOKEN);
+  });
+
+  test("--api-key-env records the variable name and warns on stderr", async () => {
+    using h = harness();
+    await claudeAuth(["save", "ci", "--api-key-env", "MY_KEY"], h.deps, h.envDeps);
+
+    expect(h.out.join("\n")).toContain("expects env var: MY_KEY (value not stored)");
+    expect(h.info.join(" ")).toContain("MY_KEY is not set");
+    expect(readFileSync(join(h.paths.profilesDir, "ci.json"), "utf-8")).not.toContain(ACCESS_TOKEN);
+  });
+
+  test("--oauth captures the claude.ai identity despite an exported API key", async () => {
+    using h = harness({ env: { ANTHROPIC_API_KEY: "sk-ant-api03-SECRET" } });
+    await claudeAuth(["save", "work", "--oauth", "--json"], h.deps, h.envDeps);
+
+    const payload = JSON.parse(h.out.join("\n"));
+    expect(payload.kind).toBe("oauth");
+    expect(payload.apiKeyEnvVar).toBeNull();
+    expect(readFileSync(join(h.paths.profilesDir, "work.json"), "utf-8")).not.toContain("sk-ant-api03-SECRET");
+  });
+
+  test("an exported ANTHROPIC_API_KEY makes save default to an api-key profile", async () => {
+    using h = harness({ env: { ANTHROPIC_API_KEY: "sk-ant-api03-SECRET" } });
+    await claudeAuth(["save", "ci", "--json"], h.deps, h.envDeps);
+
+    const payload = JSON.parse(h.out.join("\n"));
+    expect(payload).toMatchObject({ kind: "api-key", apiKeyEnvVar: "ANTHROPIC_API_KEY", active: false });
+  });
+
+  test("save --json reports the resolved credential paths", async () => {
+    using h = harness();
+    await claudeAuth(["save", "work", "--json"], h.deps, h.envDeps);
+    const payload = JSON.parse(h.out.join("\n"));
+    expect(payload.credentialsPath).toBe(h.paths.credentialsPath);
+    expect(payload.claudeConfigPath).toBe(h.paths.claudeConfigPath);
+  });
+
+  test("re-saving reports an update rather than a create", async () => {
+    using h = harness();
+    await claudeAuth(["save", "work"], h.deps, h.envDeps);
+    h.out.length = 0;
+    await claudeAuth(["save", "work"], h.deps, h.envDeps);
+    expect(h.out.join("\n")).toContain('Updated auth profile "work"');
+  });
+});
+
+describe("mcx claude auth load", () => {
+  test("switches identity and reports the side effects it performed", async () => {
+    using h = harness();
+    await claudeAuth(["save", "work"], h.deps, h.envDeps);
+    writeFileSync(h.paths.credentialsPath, JSON.stringify({ claudeAiOauth: { accessToken: "other" } }));
+    writeFileSync(h.paths.claudeConfigPath, JSON.stringify({ userID: "user-b", keep: 1 }));
+    await claudeAuth(["save", "personal"], h.deps, h.envDeps);
+    h.out.length = 0;
+
+    await claudeAuth(["load", "work"], h.deps, h.envDeps);
+
+    const text = h.out.join("\n");
+    expect(text).toContain('Loaded auth profile "work" (oauth)');
+    expect(text).toContain("credentials written");
+    expect(text).toContain("identity keys updated");
+    expect(text).toContain("org policy cache invalidated");
+    expect(JSON.parse(readFileSync(h.paths.claudeConfigPath, "utf-8")).userID).toBe("user-a");
+    expect(existsSync(h.paths.policyLimitsPath)).toBe(false);
+  });
+
+  test("--json reports the write-back target and backup location", async () => {
+    using h = harness();
+    await claudeAuth(["save", "work"], h.deps, h.envDeps);
+    h.out.length = 0;
+
+    await claudeAuth(["load", "work", "--json"], h.deps, h.envDeps);
+
+    const payload = JSON.parse(h.out.join("\n"));
+    expect(payload).toMatchObject({ ok: true, action: "load", name: "work", kind: "oauth", policyInvalidated: true });
+    expect(payload.backupDir).toContain("backups");
+    expect(h.out.join("\n")).not.toContain(ACCESS_TOKEN);
+  });
+
+  test("warnings go to stderr, not stdout", async () => {
+    using h = harness();
+    await claudeAuth(["save", "ci", "--api-key-env", "MY_KEY"], h.deps, h.envDeps);
+    h.out.length = 0;
+    h.info.length = 0;
+
+    await claudeAuth(["load", "ci"], h.deps, h.envDeps);
+
+    expect(h.info.join(" ")).toContain("export MY_KEY");
+    expect(h.out.join("\n")).not.toContain("export MY_KEY");
+  });
+});
+
+describe("mcx claude auth ls", () => {
+  test("empty store prints a hint and valid JSON", async () => {
+    using h = harness();
+    await claudeAuth(["ls"], h.deps, h.envDeps);
+    expect(h.out.join("\n")).toContain("No auth profiles saved");
+
+    h.out.length = 0;
+    await claudeAuth(["ls", "--json"], h.deps, h.envDeps);
+    expect(JSON.parse(h.out.join("\n"))).toEqual([]);
+  });
+
+  test("lists saved profiles with account, expiry and remote-control, never a token", async () => {
+    using h = harness();
+    await claudeAuth(["save", "work"], h.deps, h.envDeps);
+    await claudeAuth(["save", "ci", "--api-key-env", "MY_KEY"], h.deps, h.envDeps);
+    h.out.length = 0;
+
+    await claudeAuth(["ls"], h.deps, h.envDeps);
+
+    const text = h.out.join("\n");
+    expect(text).toContain("NAME");
+    expect(text).toContain("a@example.com");
+    expect(text).toContain("$MY_KEY");
+    expect(text).toContain("2026-08-19 03:14");
+    expect(text).toContain("yes"); // remote control allowed per the policy fixture
+    expect(text).toContain("* work"); // active marker
+    expect(text).not.toContain(ACCESS_TOKEN);
+  });
+
+  test("--json exposes the summary fields agents need", async () => {
+    using h = harness();
+    await claudeAuth(["save", "work"], h.deps, h.envDeps);
+    h.out.length = 0;
+
+    await claudeAuth(["ls", "--json"], h.deps, h.envDeps);
+
+    const [entry] = JSON.parse(h.out.join("\n"));
+    expect(entry).toMatchObject({
+      name: "work",
+      kind: "oauth",
+      active: true,
+      account: "a@example.com",
+      allowRemoteControl: true,
+      expired: false,
+    });
+    expect(entry.expiresAt).toBe(new Date(EXPIRES_AT).toISOString());
+  });
+
+  test("ls works on darwin (it only reads the mcx-owned store)", async () => {
+    using h = harness({ platform: "darwin" });
+    await claudeAuth(["ls", "--json"], h.deps, h.envDeps);
+    expect(JSON.parse(h.out.join("\n"))).toEqual([]);
+  });
+});
+
+describe("formatProfileTable", () => {
+  test("marks expired tokens and unknown policy without leaking secrets", () => {
+    const lines = formatProfileTable([
+      {
+        name: "old",
+        kind: "oauth",
+        active: false,
+        account: "old@example.com",
+        organization: null,
+        subscriptionType: "pro",
+        expiresAt: "2020-01-01T00:00:00.000Z",
+        expired: true,
+        apiKeyEnvVar: null,
+        allowRemoteControl: null,
+        hasCredentials: true,
+        updatedAt: NOW.toISOString(),
+      },
+    ]);
+
+    const text = lines.join("\n");
+    expect(text).toContain("2020-01-01 00:00 (expired)");
+    expect(text).toContain("unknown");
+    expect(text).not.toContain("Token");
+  });
+
+  test("falls back to a dash when the account is unknown", () => {
+    const lines = formatProfileTable([
+      {
+        name: "bare",
+        kind: "oauth",
+        active: true,
+        account: null,
+        organization: null,
+        subscriptionType: null,
+        expiresAt: null,
+        expired: null,
+        apiKeyEnvVar: null,
+        allowRemoteControl: true,
+        hasCredentials: true,
+        updatedAt: NOW.toISOString(),
+      },
+    ]);
+    expect(lines[1]).toContain("* bare");
+    expect(lines[1]).toContain("-");
+  });
+});

--- a/packages/command/src/commands/claude-auth.ts
+++ b/packages/command/src/commands/claude-auth.ts
@@ -1,0 +1,258 @@
+/**
+ * `mcx claude auth save|load|ls` — scriptable Claude identity switching (#3006).
+ *
+ * All three subcommands are non-interactive and agent-callable: JSON on `--json`
+ * (stdout), human text otherwise, warnings and errors on stderr, meaningful exit
+ * codes. The filesystem work lives in `../claude-auth-store` so it can be tested
+ * against injected paths — no test ever touches a real `~/.claude`.
+ */
+
+import {
+  type AuthPaths,
+  AuthProfileError,
+  type ProfileSummary,
+  defaultAuthPaths,
+  listProfiles,
+  loadProfile,
+  saveProfile,
+} from "../claude-auth-store";
+import { parseFlags } from "../flags";
+
+/**
+ * Output seams. Structurally a subset of `ClaudeDeps`, declared locally so this
+ * module stays a leaf of the import graph (`claude.ts` ↔ `agent.ts` is already a cycle).
+ */
+export interface AuthCliDeps {
+  log: (...args: unknown[]) => void;
+  printError: (msg: string) => void;
+  printInfo: (msg: string) => void;
+  exit: (code: number) => never;
+}
+
+/** Exit code for "this platform can't do credential swapping yet". */
+export const EXIT_UNSUPPORTED_PLATFORM = 2;
+/** Exit code for every other expected failure (bad name, missing profile, locked config). */
+export const EXIT_ERROR = 1;
+
+/** Environment/filesystem seams, injected by tests. */
+export interface AuthEnvDeps {
+  paths: AuthPaths;
+  env: Record<string, string | undefined>;
+  platform: string;
+  now: () => Date;
+}
+
+function resolveEnvDeps(overrides?: Partial<AuthEnvDeps>): AuthEnvDeps {
+  const env = overrides?.env ?? process.env;
+  return {
+    // Path resolution reads CLAUDE_CONFIG_DIR out of the same env object.
+    paths: overrides?.paths ?? defaultAuthPaths(env),
+    env,
+    platform: overrides?.platform ?? process.platform,
+    now: overrides?.now ?? (() => new Date()),
+  };
+}
+
+const AUTH_SUBCOMMANDS = ["save", "load", "ls"] as const;
+type AuthSubcommand = (typeof AUTH_SUBCOMMANDS)[number];
+
+function isAuthSubcommand(value: string): value is AuthSubcommand {
+  return (AUTH_SUBCOMMANDS as readonly string[]).includes(value);
+}
+
+export async function claudeAuth(args: string[], d: AuthCliDeps, overrides?: Partial<AuthEnvDeps>): Promise<void> {
+  const envDeps = resolveEnvDeps(overrides);
+  const sub = args[0] ?? "";
+
+  if (!isAuthSubcommand(sub)) {
+    d.printError(
+      `Unknown claude auth subcommand: "${sub || "(none)"}". Use "save <profile>", "load <profile>", or "ls".`,
+    );
+    return d.exit(EXIT_ERROR);
+  }
+
+  const parsed = parseFlags(args.slice(1), {
+    json: { type: "boolean" },
+    oauth: { type: "boolean" },
+    "api-key-env": { type: "string" },
+  });
+  if (parsed.errors.length > 0) {
+    for (const err of parsed.errors) d.printError(err);
+    return d.exit(EXIT_ERROR);
+  }
+  const json = parsed.flags.json === true;
+  const apiKeyEnvFlag = typeof parsed.flags["api-key-env"] === "string" ? parsed.flags["api-key-env"] : undefined;
+
+  try {
+    switch (sub) {
+      case "save":
+        return await runSave(
+          parsed.positionals,
+          { json, apiKeyEnvVar: apiKeyEnvFlag, forceOauth: parsed.flags.oauth === true },
+          d,
+          envDeps,
+        );
+      case "load":
+        return await runLoad(parsed.positionals, json, d, envDeps);
+      case "ls":
+        return await runLs(json, d, envDeps);
+    }
+  } catch (err) {
+    if (err instanceof AuthProfileError) {
+      d.printError(err.message);
+      return d.exit(err.code === "unsupported-platform" ? EXIT_UNSUPPORTED_PLATFORM : EXIT_ERROR);
+    }
+    throw err;
+  }
+}
+
+function requireName(positionals: string[], usage: string, d: AuthCliDeps): string {
+  const name = positionals[0];
+  if (!name) {
+    d.printError(`Missing profile name. Usage: ${usage}`);
+    return d.exit(EXIT_ERROR);
+  }
+  return name;
+}
+
+async function runSave(
+  positionals: string[],
+  opts: { json: boolean; apiKeyEnvVar: string | undefined; forceOauth: boolean },
+  d: AuthCliDeps,
+  envDeps: AuthEnvDeps,
+): Promise<void> {
+  const name = requireName(positionals, "mcx claude auth save <profile>", d);
+  const result = saveProfile({
+    paths: envDeps.paths,
+    name,
+    env: envDeps.env,
+    now: envDeps.now(),
+    platform: envDeps.platform,
+    apiKeyEnvVar: opts.apiKeyEnvVar,
+    forceOauth: opts.forceOauth,
+  });
+
+  for (const warning of result.warnings) d.printInfo(`warning: ${warning}`);
+
+  if (opts.json) {
+    d.log(
+      JSON.stringify(
+        {
+          ok: true,
+          action: "save",
+          name,
+          kind: result.profile.kind,
+          replaced: result.replaced,
+          active: result.becameActive,
+          apiKeyEnvVar: result.profile.apiKeyEnvVar ?? null,
+          credentialsPath: envDeps.paths.credentialsPath,
+          claudeConfigPath: envDeps.paths.claudeConfigPath,
+          warnings: result.warnings,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  const verb = result.replaced ? "Updated" : "Saved";
+  d.log(`${verb} auth profile "${name}" (${result.profile.kind})`);
+  if (result.profile.apiKeyEnvVar) d.log(`  expects env var: ${result.profile.apiKeyEnvVar} (value not stored)`);
+  if (result.becameActive) d.log(`  active profile is now "${name}"`);
+}
+
+async function runLoad(positionals: string[], json: boolean, d: AuthCliDeps, envDeps: AuthEnvDeps): Promise<void> {
+  const name = requireName(positionals, "mcx claude auth load <profile>", d);
+  const result = loadProfile({
+    paths: envDeps.paths,
+    name,
+    env: envDeps.env,
+    now: envDeps.now(),
+    platform: envDeps.platform,
+  });
+
+  for (const warning of result.warnings) d.printInfo(`warning: ${warning}`);
+
+  if (json) {
+    d.log(
+      JSON.stringify(
+        {
+          ok: true,
+          action: "load",
+          ...result,
+          credentialsPath: envDeps.paths.credentialsPath,
+          claudeConfigPath: envDeps.paths.claudeConfigPath,
+        },
+        null,
+        2,
+      ),
+    );
+    return;
+  }
+
+  d.log(`Loaded auth profile "${name}" (${result.kind})`);
+  if (result.wroteBack) {
+    d.log(
+      result.wroteBackChanged
+        ? `  wrote refreshed credentials back to "${result.wroteBack}"`
+        : `  "${result.wroteBack}" was already up to date`,
+    );
+  }
+  if (result.backupDir) d.log(`  backed up pre-existing credentials to ${result.backupDir}`);
+  if (result.orphanBackupDir) d.log(`  backed up unattributed credentials to ${result.orphanBackupDir}`);
+  if (result.credentialsWritten) d.log("  credentials written");
+  if (result.identityWritten) d.log("  identity keys updated in ~/.claude.json");
+  if (result.policyInvalidated) d.log("  org policy cache invalidated (policy-limits.json removed)");
+}
+
+async function runLs(json: boolean, d: AuthCliDeps, envDeps: AuthEnvDeps): Promise<void> {
+  const summaries = listProfiles(envDeps.paths, envDeps.now());
+
+  if (json) {
+    d.log(JSON.stringify(summaries, null, 2));
+    return;
+  }
+
+  if (summaries.length === 0) {
+    d.log('No auth profiles saved. Run "mcx claude auth save <profile>" to capture the current identity.');
+    return;
+  }
+
+  for (const line of formatProfileTable(summaries)) d.log(line);
+}
+
+/** Render the `ls` table. Exported for tests — must never contain token material. */
+export function formatProfileTable(summaries: ProfileSummary[]): string[] {
+  const rows = summaries.map((s) => ({
+    marker: s.active ? "*" : " ",
+    name: s.name,
+    kind: s.kind,
+    account: s.kind === "api-key" ? `$${s.apiKeyEnvVar ?? "ANTHROPIC_API_KEY"}` : (s.account ?? "-"),
+    expires: formatExpiry(s),
+    remote: s.allowRemoteControl === null ? "unknown" : s.allowRemoteControl ? "yes" : "no",
+  }));
+
+  const width = (pick: (r: (typeof rows)[number]) => string, header: string) =>
+    Math.max(header.length, ...rows.map((r) => pick(r).length));
+  const nameW = width((r) => r.name, "NAME");
+  const kindW = width((r) => r.kind, "KIND");
+  const accountW = width((r) => r.account, "ACCOUNT");
+  const expiresW = width((r) => r.expires, "EXPIRES");
+
+  const lines = [
+    `  ${"NAME".padEnd(nameW)}  ${"KIND".padEnd(kindW)}  ${"ACCOUNT".padEnd(accountW)}  ${"EXPIRES".padEnd(expiresW)}  REMOTE-CONTROL`,
+  ];
+  for (const r of rows) {
+    lines.push(
+      `${r.marker} ${r.name.padEnd(nameW)}  ${r.kind.padEnd(kindW)}  ${r.account.padEnd(accountW)}  ${r.expires.padEnd(expiresW)}  ${r.remote}`,
+    );
+  }
+  return lines;
+}
+
+function formatExpiry(summary: ProfileSummary): string {
+  if (summary.expiresAt === null) return "-";
+  const stamp = summary.expiresAt.replace("T", " ").slice(0, 16);
+  return summary.expired ? `${stamp} (expired)` : stamp;
+}

--- a/packages/command/src/commands/claude.ts
+++ b/packages/command/src/commands/claude.ts
@@ -174,7 +174,7 @@ export const defaultDeps: ClaudeDeps = {
  *
  * Exported so tests can assert every member routes through `cmdClaudeInternal`.
  */
-export const CLAUDE_ONLY_SUBCOMMANDS: ReadonlySet<string> = new Set(["patch-update"]);
+export const CLAUDE_ONLY_SUBCOMMANDS: ReadonlySet<string> = new Set(["patch-update", "auth"]);
 
 /**
  * `mcx claude` — thin alias that routes to `mcx agent claude` for shared
@@ -265,6 +265,11 @@ async function cmdClaudeInternal(args: string[], deps?: Partial<ClaudeDeps>): Pr
     case "patch-update":
       await claudePatchUpdate(subArgs, d);
       break;
+    case "auth": {
+      const { claudeAuth } = await import("./claude-auth");
+      await claudeAuth(subArgs, d);
+      break;
+    }
     case "status": {
       const { cmdAgent } = await import("./agent");
       await cmdAgent(["claude", sub, ...subArgs], d);
@@ -272,7 +277,7 @@ async function cmdClaudeInternal(args: string[], deps?: Partial<ClaudeDeps>): Pr
     }
     default:
       d.printError(
-        `Unknown claude subcommand: ${sub}. Use "spawn", "resume", "ls", "send", "bye", "interrupt", "log", "wait", "approve", "deny", "patch-update", "worktrees", or "status".`,
+        `Unknown claude subcommand: ${sub}. Use "spawn", "resume", "ls", "send", "bye", "interrupt", "log", "wait", "approve", "deny", "patch-update", "auth", "worktrees", or "status".`,
       );
       d.exit(1);
   }
@@ -2298,6 +2303,9 @@ Usage:
   mcx claude worktrees                     List mcx-created worktrees
   mcx claude worktrees --prune             Remove orphaned worktrees + merged branches
   mcx claude patch-update                  Refresh the patched copy used for mcx spawns (#1808)
+  mcx claude auth ls [--json]              List saved auth profiles (Linux only)
+  mcx claude auth save <profile>           Snapshot the active Claude identity into a profile
+  mcx claude auth load <profile>           Switch the active Claude identity to a profile
 
 Spawn options:
   --task, -t "description"    Task prompt for Claude

--- a/packages/command/src/help-claude.ts
+++ b/packages/command/src/help-claude.ts
@@ -192,3 +192,39 @@ registerHelp("claude patch-update", {
     "mcx claude patch-update --force            # rebuild the patched copy from scratch",
   ],
 });
+
+registerHelp("claude auth", {
+  name: "mcx claude auth",
+  summary: "Save, list, and switch Claude identities without an interactive /login (see #3006)",
+  notes: [
+    "Linux only for now — on macOS Claude Code keeps its credentials in the Keychain,",
+    "so save/load exit 2 with a clear error there (ls still works).",
+    "",
+    "Honors CLAUDE_CONFIG_DIR (and CLAUDE_SECURESTORAGE_CONFIG_DIR): with a redirected",
+    "config dir the credentials, .claude.json and policy-limits.json all live inside it.",
+    "",
+    "A profile snapshots ~/.claude/.credentials.json plus the userID/oauthAccount keys",
+    "in ~/.claude.json. Profiles live in ~/.mcp-cli/auth-profiles/ (dir 0700, files 0600).",
+    "API key VALUES are never stored: an api-key profile records only the env var name.",
+    "`load` writes the live credentials back to the active profile first, so a token",
+    "refreshed by Claude since the last save is never lost, and drops the cached",
+    "policy-limits.json so org policy does not leak across identities.",
+  ],
+  usage: [
+    "mcx claude auth save <profile> [--json]",
+    "mcx claude auth save <profile> --api-key-env ANTHROPIC_API_KEY",
+    "mcx claude auth save <profile> --oauth",
+    "mcx claude auth load <profile> [--json]",
+    "mcx claude auth ls [--json]",
+  ],
+  options: [
+    ["--json", "Structured JSON on stdout instead of human text"],
+    ["--api-key-env <VAR>", "Save an api-key profile bound to this env var name (value never stored)"],
+    ["--oauth", "Capture the claude.ai OAuth identity even when ANTHROPIC_API_KEY is exported"],
+  ],
+  examples: [
+    "mcx claude auth save work           # capture the identity that is logged in right now",
+    "mcx claude auth load personal       # switch to another saved identity",
+    "mcx claude auth ls --json | jq '.[] | {name, expiresAt}'",
+  ],
+});

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -91,6 +91,14 @@ const _originalOptions = {
   ALIASES_DIR,
   CACHE_DIR,
   CLAUDE_CONFIG_PATH: join(homedir(), ".claude.json"),
+  /** Claude Code's per-user state directory (~/.claude) */
+  CLAUDE_HOME_DIR: join(homedir(), ".claude"),
+  /** Claude Code's OAuth credential file (Linux; on macOS these live in the Keychain) */
+  CLAUDE_CREDENTIALS_PATH: join(homedir(), ".claude", ".credentials.json"),
+  /** Claude Code's cached org-policy file — refetched on CLI startup */
+  CLAUDE_POLICY_LIMITS_PATH: join(homedir(), ".claude", "policy-limits.json"),
+  /** Directory holding saved Claude auth profiles (`mcx claude auth save/load`) */
+  AUTH_PROFILES_DIR: join(MCP_CLI_DIR, "auth-profiles"),
   CLAUDE_DESKTOP_CONFIG_PATH: join(homedir(), "Library", "Application Support", "Claude", "claude_desktop_config.json"),
   USER_SERVERS_PATH: join(MCP_CLI_DIR, "servers.json"),
   PROJECTS_DIR: join(MCP_CLI_DIR, "projects"),

--- a/test/test-options.ts
+++ b/test/test-options.ts
@@ -34,6 +34,10 @@ export function testOptions(input?: TestOptionsInput) {
   options.CACHE_DIR = join(dir, "cache");
   options.USER_SERVERS_PATH = join(dir, "servers.json");
   options.CLAUDE_CONFIG_PATH = join(dir, "claude.json");
+  options.CLAUDE_HOME_DIR = join(dir, "claude-home");
+  options.CLAUDE_CREDENTIALS_PATH = join(dir, "claude-home", ".credentials.json");
+  options.CLAUDE_POLICY_LIMITS_PATH = join(dir, "claude-home", "policy-limits.json");
+  options.AUTH_PROFILES_DIR = join(dir, "auth-profiles");
   options.PROJECTS_DIR = join(dir, "projects");
   options.TYPES_PATH = join(dir, "mcp-cli.d.ts");
   options.LOCK_PATH = join(dir, "mcpd.lock");


### PR DESCRIPTION
## What

`mcx claude auth save|load|ls` — scriptable Claude identity switching, so an agent session can swap accounts without an interactive `/login`.

```
mcx claude auth save <profile> [--json] [--oauth] [--api-key-env VAR]
mcx claude auth load <profile> [--json]
mcx claude auth ls [--json]
```

Text output to stdout, warnings/errors to stderr, `--json` everywhere, exit codes `0` ok / `1` expected failure / `2` unsupported platform.

## Design decisions

**One file per profile.** `~/.mcp-cli/auth-profiles/<name>.json` (dir `0700`, files `0600`) holds a verbatim copy of `.credentials.json` plus the `userID`/`oauthAccount` keys from `.claude.json`. A single file means a profile swap is one `rename()` — there is no state where credentials were updated but identity was not. A file store beats SQLite here: the payload is a blob that must be readable/recoverable with `cat` when auth is broken, and the atomicity requirement is per-file, not transactional.

**Write-back + active pointer.** `auth-profiles/active.json` records which profile owns the live credentials **and the credential path it was recorded for**. On `load`:
- pointer matches this config dir and names a live profile → live credentials are written back to it first (so a token Claude refreshed in place is never lost), then the target is applied;
- pointer names a profile that no longer exists → warn + `backups/orphan-<ts>/`;
- pointer was recorded for a *different* `CLAUDE_CONFIG_DIR` → warn, no write-back (those credentials are not the ones the pointer names);
- no pointer at all (first ever use) → warn + back up the live files, never guess an owner. `save` establishes the pointer, which is the documented "capture what you have first" path.

**Never store a key value.** An `api-key` profile records only the *name* of the env var (`apiKeyEnvVar`), never the value, and deliberately does **not** capture the OAuth tokens that merely happen to be on disk (that would misattribute someone else's identity to it). `--oauth` forces an OAuth capture from a shell that exports `ANTHROPIC_API_KEY` — without it every save in such a shell would become an api-key profile.

**Safety.** Atomic temp+`rename` for every write; a one-time `backups/original/` snapshot before the first overwrite of files mcx did not create; `~/.claude.json` is patched under `flock(2)` with an mtime/size re-check before the rename (only the two identity keys change — every other key, the key order, and the file mode are preserved; invalid JSON is refused, not clobbered); `policy-limits.json` is deleted on switch so a stale org policy cannot leak across identities. No token value appears in any output, error, JSON payload, or test fixture.

**`CLAUDE_CONFIG_DIR` (per review feedback).** Paths are resolved from the env, not hardcoded:
- credentials: `(CLAUDE_SECURESTORAGE_CONFIG_DIR ?? CLAUDE_CONFIG_DIR ?? ~/.claude)/.credentials.json`
- policy cache: `(CLAUDE_CONFIG_DIR ?? ~/.claude)/policy-limits.json`
- global config: `(CLAUDE_CONFIG_DIR ?? ~)/.claude.json` — note the *different* base; with a redirected dir the file sits inside it, by default it sits beside `~/.claude`
- `<configDir>/.config.json` supersedes `.claude.json` when present (matches the binary's own resolution)

## Platform support

**Linux: fully supported.** **macOS: not supported in v1** — `save`/`load` fail fast with exit 2 and "Claude Code stores its credentials in the macOS Keychain, not in ~/.claude/.credentials.json. Nothing was read or written." Nothing is read or half-written on darwin. `ls` works on every platform (it only reads the mcx-owned store). Follow-up filed: **#3012**.

## What I actually ran

Real end-to-end against throwaway `CLAUDE_CONFIG_DIR`s (never the live `~/.claude`), claude 2.1.235, Linux:

1. Empty config dir, no API key → `claude --print` says `Not logged in · Please run /login`, and the dir gets `.claude.json` directly inside it (no nested `.claude/`) — confirms the layout and that there is no fallback to the real home.
2. `mcx claude auth save alpha` in config dir A, then `mcx claude auth load alpha` against config dir B → credentials + identity landed in B; `claude --print` there changed from `Not logged in` to `Failed to authenticate: OAuth session expired and could not be refreshed`. That is proof claude reads exactly the file mcx wrote (the token was a fake).
3. Two identities saved in one config dir, a token "refreshed" in place while `two` was active, then `load one`: output reported `wrote refreshed credentials back to "two"`, the profile file contained the refreshed token, live credentials/identity became `one`, unrelated `.claude.json` keys survived, `policy-limits.json` was removed. `ls` rendered account, expiry and remote-control per profile with no token material.
4. Permissions verified on disk: profile dir `0700`, profile/active/backup files `0600`.

**Not verified:** anything on macOS (no darwin host — the platform split is unit-tested only); a genuine multi-account swap with two real logged-in accounts (I have one account, so the token payloads in the e2e were synthetic — the file plumbing is what was exercised); concurrent-writer behaviour against a live `claude` process racing the `~/.claude.json` patch (the flock + mtime re-check are unit-tested, not raced for real).

**Disclosure:** before the `CLAUDE_CONFIG_DIR` guidance arrived I ran `mcx claude auth save verify-real` + `ls` once against the real `~/.claude` on this box. That path only *reads* `~/.claude`, and both files' sha256 were identical before and after; the only writes were `~/.mcp-cli/auth-profiles/{verify-real.json,active.json}`, which I deleted immediately afterwards (directory removed). No `load` was ever run against the real home, so nothing there was modified.

## Tests

`packages/command/src/claude-auth-store.spec.ts` (43 tests) — save/load semantics, write-back, active-pointer edge cases, backups, atomic write, permissions, `~/.claude.json` surgery, path resolution incl. `CLAUDE_CONFIG_DIR`, platform split, redaction. `packages/command/src/commands/claude-auth.spec.ts` (23 tests) — CLI dispatch, exit codes, JSON/text output, stderr routing, table formatting. Paths and env are injected; no test touches a real `~/.claude`. `test/test-options.ts` now also isolates the new option keys.

`bun run am-i-done` (bun 1.3.14, CI-pinned): **all checks passed**.

## Deliberately left out

`mcx claude auth rm/show` (not requested; profiles are files, `rm` works), backup pruning beyond the one-time `original` + per-orphan snapshots, and any daemon/IPC surface — this is pure CLI-side filesystem work.

## Follow-ups filed

- #3012 — macOS Keychain support for `mcx claude auth`
- #3014 — `server-pool.spec.ts` rate-limit test asserts an exact throttle count and flakes under load (hit during this work)
- #3011 — `resolve-playwright.spec.ts` fails when bun is not installed at `<home>/.bun/bin/bun` (hit while running the gate with the pinned toolchain; added a data point)

fixes #3006
